### PR TITLE
Split the Always Show Grid checkbox into 3 options inside sub menu.

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -112,7 +112,11 @@ private:
 		SNAP_RELATIVE,
 		SNAP_CONFIGURE,
 		SNAP_USE_PIXEL,
-		SHOW_GRID,
+		GRID_VISIBILITY_MENU,
+		GRID_ALWAYS_SHOW,
+		GRID_SHOW_WHEN_SNAPPING_TO_GRID,
+		GRID_ALWAYS_HIDE,
+		GRID_TOGGLE,
 		SHOW_HELPERS,
 		SHOW_RULERS,
 		SHOW_GUIDES,
@@ -243,7 +247,7 @@ private:
 	VBoxContainer *info_overlay;
 
 	Transform2D transform;
-	bool show_grid;
+	int grid_visibility_op;
 	bool show_rulers;
 	bool show_guides;
 	bool show_origin;
@@ -371,6 +375,7 @@ private:
 	MenuButton *skeleton_menu;
 	ToolButton *override_camera_button;
 	MenuButton *view_menu;
+	PopupMenu *grid_visibility_menu;
 	HBoxContainer *animation_hb;
 	MenuButton *animation_menu;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18746022/73128743-ae58b880-3fb2-11ea-98ab-53a769a22ce7.png)

This splits the Always Show Grid checkbox into 3 options:

- Show
- Show When Snapping To Grid
- Hide

Toggle Grid hides the grid when it's visible, when it's invisible it sets the visibility to Show When Grid Snapping, if grid snapping is enabled and Show, when grid snapping is disabled.

This allows disabling the 2D Grid when grid snapping is enabled, fixes #34386.