### PR TITLE
Finish up docs for materials

### DIFF
--- a/doc/classes/Material.xml
+++ b/doc/classes/Material.xml
@@ -12,8 +12,12 @@
 	</methods>
 	<members>
 		<member name="next_pass" type="Material" setter="set_next_pass" getter="get_next_pass">
+			Sets the [Material] to be used for the next pass. This renders the object again using a different material.
+			[b]Note:[/b] only applies to [SpatialMaterial]s and [ShaderMaterial]s with type "Spatial".
 		</member>
 		<member name="render_priority" type="int" setter="set_render_priority" getter="get_render_priority" default="0">
+			Sets the render priority for transparent objects in 3D scenes. Higher priority objects will be sorted in front of lower priority objects.
+			[b]Note:[/b] this only applies to sorting of transparent objects. This will not impact how transparent objects are sorted relative to opaque objects. This is because opaque objects are sorted based on depth, while transparent objects are sorted from back to front (subject to priority).
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/Shader.xml
+++ b/doc/classes/Shader.xml
@@ -4,10 +4,11 @@
 		A custom shader program.
 	</brief_description>
 	<description>
-		This class allows you to define a custom shader program that can be used for various materials to render objects.
+		This class allows you to define a custom shader program that can be used by a [ShaderMaterial]. Shaders allow you to write your own custom behavior for rendering objects or updating particle information. For a detailed explanation and usage, please see the tutorials linked below.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/shading/index.html</link>
+		<link>https://docs.godotengine.org/en/latest/tutorials/shading/your_first_shader/what_are_shaders.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_default_texture_param" qualifiers="const">
@@ -16,6 +17,8 @@
 			<argument index="0" name="param" type="String">
 			</argument>
 			<description>
+				Returns the texture that is set as default for the specified parameter.
+				[b]Note:[/b] [code]param[/code] must match the name of the uniform in the code exactly.
 			</description>
 		</method>
 		<method name="get_mode" qualifiers="const">
@@ -31,6 +34,8 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
+				Returns [code]true[/code] if the shader has this param defined as a uniform in its code.
+				[b]Note:[/b] [code]param[/code] must match the name of the uniform in the code exactly.
 			</description>
 		</method>
 		<method name="set_default_texture_param">
@@ -41,19 +46,25 @@
 			<argument index="1" name="texture" type="Texture">
 			</argument>
 			<description>
+				Sets the default texture to be used with a texture uniform. The default is used if a texture is not set in the [ShaderMaterial].
+				[b]Note:[/b] [code]param[/code] must match the name of the uniform in the code exactly.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="code" type="String" setter="set_code" getter="get_code" default="&quot;&quot;">
+			Returns the shader's code as the user has written it, not the full generated code used internally.
 		</member>
 	</members>
 	<constants>
 		<constant name="MODE_SPATIAL" value="0" enum="Mode">
+			Mode used to draw all 3D objects.
 		</constant>
 		<constant name="MODE_CANVAS_ITEM" value="1" enum="Mode">
+			Mode used to draw all 2D objects.
 		</constant>
 		<constant name="MODE_PARTICLES" value="2" enum="Mode">
+			Mode used to calculate particle information on a per-particle basis. Not used for drawing.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/ShaderMaterial.xml
+++ b/doc/classes/ShaderMaterial.xml
@@ -45,7 +45,7 @@
 			<argument index="1" name="value" type="Variant">
 			</argument>
 			<description>
-				Changes the value set for this material of a uniform in the shader.
+				Changes the value set for this material of a uniform in the shader. [b]Note:[/b] [code]param[/code] must match the name of the uniform in the code exactly.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SpatialMaterial.xml
+++ b/doc/classes/SpatialMaterial.xml
@@ -16,6 +16,7 @@
 			<argument index="0" name="feature" type="int" enum="SpatialMaterial.Feature">
 			</argument>
 			<description>
+				Returns [code]true[/code], if the specifed [enum Feature] is enabled.
 			</description>
 		</method>
 		<method name="get_flag" qualifiers="const">
@@ -24,6 +25,7 @@
 			<argument index="0" name="flag" type="int" enum="SpatialMaterial.Flags">
 			</argument>
 			<description>
+				Returns [code]true[/code], if the specified flag is enabled. See [enum Flags] enumerator for options.
 			</description>
 		</method>
 		<method name="get_texture" qualifiers="const">
@@ -32,6 +34,7 @@
 			<argument index="0" name="param" type="int" enum="SpatialMaterial.TextureParam">
 			</argument>
 			<description>
+				Returns the [Texture] associated with the specified [enum TextureParam].
 			</description>
 		</method>
 		<method name="set_feature">
@@ -42,6 +45,7 @@
 			<argument index="1" name="enable" type="bool">
 			</argument>
 			<description>
