### PR TITLE
Fix dangling and awkwardly reassigned `Variant`s [wip]

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1918,6 +1918,7 @@ Object::Object() {
 	_predelete_ok = 0;
 	_instance_id = 0;
 	_instance_id = ObjectDB::add_instance(this);
+	variant_sentinel = NULL;
 	_can_translate = true;
 	_is_queued_for_deletion = false;
 	_emitting = false;
@@ -1940,6 +1941,15 @@ Object::~Object() {
 	if (script_instance)
 		memdelete(script_instance);
 	script_instance = NULL;
+
+	if (variant_sentinel) {
+#ifdef DEBUG_ENABLED
+		int num_dangling = variant_sentinel->_clear_sentinel_chain_from_this();
+		ERR_PRINTS("Object " + to_string() + " was freed while there were still " + itos(num_dangling) + " references to it. They have been set to null.");
+#else
+		variant_sentinel->_clear_sentinel_chain_from_this();
+#endif
+	}
 
 	const StringName *S = NULL;
 

--- a/core/object.h
+++ b/core/object.h
@@ -477,6 +477,7 @@ private:
 	int _predelete_ok;
 	Set<Object *> change_receptors;
 	ObjectID _instance_id;
+	Variant *variant_sentinel;
 	bool _predelete();
 	void _postinitialize();
 	bool _can_translate;
@@ -588,6 +589,9 @@ public:
 	}
 
 	bool _is_gpl_reversed() const { return false; }
+
+	_FORCE_INLINE_ Variant *_get_variant_sentinel() const { return variant_sentinel; }
+	_FORCE_INLINE_ void _set_variant_sentinel(Variant *p_variant_sentinel) { variant_sentinel = p_variant_sentinel; }
 
 	_FORCE_INLINE_ ObjectID get_instance_id() const { return _instance_id; }
 	// this is used for editors

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -790,7 +790,7 @@ bool Variant::is_zero() const {
 		} break;
 		case OBJECT: {
 
-			return _get_obj().obj == NULL;
+			return _data._obj.obj == NULL;
 		} break;
 		case NODE_PATH: {
 
@@ -999,7 +999,7 @@ void Variant::reference(const Variant &p_variant) {
 		} break;
 		case OBJECT: {
 
-			memnew_placement(_data._mem, ObjData(p_variant._get_obj()));
+			memnew_placement(_data._mem, ObjData(p_variant._data._obj));
 		} break;
 		case NODE_PATH: {
 
@@ -1114,8 +1114,8 @@ void Variant::clear() {
 		} break;
 		case OBJECT: {
 
-			_get_obj().obj = NULL;
-			_get_obj().ref.unref();
+			_data._obj.obj = NULL;
+			_data._obj.ref.unref();
 		} break;
 		case _RID: {
 			// not much need probably
@@ -1580,16 +1580,16 @@ String Variant::stringify(List<const void *> &stack) const {
 		} break;
 		case OBJECT: {
 
-			if (_get_obj().obj) {
+			if (_data._obj.obj) {
 #ifdef DEBUG_ENABLED
-				if (ScriptDebugger::get_singleton() && _get_obj().ref.is_null()) {
+				if (ScriptDebugger::get_singleton() && _data._obj.ref.is_null()) {
 					//only if debugging!
-					if (!ObjectDB::instance_validate(_get_obj().obj)) {
+					if (!ObjectDB::instance_validate(_data._obj.obj)) {
 						return "[Deleted Object]";
 					};
 				};
 #endif
-				return _get_obj().obj->to_string();
+				return _data._obj.obj->to_string();
 			} else
 				return "[Object:null]";
 
@@ -1734,7 +1734,7 @@ Variant::operator NodePath() const {
 Variant::operator RefPtr() const {
 
 	if (type == OBJECT)
-		return _get_obj().ref;
+		return _data._obj.ref;
 	else
 		return RefPtr();
 }
@@ -1743,16 +1743,16 @@ Variant::operator RID() const {
 
 	if (type == _RID)
 		return *reinterpret_cast<const RID *>(_data._mem);
-	else if (type == OBJECT && !_get_obj().ref.is_null()) {
-		return _get_obj().ref.get_rid();
-	} else if (type == OBJECT && _get_obj().obj) {
+	else if (type == OBJECT && !_data._obj.ref.is_null()) {
+		return _data._obj.ref.get_rid();
+	} else if (type == OBJECT && _data._obj.obj) {
 #ifdef DEBUG_ENABLED
 		if (ScriptDebugger::get_singleton()) {
-			ERR_FAIL_COND_V_MSG(!ObjectDB::instance_validate(_get_obj().obj), RID(), "Invalid pointer (object was deleted).");
+			ERR_FAIL_COND_V_MSG(!ObjectDB::instance_validate(_data._obj.obj), RID(), "Invalid pointer (object was deleted).");
 		};
 #endif
 		Variant::CallError ce;
-		Variant ret = _get_obj().obj->call(CoreStringNames::get_singleton()->get_rid, NULL, 0, ce);
+		Variant ret = _data._obj.obj->call(CoreStringNames::get_singleton()->get_rid, NULL, 0, ce);
 		if (ce.error == Variant::CallError::CALL_OK && ret.get_type() == Variant::_RID) {
 			return ret;
 		}
@@ -1765,21 +1765,21 @@ Variant::operator RID() const {
 Variant::operator Object *() const {
 
 	if (type == OBJECT)
-		return _get_obj().obj;
+		return _data._obj.obj;
 	else
 		return NULL;
 }
 Variant::operator Node *() const {
 
 	if (type == OBJECT)
-		return Object::cast_to<Node>(_get_obj().obj);
+		return Object::cast_to<Node>(_data._obj.obj);
 	else
 		return NULL;
 }
 Variant::operator Control *() const {
 
 	if (type == OBJECT)
-		return Object::cast_to<Control>(_get_obj().obj);
+		return Object::cast_to<Control>(_data._obj.obj);
 	else
 		return NULL;
 }
@@ -2281,8 +2281,8 @@ Variant::Variant(const RefPtr &p_resource) {
 	type = OBJECT;
 	memnew_placement(_data._mem, ObjData);
 	REF *ref = reinterpret_cast<REF *>(p_resource.get_data());
-	_get_obj().obj = ref->ptr();
-	_get_obj().ref = p_resource;
+	_data._obj.obj = ref->ptr();
+	_data._obj.ref = p_resource;
 }
 
 Variant::Variant(const RID &p_rid) {
@@ -2296,7 +2296,7 @@ Variant::Variant(const Object *p_object) {
 	type = OBJECT;
 
 	memnew_placement(_data._mem, ObjData);
-	_get_obj().obj = const_cast<Object *>(p_object);
+	_data._obj.obj = const_cast<Object *>(p_object);
 }
 
 Variant::Variant(const Dictionary &p_dictionary) {
@@ -2607,7 +2607,7 @@ void Variant::operator=(const Variant &p_variant) {
 		} break;
 		case OBJECT: {
 
-			*reinterpret_cast<ObjData *>(_data._mem) = p_variant._get_obj();
+			*reinterpret_cast<ObjData *>(_data._mem) = p_variant._data._obj;
 		} break;
 		case NODE_PATH: {
 
@@ -2805,7 +2805,7 @@ uint32_t Variant::hash() const {
 		} break;
 		case OBJECT: {
 
-			return hash_djb2_one_64(make_uint64_t(_get_obj().obj));
+			return hash_djb2_one_64(make_uint64_t(_data._obj.obj));
 		} break;
 		case NODE_PATH: {
 
@@ -3118,7 +3118,7 @@ bool Variant::hash_compare(const Variant &p_variant) const {
 
 bool Variant::is_ref() const {
 
-	return type == OBJECT && !_get_obj().ref.is_null();
+	return type == OBJECT && !_data._obj.ref.is_null();
 }
 
 Vector<Variant> varray() {

--- a/core/variant.h
+++ b/core/variant.h
@@ -120,15 +120,18 @@ public:
 
 private:
 	friend struct _VariantCall;
-	// Variant takes 20 bytes when real_t is float, and 36 if double
-	// it only allocates extra memory for aabb/matrix.
+
+	// Variant takes 24 bytes when real_t is float, and 40 if double.
+	// It only allocates extra memory for Transform, Transform2D, AABB and Matrix.
 
 	Type type;
 
 	struct ObjData {
 
 		Object *obj;
+		bool is_ref;
 		RefPtr ref;
+		mutable Variant *next_sentinel;
 	};
 
 	union Data {
@@ -150,7 +153,13 @@ private:
 	void reference(const Variant &p_variant);
 	void clear();
 
+#ifdef DEBUG_SENTINEL_VARIANTS_ENABLED
+	void _check_sentinel_chain_sanity(const Object *p_obj, const Variant *p_ensured, bool p_check_absent = false) const;
+#endif
+
 public:
+	int _clear_sentinel_chain_from_this();
+
 	_FORCE_INLINE_ Type get_type() const { return type; }
 	static String get_type_name(Variant::Type p_type);
 	static bool can_convert(Type p_type_from, Type p_type_to);

--- a/core/variant.h
+++ b/core/variant.h
@@ -131,10 +131,7 @@ private:
 		RefPtr ref;
 	};
 
-	_FORCE_INLINE_ ObjData &_get_obj();
-	_FORCE_INLINE_ const ObjData &_get_obj() const;
-
-	union {
+	union Data {
 		bool _bool;
 		int64_t _int;
 		double _real;
@@ -143,7 +140,11 @@ private:
 		Basis *_basis;
 		Transform *_transform;
 		void *_ptr; //generic pointer
-		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)];
+		uint8_t _mem[sizeof(real_t) * 4];
+		ObjData _obj;
+
+		Data() {}
+		~Data() {}
 	} _data GCC_ALIGNED_8;
 
 	void reference(const Variant &p_variant);
@@ -438,16 +439,6 @@ struct VariantComparator {
 
 	static _FORCE_INLINE_ bool compare(const Variant &p_lhs, const Variant &p_rhs) { return p_lhs.hash_compare(p_rhs); }
 };
-
-Variant::ObjData &Variant::_get_obj() {
-
-	return *reinterpret_cast<ObjData *>(&_data._mem[0]);
-}
-
-const Variant::ObjData &Variant::_get_obj() const {
-
-	return *reinterpret_cast<const ObjData *>(&_data._mem[0]);
-}
 
 String vformat(const String &p_text, const Variant &p1 = Variant(), const Variant &p2 = Variant(), const Variant &p3 = Variant(), const Variant &p4 = Variant(), const Variant &p5 = Variant());
 #endif

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1094,13 +1094,13 @@ void Variant::call_ptr(const StringName &p_method, const Variant **p_args, int p
 
 	if (type == Variant::OBJECT) {
 		//call object
-		Object *obj = _get_obj().obj;
+		Object *obj = _data._obj.obj;
 		if (!obj) {
 			r_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;
 			return;
 		}
 #ifdef DEBUG_ENABLED
-		if (ScriptDebugger::get_singleton() && _get_obj().ref.is_null()) {
+		if (ScriptDebugger::get_singleton() && _data._obj.ref.is_null()) {
 			//only if debugging!
 			if (!ObjectDB::instance_validate(obj)) {
 				r_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;
@@ -1109,7 +1109,7 @@ void Variant::call_ptr(const StringName &p_method, const Variant **p_args, int p
 		}
 
 #endif
-		ret = _get_obj().obj->call(p_method, p_args, p_argcount, r_error);
+		ret = _data._obj.obj->call(p_method, p_args, p_argcount, r_error);
 
 		//else if (type==Variant::METHOD) {
 

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -399,7 +399,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_EQUAL, NIL) {
 				if (p_b.type == NIL) _RETURN(true);
 				if (p_b.type == OBJECT)
-					_RETURN(p_b._get_obj().obj == NULL);
+					_RETURN(p_b._data._obj.obj == NULL);
 
 				_RETURN(false);
 			}
@@ -416,9 +416,9 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 
 			CASE_TYPE(math, OP_EQUAL, OBJECT) {
 				if (p_b.type == OBJECT)
-					_RETURN((p_a._get_obj().obj == p_b._get_obj().obj));
+					_RETURN((p_a._data._obj.obj == p_b._data._obj.obj));
 				if (p_b.type == NIL)
-					_RETURN(p_a._get_obj().obj == NULL);
+					_RETURN(p_a._data._obj.obj == NULL);
 
 				_RETURN_FAIL;
 			}
@@ -486,7 +486,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_NOT_EQUAL, NIL) {
 				if (p_b.type == NIL) _RETURN(false);
 				if (p_b.type == OBJECT)
-					_RETURN(p_b._get_obj().obj != NULL);
+					_RETURN(p_b._data._obj.obj != NULL);
 
 				_RETURN(true);
 			}
@@ -504,9 +504,9 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 
 			CASE_TYPE(math, OP_NOT_EQUAL, OBJECT) {
 				if (p_b.type == OBJECT)
-					_RETURN((p_a._get_obj().obj != p_b._get_obj().obj));
+					_RETURN((p_a._data._obj.obj != p_b._data._obj.obj));
 				if (p_b.type == NIL)
-					_RETURN(p_a._get_obj().obj != NULL);
+					_RETURN(p_a._data._obj.obj != NULL);
 
 				_RETURN_FAIL;
 			}
@@ -589,7 +589,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_LESS, OBJECT) {
 				if (p_b.type != OBJECT)
 					_RETURN_FAIL;
-				_RETURN((p_a._get_obj().obj < p_b._get_obj().obj));
+				_RETURN((p_a._data._obj.obj < p_b._data._obj.obj));
 			}
 
 			CASE_TYPE(math, OP_LESS, ARRAY) {
@@ -643,7 +643,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_LESS_EQUAL, OBJECT) {
 				if (p_b.type != OBJECT)
 					_RETURN_FAIL;
-				_RETURN((p_a._get_obj().obj <= p_b._get_obj().obj));
+				_RETURN((p_a._data._obj.obj <= p_b._data._obj.obj));
 			}
 
 			DEFAULT_OP_NUM(math, OP_LESS_EQUAL, INT, <=, _int);
@@ -693,7 +693,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_GREATER, OBJECT) {
 				if (p_b.type != OBJECT)
 					_RETURN_FAIL;
-				_RETURN((p_a._get_obj().obj > p_b._get_obj().obj));
+				_RETURN((p_a._data._obj.obj > p_b._data._obj.obj));
 			}
 
 			CASE_TYPE(math, OP_GREATER, ARRAY) {
@@ -747,7 +747,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_GREATER_EQUAL, OBJECT) {
 				if (p_b.type != OBJECT)
 					_RETURN_FAIL;
-				_RETURN((p_a._get_obj().obj >= p_b._get_obj().obj));
+				_RETURN((p_a._data._obj.obj >= p_b._data._obj.obj));
 			}
 
 			DEFAULT_OP_NUM(math, OP_GREATER_EQUAL, INT, >=, _int);
@@ -1513,14 +1513,14 @@ void Variant::set_named(const StringName &p_index, const Variant &p_value, bool 
 		case OBJECT: {
 
 #ifdef DEBUG_ENABLED
-			if (!_get_obj().obj) {
+			if (!_data._obj.obj) {
 				break;
-			} else if (ScriptDebugger::get_singleton() && _get_obj().ref.is_null() && !ObjectDB::instance_validate(_get_obj().obj)) {
+			} else if (ScriptDebugger::get_singleton() && _data._obj.ref.is_null() && !ObjectDB::instance_validate(_data._obj.obj)) {
 				break;
 			}
 
 #endif
-			_get_obj().obj->set(p_index, p_value, &valid);
+			_data._obj.obj->set(p_index, p_value, &valid);
 
 		} break;
 		default: {
@@ -1678,13 +1678,13 @@ Variant Variant::get_named(const StringName &p_index, bool *r_valid) const {
 		case OBJECT: {
 
 #ifdef DEBUG_ENABLED
-			if (!_get_obj().obj) {
+			if (!_data._obj.obj) {
 				if (r_valid)
 					*r_valid = false;
 				return "Instance base is null.";
 			} else {
 
-				if (ScriptDebugger::get_singleton() && _get_obj().ref.is_null() && !ObjectDB::instance_validate(_get_obj().obj)) {
+				if (ScriptDebugger::get_singleton() && _data._obj.ref.is_null() && !ObjectDB::instance_validate(_data._obj.obj)) {
 					if (r_valid)
 						*r_valid = false;
 					return "Attempted use of stray pointer object.";
@@ -1693,7 +1693,7 @@ Variant Variant::get_named(const StringName &p_index, bool *r_valid) const {
 
 #endif
 
-			return _get_obj().obj->get(p_index, r_valid);
+			return _data._obj.obj->get(p_index, r_valid);
 
 		} break;
 		default: {
@@ -2167,12 +2167,12 @@ void Variant::set(const Variant &p_index, const Variant &p_value, bool *r_valid)
 		} break;
 		case OBJECT: {
 
-			Object *obj = _get_obj().obj;
+			Object *obj = _data._obj.obj;
 			//only if debugging!
 
 			if (obj) {
 #ifdef DEBUG_ENABLED
-				if (ScriptDebugger::get_singleton() && _get_obj().ref.is_null()) {
+				if (ScriptDebugger::get_singleton() && _data._obj.ref.is_null()) {
 
 					if (!ObjectDB::instance_validate(obj)) {
 						WARN_PRINT("Attempted use of stray pointer object.");
@@ -2542,11 +2542,11 @@ Variant Variant::get(const Variant &p_index, bool *r_valid) const {
 		case _RID: {
 		} break;
 		case OBJECT: {
-			Object *obj = _get_obj().obj;
+			Object *obj = _data._obj.obj;
 			if (obj) {
 
 #ifdef DEBUG_ENABLED
-				if (ScriptDebugger::get_singleton() && _get_obj().ref.is_null()) {
+				if (ScriptDebugger::get_singleton() && _data._obj.ref.is_null()) {
 					//only if debugging!
 					if (!ObjectDB::instance_validate(obj)) {
 						valid = false;
@@ -2606,12 +2606,12 @@ bool Variant::in(const Variant &p_index, bool *r_valid) const {
 
 		} break;
 		case OBJECT: {
-			Object *obj = _get_obj().obj;
+			Object *obj = _data._obj.obj;
 			if (obj) {
 
 				bool valid = false;
 #ifdef DEBUG_ENABLED
-				if (ScriptDebugger::get_singleton() && _get_obj().ref.is_null()) {
+				if (ScriptDebugger::get_singleton() && _data._obj.ref.is_null()) {
 					//only if debugging!
 					if (!ObjectDB::instance_validate(obj)) {
 						if (r_valid) {
@@ -2880,10 +2880,10 @@ void Variant::get_property_list(List<PropertyInfo> *p_list) const {
 		} break;
 		case OBJECT: {
 
-			Object *obj = _get_obj().obj;
+			Object *obj = _data._obj.obj;
 			if (obj) {
 #ifdef DEBUG_ENABLED
-				if (ScriptDebugger::get_singleton() && _get_obj().ref.is_null()) {
+				if (ScriptDebugger::get_singleton() && _data._obj.ref.is_null()) {
 					//only if debugging!
 					if (!ObjectDB::instance_validate(obj)) {
 						WARN_PRINT("Attempted get_property list on stray pointer.");
@@ -2962,12 +2962,12 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 		case OBJECT: {
 
 #ifdef DEBUG_ENABLED
-			if (!_get_obj().obj) {
+			if (!_data._obj.obj) {
 				valid = false;
 				return false;
 			}
 
-			if (ScriptDebugger::get_singleton() && _get_obj().ref.is_null() && !ObjectDB::instance_validate(_get_obj().obj)) {
+			if (ScriptDebugger::get_singleton() && _data._obj.ref.is_null() && !ObjectDB::instance_validate(_data._obj.obj)) {
 				valid = false;
 				return false;
 			}
@@ -2978,7 +2978,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 			ref.push_back(r_iter);
 			Variant vref = ref;
 			const Variant *refp[] = { &vref };
-			Variant ret = _get_obj().obj->call(CoreStringNames::get_singleton()->_iter_init, refp, 1, ce);
+			Variant ret = _data._obj.obj->call(CoreStringNames::get_singleton()->_iter_init, refp, 1, ce);
 
 			if (ref.size() != 1 || ce.error != Variant::CallError::CALL_OK) {
 				valid = false;
@@ -3130,12 +3130,12 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 		case OBJECT: {
 
 #ifdef DEBUG_ENABLED
-			if (!_get_obj().obj) {
+			if (!_data._obj.obj) {
 				valid = false;
 				return false;
 			}
 
-			if (ScriptDebugger::get_singleton() && _get_obj().ref.is_null() && !ObjectDB::instance_validate(_get_obj().obj)) {
+			if (ScriptDebugger::get_singleton() && _data._obj.ref.is_null() && !ObjectDB::instance_validate(_data._obj.obj)) {
 				valid = false;
 				return false;
 			}
@@ -3146,7 +3146,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 			ref.push_back(r_iter);
 			Variant vref = ref;
 			const Variant *refp[] = { &vref };
-			Variant ret = _get_obj().obj->call(CoreStringNames::get_singleton()->_iter_next, refp, 1, ce);
+			Variant ret = _data._obj.obj->call(CoreStringNames::get_singleton()->_iter_next, refp, 1, ce);
 
 			if (ref.size() != 1 || ce.error != Variant::CallError::CALL_OK) {
 				valid = false;
@@ -3289,12 +3289,12 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 		case OBJECT: {
 
 #ifdef DEBUG_ENABLED
-			if (!_get_obj().obj) {
+			if (!_data._obj.obj) {
 				r_valid = false;
 				return Variant();
 			}
 
-			if (ScriptDebugger::get_singleton() && _get_obj().ref.is_null() && !ObjectDB::instance_validate(_get_obj().obj)) {
+			if (ScriptDebugger::get_singleton() && _data._obj.ref.is_null() && !ObjectDB::instance_validate(_data._obj.obj)) {
 				r_valid = false;
 				return Variant();
 			}
@@ -3302,7 +3302,7 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 			Variant::CallError ce;
 			ce.error = Variant::CallError::CALL_OK;
 			const Variant *refp[] = { &r_iter };
-			Variant ret = _get_obj().obj->call(CoreStringNames::get_singleton()->_iter_get, refp, 1, ce);
+			Variant ret = _data._obj.obj->call(CoreStringNames::get_singleton()->_iter_get, refp, 1, ce);
 
 			if (ce.error != Variant::CallError::CALL_OK) {
 				r_valid = false;
@@ -3428,8 +3428,8 @@ Variant Variant::duplicate(bool deep) const {
 	switch (type) {
 		case OBJECT: {
 			/*  breaks stuff :(
-			if (deep && !_get_obj().ref.is_null()) {
-				Ref<Resource> resource = _get_obj().ref;
+			if (deep && !_data._obj.ref.is_null()) {
+				Ref<Resource> resource = _data._obj.ref;
 				if (resource.is_valid()) {
 					return resource->duplicate(true);
 				}


### PR DESCRIPTION
This is what the main commit does:
> This applies to non ref-counted `Object`s (i.e., any that is not a `Resource`).
> 
> When an object is freed while there are still `Variant`s referring to it, these are nullified and a warning about this is printed.
> 
> This is made possible thanks to a linked list (the 'sentinel chain') of such `Variants`. It's kept collaboratively
> - by `Object`, which contains a pointer to the first `Variant` in the chain
> - and by `Variant`, which contains a pointer to the next one.
> 
> The sentinel list is kept valid at all times by handling operations over `Variant`, such as reassignment and clearing.

The other important change is making `CowData` aware of non-trivially copyable types, much needed for the main part to work right.

Notes:
- I've tested this with pretty script-intensive projects, with no problems and **negligible performance degradation**.
- This will get us rid of crashes due to accessing freed `Object`s in scripts.
- This will fix the bug by which a script variable is reassigned to a new `Object` senselessly.
- This will help catching bugs in script logic, as the warning will let you know about those cases waiting to bite you, that were formerly hidden.

Fixes #32383.

----

**This code is generously donated by IMVU.**