### PR TITLE
Add warning for radiance_size

### DIFF
--- a/doc/classes/Sky.xml
+++ b/doc/classes/Sky.xml
@@ -14,6 +14,7 @@
 		<member name="radiance_size" type="int" setter="set_radiance_size" getter="get_radiance_size" enum="Sky.RadianceSize" default="2">
 			The [Sky]'s radiance map size. The higher the radiance map size, the more detailed the lighting from the [Sky] will be.
 			See [enum RadianceSize] constants for values.
+			[b]Note:[/b] Some hardware will have trouble with higher radiance sizes, especially [constant RADIANCE_SIZE_512] and above. Only use such high values on high-end hardware.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Adds a warning about using large radiance sizes on lower/mid end hardware.