### PR TITLE
Fix constant access in base class through subclass instance

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -67,23 +67,23 @@ Variant *GDScriptFunction::_get_variant(int p_address, GDScriptInstance *p_insta
 		case ADDR_TYPE_CLASS_CONSTANT: {
 
 			//todo change to index!
-			GDScript *o = p_script;
+			GDScript *s = p_script;
 #ifdef DEBUG_ENABLED
 			ERR_FAIL_INDEX_V(address, _global_names_count, NULL);
 #endif
 			const StringName *sn = &_global_names_ptr[address];
 
-			while (o) {
-				GDScript *s = o;
-				while (s) {
+			while (s) {
+				GDScript *o = s;
+				while (o) {
 
-					Map<StringName, Variant>::Element *E = s->constants.find(*sn);
+					Map<StringName, Variant>::Element *E = o->constants.find(*sn);
 					if (E) {
 						return &E->get();
 					}
-					s = s->_base;
+					o = o->_owner;
 				}
-				o = o->_owner;
+				s = s->_base;
 			}
 
 			ERR_FAIL_V_MSG(NULL, "GDScriptCompiler bug.");


### PR DESCRIPTION
Fixes as issue where a subclass calls a base class method that tries to access a constant from the script.
The original code went through every ower class, and for each owner, went through its inheritance tree.
This seems like the wrong order, the modified code goes to each base class, and for each base class goes through the owner tree.
This is more in line with what the parser does, as the current impelemtation allows an access that the parser does not support.
This change should not negatively affect existing code due to the way the parser works

Fixes: https://github.com/godotengine/godot/issues/35025