### PR TITLE
Allow saving anywhere when exporting CSV measures from the profiler

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1622,6 +1622,7 @@ void ScriptEditorDebugger::_output_clear() {
 void ScriptEditorDebugger::_export_csv() {
 
 	file_dialog->set_mode(EditorFileDialog::MODE_SAVE_FILE);
+	file_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	file_dialog_mode = SAVE_CSV;
 	file_dialog->popup_centered_ratio();
 }


### PR DESCRIPTION
Previously, the CSV file could only be saved in `res://`. Since this is an editor tool, it makes sense to allow saving anywhere on the filesystem.