### PR TITLE
Mark 2 constructors with noexcept.

### DIFF
--- a/core/color.h
+++ b/core/color.h
@@ -217,7 +217,7 @@ struct Color {
 	/**
 	 * RGB / RGBA construct parameters. Alpha is optional, but defaults to 1.0
 	 */
-	_FORCE_INLINE_ Color(float p_r, float p_g, float p_b, float p_a = 1.0) {
+	_FORCE_INLINE_ Color(float p_r, float p_g, float p_b, float p_a = 1.0) noexcept {
 		r = p_r;
 		g = p_g;
 		b = p_b;

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -158,7 +158,7 @@ struct Vector3 {
 		z = p_ivec.z;
 	}
 
-	_FORCE_INLINE_ Vector3(real_t p_x, real_t p_y, real_t p_z) {
+	_FORCE_INLINE_ Vector3(real_t p_x, real_t p_y, real_t p_z) noexcept {
 		x = p_x;
 		y = p_y;
 		z = p_z;


### PR DESCRIPTION
That removes 2 -Wnoexcept warnings seen and
fixes #36325.