### PR TITLE
Add a Bash completion script for the Godot editor

### DIFF
--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# Bash completion for the Godot editor
+# To use it, install this file in `/etc/bash_completion.d` then restart your shell.
+# You can also `source` this file directly in your shell startup file.
+#
+# Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.
+# Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+_complete_godot_options() {
+  # Since Bash doesn't support option descriptions in autocompletion,
+  # only display long options to be more descriptive.
+  # shellcheck disable=SC2207
+  COMPREPLY=($(compgen -W " \
+--help
+--version
+--verbose
+--quiet
+--editor
+--project-manager
+--quit
+--language
+--path
+--upwards
+--main-pack
+--render-thread
+--remote-fs
+--remote-fs-password
+--audio-driver
+--video-driver
+--fullscreen
+--maximized
+--windowed
+--always-on-top
+--resolution
+--position
+--low-dpi
+--no-window
+--enable-vsync-via-compositor
+--disable-vsync-via-compositor
+--debug
+--breakpoints
+--profiling
+--remote-debug
+--debug-collisions
+--debug-navigation
+--frame-delay
+--time-scale
+--disable-render-loop
+--disable-crash-handler
+--fixed-fps
+--print-fps
+--script
+--check-only
+--export
+--export-debug
+--export-pack
+--doctool
+--no-docbase
+--build-solutions
+--gdnative-generate-json-api
+--test
+" -- "$1"))
+}
+
+_complete_godot_bash() {
+  local cur="${COMP_WORDS[$COMP_CWORD]}" prev
+
+  # Complete options or the positional argument.
+  if [[ $cur == -* ]]; then
+    _complete_godot_options "$cur"
+  else
+    local IFS=$'\n\t'
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -f -X "!*.@(scn|tscn|escn|godot)" -- "$cur"))
+  fi
+
+  # If the array is accessed out of bounds (which will happen for the first argument),
+  # `$prev` will be an empty string and won't match any of the conditions below.
+  prev="${COMP_WORDS[$((COMP_CWORD-1))]}"
+
+  # Complete option values.
+  if [[ $prev == "--render-thread" ]]; then
+    local IFS=$' \n\t'
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -W "unsafe safe separate" -- "$cur"))
+  elif [[ $prev == "--video-driver" ]]; then
+    local IFS=$' \n\t'
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -W "GLES3 GLES2" -- "$cur"))
+  elif [[ $prev == "--path" || $prev == "--doctool" ]]; then
+    local IFS=$'\n\t'
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -d -- "$cur"))
+  elif [[ $prev == "--main-pack" ]]; then
+    local IFS=$'\n\t'
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -f -X "!*.@(pck|zip)" -- "$cur"))
+  elif [[ $prev == "-s" || $prev == "--script" ]]; then
+    local IFS=$'\n\t'
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -f -X "!*.gd" -- "$cur"))
+  fi
+}
+
+complete -o filenames -F _complete_godot_bash godot


### PR DESCRIPTION
Follow-up to #34957.

In a future pull request, the zsh completion could be updated to support features only available in the Bash completion, such as contextual extension-based file name filtering.

Props to [this article](https://iridakos.com/programming/2018/03/01/bash-programmable-completion-tutorial) for explaining how to write Bash completion scripts :slightly_smiling_face: 

## Preview

### List of options

```text
[user@host ~]$ godot --[TAB]
--always-on-top                 --export-pack                   --project-manager
--audio-driver                  --fixed-fps                     --quiet
--breakpoints                   --frame-delay                   --quit
--build-solutions               --fullscreen                    --remote-debug
--check-only                    --gdnative-generate-json-api    --remote-fs
--debug                         --help                          --remote-fs-password
--debug-collisions              --language                      --render-thread
--debug-navigation              --low-dpi                       --resolution
--disable-crash-handler         --main-pack                     --script
--disable-render-loop           --maximized                     --test
--disable-vsync-via-compositor  --no-docbase                    --time-scale
--doctool                       --no-window                     --upwards
--editor                        --path                          --verbose
--enable-vsync-via-compositor   --position                      --version
--export                        --print-fps                     --video-driver
--export-debug                  --profiling                     --windowed
```

### Option completion

```text
[user@host ~]$ godot --video-driver [TAB]
GLES2  GLES3
```

### Positional argument completion

```text
[user@host some_project]$ godot [TAB]
scene.scn  project.godot        test.tscn
```