### PR TITLE
Stop using draw_pending from sync functions

### DIFF
--- a/servers/visual/visual_server_wrap_mt.cpp
+++ b/servers/visual/visual_server_wrap_mt.cpp
@@ -46,8 +46,6 @@ void VisualServerWrapMT::thread_draw(bool p_swap_buffers, double frame_step) {
 }
 
 void VisualServerWrapMT::thread_flush() {
-
-	atomic_decrement(&draw_pending);
 }
 
 void VisualServerWrapMT::_thread_callback(void *_instance) {
@@ -83,7 +81,6 @@ void VisualServerWrapMT::sync() {
 
 	if (create_thread) {
 
-		atomic_increment(&draw_pending);
 		command_queue.push_and_sync(this, &VisualServerWrapMT::thread_flush);
 	} else {
 


### PR DESCRIPTION
Keep it in the _draw functions. That way it still makes extra sure
no two draw calls can be pending/executing at the same time,
even though the command FIFO already takes care of that.

Fixes #35718