### PR TITLE
Remove buggy check if key was already released for accumulated input on linux

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2000,11 +2000,6 @@ void OS_X11::handle_key_event(XKeyEvent *p_event, bool p_echo) {
 		if (last_is_pressed) {
 			k->set_echo(true);
 		}
-	} else {
-		//ignore
-		if (!last_is_pressed) {
-			return;
-		}
 	}
 
 	//printf("key: %x\n",k->get_scancode());


### PR DESCRIPTION
Fixes #27104

`Input::get_singleton()->is_key_pressed` returns `true` if the given scan code exists in the `Set<int> keys_pressed`. However, if the accumulation is not yet complete, the key is not found there because it is still in the `accumulated_event` list. This causes key releases to be not taken into account and makes this check unnecessary.

Edit: If the check is really necessary, it would be possible to extend the check to include the `accumulated_event` list.