### PR TITLE
Fix typo/spelling: "exisiting" -> "existing"

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2410,7 +2410,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	menu->clear();
 
 	Ref<Script> existing_script;
-	bool exisiting_script_removable = true;
+	bool existing_script_removable = true;
 	if (selection.size() == 1) {
 
 		Node *selected = selection[0];
@@ -2432,7 +2432,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		existing_script = selected->get_script();
 
 		if (EditorNode::get_singleton()->get_object_custom_type_base(selected) == existing_script) {
-			exisiting_script_removable = false;
+			existing_script_removable = false;
 		}
 	}
 
@@ -2446,7 +2446,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 				menu->add_icon_shortcut(get_icon("ScriptExtend", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/extend_script"), TOOL_EXTEND_SCRIPT);
 			}
 		}
-		if (existing_script.is_valid() && exisiting_script_removable) {
+		if (existing_script.is_valid() && existing_script_removable) {
 			add_separator = true;
 			menu->add_icon_shortcut(get_icon("ScriptRemove", "EditorIcons"), ED_GET_SHORTCUT("scene_tree/clear_script"), TOOL_CLEAR_SCRIPT);
 		} else if (full_selection.size() > 1) {


### PR DESCRIPTION
Specifically: "exisiting_script_removable" -> "existing_script_removable"

Note:

 * I haven't tested this change.

 * Not sure why this was missed by [codespell](https://github.com/godotengine/godot/commit/ab3bccdb78cc7dffb6ab796053ef63489f05558d)?