### PR TITLE
Reset origin of dragged scene preview

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5901,6 +5901,15 @@ void CanvasItemEditorViewport::_create_preview(const Vector<String> &files) cons
 					Node *instance = scene->instance();
 					if (instance) {
 						preview_node->add_child(instance);
+
+						Node2D *n = Object::cast_to<Node2D>(instance);
+						if (n) {
+							n->set_position(Vector2());
+						}
+						Control *c = Object::cast_to<Control>(instance);
+						if (c) {
+							c->set_begin(Point2());
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Closes half of #26549

Before:
![pkwwkT5i7E](https://user-images.githubusercontent.com/2223172/74679195-744b9280-51bd-11ea-8a51-d2ff276bec5a.gif)

Now:
![Yg38QpIN7o](https://user-images.githubusercontent.com/2223172/74679202-77468300-51bd-11ea-9da2-0f1c670267f2.gif)

I have no idea how to snap this to grid though.