### PR TITLE
Fix multiple issues with the "Import" dock

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -49,7 +49,7 @@ public:
 			values[p_name] = p_value;
 			if (checking) {
 				checked.insert(p_name);
-				_change_notify(String(p_name).utf8().get_data());
+				_change_notify();
 			}
 			return true;
 		}
@@ -159,24 +159,7 @@ void ImportDock::_update_options(const Ref<ConfigFile> &p_config) {
 	}
 
 	params->update();
-
-	preset->get_popup()->clear();
-
-	if (params->importer->get_preset_count() == 0) {
-		preset->get_popup()->add_item(TTR("Default"));
-	} else {
-		for (int i = 0; i < params->importer->get_preset_count(); i++) {
-			preset->get_popup()->add_item(params->importer->get_preset_name(i));
-		}
-	}
-
-	preset->get_popup()->add_separator();
-	preset->get_popup()->add_item(vformat(TTR("Set as Default for '%s'"), params->importer->get_visible_name()), ITEM_SET_AS_DEFAULT);
-	if (ProjectSettings::get_singleton()->has_setting("importer_defaults/" + params->importer->get_importer_name())) {
-		preset->get_popup()->add_item(TTR("Load Default"), ITEM_LOAD_DEFAULT);
-		preset->get_popup()->add_separator();
-		preset->get_popup()->add_item(vformat(TTR("Clear Default for '%s'"), params->importer->get_visible_name()), ITEM_CLEAR_DEFAULT);
-	}
+	_update_preset_menu();
 }
 
 void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
@@ -276,6 +259,17 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 		}
 	}
 
+	_update_preset_menu();
+
+	params->paths = p_paths;
+	import->set_disabled(false);
+	import_as->set_disabled(false);
+	preset->set_disabled(false);
+
+	imported->set_text(itos(p_paths.size()) + TTR(" Files"));
+}
+
+void ImportDock::_update_preset_menu() {
 	preset->get_popup()->clear();
 
 	if (params->importer->get_preset_count() == 0) {
@@ -286,12 +280,13 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 		}
 	}
 
-	params->paths = p_paths;
-	import->set_disabled(false);
-	import_as->set_disabled(false);
-	preset->set_disabled(false);
-
-	imported->set_text(itos(p_paths.size()) + TTR(" Files"));
+	preset->get_popup()->add_separator();
+	preset->get_popup()->add_item(vformat(TTR("Set as Default for '%s'"), params->importer->get_visible_name()), ITEM_SET_AS_DEFAULT);
+	if (ProjectSettings::get_singleton()->has_setting("importer_defaults/" + params->importer->get_importer_name())) {
+		preset->get_popup()->add_item(TTR("Load Default"), ITEM_LOAD_DEFAULT);
+		preset->get_popup()->add_separator();
+		preset->get_popup()->add_item(vformat(TTR("Clear Default for '%s'"), params->importer->get_visible_name()), ITEM_CLEAR_DEFAULT);
+	}
 }
 
 void ImportDock::_importer_selected(int i_idx) {
@@ -326,7 +321,7 @@ void ImportDock::_preset_selected(int p_idx) {
 
 			ProjectSettings::get_singleton()->set("importer_defaults/" + params->importer->get_importer_name(), d);
 			ProjectSettings::get_singleton()->save();
-
+			_update_preset_menu();
 		} break;
 		case ITEM_LOAD_DEFAULT: {
 
@@ -336,17 +331,22 @@ void ImportDock::_preset_selected(int p_idx) {
 			List<Variant> v;
 			d.get_key_list(&v);
 
+			if (params->checking) {
+				params->checked.clear();
+			}
 			for (List<Variant>::Element *E = v.front(); E; E = E->next()) {
 				params->values[E->get()] = d[E->get()];
+				if (params->checking) {
+					params->checked.insert(E->get());
+				}
 			}
 			params->update();
-
 		} break;
 		case ITEM_CLEAR_DEFAULT: {
 
 			ProjectSettings::get_singleton()->set("importer_defaults/" + params->importer->get_importer_name(), Variant());
 			ProjectSettings::get_singleton()->save();
-
+			_update_preset_menu();
 		} break;
 		default: {
 
@@ -354,11 +354,15 @@ void ImportDock::_preset_selected(int p_idx) {
 
 			params->importer->get_import_options(&options, p_idx);
 
-			for (List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
-
-				params->values[E->get().option.name] = E->get().default_value;
+			if (params->checking) {
+				params->checked.clear();
 			}
-
+			for (List<ResourceImporter::ImportOption>::Element *E = options.front(); E; E = E->next()) {
+				params->values[E->get().option.name] = E->get().default_value;
+				if (params->checking) {
+					params->checked.insert(E->get().option.name);
+				}
+			}
 			params->update();
 		} break;
 	}

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -62,6 +62,7 @@ class ImportDock : public VBoxContainer {
 	void _preset_selected(int p_idx);
 	void _importer_selected(int i_idx);
 	void _update_options(const Ref<ConfigFile> &p_config = Ref<ConfigFile>());
+	void _update_preset_menu();
 
 	void _property_toggled(const StringName &p_prop, bool p_checked);
 	void _reimport_attempt();


### PR DESCRIPTION
- Fixed setting options while having multiple files selected not visually checking them.
- Fixed selecting presets while having multiple files selected not checking the options. Fixes #35232.
- Fixed "Preset" menu not updating when selecting multiple files.