### PR TITLE
PackedByteArray, Array slice end exclusive, rename PackedByteArray subarray to slice

### DIFF
--- a/core/multiplayer/multiplayer_replicator.cpp
+++ b/core/multiplayer/multiplayer_replicator.cpp
@@ -207,7 +207,7 @@ Error MultiplayerReplicator::_send_default_spawn_despawn(int p_peer_id, const Re
 	const Vector<StringName> names = rel_path.get_names();
 	ERR_FAIL_COND_V(names.size() < 2, ERR_INVALID_PARAMETER);
 
-	NodePath parent = NodePath(names.subarray(0, names.size() - 2), false);
+	NodePath parent = NodePath(names.slice(0, names.size() - 1), false);
 	ERR_FAIL_COND_V_MSG(!root_node->has_node(parent), ERR_INVALID_PARAMETER, "Path not found: " + parent);
 
 	int path_id = 0;

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -144,27 +144,28 @@ public:
 		return ret;
 	}
 
-	Vector<T> subarray(int p_from, int p_to) const {
-		if (p_from < 0) {
-			p_from = size() + p_from;
-		}
-		if (p_to < 0) {
-			p_to = size() + p_to;
-		}
+	Vector<T> slice(int p_begin, int p_end) const {
+		Vector<T> result;
 
-		ERR_FAIL_INDEX_V(p_from, size(), Vector<T>());
-		ERR_FAIL_INDEX_V(p_to, size(), Vector<T>());
-
-		Vector<T> slice;
-		int span = 1 + p_to - p_from;
-		slice.resize(span);
-		const T *r = ptr();
-		T *w = slice.ptrw();
-		for (int i = 0; i < span; ++i) {
-			w[i] = r[p_from + i];
+		if (p_end < 0) {
+			p_end += size() + 1;
 		}
 
-		return slice;
+		ERR_FAIL_INDEX_V(p_begin, size(), result);
+		ERR_FAIL_INDEX_V(p_end, size() + 1, result);
+
+		ERR_FAIL_COND_V(p_begin > p_end, result);
+
+		int result_size = p_end - p_begin;
+		result.resize(result_size);
+
+		const T *const r = ptr();
+		T *const w = result.ptrw();
+		for (int i = 0; i < result_size; ++i) {
+			w[i] = r[p_begin + i];
+		}
+
+		return result;
 	}
 
 	bool operator==(const Vector<T> &p_arr) const {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -44,8 +44,6 @@ class Array {
 	void _ref(const Array &p_from) const;
 	void _unref() const;
 
-	inline int _clamp_slice_index(int p_index) const;
-
 protected:
 	Array(const Array &p_base, uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	bool _assign(const Array &p_array);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1848,7 +1848,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedByteArray, resize, sarray("new_size"), varray());
 	bind_method(PackedByteArray, has, sarray("value"), varray());
 	bind_method(PackedByteArray, reverse, sarray(), varray());
-	bind_method(PackedByteArray, subarray, sarray("from", "to"), varray());
+	bind_method(PackedByteArray, slice, sarray("begin", "end"), varray());
 	bind_method(PackedByteArray, sort, sarray(), varray());
 	bind_method(PackedByteArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedByteArray, duplicate, sarray(), varray());
@@ -1909,7 +1909,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedInt32Array, resize, sarray("new_size"), varray());
 	bind_method(PackedInt32Array, has, sarray("value"), varray());
 	bind_method(PackedInt32Array, reverse, sarray(), varray());
-	bind_method(PackedInt32Array, subarray, sarray("from", "to"), varray());
+	bind_method(PackedInt32Array, slice, sarray("begin", "end"), varray());
 	bind_method(PackedInt32Array, to_byte_array, sarray(), varray());
 	bind_method(PackedInt32Array, sort, sarray(), varray());
 	bind_method(PackedInt32Array, bsearch, sarray("value", "before"), varray(true));
@@ -1929,7 +1929,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedInt64Array, resize, sarray("new_size"), varray());
 	bind_method(PackedInt64Array, has, sarray("value"), varray());
 	bind_method(PackedInt64Array, reverse, sarray(), varray());
-	bind_method(PackedInt64Array, subarray, sarray("from", "to"), varray());
+	bind_method(PackedInt64Array, slice, sarray("begin", "end"), varray());
 	bind_method(PackedInt64Array, to_byte_array, sarray(), varray());
 	bind_method(PackedInt64Array, sort, sarray(), varray());
 	bind_method(PackedInt64Array, bsearch, sarray("value", "before"), varray(true));
@@ -1949,7 +1949,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedFloat32Array, resize, sarray("new_size"), varray());
 	bind_method(PackedFloat32Array, has, sarray("value"), varray());
 	bind_method(PackedFloat32Array, reverse, sarray(), varray());
-	bind_method(PackedFloat32Array, subarray, sarray("from", "to"), varray());
+	bind_method(PackedFloat32Array, slice, sarray("begin", "end"), varray());
 	bind_method(PackedFloat32Array, to_byte_array, sarray(), varray());
 	bind_method(PackedFloat32Array, sort, sarray(), varray());
 	bind_method(PackedFloat32Array, bsearch, sarray("value", "before"), varray(true));
@@ -1969,7 +1969,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedFloat64Array, resize, sarray("new_size"), varray());
 	bind_method(PackedFloat64Array, has, sarray("value"), varray());
 	bind_method(PackedFloat64Array, reverse, sarray(), varray());
