### PR TITLE
Fix wrong guideline values shown during dragging

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2599,14 +2599,14 @@ void CanvasItemEditor::_draw_guides() {
 	Color text_color = get_color("font_color", "Editor");
 	text_color.a = 0.5;
 	if (drag_type == DRAG_DOUBLE_GUIDE || drag_type == DRAG_V_GUIDE) {
-		String str = vformat("%d px", xform.affine_inverse().xform(dragged_guide_pos).x);
+		String str = vformat("%d px", Math::round(xform.affine_inverse().xform(dragged_guide_pos).x));
 		Ref<Font> font = get_font("font", "Label");
 		Size2 text_size = font->get_string_size(str);
 		viewport->draw_string(font, Point2(dragged_guide_pos.x + 10, RULER_WIDTH + text_size.y / 2 + 10), str, text_color);
 		viewport->draw_line(Point2(dragged_guide_pos.x, 0), Point2(dragged_guide_pos.x, viewport->get_size().y), guide_color, Math::round(EDSCALE));
 	}
 	if (drag_type == DRAG_DOUBLE_GUIDE || drag_type == DRAG_H_GUIDE) {
-		String str = vformat("%d px", xform.affine_inverse().xform(dragged_guide_pos).y);
+		String str = vformat("%d px", Math::round(xform.affine_inverse().xform(dragged_guide_pos).y));
 		Ref<Font> font = get_font("font", "Label");
 		Size2 text_size = font->get_string_size(str);
 		viewport->draw_string(font, Point2(RULER_WIDTH + 10, dragged_guide_pos.y + text_size.y / 2 + 10), str, text_color);


### PR DESCRIPTION
I investigated #35010 and found out that it was due to some floating-point errors. If I force the values to be printed as decimals, the errors become apparent:

![jumping_number](https://user-images.githubusercontent.com/3168908/73082808-1781f280-3f05-11ea-9743-a944062b94b5.gif)


This is due to how the offsets were calculated (some conversion from the mouse's position to the viewport's point of view). Hence different zoom levels may have different missing offsets, in fact some zoom levels seemingly do not exhibit this bug at all.

Fixed #35010 by just rounding up the numbers before printing.