### PR TITLE
doc: Sync classref with apparent Variant return type changes

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -83,6 +83,8 @@
 			</description>
 		</method>
 		<method name="append">
+			<return type="void">
+			</return>
 			<argument index="0" name="value" type="Variant">
 			</argument>
 			<description>
@@ -90,7 +92,7 @@
 			</description>
 		</method>
 		<method name="back">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<description>
 				Returns the last element of the array, or [code]null[/code] if the array is empty.
@@ -125,6 +127,8 @@
 			</description>
 		</method>
 		<method name="clear">
+			<return type="void">
+			</return>
 			<description>
 				Clears the array. This is equivalent to using [method resize] with a size of [code]0[/code].
 			</description>
@@ -156,6 +160,8 @@
 			</description>
 		</method>
 		<method name="erase">
+			<return type="void">
+			</return>
 			<argument index="0" name="value" type="Variant">
 			</argument>
 			<description>
@@ -183,7 +189,7 @@
 			</description>
 		</method>
 		<method name="front">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<description>
 				Returns the first element of the array, or [code]null[/code] if the array is empty.
@@ -212,6 +218,8 @@
 			</description>
 		</method>
 		<method name="insert">
+			<return type="void">
+			</return>
 			<argument index="0" name="position" type="int">
 			</argument>
 			<argument index="1" name="value" type="Variant">
@@ -221,39 +229,43 @@
 			</description>
 		</method>
 		<method name="invert">
+			<return type="void">
+			</return>
 			<description>
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="max">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<description>
 				Returns the maximum value contained in the array if all elements are of comparable types. If the elements can't be compared, [code]null[/code] is returned.
 			</description>
 		</method>
 		<method name="min">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<description>
 				Returns the minimum value contained in the array if all elements are of comparable types. If the elements can't be compared, [code]null[/code] is returned.
 			</description>
 		</method>
 		<method name="pop_back">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<description>
 				Removes and returns the last element of the array. Returns [code]null[/code] if the array is empty.
 			</description>
 		</method>
 		<method name="pop_front">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<description>
 				Removes and returns the first element of the array. Returns [code]null[/code] if the array is empty.
 			</description>
 		</method>
 		<method name="push_back">
+			<return type="void">
+			</return>
 			<argument index="0" name="value" type="Variant">
 			</argument>
 			<description>
@@ -261,6 +273,8 @@
 			</description>
 		</method>
 		<method name="push_front">
+			<return type="void">
+			</return>
 			<argument index="0" name="value" type="Variant">
 			</argument>
 			<description>
@@ -268,6 +282,8 @@
 			</description>
 		</method>
 		<method name="remove">
+			<return type="void">
+			</return>
 			<argument index="0" name="position" type="int">
 			</argument>
 			<description>
@@ -275,6 +291,8 @@
 			</description>
 		</method>
 		<method name="resize">
+			<return type="void">
+			</return>
 			<argument index="0" name="size" type="int">
 			</argument>
 			<description>
@@ -293,6 +311,8 @@
 			</description>
 		</method>
 		<method name="shuffle">
+			<return type="void">
+			</return>
 			<description>
 				Shuffles the array such that the items will have a random order. This method uses the global random number generator common to methods such as [method @GDScript.randi]. Call [method @GDScript.randomize] to ensure that a new seed will be used each time if you want non-reproducible shuffling.
 			</description>
@@ -320,6 +340,8 @@
 			</description>
 		</method>
 		<method name="sort">
+			<return type="void">
+			</return>
 			<description>
 				Sorts the array.
 				[b]Note:[/b] Strings are sorted in alphabetical order (as opposed to natural order). This may lead to unexpected behavior when sorting an array of strings ending with a sequence of numbers. Consider the following example:
@@ -331,6 +353,8 @@
 			</description>
 		</method>
 		<method name="sort_custom">
+			<return type="void">
+			</return>
 			<argument index="0" name="obj" type="Object">
 			</argument>
 			<argument index="1" name="func" type="String">

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -66,6 +66,8 @@
 	</tutorials>
 	<methods>
 		<method name="clear">
+			<return type="void">
+			</return>
 			<description>
 				Clear the dictionary, removing all key/value pairs.
 			</description>
@@ -96,7 +98,7 @@
 			</description>
 		</method>
 		<method name="get">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<argument index="0" name="key" type="Variant">
 			</argument>

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -20,6 +20,8 @@
 			</description>
 		</method>
 		<method name="append">
+			<return type="void">
+			</return>
 			<argument index="0" name="byte" type="int">
 			</argument>
 			<description>
