### PR TITLE
Fix error when click edge of the tree icon

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2339,13 +2339,22 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 					cache.click_type = Cache::CLICK_NONE;
 					return -1;
 				}
+
+				// Make sure the click is correct.
+				Point2 click_pos = get_global_mouse_position() - get_global_position();
+				if (!get_item_at_position(click_pos)) {
+					pressed_button = -1;
+					cache.click_type = Cache::CLICK_NONE;
+					return -1;
+				}
+
 				pressed_button = j;
 				cache.click_type = Cache::CLICK_BUTTON;
 				cache.click_index = j;
 				cache.click_id = c.buttons[j].id;
 				cache.click_item = p_item;
 				cache.click_column = col;
-				cache.click_pos = get_global_mouse_position() - get_global_position();
+				cache.click_pos = click_pos;
 				update();
 				//emit_signal(SNAME("button_pressed"));
 				return -1;


### PR DESCRIPTION
Fixes #27580

This might be a little hack though. The problem is that the method which sets `cache.click_type` and the `get_item_at_position()` use different logic and recognize clicks with different results. The clicked item is then "ensured" here, which might result in nulling a correct click:
https://github.com/godotengine/godot/blob/5f99e3396f8468ab74bff6bc2fe9742f670a054a/scene/gui/tree.cpp#L2611-L2615
If you add another null check in the code I linked above, it results in click having a visual click rectangle and no effect.

The logic of determining click is too convoluted, so I just gave up in fixing the differences and ensured the same result by calling `get_item_at_position()`.