### PR TITLE
Replace FALLTHROUGH macro by C++17 [[fallthrough]]

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -360,8 +360,6 @@ if selected_platform in platform_list:
                 shadow_local_warning = ['-Wshadow-local']
 
         if (env["warnings"] == 'extra'):
-            # Note: enable -Wimplicit-fallthrough for Clang (already part of -Wextra for GCC)
-            # once we switch to C++11 or later (necessary for our FALLTHROUGH macro).
             env.Append(CCFLAGS=['-Wall', '-Wextra', '-Wno-unused-parameter']
                 + all_plus_warnings + shadow_local_warning)
             env.Append(CXXFLAGS=['-Wctor-dtor-privacy', '-Wnon-virtual-dtor'])
@@ -374,6 +372,8 @@ if selected_platform in platform_list:
                 version = methods.get_compiler_version(env)
                 if version != None and version[0] >= '9':
                     env.Append(CCFLAGS=['-Wattribute-alias=2'])
+            if methods.using_clang(env):
+                env.Append(CCFLAGS=['-Wimplicit-fallthrough'])
         elif (env["warnings"] == 'all'):
             env.Append(CCFLAGS=['-Wall'] + shadow_local_warning)
         elif (env["warnings"] == 'moderate'):

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -51,7 +51,7 @@ _FORCE_INLINE_ bool _should_call_local(MultiplayerAPI::RPCMode mode, bool is_mas
 		case MultiplayerAPI::RPC_MODE_MASTERSYNC: {
 			if (is_master)
 				r_skip_rpc = true; // I am the master, so skip remote call.
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case MultiplayerAPI::RPC_MODE_REMOTESYNC:
 		case MultiplayerAPI::RPC_MODE_PUPPETSYNC: {

--- a/core/packed_data_container.cpp
+++ b/core/packed_data_container.cpp
@@ -225,8 +225,8 @@ uint32_t PackedDataContainer::_pack(const Variant &p_data, Vector<uint8_t> &tmpd
 
 			string_cache[s] = tmpdata.size();
 
-			FALLTHROUGH;
-		};
+			[[fallthrough]];
+		}
 		case Variant::NIL:
 		case Variant::BOOL:
 		case Variant::INT:

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -335,28 +335,6 @@ struct _GlobalLock {
  */
 #define CAST_INT_TO_UCHAR_PTR(ptr) ((uint8_t *)(uintptr_t)(ptr))
 
-/** Hint for compilers that this fallthrough in a switch is intentional.
- *  Can be replaced by [[fallthrough]] annotation if we move to C++17.
- *  Including conditional support for it for people who set -std=c++17
- *  themselves.
- *  Requires a trailing semicolon when used.
- */
-#if __cplusplus >= 201703L
-#define FALLTHROUGH [[fallthrough]]
-#elif defined(__GNUC__) && __GNUC__ >= 7
-#define FALLTHROUGH __attribute__((fallthrough))
-#elif defined(__llvm__) && __cplusplus >= 201103L && defined(__has_feature)
-#if __has_feature(cxx_attributes) && defined(__has_warning)
-#if __has_warning("-Wimplicit-fallthrough")
-#define FALLTHROUGH [[clang::fallthrough]]
-#endif
-#endif
-#endif
-
-#ifndef FALLTHROUGH
-#define FALLTHROUGH
-#endif
-
 // Home-made index sequence trick, so it can be used everywhere without the costly include of std::tuple.
 // https://stackoverflow.com/questions/15014096/c-index-of-type-during-variadic-template-expansion
 

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2169,6 +2169,7 @@ int64_t String::to_int(const CharType *p_str, int p_len) {
 				} else {
 					break;
 				}
+				[[fallthrough]];
 			}
 			case READING_INT: {
 

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -216,7 +216,7 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 				}
 
 				string_name = true;
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			case '"': {
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2178,7 +2178,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				break;
 			}
 
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case SCENE_TAB_CLOSE:
 		case FILE_SAVE_SCENE: {
@@ -2199,7 +2199,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 				break;
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case FILE_SAVE_AS_SCENE: {
 			int scene_idx = (p_option == FILE_SAVE_SCENE || p_option == FILE_SAVE_AS_SCENE) ? -1 : tab_closing;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3100,7 +3100,7 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 			case DRAG_TOP_LEFT:
 			case DRAG_BOTTOM_LEFT:
 				_draw_margin_at_position(control->get_size().width, parent_transform.xform(Vector2((node_pos_in_parent[0] + node_pos_in_parent[2]) / 2, node_pos_in_parent[3])) + Vector2(0, 5), MARGIN_BOTTOM);
-				FALLTHROUGH;
+				[[fallthrough]];
 			case DRAG_MOVE:
 				start = Vector2(node_pos_in_parent[0], Math::lerp(node_pos_in_parent[1], node_pos_in_parent[3], ratio));
 				end = start - Vector2(control->get_margin(MARGIN_LEFT), 0);
@@ -3115,7 +3115,7 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 			case DRAG_TOP_RIGHT:
 			case DRAG_BOTTOM_RIGHT:
 				_draw_margin_at_position(control->get_size().width, parent_transform.xform(Vector2((node_pos_in_parent[0] + node_pos_in_parent[2]) / 2, node_pos_in_parent[3])) + Vector2(0, 5), MARGIN_BOTTOM);
-				FALLTHROUGH;
+				[[fallthrough]];
 			case DRAG_MOVE:
 				start = Vector2(node_pos_in_parent[2], Math::lerp(node_pos_in_parent[3], node_pos_in_parent[1], ratio));
 				end = start - Vector2(control->get_margin(MARGIN_RIGHT), 0);
@@ -3130,7 +3130,7 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 			case DRAG_TOP_LEFT:
 			case DRAG_TOP_RIGHT:
 				_draw_margin_at_position(control->get_size().height, parent_transform.xform(Vector2(node_pos_in_parent[2], (node_pos_in_parent[1] + node_pos_in_parent[3]) / 2)) + Vector2(5, 0), MARGIN_RIGHT);
-				FALLTHROUGH;
+				[[fallthrough]];
 			case DRAG_MOVE:
 				start = Vector2(Math::lerp(node_pos_in_parent[0], node_pos_in_parent[2], ratio), node_pos_in_parent[1]);
 				end = start - Vector2(0, control->get_margin(MARGIN_TOP));
@@ -3145,7 +3145,7 @@ void CanvasItemEditor::_draw_control_helpers(Control *control) {
 			case DRAG_BOTTOM_LEFT:
 			case DRAG_BOTTOM_RIGHT:
 				_draw_margin_at_position(control->get_size().height, parent_transform.xform(Vector2(node_pos_in_parent[2], (node_pos_in_parent[1] + node_pos_in_parent[3]) / 2) + Vector2(5, 0)), MARGIN_RIGHT);
-				FALLTHROUGH;
+				[[fallthrough]];
 			case DRAG_MOVE:
 				start = Vector2(Math::lerp(node_pos_in_parent[2], node_pos_in_parent[0], ratio), node_pos_in_parent[3]);
 				end = start - Vector2(0, control->get_margin(MARGIN_BOTTOM));

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -214,7 +214,7 @@ void ScriptEditorQuickOpen::_notification(int p_what) {
 			connect_compat("confirmed", this, "_confirmed");
 
 			search_box->set_clear_button_enabled(true);
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
 			search_box->set_right_icon(get_icon("Search", "EditorIcons"));
@@ -900,7 +900,7 @@ void ScriptEditor::_file_dialog_action(String p_file) {
 			}
 			file->close();
 			memdelete(file);
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case FILE_OPEN: {
 
@@ -1396,7 +1396,7 @@ void ScriptEditor::_notification(int p_what) {
 			script_split->connect_compat("dragged", this, "_script_split_dragged");
 
 			EditorSettings::get_singleton()->connect_compat("settings_changed", this, "_editor_settings_changed");
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
 

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -234,7 +234,7 @@ void SpriteFramesEditor::_notification(int p_what) {
 			_delete->set_icon(get_icon("Remove", "EditorIcons"));
 			new_anim->set_icon(get_icon("New", "EditorIcons"));
 			remove_anim->set_icon(get_icon("Remove", "EditorIcons"));
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
 			splite_sheet_scroll->add_style_override("bg", get_stylebox("bg", "Tree"));

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -55,7 +55,7 @@ void TileMapEditor::_notification(int p_what) {
 			if (is_visible_in_tree()) {
 				_update_palette();
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 
 		case NOTIFICATION_ENTER_TREE: {

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -260,7 +260,7 @@ void EditorQuickOpen::_notification(int p_what) {
 			connect_compat("confirmed", this, "_confirmed");
 
 			search_box->set_clear_button_enabled(true);
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
 			search_box->set_right_icon(get_icon("Search", "EditorIcons"));

--- a/main/tests/test_gdscript.cpp
+++ b/main/tests/test_gdscript.cpp
@@ -128,7 +128,7 @@ static String _parser_expr(const GDScriptParser::Node *p_expr) {
 
 				case GDScriptParser::OperatorNode::OP_PARENT_CALL:
 					txt += ".";
-					FALLTHROUGH;
+					[[fallthrough]];
 				case GDScriptParser::OperatorNode::OP_CALL: {
 
 					ERR_FAIL_COND_V(c_node->arguments.size() < 1, "");

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2565,7 +2565,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path
 		} break;
 		case GDScriptParser::COMPLETION_FUNCTION: {
 			is_function = true;
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case GDScriptParser::COMPLETION_IDENTIFIER: {
 			_find_identifiers(context, is_function, options);
@@ -2608,7 +2608,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path
 		} break;
 		case GDScriptParser::COMPLETION_METHOD: {
 			is_function = true;
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case GDScriptParser::COMPLETION_INDEX: {
 			const GDScriptParser::Node *node = parser.get_completion_node();
@@ -3330,7 +3330,7 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 		case GDScriptParser::COMPLETION_PARENT_FUNCTION:
 		case GDScriptParser::COMPLETION_FUNCTION: {
 			is_function = true;
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case GDScriptParser::COMPLETION_IDENTIFIER: {
 
@@ -3462,7 +3462,7 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 		} break;
 		case GDScriptParser::COMPLETION_METHOD: {
 			is_function = true;
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case GDScriptParser::COMPLETION_INDEX: {
 			const GDScriptParser::Node *node = parser.get_completion_node();

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -793,7 +793,7 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 								}
 								_add_warning(GDScriptWarning::UNASSIGNED_VARIABLE_OP_ASSIGN, -1, identifier.operator String());
 							}
-							FALLTHROUGH;
+							[[fallthrough]];
 						}
 						case GDScriptTokenizer::TK_OP_ASSIGN: {
 							lv->assignments += 1;
@@ -2766,13 +2766,12 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 		}
 #endif // DEBUG_ENABLED
 		switch (token) {
-			case GDScriptTokenizer::TK_EOF:
+			case GDScriptTokenizer::TK_EOF: {
 				p_block->end_line = tokenizer->get_token_line();
+				return; // End of file!
+			} break;
 			case GDScriptTokenizer::TK_ERROR: {
-				return; //go back
-
-				//end of file!
-
+				return;
 			} break;
 			case GDScriptTokenizer::TK_NEWLINE: {
 
@@ -3525,11 +3524,12 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 			case GDScriptTokenizer::TK_CURSOR: {
 				tokenizer->advance();
 			} break;
-			case GDScriptTokenizer::TK_EOF:
+			case GDScriptTokenizer::TK_EOF: {
 				p_class->end_line = tokenizer->get_token_line();
+				return; // End of file!
+			} break;
 			case GDScriptTokenizer::TK_ERROR: {
-				return; //go back
-				//end of file!
+				return; // Go back.
 			} break;
 			case GDScriptTokenizer::TK_NEWLINE: {
 				if (!_parse_newline()) {
@@ -3719,7 +3719,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 					return;
 				}
 
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			case GDScriptTokenizer::TK_PR_FUNCTION: {
 
@@ -4220,7 +4220,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 										break;
 									}
 
-									FALLTHROUGH;
+									[[fallthrough]];
 								}
 								case Variant::REAL: {
 
@@ -5489,7 +5489,7 @@ String GDScriptParser::DataType::to_string() const {
 			if (!gds_class.empty()) {
 				return gds_class;
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case SCRIPT: {
 			if (is_meta_type) {
@@ -8345,7 +8345,7 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 				if (cn->value.get_type() == Variant::STRING) {
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			default: {
 				_mark_line_as_safe(statement->line);

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -340,7 +340,7 @@ StringName GDScriptTokenizer::get_token_literal(int p_offset) const {
 				default: {
 				}
 			}
-		}
+		} break;
 		case TK_OP_AND:
 		case TK_OP_OR:
 			break; // Don't get into default, since they can be non-literal
@@ -536,7 +536,7 @@ void GDScriptTokenizerText::_advance() {
 					ignore_warnings = true;
 				}
 #endif // DEBUG_ENABLED
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			case '\n': {
 				line++;
@@ -753,7 +753,7 @@ void GDScriptTokenizerText::_advance() {
 				}
 				INCPOS(1);
 				is_string_name = true;
-				FALLTHROUGH;
+				[[fallthrough]];
 			case '\'':
 			case '"': {
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3906,7 +3906,7 @@ void VisualScriptEditor::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			variable_editor->connect_compat("changed", this, "_update_members");
 			signal_editor->connect_compat("changed", this, "_update_members");
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
 			if (p_what != NOTIFICATION_READY && !is_visible_in_tree()) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -709,7 +709,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 					break;
 				}
 			}
-			FALLTHROUGH;
+			[[fallthrough]];
 		case WM_MBUTTONDOWN:
 		case WM_MBUTTONUP:
 		case WM_RBUTTONDOWN:
@@ -984,7 +984,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			if (wParam==VK_WIN) TODO wtf is this?
 				meta_mem=uMsg==WM_KEYDOWN;
 			*/
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case WM_CHAR: {
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -98,11 +98,18 @@ static const Vector3 speaker_directions[7] = {
 void AudioStreamPlayer3D::_calc_output_vol(const Vector3 &source_dir, real_t tightness, AudioStreamPlayer3D::Output &output) {
 	unsigned int speaker_count; // only main speakers (no LFE)
 	switch (AudioServer::get_singleton()->get_speaker_mode()) {
-		default: //fallthrough
-		case AudioServer::SPEAKER_MODE_STEREO: speaker_count = 2; break;
-		case AudioServer::SPEAKER_SURROUND_31: speaker_count = 3; break;
-		case AudioServer::SPEAKER_SURROUND_51: speaker_count = 5; break;
-		case AudioServer::SPEAKER_SURROUND_71: speaker_count = 7; break;
+		case AudioServer::SPEAKER_MODE_STEREO:
+			speaker_count = 2;
+			break;
+		case AudioServer::SPEAKER_SURROUND_31:
+			speaker_count = 3;
+			break;
+		case AudioServer::SPEAKER_SURROUND_51:
+			speaker_count = 5;
+			break;
+		case AudioServer::SPEAKER_SURROUND_71:
+			speaker_count = 7;
+			break;
 	}
 
 	Spcap spcap(speaker_count, speaker_directions); //TODO: should only be created/recreated once the speaker mode / speaker positions changes
@@ -113,18 +120,19 @@ void AudioStreamPlayer3D::_calc_output_vol(const Vector3 &source_dir, real_t tig
 		case AudioServer::SPEAKER_SURROUND_71:
 			output.vol[3].l = volumes[5]; // side-left
 			output.vol[3].r = volumes[6]; // side-right
-			//fallthrough
+			[[fallthrough]];
 		case AudioServer::SPEAKER_SURROUND_51:
 			output.vol[2].l = volumes[3]; // rear-left
 			output.vol[2].r = volumes[4]; // rear-right
-			//fallthrough
+			[[fallthrough]];
 		case AudioServer::SPEAKER_SURROUND_31:
 			output.vol[1].r = 1.0; // LFE - always full power
 			output.vol[1].l = volumes[2]; // center
-			//fallthrough
+			[[fallthrough]];
 		case AudioServer::SPEAKER_MODE_STEREO:
 			output.vol[0].r = volumes[1]; // front-right
 			output.vol[0].l = volumes[0]; // front-left
+			break;
 	}
 }
 

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -106,7 +106,7 @@ void Button::_notification(int p_what) {
 
 						break;
 					}
-					FALLTHROUGH;
+					[[fallthrough]];
 				}
 				case DRAW_PRESSED: {
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -355,7 +355,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 						handled = false;
 						break;
 					}
-					FALLTHROUGH;
+					[[fallthrough]];
 				}
 				case KEY_LEFT: {
 
@@ -402,7 +402,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 						handled = false;
 						break;
 					}
-					FALLTHROUGH;
+					[[fallthrough]];
 				}
 				case KEY_RIGHT: {
 
@@ -509,7 +509,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 						handled = false;
 						break;
 					}
-					FALLTHROUGH;
+					[[fallthrough]];
 				}
 				case KEY_HOME: {
 
@@ -522,7 +522,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 						handled = false;
 						break;
 					}
-					FALLTHROUGH;
+					[[fallthrough]];
 				}
 				case KEY_END: {
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3068,7 +3068,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					scancode_handled = false;
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			case KEY_LEFT: {
 
@@ -3144,7 +3144,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					scancode_handled = false;
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			case KEY_RIGHT: {
 
@@ -3205,7 +3205,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					scancode_handled = false;
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			case KEY_UP: {
 
@@ -3258,7 +3258,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					scancode_handled = false;
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			case KEY_DOWN: {
 
@@ -3381,7 +3381,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					scancode_handled = false;
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			case KEY_HOME: {
 #ifdef APPLE_STYLE_KEYS
@@ -3442,7 +3442,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					scancode_handled = false;
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			case KEY_END: {
 #ifdef APPLE_STYLE_KEYS
@@ -3489,7 +3489,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					scancode_handled = false;
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			case KEY_PAGEUP: {
 
@@ -3512,7 +3512,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					scancode_handled = false;
 					break;
 				}
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			case KEY_PAGEDOWN: {
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1020,7 +1020,7 @@ int Tree::compute_item_height(TreeItem *p_item) const {
 				int check_icon_h = cache.checked->get_height();
 				if (height < check_icon_h)
 					height = check_icon_h;
-				FALLTHROUGH;
+				[[fallthrough]];
 			}
 			case TreeItem::CELL_MODE_STRING:
 			case TreeItem::CELL_MODE_CUSTOM:

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -189,7 +189,7 @@ void ParticlesMaterial::_update_shader() {
 		} break;
 		case EMISSION_SHAPE_DIRECTED_POINTS: {
 			code += "uniform sampler2D emission_texture_normal : hint_black;\n";
-			FALLTHROUGH;
+			[[fallthrough]];
 		}
 		case EMISSION_SHAPE_POINTS: {
 			code += "uniform sampler2D emission_texture_points : hint_black;\n";

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1080,7 +1080,7 @@ public:
 						const Item::CommandTransform *transform = static_cast<const Item::CommandTransform *>(c);
 						xf = transform->xform;
 						found_xform = true;
-						FALLTHROUGH;
+						[[fallthrough]];
 					}
 					default: {
 						c = c->next;


### PR DESCRIPTION
This attribute is now part of the standard we target so we no longer
need compiler-specific hacks.

Also enables -Wimplicit-fallthrough for Clang now that we can properly
support it. It's already on by default for GCC's -Wextra.