### PR TITLE
Make sure we know when deleting an emitting object

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -465,8 +465,7 @@ private:
 
 		MethodInfo user;
 		VMap<Target, Slot> slot_map;
-		int lock;
-		Signal() { lock = 0; }
+		Signal() {}
 	};
 
 	HashMap<StringName, Signal> signal_map;
@@ -481,6 +480,7 @@ private:
 	bool _predelete();
 	void _postinitialize();
 	bool _can_translate;
+	bool _emitting;
 #ifdef TOOLS_ENABLED
 	bool _edited;
 	uint32_t _edited_version;


### PR DESCRIPTION
We used a lock signals in the signal_map while emitting, because it was not allowed to disconnect them while being emitted.
We used that lock to check if we where deleting an object during signal emission.

Now that we allow to disconnect signals while they are being emitted (#35088), if an object first disconnects, then gets deleted we can't know that a signal was being emitted during the destructor (like in #33290).

This commit adds a new `_emitting` boolean member to Object to be set while emitting and checked in the destructor, while removing the old signal lock which is now unused.

I hope I got this right :roll_eyes: 