### PR TITLE
GLES3: Slight optimization to irradiance compute

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -1955,7 +1955,6 @@ void RasterizerStorageGLES3::sky_set_texture(RID p_sky, RID p_panorama, int p_ra
 				glActiveTexture(GL_TEXTURE0);
 				glBindTexture(GL_TEXTURE_2D_ARRAY, sky->radiance);
 				shaders.cubemap_filter.set_uniform(CubemapFilterShaderGLES3::SOURCE_ARRAY_INDEX, j - 1); //read from previous to ensure better blur
-				shaders.cubemap_filter.set_uniform(CubemapFilterShaderGLES3::SOURCE_RESOLUTION, float(size / 2));
 			}
 
 			for (int i = 0; i < 2; i++) {
@@ -2085,7 +2084,6 @@ void RasterizerStorageGLES3::sky_set_texture(RID p_sky, RID p_panorama, int p_ra
 				glActiveTexture(GL_TEXTURE0);
 				glBindTexture(GL_TEXTURE_2D, sky->radiance);
 				shaders.cubemap_filter.set_uniform(CubemapFilterShaderGLES3::SOURCE_MIP_LEVEL, float(lod - 1)); //read from previous to ensure better blur
-				shaders.cubemap_filter.set_uniform(CubemapFilterShaderGLES3::SOURCE_RESOLUTION, float(size));
 			}
 
 			for (int i = 0; i < 2; i++) {

--- a/drivers/gles3/shaders/cubemap_filter.glsl
+++ b/drivers/gles3/shaders/cubemap_filter.glsl
@@ -23,6 +23,7 @@ precision highp int;
 
 #ifdef USE_SOURCE_PANORAMA
 uniform sampler2D source_panorama; //texunit:0
+uniform float source_resolution;
 #endif
 
 #ifdef USE_SOURCE_DUAL_PARABOLOID_ARRAY
@@ -44,7 +45,6 @@ uniform samplerCube source_cube; //texunit:0
 
 uniform int face_id;
 uniform float roughness;
-uniform float source_resolution;
 
 in highp vec2 uv_interp;
 
@@ -332,6 +332,7 @@ void main() {
 
 		if (ndotl > 0.0) {
 
+#ifdef USE_SOURCE_PANORAMA
 			float D = DistributionGGX(N, H, roughness);
 			float ndoth = max(dot(N, H), 0.0);
 			float hdotv = max(dot(H, V), 0.0);
@@ -342,17 +343,14 @@ void main() {
 
 			float mipLevel = roughness == 0.0 ? 0.0 : 0.5 * log2(saSample / saTexel);
 
-#ifdef USE_SOURCE_PANORAMA
 			sum.rgb += texturePanorama(L, source_panorama, mipLevel).rgb * ndotl;
 #endif
 
 #ifdef USE_SOURCE_DUAL_PARABOLOID_ARRAY
-
 			sum.rgb += textureDualParaboloidArray(L).rgb * ndotl;
 #endif
 
 #ifdef USE_SOURCE_DUAL_PARABOLOID
-
 			sum.rgb += textureDualParaboloid(L).rgb * ndotl;
 #endif
 


### PR DESCRIPTION
All the calculations leading up to `mipLevel` are only relevant for
Panorama mode. Similarly, the `source_resolution` uniform is only
needed for that mode.

@clayjohn The code looks safe enough IMO, but if we want to be cautious we could wait for after 3.2 and cherry-pick it for 3.2.1.

I tried it on Linux w/ Intel HD 630 and AMD Radeon RX Vega M (+ #35302), seems to work fine.