### PR TITLE
rendering_vulkan: VertexDescriptionKey equal comparator was checking …

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -354,7 +354,9 @@ class RenderingDeviceVulkan : public RenderingDevice {
 					if (a.stride != b.stride) {
 						return false;
 					}
-					return a.frequency != b.frequency;
+					if (a.frequency != b.frequency) {
+						return false;
+					}
 				}
 				return true; //they are equal
 			}


### PR DESCRIPTION
…only the first element of his vector of VertexDescription

This comparison operator is used on hashfunc.h (HashMapComparatorDefault struct)
`	static bool compare(const T &p_lhs, const T &p_rhs) {
		return p_lhs == p_rhs;
	}`

from the HashMap on rendering_device_vulkan.h:
`	HashMap<VertexDescriptionKey, VertexFormatID, VertexDescriptionHash> vertex_format_cache;`

I don't know exactly what possible bugs this was causing

Fix #36346