### PR TITLE
GraphEdit: Fix regression with GraphNode mouse filter

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -261,6 +261,7 @@ void GraphEdit::add_child_notify(Node *p_child) {
 		gn->connect("raise_request", this, "_graph_node_raised", varray(gn));
 		gn->connect("item_rect_changed", connections_layer, "update");
 		_graph_node_moved(gn);
+		gn->set_mouse_filter(MOUSE_FILTER_PASS);
 	}
 }
 


### PR DESCRIPTION
PR #35068 made Container (which GraphNode inherits) default to
MOUSE_FILTER_PASS, so I removed the manual override, but it turns out
that GraphNode's constructor still overrides it to MOUSE_FILTER_STOP.

Another fix could be to remove the STOP in the constructor, but I don't
know if it's there for a specific reason (e.g. to have GraphNodes STOP
by default, but PASS in a specific case).

Fixes #35978.