+				If [code]true[/code], enables the specified [enum Feature]. Many features that are available in [SpatialMaterial]s need to be enabled before use. This way the cost for using the feature is only incurred when specified. Features can also be enabled by setting the corresponding member to [code]true[/code].
 			</description>
 		</method>
 		<method name="set_flag">
@@ -52,6 +56,7 @@
 			<argument index="1" name="enable" type="bool">
 			</argument>
 			<description>
+				If [code]true[/code], enables the specified flag. Flags are optional behaviour that can be turned on and off. Only one flag can be enabled at a time with this function, the flag enumerators cannot be bit-masked together to enable or disable multiple flags at once. Flags can also be enabled by setting the corresponding member to [code]true[/code]. See [enum Flags] enumerator for options.
 			</description>
 		</method>
 		<method name="set_texture">
@@ -62,6 +67,7 @@
 			<argument index="1" name="texture" type="Texture">
 			</argument>
 			<description>
+				Sets the [Texture] to be used by the specified [enum TextureParam]. This function is called when setting members ending in [code]*_texture[/code].
 			</description>
 		</method>
 	</methods>
@@ -70,86 +76,115 @@
 			The material's base color.
 		</member>
 		<member name="albedo_texture" type="Texture" setter="set_texture" getter="get_texture">
+			Texture to multiply by [member albedo_color]. Used for basic texturing of objects.
 		</member>
 		<member name="anisotropy" type="float" setter="set_anisotropy" getter="get_anisotropy">
 			The strength of the anisotropy effect.
 		</member>
 		<member name="anisotropy_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
-			If [code]true[/code], anisotropy is enabled. Changes the shape of the specular blob and aligns it to tangent space.
+			If [code]true[/code], anisotropy is enabled. Changes the shape of the specular blob and aligns it to tangent space. Mesh tangents are needed for this to work. If the mesh does not contain tangents the anisotropy effect will appear broken.
 		</member>
 		<member name="anisotropy_flowmap" type="Texture" setter="set_texture" getter="get_texture">
+			Texture that offsets the tangent map for anisotropy calculations.
 		</member>
 		<member name="ao_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
-			If [code]true[/code], ambient occlusion is enabled.
+			If [code]true[/code], ambient occlusion is enabled. Ambient occlusion darkens areas based on the [member ao_texture].
 		</member>
 		<member name="ao_light_affect" type="float" setter="set_ao_light_affect" getter="get_ao_light_affect">
+			Amount that ambient occlusion affects lighting from lights. If [code]0[/code], ambient occlusion only affects ambient light. If [code]1[/code], ambient occlusion affects lights just as much as it affects ambient light. This can be used to impact the strength of the ambient occlusion effect, but typically looks unrealistic.
 		</member>
 		<member name="ao_on_uv2" type="bool" setter="set_flag" getter="get_flag">
+			If [code]true[/code], use [code]UV2[/code] coordinates to look up from the [member ao_texture].
 		</member>
 		<member name="ao_texture" type="Texture" setter="set_texture" getter="get_texture">
+			Texture that defines the amount of ambient occlusion for a given point on the object.
 		</member>
 		<member name="ao_texture_channel" type="int" setter="set_ao_texture_channel" getter="get_ao_texture_channel" enum="SpatialMaterial.TextureChannel">
+			Specifies the channel of the [member ao_texture] in which the ambient occlusion information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
 		</member>
 		<member name="clearcoat" type="float" setter="set_clearcoat" getter="get_clearcoat">
+			Sets the strength of the clearcoat effect. Setting to [code]0[/code] looks the same as disabling the clearcoat effect.
 		</member>
 		<member name="clearcoat_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
-			If [code]true[/code], clearcoat rendering is enabled. Adds a secondary transparent pass to the material.
+			If [code]true[/code], clearcoat rendering is enabled. Adds a secondary transparent pass to the lighting calculation resulting in an added specular blob. This makes materials appear as if they have a clear layer on them that can either by glossy or rough.
 		</member>
 		<member name="clearcoat_gloss" type="float" setter="set_clearcoat_gloss" getter="get_clearcoat_gloss">
+			Sets the roughness of the clearcoat pass. A higher value results in a smoother clearcoat while a lower value results in a rougher clearcoat.
 		</member>
 		<member name="clearcoat_texture" type="Texture" setter="set_texture" getter="get_texture">
+			Texture that defines the strength of the clearcoat effect and the glossiness of the clearcoat. Strength is specified in the red channel while glossiness is specified in the green channel.
 		</member>
 		<member name="depth_deep_parallax" type="bool" setter="set_depth_deep_parallax" getter="is_depth_deep_parallax_enabled">
+			If [code]true[/code], the shader will read depth texture at multiple points along the view ray to determine occlusion and parrallax. This can be very performance demanding, but results in more realistic looking depth mapping.
 		</member>
 		<member name="depth_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
 			If [code]true[/code], depth mapping is enabled (also called "parallax mapping" or "height mapping"). See also [member normal_enabled].
 		</member>
 		<member name="depth_flip_binormal" type="bool" setter="set_depth_deep_parallax_flip_binormal" getter="get_depth_deep_parallax_flip_binormal">
