### PR TITLE
Update cached_width of the line_edit element (#35699)

### DIFF
--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -132,6 +132,7 @@ private:
 	void _emit_text_change();
 	bool expand_to_text_length;
 
+	void update_cached_width();
 	void update_placeholder_width();
 
 	bool caret_blink_enabled;


### PR DESCRIPTION
The `cached_width` of the `line_edit` elements is not recalculated after the `pass` property is set/unset, or if the `secret_character` property is changed. This results in alignment issues, as evident from issue #35699.

The solution is to recalculate the width after these properties are touched; my change creates a small helper function that can be called after these properties are set in their respective setter methods.

NOTE: I just saw that the indentation looks a little weird; it appeared fine on my end, so I'll change it after the first round of review is complete.

*Bugsquad edit:* Fixes #35699.