-	bind_method(PackedFloat64Array, subarray, sarray("from", "to"), varray());
+	bind_method(PackedFloat64Array, slice, sarray("begin", "end"), varray());
 	bind_method(PackedFloat64Array, to_byte_array, sarray(), varray());
 	bind_method(PackedFloat64Array, sort, sarray(), varray());
 	bind_method(PackedFloat64Array, bsearch, sarray("value", "before"), varray(true));
@@ -1989,7 +1989,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedStringArray, resize, sarray("new_size"), varray());
 	bind_method(PackedStringArray, has, sarray("value"), varray());
 	bind_method(PackedStringArray, reverse, sarray(), varray());
-	bind_method(PackedStringArray, subarray, sarray("from", "to"), varray());
+	bind_method(PackedStringArray, slice, sarray("begin", "end"), varray());
 	bind_method(PackedStringArray, to_byte_array, sarray(), varray());
 	bind_method(PackedStringArray, sort, sarray(), varray());
 	bind_method(PackedStringArray, bsearch, sarray("value", "before"), varray(true));
@@ -2009,7 +2009,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedVector2Array, resize, sarray("new_size"), varray());
 	bind_method(PackedVector2Array, has, sarray("value"), varray());
 	bind_method(PackedVector2Array, reverse, sarray(), varray());
-	bind_method(PackedVector2Array, subarray, sarray("from", "to"), varray());
+	bind_method(PackedVector2Array, slice, sarray("begin", "end"), varray());
 	bind_method(PackedVector2Array, to_byte_array, sarray(), varray());
 	bind_method(PackedVector2Array, sort, sarray(), varray());
 	bind_method(PackedVector2Array, bsearch, sarray("value", "before"), varray(true));
@@ -2029,7 +2029,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedVector3Array, resize, sarray("new_size"), varray());
 	bind_method(PackedVector3Array, has, sarray("value"), varray());
 	bind_method(PackedVector3Array, reverse, sarray(), varray());
-	bind_method(PackedVector3Array, subarray, sarray("from", "to"), varray());
+	bind_method(PackedVector3Array, slice, sarray("begin", "end"), varray());
 	bind_method(PackedVector3Array, to_byte_array, sarray(), varray());
 	bind_method(PackedVector3Array, sort, sarray(), varray());
 	bind_method(PackedVector3Array, bsearch, sarray("value", "before"), varray(true));
@@ -2049,7 +2049,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedColorArray, resize, sarray("new_size"), varray());
 	bind_method(PackedColorArray, has, sarray("value"), varray());
 	bind_method(PackedColorArray, reverse, sarray(), varray());
-	bind_method(PackedColorArray, subarray, sarray("from", "to"), varray());
+	bind_method(PackedColorArray, slice, sarray("begin", "end"), varray());
 	bind_method(PackedColorArray, to_byte_array, sarray(), varray());
 	bind_method(PackedColorArray, sort, sarray(), varray());
 	bind_method(PackedColorArray, bsearch, sarray("value", "before"), varray(true));

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -449,7 +449,10 @@
 			<argument index="2" name="step" type="int" default="1" />
 			<argument index="3" name="deep" type="bool" default="false" />
 			<description>
-				Duplicates the subset described in the function and returns it in an array, deeply copying the array if [code]deep[/code] is [code]true[/code]. Lower and upper index are inclusive, with the [code]step[/code] describing the change between indices while slicing. Wraps around if [code]begin[/code] or [code]end[/code] are out of bounds or negative. Returns an empty array for invalid parameters.
+				Returns the slice of the [Array], from [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), as a new [Array].
+				If [code]end[/code] is negative, it will be relative to the end of the array.
+				If specified, [code]step[/code] is the relative index between source elements.
+				If [code]deep[/code] is true, each element will be copied by value rather than by reference.
 			</description>
 		</method>
 		<method name="sort">

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -366,18 +366,19 @@
 				Returns the size of the array.
 			</description>
 		</method>
