### PR TITLE
Refactor node processing in visual shader member dialog

### DIFF
--- a/doc/classes/VisualShaderNodeCustom.xml
+++ b/doc/classes/VisualShaderNodeCustom.xml
@@ -20,8 +20,8 @@
 			<return type="String">
 			</return>
 			<description>
-				Override this method to define the category of the associated custom node in the Visual Shader Editor's members dialog.
-				Defining this method is [b]optional[/b]. If not overridden, the node will be filed under the "Custom" category.
+				Override this method to define the path to the associated custom node in the Visual Shader Editor's members dialog. The path may looks like [code]"MyGame/MyFunctions/Noise"[/code].
+				Defining this method is [b]optional[/b]. If not overridden, the node will be filed under the "Addons" category.
 			</description>
 		</method>
 		<method name="_get_code" qualifiers="virtual">
@@ -133,14 +133,6 @@
 			<description>
 				Override this method to define the return icon of the associated custom node in the Visual Shader Editor's members dialog.
 				Defining this method is [b]optional[/b]. If not overridden, no return icon is shown.
-			</description>
-		</method>
-		<method name="_get_subcategory" qualifiers="virtual">
-			<return type="String">
-			</return>
-			<description>
-				Override this method to define the subcategory of the associated custom node in the Visual Shader Editor's members dialog.
-				Defining this method is [b]optional[/b]. If not overridden, the node will be filed under the root of the main category (see [method _get_category]).
 			</description>
 		</method>
 		<method name="_is_highend" qualifiers="virtual">

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -104,7 +104,6 @@ class VisualShaderEditor : public VBoxContainer {
 	struct AddOption {
 		String name;
 		String category;
-		String sub_category;
 		String type;
 		String description;
 		int sub_func;
@@ -116,12 +115,12 @@ class VisualShaderEditor : public VBoxContainer {
 		float value;
 		bool highend;
 		bool is_custom;
+		int temp_idx;
 
 		AddOption(const String &p_name = String(), const String &p_category = String(), const String &p_sub_category = String(), const String &p_type = String(), const String &p_description = String(), int p_sub_func = -1, int p_return_type = -1, int p_mode = -1, int p_func = -1, float p_value = -1, bool p_highend = false) {
 			name = p_name;
 			type = p_type;
-			category = p_category;
-			sub_category = p_sub_category;
+			category = p_category + "/" + p_sub_category;
 			description = p_description;
 			sub_func = p_sub_func;
 			return_type = p_return_type;
@@ -135,8 +134,7 @@ class VisualShaderEditor : public VBoxContainer {
 		AddOption(const String &p_name, const String &p_category, const String &p_sub_category, const String &p_type, const String &p_description, const String &p_sub_func, int p_return_type = -1, int p_mode = -1, int p_func = -1, float p_value = -1, bool p_highend = false) {
 			name = p_name;
 			type = p_type;
-			category = p_category;
-			sub_category = p_sub_category;
+			category = p_category + "/" + p_sub_category;
 			description = p_description;
 			sub_func = 0;
 			sub_func_str = p_sub_func;
@@ -146,6 +144,12 @@ class VisualShaderEditor : public VBoxContainer {
 			value = p_value;
 			highend = p_highend;
 			is_custom = false;
+		}
+	};
+	struct _OptionComparator {
+
+		_FORCE_INLINE_ bool operator()(const AddOption &a, const AddOption &b) const {
+			return a.category.count("/") > b.category.count("/") || (a.category + "/" + a.name).naturalnocasecmp_to(b.category + "/" + b.name) < 0;
 		}
 	};
 
@@ -265,7 +269,7 @@ public:
 	static VisualShaderEditor *get_singleton() { return singleton; }
 
 	void clear_custom_types();
-	void add_custom_type(const String &p_name, const Ref<Script> &p_script, const String &p_description, int p_return_icon_type, const String &p_category, const String &p_subcategory, bool p_highend);
+	void add_custom_type(const String &p_name, const Ref<Script> &p_script, const String &p_description, int p_return_icon_type, const String &p_category, bool p_highend);
 
 	virtual Size2 get_minimum_size() const;
 	void edit(VisualShader *p_visual_shader);

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -266,7 +266,6 @@ void VisualShaderNodeCustom::_bind_methods() {
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_name"));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_description"));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_category"));
-	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_subcategory"));
 	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_return_icon_type"));
 	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_input_port_count"));
 	BIND_VMETHOD(MethodInfo(Variant::INT, "_get_input_port_type", PropertyInfo(Variant::INT, "port")));


### PR DESCRIPTION
I decided to rewrite a code part responsible for adding nodes to member dialog tree. 
Changes:

- `Custom` default directory renamed to `Addons` - and will be pushed on top of the list.
- `_get_subcategory` virtual method has been removed from `VisualShaderNodeCustom`- instead, users can define it in `_get_category` with any amount of additional subdirectories like `MyNodes/RGB/Noise`. To preserve backward compatibility - usage of `_get_subcategory` still be handled (its removed from documentation part only).
- Custom nodes and its folders will be pushed to `Addons` directory, regardless of returned value in `_get_category`. I think it's better to keep them in one place.
- Internally the options will be properly sorted (only custom ones to increase performance) and this can be easily modified using `_OptionComparator`.

![image](https://user-images.githubusercontent.com/3036176/75044025-fdbad780-54d1-11ea-8166-1c555808d303.png)
