### PR TITLE
Fixes leak when importing zip in AssetLib

### DIFF
--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -97,6 +97,7 @@ int zipio_close(voidpf opaque, voidpf stream) {
 	FileAccess *&f = *(FileAccess **)opaque;
 	if (f) {
 		f->close();
+		memdelete(f);
 		f = NULL;
 	}
 	return 0;


### PR DESCRIPTION
This fixes #31965

A `FileAccess` object is allocated in `zipio_open` and stored in an opaque pointer. In `zipio_close`, it was nulled without being deleted first.