### PR TITLE
Refactor (and fix) how the connect button is disabled.

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -146,7 +146,7 @@ void ConnectDialog::_tree_node_selected() {
 		return;
 
 	dst_path = source->get_path_to(current);
-	get_ok()->set_disabled(false);
+	_update_ok_enabled();
 }
 
 /*
@@ -210,6 +210,27 @@ void ConnectDialog::_remove_bind() {
 	cdbinds->notify_changed();
 }
 
+/*
+ * Enables or disables the connect button. The connect button is enabled if a
+ * node is selected and valid in the selected mode.
+ */
+void ConnectDialog::_update_ok_enabled() {
+
+	Node *target = tree->get_selected();
+
+	if (target == nullptr) {
+		get_ok()->set_disabled(true);
+		return;
+	}
+
+	if (!advanced->is_pressed() && target->get_script().is_null()) {
+		get_ok()->set_disabled(true);
+		return;
+	}
+
+	get_ok()->set_disabled(false);
+}
+
 void ConnectDialog::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
@@ -225,6 +246,7 @@ void ConnectDialog::_bind_methods() {
 	ClassDB::bind_method("_tree_item_activated", &ConnectDialog::_tree_item_activated);
 	ClassDB::bind_method("_add_bind", &ConnectDialog::_add_bind);
 	ClassDB::bind_method("_remove_bind", &ConnectDialog::_remove_bind);
+	ClassDB::bind_method("_update_ok_enabled", &ConnectDialog::_update_ok_enabled);
 
 	ADD_SIGNAL(MethodInfo("connected"));
 }
@@ -301,12 +323,11 @@ void ConnectDialog::init(Connection c, bool bEdit) {
 	tree->set_marked(source, true);
 
 	if (c.target) {
-		get_ok()->set_disabled(false);
 		set_dst_node(static_cast<Node *>(c.target));
 		set_dst_method(c.method);
-	} else {
-		get_ok()->set_disabled(true);
 	}
+
+	_update_ok_enabled();
 
 	bool bDeferred = (c.flags & CONNECT_DEFERRED) == CONNECT_DEFERRED;
 	bool bOneshot = (c.flags & CONNECT_ONESHOT) == CONNECT_ONESHOT;
@@ -349,6 +370,8 @@ void ConnectDialog::_advanced_pressed() {
 		vbc_right->hide();
 		error_label->set_visible(!_find_first_script(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root()));
 	}
+
+	_update_ok_enabled();
 
 	set_position((get_viewport_rect().size - get_custom_minimum_size()) / 2);
 }

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -80,6 +80,7 @@ class ConnectDialog : public ConfirmationDialog {
 	void _add_bind();
 	void _remove_bind();
 	void _advanced_pressed();
+	void _update_ok_enabled();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
Currently it is possible to switch to the advanced mode (where more nodes are selectable) select a node and then switch back, such that the selected node is no longer selected in the default mode. The connect button, however, is not updated and still enabled.

[Here is a video that demonstrates the issue.](https://github.com/godotengine/godot/files/4071097/demo.zip)

I changed it such that the connect button is enabled or disabled when the mode is switched. Additionally, I moved this code into the helper function `_update_ok_enabled`.

---

As a side node: was it the right decision to create three individual pull requests (that is #35123, #35148 and this one) or would it have been better to create one pull request for all three issues? I mean all three pull request changed the same file, and all...