### PR TITLE
Cleanup unnecessary code from before the scrollbar overlapping fixes

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1477,7 +1477,6 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_hscroll->set_step(0.001);
 	uv_edit_draw->add_child(uv_hscroll);
 	uv_hscroll->set_anchors_and_margins_preset(PRESET_BOTTOM_WIDE);
-	uv_hscroll->set_margin(MARGIN_RIGHT, -uv_vscroll->get_size().x * EDSCALE);
 	uv_hscroll->connect("value_changed", this, "_uv_scroll_changed");
 
 	bone_scroll_main_vb = memnew(VBoxContainer);

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -1028,7 +1028,6 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	hscroll->set_step(0.001);
 	edit_draw->add_child(hscroll);
 	hscroll->set_anchors_and_margins_preset(PRESET_BOTTOM_WIDE);
-	hscroll->set_margin(MARGIN_RIGHT, -vscroll->get_size().x * EDSCALE);
 	hscroll->connect("value_changed", this, "_scroll_changed");
 
 	updating_scroll = false;

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -289,20 +289,6 @@ void GraphEdit::_notification(int p_what) {
 		zoom_plus->set_icon(get_icon("more"));
 		snap_button->set_icon(get_icon("snap"));
 	}
-	if (p_what == NOTIFICATION_READY) {
-		Size2 hmin = h_scroll->get_combined_minimum_size();
-		Size2 vmin = v_scroll->get_combined_minimum_size();
-
-		v_scroll->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_END, -vmin.width);
-		v_scroll->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, 0);
-		v_scroll->set_anchor_and_margin(MARGIN_TOP, ANCHOR_BEGIN, 0);
-		v_scroll->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_END, 0);
-
-		h_scroll->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_BEGIN, 0);
-		h_scroll->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, 0);
-		h_scroll->set_anchor_and_margin(MARGIN_TOP, ANCHOR_END, -hmin.height);
-		h_scroll->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_END, 0);
-	}
 	if (p_what == NOTIFICATION_DRAW) {
 
 		draw_style_box(get_stylebox("bg"), Rect2(Point2(), get_size()));
@@ -1355,10 +1341,13 @@ GraphEdit::GraphEdit() {
 	h_scroll = memnew(HScrollBar);
 	h_scroll->set_name("_h_scroll");
 	top_layer->add_child(h_scroll);
+	h_scroll->set_anchors_and_margins_preset(PRESET_BOTTOM_WIDE);
 
 	v_scroll = memnew(VScrollBar);
 	v_scroll->set_name("_v_scroll");
 	top_layer->add_child(v_scroll);
+	v_scroll->set_anchors_and_margins_preset(PRESET_RIGHT_WIDE);
+
 	updating = false;
 	connecting = false;
 	right_disconnects = false;

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -214,25 +214,6 @@ void ScrollContainer::_gui_input(const Ref<InputEvent> &p_gui_input) {
 		accept_event(); //accept event if scroll changed
 }
 
-void ScrollContainer::_update_scrollbar_position() {
-
-	Size2 hmin = h_scroll->get_combined_minimum_size();
-	Size2 vmin = v_scroll->get_combined_minimum_size();
-
-	v_scroll->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_END, -vmin.width);
-	v_scroll->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, 0);
-	v_scroll->set_anchor_and_margin(MARGIN_TOP, ANCHOR_BEGIN, 0);
-	v_scroll->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_END, 0);
-
-	h_scroll->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_BEGIN, 0);
-	h_scroll->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, 0);
-	h_scroll->set_anchor_and_margin(MARGIN_TOP, ANCHOR_END, -hmin.height);
-	h_scroll->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_END, 0);
-
-	h_scroll->raise();
-	v_scroll->raise();
-}
-
 void ScrollContainer::_ensure_focused_visible(Control *p_control) {
 
 	if (!follow_focus) {
@@ -262,7 +243,8 @@ void ScrollContainer::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
 
-		call_deferred("_update_scrollbar_position");
+		h_scroll->raise();
+		v_scroll->raise();
 	};
 
 	if (p_what == NOTIFICATION_READY) {
@@ -317,6 +299,7 @@ void ScrollContainer::_notification(int p_what) {
 			r.position += ofs;
 			fit_child_in_rect(c, r);
 		}
+
 		update();
 	};
 
@@ -408,21 +391,22 @@ void ScrollContainer::update_scrollbars() {
 
 	Size2 hmin;
 	Size2 vmin;
-	if (scroll_h) hmin = h_scroll->get_combined_minimum_size();
-	if (scroll_v) vmin = v_scroll->get_combined_minimum_size();
+	if (scroll_h) {
+		hmin = h_scroll->get_combined_minimum_size();
+	}
+	if (scroll_v) {
+		vmin = v_scroll->get_combined_minimum_size();
+	}
 
 	Size2 min = child_max_size;
 
-	bool hide_scroll_v = !scroll_v || min.height <= size.height - hmin.height;
-	bool hide_scroll_h = !scroll_h || min.width <= size.width - vmin.width;
+	bool hide_scroll_v = !scroll_v || min.height <= size.height;
+	bool hide_scroll_h = !scroll_h || min.width <= size.width;
 
 	if (hide_scroll_v) {
 
 		v_scroll->hide();
 		scroll.y = 0;
-
-		// modify the horizontal scrollbar's right anchor to fill the container's width
-		h_scroll->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, 0);
 	} else {
 
 		v_scroll->show();
@@ -434,18 +418,12 @@ void ScrollContainer::update_scrollbars() {
 		}
 
 		scroll.y = v_scroll->get_value();
-
-		// modify the horizontal scrollbar's right anchor to stop at the left of the vertical scrollbar
-		h_scroll->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, -vmin.width);
 	}
 
 	if (hide_scroll_h) {
 
 		h_scroll->hide();
 		scroll.x = 0;
-
-		// modify the vertical scrollbar's bottom anchor to fill the container's height
-		v_scroll->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_END, 0);
 	} else {
 
 		h_scroll->show();
@@ -457,10 +435,11 @@ void ScrollContainer::update_scrollbars() {
 		}
 
 		scroll.x = h_scroll->get_value();
-
-		// modify the vertical scrollbar's bottom anchor to stop at the top of the horizontal scrollbar
-		v_scroll->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_END, -hmin.height);
 	}
