### PR TITLE
TileMap: Set texture_filter and texture_repeat to generated CanvasItems...

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -412,6 +412,9 @@ void TileMap::update_dirty_quadrants() {
 				vs->canvas_item_set_light_mask(canvas_item, get_light_mask());
 				vs->canvas_item_set_z_index(canvas_item, z_index);
 
+				vs->canvas_item_set_default_texture_filter(canvas_item, RS::CanvasItemTextureFilter(CanvasItem::get_texture_filter()));
+				vs->canvas_item_set_default_texture_repeat(canvas_item, RS::CanvasItemTextureRepeat(CanvasItem::get_texture_repeat()));
+
 				q.canvas_items.push_back(canvas_item);
 
 				if (debug_shapes) {
@@ -1685,6 +1688,28 @@ void TileMap::set_clip_uv(bool p_enable) {
 
 bool TileMap::get_clip_uv() const {
 	return clip_uv;
+}
+
+void TileMap::set_texture_filter(TextureFilter p_texture_filter) {
+	CanvasItem::set_texture_filter(p_texture_filter);
+	for (Map<PosKey, Quadrant>::Element *F = quadrant_map.front(); F; F = F->next()) {
+		Quadrant &q = F->get();
+		for (List<RID>::Element *E = q.canvas_items.front(); E; E = E->next()) {
+			RenderingServer::get_singleton()->canvas_item_set_default_texture_filter(E->get(), RS::CanvasItemTextureFilter(p_texture_filter));
+			_make_quadrant_dirty(F);
+		}
+	}
+}
+
+void TileMap::set_texture_repeat(CanvasItem::TextureRepeat p_texture_repeat) {
+	CanvasItem::set_texture_repeat(p_texture_repeat);
+	for (Map<PosKey, Quadrant>::Element *F = quadrant_map.front(); F; F = F->next()) {
+		Quadrant &q = F->get();
+		for (List<RID>::Element *E = q.canvas_items.front(); E; E = E->next()) {
+			RenderingServer::get_singleton()->canvas_item_set_default_texture_repeat(E->get(), RS::CanvasItemTextureRepeat(p_texture_repeat));
+			_make_quadrant_dirty(F);
+		}
+	}
 }
 
 String TileMap::get_configuration_warning() const {

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -342,6 +342,10 @@ public:
 
 	String get_configuration_warning() const override;
 
+	virtual void set_texture_filter(CanvasItem::TextureFilter p_texture_filter) override;
+
+	virtual void set_texture_repeat(CanvasItem::TextureRepeat p_texture_repeat) override;
+
 	void fix_invalid_tiles();
 	void clear();
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1369,6 +1369,7 @@ void CanvasItem::set_texture_filter(TextureFilter p_texture_filter) {
 	}
 	texture_filter = p_texture_filter;
 	_update_texture_filter_changed(true);
+	_change_notify();
 }
 
 CanvasItem::TextureFilter CanvasItem::get_texture_filter() const {
@@ -1421,6 +1422,7 @@ void CanvasItem::set_texture_repeat(TextureRepeat p_texture_repeat) {
 	}
 	texture_repeat = p_texture_repeat;
 	_update_texture_repeat_changed(true);
+	_change_notify();
 }
 
 CanvasItem::TextureRepeat CanvasItem::get_texture_repeat() const {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -405,10 +405,10 @@ public:
 
 	void force_update_transform();
 
-	void set_texture_filter(TextureFilter p_texture_filter);
+	virtual void set_texture_filter(TextureFilter p_texture_filter);
 	TextureFilter get_texture_filter() const;
 
-	void set_texture_repeat(TextureRepeat p_texture_repeat);
+	virtual void set_texture_repeat(TextureRepeat p_texture_repeat);
 	TextureRepeat get_texture_repeat() const;
 
 	// Used by control nodes to retrieve the parent's anchorable area


### PR DESCRIPTION
...  and update when it changes

Fix #36328 

I'm getting used to Godot code, so I copied how to do some things like:

Transform from VisualServer::CanvasItemTextureFilter to CanvasItem::TextureFilter
![image](https://user-images.githubusercontent.com/12563266/74878862-c9ff7680-5346-11ea-9b97-3c320d1b3447.png)
(similar transform from VisualServer::CanvasItemTextureRepeat to CanvasItem::TextureRepeat)

And i change set_texture_filter() and set_texture_repeat() to virtual, similar to set_material to inherit from TileMap for update.