### PR TITLE
Remove deprecated PacketPeer allow_object_decoding

### DIFF
--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -625,7 +625,7 @@ Error MultiplayerAPI::_encode_and_compress_variant(const Variant &p_variant, uin
 		} break;
 		default:
 			// Any other case is not yet compressed.
-			Error err = encode_variant(p_variant, r_buffer, r_len, allow_object_decoding || network_peer->is_object_decoding_allowed());
+			Error err = encode_variant(p_variant, r_buffer, r_len, allow_object_decoding);
 			if (err != OK)
 				return err;
 			if (r_buffer) {
@@ -691,7 +691,7 @@ Error MultiplayerAPI::_decode_and_decompress_variant(Variant &r_variant, const u
 			}
 		} break;
 		default:
-			Error err = decode_variant(r_variant, p_buffer, p_len, r_len, allow_object_decoding || network_peer->is_object_decoding_allowed());
+			Error err = decode_variant(r_variant, p_buffer, p_len, r_len, allow_object_decoding);
 			if (err != OK)
 				return err;
 	}

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -37,18 +37,7 @@
 
 PacketPeer::PacketPeer() :
 		last_get_error(OK),
-		allow_object_decoding(false),
 		encode_buffer_max_size(8 * 1024 * 1024) {
-}
-
-void PacketPeer::set_allow_object_decoding(bool p_enable) {
-
-	allow_object_decoding = p_enable;
-}
-
-bool PacketPeer::is_object_decoding_allowed() const {
-
-	return allow_object_decoding;
 }
 
 void PacketPeer::set_encode_buffer_max_size(int p_max_size) {
@@ -101,13 +90,13 @@ Error PacketPeer::get_var(Variant &r_variant, bool p_allow_objects) {
 	if (err)
 		return err;
 
-	return decode_variant(r_variant, buffer, buffer_size, NULL, p_allow_objects || allow_object_decoding);
+	return decode_variant(r_variant, buffer, buffer_size, NULL, p_allow_objects);
 }
 
 Error PacketPeer::put_var(const Variant &p_packet, bool p_full_objects) {
 
 	int len;
-	Error err = encode_variant(p_packet, NULL, len, p_full_objects || allow_object_decoding); // compute len first
+	Error err = encode_variant(p_packet, NULL, len, p_full_objects); // compute len first
 	if (err)
 		return err;
 
@@ -122,7 +111,7 @@ Error PacketPeer::put_var(const Variant &p_packet, bool p_full_objects) {
 	}
 
 	PoolVector<uint8_t>::Write w = encode_buffer.write();
-	err = encode_variant(p_packet, w.ptr(), len, p_full_objects || allow_object_decoding);
+	err = encode_variant(p_packet, w.ptr(), len, p_full_objects);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Error when trying to encode Variant.");
 
 	return put_packet(w.ptr(), len);
@@ -160,13 +149,10 @@ void PacketPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_packet_error"), &PacketPeer::_get_packet_error);
 	ClassDB::bind_method(D_METHOD("get_available_packet_count"), &PacketPeer::get_available_packet_count);
 
-	ClassDB::bind_method(D_METHOD("set_allow_object_decoding", "enable"), &PacketPeer::set_allow_object_decoding);
-	ClassDB::bind_method(D_METHOD("is_object_decoding_allowed"), &PacketPeer::is_object_decoding_allowed);
 	ClassDB::bind_method(D_METHOD("get_encode_buffer_max_size"), &PacketPeer::get_encode_buffer_max_size);
 	ClassDB::bind_method(D_METHOD("set_encode_buffer_max_size", "max_size"), &PacketPeer::set_encode_buffer_max_size);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "encode_buffer_max_size"), "set_encode_buffer_max_size", "get_encode_buffer_max_size");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_object_decoding"), "set_allow_object_decoding", "is_object_decoding_allowed");
 };
 
 /***************/

--- a/core/io/packet_peer.h
+++ b/core/io/packet_peer.h
@@ -49,8 +49,6 @@ class PacketPeer : public Reference {
 
 	mutable Error last_get_error;
 
-	bool allow_object_decoding;
-
 	int encode_buffer_max_size;
 	PoolVector<uint8_t> encode_buffer;
 
@@ -68,9 +66,6 @@ public:
 
 	virtual Error get_var(Variant &r_variant, bool p_allow_objects = false);
 	virtual Error put_var(const Variant &p_packet, bool p_full_objects = false);
-
-	void set_allow_object_decoding(bool p_enable);
-	bool is_object_decoding_allowed() const;
 
 	void set_encode_buffer_max_size(int p_max_size);
 	int get_encode_buffer_max_size() const;

--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -88,7 +88,7 @@
 	</methods>
 	<members>
 		<member name="allow_object_decoding" type="bool" setter="set_allow_object_decoding" getter="is_object_decoding_allowed" default="false">
-			If [code]true[/code] (or if the [member network_peer] has [member PacketPeer.allow_object_decoding] set to [code]true[/code]), the MultiplayerAPI will allow encoding and decoding of object during RPCs/RSETs.
+			If [code]true[/code], the MultiplayerAPI will allow encoding and decoding of object during RPCs/RSETs.
 			[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 		</member>
 		<member name="network_peer" type="NetworkedMultiplayerPeer" setter="set_network_peer" getter="get_network_peer">

--- a/doc/classes/PacketPeer.xml
+++ b/doc/classes/PacketPeer.xml
@@ -36,7 +36,7 @@
 			<argument index="0" name="allow_objects" type="bool" default="false">
 			</argument>
 			<description>
-				Gets a Variant. If [code]allow_objects[/code] (or [member allow_object_decoding]) is [code]true[/code], decoding objects is allowed.
+				Gets a Variant. If [code]allow_objects[/code] is [code]true[/code], decoding objects is allowed.
 				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 			</description>
 		</method>
@@ -57,16 +57,11 @@
 			<argument index="1" name="full_objects" type="bool" default="false">
 			</argument>
 			<description>
-				Sends a [Variant] as a packet. If [code]full_objects[/code] (or [member allow_object_decoding]) is [code]true[/code], encoding objects is allowed (and can potentially include code).
+				Sends a [Variant] as a packet. If [code]full_objects[/code] is [code]true[/code], encoding objects is allowed (and can potentially include code).
 			</description>
 		</method>
 	</methods>
 	<members>
-		<member name="allow_object_decoding" type="bool" setter="set_allow_object_decoding" getter="is_object_decoding_allowed" default="false">
-			[i]Deprecated.[/i] Use [code]get_var[/code] and [code]put_var[/code] parameters instead.
-			If [code]true[/code], the PacketPeer will allow encoding and decoding of object via [method get_var] and [method put_var].
-			[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
-		</member>
 		<member name="encode_buffer_max_size" type="int" setter="set_encode_buffer_max_size" getter="get_encode_buffer_max_size" default="8388608">
 			Maximum buffer size allowed when encoding [Variant]s. Raise this value to support heavier memory allocations.
 			The [method put_var] method allocates memory on the stack, and the buffer used will grow automatically to the closest power of two to match the size of the [Variant]. If the [Variant] is bigger than [code]encode_buffer_max_size[/code], the method will error out with [constant ERR_OUT_OF_MEMORY].


### PR DESCRIPTION
It was added for 3.2 in #27485 to preserve backwards compatibility,
but we can now remove it.

It is still needed in MultiplayerAPI as it's the only way to control
it for the internal put_var calls.