### PR TITLE
Tweak the editor help comment color for better readability

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -50,7 +50,7 @@ void EditorHelp::_init_colors() {
 	text_color = get_color("default_color", "RichTextLabel");
 	headline_color = get_color("headline_color", "EditorHelp");
 	base_type_color = title_color.linear_interpolate(text_color, 0.5);
-	comment_color = text_color * Color(1, 1, 1, 0.4);
+	comment_color = text_color * Color(1, 1, 1, 0.6);
 	symbol_color = comment_color;
 	value_color = text_color * Color(1, 1, 1, 0.6);
 	qualifier_color = text_color * Color(1, 1, 1, 0.8);


### PR DESCRIPTION
The low contrast rate made it difficult to read, which was cumbersome for long property descriptions. This increases the opacity to make it easier to read.

## Preview

### Before

![2020-02-13_23 28 20](https://user-images.githubusercontent.com/180032/74484764-883f7d80-4eb9-11ea-9dfd-3a54c860b7f5.png)

### After

![image](https://user-images.githubusercontent.com/180032/74484829-a4dbb580-4eb9-11ea-935e-3e3d3eafbf37.png)