### PR TITLE
Make "Keep screen on" work on Linux

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Configure dependencies
         run: |
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
-            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
+            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm
 
       # Upload cache on completion and check it out now
       - name: Load .scons_cache directory
@@ -111,7 +111,7 @@ jobs:
       - name: Configure dependencies
         run: |
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
-            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm \
+            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm \
             xvfb wget unzip
 
       # Upload cache on completion and check it out now
@@ -204,7 +204,7 @@ jobs:
       - name: Configure dependencies
         run: |
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
-            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
+            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm
 
       # Upload cache on completion and check it out now
       - name: Load .scons_cache directory

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -9,6 +9,7 @@ common_linuxbsd = [
     "crash_handler_linuxbsd.cpp",
     "os_linuxbsd.cpp",
     "joypad_linux.cpp",
+    "freedesktop_screensaver.cpp",
 ]
 
 if "x11" in env and env["x11"]:

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -72,6 +72,7 @@ def get_opts():
         BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN)", False),
         BoolVariable("use_msan", "Use LLVM compiler memory sanitizer (MSAN)", False),
         BoolVariable("pulseaudio", "Detect and use PulseAudio", True),
+        BoolVariable("dbus", "Detect and use D-Bus to handle screensaver", True),
         BoolVariable("udev", "Use udev for gamepad connection callbacks", True),
         BoolVariable("x11", "Enable X11 display", True),
         BoolVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", True),
@@ -346,6 +347,14 @@ def configure(env):
             env.ParseConfig("pkg-config --cflags libpulse")
         else:
             print("PulseAudio development libraries not found, disabling driver")
+
+    if env["dbus"]:
+        if os.system("pkg-config --exists dbus-1") == 0:  # 0 means found
+            print("Enabling D-Bus")
+            env.Append(CPPDEFINES=["DBUS_ENABLED"])
+            env.ParseConfig("pkg-config --cflags --libs dbus-1")
+        else:
+            print("D-Bus development libraries not found, disabling dependent features")
 
     if platform.system() == "Linux":
         env.Append(CPPDEFINES=["JOYDEV_ENABLED"])

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -55,6 +55,10 @@
 #include "platform/linuxbsd/vulkan_context_x11.h"
 #endif
 
+#if defined(DBUS_ENABLED)
+#include "freedesktop_screensaver.h"
+#endif
+
 #include <X11/Xcursor/Xcursor.h>
 #include <X11/Xlib.h>
 #include <X11/extensions/XInput2.h>
