### PR TITLE
GDNative: Make godot_int an int64_t

### DIFF
--- a/modules/gdnative/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative/gdnative.cpp
@@ -171,7 +171,7 @@ bool GDAPI godot_is_instance_valid(const godot_object *p_object) {
 }
 
 godot_object GDAPI *godot_instance_from_id(godot_int p_instance_id) {
-	return (godot_object *)ObjectDB::get_instance(ObjectID((uint64_t)p_instance_id));
+	return (godot_object *)ObjectDB::get_instance(ObjectID(p_instance_id));
 }
 
 void *godot_get_class_tag(const godot_string_name *p_class) {

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -6475,7 +6475,7 @@
           "name": "godot_arvr_blit",
           "return_type": "void",
           "arguments": [
-            ["int", "p_eye"],
+            ["godot_int", "p_eye"],
             ["godot_rid *", "p_render_target"],
             ["godot_rect2 *", "p_screen_rect"]
           ]

--- a/modules/gdnative/include/gdnative/gdnative.h
+++ b/modules/gdnative/include/gdnative/gdnative.h
@@ -127,7 +127,7 @@ typedef bool godot_bool;
 
 /////// int
 
-typedef int godot_int;
+typedef int64_t godot_int;
 
 /////// real
 


### PR DESCRIPTION
Redo of the change in cf8c679a23b21d6c6f29cba6a54eaa2eed88bf92
that caused a build issue, with the extra change needed to
'godot_arvr_blit'.

Thanks @Brettink for the fix to the bindings.

CC @godotengine/gdnative 

Should fix #34254.