### PR TITLE
Travis: Force updating homebrew on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ matrix:
         homebrew:
           packages:
             - scons
+          update: true
 
 # TODO: iOS MoltenVK support
 


### PR DESCRIPTION
Temporary workaround for https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296