### PR TITLE
Improve the batch rename dialog

### DIFF
--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -109,9 +109,13 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	const int feature_min_height = 160 * EDSCALE;
 
-	CheckButton *chk_collapse_features = memnew(CheckButton);
-	chk_collapse_features->set_text(TTR("Advanced Options"));
-	vbc->add_child(chk_collapse_features);
+	cbut_regex = memnew(CheckButton);
+	cbut_regex->set_text(TTR("Use Regular Expressions"));
+	vbc->add_child(cbut_regex);
+
+	CheckButton *cbut_collapse_features = memnew(CheckButton);
+	cbut_collapse_features->set_text(TTR("Advanced Options"));
+	vbc->add_child(cbut_collapse_features);
 
 	tabc_features = memnew(TabContainer);
 	tabc_features->set_tab_align(TabContainer::ALIGN_LEFT);
@@ -195,7 +199,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	grd_substitute->add_child(but_insert_count);
 
 	chk_per_level_counter = memnew(CheckBox);
-	chk_per_level_counter->set_text(TTR("Per Level counter"));
+	chk_per_level_counter->set_text(TTR("Per-level Counter"));
 	chk_per_level_counter->set_tooltip(TTR("If set the counter restarts for each group of child nodes"));
 	vbc_substitute->add_child(chk_per_level_counter);
 
@@ -233,18 +237,6 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	spn_count_padding->set_step(1);
 	hbc_count_options->add_child(spn_count_padding);
 
-	// ---- Tab RegEx
-
-	VBoxContainer *vbc_regex = memnew(VBoxContainer);
-	vbc_regex->set_h_size_flags(SIZE_EXPAND_FILL);
-	vbc_regex->set_name(TTR("Regular Expressions"));
-	vbc_regex->set_custom_minimum_size(Size2(0, feature_min_height));
-	tabc_features->add_child(vbc_regex);
-
-	cbut_regex = memnew(CheckBox);
-	cbut_regex->set_text(TTR("Regular Expressions"));
-	vbc_regex->add_child(cbut_regex);
-
 	// ---- Tab Process
 
 	VBoxContainer *vbc_process = memnew(VBoxContainer);
@@ -268,8 +260,8 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	opt_style = memnew(OptionButton);
 	opt_style->add_item(TTR("Keep"));
-	opt_style->add_item(TTR("CamelCase to under_scored"));
-	opt_style->add_item(TTR("under_scored to CamelCase"));
+	opt_style->add_item(TTR("PascalCase to snake_case"));
+	opt_style->add_item(TTR("snake_case to PascalCase"));
 	hbc_style->add_child(opt_style);
 
 	// ------ Case
@@ -299,7 +291,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	lbl_preview = memnew(Label);
 	lbl_preview->set_text("");
-	lbl_preview->add_color_override("font_color", Color(1, 0.5f, 0, 1));
+	lbl_preview->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("error_color", "Editor"));
 	vbc->add_child(lbl_preview);
 
 	// ---- Dialog related
@@ -314,7 +306,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	// ---- Connections
 
-	chk_collapse_features->connect("toggled", this, "_features_toggled");
+	cbut_collapse_features->connect("toggled", this, "_features_toggled");
 
 	// Substitite Buttons
 
@@ -414,9 +406,12 @@ void RenameDialog::_update_preview(String new_text) {
 		lbl_preview->set_text(new_name);
 
 		if (new_name == preview_node->get_name()) {
-			lbl_preview->add_color_override("font_color", Color(0, 0.5f, 0.25f, 1));
+			// New name is identical to the old one. Don't color it as much to avoid distracting the user.
+			const Color accent_color = EditorNode::get_singleton()->get_gui_base()->get_color("accent_color", "Editor");
+			const Color text_color = EditorNode::get_singleton()->get_gui_base()->get_color("default_color", "RichTextLabel");
+			lbl_preview->add_color_override("font_color", accent_color.linear_interpolate(text_color, 0.5));
 		} else {
-			lbl_preview->add_color_override("font_color", Color(0, 1, 0.5f, 1));
+			lbl_preview->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("success_color", "Editor"));
 		}
 	}
 
@@ -501,9 +496,9 @@ void RenameDialog::_error_handler(void *p_self, const char *p_func, const char *
 	}
 
 	self->has_errors = true;
-	self->lbl_preview_title->set_text(TTR("Error"));
-	self->lbl_preview->add_color_override("font_color", Color(1, 0.25f, 0, 1));
-	self->lbl_preview->set_text(err_str);
+	self->lbl_preview_title->set_text(TTR("Regular Expression Error"));
+	self->lbl_preview->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("error_color", "Editor"));
+	self->lbl_preview->set_text(vformat(TTR("At character %s"), err_str));
 }
 
 String RenameDialog::_regex(const String &pattern, const String &subject, const String &replacement) {
@@ -520,18 +515,18 @@ String RenameDialog::_postprocess(const String &subject) {
 	String result = subject;
 
 	if (style_id == 1) {
+		// PascalCase to snake_case
 
-		// CamelCase to Under_Line
 		result = result.camelcase_to_underscore(true);
 		result = _regex("_+", result, "_");
 
 	} else if (style_id == 2) {
+		// snake_case to PascalCase
 
-		// Under_Line to CamelCase
 		RegEx pattern("_+(.?)");
 		Array matches = pattern.search_all(result);
 
-		// _ name would become empty. Ignore
+		// The name `_` would become empty; ignore it.
 		if (matches.size() && result != "_") {
 			String buffer;
 			int start = 0;

--- a/editor/rename_dialog.h
+++ b/editor/rename_dialog.h
@@ -75,7 +75,7 @@ class RenameDialog : public ConfirmationDialog {
 	TabContainer *tabc_features;
 
 	CheckBox *cbut_substitute;
-	CheckBox *cbut_regex;
+	CheckButton *cbut_regex;
 	CheckBox *cbut_process;
 	CheckBox *chk_per_level_counter;
 


### PR DESCRIPTION
- Use the editor-defined error, warning and success colors for preview texts.
- Make the "Regular Expressions" option into a CheckButton (as it does something as soon as it's toggled) and move it out of the Advanced Options submenu.
- Make it clearer that the error message originates from an invalid regular expression.
- Clarify what the number means in the regex error message.
- Tweak some strings' casing for consistency.

## Preview

![Regex error example](https://user-images.githubusercontent.com/180032/72688971-a01b2000-3b0c-11ea-9915-4c2c969c99fa.png)