### PR TITLE
SCons: Bump required C++ standard to C++17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 
 # OS config, depends on actual 'os' in build matrix
-dist: xenial
+dist: bionic
 
 stages:
   - build
@@ -26,8 +26,6 @@ matrix:
       compiler: gcc
       addons:
         apt:
-          sources:
-            - llvm-toolchain-xenial-8
           packages:
             - clang-format-8
 
@@ -39,14 +37,15 @@ matrix:
       addons:
         apt:
           sources:
-            - mono
-            - ubuntu-toolchain-r-test
+            - sourceline: "deb https://download.mono-project.com/repo/ubuntu stable-bionic main"
+              key_url: "https://raw.githubusercontent.com/travis-ci/apt-source-safelist/master/keys/mono.asc"
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - &gcc9_deps [gcc-9, g++-9]
             - &linux_deps [libasound2-dev, libgl1-mesa-dev, libglu1-mesa-dev, libx11-dev, libxcursor-dev, libxi-dev, libxinerama-dev, libxrandr-dev]
             - &linux_mono_deps [mono-devel, msbuild, nuget]
 
-    - name: Linux export template (release, Clang)
+    - name: Linux export template (release, Clang 7)
       stage: build
       env: PLATFORM=x11 TOOLS=no TARGET=release CACHE_NAME=${PLATFORM}-clang EXTRA_ARGS="warnings=extra werror=yes"
       os: linux
@@ -101,14 +100,14 @@ matrix:
 #      addons:
 #        apt:
 #          sources:
-#            - ubuntu-toolchain-r-test
+#            - sourceline: "ppa:ubuntu-toolchain-r/test"
 #          packages:
 #            - *gcc9_deps
 #            - *linux_deps
 
-    - name: Linux export template (release_debug, GCC 5, without 3D support)
+    - name: Linux export template (release_debug, GCC 7, without 3D support)
       stage: build
-      env: PLATFORM=x11 TOOLS=no TARGET=release_debug CACHE_NAME=${PLATFORM}-gcc-5 EXTRA_ARGS="CXXFLAGS=-fno-strict-aliasing disable_3d=yes"
+      env: PLATFORM=x11 TOOLS=no TARGET=release_debug CACHE_NAME=${PLATFORM}-gcc-7 EXTRA_ARGS="disable_3d=yes"
       os: linux
       compiler: gcc
       addons:
@@ -124,7 +123,7 @@ before_install:
 
 install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      pyenv global 3.7.1 system;
+      pyenv global 3.7.5 system;
       pip3 install --user scons;
     fi
   - scons --version

--- a/SConstruct
+++ b/SConstruct
@@ -310,17 +310,17 @@ if selected_platform in platform_list:
     env.Append(LINKFLAGS=str(LINKFLAGS).split())
 
     # Set our C and C++ standard requirements.
-    # Prepending to make it possible to override
+    # C++17 is required as we need guaranteed copy elision as per GH-36436.
+    # Prepending to make it possible to override.
     if not env.msvc:
         # Specifying GNU extensions support explicitly, which are supported by
-        # both GCC and Clang. This mirrors GCC and Clang's current default
-        # compile flags if no -std is specified.
+        # both GCC and Clang. Both currently default to gnu11 and gnu++14.
         env.Prepend(CFLAGS=['-std=gnu11'])
-        env.Prepend(CXXFLAGS=['-std=gnu++14'])
+        env.Prepend(CXXFLAGS=['-std=gnu++17'])
     else:
         # MSVC doesn't have clear C standard support, /std only covers C++.
         # We apply it to CCFLAGS (both C and C++ code) in case it impacts C features.
-        env.Prepend(CCFLAGS=['/std:c++14', '/permissive-'])
+        env.Prepend(CCFLAGS=['/std:c++17', '/permissive-'])
 
     # Platform specific flags
     flag_list = platform_flags[selected_platform]

--- a/misc/dist/osx_template.app/Contents/Info.plist
+++ b/misc/dist/osx_template.app/Contents/Info.plist
@@ -31,11 +31,11 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>$copyright</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.9.0</string>
+	<string>10.12.0</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>x86_64</key>
-		<string>10.9.0</string>
+		<string>10.12.0</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	$highres

--- a/misc/dist/osx_tools.app/Contents/Info.plist
+++ b/misc/dist/osx_tools.app/Contents/Info.plist
@@ -33,11 +33,11 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2007-2020 Juan Linietsky, Ariel Manzur &amp; Godot Engine contributors</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.9.0</string>
+	<string>10.12.0</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>x86_64</key>
-		<string>10.9.0</string>
+		<string>10.12.0</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -164,5 +164,5 @@ def configure(env):
 
     #env.Append(CPPDEFINES=['GLES_ENABLED', 'OPENGL_ENABLED'])
 
-    env.Append(CCFLAGS=['-mmacosx-version-min=10.11'])
-    env.Append(LINKFLAGS=['-mmacosx-version-min=10.11'])
+    env.Append(CCFLAGS=['-mmacosx-version-min=10.12'])
+    env.Append(LINKFLAGS=['-mmacosx-version-min=10.12'])

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -747,7 +747,7 @@ static void _mouseDownEvent(NSEvent *event, int index, int mask, bool pressed) {
 	const Vector2 pos = get_mouse_pos([event locationInWindow], backingScaleFactor);
 	mm->set_position(pos);
 	mm->set_pressure([event pressure]);
-	if ([event subtype] == NSTabletPointEventSubtype) {
+	if ([event subtype] == NSEventSubtypeTabletPoint) {
 		const NSPoint p = [event tilt];
 		mm->set_tilt(Vector2(p.x, p.y));
 	}
@@ -1757,7 +1757,7 @@ void OS_OSX::alert(const String &p_alert, const String &p_title) {
 	[window addButtonWithTitle:@"OK"];
 	[window setMessageText:ns_title];
 	[window setInformativeText:ns_alert];
-	[window setAlertStyle:NSWarningAlertStyle];
+	[window setAlertStyle:NSAlertStyleWarning];
 
 	// Display it, then release
 	[window runModal];


### PR DESCRIPTION
## SCons: Bump required C++ standard to C++17

As per #36436, we now need C++17's guaranteed copy elision feature to
solve ambiguities in Variant.

Core developers discussed the idea to move from C++14 to C++17 as our
minimum required C++ standard, and all agreed. Note that this doesn't
mean that Godot is going to be written in "modern C++", but we'll use
modern features where they make sense to simplify our "C with classes"
codebase. Apart from new code written recently, most of the codebase
still has to be ported to use newer features where relevant.

Proper support for C++17 means that we need recent compiler versions:

 - GCC 7+
 - Clang 6+
 - VS 2017 15.7+
 - Xcode 10+

Additionally, C++17's `std::shared_mutex` (conditionally used by
`vk_mem_alloc.h` when C++17 support is enabled) is only available in
**macOS 10.12+**, so we increase our minimum supported version.

---

## Travis: Use Ubuntu 18.04 (bionic) as base image

It's now available and allows us to have a better default environment,
with GCC 7.4.0 and Clang 7.

We now need GCC 7+ for C++17 support so it's more efficient to upgrade
the image than to install it on Ubuntu 16.04 (xenial).

Also fixes a couple -Wdeprecated-declarations warnings on macOS now
that we build against macOS 10.12.