### PR TITLE
Added possibility to send bytes through rpc.

### DIFF
--- a/core/io/multiplayer_api.h
+++ b/core/io/multiplayer_api.h
@@ -48,6 +48,39 @@ public:
 		int outgoing_rset;
 	};
 
+	enum NetworkCommands {
+		NETWORK_COMMAND_REMOTE_CALL = 0,
+		NETWORK_COMMAND_REMOTE_CALL_RAW,
+		NETWORK_COMMAND_REMOTE_SET,
+		NETWORK_COMMAND_SIMPLIFY_PATH,
+		NETWORK_COMMAND_CONFIRM_PATH,
+		NETWORK_COMMAND_RAW,
+	};
+
+	enum NetworkNodeIdCompression {
+		NETWORK_NODE_ID_COMPRESSION_8 = 0,
+		NETWORK_NODE_ID_COMPRESSION_16,
+		NETWORK_NODE_ID_COMPRESSION_32,
+	};
+
+	enum NetworkNameIdCompression {
+		NETWORK_NAME_ID_COMPRESSION_8 = 0,
+		NETWORK_NAME_ID_COMPRESSION_16,
+	};
+
+	enum RPCMode {
+
+		RPC_MODE_DISABLED, // No rpc for this method, calls to this will be blocked (default)
+		RPC_MODE_REMOTE, // Using rpc() on it will call method / set property in all remote peers
+		RPC_MODE_MASTER, // Using rpc() on it will call method on wherever the master is, be it local or remote
+		RPC_MODE_PUPPET, // Using rpc() on it will call method for all puppets
+		RPC_MODE_SLAVE = RPC_MODE_PUPPET, // Deprecated, same as puppet
+		RPC_MODE_REMOTESYNC, // Using rpc() on it will call method / set property in all remote peers and locally
+		RPC_MODE_SYNC = RPC_MODE_REMOTESYNC, // Deprecated. Same as RPC_MODE_REMOTESYNC
+		RPC_MODE_MASTERSYNC, // Using rpc() on it will call method / set property in the master peer and locally
+		RPC_MODE_PUPPETSYNC, // Using rpc() on it will call method / set property in all puppets peers and locally
+	};
+
 private:
 	//path sent caches
 	struct PathSentCache {
@@ -99,49 +132,17 @@ protected:
 	void _process_simplify_path(int p_from, const uint8_t *p_packet, int p_packet_len);
 	void _process_confirm_path(int p_from, const uint8_t *p_packet, int p_packet_len);
 	Node *_process_get_node(int p_from, const uint8_t *p_packet, uint32_t p_node_target, int p_packet_len);
-	void _process_rpc(Node *p_node, const uint16_t p_rpc_method_id, int p_from, const uint8_t *p_packet, int p_packet_len, int p_offset);
+	void _process_rpc(Node *p_node, const uint16_t p_rpc_method_id, int p_from, const uint8_t *p_packet, int p_packet_len, int p_offset, bool p_raw);
 	void _process_rset(Node *p_node, const uint16_t p_rpc_property_id, int p_from, const uint8_t *p_packet, int p_packet_len, int p_offset);
 	void _process_raw(int p_from, const uint8_t *p_packet, int p_packet_len);
 
-	void _send_rpc(Node *p_from, int p_to, bool p_unreliable, bool p_set, const StringName &p_name, const Variant **p_arg, int p_argcount);
+	void _send_rpc(Node *p_from, int p_to, bool p_unreliable, NetworkCommands p_remote_type, const StringName &p_name, const Variant **p_arg, int p_argcount, uint32_t p_raw_data_size = 0);
 	bool _send_confirm_path(Node *p_node, NodePath p_path, PathSentCache *psc, int p_target);
 
 	Error _encode_and_compress_variant(const Variant &p_variant, uint8_t *p_buffer, int &r_len);
 	Error _decode_and_decompress_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len);
 
 public:
