### PR TITLE
Protects Image against user forgetting to unlock

### DIFF
--- a/core/image.h
+++ b/core/image.h
@@ -172,8 +172,12 @@ private:
 		width = p_image.width;
 		height = p_image.height;
 		mipmaps = p_image.mipmaps;
-		data = p_image.data;
+		_safe_data_assign(p_image.data);
 	}
+
+	void _safe_data_assign(const PoolVector<uint8_t> &p_data);
+	void _safe_data_resize(int p_size);
+	void _check_for_lock();
 
 	_FORCE_INLINE_ void _get_mipmap_offset_and_size(int p_mipmap, int &r_offset, int &r_width, int &r_height) const; //get where the mipmap begins in data
 


### PR DESCRIPTION
Fixes #32797

Image is susceptible to data corruption / spurious crashes if a user locks then forgets to unlock the image, then performs certain operations such as those that change the size / location of data.

This PR adds wrapper functions for resizing and assigning new image data, which check for an existing lock, print an error message and automatically unlock to recover gracefully.

Notes:
* This potential bug is caused by a dangling Write referencing a PoolVector which has been replaced / resized. An alternative would be for the PoolVector itself would maintain a back reference to any linked Writes, and automatically cancel these on resize or assign. This would be more future proof but potentially expose linking bugs / race conditions.
* I have done a FindInFiles and similar bugs are also potentially possible in 2 files, where PoolVector::Writes are stored as member variables. These are:

soft_body.h
csg_shape.h

* The error message is printed each time. It could alternatively be an error print once, however it is quite important to spot these errors as soon as they occur, as they can potentially introduce memory corruption.
* The use of the wrapper functions _safe_data_resize and _safe_data_assign is not enforced in Image.cpp (I just used a FindInFiles to locate places needed). This could have implications for future modifications to Image.cpp unintentionally re-exposing the bug. An alternative could be to wrap the data in a nested class, make the PoolVector private, and only allow access through wrapper functions.