### PR TITLE
Fix return type for GDNative's godot_color_to_XXX64

### DIFF
--- a/modules/gdnative/gdnative/color.cpp
+++ b/modules/gdnative/gdnative/color.cpp
@@ -121,17 +121,17 @@ godot_int GDAPI godot_color_to_abgr32(const godot_color *p_self) {
 	return self->to_abgr32();
 }
 
-godot_int GDAPI godot_color_to_abgr64(const godot_color *p_self) {
+uint64_t GDAPI godot_color_to_abgr64(const godot_color *p_self) {
 	const Color *self = (const Color *)p_self;
 	return self->to_abgr64();
 }
 
-godot_int GDAPI godot_color_to_argb64(const godot_color *p_self) {
+uint64_t GDAPI godot_color_to_argb64(const godot_color *p_self) {
 	const Color *self = (const Color *)p_self;
 	return self->to_argb64();
 }
 
-godot_int GDAPI godot_color_to_rgba64(const godot_color *p_self) {
+uint64_t GDAPI godot_color_to_rgba64(const godot_color *p_self) {
 	const Color *self = (const Color *)p_self;
 	return self->to_rgba64();
 }

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -175,21 +175,21 @@
         },
         {
           "name": "godot_color_to_abgr64",
-          "return_type": "godot_int",
+          "return_type": "uint64_t",
           "arguments": [
             ["const godot_color *", "p_self"]
           ]
         },
         {
           "name": "godot_color_to_argb64",
-          "return_type": "godot_int",
+          "return_type": "uint64_t",
           "arguments": [
             ["const godot_color *", "p_self"]
           ]
         },
         {
           "name": "godot_color_to_rgba64",
-          "return_type": "godot_int",
+          "return_type": "uint64_t",
           "arguments": [
             ["const godot_color *", "p_self"]
           ]

--- a/modules/gdnative/include/gdnative/color.h
+++ b/modules/gdnative/include/gdnative/color.h
@@ -83,11 +83,11 @@ godot_int GDAPI godot_color_to_rgba32(const godot_color *p_self);
 
 godot_int GDAPI godot_color_to_abgr32(const godot_color *p_self);
 
-godot_int GDAPI godot_color_to_abgr64(const godot_color *p_self);
+uint64_t GDAPI godot_color_to_abgr64(const godot_color *p_self);
 
-godot_int GDAPI godot_color_to_argb64(const godot_color *p_self);
+uint64_t GDAPI godot_color_to_argb64(const godot_color *p_self);
 
-godot_int GDAPI godot_color_to_rgba64(const godot_color *p_self);
+uint64_t GDAPI godot_color_to_rgba64(const godot_color *p_self);
 
 godot_int GDAPI godot_color_to_argb32(const godot_color *p_self);
 


### PR DESCRIPTION
This is a breaking api change, however right now `godot_color_to_XXX64` is broken because it returns `godot_int` unlike `Color::to_XXX64` which returns `uint64_t`...