### PR TITLE
Optmized data sent during RPC and RSet calls.

### DIFF
--- a/core/io/multiplayer_api.h
+++ b/core/io/multiplayer_api.h
@@ -98,21 +98,35 @@ protected:
 	void _process_packet(int p_from, const uint8_t *p_packet, int p_packet_len);
 	void _process_simplify_path(int p_from, const uint8_t *p_packet, int p_packet_len);
 	void _process_confirm_path(int p_from, const uint8_t *p_packet, int p_packet_len);
-	Node *_process_get_node(int p_from, const uint8_t *p_packet, int p_packet_len);
-	void _process_rpc(Node *p_node, const StringName &p_name, int p_from, const uint8_t *p_packet, int p_packet_len, int p_offset);
-	void _process_rset(Node *p_node, const StringName &p_name, int p_from, const uint8_t *p_packet, int p_packet_len, int p_offset);
+	Node *_process_get_node(int p_from, const uint8_t *p_packet, uint32_t p_node_target, int p_packet_len);
+	void _process_rpc(Node *p_node, const uint16_t p_rpc_method_id, int p_from, const uint8_t *p_packet, int p_packet_len, int p_offset);
+	void _process_rset(Node *p_node, const uint16_t p_rpc_property_id, int p_from, const uint8_t *p_packet, int p_packet_len, int p_offset);
 	void _process_raw(int p_from, const uint8_t *p_packet, int p_packet_len);
 
 	void _send_rpc(Node *p_from, int p_to, bool p_unreliable, bool p_set, const StringName &p_name, const Variant **p_arg, int p_argcount);
-	bool _send_confirm_path(NodePath p_path, PathSentCache *psc, int p_target);
+	bool _send_confirm_path(Node *p_node, NodePath p_path, PathSentCache *psc, int p_target);
+
+	Error _encode_and_compress_variant(const Variant &p_variant, uint8_t *p_buffer, int &r_len);
+	Error _decode_and_decompress_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len);
 
 public:
 	enum NetworkCommands {
-		NETWORK_COMMAND_REMOTE_CALL,
+		NETWORK_COMMAND_REMOTE_CALL = 0,
 		NETWORK_COMMAND_REMOTE_SET,
 		NETWORK_COMMAND_SIMPLIFY_PATH,
 		NETWORK_COMMAND_CONFIRM_PATH,
 		NETWORK_COMMAND_RAW,
+	};
+
+	enum NetworkNodeIdCompression {
+		NETWORK_NODE_ID_COMPRESSION_8 = 0,
+		NETWORK_NODE_ID_COMPRESSION_16,
+		NETWORK_NODE_ID_COMPRESSION_32,
+	};
+
+	enum NetworkNameIdCompression {
+		NETWORK_NAME_ID_COMPRESSION_8 = 0,
+		NETWORK_NAME_ID_COMPRESSION_16,
 	};
 
 	enum RPCMode {

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -32,6 +32,7 @@
 
 #include "core/core_string_names.h"
 #include "core/project_settings.h"
+#include <stdint.h>
 
 ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES];
 int ScriptServer::_language_count = 0;
@@ -642,6 +643,14 @@ Variant PlaceHolderScriptInstance::property_get_fallback(const StringName &p_nam
 		*r_valid = false;
 
 	return Variant();
+}
+
+uint16_t PlaceHolderScriptInstance::get_rpc_method_id(const StringName &p_method) const {
+	return UINT16_MAX;
+}
+
+uint16_t PlaceHolderScriptInstance::get_rset_property_id(const StringName &p_method) const {
+	return UINT16_MAX;
 }
 
 PlaceHolderScriptInstance::PlaceHolderScriptInstance(ScriptLanguage *p_language, Ref<Script> p_script, Object *p_owner) :

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -40,6 +40,21 @@ class ScriptLanguage;
 
 typedef void (*ScriptEditRequestFunction)(const String &p_path);
 
