### PR TITLE
Revert "Exposes capture methods to AudioServer + documentation" #30468

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -32,6 +32,13 @@
 				Adds an [AudioEffect] effect to the bus [code]bus_idx[/code] at [code]at_position[/code].
 			</description>
 		</method>
+		<method name="capture_get_device">
+			<return type="String">
+			</return>
+			<description>
+				Name of the current device for audio input (see [method capture_get_device_list]).
+			</description>
+		</method>
 		<method name="capture_get_device_list">
 			<return type="Array">
 			</return>
@@ -39,18 +46,12 @@
 				Returns the names of all audio input devices detected on the system.
 			</description>
 		</method>
-		<method name="capture_start">
-			<return type="int" enum="Error">
+		<method name="capture_set_device">
+			<return type="void">
 			</return>
+			<argument index="0" name="name" type="String">
+			</argument>
 			<description>
-				Attempts to start recording from the audio driver's capture device. On success, the return value is [constant OK].
-			</description>
-		</method>
-		<method name="capture_stop">
-			<return type="int" enum="Error">
-			</return>
-			<description>
-				Attempts to stop recording from the audio driver's capture device. On success, the return value is [constant OK].
 			</description>
 		</method>
 		<method name="generate_bus_layout" qualifiers="const">
@@ -159,32 +160,11 @@
 				Returns the volume of the bus at index [code]bus_idx[/code] in dB.
 			</description>
 		</method>
-		<method name="get_capture_buffer">
-			<return type="PoolIntArray">
-			</return>
-			<description>
-				Returns an [PoolIntArray] containing audio frames from the capture device.
-			</description>
-		</method>
-		<method name="get_capture_position">
-			<return type="int">
-			</return>
-			<description>
-				Returns the write position of the capture device buffer.
-			</description>
-		</method>
-		<method name="get_capture_size">
-			<return type="int">
-			</return>
-			<description>
-				Returns the size of the capture device buffer.
-			</description>
-		</method>
 		<method name="get_device_list">
 			<return type="Array">
 			</return>
 			<description>
-				Returns the names of all audio output devices detected on the system.
+				Returns the names of all audio devices detected on the system.
 			</description>
 		</method>
 		<method name="get_mix_rate" qualifiers="const">
@@ -409,9 +389,6 @@
 		<member name="bus_count" type="int" setter="set_bus_count" getter="get_bus_count" default="1">
 			Number of available audio buses.
 		</member>
-		<member name="capture_device" type="String" setter="capture_set_device" getter="capture_get_device" default="&quot;&quot;">
-			Name of the current device for audio input (see [method capture_get_device_list]).
-		</member>
 		<member name="device" type="String" setter="set_device" getter="get_device" default="&quot;Default&quot;">
 			Name of the current device for audio output (see [method get_device_list]).
 		</member>
@@ -420,14 +397,6 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="audio_mix_callback">
-			<description>
-			</description>
-		</signal>
-		<signal name="audio_update_callback">
-			<description>
-			</description>
-		</signal>
 		<signal name="bus_layout_changed">
 			<description>
 				Emitted when the [AudioBusLayout] changes.

