### PR TITLE
Improve the `doc_status.py` console output

### DIFF
--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -81,6 +81,7 @@ colors = {
     'section': [1, 4],  # bold, underline
     'state_off': [36],  # cyan
     'state_on': [1, 35],  # bold, magenta/plum
+    'bold': [1],  # bold
 }
 overall_progress_description_weigth = 10
 
@@ -227,7 +228,7 @@ class ClassStatus:
 
         output['items'] = items_progress.to_configured_colored_string()
 
-        output['overall'] = (description_progress + items_progress).to_colored_string('{percent}%', '{pad_percent}{s}')
+        output['overall'] = (description_progress + items_progress).to_colored_string(color('bold', '{percent}%'), '{pad_percent}{s}')
 
         if self.name.startswith('Total'):
             output['url'] = color('url', 'https://docs.godotengine.org/en/latest/classes/')
@@ -309,7 +310,7 @@ if flags['i']:
     table_columns.append('items')
 
 if flags['o'] == (not flags['i']):
-    table_column_names.append('Overall')
+    table_column_names.append(color('bold', 'Overall'))
     table_columns.append('overall')
 
 if flags['u']:
@@ -435,6 +436,11 @@ if len(table) > 2 or not flags['a']:
             row.append('')
     table.append(row)
 
+if flags['a']:
+    # Duplicate the headers at the bottom of the table so they can be viewed
+    # without having to scroll back to the top.
+    table.append(table_column_names)
+
 table_column_sizes = []
 for row in table:
     for cell_i, cell in enumerate(row):
@@ -460,7 +466,10 @@ for row_i, row in enumerate(table):
 
     print(row_string)
 
-    if row_i == 0 or row_i == len(table) - 2:
+    # Account for the possible double header (if the `a` flag is enabled).
+    # No need to have a condition for the flag, as this will behave correctly
+    # if the flag is disabled.
+    if row_i == 0 or row_i == len(table) - 3 or row_i == len(table) - 2:
         print(divider_string)
 
 print(divider_string)


### PR DESCRIPTION
- Duplicate the header when all classes are shown. Since lots of items are displayed in this case, this helps the user remember which column is which without having to scroll back to the top.
  - When using the `-a` option to only display an average of all classes, the output is identical to what it was before.
- Bolden the overall percentages for easier visual grepping.

## Preview

![doc_status.py](https://user-images.githubusercontent.com/180032/73581578-f03d9f00-4489-11ea-9541-8049df039746.png)