### PR TITLE
Fix pressure / tilt ranges on Linux.

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -669,14 +669,8 @@ bool OS_X11::refresh_device_info() {
 		int range_max_x = 0;
 		int range_max_y = 0;
 		int pressure_resolution = 0;
-		int pressure_min = 0;
-		int pressure_max = 0;
 		int tilt_resolution_x = 0;
 		int tilt_resolution_y = 0;
-		int tilt_range_min_x = 0;
-		int tilt_range_min_y = 0;
-		int tilt_range_max_x = 0;
-		int tilt_range_max_y = 0;
 		for (int j = 0; j < dev->num_classes; j++) {
 #ifdef TOUCH_ENABLED
 			if (dev->classes[j]->type == XITouchClass && ((XITouchClassInfo *)dev->classes[j])->mode == XIDirectTouch) {
@@ -697,17 +691,14 @@ bool OS_X11::refresh_device_info() {
 					range_max_y = class_info->max;
 					absolute_mode = true;
 				} else if (class_info->number == VALUATOR_PRESSURE && class_info->mode == XIModeAbsolute) {
-					pressure_resolution = class_info->resolution;
-					pressure_min = class_info->min;
-					pressure_max = class_info->max;
+					pressure_resolution = (class_info->max - class_info->min);
+					if (pressure_resolution == 0) pressure_resolution = 1;
 				} else if (class_info->number == VALUATOR_TILTX && class_info->mode == XIModeAbsolute) {
-					tilt_resolution_x = class_info->resolution;
-					tilt_range_min_x = class_info->min;
-					tilt_range_max_x = class_info->max;
+					tilt_resolution_x = (class_info->max - class_info->min);
+					if (tilt_resolution_x == 0) tilt_resolution_x = 1;
 				} else if (class_info->number == VALUATOR_TILTY && class_info->mode == XIModeAbsolute) {
-					tilt_resolution_y = class_info->resolution;
-					tilt_range_min_y = class_info->min;
-					tilt_range_max_y = class_info->max;
+					tilt_resolution_y = (class_info->max - class_info->min);
+					if (tilt_resolution_y == 0) tilt_resolution_y = 1;
 				}
 			}
 		}
@@ -728,15 +719,6 @@ bool OS_X11::refresh_device_info() {
 			print_verbose("XInput: Absolute pointing device: " + String(dev->name));
 		}
 
-		if (pressure_resolution <= 0) {
-			pressure_resolution = (pressure_max - pressure_min);
-		}
-		if (tilt_resolution_x <= 0) {
-			tilt_resolution_x = (tilt_range_max_x - tilt_range_min_x);
-		}
-		if (tilt_resolution_y <= 0) {
-			tilt_resolution_y = (tilt_range_max_y - tilt_range_min_y);
-		}
 		xi.pressure = 0;
 		xi.pen_devices[dev->deviceid] = Vector3(pressure_resolution, tilt_resolution_x, tilt_resolution_y);
 	}


### PR DESCRIPTION
Fixes #35793

Apparently I misunderstood what `resolution` value is, and it should not be used like this.

```
min and max are the minimum and maximum values allowed on this
axis. If both are zero, no minumum or maximum values are set on
this device. value is the current value of this axis.

The resolution field specifies the resolution of the device in
units/m. 
```

*Note: I'm not sure what's going in mouse absolute X,Y code, it might misuse resolution too, cc @cosmicchipsocket*