### PR TITLE
Disabled non-const local/varying shader array in GLES2

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -353,11 +353,6 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 				varying_code += _typestr(E->get().type);
 				varying_code += " ";
 				varying_code += _mkid(E->key());
-				if (E->get().array_size > 0) {
-					varying_code += "[";
-					varying_code += itos(E->get().array_size);
-					varying_code += "]";
-				}
 				varying_code += ";\n";
 
 				String final_code = varying_code.as_string();
@@ -522,9 +517,7 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 			SL::ArrayDeclarationNode *arr_dec_node = (SL::ArrayDeclarationNode *)p_node;
 
 			StringBuffer<> declaration;
-			if (arr_dec_node->is_const) {
-				declaration += "const ";
-			}
+			declaration += "const ";
 			declaration += _prestr(arr_dec_node->precision);
 			declaration += _typestr(arr_dec_node->datatype);
 

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -3886,6 +3886,12 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const Map<StringName, Bui
 				tk = _get_token();
 
 				if (tk.type == TK_BRACKET_OPEN) {
+
+					if (VisualServer::get_singleton()->is_low_end() && !is_const) {
+						_set_error("Local non-const arrays are supported only on high-end platform!");
+						return ERR_PARSE_ERROR;
+					}
+
 					bool unknown_size = false;
 
 					ArrayDeclarationNode *node = alloc_node<ArrayDeclarationNode>();
@@ -5008,6 +5014,12 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 					}
 
 					if (tk.type == TK_BRACKET_OPEN) {
+
+						if (VisualServer::get_singleton()->is_low_end()) {
+							_set_error("Varying arrays are supported only on high-end platform!");
+							return ERR_PARSE_ERROR;
+						}
+
 						tk = _get_token();
 						if (tk.type == TK_INT_CONSTANT && tk.constant > 0) {
 							varying.array_size = (int)tk.constant;


### PR DESCRIPTION
Removed arrays from GLES2 backend. Since they are likely to be unsupported and @akien-mga prooved it.