### PR TITLE
Bullet: Prevent potential division by zero

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -795,12 +795,12 @@ Vector3 RigidBodyBullet::get_angular_velocity() const {
 
 void RigidBodyBullet::set_transform__bullet(const btTransform &p_global_transform) {
 	if (mode == PhysicsServer::BODY_MODE_KINEMATIC) {
-		if (space)
+		if (space && space->get_delta_time() != 0)
 			btBody->setLinearVelocity((p_global_transform.getOrigin() - btBody->getWorldTransform().getOrigin()) / space->get_delta_time());
 		// The kinematic use MotionState class
 		godotMotionState->moveBody(p_global_transform);
 	} else {
-		// Is necesasry to avoid wrong location on the rendering side on the next frame
+		// Is necessary to avoid wrong location on the rendering side on the next frame
 		godotMotionState->setWorldTransform(p_global_transform);
 	}
 	CollisionObjectBullet::set_transform__bullet(p_global_transform);


### PR DESCRIPTION
Fixes #33715.

@AndreaCatania Please check, I'm not sure if this is the proper fix here, or if it would be better to print an error instead of skipping setting the transform.