### PR TITLE
Improve the low processor mode sleep precision

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2258,25 +2258,37 @@ bool Main::iteration() {
 		return exit;
 	}
 
-	if (OS::get_singleton()->is_in_low_processor_usage_mode() || !DisplayServer::get_singleton()->can_any_window_draw()) {
-		OS::get_singleton()->delay_usec(OS::get_singleton()->get_low_processor_usage_mode_sleep_usec()); //apply some delay to force idle time
-	} else {
-		uint32_t frame_delay = Engine::get_singleton()->get_frame_delay();
-		if (frame_delay) {
-			OS::get_singleton()->delay_usec(Engine::get_singleton()->get_frame_delay() * 1000);
-		}
+	const uint32_t frame_delay = Engine::get_singleton()->get_frame_delay();
+	if (frame_delay) {
+		// Add fixed frame delay to decrease CPU/GPU usage. This doesn't take
+		// the actual frame time into account.
+		// Due to the high fluctuation of the actual sleep duration, it's not recommended
+		// to use this as a FPS limiter.
+		OS::get_singleton()->delay_usec(frame_delay * 1000);
 	}
 
-	int target_fps = Engine::get_singleton()->get_target_fps();
+	// Add a dynamic frame delay to decrease CPU/GPU usage. This takes the
+	// previous frame time into account for a smoother result.
+	uint64_t dynamic_delay = 0;
+	if (OS::get_singleton()->is_in_low_processor_usage_mode() || !DisplayServer::get_singleton()->window_can_draw()) {
+		dynamic_delay = OS::get_singleton()->get_low_processor_usage_mode_sleep_usec();
+	}
+	const int target_fps = Engine::get_singleton()->get_target_fps();
 	if (target_fps > 0 && !Engine::get_singleton()->is_editor_hint()) {
-		uint64_t time_step = 1000000L / target_fps;
-		target_ticks += time_step;
+		// Override the low processor usage mode sleep delay if the target FPS is lower.
+		dynamic_delay = MAX(dynamic_delay, (uint64_t)(1000000 / target_fps));
+	}
+
+	if (dynamic_delay > 0) {
+		target_ticks += dynamic_delay;
 		uint64_t current_ticks = OS::get_singleton()->get_ticks_usec();
+
 		if (current_ticks < target_ticks) {
 			OS::get_singleton()->delay_usec(target_ticks - current_ticks);
 		}
+
 		current_ticks = OS::get_singleton()->get_ticks_usec();
-		target_ticks = MIN(MAX(target_ticks, current_ticks - time_step), current_ticks + time_step);
+		target_ticks = MIN(MAX(target_ticks, current_ticks - dynamic_delay), current_ticks + dynamic_delay);
 	}
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
**Windows 64-bit editor build for testing:** https://0x0.st/i-iB.zip (link expires in late 2020)

The Low Processor Usage Mode Sleep Usec setting is now used as a FPS limiter rather than a constant sleep duration.

This will increase CPU/GPU usage slightly due to the higher effective FPS, but the increase in overall smoothness is worth it. When used in the editor, it will now really cap at ~145 FPS (as it's supposed to) instead of ~130 FPS.

If both Force Fps and Low Processor Usage Mode settings are enabled in the project settings, only the setting that causes the highest sleep duration will be retained.

@Zylann Please test this :slightly_smiling_face:

This closes #11030.