### PR TITLE
Remove the execName parameter from engine.startGame. (javascript platform)

### DIFF
--- a/misc/dist/html/fixed-size.html
+++ b/misc/dist/html/fixed-size.html
@@ -230,7 +230,6 @@ $GODOT_HEAD_INCLUDE
 
 		(function() {
 
-			const EXECUTABLE_NAME = '$GODOT_BASENAME';
 			const MAIN_PACK = '$GODOT_BASENAME.pck';
 			const DEBUG_ENABLED = $GODOT_DEBUG_ENABLED;
 			const INDETERMINATE_STATUS_STEP_MS = 100;
@@ -382,7 +381,7 @@ $GODOT_HEAD_INCLUDE
 			} else {
 				setStatusMode('indeterminate');
 				engine.setCanvas(canvas);
-				engine.startGame(EXECUTABLE_NAME, MAIN_PACK).then(() => {
+				engine.startGame(MAIN_PACK).then(() => {
 					setStatusMode('hidden');
 					initializing = false;
 				}, displayFailureNotice);

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -143,7 +143,6 @@ $GODOT_HEAD_INCLUDE
 
 		(function() {
 
-			const EXECUTABLE_NAME = '$GODOT_BASENAME';
 			const MAIN_PACK = '$GODOT_BASENAME.pck';
 			const INDETERMINATE_STATUS_STEP_MS = 100;
 
@@ -256,7 +255,7 @@ $GODOT_HEAD_INCLUDE
 			} else {
 				setStatusMode('indeterminate');
 				engine.setCanvas(canvas);
-				engine.startGame(EXECUTABLE_NAME, MAIN_PACK).then(() => {
+				engine.startGame(MAIN_PACK).then(() => {
 					setStatusMode('hidden');
 					initializing = false;
 				}, displayFailureNotice);

--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -131,9 +131,9 @@
 			);
 		};
 
-		this.startGame = function(execName, mainPack) {
+		this.startGame = function(mainPack) {
 
-			executableName = execName;
+			executableName = getBaseName(mainPack);
 			var mainArgs = [ '--main-pack', mainPack ];
 
 			return Promise.all([


### PR DESCRIPTION
After https://github.com/godotengine/godot-docs/issues/3146 I looked at the code to document it, but realized that the new parameter can be removed, because it can be extracted from the main pack. This way the .wasm file, and the .pck has to have the same names, and they need to be in the same folder, but that is in line with how the engine works on other platforms, so I don't think that that should be an issue.

The ability to just rename the .html file without touching the other files will still be intact with this.

(By the way, It was already pretty much working like this already, because in engine.js (L141) `this.init(getBasePath(mainPack)),` was supposed to be changed to `this.init(getBasePath(execName)),`, but apparently that change got lost during my experiments.)