@@ -27,6 +29,8 @@
 			</description>
 		</method>
 		<method name="append_array">
+			<return type="void">
+			</return>
 			<argument index="0" name="array" type="PackedByteArray">
 			</argument>
 			<description>
@@ -97,11 +101,15 @@
 			</description>
 		</method>
 		<method name="invert">
+			<return type="void">
+			</return>
 			<description>
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="push_back">
+			<return type="void">
+			</return>
 			<argument index="0" name="byte" type="int">
 			</argument>
 			<description>
@@ -109,6 +117,8 @@
 			</description>
 		</method>
 		<method name="remove">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -116,6 +126,8 @@
 			</description>
 		</method>
 		<method name="resize">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -123,6 +135,8 @@
 			</description>
 		</method>
 		<method name="set">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<argument index="1" name="byte" type="int">

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -20,6 +20,8 @@
 			</description>
 		</method>
 		<method name="append">
+			<return type="void">
+			</return>
 			<argument index="0" name="color" type="Color">
 			</argument>
 			<description>
@@ -27,6 +29,8 @@
 			</description>
 		</method>
 		<method name="append_array">
+			<return type="void">
+			</return>
 			<argument index="0" name="array" type="PackedColorArray">
 			</argument>
 			<description>
@@ -52,11 +56,15 @@
 			</description>
 		</method>
 		<method name="invert">
+			<return type="void">
+			</return>
 			<description>
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="push_back">
+			<return type="void">
+			</return>
 			<argument index="0" name="color" type="Color">
 			</argument>
 			<description>
@@ -64,6 +72,8 @@
 			</description>
 		</method>
 		<method name="remove">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -71,6 +81,8 @@
 			</description>
 		</method>
 		<method name="resize">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -78,6 +90,8 @@
 			</description>
 		</method>
 		<method name="set">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<argument index="1" name="color" type="Color">

--- a/doc/classes/PackedIntArray.xml
+++ b/doc/classes/PackedIntArray.xml
@@ -21,6 +21,8 @@
 			</description>
 		</method>
 		<method name="append">
+			<return type="void">
+			</return>
 			<argument index="0" name="integer" type="int">
 			</argument>
 			<description>
@@ -28,6 +30,8 @@
 			</description>
 		</method>
 		<method name="append_array">
+			<return type="void">
+			</return>
 			<argument index="0" name="array" type="PackedIntArray">
 			</argument>
 			<description>
@@ -53,11 +57,15 @@
 			</description>
 		</method>
 		<method name="invert">
+			<return type="void">
+			</return>
 			<description>
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="push_back">
+			<return type="void">
+			</return>
 			<argument index="0" name="integer" type="int">
 			</argument>
 			<description>
@@ -65,6 +73,8 @@
 			</description>
 		</method>
 		<method name="remove">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -72,6 +82,8 @@
 			</description>
 		</method>
 		<method name="resize">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -79,6 +91,8 @@
 			</description>
 		</method>
 		<method name="set">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<argument index="1" name="integer" type="int">

--- a/doc/classes/PackedRealArray.xml
+++ b/doc/classes/PackedRealArray.xml
@@ -20,6 +20,8 @@
 			</description>
 		</method>
 		<method name="append">
+			<return type="void">
+			</return>
 			<argument index="0" name="value" type="float">
 			</argument>
 			<description>
@@ -27,6 +29,8 @@
 			</description>
 		</method>
 		<method name="append_array">
+			<return type="void">
+			</return>
 			<argument index="0" name="array" type="PackedRealArray">
 			</argument>
 			<description>
@@ -52,11 +56,15 @@
 			</description>
 		</method>
 		<method name="invert">
+			<return type="void">
+			</return>
 			<description>
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="push_back">
+			<return type="void">
+			</return>
 			<argument index="0" name="value" type="float">
 			</argument>
 			<description>
@@ -64,6 +72,8 @@
 			</description>
 		</method>
 		<method name="remove">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -71,6 +81,8 @@
 			</description>
 		</method>
 		<method name="resize">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -78,6 +90,8 @@
 			</description>
 		</method>
 		<method name="set">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<argument index="1" name="value" type="float">

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -20,6 +20,8 @@
 			</description>
 		</method>
 		<method name="append">
+			<return type="void">
+			</return>
 			<argument index="0" name="string" type="String">
 			</argument>
 			<description>
@@ -27,6 +29,8 @@
 			</description>
 		</method>
 		<method name="append_array">
+			<return type="void">
+			</return>
 			<argument index="0" name="array" type="PackedStringArray">
 			</argument>
 			<description>
