### PR TITLE
Fix false positive "Unreachable code" warning for loops

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3167,7 +3167,6 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 				if (error_set) {
 					return;
 				}
-				p_block->has_return = cf_while->body->has_return;
 				p_block->statements.push_back(cf_while);
 			} break;
 			case GDScriptTokenizer::TK_CF_FOR: {
@@ -3308,7 +3307,6 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 				if (error_set) {
 					return;
 				}
-				p_block->has_return = cf_for->body->has_return;
 				p_block->statements.push_back(cf_for);
 			} break;
 			case GDScriptTokenizer::TK_CF_CONTINUE: {


### PR DESCRIPTION
Fix #35775. It will fix erroneous reports in these two cases:

```gdscript
func a():
	var arr = []
	for i in arr:
		return i
	# can be reached, but buggy analysis says cannot
	return -1

func b():
	var should_loop = false
	while should_loop:
		return 1
	# can be reached, but buggy analysis says cannot
	return 0
```

