### PR TITLE
Fix VisualServer bindings.

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -801,6 +801,30 @@
 				Sets the rotation of the background [Sky] expressed as a [Basis]. Equivalent to [member Environment.sky_rotation], where the rotation vector is used to construct the [Basis].
 			</description>
 		</method>
+		<method name="environment_set_ssao">
+			<return type="void">
+			</return>
+			<argument index="0" name="env" type="RID">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<argument index="2" name="radius" type="float">
+			</argument>
+			<argument index="3" name="intensity" type="float">
+			</argument>
+			<argument index="4" name="bias" type="float">
+			</argument>
+			<argument index="5" name="light_affect" type="float">
+			</argument>
+			<argument index="6" name="ao_channel_affect" type="float">
+			</argument>
+			<argument index="7" name="blur" type="int" enum="VisualServer.EnvironmentSSAOBlur">
+			</argument>
+			<argument index="8" name="bilateral_sharpness" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="environment_set_ssr">
 			<return type="void">
 			</return>
@@ -3497,15 +3521,6 @@
 		<constant name="ENV_TONE_MAPPER_ACES" value="3" enum="EnvironmentToneMapper">
 			Use the ACES tonemapper.
 		</constant>
-		<constant name="ENV_SSAO_QUALITY_LOW" value="0" enum="EnvironmentSSAOQuality">
-			Lowest quality of screen space ambient occlusion.
-		</constant>
-		<constant name="ENV_SSAO_QUALITY_MEDIUM" value="1" enum="EnvironmentSSAOQuality">
-			Medium quality screen space ambient occlusion.
-		</constant>
-		<constant name="ENV_SSAO_QUALITY_HIGH" value="2" enum="EnvironmentSSAOQuality">
-			Highest quality screen space ambient occlusion.
-		</constant>
 		<constant name="ENV_SSAO_BLUR_DISABLED" value="0" enum="EnvironmentSSAOBlur">
 			Disables the blur set for SSAO. Will make SSAO look noisier.
 		</constant>
@@ -3517,6 +3532,15 @@
 		</constant>
 		<constant name="ENV_SSAO_BLUR_3x3" value="3" enum="EnvironmentSSAOBlur">
 			Performs a 3x3 blur on the SSAO output. Use this for smoothest SSAO.
+		</constant>
+		<constant name="ENV_SSAO_QUALITY_LOW" value="0" enum="EnvironmentSSAOQuality">
+			Lowest quality of screen space ambient occlusion.
+		</constant>
+		<constant name="ENV_SSAO_QUALITY_MEDIUM" value="1" enum="EnvironmentSSAOQuality">
+			Medium quality screen space ambient occlusion.
+		</constant>
+		<constant name="ENV_SSAO_QUALITY_HIGH" value="2" enum="EnvironmentSSAOQuality">
+			Highest quality screen space ambient occlusion.
 		</constant>
 		<constant name="ENV_SSAO_QUALITY_ULTRA" value="3" enum="EnvironmentSSAOQuality">
 		</constant>

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1819,7 +1819,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_set_tonemap", "env", "tone_mapper", "exposure", "white", "auto_exposure", "min_luminance", "max_luminance", "auto_exp_speed", "auto_exp_grey"), &VisualServer::environment_set_tonemap);
 	ClassDB::bind_method(D_METHOD("environment_set_adjustment", "env", "enable", "brightness", "contrast", "saturation", "ramp"), &VisualServer::environment_set_adjustment);
 	ClassDB::bind_method(D_METHOD("environment_set_ssr", "env", "enable", "max_steps", "fade_in", "fade_out", "depth_tolerance", "roughness"), &VisualServer::environment_set_ssr);
-	ClassDB::bind_method(D_METHOD("environment_set_ssao", "env", "enable", "radius", "intensity", "radius2", "intensity2", "bias", "light_affect", "ao_channel_affect", "color", "blur", "bilateral_sharpness"), &VisualServer::environment_set_ssao);
+	ClassDB::bind_method(D_METHOD("environment_set_ssao", "env", "enable", "radius", "intensity", "bias", "light_affect", "ao_channel_affect", "blur", "bilateral_sharpness"), &VisualServer::environment_set_ssao);
 	ClassDB::bind_method(D_METHOD("environment_set_fog", "env", "enable", "color", "sun_color", "sun_amount"), &VisualServer::environment_set_fog);
 
 	ClassDB::bind_method(D_METHOD("environment_set_fog_depth", "env", "enable", "depth_begin", "depth_end", "depth_curve", "transmit", "transmit_curve"), &VisualServer::environment_set_fog_depth);
@@ -2140,10 +2140,6 @@ void VisualServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_REINHARD);
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_FILMIC);
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_ACES);
-
-	BIND_ENUM_CONSTANT(ENV_SSAO_QUALITY_LOW);
-	BIND_ENUM_CONSTANT(ENV_SSAO_QUALITY_MEDIUM);
-	BIND_ENUM_CONSTANT(ENV_SSAO_QUALITY_HIGH);
 
 	BIND_ENUM_CONSTANT(ENV_SSAO_BLUR_DISABLED);
 	BIND_ENUM_CONSTANT(ENV_SSAO_BLUR_1x1);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -753,7 +753,7 @@ public:
 		ENV_SSAO_BLUR_3x3,
 	};
 
-	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) = 0;
+	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_bias, float p_light_affect, float p_ao_channel_affect, EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) = 0;
 
 	enum EnvironmentSSAOQuality {
 		ENV_SSAO_QUALITY_LOW,


### PR DESCRIPTION
Fixes the following errors displayed when starting godot:
```
ERROR: Method definition provides more arguments than the method actually has 'VisualServer::environment_set_ssao'. at: bind_methodfi (core/class_db.cpp:1264)
ERROR: Method/Function Failed. at: bind_integer_constant (core/class_db.cpp:700)
ERROR: Method/Function Failed. at: bind_integer_constant (core/class_db.cpp:700)
ERROR: Method/Function Failed. at: bind_integer_constant (core/class_db.cpp:700)
```