### PR TITLE
SCons: Split libmodules.a in folder-based libs

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -78,7 +78,6 @@ env_base.__class__.add_module_version_string = methods.add_module_version_string
 
 env_base.__class__.add_source_files = methods.add_source_files
 env_base.__class__.use_windows_spawn_fix = methods.use_windows_spawn_fix
-env_base.__class__.split_lib = methods.split_lib
 
 env_base.__class__.add_shared_library = methods.add_shared_library
 env_base.__class__.add_library = methods.add_library
@@ -130,7 +129,6 @@ opts.Add(BoolVariable('dev', "If yes, alias for verbose=yes warnings=extra werro
 opts.Add('extra_suffix', "Custom extra suffix added to the base filename of all generated binary files", '')
 opts.Add(BoolVariable('vsproj', "Generate a Visual Studio solution", False))
 opts.Add(EnumVariable('macports_clang', "Build using Clang from MacPorts", 'no', ('no', '5.0', 'devel')))
-opts.Add(BoolVariable('split_libmodules', "Split intermediate libmodules.a in smaller chunks to prevent exceeding linker command line size (forced to True when using MinGW)", False))
 opts.Add(BoolVariable('disable_3d', "Disable 3D nodes for a smaller executable", False))
 opts.Add(BoolVariable('disable_advanced_gui', "Disable advanced GUI nodes and behaviors", False))
 opts.Add(BoolVariable('no_editor_splash', "Don't use the custom splash screen for the editor", False))

--- a/methods.py
+++ b/methods.py
@@ -257,67 +257,6 @@ def use_windows_spawn_fix(self, platform=None):
     self['SPAWN'] = mySpawn
 
 
-def split_lib(self, libname, src_list = None, env_lib = None):
-    env = self
-
-    num = 0
-    cur_base = ""
-    max_src = 64
-    list = []
-    lib_list = []
-
-    if src_list is None:
-        src_list = getattr(env, libname + "_sources")
-
-    if type(env_lib) == type(None):
-        env_lib = env
-
-    for f in src_list:
-        fname = ""
-        if type(f) == type(""):
-            fname = env.File(f).path
-        else:
-            fname = env.File(f)[0].path
-        fname = fname.replace("\\", "/")
-        base = "/".join(fname.split("/")[:2])
-        if base != cur_base and len(list) > max_src:
-            if num > 0:
-                lib = env_lib.add_library(libname + str(num), list)
-                lib_list.append(lib)
-                list = []
-            num = num + 1
-        cur_base = base
-        list.append(f)
-
-    lib = env_lib.add_library(libname + str(num), list)
-    lib_list.append(lib)
-
-    lib_base = []
-    env_lib.add_source_files(lib_base, "*.cpp")
-    lib = env_lib.add_library(libname, lib_base)
-    lib_list.insert(0, lib)
-
-    env.Prepend(LIBS=lib_list)
-
-    # When we split modules into arbitrary chunks, we end up with linking issues
-    # due to symbol dependencies split over several libs, which may not be linked
-    # in the required order. We use --start-group and --end-group to tell the
-    # linker that those archives should be searched repeatedly to resolve all
-    # undefined references.
-    # As SCons doesn't give us much control over how inserting libs in LIBS
-    # impacts the linker call, we need to hack our way into the linking commands
-    # LINKCOM and SHLINKCOM to set those flags.
-
-    if '-Wl,--start-group' in env['LINKCOM'] and '-Wl,--start-group' in env['SHLINKCOM']:
-        # Already added by a previous call, skip.
-        return
-
-    env['LINKCOM'] = str(env['LINKCOM']).replace('$_LIBFLAGS',
-            '-Wl,--start-group $_LIBFLAGS -Wl,--end-group')
-    env['SHLINKCOM'] = str(env['LINKCOM']).replace('$_LIBFLAGS',
-            '-Wl,--start-group $_LIBFLAGS -Wl,--end-group')
-
-
 def save_active_platforms(apnames, ap):
 
     for x in ap:

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -8,17 +8,26 @@ env_modules = env.Clone()
 
 Export('env_modules')
 
+# Header with MODULE_*_ENABLED defines.
 env.CommandNoCache("modules_enabled.gen.h", Value(env.module_list), modules_builders.generate_modules_enabled)
 
-env.modules_sources = []
-env_modules.add_source_files(env.modules_sources, "register_module_types.gen.cpp")
-
+# libmodule_<name>.a for each active module.
 for module in env.module_list:
+    env.modules_sources = []
     SConscript(module + "/SCsub")
 
-if env['split_libmodules']:
-    env.split_lib("modules", env_lib = env_modules)
-else:
-    lib = env_modules.add_library("modules", env.modules_sources)
+    # Some modules are not linked automatically but can be enabled optionally
+    # on iOS, so we handle those specially.
+    if env["platform"] == "iphone" and module in ["arkit", "camera"]:
+        continue
 
+    lib = env_modules.add_library("module_%s" % module, env.modules_sources)
     env.Prepend(LIBS=[lib])
+
+# libmodules.a with only register_module_types.
+# Must be last so that all libmodule_<name>.a libraries are on the right side
+# in the linker command.
+env.modules_sources = []
+env_modules.add_source_files(env.modules_sources, "register_module_types.gen.cpp")
+lib = env_modules.add_library("modules", env.modules_sources)
+env.Prepend(LIBS=[lib])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -293,12 +293,7 @@ def configure_mingw(env):
 
     ## Compiler configuration
 
-    if (os.name == "nt"):
-        # Force splitting libmodules.a in multiple chunks to work around
-        # issues reaching the linker command line size limit, which also
-        # seem to induce huge slowdown for 'ar' (GH-30892).
-        env['split_libmodules'] = True
-    else:
+    if os.name != "nt":
         env["PROGSUFFIX"] = env["PROGSUFFIX"] + ".exe"  # for linux cross-compilation
 
     if (env["bits"] == "default"):


### PR DESCRIPTION
This removes the need for the hacky split_libmodules logic on Windows,
since all libs are now of manageable size.

---

Includes #35963 which should be merged first, then this can be rebased.