### PR TITLE
Add holes support for `Geometry.decompose_polygon_in_convex`

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1636,6 +1636,27 @@ Vector<int> _Geometry::triangulate_delaunay_2d(const Vector<Vector2> &p_points) 
 	return Geometry::triangulate_delaunay_2d(p_points);
 }
 
+Array _Geometry::decompose_polygon_in_convex(const Vector<Point2> &p_polygon_outer, Array p_polygons_inner) {
+
+	Vector<Vector<Point2> > decomp;
+
+	if (!p_polygons_inner.empty()) {
+		Vector<Vector<Point2> > polygons_inner;
+		for (int i = 0; i < p_polygons_inner.size(); i++) {
+			polygons_inner.push_back(p_polygons_inner[i]);
+		}
+		decomp = Geometry::decompose_polygon_in_convex(p_polygon_outer, &polygons_inner);
+	} else {
+		decomp = Geometry::decompose_polygon_in_convex(p_polygon_outer);
+	}
+
+	Array ret;
+	for (int i = 0; i < decomp.size(); i++) {
+		ret.push_back(decomp[i]);
+	}
+	return ret;
+}
+
 Vector<Point2> _Geometry::convex_hull_2d(const Vector<Point2> &p_points) {
 
 	return Geometry::convex_hull_2d(p_points);
@@ -1807,6 +1828,7 @@ void _Geometry::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_point_in_polygon", "point", "polygon"), &_Geometry::is_point_in_polygon);
 	ClassDB::bind_method(D_METHOD("triangulate_polygon", "polygon"), &_Geometry::triangulate_polygon);
 	ClassDB::bind_method(D_METHOD("triangulate_delaunay_2d", "points"), &_Geometry::triangulate_delaunay_2d);
+	ClassDB::bind_method(D_METHOD("decompose_polygon_in_convex", "polygon", "polygons_inner"), &_Geometry::decompose_polygon_in_convex, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("convex_hull_2d", "points"), &_Geometry::convex_hull_2d);
 	ClassDB::bind_method(D_METHOD("clip_polygon", "points", "plane"), &_Geometry::clip_polygon);
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -408,6 +408,7 @@ public:
 	bool is_point_in_polygon(const Point2 &p_point, const Vector<Vector2> &p_polygon);
 	Vector<int> triangulate_polygon(const Vector<Vector2> &p_polygon);
 	Vector<int> triangulate_delaunay_2d(const Vector<Vector2> &p_points);
+	Array decompose_polygon_in_convex(const Vector<Point2> &p_polygon_outer, Array p_polygons_inner);
 	Vector<Point2> convex_hull_2d(const Vector<Point2> &p_points);
 	Vector<Vector3> clip_polygon(const Vector<Vector3> &p_points, const Plane &p_plane);
 

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -1004,7 +1004,7 @@ public:
 		H.resize(k);
 		return H;
 	}
-	static Vector<Vector<Vector2> > decompose_polygon_in_convex(Vector<Point2> polygon);
+	static Vector<Vector<Point2> > decompose_polygon_in_convex(const Vector<Point2> &p_polygon_outer, Vector<Vector<Point2> > *r_polygons_inner = NULL);
 
 	static MeshData build_convex_mesh(const PoolVector<Plane> &p_planes);
 	static PoolVector<Plane> build_sphere_planes(real_t p_radius, int p_lats, int p_lons, Vector3::Axis p_axis = Vector3::AXIS_Z);


### PR DESCRIPTION
Resolves #35676 as an alternative method to solve the use case described by @fian46 which can also be done via script bypassing `NavigationPolygon.make_polygons_from_outlines` which mostly does the same thing under the hood, yet this also: 

* helps godotengine/godot-proposals#200 as the exposed method allows to make proper convex shapes to be added to arbitrary collision objects using the results from polygon clipping, as clipping may produce polygons which lie inside other polygons (holes);

* see https://github.com/godotengine/godot-proposals/issues/199#issuecomment-549429967 for the polygon "donut" where the limitation is worked around by hacking out a [keyholed](https://www.artwork.com/gerber/oasis2gbr/holes.htm) representation of a polygon;

* see #30251 for a similar use case.

Also resolves godotengine/godot-proposals#2668.

A new `polygons_inner` parameter is added to `Geometry.decompose_polygon_in_convex` which allows to pass holes to the polygon decomposer, so this just makes the method more flexible and shouldn't break anything. The user has to separate the input into outer and inner polygons themselves (can be checked with `Geometry.is_polygon_clockwise`):

```gdscript
var clip = Geometry.clip_polygons_2d(a, b) # `a` may completely enclose `b`: clip.size() == 2
var outer = []
var inner = []
for poly in clip:
	if Geometry.is_polygon_clockwise(poly):
		inner.push_back(poly)
	else:
		outer.push_back(poly)

for outer_poly in outer:
	var convex = Geometry.decompose_polygon_in_convex(outer_poly, inner)
```

---

As an alternative, the implementation could also be reused similarly to how #26614 has done to `CollisionPolygon2D::_decompose_in_convex()`. It means that a similar method could be moved from `NavigationPolygon.make_polygons_from_outlines` to `Geometry.make_polygons_from_outlines` or similar, which would also alleviate the requirement for distinguishing between inner and outer polygons, and multiple outer polygons could also be fed, which allows to simplify the above script down to:

```gdscript
var clip = Geometry.clip_polygons_2d(a, b)
var convex = Geometry.make_convex_from_outlines(clip)
```

I'm not sure if there's anything about #34776 which would throw away existing navigation code, so yeah it might make sense to salvage this for other use cases. If you think it makes sense to do this instead of the proposed enhancement, I could close this PR and do necessary steps to make this happen, else this PR can be seen as feature-complete. This could also be done in the next PR too, as two methods can co-exist nicely, depending on what kind of input you have.

### Test project
[geometry-decomp.zip](https://github.com/godotengine/godot/files/4129361/geometry-decomp.zip)
