### PR TITLE
Fix transparent editor theme being brighter

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -534,7 +534,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_tab_disabled->set_border_color(color_disabled);
 
 	// Editor background
-	theme->set_stylebox("Background", "EditorStyles", make_flat_stylebox(background_color, default_margin_size, default_margin_size, default_margin_size, default_margin_size));
+	Color background_color_opaque = background_color;
+	background_color_opaque.a = 1.0;
+	theme->set_stylebox("Background", "EditorStyles", make_flat_stylebox(background_color_opaque, default_margin_size, default_margin_size, default_margin_size, default_margin_size));
 
 	// Focus
 	Ref<StyleBoxFlat> style_focus = style_default->duplicate();


### PR DESCRIPTION
TIL that you can have a transparent editor theme, but it makes the editor background also transparent, and the background before that is white. This update forces the background alpha to be opaque

**Before**
![image](https://user-images.githubusercontent.com/14253836/74078265-c5090180-49ed-11ea-962b-2813f086d634.png)

**After**
![image](https://user-images.githubusercontent.com/14253836/74078281-ef5abf00-49ed-11ea-9f86-c6e75bc37f22.png)
