### PR TITLE
Fix error flood with sky background

### DIFF
--- a/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -1821,7 +1821,7 @@ void RasterizerSceneHighEndRD::_render_scene(RID p_render_buffer, const Transfor
 			case VS::ENV_BG_SKY: {
 				RID sky = environment_get_sky(p_environment);
 				if (sky.is_valid()) {
-					radiance_uniform_set = sky_get_radiance_uniform_set_rd(sky, radiance_uniform_set, RADIANCE_UNIFORM_SET);
+					radiance_uniform_set = sky_get_radiance_uniform_set_rd(sky, default_shader_rd, RADIANCE_UNIFORM_SET);
 					draw_sky = true;
 				}
 			} break;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/36149

Looks like we need to pass in the shader to ``uniform_set()`` instead of the uniform set itself :P

This bug shows that it is likely a good idea to make types for things like Shaders and uniform sets. Just so we avoid issues like this. Right now they are both just plain RIDs.

Also my first foray into actual Vulkan work! This will be the first PR of many!