### PR TITLE
Fixed overwrite of image format with incorrect format causing texture load failure

### DIFF
--- a/servers/visual/rasterizer_rd/rasterizer_storage_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_storage_rd.cpp
@@ -169,7 +169,6 @@ Ref<Image> RasterizerStorageRD::_validate_texture_format(const Ref<Image> &p_ima
 				image->convert(Image::FORMAT_RGBAH);
 			}
 
-			r_format.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
 			r_format.swizzle_r = RD::TEXTURE_SWIZZLE_R;
 			r_format.swizzle_g = RD::TEXTURE_SWIZZLE_G;
 			r_format.swizzle_b = RD::TEXTURE_SWIZZLE_B;


### PR DESCRIPTION
Fixed format being overwritten if the texture format RGBH is actually supported resulting in the error:

E 0:00:15.049   texture_create: Data for slice index 0 (mapped to layer 0) differs in size (supplied: 1572864) than what is required by the format (2097152).
<C++ Error>   Condition "(uint32_t)p_data[i].size() != required_size" is true. returned: RID()
<C++ Source>  drivers/vulkan/rendering_device_vulkan.cpp:1689 @ texture_create()


which intern results in failing to load RGBH textures.
