### PR TITLE
[WIP] Added an option to preview generated GLSL code to shader editor

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -257,6 +257,7 @@ public:
 
 	void shader_set_code(RID p_shader, const String &p_code) {}
 	String shader_get_code(RID p_shader) const { return ""; }
+	String shader_get_gen_code(RID p_shader, int p_function) const { return ""; }
 	void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const {}
 
 	void shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture) {}

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1370,6 +1370,14 @@ String RasterizerStorageGLES2::shader_get_code(RID p_shader) const {
 	return shader->code;
 }
 
+String RasterizerStorageGLES2::shader_get_gen_code(RID p_shader, int p_function) const {
+
+	const Shader *shader = shader_owner.get(p_shader);
+	ERR_FAIL_COND_V(!shader, "");
+	shader->shader->bind();
+	return shader->shader->get_gen_code(p_function);
+}
+
 void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 
 	_shader_dirty_list.remove(&p_shader->dirty_list);

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -520,6 +520,7 @@ public:
 
 	virtual void shader_set_code(RID p_shader, const String &p_code);
 	virtual String shader_get_code(RID p_shader) const;
+	virtual String shader_get_gen_code(RID p_shader, int p_function) const;
 	virtual void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const;
 
 	virtual void shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture);

--- a/drivers/gles2/shader_gles2.cpp
+++ b/drivers/gles2/shader_gles2.cpp
@@ -1092,6 +1092,24 @@ void ShaderGLES2::use_material(void *p_material) {
 	}
 }
 
+String ShaderGLES2::get_gen_code(int p_function) {
+	int id = -1;
+	if (p_function == 0) {
+		id = version->vert_id;
+	} else if (p_function == 1) {
+		id = version->frag_id;
+	} else {
+		return "";
+	}
+	GLint length = 0;
+	glGetShaderiv(id, GL_SHADER_SOURCE_LENGTH, &length);
+	char *code = (char *)Memory::alloc_static(length + 1);
+	code[length] = '\0';
+	glGetShaderSource(id, length, NULL, code);
+	Memory::free_static(code);
+	return String(code);
+}
+
 ShaderGLES2::ShaderGLES2() {
 	version = NULL;
 	last_custom_code = 1;

--- a/drivers/gles2/shader_gles2.h
+++ b/drivers/gles2/shader_gles2.h
@@ -245,6 +245,7 @@ public:
 	void add_custom_define(const String &p_define) {
 		custom_defines.push_back(p_define.utf8());
 	}
+	String get_gen_code(int p_function);
 
 	virtual ~ShaderGLES2();
 };

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2240,6 +2240,14 @@ String RasterizerStorageGLES3::shader_get_code(RID p_shader) const {
 	return shader->code;
 }
 
+String RasterizerStorageGLES3::shader_get_gen_code(RID p_shader, int p_function) const {
+
+	const Shader *shader = shader_owner.get(p_shader);
+	ERR_FAIL_COND_V(!shader, String());
+	shader->shader->bind();
+	return shader->shader->get_gen_code(p_function);
+}
+
 void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 
 	_shader_dirty_list.remove(&p_shader->dirty_list);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -528,6 +528,7 @@ public:
 
 	virtual void shader_set_code(RID p_shader, const String &p_code);
 	virtual String shader_get_code(RID p_shader) const;
+	virtual String shader_get_gen_code(RID p_shader, int p_function) const;
 	virtual void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const;
 
 	virtual void shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture);

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -771,6 +771,24 @@ ShaderGLES3::ShaderGLES3() {
 	base_material_tex_index = 0;
 }
 
