### PR TITLE
Set the `title` tag in the HTML5 export immediately

### DIFF
--- a/misc/dist/html/fixed-size.html
+++ b/misc/dist/html/fixed-size.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8" />
 	<link id='-gd-engine-icon' rel='icon' type='image/png' href='favicon.png' />
-	<title></title>
+	<title>$GODOT_PROJECT_NAME</title>
 	<style type="text/css">
 
 		body {

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -4,7 +4,7 @@
 	<meta charset='utf-8' />
 	<meta name='viewport' content='width=device-width, user-scalable=no' />
 	<link id='-gd-engine-icon' rel='icon' type='image/png' href='favicon.png' />
-	<title></title>
+	<title>$GODOT_PROJECT_NAME</title>
 	<style type='text/css'>
 
 		body {

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -252,6 +252,7 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t> &p_html, const Re
 
 		String current_line = lines[i];
 		current_line = current_line.replace("$GODOT_BASENAME", p_name);
+		current_line = current_line.replace("$GODOT_PROJECT_NAME", ProjectSettings::get_singleton()->get_setting("application/config/name"));
 		current_line = current_line.replace("$GODOT_HEAD_INCLUDE", p_preset->get("html/head_include"));
 		current_line = current_line.replace("$GODOT_DEBUG_ENABLED", p_debug ? "true" : "false");
 		str_export += current_line + "\n";


### PR DESCRIPTION
Follow-up to #35381.

This makes the project title display without having to wait for the project to finish loading.

If this is merged, the [Customizing the Web export](https://docs.godotengine.org/en/latest/tutorials/platform/customizing_html5_shell.html) page should be updated to mention the new `$GODOT_PROJECT_NAME` placeholder.