### PR TITLE
Completes doc for button classes

### DIFF
--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -56,28 +56,40 @@
 	</constants>
 	<theme_items>
 		<theme_item name="bg" type="Texture">
+			The background of the color preview rect on the button.
 		</theme_item>
 		<theme_item name="disabled" type="StyleBox">
+			[StyleBox] used when the [ColorPickerButton] is disabled.
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
+			[StyleBox] used when the [ColorPickerButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 		<theme_item name="font" type="Font">
+			[Font] of the [ColorPickerButton]'s text.
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			Default text [Color] of the [ColorPickerButton].
 		</theme_item>
 		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.3 )">
+			Text [Color] used when the [ColorPickerButton] is disabled.
 		</theme_item>
 		<theme_item name="font_color_hover" type="Color" default="Color( 1, 1, 1, 1 )">
+			Text [Color] used when the [ColorPickerButton] is being hovered.
 		</theme_item>
 		<theme_item name="font_color_pressed" type="Color" default="Color( 0.8, 0.8, 0.8, 1 )">
+			Text [Color] used when the [ColorPickerButton] is being pressed.
 		</theme_item>
 		<theme_item name="hover" type="StyleBox">
+			[StyleBox] used when the [ColorPickerButton] is being hovered.
 		</theme_item>
 		<theme_item name="hseparation" type="int" default="2">
+			The horizontal space between [ColorPickerButton]'s icon and text.
 		</theme_item>
 		<theme_item name="normal" type="StyleBox">
+			Default [StyleBox] for the [ColorPickerButton].
 		</theme_item>
 		<theme_item name="pressed" type="StyleBox">
+			[StyleBox] used when the [ColorPickerButton] is being pressed.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -15,8 +15,10 @@
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="0" />
 		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" override="true" enum="Control.CursorShape" default="2" />
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
+			The button's text that will be displayed inside the button's area.
 		</member>
 		<member name="underline" type="int" setter="set_underline_mode" getter="get_underline_mode" enum="LinkButton.UnderlineMode" default="0">
+			Determines when to show the underline. See [enum UnderlineMode] for options.
 		</member>
 	</members>
 	<constants>
@@ -32,16 +34,22 @@
 	</constants>
 	<theme_items>
 		<theme_item name="focus" type="StyleBox">
+			[StyleBox] used when the [LinkButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 		<theme_item name="font" type="Font">
+			[Font] of the [LinkButton]'s text.
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+			Default text [Color] of the [LinkButton].
 		</theme_item>
 		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+			Text [Color] used when the [LinkButton] is being hovered.
 		</theme_item>
 		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+			Text [Color] used when the [LinkButton] is being pressed.
 		</theme_item>
 		<theme_item name="underline_spacing" type="int" default="2">
+			The vertical space between the baseline of text and the underline.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -48,26 +48,37 @@
 	</constants>
 	<theme_items>
 		<theme_item name="disabled" type="StyleBox">
+			[StyleBox] used when the [MenuButton] is disabled.
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
+			[StyleBox] used when the [MenuButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 		<theme_item name="font" type="Font">
+			[Font] of the [MenuButton]'s text.
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+			Default text [Color] of the [MenuButton].
 		</theme_item>
 		<theme_item name="font_color_disabled" type="Color" default="Color( 1, 1, 1, 0.3 )">
+			Text [Color] used when the [MenuButton] is disabled.
 		</theme_item>
 		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+			Text [Color] used when the [MenuButton] is being hovered.
 		</theme_item>
 		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+			Text [Color] used when the [MenuButton] is being pressed.
 		</theme_item>
 		<theme_item name="hover" type="StyleBox">
+			[StyleBox] used when the [MenuButton] is being hovered.
 		</theme_item>
 		<theme_item name="hseparation" type="int" default="3">
+			The horizontal space between [MenuButton]'s icon and text.
 		</theme_item>
 		<theme_item name="normal" type="StyleBox">
+			Default [StyleBox] for the [MenuButton].
 		</theme_item>
 		<theme_item name="pressed" type="StyleBox">
+			[StyleBox] used when the [MenuButton] is being pressed.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -232,30 +232,43 @@
 	</constants>
 	<theme_items>
 		<theme_item name="arrow" type="Texture">
+			The arrow icon to be drawn on the right end of the button.
 		</theme_item>
 		<theme_item name="arrow_margin" type="int" default="2">
+			The horizontal space between the arrow icon and the right edge of the button.
 		</theme_item>
 		<theme_item name="disabled" type="StyleBox">
+			[StyleBox] used when the [OptionButton] is disabled.
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
+			[StyleBox] used when the [OptionButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 		<theme_item name="font" type="Font">
+			[Font] of the [OptionButton]'s text.
 		</theme_item>
 		<theme_item name="font_color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+			Default text [Color] of the [OptionButton].
 		</theme_item>
 		<theme_item name="font_color_disabled" type="Color" default="Color( 0.9, 0.9, 0.9, 0.2 )">
+			Text [Color] used when the [OptionButton] is disabled.
 		</theme_item>
 		<theme_item name="font_color_hover" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+			Text [Color] used when the [OptionButton] is being hovered.
 		</theme_item>
 		<theme_item name="font_color_pressed" type="Color" default="Color( 1, 1, 1, 1 )">
+			Text [Color] used when the [OptionButton] is being pressed.
 		</theme_item>
 		<theme_item name="hover" type="StyleBox">
+			[StyleBox] used when the [OptionButton] is being hovered.
 		</theme_item>
 		<theme_item name="hseparation" type="int" default="2">
+			The horizontal space between [OptionButton]'s icon and text.
 		</theme_item>
 		<theme_item name="normal" type="StyleBox">
+			Default [StyleBox] for the [OptionButton].
 		</theme_item>
 		<theme_item name="pressed" type="StyleBox">
+			[StyleBox] used when the [OptionButton] is being pressed.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ToolButton.xml
+++ b/doc/classes/ToolButton.xml
@@ -24,7 +24,7 @@
 			[StyleBox] used when the [ToolButton] is disabled.
 		</theme_item>
 		<theme_item name="focus" type="StyleBox">
-			[StyleBox] used when the [ToolButton] is focused. It is displayed over the current [StyleBox], so using [StyleboxEmpty] will just disable the focus visual effect.
+			[StyleBox] used when the [ToolButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 		<theme_item name="font" type="Font">
 			[Font] of the [ToolButton]'s text.


### PR DESCRIPTION
Documents all `BaseButton` subclasses. Wording based on the doc for `Button`.

Also fixed the typo "StyleboxEmpty" in `ToolButton`'s doc.