### PR TITLE
Fix ClassDB API portability with some android and editor classes

### DIFF
--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -71,6 +71,13 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			while ((k = t->method_map.next(k))) {
 
+				String name = k->operator String();
+
+				ERR_CONTINUE(name.empty());
+
+				if (name[0] == '_')
+					continue; // Ignore non-virtual methods that start with an underscore
+
 				snames.push_back(*k);
 			}
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -106,7 +106,7 @@ Error CSharpLanguage::execute_file(const String &p_path) {
 void CSharpLanguage::init() {
 
 #ifdef DEBUG_METHODS_ENABLED
-	if (OS::get_singleton()->get_cmdline_args().find("--class_db_to_json")) {
+	if (OS::get_singleton()->get_cmdline_args().find("--class-db-json")) {
 		class_db_api_to_json("user://class_db_api.json", ClassDB::API_CORE);
 #ifdef TOOLS_ENABLED
 		class_db_api_to_json("user://class_db_api_editor.json", ClassDB::API_EDITOR);

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2377,10 +2377,7 @@ VisualScriptEngineSingleton::TypeGuess VisualScriptEngineSingleton::guess_output
 	return tg;
 }
 
-void VisualScriptEngineSingleton::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("set_singleton", "name"), &VisualScriptEngineSingleton::set_singleton);
-	ClassDB::bind_method(D_METHOD("get_singleton"), &VisualScriptEngineSingleton::get_singleton);
+void VisualScriptEngineSingleton::_validate_property(PropertyInfo &property) const {
 
 	String cc;
 
@@ -2397,7 +2394,16 @@ void VisualScriptEngineSingleton::_bind_methods() {
 		cc += E->get().name;
 	}
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "constant", PROPERTY_HINT_ENUM, cc), "set_singleton", "get_singleton");
+	property.hint = PROPERTY_HINT_ENUM;
+	property.hint_string = cc;
+}
+
+void VisualScriptEngineSingleton::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("set_singleton", "name"), &VisualScriptEngineSingleton::set_singleton);
+	ClassDB::bind_method(D_METHOD("get_singleton"), &VisualScriptEngineSingleton::get_singleton);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "constant"), "set_singleton", "get_singleton");
 }
 
 VisualScriptEngineSingleton::VisualScriptEngineSingleton() {

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -614,6 +614,9 @@ class VisualScriptEngineSingleton : public VisualScriptNode {
 
 	String singleton;
 
+protected:
+	void _validate_property(PropertyInfo &property) const;
+
 	static void _bind_methods();
 
 public:

--- a/platform/android/api/api.cpp
+++ b/platform/android/api/api.cpp
@@ -1,0 +1,56 @@
+#include "api.h"
+
+#include "core/engine.h"
+#include "java_class_wrapper.h"
+
+#if !defined(ANDROID_ENABLED)
+static JavaClassWrapper *java_class_wrapper = NULL;
+#endif
+
+void register_android_api() {
+
+#if !defined(ANDROID_ENABLED)
+	java_class_wrapper = memnew(JavaClassWrapper); // Dummy
+#endif
+
+	ClassDB::register_class<JavaClass>();
+	ClassDB::register_class<JavaClassWrapper>();
+	Engine::get_singleton()->add_singleton(Engine::Singleton("JavaClassWrapper", JavaClassWrapper::get_singleton()));
+}
+
+void unregister_android_api() {
+
+#if !defined(ANDROID_ENABLED)
+	memdelete(java_class_wrapper);
+#endif
+}
+
+void JavaClassWrapper::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("wrap", "name"), &JavaClassWrapper::wrap);
+}
+
+#if !defined(ANDROID_ENABLED)
+
+Variant JavaClass::call(const StringName &, const Variant **, int, Variant::CallError &) {
+	return Variant();
+}
+
+JavaClass::JavaClass() {
+}
+
+Variant JavaObject::call(const StringName &, const Variant **, int, Variant::CallError &) {
+	return Variant();
+}
+
+JavaClassWrapper *JavaClassWrapper::singleton = NULL;
+
+Ref<JavaClass> JavaClassWrapper::wrap(const String &) {
+	return Ref<JavaClass>();
+}
+
+JavaClassWrapper::JavaClassWrapper() {
+	singleton = this;
+}
+
+#endif

--- a/platform/android/api/api.h
+++ b/platform/android/api/api.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  register_types.cpp                                                   */
+/*  api.h                                                                */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,34 +28,5 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "register_types.h"
-
-#include "navigation_mesh_editor_plugin.h"
-
-#ifdef TOOLS_ENABLED
-EditorNavigationMeshGenerator *_nav_mesh_generator = NULL;
-#endif
-
-void register_recast_types() {
-#ifdef TOOLS_ENABLED
-	ClassDB::APIType prev_api = ClassDB::get_current_api();
-	ClassDB::set_current_api(ClassDB::API_EDITOR);
-
-	EditorPlugins::add_by_type<NavigationMeshEditorPlugin>();
-	_nav_mesh_generator = memnew(EditorNavigationMeshGenerator);
-
-	ClassDB::register_class<EditorNavigationMeshGenerator>();
-
-	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationMeshGenerator", EditorNavigationMeshGenerator::get_singleton()));
-
-	ClassDB::set_current_api(prev_api);
-#endif
-}
-
-void unregister_recast_types() {
-#ifdef TOOLS_ENABLED
-	if (_nav_mesh_generator) {
-		memdelete(_nav_mesh_generator);
-	}
-#endif
-}
+void register_android_api();
+void unregister_android_api();

