### PR TITLE
Reduce complexity of irradiance map generation

### DIFF
--- a/drivers/gles3/shaders/copy.glsl
+++ b/drivers/gles3/shaders/copy.glsl
@@ -104,6 +104,10 @@ uniform sampler2D CbCr; //texunit:1
 
 /* clang-format on */
 
+#ifdef USE_LOD
+uniform float mip_level;
+#endif
+
 #if defined(USE_TEXTURE3D) || defined(USE_TEXTURE2DARRAY)
 uniform float layer;
 #endif
@@ -190,7 +194,11 @@ void main() {
 	color.gb = textureLod(CbCr, uv_interp, 0.0).rg - vec2(0.5, 0.5);
 	color.a = 1.0;
 #else
+#ifdef USE_LOD
+	vec4 color = textureLod(source, uv_interp, mip_level);
+#else
 	vec4 color = textureLod(source, uv_interp, 0.0);
+#endif
 #endif
 
 #ifdef LINEAR_TO_SRGB

--- a/drivers/gles3/shaders/cubemap_filter.glsl
+++ b/drivers/gles3/shaders/cubemap_filter.glsl
@@ -183,12 +183,12 @@ vec2 Hammersley(uint i, uint N) {
 #ifdef LOW_QUALITY
 
 #define SAMPLE_COUNT 64u
-#define SAMPLE_DELTA 0.05
+#define SAMPLE_DELTA 0.1
 
 #else
 
 #define SAMPLE_COUNT 512u
-#define SAMPLE_DELTA 0.01
+#define SAMPLE_DELTA 0.03
 
 #endif
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/35242
Might help: https://github.com/godotengine/godot/issues/35257 (but I havent looked into it)

As per Juan's suggestion, this PR lowers the instructions needed per pixel by rendering to a larger buffer (specified by the radiance size property) and then downsizing. This spreads the workload out and parrellizes the instructions more. 

My tests show that on default settings the quality increases slightly while the time required to generate the irradiance map is reduce to 20% of what it previously was. The number of texture fetches per-pixel is reduced to 10% of what it was. This should be sufficiently low that no hardware will be overburdened. 

Tested on my Desktop (windows 10 Nvidia GTX 1050) and mobile (google pixel) without problems. I will be testing on my laptop as soon as it builds. 