### PR TITLE
Automatically assign labels to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug in Godot
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature---enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature---enhancement-request.md
@@ -2,7 +2,7 @@
 name: Feature / Enhancement Request
 about: Adding new features or improving existing ones.
 title: 'IMPORTANT: This repository no longer accepts feature / enhancement requests.'
-labels: ''
+labels: 'archived'
 assignees: ''
 
 ---


### PR DESCRIPTION
Since the Bug Report template is meant to be used for reporting bugs, we can automatically assign the `bug` label. We can remove the label later if the issue isn't actually a bug (e.g. it's a documentation issue).

If anyone clicks through the Feature / Enhancement Request template, we assign the `archived` label automatically to ease maintainers' job slightly. The issue will still need to be closed manually, though.

There's still manual work required to manage labels, but this should spare maintainers' mice/keyboards just a little bit :slightly_smiling_face: