### PR TITLE
Mono/C#: Fix error when parsing nested generics

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Internals/ScriptClassParser.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/ScriptClassParser.cs
@@ -25,14 +25,14 @@ namespace GodotTools.Internals
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern Error internal_ParseFile(string filePath, Array<Dictionary> classes);
+        private static extern Error internal_ParseFile(string filePath, Array<Dictionary> classes, out string errorStr);
 
         public static void ParseFileOrThrow(string filePath, out IEnumerable<ClassDecl> classes)
         {
             var classesArray = new Array<Dictionary>();
-            var error = internal_ParseFile(filePath, classesArray);
+            var error = internal_ParseFile(filePath, classesArray, out string errorStr);
             if (error != Error.Ok)
-                throw new Exception($"Failed to determine namespace and class for script: {filePath}. Parse error: {error}");
+                throw new Exception($"Failed to determine namespace and class for script: {filePath}. Parse error: {errorStr ?? error.ToString()}");
 
             var classesList = new List<ClassDecl>();
 

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -201,7 +201,9 @@ uint32_t godot_icall_BindingsGenerator_CsGlueVersion() {
 	return CS_GLUE_VERSION;
 }
 
-int32_t godot_icall_ScriptClassParser_ParseFile(MonoString *p_filepath, MonoObject *p_classes) {
+int32_t godot_icall_ScriptClassParser_ParseFile(MonoString *p_filepath, MonoObject *p_classes, MonoString **r_error_str) {
+	*r_error_str = NULL;
+
 	String filepath = GDMonoMarshal::mono_string_to_godot(p_filepath);
 
 	ScriptClassParser scp;
@@ -219,6 +221,11 @@ int32_t godot_icall_ScriptClassParser_ParseFile(MonoString *p_filepath, MonoObje
 			classDeclDict["nested"] = classDecl.nested;
 			classDeclDict["base_count"] = classDecl.base.size();
 			classes.push_back(classDeclDict);
+		}
+	} else {
+		String error_str = scp.get_error();
+		if (!error_str.empty()) {
+			*r_error_str = GDMonoMarshal::mono_string_from_godot(error_str);
 		}
 	}
 	return err;

--- a/modules/mono/editor/script_class_parser.cpp
+++ b/modules/mono/editor/script_class_parser.cpp
@@ -302,8 +302,10 @@ Error ScriptClassParser::_skip_generic_type_params() {
 				Error err = _skip_generic_type_params();
 				if (err)
 					return err;
-				continue;
-			} else if (tk == TK_OP_GREATER) {
+				tk = get_token();
+			}
+
+			if (tk == TK_OP_GREATER) {
 				return OK;
 			} else if (tk != TK_COMMA) {
 				error_str = "Unexpected token: " + get_token_name(tk);


### PR DESCRIPTION
Also fixed the editor not including the parse error message in the error.

Fixes #29523
