### PR TITLE
Fix Mono and GDNative builds after changes to ObjectID

### DIFF
--- a/modules/gdnative/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative/gdnative.cpp
@@ -171,7 +171,7 @@ bool GDAPI godot_is_instance_valid(const godot_object *p_object) {
 }
 
 godot_object GDAPI *godot_instance_from_id(godot_int p_instance_id) {
-	return (godot_object *)ObjectDB::get_instance(ObjectID(p_instance_id));
+	return (godot_object *)ObjectDB::get_instance(ObjectID((uint64_t)p_instance_id));
 }
 
 void *godot_get_class_tag(const godot_string_name *p_class) {

--- a/modules/gdnative/include/gdnative/gdnative.h
+++ b/modules/gdnative/include/gdnative/gdnative.h
@@ -127,7 +127,7 @@ typedef bool godot_bool;
 
 /////// int
 
-typedef int64_t godot_int;
+typedef int godot_int;
 
 /////// real
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -162,11 +162,11 @@ void CSharpLanguage::finish() {
 
 #ifdef DEBUG_ENABLED
 	for (Map<ObjectID, int>::Element *E = unsafe_object_references.front(); E; E = E->next()) {
-		const ObjectID &id = E->get();
+		const ObjectID &id = E->key();
 		Object *obj = ObjectDB::get_instance(id);
 
 		if (obj) {
-			ERR_PRINT("Leaked unsafe reference to object: " + obj->get_class() + ":" + itos(id));
+			ERR_PRINT("Leaked unsafe reference to object: " + obj->to_string());
 		} else {
 			ERR_PRINT("Leaked unsafe reference to deleted object: " + itos(id));
 		}

--- a/modules/mono/signal_awaiter_utils.cpp
+++ b/modules/mono/signal_awaiter_utils.cpp
@@ -68,7 +68,7 @@ Error connect_signal_awaiter(Object *p_source, const String &p_signal, Object *p
 Variant SignalAwaiterHandle::_signal_callback(const Variant **p_args, int p_argcount, Variant::CallError &r_error) {
 
 #ifdef DEBUG_ENABLED
-	ERR_FAIL_COND_V_MSG(conn_target_id && !ObjectDB::get_instance(conn_target_id), Variant(),
+	ERR_FAIL_COND_V_MSG(conn_target_id.is_valid() && !ObjectDB::get_instance(conn_target_id), Variant(),
 			"Resumed after await, but class instance is gone.");
 #endif
 
@@ -116,12 +116,7 @@ void SignalAwaiterHandle::_bind_methods() {
 }
 
 SignalAwaiterHandle::SignalAwaiterHandle(MonoObject *p_managed) :
-		MonoGCHandle(MonoGCHandle::new_strong_handle(p_managed), STRONG_HANDLE) {
-
-#ifdef DEBUG_ENABLED
-	conn_target_id = 0;
-#endif
-}
+		MonoGCHandle(MonoGCHandle::new_strong_handle(p_managed), STRONG_HANDLE) {}
 
 SignalAwaiterHandle::~SignalAwaiterHandle() {
 


### PR DESCRIPTION
Issues caused by cf8c679a23b21d6c6f29cba6a54eaa2eed88bf92.

The Mono change is actually a bugfix (used the int instead of ObjectID
by mistake).

The GDNative change is a temporary revert until a more exhaustive approach
is taken to make 'godot_int' 64-bit, and confirmed wanted by GDNative users.

And this is why @reduz should make PRs to go through CI tests properly... ;)

Fixes #36156.