### PR TITLE
Fix property editor to make changes if popup closed

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -325,6 +325,10 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 	menu->clear();
 	menu->set_size(Size2(1, 1) * EDSCALE);
 
+	for (int i = 0; i < MAX_VALUE_EDITORS / 4; i++) {
+		value_hboxes[i]->hide();
+	}
+
 	for (int i = 0; i < MAX_VALUE_EDITORS; i++) {
 		value_editor[i]->hide();
 		value_label[i]->hide();
@@ -1700,6 +1704,14 @@ void CustomPropertyEditor::config_value_editors(int p_amount, int p_columns, int
 
 	set_size(Size2(cell_margin + p_label_w + (cell_width + cell_margin + p_label_w) * p_columns, cell_margin + (cell_height + cell_margin) * rows) * EDSCALE);
 
+	for (int i = 0; i < MAX_VALUE_EDITORS / 4; i++) {
+		if (i <= p_amount / 4) {
+			value_hboxes[i]->show();
+		} else {
+			value_hboxes[i]->hide();
+		}
+	}
+
 	for (int i = 0; i < MAX_VALUE_EDITORS; i++) {
 		int c = i % p_columns;
 		int r = i / p_columns;
@@ -1729,13 +1741,24 @@ CustomPropertyEditor::CustomPropertyEditor() {
 	read_only = false;
 	updating = false;
 
+	value_vbox = memnew(VBoxContainer);
+	add_child(value_vbox);
+
+	for (int i = 0; i < MAX_VALUE_EDITORS / 4; i++) {
+		value_hboxes[i] = memnew(HBoxContainer);
+		value_vbox->add_child(value_hboxes[i]);
+		value_hboxes[i]->hide();
+	}
+
 	for (int i = 0; i < MAX_VALUE_EDITORS; i++) {
-		value_editor[i] = memnew(LineEdit);
-		add_child(value_editor[i]);
+		int hbox_idx = i / 4;
 		value_label[i] = memnew(Label);
-		add_child(value_label[i]);
-		value_editor[i]->hide();
+		value_hboxes[hbox_idx]->add_child(value_label[i]);
 		value_label[i]->hide();
+		value_editor[i] = memnew(LineEdit);
+		value_editor[i]->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		value_hboxes[hbox_idx]->add_child(value_editor[i]);
+		value_editor[i]->hide();
 		value_editor[i]->connect("text_entered", callable_mp(this, &CustomPropertyEditor::_modified));
 		value_editor[i]->connect("focus_entered", callable_mp(this, &CustomPropertyEditor::_focus_enter));
 		value_editor[i]->connect("focus_exited", callable_mp(this, &CustomPropertyEditor::_focus_exit));

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -100,6 +100,8 @@ class CustomPropertyEditor : public PopupPanel {
 	List<String> field_names;
 	int hint;
 	String hint_text;
+	HBoxContainer *value_hboxes[MAX_VALUE_EDITORS / 4];
+	VBoxContainer *value_vbox;
 	LineEdit *value_editor[MAX_VALUE_EDITORS];
 	int focused_value_editor;
 	Label *value_label[MAX_VALUE_EDITORS];


### PR DESCRIPTION
Old behavior:

![fix0](https://user-images.githubusercontent.com/3036176/72421748-27c20100-3792-11ea-8d6d-389e0d50e37d.gif)

New behavior:
![fix1](https://user-images.githubusercontent.com/3036176/72422023-ae76de00-3792-11ea-956a-1d830bbb8e6b.gif)

Affects VisualShader/VisualScripts