### PR TITLE
Fix GlobalConstant/BasicTypeConstant return type in visual scripts

### DIFF
--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1842,7 +1842,7 @@ PropertyInfo VisualScriptGlobalConstant::get_input_value_port_info(int p_idx) co
 
 PropertyInfo VisualScriptGlobalConstant::get_output_value_port_info(int p_idx) const {
 	String name = GlobalConstants::get_global_constant_name(index);
-	return PropertyInfo(Variant::REAL, name);
+	return PropertyInfo(Variant::INT, name);
 }
 
 String VisualScriptGlobalConstant::get_caption() const {
@@ -2060,7 +2060,7 @@ PropertyInfo VisualScriptBasicTypeConstant::get_input_value_port_info(int p_idx)
 
 PropertyInfo VisualScriptBasicTypeConstant::get_output_value_port_info(int p_idx) const {
 
-	return PropertyInfo(Variant::INT, "value");
+	return PropertyInfo(type, "value");
 }
 
 String VisualScriptBasicTypeConstant::get_caption() const {
@@ -2069,8 +2069,11 @@ String VisualScriptBasicTypeConstant::get_caption() const {
 }
 
 String VisualScriptBasicTypeConstant::get_text() const {
-
-	return Variant::get_type_name(type) + "." + String(name);
+	if (name == "") {
+		return Variant::get_type_name(type);
+	} else {
+		return Variant::get_type_name(type) + "." + String(name);
+	}
 }
 
 void VisualScriptBasicTypeConstant::set_basic_type_constant(const StringName &p_which) {
@@ -2087,6 +2090,23 @@ StringName VisualScriptBasicTypeConstant::get_basic_type_constant() const {
 void VisualScriptBasicTypeConstant::set_basic_type(Variant::Type p_which) {
 
 	type = p_which;
+
+	List<StringName> constants;
+	Variant::get_constants_for_type(type, &constants);
+	if (constants.size() > 0) {
+		bool found_name = false;
+		for (List<StringName>::Element *E = constants.front(); E; E = E->next()) {
+			if (E->get() == name) {
+				found_name = true;
+				break;
+			}
+		}
+		if (!found_name) {
+			name = constants[0];
+		}
+	} else {
+		name = "";
+	}
 	_change_notify();
 	ports_changed_notify();
 }


### PR DESCRIPTION
Changes:
- Make the BasicTypeConstant return port type changed when the constant type is changed
- Select first constant name by default (if available)
- Properly update it when switching on other types with same constant name
- Removes "." if no constants available for that type
- GlobalConstant changed return port type from REAL to INT (because it's correct)

![vst](https://user-images.githubusercontent.com/3036176/73473614-1be35b00-439e-11ea-9f74-0464fc4e3cc7.gif)
