### PR TITLE
Rename the "Last Modified" project list sorting option to "Last Edited"

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -628,7 +628,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	/* Extra config */
 
 	_initial_set("project_manager/sorting_order", 0);
-	hints["project_manager/sorting_order"] = PropertyInfo(Variant::INT, "project_manager/sorting_order", PROPERTY_HINT_ENUM, "Name,Path,Last Modified");
+	hints["project_manager/sorting_order"] = PropertyInfo(Variant::INT, "project_manager/sorting_order", PROPERTY_HINT_ENUM, "Name,Path,Last Edited");
 
 	if (p_extra_config.is_valid()) {
 

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -134,7 +134,7 @@ public:
 	enum FilterOption {
 		FILTER_NAME,
 		FILTER_PATH,
-		FILTER_MODIFIED,
+		FILTER_EDIT_DATE,
 	};
 
 private:


### PR DESCRIPTION
The `project.godot` file will always be modified when editing a project, but not when running it. This effectively makes the option sort by last edition date, rather than modification as is typically understood by users.

This closes #36127.