### PR TITLE
doc: Misc updates for AnimationNode* and others

### DIFF
--- a/doc/classes/ARVRAnchor.xml
+++ b/doc/classes/ARVRAnchor.xml
@@ -4,7 +4,7 @@
 		An anchor point in AR space.
 	</brief_description>
 	<description>
-		The ARVR Anchor point is a spatial node that maps a real world location identified by the AR platform to a position within the game world. For example, as long as plane detection in ARKit is on, ARKit will identify and update the position of planes (tables, floors, etc) and create anchors for them.
+		The [ARVRAnchor] point is a spatial node that maps a real world location identified by the AR platform to a position within the game world. For example, as long as plane detection in ARKit is on, ARKit will identify and update the position of planes (tables, floors, etc) and create anchors for them.
 		This node is mapped to one of the anchors through its unique ID. When you receive a signal that a new anchor is available, you should add this node to your scene for that anchor. You can predefine nodes and set the ID; the nodes will simply remain on 0,0,0 until a plane is recognized.
 		Keep in mind that, as long as plane detection is enabled, the size, placing and orientation of an anchor will be updated as the detection logic learns more about the real world out there especially if only part of the surface is in view.
 	</description>
@@ -29,7 +29,7 @@
 			<return type="Mesh">
 			</return>
 			<description>
-				If provided by the ARVR Interface, this returns a mesh object for the anchor. For an anchor, this can be a shape related to the object being tracked or it can be a mesh that provides topology related to the anchor and can be used to create shadows/reflections on surfaces or for generating collision shapes.
+				If provided by the [ARVRInterface], this returns a mesh object for the anchor. For an anchor, this can be a shape related to the object being tracked or it can be a mesh that provides topology related to the anchor and can be used to create shadows/reflections on surfaces or for generating collision shapes.
 			</description>
 		</method>
 		<method name="get_plane" qualifiers="const">

--- a/doc/classes/ARVRCamera.xml
+++ b/doc/classes/ARVRCamera.xml
@@ -8,6 +8,7 @@
 		The position and orientation of this node is automatically updated by the ARVR Server to represent the location of the HMD if such tracking is available and can thus be used by game logic. Note that, in contrast to the ARVR Controller, the render thread has access to the most up-to-date tracking data of the HMD and the location of the ARVRCamera can lag a few milliseconds behind what is used for rendering as a result.
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/vr/index.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/ARVRController.xml
+++ b/doc/classes/ARVRController.xml
@@ -9,6 +9,7 @@
 		The position of the controller node is automatically updated by the [ARVRServer]. This makes this node ideal to add child nodes to visualize the controller.
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/vr/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_controller_name" qualifiers="const">

--- a/doc/classes/ARVRInterface.xml
+++ b/doc/classes/ARVRInterface.xml
@@ -8,6 +8,7 @@
 		Interfaces should be written in such a way that simply enabling them will give us a working setup. You can query the available interfaces through [ARVRServer].
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/vr/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_camera_feed_id">
@@ -120,7 +121,7 @@
 			We don't know the status of the tracking or this interface does not provide feedback.
 		</constant>
 		<constant name="ARVR_NOT_TRACKING" value="4" enum="Tracking_status">
-			Tracking is not functional (camera not plugged in or obscured, lighthouses turned off, etc.)
+			Tracking is not functional (camera not plugged in or obscured, lighthouses turned off, etc.).
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/ARVROrigin.xml
+++ b/doc/classes/ARVROrigin.xml
@@ -10,6 +10,7 @@
 		For example, if your character is driving a car, the ARVROrigin node should be a child node of this car. Or, if you're implementing a teleport system to move your character, you should change the position of this node.
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/vr/index.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/ARVRPositionalTracker.xml
+++ b/doc/classes/ARVRPositionalTracker.xml
@@ -9,6 +9,7 @@
 		The [ARVRController] and [ARVRAnchor] both consume objects of this type and should be used in your project. The positional trackers are just under-the-hood objects that make this all work. These are mostly exposed so that GDNative-based interfaces can interact with them.
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/vr/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_hand" qualifiers="const">

--- a/doc/classes/ARVRServer.xml
+++ b/doc/classes/ARVRServer.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ARVRServer" inherits="Object" category="Core" version="3.2">
 	<brief_description>
-		The AR/VR server.
+		Server for AR and VR features.
 	</brief_description>
 	<description>
-		The AR/VR server is the heart of our AR/VR solution and handles all the processing.
+		The AR/VR server is the heart of our Advanced and Virtual Reality solution and handles all the processing.
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/vr/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="center_on_hmd">
@@ -47,14 +48,14 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Gets the interface registered at a given index in our list of interfaces.
+				Returns the interface registered at a given index in our list of interfaces.
 			</description>
 		</method>
 		<method name="get_interface_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Gets the number of interfaces currently registered with the AR/VR server. If your project supports multiple AR/VR platforms, you can look through the available interface, and either present the user with a selection or simply try to initialize each interface and use the first one that returns [code]true[/code].
+				Returns the number of interfaces currently registered with the AR/VR server. If your project supports multiple AR/VR platforms, you can look through the available interface, and either present the user with a selection or simply try to initialize each interface and use the first one that returns [code]true[/code].
 			</description>
 		</method>
 		<method name="get_interfaces" qualifiers="const">
@@ -68,25 +69,28 @@
 			<return type="int">
 			</return>
 			<description>
+				Returns the absolute timestamp (in μs) of the last [ARVRServer] commit of the AR/VR eyes to [VisualServer]. The value comes from an internal call to [method OS.get_ticks_usec].
 			</description>
 		</method>
 		<method name="get_last_frame_usec">
 			<return type="int">
 			</return>
 			<description>
+				Returns the duration (in μs) of the last frame. This is computed as the difference between [method get_last_commit_usec] and [method get_last_process_usec] when committing.
 			</description>
 		</method>
 		<method name="get_last_process_usec">
 			<return type="int">
 			</return>
 			<description>
+				Returns the absolute timestamp (in μs) of the last [ARVRServer] process callback. The value comes from an internal call to [method OS.get_ticks_usec].
 			</description>
 		</method>
 		<method name="get_reference_frame" qualifiers="const">
 			<return type="Transform">
 			</return>
 			<description>
-				Gets the reference frame transform. Mostly used internally and exposed for GDNative build interfaces.
+				Returns the reference frame transform. Mostly used internally and exposed for GDNative build interfaces.
 			</description>
 		</method>
 		<method name="get_tracker" qualifiers="const">
@@ -95,19 +99,20 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Gets the positional tracker at the given ID.
+				Returns the positional tracker at the given ID.
 			</description>
 		</method>
 		<method name="get_tracker_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Gets the number of trackers currently registered.
+				Returns the number of trackers currently registered.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="primary_interface" type="ARVRInterface" setter="set_primary_interface" getter="get_primary_interface">
+			The primary [ARVRInterface] currently bound to the [ARVRServer].
 		</member>
 		<member name="world_scale" type="float" setter="set_world_scale" getter="get_world_scale" default="1.0">
 			Allows you to adjust the scale to your game's units. Most AR/VR platforms assume a scale of 1 game world unit = 1 real world meter.

--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AStar2D" inherits="Reference" category="Core" version="3.2">
 	<brief_description>
-		AStar class representation that uses 2d-vectors as edges.
+		AStar class representation that uses 2D vectors as edges.
 	</brief_description>
 	<description>
 		This is a wrapper for the [AStar] class which uses 2D vectors instead of 3D vectors.

--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -8,6 +8,7 @@
 	Inherit this when creating nodes mainly for use in [AnimationNodeBlendTree], otherwise [AnimationRootNode] should be used instead.
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_input">
@@ -16,7 +17,7 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
-				Adds an input to the node. This is only useful for nodes created for use in an [AnimationNodeBlendTree]
+				Adds an input to the node. This is only useful for nodes created for use in an [AnimationNodeBlendTree].
 			</description>
 		</method>
 		<method name="blend_animation">
@@ -33,7 +34,7 @@
 			<argument index="4" name="blend" type="float">
 			</argument>
 			<description>
-				Blend an animation by "blend" amount (name must be valid in the linked [AnimationPlayer]). A time and delta mas be passed, as well as whether seek happened.
+				Blend an animation by [code]blend[/code] amount (name must be valid in the linked [AnimationPlayer]). A [code]time[/code] and [code]delta[/code] may be passed, as well as whether [code]seek[/code] happened.
 			</description>
 		</method>
 		<method name="blend_input">
@@ -52,7 +53,7 @@
 			<argument index="5" name="optimize" type="bool" default="true">
 			</argument>
 			<description>
-				Blend an input. This is only useful for nodes created for an [AnimationNodeBlendTree]. Time is a delta, unless "seek" is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed.
+				Blend an input. This is only useful for nodes created for an [AnimationNodeBlendTree]. The [code]time[/code] parameter is a relative delta, unless [code]seek[/code] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed (see [enum FilterAction] for options).
 			</description>
 		</method>
 		<method name="blend_node">
@@ -164,10 +165,9 @@
 			<argument index="1" name="seek" type="bool">
 			</argument>
 			<description>
-				Called when a custom node is processed. The argument "time" is relative, unless "seek" is [code]true[/code] (in which case it is absolute).
-			Here, call the [method blend_input], [method blend_node] or [method blend_animation] functions.
-			You can also use [method get_parameter] and [method set_parameter] to modify local memory.
-			This function returns the time left for the current animation to finish (if unsure, just pass  the value from the main blend being called).
+				User-defined callback called when a custom node is processed. The [code]time[/code] parameter is a relative delta, unless [code]seek[/code] is [code]true[/code], in which case it is absolute.
+				Here, call the [method blend_input], [method blend_node] or [method blend_animation] functions. You can also use [method get_parameter] and [method set_parameter] to modify local memory.
+				This function should return the time left for the current animation to finish (if unsure, pass the value from the main blend being called).
 			</description>
 		</method>
 		<method name="remove_input">

--- a/doc/classes/AnimationNodeAdd2.xml
+++ b/doc/classes/AnimationNodeAdd2.xml
@@ -7,6 +7,7 @@
 		A resource to add to an [AnimationNodeBlendTree]. Blends two animations additively based on an amount value in the [code][0.0, 1.0][/code] range.
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/AnimationNodeAdd3.xml
+++ b/doc/classes/AnimationNodeAdd3.xml
@@ -11,6 +11,7 @@
 		- A +add animation to blend with when the blend amount is in the [code][0.0, 1.0][/code] range
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/AnimationNodeAnimation.xml
+++ b/doc/classes/AnimationNodeAnimation.xml
@@ -7,6 +7,7 @@
 		A resource to add to an [AnimationNodeBlendTree]. Only features one output set using the [member animation] property. Use it as an input for [AnimationNode] that blend animations together.
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/AnimationNodeBlend2.xml
+++ b/doc/classes/AnimationNodeBlend2.xml
@@ -7,6 +7,7 @@
 		A resource to add to an [AnimationNodeBlendTree]. Blends two animations linearly based on an amount value in the [code][0.0, 1.0][/code] range.
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/AnimationNodeBlend3.xml
+++ b/doc/classes/AnimationNodeBlend3.xml
@@ -11,6 +11,7 @@
 		- A +blend animation to blend with when the blend amount is in the [code][0.0, 1.0][/code] range
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/AnimationNodeBlendSpace1D.xml
+++ b/doc/classes/AnimationNodeBlendSpace1D.xml
@@ -6,10 +6,11 @@
 	<description>
 		A resource to add to an [AnimationNodeBlendTree].
 		This is a virtual axis on which you can add any type of [AnimationNode] using [method add_blend_point].
-		Outputs the linear blend of the two [code]AnimationNode[/code] closest to the node's current [code]value[/code].
+		Outputs the linear blend of the two [AnimationNode]s closest to the node's current value.
 		You can set the extents of the axis using the [member min_space] and [member max_space].
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_blend_point">
@@ -22,7 +23,7 @@
 			<argument index="2" name="at_index" type="int" default="-1">
 			</argument>
 			<description>
-				Adds a new point that represents a [code]node[/code] on the virtual axis at a given position set by [code]pos[/code]. You can insert it at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code] , the point is inserted at the end of the blend points array.
+				Adds a new point that represents a [code]node[/code] on the virtual axis at a given position set by [code]pos[/code]. You can insert it at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code], the point is inserted at the end of the blend points array.
 			</description>
 		</method>
 		<method name="get_blend_point_count" qualifiers="const">
