### PR TITLE
Custom Skeleton3DEditorPlugin

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3199,7 +3199,7 @@ void AnimationTrackEditor::update_keying() {
 	}
 
 	keying = keying_enabled;
-	//_update_menu();
+
 	emit_signal("keying_changed");
 }
 

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -30,12 +30,384 @@
 
 #include "skeleton_3d_editor_plugin.h"
 
+#include "core/io/resource_saver.h"
+#include "editor/editor_file_dialog.h"
+#include "editor/editor_properties.h"
+#include "editor/editor_scale.h"
+#include "editor/plugins/animation_player_editor_plugin.h"
 #include "node_3d_editor_plugin.h"
 #include "scene/3d/collision_shape_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/physics_body_3d.h"
 #include "scene/3d/physics_joint_3d.h"
 #include "scene/resources/capsule_shape_3d.h"
 #include "scene/resources/sphere_shape_3d.h"
+
+void BoneTransformEditor::create_editors() {
+	const Color section_color = get_theme_color("prop_subsection", "Editor");
+
+	section = memnew(EditorInspectorSection);
+	section->setup("trf_properties", label, this, section_color, true);
+	add_child(section);
+
+	key_button = memnew(Button);
+	key_button->set_text(TTR("Key Transform"));
+	key_button->set_visible(keyable);
+	key_button->set_icon(get_theme_icon("Key", "EditorIcons"));
+	key_button->set_flat(true);
+	section->get_vbox()->add_child(key_button);
+
+	enabled_checkbox = memnew(CheckBox(TTR("Pose Enabled")));
+	enabled_checkbox->set_flat(true);
+	enabled_checkbox->set_visible(toggle_enabled);
+	section->get_vbox()->add_child(enabled_checkbox);
+
+	Label *l1 = memnew(Label(TTR("Translation")));
+	section->get_vbox()->add_child(l1);
+
+	translation_grid = memnew(GridContainer());
+	translation_grid->set_columns(TRANSLATION_COMPONENTS);
+	section->get_vbox()->add_child(translation_grid);
+
+	Label *l2 = memnew(Label(TTR("Rotation Degrees")));
+	section->get_vbox()->add_child(l2);
+
+	rotation_grid = memnew(GridContainer());
+	rotation_grid->set_columns(ROTATION_DEGREES_COMPONENTS);
+	section->get_vbox()->add_child(rotation_grid);
+
+	Label *l3 = memnew(Label(TTR("Scale")));
+	section->get_vbox()->add_child(l3);
+
+	scale_grid = memnew(GridContainer());
+	scale_grid->set_columns(SCALE_COMPONENTS);
+	section->get_vbox()->add_child(scale_grid);
+
+	Label *l4 = memnew(Label(TTR("Transform")));
+	section->get_vbox()->add_child(l4);
+
+	transform_grid = memnew(GridContainer());
+	transform_grid->set_columns(TRANSFORM_CONTROL_COMPONENTS);
+	section->get_vbox()->add_child(transform_grid);
+
+	static const char *desc[TRANSFORM_COMPONENTS] = { "x", "y", "z", "x", "y", "z", "x", "y", "z", "x", "y", "z" };
+
+	for (int i = 0; i < TRANSFORM_CONTROL_COMPONENTS; ++i) {
+		translation_slider[i] = memnew(EditorSpinSlider());
+		translation_slider[i]->set_label(desc[i]);
+		setup_spinner(translation_slider[i], false);
+		translation_grid->add_child(translation_slider[i]);
+
+		rotation_slider[i] = memnew(EditorSpinSlider());
+		rotation_slider[i]->set_label(desc[i]);
+		setup_spinner(rotation_slider[i], false);
+		rotation_grid->add_child(rotation_slider[i]);
+
+		scale_slider[i] = memnew(EditorSpinSlider());
+		scale_slider[i]->set_label(desc[i]);
+		setup_spinner(scale_slider[i], false);
+		scale_grid->add_child(scale_slider[i]);
+	}
+
+	for (int i = 0; i < TRANSFORM_COMPONENTS; ++i) {
+		transform_slider[i] = memnew(EditorSpinSlider());
+		transform_slider[i]->set_label(desc[i]);
+		setup_spinner(transform_slider[i], true);
+		transform_grid->add_child(transform_slider[i]);
+	}
+}
+
+void BoneTransformEditor::setup_spinner(EditorSpinSlider *spinner, const bool is_transform_spinner) {
+	spinner->set_flat(true);
+	spinner->set_min(-10000);
+	spinner->set_max(10000);
+	spinner->set_step(0.001f);
+	spinner->set_hide_slider(true);
+	spinner->set_allow_greater(true);
+	spinner->set_allow_lesser(true);
+	spinner->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	spinner->connect_compat("value_changed", this, "_value_changed", varray(is_transform_spinner));
+}
+
+void BoneTransformEditor::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			create_editors();
+			key_button->connect_compat("pressed", this, "_key_button_pressed");
+			enabled_checkbox->connect_compat("toggled", this, "_checkbox_toggled");
+			[[fallthrough]];
+		}
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color base = get_theme_color("accent_color", "Editor");
+			const Color bg_color = get_theme_color("property_color", "Editor");
+			const Color bg_lbl_color(bg_color.r, bg_color.g, bg_color.b, 0.5);
+
+			for (int i = 0; i < TRANSLATION_COMPONENTS; i++) {
+				Color c = base;
+				c.set_hsv(float(i % TRANSLATION_COMPONENTS) / TRANSLATION_COMPONENTS + 0.05, c.get_s() * 0.75, c.get_v());
+				if (!translation_slider[i]) {
+					continue;
+				}
+				translation_slider[i]->set_custom_label_color(true, c);
+			}
+
+			for (int i = 0; i < ROTATION_DEGREES_COMPONENTS; i++) {
+				Color c = base;
+				c.set_hsv(float(i % ROTATION_DEGREES_COMPONENTS) / ROTATION_DEGREES_COMPONENTS + 0.05, c.get_s() * 0.75, c.get_v());
+				if (!rotation_slider[i]) {
+					continue;
+				}
+				rotation_slider[i]->set_custom_label_color(true, c);
+			}
+
+			for (int i = 0; i < SCALE_COMPONENTS; i++) {
+				Color c = base;
+				c.set_hsv(float(i % SCALE_COMPONENTS) / SCALE_COMPONENTS + 0.05, c.get_s() * 0.75, c.get_v());
+				if (!scale_slider[i]) {
+					continue;
+				}
+				scale_slider[i]->set_custom_label_color(true, c);
+			}
+
+			for (int i = 0; i < TRANSFORM_COMPONENTS; i++) {
+				Color c = base;
+				c.set_hsv(float(i % TRANSFORM_COMPONENTS) / TRANSFORM_COMPONENTS + 0.05, c.get_s() * 0.75, c.get_v());
+				if (!transform_slider[i]) {
+					continue;
+				}
+				transform_slider[i]->set_custom_label_color(true, c);
+			}
+
+			break;
+		}
+		case NOTIFICATION_SORT_CHILDREN: {
+			const Ref<Font> font = get_theme_font("font", "Tree");
+
+			Point2 buffer;
+			buffer.x += get_theme_constant("inspector_margin", "Editor");
+			buffer.y += font->get_height();
+			buffer.y += get_theme_constant("vseparation", "Tree");
+
+			const float vector_height = translation_grid->get_size().y;
+			const float transform_height = transform_grid->get_size().y;
+			const float button_height = key_button->get_size().y;
+
+			const float width = get_size().x - get_theme_constant("inspector_margin", "Editor");
+			Vector<Rect2> input_rects;
+			if (keyable && section->get_vbox()->is_visible()) {
+				input_rects.push_back(Rect2(key_button->get_position() + buffer, Size2(width, button_height)));
+			} else {
+				input_rects.push_back(Rect2(0, 0, 0, 0));
+			}
+
+			if (section->get_vbox()->is_visible()) {
+				input_rects.push_back(Rect2(translation_grid->get_position() + buffer, Size2(width, vector_height)));
+				input_rects.push_back(Rect2(rotation_grid->get_position() + buffer, Size2(width, vector_height)));
+				input_rects.push_back(Rect2(scale_grid->get_position() + buffer, Size2(width, vector_height)));
+				input_rects.push_back(Rect2(transform_grid->get_position() + buffer, Size2(width, transform_height)));
+			} else {
+				const int32_t start = input_rects.size();
+				const int32_t empty_input_rect_elements = 4;
+				const int32_t end = start + empty_input_rect_elements;
+				for (int i = start; i < end; ++i) {
+					input_rects.push_back(Rect2(0, 0, 0, 0));
+				}
+			}
+
+			for (int32_t i = 0; i < input_rects.size(); i++) {
+				background_rects[i] = input_rects[i];
+			}
+
+			update();
+			break;
+		}
+		case NOTIFICATION_DRAW: {
+			const Color dark_color = get_theme_color("dark_color_2", "Editor");
+
+			for (int i = 0; i < 5; ++i) {
+				draw_rect(background_rects[i], dark_color);
+			}
+
+			break;
+		}
+	}
+}
+
+void BoneTransformEditor::_value_changed(const double p_value, const bool p_from_transform) {
+	if (updating)
+		return;
+
+	if (property.get_slicec('/', 0) == "bones" && property.get_slicec('/', 2) == "custom_pose") {
+		const Transform tform = compute_transform(p_from_transform);
+
+		undo_redo->create_action(TTR("Set Custom Bone Pose Transform"), UndoRedo::MERGE_ENDS);
+		undo_redo->add_undo_method(skeleton, "set_bone_custom_pose", property.get_slicec('/', 1).to_int(), skeleton->get_bone_custom_pose(property.get_slicec('/', 1).to_int()));
+		undo_redo->add_do_method(skeleton, "set_bone_custom_pose", property.get_slicec('/', 1).to_int(), tform);
+		undo_redo->commit_action();
+	} else if (property.get_slicec('/', 0) == "bones") {
+		const Transform tform = compute_transform(p_from_transform);
+
+		undo_redo->create_action(TTR("Set Bone Transform"), UndoRedo::MERGE_ENDS);
+		undo_redo->add_undo_property(skeleton, property, skeleton->get(property));
+		undo_redo->add_do_property(skeleton, property, tform);
+		undo_redo->commit_action();
+	}
+}
+
+Transform BoneTransformEditor::compute_transform(const bool p_from_transform) const {
+	// Last modified was a raw transform column...
+	if (p_from_transform) {
+		Transform tform;
+
+		for (int i = 0; i < BASIS_COMPONENTS; ++i) {
+			tform.basis[i / BASIS_SPLIT_COMPONENTS][i % BASIS_SPLIT_COMPONENTS] = transform_slider[i]->get_value();
+		}
+
+		for (int i = 0; i < TRANSLATION_COMPONENTS; ++i) {
+			tform.origin[i] = transform_slider[i + BASIS_COMPONENTS]->get_value();
+		}
+
+		return tform;
+	}
+
+	return Transform(
+			Basis(Vector3(Math::deg2rad(rotation_slider[0]->get_value()), Math::deg2rad(rotation_slider[1]->get_value()), Math::deg2rad(rotation_slider[2]->get_value())),
+					Vector3(scale_slider[0]->get_value(), scale_slider[1]->get_value(), scale_slider[2]->get_value())),
+			Vector3(translation_slider[0]->get_value(), translation_slider[1]->get_value(), translation_slider[2]->get_value()));
+}
+
+void BoneTransformEditor::update_enabled_checkbox() {
+	if (enabled_checkbox) {
+		const String path = "bones/" + property.get_slicec('/', 1) + "/enabled";
+		const bool is_enabled = skeleton->get(path);
+		enabled_checkbox->set_pressed(is_enabled);
+	}
+}
+
+void BoneTransformEditor::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_value_changed", "value"), &BoneTransformEditor::_value_changed);
+	ClassDB::bind_method(D_METHOD("_key_button_pressed"), &BoneTransformEditor::_key_button_pressed);
+	ClassDB::bind_method(D_METHOD("_checkbox_toggled", "toggled"), &BoneTransformEditor::_checkbox_toggled);
+}
+
+void BoneTransformEditor::_update_properties() {
+	if (updating)
+		return;
+
+	if (skeleton == nullptr)
+		return;
+
+	updating = true;
+
+	Transform tform = skeleton->get(property);
+	_update_transform_properties(tform);
+}
+
+void BoneTransformEditor::_update_custom_pose_properties() {
+	if (updating)
+		return;
+
+	if (skeleton == nullptr)
+		return;
+
+	updating = true;
+
+	Transform tform = skeleton->get_bone_custom_pose(property.to_int());
+	_update_transform_properties(tform);
+}
+
+void BoneTransformEditor::_update_transform_properties(Transform tform) {
+	Quat rot = tform.get_basis();
+	Vector3 rot_rad = rot.get_euler();
+	Vector3 rot_degrees = Vector3(Math::rad2deg(rot_rad.x), Math::rad2deg(rot_rad.y), Math::rad2deg(rot_rad.z));
+	Vector3 tr = tform.get_origin();
+	Vector3 scale = tform.basis.get_scale();
+
+	for (int i = 0; i < TRANSLATION_COMPONENTS; i++) {
+		translation_slider[i]->set_value(tr[i]);
+	}
+
+	for (int i = 0; i < ROTATION_DEGREES_COMPONENTS; i++) {
+		rotation_slider[i]->set_value(rot_degrees[i]);
+	}
+
+	for (int i = 0; i < SCALE_COMPONENTS; i++) {
+		scale_slider[i]->set_value(scale[i]);
+	}
+
+	transform_slider[0]->set_value(tform.get_basis()[Vector3::AXIS_X].x);
+	transform_slider[1]->set_value(tform.get_basis()[Vector3::AXIS_X].y);
+	transform_slider[2]->set_value(tform.get_basis()[Vector3::AXIS_X].z);
+	transform_slider[3]->set_value(tform.get_basis()[Vector3::AXIS_Y].x);
+	transform_slider[4]->set_value(tform.get_basis()[Vector3::AXIS_Y].y);
+	transform_slider[5]->set_value(tform.get_basis()[Vector3::AXIS_Y].z);
+	transform_slider[6]->set_value(tform.get_basis()[Vector3::AXIS_Z].x);
+	transform_slider[7]->set_value(tform.get_basis()[Vector3::AXIS_Z].y);
+	transform_slider[8]->set_value(tform.get_basis()[Vector3::AXIS_Z].z);
+
+	for (int i = 0; i < TRANSLATION_COMPONENTS; i++) {
+		transform_slider[BASIS_COMPONENTS + i]->set_value(tform.get_origin()[i]);
+	}
+
+	update_enabled_checkbox();
+	updating = false;
+}
+
+BoneTransformEditor::BoneTransformEditor(Skeleton3D *p_skeleton) :
+		translation_slider(),
+		rotation_slider(),
+		scale_slider(),
+		transform_slider(),
+		skeleton(p_skeleton),
+		key_button(nullptr),
+		enabled_checkbox(nullptr),
+		keyable(false),
+		toggle_enabled(false),
+		updating(false) {
+	undo_redo = EditorNode::get_undo_redo();
+}
+
+void BoneTransformEditor::set_target(const String &p_prop) {
+	property = p_prop;
+}
+
+void BoneTransformEditor::set_keyable(const bool p_keyable) {
+	keyable = p_keyable;
+	if (key_button) {
+		key_button->set_visible(p_keyable);
+	}
+}
+
+void BoneTransformEditor::set_toggle_enabled(const bool p_enabled) {
+	toggle_enabled = p_enabled;
+	if (enabled_checkbox) {
+		enabled_checkbox->set_visible(p_enabled);
+	}
+}
+
+void BoneTransformEditor::_key_button_pressed() {
+	if (skeleton == nullptr)
+		return;
+
+	const BoneId bone_id = property.get_slicec('/', 1).to_int();
+	const String name = skeleton->get_bone_name(bone_id);
+
+	if (name.empty())
+		return;
+
+	// Need to normalize the basis before you key it
+	Transform tform = compute_transform(true);
+	tform.orthonormalize();
+	AnimationPlayerEditor::singleton->get_track_editor()->insert_transform_key(skeleton, name, tform);
+}
+
+void BoneTransformEditor::_checkbox_toggled(const bool p_toggled) {
+	if (enabled_checkbox) {
+		const String path = "bones/" + property.get_slicec('/', 1) + "/enabled";
+		skeleton->set(path, p_toggled);
+	}
+}
 
 void Skeleton3DEditor::_on_click_option(int p_option) {
 	if (!skeleton) {
@@ -45,12 +417,14 @@ void Skeleton3DEditor::_on_click_option(int p_option) {
 	switch (p_option) {
 		case MENU_OPTION_CREATE_PHYSICAL_SKELETON: {
 			create_physical_skeleton();
-		} break;
+			break;
+		}
 	}
 }
 
 void Skeleton3DEditor::create_physical_skeleton() {
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	ERR_FAIL_COND(!get_tree());
 	Node *owner = skeleton == get_tree()->get_edited_scene_root() ? skeleton : skeleton->get_owner();
 
 	const int bc = skeleton->get_bone_count();
@@ -124,28 +498,164 @@ PhysicalBone3D *Skeleton3DEditor::create_physical_bone(int bone_id, int bone_chi
 	return physical_bone;
 }
 
-void Skeleton3DEditor::edit(Skeleton3D *p_node) {
-	skeleton = p_node;
+Variant Skeleton3DEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
+	TreeItem *selected = joint_tree->get_selected();
+
+	if (!selected)
+		return Variant();
+
+	Ref<Texture> icon = selected->get_icon(0);
+
+	VBoxContainer *vb = memnew(VBoxContainer);
+	HBoxContainer *hb = memnew(HBoxContainer);
+	TextureRect *tf = memnew(TextureRect);
+	tf->set_texture(icon);
+	tf->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
+	hb->add_child(tf);
+	Label *label = memnew(Label(selected->get_text(0)));
+	hb->add_child(label);
+	vb->add_child(hb);
+	hb->set_modulate(Color(1, 1, 1, 1));
+
+	set_drag_preview(vb);
+	Dictionary drag_data;
+	drag_data["type"] = "nodes";
+	drag_data["node"] = selected;
+
+	return drag_data;
 }
 
-void Skeleton3DEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		get_tree()->connect("node_removed", callable_mp(this, &Skeleton3DEditor::_node_removed));
+bool Skeleton3DEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
+	TreeItem *target = joint_tree->get_item_at_position(p_point);
+	if (!target)
+		return false;
+
+	const String path = target->get_metadata(0);
+	if (!path.begins_with("bones/"))
+		return false;
+
+	TreeItem *selected = Object::cast_to<TreeItem>(Dictionary(p_data)["node"]);
+	if (target == selected)
+		return false;
+
+	const String path2 = target->get_metadata(0);
+	if (!path2.begins_with("bones/"))
+		return false;
+
+	return true;
+}
+
+void Skeleton3DEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
+	if (!can_drop_data_fw(p_point, p_data, p_from))
+		return;
+
+	TreeItem *target = joint_tree->get_item_at_position(p_point);
+	TreeItem *selected = Object::cast_to<TreeItem>(Dictionary(p_data)["node"]);
+
+	const BoneId target_boneidx = String(target->get_metadata(0)).get_slicec('/', 1).to_int();
+	const BoneId selected_boneidx = String(selected->get_metadata(0)).get_slicec('/', 1).to_int();
+
+	move_skeleton_bone(skeleton->get_path(), selected_boneidx, target_boneidx);
+}
+
+void Skeleton3DEditor::move_skeleton_bone(NodePath p_skeleton_path, int32_t p_selected_boneidx, int32_t p_target_boneidx) {
+	Node *node = get_node_or_null(p_skeleton_path);
+	Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(node);
+	ERR_FAIL_NULL(skeleton);
+	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	ur->create_action(TTR("Set Bone Parentage"));
+	// If the target is a child of ourselves, we move only *us* and not our children
+	if (skeleton->is_bone_parent_of(p_target_boneidx, p_selected_boneidx)) {
+		const BoneId parent_idx = skeleton->get_bone_parent(p_selected_boneidx);
+		const int bone_count = skeleton->get_bone_count();
+		for (BoneId i = 0; i < bone_count; ++i) {
+			if (skeleton->get_bone_parent(i) == p_selected_boneidx) {
+				ur->add_undo_method(skeleton, "set_bone_parent", i, skeleton->get_bone_parent(i));
+				ur->add_do_method(skeleton, "set_bone_parent", i, parent_idx);
+				skeleton->set_bone_parent(i, parent_idx);
+			}
+		}
+	}
+	ur->add_undo_method(skeleton, "set_bone_parent", p_selected_boneidx, skeleton->get_bone_parent(p_selected_boneidx));
+	ur->add_do_method(skeleton, "set_bone_parent", p_selected_boneidx, p_target_boneidx);
+	skeleton->set_bone_parent(p_selected_boneidx, p_target_boneidx);
+
+	update_joint_tree();
+	ur->commit_action();
+}
+
+void Skeleton3DEditor::_joint_tree_selection_changed() {
+	TreeItem *selected = joint_tree->get_selected();
+	const String path = selected->get_metadata(0);
+
+	if (path.begins_with("bones/")) {
+		const int b_idx = path.get_slicec('/', 1).to_int();
+		const String bone_path = "bones/" + itos(b_idx) + "/";
+
+		pose_editor->set_target(bone_path + "pose");
+		rest_editor->set_target(bone_path + "rest");
+		custom_pose_editor->set_target(bone_path + "custom_pose");
+
+		pose_editor->set_visible(true);
+		rest_editor->set_visible(true);
+		custom_pose_editor->set_visible(true);
 	}
 }
 
