### PR TITLE
Allow printing any Variant using `print_line()` and `print_error()`

### DIFF
--- a/core/print_string.cpp
+++ b/core/print_string.cpp
@@ -72,36 +72,36 @@ void remove_print_handler(PrintHandlerList *p_handler) {
 	ERR_FAIL_COND(l == NULL);
 }
 
-void print_line(String p_string) {
+void print_line(Variant p_variant) {
 
 	if (!_print_line_enabled)
 		return;
 
-	OS::get_singleton()->print("%s\n", p_string.utf8().get_data());
+	OS::get_singleton()->print("%s\n", String(p_variant).utf8().get_data());
 
 	_global_lock();
 	PrintHandlerList *l = print_handler_list;
 	while (l) {
 
-		l->printfunc(l->userdata, p_string, false);
+		l->printfunc(l->userdata, String(p_variant), false);
 		l = l->next;
 	}
 
 	_global_unlock();
 }
 
-void print_error(String p_string) {
+void print_error(Variant p_variant) {
 
 	if (!_print_error_enabled)
 		return;
 
-	OS::get_singleton()->printerr("%s\n", p_string.utf8().get_data());
+	OS::get_singleton()->printerr("%s\n", String(p_variant).utf8().get_data());
 
 	_global_lock();
 	PrintHandlerList *l = print_handler_list;
 	while (l) {
 
-		l->printfunc(l->userdata, p_string, true);
+		l->printfunc(l->userdata, String(p_variant), true);
 		l = l->next;
 	}
 

--- a/core/print_string.h
+++ b/core/print_string.h
@@ -56,8 +56,8 @@ void remove_print_handler(PrintHandlerList *p_handler);
 
 extern bool _print_line_enabled;
 extern bool _print_error_enabled;
-extern void print_line(String p_string);
-extern void print_error(String p_string);
+extern void print_line(Variant p_variant);
+extern void print_error(Variant p_variant);
 extern void print_verbose(String p_string);
 
 #endif


### PR DESCRIPTION
This makes print statement debugging faster to set up by not requiring users to convert the value to a string manually.

PS: I couldn't get this to work with `print_verbose()`, as I'm getting this error:

```text
platform/x11/detect_prime.cpp:141:4: error: no matching function for call to 'print_verbose'
                        print_verbose("Failed to pipe(), using default GPU");
                        ^~~~~~~~~~~~~
./core/print_string.h:61:13: note: candidate function not viable: no known conversion from 'const char [36]' to 'Variant' for 1st argument
extern void print_verbose(Variant p_variant);
```

It works fine for `print_line()` and `print_debug()`, so I don't see why it wouldn't work for `print_verbose()` as well.

## Preview

Using the following snippet in Godot's C++ core:

```cpp
print_line("Hello world");
print_line(false);
print_line(1);
print_line(24.502);
print_line(Vector2(20, 40));
```

Results in:

```text
Hello world
False
1
24.502
(20, 40)
```