@@ -52,11 +56,15 @@
 			</description>
 		</method>
 		<method name="invert">
+			<return type="void">
+			</return>
 			<description>
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="push_back">
+			<return type="void">
+			</return>
 			<argument index="0" name="string" type="String">
 			</argument>
 			<description>
@@ -64,6 +72,8 @@
 			</description>
 		</method>
 		<method name="remove">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -71,6 +81,8 @@
 			</description>
 		</method>
 		<method name="resize">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -78,6 +90,8 @@
 			</description>
 		</method>
 		<method name="set">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<argument index="1" name="string" type="String">

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -20,6 +20,8 @@
 			</description>
 		</method>
 		<method name="append">
+			<return type="void">
+			</return>
 			<argument index="0" name="vector2" type="Vector2">
 			</argument>
 			<description>
@@ -27,6 +29,8 @@
 			</description>
 		</method>
 		<method name="append_array">
+			<return type="void">
+			</return>
 			<argument index="0" name="array" type="PackedVector2Array">
 			</argument>
 			<description>
@@ -52,11 +56,15 @@
 			</description>
 		</method>
 		<method name="invert">
+			<return type="void">
+			</return>
 			<description>
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="push_back">
+			<return type="void">
+			</return>
 			<argument index="0" name="vector2" type="Vector2">
 			</argument>
 			<description>
@@ -64,6 +72,8 @@
 			</description>
 		</method>
 		<method name="remove">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -71,6 +81,8 @@
 			</description>
 		</method>
 		<method name="resize">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -78,6 +90,8 @@
 			</description>
 		</method>
 		<method name="set">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<argument index="1" name="vector2" type="Vector2">

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -20,6 +20,8 @@
 			</description>
 		</method>
 		<method name="append">
+			<return type="void">
+			</return>
 			<argument index="0" name="vector3" type="Vector3">
 			</argument>
 			<description>
@@ -27,6 +29,8 @@
 			</description>
 		</method>
 		<method name="append_array">
+			<return type="void">
+			</return>
 			<argument index="0" name="array" type="PackedVector3Array">
 			</argument>
 			<description>
@@ -52,11 +56,15 @@
 			</description>
 		</method>
 		<method name="invert">
+			<return type="void">
+			</return>
 			<description>
 				Reverses the order of the elements in the array.
 			</description>
 		</method>
 		<method name="push_back">
+			<return type="void">
+			</return>
 			<argument index="0" name="vector3" type="Vector3">
 			</argument>
 			<description>
@@ -64,6 +72,8 @@
 			</description>
 		</method>
 		<method name="remove">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -71,6 +81,8 @@
 			</description>
 		</method>
 		<method name="resize">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
@@ -78,6 +90,8 @@
 			</description>
 		</method>
 		<method name="set">
+			<return type="void">
+			</return>
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<argument index="1" name="vector3" type="Vector3">

--- a/doc/classes/Quat.xml
+++ b/doc/classes/Quat.xml
@@ -132,6 +132,8 @@
 			</description>
 		</method>
 		<method name="set_axis_angle">
+			<return type="void">
+			</return>
 			<argument index="0" name="axis" type="Vector3">
 			</argument>
 			<argument index="1" name="angle" type="float">
@@ -141,6 +143,8 @@
 			</description>
 		</method>
 		<method name="set_euler">
+			<return type="void">
+			</return>
 			<argument index="0" name="euler" type="Vector3">
 			</argument>
 			<description>

--- a/doc/classes/Transform.xml
+++ b/doc/classes/Transform.xml
@@ -149,7 +149,7 @@
 			</description>
 		</method>
 		<method name="xform">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<argument index="0" name="v" type="Variant">
 			</argument>
@@ -158,7 +158,7 @@
 			</description>
 		</method>
 		<method name="xform_inv">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<argument index="0" name="v" type="Variant">
 			</argument>

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -151,7 +151,7 @@
 			</description>
 		</method>
 		<method name="xform">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<argument index="0" name="v" type="Variant">
 			</argument>
@@ -160,7 +160,7 @@
 			</description>
 		</method>
 		<method name="xform_inv">
-			<return type="Variant">
+			<return type="void">
 			</return>
 			<argument index="0" name="v" type="Variant">
 			</argument>


### PR DESCRIPTION
Part of those seem bogus, methods like Array.back()/front()
should return a Variant and not void.

This PR actually makes the docs incorrect, but we need to check in changes nevertheless so that we can keep using `doctool` to sync valid changes. I'll open a bug report about those (*Edit:* #36453).