### PR TITLE
Fixes broken scene created via New Resource

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1782,6 +1782,14 @@ void FileSystemDock::_resource_created() const {
 	Resource *r = Object::cast_to<Resource>(c);
 	ERR_FAIL_COND(!r);
 
+	PackedScene *scene = Object::cast_to<PackedScene>(r);
+	if (scene) {
+		Node *node = memnew(Node);
+		node->set_name("Node");
+		scene->pack(node);
+		memdelete(node);
+	}
+
 	REF res(r);
 	editor->push_item(c);
 


### PR DESCRIPTION
This fixes #23705

A scene without root node can't be saved. It will also fail with "Unexpected end of file" when trying to open an TSCN file without any node in it.

This adds a `Node` node to the newly created `PackedScene` resource, so we can open the TSCN file.