### PR TITLE
Fix to RichTextEffect `visibility` - Label Now Accounts for Skipped Characters.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -199,6 +199,8 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 	int line_ascent = cfont->get_ascent();
 	int line_descent = cfont->get_descent();
 
+	int backtrack = 0; // for dynamic hidden content.
+
 	int nonblank_line_count = 0; //number of nonblank lines as counted during PROCESS_DRAW
 
 	Variant meta;
@@ -209,6 +211,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 	{                                                                                                                                                           \
 		if (p_mode != PROCESS_CACHE) {                                                                                                                          \
 			line++;                                                                                                                                             \
+			backtrack = 0;                                                                                                                                      \
 			if (!line_is_blank) {                                                                                                                               \
 				nonblank_line_count++;                                                                                                                          \
 			}                                                                                                                                                   \
@@ -258,7 +261,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 		l.maximum_width = MAX(l.maximum_width, MIN(p_width, wofs + m_width));                                                               \
 		l.minimum_width = MAX(l.minimum_width, m_width);                                                                                    \
 	}                                                                                                                                       \
-	if (wofs + m_width > p_width) {                                                                                                         \
+	if (wofs - backtrack + m_width > p_width) {                                                                                             \
 		line_wrapped = true;                                                                                                                \
 		if (p_mode == PROCESS_CACHE) {                                                                                                      \
 			if (spaces > 0)                                                                                                                 \
@@ -385,6 +388,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 					int fw = 0;
 
 					lh = 0;
+
 					if (p_mode != PROCESS_CACHE) {
 						lh = line < l.height_caches.size() ? l.height_caches[line] : 1;
 						line_ascent = line < l.ascent_caches.size() ? l.ascent_caches[line] : 1;
@@ -427,13 +431,12 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 
 					{
 
-						int ofs = 0;
+						int ofs = 0 - backtrack;
 
 						for (int i = 0; i < end; i++) {
 							int pofs = wofs + ofs;
 
 							if (p_mode == PROCESS_POINTER && r_click_char && p_click_pos.y >= p_ofs.y + y && p_click_pos.y <= p_ofs.y + y + lh) {
-								//int o = (wofs+w)-p_click_pos.x;
 
 								int cw = font->get_char_size(c[i], c[i + 1]).x;
 
@@ -476,7 +479,10 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 								bool visible = visible_characters < 0 || ((p_char_count < visible_characters && YRANGE_VISIBLE(y + lh - line_descent - line_ascent, line_ascent + line_descent)) &&
 																				 faded_visibility > 0.0f);
 
+								const bool previously_visible = visible;
+
 								for (int j = 0; j < fx_stack.size(); j++) {
+
 									ItemFX *item_fx = fx_stack[j];
 
 									if (item_fx->type == ITEM_CUSTOMFX && custom_fx_ok) {
@@ -570,6 +576,8 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 									} else {
 										cw = drawer.draw_char(ci, p_ofs + Point2(align_ofs + pofs, y + lh - line_descent) + fx_offset, fx_char, c[i + 1], fx_color);
 									}
+								} else if (previously_visible) {
+									backtrack += font->get_char_size(fx_char, c[i + 1]).x;
 								}
 
 								p_char_count++;
@@ -643,6 +651,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 			case ITEM_NEWLINE: {
 
 				lh = 0;
+
 				if (p_mode != PROCESS_CACHE) {
 					lh = line < l.height_caches.size() ? l.height_caches[line] : 1;
 					line_is_blank = true;


### PR DESCRIPTION
A picture is easier to describe this issue than words. Picture and original issue can be found here: #35729 

Basically, rich text effects allowed for character visibility changes. While doing so would work properly, the rich text label would render the next `word` in an offset accounting for the hidden characters (leaving a huge space after hidden characters.)

This patch fixes this issue by keeping track of the amount of `backtrack` necessary per line.
Example of it working:

![Picture](https://user-images.githubusercontent.com/3040352/73514809-e2afe880-43a7-11ea-8be0-c0a986195150.png)


As an aside, is there a real reason that we're using `#define`s besides carefully crafted `static inline` functions? I understand the use case of macros over inline functions (no need for typechecks or long argument lists) but it also adds a lot of room for error when working on the rather large `_process_line` method.

*Bugsquad edit:* Fixes #35729.