### PR TITLE
Fixes leak when calling PCKPacker::pck_start multiple times

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -63,6 +63,10 @@ void PCKPacker::_bind_methods() {
 
 Error PCKPacker::pck_start(const String &p_file, int p_alignment) {
 
+	if (file != NULL) {
+		memdelete(file);
+	}
+
 	file = FileAccess::open(p_file, FileAccess::WRITE);
 
 	ERR_FAIL_COND_V_MSG(!file, ERR_CANT_CREATE, "Can't open file to write: " + String(p_file) + ".");


### PR DESCRIPTION
This fixes #35330

You can reproduce the leak using:

```gdscript
var packer: = PCKPacker.new()
packer.pck_start("test", 4)
packer.pck_start("test", 4)
```