### PR TITLE
Display scene file extensions in the editor only if there's ambiguity

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -741,7 +741,7 @@ Ref<Script> EditorData::get_scene_root_script(int p_idx) const {
 	return s;
 }
 
-String EditorData::get_scene_title(int p_idx) const {
+String EditorData::get_scene_title(int p_idx, bool p_always_strip_extension) const {
 	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), String());
 	if (!edited_scene[p_idx].root) {
 		return TTR("[empty]");
@@ -749,12 +749,28 @@ String EditorData::get_scene_title(int p_idx) const {
 	if (edited_scene[p_idx].root->get_filename() == "") {
 		return TTR("[unsaved]");
 	}
-	bool show_ext = EDITOR_DEF("interface/scene_tabs/show_extension", false);
-	String name = edited_scene[p_idx].root->get_filename().get_file();
-	if (!show_ext) {
-		name = name.get_basename();
+
+	const String filename = edited_scene[p_idx].root->get_filename().get_file();
+	const String basename = filename.get_basename();
+
+	if (p_always_strip_extension) {
+		return basename;
 	}
-	return name;
+
+	// Return the filename including the extension if there's ambiguity (e.g. both `foo.tscn` and `foo.scn` are being edited).
+	for (int i = 0; i < edited_scene.size(); i++) {
+		if (i == p_idx) {
+			// Don't compare the edited scene against itself.
+			continue;
+		}
+
+		if (edited_scene[i].root && basename == edited_scene[i].root->get_filename().get_file().get_basename()) {
+			return filename;
+		}
+	}
+
+	// Else, return just the basename as there's no ambiguity.
+	return basename;
 }
 
 void EditorData::set_scene_path(int p_idx, const String &p_path) {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -184,7 +184,7 @@ public:
 	Node *get_edited_scene_root(int p_idx = -1);
 	int get_edited_scene_count() const;
 	Vector<EditedScene> get_edited_scenes() const;
-	String get_scene_title(int p_idx) const;
+	String get_scene_title(int p_idx, bool p_always_strip_extension = false) const;
 	String get_scene_path(int p_idx) const;
 	String get_scene_type(int p_idx) const;
 	void set_scene_path(int p_idx, const String &p_path);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -460,7 +460,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/theme/custom_theme"] = PropertyInfo(Variant::STRING, "interface/theme/custom_theme", PROPERTY_HINT_GLOBAL_FILE, "*.res,*.tres,*.theme", PROPERTY_USAGE_DEFAULT);
 
 	// Scene tabs
-	_initial_set("interface/scene_tabs/show_extension", false);
 	_initial_set("interface/scene_tabs/show_thumbnail_on_hover", true);
 	_initial_set("interface/scene_tabs/resize_if_many_tabs", true);
 	_initial_set("interface/scene_tabs/minimum_width", 50);

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -434,7 +434,10 @@ String RenameDialog::_substitute(const String &subject, const Node *node, int co
 	}
 
 	int current = EditorNode::get_singleton()->get_editor_data().get_edited_scene();
-	result = result.replace("${SCENE}", EditorNode::get_singleton()->get_editor_data().get_scene_title(current));
+	// Always request the scene title with the extension stripped.
+	// Otherwise, the result could vary depending on whether a scene with the same name
+	// (but different extension) is currently open.
+	result = result.replace("${SCENE}", EditorNode::get_singleton()->get_editor_data().get_scene_title(current, true));
 
 	Node *root_node = SceneTree::get_singleton()->get_edited_scene_root();
 	if (root_node) {


### PR DESCRIPTION
This also simplifies the Editor Settings as the extension is now automatically shown to avoid ambiguity.

## Preview

![Automatic scene extensions](https://user-images.githubusercontent.com/180032/72685715-06904600-3aed-11ea-9e9b-dfba3233100e.png)