### PR TITLE
Don't allow to use too big index in ItemList

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -993,7 +993,7 @@ void ItemList::_notification(int p_what) {
 		}
 
 		//ensure_selected_visible needs to be checked before we draw the list.
-		if (ensure_selected_visible && current >= 0 && current <= items.size()) {
+		if (ensure_selected_visible && current >= 0 && current < items.size()) {
 
 			Rect2 r = items[current].rect_cache;
 			int from = scroll_bar->get_value();


### PR DESCRIPTION
I had 2 crashes(which I can't reproduce for now) with this line and seems that sometimes current is equal to item.size.