### PR TITLE
Workaround WebM playback bug after AudioServer latency fixes

### DIFF
--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -363,8 +363,10 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 };
 
 float VideoStreamPlaybackTheora::get_time() const {
-
-	return time - AudioServer::get_singleton()->get_output_latency() - delay_compensation; //-((get_total())/(float)vi.rate);
+	// FIXME: AudioServer output latency was fixed in af9bb0e, previously it used to
+	// systematically return 0. Now that it gives a proper latency, it broke this
+	// code where the delay compensation likely never really worked.
+	return time - /* AudioServer::get_singleton()->get_output_latency() - */ delay_compensation;
 };
 
 Ref<Texture> VideoStreamPlaybackTheora::get_texture() const {

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -393,17 +393,22 @@ int VideoStreamPlaybackWebm::get_mix_rate() const {
 
 inline bool VideoStreamPlaybackWebm::has_enough_video_frames() const {
 	if (video_frames_pos > 0) {
-
-		const double audio_delay = AudioServer::get_singleton()->get_output_latency();
+		// FIXME: AudioServer output latency was fixed in af9bb0e, previously it used to
+		// systematically return 0. Now that it gives a proper latency, it broke this
+		// code where the delay compensation likely never really worked.
+		//const double audio_delay = AudioServer::get_singleton()->get_output_latency();
 		const double video_time = video_frames[video_frames_pos - 1]->time;
-		return video_time >= time + audio_delay + delay_compensation;
+		return video_time >= time + /* audio_delay + */ delay_compensation;
 	}
 	return false;
 }
 
 bool VideoStreamPlaybackWebm::should_process(WebMFrame &video_frame) {
-	const double audio_delay = AudioServer::get_singleton()->get_output_latency();
-	return video_frame.time >= time + audio_delay + delay_compensation;
+	// FIXME: AudioServer output latency was fixed in af9bb0e, previously it used to
+	// systematically return 0. Now that it gives a proper latency, it broke this
+	// code where the delay compensation likely never really worked.
+	//const double audio_delay = AudioServer::get_singleton()->get_output_latency();
+	return video_frame.time >= time + /* audio_delay + */ delay_compensation;
 }
 
 void VideoStreamPlaybackWebm::delete_pointers() {

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "audio_server.h"
+
 #include "core/io/resource_loader.h"
 #include "core/os/file_access.h"
 #include "core/os/os.h"
@@ -36,14 +37,11 @@
 #include "scene/resources/audio_stream_sample.h"
 #include "servers/audio/audio_driver_dummy.h"
 #include "servers/audio/effects/audio_effect_compressor.h"
+
 #ifdef TOOLS_ENABLED
-
 #define MARK_EDITED set_edited(true);
-
 #else
-
 #define MARK_EDITED
-
 #endif
 
 AudioDriver *AudioDriver::singleton = NULL;
@@ -1405,8 +1403,6 @@ AudioServer::AudioServer() {
 	mix_frames = 0;
 	channel_count = 0;
 	to_mix = 0;
-	output_latency = 0;
-	output_latency_ticks = 0;
 #ifdef DEBUG_ENABLED
 	prof_time = 0;
 #endif

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -240,9 +240,6 @@ private:
 
 	Mutex *audio_data_lock;
 
-	float output_latency;
-	uint64_t output_latency_ticks;
-
 	void init_channels_and_buffers();
 
 	void _mix_step();


### PR DESCRIPTION
af9bb0ea15dfd3dfe8950fcfcce364485dadd92a fixed AudioServer's
`get_output_delay()` (which used to always return 0) while renaming it
to `get_output_latency()`. It now returns the latency from the
AudioDriver, which can be non-0.

While this was a clear bugfix, it broke playback for WebM files without
audio track. It seems like the playback code, even though it queried
the output delay to calculate a time compensation, was designed to work
even though the delay value was actually bogus. Now that it's correct,
it's not working.

As a workaround we comment out uses of the output latency, restoring
the behavior of Godot 3.1.

This code should still be reviewed by someone more versed in video
playback and fixed to properly account for the non-0 driver latency.

Fixes #35760.