### PR TITLE
Revert "Remove TextFile from public API"

### DIFF
--- a/doc/classes/TextFile.xml
+++ b/doc/classes/TextFile.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TextFile" inherits="Resource" version="4.0">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/scene/resources/text_file.h
+++ b/scene/resources/text_file.h
@@ -36,6 +36,8 @@
 
 class TextFile : public Resource {
 
+	GDCLASS(TextFile, Resource);
+
 private:
 	String text;
 	String path;


### PR DESCRIPTION
Reverts godotengine/godot#36182, fixes- #36297 and prevents it being mistakenly interpreted as the cause for other, refactoring related crashes.
Keeping #36297 open nevertheless to track needed changes to handle the awkwardness of TextFile.