### PR TITLE
Fixed Gradient.remove_point not allowing fewer than two points.

### DIFF
--- a/scene/resources/gradient.cpp
+++ b/scene/resources/gradient.cpp
@@ -131,7 +131,7 @@ void Gradient::add_point(float p_offset, const Color &p_color) {
 void Gradient::remove_point(int p_index) {
 
 	ERR_FAIL_INDEX(p_index, points.size());
-	ERR_FAIL_COND(points.size() <= 2);
+	ERR_FAIL_COND(points.size() <= 1);
 	points.remove(p_index);
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }


### PR DESCRIPTION
This PR addresses #35863. This may be a bug since the editor allows setting gradient texture to have only one point, but remove_point() does not. 

*Bugsquad edit:* Fixes #35863