### PR TITLE
Ignore empty 2D collision polygons

### DIFF
--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -759,6 +759,9 @@ void VisualServerCanvas::canvas_item_add_polygon(RID p_item, const Vector<Point2
 	ERR_FAIL_COND(!canvas_item);
 #ifdef DEBUG_ENABLED
 	int pointcount = p_points.size();
+	if (pointcount == 0) {
+		return;
+	}
 	ERR_FAIL_COND(pointcount < 3);
 	int color_size = p_colors.size();
 	int uv_size = p_uvs.size();


### PR DESCRIPTION
Whenever you create a new CollisionPolygon2D node, you get this error in the console:
```
 servers\visual\visual_server_canvas.cpp:762 - Condition "pointcount < 3" is true.
```
This is somewhat expected, because the polygon is empty, but the error is useless in this case and only spams the console. Then I thought that it's pretty obvious that you can't create a polygon from zero points (bruh), so it makes sense to just do nothing when this happens. The old error is still thrown when there's only 1 or 2 points.

Well, this is arguable change, but makes sense IMO. (not sure if 0 check shouldn't be before #ifdef tho)
Also probably resolves #19558