### PR TITLE
Fix error exporting to X11 with embedded PCK

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -171,7 +171,7 @@ def configure(env):
             else:
                 env.Append(CCFLAGS=['-flto'])
                 env.Append(LINKFLAGS=['-flto'])
-        
+
         if not env['use_llvm']:
             env['RANLIB'] = 'gcc-ranlib'
             env['AR'] = 'gcc-ar'
@@ -329,9 +329,15 @@ def configure(env):
 
     if env["execinfo"]:
         env.Append(LIBS=['execinfo'])
-        
+
     if not env['tools']:
-        env.Append(LINKFLAGS=['-T', 'platform/x11/pck_embed.ld'])
+        import subprocess
+        import re
+        binutils_version = re.search('\s(\d+\.\d+)', str(subprocess.check_output(['ld', '-v']))).group(1)
+        if float(binutils_version) >= 2.30:
+            env.Append(LINKFLAGS=['-T', 'platform/x11/pck_embed.ld'])
+        else:
+            env.Append(LINKFLAGS=['-T', 'platform/x11/pck_embed.legacy.ld'])
 
     ## Cross-compilation
 

--- a/platform/x11/pck_embed.ld
+++ b/platform/x11/pck_embed.ld
@@ -1,9 +1,9 @@
 SECTIONS
 {
 	/* Add a zero-sized section; the exporter will patch it to enclose the data appended to the executable (embedded PCK) */
-	pck 0 (NOLOAD) :
+	pck 0 (INFO) :
 	{
-		/* Just some content to avoid the linker discarding the section */
+		/* binutils >= 2.30 allow it being zero-sized, but needs something between the braces to keep the section */
 		. = ALIGN(8);
 	}
 }

--- a/platform/x11/pck_embed.legacy.ld
+++ b/platform/x11/pck_embed.legacy.ld
@@ -1,0 +1,10 @@
+SECTIONS
+{
+	/* The exporter will patch this section to enclose the data appended to the executable (embedded PCK) */
+	pck 0 (INFO) : AT ( ADDR (.rodata) + SIZEOF (.rodata) )
+	{
+		/* binutils < 2.30 need some actual content for the linker not to discard the section */
+		BYTE(0);
+	}
+}
+INSERT AFTER .rodata;


### PR DESCRIPTION
The primary linker script (the one we had so far) is able to create the zero-sized PCK section, but that does not work for `binutils` < v. 2.30 (like v. 2.24, currently used to build the official templates).

A version check is performed to use the "legacy" linker script that works and creates the section, but after exporting with embedded PCK there will be one stray byte in the file, that may upset some antivirus.

I think this is good enough for now. Switching to a newer Ubuntu for the build containers may be too risky at this point.

Fixes #32513.