### PR TITLE
Add an extra bit to material flag cache

### DIFF
--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -249,7 +249,7 @@ private:
 			uint64_t blend_mode : 2;
 			uint64_t depth_draw_mode : 2;
 			uint64_t cull_mode : 2;
-			uint64_t flags : 18;
+			uint64_t flags : 19;
 			uint64_t detail_blend_mode : 2;
 			uint64_t diffuse_mode : 3;
 			uint64_t specular_mode : 3;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/35665

Total bits for cache is now 57.

``FLAGS`` enum has 19 members not 18. 

@akien-mga I have this tagged for 3.2.1 as it is low priority, but if you are still merging easy changes, this is a candidate for 3.2.0.