-void Skeleton3DEditor::_node_removed(Node *p_node) {
-	if (p_node == skeleton) {
-		skeleton = nullptr;
-		options->hide();
+void Skeleton3DEditor::_joint_tree_rmb_select(const Vector2 &p_pos) {
+}
+
+void Skeleton3DEditor::_update_properties() {
+	if (rest_editor)
+		rest_editor->_update_properties();
+	if (pose_editor)
+		pose_editor->_update_properties();
+	if (custom_pose_editor)
+		custom_pose_editor->_update_custom_pose_properties();
+}
+
+void Skeleton3DEditor::update_joint_tree() {
+	joint_tree->clear();
+
+	if (skeleton == nullptr)
+		return;
+
+	TreeItem *root = joint_tree->create_item();
+
+	Map<int, TreeItem *> items;
+
+	items.insert(-1, root);
+
+	const Vector<int> &joint_porder = skeleton->get_bone_process_orders();
+
+	Ref<Texture> bone_icon = get_theme_icon("Skeleton3D", "EditorIcons");
+
+	for (int i = 0; i < joint_porder.size(); ++i) {
+		const int b_idx = joint_porder[i];
+
+		const int p_idx = skeleton->get_bone_parent(b_idx);
+		TreeItem *p_item = items.find(p_idx)->get();
+
+		TreeItem *joint_item = joint_tree->create_item(p_item);
+		items.insert(b_idx, joint_item);
+
+		joint_item->set_text(0, skeleton->get_bone_name(b_idx));
+		joint_item->set_icon(0, bone_icon);
+		joint_item->set_selectable(0, true);
+		joint_item->set_metadata(0, "bones/" + itos(b_idx));
 	}
 }
 
-void Skeleton3DEditor::_bind_methods() {
+void Skeleton3DEditor::update_editors() {
 }
 
-Skeleton3DEditor::Skeleton3DEditor() {
-	skeleton = nullptr;
+void Skeleton3DEditor::create_editors() {
+	set_h_size_flags(SIZE_EXPAND_FILL);
+	add_theme_constant_override("separation", 0);
+
+	set_focus_mode(FOCUS_ALL);
+
+	// Create Top Menu Bar
 	options = memnew(MenuButton);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
 
@@ -156,31 +666,119 @@ Skeleton3DEditor::Skeleton3DEditor() {
 
 	options->get_popup()->connect("id_pressed", callable_mp(this, &Skeleton3DEditor::_on_click_option));
 	options->hide();
+
+	const Color section_color = get_theme_color("prop_subsection", "Editor");
+
+	EditorInspectorSection *bones_section = memnew(EditorInspectorSection);
+	bones_section->setup("bones", "Bones", skeleton, section_color, true);
+	add_child(bones_section);
+	bones_section->unfold();
+
+	ScrollContainer *s_con = memnew(ScrollContainer);
+	s_con->set_h_size_flags(SIZE_EXPAND_FILL);
+	s_con->set_custom_minimum_size(Size2(1, 350) * EDSCALE);
+	bones_section->get_vbox()->add_child(s_con);
+
+	joint_tree = memnew(Tree);
+	joint_tree->set_columns(1);
+	joint_tree->set_focus_mode(Control::FocusMode::FOCUS_NONE);
+	joint_tree->set_select_mode(Tree::SELECT_SINGLE);
+	joint_tree->set_hide_root(true);
+	joint_tree->set_v_size_flags(SIZE_EXPAND_FILL);
+	joint_tree->set_h_size_flags(SIZE_EXPAND_FILL);
+	joint_tree->set_allow_rmb_select(true);
+	joint_tree->set_drag_forwarding(this);
+	s_con->add_child(joint_tree);
+
+	pose_editor = memnew(BoneTransformEditor(skeleton));
+	pose_editor->set_label(TTR("Bone Pose"));
+	pose_editor->set_keyable(AnimationPlayerEditor::singleton->get_track_editor()->has_keying());
+	pose_editor->set_toggle_enabled(true);
+	pose_editor->set_visible(false);
+	add_child(pose_editor);
+
+	rest_editor = memnew(BoneTransformEditor(skeleton));
+	rest_editor->set_label(TTR("Bone Rest"));
+	rest_editor->set_visible(false);
+	add_child(rest_editor);
+
+	custom_pose_editor = memnew(BoneTransformEditor(skeleton));
+	custom_pose_editor->set_label(TTR("Bone Custom Pose"));
+	custom_pose_editor->set_visible(false);
+	add_child(custom_pose_editor);
 }
 
-Skeleton3DEditor::~Skeleton3DEditor() {}
+void Skeleton3DEditor::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			create_editors();
+			update_joint_tree();
+			update_editors();
 
-void Skeleton3DEditorPlugin::edit(Object *p_object) {
-	skeleton_editor->edit(Object::cast_to<Skeleton3D>(p_object));
-}
+			get_tree()->connect_compat("node_removed", this, "_node_removed", Vector<Variant>(), Object::CONNECT_ONESHOT);
+			joint_tree->connect_compat("item_selected", this, "_joint_tree_selection_changed");
+			joint_tree->connect_compat("item_rmb_selected", this, "_joint_tree_rmb_select");
+#ifdef TOOLS_ENABLED
+			skeleton->connect_compat("pose_updated", this, "_update_properties");
+#endif // TOOLS_ENABLED
 
-bool Skeleton3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("Skeleton3D");
-}
-
-void Skeleton3DEditorPlugin::make_visible(bool p_visible) {
-	if (p_visible) {
-		skeleton_editor->options->show();
-	} else {
-		skeleton_editor->options->hide();
-		skeleton_editor->edit(nullptr);
+			break;
+		}
 	}
+}
+
+void Skeleton3DEditor::_node_removed(Node *p_node) {
+	if (skeleton && p_node == skeleton) {
+		skeleton = nullptr;
+		options->hide();
+	}
+
+	_update_properties();
+}
+
+void Skeleton3DEditor::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_node_removed"), &Skeleton3DEditor::_node_removed);
+	ClassDB::bind_method(D_METHOD("_joint_tree_selection_changed"), &Skeleton3DEditor::_joint_tree_selection_changed);
+	ClassDB::bind_method(D_METHOD("_joint_tree_rmb_select"), &Skeleton3DEditor::_joint_tree_rmb_select);
+	ClassDB::bind_method(D_METHOD("_update_properties"), &Skeleton3DEditor::_update_properties);
+	ClassDB::bind_method(D_METHOD("_on_click_option"), &Skeleton3DEditor::_on_click_option);
+
+	ClassDB::bind_method(D_METHOD("get_drag_data_fw"), &Skeleton3DEditor::get_drag_data_fw);
+	ClassDB::bind_method(D_METHOD("can_drop_data_fw"), &Skeleton3DEditor::can_drop_data_fw);
+	ClassDB::bind_method(D_METHOD("drop_data_fw"), &Skeleton3DEditor::drop_data_fw);
+	ClassDB::bind_method(D_METHOD("move_skeleton_bone"), &Skeleton3DEditor::move_skeleton_bone);
+}
+
+Skeleton3DEditor::Skeleton3DEditor(EditorInspectorPluginSkeleton *e_plugin, EditorNode *p_editor, Skeleton3D *p_skeleton) :
+		editor(p_editor),
+		editor_plugin(e_plugin),
+		skeleton(p_skeleton) {
+}
+
+Skeleton3DEditor::~Skeleton3DEditor() {
+	if (options) {
+		Node3DEditor::get_singleton()->remove_control_from_menu_panel(options);
+	}
+}
+
+bool EditorInspectorPluginSkeleton::can_handle(Object *p_object) {
+	return Object::cast_to<Skeleton3D>(p_object) != nullptr;
+}
+
+void EditorInspectorPluginSkeleton::parse_begin(Object *p_object) {
+	Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(p_object);
+	ERR_FAIL_COND(!skeleton);
+
+	Skeleton3DEditor *skel_editor = memnew(Skeleton3DEditor(this, editor, skeleton));
+	add_custom_control(skel_editor);
 }
 
 Skeleton3DEditorPlugin::Skeleton3DEditorPlugin(EditorNode *p_node) {
 	editor = p_node;
-	skeleton_editor = memnew(Skeleton3DEditor);
-	editor->get_viewport()->add_child(skeleton_editor);
-}
 
-Skeleton3DEditorPlugin::~Skeleton3DEditorPlugin() {}
+	Ref<EditorInspectorPluginSkeleton> skeleton_plugin;
+	skeleton_plugin.instance();
+	skeleton_plugin->editor = editor;
+
+	EditorInspector::add_inspector_plugin(skeleton_plugin);
+}

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -35,11 +35,97 @@
 #include "editor/editor_plugin.h"
 #include "scene/3d/skeleton_3d.h"
 
+class EditorInspectorPluginSkeleton;
+class Joint;
 class PhysicalBone3D;
-class Joint3D;
+class Skeleton3DEditorPlugin;
+class Button;
+class CheckBox;
 
-class Skeleton3DEditor : public Node {
-	GDCLASS(Skeleton3DEditor, Node);
+class BoneTransformEditor : public VBoxContainer {
+	GDCLASS(BoneTransformEditor, VBoxContainer);
+
+	static const int32_t TRANSLATION_COMPONENTS = 3;
+	static const int32_t ROTATION_DEGREES_COMPONENTS = 3;
+	static const int32_t SCALE_COMPONENTS = 3;
+	static const int32_t BASIS_COMPONENTS = 9;
+	static const int32_t BASIS_SPLIT_COMPONENTS = 3;
+	static const int32_t TRANSFORM_COMPONENTS = 12;
+	static const int32_t TRANSFORM_SPLIT_COMPONENTS = 3;
+	static const int32_t TRANSFORM_CONTROL_COMPONENTS = 3;
+
+	EditorInspectorSection *section;
+
+	GridContainer *translation_grid;
+	GridContainer *rotation_grid;
+	GridContainer *scale_grid;
+	GridContainer *transform_grid;
+
+	EditorSpinSlider *translation_slider[TRANSLATION_COMPONENTS];
+	EditorSpinSlider *rotation_slider[ROTATION_DEGREES_COMPONENTS];
+	EditorSpinSlider *scale_slider[SCALE_COMPONENTS];
+	EditorSpinSlider *transform_slider[TRANSFORM_COMPONENTS];
+
+	Rect2 background_rects[5];
+
+	Skeleton3D *skeleton;
+	String property;
+
+	UndoRedo *undo_redo;
+
+	Button *key_button;
+	CheckBox *enabled_checkbox;
+
+	bool keyable;
+	bool toggle_enabled;
+	bool updating;
+
+	String label;
+
+	void create_editors();
+	void setup_spinner(EditorSpinSlider *spinner, const bool is_transform_spinner);
+
+	void _value_changed(const double p_value, const bool p_from_transform);
+
+	Transform compute_transform(const bool p_from_transform) const;
+
+	void update_enabled_checkbox();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	BoneTransformEditor(Skeleton3D *p_skeleton);
+
+	// Which transform target to modify
+	void set_target(const String &p_prop);
+	void set_label(const String &p_label) { label = p_label; }
+
+	void _update_properties();
+	void _update_custom_pose_properties();
+	void _update_transform_properties(Transform p_transform);
+
+	// Can/cannot modify the spinner values for the Transform
+	void set_read_only(const bool p_read_only);
+
+	// Transform can be keyed, whether or not to show the button
+	void set_keyable(const bool p_keyable);
+
+	// Bone can be toggled enabled or disabled, whether or not to show the checkbox
+	void set_toggle_enabled(const bool p_enabled);
+
+	// Key Transform Button pressed
+	void _key_button_pressed();
+
+	// Bone Enabled Checkbox toggled
+	void _checkbox_toggled(const bool p_toggled);
+};
+
+class Skeleton3DEditor : public VBoxContainer {
+	GDCLASS(Skeleton3DEditor, VBoxContainer);
+
+	friend class Skeleton3DEditorPlugin;
 
 	enum Menu {
 		MENU_OPTION_CREATE_PHYSICAL_SKELETON
@@ -51,44 +137,78 @@ class Skeleton3DEditor : public Node {
 		BoneInfo() {}
 	};
 
+	EditorNode *editor;
+	EditorInspectorPluginSkeleton *editor_plugin;
+
 	Skeleton3D *skeleton;
 
+	Tree *joint_tree;
+	BoneTransformEditor *rest_editor;
+	BoneTransformEditor *pose_editor;
+	BoneTransformEditor *custom_pose_editor;
+
 	MenuButton *options;
+	EditorFileDialog *file_dialog;
+
+	UndoRedo *undo_redo;
 
 	void _on_click_option(int p_option);
+	void _file_selected(const String &p_file);
 
-	friend class Skeleton3DEditorPlugin;
+	EditorFileDialog *file_export_lib;
+
+	void update_joint_tree();
+	void update_editors();
+
+	void create_editors();
+
+	void create_physical_skeleton();
+	PhysicalBone3D *create_physical_bone(int bone_id, int bone_child_id, const Vector<BoneInfo> &bones_infos);
+
+	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
+	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
+	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
 protected:
 	void _notification(int p_what);
 	void _node_removed(Node *p_node);
 	static void _bind_methods();
 
-	void create_physical_skeleton();
-	PhysicalBone3D *create_physical_bone(int bone_id, int bone_child_id, const Vector<BoneInfo> &bones_infos);
+public:
+	void move_skeleton_bone(NodePath p_skeleton_path, int32_t p_selected_boneidx, int32_t p_target_boneidx);
+
+	Skeleton3D *get_skeleton() const { return skeleton; };
+
+	void _joint_tree_selection_changed();
+	void _joint_tree_rmb_select(const Vector2 &p_pos);
+
+	void _update_properties();
+
+	Skeleton3DEditor(EditorInspectorPluginSkeleton *e_plugin, EditorNode *p_editor, Skeleton3D *skeleton);
+	~Skeleton3DEditor();
+};
+
+class EditorInspectorPluginSkeleton : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPluginSkeleton, EditorInspectorPlugin);
+
+	friend class Skeleton3DEditorPlugin;
+
+	EditorNode *editor;
 
 public:
-	void edit(Skeleton3D *p_node);
-
-	Skeleton3DEditor();
-	~Skeleton3DEditor();
+	virtual bool can_handle(Object *p_object);
+	virtual void parse_begin(Object *p_object);
 };
 
 class Skeleton3DEditorPlugin : public EditorPlugin {
 	GDCLASS(Skeleton3DEditorPlugin, EditorPlugin);
 
 	EditorNode *editor;
-	Skeleton3DEditor *skeleton_editor;
 
 public:
-	virtual String get_name() const { return "Skeleton3D"; }
-	virtual bool has_main_screen() const { return false; }
-	virtual void edit(Object *p_object);
-	virtual bool handles(Object *p_object) const;
-	virtual void make_visible(bool p_visible);
-
 	Skeleton3DEditorPlugin(EditorNode *p_node);
-	~Skeleton3DEditorPlugin();
+
+	virtual String get_name() const { return "Skeleton3D"; }
 };
 
 #endif // SKELETON_3D_EDITOR_PLUGIN_H

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -36,6 +36,7 @@
 #include "core/type_info.h"
 #include "scene/3d/physics_body_3d.h"
 #include "scene/resources/surface_tool.h"
+#include "scene/scene_string_names.h"
 
 void SkinReference::_skin_changed() {
 	if (skeleton_node) {
@@ -157,12 +158,12 @@ bool Skeleton3D::_get(const StringName &p_path, Variant &r_ret) const {
 void Skeleton3D::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (int i = 0; i < bones.size(); i++) {
 		String prep = "bones/" + itos(i) + "/";
-		p_list->push_back(PropertyInfo(Variant::STRING, prep + "name"));
-		p_list->push_back(PropertyInfo(Variant::INT, prep + "parent", PROPERTY_HINT_RANGE, "-1," + itos(bones.size() - 1) + ",1"));
-		p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "rest"));
-		p_list->push_back(PropertyInfo(Variant::BOOL, prep + "enabled"));
-		p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "pose", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::ARRAY, prep + "bound_children"));
+		p_list->push_back(PropertyInfo(Variant::STRING, prep + "name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+		p_list->push_back(PropertyInfo(Variant::INT, prep + "parent", PROPERTY_HINT_RANGE, "-1," + itos(bones.size() - 1) + ",1", PROPERTY_USAGE_NOEDITOR));
+		p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "rest", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+		p_list->push_back(PropertyInfo(Variant::BOOL, prep + "enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+		p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "pose", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+		p_list->push_back(PropertyInfo(Variant::ARRAY, prep + "bound_children", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	}
 }
 
@@ -214,7 +215,7 @@ void Skeleton3D::_update_process_order() {
 	}
 
 	if (pass_count == len * len) {
-		ERR_PRINT("Skeleton parenthood graph is cyclic");
+		ERR_PRINT("Skeleton3D parenthood graph is cyclic");
 	}
 
 	process_order_dirty = false;
@@ -223,7 +224,7 @@ void Skeleton3D::_update_process_order() {
 void Skeleton3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_UPDATE_SKELETON: {
-			RenderingServer *vs = RenderingServer::get_singleton();
+			RenderingServer *rs = RenderingServer::get_singleton();
 			Bone *bonesptr = bones.ptrw();
 			int len = bones.size();
 
@@ -288,9 +289,9 @@ void Skeleton3D::_notification(int p_what) {
 				for (List<ObjectID>::Element *E = b.nodes_bound.front(); E; E = E->next()) {
 					Object *obj = ObjectDB::get_instance(E->get());
 					ERR_CONTINUE(!obj);
-					Node3D *sp = Object::cast_to<Node3D>(obj);
-					ERR_CONTINUE(!sp);
-					sp->set_transform(b.pose_global);
+					Node3D *node_3d = Object::cast_to<Node3D>(obj);
+					ERR_CONTINUE(!node_3d);
+					node_3d->set_transform(b.pose_global);
 				}
 			}
 
@@ -323,7 +324,7 @@ void Skeleton3D::_notification(int p_what) {
 							}
 
 							if (!found) {
-								ERR_PRINT("Skin bind #" + itos(i) + " contains named bind '" + String(bind_name) + "' but Skeleton has no bone by that name.");
+								ERR_PRINT("Skin bind #" + itos(i) + " contains named bind '" + String(bind_name) + "' but Skeleton3D has no bone by that name.");
 								E->get()->skin_bone_indices_ptrs[i] = 0;
 							}
 						} else if (skin->get_bind_bone(i) >= 0) {
@@ -346,11 +347,16 @@ void Skeleton3D::_notification(int p_what) {
 				for (uint32_t i = 0; i < bind_count; i++) {
 					uint32_t bone_index = E->get()->skin_bone_indices_ptrs[i];
 					ERR_CONTINUE(bone_index >= (uint32_t)len);
-					vs->skeleton_bone_set_transform(skeleton, i, bonesptr[bone_index].pose_global * skin->get_bind_pose(i));
+					rs->skeleton_bone_set_transform(skeleton, i, bonesptr[bone_index].pose_global * skin->get_bind_pose(i));
 				}
 			}
 
 			dirty = false;
+
+#ifdef TOOLS_ENABLED
+			emit_signal(SceneStringNames::get_singleton()->pose_updated);
+#endif // TOOLS_ENABLED
+
 		} break;
 
 #ifndef _3D_DISABLED
@@ -603,6 +609,11 @@ int Skeleton3D::get_process_order(int p_idx) {
 	return process_order[p_idx];
 }
 
+Vector<int> Skeleton3D::get_bone_process_orders() {
+	_update_process_order();
+	return process_order;
+}
+
 void Skeleton3D::localize_rests() {
 	_update_process_order();
 
@@ -843,6 +854,7 @@ Ref<SkinReference> Skeleton3D::register_skin(const Ref<Skin> &p_skin) {
 }
 
 void Skeleton3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_bone_process_orders"), &Skeleton3D::get_bone_process_orders);
 	ClassDB::bind_method(D_METHOD("add_bone", "name"), &Skeleton3D::add_bone);
 	ClassDB::bind_method(D_METHOD("find_bone", "name"), &Skeleton3D::find_bone);
 	ClassDB::bind_method(D_METHOD("get_bone_name", "bone_idx"), &Skeleton3D::get_bone_name);
@@ -892,6 +904,10 @@ void Skeleton3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "animate_physical_bones"), "set_animate_physical_bones", "get_animate_physical_bones");
 #endif // _3D_DISABLED
+
+#ifdef TOOLS_ENABLED
+	ADD_SIGNAL(MethodInfo("pose_updated"));
+#endif // TOOLS_ENABLED
 
 	BIND_CONSTANT(NOTIFICATION_UPDATE_SKELETON);
 }

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -196,6 +196,7 @@ public:
 
 	void localize_rests(); // used for loaders and tools
 	int get_process_order(int p_idx);
+	Vector<int> get_bone_process_orders();
 
 	Ref<SkinReference> register_skin(const Ref<Skin> &p_skin);
 

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -62,6 +62,8 @@ SceneStringNames::SceneStringNames() {
 	animation_changed = StaticCString::create("animation_changed");
 	animation_started = StaticCString::create("animation_started");
 
+	pose_updated = StaticCString::create("pose_updated");
+
 	mouse_entered = StaticCString::create("mouse_entered");
 	mouse_exited = StaticCString::create("mouse_exited");
 

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -95,6 +95,8 @@ public:
 	StringName animation_changed;
 	StringName animation_started;
 
+	StringName pose_updated;
+
 	StringName body_shape_entered;
 	StringName body_entered;
 	StringName body_shape_exited;


### PR DESCRIPTION
Co-authored-by: Marios Staikopoulos <marios@staik.net>

![Screen Shot 2020-02-20 at 9 15 03 PM](https://user-images.githubusercontent.com/32321/75006330-3f8e4400-5426-11ea-9b63-9f7cca9abe60.png)

Sponsored by IMVU.

Features:

Drag and drop skeleton parentage move with UNDO!

Rest and pose are exposed as transforms with degrees as units. [UPDATED]

Can key transforms into animation tracks.

Handles the other variables that represent a bone.

Ensure all used labels are translatable.

DOES NOT FREEZE THE EDITOR FOR 30 seconds swapping between the skeleton and any other node!!!

Use for testing:

https://github.com/KhronosGroup/glTF-Sample-Models/blob/master/2.0/Fox/glTF-Binary/Fox.glb

*Bugsquad edit:* Fixes #35652.