### PR TITLE
Fix restoring window from fullscreen to normal on Linux

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1429,7 +1429,7 @@ void OS_X11::set_window_fullscreen(bool p_enabled) {
 		set_window_maximized(true);
 	}
 	set_wm_fullscreen(p_enabled);
-	if (!p_enabled && !current_videomode.always_on_top) {
+	if (!p_enabled && current_videomode.always_on_top) {
 		// Restore
 		set_window_maximized(false);
 	}


### PR DESCRIPTION
Fix obvious logic error that prevents correct window restoration on Linux.
Closes #16672
