### PR TITLE
Adds diagonal cursors for macOS

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -115,6 +115,20 @@ static Vector2 get_mouse_pos(NSPoint locationInWindow, CGFloat backingScaleFacto
 	return Vector2(mouse_x, mouse_y);
 }
 
+static NSCursor *cursorFromSelector(SEL selector, SEL fallback = nil) {
+	if ([NSCursor respondsToSelector:selector]) {
+		id object = [NSCursor performSelector:selector];
+		if ([object isKindOfClass:[NSCursor class]]) {
+			return object;
+		}
+	}
+	if (fallback) {
+		// Fallback should be a reasonable default, no need to check.
+		return [NSCursor performSelector:fallback];
+	}
+	return [NSCursor arrowCursor];
+}
+
 @interface GodotApplication : NSApplication
 @end
 
@@ -1813,15 +1827,15 @@ void OS_OSX::set_cursor_shape(CursorShape p_shape) {
 			case CURSOR_BUSY: [[NSCursor arrowCursor] set]; break;
 			case CURSOR_DRAG: [[NSCursor closedHandCursor] set]; break;
 			case CURSOR_CAN_DROP: [[NSCursor openHandCursor] set]; break;
-			case CURSOR_FORBIDDEN: [[NSCursor arrowCursor] set]; break;
-			case CURSOR_VSIZE: [[NSCursor resizeUpDownCursor] set]; break;
-			case CURSOR_HSIZE: [[NSCursor resizeLeftRightCursor] set]; break;
-			case CURSOR_BDIAGSIZE: [[NSCursor arrowCursor] set]; break;
-			case CURSOR_FDIAGSIZE: [[NSCursor arrowCursor] set]; break;
+			case CURSOR_FORBIDDEN: [[NSCursor operationNotAllowedCursor] set]; break;
+			case CURSOR_VSIZE: [cursorFromSelector(@selector(_windowResizeNorthSouthCursor), @selector(resizeUpDownCursor)) set]; break;
+			case CURSOR_HSIZE: [cursorFromSelector(@selector(_windowResizeEastWestCursor), @selector(resizeLeftRightCursor)) set]; break;
+			case CURSOR_BDIAGSIZE: [cursorFromSelector(@selector(_windowResizeNorthEastSouthWestCursor)) set]; break;
+			case CURSOR_FDIAGSIZE: [cursorFromSelector(@selector(_windowResizeNorthWestSouthEastCursor)) set]; break;
 			case CURSOR_MOVE: [[NSCursor arrowCursor] set]; break;
 			case CURSOR_VSPLIT: [[NSCursor resizeUpDownCursor] set]; break;
 			case CURSOR_HSPLIT: [[NSCursor resizeLeftRightCursor] set]; break;
-			case CURSOR_HELP: [[NSCursor arrowCursor] set]; break;
+			case CURSOR_HELP: [cursorFromSelector(@selector(_helpCursor)) set]; break;
 			default: {
 			};
 		}


### PR DESCRIPTION
NSCursor does not provide diagonal resize cursor shapes according to the [documentation](https://developer.apple.com/documentation/appkit/nscursor). Godot currently uses the normal arrow cursor instead. I think it's confusing, because an arrow cursor does not 
seem to indicate that diagonal resizing can be performed.

[SDL uses](https://github.com/SDL-mirror/SDL/blob/89be0e49c6f10821340d1174c134864fc8c70b7c/src/video/cocoa/SDL_cocoamouse.m#L136-L139) the closed-hand cursor for diagonal resizing:
![closed-hand cursor](https://docs-assets.developer.apple.com/published/f33f7ae89c/closedHandCursor_2x_2x_cfea5b8f-b2da-43eb-a1e1-a878bf90a469.png)

[GLFW](https://github.com/glfw/glfw/blob/d973acc123826666ecc9e6fd475682e3d84c54a6/src/cocoa_window.m#L1619-L1627) and [SFML](https://github.com/SFML/SFML/blob/1d20edebc7b8608bc7feeae6580d03655cc2aa8b/src/SFML/Window/OSX/CursorImpl.mm#L103-L116) uses undocumented selectors to get the diagonal resizing cursor.
![b0SBf](https://user-images.githubusercontent.com/372476/73513548-e0da3980-4428-11ea-8829-b28d48dbbcb5.png) ![a0TZr](https://user-images.githubusercontent.com/372476/73513549-e20b6680-4428-11ea-8467-07e39f30406a.png)


This PR uses the latter approch.