@@ -38,7 +39,7 @@
 			<argument index="0" name="point" type="int">
 			</argument>
 			<description>
-				Returns the [code]AnimationNode[/code] referenced by the point at index [code]point[/code].
+				Returns the [AnimationNode] referenced by the point at index [code]point[/code].
 			</description>
 		</method>
 		<method name="get_blend_point_position" qualifiers="const">
@@ -67,7 +68,7 @@
 			<argument index="1" name="node" type="AnimationRootNode">
 			</argument>
 			<description>
-				Changes the AnimationNode referenced by the point at index [code]point[/code].
+				Changes the [AnimationNode] referenced by the point at index [code]point[/code].
 			</description>
 		</method>
 		<method name="set_blend_point_position">

--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeBlendSpace2D" inherits="AnimationRootNode" category="Core" version="3.2">
 	<brief_description>
-		Blends linearly between three [AnimationNode] of any type placed in a 2d space.
+		Blends linearly between three [AnimationNode] of any type placed in a 2D space.
 	</brief_description>
 	<description>
 		A resource to add to an [AnimationNodeBlendTree].
@@ -9,6 +9,7 @@
 		You can add vertices to the blend space with [method add_blend_point] and automatically triangulate it by setting [member auto_triangles] to [code]true[/code]. Otherwise, use [method add_triangle] and [method remove_triangle] to create up the blend space by hand.
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_blend_point">
@@ -21,7 +22,7 @@
 			<argument index="2" name="at_index" type="int" default="-1">
 			</argument>
 			<description>
-				Adds a new point that represents a [code]node[/code] at the position set by [code]pos[/code]. You can insert it at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code] , the point is inserted at the end of the blend points array.
+				Adds a new point that represents a [code]node[/code] at the position set by [code]pos[/code]. You can insert it at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code], the point is inserted at the end of the blend points array.
 			</description>
 		</method>
 		<method name="add_triangle">
@@ -36,7 +37,7 @@
 			<argument index="3" name="at_index" type="int" default="-1">
 			</argument>
 			<description>
-				Creates a new triangle using three points [code]x[/code], [code]y[/code], and [code]z[/code]. Triangles can overlap. You can insert the triangle at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code] , the point is inserted at the end of the blend points array.
+				Creates a new triangle using three points [code]x[/code], [code]y[/code], and [code]z[/code]. Triangles can overlap. You can insert the triangle at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code], the point is inserted at the end of the blend points array.
 			</description>
 		</method>
 		<method name="get_blend_point_count" qualifiers="const">
@@ -52,7 +53,7 @@
 			<argument index="0" name="point" type="int">
 			</argument>
 			<description>
-				Returns the [code]AnimationRootNode[/code] referenced by the point at index [code]point[/code].
+				Returns the [AnimationRootNode] referenced by the point at index [code]point[/code].
 			</description>
 		</method>
 		<method name="get_blend_point_position" qualifiers="const">
@@ -108,7 +109,7 @@
 			<argument index="1" name="node" type="AnimationRootNode">
 			</argument>
 			<description>
-				Changes the AnimationNode referenced by the point at index [code]point[/code].
+				Changes the [AnimationNode] referenced by the point at index [code]point[/code].
 			</description>
 		</method>
 		<method name="set_blend_point_position">

--- a/doc/classes/AnimationNodeBlendTree.xml
+++ b/doc/classes/AnimationNodeBlendTree.xml
@@ -5,6 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_node">

--- a/doc/classes/AnimationNodeOneShot.xml
+++ b/doc/classes/AnimationNodeOneShot.xml
@@ -5,6 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_mix_mode" qualifiers="const">

--- a/doc/classes/AnimationNodeOutput.xml
+++ b/doc/classes/AnimationNodeOutput.xml
@@ -5,6 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -4,7 +4,7 @@
 		State machine for control of animations.
 	</brief_description>
 	<description>
-		Contains multiple nodes representing animation states, connected in a graph. Node transitions can be configured to happen automatically or via code, using a shortest-path algorithm. Retrieve the AnimationNodeStateMachinePlayback object from the [AnimationTree] node to control it programmatically.
+		Contains multiple nodes representing animation states, connected in a graph. Node transitions can be configured to happen automatically or via code, using a shortest-path algorithm. Retrieve the [AnimationNodeStateMachinePlayback] object from the [AnimationTree] node to control it programmatically.
 		[b]Example:[/b]
 		[codeblock]
 		var state_machine = $AnimationTree.get("parameters/playback")
@@ -12,6 +12,7 @@
 		[/codeblock]
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_node">
@@ -159,7 +160,7 @@
 			<argument index="1" name="to" type="String">
 			</argument>
 			<description>
-				Deletes the given transition.
+				Deletes the transition between the two specified nodes.
 			</description>
 		</method>
 		<method name="remove_transition_by_index">
@@ -168,7 +169,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Deletes the given transition.
+				Deletes the given transition by index.
 			</description>
 		</method>
 		<method name="rename_node">

--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeStateMachinePlayback" inherits="Resource" category="Core" version="3.2">
 	<brief_description>
-		Playback control for AnimationNodeStateMachine.
+		Playback control for [AnimationNodeStateMachine].
 	</brief_description>
 	<description>
 		Allows control of [AnimationTree] state machines created with [AnimationNodeStateMachine]. Retrieve with [code]$AnimationTree.get("parameters/playback")[/code].
@@ -12,6 +12,7 @@
 		[/codeblock]
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_current_node" qualifiers="const">
@@ -25,6 +26,7 @@
 			<return type="PoolStringArray">
 			</return>
 			<description>
+				Returns the current travel path as computed internally by the A* algorithm.
 			</description>
 		</method>
 		<method name="is_playing" qualifiers="const">

--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -5,14 +5,15 @@
 	<description>
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 	</methods>
 	<members>
 		<member name="advance_condition" type="String" setter="set_advance_condition" getter="get_advance_condition" default="&quot;&quot;">
