### PR TITLE
SCons: Refactor module defines into a generated header, cleanup

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -410,7 +410,7 @@ if selected_platform in platform_list:
     env.module_icons_paths = []
     env.doc_class_path = {}
 
-    for x in module_list:
+    for x in sorted(module_list):
         if not env['module_' + x + '_enabled']:
             continue
         tmppath = "./modules/" + x
@@ -427,7 +427,7 @@ if selected_platform in platform_list:
                   "signature in its config.py file, it should be "
                   "`can_build(env, platform)`." % x)
             can_build = config.can_build(selected_platform)
-        if (can_build):
+        if can_build:
             config.configure(env)
             env.module_list.append(x)
 

--- a/SConstruct
+++ b/SConstruct
@@ -118,7 +118,6 @@ opts.Add(BoolVariable('use_precise_math_checks', 'Math checks use very precise e
 
 # Components
 opts.Add(BoolVariable('deprecated', "Enable deprecated features", True))
-opts.Add(BoolVariable('gdscript', "Enable GDScript support", True))
 opts.Add(BoolVariable('minizip', "Enable ZIP archive support using minizip", True))
 opts.Add(BoolVariable('xaudio2', "Enable the XAudio2 audio driver", False))
 
@@ -477,8 +476,6 @@ if selected_platform in platform_list:
             sys.exit(255)
         else:
             env.Append(CPPDEFINES=['_3D_DISABLED'])
-    if env['gdscript']:
-        env.Append(CPPDEFINES=['GDSCRIPT_ENABLED'])
     if env['disable_advanced_gui']:
         if env['tools']:
             print("Build option 'disable_advanced_gui=yes' cannot be used with 'tools=yes' (editor), only with 'tools=no' (export template).")

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -1,8 +1,8 @@
 """Functions used to generate source files during build time
 
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
-
 """
+
 from platform_methods import subprocess_main
 from compat import iteritems, itervalues, open_utf8, escape_string, byte_to_str
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -35,7 +35,11 @@
 #include "editor_icons.gen.h"
 #include "editor_scale.h"
 #include "editor_settings.h"
+
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_SVG_ENABLED
 #include "modules/svg/image_loader_svg.h"
+#endif
 
 static Ref<StyleBoxTexture> make_stylebox(Ref<Texture> p_texture, float p_left, float p_top, float p_right, float p_botton, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_botton = -1, bool p_draw_center = true) {
 	Ref<StyleBoxTexture> style(memnew(StyleBoxTexture));
@@ -109,7 +113,7 @@ Ref<ImageTexture> editor_generate_icon(int p_index, bool p_convert_color, float 
 
 void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = true, int p_thumb_size = 32, bool p_only_thumbs = false) {
 
-#ifdef SVG_ENABLED
+#ifdef MODULE_SVG_ENABLED
 	// The default icon theme is designed to be used for a dark theme.
 	// This dictionary stores color codes to convert to other colors
 	// for better readability on a light theme.

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "editor_scene_importer_gltf.h"
+
 #include "core/crypto/crypto_core.h"
 #include "core/io/json.h"
 #include "core/math/disjoint_set.h"

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -35,8 +35,12 @@
 #include "editor/editor_plugin.h"
 #include "editor/editor_scale.h"
 #include "editor/project_settings_editor.h"
-#include "modules/gdscript/gdscript.h"
 #include "scene/gui/grid_container.h"
+
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_GDSCRIPT_ENABLED
+#include "modules/gdscript/gdscript.h"
+#endif
 
 void PluginConfigDialog::_clear_fields() {
 	name_edit->set_text("");
@@ -75,6 +79,9 @@ void PluginConfigDialog::_on_confirmed() {
 		// TODO Use script templates. Right now, this code won't add the 'tool' annotation to other languages.
 		// TODO Better support script languages with named classes (has_named_classes).
 
+		// FIXME: It's hacky to have hardcoded access to the GDScript module here.
+		// The editor code should not have to know what languages are enabled.
+#ifdef MODULE_GDSCRIPT_ENABLED
 		if (lang_name == GDScriptLanguage::get_singleton()->get_name()) {
 			// Hard-coded GDScript template to keep usability until we use script templates.
 			Ref<Script> gdscript = memnew(GDScript);
@@ -95,12 +102,15 @@ void PluginConfigDialog::_on_confirmed() {
 			ResourceSaver::save(script_path, gdscript);
 			script = gdscript;
 		} else {
+#endif
 			String script_path = path.plus_file(script_edit->get_text());
 			String class_name = script_path.get_file().get_basename();
 			script = ScriptServer::get_language(lang_idx)->get_template(class_name, "EditorPlugin");
 			script->set_path(script_path);
 			ResourceSaver::save(script_path, script);
+#ifdef MODULE_GDSCRIPT_ENABLED
 		}
+#endif
 
 		emit_signal("plugin_ready", script.operator->(), active_edit->is_pressed() ? subfolder_edit->get_text() : "");
 	} else {
@@ -229,9 +239,11 @@ PluginConfigDialog::PluginConfigDialog() {
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 		ScriptLanguage *lang = ScriptServer::get_language(i);
 		script_option_edit->add_item(lang->get_name());
+#ifdef MODULE_GDSCRIPT_ENABLED
 		if (lang == GDScriptLanguage::get_singleton()) {
 			default_lang = i;
 		}
+#endif
 	}
 	script_option_edit->select(default_lang);
 	grid->add_child(script_option_edit);

--- a/main/tests/test_gdscript.cpp
+++ b/main/tests/test_gdscript.cpp
@@ -34,7 +34,8 @@
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
 
-#ifdef GDSCRIPT_ENABLED
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_GDSCRIPT_ENABLED
 
 #include "modules/gdscript/gdscript.h"
 #include "modules/gdscript/gdscript_compiler.h"
@@ -1091,7 +1092,7 @@ MainLoop *test(TestType p_type) {
 namespace TestGDScript {
 
 MainLoop *test(TestType p_type) {
-
+	ERR_PRINT("The GDScript module is disabled, therefore GDScript tests cannot be used.");
 	return NULL;
 }
 } // namespace TestGDScript

--- a/main/tests/test_string.cpp
+++ b/main/tests/test_string.cpp
@@ -28,15 +28,19 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "core/ustring.h"
-#include <wchar.h>
-//#include "core/math/math_funcs.h"
+#include "test_string.h"
+
 #include "core/io/ip_address.h"
 #include "core/os/os.h"
-#include "modules/regex/regex.h"
-#include <stdio.h>
+#include "core/ustring.h"
 
-#include "test_string.h"
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_REGEX_ENABLED
+#include "modules/regex/regex.h"
+#endif
+
+#include <stdio.h>
+#include <wchar.h>
 
 namespace TestString {
 

--- a/methods.py
+++ b/methods.py
@@ -160,20 +160,22 @@ def detect_modules():
         except IOError:
             pass
 
-    modules_cpp = """
-// modules.cpp - THIS FILE IS GENERATED, DO NOT EDIT!!!!!!!
+    modules_cpp = """// register_module_types.gen.cpp
+/* THIS FILE IS GENERATED DO NOT EDIT */
 #include "register_module_types.h"
 
-""" + includes_cpp + """
+#include "modules/modules_enabled.gen.h"
+
+%s
 
 void register_module_types() {
-""" + register_cpp + """
+%s
 }
 
 void unregister_module_types() {
-""" + unregister_cpp + """
+%s
 }
-"""
+""" % (includes_cpp, register_cpp, unregister_cpp)
 
     # NOTE: It is safe to generate this file here, since this is still executed serially
     with open("modules/register_module_types.gen.cpp", "w") as f:
@@ -200,37 +202,10 @@ def win32_spawn(sh, escape, cmd, args, env):
         print("=====")
     return rv
 
-"""
-def win32_spawn(sh, escape, cmd, args, spawnenv):
-	import win32file
-	import win32event
-	import win32process
-	import win32security
-	for var in spawnenv:
-		spawnenv[var] = spawnenv[var].encode('ascii', 'replace')
-
-	sAttrs = win32security.SECURITY_ATTRIBUTES()
-	StartupInfo = win32process.STARTUPINFO()
-	newargs = ' '.join(map(escape, args[1:]))
-	cmdline = cmd + " " + newargs
-
-	# check for any special operating system commands
-	if cmd == 'del':
-		for arg in args[1:]:
-			win32file.DeleteFile(arg)
-		exit_code = 0
-	else:
-		# otherwise execute the command.
-		hProcess, hThread, dwPid, dwTid = win32process.CreateProcess(None, cmdline, None, None, 1, 0, spawnenv, None, StartupInfo)
-		win32event.WaitForSingleObject(hProcess, win32event.INFINITE)
-		exit_code = win32process.GetExitCodeProcess(hProcess)
-		win32file.CloseHandle(hProcess);
-		win32file.CloseHandle(hThread);
-	return exit_code
-"""
 
 def disable_module(self):
     self.disabled_modules.append(self.current_module)
+
 
 def use_windows_spawn_fix(self, platform=None):
 

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -2,19 +2,19 @@
 
 Import('env')
 
+import modules_builders
+
 env_modules = env.Clone()
 
 Export('env_modules')
 
-env.modules_sources = []
+env.CommandNoCache("modules_enabled.gen.h", Value(env.module_list), modules_builders.generate_modules_enabled)
 
+env.modules_sources = []
 env_modules.add_source_files(env.modules_sources, "register_module_types.gen.cpp")
 
-for x in env.module_list:
-    if (x in env.disabled_modules):
-        continue
-    env_modules.Append(CPPDEFINES=["MODULE_" + x.upper() + "_ENABLED"])
-    SConscript(x + "/SCsub")
+for module in env.module_list:
+    SConscript(module + "/SCsub")
 
 if env['split_libmodules']:
     env.split_lib("modules", env_lib = env_modules)

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -102,5 +102,3 @@ if env['builtin_freetype']:
 
 # Godot source files
 env_freetype.add_source_files(env.modules_sources, "*.cpp")
-# Used in scene/, needs to be in main env
-env.Append(CPPDEFINES=['FREETYPE_ENABLED'])

--- a/modules/modules_builders.py
+++ b/modules/modules_builders.py
@@ -1,0 +1,16 @@
+"""Functions used to generate source files during build time
+
+All such functions are invoked in a subprocess on Windows to prevent build flakiness.
+"""
+
+from platform_methods import subprocess_main
+
+
+def generate_modules_enabled(target, source, env):
+    with open(target[0].path, 'w') as f:
+        for module in env.module_list:
+            f.write('#define %s\n' % ("MODULE_" + module.upper() + "_ENABLED"))
+
+
+if __name__ == '__main__':
+    subprocess_main(globals())

--- a/modules/recast/navigation_mesh_generator.cpp
+++ b/modules/recast/navigation_mesh_generator.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "navigation_mesh_generator.h"
+
 #include "core/math/quick_hull.h"
 #include "core/os/thread.h"
 #include "editor/editor_settings.h"
@@ -45,10 +46,10 @@
 #include "scene/resources/shape.h"
 #include "scene/resources/sphere_shape.h"
 
+#include "modules/modules_enabled.gen.h"
 #ifdef MODULE_CSG_ENABLED
 #include "modules/csg/csg_shape.h"
 #endif
-
 #ifdef MODULE_GRIDMAP_ENABLED
 #include "modules/gridmap/grid_map.h"
 #endif

--- a/modules/register_module_types.h
+++ b/modules/register_module_types.h
@@ -31,9 +31,7 @@
 #ifndef REGISTER_MODULE_TYPES_H
 #define REGISTER_MODULE_TYPES_H
 
-//
-
 void register_module_types();
 void unregister_module_types();
 
-#endif
+#endif // REGISTER_MODULE_TYPES_H

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -13,10 +13,6 @@ thirdparty_sources = [
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
 env_svg.Prepend(CPPPATH=[thirdparty_dir])
-# FIXME: Needed in editor/editor_themes.cpp for now, but ideally there
-# shouldn't be a dependency on modules/ and its own 3rd party deps.
-env.Prepend(CPPPATH=[thirdparty_dir])
-env.Append(CPPDEFINES=["SVG_ENABLED"])
 
 env_thirdparty = env_svg.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -30,9 +30,8 @@
 
 #include "image_loader_svg.h"
 
-#include "core/os/os.h"
-#include "core/print_string.h"
-#include "core/ustring.h"
+#include <nanosvg.h>
+#include <nanosvgrast.h>
 
 void SVGRasterizer::rasterize(NSVGimage *p_image, float p_tx, float p_ty, float p_scale, unsigned char *p_dst, int p_w, int p_h, int p_stride) {
 	nsvgRasterize(rasterizer, p_image, p_tx, p_ty, p_scale, p_dst, p_w, p_h, p_stride);

--- a/modules/svg/image_loader_svg.h
+++ b/modules/svg/image_loader_svg.h
@@ -34,12 +34,13 @@
 #include "core/io/image_loader.h"
 #include "core/ustring.h"
 
-#include <nanosvg.h>
-#include <nanosvgrast.h>
-
 /**
 	@author Daniel Ramirez <djrmuv@gmail.com>
 */
+
+// Forward declare and include thirdparty headers in .cpp.
+struct NSVGrasterizer;
+struct NSVGimage;
 
 class SVGRasterizer {
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -33,8 +33,13 @@
 #include "core/math/math_defs.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
-#include "modules/regex/regex.h"
 #include "scene/scene_string_names.h"
+
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_REGEX_ENABLED
+#include "modules/regex/regex.h"
+#endif
+
 #ifdef TOOLS_ENABLED
 #include "editor/editor_scale.h"
 #endif
@@ -2864,6 +2869,7 @@ Dictionary RichTextLabel::parse_expressions_for_values(Vector<String> p_expressi
 
 		Vector<String> values = parts[1].split(",", false);
 
+#ifdef MODULE_REGEX_ENABLED
 		RegEx color = RegEx();
 		color.compile("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$");
 		RegEx nodepath = RegEx();
@@ -2897,6 +2903,7 @@ Dictionary RichTextLabel::parse_expressions_for_values(Vector<String> p_expressi
 				a.append(values[j]);
 			}
 		}
+#endif
 
 		if (values.size() > 1) {
 			d[key] = a;

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -28,8 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef FREETYPE_ENABLED
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_FREETYPE_ENABLED
+
 #include "dynamic_font.h"
+
 #include "core/os/file_access.h"
 #include "core/os/os.h"
 

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -31,7 +31,9 @@
 #ifndef DYNAMIC_FONT_H
 #define DYNAMIC_FONT_H
 
-#ifdef FREETYPE_ENABLED
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_FREETYPE_ENABLED
+
 #include "core/io/resource_loader.h"
 #include "core/os/mutex.h"
 #include "core/os/thread_safe.h"


### PR DESCRIPTION
This supersedes #32453, which aimed at having all `MODULE_*_ENABLED` defines in a header to be able to do proper checks that modules are enabled before using them in other folders (especially in `RichTextLabel` which uses `RegEx`).

It also supersedes #32781 and fixes #31011, allowing to compile with GDScript disabled again.

Those two could have been solved with less work via more custom defines, but the new approach was discussed as cleaner and overall more resilient with @punto- and @Faless. Having all the defines in a header allow us to only include this header where needed instead of passing hacks like `SVG_ENABLED` and `FREETYPE_ENABLED` to the main environment.

In the process of fixing this, we found that the removal of `env_modules.Append(CPPDEFINES=["MODULE_" + x.upper() + "_ENABLED"])` actually triggers linking order issues. I'm not sure why these defines prevented the issue, but after debugging with @Faless we found that the best is likely to ensure that `libmodules.a` comes last on the linker command.

There was then still one issue with `script_encryption_key` which is defined in a `.gen.cpp` in core, and was thus part of `libcore.a`, triggering another linking issue. I made it a `.gen.h` to solve it -- was there any reason for it to be a `.cpp` and not a `.h` in the first place?

In a follow-up PR, I might add a few changes to split `libmodules.a` into multiple `libmodule_$name.a`, which should also remove the need for the `split_libmodules` hack on Windows (#34227).