### PR TITLE
Highlight context menu items at the top of the 2D/3D viewports

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -230,6 +230,10 @@ private:
 	HScrollBar *h_scroll;
 	VScrollBar *v_scroll;
 	HBoxContainer *hb;
+	// Used for secondary menu items which are displayed depending on the currently selected node
+	// (such as MeshInstance's "Mesh" menu).
+	PanelContainer *context_menu_container;
+	HBoxContainer *hbc_context_menu;
 
 	Map<Control *, Timer *> popup_temporarily_timers;
 
@@ -535,6 +539,7 @@ private:
 	HSplitContainer *palette_split;
 	VSplitContainer *bottom_split;
 
+	void _update_context_menu_stylebox();
 	void _popup_warning_temporarily(Control *p_control, const float p_duration);
 	void _popup_warning_depop(Control *p_control);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5963,6 +5963,18 @@ void fragment() {
 	_generate_selection_boxes();
 }
 
+void Node3DEditor::_update_context_menu_stylebox() {
+	// This must be called when the theme changes to follow the new accent color.
+	Ref<StyleBoxFlat> context_menu_stylebox = memnew(StyleBoxFlat);
+	const Color accent_color = EditorNode::get_singleton()->get_gui_base()->get_theme_color("accent_color", "Editor");
+	context_menu_stylebox->set_bg_color(accent_color * Color(1, 1, 1, 0.1));
+	// Add an underline to the StyleBox, but prevent its minimum vertical size from changing.
+	context_menu_stylebox->set_border_color(accent_color);
+	context_menu_stylebox->set_border_width(SIDE_BOTTOM, Math::round(2 * EDSCALE));
+	context_menu_stylebox->set_default_margin(SIDE_BOTTOM, 0);
+	context_menu_container->add_theme_style_override("panel", context_menu_stylebox);
+}
+
 void Node3DEditor::_update_gizmos_menu() {
 	gizmos_menu->clear();
 
@@ -6530,6 +6542,7 @@ void Node3DEditor::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_theme();
 			_update_gizmos_menu_theme();
+			_update_context_menu_stylebox();
 			sun_title->add_theme_font_override("font", get_theme_font(SNAME("title_font"), SNAME("Window")));
 			environ_title->add_theme_font_override("font", get_theme_font(SNAME("title_font"), SNAME("Window")));
 		} break;
@@ -6578,11 +6591,11 @@ Vector<int> Node3DEditor::get_subgizmo_selection() {
 }
 
 void Node3DEditor::add_control_to_menu_panel(Control *p_control) {
-	hbc_menu->add_child(p_control);
+	hbc_context_menu->add_child(p_control);
 }
 
 void Node3DEditor::remove_control_from_menu_panel(Control *p_control) {
-	hbc_menu->remove_child(p_control);
+	hbc_context_menu->remove_child(p_control);
 }
 
 void Node3DEditor::set_can_preview(Camera3D *p_preview) {
@@ -7164,6 +7177,17 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	view_menu->set_switch_on_hover(true);
 	view_menu->set_shortcut_context(this);
 	hbc_menu->add_child(view_menu);
+
+	hbc_menu->add_child(memnew(VSeparator));
+
+	context_menu_container = memnew(PanelContainer);
+	hbc_context_menu = memnew(HBoxContainer);
+	context_menu_container->add_child(hbc_context_menu);
+	// Use a custom stylebox to make contextual menu items stand out from the rest.
+	// This helps with editor usability as contextual menu items change when selecting nodes,
+	// even though it may not be immediately obvious at first.
+	hbc_menu->add_child(context_menu_container);
+	_update_context_menu_stylebox();
 
 	p = view_menu->get_popup();
 

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -625,6 +625,10 @@ private:
 	void _update_camera_override_viewport(Object *p_viewport);
 
 	HBoxContainer *hbc_menu;
+	// Used for secondary menu items which are displayed depending on the currently selected node
+	// (such as MeshInstance's "Mesh" menu).
+	PanelContainer *context_menu_container;
+	HBoxContainer *hbc_context_menu;
 
 	void _generate_selection_boxes();
 	UndoRedo *undo_redo;
@@ -632,6 +636,7 @@ private:
 	int camera_override_viewport_id;
 
 	void _init_indicators();
+	void _update_context_menu_stylebox();
 	void _update_gizmos_menu();
 	void _update_gizmos_menu_theme();
 	void _init_grid();


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/51087.

This makes it easier to notice that some menu items only appear when specific nodes are selected.

This change applies to both 2D and 3D editors, including both plugin-based menus and the hardcoded 2D layout/animation contextual menus.

This closes https://github.com/godotengine/godot/issues/11566 and possibly other issues/proposals.

## Preview

![image](https://user-images.githubusercontent.com/180032/126012384-29eabca2-6674-4407-8a62-3dba221bbdad.png)

<details>
<summary>Old versions</summary>

*A blended version of the editor theme's accent color is used for highlighting (25% opacity).*

![image](https://user-images.githubusercontent.com/180032/109908825-412f5080-7ca5-11eb-984e-7e76aefd9055.png)

### Even older versions

#### Dark theme

![3D editor](https://user-images.githubusercontent.com/180032/73682870-83ace500-46c1-11ea-8e5d-2039fcc98b19.png)

![2D editor + animation](https://user-images.githubusercontent.com/180032/73682872-84de1200-46c1-11ea-9765-2f6581d94866.png)

#### Light theme

![2D editor (GUI)](https://user-images.githubusercontent.com/180032/73682874-860f3f00-46c1-11ea-84d2-b5b43f8bdd28.png)
</details>