-			Turn on auto advance when this condition is set. The provided name will become a boolean parameter on the [AnimationTree] that can be controlled from code (see [url=https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html#controlling-from-code][/url]). For example, if [member AnimationTree.tree_root] is an [AnimationNodeStateMachine] and [member advance_condition] is set to "idle":
+			Turn on auto advance when this condition is set. The provided name will become a boolean parameter on the [AnimationTree] that can be controlled from code (see [url=https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html#controlling-from-code][/url]). For example, if [member AnimationTree.tree_root] is an [AnimationNodeStateMachine] and [member advance_condition] is set to [code]"idle"[/code]:
 			[codeblock]
-			$animation_tree["parameters/conditions/idle"] = is_on_floor and linear_velocity.x == 0
+			$animation_tree["parameters/conditions/idle"] = is_on_floor and (linear_velocity.x == 0)
 			[/codeblock]
 		</member>
 		<member name="auto_advance" type="bool" setter="set_auto_advance" getter="has_auto_advance" default="false">
@@ -34,6 +35,7 @@
 	<signals>
 		<signal name="advance_condition_changed">
 			<description>
+				Emitted when [member advance_condition] is changed.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/AnimationNodeTimeScale.xml
+++ b/doc/classes/AnimationNodeTimeScale.xml
@@ -5,6 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/AnimationNodeTimeSeek.xml
+++ b/doc/classes/AnimationNodeTimeSeek.xml
@@ -5,6 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -5,6 +5,7 @@
 	<description>
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_input_caption" qualifiers="const">
@@ -45,134 +46,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="input_0/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_0/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_1/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_1/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_10/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_10/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_11/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_11/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_12/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_12/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_13/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_13/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_14/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_14/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_15/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_15/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_16/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_16/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_17/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_17/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_18/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_18/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_19/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_19/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_2/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_2/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_20/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_20/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_21/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_21/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_22/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_22/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_23/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_23/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_24/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_24/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_25/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_25/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_26/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_26/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_27/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_27/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_28/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_28/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_29/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_29/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_3/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_3/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_30/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_30/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_31/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_31/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_4/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_4/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_5/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_5/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_6/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_6/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_7/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_7/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_8/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_8/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
-		<member name="input_9/auto_advance" type="bool" setter="set_input_as_auto_advance" getter="is_input_set_as_auto_advance">
-		</member>
-		<member name="input_9/name" type="String" setter="set_input_caption" getter="get_input_caption">
-		</member>
 		<member name="input_count" type="int" setter="set_enabled_inputs" getter="get_enabled_inputs" default="0">
 		</member>
 		<member name="xfade_time" type="float" setter="set_cross_fade_time" getter="get_cross_fade_time" default="0.0">

--- a/doc/classes/AnimationTreePlayer.xml
+++ b/doc/classes/AnimationTreePlayer.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationTreePlayer" inherits="Node" category="Core" version="3.2">
 	<brief_description>
-		Animation Player that uses a node graph for blending Animations.
+		Animation player that uses a node graph for blending animations.
 	</brief_description>
 	<description>
 		A node graph tool for blending multiple animations bound to an [AnimationPlayer]. Especially useful for animating characters or other skeleton-based rigs. It can combine several animations to form a desired pose.
 		It takes [Animation]s from an [AnimationPlayer] node and mixes them depending on the graph.
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_node">
@@ -27,7 +28,7 @@
 			<argument index="0" name="delta" type="float">
 			</argument>
 			<description>
-				Shifts position in the animation timeline. Delta is the time in seconds to shift. Events between the current frame and [code]delta[/code] are handled.
+				Shifts position in the animation timeline. [code]delta[/code] is the time in seconds to shift. Events between the current frame and [code]delta[/code] are handled.
 			</description>
 		</method>
 		<method name="animation_node_get_animation" qualifiers="const">
@@ -54,6 +55,7 @@
 			<argument index="0" name="id" type="String">
 			</argument>
 			<description>
+				Returns the absolute playback timestamp of the animation node with name [code]id[/code].
 			</description>
 		</method>
 		<method name="animation_node_set_animation">
@@ -122,10 +124,8 @@
 			</argument>
 			<description>
 				Sets the blend amount of a Blend2 node given its name and value.
-				A Blend2 Node blends two animations with the amount between 0 and 1.
-				At 0, Output is input a.
-				Towards 1, the influence of a gets lessened, the influence of b gets raised.
-				At 1, Output is input b.
+				A Blend2 node blends two animations (A and B) with the amount between 0 and 1.
+				At 0, output is input A. Towards 1, the influence of A gets lessened, the influence of B gets raised. At 1, output is input B.
 			</description>
 		</method>
 		<method name="blend2_node_set_filter_path">
@@ -138,7 +138,7 @@
 			<argument index="2" name="enable" type="bool">
 			</argument>
 			<description>
-				If [code]enable[/code] is [code]true[/code], the blend2 node with ID [code]id[/code] turns off the track modifying the property at [code]path[/code]. The modified node's children continue to animate.
+				If [code]enable[/code] is [code]true[/code], the Blend2 node with name [code]id[/code] turns off the track modifying the property at [code]path[/code]. The modified node's children continue to animate.
 			</description>
 		</method>
 		<method name="blend3_node_get_amount" qualifiers="const">
@@ -159,12 +159,8 @@
 			</argument>
 			<description>
 				Sets the blend amount of a Blend3 node given its name and value.
-				A Blend3 Node blends three animations with the amount between -1 and 1.
-				At -1, Output is input b-.
-				From -1 to 0, the influence of b- gets lessened, the influence of a gets raised and the influence of b+ is 0.
-				At 0, Output is input a.
-				From 0 to 1, the influence of a gets lessened, the influence of b+ gets raised and the influence of b+ is 0.
-				At 1, Output is input b+.
+				A Blend3 Node blends three animations (A, B-, B+) with the amount between -1 and 1.
+				At -1, output is input B-. From -1 to 0, the influence of B- gets lessened, the influence of A gets raised and the influence of B+ is 0. At 0, output is input A. From 0 to 1, the influence of A gets lessened, the influence of B+ gets raised and the influence of B+ is 0. At 1, output is input B+.
 			</description>
 		</method>
 		<method name="blend4_node_get_amount" qualifiers="const">
@@ -186,7 +182,7 @@
 			<description>
 				Sets the blend amount of a Blend4 node given its name and value.
 				A Blend4 Node blends two pairs of animations.
-				The two pairs are blended like blend2 and then added together.
+				The two pairs are blended like Blend2 and then added together.
 			</description>
 		</method>
 		<method name="connect_nodes">
@@ -226,7 +222,7 @@
 			<argument index="0" name="id" type="String">
 			</argument>
 			<description>
-				Returns mix amount of a Mix node given its name.
+				Returns the mix amount of a Mix node given its name.
 			</description>
 		</method>
 		<method name="mix_node_set_amount">
@@ -237,7 +233,7 @@
 			<argument index="1" name="ratio" type="float">
 			</argument>
 			<description>
-				Sets mix amount of a Mix node given its name and value.
+				Sets the mix amount of a Mix node given its name and value.
 				A Mix node adds input b to input a by the amount given by ratio.
 			</description>
 		</method>
@@ -296,7 +292,7 @@
 			<argument index="1" name="new_name" type="String">
 			</argument>
 			<description>
-				Rename a node in the graph.
+				Renames a node in the graph.
 			</description>
 		</method>
 		<method name="node_set_position">
@@ -307,7 +303,7 @@
 			<argument index="1" name="screen_position" type="Vector2">
 			</argument>
 			<description>
-				Sets position of a node in the graph given its name and position.
+				Sets the position of a node in the graph given its name and position.
 			</description>
 		</method>
 		<method name="oneshot_node_get_autorestart_delay" qualifiers="const">
@@ -316,7 +312,7 @@
 			<argument index="0" name="id" type="String">
 			</argument>
 			<description>
-				Returns autostart delay of a OneShot node given its name.
+				Returns the autostart delay of a OneShot node given its name.
 			</description>
 		</method>
 		<method name="oneshot_node_get_autorestart_random_delay" qualifiers="const">
@@ -325,7 +321,7 @@
 			<argument index="0" name="id" type="String">
 			</argument>
 			<description>
-				Returns autostart random delay of a OneShot node given its name.
+				Returns the autostart random delay of a OneShot node given its name.
 			</description>
 		</method>
 		<method name="oneshot_node_get_fadein_time" qualifiers="const">
@@ -334,7 +330,7 @@
 			<argument index="0" name="id" type="String">
 			</argument>
 			<description>
-				Returns fade in time of a OneShot node given its name.
+				Returns the fade in time of a OneShot node given its name.
 			</description>
 		</method>
 		<method name="oneshot_node_get_fadeout_time" qualifiers="const">
@@ -343,7 +339,7 @@
 			<argument index="0" name="id" type="String">
 			</argument>
 			<description>
-				Returns fade out time of a OneShot node given its name.
+				Returns the fade out time of a OneShot node given its name.
 			</description>
 		</method>
 		<method name="oneshot_node_has_autorestart" qualifiers="const">
@@ -372,7 +368,7 @@
 			<argument index="1" name="enable" type="bool">
 			</argument>
 			<description>
-				Sets autorestart property of a OneShot node given its name and value.
+				Sets the autorestart property of a OneShot node given its name and value.
 			</description>
 		</method>
 		<method name="oneshot_node_set_autorestart_delay">
@@ -383,7 +379,7 @@
 			<argument index="1" name="delay_sec" type="float">
 			</argument>
 			<description>
-				Sets autorestart delay of a OneShot node given its name and value in seconds.
+				Sets the autorestart delay of a OneShot node given its name and value in seconds.
 			</description>
 		</method>
 		<method name="oneshot_node_set_autorestart_random_delay">
@@ -394,7 +390,7 @@
 			<argument index="1" name="rand_sec" type="float">
 			</argument>
 			<description>
-				Sets autorestart random delay of a OneShot node given its name and value in seconds.
+				Sets the autorestart random delay of a OneShot node given its name and value in seconds.
 			</description>
 		</method>
 		<method name="oneshot_node_set_fadein_time">
@@ -405,7 +401,7 @@
 			<argument index="1" name="time_sec" type="float">
 			</argument>
 			<description>
-				Sets fade in time of a OneShot node given its name and value in seconds.
+				Sets the fade in time of a OneShot node given its name and value in seconds.
 			</description>
 		</method>
 		<method name="oneshot_node_set_fadeout_time">
@@ -416,7 +412,7 @@
 			<argument index="1" name="time_sec" type="float">
 			</argument>
 			<description>
-				Sets fade out time of a OneShot node given its name and value in seconds.
+				Sets the fade out time of a OneShot node given its name and value in seconds.
 			</description>
 		</method>
 		<method name="oneshot_node_set_filter_path">
@@ -429,7 +425,7 @@
 			<argument index="2" name="enable" type="bool">
 			</argument>
 			<description>
-				If [code]enable[/code] is [code]true[/code], the oneshot node with ID [code]id[/code] turns off the track modifying the property at [code]path[/code]. The modified node's children continue to animate.
+				If [code]enable[/code] is [code]true[/code], the OneShot node with ID [code]id[/code] turns off the track modifying the property at [code]path[/code]. The modified node's children continue to animate.
 			</description>
 		</method>
 		<method name="oneshot_node_start">
@@ -479,7 +475,7 @@
 			<argument index="0" name="id" type="String">
 			</argument>
 			<description>
-				Returns time scale value of the TimeScale node with name [code]id[/code].
+				Returns the time scale value of the TimeScale node with name [code]id[/code].
 			</description>
 		</method>
 		<method name="timescale_node_set_scale">
@@ -491,7 +487,7 @@
 			</argument>
 			<description>
 				Sets the time scale of the TimeScale node with name [code]id[/code] to [code]scale[/code].
-				The timescale node is used to speed [Animation]s up if the scale is above 1 or slow them down if it is below 1.
+				The TimeScale node is used to speed [Animation]s up if the scale is above 1 or slow them down if it is below 1.
 				If applied after a blend or mix, affects all input animations to that blend or mix.
 			</description>
 		</method>
@@ -533,7 +529,7 @@
 			<argument index="0" name="id" type="String">
 			</argument>
 			<description>
-				Returns the number of inputs for the transition node with name [code]id[/code]. You can add inputs by rightclicking on the transition node.
+				Returns the number of inputs for the transition node with name [code]id[/code]. You can add inputs by right-clicking on the transition node.
 			</description>
 		</method>
 		<method name="transition_node_get_xfade_time" qualifiers="const">
@@ -553,7 +549,7 @@
 			<argument index="1" name="input_idx" type="int">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the input at [code]input_idx[/code] on transition node with name [code]id[/code] is set to automatically advance to the next input upon completion.
+				Returns [code]true[/code] if the input at [code]input_idx[/code] on the transition node with name [code]id[/code] is set to automatically advance to the next input upon completion.
 			</description>
 		</method>
 		<method name="transition_node_set_current">
@@ -609,11 +605,11 @@
 		</member>
 		<member name="base_path" type="NodePath" setter="set_base_path" getter="get_base_path" default="NodePath(&quot;..&quot;)">
 			The node from which to relatively access other nodes.
-			It accesses the Bones, so it should point to the same Node the AnimationPlayer would point its Root Node at.
+			It accesses the bones, so it should point to the same node the [AnimationPlayer] would point its Root Node at.
 		</member>
 		<member name="master_player" type="NodePath" setter="set_master_player" getter="get_master_player" default="NodePath(&quot;&quot;)">
 			The path to the [AnimationPlayer] from which this [AnimationTreePlayer] binds animations to animation nodes.
-			Once set, Animation nodes can be added to the AnimationTreePlayer.
+			Once set, [Animation] nodes can be added to the [AnimationTreePlayer].
 		</member>
 		<member name="playback_process_mode" type="int" setter="set_animation_process_mode" getter="get_animation_process_mode" enum="AnimationTreePlayer.AnimationProcessMode" default="1">
 			The thread in which to update animations.

--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -4,7 +4,8 @@
 		[Mesh] type that provides utility for constructing a surface from arrays.
 	</brief_description>
 	<description>
-		The [ArrayMesh] is used to construct a [Mesh] by specifying the attributes as arrays. The most basic example is the creation of a single triangle
+		The [ArrayMesh] is used to construct a [Mesh] by specifying the attributes as arrays.
+		The most basic example is the creation of a single triangle:
 		[codeblock]
 		var vertices = PoolVector3Array()
 		vertices.push_back(Vector3(0, 1, 0))
@@ -20,7 +21,7 @@
 		var m = MeshInstance.new()
 		m.mesh = arr_mesh
 		[/codeblock]
-		The [code]MeshInstance[/code] is ready to be added to the SceneTree to be shown.
+		The [MeshInstance] is ready to be added to the [SceneTree] to be shown.
 	</description>
 	<tutorials>
 		<link>http://docs.godotengine.org/en/latest/tutorials/content/procedural_geometry/arraymesh.html</link>
@@ -234,10 +235,10 @@
 			Array format will include vertices (mandatory).
 		</constant>
 		<constant name="ARRAY_FORMAT_NORMAL" value="2" enum="ArrayFormat">
-			Array format will include normals
+			Array format will include normals.
 		</constant>
 		<constant name="ARRAY_FORMAT_TANGENT" value="4" enum="ArrayFormat">
-			Array format will include tangents
+			Array format will include tangents.
 		</constant>
 		<constant name="ARRAY_FORMAT_COLOR" value="8" enum="ArrayFormat">
 			Array format will include a color array.

--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -4,7 +4,7 @@
 		Server interface for low-level audio access.
 	</brief_description>
 	<description>
-		AudioServer is a low-level server interface for audio access. It is in charge of creating sample data (playable audio) as well as its playback via a voice interface.
+		[AudioServer] is a low-level server interface for audio access. It is in charge of creating sample data (playable audio) as well as its playback via a voice interface.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/audio/audio_buses.html</link>
@@ -52,6 +52,7 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
+				Sets which audio input device is used for audio capture.
 			</description>
 		</method>
 		<method name="generate_bus_layout" qualifiers="const">
@@ -100,6 +101,7 @@
 			<argument index="2" name="channel" type="int" default="0">
 			</argument>
 			<description>
+				Returns the [AudioEffectInstance] assigned to the given bus and effect indices (and optionally channel).
 			</description>
 		</method>
 		<method name="get_bus_index" qualifiers="const">
@@ -192,12 +194,14 @@
 			<return type="float">
 			</return>
 			<description>
+				Returns the relative time since the last mix occurred.
 			</description>
 		</method>
 		<method name="get_time_to_next_mix" qualifiers="const">
 			<return type="float">
 			</return>
 			<description>
+				Returns the relative time until the next mix occurs.
 			</description>
 		</method>
 		<method name="is_bus_bypassing_effects" qualifiers="const">
@@ -242,7 +246,8 @@
 			<return type="void">
 			</return>
 			<description>
-				Locks the audio driver's main loop. Remember to unlock it afterwards.
+				Locks the audio driver's main loop.
+				[b]Note:[/b] Remember to unlock it afterwards.
 			</description>
 		</method>
 		<method name="move_bus">
@@ -411,10 +416,10 @@
 			A 3.1 channel surround setup was detected.
 		</constant>
 		<constant name="SPEAKER_SURROUND_51" value="2" enum="SpeakerMode">
-			A 5.1 channel surround setup was  detected.
+			A 5.1 channel surround setup was detected.
 		</constant>
 		<constant name="SPEAKER_SURROUND_71" value="3" enum="SpeakerMode">
-			A 7.1 channel surround setup was  detected.
+			A 7.1 channel surround setup was detected.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/BitmapFont.xml
+++ b/doc/classes/BitmapFont.xml
@@ -2,7 +2,7 @@
 <class name="BitmapFont" inherits="Font" category="Core" version="3.2">
 	<brief_description>
 		Renders text using fonts under the [url=https://www.angelcode.com/products/bmfont/]BMFont[/url] format.
-		Handles files with the [code].fnt[/code] extension
+		Handles files with the [code].fnt[/code] extension.
 	</brief_description>
 	<description>
 		Renders text using [code]*.fnt[/code] fonts containing texture atlases. Supports distance fields. For using vector font files like TTF directly, see [DynamicFont].

--- a/doc/classes/CPUParticles.xml
+++ b/doc/classes/CPUParticles.xml
@@ -25,6 +25,7 @@
 			<argument index="0" name="param" type="int" enum="CPUParticles.Parameter">
 			</argument>
 			<description>
+				Returns the base value of the parameter specified by [enum Parameter].
 			</description>
 		</method>
 		<method name="get_param_curve" qualifiers="const">
@@ -33,6 +34,7 @@
 			<argument index="0" name="param" type="int" enum="CPUParticles.Parameter">
 			</argument>
 			<description>
+				Returns the [Curve] of the parameter specified by [enum Parameter].
 			</description>
 		</method>
 		<method name="get_param_randomness" qualifiers="const">
@@ -41,6 +43,7 @@
 			<argument index="0" name="param" type="int" enum="CPUParticles.Parameter">
 			</argument>
 			<description>
+				Returns the randomness factor of the parameter specified by [enum Parameter].
 			</description>
 		</method>
 		<method name="get_particle_flag" qualifiers="const">
@@ -49,6 +52,7 @@
 			<argument index="0" name="flag" type="int" enum="CPUParticles.Flags">
 			</argument>
 			<description>
+				Returns the enabled state of the given flag (see [enum Flags] for options).
 			</description>
 		</method>
 		<method name="restart">
@@ -66,6 +70,7 @@
 			<argument index="1" name="value" type="float">
 			</argument>
 			<description>
+				Sets the base value of the parameter specified by [enum Parameter].
 			</description>
 		</method>
 		<method name="set_param_curve">
@@ -76,6 +81,7 @@
 			<argument index="1" name="curve" type="Curve">
 			</argument>
 			<description>
+				Sets the [Curve] of the parameter specified by [enum Parameter].
 			</description>
 		</method>
 		<method name="set_param_randomness">
@@ -86,6 +92,7 @@
 			<argument index="1" name="randomness" type="float">
 			</argument>
 			<description>
+				Sets the randomness factor of the parameter specified by [enum Parameter].
 			</description>
 		</method>
 		<method name="set_particle_flag">
@@ -96,6 +103,7 @@
 			<argument index="1" name="enable" type="bool">
 			</argument>
 			<description>
+				Enables or disables the given flag (see [enum Flags] for options).
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -26,6 +26,7 @@
 			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter">
 			</argument>
 			<description>
+				Returns the base value of the parameter specified by [enum Parameter].
 			</description>
 		</method>
 		<method name="get_param_curve" qualifiers="const">
@@ -34,6 +35,7 @@
 			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter">
 			</argument>
 			<description>
+				Returns the [Curve] of the parameter specified by [enum Parameter].
 			</description>
 		</method>
 		<method name="get_param_randomness" qualifiers="const">
@@ -42,6 +44,7 @@
 			<argument index="0" name="param" type="int" enum="CPUParticles2D.Parameter">
 			</argument>
 			<description>
+				Returns the randomness factor of the parameter specified by [enum Parameter].
 			</description>
 		</method>
 		<method name="get_particle_flag" qualifiers="const">
@@ -50,6 +53,7 @@
 			<argument index="0" name="flag" type="int" enum="CPUParticles2D.Flags">
 			</argument>
 			<description>
+				Returns the enabled state of the given flag (see [enum Flags] for options).
 			</description>
 		</method>
 		<method name="restart">
@@ -67,6 +71,7 @@
 			<argument index="1" name="value" type="float">
 			</argument>
 			<description>
+				Sets the base value of the parameter specified by [enum Parameter].
 			</description>
 		</method>
 		<method name="set_param_curve">
@@ -77,6 +82,7 @@
 			<argument index="1" name="curve" type="Curve">
 			</argument>
 			<description>
+				Sets the [Curve] of the parameter specified by [enum Parameter].
 			</description>
 		</method>
 		<method name="set_param_randomness">
@@ -87,6 +93,7 @@
 			<argument index="1" name="randomness" type="float">
 			</argument>
 			<description>
+				Sets the randomness factor of the parameter specified by [enum Parameter].
 			</description>
 		</method>
 		<method name="set_particle_flag">
@@ -97,6 +104,7 @@
 			<argument index="1" name="enable" type="bool">
 			</argument>
 			<description>
+				Enables or disables the given flag (see [enum Flags] for options).
 			</description>
 		</method>
 	</methods>
@@ -187,8 +195,6 @@
 		</member>
 		<member name="flag_align_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
 			Align Y axis of particle with the direction of its velocity.
-		</member>
-		<member name="flatness" type="float" setter="set_flatness" getter="get_flatness" default="0.0">
 		</member>
 		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true">
 			If [code]true[/code], results in fractional delta calculation which has a smoother particles display effect.

--- a/doc/classes/CameraServer.xml
+++ b/doc/classes/CameraServer.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="CameraServer" inherits="Object" category="Core" version="3.2">
 	<brief_description>
-		The CameraServer keeps track of different cameras accessible in Godot. These are external cameras such as webcams or the cameras on your phone.
+		Server keeping track of different cameras accessible in Godot.
 	</brief_description>
 	<description>
+		The [CameraServer] keeps track of different cameras accessible in Godot. These are external cameras such as webcams or the cameras on your phone.
+		It is notably used to provide AR modules with a video feed from the camera.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -55,14 +57,14 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Emitted when a [CameraFeed] is added (webcam is plugged in).
+				Emitted when a [CameraFeed] is added (e.g. webcam is plugged in).
 			</description>
 		</signal>
 		<signal name="camera_feed_removed">
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Emitted when a [CameraFeed] is removed (webcam is removed).
+				Emitted when a [CameraFeed] is removed (e.g. webcam is unplugged).
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/CameraTexture.xml
+++ b/doc/classes/CameraTexture.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="CameraTexture" inherits="Texture" category="Core" version="3.2">
 	<brief_description>
-		This texture gives access to the camera texture provided by a [CameraFeed].
-		[b]Note:[/b] Many cameras supply YCbCr images which need to be converted in a shader.
+		Texture provided by a [CameraFeed].
 	</brief_description>
 	<description>
+		This texture gives access to the camera texture provided by a [CameraFeed].
+		[b]Note:[/b] Many cameras supply YCbCr images which need to be converted in a shader.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -4,10 +4,10 @@
 		Base class of anything 2D.
 	</brief_description>
 	<description>
-		Base class of anything 2D. Canvas items are laid out in a tree; children inherit and extend their parent's transform. CanvasItem is extended by [Control] for anything GUI-related, and by [Node2D] for anything related to the 2D engine.
-		Any CanvasItem can draw. For this, [method update] must be called, then [constant NOTIFICATION_DRAW] will be received on idle time to request redraw. Because of this, canvas items don't need to be redrawn on every frame, improving the performance significantly. Several functions for drawing on the CanvasItem are provided (see [code]draw_*[/code] functions). However, they can only be used inside the [method Object._notification], signal or [method _draw] virtual functions.
-		Canvas items are drawn in tree order. By default, children are on top of their parents so a root CanvasItem will be drawn behind everything. This behavior can be changed on a per-item basis.
-		A CanvasItem can also be hidden, which will also hide its children. It provides many ways to change parameters such as modulation (for itself and its children) and self modulation (only for itself), as well as its blend mode.
+		Base class of anything 2D. Canvas items are laid out in a tree; children inherit and extend their parent's transform. [CanvasItem] is extended by [Control] for anything GUI-related, and by [Node2D] for anything related to the 2D engine.
+		Any [CanvasItem] can draw. For this, [method update] must be called, then [constant NOTIFICATION_DRAW] will be received on idle time to request redraw. Because of this, canvas items don't need to be redrawn on every frame, improving the performance significantly. Several functions for drawing on the [CanvasItem] are provided (see [code]draw_*[/code] functions). However, they can only be used inside the [method Object._notification], signal or [method _draw] virtual functions.
+		Canvas items are drawn in tree order. By default, children are on top of their parents so a root [CanvasItem] will be drawn behind everything. This behavior can be changed on a per-item basis.
+		A [CanvasItem] can also be hidden, which will also hide its children. It provides many ways to change parameters such as modulation (for itself and its children) and self modulation (only for itself), as well as its blend mode.
 		Ultimately, a transform notification can be requested, which will notify the node that its global position changed in case the parent tree changed.
 	</description>
 	<tutorials>
@@ -19,7 +19,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Called (if exists) to draw the canvas item.
+				Overridable function called by the engine (if defined) to draw the canvas item.
 			</description>
 		</method>
 		<method name="draw_arc">
@@ -125,6 +125,7 @@
 			<argument index="4" name="modulate" type="Color" default="Color( 1, 1, 1, 1 )">
 			</argument>
 			<description>
+				Draws a [Mesh] in 2D, using the provided texture. See [MeshInstance2D] for related documentation.
 			</description>
 		</method>
 		<method name="draw_multiline">
@@ -167,6 +168,7 @@
 			<argument index="2" name="normal_map" type="Texture" default="null">
 			</argument>
 			<description>
+				Draws a [MultiMesh] in 2D with the provided texture. See [MultiMeshInstance2D] for related documentation.
 			</description>
 		</method>
 		<method name="draw_polygon">
@@ -385,70 +387,70 @@
 			<return type="Transform2D">
 			</return>
 			<description>
-				Gets the transform matrix of this item's canvas.
+				Returns the transform matrix of this item's canvas.
 			</description>
 		</method>
 		<method name="get_global_mouse_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<description>
-				Gets the global position of the mouse.
+				Returns the global position of the mouse.
 			</description>
 		</method>
 		<method name="get_global_transform" qualifiers="const">
 			<return type="Transform2D">
 			</return>
 			<description>
-				Gets the global transform matrix of this item.
+				Returns the global transform matrix of this item.
 			</description>
 		</method>
 		<method name="get_global_transform_with_canvas" qualifiers="const">
 			<return type="Transform2D">
 			</return>
 			<description>
-				Gets the global transform matrix of this item in relation to the canvas.
+				Returns the global transform matrix of this item in relation to the canvas.
 			</description>
 		</method>
 		<method name="get_local_mouse_position" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<description>
-				Gets the mouse position relative to this item's position.
+				Returns the mouse position relative to this item's position.
 			</description>
 		</method>
 		<method name="get_transform" qualifiers="const">
 			<return type="Transform2D">
 			</return>
 			<description>
-				Gets the transform matrix of this item.
+				Returns the transform matrix of this item.
 			</description>
 		</method>
 		<method name="get_viewport_rect" qualifiers="const">
 			<return type="Rect2">
 			</return>
 			<description>
-				Gets the viewport's boundaries as a [Rect2].
+				Returns the viewport's boundaries as a [Rect2].
 			</description>
 		</method>
 		<method name="get_viewport_transform" qualifiers="const">
 			<return type="Transform2D">
 			</return>
 			<description>
-				Gets this item's transform in relation to the viewport.
+				Returns this item's transform in relation to the viewport.
 			</description>
 		</method>
 		<method name="get_world_2d" qualifiers="const">
 			<return type="World2D">
 			</return>
 			<description>
-				Gets the [World2D] where this item is in.
+				Returns the [World2D] where this item is in.
 			</description>
 		</method>
 		<method name="hide">
 			<return type="void">
 			</return>
 			<description>
-				Hide the CanvasItem if it's currently visible.
+				Hide the [CanvasItem] if it's currently visible.
 			</description>
 		</method>
 		<method name="is_local_transform_notification_enabled" qualifiers="const">
@@ -528,14 +530,14 @@
 			<return type="void">
 			</return>
 			<description>
-				Show the CanvasItem if it's currently hidden. For controls that inherit [Popup], the correct way to make them visible is to call one of the multiple [code]popup*()[/code] functions instead.
+				Show the [CanvasItem] if it's currently hidden. For controls that inherit [Popup], the correct way to make them visible is to call one of the multiple [code]popup*()[/code] functions instead.
 			</description>
 		</method>
 		<method name="update">
 			<return type="void">
 			</return>
 			<description>
-				Queue the CanvasItem for update. [constant NOTIFICATION_DRAW] will be called on idle time to request redraw.
+				Queue the [CanvasItem] for update. [constant NOTIFICATION_DRAW] will be called on idle time to request redraw.
 			</description>
 		</method>
 	</methods>
@@ -568,7 +570,7 @@
 	<signals>
 		<signal name="draw">
 			<description>
-				Emitted when the CanvasItem must redraw. This can only be connected realtime, as deferred will not allow drawing.
+				Emitted when the [CanvasItem] must redraw. This can only be connected realtime, as deferred will not allow drawing.
 			</description>
 		</signal>
 		<signal name="hide">
@@ -607,19 +609,19 @@
 			Disables blending mode. Colors including alpha are written as-is. Only applicable for render targets with a transparent background. No lighting will be applied.
 		</constant>
 		<constant name="NOTIFICATION_TRANSFORM_CHANGED" value="2000">
-			The CanvasItem's transform has changed. This notification is only received if enabled by [method set_notify_transform] or [method set_notify_local_transform].
+			The [CanvasItem]'s transform has changed. This notification is only received if enabled by [method set_notify_transform] or [method set_notify_local_transform].
 		</constant>
 		<constant name="NOTIFICATION_DRAW" value="30">
-			The CanvasItem is requested to draw.
+			The [CanvasItem] is requested to draw.
 		</constant>
 		<constant name="NOTIFICATION_VISIBILITY_CHANGED" value="31">
-			The CanvasItem's visibility has changed.
+			The [CanvasItem]'s visibility has changed.
 		</constant>
 		<constant name="NOTIFICATION_ENTER_CANVAS" value="32">
-			The CanvasItem has entered the canvas.
+			The [CanvasItem] has entered the canvas.
 		</constant>
 		<constant name="NOTIFICATION_EXIT_CANVAS" value="33">
-			The CanvasItem has exited the canvas.
+			The [CanvasItem] has exited the canvas.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/CanvasItemMaterial.xml
+++ b/doc/classes/CanvasItemMaterial.xml
@@ -18,12 +18,20 @@
 			The manner in which material reacts to lighting.
 		</member>
 		<member name="particles_anim_h_frames" type="int" setter="set_particles_anim_h_frames" getter="get_particles_anim_h_frames">
+			The number of columns in the spritesheet assigned as [Texture] for a [Particles2D] or [CPUParticles2D].
+			[b]Note:[/b] This property is only used and visible in the editor if [member particles_animation] is [code]true[/code].
 		</member>
 		<member name="particles_anim_loop" type="bool" setter="set_particles_anim_loop" getter="get_particles_anim_loop">
+			If [code]true[/code], the particles animation will loop.
+			[b]Note:[/b] This property is only used and visible in the editor if [member particles_animation] is [code]true[/code].
 		</member>
 		<member name="particles_anim_v_frames" type="int" setter="set_particles_anim_v_frames" getter="get_particles_anim_v_frames">
+			The number of rows in the spritesheet assigned as [Texture] for a [Particles2D] or [CPUParticles2D].
+			[b]Note:[/b] This property is only used and visible in the editor if [member particles_animation] is [code]true[/code].
 		</member>
 		<member name="particles_animation" type="bool" setter="set_particles_animation" getter="get_particles_animation" default="false">
+			If [code]true[/code], enable spritesheet-based animation features when assigned to [Particles2D] and [CPUParticles2D] nodes. The [member ParticlesMaterial.anim_speed] or [member CPUParticles2D.anim_speed] should also be set to a positive value for the animation to play.
+			This property (and other [code]particles_anim_*[/code] properties that depend on it) has no effect on other types of nodes.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -20,7 +20,7 @@
 		[codeblock]
 		export(String, "White", "Yellow", "Orange") var my_color
 		var points_dir = {"White": 50, "Yellow": 75, "Orange": 100}
-		
+
 		func _ready():
 		    var points = points_dir[my_color]
 		[/codeblock]
@@ -42,13 +42,13 @@
 		[codeblock]
 		array1 = [1, 2, 3]
 		array2 = [1, 2, 3]
-		
+
 		func compare_arrays():
-		    print(array1 == array2) # Will print true. 
-		
+		    print(array1 == array2) # Will print true.
+
 		dir1 = {"a": 1, "b": 2, "c": 3}
 		dir2 = {"a": 1, "b": 2, "c": 3}
-		
+
 		func compare_dictionaries():
 		    print(dir1 == dir2) # Will NOT print true.
 		[/codeblock]
@@ -56,7 +56,7 @@
 		[codeblock]
 		dir1 = {"a": 1, "b": 2, "c": 3}
 		dir2 = {"a": 1, "b": 2, "c": 3}
-		
+
 		func compare_dictionaries():
 		    print(dir1.hash() == dir2.hash()) # Will print true.
 		[/codeblock]

--- a/doc/classes/EditorInspectorPlugin.xml
+++ b/doc/classes/EditorInspectorPlugin.xml
@@ -100,7 +100,7 @@
 			<argument index="5" name="usage" type="int">
 			</argument>
 			<description>
-				Called to allow adding property specific editors to the inspector. Usually these inherit [EditorProperty]
+				Called to allow adding property specific editors to the inspector. Usually these inherit [EditorProperty].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorSpatialGizmoPlugin.xml
+++ b/doc/classes/EditorSpatialGizmoPlugin.xml
@@ -49,7 +49,7 @@
 			<argument index="0" name="spatial" type="Spatial">
 			</argument>
 			<description>
-				Override this method to return a custom [EditorSpatialGizmo] for the spatial nodes of your choice, return [code]null[/code] for the rest of nodes. (See also [method has_gizmo])
+				Override this method to return a custom [EditorSpatialGizmo] for the spatial nodes of your choice, return [code]null[/code] for the rest of nodes. See also [method has_gizmo].
 			</description>
 		</method>
 		<method name="create_handle_material">

--- a/doc/classes/EditorVCSInterface.xml
+++ b/doc/classes/EditorVCSInterface.xml
@@ -51,14 +51,14 @@
 			<return type="String">
 			</return>
 			<description>
-				Return the project name of the VCS working directory
+				Returns the project name of the VCS working directory.
 			</description>
 		</method>
 		<method name="get_vcs_name">
 			<return type="String">
 			</return>
 			<description>
-				Return the name of the VCS if the VCS has been initialized, else return an empty string.
+				Returns the name of the VCS if the VCS has been initialized, else return an empty string.
 			</description>
 		</method>
 		<method name="initialize">
@@ -67,7 +67,7 @@
 			<argument index="0" name="project_root_path" type="String">
 			</argument>
 			<description>
-				Initialize the VCS addon if not already. Uses the argument value as the path to the working directory of the project. Creates the initial commit if required. Returns [code]true[/code] if no failure occurs, else returns [code]false[/code].
+				Initializes the VCS addon if not already. Uses the argument value as the path to the working directory of the project. Creates the initial commit if required. Returns [code]true[/code] if no failure occurs, else returns [code]false[/code].
 			</description>
 		</method>
 		<method name="is_addon_ready">
@@ -97,7 +97,7 @@
 			<argument index="0" name="file_path" type="String">
 			</argument>
 			<description>
-				Stage the file which should be committed when [method EditorVCSInterface.commit] is called. Argument should contain the absolute path.
+				Stages the file which should be committed when [method EditorVCSInterface.commit] is called. Argument should contain the absolute path.
 			</description>
 		</method>
 		<method name="unstage_file">
@@ -106,7 +106,7 @@
 			<argument index="0" name="file_path" type="String">
 			</argument>
 			<description>
-				Unstage the file which was staged previously to be committed, so that it is no longer committed when [method EditorVCSInterface.commit] is called. Argument should contain the absolute path.
+				Unstages the file which was staged previously to be committed, so that it is no longer committed when [method EditorVCSInterface.commit] is called. Argument should contain the absolute path.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Geometry.xml
+++ b/doc/classes/Geometry.xml
@@ -115,7 +115,7 @@
 			<argument index="2" name="s2" type="Vector3">
 			</argument>
 			<description>
-				Returns the 3d point on the 3d segment ([code]s1[/code], [code]s2[/code]) that is closest to [code]point[/code]. The returned point will always be inside the specified segment.
+				Returns the 3D point on the 3D segment ([code]s1[/code], [code]s2[/code]) that is closest to [code]point[/code]. The returned point will always be inside the specified segment.
 			</description>
 		</method>
 		<method name="get_closest_point_to_segment_2d">
@@ -128,7 +128,7 @@
 			<argument index="2" name="s2" type="Vector2">
 			</argument>
 			<description>
-				Returns the 2d point on the 2d segment ([code]s1[/code], [code]s2[/code]) that is closest to [code]point[/code]. The returned point will always be inside the specified segment.
+				Returns the 2D point on the 2D segment ([code]s1[/code], [code]s2[/code]) that is closest to [code]point[/code]. The returned point will always be inside the specified segment.
 			</description>
 		</method>
 		<method name="get_closest_point_to_segment_uncapped">
@@ -141,7 +141,7 @@
 			<argument index="2" name="s2" type="Vector3">
 			</argument>
 			<description>
-				Returns the 3d point on the 3d line defined by ([code]s1[/code], [code]s2[/code]) that is closest to [code]point[/code]. The returned point can be inside the segment ([code]s1[/code], [code]s2[/code]) or outside of it, i.e. somewhere on the line extending from the segment.
+				Returns the 3D point on the 3D line defined by ([code]s1[/code], [code]s2[/code]) that is closest to [code]point[/code]. The returned point can be inside the segment ([code]s1[/code], [code]s2[/code]) or outside of it, i.e. somewhere on the line extending from the segment.
 			</description>
 		</method>
 		<method name="get_closest_point_to_segment_uncapped_2d">
@@ -154,7 +154,7 @@
 			<argument index="2" name="s2" type="Vector2">
 			</argument>
 			<description>
-				Returns the 2d point on the 2d line defined by ([code]s1[/code], [code]s2[/code]) that is closest to [code]point[/code]. The returned point can be inside the segment ([code]s1[/code], [code]s2[/code]) or outside of it, i.e. somewhere on the line extending from the segment.
+				Returns the 2D point on the 2D line defined by ([code]s1[/code], [code]s2[/code]) that is closest to [code]point[/code]. The returned point can be inside the segment ([code]s1[/code], [code]s2[/code]) or outside of it, i.e. somewhere on the line extending from the segment.
 			</description>
 		</method>
 		<method name="get_closest_points_between_segments">
@@ -169,7 +169,7 @@
 			<argument index="3" name="q2" type="Vector3">
 			</argument>
 			<description>
-				Given the two 3d segments ([code]p1[/code], [code]p2[/code]) and ([code]q1[/code], [code]q2[/code]), finds those two points on the two segments that are closest to each other. Returns a [PoolVector3Array] that contains this point on ([code]p1[/code], [code]p2[/code]) as well the accompanying point on ([code]q1[/code], [code]q2[/code]).
+				Given the two 3D segments ([code]p1[/code], [code]p2[/code]) and ([code]q1[/code], [code]q2[/code]), finds those two points on the two segments that are closest to each other. Returns a [PoolVector3Array] that contains this point on ([code]p1[/code], [code]p2[/code]) as well the accompanying point on ([code]q1[/code], [code]q2[/code]).
 			</description>
 		</method>
 		<method name="get_closest_points_between_segments_2d">
@@ -184,7 +184,7 @@
 			<argument index="3" name="q2" type="Vector2">
 			</argument>
 			<description>
-				Given the two 2d segments ([code]p1[/code], [code]p2[/code]) and ([code]q1[/code], [code]q2[/code]), finds those two points on the two segments that are closest to each other. Returns a [PoolVector2Array] that contains this point on ([code]p1[/code], [code]p2[/code]) as well the accompanying point on ([code]q1[/code], [code]q2[/code]).
+				Given the two 2D segments ([code]p1[/code], [code]p2[/code]) and ([code]q1[/code], [code]q2[/code]), finds those two points on the two segments that are closest to each other. Returns a [PoolVector2Array] that contains this point on ([code]p1[/code], [code]p2[/code]) as well the accompanying point on ([code]q1[/code], [code]q2[/code]).
 			</description>
 		</method>
 		<method name="get_uv84_normal_bit">
@@ -350,7 +350,7 @@
 			<argument index="4" name="c" type="Vector3">
 			</argument>
 			<description>
-				Tests if the 3d ray starting at [code]from[/code] with the direction of [code]dir[/code] intersects the triangle specified by [code]a[/code], [code]b[/code] and [code]c[/code]. If yes, returns the point of intersection as [Vector3]. If no intersection takes place, an empty [Variant] is returned.
+				Tests if the 3D ray starting at [code]from[/code] with the direction of [code]dir[/code] intersects the triangle specified by [code]a[/code], [code]b[/code] and [code]c[/code]. If yes, returns the point of intersection as [Vector3]. If no intersection takes place, an empty [Variant] is returned.
 			</description>
 		</method>
 		<method name="segment_intersects_circle">
@@ -365,7 +365,7 @@
 			<argument index="3" name="circle_radius" type="float">
 			</argument>
 			<description>
-				Given the 2d segment ([code]segment_from[/code], [code]segment_to[/code]), returns the position on the segment (as a number between 0 and 1) at which the segment hits the circle that is located at position [code]circle_position[/code] and has radius [code]circle_radius[/code]. If the segment does not intersect the circle, -1 is returned (this is also the case if the line extending the segment would intersect the circle, but the segment does not).
+				Given the 2D segment ([code]segment_from[/code], [code]segment_to[/code]), returns the position on the segment (as a number between 0 and 1) at which the segment hits the circle that is located at position [code]circle_position[/code] and has radius [code]circle_radius[/code]. If the segment does not intersect the circle, -1 is returned (this is also the case if the line extending the segment would intersect the circle, but the segment does not).
 			</description>
 		</method>
 		<method name="segment_intersects_convex">

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -4,8 +4,8 @@
 		A GraphNode is a container with potentially several input and output slots allowing connections between GraphNodes. Slots can have different, incompatible types.
 	</brief_description>
 	<description>
-		A GraphNode is a container. Each GraphNode can have several input and output slots, sometimes refered to as ports, allowing connections between GraphNodes. To add a slot to GraphNode, add any [Control]-derived child node to it. 
-		After adding at least one child to GraphNode new sections will be automatically created in the Inspector called 'Slot'. When 'Slot' is expanded you will see list with index number for each slot. You can click on each of them to expand further.  
+		A GraphNode is a container. Each GraphNode can have several input and output slots, sometimes refered to as ports, allowing connections between GraphNodes. To add a slot to GraphNode, add any [Control]-derived child node to it.
+		After adding at least one child to GraphNode new sections will be automatically created in the Inspector called 'Slot'. When 'Slot' is expanded you will see list with index number for each slot. You can click on each of them to expand further.
 		In the Inspector you can enable (show) or disable (hide) slots. By default all slots are disabled so you may not see any slots on your GraphNode initially. You can assign a type to each slot. Only slots of the same type will be able to connect to each other. You can also assign colors to slots. A tuple of input and output slots is defined for each GUI element included in the GraphNode. Input connections are on the left and output connections are on the right side of GraphNode. Only enabled slots are counted as connections.
 	</description>
 	<tutorials>

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -100,7 +100,7 @@
 			<return type="int" enum="Error">
 			</return>
 			<description>
-				This needs to be called in order to have any request processed. Check results with [method get_status]
+				This needs to be called in order to have any request processed. Check results with [method get_status].
 			</description>
 		</method>
 		<method name="query_string_from_dict">

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -170,7 +170,7 @@
 			Request exceeded its maximum size limit, see [member body_size_limit].
 		</constant>
 		<constant name="RESULT_REQUEST_FAILED" value="8" enum="Result">
-			Request failed. (Unused)
+			Request failed (currently unused).
 		</constant>
 		<constant name="RESULT_DOWNLOAD_FILE_CANT_OPEN" value="9" enum="Result">
 			HTTPRequest couldn't open the download file.

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Input" inherits="Object" category="Core" version="3.2">
 	<brief_description>
-		A Singleton that deals with inputs.
+		A singleton that deals with inputs.
 	</brief_description>
 	<description>
-		A Singleton that deals with inputs. This includes key presses, mouse buttons and movement, joypads, and input actions. Actions and their events can be set in the [b]Input Map[/b] tab in the [b]Project &gt; Project Settings[/b], or with the [InputMap] class.
+		A singleton that deals with inputs. This includes key presses, mouse buttons and movement, joypads, and input actions. Actions and their events can be set in the [b]Input Map[/b] tab in the [b]Project &gt; Project Settings[/b], or with the [InputMap] class.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/index.html</link>

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEvent" inherits="Resource" category="Core" version="3.2">
 	<brief_description>
-		Generic input event
+		Generic input event.
 	</brief_description>
 	<description>
 		Base class of all sort of input event. See [method Node._input].

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -4,7 +4,8 @@
 		Control that provides single-line string editing.
 	</brief_description>
 	<description>
-		LineEdit provides a single-line string editor, used for text fields. It features many built-in shortcuts which will always be available: (the Ctrl here maps to Command on macOS)
+		LineEdit provides a single-line string editor, used for text fields.
+		It features many built-in shortcuts which will always be available ([code]Ctrl[/code] here maps to [code]Command[/code] on macOS):
 		- Ctrl + C: Copy
 		- Ctrl + X: Cut
 		- Ctrl + V or Ctrl + Y: Paste/"yank"

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -4,8 +4,8 @@
 		Special button that brings up a [PopupMenu] when clicked.
 	</brief_description>
 	<description>
-		Special button that brings up a [PopupMenu] when clicked. 
-		New items can be created inside this [PopupMenu] using [code]get_popup().add_item("My Item Name")[/code]. You can also create them directly from the editor. To do so, select the MenuButton node, then in the toolbar at the top of the 2D editor, click [b]Items[/b] then click [b]Add[/b] in the popup. You will be able to give each items new properties.
+		Special button that brings up a [PopupMenu] when clicked.
+		New items can be created inside this [PopupMenu] using [code]get_popup().add_item("My Item Name")[/code]. You can also create them directly from the editor. To do so, select the [MenuButton] node, then in the toolbar at the top of the 2D editor, click [b]Items[/b] then click [b]Add[/b] in the popup. You will be able to give each items new properties.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -23,6 +23,7 @@
 			<argument index="0" name="disabled" type="bool">
 			</argument>
 			<description>
+				If [code]true[/code], shortcuts are disabled and cannot be used to trigger the button.
 			</description>
 		</method>
 	</methods>
@@ -32,7 +33,7 @@
 		<member name="flat" type="bool" setter="set_flat" getter="is_flat" override="true" default="true" />
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="0" />
 		<member name="switch_on_hover" type="bool" setter="set_switch_on_hover" getter="is_switch_on_hover" default="false">
-			If [code]true[/code], when the cursor hovers above another MenuButton within the same parent which also has [code]switch_on_hover[/code] enabled, it will close the current MenuButton and open the other one.
+			If [code]true[/code], when the cursor hovers above another [MenuButton] within the same parent which also has [code]switch_on_hover[/code] enabled, it will close the current [MenuButton] and open the other one.
 		</member>
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true" />
 	</members>

--- a/doc/classes/MeshInstance2D.xml
+++ b/doc/classes/MeshInstance2D.xml
@@ -4,7 +4,7 @@
 		Node used for displaying a [Mesh] in 2D.
 	</brief_description>
 	<description>
-		Node used for displaying a [Mesh] in 2D. Can be constructed from an existing [Sprite] use tool in Toolbar. Select "Sprite" then "Convert to Mesh2D", select settings in popup and press "Create Mesh2D".
+		Node used for displaying a [Mesh] in 2D. Can be constructed from an existing [Sprite] via a tool in the editor toolbar. Select "Sprite" then "Convert to Mesh2D", select settings in popup and press "Create Mesh2D".
 	</description>
 	<tutorials>
 		<link>http://docs.godotengine.org/en/latest/tutorials/2d/2d_meshes.html</link>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -33,7 +33,7 @@
 			</return>
 			<description>
 				Called when the node is about to leave the [SceneTree] (e.g. upon freeing, scene changing, or after calling [method remove_child] in a script). If the node has children, its [method _exit_tree] callback will be called last, after all its children have left the tree.
-				Corresponds to the [constant NOTIFICATION_EXIT_TREE] notification in [method Object._notification] and signal [signal tree_exiting]. To get notified when the node has already left the active tree, connect to the [signal tree_exited]
+				Corresponds to the [constant NOTIFICATION_EXIT_TREE] notification in [method Object._notification] and signal [signal tree_exiting]. To get notified when the node has already left the active tree, connect to the [signal tree_exited].
 			</description>
 		</method>
 		<method name="_get_configuration_warning" qualifiers="virtual">

--- a/doc/classes/PhysicsServer.xml
+++ b/doc/classes/PhysicsServer.xml
@@ -1315,7 +1315,7 @@
 			If [code]true[/code], the Hinge has a maximum and a minimum rotation.
 		</constant>
 		<constant name="HINGE_JOINT_FLAG_ENABLE_MOTOR" value="1" enum="HingeJointFlag">
-			If [code]true[/code], a motor turns the Hinge
+			If [code]true[/code], a motor turns the Hinge.
 		</constant>
 		<constant name="SLIDER_JOINT_LINEAR_LIMIT_UPPER" value="0" enum="SliderJointParam">
 			The maximum difference between the pivot points on their X axis before damping happens.

--- a/doc/classes/Shader.xml
+++ b/doc/classes/Shader.xml
@@ -25,7 +25,7 @@
 			<return type="int" enum="Shader.Mode">
 			</return>
 			<description>
-				Returns the shader mode for the shader, either [constant MODE_CANVAS_ITEM], [constant MODE_SPATIAL] or [constant MODE_PARTICLES]
+				Returns the shader mode for the shader, either [constant MODE_CANVAS_ITEM], [constant MODE_SPATIAL] or [constant MODE_PARTICLES].
 			</description>
 		</method>
 		<method name="has_param" qualifiers="const">

--- a/doc/classes/SpatialMaterial.xml
+++ b/doc/classes/SpatialMaterial.xml
@@ -609,7 +609,8 @@
 			The object's X axis will always face the camera.
 		</constant>
 		<constant name="BILLBOARD_PARTICLES" value="3" enum="BillboardMode">
-			Used for particle systems. Enables particle animation options.
+			Used for particle systems when assigned to [Particles] and [CPUParticles] nodes. Enables [code]particles_anim_*[/code] properties.
+			The [member ParticlesMaterial.anim_speed] or [member CPUParticles.anim_speed] should also be set to a positive value for the animation to play.
 		</constant>
 		<constant name="TEXTURE_CHANNEL_RED" value="0" enum="TextureChannel">
 			Used to read from the red channel of a texture.

--- a/doc/classes/VisualInstance.xml
+++ b/doc/classes/VisualInstance.xml
@@ -4,7 +4,7 @@
 		Parent of all visual 3D nodes.
 	</brief_description>
 	<description>
-		The VisualInstance is used to connect a resource to a visual representation. All visual 3D nodes inherit from the VisualInstance. In general, you should not access the VisualInstance properties directly as they are accessed and managed by the nodes that inherit from VisualInstance. VisualInstance is the node representation of the [VisualServer] instance.
+		The [VisualInstance] is used to connect a resource to a visual representation. All visual 3D nodes inherit from the [VisualInstance]. In general, you should not access the [VisualInstance] properties directly as they are accessed and managed by the nodes that inherit from [VisualInstance]. [VisualInstance] is the node representation of the [VisualServer] instance.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -13,21 +13,21 @@
 			<return type="AABB">
 			</return>
 			<description>
-				Returns the [AABB] (also known as the bounding box) for this VisualInstance.
+				Returns the [AABB] (also known as the bounding box) for this [VisualInstance].
 			</description>
 		</method>
 		<method name="get_base" qualifiers="const">
 			<return type="RID">
 			</return>
 			<description>
-				Returns the RID of the resource associated with this VisualInstance. For example, if the Node is a [MeshInstance], this will return the RID of the associated [Mesh].
+				Returns the RID of the resource associated with this [VisualInstance]. For example, if the Node is a [MeshInstance], this will return the RID of the associated [Mesh].
 			</description>
 		</method>
 		<method name="get_instance" qualifiers="const">
 			<return type="RID">
 			</return>
 			<description>
-				Returns the RID of this instance. This RID is the same as the RID returned by [method VisualServer.instance_create]. This RID is needed if you want to call [VisualServer] functions directly on this VisualInstance.
+				Returns the RID of this instance. This RID is the same as the RID returned by [method VisualServer.instance_create]. This RID is needed if you want to call [VisualServer] functions directly on this [VisualInstance].
 			</description>
 		</method>
 		<method name="get_layer_mask_bit" qualifiers="const">
@@ -43,8 +43,8 @@
 			<return type="AABB">
 			</return>
 			<description>
-				Returns the transformed [AABB] (also known as the bounding box) for this VisualInstance.
-				Transformed in this case means the [AABB] plus the position, rotation, and scale of the [Spatial]s [Transform]
+				Returns the transformed [AABB] (also known as the bounding box) for this [VisualInstance].
+				Transformed in this case means the [AABB] plus the position, rotation, and scale of the [Spatial]'s [Transform].
 			</description>
 		</method>
 		<method name="set_base">
@@ -53,7 +53,7 @@
 			<argument index="0" name="base" type="RID">
 			</argument>
 			<description>
-				Sets the resource that is instantiated by this VisualInstance, which changes how the engine handles the VisualInstance under the hood. Equivalent to [method VisualServer.instance_set_base].
+				Sets the resource that is instantiated by this [VisualInstance], which changes how the engine handles the [VisualInstance] under the hood. Equivalent to [method VisualServer.instance_set_base].
 			</description>
 		</method>
 		<method name="set_layer_mask_bit">
@@ -70,8 +70,8 @@
 	</methods>
 	<members>
 		<member name="layers" type="int" setter="set_layer_mask" getter="get_layer_mask" default="1">
-			The render layer(s) this VisualInstance is drawn on.
-			This object will only be visible for [Camera]s whose cull mask includes the render object this VisualInstance is set to.
+			The render layer(s) this [VisualInstance] is drawn on.
+			This object will only be visible for [Camera]s whose cull mask includes the render object this [VisualInstance] is set to.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -64,7 +64,7 @@
 			<argument index="1" name="layers" type="int">
 			</argument>
 			<description>
-				Sets the cull mask associated with this camera. The cull mask describes which 3d layers are rendered by this camera. Equivalent to [member Camera.cull_mask].
+				Sets the cull mask associated with this camera. The cull mask describes which 3D layers are rendered by this camera. Equivalent to [member Camera.cull_mask].
 			</description>
 		</method>
 		<method name="camera_set_environment">
@@ -1679,7 +1679,7 @@
 			<argument index="0" name="feature" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the OS supports a certain feature. Features might be s3tc, etc, etc2 and pvrtc,
+				Returns [code]true[/code] if the OS supports a certain feature. Features might be [code]s3tc[/code], [code]etc[/code], [code]etc2[/code] and [code]pvrtc[/code].
 			</description>
 		</method>
 		<method name="immediate_begin">
@@ -3018,7 +3018,7 @@
 			<argument index="0" name="particles" type="RID">
 			</argument>
 			<description>
-				Reset the particles on the next update. Equivalent to [method Particles.restart]
+				Reset the particles on the next update. Equivalent to [method Particles.restart].
 			</description>
 		</method>
 		<method name="particles_set_amount">

--- a/doc/classes/VisualShaderNode.xml
+++ b/doc/classes/VisualShaderNode.xml
@@ -7,10 +7,24 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_default_input_values" qualifiers="const">
+			<return type="Array">
+			</return>
+			<description>
+			</description>
+		</method>
 		<method name="get_input_port_default_value" qualifiers="const">
 			<return type="Variant">
 			</return>
 			<argument index="0" name="port" type="int">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="set_default_input_values">
+			<return type="void">
+			</return>
+			<argument index="0" name="values" type="Array">
 			</argument>
 			<description>
 			</description>
@@ -27,8 +41,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" default="[ 0, Vector3( 0, 0, 0 ) ]">
-		</member>
 		<member name="output_port_for_preview" type="int" setter="set_output_port_for_preview" getter="get_output_port_for_preview" default="-1">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeBooleanConstant.xml
+++ b/doc/classes/VisualShaderNodeBooleanConstant.xml
@@ -11,7 +11,6 @@
 	<members>
 		<member name="constant" type="bool" setter="set_constant" getter="get_constant" default="false">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeColorConstant.xml
+++ b/doc/classes/VisualShaderNodeColorConstant.xml
@@ -11,7 +11,6 @@
 	<members>
 		<member name="constant" type="Color" setter="set_constant" getter="get_constant" default="Color( 1, 1, 1, 1 )">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeColorOp.xml
+++ b/doc/classes/VisualShaderNodeColorOp.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]" />
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeColorOp.Operator" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeCompare.xml
+++ b/doc/classes/VisualShaderNodeCompare.xml
@@ -11,7 +11,6 @@
 	<members>
 		<member name="condition" type="int" setter="set_condition" getter="get_condition" enum="VisualShaderNodeCompare.Condition" default="0">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 1e-05 ]" />
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeCompare.Function" default="0">
 		</member>
 		<member name="type" type="int" setter="set_comparsion_type" getter="get_comparsion_type" enum="VisualShaderNodeCompare.ComparsionType" default="0">

--- a/doc/classes/VisualShaderNodeCubeMap.xml
+++ b/doc/classes/VisualShaderNodeCubeMap.xml
@@ -11,7 +11,6 @@
 	<members>
 		<member name="cube_map" type="CubeMap" setter="set_cube_map" getter="get_cube_map">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 		<member name="source" type="int" setter="set_source" getter="get_source" enum="VisualShaderNodeCubeMap.Source" default="0">
 		</member>
 		<member name="texture_type" type="int" setter="set_texture_type" getter="get_texture_type" enum="VisualShaderNodeCubeMap.TextureType" default="0">

--- a/doc/classes/VisualShaderNodeCustom.xml
+++ b/doc/classes/VisualShaderNodeCustom.xml
@@ -144,9 +144,6 @@
 			</description>
 		</method>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeDeterminant.xml
+++ b/doc/classes/VisualShaderNodeDeterminant.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeDotProduct.xml
+++ b/doc/classes/VisualShaderNodeDotProduct.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeFaceForward.xml
+++ b/doc/classes/VisualShaderNodeFaceForward.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, Vector3( 0, 0, 0 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeFresnel.xml
+++ b/doc/classes/VisualShaderNodeFresnel.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 2, false, 3, 1.0 ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeGroupBase.xml
+++ b/doc/classes/VisualShaderNodeGroupBase.xml
@@ -209,7 +209,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="false">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeIf.xml
+++ b/doc/classes/VisualShaderNodeIf.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 1e-05, 3, Vector3( 0, 0, 0 ), 4, Vector3( 0, 0, 0 ), 5, Vector3( 0, 0, 0 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeInput.xml
+++ b/doc/classes/VisualShaderNodeInput.xml
@@ -15,7 +15,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 		<member name="input_name" type="String" setter="set_input_name" getter="get_input_name" default="&quot;[None]&quot;">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeIs.xml
+++ b/doc/classes/VisualShaderNodeIs.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0 ]" />
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeIs.Function" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeOuterProduct.xml
+++ b/doc/classes/VisualShaderNodeOuterProduct.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeScalarClamp.xml
+++ b/doc/classes/VisualShaderNodeScalarClamp.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 1.0 ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeScalarConstant.xml
+++ b/doc/classes/VisualShaderNodeScalarConstant.xml
@@ -11,7 +11,6 @@
 	<members>
 		<member name="constant" type="float" setter="set_constant" getter="get_constant" default="0.0">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeScalarDerivativeFunc.xml
+++ b/doc/classes/VisualShaderNodeScalarDerivativeFunc.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0 ]" />
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeScalarDerivativeFunc.Function" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeScalarFunc.xml
+++ b/doc/classes/VisualShaderNodeScalarFunc.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0 ]" />
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeScalarFunc.Function" default="13">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeScalarInterp.xml
+++ b/doc/classes/VisualShaderNodeScalarInterp.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 1.0, 2, 0.5 ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeScalarOp.xml
+++ b/doc/classes/VisualShaderNodeScalarOp.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0 ]" />
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeScalarOp.Operator" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeScalarSmoothStep.xml
+++ b/doc/classes/VisualShaderNodeScalarSmoothStep.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 0.0 ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeScalarSwitch.xml
+++ b/doc/classes/VisualShaderNodeScalarSwitch.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, false, 1, 1.0, 2, 0.0 ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeSwitch.xml
+++ b/doc/classes/VisualShaderNodeSwitch.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, false, 1, Vector3( 1, 1, 1 ), 2, Vector3( 0, 0, 0 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeTexture.xml
+++ b/doc/classes/VisualShaderNodeTexture.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 		<member name="source" type="int" setter="set_source" getter="get_source" enum="VisualShaderNodeTexture.Source" default="0">
 		</member>
 		<member name="texture" type="Texture" setter="set_texture" getter="get_texture">

--- a/doc/classes/VisualShaderNodeTransformCompose.xml
+++ b/doc/classes/VisualShaderNodeTransformCompose.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, Vector3( 0, 0, 0 ), 3, Vector3( 0, 0, 0 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeTransformConstant.xml
+++ b/doc/classes/VisualShaderNodeTransformConstant.xml
@@ -11,7 +11,6 @@
 	<members>
 		<member name="constant" type="Transform" setter="set_constant" getter="get_constant" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeTransformDecompose.xml
+++ b/doc/classes/VisualShaderNodeTransformDecompose.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeTransformFunc.xml
+++ b/doc/classes/VisualShaderNodeTransformFunc.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ) ]" />
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeTransformFunc.Function" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeTransformMult.xml
+++ b/doc/classes/VisualShaderNodeTransformMult.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ), 1, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ) ]" />
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeTransformMult.Operator" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeTransformVecMult.xml
+++ b/doc/classes/VisualShaderNodeTransformVecMult.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]" />
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeTransformVecMult.Operator" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeUniform.xml
+++ b/doc/classes/VisualShaderNodeUniform.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 		<member name="uniform_name" type="String" setter="set_uniform_name" getter="get_uniform_name" default="&quot;&quot;">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeVec3Constant.xml
+++ b/doc/classes/VisualShaderNodeVec3Constant.xml
@@ -11,7 +11,6 @@
 	<members>
 		<member name="constant" type="Vector3" setter="set_constant" getter="get_constant" default="Vector3( 0, 0, 0 )">
 		</member>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[  ]" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeVectorClamp.xml
