### PR TITLE
Vulkan: Work around false positive on 64-bit Linux w/ 32-bit ICDs

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -29,11 +29,14 @@
 /*************************************************************************/
 
 #include "vulkan_context.h"
+
 #include "core/engine.h"
 #include "core/project_settings.h"
 #include "core/ustring.h"
 #include "core/version.h"
+
 #include "vk_enum_string_helper.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -47,14 +50,18 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanContext::_debug_messenger_callback(VkDebugU
 		const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData,
 		void *pUserData) {
 
-	//This error needs to be ignored because the AMD allocator will mix up memory types on IGP processors
+	// This error needs to be ignored because the AMD allocator will mix up memory types on IGP processors.
 	if (strstr(pCallbackData->pMessage, "Mapping an image with layout") != NULL &&
 			strstr(pCallbackData->pMessage, "can result in undefined behavior if this memory is used by the device") != NULL) {
 		return VK_FALSE;
 	}
-	// This needs to be ignored because Validator is wrong here
+	// This needs to be ignored because Validator is wrong here.
 	if (strstr(pCallbackData->pMessage, "SPIR-V module not valid: Pointer operand") != NULL &&
 			strstr(pCallbackData->pMessage, "must be a memory object") != NULL) {
+		return VK_FALSE;
+	}
+	// Workaround for Vulkan-Loader usability bug: https://github.com/KhronosGroup/Vulkan-Loader/issues/262.
+	if (strstr(pCallbackData->pMessage, "wrong ELF class: ELFCLASS32") != NULL) {
 		return VK_FALSE;
 	}
 	if (strstr(pCallbackData->pMessageIdName, "UNASSIGNED-CoreValidation-DrawState-ClearCmdBeforeDraw") != NULL) {


### PR DESCRIPTION
In the vast majority of cases, this will be a false positive error
thrown by Vulkan-Loader when a Linux system has Vulkan ICDs for both
32-bit and 64-bit. The error is of the form:
```
ERROR: [Loader Message] Code 0 : /usr/lib/libvulkan_intel.so: wrong ELF class: ELFCLASS32
ERROR: [Loader Message] Code 0 : /usr/lib/libvulkan_radeon.so: wrong ELF class: ELFCLASS32
```

The loader dlopen's the 32-bit ICDs first, raises this error, and then
happily goes on to try and use the 64-bit ICDs.

Upstream report: https://github.com/KhronosGroup/Vulkan-Loader/issues/262

Fixes #36185.