### PR TITLE
Enable Appveyor cache on 3.2 branch.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
       TARGET: release_debug
 
 init:
-  - ps: if ($env:APPVEYOR_REPO_BRANCH -ne "master") { $env:APPVEYOR_CACHE_SKIP_SAVE = "true" }
+  - ps: if ($env:APPVEYOR_REPO_BRANCH -ne "3.2") { $env:APPVEYOR_CACHE_SKIP_SAVE = "true" }
 
 cache:
   - "%SCONS_CACHE_ROOT%"


### PR DESCRIPTION
Further to https://github.com/godotengine/godot/pull/33736#issuecomment-588156933, enabling the cache on the 3.2 branch will speed up CI checks of PRs against the 3.2 branch, which are significantly delaying other CI checks caught in the queue.