### PR TITLE
Fix crash after closing a GDScript LSP session

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -122,7 +122,7 @@ Error GDScriptLanguageProtocol::LSPeer::send_data() {
 Error GDScriptLanguageProtocol::on_client_connected() {
 	Ref<StreamPeerTCP> tcp_peer = server->take_connection();
 	ERR_FAIL_COND_V_MSG(clients.size() >= LSP_MAX_CLIENTS, FAILED, "Max client limits reached");
-	Ref<LSPeer> peer = new LSPeer;
+	Ref<LSPeer> peer = memnew(LSPeer);
 	peer->connection = tcp_peer;
 	clients.set(next_client_id, peer);
 	next_client_id++;
@@ -130,7 +130,7 @@ Error GDScriptLanguageProtocol::on_client_connected() {
 	return OK;
 }
 
-void GDScriptLanguageProtocol::on_client_disconnected(int p_client_id) {
+void GDScriptLanguageProtocol::on_client_disconnected(const int &p_client_id) {
 	clients.erase(p_client_id);
 	EditorNode::get_log()->add_message("Disconnected", EditorLog::MSG_TYPE_EDITOR);
 }

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -77,7 +77,7 @@ private:
 	Ref<GDScriptWorkspace> workspace;
 
 	Error on_client_connected();
-	void on_client_disconnected(int p_client_id);
+	void on_client_disconnected(const int &p_client_id);
 
 	String process_message(const String &p_text);
 	String format_output(const String &p_text);


### PR DESCRIPTION
This fixes Issue #36472.  It was a mistake I made when I switched from using a class to a struct with LSPeer and I used a `new` statement instead of the Godot's `memnew`.  Tested on master and the 3.2 branch.

*Bugsquad edit:* Fixes #36472