### PR TITLE
Allow using `MeshLibrary.get_item_preview()` in non-editor builds again

### DIFF
--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -84,8 +84,7 @@
 			<argument index="0" name="id" type="int">
 			</argument>
 			<description>
-				Returns a generated item preview (a 3D rendering in isometric perspective).
-				[b]Note:[/b] Since item previews are only generated in an editor context, this function will return an empty [Texture2D] in a running project.
+				When running in the editor, returns a generated item preview (a 3D rendering in isometric perspective). When used in a running project, returns the manually-defined item preview which can be set using [method set_item_preview]. Returns an empty [Texture2D] if no preview was manually set in a running project.
 			</description>
 		</method>
 		<method name="get_item_shapes" qualifiers="const">

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -29,7 +29,6 @@
 /*************************************************************************/
 
 #include "mesh_library.h"
-#include "core/engine.h"
 
 bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 
@@ -201,11 +200,6 @@ Transform MeshLibrary::get_item_navmesh_transform(int p_item) const {
 }
 
 Ref<Texture2D> MeshLibrary::get_item_preview(int p_item) const {
-
-	if (!Engine::get_singleton()->is_editor_hint()) {
-		ERR_PRINT("MeshLibrary item previews are only generated in an editor context, which means they aren't available in a running project.");
-		return Ref<Texture2D>();
-	}
 
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<Texture2D>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].preview;


### PR DESCRIPTION
This closes #36268.