### PR TITLE
Increase the default 2D gravity to 980

### DIFF
--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -60,7 +60,7 @@
 		<member name="audio_bus_override" type="bool" setter="set_audio_bus_override" getter="is_overriding_audio_bus" default="false">
 			If [code]true[/code], the area's audio bus overrides the default audio bus.
 		</member>
-		<member name="gravity" type="float" setter="set_gravity" getter="get_gravity" default="98.0">
+		<member name="gravity" type="float" setter="set_gravity" getter="get_gravity" default="980.0">
 			The area's gravity intensity (ranges from -1024 to 1024). This value multiplies the gravity vector. This is useful to alter the force of gravity without altering its direction.
 		</member>
 		<member name="gravity_distance_scale" type="float" setter="set_gravity_distance_scale" getter="get_gravity_distance_scale" default="0.0">

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -199,7 +199,7 @@
 		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true">
 			If [code]true[/code], results in fractional delta calculation which has a smoother particles display effect.
 		</member>
-		<member name="gravity" type="Vector2" setter="set_gravity" getter="get_gravity" default="Vector2( 0, 98 )">
+		<member name="gravity" type="Vector2" setter="set_gravity" getter="get_gravity" default="Vector2( 0, 980 )">
 			Gravity applied to every particle.
 		</member>
 		<member name="hue_variation" type="float" setter="set_param" getter="get_param" default="0.0">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1199,17 +1199,17 @@
 			The default angular damp in 2D.
 			[b]Note:[/b] Good values are in the range [code]0[/code] to [code]1[/code]. At value [code]0[/code] objects will keep moving with the same velocity. Values greater than [code]1[/code] will aim to reduce the velocity to [code]0[/code] in less than a second e.g. a value of [code]2[/code] will aim to reduce the velocity to [code]0[/code] in half a second. A value equal to or greater than the physics frame rate ([member ProjectSettings.physics/common/physics_fps], [code]60[/code] by default) will bring the object to a stop in one iteration.
 		</member>
-		<member name="physics/2d/default_gravity" type="int" setter="" getter="" default="98">
+		<member name="physics/2d/default_gravity" type="float" setter="" getter="" default="980.0">
 			The default gravity strength in 2D.
 			[b]Note:[/b] This property is only read when the project starts. To change the default gravity at runtime, use the following code sample:
 			[codeblocks]
 			[gdscript]
-			# Set the default gravity strength to 98.
-			PhysicsServer2D.area_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.AREA_PARAM_GRAVITY, 98)
+			# Set the default gravity strength to 980.
+			PhysicsServer2D.area_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.AREA_PARAM_GRAVITY, 980)
 			[/gdscript]
 			[csharp]
-			// Set the default gravity strength to 98.
-			PhysicsServer2D.AreaSetParam(GetViewport().FindWorld2d().Space, PhysicsServer2D.AreaParameter.Gravity, 98);
+			// Set the default gravity strength to 980.
+			PhysicsServer2D.AreaSetParam(GetViewport().FindWorld2d().Space, PhysicsServer2D.AreaParameter.Gravity, 980);
 			[/csharp]
 			[/codeblocks]
 		</member>

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -568,7 +568,7 @@ void Area2D::_bind_methods() {
 
 Area2D::Area2D() :
 		CollisionObject2D(PhysicsServer2D::get_singleton()->area_create(), true) {
-	set_gravity(98);
+	set_gravity(980);
 	set_gravity_vector(Vector2(0, 1));
 	set_monitoring(true);
 	set_monitorable(true);

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -169,7 +169,7 @@ private:
 	Vector<Color> emission_colors;
 	int emission_point_count = 0;
 
-	Vector2 gravity = Vector2(0, 98);
+	Vector2 gravity = Vector2(0, 980);
 
 	void _update_internal();
 	void _particles_process(float p_delta);

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -357,7 +357,7 @@ World2D::World2D() {
 	// Create and configure space2D to be more friendly with pixels than meters
 	space = PhysicsServer2D::get_singleton()->space_create();
 	PhysicsServer2D::get_singleton()->space_set_active(space, true);
-	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY, GLOBAL_DEF("physics/2d/default_gravity", 98));
+	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY, GLOBAL_DEF("physics/2d/default_gravity", 980.0));
 	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY_VECTOR, GLOBAL_DEF("physics/2d/default_gravity_vector", Vector2(0, 1)));
 	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_LINEAR_DAMP, GLOBAL_DEF("physics/2d/default_linear_damp", 0.1));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/default_linear_damp", PropertyInfo(Variant::FLOAT, "physics/2d/default_linear_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"));

--- a/tests/test_physics_2d.cpp
+++ b/tests/test_physics_2d.cpp
@@ -320,7 +320,7 @@ public:
 		ps->space_set_active(space, true);
 		ps->set_active(true);
 		ps->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY_VECTOR, Vector2(0, 1));
-		ps->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY, 98);
+		ps->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY, 980);
 
 		{
 			RID vp = vs->viewport_create();


### PR DESCRIPTION
This makes 2D RigidBody physics feel less floaty out of the box.

This closes https://github.com/godotengine/godot-proposals/issues/98.