### PR TITLE
Fixes OptionButton minimum size

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -36,7 +36,14 @@ Size2 OptionButton::get_minimum_size() const {
 	Size2 minsize = Button::get_minimum_size();
 
 	if (has_icon("arrow")) {
-		minsize.width += Control::get_icon("arrow")->get_width() + get_constant("hseparation");
+		const Size2 padding = get_stylebox("normal")->get_minimum_size();
+		const Size2 arrow_size = Control::get_icon("arrow")->get_size();
+
+		Size2 content_size = minsize - padding;
+		content_size.width += arrow_size.width + get_constant("hseparation");
+		content_size.height = MAX(content_size.height, arrow_size.height);
+
+		minsize = content_size + padding;
 	}
 
 	return minsize;


### PR DESCRIPTION
Before this fix, OptionButton did not take the height of arrow icon into account when calculating its minimum size.

![demo](https://user-images.githubusercontent.com/372476/73155386-846bd700-4115-11ea-8b1e-154f2b9be5c3.gif)
