### PR TITLE
changed toon shader to step the accumulated light instead of each light separately

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1053,10 +1053,6 @@ LIGHT_SHADER_CODE
 			diffuse_brdf_NL = cNdotL * (A + vec3(B) * s / t) * (1.0 / M_PI);
 		}
 
-#elif defined(DIFFUSE_TOON)
-
-		diffuse_brdf_NL = smoothstep(-roughness, max(roughness, 0.01), NdotL);
-
 #elif defined(DIFFUSE_BURLEY)
 
 		{
@@ -2143,6 +2139,14 @@ FRAGMENT_SHADER_CODE
 		specular_light *= rev_amount;
 		diffuse_light *= rev_amount;
 	}
+
+
+#ifdef DIFFUSE_TOON
+
+    diffuse_light *= step(0.1, max(diffuse_light.r, max(diffuse_light.g, diffuse_light.b)));
+
+
+# endif // DIFFUSE_TOON
 
 #ifdef USE_MULTIPLE_RENDER_TARGETS
 


### PR DESCRIPTION
In [this proposal](https://github.com/godotengine/godot-proposals/issues/484) the issue is highlighted. This is a different solution than the one proposed, but breaks compatibility with existing toon shaded games.

Here you can see on the left current Godot's toon shader, and on the right the look with this implementation
![Screenshot_2020-02-16_16-10-59](https://user-images.githubusercontent.com/7917475/74608738-fcf60000-50e3-11ea-904a-11ae59f74cd4.png)