--- a/platform/android/api/java_class_wrapper.h
+++ b/platform/android/api/java_class_wrapper.h
@@ -32,16 +32,22 @@
 #define JAVA_CLASS_WRAPPER_H
 
 #include "core/reference.h"
+
+#ifdef ANDROID_ENABLED
 #include <android/log.h>
 #include <jni.h>
+#endif
 
+#ifdef ANDROID_ENABLED
 class JavaObject;
+#endif
 
 class JavaClass : public Reference {
 
 	GDCLASS(JavaClass, Reference);
 
-	enum ArgumentType {
+#ifdef ANDROID_ENABLED
+	enum ArgumentType{
 
 		ARG_TYPE_VOID,
 		ARG_TYPE_BOOLEAN,
@@ -159,6 +165,7 @@ class JavaClass : public Reference {
 	friend class JavaClassWrapper;
 	Map<StringName, List<MethodInfo> > methods;
 	jclass _class;
+#endif
 
 public:
 	virtual Variant call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error);
@@ -170,22 +177,27 @@ class JavaObject : public Reference {
 
 	GDCLASS(JavaObject, Reference);
 
+#ifdef ANDROID_ENABLED
 	Ref<JavaClass> base_class;
 	friend class JavaClass;
 
 	jobject instance;
+#endif
 
 public:
 	virtual Variant call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 
+#ifdef ANDROID_ENABLED
 	JavaObject(const Ref<JavaClass> &p_base, jobject *p_instance);
 	~JavaObject();
+#endif
 };
 
 class JavaClassWrapper : public Object {
 
 	GDCLASS(JavaClassWrapper, Object);
 
+#ifdef ANDROID_ENABLED
 	Map<String, Ref<JavaClass> > class_cache;
 	friend class JavaClass;
 	jclass activityClass;
@@ -211,6 +223,7 @@ class JavaClassWrapper : public Object {
 	jobject classLoader;
 
 	bool _get_type_sig(JNIEnv *env, jobject obj, uint32_t &sig, String &strsig);
+#endif
 
 	static JavaClassWrapper *singleton;
 
@@ -222,7 +235,11 @@ public:
 
 	Ref<JavaClass> wrap(const String &p_class);
 
+#ifdef ANDROID_ENABLED
 	JavaClassWrapper(jobject p_activity = NULL);
+#else
+	JavaClassWrapper();
+#endif
 };
 
 #endif // JAVA_CLASS_WRAPPER_H

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "java_class_wrapper.h"
+#include "api/java_class_wrapper.h"
 #include "string_android.h"
 #include "thread_jandroid.h"
 
@@ -545,11 +545,6 @@ JavaObject::~JavaObject() {
 }
 
 ////////////////////
-
-void JavaClassWrapper::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("wrap", "name"), &JavaClassWrapper::wrap);
-}
 
 bool JavaClassWrapper::_get_type_sig(JNIEnv *env, jobject obj, uint32_t &sig, String &strsig) {
 

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -33,6 +33,7 @@
 #include "java_godot_wrapper.h"
 
 #include "android/asset_manager_jni.h"
+#include "api/java_class_wrapper.h"
 #include "audio_driver_jandroid.h"
 #include "core/engine.h"
 #include "core/os/keyboard.h"
@@ -40,7 +41,6 @@
 #include "dir_access_jandroid.h"
 #include "file_access_android.h"
 #include "file_access_jandroid.h"
-#include "java_class_wrapper.h"
 #include "main/input_default.h"
 #include "main/main.h"
 #include "net_socket_android.h"
@@ -739,7 +739,6 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setup(JNIEnv *env, jo
 	}
 
 	java_class_wrapper = memnew(JavaClassWrapper(godot_java->get_activity()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("JavaClassWrapper", java_class_wrapper));
 	_initialize_java_modules();
 }
 


### PR DESCRIPTION
- `EditorNavigationMeshGenerator` was being registered as part of the Core API,
even after d3f48f88bb84d22b7805ce971ac86cf1953a29fd. We must make sure to
set Editor as the current ClassDB API type before creating an instance.

- The `VisualScriptEngineSingleton.constant` property has a property hint string
that's different between tools and non-tools builds. This commit makes the
hint string to no longer be set in `_bind_methods`, and to instead set it in
`_validate_property`. This way it's ignored when calculating the API hash.

- `JavaClassWrapper` is now registered in ClassDB on all platforms,
using a dummy implementation on platforms other than Android.
This fixes API portability between Android and other platforms.

- Updated `--class-db-json` command to ignore non-virtual methods that start
with an underscore (see: 4be87c6016a5893cbde897924e540df4c988cee5).

Fixes #30496 and fixes #35290.

Thanks to @bojidar-bg and @akien-mga for suggesting the solutions for `VisualScriptEngineSingleton.constant` and `JavaClassWrapper`.

