### PR TITLE
Allow decimal values for StyleBoxFlat expand margins

### DIFF
--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -152,7 +152,7 @@ class StyleBoxFlat : public StyleBox {
 	Color border_color;
 
 	int border_width[4];
-	int expand_margin[4];
+	float expand_margin[4];
 	int corner_radius[4];
 
 	bool draw_center;


### PR DESCRIPTION
`StyleBoxFlat` now uses float values for expand margins just like `StyleBoxTexture` does, so it no longer converts to integers when using decimal values in `set_expand_margin_` functions.

Helps with fixing #35279