### PR TITLE
Resize bit field to be able to store all available enum values inside.

### DIFF
--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -286,7 +286,7 @@ private:
 			uint64_t distance_fade : 2;
 			uint64_t emission_op : 1;
 			uint64_t texture_filter : 3;
-			uint64_t transparency : 2;
+			uint64_t transparency : 3;
 			uint64_t shading_mode : 2;
 			uint64_t roughness_channel : 3;
 		};

--- a/scene/resources/particles_material.h
+++ b/scene/resources/particles_material.h
@@ -79,7 +79,7 @@ private:
 			uint32_t texture_mask : 16;
 			uint32_t texture_color : 1;
 			uint32_t flags : 4;
-			uint32_t emission_shape : 2;
+			uint32_t emission_shape : 3;
 			uint32_t trail_size_texture : 1;
 			uint32_t trail_color_texture : 1;
 			uint32_t invalid_key : 1;


### PR DESCRIPTION
mk.transparency can only store 4 values(2 bit) but have 5 possible values (with TRANSPARENCY_MAX)

mk.emission_shape can store 4 values(also 2 bit) but can have 6 possible values