### PR TITLE
Read and write exported infs/nans correctly (#35388)

### DIFF
--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -512,6 +512,10 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = false;
 		else if (id == "null" || id == "nil")
 			value = Variant();
+		else if (id == "inf")
+			value = Math_INF;
+		else if (id == "nan")
+			value = Math_NAN;
 		else if (id == "Vector2") {
 
 			Vector<float> args;
@@ -1586,8 +1590,10 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 		case Variant::REAL: {
 
 			String s = rtosfix(p_variant.operator real_t());
-			if (s.find(".") == -1 && s.find("e") == -1)
-				s += ".0";
+			if (s != "inf" && s != "nan") {
+				if (s.find(".") == -1 && s.find("e") == -1)
+					s += ".0";
+			}
 			p_store_string_func(p_store_string_ud, s);
 		} break;
 		case Variant::STRING: {


### PR DESCRIPTION
Exported `INF` and `NAN` values are not written correctly to the `TSCN` files, and consequently, cannot be read correctly. The fix is to check if a number is an `INF` or a `NAN` before writing it, and similarly before reading it.

This fixes #35388.