+struct ScriptNetData {
+	StringName name;
+	MultiplayerAPI::RPCMode mode;
+	bool operator==(ScriptNetData const &p_other) const {
+		return name == p_other.name;
+	}
+};
+
+struct SortNetData {
+	StringName::AlphCompare compare;
+	bool operator()(const ScriptNetData &p_a, const ScriptNetData &p_b) const {
+		return compare(p_a.name, p_b.name);
+	}
+};
+
 class ScriptServer {
 	enum {
 
@@ -154,6 +169,18 @@ public:
 
 	virtual bool is_placeholder_fallback_enabled() const { return false; }
 
+	virtual Vector<ScriptNetData> get_rpc_methods() const = 0;
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const = 0;
+	virtual StringName get_rpc_method(const uint16_t p_rpc_method_id) const = 0;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(const uint16_t p_rpc_method_id) const = 0;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const = 0;
+
+	virtual Vector<ScriptNetData> get_rset_properties() const = 0;
+	virtual uint16_t get_rset_property_id(const StringName &p_property) const = 0;
+	virtual StringName get_rset_property(const uint16_t p_rset_property_id) const = 0;
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(const uint16_t p_rpc_method_id) const = 0;
+	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const = 0;
+
 	Script() {}
 };
 
@@ -195,7 +222,16 @@ public:
 	virtual void property_set_fallback(const StringName &p_name, const Variant &p_value, bool *r_valid);
 	virtual Variant property_get_fallback(const StringName &p_name, bool *r_valid);
 
+	virtual Vector<ScriptNetData> get_rpc_methods() const = 0;
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const = 0;
+	virtual StringName get_rpc_method(uint16_t p_id) const = 0;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(uint16_t p_id) const = 0;
 	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const = 0;
+
+	virtual Vector<ScriptNetData> get_rset_properties() const = 0;
+	virtual uint16_t get_rset_property_id(const StringName &p_variable) const = 0;
+	virtual StringName get_rset_property(uint16_t p_id) const = 0;
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(uint16_t p_id) const = 0;
 	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const = 0;
 
 	virtual ScriptLanguage *get_language() = 0;
@@ -409,7 +445,16 @@ public:
 	virtual void property_set_fallback(const StringName &p_name, const Variant &p_value, bool *r_valid = NULL);
 	virtual Variant property_get_fallback(const StringName &p_name, bool *r_valid = NULL);
 
+	virtual Vector<ScriptNetData> get_rpc_methods() const { return Vector<ScriptNetData>(); }
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const;
+	virtual StringName get_rpc_method(uint16_t p_id) const { return StringName(); }
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(uint16_t p_id) const { return MultiplayerAPI::RPC_MODE_DISABLED; }
 	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const { return MultiplayerAPI::RPC_MODE_DISABLED; }
+
+	virtual Vector<ScriptNetData> get_rset_properties() const { return Vector<ScriptNetData>(); }
+	virtual uint16_t get_rset_property_id(const StringName &p_variable) const;
+	virtual StringName get_rset_property(uint16_t p_id) const { return StringName(); }
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(uint16_t p_id) const { return MultiplayerAPI::RPC_MODE_DISABLED; }
 	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const { return MultiplayerAPI::RPC_MODE_DISABLED; }
 
 	PlaceHolderScriptInstance(ScriptLanguage *p_language, Ref<Script> p_script, Object *p_owner);

--- a/modules/gdnative/nativescript/godot_nativescript.cpp
+++ b/modules/gdnative/nativescript/godot_nativescript.cpp
@@ -36,6 +36,7 @@
 #include "core/project_settings.h"
 #include "core/variant.h"
 #include "gdnative/gdnative.h"
+#include <stdint.h>
 
 #include "nativescript.h"
 
@@ -67,6 +68,14 @@ void GDAPI godot_nativescript_register_class(void *p_gdnative_handle, const char
 	if (classes->has(p_base)) {
 		desc.base_data = &(*classes)[p_base];
 		desc.base_native_type = desc.base_data->base_native_type;
+
+		const NativeScriptDesc *b = desc.base_data;
+		while (b) {
+			desc.rpc_count += b->rpc_count;
+			desc.rset_count += b->rset_count;
+			b = b->base_data;
+		}
+
 	} else {
 		desc.base_data = NULL;
 		desc.base_native_type = p_base;
@@ -87,10 +96,20 @@ void GDAPI godot_nativescript_register_tool_class(void *p_gdnative_handle, const
 	desc.destroy_func = p_destroy_func;
 	desc.is_tool = true;
 	desc.base = p_base;
+	desc.rpc_count = 0;
+	desc.rset_count = 0;
 
 	if (classes->has(p_base)) {
 		desc.base_data = &(*classes)[p_base];
 		desc.base_native_type = desc.base_data->base_native_type;
+
+		const NativeScriptDesc *b = desc.base_data;
+		while (b) {
+			desc.rpc_count += b->rpc_count;
+			desc.rset_count += b->rset_count;
+			b = b->base_data;
+		}
+
 	} else {
 		desc.base_data = NULL;
 		desc.base_native_type = p_base;
@@ -109,6 +128,11 @@ void GDAPI godot_nativescript_register_method(void *p_gdnative_handle, const cha
 	NativeScriptDesc::Method method;
 	method.method = p_method;
 	method.rpc_mode = p_attr.rpc_type;
+	method.rpc_method_id = UINT16_MAX;
+	if (p_attr.rpc_type != GODOT_METHOD_RPC_MODE_DISABLED) {
+		method.rpc_method_id = E->get().rpc_count;
+		E->get().rpc_count += 1;
+	}
 	method.info = MethodInfo(p_function_name);
 
 	E->get().methods.insert(p_function_name, method);
@@ -125,6 +149,10 @@ void GDAPI godot_nativescript_register_property(void *p_gdnative_handle, const c
 	property.default_value = *(Variant *)&p_attr->default_value;
 	property.getter = p_get_func;
 	property.rset_mode = p_attr->rset_type;
+	if (p_attr->rset_type != GODOT_METHOD_RPC_MODE_DISABLED) {
+		property.rset_property_id = E->get().rset_count;
+		E->get().rset_count += 1;
+	}
 	property.setter = p_set_func;
 	property.info = PropertyInfo((Variant::Type)p_attr->type,
 			p_path,

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -30,6 +30,8 @@
 
 #include "nativescript.h"
 
+#include <stdint.h>
+
 #include "gdnative/gdnative.h"
 
 #include "core/core_string_names.h"
@@ -400,6 +402,262 @@ void NativeScript::get_script_property_list(List<PropertyInfo> *p_list) const {
 		}
 		script_data = script_data->base_data;
 	}
+}
+
+Vector<ScriptNetData> NativeScript::get_rpc_methods() const {
+
+	Vector<ScriptNetData> v;
+
+	NativeScriptDesc *script_data = get_script_desc();
+
+	while (script_data) {
+
+		for (Map<StringName, NativeScriptDesc::Method>::Element *E = script_data->methods.front(); E; E = E->next()) {
+			if (E->get().rpc_mode != GODOT_METHOD_RPC_MODE_DISABLED) {
+				ScriptNetData nd;
+				nd.name = E->key();
+				nd.mode = MultiplayerAPI::RPCMode(E->get().rpc_mode);
+				v.push_back(nd);
+			}
+		}
+
+		script_data = script_data->base_data;
+	}
+
+	return v;
+}
+
+uint16_t NativeScript::get_rpc_method_id(const StringName &p_method) const {
+	NativeScriptDesc *script_data = get_script_desc();
+
+	while (script_data) {
+
+		Map<StringName, NativeScriptDesc::Method>::Element *E = script_data->methods.find(p_method);
+		if (E) {
+			return E->get().rpc_method_id;
+		}
+
+		script_data = script_data->base_data;
+	}
+
+	return UINT16_MAX;
+}
+
+StringName NativeScript::get_rpc_method(uint16_t p_id) const {
+	ERR_FAIL_COND_V(p_id == UINT16_MAX, StringName());
+
+	NativeScriptDesc *script_data = get_script_desc();
+
+	while (script_data) {
+
+		for (Map<StringName, NativeScriptDesc::Method>::Element *E = script_data->methods.front(); E; E = E->next()) {
+			if (E->get().rpc_method_id == p_id) {
+				return E->key();
+			}
+		}
+
+		script_data = script_data->base_data;
+	}
+
+	return StringName();
+}
+
+MultiplayerAPI::RPCMode NativeScript::get_rpc_mode_by_id(uint16_t p_id) const {
+
+	ERR_FAIL_COND_V(p_id == UINT16_MAX, MultiplayerAPI::RPC_MODE_DISABLED);
+
+	NativeScriptDesc *script_data = get_script_desc();
+
+	while (script_data) {
+
+		for (Map<StringName, NativeScriptDesc::Method>::Element *E = script_data->methods.front(); E; E = E->next()) {
+			if (E->get().rpc_method_id == p_id) {
+				switch (E->get().rpc_mode) {
+					case GODOT_METHOD_RPC_MODE_DISABLED:
+						return MultiplayerAPI::RPC_MODE_DISABLED;
+					case GODOT_METHOD_RPC_MODE_REMOTE:
+						return MultiplayerAPI::RPC_MODE_REMOTE;
+					case GODOT_METHOD_RPC_MODE_MASTER:
+						return MultiplayerAPI::RPC_MODE_MASTER;
+					case GODOT_METHOD_RPC_MODE_PUPPET:
+						return MultiplayerAPI::RPC_MODE_PUPPET;
+					case GODOT_METHOD_RPC_MODE_REMOTESYNC:
+						return MultiplayerAPI::RPC_MODE_REMOTESYNC;
+					case GODOT_METHOD_RPC_MODE_MASTERSYNC:
+						return MultiplayerAPI::RPC_MODE_MASTERSYNC;
+					case GODOT_METHOD_RPC_MODE_PUPPETSYNC:
+						return MultiplayerAPI::RPC_MODE_PUPPETSYNC;
+					default:
+						return MultiplayerAPI::RPC_MODE_DISABLED;
+				}
+			}
+		}
+
+		script_data = script_data->base_data;
+	}
+
+	return MultiplayerAPI::RPC_MODE_DISABLED;
+}
+
+MultiplayerAPI::RPCMode NativeScript::get_rpc_mode(const StringName &p_method) const {
+
+	NativeScriptDesc *script_data = get_script_desc();
+
+	while (script_data) {
+
+		Map<StringName, NativeScriptDesc::Method>::Element *E = script_data->methods.find(p_method);
+		if (E) {
+			switch (E->get().rpc_mode) {
+				case GODOT_METHOD_RPC_MODE_DISABLED:
+					return MultiplayerAPI::RPC_MODE_DISABLED;
+				case GODOT_METHOD_RPC_MODE_REMOTE:
+					return MultiplayerAPI::RPC_MODE_REMOTE;
+				case GODOT_METHOD_RPC_MODE_MASTER:
+					return MultiplayerAPI::RPC_MODE_MASTER;
+				case GODOT_METHOD_RPC_MODE_PUPPET:
+					return MultiplayerAPI::RPC_MODE_PUPPET;
+				case GODOT_METHOD_RPC_MODE_REMOTESYNC:
+					return MultiplayerAPI::RPC_MODE_REMOTESYNC;
+				case GODOT_METHOD_RPC_MODE_MASTERSYNC:
+					return MultiplayerAPI::RPC_MODE_MASTERSYNC;
+				case GODOT_METHOD_RPC_MODE_PUPPETSYNC:
+					return MultiplayerAPI::RPC_MODE_PUPPETSYNC;
+				default:
+					return MultiplayerAPI::RPC_MODE_DISABLED;
+			}
+		}
+
+		script_data = script_data->base_data;
+	}
+
+	return MultiplayerAPI::RPC_MODE_DISABLED;
+}
+
+Vector<ScriptNetData> NativeScript::get_rset_properties() const {
+	Vector<ScriptNetData> v;
+
+	NativeScriptDesc *script_data = get_script_desc();
+
+	while (script_data) {
+
+		for (OrderedHashMap<StringName, NativeScriptDesc::Property>::Element E = script_data->properties.front(); E; E = E.next()) {
+			if (E.get().rset_mode != GODOT_METHOD_RPC_MODE_DISABLED) {
+				ScriptNetData nd;
+				nd.name = E.key();
+				nd.mode = MultiplayerAPI::RPCMode(E.get().rset_mode);
+				v.push_back(nd);
+			}
+		}
+		script_data = script_data->base_data;
+	}
+
+	return v;
+}
+
+uint16_t NativeScript::get_rset_property_id(const StringName &p_variable) const {
+	NativeScriptDesc *script_data = get_script_desc();
+
+	while (script_data) {
+
+		OrderedHashMap<StringName, NativeScriptDesc::Property>::Element E = script_data->properties.find(p_variable);
+		if (E) {
+			return E.get().rset_property_id;
+		}
+
+		script_data = script_data->base_data;
+	}
+
+	return UINT16_MAX;
+}
+
+StringName NativeScript::get_rset_property(uint16_t p_id) const {
+	ERR_FAIL_COND_V(p_id == UINT16_MAX, StringName());
+
+	NativeScriptDesc *script_data = get_script_desc();
+
+	while (script_data) {
+
+		for (OrderedHashMap<StringName, NativeScriptDesc::Property>::Element E = script_data->properties.front(); E; E = E.next()) {
+			if (E.get().rset_property_id == p_id) {
+				return E.key();
+			}
+		}
+
+		script_data = script_data->base_data;
+	}
+
+	return StringName();
+}
+
+MultiplayerAPI::RPCMode NativeScript::get_rset_mode_by_id(uint16_t p_id) const {
+
+	ERR_FAIL_COND_V(p_id == UINT16_MAX, MultiplayerAPI::RPC_MODE_DISABLED);
+
+	NativeScriptDesc *script_data = get_script_desc();
+
+	while (script_data) {
+
+		for (OrderedHashMap<StringName, NativeScriptDesc::Property>::Element E = script_data->properties.front(); E; E = E.next()) {
+			if (E.get().rset_property_id == p_id) {
+				switch (E.get().rset_mode) {
+					case GODOT_METHOD_RPC_MODE_DISABLED:
+						return MultiplayerAPI::RPC_MODE_DISABLED;
+					case GODOT_METHOD_RPC_MODE_REMOTE:
+						return MultiplayerAPI::RPC_MODE_REMOTE;
+					case GODOT_METHOD_RPC_MODE_MASTER:
+						return MultiplayerAPI::RPC_MODE_MASTER;
+					case GODOT_METHOD_RPC_MODE_PUPPET:
+						return MultiplayerAPI::RPC_MODE_PUPPET;
+					case GODOT_METHOD_RPC_MODE_REMOTESYNC:
+						return MultiplayerAPI::RPC_MODE_REMOTESYNC;
+					case GODOT_METHOD_RPC_MODE_MASTERSYNC:
+						return MultiplayerAPI::RPC_MODE_MASTERSYNC;
+					case GODOT_METHOD_RPC_MODE_PUPPETSYNC:
+						return MultiplayerAPI::RPC_MODE_PUPPETSYNC;
+					default:
+						return MultiplayerAPI::RPC_MODE_DISABLED;
+				}
+			}
+		}
+
+		script_data = script_data->base_data;
+	}
+
+	return MultiplayerAPI::RPC_MODE_DISABLED;
+}
+
+MultiplayerAPI::RPCMode NativeScript::get_rset_mode(const StringName &p_variable) const {
+
+	NativeScriptDesc *script_data = get_script_desc();
+
+	while (script_data) {
+
+		OrderedHashMap<StringName, NativeScriptDesc::Property>::Element E = script_data->properties.find(p_variable);
+		if (E) {
+			switch (E.get().rset_mode) {
+				case GODOT_METHOD_RPC_MODE_DISABLED:
+					return MultiplayerAPI::RPC_MODE_DISABLED;
+				case GODOT_METHOD_RPC_MODE_REMOTE:
+					return MultiplayerAPI::RPC_MODE_REMOTE;
+				case GODOT_METHOD_RPC_MODE_MASTER:
+					return MultiplayerAPI::RPC_MODE_MASTER;
+				case GODOT_METHOD_RPC_MODE_PUPPET:
+					return MultiplayerAPI::RPC_MODE_PUPPET;
+				case GODOT_METHOD_RPC_MODE_REMOTESYNC:
+					return MultiplayerAPI::RPC_MODE_REMOTESYNC;
+				case GODOT_METHOD_RPC_MODE_MASTERSYNC:
+					return MultiplayerAPI::RPC_MODE_MASTERSYNC;
+				case GODOT_METHOD_RPC_MODE_PUPPETSYNC:
+					return MultiplayerAPI::RPC_MODE_PUPPETSYNC;
+				default:
+					return MultiplayerAPI::RPC_MODE_DISABLED;
+			}
+		}
+
+		script_data = script_data->base_data;
+	}
+
+	return MultiplayerAPI::RPC_MODE_DISABLED;
 }
 
 String NativeScript::get_class_documentation() const {
@@ -803,72 +1061,44 @@ Ref<Script> NativeScriptInstance::get_script() const {
 	return script;
 }
 
+Vector<ScriptNetData> NativeScriptInstance::get_rpc_methods() const {
+	return script->get_rpc_methods();
+}
+
+uint16_t NativeScriptInstance::get_rpc_method_id(const StringName &p_method) const {
+	return script->get_rpc_method_id(p_method);
+}
+
+StringName NativeScriptInstance::get_rpc_method(uint16_t p_id) const {
+	return script->get_rpc_method(p_id);
+}
+
+MultiplayerAPI::RPCMode NativeScriptInstance::get_rpc_mode_by_id(uint16_t p_id) const {
+	return script->get_rpc_mode_by_id(p_id);
+}
+
 MultiplayerAPI::RPCMode NativeScriptInstance::get_rpc_mode(const StringName &p_method) const {
+	return script->get_rpc_mode(p_method);
+}
 
-	NativeScriptDesc *script_data = GET_SCRIPT_DESC();
+Vector<ScriptNetData> NativeScriptInstance::get_rset_properties() const {
+	return script->get_rset_properties();
+}
 
-	while (script_data) {
+uint16_t NativeScriptInstance::get_rset_property_id(const StringName &p_variable) const {
+	return script->get_rset_property_id(p_variable);
+}
 
-		Map<StringName, NativeScriptDesc::Method>::Element *E = script_data->methods.find(p_method);
-		if (E) {
-			switch (E->get().rpc_mode) {
-				case GODOT_METHOD_RPC_MODE_DISABLED:
-					return MultiplayerAPI::RPC_MODE_DISABLED;
-				case GODOT_METHOD_RPC_MODE_REMOTE:
-					return MultiplayerAPI::RPC_MODE_REMOTE;
-				case GODOT_METHOD_RPC_MODE_MASTER:
-					return MultiplayerAPI::RPC_MODE_MASTER;
-				case GODOT_METHOD_RPC_MODE_PUPPET:
-					return MultiplayerAPI::RPC_MODE_PUPPET;
-				case GODOT_METHOD_RPC_MODE_REMOTESYNC:
-					return MultiplayerAPI::RPC_MODE_REMOTESYNC;
-				case GODOT_METHOD_RPC_MODE_MASTERSYNC:
-					return MultiplayerAPI::RPC_MODE_MASTERSYNC;
-				case GODOT_METHOD_RPC_MODE_PUPPETSYNC:
-					return MultiplayerAPI::RPC_MODE_PUPPETSYNC;
-				default:
-					return MultiplayerAPI::RPC_MODE_DISABLED;
-			}
-		}
+StringName NativeScriptInstance::get_rset_property(uint16_t p_id) const {
+	return script->get_rset_property(p_id);
+}
 
-		script_data = script_data->base_data;
-	}
-
-	return MultiplayerAPI::RPC_MODE_DISABLED;
+MultiplayerAPI::RPCMode NativeScriptInstance::get_rset_mode_by_id(uint16_t p_id) const {
+	return script->get_rset_mode_by_id(p_id);
 }
 
 MultiplayerAPI::RPCMode NativeScriptInstance::get_rset_mode(const StringName &p_variable) const {
-
-	NativeScriptDesc *script_data = GET_SCRIPT_DESC();
-
-	while (script_data) {
-
-		OrderedHashMap<StringName, NativeScriptDesc::Property>::Element E = script_data->properties.find(p_variable);
-		if (E) {
-			switch (E.get().rset_mode) {
-				case GODOT_METHOD_RPC_MODE_DISABLED:
-					return MultiplayerAPI::RPC_MODE_DISABLED;
-				case GODOT_METHOD_RPC_MODE_REMOTE:
-					return MultiplayerAPI::RPC_MODE_REMOTE;
-				case GODOT_METHOD_RPC_MODE_MASTER:
-					return MultiplayerAPI::RPC_MODE_MASTER;
-				case GODOT_METHOD_RPC_MODE_PUPPET:
-					return MultiplayerAPI::RPC_MODE_PUPPET;
-				case GODOT_METHOD_RPC_MODE_REMOTESYNC:
-					return MultiplayerAPI::RPC_MODE_REMOTESYNC;
-				case GODOT_METHOD_RPC_MODE_MASTERSYNC:
-					return MultiplayerAPI::RPC_MODE_MASTERSYNC;
-				case GODOT_METHOD_RPC_MODE_PUPPETSYNC:
-					return MultiplayerAPI::RPC_MODE_PUPPETSYNC;
-				default:
-					return MultiplayerAPI::RPC_MODE_DISABLED;
-			}
-		}
-
-		script_data = script_data->base_data;
-	}
-
-	return MultiplayerAPI::RPC_MODE_DISABLED;
+	return script->get_rset_mode(p_variable);
 }
 
 ScriptLanguage *NativeScriptInstance::get_language() {

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -54,6 +54,7 @@ struct NativeScriptDesc {
 		godot_instance_method method;
 		MethodInfo info;
 		int rpc_mode;
+		uint16_t rpc_method_id;
 		String documentation;
 	};
 	struct Property {
@@ -62,6 +63,7 @@ struct NativeScriptDesc {
 		PropertyInfo info;
 		Variant default_value;
 		int rset_mode;
+		uint16_t rset_property_id;
 		String documentation;
 	};
 
@@ -70,7 +72,9 @@ struct NativeScriptDesc {
 		String documentation;
 	};
 
+	uint16_t rpc_count;
 	Map<StringName, Method> methods;
+	uint16_t rset_count;
 	OrderedHashMap<StringName, Property> properties;
 	Map<StringName, Signal> signals_; // QtCreator doesn't like the name signals
 	StringName base;
@@ -86,7 +90,9 @@ struct NativeScriptDesc {
 	bool is_tool;
 
 	inline NativeScriptDesc() :
+			rpc_count(0),
 			methods(),
+			rset_count(0),
 			properties(),
 			signals_(),
 			base(),
@@ -174,6 +180,18 @@ public:
 	virtual void get_script_method_list(List<MethodInfo> *p_list) const;
 	virtual void get_script_property_list(List<PropertyInfo> *p_list) const;
 
+	virtual Vector<ScriptNetData> get_rpc_methods() const;
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const;
+	virtual StringName get_rpc_method(uint16_t p_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(uint16_t p_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const;
+
+	virtual Vector<ScriptNetData> get_rset_properties() const;
+	virtual uint16_t get_rset_property_id(const StringName &p_variable) const;
+	virtual StringName get_rset_property(uint16_t p_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(uint16_t p_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const;
+
 	String get_class_documentation() const;
 	String get_method_documentation(const StringName &p_method) const;
 	String get_signal_documentation(const StringName &p_signal_name) const;
@@ -210,8 +228,19 @@ public:
 	virtual void notification(int p_notification);
 	String to_string(bool *r_valid);
 	virtual Ref<Script> get_script() const;
+
+	virtual Vector<ScriptNetData> get_rpc_methods() const;
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const;
+	virtual StringName get_rpc_method(uint16_t p_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(uint16_t p_id) const;
 	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const;
+
+	virtual Vector<ScriptNetData> get_rset_properties() const;
+	virtual uint16_t get_rset_property_id(const StringName &p_variable) const;
+	virtual StringName get_rset_property(uint16_t p_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(uint16_t p_id) const;
 	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const;
+
 	virtual ScriptLanguage *get_language();
 
 	virtual void call_multilevel(const StringName &p_method, const Variant **p_args, int p_argcount);

--- a/modules/gdnative/pluginscript/pluginscript_instance.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_instance.cpp
@@ -93,8 +93,40 @@ void PluginScriptInstance::notification(int p_notification) {
 	_desc->notification(_data, p_notification);
 }
 
+Vector<ScriptNetData> PluginScriptInstance::get_rpc_methods() const {
+	return _script->get_rpc_methods();
+}
+
+uint16_t PluginScriptInstance::get_rpc_method_id(const StringName &p_variable) const {
+	return _script->get_rpc_method_id(p_variable);
+}
+
+StringName PluginScriptInstance::get_rpc_method(uint16_t p_id) const {
+	return _script->get_rpc_method(p_id);
+}
+
+MultiplayerAPI::RPCMode PluginScriptInstance::get_rpc_mode_by_id(uint16_t p_id) const {
+	return _script->get_rpc_mode_by_id(p_id);
+}
+
 MultiplayerAPI::RPCMode PluginScriptInstance::get_rpc_mode(const StringName &p_method) const {
 	return _script->get_rpc_mode(p_method);
+}
+
+Vector<ScriptNetData> PluginScriptInstance::get_rset_properties() const {
+	return _script->get_rset_properties();
+}
+
+uint16_t PluginScriptInstance::get_rset_property_id(const StringName &p_variable) const {
+	return _script->get_rset_property_id(p_variable);
+}
+
+StringName PluginScriptInstance::get_rset_property(uint16_t p_id) const {
+	return _script->get_rset_property(p_id);
+}
+
+MultiplayerAPI::RPCMode PluginScriptInstance::get_rset_mode_by_id(uint16_t p_id) const {
+	return _script->get_rset_mode_by_id(p_id);
 }
 
 MultiplayerAPI::RPCMode PluginScriptInstance::get_rset_mode(const StringName &p_variable) const {

--- a/modules/gdnative/pluginscript/pluginscript_instance.h
+++ b/modules/gdnative/pluginscript/pluginscript_instance.h
@@ -76,7 +76,16 @@ public:
 
 	void set_path(const String &p_path);
 
+	virtual Vector<ScriptNetData> get_rpc_methods() const;
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const;
+	virtual StringName get_rpc_method(uint16_t p_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(uint16_t p_id) const;
 	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const;
+
+	virtual Vector<ScriptNetData> get_rset_properties() const;
+	virtual uint16_t get_rset_property_id(const StringName &p_variable) const;
+	virtual StringName get_rset_property(uint16_t p_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(uint16_t p_id) const;
 	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const;
 
 	virtual void refcount_incremented();

--- a/modules/gdnative/pluginscript/pluginscript_script.h
+++ b/modules/gdnative/pluginscript/pluginscript_script.h
@@ -60,8 +60,8 @@ private:
 	Map<StringName, PropertyInfo> _properties_info;
 	Map<StringName, MethodInfo> _signals_info;
 	Map<StringName, MethodInfo> _methods_info;
-	Map<StringName, MultiplayerAPI::RPCMode> _variables_rset_mode;
-	Map<StringName, MultiplayerAPI::RPCMode> _methods_rpc_mode;
+	Vector<ScriptNetData> _rpc_methods;
+	Vector<ScriptNetData> _rpc_variables;
 
 	Set<Object *> _instances;
 	//exported members
@@ -118,8 +118,17 @@ public:
 
 	virtual int get_member_line(const StringName &p_member) const;
 
-	MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const;
-	MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const;
+	virtual Vector<ScriptNetData> get_rpc_methods() const;
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const;
+	virtual StringName get_rpc_method(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const;
+
+	virtual Vector<ScriptNetData> get_rset_properties() const;
+	virtual uint16_t get_rset_property_id(const StringName &p_property) const;
+	virtual StringName get_rset_property(const uint16_t p_rset_property_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const;
 
 	PluginScript();
 	void init(PluginScriptLanguage *language);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -85,6 +85,8 @@ class GDScript : public Script {
 	Map<StringName, MemberInfo> member_indices; //members are just indices to the instanced script.
 	Map<StringName, Ref<GDScript> > subclasses;
 	Map<StringName, Vector<StringName> > _signals;
+	Vector<ScriptNetData> rpc_functions;
+	Vector<ScriptNetData> rpc_variables;
 
 #ifdef TOOLS_ENABLED
 
@@ -213,6 +215,18 @@ public:
 	virtual void get_constants(Map<StringName, Variant> *p_constants);
 	virtual void get_members(Set<StringName> *p_members);
 
+	virtual Vector<ScriptNetData> get_rpc_methods() const;
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const;
+	virtual StringName get_rpc_method(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const;
+
+	virtual Vector<ScriptNetData> get_rset_properties() const;
+	virtual uint16_t get_rset_property_id(const StringName &p_variable) const;
+	virtual StringName get_rset_property(const uint16_t p_variable_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(const uint16_t p_variable_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const;
+
 #ifdef TOOLS_ENABLED
 	virtual bool is_placeholder_fallback_enabled() const { return placeholder_fallback_enabled; }
 #endif
@@ -264,7 +278,16 @@ public:
 
 	void reload_members();
 
+	virtual Vector<ScriptNetData> get_rpc_methods() const;
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const;
+	virtual StringName get_rpc_method(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(const uint16_t p_rpc_method_id) const;
 	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const;
+
+	virtual Vector<ScriptNetData> get_rset_properties() const;
+	virtual uint16_t get_rset_property_id(const StringName &p_variable) const;
+	virtual StringName get_rset_property(const uint16_t p_variable_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(const uint16_t p_variable_id) const;
 	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const;
 
 	GDScriptInstance();

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -113,6 +113,9 @@ class CSharpScript : public Script {
 	Map<StringName, Vector<Argument> > _signals;
 	bool signals_invalidated;
 
+	Vector<ScriptNetData> rpc_functions;
+	Vector<ScriptNetData> rpc_variables;
+
 #ifdef TOOLS_ENABLED
 	List<PropertyInfo> exported_members_cache; // members_cache
 	Map<StringName, Variant> exported_members_defval_cache; // member_default_values_cache
@@ -145,6 +148,8 @@ class CSharpScript : public Script {
 	friend void GDMonoInternals::tie_managed_to_unmanaged(MonoObject *, Object *);
 	static Ref<CSharpScript> create_for_managed_type(GDMonoClass *p_class, GDMonoClass *p_native);
 	static void initialize_for_managed_type(Ref<CSharpScript> p_script, GDMonoClass *p_class, GDMonoClass *p_native);
+
+	MultiplayerAPI::RPCMode _member_get_rpc_mode(IMonoClassMember *p_member) const;
 
 protected:
 	static void _bind_methods();
@@ -186,6 +191,18 @@ public:
 	MethodInfo get_method_info(const StringName &p_method) const;
 
 	virtual int get_member_line(const StringName &p_member) const;
+
+	virtual Vector<ScriptNetData> get_rpc_methods() const;
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const;
+	virtual StringName get_rpc_method(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const;
+
+	virtual Vector<ScriptNetData> get_rset_properties() const;
+	virtual uint16_t get_rset_property_id(const StringName &p_variable) const;
+	virtual StringName get_rset_property(const uint16_t p_variable_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(const uint16_t p_variable_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const;
 
 #ifdef TOOLS_ENABLED
 	virtual bool is_placeholder_fallback_enabled() const { return placeholder_fallback_enabled; }
@@ -232,8 +249,6 @@ class CSharpInstance : public ScriptInstance {
 
 	void _call_multilevel(MonoObject *p_mono_object, const StringName &p_method, const Variant **p_args, int p_argcount);
 
-	MultiplayerAPI::RPCMode _member_get_rpc_mode(IMonoClassMember *p_member) const;
-
 	void get_properties_state_for_reloading(List<Pair<StringName, Variant> > &r_state);
 
 public:
@@ -265,7 +280,16 @@ public:
 	virtual void refcount_incremented();
 	virtual bool refcount_decremented();
 
+	virtual Vector<ScriptNetData> get_rpc_methods() const;
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const;
+	virtual StringName get_rpc_method(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(const uint16_t p_rpc_method_id) const;
 	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const;
+
+	virtual Vector<ScriptNetData> get_rset_properties() const;
+	virtual uint16_t get_rset_property_id(const StringName &p_variable) const;
+	virtual StringName get_rset_property(const uint16_t p_variable_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(const uint16_t p_variable_id) const;
 	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const;
 
 	virtual void notification(int p_notification);

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -245,6 +245,8 @@ private:
 	Map<StringName, Function> functions;
 	Map<StringName, Variable> variables;
 	Map<StringName, Vector<Argument> > custom_signals;
+	Vector<ScriptNetData> rpc_functions;
+	Vector<ScriptNetData> rpc_variables;
 
 	Map<Object *, VisualScriptInstance *> instances;
 
@@ -362,6 +364,18 @@ public:
 
 	virtual int get_member_line(const StringName &p_member) const;
 
+	virtual Vector<ScriptNetData> get_rpc_methods() const;
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const;
+	virtual StringName get_rpc_method(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const;
+
+	virtual Vector<ScriptNetData> get_rset_properties() const;
+	virtual uint16_t get_rset_property_id(const StringName &p_property) const;
+	virtual StringName get_rset_property(const uint16_t p_rset_property_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const;
+
 #ifdef TOOLS_ENABLED
 	virtual bool are_subnodes_edited() const;
 #endif
@@ -441,7 +455,16 @@ public:
 
 	virtual ScriptLanguage *get_language();
 
+	virtual Vector<ScriptNetData> get_rpc_methods() const;
+	virtual uint16_t get_rpc_method_id(const StringName &p_method) const;
+	virtual StringName get_rpc_method(const uint16_t p_rpc_method_id) const;
+	virtual MultiplayerAPI::RPCMode get_rpc_mode_by_id(const uint16_t p_rpc_method_id) const;
 	virtual MultiplayerAPI::RPCMode get_rpc_mode(const StringName &p_method) const;
+
+	virtual Vector<ScriptNetData> get_rset_properties() const;
+	virtual uint16_t get_rset_property_id(const StringName &p_property) const;
+	virtual StringName get_rset_property(const uint16_t p_rset_property_id) const;
+	virtual MultiplayerAPI::RPCMode get_rset_mode_by_id(const uint16_t p_rpc_method_id) const;
 	virtual MultiplayerAPI::RPCMode get_rset_mode(const StringName &p_variable) const;
 
 	VisualScriptInstance();

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -30,6 +30,8 @@
 
 #include "node.h"
 
+#include <stdint.h>
+
 #include "core/core_string_names.h"
 #include "core/io/resource_loader.h"
 #include "core/message_queue.h"
@@ -498,22 +500,38 @@ bool Node::is_network_master() const {
 
 /***** RPC CONFIG ********/
 
-void Node::rpc_config(const StringName &p_method, MultiplayerAPI::RPCMode p_mode) {
+uint16_t Node::rpc_config(const StringName &p_method, MultiplayerAPI::RPCMode p_mode) {
 
-	if (p_mode == MultiplayerAPI::RPC_MODE_DISABLED) {
-		data.rpc_methods.erase(p_method);
+	uint16_t mid = get_node_rpc_method_id(p_method);
+	if (mid == UINT16_MAX) {
+		// It's new
+		NetData nd;
+		nd.name = p_method;
+		nd.mode = p_mode;
+		data.rpc_methods.push_back(nd);
+		return ((uint16_t)data.rpc_properties.size() - 1) | (1 << 15);
 	} else {
-		data.rpc_methods[p_method] = p_mode;
-	};
+		int c_mid = (~(1 << 15)) & mid;
+		data.rpc_methods.write[c_mid].mode = p_mode;
+		return mid;
+	}
 }
 
-void Node::rset_config(const StringName &p_property, MultiplayerAPI::RPCMode p_mode) {
+uint16_t Node::rset_config(const StringName &p_property, MultiplayerAPI::RPCMode p_mode) {
 
-	if (p_mode == MultiplayerAPI::RPC_MODE_DISABLED) {
-		data.rpc_properties.erase(p_property);
+	uint16_t pid = get_node_rset_property_id(p_property);
+	if (pid == UINT16_MAX) {
+		// It's new
+		NetData nd;
+		nd.name = p_property;
+		nd.mode = p_mode;
+		data.rpc_properties.push_back(nd);
+		return ((uint16_t)data.rpc_properties.size() - 1) | (1 << 15);
 	} else {
-		data.rpc_properties[p_property] = p_mode;
-	};
+		int c_pid = (~(1 << 15)) & pid;
+		data.rpc_properties.write[c_pid].mode = p_mode;
+		return pid;
+	}
 }
 
 /***** RPC FUNCTIONS ********/
@@ -731,12 +749,94 @@ void Node::set_custom_multiplayer(Ref<MultiplayerAPI> p_multiplayer) {
 	multiplayer = p_multiplayer;
 }
 
-const Map<StringName, MultiplayerAPI::RPCMode>::Element *Node::get_node_rpc_mode(const StringName &p_method) {
-	return data.rpc_methods.find(p_method);
+uint16_t Node::get_node_rpc_method_id(const StringName &p_method) const {
+	for (int i = 0; i < data.rpc_methods.size(); i++) {
+		if (data.rpc_methods[i].name == p_method) {
+			// Returns `i` with the high bit set to 1 so we know that this id comes
+			// from the node and not the script.
+			return i | (1 << 15);
+		}
+	}
+	return UINT16_MAX;
 }
 
-const Map<StringName, MultiplayerAPI::RPCMode>::Element *Node::get_node_rset_mode(const StringName &p_property) {
-	return data.rpc_properties.find(p_property);
+StringName Node::get_node_rpc_method(const uint16_t p_rpc_method_id) const {
+	// Make sure this is a node generated ID.
+	if (((1 << 15) & p_rpc_method_id) > 0) {
+		int mid = (~(1 << 15)) & p_rpc_method_id;
+		if (mid < data.rpc_methods.size())
+			return data.rpc_methods[mid].name;
+	}
+	return StringName();
+}
+
+MultiplayerAPI::RPCMode Node::get_node_rpc_mode_by_id(const uint16_t p_rpc_method_id) const {
+	// Make sure this is a node generated ID.
+	if (((1 << 15) & p_rpc_method_id) > 0) {
+		int mid = (~(1 << 15)) & p_rpc_method_id;
+		if (mid < data.rpc_methods.size())
+			return data.rpc_methods[mid].mode;
+	}
+	return MultiplayerAPI::RPC_MODE_DISABLED;
+}
+
+MultiplayerAPI::RPCMode Node::get_node_rpc_mode(const StringName &p_method) const {
+	return get_node_rpc_mode_by_id(get_node_rpc_method_id(p_method));
+}
+
+uint16_t Node::get_node_rset_property_id(const StringName &p_property) const {
+	for (int i = 0; i < data.rpc_properties.size(); i++) {
+		if (data.rpc_properties[i].name == p_property) {
+			// Returns `i` with the high bit set to 1 so we know that this id comes
+			// from the node and not the script.
+			return i | (1 << 15);
+		}
+	}
+	return UINT16_MAX;
+}
+
+StringName Node::get_node_rset_property(const uint16_t p_rset_property_id) const {
+	// Make sure this is a node generated ID.
+	if (((1 << 15) & p_rset_property_id) > 0) {
+		int mid = (~(1 << 15)) & p_rset_property_id;
+		if (mid < data.rpc_properties.size())
+			return data.rpc_properties[mid].name;
+	}
+	return StringName();
+}
+
+MultiplayerAPI::RPCMode Node::get_node_rset_mode_by_id(const uint16_t p_rset_property_id) const {
+	if (((1 << 15) & p_rset_property_id) > 0) {
+		int mid = (~(1 << 15)) & p_rset_property_id;
+		if (mid < data.rpc_properties.size())
+			return data.rpc_properties[mid].mode;
+	}
+	return MultiplayerAPI::RPC_MODE_DISABLED;
+}
+
+MultiplayerAPI::RPCMode Node::get_node_rset_mode(const StringName &p_property) const {
+	return get_node_rset_mode_by_id(get_node_rset_property_id(p_property));
+}
+
+String Node::get_rpc_md5() const {
+	String rpc_list;
+	for (int i = 0; i < data.rpc_methods.size(); i += 1) {
+		rpc_list += String(data.rpc_methods[i].name);
+	}
+	for (int i = 0; i < data.rpc_properties.size(); i += 1) {
+		rpc_list += String(data.rpc_properties[i].name);
+	}
+	if (get_script_instance()) {
+		Vector<ScriptNetData> rpc = get_script_instance()->get_rpc_methods();
+		for (int i = 0; i < rpc.size(); i += 1) {
+			rpc_list += String(rpc[i].name);
+		}
+		rpc = get_script_instance()->get_rset_properties();
+		for (int i = 0; i < rpc.size(); i += 1) {
+			rpc_list += String(rpc[i].name);
+		}
+	}
+	return rpc_list.md5_text();
 }
 
 bool Node::can_process_notification(int p_what) const {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -85,6 +85,11 @@ private:
 		GroupData() { persistent = false; }
 	};
 
+	struct NetData {
+		StringName name;
+		MultiplayerAPI::RPCMode mode;
+	};
+
 	struct Data {
 
 		String filename;
@@ -118,8 +123,8 @@ private:
 		Node *pause_owner;
 
 		int network_master;
-		Map<StringName, MultiplayerAPI::RPCMode> rpc_methods;
-		Map<StringName, MultiplayerAPI::RPCMode> rpc_properties;
+		Vector<NetData> rpc_methods;
+		Vector<NetData> rpc_properties;
 
 		// variables used to properly sort the node when processing, ignored otherwise
 		//should move all the stuff below to bits
@@ -427,8 +432,8 @@ public:
 	int get_network_master() const;
 	bool is_network_master() const;
 
-	void rpc_config(const StringName &p_method, MultiplayerAPI::RPCMode p_mode); // config a local method for RPC
-	void rset_config(const StringName &p_property, MultiplayerAPI::RPCMode p_mode); // config a local property for RPC
+	uint16_t rpc_config(const StringName &p_method, MultiplayerAPI::RPCMode p_mode); // config a local method for RPC
+	uint16_t rset_config(const StringName &p_property, MultiplayerAPI::RPCMode p_mode); // config a local property for RPC
 
 	void rpc(const StringName &p_method, VARIANT_ARG_LIST); //rpc call, honors RPCMode
 	void rpc_unreliable(const StringName &p_method, VARIANT_ARG_LIST); //rpc call, honors RPCMode
@@ -446,8 +451,22 @@ public:
 	Ref<MultiplayerAPI> get_multiplayer() const;
 	Ref<MultiplayerAPI> get_custom_multiplayer() const;
 	void set_custom_multiplayer(Ref<MultiplayerAPI> p_multiplayer);
-	const Map<StringName, MultiplayerAPI::RPCMode>::Element *get_node_rpc_mode(const StringName &p_method);
-	const Map<StringName, MultiplayerAPI::RPCMode>::Element *get_node_rset_mode(const StringName &p_property);
+
+	/// Returns the rpc method ID, otherwise UINT32_MAX
+	uint16_t get_node_rpc_method_id(const StringName &p_method) const;
+	StringName get_node_rpc_method(const uint16_t p_rpc_method_id) const;
+	MultiplayerAPI::RPCMode get_node_rpc_mode_by_id(const uint16_t p_rpc_method_id) const;
+	MultiplayerAPI::RPCMode get_node_rpc_mode(const StringName &p_method) const;
+
+	/// Returns the rpc property ID, otherwise UINT32_MAX
+	uint16_t get_node_rset_property_id(const StringName &p_property) const;
+	StringName get_node_rset_property(const uint16_t p_rset_property_id) const;
+	MultiplayerAPI::RPCMode get_node_rset_mode_by_id(const uint16_t p_rpc_method_id) const;
+	MultiplayerAPI::RPCMode get_node_rset_mode(const StringName &p_property) const;
+
+	/// Can be used to check if the rpc methods and the rset properties are the
+	/// same across the peers.
+	String get_rpc_md5() const;
 
 	Node();
 	~Node();


### PR DESCRIPTION
- Now is sent the method ID rather the full function name.
- The passed IDs (Node and Method) are compressed so to use less possible space.
- The variant (INT and BOOL) is now encoded and compressed so to use much less data.
- Optimized RPCMode retrieval for GDScript functions.

This work has been kindly sponsored by IMVU.