### PR TITLE
RichTextLabel Highlighting, Redacting

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -170,6 +170,15 @@
 				Terminates the current tag. Use after [code]push_*[/code] methods to close BBCodes manually. Does not need to follow [code]add_*[/code] methods.
 			</description>
 		</method>
+		<method name="push_bgcolor">
+			<return type="void">
+			</return>
+			<argument index="0" name="bgcolor" type="Color">
+			</argument>
+			<description>
+				Adds a [code][bgcolor][/code] tag to the tag stack.
+			</description>
+		</method>
 		<method name="push_bold">
 			<return type="void">
 			</return>
@@ -219,6 +228,15 @@
 			</argument>
 			<description>
 				Adds a [code][dropcap][/code] tag to the tag stack. Drop cap (dropped capital) is a decorative element at the beginning of a paragraph that is larger than the rest of the text.
+			</description>
+		</method>
+		<method name="push_fgcolor">
+			<return type="void">
+			</return>
+			<argument index="0" name="fgcolor" type="Color">
+			</argument>
+			<description>
+				Adds a [code][fgcolor][/code] tag to the tag stack.
 			</description>
 		</method>
 		<method name="push_font">
@@ -592,11 +610,15 @@
 		</constant>
 		<constant name="ITEM_RAINBOW" value="20" enum="ItemType">
 		</constant>
-		<constant name="ITEM_META" value="21" enum="ItemType">
+		<constant name="ITEM_BGCOLOR" value="21" enum="ItemType">
 		</constant>
-		<constant name="ITEM_DROPCAP" value="22" enum="ItemType">
+		<constant name="ITEM_FGCOLOR" value="22" enum="ItemType">
 		</constant>
-		<constant name="ITEM_CUSTOMFX" value="23" enum="ItemType">
+		<constant name="ITEM_META" value="23" enum="ItemType">
+		</constant>
+		<constant name="ITEM_DROPCAP" value="24" enum="ItemType">
+		</constant>
+		<constant name="ITEM_CUSTOMFX" value="25" enum="ItemType">
 		</constant>
 	</constants>
 	<theme_items>

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -75,6 +75,8 @@ public:
 		ITEM_WAVE,
 		ITEM_TORNADO,
 		ITEM_RAINBOW,
+		ITEM_BGCOLOR,
+		ITEM_FGCOLOR,
 		ITEM_META,
 		ITEM_DROPCAP,
 		ITEM_CUSTOMFX
@@ -307,6 +309,16 @@ private:
 		ItemRainbow() { type = ITEM_RAINBOW; }
 	};
 
+	struct ItemBGColor : public Item {
+		Color color;
+		ItemBGColor() { type = ITEM_BGCOLOR; }
+	};
+
+	struct ItemFGColor : public Item {
+		Color color;
+		ItemFGColor() { type = ITEM_FGCOLOR; }
+	};
+
 	struct ItemCustomFX : public ItemFX {
 		Ref<CharFXTransform> char_fx_transform;
 		Ref<RichTextEffect> custom_effect;
@@ -422,6 +434,8 @@ private:
 	bool _find_underline(Item *p_item);
 	bool _find_strikethrough(Item *p_item);
 	bool _find_meta(Item *p_item, Variant *r_meta, ItemMeta **r_item = nullptr);
+	Color _find_bgcolor(Item *p_item);
+	Color _find_fgcolor(Item *p_item);
 	bool _find_layout_subitem(Item *from, Item *to);
 	void _fetch_item_fx_stack(Item *p_item, Vector<ItemFX *> &r_stack);
 
@@ -436,6 +450,8 @@ private:
 	Rect2 _get_text_rect();
 	Ref<RichTextEffect> _get_custom_effect_by_code(String p_bbcode_identifier);
 	virtual Dictionary parse_expressions_for_values(Vector<String> p_expressions);
+
+	void _draw_fbg_boxes(RID p_ci, RID p_rid, Vector2 line_off, Item *it_from, Item *it_to, int start, int end, int fbg_flag);
 
 	bool use_bbcode = false;
 	String bbcode;
@@ -474,6 +490,8 @@ public:
 	void push_wave(float p_frequency, float p_amplitude);
 	void push_tornado(float p_frequency, float p_radius);
 	void push_rainbow(float p_saturation, float p_value, float p_frequency);
+	void push_bgcolor(const Color &p_color);
+	void push_fgcolor(const Color &p_color);
 	void push_customfx(Ref<RichTextEffect> p_custom_effect, Dictionary p_environment);
 	void set_table_column_expand(int p_column, bool p_expand, int p_ratio = 1);
 	void set_cell_row_background_color(const Color &p_odd_row_bg, const Color &p_even_row_bg);


### PR DESCRIPTION
This pull request addresses godotengine/godot-proposals#367 by adding highlighting and redacting capabilities to RichTextLabel with the tags bgcolor= and fgcolor=

Edit: Removed outdated information