### PR TITLE
Add a method to retrieve active material from MeshInstance

### DIFF
--- a/doc/classes/MeshInstance3D.xml
+++ b/doc/classes/MeshInstance3D.xml
@@ -4,7 +4,7 @@
 		Node that instances meshes into a scenario.
 	</brief_description>
 	<description>
-		MeshInstance3D is a node that takes a [Mesh] resource and adds it to the current scenario by creating an instance of it. This is the class most often used to get 3D geometry rendered and can be used to instance a single [Mesh] in many places. This allows to reuse geometry and save on resources. When a [Mesh] has to be instanced more than thousands of times at close proximity, consider using a [MultiMesh] in a [MultiMeshInstance3D] instead.
+		MeshInstance3D is a node that takes a [Mesh] resource and adds it to the current scenario by creating an instance of it. This is the class most often used render 3D geometry and can be used to instance a single [Mesh] in many places. This allows reuse of geometry which can save on resources. When a [Mesh] has to be instanced more than thousands of times at close proximity, consider using a [MultiMesh] in a [MultiMeshInstance3D] instead.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -30,13 +30,22 @@
 				This helper creates a [StaticBody3D] child node with a [ConcavePolygonShape3D] collision shape calculated from the mesh geometry. It's mainly used for testing.
 			</description>
 		</method>
+		<method name="get_active_material" qualifiers="const">
+			<return type="Material">
+			</return>
+			<argument index="0" name="surface" type="int">
+			</argument>
+			<description>
+				Returns the [Material] that will be used by the [Mesh] when drawing. This can return the [member GeometryInstance3D.material_override], the surface override [Material] defined in this [MeshInstance3D], or the surface [Material] defined in the [Mesh]. For example, if [member GeometryInstance3D.material_override] is used, all surfaces will return the override material.
+			</description>
+		</method>
 		<method name="get_surface_material" qualifiers="const">
 			<return type="Material">
 			</return>
 			<argument index="0" name="surface" type="int">
 			</argument>
 			<description>
-				Returns the [Material] for a surface of the [Mesh] resource.
+				Returns the override [Material] for the specified surface of the [Mesh] resource.
 			</description>
 		</method>
 		<method name="get_surface_material_count" qualifiers="const">
@@ -54,7 +63,7 @@
 			<argument index="1" name="material" type="Material">
 			</argument>
 			<description>
-				Sets the [Material] for a surface of the [Mesh] resource.
+				Sets the override [Material] for the specified surface of the [Mesh] resource. This material is associated with this [MeshInstance3D] rather than with the [Mesh] resource.
 			</description>
 		</method>
 	</methods>

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -305,6 +305,23 @@ Ref<Material> MeshInstance3D::get_surface_material(int p_surface) const {
 	return materials[p_surface];
 }
 
+Ref<Material> MeshInstance3D::get_active_material(int p_surface) const {
+
+	if (get_material_override() != Ref<Material>()) {
+		return get_material_override();
+	} else if (p_surface < materials.size()) {
+		return materials[p_surface];
+	} else {
+		Ref<Mesh> mesh = get_mesh();
+
+		if (mesh.is_null() || p_surface >= mesh->get_surface_count()) {
+			return Ref<Material>();
+		}
+
+		return mesh->surface_get_material(p_surface);
+	}
+}
+
 void MeshInstance3D::_mesh_changed() {
 
 	materials.resize(mesh->get_surface_count());
@@ -397,6 +414,7 @@ void MeshInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_surface_material_count"), &MeshInstance3D::get_surface_material_count);
 	ClassDB::bind_method(D_METHOD("set_surface_material", "surface", "material"), &MeshInstance3D::set_surface_material);
 	ClassDB::bind_method(D_METHOD("get_surface_material", "surface"), &MeshInstance3D::get_surface_material);
+	ClassDB::bind_method(D_METHOD("get_active_material", "surface"), &MeshInstance3D::get_active_material);
 
 	ClassDB::bind_method(D_METHOD("create_trimesh_collision"), &MeshInstance3D::create_trimesh_collision);
 	ClassDB::set_method_flags("MeshInstance3D", "create_trimesh_collision", METHOD_FLAGS_DEFAULT);

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -84,6 +84,7 @@ public:
 	int get_surface_material_count() const;
 	void set_surface_material(int p_surface, const Ref<Material> &p_material);
 	Ref<Material> get_surface_material(int p_surface) const;
+	Ref<Material> get_active_material(int p_surface) const;
 
 	Node *create_trimesh_collision_node();
 	void create_trimesh_collision();


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot/issues/31558#issuecomment-580364068

Adds a new method to ``MeshInstance``. ``get_active_material()`` returns the material that will be used to draw the mesh in order of overrides.

This should help fix the confusion users have when trying to retrieve the active material. Users often set the material in the mesh and then attempt to retrieve the MeshInstance surface material override and get null.