### PR TITLE
Add clear instructions on how to get the Import dock to do something inside the import dock itself when no file is selected.

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -31,6 +31,7 @@
 #include "import_dock.h"
 #include "editor_node.h"
 #include "editor_resource_preview.h"
+#include "editor_scale.h"
 
 class ImportDockParameters : public Object {
 	GDCLASS(ImportDockParameters, Object);
@@ -134,6 +135,9 @@ void ImportDock::set_edit_path(const String &p_path) {
 	import->set_disabled(false);
 	import_as->set_disabled(false);
 	preset->set_disabled(false);
+
+	content->show();
+	select_a_resource->hide();
 
 	imported->set_text(p_path.get_file());
 }
@@ -375,6 +379,9 @@ void ImportDock::clear() {
 	params->properties.clear();
 	params->update();
 	preset->get_popup()->clear();
+
+	content->hide();
+	select_a_resource->show();
 }
 
 static bool _find_owners(EditorFileSystemDirectory *efsd, const String &p_path) {
@@ -525,12 +532,18 @@ void ImportDock::initialize_import_options() const {
 ImportDock::ImportDock() {
 
 	set_name("Import");
+
+	content = memnew(VBoxContainer);
+	content->set_v_size_flags(SIZE_EXPAND_FILL);
+	add_child(content);
+	content->hide();
+
 	imported = memnew(Label);
 	imported->add_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_stylebox("normal", "LineEdit"));
 	imported->set_clip_text(true);
-	add_child(imported);
+	content->add_child(imported);
 	HBoxContainer *hb = memnew(HBoxContainer);
-	add_margin_child(TTR("Import As:"), hb);
+	content->add_margin_child(TTR("Import As:"), hb);
 	import_as = memnew(OptionButton);
 	import_as->set_disabled(true);
 	import_as->connect("item_selected", this, "_importer_selected");
@@ -543,12 +556,12 @@ ImportDock::ImportDock() {
 	hb->add_child(preset);
 
 	import_opts = memnew(EditorInspector);
-	add_child(import_opts);
+	content->add_child(import_opts);
 	import_opts->set_v_size_flags(SIZE_EXPAND_FILL);
 	import_opts->connect("property_toggled", this, "_property_toggled");
 
 	hb = memnew(HBoxContainer);
-	add_child(hb);
+	content->add_child(hb);
 	import = memnew(Button);
 	import->set_text(TTR("Reimport"));
 	import->set_disabled(true);
@@ -559,7 +572,7 @@ ImportDock::ImportDock() {
 
 	reimport_confirm = memnew(ConfirmationDialog);
 	reimport_confirm->get_ok()->set_text(TTR("Save scenes, re-import and restart"));
-	add_child(reimport_confirm);
+	content->add_child(reimport_confirm);
 	reimport_confirm->connect("confirmed", this, "_reimport_and_restart");
 
 	VBoxContainer *vbc_confirm = memnew(VBoxContainer());
@@ -569,6 +582,15 @@ ImportDock::ImportDock() {
 	reimport_confirm->add_child(vbc_confirm);
 
 	params = memnew(ImportDockParameters);
+
+	select_a_resource = memnew(Label);
+	select_a_resource->set_text(TTR("Select a resource file in the filesystem or in the inspector to adjust import settings."));
+	select_a_resource->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+	select_a_resource->set_v_size_flags(SIZE_EXPAND_FILL);
+	select_a_resource->set_valign(Label::VALIGN_CENTER);
+	select_a_resource->set_align(Label::ALIGN_CENTER);
+	select_a_resource->set_autowrap(true);
+	add_child(select_a_resource);
 }
 
 ImportDock::~ImportDock() {

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -59,6 +59,9 @@ class ImportDock : public VBoxContainer {
 
 	ImportDockParameters *params;
 
+	VBoxContainer *content;
+	Label *select_a_resource;
+
 	void _preset_selected(int p_idx);
 	void _importer_selected(int i_idx);
 	void _update_options(const Ref<ConfigFile> &p_config = Ref<ConfigFile>());


### PR DESCRIPTION
…inside the import dock itself when no file is selected.

Fixes #14714

Right now the text goes: **Select a resource file to adjust import settings**. Feel free to change or suggest a better one.