### PR TITLE
Add a margin to EditorSpinSlider to visually line up the edited number

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -31,6 +31,7 @@
 #include "editor_spin_slider.h"
 #include "core/math/expression.h"
 #include "core/os/input.h"
+#include "editor_node.h"
 #include "editor_scale.h"
 
 String EditorSpinSlider::get_tooltip(const Point2 &p_pos) const {
@@ -183,6 +184,19 @@ void EditorSpinSlider::_notification(int p_what) {
 			grabbing_spinner = false;
 			grabbing_spinner_attempt = false;
 		}
+	}
+
+	if (p_what == NOTIFICATION_READY) {
+		// Add a left margin to the stylebox to make the number align with the Label
+		// when it's edited. The LineEdit "focus" stylebox uses the "normal" stylebox's
+		// default margins.
+		Ref<StyleBoxFlat> stylebox =
+				EditorNode::get_singleton()->get_theme_base()->get_stylebox("normal", "LineEdit")->duplicate();
+		// EditorSpinSliders with a label have more space on the left, so add an
+		// higher margin to match the location where the text begins.
+		// The margin values below were determined by empirical testing.
+		stylebox->set_default_margin(MARGIN_LEFT, (get_label() != String() ? 23 : 16) * EDSCALE);
+		value_input->add_style_override("normal", stylebox);
 	}
 
 	if (p_what == NOTIFICATION_DRAW) {


### PR DESCRIPTION
This means clicking on an EditorSpinSlider to edit its value will no longer cause the number to be visually offset while it's being edited.

~~I'm pretty sure this closes an open proposal, but I can't find it right now.~~ **Edit:** This closes https://github.com/godotengine/godot/issues/28618.

## Preview

![image](https://user-images.githubusercontent.com/180032/74579606-fc525200-4f9b-11ea-85ee-e4bc6f14c08e.png)