### PR TITLE
Fixes get_floor_normal() returning the user defined floor_normal.

### DIFF
--- a/doc/classes/KinematicBody.xml
+++ b/doc/classes/KinematicBody.xml
@@ -25,14 +25,14 @@
 			<return type="Vector3">
 			</return>
 			<description>
-				Returns the normal vector of the floor.
+				Returns the surface normal of the floor at the last collision point. Only valid after calling [method move_and_slide] or [method move_and_slide_with_snap] and when [method is_on_floor] returns [code]true[/code].
 			</description>
 		</method>
 		<method name="get_floor_velocity" qualifiers="const">
 			<return type="Vector3">
 			</return>
 			<description>
-				Returns the velocity of the floor. Only updates when calling [method move_and_slide].
+				Returns the linear velocity of the floor at the last collision point. Only valid after calling [method move_and_slide] or [method move_and_slide_with_snap] and when [method is_on_floor] returns [code]true[/code].
 			</description>
 		</method>
 		<method name="get_slide_collision">
@@ -106,7 +106,7 @@
 			<description>
 				Moves the body along a vector. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [KinematicBody] or [RigidBody], it will also be affected by the motion of the other body. You can use this to make moving or rotating platforms, or to make nodes push other nodes.
 				[code]linear_velocity[/code] is the velocity vector (typically meters per second). Unlike in [method move_and_collide], you should [i]not[/i] multiply it by [code]delta[/code] — the physics engine handles applying the velocity.
-				[code]floor_normal[/code] is the up direction, used to determine what is a wall and what is a floor or a ceiling. If set to the default value of [code]Vector3(0, 0, 0)[/code], everything is considered a wall. This is useful for topdown games.
+				[code]up_direction[/code] is the up direction, used to determine what is a wall and what is a floor or a ceiling. If set to the default value of [code]Vector3(0, 0, 0)[/code], everything is considered a wall.
 				If [code]stop_on_slope[/code] is [code]true[/code], body will not slide on slopes if you include gravity in [code]linear_velocity[/code].
 				If the body collides, it will change direction a maximum of [code]max_slides[/code] times before it stops.
 				[code]floor_max_angle[/code] is the maximum angle (in radians) where a slope is still considered a floor (or a ceiling), rather than a wall. The default value equals 45 degrees.
@@ -121,7 +121,7 @@
 			</argument>
 			<argument index="1" name="snap" type="Vector3">
 			</argument>
-			<argument index="2" name="floor_normal" type="Vector3" default="Vector3( 0, 0, 0 )">
+			<argument index="2" name="up_direction" type="Vector3" default="Vector3( 0, 0, 0 )">
 			</argument>
 			<argument index="3" name="stop_on_slope" type="bool" default="false">
 			</argument>

--- a/doc/classes/KinematicBody2D.xml
+++ b/doc/classes/KinematicBody2D.xml
@@ -17,14 +17,14 @@
 			<return type="Vector2">
 			</return>
 			<description>
-				Returns the normal vector of the floor.
+				Returns the surface normal of the floor at the last collision point. Only valid after calling [method move_and_slide] or [method move_and_slide_with_snap] and when [method is_on_floor] returns [code]true[/code].
 			</description>
 		</method>
 		<method name="get_floor_velocity" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<description>
-				Returns the velocity of the floor. Only updates when calling [method move_and_slide].
+				Returns the linear velocity of the floor at the last collision point. Only valid after calling [method move_and_slide] or [method move_and_slide_with_snap] and when [method is_on_floor] returns [code]true[/code].
 			</description>
 		</method>
 		<method name="get_slide_collision">
@@ -91,7 +91,7 @@
 			</return>
 			<argument index="0" name="linear_velocity" type="Vector2">
 			</argument>
-			<argument index="1" name="floor_normal" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="1" name="up_direction" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
 			<argument index="2" name="stop_on_slope" type="bool" default="false">
 			</argument>
@@ -104,7 +104,7 @@
 			<description>
 				Moves the body along a vector. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [KinematicBody2D] or [RigidBody2D], it will also be affected by the motion of the other body. You can use this to make moving or rotating platforms, or to make nodes push other nodes.
 				[code]linear_velocity[/code] is the velocity vector in pixels per second. Unlike in [method move_and_collide], you should [i]not[/i] multiply it by [code]delta[/code] — the physics engine handles applying the velocity.
-				[code]floor_normal[/code] is the up direction, used to determine what is a wall and what is a floor or a ceiling. If set to the default value of [code]Vector2(0, 0)[/code], everything is considered a wall. This is useful for topdown games.
+				[code]up_direction[/code] is the up direction, used to determine what is a wall and what is a floor or a ceiling. If set to the default value of [code]Vector2(0, 0)[/code], everything is considered a wall. This is useful for topdown games.
 				If [code]stop_on_slope[/code] is [code]true[/code], body will not slide on slopes when you include gravity in [code]linear_velocity[/code] and the body is standing still.
 				If the body collides, it will change direction a maximum of [code]max_slides[/code] times before it stops.
 				[code]floor_max_angle[/code] is the maximum angle (in radians) where a slope is still considered a floor (or a ceiling), rather than a wall. The default value equals 45 degrees.
