### PR TITLE
Lower WebSocket latency, fixes.

### DIFF
--- a/modules/websocket/websocket_server.cpp
+++ b/modules/websocket/websocket_server.cpp
@@ -114,7 +114,7 @@ NetworkedMultiplayerPeer::ConnectionStatus WebSocketServer::get_connection_statu
 		return CONNECTION_CONNECTED;
 
 	return CONNECTION_DISCONNECTED;
-};
+}
 
 bool WebSocketServer::is_server() const {
 

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -243,6 +243,10 @@ Error WSLPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 	msg.msg_length = p_buffer_size;
 
 	wslay_event_queue_msg(_data->ctx, &msg);
+	if (wslay_event_send(_data->ctx) < 0) {
+		close_now();
+		return FAILED;
+	}
 	return OK;
 }
 

--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -165,9 +165,7 @@ Error WSLServer::listen(int p_port, const Vector<String> p_protocols, bool gd_mp
 	for (int i = 0; i < p_protocols.size(); i++) {
 		pw[i] = p_protocols[i].strip_edges();
 	}
-	_server->listen(p_port, bind_ip);
-
-	return OK;
+	return _server->listen(p_port, bind_ip);
 }
 
 void WSLServer::poll() {


### PR DESCRIPTION
WSLPeer now tries to flush packet queue after put_packet call.
WSLServer::listen correctly returns TCP_Server::listen return value.

Aims to fix- #35374 (**please confirm**).