### PR TITLE
Prevent negative zero shown in SpotLight gizmo

### DIFF
--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -885,7 +885,7 @@ void LightSpatialGizmoPlugin::set_handle(EditorSpatialGizmo *p_gizmo, int p_idx,
 				d = Math::stepify(d, SpatialEditor::get_singleton()->get_translate_snap());
 			}
 
-			if (d < 0)
+			if (d <= 0) // Equal is here for negative zero.
 				d = 0;
 
 			light->set_param(Light::PARAM_RANGE, d);


### PR DESCRIPTION
... by setting the radius to zero when it's equal to zero.

Before this fix, it shows a "-0" radius when dragging the spot light radius handle, which is confusing.

![demo](https://user-images.githubusercontent.com/372476/72692197-74785400-3b65-11ea-8dc2-320968b3ae73.gif)