@@ -119,7 +119,7 @@
 			</argument>
 			<argument index="1" name="snap" type="Vector2">
 			</argument>
-			<argument index="2" name="floor_normal" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="2" name="up_direction" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
 			<argument index="3" name="stop_on_slope" type="bool" default="false">
 			</argument>

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1234,7 +1234,7 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 	on_ceiling = false;
 	on_wall = false;
 	colliders.clear();
-	floor_normal = p_up_direction;
+	floor_normal = Vector2();
 	floor_velocity = Vector2();
 
 	while (p_max_slides) {
@@ -1473,8 +1473,8 @@ void KinematicBody2D::_notification(int p_what) {
 void KinematicBody2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("move_and_collide", "rel_vec", "infinite_inertia", "exclude_raycast_shapes", "test_only"), &KinematicBody2D::_move, DEFVAL(true), DEFVAL(true), DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("move_and_slide", "linear_velocity", "floor_normal", "stop_on_slope", "max_slides", "floor_max_angle", "infinite_inertia"), &KinematicBody2D::move_and_slide, DEFVAL(Vector2(0, 0)), DEFVAL(false), DEFVAL(4), DEFVAL(Math::deg2rad((float)45)), DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("move_and_slide_with_snap", "linear_velocity", "snap", "floor_normal", "stop_on_slope", "max_slides", "floor_max_angle", "infinite_inertia"), &KinematicBody2D::move_and_slide_with_snap, DEFVAL(Vector2(0, 0)), DEFVAL(false), DEFVAL(4), DEFVAL(Math::deg2rad((float)45)), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("move_and_slide", "linear_velocity", "up_direction", "stop_on_slope", "max_slides", "floor_max_angle", "infinite_inertia"), &KinematicBody2D::move_and_slide, DEFVAL(Vector2(0, 0)), DEFVAL(false), DEFVAL(4), DEFVAL(Math::deg2rad((float)45)), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("move_and_slide_with_snap", "linear_velocity", "snap", "up_direction", "stop_on_slope", "max_slides", "floor_max_angle", "infinite_inertia"), &KinematicBody2D::move_and_slide_with_snap, DEFVAL(Vector2(0, 0)), DEFVAL(false), DEFVAL(4), DEFVAL(Math::deg2rad((float)45)), DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("test_move", "from", "rel_vec", "infinite_inertia"), &KinematicBody2D::test_move, DEFVAL(true));
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -1159,7 +1159,7 @@ Vector3 KinematicBody::move_and_slide(const Vector3 &p_linear_velocity, const Ve
 	on_ceiling = false;
 	on_wall = false;
 	colliders.clear();
-	floor_normal = p_up_direction;
+	floor_normal = Vector3();
 	floor_velocity = Vector3();
 
 	while (p_max_slides) {
@@ -1401,7 +1401,7 @@ void KinematicBody::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("move_and_collide", "rel_vec", "infinite_inertia", "exclude_raycast_shapes", "test_only"), &KinematicBody::_move, DEFVAL(true), DEFVAL(true), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("move_and_slide", "linear_velocity", "up_direction", "stop_on_slope", "max_slides", "floor_max_angle", "infinite_inertia"), &KinematicBody::move_and_slide, DEFVAL(Vector3(0, 0, 0)), DEFVAL(false), DEFVAL(4), DEFVAL(Math::deg2rad((float)45)), DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("move_and_slide_with_snap", "linear_velocity", "snap", "floor_normal", "stop_on_slope", "max_slides", "floor_max_angle", "infinite_inertia"), &KinematicBody::move_and_slide_with_snap, DEFVAL(Vector3(0, 0, 0)), DEFVAL(false), DEFVAL(4), DEFVAL(Math::deg2rad((float)45)), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("move_and_slide_with_snap", "linear_velocity", "snap", "up_direction", "stop_on_slope", "max_slides", "floor_max_angle", "infinite_inertia"), &KinematicBody::move_and_slide_with_snap, DEFVAL(Vector3(0, 0, 0)), DEFVAL(false), DEFVAL(4), DEFVAL(Math::deg2rad((float)45)), DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("test_move", "from", "rel_vec", "infinite_inertia"), &KinematicBody::test_move, DEFVAL(true));
 


### PR DESCRIPTION
Fixes #34992.

When there is no collision with a floor the `get_floor_normal()` function currently returns the user defined `up_direction` vector. Instead, this should be the zero vector so that it is consistent with `get_floor_velocity()`. This patch sets the default value returned by `get_floor_normal()` to the zero vector.

Also renames `floor_normal` to `up_direction` in all the `move_and_slide()` and `move_and_slide_with_snap()` bindings.

Finally, it also updates the documentation of `get_floor_normal()` and `get_floor_velocity()` to make it clear when the values are valid, and updates the documentation for `move_and_slide()` and `move_and_slide_with_snap()` to use the new `up_direction` parameter name.