### PR TITLE
Fix crash when exporting improperly configured project.

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1495,17 +1495,19 @@ public:
 	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) {
 
 		ERR_FAIL_INDEX_V(p_device, devices.size(), ERR_INVALID_PARAMETER);
+
+		String can_export_error;
+		bool can_export_missing_templates;
+		if (!can_export(p_preset, can_export_error, can_export_missing_templates)) {
+			EditorNode::add_io_error(can_export_error);
+			return ERR_UNCONFIGURED;
+		}
+
 		device_lock->lock();
 
 		EditorProgress ep("run", "Running on " + devices[p_device].name, 3);
 
 		String adb = EditorSettings::get_singleton()->get("export/android/adb");
-		if (adb == "") {
-
-			EditorNode::add_io_error("ADB executable not configured in settings, can't run.");
-			device_lock->unlock();
-			return ERR_UNCONFIGURED;
-		}
 
 		// Export_temp APK.
 		if (ep.step("Exporting APK", 0)) {


### PR DESCRIPTION
Crash call stack:
```
Thread 1 "godot.x11.tools" received signal SIGSEGV, Segmentation fault.
0x000000000287dafa in EditorExportPlatformAndroid::_update_custom_build_project (this=0x7d65e70) at platform/android/export/export.cpp:1954
1954				f->store_string(new_file);

EditorExportPlatformAndroid::_update_custom_build_project(EditorExportPlatformAndroid * const this) (/home/mark/projects/godot/platform/android/export/export.cpp:1954)
EditorExportPlatformAndroid::export_project(EditorExportPlatformAndroid * const this, const Ref<EditorExportPreset> & p_preset, bool p_debug, const String & p_path, int p_flags) (/home/mark/projects/godot/platform/android/export/export.cpp:2062)
EditorExportPlatformAndroid::run(EditorExportPlatformAndroid * const this, const Ref<EditorExportPreset> & p_preset, int p_device, int p_debug_flags) (/home/mark/projects/godot/platform/android/export/export.cpp:1534)
EditorRunNative::_run_native(EditorRunNative * const this, int p_idx, int p_platform) (/home/mark/projects/godot/editor/editor_run_native.cpp:148)
MethodBind2<int, int>::call(MethodBind2<int, int> * const this, Object * p_object, const Variant ** p_args, int p_arg_count, Variant::CallError & r_error) (/home/mark/projects/godot/core/method_bind.gen.inc:1523)
Object::call(Object * const this, const StringName & p_method, const Variant ** p_args, int p_argcount, Variant::CallError & r_error) (/home/mark/projects/godot/core/object.cpp:921)
Object::emit_signal(Object * const this, const StringName & p_name, const Variant ** p_args, int p_argcount) (/home/mark/projects/godot/core/object.cpp:1217)
Object::emit_signal(Object * const this, const StringName & p_name, const Variant & p_arg1, const Variant & p_arg2, const Variant & p_arg3, const Variant & p_arg4, const Variant & p_arg5) (/home/mark/projects/godot/core/object.cpp:1274)
BaseButton::_pressed(BaseButton * const this) (/home/mark/projects/godot/scene/gui/base_button.cpp:135)
BaseButton::on_action_event(BaseButton * const this, Ref<InputEvent> p_event) (/home/mark/projects/godot/scene/gui/base_button.cpp:165)
BaseButton::_gui_input(BaseButton * const this, Ref<InputEvent> p_event) (/home/mark/projects/godot/scene/gui/base_button.cpp:64)
MenuButton::_gui_input(MenuButton * const this, Ref<InputEvent> p_event) (/home/mark/projects/godot/scene/gui/menu_button.cpp:67)
MethodBind1<Ref<InputEvent> >::call(MethodBind1<Ref<InputEvent> > * const this, Object * p_object, const Variant ** p_args, int p_arg_count, Variant::CallError & r_error) (/home/mark/projects/godot/core/method_bind.gen.inc:775)
Object::call_multilevel(Object * const this, const StringName & p_method, const Variant ** p_args, int p_argcount) (/home/mark/projects/godot/core/object.cpp:763)
Object::call_multilevel(Object * const this, const StringName & p_name, const Variant & p_arg1, const Variant & p_arg2, const Variant & p_arg3, const Variant & p_arg4, const Variant & p_arg5) (/home/mark/projects/godot/core/object.cpp:863)
Viewport::_gui_call_input(Viewport * const this, Control * p_control, const Ref<InputEvent> & p_input) (/home/mark/projects/godot/scene/main/viewport.cpp:1669)
Viewport::_gui_input_event(Viewport * const this, Ref<InputEvent> p_event) (/home/mark/projects/godot/scene/main/viewport.cpp:1979)
Viewport::input(Viewport * const this, const Ref<InputEvent> & p_event) (/home/mark/projects/godot/scene/main/viewport.cpp:2825)
Viewport::_vp_input(Viewport * const this, const Ref<InputEvent> & p_ev) (/home/mark/projects/godot/scene/main/viewport.cpp:1446)
MethodBind1<Ref<InputEvent> const&>::call(MethodBind1<Ref<InputEvent> const&> * const this, Object * p_object, const Variant ** p_args, int p_arg_count, Variant::CallError & r_error) (/home/mark/projects/godot/core/method_bind.gen.inc:775)
```

Also surface error message if can't export:
![image](https://user-images.githubusercontent.com/3414588/73130370-139fbe80-4032-11ea-83de-030c9747764e.png)