### PR TITLE
Incorrect joystick id was returned on an inactive ARVR controller

### DIFF
--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -295,7 +295,8 @@ int ARVRController::get_joystick_id() const {
 
 	ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, controller_id);
 	if (tracker == NULL) {
-		return 0;
+		// No tracker? no joystick id... (0 is our first joystick)
+		return -1;
 	};
 
 	return tracker->get_joy_id();


### PR DESCRIPTION
If an XR controller did not have an active tracker we were returning joystick id 0.
Joystick id 0 is a valid joystick id resulting in us returning data from an active joystick that had nothing to do with this XR controller.

Simple fix :)

fixes #35427 