### PR TITLE
Display times as milliseconds in the profiler and performance monitors

### DIFF
--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -102,26 +102,28 @@ void EditorProfiler::clear() {
 }
 
 static String _get_percent_txt(float p_value, float p_total) {
-	if (p_total == 0)
+	if (p_total == 0) {
 		p_total = 0.00001;
+	}
+
 	return String::num((p_value / p_total) * 100, 1) + "%";
 }
 
 String EditorProfiler::_get_time_as_text(const Metric &m, float p_time, int p_calls) {
 
-	int dmode = display_mode->get_selected();
+	const int dmode = display_mode->get_selected();
 
 	if (dmode == DISPLAY_FRAME_TIME) {
-		return rtos(p_time);
+		return rtos(p_time * 1000).pad_decimals(2) + " ms";
 	} else if (dmode == DISPLAY_AVERAGE_TIME) {
-		if (p_calls == 0)
-			return "0";
-		else
-			return rtos(p_time / p_calls);
+		if (p_calls == 0) {
+			return "0.00 ms";
+		} else {
+			return rtos((p_time / p_calls) * 1000).pad_decimals(2) + " ms";
+		}
 	} else if (dmode == DISPLAY_FRAME_PERCENT) {
 		return _get_percent_txt(p_time, m.frame_time);
 	} else if (dmode == DISPLAY_PHYSICS_FRAME_PERCENT) {
-
 		return _get_percent_txt(p_time, m.physics_frame_time);
 	}
 
@@ -729,7 +731,7 @@ EditorProfiler::EditorProfiler() {
 	h_split->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	variables = memnew(Tree);
-	variables->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
+	variables->set_custom_minimum_size(Size2(320, 0) * EDSCALE);
 	variables->set_hide_folding(true);
 	h_split->add_child(variables);
 	variables->set_hide_root(true);
@@ -737,10 +739,10 @@ EditorProfiler::EditorProfiler() {
 	variables->set_column_titles_visible(true);
 	variables->set_column_title(0, TTR("Name"));
 	variables->set_column_expand(0, true);
-	variables->set_column_min_width(0, 60);
+	variables->set_column_min_width(0, 60 * EDSCALE);
 	variables->set_column_title(1, TTR("Time"));
 	variables->set_column_expand(1, false);
-	variables->set_column_min_width(1, 60 * EDSCALE);
+	variables->set_column_min_width(1, 100 * EDSCALE);
 	variables->set_column_title(2, TTR("Calls"));
 	variables->set_column_expand(2, false);
 	variables->set_column_min_width(2, 60 * EDSCALE);
@@ -749,7 +751,6 @@ EditorProfiler::EditorProfiler() {
 	graph = memnew(TextureRect);
 	graph->set_expand(true);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
-	//graph->set_ignore_mouse(false);
 	graph->connect("draw", this, "_graph_tex_draw");
 	graph->connect("gui_input", this, "_graph_tex_input");
 	graph->connect("mouse_exited", this, "_graph_tex_mouse_exit");
@@ -760,12 +761,9 @@ EditorProfiler::EditorProfiler() {
 	int metric_size = CLAMP(int(EDITOR_DEF("debugger/profiler_frame_history_size", 600)), 60, 1024);
 	frame_metrics.resize(metric_size);
 	last_metric = -1;
-	//cursor_metric=-1;
 	hover_metric = -1;
 
 	EDITOR_DEF("debugger/profiler_frame_max_functions", 64);
-
-	//display_mode=DISPLAY_FRAME_TIME;
 
 	frame_delay = memnew(Timer);
 	frame_delay->set_wait_time(0.1);
@@ -784,6 +782,4 @@ EditorProfiler::EditorProfiler() {
 
 	seeking = false;
 	graph_height = 1;
-
-	//activate->set_disabled(true);
 }

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -806,25 +806,25 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			p.write[i] = arr[i];
 			if (i < perf_items.size()) {
 
-				float v = p[i];
-				String vs = rtos(v);
-				String tt = vs;
+				const float value = p[i];
+				String label = rtos(value);
+				String tooltip = label;
 				switch (Performance::MonitorType((int)perf_items[i]->get_metadata(1))) {
 					case Performance::MONITOR_TYPE_MEMORY: {
-						vs = String::humanize_size(v);
-						tt = vs;
+						label = String::humanize_size(value);
+						tooltip = label;
 					} break;
 					case Performance::MONITOR_TYPE_TIME: {
-						tt += " seconds";
-						vs += " s";
+						label = rtos(value * 1000).pad_decimals(2) + " ms";
+						tooltip = label;
 					} break;
 					default: {
-						tt += " " + perf_items[i]->get_text(0);
+						tooltip += " " + perf_items[i]->get_text(0);
 					} break;
 				}
 
-				perf_items[i]->set_text(1, vs);
-				perf_items[i]->set_tooltip(1, tt);
+				perf_items[i]->set_text(1, label);
+				perf_items[i]->set_tooltip(1, tooltip);
 				if (p[i] > perf_max[i])
 					perf_max.write[i] = p[i];
 			}


### PR DESCRIPTION
Small values are easier to read as milliseconds compared to seconds.

## Preview

![Profiler](https://user-images.githubusercontent.com/180032/73064766-3bf8b300-3ea2-11ea-8e3c-d0cc55dcd7ff.png)

![Monitors](https://user-images.githubusercontent.com/180032/73064782-431fc100-3ea2-11ea-8931-a7c5e0c7bf1f.png)