### PR TITLE
Add hysteresis to PopupMenu

### DIFF
--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -80,6 +80,7 @@ class PopupMenu : public Popup {
 	Timer *submenu_timer;
 	List<Rect2> autohide_areas;
 	Vector<Item> items;
+	PopupMenu *current_submenu;
 	int initial_button_mask;
 	bool during_grabbed_click;
 	int mouse_over;


### PR DESCRIPTION
Closes #11219

Before:
![9jAGZdts5i](https://user-images.githubusercontent.com/2223172/73011157-fc838580-3e13-11ea-9ada-a5c24395f2de.gif)

After:
![Yq4ydIJHlQ](https://user-images.githubusercontent.com/2223172/73011162-fee5df80-3e13-11ea-85b4-54df229b2547.gif)

However I have some problem with menus not closing correctly, so the PR is WIP. If anyone knows why using `popup()` on a sub-menu disables `gui_input` on the parent popup and why changing it to `show`+`grab_focus` breaks nested menus, that would be helpful.

Here's some scene for testing:
[GUI.zip](https://github.com/godotengine/godot/files/4104764/GUI.zip)