### PR TITLE
[3.x] GLES3: Blit render target with appropriate texture filter.

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -347,7 +347,8 @@ void RasterizerGLES3::blit_render_target_to_screen(RID p_render_target, const Re
 	}
 	glReadBuffer(GL_COLOR_ATTACHMENT0);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, RasterizerStorageGLES3::system_fbo);
-	glBlitFramebuffer(0, 0, rt->width, rt->height, p_screen_rect.position.x, win_size.height - p_screen_rect.position.y - p_screen_rect.size.height, p_screen_rect.position.x + p_screen_rect.size.width, win_size.height - p_screen_rect.position.y, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+	GLenum filter = storage->texture_get_flags(rt->texture) & VS::TEXTURE_FLAG_FILTER ? GL_LINEAR : GL_NEAREST;
+	glBlitFramebuffer(0, 0, rt->width, rt->height, p_screen_rect.position.x, win_size.height - p_screen_rect.position.y - p_screen_rect.size.height, p_screen_rect.position.x + p_screen_rect.size.width, win_size.height - p_screen_rect.position.y, GL_COLOR_BUFFER_BIT, filter);
 }
 
 void RasterizerGLES3::output_lens_distorted_to_screen(RID p_render_target, const Rect2 &p_screen_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample) {


### PR DESCRIPTION
EDIT: With this one can enable main viewport filtering by setting get_viewport().get_texture().flags to Texture.FLAG_FILTER. Useful for non pixel arty games rendered at lower resolution. GLES2 renderer was already working like this.