### PR TITLE
Fix bug where canvas culls things at origin with size 0

### DIFF
--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -60,6 +60,19 @@ struct Rect2 {
 		return true;
 	}
 
+	inline bool intersects_touch(const Rect2 &p_rect) const {
+		if (position.x > (p_rect.position.x + p_rect.size.width))
+			return false;
+		if ((position.x + size.width) < p_rect.position.x)
+			return false;
+		if (position.y > (p_rect.position.y + p_rect.size.height))
+			return false;
+		if ((position.y + size.height) < p_rect.position.y)
+			return false;
+
+		return true;
+	}
+
 	inline real_t distance_to(const Vector2 &p_point) const {
 
 		real_t dist = 0.0;

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -168,7 +168,7 @@ void VisualServerCanvas::_render_canvas_item(Item *p_canvas_item, const Transfor
 		VisualServerRaster::redraw_request();
 	}
 
-	if ((!ci->commands.empty() && p_clip_rect.intersects(global_rect)) || ci->vp_render || ci->copy_back_buffer) {
+	if ((!ci->commands.empty() && p_clip_rect.intersects_touch(global_rect)) || ci->vp_render || ci->copy_back_buffer) {
 		//something to draw?
 		ci->final_transform = xform;
 		ci->final_modulate = Color(modulate.r * ci->self_modulate.r, modulate.g * ci->self_modulate.g, modulate.b * ci->self_modulate.b, modulate.a * ci->self_modulate.a);


### PR DESCRIPTION
Fixes #17917 

Rather than detecting if the control rectangle is intersecting, detect if it is intersecting or touching.  
It should be noted that I added another function to `Rect2` which may not be favourable

Note: Special thanks to @clayjohn for helping me find where the culling is, otherwise I couldn't have made this change

*In my opinion, this should be cherry-picked for the first maintenance release of Godot 3.2*