### PR TITLE
Add visual feedback when hovering or dragging the code minimap grabber

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -446,12 +446,14 @@ private:
 
 	// minimap scroll
 	bool minimap_clicked = false;
+	bool hovering_minimap = false;
 	bool dragging_minimap = false;
 	bool can_drag_minimap = false;
 
 	double minimap_scroll_ratio = 0.0;
 	double minimap_scroll_click_pos = 0.0;
 
+	void _update_minimap_hover();
 	void _update_minimap_click();
 	void _update_minimap_drag();
 


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/52361.

This makes it more obvious that the minimap grabber can be dragged to scroll.

## Preview

[Preview on Gfycat](https://gfycat.com/reasonablerevolvingafricanwilddog)