### PR TITLE
Change CRASH_COND to ERR_FAIL in Cowdata::set

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -142,7 +142,7 @@ public:
 	_FORCE_INLINE_ bool is_empty() const { return _ptr == nullptr; }
 
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) {
-		CRASH_BAD_INDEX(p_index, size());
+		ERR_FAIL_INDEX(p_index, size());
 		_copy_on_write();
 		_get_data()[p_index] = p_elem;
 	}


### PR DESCRIPTION
Fixes #46395


Since #36311, some functions which used to ERR_FAIL macro inside PoolVector `set` function like 
```
void Line2D::set_point_position(int i, Vector2 p_pos) {
	_points.set(i, p_pos);
	update();
}
```
now use Vector `set` function with CRASH_COND which cause a lot of crashes

Vector.h set function now
https://github.com/godotengine/godot/blob/63b0d822d109f3612d5c22e4342ebef9cd3b9163/core/vector.h#L83
and inside cowdata
https://github.com/godotengine/godot/blob/6fc50d785e98bbd1d82755630345b692c8fc153b/core/cowdata.h#L136-L141

and PoolVector function
https://github.com/godotengine/godot/blob/6fc50d785e98bbd1d82755630345b692c8fc153b/core/pool_vector.h#L490-L497