### PR TITLE
Change light attentuation for GIProbes

### DIFF
--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -2691,11 +2691,7 @@ void VisualServerScene::_bake_gi_probe_light(const GIProbeDataHeader *header, co
 						(((cells[idx].normal >> 8) & 0xFF) / 255.0) * 2.0 - 1.0,
 						(((cells[idx].normal >> 0) & 0xFF) / 255.0) * 2.0 - 1.0);
 
-				float att = norm.dot(-light_axis);
-				if (att < 0.001) {
-					//not lighting towards this
-					continue;
-				}
+				float att = 1.0;
 
 				Vector3 from = to - max_len * light_axis;
 
@@ -2762,12 +2758,7 @@ void VisualServerScene::_bake_gi_probe_light(const GIProbeDataHeader *header, co
 				Vector3 light_axis = (to - light_pos).normalized();
 				float distance_adv = _get_normal_advance(light_axis);
 
-				float att = norm.dot(-light_axis);
-				if (att < 0.001) {
-					//not lighting towards this
-					continue;
-				}
-
+				float att = 1.0;
 				{
 					float d = light_pos.distance_to(to);
 					if (d + distance_adv > local_radius)


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/35200

From my understanding, we are taking a dot product between the cell normal and the light direction to easily exclude certain surfaces. However, it seems the normal and light direction are either in very different spaces or the normal is completely broken. Either way, starting with an ``attenuation`` of ``1.0`` results in accurate lighting.

Because I don't totally understand why the current approach is broken, this will need @reduz's approval before merging. 

**Before**
![Screenshot (40)](https://user-images.githubusercontent.com/16521339/73569621-ab7d1e00-441f-11ea-9690-cf3de0404e40.png)

**After**
![Screenshot (41)](https://user-images.githubusercontent.com/16521339/73569625-addf7800-441f-11ea-8cdd-303b83f9a3bf.png)
