### PR TITLE
RichTextLabel: allow 'scroll_to_line' when scroll_active is 'false'

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -873,7 +873,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 }
 
 void RichTextLabel::_scroll_changed(double) {
-	if (updating_scroll || !scroll_active) {
+	if (updating_scroll) {
 		return;
 	}
 
@@ -2008,6 +2008,7 @@ void RichTextLabel::set_scroll_active(bool p_active) {
 	}
 
 	scroll_active = p_active;
+	vscroll->set_drag_node_enabled(p_active);
 	update();
 }
 

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -506,6 +506,10 @@ void ScrollBar::_drag_node_exit() {
 }
 
 void ScrollBar::_drag_node_input(const Ref<InputEvent> &p_input) {
+	if (!drag_node_enabled) {
+		return;
+	}
+
 	Ref<InputEventMouseButton> mb = p_input;
 
 	if (mb.is_valid()) {
@@ -590,6 +594,10 @@ NodePath ScrollBar::get_drag_node() const {
 	return drag_node_path;
 }
 
+void ScrollBar::set_drag_node_enabled(bool p_enable) {
+	drag_node_enabled = p_enable;
+}
+
 void ScrollBar::set_smooth_scroll_enabled(bool p_enable) {
 	smooth_scroll_enabled = p_enable;
 }
@@ -610,19 +618,6 @@ void ScrollBar::_bind_methods() {
 
 ScrollBar::ScrollBar(Orientation p_orientation) {
 	orientation = p_orientation;
-	highlight = HIGHLIGHT_NONE;
-	custom_step = -1;
-	drag_node = nullptr;
-
-	drag.active = false;
-
-	drag_node_speed = Vector2();
-	drag_node_touching = false;
-	drag_node_touching_deaccel = false;
-
-	scrolling = false;
-	target_scroll = 0;
-	smooth_scroll_enabled = false;
 
 	if (focus_by_default) {
 		set_focus_mode(FOCUS_ALL);

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -47,12 +47,12 @@ class ScrollBar : public Range {
 
 	Orientation orientation;
 	Size2 size;
-	float custom_step;
+	float custom_step = -1;
 
-	HighlightStatus highlight;
+	HighlightStatus highlight = HIGHLIGHT_NONE;
 
 	struct Drag {
-		bool active;
+		bool active = false;
 		float pos_at_click;
 		float value_at_click;
 	} drag;
@@ -66,22 +66,23 @@ class ScrollBar : public Range {
 
 	static void set_can_focus_by_default(bool p_can_focus);
 
-	Node *drag_node;
+	Node *drag_node = nullptr;
 	NodePath drag_node_path;
+	bool drag_node_enabled = true;
 
-	Vector2 drag_node_speed;
+	Vector2 drag_node_speed = Vector2();
 	Vector2 drag_node_accum;
 	Vector2 drag_node_from;
 	Vector2 last_drag_node_accum;
 	float last_drag_node_time;
 	float time_since_motion;
-	bool drag_node_touching;
-	bool drag_node_touching_deaccel;
+	bool drag_node_touching = false;
+	bool drag_node_touching_deaccel = false;
 	bool click_handled;
 
-	bool scrolling;
-	double target_scroll;
-	bool smooth_scroll_enabled;
+	bool scrolling = false;
+	double target_scroll = 0;
+	bool smooth_scroll_enabled = false;
 
 	void _drag_node_exit();
 	void _drag_node_input(const Ref<InputEvent> &p_input);
@@ -99,6 +100,7 @@ public:
 
 	void set_drag_node(const NodePath &p_path);
 	NodePath get_drag_node() const;
+	void set_drag_node_enabled(bool p_enable);
 
 	void set_smooth_scroll_enabled(bool p_enable);
 	bool is_smooth_scroll_enabled() const;


### PR DESCRIPTION
Fixes #36134.

That functionally actually worked previously, but was broken due to fixing other issue: #32964

With my PR both of those stories are satisfied:)