### PR TITLE
Fixed invalid canvas_item:COLOR initialization in shaders

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -620,7 +620,19 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 			SL::OperatorNode *op_node = (SL::OperatorNode *)p_node;
 
 			switch (op_node->op) {
-				case SL::OP_ASSIGN:
+				case SL::OP_ASSIGN: {
+					SL::VariableNode *var_node = (SL::VariableNode *)op_node->arguments[0];
+
+					if (p_default_actions.setter_defines.has(var_node->name) && !used_setter_defines.has(var_node->name)) {
+						String define = p_default_actions.setter_defines[var_node->name];
+						if (define.begins_with("@")) {
+							define = p_default_actions.setter_defines[define.substr(1, define.length())];
+						}
+						r_gen_code.custom_defines.push_back(define.utf8());
+						used_setter_defines.insert(var_node->name);
+					}
+					FALLTHROUGH;
+				}
 				case SL::OP_ASSIGN_ADD:
 				case SL::OP_ASSIGN_SUB:
 				case SL::OP_ASSIGN_MUL:
@@ -899,6 +911,7 @@ Error ShaderCompilerGLES2::compile(VS::ShaderMode p_mode, const String &p_code, 
 	used_name_defines.clear();
 	used_rmode_defines.clear();
 	used_flag_pointers.clear();
+	used_setter_defines.clear();
 
 	_dump_node_code(parser.get_shader(), 1, r_gen_code, *p_actions, actions[p_mode], false);
 
@@ -941,7 +954,7 @@ ShaderCompilerGLES2::ShaderCompilerGLES2() {
 	actions[VS::SHADER_CANVAS_ITEM].renames["SHADOW_COLOR"] = "shadow_color";
 	actions[VS::SHADER_CANVAS_ITEM].renames["SHADOW_VEC"] = "shadow_vec";
 
-	actions[VS::SHADER_CANVAS_ITEM].usage_defines["COLOR"] = "#define COLOR_USED\n";
+	actions[VS::SHADER_CANVAS_ITEM].setter_defines["COLOR"] = "#define COLOR_USED\n";
 	actions[VS::SHADER_CANVAS_ITEM].usage_defines["SCREEN_TEXTURE"] = "#define SCREEN_TEXTURE_USED\n";
 	actions[VS::SHADER_CANVAS_ITEM].usage_defines["SCREEN_UV"] = "#define SCREEN_UV_USED\n";
 	actions[VS::SHADER_CANVAS_ITEM].usage_defines["SCREEN_PIXEL_SIZE"] = "@SCREEN_UV";

--- a/drivers/gles2/shader_compiler_gles2.h
+++ b/drivers/gles2/shader_compiler_gles2.h
@@ -74,6 +74,7 @@ private:
 		Map<StringName, String> renames;
 		Map<StringName, String> render_mode_defines;
 		Map<StringName, String> usage_defines;
+		Map<StringName, String> setter_defines;
 	};
 
 	void _dump_function_deps(ShaderLanguage::ShaderNode *p_node, const StringName &p_for_func, const Map<StringName, String> &p_func_code, StringBuilder &r_to_add, Set<StringName> &r_added);
@@ -86,6 +87,7 @@ private:
 	StringName time_name;
 
 	Set<StringName> used_name_defines;
+	Set<StringName> used_setter_defines;
 	Set<StringName> used_flag_pointers;
 	Set<StringName> used_rmode_defines;
 	Set<StringName> internal_functions;

--- a/drivers/gles3/shader_compiler_gles3.h
+++ b/drivers/gles3/shader_compiler_gles3.h
@@ -76,6 +76,7 @@ private:
 		Map<StringName, String> renames;
 		Map<StringName, String> render_mode_defines;
 		Map<StringName, String> usage_defines;
+		Map<StringName, String> setter_defines;
 	};
 
 	void _dump_function_deps(ShaderLanguage::ShaderNode *p_node, const StringName &p_for_func, const Map<StringName, String> &p_func_code, String &r_to_add, Set<StringName> &added);
@@ -88,6 +89,7 @@ private:
 	StringName time_name;
 
 	Set<StringName> used_name_defines;
+	Set<StringName> used_setter_defines;
 	Set<StringName> used_flag_pointers;
 	Set<StringName> used_rmode_defines;
 	Set<StringName> internal_functions;


### PR DESCRIPTION
!COLOR_USED condition in canvas.glsl will be applied only if "COLOR = [some vec4]" is performed, COLOR.rgb or COLOR.a will not attract this as well as COLOR (+=, *=, /= etc) <some vec4>.

Fix #25009