### PR TITLE
Added high-end (Vulkan) label to some functions in visual shader

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5356,7 +5356,7 @@ void EditorNode::_update_video_driver_color() {
 	} else if (video_driver->get_text() == "GLES3") {
 		video_driver->add_color_override("font_color", Color::hex(0xa5557dff));
 	} else if (video_driver->get_text() == "Vulkan") {
-		video_driver->add_color_override("font_color", Color::hex(0xad1128ff));
+		video_driver->add_color_override("font_color", theme_base->get_color("vulkan_color", "Editor"));
 	}
 }
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -409,6 +409,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("error_color", "Editor", error_color);
 	theme->set_color("property_color", "Editor", property_color);
 
+	if (!dark_theme) {
+		theme->set_color("vulkan_color", "Editor", Color::hex(0xad1128ff));
+	} else {
+		theme->set_color("vulkan_color", "Editor", Color(1.0, 0.0, 0.0));
+	}
 	const int thumb_size = EDITOR_GET("filesystem/file_dialog/thumbnail_size");
 	theme->set_constant("scale", "Editor", EDSCALE);
 	theme->set_constant("thumb_size", "Editor", thumb_size);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -284,11 +284,7 @@ void VisualShaderEditor::update_custom_nodes() {
 }
 
 String VisualShaderEditor::_get_description(int p_idx) {
-	if (add_options[p_idx].highend) {
-		return TTR("(GLES3 only)") + " " + add_options[p_idx].description; // TODO: change it to (Vulkan Only) when its ready
-	} else {
-		return add_options[p_idx].description;
-	}
+	return add_options[p_idx].description;
 }
 
 void VisualShaderEditor::_update_options_menu() {
@@ -1680,6 +1676,8 @@ void VisualShaderEditor::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
 
+		highend_label->set_modulate(get_color("vulkan_color", "Editor"));
+
 		error_panel->add_style_override("panel", get_stylebox("bg", "Tree"));
 		error_label->add_color_override("font_color", get_color("error_color", "Editor"));
 
@@ -2037,8 +2035,10 @@ void VisualShaderEditor::_member_selected() {
 
 	if (item != NULL && item->has_meta("id")) {
 		members_dialog->get_ok()->set_disabled(false);
+		highend_label->set_visible(add_options[item->get_meta("id")].highend);
 		node_desc->set_text(_get_description(item->get_meta("id")));
 	} else {
+		highend_label->set_visible(false);
 		members_dialog->get_ok()->set_disabled(true);
 		node_desc->set_text("");
 	}
@@ -2425,9 +2425,21 @@ VisualShaderEditor::VisualShaderEditor() {
 	members->connect("item_selected", this, "_member_selected");
 	members->connect("nothing_selected", this, "_member_unselected");
 
+	HBoxContainer *desc_hbox = memnew(HBoxContainer);
+	members_vb->add_child(desc_hbox);
+
 	Label *desc_label = memnew(Label);
-	members_vb->add_child(desc_label);
+	desc_hbox->add_child(desc_label);
 	desc_label->set_text(TTR("Description:"));
+
+	desc_hbox->add_spacer();
+
+	highend_label = memnew(Label);
+	desc_hbox->add_child(highend_label);
+	highend_label->set_visible(false);
+	highend_label->set_text("Vulkan");
+	highend_label->set_mouse_filter(Control::MOUSE_FILTER_STOP);
+	highend_label->set_tooltip(TTR("High-end node"));
 
 	node_desc = memnew(RichTextLabel);
 	members_vb->add_child(node_desc);

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -94,6 +94,7 @@ class VisualShaderEditor : public VBoxContainer {
 	AcceptDialog *alert;
 	LineEdit *node_filter;
 	RichTextLabel *node_desc;
+	Label *highend_label;
 
 	void _tools_menu_option(int p_idx);
 	void _show_members_dialog(bool at_mouse_pos);


### PR DESCRIPTION
Removed "(GLES3 only)" text and added a label with tooltip to description:

![image](https://user-images.githubusercontent.com/3036176/74350660-14bd4380-4dc7-11ea-80ee-c13fed0f92c6.png)

Note: currently color seems bugged but it's the same as the top right label.