### PR TITLE
Allow constructors with same arg count but different types

### DIFF
--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -913,8 +913,8 @@ Vector<Plane> Geometry::build_sphere_planes(real_t p_radius, int p_lats, int p_l
 			// FIXME: This is stupid.
 			Vector3 angle = normal.linear_interpolate(axis, j / (real_t)p_lats).normalized();
 			Vector3 pos = angle * p_radius;
-			planes.push_back(Plane(pos, angle));
-			planes.push_back(Plane(pos * axis_neg, angle * axis_neg));
+			planes.push_back(Plane(angle, pos));
+			planes.push_back(Plane(angle * axis_neg, pos * axis_neg));
 		}
 	}
 
@@ -945,8 +945,8 @@ Vector<Plane> Geometry::build_capsule_planes(real_t p_radius, real_t p_height, i
 
 			Vector3 angle = normal.linear_interpolate(axis, j / (real_t)p_lats).normalized();
 			Vector3 pos = axis * p_height * 0.5 + angle * p_radius;
-			planes.push_back(Plane(pos, angle));
-			planes.push_back(Plane(pos * axis_neg, angle * axis_neg));
+			planes.push_back(Plane(angle, pos));
+			planes.push_back(Plane(angle * axis_neg, pos * axis_neg));
 		}
 	}
 

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -107,7 +107,7 @@ Plane::Plane(const Vector3 &p_normal, real_t p_d) :
 		d(p_d) {
 }
 
