### PR TITLE
Prevent shader crash when name conflict with "dus" and "__" occured

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -662,6 +662,8 @@ ShaderLanguage::Token ShaderLanguage::_get_token() {
 						idx++;
 					}
 
+					str = str.replace("dus_", "_");
+
 					return _make_token(TK_IDENTIFIER, str);
 				}
 


### PR DESCRIPTION
As described in: https://github.com/godotengine/godot/issues/1326#issuecomment-443547784
```
float _dump_code; // both get translated to m_dus_dump_code
float dus_dump_code;
```
which causes shader crash...

![image](https://user-images.githubusercontent.com/3036176/73590420-324efb00-44f3-11ea-84d2-032387fcf470.png)

