### PR TITLE
Added const input ports support for visual shaders

### DIFF
--- a/doc/classes/VisualShaderNode.xml
+++ b/doc/classes/VisualShaderNode.xml
@@ -15,6 +15,15 @@
 				Returns an [Array] containing default values for all of the input ports of the node in the form [code][index0, value0, index1, value1, ...][/code].
 			</description>
 		</method>
+		<method name="get_input_port_constness" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="port" type="int">
+			</argument>
+			<description>
+				Returns the constness of input [code]port[/code] (see [method set_input_port_constness]).
+			</description>
+		</method>
 		<method name="get_input_port_default_value" qualifiers="const">
 			<return type="Variant">
 			</return>
@@ -31,6 +40,17 @@
 			</argument>
 			<description>
 				Sets the default input ports values using an [Array] of the form [code][index0, value0, index1, value1, ...][/code]. For example: [code][0, Vector3(0, 0, 0), 1, Vector3(0, 0, 0)][/code].
+			</description>
+		</method>
+		<method name="set_input_port_constness">
+			<return type="void">
+			</return>
+			<argument index="0" name="port" type="int">
+			</argument>
+			<argument index="1" name="enabled" type="bool" default="true">
+			</argument>
+			<description>
+				Disables input port from incoming connections while keeping it changeable for user through input field in the node. In order to show that field the method [method set_input_port_default_value] should be used.
 			</description>
 		</method>
 		<method name="set_input_port_default_value">

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -648,9 +648,11 @@ void VisualShaderEditor::_update_graph() {
 			hb->add_constant_override("separation", 7 * EDSCALE);
 
 			Variant default_value;
+			bool is_const = false;
 
 			if (valid_left && !port_left_used) {
 				default_value = vsnode->get_input_port_default_value(i);
+				is_const = vsnode->get_input_port_constness(i);
 			}
 
 			if (default_value.get_type() != Variant::NIL) { // only a label
@@ -792,7 +794,7 @@ void VisualShaderEditor::_update_graph() {
 
 			node->add_child(hb);
 
-			node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], valid_right, port_right, type_color[port_right]);
+			node->set_slot(i + port_offset, valid_left && !is_const, port_left, type_color[port_left], valid_right, port_right, type_color[port_right]);
 		}
 
 		if (vsnode->get_output_port_for_preview() >= 0) {

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -103,6 +103,19 @@ void VisualShaderNode::set_default_input_values(const Array &p_values) {
 	emit_changed();
 }
 
+void VisualShaderNode::set_input_port_constness(int p_port, bool p_enabled) {
+	port_const_values[p_port] = p_enabled;
+	emit_changed();
+}
+
+bool VisualShaderNode::get_input_port_constness(int p_port) const {
+	if (port_const_values.has(p_port)) {
+		return port_const_values[p_port];
+	}
+
+	return false;
+}
+
 String VisualShaderNode::get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const {
 	return String();
 }
@@ -115,6 +128,9 @@ void VisualShaderNode::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_output_port_for_preview", "port"), &VisualShaderNode::set_output_port_for_preview);
 	ClassDB::bind_method(D_METHOD("get_output_port_for_preview"), &VisualShaderNode::get_output_port_for_preview);
+
+	ClassDB::bind_method(D_METHOD("set_input_port_constness", "port", "enabled"), &VisualShaderNode::set_input_port_constness, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("get_input_port_constness", "port"), &VisualShaderNode::get_input_port_constness);
 
 	ClassDB::bind_method(D_METHOD("set_input_port_default_value", "port", "value"), &VisualShaderNode::set_input_port_default_value);
 	ClassDB::bind_method(D_METHOD("get_input_port_default_value", "port"), &VisualShaderNode::get_input_port_default_value);
@@ -1085,6 +1101,11 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 	String *inputs = input_vars.ptrw();
 
 	for (int i = 0; i < input_count; i++) {
+
+		if (vsnode->get_input_port_constness(i)) {
+			continue;
+		}
+
 		ConnectionKey ck;
 		ck.node = node;
 		ck.port = i;

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -174,6 +174,7 @@ class VisualShaderNode : public Resource {
 	int port_preview;
 
 	Map<int, Variant> default_input_values;
+	Map<int, bool> port_const_values;
 
 protected:
 	bool simple_decl;
@@ -201,6 +202,9 @@ public:
 	Variant get_input_port_default_value(int p_port) const; // if NIL (default if node does not set anything) is returned, it means no default value is wanted if disconnected, thus no input var must be supplied (empty string will be supplied)
 	Array get_default_input_values() const;
 	void set_default_input_values(const Array &p_values);
+
+	void set_input_port_constness(int p_port, bool p_enabled = true);
+	bool get_input_port_constness(int p_port) const;
 
 	virtual int get_output_port_count() const = 0;
 	virtual PortType get_output_port_type(int p_port) const = 0;

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -3764,7 +3764,11 @@ String VisualShaderNodeFresnel::generate_code(Shader::Mode p_mode, VisualShader:
 		view = p_input_vars[1];
 	}
 
-	return "\t" + p_output_vars[0] + " = " + p_input_vars[2] + " ? (pow(clamp(dot(" + normal + ", " + view + "), 0.0, 1.0), " + p_input_vars[3] + ")) : (pow(1.0 - clamp(dot(" + normal + ", " + view + "), 0.0, 1.0), " + p_input_vars[3] + "));\n";
+	if (get_input_port_default_value(2)) {
+		return "\t" + p_output_vars[0] + " = pow(clamp(dot(" + normal + ", " + view + "), 0.0, 1.0), " + p_input_vars[3] + ");\n";
+	} else {
+		return "\t" + p_output_vars[0] + " = pow(1.0 - clamp(dot(" + normal + ", " + view + "), 0.0, 1.0), " + p_input_vars[3] + ");\n";
+	}
 }
 
 String VisualShaderNodeFresnel::get_input_port_default_hint(int p_port) const {
@@ -3777,6 +3781,7 @@ String VisualShaderNodeFresnel::get_input_port_default_hint(int p_port) const {
 }
 
 VisualShaderNodeFresnel::VisualShaderNodeFresnel() {
+	set_input_port_constness(2);
 	set_input_port_default_value(2, false);
 	set_input_port_default_value(3, 1.0);
 }


### PR DESCRIPTION
Adds a "constness" ports, which act as a node parameter without port, I think its a good change that should increases performance for Fresnel node by removing a direct condition for "invert" from code generation.

Its a small compatibility breakage but I think its worth to do it.

![fresnel](https://user-images.githubusercontent.com/3036176/73916999-96950480-48cf-11ea-99e0-12a6403305cf.gif)
