### PR TITLE
Add the "invert condition" property to AnimationNodeStateMachineTransition

### DIFF
--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -27,6 +27,9 @@
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
 			Don't use this transition during [method AnimationNodeStateMachinePlayback.travel] or [member auto_advance].
 		</member>
+		<member name="invert_condition" type="bool" setter="set_invert_condition" getter="get_invert_condition" default="false">
+			If [code]true[/code], instead of turning on auto advance when the [member advance_condition] is met (i.e. evaluates to [code]true[/code]), auto advance will be turned on when the [member advance_condition] is [i]not[/i] met (i.e. evaluates to [code]false[/code]).
+		</member>
 		<member name="priority" type="int" setter="set_priority" getter="get_priority" default="1">
 			Lower priority transitions are preferred when travelling through the tree via [method AnimationNodeStateMachinePlayback.travel] or [member auto_advance].
 		</member>

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -684,6 +684,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(i);
 		tl.disabled = tr->is_disabled();
 		tl.auto_advance = tr->has_auto_advance();
+		tl.invert_condition = tr->get_invert_condition();
 		tl.advance_condition_name = tr->get_advance_condition_name();
 		tl.advance_condition_state = false;
 		tl.mode = tr->get_switch_mode();
@@ -727,9 +728,16 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 
 		bool auto_advance = tl.auto_advance;
 		StringName fullpath = AnimationTreeEditor::get_singleton()->get_base_path() + String(tl.advance_condition_name);
-		if (tl.advance_condition_name != StringName() && bool(AnimationTreeEditor::get_singleton()->get_tree()->get(fullpath))) {
-			tl.advance_condition_state = true;
-			auto_advance = true;
+		if (tl.advance_condition_name != StringName()) {
+			if (bool(AnimationTreeEditor::get_singleton()->get_tree()->get(fullpath))) {
+				tl.advance_condition_state = true;
+				auto_advance = true;
+			}
+
+			if (tl.invert_condition) {
+				tl.advance_condition_state = !tl.advance_condition_state;
+				auto_advance = !auto_advance;
+			}
 		}
 		_connection_draw(tl.from, tl.to, tl.mode, !tl.disabled, selected, travel, auto_advance);
 

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -126,6 +126,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 		Vector2 to;
 		AnimationNodeStateMachineTransition::SwitchMode mode;
 		StringName advance_condition_name;
+		bool invert_condition;
 		bool advance_condition_state = false;
 		bool disabled = false;
 		bool auto_advance = false;

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -68,6 +68,14 @@ StringName AnimationNodeStateMachineTransition::get_advance_condition_name() con
 	return advance_condition_name;
 }
 
+void AnimationNodeStateMachineTransition::set_invert_condition(bool p_enable) {
+	invert_condition = p_enable;
+}
+
+bool AnimationNodeStateMachineTransition::get_invert_condition() const {
+	return invert_condition;
+}
+
 void AnimationNodeStateMachineTransition::set_xfade_time(float p_xfade) {
 	ERR_FAIL_COND(p_xfade < 0);
 	xfade = p_xfade;
@@ -106,6 +114,9 @@ void AnimationNodeStateMachineTransition::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_advance_condition", "name"), &AnimationNodeStateMachineTransition::set_advance_condition);
 	ClassDB::bind_method(D_METHOD("get_advance_condition"), &AnimationNodeStateMachineTransition::get_advance_condition);
 
+	ClassDB::bind_method(D_METHOD("set_invert_condition", "invert"), &AnimationNodeStateMachineTransition::set_invert_condition);
+	ClassDB::bind_method(D_METHOD("get_invert_condition"), &AnimationNodeStateMachineTransition::get_invert_condition);
+
 	ClassDB::bind_method(D_METHOD("set_xfade_time", "secs"), &AnimationNodeStateMachineTransition::set_xfade_time);
 	ClassDB::bind_method(D_METHOD("get_xfade_time"), &AnimationNodeStateMachineTransition::get_xfade_time);
 
@@ -118,6 +129,7 @@ void AnimationNodeStateMachineTransition::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "switch_mode", PROPERTY_HINT_ENUM, "Immediate,Sync,AtEnd"), "set_switch_mode", "get_switch_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_advance"), "set_auto_advance", "has_auto_advance");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "advance_condition"), "set_advance_condition", "get_advance_condition");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "invert_condition"), "set_invert_condition", "get_invert_condition");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "xfade_time", PROPERTY_HINT_RANGE, "0,240,0.01"), "set_xfade_time", "get_xfade_time");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "priority", PROPERTY_HINT_RANGE, "0,32,1"), "set_priority", "get_priority");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
@@ -132,6 +144,7 @@ void AnimationNodeStateMachineTransition::_bind_methods() {
 AnimationNodeStateMachineTransition::AnimationNodeStateMachineTransition() {
 	switch_mode = SWITCH_MODE_IMMEDIATE;
 	auto_advance = false;
+	invert_condition = false;
 	xfade = 0;
 	disabled = false;
 	priority = 1;
@@ -418,8 +431,14 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 				auto_advance = true;
 			}
 			StringName advance_condition_name = p_state_machine->transitions[i].transition->get_advance_condition_name();
-			if (advance_condition_name != StringName() && bool(p_state_machine->get_parameter(advance_condition_name))) {
-				auto_advance = true;
+			if (advance_condition_name != StringName()) {
+				if (bool(p_state_machine->get_parameter(advance_condition_name))) {
+					auto_advance = true;
+				}
+
+				if (p_state_machine->transitions[i].transition->get_invert_condition()) {
+					auto_advance = !auto_advance;
+				}
 			}
 
 			if (p_state_machine->transitions[i].from == current && auto_advance) {

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -48,6 +48,7 @@ private:
 	bool auto_advance;
 	StringName advance_condition;
 	StringName advance_condition_name;
+	bool invert_condition;
 	float xfade;
 	bool disabled;
 	int priority;
@@ -66,6 +67,9 @@ public:
 	StringName get_advance_condition() const;
 
 	StringName get_advance_condition_name() const;
+
+	void set_invert_condition(bool p_enable);
+	bool get_invert_condition() const;
 
 	void set_xfade_time(float p_xfade);
 	float get_xfade_time() const;


### PR DESCRIPTION
Resolves [godotengine/godot-proposals#454](https://github.com/godotengine/godot-proposals/issues/454)

Adds the "Invert Condition" parameter to AnimationNodeStateMachinetransition, which avoids the creation of "not" conditions("IsMoving" "NotIsMoving")

Also, i've created a quick test project for testing this feature at https://github.com/Riteo/godot-invert-condition-test-project
