### PR TITLE
Minor improvements to the Polygon 2D UV editor

### DIFF
--- a/editor/icons/PaintVertex.svg
+++ b/editor/icons/PaintVertex.svg
@@ -1,1 +1,0 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><ellipse cx="8.372881" cy="8.169492" fill="#fff" rx="6.677966" ry="6.067797"/></svg>

--- a/editor/icons/UnpaintVertex.svg
+++ b/editor/icons/UnpaintVertex.svg
@@ -1,1 +1,0 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><ellipse cx="8.372881" cy="8.169492" rx="6.677966" ry="6.067797"/></svg>

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -79,8 +79,8 @@ void Polygon2DEditor::_notification(int p_what) {
 			uv_button[UV_MODE_SCALE]->set_icon(get_theme_icon("ToolScale", "EditorIcons"));
 			uv_button[UV_MODE_ADD_POLYGON]->set_icon(get_theme_icon("Edit", "EditorIcons"));
 			uv_button[UV_MODE_REMOVE_POLYGON]->set_icon(get_theme_icon("Close", "EditorIcons"));
-			uv_button[UV_MODE_PAINT_WEIGHT]->set_icon(get_theme_icon("PaintVertex", "EditorIcons"));
-			uv_button[UV_MODE_CLEAR_WEIGHT]->set_icon(get_theme_icon("UnpaintVertex", "EditorIcons"));
+			uv_button[UV_MODE_PAINT_WEIGHT]->set_icon(get_theme_icon("Bucket", "EditorIcons"));
+			uv_button[UV_MODE_CLEAR_WEIGHT]->set_icon(get_theme_icon("Clear", "EditorIcons"));
 
 			b_snap_grid->set_icon(get_theme_icon("Grid", "EditorIcons"));
 			b_snap_enable->set_icon(get_theme_icon("SnapGrid", "EditorIcons"));
@@ -1325,11 +1325,16 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_main_hsc->add_child(uv_edit_draw);
 	uv_edit_draw->set_h_size_flags(SIZE_EXPAND_FILL);
 	uv_edit_draw->set_custom_minimum_size(Size2(200, 200) * EDSCALE);
+
+	Control *space = memnew(Control);
+	uv_mode_hb->add_child(space);
+	space->set_h_size_flags(SIZE_EXPAND_FILL);
+
 	uv_menu = memnew(MenuButton);
 	uv_mode_hb->add_child(uv_menu);
 	uv_menu->set_text(TTR("Edit"));
-	uv_menu->get_popup()->add_item(TTR("Polygon->UV"), UVEDIT_POLYGON_TO_UV);
-	uv_menu->get_popup()->add_item(TTR("UV->Polygon"), UVEDIT_UV_TO_POLYGON);
+	uv_menu->get_popup()->add_item(TTR("Copy Polygon to UV"), UVEDIT_POLYGON_TO_UV);
+	uv_menu->get_popup()->add_item(TTR("Copy UV to Polygon"), UVEDIT_UV_TO_POLYGON);
 	uv_menu->get_popup()->add_separator();
 	uv_menu->get_popup()->add_item(TTR("Clear UV"), UVEDIT_UV_CLEAR);
 	uv_menu->get_popup()->add_separator();


### PR DESCRIPTION
- Added a spacing between the tool button and the other options, so the latter doesn't keep changing position on mode change.
- Changed the vertex painting icons to "Bucket" and "Clear". Not perfect, but more clearer than a pair of filled circles, one which was pitch black and looked the same when selected.
- Made the Polygon to/from UV texts better formatted.

![Screenshot_20200130_234826](https://user-images.githubusercontent.com/30739239/73510039-fd4e8580-43d8-11ea-9670-58f9489a4240.png)