+			If [code]true[/code], direction of the binormal is flipped before using in the depth effect. This may be necessary if you have encoded your binormals in a way that is conflicting with the depth effect.
 		</member>
 		<member name="depth_flip_tangent" type="bool" setter="set_depth_deep_parallax_flip_tangent" getter="get_depth_deep_parallax_flip_tangent">
+			If [code]true[/code], direction of the tangent is flipped before using in the depth effect. This may be necessary if you have encoded your tangents in a way that is conflicting with the depth effect.
 		</member>
 		<member name="depth_max_layers" type="int" setter="set_depth_deep_parallax_max_layers" getter="get_depth_deep_parallax_max_layers">
+			Number of layers to use when using [member depth_deep_parallax] and the view direction is perpendicular to the surface of the object. A higher number will be more performance demanding while a lower number may not look as crisp.
 		</member>
 		<member name="depth_min_layers" type="int" setter="set_depth_deep_parallax_min_layers" getter="get_depth_deep_parallax_min_layers">
+			Number of layers to use when using [member depth_deep_parallax] and the view direction is parallel to the surface of the object. A higher number will be more performance demanding while a lower number may not look as crisp.
 		</member>
 		<member name="depth_scale" type="float" setter="set_depth_scale" getter="get_depth_scale">
+			Scales the depth offset effect. A higher number will create a larger depth.
 		</member>
 		<member name="depth_texture" type="Texture" setter="set_texture" getter="get_texture">
+			Texture used to determine depth at a given pixel. Depth is always stored in the red channel.
 		</member>
 		<member name="detail_albedo" type="Texture" setter="set_texture" getter="get_texture">
+			Texture that specifies the color of the detail overlay.
 		</member>
 		<member name="detail_blend_mode" type="int" setter="set_detail_blend_mode" getter="get_detail_blend_mode" enum="SpatialMaterial.BlendMode">
+			Specifies how the [member detail_albedo] should blend with the current [code]ALBEDO[/code]. See [enum BlendMode] for options.
 		</member>
 		<member name="detail_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
+			If [code]true[/code], enables the detail overlay. Detail is a second texture that gets mixed over the surface of the object based on [member detail_mask]. This can be used to add variation to objects, or to blend between two different albedo/normal textures.
 		</member>
 		<member name="detail_mask" type="Texture" setter="set_texture" getter="get_texture">
+			Texture used to specify how the detail textures get blended with the base textures.
 		</member>
 		<member name="detail_normal" type="Texture" setter="set_texture" getter="get_texture">
+			Texture that specifies the per-pixel normal of the detail overlay.
 		</member>
 		<member name="detail_uv_layer" type="int" setter="set_detail_uv" getter="get_detail_uv" enum="SpatialMaterial.DetailUV">
+			Specifies whether to use [code]UV[/code] or [code]UV2[/code] for the detail layer. See [enum DetailUV] for options.
 		</member>
 		<member name="distance_fade_max_distance" type="float" setter="set_distance_fade_max_distance" getter="get_distance_fade_max_distance">
+			Distance at which the object fades fully and is no longer visible.
 		</member>
 		<member name="distance_fade_min_distance" type="float" setter="set_distance_fade_min_distance" getter="get_distance_fade_min_distance">
+			Distance at which the object starts to fade. If the object is less than this distance away it will appear normal.
 		</member>
 		<member name="distance_fade_mode" type="int" setter="set_distance_fade" getter="get_distance_fade" enum="SpatialMaterial.DistanceFadeMode" default="0">
+			Specifies which type of fade to use. Can be any of the [enum DistanceFadeMode]s.
 		</member>
 		<member name="emission" type="Color" setter="set_emission" getter="get_emission">
 			The emitted light's color. See [member emission_enabled].
 		</member>
 		<member name="emission_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
-			If [code]true[/code], the body emits light.
+			If [code]true[/code], the body emits light. Emitting light makes the object appear brighter. The object can also cast light on other objects if a [GIProbe] or [BakedLightmap] is used and this object is used in baked lighting.
 		</member>
 		<member name="emission_energy" type="float" setter="set_emission_energy" getter="get_emission_energy">
 			The emitted light's strength. See [member emission_enabled].
 		</member>
 		<member name="emission_on_uv2" type="bool" setter="set_flag" getter="get_flag">
+			Use [code]UV2[/code] to read from the [member emission_texture].
 		</member>
 		<member name="emission_operator" type="int" setter="set_emission_operator" getter="get_emission_operator" enum="SpatialMaterial.EmissionOperator">
+			Sets how [member emission] interacts with [member emission_texture]. Can either add or multiply. See [enum EmissionOperator] for options.
 		</member>
 		<member name="emission_texture" type="Texture" setter="set_texture" getter="get_texture">