+String ShaderGLES3::get_gen_code(int p_function) {
+	int id = -1;
+	if (p_function == 0) {
+		id = version->vert_id;
+	} else if (p_function == 1) {
+		id = version->frag_id;
+	} else {
+		return "";
+	}
+	GLint length = 0;
+	glGetShaderiv(id, GL_SHADER_SOURCE_LENGTH, &length);
+	char *code = (char *)Memory::alloc_static(length + 1);
+	code[length] = '\0';
+	glGetShaderSource(id, length, NULL, code);
+	Memory::free_static(code);
+	return String(code);
+}
+
 ShaderGLES3::~ShaderGLES3() {
 
 	finish();

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -367,6 +367,7 @@ public:
 	void add_custom_define(const String &p_define) {
 		custom_defines.push_back(p_define.utf8());
 	}
+	String get_gen_code(int p_function);
 
 	virtual ~ShaderGLES3();
 };

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -101,17 +101,23 @@ class ShaderEditor : public PanelContainer {
 	MenuButton *search_menu;
 	PopupMenu *bookmarks_menu;
 	MenuButton *help_menu;
+	ToolButton *code_button;
 	PopupMenu *context_menu;
 	uint64_t idle;
+	int final_func;
 
 	GotoLineDialog *goto_line_dialog;
 	ConfirmationDialog *erase_tab_confirm;
 	ConfirmationDialog *disk_changed;
 
 	ShaderTextEditor *shader_editor;
+	VBoxContainer *final_code_container;
+	TextEdit *final_code_box;
+	List<String> keyword_list;
 
 	void _menu_option(int p_option);
 	void _params_changed();
+	void _show_final_code();
 	mutable Ref<Shader> shader;
 
 	void _editor_settings_changed();
@@ -124,6 +130,7 @@ protected:
 	static void _bind_methods();
 	void _make_context_menu(bool p_selection, Vector2 p_position);
 	void _text_edit_gui_input(const Ref<InputEvent> &ev);
+	void _on_final_code_item_selected(int p_idx);
 
 	void _update_bookmark_list();
 	void _bookmark_item_pressed(int p_idx);

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -237,6 +237,7 @@ public:
 
 	virtual void shader_set_code(RID p_shader, const String &p_code) = 0;
 	virtual String shader_get_code(RID p_shader) const = 0;
+	virtual String shader_get_gen_code(RID p_shader, int p_function) const = 0;
 	virtual void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const = 0;
 
 	virtual void shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture) = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -184,6 +184,7 @@ public:
 
 	BIND2(shader_set_code, RID, const String &)
 	BIND1RC(String, shader_get_code, RID)
+	BIND2RC(String, shader_get_gen_code, RID, int)
 
 	BIND2C(shader_get_param_list, RID, List<PropertyInfo> *)
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -120,6 +120,7 @@ public:
 
 	FUNC2(shader_set_code, RID, const String &)
 	FUNC1RC(String, shader_get_code, RID)
+	FUNC2RC(String, shader_get_gen_code, RID, int)
 
 	FUNC2SC(shader_get_param_list, RID, List<PropertyInfo> *)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1676,6 +1676,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shader_create"), &VisualServer::shader_create);
 	ClassDB::bind_method(D_METHOD("shader_set_code", "shader", "code"), &VisualServer::shader_set_code);
 	ClassDB::bind_method(D_METHOD("shader_get_code", "shader"), &VisualServer::shader_get_code);
+	ClassDB::bind_method(D_METHOD("shader_get_gen_code", "shader", "function"), &VisualServer::shader_get_gen_code);
 	ClassDB::bind_method(D_METHOD("shader_get_param_list", "shader"), &VisualServer::_shader_get_param_list_bind);
 	ClassDB::bind_method(D_METHOD("shader_set_default_texture_param", "shader", "name", "texture"), &VisualServer::shader_set_default_texture_param);
 	ClassDB::bind_method(D_METHOD("shader_get_default_texture_param", "shader", "name"), &VisualServer::shader_get_default_texture_param);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -187,6 +187,7 @@ public:
 
 	virtual void shader_set_code(RID p_shader, const String &p_code) = 0;
 	virtual String shader_get_code(RID p_shader) const = 0;
+	virtual String shader_get_gen_code(RID p_shader, int p_function) const = 0;
 	virtual void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const = 0;
 	Array _shader_get_param_list_bind(RID p_shader) const;
 


### PR DESCRIPTION
This PR allows seeing generated code directly within shader editor. I've implemented it maximally gently - only one new function `shader_get_gen_code` to VisualServer, no string 
 buffers for code - only simple call of glGetShaderCode... 

![experimental](https://user-images.githubusercontent.com/3036176/73545206-f1e87200-444b-11ea-9e8a-40d3f44c4f86.gif)
Of course, currently, it lacks some features like a search bar, but I need to know whether is this change is desired before continue.
Closes #1326