### PR TITLE
Use a cheaper viewport usage mode in the project manager

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1900,6 +1900,8 @@ bool Main::start() {
 			ProgressDialog *progress_dialog = memnew(ProgressDialog);
 			pmanager->add_child(progress_dialog);
 			sml->get_root()->add_child(pmanager);
+			// Speed up rendering slightly by disabling 3D features while in the project manager.
+			sml->get_root()->set_usage(Viewport::USAGE_2D_NO_SAMPLING);
 			OS::get_singleton()->set_context(OS::CONTEXT_PROJECTMAN);
 			project_manager = true;
 		}


### PR DESCRIPTION
This should speed up rendering slightly. While the project manager is hardly demanding, this may help on high refresh-rate displays or very slow machines.

Testing would be appreciated. My desktop GPU is too fast to show any noticeable difference :slightly_smiling_face:

Note that this PR won't make sense to be merged in 4.0, as viewport usage is determined automatically there.