### PR TITLE
Added support for flipping BoxContainer children

### DIFF
--- a/doc/classes/BoxContainer.xml
+++ b/doc/classes/BoxContainer.xml
@@ -23,6 +23,9 @@
 		<member name="alignment" type="int" setter="set_alignment" getter="get_alignment" enum="BoxContainer.AlignMode" default="0">
 			The alignment of the container's children (must be one of [constant ALIGN_BEGIN], [constant ALIGN_CENTER] or [constant ALIGN_END]).
 		</member>
+		<member name="flip_order" type="bool" setter="set_flip_order" getter="is_flip_order_enabled" default="false">
+			When enabled, the container's children are arranged in inverted order (from right to left for horizontal and from bottom to top for vertical).
+		</member>
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="1" />
 	</members>
 	<constants>

--- a/scene/gui/box_container.h
+++ b/scene/gui/box_container.h
@@ -46,6 +46,7 @@ public:
 
 private:
 	bool vertical;
+	bool flip_order;
 	AlignMode align;
 
 	void _resort();
@@ -60,6 +61,9 @@ public:
 
 	void set_alignment(AlignMode p_align);
 	AlignMode get_alignment() const;
+
+	void set_flip_order(bool p_enabled);
+	bool is_flip_order_enabled() const;
 
 	virtual Size2 get_minimum_size() const;
 


### PR DESCRIPTION
This change adds a `flip_order property` which allows inverting the container's children positions without changing the order they are rendered.

| Flip Order off  | Flip Order on |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/1075032/73559555-928f5f80-4455-11ea-9be2-2932ff8f7e6b.png" width="100" />  | <img src="https://user-images.githubusercontent.com/1075032/73559560-94592300-4455-11ea-8ef1-12a936f7612b.png" width="100" />  |

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/804.*