-Plane::Plane(const Vector3 &p_point, const Vector3 &p_normal) :
+Plane::Plane(const Vector3 &p_normal, const Vector3 &p_point) :
 		normal(p_normal),
 		d(p_normal.dot(p_point)) {
 }

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -612,7 +612,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 
 	if (collision_segments.size()) {
 
-		Plane camp(p_camera->get_transform().origin, (-p_camera->get_transform().basis.get_axis(2)).normalized());
+		Plane camp((-p_camera->get_transform().basis.get_axis(2)).normalized(), p_camera->get_transform().origin);
 
 		int vc = collision_segments.size();
 		const Vector3 *vptr = collision_segments.ptr();
@@ -898,7 +898,7 @@ void Light3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camer
 			light->set_param(Light3D::PARAM_RANGE, d);
 		} else if (Object::cast_to<OmniLight3D>(light)) {
 
-			Plane cp = Plane(gt.origin, p_camera->get_transform().basis.get_axis(2));
+			Plane cp = Plane(p_camera->get_transform().basis.get_axis(2), gt.origin);
 
 			Vector3 inters;
 			if (cp.intersects_ray(ray_from, ray_dir, &inters)) {
@@ -1457,7 +1457,7 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Vector3 cam_pos = camera->get_global_transform().origin;
 		Vector3 parent_pos = parent->get_global_transform().origin;
 
-		Plane parent_plane(parent_pos, cam_normal);
+		Plane parent_plane(cam_normal, parent_pos);
 		Vector3 ray_from = parent_plane.project(cam_pos);
 
 		lines.clear();

--- a/editor/plugins/collision_polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_3d_editor_plugin.cpp
@@ -118,7 +118,7 @@ bool CollisionPolygon3DEditor::forward_spatial_gui_input(Camera3D *p_camera, con
 	Transform gi = gt.affine_inverse();
 	float depth = _get_depth() * 0.5;
 	Vector3 n = gt.basis.get_axis(2).normalized();
-	Plane p(gt.origin + n * depth, n);
+	Plane p(n, gt.origin + n * depth);
 
 	Ref<InputEventMouseButton> mb = p_event;
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -668,14 +668,14 @@ void Node3DEditorViewport::_select_region() {
 		Vector3 a = _get_screen_to_space(box[i]);
 		Vector3 b = _get_screen_to_space(box[(i + 1) % 4]);
 		if (orthogonal) {
-			frustum.push_back(Plane(a, (a - b).normalized()));
+			frustum.push_back(Plane((a - b).normalized(), a));
 		} else {
 			frustum.push_back(Plane(a, b, cam_pos));
 		}
 	}
 
 	if (!orthogonal) {
-		Plane near(cam_pos, -_get_camera_normal());
+		Plane near(-_get_camera_normal(), cam_pos);
 		near.d -= get_znear();
 
 		frustum.push_back(near);
@@ -851,7 +851,7 @@ bool Node3DEditorViewport::_gizmo_select(const Vector2 &p_screenpos, bool p_high
 				Vector3 grabber_pos = gt.origin + (ivec2 + ivec3) * gs * (GIZMO_PLANE_SIZE + GIZMO_PLANE_DST);
 
 				Vector3 r;
-				Plane plane(gt.origin, gt.basis.get_axis(i).normalized());
+				Plane plane(gt.basis.get_axis(i).normalized(), gt.origin);
 
 				if (plane.intersects_ray(ray_pos, ray, &r)) {
 
@@ -893,7 +893,7 @@ bool Node3DEditorViewport::_gizmo_select(const Vector2 &p_screenpos, bool p_high
 
 		for (int i = 0; i < 3; i++) {
 
-			Plane plane(gt.origin, gt.basis.get_axis(i).normalized());
+			Plane plane(gt.basis.get_axis(i).normalized(), gt.origin);
 			Vector3 r;
 			if (!plane.intersects_ray(ray_pos, ray, &r))
 				continue;
@@ -959,7 +959,7 @@ bool Node3DEditorViewport::_gizmo_select(const Vector2 &p_screenpos, bool p_high
 				Vector3 grabber_pos = gt.origin + (ivec2 + ivec3) * gs * (GIZMO_PLANE_SIZE + GIZMO_PLANE_DST);
 
 				Vector3 r;
-				Plane plane(gt.origin, gt.basis.get_axis(i).normalized());
+				Plane plane(gt.basis.get_axis(i).normalized(), gt.origin);
 
 				if (plane.intersects_ray(ray_pos, ray, &r)) {
 
@@ -1513,33 +1513,33 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						switch (_edit.plane) {
 							case TRANSFORM_VIEW:
 								motion_mask = Vector3(0, 0, 0);
-								plane = Plane(_edit.center, _get_camera_normal());
+								plane = Plane(_get_camera_normal(), _edit.center);
 								break;
 							case TRANSFORM_X_AXIS:
 								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(0);
-								plane = Plane(_edit.center, motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized());
+								plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
 								break;
 							case TRANSFORM_Y_AXIS:
 								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(1);
-								plane = Plane(_edit.center, motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized());
+								plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
 								break;
 							case TRANSFORM_Z_AXIS:
 								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(2);
-								plane = Plane(_edit.center, motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized());
+								plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
 								break;
 							case TRANSFORM_YZ:
 								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(2) + spatial_editor->get_gizmo_transform().basis.get_axis(1);
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(0));
+								plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(0), _edit.center);
 								plane_mv = true;
 								break;
 							case TRANSFORM_XZ:
 								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(2) + spatial_editor->get_gizmo_transform().basis.get_axis(0);
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(1));
+								plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(1), _edit.center);
 								plane_mv = true;
 								break;
 							case TRANSFORM_XY:
 								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(0) + spatial_editor->get_gizmo_transform().basis.get_axis(1);
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(2));
+								plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(2), _edit.center);
 								plane_mv = true;
 								break;
 						}
@@ -1660,30 +1660,30 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 						switch (_edit.plane) {
 							case TRANSFORM_VIEW:
-								plane = Plane(_edit.center, _get_camera_normal());
+								plane = Plane(_get_camera_normal(), _edit.center);
 								break;
 							case TRANSFORM_X_AXIS:
 								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(0);
-								plane = Plane(_edit.center, motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized());
+								plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
 								break;
 							case TRANSFORM_Y_AXIS:
 								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(1);
-								plane = Plane(_edit.center, motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized());
+								plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
 								break;
 							case TRANSFORM_Z_AXIS:
 								motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(2);
-								plane = Plane(_edit.center, motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized());
+								plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
 								break;
 							case TRANSFORM_YZ:
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(0));
+								plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(0), _edit.center);
 								plane_mv = true;
 								break;
 							case TRANSFORM_XZ:
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(1));
+								plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(1), _edit.center);
 								plane_mv = true;
 								break;
 							case TRANSFORM_XY:
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(2));
+								plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(2), _edit.center);
 								plane_mv = true;
 								break;
 						}
@@ -1769,18 +1769,18 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 						switch (_edit.plane) {
 							case TRANSFORM_VIEW:
-								plane = Plane(_edit.center, _get_camera_normal());
+								plane = Plane(_get_camera_normal(), _edit.center);
 								break;
 							case TRANSFORM_X_AXIS:
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(0));
+								plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(0), _edit.center);
 								axis = Vector3(1, 0, 0);
 								break;
 							case TRANSFORM_Y_AXIS:
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(1));
+								plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(1), _edit.center);
 								axis = Vector3(0, 1, 0);
 								break;
 							case TRANSFORM_Z_AXIS:
