### PR TITLE
Fixes friend declaration tag mismatch

### DIFF
--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -113,7 +113,7 @@ public:
 		~InstanceDependency();
 
 	private:
-		friend class InstanceBase;
+		friend struct InstanceBase;
 		Map<InstanceBase *, uint32_t> instances;
 	};
 


### PR DESCRIPTION
`InstanceBase` is a `struct`, but declared as `class`.

```
./servers/visual/rasterizer.h:116:10: warning: class 'InstanceBase' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI
      [-Wmismatched-tags]
                friend class InstanceBase;
                       ^
./servers/visual/rasterizer.h:106:9: note: previous use is here
        struct InstanceBase;
               ^
```