### PR TITLE
Add project setting for max irradiance size

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -901,6 +901,10 @@
 		</member>
 		<member name="rendering/quality/reflections/high_quality_ggx.mobile" type="bool" setter="" getter="" default="false">
 		</member>
+		<member name="rendering/quality/reflections/irradiance_max_size" type="int" setter="" getter="" default="128">
+			Limits the size of the irradiance map which is normally determined by [member Sky.radiance_size]. A higher size results in a higher quality irradiance map similarly to [member rendering/quality/reflections/high_quality_ggx]. Use a higher value when using high-frequency HDRI maps, otherwise keep this as low as possible.
+			[b]Note:[/b] Low and mid range hardware do not support complex irradiance maps well and may crash if this is set too high.
+		</member>
 		<member name="rendering/quality/reflections/texture_array_reflections" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], uses texture arrays instead of mipmaps for reflection probes and panorama backgrounds (sky). This reduces jitter noise on reflections, but costs more performance and memory.
 		</member>

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2397,6 +2397,8 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/quality/reflections/texture_array_reflections.mobile", false);
 	GLOBAL_DEF("rendering/quality/reflections/high_quality_ggx", true);
 	GLOBAL_DEF("rendering/quality/reflections/high_quality_ggx.mobile", false);
+	GLOBAL_DEF("rendering/quality/reflections/irradiance_max_size", 128);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/reflections/irradiance_max_size", PropertyInfo(Variant::INT, "rendering/quality/reflections/irradiance_max_size", PROPERTY_HINT_RANGE, "32,2048"));
 
 	GLOBAL_DEF("rendering/quality/shading/force_vertex_shading", false);
 	GLOBAL_DEF("rendering/quality/shading/force_vertex_shading.mobile", true);


### PR DESCRIPTION
This places a cap on the size of the irradiance map. I found that most of the delay in radiance map generation was caused by generating the irradiance map. However, for most skies, the irradiance map needs few samples (and thus a small size). We were generating complex irradiance maps only because some high-frequency HDRI maps need them. 

This PR restricts the size of the irradiance map. Effectively placing a cap on the number of samples taken, it should greatly increase the speed of radiance map generation and allow us to maintain the quality of irradiance maps for most HDRIs, when users need to improve quality for high-frequency maps, they can manually adjust the limit. 

I wanted to add docs for it, but when I run --doctool I get the following error:
```
ERROR: CryptoMbedTLS::load_default_certificates: Condition ' default_certs != 0 ' is true.
   At: modules\mbedtls\crypto_mbedtls.cpp:201
```

@RodZill4 Can you test this out? I think it may be enough to solve https://github.com/godotengine/godot/issues/35552