### PR TITLE
Clip text in NodeDock toolbuttons to prevent dock size changes

### DIFF
--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -105,6 +105,7 @@ NodeDock::NodeDock() {
 	connections_button->set_toggle_mode(true);
 	connections_button->set_pressed(true);
 	connections_button->set_h_size_flags(SIZE_EXPAND_FILL);
+	connections_button->set_clip_text(true);
 	mode_hb->add_child(connections_button);
 	connections_button->connect("pressed", this, "show_connections");
 
@@ -113,6 +114,7 @@ NodeDock::NodeDock() {
 	groups_button->set_toggle_mode(true);
 	groups_button->set_pressed(false);
 	groups_button->set_h_size_flags(SIZE_EXPAND_FILL);
+	groups_button->set_clip_text(true);
 	mode_hb->add_child(groups_button);
 	groups_button->connect("pressed", this, "show_groups");
 


### PR DESCRIPTION
Fixes #35367

Button icons are loaded / unloaded everytime the visible state of the node or its parent changes. As a result, the space needed for icon and text is recalculated. Enabling text clipping prevents the toolbutton from adding space to the total needed size. Instead, it strips it from the text element.