+			Texture that specifies how much surface emits light at a given point.
 		</member>
 		<member name="flags_albedo_tex_force_srgb" type="bool" setter="set_flag" getter="get_flag" default="false">
+			Forces a conversion of the [member albedo_texture] from sRGB space to linear space.
 		</member>
 		<member name="flags_disable_ambient_light" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the object receives no ambient light.
@@ -158,6 +193,7 @@
 			If [code]true[/code], the object receives no shadow that would otherwise be cast onto it.
 		</member>
 		<member name="flags_ensure_correct_normals" type="bool" setter="set_flag" getter="get_flag" default="false">
+			If [code]true[/code], the shader will compute extra operations to make sure the normal stays correct when using a non-uniform scale. Only enable if using non-uniform scaling.
 		</member>
 		<member name="flags_fixed_size" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the object is rendered at the same size regardless of distance.
@@ -176,6 +212,7 @@
 			[b]Note:[/b] this is only effective for objects whose geometry is point-based rather than triangle-based. See also [member params_point_size].
 		</member>
 		<member name="flags_use_shadow_to_opacity" type="bool" setter="set_flag" getter="get_flag" default="false">
+			If [code]true[/code], enables the "shadow to opacity" render mode where lighting modifies the alpha so shadowed areas are opaque and non-shadowed areas are transparent. Useful for overlaying shadows onto a camera feed in AR.
 		</member>
 		<member name="flags_vertex_lighting" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], lighting is calculated per vertex rather than per pixel. This may increase performance on low-end devices.
@@ -187,12 +224,14 @@
 			The reflectivity of the object's surface. The higher the value, the more light is reflected.
 		</member>
 		<member name="metallic_specular" type="float" setter="set_specular" getter="get_specular" default="0.5">
-			General reflectivity amount.
+			Sets the size of the specular lobe. The specular lobe is the bright spot that is reflected from light sources.
 			[b]Note:[/b] unlike [member metallic], this is not energy-conserving, so it should be left at [code]0.5[/code] in most cases. See also [member roughness].
 		</member>
 		<member name="metallic_texture" type="Texture" setter="set_texture" getter="get_texture">
+			Texture used to specify metallic for an object. This is multiplied by [member metallic].
 		</member>
 		<member name="metallic_texture_channel" type="int" setter="set_metallic_texture_channel" getter="get_metallic_texture_channel" enum="SpatialMaterial.TextureChannel" default="0">
+			Specifies the channel of the [member metallic_texture] in which the metallic information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
 		</member>
 		<member name="normal_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
 			If [code]true[/code], normal mapping is enabled.
@@ -201,10 +240,13 @@
 			The strength of the normal map's effect.
 		</member>
 		<member name="normal_texture" type="Texture" setter="set_texture" getter="get_texture">
+			Texture used to specify the normal at a given pixel. The [code]normal_texture[/code] only uses the red and green channels. The normal read from [code]normal_texture[/code] is oriented around the surface normal provided by the [Mesh].
 		</member>
 		<member name="params_alpha_scissor_threshold" type="float" setter="set_alpha_scissor_threshold" getter="get_alpha_scissor_threshold">
+			Threshold at which the alpha scissor will discard values.
 		</member>
 		<member name="params_billboard_keep_scale" type="bool" setter="set_flag" getter="get_flag" default="false">
+			If [code]true[/code], the shader will keep the scale set for the mesh. Otherwise the scale is lost when billboarding. Only applies when [member params_billboard_mode] is [constant BILLBOARD_ENABLED].
 		</member>
 		<member name="params_billboard_mode" type="int" setter="set_billboard_mode" getter="get_billboard_mode" enum="SpatialMaterial.BillboardMode" default="0">
 			Controls how the object faces the camera. See [enum BillboardMode].
@@ -229,6 +271,7 @@
 			Grows object vertices in the direction of their normals.
 		</member>
 		<member name="params_line_width" type="float" setter="set_line_width" getter="get_line_width" default="1.0">
+			Currently unimplemented in Godot.
 		</member>
 		<member name="params_point_size" type="float" setter="set_point_size" getter="get_point_size" default="1.0">
 			The point size in pixels. See [member flags_use_point_size].
@@ -237,6 +280,7 @@
 			The method for rendering the specular blob. See [enum SpecularMode].
 		</member>
 		<member name="params_use_alpha_scissor" type="bool" setter="set_flag" getter="get_flag" default="false">
+			If [code]true[/code], the shader will discard all pixels that have an alpha value less than [member params_alpha_scissor_threshold].
 		</member>
 		<member name="particles_anim_h_frames" type="int" setter="set_particles_anim_h_frames" getter="get_particles_anim_h_frames">
 			The number of horizontal frames in the particle sprite sheet. Only enabled when using [constant BILLBOARD_PARTICLES]. See [member params_billboard_mode].
