### PR TITLE
Fixes some memory leaks

### DIFF
--- a/core/thread_work_pool.h
+++ b/core/thread_work_pool.h
@@ -43,6 +43,7 @@ class ThreadWorkPool {
 		std::atomic<uint32_t> *index;
 		uint32_t max_elements;
 		virtual void work() = 0;
+		virtual ~BaseWork() = default;
 	};
 
 	template <class C, class M, class U>
@@ -98,6 +99,8 @@ public:
 			threads[i].completed.wait();
 			threads[i].work = nullptr;
 		}
+
+		memdelete(w);
 	}
 
 	void init(int p_thread_count = -1);


### PR DESCRIPTION
The leaks are mostly on error returns in `VulkanContext`, but there are also two or three leaks on the happy path.

`ThreadWorkPool::BaseWork` also lacks a virtual destructor for subclasses to be correctly deleted. I think it's OK to use `= default` since the class is already using `std::thread` in C++11.