### PR TITLE
Fix bugs in shader swizzling

### DIFF
--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -538,6 +538,7 @@ public:
 		StringName name;
 		Node *owner;
 		Node *index_expression;
+		bool has_swizzling_duplicates;
 
 		virtual DataType get_datatype() const { return datatype; }
 		virtual String get_datatype_name() const { return String(struct_name); }
@@ -549,7 +550,8 @@ public:
 				datatype(TYPE_VOID),
 				array_size(0),
 				owner(NULL),
-				index_expression(NULL) {}
+				index_expression(NULL),
+				has_swizzling_duplicates(false) {}
 	};
 
 	struct StructNode : public Node {


### PR DESCRIPTION
- Forbid swizzling duplicates in a shader assignment expression (leads to invalid behavior / possible crash)
`COLOR.rrr = ...`
 
- Forbid mixing different sets of indexing characters (leads to crash)
`COLOR.rxbz`
 
- Allow using 'stpq' expressions (similar to rgba / xyzw) which are allowed by GLSL (designed for vectors retrieved from textures)