### PR TITLE
HTML5: Address removal of 'timestamp' in Emscripten 1.39.5

### DIFF
--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -301,6 +301,7 @@ EM_BOOL OS_JavaScript::mouse_button_callback(int p_event_type, const EmscriptenM
 	ev->set_position(correct_canvas_position(p_event->canvasX, p_event->canvasY));
 	ev->set_global_position(ev->get_position());
 	dom2godot_mod(p_event, ev);
+
 	switch (p_event->button) {
 		case DOM_BUTTON_LEFT: ev->set_button_index(BUTTON_LEFT); break;
 		case DOM_BUTTON_MIDDLE: ev->set_button_index(BUTTON_MIDDLE); break;
@@ -312,7 +313,7 @@ EM_BOOL OS_JavaScript::mouse_button_callback(int p_event_type, const EmscriptenM
 
 	if (ev->is_pressed()) {
 
-		uint64_t diff = p_event->timestamp - os->last_click_ms;
+		double diff = emscripten_get_now() - os->last_click_ms;
 
 		if (ev->get_button_index() == os->last_click_button_index) {
 

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -55,7 +55,7 @@ class OS_JavaScript : public OS_Unix {
 	Point2 touches[32];
 
 	Point2i last_click_pos;
-	uint64_t last_click_ms;
+	double last_click_ms;
 	int last_click_button_index;
 
 	MainLoop *main_loop;


### PR DESCRIPTION
It was removed as noted in the changelog:
https://github.com/emscripten-core/emscripten/blob/1.39.5/ChangeLog.md#v1395-12202019

> Removed `timestamp` field from mouse, wheel, devicemotion and
> deviceorientation events. The presence of a `timestamp` on these
> events was slightly arbitrary, and populating this field caused
> a small profileable overhead that all users might not care about.
> It is easy to get a timestamp of an event by calling
> `emscripten_get_now()` or `emscripten_performance_now()` inside
> the event handler function of any event.

Fixes #34648.

----

It builds fine with 1.39.5 as well as 1.39.1.

While testing with 1.39.5 I ran into another issue (likely another compat change to address) but things work fine in 1.39.1 (including double click detection).