### PR TITLE
Fixes crash when loading StreamTexture from file

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -405,7 +405,6 @@ Ref<Image> StreamTexture::load_image_from_file(FileAccess *f, int p_size_limit) 
 			}
 
 			if (img.is_null() || img->empty()) {
-				memdelete(f);
 				ERR_FAIL_COND_V(img.is_null() || img->empty(), Ref<Image>());
 			}
 


### PR DESCRIPTION
This fixes a regression from #36260. The crash is caused by a double free, reproducable using @qarmin's great The-Worst-Godot-Test-Project™ :)

`StreamTexture::load_image_from_file` deletes the `FileAccess` on one of its fail returns. Since the caller can't figure out whether the `FileAccess` object is deleted on failure, it's better to leave the job to the caller.