### PR TITLE
Hide "editable" property from VisualShaderNodeGroupBase public interface

### DIFF
--- a/doc/classes/VisualShaderNodeExpression.xml
+++ b/doc/classes/VisualShaderNodeExpression.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="editable" type="bool" setter="set_editable" getter="is_editable" override="true" default="true" />
 		<member name="expression" type="String" setter="set_expression" getter="get_expression" default="&quot;&quot;">
 		</member>
 	</members>

--- a/doc/classes/VisualShaderNodeGlobalExpression.xml
+++ b/doc/classes/VisualShaderNodeGlobalExpression.xml
@@ -9,7 +9,6 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="editable" type="bool" setter="set_editable" getter="is_editable" override="true" default="false" />
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisualShaderNodeGroupBase.xml
+++ b/doc/classes/VisualShaderNodeGroupBase.xml
@@ -195,8 +195,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="false">
-		</member>
 		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2( 0, 0 )">
 		</member>
 	</members>

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2505,10 +2505,6 @@ void VisualShaderNodeGroupBase::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_control", "control", "index"), &VisualShaderNodeGroupBase::set_control);
 	ClassDB::bind_method(D_METHOD("get_control", "index"), &VisualShaderNodeGroupBase::get_control);
 
-	ClassDB::bind_method(D_METHOD("set_editable", "enabled"), &VisualShaderNodeGroupBase::set_editable);
-	ClassDB::bind_method(D_METHOD("is_editable"), &VisualShaderNodeGroupBase::is_editable);
-
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size"), "set_size", "get_size");
 }
 


### PR DESCRIPTION
I think this needs to be an internal property cuz it has no usage for the public user (it's just hiding Add port/Remove port buttons)