### PR TITLE
ALSA MIDI: Pitch bend and System Common messages

### DIFF
--- a/core/os/midi_driver.cpp
+++ b/core/os/midi_driver.cpp
@@ -52,7 +52,12 @@ void MIDIDriver::receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_
 	uint32_t param_position = 1;
 
 	if (length >= 1) {
-		if ((data[0] & 0x80) == 0x00) {
+		if (data[0] >= 0xF0) {
+			// channel does not apply to system common messages
+			event->set_channel(0);
+			event->set_message(data[0]);
+			last_received_message = data[0];
+		} else if ((data[0] & 0x80) == 0x00) {
 			// running status
 			event->set_channel(last_received_message & 0xF);
 			event->set_message(last_received_message >> 4);

--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -43,12 +43,30 @@ static int get_message_size(uint8_t message) {
 		case 0x90: // note on
 		case 0xA0: // aftertouch
 		case 0xB0: // continuous controller
+		case 0xE0: // pitch bend
+		case 0xF2: // song position pointer
 			return 3;
 
 		case 0xC0: // patch change
 		case 0xD0: // channel pressure
-		case 0xE0: // pitch bend
+		case 0xF1: // time code quarter frame
+		case 0xF3: // song select
 			return 2;
+
+		case 0xF0: // SysEx start
+		case 0xF4: // reserved
+		case 0xF5: // reserved
+		case 0xF6: // tune request
+		case 0xF7: // SysEx end
+		case 0xF8: // timing clock
+		case 0xF9: // reserved
+		case 0xFA: // start
+		case 0xFB: // continue
+		case 0xFC: // stop
+		case 0xFD: // reserved
+		case 0xFE: // active sensing
+		case 0xFF: // reset
+			return 1;
 	}
 
 	return 256;
@@ -83,6 +101,9 @@ void MIDIDriverALSAMidi::thread_func(void *p_udata) {
 							bytes = 0;
 						}
 						expected_size = get_message_size(byte);
+						// After a SysEx start, all bytes are data until a SysEx end, so
+						// we're going to end the command at the SES, and let the common
+						// driver ignore the following data bytes.
 					}
 
 					if (bytes < 256) {


### PR DESCRIPTION
* Pitch bend message now has correct size (was 2 bytes instead of 3).
* Recognized (but not implemented) 0xF? messages. System common messages will be recognized as such, but ignored. SysEx contents will be ignored by the <0x80 rule in the common midi driver.