### PR TITLE
Print suggestions when requesting a nonexistent InputMap action

### DIFF
--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -61,6 +61,7 @@ private:
 
 	Array _action_get_events(const StringName &p_action);
 	Array _get_actions();
+	String _suggest_actions(const StringName &p_action) const;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
This should make debugging input actions a bit easier. In the future, we can extend this to `get_node()` errors, signal connection errors and much more. If no action name is close enough to the requested action, no suggestion will be made.

`3.2` version of this PR: https://github.com/godotengine/godot/pull/45902

## Preview

```text
ERROR: event_get_action_status: The InputMap action "move_forwards" doesn't exist. Did you mean "move_forward"?
   At: core/input_map.cpp:241.
```

~~Note that this method is fairly slow (taking 2-5 ms to run in a debug build). Thankfully, it's only called in debug builds when the input action doesn't exist, so the impact should be minimal in a release build.~~

~~@Zylann Is there a way to optimize this? I'm not sure if putting the Comparator struct outside the function would improve the performance (to avoid creating it every time).~~

**Edit:** The method has been optimized, it takes about 100-150 µs to run now.