### PR TITLE
Fix compilation warnings and re-enable werror=yes on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     - SCONS_CACHE=$HOME/.scons_cache/$TRAVIS_BRANCH
     - SCONS_CACHE_LIMIT=1024
-    - OPTIONS="debug_symbols=no verbose=yes progress=no builtin_libpng=yes"
+    - OPTIONS="debug_symbols=no verbose=yes progress=no"
     - secure: "uch9QszCgsl1qVbuzY41P7S2hWL2IiNFV4SbAYRCdi0oJ9MIu+pVyrQdpf3+jG4rH6j4Rffl+sN17Zz4dIDDioFL1JwqyCqyCyswR8uACC0Rr8gr4Mi3+HIRbv+2s2P4cIQq41JM8FJe84k9jLEMGCGh69w+ibCWoWs74CokYVA="
 
 cache:
@@ -33,7 +33,7 @@ matrix:
 
     - name: Linux editor (debug, GCC 9, with Mono)
       stage: build
-      env: PLATFORM=x11 TOOLS=yes TARGET=debug CACHE_NAME=${PLATFORM}-tools-mono-gcc-9 MATRIX_EVAL="CC=gcc-9 && CXX=g++-9" EXTRA_ARGS="module_mono_enabled=yes mono_glue=no warnings=extra"
+      env: PLATFORM=x11 TOOLS=yes TARGET=debug CACHE_NAME=${PLATFORM}-tools-mono-gcc-9 MATRIX_EVAL="CC=gcc-9 && CXX=g++-9" EXTRA_ARGS="module_mono_enabled=yes mono_glue=no warnings=extra werror=yes"
       os: linux
       compiler: gcc-9
       addons:
@@ -48,7 +48,7 @@ matrix:
 
     - name: Linux export template (release, Clang)
       stage: build
-      env: PLATFORM=x11 TOOLS=no TARGET=release CACHE_NAME=${PLATFORM}-clang EXTRA_ARGS="warnings=extra"
+      env: PLATFORM=x11 TOOLS=no TARGET=release CACHE_NAME=${PLATFORM}-clang EXTRA_ARGS="warnings=extra werror=yes"
       os: linux
       compiler: clang
       addons:
@@ -70,7 +70,7 @@ matrix:
 
     - name: macOS editor (debug, Clang)
       stage: build
-      env: PLATFORM=osx TOOLS=yes TARGET=debug CACHE_NAME=${PLATFORM}-tools-clang EXTRA_ARGS="warnings=extra" # werror=yes
+      env: PLATFORM=osx TOOLS=yes TARGET=debug CACHE_NAME=${PLATFORM}-tools-clang EXTRA_ARGS="warnings=extra werror=yes"
       os: osx
       compiler: clang
       addons:

--- a/SConstruct
+++ b/SConstruct
@@ -357,7 +357,8 @@ if selected_platform in platform_list:
                 env.Append(CCFLAGS=['-Walloc-zero',
                     '-Wduplicated-branches', '-Wduplicated-cond',
                     '-Wstringop-overflow=4', '-Wlogical-op'])
-                env.Append(CXXFLAGS=['-Wnoexcept', '-Wplacement-new=1'])
+                # -Wnoexcept was removed temporarily due to GH-36325.
+                env.Append(CXXFLAGS=['-Wplacement-new=1'])
                 version = methods.get_compiler_version(env)
                 if version != None and version[0] >= '9':
                     env.Append(CCFLAGS=['-Wattribute-alias=2'])
@@ -369,6 +370,11 @@ if selected_platform in platform_list:
             env.Append(CCFLAGS=['-w'])
         if (env["werror"]):
             env.Append(CCFLAGS=['-Werror'])
+            # FIXME: Temporary workaround after the Vulkan merge, remove once warnings are fixed.
+            if methods.using_gcc(env):
+                env.Append(CXXFLAGS=['-Wno-error=cpp'])
+            else:
+                env.Append(CXXFLAGS=['-Wno-error=#warnings'])
         else: # always enable those errors
             env.Append(CCFLAGS=['-Werror=return-type'])
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1040,9 +1040,6 @@
 		</member>
 		<member name="rendering/quality/reflection_atlas/reflection_size.mobile" type="int" setter="" getter="" default="128">
 		</member>
