### PR TITLE
Highlight the error column in the script editor

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -614,7 +614,7 @@
 		<theme_item name="line_spacing" type="int" default="4">
 			Sets the spacing between the lines.
 		</theme_item>
-		<theme_item name="mark_color" type="Color" default="Color( 1, 0.4, 0.4, 0.4 )">
+		<theme_item name="mark_color" type="Color" default="Color( 1, 0.4, 0.4, 0.15 )">
 			Sets the [Color] of marked text.
 		</theme_item>
 		<theme_item name="member_variable_color" type="Color" default="Color( 0.9, 0.31, 0.35, 1 )">

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -688,7 +688,7 @@ void EditorSettings::_load_default_text_editor_theme() {
 	_initial_set("text_editor/highlighting/number_color", Color(0.92, 0.58, 0.2));
 	_initial_set("text_editor/highlighting/function_color", Color(0.4, 0.64, 0.81));
 	_initial_set("text_editor/highlighting/member_variable_color", Color(0.9, 0.31, 0.35));
-	_initial_set("text_editor/highlighting/mark_color", Color(1.0, 0.4, 0.4, 0.4));
+	_initial_set("text_editor/highlighting/mark_color", Color(1.0, 0.4, 0.4, 0.15));
 	_initial_set("text_editor/highlighting/bookmark_color", Color(0.08, 0.49, 0.98));
 	_initial_set("text_editor/highlighting/breakpoint_color", Color(0.8, 0.8, 0.4, 0.2));
 	_initial_set("text_editor/highlighting/executing_line_color", Color(0.2, 0.8, 0.2, 0.4));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1176,7 +1176,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color number_color = basetype_color.linear_interpolate(mono_color, dark_theme ? 0.5 : 0.3);
 	const Color function_color = main_color;
 	const Color member_variable_color = main_color.linear_interpolate(mono_color, 0.6);
-	const Color mark_color = Color(error_color.r, error_color.g, error_color.b, 0.3);
+	const Color mark_color = Color(error_color.r, error_color.g, error_color.b, 0.15);
 	const Color bookmark_color = Color(0.08, 0.49, 0.98);
 	const Color breakpoint_color = error_color;
 	const Color executing_line_color = Color(0.2, 0.8, 0.2, 0.4);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -653,7 +653,8 @@ void ScriptTextEditor::_validate_script() {
 	bool highlight_safe = EDITOR_DEF("text_editor/highlighting/highlight_type_safe_lines", true);
 	bool last_is_safe = false;
 	for (int i = 0; i < te->get_line_count(); i++) {
-		te->set_line_as_marked(i, line == i);
+		// Setting the mark position to `0` makes the line non-marked (as it is by default).
+		te->set_line_mark_position(i, line == i ? col : 0);
 		if (highlight_safe) {
 			if (safe_lines.has(i + 1)) {
 				te->set_line_as_safe(i, true);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -221,12 +221,12 @@ void ShaderTextEditor::_validate_script() {
 		set_error(error_text);
 		set_error_pos(sl.get_error_line() - 1, 0);
 		for (int i = 0; i < get_text_edit()->get_line_count(); i++)
-			get_text_edit()->set_line_as_marked(i, false);
-		get_text_edit()->set_line_as_marked(sl.get_error_line() - 1, true);
+			get_text_edit()->set_line_mark_position(i, false);
+		get_text_edit()->set_line_mark_position(sl.get_error_line() - 1, true);
 
 	} else {
 		for (int i = 0; i < get_text_edit()->get_line_count(); i++)
-			get_text_edit()->set_line_as_marked(i, false);
+			get_text_edit()->set_line_mark_position(i, false);
 		set_error("");
 	}
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2203,10 +2203,10 @@ void VisualShaderEditor::_update_preview() {
 	Error err = sl.compile(code, ShaderTypes::get_singleton()->get_functions(VisualServer::ShaderMode(visual_shader->get_mode())), ShaderTypes::get_singleton()->get_modes(VisualServer::ShaderMode(visual_shader->get_mode())), ShaderTypes::get_singleton()->get_types());
 
 	for (int i = 0; i < preview_text->get_line_count(); i++) {
-		preview_text->set_line_as_marked(i, false);
+		preview_text->set_line_mark_position(i, false);
 	}
 	if (err != OK) {
-		preview_text->set_line_as_marked(sl.get_error_line() - 1, true);
+		preview_text->set_line_mark_position(sl.get_error_line() - 1, true);
 		error_text->set_visible(true);
 
 		String text = "error(" + itos(sl.get_error_line()) + "): " + sl.get_error_text();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -77,7 +77,9 @@ public:
 
 		struct Line {
 			int width_cache : 24;
-			bool marked : 1;
+			// The mark's column position, if any. "0" means the line isn't marked.
+			// Only positive values make sense here.
+			int mark_position : 16;
 			bool breakpoint : 1;
 			bool bookmark : 1;
 			bool hidden : 1;
@@ -90,7 +92,7 @@ public:
 			String data;
 			Line() {
 				width_cache = 0;
-				marked = false;
+				mark_position = 0;
 				breakpoint = false;
 				bookmark = false;
 				hidden = false;
@@ -119,8 +121,8 @@ public:
 		int get_line_wrap_amount(int p_line) const;
 		const Map<int, ColorRegionInfo> &get_color_region_info(int p_line) const;
 		void set(int p_line, const String &p_text);
-		void set_marked(int p_line, bool p_marked) { text.write[p_line].marked = p_marked; }
-		bool is_marked(int p_line) const { return text[p_line].marked; }
+		void set_mark_position(int p_line, int p_mark_position = 0) { text.write[p_line].mark_position = p_mark_position; }
+		int get_mark_position(int p_line) const { return text[p_line].mark_position; }
 		void set_bookmark(int p_line, bool p_bookmark) { text.write[p_line].bookmark = p_bookmark; }
 		bool is_bookmark(int p_line) const { return text[p_line].bookmark; }
 		void set_breakpoint(int p_line, bool p_breakpoint) { text.write[p_line].breakpoint = p_breakpoint; }
@@ -576,9 +578,6 @@ public:
 	void _get_mouse_pos(const Point2i &p_mouse, int &r_row, int &r_col) const;
 	void _get_minimap_mouse_row(const Point2i &p_mouse, int &r_row) const;
 
-	//void delete_char();
-	//void delete_line();
-
 	void begin_complex_operation();
 	void end_complex_operation();
 
@@ -588,7 +587,7 @@ public:
 	void insert_text_at_cursor(const String &p_text);
 	void insert_at(const String &p_text, int at);
 	int get_line_count() const;
-	void set_line_as_marked(int p_line, bool p_marked);
+	void set_line_mark_position(int p_line, int p_column = 0);
 	void set_line_as_bookmark(int p_line, bool p_bookmark);
 	bool is_line_set_as_bookmark(int p_line) const;
 	void get_bookmarks(List<int> *p_bookmarks) const;
@@ -628,7 +627,7 @@ public:
 
 	void indent_left();
 	void indent_right();
-	int get_indent_level(int p_line) const;
+	int get_indent_level(int p_line, bool p_count_tabs_as_spaces = false) const;
 	bool is_line_comment(int p_line) const;
 
 	inline void set_scroll_pass_end_of_file(bool p_enabled) {

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -442,7 +442,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_color_selected", "TextEdit", Color(0, 0, 0));
 	theme->set_color("font_color_readonly", "TextEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
 	theme->set_color("selection_color", "TextEdit", font_color_selection);
-	theme->set_color("mark_color", "TextEdit", Color(1.0, 0.4, 0.4, 0.4));
+	theme->set_color("mark_color", "TextEdit", Color(1.0, 0.4, 0.4, 0.15));
 	theme->set_color("bookmark_color", "TextEdit", Color(0.08, 0.49, 0.98));
 	theme->set_color("breakpoint_color", "TextEdit", Color(0.8, 0.8, 0.4, 0.2));
 	theme->set_color("executing_line_color", "TextEdit", Color(0.2, 0.8, 0.2, 0.4));


### PR DESCRIPTION
This makes it easier to see where the script error is located exactly. The line's background is still highlighted to get the user's attention.

The default mark color was changed to be more transparent, as the underline makes the line more noticeable on its own.

This breaks compatibility in a minor way as some TextEdit methods' signatures had to be changed in a backwards-incompatible manner.

## Preview

### Error with column information

(e.g. many syntax errors)

![2020-02-06_22 09 57](https://user-images.githubusercontent.com/180032/73979192-0043fb80-492e-11ea-8b66-f93b98904fbc.png)

### Error without column information

(e.g. identifier not found)

![2020-02-06_22 10 16](https://user-images.githubusercontent.com/180032/73979193-00dc9200-492e-11ea-8756-92b2299ee310.png)