### PR TITLE
Alsa MIDI input thread gets properly reinitialized on open_midi_input.

### DIFF
--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -128,6 +128,7 @@ Error MIDIDriverALSAMidi::open() {
 	snd_device_name_free_hint(hints);
 
 	mutex = Mutex::create();
+	exit_thread = false;
 	thread = Thread::create(MIDIDriverALSAMidi::thread_func, this);
 
 	return OK;


### PR DESCRIPTION
Under ALSA, the midi input creates a thread to read from the device list. An endless loop inside it does the reading as long as a controller variable allows it so.

That controller is modified on `OS.close_midi_input`, but never reset on `OS.open_midi_input` so, after closing the midi input, reopening creates a thread that exits immediately.

`OS.open_midi_input` now resets that controller, allowing the thread to run until requested to stop.