+++ b/doc/classes/VisualShaderNodeVectorClamp.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, Vector3( 1, 1, 1 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVectorCompose.xml
+++ b/doc/classes/VisualShaderNodeVectorCompose.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, 0.0 ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVectorDistance.xml
+++ b/doc/classes/VisualShaderNodeVectorDistance.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVectorInterp.xml
+++ b/doc/classes/VisualShaderNodeVectorInterp.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 1, 1, 1 ), 2, Vector3( 0.5, 0.5, 0.5 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVectorOp.xml
+++ b/doc/classes/VisualShaderNodeVectorOp.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ) ]" />
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeVectorOp.Operator" default="0">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeVectorRefract.xml
+++ b/doc/classes/VisualShaderNodeVectorRefract.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, 0.0 ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVectorScalarMix.xml
+++ b/doc/classes/VisualShaderNodeVectorScalarMix.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 1, 1, 1 ), 2, 0.5 ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVectorScalarSmoothStep.xml
+++ b/doc/classes/VisualShaderNodeVectorScalarSmoothStep.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, 0.0, 2, Vector3( 0, 0, 0 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVectorScalarStep.xml
+++ b/doc/classes/VisualShaderNodeVectorScalarStep.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, 0.0, 1, Vector3( 0, 0, 0 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVectorSmoothStep.xml
+++ b/doc/classes/VisualShaderNodeVectorSmoothStep.xml
@@ -8,9 +8,6 @@
 	</tutorials>
 	<methods>
 	</methods>
-	<members>
-		<member name="default_input_values" type="Array" setter="_set_default_input_values" getter="_get_default_input_values" override="true" default="[ 0, Vector3( 0, 0, 0 ), 1, Vector3( 0, 0, 0 ), 2, Vector3( 0, 0, 0 ) ]" />
-	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/XMLParser.xml
+++ b/doc/classes/XMLParser.xml
@@ -147,25 +147,25 @@
 	</methods>
 	<constants>
 		<constant name="NODE_NONE" value="0" enum="NodeType">
-			There's no node (no file or buffer opened)
+			There's no node (no file or buffer opened).
 		</constant>
 		<constant name="NODE_ELEMENT" value="1" enum="NodeType">
-			Element (tag)
+			Element (tag).
 		</constant>
 		<constant name="NODE_ELEMENT_END" value="2" enum="NodeType">
-			End of element
+			End of element.
 		</constant>
 		<constant name="NODE_TEXT" value="3" enum="NodeType">
-			Text node
+			Text node.
 		</constant>
 		<constant name="NODE_COMMENT" value="4" enum="NodeType">
-			Comment node
+			Comment node.
 		</constant>
 		<constant name="NODE_CDATA" value="5" enum="NodeType">
-			CDATA content
+			CDATA content.
 		</constant>
 		<constant name="NODE_UNKNOWN" value="6" enum="NodeType">
-			Unknown node
+			Unknown node.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/bool.xml
+++ b/doc/classes/bool.xml
@@ -4,7 +4,7 @@
 		Boolean built-in type.
 	</brief_description>
 	<description>
-		Boolean is a built-in type. It can represent any data type that is either a true or false value. You can think of it as an switch with on or off (1 or 0) setting . It's often used as part of programming logic in condition statements like [code]if[/code] statements.
+		Boolean is a built-in type. It can represent any data type that is either a true or false value. You can think of it as an switch with on or off (1 or 0) setting. It's often used as part of programming logic in condition statements like [code]if[/code] statements.
 		[b]Note:[/b] In a code below [code]if can_shoot[/code] is equivalent of [code]if can_shoot == true[/code]. It is good practice to follow the natural spoken language structure when possible. Use [code]if can_shoot[/code] rather than [code]if can_shoot == true[/code] and use [code]if not can_shoot[/code] rather than [code]if can_shoot == false[/code].
 		[codeblock]
 		var can_shoot = true

--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -67,14 +67,14 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the channel of the last packet fetched via [method PacketPeer.get_packet]
+				Returns the channel of the last packet fetched via [method PacketPeer.get_packet].
 			</description>
 		</method>
 		<method name="get_packet_channel" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Returns the channel of the next packet that will be retrieved via [method PacketPeer.get_packet]
+				Returns the channel of the next packet that will be retrieved via [method PacketPeer.get_packet].
 			</description>
 		</method>
 		<method name="get_peer_address" qualifiers="const">

--- a/modules/regex/doc_classes/RegEx.xml
+++ b/modules/regex/doc_classes/RegEx.xml
@@ -10,7 +10,7 @@
 		var regex = RegEx.new()
 		regex.compile("\\w-(\\d+)")
 		[/codeblock]
-		The search pattern must be escaped first for gdscript before it is escaped for the expression. For example, [code]compile("\\d+")[/code] would be read by RegEx as [code]\d+[/code]. Similarly, [code]compile("\"(?:\\\\.|[^\"])*\"")[/code] would be read as [code]"(?:\\.|[^"])*"[/code]
+		The search pattern must be escaped first for gdscript before it is escaped for the expression. For example, [code]compile("\\d+")[/code] would be read by RegEx as [code]\d+[/code]. Similarly, [code]compile("\"(?:\\\\.|[^\"])*\"")[/code] would be read as [code]"(?:\\.|[^"])*"[/code].
 		Using [method search] you can find the pattern within the given text. If a pattern is found, [RegExMatch] is returned and you can retrieve details of the results using functions such as [method RegExMatch.get_string] and [method RegExMatch.get_start].
 		[codeblock]
 		var regex = RegEx.new()

