### PR TITLE
Increase the maximum number of octaves in OpenSimplexNoise to 9

### DIFF
--- a/modules/opensimplex/doc_classes/OpenSimplexNoise.xml
+++ b/modules/opensimplex/doc_classes/OpenSimplexNoise.xml
@@ -117,7 +117,8 @@
 			Difference in period between [member octaves].
 		</member>
 		<member name="octaves" type="int" setter="set_octaves" getter="get_octaves" default="3">
-			Number of OpenSimplex noise layers that are sampled to get the fractal noise.
+			Number of OpenSimplex noise layers that are sampled to get the fractal noise. Higher values result in more detailed noise but take more time to generate.
+			[b]Note:[/b] The maximum allowed value is 9.
 		</member>
 		<member name="period" type="float" setter="set_period" getter="get_period" default="64.0">
 			Period of the base octave. A lower period results in a higher-frequency noise (more value changes across the same distance).

--- a/modules/opensimplex/open_simplex_noise.cpp
+++ b/modules/opensimplex/open_simplex_noise.cpp
@@ -47,7 +47,7 @@ OpenSimplexNoise::~OpenSimplexNoise() {
 }
 
 void OpenSimplexNoise::_init_seeds() {
-	for (int i = 0; i < 6; ++i) {
+	for (int i = 0; i < MAX_OCTAVES; ++i) {
 		open_simplex_noise(seed + i * 2, &(contexts[i]));
 	}
 }
@@ -71,7 +71,10 @@ int OpenSimplexNoise::get_seed() {
 
 void OpenSimplexNoise::set_octaves(int p_octaves) {
 	if (p_octaves == octaves) return;
-	octaves = CLAMP(p_octaves, 1, 6);
+
+	ERR_FAIL_COND_MSG(p_octaves > MAX_OCTAVES, vformat("The number of OpenSimplexNoise octaves is limited to %d; ignoring the new value.", MAX_OCTAVES));
+
+	octaves = CLAMP(p_octaves, 1, MAX_OCTAVES);
 	emit_changed();
 }
 
@@ -182,7 +185,7 @@ void OpenSimplexNoise::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_noise_3dv", "pos"), &OpenSimplexNoise::get_noise_3dv);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "seed"), "set_seed", "get_seed");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "octaves", PROPERTY_HINT_RANGE, "1,6,1"), "set_octaves", "get_octaves");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "octaves", PROPERTY_HINT_RANGE, vformat("1,%d,1", MAX_OCTAVES)), "set_octaves", "get_octaves");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "period", PROPERTY_HINT_RANGE, "0.1,256.0,0.1"), "set_period", "get_period");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "persistence", PROPERTY_HINT_RANGE, "0.0,1.0,0.001"), "set_persistence", "get_persistence");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "lacunarity", PROPERTY_HINT_RANGE, "0.1,4.0,0.01"), "set_lacunarity", "get_lacunarity");

--- a/modules/opensimplex/open_simplex_noise.h
+++ b/modules/opensimplex/open_simplex_noise.h
@@ -37,11 +37,16 @@
 
 #include "thirdparty/misc/open-simplex-noise.h"
 
+// The maximum number of octaves allowed. Note that these are statically allocated.
+// Higher values become exponentially slower, so this shouldn't be set too high
+// to avoid freezing the editor for long periods of time.
+#define MAX_OCTAVES 9
+
 class OpenSimplexNoise : public Resource {
 	GDCLASS(OpenSimplexNoise, Resource);
 	OBJ_SAVE_TYPE(OpenSimplexNoise);
 
-	osn_context contexts[6];
+	osn_context contexts[MAX_OCTAVES];
 
 	int seed;
 	float persistence; // Controls details, value in [0,1]. Higher increases grain, lower increases smoothness.


### PR DESCRIPTION
An error message is now printed when trying to set the number of octaves above the maximum allowed value.

The magic constant was also replaced with a define that can be easily changed.

I couldn't measure a difference in startup time or memory usage with this change. Still, this should be tested on mobile/Web platforms just in case.

This closes #28714.