### PR TITLE
Prevent "node_renamed" from calling when the game instance is run

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3292,6 +3292,10 @@ bool EditorNode::is_scene_open(const String &p_path) {
 	return false;
 }
 
+EditorRun::Status EditorNode::get_run_status() const {
+	return editor_run.get_status();
+}
+
 void EditorNode::fix_dependencies(const String &p_for_file) {
 	dependency_fixer->edit(p_for_file);
 }

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -742,6 +742,7 @@ public:
 	Error load_resource(const String &p_resource, bool p_ignore_broken_deps = false);
 
 	bool is_scene_open(const String &p_path);
+	EditorRun::Status get_run_status() const;
 
 	void set_current_version(uint64_t p_version);
 	void set_current_scene(int p_idx);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -534,6 +534,9 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 }
 
 void SceneTreeEditor::_node_renamed(Node *p_node) {
+	if (EditorNode::get_singleton()->get_run_status() != EditorRun::Status::STATUS_STOP) { // to prevent incorrect closing of shader editor
+		return;
+	}
 
 	emit_signal("node_renamed");
 


### PR DESCRIPTION
If the @pouleyKetchoupp is unavailable here is mine fix #32832. I didn't find an open method to check if the play button is pressed so I created it myself - correct me if I'm wrong. I think the tool scripts should proceed that event as always, just not when a game is run from the editor.

