### PR TITLE
ClassDB: Workaround double-free for GDScript

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -1410,7 +1410,10 @@ Variant ClassDB::class_get_default_property_value(const StringName &p_class, con
 			cleanup_c = false;
 		} else if (ClassDB::can_instance(p_class)) {
 			c = ClassDB::instance(p_class);
-			cleanup_c = true;
+#ifndef _MSC_VER
+#warning FIXME: ObjectID refactoring broke GDScript handling of reference pointers, this needs a proper fix.
+#endif
+			cleanup_c = (p_class != StringName("GDScript"));
 		}
 
 		if (c) {


### PR DESCRIPTION
This is a temporary hack until vnen and reduz can work on a proper fix.
The changes in 867d073b98344b848c96012418912a7e72841a31 exposed a
GDScript issue, which apparently triggers an automatic unreferencing.

This hack only makes it possible to use the editor again, but GDScript
is still broken.

Supersedes #36270 with a slightly finer hack, but credits to @Chaosus for the initial debugging.