### PR TITLE
Use left/right arrow to move cursor when unselecting in LineEdit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -358,11 +358,20 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 					FALLTHROUGH;
 				}
 				case KEY_LEFT: {
-
 #ifndef APPLE_STYLE_KEYS
-					if (!k->get_alt())
+					if (!k->get_alt()) {
 #endif
+						if (selection.enabled && !k->get_shift()) {
+							set_cursor_position(selection.begin);
+							deselect();
+							handled = true;
+							break;
+						}
+
 						shift_selection_check_pre(k->get_shift());
+#ifndef APPLE_STYLE_KEYS
+					}
+#endif
 
 #ifdef APPLE_STYLE_KEYS
 					if (k->get_command()) {
@@ -405,8 +414,20 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 					FALLTHROUGH;
 				}
 				case KEY_RIGHT: {
+#ifndef APPLE_STYLE_KEYS
+					if (!k->get_alt()) {
+#endif
+						if (selection.enabled && !k->get_shift()) {
+							set_cursor_position(selection.end);
+							deselect();
+							handled = true;
+							break;
+						}
 
-					shift_selection_check_pre(k->get_shift());
+						shift_selection_check_pre(k->get_shift());
+#ifndef APPLE_STYLE_KEYS
+					}
+#endif
 
 #ifdef APPLE_STYLE_KEYS
 					if (k->get_command()) {


### PR DESCRIPTION
-- this behavior matches TextEdit and other GUIs out there
-- my main use case was for the rename dialog (the filename portion is selected by
default, and usually, I want to change the end of the name, not the beginning)
