### PR TITLE
Blank/Comment lines at the beginning are considered "unsafe" #20418

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -450,13 +450,13 @@ void GDScriptTokenizerText::_make_error(const String &p_error) {
 	tk_rb_pos = (tk_rb_pos + 1) % TK_RB_SIZE;
 }
 
-void GDScriptTokenizerText::_make_newline(int p_indentation, int p_tabs) {
+void GDScriptTokenizerText::_make_newline(int p_line, int p_column, int p_indentation, int p_tabs) {
 
 	TokenData &tk = tk_rb[tk_rb_pos];
 	tk.type = TK_NEWLINE;
 	tk.constant = Vector2(p_indentation, p_tabs);
-	tk.line = line;
-	tk.col = column;
+	tk.line = p_line;
+	tk.col = p_column;
 	tk_rb_pos = (tk_rb_pos + 1) % TK_RB_SIZE;
 }
 
@@ -541,6 +541,8 @@ void GDScriptTokenizerText::_advance() {
 				FALLTHROUGH;
 			}
 			case '\n': {
+				const int newline_line = line;
+				const int newline_column = column;
 				line++;
 				INCPOS(1);
 				bool used_spaces = false;
@@ -563,7 +565,7 @@ void GDScriptTokenizerText::_advance() {
 					}
 				}
 
-				_make_newline(i, tabs);
+				_make_newline(newline_line, newline_column, i, tabs);
 				return;
 			}
 			case '/': {

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -206,7 +206,7 @@ class GDScriptTokenizerText : public GDScriptTokenizer {
 	};
 
 	void _make_token(Token p_type);
-	void _make_newline(int p_indentation = 0, int p_tabs = 0);
+	void _make_newline(int p_line, int p_column, int p_indentation = 0, int p_tabs = 0);
 	void _make_identifier(const StringName &p_identifier);
 	void _make_built_in_func(GDScriptFunctions::Function p_func);
 	void _make_constant(const Variant &p_constant);


### PR DESCRIPTION
GDScriptTokenizerText::_advance when detecting new line would first increment line number, parse leading spaces and tabs in new line and only then whould create new line token with incorrect data. I've added code to save correct line and column and pass it to _make_newline. This seems to fix #20418.