@@ -248,9 +292,10 @@
 			The number of vertical frames in the particle sprite sheet. Only enabled when using [constant BILLBOARD_PARTICLES]. See [member params_billboard_mode].
 		</member>
 		<member name="proximity_fade_distance" type="float" setter="set_proximity_fade_distance" getter="get_proximity_fade_distance">
+			Distance over which the fade effect takes place. The larger the distance the longer it takes for an object to fade.
 		</member>
 		<member name="proximity_fade_enable" type="bool" setter="set_proximity_fade" getter="is_proximity_fade_enabled" default="false">
-			If [code]true[/code], the proximity and distance fade effect is enabled.
+			If [code]true[/code], the proximity fade effect is enabled. The proximity fade effect fades out each pixel based on its distance to another object.
 		</member>
 		<member name="refraction_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
 			If [code]true[/code], the refraction effect is enabled. Distorts transparency based on light from behind the object.
@@ -259,15 +304,19 @@
 			The strength of the refraction effect.
 		</member>
 		<member name="refraction_texture" type="Texture" setter="set_texture" getter="get_texture">
+			Texture that controls the strength of the refraction per-pixel. Multiplied by [member refraction_scale].
 		</member>
 		<member name="refraction_texture_channel" type="int" setter="set_refraction_texture_channel" getter="get_refraction_texture_channel" enum="SpatialMaterial.TextureChannel">
+			Specifies the channel of the [member ao_texture] in which the ambient occlusion information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
 		</member>
 		<member name="rim" type="float" setter="set_rim" getter="get_rim">
+			Sets the strength of the rim lighting effect.
 		</member>
 		<member name="rim_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
-			If [code]true[/code], rim effect is enabled.
+			If [code]true[/code], rim effect is enabled. Rim lighting increases the brightness at glancing angles on an object.
 		</member>
 		<member name="rim_texture" type="Texture" setter="set_texture" getter="get_texture">
+			Texture used to set the strength of the rim lighting effect per-pixel. Multiplied by [member rim].
 		</member>
 		<member name="rim_tint" type="float" setter="set_rim_tint" getter="get_rim_tint">
 			The amount of to blend light and albedo color when rendering rim effect. If [code]0[/code] the light color is used, while [code]1[/code] means albedo color is used. An intermediate value generally works best.
@@ -276,8 +325,10 @@
 			Surface reflection. A value of [code]0[/code] represents a perfect mirror while a value of [code]1[/code] completely blurs the reflection. See also [member metallic].
 		</member>
 		<member name="roughness_texture" type="Texture" setter="set_texture" getter="get_texture">
+			Texture used to control the roughness per-pixel. Multiplied by [member roughness].
 		</member>
 		<member name="roughness_texture_channel" type="int" setter="set_roughness_texture_channel" getter="get_roughness_texture_channel" enum="SpatialMaterial.TextureChannel" default="0">
+			Specifies the channel of the [member ao_texture] in which the ambient occlusion information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
 		</member>
 		<member name="subsurf_scatter_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
 			If [code]true[/code], subsurface scattering is enabled. Emulates light that penetrates an object's surface, is scattered, and then emerges.
@@ -286,6 +337,7 @@
 			The strength of the subsurface scattering effect.
 		</member>
 		<member name="subsurf_scatter_texture" type="Texture" setter="set_texture" getter="get_texture">
+			Texture used to control the subsurface scattering strength. Stored in the red texture channel. Multiplied by [member subsurf_scatter_strength].
 		</member>
 		<member name="transmission" type="Color" setter="set_transmission" getter="get_transmission">
 			The color used by the transmission effect. Represents the light passing through an object.
@@ -294,22 +346,31 @@
 			If [code]true[/code], the transmission effect is enabled.
 		</member>
 		<member name="transmission_texture" type="Texture" setter="set_texture" getter="get_texture">
+			Texture used to control the transmission effect per-pixel. Added to [member transmission].
 		</member>
 		<member name="uv1_offset" type="Vector3" setter="set_uv1_offset" getter="get_uv1_offset" default="Vector3( 0, 0, 0 )">
+			How much to offset the [code]UV[/code] coordinates. This amount will be added to [code]UV[/code] in the vertex function. This can be used to offset a texture.
 		</member>
 		<member name="uv1_scale" type="Vector3" setter="set_uv1_scale" getter="get_uv1_scale" default="Vector3( 1, 1, 1 )">
+			How much to scale the [code]UV[/code] coordinates. This is multiplied by [code]UV[/code] in the vertex function.
 		</member>
 		<member name="uv1_triplanar" type="bool" setter="set_flag" getter="get_flag" default="false">
