### PR TITLE
Allow non-constants for indexing builtin types in shaders

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -3301,9 +3301,6 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 								_set_error("Index out of range (0-1)");
 								return NULL;
 							}
-						} else {
-							_set_error("Only integer constants are allowed as index at the moment");
-							return NULL;
 						}
 
 						switch (expr->get_datatype()) {
@@ -3327,9 +3324,6 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 								_set_error("Index out of range (0-2)");
 								return NULL;
 							}
-						} else {
-							_set_error("Only integer constants are allowed as index at the moment");
-							return NULL;
 						}
 
 						switch (expr->get_datatype()) {
@@ -3352,9 +3346,6 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 								_set_error("Index out of range (0-3)");
 								return NULL;
 							}
-						} else {
-							_set_error("Only integer constants are allowed as index at the moment");
-							return NULL;
 						}
 
 						switch (expr->get_datatype()) {


### PR DESCRIPTION
I don't know for what this restriction is intended, but in GLSL shaders, you may use non-constant as an index for these types, allowing such constructions:

![image](https://user-images.githubusercontent.com/3036176/74043372-4d7da700-49da-11ea-90d0-d014616a8dbb.png)
