### PR TITLE
Add BLEND_MODE_DISABLED to Spatial Shader render_mode as blend_disabled

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2168,6 +2168,11 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 
 			if (p_alpha_pass || p_directional_add) {
 				int desired_blend_mode;
+				if (desired_blend_mode == RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_DISABLED && (!storage->frame.current_rt || !storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT])) {
+					desired_blend_mode = RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_MIX;
+				}
+
+
 				if (p_directional_add) {
 					desired_blend_mode = RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_ADD;
 				} else {
@@ -2176,8 +2181,19 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 
 				if (desired_blend_mode != current_blend_mode) {
 
-					switch (desired_blend_mode) {
+					if (current_blend_mode == RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_DISABLED) {
+						// re-enable it
+						glEnable(GL_BLEND);
+					} else if (desired_blend_mode == RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_DISABLED) {
+						// disable it
+						glDisable(GL_BLEND);
+					}
 
+
+					switch (desired_blend_mode) {
+						case RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_DISABLED: {
+
+						} break;
 						case RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_MIX: {
 							glBlendEquation(GL_FUNC_ADD);
 							if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]) {

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2269,6 +2269,7 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 			shaders.actions_scene.render_mode_values["blend_mix"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_MIX);
 			shaders.actions_scene.render_mode_values["blend_sub"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_SUB);
 			shaders.actions_scene.render_mode_values["blend_mul"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_MUL);
+			shaders.actions_scene.render_mode_values["blend_disabled"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_DISABLED);
 
 			shaders.actions_scene.render_mode_values["depth_draw_opaque"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_OPAQUE);
 			shaders.actions_scene.render_mode_values["depth_draw_always"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_ALWAYS);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -464,6 +464,7 @@ public:
 				BLEND_MODE_ADD,
 				BLEND_MODE_SUB,
 				BLEND_MODE_MUL,
+				BLEND_MODE_DISABLED,
 			};
 
 			int blend_mode;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -423,6 +423,7 @@ void SpatialMaterial::_update_shader() {
 		case BLEND_MODE_ADD: code += "blend_add"; break;
 		case BLEND_MODE_SUB: code += "blend_sub"; break;
 		case BLEND_MODE_MUL: code += "blend_mul"; break;
+		case BLEND_MODE_DISABLED: code += "blend_disabled"; break;
 	}
 
 	DepthDrawMode ddm = depth_draw_mode;
@@ -1035,6 +1036,9 @@ void SpatialMaterial::_update_shader() {
 			} break;
 			case BLEND_MODE_MUL: {
 				code += "\tvec3 detail = mix(ALBEDO.rgb,ALBEDO.rgb*detail_tex.rgb,detail_tex.a);\n";
+			} break;
+			case BLEND_MODE_DISABLED: {
+				code += "\tvec3 detail = ALBEDO.rgb;\n";
 			} break;
 		}
 
@@ -2119,7 +2123,7 @@ void SpatialMaterial::_bind_methods() {
 	ADD_GROUP("Parameters", "params_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_diffuse_mode", PROPERTY_HINT_ENUM, "Burley,Lambert,Lambert Wrap,Oren Nayar,Toon"), "set_diffuse_mode", "get_diffuse_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_specular_mode", PROPERTY_HINT_ENUM, "SchlickGGX,Blinn,Phong,Toon,Disabled"), "set_specular_mode", "get_specular_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Sub,Mul"), "set_blend_mode", "get_blend_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Sub,Mul,Disabled"), "set_blend_mode", "get_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_cull_mode", PROPERTY_HINT_ENUM, "Back,Front,Disabled"), "set_cull_mode", "get_cull_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_depth_draw_mode", PROPERTY_HINT_ENUM, "Opaque Only,Always,Never,Opaque Pre-Pass"), "set_depth_draw_mode", "get_depth_draw_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "params_line_width", PROPERTY_HINT_RANGE, "0.1,128,0.1"), "set_line_width", "get_line_width");
@@ -2216,7 +2220,7 @@ void SpatialMaterial::_bind_methods() {
 	ADD_GROUP("Detail", "detail_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "detail_enabled"), "set_feature", "get_feature", FEATURE_DETAIL);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "detail_mask", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_texture", "get_texture", TEXTURE_DETAIL_MASK);
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "detail_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Sub,Mul"), "set_detail_blend_mode", "get_detail_blend_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "detail_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Sub,Mul,Disabled"), "set_detail_blend_mode", "get_detail_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "detail_uv_layer", PROPERTY_HINT_ENUM, "UV1,UV2"), "set_detail_uv", "get_detail_uv");
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "detail_albedo", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_texture", "get_texture", TEXTURE_DETAIL_ALBEDO);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "detail_normal", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_texture", "get_texture", TEXTURE_DETAIL_NORMAL);
@@ -2280,6 +2284,7 @@ void SpatialMaterial::_bind_methods() {
 	BIND_ENUM_CONSTANT(BLEND_MODE_ADD);
 	BIND_ENUM_CONSTANT(BLEND_MODE_SUB);
 	BIND_ENUM_CONSTANT(BLEND_MODE_MUL);
+	BIND_ENUM_CONSTANT(BLEND_MODE_DISABLED);
 
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_OPAQUE_ONLY);
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_ALWAYS);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -158,6 +158,7 @@ public:
 		BLEND_MODE_ADD,
 		BLEND_MODE_SUB,
 		BLEND_MODE_MUL,
+		BLEND_MODE_DISABLED,
 	};
 
 	enum DepthDrawMode {

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -158,6 +158,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_add");
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_sub");
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_mul");
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_disabled");
 
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("depth_draw_opaque");
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("depth_draw_always");


### PR DESCRIPTION
This allows for Viewports with mesh instances to capture the RGBA independently of blend modes..

An extremely necessary feature for Creating any kind of advanced Multi-pass shaders or Render passes that require dense packing.  

It follows the Add "No-blend" branch of the canvas item.  Same just for spatial. It was a bit of work!

I would really love it if this get's pulled .. I saw lots of people who wanted this feature.