@@ -101,6 +105,11 @@ class DisplayServerX11 : public DisplayServer {
 #if defined(VULKAN_ENABLED)
 	VulkanContextX11 *context_vulkan;
 	RenderingDeviceVulkan *rendering_device_vulkan;
+#endif
+
+#if defined(DBUS_ENABLED)
+	FreeDesktopScreenSaver *screensaver;
+	bool keep_screen_on = false;
 #endif
 
 	struct WindowData {
@@ -290,6 +299,11 @@ public:
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
+
+#if defined(DBUS_ENABLED)
+	virtual void screen_set_keep_on(bool p_enable);
+	virtual bool screen_is_kept_on() const;
+#endif
 
 	virtual Vector<DisplayServer::WindowID> get_window_list() const;
 

--- a/platform/linuxbsd/freedesktop_screensaver.cpp
+++ b/platform/linuxbsd/freedesktop_screensaver.cpp
@@ -1,0 +1,124 @@
+/*************************************************************************/
+/*  freedesktop_screensaver.cpp                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "freedesktop_screensaver.h"
+
+#ifdef DBUS_ENABLED
+
+#include "core/config/project_settings.h"
+
+#include <dbus/dbus.h>
+
+#define BUS_OBJECT_NAME "org.freedesktop.ScreenSaver"
+#define BUS_OBJECT_PATH "/org/freedesktop/ScreenSaver"
+#define BUS_INTERFACE "org.freedesktop.ScreenSaver"
+
+void FreeDesktopScreenSaver::inhibit() {
+	if (unsupported) {
+		return;
+	}
+
+	DBusError error;
+	dbus_error_init(&error);
+
+	DBusConnection *bus = dbus_bus_get(DBUS_BUS_SESSION, &error);
+	if (dbus_error_is_set(&error)) {
+		unsupported = true;
+		return;
+	}
+
+	String app_name_string = ProjectSettings::get_singleton()->get("application/config/name");
+	const char *app_name = app_name_string.is_empty() ? "Godot Engine" : app_name_string.utf8().get_data();
+
+	const char *reason = "Running Godot Engine project";
+
+	DBusMessage *message = dbus_message_new_method_call(
+			BUS_OBJECT_NAME, BUS_OBJECT_PATH, BUS_INTERFACE,
+			"Inhibit");
+	dbus_message_append_args(
+			message,
+			DBUS_TYPE_STRING, &app_name,
+			DBUS_TYPE_STRING, &reason,
+			DBUS_TYPE_INVALID);
+
+	DBusMessage *reply = dbus_connection_send_with_reply_and_block(bus, message, 50, &error);
+	dbus_message_unref(message);
+	if (dbus_error_is_set(&error)) {
+		dbus_connection_unref(bus);
+		unsupported = false;
+		return;
+	}
+
+	DBusMessageIter reply_iter;
+	dbus_message_iter_init(reply, &reply_iter);
+	dbus_message_iter_get_basic(&reply_iter, &cookie);
+	print_verbose("FreeDesktopScreenSaver: Acquired screensaver inhibition cookie: " + uitos(cookie));
+
+	dbus_message_unref(reply);
+	dbus_connection_unref(bus);
+}
+
+void FreeDesktopScreenSaver::uninhibit() {
+	if (unsupported) {
+		return;
+	}
+
+	DBusError error;
+	dbus_error_init(&error);
+
+	DBusConnection *bus = dbus_bus_get(DBUS_BUS_SESSION, &error);
+	if (dbus_error_is_set(&error)) {
+		unsupported = true;
+		return;
+	}
+
+	DBusMessage *message = dbus_message_new_method_call(
+			BUS_OBJECT_NAME, BUS_OBJECT_PATH, BUS_INTERFACE,
+			"UnInhibit");
+	dbus_message_append_args(
+			message,
+			DBUS_TYPE_UINT32, &cookie,
+			DBUS_TYPE_INVALID);
+
+	DBusMessage *reply = dbus_connection_send_with_reply_and_block(bus, message, 50, &error);
+	if (dbus_error_is_set(&error)) {
+		dbus_connection_unref(bus);
+		unsupported = true;
+		return;
+	}
+
+	print_verbose("FreeDesktopScreenSaver: Released screensaver inhibition cookie: " + uitos(cookie));
+
+	dbus_message_unref(message);
+	dbus_message_unref(reply);
+	dbus_connection_unref(bus);
+}
+
+#endif // DBUS_ENABLED

--- a/platform/linuxbsd/freedesktop_screensaver.h
+++ b/platform/linuxbsd/freedesktop_screensaver.h
@@ -1,0 +1,47 @@
+/*************************************************************************/
+/*  freedesktop_screensaver.h                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifdef DBUS_ENABLED
+
+#include <dbus/dbus.h>
+#include <stdint.h>
+
+class FreeDesktopScreenSaver {
+private:
+	uint32_t cookie = 0;
+	bool unsupported = false;
+
+public:
+	FreeDesktopScreenSaver() {}
+	void inhibit();
+	void uninhibit();
+};
+
+#endif // DBUS_ENABLED


### PR DESCRIPTION
This pull request adds [`keep_screen_on`](https://docs.godotengine.org/en/latest/classes/class_os.html#class-os-property-keep-screen-on) support for Linux through the [`org.freedesktop.ScreenSaver` D-Bus service](https://people.freedesktop.org/~hadess/idle-inhibition-spec/re01.html) which is supported by most desktop environments as a way to keep the screen from turning off after a certain period of inactivity.

This is my first time contributing to Godot and the first time implementing something non-trivial in C++, so here are some things I'm not sure about yet:

1. **Is it a good idea to make Godot dependent on D-Bus?**
  I've added a [`DBUS_ENABLE` define](https://github.com/shroudedcode/godot/blob/b73812dade3e44ffcb6eeff43a2250656e813465/platform/x11/detect.py#L306-L312) similar to `PULSEAUDIO_ENABLED`, so that Godot can be built without D-Bus development libraries but games using the regular Godot build will still crash if D-Bus isn't installed. All the desktop distributions I know ship with D-Bus, but can we assume that this is the case for all users?

2. **Is my "error handling" sufficient?**
  Because some desktop environments might not have implemented the `org.freedesktop.ScreenSaver` service, I added some basic error handling (if you can call it that) to disable the feature and do nothing on future calls if a D-Bus interaction fails. Is that enough?

3. **Am I doing anything horribly wrong?**
  As I said, I'm just starting out with C++, so I might have messed up some really basic things. If that's the case, please let me know!

I'm happy to hear any kind of feedback on this PR.

*Fixes #5073*