### PR TITLE
Remove redundant thread sync counter draw_pending

### DIFF
--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -333,13 +333,10 @@ void RenderingServerDefault::_thread_exit() {
 }
 
 void RenderingServerDefault::_thread_draw(bool p_swap_buffers, double frame_step) {
-	if (!draw_pending.decrement()) {
-		_draw(p_swap_buffers, frame_step);
-	}
+	_draw(p_swap_buffers, frame_step);
 }
 
 void RenderingServerDefault::_thread_flush() {
-	draw_pending.decrement();
 }
 
 void RenderingServerDefault::_thread_callback(void *_instance) {
@@ -370,7 +367,6 @@ void RenderingServerDefault::_thread_loop() {
 
 void RenderingServerDefault::sync() {
 	if (create_thread) {
-		draw_pending.increment();
 		command_queue.push_and_sync(this, &RenderingServerDefault::_thread_flush);
 	} else {
 		command_queue.flush_all(); //flush all pending from other threads
@@ -379,7 +375,6 @@ void RenderingServerDefault::sync() {
 
 void RenderingServerDefault::draw(bool p_swap_buffers, double frame_step) {
 	if (create_thread) {
-		draw_pending.increment();
 		command_queue.push(this, &RenderingServerDefault::_thread_draw, p_swap_buffers, frame_step);
 	} else {
 		_draw(p_swap_buffers, frame_step);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -94,7 +94,6 @@ class RenderingServerDefault : public RenderingServer {
 	SafeFlag draw_thread_up;
 	bool create_thread;
 
-	SafeNumeric<uint64_t> draw_pending;
 	void _thread_draw(bool p_swap_buffers, double frame_step);
 	void _thread_flush();
 


### PR DESCRIPTION
The functions that used it already use a threadsafe FIFO queue
to communicate between threads and a sync to have the main thread
wait for the render thread.

Fixes #35718