### PR TITLE
Improve the editor export template downloader

### DIFF
--- a/editor/export_template_manager.h
+++ b/editor/export_template_manager.h
@@ -43,6 +43,8 @@ class ExportTemplateVersion;
 class ExportTemplateManager : public ConfirmationDialog {
 	GDCLASS(ExportTemplateManager, ConfirmationDialog);
 
+	ScrollContainer *sc;
+	Label *template_list_help;
 	AcceptDialog *template_downloader;
 	VBoxContainer *template_list;
 	Label *template_list_state;


### PR DESCRIPTION
- Begin downloading as soon as the list of mirrors is fetched if only one mirror is available.
- Only show the help text if there's more than one mirror available.
- Only show the progress bar once the download has started.
- Hide the list of mirrors and the help text once the download has started.
- Make the window slightly shorter due to the low number of mirrors available.

PS: To test this locally, you need to change `version.py`'s `status` line to `rc3` then recompile.