### PR TITLE
Fix MultiplayerAPI crash when peer implementation misbehave.

### DIFF
--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -111,6 +111,7 @@ void MultiplayerAPI::poll() {
 		Error err = network_peer->get_packet(&packet, len);
 		if (err != OK) {
 			ERR_PRINT("Error getting packet!");
+			break; // Something is wrong!
 		}
 
 		rpc_sender_id = sender;

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -98,7 +98,7 @@ void WebSocketMultiplayerPeer::_bind_methods() {
 //
 int WebSocketMultiplayerPeer::get_available_packet_count() const {
 
-	ERR_FAIL_COND_V_MSG(!_is_multiplayer, ERR_UNCONFIGURED, "Please use get_peer(ID).get_available_packet_count to get available packet count from peers when not using the MultiplayerAPI.");
+	ERR_FAIL_COND_V_MSG(!_is_multiplayer, 0, "Please use get_peer(ID).get_available_packet_count to get available packet count from peers when not using the MultiplayerAPI.");
 
 	return _incoming_packets.size();
 }


### PR DESCRIPTION
Also fix WebSocketMultiplayer::get_available_packet_count() return value
when peer is not configured to use the multiplayer API.