### PR TITLE
Accelerate 2D by tracking state client-side

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.h
+++ b/drivers/gles2/rasterizer_canvas_gles2.h
@@ -98,6 +98,29 @@ public:
 
 	} state;
 
+	struct CommandState {
+		CommandState(RasterizerCanvasGLES2 *p_owner) {
+			reset();
+			owner = p_owner;
+		}
+
+		void reset();
+		bool release(Item::Command::Type p_command_type);
+		void set_force_repeat(bool p_repeat);
+		void set_tiling(bool p_tile);
+
+		Item::Command::Type type;
+		bool complete; // whether state change is completed
+		bool tiling;
+		bool force_repeat;
+		RID RID_texture;
+		RID RID_normal;
+		RasterizerStorageGLES2::Texture *current_tex;
+		Size2 tex_pixel_size;
+		Color color;
+		RasterizerCanvasGLES2 *owner;
+	};
+
 	typedef void Texture;
 
 	RasterizerSceneGLES2 *scene_render;
@@ -144,5 +167,72 @@ public:
 
 	RasterizerCanvasGLES2();
 };
+
+// clear our internal records of state
+inline void RasterizerCanvasGLES2::CommandState::reset() {
+	complete = false;
+	tiling = false;
+	force_repeat = false;
+	RID_texture = RID();
+	RID_normal = RID();
+	current_tex = 0;
+	color.a = -1; // just to ensure a difference is found
+	type = Item::Command::TYPE_NULL;
+}
+
+// return whether command type changed
+inline bool RasterizerCanvasGLES2::CommandState::release(Item::Command::Type p_command_type) {
+	// noop, no state change
+	if (p_command_type == type)
+		return false;
+
+	// this will always occur on the first command item
+	if (type == Item::Command::TYPE_NULL)
+		return true; // nothing to do
+
+	// put opengl back into a 'default' state when finishing a 'batch' of similar commands
+	switch (type) {
+		// only dealing with speeding up rects so far
+		case Item::Command::TYPE_RECT: {
+			// only considering one case for now
+			if (!owner->use_nvidia_rect_workaround) {
+				set_tiling(false);
+				set_force_repeat(false);
+				glBindBuffer(GL_ARRAY_BUFFER, 0);
+				glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+			}
+		} break;
+		default:
+			break;
+	}
+
+	reset();
+
+	return true;
+}
+
+inline void RasterizerCanvasGLES2::CommandState::set_force_repeat(bool p_repeat) {
+	// noop
+	if (p_repeat == force_repeat)
+		return;
+
+	owner->state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_FORCE_REPEAT, p_repeat);
+	force_repeat = p_repeat;
+}
+
+inline void RasterizerCanvasGLES2::CommandState::set_tiling(bool p_tile) {
+	// noop?
+	if (p_tile == tiling)
+		return;
+
+	if (p_tile) {
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+	} else {
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	}
+	tiling = p_tile;
+}
 
 #endif // RASTERIZERCANVASGLES2_H

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1250,6 +1250,8 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 				}
 
 			} break;
+			case Item::Command::TYPE_NULL: {
+			} break;
 		}
 	}
 }

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -684,6 +684,7 @@ public:
 
 			enum Type {
 
+				TYPE_NULL,
 				TYPE_LINE,
 				TYPE_POLYLINE,
 				TYPE_RECT,
@@ -1006,6 +1007,10 @@ public:
 					} break;
 
 					case Item::Command::TYPE_CLIP_IGNORE: {
+
+					} break;
+
+					case Item::Command::TYPE_NULL: {
 
 					} break;
 				}


### PR DESCRIPTION
GLES2 only first.

Godot 2D performance is usually bottlenecked by the methods used with OpenGL, there are currently drawcalls per quad.

In this PR basic state tracking is added to rasterizer_canvas_gles2::_canvas_item_render_commands().

This gives a 'free' performance increase of around 40% frames per second in a test scene, while requiring minimal changes to the overall mechanism.

### Notes

- I have been using the test project in this issue #27230 with the tilemap selected as the one under test.

- The actual speed increase will scale with the number of Rects being drawn. There is also likely to be more benefit on some hardware / platform combinations than others, all should receive some benefit.

- The best solution to this problem is batching, which will give far greater performance increases. But this might help as a simpler interim solution.

Mentioning @clayjohn as we discussed this yesterday.