### PR TITLE
Fix empty audio infinite loop

### DIFF
--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -57,7 +57,7 @@ void AudioStreamPlaybackOGGVorbis::_mix_internal(AudioFrame *p_buffer, int p_fra
 
 		if (todo) {
 			//end of file!
-			if (vorbis_stream->loop) {
+			if (vorbis_stream->loop && mixed > 0) {
 				//loop
 				seek(vorbis_stream->loop_offset);
 				loops++;


### PR DESCRIPTION
Fixes #35907, entering an infinite loop trying to read a looping audio of length zero.