### PR TITLE
Implement the `%command%` placeholder in the Main Run Args setting

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1104,6 +1104,8 @@ ProjectSettings::ProjectSettings() {
 	}
 	extensions.push_back("shader");
 
+	GLOBAL_DEF("editor/run/main_run_args", "");
+
 	GLOBAL_DEF("editor/script/search_in_file_extensions", extensions);
 	custom_prop_info["editor/script/search_in_file_extensions"] = PropertyInfo(Variant::PACKED_STRING_ARRAY, "editor/script/search_in_file_extensions");
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -143,7 +143,7 @@
 				Returns the command-line arguments passed to the engine.
 				Command-line arguments can be written in any form, including both [code]--key value[/code] and [code]--key=value[/code] forms so they can be properly parsed, as long as custom command-line arguments do not conflict with engine arguments.
 				You can also incorporate environment variables using the [method get_environment] method.
-				You can set [code]editor/main_run_args[/code] in the Project Settings to define command-line arguments to be passed by the editor when running the project.
+				You can set [member ProjectSettings.editor/run/main_run_args] to define command-line arguments to be passed by the editor when running the project.
 				Here's a minimal example on how to parse command-line arguments into a dictionary using the [code]--key=value[/code] form for arguments:
 				[codeblocks]
 				[gdscript]

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -542,6 +542,14 @@
 		<member name="editor/node_naming/name_num_separator" type="int" setter="" getter="" default="0">
 			What to use to separate node name from number. This is mostly an editor setting.
 		</member>
+		<member name="editor/run/main_run_args" type="String" setter="" getter="" default="&quot;&quot;">
+			The command-line arguments to append to Godot's own command line when running the project. This doesn't affect the editor itself.
+			It is possible to make another executable run Godot by using the [code]%command%[/code] placeholder. The placeholder will be replaced with Godot's own command line. Program-specific arguments should be placed [i]before[/i] the placeholder, whereas Godot-specific arguments should be placed [i]after[/i] the placeholder.
+			For example, this can be used to force the project to run on the dedicated GPU in a NVIDIA Optimus system on Linux:
+			[codeblock]
+			prime-run %command%
+			[/codeblock]
+		</member>
 		<member name="editor/script/search_in_file_extensions" type="PackedStringArray" setter="" getter="" default="PackedStringArray( &quot;gd&quot;, &quot;shader&quot; )">
 			Text-based file extensions to include in the script editor's "Find in Files" feature. You can add e.g. [code]tscn[/code] if you wish to also parse your scene files, especially if you use built-in scripts which are serialized in the scene files.
 		</member>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5877,8 +5877,6 @@ EditorNode::EditorNode() {
 
 	register_exporters();
 
-	GLOBAL_DEF("editor/run/main_run_args", "");
-
 	ClassDB::set_class_enabled("RootMotionView", true);
 
 	//defs here, use EDITOR_GET in logic


### PR DESCRIPTION
This can be used to tell Godot to run an executable that will run Godot rather than running Godot directly. This is useful to make Godot start on the dedicated GPU when using a NVIDIA Optimus setup on Linux: `prime-run %command%`

This is also useful for [MangoHud](https://github.com/flightlessmango/MangoHud), [vkBasalt](https://github.com/DadSchoorse/vkBasalt) and the like.

The `editor/main_run_args` setting declaration was moved to make it visible in the ProjectSettings documentation.

This closes #34630.