### PR TITLE
Fix text clipping in Tree items not working with negative values

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1121,7 +1121,7 @@ void Tree::draw_item_rect(const TreeItem::Cell &p_cell, const Rect2i &p_rect, co
 	}
 
 	rect.position.y += Math::floor((rect.size.y - font->get_height()) / 2.0) + font->get_ascent();
-	font->draw(ci, rect.position, text, p_color, rect.size.x);
+	font->draw(ci, rect.position, text, p_color, MAX(0, rect.size.width));
 }
 
 int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item) {


### PR DESCRIPTION
Before this, Trees with short widths could fail to clip texts:
![Screenshot_20200208_210808](https://user-images.githubusercontent.com/30739239/74093893-45079800-4ad0-11ea-9135-ca7ad12ec0af.png)