### PR TITLE
Add `PluginUITexture` import option for images

### DIFF
--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -101,6 +101,7 @@ public:
 	virtual String get_visible_name() const = 0;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
 	virtual String get_save_extension() const = 0;
+	virtual bool is_dummy() const { return false; }
 	virtual String get_resource_type() const = 0;
 	virtual float get_priority() const { return 1.0; }
 	virtual int get_import_order() const { return 0; }

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1831,7 +1831,9 @@ void EditorFileSystem::_reimport_file(const String &p_file) {
 		} else {
 			String path = base_path + "." + importer->get_save_extension();
 			f->store_line("path=\"" + path + "\"");
-			dest_paths.push_back(path);
+			if (!importer->is_dummy()) {
+				dest_paths.push_back(path);
+			}
 		}
 
 	} else {
@@ -1886,16 +1888,18 @@ void EditorFileSystem::_reimport_file(const String &p_file) {
 	f->close();
 	memdelete(f);
 
-	// Store the md5's of the various files. These are stored separately so that the .import files can be version controlled.
-	FileAccess *md5s = FileAccess::open(base_path + ".md5", FileAccess::WRITE);
-	ERR_FAIL_COND_MSG(!md5s, "Cannot open MD5 file '" + base_path + ".md5'.");
+	if (!importer->is_dummy()) {
+		// Store the md5's of the various files. These are stored separately so that the .import files can be version controlled.
+		FileAccess *md5s = FileAccess::open(base_path + ".md5", FileAccess::WRITE);
+		ERR_FAIL_COND_MSG(!md5s, "Cannot open MD5 file '" + base_path + ".md5'.");
 
-	md5s->store_line("source_md5=\"" + FileAccess::get_md5(p_file) + "\"");
-	if (dest_paths.size()) {
-		md5s->store_line("dest_md5=\"" + FileAccess::get_multiple_md5(dest_paths) + "\"\n");
+		md5s->store_line("source_md5=\"" + FileAccess::get_md5(p_file) + "\"");
+		if (dest_paths.size()) {
+			md5s->store_line("dest_md5=\"" + FileAccess::get_multiple_md5(dest_paths) + "\"\n");
+		}
+		md5s->close();
+		memdelete(md5s);
 	}
-	md5s->close();
-	memdelete(md5s);
 
 	//update modified times, to avoid reimport
 	fs->files[cpos]->modified_time = FileAccess::get_modified_time(p_file);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -97,6 +97,7 @@
 #include "editor/import/resource_importer_image.h"
 #include "editor/import/resource_importer_layered_texture.h"
 #include "editor/import/resource_importer_obj.h"
+#include "editor/import/resource_importer_plugin_ui_texture.h"
 #include "editor/import/resource_importer_scene.h"
 #include "editor/import/resource_importer_texture.h"
 #include "editor/import/resource_importer_texture_atlas.h"
@@ -5739,6 +5740,10 @@ EditorNode::EditorNode() {
 		Ref<ResourceImporterTextureAtlas> import_texture_atlas;
 		import_texture_atlas.instance();
 		ResourceFormatImporter::get_singleton()->add_importer(import_texture_atlas);
+
+		Ref<ResourceImporterPluginUITexture> import_plugin_ui_texture;
+		import_plugin_ui_texture.instance();
+		ResourceFormatImporter::get_singleton()->add_importer(import_plugin_ui_texture);
 
 		Ref<ResourceImporterCSVTranslation> import_csv_translation;
 		import_csv_translation.instance();

--- a/editor/import/resource_importer_plugin_ui_texture.cpp
+++ b/editor/import/resource_importer_plugin_ui_texture.cpp
@@ -1,0 +1,88 @@
+/*************************************************************************/
+/*  resource_importer_plugin_ui_texture.cpp                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "resource_importer_plugin_ui_texture.h"
+
+#include "core/io/image_loader.h"
+#include "core/os/file_access.h"
+#include "scene/resources/texture.h"
+
+String ResourceImporterPluginUITexture::get_importer_name() const {
+
+	return "plugin_ui_texture";
+}
+
+String ResourceImporterPluginUITexture::get_visible_name() const {
+
+	return "PluginUITexture";
+}
+
+void ResourceImporterPluginUITexture::get_recognized_extensions(List<String> *p_extensions) const {
+
+	ImageLoader::get_recognized_extensions(p_extensions);
+}
+
+String ResourceImporterPluginUITexture::get_save_extension() const {
+
+	return "uitex";
+}
+
+String ResourceImporterPluginUITexture::get_resource_type() const {
+
+	return "ImageTexture";
+}
+
+bool ResourceImporterPluginUITexture::get_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const {
+
+	return true;
+}
+
+int ResourceImporterPluginUITexture::get_preset_count() const {
+	return 0;
+}
+String ResourceImporterPluginUITexture::get_preset_name(int p_idx) const {
+
+	return String();
+}
+
+void ResourceImporterPluginUITexture::get_import_options(List<ImportOption> *r_options, int p_preset) const {
+}
+
+Error ResourceImporterPluginUITexture::import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+
+	if (FileAccess::exists(p_source_file)) {
+		return OK;
+	} else {
+		return ERR_DOES_NOT_EXIST;
+	}
+}
+
+ResourceImporterPluginUITexture::ResourceImporterPluginUITexture() {
+}

--- a/editor/import/resource_importer_plugin_ui_texture.h
+++ b/editor/import/resource_importer_plugin_ui_texture.h
@@ -1,0 +1,57 @@
+/*************************************************************************/
+/*  resource_importer_plugin_ui_texture.h                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef RESOURCE_IMPORTER_PLUGIN_UI_TEXTURE_H
+#define RESOURCE_IMPORTER_PLUGIN_UI_TEXTURE_H
+
+#include "core/io/resource_importer.h"
+
+class ResourceImporterPluginUITexture : public ResourceImporter {
+	GDCLASS(ResourceImporterPluginUITexture, ResourceImporter)
+public:
+	virtual String get_importer_name() const;
+	virtual String get_visible_name() const;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual String get_save_extension() const;
+	virtual bool is_dummy() const { return true; }
+	virtual String get_resource_type() const;
+
+	virtual int get_preset_count() const;
+	virtual String get_preset_name(int p_idx) const;
+
+	virtual void get_import_options(List<ImportOption> *r_options, int p_preset = 0) const;
+	virtual bool get_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const;
+
+	virtual Error import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = NULL, Variant *r_metadata = NULL);
+
+	ResourceImporterPluginUITexture();
+};
+
+#endif // RESOURCE_IMPORTER_PLUGIN_UI_TEXTURE_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -221,6 +221,9 @@ static Ref<ResourceFormatLoaderDynamicFont> resource_loader_dynamic_font;
 
 static Ref<ResourceFormatLoaderStreamTexture> resource_loader_stream_texture;
 static Ref<ResourceFormatLoaderTextureLayered> resource_loader_texture_layered;
+#ifdef TOOLS_ENABLED
+static Ref<ResourceFormatLoaderPluginUITexture> resource_loader_plugin_ui_texture;
+#endif
 
 static Ref<ResourceFormatLoaderBMFont> resource_loader_bmfont;
 
@@ -243,6 +246,11 @@ void register_scene_types() {
 
 	resource_loader_texture_layered.instance();
 	ResourceLoader::add_resource_format_loader(resource_loader_texture_layered);
+
+#ifdef TOOLS_ENABLED
+	resource_loader_plugin_ui_texture.instance();
+	ResourceLoader::add_resource_format_loader(resource_loader_plugin_ui_texture);
+#endif
 
 	resource_saver_text.instance();
 	ResourceSaver::add_resource_format_saver(resource_saver_text, true);
@@ -794,6 +802,11 @@ void unregister_scene_types() {
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_stream_texture);
 	resource_loader_stream_texture.unref();
+
+#ifdef TOOLS_ENABLED
+	ResourceLoader::remove_resource_format_loader(resource_loader_plugin_ui_texture);
+	resource_loader_plugin_ui_texture.unref();
+#endif
 
 	DynamicFont::finish_dynamic_fonts();
 

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2316,3 +2316,37 @@ CameraTexture::CameraTexture() {
 CameraTexture::~CameraTexture() {
 	// nothing to do here yet
 }
+
+///////////////////////////////
+
+#ifdef TOOLS_ENABLED
+RES ResourceFormatLoaderPluginUITexture::load(const String &p_path, const String &p_original_path, Error *r_error) {
+	Ref<Image> img = memnew(Image);
+	Error err = ImageLoader::load_image(p_original_path, img);
+	if (err) {
+		if (r_error)
+			*r_error = err;
+		return RES();
+	}
+
+	Ref<ImageTexture> texture = memnew(ImageTexture);
+	texture->create_from_image(img, ImageTexture::FLAG_FILTER | ImageTexture::FLAG_MIPMAPS);
+
+	if (r_error)
+		*r_error = OK;
+
+	return texture;
+}
+
+void ResourceFormatLoaderPluginUITexture::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("uitex");
+}
+
+bool ResourceFormatLoaderPluginUITexture::handles_type(const String &p_type) const {
+	return ClassDB::is_parent_class(p_type, "ImageTexture");
+}
+
+String ResourceFormatLoaderPluginUITexture::get_resource_type(const String &p_path) const {
+	return "ImageTexture";
+}
+#endif

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -641,4 +641,15 @@ public:
 	~CameraTexture();
 };
 
+#ifdef TOOLS_ENABLED
+class ResourceFormatLoaderPluginUITexture : public ResourceFormatLoader {
+	GDCLASS(ResourceFormatLoaderPluginUITexture, ResourceFormatLoader)
+public:
+	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = NULL);
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual bool handles_type(const String &p_type) const;
+	virtual String get_resource_type(const String &p_path) const;
+};
+#endif
+
 #endif


### PR DESCRIPTION
When you write a plugin requiring some textures for its in-editor UI, you face the problem that they need to be imported. That's a problem especially if your plugin needs to be able to load them from the very beginning (because of preloads or because it needs to display some UI as soon as it's activated).

Normally, textures in Godot are imported so they are converted to proper formats depending on the import kind and settings, and that's good. However, in this scenario there's no ambiguity: you need to plug some textures into some `Control`s and you just need them to work.

To meet that need, this PR adds a new import mode for images: `PluginUITexture`. What it does is importing the image as an `ImageTexture` with sensible flags for UI use (filter and mip-maps). This mode will have the original image loaded instead of any import "artifact" that is normally generated by other modes. For that, this mode is flagged as dummy.

(The mode could have been named `ImageTexture`, but by giving it the name of `PluginUITexture` it's only reasonable use case is made explicit and confusion among the other import modes is avoided.)

Finally, it's only enabled in tools builds. If a texture imported this way is attempted to be loaded in an exported game, a no-loader-found-for-this-resource error will be thrown.

---
**This code is generously donated by IMVU.**