+			If [code]true[/code], instead of using [code]UV[/code] textures will use a triplanar texture lookup to determine how to apply textures. Triplanar uses the orientation of the object's surface to blend between texture coordinates. It reads from the source texture 3 times, once for each axis and then blends between the results based on how closely the pixel aligns with each axis. This is often used for natural features to get a realistic blend of materials. Because triplanar texturing requires many more texture reads per-pixel it is much slower than normal UV texturing. Additionally, because it is blending the texture between the three axes, it is unsuitable when you are trying to achieve crisp texturing.
 		</member>
 		<member name="uv1_triplanar_sharpness" type="float" setter="set_uv1_triplanar_blend_sharpness" getter="get_uv1_triplanar_blend_sharpness" default="1.0">
+			A lower number blends the texture more softly while a higher number blends the texture more sharply.
 		</member>
 		<member name="uv2_offset" type="Vector3" setter="set_uv2_offset" getter="get_uv2_offset" default="Vector3( 0, 0, 0 )">
+			How much to offset the [code]UV2[/code] coordinates. This amount will be added to [code]UV2[/code] in the vertex function. This can be used to offset a texture.
 		</member>
 		<member name="uv2_scale" type="Vector3" setter="set_uv2_scale" getter="get_uv2_scale" default="Vector3( 1, 1, 1 )">
+			How much to scale the [code]UV2[/code] coordinates. This is multiplied by [code]UV2[/code] in the vertex function.
 		</member>
 		<member name="uv2_triplanar" type="bool" setter="set_flag" getter="get_flag" default="false">
+			If [code]true[/code], instead of using [code]UV2[/code] textures will use a triplanar texture lookup to determine how to apply textures. Triplanar uses the orientation of the object's surface to blend between texture coordinates. It reads from the source texture 3 times, once for each axis and then blends between the results based on how closely the pixel aligns with each axis. This is often used for natural features to get a realistic blend of materials. Because triplanar texturing requires many more texture reads per-pixel it is much slower than normal UV texturing. Additionally, because it is blending the texture between the three axes, it is unsuitable when you are trying to achieve crisp texturing.
 		</member>
 		<member name="uv2_triplanar_sharpness" type="float" setter="set_uv2_triplanar_blend_sharpness" getter="get_uv2_triplanar_blend_sharpness" default="1.0">
+			A lower number blends the texture more softly while a higher number blends the texture more sharply.
 		</member>
 		<member name="vertex_color_is_srgb" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the model's vertex colors are processed as sRGB mode.
@@ -320,79 +381,112 @@
 	</members>
 	<constants>
 		<constant name="TEXTURE_ALBEDO" value="0" enum="TextureParam">
+			Texture specifying per-pixel color.
 		</constant>
 		<constant name="TEXTURE_METALLIC" value="1" enum="TextureParam">
+			Texture specifying per-pixel metallic value.
 		</constant>
 		<constant name="TEXTURE_ROUGHNESS" value="2" enum="TextureParam">
+			Texture specifying per-pixel roughness value.
 		</constant>
 		<constant name="TEXTURE_EMISSION" value="3" enum="TextureParam">
+			Texture specifying per-pixel emission color.
 		</constant>
 		<constant name="TEXTURE_NORMAL" value="4" enum="TextureParam">
+			Texture specifying per-pixel normal vector.
 		</constant>
 		<constant name="TEXTURE_RIM" value="5" enum="TextureParam">
+			Texture specifying per-pixel rim value.
 		</constant>
 		<constant name="TEXTURE_CLEARCOAT" value="6" enum="TextureParam">
+			Texture specifying per-pixel clearcoat value.
 		</constant>
 		<constant name="TEXTURE_FLOWMAP" value="7" enum="TextureParam">
+			Texture specifying per-pixel flowmap direction for use with [member anisotropy].
 		</constant>
 		<constant name="TEXTURE_AMBIENT_OCCLUSION" value="8" enum="TextureParam">
+			Texture specifying per-pixel ambient occlusion value.
 		</constant>
 		<constant name="TEXTURE_DEPTH" value="9" enum="TextureParam">
+			Texture specifying per-pixel depth.
 		</constant>
 		<constant name="TEXTURE_SUBSURFACE_SCATTERING" value="10" enum="TextureParam">
+			Texture specifying per-pixel subsurface scattering.
 		</constant>
 		<constant name="TEXTURE_TRANSMISSION" value="11" enum="TextureParam">
+			Texture specifying per-pixel transmission color.
 		</constant>
 		<constant name="TEXTURE_REFRACTION" value="12" enum="TextureParam">
+			Texture specifying per-pixel refraction strength.
 		</constant>
 		<constant name="TEXTURE_DETAIL_MASK" value="13" enum="TextureParam">
+			Texture specifying per-pixel detail mask blending value.
 		</constant>
 		<constant name="TEXTURE_DETAIL_ALBEDO" value="14" enum="TextureParam">
+			Texture specifying per-pixel detail color.
 		</constant>
 		<constant name="TEXTURE_DETAIL_NORMAL" value="15" enum="TextureParam">
+			Texture specifying per-pixel detail normal.
 		</constant>
 		<constant name="TEXTURE_MAX" value="16" enum="TextureParam">
 			Represents the size of the [enum TextureParam] enum.
 		</constant>
 		<constant name="DETAIL_UV_1" value="0" enum="DetailUV">
