### PR TITLE
Reorder drives selector for editor_file_dialog

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1541,6 +1541,10 @@ EditorFileDialog::EditorFileDialog() {
 	dir_next->connect_compat("pressed", this, "_go_forward");
 	dir_up->connect_compat("pressed", this, "_go_up");
 
+	drives = memnew(OptionButton);
+	pathhb->add_child(drives);
+	drives->connect_compat("item_selected", this, "_select_drive");
+
 	pathhb->add_child(memnew(Label(TTR("Path:"))));
 
 	dir = memnew(LineEdit);
@@ -1585,10 +1589,6 @@ EditorFileDialog::EditorFileDialog() {
 	mode_list->set_button_group(view_mode_group);
 	mode_list->set_tooltip(TTR("View items as a list."));
 	pathhb->add_child(mode_list);
-
-	drives = memnew(OptionButton);
-	pathhb->add_child(drives);
-	drives->connect_compat("item_selected", this, "_select_drive");
 
 	makedir = memnew(Button);
 	makedir->set_text(TTR("Create Folder"));


### PR DESCRIPTION
What I am suggesting and asking for PR is very small usability change.

In various 'Open [something]' dialog windows (for example on Script tab) there is a path for choosing right directory and drives selector - but is moved **far to the right of top bar**, which seems at least confusing and counter-intuitive to dialogs, users are mostly used to work with.

With that PR, I am moving from that layout:

![before](https://user-images.githubusercontent.com/1110337/75080578-ad14a000-550c-11ea-8e40-977fe04d8855.png)

to this:

![after](https://user-images.githubusercontent.com/1110337/75080560-9bcb9380-550c-11ea-9389-b45d6283c9e3.png)

