### PR TITLE
Pass missing args in AnimationNode script calls

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -49,7 +49,7 @@ void AnimationNode::get_parameter_list(List<PropertyInfo> *r_list) const {
 
 Variant AnimationNode::get_parameter_default_value(const StringName &p_parameter) const {
 	if (get_script_instance()) {
-		return get_script_instance()->call("get_parameter_default_value");
+		return get_script_instance()->call("get_parameter_default_value", p_parameter);
 	}
 	return Variant();
 }
@@ -397,7 +397,7 @@ void AnimationNode::_validate_property(PropertyInfo &property) const {
 
 Ref<AnimationNode> AnimationNode::get_child_by_name(const StringName &p_name) {
 	if (get_script_instance()) {
-		return get_script_instance()->call("get_child_by_name");
+		return get_script_instance()->call("get_child_by_name", p_name);
 	}
 	return Ref<AnimationNode>();
 }


### PR DESCRIPTION
found in c4daac279b8ec6f4893056ba6717624f701ab970 mono custom build

EDIT3: for the record: later GetParameter was returning nulls because those parameters where serialized in the tscn as nulls

I was translating an old AnimationNode from GDScript to C#,
GetParameter returned null for all parameters:
The default value wasn't getting set:
GetParameterDefaultValue was never getting called:
Its variant call resulted with 0 parameters so GDMonoClass::get_method couldnt find the correct method_bind

It worked in GDScript likely for the implicit conversions.
