### PR TITLE
Split macOS debug and release export templates into two ZIP archives

### DIFF
--- a/platform/osx/SCsub
+++ b/platform/osx/SCsub
@@ -21,3 +21,17 @@ prog = env.add_program('#bin/godot', files)
 if (env["debug_symbols"] == "full" or env["debug_symbols"] == "yes") and env["separate_debug_symbols"]:
     env.AddPostAction(prog, run_in_subprocess(platform_osx_builders.make_debug_osx))
 
+# Create a ZIP archive so the export template can be used directly in Godot.
+zip_dir = env.Dir('#bin/.osx_zip')
+zip_files = env.InstallAs([
+    zip_dir.File('osx_template.app/Contents/Info.plist'),
+    zip_dir.File('osx_template.app/Contents/PkgInfo'),
+    zip_dir.File('osx_template.app/Contents/Resources/icon.icns'),
+    zip_dir.File('osx_template.app/Contents/MacOS/godot'),
+], [
+    '#misc/dist/osx_template.app/Contents/Info.plist',
+    '#misc/dist/osx_template.app/Contents/PkgInfo',
+    '#misc/dist/osx_template.app/Contents/Resources/icon.icns',
+    prog,
+])
+env.Zip('#bin/godot', zip_files, ZIPROOT=zip_dir, ZIPSUFFIX='${PROGSUFFIX}${ZIPSUFFIX}', ZIPCOMSTR='Archving $SOURCES as $TARGET')

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -45,6 +45,9 @@
 #include "string.h"
 #include <sys/stat.h>
 
+#define EXPORT_TEMPLATE_OSX_RELEASE "osx_release.zip"
+#define EXPORT_TEMPLATE_OSX_DEBUG "osx_debug.zip"
+
 class EditorExportPlatformOSX : public EditorExportPlatform {
 
 	GDCLASS(EditorExportPlatformOSX, EditorExportPlatform);
@@ -465,7 +468,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 
 	if (src_pkg_name == "") {
 		String err;
-		src_pkg_name = find_export_template("osx.zip", &err);
+		src_pkg_name = find_export_template(p_debug ? EXPORT_TEMPLATE_OSX_DEBUG : EXPORT_TEMPLATE_OSX_RELEASE, &err);
 		if (src_pkg_name == "") {
 			EditorNode::add_io_error(err);
 			return ERR_FILE_NOT_FOUND;
@@ -491,8 +494,6 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 	}
 
 	int ret = unzGoToFirstFile(src_pkg_zip);
-
-	String binary_to_use = "godot_osx_" + String(p_debug ? "debug" : "release") + ".64";
 
 	String pkg_name;
 	if (p_preset->get("application/name") != "")
@@ -575,8 +576,8 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			_fix_plist(p_preset, data, pkg_name);
 		}
 
-		if (file.begins_with("Contents/MacOS/godot_")) {
-			if (file != "Contents/MacOS/" + binary_to_use) {
+		if (file.begins_with("Contents/MacOS/godot")) {
+			if (file != "Contents/MacOS/godot") {
 				ret = unzGoToNextFile(src_pkg_zip);
 				continue; //ignore!
 			}
@@ -692,7 +693,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 	unzClose(src_pkg_zip);
 
 	if (!found_binary) {
-		ERR_PRINT("Requested template binary '" + binary_to_use + "' not found. It might be missing from your template archive.");
+		ERR_PRINT("Requested template binary \"godot\" not found. It might be missing from your template archive.");
 		err = ERR_FILE_NOT_FOUND;
 	}
 
@@ -824,8 +825,8 @@ bool EditorExportPlatformOSX::can_export(const Ref<EditorExportPreset> &p_preset
 
 	// Look for export templates (first official, and if defined custom templates).
 
-	bool dvalid = exists_export_template("osx.zip", &err);
-	bool rvalid = dvalid; // Both in the same ZIP.
+	bool dvalid = exists_export_template(EXPORT_TEMPLATE_OSX_DEBUG, &err);
+	bool rvalid = exists_export_template(EXPORT_TEMPLATE_OSX_RELEASE, &err);
 
 	if (p_preset->get("custom_template/debug") != "") {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));


### PR DESCRIPTION
This makes it possible for SCons to generate the ZIPs automatically, as the targets can be built individually. This is more consistent with how other export templates are packaged (especially HTML5).

Please test this, as my limited testing is probably not sufficient to confirm it works without regressions. Most importantly, I'm not sure if file permissions are being set correctly. Extracing the ZIP on Linux or macOS directly after it has built preserves the executable flag, but it's not preserved when extracting an exported project ZIP. Is there a macOS security feature coming into play?

See also #16415, which is about the editor (not export templates).