### PR TITLE
doc: Improve distance_fade documentation

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -175,10 +175,12 @@
 			If [code]true[/code], the object receives no shadow that would otherwise be cast onto it.
 		</member>
 		<member name="distance_fade_max_distance" type="float" setter="set_distance_fade_max_distance" getter="get_distance_fade_max_distance">
-			Distance at which the object fades fully and is no longer visible.
+			Distance at which the object appears fully opaque.
+			[b]Note:[/b] If [code]distance_fade_max_distance[/code] is less than [code]distance_fade_min_distance[/code], the behavior will be reversed. The object will start to fade away at [code]distance_fade_max_distance[/code] and will fully disappear once it reaches [code]distance_fade_min_distance[/code].
 		</member>
 		<member name="distance_fade_min_distance" type="float" setter="set_distance_fade_min_distance" getter="get_distance_fade_min_distance">
-			Distance at which the object starts to fade. If the object is less than this distance away it will appear normal.
+			Distance at which the object starts to become visible. If the object is less than this distance away, it will be invisible.
+			[b]Note:[/b] If [code]distance_fade_min_distance[/code] is greater than [code]distance_fade_max_distance[/code], the behavior will be reversed. The object will start to fade away at [code]distance_fade_max_distance[/code] and will fully disappear once it reaches [code]distance_fade_min_distance[/code].
 		</member>
 		<member name="distance_fade_mode" type="int" setter="set_distance_fade" getter="get_distance_fade" enum="BaseMaterial3D.DistanceFadeMode" default="0">
 			Specifies which type of fade to use. Can be any of the [enum DistanceFadeMode]s.


### PR DESCRIPTION
Changed the documentation of distance_fade_max_distance and distance_fade_min_distance to be consistent with the behavior of the code as well as the user documentation.  

Also noted the behavior of swapping max_distance and min_distance (where max_distance < min_distance).   

Fixes godotengine#36051