-								plane = Plane(_edit.center, spatial_editor->get_gizmo_transform().basis.get_axis(2));
+								plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(2), _edit.center);
 								axis = Vector3(0, 0, 1);
 								break;
 							case TRANSFORM_YZ:
@@ -3259,7 +3259,7 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 
 	Vector3 camz = -camera_xform.get_basis().get_axis(2).normalized();
 	Vector3 camy = -camera_xform.get_basis().get_axis(1).normalized();
-	Plane p(camera_xform.origin, camz);
+	Plane p(camz, camera_xform.origin);
 	float gizmo_d = Math::abs(p.distance_to(xform.origin));
 	float d0 = camera->unproject_position(camera_xform.origin + camz * gizmo_d).y;
 	float d1 = camera->unproject_position(camera_xform.origin + camz * gizmo_d + camy).y;

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -98,7 +98,7 @@ void Path3DGizmo::set_handle(int p_idx, Camera3D *p_camera, const Point2 &p_poin
 	// Setting curve point positions
 	if (p_idx < c->get_point_count()) {
 
-		Plane p(gt.xform(original), p_camera->get_transform().basis.get_axis(2));
+		Plane p(p_camera->get_transform().basis.get_axis(2), gt.xform(original));
 
 		Vector3 inters;
 
@@ -123,7 +123,7 @@ void Path3DGizmo::set_handle(int p_idx, Camera3D *p_camera, const Point2 &p_poin
 
 	Vector3 base = c->get_point_position(idx);
 
-	Plane p(gt.xform(original), p_camera->get_transform().basis.get_axis(2));
+	Plane p(p_camera->get_transform().basis.get_axis(2), gt.xform(original));
 
 	Vector3 inters;
 
@@ -390,7 +390,7 @@ bool Path3DEditorPlugin::forward_spatial_gui_input(Camera3D *p_camera, const Ref
 					org = path->get_transform().get_origin();
 				else
 					org = gt.xform(c->get_point_position(c->get_point_count() - 1));
-				Plane p(org, p_camera->get_transform().basis.get_axis(2));
+				Plane p(p_camera->get_transform().basis.get_axis(2), org);
 				Vector3 ray_from = p_camera->project_ray_origin(mbpos);
 				Vector3 ray_dir = p_camera->project_ray_normal(mbpos);
 

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -750,7 +750,7 @@ void ClippedCamera3D::_notification(int p_what) {
 		Vector3 cam_pos = get_global_transform().origin;
 		Vector3 parent_pos = parent->get_global_transform().origin;
 
-		Plane parent_plane(parent_pos, cam_fw);
+		Plane parent_plane(cam_fw, parent_pos);
 
 		if (parent_plane.is_point_over(cam_pos)) {
 			//cam is beyond parent plane

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -511,7 +511,7 @@ Plane XRAnchor3D::get_plane() const {
 	Vector3 location = get_translation();
 	Basis orientation = get_transform().basis;
 
-	Plane plane(location, orientation.get_axis(1).normalized());
+	Plane plane(orientation.get_axis(1).normalized(), location);
 
 	return plane;
 };

--- a/servers/physics_3d/collision_solver_3d_sat.cpp
+++ b/servers/physics_3d/collision_solver_3d_sat.cpp
@@ -167,7 +167,7 @@ static void _generate_contacts_face_face(const Vector3 *p_points_A, int p_point_
 		Vector3 clip_normal = (edge0_B - edge1_B).cross(plane_B.normal).normalized();
 		// make a clip plane
 
-		Plane clip(edge0_B, clip_normal);
+		Plane clip(clip_normal, edge0_B);
 		// avoid double clip if A is edge
 		int dst_idx = 0;
 		bool edge = clipbuf_len == 2;

--- a/servers/physics_3d/shape_3d_sw.cpp
+++ b/servers/physics_3d/shape_3d_sw.cpp
@@ -902,7 +902,7 @@ Vector3 ConvexPolygonShape3DSW::get_closest_point_to(const Vector3 &p_point) con
 			Vector3 a = vertices[indices[j]];
 			Vector3 b = vertices[indices[(j + 1) % ic]];
 			Vector3 n = (a - b).cross(faces[i].plane.normal).normalized();
-			if (Plane(a, n).is_point_over(p_point)) {
+			if (Plane(n, a).is_point_over(p_point)) {
 				is_inside = false;
 				break;
 			}

--- a/servers/rendering/rendering_server_scene.cpp
+++ b/servers/rendering/rendering_server_scene.cpp
@@ -1363,7 +1363,7 @@ bool RenderingServerScene::_light_instance_update_shadow(Instance *p_instance, c
 				//optimize min/max
 				Vector<Plane> planes = p_cam_projection.get_projection_planes(p_cam_transform);
 				int cull_count = p_scenario->octree.cull_convex(planes, instance_shadow_cull_result, MAX_INSTANCE_CULL, RS::INSTANCE_GEOMETRY_MASK);
-				Plane base(p_cam_transform.origin, -p_cam_transform.basis.get_axis(2));
+				Plane base(-p_cam_transform.basis.get_axis(2), p_cam_transform.origin);
 				//check distance max and min
 
 				bool found_items = false;
@@ -1586,7 +1586,7 @@ bool RenderingServerScene::_light_instance_update_shadow(Instance *p_instance, c
 
 				// a pre pass will need to be needed to determine the actual z-near to be used
 
-				Plane near_plane(light_transform.origin, -light_transform.basis.get_axis(2));
+				Plane near_plane(-light_transform.basis.get_axis(2), light_transform.origin);
 
 				real_t cull_max = 0;
 				for (int j = 0; j < cull_count; j++) {
@@ -1740,7 +1740,7 @@ bool RenderingServerScene::_light_instance_update_shadow(Instance *p_instance, c
 					planes.write[4] = light_transform.xform(Plane(Vector3(0, -1, z).normalized(), radius));
 
 					int cull_count = p_scenario->octree.cull_convex(planes, instance_shadow_cull_result, MAX_INSTANCE_CULL, RS::INSTANCE_GEOMETRY_MASK);
-					Plane near_plane(light_transform.origin, light_transform.basis.get_axis(2) * z);
+					Plane near_plane(light_transform.basis.get_axis(2) * z, light_transform.origin);
 
 					for (int j = 0; j < cull_count; j++) {
 
@@ -1796,7 +1796,7 @@ bool RenderingServerScene::_light_instance_update_shadow(Instance *p_instance, c
 
 					int cull_count = p_scenario->octree.cull_convex(planes, instance_shadow_cull_result, MAX_INSTANCE_CULL, RS::INSTANCE_GEOMETRY_MASK);
 
-					Plane near_plane(xform.origin, -xform.basis.get_axis(2));
+					Plane near_plane(-xform.basis.get_axis(2), xform.origin);
 					for (int j = 0; j < cull_count; j++) {
 
 						Instance *instance = instance_shadow_cull_result[j];
@@ -1835,7 +1835,7 @@ bool RenderingServerScene::_light_instance_update_shadow(Instance *p_instance, c
 			Vector<Plane> planes = cm.get_projection_planes(light_transform);
 			int cull_count = p_scenario->octree.cull_convex(planes, instance_shadow_cull_result, MAX_INSTANCE_CULL, RS::INSTANCE_GEOMETRY_MASK);
 
-			Plane near_plane(light_transform.origin, -light_transform.basis.get_axis(2));
+			Plane near_plane(-light_transform.basis.get_axis(2), light_transform.origin);
 			for (int j = 0; j < cull_count; j++) {
 
 				Instance *instance = instance_shadow_cull_result[j];
@@ -2012,7 +2012,7 @@ void RenderingServerScene::_prepare_scene(const Transform p_cam_transform, const
 
 	Vector<Plane> planes = p_cam_projection.get_projection_planes(p_cam_transform);
 
-	Plane near_plane(p_cam_transform.origin, -p_cam_transform.basis.get_axis(2).normalized());
+	Plane near_plane(-p_cam_transform.basis.get_axis(2).normalized(), p_cam_transform.origin);
 	float z_far = p_cam_projection.get_z_far();
 
 	/* STEP 2 - CULL */
@@ -2249,7 +2249,7 @@ void RenderingServerScene::_prepare_scene(const Transform p_cam_transform, const
 
 				Transform cam_xf = p_cam_transform;
 				float zn = p_cam_projection.get_z_near();
-				Plane p(cam_xf.origin + cam_xf.basis.get_axis(2) * -zn, -cam_xf.basis.get_axis(2)); //camera near plane
+				Plane p(-cam_xf.basis.get_axis(2), cam_xf.origin + cam_xf.basis.get_axis(2) * -zn); //camera near plane
 
 				// near plane half width and height
 				Vector2 vp_half_extents = p_cam_projection.get_viewport_half_extents();


### PR DESCRIPTION
Currently, only the first found constructor with the same arg count is being checked for matching types, ignoring other constructors that might match instead.

This commit changes that and exposes Plane(point, normal), closes https://github.com/godotengine/godot/issues/21113

Since I'm not experienced in C++, please pay attention to things that could be done better.