### PR TITLE
Skeleton animates physical bones

### DIFF
--- a/editor/plugins/skeleton_editor_plugin.cpp
+++ b/editor/plugins/skeleton_editor_plugin.cpp
@@ -103,8 +103,10 @@ void SkeletonEditor::create_physical_skeleton() {
 
 PhysicalBone *SkeletonEditor::create_physical_bone(int bone_id, int bone_child_id, const Vector<BoneInfo> &bones_infos) {
 
-	real_t half_height(skeleton->get_bone_rest(bone_child_id).origin.length() * 0.5);
-	real_t radius(half_height * 0.2);
+	const Transform child_rest = skeleton->get_bone_rest(bone_child_id);
+
+	const real_t half_height(child_rest.origin.length() * 0.5);
+	const real_t radius(half_height * 0.2);
 
 	CapsuleShape *bone_shape_capsule = memnew(CapsuleShape);
 	bone_shape_capsule->set_height((half_height - radius) * 2);
@@ -114,7 +116,8 @@ PhysicalBone *SkeletonEditor::create_physical_bone(int bone_id, int bone_child_i
 	bone_shape->set_shape(bone_shape_capsule);
 
 	Transform body_transform;
-	body_transform.origin = Vector3(0, 0, -half_height);
+	body_transform.set_look_at(Vector3(0, 0, 0), child_rest.origin, Vector3(0, 1, 0));
+	body_transform.origin = body_transform.basis.xform(Vector3(0, 0, -half_height));
 
 	Transform joint_transform;
 	joint_transform.origin = Vector3(0, 0, half_height);

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -562,8 +562,6 @@ private:
 	Skeleton *parent_skeleton;
 	Transform body_offset;
 	Transform body_offset_inverse;
-	bool static_body;
-	bool _internal_static_body;
 	bool simulate_physics;
 	bool _internal_simulate_physics;
 	int bone_id;
@@ -613,9 +611,6 @@ public:
 	void set_body_offset(const Transform &p_offset);
 	const Transform &get_body_offset() const;
 
-	void set_static_body(bool p_static);
-	bool is_static_body();
-
 	void set_simulate_physics(bool p_simulate);
 	bool get_simulate_physics();
 	bool is_simulating_physics();
@@ -641,16 +636,15 @@ public:
 	void apply_central_impulse(const Vector3 &p_impulse);
 	void apply_impulse(const Vector3 &p_pos, const Vector3 &p_impulse);
 
+	void reset_physics_simulation_state();
+	void reset_to_rest_position();
+
 	PhysicalBone();
 	~PhysicalBone();
 
 private:
 	void update_bone_id();
 	void update_offset();
-	void reset_to_rest_position();
-
-	void _reset_physics_simulation_state();
-	void _reset_staticness_state();
 
 	void _start_physics_simulation();
 	void _stop_physics_simulation();

--- a/scene/3d/skeleton.h
+++ b/scene/3d/skeleton.h
@@ -115,6 +115,7 @@ private:
 		}
 	};
 
+	bool animate_physical_bones;
 	Vector<Bone> bones;
 	Vector<int> process_order;
 	bool process_order_dirty;
@@ -198,6 +199,9 @@ public:
 
 #ifndef _3D_DISABLED
 	// Physical bone API
+
+	void set_animate_physical_bones(bool p_animate);
+	bool get_animate_physical_bones() const;
 
 	void bind_physical_bone_to_bone(int p_bone, PhysicalBone *p_physical_bone);
 	void unbind_physical_bone_from_bone(int p_bone);


### PR DESCRIPTION
Added feature to move physical bones with skeleton when not simulating physics.

So now we have the possibility to:
- Don't simulate physics and don't animate the physical bones
- Don't simulate physics and animate the physical bones
- Simulates the physics

Fixes #24359
Fixes: #26060
Fixes: #24836

![ezgif com-video-to-gif(13)](https://user-images.githubusercontent.com/8342599/74082315-0b477a80-4a59-11ea-823b-46aa36bb946c.gif)