### PR TITLE
Fix remembering of an unsaved scene on exit

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2292,6 +2292,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case FILE_CLOSE: {
 			if (!p_confirmed) {
 				tab_closing = p_option == FILE_CLOSE ? editor_data.get_edited_scene() : _next_unsaved_scene(false);
+				_scene_tab_changed(tab_closing);
 
 				if (unsaved_cache || p_option == FILE_CLOSE_ALL_AND_QUIT || p_option == FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER) {
 					String scene_filename = editor_data.get_edited_scene_root(tab_closing)->get_filename();
@@ -2813,6 +2814,10 @@ void EditorNode::_discard_changes(const String &p_str) {
 			_update_scene_tabs();
 
 			if (current_option == FILE_CLOSE_ALL_AND_QUIT || current_option == FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER) {
+				// If restore tabs is enabled, reopen the scene that has just been closed, so it's remembered properly.
+				if (bool(EDITOR_GET("interface/scene_tabs/restore_scenes_on_load"))) {
+					_menu_option_confirm(FILE_OPEN_PREV, true);
+				}
 				if (_next_unsaved_scene(false) == -1) {
 					current_option = current_option == FILE_CLOSE_ALL_AND_QUIT ? FILE_QUIT : RUN_PROJECT_MANAGER;
 					_discard_changes();


### PR DESCRIPTION
So, take 2.

The problem was that the actual flow does not include this possibility: if the save popup appears, the editor always closes the scene by calling `_remove_scene(tab_closing)`.

Obviously, at first I tried to stop the editor from indistinctly removing the scenes, but then it wouldn't work with more than one unsaved scene. I tried different approaches, but every solution broke something else. AFAIK the bottom line is: `_remove_scene` has to be called. So that's why this  fix reopens scenes that have just been closed if the user wants to restore the scene tabs. 

This honestly looks like the best solution to me, it works fine and does not mess around with the flow too much. It's not the most efficient, but the flow would probably need a rework otherwise.
I'd be very interested to know what more experienced developers think about this.

Fixes #33326 