### PR TITLE
Implicit copy ctor have been deprecated since C++11

### DIFF
--- a/core/ustring.h
+++ b/core/ustring.h
@@ -68,6 +68,8 @@ public:
 	_FORCE_INLINE_ void operator=(const CharProxy<T> &other) const {
 		_cowdata.set(_index, other.operator T());
 	}
+
+	_FORCE_INLINE_ CharProxy(const CharProxy &) = default;
 };
 
 class CharString {


### PR DESCRIPTION
This will satisfy the warning -Wdeprecated