### PR TITLE
Fixes crash when saving scene

### DIFF
--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
@@ -3208,9 +3208,9 @@ Vector<float> RasterizerStorageRD::multimesh_get_buffer(RID p_multimesh) const {
 
 		Vector<uint8_t> buffer = RD::get_singleton()->buffer_get_data(multimesh->buffer);
 		Vector<float> ret;
-		ret.resize(multimesh->instances);
+		ret.resize(multimesh->instances * multimesh->stride_cache);
 		{
-			float *w = multimesh->data_cache.ptrw();
+			float *w = ret.ptrw();
 			const uint8_t *r = buffer.ptr();
 			copymem(w, r, buffer.size());
 		}


### PR DESCRIPTION
This fixes #36253

* Data was written to `multimesh->data_cache` instead of the return value `ret`.
* The size of `ret` is adjusted according to https://github.com/godotengine/godot/blob/851cb429631168369d2a51812de763b658795fbf/servers/visual/rasterizer_rd/rasterizer_storage_rd.cpp#L2442