### PR TITLE
Travis: Fix clang-format on non-master branches

### DIFF
--- a/misc/travis/clang-format.sh
+++ b/misc/travis/clang-format.sh
@@ -3,11 +3,17 @@
 CLANG_FORMAT=clang-format-8
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-    # Check the whole commit range against $TRAVIS_BRANCH, the base merge branch
-    # We could use $TRAVIS_COMMIT_RANGE but it doesn't play well with force pushes
-    RANGE="$(git rev-parse $TRAVIS_BRANCH) HEAD"
+    # Travis only clones the PR branch and uses its HEAD commit as detached HEAD,
+    # so it's problematic when we want an exact commit range for format checks.
+    # We fetch upstream to ensure that we have the proper references to resolve.
+    # Ideally we would use $TRAVIS_COMMIT_RANGE but it doesn't play well with PR
+    # updates, as it only includes changes since the previous state of the PR.
+    git remote add upstream https://github.com/godotengine/godot \
+        --no-tags -f -t $TRAVIS_BRANCH
+    RANGE="upstream/$TRAVIS_BRANCH HEAD"
 else
-    # Test only the last commit
+    # Test only the last commit, since $TRAVIS_COMMIT_RANGE wouldn't support
+    # force pushes.
     RANGE=HEAD
 fi
 


### PR DESCRIPTION
`git diff-tree` used to fail on the `3.2` branch (and other non-master
branches) as Travis doesn't actually check that branch from the remote:
```
fatal: ambiguous argument '3.2': unknown revision or path not in the
working tree.
```

The exit code would still be 0 so we'd miss badly formatted commits
targeting stable branches.

We do it manually to ensure that it's going to work as we want it.