### PR TITLE
Add fully_qualified_name for GDScript class

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -111,6 +111,7 @@ class GDScript : public Script {
 	String source;
 	String path;
 	String name;
+	String fully_qualified_name;
 	SelfList<GDScript> script_list;
 
 	GDScriptInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_isref, Variant::CallError &r_error);

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2131,6 +2131,7 @@ void GDScriptCompiler::_make_scripts(GDScript *p_script, const GDScriptParser::C
 		}
 
 		subclass->_owner = p_script;
+		subclass->fully_qualified_name = p_script->fully_qualified_name + "::" + name;
 		p_script->subclasses.insert(name, subclass);
 
 		_make_scripts(subclass.ptr(), p_class->subclasses[i], false);
@@ -2148,6 +2149,9 @@ Error GDScriptCompiler::compile(const GDScriptParser *p_parser, GDScript *p_scri
 	ERR_FAIL_COND_V(root->type != GDScriptParser::Node::TYPE_CLASS, ERR_INVALID_DATA);
 
 	source = p_script->get_path();
+
+	// The best fully qualified name for a base level script is its file path
+	p_script->fully_qualified_name = p_script->path;
 
 	// Create scripts for subclasses beforehand so they can be referenced
 	_make_scripts(p_script, static_cast<const GDScriptParser::ClassNode *>(root), p_keep_state);


### PR DESCRIPTION
This change adds a full name for GDScript to give them a unique identifier across the entire project

names for top level classes are the file path
every subclass is appended after double colon "::"
for example 
if the file is named my_script.gd
and has the following code:

```gdscript
class first_inner_class:
    class inner_inner_class:
        pass
```

the full names will be

```text
res://my_script.gd
res://my_script.gd::first_inner_class
res://my_script.gd::first_inner_class::inner_inner_class
```