### PR TITLE
Add polygon boolean methods operating on multiple paths

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1646,6 +1646,42 @@ Vector<Vector3> _Geometry::clip_polygon(const Vector<Vector3> &p_points, const P
 	return Geometry::clip_polygon(p_points, p_plane);
 }
 
+Array _Geometry::polygons_boolean_2d(PolyBooleanOperation p_operation, Array p_polygons_a, Array p_polygons_b) {
+	Vector<Vector<Point2> > polygons_a;
+	for (int i = 0; i < p_polygons_a.size(); i++) {
+		polygons_a.push_back(p_polygons_a[i]);
+	}
+	Vector<Vector<Point2> > polygons_b;
+	for (int i = 0; i < p_polygons_b.size(); i++) {
+		polygons_b.push_back(p_polygons_b[i]);
+	}
+	Vector<Vector<Point2> > solution = Geometry::polygons_boolean_2d(Geometry::PolyBooleanOperation(p_operation), polygons_a, polygons_b);
+
+	Array ret;
+	for (int i = 0; i < solution.size(); i++) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
+Array _Geometry::polylines_boolean_2d(PolyBooleanOperation p_operation, Array p_polylines, Array p_polygons) {
+	Vector<Vector<Point2> > polylines;
+	for (int i = 0; i < p_polylines.size(); i++) {
+		polylines.push_back(p_polylines[i]);
+	}
+	Vector<Vector<Point2> > polygons;
+	for (int i = 0; i < p_polygons.size(); i++) {
+		polygons.push_back(p_polygons[i]);
+	}
+	Vector<Vector<Point2> > solution = Geometry::polylines_boolean_2d(Geometry::PolyBooleanOperation(p_operation), polylines, polygons);
+
+	Array ret;
+	for (int i = 0; i < solution.size(); i++) {
+		ret.push_back(solution[i]);
+	}
+	return ret;
+}
+
 Array _Geometry::merge_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
 
 	Vector<Vector<Point2> > polys = Geometry::merge_polygons_2d(p_polygon_a, p_polygon_b);
@@ -1814,9 +1850,11 @@ void _Geometry::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clip_polygons_2d", "polygon_a", "polygon_b"), &_Geometry::clip_polygons_2d);
 	ClassDB::bind_method(D_METHOD("intersect_polygons_2d", "polygon_a", "polygon_b"), &_Geometry::intersect_polygons_2d);
 	ClassDB::bind_method(D_METHOD("exclude_polygons_2d", "polygon_a", "polygon_b"), &_Geometry::exclude_polygons_2d);
+	ClassDB::bind_method(D_METHOD("polygons_boolean_2d", "operation", "polygons_a", "polygons_b"), &_Geometry::polygons_boolean_2d, DEFVAL(Variant()));
 
 	ClassDB::bind_method(D_METHOD("clip_polyline_with_polygon_2d", "polyline", "polygon"), &_Geometry::clip_polyline_with_polygon_2d);
 	ClassDB::bind_method(D_METHOD("intersect_polyline_with_polygon_2d", "polyline", "polygon"), &_Geometry::intersect_polyline_with_polygon_2d);
+	ClassDB::bind_method(D_METHOD("polylines_boolean_2d", "operation", "polylines", "polygons"), &_Geometry::polylines_boolean_2d);
 
 	ClassDB::bind_method(D_METHOD("offset_polygon_2d", "polygon", "delta", "join_type"), &_Geometry::offset_polygon_2d, DEFVAL(JOIN_SQUARE));
 	ClassDB::bind_method(D_METHOD("offset_polyline_2d", "polyline", "delta", "join_type", "end_type"), &_Geometry::offset_polyline_2d, DEFVAL(JOIN_SQUARE), DEFVAL(END_SQUARE));

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -422,10 +422,14 @@ public:
 	Array clip_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b); // Difference (subtract).
 	Array intersect_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b); // Common area (multiply).
 	Array exclude_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b); // All but common area (xor).
+	// All of the above, but accepts lists of polygons.
+	Array polygons_boolean_2d(PolyBooleanOperation p_operation, Array p_polygons_a, Array p_polygons_b = Variant());
 
 	// 2D polyline vs polygon operations.
 	Array clip_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon); // Cut.
 	Array intersect_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon); // Chop.
+	// All of the above, but accepts lists of polypaths.
+	Array polylines_boolean_2d(PolyBooleanOperation p_operation, Array p_polylines_a, Array p_polygons_b);
 
 	// 2D offset polygons/polylines.
 	enum PolyJoinType {

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -790,45 +790,68 @@ public:
 		END_ROUND
 	};
 
-	static Vector<Vector<Point2> > merge_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
+	static Vector<Vector<Point2> > polygons_boolean_2d(PolyBooleanOperation p_op, const Vector<Vector<Point2> > &p_polygons_a, const Vector<Vector<Point2> > &p_polygons_b = Vector<Vector<Point2> >()) {
+		return _polypaths_do_operation(p_op, p_polygons_a, p_polygons_b);
+	}
 
