### PR TITLE
Improves VideoPlayer's documentation

### DIFF
--- a/doc/classes/VideoPlayer.xml
+++ b/doc/classes/VideoPlayer.xml
@@ -13,7 +13,7 @@
 			<return type="String">
 			</return>
 			<description>
-				Returns the video stream's name.
+				Returns the video stream's name, or [code]"&lt;No Stream&gt;"[/code] if no video stream is assigned.
 			</description>
 		</method>
 		<method name="get_video_texture" qualifiers="const">
@@ -28,20 +28,22 @@
 			</return>
 			<description>
 				Returns [code]true[/code] if the video is playing.
+				[b]Note:[/b] The video is still considered playing if paused during playback.
 			</description>
 		</method>
 		<method name="play">
 			<return type="void">
 			</return>
 			<description>
-				Starts the video playback.
+				Starts the video playback from the beginning. If the video is paused, this will not unpause the video.
 			</description>
 		</method>
 		<method name="stop">
 			<return type="void">
 			</return>
 			<description>
-				Stops the video playback.
+				Stops the video playback and sets the stream position to 0.
+				[b]Note:[/b] Although the stream position will be set to 0, the first frame of the video stream won't become the current frame.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Adds something that was not mentioned:
* `get_stream_name` does not return an empty string when there is no stream assigned
*  `start` does not unpause the playback
* `stop` resets the current position to 0, but leaves the current frame unchanged
* Pausing a video won't make `is_playing` false