+			Use [code]UV[/code] with the detail texture.
 		</constant>
 		<constant name="DETAIL_UV_2" value="1" enum="DetailUV">
+			Use [code]UV2[/code] with the detail texture.
 		</constant>
 		<constant name="FEATURE_TRANSPARENT" value="0" enum="Feature">
+			Constant for setting [member flags_transparent].
 		</constant>
 		<constant name="FEATURE_EMISSION" value="1" enum="Feature">
+			Constant for setting [member emission_enabled].
 		</constant>
 		<constant name="FEATURE_NORMAL_MAPPING" value="2" enum="Feature">
+			Constant for setting [member normal_enabled].
 		</constant>
 		<constant name="FEATURE_RIM" value="3" enum="Feature">
+			Constant for setting [member rim_enabled].
 		</constant>
 		<constant name="FEATURE_CLEARCOAT" value="4" enum="Feature">
+			Constant for setting [member clearcoat_enabled].
 		</constant>
 		<constant name="FEATURE_ANISOTROPY" value="5" enum="Feature">
+			Constant for setting [member anisotropy_enabled].
 		</constant>
 		<constant name="FEATURE_AMBIENT_OCCLUSION" value="6" enum="Feature">
+			Constant for setting [member ao_enabled].
 		</constant>
 		<constant name="FEATURE_DEPTH_MAPPING" value="7" enum="Feature">
+			Constant for setting [member depth_enabled].
 		</constant>
 		<constant name="FEATURE_SUBSURACE_SCATTERING" value="8" enum="Feature">
+			Constant for setting [member subsurf_scatter_enabled].
 		</constant>
 		<constant name="FEATURE_TRANSMISSION" value="9" enum="Feature">
+			Constant for setting [member transmission_enabled].
 		</constant>
 		<constant name="FEATURE_REFRACTION" value="10" enum="Feature">
+			Constant for setting [member refraction_enabled].
 		</constant>
 		<constant name="FEATURE_DETAIL" value="11" enum="Feature">
+			Constant for setting [member detail_enabled].
 		</constant>
 		<constant name="FEATURE_MAX" value="12" enum="Feature">
 			Represents the size of the [enum Feature] enum.
 		</constant>
 		<constant name="BLEND_MODE_MIX" value="0" enum="BlendMode">
-			Default blend mode.
+			Default blend mode. The color of the object is blended over the background based on the object's alpha value.
 		</constant>
 		<constant name="BLEND_MODE_ADD" value="1" enum="BlendMode">
+			The color of the object is added to the background.
 		</constant>
 		<constant name="BLEND_MODE_SUB" value="2" enum="BlendMode">
+			The color of the object is subtracted from the background.
 		</constant>
 		<constant name="BLEND_MODE_MUL" value="3" enum="BlendMode">
+			The color of the object is multiplied by the background.
 		</constant>
 		<constant name="DEPTH_DRAW_OPAQUE_ONLY" value="0" enum="DepthDrawMode">
 			Default depth draw mode. Depth is drawn only for opaque objects.
@@ -416,42 +510,61 @@
 			No culling is performed.
 		</constant>
 		<constant name="FLAG_UNSHADED" value="0" enum="Flags">
+			No lighting is used on the object. Color comes directly from [code]ALBEDO[/code].
 		</constant>
 		<constant name="FLAG_USE_VERTEX_LIGHTING" value="1" enum="Flags">
+			Lighting is calculated per-vertex rather than per-pixel. This can be used to increase the speed of the shader at the cost of quality.
 		</constant>
 		<constant name="FLAG_DISABLE_DEPTH_TEST" value="2" enum="Flags">
+			Disables the depth test, so this object is drawn on top of all others. However, objects drawn after it in the draw order may cover it.
 		</constant>
 		<constant name="FLAG_ALBEDO_FROM_VERTEX_COLOR" value="3" enum="Flags">
+			Set [code]ALBEDO[/code] to the per-vertex color specified in the mesh.
 		</constant>
 		<constant name="FLAG_SRGB_VERTEX_COLOR" value="4" enum="Flags">
+			Vertex color is in sRGB space and needs to be converted to linear. Only applies in the GLES3 renderer.
 		</constant>
 		<constant name="FLAG_USE_POINT_SIZE" value="5" enum="Flags">
+			Uses point size to alter the size of primitive points. Also changes the albedo texture lookup to use [code]POINT_COORD[/code] instead of [code]UV[/code].
 		</constant>
 		<constant name="FLAG_FIXED_SIZE" value="6" enum="Flags">
+			Object is scaled by depth so that it always appears the same size on screen.
 		</constant>
 		<constant name="FLAG_BILLBOARD_KEEP_SCALE" value="7" enum="Flags">
