### PR TITLE
Fixes memory leak in NavigationPolygon

### DIFF
--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -363,8 +363,11 @@ void NavigationPolygon::_bind_methods() {
 
 NavigationPolygon::NavigationPolygon() :
 		rect_cache_dirty(true),
-		navmesh_generation(NULL) {
-	navmesh_generation = Mutex::create();
+		navmesh_generation(Mutex::create()) {
+}
+
+NavigationPolygon::~NavigationPolygon() {
+	memdelete(navmesh_generation);
 }
 
 void NavigationPolygonInstance::set_enabled(bool p_enabled) {

--- a/scene/2d/navigation_polygon.h
+++ b/scene/2d/navigation_polygon.h
@@ -91,6 +91,7 @@ public:
 	Ref<NavigationMesh> get_mesh();
 
 	NavigationPolygon();
+	~NavigationPolygon();
 };
 
 class Navigation2D;


### PR DESCRIPTION
The `navmesh_generation` mutex was not deleted in destructor.

I also moved the initialization of it to the constructor's member initializer list, since there is no point setting it to `NULL` first.