### PR TITLE
Clip text in EditorPath button to avoid dock size changes

### DIFF
--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -150,6 +150,7 @@ void EditorPath::_bind_methods() {
 EditorPath::EditorPath(EditorHistory *p_history) {
 
 	history = p_history;
+	set_clip_text(true);
 	set_text_align(ALIGN_LEFT);
 	get_popup()->connect("about_to_show", this, "_about_to_show");
 	get_popup()->connect("id_pressed", this, "_id_pressed");


### PR DESCRIPTION
Fixes #33741.
Fixes #35324.
Fixes #35367.