### PR TITLE
Unified named colors in RichTextLabel

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -355,6 +355,23 @@ bool Color::html_is_valid(const String &p_color) {
 }
 
 Color Color::named(const String &p_name) {
+	int idx = find_named_color(p_name);
+	if (idx == -1) {
+		ERR_FAIL_V_MSG(Color(), "Invalid color name: " + p_name + ".");
+		return Color();
+	}
+	return get_named_color(idx);
+}
+
+Color Color::named(const String &p_name, const Color &p_default) {
+	int idx = find_named_color(p_name);
+	if (idx == -1) {
+		return p_default;
+	}
+	return get_named_color(idx);
+}
+
+int Color::find_named_color(const String &p_name) {
 	String name = p_name;
 	// Normalize name
 	name = name.replace(" ", "");
@@ -367,14 +384,12 @@ Color Color::named(const String &p_name) {
 	int idx = 0;
 	while (named_colors[idx].name != nullptr) {
 		if (name == named_colors[idx].name) {
-			return named_colors[idx].color;
+			return idx;
 		}
 		idx++;
 	}
 
-	ERR_FAIL_V_MSG(Color(), "Invalid color name: " + p_name + ".");
-
-	return Color();
+	return -1;
 }
 
 int Color::get_named_color_count() {
@@ -384,11 +399,21 @@ int Color::get_named_color_count() {
 	}
 	return idx;
 }
+
 String Color::get_named_color_name(int p_idx) {
 	return named_colors[p_idx].name;
 }
+
 Color Color::get_named_color(int p_idx) {
 	return named_colors[p_idx].color;
+}
+
+Color Color::from_string(const String &p_string, const Color &p_default) {
+	if (html_is_valid(p_string)) {
+		return html(p_string);
+	} else {
+		return named(p_string, p_default);
+	}
 }
 
 String _to_hex(float p_val) {

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -182,9 +182,12 @@ struct Color {
 	static Color html(const String &p_rgba);
 	static bool html_is_valid(const String &p_color);
 	static Color named(const String &p_name);
+	static Color named(const String &p_name, const Color &p_default);
+	static int find_named_color(const String &p_name);
 	static int get_named_color_count();
 	static String get_named_color_name(int p_idx);
 	static Color get_named_color(int p_idx);
+	static Color from_string(const String &p_string, const Color &p_default);
 	String to_html(bool p_alpha = true) const;
 	Color from_hsv(float p_h, float p_s, float p_v, float p_a) const;
 	static Color from_rgbe9995(uint32_t p_rgbe);

--- a/core/math/color_names.inc
+++ b/core/math/color_names.inc
@@ -156,5 +156,5 @@ static NamedColor named_colors[] = {
 	{ "whitesmoke", Color(0.96, 0.96, 0.96) },
 	{ "yellow", Color(1.00, 1.00, 0.00) },
 	{ "yellowgreen", Color(0.60, 0.80, 0.20) },
-	{ nullptr, Color(0.60, 0.80, 0.20) },
+	{ nullptr, Color() },
 };

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1461,46 +1461,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			tag_stack.push_front(tag);
 		} else if (tag.begins_with("color=")) {
 			String col = tag.substr(6, tag.length());
-			Color color;
-
-			if (col.begins_with("#")) {
-				color = Color::html(col);
-			} else if (col == "aqua") {
-				color = Color(0, 1, 1);
-			} else if (col == "black") {
-				color = Color(0, 0, 0);
-			} else if (col == "blue") {
-				color = Color(0, 0, 1);
-			} else if (col == "fuchsia") {
-				color = Color(1, 0, 1);
-			} else if (col == "gray" || col == "grey") {
-				color = Color(0.5, 0.5, 0.5);
-			} else if (col == "green") {
-				color = Color(0, 0.5, 0);
-			} else if (col == "lime") {
-				color = Color(0, 1, 0);
-			} else if (col == "maroon") {
-				color = Color(0.5, 0, 0);
-			} else if (col == "navy") {
-				color = Color(0, 0, 0.5);
-			} else if (col == "olive") {
-				color = Color(0.5, 0.5, 0);
-			} else if (col == "purple") {
-				color = Color(0.5, 0, 0.5);
-			} else if (col == "red") {
-				color = Color(1, 0, 0);
-			} else if (col == "silver") {
-				color = Color(0.75, 0.75, 0.75);
-			} else if (col == "teal") {
-				color = Color(0, 0.5, 0.5);
-			} else if (col == "white") {
-				color = Color(1, 1, 1);
-			} else if (col == "yellow") {
-				color = Color(1, 1, 0);
-			} else {
-				color = Color(0, 0, 0); //base_color;
-			}
-
+			Color color = Color::from_string(col, Color());
 			p_rt->push_color(color);
 			pos = brk_end + 1;
 			tag_stack.push_front("color");

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1449,46 +1449,6 @@ void RichTextLabel::_fetch_item_fx_stack(Item *p_item, Vector<ItemFX *> &r_stack
 	}
 }
 
-Color RichTextLabel::_get_color_from_string(const String &p_color_str, const Color &p_default_color) {
-	if (p_color_str.begins_with("#")) {
-		return Color::html(p_color_str);
-	} else if (p_color_str == "aqua") {
-		return Color(0, 1, 1);
-	} else if (p_color_str == "black") {
-		return Color(0, 0, 0);
-	} else if (p_color_str == "blue") {
-		return Color(0, 0, 1);
-	} else if (p_color_str == "fuchsia") {
-		return Color(1, 0, 1);
-	} else if (p_color_str == "gray" || p_color_str == "grey") {
-		return Color(0.5, 0.5, 0.5);
-	} else if (p_color_str == "green") {
-		return Color(0, 0.5, 0);
-	} else if (p_color_str == "lime") {
-		return Color(0, 1, 0);
-	} else if (p_color_str == "maroon") {
-		return Color(0.5, 0, 0);
-	} else if (p_color_str == "navy") {
-		return Color(0, 0, 0.5);
-	} else if (p_color_str == "olive") {
-		return Color(0.5, 0.5, 0);
-	} else if (p_color_str == "purple") {
-		return Color(0.5, 0, 0.5);
-	} else if (p_color_str == "red") {
-		return Color(1, 0, 0);
-	} else if (p_color_str == "silver") {
-		return Color(0.75, 0.75, 0.75);
-	} else if (p_color_str == "teal") {
-		return Color(0, 0.5, 0.5);
-	} else if (p_color_str == "white") {
-		return Color(1, 1, 1);
-	} else if (p_color_str == "yellow") {
-		return Color(1, 1, 0);
-	} else {
-		return p_default_color;
-	}
-}
-
 bool RichTextLabel::_find_meta(Item *p_item, Variant *r_meta, ItemMeta **r_item) {
 	Item *item = p_item;
 
@@ -2264,7 +2224,7 @@ Error RichTextLabel::append_bbcode(const String &p_bbcode) {
 				Color color = Color(1.0, 1.0, 1.0);
 				OptionMap::Element *color_option = bbcode_options.find("color");
 				if (color_option) {
-					color = _get_color_from_string(color_option->value(), color);
+					color = Color::from_string(color_option->value(), color);
 				}
 
 				int width = 0;
@@ -2296,7 +2256,7 @@ Error RichTextLabel::append_bbcode(const String &p_bbcode) {
 			tag_stack.push_front(bbcode_name);
 		} else if (tag.begins_with("color=")) {
 			String color_str = tag.substr(6, tag.length());
-			Color color = _get_color_from_string(color_str, base_color);
+			Color color = Color::from_string(color_str, base_color);
 			push_color(color);
 			pos = brk_end + 1;
 			tag_stack.push_front("color");

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -382,8 +382,6 @@ private:
 	bool _find_by_type(Item *p_item, ItemType p_type);
 	void _fetch_item_fx_stack(Item *p_item, Vector<ItemFX *> &r_stack);
 
-	static Color _get_color_from_string(const String &p_color_str, const Color &p_default_color);
-
 	void _update_scroll();
 	void _update_fx(ItemFrame *p_frame, float p_delta_time);
 	void _scroll_changed(double);


### PR DESCRIPTION
Now the BB tag `[color]` uses the color names from the `Color` class.
Also, the use of the `#` symbol in an HTML color code has become optional.

---

Please note that there is backward incompatibility with several old color names.

![200124-1](https://user-images.githubusercontent.com/47700418/73067885-db29a480-3eba-11ea-85c7-a1865fd68c33.png)
