### PR TITLE
[3.x] Tooltips for exported variables

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -150,6 +150,9 @@ struct PropertyInfo {
 	StringName class_name; //for classes
 	PropertyHint hint;
 	String hint_string;
+#ifdef TOOLS_ENABLED
+	String tooltip;
+#endif
 	uint32_t usage;
 
 	_FORCE_INLINE_ PropertyInfo added_usage(int p_fl) const {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1766,7 +1766,7 @@ void EditorInspector::update_tree() {
 					if (doc_hint != String()) {
 						ep->set_tooltip(property_prefix + p.name + "::" + doc_hint);
 					} else {
-						ep->set_tooltip(property_prefix + p.name);
+						ep->set_tooltip(property_prefix + p.name + "::" + p.tooltip);
 					}
 					ep->update_property();
 					ep->_update_pin_flags();

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3719,6 +3719,28 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 			case GDScriptTokenizer::TK_CURSOR: {
 				tokenizer->advance();
 			} break;
+			case GDScriptTokenizer::TK_TOOLTIP: {
+				tokenizer->advance();
+#ifdef TOOLS_ENABLED
+				if (tokenizer->get_token() == GDScriptTokenizer::TK_CONSTANT && tokenizer->get_token_constant().get_type() == Variant::STRING) {
+					Variant constant = tokenizer->get_token_constant();
+					current_export.tooltip = constant;
+				}
+
+				// Handle multiline tooltips.
+				while (tokenizer->get_token(2) == GDScriptTokenizer::TK_TOOLTIP) {
+					tokenizer->advance(3);
+					if (tokenizer->get_token() == GDScriptTokenizer::TK_CONSTANT && tokenizer->get_token_constant().get_type() == Variant::STRING) {
+						Variant constant = tokenizer->get_token_constant();
+						current_export.tooltip += constant.operator String();
+					}
+				}
+#else
+				if (tokenizer->get_token() == GDScriptTokenizer::TK_CONSTANT && tokenizer->get_token_constant().get_type() == Variant::STRING) {
+					tokenizer->advance();
+				}
+#endif
+			} break;
 			case GDScriptTokenizer::TK_EOF:
 				p_class->end_line = tokenizer->get_token_line();
 			case GDScriptTokenizer::TK_ERROR: {
@@ -4921,7 +4943,12 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 					member._export = current_export;
 					current_export = PropertyInfo();
 				}
-
+#ifdef TOOLS_ENABLED
+				if (autoexport) {
+					member._export.tooltip = current_export.tooltip;
+					current_export.tooltip = "";
+				}
+#endif
 				bool onready = tokenizer->get_token(-1) == GDScriptTokenizer::TK_PR_ONREADY;
 
 				tokenizer->advance();

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -143,6 +143,7 @@ public:
 		TK_ERROR,
 		TK_EOF,
 		TK_CURSOR, //used for code completion
+		TK_TOOLTIP,
 		TK_MAX
 	};
 


### PR DESCRIPTION
Backward compatible solution to add custom tooltips for exported variables.
Uses comments syntax, so it won't throw errors on previous versions. Tooltips are parsed only in editor. Supports BBCode.
``` gdscript
## [b]Tooltips[/b] for exported variables. [br][img]icon.png[/img] [br]With [color=green]BBCode[/color] support. [br]Enjoy!
export var with_tooltip = 2
```
![tooltips1](https://user-images.githubusercontent.com/1554127/73392683-8df26c00-42da-11ea-9fc5-f6287db5b410.jpg)
![tooltips2](https://user-images.githubusercontent.com/1554127/73392659-8632c780-42da-11ea-9d96-a67a7f9f3a83.jpg)

Related issue https://github.com/godotengine/godot/issues/6204