### PR TITLE
Use an icon in the top Animation Key menu

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3850,6 +3850,7 @@ void CanvasItemEditor::_notification(int p_what) {
 		key_scale_button->set_icon(get_icon("KeyScale", "EditorIcons"));
 		key_insert_button->set_icon(get_icon("Key", "EditorIcons"));
 		key_auto_insert_button->set_icon(get_icon("AutoKey", "EditorIcons"));
+		animation_menu->set_icon(get_icon("GuiTabMenu", "EditorIcons"));
 
 		zoom_minus->set_icon(get_icon("ZoomLess", "EditorIcons"));
 		zoom_plus->set_icon(get_icon("ZoomMore", "EditorIcons"));
@@ -5667,7 +5668,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	animation_hb->add_child(key_auto_insert_button);
 
 	animation_menu = memnew(MenuButton);
-	animation_menu->set_text(TTR("Animation"));
+	animation_menu->set_tooltip(TTR("Animation Key and Pose Options"));
 	animation_hb->add_child(animation_menu);
 	animation_menu->get_popup()->connect("id_pressed", this, "_popup_callback");
 	animation_menu->set_switch_on_hover(true);


### PR DESCRIPTION
Partially fixes- #35420.

Before:
![image](https://user-images.githubusercontent.com/10428035/72849558-b7c9e400-3c85-11ea-8d35-05c02b8d7cda.png)

After:
![image](https://user-images.githubusercontent.com/10428035/72849582-c6b09680-3c85-11ea-91c4-6e73389fa6e9.png)

I think the "EditKey" icon fits better than the "Animation" text as this menu has keyframe stuff.