### PR TITLE
Prevent memory leak on homonymous files in Filesystem dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -139,7 +139,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 		if (parent_should_expand) {
 			subdirectory_item->set_collapsed(false);
 		} else if (dname != "res://") {
-			subdirectory_item->get_parent()->remove_child(subdirectory_item);
+			memdelete(subdirectory_item);
 		}
 	}
 


### PR DESCRIPTION
Fixes #29215.

Co-authored-by: @qarmin 

----

The errors mentioned by @qarmin in #29215 that should arise from this fix no longer seem reproducible, so I guess it should be good to go.