+		<method name="slice" qualifiers="const">
+			<return type="PackedByteArray" />
+			<argument index="0" name="begin" type="int" />
+			<argument index="1" name="end" type="int" />
+			<description>
+				Returns the slice of the [PackedByteArray], from [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), as a new [PackedByteArray].
+				If [code]end[/code]is negative, it will be relative to the end of the array.
+			</description>
+		</method>
 		<method name="sort">
 			<return type="void" />
 			<description>
 				Sorts the elements of the array in ascending order.
-			</description>
-		</method>
-		<method name="subarray" qualifiers="const">
-			<return type="PackedByteArray" />
-			<argument index="0" name="from" type="int" />
-			<argument index="1" name="to" type="int" />
-			<description>
-				Returns the slice of the [PackedByteArray] between indices (inclusive) as a new [PackedByteArray]. Any negative index is considered to be from the end of the array.
 			</description>
 		</method>
 		<method name="to_float32_array" qualifiers="const">

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -129,17 +129,17 @@
 				Returns the size of the array.
 			</description>
 		</method>
+		<method name="slice" qualifiers="const">
+			<return type="PackedColorArray" />
+			<argument index="0" name="begin" type="int" />
+			<argument index="1" name="end" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="sort">
 			<return type="void" />
 			<description>
 				Sorts the elements of the array in ascending order.
-			</description>
-		</method>
-		<method name="subarray" qualifiers="const">
-			<return type="PackedColorArray" />
-			<argument index="0" name="from" type="int" />
-			<argument index="1" name="to" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="to_byte_array" qualifiers="const">

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -130,17 +130,17 @@
 				Returns the size of the array.
 			</description>
 		</method>
+		<method name="slice" qualifiers="const">
+			<return type="PackedFloat32Array" />
+			<argument index="0" name="begin" type="int" />
+			<argument index="1" name="end" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="sort">
 			<return type="void" />
 			<description>
 				Sorts the elements of the array in ascending order.
-			</description>
-		</method>
-		<method name="subarray" qualifiers="const">
-			<return type="PackedFloat32Array" />
-			<argument index="0" name="from" type="int" />
-			<argument index="1" name="to" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="to_byte_array" qualifiers="const">

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -130,17 +130,17 @@
 				Returns the size of the array.
 			</description>
 		</method>
+		<method name="slice" qualifiers="const">
+			<return type="PackedFloat64Array" />
+			<argument index="0" name="begin" type="int" />
+			<argument index="1" name="end" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="sort">
 			<return type="void" />
 			<description>
 				Sorts the elements of the array in ascending order.
-			</description>
-		</method>
-		<method name="subarray" qualifiers="const">
-			<return type="PackedFloat64Array" />
-			<argument index="0" name="from" type="int" />
-			<argument index="1" name="to" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="to_byte_array" qualifiers="const">

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -130,17 +130,17 @@
 				Returns the array size.
 			</description>
 		</method>
+		<method name="slice" qualifiers="const">
+			<return type="PackedInt32Array" />
+			<argument index="0" name="begin" type="int" />
+			<argument index="1" name="end" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="sort">
 			<return type="void" />
 			<description>
 				Sorts the elements of the array in ascending order.
-			</description>
-		</method>
-		<method name="subarray" qualifiers="const">
-			<return type="PackedInt32Array" />
-			<argument index="0" name="from" type="int" />
-			<argument index="1" name="to" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="to_byte_array" qualifiers="const">

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -130,17 +130,17 @@
 				Returns the array size.
 			</description>
 		</method>
+		<method name="slice" qualifiers="const">
+			<return type="PackedInt64Array" />
+			<argument index="0" name="begin" type="int" />
+			<argument index="1" name="end" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="sort">
 			<return type="void" />
 			<description>
 				Sorts the elements of the array in ascending order.
-			</description>
-		</method>
-		<method name="subarray" qualifiers="const">
-			<return type="PackedInt64Array" />
-			<argument index="0" name="from" type="int" />
-			<argument index="1" name="to" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="to_byte_array" qualifiers="const">

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -130,17 +130,17 @@
 				Returns the size of the array.
 			</description>
 		</method>
+		<method name="slice" qualifiers="const">
+			<return type="PackedStringArray" />
+			<argument index="0" name="begin" type="int" />
+			<argument index="1" name="end" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="sort">
 			<return type="void" />
 			<description>
 				Sorts the elements of the array in ascending order.
