### PR TITLE
Fixed Tween::start() with pending updates

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -827,6 +827,7 @@ bool Tween::start() {
 	// Are there any pending updates?
 	if (pending_update != 0) {
 		// Start the tweens after deferring
+		call_deferred("start");
 		return true;
 	}
 


### PR DESCRIPTION
Start was canceled instead of deferred in case of an update in progress.

This line was removed in commit 5e337b31ebcf4509e1cf4cb64b02908ade59df05 but the description doesn't explain the reason.
CC @2shady4u 

Fixes #35441