-		return _polypaths_do_operation(OPERATION_UNION, p_polygon_a, p_polygon_b);
+	static Vector<Vector<Point2> > polylines_boolean_2d(PolyBooleanOperation p_op, const Vector<Vector<Point2> > &p_polylines, const Vector<Vector<Point2> > &p_polygons) {
+		return _polypaths_do_operation(p_op, p_polylines, p_polygons, true);
+	}
+
+	static Vector<Vector<Point2> > merge_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
+		Vector<Vector<Point2> > subject;
+		subject.push_back(p_polygon_a);
+		Vector<Vector<Point2> > clip;
+		clip.push_back(p_polygon_b);
+		return _polypaths_do_operation(OPERATION_UNION, subject, clip);
 	}
 
 	static Vector<Vector<Point2> > clip_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
-
-		return _polypaths_do_operation(OPERATION_DIFFERENCE, p_polygon_a, p_polygon_b);
+		Vector<Vector<Point2> > subject;
+		subject.push_back(p_polygon_a);
+		Vector<Vector<Point2> > clip;
+		clip.push_back(p_polygon_b);
+		return _polypaths_do_operation(OPERATION_DIFFERENCE, subject, clip);
 	}
 
 	static Vector<Vector<Point2> > intersect_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
-
-		return _polypaths_do_operation(OPERATION_INTERSECTION, p_polygon_a, p_polygon_b);
+		Vector<Vector<Point2> > subject;
+		subject.push_back(p_polygon_a);
+		Vector<Vector<Point2> > clip;
+		clip.push_back(p_polygon_b);
+		return _polypaths_do_operation(OPERATION_INTERSECTION, subject, clip);
 	}
 
 	static Vector<Vector<Point2> > exclude_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
-
-		return _polypaths_do_operation(OPERATION_XOR, p_polygon_a, p_polygon_b);
+		Vector<Vector<Point2> > subject;
+		subject.push_back(p_polygon_a);
+		Vector<Vector<Point2> > clip;
+		clip.push_back(p_polygon_b);
+		return _polypaths_do_operation(OPERATION_XOR, subject, clip);
 	}
 
 	static Vector<Vector<Point2> > clip_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
-
-		return _polypaths_do_operation(OPERATION_DIFFERENCE, p_polyline, p_polygon, true);
+		Vector<Vector<Point2> > subject;
+		subject.push_back(p_polyline);
+		Vector<Vector<Point2> > clip;
+		clip.push_back(p_polygon);
+		return _polypaths_do_operation(OPERATION_DIFFERENCE, subject, clip, true);
 	}
 
 	static Vector<Vector<Point2> > intersect_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
-
-		return _polypaths_do_operation(OPERATION_INTERSECTION, p_polyline, p_polygon, true);
+		Vector<Vector<Point2> > subject;
+		subject.push_back(p_polyline);
+		Vector<Vector<Point2> > clip;
+		clip.push_back(p_polygon);
+		return _polypaths_do_operation(OPERATION_INTERSECTION, subject, clip, true);
 	}
 
 	static Vector<Vector<Point2> > offset_polygon_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type) {
-
 		return _polypath_offset(p_polygon, p_delta, p_join_type, END_POLYGON);
 	}
 
 	static Vector<Vector<Point2> > offset_polyline_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
-
 		ERR_FAIL_COND_V_MSG(p_end_type == END_POLYGON, Vector<Vector<Point2> >(), "Attempt to offset a polyline like a polygon (use offset_polygon_2d instead).");
-
 		return _polypath_offset(p_polygon, p_delta, p_join_type, p_end_type);
 	}
 
@@ -1015,7 +1038,7 @@ public:
 	static void make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_result, Size2i &r_size);
 
 private:
-	static Vector<Vector<Point2> > _polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Point2> &p_polypath_a, const Vector<Point2> &p_polypath_b, bool is_a_open = false);
+	static Vector<Vector<Point2> > _polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Vector<Point2> > &p_polypaths_a, const Vector<Vector<Point2> > &p_polypaths_b, bool is_a_open = false);
 	static Vector<Vector<Point2> > _polypath_offset(const Vector<Point2> &p_polypath, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type);
 };
 


### PR DESCRIPTION
Supersedes #29881.
Closes #29784.

Two methods were added to unify all polypaths operations:
* polygons_boolean_2d
* polylines_boolean_2d

Compared to existing methods which act per operation (merge_polygons/clip_polygons etc), these can be used as general-purpose methods. These accept `PolyBooleanOperation` and a list of both subject and clip polygons/polylines. Compared to #29881 implementation, this doesn't do any hacks with Variants, and requires less code changes, and makes the documentation much clear.

To reiterate, the PR's implementation was inspired by #35676 from which we see that passing single polygons is not enough, as all these boolean methods may return multiple polygons comprising both from outer and inner polygons which basically can describe any type of 2D object geometrically, so being able to pass a list of polygons is required in such cases. Also see my next PR which can make use of this later on: #35706.

I think it's reasonable to keep dedicated methods per operation (merge_polygons/clip_polygons etc) because they are much easier to find in the documentation and are more or less intuitive to use.

A fairly common request I've noticed is being able to simply merge a list of polygons, so this can be achieved like this now (CC @torshid, https://github.com/godotengine/godot/pull/29881#issuecomment-526926079):
```gdscript
var polygons = [] # PoolVector2Array's
var solution = Geometry.polygons_boolean_2d(Geometry.OPERATION_UNION, polygons) # third argument is optional for UNION
```
and any other type of operation of course. This is where `PolyBooleanOperation` actually becomes useful.

### Test project
[geometry-clipper-array.zip](https://github.com/godotengine/godot/files/4160386/geometry-clipper-array.zip)

