### PR TITLE
Don't close the connection dialog when the validation failed.

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -127,6 +127,7 @@ void ConnectDialog::ok_pressed() {
 		}
 	}
 	emit_signal("connected");
+	hide();
 }
 
 void ConnectDialog::_cancel_pressed() {
@@ -279,6 +280,8 @@ bool ConnectDialog::is_editing() const {
  * If editing an existing connection, previous data is retained.
  */
 void ConnectDialog::init(Connection c, bool bEdit) {
+
+	set_hide_on_ok(false);
 
 	source = static_cast<Node *>(c.source);
 	signal = c.signal;


### PR DESCRIPTION
Currently the connections dialog closes when no method name is specified. Essentially the inputs are validated and if they are valid, they are applied, otherwise the window is closed without doing anything.

[I've recorded a video that demonstrates this issue][2]

This happens because by default an `AcceptDialog` hides the dialog after the "Ok" button is pressed. This can be configured, from the documentation:

 >   `bool dialog_hide_on_ok`
 >  
 >  If true, the dialog is hidden when the OK button is pressed. You can set it to false if you want to do **e.g. input validation when receiving the confirmed signal, and handle hiding the dialog in your own logic.** Default value: true. ([docs][1])

  [1]: https://docs.godotengine.org/en/3.1/classes/class_acceptdialog.html#class-acceptdialog-property-dialog-hide-on-ok
  [2]: https://github.com/godotengine/godot/files/4064409/demo.zip