### PR TITLE
Use int64_t for EditorPropertyInteger and warn when out of double range

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -805,10 +805,10 @@ EditorPropertyLayers::EditorPropertyLayers() {
 
 ///////////////////// INT /////////////////////////
 
-void EditorPropertyInteger::_value_changed(double val) {
+void EditorPropertyInteger::_value_changed(int64_t val) {
 	if (setting)
 		return;
-	emit_changed(get_edited_property(), (int64_t)val);
+	emit_changed(get_edited_property(), val);
 }
 
 void EditorPropertyInteger::update_property() {
@@ -816,14 +816,19 @@ void EditorPropertyInteger::update_property() {
 	setting = true;
 	spin->set_value(val);
 	setting = false;
+#ifdef DEBUG_ENABLED
+	// If spin (currently EditorSplinSlider : Range) is changed so that it can use int64_t, then the below warning wouldn't be a problem.
+	if (val != (int64_t)(double)(val)) {
+		WARN_PRINT("Cannot reliably represent '" + itos(val) + "' in the inspector, value is too large.");
+	}
+#endif
 }
 
 void EditorPropertyInteger::_bind_methods() {
-
 	ClassDB::bind_method(D_METHOD("_value_changed"), &EditorPropertyInteger::_value_changed);
 }
 
-void EditorPropertyInteger::setup(int p_min, int p_max, int p_step, bool p_allow_greater, bool p_allow_lesser) {
+void EditorPropertyInteger::setup(int64_t p_min, int64_t p_max, int64_t p_step, bool p_allow_greater, bool p_allow_lesser) {
 	spin->set_min(p_min);
 	spin->set_max(p_max);
 	spin->set_step(p_step);

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -263,14 +263,14 @@ class EditorPropertyInteger : public EditorProperty {
 	GDCLASS(EditorPropertyInteger, EditorProperty);
 	EditorSpinSlider *spin;
 	bool setting;
-	void _value_changed(double p_val);
+	void _value_changed(int64_t p_val);
 
 protected:
 	static void _bind_methods();
 
 public:
 	virtual void update_property();
-	void setup(int p_min, int p_max, int p_step, bool p_allow_greater, bool p_allow_lesser);
+	void setup(int64_t p_min, int64_t p_max, int64_t p_step, bool p_allow_greater, bool p_allow_lesser);
 	EditorPropertyInteger();
 };
 


### PR DESCRIPTION
Related to #32106, does not completely fix it, but that issue can be pushed back to 4.0 after this PR for reasons I'll explain below.

`EditorPropertyInteger` should use `int64_t` whenever possible, but there are still some editor limitations with no easy fixes (easy as in minimal code change).

Due to `EditorSpinSlider` using `double`, there is no way to fully solve #32106 without duplicating `EditorSpinSlider` and its parent class `Range` to make a version using `int64_t`, or refactoring it so that it's generic somehow. If desired, that would be a big change which should wait 4.0, so in the meantime we should just show a warning when out of `double`'s range (what this PR does).

But also, the inspector limits you to the values possible for `int32_t`, so the only way to produce this warning is by writing code that outputs these values to the editor as #32106 does. Therefore the rest of this issue is quite low priority in my opinion, the warnings only show up when extremely large user-code-generated values are shown in the editor.