-	enum NetworkCommands {
-		NETWORK_COMMAND_REMOTE_CALL = 0,
-		NETWORK_COMMAND_REMOTE_SET,
-		NETWORK_COMMAND_SIMPLIFY_PATH,
-		NETWORK_COMMAND_CONFIRM_PATH,
-		NETWORK_COMMAND_RAW,
-	};
-
-	enum NetworkNodeIdCompression {
-		NETWORK_NODE_ID_COMPRESSION_8 = 0,
-		NETWORK_NODE_ID_COMPRESSION_16,
-		NETWORK_NODE_ID_COMPRESSION_32,
-	};
-
-	enum NetworkNameIdCompression {
-		NETWORK_NAME_ID_COMPRESSION_8 = 0,
-		NETWORK_NAME_ID_COMPRESSION_16,
-	};
-
-	enum RPCMode {
-
-		RPC_MODE_DISABLED, // No rpc for this method, calls to this will be blocked (default)
-		RPC_MODE_REMOTE, // Using rpc() on it will call method / set property in all remote peers
-		RPC_MODE_MASTER, // Using rpc() on it will call method on wherever the master is, be it local or remote
-		RPC_MODE_PUPPET, // Using rpc() on it will call method for all puppets
-		RPC_MODE_SLAVE = RPC_MODE_PUPPET, // Deprecated, same as puppet
-		RPC_MODE_REMOTESYNC, // Using rpc() on it will call method / set property in all remote peers and locally
-		RPC_MODE_SYNC = RPC_MODE_REMOTESYNC, // Deprecated. Same as RPC_MODE_REMOTESYNC
-		RPC_MODE_MASTERSYNC, // Using rpc() on it will call method / set property in the master peer and locally
-		RPC_MODE_PUPPETSYNC, // Using rpc() on it will call method / set property in all puppets peers and locally
-	};
-
 	void poll();
 	void clear();
 	void set_root_node(Node *p_node);
@@ -149,6 +150,8 @@ public:
 	Ref<NetworkedMultiplayerPeer> get_network_peer() const;
 	Error send_bytes(PoolVector<uint8_t> p_data, int p_to = NetworkedMultiplayerPeer::TARGET_PEER_BROADCAST, NetworkedMultiplayerPeer::TransferMode p_mode = NetworkedMultiplayerPeer::TRANSFER_MODE_RELIABLE);
 
+	// Called by Node.rpc_send_bytes
+	void rpcp_send_bytes(Node *p_node, int p_peer_id, bool p_unreliable, const StringName &p_method, const PoolByteArray p_bytes, uint32_t p_custom_data_size = 0);
 	// Called by Node.rpc
 	void rpcp(Node *p_node, int p_peer_id, bool p_unreliable, const StringName &p_method, const Variant **p_arg, int p_argcount);
 	// Called by Node.rset

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -660,6 +660,24 @@
 				Sends a [method rpc] to a specific peer identified by [code]peer_id[/code] using an unreliable protocol (see [method NetworkedMultiplayerPeer.set_target_peer]). Returns an empty [Variant].
 			</description>
 		</method>
+		<method name="rpc_send_bytes" qualifiers="vararg">
+			<return type="void">
+			</return>
+			<argument index="0" name="peer_id" type="int">
+			</argument>
+			<argument index="1" name="unreliable" type="bool">
+			</argument>
+			<argument index="2" name="method" type="String">
+			</argument>
+			<argument index="3" name="bytes" type="PoolByteArray">
+			</argument>
+			<argument index="4" name="custom_data_size" type="int" default="0">
+			</argument>
+			<description>
+				Sends bytes to a [method rpc] to a specific peer identified by [code]peer_id[/code]. If [code]unreliable[/code] is [code]true[/code], the unreliable protocol will be used (see [method NetworkedMultiplayerPeer.set_target_peer]). This is a low-level function which doesn't guarantee that the bytes will arrive correctly. You must always check the received bytes on the receiving peer's side carefully.
+				If [code]custom_data_size[/code] is [code]0[/code], the full [PoolByteArray] will be sent to the target peer.
+			</description>
+		</method>
 		<method name="rset">
 			<return type="void">
 			</return>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -700,6 +700,11 @@ Variant Node::_rpc_unreliable_id_bind(const Variant **p_args, int p_argcount, Va
 	return Variant();
 }
 
+void Node::rpcp_send_bytes(int p_peer_id, bool p_unreliable, const StringName &p_method, const PoolByteArray p_bytes, int p_custom_data_size) {
+	ERR_FAIL_COND(!is_inside_tree());
+	get_multiplayer()->rpcp_send_bytes(this, p_peer_id, p_unreliable, p_method, p_bytes, p_custom_data_size);
+}
+
 void Node::rpcp(int p_peer_id, bool p_unreliable, const StringName &p_method, const Variant **p_arg, int p_argcount) {
 	ERR_FAIL_COND(!is_inside_tree());
 	get_multiplayer()->rpcp(this, p_peer_id, p_unreliable, p_method, p_arg, p_argcount);
@@ -2940,6 +2945,8 @@ void Node::_bind_methods() {
 		mi.name = "rpc_unreliable_id";
 		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "rpc_unreliable_id", &Node::_rpc_unreliable_id_bind, mi);
 	}