+
+	// Avoid scrollbar overlapping.
+	h_scroll->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, hide_scroll_v ? 0 : -vmin.width);
+	v_scroll->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_END, hide_scroll_h ? 0 : -hmin.height);
 }
 
 void ScrollContainer::_scroll_moved(float) {
@@ -571,7 +550,6 @@ void ScrollContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_h_scroll_enabled"), &ScrollContainer::is_h_scroll_enabled);
 	ClassDB::bind_method(D_METHOD("set_enable_v_scroll", "enable"), &ScrollContainer::set_enable_v_scroll);
 	ClassDB::bind_method(D_METHOD("is_v_scroll_enabled"), &ScrollContainer::is_v_scroll_enabled);
-	ClassDB::bind_method(D_METHOD("_update_scrollbar_position"), &ScrollContainer::_update_scrollbar_position);
 	ClassDB::bind_method(D_METHOD("_ensure_focused_visible"), &ScrollContainer::_ensure_focused_visible);
 	ClassDB::bind_method(D_METHOD("set_h_scroll", "value"), &ScrollContainer::set_h_scroll);
 	ClassDB::bind_method(D_METHOD("get_h_scroll"), &ScrollContainer::get_h_scroll);
@@ -605,13 +583,14 @@ ScrollContainer::ScrollContainer() {
 	h_scroll = memnew(HScrollBar);
 	h_scroll->set_name("_h_scroll");
 	add_child(h_scroll);
+	h_scroll->connect("value_changed", this, "_scroll_moved");
+	h_scroll->set_anchors_and_margins_preset(PRESET_BOTTOM_WIDE);
 
 	v_scroll = memnew(VScrollBar);
 	v_scroll->set_name("_v_scroll");
 	add_child(v_scroll);
-
-	h_scroll->connect("value_changed", this, "_scroll_moved");
 	v_scroll->connect("value_changed", this, "_scroll_moved");
+	v_scroll->set_anchors_and_margins_preset(PRESET_RIGHT_WIDE);
 
 	drag_speed = Vector2();
 	drag_touching = false;

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -75,7 +75,6 @@ protected:
 	void _scroll_moved(float);
 	static void _bind_methods();
 
-	void _update_scrollbar_position();
 	void _ensure_focused_visible(Control *p_node);
 
 public:


### PR DESCRIPTION
Now with the new code that deals with the overlapping, there was old code that needed to be removed.

This commit also fixes a bug on `ScrollContainer` where the scroll didn't hide when they should.