### PR TITLE
Updates minimum size on VideoPlayer::set_stream

### DIFF
--- a/scene/gui/video_player.cpp
+++ b/scene/gui/video_player.cpp
@@ -249,6 +249,10 @@ void VideoPlayer::set_stream(const Ref<VideoStream> &p_stream) {
 	}
 
 	update();
+
+	if (!expand) {
+		minimum_size_changed();
+	}
 };
 
 Ref<VideoStream> VideoPlayer::get_stream() const {


### PR DESCRIPTION
When `expand` is false, the minimum size of VideoPlayer is equal to the stream texture's size.