### PR TITLE
Added new method to edit an already added node to anim state machine

### DIFF
--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -28,6 +28,17 @@
 				Adds a new node to the graph. The [code]position[/code] is used for display in the editor.
 			</description>
 		</method>
+		<method name="replace_node">
+			<return type="void">
+			</return>
+			<argument index="0" name="name" type="String">
+			</argument>
+			<argument index="1" name="node" type="AnimationNode">
+			</argument>
+			<description>
+				Replaces the node and keeps its transitions unchanged.
+			</description>
+		</method>
 		<method name="add_transition">
 			<return type="void">
 			</return>

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -565,6 +565,27 @@ void AnimationNodeStateMachine::add_node(const StringName &p_name, Ref<Animation
 	p_node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
 }
 
+void AnimationNodeStateMachine::replace_node(const StringName &p_name, Ref<AnimationNode> p_node) {
+
+	ERR_FAIL_COND(states.has(p_name) == false);
+	ERR_FAIL_COND(p_node.is_null());
+	ERR_FAIL_COND(String(p_name).find("/") != -1);
+
+	{
+		Ref<AnimationNode> node = states[p_name].node;
+		if (node.is_valid()) {
+			node->disconnect_compat("tree_changed", this, "_tree_changed");
+		}
+	}
+
+	states[p_name].node = p_node;
+
+	emit_changed();
+	emit_signal("tree_changed");
+
+	p_node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+}
+
 Ref<AnimationNode> AnimationNodeStateMachine::get_node(const StringName &p_name) const {
 
 	ERR_FAIL_COND_V(!states.has(p_name), Ref<AnimationNode>());
@@ -949,6 +970,7 @@ void AnimationNodeStateMachine::_tree_changed() {
 void AnimationNodeStateMachine::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_node", "name", "node", "position"), &AnimationNodeStateMachine::add_node, DEFVAL(Vector2()));
+	ClassDB::bind_method(D_METHOD("replace_node", "name", "node"), &AnimationNodeStateMachine::replace_node);
 	ClassDB::bind_method(D_METHOD("get_node", "name"), &AnimationNodeStateMachine::get_node);
 	ClassDB::bind_method(D_METHOD("remove_node", "name"), &AnimationNodeStateMachine::remove_node);
 	ClassDB::bind_method(D_METHOD("rename_node", "name", "new_name"), &AnimationNodeStateMachine::rename_node);

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -178,6 +178,7 @@ public:
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const;
 
 	void add_node(const StringName &p_name, Ref<AnimationNode> p_node, const Vector2 &p_position = Vector2());
+	void replace_node(const StringName &p_name, Ref<AnimationNode> p_node);
 	Ref<AnimationNode> get_node(const StringName &p_name) const;
 	void remove_node(const StringName &p_name);
 	void rename_node(const StringName &p_name, const StringName &p_new_name);


### PR DESCRIPTION
Added new method to edit an already added node to animation state machine without altering its transitions.

This method is useful when you need to create an animation state machine that can be dynamically changed.