### PR TITLE
Adds CTRL-A CTRL-E support to LineEdit on macOS

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -22,6 +22,8 @@
 		- Ctrl + N: Like the down arrow key, move the cursor to the next line
 		- Ctrl + D: Like the Delete key, delete the character on the right side of cursor
 		- Ctrl + H: Like the Backspace key, delete the character on the left side of the cursor
+		- Ctrl + A: Like the Home key, move the cursor to the beginning of the line
+		- Ctrl + E: Like the End key, move the cursor to the end of the line
 		- Command + Left arrow: Like the Home key, move the cursor to the beginning of the line
 		- Command + Right arrow: Like the End key, move the cursor to the end of the line
 	</description>

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -184,6 +184,12 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 				case KEY_H: {
 					remap_key = KEY_BACKSPACE;
 				} break;
+				case KEY_A: {
+					remap_key = KEY_HOME;
+				} break;
+				case KEY_E: {
+					remap_key = KEY_END;
+				} break;
 			}
 
 			if (remap_key != KEY_UNKNOWN) {


### PR DESCRIPTION
These two shortcuts are commonly available on macOS.