-		<member name="rendering/quality/reflections/atlas_size" type="int" setter="" getter="" default="2048">
-			Size of the atlas used by reflection probes. A larger size can result in higher visual quality, while a smaller size will be faster and take up less memory.
-		</member>
 		<member name="rendering/quality/reflections/ggx_samples" type="int" setter="" getter="" default="1024">
 		</member>
 		<member name="rendering/quality/reflections/ggx_samples.mobile" type="int" setter="" getter="" default="128">

--- a/modules/basis_universal/register_types.cpp
+++ b/modules/basis_universal/register_types.cpp
@@ -52,11 +52,10 @@ enum BasisDecompressFormat {
 
 basist::etc1_global_selector_codebook *sel_codebook = nullptr;
 
+#ifdef TOOLS_ENABLED
 static Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::UsedChannels p_channels) {
 
 	Vector<uint8_t> budata;
-
-#ifdef TOOLS_ENABLED
 
 	{
 		Ref<Image> image = p_image->duplicate();
@@ -117,14 +116,10 @@ static Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::
 #ifdef USE_RG_AS_RGBA
 				image->convert_rg_to_ra_rgba8();
 				decompress_format = BASIS_DECOMPRESS_RG_AS_RA;
-
 #else
-
 				params.m_seperate_rg_to_color_alpha = true;
 				decompress_format = BASIS_DECOMPRESS_RG;
-
 #endif
-
 			} break;
 			case Image::USED_CHANNELS_RGB: {
 				decompress_format = BASIS_DECOMPRESS_RGB;
@@ -152,9 +147,9 @@ static Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::
 		}
 	}
 
-#endif
 	return budata;
 }
