### PR TITLE
Tweak the "Changes may be lost!" text color to match the icon's color

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -337,6 +337,7 @@ void InspectorDock::_notification(int p_what) {
 			history_menu->set_icon(get_icon("History", "EditorIcons"));
 			object_menu->set_icon(get_icon("Tools", "EditorIcons"));
 			warning->set_icon(get_icon("NodeWarning", "EditorIcons"));
+			warning->add_color_override("font_color", get_color("warning_color", "Editor"));
 		} break;
 	}
 }
@@ -584,6 +585,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	add_child(warning);
 	warning->set_text(TTR("Changes may be lost!"));
 	warning->set_icon(get_icon("NodeWarning", "EditorIcons"));
+	warning->add_color_override("font_color", get_color("warning_color", "Editor"));
 	warning->set_clip_text(true);
 	warning->hide();
 	warning->connect("pressed", this, "_warning_pressed");


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/49642.

## Preview

![Changes may be lost!](https://user-images.githubusercontent.com/180032/74110205-ce7ba080-4b8a-11ea-8920-a87944cb955d.png)
