### PR TITLE
Calculate __focus_rect when TreeItem is focused

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1388,7 +1388,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				}
 			}
 
-			if ((select_mode == SELECT_ROW && selected_item == p_item) || p_item->cells[i].selected) {
+			if ((select_mode == SELECT_ROW && selected_item == p_item) || p_item->cells[i].selected || !p_item->has_meta("__focus_rect")) {
 				Rect2i r(cell_rect.position, cell_rect.size);
 
 				p_item->set_meta("__focus_rect", Rect2(r.position, r.size));


### PR DESCRIPTION
Fixes #35876

No idea what this condition was supposed to do. It only disables the `__focus_rect` calculation as the cell needs to be selected anyways to do anything visually. The `||` part might be unnecessary too, but I left it there just in case.