### PR TITLE
Use a loading placeholder for project icons in the project manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1313,7 +1313,9 @@ void ProjectList::create_project_item_control(int p_index) {
 	hb->set_is_favorite(item.favorite);
 
 	TextureRect *tf = memnew(TextureRect);
-	tf->set_texture(get_icon("DefaultProjectIcon", "EditorIcons"));
+	// The project icon may not be loaded by the time the control is displayed,
+	// so use a loading placeholder.
+	tf->set_texture(get_icon("ProjectIconLoading", "EditorIcons"));
 	if (item.missing) {
 		tf->set_modulate(Color(1, 1, 1, 0.5));
 	}


### PR DESCRIPTION
Now that projects are loaded asynchronously, some projects in the list may be displayed before their icon is done loading. This is especially common on slower hardware.

In such cases, this makes the project manager display a loading placeholder instead of the default project icon.