--- a/modules/visual_script/doc_classes/VisualScriptBuiltinFunc.xml
+++ b/modules/visual_script/doc_classes/VisualScriptBuiltinFunc.xml
@@ -203,7 +203,7 @@
 			Deserialize a [Variant] from a [PoolByteArray] serialized using [constant VAR_TO_BYTES].
 		</constant>
 		<constant name="COLORN" value="63" enum="BuiltinFunc">
-			Return the [Color] with the given name and alpha ranging from 0 to 1
+			Return the [Color] with the given name and alpha ranging from 0 to 1.
 			[b]Note:[/b] Names are defined in [code]color_names.inc[/code].
 		</constant>
 		<constant name="MATH_SMOOTHSTEP" value="64" enum="BuiltinFunc">

--- a/modules/visual_script/doc_classes/VisualScriptEngineSingleton.xml
+++ b/modules/visual_script/doc_classes/VisualScriptEngineSingleton.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualScriptEngineSingleton" inherits="VisualScriptNode" category="Core" version="3.2">
 	<brief_description>
-		A Visual Script node returning a singleton from [@GlobalScope]
+		A Visual Script node returning a singleton from [@GlobalScope].
 	</brief_description>
 	<description>
-		A Visual Script node returning a singleton from [@GlobalScope]
+		A Visual Script node returning a singleton from [@GlobalScope].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/visual_script/doc_classes/VisualScriptMathConstant.xml
+++ b/modules/visual_script/doc_classes/VisualScriptMathConstant.xml
@@ -21,28 +21,28 @@
 	</members>
 	<constants>
 		<constant name="MATH_CONSTANT_ONE" value="0" enum="MathConstant">
