### PR TITLE
Fixes crash when pressing enter in ConnectDialog with nothing selected

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -119,6 +119,9 @@ void ConnectDialog::ok_pressed() {
 		return;
 	}
 	Node *target = tree->get_selected();
+	if (!target) {
+		return; // Nothing selected in the tree, not an error.
+	}
 	if (target->get_script().is_null()) {
 		if (!target->has_method(dst_method->get_text())) {
 			error->set_text(TTR("Target method not found. Specify a valid method or attach a script to the target node."));
@@ -147,16 +150,6 @@ void ConnectDialog::_tree_node_selected() {
 
 	dst_path = source->get_path_to(current);
 	_update_ok_enabled();
-}
-
-/*
- * Called each time a target node is activated within the target node tree.
- */
-void ConnectDialog::_tree_item_activated() {
-
-	if (!get_ok()->is_disabled()) {
-		get_ok()->emit_signal("pressed");
-	}
 }
 
 /*
@@ -243,7 +236,6 @@ void ConnectDialog::_bind_methods() {
 	ClassDB::bind_method("_advanced_pressed", &ConnectDialog::_advanced_pressed);
 	ClassDB::bind_method("_cancel", &ConnectDialog::_cancel_pressed);
 	ClassDB::bind_method("_tree_node_selected", &ConnectDialog::_tree_node_selected);
-	ClassDB::bind_method("_tree_item_activated", &ConnectDialog::_tree_item_activated);
 	ClassDB::bind_method("_add_bind", &ConnectDialog::_add_bind);
 	ClassDB::bind_method("_remove_bind", &ConnectDialog::_remove_bind);
 	ClassDB::bind_method("_update_ok_enabled", &ConnectDialog::_update_ok_enabled);
@@ -397,7 +389,7 @@ ConnectDialog::ConnectDialog() {
 
 	tree = memnew(SceneTreeEditor(false));
 	tree->set_connecting_signal(true);
-	tree->get_scene_tree()->connect("item_activated", this, "_tree_item_activated");
+	tree->get_scene_tree()->connect("item_activated", this, "_ok");
 	tree->connect("node_selected", this, "_tree_node_selected");
 	tree->set_connect_to_script_mode(true);
 

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -76,7 +76,6 @@ class ConnectDialog : public ConfirmationDialog {
 	void ok_pressed();
 	void _cancel_pressed();
 	void _tree_node_selected();
-	void _tree_item_activated();
 	void _add_bind();
 	void _remove_bind();
 	void _advanced_pressed();


### PR DESCRIPTION
This fixes #36264.

The null check of `target` is the only thing needed to prevent the crash.

The `ConnectDialog::_tree_item_activated` method is removed. It's no longer needed if the null check exists. It was added to fix #34555, the same crash triggered in a different way.