### PR TITLE
Fix gdnative api generation for methods that return enums

### DIFF
--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -366,7 +366,7 @@ List<ClassAPI> generate_c_api_classes() {
 							arg_type = Variant::get_type_name(arg_info.type);
 						}
 					} else {
-						arg_type = Variant::get_type_name(arg_info.type);
+						arg_type = get_type_name(arg_info);
 					}
 
 					method_api.argument_names.push_back(arg_name);


### PR DESCRIPTION
Resolves #27877.

Before this PR the generated return type was an `int`.

Before:

```json
{
	"name": "set_align",
	"return_type": "void",
	"is_editor": false,
	"is_noscript": false,
	"is_const": false,
	"is_reverse": false,
	"is_virtual": false,
	"has_varargs": false,
	"is_from_script": false,
	"arguments": [
		{
			"name": "align",
			"type": "int",
			"has_default_value": false,
			"default_value": ""
		}
	]
},
```

After:
```json
{
	"name": "set_align",
	"return_type": "void",
	"is_editor": false,
	"is_noscript": false,
	"is_const": false,
	"is_reverse": false,
	"is_virtual": false,
	"has_varargs": false,
	"is_from_script": false,
	"arguments": [
		{
			"name": "align",
			"type": "enum.Label::Align",
			"has_default_value": false,
			"default_value": ""
		}
	]
},
```