### PR TITLE
Fixes memory leaks in GdNavigationServer and RasterizerSceneHighEndRD

### DIFF
--- a/modules/gdnavigation/gd_navigation_server.cpp
+++ b/modules/gdnavigation/gd_navigation_server.cpp
@@ -115,12 +115,15 @@
 
 GdNavigationServer::GdNavigationServer() :
 		NavigationServer(),
+		commands_mutex(Mutex::create()),
+		operations_mutex(Mutex::create()),
 		active(true) {
-	commands_mutex = Mutex::create();
-	operations_mutex = Mutex::create();
 }
 
-GdNavigationServer::~GdNavigationServer() {}
+GdNavigationServer::~GdNavigationServer() {
+	memdelete(operations_mutex);
+	memdelete(commands_mutex);
+}
 
 void GdNavigationServer::add_command(SetCommand *command) const {
 	auto mut_this = const_cast<GdNavigationServer *>(this);

--- a/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -2697,8 +2697,20 @@ RasterizerSceneHighEndRD::~RasterizerSceneHighEndRD() {
 		RD::get_singleton()->free(view_dependant_uniform_set);
 	}
 
+	storage->free(wireframe_material_shader);
+	storage->free(overdraw_material_shader);
+	storage->free(default_shader);
+
+	storage->free(wireframe_material);
+	storage->free(overdraw_material);
+	storage->free(default_material);
+
 	{
 		RD::get_singleton()->free(scene_state.reflection_buffer);
+		memdelete_arr(scene_state.instances);
+		memdelete_arr(scene_state.gi_probes);
+		memdelete_arr(scene_state.directional_lights);
+		memdelete_arr(scene_state.lights);
 		memdelete_arr(scene_state.reflections);
 	}
 }


### PR DESCRIPTION
In `GdNavigationServer`, I also moved the initialization of the two mutexes to the member initializer list to be consistent with the initialization of other variables.

In `RasterizerSceneHighEndRD`, the first three `RasterizerStorageRD::free` calls to free the shaders can eliminate the memory leak. The other three material free calls are there to fix the errors in the log

    ERROR: 3 RID allocations of type 'N19RasterizerStorageRD8MaterialE' were leaked at exit.