### PR TITLE
Fix project settings modifications requiring scene save

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -555,14 +555,17 @@ void EditorNode::_notification(int p_what) {
 				opening_prev = false;
 			}
 
-			if (unsaved_cache != (saved_version != editor_data.get_undo_redo().get_version())) {
-				unsaved_cache = (saved_version != editor_data.get_undo_redo().get_version());
-				_update_title();
+			uint64_t current_version = editor_data.get_undo_redo().get_version();
+
+			if (last_checked_version != current_version) {
+				_update_scene_tabs();
+				last_checked_version = current_version;
 			}
 
-			if (last_checked_version != editor_data.get_undo_redo().get_version()) {
-				_update_scene_tabs();
-				last_checked_version = editor_data.get_undo_redo().get_version();
+			bool unsaved = saved_version != current_version;
+			if (unsaved_cache != unsaved) {
+				_update_title();
+				unsaved_cache = unsaved;
 			}
 
 			// Update the animation frame of the update spinner.

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -102,6 +102,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 
 protected:
 	void _notification(int p_what);
+	void unhandled_input(const Ref<InputEvent> &p_event) override;
 	static void _bind_methods();
 
 public:
@@ -116,6 +117,7 @@ public:
 	void queue_save();
 
 	ProjectSettingsEditor(EditorData *p_data);
+	virtual ~ProjectSettingsEditor();
 };
 
 #endif // PROJECT_SETTINGS_EDITOR_H


### PR DESCRIPTION
Changes to editor_node.cpp shouldn't do anything, just making code more readable.

Basically, changes done to project settings used to add a `(*)` and you would need to CTRL+S even though the changes are saved automatically and have nothing to do with the scene