### PR TITLE
Fixed flipped scene preview thumbnail

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1172,8 +1172,6 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			}
 			img->convert(Image::FORMAT_RGB8);
 
-			img->flip_y();
-
 			//save thumbnail directly, as thumbnailer may not update due to actual scene not changing md5
 			String temp_path = EditorSettings::get_singleton()->get_cache_dir();
 			String cache_base = ProjectSettings::get_singleton()->globalize_path(p_file).md5_text();


### PR DESCRIPTION
It seems there's no need to flip the image generated from the viewport texture anymore.

Fixes #36425, unless I'm mistaken and it's a platform/gpu specific issue.