### PR TITLE
Allow changing the maximum renderable elements in the scene.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -774,6 +774,15 @@
 		<member name="rendering/limits/rendering/max_renderable_reflections" type="int" setter="" getter="" default="1024">
 			Max number of reflection probes renderable in a frame. If more than this number are used, they will be ignored. On some systems (particularly web) setting this number as low as possible can increase the speed of shader compilation.
 		</member>
+		<member name="rendering/limits/culling/max_instance_cull" type="int" setter="" getter="" default="65536">
+			Max amount of elements renderable in a frame. If more than this are visible per frame, they will be dropped. Keep in mind elements refer to mesh surfaces and not meshes themselves. You may want to modify this value if you also modify the max renderable elements value.
+		</member>
+		<member name="rendering/limits/culling/max_lights_culled" type="int" setter="" getter="" default="4096">
+			Max number of lights renderable in a frame. If more than this number are used, they will be ignored. On some systems (particularly web) setting this number as low as possible can increase the speed of shader compilation. You may want to modify this value if you also modify the max renderable lights value.
+		</member>
+		<member name="rendering/limits/culling/max_reflection_probes_culled" type="int" setter="" getter="" default="4096">
+			Max number of reflection probes renderable in a frame. If more than this number are used, they will be ignored. On some systems (particularly web) setting this number as low as possible can increase the speed of shader compilation. You may want to modify this value if you also modify the max renderable reflections.
+		</member>
 		<member name="rendering/limits/time/time_rollover_secs" type="float" setter="" getter="" default="3600">
 			Shaders have a time variable that constantly increases. At some point, it needs to be rolled back to zero to avoid precision errors on shader animations. This setting specifies when (in seconds).
 		</member>

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -44,12 +44,14 @@ class VisualServerScene {
 public:
 	enum {
 
-		MAX_INSTANCE_CULL = 65536,
-		MAX_LIGHTS_CULLED = 4096,
-		MAX_REFLECTION_PROBES_CULLED = 4096,
-		MAX_ROOM_CULL = 32,
-		MAX_EXTERIOR_PORTALS = 128,
+		DEFAULT_MAX_INSTANCE_CULL = 65536,
+		DEFAULT_MAX_LIGHTS_CULLED = 4096,
+		DEFAULT_MAX_REFLECTION_PROBES_CULLED = 4096,
 	};
+
+	int max_instance_cull;
+	int max_lights_culled;
+	int max_reflection_probes_culled;
 
 	uint64_t render_pass;
 
@@ -423,13 +425,13 @@ public:
 	};
 
 	int instance_cull_count;
-	Instance *instance_cull_result[MAX_INSTANCE_CULL];
-	Instance *instance_shadow_cull_result[MAX_INSTANCE_CULL]; //used for generating shadowmaps
-	Instance *light_cull_result[MAX_LIGHTS_CULLED];
-	RID light_instance_cull_result[MAX_LIGHTS_CULLED];
+	Instance **instance_cull_result;
+	Instance **instance_shadow_cull_result; //used for generating shadowmaps
+	Instance **light_cull_result;
+	RID *light_instance_cull_result;
 	int light_cull_count;
 	int directional_light_count;
-	RID reflection_probe_instance_cull_result[MAX_REFLECTION_PROBES_CULLED];
+	RID *reflection_probe_instance_cull_result;
 	int reflection_probe_cull_count;
 
 	RID_Owner<Instance> instance_owner;


### PR DESCRIPTION
_**Edit:** Godot 4.0 no longer has this problem since [this](https://github.com/godotengine/godot/commit/449df8f688080c02bfbbfafc45421875b77deb1b#diff-95422848acf4f7c897e5a88d02d9db719b21993747181537705ef433b8df75dfR1955) commit._

_**Old PR:**_

Fixes #30597

### The problem:
Setting a value in the project settings for: `rendering/limits/rendering/max_renderable_elements` does not lift the maximum number of elements that can be drawn. For example when loading 50,000 objects to the scene the total number of objects is loaded fine, but only a fixed number is drawn (see screenshot below). This prevents rendering/showing large numbers of e.g. people in a city or a building. Altering the max_renderable_elements value to 1,000,000 makes no difference.

![godot_cull_limitation](https://user-images.githubusercontent.com/48187847/72926605-a26bbd00-3d4c-11ea-855c-39f040f205d0.png)

There is a hard-coded value `MAX_INSTANCE_CULL` in `visual_server_scene.h` file that cannot be edited through the editor or through code at runtime. It is used to allocate a fixed size array for storing drawable elements. It is related to the `DEFAULT_MAX_ELEMENTS` value that was exposed in a previous pull request: #1339. For large scenes it is necessary to increase both values.

### The solution:
This commit exposes (and renames) the `MAX_INSTANCE_CULL`, `DEFAULT_MAX_LIGHTS_CULLED` and `DEFAULT_MAX_REFLECTION_PROBES_CULLED` to match the previously exposed and related values `DEFAULT_MAX_ELEMENTS`, `DEFAULT_MAX_LIGHTS` and `DEFAULT_MAX_REFLECTIONS`.

These are the enum values in `visual_server_scene.h`:
* `MAX_INSTANCE_CULL = 65536`
* `MAX_LIGHTS_CULLED = 4096`
* `MAX_REFLECTION_PROBES_CULLED = 4096`
* `MAX_ROOM_CULL = 32`
* `MAX_EXTERIOR_PORTALS = 128`

The last two are never used (now removed) and the first three could not be previously edited through the editor or through code.

_Note: the tooltip texts for the `ProjectSettings.xml` may need rewording. The tooltips from the related values were re-used with an extra explanation._

### TL;DR:
Allow changing some hard-coded limits (values) through the editor. No default values have been changed. No difference to anyone who can already work within the hard limits. However, anyone who needs to render large numbers of objects needs this patch (we are using this in-house).