### PR TITLE
Fix asset library video play overlay not being centered on the thumbnail

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -162,7 +162,7 @@ void EditorAssetLibraryItemDescription::set_image(int p_type, int p_index, const
 						Ref<Image> overlay = get_icon("PlayOverlay", "EditorIcons")->get_data();
 						Ref<Image> thumbnail = p_image->get_data();
 						thumbnail = thumbnail->duplicate();
-						Point2 overlay_pos = Point2((thumbnail->get_width() - overlay->get_width() / 2) / 2, (thumbnail->get_height() - overlay->get_height() / 2) / 2);
+						Point2 overlay_pos = Point2((thumbnail->get_width() - overlay->get_width()) / 2, (thumbnail->get_height() - overlay->get_height()) / 2);
 
 						// Overlay and thumbnail need the same format for `blend_rect` to work.
 						thumbnail->convert(Image::FORMAT_RGBA8);


### PR DESCRIPTION
together with #35363 it should address the first problem described in #31683.

before:
![centerNO](https://user-images.githubusercontent.com/8831226/72782862-2591f380-3c25-11ea-86c1-f3be8493557a.png)
after:
![center](https://user-images.githubusercontent.com/8831226/72782869-2aef3e00-3c25-11ea-97ed-ca1c02e18751.png)
