### PR TITLE
Re-Remove this signal call that was mistakenly added in #36244

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1698,7 +1698,6 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		visual_profiler->set_name(TTR("Visual Profiler"));
 		tabs->add_child(visual_profiler);
 		visual_profiler->connect_compat("enable_profiling", this, "_visual_profiler_activate");
-		visual_profiler->connect_compat("break_request", this, "_profiler_seeked");
 	}
 
 	{ //network profiler


### PR DESCRIPTION
The original change was in #36340

Hopefully this is the last pull request regarding these signals :stuck_out_tongue: 