### PR TITLE
Document theme_items of multiple classes

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -43,26 +43,37 @@
 	</constants>
 	<theme_items>
 		<theme_item name="disabled" type="StyleBox">
+			[StyleBox] used when the [Button] is disabled.
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
+			[StyleBox] used when the [Button] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 		<theme_item name="font" type="Font">
+			[Font] of the [Button]'s text.
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+			Default text [Color] of the [Button].
 		</theme_item>
 		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+			Text [Color] used when the [Button] is disabled.
 		</theme_item>
 		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+			Text [Color] used when the [Button] is being hovered.
 		</theme_item>
 		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+			Text [Color] used when the [Button] is being pressed.
 		</theme_item>
 		<theme_item name="hover" type="StyleBox">
+			[StyleBox] used when the [Button] is being hovered.
 		</theme_item>
 		<theme_item name="hseparation" type="int" default="2">
+			The horizontal space between [Button]'s icon and text.
 		</theme_item>
 		<theme_item name="normal" type="StyleBox">
+			Default [StyleBox] for the [Button].
 		</theme_item>
 		<theme_item name="pressed" type="StyleBox">
+			[StyleBox] used when the [Button] is being pressed.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/HBoxContainer.xml
+++ b/doc/classes/HBoxContainer.xml
@@ -14,6 +14,7 @@
 	</constants>
 	<theme_items>
 		<theme_item name="separation" type="int" default="4">
+			The horizontal space between the [HBoxContainer]'s elements.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -101,22 +101,31 @@
 	</constants>
 	<theme_items>
 		<theme_item name="font" type="Font">
+			[Font] used for the [Label]'s text.
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			Default text [Color] of the [Label].
 		</theme_item>
 		<theme_item name="font_color_shadow" type="Color" default="Color( 0, 0, 0, 0 )">
+			[Color] of the text's shadow effect.
 		</theme_item>
 		<theme_item name="font_outline_modulate" type="Color" default="Color( 1, 1, 1, 1 )">
+			The tint of [Font]'s outline. See [member DynamicFont.outline_color].
 		</theme_item>
 		<theme_item name="line_spacing" type="int" default="3">
+			Vertical space between lines in multiline [Label].
 		</theme_item>
 		<theme_item name="normal" type="StyleBox">
+			Background [StyleBox] for the [Label].
 		</theme_item>
 		<theme_item name="shadow_as_outline" type="int" default="0">
+			Boolean value. If set to 1 ([code]true[/code]), the shadow will be displayed around the whole text as an outline.
 		</theme_item>
 		<theme_item name="shadow_offset_x" type="int" default="1">
+			The horizontal offset of the text's shadow.
 		</theme_item>
 		<theme_item name="shadow_offset_y" type="int" default="1">
+			The vertical offset of the text's shadow.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -645,55 +645,58 @@
 	</constants>
 	<theme_items>
 		<theme_item name="checked" type="Texture">
-			Sets a custom [Texture] icon for [code]checked[/code] state of checkbox items.
+			[Texture] icon for the checked checkbox items.
 		</theme_item>
 		<theme_item name="font" type="Font">
-			Sets a custom [Font].
+			[Font] used for the menu items.
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
-			Sets a custom [Color] for the [Font].
+			The default text [Color] for menu items' names.
 		</theme_item>
 		<theme_item name="font_color_accel" type="Color" default="Color( 0.7, 0.7, 0.7, 0.8 )">
+			The text [Color] used for shortcuts and accelerators that show next to the menu item name when defined. See [method get_item_accelerator] for more info on accelerators.
 		</theme_item>
 		<theme_item name="font_color_disabled" type="Color" default="Color( 0.4, 0.4, 0.4, 0.8 )">
-			Sets a custom [Color] for disabled text.
+			[Color] used for disabled menu items' text.
 		</theme_item>
 		<theme_item name="font_color_hover" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
-			Sets a custom [Color] for the hovered text.
+			[Color] used for the hovered text.
 		</theme_item>
 		<theme_item name="hover" type="StyleBox">
-			Sets a custom [StyleBox] when the [PopupMenu] is hovered.
+			[StyleBox] displayed when the [PopupMenu] item is hovered.
 		</theme_item>
 		<theme_item name="hseparation" type="int" default="4">
