### PR TITLE
Export and reference the icon as favicon when exporting to HTML5

### DIFF
--- a/misc/dist/html/fixed-size.html
+++ b/misc/dist/html/fixed-size.html
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
 <head>
 	<meta charset="utf-8" />
+	<link id='-gd-engine-icon' rel='icon' type='image/png' href='favicon.png' />
 	<title></title>
 	<style type="text/css">
 

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset='utf-8' />
 	<meta name='viewport' content='width=device-width, user-scalable=no' />
+	<link id='-gd-engine-icon' rel='icon' type='image/png' href='favicon.png' />
 	<title></title>
 	<style type='text/css'>
 


### PR DESCRIPTION
This makes the project icon display immediately as a favicon when opening the page, without having to wait for the project to finish loading.