### PR TITLE
Fix Breakpoint compare in new Debugger.

### DIFF
--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -59,7 +59,7 @@ private:
 
 		bool operator<(const Breakpoint &p_b) const {
 			if (line == p_b.line)
-				return line < p_b.line;
+				return source < p_b.source;
 			return line < p_b.line;
 		}
 


### PR DESCRIPTION
Only used to keep the hashmap, but clearly bogus.

Fixes #36477 .