### PR TITLE
Workaround negative delta by clamping it to zero

### DIFF
--- a/main/main_timer_sync.cpp
+++ b/main/main_timer_sync.cpp
@@ -182,6 +182,9 @@ MainFrameTime MainTimerSync::advance_checked(float p_frame_slice, int p_iteratio
 	// i.e. the time in seconds taken by a physics tick
 	ret.interpolation_fraction = time_accum / p_frame_slice;
 
+	// workaround for when time_deficit makes idle_step negative
+	ret.idle_step = MAX(ret.idle_step, 0.0);
+
 	return ret;
 }
 

--- a/main/main_timer_sync.cpp
+++ b/main/main_timer_sync.cpp
@@ -147,8 +147,7 @@ MainFrameTime MainTimerSync::advance_checked(float p_frame_slice, int p_iteratio
 		p_idle_step = 1.0 / fixed_fps;
 
 	// compensate for last deficit
-	// Disabled: Causes negative delta times during lag spikes
-	//p_idle_step += time_deficit;
+	p_idle_step += time_deficit;
 
 	MainFrameTime ret = advance_core(p_frame_slice, p_iterations_per_second, p_idle_step);
 
@@ -177,8 +176,7 @@ MainFrameTime MainTimerSync::advance_checked(float p_frame_slice, int p_iteratio
 	time_accum = ret.idle_step - idle_minus_accum;
 
 	// track deficit
-	// Disabled: Causes negative delta times during lag spikes
-	//time_deficit = p_idle_step - ret.idle_step;
+	time_deficit = p_idle_step - ret.idle_step;
 
 	// p_frame_slice is 1.0 / iterations_per_sec
 	// i.e. the time in seconds taken by a physics tick
@@ -199,8 +197,7 @@ MainTimerSync::MainTimerSync() :
 		last_cpu_ticks_usec(0),
 		current_cpu_ticks_usec(0),
 		time_accum(0),
-		// Disabled: Causes negative delta times during lag spikes
-		//time_deficit(0),
+		time_deficit(0),
 		fixed_fps(0) {
 	for (int i = CONTROL_STEPS - 1; i >= 0; --i) {
 		typical_physics_steps[i] = i;

--- a/main/main_timer_sync.cpp
+++ b/main/main_timer_sync.cpp
@@ -147,7 +147,8 @@ MainFrameTime MainTimerSync::advance_checked(float p_frame_slice, int p_iteratio
 		p_idle_step = 1.0 / fixed_fps;
 
 	// compensate for last deficit
-	p_idle_step += time_deficit;
+	// Disabled: Causes negative delta times during lag spikes
+	//p_idle_step += time_deficit;
 
 	MainFrameTime ret = advance_core(p_frame_slice, p_iterations_per_second, p_idle_step);
 
@@ -176,7 +177,8 @@ MainFrameTime MainTimerSync::advance_checked(float p_frame_slice, int p_iteratio
 	time_accum = ret.idle_step - idle_minus_accum;
 
 	// track deficit
-	time_deficit = p_idle_step - ret.idle_step;
+	// Disabled: Causes negative delta times during lag spikes
+	//time_deficit = p_idle_step - ret.idle_step;
 
 	// p_frame_slice is 1.0 / iterations_per_sec
 	// i.e. the time in seconds taken by a physics tick
@@ -197,7 +199,8 @@ MainTimerSync::MainTimerSync() :
 		last_cpu_ticks_usec(0),
 		current_cpu_ticks_usec(0),
 		time_accum(0),
-		time_deficit(0),
+		// Disabled: Causes negative delta times during lag spikes
+		//time_deficit(0),
 		fixed_fps(0) {
 	for (int i = CONTROL_STEPS - 1; i >= 0; --i) {
 		typical_physics_steps[i] = i;

--- a/main/main_timer_sync.cpp
+++ b/main/main_timer_sync.cpp
@@ -141,10 +141,14 @@ MainFrameTime MainTimerSync::advance_core(float p_frame_slice, int p_iterations_
 	return ret;
 }
 
-// calls advance_core, forces fixed fps to have a consistent idle step among other things
+// calls advance_core, keeps track of deficit it adds to animaption_step, make sure the deficit sum stays close to zero
 MainFrameTime MainTimerSync::advance_checked(float p_frame_slice, int p_iterations_per_second, float p_idle_step) {
 	if (fixed_fps != -1)
 		p_idle_step = 1.0 / fixed_fps;
+
+	// compensate for last deficit
+	// Disabled: Causes negative delta times during lag spikes
+	//p_idle_step += time_deficit;
 
 	MainFrameTime ret = advance_core(p_frame_slice, p_iterations_per_second, p_idle_step);
 
@@ -162,11 +166,19 @@ MainFrameTime MainTimerSync::advance_checked(float p_frame_slice, int p_iteratio
 		}
 	}
 
-	// make sure time_accum is between 0 and p_frame_slice for consistency between physics and idle
+	// second clamping: keep abs(time_deficit) < jitter_fix * frame_slise
+	float max_clock_deviation = get_physics_jitter_fix() * p_frame_slice;
+	ret.clamp_idle(p_idle_step - max_clock_deviation, p_idle_step + max_clock_deviation);
+
+	// last clamping: make sure time_accum is between 0 and p_frame_slice for consistency between physics and idle
 	ret.clamp_idle(idle_minus_accum, idle_minus_accum + p_frame_slice);
 
 	// restore time_accum
 	time_accum = ret.idle_step - idle_minus_accum;
+
+	// track deficit
+	// Disabled: Causes negative delta times during lag spikes
+	//time_deficit = p_idle_step - ret.idle_step;
 
 	// p_frame_slice is 1.0 / iterations_per_sec
 	// i.e. the time in seconds taken by a physics tick
@@ -187,6 +199,8 @@ MainTimerSync::MainTimerSync() :
 		last_cpu_ticks_usec(0),
 		current_cpu_ticks_usec(0),
 		time_accum(0),
+		// Disabled: Causes negative delta times during lag spikes
+		//time_deficit(0),
 		fixed_fps(0) {
 	for (int i = CONTROL_STEPS - 1; i >= 0; --i) {
 		typical_physics_steps[i] = i;

--- a/main/main_timer_sync.h
+++ b/main/main_timer_sync.h
@@ -50,7 +50,8 @@ class MainTimerSync {
 	float time_accum;
 
 	// current difference between wall clock time and reported sum of idle_steps
-	float time_deficit;
+	// Disabled: Causes negative delta times during lag spikes
+	//float time_deficit;
 
 	// number of frames back for keeping accumulated physics steps roughly constant.
 	// value of 12 chosen because that is what is required to make 144 Hz monitors

--- a/main/main_timer_sync.h
+++ b/main/main_timer_sync.h
@@ -50,8 +50,7 @@ class MainTimerSync {
 	float time_accum;
 
 	// current difference between wall clock time and reported sum of idle_steps
-	// Disabled: Causes negative delta times during lag spikes
-	//float time_deficit;
+	float time_deficit;
 
 	// number of frames back for keeping accumulated physics steps roughly constant.
 	// value of 12 chosen because that is what is required to make 144 Hz monitors

--- a/main/main_timer_sync.h
+++ b/main/main_timer_sync.h
@@ -49,10 +49,6 @@ class MainTimerSync {
 	// logical game time since last physics timestep
 	float time_accum;
 
-	// current difference between wall clock time and reported sum of idle_steps
-	// Disabled: Causes negative delta times during lag spikes
-	//float time_deficit;
-
 	// number of frames back for keeping accumulated physics steps roughly constant.
 	// value of 12 chosen because that is what is required to make 144 Hz monitors
 	// behave well with 60 Hz physics updates. The only worse commonly available refresh
@@ -80,7 +76,7 @@ protected:
 	// advance physics clock by p_idle_step, return appropriate number of steps to simulate
 	MainFrameTime advance_core(float p_frame_slice, int p_iterations_per_second, float p_idle_step);
 
-	// calls advance_core, keeps track of deficit it adds to animaption_step, make sure the deficit sum stays close to zero
+	// calls advance_core, forces fixed fps to have a consistent idle step among other things
 	MainFrameTime advance_checked(float p_frame_slice, int p_iterations_per_second, float p_idle_step);
 
 	// determine wall clock step since last iteration

--- a/main/main_timer_sync.h
+++ b/main/main_timer_sync.h
@@ -49,6 +49,10 @@ class MainTimerSync {
 	// logical game time since last physics timestep
 	float time_accum;
 
+	// current difference between wall clock time and reported sum of idle_steps
+	// Disabled: Causes negative delta times during lag spikes
+	//float time_deficit;
+
 	// number of frames back for keeping accumulated physics steps roughly constant.
 	// value of 12 chosen because that is what is required to make 144 Hz monitors
 	// behave well with 60 Hz physics updates. The only worse commonly available refresh
@@ -76,7 +80,7 @@ protected:
 	// advance physics clock by p_idle_step, return appropriate number of steps to simulate
 	MainFrameTime advance_core(float p_frame_slice, int p_iterations_per_second, float p_idle_step);
 
-	// calls advance_core, forces fixed fps to have a consistent idle step among other things
+	// calls advance_core, keeps track of deficit it adds to animaption_step, make sure the deficit sum stays close to zero
 	MainFrameTime advance_checked(float p_frame_slice, int p_iterations_per_second, float p_idle_step);
 
 	// determine wall clock step since last iteration


### PR DESCRIPTION
**EDIT: Go to** #35617 **for improved changes**

Workaround for #26887 

CC @reduz, not sure what time_deficit is supposed to do. (Is it related to issues with the time diverging?)

Edit: Good project for reproducing this bug, it causes a lag spike about once every 4 ticks. I haven't had any problems after making this change.  
[TimeBug.zip](https://github.com/godotengine/godot/files/4112856/TimeBug.zip)
