### PR TITLE
Add audio distance and attenuation visualization to AudioStreamPlayer2D

### DIFF
--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -63,6 +63,12 @@
 		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="@&quot;Master&quot;">
 			Bus on which this audio is playing.
 		</member>
+		<member name="editor_draw_attenuation" type="float" setter="set_attenuation_drawing_enabled" getter="get_attenuation_drawing_enabled" default="false">
+			If [code]true[/code], shows a visual representation of the player's [member attenuation]. Editor only, and [member editor_draw_distance] must also be enabled.
+		</member>
+		<member name="editor_draw_distance" type="float" setter="set_distance_drawing_enabled" getter="get_distance_drawing_enabled" default="true">
+			If [code]true[/code], shows a visual representation of the player's [member max_distance]. Editor only.
+		</member>
 		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="2000.0">
 			Maximum distance from which audio is still hearable.
 		</member>

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -142,13 +142,13 @@
 			[b]Note:[/b] Used to set the initial vertical drag offset; determine the current offset; or force the current offset. It's not automatically updated when the vertical drag margin is enabled or the drag margins are changed.
 		</member>
 		<member name="editor_draw_drag_margin" type="bool" setter="set_margin_drawing_enabled" getter="is_margin_drawing_enabled" default="false">
-			If [code]true[/code], draws the camera's drag margin rectangle in the editor.
+			If [code]true[/code], draws the camera's drag margin rectangle. Editor only.
 		</member>
 		<member name="editor_draw_limits" type="bool" setter="set_limit_drawing_enabled" getter="is_limit_drawing_enabled" default="false">
-			If [code]true[/code], draws the camera's limits rectangle in the editor.
+			If [code]true[/code], draws the camera's limits rectangle. Editor only.
 		</member>
 		<member name="editor_draw_screen" type="bool" setter="set_screen_drawing_enabled" getter="is_screen_drawing_enabled" default="true">
-			If [code]true[/code], draws the camera's screen rectangle in the editor.
+			If [code]true[/code], draws the camera's screen rectangle. Editor only.
 		</member>
 		<member name="limit_bottom" type="int" setter="set_limit" getter="get_limit" default="10000000">
 			Bottom scroll limit in pixels. The camera stops moving when reaching this value.

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -89,6 +89,9 @@ private:
 	float max_distance = 2000.0;
 	float attenuation = 1.0;
 
+	bool distance_drawing_enabled = true;
+	bool attenuation_drawing_enabled = false;
+
 protected:
 	void _validate_property(PropertyInfo &property) const override;
 	void _notification(int p_what);
@@ -129,6 +132,12 @@ public:
 	bool get_stream_paused() const;
 
 	Ref<AudioStreamPlayback> get_stream_playback();
+
+	void set_distance_drawing_enabled(bool p_enable);
+	bool is_distance_drawing_enabled() const;
+
+	void set_attenuation_drawing_enabled(bool p_enable);
+	bool is_attenuation_drawing_enabled() const;
 
 	AudioStreamPlayer2D();
 	~AudioStreamPlayer2D();


### PR DESCRIPTION
Idea shameless stolen from here: https://www.reddit.com/r/godot/comments/ewn1wv/audiostreamplayer2d_visualization/

This commit adds visual representations of the `AudioStreamPlayer2D`'s distance and attenuation (note that the attenuation drawing is disabled by default, as it can make the scene too noisy if there are multiple players):
![Peek 2020-02-11 09-40](https://user-images.githubusercontent.com/30739239/74238378-9466e780-4ccd-11ea-8f58-35bf4bd86f0a.gif)

As this adds documentation to the new members, the leftovers of `AnimationTreePlayer`'s docs have been removed automatically in process.