### PR TITLE
Improve Description of GraphNode

### DIFF
--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GraphNode" inherits="Container" category="Core" version="3.2">
 	<brief_description>
-		A GraphNode is a container with several input and output slots allowing connections between GraphNodes. Slots can have different, incompatible types.
+		A GraphNode is a container with potentially several input and output slots allowing connections between GraphNodes. Slots can have different, incompatible types.
 	</brief_description>
 	<description>
-		A GraphNode is a container defined by a title. It can have one or more input and output slots, which can be enabled (shown) or disabled (not shown) and have different (incompatible) types. Colors can also be assigned to slots. A tuple of input and output slots is defined for each GUI element included in the GraphNode. Input and output connections are left and right slots, but only enabled slots are counted as connections.
-		To add a slot to GraphNode, add any [Control]-derived child node to it.
+		A GraphNode is a container. Each GraphNode can have several input and output slots, sometimes refered to as ports, allowing connections between GraphNodes. To add a slot to GraphNode, add any [Control]-derived child node to it. 
+		After adding at least one child to GraphNode new sections will be automatically created in the Inspector called 'Slot'. When 'Slot' is expanded you will see list with index number for each slot. You can click on each of them to expand further.  
+		In the Inspector you can enable (show) or disable (hide) slots. By default all slots are disabled so you may not see any slots on your GraphNode initially. You can assign a type to each slot. Only slots of the same type will be able to connect to each other. You can also assign colors to slots. A tuple of input and output slots is defined for each GUI element included in the GraphNode. Input connections are on the left and output connections are on the right side of GraphNode. Only enabled slots are counted as connections.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -192,14 +193,14 @@
 		</member>
 		<member name="resizable" type="bool" setter="set_resizable" getter="is_resizable" default="false">
 			If [code]true[/code], the user can resize the GraphNode.
-			[b]Note:[/b] Dragging the handle will only trigger the [signal resize_request] signal, the GraphNode needs to be resized manually.
+			[b]Note:[/b] Dragging the handle will only emit the [signal resize_request] signal, the GraphNode needs to be resized manually.
 		</member>
 		<member name="selected" type="bool" setter="set_selected" getter="is_selected" default="false">
 			If [code]true[/code], the GraphNode is selected.
 		</member>
 		<member name="show_close" type="bool" setter="set_show_close_button" getter="is_close_button_visible" default="false">
 			If [code]true[/code], the close button will be visible.
-			[b]Note:[/b] Pressing it will only trigger the [signal close_request] signal, the GraphNode needs to be removed manually.
+			[b]Note:[/b] Pressing it will only emit the [signal close_request] signal, the GraphNode needs to be removed manually.
 		</member>
 		<member name="title" type="String" setter="set_title" getter="get_title" default="&quot;&quot;">
 			The text displayed in the GraphNode's title bar.


### PR DESCRIPTION
It mostly fixes issues I have listed in https://github.com/godotengine/godot-docs/issues/3065 where GraphNode description was rather lacking clarity. It was near impossible how to use the them or how to create new slots etc. 

I improved it quite a bit if anyone has idea how to reword original "A tuple of input and output slots is defined for each GUI element included in the GraphNode." I would love to hear it. I am unsure how to word it in more understandable way. 