### PR TITLE
Fixes leak in Animation Track editor

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4839,19 +4839,22 @@ struct _AnimMoveRestore {
 void AnimationTrackEditor::_clear_key_edit() {
 	if (key_edit) {
 		//if key edit is the object being inspected, remove it first
-		if (EditorNode::get_singleton()->get_inspector()->get_edited_object() == key_edit ||
-				EditorNode::get_singleton()->get_inspector()->get_edited_object() == multi_key_edit) {
+		if (EditorNode::get_singleton()->get_inspector()->get_edited_object() == key_edit) {
 			EditorNode::get_singleton()->push_item(NULL);
 		}
 
 		//then actually delete it
-		if (key_edit) {
-			memdelete(key_edit);
-			key_edit = NULL;
-		} else if (multi_key_edit) {
-			memdelete(multi_key_edit);
-			multi_key_edit = NULL;
+		memdelete(key_edit);
+		key_edit = NULL;
+	}
+
+	if (multi_key_edit) {
+		if (EditorNode::get_singleton()->get_inspector()->get_edited_object() == multi_key_edit) {
+			EditorNode::get_singleton()->push_item(NULL);
 		}
+
+		memdelete(multi_key_edit);
+		multi_key_edit = NULL;
 	}
 }
 
@@ -4907,7 +4910,7 @@ void AnimationTrackEditor::_update_key_edit() {
 
 			if (!key_ofs_map.has(track)) {
 				key_ofs_map[track] = List<float>();
-				base_map[track] = *memnew(NodePath);
+				base_map[track] = NodePath();
 			}
 
 			key_ofs_map[track].push_back(animation->track_get_key_time(track, E->key().key));
@@ -5974,6 +5977,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	keying = false;
 	moving_selection = 0;
 	key_edit = NULL;
+	multi_key_edit = NULL;
 
 	box_selection = memnew(Control);
 	add_child(box_selection);
@@ -6084,5 +6088,8 @@ AnimationTrackEditor::AnimationTrackEditor() {
 AnimationTrackEditor::~AnimationTrackEditor() {
 	if (key_edit) {
 		memdelete(key_edit);
+	}
+	if (multi_key_edit) {
+		memdelete(multi_key_edit);
 	}
 }


### PR DESCRIPTION
This fixes #31962

* `multi_key_edit`
    * was not initialized to `NULL` in constructor
    * was not deleted in destructor
    * the delete code before reassignment never got executed
* `NodePath`
    * was used in a strange way (`*memnew(NodePath)` instead of `NodePath()`), and never got deleted