+			Shader will keep the scale set for the mesh. Otherwise the scale is lost when billboarding. Only applies when [member params_billboard_mode] is [constant BILLBOARD_ENABLED].
 		</constant>
 		<constant name="FLAG_UV1_USE_TRIPLANAR" value="8" enum="Flags">
+			Use triplanar texture lookup for all texture lookups that would normally use [code]UV[/code].
 		</constant>
 		<constant name="FLAG_UV2_USE_TRIPLANAR" value="9" enum="Flags">
+			Use triplanar texture lookup for all texture lookups that would normally use [code]UV2[/code].
 		</constant>
 		<constant name="FLAG_AO_ON_UV2" value="11" enum="Flags">
+			Use [code]UV2[/code] coordinates to look up from the [member ao_texture].
 		</constant>
 		<constant name="FLAG_EMISSION_ON_UV2" value="12" enum="Flags">
+			Use [code]UV2[/code] coordinates to look up from the [member emission_texture].
 		</constant>
 		<constant name="FLAG_USE_ALPHA_SCISSOR" value="13" enum="Flags">
+			Use alpha scissor. Set by [member params_use_alpha_scissor].
 		</constant>
 		<constant name="FLAG_TRIPLANAR_USE_WORLD" value="10" enum="Flags">
+			Use world coordinates in the triplanar texture lookup instead of local coordinates.
 		</constant>
 		<constant name="FLAG_ALBEDO_TEXTURE_FORCE_SRGB" value="14" enum="Flags">
+			Forces the shader to convert albedo from sRGB space to linear space.
 		</constant>
 		<constant name="FLAG_DONT_RECEIVE_SHADOWS" value="15" enum="Flags">
+			Disables receiving shadows from other objects.
 		</constant>
 		<constant name="FLAG_DISABLE_AMBIENT_LIGHT" value="17" enum="Flags">
+			Disables receiving ambient light.
 		</constant>
 		<constant name="FLAG_ENSURE_CORRECT_NORMALS" value="16" enum="Flags">
+			Ensures that normals appear correct, even with non-uniform scaling.
 		</constant>
 		<constant name="FLAG_USE_SHADOW_TO_OPACITY" value="18" enum="Flags">
+			Enables the shadow to opacity feature.
 		</constant>
 		<constant name="FLAG_MAX" value="19" enum="Flags">
 			Represents the size of the [enum Flags] enum.
@@ -499,26 +612,37 @@
 			Used for particle systems. Enables particle animation options.
 		</constant>
 		<constant name="TEXTURE_CHANNEL_RED" value="0" enum="TextureChannel">
+			Used to read from the red channel of a texture.
 		</constant>
 		<constant name="TEXTURE_CHANNEL_GREEN" value="1" enum="TextureChannel">
+			Used to read from the green channel of a texture.
 		</constant>
 		<constant name="TEXTURE_CHANNEL_BLUE" value="2" enum="TextureChannel">
+			Used to read from the blue channel of a texture.
 		</constant>
 		<constant name="TEXTURE_CHANNEL_ALPHA" value="3" enum="TextureChannel">
+			Used to read from the alpha channel of a texture.
 		</constant>
 		<constant name="TEXTURE_CHANNEL_GRAYSCALE" value="4" enum="TextureChannel">
+			Currently unused.
 		</constant>
 		<constant name="EMISSION_OP_ADD" value="0" enum="EmissionOperator">
+			Adds the emission color to the color from the emission texture.
 		</constant>
 		<constant name="EMISSION_OP_MULTIPLY" value="1" enum="EmissionOperator">
+			Multiplies the emission color by the color from the emission texture.
 		</constant>
 		<constant name="DISTANCE_FADE_DISABLED" value="0" enum="DistanceFadeMode">
+			Do not use distance fade.
 		</constant>
 		<constant name="DISTANCE_FADE_PIXEL_ALPHA" value="1" enum="DistanceFadeMode">
+			Smoothly fades the object out based on each pixel's distance from the camera using the alpha channel.
 		</constant>
 		<constant name="DISTANCE_FADE_PIXEL_DITHER" value="2" enum="DistanceFadeMode">
+			Smoothly fades the object out based on each pixel's distance from the camera using a dither approach. Dithering discards pixels based on a set pattern to smoothly fade without enabling transparency. On certain hardware this can be faster than [constant DISTANCE_FADE_PIXEL_ALPHA].
 		</constant>
 		<constant name="DISTANCE_FADE_OBJECT_DITHER" value="3" enum="DistanceFadeMode">
+			Smoothly fades the object out based on the object's distance from the camera using a dither approach. Dithering discards pixels based on a set pattern to smoothly fade without enabling transparency. On certain hardware this can be faster than [constant DISTANCE_FADE_PIXEL_ALPHA].
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
Fixes: #35158 and fixes #28927

Finishes the documentation for Material, Shader, ShaderMaterial, and SpatialMaterial.

PS. I actually remembered to run makerst.py before committing this time. Can't promise the spelling is good though... 