-			Sets the horizontal space separation between each item.
+			The horizontal space between the item's name and the shortcut text/submenu arrow.
 		</theme_item>
 		<theme_item name="labeled_separator_left" type="StyleBox">
+			[StyleBox] for the left side of labeled separator. See [method add_separator].
 		</theme_item>
 		<theme_item name="labeled_separator_right" type="StyleBox">
+			[StyleBox] for the right side of labeled separator. See [method add_separator].
 		</theme_item>
 		<theme_item name="panel" type="StyleBox">
-			Sets a custom [StyleBox] for the panel of the [PopupMenu].
+			Default [StyleBox] of the [PopupMenu] items.
 		</theme_item>
 		<theme_item name="panel_disabled" type="StyleBox">
-			Sets a custom [StyleBox] for the panel of the [PopupMenu], when the panel is disabled.
+			[StyleBox] used when the [PopupMenu] item is disabled.
 		</theme_item>
 		<theme_item name="radio_checked" type="Texture">
-			Sets a custom [Texture] icon for [code]checked[/code] of radio button items.
+			[Texture] icon for the checked radio button items.
 		</theme_item>
 		<theme_item name="radio_unchecked" type="Texture">
-			Sets a custom [Texture] icon for [code]unchecked[/code] of radio button items.
+			[Texture] icon for the unchecked radio button items.
 		</theme_item>
 		<theme_item name="separator" type="StyleBox">
-			Sets a custom [StyleBox] for separator's.
+			[StyleBox] used for the separators. See [method add_separator].
 		</theme_item>
 		<theme_item name="submenu" type="Texture">
-			Sets a custom [Texture] for submenu's.
+			[Texture] icon for the submenu arrow.
 		</theme_item>
 		<theme_item name="unchecked" type="Texture">
-			Sets a custom [Texture] icon for [code]unchecked[/code] of checkbox items.
+			[Texture] icon for the unchecked checkbox items.
 		</theme_item>
 		<theme_item name="vseparation" type="int" default="4">
-			Sets the vertical space separation between each item.
+			The vertical space between each menu item.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -60,6 +60,7 @@
 	</constants>
 	<theme_items>
 		<theme_item name="bg" type="StyleBox">
+			The background [StyleBox] of the [ScrollContainer].
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ToolButton.xml
+++ b/doc/classes/ToolButton.xml
@@ -21,26 +21,37 @@
 	</constants>
 	<theme_items>
 		<theme_item name="disabled" type="StyleBox">
+			[StyleBox] used when the [ToolButton] is disabled.
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
+			[StyleBox] used when the [ToolButton] is focused. It is displayed over the current [StyleBox], so using [StyleboxEmpty] will just disable the focus visual effect.
 		</theme_item>
 		<theme_item name="font" type="Font">
+			[Font] of the [ToolButton]'s text.
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+			Default text [Color] of the [ToolButton].
 		</theme_item>
 		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.95, 1, 0.3 )">
+			Text [Color] used when the [ToolButton] is disabled.
 		</theme_item>
 		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+			Text [Color] used when the [ToolButton] is being hovered.
 		</theme_item>
 		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+			Text [Color] used when the [ToolButton] is being pressed.
 		</theme_item>
 		<theme_item name="hover" type="StyleBox">
+			[StyleBox] used when the [ToolButton] is being hovered.
 		</theme_item>
 		<theme_item name="hseparation" type="int" default="3">
+			The horizontal space between [ToolButton]'s icon and text.
 		</theme_item>
 		<theme_item name="normal" type="StyleBox">
+			Default [StyleBox] for the [ToolButton].
 		</theme_item>
 		<theme_item name="pressed" type="StyleBox">
+			[StyleBox] used when the [ToolButton] is being pressed.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/VBoxContainer.xml
+++ b/doc/classes/VBoxContainer.xml
@@ -14,6 +14,7 @@
 	</constants>
 	<theme_items>
 		<theme_item name="separation" type="int" default="4">
+			The vertical space between the [VBoxContainer]'s elements.
 		</theme_item>
 	</theme_items>
 </class>


### PR DESCRIPTION
This PR just adds documentation for `theme_items` of various random classes. Also rewords `PopupMenu` theme docs, because they were weird.