### PR TITLE
Check if bbcode is enable and filled before parsing and overwrite text property

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2016,8 +2016,12 @@ bool RichTextLabel::is_scroll_following() const {
 
 Error RichTextLabel::parse_bbcode(const String &p_bbcode) {
 
-	clear();
-	return append_bbcode(p_bbcode);
+	// Fix Issue 35553: check if bbcode is enable and filled before parsing bbcode and overwrite text property
+	if (use_bbcode && p_bbcode.length() > 0) {
+		clear();
+		return append_bbcode(p_bbcode);
+	} else
+		return OK;
 }
 
 Error RichTextLabel::append_bbcode(const String &p_bbcode) {


### PR DESCRIPTION
When the RichTextLabel node gets duplicates the last property to be duplicate is CustomEffects wich calls the parse_bbcode method. I've fix the parse_bbcode method to process only if the use_bbcode is flagged and there is actual bbcode to be parsed, otherwise keep the current node text.

_Bugsquad edit:_ Fixes #35553