### PR TITLE
Fixed LineEdit virtual keyboard inputs on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotEditText.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotEditText.java
@@ -123,7 +123,7 @@ public class GodotEditText extends EditText {
 	}
 
 	private void setMaxInputLength(EditText p_edit_text, int p_max_input_length) {
-		if (p_max_input_length >= 0) {
+		if (p_max_input_length > 0) {
 			InputFilter[] filters = new InputFilter[1];
 			filters[0] = new InputFilter.LengthFilter(p_max_input_length);
 			p_edit_text.setFilters(filters);


### PR DESCRIPTION
Changed the condition to add a length filter to make it consistent with the documentation (0 means no character limit). Otherwise the default value in `LineEdit` causes the virtual keyboard to be non-fonctional on Android.

Fixes #35753