### PR TITLE
Adds pan and zoom gestures to TextureRegion editor

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -546,6 +546,17 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 			edit_draw->update();
 		}
 	}
+
+	Ref<InputEventMagnifyGesture> magnify_gesture = p_input;
+	if (magnify_gesture.is_valid()) {
+		_zoom_on_position(draw_zoom * magnify_gesture->get_factor(), magnify_gesture->get_position());
+	}
+
+	Ref<InputEventPanGesture> pan_gesture = p_input;
+	if (pan_gesture.is_valid()) {
+		hscroll->set_value(hscroll->get_value() + hscroll->get_page() * pan_gesture->get_delta().x / 8);
+		vscroll->set_value(vscroll->get_value() + vscroll->get_page() * pan_gesture->get_delta().y / 8);
+	}
 }
 
 void TextureRegionEditor::_scroll_changed(float) {


### PR DESCRIPTION
The magic number "8" is used in many pan gesture handling code, e.g. in GraphEdit, ScrollContainer and the Polygon 2D UV editor.