### PR TITLE
Do not override Path2D.self_modulate property

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -102,7 +102,7 @@ void Path2D::_notification(int p_what) {
 #else
 		const float line_width = 2;
 #endif
-		const Color color = Color(1.0, 1.0, 1.0, 1.0);
+		const Color color = Color(0.5, 0.6, 1.0, 0.7);
 
 		for (int i = 0; i < curve->get_point_count(); i++) {
 
@@ -163,7 +163,6 @@ void Path2D::_bind_methods() {
 Path2D::Path2D() {
 
 	set_curve(Ref<Curve2D>(memnew(Curve2D))); //create one by default
-	set_self_modulate(Color(0.5, 0.6, 1.0, 0.7));
 }
 
 /////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Self-modulation was forcefully used for the curve drawing which can interfere with scripted drawing. The curve color is specified by the `draw_line()` method instead.

That's something unexpected which I stumbled upon while attempting to do custom drawing by extending `Path2D` which also provides `Curve2D` editing abilities (use case: drawing textures along the curve). I had to revert `self_modulate` property to the default value to see the textures unaffected by the forced modulation.

Works the same way:

![Annotation 2020-02-09 010537](https://user-images.githubusercontent.com/17108460/74093274-62406480-4ad8-11ea-98fe-29f1bb310fc1.png)