--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -233,11 +233,11 @@ OSStatus AudioDriverCoreAudio::input_callback(void *inRefCon,
 	if (result == noErr) {
 		for (unsigned int i = 0; i < inNumberFrames * ad->capture_channels; i++) {
 			int32_t sample = ad->input_buf[i] << 16;
-			ad->capture_buffer_write(sample);
+			ad->input_buffer_write(sample);
 
 			if (ad->capture_channels == 1) {
-				// In case capture device is single channel convert it to Stereo
-				ad->capture_buffer_write(sample);
+				// In case input device is single channel convert it to Stereo
+				ad->input_buffer_write(sample);
 			}
 		}
 	} else {
@@ -487,7 +487,7 @@ void AudioDriverCoreAudio::capture_finish() {
 
 Error AudioDriverCoreAudio::capture_start() {
 
-	capture_buffer_init(buffer_frames);
+	input_buffer_init(buffer_frames);
 
 	OSStatus result = AudioOutputUnitStart(input_unit);
 	if (result != noErr) {
@@ -642,9 +642,9 @@ void AudioDriverCoreAudio::_set_device(const String &device, bool capture) {
 		ERR_FAIL_COND(result != noErr);
 
 		if (capture) {
-			// Reset audio capture to keep synchronisation.
-			capture_position = 0;
-			capture_size = 0;
+			// Reset audio input to keep synchronisation.
+			input_position = 0;
+			input_size = 0;
 		}
 	}
 }

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -229,8 +229,8 @@ Error AudioDriverPulseAudio::init_device() {
 	samples_out.resize(pa_buffer_size);
 
 	// Reset audio input to keep synchronisation.
-	capture_position = 0;
-	capture_size = 0;
+	input_position = 0;
+	input_size = 0;
 
 	return OK;
 }
@@ -465,7 +465,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 			size_t bytes = pa_stream_readable_size(ad->pa_rec_str);
 			if (bytes > 0) {
 				const void *ptr = NULL;
-				size_t maxbytes = ad->capture_buffer.size() * sizeof(int16_t);
+				size_t maxbytes = ad->input_buffer.size() * sizeof(int16_t);
 
 				bytes = MIN(bytes, maxbytes);
 				ret = pa_stream_peek(ad->pa_rec_str, &ptr, &bytes);
@@ -475,11 +475,11 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 					int16_t *srcptr = (int16_t *)ptr;
 					for (size_t i = bytes >> 1; i > 0; i--) {
 						int32_t sample = int32_t(*srcptr++) << 16;
-						ad->capture_buffer_write(sample);
+						ad->input_buffer_write(sample);
 
 						if (ad->pa_rec_map.channels == 1) {
-							// In case capture device is single channel convert it to Stereo
-							ad->capture_buffer_write(sample);
+							// In case input device is single channel convert it to Stereo
+							ad->input_buffer_write(sample);
 						}
 					}
 
@@ -666,7 +666,7 @@ Error AudioDriverPulseAudio::capture_init_device() {
 			break;
 
 		default:
-			WARN_PRINTS("PulseAudio: Unsupported number of capture channels: " + itos(pa_rec_map.channels));
+			WARN_PRINTS("PulseAudio: Unsupported number of input channels: " + itos(pa_rec_map.channels));
 			pa_channel_map_init_stereo(&pa_rec_map);
 			break;
 	}
@@ -698,10 +698,10 @@ Error AudioDriverPulseAudio::capture_init_device() {
 		ERR_FAIL_V(ERR_CANT_OPEN);
 	}
 
-	capture_buffer_init(input_buffer_frames);
+	input_buffer_init(input_buffer_frames);
 
-	print_verbose("PulseAudio: detected " + itos(pa_rec_map.channels) + " capture channels");
-	print_verbose("PulseAudio: capture buffer frames: " + itos(input_buffer_frames) + " calculated latency: " + itos(input_buffer_frames * 1000 / mix_rate) + "ms");
+	print_verbose("PulseAudio: detected " + itos(pa_rec_map.channels) + " input channels");
+	print_verbose("PulseAudio: input buffer frames: " + itos(input_buffer_frames) + " calculated latency: " + itos(input_buffer_frames * 1000 / mix_rate) + "ms");
 
 	return OK;
 }

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -342,8 +342,8 @@ Error AudioDriverWASAPI::init_render_device(bool reinit) {
 	// Sample rate is independent of channels (ref: https://stackoverflow.com/questions/11048825/audio-sample-frequency-rely-on-channels)
 	samples_in.resize(buffer_frames * channels);
 
-	capture_position = 0;
-	capture_size = 0;
+	input_position = 0;
+	input_size = 0;
 
 	print_verbose("WASAPI: detected " + itos(channels) + " channels");
 	print_verbose("WASAPI: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
@@ -362,7 +362,7 @@ Error AudioDriverWASAPI::init_capture_device(bool reinit) {
 	HRESULT hr = audio_input.audio_client->GetBufferSize(&max_frames);
 	ERR_FAIL_COND_V(hr != S_OK, ERR_CANT_OPEN);
 
-	capture_buffer_init(max_frames);
+	input_buffer_init(max_frames);
 
 	return OK;
 }
@@ -715,8 +715,8 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 							}
 						}
 
-						ad->capture_buffer_write(l);
-						ad->capture_buffer_write(r);
+						ad->input_buffer_write(l);
+						ad->input_buffer_write(r);
 					}
 
 					read_frames += num_frames_available;

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -208,8 +208,8 @@ void AudioDriverOpenSL::_record_buffer_callback(SLAndroidSimpleBufferQueueItf qu
 
 	for (int i = 0; i < rec_buffer.size(); i++) {
 		int32_t sample = rec_buffer[i] << 16;
-		capture_buffer_write(sample);
-		capture_buffer_write(sample); // call twice to convert to Stereo
+		input_buffer_write(sample);
+		input_buffer_write(sample); // call twice to convert to Stereo
 	}
 
 	SLresult res = (*recordBufferQueueItf)->Enqueue(recordBufferQueueItf, rec_buffer.ptrw(), rec_buffer.size() * sizeof(int16_t));
@@ -280,7 +280,7 @@ Error AudioDriverOpenSL::capture_init_device() {
 
 	const int rec_buffer_frames = 2048;
 	rec_buffer.resize(rec_buffer_frames);
-	capture_buffer_init(rec_buffer_frames);
+	input_buffer_init(rec_buffer_frames);
 
 	res = (*recordBufferQueueItf)->Enqueue(recordBufferQueueItf, rec_buffer.ptrw(), rec_buffer.size() * sizeof(int16_t));
 	ERR_FAIL_COND_V(res != SL_RESULT_SUCCESS, ERR_CANT_OPEN);

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -134,31 +134,31 @@ AudioStreamMicrophone::AudioStreamMicrophone() {
 
 void AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 
-	AudioServer::get_singleton()->lock();
+	AudioDriver::get_singleton()->lock();
 
-	PoolVector<int32_t> capture_buffer = AudioServer::get_singleton()->get_capture_buffer();
-	unsigned int capture_size = AudioServer::get_singleton()->get_capture_size();
-	int mix_rate = AudioServer::get_singleton()->get_mix_rate();
-	unsigned int playback_delay = MIN(((50 * mix_rate) / 1000) * 2, capture_buffer.size() >> 1);
+	Vector<int32_t> buf = AudioDriver::get_singleton()->get_input_buffer();
+	unsigned int input_size = AudioDriver::get_singleton()->get_input_size();
+	int mix_rate = AudioDriver::get_singleton()->get_mix_rate();
+	unsigned int playback_delay = MIN(((50 * mix_rate) / 1000) * 2, buf.size() >> 1);
 #ifdef DEBUG_ENABLED
-	unsigned int capture_position = AudioServer::get_singleton()->get_capture_position();
+	unsigned int input_position = AudioDriver::get_singleton()->get_input_position();
 #endif
 
-	if (playback_delay > capture_size) {
+	if (playback_delay > input_size) {
 		for (int i = 0; i < p_frames; i++) {
 			p_buffer[i] = AudioFrame(0.0f, 0.0f);
 		}
-		capture_ofs = 0;
+		input_ofs = 0;
 	} else {
 		for (int i = 0; i < p_frames; i++) {
-			if (capture_size > capture_ofs && (int)capture_ofs < capture_buffer.size()) {
-				float l = (capture_buffer[capture_ofs++] >> 16) / 32768.f;
-				if ((int)capture_ofs >= capture_buffer.size()) {
-					capture_ofs = 0;
+			if (input_size > input_ofs && (int)input_ofs < buf.size()) {
+				float l = (buf[input_ofs++] >> 16) / 32768.f;
+				if ((int)input_ofs >= buf.size()) {
+					input_ofs = 0;
 				}
-				float r = (capture_buffer[capture_ofs++] >> 16) / 32768.f;
-				if ((int)capture_ofs >= capture_buffer.size()) {
-					capture_ofs = 0;
+				float r = (buf[input_ofs++] >> 16) / 32768.f;
+				if ((int)input_ofs >= buf.size()) {
+					input_ofs = 0;
 				}
 
 				p_buffer[i] = AudioFrame(l, r);
@@ -169,12 +169,12 @@ void AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fr
 	}
 
 #ifdef DEBUG_ENABLED
-	if (capture_ofs > capture_position && (int)(capture_ofs - capture_position) < (p_frames * 2)) {
-		print_verbose(String(get_class_name()) + " buffer underrun: capture_position=" + itos(capture_position) + " capture_ofs=" + itos(capture_ofs) + " capture_size=" + itos(capture_size));
+	if (input_ofs > input_position && (int)(input_ofs - input_position) < (p_frames * 2)) {
+		print_verbose(String(get_class_name()) + " buffer underrun: input_position=" + itos(input_position) + " input_ofs=" + itos(input_ofs) + " input_size=" + itos(input_size));
 	}
 #endif
 
-	AudioServer::get_singleton()->unlock();
+	AudioDriver::get_singleton()->unlock();
 }
 
 void AudioStreamPlaybackMicrophone::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
@@ -196,9 +196,9 @@ void AudioStreamPlaybackMicrophone::start(float p_from_pos) {
 		return;
 	}
 
-	capture_ofs = 0;
+	input_ofs = 0;
 
-	if (AudioServer::get_singleton()->capture_start() == OK) {
+	if (AudioDriver::get_singleton()->capture_start() == OK) {
 		active = true;
 		_begin_resample();
 	}
@@ -206,7 +206,7 @@ void AudioStreamPlaybackMicrophone::start(float p_from_pos) {
 
 void AudioStreamPlaybackMicrophone::stop() {
 	if (active) {
-		AudioServer::get_singleton()->capture_stop();
+		AudioDriver::get_singleton()->capture_stop();
 		active = false;
 	}
 }

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -123,7 +123,7 @@ class AudioStreamPlaybackMicrophone : public AudioStreamPlaybackResampled {
 	friend class AudioStreamMicrophone;
 
 	bool active;
-	unsigned int capture_ofs;
+	unsigned int input_ofs;
 
 	Ref<AudioStreamMicrophone> microphone;
 

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -85,26 +85,26 @@ double AudioDriver::get_time_to_next_mix() const {
 	return mix_buffer - total;
 }
 
-void AudioDriver::capture_buffer_init(int driver_buffer_frames) {
+void AudioDriver::input_buffer_init(int driver_buffer_frames) {
 
-	const int capture_buffer_channels = 2;
-	capture_buffer.resize(driver_buffer_frames * capture_buffer_channels * 4);
-	capture_position = 0;
-	capture_size = 0;
+	const int input_buffer_channels = 2;
+	input_buffer.resize(driver_buffer_frames * input_buffer_channels * 4);
+	input_position = 0;
+	input_size = 0;
 }
 
-void AudioDriver::capture_buffer_write(int32_t sample) {
+void AudioDriver::input_buffer_write(int32_t sample) {
 
-	if ((int)capture_position < capture_buffer.size()) {
-		capture_buffer.write()[capture_position++] = sample;
-		if ((int)capture_position >= capture_buffer.size()) {
-			capture_position = 0;
+	if ((int)input_position < input_buffer.size()) {
+		input_buffer.write[input_position++] = sample;
+		if ((int)input_position >= input_buffer.size()) {
+			input_position = 0;
 		}
-		if ((int)capture_size < capture_buffer.size()) {
-			capture_size++;
+		if ((int)input_size < input_buffer.size()) {
+			input_size++;
 		}
 	} else {
-		WARN_PRINTS("capture_buffer_write: Invalid capture_position=" + itos(capture_position) + " capture_buffer.size()=" + itos(capture_buffer.size()));
+		WARN_PRINTS("input_buffer_write: Invalid input_position=" + itos(input_position) + " input_buffer.size()=" + itos(input_buffer.size()));
 	}
 }
 
@@ -154,8 +154,8 @@ AudioDriver::AudioDriver() {
 
 	_last_mix_time = 0;
 	_last_mix_frames = 0;
-	capture_position = 0;
-	capture_size = 0;
+	input_position = 0;
+	input_size = 0;
 
 #ifdef DEBUG_ENABLED
 	prof_time = 0;
@@ -337,8 +337,6 @@ void AudioServer::_mix_step() {
 
 		E->get().callback(E->get().userdata);
 	}
-
-	emit_signal("audio_mix_callback");
 
 	for (int i = buses.size() - 1; i >= 0; i--) {
 		//go bus by bus
@@ -1059,8 +1057,6 @@ void AudioServer::update() {
 
 		E->get().callback(E->get().userdata);
 	}
-
-	emit_signal("audio_update_callback");
 }
 
 void AudioServer::load_default_bus_layout() {
@@ -1079,7 +1075,6 @@ void AudioServer::finish() {
 
 	for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
 		AudioDriverManager::get_driver(i)->finish();
-		AudioDriverManager::get_driver(i)->clear_capture_buffer();
 	}
 
 	for (int i = 0; i < buses.size(); i++) {
@@ -1307,14 +1302,6 @@ void AudioServer::set_device(String device) {
 	AudioDriver::get_singleton()->set_device(device);
 }
 
-Error AudioServer::capture_start() {
-	return AudioDriver::get_singleton()->capture_start();
-}
-
-Error AudioServer::capture_stop() {
-	return AudioDriver::get_singleton()->capture_stop();
-}
-
 Array AudioServer::capture_get_device_list() {
 
 	return AudioDriver::get_singleton()->capture_get_device_list();
@@ -1328,18 +1315,6 @@ String AudioServer::capture_get_device() {
 void AudioServer::capture_set_device(const String &p_name) {
 
 	AudioDriver::get_singleton()->capture_set_device(p_name);
-}
-
-PoolVector<int32_t> AudioServer::get_capture_buffer() {
-	return AudioDriver::get_singleton()->get_capture_buffer();
-}
-
-unsigned int AudioServer::get_capture_position() {
-	return AudioDriver::get_singleton()->get_capture_position();
-}
-
-unsigned int AudioServer::get_capture_size() {
-	return AudioDriver::get_singleton()->get_capture_size();
 }
 
 void AudioServer::_bind_methods() {
@@ -1402,28 +1377,18 @@ void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_time_since_last_mix"), &AudioServer::get_time_since_last_mix);
 	ClassDB::bind_method(D_METHOD("get_output_latency"), &AudioServer::get_output_latency);
 
-	ClassDB::bind_method(D_METHOD("capture_start"), &AudioServer::capture_start);
-	ClassDB::bind_method(D_METHOD("capture_stop"), &AudioServer::capture_stop);
-
 	ClassDB::bind_method(D_METHOD("capture_get_device_list"), &AudioServer::capture_get_device_list);
 	ClassDB::bind_method(D_METHOD("capture_get_device"), &AudioServer::capture_get_device);
 	ClassDB::bind_method(D_METHOD("capture_set_device", "name"), &AudioServer::capture_set_device);
-
-	ClassDB::bind_method(D_METHOD("get_capture_buffer"), &AudioServer::get_capture_buffer);
-	ClassDB::bind_method(D_METHOD("get_capture_position"), &AudioServer::get_capture_position);
-	ClassDB::bind_method(D_METHOD("get_capture_size"), &AudioServer::get_capture_size);
 
 	ClassDB::bind_method(D_METHOD("set_bus_layout", "bus_layout"), &AudioServer::set_bus_layout);
 	ClassDB::bind_method(D_METHOD("generate_bus_layout"), &AudioServer::generate_bus_layout);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bus_count"), "set_bus_count", "get_bus_count");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "device"), "set_device", "get_device");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "capture_device"), "capture_set_device", "capture_get_device");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "global_rate_scale"), "set_global_rate_scale", "get_global_rate_scale");
 
 	ADD_SIGNAL(MethodInfo("bus_layout_changed"));
-	ADD_SIGNAL(MethodInfo("audio_mix_callback"));
-	ADD_SIGNAL(MethodInfo("audio_update_callback"));
 
 	BIND_ENUM_CONSTANT(SPEAKER_MODE_STEREO);
 	BIND_ENUM_CONSTANT(SPEAKER_SURROUND_31);

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -53,14 +53,14 @@ class AudioDriver {
 #endif
 
 protected:
-	PoolVector<int32_t> capture_buffer;
-	unsigned int capture_position;
-	unsigned int capture_size;
+	Vector<int32_t> input_buffer;
+	unsigned int input_position;
+	unsigned int input_size;
 
 	void audio_server_process(int p_frames, int32_t *p_buffer, bool p_update_mix_time = true);
 	void update_mix_time(int p_frames);
-	void capture_buffer_init(int driver_buffer_frames);
-	void capture_buffer_write(int32_t sample);
+	void input_buffer_init(int driver_buffer_frames);
+	void input_buffer_write(int32_t sample);
 
 #ifdef DEBUG_ENABLED
 	_FORCE_INLINE_ void start_counting_ticks() { prof_ticks = OS::get_singleton()->get_ticks_usec(); }
@@ -111,11 +111,9 @@ public:
 	SpeakerMode get_speaker_mode_by_total_channels(int p_channels) const;
 	int get_total_channels_by_speaker_mode(SpeakerMode) const;
 
-	PoolVector<int32_t> get_capture_buffer() { return capture_buffer; }
-	unsigned int get_capture_position() { return capture_position; }
-	unsigned int get_capture_size() { return capture_size; }
-
-	void clear_capture_buffer() { capture_buffer.resize(0); }
+	Vector<int32_t> get_input_buffer() { return input_buffer; }
+	unsigned int get_input_position() { return input_position; }
+	unsigned int get_input_size() { return input_size; }
 
 #ifdef DEBUG_ENABLED
 	uint64_t get_profiling_time() const { return prof_time; }
@@ -386,16 +384,9 @@ public:
 	String get_device();
 	void set_device(String device);
 
-	Error capture_start();
-	Error capture_stop();
-
 	Array capture_get_device_list();
 	String capture_get_device();
 	void capture_set_device(const String &p_name);
-
-	PoolVector<int32_t> get_capture_buffer();
-	unsigned int get_capture_position();
-	unsigned int get_capture_size();
 
 	AudioServer();
 	virtual ~AudioServer();


### PR DESCRIPTION
Reverts the following commits (from #30468 and #32760):

- c81ec6f26d40b70283958a4ef3e216fb32cbaf14:
  "Exposes capture methods to AudioServer, variable renames for
  consistency, added documentation."
- 47c558b98abf842910c780294314326662410cdf:
  "Expose audio callbacks as signals."
- dabaa11b3c451e9b8f2cca7e563bd9ec51edb169:
  "Fix to make sure the capture buffers are deallocated at shutdown.
  Silences warnings."

Some documentation improvements were kept for pre-existing methods.

See rationale for reverting these changes in #30468.