### PR TITLE
Fix incorrect size calculation of GDNative godot_variant for android armv7

### DIFF
--- a/core/variant.h
+++ b/core/variant.h
@@ -65,13 +65,6 @@ typedef PoolVector<Vector2> PoolVector2Array;
 typedef PoolVector<Vector3> PoolVector3Array;
 typedef PoolVector<Color> PoolColorArray;
 
-// Temporary workaround until c++11 alignas()
-#ifdef __GNUC__
-#define GCC_ALIGNED_8 __attribute__((aligned(8)))
-#else
-#define GCC_ALIGNED_8
-#endif
-
 class Variant {
 public:
 	// If this changes the table in variant_op must be updated
@@ -123,8 +116,6 @@ private:
 	// Variant takes 20 bytes when real_t is float, and 36 if double
 	// it only allocates extra memory for aabb/matrix.
 
-	Type type;
-
 	struct ObjData {
 
 		Object *obj;
@@ -144,7 +135,9 @@ private:
 		Transform *_transform;
 		void *_ptr; //generic pointer
 		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)];
-	} _data GCC_ALIGNED_8;
+	} _data;
+
+	Type type;
 
 	void reference(const Variant &p_variant);
 	void clear();

--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -38,6 +38,32 @@
 
 #include "scene/main/scene_tree.h"
 
+typedef int godot_variant_size_check[sizeof(godot_variant) == sizeof(Variant) ? 1 : -1];
+typedef int godot_string_size_check[sizeof(godot_string) == sizeof(String) ? 1 : -1];
+typedef int godot_string_name_size_check[sizeof(godot_string_name) == sizeof(StringName) ? 1 : -1];
+typedef int godot_vector2_size_check[sizeof(godot_vector2) == sizeof(Vector2) ? 1 : -1];
+typedef int godot_rect2_size_check[sizeof(godot_rect2) == sizeof(Rect2) ? 1 : -1];
+typedef int godot_vector3_size_check[sizeof(godot_vector3) == sizeof(Vector3) ? 1 : -1];
+typedef int godot_transform2d_size_check[sizeof(godot_transform2d) == sizeof(Transform2D) ? 1 : -1];
+typedef int godot_plane_size_check[sizeof(godot_plane) == sizeof(Plane) ? 1 : -1];
+typedef int godot_quat_size_check[sizeof(godot_quat) == sizeof(Quat) ? 1 : -1];
+typedef int godot_aabb_size_check[sizeof(godot_aabb) == sizeof(AABB) ? 1 : -1];
+typedef int godot_basis_size_check[sizeof(godot_basis) == sizeof(Basis) ? 1 : -1];
+typedef int godot_transform_size_check[sizeof(godot_transform) == sizeof(Transform) ? 1 : -1];
+typedef int godot_transform2d_size_check[sizeof(godot_transform2d) == sizeof(Transform2D) ? 1 : -1];
+typedef int godot_color_size_check[sizeof(godot_color) == sizeof(Color) ? 1 : -1];
+typedef int godot_node_path_size_check[sizeof(godot_node_path) == sizeof(NodePath) ? 1 : -1];
+typedef int godot_rid_size_check[sizeof(godot_rid) == sizeof(RID) ? 1 : -1];
+typedef int godot_dictionary_size_check[sizeof(godot_dictionary) == sizeof(Dictionary) ? 1 : -1];
+typedef int godot_array_size_check[sizeof(godot_array) == sizeof(Array) ? 1 : -1];
+typedef int godot_pool_byte_array_size_check[sizeof(godot_pool_byte_array) == sizeof(PoolByteArray) ? 1 : -1];
+typedef int godot_pool_int_array_size_check[sizeof(godot_pool_int_array) == sizeof(PoolIntArray) ? 1 : -1];
+typedef int godot_pool_real_array_size_check[sizeof(godot_pool_real_array) == sizeof(PoolRealArray) ? 1 : -1];
+typedef int godot_pool_string_array_size_check[sizeof(godot_pool_string_array) == sizeof(PoolStringArray) ? 1 : -1];
+typedef int godot_pool_vector2_array_size_check[sizeof(godot_pool_vector2_array) == sizeof(PoolVector2Array) ? 1 : -1];
+typedef int godot_pool_vector3_array_size_check[sizeof(godot_pool_vector3_array) == sizeof(PoolVector3Array) ? 1 : -1];
+typedef int godot_pool_color_array_size_check[sizeof(godot_pool_color_array) == sizeof(PoolColorArray) ? 1 : -1];
+
 static const String init_symbol = "gdnative_init";
 static const String terminate_symbol = "gdnative_terminate";
 static const String default_symbol_prefix = "godot_";

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -37,12 +37,11 @@ extern "C" {
 
 #include <stdint.h>
 
-#define GODOT_VARIANT_SIZE (16 + sizeof(void *))
-
 #ifndef GODOT_CORE_API_GODOT_VARIANT_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_VARIANT_TYPE_DEFINED
 typedef struct {
-	uint8_t _dont_touch_that[GODOT_VARIANT_SIZE];
+	int64_t _dont_touch_that[2]; // uses workaround to correct calculate sizeof(Variant) for armv7 with memory aligment to 8 bytes
+	int type;
 } godot_variant;
 #endif
 


### PR DESCRIPTION
I found that `Variant` type for android armv7 has size = `24` bytes, but GDNative godot_variant has `20` bytes
The reason is that compiler auto align memory for largest member size, in case of `Variant` it is `int64_t`
I have fixed `godot_variant` declaration to be similar as `Variant` and added compile-time size check guards for GDNative types