### PR TITLE
Persisting view mode for new scene

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2147,6 +2147,8 @@ void SpatialEditorViewport::_notification(int p_what) {
 		set_process(visible);
 
 		if (visible) {
+			orthogonal = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_ORTHOGONAL));
+			_update_name();
 			_update_camera(0);
 		} else {
 			set_freelook_active(false);


### PR DESCRIPTION
Fixes #36339 
Persistence the view mode for a new scene, but don't change the view for the already opened scene. It might be confusing as view mode doesn't persistent for all scenes. 
![Peek 2020-02-19 12-55](https://user-images.githubusercontent.com/29702428/74811475-893c3900-5317-11ea-8708-7cf46d1d2cd0.gif)
PS: Sorry for flickering. 