### PR TITLE
Mono/C#: Lighten up unsafe reference checks

### DIFF
--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -308,8 +308,9 @@ class CSharpLanguage : public ScriptLanguage {
 	Map<Object *, CSharpScriptBinding> script_bindings;
 
 #ifdef DEBUG_ENABLED
-	// List of unsafely referenced objects
-	List<ObjectID> unsafely_referenced_objects;
+	// List of unsafe object references
+	Map<ObjectID, int> unsafe_object_references;
+	Mutex *unsafe_object_references_lock;
 #endif
 
 	struct StringNameCache {


### PR DESCRIPTION
Because of the weird case with multi-threading and ResourceLoader, it can be the case that a resource is GCed while being referenced again in the main thread. In such cases, a new unsafe reference is created before the finalizer thread removes the previous one.

Fixes the unsafe reference error messages from #35450
