### PR TITLE
Fixes XMLParser leak when open multiple times

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -471,6 +471,10 @@ Error XMLParser::open_buffer(const Vector<uint8_t> &p_buffer) {
 
 	ERR_FAIL_COND_V(p_buffer.size() == 0, ERR_INVALID_DATA);
 
+	if (data) {
+		memdelete_arr(data);
+	}
+
 	length = p_buffer.size();
 	data = memnew_arr(char, length + 1);
 	copymem(data, p_buffer.ptr(), length);
@@ -488,6 +492,10 @@ Error XMLParser::open(const String &p_path) {
 
 	length = file->get_len();
 	ERR_FAIL_COND_V(length < 1, ERR_FILE_CORRUPT);
+
+	if (data) {
+		memdelete_arr(data);
+	}
 
 	data = memnew_arr(char, length + 1);
 	file->get_buffer((uint8_t *)data, length);


### PR DESCRIPTION
This fixes #35331

You can use this code to reproduce the leaks:

```gdscript
var parser: = XMLParser.new()
parser.open_buffer(PoolByteArray([11,124,1241,24,21,214,12,11]))
parser.open_buffer(PoolByteArray([11,124,1241,24,21,214,12,11]))
parser.open("res://project.godot")
parser.open("res://project.godot")
```