### PR TITLE
 Improve the error message about MAX_EXTENSIONS. Add two comments about where extensions are being registered

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -228,6 +228,7 @@ Error VulkanContext::_initialize_extensions() {
 			free(instance_extensions);
 			ERR_FAIL_V(ERR_CANT_CREATE);
 		}
+		//extensions used by VkInstanceCreateInfo inst_info
 		for (uint32_t i = 0; i < instance_extension_count; i++) {
 			if (!strcmp(VK_KHR_SURFACE_EXTENSION_NAME, instance_extensions[i].extensionName)) {
 				surfaceExtFound = 1;
@@ -250,7 +251,7 @@ Error VulkanContext::_initialize_extensions() {
 			}
 			if (enabled_extension_count >= MAX_EXTENSIONS) {
 				free(instance_extensions);
-				ERR_FAIL_V_MSG(ERR_BUG, "Enabled extension count reaches MAX_EXTENSIONS, BUG");
+				ERR_FAIL_V_MSG(ERR_BUG, "Enabled extension count reaches MAX_EXTENSIONS, BUG. Increase the size of extension_names");
 			}
 		}
 
@@ -373,6 +374,7 @@ Error VulkanContext::_create_physical_device() {
 			ERR_FAIL_V(ERR_CANT_CREATE);
 		}
 
+		//extensions used by VkDeviceCreateInfo sdevice
 		for (uint32_t i = 0; i < device_extension_count; i++) {
 			if (!strcmp(VK_KHR_SWAPCHAIN_EXTENSION_NAME, device_extensions[i].extensionName)) {
 				swapchainExtFound = 1;
@@ -380,7 +382,7 @@ Error VulkanContext::_create_physical_device() {
 			}
 			if (enabled_extension_count >= MAX_EXTENSIONS) {
 				free(device_extensions);
-				ERR_FAIL_V_MSG(ERR_BUG, "Enabled extension count reaches MAX_EXTENSIONS, BUG");
+				ERR_FAIL_V_MSG(ERR_BUG, "Enabled extension count reaches MAX_EXTENSIONS, BUG. Increase the length of extension_names");
 			}
 		}
 
@@ -398,7 +400,7 @@ Error VulkanContext::_create_physical_device() {
 				}
 				if (enabled_extension_count >= MAX_EXTENSIONS) {
 					free(device_extensions);
-					ERR_FAIL_V_MSG(ERR_BUG, "Enabled extension count reaches MAX_EXTENSIONS, BUG");
+					ERR_FAIL_V_MSG(ERR_BUG, "Enabled extension count reaches MAX_EXTENSIONS, BUG. Increase the length of extension_names");
 				}
 			}
 			if (!VK_KHR_incremental_present_enabled) {
@@ -420,7 +422,7 @@ Error VulkanContext::_create_physical_device() {
 				}
 				if (enabled_extension_count >= MAX_EXTENSIONS) {
 					free(device_extensions);
-					ERR_FAIL_V_MSG(ERR_BUG, "Enabled extension count reaches MAX_EXTENSIONS, BUG");
+					ERR_FAIL_V_MSG(ERR_BUG, "Enabled extension count reaches MAX_EXTENSIONS, BUG. Increase the length of extension_names");
 				}
 			}
 			if (!VK_GOOGLE_display_timing_enabled) {


### PR DESCRIPTION
Some error checks therefore were removed.

See: https://github.com/godotengine/godot/issues/36405