### PR TITLE
Use a new approach to fix bone pose override not being reset when IK animation is stopped.

### DIFF
--- a/editor/plugins/skeleton_ik_editor_plugin.cpp
+++ b/editor/plugins/skeleton_ik_editor_plugin.cpp
@@ -41,21 +41,12 @@ void SkeletonIKEditorPlugin::_play() {
 		return;
 
 	if (play_btn->is_pressed()) {
-
-		initial_bone_poses.resize(skeleton_ik->get_parent_skeleton()->get_bone_count());
-		for (int i = 0; i < skeleton_ik->get_parent_skeleton()->get_bone_count(); ++i) {
-			initial_bone_poses.write[i] = skeleton_ik->get_parent_skeleton()->get_bone_pose(i);
-		}
-
 		skeleton_ik->start();
 	} else {
 		skeleton_ik->stop();
 
-		if (initial_bone_poses.size() != skeleton_ik->get_parent_skeleton()->get_bone_count())
-			return;
-
 		for (int i = 0; i < skeleton_ik->get_parent_skeleton()->get_bone_count(); ++i) {
-			skeleton_ik->get_parent_skeleton()->set_bone_pose(i, initial_bone_poses[i]);
+			skeleton_ik->get_parent_skeleton()->set_bone_global_pose_override(i, Transform(), 0);
 		}
 	}
 }

--- a/editor/plugins/skeleton_ik_editor_plugin.h
+++ b/editor/plugins/skeleton_ik_editor_plugin.h
@@ -44,7 +44,6 @@ class SkeletonIKEditorPlugin : public EditorPlugin {
 
 	Button *play_btn;
 	EditorNode *editor;
-	Vector<Transform> initial_bone_poses;
 
 	void _play();
 

--- a/scene/animation/skeleton_ik.cpp
+++ b/scene/animation/skeleton_ik.cpp
@@ -329,17 +329,6 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 	}
 }
 
-void FabrikInverseKinematic::reset(Task *p_task) {
-	ChainItem *ci(&p_task->chain.chain_root);
-	while (ci) {
-		p_task->skeleton->set_bone_global_pose_override(ci->bone, Transform(), 0);
-		if (!ci->children.empty())
-			ci = &ci->children.write[0];
-		else
-			ci = NULL;
-	}
-}
-
 void SkeletonIK::_validate_property(PropertyInfo &property) const {
 
 	if (property.name == "root_bone" || property.name == "tip_bone") {
@@ -542,8 +531,6 @@ void SkeletonIK::start(bool p_one_time) {
 
 void SkeletonIK::stop() {
 	set_process_internal(false);
-	if (task)
-		FabrikInverseKinematic::reset(task);
 }
 
 Transform SkeletonIK::_get_target_transform() {

--- a/scene/animation/skeleton_ik.h
+++ b/scene/animation/skeleton_ik.h
@@ -139,7 +139,6 @@ public:
 	static void set_goal(Task *p_task, const Transform &p_goal);
 	static void make_goal(Task *p_task, const Transform &p_inverse_transf, real_t blending_delta);
 	static void solve(Task *p_task, real_t blending_delta, bool override_tip_basis, bool p_use_magnet, const Vector3 &p_magnet_position);
-	static void reset(Task *p_task);
 };
 
 class SkeletonIK : public Node {


### PR DESCRIPTION
As discussed with @AndreaCatania in #35460, resetting the bone pose is an in-editor feature and not an inverse kinematic feature. Therefore, the editor plugin should contain all the necessary logic to reset a skeleton when the IK is stopped.

This reverts #35460 and fixes the skeleton reset logic within the ik editor plugin.