### PR TITLE
Renamed test_width/height settings to window_width/height

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -441,20 +441,20 @@
 		<member name="display/window/size/fullscreen" type="bool" setter="" getter="" default="false">
 			Sets the window to full screen when it starts.
 		</member>
-		<member name="display/window/size/height" type="int" setter="" getter="" default="600">
-			Sets the game's main viewport height. On desktop platforms, this is the default window size. Stretch mode settings also use this as a reference when enabled.
-		</member>
 		<member name="display/window/size/resizable" type="bool" setter="" getter="" default="true">
 			Allows the window to be resizable by default.
 		</member>
-		<member name="display/window/size/test_height" type="int" setter="" getter="" default="0">
-			If greater than zero, overrides the window height when running the game. Useful for testing stretch modes.
+		<member name="display/window/size/viewport_height" type="int" setter="" getter="" default="600">
+			Sets the game's main viewport height. On desktop platforms, this is the default window size. Stretch mode settings also use this as a reference when enabled.
 		</member>
-		<member name="display/window/size/test_width" type="int" setter="" getter="" default="0">
-			If greater than zero, overrides the window width when running the game. Useful for testing stretch modes.
-		</member>
-		<member name="display/window/size/width" type="int" setter="" getter="" default="1024">
+		<member name="display/window/size/viewport_width" type="int" setter="" getter="" default="1024">
 			Sets the game's main viewport width. On desktop platforms, this is the default window size. Stretch mode settings also use this as a reference when enabled.
