### PR TITLE
Vulkan-Loader: Mark secure_getenv as available on Linux

### DIFF
--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -57,6 +57,10 @@ if env['builtin_vulkan']:
             'FALLBACK_DATA_DIRS=\\"%s\\"' % '/usr/local/share:/usr/share',
             'FALLBACK_CONFIG_DIRS=\\"%s\\"' % '/etc/xdg'
         ])
+        import platform
+        if (platform.system() == "Linux"):
+            # In glibc since 2.17 and musl libc since 1.1.24. Used by loader.c.
+            env_thirdparty.AppendUnique(CPPDEFINES=['HAVE_SECURE_GETENV'])
 
     loader_sources = [thirdparty_dir + "/loader/" + file for file in loader_sources]
     env_thirdparty.add_source_files(env.drivers_sources, loader_sources)


### PR DESCRIPTION
It's a GNU extension part of glibc since 2.17, and it was also added
recently to musl libc. It doesn't seem to be available on *BSD (but
also not used there by Vulkan-Loader).

Could be made more thorough by doing a test compilation of a file to
check for the existence of the function on the host system, but unless
we run into actual issues, that's likely overkill.