### PR TITLE
Make it possible to copy the Godot version identifier by clicking it

### DIFF
--- a/editor/editor_about.h
+++ b/editor/editor_about.h
@@ -34,6 +34,7 @@
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/item_list.h"
+#include "scene/gui/link_button.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/separator.h"
@@ -53,8 +54,10 @@ class EditorAbout : public AcceptDialog {
 
 private:
 	void _license_tree_selected();
+	void _version_button_pressed();
 	ScrollContainer *_populate_list(const String &p_name, const List<String> &p_sections, const char *const *const p_src[], const int p_flag_single_column = 0);
 
+	LinkButton *version_btn;
 	Tree *_tpl_tree;
 	RichTextLabel *_license_text;
 	RichTextLabel *_tpl_text;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -40,6 +40,7 @@
 #include "editor/inspector_dock.h"
 #include "editor/property_editor.h"
 #include "editor/scene_tree_dock.h"
+#include "scene/gui/link_button.h"
 
 typedef void (*EditorNodeInitCallback)();
 typedef void (*EditorPluginInitializeCallback)();
@@ -424,7 +425,7 @@ private:
 	HBoxContainer *bottom_panel_hb;
 	HBoxContainer *bottom_panel_hb_editors;
 	VBoxContainer *bottom_panel_vb;
-	Label *version_label;
+	LinkButton *version_btn;
 	Button *bottom_panel_raise;
 
 	Tree *disk_changed_list;
@@ -477,6 +478,7 @@ private:
 	void _close_messages();
 	void _show_messages();
 	void _vp_resized();
+	void _version_button_pressed();
 
 	int _save_external_resources();
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2371,11 +2371,16 @@ void ProjectManager::_on_search_term_changed(const String &p_term) {
 void ProjectManager::_bind_methods() {
 	ClassDB::bind_method("_unhandled_key_input", &ProjectManager::_unhandled_key_input);
 	ClassDB::bind_method("_update_project_buttons", &ProjectManager::_update_project_buttons);
+	ClassDB::bind_method("_version_button_pressed", &ProjectManager::_version_button_pressed);
 }
 
 void ProjectManager::_open_asset_library() {
 	asset_library->disable_community_support();
 	tabs->set_current_tab(1);
+}
+
+void ProjectManager::_version_button_pressed() {
+	DisplayServer::get_singleton()->clipboard_set(version_btn->get_text());
 }
 
 ProjectManager::ProjectManager() {
@@ -2601,15 +2606,30 @@ ProjectManager::ProjectManager() {
 		settings_hb->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);
 		settings_hb->set_anchors_and_offsets_preset(Control::PRESET_TOP_RIGHT);
 
-		Label *version_label = memnew(Label);
+		// A VBoxContainer that contains a dummy Control node to adjust the LinkButton's vertical position.
+		VBoxContainer *spacer_vb = memnew(VBoxContainer);
+		settings_hb->add_child(spacer_vb);
+
+		Control *v_spacer = memnew(Control);
+		spacer_vb->add_child(v_spacer);
+
+		version_btn = memnew(LinkButton);
 		String hash = String(VERSION_HASH);
 		if (hash.length() != 0) {
 			hash = "." + hash.left(9);
 		}
-		version_label->set_text("v" VERSION_FULL_BUILD "" + hash);
-		version_label->set_self_modulate(Color(1, 1, 1, 0.6));
-		version_label->set_align(Label::ALIGN_CENTER);
-		settings_hb->add_child(version_label);
+		version_btn->set_text("v" VERSION_FULL_BUILD + hash);
+		// Fade the version label to be less prominent, but still readable.
+		version_btn->set_self_modulate(Color(1, 1, 1, 0.6));
+		version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
+		version_btn->set_tooltip(TTR("Click to copy."));
+		version_btn->connect("pressed", callable_mp(this, &ProjectManager::_version_button_pressed));
+		spacer_vb->add_child(version_btn);
+
+		// Add a small horizontal spacer between the version and language buttons
+		// to distinguish them.
+		Control *h_spacer = memnew(Control);
+		settings_hb->add_child(h_spacer);
 
 		language_btn = memnew(OptionButton);
 		language_btn->set_flat(true);

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -89,6 +89,7 @@ class ProjectManager : public Control {
 	ProjectDialog *npdialog;
 
 	OptionButton *language_btn;
+	LinkButton *version_btn;
 
 	void _open_asset_library();
 	void _scan_projects();
@@ -123,6 +124,7 @@ class ProjectManager : public Control {
 	void _unhandled_key_input(const Ref<InputEvent> &p_ev);
 	void _files_dropped(PackedStringArray p_files, int p_screen);
 
+	void _version_button_pressed();
 	void _on_order_option_changed(int p_idx);
 	void _on_tab_changed(int p_tab);
 	void _on_search_term_changed(const String &p_term);


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/48450.

I managed to sort out the alignment issues mentioned in https://github.com/godotengine/godot/issues/24317#issuecomment-576074059. The appearance is now almost identical to the original, except that version identifiers are now clickable in the Project Manager, the editor's bottom panel and About dialog. All three buttons will copy the same text (full version identifier with hash for Git builds).

This closes #24317.

<details>
<summary>January 2020 patch</summary>

```patch
From be778599eb545fc426ac3c1fb3ac44dd02df0e28 Mon Sep 17 00:00:00 2001
From: Hugo Locurcio <hugo.locurcio@hugo.pro>
Date: Tue, 24 Dec 2019 01:20:54 +0100
Subject: [PATCH] Make it possible to copy the Godot version identifier by
 clicking it

This closes #24317.
---
 editor/editor_about.cpp    | 33 ++++++++++++++++++++++++++++-----
 editor/editor_about.h      |  3 +++
 editor/editor_node.cpp     | 38 ++++++++++++++++++++++++++++++++++----
 editor/editor_node.h       |  4 +++-
 editor/project_manager.cpp | 31 +++++++++++++++++++++++++------
 editor/project_manager.h   |  2 ++
 6 files changed, 95 insertions(+), 16 deletions(-)

diff --git a/editor/editor_about.cpp b/editor/editor_about.cpp
index ba653017ef8..df22f60ce22 100644
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -37,6 +37,9 @@
 #include "core/version.h"
 #include "core/version_hash.gen.h"
 
+// The metadata key used to store and retrieve the version text to copy to the clipboard.
+static const String META_TEXT_TO_COPY = "text_to_copy";
+
 void EditorAbout::_notification(int p_what) {
 
 	switch (p_what) {
@@ -62,8 +65,13 @@ void EditorAbout::_license_tree_selected() {
 	_tpl_text->set_text(selected->get_metadata(0));
 }
 
+void EditorAbout::_version_button_pressed() {
+	OS::get_singleton()->set_clipboard(version_btn->get_meta(META_TEXT_TO_COPY));
+}
+
 void EditorAbout::_bind_methods() {
 
+	ClassDB::bind_method("_version_button_pressed", &EditorAbout::_version_button_pressed);
 	ClassDB::bind_method(D_METHOD("_license_tree_selected"), &EditorAbout::_license_tree_selected);
 }
 
@@ -130,16 +138,31 @@ EditorAbout::EditorAbout() {
 	_logo = memnew(TextureRect);
 	hbc->add_child(_logo);
 
+	VBoxContainer *version_info_vbc = memnew(VBoxContainer);
+
+	// Add a dummy control node for spacing.
+	Control *v_spacer = memnew(Control);
+	version_info_vbc->add_child(v_spacer);
+
+	version_btn = memnew(LinkButton);
 	String hash = String(VERSION_HASH);
-	if (hash.length() != 0)
+	if (hash.length() != 0) {
 		hash = "." + hash.left(9);
+	}
+	version_btn->set_text(VERSION_FULL_NAME + hash);
+	// Set the text to copy in metadata as it slightly differs from the button's text.
+	version_btn->set_meta(META_TEXT_TO_COPY, "v" VERSION_FULL_BUILD + hash);
+	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
+	version_btn->set_tooltip(TTR("Click to copy."));
+	version_btn->connect("pressed", this, "_version_button_pressed");
+	version_info_vbc->add_child(version_btn);
 
 	Label *about_text = memnew(Label);
-	about_text->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
-	about_text->set_text(VERSION_FULL_NAME + hash +
-						 String::utf8("\n\xc2\xa9 2007-2020 Juan Linietsky, Ariel Manzur.\n\xc2\xa9 2014-2020 ") +
+	about_text->set_text(String::utf8("\xc2\xa9 2007-2020 Juan Linietsky, Ariel Manzur.\n\xc2\xa9 2014-2020 ") +
 						 TTR("Godot Engine contributors") + "\n");
-	hbc->add_child(about_text);
+	version_info_vbc->add_child(about_text);
+
+	hbc->add_child(version_info_vbc);
 
 	TabContainer *tc = memnew(TabContainer);
 	tc->set_custom_minimum_size(Size2(950, 400) * EDSCALE);
diff --git a/editor/editor_about.h b/editor/editor_about.h
index 51438ee953b..3b43ef33e9a 100644
--- a/editor/editor_about.h
+++ b/editor/editor_about.h
@@ -34,6 +34,7 @@
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/item_list.h"
+#include "scene/gui/link_button.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/separator.h"
@@ -50,8 +51,10 @@ class EditorAbout : public AcceptDialog {
 
 private:
 	void _license_tree_selected();
+	void _version_button_pressed();
 	ScrollContainer *_populate_list(const String &p_name, const List<String> &p_sections, const char *const *const p_src[], const int p_flag_single_column = 0);
 
+	LinkButton *version_btn;
 	Tree *_tpl_tree;
 	RichTextLabel *_license_text;
 	RichTextLabel *_tpl_text;
diff --git a/editor/editor_node.cpp b/editor/editor_node.cpp
index c5b67eb9712..4d2c5865851 100644
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -47,12 +47,14 @@
 #include "core/project_settings.h"
 #include "core/translation.h"
 #include "core/version.h"
+#include "core/version_hash.gen.h"
 #include "main/input_default.h"
 #include "main/main.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/file_dialog.h"
+#include "scene/gui/link_button.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/panel_container.h"
@@ -175,6 +177,9 @@
 
 EditorNode *EditorNode::singleton = NULL;
 
+// The metadata key used to store and retrieve the version text to copy to the clipboard.
+static const String META_TEXT_TO_COPY = "text_to_copy";
+
 void EditorNode::_update_scene_tabs() {
 
 	bool show_rb = EditorSettings::get_singleton()->get("interface/scene_tabs/show_script_button");
@@ -690,6 +695,10 @@ void EditorNode::_sources_changed(bool p_exist) {
 void EditorNode::_vp_resized() {
 }
 
+void EditorNode::_version_button_pressed() {
+	OS::get_singleton()->set_clipboard(version_btn->get_meta(META_TEXT_TO_COPY));
+}
+
 void EditorNode::_node_renamed() {
 
 	if (get_inspector())
@@ -5422,6 +5431,7 @@ void EditorNode::_bind_methods() {
 	ClassDB::bind_method("_close_messages", &EditorNode::_close_messages);
 	ClassDB::bind_method("_show_messages", &EditorNode::_show_messages);
 	ClassDB::bind_method("_vp_resized", &EditorNode::_vp_resized);
+	ClassDB::bind_method("_version_button_pressed", &EditorNode::_version_button_pressed);
 	ClassDB::bind_method("_quick_opened", &EditorNode::_quick_opened);
 	ClassDB::bind_method("_quick_run", &EditorNode::_quick_run);
 
@@ -6501,11 +6511,31 @@ EditorNode::EditorNode() {
 	bottom_panel_hb_editors->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	bottom_panel_hb->add_child(bottom_panel_hb_editors);
 
-	version_label = memnew(Label);
-	version_label->set_text(VERSION_FULL_CONFIG);
+	VBoxContainer *version_info_vbc = memnew(VBoxContainer);
+	bottom_panel_hb->add_child(version_info_vbc);
+
+	// Add a dummy control node for vertical spacing.
+	Control *v_spacer = memnew(Control);
+	version_info_vbc->add_child(v_spacer);
+
+	version_btn = memnew(LinkButton);
+	version_btn->set_text(VERSION_FULL_CONFIG);
+	String hash = String(VERSION_HASH);
+	if (hash.length() != 0) {
+		hash = "." + hash.left(9);
+	}
+	// Set the text to copy in metadata as it slightly differs from the button's text.
+	version_btn->set_meta(META_TEXT_TO_COPY, "v" VERSION_FULL_BUILD + hash);
 	// Fade out the version label to be less prominent, but still readable
-	version_label->set_self_modulate(Color(1, 1, 1, 0.6));
-	bottom_panel_hb->add_child(version_label);
+	version_btn->set_self_modulate(Color(1, 1, 1, 0.65));
+	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
+	version_btn->set_tooltip(TTR("Click to copy."));
+	version_btn->connect("pressed", this, "_version_button_pressed");
+	version_info_vbc->add_child(version_btn);
+
+	// Add a dummy control node for horizontal spacing.
+	Control *h_spacer = memnew(Control);
+	bottom_panel_hb->add_child(h_spacer);
 
 	bottom_panel_raise = memnew(ToolButton);
 	bottom_panel_raise->set_icon(gui_base->get_icon("ExpandBottomDock", "EditorIcons"));
diff --git a/editor/editor_node.h b/editor/editor_node.h
index a5c04d35319..dc38f370fb2 100644
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -37,6 +37,7 @@
 #include "editor/inspector_dock.h"
 #include "editor/property_editor.h"
 #include "editor/scene_tree_dock.h"
+#include "scene/gui/link_button.h"
 
 typedef void (*EditorNodeInitCallback)();
 typedef void (*EditorPluginInitializeCallback)();
@@ -424,7 +425,7 @@ class EditorNode : public Node {
 	HBoxContainer *bottom_panel_hb;
 	HBoxContainer *bottom_panel_hb_editors;
 	VBoxContainer *bottom_panel_vb;
-	Label *version_label;
+	LinkButton *version_btn;
 	ToolButton *bottom_panel_raise;
 
 	void _bottom_panel_raise_toggled(bool);
@@ -475,6 +476,7 @@ class EditorNode : public Node {
 	void _close_messages();
 	void _show_messages();
 	void _vp_resized();
+	void _version_button_pressed();
 
 	int _save_external_resources();
 
diff --git a/editor/project_manager.cpp b/editor/project_manager.cpp
index 9bbb9bd38c4..4056793d4c2 100644
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2354,6 +2354,7 @@ void ProjectManager::_bind_methods() {
 	ClassDB::bind_method("_erase_missing_projects", &ProjectManager::_erase_missing_projects);
 	ClassDB::bind_method("_erase_project_confirm", &ProjectManager::_erase_project_confirm);
 	ClassDB::bind_method("_erase_missing_projects_confirm", &ProjectManager::_erase_missing_projects_confirm);
+	ClassDB::bind_method("_version_button_pressed", &ProjectManager::_version_button_pressed);
 	ClassDB::bind_method("_language_selected", &ProjectManager::_language_selected);
 	ClassDB::bind_method("_restart_confirm", &ProjectManager::_restart_confirm);
 	ClassDB::bind_method("_exit_dialog", &ProjectManager::_exit_dialog);
@@ -2375,6 +2376,10 @@ void ProjectManager::_open_asset_library() {
 	tabs->set_current_tab(1);
 }
 
+void ProjectManager::_version_button_pressed() {
+	OS::get_singleton()->set_clipboard(version_btn->get_text());
+}
+
 ProjectManager::ProjectManager() {
 
 	// load settings
@@ -2573,16 +2578,30 @@ ProjectManager::ProjectManager() {
 	settings_hb->set_alignment(BoxContainer::ALIGN_END);
 	settings_hb->set_h_grow_direction(Control::GROW_DIRECTION_BEGIN);
 
-	Label *version_label = memnew(Label);
+	// A VBoxContainer that contains a dummy Control node to adjust the LinkButton's vertical position.
+	VBoxContainer *spacer_vb = memnew(VBoxContainer);
+	settings_hb->add_child(spacer_vb);
+
+	Control *v_spacer = memnew(Control);
+	spacer_vb->add_child(v_spacer);
+
+	version_btn = memnew(LinkButton);
 	String hash = String(VERSION_HASH);
 	if (hash.length() != 0) {
 		hash = "." + hash.left(9);
 	}
-	version_label->set_text("v" VERSION_FULL_BUILD "" + hash);
-	// Fade out the version label to be less prominent, but still readable
-	version_label->set_self_modulate(Color(1, 1, 1, 0.6));
-	version_label->set_align(Label::ALIGN_CENTER);
-	settings_hb->add_child(version_label);
+	version_btn->set_text("v" VERSION_FULL_BUILD + hash);
+	// Fade the version label to be less prominent, but still readable.
+	version_btn->set_self_modulate(Color(1, 1, 1, 0.6));
+	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
+	version_btn->set_tooltip(TTR("Click to copy."));
+	version_btn->connect("pressed", this, "_version_button_pressed");
+	spacer_vb->add_child(version_btn);
+
+	// Add a small horizontal spacer between the version and language buttons
+	// to distinguish them.
+	Control *h_spacer = memnew(Control);
+	settings_hb->add_child(h_spacer);
 
 	language_btn = memnew(OptionButton);
 	language_btn->set_flat(true);
diff --git a/editor/project_manager.h b/editor/project_manager.h
index b8f7403e276..e59ca835fdb 100644
--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -74,6 +74,7 @@ class ProjectManager : public Control {
 	TabContainer *tabs;
 	ProjectList *_project_list;
 
+	LinkButton *version_btn;
 	OptionButton *language_btn;
 	Control *gui_base;
 
@@ -114,6 +115,7 @@ class ProjectManager : public Control {
 	void _files_dropped(PoolStringArray p_files, int p_screen);
 	void _scan_multiple_folders(PoolStringArray p_files);
 
+	void _version_button_pressed();
 	void _on_order_option_changed();
 	void _on_filter_option_changed();
```
</details>