+#endif // TOOLS_ENABLED
 
 static Ref<Image> basis_universal_unpacker(const Vector<uint8_t> &p_buffer) {
 	Ref<Image> image;
@@ -286,7 +281,7 @@ void unregister_basis_universal_types() {
 
 #ifdef TOOLS_ENABLED
 	delete sel_codebook;
-#endif
 	Image::basis_universal_packer = NULL;
+#endif
 	Image::basis_universal_unpacker = NULL;
 }

--- a/modules/glslang/SCsub
+++ b/modules/glslang/SCsub
@@ -58,7 +58,11 @@ if env['builtin_glslang']:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_glslang.Prepend(CPPPATH=[thirdparty_dir])
+    # Treat glslang headers as system headers to avoid raising warnings. Not supported on MSVC.
+    if not env.msvc:
+        env_glslang.Append(CPPFLAGS=['-isystem', Dir(thirdparty_dir).path])
+    else:
+        env_glslang.Prepend(CPPPATH=[thirdparty_dir])
 
     env_thirdparty = env_glslang.Clone()
     env_thirdparty.disable_warnings()

--- a/scene/3d/soft_body.cpp
+++ b/scene/3d/soft_body.cpp
@@ -561,7 +561,6 @@ const NodePath &SoftBody::get_parent_collision_ignore() const {
 
 void SoftBody::set_pinned_points_indices(Vector<SoftBody::PinnedPoint> p_pinned_points_indices) {
 	pinned_points = p_pinned_points_indices;
-	const PinnedPoint *w = pinned_points.ptr();
 	for (int i = pinned_points.size() - 1; 0 <= i; --i) {
 		pin_point(p_pinned_points_indices[i].point_index, true);
 	}

--- a/scene/3d/voxelizer.h
+++ b/scene/3d/voxelizer.h
@@ -109,7 +109,6 @@ private:
 	int color_scan_cell_width;
 	int bake_texture_size;
 	float cell_size;
-	float propagation;
 
 	int max_original_cells;
 	int leaf_voxel_count;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2073,8 +2073,6 @@ SceneTree::SceneTree() {
 	root->set_as_audio_listener_2d(true);
 	current_scene = NULL;
 
-	int ref_atlas_size = GLOBAL_DEF("rendering/quality/reflections/atlas_size", 2048);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/reflections/atlas_size", PropertyInfo(Variant::INT, "rendering/quality/reflections/atlas_size", PROPERTY_HINT_RANGE, "0,8192,or_greater")); //next_power_of_2 will return a 0 as min value
 	int msaa_mode = GLOBAL_DEF("rendering/quality/filters/msaa", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/filters/msaa", PropertyInfo(Variant::INT, "rendering/quality/filters/msaa", PROPERTY_HINT_ENUM, "Disabled,2x,4x,8x,16x,AndroidVR 2x,AndroidVR 4x"));
 	root->set_msaa(Viewport::MSAA(msaa_mode));

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -537,58 +537,36 @@ Vector<SurfaceTool::Vertex> SurfaceTool::create_vertex_array_from_triangle_array
 	Vector<float> warr = p_arrays[VS::ARRAY_WEIGHTS];
 
 	int vc = varr.size();
-
 	if (vc == 0)
 		return ret;
-	int lformat = 0;
 
-	const Vector3 *rv;
+	int lformat = 0;
 	if (varr.size()) {
 		lformat |= VS::ARRAY_FORMAT_VERTEX;
-		rv = varr.ptr();
 	}
-	const Vector3 *rn;
 	if (narr.size()) {
 		lformat |= VS::ARRAY_FORMAT_NORMAL;
-		rn = narr.ptr();
 	}
-	const float *rt;
 	if (tarr.size()) {
 		lformat |= VS::ARRAY_FORMAT_TANGENT;
-		rt = tarr.ptr();
 	}
-	const Color *rc;
 	if (carr.size()) {
 		lformat |= VS::ARRAY_FORMAT_COLOR;
-		rc = carr.ptr();
 	}
-
-	const Vector2 *ruv;
 	if (uvarr.size()) {
 		lformat |= VS::ARRAY_FORMAT_TEX_UV;
-		ruv = uvarr.ptr();
 	}
-
-	const Vector2 *ruv2;
 	if (uv2arr.size()) {
 		lformat |= VS::ARRAY_FORMAT_TEX_UV2;
-		ruv2 = uv2arr.ptr();
 	}
-
-	const int *rb;
 	if (barr.size()) {
 		lformat |= VS::ARRAY_FORMAT_BONES;
-		rb = barr.ptr();
 	}
-
-	const float *rw;
 	if (warr.size()) {
 		lformat |= VS::ARRAY_FORMAT_WEIGHTS;
-		rw = warr.ptr();
 	}
 
 	for (int i = 0; i < vc; i++) {
-
 		Vertex v;
 		if (lformat & VS::ARRAY_FORMAT_VERTEX)
 			v.vertex = varr[i];
@@ -642,58 +620,36 @@ void SurfaceTool::_create_list_from_arrays(Array arr, List<Vertex> *r_vertex, Li
 	Vector<float> warr = arr[VS::ARRAY_WEIGHTS];
 
 	int vc = varr.size();
-
 	if (vc == 0)
 		return;
-	lformat = 0;
 
-	const Vector3 *rv;
+	lformat = 0;
 	if (varr.size()) {
 		lformat |= VS::ARRAY_FORMAT_VERTEX;
-		rv = varr.ptr();
 	}
-	const Vector3 *rn;
 	if (narr.size()) {
 		lformat |= VS::ARRAY_FORMAT_NORMAL;
-		rn = narr.ptr();
 	}
-	const float *rt;
 	if (tarr.size()) {
 		lformat |= VS::ARRAY_FORMAT_TANGENT;
-		rt = tarr.ptr();
 	}
-	const Color *rc;
 	if (carr.size()) {
 		lformat |= VS::ARRAY_FORMAT_COLOR;
-		rc = carr.ptr();
 	}
-
-	const Vector2 *ruv;
 	if (uvarr.size()) {
 		lformat |= VS::ARRAY_FORMAT_TEX_UV;
-		ruv = uvarr.ptr();
 	}
-
-	const Vector2 *ruv2;
 	if (uv2arr.size()) {
 		lformat |= VS::ARRAY_FORMAT_TEX_UV2;
-		ruv2 = uv2arr.ptr();
 	}
-
-	const int *rb;
 	if (barr.size()) {
 		lformat |= VS::ARRAY_FORMAT_BONES;
-		rb = barr.ptr();
 	}
-
-	const float *rw;
 	if (warr.size()) {
 		lformat |= VS::ARRAY_FORMAT_WEIGHTS;
-		rw = warr.ptr();
 	}
 
 	for (int i = 0; i < vc; i++) {
-
 		Vertex v;
 		if (lformat & VS::ARRAY_FORMAT_VERTEX)
 			v.vertex = varr[i];

--- a/servers/visual/rasterizer_rd/rasterizer_canvas_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_canvas_rd.cpp
@@ -991,6 +991,15 @@ void RasterizerCanvasRD::_render_item(RD::DrawListID p_draw_list, const Item *p_
 				}
 
 			} break;
+			case Item::Command::TYPE_MESH:
+			case Item::Command::TYPE_MULTIMESH:
+			case Item::Command::TYPE_PARTICLES: {
+				ERR_PRINT("FIXME: Mesh, MultiMesh and Particles render commands are unimplemented currently, they need to be ported to the 4.0 rendering architecture.");
+#ifndef _MSC_VER
+#warning Item::Command types for Mesh, MultiMesh and Particles need to be implemented.
+#endif
+				// See #if 0'ed code below to port from GLES3.
+			} break;
 
 #if 0
 			case Item::Command::TYPE_MESH: {

--- a/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -67,18 +67,6 @@ static _FORCE_INLINE_ void store_transform_3x3(const Transform &p_mtx, float *p_
 	p_array[11] = 0;
 }
 
-static _FORCE_INLINE_ void store_transform_3x3_430(const Transform &p_mtx, float *p_array) {
-	p_array[0] = p_mtx.basis.elements[0][0];
-	p_array[1] = p_mtx.basis.elements[1][0];
-	p_array[2] = p_mtx.basis.elements[2][0];
-	p_array[3] = p_mtx.basis.elements[0][1];
-	p_array[4] = p_mtx.basis.elements[1][1];
-	p_array[5] = p_mtx.basis.elements[2][1];
-	p_array[6] = p_mtx.basis.elements[0][2];
-	p_array[7] = p_mtx.basis.elements[1][2];
-	p_array[8] = p_mtx.basis.elements[2][2];
-}
-
 static _FORCE_INLINE_ void store_camera(const CameraMatrix &p_mtx, float *p_array) {
 
 	for (int i = 0; i < 4; i++) {

--- a/servers/visual/rasterizer_rd/rasterizer_scene_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_rd.cpp
@@ -2745,7 +2745,6 @@ void RasterizerSceneRD::render_shadow(RID p_light, RID p_shadow_atlas, int p_pas
 
 	Rect2i atlas_rect;
 	RID atlas_fb;
-	int atlas_fb_size;
 
 	bool using_dual_paraboloid = false;
 	bool using_dual_paraboloid_flip = false;
@@ -2816,7 +2815,6 @@ void RasterizerSceneRD::render_shadow(RID p_light, RID p_shadow_atlas, int p_pas
 		render_fb = shadow_map->fb;
 		render_texture = shadow_map->depth;
 		atlas_fb = directional_shadow.fb;
-		atlas_fb_size = directional_shadow.size;
 
 	} else {
 		//set from shadow atlas
@@ -2844,7 +2842,6 @@ void RasterizerSceneRD::render_shadow(RID p_light, RID p_shadow_atlas, int p_pas
 		atlas_rect.size.width = shadow_size;
 		atlas_rect.size.height = shadow_size;
 		atlas_fb = shadow_atlas->fb;
-		atlas_fb_size = shadow_atlas->size;
 
 		zfar = storage->light_get_param(light_instance->light, VS::LIGHT_PARAM_RANGE);
 		bias = storage->light_get_param(light_instance->light, VS::LIGHT_PARAM_SHADOW_BIAS);

--- a/servers/visual/rasterizer_rd/rasterizer_storage_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_storage_rd.cpp
@@ -1944,7 +1944,7 @@ int RasterizerStorageRD::mesh_get_blend_shape_count(RID p_mesh) const {
 void RasterizerStorageRD::mesh_set_blend_shape_mode(RID p_mesh, VS::BlendShapeMode p_mode) {
 	Mesh *mesh = mesh_owner.getornull(p_mesh);
 	ERR_FAIL_COND(!mesh);
-	ERR_FAIL_INDEX(p_mode, 2);
+	ERR_FAIL_INDEX((int)p_mode, 2);
 
 	mesh->blend_shape_mode = p_mode;
 }
@@ -2636,7 +2636,7 @@ void RasterizerStorageRD::multimesh_instance_set_custom_data(RID p_multimesh, in
 	MultiMesh *multimesh = multimesh_owner.getornull(p_multimesh);
 	ERR_FAIL_COND(!multimesh);
 	ERR_FAIL_INDEX(p_index, multimesh->instances);
-	ERR_FAIL_INDEX(p_index, !multimesh->uses_custom_data);
+	ERR_FAIL_COND(!multimesh->uses_custom_data);
 
 	_multimesh_make_local(multimesh);
 
@@ -2723,7 +2723,7 @@ Color RasterizerStorageRD::multimesh_instance_get_color(RID p_multimesh, int p_i
 	MultiMesh *multimesh = multimesh_owner.getornull(p_multimesh);
 	ERR_FAIL_COND_V(!multimesh, Color());
 	ERR_FAIL_INDEX_V(p_index, multimesh->instances, Color());
-	ERR_FAIL_INDEX_V(p_index, !multimesh->uses_colors, Color());
+	ERR_FAIL_COND_V(!multimesh->uses_colors, Color());
 
 	_multimesh_make_local(multimesh);
 
@@ -2746,7 +2746,7 @@ Color RasterizerStorageRD::multimesh_instance_get_custom_data(RID p_multimesh, i
 	MultiMesh *multimesh = multimesh_owner.getornull(p_multimesh);
 	ERR_FAIL_COND_V(!multimesh, Color());
 	ERR_FAIL_INDEX_V(p_index, multimesh->instances, Color());
-	ERR_FAIL_INDEX_V(p_index, !multimesh->uses_custom_data, Color());
+	ERR_FAIL_COND_V(!multimesh->uses_custom_data, Color());
 
 	_multimesh_make_local(multimesh);
 

--- a/servers/visual/rasterizer_rd/render_pipeline_vertex_format_cache_rd.h
+++ b/servers/visual/rasterizer_rd/render_pipeline_vertex_format_cache_rd.h
@@ -41,7 +41,6 @@ class RenderPipelineVertexFormatCacheRD {
 	RID shader;
 	uint32_t input_mask;
 
-	RD::FramebufferFormatID framebuffer_format;
 	RD::RenderPrimitive render_primitive;
 	RD::PipelineRasterizationState rasterization_state;
 	RD::PipelineMultisampleState multisample_state;

--- a/servers/visual/rasterizer_rd/shader_rd.h
+++ b/servers/visual/rasterizer_rd/shader_rd.h
@@ -35,6 +35,7 @@
 #include "core/map.h"
 #include "core/rid_owner.h"
 #include "core/variant.h"
+
 #include <stdio.h>
 #include <mutex>
 /**
@@ -47,11 +48,7 @@ class ShaderRD {
 	CharString general_defines;
 	Vector<CharString> variant_defines;
 
-	int vertex_code_start;
-	int fragment_code_start;
-
 	struct Version {
-
 		CharString uniforms;
 		CharString vertex_globals;
 		CharString vertex_code;


### PR DESCRIPTION
Fix -Wunused-variable, -Wunused-but-set-variable and -Wswitch warnings
raised by GCC 8 and 9.

Fix -Wunused-function, -Wunused-private-field and
-Wtautological-constant-out-of-range-compare raised by Clang.

GCC -Wcpp warnings/Clang -W#warnings (`#warning`) are no longer raising
errors and will thus not abort compilation with `werror=yes`.

Treat glslang headers are system headers to avoid raising warnings.

Re-enables us to build with `werror=yes` on Linux and macOS, thus
catching warnings that would be introduced by new code.

Fixes #36132.