### PR TITLE
Only create the editor theme once

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1218,7 +1218,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
 	Ref<Theme> theme;
 
-	String custom_theme = EditorSettings::get_singleton()->get("interface/theme/custom_theme");
+	const String custom_theme = EditorSettings::get_singleton()->get("interface/theme/custom_theme");
 	if (custom_theme != "") {
 		theme = ResourceLoader::load(custom_theme);
 	}

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2419,12 +2419,11 @@ ProjectManager::ProjectManager() {
 	FileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));
 
 	set_anchors_and_margins_preset(Control::PRESET_WIDE);
-	set_theme(create_editor_theme());
+	set_theme(create_custom_theme());
 
 	gui_base = memnew(Control);
 	add_child(gui_base);
 	gui_base->set_anchors_and_margins_preset(Control::PRESET_WIDE);
-	gui_base->set_theme(create_custom_theme());
 
 	Panel *panel = memnew(Panel);
 	gui_base->add_child(panel);

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -109,14 +109,8 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	const int feature_min_height = 160 * EDSCALE;
 
-	Ref<Theme> collapse_theme = create_editor_theme();
-	collapse_theme->set_icon("checked", "CheckBox", collapse_theme->get_icon("GuiTreeArrowDown", "EditorIcons"));
-	collapse_theme->set_icon("unchecked", "CheckBox", collapse_theme->get_icon("GuiTreeArrowRight", "EditorIcons"));
-
-	CheckBox *chk_collapse_features = memnew(CheckBox);
+	CheckButton *chk_collapse_features = memnew(CheckButton);
 	chk_collapse_features->set_text(TTR("Advanced Options"));
-	chk_collapse_features->set_theme(collapse_theme);
-	chk_collapse_features->set_focus_mode(FOCUS_NONE);
 	vbc->add_child(chk_collapse_features);
 
 	tabc_features = memnew(TabContainer);


### PR DESCRIPTION
This prevents the editor theme from being created twice.

This speeds up the project editor and editor startup significantly; startup is now 1.3 times faster on average (tested on a debug build). RAM usage was also lowered by 7.5 MB on average.

This partially addresses #35321.

## Benchmark

Loading a simple 3D project and quitting immediately, measured using [hyperfine](https://github.com/sharkdp/hyperfine):

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `bin/godot.x11.tools.64.llvm.vanilla ~/Documents/Godot/test_fog/project.godot --quit` | 4.251 ± 0.021 | 4.231 | 4.280 | 1.30 ± 0.01 |
| `bin/godot.x11.tools.64.llvm ~/Documents/Godot/test_fog/project.godot --quit` | 3.269 ± 0.018 | 3.252 | 3.301 | 1.00 |