### PR TITLE
Allow NavMesh to be baked in-game

### DIFF
--- a/modules/recast/navigation_mesh_generator.h
+++ b/modules/recast/navigation_mesh_generator.h
@@ -50,9 +50,9 @@ protected:
 	static void _parse_geometry(Transform p_accumulated_transform, Node *p_node, Vector<float> &p_verticies, Vector<int> &p_indices, int p_generate_from, uint32_t p_collision_mask, bool p_recurse_children);
 
 	static void _convert_detail_mesh_to_native_navigation_mesh(const rcPolyMeshDetail *p_detail_mesh, Ref<NavigationMesh> p_nav_mesh);
-	static void _build_recast_navigation_mesh(Ref<NavigationMesh> p_nav_mesh, EditorProgress *ep,
+	static void _build_recast_navigation_mesh(Ref<NavigationMesh> p_nav_mesh,
 			rcHeightfield *hf, rcCompactHeightfield *chf, rcContourSet *cset, rcPolyMesh *poly_mesh,
-			rcPolyMeshDetail *detail_mesh, Vector<float> &vertices, Vector<int> &indices);
+			rcPolyMeshDetail *detail_mesh, Vector<float> &vertices, Vector<int> &indices, EditorProgress *ep);
 
 public:
 	static EditorNavigationMeshGenerator *get_singleton();


### PR DESCRIPTION
This allows developers to generate a navigation mesh in-game, which is immensely useful for procedurally generated levels. Before, you could generate a navigation mesh through code, but it was only supported for tools. Attempting to use it in-game would cause it to crash. This was probably because the game was trying to display the EditorProgress, so I've made it only available in the editor. Now you can generate the navmesh doing the following:
```
extends NavigationMeshInstance

func _ready():
	NavigationMeshGenerator.bake(self.navmesh, self)
	var nav: Navigation = get_parent()
	nav.navmesh_add(self.navmesh, global_transform)
```

It's probably not the most elegant solution. Addresses issue #22767
PS: The generated navmesh won't be visible using "Visible Navigation".