-			Unity: [code]1[/code]
+			Unity: [code]1[/code].
 		</constant>
 		<constant name="MATH_CONSTANT_PI" value="1" enum="MathConstant">
-			Pi: [code]3.141593[/code]
+			Pi: [code]3.141593[/code].
 		</constant>
 		<constant name="MATH_CONSTANT_HALF_PI" value="2" enum="MathConstant">
-			Pi divided by two: [code]1.570796[/code]
+			Pi divided by two: [code]1.570796[/code].
 		</constant>
 		<constant name="MATH_CONSTANT_TAU" value="3" enum="MathConstant">
-			Tau: [code]6.283185[/code]
+			Tau: [code]6.283185[/code].
 		</constant>
 		<constant name="MATH_CONSTANT_E" value="4" enum="MathConstant">
-			Mathematical constant [code]e[/code], the natural log base: [code]2.718282[/code]
+			Mathematical constant [code]e[/code], the natural log base: [code]2.718282[/code].
 		</constant>
 		<constant name="MATH_CONSTANT_SQRT2" value="5" enum="MathConstant">
-			Square root of two: [code]1.414214[/code]
+			Square root of two: [code]1.414214[/code].
 		</constant>
 		<constant name="MATH_CONSTANT_INF" value="6" enum="MathConstant">
