### PR TITLE
Fix shader crash if using multiple underscores in identifier names

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -80,7 +80,7 @@ static String _opstr(SL::Operator p_op) {
 
 static String _mkid(const String &p_id) {
 
-	String id = "m_" + p_id;
+	String id = "m_" + p_id.replace("__", "_dus_");
 	return id.replace("__", "_dus_"); //doubleunderscore is reserved in glsl
 }
 

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -166,7 +166,7 @@ static String _opstr(SL::Operator p_op) {
 
 static String _mkid(const String &p_id) {
 
-	String id = "m_" + p_id;
+	String id = "m_" + p_id.replace("__", "_dus_");
 	return id.replace("__", "_dus_"); //doubleunderscore is reserved in glsl
 }
 


### PR DESCRIPTION
Before: `__t  => m_dus__t // leads to crash due to double underscore`
after: `__t => m_dus_dus_t // OK`

Before: `__k________t;` => `m_dus__k_dus__dus__dus__dus_t; // leads to crash due to double underscores`
After: `__k________t;` => `m_dus_dus_k_dus_dus_dus_dus_dus_dus_dus_t` // OK