### PR TITLE
Fixes add group in Group Editor dialog

### DIFF
--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -197,7 +197,7 @@ void GroupDialog::_add_group(String p_name) {
 	}
 
 	String name = p_name.strip_edges();
-	if (name == "" || groups->search_item_text(name)) {
+	if (name.empty() || groups->get_item_with_text(name)) {
 		return;
 	}
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3630,6 +3630,17 @@ TreeItem *Tree::search_item_text(const String &p_find, int *r_col, bool p_select
 	return _search_item_text(from->get_next_visible(true), p_find, r_col, p_selectable);
 }
 
+TreeItem *Tree::get_item_with_text(const String &p_find) const {
+	for (TreeItem *current = root; current; current = current->get_next_visible()) {
+		for (int i = 0; i < columns.size(); i++) {
+			if (current->get_text(i) == p_find) {
+				return current;
+			}
+		}
+	}
+	return NULL;
+}
+
 void Tree::_do_incr_search(const String &p_add) {
 
 	uint64_t time = OS::get_singleton()->get_ticks_usec() / 1000; // convert to msec

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -577,7 +577,10 @@ public:
 	Rect2 get_item_rect(TreeItem *p_item, int p_column = -1) const;
 	bool edit_selected();
 
+	// First item that starts with the text, from the current focused item down and wraps around.
 	TreeItem *search_item_text(const String &p_find, int *r_col = NULL, bool p_selectable = false);
+	// First item that matches the whole text, from the first item down.
+	TreeItem *get_item_with_text(const String &p_find) const;
 
 	Point2 get_scroll() const;
 	void scroll_to_item(TreeItem *p_item);


### PR DESCRIPTION
Before this fix, new group can't be created if any existing group starts with the new name.

To reproduce the issue:
1. Click "Manage Groups" in the Node panel to open the dialog.
2. Add a group named "xxx".
3. Try to add a group named "x" or "xx".