### PR TITLE
RichTextLabel: proper handling of internal key events

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1208,49 +1208,59 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 
 	if (k.is_valid()) {
 		if (k->is_pressed() && !k->get_alt() && !k->get_shift()) {
-			bool handled = true;
+			bool handled = false;
 			switch (k->get_scancode()) {
 				case KEY_PAGEUP: {
 
-					if (vscroll->is_visible_in_tree())
+					if (vscroll->is_visible_in_tree()) {
 						vscroll->set_value(vscroll->get_value() - vscroll->get_page());
+						handled = true;
+					}
 				} break;
 				case KEY_PAGEDOWN: {
 
-					if (vscroll->is_visible_in_tree())
+					if (vscroll->is_visible_in_tree()) {
 						vscroll->set_value(vscroll->get_value() + vscroll->get_page());
+						handled = true;
+					}
 				} break;
 				case KEY_UP: {
 
-					if (vscroll->is_visible_in_tree())
+					if (vscroll->is_visible_in_tree()) {
 						vscroll->set_value(vscroll->get_value() - get_font("normal_font")->get_height());
+						handled = true;
+					}
 				} break;
 				case KEY_DOWN: {
 
-					if (vscroll->is_visible_in_tree())
+					if (vscroll->is_visible_in_tree()) {
 						vscroll->set_value(vscroll->get_value() + get_font("normal_font")->get_height());
+						handled = true;
+					}
 				} break;
 				case KEY_HOME: {
 
-					if (vscroll->is_visible_in_tree())
+					if (vscroll->is_visible_in_tree()) {
 						vscroll->set_value(0);
+						handled = true;
+					}
 				} break;
 				case KEY_END: {
 
-					if (vscroll->is_visible_in_tree())
+					if (vscroll->is_visible_in_tree()) {
 						vscroll->set_value(vscroll->get_max());
+						handled = true;
+					}
 				} break;
 				case KEY_INSERT:
 				case KEY_C: {
 
 					if (k->get_command()) {
 						selection_copy();
-					} else {
-						handled = false;
+						handled = true;
 					}
 
 				} break;
-				default: handled = false;
 			}
 
 			if (handled)


### PR DESCRIPTION
Modifies, how key events are handled internally in RichTextLabel.

Previously, each special event (KEY_PAGEUP, KEY_PAGEDOWN, KEY_UP, KEY_DOWN, KEY_HOME, KEY_END, KEY_INSERT) was treated as "handled" even if no associated action was performed. 

That prevented specific Input Mappings to fire (like: `ui_up` with KEY_UP was not switching the focus).

Now, each of those special events is treated as 'handled' when associated action IS actually performed, otherwise, event is passed for further processing, so Input Action mappigns can take place.

Do notice, that all of those special keys mentioned above WILL NOT work with Input Action mappings, if they will actually perform their associated actions for that control (for example, when scrollbars appear on two RichTextLabels, KEY_UP/KEY_DOWN won't switch a focus between them, but instead will move the scrollbar up/down on focused Control - that's actual associated behaviour for those keys for RichTextLabel control).

Fixes #36211