### PR TITLE
Fix Camera2D jitter

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -54,6 +54,9 @@ void Camera2D::_update_scroll() {
 
 		Transform2D xform = get_camera_transform();
 
+		// Round origin to nearest whole pixel to prevent sprite jittering
+		xform.set_origin(xform.get_origin().round());
+
 		viewport->set_canvas_transform(xform);
 
 		Size2 screen_size = viewport->get_visible_rect().size;


### PR DESCRIPTION
Fix #35606 by rounding Camera2D transform origin to the nearest whole pixel before setting canvas transform.

_Bugsquad edit:_ fixes https://github.com/godotengine/godot/issues/2667