+
+	ClassDB::bind_method(D_METHOD("rpc_send_bytes", "peer_id", "unreliable", "method", "bytes", "custom_data_size"), &Node::rpcp_send_bytes, DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("rset", "property", "value"), &Node::rset);
 	ClassDB::bind_method(D_METHOD("rset_id", "peer_id", "property", "value"), &Node::rset_id);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -445,6 +445,7 @@ public:
 	void rset_id(int p_peer_id, const StringName &p_property, const Variant &p_value); //remote set call, honors RPCMode
 	void rset_unreliable_id(int p_peer_id, const StringName &p_property, const Variant &p_value); //remote set call, honors RPCMode
 
+	void rpcp_send_bytes(int p_peer_id, bool p_unreliable, const StringName &p_method, const PoolByteArray p_bytes, int p_custom_data_size = 0);
 	void rpcp(int p_peer_id, bool p_unreliable, const StringName &p_method, const Variant **p_arg, int p_argcount);
 	void rsetp(int p_peer_id, bool p_unreliable, const StringName &p_property, const Variant &p_value);
 


### PR DESCRIPTION
I've added the possibility to send bytes through rpc.

The new method `rpc_send_bytes` stands in between a standard `rpc` call and a `send_bytes`, indeed it take the good of both worlds allowing to send just bytes (like the `send_bytes` does) in rpc style (so to a specific node to a specific method).

This is not a replacement of the standard `rpc` method (In normal scenario is desiderable use it.); rather this method is intended for fine tuning of specific features and it require extra attention when used.

__Here a sample code to test it:__
```gdscript
extends Node

func _ready():
	var args = Array(OS.get_cmdline_args())
	while args.size():
		var a = args.pop_front()
		if a == 'c':
			var peer = NetworkedMultiplayerENet.new()
			peer.create_client("localhost", 8092)
			multiplayer.connect("network_peer_connected", self, "_connected")
			multiplayer.connect("network_peer_packet", self, "_pkt")
			multiplayer.set_network_peer(peer)
		elif a == 's':
			var peer = NetworkedMultiplayerENet.new()
			peer.create_server(8092)
			multiplayer.connect("network_peer_connected", self, "_connected")
			multiplayer.connect("network_peer_packet", self, "_pkt")
			multiplayer.set_network_peer(peer)
	rpc_config("_added", MultiplayerAPI.RPC_MODE_REMOTESYNC)
	rpc_config("_other", MultiplayerAPI.RPC_MODE_REMOTESYNC)


func _pkt(p_id : int, pkt : PoolByteArray):
	if pkt[0] != 0:
		return # Just for testing
	if not multiplayer.is_network_server():
		prints(p_id, pkt.subarray(1, pkt.size() - 1).get_string_from_utf8(), "at", OS.get_ticks_msec())
		multiplayer.send_bytes(pkt, 1)
	else:
		pkt = pkt.subarray(1, pkt.size() - 1)
		print("Recv ping at: %s = %s" % [OS.get_ticks_msec(), OS.get_ticks_msec() - int(pkt.get_string_from_utf8())])
		return
		multiplayer.send_bytes(str(OS.get_ticks_msec()).to_utf8(), p_id)


func _connected(p_id):
	print("Connected to: %d" % p_id)
	if multiplayer.is_network_server():
		while true:
			yield(get_tree().create_timer(1),"timeout")
			if not p_id in multiplayer.get_network_connected_peers():
				break
			print("Sending ping at ", OS.get_ticks_msec())
			var pkt = PoolByteArray([0])
			pkt.append_array(str(OS.get_ticks_msec()).to_utf8())
			multiplayer.send_bytes(pkt, p_id)
			rpc_id(p_id, "_ping", OS.get_ticks_msec())
			rpc("_added", "Added Called")
			var bytes = PoolByteArray()
			bytes.resize(4)
			bytes[0] = 1
			bytes[1] = 2
			bytes[2] = 3
			bytes[3] = 4
			rpc_send_bytes(p_id, false, "_other", bytes)

	if multiplayer.is_network_server():
		var ticks = OS.get_ticks_msec()
		print("Ping: %d" % ticks)
		rpc_id(p_id, "_ping", ticks)
		for i in range(0, 10):
			yield(get_tree().create_timer(1),"timeout")
			ticks = OS.get_ticks_msec()
			print("Ping: %d" % ticks)
			rpc_id(p_id, "_ping", ticks)

remote func _ping(time):
	print("Ping: %d" % time)
	rpc_id(1, "_pong", time)

remote func _pong(time):
	print("Pong: %d - %d = %d" % [OS.get_ticks_msec(), time, OS.get_ticks_msec() - time])


func _added(msg):
	print("Added called with: ", msg)


func _other(bytes):
	if bytes.size() != 4:
		print("Other call, but the size is wrong")
		return
	print("Other called with bytes: ", bytes[0], bytes[1], bytes[2], bytes[3])


```

_This work has been kindly sponsored by IMVU._