### PR TITLE
Disable NetSocket reuse address on Windows.

### DIFF
--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -673,22 +673,29 @@ void NetSocketPosix::set_tcp_no_delay_enabled(bool p_enabled) {
 void NetSocketPosix::set_reuse_address_enabled(bool p_enabled) {
 	ERR_FAIL_COND(!is_open());
 
+// On Windows, enabling SO_REUSEADDR actually would also enable reuse port, very bad on TCP. Denying...
+// Windows does not have this option, SO_REUSEADDR in this magical world means SO_REUSEPORT
+#ifndef WINDOWS_ENABLED
+	if (_is_stream)
+		return;
 	int par = p_enabled ? 1 : 0;
 	if (setsockopt(_sock, SOL_SOCKET, SO_REUSEADDR, SOCK_CBUF(&par), sizeof(int)) < 0) {
 		WARN_PRINT("Unable to set socket REUSEADDR option!");
 	}
+#endif
 }
 
 void NetSocketPosix::set_reuse_port_enabled(bool p_enabled) {
-// Windows does not have this option, as it is always ON when setting REUSEADDR.
-#ifndef WINDOWS_ENABLED
 	ERR_FAIL_COND(!is_open());
 
+// See comment above...
+#ifdef WINDOWS_ENABLED
+#define SO_REUSEPORT SO_REUSEADDR
+#endif
 	int par = p_enabled ? 1 : 0;
 	if (setsockopt(_sock, SOL_SOCKET, SO_REUSEPORT, SOCK_CBUF(&par), sizeof(int)) < 0) {
 		WARN_PRINT("Unable to set socket REUSEPORT option!");
 	}
-#endif
 }
 
 bool NetSocketPosix::is_open() const {


### PR DESCRIPTION
It actually means reuse port -.- ...

See https://docs.microsoft.com/en-us/windows/win32/winsock/so-exclusiveaddruse .

Potentially fixes #35350 . Needs testing.