### PR TITLE
Range: Properly bind value emitted by 'changed' signal

### DIFF
--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -60,6 +60,8 @@
 	</members>
 	<signals>
 		<signal name="changed">
+			<argument index="0" name="value" type="float">
+			</argument>
 			<description>
 				Emitted when [member min_value], [member max_value], [member page], or [member step] change.
 			</description>

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -266,7 +266,7 @@ void Range::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("unshare"), &Range::unshare);
 
 	ADD_SIGNAL(MethodInfo("value_changed", PropertyInfo(Variant::REAL, "value")));
-	ADD_SIGNAL(MethodInfo("changed"));
+	ADD_SIGNAL(MethodInfo("changed", PropertyInfo(Variant::REAL, "value")));
 
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "min_value"), "set_min", "get_min");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "max_value"), "set_max", "get_max");


### PR DESCRIPTION
This was fixed in the `master` branch by removing the value in #29831,
but for `3.1` we preserve compatibility, even if redundant with
'value_changed'.

Fixes #35395.