### PR TITLE
Fix GridMap getter of baked meshes.

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -122,7 +122,7 @@ bool GridMap::_get(const StringName &p_name, Variant &r_ret) const {
 		Array ret;
 		ret.resize(baked_meshes.size());
 		for (int i = 0; i < baked_meshes.size(); i++) {
-			ret.push_back(baked_meshes[i].mesh);
+			ret[i] = baked_meshes[i].mesh;
 		}
 		r_ret = ret;
 


### PR DESCRIPTION
Fixes #32028.

The issue happened when saving the Scene to disk, The baked mesh list ended up being double the size with the first half as invalid refs.

Then, when loading the Scene all the invalid refs would trigger the macro on the `_set` method:
https://github.com/godotengine/godot/blob/7c624949b5c17d6a4f503b4e299c8c717280cd23/modules/gridmap/grid_map.cpp#L68-L77