### PR TITLE
Fixes scrollbar positions on HiDPI display

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -92,6 +92,9 @@ void Polygon2DEditor::_notification(int p_what) {
 			b_snap_grid->set_icon(get_icon("Grid", "EditorIcons"));
 			b_snap_enable->set_icon(get_icon("SnapGrid", "EditorIcons"));
 			uv_icon_zoom->set_texture(get_icon("Zoom", "EditorIcons"));
+
+			uv_vscroll->set_anchors_and_margins_preset(PRESET_RIGHT_WIDE);
+			uv_hscroll->set_anchors_and_margins_preset(PRESET_BOTTOM_WIDE);
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 
@@ -1471,12 +1474,10 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_vscroll = memnew(VScrollBar);
 	uv_vscroll->set_step(0.001);
 	uv_edit_draw->add_child(uv_vscroll);
-	uv_vscroll->set_anchors_and_margins_preset(PRESET_RIGHT_WIDE);
 	uv_vscroll->connect("value_changed", this, "_uv_scroll_changed");
 	uv_hscroll = memnew(HScrollBar);
 	uv_hscroll->set_step(0.001);
 	uv_edit_draw->add_child(uv_hscroll);
-	uv_hscroll->set_anchors_and_margins_preset(PRESET_BOTTOM_WIDE);
 	uv_hscroll->connect("value_changed", this, "_uv_scroll_changed");
 
 	bone_scroll_main_vb = memnew(VBoxContainer);

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -736,6 +736,9 @@ void TextureRegionEditor::_notification(int p_what) {
 			zoom_out->set_icon(get_icon("ZoomLess", "EditorIcons"));
 			zoom_reset->set_icon(get_icon("ZoomReset", "EditorIcons"));
 			zoom_in->set_icon(get_icon("ZoomMore", "EditorIcons"));
+
+			vscroll->set_anchors_and_margins_preset(PRESET_RIGHT_WIDE);
+			hscroll->set_anchors_and_margins_preset(PRESET_BOTTOM_WIDE);
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (snap_mode == SNAP_AUTOSLICE && is_visible() && autoslice_is_dirty) {
@@ -1022,12 +1025,10 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	vscroll = memnew(VScrollBar);
 	vscroll->set_step(0.001);
 	edit_draw->add_child(vscroll);
-	vscroll->set_anchors_and_margins_preset(PRESET_RIGHT_WIDE);
 	vscroll->connect("value_changed", this, "_scroll_changed");
 	hscroll = memnew(HScrollBar);
 	hscroll->set_step(0.001);
 	edit_draw->add_child(hscroll);
-	hscroll->set_anchors_and_margins_preset(PRESET_BOTTOM_WIDE);
 	hscroll->connect("value_changed", this, "_scroll_changed");
 
 	updating_scroll = false;


### PR DESCRIPTION
Applies the initial anchor and margin preset when the control enters the tree, instead of in the constructor.

Before this fix, these two editor's scrollbars are offset on HiDPI display. They are already like this in 3.1.2.

TextureRegion editor:
<img width="636" alt="texture-region" src="https://user-images.githubusercontent.com/372476/72948085-18a90780-3dbf-11ea-81bd-4213e52bd81e.png">

Polygon2D UV editor:
<img width="722" alt="ploygon-uv" src="https://user-images.githubusercontent.com/372476/72948089-1ba3f800-3dbf-11ea-981b-369881089f7a.png">