-			</description>
-		</method>
-		<method name="subarray" qualifiers="const">
-			<return type="PackedStringArray" />
-			<argument index="0" name="from" type="int" />
-			<argument index="1" name="to" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="to_byte_array" qualifiers="const">

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -130,17 +130,17 @@
 				Returns the size of the array.
 			</description>
 		</method>
+		<method name="slice" qualifiers="const">
+			<return type="PackedVector2Array" />
+			<argument index="0" name="begin" type="int" />
+			<argument index="1" name="end" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="sort">
 			<return type="void" />
 			<description>
 				Sorts the elements of the array in ascending order.
-			</description>
-		</method>
-		<method name="subarray" qualifiers="const">
-			<return type="PackedVector2Array" />
-			<argument index="0" name="from" type="int" />
-			<argument index="1" name="to" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="to_byte_array" qualifiers="const">

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -129,17 +129,17 @@
 				Returns the size of the array.
 			</description>
 		</method>
+		<method name="slice" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<argument index="0" name="begin" type="int" />
+			<argument index="1" name="end" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="sort">
 			<return type="void" />
 			<description>
 				Sorts the elements of the array in ascending order.
-			</description>
-		</method>
-		<method name="subarray" qualifiers="const">
-			<return type="PackedVector3Array" />
-			<argument index="0" name="from" type="int" />
-			<argument index="1" name="to" type="int" />
-			<description>
 			</description>
 		</method>
 		<method name="to_byte_array" qualifiers="const">

