### PR TITLE
Fix shader crash if duplicated struct members created

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -5675,7 +5675,7 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 				st.shader_struct = st_node;
 
 				int member_count = 0;
-
+				Set<String> member_names;
 				while (true) { // variables list
 					tk = _get_token();
 					if (tk.type == TK_CURLY_BRACKET_CLOSE) {
@@ -5731,6 +5731,12 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 						member->datatype = type;
 						member->struct_name = struct_name;
 						member->name = tk.text;
+
+						if (member_names.has(member->name)) {
+							_set_error("Redefinition of '" + String(member->name) + "'");
+							return ERR_PARSE_ERROR;
+						}
+						member_names.insert(member->name);
 
 						tk = _get_token();
 						if (tk.type == TK_BRACKET_OPEN) {


### PR DESCRIPTION
Fix crash:
```
struct Test{
int a;
int a;
};
```