### PR TITLE
AppVeyor: Add release build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,10 +13,9 @@ environment:
   - GD_PLATFORM: windows
     TARGET: release_debug
     TOOLS: yes
-# Disabled for performance reasons until master is more stable.
-#  - GD_PLATFORM: windows
-#    TARGET: release
-#    TOOLS: no
+  - GD_PLATFORM: windows
+    TARGET: release
+    TOOLS: no
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Following https://github.com/godotengine/godot/pull/33736#issuecomment-587746822, the addition of the release build was removed from #33736. This PR adds the release build.