### PR TITLE
Adjusted linux cursors and added fallbacks

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -526,19 +526,73 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 			"watch",
 			"left_ptr_watch",
 			"fleur",
-			"hand1",
-			"X_cursor",
-			"sb_v_double_arrow",
-			"sb_h_double_arrow",
+			"dnd-move",
+			"crossed_circle",
+			"v_double_arrow",
+			"h_double_arrow",
 			"size_bdiag",
 			"size_fdiag",
-			"hand1",
-			"sb_v_double_arrow",
-			"sb_h_double_arrow",
+			"move",
+			"row_resize",
+			"col_resize",
 			"question_arrow"
 		};
 
 		img[i] = XcursorLibraryLoadImage(cursor_file[i], cursor_theme, cursor_size);
+		if (!img[i]) {
+			const char *fallback = NULL;
+
+			switch (i) {
+				case CURSOR_POINTING_HAND:
+					fallback = "pointer";
+					break;
+				case CURSOR_CROSS:
+					fallback = "crosshair";
+					break;
+				case CURSOR_WAIT:
+					fallback = "wait";
+					break;
+				case CURSOR_BUSY:
+					fallback = "progress";
+					break;
+				case CURSOR_DRAG:
+					fallback = "grabbing";
+					break;
+				case CURSOR_CAN_DROP:
+					fallback = "hand1";
+					break;
+				case CURSOR_FORBIDDEN:
+					fallback = "forbidden";
+					break;
+				case CURSOR_VSIZE:
+					fallback = "ns-resize";
+					break;
+				case CURSOR_HSIZE:
+					fallback = "ew-resize";
+					break;
+				case CURSOR_BDIAGSIZE:
+					fallback = "fd_double_arrow";
+					break;
+				case CURSOR_FDIAGSIZE:
+					fallback = "bd_double_arrow";
+					break;
+				case CURSOR_MOVE:
+					img[i] = img[CURSOR_DRAG];
+					break;
+				case CURSOR_VSPLIT:
+					fallback = "sb_v_double_arrow";
+					break;
+				case CURSOR_HSPLIT:
+					fallback = "sb_h_double_arrow";
+					break;
+				case CURSOR_HELP:
+					fallback = "help";
+					break;
+			}
+			if (fallback != NULL) {
+				img[i] = XcursorLibraryLoadImage(fallback, cursor_theme, cursor_size);
+			}
+		}
 		if (img[i]) {
 			cursors[i] = XcursorImageLoadCursor(x11_display, img[i]);
 		} else {


### PR DESCRIPTION
While we can not fix ALL inconsistencies regarding cursor icons, we should at least aim to eliminate most of them. This commit adds fallbacks for x11 cursors.

Should properly close https://github.com/godotengine/godot/issues/14878

These changes are based on:
- the most used linux distributions according to the steam hardware survey (Ubuntu, Arch, Manjaro and Mint)
- 4 commonly used themes (DMZ-White/Black, Breeze, Bibata Classic, Adwaita)
- cursors of other platforms

**Default cursors that were changed:**

- CURSOR_CAN_DROP - "hand1" (pointing hand) -> "dnd-move", since this is what Mint uses for indicating that e.g. a file can be dropped, hand1 has been kept as fallback

- CURSOR_FORBIDDEN - "X_cursor" -> "crossed_circle", since the other OS used the crossed circle as well, linux was the only one using the x cursor

- CURSOR_VSIZE and _HSIZE  - "sb_(v/h)_double_arrow" -> "(h/v)_double_arrow", because the sb cursor had the bar inbetween on most themes which is only used for HSPLIT/VSPLIT across the other platforms

- CURSOR_MOVE - "hand1" -> "move", which is most commonly used, with the cursor from CURSOR_DRAG as fallback

**Edit**: Added a small project to test the cursors. Simply hover over the labels.
[CursorTest.zip](https://github.com/godotengine/godot/files/4174294/CursorTest.zip)