### PR TITLE
Improve InstancePlaceholder documentation and expose instance_path property

### DIFF
--- a/doc/classes/InstancePlaceholder.xml
+++ b/doc/classes/InstancePlaceholder.xml
@@ -18,14 +18,7 @@
 			<argument index="1" name="custom_scene" type="PackedScene" default="null">
 			</argument>
 			<description>
-				Not thread-safe. Use [method Object.call_deferred] if calling from a thread.
-			</description>
-		</method>
-		<method name="get_instance_path" qualifiers="const">
-			<return type="String">
-			</return>
-			<description>
-				Gets the path to the [PackedScene] resource file that is loaded by default when calling [method create_instance]. Not thread-safe. Use [method Object.call_deferred] if calling from a thread.
+				Returns an instance of the scene handed as an argument, or the scene at [member instance_path] if no argument is given. As for all resources, the scene is loaded only if it's not loaded already. By manually loading the scene beforehand, delays caused by this function can be avoided. If [code]replace[/code] is [code]true[/code], replaces this placeholder by the created instance.
 			</description>
 		</method>
 		<method name="get_stored_values">
@@ -34,9 +27,15 @@
 			<argument index="0" name="with_order" type="bool" default="false">
 			</argument>
 			<description>
+				Returns the changed properties and their values as key/value pairs. If [code]with_order[/code] is true, the dictionary will have an array with the property names in the order of modification under the key [code].order[/code].
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="instance_path" type="String" setter="set_instance_path" getter="get_instance_path">
+			The path to the [PackedScene] resource file that is loaded by default when calling [method create_instance]. Not thread-safe. Use [method Object.call_deferred] if calling from a thread.
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/scene/main/instance_placeholder.cpp
+++ b/scene/main/instance_placeholder.cpp
@@ -132,6 +132,8 @@ void InstancePlaceholder::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_stored_values", "with_order"), &InstancePlaceholder::get_stored_values, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("create_instance", "replace", "custom_scene"), &InstancePlaceholder::create_instance, DEFVAL(false), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("get_instance_path"), &InstancePlaceholder::get_instance_path);
+	ClassDB::bind_method(D_METHOD("set_instance_path"), &InstancePlaceholder::set_instance_path);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "instance_path"), "set_instance_path", "get_instance_path");
 }
 
 InstancePlaceholder::InstancePlaceholder() {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -279,7 +279,7 @@ void register_scene_types() {
 	ClassDB::register_class<Object>();
 
 	ClassDB::register_class<Node>();
-	ClassDB::register_virtual_class<InstancePlaceholder>();
+	ClassDB::register_class<InstancePlaceholder>();
 
 	ClassDB::register_virtual_class<Viewport>();
 	ClassDB::register_class<SubViewport>();


### PR DESCRIPTION
Some of this may not make any sense because I don't know if InstancePlaceholders are meant to be used per script. If not, then making `instance_path` a property is pointless.