### PR TITLE
Fix light related crashes

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -1169,7 +1169,7 @@ void RasterizerSceneGLES2::_add_geometry_with_material(RasterizerStorageGLES2::G
 
 				LightInstance *li = light_instance_owner.getornull(e->instance->light_instances[i]);
 
-				if (li->light_index >= render_light_instance_count || render_light_instances[li->light_index] != li) {
+				if (!li || li->light_index >= render_light_instance_count || render_light_instances[li->light_index] != li) {
 					continue; // too many or light_index did not correspond to the light instances to be rendered
 				}
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1887,8 +1887,8 @@ void RasterizerSceneGLES3::_setup_light(RenderList::Element *e, const Transform 
 		const RID *lights = e->instance->light_instances.ptr();
 
 		for (int i = 0; i < lc; i++) {
-			LightInstance *li = light_instance_owner.getptr(lights[i]);
-			if (li->last_pass != render_pass) //not visible
+			LightInstance *li = light_instance_owner.getornull(lights[i]);
+			if (!li || li->last_pass != render_pass) //not visible
 				continue;
 
 			if (li && li->light_ptr->type == VS::LIGHT_OMNI) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/33007

@qarmin Can you test this out? I wasn't able to reproduce the GLES3 crash, but this should fix it.