### PR TITLE
doc: Mention the limited comment support in ConfigFile

### DIFF
--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -26,6 +26,7 @@
 		    config.save("user://settings.cfg")
 		[/codeblock]
 		Keep in mind that section and property names can't contain spaces. Anything after a space will be ignored on save and on load.
+		ConfigFiles can also contain manually written comment lines starting with a semicolon ([code];[/code]). Those lines will be ignored when parsing the file. Note that comments will be lost when saving the ConfigFile. This can still be useful for dedicated server configuration files, which are typically never overwritten without explicit user action.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
ConfigFile supports comments to some extent, so I thought it'd be good to document it here as well. (It's already documented on [TSCN file format](https://docs.godotengine.org/en/latest/development/file_formats/tscn.html).)