### PR TITLE
Fixed crash when connecting a signal in GDScript

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1311,6 +1311,8 @@ Variant::operator uint64_t() const {
 Variant::operator ObjectID() const {
 	if (type == INT) {
 		return ObjectID(_data._int);
+	} else if (type == OBJECT) {
+		return _get_obj().id;
 	} else {
 		return ObjectID();
 	}


### PR DESCRIPTION
This PR helps with the crashes from #36444, but it doesn't fully solve it as there are still script errors when trying to construct a `Callable` with `self` directly.

This code requires casting a `Variant` of type `Object` to `ObjectID`:
https://github.com/godotengine/godot/blob/c9e1d98c6287a00cd003f19e57207da6e174d6b4/core/variant_call.cpp#L1071-L1074

I've also put checks for valid objects at the very beginning of `connect()` and `disconnect()` methods to return with an error immediately when this case happens.