### PR TITLE
Fix one-way collision for moving objects

### DIFF
--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -290,11 +290,12 @@ bool BodyPair2DSW::setup(real_t p_step) {
 			bool valid = false;
 			for (int i = 0; i < contact_count; i++) {
 				Contact &c = contacts[i];
-				if (!c.reused){
+				if (!c.reused) {
 					continue;
 				}
-					if (c.normal.dot(direction) > 0) {//greater (normal inverted)
-					continue;}
+				if (c.normal.dot(direction) > 0) { //greater (normal inverted)
+					continue;
+				}
 
 				valid = true;
 				break;
@@ -312,11 +313,12 @@ bool BodyPair2DSW::setup(real_t p_step) {
 			bool valid = false;
 			for (int i = 0; i < contact_count; i++) {
 				Contact &c = contacts[i];
-				if (!c.reused){
+				if (!c.reused) {
 					continue;
 				}
-					if (c.normal.dot(direction) < 0) {//less (normal ok)
-					continue;}
+				if (c.normal.dot(direction) < 0) { //less (normal ok)
+					continue;
+				}
 
 				valid = true;
 				break;

--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -288,19 +288,16 @@ bool BodyPair2DSW::setup(real_t p_step) {
 		if (A->is_shape_set_as_one_way_collision(shape_A)) {
 			Vector2 direction = xform_A.get_axis(1).normalized();
 			bool valid = false;
-			if (B->get_linear_velocity().dot(direction) >= 0) {
-				for (int i = 0; i < contact_count; i++) {
-					Contact &c = contacts[i];
-					if (!c.reused) {
-						continue;
-					}
-					if (c.normal.dot(direction) > 0) { //greater (normal inverted)
-						continue;
-					}
-
-					valid = true;
-					break;
+			for (int i = 0; i < contact_count; i++) {
+				Contact &c = contacts[i];
+				if (!c.reused){
+					continue;
 				}
+					if (c.normal.dot(direction) > 0) {//greater (normal inverted)
+					continue;}
+
+				valid = true;
+				break;
 			}
 
 			if (!valid) {
@@ -313,19 +310,16 @@ bool BodyPair2DSW::setup(real_t p_step) {
 		if (B->is_shape_set_as_one_way_collision(shape_B)) {
 			Vector2 direction = xform_B.get_axis(1).normalized();
 			bool valid = false;
-			if (A->get_linear_velocity().dot(direction) >= 0) {
-				for (int i = 0; i < contact_count; i++) {
-					Contact &c = contacts[i];
-					if (!c.reused) {
-						continue;
-					}
-					if (c.normal.dot(direction) < 0) { //less (normal ok)
-						continue;
-					}
-
-					valid = true;
-					break;
+			for (int i = 0; i < contact_count; i++) {
+				Contact &c = contacts[i];
+				if (!c.reused){
+					continue;
 				}
+					if (c.normal.dot(direction) < 0) {//less (normal ok)
+					continue;}
+
+				valid = true;
+				break;
 			}
 			if (!valid) {
 				collided = false;

--- a/servers/physics_2d/physics_server_2d_sw.cpp
+++ b/servers/physics_2d/physics_server_2d_sw.cpp
@@ -156,16 +156,8 @@ void PhysicsServer2DSW::_shape_col_cbk(const Vector2 &p_point_A, const Vector2 &
 		}
 		Vector2 rel_dir = (p_point_A - p_point_B).normalized();
 
-		if (cbk->valid_dir.dot(rel_dir) < Math_SQRT12) { //sqrt(2)/2.0 - 45 degrees
+		if (rel_dir != Vector2() && cbk->valid_dir.dot(rel_dir) <= 0) {
 			cbk->invalid_by_dir++;
-
-			/*
-			print_line("A: "+p_point_A);
-			print_line("B: "+p_point_B);
-			print_line("discard too angled "+rtos(cbk->valid_dir.dot((p_point_A-p_point_B))));
-			print_line("resnorm: "+(p_point_A-p_point_B).normalized());
-			print_line("distance: "+rtos(p_point_A.distance_to(p_point_B)));
-			*/
 			return;
 		}
 	}

--- a/servers/physics_2d/physics_server_2d_sw.cpp
+++ b/servers/physics_2d/physics_server_2d_sw.cpp
@@ -149,14 +149,14 @@ void PhysicsServer2DSW::_shape_col_cbk(const Vector2 &p_point_A, const Vector2 &
 		return;
 	}
 
-	if (cbk->valid_dir != Vector2()) {
+	Vector2 rel_dir = (p_point_A - p_point_B).normalized();
+	if (cbk->valid_dir != Vector2() && rel_dir != Vector2() && cbk->valid_depth < 10e20) {
 		if (p_point_A.distance_squared_to(p_point_B) > cbk->valid_depth * cbk->valid_depth) {
 			cbk->invalid_by_dir++;
 			return;
 		}
-		Vector2 rel_dir = (p_point_A - p_point_B).normalized();
 
-		if (rel_dir != Vector2() && cbk->valid_dir.dot(rel_dir) <= 0) {
+		if (cbk->valid_dir.dot(rel_dir) <= 0) {
 			cbk->invalid_by_dir++;
 			return;
 		}

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -798,7 +798,6 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 
 						float owc_margin = col_obj->get_shape_one_way_collision_margin(shape_idx);
 						cbk.valid_depth = MAX(owc_margin, p_margin); //user specified, but never less than actual margin or it won't work
-						cbk.invalid_by_dir = 0;
 
 						if (col_obj->get_type() == CollisionObject2DSW::TYPE_BODY) {
 							const Body2DSW *b = static_cast<const Body2DSW *>(col_obj);
@@ -806,16 +805,19 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 								//fix for moving platforms (kinematic and dynamic), margin is increased by how much it moved in the given direction
 								Vector2 lv = b->get_linear_velocity();
 								//compute displacement from linear velocity
-								Vector2 motion = lv * PhysicsDirectBodyState2DSW::singleton->step;
-								float motion_len = motion.length();
-								motion.normalize();
-								cbk.valid_depth += motion_len * MAX(motion.dot(-cbk.valid_dir), 0.0);
+								Vector2 b_motion = lv * PhysicsDirectBodyState2DSW::singleton->step;
+								float b_depth = b_motion.dot(-cbk.valid_dir);
+								cbk.valid_depth += MAX(b_depth, 0.0);
+
+								//we need take out own movement into account
+								Vector2 a_motion = p_motion;
+								float a_depth = MAX(a_motion.dot(-cbk.valid_dir), 0.0);
+								cbk.valid_depth += a_depth;
 							}
 						}
 					} else {
 						cbk.valid_dir = Vector2();
 						cbk.valid_depth = 0;
-						cbk.invalid_by_dir = 0;
 					}
 
 					int current_passed = cbk.passed; //save how many points passed collision
@@ -852,7 +854,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 			for (int i = 0; i < cbk.amount; i++) {
 				Vector2 a = sr[i * 2 + 0];
 				Vector2 b = sr[i * 2 + 1];
-				recover_motion += (b - a) * 0.4;
+				recover_motion += (b - a) / cbk.amount;
 			}
 
 			if (recover_motion == Vector2()) {

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -799,6 +799,11 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 						float owc_margin = col_obj->get_shape_one_way_collision_margin(shape_idx);
 						cbk.valid_depth = MAX(owc_margin, p_margin); //user specified, but never less than actual margin or it won't work
 
+						//we need take out own movement into account
+						Vector2 a_motion = p_motion;
+						float a_depth = a_motion.dot(cbk.valid_dir);
+						cbk.valid_depth += a_depth;
+
 						if (col_obj->get_type() == CollisionObject2DSW::TYPE_BODY) {
 							const Body2DSW *b = static_cast<const Body2DSW *>(col_obj);
 							if (b->get_mode() == PhysicsServer2D::BODY_MODE_KINEMATIC || b->get_mode() == PhysicsServer2D::BODY_MODE_RIGID) {
@@ -807,12 +812,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 								//compute displacement from linear velocity
 								Vector2 b_motion = lv * PhysicsDirectBodyState2DSW::singleton->step;
 								float b_depth = b_motion.dot(-cbk.valid_dir);
-								cbk.valid_depth += MAX(b_depth, 0.0);
-
-								//we need take out own movement into account
-								Vector2 a_motion = p_motion;
-								float a_depth = MAX(a_motion.dot(-cbk.valid_dir), 0.0);
-								cbk.valid_depth += a_depth;
+								cbk.valid_depth += b_depth;
 							}
 						}
 					} else {


### PR DESCRIPTION
There are several bugs with one-way collisions:
Fixes https://github.com/godotengine/godot/issues/25732
Fixes https://github.com/godotengine/godot/issues/27593
Fixes https://github.com/godotengine/godot/issues/28794
Fixes https://github.com/godotengine/godot/issues/35776
Fixes https://github.com/godotengine/godot/issues/34242
Fixes https://github.com/godotengine/godot/issues/34215
Fixes https://github.com/godotengine/godot/issues/32138
Fixes https://github.com/godotengine/godot/issues/27689
Fixes https://github.com/godotengine/godot/issues/27652
Fixes https://github.com/godotengine/godot/issues/7920
Fixes https://github.com/godotengine/godot/issues/9332
*Bugsquad edit:* Fixes #40006
(probably few more, too lazy to find all of them)

Removing [this check](https://github.com/godotengine/godot/pull/36280/files#diff-6c47c53691e42eac4273e709791caa37L301) seems to fix them ~~or at least occur less frequently~~. I can't come up with a reason why that check was there before.

~~There are still problems when a body is being pushed through one-way collision, I'm trying to figure out how to fix it.~~

UPDATE: Some (lots of, actually) debugging  lead me to several issues in `servers/physics_2d/space_2d_sw.cpp`:
1. We're setting `invalid_by_dir` at the beginning of do...while loop, no reason to set it again and again
2. When we are calculating `cbk.valid_depth` we need take the motion of current body into account as well as platform's motion
3. When applying `recover_motion` we used to multiply it by magic `0.4`. Thus the entire do...while loop could end **only** when run out of `recover_attempts`.

UPDATE2: Looks like I fixed all one-way collision bugs except mine :smile: 
So, the reason to "weaken" [this condition](https://github.com/godotengine/godot/pull/36280/files#diff-2690fb5a19c73f3f0f4a434e992a8d8dR177) in `servers/physics_2d/physics_2d_server_sw.cpp` is how TileMaps work. If your body is moving along TileMap line, there will be a moment when it'll step on a new tile. In that case it's movement will not match the condition and it will fall through that new tile.

UPDATE3: The last commit also fixes https://github.com/godotengine/godot/issues/28895
UPDATE4: I uploaded 3.2 builds with this patch included here so it'll be easier to test it: https://pepya.tk/nextcloud/index.php/s/3Bqbfe7EMsrE9px

Before merging this, I highly recommend merging https://github.com/godotengine/godot/pull/38471 first, it fixes most of the bugs in a proper and clean way.