### PR TITLE
Travis: Use Xcode 11.3 for macOS/iOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ matrix:
       stage: build
       env: PLATFORM=osx TOOLS=yes TARGET=debug CACHE_NAME=${PLATFORM}-tools-clang EXTRA_ARGS="warnings=extra werror=yes"
       os: osx
+      osx_image: xcode11.3
       compiler: clang
       addons:
         homebrew:
@@ -84,6 +85,7 @@ matrix:
 #      stage: build
 #      env: PLATFORM=iphone TOOLS=no TARGET=debug CACHE_NAME=${PLATFORM}-clang
 #      os: osx
+#      osx_image: xcode11.3
 #      compiler: clang
 #      addons:
 #        homebrew:


### PR DESCRIPTION
Xcode 10+ is needed for exhaustive C++17 support (gnu++17).

11.3 is the latest available version on Travis, and we don't have a
specific reason not to use it.

Follow-up to #36457.