### PR TITLE
Mention that KinematicCollisions use global coords

### DIFF
--- a/doc/classes/KinematicCollision.xml
+++ b/doc/classes/KinematicCollision.xml
@@ -37,7 +37,7 @@
 			The colliding body's shape's normal at the point of collision.
 		</member>
 		<member name="position" type="Vector3" setter="" getter="get_position" default="Vector3( 0, 0, 0 )">
-			The point of collision.
+			The point of collision, in global coordinates.
 		</member>
 		<member name="remainder" type="Vector3" setter="" getter="get_remainder" default="Vector3( 0, 0, 0 )">
 			The moving object's remaining movement vector.

--- a/doc/classes/KinematicCollision2D.xml
+++ b/doc/classes/KinematicCollision2D.xml
@@ -37,7 +37,7 @@
 			The colliding body's shape's normal at the point of collision.
 		</member>
 		<member name="position" type="Vector2" setter="" getter="get_position" default="Vector2( 0, 0 )">
-			The point of collision.
+			The point of collision, in global coordinates.
 		</member>
 		<member name="remainder" type="Vector2" setter="" getter="get_remainder" default="Vector2( 0, 0 )">
 			The moving object's remaining movement vector.


### PR DESCRIPTION
It might seem obvious (?), but I just had to check it with trial and error, so I thought it could be clarified.