### PR TITLE
added open export directory in file manager option to export window

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -125,6 +125,15 @@ bool EditorExportPreset::is_runnable() const {
 	return runnable;
 }
 
+void EditorExportPreset::set_open_directory(bool p_enable) {
+	open_directory = p_enable;
+	EditorExport::singleton->save_presets();
+}
+
+bool EditorExportPreset::get_open_directory() const {
+	return open_directory;
+}
+
 void EditorExportPreset::set_export_filter(ExportFilter p_filter) {
 
 	export_filter = p_filter;
@@ -256,6 +265,7 @@ EditorExportPreset::EditorExportPreset() :
 		export_filter(EXPORT_ALL_RESOURCES),
 		export_path(""),
 		runnable(false),
+		open_directory(false),
 		script_mode(MODE_SCRIPT_COMPILED) {
 }
 
@@ -1167,6 +1177,7 @@ void EditorExport::_save() {
 		config->set_value(section, "name", preset->get_name());
 		config->set_value(section, "platform", preset->get_platform()->get_name());
 		config->set_value(section, "runnable", preset->is_runnable());
+		config->set_value(section, "opendirectory", preset->get_open_directory());
 		config->set_value(section, "custom_features", preset->get_custom_features());
 
 		bool save_files = false;
@@ -1342,6 +1353,7 @@ void EditorExport::load_config() {
 
 		preset->set_name(config->get_value(section, "name"));
 		preset->set_runnable(config->get_value(section, "runnable"));
+		preset->set_open_directory(config->get_value(section, "opendirectory"));
 
 		if (config->has_section_key(section, "custom_features")) {
 			preset->set_custom_features(config->get_value(section, "custom_features"));

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -69,7 +69,7 @@ private:
 	String exporter;
 	Set<String> selected_files;
 	bool runnable;
-
+	bool open_directory;
 	Vector<String> patches;
 
 	friend class EditorExport;
@@ -106,6 +106,9 @@ public:
 
 	void set_runnable(bool p_enable);
 	bool is_runnable() const;
+
+	void set_open_directory(bool p_enable);
+	bool get_open_directory() const;
 
 	void set_export_filter(ExportFilter p_filter);
 	ExportFilter get_export_filter() const;

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -70,6 +70,7 @@ private:
 	EditorPropertyPath *export_path;
 	EditorInspector *parameters;
 	CheckButton *runnable;
+	CheckButton *open_directory;
 
 	Button *button_export;
 	bool updating;
@@ -113,6 +114,7 @@ private:
 	void _patch_deleted();
 
 	void _runnable_pressed();
+	void _open_directory_pressed();
 	void _update_parameters(const String &p_edited_property);
 	void _name_changed(const String &p_string);
 	void _export_path_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing);


### PR DESCRIPTION
this feature can be useful for when you have different export paths or when you want quick access to your exported binary without having to look for it in file manager.