### PR TITLE
Fix crash when confirming dialogs with Return key

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -423,7 +423,8 @@ void SceneTree::input_event(const Ref<InputEvent> &p_event) {
 
 	input_handled = false;
 
-	const Ref<InputEvent> &ev = p_event;
+	// Don't make const ref unless you can find and fix what caused GH-34691.
+	Ref<InputEvent> ev = p_event;
 
 	MainLoop::input_event(ev);
 


### PR DESCRIPTION
Regression from #34040, apparently making this a const reference
introduces issues (not sure why, but previous code worked fine).

Fixes #34691.

Co-authored-by: @dankan1890