### PR TITLE
Add missing header guards in android api.h

### DIFF
--- a/platform/android/api/api.h
+++ b/platform/android/api/api.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef API_H
+#define API_H
+
 void register_android_api();
 void unregister_android_api();
+
+#endif // API_H


### PR DESCRIPTION
Fixes #36324 
Minor addition doesn't affect the build at all.