### PR TITLE
Allow moving the editor's bottom panel to the right

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -66,6 +66,7 @@ class TextureProgressBar;
 class Tree;
 class VBoxContainer;
 class VSplitContainer;
+class SplitContainer;
 class Window;
 
 class AudioStreamImportSettings;
@@ -313,7 +314,7 @@ private:
 	HSplitContainer *right_hsplit = nullptr;
 	VSplitContainer *right_l_vsplit = nullptr;
 	VSplitContainer *right_r_vsplit = nullptr;
-	VSplitContainer *center_split = nullptr;
+	SplitContainer *center_split = nullptr;
 	// To access those easily by index.
 	Vector<VSplitContainer *> vsplits;
 	Vector<HSplitContainer *> hsplits;
@@ -451,6 +452,7 @@ private:
 	EditorToaster *editor_toaster = nullptr;
 	LinkButton *version_btn = nullptr;
 	Button *bottom_panel_raise = nullptr;
+	Button *bottom_panel_move = nullptr;
 	bool bottom_panel_updating = false;
 
 	Tree *disk_changed_list = nullptr;
@@ -697,6 +699,7 @@ private:
 
 	void _bottom_panel_switch(bool p_enable, int p_idx);
 	void _bottom_panel_raise_toggled(bool);
+	void _bottom_panel_move_pressed();
 
 	void _begin_first_scan();
 

--- a/editor/icons/ExpandBottomDockRight.svg
+++ b/editor/icons/ExpandBottomDockRight.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="M4.5 12 8 15v-2h5v-2H8V9zm0-8L8 7V5h5V3H8V1zM1 15V1h2v14z" fill="#e0e0e0"/></svg>


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/53643.

This lets people make better use of their display if it's wide enough.

There's a shortcut to toggle the bottom panel's position: <kbd>Shift + F10</kbd>. Let me know if another combination would be more appropriate.

This is a WIP and needs some changes before it can be merged:

- [ ] Disallow moving the bottom panel to the right side if the editor window isn't wide enough. In my experience, this feature is only usable if the window is at least 1800 pixels wide. In practice, this means you need a 1920×1080 monitor at least. Ultrawide monitors are a particularly good fit for this feature.
- [ ] Figure out what to do when no subpanel is displayed while the panel is on the right. Right now, the panel can still be resized but it just wastes space. Should we forbid closing a subpanel while the panel is moved to the right?
- [ ] Collapse the splitter to make it non-draggable when moving the bottom panel back to the bottom while it's collapsed.
  - This can also be solved by not allowing the user to close a subpanel while the panel is moved to the right (see above).
- [ ] Save the setting and make it persist across editor restarts.
- [x] ~~Change the button's tooltip after moving the bottom panel to the right.~~
  - Renamed the tooltip to "Toggle Bottom Panel Position" to make it more logical in the editor shortcuts dialog.
- [ ] Use an icon that better represents moving the panel? Right now, I just use a generic arrow icon.

We could also investigate making the panel movable to the left, but I think this is better left for a future pull request.

This partially addresses #26229 (and probably a few other issues I can't find right now).

## Preview

![Screenshot_20230327_175722 webp](https://user-images.githubusercontent.com/180032/227996782-1e478b63-3879-4b7e-ad78-8621bb74bf2d.png)