### PR TITLE
Fix two signal errors, remove unused break_request signals in profilers

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -917,7 +917,6 @@ Variant Object::call(const StringName &p_method, const Variant **p_args, int p_a
 	MethodBind *method = ClassDB::get_method(get_class_name(), p_method);
 
 	if (method) {
-
 		ret = method->call(this, p_args, p_argcount, r_error);
 	} else {
 		r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;

--- a/editor/editor_visual_profiler.cpp
+++ b/editor/editor_visual_profiler.cpp
@@ -588,8 +588,7 @@ void EditorVisualProfiler::_graph_tex_input(const Ref<InputEvent> &p_ev) {
 
 			if (activate->is_pressed()) {
 				if (!seeking) {
-					//probably not need to break request, can just stop profiling
-					//emit_signal("break_request");
+					// Break request is not required, just stop profiling
 				}
 			}
 
@@ -679,7 +678,6 @@ void EditorVisualProfiler::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_item_selected"), &EditorVisualProfiler::_item_selected);
 	ADD_SIGNAL(MethodInfo("enable_profiling", PropertyInfo(Variant::BOOL, "enable")));
-	ADD_SIGNAL(MethodInfo("break_request"));
 }
 
 void EditorVisualProfiler::set_enabled(bool p_enable) {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5413,8 +5413,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	editor_selection->connect("selection_changed", this, "update");
 	editor_selection->connect("selection_changed", this, "_selection_changed");
 
-	editor->call_deferred("connect", "play_pressed", this, "_update_override_camera_button", make_binds(true));
-	editor->call_deferred("connect", "stop_pressed", this, "_update_override_camera_button", make_binds(false));
+	editor->call_deferred("connect", make_binds("play_pressed", this, "_update_override_camera_button", true));
+	editor->call_deferred("connect", make_binds("stop_pressed", this, "_update_override_camera_button", false));
 
 	hb = memnew(HBoxContainer);
 	add_child(hb);

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -2508,7 +2508,6 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		visual_profiler->set_name(TTR("Visual Profiler"));
 		tabs->add_child(visual_profiler);
 		visual_profiler->connect("enable_profiling", this, "_visual_profiler_activate");
-		visual_profiler->connect("break_request", this, "_profiler_seeked");
 	}
 
 	{ //network profiler
@@ -2516,7 +2515,6 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		network_profiler->set_name(TTR("Network Profiler"));
 		tabs->add_child(network_profiler);
 		network_profiler->connect("enable_profiling", this, "_network_profiler_activate");
-		network_profiler->connect("break_request", this, "_profiler_seeked");
 	}
 
 	{ //monitors


### PR DESCRIPTION
This change fixes two errors I found while running the latest master. Not sure when they came about

---

This signal just doesn't exist. I added it, but it currently is never emitted. Keeping it to be consistent with the other profiler classes
```
ERROR: In Object of type 'EditorNetworkProfiler': Attempt to connect nonexistent signal 'break_request' to method 'ScriptEditorDebugger._profiler_seeked'.
   at: connect (core/object.cpp:1452)
```

---

Calling for @rxlecky who authored #27742 

(?) Not sure exactly what was happening here. Presumably `call_deferred` takes a vararg (Vector<Variant>) but the connect will mess up if the binds argument is another vararg.

Once `connect` was called, the first value in `p_args` was `Nil`, now it correctly holds true/false
```
ERROR: Error calling method from signal 'play_pressed': 'CanvasItemEditor::_update_override_camera_button': Cannot convert argument 1 from Nil to bool..
   at: emit_signal (core/object.cpp:1228)
```