### PR TITLE
Remove Vulkan debugging prints

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -39,7 +39,6 @@
 #include <string.h>
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
-#define VULKAN_DEBUG(m_text) print_line(m_text)
 #define APP_SHORT_NAME "GodotEngine"
 
 VKAPI_ATTR VkBool32 VKAPI_CALL VulkanContext::_debug_messenger_callback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
@@ -389,15 +388,11 @@ Error VulkanContext::_create_physical_device() {
 				if (!strcmp(VK_KHR_INCREMENTAL_PRESENT_EXTENSION_NAME, device_extensions[i].extensionName)) {
 					extension_names[enabled_extension_count++] = VK_KHR_INCREMENTAL_PRESENT_EXTENSION_NAME;
 					VK_KHR_incremental_present_enabled = true;
-					VULKAN_DEBUG("VK_KHR_incremental_present extension enabled\n");
 				}
 				if (enabled_extension_count >= MAX_EXTENSIONS) {
 					free(device_extensions);
 					ERR_FAIL_V_MSG(ERR_BUG, "Enabled extension count reaches MAX_EXTENSIONS, BUG");
 				}
-			}
-			if (!VK_KHR_incremental_present_enabled) {
-				VULKAN_DEBUG("VK_KHR_incremental_present extension NOT AVAILABLE\n");
 			}
 		}
 
@@ -411,15 +406,11 @@ Error VulkanContext::_create_physical_device() {
 				if (!strcmp(VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME, device_extensions[i].extensionName)) {
 					extension_names[enabled_extension_count++] = VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME;
 					VK_GOOGLE_display_timing_enabled = true;
-					VULKAN_DEBUG("VK_GOOGLE_display_timing extension enabled\n");
 				}
 				if (enabled_extension_count >= MAX_EXTENSIONS) {
 					free(device_extensions);
 					ERR_FAIL_V_MSG(ERR_BUG, "Enabled extension count reaches MAX_EXTENSIONS, BUG");
 				}
-			}
-			if (!VK_GOOGLE_display_timing_enabled) {
-				VULKAN_DEBUG("VK_GOOGLE_display_timing extension NOT AVAILABLE\n");
 			}
 		}
 
@@ -1132,7 +1123,7 @@ Error VulkanContext::initialize() {
 	if (err) {
 		return err;
 	}
-	print_line("Vulkan physical device creation success o_O");
+
 	return OK;
 }
 

--- a/servers/visual/rasterizer_rd/rasterizer_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_rd.cpp
@@ -121,9 +121,7 @@ void RasterizerRD::initialize() {
 		String error;
 		copy_viewports_rd_shader = RD::get_singleton()->shader_create(source);
 		if (!copy_viewports_rd_shader.is_valid()) {
-			print_line("failed compilation: " + error);
-		} else {
-			print_line("compilation success");
+			print_line("Failed compilation: " + error);
 		}
 	}
 

--- a/servers/visual/rasterizer_rd/shader_compiler_rd.cpp
+++ b/servers/visual/rasterizer_rd/shader_compiler_rd.cpp
@@ -483,7 +483,7 @@ String ShaderCompilerRD::_dump_node_code(const SL::Node *p_node, int p_level, Ge
 			}
 
 			r_gen_code.uniform_total_size = offset;
-			print_line("uniform total: " + itos(r_gen_code.uniform_total_size));
+
 			if (r_gen_code.uniform_total_size % 16 != 0) { //UBO sizes must be multiples of 16
 				r_gen_code.uniform_total_size += 16 - (r_gen_code.uniform_total_size % 16);
 			}


### PR DESCRIPTION
Please advise if some of those should be turned into `print_verbose()` instead :slightly_smiling_face:

PS: I can see two messages when exiting Godot (before it segfaults), but I can't find them in the codebase:

```text
pure virtual method called
terminate called without an active exception
```