### PR TITLE
Implemented hint_range for VisualShaderNodeScalarUniform

### DIFF
--- a/doc/classes/VisualShaderNodeScalarUniform.xml
+++ b/doc/classes/VisualShaderNodeScalarUniform.xml
@@ -1,13 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeScalarUniform" inherits="VisualShaderNodeUniform" version="4.0">
 	<brief_description>
+		A scalar uniform to be used within the visual shader graph.
 	</brief_description>
 	<description>
+		Translated to [code]uniform float[/code] in the shader language.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 	</methods>
+	<members>
+		<member name="hint" type="int" setter="set_hint" getter="get_hint" enum="VisualShaderNodeScalarUniform.Hint" default="0">
+			A hint applied to the uniform, which controls the values it can take when set through the inspector.
+		</member>
+		<member name="max" type="float" setter="set_max" getter="get_max" default="1.0">
+			Minimum value for range hints. Used if [member hint] is set to [constant HINT_RANGE] or [constant HINT_RANGE_STEP].
+		</member>
+		<member name="min" type="float" setter="set_min" getter="get_min" default="0.0">
+			Maximum value for range hints. Used if [member hint] is set to [constant HINT_RANGE] or [constant HINT_RANGE_STEP].
+		</member>
+		<member name="step" type="float" setter="set_step" getter="get_step" default="0.1">
+			Step (increment) value for the range hint with step. Used if [member hint] is set to [constant HINT_RANGE_STEP].
+		</member>
+	</members>
 	<constants>
+		<constant name="HINT_NONE" value="0" enum="Hint">
+			No hint used.
+		</constant>
+		<constant name="HINT_RANGE" value="1" enum="Hint">
+			A range hint for scalar value, which limits possible input values between [member min] and [member max]. Translated to [code]hint_range(min, max)[/code] in shader code.
+		</constant>
+		<constant name="HINT_RANGE_STEP" value="2" enum="Hint">
+			A range hint for scalar value with step, which limits possible input values between [member min] and [member max], with a step (increment) of [member step]). Translated to [code]hint_range(min, max, step)[/code] in shader code.
+		</constant>
 	</constants>
 </class>

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -3039,6 +3039,11 @@ String VisualShaderNodeScalarUniform::get_output_port_name(int p_port) const {
 }
 
 String VisualShaderNodeScalarUniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
+	if (hint == HINT_RANGE) {
+		return "uniform float " + get_uniform_name() + " : hint_range(" + rtos(hint_range_min) + ", " + rtos(hint_range_max) + ");\n";
+	} else if (hint == HINT_RANGE_STEP) {
+		return "uniform float " + get_uniform_name() + " : hint_range(" + rtos(hint_range_min) + ", " + rtos(hint_range_max) + ", " + rtos(hint_range_step) + ");\n";
+	}
 	return "uniform float " + get_uniform_name() + ";\n";
 }
 
@@ -3046,7 +3051,83 @@ String VisualShaderNodeScalarUniform::generate_code(Shader::Mode p_mode, VisualS
 	return "\t" + p_output_vars[0] + " = " + get_uniform_name() + ";\n";
 }
 
+void VisualShaderNodeScalarUniform::set_hint(Hint p_hint) {
+	hint = p_hint;
+	emit_changed();
+}
+
+VisualShaderNodeScalarUniform::Hint VisualShaderNodeScalarUniform::get_hint() const {
+	return hint;
+}
+
+void VisualShaderNodeScalarUniform::set_min(float p_value) {
+	hint_range_min = p_value;
+	emit_changed();
+}
+
+float VisualShaderNodeScalarUniform::get_min() const {
+	return hint_range_min;
+}
+
+void VisualShaderNodeScalarUniform::set_max(float p_value) {
+	hint_range_max = p_value;
+	emit_changed();
+}
+
+float VisualShaderNodeScalarUniform::get_max() const {
+	return hint_range_max;
+}
+
+void VisualShaderNodeScalarUniform::set_step(float p_value) {
+	hint_range_step = p_value;
+	emit_changed();
+}
+
+float VisualShaderNodeScalarUniform::get_step() const {
+	return hint_range_step;
+}
+
+void VisualShaderNodeScalarUniform::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_hint", "hint"), &VisualShaderNodeScalarUniform::set_hint);
+	ClassDB::bind_method(D_METHOD("get_hint"), &VisualShaderNodeScalarUniform::get_hint);
+
+	ClassDB::bind_method(D_METHOD("set_min", "value"), &VisualShaderNodeScalarUniform::set_min);
+	ClassDB::bind_method(D_METHOD("get_min"), &VisualShaderNodeScalarUniform::get_min);
+
+	ClassDB::bind_method(D_METHOD("set_max", "value"), &VisualShaderNodeScalarUniform::set_max);
+	ClassDB::bind_method(D_METHOD("get_max"), &VisualShaderNodeScalarUniform::get_max);
+
+	ClassDB::bind_method(D_METHOD("set_step", "value"), &VisualShaderNodeScalarUniform::set_step);
+	ClassDB::bind_method(D_METHOD("get_step"), &VisualShaderNodeScalarUniform::get_step);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "hint", PROPERTY_HINT_ENUM, "None,Range,Range+Step"), "set_hint", "get_hint");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "min"), "set_min", "get_min");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "max"), "set_max", "get_max");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "step"), "set_step", "get_step");
+
+	BIND_ENUM_CONSTANT(HINT_NONE);
+	BIND_ENUM_CONSTANT(HINT_RANGE);
+	BIND_ENUM_CONSTANT(HINT_RANGE_STEP);
+}
+
+Vector<StringName> VisualShaderNodeScalarUniform::get_editable_properties() const {
+	Vector<StringName> props;
+	props.push_back("hint");
+	if (hint == HINT_RANGE || hint == HINT_RANGE_STEP) {
+		props.push_back("min");
+		props.push_back("max");
+	}
+	if (hint == HINT_RANGE_STEP) {
+		props.push_back("step");
+	}
+	return props;
+}
+
 VisualShaderNodeScalarUniform::VisualShaderNodeScalarUniform() {
+	hint = HINT_NONE;
+	hint_range_min = 0.0;
+	hint_range_max = 1.0;
+	hint_range_step = 0.1;
 }
 
 ////////////// Boolean Uniform

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -1301,6 +1301,22 @@ class VisualShaderNodeScalarUniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeScalarUniform, VisualShaderNodeUniform);
 
 public:
+	enum Hint {
+		HINT_NONE,
+		HINT_RANGE,
+		HINT_RANGE_STEP,
+	};
+
+private:
+	Hint hint;
+	float hint_range_min;
+	float hint_range_max;
+	float hint_range_step;
+
+protected:
+	static void _bind_methods();
+
+public:
 	virtual String get_caption() const;
 
 	virtual int get_input_port_count() const;
@@ -1314,8 +1330,24 @@ public:
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
 
+	void set_hint(Hint p_hint);
+	Hint get_hint() const;
+
+	void set_min(float p_value);
+	float get_min() const;
+
+	void set_max(float p_value);
+	float get_max() const;
+
+	void set_step(float p_value);
+	float get_step() const;
+
+	virtual Vector<StringName> get_editable_properties() const;
+
 	VisualShaderNodeScalarUniform();
 };
+
+VARIANT_ENUM_CAST(VisualShaderNodeScalarUniform::Hint)
 
 ///////////////////////////////////////
 


### PR DESCRIPTION
Added missing capability to define hint_range like:

![hint_range](https://user-images.githubusercontent.com/3036176/73936103-1e403a80-48f3-11ea-9dd5-305de9450e9f.gif)
