### PR TITLE
Fix Softbody always spawns from world center [gles2]

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -2692,6 +2692,7 @@ void RasterizerStorageGLES2::mesh_set_custom_aabb(RID p_mesh, const AABB &p_aabb
 	ERR_FAIL_COND(!mesh);
 
 	mesh->custom_aabb = p_aabb;
+	mesh->instance_change_notify(true, false);
 }
 
 AABB RasterizerStorageGLES2::mesh_get_custom_aabb(RID p_mesh) const {


### PR DESCRIPTION
Fixes #35373

There was just a little notification missing.

See : https://github.com/godotengine/godot/blob/a1ffa3edc228eac8f46b354633f3d85100430885/drivers/gles3/rasterizer_storage_gles3.cpp#L4118