### PR TITLE
Expose shape property for shape query parameters classes

### DIFF
--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -9,15 +9,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="set_shape">
-			<return type="void">
-			</return>
-			<argument index="0" name="shape" type="Resource">
-			</argument>
-			<description>
-				Sets the [Shape2D] that will be used for collision/intersection queries.
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
@@ -38,8 +29,24 @@
 		<member name="motion" type="Vector2" setter="set_motion" getter="get_motion" default="Vector2( 0, 0 )">
 			The motion of the shape being queried for.
 		</member>
+		<member name="shape" type="Resource" setter="set_shape" getter="get_shape">
+			The [Shape2D] that will be used for collision/intersection queries. This stores the actual reference which avoids the shape to be released while being used for queries, so always prefer using this over [member shape_rid].
+		</member>
 		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid">
-			The queried shape's [RID]. See also [method set_shape].
+			The queried shape's [RID] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:
+			[codeblock]
+			var shape_rid = PhysicsServer2D.circle_shape_create()
+			var radius = 64
+			PhysicsServer2D.shape_set_data(shape_rid, radius)
+
+			var params = PhysicsShapeQueryParameters2D.new()
+			params.shape_rid = shape_rid
+
+			# Execute physics queries here...
+
+			# Release the shape when done with physics queries.
+			PhysicsServer2D.free_rid(shape_rid)
+			[/codeblock]
 		</member>
 		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D( 1, 0, 0, 1, 0, 0 )">
 			The queried shape's transform matrix.

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -9,15 +9,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="set_shape">
-			<return type="void">
-			</return>
-			<argument index="0" name="shape" type="Resource">
-			</argument>
-			<description>
-				Sets the [Shape3D] that will be used for collision/intersection queries.
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
@@ -35,8 +26,24 @@
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.0">
 			The collision margin for the shape.
 		</member>
+		<member name="shape" type="Resource" setter="set_shape" getter="get_shape">
+			The [Shape3D] that will be used for collision/intersection queries. This stores the actual reference which avoids the shape to be released while being used for queries, so always prefer using this over [member shape_rid].
+		</member>
 		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid">
-			The queried shape's [RID]. See also [method set_shape].
+			The queried shape's [RID] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:
+			[codeblock]
+			var shape_rid = PhysicsServer3D.shape_create(PhysicsServer3D.SHAPE_SPHERE)
+			var radius = 2.0
+			PhysicsServer3D.shape_set_data(shape_rid, radius)
+
+			var params = PhysicsShapeQueryParameters3D.new()
+			params.shape_rid = shape_rid
+
+			# Execute physics queries here...
+
+			# Release the shape when done with physics queries.
+			PhysicsServer3D.free_rid(shape_rid)
+			[/codeblock]
 		</member>
 		<member name="transform" type="Transform" setter="set_transform" getter="get_transform" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
 			The queried shape's transform matrix.

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -132,13 +132,21 @@ PhysicsDirectBodyState2D::PhysicsDirectBodyState2D() {}
 
 ///////////////////////////////////////////////////////
 
