### PR TITLE
MinGW: Avoid GCC -Wcast-function-type warnings on GetProcAddress

### DIFF
--- a/platform/windows/context_gl_windows.cpp
+++ b/platform/windows/context_gl_windows.cpp
@@ -43,6 +43,11 @@
 #define WGL_CONTEXT_PROFILE_MASK_ARB 0x9126
 #define WGL_CONTEXT_CORE_PROFILE_BIT_ARB 0x00000001
 
+#if defined(__GNUC__)
+// Workaround GCC warning from -Wcast-function-type.
+#define wglGetProcAddress (void *)wglGetProcAddress
+#endif
+
 typedef HGLRC(APIENTRY *PFNWGLCREATECONTEXTATTRIBSARBPROC)(HDC, HGLRC, const int *);
 
 void ContextGL_Windows::release_current() {

--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -37,6 +37,11 @@
 #define __builtin_bswap32 _byteswap_ulong
 #endif
 
+#if defined(__GNUC__)
+// Workaround GCC warning from -Wcast-function-type.
+#define GetProcAddress (void *)GetProcAddress
+#endif
+
 DWORD WINAPI _xinput_get_state(DWORD dwUserIndex, XINPUT_STATE *pState) {
 	return ERROR_DEVICE_NOT_CONNECTED;
 }

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -74,6 +74,11 @@ __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 #define WM_POINTERUPDATE 0x0245
 #endif
 
+#if defined(__GNUC__)
+// Workaround GCC warning from -Wcast-function-type.
+#define GetProcAddress (void *)GetProcAddress
+#endif
+
 typedef struct {
 	int count;
 	int screen;


### PR DESCRIPTION
Using the same method as GNUlib and various other projects.
https://lists.gnu.org/archive/html/bug-gnulib/2018-08/msg00109.html

The warning is valid, but there's no way around it since the issue
comes from the Windows SDK. It's also harmless in this case.

Part of #29801.