### PR TITLE
Make stationary Area2D re-detect bodies when its shapes change

### DIFF
--- a/servers/physics/area_sw.cpp
+++ b/servers/physics/area_sw.cpp
@@ -46,6 +46,8 @@ AreaSW::BodyKey::BodyKey(AreaSW *p_body, uint32_t p_body_shape, uint32_t p_area_
 }
 
 void AreaSW::_shapes_changed() {
+	if (!moved_list.in_list() && get_space())
+		get_space()->area_add_to_moved_list(&moved_list);
 }
 
 void AreaSW::set_transform(const Transform &p_transform) {

--- a/servers/physics_2d/area_2d_sw.cpp
+++ b/servers/physics_2d/area_2d_sw.cpp
@@ -46,6 +46,8 @@ Area2DSW::BodyKey::BodyKey(Area2DSW *p_body, uint32_t p_body_shape, uint32_t p_a
 }
 
 void Area2DSW::_shapes_changed() {
+	if (!moved_list.in_list() && get_space())
+		get_space()->area_add_to_moved_list(&moved_list);
 }
 
 void Area2DSW::set_transform(const Transform2D &p_transform) {


### PR DESCRIPTION
Fixes #34124 (potentially other issues as well, I think this has popped up quite a bit of times).

Changed 3D Area for Godot default physics in a similar manner, to maintain feature parity. 3D Area in Bullet should be already working, though I didn't test it.