+		</member>
+		<member name="display/window/size/window_height" type="int" setter="" getter="" default="0">
+			If greater than zero, overrides the window height and [member display/window/size/viewport_height] of running game. Useful for testing stretch modes.
+		</member>
+		<member name="display/window/size/window_width" type="int" setter="" getter="" default="0">
+			If greater than zero, overrides the window width and [member display/window/size/viewport_width] of running game. Useful for testing stretch modes.
 		</member>
 		<member name="display/window/vsync/use_vsync" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], enables vertical synchronization. This eliminates tearing that may appear in moving scenes, at the cost of higher input latency and stuttering at lower framerates. If [code]false[/code], vertical synchronization will be disabled, however, many platforms will enforce it regardless (such as mobile platforms and HTML5).

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -344,7 +344,7 @@ void EditorNode::_notification(int p_what) {
 
 			editor_selection->update();
 
-			//scene_root->set_size_override(true, Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height")));
+			//scene_root->set_size_override(true, Size2(ProjectSettings::get_singleton()->get("display/window/size/viewport_width"), ProjectSettings::get_singleton()->get("display/window/size/viewport_height")));
 
 			{ //TODO should only happen on settings changed
 				int current_filter = GLOBAL_GET("rendering/canvas_textures/default_texture_filter");

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -99,12 +99,12 @@ Error EditorRun::run(const String &p_scene, const String &p_custom_args, const L
 	screen_rect.size = DisplayServer::get_singleton()->screen_get_size(screen);
 
 	Size2 desired_size;
-	desired_size.x = ProjectSettings::get_singleton()->get("display/window/size/width");
-	desired_size.y = ProjectSettings::get_singleton()->get("display/window/size/height");
+	desired_size.x = ProjectSettings::get_singleton()->get("display/window/size/viewport_width");
+	desired_size.y = ProjectSettings::get_singleton()->get("display/window/size/viewport_height");
 
 	Size2 test_size;
-	test_size.x = ProjectSettings::get_singleton()->get("display/window/size/test_width");
-	test_size.y = ProjectSettings::get_singleton()->get("display/window/size/test_height");
+	test_size.x = ProjectSettings::get_singleton()->get("display/window/size/window_width");
+	test_size.y = ProjectSettings::get_singleton()->get("display/window/size/window_height");
 	if (test_size.x > 0 && test_size.y > 0) {
 
 		desired_size = test_size;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3445,7 +3445,7 @@ void CanvasItemEditor::_draw_axis() {
 
 		Color area_axis_color = EditorSettings::get_singleton()->get("editors/2d/viewport_border_color");
 
-		Size2 screen_size = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+		Size2 screen_size = Size2(ProjectSettings::get_singleton()->get("display/window/size/viewport_width"), ProjectSettings::get_singleton()->get("display/window/size/viewport_height"));
 
 		Vector2 screen_endpoints[4] = {
 			transform.xform(Vector2(0, 0)),
@@ -4098,7 +4098,7 @@ void CanvasItemEditor::_update_scrollbars() {
 	Size2 vmin = v_scroll->get_minimum_size();
 
 	// Get the visible frame.
-	Size2 screen_rect = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+	Size2 screen_rect = Size2(ProjectSettings::get_singleton()->get("display/window/size/viewport_width"), ProjectSettings::get_singleton()->get("display/window/size/viewport_height"));
 	Rect2 local_rect = Rect2(Point2(), viewport->get_size() - Size2(vmin.width, hmin.height));
 
 	_queue_update_bone_list();

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2652,7 +2652,7 @@ void Node3DEditorViewport::_draw() {
 	}
 	if (previewing) {
 
-		Size2 ss = Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+		Size2 ss = Size2(ProjectSettings::get_singleton()->get("display/window/size/viewport_width"), ProjectSettings::get_singleton()->get("display/window/size/viewport_height"));
 		float aspect = ss.aspect();
 		Size2 s = get_size();
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1006,32 +1006,32 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// Assigning here even though it's GLES2-specific, to be sure that it appears in docs
 	GLOBAL_DEF("rendering/quality/2d/gles2_use_nvidia_rect_flicker_workaround", false);
 
-	GLOBAL_DEF("display/window/size/width", 1024);
-	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/width", PropertyInfo(Variant::INT, "display/window/size/width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
-	GLOBAL_DEF("display/window/size/height", 600);
-	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/height", PropertyInfo(Variant::INT, "display/window/size/height", PROPERTY_HINT_RANGE, "0,4320,or_greater")); // 8K resolution
+	GLOBAL_DEF("display/window/size/viewport_width", 1024);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/viewport_width", PropertyInfo(Variant::INT, "display/window/size/viewport_width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
+	GLOBAL_DEF("display/window/size/viewport_height", 600);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/viewport_height", PropertyInfo(Variant::INT, "display/window/size/viewport_height", PROPERTY_HINT_RANGE, "0,4320,or_greater")); // 8K resolution
 	GLOBAL_DEF("display/window/size/resizable", true);
 	GLOBAL_DEF("display/window/size/borderless", false);
 	GLOBAL_DEF("display/window/size/fullscreen", false);
 	GLOBAL_DEF("display/window/size/always_on_top", false);
-	GLOBAL_DEF("display/window/size/test_width", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_width", PropertyInfo(Variant::INT, "display/window/size/test_width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
-	GLOBAL_DEF("display/window/size/test_height", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_height", PropertyInfo(Variant::INT, "display/window/size/test_height", PROPERTY_HINT_RANGE, "0,4320,or_greater")); // 8K resolution
+	GLOBAL_DEF("display/window/size/window_width", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/window_width", PropertyInfo(Variant::INT, "display/window/size/window_width", PROPERTY_HINT_RANGE, "0,7680,or_greater")); // 8K resolution
+	GLOBAL_DEF("display/window/size/window_height", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/window_height", PropertyInfo(Variant::INT, "display/window/size/window_height", PROPERTY_HINT_RANGE, "0,4320,or_greater")); // 8K resolution
 
 	if (use_custom_res) {
 
 		if (!force_res) {
-			window_size.width = GLOBAL_GET("display/window/size/width");
-			window_size.height = GLOBAL_GET("display/window/size/height");
+			window_size.width = GLOBAL_GET("display/window/size/viewport_width");
+			window_size.height = GLOBAL_GET("display/window/size/viewport_height");
 
-			if (globals->has_setting("display/window/size/test_width") && globals->has_setting("display/window/size/test_height")) {
+			if (globals->has_setting("display/window/size/window_width") && globals->has_setting("display/window/size/window_height")) {
 
-				int tw = globals->get("display/window/size/test_width");
+				int tw = globals->get("display/window/size/window_width");
 				if (tw > 0) {
 					window_size.width = tw;
 				}
-				int th = globals->get("display/window/size/test_height");
+				int th = globals->get("display/window/size/window_height");
 				if (th > 0) {
 					window_size.height = th;
 				}
@@ -1834,7 +1834,7 @@ bool Main::start() {
 
 			String stretch_mode = GLOBAL_DEF("display/window/stretch/mode", "disabled");
 			String stretch_aspect = GLOBAL_DEF("display/window/stretch/aspect", "ignore");
-			Size2i stretch_size = Size2(GLOBAL_DEF("display/window/size/width", 0), GLOBAL_DEF("display/window/size/height", 0));
+			Size2i stretch_size = Size2(GLOBAL_DEF("display/window/size/viewport_width", 0), GLOBAL_DEF("display/window/size/viewport_height", 0));
 
 			Window::ContentScaleMode cs_sm = Window::CONTENT_SCALE_MODE_DISABLED;
 			if (stretch_mode == "objects")


### PR DESCRIPTION
One of the planned renames from:
https://github.com/godotengine/godot/issues/16863#issuecomment-412308210
`width/height` is also renamed to `viewport_width/height`