-			Infinity: [code]inf[/code]
+			Infinity: [code]inf[/code].
 		</constant>
 		<constant name="MATH_CONSTANT_NAN" value="7" enum="MathConstant">
-			Not a number: [code]nan[/code]
+			Not a number: [code]nan[/code].
 		</constant>
 		<constant name="MATH_CONSTANT_MAX" value="8" enum="MathConstant">
 			Represents the size of the [enum MathConstant] enum.

--- a/modules/webrtc/doc_classes/WebRTCMultiplayer.xml
+++ b/modules/webrtc/doc_classes/WebRTCMultiplayer.xml
@@ -45,7 +45,7 @@
 			<return type="Dictionary">
 			</return>
 			<description>
-				Returns a dictionary which keys are the peer ids and values the peer representation as in [method get_peer]
+				Returns a dictionary which keys are the peer ids and values the peer representation as in [method get_peer].
 			</description>
 		</method>
 		<method name="has_peer">

--- a/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
@@ -143,7 +143,7 @@
 			</argument>
 			<description>
 				Emitted when a new in-band channel is received, i.e. when the channel was created with [code]negotiated: false[/code] (default).
-				The object will be an instance of [WebRTCDataChannel]. You must keep a reference of it or it will be closed automatically. See [method create_data_channel]
+				The object will be an instance of [WebRTCDataChannel]. You must keep a reference of it or it will be closed automatically. See [method create_data_channel].
 			</description>
 		</signal>
 		<signal name="ice_candidate_created">

