### PR TITLE
Hide "control" methods from VisualShaderNodeGroupBase

### DIFF
--- a/doc/classes/VisualShaderNodeGroupBase.xml
+++ b/doc/classes/VisualShaderNodeGroupBase.xml
@@ -43,14 +43,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_control">
-			<return type="Control">
-			</return>
-			<argument index="0" name="index" type="int">
-			</argument>
-			<description>
-			</description>
-		</method>
 		<method name="get_free_input_port_id" qualifiers="const">
 			<return type="int">
 			</return>
@@ -123,16 +115,6 @@
 			<return type="void">
 			</return>
 			<argument index="0" name="id" type="int">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="set_control">
-			<return type="void">
-			</return>
-			<argument index="0" name="control" type="Control">
-			</argument>
-			<argument index="1" name="index" type="int">
 			</argument>
 			<description>
 			</description>

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2502,9 +2502,6 @@ void VisualShaderNodeGroupBase::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_free_input_port_id"), &VisualShaderNodeGroupBase::get_free_input_port_id);
 	ClassDB::bind_method(D_METHOD("get_free_output_port_id"), &VisualShaderNodeGroupBase::get_free_output_port_id);
 
-	ClassDB::bind_method(D_METHOD("set_control", "control", "index"), &VisualShaderNodeGroupBase::set_control);
-	ClassDB::bind_method(D_METHOD("get_control", "index"), &VisualShaderNodeGroupBase::get_control);
-
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size"), "set_size", "get_size");
 }
 


### PR DESCRIPTION
Like an `editable`, it has no user usage.