### PR TITLE
Add a tooltip delay setting for editor

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -442,6 +442,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/single_window_mode", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	_initial_set("interface/editor/mouse_extra_buttons_navigate_history", true);
 	_initial_set("interface/editor/save_each_scene_on_quit", true); // Regression
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/editor/tooltip_delay", 0.5f, "0,5,0.01")
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/accept_dialog_cancel_ok_buttons", 0,
 			vformat("Auto (%s),Cancel First,OK First", DisplayServer::get_singleton()->get_swap_cancel_ok() ? "OK First" : "Cancel First"),
 			PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
@@ -934,6 +935,9 @@ void EditorSettings::create() {
 		}
 
 		singleton->save_changed_setting = true;
+
+		// Apply the tooltip delay setting.
+		Viewport::editor_tooltip_delay = EditorSettings::get_singleton()->get("interface/editor/tooltip_delay");
 
 		print_verbose("EditorSettings: Load OK!");
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4658,6 +4658,8 @@ void Viewport::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
+float Viewport::editor_tooltip_delay = 0.5f;
+
 Viewport::Viewport() {
 	world_2d = Ref<World2D>(memnew(World2D));
 	world_2d->register_viewport(this);
@@ -4691,8 +4693,12 @@ Viewport::Viewport() {
 	shortcut_input_group = "_vp_shortcut_input" + id;
 	unhandled_key_input_group = "_vp_unhandled_key_input" + id;
 
-	// Window tooltip.
-	gui.tooltip_delay = GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "gui/timers/tooltip_delay_sec", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"), 0.5);
+	// Set the tooltip delay to be either the editor delay, or regular delay, depending on whether this is in the editor or not.
+	if (Engine::get_singleton()->is_editor_hint()) {
+		gui.tooltip_delay = editor_tooltip_delay;
+	} else {
+		gui.tooltip_delay = GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "gui/timers/tooltip_delay_sec", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"), 0.5);
+	}
 
 #ifndef _3D_DISABLED
 	set_scaling_3d_mode((Viewport::Scaling3DMode)(int)GLOBAL_GET("rendering/scaling_3d/mode"));

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -95,6 +95,8 @@ class Viewport : public Node {
 	GDCLASS(Viewport, Node);
 
 public:
+	static float editor_tooltip_delay;
+
 	enum Scaling3DMode {
 		SCALING_3D_MODE_BILINEAR,
 		SCALING_3D_MODE_FSR,


### PR DESCRIPTION
Resolves #27879 and resolves #9030.

Adds an editor setting which changes the tooltip delay for tooltips inside the editor.

A restart is required for this change to be applied, however the code could be extended so that this is not required.

This is my first time contributing to a major open source project, and my first time using C++, so let me know if I should have done anything differently.