### PR TITLE
Validate instances of objects before trying to check their type in GDScript

### DIFF
--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -76,14 +76,17 @@ struct GDScriptDataType {
 				if (p_variant.get_type() != Variant::OBJECT) {
 					return false;
 				}
+
 				Object *obj = p_variant.operator Object *();
-				if (obj) {
-					if (!ClassDB::is_parent_class(obj->get_class_name(), native_type)) {
-						// Try with underscore prefix
-						StringName underscore_native_type = "_" + native_type;
-						if (!ClassDB::is_parent_class(obj->get_class_name(), underscore_native_type)) {
-							return false;
-						}
+				if (!obj || !ObjectDB::instance_validate(obj)) {
+					return false;
+				}
+
+				if (!ClassDB::is_parent_class(obj->get_class_name(), native_type)) {
+					// Try with underscore prefix
+					StringName underscore_native_type = "_" + native_type;
+					if (!ClassDB::is_parent_class(obj->get_class_name(), underscore_native_type)) {
+						return false;
 					}
 				}
 				return true;
@@ -96,7 +99,12 @@ struct GDScriptDataType {
 				if (p_variant.get_type() != Variant::OBJECT) {
 					return false;
 				}
+
 				Object *obj = p_variant.operator Object *();
+				if (!obj || !ObjectDB::instance_validate(obj)) {
+					return false;
+				}
+
 				Ref<Script> base = obj && obj->get_script_instance() ? obj->get_script_instance()->get_script() : NULL;
 				bool valid = false;
 				while (base.is_valid()) {


### PR DESCRIPTION
Opening as a draft PR as this can potentially be detrimental to performance.

There are three approaches to fixing the problem:
* Patch it in `Variant::operator Object*()` so that freed objects result in `NULL`. Potentially breaking, would likely have to wait for 4.0, if not more.
* Validate instance only in debug builds, raising an error similar to `Variant::call_ptr`. Unfortunately, making an error out of this behavior means that genuine usecases such as the one in #29970 cannot use free()/queue_free() without potentially messing up one or more signal/deferred callbacks.
* Validate instance in all cases we have an Object-typed argument in a function call. This means that such arguments are a bit more taxing on performance, as validating the object instance involves acquiring a global read lock in ObjectDB.

Fixes #27582, fixes #29970.