-void PhysicsShapeQueryParameters2D::set_shape(const RES &p_shape) {
-	ERR_FAIL_COND(p_shape.is_null());
-	shape = p_shape->get_rid();
+void PhysicsShapeQueryParameters2D::set_shape(const RES &p_shape_ref) {
+	ERR_FAIL_COND(p_shape_ref.is_null());
+	shape_ref = p_shape_ref;
+	shape = p_shape_ref->get_rid();
+}
+
+RES PhysicsShapeQueryParameters2D::get_shape() const {
+	return shape_ref;
 }
 
 void PhysicsShapeQueryParameters2D::set_shape_rid(const RID &p_shape) {
-	shape = p_shape;
+	if (shape != p_shape) {
+		shape_ref = RES();
+		shape = p_shape;
+	}
 }
 
 RID PhysicsShapeQueryParameters2D::get_shape_rid() const {
@@ -212,6 +220,7 @@ bool PhysicsShapeQueryParameters2D::is_collide_with_areas_enabled() const {
 
 void PhysicsShapeQueryParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &PhysicsShapeQueryParameters2D::set_shape);
+	ClassDB::bind_method(D_METHOD("get_shape"), &PhysicsShapeQueryParameters2D::get_shape);
 	ClassDB::bind_method(D_METHOD("set_shape_rid", "shape"), &PhysicsShapeQueryParameters2D::set_shape_rid);
 	ClassDB::bind_method(D_METHOD("get_shape_rid"), &PhysicsShapeQueryParameters2D::get_shape_rid);
 
@@ -240,7 +249,7 @@ void PhysicsShapeQueryParameters2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude", PROPERTY_HINT_NONE, itos(Variant::_RID) + ":"), "set_exclude", "get_exclude");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_margin", "get_margin");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "motion"), "set_motion", "get_motion");
-	//ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", ""); // FIXME: Lacks a getter
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", "get_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::_RID, "shape_rid"), "set_shape_rid", "get_shape_rid");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "transform"), "set_transform", "get_transform");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies"), "set_collide_with_bodies", "is_collide_with_bodies_enabled");

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -98,6 +98,8 @@ class PhysicsShapeQueryResult2D;
 class PhysicsShapeQueryParameters2D : public Reference {
 	GDCLASS(PhysicsShapeQueryParameters2D, Reference);
 	friend class PhysicsDirectSpaceState2D;
+
+	RES shape_ref;
 	RID shape;
 	Transform2D transform;
 	Vector2 motion;
@@ -112,7 +114,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_shape(const RES &p_shape);
+	void set_shape(const RES &p_shape_ref);
+	RES get_shape() const;
 	void set_shape_rid(const RID &p_shape);
 	RID get_shape_rid() const;
 

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -136,13 +136,21 @@ PhysicsDirectBodyState3D::PhysicsDirectBodyState3D() {}
 
 ///////////////////////////////////////////////////////
 
-void PhysicsShapeQueryParameters3D::set_shape(const RES &p_shape) {
-	ERR_FAIL_COND(p_shape.is_null());
-	shape = p_shape->get_rid();
+void PhysicsShapeQueryParameters3D::set_shape(const RES &p_shape_ref) {
+	ERR_FAIL_COND(p_shape_ref.is_null());
+	shape_ref = p_shape_ref;
+	shape = p_shape_ref->get_rid();
+}
+
+RES PhysicsShapeQueryParameters3D::get_shape() const {
+	return shape_ref;
 }
 
 void PhysicsShapeQueryParameters3D::set_shape_rid(const RID &p_shape) {
-	shape = p_shape;
+	if (shape != p_shape) {
+		shape_ref = RES();
+		shape = p_shape;
+	}
 }
 
 RID PhysicsShapeQueryParameters3D::get_shape_rid() const {
@@ -208,6 +216,7 @@ bool PhysicsShapeQueryParameters3D::is_collide_with_areas_enabled() const {
 
 void PhysicsShapeQueryParameters3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &PhysicsShapeQueryParameters3D::set_shape);
+	ClassDB::bind_method(D_METHOD("get_shape"), &PhysicsShapeQueryParameters3D::get_shape);
 	ClassDB::bind_method(D_METHOD("set_shape_rid", "shape"), &PhysicsShapeQueryParameters3D::set_shape_rid);
 	ClassDB::bind_method(D_METHOD("get_shape_rid"), &PhysicsShapeQueryParameters3D::get_shape_rid);
 
@@ -232,7 +241,7 @@ void PhysicsShapeQueryParameters3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude", PROPERTY_HINT_NONE, itos(Variant::_RID) + ":"), "set_exclude", "get_exclude");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_margin", "get_margin");
-	//ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", ""); // FIXME: Lacks a getter
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape3D"), "set_shape", "get_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::_RID, "shape_rid"), "set_shape_rid", "get_shape_rid");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM, "transform"), "set_transform", "get_transform");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies"), "set_collide_with_bodies", "is_collide_with_bodies_enabled");

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -100,6 +100,7 @@ class PhysicsShapeQueryParameters3D : public Reference {
 	GDCLASS(PhysicsShapeQueryParameters3D, Reference);
 	friend class PhysicsDirectSpaceState3D;
 
+	RES shape_ref;
 	RID shape;
 	Transform transform;
 	float margin;
@@ -113,7 +114,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_shape(const RES &p_shape);
+	void set_shape(const RES &p_shape_ref);
+	RES get_shape() const;
 	void set_shape_rid(const RID &p_shape);
 	RID get_shape_rid() const;
 


### PR DESCRIPTION
Exposed properties for both 2D and 3D physics (missing getter).

Related to #15611 (CC @bojidar-bg):

> OS.window_title, **Physics{,2D}ShapeQueryParameters.shape** and Viewport.attach_to_screen_rect lack getters, so I didn't bind them.

Thoughts:
1. ~~Should `shape_rid` be unexposed in favor high-level `shape` member? (4.0)~~ no, see a use case at https://github.com/godotengine/godot/pull/39846#issuecomment-650121026.
2. The doc gen doesn't seem to respect `Shape[2D]` resource type hints for these properties.

Fixes #39699 (see #39846).