### PR TITLE
Fixes range hint for default_float_step

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5798,7 +5798,7 @@ EditorNode::EditorNode() {
 	EDITOR_DEF_RST("interface/scene_tabs/show_thumbnail_on_hover", true);
 	EDITOR_DEF_RST("interface/inspector/capitalize_properties", true);
 	EDITOR_DEF_RST("interface/inspector/default_float_step", 0.001);
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::REAL, "interface/inspector/default_float_step", PROPERTY_HINT_EXP_RANGE, "0,1,0"));
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::REAL, "interface/inspector/default_float_step", PROPERTY_HINT_RANGE, "0,1,0"));
 	EDITOR_DEF_RST("interface/inspector/disable_folding", false);
 	EDITOR_DEF_RST("interface/inspector/auto_unfold_foreign_scenes", true);
 	EDITOR_DEF("interface/inspector/horizontal_vector2_editing", false);


### PR DESCRIPTION
Uses linear range hint instead of exponential range hint for the property `interface/inspector/default_float_step`.

Currently, the slider is broken. Dragging always sets the value to 1, and the grabber is then missing.
![demo](https://user-images.githubusercontent.com/372476/74120073-091e2100-4bfd-11ea-9ea5-38fb596af6db.gif)

This is because for `log(0)` is hardcoded to be 0, and `log(1)` is 0. So both `exp_min` and `exp_max` are zero, resulting in a division-by-zero on line 183, making the return value `NAN`:
https://github.com/godotengine/godot/blob/8cb2de524373566bd0faffe1c70e9a201b20e6be/scene/gui/range.cpp#L178-L183

A `git blame` shows that the hardcoded zero is introduced to solve some other problem, and there are indeed some existing properties whose exp-range-hint's min value is zero.

Does the min value of this property have to be zero? Yes, zero disables stepping. However, even if I change the min value of this property to 0.001, dragging the slider will generate values like 0.122342347, which seems unreasonable for a step value.

So I just changed the exponential range hint to linear.