### PR TITLE
Removed unused method "build" from VisualShaderNodeExpression

### DIFF
--- a/doc/classes/VisualShaderNodeExpression.xml
+++ b/doc/classes/VisualShaderNodeExpression.xml
@@ -7,12 +7,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="build">
-			<return type="void">
-			</return>
-			<description>
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" override="true" default="true" />

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2532,10 +2532,6 @@ void VisualShaderNodeExpression::set_expression(const String &p_expression) {
 	expression = p_expression;
 }
 
-void VisualShaderNodeExpression::build() {
-	emit_changed();
-}
-
 String VisualShaderNodeExpression::get_expression() const {
 	return expression;
 }
@@ -2641,8 +2637,6 @@ void VisualShaderNodeExpression::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_expression", "expression"), &VisualShaderNodeExpression::set_expression);
 	ClassDB::bind_method(D_METHOD("get_expression"), &VisualShaderNodeExpression::get_expression);
-
-	ClassDB::bind_method(D_METHOD("build"), &VisualShaderNodeExpression::build);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "expression"), "set_expression", "get_expression");
 }

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -457,8 +457,6 @@ public:
 	void set_expression(const String &p_expression);
 	String get_expression() const;
 
-	void build();
-
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const;
 
 	VisualShaderNodeExpression();


### PR DESCRIPTION
I think it will only confuse users, and it's not used anywhere, seems like an artifact from the development.