--- a/modules/websocket/doc_classes/WebSocketPeer.xml
+++ b/modules/websocket/doc_classes/WebSocketPeer.xml
@@ -66,7 +66,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the last received packet was sent as a text payload. See [enum WriteMode]
+				Returns [code]true[/code] if the last received packet was sent as a text payload. See [enum WriteMode].
 			</description>
 		</method>
 	</methods>

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -294,15 +294,6 @@ float CPUParticles2D::get_spread() const {
 	return spread;
 }
 
-void CPUParticles2D::set_flatness(float p_flatness) {
-
-	flatness = p_flatness;
-}
-float CPUParticles2D::get_flatness() const {
-
-	return flatness;
-}
-
 void CPUParticles2D::set_param(Parameter p_param, float p_value) {
 
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
@@ -1169,7 +1160,6 @@ void CPUParticles2D::convert_from_particles(Node *p_particles) {
 	Vector3 dir = material->get_direction();
 	set_direction(Vector2(dir.x, dir.y));
 	set_spread(material->get_spread());
-	set_flatness(material->get_flatness());
 
 	set_color(material->get_color());
 
@@ -1283,9 +1273,6 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_spread", "degrees"), &CPUParticles2D::set_spread);
 	ClassDB::bind_method(D_METHOD("get_spread"), &CPUParticles2D::get_spread);
 
-	ClassDB::bind_method(D_METHOD("set_flatness", "amount"), &CPUParticles2D::set_flatness);
-	ClassDB::bind_method(D_METHOD("get_flatness"), &CPUParticles2D::get_flatness);
-
 	ClassDB::bind_method(D_METHOD("set_param", "param", "value"), &CPUParticles2D::set_param);
 	ClassDB::bind_method(D_METHOD("get_param", "param"), &CPUParticles2D::get_param);
 
@@ -1341,7 +1328,6 @@ void CPUParticles2D::_bind_methods() {
 	ADD_GROUP("Direction", "");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "direction"), "set_direction", "get_direction");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "spread", PROPERTY_HINT_RANGE, "0,180,0.01"), "set_spread", "get_spread");
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "flatness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_flatness", "get_flatness");
 	ADD_GROUP("Gravity", "");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "gravity"), "set_gravity", "get_gravity");
 	ADD_GROUP("Initial Velocity", "initial_");
@@ -1452,7 +1438,6 @@ CPUParticles2D::CPUParticles2D() {
 
 	set_direction(Vector2(1, 0));
 	set_spread(45);
-	set_flatness(0);
 	set_param(PARAM_INITIAL_LINEAR_VELOCITY, 0);
 	set_param(PARAM_ANGULAR_VELOCITY, 0);
 	set_param(PARAM_ORBIT_VELOCITY, 0);

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -154,7 +154,6 @@ private:
 
 	Vector2 direction;
 	float spread;
-	float flatness;
 
 	float parameters[PARAM_MAX];
 	float randomness[PARAM_MAX];
@@ -242,9 +241,6 @@ public:
 
 	void set_spread(float p_spread);
 	float get_spread() const;
-
-	void set_flatness(float p_flatness);
-	float get_flatness() const;
 
 	void set_param(Parameter p_param, float p_value);
 	float get_param(Parameter p_param) const;

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -832,8 +832,8 @@ void AnimationNodeTransition::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "xfade_time", PROPERTY_HINT_RANGE, "0,120,0.01"), "set_cross_fade_time", "get_cross_fade_time");
 
 	for (int i = 0; i < MAX_INPUTS; i++) {
-		ADD_PROPERTYI(PropertyInfo(Variant::STRING, "input_" + itos(i) + "/name"), "set_input_caption", "get_input_caption", i);
-		ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "input_" + itos(i) + "/auto_advance"), "set_input_as_auto_advance", "is_input_set_as_auto_advance", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::STRING, "input_" + itos(i) + "/name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_input_caption", "get_input_caption", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "input_" + itos(i) + "/auto_advance", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_input_as_auto_advance", "is_input_set_as_auto_advance", i);
 	}
 }
 


### PR DESCRIPTION
- Add some missing descriptions.
- Add links to tutorials for ARVR and AnimationTree.
- Style fixes.
- Engine changes:
  * Make `AnimationNodeTransition.input_<number>` properties internal
    so that they don't appear in the docs. They still appear in the
    inspector based on the actual number of inputs requested.
  * Drop unimplemented `CPUParticles.flatness`. It's only used for 3D
    particles in `ParticlesMaterial`, and thus only relevant for
    `CPUParticles3D`.