### PR TITLE
SCons: Add GCC/Clang minimum version check

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -550,11 +550,13 @@ def detect_darwin_sdk_path(platform, env):
             raise
 
 def get_compiler_version(env):
-    # Not using this method on clang because it returns 4.2.1 # https://reviews.llvm.org/D56803
     if using_gcc(env):
         version = decode_utf8(subprocess.check_output([env['CXX'], '-dumpversion']).strip())
-    else:
+    elif using_clang(env):
+        # Not using -dumpversion as it used to return 4.2.1: https://reviews.llvm.org/D56803
         version = decode_utf8(subprocess.check_output([env['CXX'], '--version']).strip())
+    else:  # TODO: Implement for MSVC
+        return None
     match = re.search('[0-9][0-9.]*', version)
     if match is not None:
         return match.group().split('.')


### PR DESCRIPTION
Prevent using GCC 8 as it does not properly support C++17's
guaranteed copy elision which we now need.
(Upstream bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86521)

Follow-up to #36457 and #36436.