### PR TITLE
Avoid going out of bounds in IsSubsequenceOf

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -474,7 +474,7 @@ namespace Godot
             int source = 0;
             int target = 0;
 
-            while (instance[source] != 0 && text[target] != 0)
+            while (source < len && target < text.Length)
             {
                 bool match;
 
@@ -491,7 +491,7 @@ namespace Godot
                 if (match)
                 {
                     source++;
-                    if (instance[source] == 0)
+                    if (source >= len)
                         return true;
                 }
 


### PR DESCRIPTION
Fixes #35598 as discussed, preventing `IsSubsequenceOf` from throwing `IndexOutOfRangeException`.