### PR TITLE
Use the blend parameter passed to blend_animation

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -820,6 +820,7 @@ void AnimationTree::_process_graph(float p_delta) {
 			Ref<Animation> a = as.animation;
 			float time = as.time;
 			float delta = as.delta;
+			float weight = as.blend;
 			bool seeked = as.seeked;
 
 			for (int i = 0; i < a->get_track_count(); i++) {
@@ -839,7 +840,7 @@ void AnimationTree::_process_graph(float p_delta) {
 
 				ERR_CONTINUE(blend_idx < 0 || blend_idx >= state.track_count);
 
-				float blend = (*as.track_blends)[blend_idx];
+				float blend = (*as.track_blends)[blend_idx] * weight;
 
 				if (blend < CMP_EPSILON) {
 					continue; //nothing to blend


### PR DESCRIPTION
40d1b0bfdb62d24d72f1f0102a7caf6f1c14e595 custom build + mono

In a custom AnimationNode, I was trying to do a cross fade with something like this
```
var action_blend = 0.75
var base_blend = 1.0 - action_blend
blend_input(0, time, seek, base_blend)
blend_animation(action, action_time, action_dt, seek, action_blend)
```
but the result was wrong: the blend parameter of blend_animation gets stored in AnimationState but it isn't used.

Note: using multiple blend_inputs (and doing the blend_animation in a linked subnode) works, because then the blend parameter of blend_input gets "baked" to the blend_tracks array