### PR TITLE
Physical Skeleton Alignment Fix

### DIFF
--- a/editor/plugins/skeleton_editor_plugin.cpp
+++ b/editor/plugins/skeleton_editor_plugin.cpp
@@ -114,7 +114,8 @@ PhysicalBone *SkeletonEditor::create_physical_bone(int bone_id, int bone_child_i
 	bone_shape->set_shape(bone_shape_capsule);
 
 	Transform body_transform;
-	body_transform.origin = Vector3(0, 0, -half_height);
+	body_transform.origin = Vector3(0, half_height, 0);
+	body_transform.basis = body_transform.rotated(body_transform.basis[0], Math_PI / 2.0).basis;
 
 	Transform joint_transform;
 	joint_transform.origin = Vector3(0, 0, half_height);


### PR DESCRIPTION
This fixes #24836

I have just rotated the bones created over local x by 90 degrees and adjusted the origin of the PhysicalBone transform to fit. This seems to fix all of my issues with armatures imported from blender but I'd be curious to see if this causes new issues with skeletons that aren't coming from blender or are coming from software where the axes don't need to be swapped.