### PR TITLE
Disconnect while downloading

### DIFF
--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -349,8 +349,9 @@ bool HTTPRequest::_update_connection() {
 			}
 
 			client->poll();
-			if (client->get_status() != HTTPClient::STATUS_BODY)
-				break; // State changed after this poll, will check at next iteration.
+			if (client->get_status() != HTTPClient::STATUS_BODY) {
+				return false;
+			}
 
 			PoolByteArray chunk = client->read_response_body_chunk();
 			downloaded += chunk.size();

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -349,6 +349,8 @@ bool HTTPRequest::_update_connection() {
 			}
 
 			client->poll();
+			if (client->get_status() != HTTPClient::STATUS_BODY)
+				break; // State changed after this poll, will check at next iteration.
 
 			PoolByteArray chunk = client->read_response_body_chunk();
 			downloaded += chunk.size();


### PR DESCRIPTION
Previously if a disconnect occured while downloading a non recoverable error was displayed which could not be captured. This PR attempts to fix this by making sure `request_completed` signal is emitted with an `STATUS_CONNECTION_ERROR` response code so that the user can act accordingly (restart the download in my case).