### PR TITLE
Mono/C#: Fix _update_exports possible crash with Reference types

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2408,6 +2408,9 @@ bool CSharpScript::_update_exports() {
 			top = top->get_parent_class();
 		}
 
+		// Need to check this here, before disposal
+		bool base_ref = Object::cast_to<Reference>(tmp_native) != NULL;
+
 		// Dispose the temporary managed instance
 
 		MonoException *exc = NULL;
@@ -2421,7 +2424,7 @@ bool CSharpScript::_update_exports() {
 		MonoGCHandle::free_handle(tmp_pinned_gchandle);
 		tmp_object = NULL;
 
-		if (tmp_native && !Object::cast_to<Reference>(tmp_native)) {
+		if (tmp_native && !base_ref) {
 			Node *node = Object::cast_to<Node>(tmp_native);
 			if (node && node->is_inside_tree()) {
 				ERR_PRINTS("Temporary instance was added to the scene tree.");


### PR DESCRIPTION
The code was attempting to dynamic cast the native instance to Reference after the managed instance was disposed. As the managed instance acts as a Ref, the native instance was freed during that disposal. This made the dynamic cast fail and we attempted to memdelete a second time.

The fix is to make the dynamic cast before disposal.

Fixes #35259
