### PR TITLE
Fixes crash in Spatial::notification

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -125,6 +125,7 @@ void Spatial::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
+			ERR_FAIL_COND(!get_tree());
 
 			Node *p = get_parent();
 			if (p)


### PR DESCRIPTION
This fixes #29766. (The original Object::notification crash has been fixed by #29980, but the new reproduction project crashes in Spatial::notification.)

`NOTIFICATION_ENTER_TREE` needs the `get_tree()` check because users can always send notifications manually. The reproduction project uses a loop to send notifications from 0 to 1500: `NOTIFICATION_PREDELETE` (2) is first sent, nullify the tree, and then `NOTIFICATION_ENTER_TREE` (10) is sent.