### PR TITLE
Fix #36047 - No deselect on already selected row when selection mode set to SELECT_ROW

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1594,7 +1594,10 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 
 			} else if (c.selected) {
 
-				c.selected = false;
+				if (p_selected != p_current) {
+					//Deselect other rows
+					c.selected = false;
+				}
 				//p_current->deselected_signal.call(p_col);
 			}
 		} else if (select_mode == SELECT_SINGLE || select_mode == SELECT_MULTI) {


### PR DESCRIPTION
Fixes #36047
I checked and it worked, it no longer de-selects an already selected row if the SELECT_MODE is set to SELECT_ROW.
How can I test this? I manually tested this but I think there are some edge cases or something.