### PR TITLE
Fix static functions loop using class' functions in Language Server

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -757,7 +757,7 @@ Dictionary ExtendGDScriptParser::dump_class_api(const GDScriptParser::ClassNode 
 
 	Array static_functions;
 	for (int i = 0; i < p_class->static_functions.size(); ++i) {
-		static_functions.append(dump_function_api(p_class->functions[i]));
+		static_functions.append(dump_function_api(p_class->static_functions[i]));
 	}
 	class_api["static_functions"] = static_functions;
 


### PR DESCRIPTION
Fixes #35672 

Besides leading to incorrect output, it also caused a hard editor crash for purely static classes or classes with more static functions than methods due to an index out of range error.