### PR TITLE
Android: Improve name of icon export properties

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -203,9 +203,9 @@ struct LauncherIcon {
 };
 
 static const int icon_densities_count = 6;
-static const char *launcher_icon_option = "launcher_icon/xxxhdpi_192x192";
-static const char *launcher_adaptive_icon_foreground_option = "launcher_adaptive_icon_foreground/xxxhdpi_432x432";
-static const char *launcher_adaptive_icon_background_option = "launcher_adaptive_icon_background/xxxhdpi_432x432";
+static const char *launcher_icon_option = "launcher_icons/main_192x192";
+static const char *launcher_adaptive_icon_foreground_option = "launcher_icons/adaptive_foreground_432x432";
+static const char *launcher_adaptive_icon_background_option = "launcher_icons/adaptive_background_432x432";
 
 static const LauncherIcon launcher_icons[icon_densities_count] = {
 	{ "res/mipmap-xxxhdpi-v4/icon.png", 192 },


### PR DESCRIPTION
This seems more readable and still includes the required dimensions.

Before:
![Screenshot_20200117_130453](https://user-images.githubusercontent.com/4701338/72611432-596dd000-392a-11ea-83d7-a1b2ebab73cb.png)

After:
![Screenshot_20200117_130543](https://user-images.githubusercontent.com/4701338/72611435-5bd02a00-392a-11ea-90a2-f6b4c9470deb.png)

CC @MadEqua @m4gr3d - I didn't test the change but as I read it I think it should be safe enough. Unless it's really important to feature `xxxhdpi` in the name, I think it's more readable this way.