### PR TITLE
[2.1] Fixed hang when segfaulting after OS object destroyed (OSX and X11)

### DIFF
--- a/platform/osx/crash_handler_osx.mm
+++ b/platform/osx/crash_handler_osx.mm
@@ -27,13 +27,13 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
+
 #include "main/main.h"
 #include "os_osx.h"
 
 #include <string.h>
 #include <unistd.h>
 
-// Note: Dump backtrace in 32bit mode is getting a bus error on the fgets by the ->execute, so enable only on 64bit
 #if defined(DEBUG_ENABLED) && defined(__x86_64__)
 #define CRASH_HANDLER_ENABLED 1
 #endif
@@ -72,8 +72,9 @@ static uint32_t load_address() {
 }
 
 static void handle_crash(int sig) {
-	if (OS::get_singleton() == NULL || Globals::get_singleton() == NULL)
-		return;
+	if (OS::get_singleton() == NULL) {
+		abort();
+	}
 
 	void *bt_buffer[256];
 	size_t size = backtrace(bt_buffer, 256);
@@ -82,6 +83,7 @@ static void handle_crash(int sig) {
 
 	// Dump the backtrace to stderr with a message to the user
 	fprintf(stderr, "%s: Program crashed with signal %d\n", __FUNCTION__, sig);
+
 	fprintf(stderr, "Dumping the backtrace. %ls\n", msg.c_str());
 	char **strings = backtrace_symbols(bt_buffer, size);
 	if (strings) {
@@ -155,6 +157,7 @@ CrashHandler::CrashHandler() {
 }
 
 CrashHandler::~CrashHandler() {
+	disable();
 }
 
 void CrashHandler::disable() {

--- a/platform/x11/crash_handler_x11.cpp
+++ b/platform/x11/crash_handler_x11.cpp
@@ -27,6 +27,7 @@
 /* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
+
 #ifdef DEBUG_ENABLED
 #define CRASH_HANDLER_ENABLED 1
 #endif
@@ -42,8 +43,9 @@
 #include <stdlib.h>
 
 static void handle_crash(int sig) {
-	if (OS::get_singleton() == NULL || Globals::get_singleton() == NULL)
-		return;
+	if (OS::get_singleton() == NULL) {
+		abort();
+	}
 
 	void *bt_buffer[256];
 	size_t size = backtrace(bt_buffer, 256);
@@ -52,6 +54,7 @@ static void handle_crash(int sig) {
 
 	// Dump the backtrace to stderr with a message to the user
 	fprintf(stderr, "%s: Program crashed with signal %d\n", __FUNCTION__, sig);
+
 	fprintf(stderr, "Dumping the backtrace. %ls\n", msg.c_str());
 	char **strings = backtrace_symbols(bt_buffer, size);
 	if (strings) {
@@ -112,6 +115,7 @@ CrashHandler::CrashHandler() {
 }
 
 CrashHandler::~CrashHandler() {
+	disable();
 }
 
 void CrashHandler::disable() {


### PR DESCRIPTION
Encountered the same issue today.

The two POSIX style crash handlers (OSX and X11) now remove their signal
handlers when they are destroyed.
Additonally if they are called while no OS singleton is set, they will
simply abort(). This should not happen now that they remove themselves,
but if a future change seperates OS object and crash handler lifetimes,
this may be easier to report/debug than hanging on SIGSEGV.

*Bugsquad edit:* Cherry-picked from commit 653b8324223414002e198eb2a8a685903186b97e.