### PR TITLE
Fix startGame's logic in engine.js.

### DIFF
--- a/platform/javascript/engine.js
+++ b/platform/javascript/engine.js
@@ -134,12 +134,10 @@
 		this.startGame = function(execName, mainPack) {
 
 			executableName = execName;
-			var mainArgs = [ '--main-pack', mainPack ];
+			var mainArgs = [ '--main-pack', getPathLeaf(mainPack) ];
 
 			return Promise.all([
-				// Load from directory,
-				this.init(getBasePath(mainPack)),
-				// ...but write to root where the engine expects it.
+				this.init(getBasePath(execName)),
 				this.preloadFile(mainPack, getPathLeaf(mainPack))
 			]).then(
 				Function.prototype.apply.bind(synchronousStart, this, mainArgs)


### PR DESCRIPTION
This fixes startGame in engine.js, so the executable's name, and the main pack's name can actually be different, and also they'll properly load from different directories now.

3.2, and 3.1.2 needs this aswell.