### PR TITLE
Added missing '\n' in visual shader custom node code generation

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -246,6 +246,7 @@ String VisualShaderNodeCustom::generate_code(Shader::Mode p_mode, VisualShader::
 		code.remove(code.size() - 1);
 		code += "}";
 	}
+	code += "\n";
 	return code;
 }
 


### PR DESCRIPTION
Small formatting fix for consistency with other nodes...

![image](https://user-images.githubusercontent.com/3036176/73592845-b4e5b380-450f-11ea-9c4a-856649caee0d.png)
