### PR TITLE
Decrease the script editor's default split width to 70

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3228,7 +3228,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	scripts_vbox->add_child(script_list);
 	script_list->set_custom_minimum_size(Size2(150, 60) * EDSCALE); //need to give a bit of limit to avoid it from disappearing
 	script_list->set_v_size_flags(SIZE_EXPAND_FILL);
-	script_split->set_split_offset(140);
+	script_split->set_split_offset(70 * EDSCALE);
 	_sort_list_on_update = true;
 	script_list->connect("gui_input", this, "_script_list_gui_input", varray(), CONNECT_DEFERRED);
 	script_list->set_allow_rmb_select(true);


### PR DESCRIPTION
This also makes its value change to match the editor scale.

This change increases the screen real estate available to the code editor out of the box. The split width can still be adjusted manually, of course.

Should we decrease it even further? Maybe 60 would be a better default, though it would likely end up cutting longer script names.

## Preview

*Both screenshots were taken in 1920×1080.*

### Before

![2020-02-18_22 55 16](https://user-images.githubusercontent.com/180032/74781653-25c3f400-52a2-11ea-87ef-738e05b722fb.png)

### After

![2020-02-18_22 56 45](https://user-images.githubusercontent.com/180032/74781662-2c526b80-52a2-11ea-9eae-896914c930b4.png)