### PR TITLE
Unhide hidden members by renaming them and rebind Mesh enums

### DIFF
--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -209,13 +209,19 @@
 		</method>
 	</methods>
 	<members>
-		<member name="blend_shape_mode" type="int" setter="set_blend_shape_mode" getter="get_blend_shape_mode" enum="Mesh.BlendShapeMode" default="1">
-			Sets the blend shape mode to one of [enum Mesh.BlendShapeMode].
+		<member name="blend_shape_mode" type="int" setter="set_blend_shape_mode" getter="get_blend_shape_mode" enum="ArrayMesh.BlendShapeMode" default="1">
+			Sets the blend shape mode to one of [enum ArrayMesh.BlendShapeMode].
 		</member>
 		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB( 0, 0, 0, 0, 0, 0 )">
 			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
 		</member>
 	</members>
 	<constants>
+		<constant name="BLEND_SHAPE_MODE_NORMALIZED" value="0" enum="BlendShapeMode">
+			Blend shapes are normalized.
+		</constant>
+		<constant name="BLEND_SHAPE_MODE_RELATIVE" value="1" enum="BlendShapeMode">
+			Blend shapes are relative to base weight.
+		</constant>
 	</constants>
 </class>

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -50,10 +50,10 @@
 		<method name="get_particle_flag" qualifiers="const">
 			<return type="bool">
 			</return>
-			<argument index="0" name="flag" type="int" enum="CPUParticles2D.Flags">
+			<argument index="0" name="particle_flag" type="int" enum="CPUParticles2D.ParticleFlags">
 			</argument>
 			<description>
-				Returns the enabled state of the given flag (see [enum Flags] for options).
+				Returns the enabled state of the given flag (see [enum ParticleFlags] for options).
 			</description>
 		</method>
 		<method name="restart">
@@ -99,12 +99,12 @@
 		<method name="set_particle_flag">
 			<return type="void">
 			</return>
-			<argument index="0" name="flag" type="int" enum="CPUParticles2D.Flags">
+			<argument index="0" name="particle_flag" type="int" enum="CPUParticles2D.ParticleFlags">
 			</argument>
 			<argument index="1" name="enable" type="bool">
 			</argument>
 			<description>
-				Enables or disables the given flag (see [enum Flags] for options).
+				Enables or disables the given flag (see [enum ParticleFlags] for options).
 			</description>
 		</method>
 	</methods>
@@ -196,9 +196,6 @@
 		<member name="fixed_fps" type="int" setter="set_fixed_fps" getter="get_fixed_fps" default="0">
 			The particle system's frame rate is fixed to a value. For instance, changing the value to 2 will make the particles render at 2 frames per second. Note this does not slow down the simulation of the particle system itself.
 		</member>
-		<member name="flag_align_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
-			Align Y axis of particle with the direction of its velocity.
-		</member>
 		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true">
 			If [code]true[/code], results in fractional delta calculation which has a smoother particles display effect.
 		</member>
@@ -249,6 +246,9 @@
 		</member>
 		<member name="orbit_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness" default="0.0">
 			Orbital velocity randomness ratio.
+		</member>
+		<member name="particle_flag_align_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
+			Align Y axis of particle with the direction of its velocity.
 		</member>
 		<member name="preprocess" type="float" setter="set_pre_process_time" getter="get_pre_process_time" default="0.0">
 			Particle system starts as if it had already run for this many seconds.
@@ -339,17 +339,17 @@
 		<constant name="PARAM_MAX" value="12" enum="Parameter">
 			Represents the size of the [enum Parameter] enum.
 		</constant>
-		<constant name="FLAG_ALIGN_Y_TO_VELOCITY" value="0" enum="Flags">
-			Use with [method set_particle_flag] to set [member flag_align_y].
+		<constant name="PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY" value="0" enum="ParticleFlags">
+			Use with [method set_particle_flag] to set [member particle_flag_align_y].
 		</constant>
-		<constant name="FLAG_ROTATE_Y" value="1" enum="Flags">
+		<constant name="PARTICLE_FLAG_ROTATE_Y" value="1" enum="ParticleFlags">
 			Present for consistency with 3D particle nodes, not used in 2D.
 		</constant>
-		<constant name="FLAG_DISABLE_Z" value="2" enum="Flags">
+		<constant name="PARTICLE_FLAG_DISABLE_Z" value="2" enum="ParticleFlags">
 			Present for consistency with 3D particle nodes, not used in 2D.
 		</constant>
-		<constant name="FLAG_MAX" value="3" enum="Flags">
-			Represents the size of the [enum Flags] enum.
+		<constant name="PARTICLE_FLAG_MAX" value="3" enum="ParticleFlags">
+			Represents the size of the [enum ParticleFlags] enum.
 		</constant>
 		<constant name="EMISSION_SHAPE_POINT" value="0" enum="EmissionShape">
 			All particles will be emitted from a single point.

--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -49,10 +49,10 @@
 		<method name="get_particle_flag" qualifiers="const">
 			<return type="bool">
 			</return>
-			<argument index="0" name="flag" type="int" enum="CPUParticles3D.Flags">
+			<argument index="0" name="particle_flag" type="int" enum="CPUParticles3D.ParticleFlags">
 			</argument>
 			<description>
-				Returns the enabled state of the given flag (see [enum Flags] for options).
+				Returns the enabled state of the given particle flag (see [enum ParticleFlags] for options).
 			</description>
 		</method>
 		<method name="restart">
@@ -98,12 +98,12 @@
 		<method name="set_particle_flag">
 			<return type="void">
 			</return>
-			<argument index="0" name="flag" type="int" enum="CPUParticles3D.Flags">
+			<argument index="0" name="particle_flag" type="int" enum="CPUParticles3D.ParticleFlags">
 			</argument>
 			<argument index="1" name="enable" type="bool">
 			</argument>
 			<description>
-				Enables or disables the given flag (see [enum Flags] for options).
+				Enables or disables the given particle flag (see [enum ParticleFlags] for options).
 			</description>
 		</method>
 	</methods>
@@ -195,15 +195,6 @@
 		<member name="fixed_fps" type="int" setter="set_fixed_fps" getter="get_fixed_fps" default="0">
 			The particle system's frame rate is fixed to a value. For instance, changing the value to 2 will make the particles render at 2 frames per second. Note this does not slow down the particle system itself.
 		</member>
-		<member name="flag_align_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
-			Align Y axis of particle with the direction of its velocity.
-		</member>
-		<member name="flag_disable_z" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
-			If [code]true[/code], particles will not move on the z axis.
-		</member>
-		<member name="flag_rotate_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
-			If [code]true[/code], particles rotate around Y axis by [member angle].
-		</member>
 		<member name="flatness" type="float" setter="set_flatness" getter="get_flatness" default="0.0">
 			Amount of [member spread] in Y/Z plane. A value of [code]1[/code] restricts particles to X/Z plane.
 		</member>
@@ -254,13 +245,22 @@
 		</member>
 		<member name="orbit_velocity" type="float" setter="set_param" getter="get_param">
 			Orbital velocity applied to each particle. Makes the particles circle around origin in the local XY plane. Specified in number of full rotations around origin per second.
-			This property is only available when [member flag_disable_z] is [code]true[/code].
+			This property is only available when [member particle_flag_disable_z] is [code]true[/code].
 		</member>
 		<member name="orbit_velocity_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's orbital velocity will vary along this [Curve].
 		</member>
 		<member name="orbit_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness">
 			Orbital velocity randomness ratio.
+		</member>
+		<member name="particle_flag_align_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
+			Align Y axis of particle with the direction of its velocity.
+		</member>
+		<member name="particle_flag_disable_z" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
+			If [code]true[/code], particles will not move on the Z axis.
+		</member>
+		<member name="particle_flag_rotate_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
+			If [code]true[/code], particles rotate around Y axis by [member angle].
 		</member>
 		<member name="preprocess" type="float" setter="set_pre_process_time" getter="get_pre_process_time" default="0.0">
 			Particle system starts as if it had already run for this many seconds.
@@ -351,17 +351,17 @@
 		<constant name="PARAM_MAX" value="12" enum="Parameter">
 			Represents the size of the [enum Parameter] enum.
 		</constant>
-		<constant name="FLAG_ALIGN_Y_TO_VELOCITY" value="0" enum="Flags">
-			Use with [method set_particle_flag] to set [member flag_align_y].
+		<constant name="PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY" value="0" enum="ParticleFlags">
+			Use with [method set_particle_flag] to set [member particle_flag_align_y].
 		</constant>
-		<constant name="FLAG_ROTATE_Y" value="1" enum="Flags">
-			Use with [method set_particle_flag] to set [member flag_rotate_y].
+		<constant name="PARTICLE_FLAG_ROTATE_Y" value="1" enum="ParticleFlags">
+			Use with [method set_particle_flag] to set [member particle_flag_rotate_y].
 		</constant>
-		<constant name="FLAG_DISABLE_Z" value="2" enum="Flags">
-			Use with [method set_particle_flag] to set [member flag_disable_z].
+		<constant name="PARTICLE_FLAG_DISABLE_Z" value="2" enum="ParticleFlags">
+			Use with [method set_particle_flag] to set [member particle_flag_disable_z].
 		</constant>
-		<constant name="FLAG_MAX" value="3" enum="Flags">
-			Represents the size of the [enum Flags] enum.
+		<constant name="PARTICLE_FLAG_MAX" value="3" enum="ParticleFlags">
+			Represents the size of the [enum ParticleFlags] enum.
 		</constant>
 		<constant name="EMISSION_SHAPE_POINT" value="0" enum="EmissionShape">
 			All particles will be emitted from a single point.

--- a/doc/classes/LightOccluder2D.xml
+++ b/doc/classes/LightOccluder2D.xml
@@ -12,11 +12,11 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="light_mask" type="int" setter="set_occluder_light_mask" getter="get_occluder_light_mask" default="1">
-			The LightOccluder2D's light mask. The LightOccluder2D will cast shadows only from Light2D(s) that have the same light mask(s).
-		</member>
 		<member name="occluder" type="OccluderPolygon2D" setter="set_occluder_polygon" getter="get_occluder_polygon">
 			The [OccluderPolygon2D] used to compute the shadow.
+		</member>
+		<member name="occluder_light_mask" type="int" setter="set_occluder_light_mask" getter="get_occluder_light_mask" default="1">
+			The LightOccluder2D's occluder light mask. The LightOccluder2D will cast shadows only from Light2D(s) that have the same light mask(s).
 		</member>
 		<member name="sdf_collision" type="bool" setter="set_as_sdf_collision" getter="is_set_as_sdf_collision" default="true">
 		</member>

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -126,29 +126,23 @@
 		<constant name="PRIMITIVE_TRIANGLE_STRIP" value="4" enum="PrimitiveType">
 			Render array as triangle strips.
 		</constant>
-		<constant name="BLEND_SHAPE_MODE_NORMALIZED" value="0" enum="BlendShapeMode">
-			Blend shapes are normalized.
-		</constant>
-		<constant name="BLEND_SHAPE_MODE_RELATIVE" value="1" enum="BlendShapeMode">
-			Blend shapes are relative to base weight.
-		</constant>
 		<constant name="ARRAY_VERTEX" value="0" enum="ArrayType">
-			Array of vertices.
+			[PackedVector3Array], [PackedVector2Array], or [Array] of vertex positions.
 		</constant>
 		<constant name="ARRAY_NORMAL" value="1" enum="ArrayType">
-			Array of normals.
+			[PackedVector3Array] of vertex normals.
 		</constant>
 		<constant name="ARRAY_TANGENT" value="2" enum="ArrayType">
-			Array of tangents as an array of floats, 4 floats per tangent.
+			[PackedFloat32Array] of vertex tangents. Each element in groups of 4 floats, first 3 floats determine the tangent, and the last the binormal direction as -1 or 1.
 		</constant>
 		<constant name="ARRAY_COLOR" value="3" enum="ArrayType">
-			Array of colors.
+			[PackedColorArray] of vertex colors.
 		</constant>
 		<constant name="ARRAY_TEX_UV" value="4" enum="ArrayType">
-			Array of UV coordinates.
+			[PackedVector2Array] for UV coordinates.
 		</constant>
 		<constant name="ARRAY_TEX_UV2" value="5" enum="ArrayType">
-			Array of second set of UV coordinates.
+			[PackedVector2Array] for second UV coordinates.
 		</constant>
 		<constant name="ARRAY_CUSTOM0" value="6" enum="ArrayType">
 		</constant>
@@ -159,13 +153,14 @@
 		<constant name="ARRAY_CUSTOM3" value="9" enum="ArrayType">
 		</constant>
 		<constant name="ARRAY_BONES" value="10" enum="ArrayType">
-			Array of bone data.
+			[PackedFloat32Array] or [PackedInt32Array] of bone indices. Each element is a group of 4 numbers.
 		</constant>
 		<constant name="ARRAY_WEIGHTS" value="11" enum="ArrayType">
-			Array of weights.
+			[PackedFloat32Array] of bone weights. Each element in groups of 4 floats.
 		</constant>
 		<constant name="ARRAY_INDEX" value="12" enum="ArrayType">
-			Array of indices.
+			[PackedInt32Array] of integers used as indices referencing vertices, colors, normals, tangents, and textures. All of those arrays must have the same number of elements as the vertex array. No index can be beyond the vertex array size. When this index array is present, it puts the function into "index mode," where the index selects the *i*'th vertex, normal, tangent, color, UV, etc. This means if you want to have different normals or colors along an edge, you have to duplicate the vertices.
+			For triangles, the index array is interpreted as triples, referring to the vertices of each triangle. For lines, the index array is in pairs indicating the start and end of each line.
 		</constant>
 		<constant name="ARRAY_MAX" value="13" enum="ArrayType">
 			Represents the size of the [enum ArrayType] enum.
@@ -187,6 +182,7 @@
 		<constant name="ARRAY_CUSTOM_RGBA_FLOAT" value="7" enum="ArrayCustomFormat">
 		</constant>
 		<constant name="ARRAY_CUSTOM_MAX" value="8" enum="ArrayCustomFormat">
+			Represents the size of the [enum ArrayCustomFormat] enum.
 		</constant>
 		<constant name="ARRAY_FORMAT_VERTEX" value="1" enum="ArrayFormat">
 			Mesh array contains vertices. All meshes require a vertex array so this should always be present.
@@ -223,7 +219,7 @@
 		<constant name="ARRAY_FORMAT_INDEX" value="4096" enum="ArrayFormat">
 			Mesh array uses indices.
 		</constant>
-		<constant name="ARRAY_FORMAT_BLEND_SHAPE_MASK" value="-8185" enum="ArrayFormat">
+		<constant name="ARRAY_FORMAT_BLEND_SHAPE_MASK" value="2147475463" enum="ArrayFormat">
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM_BASE" value="13" enum="ArrayFormat">
 		</constant>

--- a/doc/classes/ParticlesMaterial.xml
+++ b/doc/classes/ParticlesMaterial.xml
@@ -11,15 +11,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_flag" qualifiers="const">
-			<return type="bool">
-			</return>
-			<argument index="0" name="flag" type="int" enum="ParticlesMaterial.Flags">
-			</argument>
-			<description>
-				Returns [code]true[/code] if the specified flag is enabled.
-			</description>
-		</method>
 		<method name="get_param" qualifiers="const">
 			<return type="float">
 			</return>
@@ -47,15 +38,13 @@
 				Returns the [Texture2D] used by the specified parameter.
 			</description>
 		</method>
-		<method name="set_flag">
-			<return type="void">
+		<method name="get_particle_flag" qualifiers="const">
+			<return type="bool">
 			</return>
-			<argument index="0" name="flag" type="int" enum="ParticlesMaterial.Flags">
-			</argument>
-			<argument index="1" name="enable" type="bool">
+			<argument index="0" name="particle_flag" type="int" enum="ParticlesMaterial.ParticleFlags">
 			</argument>
 			<description>
-				If [code]true[/code], enables the specified flag. See [enum Flags] for options.
+				Returns [code]true[/code] if the specified particle flag is enabled. See [enum ParticleFlags] for options.
 			</description>
 		</method>
 		<method name="set_param">
@@ -91,11 +80,22 @@
 				Sets the [Texture2D] for the specified [enum Parameter].
 			</description>
 		</method>
+		<method name="set_particle_flag">
+			<return type="void">
+			</return>
+			<argument index="0" name="particle_flag" type="int" enum="ParticlesMaterial.ParticleFlags">
+			</argument>
+			<argument index="1" name="enable" type="bool">
+			</argument>
+			<description>
+				If [code]true[/code], enables the specified particle flag. See [enum ParticleFlags] for options.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="angle" type="float" setter="set_param" getter="get_param" default="0.0">
 			Initial rotation applied to each particle, in degrees.
-			Only applied when [member flag_disable_z] or [member flag_rotate_y] are [code]true[/code] or the [BaseMaterial3D] being used to draw the particle is using [constant BaseMaterial3D.BILLBOARD_PARTICLES].
+			Only applied when [member particle_flag_disable_z] or [member particle_flag_rotate_y] are [code]true[/code] or the [BaseMaterial3D] being used to draw the particle is using [constant BaseMaterial3D.BILLBOARD_PARTICLES].
 		</member>
 		<member name="angle_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's rotation will be animated along this [CurveTexture].
@@ -105,7 +105,7 @@
 		</member>
 		<member name="angular_velocity" type="float" setter="set_param" getter="get_param" default="0.0">
 			Initial angular velocity applied to each particle. Sets the speed of rotation of the particle.
-			Only applied when [member flag_disable_z] or [member flag_rotate_y] are [code]true[/code] or the [BaseMaterial3D] being used to draw the particle is using [constant BaseMaterial3D.BILLBOARD_PARTICLES].
+			Only applied when [member particle_flag_disable_z] or [member particle_flag_rotate_y] are [code]true[/code] or the [BaseMaterial3D] being used to draw the particle is using [constant BaseMaterial3D.BILLBOARD_PARTICLES].
 		</member>
 		<member name="angular_velocity_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's angular velocity will vary along this [CurveTexture].
@@ -180,15 +180,6 @@
 		<member name="emission_sphere_radius" type="float" setter="set_emission_sphere_radius" getter="get_emission_sphere_radius">
 			The sphere's radius if [code]emission_shape[/code] is set to [constant EMISSION_SHAPE_SPHERE].
 		</member>
-		<member name="flag_align_y" type="bool" setter="set_flag" getter="get_flag" default="false">
-			Align Y axis of particle with the direction of its velocity.
-		</member>
-		<member name="flag_disable_z" type="bool" setter="set_flag" getter="get_flag" default="false">
-			If [code]true[/code], particles will not move on the z axis.
-		</member>
-		<member name="flag_rotate_y" type="bool" setter="set_flag" getter="get_flag" default="false">
-			If [code]true[/code], particles rotate around Y axis by [member angle].
-		</member>
 		<member name="flatness" type="float" setter="set_flatness" getter="get_flatness" default="0.0">
 			Amount of [member spread] in Y/Z plane. A value of [code]1[/code] restricts particles to X/Z plane.
 		</member>
@@ -224,13 +215,22 @@
 		</member>
 		<member name="orbit_velocity" type="float" setter="set_param" getter="get_param">
 			Orbital velocity applied to each particle. Makes the particles circle around origin. Specified in number of full rotations around origin per second.
-			Only available when [member flag_disable_z] is [code]true[/code].
+			Only available when [member particle_flag_disable_z] is [code]true[/code].
 		</member>
 		<member name="orbit_velocity_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's orbital velocity will vary along this [CurveTexture].
 		</member>
 		<member name="orbit_velocity_random" type="float" setter="set_param_randomness" getter="get_param_randomness">
 			Orbital velocity randomness ratio.
+		</member>
+		<member name="particle_flag_align_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
+			Align Y axis of particle with the direction of its velocity.
+		</member>
+		<member name="particle_flag_disable_z" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
+			If [code]true[/code], particles will not move on the z axis.
+		</member>
+		<member name="particle_flag_rotate_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
+			If [code]true[/code], particles rotate around Y axis by [member angle].
 		</member>
 		<member name="radial_accel" type="float" setter="set_param" getter="get_param" default="0.0">
 			Radial acceleration applied to each particle. Makes particle accelerate away from origin.
@@ -311,17 +311,17 @@
 		<constant name="PARAM_MAX" value="12" enum="Parameter">
 			Represents the size of the [enum Parameter] enum.
 		</constant>