--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
@@ -1864,7 +1864,7 @@ void RendererSceneGIRD::SDFGI::render_region(RID p_render_buffers, int p_region,
 		Ref<Image> img;
 		img.instantiate();
 		for (uint32_t i = 0; i < cascade_size; i++) {
-			Vector<uint8_t> subarr = data.subarray(128 * 128 * i, 128 * 128 * (i + 1) - 1);
+			Vector<uint8_t> subarr = data.slice(128 * 128 * i, 128 * 128 * (i + 1));
 			img->create(cascade_size, cascade_size, false, Image::FORMAT_L8, subarr);
 			img->save_png("res://cascade_sdf_" + itos(cascade) + "_" + itos(i) + ".png");
 		}
@@ -1877,7 +1877,7 @@ void RendererSceneGIRD::SDFGI::render_region(RID p_render_buffers, int p_region,
 		Ref<Image> img;
 		img.instantiate();
 		for (uint32_t i = 0; i < cascade_size; i++) {
-			Vector<uint8_t> subarr = data.subarray(128 * 128 * i * 2, 128 * 128 * (i + 1) * 2 - 1);
+			Vector<uint8_t> subarr = data.slice(128 * 128 * i * 2, 128 * 128 * (i + 1) * 2);
 			img->createcascade_size, cascade_size, false, Image::FORMAT_RGB565, subarr);
 			img->convert(Image::FORMAT_RGBA8);
 			img->save_png("res://cascade_" + itos(cascade) + "_" + itos(i) + ".png");

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -1089,7 +1089,7 @@ Vector<Ref<Image>> RendererStorageRD::texture_3d_get(RID p_texture) const {
 		const Texture::BufferSlice3D &bs = tex->buffer_slices_3d[i];
 		ERR_FAIL_COND_V(bs.offset >= (uint32_t)all_data.size(), Vector<Ref<Image>>());
 		ERR_FAIL_COND_V(bs.offset + bs.buffer_size > (uint32_t)all_data.size(), Vector<Ref<Image>>());
-		Vector<uint8_t> sub_region = all_data.subarray(bs.offset, bs.offset + bs.buffer_size - 1);
+		Vector<uint8_t> sub_region = all_data.slice(bs.offset, bs.offset + bs.buffer_size);
 
 		Ref<Image> img;
 		img.instantiate();

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1376,7 +1376,7 @@ Array RenderingServer::mesh_surface_get_blend_shape_arrays(RID p_mesh, int p_sur
 		Array blend_shape_array;
 		blend_shape_array.resize(mesh_get_blend_shape_count(p_mesh));
 		for (uint32_t i = 0; i < blend_shape_count; i++) {
-			Vector<uint8_t> bs_data = blend_shape_data.subarray(i * divisor, (i + 1) * divisor - 1);
+			Vector<uint8_t> bs_data = blend_shape_data.slice(i * divisor, (i + 1) * divisor);
 			Vector<uint8_t> unused;
 			blend_shape_array.set(i, _get_array_from_surface(bs_format, bs_data, unused, unused, sd.vertex_count, unused, 0));
 		}

--- a/tests/core/templates/test_vector.h
+++ b/tests/core/templates/test_vector.h
@@ -238,7 +238,7 @@ TEST_CASE("[Vector] To byte array") {
 	CHECK(byte_array[15] == 59);
 }
 
-TEST_CASE("[Vector] Subarray") {
+TEST_CASE("[Vector] Slice") {
 	Vector<int> vector;
 	vector.push_back(0);
 	vector.push_back(1);
@@ -246,27 +246,27 @@ TEST_CASE("[Vector] Subarray") {
 	vector.push_back(3);
 	vector.push_back(4);
 
-	Vector<int> subarray1 = vector.subarray(1, 2);
-	CHECK(subarray1.size() == 2);
-	CHECK(subarray1[0] == 1);
-	CHECK(subarray1[1] == 2);
+	Vector<int> slice1 = vector.slice(1, 3);
+	CHECK(slice1.size() == 2);
+	CHECK(slice1[0] == 1);
+	CHECK(slice1[1] == 2);
 
-	Vector<int> subarray2 = vector.subarray(1, -1);
-	CHECK(subarray2.size() == 4);
-	CHECK(subarray2[0] == 1);
-	CHECK(subarray2[1] == 2);
-	CHECK(subarray2[2] == 3);
-	CHECK(subarray2[3] == 4);
+	Vector<int> slice2 = vector.slice(1, -1);
+	CHECK(slice2.size() == 4);
+	CHECK(slice2[0] == 1);
+	CHECK(slice2[1] == 2);
+	CHECK(slice2[2] == 3);
+	CHECK(slice2[3] == 4);
 
-	Vector<int> subarray3 = vector.subarray(-2, -1);
-	CHECK(subarray3.size() == 2);
-	CHECK(subarray3[0] == 3);
-	CHECK(subarray3[1] == 4);
+	Vector<int> slice3 = vector.slice(3, -1);
+	CHECK(slice3.size() == 2);
+	CHECK(slice3[0] == 3);
+	CHECK(slice3[1] == 4);
 
-	Vector<int> subarray4 = vector.subarray(-3, 3);
-	CHECK(subarray4.size() == 2);
-	CHECK(subarray4[0] == 2);
-	CHECK(subarray4[1] == 3);
+	Vector<int> slice4 = vector.slice(2, -2);
+	CHECK(slice4.size() == 2);
+	CHECK(slice4[0] == 2);
+	CHECK(slice4[1] == 3);
 }
 
 TEST_CASE("[Vector] Find, has") {

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -246,6 +246,37 @@ TEST_CASE("[Array] max() and min()") {
 	CHECK(min == 2);
 }
 
+TEST_CASE("[Array] slice()") {
+	Array array;
+	array.push_back(0);
+	array.push_back(1);
+	array.push_back(2);
+	array.push_back(3);
+	array.push_back(4);
+
+	Array slice1 = array.slice(1, 3);
+	CHECK(slice1.size() == 2);
+	CHECK(slice1[0] == Variant(1));
+	CHECK(slice1[1] == Variant(2));
+
+	Array slice2 = array.slice(1, -1);
+	CHECK(slice2.size() == 4);
+	CHECK(slice2[0] == Variant(1));
+	CHECK(slice2[1] == Variant(2));
+	CHECK(slice2[2] == Variant(3));
+	CHECK(slice2[3] == Variant(4));
+
+	Array slice3 = array.slice(3, -1);
+	CHECK(slice3.size() == 2);
+	CHECK(slice3[0] == Variant(3));
+	CHECK(slice3[1] == Variant(4));
+
+	Array slice4 = array.slice(2, -2);
+	CHECK(slice4.size() == 2);
+	CHECK(slice4[0] == Variant(2));
+	CHECK(slice4[1] == Variant(3));
+}
+
 TEST_CASE("[Array] Duplicate array") {
 	// a = [1, [2, 2], {3: 3}]
 	Array a = build_array(1, build_array(2, 2), build_dictionary(3, 3));


### PR DESCRIPTION
- `slice` end index is now exclusive 
- `Packed*Array::subarray` is now `Packed*Array::slice`

```swift
func _ready() -> void:
	var array := PackedByteArray([0, 1, 2, 3, 4, 5, 6, 7])
	
	aprint(array.slice(0, 4))             ### 0, 1, 2, 3
	# Lines below would have crashed
	aprint(array.slice(4, 8))             ### 4, 5, 6, 7
	aprint(array.slice(0, array.size()))   ### 0, 1, 2, 3, 4, 5, 6, 7

func aprint(array: PackedByteArray) -> void:
	var s := String()
	for i in array:
		s += ", " + str(i)
	print(s.substr(2))
```