### PR TITLE
Use a fixed-width font for internal references in the editor help

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1599,22 +1599,26 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			pos = brk_pos + 1;
 
 		} else if (tag.begins_with("method ") || tag.begins_with("member ") || tag.begins_with("signal ") || tag.begins_with("enum ") || tag.begins_with("constant ") || tag.begins_with("theme_item ")) {
-			int tag_end = tag.find(" ");
+			const int tag_end = tag.find(" ");
+			const String link_tag = tag.substr(0, tag_end);
+			const String link_target = tag.substr(tag_end + 1, tag.length()).lstrip(" ");
 
-			String link_tag = tag.substr(0, tag_end);
-			String link_target = tag.substr(tag_end + 1, tag.length()).lstrip(" ");
-
+			p_rt->push_font(doc_code_font);
 			p_rt->push_color(link_color);
 			p_rt->push_meta("@" + link_tag + " " + link_target);
 			p_rt->add_text(link_target + (tag.begins_with("method ") ? "()" : ""));
 			p_rt->pop();
 			p_rt->pop();
+			p_rt->pop();
 			pos = brk_end + 1;
 
 		} else if (doc->class_list.has(tag)) {
+			// Class reference tag such as [Node2D] or [SceneTree].
+			p_rt->push_font(doc_code_font);
 			p_rt->push_color(link_color);
 			p_rt->push_meta("#" + tag);
 			p_rt->add_text(tag);
+			p_rt->pop();
 			p_rt->pop();
 			p_rt->pop();
 			pos = brk_end + 1;


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/57093.

Since internal references are often written in scripts, it makes sense to use a fixed-width font for them. This was requested by @akien-mga :slightly_smiling_face:

We can't do this in reStructuredText easily (it requires defining an extension or something), so this only affects the editor help.

## Preview

### Before

![2022-01-21_23 50 13](https://user-images.githubusercontent.com/180032/150610550-94d897c4-0bf0-495b-9587-f8bd6a9d49cf.png)

### After

![2022-01-21_23 49 43](https://user-images.githubusercontent.com/180032/150610548-d87b9afb-e046-414a-b9f5-598c73a51745.png)

<details>
<summary>January 2020 patch</summary>

```patch
From eb009cd29f4941986a59dd205b5f7602fec1a0b3 Mon Sep 17 00:00:00 2001
From: Hugo Locurcio <hugo.locurcio@hugo.pro>
Date: Fri, 24 Jan 2020 13:29:19 +0100
Subject: [PATCH] Use a fixed-width font for internal references in the editor
 help

Since internal references are often written in scripts, it makes sense
to use a fixed-width font for them.
---
 editor/editor_help.cpp | 12 ++++++++----
 1 file changed, 8 insertions(+), 4 deletions(-)

diff --git a/editor/editor_help.cpp b/editor/editor_help.cpp
index d3c50423b780..ac32a382f80b 100644
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1294,25 +1294,29 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 
 		} else if (tag.begins_with("method ") || tag.begins_with("member ") || tag.begins_with("signal ") || tag.begins_with("enum ") || tag.begins_with("constant ")) {
 
-			int tag_end = tag.find(" ");
-
-			String link_tag = tag.substr(0, tag_end);
-			String link_target = tag.substr(tag_end + 1, tag.length()).lstrip(" ");
+			const int tag_end = tag.find(" ");
+			const String link_tag = tag.substr(0, tag_end);
+			const String link_target = tag.substr(tag_end + 1, tag.length()).lstrip(" ");
 
+			p_rt->push_font(doc_code_font);
 			p_rt->push_color(link_color);
 			p_rt->push_meta("@" + link_tag + " " + link_target);
 			p_rt->add_text(link_target + (tag.begins_with("method ") ? "()" : ""));
 			p_rt->pop();
 			p_rt->pop();
+			p_rt->pop();
 			pos = brk_end + 1;
 
 		} else if (doc->class_list.has(tag)) {
 
+			// Class reference tag such as [Node2D] or [SceneTree].
+			p_rt->push_font(doc_code_font);
 			p_rt->push_color(link_color);
 			p_rt->push_meta("#" + tag);
 			p_rt->add_text(tag);
 			p_rt->pop();
 			p_rt->pop();
+			p_rt->pop();
 			pos = brk_end + 1;
 
 		} else if (tag == "b") {

```
</details>