### PR TITLE
Fix double tap pressed event regression

### DIFF
--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -507,9 +507,8 @@ void OS_Android::process_double_tap(Point2 p_pos) {
 	ev.instance();
 	ev->set_position(p_pos);
 	ev->set_global_position(p_pos);
-	ev->set_pressed(true);
+	ev->set_pressed(false);
 	ev->set_doubleclick(true);
-	ev->set_button_index(1);
 	input->parse_input_event(ev);
 }
 


### PR DESCRIPTION
closes https://github.com/godotengine/godot/issues/35655

please test it.

The double click was recognized as a pressed event.