-		<constant name="FLAG_ALIGN_Y_TO_VELOCITY" value="0" enum="Flags">
-			Use with [method set_flag] to set [member flag_align_y].
+		<constant name="PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY" value="0" enum="ParticleFlags">
+			Use with [method set_particle_flag] to set [member particle_flag_align_y].
 		</constant>
-		<constant name="FLAG_ROTATE_Y" value="1" enum="Flags">
-			Use with [method set_flag] to set [member flag_rotate_y].
+		<constant name="PARTICLE_FLAG_ROTATE_Y" value="1" enum="ParticleFlags">
+			Use with [method set_particle_flag] to set [member particle_flag_rotate_y].
 		</constant>
-		<constant name="FLAG_DISABLE_Z" value="2" enum="Flags">
-			Use with [method set_flag] to set [member flag_disable_z].
+		<constant name="PARTICLE_FLAG_DISABLE_Z" value="2" enum="ParticleFlags">
+			Use with [method set_particle_flag] to set [member particle_flag_disable_z].
 		</constant>
-		<constant name="FLAG_MAX" value="3" enum="Flags">
-			Represents the size of the [enum Flags] enum.
+		<constant name="PARTICLE_FLAG_MAX" value="3" enum="ParticleFlags">
+			Represents the size of the [enum ParticleFlags] enum.
 		</constant>
 		<constant name="EMISSION_SHAPE_POINT" value="0" enum="EmissionShape">
 			All particles will be emitted from a single point.

--- a/doc/classes/PathFollow2D.xml
+++ b/doc/classes/PathFollow2D.xml
@@ -29,8 +29,8 @@
 		<member name="offset" type="float" setter="set_offset" getter="get_offset" default="0.0">
 			The distance along the path in pixels.
 		</member>
-		<member name="rotate" type="bool" setter="set_rotate" getter="is_rotating" default="true">
-			If [code]true[/code], this node rotates to follow the path, making its descendants rotate.
+		<member name="rotates" type="bool" setter="set_rotates" getter="is_rotating" default="true">
+			If [code]true[/code], this node rotates to follow the path, with the +X direction facing forward on the path.
 		</member>
 		<member name="unit_offset" type="float" setter="set_unit_offset" getter="get_unit_offset" default="0.0">
 			The distance along the path as a number in the range 0.0 (for the first vertex) to 1.0 (for the last). This is just another way of expressing the offset within the path, as the offset supplied is multiplied internally by the path's length.

--- a/doc/classes/RDTextureFormat.xml
+++ b/doc/classes/RDTextureFormat.xml
@@ -37,7 +37,7 @@
 		</member>
 		<member name="samples" type="int" setter="set_samples" getter="get_samples" enum="RenderingDevice.TextureSamples" default="0">
 		</member>
-		<member name="type" type="int" setter="set_type" getter="get_type" enum="RenderingDevice.TextureType" default="1">
+		<member name="texture_type" type="int" setter="set_texture_type" getter="get_texture_type" enum="RenderingDevice.TextureType" default="1">
 		</member>
 		<member name="usage_bits" type="int" setter="set_usage_bits" getter="get_usage_bits" default="0">
 		</member>

--- a/doc/classes/RDUniform.xml
+++ b/doc/classes/RDUniform.xml
@@ -31,7 +31,7 @@
 	<members>
 		<member name="binding" type="int" setter="set_binding" getter="get_binding" default="0">
 		</member>
-		<member name="type" type="int" setter="set_type" getter="get_type" enum="RenderingDevice.UniformType" default="3">
+		<member name="uniform_type" type="int" setter="set_uniform_type" getter="get_uniform_type" enum="RenderingDevice.UniformType" default="3">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3123,7 +3123,7 @@
 		<constant name="ARRAY_FORMAT_INDEX" value="4096" enum="ArrayFormat">
 			Flag used to mark an index array.
 		</constant>
-		<constant name="ARRAY_FORMAT_BLEND_SHAPE_MASK" value="-8185" enum="ArrayFormat">
+		<constant name="ARRAY_FORMAT_BLEND_SHAPE_MASK" value="2147475463" enum="ArrayFormat">
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM_BASE" value="13" enum="ArrayFormat">
 		</constant>

--- a/doc/classes/XRPositionalTracker.xml
+++ b/doc/classes/XRPositionalTracker.xml
@@ -33,13 +33,6 @@
 				Returns the mesh related to a controller or anchor point if one is available.
 			</description>
 		</method>
-		<method name="get_name" qualifiers="const">
-			<return type="StringName">
-			</return>
-			<description>
-				Returns the controller or anchor point's name if available.
-			</description>
-		</method>
 		<method name="get_orientation" qualifiers="const">
 			<return type="Basis">
 			</return>
@@ -59,6 +52,20 @@
 			</return>
 			<description>
 				Returns the internal tracker ID. This uniquely identifies the tracker per tracker type and matches the ID you need to specify for nodes such as the [XRController3D] and [XRAnchor3D] nodes.
+			</description>
+		</method>
+		<method name="get_tracker_name" qualifiers="const">
+			<return type="StringName">
+			</return>
+			<description>
+				Returns the controller or anchor point's name, if applicable.
+			</description>
+		</method>
+		<method name="get_tracker_type" qualifiers="const">
+			<return type="int" enum="XRServer.TrackerType">
+			</return>
+			<description>
+				Returns the tracker's type, which will be one of the values from the [enum XRServer.TrackerType] enum.
 			</description>
 		</method>
 		<method name="get_tracks_orientation" qualifiers="const">
@@ -82,13 +89,6 @@
 			</argument>
 			<description>
 				Returns the transform combining this device's orientation and position.
