### PR TITLE
Fix visuals of the new debugger editor

### DIFF
--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -38,9 +38,9 @@
 
 class EditorDebuggerTree;
 
-class EditorDebuggerNode : public TabContainer {
+class EditorDebuggerNode : public MarginContainer {
 
-	GDCLASS(EditorDebuggerNode, TabContainer);
+	GDCLASS(EditorDebuggerNode, MarginContainer);
 
 private:
 	enum Options {
@@ -72,6 +72,7 @@ private:
 	};
 
 	Ref<TCP_Server> server = NULL;
+	TabContainer *tabs = NULL;
 	Button *debugger_button = NULL;
 	MenuButton *script_menu = NULL;
 
@@ -89,7 +90,7 @@ private:
 	ScriptEditorDebugger::CameraOverride camera_override = ScriptEditorDebugger::OVERRIDE_NONE;
 	Map<Breakpoint, bool> breakpoints;
 
-	ScriptEditorDebugger *_add_debugger(String p_name);
+	ScriptEditorDebugger *_add_debugger();
 	EditorDebuggerRemoteObject *get_inspected_remote_object();
 
 	friend class DebuggerEditorPlugin;

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -133,6 +133,10 @@ void ScriptEditorDebugger::update_tabs() {
 	}
 }
 
+void ScriptEditorDebugger::clear_style() {
+	tabs->add_style_override("panel", NULL);
+}
+
 void ScriptEditorDebugger::save_node(ObjectID p_id, const String &p_file) {
 	Array msg;
 	msg.push_back(p_id);
@@ -843,12 +847,9 @@ void ScriptEditorDebugger::_notification(int p_what) {
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 
-			add_constant_override("margin_left", -EditorNode::get_singleton()->get_gui_base()->get_stylebox("BottomPanelDebuggerOverride", "EditorStyles")->get_margin(MARGIN_LEFT));
-			add_constant_override("margin_right", -EditorNode::get_singleton()->get_gui_base()->get_stylebox("BottomPanelDebuggerOverride", "EditorStyles")->get_margin(MARGIN_RIGHT));
-
-			tabs->add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("DebuggerPanel", "EditorStyles"));
-			tabs->add_style_override("tab_fg", EditorNode::get_singleton()->get_gui_base()->get_stylebox("DebuggerTabFG", "EditorStyles"));
-			tabs->add_style_override("tab_bg", EditorNode::get_singleton()->get_gui_base()->get_stylebox("DebuggerTabBG", "EditorStyles"));
+			if (tabs->has_stylebox_override("panel")) {
+				tabs->add_style_override("panel", editor->get_gui_base()->get_stylebox("DebuggerPanel", "EditorStyles"));
+			}
 
 			copy->set_icon(get_icon("ActionCopy", "EditorIcons"));
 			step->set_icon(get_icon("DebugStep", "EditorIcons"));
@@ -1535,9 +1536,6 @@ void ScriptEditorDebugger::_bind_methods() {
 
 ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
-	add_constant_override("margin_left", -EditorNode::get_singleton()->get_gui_base()->get_stylebox("BottomPanelDebuggerOverride", "EditorStyles")->get_margin(MARGIN_LEFT));
-	add_constant_override("margin_right", -EditorNode::get_singleton()->get_gui_base()->get_stylebox("BottomPanelDebuggerOverride", "EditorStyles")->get_margin(MARGIN_RIGHT));
-
 	ppeer = Ref<PacketPeerStream>(memnew(PacketPeerStream));
 	ppeer->set_input_buffer_max_size((1024 * 1024 * 8) - 4); // 8 MiB should be enough, minus 4 bytes for separator.
 	editor = p_editor;
@@ -1545,8 +1543,6 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	tabs = memnew(TabContainer);
 	tabs->set_tab_align(TabContainer::ALIGN_LEFT);
 	tabs->add_style_override("panel", editor->get_gui_base()->get_stylebox("DebuggerPanel", "EditorStyles"));
-	tabs->add_style_override("tab_fg", editor->get_gui_base()->get_stylebox("DebuggerTabFG", "EditorStyles"));
-	tabs->add_style_override("tab_bg", editor->get_gui_base()->get_stylebox("DebuggerTabBG", "EditorStyles"));
 	tabs->connect_compat("tab_changed", this, "_tab_changed");
 
 	add_child(tabs);

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -238,6 +238,7 @@ public:
 	int get_stack_script_frame() const;
 
 	void update_tabs();
+	void clear_style();
 	String get_var_value(const String &p_var) const;
 
 	void save_node(ObjectID p_id, const String &p_file);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -852,8 +852,6 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<StyleBoxFlat> style_panel_debugger = style_content_panel->duplicate();
 	style_panel_debugger->set_border_width(MARGIN_BOTTOM, 0);
 	theme->set_stylebox("DebuggerPanel", "EditorStyles", style_panel_debugger);
-	theme->set_stylebox("DebuggerTabFG", "EditorStyles", style_tab_selected);
-	theme->set_stylebox("DebuggerTabBG", "EditorStyles", style_tab_unselected);
 
 	Ref<StyleBoxFlat> style_panel_invisible_top = style_content_panel->duplicate();
 	int stylebox_offset = theme->get_font("tab_fg", "TabContainer")->get_height() + theme->get_stylebox("tab_fg", "TabContainer")->get_minimum_size().height + theme->get_stylebox("panel", "TabContainer")->get_default_margin(MARGIN_TOP);


### PR DESCRIPTION
- Fixed (if I understood how they are supposed to work) naming of session tabs. Now being "Session 1...4" instead of "Debugger"/"Session 1...3".
- Start with session tabs invisible and show them when more than one is available.
- Improved margin visuals between `EditorDebuggerNode` and `ScriptEditorDebugger`.

@Faless Now, there is one last thing that I couldn't manage to fix myself, is that `EditorDebuggerNode` needs to be a `MarginContainer` that has a `TabContainer` child, so the margin workaround can be done to avoid this:
![Screenshot_20200222_011350](https://user-images.githubusercontent.com/30739239/75086229-bfe99d80-5529-11ea-89a0-91d28f379ac2.png)

I tried, but the editor refused to run.