### PR TITLE
Fix assign instead of comparison in image_save_tinyexr.cpp.

### DIFF
--- a/modules/tinyexr/image_saver_tinyexr.cpp
+++ b/modules/tinyexr/image_saver_tinyexr.cpp
@@ -182,7 +182,7 @@ Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) 
 	int target_pixel_type_size = get_pixel_type_size(target_pixel_type);
 	ERR_FAIL_COND_V(target_pixel_type_size < 0, ERR_UNAVAILABLE);
 	SrcPixelType src_pixel_type = get_source_pixel_type(format);
-	ERR_FAIL_COND_V(src_pixel_type = SRC_UNSUPPORTED, ERR_UNAVAILABLE);
+	ERR_FAIL_COND_V(src_pixel_type == SRC_UNSUPPORTED, ERR_UNAVAILABLE);
 	const int pixel_count = p_img->get_width() * p_img->get_height();
 
 	const int *channel_mapping = channel_mappings[channel_count - 1];


### PR DESCRIPTION
As identified by @Calinou [here](https://github.com/godotengine/godot/commit/a3b938d6dc9c74c3de67ad2c52f69572367a8f11#r37233122):

https://github.com/godotengine/godot/blob/8c73e813134001e575b6f59e3b0100471c007410/modules/tinyexr/image_saver_tinyexr.cpp#L185
`src_pixel_type` should be compared to not assigned `SRC_UNSUPPORTED`.