### PR TITLE
Fix SkeletonIK not playing animation if more than one IK-Bone is active

### DIFF
--- a/scene/animation/skeleton_ik.cpp
+++ b/scene/animation/skeleton_ik.cpp
@@ -320,7 +320,7 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 				new_bone_pose.basis = new_bone_pose.basis * p_task->chain.tips[0].end_effector->goal_transform.basis;
 		}
 
-		p_task->skeleton->set_bone_global_pose_override(ci->bone, new_bone_pose, 1.0);
+		p_task->skeleton->set_bone_global_pose_override(ci->bone, new_bone_pose, 1.0, true);
 
 		if (!ci->children.empty())
 			ci = &ci->children.write[0];


### PR DESCRIPTION
Fixes #35035 
SkeletonIK was not marked as persistent and therefore "global_pose_override_amount" was reset every tick.