### PR TITLE
Allow expressions to be used in shader variable indexing

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -3278,8 +3278,8 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 								_set_error("Index out of range (0-1)");
 								return NULL;
 							}
-						} else {
-							_set_error("Only integer constants are allowed as index at the moment");
+						} else if (index->type != Node::TYPE_VARIABLE && index->type != Node::TYPE_ARRAY && index->type != Node::TYPE_OPERATOR) {
+							_set_error("Only integer expressions are allowed as index.");
 							return NULL;
 						}
 
@@ -3304,8 +3304,8 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 								_set_error("Index out of range (0-2)");
 								return NULL;
 							}
-						} else {
-							_set_error("Only integer constants are allowed as index at the moment");
+						} else if (index->type != Node::TYPE_VARIABLE && index->type != Node::TYPE_ARRAY && index->type != Node::TYPE_OPERATOR) {
+							_set_error("Only integer expressions are allowed as index.");
 							return NULL;
 						}
 
@@ -3329,8 +3329,8 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 								_set_error("Index out of range (0-3)");
 								return NULL;
 							}
-						} else {
-							_set_error("Only integer constants are allowed as index at the moment");
+						} else if (index->type != Node::TYPE_VARIABLE && index->type != Node::TYPE_ARRAY && index->type != Node::TYPE_OPERATOR) {
+							_set_error("Only integer expressions are allowed as index.");
 							return NULL;
 						}
 


### PR DESCRIPTION
```
int n = 1;
float v = vec2(1.0, 0.5)[n]; // USING VARIABLE
```

```
int n[] = {1, 0, 0};
float v = vec2(1.0, 0.5)[n[0]]; // USING ARRAY
```

```
int get_n() {
	return 0;
}
void fragment() {
float v = vec2(1.0, 0.5)[get_n()]; // USING FUNC CALL
}
```

UPDATE: Also other expressions can now be used like:
```
int i = 0;
float v = vec3(1.0, 0.5, 0.25)[++i + 1]; 
```

Fix #35149