### PR TITLE
Dragging a node under the last item of the tree raises it a level

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1221,6 +1221,11 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				if (drop_mode_section == 1 || drop_mode_section == 0) {
 					RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y + r.size.y, r.size.x, 1), cache.drop_position_color);
 				}
+
+				if (drop_mode_section == 2) {
+					// This rect is the same as the drop_mode_section == 1 but sums the item height considering children
+					RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y + get_item_height(p_item), r.size.x, 2), cache.drop_position_color);
+				}
 			}
 
 			Color col = p_item->cells[i].custom_color ? p_item->cells[i].color : get_theme_color(p_item->cells[i].selected ? "font_color_selected" : "font_color");
@@ -3512,7 +3517,33 @@ TreeItem *Tree::_find_item_at_pos(TreeItem *p_item, const Point2 &p_pos, int &r_
 
 			return nullptr;
 		} else {
-			pos.y -= h;
+			if (p_item != root && !p_item->is_collapsed() && !p_item->get_children() && !p_item->get_next() && p_item->get_parent() != root && pos.y < h + cache.vseparation // pos.y < compute_item_height() + 2*vseparation
+					&& drop_mode_flags != DROP_MODE_ON_ITEM) {
+				// This section considers drawing the line on the bottom of the tree
+				section = 2;
+
+				for (int i = 0; i < columns.size(); i++) {
+					int w = get_column_width(i);
+					if (pos.x < w) {
+						r_column = i;
+
+						TreeItem *parent = p_item->get_parent();
+
+						// Second parent to get node at the same tree level as the one dragged on
+						TreeItem *parent2 = parent->get_parent();
+						if (parent2)
+							return parent2;
+						else
+							return parent;
+					}
+
+					pos.x -= w;
+				}
+
+				return NULL;
+			} else {
+				pos.y -= h;
+			}
 		}
 	} else {
 		h = 0;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3517,7 +3517,7 @@ TreeItem *Tree::_find_item_at_pos(TreeItem *p_item, const Point2 &p_pos, int &r_
 
 			return nullptr;
 		} else {
-			if (p_item != root && !p_item->is_collapsed() && !p_item->get_children() && !p_item->get_next() && p_item->get_parent() != root && pos.y < h + cache.vseparation // pos.y < compute_item_height() + 2*vseparation
+			if (p_item != root && !p_item->is_collapsed() && !p_item->get_first_child() && !p_item->get_next() && p_item->get_parent() != root && pos.y < h + cache.vseparation // pos.y < compute_item_height() + 2*vseparation
 					&& drop_mode_flags != DROP_MODE_ON_ITEM) {
 				// This section considers drawing the line on the bottom of the tree
 				section = 2;


### PR DESCRIPTION
A children node couldn't be taken out of the father without scrolling back to the parent node icon
and thus making very troublesome to rearrange a children to be a sibling of its parent if the list of the nodes was long.

By adding an extra dragging line at the end of any children tree we can ensure that the user can move without effort a children up to parent's level even if the parent is many nodes away.

![dragging](https://user-images.githubusercontent.com/45542433/74770082-d5da3280-528b-11ea-970a-c71845389fe0.gif)

If needed, spacing or thickness for the new line can be increased.

EDIT: As requested, thickness has been increased from 1 to 2.

Fixes #34033.