-			</description>
-		</method>
-		<method name="get_type" qualifiers="const">
-			<return type="int" enum="XRServer.TrackerType">
-			</return>
-			<description>
-				Returns the tracker's type.
 			</description>
 		</method>
 	</methods>

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -4612,8 +4612,8 @@ RID RenderingDeviceVulkan::uniform_set_create(const Vector<Uniform> &p_uniforms,
 
 		const Uniform &uniform = uniforms[uniform_idx];
 
-		ERR_FAIL_COND_V_MSG(uniform.type != set_uniform.type, RID(),
-				"Mismatch uniform type for binding (" + itos(set_uniform.binding) + "), set (" + itos(p_shader_set) + "). Expected '" + shader_uniform_names[set_uniform.type] + "', supplied: '" + shader_uniform_names[uniform.type] + "'.");
+		ERR_FAIL_COND_V_MSG(uniform.uniform_type != set_uniform.type, RID(),
+				"Mismatch uniform type for binding (" + itos(set_uniform.binding) + "), set (" + itos(p_shader_set) + "). Expected '" + shader_uniform_names[set_uniform.type] + "', supplied: '" + shader_uniform_names[uniform.uniform_type] + "'.");
 
 		VkWriteDescriptorSet write; //common header
 		write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -4628,7 +4628,7 @@ RID RenderingDeviceVulkan::uniform_set_create(const Vector<Uniform> &p_uniforms,
 		write.pTexelBufferView = nullptr;
 		uint32_t type_size = 1;
 
-		switch (uniform.type) {
+		switch (uniform.uniform_type) {
 			case UNIFORM_TYPE_SAMPLER: {
 				if (uniform.ids.size() != set_uniform.length) {
 					if (set_uniform.length > 1) {

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -1692,16 +1692,16 @@ RID RenderingDeviceVulkan::texture_create(const TextureFormat &p_format, const T
 #endif
 	}
 
-	if (p_format.type == TEXTURE_TYPE_CUBE || p_format.type == TEXTURE_TYPE_CUBE_ARRAY) {
+	if (p_format.texture_type == TEXTURE_TYPE_CUBE || p_format.texture_type == TEXTURE_TYPE_CUBE_ARRAY) {
 		image_create_info.flags |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
 	}
 	/*if (p_format.type == TEXTURE_TYPE_2D || p_format.type == TEXTURE_TYPE_2D_ARRAY) {
 		image_create_info.flags |= VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
 	}*/
 
-	ERR_FAIL_INDEX_V(p_format.type, TEXTURE_TYPE_MAX, RID());
+	ERR_FAIL_INDEX_V(p_format.texture_type, TEXTURE_TYPE_MAX, RID());
 
-	image_create_info.imageType = vulkan_image_type[p_format.type];
+	image_create_info.imageType = vulkan_image_type[p_format.texture_type];
 
 	ERR_FAIL_COND_V_MSG(p_format.width < 1, RID(), "Width must be equal or greater than 1 for all textures");
 
@@ -1726,10 +1726,10 @@ RID RenderingDeviceVulkan::texture_create(const TextureFormat &p_format, const T
 
 	image_create_info.mipLevels = p_format.mipmaps;
 
-	if (p_format.type == TEXTURE_TYPE_1D_ARRAY || p_format.type == TEXTURE_TYPE_2D_ARRAY || p_format.type == TEXTURE_TYPE_CUBE_ARRAY || p_format.type == TEXTURE_TYPE_CUBE) {
+	if (p_format.texture_type == TEXTURE_TYPE_1D_ARRAY || p_format.texture_type == TEXTURE_TYPE_2D_ARRAY || p_format.texture_type == TEXTURE_TYPE_CUBE_ARRAY || p_format.texture_type == TEXTURE_TYPE_CUBE) {
 		ERR_FAIL_COND_V_MSG(p_format.array_layers < 1, RID(),
 				"Amount of layers must be equal or greater than 1 for arrays and cubemaps.");
-		ERR_FAIL_COND_V_MSG((p_format.type == TEXTURE_TYPE_CUBE_ARRAY || p_format.type == TEXTURE_TYPE_CUBE) && (p_format.array_layers % 6) != 0, RID(),
+		ERR_FAIL_COND_V_MSG((p_format.texture_type == TEXTURE_TYPE_CUBE_ARRAY || p_format.texture_type == TEXTURE_TYPE_CUBE) && (p_format.array_layers % 6) != 0, RID(),
 				"Cubemap and cubemap array textures must provide a layer number that is multiple of 6");
 		image_create_info.arrayLayers = p_format.array_layers;
 	} else {
@@ -1859,7 +1859,7 @@ RID RenderingDeviceVulkan::texture_create(const TextureFormat &p_format, const T
 	VkResult err = vmaCreateImage(allocator, &image_create_info, &allocInfo, &texture.image, &texture.allocation, &texture.allocation_info);
 	ERR_FAIL_COND_V_MSG(err, RID(), "vmaCreateImage failed with error " + itos(err) + ".");
 
-	texture.type = p_format.type;
+	texture.type = p_format.texture_type;
 	texture.format = p_format.format;
 	texture.width = image_create_info.extent.width;
 	texture.height = image_create_info.extent.height;
@@ -1927,7 +1927,7 @@ RID RenderingDeviceVulkan::texture_create(const TextureFormat &p_format, const T
 		VK_IMAGE_VIEW_TYPE_CUBE_ARRAY,
 	};
 
-	image_view_create_info.viewType = view_types[p_format.type];
+	image_view_create_info.viewType = view_types[p_format.texture_type];
 	if (p_view.format_override == DATA_FORMAT_MAX) {
 		image_view_create_info.format = image_create_info.format;
 	} else {

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -470,9 +470,9 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 			p_mesh->add_blend_shape(name);
 		}
 		if (p_morph_data->mode == "RELATIVE") {
-			p_mesh->set_blend_shape_mode(Mesh::BLEND_SHAPE_MODE_RELATIVE);
+			p_mesh->set_blend_shape_mode(ArrayMesh::BLEND_SHAPE_MODE_RELATIVE);
 		} else if (p_morph_data->mode == "NORMALIZED") {
-			p_mesh->set_blend_shape_mode(Mesh::BLEND_SHAPE_MODE_NORMALIZED);
+			p_mesh->set_blend_shape_mode(ArrayMesh::BLEND_SHAPE_MODE_NORMALIZED);
 		}
 	}
 

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -1112,7 +1112,7 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 
 				//ideally BLEND_SHAPE_MODE_RELATIVE since gltf2 stores in displacement
 				//but it could require a larger refactor?
-				mesh.mesh->set_blend_shape_mode(Mesh::BLEND_SHAPE_MODE_NORMALIZED);
+				mesh.mesh->set_blend_shape_mode(ArrayMesh::BLEND_SHAPE_MODE_NORMALIZED);
 
 				if (j == 0) {
 					const Array &target_names = extras.has("targetNames") ? (Array)extras["targetNames"] : Array();

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -792,7 +792,7 @@ bool Light3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<Light3D>(p_spatial) != nullptr;
 }
 
-String Light3DGizmoPlugin::get_name() const {
+String Light3DGizmoPlugin::get_gizmo_name() const {
 	return "Light3D";
 }
 
@@ -1061,7 +1061,7 @@ bool AudioStreamPlayer3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<AudioStreamPlayer3D>(p_spatial) != nullptr;
 }
 
-String AudioStreamPlayer3DGizmoPlugin::get_name() const {
+String AudioStreamPlayer3DGizmoPlugin::get_gizmo_name() const {
 	return "AudioStreamPlayer3D";
 }
 
@@ -1195,7 +1195,7 @@ bool Camera3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<Camera3D>(p_spatial) != nullptr;
 }
 
-String Camera3DGizmoPlugin::get_name() const {
+String Camera3DGizmoPlugin::get_gizmo_name() const {
 	return "Camera3D";
 }
 
@@ -1432,7 +1432,7 @@ bool MeshInstance3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<MeshInstance3D>(p_spatial) != nullptr && Object::cast_to<SoftBody3D>(p_spatial) == nullptr;
 }
 
-String MeshInstance3DGizmoPlugin::get_name() const {
+String MeshInstance3DGizmoPlugin::get_gizmo_name() const {
 	return "MeshInstance3D";
 }
 
@@ -1469,7 +1469,7 @@ bool Sprite3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<Sprite3D>(p_spatial) != nullptr;
 }
 
-String Sprite3DGizmoPlugin::get_name() const {
+String Sprite3DGizmoPlugin::get_gizmo_name() const {
 	return "Sprite3D";
 }
 
@@ -1531,7 +1531,7 @@ bool Position3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<Position3D>(p_spatial) != nullptr;
 }
 
-String Position3DGizmoPlugin::get_name() const {
+String Position3DGizmoPlugin::get_gizmo_name() const {
 	return "Position3D";
 }
 
@@ -1556,7 +1556,7 @@ bool Skeleton3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<Skeleton3D>(p_spatial) != nullptr;
 }
 
-String Skeleton3DGizmoPlugin::get_name() const {
+String Skeleton3DGizmoPlugin::get_gizmo_name() const {
 	return "Skeleton3D";
 }
 
@@ -1758,7 +1758,7 @@ bool PhysicalBone3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<PhysicalBone3D>(p_spatial) != nullptr;
 }
 
-String PhysicalBone3DGizmoPlugin::get_name() const {
+String PhysicalBone3DGizmoPlugin::get_gizmo_name() const {
 	return "PhysicalBone3D";
 }
 
@@ -1895,7 +1895,7 @@ bool RayCast3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<RayCast3D>(p_spatial) != nullptr;
 }
 
-String RayCast3DGizmoPlugin::get_name() const {
+String RayCast3DGizmoPlugin::get_gizmo_name() const {
 	return "RayCast3D";
 }
 
@@ -1947,7 +1947,7 @@ bool SpringArm3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<SpringArm3D>(p_spatial) != nullptr;
 }
 
-String SpringArm3DGizmoPlugin::get_name() const {
+String SpringArm3DGizmoPlugin::get_gizmo_name() const {
 	return "SpringArm3D";
 }
 
@@ -1966,7 +1966,7 @@ bool VehicleWheel3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<VehicleWheel3D>(p_spatial) != nullptr;
 }
 
-String VehicleWheel3DGizmoPlugin::get_name() const {
+String VehicleWheel3DGizmoPlugin::get_gizmo_name() const {
 	return "VehicleWheel3D";
 }
 
@@ -2038,7 +2038,7 @@ bool SoftBody3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<SoftBody3D>(p_spatial) != nullptr;
 }
 
-String SoftBody3DGizmoPlugin::get_name() const {
+String SoftBody3DGizmoPlugin::get_gizmo_name() const {
 	return "SoftBody3D";
 }
 
@@ -2114,7 +2114,7 @@ bool VisibilityNotifier3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<VisibilityNotifier3D>(p_spatial) != nullptr;
 }
 
-String VisibilityNotifier3DGizmoPlugin::get_name() const {
+String VisibilityNotifier3DGizmoPlugin::get_gizmo_name() const {
 	return "VisibilityNotifier3D";
 }
 
@@ -2270,7 +2270,7 @@ bool CPUParticles3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<CPUParticles3D>(p_spatial) != nullptr;
 }
 
-String CPUParticles3DGizmoPlugin::get_name() const {
+String CPUParticles3DGizmoPlugin::get_gizmo_name() const {
 	return "CPUParticles3D";
 }
 
@@ -2302,7 +2302,7 @@ bool GPUParticles3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<GPUParticles3D>(p_spatial) != nullptr;
 }
 
-String GPUParticles3DGizmoPlugin::get_name() const {
+String GPUParticles3DGizmoPlugin::get_gizmo_name() const {
 	return "GPUParticles3D";
 }
 
@@ -2469,7 +2469,7 @@ bool GPUParticlesCollision3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return (Object::cast_to<GPUParticlesCollision3D>(p_spatial) != nullptr) || (Object::cast_to<GPUParticlesAttractor3D>(p_spatial) != nullptr);
 }
 
-String GPUParticlesCollision3DGizmoPlugin::get_name() const {
+String GPUParticlesCollision3DGizmoPlugin::get_gizmo_name() const {
 	return "GPUParticlesCollision3D";
 }
 
@@ -2733,7 +2733,7 @@ bool ReflectionProbeGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<ReflectionProbe>(p_spatial) != nullptr;
 }
 
-String ReflectionProbeGizmoPlugin::get_name() const {
+String ReflectionProbeGizmoPlugin::get_gizmo_name() const {
 	return "ReflectionProbe";
 }
 
@@ -2918,7 +2918,7 @@ bool DecalGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<Decal>(p_spatial) != nullptr;
 }
 
-String DecalGizmoPlugin::get_name() const {
+String DecalGizmoPlugin::get_gizmo_name() const {
 	return "Decal";
 }
 
@@ -3059,7 +3059,7 @@ bool GIProbeGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<GIProbe>(p_spatial) != nullptr;
 }
 
-String GIProbeGizmoPlugin::get_name() const {
+String GIProbeGizmoPlugin::get_gizmo_name() const {
 	return "GIProbe";
 }
 
@@ -3254,7 +3254,7 @@ bool BakedLightmapGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<BakedLightmap>(p_spatial) != nullptr;
 }
 
-String BakedLightmapGizmoPlugin::get_name() const {
+String BakedLightmapGizmoPlugin::get_gizmo_name() const {
 	return "BakedLightmap";
 }
 
@@ -3436,7 +3436,7 @@ bool LightmapProbeGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<LightmapProbe>(p_spatial) != nullptr;
 }
 
-String LightmapProbeGizmoPlugin::get_name() const {
+String LightmapProbeGizmoPlugin::get_gizmo_name() const {
 	return "LightmapProbe";
 }
 
@@ -3520,7 +3520,7 @@ bool CollisionShape3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<CollisionShape3D>(p_spatial) != nullptr;
 }
 
-String CollisionShape3DGizmoPlugin::get_name() const {
+String CollisionShape3DGizmoPlugin::get_gizmo_name() const {
 	return "CollisionShape3D";
 }
 
@@ -4120,7 +4120,7 @@ bool CollisionPolygon3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<CollisionPolygon3D>(p_spatial) != nullptr;
 }
 
-String CollisionPolygon3DGizmoPlugin::get_name() const {
+String CollisionPolygon3DGizmoPlugin::get_gizmo_name() const {
 	return "CollisionPolygon3D";
 }
 
@@ -4167,7 +4167,7 @@ bool NavigationRegion3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<NavigationRegion3D>(p_spatial) != nullptr;
 }
 
-String NavigationRegion3DGizmoPlugin::get_name() const {
+String NavigationRegion3DGizmoPlugin::get_gizmo_name() const {
 	return "NavigationRegion3D";
 }
 
@@ -4532,7 +4532,7 @@ bool Joint3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<Joint3D>(p_spatial) != nullptr;
 }
 
-String Joint3DGizmoPlugin::get_name() const {
+String Joint3DGizmoPlugin::get_gizmo_name() const {
 	return "Joint3D";
 }
 

--- a/editor/node_3d_editor_gizmos.h
+++ b/editor/node_3d_editor_gizmos.h
@@ -41,7 +41,7 @@ class Light3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 
 	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
@@ -58,7 +58,7 @@ class AudioStreamPlayer3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 
 	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
@@ -75,7 +75,7 @@ class Camera3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 
 	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_idx) const override;
@@ -92,7 +92,7 @@ class MeshInstance3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	bool can_be_hidden() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
@@ -105,7 +105,7 @@ class Sprite3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	bool can_be_hidden() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
@@ -121,7 +121,7 @@ class Position3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -133,7 +133,7 @@ class Skeleton3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -145,7 +145,7 @@ class PhysicalBone3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -157,7 +157,7 @@ class RayCast3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -169,7 +169,7 @@ class SpringArm3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -181,7 +181,7 @@ class VehicleWheel3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -193,7 +193,7 @@ class SoftBody3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	bool is_selectable_when_hidden() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
@@ -211,7 +211,7 @@ class VisibilityNotifier3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -228,7 +228,7 @@ class CPUParticles3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	bool is_selectable_when_hidden() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
@@ -240,7 +240,7 @@ class GPUParticles3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	bool is_selectable_when_hidden() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
@@ -258,7 +258,7 @@ class GPUParticlesCollision3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -275,7 +275,7 @@ class ReflectionProbeGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -292,7 +292,7 @@ class DecalGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -309,7 +309,7 @@ class GIProbeGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -326,7 +326,7 @@ class BakedLightmapGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -343,7 +343,7 @@ class LightmapProbeGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -360,7 +360,7 @@ class CollisionShape3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -377,7 +377,7 @@ class CollisionPolygon3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 	CollisionPolygon3DGizmoPlugin();
@@ -395,7 +395,7 @@ class NavigationRegion3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
@@ -427,7 +427,7 @@ class Joint3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6802,9 +6802,9 @@ Ref<StandardMaterial3D> EditorNode3DGizmoPlugin::get_material(const String &p_na
 	return mat;
 }
 
-String EditorNode3DGizmoPlugin::get_name() const {
-	if (get_script_instance() && get_script_instance()->has_method("get_name")) {
-		return get_script_instance()->call("get_name");
+String EditorNode3DGizmoPlugin::get_gizmo_name() const {
+	if (get_script_instance() && get_script_instance()->has_method("get_gizmo_name")) {
+		return get_script_instance()->call("get_gizmo_name");
 	}
 	return TTR("Nameless gizmo");
 }

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -868,7 +868,7 @@ public:
 
 	Ref<StandardMaterial3D> get_material(const String &p_name, const Ref<EditorNode3DGizmo> &p_gizmo = Ref<EditorNode3DGizmo>());
 
-	virtual String get_name() const;
+	virtual String get_gizmo_name() const;
 	virtual int get_priority() const;
 	virtual bool can_be_hidden() const;
 	virtual bool is_selectable_when_hidden() const;

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -630,7 +630,7 @@ Ref<EditorNode3DGizmo> Path3DGizmoPlugin::create_gizmo(Node3D *p_spatial) {
 	return ref;
 }
 
-String Path3DGizmoPlugin::get_name() const {
+String Path3DGizmoPlugin::get_gizmo_name() const {
 	return "Path3D";
 }
 

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -59,7 +59,7 @@ protected:
 	Ref<EditorNode3DGizmo> create_gizmo(Node3D *p_spatial) override;
 
 public:
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	Path3DGizmoPlugin();
 };

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -838,7 +838,7 @@ EditorSceneImporterAssimp::_generate_mesh_from_surface_indices(ImportState &stat
 			String ai_anim_mesh_name = AssimpUtils::get_assimp_string(ai_mesh->mAnimMeshes[j]->mName);
 			if (!morph_mesh_string_lookup.has(ai_anim_mesh_name)) {
 				morph_mesh_string_lookup.insert(ai_anim_mesh_name, j);
-				mesh->set_blend_shape_mode(Mesh::BLEND_SHAPE_MODE_NORMALIZED);
+				mesh->set_blend_shape_mode(ArrayMesh::BLEND_SHAPE_MODE_NORMALIZED);
 				if (ai_anim_mesh_name.empty()) {
 					ai_anim_mesh_name = String("morph_") + itos(j);
 				}

--- a/modules/csg/csg_gizmos.cpp
+++ b/modules/csg/csg_gizmos.cpp
@@ -319,7 +319,7 @@ bool CSGShape3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<CSGSphere3D>(p_spatial) || Object::cast_to<CSGBox3D>(p_spatial) || Object::cast_to<CSGCylinder3D>(p_spatial) || Object::cast_to<CSGTorus3D>(p_spatial) || Object::cast_to<CSGMesh3D>(p_spatial) || Object::cast_to<CSGPolygon3D>(p_spatial);
 }
 
-String CSGShape3DGizmoPlugin::get_name() const {
+String CSGShape3DGizmoPlugin::get_gizmo_name() const {
 	return "CSGShape3D";
 }
 

--- a/modules/csg/csg_gizmos.h
+++ b/modules/csg/csg_gizmos.h
@@ -40,7 +40,7 @@ class CSGShape3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
-	String get_name() const override;
+	String get_gizmo_name() const override;
 	int get_priority() const override;
 	bool is_selectable_when_hidden() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -826,84 +826,84 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	{
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 1;
 			u.ids.push_back(vertex_buffer);
 			base_uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 2;
 			u.ids.push_back(triangle_buffer);
 			base_uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 3;
 			u.ids.push_back(box_buffer);
 			base_uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 4;
 			u.ids.push_back(triangle_cell_indices_buffer);
 			base_uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 5;
 			u.ids.push_back(lights_buffer);
 			base_uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 6;
 			u.ids.push_back(seams_buffer);
 			base_uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 7;
 			u.ids.push_back(probe_positions_buffer);
 			base_uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 8;
 			u.ids.push_back(grid_texture);
 			base_uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 9;
 			u.ids.push_back(grid_texture_sdf);
 			base_uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 10;
 			u.ids.push_back(albedo_array_tex);
 			base_uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 11;
 			u.ids.push_back(emission_array_tex);
 			base_uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.binding = 12;
 			u.ids.push_back(sampler);
 			base_uniforms.push_back(u);
@@ -1049,14 +1049,14 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		{
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 0;
 				u.ids.push_back(position_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 1;
 				u.ids.push_back(unocclude_tex); //will be unused
 				uniforms.push_back(u);
@@ -1089,42 +1089,42 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		{
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 0;
 				u.ids.push_back(light_source_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 1;
 				u.ids.push_back(light_dest_tex); //will be unused
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 2;
 				u.ids.push_back(position_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 3;
 				u.ids.push_back(normal_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 4;
 				u.ids.push_back(light_accum_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 5;
 				u.ids.push_back(light_primary_dynamic_tex);
 				uniforms.push_back(u);
@@ -1169,49 +1169,49 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		{
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 0;
 				u.ids.push_back(light_dest_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 1;
 				u.ids.push_back(light_source_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 2;
 				u.ids.push_back(position_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 3;
 				u.ids.push_back(normal_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 4;
 				u.ids.push_back(light_accum_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 5;
 				u.ids.push_back(unocclude_tex); //reuse unocclude tex
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 6;
 				u.ids.push_back(light_environment_tex); //reuse unocclude tex
 				uniforms.push_back(u);
@@ -1317,28 +1317,28 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		{
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 				u.binding = 0;
 				u.ids.push_back(light_probe_buffer);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 1;
 				u.ids.push_back(light_dest_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 2;
 				u.ids.push_back(light_primary_dynamic_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 3;
 				u.ids.push_back(light_environment_tex);
 				uniforms.push_back(u);
@@ -1463,14 +1463,14 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		{
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 0;
 				u.ids.push_back(light_accum_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 1;
 				u.ids.push_back(light_accum_tex2);
 				uniforms.push_back(u);
@@ -1554,7 +1554,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		{
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 0;
 				u.ids.push_back(light_accum_tex2);
 				uniforms.push_back(u);

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -543,7 +543,7 @@ void LightmapperRD::_create_acceleration_structures(RenderingDevice *rd, Size2i 
 		tf.width = grid_size;
 		tf.height = grid_size;
 		tf.depth = grid_size;
-		tf.type = RD::TEXTURE_TYPE_3D;
+		tf.texture_type = RD::TEXTURE_TYPE_3D;
 		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
 
 		Vector<Vector<uint8_t>> texdata;
@@ -695,7 +695,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		tf.width = atlas_size.width;
 		tf.height = atlas_size.height;
 		tf.array_layers = atlas_slices;
-		tf.type = RD::TEXTURE_TYPE_2D_ARRAY;
+		tf.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
 		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
 		tf.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
 
@@ -917,7 +917,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		tf.width = atlas_size.width;
 		tf.height = atlas_size.height;
 		tf.depth = 1;
-		tf.type = RD::TEXTURE_TYPE_2D;
+		tf.texture_type = RD::TEXTURE_TYPE_2D;
 		tf.usage_bits = RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
 		tf.format = RD::DATA_FORMAT_D32_SFLOAT;
 

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -397,14 +397,14 @@ Ref<Gradient> CPUParticles2D::get_color_ramp() const {
 	return color_ramp;
 }
 
-void CPUParticles2D::set_particle_flag(Flags p_flag, bool p_enable) {
-	ERR_FAIL_INDEX(p_flag, FLAG_MAX);
-	flags[p_flag] = p_enable;
+void CPUParticles2D::set_particle_flag(ParticleFlags p_particle_flag, bool p_enable) {
+	ERR_FAIL_INDEX(p_particle_flag, PARTICLE_FLAG_MAX);
+	particle_flags[p_particle_flag] = p_enable;
 }
 
-bool CPUParticles2D::get_particle_flag(Flags p_flag) const {
-	ERR_FAIL_INDEX_V(p_flag, FLAG_MAX, false);
-	return flags[p_flag];
+bool CPUParticles2D::get_particle_flag(ParticleFlags p_particle_flag) const {
+	ERR_FAIL_INDEX_V(p_particle_flag, PARTICLE_FLAG_MAX, false);
+	return particle_flags[p_particle_flag];
 }
 
 void CPUParticles2D::set_emission_shape(EmissionShape p_shape) {
@@ -905,7 +905,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 
 		p.color *= p.base_color;
 
-		if (flags[FLAG_ALIGN_Y_TO_VELOCITY]) {
+		if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
 			if (p.velocity.length() > 0.0) {
 				p.transform.elements[1] = p.velocity.normalized();
 				p.transform.elements[0] = p.transform.elements[1].tangent();
@@ -1130,7 +1130,7 @@ void CPUParticles2D::convert_from_particles(Node *p_particles) {
 		set_color_ramp(gt->get_gradient());
 	}
 
-	set_particle_flag(FLAG_ALIGN_Y_TO_VELOCITY, material->get_flag(ParticlesMaterial::FLAG_ALIGN_Y_TO_VELOCITY));
+	set_particle_flag(PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY, material->get_particle_flag(ParticlesMaterial::PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY));
 
 	set_emission_shape(EmissionShape(material->get_emission_shape()));
 	set_emission_sphere_radius(material->get_emission_sphere_radius());
@@ -1246,8 +1246,8 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_color_ramp", "ramp"), &CPUParticles2D::set_color_ramp);
 	ClassDB::bind_method(D_METHOD("get_color_ramp"), &CPUParticles2D::get_color_ramp);
 
-	ClassDB::bind_method(D_METHOD("set_particle_flag", "flag", "enable"), &CPUParticles2D::set_particle_flag);
-	ClassDB::bind_method(D_METHOD("get_particle_flag", "flag"), &CPUParticles2D::get_particle_flag);
+	ClassDB::bind_method(D_METHOD("set_particle_flag", "particle_flag", "enable"), &CPUParticles2D::set_particle_flag);
+	ClassDB::bind_method(D_METHOD("get_particle_flag", "particle_flag"), &CPUParticles2D::get_particle_flag);
 
 	ClassDB::bind_method(D_METHOD("set_emission_shape", "shape"), &CPUParticles2D::set_emission_shape);
 	ClassDB::bind_method(D_METHOD("get_emission_shape"), &CPUParticles2D::get_emission_shape);
@@ -1279,8 +1279,8 @@ void CPUParticles2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "emission_points"), "set_emission_points", "get_emission_points");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "emission_normals"), "set_emission_normals", "get_emission_normals");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_COLOR_ARRAY, "emission_colors"), "set_emission_colors", "get_emission_colors");
-	ADD_GROUP("Flags", "flag_");
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flag_align_y"), "set_particle_flag", "get_particle_flag", FLAG_ALIGN_Y_TO_VELOCITY);
+	ADD_GROUP("Particle Flags", "particle_flag_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "particle_flag_align_y"), "set_particle_flag", "get_particle_flag", PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY);
 	ADD_GROUP("Direction", "");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "direction"), "set_direction", "get_direction");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "spread", PROPERTY_HINT_RANGE, "0,180,0.01"), "set_spread", "get_spread");
@@ -1351,10 +1351,10 @@ void CPUParticles2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(PARAM_ANIM_OFFSET);
 	BIND_ENUM_CONSTANT(PARAM_MAX);
 
-	BIND_ENUM_CONSTANT(FLAG_ALIGN_Y_TO_VELOCITY);
-	BIND_ENUM_CONSTANT(FLAG_ROTATE_Y); // Unused, but exposed for consistency with 3D.
-	BIND_ENUM_CONSTANT(FLAG_DISABLE_Z); // Unused, but exposed for consistency with 3D.
-	BIND_ENUM_CONSTANT(FLAG_MAX);
+	BIND_ENUM_CONSTANT(PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY);
+	BIND_ENUM_CONSTANT(PARTICLE_FLAG_ROTATE_Y); // Unused, but exposed for consistency with 3D.
+	BIND_ENUM_CONSTANT(PARTICLE_FLAG_DISABLE_Z); // Unused, but exposed for consistency with 3D.
+	BIND_ENUM_CONSTANT(PARTICLE_FLAG_MAX);
 
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_POINT);
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_SPHERE);
@@ -1415,8 +1415,8 @@ CPUParticles2D::CPUParticles2D() {
 		set_param_randomness(Parameter(i), 0);
 	}
 
-	for (int i = 0; i < FLAG_MAX; i++) {
-		flags[i] = false;
+	for (int i = 0; i < PARTICLE_FLAG_MAX; i++) {
+		particle_flags[i] = false;
 	}
 
 	set_color(Color(1, 1, 1, 1));

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -61,11 +61,11 @@ public:
 		PARAM_MAX
 	};
 
-	enum Flags {
-		FLAG_ALIGN_Y_TO_VELOCITY,
-		FLAG_ROTATE_Y, // Unused, but exposed for consistency with 3D.
-		FLAG_DISABLE_Z, // Unused, but exposed for consistency with 3D.
-		FLAG_MAX
+	enum ParticleFlags {
+		PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY,
+		PARTICLE_FLAG_ROTATE_Y, // Unused, but exposed for consistency with 3D.
+		PARTICLE_FLAG_DISABLE_Z, // Unused, but exposed for consistency with 3D.
+		PARTICLE_FLAG_MAX
 	};
 
 	enum EmissionShape {
@@ -159,7 +159,7 @@ private:
 	Color color;
 	Ref<Gradient> color_ramp;
 
-	bool flags[FLAG_MAX];
+	bool particle_flags[PARTICLE_FLAG_MAX];
 
 	EmissionShape emission_shape;
 	float emission_sphere_radius;
@@ -253,8 +253,8 @@ public:
 	void set_color_ramp(const Ref<Gradient> &p_ramp);
 	Ref<Gradient> get_color_ramp() const;
 
-	void set_particle_flag(Flags p_flag, bool p_enable);
-	bool get_particle_flag(Flags p_flag) const;
+	void set_particle_flag(ParticleFlags p_particle_flag, bool p_enable);
+	bool get_particle_flag(ParticleFlags p_particle_flag) const;
 
 	void set_emission_shape(EmissionShape p_shape);
 	void set_emission_sphere_radius(float p_radius);
@@ -287,7 +287,7 @@ public:
 
 VARIANT_ENUM_CAST(CPUParticles2D::DrawOrder)
 VARIANT_ENUM_CAST(CPUParticles2D::Parameter)
-VARIANT_ENUM_CAST(CPUParticles2D::Flags)
+VARIANT_ENUM_CAST(CPUParticles2D::ParticleFlags)
 VARIANT_ENUM_CAST(CPUParticles2D::EmissionShape)
 
 #endif // CPU_PARTICLES_2D_H

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -127,9 +127,9 @@ void GPUParticles2D::_update_particle_emission_transform() {
 void GPUParticles2D::set_process_material(const Ref<Material> &p_material) {
 	process_material = p_material;
 	Ref<ParticlesMaterial> pm = p_material;
-	if (pm.is_valid() && !pm->get_flag(ParticlesMaterial::FLAG_DISABLE_Z) && pm->get_gravity() == Vector3(0, -9.8, 0)) {
+	if (pm.is_valid() && !pm->get_particle_flag(ParticlesMaterial::PARTICLE_FLAG_DISABLE_Z) && pm->get_gravity() == Vector3(0, -9.8, 0)) {
 		// Likely a new (3D) material, modify it to match 2D space
-		pm->set_flag(ParticlesMaterial::FLAG_DISABLE_Z, true);
+		pm->set_particle_flag(ParticlesMaterial::PARTICLE_FLAG_DISABLE_Z, true);
 		pm->set_gravity(Vector3(0, 98, 0));
 	}
 	RID material_rid;

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -238,7 +238,7 @@ Ref<OccluderPolygon2D> LightOccluder2D::get_occluder_polygon() const {
 
 void LightOccluder2D::set_occluder_light_mask(int p_mask) {
 	mask = p_mask;
-	RS::get_singleton()->canvas_light_occluder_set_light_mask(occluder, mask);
+	RS::get_singleton()->canvas_light_occluder_set_light_mask(occluder, p_mask);
 }
 
 int LightOccluder2D::get_occluder_light_mask() const {
@@ -285,7 +285,7 @@ void LightOccluder2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "occluder", PROPERTY_HINT_RESOURCE_TYPE, "OccluderPolygon2D"), "set_occluder_polygon", "get_occluder_polygon");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sdf_collision"), "set_as_sdf_collision", "is_set_as_sdf_collision");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_mask", PROPERTY_HINT_LAYERS_2D_RENDER), "set_occluder_light_mask", "get_occluder_light_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "occluder_light_mask", PROPERTY_HINT_LAYERS_2D_RENDER), "set_occluder_light_mask", "get_occluder_light_mask");
 }
 
 LightOccluder2D::LightOccluder2D() {

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -170,7 +170,7 @@ void PathFollow2D::_update_transform() {
 	}
 	Vector2 pos = c->interpolate_baked(offset, cubic);
 
-	if (rotate) {
+	if (rotates) {
 		float ahead = offset + lookahead;
 
 		if (loop && ahead >= path_length) {
@@ -279,7 +279,7 @@ void PathFollow2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_unit_offset", "unit_offset"), &PathFollow2D::set_unit_offset);
 	ClassDB::bind_method(D_METHOD("get_unit_offset"), &PathFollow2D::get_unit_offset);
 
-	ClassDB::bind_method(D_METHOD("set_rotate", "enable"), &PathFollow2D::set_rotate);
+	ClassDB::bind_method(D_METHOD("set_rotates", "enable"), &PathFollow2D::set_rotates);
 	ClassDB::bind_method(D_METHOD("is_rotating"), &PathFollow2D::is_rotating);
 
 	ClassDB::bind_method(D_METHOD("set_cubic_interpolation", "enable"), &PathFollow2D::set_cubic_interpolation);
@@ -295,7 +295,7 @@ void PathFollow2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "unit_offset", PROPERTY_HINT_RANGE, "0,1,0.0001,or_lesser,or_greater", PROPERTY_USAGE_EDITOR), "set_unit_offset", "get_unit_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "h_offset"), "set_h_offset", "get_h_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "v_offset"), "set_v_offset", "get_v_offset");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rotate"), "set_rotate", "is_rotating");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rotates"), "set_rotates", "is_rotating");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cubic_interp"), "set_cubic_interpolation", "get_cubic_interpolation");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "has_loop");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lookahead", PROPERTY_HINT_RANGE, "0.001,1024.0,0.001"), "set_lookahead", "get_lookahead");
@@ -371,13 +371,13 @@ float PathFollow2D::get_lookahead() const {
 	return lookahead;
 }
 
-void PathFollow2D::set_rotate(bool p_rotate) {
-	rotate = p_rotate;
+void PathFollow2D::set_rotates(bool p_rotates) {
+	rotates = p_rotates;
 	_update_transform();
 }
 
 bool PathFollow2D::is_rotating() const {
-	return rotate;
+	return rotates;
 }
 
 void PathFollow2D::set_loop(bool p_loop) {
@@ -393,7 +393,7 @@ PathFollow2D::PathFollow2D() {
 	h_offset = 0;
 	v_offset = 0;
 	path = nullptr;
-	rotate = true;
+	rotates = true;
 	cubic = true;
 	loop = true;
 	lookahead = 4;

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -70,7 +70,7 @@ private:
 	real_t lookahead;
 	bool cubic;
 	bool loop;
-	bool rotate;
+	bool rotates;
 
 	void _update_transform();
 
@@ -99,7 +99,7 @@ public:
 	void set_loop(bool p_loop);
 	bool has_loop() const;
 
-	void set_rotate(bool p_rotate);
+	void set_rotates(bool p_rotates);
 	bool is_rotating() const;
 
 	void set_cubic_interpolation(bool p_enable);

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -61,11 +61,11 @@ public:
 		PARAM_MAX
 	};
 
-	enum Flags {
-		FLAG_ALIGN_Y_TO_VELOCITY,
-		FLAG_ROTATE_Y,
-		FLAG_DISABLE_Z,
-		FLAG_MAX
+	enum ParticleFlags {
+		PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY,
+		PARTICLE_FLAG_ROTATE_Y,
+		PARTICLE_FLAG_DISABLE_Z,
+		PARTICLE_FLAG_MAX
 	};
 
 	enum EmissionShape {
@@ -160,7 +160,7 @@ private:
 	Color color;
 	Ref<Gradient> color_ramp;
 
-	bool flags[FLAG_MAX];
+	bool particle_flags[PARTICLE_FLAG_MAX];
 
 	EmissionShape emission_shape;
 	float emission_sphere_radius;
@@ -256,8 +256,8 @@ public:
 	void set_color_ramp(const Ref<Gradient> &p_ramp);
 	Ref<Gradient> get_color_ramp() const;
 
-	void set_particle_flag(Flags p_flag, bool p_enable);
-	bool get_particle_flag(Flags p_flag) const;
+	void set_particle_flag(ParticleFlags p_particle_flag, bool p_enable);
+	bool get_particle_flag(ParticleFlags p_particle_flag) const;
 
 	void set_emission_shape(EmissionShape p_shape);
 	void set_emission_sphere_radius(float p_radius);
@@ -290,7 +290,7 @@ public:
 
 VARIANT_ENUM_CAST(CPUParticles3D::DrawOrder)
 VARIANT_ENUM_CAST(CPUParticles3D::Parameter)
-VARIANT_ENUM_CAST(CPUParticles3D::Flags)
+VARIANT_ENUM_CAST(CPUParticles3D::ParticleFlags)
 VARIANT_ENUM_CAST(CPUParticles3D::EmissionShape)
 
 #endif // CPU_PARTICLES_H

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -282,7 +282,7 @@ String XRController3D::get_controller_name() const {
 		return String("Not connected");
 	};
 
-	return tracker->get_name();
+	return tracker->get_tracker_name();
 };
 
 int XRController3D::get_joystick_id() const {
@@ -480,7 +480,7 @@ String XRAnchor3D::get_anchor_name() const {
 		return String("Not connected");
 	};
 
-	return tracker->get_name();
+	return tracker->get_tracker_name();
 };
 
 bool XRAnchor3D::get_is_active() const {

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -480,9 +480,6 @@ void Mesh::_bind_methods() {
 	BIND_ENUM_CONSTANT(PRIMITIVE_TRIANGLES);
 	BIND_ENUM_CONSTANT(PRIMITIVE_TRIANGLE_STRIP);
 
-	BIND_ENUM_CONSTANT(BLEND_SHAPE_MODE_NORMALIZED);
-	BIND_ENUM_CONSTANT(BLEND_SHAPE_MODE_RELATIVE);
-
 	BIND_ENUM_CONSTANT(ARRAY_VERTEX);
 	BIND_ENUM_CONSTANT(ARRAY_NORMAL);
 	BIND_ENUM_CONSTANT(ARRAY_TANGENT);
@@ -1615,6 +1612,9 @@ void ArrayMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "_surfaces", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "_set_surfaces", "_get_surfaces");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "blend_shape_mode", PROPERTY_HINT_ENUM, "Normalized,Relative"), "set_blend_shape_mode", "get_blend_shape_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::AABB, "custom_aabb", PROPERTY_HINT_NONE, ""), "set_custom_aabb", "get_custom_aabb");
+
+	BIND_ENUM_CONSTANT(BLEND_SHAPE_MODE_NORMALIZED);
+	BIND_ENUM_CONSTANT(BLEND_SHAPE_MODE_RELATIVE);
 }
 
 void ArrayMesh::reload_from_file() {

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -125,11 +125,6 @@ public:
 		PRIMITIVE_MAX = RenderingServer::PRIMITIVE_MAX,
 	};
 
-	enum BlendShapeMode {
-		BLEND_SHAPE_MODE_NORMALIZED = RS::BLEND_SHAPE_MODE_NORMALIZED,
-		BLEND_SHAPE_MODE_RELATIVE = RS::BLEND_SHAPE_MODE_RELATIVE,
-	};
-
 	virtual int get_surface_count() const = 0;
 	virtual int surface_get_array_len(int p_idx) const = 0;
 	virtual int surface_get_array_index_len(int p_idx) const = 0;
@@ -175,6 +170,12 @@ class ArrayMesh : public Mesh {
 
 	Array _get_surfaces() const;
 	void _set_surfaces(const Array &p_data);
+
+public:
+	enum BlendShapeMode {
+		BLEND_SHAPE_MODE_NORMALIZED = RS::BLEND_SHAPE_MODE_NORMALIZED,
+		BLEND_SHAPE_MODE_RELATIVE = RS::BLEND_SHAPE_MODE_RELATIVE,
+	};
 
 private:
 	struct Surface {
@@ -267,6 +268,6 @@ VARIANT_ENUM_CAST(Mesh::ArrayType);
 VARIANT_ENUM_CAST(Mesh::ArrayFormat);
 VARIANT_ENUM_CAST(Mesh::ArrayCustomFormat);
 VARIANT_ENUM_CAST(Mesh::PrimitiveType);
-VARIANT_ENUM_CAST(Mesh::BlendShapeMode);
+VARIANT_ENUM_CAST(ArrayMesh::BlendShapeMode);
 
 #endif

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -329,7 +329,7 @@ void ParticlesMaterial::_update_shader() {
 		code += "			float tex_linear_velocity = 0.0;\n";
 	}
 
-	if (flags[FLAG_DISABLE_Z]) {
+	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		code += "			float angle1_rad = rand_from_seed_m1_p1(alt_seed) * spread_rad;\n";
 		code += "			angle1_rad += direction.x != 0.0 ? atan(direction.y, direction.x) : sign(direction.y) * (pi / 2.0);\n";
 		code += "			vec3 rot = vec3(cos(angle1_rad), sin(angle1_rad), 0.0);\n";
@@ -377,7 +377,7 @@ void ParticlesMaterial::_update_shader() {
 			code += "			TRANSFORM[3].xyz = texelFetch(emission_texture_points, emission_tex_ofs, 0).xyz;\n";
 
 			if (emission_shape == EMISSION_SHAPE_DIRECTED_POINTS) {
-				if (flags[FLAG_DISABLE_Z]) {
+				if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 					code += "			mat2 rotm;";
 					code += "			rotm[0] = texelFetch(emission_texture_normal, emission_tex_ofs, 0).xy;\n";
 					code += "			rotm[1] = rotm[0].yx * vec2(1.0, -1.0);\n";
@@ -398,7 +398,7 @@ void ParticlesMaterial::_update_shader() {
 
 	code += "			if (RESTART_VELOCITY) VELOCITY = (EMISSION_TRANSFORM * vec4(VELOCITY, 0.0)).xyz;\n";
 	code += "			TRANSFORM = EMISSION_TRANSFORM * TRANSFORM;\n";
-	if (flags[FLAG_DISABLE_Z]) {
+	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		code += "			VELOCITY.z = 0.0;\n";
 		code += "			TRANSFORM[3].z = 0.0;\n";
 	}
@@ -413,7 +413,7 @@ void ParticlesMaterial::_update_shader() {
 		code += "		float tex_linear_velocity = 0.0;\n";
 	}
 
-	if (flags[FLAG_DISABLE_Z]) {
+	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		if (tex_parameters[PARAM_ORBIT_VELOCITY].is_valid()) {
 			code += "		float tex_orbit_velocity = textureLod(orbit_velocity_texture, vec2(CUSTOM.y, 0.0), 0.0).r;\n";
 		} else {
@@ -471,7 +471,7 @@ void ParticlesMaterial::_update_shader() {
 
 	code += "		vec3 force = gravity;\n";
 	code += "		vec3 pos = TRANSFORM[3].xyz;\n";
-	if (flags[FLAG_DISABLE_Z]) {
+	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		code += "		pos.z = 0.0;\n";
 	}
 	code += "		// apply linear acceleration\n";
@@ -481,7 +481,7 @@ void ParticlesMaterial::_update_shader() {
 	code += "		vec3 diff = pos - org;\n";
 	code += "		force += length(diff) > 0.0 ? normalize(diff) * (radial_accel + tex_radial_accel) * mix(1.0, rand_from_seed(alt_seed), radial_accel_random) : vec3(0.0);\n";
 	code += "		// apply tangential acceleration;\n";
-	if (flags[FLAG_DISABLE_Z]) {
+	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		code += "		force += length(diff.yx) > 0.0 ? vec3(normalize(diff.yx * vec2(-1.0, 1.0)), 0.0) * ((tangent_accel + tex_tangent_accel) * mix(1.0, rand_from_seed(alt_seed), tangent_accel_random)) : vec3(0.0);\n";
 
 	} else {
@@ -495,7 +495,7 @@ void ParticlesMaterial::_update_shader() {
 	code += "		// apply attractor forces\n";
 	code += "		VELOCITY += force * DELTA;\n";
 	code += "		// orbit velocity\n";
-	if (flags[FLAG_DISABLE_Z]) {
+	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		code += "		float orbit_amount = (orbit_velocity + tex_orbit_velocity) * mix(1.0, rand_from_seed(alt_seed), orbit_velocity_random);\n";
 		code += "		if (orbit_amount != 0.0) {\n";
 		code += "		     float ang = orbit_amount * DELTA * pi * 2.0;\n";
@@ -562,8 +562,8 @@ void ParticlesMaterial::_update_shader() {
 	}
 	code += "\n";
 
-	if (flags[FLAG_DISABLE_Z]) {
-		if (flags[FLAG_ALIGN_Y_TO_VELOCITY]) {
+	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
+		if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
 			code += "	if (length(VELOCITY) > 0.0) {\n";
 			code += "		TRANSFORM[1].xyz = normalize(VELOCITY);\n";
 			code += "	} else {\n";
@@ -579,7 +579,7 @@ void ParticlesMaterial::_update_shader() {
 
 	} else {
 		// orient particle Y towards velocity
-		if (flags[FLAG_ALIGN_Y_TO_VELOCITY]) {
+		if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
 			code += "	if (length(VELOCITY) > 0.0) {\n";
 			code += "		TRANSFORM[1].xyz = normalize(VELOCITY);\n";
 			code += "	} else {\n";
@@ -598,7 +598,7 @@ void ParticlesMaterial::_update_shader() {
 			code += "	TRANSFORM[2].xyz = normalize(TRANSFORM[2].xyz);\n";
 		}
 		// turn particle by rotation in Y
-		if (flags[FLAG_ROTATE_Y]) {
+		if (particle_flags[PARTICLE_FLAG_ROTATE_Y]) {
 			code += "	TRANSFORM = TRANSFORM * mat4(vec4(cos(CUSTOM.x), 0.0, -sin(CUSTOM.x), 0.0), vec4(0.0, 1.0, 0.0, 0.0), vec4(sin(CUSTOM.x), 0.0, cos(CUSTOM.x), 0.0), vec4(0.0, 0.0, 0.0, 1.0));\n";
 		}
 	}
@@ -611,7 +611,7 @@ void ParticlesMaterial::_update_shader() {
 	code += "	TRANSFORM[0].xyz *= base_scale;\n";
 	code += "	TRANSFORM[1].xyz *= base_scale;\n";
 	code += "	TRANSFORM[2].xyz *= base_scale;\n";
-	if (flags[FLAG_DISABLE_Z]) {
+	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		code += "	VELOCITY.z = 0.0;\n";
 		code += "	TRANSFORM[3].z = 0.0;\n";
 	}
@@ -916,18 +916,18 @@ Ref<Texture2D> ParticlesMaterial::get_color_ramp() const {
 	return color_ramp;
 }
 
-void ParticlesMaterial::set_flag(Flags p_flag, bool p_enable) {
-	ERR_FAIL_INDEX(p_flag, FLAG_MAX);
-	flags[p_flag] = p_enable;
+void ParticlesMaterial::set_particle_flag(ParticleFlags p_particle_flag, bool p_enable) {
+	ERR_FAIL_INDEX(p_particle_flag, PARTICLE_FLAG_MAX);
+	particle_flags[p_particle_flag] = p_enable;
 	_queue_shader_change();
-	if (p_flag == FLAG_DISABLE_Z) {
+	if (p_particle_flag == PARTICLE_FLAG_DISABLE_Z) {
 		_change_notify();
 	}
 }
 
-bool ParticlesMaterial::get_flag(Flags p_flag) const {
-	ERR_FAIL_INDEX_V(p_flag, FLAG_MAX, false);
-	return flags[p_flag];
+bool ParticlesMaterial::get_particle_flag(ParticleFlags p_particle_flag) const {
+	ERR_FAIL_INDEX_V(p_particle_flag, PARTICLE_FLAG_MAX, false);
+	return particle_flags[p_particle_flag];
 }
 
 void ParticlesMaterial::set_emission_shape(EmissionShape p_shape) {
@@ -1056,7 +1056,7 @@ void ParticlesMaterial::_validate_property(PropertyInfo &property) const {
 		property.usage = 0;
 	}
 
-	if (property.name.begins_with("orbit_") && !flags[FLAG_DISABLE_Z]) {
+	if (property.name.begins_with("orbit_") && !particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		property.usage = 0;
 	}
 }
@@ -1170,8 +1170,8 @@ void ParticlesMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_color_ramp", "ramp"), &ParticlesMaterial::set_color_ramp);
 	ClassDB::bind_method(D_METHOD("get_color_ramp"), &ParticlesMaterial::get_color_ramp);
 
-	ClassDB::bind_method(D_METHOD("set_flag", "flag", "enable"), &ParticlesMaterial::set_flag);
-	ClassDB::bind_method(D_METHOD("get_flag", "flag"), &ParticlesMaterial::get_flag);
+	ClassDB::bind_method(D_METHOD("set_particle_flag", "particle_flag", "enable"), &ParticlesMaterial::set_particle_flag);
+	ClassDB::bind_method(D_METHOD("get_particle_flag", "particle_flag"), &ParticlesMaterial::get_particle_flag);
 
 	ClassDB::bind_method(D_METHOD("set_emission_shape", "shape"), &ParticlesMaterial::set_emission_shape);
 	ClassDB::bind_method(D_METHOD("get_emission_shape"), &ParticlesMaterial::get_emission_shape);
@@ -1238,10 +1238,10 @@ void ParticlesMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "emission_normal_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_emission_normal_texture", "get_emission_normal_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "emission_color_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_emission_color_texture", "get_emission_color_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "emission_point_count", PROPERTY_HINT_RANGE, "0,1000000,1"), "set_emission_point_count", "get_emission_point_count");
-	ADD_GROUP("Flags", "flag_");
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flag_align_y"), "set_flag", "get_flag", FLAG_ALIGN_Y_TO_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flag_rotate_y"), "set_flag", "get_flag", FLAG_ROTATE_Y);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "flag_disable_z"), "set_flag", "get_flag", FLAG_DISABLE_Z);
+	ADD_GROUP("ParticleFlags", "particle_flag_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "particle_flag_align_y"), "set_particle_flag", "get_particle_flag", PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "particle_flag_rotate_y"), "set_particle_flag", "get_particle_flag", PARTICLE_FLAG_ROTATE_Y);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "particle_flag_disable_z"), "set_particle_flag", "get_particle_flag", PARTICLE_FLAG_DISABLE_Z);
 	ADD_GROUP("Direction", "");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "direction"), "set_direction", "get_direction");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "spread", PROPERTY_HINT_RANGE, "0,180,0.01"), "set_spread", "get_spread");
@@ -1327,10 +1327,10 @@ void ParticlesMaterial::_bind_methods() {
 	BIND_ENUM_CONSTANT(PARAM_ANIM_OFFSET);
 	BIND_ENUM_CONSTANT(PARAM_MAX);
 
-	BIND_ENUM_CONSTANT(FLAG_ALIGN_Y_TO_VELOCITY);
-	BIND_ENUM_CONSTANT(FLAG_ROTATE_Y);
-	BIND_ENUM_CONSTANT(FLAG_DISABLE_Z);
-	BIND_ENUM_CONSTANT(FLAG_MAX);
+	BIND_ENUM_CONSTANT(PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY);
+	BIND_ENUM_CONSTANT(PARTICLE_FLAG_ROTATE_Y);
+	BIND_ENUM_CONSTANT(PARTICLE_FLAG_DISABLE_Z);
+	BIND_ENUM_CONSTANT(PARTICLE_FLAG_MAX);
 
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_POINT);
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_SPHERE);
@@ -1385,8 +1385,8 @@ ParticlesMaterial::ParticlesMaterial() :
 		set_param_randomness(Parameter(i), 0);
 	}
 
-	for (int i = 0; i < FLAG_MAX; i++) {
-		flags[i] = false;
+	for (int i = 0; i < PARTICLE_FLAG_MAX; i++) {
+		particle_flags[i] = false;
 	}
 
 	set_color(Color(1, 1, 1, 1));

--- a/scene/resources/particles_material.h
+++ b/scene/resources/particles_material.h
@@ -61,11 +61,11 @@ public:
 		PARAM_MAX
 	};
 
-	enum Flags {
-		FLAG_ALIGN_Y_TO_VELOCITY,
-		FLAG_ROTATE_Y,
-		FLAG_DISABLE_Z,
-		FLAG_MAX
+	enum ParticleFlags {
+		PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY,
+		PARTICLE_FLAG_ROTATE_Y,
+		PARTICLE_FLAG_DISABLE_Z,
+		PARTICLE_FLAG_MAX
 	};
 
 	enum EmissionShape {
@@ -90,7 +90,7 @@ private:
 		struct {
 			uint32_t texture_mask : 16;
 			uint32_t texture_color : 1;
-			uint32_t flags : 4;
+			uint32_t particle_flags : 4;
 			uint32_t emission_shape : 2;
 			uint32_t invalid_key : 1;
 			uint32_t has_emission_color : 1;
@@ -124,9 +124,9 @@ private:
 				mk.texture_mask |= (1 << i);
 			}
 		}
-		for (int i = 0; i < FLAG_MAX; i++) {
-			if (flags[i]) {
-				mk.flags |= (1 << i);
+		for (int i = 0; i < PARTICLE_FLAG_MAX; i++) {
+			if (particle_flags[i]) {
+				mk.particle_flags |= (1 << i);
 			}
 		}
 
@@ -227,7 +227,7 @@ private:
 	Color color;
 	Ref<Texture2D> color_ramp;
 
-	bool flags[FLAG_MAX];
+	bool particle_flags[PARTICLE_FLAG_MAX];
 
 	EmissionShape emission_shape;
 	float emission_sphere_radius;
@@ -284,8 +284,8 @@ public:
 	void set_color_ramp(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_color_ramp() const;
 
-	void set_flag(Flags p_flag, bool p_enable);
-	bool get_flag(Flags p_flag) const;
+	void set_particle_flag(ParticleFlags p_particle_flag, bool p_enable);
+	bool get_particle_flag(ParticleFlags p_particle_flag) const;
 
 	void set_emission_shape(EmissionShape p_shape);
 	void set_emission_sphere_radius(float p_radius);
@@ -349,7 +349,7 @@ public:
 };
 
 VARIANT_ENUM_CAST(ParticlesMaterial::Parameter)
-VARIANT_ENUM_CAST(ParticlesMaterial::Flags)
+VARIANT_ENUM_CAST(ParticlesMaterial::ParticleFlags)
 VARIANT_ENUM_CAST(ParticlesMaterial::EmissionShape)
 VARIANT_ENUM_CAST(ParticlesMaterial::SubEmitterMode)
 

--- a/servers/rendering/renderer_rd/effects_rd.cpp
+++ b/servers/rendering/renderer_rd/effects_rd.cpp
@@ -67,7 +67,7 @@ RID EffectsRD::_get_uniform_set_from_image(RID p_image) {
 	}
 	Vector<RD::Uniform> uniforms;
 	RD::Uniform u;
-	u.type = RD::UNIFORM_TYPE_IMAGE;
+	u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 	u.binding = 0;
 	u.ids.push_back(p_image);
 	uniforms.push_back(u);
@@ -89,7 +89,7 @@ RID EffectsRD::_get_uniform_set_from_texture(RID p_texture, bool p_use_mipmaps) 
 
 	Vector<RD::Uniform> uniforms;
 	RD::Uniform u;
-	u.type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+	u.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
 	u.binding = 0;
 	u.ids.push_back(p_use_mipmaps ? default_mipmap_sampler : default_sampler);
 	u.ids.push_back(p_texture);
@@ -112,7 +112,7 @@ RID EffectsRD::_get_compute_uniform_set_from_texture(RID p_texture, bool p_use_m
 
 	Vector<RD::Uniform> uniforms;
 	RD::Uniform u;
-	u.type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+	u.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
 	u.binding = 0;
 	u.ids.push_back(p_use_mipmaps ? default_mipmap_sampler : default_sampler);
 	u.ids.push_back(p_texture);
@@ -140,7 +140,7 @@ RID EffectsRD::_get_compute_uniform_set_from_texture_pair(RID p_texture1, RID p_
 	Vector<RD::Uniform> uniforms;
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
 		u.binding = 0;
 		u.ids.push_back(p_use_mipmaps ? default_mipmap_sampler : default_sampler);
 		u.ids.push_back(p_texture1);
@@ -148,7 +148,7 @@ RID EffectsRD::_get_compute_uniform_set_from_texture_pair(RID p_texture1, RID p_
 	}
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
 		u.binding = 1;
 		u.ids.push_back(p_use_mipmaps ? default_mipmap_sampler : default_sampler);
 		u.ids.push_back(p_texture2);
@@ -177,14 +177,14 @@ RID EffectsRD::_get_compute_uniform_set_from_image_pair(RID p_texture1, RID p_te
 	Vector<RD::Uniform> uniforms;
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_IMAGE;
+		u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 		u.binding = 0;
 		u.ids.push_back(p_texture1);
 		uniforms.push_back(u);
 	}
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_IMAGE;
+		u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 		u.binding = 1;
 		u.ids.push_back(p_texture2);
 		uniforms.push_back(u);
@@ -1171,7 +1171,7 @@ void EffectsRD::cubemap_filter(RID p_source_cubemap, Vector<RID> p_dest_cubemap,
 	Vector<RD::Uniform> uniforms;
 	for (int i = 0; i < p_dest_cubemap.size(); i++) {
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_IMAGE;
+		u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 		u.binding = i;
 		u.ids.push_back(p_dest_cubemap[i]);
 		uniforms.push_back(u);
@@ -1591,7 +1591,7 @@ EffectsRD::EffectsRD() {
 		Vector<RD::Uniform> uniforms;
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 0;
 			u.ids.push_back(filter.coefficient_buffer);
 			uniforms.push_back(u);

--- a/servers/rendering/renderer_rd/light_cluster_builder.cpp
+++ b/servers/rendering/renderer_rd/light_cluster_builder.cpp
@@ -190,7 +190,7 @@ void LightClusterBuilder::setup(uint32_t p_width, uint32_t p_height, uint32_t p_
 	{
 		RD::TextureFormat tf;
 		tf.format = RD::DATA_FORMAT_R32G32B32A32_UINT;
-		tf.type = RD::TEXTURE_TYPE_3D;
+		tf.texture_type = RD::TEXTURE_TYPE_3D;
 		tf.width = width;
 		tf.height = height;
 		tf.depth = depth;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1022,7 +1022,7 @@ RID RendererCanvasRenderRD::_create_base_uniform_set(RID p_to_render_target, boo
 
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+		u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 		u.binding = 1;
 		u.ids.push_back(state.canvas_state_buffer);
 		uniforms.push_back(u);
@@ -1030,7 +1030,7 @@ RID RendererCanvasRenderRD::_create_base_uniform_set(RID p_to_render_target, boo
 
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+		u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 		u.binding = 2;
 		u.ids.push_back(state.lights_uniform_buffer);
 		uniforms.push_back(u);
@@ -1038,7 +1038,7 @@ RID RendererCanvasRenderRD::_create_base_uniform_set(RID p_to_render_target, boo
 
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		u.binding = 3;
 		u.ids.push_back(storage->decal_atlas_get_texture());
 		uniforms.push_back(u);
@@ -1046,7 +1046,7 @@ RID RendererCanvasRenderRD::_create_base_uniform_set(RID p_to_render_target, boo
 
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		u.binding = 4;
 		u.ids.push_back(state.shadow_texture);
 		uniforms.push_back(u);
@@ -1054,7 +1054,7 @@ RID RendererCanvasRenderRD::_create_base_uniform_set(RID p_to_render_target, boo
 
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_SAMPLER;
+		u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 		u.binding = 5;
 		u.ids.push_back(state.shadow_sampler);
 		uniforms.push_back(u);
@@ -1062,7 +1062,7 @@ RID RendererCanvasRenderRD::_create_base_uniform_set(RID p_to_render_target, boo
 
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		u.binding = 6;
 		RID screen;
 		if (p_backbuffer) {
@@ -1079,7 +1079,7 @@ RID RendererCanvasRenderRD::_create_base_uniform_set(RID p_to_render_target, boo
 
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		u.binding = 7;
 		RID sdf = storage->render_target_get_sdf_texture(p_to_render_target);
 		u.ids.push_back(sdf);
@@ -1089,7 +1089,7 @@ RID RendererCanvasRenderRD::_create_base_uniform_set(RID p_to_render_target, boo
 	{
 		//needs samplers for the material (uses custom textures) create them
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_SAMPLER;
+		u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 		u.binding = 8;
 		u.ids.resize(12);
 		RID *ids_ptr = u.ids.ptrw();
@@ -1110,7 +1110,7 @@ RID RendererCanvasRenderRD::_create_base_uniform_set(RID p_to_render_target, boo
 
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 		u.binding = 9;
 		u.ids.push_back(storage->global_variables_get_storage_buffer());
 		uniforms.push_back(u);
@@ -2320,7 +2320,7 @@ void RendererCanvasRenderRD::MaterialData::update_parameters(const Map<StringNam
 	{
 		if (shader_data->ubo_size) {
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.binding = 0;
 			u.ids.push_back(uniform_buffer);
 			uniforms.push_back(u);
@@ -2329,7 +2329,7 @@ void RendererCanvasRenderRD::MaterialData::update_parameters(const Map<StringNam
 		const RID *textures = texture_cache.ptrw();
 		for (uint32_t i = 0; i < tex_uniform_count; i++) {
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 1 + i;
 			u.ids.push_back(textures[i]);
 			uniforms.push_back(u);
@@ -2681,7 +2681,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD(RendererStorageRD *p_storage) {
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 0;
 			u.ids.push_back(storage->get_default_rd_storage_buffer());
 			uniforms.push_back(u);

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1564,7 +1564,7 @@ void RendererCanvasRenderRD::_update_shadow_atlas() {
 
 		{ //texture
 			RD::TextureFormat tf;
-			tf.type = RD::TEXTURE_TYPE_2D;
+			tf.texture_type = RD::TEXTURE_TYPE_2D;
 			tf.width = state.shadow_texture_size;
 			tf.height = state.max_lights_per_render * 2;
 			tf.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT;
@@ -1575,7 +1575,7 @@ void RendererCanvasRenderRD::_update_shadow_atlas() {
 		}
 		{
 			RD::TextureFormat tf;
-			tf.type = RD::TEXTURE_TYPE_2D;
+			tf.texture_type = RD::TEXTURE_TYPE_2D;
 			tf.width = state.shadow_texture_size;
 			tf.height = state.max_lights_per_render * 2;
 			tf.usage_bits = RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
@@ -2667,7 +2667,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD(RendererStorageRD *p_storage) {
 	{
 		//default shadow texture to keep uniform set happy
 		RD::TextureFormat tf;
-		tf.type = RD::TEXTURE_TYPE_2D;
+		tf.texture_type = RD::TEXTURE_TYPE_2D;
 		tf.width = 4;
 		tf.height = 4;
 		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT;
@@ -2740,7 +2740,7 @@ void RendererCanvasRenderRD::set_shadow_texture_size(int p_size) {
 		{
 			//create a default shadow texture to keep uniform set happy (and that it gets erased when a new one is created)
 			RD::TextureFormat tf;
-			tf.type = RD::TEXTURE_TYPE_2D;
+			tf.texture_type = RD::TEXTURE_TYPE_2D;
 			tf.width = 4;
 			tf.height = 4;
 			tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -47,7 +47,7 @@ void RendererCompositorRD::blit_render_targets_to_screen(DisplayServer::WindowID
 		if (!render_target_descriptors.has(rd_texture) || !RD::get_singleton()->uniform_set_is_valid(render_target_descriptors[rd_texture])) {
 			Vector<RD::Uniform> uniforms;
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE;
 			u.binding = 0;
 			u.ids.push_back(copy_viewports_sampler);
 			u.ids.push_back(rd_texture);

--- a/servers/rendering/renderer_rd/renderer_scene_render_forward.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_forward.cpp
@@ -479,7 +479,7 @@ void RendererSceneRenderForward::MaterialData::update_parameters(const Map<Strin
 	{
 		if (shader_data->ubo_size) {
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.binding = 0;
 			u.ids.push_back(uniform_buffer);
 			uniforms.push_back(u);
@@ -488,7 +488,7 @@ void RendererSceneRenderForward::MaterialData::update_parameters(const Map<Strin
 		const RID *textures = texture_cache.ptrw();
 		for (uint32_t i = 0; i < tex_uniform_count; i++) {
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 1 + i;
 			u.ids.push_back(textures[i]);
 			uniforms.push_back(u);
@@ -2202,28 +2202,28 @@ void RendererSceneRenderForward::_render_sdfgi(RID p_render_buffers, const Vecto
 		Vector<RD::Uniform> uniforms;
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.binding = 0;
 			u.ids.push_back(p_albedo_texture);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.binding = 1;
 			u.ids.push_back(p_emission_texture);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.binding = 2;
 			u.ids.push_back(p_emission_aniso_texture);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.binding = 3;
 			u.ids.push_back(p_geom_facing_texture);
 			uniforms.push_back(u);
@@ -2311,7 +2311,7 @@ void RendererSceneRenderForward::_update_render_base_uniform_set() {
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.binding = 1;
 			u.ids.resize(12);
 			RID *ids_ptr = u.ids.ptrw();
@@ -2333,7 +2333,7 @@ void RendererSceneRenderForward::_update_render_base_uniform_set() {
 		{
 			RD::Uniform u;
 			u.binding = 2;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.ids.push_back(shadow_sampler);
 			uniforms.push_back(u);
 		}
@@ -2341,14 +2341,14 @@ void RendererSceneRenderForward::_update_render_base_uniform_set() {
 		{
 			RD::Uniform u;
 			u.binding = 3;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.ids.push_back(scene_state.uniform_buffer);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 4;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.ids.push_back(scene_state.instance_buffer);
 			uniforms.push_back(u);
 		}
@@ -2356,7 +2356,7 @@ void RendererSceneRenderForward::_update_render_base_uniform_set() {
 		{
 			RD::Uniform u;
 			u.binding = 5;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.ids.push_back(get_positional_light_buffer());
 			uniforms.push_back(u);
 		}
@@ -2364,42 +2364,42 @@ void RendererSceneRenderForward::_update_render_base_uniform_set() {
 		{
 			RD::Uniform u;
 			u.binding = 6;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.ids.push_back(get_reflection_probe_buffer());
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 7;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.ids.push_back(get_directional_light_buffer());
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 10;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.ids.push_back(scene_state.lightmap_buffer);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 11;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.ids = storage->lightmap_array_get_textures();
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 12;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.ids.push_back(scene_state.lightmap_capture_buffer);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 13;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID decal_atlas = storage->decal_atlas_get_texture();
 			u.ids.push_back(decal_atlas);
 			uniforms.push_back(u);
@@ -2407,7 +2407,7 @@ void RendererSceneRenderForward::_update_render_base_uniform_set() {
 		{
 			RD::Uniform u;
 			u.binding = 14;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID decal_atlas = storage->decal_atlas_get_texture_srgb();
 			u.ids.push_back(decal_atlas);
 			uniforms.push_back(u);
@@ -2415,7 +2415,7 @@ void RendererSceneRenderForward::_update_render_base_uniform_set() {
 		{
 			RD::Uniform u;
 			u.binding = 15;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.ids.push_back(get_decal_buffer());
 			uniforms.push_back(u);
 		}
@@ -2423,14 +2423,14 @@ void RendererSceneRenderForward::_update_render_base_uniform_set() {
 		{
 			RD::Uniform u;
 			u.binding = 16;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.ids.push_back(get_cluster_builder_texture());
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 17;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.ids.push_back(get_cluster_builder_indices_buffer());
 			uniforms.push_back(u);
 		}
@@ -2438,7 +2438,7 @@ void RendererSceneRenderForward::_update_render_base_uniform_set() {
 		{
 			RD::Uniform u;
 			u.binding = 18;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			if (directional_shadow_get_texture().is_valid()) {
 				u.ids.push_back(directional_shadow_get_texture());
 			} else {
@@ -2449,7 +2449,7 @@ void RendererSceneRenderForward::_update_render_base_uniform_set() {
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 19;
 			u.ids.push_back(storage->global_variables_get_storage_buffer());
 			uniforms.push_back(u);
@@ -2457,7 +2457,7 @@ void RendererSceneRenderForward::_update_render_base_uniform_set() {
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.binding = 20;
 			u.ids.push_back(sdfgi_get_ubo());
 			uniforms.push_back(u);
@@ -2480,7 +2480,7 @@ void RendererSceneRenderForward::_setup_view_dependant_uniform_set(RID p_shadow_
 		RID ref_texture = p_reflection_atlas.is_valid() ? reflection_atlas_get_texture(p_reflection_atlas) : RID();
 		RD::Uniform u;
 		u.binding = 0;
-		u.type = RD::UNIFORM_TYPE_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		if (ref_texture.is_valid()) {
 			u.ids.push_back(ref_texture);
 		} else {
@@ -2492,7 +2492,7 @@ void RendererSceneRenderForward::_setup_view_dependant_uniform_set(RID p_shadow_
 	{
 		RD::Uniform u;
 		u.binding = 1;
-		u.type = RD::UNIFORM_TYPE_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID texture;
 		if (p_shadow_atlas.is_valid()) {
 			texture = shadow_atlas_get_texture(p_shadow_atlas);
@@ -2507,7 +2507,7 @@ void RendererSceneRenderForward::_setup_view_dependant_uniform_set(RID p_shadow_
 	{
 		RD::Uniform u;
 		u.binding = 2;
-		u.type = RD::UNIFORM_TYPE_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID default_tex = storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE);
 		for (int i = 0; i < MAX_GI_PROBES; i++) {
 			if (i < p_gi_probe_cull_count) {
@@ -2565,7 +2565,7 @@ void RendererSceneRenderForward::_update_render_buffers_uniform_set(RID p_render
 		{
 			RD::Uniform u;
 			u.binding = 0;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID texture = false && rb->depth.is_valid() ? rb->depth : storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_WHITE);
 			u.ids.push_back(texture);
 			uniforms.push_back(u);
@@ -2573,7 +2573,7 @@ void RendererSceneRenderForward::_update_render_buffers_uniform_set(RID p_render
 		{
 			RD::Uniform u;
 			u.binding = 1;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID bbt = render_buffers_get_back_buffer_texture(p_render_buffers);
 			RID texture = bbt.is_valid() ? bbt : storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_BLACK);
 			u.ids.push_back(texture);
@@ -2582,7 +2582,7 @@ void RendererSceneRenderForward::_update_render_buffers_uniform_set(RID p_render
 		{
 			RD::Uniform u;
 			u.binding = 2;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID texture = rb->normal_roughness_buffer.is_valid() ? rb->normal_roughness_buffer : storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_NORMAL);
 			u.ids.push_back(texture);
 			uniforms.push_back(u);
@@ -2591,7 +2591,7 @@ void RendererSceneRenderForward::_update_render_buffers_uniform_set(RID p_render
 		{
 			RD::Uniform u;
 			u.binding = 4;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID aot = render_buffers_get_ao_texture(p_render_buffers);
 			RID texture = aot.is_valid() ? aot : storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_BLACK);
 			u.ids.push_back(texture);
@@ -2601,7 +2601,7 @@ void RendererSceneRenderForward::_update_render_buffers_uniform_set(RID p_render
 		{
 			RD::Uniform u;
 			u.binding = 5;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID texture = rb->ambient_buffer.is_valid() ? rb->ambient_buffer : storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_BLACK);
 			u.ids.push_back(texture);
 			uniforms.push_back(u);
@@ -2610,7 +2610,7 @@ void RendererSceneRenderForward::_update_render_buffers_uniform_set(RID p_render
 		{
 			RD::Uniform u;
 			u.binding = 6;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID texture = rb->reflection_buffer.is_valid() ? rb->reflection_buffer : storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_BLACK);
 			u.ids.push_back(texture);
 			uniforms.push_back(u);
@@ -2618,7 +2618,7 @@ void RendererSceneRenderForward::_update_render_buffers_uniform_set(RID p_render
 		{
 			RD::Uniform u;
 			u.binding = 7;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID t;
 			if (render_buffers_is_sdfgi_enabled(p_render_buffers)) {
 				t = render_buffers_get_sdfgi_irradiance_probes(p_render_buffers);
@@ -2631,7 +2631,7 @@ void RendererSceneRenderForward::_update_render_buffers_uniform_set(RID p_render
 		{
 			RD::Uniform u;
 			u.binding = 8;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			if (render_buffers_is_sdfgi_enabled(p_render_buffers)) {
 				u.ids.push_back(render_buffers_get_sdfgi_occlusion_texture(p_render_buffers));
 			} else {
@@ -2642,14 +2642,14 @@ void RendererSceneRenderForward::_update_render_buffers_uniform_set(RID p_render
 		{
 			RD::Uniform u;
 			u.binding = 9;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.ids.push_back(render_buffers_get_gi_probe_buffer(p_render_buffers));
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 10;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID vfog = RID();
 			if (p_render_buffers.is_valid() && render_buffers_has_volumetric_fog(p_render_buffers)) {
 				vfog = render_buffers_get_volumetric_fog_texture(p_render_buffers);
@@ -2943,7 +2943,7 @@ RendererSceneRenderForward::RendererSceneRenderForward(RendererStorageRD *p_stor
 		default_vec4_xform_buffer = RD::get_singleton()->storage_buffer_create(256);
 		Vector<RD::Uniform> uniforms;
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 		u.ids.push_back(default_vec4_xform_buffer);
 		u.binding = 0;
 		uniforms.push_back(u);
@@ -2964,7 +2964,7 @@ RendererSceneRenderForward::RendererSceneRenderForward(RendererStorageRD *p_stor
 
 		RD::Uniform u;
 		u.binding = 0;
-		u.type = RD::UNIFORM_TYPE_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID texture = storage->texture_rd_get_default(is_using_radiance_cubemap_array() ? RendererStorageRD::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK : RendererStorageRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK);
 		u.ids.push_back(texture);
 		uniforms.push_back(u);
@@ -2977,7 +2977,7 @@ RendererSceneRenderForward::RendererSceneRenderForward(RendererStorageRD *p_stor
 		for (int i = 0; i < 7; i++) {
 			RD::Uniform u;
 			u.binding = i;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID texture = storage->texture_rd_get_default(i == 0 ? RendererStorageRD::DEFAULT_RD_TEXTURE_WHITE : (i == 2 ? RendererStorageRD::DEFAULT_RD_TEXTURE_NORMAL : RendererStorageRD::DEFAULT_RD_TEXTURE_BLACK));
 			u.ids.push_back(texture);
 			uniforms.push_back(u);
@@ -2985,7 +2985,7 @@ RendererSceneRenderForward::RendererSceneRenderForward(RendererStorageRD *p_stor
 		{
 			RD::Uniform u;
 			u.binding = 7;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID texture = storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
 			u.ids.push_back(texture);
 			uniforms.push_back(u);
@@ -2993,21 +2993,21 @@ RendererSceneRenderForward::RendererSceneRenderForward(RendererStorageRD *p_stor
 		{
 			RD::Uniform u;
 			u.binding = 8;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 9;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.ids.push_back(render_buffers_get_default_gi_probe_buffer());
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 10;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE));
 			uniforms.push_back(u);
 		}

--- a/servers/rendering/renderer_rd/renderer_scene_render_forward.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_forward.cpp
@@ -717,7 +717,7 @@ void RendererSceneRenderForward::RenderBufferDataHighEnd::configure(RID p_color_
 		tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
 		tf.width = p_width;
 		tf.height = p_height;
-		tf.type = RD::TEXTURE_TYPE_2D;
+		tf.texture_type = RD::TEXTURE_TYPE_2D;
 		tf.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT;
 
 		RD::TextureSamples ts[RS::VIEWPORT_MSAA_MAX] = {

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -129,7 +129,7 @@ void RendererSceneRenderRD::_update_reflection_data(ReflectionData &rd, int p_si
 	tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
 	tf.width = 64; // Always 64x64
 	tf.height = 64;
-	tf.type = RD::TEXTURE_TYPE_CUBE;
+	tf.texture_type = RD::TEXTURE_TYPE_CUBE;
 	tf.array_layers = 6;
 	tf.mipmaps = 7;
 	tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -284,7 +284,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 		tf_sdf.width = sdfgi->cascade_size; // Always 64x64
 		tf_sdf.height = sdfgi->cascade_size;
 		tf_sdf.depth = sdfgi->cascade_size;
-		tf_sdf.type = RD::TEXTURE_TYPE_3D;
+		tf_sdf.texture_type = RD::TEXTURE_TYPE_3D;
 		tf_sdf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
 
 		{
@@ -341,7 +341,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 		tf_probes.width = sdfgi->probe_axis_count * sdfgi->probe_axis_count;
 		tf_probes.height = sdfgi->probe_axis_count * SDFGI::SH_SIZE;
 		tf_probes.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
-		tf_probes.type = RD::TEXTURE_TYPE_2D_ARRAY;
+		tf_probes.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
 
 		sdfgi->history_size = requested_history_size;
 
@@ -351,7 +351,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 
 		RD::TextureFormat tf_probe_average = tf_probes;
 		tf_probe_average.format = RD::DATA_FORMAT_R32G32B32A32_SINT; //signed integer because SH are signed
-		tf_probe_average.type = RD::TEXTURE_TYPE_2D;
+		tf_probe_average.texture_type = RD::TEXTURE_TYPE_2D;
 
 		sdfgi->lightprobe_history_scroll = RD::get_singleton()->texture_create(tf_probe_history, RD::TextureView());
 		sdfgi->lightprobe_average_scroll = RD::get_singleton()->texture_create(tf_probe_average, RD::TextureView());
@@ -378,7 +378,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			tf_ambient.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT; //pack well with RGBE
 			tf_ambient.width = sdfgi->probe_axis_count * sdfgi->probe_axis_count;
 			tf_ambient.height = sdfgi->probe_axis_count;
-			tf_ambient.type = RD::TEXTURE_TYPE_2D_ARRAY;
+			tf_ambient.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
 			//lightprobe texture is an octahedral texture
 			sdfgi->ambient_texture = RD::get_singleton()->texture_create(tf_ambient, RD::TextureView());
 		}
@@ -1897,7 +1897,7 @@ void RendererSceneRenderRD::_update_dirty_skys() {
 				RD::TextureFormat tf;
 				tf.array_layers = layers * 6;
 				tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
-				tf.type = RD::TEXTURE_TYPE_CUBE_ARRAY;
+				tf.texture_type = RD::TEXTURE_TYPE_CUBE_ARRAY;
 				tf.mipmaps = mipmaps;
 				tf.width = w;
 				tf.height = h;
@@ -1912,7 +1912,7 @@ void RendererSceneRenderRD::_update_dirty_skys() {
 				RD::TextureFormat tf;
 				tf.array_layers = 6;
 				tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
-				tf.type = RD::TEXTURE_TYPE_CUBE;
+				tf.texture_type = RD::TEXTURE_TYPE_CUBE;
 				tf.mipmaps = MIN(mipmaps, layers);
 				tf.width = w;
 				tf.height = h;
@@ -1932,7 +1932,7 @@ void RendererSceneRenderRD::_update_dirty_skys() {
 			tformat.width = sky->screen_size.x / 2;
 			tformat.height = sky->screen_size.y / 2;
 			tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
-			tformat.type = RD::TEXTURE_TYPE_2D;
+			tformat.texture_type = RD::TEXTURE_TYPE_2D;
 
 			sky->half_res_pass = RD::get_singleton()->texture_create(tformat, RD::TextureView());
 			Vector<RID> texs;
@@ -1947,7 +1947,7 @@ void RendererSceneRenderRD::_update_dirty_skys() {
 			tformat.width = sky->screen_size.x / 4;
 			tformat.height = sky->screen_size.y / 4;
 			tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
-			tformat.type = RD::TEXTURE_TYPE_2D;
+			tformat.texture_type = RD::TEXTURE_TYPE_2D;
 
 			sky->quarter_res_pass = RD::get_singleton()->texture_create(tformat, RD::TextureView());
 			Vector<RID> texs;
@@ -3331,7 +3331,7 @@ bool RendererSceneRenderRD::reflection_probe_instance_begin_render(RID p_instanc
 			RD::TextureFormat tf;
 			tf.array_layers = 6 * atlas->count;
 			tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
-			tf.type = RD::TEXTURE_TYPE_CUBE_ARRAY;
+			tf.texture_type = RD::TEXTURE_TYPE_CUBE_ARRAY;
 			tf.mipmaps = mipmaps;
 			tf.width = atlas->size;
 			tf.height = atlas->size;
@@ -3948,7 +3948,7 @@ RendererSceneRenderRD::ShadowCubemap *RendererSceneRenderRD::_get_shadow_cubemap
 			tf.format = RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_D32_SFLOAT, RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) ? RD::DATA_FORMAT_D32_SFLOAT : RD::DATA_FORMAT_X8_D24_UNORM_PACK32;
 			tf.width = p_size;
 			tf.height = p_size;
-			tf.type = RD::TEXTURE_TYPE_CUBE;
+			tf.texture_type = RD::TEXTURE_TYPE_CUBE;
 			tf.array_layers = 6;
 			tf.usage_bits = RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT;
 			sc.cubemap = RD::get_singleton()->texture_create(tf, RD::TextureView());
@@ -4062,7 +4062,7 @@ void RendererSceneRenderRD::gi_probe_update(RID p_probe, bool p_update_light_ins
 			tf.width = octree_size.x;
 			tf.height = octree_size.y;
 			tf.depth = octree_size.z;
-			tf.type = RD::TEXTURE_TYPE_3D;
+			tf.texture_type = RD::TEXTURE_TYPE_3D;
 			tf.mipmaps = levels.size();
 
 			tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
@@ -4950,7 +4950,7 @@ void RendererSceneRenderRD::_allocate_blur_textures(RenderBuffers *rb) {
 	tf.format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
 	tf.width = rb->width;
 	tf.height = rb->height;
-	tf.type = RD::TEXTURE_TYPE_2D;
+	tf.texture_type = RD::TEXTURE_TYPE_2D;
 	tf.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
 	tf.mipmaps = mipmaps_required;
 
@@ -5123,7 +5123,7 @@ void RendererSceneRenderRD::_process_ssr(RID p_render_buffers, RID p_dest_frameb
 		tf.format = RD::DATA_FORMAT_R32_SFLOAT;
 		tf.width = rb->width / 2;
 		tf.height = rb->height / 2;
-		tf.type = RD::TEXTURE_TYPE_2D;
+		tf.texture_type = RD::TEXTURE_TYPE_2D;
 		tf.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT;
 
 		rb->ssr.depth_scaled = RD::get_singleton()->texture_create(tf, RD::TextureView());
@@ -5138,7 +5138,7 @@ void RendererSceneRenderRD::_process_ssr(RID p_render_buffers, RID p_dest_frameb
 		tf.format = RD::DATA_FORMAT_R8_UNORM;
 		tf.width = rb->width / 2;
 		tf.height = rb->height / 2;
-		tf.type = RD::TEXTURE_TYPE_2D;
+		tf.texture_type = RD::TEXTURE_TYPE_2D;
 		tf.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT;
 
 		rb->ssr.blur_radius[0] = RD::get_singleton()->texture_create(tf, RD::TextureView());
@@ -6543,7 +6543,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 		tf.width = target_width;
 		tf.height = target_height;
 		tf.depth = volumetric_fog_depth;
-		tf.type = RD::TEXTURE_TYPE_3D;
+		tf.texture_type = RD::TEXTURE_TYPE_3D;
 		tf.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT;
 
 		rb->volumetric_fog->light_density_map = RD::get_singleton()->texture_create(tf, RD::TextureView());

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -443,21 +443,21 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 				Vector<RD::Uniform> uniforms;
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 1;
 					u.ids.push_back(sdfgi->render_sdf[(passes & 1) ? 1 : 0]); //if passes are even, we read from buffer 0, else we read from buffer 1
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 2;
 					u.ids.push_back(sdfgi->render_albedo);
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 3;
 					for (int j = 0; j < 8; j++) {
 						u.ids.push_back(sdfgi->render_occlusion[j]);
@@ -466,21 +466,21 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 4;
 					u.ids.push_back(sdfgi->render_emission);
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 5;
 					u.ids.push_back(sdfgi->render_emission_aniso);
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 6;
 					u.ids.push_back(sdfgi->render_geom_facing);
 					uniforms.push_back(u);
@@ -488,28 +488,28 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 7;
 					u.ids.push_back(cascade.sdf_tex);
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 8;
 					u.ids.push_back(sdfgi->occlusion_data);
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+					u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 					u.binding = 10;
 					u.ids.push_back(cascade.solid_cell_dispatch_buffer);
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+					u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 					u.binding = 11;
 					u.ids.push_back(cascade.solid_cell_buffer);
 					uniforms.push_back(u);
@@ -522,42 +522,42 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 				Vector<RD::Uniform> uniforms;
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 1;
 					u.ids.push_back(sdfgi->render_albedo);
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 2;
 					u.ids.push_back(sdfgi->render_geom_facing);
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 3;
 					u.ids.push_back(sdfgi->render_emission);
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 4;
 					u.ids.push_back(sdfgi->render_emission_aniso);
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+					u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 					u.binding = 5;
 					u.ids.push_back(cascade.solid_cell_dispatch_buffer);
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+					u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 					u.binding = 6;
 					u.ids.push_back(cascade.solid_cell_buffer);
 					uniforms.push_back(u);
@@ -569,7 +569,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 				Vector<RD::Uniform> uniforms;
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 1;
 					for (int j = 0; j < 8; j++) {
 						u.ids.push_back(sdfgi->render_occlusion[j]);
@@ -578,7 +578,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 2;
 					u.ids.push_back(sdfgi->occlusion_data);
 					uniforms.push_back(u);
@@ -596,7 +596,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			{
 				RD::Uniform u;
 				u.binding = 1;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
 					if (j < rb->sdfgi->cascades.size()) {
 						u.ids.push_back(rb->sdfgi->cascades[j].sdf_tex);
@@ -609,63 +609,63 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			{
 				RD::Uniform u;
 				u.binding = 2;
-				u.type = RD::UNIFORM_TYPE_SAMPLER;
+				u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 				u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
 				u.binding = 3;
-				u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 				u.ids.push_back(cascade.solid_cell_dispatch_buffer);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
 				u.binding = 4;
-				u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 				u.ids.push_back(cascade.solid_cell_buffer);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
 				u.binding = 5;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.ids.push_back(cascade.light_data);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
 				u.binding = 6;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.ids.push_back(cascade.light_aniso_0_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
 				u.binding = 7;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.ids.push_back(cascade.light_aniso_1_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
 				u.binding = 8;
-				u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 				u.ids.push_back(rb->sdfgi->cascades_ubo);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
 				u.binding = 9;
-				u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 				u.ids.push_back(cascade.lights_buffer);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
 				u.binding = 10;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.ids.push_back(rb->sdfgi->lightprobe_texture);
 				uniforms.push_back(u);
 			}
@@ -678,14 +678,14 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			Vector<RD::Uniform> uniforms;
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 1;
 				u.ids.push_back(sdfgi->render_albedo);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 2;
 				u.ids.push_back(sdfgi->render_sdf[0]);
 				uniforms.push_back(u);
@@ -698,14 +698,14 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			Vector<RD::Uniform> uniforms;
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 1;
 				u.ids.push_back(sdfgi->render_albedo);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 2;
 				u.ids.push_back(sdfgi->render_sdf_half[0]);
 				uniforms.push_back(u);
@@ -719,14 +719,14 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			Vector<RD::Uniform> uniforms;
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 1;
 				u.ids.push_back(sdfgi->render_sdf[0]);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 2;
 				u.ids.push_back(sdfgi->render_sdf[1]);
 				uniforms.push_back(u);
@@ -741,14 +741,14 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			Vector<RD::Uniform> uniforms;
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 1;
 				u.ids.push_back(sdfgi->render_sdf_half[0]);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 2;
 				u.ids.push_back(sdfgi->render_sdf_half[1]);
 				uniforms.push_back(u);
@@ -764,21 +764,21 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			Vector<RD::Uniform> uniforms;
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 1;
 				u.ids.push_back(sdfgi->render_albedo);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 2;
 				u.ids.push_back(sdfgi->render_sdf_half[(passes & 1) ? 0 : 1]); //reverse pass order because half size
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 3;
 				u.ids.push_back(sdfgi->render_sdf[(passes & 1) ? 0 : 1]); //reverse pass order because it needs an extra JFA pass
 				uniforms.push_back(u);
@@ -793,14 +793,14 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			Vector<RD::Uniform> uniforms;
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 1;
 				u.ids.push_back(sdfgi->render_albedo);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 2;
 				for (int i = 0; i < 8; i++) {
 					u.ids.push_back(sdfgi->render_occlusion[i]);
@@ -809,7 +809,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 3;
 				u.ids.push_back(sdfgi->render_geom_facing);
 				uniforms.push_back(u);
@@ -826,7 +826,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			{
 				RD::Uniform u;
 				u.binding = 1;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
 					if (j < sdfgi->cascades.size()) {
 						u.ids.push_back(sdfgi->cascades[j].sdf_tex);
@@ -839,7 +839,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			{
 				RD::Uniform u;
 				u.binding = 2;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
 					if (j < sdfgi->cascades.size()) {
 						u.ids.push_back(sdfgi->cascades[j].light_tex);
@@ -852,7 +852,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			{
 				RD::Uniform u;
 				u.binding = 3;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
 					if (j < sdfgi->cascades.size()) {
 						u.ids.push_back(sdfgi->cascades[j].light_aniso_0_tex);
@@ -865,7 +865,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			{
 				RD::Uniform u;
 				u.binding = 4;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
 					if (j < sdfgi->cascades.size()) {
 						u.ids.push_back(sdfgi->cascades[j].light_aniso_1_tex);
@@ -877,7 +877,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_SAMPLER;
+				u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 				u.binding = 6;
 				u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 				uniforms.push_back(u);
@@ -885,14 +885,14 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 				u.binding = 7;
 				u.ids.push_back(sdfgi->cascades_ubo);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 8;
 				u.ids.push_back(sdfgi->lightprobe_data);
 				uniforms.push_back(u);
@@ -900,14 +900,14 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 9;
 				u.ids.push_back(sdfgi->cascades[i].lightprobe_history_tex);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 10;
 				u.ids.push_back(sdfgi->cascades[i].lightprobe_average_tex);
 				uniforms.push_back(u);
@@ -915,21 +915,21 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 11;
 				u.ids.push_back(sdfgi->lightprobe_history_scroll);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 12;
 				u.ids.push_back(sdfgi->lightprobe_average_scroll);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 13;
 				RID parent_average;
 				if (i < sdfgi->cascades.size() - 1) {
@@ -942,7 +942,7 @@ void RendererSceneRenderRD::sdfgi_update(RID p_render_buffers, RID p_environment
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 14;
 				u.ids.push_back(sdfgi->ambient_texture);
 				uniforms.push_back(u);
@@ -1338,7 +1338,7 @@ void RendererSceneRenderRD::sdfgi_update_probes(RID p_render_buffers, RID p_envi
 
 					{
 						RD::Uniform u;
-						u.type = RD::UNIFORM_TYPE_TEXTURE;
+						u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 						u.binding = 0;
 						u.ids.push_back(sky->radiance);
 						uniforms.push_back(u);
@@ -1346,7 +1346,7 @@ void RendererSceneRenderRD::sdfgi_update_probes(RID p_render_buffers, RID p_envi
 
 					{
 						RD::Uniform u;
-						u.type = RD::UNIFORM_TYPE_SAMPLER;
+						u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 						u.binding = 1;
 						u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 						uniforms.push_back(u);
@@ -1614,7 +1614,7 @@ void RendererSceneRenderRD::_process_gi(RID p_render_buffers, RID p_normal_rough
 		{
 			RD::Uniform u;
 			u.binding = 1;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
 				if (rb->sdfgi && j < rb->sdfgi->cascades.size()) {
 					u.ids.push_back(rb->sdfgi->cascades[j].sdf_tex);
@@ -1627,7 +1627,7 @@ void RendererSceneRenderRD::_process_gi(RID p_render_buffers, RID p_normal_rough
 		{
 			RD::Uniform u;
 			u.binding = 2;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
 				if (rb->sdfgi && j < rb->sdfgi->cascades.size()) {
 					u.ids.push_back(rb->sdfgi->cascades[j].light_tex);
@@ -1640,7 +1640,7 @@ void RendererSceneRenderRD::_process_gi(RID p_render_buffers, RID p_normal_rough
 		{
 			RD::Uniform u;
 			u.binding = 3;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
 				if (rb->sdfgi && j < rb->sdfgi->cascades.size()) {
 					u.ids.push_back(rb->sdfgi->cascades[j].light_aniso_0_tex);
@@ -1653,7 +1653,7 @@ void RendererSceneRenderRD::_process_gi(RID p_render_buffers, RID p_normal_rough
 		{
 			RD::Uniform u;
 			u.binding = 4;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			for (uint32_t j = 0; j < SDFGI::MAX_CASCADES; j++) {
 				if (rb->sdfgi && j < rb->sdfgi->cascades.size()) {
 					u.ids.push_back(rb->sdfgi->cascades[j].light_aniso_1_tex);
@@ -1665,7 +1665,7 @@ void RendererSceneRenderRD::_process_gi(RID p_render_buffers, RID p_normal_rough
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 5;
 			if (rb->sdfgi) {
 				u.ids.push_back(rb->sdfgi->occlusion_texture);
@@ -1676,14 +1676,14 @@ void RendererSceneRenderRD::_process_gi(RID p_render_buffers, RID p_normal_rough
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.binding = 6;
 			u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.binding = 7;
 			u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 			uniforms.push_back(u);
@@ -1691,7 +1691,7 @@ void RendererSceneRenderRD::_process_gi(RID p_render_buffers, RID p_normal_rough
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.binding = 9;
 			u.ids.push_back(p_ambient_buffer);
 			uniforms.push_back(u);
@@ -1699,7 +1699,7 @@ void RendererSceneRenderRD::_process_gi(RID p_render_buffers, RID p_normal_rough
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.binding = 10;
 			u.ids.push_back(p_reflection_buffer);
 			uniforms.push_back(u);
@@ -1707,7 +1707,7 @@ void RendererSceneRenderRD::_process_gi(RID p_render_buffers, RID p_normal_rough
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 11;
 			if (rb->sdfgi) {
 				u.ids.push_back(rb->sdfgi->lightprobe_texture);
@@ -1718,21 +1718,21 @@ void RendererSceneRenderRD::_process_gi(RID p_render_buffers, RID p_normal_rough
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 12;
 			u.ids.push_back(rb->depth_texture);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 13;
 			u.ids.push_back(p_normal_roughness_buffer);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 14;
 			RID buffer = p_gi_probe_buffer.is_valid() ? p_gi_probe_buffer : storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_BLACK);
 			u.ids.push_back(buffer);
@@ -1740,21 +1740,21 @@ void RendererSceneRenderRD::_process_gi(RID p_render_buffers, RID p_normal_rough
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.binding = 15;
 			u.ids.push_back(gi.sdfgi_ubo);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.binding = 16;
 			u.ids.push_back(rb->giprobe_buffer);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 17;
 			for (int i = 0; i < RenderBuffers::MAX_GIPROBES; i++) {
 				u.ids.push_back(rb->giprobe_textures[i]);
@@ -1994,7 +1994,7 @@ RID RendererSceneRenderRD::sky_get_radiance_uniform_set_rd(RID p_sky, RID p_shad
 			Vector<RD::Uniform> uniforms;
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 0;
 				u.ids.push_back(sky->radiance);
 				uniforms.push_back(u);
@@ -2014,7 +2014,7 @@ RID RendererSceneRenderRD::_get_sky_textures(Sky *p_sky, SkyTextureSetVersion p_
 	Vector<RD::Uniform> uniforms;
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		u.binding = 0;
 		if (p_sky->radiance.is_valid() && p_version <= SKY_TEXTURE_SET_QUARTER_RES) {
 			u.ids.push_back(p_sky->radiance);
@@ -2025,7 +2025,7 @@ RID RendererSceneRenderRD::_get_sky_textures(Sky *p_sky, SkyTextureSetVersion p_
 	}
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		u.binding = 1; // half res
 		if (p_sky->half_res_pass.is_valid() && p_version != SKY_TEXTURE_SET_HALF_RES && p_version != SKY_TEXTURE_SET_CUBEMAP_HALF_RES) {
 			if (p_version >= SKY_TEXTURE_SET_CUBEMAP) {
@@ -2044,7 +2044,7 @@ RID RendererSceneRenderRD::_get_sky_textures(Sky *p_sky, SkyTextureSetVersion p_
 	}
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		u.binding = 2; // quarter res
 		if (p_sky->quarter_res_pass.is_valid() && p_version != SKY_TEXTURE_SET_QUARTER_RES && p_version != SKY_TEXTURE_SET_CUBEMAP_QUARTER_RES) {
 			if (p_version >= SKY_TEXTURE_SET_CUBEMAP) {
@@ -2755,7 +2755,7 @@ void RendererSceneRenderRD::SkyMaterialData::update_parameters(const Map<StringN
 	{
 		if (shader_data->ubo_size) {
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.binding = 0;
 			u.ids.push_back(uniform_buffer);
 			uniforms.push_back(u);
@@ -2764,7 +2764,7 @@ void RendererSceneRenderRD::SkyMaterialData::update_parameters(const Map<StringN
 		const RID *textures = texture_cache.ptrw();
 		for (uint32_t i = 0; i < tex_uniform_count; i++) {
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 1 + i;
 			u.ids.push_back(textures[i]);
 			uniforms.push_back(u);
@@ -4093,14 +4093,14 @@ void RendererSceneRenderRD::gi_probe_update(RID p_probe, bool p_update_light_ins
 				Vector<RD::Uniform> uniforms;
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+					u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 					u.binding = 1;
 					u.ids.push_back(storage->gi_probe_get_octree_buffer(gi_probe->probe));
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+					u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 					u.binding = 2;
 					u.ids.push_back(storage->gi_probe_get_data_buffer(gi_probe->probe));
 					uniforms.push_back(u);
@@ -4108,21 +4108,21 @@ void RendererSceneRenderRD::gi_probe_update(RID p_probe, bool p_update_light_ins
 
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+					u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 					u.binding = 4;
 					u.ids.push_back(gi_probe->write_buffer);
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_TEXTURE;
+					u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 					u.binding = 9;
 					u.ids.push_back(storage->gi_probe_get_sdf_texture(gi_probe->probe));
 					uniforms.push_back(u);
 				}
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_SAMPLER;
+					u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 					u.binding = 10;
 					u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 					uniforms.push_back(u);
@@ -4133,7 +4133,7 @@ void RendererSceneRenderRD::gi_probe_update(RID p_probe, bool p_update_light_ins
 					if (i == 0) {
 						{
 							RD::Uniform u;
-							u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+							u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 							u.binding = 3;
 							u.ids.push_back(gi_probe_lights_uniform);
 							copy_uniforms.push_back(u);
@@ -4145,7 +4145,7 @@ void RendererSceneRenderRD::gi_probe_update(RID p_probe, bool p_update_light_ins
 
 						{
 							RD::Uniform u;
-							u.type = RD::UNIFORM_TYPE_TEXTURE;
+							u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 							u.binding = 5;
 							u.ids.push_back(gi_probe->texture);
 							copy_uniforms.push_back(u);
@@ -4158,7 +4158,7 @@ void RendererSceneRenderRD::gi_probe_update(RID p_probe, bool p_update_light_ins
 
 				{
 					RD::Uniform u;
-					u.type = RD::UNIFORM_TYPE_IMAGE;
+					u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 					u.binding = 5;
 					u.ids.push_back(mipmap.texture);
 					uniforms.push_back(u);
@@ -4232,7 +4232,7 @@ void RendererSceneRenderRD::gi_probe_update(RID p_probe, bool p_update_light_ins
 							Vector<RD::Uniform> uniforms;
 							{
 								RD::Uniform u;
-								u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+								u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 								u.binding = 3;
 								u.ids.push_back(gi_probe_lights_uniform);
 								uniforms.push_back(u);
@@ -4240,56 +4240,56 @@ void RendererSceneRenderRD::gi_probe_update(RID p_probe, bool p_update_light_ins
 
 							{
 								RD::Uniform u;
-								u.type = RD::UNIFORM_TYPE_IMAGE;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 								u.binding = 5;
 								u.ids.push_back(dmap.albedo);
 								uniforms.push_back(u);
 							}
 							{
 								RD::Uniform u;
-								u.type = RD::UNIFORM_TYPE_IMAGE;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 								u.binding = 6;
 								u.ids.push_back(dmap.normal);
 								uniforms.push_back(u);
 							}
 							{
 								RD::Uniform u;
-								u.type = RD::UNIFORM_TYPE_IMAGE;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 								u.binding = 7;
 								u.ids.push_back(dmap.orm);
 								uniforms.push_back(u);
 							}
 							{
 								RD::Uniform u;
-								u.type = RD::UNIFORM_TYPE_TEXTURE;
+								u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 								u.binding = 8;
 								u.ids.push_back(dmap.fb_depth);
 								uniforms.push_back(u);
 							}
 							{
 								RD::Uniform u;
-								u.type = RD::UNIFORM_TYPE_TEXTURE;
+								u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 								u.binding = 9;
 								u.ids.push_back(storage->gi_probe_get_sdf_texture(gi_probe->probe));
 								uniforms.push_back(u);
 							}
 							{
 								RD::Uniform u;
-								u.type = RD::UNIFORM_TYPE_SAMPLER;
+								u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 								u.binding = 10;
 								u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 								uniforms.push_back(u);
 							}
 							{
 								RD::Uniform u;
-								u.type = RD::UNIFORM_TYPE_IMAGE;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 								u.binding = 11;
 								u.ids.push_back(dmap.texture);
 								uniforms.push_back(u);
 							}
 							{
 								RD::Uniform u;
-								u.type = RD::UNIFORM_TYPE_IMAGE;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 								u.binding = 12;
 								u.ids.push_back(dmap.depth);
 								uniforms.push_back(u);
@@ -4305,14 +4305,14 @@ void RendererSceneRenderRD::gi_probe_update(RID p_probe, bool p_update_light_ins
 
 						{
 							RD::Uniform u;
-							u.type = RD::UNIFORM_TYPE_IMAGE;
+							u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 							u.binding = 5;
 							u.ids.push_back(gi_probe->dynamic_maps[gi_probe->dynamic_maps.size() - 1].texture);
 							uniforms.push_back(u);
 						}
 						{
 							RD::Uniform u;
-							u.type = RD::UNIFORM_TYPE_IMAGE;
+							u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 							u.binding = 6;
 							u.ids.push_back(gi_probe->dynamic_maps[gi_probe->dynamic_maps.size() - 1].depth);
 							uniforms.push_back(u);
@@ -4321,14 +4321,14 @@ void RendererSceneRenderRD::gi_probe_update(RID p_probe, bool p_update_light_ins
 						if (write) {
 							{
 								RD::Uniform u;
-								u.type = RD::UNIFORM_TYPE_IMAGE;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 								u.binding = 7;
 								u.ids.push_back(dmap.texture);
 								uniforms.push_back(u);
 							}
 							{
 								RD::Uniform u;
-								u.type = RD::UNIFORM_TYPE_IMAGE;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 								u.binding = 8;
 								u.ids.push_back(dmap.depth);
 								uniforms.push_back(u);
@@ -4337,14 +4337,14 @@ void RendererSceneRenderRD::gi_probe_update(RID p_probe, bool p_update_light_ins
 
 						{
 							RD::Uniform u;
-							u.type = RD::UNIFORM_TYPE_TEXTURE;
+							u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 							u.binding = 9;
 							u.ids.push_back(storage->gi_probe_get_sdf_texture(gi_probe->probe));
 							uniforms.push_back(u);
 						}
 						{
 							RD::Uniform u;
-							u.type = RD::UNIFORM_TYPE_SAMPLER;
+							u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 							u.binding = 10;
 							u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 							uniforms.push_back(u);
@@ -4353,7 +4353,7 @@ void RendererSceneRenderRD::gi_probe_update(RID p_probe, bool p_update_light_ins
 						if (plot) {
 							{
 								RD::Uniform u;
-								u.type = RD::UNIFORM_TYPE_IMAGE;
+								u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 								u.binding = 11;
 								u.ids.push_back(gi_probe->mipmaps[dmap.mipmap].texture);
 								uniforms.push_back(u);
@@ -4764,21 +4764,21 @@ void RendererSceneRenderRD::_debug_giprobe(RID p_gi_probe, RD::DrawListID p_draw
 	Vector<RD::Uniform> uniforms;
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 		u.binding = 1;
 		u.ids.push_back(storage->gi_probe_get_data_buffer(gi_probe->probe));
 		uniforms.push_back(u);
 	}
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_TEXTURE;
+		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		u.binding = 2;
 		u.ids.push_back(gi_probe->texture);
 		uniforms.push_back(u);
 	}
 	{
 		RD::Uniform u;
-		u.type = RD::UNIFORM_TYPE_SAMPLER;
+		u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 		u.binding = 3;
 		u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 		uniforms.push_back(u);
@@ -4837,28 +4837,28 @@ void RendererSceneRenderRD::_debug_sdfgi_probes(RID p_render_buffers, RD::DrawLi
 		{
 			RD::Uniform u;
 			u.binding = 1;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.ids.push_back(rb->sdfgi->cascades_ubo);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 2;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.ids.push_back(rb->sdfgi->lightprobe_texture);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 3;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 4;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.ids.push_back(rb->sdfgi->occlusion_texture);
 			uniforms.push_back(u);
 		}
@@ -5444,7 +5444,7 @@ void RendererSceneRenderRD::_sdfgi_debug_draw(RID p_render_buffers, const Camera
 		{
 			RD::Uniform u;
 			u.binding = 1;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			for (uint32_t i = 0; i < SDFGI::MAX_CASCADES; i++) {
 				if (i < rb->sdfgi->cascades.size()) {
 					u.ids.push_back(rb->sdfgi->cascades[i].sdf_tex);
@@ -5457,7 +5457,7 @@ void RendererSceneRenderRD::_sdfgi_debug_draw(RID p_render_buffers, const Camera
 		{
 			RD::Uniform u;
 			u.binding = 2;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			for (uint32_t i = 0; i < SDFGI::MAX_CASCADES; i++) {
 				if (i < rb->sdfgi->cascades.size()) {
 					u.ids.push_back(rb->sdfgi->cascades[i].light_tex);
@@ -5470,7 +5470,7 @@ void RendererSceneRenderRD::_sdfgi_debug_draw(RID p_render_buffers, const Camera
 		{
 			RD::Uniform u;
 			u.binding = 3;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			for (uint32_t i = 0; i < SDFGI::MAX_CASCADES; i++) {
 				if (i < rb->sdfgi->cascades.size()) {
 					u.ids.push_back(rb->sdfgi->cascades[i].light_aniso_0_tex);
@@ -5483,7 +5483,7 @@ void RendererSceneRenderRD::_sdfgi_debug_draw(RID p_render_buffers, const Camera
 		{
 			RD::Uniform u;
 			u.binding = 4;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			for (uint32_t i = 0; i < SDFGI::MAX_CASCADES; i++) {
 				if (i < rb->sdfgi->cascades.size()) {
 					u.ids.push_back(rb->sdfgi->cascades[i].light_aniso_1_tex);
@@ -5496,35 +5496,35 @@ void RendererSceneRenderRD::_sdfgi_debug_draw(RID p_render_buffers, const Camera
 		{
 			RD::Uniform u;
 			u.binding = 5;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.ids.push_back(rb->sdfgi->occlusion_texture);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 8;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 9;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.ids.push_back(rb->sdfgi->cascades_ubo);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 10;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.ids.push_back(rb->texture);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.binding = 11;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.ids.push_back(rb->sdfgi->lightprobe_texture);
 			uniforms.push_back(u);
 		}
@@ -6557,7 +6557,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 		{
 			RD::Uniform u;
 			u.binding = 0;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.ids.push_back(rb->volumetric_fog->fog_map);
 			uniforms.push_back(u);
 		}
@@ -6730,7 +6730,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 1;
 			if (shadow_atlas == nullptr || shadow_atlas->shrink_stages.size() == 0) {
 				u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_BLACK));
@@ -6743,7 +6743,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 2;
 			if (directional_shadow.shrink_stages.size() == 0) {
 				u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_BLACK));
@@ -6755,7 +6755,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 3;
 			u.ids.push_back(get_positional_light_buffer());
 			uniforms.push_back(u);
@@ -6763,7 +6763,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.binding = 4;
 			u.ids.push_back(get_directional_light_buffer());
 			uniforms.push_back(u);
@@ -6771,7 +6771,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 5;
 			u.ids.push_back(get_cluster_builder_texture());
 			uniforms.push_back(u);
@@ -6779,7 +6779,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 6;
 			u.ids.push_back(get_cluster_builder_indices_buffer());
 			uniforms.push_back(u);
@@ -6787,7 +6787,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.binding = 7;
 			u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 			uniforms.push_back(u);
@@ -6795,7 +6795,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.binding = 8;
 			u.ids.push_back(rb->volumetric_fog->light_density_map);
 			uniforms.push_back(u);
@@ -6803,7 +6803,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.binding = 9;
 			u.ids.push_back(rb->volumetric_fog->fog_map);
 			uniforms.push_back(u);
@@ -6811,7 +6811,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.binding = 10;
 			u.ids.push_back(shadow_sampler);
 			uniforms.push_back(u);
@@ -6819,7 +6819,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.binding = 11;
 			u.ids.push_back(render_buffers_get_gi_probe_buffer(p_render_buffers));
 			uniforms.push_back(u);
@@ -6827,7 +6827,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 12;
 			for (int i = 0; i < RenderBuffers::MAX_GIPROBES; i++) {
 				u.ids.push_back(rb->giprobe_textures[i]);
@@ -6836,7 +6836,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.binding = 13;
 			u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 			uniforms.push_back(u);
@@ -6857,7 +6857,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 				u.binding = 0;
 				u.ids.push_back(gi.sdfgi_ubo);
 				uniforms.push_back(u);
@@ -6865,7 +6865,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 1;
 				u.ids.push_back(rb->sdfgi->ambient_texture);
 				uniforms.push_back(u);
@@ -6873,7 +6873,7 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 2;
 				u.ids.push_back(rb->sdfgi->occlusion_texture);
 				uniforms.push_back(u);
@@ -8115,7 +8115,7 @@ RendererSceneRenderRD::RendererSceneRenderRD(RendererStorageRD *p_storage) {
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.binding = 0;
 			u.ids.resize(12);
 			RID *ids_ptr = u.ids.ptrw();
@@ -8136,7 +8136,7 @@ RendererSceneRenderRD::RendererSceneRenderRD(RendererStorageRD *p_storage) {
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 1;
 			u.ids.push_back(storage->global_variables_get_storage_buffer());
 			uniforms.push_back(u);
@@ -8145,7 +8145,7 @@ RendererSceneRenderRD::RendererSceneRenderRD(RendererStorageRD *p_storage) {
 		{
 			RD::Uniform u;
 			u.binding = 2;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.ids.push_back(sky_scene_state.uniform_buffer);
 			uniforms.push_back(u);
 		}
@@ -8153,7 +8153,7 @@ RendererSceneRenderRD::RendererSceneRenderRD(RendererStorageRD *p_storage) {
 		{
 			RD::Uniform u;
 			u.binding = 3;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.ids.push_back(sky_scene_state.directional_light_buffer);
 			uniforms.push_back(u);
 		}
@@ -8166,7 +8166,7 @@ RendererSceneRenderRD::RendererSceneRenderRD(RendererStorageRD *p_storage) {
 		{
 			RD::Uniform u;
 			u.binding = 0;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID vfog = storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_3D_WHITE);
 			u.ids.push_back(vfog);
 			uniforms.push_back(u);
@@ -8185,21 +8185,21 @@ RendererSceneRenderRD::RendererSceneRenderRD(RendererStorageRD *p_storage) {
 		Vector<RD::Uniform> uniforms;
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 0;
 			u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 1;
 			u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_WHITE));
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 2;
 			u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_WHITE));
 			uniforms.push_back(u);
@@ -8263,14 +8263,14 @@ RendererSceneRenderRD::RendererSceneRenderRD(RendererStorageRD *p_storage) {
 
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 0;
 				u.ids.push_back(storage->texture_rd_get_default(RendererStorageRD::DEFAULT_RD_TEXTURE_CUBEMAP_WHITE));
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_SAMPLER;
+				u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 				u.binding = 1;
 				u.ids.push_back(storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 				uniforms.push_back(u);

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -567,7 +567,7 @@ RID RendererStorageRD::texture_2d_create(const Ref<Image> &p_image) {
 		rd_format.depth = 1;
 		rd_format.array_layers = 1;
 		rd_format.mipmaps = texture.mipmaps;
-		rd_format.type = texture.rd_type;
+		rd_format.texture_type = texture.rd_type;
 		rd_format.samples = RD::TEXTURE_SAMPLES_1;
 		rd_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
 		if (texture.rd_format_srgb != RD::DATA_FORMAT_MAX) {
@@ -675,7 +675,7 @@ RID RendererStorageRD::texture_2d_layered_create(const Vector<Ref<Image>> &p_lay
 		rd_format.depth = 1;
 		rd_format.array_layers = texture.layers;
 		rd_format.mipmaps = texture.mipmaps;
-		rd_format.type = texture.rd_type;
+		rd_format.texture_type = texture.rd_type;
 		rd_format.samples = RD::TEXTURE_SAMPLES_1;
 		rd_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
 		if (texture.rd_format_srgb != RD::DATA_FORMAT_MAX) {
@@ -793,7 +793,7 @@ RID RendererStorageRD::texture_3d_create(Image::Format p_format, int p_width, in
 		rd_format.depth = texture.depth;
 		rd_format.array_layers = 1;
 		rd_format.mipmaps = texture.mipmaps;
-		rd_format.type = texture.rd_type;
+		rd_format.texture_type = texture.rd_type;
 		rd_format.samples = RD::TEXTURE_SAMPLES_1;
 		rd_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
 		if (texture.rd_format_srgb != RD::DATA_FORMAT_MAX) {
@@ -4679,7 +4679,7 @@ RID RendererStorageRD::particles_collision_get_heightfield_framebuffer(RID p_par
 		tf.format = RD::DATA_FORMAT_D32_SFLOAT;
 		tf.width = size.x;
 		tf.height = size.y;
-		tf.type = RD::TEXTURE_TYPE_2D;
+		tf.texture_type = RD::TEXTURE_TYPE_2D;
 		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
 
 		particles_collision->heightfield_texture = RD::get_singleton()->texture_create(tf, RD::TextureView());
@@ -5588,7 +5588,7 @@ void RendererStorageRD::gi_probe_allocate(RID p_gi_probe, const Transform &p_to_
 			tf.width = gi_probe->octree_size.x;
 			tf.height = gi_probe->octree_size.y;
 			tf.depth = gi_probe->octree_size.z;
-			tf.type = RD::TEXTURE_TYPE_3D;
+			tf.texture_type = RD::TEXTURE_TYPE_3D;
 			tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
 			Vector<Vector<uint8_t>> s;
 			s.push_back(p_distance_field);
@@ -6122,7 +6122,7 @@ void RendererStorageRD::_update_render_target(RenderTarget *rt) {
 		rd_format.depth = 1;
 		rd_format.array_layers = 1;
 		rd_format.mipmaps = 1;
-		rd_format.type = RD::TEXTURE_TYPE_2D;
+		rd_format.texture_type = RD::TEXTURE_TYPE_2D;
 		rd_format.samples = RD::TEXTURE_SAMPLES_1;
 		rd_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
 		rd_format.shareable_formats.push_back(rt->color_format);
@@ -6191,7 +6191,7 @@ void RendererStorageRD::_create_render_target_backbuffer(RenderTarget *rt) {
 	tf.format = rt->color_format;
 	tf.width = rt->size.width;
 	tf.height = rt->size.height;
-	tf.type = RD::TEXTURE_TYPE_2D;
+	tf.texture_type = RD::TEXTURE_TYPE_2D;
 	tf.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
 	tf.mipmaps = mipmaps_required;
 
@@ -6420,7 +6420,7 @@ RID RendererStorageRD::render_target_get_sdf_texture(RID p_render_target) {
 		tformat.width = 4;
 		tformat.height = 4;
 		tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT;
-		tformat.type = RD::TEXTURE_TYPE_2D;
+		tformat.texture_type = RD::TEXTURE_TYPE_2D;
 
 		Vector<uint8_t> pv;
 		pv.resize(16 * 4);
@@ -6447,7 +6447,7 @@ void RendererStorageRD::_render_target_allocate_sdf(RenderTarget *rt) {
 	tformat.width = size.width;
 	tformat.height = size.height;
 	tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
-	tformat.type = RD::TEXTURE_TYPE_2D;
+	tformat.texture_type = RD::TEXTURE_TYPE_2D;
 
 	rt->sdf_buffer_write = RD::get_singleton()->texture_create(tformat, RD::TextureView());
 
@@ -6983,7 +6983,7 @@ void RendererStorageRD::_update_decal_atlas() {
 	tformat.width = decal_atlas.size.width;
 	tformat.height = decal_atlas.size.height;
 	tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
-	tformat.type = RD::TEXTURE_TYPE_2D;
+	tformat.texture_type = RD::TEXTURE_TYPE_2D;
 	tformat.mipmaps = decal_atlas.mipmaps;
 	tformat.shareable_formats.push_back(RD::DATA_FORMAT_R8G8B8A8_UNORM);
 	tformat.shareable_formats.push_back(RD::DATA_FORMAT_R8G8B8A8_SRGB);
@@ -7946,7 +7946,7 @@ RendererStorageRD::RendererStorageRD() {
 		tformat.width = 4;
 		tformat.height = 4;
 		tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
-		tformat.type = RD::TEXTURE_TYPE_2D;
+		tformat.texture_type = RD::TEXTURE_TYPE_2D;
 
 		Vector<uint8_t> pv;
 		pv.resize(16 * 4);
@@ -8038,7 +8038,7 @@ RendererStorageRD::RendererStorageRD() {
 		tformat.height = 4;
 		tformat.array_layers = 6;
 		tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
-		tformat.type = RD::TEXTURE_TYPE_CUBE_ARRAY;
+		tformat.texture_type = RD::TEXTURE_TYPE_CUBE_ARRAY;
 
 		Vector<uint8_t> pv;
 		pv.resize(16 * 4);
@@ -8066,7 +8066,7 @@ RendererStorageRD::RendererStorageRD() {
 		tformat.height = 4;
 		tformat.array_layers = 6;
 		tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
-		tformat.type = RD::TEXTURE_TYPE_CUBE;
+		tformat.texture_type = RD::TEXTURE_TYPE_CUBE;
 
 		Vector<uint8_t> pv;
 		pv.resize(16 * 4);
@@ -8094,7 +8094,7 @@ RendererStorageRD::RendererStorageRD() {
 		tformat.height = 4;
 		tformat.array_layers = 6;
 		tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
-		tformat.type = RD::TEXTURE_TYPE_CUBE;
+		tformat.texture_type = RD::TEXTURE_TYPE_CUBE;
 
 		Vector<uint8_t> pv;
 		pv.resize(16 * 4);
@@ -8122,7 +8122,7 @@ RendererStorageRD::RendererStorageRD() {
 		tformat.height = 4;
 		tformat.depth = 4;
 		tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
-		tformat.type = RD::TEXTURE_TYPE_3D;
+		tformat.texture_type = RD::TEXTURE_TYPE_3D;
 
 		Vector<uint8_t> pv;
 		pv.resize(64 * 4);
@@ -8148,7 +8148,7 @@ RendererStorageRD::RendererStorageRD() {
 		tformat.height = 4;
 		tformat.array_layers = 1;
 		tformat.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
-		tformat.type = RD::TEXTURE_TYPE_2D_ARRAY;
+		tformat.texture_type = RD::TEXTURE_TYPE_2D_ARRAY;
 
 		Vector<uint8_t> pv;
 		pv.resize(16 * 4);

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -1298,7 +1298,7 @@ bool RendererStorageRD::canvas_texture_get_uniform_set(RID p_texture, RS::Canvas
 		Vector<RD::Uniform> uniforms;
 		{ //diffuse
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 0;
 
 			t = texture_owner.getornull(ct->diffuse);
@@ -1313,7 +1313,7 @@ bool RendererStorageRD::canvas_texture_get_uniform_set(RID p_texture, RS::Canvas
 		}
 		{ //normal
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 1;
 
 			t = texture_owner.getornull(ct->normalmap);
@@ -1328,7 +1328,7 @@ bool RendererStorageRD::canvas_texture_get_uniform_set(RID p_texture, RS::Canvas
 		}
 		{ //specular
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 2;
 
 			t = texture_owner.getornull(ct->specular);
@@ -1343,7 +1343,7 @@ bool RendererStorageRD::canvas_texture_get_uniform_set(RID p_texture, RS::Canvas
 		}
 		{ //sampler
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.binding = 3;
 			u.ids.push_back(sampler_rd_get_default(filter, repeat));
 			uniforms.push_back(u);
@@ -3591,14 +3591,14 @@ void RendererStorageRD::particles_set_amount(RID p_particles, int p_amount) {
 
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 				u.binding = 1;
 				u.ids.push_back(particles->particle_buffer);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 				u.binding = 2;
 				u.ids.push_back(particles->particle_instance_buffer);
 				uniforms.push_back(u);
@@ -3901,14 +3901,14 @@ void RendererStorageRD::_particles_process(Particles *p_particles, float p_delta
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 0;
 			u.ids.push_back(p_particles->frame_params_buffer);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 1;
 			u.ids.push_back(p_particles->particle_buffer);
 			uniforms.push_back(u);
@@ -3916,7 +3916,7 @@ void RendererStorageRD::_particles_process(Particles *p_particles, float p_delta
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 2;
 			if (p_particles->emission_storage_buffer.is_valid()) {
 				u.ids.push_back(p_particles->emission_storage_buffer);
@@ -3927,7 +3927,7 @@ void RendererStorageRD::_particles_process(Particles *p_particles, float p_delta
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 3;
 			Particles *sub_emitter = particles_owner.getornull(p_particles->sub_emitter);
 			if (sub_emitter) {
@@ -4134,7 +4134,7 @@ void RendererStorageRD::_particles_process(Particles *p_particles, float p_delta
 
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 0;
 				for (uint32_t i = 0; i < ParticlesFrameParams::MAX_3D_TEXTURES; i++) {
 					RID rd_tex;
@@ -4154,7 +4154,7 @@ void RendererStorageRD::_particles_process(Particles *p_particles, float p_delta
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_TEXTURE;
+				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 1;
 				if (collision_heightmap_texture.is_valid()) {
 					u.ids.push_back(collision_heightmap_texture);
@@ -4255,7 +4255,7 @@ void RendererStorageRD::particles_set_view_axis(RID p_particles, const Vector3 &
 
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 				u.binding = 0;
 				u.ids.push_back(particles->particles_sort_buffer);
 				uniforms.push_back(u);
@@ -4614,7 +4614,7 @@ void RendererStorageRD::ParticlesMaterialData::update_parameters(const Map<Strin
 	{
 		if (shader_data->ubo_size) {
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_UNIFORM_BUFFER;
 			u.binding = 0;
 			u.ids.push_back(uniform_buffer);
 			uniforms.push_back(u);
@@ -4623,7 +4623,7 @@ void RendererStorageRD::ParticlesMaterialData::update_parameters(const Map<Strin
 		const RID *textures = texture_cache.ptrw();
 		for (uint32_t i = 0; i < tex_uniform_count; i++) {
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_TEXTURE;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 1 + i;
 			u.ids.push_back(textures[i]);
 			uniforms.push_back(u);
@@ -5617,21 +5617,21 @@ void RendererStorageRD::gi_probe_allocate(RID p_gi_probe, const Transform &p_to_
 			Vector<RD::Uniform> uniforms;
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 				u.binding = 1;
 				u.ids.push_back(gi_probe->octree_buffer);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 				u.binding = 2;
 				u.ids.push_back(gi_probe->data_buffer);
 				uniforms.push_back(u);
 			}
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_IMAGE;
+				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 3;
 				u.ids.push_back(shared_tex);
 				uniforms.push_back(u);
@@ -6494,28 +6494,28 @@ void RendererStorageRD::_render_target_allocate_sdf(RenderTarget *rt) {
 		Vector<RD::Uniform> uniforms;
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.binding = 1;
 			u.ids.push_back(rt->sdf_buffer_write);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.binding = 2;
 			u.ids.push_back(rt->sdf_buffer_read);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.binding = 3;
 			u.ids.push_back(rt->sdf_buffer_process[0]);
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_IMAGE;
+			u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 			u.binding = 4;
 			u.ids.push_back(rt->sdf_buffer_process[1]);
 			uniforms.push_back(u);
@@ -8453,7 +8453,7 @@ RendererStorageRD::RendererStorageRD() {
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_SAMPLER;
+			u.uniform_type = RD::UNIFORM_TYPE_SAMPLER;
 			u.binding = 1;
 			u.ids.resize(12);
 			RID *ids_ptr = u.ids.ptrw();
@@ -8474,7 +8474,7 @@ RendererStorageRD::RendererStorageRD() {
 
 		{
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 2;
 			u.ids.push_back(global_variables_get_storage_buffer());
 			uniforms.push_back(u);

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -1463,7 +1463,7 @@ public:
 		if (!multimesh->uniform_set_3d.is_valid()) {
 			Vector<RD::Uniform> uniforms;
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 0;
 			u.ids.push_back(multimesh->buffer);
 			uniforms.push_back(u);
@@ -1511,7 +1511,7 @@ public:
 		if (!skeleton->uniform_set_3d.is_valid()) {
 			Vector<RD::Uniform> uniforms;
 			RD::Uniform u;
-			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 0;
 			u.ids.push_back(skeleton->buffer);
 			uniforms.push_back(u);
@@ -1900,7 +1900,7 @@ public:
 
 			{
 				RD::Uniform u;
-				u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+				u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 				u.binding = 0;
 				u.ids.push_back(particles->particle_instance_buffer);
 				uniforms.push_back(u);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -629,7 +629,7 @@ public:
 	virtual RID texture_buffer_create(uint32_t p_size_elements, DataFormat p_format, const Vector<uint8_t> &p_data = Vector<uint8_t>()) = 0;
 
 	struct Uniform {
-		UniformType type;
+		UniformType uniform_type;
 		int binding; //binding index as specified in shader
 
 		//for single items, provide one ID, for
@@ -640,7 +640,7 @@ public:
 		Vector<RID> ids;
 
 		Uniform() {
-			type = UNIFORM_TYPE_IMAGE;
+			uniform_type = UNIFORM_TYPE_IMAGE;
 			binding = 0;
 		}
 	};

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -392,7 +392,7 @@ public:
 		uint32_t depth;
 		uint32_t array_layers;
 		uint32_t mipmaps;
-		TextureType type;
+		TextureType texture_type;
 		TextureSamples samples;
 		uint32_t usage_bits;
 		Vector<DataFormat> shareable_formats;
@@ -404,7 +404,7 @@ public:
 			depth = 1;
 			array_layers = 1;
 			mipmaps = 1;
-			type = TEXTURE_TYPE_2D;
+			texture_type = TEXTURE_TYPE_2D;
 			samples = TEXTURE_SAMPLES_1;
 			usage_bits = 0;
 		}

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -392,7 +392,7 @@ class RDUniform : public Reference {
 	RD::Uniform base;
 
 public:
-	RD_SETGET(RD::UniformType, type)
+	RD_SETGET(RD::UniformType, uniform_type)
 	RD_SETGET(int32_t, binding)
 
 	void add_id(const RID &p_id) { base.ids.push_back(p_id); }
@@ -415,7 +415,7 @@ protected:
 		}
 	}
 	static void _bind_methods() {
-		RD_BIND(Variant::INT, RDUniform, type);
+		RD_BIND(Variant::INT, RDUniform, uniform_type);
 		RD_BIND(Variant::INT, RDUniform, binding);
 		ClassDB::bind_method(D_METHOD("add_id", "id"), &RDUniform::add_id);
 		ClassDB::bind_method(D_METHOD("clear_ids"), &RDUniform::clear_ids);

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -64,7 +64,7 @@ public:
 	RD_SETGET(uint32_t, depth)
 	RD_SETGET(uint32_t, array_layers)
 	RD_SETGET(uint32_t, mipmaps)
-	RD_SETGET(RD::TextureType, type)
+	RD_SETGET(RD::TextureType, texture_type)
 	RD_SETGET(RD::TextureSamples, samples)
 	RD_SETGET(uint32_t, usage_bits)
 
@@ -79,7 +79,7 @@ protected:
 		RD_BIND(Variant::INT, RDTextureFormat, depth);
 		RD_BIND(Variant::INT, RDTextureFormat, array_layers);
 		RD_BIND(Variant::INT, RDTextureFormat, mipmaps);
-		RD_BIND(Variant::INT, RDTextureFormat, type);
+		RD_BIND(Variant::INT, RDTextureFormat, texture_type);
 		RD_BIND(Variant::INT, RDTextureFormat, samples);
 		RD_BIND(Variant::INT, RDTextureFormat, usage_bits);
 		ClassDB::bind_method(D_METHOD("add_shareable_format", "format"), &RDTextureFormat::add_shareable_format);

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -38,9 +38,9 @@ void XRPositionalTracker::_bind_methods() {
 	BIND_ENUM_CONSTANT(TRACKER_RIGHT_HAND);
 
 	// this class is read only from GDScript, so we only have access to getters..
-	ClassDB::bind_method(D_METHOD("get_type"), &XRPositionalTracker::get_type);
+	ClassDB::bind_method(D_METHOD("get_tracker_type"), &XRPositionalTracker::get_tracker_type);
 	ClassDB::bind_method(D_METHOD("get_tracker_id"), &XRPositionalTracker::get_tracker_id);
-	ClassDB::bind_method(D_METHOD("get_name"), &XRPositionalTracker::get_name);
+	ClassDB::bind_method(D_METHOD("get_tracker_name"), &XRPositionalTracker::get_tracker_name);
 	ClassDB::bind_method(D_METHOD("get_joy_id"), &XRPositionalTracker::get_joy_id);
 	ClassDB::bind_method(D_METHOD("get_tracks_orientation"), &XRPositionalTracker::get_tracks_orientation);
 	ClassDB::bind_method(D_METHOD("get_orientation"), &XRPositionalTracker::get_orientation);
@@ -77,7 +77,7 @@ void XRPositionalTracker::set_type(XRServer::TrackerType p_type) {
 	};
 };
 
-XRServer::TrackerType XRPositionalTracker::get_type() const {
+XRServer::TrackerType XRPositionalTracker::get_tracker_type() const {
 	return type;
 };
 
@@ -85,7 +85,7 @@ void XRPositionalTracker::set_name(const String &p_name) {
 	name = p_name;
 };
 
-StringName XRPositionalTracker::get_name() const {
+StringName XRPositionalTracker::get_tracker_name() const {
 	return name;
 };
 

--- a/servers/xr/xr_positional_tracker.h
+++ b/servers/xr/xr_positional_tracker.h
@@ -72,9 +72,9 @@ protected:
 
 public:
 	void set_type(XRServer::TrackerType p_type);
-	XRServer::TrackerType get_type() const;
+	XRServer::TrackerType get_tracker_type() const;
 	void set_name(const String &p_name);
-	StringName get_name() const;
+	StringName get_tracker_name() const;
 	int get_tracker_id() const;
 	void set_joy_id(int p_joy_id);
 	int get_joy_id() const;

--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -235,7 +235,7 @@ Array XRServer::get_interfaces() const {
 
 bool XRServer::is_tracker_id_in_use_for_type(TrackerType p_tracker_type, int p_tracker_id) const {
 	for (int i = 0; i < trackers.size(); i++) {
-		if (trackers[i]->get_type() == p_tracker_type && trackers[i]->get_tracker_id() == p_tracker_id) {
+		if (trackers[i]->get_tracker_type() == p_tracker_type && trackers[i]->get_tracker_id() == p_tracker_id) {
 			return true;
 		};
 	};
@@ -264,7 +264,7 @@ void XRServer::add_tracker(XRPositionalTracker *p_tracker) {
 	ERR_FAIL_NULL(p_tracker);
 
 	trackers.push_back(p_tracker);
-	emit_signal("tracker_added", p_tracker->get_name(), p_tracker->get_type(), p_tracker->get_tracker_id());
+	emit_signal("tracker_added", p_tracker->get_tracker_name(), p_tracker->get_tracker_type(), p_tracker->get_tracker_id());
 };
 
 void XRServer::remove_tracker(XRPositionalTracker *p_tracker) {
@@ -280,7 +280,7 @@ void XRServer::remove_tracker(XRPositionalTracker *p_tracker) {
 
 	ERR_FAIL_COND(idx == -1);
 
-	emit_signal("tracker_removed", p_tracker->get_name(), p_tracker->get_type(), p_tracker->get_tracker_id());
+	emit_signal("tracker_removed", p_tracker->get_tracker_name(), p_tracker->get_tracker_type(), p_tracker->get_tracker_id());
 	trackers.remove(idx);
 };
 
@@ -298,7 +298,7 @@ XRPositionalTracker *XRServer::find_by_type_and_id(TrackerType p_tracker_type, i
 	ERR_FAIL_COND_V(p_tracker_id == 0, nullptr);
 
 	for (int i = 0; i < trackers.size(); i++) {
-		if (trackers[i]->get_type() == p_tracker_type && trackers[i]->get_tracker_id() == p_tracker_id) {
+		if (trackers[i]->get_tracker_type() == p_tracker_type && trackers[i]->get_tracker_id() == p_tracker_id) {
 			return trackers[i];
 		};
 	};


### PR DESCRIPTION
The entire purpose of this PR is to break compatibility. It benefits the scripting API due to not having members shadow one another, and it increases verbosity. For details, see https://github.com/godotengine/godot/issues/15763#issuecomment-568908661, but this PR does not close that issue since there are still a few other things.

* Rename XR `get_type` and `get_name` to `get_tracker_type` and `get_tracker_name`.

* Rename CPUParticles/CPUParticles2D/ParticlesMaterial `Flags` enum to `ParticleFlags`.

* Rename PathFollow2D `rotate` bool to `rotates`.

* Rebind Mesh/ArrayMesh enums based on where they are used and to not have a duplicate `ArrayType` enum.

* Rename LightOccluder2D `light_mask` to `occluder_light_mask` to avoid masking `light_mask`.

* Rename RD uniform `type` to `uniform_type` (newly exposed in April 2020).

* Rename RD texture `type` to `texture_type` (newly exposed sometime in mid-2020).

* Rename EditorNode3DGizmoPlugin `get_name` to `get_gizmo_name`.

In a nutshell, we should avoid ambiguous words like `name` and `type` and `flags`. For example, with RDUniform `type`, how do you know that "type" refers to a variable of type enum `RenderingDevice.UniformType`? Maybe it could be the type of the variable in Variant `TYPE` (so `Variant::INT`)? Maybe it could be some way to express the struct type `RDUniform`? What if you just have `var u` in GDScript and then `u.type` with no mention of "Uniform"? We should try to write things to be self-evident and not confusing. Also, `type` in a getter is `get_type`, which in C# would be `GetType()`, which conflicts with C#'s `GetType()`.