### PR TITLE
Remove signal _compat in favor of Callable

### DIFF
--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -145,22 +145,22 @@ void MultiplayerAPI::set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_pee
 			"Supplied NetworkedMultiplayerPeer must be connecting or connected.");
 
 	if (network_peer.is_valid()) {
-		network_peer->disconnect_compat("peer_connected", this, "_add_peer");
-		network_peer->disconnect_compat("peer_disconnected", this, "_del_peer");
-		network_peer->disconnect_compat("connection_succeeded", this, "_connected_to_server");
-		network_peer->disconnect_compat("connection_failed", this, "_connection_failed");
-		network_peer->disconnect_compat("server_disconnected", this, "_server_disconnected");
+		network_peer->disconnect("peer_connected", Callable(this, "_add_peer"));
+		network_peer->disconnect("peer_disconnected", Callable(this, "_del_peer"));
+		network_peer->disconnect("connection_succeeded", Callable(this, "_connected_to_server"));
+		network_peer->disconnect("connection_failed", Callable(this, "_connection_failed"));
+		network_peer->disconnect("server_disconnected", Callable(this, "_server_disconnected"));
 		clear();
 	}
 
 	network_peer = p_peer;
 
 	if (network_peer.is_valid()) {
-		network_peer->connect_compat("peer_connected", this, "_add_peer");
-		network_peer->connect_compat("peer_disconnected", this, "_del_peer");
-		network_peer->connect_compat("connection_succeeded", this, "_connected_to_server");
-		network_peer->connect_compat("connection_failed", this, "_connection_failed");
-		network_peer->connect_compat("server_disconnected", this, "_server_disconnected");
+		network_peer->connect("peer_connected", Callable(this, "_add_peer"));
+		network_peer->connect("peer_disconnected", Callable(this, "_del_peer"));
+		network_peer->connect("connection_succeeded", Callable(this, "_connected_to_server"));
+		network_peer->connect("connection_failed", Callable(this, "_connection_failed"));
+		network_peer->connect("server_disconnected", Callable(this, "_server_disconnected"));
 	}
 }
 

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1397,10 +1397,6 @@ void Object::get_signals_connected_to_this(List<Connection> *p_connections) cons
 	}
 }
 
-Error Object::connect_compat(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method, const Vector<Variant> &p_binds, uint32_t p_flags) {
-
-	return connect(p_signal, Callable(p_to_object, p_to_method), p_binds, p_flags);
-}
 Error Object::connect(const StringName &p_signal, const Callable &p_callable, const Vector<Variant> &p_binds, uint32_t p_flags) {
 
 	ERR_FAIL_COND_V(p_callable.is_null(), ERR_INVALID_PARAMETER);
@@ -1459,11 +1455,6 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, co
 	return OK;
 }
 
-bool Object::is_connected_compat(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method) const {
-
-	return is_connected(p_signal, Callable(p_to_object, p_to_method));
-}
-
 bool Object::is_connected(const StringName &p_signal, const Callable &p_callable) const {
 
 	ERR_FAIL_COND_V(p_callable.is_null(), false);
@@ -1484,11 +1475,6 @@ bool Object::is_connected(const StringName &p_signal, const Callable &p_callable
 	return s->slot_map.has(target);
 	//const Map<Signal::Target,Signal::Slot>::Element *E = s->slot_map.find(target);
 	//return (E!=NULL);
-}
-
-void Object::disconnect_compat(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method) {
-
-	_disconnect(p_signal, Callable(p_to_object, p_to_method));
 }
 
 void Object::disconnect(const StringName &p_signal, const Callable &p_callable) {

--- a/core/object.h
+++ b/core/object.h
@@ -699,10 +699,6 @@ public:
 	int get_persistent_signal_connection_count() const;
 	void get_signals_connected_to_this(List<Connection> *p_connections) const;
 
-	Error connect_compat(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method, const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0);
-	void disconnect_compat(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method);
-	bool is_connected_compat(const StringName &p_signal, Object *p_to_object, const StringName &p_to_method) const;
-
 	Error connect(const StringName &p_signal, const Callable &p_callable, const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0);
 	void disconnect(const StringName &p_signal, const Callable &p_callable);
 	bool is_connected(const StringName &p_signal, const Callable &p_callable) const;

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -502,12 +502,12 @@ void AnimationBezierTrackEdit::set_animation_and_track(const Ref<Animation> &p_a
 
 	animation = p_animation;
 	track = p_track;
-	if (is_connected_compat("select_key", editor, "_key_selected"))
-		disconnect_compat("select_key", editor, "_key_selected");
-	if (is_connected_compat("deselect_key", editor, "_key_deselected"))
-		disconnect_compat("deselect_key", editor, "_key_deselected");
-	connect_compat("select_key", editor, "_key_selected", varray(p_track), CONNECT_DEFERRED);
-	connect_compat("deselect_key", editor, "_key_deselected", varray(p_track), CONNECT_DEFERRED);
+	if (is_connected("select_key", Callable(editor, "_key_selected")))
+		disconnect("select_key", Callable(editor, "_key_selected"));
+	if (is_connected("deselect_key", Callable(editor, "_key_deselected")))
+		disconnect("deselect_key", Callable(editor, "_key_deselected"));
+	connect("select_key", Callable(editor, "_key_selected"), varray(p_track), CONNECT_DEFERRED);
+	connect("deselect_key", Callable(editor, "_key_deselected"), varray(p_track), CONNECT_DEFERRED);
 	update();
 }
 
@@ -522,11 +522,11 @@ void AnimationBezierTrackEdit::set_undo_redo(UndoRedo *p_undo_redo) {
 
 void AnimationBezierTrackEdit::set_timeline(AnimationTimelineEdit *p_timeline) {
 	timeline = p_timeline;
-	timeline->connect_compat("zoom_changed", this, "_zoom_changed");
+	timeline->connect("zoom_changed", Callable(this, "_zoom_changed"));
 }
 void AnimationBezierTrackEdit::set_editor(AnimationTrackEditor *p_editor) {
 	editor = p_editor;
-	connect_compat("clear_selection", editor, "_clear_selection", varray(false));
+	connect("clear_selection", Callable(editor, "_clear_selection"), varray(false));
 }
 
 void AnimationBezierTrackEdit::_play_position_draw() {
@@ -1184,7 +1184,7 @@ AnimationBezierTrackEdit::AnimationBezierTrackEdit() {
 	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
 	add_child(play_position);
 	play_position->set_anchors_and_margins_preset(PRESET_WIDE);
-	play_position->connect_compat("draw", this, "_play_position_draw");
+	play_position->connect("draw", Callable(this, "_play_position_draw"));
 	set_focus_mode(FOCUS_CLICK);
 
 	v_scroll = 0;
@@ -1198,7 +1198,7 @@ AnimationBezierTrackEdit::AnimationBezierTrackEdit() {
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
-	menu->connect_compat("id_pressed", this, "_menu_selected");
+	menu->connect("id_pressed", Callable(this, "_menu_selected"));
 
 	//set_mouse_filter(MOUSE_FILTER_PASS); //scroll has to work too for selection
 }

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1697,7 +1697,7 @@ void AnimationTimelineEdit::set_undo_redo(UndoRedo *p_undo_redo) {
 
 void AnimationTimelineEdit::set_zoom(Range *p_zoom) {
 	zoom = p_zoom;
-	zoom->connect_compat("value_changed", this, "_zoom_changed");
+	zoom->connect("value_changed", Callable(this, "_zoom_changed"));
 }
 
 void AnimationTimelineEdit::set_play_position(float p_pos) {
@@ -1871,7 +1871,7 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
 	add_child(play_position);
 	play_position->set_anchors_and_margins_preset(PRESET_WIDE);
-	play_position->connect_compat("draw", this, "_play_position_draw");
+	play_position->connect("draw", Callable(this, "_play_position_draw"));
 
 	add_track = memnew(MenuButton);
 	add_track->set_position(Vector2(0, 0));
@@ -1895,17 +1895,17 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
 	length->set_hide_slider(true);
 	length->set_tooltip(TTR("Animation length (seconds)"));
-	length->connect_compat("value_changed", this, "_anim_length_changed");
+	length->connect("value_changed", Callable(this, "_anim_length_changed"));
 	len_hb->add_child(length);
 	loop = memnew(ToolButton);
 	loop->set_tooltip(TTR("Animation Looping"));
-	loop->connect_compat("pressed", this, "_anim_loop_pressed");
+	loop->connect("pressed", Callable(this, "_anim_loop_pressed"));
 	loop->set_toggle_mode(true);
 	len_hb->add_child(loop);
 	add_child(len_hb);
 
 	add_track->hide();
-	add_track->get_popup()->connect_compat("index_pressed", this, "_track_added");
+	add_track->get_popup()->connect("index_pressed", Callable(this, "_track_added"));
 	len_hb->hide();
 
 	panning_timeline = false;
@@ -2429,8 +2429,8 @@ void AnimationTrackEdit::set_undo_redo(UndoRedo *p_undo_redo) {
 
 void AnimationTrackEdit::set_timeline(AnimationTimelineEdit *p_timeline) {
 	timeline = p_timeline;
-	timeline->connect_compat("zoom_changed", this, "_zoom_changed");
-	timeline->connect_compat("name_limit_changed", this, "_zoom_changed");
+	timeline->connect("zoom_changed", Callable(this, "_zoom_changed"));
+	timeline->connect("name_limit_changed", Callable(this, "_zoom_changed"));
 }
 void AnimationTrackEdit::set_editor(AnimationTrackEditor *p_editor) {
 	editor = p_editor;
@@ -2688,7 +2688,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			if (!menu) {
 				menu = memnew(PopupMenu);
 				add_child(menu);
-				menu->connect_compat("id_pressed", this, "_menu_selected");
+				menu->connect("id_pressed", Callable(this, "_menu_selected"));
 			}
 			menu->clear();
 			menu->add_icon_item(get_icon("TrackContinuous", "EditorIcons"), TTR("Continuous"), MENU_CALL_MODE_CONTINUOUS);
@@ -2707,7 +2707,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			if (!menu) {
 				menu = memnew(PopupMenu);
 				add_child(menu);
-				menu->connect_compat("id_pressed", this, "_menu_selected");
+				menu->connect("id_pressed", Callable(this, "_menu_selected"));
 			}
 			menu->clear();
 			menu->add_icon_item(get_icon("InterpRaw", "EditorIcons"), TTR("Nearest"), MENU_INTERPOLATION_NEAREST);
@@ -2725,7 +2725,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			if (!menu) {
 				menu = memnew(PopupMenu);
 				add_child(menu);
-				menu->connect_compat("id_pressed", this, "_menu_selected");
+				menu->connect("id_pressed", Callable(this, "_menu_selected"));
 			}
 			menu->clear();
 			menu->add_icon_item(get_icon("InterpWrapClamp", "EditorIcons"), TTR("Clamp Loop Interp"), MENU_LOOP_CLAMP);
@@ -2820,7 +2820,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			if (!menu) {
 				menu = memnew(PopupMenu);
 				add_child(menu);
-				menu->connect_compat("id_pressed", this, "_menu_selected");
+				menu->connect("id_pressed", Callable(this, "_menu_selected"));
 			}
 
 			menu->clear();
@@ -2848,7 +2848,7 @@ void AnimationTrackEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			path = memnew(LineEdit);
 			add_child(path);
 			path->set_as_toplevel(true);
-			path->connect_compat("text_entered", this, "_path_entered");
+			path->connect("text_entered", Callable(this, "_path_entered"));
 		}
 
 		path->set_text(animation->track_get_path(track));
@@ -3111,7 +3111,7 @@ AnimationTrackEdit::AnimationTrackEdit() {
 	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
 	add_child(play_position);
 	play_position->set_anchors_and_margins_preset(PRESET_WIDE);
-	play_position->connect_compat("draw", this, "_play_position_draw");
+	play_position->connect("draw", Callable(this, "_play_position_draw"));
 	set_focus_mode(FOCUS_CLICK);
 	set_mouse_filter(MOUSE_FILTER_PASS); //scroll has to work too for selection
 }
@@ -3217,8 +3217,8 @@ Size2 AnimationTrackEditGroup::get_minimum_size() const {
 
 void AnimationTrackEditGroup::set_timeline(AnimationTimelineEdit *p_timeline) {
 	timeline = p_timeline;
-	timeline->connect_compat("zoom_changed", this, "_zoom_changed");
-	timeline->connect_compat("name_limit_changed", this, "_zoom_changed");
+	timeline->connect("zoom_changed", Callable(this, "_zoom_changed"));
+	timeline->connect("name_limit_changed", Callable(this, "_zoom_changed"));
 }
 
 void AnimationTrackEditGroup::set_root(Node *p_root) {
@@ -3258,7 +3258,7 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim) {
 		track_edits[_get_track_selected()]->release_focus();
 	}
 	if (animation.is_valid()) {
-		animation->disconnect_compat("changed", this, "_animation_changed");
+		animation->disconnect("changed", Callable(this, "_animation_changed"));
 		_clear_selection();
 	}
 	animation = p_anim;
@@ -3268,7 +3268,7 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim) {
 	_update_tracks();
 
 	if (animation.is_valid()) {
-		animation->connect_compat("changed", this, "_animation_changed");
+		animation->connect("changed", Callable(this, "_animation_changed"));
 
 		hscroll->show();
 		edit->set_disabled(false);
@@ -3311,13 +3311,13 @@ void AnimationTrackEditor::_root_removed(Node *p_root) {
 
 void AnimationTrackEditor::set_root(Node *p_root) {
 	if (root) {
-		root->disconnect_compat("tree_exiting", this, "_root_removed");
+		root->disconnect("tree_exiting", Callable(this, "_root_removed"));
 	}
 
 	root = p_root;
 
 	if (root) {
-		root->connect_compat("tree_exiting", this, "_root_removed", make_binds(), CONNECT_ONESHOT);
+		root->connect("tree_exiting", Callable(this, "_root_removed"), make_binds(), CONNECT_ONESHOT);
 	}
 
 	_update_tracks();
@@ -4257,21 +4257,21 @@ void AnimationTrackEditor::_update_tracks() {
 			track_edit->grab_focus();
 		}
 
-		track_edit->connect_compat("timeline_changed", this, "_timeline_changed");
-		track_edit->connect_compat("remove_request", this, "_track_remove_request", varray(), CONNECT_DEFERRED);
-		track_edit->connect_compat("dropped", this, "_dropped_track", varray(), CONNECT_DEFERRED);
-		track_edit->connect_compat("insert_key", this, "_insert_key_from_track", varray(i), CONNECT_DEFERRED);
-		track_edit->connect_compat("select_key", this, "_key_selected", varray(i), CONNECT_DEFERRED);
-		track_edit->connect_compat("deselect_key", this, "_key_deselected", varray(i), CONNECT_DEFERRED);
-		track_edit->connect_compat("bezier_edit", this, "_bezier_edit", varray(i), CONNECT_DEFERRED);
-		track_edit->connect_compat("move_selection_begin", this, "_move_selection_begin");
-		track_edit->connect_compat("move_selection", this, "_move_selection");
-		track_edit->connect_compat("move_selection_commit", this, "_move_selection_commit");
-		track_edit->connect_compat("move_selection_cancel", this, "_move_selection_cancel");
+		track_edit->connect("timeline_changed", Callable(this, "_timeline_changed"));
+		track_edit->connect("remove_request", Callable(this, "_track_remove_request"), varray(), CONNECT_DEFERRED);
+		track_edit->connect("dropped", Callable(this, "_dropped_track"), varray(), CONNECT_DEFERRED);
+		track_edit->connect("insert_key", Callable(this, "_insert_key_from_track"), varray(i), CONNECT_DEFERRED);
+		track_edit->connect("select_key", Callable(this, "_key_selected"), varray(i), CONNECT_DEFERRED);
+		track_edit->connect("deselect_key", Callable(this, "_key_deselected"), varray(i), CONNECT_DEFERRED);
+		track_edit->connect("bezier_edit", Callable(this, "_bezier_edit"), varray(i), CONNECT_DEFERRED);
+		track_edit->connect("move_selection_begin", Callable(this, "_move_selection_begin"));
+		track_edit->connect("move_selection", Callable(this, "_move_selection"));
+		track_edit->connect("move_selection_commit", Callable(this, "_move_selection_commit"));
+		track_edit->connect("move_selection_cancel", Callable(this, "_move_selection_cancel"));
 
-		track_edit->connect_compat("duplicate_request", this, "_edit_menu_pressed", varray(EDIT_DUPLICATE_SELECTION), CONNECT_DEFERRED);
-		track_edit->connect_compat("duplicate_transpose_request", this, "_edit_menu_pressed", varray(EDIT_DUPLICATE_TRANSPOSED), CONNECT_DEFERRED);
-		track_edit->connect_compat("delete_request", this, "_edit_menu_pressed", varray(EDIT_DELETE_SELECTION), CONNECT_DEFERRED);
+		track_edit->connect("duplicate_request", Callable(this, "_edit_menu_pressed"), varray(EDIT_DUPLICATE_SELECTION), CONNECT_DEFERRED);
+		track_edit->connect("duplicate_transpose_request", Callable(this, "_edit_menu_pressed"), varray(EDIT_DUPLICATE_TRANSPOSED), CONNECT_DEFERRED);
+		track_edit->connect("delete_request", Callable(this, "_edit_menu_pressed"), varray(EDIT_DELETE_SELECTION), CONNECT_DEFERRED);
 	}
 }
 
@@ -4384,7 +4384,7 @@ void AnimationTrackEditor::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_READY) {
-		EditorNode::get_singleton()->get_editor_selection()->connect_compat("selection_changed", this, "_selection_changed");
+		EditorNode::get_singleton()->get_editor_selection()->connect("selection_changed", Callable(this, "_selection_changed"));
 	}
 
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
@@ -5813,11 +5813,11 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	timeline = memnew(AnimationTimelineEdit);
 	timeline->set_undo_redo(undo_redo);
 	timeline_vbox->add_child(timeline);
-	timeline->connect_compat("timeline_changed", this, "_timeline_changed");
-	timeline->connect_compat("name_limit_changed", this, "_name_limit_changed");
-	timeline->connect_compat("track_added", this, "_add_track");
-	timeline->connect_compat("value_changed", this, "_timeline_value_changed");
-	timeline->connect_compat("length_changed", this, "_update_length");
+	timeline->connect("timeline_changed", Callable(this, "_timeline_changed"));
+	timeline->connect("name_limit_changed", Callable(this, "_name_limit_changed"));
+	timeline->connect("track_added", Callable(this, "_add_track"));
+	timeline->connect("value_changed", Callable(this, "_timeline_value_changed"));
+	timeline->connect("length_changed", Callable(this, "_update_length"));
 
 	scroll = memnew(ScrollContainer);
 	timeline_vbox->add_child(scroll);
@@ -5825,7 +5825,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	VScrollBar *sb = scroll->get_v_scrollbar();
 	scroll->remove_child(sb);
 	timeline_scroll->add_child(sb); //move here so timeline and tracks are always aligned
-	scroll->connect_compat("gui_input", this, "_scroll_input");
+	scroll->connect("gui_input", Callable(this, "_scroll_input"));
 
 	bezier_edit = memnew(AnimationBezierTrackEdit);
 	timeline_vbox->add_child(bezier_edit);
@@ -5834,14 +5834,14 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	bezier_edit->set_timeline(timeline);
 	bezier_edit->hide();
 	bezier_edit->set_v_size_flags(SIZE_EXPAND_FILL);
-	bezier_edit->connect_compat("close_request", this, "_cancel_bezier_edit");
+	bezier_edit->connect("close_request", Callable(this, "_cancel_bezier_edit"));
 
 	timeline_vbox->set_custom_minimum_size(Size2(0, 150) * EDSCALE);
 
 	hscroll = memnew(HScrollBar);
 	hscroll->share(timeline);
 	hscroll->hide();
-	hscroll->connect_compat("value_changed", this, "_update_scroll");
+	hscroll->connect("value_changed", Callable(this, "_update_scroll"));
 	timeline_vbox->add_child(hscroll);
 	timeline->set_hscroll(hscroll);
 
@@ -5858,20 +5858,20 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	imported_anim_warning = memnew(Button);
 	imported_anim_warning->hide();
 	imported_anim_warning->set_tooltip(TTR("Warning: Editing imported animation"));
-	imported_anim_warning->connect_compat("pressed", this, "_show_imported_anim_warning");
+	imported_anim_warning->connect("pressed", Callable(this, "_show_imported_anim_warning"));
 	bottom_hb->add_child(imported_anim_warning);
 
 	bottom_hb->add_spacer();
 
 	selected_filter = memnew(ToolButton);
-	selected_filter->connect_compat("pressed", this, "_view_group_toggle"); //same function works the same
+	selected_filter->connect("pressed", Callable(this, "_view_group_toggle")); //same function works the same
 	selected_filter->set_toggle_mode(true);
 	selected_filter->set_tooltip(TTR("Only show tracks from nodes selected in tree."));
 
 	bottom_hb->add_child(selected_filter);
 
 	view_group = memnew(ToolButton);
-	view_group->connect_compat("pressed", this, "_view_group_toggle");
+	view_group->connect("pressed", Callable(this, "_view_group_toggle"));
 	view_group->set_toggle_mode(true);
 	view_group->set_tooltip(TTR("Group tracks by node or display them as plain list."));
 
@@ -5893,14 +5893,14 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	step->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 	step->set_tooltip(TTR("Animation step value."));
 	bottom_hb->add_child(step);
-	step->connect_compat("value_changed", this, "_update_step");
+	step->connect("value_changed", Callable(this, "_update_step"));
 	step->set_read_only(true);
 
 	snap_mode = memnew(OptionButton);
 	snap_mode->add_item(TTR("Seconds"));
 	snap_mode->add_item(TTR("FPS"));
 	bottom_hb->add_child(snap_mode);
-	snap_mode->connect_compat("item_selected", this, "_snap_mode_changed");
+	snap_mode->connect("item_selected", Callable(this, "_snap_mode_changed"));
 	snap_mode->set_disabled(true);
 
 	bottom_hb->add_child(memnew(VSeparator));
@@ -5945,19 +5945,19 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	edit->get_popup()->add_item(TTR("Optimize Animation"), EDIT_OPTIMIZE_ANIMATION);
 	edit->get_popup()->add_item(TTR("Clean-Up Animation"), EDIT_CLEAN_UP_ANIMATION);
 
-	edit->get_popup()->connect_compat("id_pressed", this, "_edit_menu_pressed");
+	edit->get_popup()->connect("id_pressed", Callable(this, "_edit_menu_pressed"));
 
 	pick_track = memnew(SceneTreeDialog);
 	add_child(pick_track);
 	pick_track->set_title(TTR("Pick the node that will be animated:"));
-	pick_track->connect_compat("selected", this, "_new_track_node_selected");
+	pick_track->connect("selected", Callable(this, "_new_track_node_selected"));
 	prop_selector = memnew(PropertySelector);
 	add_child(prop_selector);
-	prop_selector->connect_compat("selected", this, "_new_track_property_selected");
+	prop_selector->connect("selected", Callable(this, "_new_track_property_selected"));
 
 	method_selector = memnew(PropertySelector);
 	add_child(method_selector);
-	method_selector->connect_compat("selected", this, "_add_method_key");
+	method_selector->connect("selected", Callable(this, "_add_method_key"));
 
 	inserting = false;
 	insert_query = false;
@@ -5966,7 +5966,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	insert_confirm = memnew(ConfirmationDialog);
 	add_child(insert_confirm);
-	insert_confirm->connect_compat("confirmed", this, "_confirm_insert_list");
+	insert_confirm->connect("confirmed", Callable(this, "_confirm_insert_list"));
 	VBoxContainer *icvb = memnew(VBoxContainer);
 	insert_confirm->add_child(icvb);
 	insert_confirm_text = memnew(Label);
@@ -5984,7 +5984,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	box_selection->set_as_toplevel(true);
 	box_selection->set_mouse_filter(MOUSE_FILTER_IGNORE);
 	box_selection->hide();
-	box_selection->connect_compat("draw", this, "_box_selection_draw");
+	box_selection->connect("draw", Callable(this, "_box_selection_draw"));
 	box_selecting = false;
 
 	//default plugins
@@ -6022,7 +6022,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	optimize_max_angle->set_value(22);
 
 	optimize_dialog->get_ok()->set_text(TTR("Optimize"));
-	optimize_dialog->connect_compat("confirmed", this, "_edit_menu_pressed", varray(EDIT_CLEAN_UP_ANIMATION_CONFIRM));
+	optimize_dialog->connect("confirmed", Callable(this, "_edit_menu_pressed"), varray(EDIT_CLEAN_UP_ANIMATION_CONFIRM));
 
 	//
 
@@ -6048,7 +6048,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	cleanup_dialog->set_title(TTR("Clean-Up Animation(s) (NO UNDO!)"));
 	cleanup_dialog->get_ok()->set_text(TTR("Clean-Up"));
 
-	cleanup_dialog->connect_compat("confirmed", this, "_edit_menu_pressed", varray(EDIT_CLEAN_UP_ANIMATION_CONFIRM));
+	cleanup_dialog->connect("confirmed", Callable(this, "_edit_menu_pressed"), varray(EDIT_CLEAN_UP_ANIMATION_CONFIRM));
 
 	//
 	scale_dialog = memnew(ConfirmationDialog);
@@ -6060,7 +6060,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	scale->set_max(99999);
 	scale->set_step(0.001);
 	vbc->add_margin_child(TTR("Scale Ratio:"), scale);
-	scale_dialog->connect_compat("confirmed", this, "_edit_menu_pressed", varray(EDIT_SCALE_CONFIRM));
+	scale_dialog->connect("confirmed", Callable(this, "_edit_menu_pressed"), varray(EDIT_SCALE_CONFIRM));
 	add_child(scale_dialog);
 
 	track_copy_dialog = memnew(ConfirmationDialog);
@@ -6073,7 +6073,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	Button *select_all_button = memnew(Button);
 	select_all_button->set_text(TTR("Select All/None"));
-	select_all_button->connect_compat("pressed", this, "_select_all_tracks_for_copy");
+	select_all_button->connect("pressed", Callable(this, "_select_all_tracks_for_copy"));
 	track_vbox->add_child(select_all_button);
 
 	track_copy_select = memnew(Tree);
@@ -6081,7 +6081,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	track_copy_select->set_v_size_flags(SIZE_EXPAND_FILL);
 	track_copy_select->set_hide_root(true);
 	track_vbox->add_child(track_copy_select);
-	track_copy_dialog->connect_compat("confirmed", this, "_edit_menu_pressed", varray(EDIT_COPY_TRACKS_CONFIRM));
+	track_copy_dialog->connect("confirmed", Callable(this, "_edit_menu_pressed"), varray(EDIT_COPY_TRACKS_CONFIRM));
 	animation_changing_awaiting_update = false;
 }
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -334,7 +334,7 @@ void AnimationTrackEditAudio::_bind_methods() {
 }
 
 AnimationTrackEditAudio::AnimationTrackEditAudio() {
-	AudioStreamPreviewGenerator::get_singleton()->connect_compat("preview_updated", this, "_preview_changed");
+	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", Callable(this, "_preview_changed"));
 }
 
 /// SPRITE FRAME / FRAME_COORDS ///
@@ -949,7 +949,7 @@ void AnimationTrackEditTypeAudio::_bind_methods() {
 }
 
 AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
-	AudioStreamPreviewGenerator::get_singleton()->connect_compat("preview_updated", this, "_preview_changed");
+	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", Callable(this, "_preview_changed"));
 	len_resizing = false;
 }
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -200,7 +200,7 @@ void FindReplaceBar::_replace() {
 
 void FindReplaceBar::_replace_all() {
 
-	text_edit->disconnect_compat("text_changed", this, "_editor_text_changed");
+	text_edit->disconnect("text_changed", Callable(this, "_editor_text_changed"));
 	// Line as x so it gets priority in comparison, column as y.
 	Point2i orig_cursor(text_edit->cursor_get_line(), text_edit->cursor_get_column());
 	Point2i prev_match = Point2(-1, -1);
@@ -559,7 +559,7 @@ void FindReplaceBar::set_text_edit(TextEdit *p_text_edit) {
 
 	results_count = -1;
 	text_edit = p_text_edit;
-	text_edit->connect_compat("text_changed", this, "_editor_text_changed");
+	text_edit->connect("text_changed", Callable(this, "_editor_text_changed"));
 }
 
 void FindReplaceBar::_bind_methods() {
@@ -613,8 +613,8 @@ FindReplaceBar::FindReplaceBar() {
 	search_text = memnew(LineEdit);
 	vbc_lineedit->add_child(search_text);
 	search_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-	search_text->connect_compat("text_changed", this, "_search_text_changed");
-	search_text->connect_compat("text_entered", this, "_search_text_entered");
+	search_text->connect("text_changed", Callable(this, "_search_text_changed"));
+	search_text->connect("text_entered", Callable(this, "_search_text_entered"));
 
 	matches_label = memnew(Label);
 	hbc_button_search->add_child(matches_label);
@@ -623,51 +623,51 @@ FindReplaceBar::FindReplaceBar() {
 	find_prev = memnew(ToolButton);
 	hbc_button_search->add_child(find_prev);
 	find_prev->set_focus_mode(FOCUS_NONE);
-	find_prev->connect_compat("pressed", this, "_search_prev");
+	find_prev->connect("pressed", Callable(this, "_search_prev"));
 
 	find_next = memnew(ToolButton);
 	hbc_button_search->add_child(find_next);
 	find_next->set_focus_mode(FOCUS_NONE);
-	find_next->connect_compat("pressed", this, "_search_next");
+	find_next->connect("pressed", Callable(this, "_search_next"));
 
 	case_sensitive = memnew(CheckBox);
 	hbc_option_search->add_child(case_sensitive);
 	case_sensitive->set_text(TTR("Match Case"));
 	case_sensitive->set_focus_mode(FOCUS_NONE);
-	case_sensitive->connect_compat("toggled", this, "_search_options_changed");
+	case_sensitive->connect("toggled", Callable(this, "_search_options_changed"));
 
 	whole_words = memnew(CheckBox);
 	hbc_option_search->add_child(whole_words);
 	whole_words->set_text(TTR("Whole Words"));
 	whole_words->set_focus_mode(FOCUS_NONE);
-	whole_words->connect_compat("toggled", this, "_search_options_changed");
+	whole_words->connect("toggled", Callable(this, "_search_options_changed"));
 
 	// replace toolbar
 	replace_text = memnew(LineEdit);
 	vbc_lineedit->add_child(replace_text);
 	replace_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-	replace_text->connect_compat("text_entered", this, "_replace_text_entered");
+	replace_text->connect("text_entered", Callable(this, "_replace_text_entered"));
 
 	replace = memnew(Button);
 	hbc_button_replace->add_child(replace);
 	replace->set_text(TTR("Replace"));
-	replace->connect_compat("pressed", this, "_replace_pressed");
+	replace->connect("pressed", Callable(this, "_replace_pressed"));
 
 	replace_all = memnew(Button);
 	hbc_button_replace->add_child(replace_all);
 	replace_all->set_text(TTR("Replace All"));
-	replace_all->connect_compat("pressed", this, "_replace_all_pressed");
+	replace_all->connect("pressed", Callable(this, "_replace_all_pressed"));
 
 	selection_only = memnew(CheckBox);
 	hbc_option_replace->add_child(selection_only);
 	selection_only->set_text(TTR("Selection Only"));
 	selection_only->set_focus_mode(FOCUS_NONE);
-	selection_only->connect_compat("toggled", this, "_search_options_changed");
+	selection_only->connect("toggled", Callable(this, "_search_options_changed"));
 
 	hide_button = memnew(TextureButton);
 	add_child(hide_button);
 	hide_button->set_focus_mode(FOCUS_NONE);
-	hide_button->connect_compat("pressed", this, "_hide_pressed");
+	hide_button->connect("pressed", Callable(this, "_hide_pressed"));
 	hide_button->set_v_size_flags(SIZE_SHRINK_CENTER);
 }
 
@@ -1717,7 +1717,7 @@ CodeTextEditor::CodeTextEditor() {
 	error_column = 0;
 
 	toggle_scripts_button = memnew(ToolButton);
-	toggle_scripts_button->connect_compat("pressed", this, "_toggle_scripts_pressed");
+	toggle_scripts_button->connect("pressed", Callable(this, "_toggle_scripts_pressed"));
 	status_bar->add_child(toggle_scripts_button);
 	toggle_scripts_button->hide();
 
@@ -1732,15 +1732,15 @@ CodeTextEditor::CodeTextEditor() {
 	scroll->add_child(error);
 	error->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
 	error->set_mouse_filter(MOUSE_FILTER_STOP);
-	error->connect_compat("gui_input", this, "_error_pressed");
-	find_replace_bar->connect_compat("error", error, "set_text");
+	error->connect("gui_input", Callable(this, "_error_pressed"));
+	find_replace_bar->connect("error", Callable(error, "set_text"));
 
 	// Warnings
 	warning_button = memnew(ToolButton);
 	status_bar->add_child(warning_button);
 	warning_button->set_v_size_flags(SIZE_EXPAND | SIZE_SHRINK_CENTER);
 	warning_button->set_default_cursor_shape(CURSOR_POINTING_HAND);
-	warning_button->connect_compat("pressed", this, "_warning_button_pressed");
+	warning_button->connect("pressed", Callable(this, "_warning_button_pressed"));
 	warning_button->set_tooltip(TTR("Warnings"));
 
 	warning_count_label = memnew(Label);
@@ -1752,7 +1752,7 @@ CodeTextEditor::CodeTextEditor() {
 	warning_count_label->set_tooltip(TTR("Warnings"));
 	warning_count_label->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("warning_color", "Editor"));
 	warning_count_label->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("status_source", "EditorFonts"));
-	warning_count_label->connect_compat("gui_input", this, "_warning_label_gui_input");
+	warning_count_label->connect("gui_input", Callable(this, "_warning_label_gui_input"));
 
 	is_warnings_panel_opened = false;
 	set_warning_nb(0);
@@ -1765,10 +1765,10 @@ CodeTextEditor::CodeTextEditor() {
 	line_and_col_txt->set_tooltip(TTR("Line and column numbers."));
 	line_and_col_txt->set_mouse_filter(MOUSE_FILTER_STOP);
 
-	text_editor->connect_compat("gui_input", this, "_text_editor_gui_input");
-	text_editor->connect_compat("cursor_changed", this, "_line_col_changed");
-	text_editor->connect_compat("text_changed", this, "_text_changed");
-	text_editor->connect_compat("request_completion", this, "_complete_request");
+	text_editor->connect("gui_input", Callable(this, "_text_editor_gui_input"));
+	text_editor->connect("cursor_changed", Callable(this, "_line_col_changed"));
+	text_editor->connect("text_changed", Callable(this, "_text_changed"));
+	text_editor->connect("request_completion", Callable(this, "_complete_request"));
 	Vector<String> cs;
 	cs.push_back(".");
 	cs.push_back(",");
@@ -1776,9 +1776,9 @@ CodeTextEditor::CodeTextEditor() {
 	cs.push_back("=");
 	cs.push_back("$");
 	text_editor->set_completion(true, cs);
-	idle->connect_compat("timeout", this, "_text_changed_idle_timeout");
+	idle->connect("timeout", Callable(this, "_text_changed_idle_timeout"));
 
-	code_complete_timer->connect_compat("timeout", this, "_code_complete_timer_timeout");
+	code_complete_timer->connect("timeout", Callable(this, "_code_complete_timer_timeout"));
 
 	font_resize_val = 0;
 	font_size = EditorSettings::get_singleton()->get("interface/editor/code_font_size");
@@ -1786,7 +1786,7 @@ CodeTextEditor::CodeTextEditor() {
 	add_child(font_resize_timer);
 	font_resize_timer->set_one_shot(true);
 	font_resize_timer->set_wait_time(0.07);
-	font_resize_timer->connect_compat("timeout", this, "_font_resize_timeout");
+	font_resize_timer->connect("timeout", Callable(this, "_font_resize_timeout"));
 
-	EditorSettings::get_singleton()->connect_compat("settings_changed", this, "_on_settings_change");
+	EditorSettings::get_singleton()->connect("settings_changed", Callable(this, "_on_settings_change"));
 }

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -390,8 +390,8 @@ ConnectDialog::ConnectDialog() {
 
 	tree = memnew(SceneTreeEditor(false));
 	tree->set_connecting_signal(true);
-	tree->get_scene_tree()->connect_compat("item_activated", this, "_ok");
-	tree->connect_compat("node_selected", this, "_tree_node_selected");
+	tree->get_scene_tree()->connect("item_activated", Callable(this, "_ok"));
+	tree->connect("node_selected", Callable(this, "_tree_node_selected"));
 	tree->set_connect_to_script_mode(true);
 
 	Node *mc = vbc_left->add_margin_child(TTR("Connect to Script:"), tree, true);
@@ -431,12 +431,12 @@ ConnectDialog::ConnectDialog() {
 	Button *add_bind = memnew(Button);
 	add_bind->set_text(TTR("Add"));
 	add_bind_hb->add_child(add_bind);
-	add_bind->connect_compat("pressed", this, "_add_bind");
+	add_bind->connect("pressed", Callable(this, "_add_bind"));
 
 	Button *del_bind = memnew(Button);
 	del_bind->set_text(TTR("Remove"));
 	add_bind_hb->add_child(del_bind);
-	del_bind->connect_compat("pressed", this, "_remove_bind");
+	del_bind->connect("pressed", Callable(this, "_remove_bind"));
 
 	vbc_right->add_margin_child(TTR("Add Extra Call Argument:"), add_bind_hb);
 
@@ -449,13 +449,13 @@ ConnectDialog::ConnectDialog() {
 
 	dst_method = memnew(LineEdit);
 	dst_method->set_h_size_flags(SIZE_EXPAND_FILL);
-	dst_method->connect_compat("text_entered", this, "_builtin_text_entered");
+	dst_method->connect("text_entered", Callable(this, "_builtin_text_entered"));
 	dstm_hb->add_child(dst_method);
 
 	advanced = memnew(CheckButton);
 	dstm_hb->add_child(advanced);
 	advanced->set_text(TTR("Advanced"));
-	advanced->connect_compat("pressed", this, "_advanced_pressed");
+	advanced->connect("pressed", Callable(this, "_advanced_pressed"));
 
 	// Add spacing so the tree and inspector are the same size.
 	Control *spacing = memnew(Control);
@@ -1086,7 +1086,7 @@ ConnectionsDock::ConnectionsDock(EditorNode *p_editor) {
 	vbc->add_child(hb);
 	hb->add_spacer();
 	hb->add_child(connect_button);
-	connect_button->connect_compat("pressed", this, "_connect_pressed");
+	connect_button->connect("pressed", Callable(this, "_connect_pressed"));
 
 	connect_dialog = memnew(ConnectDialog);
 	connect_dialog->set_as_toplevel(true);
@@ -1095,26 +1095,26 @@ ConnectionsDock::ConnectionsDock(EditorNode *p_editor) {
 	disconnect_all_dialog = memnew(ConfirmationDialog);
 	disconnect_all_dialog->set_as_toplevel(true);
 	add_child(disconnect_all_dialog);
-	disconnect_all_dialog->connect_compat("confirmed", this, "_disconnect_all");
+	disconnect_all_dialog->connect("confirmed", Callable(this, "_disconnect_all"));
 	disconnect_all_dialog->set_text(TTR("Are you sure you want to remove all connections from this signal?"));
 
 	signal_menu = memnew(PopupMenu);
 	add_child(signal_menu);
-	signal_menu->connect_compat("id_pressed", this, "_handle_signal_menu_option");
+	signal_menu->connect("id_pressed", Callable(this, "_handle_signal_menu_option"));
 	signal_menu->add_item(TTR("Connect..."), CONNECT);
 	signal_menu->add_item(TTR("Disconnect All"), DISCONNECT_ALL);
 
 	slot_menu = memnew(PopupMenu);
 	add_child(slot_menu);
-	slot_menu->connect_compat("id_pressed", this, "_handle_slot_menu_option");
+	slot_menu->connect("id_pressed", Callable(this, "_handle_slot_menu_option"));
 	slot_menu->add_item(TTR("Edit..."), EDIT);
 	slot_menu->add_item(TTR("Go To Method"), GO_TO_SCRIPT);
 	slot_menu->add_item(TTR("Disconnect"), DISCONNECT);
 
-	connect_dialog->connect_compat("connected", this, "_make_or_edit_connection");
-	tree->connect_compat("item_selected", this, "_tree_item_selected");
-	tree->connect_compat("item_activated", this, "_tree_item_activated");
-	tree->connect_compat("item_rmb_selected", this, "_rmb_pressed");
+	connect_dialog->connect("connected", Callable(this, "_make_or_edit_connection"));
+	tree->connect("item_selected", Callable(this, "_tree_item_selected"));
+	tree->connect("item_activated", Callable(this, "_tree_item_activated"));
+	tree->connect("item_rmb_selected", Callable(this, "_rmb_pressed"));
 
 	add_constant_override("separation", 3 * EDSCALE);
 }

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -459,13 +459,13 @@ void CreateDialog::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			connect_compat("confirmed", this, "_confirmed");
+			connect("confirmed", Callable(this, "_confirmed"));
 			search_box->set_right_icon(get_icon("Search", "EditorIcons"));
 			search_box->set_clear_button_enabled(true);
 			favorite->set_icon(get_icon("Favorites", "EditorIcons"));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			disconnect_compat("confirmed", this, "_confirmed");
+			disconnect("confirmed", Callable(this, "_confirmed"));
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible_in_tree()) {
@@ -766,8 +766,8 @@ CreateDialog::CreateDialog() {
 	favorites->set_hide_root(true);
 	favorites->set_hide_folding(true);
 	favorites->set_allow_reselect(true);
-	favorites->connect_compat("cell_selected", this, "_favorite_selected");
-	favorites->connect_compat("item_activated", this, "_favorite_activated");
+	favorites->connect("cell_selected", Callable(this, "_favorite_selected"));
+	favorites->connect("item_activated", Callable(this, "_favorite_activated"));
 	favorites->set_drag_forwarding(this);
 	favorites->add_constant_override("draw_guides", 1);
 
@@ -781,8 +781,8 @@ CreateDialog::CreateDialog() {
 	recent->set_hide_root(true);
 	recent->set_hide_folding(true);
 	recent->set_allow_reselect(true);
-	recent->connect_compat("cell_selected", this, "_history_selected");
-	recent->connect_compat("item_activated", this, "_history_activated");
+	recent->connect("cell_selected", Callable(this, "_history_selected"));
+	recent->connect("item_activated", Callable(this, "_history_activated"));
 	recent->add_constant_override("draw_guides", 1);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
@@ -797,23 +797,23 @@ CreateDialog::CreateDialog() {
 	favorite->set_flat(true);
 	favorite->set_toggle_mode(true);
 	search_hb->add_child(favorite);
-	favorite->connect_compat("pressed", this, "_favorite_toggled");
+	favorite->connect("pressed", Callable(this, "_favorite_toggled"));
 	vbc->add_margin_child(TTR("Search:"), search_hb);
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_changed", Callable(this, "_text_changed"));
+	search_box->connect("gui_input", Callable(this, "_sbox_input"));
 	search_options = memnew(Tree);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 	get_ok()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect_compat("item_activated", this, "_confirmed");
-	search_options->connect_compat("cell_selected", this, "_item_selected");
+	search_options->connect("item_activated", Callable(this, "_confirmed"));
+	search_options->connect("cell_selected", Callable(this, "_item_selected"));
 	base_type = "Object";
 	preferred_search_result_type = "";
 
 	help_bit = memnew(EditorHelpBit);
 	vbc->add_margin_child(TTR("Description:"), help_bit);
-	help_bit->connect_compat("request_hide", this, "_closed");
+	help_bit->connect("request_hide", Callable(this, "_closed"));
 
 	type_blacklist.insert("PluginScript"); // PluginScript must be initialized before use, which is not possible here
 	type_blacklist.insert("ScriptCreateDialog"); // This is an exposed editor Node that doesn't have an Editor prefix.

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -105,7 +105,7 @@ void EditorDebuggerInspector::_bind_methods() {
 void EditorDebuggerInspector::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POSTINITIALIZE:
-			connect_compat("object_id_selected", this, "_object_selected");
+			connect("object_id_selected", Callable(this, "_object_selected"));
 			break;
 		case NOTIFICATION_ENTER_TREE:
 			edit(variables);
@@ -139,7 +139,7 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 		debugObj->remote_object_id = obj.id;
 		debugObj->type_name = obj.class_name;
 		remote_objects[obj.id] = debugObj;
-		debugObj->connect_compat("value_edited", this, "_object_edited");
+		debugObj->connect("value_edited", Callable(this, "_object_edited"));
 	}
 
 	int old_prop_size = debugObj->prop_list.size();

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -57,7 +57,7 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	tabs = memnew(TabContainer);
 	tabs->set_tab_align(TabContainer::ALIGN_LEFT);
 	tabs->set_tabs_visible(false);
-	tabs->connect_compat("tab_changed", this, "_debugger_changed");
+	tabs->connect("tab_changed", Callable(this, "_debugger_changed"));
 	add_child(tabs);
 
 	Ref<StyleBoxEmpty> empty;
@@ -69,10 +69,10 @@ EditorDebuggerNode::EditorDebuggerNode() {
 
 	// Remote scene tree
 	remote_scene_tree = memnew(EditorDebuggerTree);
-	remote_scene_tree->connect_compat("object_selected", this, "_remote_object_requested");
-	remote_scene_tree->connect_compat("save_node", this, "_save_node_requested");
+	remote_scene_tree->connect("object_selected", Callable(this, "_remote_object_requested"));
+	remote_scene_tree->connect("save_node", Callable(this, "_save_node_requested"));
 	EditorNode::get_singleton()->get_scene_tree_dock()->add_remote_tree_editor(remote_scene_tree);
-	EditorNode::get_singleton()->get_scene_tree_dock()->connect_compat("remote_tree_selected", this, "request_remote_tree");
+	EditorNode::get_singleton()->get_scene_tree_dock()->connect("remote_tree_selected", Callable(this, "request_remote_tree"));
 
 	remote_scene_tree_timeout = EDITOR_DEF("debugger/remote_scene_tree_refresh_interval", 1.0);
 	inspect_edited_object_timeout = EDITOR_DEF("debugger/remote_inspect_refresh_interval", 0.2);
@@ -80,23 +80,23 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	EditorNode *editor = EditorNode::get_singleton();
 	editor->get_undo_redo()->set_method_notify_callback(_method_changeds, this);
 	editor->get_undo_redo()->set_property_notify_callback(_property_changeds, this);
-	editor->get_pause_button()->connect_compat("pressed", this, "_paused");
+	editor->get_pause_button()->connect("pressed", Callable(this, "_paused"));
 }
 
 ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 	ScriptEditorDebugger *node = memnew(ScriptEditorDebugger(EditorNode::get_singleton()));
 
 	int id = tabs->get_tab_count();
-	node->connect_compat("stop_requested", this, "_debugger_wants_stop", varray(id));
-	node->connect_compat("stopped", this, "_debugger_stopped", varray(id));
-	node->connect_compat("stack_frame_selected", this, "_stack_frame_selected", varray(id));
-	node->connect_compat("error_selected", this, "_error_selected", varray(id));
-	node->connect_compat("clear_execution", this, "_clear_execution");
-	node->connect_compat("breaked", this, "_breaked", varray(id));
-	node->connect_compat("remote_tree_updated", this, "_remote_tree_updated", varray(id));
-	node->connect_compat("remote_object_updated", this, "_remote_object_updated", varray(id));
-	node->connect_compat("remote_object_property_updated", this, "_remote_object_property_updated", varray(id));
-	node->connect_compat("remote_object_requested", this, "_remote_object_requested", varray(id));
+	node->connect("stop_requested", Callable(this, "_debugger_wants_stop"), varray(id));
+	node->connect("stopped", Callable(this, "_debugger_stopped"), varray(id));
+	node->connect("stack_frame_selected", Callable(this, "_stack_frame_selected"), varray(id));
+	node->connect("error_selected", Callable(this, "_error_selected"), varray(id));
+	node->connect("clear_execution", Callable(this, "_clear_execution"));
+	node->connect("breaked", Callable(this, "_breaked"), varray(id));
+	node->connect("remote_tree_updated", Callable(this, "_remote_tree_updated"), varray(id));
+	node->connect("remote_object_updated", Callable(this, "_remote_object_updated"), varray(id));
+	node->connect("remote_object_property_updated", Callable(this, "_remote_object_property_updated"), varray(id));
+	node->connect("remote_object_requested", Callable(this, "_remote_object_requested"), varray(id));
 
 	if (tabs->get_tab_count() > 0) {
 		get_debugger(0)->clear_style();
@@ -229,12 +229,12 @@ void EditorDebuggerNode::stop() {
 void EditorDebuggerNode::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			EditorNode::get_singleton()->connect_compat("play_pressed", this, "start");
-			EditorNode::get_singleton()->connect_compat("stop_pressed", this, "stop");
+			EditorNode::get_singleton()->connect("play_pressed", Callable(this, "start"));
+			EditorNode::get_singleton()->connect("stop_pressed", Callable(this, "stop"));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			EditorNode::get_singleton()->disconnect_compat("play_pressed", this, "start");
-			EditorNode::get_singleton()->disconnect_compat("stop_pressed", this, "stop");
+			EditorNode::get_singleton()->disconnect("play_pressed", Callable(this, "start"));
+			EditorNode::get_singleton()->disconnect("stop_pressed", Callable(this, "stop"));
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (tabs->get_tab_count() > 1) {
@@ -390,7 +390,7 @@ void EditorDebuggerNode::set_script_debug_button(MenuButton *p_button) {
 	p->add_separator();
 	p->add_check_shortcut(ED_GET_SHORTCUT("debugger/keep_debugger_open"), DEBUG_SHOW_KEEP_OPEN);
 	p->add_check_shortcut(ED_GET_SHORTCUT("debugger/debug_with_external_editor"), DEBUG_WITH_EXTERNAL_EDITOR);
-	p->connect_compat("id_pressed", this, "_menu_option");
+	p->connect("id_pressed", Callable(this, "_menu_option"));
 
 	_break_state_changed();
 	script_menu->show();

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -40,20 +40,20 @@ EditorDebuggerTree::EditorDebuggerTree() {
 
 	// Popup
 	item_menu = memnew(PopupMenu);
-	item_menu->connect_compat("id_pressed", this, "_item_menu_id_pressed");
+	item_menu->connect("id_pressed", Callable(this, "_item_menu_id_pressed"));
 	add_child(item_menu);
 
 	// File Dialog
 	file_dialog = memnew(EditorFileDialog);
-	file_dialog->connect_compat("file_selected", this, "_file_selected");
+	file_dialog->connect("file_selected", Callable(this, "_file_selected"));
 	add_child(file_dialog);
 }
 
 void EditorDebuggerTree::_notification(int p_what) {
 	if (p_what == NOTIFICATION_POSTINITIALIZE) {
-		connect_compat("cell_selected", this, "_scene_tree_selected");
-		connect_compat("item_collapsed", this, "_scene_tree_folded");
-		connect_compat("item_rmb_selected", this, "_scene_tree_rmb_selected");
+		connect("cell_selected", Callable(this, "_scene_tree_selected"));
+		connect("item_collapsed", Callable(this, "_scene_tree_folded"));
+		connect("item_rmb_selected", Callable(this, "_scene_tree_rmb_selected"));
 	}
 }
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -763,10 +763,10 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			next->set_icon(get_icon("DebugNext", "EditorIcons"));
 			dobreak->set_icon(get_icon("Pause", "EditorIcons"));
 			docontinue->set_icon(get_icon("DebugContinue", "EditorIcons"));
-			le_set->connect_compat("pressed", this, "_live_edit_set");
-			le_clear->connect_compat("pressed", this, "_live_edit_clear");
-			error_tree->connect_compat("item_selected", this, "_error_selected");
-			error_tree->connect_compat("item_activated", this, "_error_activated");
+			le_set->connect("pressed", Callable(this, "_live_edit_set"));
+			le_clear->connect("pressed", Callable(this, "_live_edit_clear"));
+			error_tree->connect("item_selected", Callable(this, "_error_selected"));
+			error_tree->connect("item_activated", Callable(this, "_error_activated"));
 			vmem_refresh->set_icon(get_icon("Reload", "EditorIcons"));
 
 			reason->add_color_override("font_color", get_color("error_color", "Editor"));
@@ -1543,7 +1543,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	tabs = memnew(TabContainer);
 	tabs->set_tab_align(TabContainer::ALIGN_LEFT);
 	tabs->add_style_override("panel", editor->get_gui_base()->get_stylebox("DebuggerPanel", "EditorStyles"));
-	tabs->connect_compat("tab_changed", this, "_tab_changed");
+	tabs->connect("tab_changed", Callable(this, "_tab_changed"));
 
 	add_child(tabs);
 
@@ -1568,14 +1568,14 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		skip_breakpoints = memnew(ToolButton);
 		hbc->add_child(skip_breakpoints);
 		skip_breakpoints->set_tooltip(TTR("Skip Breakpoints"));
-		skip_breakpoints->connect_compat("pressed", this, "debug_skip_breakpoints");
+		skip_breakpoints->connect("pressed", Callable(this, "debug_skip_breakpoints"));
 
 		hbc->add_child(memnew(VSeparator));
 
 		copy = memnew(ToolButton);
 		hbc->add_child(copy);
 		copy->set_tooltip(TTR("Copy Error"));
-		copy->connect_compat("pressed", this, "debug_copy");
+		copy->connect("pressed", Callable(this, "debug_copy"));
 
 		hbc->add_child(memnew(VSeparator));
 
@@ -1583,13 +1583,13 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		hbc->add_child(step);
 		step->set_tooltip(TTR("Step Into"));
 		step->set_shortcut(ED_GET_SHORTCUT("debugger/step_into"));
-		step->connect_compat("pressed", this, "debug_step");
+		step->connect("pressed", Callable(this, "debug_step"));
 
 		next = memnew(ToolButton);
 		hbc->add_child(next);
 		next->set_tooltip(TTR("Step Over"));
 		next->set_shortcut(ED_GET_SHORTCUT("debugger/step_over"));
-		next->connect_compat("pressed", this, "debug_next");
+		next->connect("pressed", Callable(this, "debug_next"));
 
 		hbc->add_child(memnew(VSeparator));
 
@@ -1597,13 +1597,13 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		hbc->add_child(dobreak);
 		dobreak->set_tooltip(TTR("Break"));
 		dobreak->set_shortcut(ED_GET_SHORTCUT("debugger/break"));
-		dobreak->connect_compat("pressed", this, "debug_break");
+		dobreak->connect("pressed", Callable(this, "debug_break"));
 
 		docontinue = memnew(ToolButton);
 		hbc->add_child(docontinue);
 		docontinue->set_tooltip(TTR("Continue"));
 		docontinue->set_shortcut(ED_GET_SHORTCUT("debugger/continue"));
-		docontinue->connect_compat("pressed", this, "debug_continue");
+		docontinue->connect("pressed", Callable(this, "debug_continue"));
 
 		HSplitContainer *sc = memnew(HSplitContainer);
 		vbc->add_child(sc);
@@ -1616,16 +1616,16 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		stack_dump->set_column_title(0, TTR("Stack Frames"));
 		stack_dump->set_h_size_flags(SIZE_EXPAND_FILL);
 		stack_dump->set_hide_root(true);
-		stack_dump->connect_compat("cell_selected", this, "_stack_dump_frame_selected");
+		stack_dump->connect("cell_selected", Callable(this, "_stack_dump_frame_selected"));
 		sc->add_child(stack_dump);
 
 		inspector = memnew(EditorDebuggerInspector);
 		inspector->set_h_size_flags(SIZE_EXPAND_FILL);
 		inspector->set_enable_capitalize_paths(false);
 		inspector->set_read_only(true);
-		inspector->connect_compat("object_selected", this, "_remote_object_selected");
-		inspector->connect_compat("object_edited", this, "_remote_object_edited");
-		inspector->connect_compat("object_property_updated", this, "_remote_object_property_updated");
+		inspector->connect("object_selected", Callable(this, "_remote_object_selected"));
+		inspector->connect("object_edited", Callable(this, "_remote_object_edited"));
+		inspector->connect("object_property_updated", Callable(this, "_remote_object_property_updated"));
 		sc->add_child(inspector);
 		tabs->add_child(dbg);
 	}
@@ -1639,12 +1639,12 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 		Button *expand_all = memnew(Button);
 		expand_all->set_text(TTR("Expand All"));
-		expand_all->connect_compat("pressed", this, "_expand_errors_list");
+		expand_all->connect("pressed", Callable(this, "_expand_errors_list"));
 		errhb->add_child(expand_all);
 
 		Button *collapse_all = memnew(Button);
 		collapse_all->set_text(TTR("Collapse All"));
-		collapse_all->connect_compat("pressed", this, "_collapse_errors_list");
+		collapse_all->connect("pressed", Callable(this, "_collapse_errors_list"));
 		errhb->add_child(collapse_all);
 
 		Control *space = memnew(Control);
@@ -1654,7 +1654,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		clearbutton = memnew(Button);
 		clearbutton->set_text(TTR("Clear"));
 		clearbutton->set_h_size_flags(0);
-		clearbutton->connect_compat("pressed", this, "_clear_errors_list");
+		clearbutton->connect("pressed", Callable(this, "_clear_errors_list"));
 		errhb->add_child(clearbutton);
 
 		error_tree = memnew(Tree);
@@ -1669,11 +1669,11 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		error_tree->set_hide_root(true);
 		error_tree->set_v_size_flags(SIZE_EXPAND_FILL);
 		error_tree->set_allow_rmb_select(true);
-		error_tree->connect_compat("item_rmb_selected", this, "_error_tree_item_rmb_selected");
+		error_tree->connect("item_rmb_selected", Callable(this, "_error_tree_item_rmb_selected"));
 		errors_tab->add_child(error_tree);
 
 		item_menu = memnew(PopupMenu);
-		item_menu->connect_compat("id_pressed", this, "_item_menu_id_pressed");
+		item_menu->connect("id_pressed", Callable(this, "_item_menu_id_pressed"));
 		error_tree->add_child(item_menu);
 
 		tabs->add_child(errors_tab);
@@ -1681,7 +1681,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 	{ // File dialog
 		file_dialog = memnew(EditorFileDialog);
-		file_dialog->connect_compat("file_selected", this, "_file_selected");
+		file_dialog->connect("file_selected", Callable(this, "_file_selected"));
 		add_child(file_dialog);
 	}
 
@@ -1689,23 +1689,23 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		profiler = memnew(EditorProfiler);
 		profiler->set_name(TTR("Profiler"));
 		tabs->add_child(profiler);
-		profiler->connect_compat("enable_profiling", this, "_profiler_activate");
-		profiler->connect_compat("break_request", this, "_profiler_seeked");
+		profiler->connect("enable_profiling", Callable(this, "_profiler_activate"));
+		profiler->connect("break_request", Callable(this, "_profiler_seeked"));
 	}
 
 	{ //frame profiler
 		visual_profiler = memnew(EditorVisualProfiler);
 		visual_profiler->set_name(TTR("Visual Profiler"));
 		tabs->add_child(visual_profiler);
-		visual_profiler->connect_compat("enable_profiling", this, "_visual_profiler_activate");
-		visual_profiler->connect_compat("break_request", this, "_profiler_seeked");
+		visual_profiler->connect("enable_profiling", Callable(this, "_visual_profiler_activate"));
+		visual_profiler->connect("break_request", Callable(this, "_profiler_seeked"));
 	}
 
 	{ //network profiler
 		network_profiler = memnew(EditorNetworkProfiler);
 		network_profiler->set_name(TTR("Network Profiler"));
 		tabs->add_child(network_profiler);
-		network_profiler->connect_compat("enable_profiling", this, "_network_profiler_activate");
+		network_profiler->connect("enable_profiling", Callable(this, "_network_profiler_activate"));
 	}
 
 	{ //monitors
@@ -1717,12 +1717,12 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		perf_monitors->set_column_title(0, TTR("Monitor"));
 		perf_monitors->set_column_title(1, TTR("Value"));
 		perf_monitors->set_column_titles_visible(true);
-		perf_monitors->connect_compat("item_edited", this, "_performance_select");
+		perf_monitors->connect("item_edited", Callable(this, "_performance_select"));
 		hsp->add_child(perf_monitors);
 
 		perf_draw = memnew(Control);
 		perf_draw->set_clip_contents(true);
-		perf_draw->connect_compat("draw", this, "_performance_draw");
+		perf_draw->connect("draw", Callable(this, "_performance_draw"));
 		hsp->add_child(perf_draw);
 
 		hsp->set_name(TTR("Monitors"));
@@ -1783,7 +1783,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		vmem_refresh = memnew(ToolButton);
 		vmem_hb->add_child(vmem_refresh);
 		vmem_vb->add_child(vmem_hb);
-		vmem_refresh->connect_compat("pressed", this, "_video_mem_request");
+		vmem_refresh->connect("pressed", Callable(this, "_video_mem_request"));
 
 		VBoxContainer *vmmc = memnew(VBoxContainer);
 		vmem_tree = memnew(Tree);
@@ -1849,7 +1849,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		HBoxContainer *buttons = memnew(HBoxContainer);
 
 		export_csv = memnew(Button(TTR("Export measures as CSV")));
-		export_csv->connect_compat("pressed", this, "_export_csv");
+		export_csv->connect("pressed", Callable(this, "_export_csv"));
 		buttons->add_child(export_csv);
 
 		misc->add_child(buttons);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -247,7 +247,7 @@ DependencyEditor::DependencyEditor() {
 	tree->set_column_title(0, TTR("Resource"));
 	tree->set_column_title(1, TTR("Path"));
 	tree->set_hide_root(true);
-	tree->connect_compat("button_pressed", this, "_load_pressed");
+	tree->connect("button_pressed", Callable(this, "_load_pressed"));
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	Label *label = memnew(Label(TTR("Dependencies:")));
@@ -255,7 +255,7 @@ DependencyEditor::DependencyEditor() {
 	hbc->add_spacer();
 	fixdeps = memnew(Button(TTR("Fix Broken")));
 	hbc->add_child(fixdeps);
-	fixdeps->connect_compat("pressed", this, "_fix_all");
+	fixdeps->connect("pressed", Callable(this, "_fix_all"));
 
 	vb->add_child(hbc);
 
@@ -267,7 +267,7 @@ DependencyEditor::DependencyEditor() {
 
 	set_title(TTR("Dependency Editor"));
 	search = memnew(EditorFileDialog);
-	search->connect_compat("file_selected", this, "_searched");
+	search->connect("file_selected", Callable(this, "_searched"));
 	search->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 	search->set_title(TTR("Search Replacement Resource:"));
 	add_child(search);
@@ -360,12 +360,12 @@ DependencyEditorOwners::DependencyEditorOwners(EditorNode *p_editor) {
 
 	file_options = memnew(PopupMenu);
 	add_child(file_options);
-	file_options->connect_compat("id_pressed", this, "_file_option");
+	file_options->connect("id_pressed", Callable(this, "_file_option"));
 
 	owners = memnew(ItemList);
 	owners->set_select_mode(ItemList::SELECT_SINGLE);
-	owners->connect_compat("item_rmb_selected", this, "_list_rmb_select");
-	owners->connect_compat("item_activated", this, "_select_file");
+	owners->connect("item_rmb_selected", Callable(this, "_list_rmb_select"));
+	owners->connect("item_activated", Callable(this, "_select_file"));
 	owners->set_allow_rmb_select(true);
 	add_child(owners);
 }
@@ -800,7 +800,7 @@ OrphanResourcesDialog::OrphanResourcesDialog() {
 	add_child(delete_confirm);
 	dep_edit = memnew(DependencyEditor);
 	add_child(dep_edit);
-	delete_confirm->connect_compat("confirmed", this, "_delete_confirm");
+	delete_confirm->connect("confirmed", Callable(this, "_delete_confirm"));
 	set_hide_on_ok(false);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
@@ -816,5 +816,5 @@ OrphanResourcesDialog::OrphanResourcesDialog() {
 	files->set_column_title(1, TTR("Owns"));
 	files->set_hide_root(true);
 	vbc->add_margin_child(TTR("Resources Without Explicit Ownership:"), files, true);
-	files->connect_compat("button_pressed", this, "_button_pressed");
+	files->connect("button_pressed", Callable(this, "_button_pressed"));
 }

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -255,7 +255,7 @@ EditorAbout::EditorAbout() {
 	_tpl_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tpl_hbc->add_child(_tpl_text);
 
-	_tpl_tree->connect_compat("item_selected", this, "_license_tree_selected");
+	_tpl_tree->connect("item_selected", Callable(this, "_license_tree_selected"));
 	tpl_ti_all->select(0);
 	_tpl_text->set_text(tpl_ti_all->get_metadata(0));
 }

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -318,7 +318,7 @@ EditorAssetInstaller::EditorAssetInstaller() {
 
 	tree = memnew(Tree);
 	vb->add_margin_child(TTR("Package Contents:"), tree, true);
-	tree->connect_compat("item_edited", this, "_item_edited");
+	tree->connect("item_edited", Callable(this, "_item_edited"));
 
 	error = memnew(AcceptDialog);
 	add_child(error);

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -799,8 +799,8 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	set_v_size_flags(SIZE_EXPAND_FILL);
 
 	track_name = memnew(LineEdit);
-	track_name->connect_compat("text_entered", this, "_name_changed");
-	track_name->connect_compat("focus_exited", this, "_name_focus_exit");
+	track_name->connect("text_entered", Callable(this, "_name_changed"));
+	track_name->connect("focus_exited", Callable(this, "_name_focus_exit"));
 	vb->add_child(track_name);
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
@@ -809,19 +809,19 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	solo->set_toggle_mode(true);
 	solo->set_tooltip(TTR("Solo"));
 	solo->set_focus_mode(FOCUS_NONE);
-	solo->connect_compat("pressed", this, "_solo_toggled");
+	solo->connect("pressed", Callable(this, "_solo_toggled"));
 	hbc->add_child(solo);
 	mute = memnew(ToolButton);
 	mute->set_toggle_mode(true);
 	mute->set_tooltip(TTR("Mute"));
 	mute->set_focus_mode(FOCUS_NONE);
-	mute->connect_compat("pressed", this, "_mute_toggled");
+	mute->connect("pressed", Callable(this, "_mute_toggled"));
 	hbc->add_child(mute);
 	bypass = memnew(ToolButton);
 	bypass->set_toggle_mode(true);
 	bypass->set_tooltip(TTR("Bypass"));
 	bypass->set_focus_mode(FOCUS_NONE);
-	bypass->connect_compat("pressed", this, "_bypass_toggled");
+	bypass->connect("pressed", Callable(this, "_bypass_toggled"));
 	hbc->add_child(bypass);
 	hbc->add_spacer();
 
@@ -878,9 +878,9 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	preview_timer->set_one_shot(true);
 	add_child(preview_timer);
 
-	slider->connect_compat("value_changed", this, "_volume_changed");
-	slider->connect_compat("value_changed", this, "_show_value");
-	preview_timer->connect_compat("timeout", this, "_hide_value_preview");
+	slider->connect("value_changed", Callable(this, "_volume_changed"));
+	slider->connect("value_changed", Callable(this, "_show_value"));
+	preview_timer->connect("timeout", Callable(this, "_hide_value_preview"));
 	hb->add_child(slider);
 
 	cc = 0;
@@ -918,24 +918,24 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	effects->set_hide_folding(true);
 	effects->set_v_size_flags(SIZE_EXPAND_FILL);
 	vb->add_child(effects);
-	effects->connect_compat("item_edited", this, "_effect_edited");
-	effects->connect_compat("cell_selected", this, "_effect_selected");
+	effects->connect("item_edited", Callable(this, "_effect_edited"));
+	effects->connect("cell_selected", Callable(this, "_effect_selected"));
 	effects->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
 	effects->set_drag_forwarding(this);
-	effects->connect_compat("item_rmb_selected", this, "_effect_rmb");
+	effects->connect("item_rmb_selected", Callable(this, "_effect_rmb"));
 	effects->set_allow_rmb_select(true);
 	effects->set_focus_mode(FOCUS_CLICK);
 	effects->set_allow_reselect(true);
 
 	send = memnew(OptionButton);
 	send->set_clip_text(true);
-	send->connect_compat("item_selected", this, "_send_selected");
+	send->connect("item_selected", Callable(this, "_send_selected"));
 	vb->add_child(send);
 
 	set_focus_mode(FOCUS_CLICK);
 
 	effect_options = memnew(PopupMenu);
-	effect_options->connect_compat("index_pressed", this, "_effect_add");
+	effect_options->connect("index_pressed", Callable(this, "_effect_add"));
 	add_child(effect_options);
 	List<StringName> effects;
 	ClassDB::get_inheriters_from_class("AudioEffect", &effects);
@@ -956,12 +956,12 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	bus_popup->add_item(TTR("Delete"));
 	bus_popup->set_item_disabled(1, is_master);
 	bus_popup->add_item(TTR("Reset Volume"));
-	bus_popup->connect_compat("index_pressed", this, "_bus_popup_pressed");
+	bus_popup->connect("index_pressed", Callable(this, "_bus_popup_pressed"));
 
 	delete_effect_popup = memnew(PopupMenu);
 	delete_effect_popup->add_item(TTR("Delete Effect"));
 	add_child(delete_effect_popup);
-	delete_effect_popup->connect_compat("index_pressed", this, "_delete_effect_pressed");
+	delete_effect_popup->connect("index_pressed", Callable(this, "_delete_effect_pressed"));
 }
 
 void EditorAudioBusDrop::_notification(int p_what) {
@@ -1029,11 +1029,11 @@ void EditorAudioBuses::_update_buses() {
 		bool is_master = (i == 0);
 		EditorAudioBus *audio_bus = memnew(EditorAudioBus(this, is_master));
 		bus_hb->add_child(audio_bus);
-		audio_bus->connect_compat("delete_request", this, "_delete_bus", varray(audio_bus), CONNECT_DEFERRED);
-		audio_bus->connect_compat("duplicate_request", this, "_duplicate_bus", varray(), CONNECT_DEFERRED);
-		audio_bus->connect_compat("vol_reset_request", this, "_reset_bus_volume", varray(audio_bus), CONNECT_DEFERRED);
-		audio_bus->connect_compat("drop_end_request", this, "_request_drop_end");
-		audio_bus->connect_compat("dropped", this, "_drop_at_index", varray(), CONNECT_DEFERRED);
+		audio_bus->connect("delete_request", Callable(this, "_delete_bus"), varray(audio_bus), CONNECT_DEFERRED);
+		audio_bus->connect("duplicate_request", Callable(this, "_duplicate_bus"), varray(), CONNECT_DEFERRED);
+		audio_bus->connect("vol_reset_request", Callable(this, "_reset_bus_volume"), varray(audio_bus), CONNECT_DEFERRED);
+		audio_bus->connect("drop_end_request", Callable(this, "_request_drop_end"));
+		audio_bus->connect("dropped", Callable(this, "_drop_at_index"), varray(), CONNECT_DEFERRED);
 	}
 }
 
@@ -1187,7 +1187,7 @@ void EditorAudioBuses::_request_drop_end() {
 
 		bus_hb->add_child(drop_end);
 		drop_end->set_custom_minimum_size(Object::cast_to<Control>(bus_hb->get_child(0))->get_size());
-		drop_end->connect_compat("dropped", this, "_drop_at_index", varray(), CONNECT_DEFERRED);
+		drop_end->connect("dropped", Callable(this, "_drop_at_index"), varray(), CONNECT_DEFERRED);
 	}
 }
 
@@ -1339,7 +1339,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	top_hb->add_child(add);
 	add->set_text(TTR("Add Bus"));
 	add->set_tooltip(TTR("Add a new Audio Bus to this layout."));
-	add->connect_compat("pressed", this, "_add_bus");
+	add->connect("pressed", Callable(this, "_add_bus"));
 
 	VSeparator *separator = memnew(VSeparator);
 	top_hb->add_child(separator);
@@ -1348,25 +1348,25 @@ EditorAudioBuses::EditorAudioBuses() {
 	load->set_text(TTR("Load"));
 	load->set_tooltip(TTR("Load an existing Bus Layout."));
 	top_hb->add_child(load);
-	load->connect_compat("pressed", this, "_load_layout");
+	load->connect("pressed", Callable(this, "_load_layout"));
 
 	save_as = memnew(Button);
 	save_as->set_text(TTR("Save As"));
 	save_as->set_tooltip(TTR("Save this Bus Layout to a file."));
 	top_hb->add_child(save_as);
-	save_as->connect_compat("pressed", this, "_save_as_layout");
+	save_as->connect("pressed", Callable(this, "_save_as_layout"));
 
 	_default = memnew(Button);
 	_default->set_text(TTR("Load Default"));
 	_default->set_tooltip(TTR("Load the default Bus Layout."));
 	top_hb->add_child(_default);
-	_default->connect_compat("pressed", this, "_load_default_layout");
+	_default->connect("pressed", Callable(this, "_load_default_layout"));
 
 	_new = memnew(Button);
 	_new->set_text(TTR("Create"));
 	_new->set_tooltip(TTR("Create a new Bus Layout."));
 	top_hb->add_child(_new);
-	_new->connect_compat("pressed", this, "_new_layout");
+	_new->connect("pressed", Callable(this, "_new_layout"));
 
 	bus_scroll = memnew(ScrollContainer);
 	bus_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
@@ -1381,7 +1381,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	save_timer->set_wait_time(0.8);
 	save_timer->set_one_shot(true);
 	add_child(save_timer);
-	save_timer->connect_compat("timeout", this, "_server_save");
+	save_timer->connect("timeout", Callable(this, "_server_save"));
 
 	set_v_size_flags(SIZE_EXPAND_FILL);
 
@@ -1394,7 +1394,7 @@ EditorAudioBuses::EditorAudioBuses() {
 		file_dialog->add_filter("*." + E->get() + "; Audio Bus Layout");
 	}
 	add_child(file_dialog);
-	file_dialog->connect_compat("file_selected", this, "_file_dialog_callback");
+	file_dialog->connect("file_selected", Callable(this, "_file_dialog_callback"));
 
 	set_process(true);
 }

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -835,8 +835,8 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	autoload_add_path = memnew(EditorLineEditFileChooser);
 	autoload_add_path->set_h_size_flags(SIZE_EXPAND_FILL);
 	autoload_add_path->get_file_dialog()->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-	autoload_add_path->get_file_dialog()->connect_compat("file_selected", this, "_autoload_file_callback");
-	autoload_add_path->get_line_edit()->connect_compat("text_changed", this, "_autoload_path_text_changed");
+	autoload_add_path->get_file_dialog()->connect("file_selected", Callable(this, "_autoload_file_callback"));
+	autoload_add_path->get_line_edit()->connect("text_changed", Callable(this, "_autoload_path_text_changed"));
 
 	hbc->add_child(autoload_add_path);
 
@@ -846,13 +846,13 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	autoload_add_name = memnew(LineEdit);
 	autoload_add_name->set_h_size_flags(SIZE_EXPAND_FILL);
-	autoload_add_name->connect_compat("text_entered", this, "_autoload_text_entered");
-	autoload_add_name->connect_compat("text_changed", this, "_autoload_text_changed");
+	autoload_add_name->connect("text_entered", Callable(this, "_autoload_text_entered"));
+	autoload_add_name->connect("text_changed", Callable(this, "_autoload_text_changed"));
 	hbc->add_child(autoload_add_name);
 
 	add_autoload = memnew(Button);
 	add_autoload->set_text(TTR("Add"));
-	add_autoload->connect_compat("pressed", this, "_autoload_add");
+	add_autoload->connect("pressed", Callable(this, "_autoload_add"));
 	// The button will be enabled once a valid name is entered (either automatically or manually).
 	add_autoload->set_disabled(true);
 	hbc->add_child(add_autoload);
@@ -882,10 +882,10 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	tree->set_column_expand(3, false);
 	tree->set_column_min_width(3, 120 * EDSCALE);
 
-	tree->connect_compat("cell_selected", this, "_autoload_selected");
-	tree->connect_compat("item_edited", this, "_autoload_edited");
-	tree->connect_compat("button_pressed", this, "_autoload_button_pressed");
-	tree->connect_compat("item_activated", this, "_autoload_activated");
+	tree->connect("cell_selected", Callable(this, "_autoload_selected"));
+	tree->connect("item_edited", Callable(this, "_autoload_edited"));
+	tree->connect("button_pressed", Callable(this, "_autoload_button_pressed"));
+	tree->connect("item_activated", Callable(this, "_autoload_activated"));
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	add_child(tree, true);

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1024,7 +1024,7 @@ void EditorSelection::add_node(Node *p_node) {
 	}
 	selection[p_node] = meta;
 
-	p_node->connect_compat("tree_exiting", this, "_node_removed", varray(p_node), CONNECT_ONESHOT);
+	p_node->connect("tree_exiting", Callable(this, "_node_removed"), varray(p_node), CONNECT_ONESHOT);
 
 	//emit_signal("selection_changed");
 }
@@ -1042,7 +1042,7 @@ void EditorSelection::remove_node(Node *p_node) {
 	if (meta)
 		memdelete(meta);
 	selection.erase(p_node);
-	p_node->disconnect_compat("tree_exiting", this, "_node_removed");
+	p_node->disconnect("tree_exiting", Callable(this, "_node_removed"));
 	//emit_signal("selection_changed");
 }
 bool EditorSelection::is_selected(Node *p_node) const {

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -82,21 +82,21 @@ void EditorDirDialog::reload(const String &p_path) {
 void EditorDirDialog::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		EditorFileSystem::get_singleton()->connect_compat("filesystem_changed", this, "reload");
+		EditorFileSystem::get_singleton()->connect("filesystem_changed", Callable(this, "reload"));
 		reload();
 
-		if (!tree->is_connected_compat("item_collapsed", this, "_item_collapsed")) {
-			tree->connect_compat("item_collapsed", this, "_item_collapsed", varray(), CONNECT_DEFERRED);
+		if (!tree->is_connected("item_collapsed", Callable(this, "_item_collapsed"))) {
+			tree->connect("item_collapsed", Callable(this, "_item_collapsed"), varray(), CONNECT_DEFERRED);
 		}
 
-		if (!EditorFileSystem::get_singleton()->is_connected_compat("filesystem_changed", this, "reload")) {
-			EditorFileSystem::get_singleton()->connect_compat("filesystem_changed", this, "reload");
+		if (!EditorFileSystem::get_singleton()->is_connected("filesystem_changed", Callable(this, "reload"))) {
+			EditorFileSystem::get_singleton()->connect("filesystem_changed", Callable(this, "reload"));
 		}
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {
-		if (EditorFileSystem::get_singleton()->is_connected_compat("filesystem_changed", this, "reload")) {
-			EditorFileSystem::get_singleton()->disconnect_compat("filesystem_changed", this, "reload");
+		if (EditorFileSystem::get_singleton()->is_connected("filesystem_changed", Callable(this, "reload"))) {
+			EditorFileSystem::get_singleton()->disconnect("filesystem_changed", Callable(this, "reload"));
 		}
 	}
 
@@ -186,10 +186,10 @@ EditorDirDialog::EditorDirDialog() {
 	tree = memnew(Tree);
 	add_child(tree);
 
-	tree->connect_compat("item_activated", this, "_ok");
+	tree->connect("item_activated", Callable(this, "_ok"));
 
 	makedir = add_button(TTR("Create Folder"), OS::get_singleton()->get_swap_ok_cancel(), "makedir");
-	makedir->connect_compat("pressed", this, "_make_dir");
+	makedir->connect("pressed", Callable(this, "_make_dir"));
 
 	makedialog = memnew(ConfirmationDialog);
 	makedialog->set_title(TTR("Create Folder"));
@@ -202,7 +202,7 @@ EditorDirDialog::EditorDirDialog() {
 	makedirname = memnew(LineEdit);
 	makevb->add_margin_child(TTR("Name:"), makedirname);
 	makedialog->register_text_enter(makedirname);
-	makedialog->connect_compat("confirmed", this, "_make_dir_confirm");
+	makedialog->connect("confirmed", Callable(this, "_make_dir_confirm"));
 
 	mkdirerr = memnew(AcceptDialog);
 	mkdirerr->set_text(TTR("Could not create folder."));

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1416,7 +1416,7 @@ EditorExport::EditorExport() {
 	add_child(save_timer);
 	save_timer->set_wait_time(0.8);
 	save_timer->set_one_shot(true);
-	save_timer->connect_compat("timeout", this, "_save");
+	save_timer->connect("timeout", Callable(this, "_save"));
 	block_save = false;
 
 	singleton = this;

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -819,7 +819,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	profile_actions[PROFILE_CLEAR] = memnew(Button(TTR("Unset")));
 	name_hbc->add_child(profile_actions[PROFILE_CLEAR]);
 	profile_actions[PROFILE_CLEAR]->set_disabled(true);
-	profile_actions[PROFILE_CLEAR]->connect_compat("pressed", this, "_profile_action", varray(PROFILE_CLEAR));
+	profile_actions[PROFILE_CLEAR]->connect("pressed", Callable(this, "_profile_action"), varray(PROFILE_CLEAR));
 
 	main_vbc->add_margin_child(TTR("Current Profile:"), name_hbc);
 
@@ -827,34 +827,34 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	profile_list = memnew(OptionButton);
 	profile_list->set_h_size_flags(SIZE_EXPAND_FILL);
 	profiles_hbc->add_child(profile_list);
-	profile_list->connect_compat("item_selected", this, "_profile_selected");
+	profile_list->connect("item_selected", Callable(this, "_profile_selected"));
 
 	profile_actions[PROFILE_SET] = memnew(Button(TTR("Make Current")));
 	profiles_hbc->add_child(profile_actions[PROFILE_SET]);
 	profile_actions[PROFILE_SET]->set_disabled(true);
-	profile_actions[PROFILE_SET]->connect_compat("pressed", this, "_profile_action", varray(PROFILE_SET));
+	profile_actions[PROFILE_SET]->connect("pressed", Callable(this, "_profile_action"), varray(PROFILE_SET));
 
 	profile_actions[PROFILE_ERASE] = memnew(Button(TTR("Remove")));
 	profiles_hbc->add_child(profile_actions[PROFILE_ERASE]);
 	profile_actions[PROFILE_ERASE]->set_disabled(true);
-	profile_actions[PROFILE_ERASE]->connect_compat("pressed", this, "_profile_action", varray(PROFILE_ERASE));
+	profile_actions[PROFILE_ERASE]->connect("pressed", Callable(this, "_profile_action"), varray(PROFILE_ERASE));
 
 	profiles_hbc->add_child(memnew(VSeparator));
 
 	profile_actions[PROFILE_NEW] = memnew(Button(TTR("New")));
 	profiles_hbc->add_child(profile_actions[PROFILE_NEW]);
-	profile_actions[PROFILE_NEW]->connect_compat("pressed", this, "_profile_action", varray(PROFILE_NEW));
+	profile_actions[PROFILE_NEW]->connect("pressed", Callable(this, "_profile_action"), varray(PROFILE_NEW));
 
 	profiles_hbc->add_child(memnew(VSeparator));
 
 	profile_actions[PROFILE_IMPORT] = memnew(Button(TTR("Import")));
 	profiles_hbc->add_child(profile_actions[PROFILE_IMPORT]);
-	profile_actions[PROFILE_IMPORT]->connect_compat("pressed", this, "_profile_action", varray(PROFILE_IMPORT));
+	profile_actions[PROFILE_IMPORT]->connect("pressed", Callable(this, "_profile_action"), varray(PROFILE_IMPORT));
 
 	profile_actions[PROFILE_EXPORT] = memnew(Button(TTR("Export")));
 	profiles_hbc->add_child(profile_actions[PROFILE_EXPORT]);
 	profile_actions[PROFILE_EXPORT]->set_disabled(true);
-	profile_actions[PROFILE_EXPORT]->connect_compat("pressed", this, "_profile_action", varray(PROFILE_EXPORT));
+	profile_actions[PROFILE_EXPORT]->connect("pressed", Callable(this, "_profile_action"), varray(PROFILE_EXPORT));
 
 	main_vbc->add_margin_child(TTR("Available Profiles:"), profiles_hbc);
 
@@ -870,8 +870,8 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	class_list_vbc->add_margin_child(TTR("Enabled Classes:"), class_list, true);
 	class_list->set_hide_root(true);
 	class_list->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
-	class_list->connect_compat("cell_selected", this, "_class_list_item_selected");
-	class_list->connect_compat("item_edited", this, "_class_list_item_edited", varray(), CONNECT_DEFERRED);
+	class_list->connect("cell_selected", Callable(this, "_class_list_item_selected"));
+	class_list->connect("item_edited", Callable(this, "_class_list_item_edited"), varray(), CONNECT_DEFERRED);
 
 	VBoxContainer *property_list_vbc = memnew(VBoxContainer);
 	h_split->add_child(property_list_vbc);
@@ -882,7 +882,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	property_list->set_hide_root(true);
 	property_list->set_hide_folding(true);
 	property_list->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
-	property_list->connect_compat("item_edited", this, "_property_item_edited", varray(), CONNECT_DEFERRED);
+	property_list->connect("item_edited", Callable(this, "_property_item_edited"), varray(), CONNECT_DEFERRED);
 
 	new_profile_dialog = memnew(ConfirmationDialog);
 	new_profile_dialog->set_title(TTR("New profile name:"));
@@ -890,20 +890,20 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	new_profile_dialog->add_child(new_profile_name);
 	new_profile_name->set_custom_minimum_size(Size2(300 * EDSCALE, 1));
 	add_child(new_profile_dialog);
-	new_profile_dialog->connect_compat("confirmed", this, "_create_new_profile");
+	new_profile_dialog->connect("confirmed", Callable(this, "_create_new_profile"));
 	new_profile_dialog->register_text_enter(new_profile_name);
 	new_profile_dialog->get_ok()->set_text(TTR("Create"));
 
 	erase_profile_dialog = memnew(ConfirmationDialog);
 	add_child(erase_profile_dialog);
 	erase_profile_dialog->set_title(TTR("Erase Profile"));
-	erase_profile_dialog->connect_compat("confirmed", this, "_erase_selected_profile");
+	erase_profile_dialog->connect("confirmed", Callable(this, "_erase_selected_profile"));
 
 	import_profiles = memnew(EditorFileDialog);
 	add_child(import_profiles);
 	import_profiles->set_mode(EditorFileDialog::MODE_OPEN_FILES);
 	import_profiles->add_filter("*.profile; " + TTR("Godot Feature Profile"));
-	import_profiles->connect_compat("files_selected", this, "_import_profiles");
+	import_profiles->connect("files_selected", Callable(this, "_import_profiles"));
 	import_profiles->set_title(TTR("Import Profile(s)"));
 	import_profiles->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 
@@ -911,7 +911,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	add_child(export_profile);
 	export_profile->set_mode(EditorFileDialog::MODE_SAVE_FILE);
 	export_profile->add_filter("*.profile; " + TTR("Godot Feature Profile"));
-	export_profile->connect_compat("file_selected", this, "_export_profile");
+	export_profile->connect("file_selected", Callable(this, "_export_profile"));
 	export_profile->set_title(TTR("Export Profile"));
 	export_profile->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 
@@ -921,7 +921,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	update_timer = memnew(Timer);
 	update_timer->set_wait_time(1); //wait a second before updating editor
 	add_child(update_timer);
-	update_timer->connect_compat("timeout", this, "_emit_current_profile_changed");
+	update_timer->connect("timeout", Callable(this, "_emit_current_profile_changed"));
 	update_timer->set_one_shot(true);
 
 	updating_features = false;

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1537,9 +1537,9 @@ EditorFileDialog::EditorFileDialog() {
 	pathhb->add_child(dir_next);
 	pathhb->add_child(dir_up);
 
-	dir_prev->connect_compat("pressed", this, "_go_back");
-	dir_next->connect_compat("pressed", this, "_go_forward");
-	dir_up->connect_compat("pressed", this, "_go_up");
+	dir_prev->connect("pressed", Callable(this, "_go_back"));
+	dir_next->connect("pressed", Callable(this, "_go_forward"));
+	dir_up->connect("pressed", Callable(this, "_go_up"));
 
 	pathhb->add_child(memnew(Label(TTR("Path:"))));
 
@@ -1549,20 +1549,20 @@ EditorFileDialog::EditorFileDialog() {
 
 	refresh = memnew(ToolButton);
 	refresh->set_tooltip(TTR("Refresh files."));
-	refresh->connect_compat("pressed", this, "_update_file_list");
+	refresh->connect("pressed", Callable(this, "_update_file_list"));
 	pathhb->add_child(refresh);
 
 	favorite = memnew(ToolButton);
 	favorite->set_toggle_mode(true);
 	favorite->set_tooltip(TTR("(Un)favorite current folder."));
-	favorite->connect_compat("pressed", this, "_favorite_pressed");
+	favorite->connect("pressed", Callable(this, "_favorite_pressed"));
 	pathhb->add_child(favorite);
 
 	show_hidden = memnew(ToolButton);
 	show_hidden->set_toggle_mode(true);
 	show_hidden->set_pressed(is_showing_hidden_files());
 	show_hidden->set_tooltip(TTR("Toggle the visibility of hidden files."));
-	show_hidden->connect_compat("toggled", this, "set_show_hidden_files");
+	show_hidden->connect("toggled", Callable(this, "set_show_hidden_files"));
 	pathhb->add_child(show_hidden);
 
 	pathhb->add_child(memnew(VSeparator));
@@ -1571,7 +1571,7 @@ EditorFileDialog::EditorFileDialog() {
 	view_mode_group.instance();
 
 	mode_thumbnails = memnew(ToolButton);
-	mode_thumbnails->connect_compat("pressed", this, "set_display_mode", varray(DISPLAY_THUMBNAILS));
+	mode_thumbnails->connect("pressed", Callable(this, "set_display_mode"), varray(DISPLAY_THUMBNAILS));
 	mode_thumbnails->set_toggle_mode(true);
 	mode_thumbnails->set_pressed(display_mode == DISPLAY_THUMBNAILS);
 	mode_thumbnails->set_button_group(view_mode_group);
@@ -1579,7 +1579,7 @@ EditorFileDialog::EditorFileDialog() {
 	pathhb->add_child(mode_thumbnails);
 
 	mode_list = memnew(ToolButton);
-	mode_list->connect_compat("pressed", this, "set_display_mode", varray(DISPLAY_LIST));
+	mode_list->connect("pressed", Callable(this, "set_display_mode"), varray(DISPLAY_LIST));
 	mode_list->set_toggle_mode(true);
 	mode_list->set_pressed(display_mode == DISPLAY_LIST);
 	mode_list->set_button_group(view_mode_group);
@@ -1588,11 +1588,11 @@ EditorFileDialog::EditorFileDialog() {
 
 	drives = memnew(OptionButton);
 	pathhb->add_child(drives);
-	drives->connect_compat("item_selected", this, "_select_drive");
+	drives->connect("item_selected", Callable(this, "_select_drive"));
 
 	makedir = memnew(Button);
 	makedir->set_text(TTR("Create Folder"));
-	makedir->connect_compat("pressed", this, "_make_dir");
+	makedir->connect("pressed", Callable(this, "_make_dir"));
 	pathhb->add_child(makedir);
 
 	list_hb = memnew(HSplitContainer);
@@ -1614,15 +1614,15 @@ EditorFileDialog::EditorFileDialog() {
 	fav_hb->add_spacer();
 	fav_up = memnew(ToolButton);
 	fav_hb->add_child(fav_up);
-	fav_up->connect_compat("pressed", this, "_favorite_move_up");
+	fav_up->connect("pressed", Callable(this, "_favorite_move_up"));
 	fav_down = memnew(ToolButton);
 	fav_hb->add_child(fav_down);
-	fav_down->connect_compat("pressed", this, "_favorite_move_down");
+	fav_down->connect("pressed", Callable(this, "_favorite_move_down"));
 
 	favorites = memnew(ItemList);
 	fav_vb->add_child(favorites);
 	favorites->set_v_size_flags(SIZE_EXPAND_FILL);
-	favorites->connect_compat("item_selected", this, "_favorite_selected");
+	favorites->connect("item_selected", Callable(this, "_favorite_selected"));
 
 	VBoxContainer *rec_vb = memnew(VBoxContainer);
 	vsc->add_child(rec_vb);
@@ -1631,7 +1631,7 @@ EditorFileDialog::EditorFileDialog() {
 	recent = memnew(ItemList);
 	recent->set_allow_reselect(true);
 	rec_vb->add_margin_child(TTR("Recent:"), recent, true);
-	recent->connect_compat("item_selected", this, "_recent_selected");
+	recent->connect("item_selected", Callable(this, "_recent_selected"));
 
 	VBoxContainer *item_vb = memnew(VBoxContainer);
 	list_hb->add_child(item_vb);
@@ -1650,13 +1650,13 @@ EditorFileDialog::EditorFileDialog() {
 
 	item_list = memnew(ItemList);
 	item_list->set_v_size_flags(SIZE_EXPAND_FILL);
-	item_list->connect_compat("item_rmb_selected", this, "_item_list_item_rmb_selected");
-	item_list->connect_compat("rmb_clicked", this, "_item_list_rmb_clicked");
+	item_list->connect("item_rmb_selected", Callable(this, "_item_list_item_rmb_selected"));
+	item_list->connect("rmb_clicked", Callable(this, "_item_list_rmb_clicked"));
 	item_list->set_allow_rmb_select(true);
 	list_vb->add_child(item_list);
 
 	item_menu = memnew(PopupMenu);
-	item_menu->connect_compat("id_pressed", this, "_item_menu_id_pressed");
+	item_menu->connect("id_pressed", Callable(this, "_item_menu_id_pressed"));
 	add_child(item_menu);
 
 	// Other stuff.
@@ -1687,19 +1687,19 @@ EditorFileDialog::EditorFileDialog() {
 	access = ACCESS_RESOURCES;
 	_update_drives();
 
-	connect_compat("confirmed", this, "_action_pressed");
-	item_list->connect_compat("item_selected", this, "_item_selected", varray(), CONNECT_DEFERRED);
-	item_list->connect_compat("multi_selected", this, "_multi_selected", varray(), CONNECT_DEFERRED);
-	item_list->connect_compat("item_activated", this, "_item_db_selected", varray());
-	item_list->connect_compat("nothing_selected", this, "_items_clear_selection");
-	dir->connect_compat("text_entered", this, "_dir_entered");
-	file->connect_compat("text_entered", this, "_file_entered");
-	filter->connect_compat("item_selected", this, "_filter_selected");
+	connect("confirmed", Callable(this, "_action_pressed"));
+	item_list->connect("item_selected", Callable(this, "_item_selected"), varray(), CONNECT_DEFERRED);
+	item_list->connect("multi_selected", Callable(this, "_multi_selected"), varray(), CONNECT_DEFERRED);
+	item_list->connect("item_activated", Callable(this, "_item_db_selected"), varray());
+	item_list->connect("nothing_selected", Callable(this, "_items_clear_selection"));
+	dir->connect("text_entered", Callable(this, "_dir_entered"));
+	file->connect("text_entered", Callable(this, "_file_entered"));
+	filter->connect("item_selected", Callable(this, "_filter_selected"));
 
 	confirm_save = memnew(ConfirmationDialog);
 	confirm_save->set_as_toplevel(true);
 	add_child(confirm_save);
-	confirm_save->connect_compat("confirmed", this, "_save_confirm_pressed");
+	confirm_save->connect("confirmed", Callable(this, "_save_confirm_pressed"));
 
 	remove_dialog = memnew(DependencyRemoveDialog);
 	add_child(remove_dialog);
@@ -1713,7 +1713,7 @@ EditorFileDialog::EditorFileDialog() {
 	makevb->add_margin_child(TTR("Name:"), makedirname);
 	add_child(makedialog);
 	makedialog->register_text_enter(makedirname);
-	makedialog->connect_compat("confirmed", this, "_make_dir_confirm");
+	makedialog->connect("confirmed", Callable(this, "_make_dir_confirm"));
 	mkdirerr = memnew(AcceptDialog);
 	mkdirerr->set_text(TTR("Could not create folder."));
 	add_child(mkdirerr);
@@ -1777,10 +1777,10 @@ EditorLineEditFileChooser::EditorLineEditFileChooser() {
 	line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	button = memnew(Button);
 	add_child(button);
-	button->connect_compat("pressed", this, "_browse");
+	button->connect("pressed", Callable(this, "_browse"));
 	dialog = memnew(EditorFileDialog);
 	add_child(dialog);
-	dialog->connect_compat("file_selected", this, "_chosen");
-	dialog->connect_compat("dir_selected", this, "_chosen");
-	dialog->connect_compat("files_selected", this, "_chosen");
+	dialog->connect("file_selected", Callable(this, "_chosen"));
+	dialog->connect("dir_selected", Callable(this, "_chosen"));
+	dialog->connect("files_selected", Callable(this, "_chosen"));
 }

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1551,9 +1551,9 @@ EditorHelp::EditorHelp() {
 	class_desc->set_v_size_flags(SIZE_EXPAND_FILL);
 	class_desc->add_color_override("selection_color", get_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
 
-	class_desc->connect_compat("meta_clicked", this, "_class_desc_select");
-	class_desc->connect_compat("gui_input", this, "_class_desc_input");
-	class_desc->connect_compat("resized", this, "_class_desc_resized");
+	class_desc->connect("meta_clicked", Callable(this, "_class_desc_select"));
+	class_desc->connect("gui_input", Callable(this, "_class_desc_input"));
+	class_desc->connect("resized", Callable(this, "_class_desc_resized"));
 	_class_desc_resized();
 
 	// Added second so it opens at the bottom so it won't offset the entire widget.
@@ -1633,7 +1633,7 @@ EditorHelpBit::EditorHelpBit() {
 
 	rich_text = memnew(RichTextLabel);
 	add_child(rich_text);
-	rich_text->connect_compat("meta_clicked", this, "_meta_clicked");
+	rich_text->connect("meta_clicked", Callable(this, "_meta_clicked"));
 	rich_text->add_color_override("selection_color", get_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
 	rich_text->set_override_selected_font_color(false);
 	set_custom_minimum_size(Size2(0, 70 * EDSCALE));
@@ -1645,8 +1645,8 @@ FindBar::FindBar() {
 	add_child(search_text);
 	search_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	search_text->set_h_size_flags(SIZE_EXPAND_FILL);
-	search_text->connect_compat("text_changed", this, "_search_text_changed");
-	search_text->connect_compat("text_entered", this, "_search_text_entered");
+	search_text->connect("text_changed", Callable(this, "_search_text_changed"));
+	search_text->connect("text_entered", Callable(this, "_search_text_entered"));
 
 	matches_label = memnew(Label);
 	add_child(matches_label);
@@ -1655,12 +1655,12 @@ FindBar::FindBar() {
 	find_prev = memnew(ToolButton);
 	add_child(find_prev);
 	find_prev->set_focus_mode(FOCUS_NONE);
-	find_prev->connect_compat("pressed", this, "_search_prev");
+	find_prev->connect("pressed", Callable(this, "_search_prev"));
 
 	find_next = memnew(ToolButton);
 	add_child(find_next);
 	find_next->set_focus_mode(FOCUS_NONE);
-	find_next->connect_compat("pressed", this, "_search_next");
+	find_next->connect("pressed", Callable(this, "_search_next"));
 
 	Control *space = memnew(Control);
 	add_child(space);
@@ -1671,7 +1671,7 @@ FindBar::FindBar() {
 	hide_button->set_focus_mode(FOCUS_NONE);
 	hide_button->set_expand(true);
 	hide_button->set_stretch_mode(TextureButton::STRETCH_KEEP_CENTERED);
-	hide_button->connect_compat("pressed", this, "_hide_pressed");
+	hide_button->connect("pressed", Callable(this, "_hide_pressed"));
 }
 
 void FindBar::popup_search() {

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -111,7 +111,7 @@ void EditorHelpSearch::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
 
-			connect_compat("confirmed", this, "_confirmed");
+			connect("confirmed", Callable(this, "_confirmed"));
 			_update_icons();
 		} break;
 		case NOTIFICATION_POPUP_HIDE: {
@@ -206,21 +206,21 @@ EditorHelpSearch::EditorHelpSearch() {
 	search_box = memnew(LineEdit);
 	search_box->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
-	search_box->connect_compat("gui_input", this, "_search_box_gui_input");
-	search_box->connect_compat("text_changed", this, "_search_box_text_changed");
+	search_box->connect("gui_input", Callable(this, "_search_box_gui_input"));
+	search_box->connect("text_changed", Callable(this, "_search_box_text_changed"));
 	register_text_enter(search_box);
 	hbox->add_child(search_box);
 
 	case_sensitive_button = memnew(ToolButton);
 	case_sensitive_button->set_tooltip(TTR("Case Sensitive"));
-	case_sensitive_button->connect_compat("pressed", this, "_update_results");
+	case_sensitive_button->connect("pressed", Callable(this, "_update_results"));
 	case_sensitive_button->set_toggle_mode(true);
 	case_sensitive_button->set_focus_mode(FOCUS_NONE);
 	hbox->add_child(case_sensitive_button);
 
 	hierarchy_button = memnew(ToolButton);
 	hierarchy_button->set_tooltip(TTR("Show Hierarchy"));
-	hierarchy_button->connect_compat("pressed", this, "_update_results");
+	hierarchy_button->connect("pressed", Callable(this, "_update_results"));
 	hierarchy_button->set_toggle_mode(true);
 	hierarchy_button->set_pressed(true);
 	hierarchy_button->set_focus_mode(FOCUS_NONE);
@@ -237,7 +237,7 @@ EditorHelpSearch::EditorHelpSearch() {
 	filter_combo->add_item(TTR("Constants Only"), SEARCH_CONSTANTS);
 	filter_combo->add_item(TTR("Properties Only"), SEARCH_PROPERTIES);
 	filter_combo->add_item(TTR("Theme Properties Only"), SEARCH_THEME_ITEMS);
-	filter_combo->connect_compat("item_selected", this, "_filter_combo_item_selected");
+	filter_combo->connect("item_selected", Callable(this, "_filter_combo_item_selected"));
 	hbox->add_child(filter_combo);
 
 	// Create the results tree.
@@ -251,8 +251,8 @@ EditorHelpSearch::EditorHelpSearch() {
 	results_tree->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
 	results_tree->set_hide_root(true);
 	results_tree->set_select_mode(Tree::SELECT_ROW);
-	results_tree->connect_compat("item_activated", this, "_confirmed");
-	results_tree->connect_compat("item_selected", get_ok(), "set_disabled", varray(false));
+	results_tree->connect("item_activated", Callable(this, "_confirmed"));
+	results_tree->connect("item_selected", Callable(get_ok(), "set_disabled"), varray(false));
 	vbox->add_child(results_tree, true);
 }
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -570,7 +570,7 @@ void EditorProperty::_focusable_focused(int p_index) {
 
 void EditorProperty::add_focusable(Control *p_control) {
 
-	p_control->connect_compat("focus_entered", this, "_focusable_focused", varray(focusables.size()));
+	p_control->connect("focus_entered", Callable(this, "_focusable_focused"), varray(focusables.size()));
 	focusables.push_back(p_control);
 }
 
@@ -1339,14 +1339,14 @@ void EditorInspector::_parse_added_editors(VBoxContainer *current_vbox, Ref<Edit
 		if (ep) {
 
 			ep->object = object;
-			ep->connect_compat("property_changed", this, "_property_changed");
-			ep->connect_compat("property_keyed", this, "_property_keyed");
-			ep->connect_compat("property_keyed_with_value", this, "_property_keyed_with_value");
-			ep->connect_compat("property_checked", this, "_property_checked");
-			ep->connect_compat("selected", this, "_property_selected");
-			ep->connect_compat("multiple_properties_changed", this, "_multiple_properties_changed");
-			ep->connect_compat("resource_selected", this, "_resource_selected", varray(), CONNECT_DEFERRED);
-			ep->connect_compat("object_id_selected", this, "_object_id_selected", varray(), CONNECT_DEFERRED);
+			ep->connect("property_changed", Callable(this, "_property_changed"));
+			ep->connect("property_keyed", Callable(this, "_property_keyed"));
+			ep->connect("property_keyed_with_value", Callable(this, "_property_keyed_with_value"));
+			ep->connect("property_checked", Callable(this, "_property_checked"));
+			ep->connect("selected", Callable(this, "_property_selected"));
+			ep->connect("multiple_properties_changed", Callable(this, "_multiple_properties_changed"));
+			ep->connect("resource_selected", Callable(this, "_resource_selected"), varray(), CONNECT_DEFERRED);
+			ep->connect("object_id_selected", Callable(this, "_object_id_selected"), varray(), CONNECT_DEFERRED);
 
 			if (F->get().properties.size()) {
 
@@ -1751,17 +1751,17 @@ void EditorInspector::update_tree() {
 
 				if (ep) {
 
-					ep->connect_compat("property_changed", this, "_property_changed");
+					ep->connect("property_changed", Callable(this, "_property_changed"));
 					if (p.usage & PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED) {
-						ep->connect_compat("property_changed", this, "_property_changed_update_all", varray(), CONNECT_DEFERRED);
+						ep->connect("property_changed", Callable(this, "_property_changed_update_all"), varray(), CONNECT_DEFERRED);
 					}
-					ep->connect_compat("property_keyed", this, "_property_keyed");
-					ep->connect_compat("property_keyed_with_value", this, "_property_keyed_with_value");
-					ep->connect_compat("property_checked", this, "_property_checked");
-					ep->connect_compat("selected", this, "_property_selected");
-					ep->connect_compat("multiple_properties_changed", this, "_multiple_properties_changed");
-					ep->connect_compat("resource_selected", this, "_resource_selected", varray(), CONNECT_DEFERRED);
-					ep->connect_compat("object_id_selected", this, "_object_id_selected", varray(), CONNECT_DEFERRED);
+					ep->connect("property_keyed", Callable(this, "_property_keyed"));
+					ep->connect("property_keyed_with_value", Callable(this, "_property_keyed_with_value"));
+					ep->connect("property_checked", Callable(this, "_property_checked"));
+					ep->connect("selected", Callable(this, "_property_selected"));
+					ep->connect("multiple_properties_changed", Callable(this, "_multiple_properties_changed"));
+					ep->connect("resource_selected", Callable(this, "_resource_selected"), varray(), CONNECT_DEFERRED);
+					ep->connect("object_id_selected", Callable(this, "_object_id_selected"), varray(), CONNECT_DEFERRED);
 					if (doc_hint != String()) {
 						ep->set_tooltip(property_prefix + p.name + "::" + doc_hint);
 					} else {
@@ -1889,7 +1889,7 @@ void EditorInspector::set_use_filter(bool p_use) {
 void EditorInspector::register_text_enter(Node *p_line_edit) {
 	search_box = Object::cast_to<LineEdit>(p_line_edit);
 	if (search_box)
-		search_box->connect_compat("text_changed", this, "_filter_changed");
+		search_box->connect("text_changed", Callable(this, "_filter_changed"));
 }
 
 void EditorInspector::_filter_changed(const String &p_text) {
@@ -2165,7 +2165,7 @@ void EditorInspector::_node_removed(Node *p_node) {
 void EditorInspector::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_READY) {
-		EditorFeatureProfileManager::get_singleton()->connect_compat("current_feature_profile_changed", this, "_feature_profile_changed");
+		EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", Callable(this, "_feature_profile_changed"));
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
@@ -2174,7 +2174,7 @@ void EditorInspector::_notification(int p_what) {
 			add_style_override("bg", get_stylebox("sub_inspector_bg", "Editor"));
 		} else {
 			add_style_override("bg", get_stylebox("bg", "Tree"));
-			get_tree()->connect_compat("node_removed", this, "_node_removed");
+			get_tree()->connect("node_removed", Callable(this, "_node_removed"));
 		}
 	}
 	if (p_what == NOTIFICATION_PREDELETE) {
@@ -2183,7 +2183,7 @@ void EditorInspector::_notification(int p_what) {
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 
 		if (!sub_inspector) {
-			get_tree()->disconnect_compat("node_removed", this, "_node_removed");
+			get_tree()->disconnect("node_removed", Callable(this, "_node_removed"));
 		}
 		edit(NULL);
 	}
@@ -2337,6 +2337,6 @@ EditorInspector::EditorInspector() {
 	property_focusable = -1;
 	sub_inspector = false;
 
-	get_v_scrollbar()->connect_compat("value_changed", this, "_vscroll_changed");
+	get_v_scrollbar()->connect("value_changed", Callable(this, "_vscroll_changed"));
 	update_scroll_request = -1;
 }

--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -128,8 +128,8 @@ EditorLayoutsDialog::EditorLayoutsDialog() {
 	name->set_margin(MARGIN_TOP, 5);
 	name->set_anchor_and_margin(MARGIN_LEFT, ANCHOR_BEGIN, 5);
 	name->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, -5);
-	name->connect_compat("gui_input", this, "_line_gui_input");
-	name->connect_compat("focus_entered", layout_names, "unselect_all");
+	name->connect("gui_input", Callable(this, "_line_gui_input"));
+	name->connect("focus_entered", Callable(layout_names, "unselect_all"));
 }
 
 void EditorLayoutsDialog::set_name_line_enabled(bool p_enabled) {

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -159,13 +159,13 @@ EditorLog::EditorLog() {
 	hb->add_child(copybutton);
 	copybutton->set_text(TTR("Copy"));
 	copybutton->set_shortcut(ED_SHORTCUT("editor/copy_output", TTR("Copy Selection"), KEY_MASK_CMD | KEY_C));
-	copybutton->connect_compat("pressed", this, "_copy_request");
+	copybutton->connect("pressed", Callable(this, "_copy_request"));
 
 	clearbutton = memnew(Button);
 	hb->add_child(clearbutton);
 	clearbutton->set_text(TTR("Clear"));
 	clearbutton->set_shortcut(ED_SHORTCUT("editor/clear_output", TTR("Clear Output"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_K));
-	clearbutton->connect_compat("pressed", this, "_clear_request");
+	clearbutton->connect("pressed", Callable(this, "_clear_request"));
 
 	log = memnew(RichTextLabel);
 	log->set_scroll_follow(true);

--- a/editor/editor_network_profiler.cpp
+++ b/editor/editor_network_profiler.cpp
@@ -142,12 +142,12 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_text(TTR("Start"));
-	activate->connect_compat("pressed", this, "_activate_pressed");
+	activate->connect("pressed", Callable(this, "_activate_pressed"));
 	hb->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
-	clear_button->connect_compat("pressed", this, "_clear_pressed");
+	clear_button->connect("pressed", Callable(this, "_clear_pressed"));
 	hb->add_child(clear_button);
 
 	hb->add_spacer();
@@ -207,5 +207,5 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	frame_delay->set_wait_time(0.1);
 	frame_delay->set_one_shot(true);
 	add_child(frame_delay);
-	frame_delay->connect_compat("timeout", this, "_update_frame");
+	frame_delay->connect("timeout", Callable(this, "_update_frame"));
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -374,8 +374,8 @@ void EditorNode::_notification(int p_what) {
 			get_tree()->get_root()->set_as_audio_listener(false);
 			get_tree()->get_root()->set_as_audio_listener_2d(false);
 			get_tree()->set_auto_accept_quit(false);
-			get_tree()->connect_compat("files_dropped", this, "_dropped_files");
-			get_tree()->connect_compat("global_menu_action", this, "_global_menu_action");
+			get_tree()->connect("files_dropped", Callable(this, "_dropped_files"));
+			get_tree()->connect("global_menu_action", Callable(this, "_global_menu_action"));
 
 			/* DO NOT LOAD SCENES HERE, WAIT FOR FILE SCANNING AND REIMPORT TO COMPLETE */
 		} break;
@@ -2972,7 +2972,7 @@ void EditorNode::add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed
 
 		ToolButton *tb = memnew(ToolButton);
 		tb->set_toggle_mode(true);
-		tb->connect_compat("pressed", singleton, "_editor_select", varray(singleton->main_editor_buttons.size()));
+		tb->connect("pressed", Callable(singleton, "_editor_select"), varray(singleton->main_editor_buttons.size()));
 		tb->set_text(p_editor->get_name());
 		Ref<Texture2D> icon = p_editor->get_icon();
 
@@ -4803,7 +4803,7 @@ void EditorNode::_scene_tab_changed(int p_tab) {
 ToolButton *EditorNode::add_bottom_panel_item(String p_text, Control *p_item) {
 
 	ToolButton *tb = memnew(ToolButton);
-	tb->connect_compat("toggled", this, "_bottom_panel_switch", varray(bottom_panel_items.size()));
+	tb->connect("toggled", Callable(this, "_bottom_panel_switch"), varray(bottom_panel_items.size()));
 	tb->set_text(p_text);
 	tb->set_toggle_mode(true);
 	tb->set_focus_mode(Control::FOCUS_NONE);
@@ -4865,8 +4865,8 @@ void EditorNode::raise_bottom_panel_item(Control *p_item) {
 	}
 
 	for (int i = 0; i < bottom_panel_items.size(); i++) {
-		bottom_panel_items[i].button->disconnect_compat("toggled", this, "_bottom_panel_switch");
-		bottom_panel_items[i].button->connect_compat("toggled", this, "_bottom_panel_switch", varray(i));
+		bottom_panel_items[i].button->disconnect("toggled", Callable(this, "_bottom_panel_switch"));
+		bottom_panel_items[i].button->connect("toggled", Callable(this, "_bottom_panel_switch"), varray(i));
 	}
 }
 
@@ -4887,8 +4887,8 @@ void EditorNode::remove_bottom_panel_item(Control *p_item) {
 	}
 
 	for (int i = 0; i < bottom_panel_items.size(); i++) {
-		bottom_panel_items[i].button->disconnect_compat("toggled", this, "_bottom_panel_switch");
-		bottom_panel_items[i].button->connect_compat("toggled", this, "_bottom_panel_switch", varray(i));
+		bottom_panel_items[i].button->disconnect("toggled", Callable(this, "_bottom_panel_switch"));
+		bottom_panel_items[i].button->connect("toggled", Callable(this, "_bottom_panel_switch"), varray(i));
 	}
 }
 
@@ -5943,8 +5943,8 @@ EditorNode::EditorNode() {
 	hsplits.push_back(right_hsplit);
 
 	for (int i = 0; i < vsplits.size(); i++) {
-		vsplits[i]->connect_compat("dragged", this, "_dock_split_dragged");
-		hsplits[i]->connect_compat("dragged", this, "_dock_split_dragged");
+		vsplits[i]->connect("dragged", Callable(this, "_dock_split_dragged"));
+		hsplits[i]->connect("dragged", Callable(this, "_dock_split_dragged"));
 	}
 
 	dock_select_popup = memnew(PopupPanel);
@@ -5956,7 +5956,7 @@ EditorNode::EditorNode() {
 	dock_tab_move_left = memnew(ToolButton);
 	dock_tab_move_left->set_icon(theme->get_icon("Back", "EditorIcons"));
 	dock_tab_move_left->set_focus_mode(Control::FOCUS_NONE);
-	dock_tab_move_left->connect_compat("pressed", this, "_dock_move_left");
+	dock_tab_move_left->connect("pressed", Callable(this, "_dock_move_left"));
 	dock_hb->add_child(dock_tab_move_left);
 
 	Label *dock_label = memnew(Label);
@@ -5968,16 +5968,16 @@ EditorNode::EditorNode() {
 	dock_tab_move_right = memnew(ToolButton);
 	dock_tab_move_right->set_icon(theme->get_icon("Forward", "EditorIcons"));
 	dock_tab_move_right->set_focus_mode(Control::FOCUS_NONE);
-	dock_tab_move_right->connect_compat("pressed", this, "_dock_move_right");
+	dock_tab_move_right->connect("pressed", Callable(this, "_dock_move_right"));
 
 	dock_hb->add_child(dock_tab_move_right);
 	dock_vb->add_child(dock_hb);
 
 	dock_select = memnew(Control);
 	dock_select->set_custom_minimum_size(Size2(128, 64) * EDSCALE);
-	dock_select->connect_compat("gui_input", this, "_dock_select_input");
-	dock_select->connect_compat("draw", this, "_dock_select_draw");
-	dock_select->connect_compat("mouse_exited", this, "_dock_popup_exit");
+	dock_select->connect("gui_input", Callable(this, "_dock_select_input"));
+	dock_select->connect("draw", Callable(this, "_dock_select_draw"));
+	dock_select->connect("mouse_exited", Callable(this, "_dock_popup_exit"));
 	dock_select->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	dock_vb->add_child(dock_select);
 
@@ -5988,11 +5988,11 @@ EditorNode::EditorNode() {
 		dock_slot[i]->set_custom_minimum_size(Size2(170, 0) * EDSCALE);
 		dock_slot[i]->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		dock_slot[i]->set_popup(dock_select_popup);
-		dock_slot[i]->connect_compat("pre_popup_pressed", this, "_dock_pre_popup", varray(i));
+		dock_slot[i]->connect("pre_popup_pressed", Callable(this, "_dock_pre_popup"), varray(i));
 		dock_slot[i]->set_tab_align(TabContainer::ALIGN_LEFT);
 		dock_slot[i]->set_drag_to_rearrange_enabled(true);
 		dock_slot[i]->set_tabs_rearrange_group(1);
-		dock_slot[i]->connect_compat("tab_changed", this, "_dock_tab_changed");
+		dock_slot[i]->connect("tab_changed", Callable(this, "_dock_tab_changed"));
 		dock_slot[i]->set_use_hidden_tabs_for_min_size(true);
 	}
 
@@ -6000,7 +6000,7 @@ EditorNode::EditorNode() {
 	add_child(dock_drag_timer);
 	dock_drag_timer->set_wait_time(0.5);
 	dock_drag_timer->set_one_shot(true);
-	dock_drag_timer->connect_compat("timeout", this, "_save_docks");
+	dock_drag_timer->connect("timeout", Callable(this, "_save_docks"));
 
 	top_split = memnew(VSplitContainer);
 	center_split->add_child(top_split);
@@ -6033,21 +6033,21 @@ EditorNode::EditorNode() {
 	scene_tabs->set_tab_close_display_policy((bool(EDITOR_DEF("interface/scene_tabs/always_show_close_button", false)) ? Tabs::CLOSE_BUTTON_SHOW_ALWAYS : Tabs::CLOSE_BUTTON_SHOW_ACTIVE_ONLY));
 	scene_tabs->set_min_width(int(EDITOR_DEF("interface/scene_tabs/minimum_width", 50)) * EDSCALE);
 	scene_tabs->set_drag_to_rearrange_enabled(true);
-	scene_tabs->connect_compat("tab_changed", this, "_scene_tab_changed");
-	scene_tabs->connect_compat("right_button_pressed", this, "_scene_tab_script_edited");
-	scene_tabs->connect_compat("tab_close", this, "_scene_tab_closed", varray(SCENE_TAB_CLOSE));
-	scene_tabs->connect_compat("tab_hover", this, "_scene_tab_hover");
-	scene_tabs->connect_compat("mouse_exited", this, "_scene_tab_exit");
-	scene_tabs->connect_compat("gui_input", this, "_scene_tab_input");
-	scene_tabs->connect_compat("reposition_active_tab_request", this, "_reposition_active_tab");
-	scene_tabs->connect_compat("resized", this, "_update_scene_tabs");
+	scene_tabs->connect("tab_changed", Callable(this, "_scene_tab_changed"));
+	scene_tabs->connect("right_button_pressed", Callable(this, "_scene_tab_script_edited"));
+	scene_tabs->connect("tab_close", Callable(this, "_scene_tab_closed"), varray(SCENE_TAB_CLOSE));
+	scene_tabs->connect("tab_hover", Callable(this, "_scene_tab_hover"));
+	scene_tabs->connect("mouse_exited", Callable(this, "_scene_tab_exit"));
+	scene_tabs->connect("gui_input", Callable(this, "_scene_tab_input"));
+	scene_tabs->connect("reposition_active_tab_request", Callable(this, "_reposition_active_tab"));
+	scene_tabs->connect("resized", Callable(this, "_update_scene_tabs"));
 
 	tabbar_container = memnew(HBoxContainer);
 	scene_tabs->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	scene_tabs_context_menu = memnew(PopupMenu);
 	tabbar_container->add_child(scene_tabs_context_menu);
-	scene_tabs_context_menu->connect_compat("id_pressed", this, "_menu_option");
+	scene_tabs_context_menu->connect("id_pressed", Callable(this, "_menu_option"));
 	scene_tabs_context_menu->set_hide_on_window_lose_focus(true);
 
 	srt->add_child(tabbar_container);
@@ -6059,7 +6059,7 @@ EditorNode::EditorNode() {
 	distraction_free->set_shortcut(ED_SHORTCUT("editor/distraction_free_mode", TTR("Distraction Free Mode"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_F11));
 #endif
 	distraction_free->set_tooltip(TTR("Toggle distraction-free mode."));
-	distraction_free->connect_compat("pressed", this, "_toggle_distraction_free_mode");
+	distraction_free->connect("pressed", Callable(this, "_toggle_distraction_free_mode"));
 	distraction_free->set_icon(gui_base->get_icon("DistractionFree", "EditorIcons"));
 	distraction_free->set_toggle_mode(true);
 
@@ -6069,7 +6069,7 @@ EditorNode::EditorNode() {
 	scene_tab_add->set_tooltip(TTR("Add a new scene."));
 	scene_tab_add->set_icon(gui_base->get_icon("Add", "EditorIcons"));
 	scene_tab_add->add_color_override("icon_color_normal", Color(0.6f, 0.6f, 0.6f, 0.8f));
-	scene_tab_add->connect_compat("pressed", this, "_menu_option", make_binds(FILE_NEW_SCENE));
+	scene_tab_add->connect("pressed", Callable(this, "_menu_option"), make_binds(FILE_NEW_SCENE));
 
 	scene_root_parent = memnew(PanelContainer);
 	scene_root_parent->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
@@ -6104,14 +6104,14 @@ EditorNode::EditorNode() {
 	prev_scene->set_icon(gui_base->get_icon("PrevScene", "EditorIcons"));
 	prev_scene->set_tooltip(TTR("Go to previously opened scene."));
 	prev_scene->set_disabled(true);
-	prev_scene->connect_compat("pressed", this, "_menu_option", make_binds(FILE_OPEN_PREV));
+	prev_scene->connect("pressed", Callable(this, "_menu_option"), make_binds(FILE_OPEN_PREV));
 	gui_base->add_child(prev_scene);
 	prev_scene->set_position(Point2(3, 24));
 	prev_scene->hide();
 
 	accept = memnew(AcceptDialog);
 	gui_base->add_child(accept);
-	accept->connect_compat("confirmed", this, "_menu_confirm_current");
+	accept->connect("confirmed", Callable(this, "_menu_confirm_current"));
 
 	project_export = memnew(ProjectExportDialog);
 	gui_base->add_child(project_export);
@@ -6138,12 +6138,12 @@ EditorNode::EditorNode() {
 	gui_base->add_child(feature_profile_manager);
 	about = memnew(EditorAbout);
 	gui_base->add_child(about);
-	feature_profile_manager->connect_compat("current_feature_profile_changed", this, "_feature_profile_changed");
+	feature_profile_manager->connect("current_feature_profile_changed", Callable(this, "_feature_profile_changed"));
 
 	warning = memnew(AcceptDialog);
 	warning->add_button(TTR("Copy Text"), true, "copy");
 	gui_base->add_child(warning);
-	warning->connect_compat("custom_action", this, "_copy_warning");
+	warning->connect("custom_action", Callable(this, "_copy_warning"));
 
 	ED_SHORTCUT("editor/next_tab", TTR("Next tab"), KEY_MASK_CMD + KEY_TAB);
 	ED_SHORTCUT("editor/prev_tab", TTR("Previous tab"), KEY_MASK_CMD + KEY_MASK_SHIFT + KEY_TAB);
@@ -6177,7 +6177,7 @@ EditorNode::EditorNode() {
 	p->add_submenu_item(TTR("Convert To..."), "Export");
 	pm_export->add_shortcut(ED_SHORTCUT("editor/convert_to_MeshLibrary", TTR("MeshLibrary...")), FILE_EXPORT_MESH_LIBRARY);
 	pm_export->add_shortcut(ED_SHORTCUT("editor/convert_to_TileSet", TTR("TileSet...")), FILE_EXPORT_TILESET);
-	pm_export->connect_compat("id_pressed", this, "_menu_option");
+	pm_export->connect("id_pressed", Callable(this, "_menu_option"));
 
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("editor/undo", TTR("Undo"), KEY_MASK_CMD + KEY_Z), EDIT_UNDO, true);
@@ -6190,7 +6190,7 @@ EditorNode::EditorNode() {
 	recent_scenes = memnew(PopupMenu);
 	recent_scenes->set_name("RecentScenes");
 	p->add_child(recent_scenes);
-	recent_scenes->connect_compat("id_pressed", this, "_open_recent_scene");
+	recent_scenes->connect("id_pressed", Callable(this, "_open_recent_scene"));
 
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("editor/file_quit", TTR("Quit"), KEY_MASK_CMD + KEY_Q), FILE_QUIT, true);
@@ -6206,11 +6206,11 @@ EditorNode::EditorNode() {
 	p = project_menu->get_popup();
 	p->set_hide_on_window_lose_focus(true);
 	p->add_shortcut(ED_SHORTCUT("editor/project_settings", TTR("Project Settings...")), RUN_SETTINGS);
-	p->connect_compat("id_pressed", this, "_menu_option");
+	p->connect("id_pressed", Callable(this, "_menu_option"));
 
 	vcs_actions_menu = VersionControlEditorPlugin::get_singleton()->get_version_control_actions_panel();
 	vcs_actions_menu->set_name("Version Control");
-	vcs_actions_menu->connect_compat("index_pressed", this, "_version_control_menu_option");
+	vcs_actions_menu->connect("index_pressed", Callable(this, "_version_control_menu_option"));
 	p->add_separator();
 	p->add_child(vcs_actions_menu);
 	p->add_submenu_item(TTR("Version Control"), "Version Control");
@@ -6223,12 +6223,12 @@ EditorNode::EditorNode() {
 	p->add_item(TTR("Open Project Data Folder"), RUN_PROJECT_DATA_FOLDER);
 
 	plugin_config_dialog = memnew(PluginConfigDialog);
-	plugin_config_dialog->connect_compat("plugin_ready", this, "_on_plugin_ready");
+	plugin_config_dialog->connect("plugin_ready", Callable(this, "_on_plugin_ready"));
 	gui_base->add_child(plugin_config_dialog);
 
 	tool_menu = memnew(PopupMenu);
 	tool_menu->set_name("Tools");
-	tool_menu->connect_compat("index_pressed", this, "_tool_menu_option");
+	tool_menu->connect("index_pressed", Callable(this, "_tool_menu_option"));
 	p->add_child(tool_menu);
 	p->add_submenu_item(TTR("Tools"), "Tools");
 	tool_menu->add_item(TTR("Orphan Resource Explorer..."), TOOLS_ORPHAN_RESOURCES);
@@ -6279,7 +6279,7 @@ EditorNode::EditorNode() {
 	p->add_radio_check_item(TTR("Debug 2 instances"), RUN_DEBUG_TWO);
 	p->set_item_checked(p->get_item_index(RUN_DEBUG_ONE), true);
 
-	p->connect_compat("id_pressed", this, "_menu_option");
+	p->connect("id_pressed", Callable(this, "_menu_option"));
 
 	menu_hb->add_spacer();
 
@@ -6298,7 +6298,7 @@ EditorNode::EditorNode() {
 	editor_layouts = memnew(PopupMenu);
 	editor_layouts->set_name("Layouts");
 	p->add_child(editor_layouts);
-	editor_layouts->connect_compat("id_pressed", this, "_layout_menu_option");
+	editor_layouts->connect("id_pressed", Callable(this, "_layout_menu_option"));
 	p->add_submenu_item(TTR("Editor Layout"), "Layouts");
 	p->add_separator();
 #ifdef OSX_ENABLED
@@ -6340,7 +6340,7 @@ EditorNode::EditorNode() {
 
 	p = help_menu->get_popup();
 	p->set_hide_on_window_lose_focus(true);
-	p->connect_compat("id_pressed", this, "_menu_option");
+	p->connect("id_pressed", Callable(this, "_menu_option"));
 	p->add_icon_shortcut(gui_base->get_icon("HelpSearch", "EditorIcons"), ED_SHORTCUT("editor/editor_help", TTR("Search"), KEY_MASK_SHIFT | KEY_F1), HELP_SEARCH);
 	p->add_separator();
 	p->add_icon_shortcut(gui_base->get_icon("Instance", "EditorIcons"), ED_SHORTCUT("editor/online_docs", TTR("Online Docs")), HELP_DOCS);
@@ -6358,7 +6358,7 @@ EditorNode::EditorNode() {
 	play_button->set_toggle_mode(true);
 	play_button->set_icon(gui_base->get_icon("MainPlay", "EditorIcons"));
 	play_button->set_focus_mode(Control::FOCUS_NONE);
-	play_button->connect_compat("pressed", this, "_menu_option", make_binds(RUN_PLAY));
+	play_button->connect("pressed", Callable(this, "_menu_option"), make_binds(RUN_PLAY));
 	play_button->set_tooltip(TTR("Play the project."));
 #ifdef OSX_ENABLED
 	play_button->set_shortcut(ED_SHORTCUT("editor/play", TTR("Play"), KEY_MASK_CMD | KEY_B));
@@ -6383,7 +6383,7 @@ EditorNode::EditorNode() {
 	play_hb->add_child(stop_button);
 	stop_button->set_focus_mode(Control::FOCUS_NONE);
 	stop_button->set_icon(gui_base->get_icon("Stop", "EditorIcons"));
-	stop_button->connect_compat("pressed", this, "_menu_option", make_binds(RUN_STOP));
+	stop_button->connect("pressed", Callable(this, "_menu_option"), make_binds(RUN_STOP));
 	stop_button->set_tooltip(TTR("Stop the scene."));
 	stop_button->set_disabled(true);
 #ifdef OSX_ENABLED
@@ -6394,14 +6394,14 @@ EditorNode::EditorNode() {
 
 	run_native = memnew(EditorRunNative);
 	play_hb->add_child(run_native);
-	run_native->connect_compat("native_run", this, "_menu_option", varray(RUN_PLAY_NATIVE));
+	run_native->connect("native_run", Callable(this, "_menu_option"), varray(RUN_PLAY_NATIVE));
 
 	play_scene_button = memnew(ToolButton);
 	play_hb->add_child(play_scene_button);
 	play_scene_button->set_toggle_mode(true);
 	play_scene_button->set_focus_mode(Control::FOCUS_NONE);
 	play_scene_button->set_icon(gui_base->get_icon("PlayScene", "EditorIcons"));
-	play_scene_button->connect_compat("pressed", this, "_menu_option", make_binds(RUN_PLAY_SCENE));
+	play_scene_button->connect("pressed", Callable(this, "_menu_option"), make_binds(RUN_PLAY_SCENE));
 	play_scene_button->set_tooltip(TTR("Play the edited scene."));
 #ifdef OSX_ENABLED
 	play_scene_button->set_shortcut(ED_SHORTCUT("editor/play_scene", TTR("Play Scene"), KEY_MASK_CMD | KEY_R));
@@ -6414,7 +6414,7 @@ EditorNode::EditorNode() {
 	play_custom_scene_button->set_toggle_mode(true);
 	play_custom_scene_button->set_focus_mode(Control::FOCUS_NONE);
 	play_custom_scene_button->set_icon(gui_base->get_icon("PlayCustom", "EditorIcons"));
-	play_custom_scene_button->connect_compat("pressed", this, "_menu_option", make_binds(RUN_PLAY_CUSTOM_SCENE));
+	play_custom_scene_button->connect("pressed", Callable(this, "_menu_option"), make_binds(RUN_PLAY_CUSTOM_SCENE));
 	play_custom_scene_button->set_tooltip(TTR("Play custom scene"));
 #ifdef OSX_ENABLED
 	play_custom_scene_button->set_shortcut(ED_SHORTCUT("editor/play_custom_scene", TTR("Play Custom Scene"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_R));
@@ -6429,7 +6429,7 @@ EditorNode::EditorNode() {
 	video_driver = memnew(OptionButton);
 	video_driver->set_flat(true);
 	video_driver->set_focus_mode(Control::FOCUS_NONE);
-	video_driver->connect_compat("item_selected", this, "_video_driver_selected");
+	video_driver->connect("item_selected", Callable(this, "_video_driver_selected"));
 	video_driver->add_font_override("font", gui_base->get_font("bold", "EditorFonts"));
 	// TODO re-enable when GLES2 is ported
 	video_driver->set_disabled(true);
@@ -6454,7 +6454,7 @@ EditorNode::EditorNode() {
 	video_restart_dialog = memnew(ConfirmationDialog);
 	video_restart_dialog->set_text(TTR("Changing the video driver requires restarting the editor."));
 	video_restart_dialog->get_ok()->set_text(TTR("Save & Restart"));
-	video_restart_dialog->connect_compat("confirmed", this, "_menu_option", varray(SET_VIDEO_DRIVER_SAVE_AND_RESTART));
+	video_restart_dialog->connect("confirmed", Callable(this, "_menu_option"), varray(SET_VIDEO_DRIVER_SAVE_AND_RESTART));
 	gui_base->add_child(video_restart_dialog);
 
 	progress_hb = memnew(BackgroundProgress);
@@ -6463,13 +6463,13 @@ EditorNode::EditorNode() {
 	gui_base->add_child(layout_dialog);
 	layout_dialog->set_hide_on_ok(false);
 	layout_dialog->set_size(Size2(225, 270) * EDSCALE);
-	layout_dialog->connect_compat("name_confirmed", this, "_dialog_action");
+	layout_dialog->connect("name_confirmed", Callable(this, "_dialog_action"));
 
 	update_spinner = memnew(MenuButton);
 	update_spinner->set_tooltip(TTR("Spins when the editor window redraws."));
 	right_menu_hb->add_child(update_spinner);
 	update_spinner->set_icon(gui_base->get_icon("Progress1", "EditorIcons"));
-	update_spinner->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	update_spinner->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 	p = update_spinner->get_popup();
 	p->add_radio_check_item(TTR("Update Continuously"), SETTINGS_UPDATE_CONTINUOUSLY);
 	p->add_radio_check_item(TTR("Update When Changed"), SETTINGS_UPDATE_WHEN_CHANGED);
@@ -6485,9 +6485,9 @@ EditorNode::EditorNode() {
 	node_dock = memnew(NodeDock);
 
 	filesystem_dock = memnew(FileSystemDock(this));
-	filesystem_dock->connect_compat("inherit", this, "_inherit_request");
-	filesystem_dock->connect_compat("instance", this, "_instance_request");
-	filesystem_dock->connect_compat("display_mode_changed", this, "_save_docks");
+	filesystem_dock->connect("inherit", Callable(this, "_inherit_request"));
+	filesystem_dock->connect("instance", Callable(this, "_instance_request"));
+	filesystem_dock->connect("display_mode_changed", Callable(this, "_save_docks"));
 
 	// Scene: Top left
 	dock_slot[DOCK_SLOT_LEFT_UR]->add_child(scene_tree_dock);
@@ -6573,7 +6573,7 @@ EditorNode::EditorNode() {
 	bottom_panel_hb->add_child(bottom_panel_raise);
 	bottom_panel_raise->hide();
 	bottom_panel_raise->set_toggle_mode(true);
-	bottom_panel_raise->connect_compat("toggled", this, "_bottom_panel_raise_toggled");
+	bottom_panel_raise->connect("toggled", Callable(this, "_bottom_panel_raise_toggled"));
 
 	log = memnew(EditorLog);
 	ToolButton *output_button = add_bottom_panel_item(TTR("Output"), log);
@@ -6581,37 +6581,37 @@ EditorNode::EditorNode() {
 
 	old_split_ofs = 0;
 
-	center_split->connect_compat("resized", this, "_vp_resized");
+	center_split->connect("resized", Callable(this, "_vp_resized"));
 
 	orphan_resources = memnew(OrphanResourcesDialog);
 	gui_base->add_child(orphan_resources);
 
 	confirmation = memnew(ConfirmationDialog);
 	gui_base->add_child(confirmation);
-	confirmation->connect_compat("confirmed", this, "_menu_confirm_current");
+	confirmation->connect("confirmed", Callable(this, "_menu_confirm_current"));
 
 	save_confirmation = memnew(ConfirmationDialog);
 	save_confirmation->add_button(TTR("Don't Save"), OS::get_singleton()->get_swap_ok_cancel(), "discard");
 	gui_base->add_child(save_confirmation);
-	save_confirmation->connect_compat("confirmed", this, "_menu_confirm_current");
-	save_confirmation->connect_compat("custom_action", this, "_discard_changes");
+	save_confirmation->connect("confirmed", Callable(this, "_menu_confirm_current"));
+	save_confirmation->connect("custom_action", Callable(this, "_discard_changes"));
 
 	custom_build_manage_templates = memnew(ConfirmationDialog);
 	custom_build_manage_templates->set_text(TTR("Android build template is missing, please install relevant templates."));
 	custom_build_manage_templates->get_ok()->set_text(TTR("Manage Templates"));
-	custom_build_manage_templates->connect_compat("confirmed", this, "_menu_option", varray(SETTINGS_MANAGE_EXPORT_TEMPLATES));
+	custom_build_manage_templates->connect("confirmed", Callable(this, "_menu_option"), varray(SETTINGS_MANAGE_EXPORT_TEMPLATES));
 	gui_base->add_child(custom_build_manage_templates);
 
 	install_android_build_template = memnew(ConfirmationDialog);
 	install_android_build_template->set_text(TTR("This will set up your project for custom Android builds by installing the source template to \"res://android/build\".\nYou can then apply modifications and build your own custom APK on export (adding modules, changing the AndroidManifest.xml, etc.).\nNote that in order to make custom builds instead of using pre-built APKs, the \"Use Custom Build\" option should be enabled in the Android export preset."));
 	install_android_build_template->get_ok()->set_text(TTR("Install"));
-	install_android_build_template->connect_compat("confirmed", this, "_menu_confirm_current");
+	install_android_build_template->connect("confirmed", Callable(this, "_menu_confirm_current"));
 	gui_base->add_child(install_android_build_template);
 
 	remove_android_build_template = memnew(ConfirmationDialog);
 	remove_android_build_template->set_text(TTR("The Android build template is already installed in this project and it won't be overwritten.\nRemove the \"res://android/build\" directory manually before attempting this operation again."));
 	remove_android_build_template->get_ok()->set_text(TTR("Show in File Manager"));
-	remove_android_build_template->connect_compat("confirmed", this, "_menu_option", varray(FILE_EXPLORE_ANDROID_BUILD_TEMPLATES));
+	remove_android_build_template->connect("confirmed", Callable(this, "_menu_option"), varray(FILE_EXPLORE_ANDROID_BUILD_TEMPLATES));
 	gui_base->add_child(remove_android_build_template);
 
 	file_templates = memnew(EditorFileDialog);
@@ -6630,7 +6630,7 @@ EditorNode::EditorNode() {
 	file_export_lib = memnew(EditorFileDialog);
 	file_export_lib->set_title(TTR("Export Library"));
 	file_export_lib->set_mode(EditorFileDialog::MODE_SAVE_FILE);
-	file_export_lib->connect_compat("file_selected", this, "_dialog_action");
+	file_export_lib->connect("file_selected", Callable(this, "_dialog_action"));
 	file_export_lib_merge = memnew(CheckBox);
 	file_export_lib_merge->set_text(TTR("Merge With Existing"));
 	file_export_lib_merge->set_pressed(true);
@@ -6647,16 +6647,16 @@ EditorNode::EditorNode() {
 		file_script->add_filter("*." + E->get());
 	}
 	gui_base->add_child(file_script);
-	file_script->connect_compat("file_selected", this, "_dialog_action");
+	file_script->connect("file_selected", Callable(this, "_dialog_action"));
 
-	file_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
-	file_menu->connect_compat("about_to_show", this, "_update_file_menu_opened");
-	file_menu->get_popup()->connect_compat("popup_hide", this, "_update_file_menu_closed");
+	file_menu->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
+	file_menu->connect("about_to_show", Callable(this, "_update_file_menu_opened"));
+	file_menu->get_popup()->connect("popup_hide", Callable(this, "_update_file_menu_closed"));
 
-	settings_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	settings_menu->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
-	file->connect_compat("file_selected", this, "_dialog_action");
-	file_templates->connect_compat("file_selected", this, "_dialog_action");
+	file->connect("file_selected", Callable(this, "_dialog_action"));
+	file_templates->connect("file_selected", Callable(this, "_dialog_action"));
 
 	preview_gen = memnew(AudioStreamPreviewGenerator);
 	add_child(preview_gen);
@@ -6793,8 +6793,8 @@ EditorNode::EditorNode() {
 	open_imported = memnew(ConfirmationDialog);
 	open_imported->get_ok()->set_text(TTR("Open Anyway"));
 	new_inherited_button = open_imported->add_button(TTR("New Inherited"), !OS::get_singleton()->get_swap_ok_cancel(), "inherit");
-	open_imported->connect_compat("confirmed", this, "_open_imported");
-	open_imported->connect_compat("custom_action", this, "_inherit_imported");
+	open_imported->connect("confirmed", Callable(this, "_open_imported"));
+	open_imported->connect("custom_action", Callable(this, "_inherit_imported"));
 	gui_base->add_child(open_imported);
 
 	saved_version = 1;
@@ -6803,11 +6803,11 @@ EditorNode::EditorNode() {
 
 	quick_open = memnew(EditorQuickOpen);
 	gui_base->add_child(quick_open);
-	quick_open->connect_compat("quick_open", this, "_quick_opened");
+	quick_open->connect("quick_open", Callable(this, "_quick_opened"));
 
 	quick_run = memnew(EditorQuickOpen);
 	gui_base->add_child(quick_run);
-	quick_run->connect_compat("quick_open", this, "_quick_run");
+	quick_run->connect("quick_open", Callable(this, "_quick_run"));
 
 	_update_recent_scenes();
 
@@ -6829,10 +6829,10 @@ EditorNode::EditorNode() {
 	execute_output_dialog->set_title("");
 	gui_base->add_child(execute_output_dialog);
 
-	EditorFileSystem::get_singleton()->connect_compat("sources_changed", this, "_sources_changed");
-	EditorFileSystem::get_singleton()->connect_compat("filesystem_changed", this, "_fs_changed");
-	EditorFileSystem::get_singleton()->connect_compat("resources_reimported", this, "_resources_reimported");
-	EditorFileSystem::get_singleton()->connect_compat("resources_reload", this, "_resources_changed");
+	EditorFileSystem::get_singleton()->connect("sources_changed", Callable(this, "_sources_changed"));
+	EditorFileSystem::get_singleton()->connect("filesystem_changed", Callable(this, "_fs_changed"));
+	EditorFileSystem::get_singleton()->connect("resources_reimported", Callable(this, "_resources_reimported"));
+	EditorFileSystem::get_singleton()->connect("resources_reload", Callable(this, "_resources_changed"));
 
 	_build_icon_type_cache();
 
@@ -6841,7 +6841,7 @@ EditorNode::EditorNode() {
 	pick_main_scene = memnew(ConfirmationDialog);
 	gui_base->add_child(pick_main_scene);
 	pick_main_scene->get_ok()->set_text(TTR("Select"));
-	pick_main_scene->connect_compat("confirmed", this, "_menu_option", varray(SETTINGS_PICK_MAIN_SCENE));
+	pick_main_scene->connect("confirmed", Callable(this, "_menu_option"), varray(SETTINGS_PICK_MAIN_SCENE));
 
 	for (int i = 0; i < _init_callbacks.size(); i++)
 		_init_callbacks[i]();
@@ -6881,7 +6881,7 @@ EditorNode::EditorNode() {
 	screenshot_timer = memnew(Timer);
 	screenshot_timer->set_one_shot(true);
 	screenshot_timer->set_wait_time(settings_menu->get_popup()->get_submenu_popup_delay() + 0.1f);
-	screenshot_timer->connect_compat("timeout", this, "_request_screenshot");
+	screenshot_timer->connect("timeout", Callable(this, "_request_screenshot"));
 	add_child(screenshot_timer);
 	screenshot_timer->set_owner(get_owner());
 }

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -152,6 +152,6 @@ EditorPath::EditorPath(EditorHistory *p_history) {
 	history = p_history;
 	set_clip_text(true);
 	set_text_align(ALIGN_LEFT);
-	get_popup()->connect_compat("about_to_show", this, "_about_to_show");
-	get_popup()->connect_compat("id_pressed", this, "_id_pressed");
+	get_popup()->connect("about_to_show", Callable(this, "_about_to_show"));
+	get_popup()->connect("id_pressed", Callable(this, "_id_pressed"));
 }

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -43,8 +43,8 @@ void EditorPluginSettings::_notification(int p_what) {
 	if (p_what == MainLoop::NOTIFICATION_WM_FOCUS_IN) {
 		update_plugins();
 	} else if (p_what == Node::NOTIFICATION_READY) {
-		plugin_config_dialog->connect_compat("plugin_ready", EditorNode::get_singleton(), "_on_plugin_ready");
-		plugin_list->connect_compat("button_pressed", this, "_cell_button_pressed");
+		plugin_config_dialog->connect("plugin_ready", Callable(EditorNode::get_singleton(), "_on_plugin_ready"));
+		plugin_list->connect("button_pressed", Callable(this, "_cell_button_pressed"));
 	}
 }
 
@@ -219,10 +219,10 @@ EditorPluginSettings::EditorPluginSettings() {
 	title_hb->add_child(memnew(Label(TTR("Installed Plugins:"))));
 	title_hb->add_spacer();
 	create_plugin = memnew(Button(TTR("Create")));
-	create_plugin->connect_compat("pressed", this, "_create_clicked");
+	create_plugin->connect("pressed", Callable(this, "_create_clicked"));
 	title_hb->add_child(create_plugin);
 	update_list = memnew(Button(TTR("Update")));
-	update_list->connect_compat("pressed", this, "update_plugins");
+	update_list->connect("pressed", Callable(this, "update_plugins"));
 	title_hb->add_child(update_list);
 	add_child(title_hb);
 
@@ -245,7 +245,7 @@ EditorPluginSettings::EditorPluginSettings() {
 	plugin_list->set_column_min_width(3, 80 * EDSCALE);
 	plugin_list->set_column_min_width(4, 40 * EDSCALE);
 	plugin_list->set_hide_root(true);
-	plugin_list->connect_compat("item_edited", this, "_plugin_activity_changed");
+	plugin_list->connect("item_edited", Callable(this, "_plugin_activity_changed"));
 
 	VBoxContainer *mc = memnew(VBoxContainer);
 	mc->add_child(plugin_list);

--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -686,12 +686,12 @@ EditorProfiler::EditorProfiler() {
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_text(TTR("Start"));
-	activate->connect_compat("pressed", this, "_activate_pressed");
+	activate->connect("pressed", Callable(this, "_activate_pressed"));
 	hb->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
-	clear_button->connect_compat("pressed", this, "_clear_pressed");
+	clear_button->connect("pressed", Callable(this, "_clear_pressed"));
 	hb->add_child(clear_button);
 
 	hb->add_child(memnew(Label(TTR("Measure:"))));
@@ -701,7 +701,7 @@ EditorProfiler::EditorProfiler() {
 	display_mode->add_item(TTR("Average Time (sec)"));
 	display_mode->add_item(TTR("Frame %"));
 	display_mode->add_item(TTR("Physics Frame %"));
-	display_mode->connect_compat("item_selected", this, "_combo_changed");
+	display_mode->connect("item_selected", Callable(this, "_combo_changed"));
 
 	hb->add_child(display_mode);
 
@@ -710,7 +710,7 @@ EditorProfiler::EditorProfiler() {
 	display_time = memnew(OptionButton);
 	display_time->add_item(TTR("Inclusive"));
 	display_time->add_item(TTR("Self"));
-	display_time->connect_compat("item_selected", this, "_combo_changed");
+	display_time->connect("item_selected", Callable(this, "_combo_changed"));
 
 	hb->add_child(display_time);
 
@@ -721,7 +721,7 @@ EditorProfiler::EditorProfiler() {
 	cursor_metric_edit = memnew(SpinBox);
 	cursor_metric_edit->set_h_size_flags(SIZE_FILL);
 	hb->add_child(cursor_metric_edit);
-	cursor_metric_edit->connect_compat("value_changed", this, "_cursor_metric_changed");
+	cursor_metric_edit->connect("value_changed", Callable(this, "_cursor_metric_changed"));
 
 	hb->add_constant_override("separation", 8 * EDSCALE);
 
@@ -745,14 +745,14 @@ EditorProfiler::EditorProfiler() {
 	variables->set_column_title(2, TTR("Calls"));
 	variables->set_column_expand(2, false);
 	variables->set_column_min_width(2, 60 * EDSCALE);
-	variables->connect_compat("item_edited", this, "_item_edited");
+	variables->connect("item_edited", Callable(this, "_item_edited"));
 
 	graph = memnew(TextureRect);
 	graph->set_expand(true);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
-	graph->connect_compat("draw", this, "_graph_tex_draw");
-	graph->connect_compat("gui_input", this, "_graph_tex_input");
-	graph->connect_compat("mouse_exited", this, "_graph_tex_mouse_exit");
+	graph->connect("draw", Callable(this, "_graph_tex_draw"));
+	graph->connect("gui_input", Callable(this, "_graph_tex_input"));
+	graph->connect("mouse_exited", Callable(this, "_graph_tex_mouse_exit"));
 
 	h_split->add_child(graph);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -768,13 +768,13 @@ EditorProfiler::EditorProfiler() {
 	frame_delay->set_wait_time(0.1);
 	frame_delay->set_one_shot(true);
 	add_child(frame_delay);
-	frame_delay->connect_compat("timeout", this, "_update_frame");
+	frame_delay->connect("timeout", Callable(this, "_update_frame"));
 
 	plot_delay = memnew(Timer);
 	plot_delay->set_wait_time(0.1);
 	plot_delay->set_one_shot(true);
 	add_child(plot_delay);
-	plot_delay->connect_compat("timeout", this, "_update_plot");
+	plot_delay->connect("timeout", Callable(this, "_update_plot"));
 
 	plot_sigs.insert("physics_frame_time");
 	plot_sigs.insert("category_frame_time");

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -96,8 +96,8 @@ EditorPropertyText::EditorPropertyText() {
 	text = memnew(LineEdit);
 	add_child(text);
 	add_focusable(text);
-	text->connect_compat("text_changed", this, "_text_changed");
-	text->connect_compat("text_entered", this, "_text_entered");
+	text->connect("text_changed", Callable(this, "_text_changed"));
+	text->connect("text_entered", Callable(this, "_text_entered"));
 
 	string_name = false;
 	updating = false;
@@ -118,7 +118,7 @@ void EditorPropertyMultilineText::_open_big_text() {
 
 	if (!big_text_dialog) {
 		big_text = memnew(TextEdit);
-		big_text->connect_compat("text_changed", this, "_big_text_changed");
+		big_text->connect("text_changed", Callable(this, "_big_text_changed"));
 		big_text->set_wrap_enabled(true);
 		big_text_dialog = memnew(AcceptDialog);
 		big_text_dialog->add_child(big_text);
@@ -164,13 +164,13 @@ EditorPropertyMultilineText::EditorPropertyMultilineText() {
 	add_child(hb);
 	set_bottom_editor(hb);
 	text = memnew(TextEdit);
-	text->connect_compat("text_changed", this, "_text_changed");
+	text->connect("text_changed", Callable(this, "_text_changed"));
 	text->set_wrap_enabled(true);
 	add_focusable(text);
 	hb->add_child(text);
 	text->set_h_size_flags(SIZE_EXPAND_FILL);
 	open_big_text = memnew(ToolButton);
-	open_big_text->connect_compat("pressed", this, "_open_big_text");
+	open_big_text->connect("pressed", Callable(this, "_open_big_text"));
 	hb->add_child(open_big_text);
 	big_text_dialog = NULL;
 	big_text = NULL;
@@ -220,7 +220,7 @@ EditorPropertyTextEnum::EditorPropertyTextEnum() {
 
 	add_child(options);
 	add_focusable(options);
-	options->connect_compat("item_selected", this, "_option_selected");
+	options->connect("item_selected", Callable(this, "_option_selected"));
 }
 ///////////////////// PATH /////////////////////////
 
@@ -233,8 +233,8 @@ void EditorPropertyPath::_path_pressed() {
 
 	if (!dialog) {
 		dialog = memnew(EditorFileDialog);
-		dialog->connect_compat("file_selected", this, "_path_selected");
-		dialog->connect_compat("dir_selected", this, "_path_selected");
+		dialog->connect("file_selected", Callable(this, "_path_selected"));
+		dialog->connect("dir_selected", Callable(this, "_path_selected"));
 		add_child(dialog);
 	}
 
@@ -308,8 +308,8 @@ EditorPropertyPath::EditorPropertyPath() {
 	add_child(path_hb);
 	path = memnew(LineEdit);
 	path_hb->add_child(path);
-	path->connect_compat("text_entered", this, "_path_selected");
-	path->connect_compat("focus_exited", this, "_path_focus_exited");
+	path->connect("text_entered", Callable(this, "_path_selected"));
+	path->connect("focus_exited", Callable(this, "_path_focus_exited"));
 	path->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	path_edit = memnew(Button);
@@ -317,7 +317,7 @@ EditorPropertyPath::EditorPropertyPath() {
 	path_hb->add_child(path_edit);
 	add_focusable(path);
 	dialog = NULL;
-	path_edit->connect_compat("pressed", this, "_path_pressed");
+	path_edit->connect("pressed", Callable(this, "_path_pressed"));
 	folder = false;
 	global = false;
 	save_mode = false;
@@ -361,10 +361,10 @@ EditorPropertyClassName::EditorPropertyClassName() {
 	add_child(property);
 	add_focusable(property);
 	property->set_text(selected_type);
-	property->connect_compat("pressed", this, "_property_selected");
+	property->connect("pressed", Callable(this, "_property_selected"));
 	dialog = memnew(CreateDialog);
 	dialog->set_base_type(base_type);
-	dialog->connect_compat("create", this, "_dialog_created");
+	dialog->connect("create", Callable(this, "_dialog_created"));
 	add_child(dialog);
 }
 
@@ -380,7 +380,7 @@ void EditorPropertyMember::_property_select() {
 
 	if (!selector) {
 		selector = memnew(PropertySelector);
-		selector->connect_compat("selected", this, "_property_selected");
+		selector->connect("selected", Callable(this, "_property_selected"));
 		add_child(selector);
 	}
 
@@ -470,7 +470,7 @@ EditorPropertyMember::EditorPropertyMember() {
 	property->set_clip_text(true);
 	add_child(property);
 	add_focusable(property);
-	property->connect_compat("pressed", this, "_property_select");
+	property->connect("pressed", Callable(this, "_property_select"));
 }
 
 ///////////////////// CHECK /////////////////////////
@@ -495,7 +495,7 @@ EditorPropertyCheck::EditorPropertyCheck() {
 	checkbox->set_text(TTR("On"));
 	add_child(checkbox);
 	add_focusable(checkbox);
-	checkbox->connect_compat("pressed", this, "_checkbox_pressed");
+	checkbox->connect("pressed", Callable(this, "_checkbox_pressed"));
 }
 
 ///////////////////// ENUM /////////////////////////
@@ -546,7 +546,7 @@ EditorPropertyEnum::EditorPropertyEnum() {
 	options->set_flat(true);
 	add_child(options);
 	add_focusable(options);
-	options->connect_compat("item_selected", this, "_option_selected");
+	options->connect("item_selected", Callable(this, "_option_selected"));
 }
 
 ///////////////////// FLAGS /////////////////////////
@@ -591,7 +591,7 @@ void EditorPropertyFlags::setup(const Vector<String> &p_options) {
 			CheckBox *cb = memnew(CheckBox);
 			cb->set_text(option);
 			cb->set_clip_text(true);
-			cb->connect_compat("pressed", this, "_flag_toggled");
+			cb->connect("pressed", Callable(this, "_flag_toggled"));
 			add_focusable(cb);
 			vbox->add_child(cb);
 			flags.push_back(cb);
@@ -802,20 +802,20 @@ EditorPropertyLayers::EditorPropertyLayers() {
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_child(hb);
 	grid = memnew(EditorPropertyLayersGrid);
-	grid->connect_compat("flag_changed", this, "_grid_changed");
+	grid->connect("flag_changed", Callable(this, "_grid_changed"));
 	grid->set_h_size_flags(SIZE_EXPAND_FILL);
 	hb->add_child(grid);
 	button = memnew(Button);
 	button->set_toggle_mode(true);
 	button->set_text("..");
-	button->connect_compat("pressed", this, "_button_pressed");
+	button->connect("pressed", Callable(this, "_button_pressed"));
 	hb->add_child(button);
 	set_bottom_editor(hb);
 	layers = memnew(PopupMenu);
 	add_child(layers);
 	layers->set_hide_on_checkable_item_selection(false);
-	layers->connect_compat("id_pressed", this, "_menu_pressed");
-	layers->connect_compat("popup_hide", button, "set_pressed", varray(false));
+	layers->connect("id_pressed", Callable(this, "_menu_pressed"));
+	layers->connect("popup_hide", Callable(button, "set_pressed"), varray(false));
 }
 
 ///////////////////// INT /////////////////////////
@@ -856,7 +856,7 @@ EditorPropertyInteger::EditorPropertyInteger() {
 	spin->set_flat(true);
 	add_child(spin);
 	add_focusable(spin);
-	spin->connect_compat("value_changed", this, "_value_changed");
+	spin->connect("value_changed", Callable(this, "_value_changed"));
 	setting = false;
 }
 
@@ -896,7 +896,7 @@ EditorPropertyObjectID::EditorPropertyObjectID() {
 	edit = memnew(Button);
 	add_child(edit);
 	add_focusable(edit);
-	edit->connect_compat("pressed", this, "_edit_pressed");
+	edit->connect("pressed", Callable(this, "_edit_pressed"));
 }
 
 ///////////////////// FLOAT /////////////////////////
@@ -936,7 +936,7 @@ EditorPropertyFloat::EditorPropertyFloat() {
 	spin->set_flat(true);
 	add_child(spin);
 	add_focusable(spin);
-	spin->connect_compat("value_changed", this, "_value_changed");
+	spin->connect("value_changed", Callable(this, "_value_changed"));
 	setting = false;
 }
 
@@ -1115,14 +1115,14 @@ void EditorPropertyEasing::_bind_methods() {
 EditorPropertyEasing::EditorPropertyEasing() {
 
 	easing_draw = memnew(Control);
-	easing_draw->connect_compat("draw", this, "_draw_easing");
-	easing_draw->connect_compat("gui_input", this, "_drag_easing");
+	easing_draw->connect("draw", Callable(this, "_draw_easing"));
+	easing_draw->connect("gui_input", Callable(this, "_drag_easing"));
 	easing_draw->set_default_cursor_shape(Control::CURSOR_MOVE);
 	add_child(easing_draw);
 
 	preset = memnew(PopupMenu);
 	add_child(preset);
-	preset->connect_compat("id_pressed", this, "_set_preset");
+	preset->connect("id_pressed", Callable(this, "_set_preset"));
 
 	spin = memnew(EditorSpinSlider);
 	spin->set_flat(true);
@@ -1132,8 +1132,8 @@ EditorPropertyEasing::EditorPropertyEasing() {
 	spin->set_hide_slider(true);
 	spin->set_allow_lesser(true);
 	spin->set_allow_greater(true);
-	spin->connect_compat("value_changed", this, "_spin_value_changed");
-	spin->get_line_edit()->connect_compat("focus_exited", this, "_spin_focus_exited");
+	spin->connect("value_changed", Callable(this, "_spin_value_changed"));
+	spin->get_line_edit()->connect("focus_exited", Callable(this, "_spin_focus_exited"));
 	spin->hide();
 	add_child(spin);
 
@@ -1211,7 +1211,7 @@ EditorPropertyVector2::EditorPropertyVector2() {
 		spin[i]->set_label(desc[i]);
 		bc->add_child(spin[i]);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", Callable(this, "_value_changed"), varray(desc[i]));
 		if (horizontal) {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
@@ -1295,7 +1295,7 @@ EditorPropertyRect2::EditorPropertyRect2() {
 		spin[i]->set_flat(true);
 		bc->add_child(spin[i]);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", Callable(this, "_value_changed"), varray(desc[i]));
 		if (horizontal) {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
@@ -1376,7 +1376,7 @@ EditorPropertyVector3::EditorPropertyVector3() {
 		spin[i]->set_label(desc[i]);
 		bc->add_child(spin[i]);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", Callable(this, "_value_changed"), varray(desc[i]));
 		if (horizontal) {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
@@ -1459,7 +1459,7 @@ EditorPropertyPlane::EditorPropertyPlane() {
 		spin[i]->set_label(desc[i]);
 		bc->add_child(spin[i]);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", Callable(this, "_value_changed"), varray(desc[i]));
 		if (horizontal) {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
@@ -1542,7 +1542,7 @@ EditorPropertyQuat::EditorPropertyQuat() {
 		spin[i]->set_label(desc[i]);
 		bc->add_child(spin[i]);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", Callable(this, "_value_changed"), varray(desc[i]));
 		if (horizontal) {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
@@ -1624,7 +1624,7 @@ EditorPropertyAABB::EditorPropertyAABB() {
 		g->add_child(spin[i]);
 		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", Callable(this, "_value_changed"), varray(desc[i]));
 	}
 	set_bottom_editor(g);
 	setting = false;
@@ -1699,7 +1699,7 @@ EditorPropertyTransform2D::EditorPropertyTransform2D() {
 		g->add_child(spin[i]);
 		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", Callable(this, "_value_changed"), varray(desc[i]));
 	}
 	set_bottom_editor(g);
 	setting = false;
@@ -1780,7 +1780,7 @@ EditorPropertyBasis::EditorPropertyBasis() {
 		g->add_child(spin[i]);
 		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", Callable(this, "_value_changed"), varray(desc[i]));
 	}
 	set_bottom_editor(g);
 	setting = false;
@@ -1867,7 +1867,7 @@ EditorPropertyTransform::EditorPropertyTransform() {
 		g->add_child(spin[i]);
 		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		add_focusable(spin[i]);
-		spin[i]->connect_compat("value_changed", this, "_value_changed", varray(desc[i]));
+		spin[i]->connect("value_changed", Callable(this, "_value_changed"), varray(desc[i]));
 	}
 	set_bottom_editor(g);
 	setting = false;
@@ -1932,9 +1932,9 @@ EditorPropertyColor::EditorPropertyColor() {
 	picker = memnew(ColorPickerButton);
 	add_child(picker);
 	picker->set_flat(true);
-	picker->connect_compat("color_changed", this, "_color_changed");
-	picker->connect_compat("popup_closed", this, "_popup_closed");
-	picker->connect_compat("picker_created", this, "_picker_created");
+	picker->connect("color_changed", Callable(this, "_color_changed"));
+	picker->connect("popup_closed", Callable(this, "_popup_closed"));
+	picker->connect("picker_created", Callable(this, "_picker_created"));
 }
 
 ////////////// NODE PATH //////////////////////
@@ -1981,7 +1981,7 @@ void EditorPropertyNodePath::_node_assign() {
 		scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
 		scene_tree->get_scene_tree()->set_valid_types(valid_types);
 		add_child(scene_tree);
-		scene_tree->connect_compat("selected", this, "_node_selected");
+		scene_tree->connect("selected", Callable(this, "_node_selected"));
 	}
 	scene_tree->popup_centered_ratio();
 }
@@ -2063,12 +2063,12 @@ EditorPropertyNodePath::EditorPropertyNodePath() {
 	assign->set_flat(true);
 	assign->set_h_size_flags(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
-	assign->connect_compat("pressed", this, "_node_assign");
+	assign->connect("pressed", Callable(this, "_node_assign"));
 	hbc->add_child(assign);
 
 	clear = memnew(Button);
 	clear->set_flat(true);
-	clear->connect_compat("pressed", this, "_node_clear");
+	clear->connect("pressed", Callable(this, "_node_clear"));
 	hbc->add_child(clear);
 	use_path_from_scene_root = false;
 
@@ -2135,7 +2135,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 
 			if (!file) {
 				file = memnew(EditorFileDialog);
-				file->connect_compat("file_selected", this, "_file_selected");
+				file->connect("file_selected", Callable(this, "_file_selected"));
 				add_child(file);
 			}
 			file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
@@ -2304,7 +2304,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 					scene_tree->get_scene_tree()->set_valid_types(valid_types);
 					scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
 					add_child(scene_tree);
-					scene_tree->connect_compat("selected", this, "_viewport_selected");
+					scene_tree->connect("selected", Callable(this, "_viewport_selected"));
 					scene_tree->set_title(TTR("Pick a Viewport"));
 				}
 				scene_tree->popup_centered_ratio();
@@ -2622,9 +2622,9 @@ void EditorPropertyResource::update_property() {
 				sub_inspector->set_sub_inspector(true);
 				sub_inspector->set_enable_capitalize_paths(true);
 
-				sub_inspector->connect_compat("property_keyed", this, "_sub_inspector_property_keyed");
-				sub_inspector->connect_compat("resource_selected", this, "_sub_inspector_resource_selected");
-				sub_inspector->connect_compat("object_id_selected", this, "_sub_inspector_object_id_selected");
+				sub_inspector->connect("property_keyed", Callable(this, "_sub_inspector_property_keyed"));
+				sub_inspector->connect("resource_selected", Callable(this, "_sub_inspector_resource_selected"));
+				sub_inspector->connect("object_id_selected", Callable(this, "_sub_inspector_object_id_selected"));
 				sub_inspector->set_keying(is_keying());
 				sub_inspector->set_read_only(is_read_only());
 				sub_inspector->set_use_folding(is_using_folding());
@@ -2907,9 +2907,9 @@ EditorPropertyResource::EditorPropertyResource() {
 	assign->set_flat(true);
 	assign->set_h_size_flags(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
-	assign->connect_compat("pressed", this, "_resource_selected");
+	assign->connect("pressed", Callable(this, "_resource_selected"));
 	assign->set_drag_forwarding(this);
-	assign->connect_compat("draw", this, "_button_draw");
+	assign->connect("draw", Callable(this, "_button_draw"));
 	hbc->add_child(assign);
 	add_focusable(assign);
 
@@ -2920,18 +2920,18 @@ EditorPropertyResource::EditorPropertyResource() {
 	preview->set_margin(MARGIN_BOTTOM, -1);
 	preview->set_margin(MARGIN_RIGHT, -1);
 	assign->add_child(preview);
-	assign->connect_compat("gui_input", this, "_button_input");
+	assign->connect("gui_input", Callable(this, "_button_input"));
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
 	edit = memnew(Button);
 	edit->set_flat(true);
 	edit->set_toggle_mode(true);
-	menu->connect_compat("id_pressed", this, "_menu_option");
-	menu->connect_compat("popup_hide", edit, "set_pressed", varray(false));
-	edit->connect_compat("pressed", this, "_update_menu");
+	menu->connect("id_pressed", Callable(this, "_menu_option"));
+	menu->connect("popup_hide", Callable(edit, "set_pressed"), varray(false));
+	edit->connect("pressed", Callable(this, "_update_menu"));
 	hbc->add_child(edit);
-	edit->connect_compat("gui_input", this, "_button_input");
+	edit->connect("gui_input", Callable(this, "_button_input"));
 	add_focusable(edit);
 
 	file = NULL;

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -290,7 +290,7 @@ void EditorPropertyArray::update_property() {
 			length->set_max(1000000);
 			length->set_h_size_flags(SIZE_EXPAND_FILL);
 			hbc->add_child(length);
-			length->connect_compat("value_changed", this, "_length_changed");
+			length->connect("value_changed", Callable(this, "_length_changed"));
 
 			page_hb = memnew(HBoxContainer);
 			vbox->add_child(page_hb);
@@ -301,7 +301,7 @@ void EditorPropertyArray::update_property() {
 			page->set_step(1);
 			page_hb->add_child(page);
 			page->set_h_size_flags(SIZE_EXPAND_FILL);
-			page->connect_compat("value_changed", this, "_page_changed");
+			page->connect("value_changed", Callable(this, "_page_changed"));
 		} else {
 			//bye bye children of the box
 			while (vbox->get_child_count() > 2) {
@@ -353,8 +353,8 @@ void EditorPropertyArray::update_property() {
 			prop->set_object_and_property(object.ptr(), prop_name);
 			prop->set_label(itos(i + offset));
 			prop->set_selectable(false);
-			prop->connect_compat("property_changed", this, "_property_changed");
-			prop->connect_compat("object_id_selected", this, "_object_id_selected");
+			prop->connect("property_changed", Callable(this, "_property_changed"));
+			prop->connect("object_id_selected", Callable(this, "_object_id_selected"));
 			prop->set_h_size_flags(SIZE_EXPAND_FILL);
 
 			HBoxContainer *hb = memnew(HBoxContainer);
@@ -369,12 +369,12 @@ void EditorPropertyArray::update_property() {
 				Button *edit = memnew(Button);
 				edit->set_icon(get_icon("Edit", "EditorIcons"));
 				hb->add_child(edit);
-				edit->connect_compat("pressed", this, "_change_type", varray(edit, i + offset));
+				edit->connect("pressed", Callable(this, "_change_type"), varray(edit, i + offset));
 			} else {
 
 				Button *remove = memnew(Button);
 				remove->set_icon(get_icon("Remove", "EditorIcons"));
-				remove->connect_compat("pressed", this, "_remove_pressed", varray(i + offset));
+				remove->connect("pressed", Callable(this, "_remove_pressed"), varray(i + offset));
 				hb->add_child(remove);
 			}
 
@@ -503,7 +503,7 @@ EditorPropertyArray::EditorPropertyArray() {
 	edit->set_flat(true);
 	edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit->set_clip_text(true);
-	edit->connect_compat("pressed", this, "_edit_pressed");
+	edit->connect("pressed", Callable(this, "_edit_pressed"));
 	edit->set_toggle_mode(true);
 	add_child(edit);
 	add_focusable(edit);
@@ -513,7 +513,7 @@ EditorPropertyArray::EditorPropertyArray() {
 	updating = false;
 	change_type = memnew(PopupMenu);
 	add_child(change_type);
-	change_type->connect_compat("id_pressed", this, "_change_type_menu");
+	change_type->connect("id_pressed", Callable(this, "_change_type_menu"));
 
 	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
 		String type = Variant::get_type_name(Variant::Type(i));
@@ -661,7 +661,7 @@ void EditorPropertyDictionary::update_property() {
 			page->set_step(1);
 			page_hb->add_child(page);
 			page->set_h_size_flags(SIZE_EXPAND_FILL);
-			page->connect_compat("value_changed", this, "_page_changed");
+			page->connect("value_changed", Callable(this, "_page_changed"));
 		} else {
 			// Queue children for deletion, deleting immediately might cause errors.
 			for (int i = 1; i < vbox->get_child_count(); i++) {
@@ -922,8 +922,8 @@ void EditorPropertyDictionary::update_property() {
 			}
 
 			prop->set_selectable(false);
-			prop->connect_compat("property_changed", this, "_property_changed");
-			prop->connect_compat("object_id_selected", this, "_object_id_selected");
+			prop->connect("property_changed", Callable(this, "_property_changed"));
+			prop->connect("object_id_selected", Callable(this, "_object_id_selected"));
 
 			HBoxContainer *hb = memnew(HBoxContainer);
 			if (add_vbox) {
@@ -936,14 +936,14 @@ void EditorPropertyDictionary::update_property() {
 			Button *edit = memnew(Button);
 			edit->set_icon(get_icon("Edit", "EditorIcons"));
 			hb->add_child(edit);
-			edit->connect_compat("pressed", this, "_change_type", varray(edit, change_index));
+			edit->connect("pressed", Callable(this, "_change_type"), varray(edit, change_index));
 
 			prop->update_property();
 
 			if (i == amount + 1) {
 				Button *butt_add_item = memnew(Button);
 				butt_add_item->set_text(TTR("Add Key/Value Pair"));
-				butt_add_item->connect_compat("pressed", this, "_add_key_value");
+				butt_add_item->connect("pressed", Callable(this, "_add_key_value"));
 				add_vbox->add_child(butt_add_item);
 			}
 		}
@@ -1005,7 +1005,7 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 	edit->set_flat(true);
 	edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit->set_clip_text(true);
-	edit->connect_compat("pressed", this, "_edit_pressed");
+	edit->connect("pressed", Callable(this, "_edit_pressed"));
 	edit->set_toggle_mode(true);
 	add_child(edit);
 	add_focusable(edit);
@@ -1014,7 +1014,7 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 	updating = false;
 	change_type = memnew(PopupMenu);
 	add_child(change_type);
-	change_type->connect_compat("id_pressed", this, "_change_type_menu");
+	change_type->connect("id_pressed", Callable(this, "_change_type_menu"));
 
 	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
 		String type = Variant::get_type_name(Variant::Type(i));

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -55,8 +55,8 @@ void EditorRunNative::_notification(int p_what) {
 					small_icon.instance();
 					small_icon->create_from_image(im);
 					MenuButton *mb = memnew(MenuButton);
-					mb->get_popup()->connect_compat("id_pressed", this, "_run_native", varray(i));
-					mb->connect_compat("pressed", this, "_run_native", varray(-1, i));
+					mb->get_popup()->connect("id_pressed", Callable(this, "_run_native"), varray(i));
+					mb->connect("pressed", Callable(this, "_run_native"), varray(-1, i));
 					mb->set_icon(small_icon);
 					add_child(mb);
 					menus[i] = mb;

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -294,7 +294,7 @@ void SectionedInspector::register_search_box(LineEdit *p_box) {
 
 	search_box = p_box;
 	inspector->register_text_enter(p_box);
-	search_box->connect_compat("text_changed", this, "_search_changed");
+	search_box->connect("text_changed", Callable(this, "_search_changed"));
 }
 
 void SectionedInspector::_search_changed(const String &p_what) {
@@ -332,7 +332,7 @@ SectionedInspector::SectionedInspector() :
 	right_vb->add_child(inspector, true);
 	inspector->set_use_doc_hints(true);
 
-	sections->connect_compat("cell_selected", this, "_section_selected");
+	sections->connect("cell_selected", Callable(this, "_section_selected"));
 }
 
 SectionedInspector::~SectionedInspector() {

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -490,9 +490,9 @@ EditorSpinSlider::EditorSpinSlider() {
 	grabber->hide();
 	grabber->set_as_toplevel(true);
 	grabber->set_mouse_filter(MOUSE_FILTER_STOP);
-	grabber->connect_compat("mouse_entered", this, "_grabber_mouse_entered");
-	grabber->connect_compat("mouse_exited", this, "_grabber_mouse_exited");
-	grabber->connect_compat("gui_input", this, "_grabber_gui_input");
+	grabber->connect("mouse_entered", Callable(this, "_grabber_mouse_entered"));
+	grabber->connect("mouse_exited", Callable(this, "_grabber_mouse_exited"));
+	grabber->connect("gui_input", Callable(this, "_grabber_gui_input"));
 	mouse_over_spin = false;
 	mouse_over_grabber = false;
 	mousewheel_over_grabber = false;
@@ -502,9 +502,9 @@ EditorSpinSlider::EditorSpinSlider() {
 	add_child(value_input);
 	value_input->set_as_toplevel(true);
 	value_input->hide();
-	value_input->connect_compat("modal_closed", this, "_value_input_closed");
-	value_input->connect_compat("text_entered", this, "_value_input_entered");
-	value_input->connect_compat("focus_exited", this, "_value_focus_exited");
+	value_input->connect("modal_closed", Callable(this, "_value_input_closed"));
+	value_input->connect("text_entered", Callable(this, "_value_input_entered"));
+	value_input->connect("focus_exited", Callable(this, "_value_focus_exited"));
 	value_input_just_closed = false;
 	hide_slider = false;
 	read_only = false;

--- a/editor/editor_sub_scene.cpp
+++ b/editor/editor_sub_scene.cpp
@@ -239,24 +239,24 @@ EditorSubScene::EditorSubScene() {
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	path = memnew(LineEdit);
-	path->connect_compat("text_entered", this, "_path_changed");
+	path->connect("text_entered", Callable(this, "_path_changed"));
 	hb->add_child(path);
 	path->set_h_size_flags(SIZE_EXPAND_FILL);
 	Button *b = memnew(Button);
 	b->set_text(TTR("Browse"));
 	hb->add_child(b);
-	b->connect_compat("pressed", this, "_path_browse");
+	b->connect("pressed", Callable(this, "_path_browse"));
 	vb->add_margin_child(TTR("Scene Path:"), hb);
 
 	tree = memnew(Tree);
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 	vb->add_margin_child(TTR("Import From Node:"), tree, true);
 	tree->set_select_mode(Tree::SELECT_MULTI);
-	tree->connect_compat("multi_selected", this, "_item_multi_selected");
+	tree->connect("multi_selected", Callable(this, "_item_multi_selected"));
 	//tree->connect("nothing_selected", this, "_deselect_items");
-	tree->connect_compat("cell_selected", this, "_selected_changed");
+	tree->connect("cell_selected", Callable(this, "_selected_changed"));
 
-	tree->connect_compat("item_activated", this, "_ok", make_binds(), CONNECT_DEFERRED);
+	tree->connect("item_activated", Callable(this, "_ok"), make_binds(), CONNECT_DEFERRED);
 
 	file_dialog = memnew(EditorFileDialog);
 	List<String> extensions;
@@ -269,5 +269,5 @@ EditorSubScene::EditorSubScene() {
 
 	file_dialog->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 	add_child(file_dialog);
-	file_dialog->connect_compat("file_selected", this, "_path_selected");
+	file_dialog->connect("file_selected", Callable(this, "_path_selected"));
 }

--- a/editor/editor_visual_profiler.cpp
+++ b/editor/editor_visual_profiler.cpp
@@ -753,12 +753,12 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_text(TTR("Start"));
-	activate->connect_compat("pressed", this, "_activate_pressed");
+	activate->connect("pressed", Callable(this, "_activate_pressed"));
 	hb->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
-	clear_button->connect_compat("pressed", this, "_clear_pressed");
+	clear_button->connect("pressed", Callable(this, "_clear_pressed"));
 	hb->add_child(clear_button);
 
 	hb->add_child(memnew(Label(TTR("Measure:"))));
@@ -766,18 +766,18 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	display_mode = memnew(OptionButton);
 	display_mode->add_item(TTR("Frame Time (msec)"));
 	display_mode->add_item(TTR("Frame %"));
-	display_mode->connect_compat("item_selected", this, "_combo_changed");
+	display_mode->connect("item_selected", Callable(this, "_combo_changed"));
 
 	hb->add_child(display_mode);
 
 	frame_relative = memnew(CheckBox(TTR("Fit to Frame")));
 	frame_relative->set_pressed(true);
 	hb->add_child(frame_relative);
-	frame_relative->connect_compat("pressed", this, "_update_plot");
+	frame_relative->connect("pressed", Callable(this, "_update_plot"));
 	linked = memnew(CheckBox(TTR("Linked")));
 	linked->set_pressed(true);
 	hb->add_child(linked);
-	linked->connect_compat("pressed", this, "_update_plot");
+	linked->connect("pressed", Callable(this, "_update_plot"));
 
 	hb->add_spacer();
 
@@ -786,7 +786,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	cursor_metric_edit = memnew(SpinBox);
 	cursor_metric_edit->set_h_size_flags(SIZE_FILL);
 	hb->add_child(cursor_metric_edit);
-	cursor_metric_edit->connect_compat("value_changed", this, "_cursor_metric_changed");
+	cursor_metric_edit->connect("value_changed", Callable(this, "_cursor_metric_changed"));
 
 	hb->add_constant_override("separation", 8 * EDSCALE);
 
@@ -810,15 +810,15 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	variables->set_column_title(2, TTR("GPU"));
 	variables->set_column_expand(2, false);
 	variables->set_column_min_width(2, 60 * EDSCALE);
-	variables->connect_compat("cell_selected", this, "_item_selected");
+	variables->connect("cell_selected", Callable(this, "_item_selected"));
 
 	graph = memnew(TextureRect);
 	graph->set_expand(true);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
 	//graph->set_ignore_mouse(false);
-	graph->connect_compat("draw", this, "_graph_tex_draw");
-	graph->connect_compat("gui_input", this, "_graph_tex_input");
-	graph->connect_compat("mouse_exited", this, "_graph_tex_mouse_exit");
+	graph->connect("draw", Callable(this, "_graph_tex_draw"));
+	graph->connect("gui_input", Callable(this, "_graph_tex_input"));
+	graph->connect("mouse_exited", Callable(this, "_graph_tex_mouse_exit"));
 
 	h_split->add_child(graph);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -835,13 +835,13 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	frame_delay->set_wait_time(0.1);
 	frame_delay->set_one_shot(true);
 	add_child(frame_delay);
-	frame_delay->connect_compat("timeout", this, "_update_frame");
+	frame_delay->connect("timeout", Callable(this, "_update_frame"));
 
 	plot_delay = memnew(Timer);
 	plot_delay->set_wait_time(0.1);
 	plot_delay->set_one_shot(true);
 	add_child(plot_delay);
-	plot_delay->connect_compat("timeout", this, "_update_plot");
+	plot_delay->connect("timeout", Callable(this, "_update_plot"));
 
 	seeking = false;
 	graph_height_cpu = 1;

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -93,14 +93,14 @@ void ExportTemplateManager::_update_template_list() {
 			Button *redownload = memnew(Button);
 			redownload->set_text(TTR("Redownload"));
 			current_hb->add_child(redownload);
-			redownload->connect_compat("pressed", this, "_download_template", varray(current_version));
+			redownload->connect("pressed", Callable(this, "_download_template"), varray(current_version));
 		}
 
 		Button *uninstall = memnew(Button);
 		uninstall->set_text(TTR("Uninstall"));
 		current_hb->add_child(uninstall);
 		current->set_text(current_version + " " + TTR("(Installed)"));
-		uninstall->connect_compat("pressed", this, "_uninstall_template", varray(current_version));
+		uninstall->connect("pressed", Callable(this, "_uninstall_template"), varray(current_version));
 
 	} else {
 		current->add_color_override("font_color", get_color("error_color", "Editor"));
@@ -112,7 +112,7 @@ void ExportTemplateManager::_update_template_list() {
 			redownload->set_tooltip(TTR("Official export templates aren't available for development builds."));
 		}
 
-		redownload->connect_compat("pressed", this, "_download_template", varray(current_version));
+		redownload->connect("pressed", Callable(this, "_download_template"), varray(current_version));
 		current_hb->add_child(redownload);
 		current->set_text(current_version + " " + TTR("(Missing)"));
 	}
@@ -134,7 +134,7 @@ void ExportTemplateManager::_update_template_list() {
 
 		uninstall->set_text(TTR("Uninstall"));
 		hbc->add_child(uninstall);
-		uninstall->connect_compat("pressed", this, "_uninstall_template", varray(E->get()));
+		uninstall->connect("pressed", Callable(this, "_uninstall_template"), varray(E->get()));
 
 		installed_vb->add_child(hbc);
 	}
@@ -385,7 +385,7 @@ void ExportTemplateManager::_http_download_mirror_completed(int p_status, int p_
 			ERR_CONTINUE(!m.has("url") || !m.has("name"));
 			LinkButton *lb = memnew(LinkButton);
 			lb->set_text(m["name"]);
-			lb->connect_compat("pressed", this, "_begin_template_download", varray(m["url"]));
+			lb->connect("pressed", Callable(this, "_begin_template_download"), varray(m["url"]));
 			template_list->add_child(lb);
 			mirrors_found = true;
 		}
@@ -689,14 +689,14 @@ ExportTemplateManager::ExportTemplateManager() {
 	remove_confirm = memnew(ConfirmationDialog);
 	remove_confirm->set_title(TTR("Remove Template"));
 	add_child(remove_confirm);
-	remove_confirm->connect_compat("confirmed", this, "_uninstall_template_confirm");
+	remove_confirm->connect("confirmed", Callable(this, "_uninstall_template_confirm"));
 
 	template_open = memnew(FileDialog);
 	template_open->set_title(TTR("Select Template File"));
 	template_open->add_filter("*.tpz ; " + TTR("Godot Export Templates"));
 	template_open->set_access(FileDialog::ACCESS_FILESYSTEM);
 	template_open->set_mode(FileDialog::MODE_OPEN_FILE);
-	template_open->connect_compat("file_selected", this, "_install_from_file", varray(true));
+	template_open->connect("file_selected", Callable(this, "_install_from_file"), varray(true));
 	add_child(template_open);
 
 	set_title(TTR("Export Template Manager"));
@@ -704,18 +704,18 @@ ExportTemplateManager::ExportTemplateManager() {
 
 	request_mirror = memnew(HTTPRequest);
 	add_child(request_mirror);
-	request_mirror->connect_compat("request_completed", this, "_http_download_mirror_completed");
+	request_mirror->connect("request_completed", Callable(this, "_http_download_mirror_completed"));
 
 	download_templates = memnew(HTTPRequest);
 	add_child(download_templates);
-	download_templates->connect_compat("request_completed", this, "_http_download_templates_completed");
+	download_templates->connect("request_completed", Callable(this, "_http_download_templates_completed"));
 
 	template_downloader = memnew(AcceptDialog);
 	template_downloader->set_title(TTR("Download Templates"));
 	template_downloader->get_ok()->set_text(TTR("Close"));
 	template_downloader->set_exclusive(true);
 	add_child(template_downloader);
-	template_downloader->connect_compat("popup_hide", this, "_window_template_downloader_closed");
+	template_downloader->connect("popup_hide", Callable(this, "_window_template_downloader_closed"));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	template_downloader->add_child(vbc);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -300,19 +300,19 @@ void FileSystemDock::_notification(int p_what) {
 			if (initialized)
 				return;
 			initialized = true;
-			EditorFeatureProfileManager::get_singleton()->connect_compat("current_feature_profile_changed", this, "_feature_profile_changed");
+			EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", Callable(this, "_feature_profile_changed"));
 
-			EditorFileSystem::get_singleton()->connect_compat("filesystem_changed", this, "_fs_changed");
-			EditorResourcePreview::get_singleton()->connect_compat("preview_invalidated", this, "_preview_invalidated");
+			EditorFileSystem::get_singleton()->connect("filesystem_changed", Callable(this, "_fs_changed"));
+			EditorResourcePreview::get_singleton()->connect("preview_invalidated", Callable(this, "_preview_invalidated"));
 
 			String ei = "EditorIcons";
 			button_reload->set_icon(get_icon("Reload", ei));
 			button_toggle_display_mode->set_icon(get_icon("Panels2", ei));
-			button_file_list_display_mode->connect_compat("pressed", this, "_toggle_file_display");
+			button_file_list_display_mode->connect("pressed", Callable(this, "_toggle_file_display"));
 
-			files->connect_compat("item_activated", this, "_file_list_activate_file");
-			button_hist_next->connect_compat("pressed", this, "_fw_history");
-			button_hist_prev->connect_compat("pressed", this, "_bw_history");
+			files->connect("item_activated", Callable(this, "_file_list_activate_file"));
+			button_hist_next->connect("pressed", Callable(this, "_fw_history"));
+			button_hist_prev->connect("pressed", Callable(this, "_bw_history"));
 			tree_search_box->set_right_icon(get_icon("Search", ei));
 			tree_search_box->set_clear_button_enabled(true);
 			file_list_search_box->set_right_icon(get_icon("Search", ei));
@@ -320,10 +320,10 @@ void FileSystemDock::_notification(int p_what) {
 
 			button_hist_next->set_icon(get_icon("Forward", ei));
 			button_hist_prev->set_icon(get_icon("Back", ei));
-			file_list_popup->connect_compat("id_pressed", this, "_file_list_rmb_option");
-			tree_popup->connect_compat("id_pressed", this, "_tree_rmb_option");
+			file_list_popup->connect("id_pressed", Callable(this, "_file_list_rmb_option"));
+			tree_popup->connect("id_pressed", Callable(this, "_tree_rmb_option"));
 
-			current_path->connect_compat("text_entered", this, "_navigate_to_path");
+			current_path->connect("text_entered", Callable(this, "_navigate_to_path"));
 
 			always_show_folders = bool(EditorSettings::get_singleton()->get("docks/filesystem/always_show_folders"));
 
@@ -2552,7 +2552,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 
 	button_reload = memnew(Button);
 	button_reload->set_flat(true);
-	button_reload->connect_compat("pressed", this, "_rescan");
+	button_reload->connect("pressed", Callable(this, "_rescan"));
 	button_reload->set_focus_mode(FOCUS_NONE);
 	button_reload->set_tooltip(TTR("Re-Scan Filesystem"));
 	button_reload->hide();
@@ -2561,7 +2561,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	button_toggle_display_mode = memnew(Button);
 	button_toggle_display_mode->set_flat(true);
 	button_toggle_display_mode->set_toggle_mode(true);
-	button_toggle_display_mode->connect_compat("toggled", this, "_toggle_split_mode");
+	button_toggle_display_mode->connect("toggled", Callable(this, "_toggle_split_mode"));
 	button_toggle_display_mode->set_focus_mode(FOCUS_NONE);
 	button_toggle_display_mode->set_tooltip(TTR("Toggle Split Mode"));
 	toolbar_hbc->add_child(button_toggle_display_mode);
@@ -2573,7 +2573,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	tree_search_box = memnew(LineEdit);
 	tree_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	tree_search_box->set_placeholder(TTR("Search files"));
-	tree_search_box->connect_compat("text_changed", this, "_search_changed", varray(tree_search_box));
+	tree_search_box->connect("text_changed", Callable(this, "_search_changed"), varray(tree_search_box));
 	toolbar2_hbc->add_child(tree_search_box);
 
 	file_list_popup = memnew(PopupMenu);
@@ -2597,12 +2597,12 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	tree->set_custom_minimum_size(Size2(0, 15 * EDSCALE));
 	split_box->add_child(tree);
 
-	tree->connect_compat("item_activated", this, "_tree_activate_file");
-	tree->connect_compat("multi_selected", this, "_tree_multi_selected");
-	tree->connect_compat("item_rmb_selected", this, "_tree_rmb_select");
-	tree->connect_compat("empty_rmb", this, "_tree_rmb_empty");
-	tree->connect_compat("nothing_selected", this, "_tree_empty_selected");
-	tree->connect_compat("gui_input", this, "_tree_gui_input");
+	tree->connect("item_activated", Callable(this, "_tree_activate_file"));
+	tree->connect("multi_selected", Callable(this, "_tree_multi_selected"));
+	tree->connect("item_rmb_selected", Callable(this, "_tree_rmb_select"));
+	tree->connect("empty_rmb", Callable(this, "_tree_rmb_empty"));
+	tree->connect("nothing_selected", Callable(this, "_tree_empty_selected"));
+	tree->connect("gui_input", Callable(this, "_tree_gui_input"));
 
 	file_list_vb = memnew(VBoxContainer);
 	file_list_vb->set_v_size_flags(SIZE_EXPAND_FILL);
@@ -2614,7 +2614,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	file_list_search_box = memnew(LineEdit);
 	file_list_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	file_list_search_box->set_placeholder(TTR("Search files"));
-	file_list_search_box->connect_compat("text_changed", this, "_search_changed", varray(file_list_search_box));
+	file_list_search_box->connect("text_changed", Callable(this, "_search_changed"), varray(file_list_search_box));
 	path_hb->add_child(file_list_search_box);
 
 	button_file_list_display_mode = memnew(ToolButton);
@@ -2624,10 +2624,10 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	files->set_v_size_flags(SIZE_EXPAND_FILL);
 	files->set_select_mode(ItemList::SELECT_MULTI);
 	files->set_drag_forwarding(this);
-	files->connect_compat("item_rmb_selected", this, "_file_list_rmb_select");
-	files->connect_compat("gui_input", this, "_file_list_gui_input");
-	files->connect_compat("multi_selected", this, "_file_multi_selected");
-	files->connect_compat("rmb_clicked", this, "_file_list_rmb_pressed");
+	files->connect("item_rmb_selected", Callable(this, "_file_list_rmb_select"));
+	files->connect("gui_input", Callable(this, "_file_list_gui_input"));
+	files->connect("multi_selected", Callable(this, "_file_multi_selected"));
+	files->connect("rmb_clicked", Callable(this, "_file_list_rmb_pressed"));
 	files->set_custom_minimum_size(Size2(0, 15 * EDSCALE));
 	files->set_allow_rmb_select(true);
 	file_list_vb->add_child(files);
@@ -2651,14 +2651,14 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	add_child(owners_editor);
 
 	remove_dialog = memnew(DependencyRemoveDialog);
-	remove_dialog->connect_compat("file_removed", this, "_file_deleted");
-	remove_dialog->connect_compat("folder_removed", this, "_folder_deleted");
+	remove_dialog->connect("file_removed", Callable(this, "_file_deleted"));
+	remove_dialog->connect("folder_removed", Callable(this, "_folder_deleted"));
 	add_child(remove_dialog);
 
 	move_dialog = memnew(EditorDirDialog);
 	move_dialog->get_ok()->set_text(TTR("Move"));
 	add_child(move_dialog);
-	move_dialog->connect_compat("dir_selected", this, "_move_operation_confirm");
+	move_dialog->connect("dir_selected", Callable(this, "_move_operation_confirm"));
 
 	rename_dialog = memnew(ConfirmationDialog);
 	VBoxContainer *rename_dialog_vb = memnew(VBoxContainer);
@@ -2669,13 +2669,13 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	rename_dialog->get_ok()->set_text(TTR("Rename"));
 	add_child(rename_dialog);
 	rename_dialog->register_text_enter(rename_dialog_text);
-	rename_dialog->connect_compat("confirmed", this, "_rename_operation_confirm");
+	rename_dialog->connect("confirmed", Callable(this, "_rename_operation_confirm"));
 
 	overwrite_dialog = memnew(ConfirmationDialog);
 	overwrite_dialog->set_text(TTR("There is already file or folder with the same name in this location."));
 	overwrite_dialog->get_ok()->set_text(TTR("Overwrite"));
 	add_child(overwrite_dialog);
-	overwrite_dialog->connect_compat("confirmed", this, "_move_with_overwrite");
+	overwrite_dialog->connect("confirmed", Callable(this, "_move_with_overwrite"));
 
 	duplicate_dialog = memnew(ConfirmationDialog);
 	VBoxContainer *duplicate_dialog_vb = memnew(VBoxContainer);
@@ -2686,7 +2686,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	duplicate_dialog->get_ok()->set_text(TTR("Duplicate"));
 	add_child(duplicate_dialog);
 	duplicate_dialog->register_text_enter(duplicate_dialog_text);
-	duplicate_dialog->connect_compat("confirmed", this, "_duplicate_operation_confirm");
+	duplicate_dialog->connect("confirmed", Callable(this, "_duplicate_operation_confirm"));
 
 	make_dir_dialog = memnew(ConfirmationDialog);
 	make_dir_dialog->set_title(TTR("Create Folder"));
@@ -2697,7 +2697,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	make_folder_dialog_vb->add_margin_child(TTR("Name:"), make_dir_dialog_text);
 	add_child(make_dir_dialog);
 	make_dir_dialog->register_text_enter(make_dir_dialog_text);
-	make_dir_dialog->connect_compat("confirmed", this, "_make_dir_confirm");
+	make_dir_dialog->connect("confirmed", Callable(this, "_make_dir_confirm"));
 
 	make_scene_dialog = memnew(ConfirmationDialog);
 	make_scene_dialog->set_title(TTR("Create Scene"));
@@ -2708,7 +2708,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	make_scene_dialog_vb->add_margin_child(TTR("Name:"), make_scene_dialog_text);
 	add_child(make_scene_dialog);
 	make_scene_dialog->register_text_enter(make_scene_dialog_text);
-	make_scene_dialog->connect_compat("confirmed", this, "_make_scene_confirm");
+	make_scene_dialog->connect("confirmed", Callable(this, "_make_scene_confirm"));
 
 	make_script_dialog = memnew(ScriptCreateDialog);
 	make_script_dialog->set_title(TTR("Create Script"));
@@ -2717,7 +2717,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	new_resource_dialog = memnew(CreateDialog);
 	add_child(new_resource_dialog);
 	new_resource_dialog->set_base_type("Resource");
-	new_resource_dialog->connect_compat("create", this, "_resource_created");
+	new_resource_dialog->connect("create", Callable(this, "_resource_created"));
 
 	searched_string = String();
 	uncollapsed_paths_before_search = Vector<String>();

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -319,8 +319,8 @@ FindInFilesDialog::FindInFilesDialog() {
 
 	_search_text_line_edit = memnew(LineEdit);
 	_search_text_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
-	_search_text_line_edit->connect_compat("text_changed", this, "_on_search_text_modified");
-	_search_text_line_edit->connect_compat("text_entered", this, "_on_search_text_entered");
+	_search_text_line_edit->connect("text_changed", Callable(this, "_on_search_text_modified"));
+	_search_text_line_edit->connect("text_entered", Callable(this, "_on_search_text_entered"));
 	gc->add_child(_search_text_line_edit);
 
 	_replace_label = memnew(Label);
@@ -330,7 +330,7 @@ FindInFilesDialog::FindInFilesDialog() {
 
 	_replace_text_line_edit = memnew(LineEdit);
 	_replace_text_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
-	_replace_text_line_edit->connect_compat("text_entered", this, "_on_replace_text_entered");
+	_replace_text_line_edit->connect("text_entered", Callable(this, "_on_replace_text_entered"));
 	_replace_text_line_edit->hide();
 	gc->add_child(_replace_text_line_edit);
 
@@ -367,12 +367,12 @@ FindInFilesDialog::FindInFilesDialog() {
 
 		Button *folder_button = memnew(Button);
 		folder_button->set_text("...");
-		folder_button->connect_compat("pressed", this, "_on_folder_button_pressed");
+		folder_button->connect("pressed", Callable(this, "_on_folder_button_pressed"));
 		hbc->add_child(folder_button);
 
 		_folder_dialog = memnew(FileDialog);
 		_folder_dialog->set_mode(FileDialog::MODE_OPEN_DIR);
-		_folder_dialog->connect_compat("dir_selected", this, "_on_folder_selected");
+		_folder_dialog->connect("dir_selected", Callable(this, "_on_folder_selected"));
 		add_child(_folder_dialog);
 
 		gc->add_child(hbc);
@@ -563,8 +563,8 @@ const char *FindInFilesPanel::SIGNAL_FILES_MODIFIED = "files_modified";
 FindInFilesPanel::FindInFilesPanel() {
 
 	_finder = memnew(FindInFiles);
-	_finder->connect_compat(FindInFiles::SIGNAL_RESULT_FOUND, this, "_on_result_found");
-	_finder->connect_compat(FindInFiles::SIGNAL_FINISHED, this, "_on_finished");
+	_finder->connect(FindInFiles::SIGNAL_RESULT_FOUND, Callable(this, "_on_result_found"));
+	_finder->connect(FindInFiles::SIGNAL_FINISHED, Callable(this, "_on_finished"));
 	add_child(_finder);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
@@ -596,7 +596,7 @@ FindInFilesPanel::FindInFilesPanel() {
 
 		_cancel_button = memnew(Button);
 		_cancel_button->set_text(TTR("Cancel"));
-		_cancel_button->connect_compat("pressed", this, "_on_cancel_button_clicked");
+		_cancel_button->connect("pressed", Callable(this, "_on_cancel_button_clicked"));
 		_cancel_button->hide();
 		hbc->add_child(_cancel_button);
 
@@ -606,8 +606,8 @@ FindInFilesPanel::FindInFilesPanel() {
 	_results_display = memnew(Tree);
 	_results_display->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("source", "EditorFonts"));
 	_results_display->set_v_size_flags(SIZE_EXPAND_FILL);
-	_results_display->connect_compat("item_selected", this, "_on_result_selected");
-	_results_display->connect_compat("item_edited", this, "_on_item_edited");
+	_results_display->connect("item_selected", Callable(this, "_on_result_selected"));
+	_results_display->connect("item_edited", Callable(this, "_on_item_edited"));
 	_results_display->set_hide_root(true);
 	_results_display->set_select_mode(Tree::SELECT_ROW);
 	_results_display->set_allow_rmb_select(true);
@@ -625,12 +625,12 @@ FindInFilesPanel::FindInFilesPanel() {
 
 		_replace_line_edit = memnew(LineEdit);
 		_replace_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
-		_replace_line_edit->connect_compat("text_changed", this, "_on_replace_text_changed");
+		_replace_line_edit->connect("text_changed", Callable(this, "_on_replace_text_changed"));
 		_replace_container->add_child(_replace_line_edit);
 
 		_replace_all_button = memnew(Button);
 		_replace_all_button->set_text(TTR("Replace all (no undo)"));
-		_replace_all_button->connect_compat("pressed", this, "_on_replace_all_clicked");
+		_replace_all_button->connect("pressed", Callable(this, "_on_replace_all_clicked"));
 		_replace_container->add_child(_replace_all_button);
 
 		_replace_container->hide();

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -436,9 +436,9 @@ GroupDialog::GroupDialog() {
 	groups->set_allow_rmb_select(true);
 	groups->set_v_size_flags(SIZE_EXPAND_FILL);
 	groups->add_constant_override("draw_guides", 1);
-	groups->connect_compat("item_selected", this, "_group_selected");
-	groups->connect_compat("button_pressed", this, "_delete_group_pressed");
-	groups->connect_compat("item_edited", this, "_group_renamed");
+	groups->connect("item_selected", Callable(this, "_group_selected"));
+	groups->connect("button_pressed", Callable(this, "_delete_group_pressed"));
+	groups->connect("item_edited", Callable(this, "_group_renamed"));
 
 	HBoxContainer *chbc = memnew(HBoxContainer);
 	vbc_left->add_child(chbc);
@@ -447,12 +447,12 @@ GroupDialog::GroupDialog() {
 	add_group_text = memnew(LineEdit);
 	chbc->add_child(add_group_text);
 	add_group_text->set_h_size_flags(SIZE_EXPAND_FILL);
-	add_group_text->connect_compat("text_entered", this, "_add_group_pressed");
+	add_group_text->connect("text_entered", Callable(this, "_add_group_pressed"));
 
 	Button *add_group_button = memnew(Button);
 	add_group_button->set_text(TTR("Add"));
 	chbc->add_child(add_group_button);
-	add_group_button->connect_compat("pressed", this, "_add_group_pressed", varray(String()));
+	add_group_button->connect("pressed", Callable(this, "_add_group_pressed"), varray(String()));
 
 	VBoxContainer *vbc_add = memnew(VBoxContainer);
 	hbc->add_child(vbc_add);
@@ -478,7 +478,7 @@ GroupDialog::GroupDialog() {
 	add_filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	add_filter->set_placeholder(TTR("Filter nodes"));
 	add_filter_hbc->add_child(add_filter);
-	add_filter->connect_compat("text_changed", this, "_add_filter_changed");
+	add_filter->connect("text_changed", Callable(this, "_add_filter_changed"));
 
 	VBoxContainer *vbc_buttons = memnew(VBoxContainer);
 	hbc->add_child(vbc_buttons);
@@ -487,7 +487,7 @@ GroupDialog::GroupDialog() {
 
 	add_button = memnew(ToolButton);
 	add_button->set_text(TTR("Add"));
-	add_button->connect_compat("pressed", this, "_add_pressed");
+	add_button->connect("pressed", Callable(this, "_add_pressed"));
 
 	vbc_buttons->add_child(add_button);
 	vbc_buttons->add_spacer();
@@ -496,7 +496,7 @@ GroupDialog::GroupDialog() {
 
 	remove_button = memnew(ToolButton);
 	remove_button->set_text(TTR("Remove"));
-	remove_button->connect_compat("pressed", this, "_removed_pressed");
+	remove_button->connect("pressed", Callable(this, "_removed_pressed"));
 
 	vbc_buttons->add_child(remove_button);
 
@@ -524,7 +524,7 @@ GroupDialog::GroupDialog() {
 	remove_filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	remove_filter->set_placeholder(TTR("Filter nodes"));
 	remove_filter_hbc->add_child(remove_filter);
-	remove_filter->connect_compat("text_changed", this, "_remove_filter_changed");
+	remove_filter->connect("text_changed", Callable(this, "_remove_filter_changed"));
 
 	group_empty = memnew(Label());
 	group_empty->set_text(TTR("Empty groups will be automatically removed."));
@@ -685,12 +685,12 @@ GroupsEditor::GroupsEditor() {
 	group_dialog = memnew(GroupDialog);
 	group_dialog->set_as_toplevel(true);
 	add_child(group_dialog);
-	group_dialog->connect_compat("group_edited", this, "update_tree");
+	group_dialog->connect("group_edited", Callable(this, "update_tree"));
 
 	Button *group_dialog_button = memnew(Button);
 	group_dialog_button->set_text(TTR("Manage Groups"));
 	vbc->add_child(group_dialog_button);
-	group_dialog_button->connect_compat("pressed", this, "_show_group_dialog");
+	group_dialog_button->connect("pressed", Callable(this, "_show_group_dialog"));
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	vbc->add_child(hbc);
@@ -698,18 +698,18 @@ GroupsEditor::GroupsEditor() {
 	group_name = memnew(LineEdit);
 	group_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	hbc->add_child(group_name);
-	group_name->connect_compat("text_entered", this, "_add_group");
+	group_name->connect("text_entered", Callable(this, "_add_group"));
 
 	add = memnew(Button);
 	add->set_text(TTR("Add"));
 	hbc->add_child(add);
-	add->connect_compat("pressed", this, "_add_group", varray(String()));
+	add->connect("pressed", Callable(this, "_add_group"), varray(String()));
 
 	tree = memnew(Tree);
 	tree->set_hide_root(true);
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 	vbc->add_child(tree);
-	tree->connect_compat("button_pressed", this, "_remove_group");
+	tree->connect("button_pressed", Callable(this, "_remove_group"));
 	tree->add_constant_override("draw_guides", 1);
 	add_constant_override("separation", 3 * EDSCALE);
 }

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -537,26 +537,26 @@ ImportDock::ImportDock() {
 	add_margin_child(TTR("Import As:"), hb);
 	import_as = memnew(OptionButton);
 	import_as->set_disabled(true);
-	import_as->connect_compat("item_selected", this, "_importer_selected");
+	import_as->connect("item_selected", Callable(this, "_importer_selected"));
 	hb->add_child(import_as);
 	import_as->set_h_size_flags(SIZE_EXPAND_FILL);
 	preset = memnew(MenuButton);
 	preset->set_text(TTR("Preset"));
 	preset->set_disabled(true);
-	preset->get_popup()->connect_compat("index_pressed", this, "_preset_selected");
+	preset->get_popup()->connect("index_pressed", Callable(this, "_preset_selected"));
 	hb->add_child(preset);
 
 	import_opts = memnew(EditorInspector);
 	add_child(import_opts);
 	import_opts->set_v_size_flags(SIZE_EXPAND_FILL);
-	import_opts->connect_compat("property_toggled", this, "_property_toggled");
+	import_opts->connect("property_toggled", Callable(this, "_property_toggled"));
 
 	hb = memnew(HBoxContainer);
 	add_child(hb);
 	import = memnew(Button);
 	import->set_text(TTR("Reimport"));
 	import->set_disabled(true);
-	import->connect_compat("pressed", this, "_reimport_attempt");
+	import->connect("pressed", Callable(this, "_reimport_attempt"));
 	hb->add_spacer();
 	hb->add_child(import);
 	hb->add_spacer();
@@ -564,7 +564,7 @@ ImportDock::ImportDock() {
 	reimport_confirm = memnew(ConfirmationDialog);
 	reimport_confirm->get_ok()->set_text(TTR("Save scenes, re-import and restart"));
 	add_child(reimport_confirm);
-	reimport_confirm->connect_compat("confirmed", this, "_reimport_and_restart");
+	reimport_confirm->connect("confirmed", Callable(this, "_reimport_and_restart"));
 
 	VBoxContainer *vbc_confirm = memnew(VBoxContainer());
 	vbc_confirm->add_child(memnew(Label(TTR("Changing the type of an imported file requires editor restart."))));

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -517,7 +517,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	resource_load_button->set_tooltip(TTR("Load an existing resource from disk and edit it."));
 	resource_load_button->set_icon(get_icon("Load", "EditorIcons"));
 	general_options_hb->add_child(resource_load_button);
-	resource_load_button->connect_compat("pressed", this, "_open_resource_selector");
+	resource_load_button->connect("pressed", Callable(this, "_open_resource_selector"));
 	resource_load_button->set_focus_mode(Control::FOCUS_NONE);
 
 	resource_save_button = memnew(MenuButton);
@@ -526,7 +526,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	general_options_hb->add_child(resource_save_button);
 	resource_save_button->get_popup()->add_item(TTR("Save"), RESOURCE_SAVE);
 	resource_save_button->get_popup()->add_item(TTR("Save As..."), RESOURCE_SAVE_AS);
-	resource_save_button->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	resource_save_button->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 	resource_save_button->set_focus_mode(Control::FOCUS_NONE);
 	resource_save_button->set_disabled(true);
 
@@ -538,7 +538,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	backward_button->set_flat(true);
 	backward_button->set_tooltip(TTR("Go to the previous edited object in history."));
 	backward_button->set_disabled(true);
-	backward_button->connect_compat("pressed", this, "_edit_back");
+	backward_button->connect("pressed", Callable(this, "_edit_back"));
 
 	forward_button = memnew(ToolButton);
 	general_options_hb->add_child(forward_button);
@@ -546,14 +546,14 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	forward_button->set_flat(true);
 	forward_button->set_tooltip(TTR("Go to the next edited object in history."));
 	forward_button->set_disabled(true);
-	forward_button->connect_compat("pressed", this, "_edit_forward");
+	forward_button->connect("pressed", Callable(this, "_edit_forward"));
 
 	history_menu = memnew(MenuButton);
 	history_menu->set_tooltip(TTR("History of recently edited objects."));
 	history_menu->set_icon(get_icon("History", "EditorIcons"));
 	general_options_hb->add_child(history_menu);
-	history_menu->connect_compat("about_to_show", this, "_prepare_history");
-	history_menu->get_popup()->connect_compat("id_pressed", this, "_select_history");
+	history_menu->connect("about_to_show", Callable(this, "_prepare_history"));
+	history_menu->get_popup()->connect("id_pressed", Callable(this, "_select_history"));
 
 	HBoxContainer *node_info_hb = memnew(HBoxContainer);
 	add_child(node_info_hb);
@@ -566,12 +566,12 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	object_menu->set_icon(get_icon("Tools", "EditorIcons"));
 	node_info_hb->add_child(object_menu);
 	object_menu->set_tooltip(TTR("Object properties."));
-	object_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	object_menu->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	new_resource_dialog = memnew(CreateDialog);
 	editor->get_gui_base()->add_child(new_resource_dialog);
 	new_resource_dialog->set_base_type("Resource");
-	new_resource_dialog->connect_compat("create", this, "_resource_created");
+	new_resource_dialog->connect("create", Callable(this, "_resource_created"));
 
 	search = memnew(LineEdit);
 	search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -587,7 +587,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	warning->add_color_override("font_color", get_color("warning_color", "Editor"));
 	warning->set_clip_text(true);
 	warning->hide();
-	warning->connect_compat("pressed", this, "_warning_pressed");
+	warning->connect("pressed", Callable(this, "_warning_pressed"));
 
 	warning_dialog = memnew(AcceptDialog);
 	editor->get_gui_base()->add_child(warning_dialog);
@@ -595,7 +595,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	load_resource_dialog = memnew(EditorFileDialog);
 	add_child(load_resource_dialog);
 	load_resource_dialog->set_current_dir("res://");
-	load_resource_dialog->connect_compat("file_selected", this, "_resource_file_selected");
+	load_resource_dialog->connect("file_selected", Callable(this, "_resource_file_selected"));
 
 	inspector = memnew(EditorInspector);
 	add_child(inspector);
@@ -611,8 +611,8 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 
 	inspector->set_use_filter(true); // TODO: check me
 
-	inspector->connect_compat("resource_selected", this, "_resource_selected");
-	inspector->connect_compat("property_keyed", this, "_property_keyed");
+	inspector->connect("resource_selected", Callable(this, "_resource_selected"));
+	inspector->connect("property_keyed", Callable(this, "_property_keyed"));
 }
 
 InspectorDock::~InspectorDock() {

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -107,7 +107,7 @@ NodeDock::NodeDock() {
 	connections_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	connections_button->set_clip_text(true);
 	mode_hb->add_child(connections_button);
-	connections_button->connect_compat("pressed", this, "show_connections");
+	connections_button->connect("pressed", Callable(this, "show_connections"));
 
 	groups_button = memnew(ToolButton);
 	groups_button->set_text(TTR("Groups"));
@@ -116,7 +116,7 @@ NodeDock::NodeDock() {
 	groups_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	groups_button->set_clip_text(true);
 	mode_hb->add_child(groups_button);
-	groups_button->connect_compat("pressed", this, "show_groups");
+	groups_button->connect("pressed", Callable(this, "show_groups"));
 
 	connections = memnew(ConnectionsDock(EditorNode::get_singleton()));
 	connections->set_undoredo(EditorNode::get_undo_redo());

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -132,8 +132,8 @@ void PluginConfigDialog::_on_required_text_changed(const String &) {
 void PluginConfigDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			connect_compat("confirmed", this, "_on_confirmed");
-			get_cancel()->connect_compat("pressed", this, "_on_cancelled");
+			connect("confirmed", Callable(this, "_on_confirmed"));
+			get_cancel()->connect("pressed", Callable(this, "_on_cancelled"));
 		} break;
 
 		case NOTIFICATION_POST_POPUP: {
@@ -194,7 +194,7 @@ PluginConfigDialog::PluginConfigDialog() {
 	grid->add_child(name_lb);
 
 	name_edit = memnew(LineEdit);
-	name_edit->connect_compat("text_changed", this, "_on_required_text_changed");
+	name_edit->connect("text_changed", Callable(this, "_on_required_text_changed"));
 	name_edit->set_placeholder("MyPlugin");
 	grid->add_child(name_edit);
 
@@ -253,7 +253,7 @@ PluginConfigDialog::PluginConfigDialog() {
 	grid->add_child(script_lb);
 
 	script_edit = memnew(LineEdit);
-	script_edit->connect_compat("text_changed", this, "_on_required_text_changed");
+	script_edit->connect("text_changed", Callable(this, "_on_required_text_changed"));
 	script_edit->set_placeholder("\"plugin.gd\" -> res://addons/my_plugin/plugin.gd");
 	grid->add_child(script_edit);
 

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -209,8 +209,8 @@ void AbstractPolygon2DEditor::_notification(int p_what) {
 			button_delete->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("CurveDelete", "EditorIcons"));
 			button_edit->set_pressed(true);
 
-			get_tree()->connect_compat("node_removed", this, "_node_removed");
-			create_resource->connect_compat("confirmed", this, "_create_resource");
+			get_tree()->connect("node_removed", Callable(this, "_node_removed"));
+			create_resource->connect("confirmed", Callable(this, "_create_resource"));
 		} break;
 	}
 }
@@ -820,17 +820,17 @@ AbstractPolygon2DEditor::AbstractPolygon2DEditor(EditorNode *p_editor, bool p_wi
 	add_child(memnew(VSeparator));
 	button_create = memnew(ToolButton);
 	add_child(button_create);
-	button_create->connect_compat("pressed", this, "_menu_option", varray(MODE_CREATE));
+	button_create->connect("pressed", Callable(this, "_menu_option"), varray(MODE_CREATE));
 	button_create->set_toggle_mode(true);
 
 	button_edit = memnew(ToolButton);
 	add_child(button_edit);
-	button_edit->connect_compat("pressed", this, "_menu_option", varray(MODE_EDIT));
+	button_edit->connect("pressed", Callable(this, "_menu_option"), varray(MODE_EDIT));
 	button_edit->set_toggle_mode(true);
 
 	button_delete = memnew(ToolButton);
 	add_child(button_delete);
-	button_delete->connect_compat("pressed", this, "_menu_option", varray(MODE_DELETE));
+	button_delete->connect("pressed", Callable(this, "_menu_option"), varray(MODE_DELETE));
 	button_delete->set_toggle_mode(true);
 
 	create_resource = memnew(ConfirmationDialog);

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -622,28 +622,28 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	top_hb->add_child(tool_blend);
 	tool_blend->set_pressed(true);
 	tool_blend->set_tooltip(TTR("Set the blending position within the space"));
-	tool_blend->connect_compat("pressed", this, "_tool_switch", varray(3));
+	tool_blend->connect("pressed", Callable(this, "_tool_switch"), varray(3));
 
 	tool_select = memnew(ToolButton);
 	tool_select->set_toggle_mode(true);
 	tool_select->set_button_group(bg);
 	top_hb->add_child(tool_select);
 	tool_select->set_tooltip(TTR("Select and move points, create points with RMB."));
-	tool_select->connect_compat("pressed", this, "_tool_switch", varray(0));
+	tool_select->connect("pressed", Callable(this, "_tool_switch"), varray(0));
 
 	tool_create = memnew(ToolButton);
 	tool_create->set_toggle_mode(true);
 	tool_create->set_button_group(bg);
 	top_hb->add_child(tool_create);
 	tool_create->set_tooltip(TTR("Create points."));
-	tool_create->connect_compat("pressed", this, "_tool_switch", varray(1));
+	tool_create->connect("pressed", Callable(this, "_tool_switch"), varray(1));
 
 	tool_erase_sep = memnew(VSeparator);
 	top_hb->add_child(tool_erase_sep);
 	tool_erase = memnew(ToolButton);
 	top_hb->add_child(tool_erase);
 	tool_erase->set_tooltip(TTR("Erase points."));
-	tool_erase->connect_compat("pressed", this, "_erase_selected");
+	tool_erase->connect("pressed", Callable(this, "_erase_selected"));
 
 	top_hb->add_child(memnew(VSeparator));
 
@@ -652,7 +652,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	top_hb->add_child(snap);
 	snap->set_pressed(true);
 	snap->set_tooltip(TTR("Enable snap and show grid."));
-	snap->connect_compat("pressed", this, "_snap_toggled");
+	snap->connect("pressed", Callable(this, "_snap_toggled"));
 
 	snap_value = memnew(SpinBox);
 	top_hb->add_child(snap_value);
@@ -670,12 +670,12 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	edit_value->set_min(-1000);
 	edit_value->set_max(1000);
 	edit_value->set_step(0.01);
-	edit_value->connect_compat("value_changed", this, "_edit_point_pos");
+	edit_value->connect("value_changed", Callable(this, "_edit_point_pos"));
 
 	open_editor = memnew(Button);
 	edit_hb->add_child(open_editor);
 	open_editor->set_text(TTR("Open Editor"));
-	open_editor->connect_compat("pressed", this, "_open_editor", varray(), CONNECT_DEFERRED);
+	open_editor->connect("pressed", Callable(this, "_open_editor"), varray(), CONNECT_DEFERRED);
 
 	edit_hb->hide();
 	open_editor->hide();
@@ -691,8 +691,8 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	panel->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	blend_space_draw = memnew(Control);
-	blend_space_draw->connect_compat("gui_input", this, "_blend_space_gui_input");
-	blend_space_draw->connect_compat("draw", this, "_blend_space_draw");
+	blend_space_draw->connect("gui_input", Callable(this, "_blend_space_gui_input"));
+	blend_space_draw->connect("draw", Callable(this, "_blend_space_draw"));
 	blend_space_draw->set_focus_mode(FOCUS_ALL);
 
 	panel->add_child(blend_space_draw);
@@ -724,10 +724,10 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 		bottom_hb->add_child(max_value);
 	}
 
-	snap_value->connect_compat("value_changed", this, "_config_changed");
-	min_value->connect_compat("value_changed", this, "_config_changed");
-	max_value->connect_compat("value_changed", this, "_config_changed");
-	label_value->connect_compat("text_changed", this, "_labels_changed");
+	snap_value->connect("value_changed", Callable(this, "_config_changed"));
+	min_value->connect("value_changed", Callable(this, "_config_changed"));
+	max_value->connect("value_changed", Callable(this, "_config_changed"));
+	label_value->connect("text_changed", Callable(this, "_labels_changed"));
 
 	error_panel = memnew(PanelContainer);
 	add_child(error_panel);
@@ -740,18 +740,18 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
-	menu->connect_compat("id_pressed", this, "_add_menu_type");
+	menu->connect("id_pressed", Callable(this, "_add_menu_type"));
 
 	animations_menu = memnew(PopupMenu);
 	menu->add_child(animations_menu);
 	animations_menu->set_name("animations");
-	animations_menu->connect_compat("index_pressed", this, "_add_animation_type");
+	animations_menu->connect("index_pressed", Callable(this, "_add_animation_type"));
 
 	open_file = memnew(EditorFileDialog);
 	add_child(open_file);
 	open_file->set_title(TTR("Open Animation Node"));
 	open_file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-	open_file->connect_compat("file_selected", this, "_file_opened");
+	open_file->connect("file_selected", Callable(this, "_file_opened"));
 	undo_redo = EditorNode::get_undo_redo();
 
 	selected_point = -1;

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -55,12 +55,12 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_changed() {
 void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 
 	if (blend_space.is_valid()) {
-		blend_space->disconnect_compat("triangles_updated", this, "_blend_space_changed");
+		blend_space->disconnect("triangles_updated", Callable(this, "_blend_space_changed"));
 	}
 	blend_space = p_node;
 
 	if (!blend_space.is_null()) {
-		blend_space->connect_compat("triangles_updated", this, "_blend_space_changed");
+		blend_space->connect("triangles_updated", Callable(this, "_blend_space_changed"));
 		_update_space();
 	}
 }
@@ -870,42 +870,42 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	top_hb->add_child(tool_blend);
 	tool_blend->set_pressed(true);
 	tool_blend->set_tooltip(TTR("Set the blending position within the space"));
-	tool_blend->connect_compat("pressed", this, "_tool_switch", varray(3));
+	tool_blend->connect("pressed", Callable(this, "_tool_switch"), varray(3));
 
 	tool_select = memnew(ToolButton);
 	tool_select->set_toggle_mode(true);
 	tool_select->set_button_group(bg);
 	top_hb->add_child(tool_select);
 	tool_select->set_tooltip(TTR("Select and move points, create points with RMB."));
-	tool_select->connect_compat("pressed", this, "_tool_switch", varray(0));
+	tool_select->connect("pressed", Callable(this, "_tool_switch"), varray(0));
 
 	tool_create = memnew(ToolButton);
 	tool_create->set_toggle_mode(true);
 	tool_create->set_button_group(bg);
 	top_hb->add_child(tool_create);
 	tool_create->set_tooltip(TTR("Create points."));
-	tool_create->connect_compat("pressed", this, "_tool_switch", varray(1));
+	tool_create->connect("pressed", Callable(this, "_tool_switch"), varray(1));
 
 	tool_triangle = memnew(ToolButton);
 	tool_triangle->set_toggle_mode(true);
 	tool_triangle->set_button_group(bg);
 	top_hb->add_child(tool_triangle);
 	tool_triangle->set_tooltip(TTR("Create triangles by connecting points."));
-	tool_triangle->connect_compat("pressed", this, "_tool_switch", varray(2));
+	tool_triangle->connect("pressed", Callable(this, "_tool_switch"), varray(2));
 
 	tool_erase_sep = memnew(VSeparator);
 	top_hb->add_child(tool_erase_sep);
 	tool_erase = memnew(ToolButton);
 	top_hb->add_child(tool_erase);
 	tool_erase->set_tooltip(TTR("Erase points and triangles."));
-	tool_erase->connect_compat("pressed", this, "_erase_selected");
+	tool_erase->connect("pressed", Callable(this, "_erase_selected"));
 	tool_erase->set_disabled(true);
 
 	top_hb->add_child(memnew(VSeparator));
 
 	auto_triangles = memnew(ToolButton);
 	top_hb->add_child(auto_triangles);
-	auto_triangles->connect_compat("pressed", this, "_auto_triangles_toggled");
+	auto_triangles->connect("pressed", Callable(this, "_auto_triangles_toggled"));
 	auto_triangles->set_toggle_mode(true);
 	auto_triangles->set_tooltip(TTR("Generate blend triangles automatically (instead of manually)"));
 
@@ -916,7 +916,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	top_hb->add_child(snap);
 	snap->set_pressed(true);
 	snap->set_tooltip(TTR("Enable snap and show grid."));
-	snap->connect_compat("pressed", this, "_snap_toggled");
+	snap->connect("pressed", Callable(this, "_snap_toggled"));
 
 	snap_x = memnew(SpinBox);
 	top_hb->add_child(snap_x);
@@ -937,7 +937,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	top_hb->add_child(memnew(Label(TTR("Blend:"))));
 	interpolation = memnew(OptionButton);
 	top_hb->add_child(interpolation);
-	interpolation->connect_compat("item_selected", this, "_config_changed");
+	interpolation->connect("item_selected", Callable(this, "_config_changed"));
 
 	edit_hb = memnew(HBoxContainer);
 	top_hb->add_child(edit_hb);
@@ -948,17 +948,17 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	edit_x->set_min(-1000);
 	edit_x->set_step(0.01);
 	edit_x->set_max(1000);
-	edit_x->connect_compat("value_changed", this, "_edit_point_pos");
+	edit_x->connect("value_changed", Callable(this, "_edit_point_pos"));
 	edit_y = memnew(SpinBox);
 	edit_hb->add_child(edit_y);
 	edit_y->set_min(-1000);
 	edit_y->set_step(0.01);
 	edit_y->set_max(1000);
-	edit_y->connect_compat("value_changed", this, "_edit_point_pos");
+	edit_y->connect("value_changed", Callable(this, "_edit_point_pos"));
 	open_editor = memnew(Button);
 	edit_hb->add_child(open_editor);
 	open_editor->set_text(TTR("Open Editor"));
-	open_editor->connect_compat("pressed", this, "_open_editor", varray(), CONNECT_DEFERRED);
+	open_editor->connect("pressed", Callable(this, "_open_editor"), varray(), CONNECT_DEFERRED);
 	edit_hb->hide();
 	open_editor->hide();
 
@@ -999,8 +999,8 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	panel->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	blend_space_draw = memnew(Control);
-	blend_space_draw->connect_compat("gui_input", this, "_blend_space_gui_input");
-	blend_space_draw->connect_compat("draw", this, "_blend_space_draw");
+	blend_space_draw->connect("gui_input", Callable(this, "_blend_space_gui_input"));
+	blend_space_draw->connect("draw", Callable(this, "_blend_space_draw"));
 	blend_space_draw->set_focus_mode(FOCUS_ALL);
 
 	panel->add_child(blend_space_draw);
@@ -1029,14 +1029,14 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 		min_x_value->set_step(0.01);
 	}
 
-	snap_x->connect_compat("value_changed", this, "_config_changed");
-	snap_y->connect_compat("value_changed", this, "_config_changed");
-	max_x_value->connect_compat("value_changed", this, "_config_changed");
-	min_x_value->connect_compat("value_changed", this, "_config_changed");
-	max_y_value->connect_compat("value_changed", this, "_config_changed");
-	min_y_value->connect_compat("value_changed", this, "_config_changed");
-	label_x->connect_compat("text_changed", this, "_labels_changed");
-	label_y->connect_compat("text_changed", this, "_labels_changed");
+	snap_x->connect("value_changed", Callable(this, "_config_changed"));
+	snap_y->connect("value_changed", Callable(this, "_config_changed"));
+	max_x_value->connect("value_changed", Callable(this, "_config_changed"));
+	min_x_value->connect("value_changed", Callable(this, "_config_changed"));
+	max_y_value->connect("value_changed", Callable(this, "_config_changed"));
+	min_y_value->connect("value_changed", Callable(this, "_config_changed"));
+	label_x->connect("text_changed", Callable(this, "_labels_changed"));
+	label_y->connect("text_changed", Callable(this, "_labels_changed"));
 
 	error_panel = memnew(PanelContainer);
 	add_child(error_panel);
@@ -1050,18 +1050,18 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
-	menu->connect_compat("id_pressed", this, "_add_menu_type");
+	menu->connect("id_pressed", Callable(this, "_add_menu_type"));
 
 	animations_menu = memnew(PopupMenu);
 	menu->add_child(animations_menu);
 	animations_menu->set_name("animations");
-	animations_menu->connect_compat("index_pressed", this, "_add_animation_type");
+	animations_menu->connect("index_pressed", Callable(this, "_add_animation_type"));
 
 	open_file = memnew(EditorFileDialog);
 	add_child(open_file);
 	open_file->set_title(TTR("Open Animation Node"));
 	open_file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-	open_file->connect_compat("file_selected", this, "_file_opened");
+	open_file->connect("file_selected", Callable(this, "_file_opened"));
 	undo_redo = EditorNode::get_undo_redo();
 
 	selected_point = -1;

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -146,11 +146,11 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			name->set_expand_to_text_length(true);
 			node->add_child(name);
 			node->set_slot(0, false, 0, Color(), true, 0, get_color("font_color", "Label"));
-			name->connect_compat("text_entered", this, "_node_renamed", varray(agnode));
-			name->connect_compat("focus_exited", this, "_node_renamed_focus_out", varray(name, agnode), CONNECT_DEFERRED);
+			name->connect("text_entered", Callable(this, "_node_renamed"), varray(agnode));
+			name->connect("focus_exited", Callable(this, "_node_renamed_focus_out"), varray(name, agnode), CONNECT_DEFERRED);
 			base = 1;
 			node->set_show_close_button(true);
-			node->connect_compat("close_request", this, "_delete_request", varray(E->get()), CONNECT_DEFERRED);
+			node->connect("close_request", Callable(this, "_delete_request"), varray(E->get()), CONNECT_DEFERRED);
 		}
 
 		for (int i = 0; i < agnode->get_input_count(); i++) {
@@ -173,13 +173,13 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 				prop->set_object_and_property(AnimationTreeEditor::get_singleton()->get_tree(), base_path);
 				prop->update_property();
 				prop->set_name_split_ratio(0);
-				prop->connect_compat("property_changed", this, "_property_changed");
+				prop->connect("property_changed", Callable(this, "_property_changed"));
 				node->add_child(prop);
 				visible_properties.push_back(prop);
 			}
 		}
 
-		node->connect_compat("dragged", this, "_node_dragged", varray(E->get()));
+		node->connect("dragged", Callable(this, "_node_dragged"), varray(E->get()));
 
 		if (AnimationTreeEditor::get_singleton()->can_edit(agnode)) {
 			node->add_child(memnew(HSeparator));
@@ -187,7 +187,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			open_in_editor->set_text(TTR("Open Editor"));
 			open_in_editor->set_icon(get_icon("Edit", "EditorIcons"));
 			node->add_child(open_in_editor);
-			open_in_editor->connect_compat("pressed", this, "_open_in_editor", varray(E->get()), CONNECT_DEFERRED);
+			open_in_editor->connect("pressed", Callable(this, "_open_in_editor"), varray(E->get()), CONNECT_DEFERRED);
 			open_in_editor->set_h_size_flags(SIZE_SHRINK_CENTER);
 		}
 
@@ -198,7 +198,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			edit_filters->set_text(TTR("Edit Filters"));
 			edit_filters->set_icon(get_icon("AnimationFilter", "EditorIcons"));
 			node->add_child(edit_filters);
-			edit_filters->connect_compat("pressed", this, "_edit_filters", varray(E->get()), CONNECT_DEFERRED);
+			edit_filters->connect("pressed", Callable(this, "_edit_filters"), varray(E->get()), CONNECT_DEFERRED);
 			edit_filters->set_h_size_flags(SIZE_SHRINK_CENTER);
 		}
 
@@ -238,7 +238,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			animations[E->get()] = pb;
 			node->add_child(pb);
 
-			mb->get_popup()->connect_compat("index_pressed", this, "_anim_selected", varray(options, E->get()), CONNECT_DEFERRED);
+			mb->get_popup()->connect("index_pressed", Callable(this, "_anim_selected"), varray(options, E->get()), CONNECT_DEFERRED);
 		}
 
 		if (EditorSettings::get_singleton()->get("interface/theme/use_graph_node_headers")) {
@@ -911,7 +911,7 @@ bool AnimationNodeBlendTreeEditor::can_edit(const Ref<AnimationNode> &p_node) {
 void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 
 	if (blend_tree.is_valid()) {
-		blend_tree->disconnect_compat("removed_from_graph", this, "_removed_from_graph");
+		blend_tree->disconnect("removed_from_graph", Callable(this, "_removed_from_graph"));
 	}
 
 	blend_tree = p_node;
@@ -919,7 +919,7 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 	if (blend_tree.is_null()) {
 		hide();
 	} else {
-		blend_tree->connect_compat("removed_from_graph", this, "_removed_from_graph");
+		blend_tree->connect("removed_from_graph", Callable(this, "_removed_from_graph"));
 
 		_update_graph();
 	}
@@ -936,12 +936,12 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	graph->add_valid_right_disconnect_type(0);
 	graph->add_valid_left_disconnect_type(0);
 	graph->set_v_size_flags(SIZE_EXPAND_FILL);
-	graph->connect_compat("connection_request", this, "_connection_request", varray(), CONNECT_DEFERRED);
-	graph->connect_compat("disconnection_request", this, "_disconnection_request", varray(), CONNECT_DEFERRED);
-	graph->connect_compat("node_selected", this, "_node_selected");
-	graph->connect_compat("scroll_offset_changed", this, "_scroll_changed");
-	graph->connect_compat("delete_nodes_request", this, "_delete_nodes_request");
-	graph->connect_compat("popup_request", this, "_popup_request");
+	graph->connect("connection_request", Callable(this, "_connection_request"), varray(), CONNECT_DEFERRED);
+	graph->connect("disconnection_request", Callable(this, "_disconnection_request"), varray(), CONNECT_DEFERRED);
+	graph->connect("node_selected", Callable(this, "_node_selected"));
+	graph->connect("scroll_offset_changed", Callable(this, "_scroll_changed"));
+	graph->connect("delete_nodes_request", Callable(this, "_delete_nodes_request"));
+	graph->connect("popup_request", Callable(this, "_popup_request"));
 
 	VSeparator *vs = memnew(VSeparator);
 	graph->get_zoom_hbox()->add_child(vs);
@@ -951,8 +951,8 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	graph->get_zoom_hbox()->add_child(add_node);
 	add_node->set_text(TTR("Add Node..."));
 	graph->get_zoom_hbox()->move_child(add_node, 0);
-	add_node->get_popup()->connect_compat("id_pressed", this, "_add_node");
-	add_node->connect_compat("about_to_show", this, "_update_options_menu");
+	add_node->get_popup()->connect("id_pressed", Callable(this, "_add_node"));
+	add_node->connect("about_to_show", Callable(this, "_update_options_menu"));
 
 	add_options.push_back(AddOption("Animation", "AnimationNodeAnimation"));
 	add_options.push_back(AddOption("OneShot", "AnimationNodeOneShot"));
@@ -984,19 +984,19 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 
 	filter_enabled = memnew(CheckBox);
 	filter_enabled->set_text(TTR("Enable Filtering"));
-	filter_enabled->connect_compat("pressed", this, "_filter_toggled");
+	filter_enabled->connect("pressed", Callable(this, "_filter_toggled"));
 	filter_vbox->add_child(filter_enabled);
 
 	filters = memnew(Tree);
 	filter_vbox->add_child(filters);
 	filters->set_v_size_flags(SIZE_EXPAND_FILL);
 	filters->set_hide_root(true);
-	filters->connect_compat("item_edited", this, "_filter_edited");
+	filters->connect("item_edited", Callable(this, "_filter_edited"));
 
 	open_file = memnew(EditorFileDialog);
 	add_child(open_file);
 	open_file->set_title(TTR("Open Animation Node"));
 	open_file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-	open_file->connect_compat("file_selected", this, "_file_opened");
+	open_file->connect("file_selected", Callable(this, "_file_opened"));
 	undo_redo = EditorNode::get_undo_redo();
 }

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -97,13 +97,13 @@ void AnimationPlayerEditor::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
 
-			tool_anim->get_popup()->connect_compat("id_pressed", this, "_animation_tool_menu");
+			tool_anim->get_popup()->connect("id_pressed", Callable(this, "_animation_tool_menu"));
 
-			onion_skinning->get_popup()->connect_compat("id_pressed", this, "_onion_skinning_menu");
+			onion_skinning->get_popup()->connect("id_pressed", Callable(this, "_onion_skinning_menu"));
 
-			blend_editor.next->connect_compat("item_selected", this, "_blend_editor_next_changed");
+			blend_editor.next->connect("item_selected", Callable(this, "_blend_editor_next_changed"));
 
-			get_tree()->connect_compat("node_removed", this, "_node_removed");
+			get_tree()->connect("node_removed", Callable(this, "_node_removed"));
 
 			add_style_override("panel", editor->get_gui_base()->get_stylebox("panel", "Panel"));
 		} break;
@@ -1501,16 +1501,16 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 void AnimationPlayerEditor::_start_onion_skinning() {
 
 	// FIXME: Using "idle_frame" makes onion layers update one frame behind the current.
-	if (!get_tree()->is_connected_compat("idle_frame", this, "call_deferred")) {
-		get_tree()->connect_compat("idle_frame", this, "call_deferred", varray("_prepare_onion_layers_1"));
+	if (!get_tree()->is_connected("idle_frame", Callable(this, "call_deferred"))) {
+		get_tree()->connect("idle_frame", Callable(this, "call_deferred"), varray("_prepare_onion_layers_1"));
 	}
 }
 
 void AnimationPlayerEditor::_stop_onion_skinning() {
 
-	if (get_tree()->is_connected_compat("idle_frame", this, "call_deferred")) {
+	if (get_tree()->is_connected("idle_frame", Callable(this, "call_deferred"))) {
 
-		get_tree()->disconnect_compat("idle_frame", this, "call_deferred");
+		get_tree()->disconnect("idle_frame", Callable(this, "call_deferred"));
 
 		_free_onion_layers();
 
@@ -1627,7 +1627,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 
 	delete_dialog = memnew(ConfirmationDialog);
 	add_child(delete_dialog);
-	delete_dialog->connect_compat("confirmed", this, "_animation_remove_confirmed");
+	delete_dialog->connect("confirmed", Callable(this, "_animation_remove_confirmed"));
 
 	tool_anim = memnew(MenuButton);
 	tool_anim->set_flat(false);
@@ -1672,7 +1672,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	onion_toggle = memnew(ToolButton);
 	onion_toggle->set_toggle_mode(true);
 	onion_toggle->set_tooltip(TTR("Enable Onion Skinning"));
-	onion_toggle->connect_compat("pressed", this, "_onion_skinning_menu", varray(ONION_SKINNING_ENABLE));
+	onion_toggle->connect("pressed", Callable(this, "_onion_skinning_menu"), varray(ONION_SKINNING_ENABLE));
 	hb->add_child(onion_toggle);
 
 	onion_skinning = memnew(MenuButton);
@@ -1698,7 +1698,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	pin->set_toggle_mode(true);
 	pin->set_tooltip(TTR("Pin AnimationPlayer"));
 	hb->add_child(pin);
-	pin->connect_compat("pressed", this, "_pin_pressed");
+	pin->connect("pressed", Callable(this, "_pin_pressed"));
 
 	file = memnew(EditorFileDialog);
 	add_child(file);
@@ -1722,7 +1722,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	error_dialog->set_title(TTR("Error!"));
 	add_child(error_dialog);
 
-	name_dialog->connect_compat("confirmed", this, "_animation_name_edited");
+	name_dialog->connect("confirmed", Callable(this, "_animation_name_edited"));
 
 	blend_editor.dialog = memnew(AcceptDialog);
 	add_child(blend_editor.dialog);
@@ -1738,21 +1738,21 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	blend_editor.dialog->set_title(TTR("Cross-Animation Blend Times"));
 	updating_blends = false;
 
-	blend_editor.tree->connect_compat("item_edited", this, "_blend_edited");
+	blend_editor.tree->connect("item_edited", Callable(this, "_blend_edited"));
 
-	autoplay->connect_compat("pressed", this, "_autoplay_pressed");
+	autoplay->connect("pressed", Callable(this, "_autoplay_pressed"));
 	autoplay->set_toggle_mode(true);
-	play->connect_compat("pressed", this, "_play_pressed");
-	play_from->connect_compat("pressed", this, "_play_from_pressed");
-	play_bw->connect_compat("pressed", this, "_play_bw_pressed");
-	play_bw_from->connect_compat("pressed", this, "_play_bw_from_pressed");
-	stop->connect_compat("pressed", this, "_stop_pressed");
+	play->connect("pressed", Callable(this, "_play_pressed"));
+	play_from->connect("pressed", Callable(this, "_play_from_pressed"));
+	play_bw->connect("pressed", Callable(this, "_play_bw_pressed"));
+	play_bw_from->connect("pressed", Callable(this, "_play_bw_from_pressed"));
+	stop->connect("pressed", Callable(this, "_stop_pressed"));
 
-	animation->connect_compat("item_selected", this, "_animation_selected", Vector<Variant>(), true);
+	animation->connect("item_selected", Callable(this, "_animation_selected"), Vector<Variant>(), true);
 
-	file->connect_compat("file_selected", this, "_dialog_action");
-	frame->connect_compat("value_changed", this, "_seek_value_changed", Vector<Variant>(), true);
-	scale->connect_compat("text_entered", this, "_scale_changed", Vector<Variant>(), true);
+	file->connect("file_selected", Callable(this, "_dialog_action"));
+	frame->connect("value_changed", Callable(this, "_seek_value_changed"), Vector<Variant>(), true);
+	scale->connect("text_entered", Callable(this, "_scale_changed"), Vector<Variant>(), true);
 
 	renaming = false;
 	last_active = false;
@@ -1762,14 +1762,14 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 
 	add_child(track_editor);
 	track_editor->set_v_size_flags(SIZE_EXPAND_FILL);
-	track_editor->connect_compat("timeline_changed", this, "_animation_key_editor_seek");
-	track_editor->connect_compat("animation_len_changed", this, "_animation_key_editor_anim_len_changed");
+	track_editor->connect("timeline_changed", Callable(this, "_animation_key_editor_seek"));
+	track_editor->connect("animation_len_changed", Callable(this, "_animation_key_editor_anim_len_changed"));
 
 	_update_player();
 
 	// Onion skinning.
 
-	track_editor->connect_compat("visibility_changed", this, "_editor_visibility_changed");
+	track_editor->connect("visibility_changed", Callable(this, "_editor_visibility_changed"));
 
 	onion.enabled = false;
 	onion.past = true;

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1276,21 +1276,21 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_select->set_button_group(bg);
 	tool_select->set_pressed(true);
 	tool_select->set_tooltip(TTR("Select and move nodes.\nRMB to add new nodes.\nShift+LMB to create connections."));
-	tool_select->connect_compat("pressed", this, "_update_mode", varray(), CONNECT_DEFERRED);
+	tool_select->connect("pressed", Callable(this, "_update_mode"), varray(), CONNECT_DEFERRED);
 
 	tool_create = memnew(ToolButton);
 	top_hb->add_child(tool_create);
 	tool_create->set_toggle_mode(true);
 	tool_create->set_button_group(bg);
 	tool_create->set_tooltip(TTR("Create new nodes."));
-	tool_create->connect_compat("pressed", this, "_update_mode", varray(), CONNECT_DEFERRED);
+	tool_create->connect("pressed", Callable(this, "_update_mode"), varray(), CONNECT_DEFERRED);
 
 	tool_connect = memnew(ToolButton);
 	top_hb->add_child(tool_connect);
 	tool_connect->set_toggle_mode(true);
 	tool_connect->set_button_group(bg);
 	tool_connect->set_tooltip(TTR("Connect nodes."));
-	tool_connect->connect_compat("pressed", this, "_update_mode", varray(), CONNECT_DEFERRED);
+	tool_connect->connect("pressed", Callable(this, "_update_mode"), varray(), CONNECT_DEFERRED);
 
 	tool_erase_hb = memnew(HBoxContainer);
 	top_hb->add_child(tool_erase_hb);
@@ -1298,7 +1298,7 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_erase = memnew(ToolButton);
 	tool_erase->set_tooltip(TTR("Remove selected node or transition."));
 	tool_erase_hb->add_child(tool_erase);
-	tool_erase->connect_compat("pressed", this, "_erase_selected");
+	tool_erase->connect("pressed", Callable(this, "_erase_selected"));
 	tool_erase->set_disabled(true);
 
 	tool_erase_hb->add_child(memnew(VSeparator));
@@ -1306,13 +1306,13 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	tool_autoplay = memnew(ToolButton);
 	tool_autoplay->set_tooltip(TTR("Toggle autoplay this animation on start, restart or seek to zero."));
 	tool_erase_hb->add_child(tool_autoplay);
-	tool_autoplay->connect_compat("pressed", this, "_autoplay_selected");
+	tool_autoplay->connect("pressed", Callable(this, "_autoplay_selected"));
 	tool_autoplay->set_disabled(true);
 
 	tool_end = memnew(ToolButton);
 	tool_end->set_tooltip(TTR("Set the end animation. This is useful for sub-transitions."));
 	tool_erase_hb->add_child(tool_end);
-	tool_end->connect_compat("pressed", this, "_end_selected");
+	tool_end->connect("pressed", Callable(this, "_end_selected"));
 	tool_end->set_disabled(true);
 
 	top_hb->add_child(memnew(VSeparator));
@@ -1333,26 +1333,26 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 
 	state_machine_draw = memnew(Control);
 	panel->add_child(state_machine_draw);
-	state_machine_draw->connect_compat("gui_input", this, "_state_machine_gui_input");
-	state_machine_draw->connect_compat("draw", this, "_state_machine_draw");
+	state_machine_draw->connect("gui_input", Callable(this, "_state_machine_gui_input"));
+	state_machine_draw->connect("draw", Callable(this, "_state_machine_draw"));
 	state_machine_draw->set_focus_mode(FOCUS_ALL);
 
 	state_machine_play_pos = memnew(Control);
 	state_machine_draw->add_child(state_machine_play_pos);
 	state_machine_play_pos->set_mouse_filter(MOUSE_FILTER_PASS); //pass all to parent
 	state_machine_play_pos->set_anchors_and_margins_preset(PRESET_WIDE);
-	state_machine_play_pos->connect_compat("draw", this, "_state_machine_pos_draw");
+	state_machine_play_pos->connect("draw", Callable(this, "_state_machine_pos_draw"));
 
 	v_scroll = memnew(VScrollBar);
 	state_machine_draw->add_child(v_scroll);
 	v_scroll->set_anchors_and_margins_preset(PRESET_RIGHT_WIDE);
-	v_scroll->connect_compat("value_changed", this, "_scroll_changed");
+	v_scroll->connect("value_changed", Callable(this, "_scroll_changed"));
 
 	h_scroll = memnew(HScrollBar);
 	state_machine_draw->add_child(h_scroll);
 	h_scroll->set_anchors_and_margins_preset(PRESET_BOTTOM_WIDE);
 	h_scroll->set_margin(MARGIN_RIGHT, -v_scroll->get_size().x * EDSCALE);
-	h_scroll->connect_compat("value_changed", this, "_scroll_changed");
+	h_scroll->connect("value_changed", Callable(this, "_scroll_changed"));
 
 	error_panel = memnew(PanelContainer);
 	add_child(error_panel);
@@ -1366,25 +1366,25 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
-	menu->connect_compat("id_pressed", this, "_add_menu_type");
+	menu->connect("id_pressed", Callable(this, "_add_menu_type"));
 
 	animations_menu = memnew(PopupMenu);
 	menu->add_child(animations_menu);
 	animations_menu->set_name("animations");
-	animations_menu->connect_compat("index_pressed", this, "_add_animation_type");
+	animations_menu->connect("index_pressed", Callable(this, "_add_animation_type"));
 
 	name_edit = memnew(LineEdit);
 	state_machine_draw->add_child(name_edit);
 	name_edit->hide();
-	name_edit->connect_compat("text_entered", this, "_name_edited");
-	name_edit->connect_compat("focus_exited", this, "_name_edited_focus_out");
+	name_edit->connect("text_entered", Callable(this, "_name_edited"));
+	name_edit->connect("focus_exited", Callable(this, "_name_edited_focus_out"));
 	name_edit->set_as_toplevel(true);
 
 	open_file = memnew(EditorFileDialog);
 	add_child(open_file);
 	open_file->set_title(TTR("Open Animation Node"));
 	open_file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-	open_file->connect_compat("file_selected", this, "_file_opened");
+	open_file->connect("file_selected", Callable(this, "_file_opened"));
 	undo_redo = EditorNode::get_undo_redo();
 
 	over_text = false;

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -85,7 +85,7 @@ void AnimationTreeEditor::_update_path() {
 	b->set_button_group(group);
 	b->set_pressed(true);
 	b->set_focus_mode(FOCUS_NONE);
-	b->connect_compat("pressed", this, "_path_button_pressed", varray(-1));
+	b->connect("pressed", Callable(this, "_path_button_pressed"), varray(-1));
 	path_hb->add_child(b);
 	for (int i = 0; i < button_path.size(); i++) {
 		b = memnew(Button);
@@ -95,7 +95,7 @@ void AnimationTreeEditor::_update_path() {
 		path_hb->add_child(b);
 		b->set_pressed(true);
 		b->set_focus_mode(FOCUS_NONE);
-		b->connect_compat("pressed", this, "_path_button_pressed", varray(i));
+		b->connect("pressed", Callable(this, "_path_button_pressed"), varray(i));
 	}
 }
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -112,7 +112,7 @@ EditorAssetLibraryItem::EditorAssetLibraryItem() {
 	icon = memnew(TextureButton);
 	icon->set_custom_minimum_size(Size2(64, 64) * EDSCALE);
 	icon->set_default_cursor_shape(CURSOR_POINTING_HAND);
-	icon->connect_compat("pressed", this, "_asset_clicked");
+	icon->connect("pressed", Callable(this, "_asset_clicked"));
 
 	hb->add_child(icon);
 
@@ -123,17 +123,17 @@ EditorAssetLibraryItem::EditorAssetLibraryItem() {
 
 	title = memnew(LinkButton);
 	title->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-	title->connect_compat("pressed", this, "_asset_clicked");
+	title->connect("pressed", Callable(this, "_asset_clicked"));
 	vb->add_child(title);
 
 	category = memnew(LinkButton);
 	category->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-	category->connect_compat("pressed", this, "_category_clicked");
+	category->connect("pressed", Callable(this, "_category_clicked"));
 	vb->add_child(category);
 
 	author = memnew(LinkButton);
 	author->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-	author->connect_compat("pressed", this, "_author_clicked");
+	author->connect("pressed", Callable(this, "_author_clicked"));
 	vb->add_child(author);
 
 	price = memnew(Label);
@@ -263,7 +263,7 @@ void EditorAssetLibraryItemDescription::add_preview(int p_id, bool p_video, cons
 	preview.button->set_flat(true);
 	preview.button->set_icon(get_icon("ThumbnailWait", "EditorIcons"));
 	preview.button->set_toggle_mode(true);
-	preview.button->connect_compat("pressed", this, "_preview_click", varray(p_id));
+	preview.button->connect("pressed", Callable(this, "_preview_click"), varray(p_id));
 	preview_hb->add_child(preview.button);
 	if (!p_video) {
 		preview.image = get_icon("ThumbnailWait", "EditorIcons");
@@ -290,7 +290,7 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 	description = memnew(RichTextLabel);
 	desc_vbox->add_child(description);
 	description->set_v_size_flags(SIZE_EXPAND_FILL);
-	description->connect_compat("meta_clicked", this, "_link_click");
+	description->connect("meta_clicked", Callable(this, "_link_click"));
 	description->add_constant_override("line_separation", Math::round(5 * EDSCALE));
 
 	VBoxContainer *previews_vbox = memnew(VBoxContainer);
@@ -526,7 +526,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 	title->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	dismiss = memnew(TextureButton);
-	dismiss->connect_compat("pressed", this, "_close");
+	dismiss->connect("pressed", Callable(this, "_close"));
 	title_hb->add_child(dismiss);
 
 	title->set_clip_text(true);
@@ -546,11 +546,11 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 	install = memnew(Button);
 	install->set_text(TTR("Install..."));
 	install->set_disabled(true);
-	install->connect_compat("pressed", this, "_install");
+	install->connect("pressed", Callable(this, "_install"));
 
 	retry = memnew(Button);
 	retry->set_text(TTR("Retry"));
-	retry->connect_compat("pressed", this, "_make_request");
+	retry->connect("pressed", Callable(this, "_make_request"));
 
 	hb2->add_child(retry);
 	hb2->add_child(install);
@@ -558,7 +558,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 
 	download = memnew(HTTPRequest);
 	add_child(download);
-	download->connect_compat("request_completed", this, "_http_download_completed");
+	download->connect("request_completed", Callable(this, "_http_download_completed"));
 	download->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
 
 	download_error = memnew(AcceptDialog);
@@ -567,7 +567,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 
 	asset_installer = memnew(EditorAssetInstaller);
 	add_child(asset_installer);
-	asset_installer->connect_compat("confirmed", this, "_close");
+	asset_installer->connect("confirmed", Callable(this, "_close"));
 
 	prev_status = -1;
 
@@ -657,7 +657,7 @@ void EditorAssetLibrary::_install_asset() {
 
 	if (templates_only) {
 		download->set_external_install(true);
-		download->connect_compat("install_asset", this, "_install_external_asset");
+		download->connect("install_asset", Callable(this, "_install_external_asset"));
 	}
 }
 
@@ -892,7 +892,7 @@ void EditorAssetLibrary::_request_image(ObjectID p_for, String p_image_url, Imag
 	iq.queue_id = ++last_queue_id;
 	iq.active = false;
 
-	iq.request->connect_compat("request_completed", this, "_image_request_completed", varray(iq.queue_id));
+	iq.request->connect("request_completed", Callable(this, "_image_request_completed"), varray(iq.queue_id));
 
 	image_queue[iq.queue_id] = iq;
 
@@ -991,7 +991,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	Button *first = memnew(Button);
 	first->set_text(TTR("First"));
 	if (p_page != 0) {
-		first->connect_compat("pressed", this, "_search", varray(0));
+		first->connect("pressed", Callable(this, "_search"), varray(0));
 	} else {
 		first->set_disabled(true);
 		first->set_focus_mode(Control::FOCUS_NONE);
@@ -1001,7 +1001,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	Button *prev = memnew(Button);
 	prev->set_text(TTR("Previous"));
 	if (p_page > 0) {
-		prev->connect_compat("pressed", this, "_search", varray(p_page - 1));
+		prev->connect("pressed", Callable(this, "_search"), varray(p_page - 1));
 	} else {
 		prev->set_disabled(true);
 		prev->set_focus_mode(Control::FOCUS_NONE);
@@ -1023,7 +1023,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 
 			Button *current = memnew(Button);
 			current->set_text(itos(i + 1));
-			current->connect_compat("pressed", this, "_search", varray(i));
+			current->connect("pressed", Callable(this, "_search"), varray(i));
 
 			hbc->add_child(current);
 		}
@@ -1032,7 +1032,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	Button *next = memnew(Button);
 	next->set_text(TTR("Next"));
 	if (p_page < p_page_count - 1) {
-		next->connect_compat("pressed", this, "_search", varray(p_page + 1));
+		next->connect("pressed", Callable(this, "_search"), varray(p_page + 1));
 	} else {
 		next->set_disabled(true);
 		next->set_focus_mode(Control::FOCUS_NONE);
@@ -1043,7 +1043,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	Button *last = memnew(Button);
 	last->set_text(TTR("Last"));
 	if (p_page != p_page_count - 1) {
-		last->connect_compat("pressed", this, "_search", varray(p_page_count - 1));
+		last->connect("pressed", Callable(this, "_search"), varray(p_page_count - 1));
 	} else {
 		last->set_disabled(true);
 		last->set_focus_mode(Control::FOCUS_NONE);
@@ -1229,9 +1229,9 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 				EditorAssetLibraryItem *item = memnew(EditorAssetLibraryItem);
 				asset_items->add_child(item);
 				item->configure(r["title"], r["asset_id"], category_map[r["category_id"]], r["category_id"], r["author"], r["author_id"], r["cost"]);
-				item->connect_compat("asset_selected", this, "_select_asset");
-				item->connect_compat("author_selected", this, "_select_author");
-				item->connect_compat("category_selected", this, "_select_category");
+				item->connect("asset_selected", Callable(this, "_select_asset"));
+				item->connect("author_selected", Callable(this, "_select_author"));
+				item->connect("category_selected", Callable(this, "_select_category"));
 
 				if (r.has("icon_url") && r["icon_url"] != "") {
 					_request_image(item->get_instance_id(), r["icon_url"], IMAGE_QUEUE_ICON, 0);
@@ -1262,7 +1262,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 			description = memnew(EditorAssetLibraryItemDescription);
 			add_child(description);
 			description->popup_centered_minsize();
-			description->connect_compat("confirmed", this, "_install_asset");
+			description->connect("confirmed", Callable(this, "_install_asset"));
 
 			description->configure(r["title"], r["asset_id"], category_map[r["category_id"]], r["category_id"], r["author"], r["author_id"], r["cost"], r["version"], r["version_string"], r["description"], r["download_url"], r["browse_url"], r["download_hash"]);
 
@@ -1374,9 +1374,9 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	filter = memnew(LineEdit);
 	search_hb->add_child(filter);
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
-	filter->connect_compat("text_entered", this, "_search_text_entered");
+	filter->connect("text_entered", Callable(this, "_search_text_entered"));
 	search = memnew(Button(TTR("Search")));
-	search->connect_compat("pressed", this, "_search");
+	search->connect("pressed", Callable(this, "_search"));
 	search_hb->add_child(search);
 
 	if (!p_templates_only)
@@ -1385,12 +1385,12 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	Button *open_asset = memnew(Button);
 	open_asset->set_text(TTR("Import..."));
 	search_hb->add_child(open_asset);
-	open_asset->connect_compat("pressed", this, "_asset_open");
+	open_asset->connect("pressed", Callable(this, "_asset_open"));
 
 	Button *plugins = memnew(Button);
 	plugins->set_text(TTR("Plugins..."));
 	search_hb->add_child(plugins);
-	plugins->connect_compat("pressed", this, "_manage_plugins");
+	plugins->connect("pressed", Callable(this, "_manage_plugins"));
 
 	if (p_templates_only) {
 		open_asset->hide();
@@ -1409,7 +1409,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	search_hb2->add_child(sort);
 
 	sort->set_h_size_flags(SIZE_EXPAND_FILL);
-	sort->connect_compat("item_selected", this, "_rerun_search");
+	sort->connect("item_selected", Callable(this, "_rerun_search"));
 
 	search_hb2->add_child(memnew(VSeparator));
 
@@ -1418,7 +1418,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	categories->add_item(TTR("All"));
 	search_hb2->add_child(categories);
 	categories->set_h_size_flags(SIZE_EXPAND_FILL);
-	categories->connect_compat("item_selected", this, "_rerun_search");
+	categories->connect("item_selected", Callable(this, "_rerun_search"));
 
 	search_hb2->add_child(memnew(VSeparator));
 
@@ -1430,7 +1430,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	repository->add_item("localhost");
 	repository->set_item_metadata(1, "http://127.0.0.1/asset-library/api");
 
-	repository->connect_compat("item_selected", this, "_repository_changed");
+	repository->connect("item_selected", Callable(this, "_repository_changed"));
 
 	search_hb2->add_child(repository);
 	repository->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1445,7 +1445,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	support->get_popup()->add_check_item(TTR("Testing"), SUPPORT_TESTING);
 	support->get_popup()->set_item_checked(SUPPORT_OFFICIAL, true);
 	support->get_popup()->set_item_checked(SUPPORT_COMMUNITY, true);
-	support->get_popup()->connect_compat("id_pressed", this, "_support_toggled");
+	support->get_popup()->connect("id_pressed", Callable(this, "_support_toggled"));
 
 	/////////
 
@@ -1501,7 +1501,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	request = memnew(HTTPRequest);
 	add_child(request);
 	request->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
-	request->connect_compat("request_completed", this, "_http_request_completed");
+	request->connect("request_completed", Callable(this, "_http_request_completed"));
 
 	last_queue_id = 0;
 
@@ -1534,7 +1534,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	asset_open->add_filter("*.zip ; " + TTR("Assets ZIP File"));
 	asset_open->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 	add_child(asset_open);
-	asset_open->connect_compat("file_selected", this, "_asset_file_selected");
+	asset_open->connect("file_selected", Callable(this, "_asset_file_selected"));
 
 	asset_installer = NULL;
 }

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -39,7 +39,7 @@
 void AudioStreamEditor::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_READY) {
-		AudioStreamPreviewGenerator::get_singleton()->connect_compat("preview_updated", this, "_preview_changed");
+		AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", Callable(this, "_preview_changed"));
 	}
 
 	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
@@ -214,7 +214,7 @@ AudioStreamEditor::AudioStreamEditor() {
 	_dragging = false;
 
 	_player = memnew(AudioStreamPlayer);
-	_player->connect_compat("finished", this, "_on_finished");
+	_player->connect("finished", Callable(this, "_on_finished"));
 	add_child(_player);
 
 	VBoxContainer *vbox = memnew(VBoxContainer);
@@ -223,13 +223,13 @@ AudioStreamEditor::AudioStreamEditor() {
 
 	_preview = memnew(ColorRect);
 	_preview->set_v_size_flags(SIZE_EXPAND_FILL);
-	_preview->connect_compat("draw", this, "_draw_preview");
+	_preview->connect("draw", Callable(this, "_draw_preview"));
 	vbox->add_child(_preview);
 
 	_indicator = memnew(Control);
 	_indicator->set_anchors_and_margins_preset(PRESET_WIDE);
-	_indicator->connect_compat("draw", this, "_draw_indicator");
-	_indicator->connect_compat("gui_input", this, "_on_input_indicator");
+	_indicator->connect("draw", Callable(this, "_draw_indicator"));
+	_indicator->connect("gui_input", Callable(this, "_on_input_indicator"));
 	_preview->add_child(_indicator);
 
 	HBoxContainer *hbox = memnew(HBoxContainer);
@@ -239,12 +239,12 @@ AudioStreamEditor::AudioStreamEditor() {
 	_play_button = memnew(ToolButton);
 	hbox->add_child(_play_button);
 	_play_button->set_focus_mode(Control::FOCUS_NONE);
-	_play_button->connect_compat("pressed", this, "_play");
+	_play_button->connect("pressed", Callable(this, "_play"));
 
 	_stop_button = memnew(ToolButton);
 	hbox->add_child(_stop_button);
 	_stop_button->set_focus_mode(Control::FOCUS_NONE);
-	_stop_button->connect_compat("pressed", this, "_stop");
+	_stop_button->connect("pressed", Callable(this, "_stop"));
 
 	_current_label = memnew(Label);
 	_current_label->set_align(Label::ALIGN_RIGHT);

--- a/editor/plugins/camera_editor_plugin.cpp
+++ b/editor/plugins/camera_editor_plugin.cpp
@@ -81,7 +81,7 @@ CameraEditor::CameraEditor() {
 	preview->set_margin(MARGIN_RIGHT, 0);
 	preview->set_margin(MARGIN_TOP, 0);
 	preview->set_margin(MARGIN_BOTTOM, 10);
-	preview->connect_compat("pressed", this, "_pressed");
+	preview->connect("pressed", Callable(this, "_pressed"));
 }
 
 void CameraEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3891,10 +3891,10 @@ void CanvasItemEditor::_notification(int p_what) {
 			select_sb->set_default_margin(Margin(i), 4);
 		}
 
-		AnimationPlayerEditor::singleton->get_track_editor()->connect_compat("visibility_changed", this, "_keying_changed");
+		AnimationPlayerEditor::singleton->get_track_editor()->connect("visibility_changed", Callable(this, "_keying_changed"));
 		_keying_changed();
-		get_tree()->connect_compat("node_added", this, "_tree_changed", varray());
-		get_tree()->connect_compat("node_removed", this, "_tree_changed", varray());
+		get_tree()->connect("node_added", Callable(this, "_tree_changed"), varray());
+		get_tree()->connect("node_removed", Callable(this, "_tree_changed"), varray());
 
 	} else if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
 
@@ -3902,8 +3902,8 @@ void CanvasItemEditor::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {
-		get_tree()->disconnect_compat("node_added", this, "_tree_changed");
-		get_tree()->disconnect_compat("node_removed", this, "_tree_changed");
+		get_tree()->disconnect("node_added", Callable(this, "_tree_changed"));
+		get_tree()->disconnect("node_removed", Callable(this, "_tree_changed"));
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
@@ -4181,7 +4181,7 @@ void CanvasItemEditor::_popup_warning_temporarily(Control *p_control, const floa
 	Timer *timer;
 	if (!popup_temporarily_timers.has(p_control)) {
 		timer = memnew(Timer);
-		timer->connect_compat("timeout", this, "_popup_warning_depop", varray(p_control));
+		timer->connect("timeout", Callable(this, "_popup_warning_depop"), varray(p_control));
 		timer->set_one_shot(true);
 		add_child(timer);
 
@@ -5410,8 +5410,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	editor = p_editor;
 	editor_selection = p_editor->get_editor_selection();
 	editor_selection->add_editor_plugin(this);
-	editor_selection->connect_compat("selection_changed", this, "update");
-	editor_selection->connect_compat("selection_changed", this, "_selection_changed");
+	editor_selection->connect("selection_changed", Callable(this, "update"));
+	editor_selection->connect("selection_changed", Callable(this, "_selection_changed"));
 
 	editor->call_deferred("connect", make_binds("play_pressed", Callable(this, "_update_override_camera_button"), true));
 	editor->call_deferred("connect", make_binds("stop_pressed", Callable(this, "_update_override_camera_button"), false));
@@ -5434,7 +5434,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	viewport_scrollable->set_clip_contents(true);
 	viewport_scrollable->set_v_size_flags(SIZE_EXPAND_FILL);
 	viewport_scrollable->set_h_size_flags(SIZE_EXPAND_FILL);
-	viewport_scrollable->connect_compat("draw", this, "_update_scrollbars");
+	viewport_scrollable->connect("draw", Callable(this, "_update_scrollbars"));
 
 	ViewportContainer *scene_tree = memnew(ViewportContainer);
 	viewport_scrollable->add_child(scene_tree);
@@ -5456,8 +5456,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	viewport->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	viewport->set_clip_contents(true);
 	viewport->set_focus_mode(FOCUS_ALL);
-	viewport->connect_compat("draw", this, "_draw_viewport");
-	viewport->connect_compat("gui_input", this, "_gui_input_viewport");
+	viewport->connect("draw", Callable(this, "_draw_viewport"));
+	viewport->connect("gui_input", Callable(this, "_gui_input_viewport"));
 
 	info_overlay = memnew(VBoxContainer);
 	info_overlay->set_anchors_and_margins_preset(Control::PRESET_BOTTOM_LEFT);
@@ -5485,25 +5485,25 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 
 	h_scroll = memnew(HScrollBar);
 	viewport->add_child(h_scroll);
-	h_scroll->connect_compat("value_changed", this, "_update_scroll");
+	h_scroll->connect("value_changed", Callable(this, "_update_scroll"));
 	h_scroll->hide();
 
 	v_scroll = memnew(VScrollBar);
 	viewport->add_child(v_scroll);
-	v_scroll->connect_compat("value_changed", this, "_update_scroll");
+	v_scroll->connect("value_changed", Callable(this, "_update_scroll"));
 	v_scroll->hide();
 
 	viewport->add_child(controls_vb);
 
 	zoom_minus = memnew(ToolButton);
 	zoom_hb->add_child(zoom_minus);
-	zoom_minus->connect_compat("pressed", this, "_button_zoom_minus");
+	zoom_minus->connect("pressed", Callable(this, "_button_zoom_minus"));
 	zoom_minus->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_minus", TTR("Zoom Out"), KEY_MASK_CMD | KEY_MINUS));
 	zoom_minus->set_focus_mode(FOCUS_NONE);
 
 	zoom_reset = memnew(ToolButton);
 	zoom_hb->add_child(zoom_reset);
-	zoom_reset->connect_compat("pressed", this, "_button_zoom_reset");
+	zoom_reset->connect("pressed", Callable(this, "_button_zoom_reset"));
 	zoom_reset->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_reset", TTR("Zoom Reset"), KEY_MASK_CMD | KEY_0));
 	zoom_reset->set_focus_mode(FOCUS_NONE);
 	zoom_reset->set_text_align(Button::TextAlign::ALIGN_CENTER);
@@ -5512,7 +5512,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 
 	zoom_plus = memnew(ToolButton);
 	zoom_hb->add_child(zoom_plus);
-	zoom_plus->connect_compat("pressed", this, "_button_zoom_plus");
+	zoom_plus->connect("pressed", Callable(this, "_button_zoom_plus"));
 	zoom_plus->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_plus", TTR("Zoom In"), KEY_MASK_CMD | KEY_EQUAL)); // Usually direct access key for PLUS
 	zoom_plus->set_focus_mode(FOCUS_NONE);
 
@@ -5521,7 +5521,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	select_button = memnew(ToolButton);
 	hb->add_child(select_button);
 	select_button->set_toggle_mode(true);
-	select_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_SELECT));
+	select_button->connect("pressed", Callable(this, "_button_tool_select"), make_binds(TOOL_SELECT));
 	select_button->set_pressed(true);
 	select_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/select_mode", TTR("Select Mode"), KEY_Q));
 	select_button->set_tooltip(keycode_get_string(KEY_MASK_CMD) + TTR("Drag: Rotate") + "\n" + TTR("Alt+Drag: Move") + "\n" + TTR("Press 'v' to Change Pivot, 'Shift+v' to Drag Pivot (while moving).") + "\n" + TTR("Alt+RMB: Depth list selection"));
@@ -5531,21 +5531,21 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	move_button = memnew(ToolButton);
 	hb->add_child(move_button);
 	move_button->set_toggle_mode(true);
-	move_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_MOVE));
+	move_button->connect("pressed", Callable(this, "_button_tool_select"), make_binds(TOOL_MOVE));
 	move_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/move_mode", TTR("Move Mode"), KEY_W));
 	move_button->set_tooltip(TTR("Move Mode"));
 
 	rotate_button = memnew(ToolButton);
 	hb->add_child(rotate_button);
 	rotate_button->set_toggle_mode(true);
-	rotate_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_ROTATE));
+	rotate_button->connect("pressed", Callable(this, "_button_tool_select"), make_binds(TOOL_ROTATE));
 	rotate_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/rotate_mode", TTR("Rotate Mode"), KEY_E));
 	rotate_button->set_tooltip(TTR("Rotate Mode"));
 
 	scale_button = memnew(ToolButton);
 	hb->add_child(scale_button);
 	scale_button->set_toggle_mode(true);
-	scale_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_SCALE));
+	scale_button->connect("pressed", Callable(this, "_button_tool_select"), make_binds(TOOL_SCALE));
 	scale_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/scale_mode", TTR("Scale Mode"), KEY_S));
 	scale_button->set_tooltip(TTR("Scale Mode"));
 
@@ -5554,25 +5554,25 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	list_select_button = memnew(ToolButton);
 	hb->add_child(list_select_button);
 	list_select_button->set_toggle_mode(true);
-	list_select_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_LIST_SELECT));
+	list_select_button->connect("pressed", Callable(this, "_button_tool_select"), make_binds(TOOL_LIST_SELECT));
 	list_select_button->set_tooltip(TTR("Show a list of all objects at the position clicked\n(same as Alt+RMB in select mode)."));
 
 	pivot_button = memnew(ToolButton);
 	hb->add_child(pivot_button);
 	pivot_button->set_toggle_mode(true);
-	pivot_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_EDIT_PIVOT));
+	pivot_button->connect("pressed", Callable(this, "_button_tool_select"), make_binds(TOOL_EDIT_PIVOT));
 	pivot_button->set_tooltip(TTR("Click to change object's rotation pivot."));
 
 	pan_button = memnew(ToolButton);
 	hb->add_child(pan_button);
 	pan_button->set_toggle_mode(true);
-	pan_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_PAN));
+	pan_button->connect("pressed", Callable(this, "_button_tool_select"), make_binds(TOOL_PAN));
 	pan_button->set_tooltip(TTR("Pan Mode"));
 
 	ruler_button = memnew(ToolButton);
 	hb->add_child(ruler_button);
 	ruler_button->set_toggle_mode(true);
-	ruler_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_RULER));
+	ruler_button->connect("pressed", Callable(this, "_button_tool_select"), make_binds(TOOL_RULER));
 	ruler_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/ruler_mode", TTR("Ruler Mode"), KEY_R));
 	ruler_button->set_tooltip(TTR("Ruler Mode"));
 
@@ -5581,14 +5581,14 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	smart_snap_button = memnew(ToolButton);
 	hb->add_child(smart_snap_button);
 	smart_snap_button->set_toggle_mode(true);
-	smart_snap_button->connect_compat("toggled", this, "_button_toggle_smart_snap");
+	smart_snap_button->connect("toggled", Callable(this, "_button_toggle_smart_snap"));
 	smart_snap_button->set_tooltip(TTR("Toggle smart snapping."));
 	smart_snap_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/use_smart_snap", TTR("Use Smart Snap"), KEY_MASK_SHIFT | KEY_S));
 
 	grid_snap_button = memnew(ToolButton);
 	hb->add_child(grid_snap_button);
 	grid_snap_button->set_toggle_mode(true);
-	grid_snap_button->connect_compat("toggled", this, "_button_toggle_grid_snap");
+	grid_snap_button->connect("toggled", Callable(this, "_button_toggle_grid_snap"));
 	grid_snap_button->set_tooltip(TTR("Toggle grid snapping."));
 	grid_snap_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/use_grid_snap", TTR("Use Grid Snap"), KEY_MASK_SHIFT | KEY_G));
 
@@ -5599,7 +5599,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	snap_config_menu->set_switch_on_hover(true);
 
 	PopupMenu *p = snap_config_menu->get_popup();
-	p->connect_compat("id_pressed", this, "_popup_callback");
+	p->connect("id_pressed", Callable(this, "_popup_callback"));
 	p->set_hide_on_checkable_item_selection(false);
 	p->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/use_rotation_snap", TTR("Use Rotation Snap")), SNAP_USE_ROTATION);
 	p->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/use_scale_snap", TTR("Use Scale Snap")), SNAP_USE_SCALE);
@@ -5613,7 +5613,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	smartsnap_config_popup = memnew(PopupMenu);
 	p->add_child(smartsnap_config_popup);
 	smartsnap_config_popup->set_name("SmartSnapping");
-	smartsnap_config_popup->connect_compat("id_pressed", this, "_popup_callback");
+	smartsnap_config_popup->connect("id_pressed", Callable(this, "_popup_callback"));
 	smartsnap_config_popup->set_hide_on_checkable_item_selection(false);
 	smartsnap_config_popup->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/snap_node_parent", TTR("Snap to Parent")), SNAP_USE_NODE_PARENT);
 	smartsnap_config_popup->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/snap_node_anchors", TTR("Snap to Node Anchor")), SNAP_USE_NODE_ANCHORS);
@@ -5627,22 +5627,22 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	lock_button = memnew(ToolButton);
 	hb->add_child(lock_button);
 
-	lock_button->connect_compat("pressed", this, "_popup_callback", varray(LOCK_SELECTED));
+	lock_button->connect("pressed", Callable(this, "_popup_callback"), varray(LOCK_SELECTED));
 	lock_button->set_tooltip(TTR("Lock the selected object in place (can't be moved)."));
 
 	unlock_button = memnew(ToolButton);
 	hb->add_child(unlock_button);
-	unlock_button->connect_compat("pressed", this, "_popup_callback", varray(UNLOCK_SELECTED));
+	unlock_button->connect("pressed", Callable(this, "_popup_callback"), varray(UNLOCK_SELECTED));
 	unlock_button->set_tooltip(TTR("Unlock the selected object (can be moved)."));
 
 	group_button = memnew(ToolButton);
 	hb->add_child(group_button);
-	group_button->connect_compat("pressed", this, "_popup_callback", varray(GROUP_SELECTED));
+	group_button->connect("pressed", Callable(this, "_popup_callback"), varray(GROUP_SELECTED));
 	group_button->set_tooltip(TTR("Makes sure the object's children are not selectable."));
 
 	ungroup_button = memnew(ToolButton);
 	hb->add_child(ungroup_button);
-	ungroup_button->connect_compat("pressed", this, "_popup_callback", varray(UNGROUP_SELECTED));
+	ungroup_button->connect("pressed", Callable(this, "_popup_callback"), varray(UNGROUP_SELECTED));
 	ungroup_button->set_tooltip(TTR("Restores the object's children's ability to be selected."));
 
 	hb->add_child(memnew(VSeparator));
@@ -5661,13 +5661,13 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/skeleton_make_bones", TTR("Make Custom Bone(s) from Node(s)"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_B), SKELETON_MAKE_BONES);
 	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/skeleton_clear_bones", TTR("Clear Custom Bones")), SKELETON_CLEAR_BONES);
-	p->connect_compat("id_pressed", this, "_popup_callback");
+	p->connect("id_pressed", Callable(this, "_popup_callback"));
 
 	hb->add_child(memnew(VSeparator));
 
 	override_camera_button = memnew(ToolButton);
 	hb->add_child(override_camera_button);
-	override_camera_button->connect_compat("toggled", this, "_button_override_camera");
+	override_camera_button->connect("toggled", Callable(this, "_button_override_camera"));
 	override_camera_button->set_toggle_mode(true);
 	override_camera_button->set_disabled(true);
 	_update_override_camera_button(false);
@@ -5677,7 +5677,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	view_menu = memnew(MenuButton);
 	view_menu->set_text(TTR("View"));
 	hb->add_child(view_menu);
-	view_menu->get_popup()->connect_compat("id_pressed", this, "_popup_callback");
+	view_menu->get_popup()->connect("id_pressed", Callable(this, "_popup_callback"));
 	view_menu->set_switch_on_hover(true);
 
 	p = view_menu->get_popup();
@@ -5705,18 +5705,18 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	presets_menu->set_switch_on_hover(true);
 
 	p = presets_menu->get_popup();
-	p->connect_compat("id_pressed", this, "_popup_callback");
+	p->connect("id_pressed", Callable(this, "_popup_callback"));
 
 	anchors_popup = memnew(PopupMenu);
 	p->add_child(anchors_popup);
 	anchors_popup->set_name("Anchors");
-	anchors_popup->connect_compat("id_pressed", this, "_popup_callback");
+	anchors_popup->connect("id_pressed", Callable(this, "_popup_callback"));
 
 	anchor_mode_button = memnew(ToolButton);
 	hb->add_child(anchor_mode_button);
 	anchor_mode_button->set_toggle_mode(true);
 	anchor_mode_button->hide();
-	anchor_mode_button->connect_compat("toggled", this, "_button_toggle_anchor_mode");
+	anchor_mode_button->connect("toggled", Callable(this, "_button_toggle_anchor_mode"));
 
 	animation_hb = memnew(HBoxContainer);
 	hb->add_child(animation_hb);
@@ -5728,7 +5728,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	key_loc_button->set_flat(true);
 	key_loc_button->set_pressed(true);
 	key_loc_button->set_focus_mode(FOCUS_NONE);
-	key_loc_button->connect_compat("pressed", this, "_popup_callback", varray(ANIM_INSERT_POS));
+	key_loc_button->connect("pressed", Callable(this, "_popup_callback"), varray(ANIM_INSERT_POS));
 	key_loc_button->set_tooltip(TTR("Translation mask for inserting keys."));
 	animation_hb->add_child(key_loc_button);
 	key_rot_button = memnew(Button);
@@ -5736,20 +5736,20 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	key_rot_button->set_flat(true);
 	key_rot_button->set_pressed(true);
 	key_rot_button->set_focus_mode(FOCUS_NONE);
-	key_rot_button->connect_compat("pressed", this, "_popup_callback", varray(ANIM_INSERT_ROT));
+	key_rot_button->connect("pressed", Callable(this, "_popup_callback"), varray(ANIM_INSERT_ROT));
 	key_rot_button->set_tooltip(TTR("Rotation mask for inserting keys."));
 	animation_hb->add_child(key_rot_button);
 	key_scale_button = memnew(Button);
 	key_scale_button->set_toggle_mode(true);
 	key_scale_button->set_flat(true);
 	key_scale_button->set_focus_mode(FOCUS_NONE);
-	key_scale_button->connect_compat("pressed", this, "_popup_callback", varray(ANIM_INSERT_SCALE));
+	key_scale_button->connect("pressed", Callable(this, "_popup_callback"), varray(ANIM_INSERT_SCALE));
 	key_scale_button->set_tooltip(TTR("Scale mask for inserting keys."));
 	animation_hb->add_child(key_scale_button);
 	key_insert_button = memnew(Button);
 	key_insert_button->set_flat(true);
 	key_insert_button->set_focus_mode(FOCUS_NONE);
-	key_insert_button->connect_compat("pressed", this, "_popup_callback", varray(ANIM_INSERT_KEY));
+	key_insert_button->connect("pressed", Callable(this, "_popup_callback"), varray(ANIM_INSERT_KEY));
 	key_insert_button->set_tooltip(TTR("Insert keys (based on mask)."));
 	key_insert_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/anim_insert_key", TTR("Insert Key"), KEY_INSERT));
 	animation_hb->add_child(key_insert_button);
@@ -5765,7 +5765,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	animation_menu = memnew(MenuButton);
 	animation_menu->set_tooltip(TTR("Animation Key and Pose Options"));
 	animation_hb->add_child(animation_menu);
-	animation_menu->get_popup()->connect_compat("id_pressed", this, "_popup_callback");
+	animation_menu->get_popup()->connect("id_pressed", Callable(this, "_popup_callback"));
 	animation_menu->set_switch_on_hover(true);
 
 	p = animation_menu->get_popup();
@@ -5778,7 +5778,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/anim_clear_pose", TTR("Clear Pose"), KEY_MASK_SHIFT | KEY_K), ANIM_CLEAR_POSE);
 
 	snap_dialog = memnew(SnapDialog);
-	snap_dialog->connect_compat("confirmed", this, "_snap_changed");
+	snap_dialog->connect("confirmed", Callable(this, "_snap_changed"));
 	add_child(snap_dialog);
 
 	select_sb = Ref<StyleBoxTexture>(memnew(StyleBoxTexture));
@@ -5786,8 +5786,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	selection_menu = memnew(PopupMenu);
 	add_child(selection_menu);
 	selection_menu->set_custom_minimum_size(Vector2(100, 0));
-	selection_menu->connect_compat("id_pressed", this, "_selection_result_pressed");
-	selection_menu->connect_compat("popup_hide", this, "_selection_menu_hide");
+	selection_menu->connect("id_pressed", Callable(this, "_selection_result_pressed"));
+	selection_menu->connect("popup_hide", Callable(this, "_selection_menu_hide"));
 
 	multiply_grid_step_shortcut = ED_SHORTCUT("canvas_item_editor/multiply_grid_step", TTR("Multiply grid step by 2"), KEY_KP_MULTIPLY);
 	divide_grid_step_shortcut = ED_SHORTCUT("canvas_item_editor/divide_grid_step", TTR("Divide grid step by 2"), KEY_KP_DIVIDE);
@@ -6234,11 +6234,11 @@ void CanvasItemEditorViewport::drop_data(const Point2 &p_point, const Variant &p
 void CanvasItemEditorViewport::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			connect_compat("mouse_exited", this, "_on_mouse_exit");
+			connect("mouse_exited", Callable(this, "_on_mouse_exit"));
 			label->add_color_override("font_color", get_color("warning_color", "Editor"));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			disconnect_compat("mouse_exited", this, "_on_mouse_exit");
+			disconnect("mouse_exited", Callable(this, "_on_mouse_exit"));
 		} break;
 
 		default: break;
@@ -6276,8 +6276,8 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 	selector = memnew(AcceptDialog);
 	editor->get_gui_base()->add_child(selector);
 	selector->set_title(TTR("Change Default Type"));
-	selector->connect_compat("confirmed", this, "_on_change_type_confirmed");
-	selector->connect_compat("popup_hide", this, "_on_change_type_closed");
+	selector->connect("confirmed", Callable(this, "_on_change_type_confirmed"));
+	selector->connect("popup_hide", Callable(this, "_on_change_type_closed"));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	selector->add_child(vbc);
@@ -6294,7 +6294,7 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 		CheckBox *check = memnew(CheckBox);
 		btn_group->add_child(check);
 		check->set_text(types[i]);
-		check->connect_compat("button_down", this, "_on_select_type", varray(check));
+		check->connect("button_down", Callable(this, "_on_select_type"), varray(check));
 		check->set_button_group(button_group);
 	}
 

--- a/editor/plugins/collision_polygon_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_editor_plugin.cpp
@@ -47,7 +47,7 @@ void Polygon3DEditor::_notification(int p_what) {
 			button_create->set_icon(get_icon("Edit", "EditorIcons"));
 			button_edit->set_icon(get_icon("MovePoint", "EditorIcons"));
 			button_edit->set_pressed(true);
-			get_tree()->connect_compat("node_removed", this, "_node_removed");
+			get_tree()->connect("node_removed", Callable(this, "_node_removed"));
 
 		} break;
 		case NOTIFICATION_PROCESS: {
@@ -532,12 +532,12 @@ Polygon3DEditor::Polygon3DEditor(EditorNode *p_editor) {
 	add_child(memnew(VSeparator));
 	button_create = memnew(ToolButton);
 	add_child(button_create);
-	button_create->connect_compat("pressed", this, "_menu_option", varray(MODE_CREATE));
+	button_create->connect("pressed", Callable(this, "_menu_option"), varray(MODE_CREATE));
 	button_create->set_toggle_mode(true);
 
 	button_edit = memnew(ToolButton);
 	add_child(button_edit);
-	button_edit->connect_compat("pressed", this, "_menu_option", varray(MODE_EDIT));
+	button_edit->connect("pressed", Callable(this, "_menu_option"), varray(MODE_EDIT));
 	button_edit->set_toggle_mode(true);
 
 	mode = MODE_EDIT;

--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -240,9 +240,9 @@ void CPUParticles2DEditorPlugin::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		menu->get_popup()->connect_compat("id_pressed", this, "_menu_callback");
+		menu->get_popup()->connect("id_pressed", Callable(this, "_menu_callback"));
 		menu->set_icon(menu->get_popup()->get_icon("Particles2D", "EditorIcons"));
-		file->connect_compat("file_selected", this, "_file_selected");
+		file->connect("file_selected", Callable(this, "_file_selected"));
 	}
 }
 
@@ -305,7 +305,7 @@ CPUParticles2DEditorPlugin::CPUParticles2DEditorPlugin(EditorNode *p_node) {
 
 	toolbar->add_child(emission_mask);
 
-	emission_mask->connect_compat("confirmed", this, "_generate_emission_mask");
+	emission_mask->connect("confirmed", Callable(this, "_generate_emission_mask"));
 }
 
 CPUParticles2DEditorPlugin::~CPUParticles2DEditorPlugin() {

--- a/editor/plugins/cpu_particles_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_editor_plugin.cpp
@@ -109,7 +109,7 @@ CPUParticlesEditor::CPUParticlesEditor() {
 	options->get_popup()->add_item(TTR("Create Emission Points From Node"), MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_NODE);
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Restart"), MENU_OPTION_RESTART);
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 }
 
 void CPUParticlesEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -49,7 +49,7 @@ CurveEditor::CurveEditor() {
 	set_clip_contents(true);
 
 	_context_menu = memnew(PopupMenu);
-	_context_menu->connect_compat("id_pressed", this, "_on_context_menu_item_selected");
+	_context_menu->connect("id_pressed", Callable(this, "_on_context_menu_item_selected"));
 	add_child(_context_menu);
 
 	_presets_menu = memnew(PopupMenu);
@@ -60,7 +60,7 @@ CurveEditor::CurveEditor() {
 	_presets_menu->add_item(TTR("Ease In"), PRESET_EASE_IN);
 	_presets_menu->add_item(TTR("Ease Out"), PRESET_EASE_OUT);
 	_presets_menu->add_item(TTR("Smoothstep"), PRESET_SMOOTHSTEP);
-	_presets_menu->connect_compat("id_pressed", this, "_on_preset_item_selected");
+	_presets_menu->connect("id_pressed", Callable(this, "_on_preset_item_selected"));
 	_context_menu->add_child(_presets_menu);
 }
 
@@ -70,15 +70,15 @@ void CurveEditor::set_curve(Ref<Curve> curve) {
 		return;
 
 	if (_curve_ref.is_valid()) {
-		_curve_ref->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_curve_changed");
-		_curve_ref->disconnect_compat(Curve::SIGNAL_RANGE_CHANGED, this, "_curve_changed");
+		_curve_ref->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_curve_changed"));
+		_curve_ref->disconnect(Curve::SIGNAL_RANGE_CHANGED, Callable(this, "_curve_changed"));
 	}
 
 	_curve_ref = curve;
 
 	if (_curve_ref.is_valid()) {
-		_curve_ref->connect_compat(CoreStringNames::get_singleton()->changed, this, "_curve_changed");
-		_curve_ref->connect_compat(Curve::SIGNAL_RANGE_CHANGED, this, "_curve_changed");
+		_curve_ref->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_curve_changed"));
+		_curve_ref->connect(Curve::SIGNAL_RANGE_CHANGED, Callable(this, "_curve_changed"));
 	}
 
 	_selected_point = -1;

--- a/editor/plugins/gi_probe_editor_plugin.cpp
+++ b/editor/plugins/gi_probe_editor_plugin.cpp
@@ -147,7 +147,7 @@ GIProbeEditorPlugin::GIProbeEditorPlugin(EditorNode *p_node) {
 	bake = memnew(ToolButton);
 	bake->set_icon(editor->get_gui_base()->get_icon("Bake", "EditorIcons"));
 	bake->set_text(TTR("Bake GI Probe"));
-	bake->connect_compat("pressed", this, "_bake");
+	bake->connect("pressed", Callable(this, "_bake"));
 	bake_hb->add_child(bake);
 	bake_info = memnew(Label);
 	bake_info->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -159,7 +159,7 @@ GIProbeEditorPlugin::GIProbeEditorPlugin(EditorNode *p_node) {
 	probe_file = memnew(EditorFileDialog);
 	probe_file->set_mode(EditorFileDialog::MODE_SAVE_FILE);
 	probe_file->add_filter("*.res");
-	probe_file->connect_compat("file_selected", this, "_giprobe_save_path_and_bake");
+	probe_file->connect("file_selected", Callable(this, "_giprobe_save_path_and_bake"));
 	get_editor_interface()->get_base_control()->add_child(probe_file);
 	probe_file->set_title(TTR("Select path for GIProbe Data File"));
 

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -69,8 +69,8 @@ void GradientEditor::_bind_methods() {
 
 void GradientEditor::set_gradient(const Ref<Gradient> &p_gradient) {
 	gradient = p_gradient;
-	connect_compat("ramp_changed", this, "_ramp_changed");
-	gradient->connect_compat("changed", this, "_gradient_changed");
+	connect("ramp_changed", Callable(this, "_ramp_changed"));
+	gradient->connect("changed", Callable(this, "_gradient_changed"));
 	set_points(gradient->get_points());
 }
 

--- a/editor/plugins/item_list_editor_plugin.cpp
+++ b/editor/plugins/item_list_editor_plugin.cpp
@@ -268,7 +268,7 @@ void ItemListEditor::_notification(int p_notification) {
 		del_button->set_icon(get_icon("Remove", "EditorIcons"));
 	} else if (p_notification == NOTIFICATION_READY) {
 
-		get_tree()->connect_compat("node_removed", this, "_node_removed");
+		get_tree()->connect("node_removed", Callable(this, "_node_removed"));
 	}
 }
 
@@ -359,7 +359,7 @@ ItemListEditor::ItemListEditor() {
 	toolbar_button = memnew(ToolButton);
 	toolbar_button->set_text(TTR("Items"));
 	add_child(toolbar_button);
-	toolbar_button->connect_compat("pressed", this, "_edit_items");
+	toolbar_button->connect("pressed", Callable(this, "_edit_items"));
 
 	dialog = memnew(AcceptDialog);
 	dialog->set_title(TTR("Item List Editor"));
@@ -376,14 +376,14 @@ ItemListEditor::ItemListEditor() {
 	add_button = memnew(Button);
 	add_button->set_text(TTR("Add"));
 	hbc->add_child(add_button);
-	add_button->connect_compat("pressed", this, "_add_button");
+	add_button->connect("pressed", Callable(this, "_add_button"));
 
 	hbc->add_spacer();
 
 	del_button = memnew(Button);
 	del_button->set_text(TTR("Delete"));
 	hbc->add_child(del_button);
-	del_button->connect_compat("pressed", this, "_delete_button");
+	del_button->connect("pressed", Callable(this, "_delete_button"));
 
 	property_editor = memnew(EditorInspector);
 	vbc->add_child(property_editor);

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -171,13 +171,13 @@ MaterialEditor::MaterialEditor() {
 	sphere_switch->set_toggle_mode(true);
 	sphere_switch->set_pressed(true);
 	vb_shape->add_child(sphere_switch);
-	sphere_switch->connect_compat("pressed", this, "_button_pressed", varray(sphere_switch));
+	sphere_switch->connect("pressed", Callable(this, "_button_pressed"), varray(sphere_switch));
 
 	box_switch = memnew(TextureButton);
 	box_switch->set_toggle_mode(true);
 	box_switch->set_pressed(false);
 	vb_shape->add_child(box_switch);
-	box_switch->connect_compat("pressed", this, "_button_pressed", varray(box_switch));
+	box_switch->connect("pressed", Callable(this, "_button_pressed"), varray(box_switch));
 
 	hb->add_spacer();
 
@@ -187,12 +187,12 @@ MaterialEditor::MaterialEditor() {
 	light_1_switch = memnew(TextureButton);
 	light_1_switch->set_toggle_mode(true);
 	vb_light->add_child(light_1_switch);
-	light_1_switch->connect_compat("pressed", this, "_button_pressed", varray(light_1_switch));
+	light_1_switch->connect("pressed", Callable(this, "_button_pressed"), varray(light_1_switch));
 
 	light_2_switch = memnew(TextureButton);
 	light_2_switch->set_toggle_mode(true);
 	vb_light->add_child(light_2_switch);
-	light_2_switch->connect_compat("pressed", this, "_button_pressed", varray(light_2_switch));
+	light_2_switch->connect("pressed", Callable(this, "_button_pressed"), varray(light_2_switch));
 
 	first_enter = true;
 }

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -157,12 +157,12 @@ MeshEditor::MeshEditor() {
 	light_1_switch = memnew(TextureButton);
 	light_1_switch->set_toggle_mode(true);
 	vb_light->add_child(light_1_switch);
-	light_1_switch->connect_compat("pressed", this, "_button_pressed", varray(light_1_switch));
+	light_1_switch->connect("pressed", Callable(this, "_button_pressed"), varray(light_1_switch));
 
 	light_2_switch = memnew(TextureButton);
 	light_2_switch->set_toggle_mode(true);
 	vb_light->add_child(light_2_switch);
-	light_2_switch->connect_compat("pressed", this, "_button_pressed", varray(light_2_switch));
+	light_2_switch->connect("pressed", Callable(this, "_button_pressed"), varray(light_2_switch));
 
 	first_enter = true;
 

--- a/editor/plugins/mesh_instance_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_editor_plugin.cpp
@@ -469,7 +469,7 @@ MeshInstanceEditor::MeshInstanceEditor() {
 	options->get_popup()->add_item(TTR("View UV2"), MENU_OPTION_DEBUG_UV2);
 	options->get_popup()->add_item(TTR("Unwrap UV2 for Lightmap/AO"), MENU_OPTION_CREATE_UV2);
 
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	outline_dialog = memnew(ConfirmationDialog);
 	outline_dialog->set_title(TTR("Create Outline Mesh"));
@@ -487,7 +487,7 @@ MeshInstanceEditor::MeshInstanceEditor() {
 	outline_dialog_vbc->add_margin_child(TTR("Outline Size:"), outline_size);
 
 	add_child(outline_dialog);
-	outline_dialog->connect_compat("confirmed", this, "_create_outline_mesh");
+	outline_dialog->connect("confirmed", Callable(this, "_create_outline_mesh"));
 
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);
@@ -497,7 +497,7 @@ MeshInstanceEditor::MeshInstanceEditor() {
 	add_child(debug_uv_dialog);
 	debug_uv = memnew(Control);
 	debug_uv->set_custom_minimum_size(Size2(600, 600) * EDSCALE);
-	debug_uv->connect_compat("draw", this, "_debug_uv_draw");
+	debug_uv->connect("draw", Callable(this, "_debug_uv_draw"));
 	debug_uv_dialog->add_child(debug_uv);
 }
 

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -268,7 +268,7 @@ MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
 		file->add_filter("*." + extensions[i] + " ; " + extensions[i].to_upper());
 	}
 	add_child(file);
-	file->connect_compat("file_selected", this, "_import_scene_cbk");
+	file->connect("file_selected", Callable(this, "_import_scene_cbk"));
 
 	menu = memnew(MenuButton);
 	SpatialEditor::get_singleton()->add_control_to_menu_panel(menu);
@@ -281,13 +281,13 @@ MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
 	menu->get_popup()->add_item(TTR("Import from Scene"), MENU_OPTION_IMPORT_FROM_SCENE);
 	menu->get_popup()->add_item(TTR("Update from Scene"), MENU_OPTION_UPDATE_FROM_SCENE);
 	menu->get_popup()->set_item_disabled(menu->get_popup()->get_item_index(MENU_OPTION_UPDATE_FROM_SCENE), true);
-	menu->get_popup()->connect_compat("id_pressed", this, "_menu_cbk");
+	menu->get_popup()->connect("id_pressed", Callable(this, "_menu_cbk"));
 	menu->hide();
 
 	editor = p_editor;
 	cd = memnew(ConfirmationDialog);
 	add_child(cd);
-	cd->get_ok()->connect_compat("pressed", this, "_menu_confirm");
+	cd->get_ok()->connect("pressed", Callable(this, "_menu_confirm"));
 }
 
 void MeshLibraryEditorPlugin::edit(Object *p_node) {

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -295,7 +295,7 @@ MultiMeshEditor::MultiMeshEditor() {
 	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("MultiMeshInstance", "EditorIcons"));
 
 	options->get_popup()->add_item(TTR("Populate Surface"));
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	populate_dialog = memnew(ConfirmationDialog);
 	populate_dialog->set_title(TTR("Populate MultiMesh"));
@@ -313,7 +313,7 @@ MultiMeshEditor::MultiMeshEditor() {
 	Button *b = memnew(Button);
 	hbc->add_child(b);
 	b->set_text("..");
-	b->connect_compat("pressed", this, "_browse", make_binds(false));
+	b->connect("pressed", Callable(this, "_browse"), make_binds(false));
 
 	vbc->add_margin_child(TTR("Target Surface:"), hbc);
 
@@ -325,7 +325,7 @@ MultiMeshEditor::MultiMeshEditor() {
 	hbc->add_child(b);
 	b->set_text("..");
 	vbc->add_margin_child(TTR("Source Mesh:"), hbc);
-	b->connect_compat("pressed", this, "_browse", make_binds(true));
+	b->connect("pressed", Callable(this, "_browse"), make_binds(true));
 
 	populate_axis = memnew(OptionButton);
 	populate_axis->add_item(TTR("X-Axis"));
@@ -371,10 +371,10 @@ MultiMeshEditor::MultiMeshEditor() {
 
 	populate_dialog->get_ok()->set_text(TTR("Populate"));
 
-	populate_dialog->get_ok()->connect_compat("pressed", this, "_populate");
+	populate_dialog->get_ok()->connect("pressed", Callable(this, "_populate"));
 	std = memnew(SceneTreeDialog);
 	populate_dialog->add_child(std);
-	std->connect_compat("selected", this, "_browsed");
+	std->connect("selected", Callable(this, "_browsed"));
 
 	_last_pp_node = NULL;
 

--- a/editor/plugins/particles_2d_editor_plugin.cpp
+++ b/editor/plugins/particles_2d_editor_plugin.cpp
@@ -349,9 +349,9 @@ void Particles2DEditorPlugin::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		menu->get_popup()->connect_compat("id_pressed", this, "_menu_callback");
+		menu->get_popup()->connect("id_pressed", Callable(this, "_menu_callback"));
 		menu->set_icon(menu->get_popup()->get_icon("Particles2D", "EditorIcons"));
-		file->connect_compat("file_selected", this, "_file_selected");
+		file->connect("file_selected", Callable(this, "_file_selected"));
 	}
 }
 
@@ -416,7 +416,7 @@ Particles2DEditorPlugin::Particles2DEditorPlugin(EditorNode *p_node) {
 
 	toolbar->add_child(generate_visibility_rect);
 
-	generate_visibility_rect->connect_compat("confirmed", this, "_generate_visibility_rect");
+	generate_visibility_rect->connect("confirmed", Callable(this, "_generate_visibility_rect"));
 
 	emission_mask = memnew(ConfirmationDialog);
 	emission_mask->set_title(TTR("Load Emission Mask"));
@@ -433,7 +433,7 @@ Particles2DEditorPlugin::Particles2DEditorPlugin(EditorNode *p_node) {
 
 	toolbar->add_child(emission_mask);
 
-	emission_mask->connect_compat("confirmed", this, "_generate_emission_mask");
+	emission_mask->connect("confirmed", Callable(this, "_generate_emission_mask"));
 }
 
 Particles2DEditorPlugin::~Particles2DEditorPlugin() {

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -229,11 +229,11 @@ ParticlesEditorBase::ParticlesEditorBase() {
 	emd_vb->add_margin_child(TTR("Emission Source: "), emission_fill);
 
 	emission_dialog->get_ok()->set_text(TTR("Create"));
-	emission_dialog->connect_compat("confirmed", this, "_generate_emission_points");
+	emission_dialog->connect("confirmed", Callable(this, "_generate_emission_points"));
 
 	emission_tree_dialog = memnew(SceneTreeDialog);
 	add_child(emission_tree_dialog);
-	emission_tree_dialog->connect_compat("selected", this, "_node_selected");
+	emission_tree_dialog->connect("selected", Callable(this, "_node_selected"));
 }
 
 void ParticlesEditor::_node_removed(Node *p_node) {
@@ -248,7 +248,7 @@ void ParticlesEditor::_notification(int p_notification) {
 
 	if (p_notification == NOTIFICATION_ENTER_TREE) {
 		options->set_icon(options->get_popup()->get_icon("Particles", "EditorIcons"));
-		get_tree()->connect_compat("node_removed", this, "_node_removed");
+		get_tree()->connect("node_removed", Callable(this, "_node_removed"));
 	}
 }
 
@@ -448,7 +448,7 @@ ParticlesEditor::ParticlesEditor() {
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Restart"), MENU_OPTION_RESTART);
 
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	generate_aabb = memnew(ConfirmationDialog);
 	generate_aabb->set_title(TTR("Generate Visibility AABB"));
@@ -462,7 +462,7 @@ ParticlesEditor::ParticlesEditor() {
 
 	add_child(generate_aabb);
 
-	generate_aabb->connect_compat("confirmed", this, "_generate_aabb");
+	generate_aabb->connect("confirmed", Callable(this, "_generate_aabb"));
 }
 
 void ParticlesEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -441,14 +441,14 @@ void Path2DEditor::edit(Node *p_path2d) {
 	if (p_path2d) {
 
 		node = Object::cast_to<Path2D>(p_path2d);
-		if (!node->is_connected_compat("visibility_changed", this, "_node_visibility_changed"))
-			node->connect_compat("visibility_changed", this, "_node_visibility_changed");
+		if (!node->is_connected("visibility_changed", Callable(this, "_node_visibility_changed")))
+			node->connect("visibility_changed", Callable(this, "_node_visibility_changed"));
 
 	} else {
 
 		// node may have been deleted at this point
-		if (node && node->is_connected_compat("visibility_changed", this, "_node_visibility_changed"))
-			node->disconnect_compat("visibility_changed", this, "_node_visibility_changed");
+		if (node && node->is_connected("visibility_changed", Callable(this, "_node_visibility_changed")))
+			node->disconnect("visibility_changed", Callable(this, "_node_visibility_changed"));
 		node = NULL;
 	}
 }
@@ -555,34 +555,34 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	curve_edit->set_toggle_mode(true);
 	curve_edit->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit->set_tooltip(TTR("Select Points") + "\n" + TTR("Shift+Drag: Select Control Points") + "\n" + keycode_get_string(KEY_MASK_CMD) + TTR("Click: Add Point") + "\n" + TTR("Left Click: Split Segment (in curve)") + "\n" + TTR("Right Click: Delete Point"));
-	curve_edit->connect_compat("pressed", this, "_mode_selected", varray(MODE_EDIT));
+	curve_edit->connect("pressed", Callable(this, "_mode_selected"), varray(MODE_EDIT));
 	base_hb->add_child(curve_edit);
 	curve_edit_curve = memnew(ToolButton);
 	curve_edit_curve->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("CurveCurve", "EditorIcons"));
 	curve_edit_curve->set_toggle_mode(true);
 	curve_edit_curve->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit_curve->set_tooltip(TTR("Select Control Points (Shift+Drag)"));
-	curve_edit_curve->connect_compat("pressed", this, "_mode_selected", varray(MODE_EDIT_CURVE));
+	curve_edit_curve->connect("pressed", Callable(this, "_mode_selected"), varray(MODE_EDIT_CURVE));
 	base_hb->add_child(curve_edit_curve);
 	curve_create = memnew(ToolButton);
 	curve_create->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("CurveCreate", "EditorIcons"));
 	curve_create->set_toggle_mode(true);
 	curve_create->set_focus_mode(Control::FOCUS_NONE);
 	curve_create->set_tooltip(TTR("Add Point (in empty space)"));
-	curve_create->connect_compat("pressed", this, "_mode_selected", varray(MODE_CREATE));
+	curve_create->connect("pressed", Callable(this, "_mode_selected"), varray(MODE_CREATE));
 	base_hb->add_child(curve_create);
 	curve_del = memnew(ToolButton);
 	curve_del->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("CurveDelete", "EditorIcons"));
 	curve_del->set_toggle_mode(true);
 	curve_del->set_focus_mode(Control::FOCUS_NONE);
 	curve_del->set_tooltip(TTR("Delete Point"));
-	curve_del->connect_compat("pressed", this, "_mode_selected", varray(MODE_DELETE));
+	curve_del->connect("pressed", Callable(this, "_mode_selected"), varray(MODE_DELETE));
 	base_hb->add_child(curve_del);
 	curve_close = memnew(ToolButton);
 	curve_close->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("CurveClose", "EditorIcons"));
 	curve_close->set_focus_mode(Control::FOCUS_NONE);
 	curve_close->set_tooltip(TTR("Close Curve"));
-	curve_close->connect_compat("pressed", this, "_mode_selected", varray(ACTION_CLOSE));
+	curve_close->connect("pressed", Callable(this, "_mode_selected"), varray(ACTION_CLOSE));
 	base_hb->add_child(curve_close);
 
 	PopupMenu *menu;
@@ -596,7 +596,7 @@ Path2DEditor::Path2DEditor(EditorNode *p_editor) {
 	menu->set_item_checked(HANDLE_OPTION_ANGLE, mirror_handle_angle);
 	menu->add_check_item(TTR("Mirror Handle Lengths"));
 	menu->set_item_checked(HANDLE_OPTION_LENGTH, mirror_handle_length);
-	menu->connect_compat("id_pressed", this, "_handle_option_pressed");
+	menu->connect("id_pressed", Callable(this, "_handle_option_pressed"));
 
 	base_hb->hide();
 

--- a/editor/plugins/path_editor_plugin.cpp
+++ b/editor/plugins/path_editor_plugin.cpp
@@ -543,10 +543,10 @@ void PathEditorPlugin::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		curve_create->connect_compat("pressed", this, "_mode_changed", make_binds(0));
-		curve_edit->connect_compat("pressed", this, "_mode_changed", make_binds(1));
-		curve_del->connect_compat("pressed", this, "_mode_changed", make_binds(2));
-		curve_close->connect_compat("pressed", this, "_close_curve");
+		curve_create->connect("pressed", Callable(this, "_mode_changed"), make_binds(0));
+		curve_edit->connect("pressed", Callable(this, "_mode_changed"), make_binds(1));
+		curve_del->connect("pressed", Callable(this, "_mode_changed"), make_binds(2));
+		curve_close->connect("pressed", Callable(this, "_close_curve"));
 	}
 }
 
@@ -614,7 +614,7 @@ PathEditorPlugin::PathEditorPlugin(EditorNode *p_node) {
 	menu->set_item_checked(HANDLE_OPTION_ANGLE, mirror_handle_angle);
 	menu->add_check_item(TTR("Mirror Handle Lengths"));
 	menu->set_item_checked(HANDLE_OPTION_LENGTH, mirror_handle_length);
-	menu->connect_compat("id_pressed", this, "_handle_option_pressed");
+	menu->connect("id_pressed", Callable(this, "_handle_option_pressed"));
 
 	curve_edit->set_pressed(true);
 	/*

--- a/editor/plugins/physical_bone_plugin.cpp
+++ b/editor/plugins/physical_bone_plugin.cpp
@@ -64,7 +64,7 @@ PhysicalBoneEditor::PhysicalBoneEditor(EditorNode *p_editor) :
 	button_transform_joint->set_text(TTR("Move Joint"));
 	button_transform_joint->set_icon(SpatialEditor::get_singleton()->get_icon("PhysicalBone", "EditorIcons"));
 	button_transform_joint->set_toggle_mode(true);
-	button_transform_joint->connect_compat("toggled", this, "_on_toggle_button_transform_joint");
+	button_transform_joint->connect("toggled", Callable(this, "_on_toggle_button_transform_joint"));
 
 	hide();
 }

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -192,7 +192,7 @@ void Polygon2DEditor::_update_bone_list() {
 		if (np == selected || bone_scroll_vb->get_child_count() < 2)
 			cb->set_pressed(true);
 
-		cb->connect_compat("pressed", this, "_bone_paint_selected", varray(i));
+		cb->connect("pressed", Callable(this, "_bone_paint_selected"), varray(i));
 	}
 
 	uv_edit_draw->update();
@@ -1273,14 +1273,14 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	button_uv = memnew(ToolButton);
 	add_child(button_uv);
 	button_uv->set_tooltip(TTR("Open Polygon 2D UV editor."));
-	button_uv->connect_compat("pressed", this, "_menu_option", varray(MODE_EDIT_UV));
+	button_uv->connect("pressed", Callable(this, "_menu_option"), varray(MODE_EDIT_UV));
 
 	uv_mode = UV_MODE_EDIT_POINT;
 	uv_edit = memnew(AcceptDialog);
 	add_child(uv_edit);
 	uv_edit->set_title(TTR("Polygon 2D UV Editor"));
 	uv_edit->set_resizable(true);
-	uv_edit->connect_compat("popup_hide", this, "_uv_edit_popup_hide");
+	uv_edit->connect("popup_hide", Callable(this, "_uv_edit_popup_hide"));
 
 	VBoxContainer *uv_main_vb = memnew(VBoxContainer);
 	uv_edit->add_child(uv_main_vb);
@@ -1312,10 +1312,10 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_edit_mode[2]->set_button_group(uv_edit_group);
 	uv_edit_mode[3]->set_button_group(uv_edit_group);
 
-	uv_edit_mode[0]->connect_compat("pressed", this, "_uv_edit_mode_select", varray(0));
-	uv_edit_mode[1]->connect_compat("pressed", this, "_uv_edit_mode_select", varray(1));
-	uv_edit_mode[2]->connect_compat("pressed", this, "_uv_edit_mode_select", varray(2));
-	uv_edit_mode[3]->connect_compat("pressed", this, "_uv_edit_mode_select", varray(3));
+	uv_edit_mode[0]->connect("pressed", Callable(this, "_uv_edit_mode_select"), varray(0));
+	uv_edit_mode[1]->connect("pressed", Callable(this, "_uv_edit_mode_select"), varray(1));
+	uv_edit_mode[2]->connect("pressed", Callable(this, "_uv_edit_mode_select"), varray(2));
+	uv_edit_mode[3]->connect("pressed", Callable(this, "_uv_edit_mode_select"), varray(3));
 
 	uv_mode_hb->add_child(memnew(VSeparator));
 
@@ -1325,7 +1325,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 		uv_button[i] = memnew(ToolButton);
 		uv_button[i]->set_toggle_mode(true);
 		uv_mode_hb->add_child(uv_button[i]);
-		uv_button[i]->connect_compat("pressed", this, "_uv_mode", varray(i));
+		uv_button[i]->connect("pressed", Callable(this, "_uv_mode"), varray(i));
 		uv_button[i]->set_focus_mode(FOCUS_NONE);
 	}
 
@@ -1388,7 +1388,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_menu->get_popup()->add_item(TTR("Clear UV"), UVEDIT_UV_CLEAR);
 	uv_menu->get_popup()->add_separator();
 	uv_menu->get_popup()->add_item(TTR("Grid Settings"), UVEDIT_GRID_SETTINGS);
-	uv_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	uv_menu->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	uv_mode_hb->add_child(memnew(VSeparator));
 
@@ -1399,7 +1399,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	b_snap_enable->set_toggle_mode(true);
 	b_snap_enable->set_pressed(use_snap);
 	b_snap_enable->set_tooltip(TTR("Enable Snap"));
-	b_snap_enable->connect_compat("toggled", this, "_set_use_snap");
+	b_snap_enable->connect("toggled", Callable(this, "_set_use_snap"));
 
 	b_snap_grid = memnew(ToolButton);
 	uv_mode_hb->add_child(b_snap_grid);
@@ -1408,7 +1408,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	b_snap_grid->set_toggle_mode(true);
 	b_snap_grid->set_pressed(snap_show_grid);
 	b_snap_grid->set_tooltip(TTR("Show Grid"));
-	b_snap_grid->connect_compat("toggled", this, "_set_show_grid");
+	b_snap_grid->connect("toggled", Callable(this, "_set_show_grid"));
 
 	grid_settings = memnew(AcceptDialog);
 	grid_settings->set_title(TTR("Configure Grid:"));
@@ -1422,7 +1422,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	sb_off_x->set_step(1);
 	sb_off_x->set_value(snap_offset.x);
 	sb_off_x->set_suffix("px");
-	sb_off_x->connect_compat("value_changed", this, "_set_snap_off_x");
+	sb_off_x->connect("value_changed", Callable(this, "_set_snap_off_x"));
 	grid_settings_vb->add_margin_child(TTR("Grid Offset X:"), sb_off_x);
 
 	SpinBox *sb_off_y = memnew(SpinBox);
@@ -1431,7 +1431,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	sb_off_y->set_step(1);
 	sb_off_y->set_value(snap_offset.y);
 	sb_off_y->set_suffix("px");
-	sb_off_y->connect_compat("value_changed", this, "_set_snap_off_y");
+	sb_off_y->connect("value_changed", Callable(this, "_set_snap_off_y"));
 	grid_settings_vb->add_margin_child(TTR("Grid Offset Y:"), sb_off_y);
 
 	SpinBox *sb_step_x = memnew(SpinBox);
@@ -1440,7 +1440,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	sb_step_x->set_step(1);
 	sb_step_x->set_value(snap_step.x);
 	sb_step_x->set_suffix("px");
-	sb_step_x->connect_compat("value_changed", this, "_set_snap_step_x");
+	sb_step_x->connect("value_changed", Callable(this, "_set_snap_step_x"));
 	grid_settings_vb->add_margin_child(TTR("Grid Step X:"), sb_step_x);
 
 	SpinBox *sb_step_y = memnew(SpinBox);
@@ -1449,7 +1449,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	sb_step_y->set_step(1);
 	sb_step_y->set_value(snap_step.y);
 	sb_step_y->set_suffix("px");
-	sb_step_y->connect_compat("value_changed", this, "_set_snap_step_y");
+	sb_step_y->connect("value_changed", Callable(this, "_set_snap_step_y"));
 	grid_settings_vb->add_margin_child(TTR("Grid Step Y:"), sb_step_y);
 
 	uv_mode_hb->add_child(memnew(VSeparator));
@@ -1469,16 +1469,16 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_zoom->share(uv_zoom_value);
 	uv_zoom_value->set_custom_minimum_size(Size2(50, 0));
 	uv_mode_hb->add_child(uv_zoom_value);
-	uv_zoom->connect_compat("value_changed", this, "_uv_scroll_changed");
+	uv_zoom->connect("value_changed", Callable(this, "_uv_scroll_changed"));
 
 	uv_vscroll = memnew(VScrollBar);
 	uv_vscroll->set_step(0.001);
 	uv_edit_draw->add_child(uv_vscroll);
-	uv_vscroll->connect_compat("value_changed", this, "_uv_scroll_changed");
+	uv_vscroll->connect("value_changed", Callable(this, "_uv_scroll_changed"));
 	uv_hscroll = memnew(HScrollBar);
 	uv_hscroll->set_step(0.001);
 	uv_edit_draw->add_child(uv_hscroll);
-	uv_hscroll->connect_compat("value_changed", this, "_uv_scroll_changed");
+	uv_hscroll->connect("value_changed", Callable(this, "_uv_scroll_changed"));
 
 	bone_scroll_main_vb = memnew(VBoxContainer);
 	bone_scroll_main_vb->hide();
@@ -1486,7 +1486,7 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	sync_bones = memnew(Button(TTR("Sync Bones to Polygon")));
 	bone_scroll_main_vb->add_child(sync_bones);
 	sync_bones->set_h_size_flags(0);
-	sync_bones->connect_compat("pressed", this, "_sync_bones");
+	sync_bones->connect("pressed", Callable(this, "_sync_bones"));
 	uv_main_hsc->add_child(bone_scroll_main_vb);
 	bone_scroll = memnew(ScrollContainer);
 	bone_scroll->set_v_scroll(true);
@@ -1496,8 +1496,8 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	bone_scroll_vb = memnew(VBoxContainer);
 	bone_scroll->add_child(bone_scroll_vb);
 
-	uv_edit_draw->connect_compat("draw", this, "_uv_draw");
-	uv_edit_draw->connect_compat("gui_input", this, "_uv_input");
+	uv_edit_draw->connect("draw", Callable(this, "_uv_draw"));
+	uv_edit_draw->connect("gui_input", Callable(this, "_uv_input"));
 	uv_draw_zoom = 1.0;
 	point_drag_index = -1;
 	uv_drag = false;

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -382,7 +382,7 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	add_child(file);
 
 	tree = memnew(Tree);
-	tree->connect_compat("button_pressed", this, "_cell_button_pressed");
+	tree->connect("button_pressed", Callable(this, "_cell_button_pressed"));
 	tree->set_columns(2);
 	tree->set_column_min_width(0, 2);
 	tree->set_column_min_width(1, 3);
@@ -396,10 +396,10 @@ ResourcePreloaderEditor::ResourcePreloaderEditor() {
 	dialog = memnew(AcceptDialog);
 	add_child(dialog);
 
-	load->connect_compat("pressed", this, "_load_pressed");
-	paste->connect_compat("pressed", this, "_paste_pressed");
-	file->connect_compat("files_selected", this, "_files_load_request");
-	tree->connect_compat("item_edited", this, "_item_edited");
+	load->connect("pressed", Callable(this, "_load_pressed"));
+	paste->connect("pressed", Callable(this, "_paste_pressed"));
+	file->connect("files_selected", Callable(this, "_files_load_request"));
+	tree->connect("item_edited", Callable(this, "_item_edited"));
 	loading_scene = false;
 }
 

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -262,24 +262,24 @@ EditorPropertyRootMotion::EditorPropertyRootMotion() {
 	assign->set_flat(true);
 	assign->set_h_size_flags(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
-	assign->connect_compat("pressed", this, "_node_assign");
+	assign->connect("pressed", Callable(this, "_node_assign"));
 	hbc->add_child(assign);
 
 	clear = memnew(Button);
 	clear->set_flat(true);
-	clear->connect_compat("pressed", this, "_node_clear");
+	clear->connect("pressed", Callable(this, "_node_clear"));
 	hbc->add_child(clear);
 
 	filter_dialog = memnew(ConfirmationDialog);
 	add_child(filter_dialog);
 	filter_dialog->set_title(TTR("Edit Filtered Tracks:"));
-	filter_dialog->connect_compat("confirmed", this, "_confirmed");
+	filter_dialog->connect("confirmed", Callable(this, "_confirmed"));
 
 	filters = memnew(Tree);
 	filter_dialog->add_child(filters);
 	filters->set_v_size_flags(SIZE_EXPAND_FILL);
 	filters->set_hide_root(true);
-	filters->connect_compat("item_activated", this, "_confirmed");
+	filters->connect("item_activated", Callable(this, "_confirmed"));
 	//filters->connect("item_edited", this, "_filter_edited");
 }
 //////////////////////////

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -211,7 +211,7 @@ void ScriptEditorQuickOpen::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			connect_compat("confirmed", this, "_confirmed");
+			connect("confirmed", Callable(this, "_confirmed"));
 
 			search_box->set_clear_button_enabled(true);
 			[[fallthrough]];
@@ -220,7 +220,7 @@ void ScriptEditorQuickOpen::_notification(int p_what) {
 			search_box->set_right_icon(get_icon("Search", "EditorIcons"));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			disconnect_compat("confirmed", this, "_confirmed");
+			disconnect("confirmed", Callable(this, "_confirmed"));
 		} break;
 	}
 }
@@ -240,15 +240,15 @@ ScriptEditorQuickOpen::ScriptEditorQuickOpen() {
 	add_child(vbc);
 	search_box = memnew(LineEdit);
 	vbc->add_margin_child(TTR("Search:"), search_box);
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_changed", Callable(this, "_text_changed"));
+	search_box->connect("gui_input", Callable(this, "_sbox_input"));
 	search_options = memnew(Tree);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 	get_ok()->set_text(TTR("Open"));
 	get_ok()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect_compat("item_activated", this, "_confirmed");
+	search_options->connect("item_activated", Callable(this, "_confirmed"));
 	search_options->set_hide_root(true);
 	search_options->set_hide_folding(true);
 	search_options->add_constant_override("draw_guides", 1);
@@ -1386,16 +1386,16 @@ void ScriptEditor::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 
-			editor->connect_compat("stop_pressed", this, "_editor_stop");
-			editor->connect_compat("script_add_function_request", this, "_add_callback");
-			editor->connect_compat("resource_saved", this, "_res_saved_callback");
-			script_list->connect_compat("item_selected", this, "_script_selected");
+			editor->connect("stop_pressed", Callable(this, "_editor_stop"));
+			editor->connect("script_add_function_request", Callable(this, "_add_callback"));
+			editor->connect("resource_saved", Callable(this, "_res_saved_callback"));
+			script_list->connect("item_selected", Callable(this, "_script_selected"));
 
-			members_overview->connect_compat("item_selected", this, "_members_overview_selected");
-			help_overview->connect_compat("item_selected", this, "_help_overview_selected");
-			script_split->connect_compat("dragged", this, "_script_split_dragged");
+			members_overview->connect("item_selected", Callable(this, "_members_overview_selected"));
+			help_overview->connect("item_selected", Callable(this, "_help_overview_selected"));
+			script_split->connect("dragged", Callable(this, "_script_split_dragged"));
 
-			EditorSettings::get_singleton()->connect_compat("settings_changed", this, "_editor_settings_changed");
+			EditorSettings::get_singleton()->connect("settings_changed", Callable(this, "_editor_settings_changed"));
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
@@ -1419,14 +1419,14 @@ void ScriptEditor::_notification(int p_what) {
 
 		case NOTIFICATION_READY: {
 
-			get_tree()->connect_compat("tree_changed", this, "_tree_changed");
-			editor->get_inspector_dock()->connect_compat("request_help", this, "_request_help");
-			editor->connect_compat("request_help_search", this, "_help_search");
+			get_tree()->connect("tree_changed", Callable(this, "_tree_changed"));
+			editor->get_inspector_dock()->connect("request_help", Callable(this, "_request_help"));
+			editor->connect("request_help_search", Callable(this, "_help_search"));
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
 
-			editor->disconnect_compat("stop_pressed", this, "_editor_stop");
+			editor->disconnect("stop_pressed", Callable(this, "_editor_stop"));
 		} break;
 
 		case MainLoop::NOTIFICATION_WM_FOCUS_IN: {
@@ -2137,14 +2137,14 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 	_sort_list_on_update = true;
 	_update_script_names();
 	_save_layout();
-	se->connect_compat("name_changed", this, "_update_script_names");
-	se->connect_compat("edited_script_changed", this, "_script_changed");
-	se->connect_compat("request_help", this, "_help_search");
-	se->connect_compat("request_open_script_at_line", this, "_goto_script_line");
-	se->connect_compat("go_to_help", this, "_help_class_goto");
-	se->connect_compat("request_save_history", this, "_save_history");
-	se->connect_compat("search_in_files_requested", this, "_on_find_in_files_requested");
-	se->connect_compat("replace_in_files_requested", this, "_on_replace_in_files_requested");
+	se->connect("name_changed", Callable(this, "_update_script_names"));
+	se->connect("edited_script_changed", Callable(this, "_script_changed"));
+	se->connect("request_help", Callable(this, "_help_search"));
+	se->connect("request_open_script_at_line", Callable(this, "_goto_script_line"));
+	se->connect("go_to_help", Callable(this, "_help_class_goto"));
+	se->connect("request_save_history", Callable(this, "_save_history"));
+	se->connect("search_in_files_requested", Callable(this, "_on_find_in_files_requested"));
+	se->connect("replace_in_files_requested", Callable(this, "_on_replace_in_files_requested"));
 
 	//test for modification, maybe the script was not edited but was loaded
 
@@ -2737,7 +2737,7 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 	tab_container->add_child(eh);
 	_go_to_tab(tab_container->get_tab_count() - 1);
 	eh->go_to_class(p_class, 0);
-	eh->connect_compat("go_to_help", this, "_help_class_goto");
+	eh->connect("go_to_help", Callable(this, "_help_class_goto"));
 	_add_recent_script(p_class);
 	_sort_list_on_update = true;
 	_update_script_names();
@@ -2767,7 +2767,7 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 	tab_container->add_child(eh);
 	_go_to_tab(tab_container->get_tab_count() - 1);
 	eh->go_to_help(p_desc);
-	eh->connect_compat("go_to_help", this, "_help_class_goto");
+	eh->connect("go_to_help", Callable(this, "_help_class_goto"));
 	_add_recent_script(eh->get_class());
 	_sort_list_on_update = true;
 	_update_script_names();
@@ -3142,7 +3142,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	filter_scripts = memnew(LineEdit);
 	filter_scripts->set_placeholder(TTR("Filter scripts"));
 	filter_scripts->set_clear_button_enabled(true);
-	filter_scripts->connect_compat("text_changed", this, "_filter_scripts_text_changed");
+	filter_scripts->connect("text_changed", Callable(this, "_filter_scripts_text_changed"));
 	scripts_vbox->add_child(filter_scripts);
 
 	script_list = memnew(ItemList);
@@ -3151,13 +3151,13 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	script_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	script_split->set_split_offset(140);
 	_sort_list_on_update = true;
-	script_list->connect_compat("gui_input", this, "_script_list_gui_input", varray(), CONNECT_DEFERRED);
+	script_list->connect("gui_input", Callable(this, "_script_list_gui_input"), varray(), CONNECT_DEFERRED);
 	script_list->set_allow_rmb_select(true);
 	script_list->set_drag_forwarding(this);
 
 	context_menu = memnew(PopupMenu);
 	add_child(context_menu);
-	context_menu->connect_compat("id_pressed", this, "_menu_option");
+	context_menu->connect("id_pressed", Callable(this, "_menu_option"));
 	context_menu->set_hide_on_window_lose_focus(true);
 
 	overview_vbox = memnew(VBoxContainer);
@@ -3178,14 +3178,14 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	members_overview_alphabeta_sort_button->set_tooltip(TTR("Toggle alphabetical sorting of the method list."));
 	members_overview_alphabeta_sort_button->set_toggle_mode(true);
 	members_overview_alphabeta_sort_button->set_pressed(EditorSettings::get_singleton()->get("text_editor/tools/sort_members_outline_alphabetically"));
-	members_overview_alphabeta_sort_button->connect_compat("toggled", this, "_toggle_members_overview_alpha_sort");
+	members_overview_alphabeta_sort_button->connect("toggled", Callable(this, "_toggle_members_overview_alpha_sort"));
 
 	buttons_hbox->add_child(members_overview_alphabeta_sort_button);
 
 	filter_methods = memnew(LineEdit);
 	filter_methods->set_placeholder(TTR("Filter methods"));
 	filter_methods->set_clear_button_enabled(true);
-	filter_methods->connect_compat("text_changed", this, "_filter_methods_text_changed");
+	filter_methods->connect("text_changed", Callable(this, "_filter_methods_text_changed"));
 	overview_vbox->add_child(filter_methods);
 
 	members_overview = memnew(ItemList);
@@ -3229,7 +3229,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	recent_scripts = memnew(PopupMenu);
 	recent_scripts->set_name("RecentScripts");
 	file_menu->get_popup()->add_child(recent_scripts);
-	recent_scripts->connect_compat("id_pressed", this, "_open_recent_script");
+	recent_scripts->connect("id_pressed", Callable(this, "_open_recent_script"));
 	_update_recent_scripts();
 
 	file_menu->get_popup()->add_separator();
@@ -3251,7 +3251,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	theme_submenu = memnew(PopupMenu);
 	theme_submenu->set_name("Theme");
 	file_menu->get_popup()->add_child(theme_submenu);
-	theme_submenu->connect_compat("id_pressed", this, "_theme_option");
+	theme_submenu->connect("id_pressed", Callable(this, "_theme_option"));
 	theme_submenu->add_shortcut(ED_SHORTCUT("script_editor/import_theme", TTR("Import Theme...")), THEME_IMPORT);
 	theme_submenu->add_shortcut(ED_SHORTCUT("script_editor/reload_theme", TTR("Reload Theme")), THEME_RELOAD);
 
@@ -3270,14 +3270,14 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	file_menu->get_popup()->add_separator();
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/toggle_scripts_panel", TTR("Toggle Scripts Panel"), KEY_MASK_CMD | KEY_BACKSLASH), TOGGLE_SCRIPTS_PANEL);
-	file_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	file_menu->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	script_search_menu = memnew(MenuButton);
 	menu_hb->add_child(script_search_menu);
 	script_search_menu->set_text(TTR("Search"));
 	script_search_menu->set_switch_on_hover(true);
 	script_search_menu->get_popup()->set_hide_on_window_lose_focus(true);
-	script_search_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	script_search_menu->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	MenuButton *debug_menu = memnew(MenuButton);
 	menu_hb->add_child(debug_menu);
@@ -3285,10 +3285,10 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	EditorDebuggerNode *debugger = EditorDebuggerNode::get_singleton();
 	debugger->set_script_debug_button(debug_menu);
-	debugger->connect_compat("goto_script_line", this, "_goto_script_line");
-	debugger->connect_compat("set_execution", this, "_set_execution");
-	debugger->connect_compat("clear_execution", this, "_clear_execution");
-	debugger->connect_compat("breaked", this, "_breaked");
+	debugger->connect("goto_script_line", Callable(this, "_goto_script_line"));
+	debugger->connect("set_execution", Callable(this, "_set_execution"));
+	debugger->connect("clear_execution", Callable(this, "_clear_execution"));
+	debugger->connect("breaked", Callable(this, "_breaked"));
 
 	menu_hb->add_spacer();
 
@@ -3304,54 +3304,54 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	site_search = memnew(ToolButton);
 	site_search->set_text(TTR("Online Docs"));
-	site_search->connect_compat("pressed", this, "_menu_option", varray(SEARCH_WEBSITE));
+	site_search->connect("pressed", Callable(this, "_menu_option"), varray(SEARCH_WEBSITE));
 	menu_hb->add_child(site_search);
 	site_search->set_tooltip(TTR("Open Godot online documentation."));
 
 	request_docs = memnew(ToolButton);
 	request_docs->set_text(TTR("Request Docs"));
-	request_docs->connect_compat("pressed", this, "_menu_option", varray(REQUEST_DOCS));
+	request_docs->connect("pressed", Callable(this, "_menu_option"), varray(REQUEST_DOCS));
 	menu_hb->add_child(request_docs);
 	request_docs->set_tooltip(TTR("Help improve the Godot documentation by giving feedback."));
 
 	help_search = memnew(ToolButton);
 	help_search->set_text(TTR("Search Help"));
-	help_search->connect_compat("pressed", this, "_menu_option", varray(SEARCH_HELP));
+	help_search->connect("pressed", Callable(this, "_menu_option"), varray(SEARCH_HELP));
 	menu_hb->add_child(help_search);
 	help_search->set_tooltip(TTR("Search the reference documentation."));
 
 	menu_hb->add_child(memnew(VSeparator));
 
 	script_back = memnew(ToolButton);
-	script_back->connect_compat("pressed", this, "_history_back");
+	script_back->connect("pressed", Callable(this, "_history_back"));
 	menu_hb->add_child(script_back);
 	script_back->set_disabled(true);
 	script_back->set_tooltip(TTR("Go to previous edited document."));
 
 	script_forward = memnew(ToolButton);
-	script_forward->connect_compat("pressed", this, "_history_forward");
+	script_forward->connect("pressed", Callable(this, "_history_forward"));
 	menu_hb->add_child(script_forward);
 	script_forward->set_disabled(true);
 	script_forward->set_tooltip(TTR("Go to next edited document."));
 
-	tab_container->connect_compat("tab_changed", this, "_tab_changed");
+	tab_container->connect("tab_changed", Callable(this, "_tab_changed"));
 
 	erase_tab_confirm = memnew(ConfirmationDialog);
 	erase_tab_confirm->get_ok()->set_text(TTR("Save"));
 	erase_tab_confirm->add_button(TTR("Discard"), OS::get_singleton()->get_swap_ok_cancel(), "discard");
-	erase_tab_confirm->connect_compat("confirmed", this, "_close_current_tab");
-	erase_tab_confirm->connect_compat("custom_action", this, "_close_discard_current_tab");
+	erase_tab_confirm->connect("confirmed", Callable(this, "_close_current_tab"));
+	erase_tab_confirm->connect("custom_action", Callable(this, "_close_discard_current_tab"));
 	add_child(erase_tab_confirm);
 
 	script_create_dialog = memnew(ScriptCreateDialog);
 	script_create_dialog->set_title(TTR("Create Script"));
 	add_child(script_create_dialog);
-	script_create_dialog->connect_compat("script_created", this, "_script_created");
+	script_create_dialog->connect("script_created", Callable(this, "_script_created"));
 
 	file_dialog_option = -1;
 	file_dialog = memnew(EditorFileDialog);
 	add_child(file_dialog);
-	file_dialog->connect_compat("file_selected", this, "_file_dialog_action");
+	file_dialog->connect("file_selected", Callable(this, "_file_dialog_action"));
 
 	error_dialog = memnew(AcceptDialog);
 	add_child(error_dialog);
@@ -3369,11 +3369,11 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 		vbc->add_child(disk_changed_list);
 		disk_changed_list->set_v_size_flags(SIZE_EXPAND_FILL);
 
-		disk_changed->connect_compat("confirmed", this, "_reload_scripts");
+		disk_changed->connect("confirmed", Callable(this, "_reload_scripts"));
 		disk_changed->get_ok()->set_text(TTR("Reload"));
 
 		disk_changed->add_button(TTR("Resave"), !OS::get_singleton()->get_swap_ok_cancel(), "resave");
-		disk_changed->connect_compat("custom_action", this, "_resave_scripts");
+		disk_changed->connect("custom_action", Callable(this, "_resave_scripts"));
 	}
 
 	add_child(disk_changed);
@@ -3382,25 +3382,25 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	autosave_timer = memnew(Timer);
 	autosave_timer->set_one_shot(false);
-	autosave_timer->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, "_update_autosave_timer");
-	autosave_timer->connect_compat("timeout", this, "_autosave_scripts");
+	autosave_timer->connect(SceneStringNames::get_singleton()->tree_entered, Callable(this, "_update_autosave_timer"));
+	autosave_timer->connect("timeout", Callable(this, "_autosave_scripts"));
 	add_child(autosave_timer);
 
 	grab_focus_block = false;
 
 	help_search_dialog = memnew(EditorHelpSearch);
 	add_child(help_search_dialog);
-	help_search_dialog->connect_compat("go_to_help", this, "_help_class_goto");
+	help_search_dialog->connect("go_to_help", Callable(this, "_help_class_goto"));
 
 	find_in_files_dialog = memnew(FindInFilesDialog);
-	find_in_files_dialog->connect_compat(FindInFilesDialog::SIGNAL_FIND_REQUESTED, this, "_start_find_in_files", varray(false));
-	find_in_files_dialog->connect_compat(FindInFilesDialog::SIGNAL_REPLACE_REQUESTED, this, "_start_find_in_files", varray(true));
+	find_in_files_dialog->connect(FindInFilesDialog::SIGNAL_FIND_REQUESTED, Callable(this, "_start_find_in_files"), varray(false));
+	find_in_files_dialog->connect(FindInFilesDialog::SIGNAL_REPLACE_REQUESTED, Callable(this, "_start_find_in_files"), varray(true));
 	add_child(find_in_files_dialog);
 	find_in_files = memnew(FindInFilesPanel);
 	find_in_files_button = editor->add_bottom_panel_item(TTR("Search Results"), find_in_files);
 	find_in_files->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
-	find_in_files->connect_compat(FindInFilesPanel::SIGNAL_RESULT_SELECTED, this, "_on_find_in_files_result_selected");
-	find_in_files->connect_compat(FindInFilesPanel::SIGNAL_FILES_MODIFIED, this, "_on_find_in_files_modified_files");
+	find_in_files->connect(FindInFilesPanel::SIGNAL_RESULT_SELECTED, Callable(this, "_on_find_in_files_result_selected"));
+	find_in_files->connect(FindInFilesPanel::SIGNAL_FILES_MODIFIED, Callable(this, "_on_find_in_files_modified_files"));
 	find_in_files->hide();
 	find_in_files_button->hide();
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1774,12 +1774,12 @@ ScriptTextEditor::ScriptTextEditor() {
 	editor_box->add_child(code_editor);
 	code_editor->add_constant_override("separation", 2);
 	code_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
-	code_editor->connect_compat("validate_script", this, "_validate_script");
-	code_editor->connect_compat("load_theme_settings", this, "_load_theme_settings");
+	code_editor->connect("validate_script", Callable(this, "_validate_script"));
+	code_editor->connect("load_theme_settings", Callable(this, "_load_theme_settings"));
 	code_editor->set_code_complete_func(_code_complete_scripts, this);
-	code_editor->get_text_edit()->connect_compat("breakpoint_toggled", this, "_breakpoint_toggled");
-	code_editor->get_text_edit()->connect_compat("symbol_lookup", this, "_lookup_symbol");
-	code_editor->get_text_edit()->connect_compat("info_clicked", this, "_lookup_connections");
+	code_editor->get_text_edit()->connect("breakpoint_toggled", Callable(this, "_breakpoint_toggled"));
+	code_editor->get_text_edit()->connect("symbol_lookup", Callable(this, "_lookup_symbol"));
+	code_editor->get_text_edit()->connect("info_clicked", Callable(this, "_lookup_connections"));
 	code_editor->set_v_size_flags(SIZE_EXPAND_FILL);
 	code_editor->show_toggle_scripts_button();
 
@@ -1792,9 +1792,9 @@ ScriptTextEditor::ScriptTextEditor() {
 	warnings_panel->set_focus_mode(FOCUS_CLICK);
 	warnings_panel->hide();
 
-	code_editor->connect_compat("error_pressed", this, "_error_pressed");
-	code_editor->connect_compat("show_warnings_panel", this, "_show_warnings_panel");
-	warnings_panel->connect_compat("meta_clicked", this, "_warning_clicked");
+	code_editor->connect("error_pressed", Callable(this, "_error_pressed"));
+	code_editor->connect("show_warnings_panel", Callable(this, "_show_warnings_panel"));
+	warnings_panel->connect("meta_clicked", Callable(this, "_warning_clicked"));
 
 	update_settings();
 
@@ -1804,11 +1804,11 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	code_editor->get_text_edit()->set_select_identifiers_on_hover(true);
 	code_editor->get_text_edit()->set_context_menu_enabled(false);
-	code_editor->get_text_edit()->connect_compat("gui_input", this, "_text_edit_gui_input");
+	code_editor->get_text_edit()->connect("gui_input", Callable(this, "_text_edit_gui_input"));
 
 	context_menu = memnew(PopupMenu);
 	add_child(context_menu);
-	context_menu->connect_compat("id_pressed", this, "_edit_option");
+	context_menu->connect("id_pressed", Callable(this, "_edit_option"));
 	context_menu->set_hide_on_window_lose_focus(true);
 
 	color_panel = memnew(PopupPanel);
@@ -1816,7 +1816,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	color_picker = memnew(ColorPicker);
 	color_picker->set_deferred_mode(true);
 	color_panel->add_child(color_picker);
-	color_picker->connect_compat("color_changed", this, "_color_changed");
+	color_picker->connect("color_changed", Callable(this, "_color_changed"));
 
 	// get default color picker mode from editor settings
 	int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
@@ -1857,7 +1857,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_spaces"), EDIT_CONVERT_INDENT_TO_SPACES);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_tabs"), EDIT_CONVERT_INDENT_TO_TABS);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/auto_indent"), EDIT_AUTO_INDENT);
-	edit_menu->get_popup()->connect_compat("id_pressed", this, "_edit_option");
+	edit_menu->get_popup()->connect("id_pressed", Callable(this, "_edit_option"));
 	edit_menu->get_popup()->add_separator();
 
 	PopupMenu *convert_case = memnew(PopupMenu);
@@ -1867,7 +1867,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/convert_to_uppercase", TTR("Uppercase"), KEY_MASK_SHIFT | KEY_F4), EDIT_TO_UPPERCASE);
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/convert_to_lowercase", TTR("Lowercase"), KEY_MASK_SHIFT | KEY_F5), EDIT_TO_LOWERCASE);
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/capitalize", TTR("Capitalize"), KEY_MASK_SHIFT | KEY_F6), EDIT_CAPITALIZE);
-	convert_case->connect_compat("id_pressed", this, "_edit_option");
+	convert_case->connect("id_pressed", Callable(this, "_edit_option"));
 
 	highlighters[TTR("Standard")] = NULL;
 	highlighter_menu = memnew(PopupMenu);
@@ -1875,7 +1875,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	edit_menu->get_popup()->add_child(highlighter_menu);
 	edit_menu->get_popup()->add_submenu_item(TTR("Syntax Highlighter"), "highlighter_menu");
 	highlighter_menu->add_radio_check_item(TTR("Standard"));
-	highlighter_menu->connect_compat("id_pressed", this, "_change_syntax_highlighter");
+	highlighter_menu->connect("id_pressed", Callable(this, "_change_syntax_highlighter"));
 
 	search_menu = memnew(MenuButton);
 	edit_hb->add_child(search_menu);
@@ -1891,7 +1891,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace_in_files"), REPLACE_IN_FILES);
 	search_menu->get_popup()->add_separator();
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/contextual_help"), HELP_CONTEXTUAL);
-	search_menu->get_popup()->connect_compat("id_pressed", this, "_edit_option");
+	search_menu->get_popup()->connect("id_pressed", Callable(this, "_edit_option"));
 
 	edit_hb->add_child(edit_menu);
 
@@ -1899,7 +1899,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	edit_hb->add_child(goto_menu);
 	goto_menu->set_text(TTR("Go To"));
 	goto_menu->set_switch_on_hover(true);
-	goto_menu->get_popup()->connect_compat("id_pressed", this, "_edit_option");
+	goto_menu->get_popup()->connect("id_pressed", Callable(this, "_edit_option"));
 
 	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_function"), SEARCH_LOCATE_FUNCTION);
 	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
@@ -1910,20 +1910,20 @@ ScriptTextEditor::ScriptTextEditor() {
 	goto_menu->get_popup()->add_child(bookmarks_menu);
 	goto_menu->get_popup()->add_submenu_item(TTR("Bookmarks"), "Bookmarks");
 	_update_bookmark_list();
-	bookmarks_menu->connect_compat("about_to_show", this, "_update_bookmark_list");
-	bookmarks_menu->connect_compat("index_pressed", this, "_bookmark_item_pressed");
+	bookmarks_menu->connect("about_to_show", Callable(this, "_update_bookmark_list"));
+	bookmarks_menu->connect("index_pressed", Callable(this, "_bookmark_item_pressed"));
 
 	breakpoints_menu = memnew(PopupMenu);
 	breakpoints_menu->set_name("Breakpoints");
 	goto_menu->get_popup()->add_child(breakpoints_menu);
 	goto_menu->get_popup()->add_submenu_item(TTR("Breakpoints"), "Breakpoints");
 	_update_breakpoint_list();
-	breakpoints_menu->connect_compat("about_to_show", this, "_update_breakpoint_list");
-	breakpoints_menu->connect_compat("index_pressed", this, "_breakpoint_item_pressed");
+	breakpoints_menu->connect("about_to_show", Callable(this, "_update_breakpoint_list"));
+	breakpoints_menu->connect("index_pressed", Callable(this, "_breakpoint_item_pressed"));
 
 	quick_open = memnew(ScriptEditorQuickOpen);
 	add_child(quick_open);
-	quick_open->connect_compat("goto_line", this, "_goto_line");
+	quick_open->connect("goto_line", Callable(this, "_goto_line"));
 
 	goto_line_dialog = memnew(GotoLineDialog);
 	add_child(goto_line_dialog);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -607,8 +607,8 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	shader_editor->add_constant_override("separation", 0);
 	shader_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 
-	shader_editor->connect_compat("script_changed", this, "apply_shaders");
-	EditorSettings::get_singleton()->connect_compat("settings_changed", this, "_editor_settings_changed");
+	shader_editor->connect("script_changed", Callable(this, "apply_shaders"));
+	EditorSettings::get_singleton()->connect("settings_changed", Callable(this, "_editor_settings_changed"));
 
 	shader_editor->get_text_edit()->set_callhint_settings(
 			EditorSettings::get_singleton()->get("text_editor/completion/put_callhint_tooltip_below_current_line"),
@@ -616,13 +616,13 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 
 	shader_editor->get_text_edit()->set_select_identifiers_on_hover(true);
 	shader_editor->get_text_edit()->set_context_menu_enabled(false);
-	shader_editor->get_text_edit()->connect_compat("gui_input", this, "_text_edit_gui_input");
+	shader_editor->get_text_edit()->connect("gui_input", Callable(this, "_text_edit_gui_input"));
 
 	shader_editor->update_editor_settings();
 
 	context_menu = memnew(PopupMenu);
 	add_child(context_menu);
-	context_menu->connect_compat("id_pressed", this, "_menu_option");
+	context_menu->connect("id_pressed", Callable(this, "_menu_option"));
 	context_menu->set_hide_on_window_lose_focus(true);
 
 	VBoxContainer *main_container = memnew(VBoxContainer);
@@ -650,7 +650,7 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/clone_down"), EDIT_CLONE_DOWN);
 	edit_menu->get_popup()->add_separator();
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/complete_symbol"), EDIT_COMPLETE);
-	edit_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	edit_menu->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	search_menu = memnew(MenuButton);
 	search_menu->set_text(TTR("Search"));
@@ -660,12 +660,12 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_next"), SEARCH_FIND_NEXT);
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_previous"), SEARCH_FIND_PREV);
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/replace"), SEARCH_REPLACE);
-	search_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	search_menu->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	MenuButton *goto_menu = memnew(MenuButton);
 	goto_menu->set_text(TTR("Go To"));
 	goto_menu->set_switch_on_hover(true);
-	goto_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	goto_menu->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
 	goto_menu->get_popup()->add_separator();
@@ -675,14 +675,14 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	goto_menu->get_popup()->add_child(bookmarks_menu);
 	goto_menu->get_popup()->add_submenu_item(TTR("Bookmarks"), "Bookmarks");
 	_update_bookmark_list();
-	bookmarks_menu->connect_compat("about_to_show", this, "_update_bookmark_list");
-	bookmarks_menu->connect_compat("index_pressed", this, "_bookmark_item_pressed");
+	bookmarks_menu->connect("about_to_show", Callable(this, "_update_bookmark_list"));
+	bookmarks_menu->connect("index_pressed", Callable(this, "_bookmark_item_pressed"));
 
 	help_menu = memnew(MenuButton);
 	help_menu->set_text(TTR("Help"));
 	help_menu->set_switch_on_hover(true);
 	help_menu->get_popup()->add_icon_item(p_node->get_gui_base()->get_icon("Instance", "EditorIcons"), TTR("Online Docs"), HELP_DOCS);
-	help_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	help_menu->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	add_child(main_container);
 	main_container->add_child(hbc);
@@ -705,11 +705,11 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	dl->set_text(TTR("This shader has been modified on on disk.\nWhat action should be taken?"));
 	vbc->add_child(dl);
 
-	disk_changed->connect_compat("confirmed", this, "_reload_shader_from_disk");
+	disk_changed->connect("confirmed", Callable(this, "_reload_shader_from_disk"));
 	disk_changed->get_ok()->set_text(TTR("Reload"));
 
 	disk_changed->add_button(TTR("Resave"), !OS::get_singleton()->get_swap_ok_cancel(), "resave");
-	disk_changed->connect_compat("custom_action", this, "save_external_data");
+	disk_changed->connect("custom_action", Callable(this, "save_external_data"));
 
 	add_child(disk_changed);
 

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -110,7 +110,7 @@ Skeleton2DEditor::Skeleton2DEditor() {
 	options->get_popup()->add_item(TTR("Set Bones to Rest Pose"), MENU_OPTION_SET_REST);
 	options->set_switch_on_hover(true);
 
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);

--- a/editor/plugins/skeleton_editor_plugin.cpp
+++ b/editor/plugins/skeleton_editor_plugin.cpp
@@ -137,7 +137,7 @@ void SkeletonEditor::edit(Skeleton *p_node) {
 
 void SkeletonEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		get_tree()->connect_compat("node_removed", this, "_node_removed");
+		get_tree()->connect("node_removed", Callable(this, "_node_removed"));
 	}
 }
 
@@ -164,7 +164,7 @@ SkeletonEditor::SkeletonEditor() {
 
 	options->get_popup()->add_item(TTR("Create physical skeleton"), MENU_OPTION_CREATE_PHYSICAL_SKELETON);
 
-	options->get_popup()->connect_compat("id_pressed", this, "_on_click_option");
+	options->get_popup()->connect("id_pressed", Callable(this, "_on_click_option"));
 	options->hide();
 }
 

--- a/editor/plugins/skeleton_ik_editor_plugin.cpp
+++ b/editor/plugins/skeleton_ik_editor_plugin.cpp
@@ -93,7 +93,7 @@ SkeletonIKEditorPlugin::SkeletonIKEditorPlugin(EditorNode *p_node) {
 	play_btn->set_text(TTR("Play IK"));
 	play_btn->set_toggle_mode(true);
 	play_btn->hide();
-	play_btn->connect_compat("pressed", this, "_play");
+	play_btn->connect("pressed", Callable(this, "_play"));
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, play_btn);
 	skeleton_ik = NULL;
 }

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2187,10 +2187,10 @@ void SpatialEditorViewport::_notification(int p_what) {
 			if (cam != NULL && cam != previewing) {
 				//then switch the viewport's camera to the scene's viewport camera
 				if (previewing != NULL) {
-					previewing->disconnect_compat("tree_exited", this, "_preview_exited_scene");
+					previewing->disconnect("tree_exited", Callable(this, "_preview_exited_scene"));
 				}
 				previewing = cam;
-				previewing->connect_compat("tree_exited", this, "_preview_exited_scene");
+				previewing->connect("tree_exited", Callable(this, "_preview_exited_scene"));
 				VS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), cam->get_camera());
 				surface->update();
 			}
@@ -2331,12 +2331,12 @@ void SpatialEditorViewport::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		surface->connect_compat("draw", this, "_draw");
-		surface->connect_compat("gui_input", this, "_sinput");
-		surface->connect_compat("mouse_entered", this, "_surface_mouse_enter");
-		surface->connect_compat("mouse_exited", this, "_surface_mouse_exit");
-		surface->connect_compat("focus_entered", this, "_surface_focus_enter");
-		surface->connect_compat("focus_exited", this, "_surface_focus_exit");
+		surface->connect("draw", Callable(this, "_draw"));
+		surface->connect("gui_input", Callable(this, "_sinput"));
+		surface->connect("mouse_entered", Callable(this, "_surface_mouse_enter"));
+		surface->connect("mouse_exited", Callable(this, "_surface_mouse_exit"));
+		surface->connect("focus_entered", Callable(this, "_surface_focus_enter"));
+		surface->connect("focus_exited", Callable(this, "_surface_focus_exit"));
 
 		_init_gizmo_instance(index);
 	}
@@ -2837,10 +2837,10 @@ void SpatialEditorViewport::_menu_option(int p_option) {
 
 void SpatialEditorViewport::_preview_exited_scene() {
 
-	preview_camera->disconnect_compat("toggled", this, "_toggle_camera_preview");
+	preview_camera->disconnect("toggled", Callable(this, "_toggle_camera_preview"));
 	preview_camera->set_pressed(false);
 	_toggle_camera_preview(false);
-	preview_camera->connect_compat("toggled", this, "_toggle_camera_preview");
+	preview_camera->connect("toggled", Callable(this, "_toggle_camera_preview"));
 	view_menu->show();
 }
 
@@ -2903,7 +2903,7 @@ void SpatialEditorViewport::_toggle_camera_preview(bool p_activate) {
 
 	if (!p_activate) {
 
-		previewing->disconnect_compat("tree_exiting", this, "_preview_exited_scene");
+		previewing->disconnect("tree_exiting", Callable(this, "_preview_exited_scene"));
 		previewing = NULL;
 		VS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), camera->get_camera()); //restore
 		if (!preview)
@@ -2914,7 +2914,7 @@ void SpatialEditorViewport::_toggle_camera_preview(bool p_activate) {
 	} else {
 
 		previewing = preview;
-		previewing->connect_compat("tree_exiting", this, "_preview_exited_scene");
+		previewing->connect("tree_exiting", Callable(this, "_preview_exited_scene"));
 		VS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), preview->get_camera()); //replace
 		view_menu->set_disabled(true);
 		surface->update();
@@ -2925,7 +2925,7 @@ void SpatialEditorViewport::_toggle_cinema_preview(bool p_activate) {
 	previewing_cinema = p_activate;
 	if (!previewing_cinema) {
 		if (previewing != NULL)
-			previewing->disconnect_compat("tree_exited", this, "_preview_exited_scene");
+			previewing->disconnect("tree_exited", Callable(this, "_preview_exited_scene"));
 
 		previewing = NULL;
 		VS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), camera->get_camera()); //restore
@@ -3110,14 +3110,14 @@ void SpatialEditorViewport::set_state(const Dictionary &p_state) {
 		view_menu->get_popup()->set_item_checked(idx, previewing_cinema);
 	}
 
-	if (preview_camera->is_connected_compat("toggled", this, "_toggle_camera_preview")) {
-		preview_camera->disconnect_compat("toggled", this, "_toggle_camera_preview");
+	if (preview_camera->is_connected("toggled", Callable(this, "_toggle_camera_preview"))) {
+		preview_camera->disconnect("toggled", Callable(this, "_toggle_camera_preview"));
 	}
 	if (p_state.has("previewing")) {
 		Node *pv = EditorNode::get_singleton()->get_edited_scene()->get_node(p_state["previewing"]);
 		if (Object::cast_to<Camera>(pv)) {
 			previewing = Object::cast_to<Camera>(pv);
-			previewing->connect_compat("tree_exiting", this, "_preview_exited_scene");
+			previewing->connect("tree_exiting", Callable(this, "_preview_exited_scene"));
 			VS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), previewing->get_camera()); //replace
 			view_menu->set_disabled(true);
 			surface->update();
@@ -3125,7 +3125,7 @@ void SpatialEditorViewport::set_state(const Dictionary &p_state) {
 			preview_camera->show();
 		}
 	}
-	preview_camera->connect_compat("toggled", this, "_toggle_camera_preview");
+	preview_camera->connect("toggled", Callable(this, "_toggle_camera_preview"));
 }
 
 Dictionary SpatialEditorViewport::get_state() const {
@@ -3684,8 +3684,8 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_selection"), VIEW_CENTER_TO_SELECTION);
 	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_transform_with_view"), VIEW_ALIGN_TRANSFORM_WITH_VIEW);
 	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_rotation_with_view"), VIEW_ALIGN_ROTATION_WITH_VIEW);
-	view_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
-	display_submenu->connect_compat("id_pressed", this, "_menu_option");
+	view_menu->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
+	display_submenu->connect("id_pressed", Callable(this, "_menu_option"));
 	view_menu->set_disable_shortcuts(true);
 
 	if (OS::get_singleton()->get_current_video_driver() == OS::VIDEO_DRIVER_GLES2) {
@@ -3720,7 +3720,7 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	vbox->add_child(preview_camera);
 	preview_camera->set_h_size_flags(0);
 	preview_camera->hide();
-	preview_camera->connect_compat("toggled", this, "_toggle_camera_preview");
+	preview_camera->connect("toggled", Callable(this, "_toggle_camera_preview"));
 	previewing = NULL;
 	gizmo_scale = 1.0;
 
@@ -3773,8 +3773,8 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	selection_menu = memnew(PopupMenu);
 	add_child(selection_menu);
 	selection_menu->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
-	selection_menu->connect_compat("id_pressed", this, "_selection_result_pressed");
-	selection_menu->connect_compat("popup_hide", this, "_selection_menu_hide");
+	selection_menu->connect("id_pressed", Callable(this, "_selection_result_pressed"));
+	selection_menu->connect("popup_hide", Callable(this, "_selection_menu_hide"));
 
 	if (p_index == 0) {
 		view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(VIEW_AUDIO_LISTENER), true);
@@ -3784,7 +3784,7 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 	name = "";
 	_update_name();
 
-	EditorSettings::get_singleton()->connect_compat("settings_changed", this, "update_transform_gizmo_view");
+	EditorSettings::get_singleton()->connect("settings_changed", Callable(this, "update_transform_gizmo_view"));
 }
 
 //////////////////////////////////////////////////////////////
@@ -5471,12 +5471,12 @@ void SpatialEditor::_notification(int p_what) {
 
 		_refresh_menu_icons();
 
-		get_tree()->connect_compat("node_removed", this, "_node_removed");
-		EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->connect_compat("node_changed", this, "_refresh_menu_icons");
-		editor_selection->connect_compat("selection_changed", this, "_refresh_menu_icons");
+		get_tree()->connect("node_removed", Callable(this, "_node_removed"));
+		EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->connect("node_changed", Callable(this, "_refresh_menu_icons"));
+		editor_selection->connect("selection_changed", Callable(this, "_refresh_menu_icons"));
 
-		editor->connect_compat("stop_pressed", this, "_update_camera_override_button", make_binds(false));
-		editor->connect_compat("play_pressed", this, "_update_camera_override_button", make_binds(true));
+		editor->connect("stop_pressed", Callable(this, "_update_camera_override_button"), make_binds(false));
+		editor->connect("play_pressed", Callable(this, "_update_camera_override_button"), make_binds(true));
 	} else if (p_what == NOTIFICATION_ENTER_TREE) {
 
 		_register_all_gizmos();
@@ -5732,7 +5732,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_SELECT]->set_flat(true);
 	tool_button[TOOL_MODE_SELECT]->set_pressed(true);
 	button_binds.write[0] = MENU_TOOL_SELECT;
-	tool_button[TOOL_MODE_SELECT]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_MODE_SELECT]->connect("pressed", Callable(this, "_menu_item_pressed"), button_binds);
 	tool_button[TOOL_MODE_SELECT]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_select", TTR("Select Mode"), KEY_Q));
 	tool_button[TOOL_MODE_SELECT]->set_tooltip(keycode_get_string(KEY_MASK_CMD) + TTR("Drag: Rotate\nAlt+Drag: Move\nAlt+RMB: Depth list selection"));
 
@@ -5743,7 +5743,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_MOVE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_MOVE]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_MOVE;
-	tool_button[TOOL_MODE_MOVE]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_MODE_MOVE]->connect("pressed", Callable(this, "_menu_item_pressed"), button_binds);
 	tool_button[TOOL_MODE_MOVE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_move", TTR("Move Mode"), KEY_W));
 
 	tool_button[TOOL_MODE_ROTATE] = memnew(ToolButton);
@@ -5751,7 +5751,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_ROTATE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_ROTATE]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_ROTATE;
-	tool_button[TOOL_MODE_ROTATE]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_MODE_ROTATE]->connect("pressed", Callable(this, "_menu_item_pressed"), button_binds);
 	tool_button[TOOL_MODE_ROTATE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_rotate", TTR("Rotate Mode"), KEY_E));
 
 	tool_button[TOOL_MODE_SCALE] = memnew(ToolButton);
@@ -5759,7 +5759,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_SCALE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_SCALE]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_SCALE;
-	tool_button[TOOL_MODE_SCALE]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_MODE_SCALE]->connect("pressed", Callable(this, "_menu_item_pressed"), button_binds);
 	tool_button[TOOL_MODE_SCALE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_scale", TTR("Scale Mode"), KEY_R));
 
 	hbc_menu->add_child(memnew(VSeparator));
@@ -5769,31 +5769,31 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_button[TOOL_MODE_LIST_SELECT]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_LIST_SELECT]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_LIST_SELECT;
-	tool_button[TOOL_MODE_LIST_SELECT]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_MODE_LIST_SELECT]->connect("pressed", Callable(this, "_menu_item_pressed"), button_binds);
 	tool_button[TOOL_MODE_LIST_SELECT]->set_tooltip(TTR("Show a list of all objects at the position clicked\n(same as Alt+RMB in select mode)."));
 
 	tool_button[TOOL_LOCK_SELECTED] = memnew(ToolButton);
 	hbc_menu->add_child(tool_button[TOOL_LOCK_SELECTED]);
 	button_binds.write[0] = MENU_LOCK_SELECTED;
-	tool_button[TOOL_LOCK_SELECTED]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_LOCK_SELECTED]->connect("pressed", Callable(this, "_menu_item_pressed"), button_binds);
 	tool_button[TOOL_LOCK_SELECTED]->set_tooltip(TTR("Lock the selected object in place (can't be moved)."));
 
 	tool_button[TOOL_UNLOCK_SELECTED] = memnew(ToolButton);
 	hbc_menu->add_child(tool_button[TOOL_UNLOCK_SELECTED]);
 	button_binds.write[0] = MENU_UNLOCK_SELECTED;
-	tool_button[TOOL_UNLOCK_SELECTED]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_UNLOCK_SELECTED]->connect("pressed", Callable(this, "_menu_item_pressed"), button_binds);
 	tool_button[TOOL_UNLOCK_SELECTED]->set_tooltip(TTR("Unlock the selected object (can be moved)."));
 
 	tool_button[TOOL_GROUP_SELECTED] = memnew(ToolButton);
 	hbc_menu->add_child(tool_button[TOOL_GROUP_SELECTED]);
 	button_binds.write[0] = MENU_GROUP_SELECTED;
-	tool_button[TOOL_GROUP_SELECTED]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_GROUP_SELECTED]->connect("pressed", Callable(this, "_menu_item_pressed"), button_binds);
 	tool_button[TOOL_GROUP_SELECTED]->set_tooltip(TTR("Makes sure the object's children are not selectable."));
 
 	tool_button[TOOL_UNGROUP_SELECTED] = memnew(ToolButton);
 	hbc_menu->add_child(tool_button[TOOL_UNGROUP_SELECTED]);
 	button_binds.write[0] = MENU_UNGROUP_SELECTED;
-	tool_button[TOOL_UNGROUP_SELECTED]->connect_compat("pressed", this, "_menu_item_pressed", button_binds);
+	tool_button[TOOL_UNGROUP_SELECTED]->connect("pressed", Callable(this, "_menu_item_pressed"), button_binds);
 	tool_button[TOOL_UNGROUP_SELECTED]->set_tooltip(TTR("Restores the object's children's ability to be selected."));
 
 	hbc_menu->add_child(memnew(VSeparator));
@@ -5803,7 +5803,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_LOCAL_COORDS;
-	tool_option_button[TOOL_OPT_LOCAL_COORDS]->connect_compat("toggled", this, "_menu_item_toggled", button_binds);
+	tool_option_button[TOOL_OPT_LOCAL_COORDS]->connect("toggled", Callable(this, "_menu_item_toggled"), button_binds);
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_shortcut(ED_SHORTCUT("spatial_editor/local_coords", TTR("Use Local Space"), KEY_T));
 
 	tool_option_button[TOOL_OPT_USE_SNAP] = memnew(ToolButton);
@@ -5811,7 +5811,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_flat(true);
 	button_binds.write[0] = MENU_TOOL_USE_SNAP;
-	tool_option_button[TOOL_OPT_USE_SNAP]->connect_compat("toggled", this, "_menu_item_toggled", button_binds);
+	tool_option_button[TOOL_OPT_USE_SNAP]->connect("toggled", Callable(this, "_menu_item_toggled"), button_binds);
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_shortcut(ED_SHORTCUT("spatial_editor/snap", TTR("Use Snap"), KEY_Y));
 
 	hbc_menu->add_child(memnew(VSeparator));
@@ -5822,7 +5822,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	tool_option_button[TOOL_OPT_OVERRIDE_CAMERA]->set_flat(true);
 	tool_option_button[TOOL_OPT_OVERRIDE_CAMERA]->set_disabled(true);
 	button_binds.write[0] = MENU_TOOL_OVERRIDE_CAMERA;
-	tool_option_button[TOOL_OPT_OVERRIDE_CAMERA]->connect_compat("toggled", this, "_menu_item_toggled", button_binds);
+	tool_option_button[TOOL_OPT_OVERRIDE_CAMERA]->connect("toggled", Callable(this, "_menu_item_toggled"), button_binds);
 	_update_camera_override_button(false);
 
 	hbc_menu->add_child(memnew(VSeparator));
@@ -5859,7 +5859,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("spatial_editor/configure_snap", TTR("Configure Snap...")), MENU_TRANSFORM_CONFIGURE_SNAP);
 
-	p->connect_compat("id_pressed", this, "_menu_item_pressed");
+	p->connect("id_pressed", Callable(this, "_menu_item_pressed"));
 
 	view_menu = memnew(MenuButton);
 	view_menu->set_text(TTR("View"));
@@ -5891,13 +5891,13 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	p->set_item_checked(p->get_item_index(MENU_VIEW_ORIGIN), true);
 	p->set_item_checked(p->get_item_index(MENU_VIEW_GRID), true);
 
-	p->connect_compat("id_pressed", this, "_menu_item_pressed");
+	p->connect("id_pressed", Callable(this, "_menu_item_pressed"));
 
 	gizmos_menu = memnew(PopupMenu);
 	p->add_child(gizmos_menu);
 	gizmos_menu->set_name("GizmosMenu");
 	gizmos_menu->set_hide_on_checkable_item_selection(false);
-	gizmos_menu->connect_compat("id_pressed", this, "_menu_gizmo_toggled");
+	gizmos_menu->connect("id_pressed", Callable(this, "_menu_gizmo_toggled"));
 
 	/* REST OF MENU */
 
@@ -5914,8 +5914,8 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
 
 		viewports[i] = memnew(SpatialEditorViewport(this, editor, i));
-		viewports[i]->connect_compat("toggle_maximize_view", this, "_toggle_maximize_view");
-		viewports[i]->connect_compat("clicked", this, "_update_camera_override_viewport");
+		viewports[i]->connect("toggle_maximize_view", Callable(this, "_toggle_maximize_view"));
+		viewports[i]->connect("clicked", Callable(this, "_update_camera_override_viewport"));
 		viewports[i]->assign_pending_data_pointers(preview_node, &preview_bounds, accept);
 		viewport_base->add_child(viewports[i]);
 	}
@@ -6030,7 +6030,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	xform_type->add_item(TTR("Post"));
 	xform_vbc->add_child(xform_type);
 
-	xform_dialog->connect_compat("confirmed", this, "_xform_dialog_action");
+	xform_dialog->connect("confirmed", Callable(this, "_xform_dialog_action"));
 
 	scenario_debug = VisualServer::SCENARIO_DEBUG_DISABLED;
 
@@ -6184,7 +6184,7 @@ SpatialEditorPlugin::SpatialEditorPlugin(EditorNode *p_node) {
 	editor->get_viewport()->add_child(spatial_editor);
 
 	spatial_editor->hide();
-	spatial_editor->connect_compat("transform_key_request", editor->get_inspector_dock(), "_transform_keyed");
+	spatial_editor->connect("transform_key_request", Callable(editor->get_inspector_dock(), "_transform_keyed"));
 }
 
 SpatialEditorPlugin::~SpatialEditorPlugin() {

--- a/editor/plugins/sprite_editor_plugin.cpp
+++ b/editor/plugins/sprite_editor_plugin.cpp
@@ -526,7 +526,7 @@ SpriteEditor::SpriteEditor() {
 	options->get_popup()->add_item(TTR("Create LightOccluder2D Sibling"), MENU_OPTION_CREATE_LIGHT_OCCLUDER_2D);
 	options->set_switch_on_hover(true);
 
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);
@@ -542,9 +542,9 @@ SpriteEditor::SpriteEditor() {
 	scroll->set_enable_v_scroll(true);
 	vb->add_margin_child(TTR("Preview:"), scroll, true);
 	debug_uv = memnew(Control);
-	debug_uv->connect_compat("draw", this, "_debug_uv_draw");
+	debug_uv->connect("draw", Callable(this, "_debug_uv_draw"));
 	scroll->add_child(debug_uv);
-	debug_uv_dialog->connect_compat("confirmed", this, "_create_node");
+	debug_uv_dialog->connect("confirmed", Callable(this, "_create_node"));
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->add_child(memnew(Label(TTR("Simplification: "))));
@@ -573,7 +573,7 @@ SpriteEditor::SpriteEditor() {
 	hb->add_spacer();
 	update_preview = memnew(Button);
 	update_preview->set_text(TTR("Update Preview"));
-	update_preview->connect_compat("pressed", this, "_update_mesh_data");
+	update_preview->connect("pressed", Callable(this, "_update_mesh_data"));
 	hb->add_child(update_preview);
 	vb->add_margin_child(TTR("Settings:"), hb);
 

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -905,19 +905,19 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	new_anim = memnew(ToolButton);
 	new_anim->set_tooltip(TTR("New Animation"));
 	hbc_animlist->add_child(new_anim);
-	new_anim->connect_compat("pressed", this, "_animation_add");
+	new_anim->connect("pressed", Callable(this, "_animation_add"));
 
 	remove_anim = memnew(ToolButton);
 	remove_anim->set_tooltip(TTR("Remove Animation"));
 	hbc_animlist->add_child(remove_anim);
-	remove_anim->connect_compat("pressed", this, "_animation_remove");
+	remove_anim->connect("pressed", Callable(this, "_animation_remove"));
 
 	animations = memnew(Tree);
 	sub_vb->add_child(animations);
 	animations->set_v_size_flags(SIZE_EXPAND_FILL);
 	animations->set_hide_root(true);
-	animations->connect_compat("cell_selected", this, "_animation_select");
-	animations->connect_compat("item_edited", this, "_animation_name_edited");
+	animations->connect("cell_selected", Callable(this, "_animation_select"));
+	animations->connect("item_edited", Callable(this, "_animation_name_edited"));
 	animations->set_allow_reselect(true);
 
 	anim_speed = memnew(SpinBox);
@@ -925,12 +925,12 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	anim_speed->set_min(0);
 	anim_speed->set_max(100);
 	anim_speed->set_step(0.01);
-	anim_speed->connect_compat("value_changed", this, "_animation_fps_changed");
+	anim_speed->connect("value_changed", Callable(this, "_animation_fps_changed"));
 
 	anim_loop = memnew(CheckButton);
 	anim_loop->set_text(TTR("Loop"));
 	vbc_animlist->add_child(anim_loop);
-	anim_loop->connect_compat("pressed", this, "_animation_loop_changed");
+	anim_loop->connect("pressed", Callable(this, "_animation_loop_changed"));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
@@ -1004,16 +1004,16 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	dialog = memnew(AcceptDialog);
 	add_child(dialog);
 
-	load->connect_compat("pressed", this, "_load_pressed");
-	load_sheet->connect_compat("pressed", this, "_open_sprite_sheet");
-	_delete->connect_compat("pressed", this, "_delete_pressed");
-	copy->connect_compat("pressed", this, "_copy_pressed");
-	paste->connect_compat("pressed", this, "_paste_pressed");
-	empty->connect_compat("pressed", this, "_empty_pressed");
-	empty2->connect_compat("pressed", this, "_empty2_pressed");
-	move_up->connect_compat("pressed", this, "_up_pressed");
-	move_down->connect_compat("pressed", this, "_down_pressed");
-	file->connect_compat("files_selected", this, "_file_load_request");
+	load->connect("pressed", Callable(this, "_load_pressed"));
+	load_sheet->connect("pressed", Callable(this, "_open_sprite_sheet"));
+	_delete->connect("pressed", Callable(this, "_delete_pressed"));
+	copy->connect("pressed", Callable(this, "_copy_pressed"));
+	paste->connect("pressed", Callable(this, "_paste_pressed"));
+	empty->connect("pressed", Callable(this, "_empty_pressed"));
+	empty2->connect("pressed", Callable(this, "_empty2_pressed"));
+	move_up->connect("pressed", Callable(this, "_up_pressed"));
+	move_down->connect("pressed", Callable(this, "_down_pressed"));
+	file->connect("files_selected", Callable(this, "_file_load_request"));
 	loading_scene = false;
 	sel = -1;
 
@@ -1023,14 +1023,14 @@ SpriteFramesEditor::SpriteFramesEditor() {
 
 	delete_dialog = memnew(ConfirmationDialog);
 	add_child(delete_dialog);
-	delete_dialog->connect_compat("confirmed", this, "_animation_remove_confirmed");
+	delete_dialog->connect("confirmed", Callable(this, "_animation_remove_confirmed"));
 
 	split_sheet_dialog = memnew(ConfirmationDialog);
 	add_child(split_sheet_dialog);
 	VBoxContainer *split_sheet_vb = memnew(VBoxContainer);
 	split_sheet_dialog->add_child(split_sheet_vb);
 	split_sheet_dialog->set_title(TTR("Select Frames"));
-	split_sheet_dialog->connect_compat("confirmed", this, "_sheet_add_frames");
+	split_sheet_dialog->connect("confirmed", Callable(this, "_sheet_add_frames"));
 
 	HBoxContainer *split_sheet_hb = memnew(HBoxContainer);
 
@@ -1041,7 +1041,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_h->set_max(128);
 	split_sheet_h->set_step(1);
 	split_sheet_hb->add_child(split_sheet_h);
-	split_sheet_h->connect_compat("value_changed", this, "_sheet_spin_changed");
+	split_sheet_h->connect("value_changed", Callable(this, "_sheet_spin_changed"));
 
 	ss_label = memnew(Label(TTR("Vertical:")));
 	split_sheet_hb->add_child(ss_label);
@@ -1050,13 +1050,13 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_v->set_max(128);
 	split_sheet_v->set_step(1);
 	split_sheet_hb->add_child(split_sheet_v);
-	split_sheet_v->connect_compat("value_changed", this, "_sheet_spin_changed");
+	split_sheet_v->connect("value_changed", Callable(this, "_sheet_spin_changed"));
 
 	split_sheet_hb->add_spacer();
 
 	Button *select_clear_all = memnew(Button);
 	select_clear_all->set_text(TTR("Select/Clear All Frames"));
-	select_clear_all->connect_compat("pressed", this, "_sheet_select_clear_all_frames");
+	select_clear_all->connect("pressed", Callable(this, "_sheet_select_clear_all_frames"));
 	split_sheet_hb->add_child(select_clear_all);
 
 	split_sheet_vb->add_child(split_sheet_hb);
@@ -1064,8 +1064,8 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_preview = memnew(TextureRect);
 	split_sheet_preview->set_expand(false);
 	split_sheet_preview->set_mouse_filter(MOUSE_FILTER_PASS);
-	split_sheet_preview->connect_compat("draw", this, "_sheet_preview_draw");
-	split_sheet_preview->connect_compat("gui_input", this, "_sheet_preview_input");
+	split_sheet_preview->connect("draw", Callable(this, "_sheet_preview_draw"));
+	split_sheet_preview->connect("gui_input", Callable(this, "_sheet_preview_input"));
 
 	splite_sheet_scroll = memnew(ScrollContainer);
 	splite_sheet_scroll->set_enable_h_scroll(true);
@@ -1083,7 +1083,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	file_split_sheet->set_title(TTR("Create Frames from Sprite Sheet"));
 	file_split_sheet->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 	add_child(file_split_sheet);
-	file_split_sheet->connect_compat("file_selected", this, "_prepare_sprite_sheet");
+	file_split_sheet->connect("file_selected", Callable(this, "_prepare_sprite_sheet"));
 }
 
 void SpriteFramesEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -54,11 +54,11 @@ void EditorInspectorPluginStyleBox::parse_end() {
 void StyleBoxPreview::edit(const Ref<StyleBox> &p_stylebox) {
 
 	if (stylebox.is_valid())
-		stylebox->disconnect_compat("changed", this, "_sb_changed");
+		stylebox->disconnect("changed", Callable(this, "_sb_changed"));
 	stylebox = p_stylebox;
 	if (p_stylebox.is_valid()) {
 		preview->add_style_override("panel", stylebox);
-		stylebox->connect_compat("changed", this, "_sb_changed");
+		stylebox->connect("changed", Callable(this, "_sb_changed"));
 	}
 	_sb_changed();
 }
@@ -91,7 +91,7 @@ StyleBoxPreview::StyleBoxPreview() {
 	preview = memnew(Control);
 	preview->set_custom_minimum_size(Size2(0, 150 * EDSCALE));
 	preview->set_clip_contents(true);
-	preview->connect_compat("draw", this, "_redraw");
+	preview->connect("draw", Callable(this, "_redraw"));
 	add_margin_child(TTR("Preview:"), preview);
 }
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -633,19 +633,19 @@ TextEditor::TextEditor() {
 	code_editor = memnew(CodeTextEditor);
 	add_child(code_editor);
 	code_editor->add_constant_override("separation", 0);
-	code_editor->connect_compat("load_theme_settings", this, "_load_theme_settings");
-	code_editor->connect_compat("validate_script", this, "_validate_script");
+	code_editor->connect("load_theme_settings", Callable(this, "_load_theme_settings"));
+	code_editor->connect("validate_script", Callable(this, "_validate_script"));
 	code_editor->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	code_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	update_settings();
 
 	code_editor->get_text_edit()->set_context_menu_enabled(false);
-	code_editor->get_text_edit()->connect_compat("gui_input", this, "_text_edit_gui_input");
+	code_editor->get_text_edit()->connect("gui_input", Callable(this, "_text_edit_gui_input"));
 
 	context_menu = memnew(PopupMenu);
 	add_child(context_menu);
-	context_menu->connect_compat("id_pressed", this, "_edit_option");
+	context_menu->connect("id_pressed", Callable(this, "_edit_option"));
 
 	edit_hb = memnew(HBoxContainer);
 
@@ -653,7 +653,7 @@ TextEditor::TextEditor() {
 	edit_hb->add_child(search_menu);
 	search_menu->set_text(TTR("Search"));
 	search_menu->set_switch_on_hover(true);
-	search_menu->get_popup()->connect_compat("id_pressed", this, "_edit_option");
+	search_menu->get_popup()->connect("id_pressed", Callable(this, "_edit_option"));
 
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find"), SEARCH_FIND);
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find_next"), SEARCH_FIND_NEXT);
@@ -667,7 +667,7 @@ TextEditor::TextEditor() {
 	edit_hb->add_child(edit_menu);
 	edit_menu->set_text(TTR("Edit"));
 	edit_menu->set_switch_on_hover(true);
-	edit_menu->get_popup()->connect_compat("id_pressed", this, "_edit_option");
+	edit_menu->get_popup()->connect("id_pressed", Callable(this, "_edit_option"));
 
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/undo"), EDIT_UNDO);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/redo"), EDIT_REDO);
@@ -700,7 +700,7 @@ TextEditor::TextEditor() {
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/convert_to_uppercase", TTR("Uppercase")), EDIT_TO_UPPERCASE);
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/convert_to_lowercase", TTR("Lowercase")), EDIT_TO_LOWERCASE);
 	convert_case->add_shortcut(ED_SHORTCUT("script_text_editor/capitalize", TTR("Capitalize")), EDIT_CAPITALIZE);
-	convert_case->connect_compat("id_pressed", this, "_edit_option");
+	convert_case->connect("id_pressed", Callable(this, "_edit_option"));
 
 	highlighters["Standard"] = NULL;
 	highlighter_menu = memnew(PopupMenu);
@@ -708,13 +708,13 @@ TextEditor::TextEditor() {
 	edit_menu->get_popup()->add_child(highlighter_menu);
 	edit_menu->get_popup()->add_submenu_item(TTR("Syntax Highlighter"), "highlighter_menu");
 	highlighter_menu->add_radio_check_item(TTR("Standard"));
-	highlighter_menu->connect_compat("id_pressed", this, "_change_syntax_highlighter");
+	highlighter_menu->connect("id_pressed", Callable(this, "_change_syntax_highlighter"));
 
 	MenuButton *goto_menu = memnew(MenuButton);
 	edit_hb->add_child(goto_menu);
 	goto_menu->set_text(TTR("Go To"));
 	goto_menu->set_switch_on_hover(true);
-	goto_menu->get_popup()->connect_compat("id_pressed", this, "_edit_option");
+	goto_menu->get_popup()->connect("id_pressed", Callable(this, "_edit_option"));
 
 	goto_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_line"), SEARCH_GOTO_LINE);
 	goto_menu->get_popup()->add_separator();
@@ -724,8 +724,8 @@ TextEditor::TextEditor() {
 	goto_menu->get_popup()->add_child(bookmarks_menu);
 	goto_menu->get_popup()->add_submenu_item(TTR("Bookmarks"), "Bookmarks");
 	_update_bookmark_list();
-	bookmarks_menu->connect_compat("about_to_show", this, "_update_bookmark_list");
-	bookmarks_menu->connect_compat("index_pressed", this, "_bookmark_item_pressed");
+	bookmarks_menu->connect("about_to_show", Callable(this, "_update_bookmark_list"));
+	bookmarks_menu->connect("index_pressed", Callable(this, "_bookmark_item_pressed"));
 
 	goto_line_dialog = memnew(GotoLineDialog);
 	add_child(goto_line_dialog);

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -935,7 +935,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	snap_mode_button->add_item(TTR("Grid Snap"), 2);
 	snap_mode_button->add_item(TTR("Auto Slice"), 3);
 	snap_mode_button->select(0);
-	snap_mode_button->connect_compat("item_selected", this, "_set_snap_mode");
+	snap_mode_button->connect("item_selected", Callable(this, "_set_snap_mode"));
 
 	hb_grid = memnew(HBoxContainer);
 	hb_tools->add_child(hb_grid);
@@ -949,7 +949,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	sb_off_x->set_step(1);
 	sb_off_x->set_value(snap_offset.x);
 	sb_off_x->set_suffix("px");
-	sb_off_x->connect_compat("value_changed", this, "_set_snap_off_x");
+	sb_off_x->connect("value_changed", Callable(this, "_set_snap_off_x"));
 	hb_grid->add_child(sb_off_x);
 
 	sb_off_y = memnew(SpinBox);
@@ -958,7 +958,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	sb_off_y->set_step(1);
 	sb_off_y->set_value(snap_offset.y);
 	sb_off_y->set_suffix("px");
-	sb_off_y->connect_compat("value_changed", this, "_set_snap_off_y");
+	sb_off_y->connect("value_changed", Callable(this, "_set_snap_off_y"));
 	hb_grid->add_child(sb_off_y);
 
 	hb_grid->add_child(memnew(VSeparator));
@@ -970,7 +970,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	sb_step_x->set_step(1);
 	sb_step_x->set_value(snap_step.x);
 	sb_step_x->set_suffix("px");
-	sb_step_x->connect_compat("value_changed", this, "_set_snap_step_x");
+	sb_step_x->connect("value_changed", Callable(this, "_set_snap_step_x"));
 	hb_grid->add_child(sb_step_x);
 
 	sb_step_y = memnew(SpinBox);
@@ -979,7 +979,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	sb_step_y->set_step(1);
 	sb_step_y->set_value(snap_step.y);
 	sb_step_y->set_suffix("px");
-	sb_step_y->connect_compat("value_changed", this, "_set_snap_step_y");
+	sb_step_y->connect("value_changed", Callable(this, "_set_snap_step_y"));
 	hb_grid->add_child(sb_step_y);
 
 	hb_grid->add_child(memnew(VSeparator));
@@ -991,7 +991,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	sb_sep_x->set_step(1);
 	sb_sep_x->set_value(snap_separation.x);
 	sb_sep_x->set_suffix("px");
-	sb_sep_x->connect_compat("value_changed", this, "_set_snap_sep_x");
+	sb_sep_x->connect("value_changed", Callable(this, "_set_snap_sep_x"));
 	hb_grid->add_child(sb_sep_x);
 
 	sb_sep_y = memnew(SpinBox);
@@ -1000,7 +1000,7 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	sb_sep_y->set_step(1);
 	sb_sep_y->set_value(snap_separation.y);
 	sb_sep_y->set_suffix("px");
-	sb_sep_y->connect_compat("value_changed", this, "_set_snap_sep_y");
+	sb_sep_y->connect("value_changed", Callable(this, "_set_snap_sep_y"));
 	hb_grid->add_child(sb_sep_y);
 
 	hb_grid->hide();
@@ -1008,8 +1008,8 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 	edit_draw = memnew(Panel);
 	add_child(edit_draw);
 	edit_draw->set_v_size_flags(SIZE_EXPAND_FILL);
-	edit_draw->connect_compat("draw", this, "_region_draw");
-	edit_draw->connect_compat("gui_input", this, "_region_input");
+	edit_draw->connect("draw", Callable(this, "_region_draw"));
+	edit_draw->connect("gui_input", Callable(this, "_region_input"));
 
 	draw_zoom = 1.0;
 	edit_draw->set_clip_contents(true);
@@ -1020,27 +1020,27 @@ TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
 
 	zoom_out = memnew(ToolButton);
 	zoom_out->set_tooltip(TTR("Zoom Out"));
-	zoom_out->connect_compat("pressed", this, "_zoom_out");
+	zoom_out->connect("pressed", Callable(this, "_zoom_out"));
 	zoom_hb->add_child(zoom_out);
 
 	zoom_reset = memnew(ToolButton);
 	zoom_reset->set_tooltip(TTR("Zoom Reset"));
-	zoom_reset->connect_compat("pressed", this, "_zoom_reset");
+	zoom_reset->connect("pressed", Callable(this, "_zoom_reset"));
 	zoom_hb->add_child(zoom_reset);
 
 	zoom_in = memnew(ToolButton);
 	zoom_in->set_tooltip(TTR("Zoom In"));
-	zoom_in->connect_compat("pressed", this, "_zoom_in");
+	zoom_in->connect("pressed", Callable(this, "_zoom_in"));
 	zoom_hb->add_child(zoom_in);
 
 	vscroll = memnew(VScrollBar);
 	vscroll->set_step(0.001);
 	edit_draw->add_child(vscroll);
-	vscroll->connect_compat("value_changed", this, "_scroll_changed");
+	vscroll->connect("value_changed", Callable(this, "_scroll_changed"));
 	hscroll = memnew(HScrollBar);
 	hscroll->set_step(0.001);
 	edit_draw->add_child(hscroll);
-	hscroll->connect_compat("value_changed", this, "_scroll_changed");
+	hscroll->connect("value_changed", Callable(this, "_scroll_changed"));
 
 	updating_scroll = false;
 }
@@ -1125,7 +1125,7 @@ TextureRegionEditorPlugin::TextureRegionEditorPlugin(EditorNode *p_node) {
 	region_editor = memnew(TextureRegionEditor(p_node));
 	region_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 	region_editor->hide();
-	region_editor->connect_compat("visibility_changed", this, "_editor_visiblity_changed");
+	region_editor->connect("visibility_changed", Callable(this, "_editor_visiblity_changed"));
 
 	texture_region_button = p_node->add_bottom_panel_item(TTR("TextureRegion"), region_editor);
 	texture_region_button->hide();

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -629,7 +629,7 @@ ThemeEditor::ThemeEditor() {
 	theme_menu->get_popup()->add_item(TTR("Create Empty Editor Template"), POPUP_CREATE_EDITOR_EMPTY);
 	theme_menu->get_popup()->add_item(TTR("Create From Current Editor Theme"), POPUP_IMPORT_EDITOR_THEME);
 	top_menu->add_child(theme_menu);
-	theme_menu->get_popup()->connect_compat("id_pressed", this, "_theme_menu_cbk");
+	theme_menu->get_popup()->connect("id_pressed", Callable(this, "_theme_menu_cbk"));
 
 	ScrollContainer *scroll = memnew(ScrollContainer);
 	add_child(scroll);
@@ -835,7 +835,7 @@ ThemeEditor::ThemeEditor() {
 	type_menu->set_text("..");
 	type_hbc->add_child(type_menu);
 
-	type_menu->get_popup()->connect_compat("id_pressed", this, "_type_menu_cbk");
+	type_menu->get_popup()->connect("id_pressed", Callable(this, "_type_menu_cbk"));
 
 	l = memnew(Label);
 	l->set_text(TTR("Name:"));
@@ -853,8 +853,8 @@ ThemeEditor::ThemeEditor() {
 	name_menu->set_text("..");
 	name_hbc->add_child(name_menu);
 
-	name_menu->get_popup()->connect_compat("about_to_show", this, "_name_menu_about_to_show");
-	name_menu->get_popup()->connect_compat("id_pressed", this, "_name_menu_cbk");
+	name_menu->get_popup()->connect("about_to_show", Callable(this, "_name_menu_about_to_show"));
+	name_menu->get_popup()->connect("id_pressed", Callable(this, "_name_menu_cbk"));
 
 	type_select_label = memnew(Label);
 	type_select_label->set_text(TTR("Data Type:"));
@@ -869,12 +869,12 @@ ThemeEditor::ThemeEditor() {
 
 	dialog_vbc->add_child(type_select);
 
-	add_del_dialog->get_ok()->connect_compat("pressed", this, "_dialog_cbk");
+	add_del_dialog->get_ok()->connect("pressed", Callable(this, "_dialog_cbk"));
 
 	file_dialog = memnew(EditorFileDialog);
 	file_dialog->add_filter("*.theme ; " + TTR("Theme File"));
 	add_child(file_dialog);
-	file_dialog->connect_compat("file_selected", this, "_save_template_cbk");
+	file_dialog->connect("file_selected", Callable(this, "_save_template_cbk"));
 }
 
 void ThemeEditorPlugin::edit(Object *p_node) {

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -1761,30 +1761,30 @@ void TileMapEditor::edit(Node *p_tile_map) {
 	}
 
 	if (node)
-		node->disconnect_compat("settings_changed", this, "_tileset_settings_changed");
+		node->disconnect("settings_changed", Callable(this, "_tileset_settings_changed"));
 	if (p_tile_map) {
 
 		node = Object::cast_to<TileMap>(p_tile_map);
-		if (!canvas_item_editor_viewport->is_connected_compat("mouse_entered", this, "_canvas_mouse_enter"))
-			canvas_item_editor_viewport->connect_compat("mouse_entered", this, "_canvas_mouse_enter");
-		if (!canvas_item_editor_viewport->is_connected_compat("mouse_exited", this, "_canvas_mouse_exit"))
-			canvas_item_editor_viewport->connect_compat("mouse_exited", this, "_canvas_mouse_exit");
+		if (!canvas_item_editor_viewport->is_connected("mouse_entered", Callable(this, "_canvas_mouse_enter")))
+			canvas_item_editor_viewport->connect("mouse_entered", Callable(this, "_canvas_mouse_enter"));
+		if (!canvas_item_editor_viewport->is_connected("mouse_exited", Callable(this, "_canvas_mouse_exit")))
+			canvas_item_editor_viewport->connect("mouse_exited", Callable(this, "_canvas_mouse_exit"));
 
 		_update_palette();
 
 	} else {
 		node = NULL;
 
-		if (canvas_item_editor_viewport->is_connected_compat("mouse_entered", this, "_canvas_mouse_enter"))
-			canvas_item_editor_viewport->disconnect_compat("mouse_entered", this, "_canvas_mouse_enter");
-		if (canvas_item_editor_viewport->is_connected_compat("mouse_exited", this, "_canvas_mouse_exit"))
-			canvas_item_editor_viewport->disconnect_compat("mouse_exited", this, "_canvas_mouse_exit");
+		if (canvas_item_editor_viewport->is_connected("mouse_entered", Callable(this, "_canvas_mouse_enter")))
+			canvas_item_editor_viewport->disconnect("mouse_entered", Callable(this, "_canvas_mouse_enter"));
+		if (canvas_item_editor_viewport->is_connected("mouse_exited", Callable(this, "_canvas_mouse_exit")))
+			canvas_item_editor_viewport->disconnect("mouse_exited", Callable(this, "_canvas_mouse_exit"));
 
 		_update_palette();
 	}
 
 	if (node)
-		node->connect_compat("settings_changed", this, "_tileset_settings_changed");
+		node->connect("settings_changed", Callable(this, "_tileset_settings_changed"));
 
 	_clear_bucket_cache();
 }
@@ -1939,20 +1939,20 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 
 	manual_button = memnew(CheckBox);
 	manual_button->set_text(TTR("Disable Autotile"));
-	manual_button->connect_compat("toggled", this, "_manual_toggled");
+	manual_button->connect("toggled", Callable(this, "_manual_toggled"));
 	add_child(manual_button);
 
 	priority_button = memnew(CheckBox);
 	priority_button->set_text(TTR("Enable Priority"));
-	priority_button->connect_compat("toggled", this, "_priority_toggled");
+	priority_button->connect("toggled", Callable(this, "_priority_toggled"));
 	add_child(priority_button);
 
 	search_box = memnew(LineEdit);
 	search_box->set_placeholder(TTR("Filter tiles"));
 	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
-	search_box->connect_compat("text_entered", this, "_text_entered");
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_entered", Callable(this, "_text_entered"));
+	search_box->connect("text_changed", Callable(this, "_text_changed"));
+	search_box->connect("gui_input", Callable(this, "_sbox_input"));
 	add_child(search_box);
 
 	size_slider = memnew(HSlider);
@@ -1961,7 +1961,7 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	size_slider->set_max(4.0f);
 	size_slider->set_step(0.1f);
 	size_slider->set_value(1.0f);
-	size_slider->connect_compat("value_changed", this, "_icon_size_changed");
+	size_slider->connect("value_changed", Callable(this, "_icon_size_changed"));
 	add_child(size_slider);
 
 	int mw = EDITOR_DEF("editors/tile_map/palette_min_width", 80);
@@ -1980,8 +1980,8 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	palette->set_max_text_lines(2);
 	palette->set_select_mode(ItemList::SELECT_MULTI);
 	palette->add_constant_override("vseparation", 8 * EDSCALE);
-	palette->connect_compat("item_selected", this, "_palette_selected");
-	palette->connect_compat("multi_selected", this, "_palette_multi_selected");
+	palette->connect("item_selected", Callable(this, "_palette_selected"));
+	palette->connect("multi_selected", Callable(this, "_palette_multi_selected"));
 	palette_container->add_child(palette);
 
 	// Add message for when no texture is selected.
@@ -2015,25 +2015,25 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	paint_button = memnew(ToolButton);
 	paint_button->set_shortcut(ED_SHORTCUT("tile_map_editor/paint_tile", TTR("Paint Tile"), KEY_P));
 	paint_button->set_tooltip(TTR("Shift+LMB: Line Draw\nShift+Ctrl+LMB: Rectangle Paint"));
-	paint_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_NONE));
+	paint_button->connect("pressed", Callable(this, "_button_tool_select"), make_binds(TOOL_NONE));
 	paint_button->set_toggle_mode(true);
 	toolbar->add_child(paint_button);
 
 	bucket_fill_button = memnew(ToolButton);
 	bucket_fill_button->set_shortcut(ED_SHORTCUT("tile_map_editor/bucket_fill", TTR("Bucket Fill"), KEY_G));
-	bucket_fill_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_BUCKET));
+	bucket_fill_button->connect("pressed", Callable(this, "_button_tool_select"), make_binds(TOOL_BUCKET));
 	bucket_fill_button->set_toggle_mode(true);
 	toolbar->add_child(bucket_fill_button);
 
 	picker_button = memnew(ToolButton);
 	picker_button->set_shortcut(ED_SHORTCUT("tile_map_editor/pick_tile", TTR("Pick Tile"), KEY_I));
-	picker_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_PICKING));
+	picker_button->connect("pressed", Callable(this, "_button_tool_select"), make_binds(TOOL_PICKING));
 	picker_button->set_toggle_mode(true);
 	toolbar->add_child(picker_button);
 
 	select_button = memnew(ToolButton);
 	select_button->set_shortcut(ED_SHORTCUT("tile_map_editor/select", TTR("Select"), KEY_M));
-	select_button->connect_compat("pressed", this, "_button_tool_select", make_binds(TOOL_SELECTING));
+	select_button->connect("pressed", Callable(this, "_button_tool_select"), make_binds(TOOL_SELECTING));
 	select_button->set_toggle_mode(true);
 	toolbar->add_child(select_button);
 
@@ -2068,40 +2068,40 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	p->add_shortcut(ED_GET_SHORTCUT("tile_map_editor/erase_selection"), OPTION_ERASE_SELECTION);
 	p->add_separator();
 	p->add_item(TTR("Fix Invalid Tiles"), OPTION_FIX_INVALID);
-	p->connect_compat("id_pressed", this, "_menu_option");
+	p->connect("id_pressed", Callable(this, "_menu_option"));
 
 	rotate_left_button = memnew(ToolButton);
 	rotate_left_button->set_tooltip(TTR("Rotate Left"));
 	rotate_left_button->set_focus_mode(FOCUS_NONE);
-	rotate_left_button->connect_compat("pressed", this, "_rotate", varray(-1));
+	rotate_left_button->connect("pressed", Callable(this, "_rotate"), varray(-1));
 	rotate_left_button->set_shortcut(ED_SHORTCUT("tile_map_editor/rotate_left", TTR("Rotate Left"), KEY_A));
 	tool_hb->add_child(rotate_left_button);
 
 	rotate_right_button = memnew(ToolButton);
 	rotate_right_button->set_tooltip(TTR("Rotate Right"));
 	rotate_right_button->set_focus_mode(FOCUS_NONE);
-	rotate_right_button->connect_compat("pressed", this, "_rotate", varray(1));
+	rotate_right_button->connect("pressed", Callable(this, "_rotate"), varray(1));
 	rotate_right_button->set_shortcut(ED_SHORTCUT("tile_map_editor/rotate_right", TTR("Rotate Right"), KEY_S));
 	tool_hb->add_child(rotate_right_button);
 
 	flip_horizontal_button = memnew(ToolButton);
 	flip_horizontal_button->set_tooltip(TTR("Flip Horizontally"));
 	flip_horizontal_button->set_focus_mode(FOCUS_NONE);
-	flip_horizontal_button->connect_compat("pressed", this, "_flip_horizontal");
+	flip_horizontal_button->connect("pressed", Callable(this, "_flip_horizontal"));
 	flip_horizontal_button->set_shortcut(ED_SHORTCUT("tile_map_editor/flip_horizontal", TTR("Flip Horizontally"), KEY_X));
 	tool_hb->add_child(flip_horizontal_button);
 
 	flip_vertical_button = memnew(ToolButton);
 	flip_vertical_button->set_tooltip(TTR("Flip Vertically"));
 	flip_vertical_button->set_focus_mode(FOCUS_NONE);
-	flip_vertical_button->connect_compat("pressed", this, "_flip_vertical");
+	flip_vertical_button->connect("pressed", Callable(this, "_flip_vertical"));
 	flip_vertical_button->set_shortcut(ED_SHORTCUT("tile_map_editor/flip_vertical", TTR("Flip Vertically"), KEY_Z));
 	tool_hb->add_child(flip_vertical_button);
 
 	clear_transform_button = memnew(ToolButton);
 	clear_transform_button->set_tooltip(TTR("Clear Transform"));
 	clear_transform_button->set_focus_mode(FOCUS_NONE);
-	clear_transform_button->connect_compat("pressed", this, "_clear_transform");
+	clear_transform_button->connect("pressed", Callable(this, "_clear_transform"));
 	clear_transform_button->set_shortcut(ED_SHORTCUT("tile_map_editor/clear_transform", TTR("Clear Transform"), KEY_W));
 	tool_hb->add_child(clear_transform_button);
 

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -358,19 +358,19 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	left_container->add_child(texture_list);
 	texture_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	texture_list->set_custom_minimum_size(Size2(200, 0));
-	texture_list->connect_compat("item_selected", this, "_on_texture_list_selected");
+	texture_list->connect("item_selected", Callable(this, "_on_texture_list_selected"));
 	texture_list->set_drag_forwarding(this);
 
 	HBoxContainer *tileset_toolbar_container = memnew(HBoxContainer);
 	left_container->add_child(tileset_toolbar_container);
 
 	tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE] = memnew(ToolButton);
-	tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]->connect_compat("pressed", this, "_on_tileset_toolbar_button_pressed", varray(TOOL_TILESET_ADD_TEXTURE));
+	tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]->connect("pressed", Callable(this, "_on_tileset_toolbar_button_pressed"), varray(TOOL_TILESET_ADD_TEXTURE));
 	tileset_toolbar_container->add_child(tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]);
 	tileset_toolbar_buttons[TOOL_TILESET_ADD_TEXTURE]->set_tooltip(TTR("Add Texture(s) to TileSet."));
 
 	tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE] = memnew(ToolButton);
-	tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]->connect_compat("pressed", this, "_on_tileset_toolbar_button_pressed", varray(TOOL_TILESET_REMOVE_TEXTURE));
+	tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]->connect("pressed", Callable(this, "_on_tileset_toolbar_button_pressed"), varray(TOOL_TILESET_REMOVE_TEXTURE));
 	tileset_toolbar_container->add_child(tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]);
 	tileset_toolbar_buttons[TOOL_TILESET_REMOVE_TEXTURE]->set_tooltip(TTR("Remove selected Texture from TileSet."));
 
@@ -383,7 +383,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tileset_toolbar_tools->get_popup()->add_item(TTR("Create from Scene"), TOOL_TILESET_CREATE_SCENE);
 	tileset_toolbar_tools->get_popup()->add_item(TTR("Merge from Scene"), TOOL_TILESET_MERGE_SCENE);
 
-	tileset_toolbar_tools->get_popup()->connect_compat("id_pressed", this, "_on_tileset_toolbar_button_pressed");
+	tileset_toolbar_tools->get_popup()->connect("id_pressed", Callable(this, "_on_tileset_toolbar_button_pressed"));
 	tileset_toolbar_container->add_child(tileset_toolbar_tools);
 
 	//---------------
@@ -416,7 +416,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 		tool_workspacemode[i]->set_text(workspace_label[i]);
 		tool_workspacemode[i]->set_toggle_mode(true);
 		tool_workspacemode[i]->set_button_group(g);
-		tool_workspacemode[i]->connect_compat("pressed", this, "_on_workspace_mode_changed", varray(i));
+		tool_workspacemode[i]->connect("pressed", Callable(this, "_on_workspace_mode_changed"), varray(i));
 		tool_hb->add_child(tool_workspacemode[i]);
 	}
 
@@ -429,14 +429,14 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tool_hb->add_child(tools[SELECT_NEXT]);
 	tool_hb->move_child(tools[SELECT_NEXT], WORKSPACE_CREATE_SINGLE);
 	tools[SELECT_NEXT]->set_shortcut(ED_SHORTCUT("tileset_editor/next_shape", TTR("Next Coordinate"), KEY_PAGEDOWN));
-	tools[SELECT_NEXT]->connect_compat("pressed", this, "_on_tool_clicked", varray(SELECT_NEXT));
+	tools[SELECT_NEXT]->connect("pressed", Callable(this, "_on_tool_clicked"), varray(SELECT_NEXT));
 	tools[SELECT_NEXT]->set_tooltip(TTR("Select the next shape, subtile, or Tile."));
 	tools[SELECT_PREVIOUS] = memnew(ToolButton);
 	tool_hb->add_child(tools[SELECT_PREVIOUS]);
 	tool_hb->move_child(tools[SELECT_PREVIOUS], WORKSPACE_CREATE_SINGLE);
 	tools[SELECT_PREVIOUS]->set_shortcut(ED_SHORTCUT("tileset_editor/previous_shape", TTR("Previous Coordinate"), KEY_PAGEUP));
 	tools[SELECT_PREVIOUS]->set_tooltip(TTR("Select the previous shape, subtile, or Tile."));
-	tools[SELECT_PREVIOUS]->connect_compat("pressed", this, "_on_tool_clicked", varray(SELECT_PREVIOUS));
+	tools[SELECT_PREVIOUS]->connect("pressed", Callable(this, "_on_tool_clicked"), varray(SELECT_PREVIOUS));
 
 	VSeparator *separator_shape_selection = memnew(VSeparator);
 	tool_hb->add_child(separator_shape_selection);
@@ -466,7 +466,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 		tool_editmode[i]->set_text(label[i]);
 		tool_editmode[i]->set_toggle_mode(true);
 		tool_editmode[i]->set_button_group(g);
-		tool_editmode[i]->connect_compat("pressed", this, "_on_edit_mode_changed", varray(i));
+		tool_editmode[i]->connect("pressed", Callable(this, "_on_edit_mode_changed"), varray(i));
 		tool_hb->add_child(tool_editmode[i]);
 	}
 	tool_editmode[EDITMODE_COLLISION]->set_pressed(true);
@@ -493,21 +493,21 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tools[TOOL_SELECT]->set_toggle_mode(true);
 	tools[TOOL_SELECT]->set_button_group(tg);
 	tools[TOOL_SELECT]->set_pressed(true);
-	tools[TOOL_SELECT]->connect_compat("pressed", this, "_on_tool_clicked", varray(TOOL_SELECT));
+	tools[TOOL_SELECT]->connect("pressed", Callable(this, "_on_tool_clicked"), varray(TOOL_SELECT));
 
 	separator_bitmask = memnew(VSeparator);
 	toolbar->add_child(separator_bitmask);
 	tools[BITMASK_COPY] = memnew(ToolButton);
 	tools[BITMASK_COPY]->set_tooltip(TTR("Copy bitmask."));
-	tools[BITMASK_COPY]->connect_compat("pressed", this, "_on_tool_clicked", varray(BITMASK_COPY));
+	tools[BITMASK_COPY]->connect("pressed", Callable(this, "_on_tool_clicked"), varray(BITMASK_COPY));
 	toolbar->add_child(tools[BITMASK_COPY]);
 	tools[BITMASK_PASTE] = memnew(ToolButton);
 	tools[BITMASK_PASTE]->set_tooltip(TTR("Paste bitmask."));
-	tools[BITMASK_PASTE]->connect_compat("pressed", this, "_on_tool_clicked", varray(BITMASK_PASTE));
+	tools[BITMASK_PASTE]->connect("pressed", Callable(this, "_on_tool_clicked"), varray(BITMASK_PASTE));
 	toolbar->add_child(tools[BITMASK_PASTE]);
 	tools[BITMASK_CLEAR] = memnew(ToolButton);
 	tools[BITMASK_CLEAR]->set_tooltip(TTR("Erase bitmask."));
-	tools[BITMASK_CLEAR]->connect_compat("pressed", this, "_on_tool_clicked", varray(BITMASK_CLEAR));
+	tools[BITMASK_CLEAR]->connect("pressed", Callable(this, "_on_tool_clicked"), varray(BITMASK_CLEAR));
 	toolbar->add_child(tools[BITMASK_CLEAR]);
 
 	tools[SHAPE_NEW_RECTANGLE] = memnew(ToolButton);
@@ -525,13 +525,13 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	separator_shape_toggle = memnew(VSeparator);
 	toolbar->add_child(separator_shape_toggle);
 	tools[SHAPE_TOGGLE_TYPE] = memnew(ToolButton);
-	tools[SHAPE_TOGGLE_TYPE]->connect_compat("pressed", this, "_on_tool_clicked", varray(SHAPE_TOGGLE_TYPE));
+	tools[SHAPE_TOGGLE_TYPE]->connect("pressed", Callable(this, "_on_tool_clicked"), varray(SHAPE_TOGGLE_TYPE));
 	toolbar->add_child(tools[SHAPE_TOGGLE_TYPE]);
 
 	separator_delete = memnew(VSeparator);
 	toolbar->add_child(separator_delete);
 	tools[SHAPE_DELETE] = memnew(ToolButton);
-	tools[SHAPE_DELETE]->connect_compat("pressed", this, "_on_tool_clicked", varray(SHAPE_DELETE));
+	tools[SHAPE_DELETE]->connect("pressed", Callable(this, "_on_tool_clicked"), varray(SHAPE_DELETE));
 	toolbar->add_child(tools[SHAPE_DELETE]);
 
 	spin_priority = memnew(SpinBox);
@@ -539,7 +539,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	spin_priority->set_max(255);
 	spin_priority->set_step(1);
 	spin_priority->set_custom_minimum_size(Size2(100, 0));
-	spin_priority->connect_compat("value_changed", this, "_on_priority_changed");
+	spin_priority->connect("value_changed", Callable(this, "_on_priority_changed"));
 	spin_priority->hide();
 	toolbar->add_child(spin_priority);
 
@@ -548,7 +548,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	spin_z_index->set_max(VS::CANVAS_ITEM_Z_MAX);
 	spin_z_index->set_step(1);
 	spin_z_index->set_custom_minimum_size(Size2(100, 0));
-	spin_z_index->connect_compat("value_changed", this, "_on_z_index_changed");
+	spin_z_index->connect("value_changed", Callable(this, "_on_z_index_changed"));
 	spin_z_index->hide();
 	toolbar->add_child(spin_z_index);
 
@@ -562,7 +562,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tools[TOOL_GRID_SNAP] = memnew(ToolButton);
 	tools[TOOL_GRID_SNAP]->set_toggle_mode(true);
 	tools[TOOL_GRID_SNAP]->set_tooltip(TTR("Enable snap and show grid (configurable via the Inspector)."));
-	tools[TOOL_GRID_SNAP]->connect_compat("toggled", this, "_on_grid_snap_toggled");
+	tools[TOOL_GRID_SNAP]->connect("toggled", Callable(this, "_on_grid_snap_toggled"));
 	toolbar->add_child(tools[TOOL_GRID_SNAP]);
 
 	Control *separator = memnew(Control);
@@ -570,15 +570,15 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	toolbar->add_child(separator);
 
 	tools[ZOOM_OUT] = memnew(ToolButton);
-	tools[ZOOM_OUT]->connect_compat("pressed", this, "_zoom_out");
+	tools[ZOOM_OUT]->connect("pressed", Callable(this, "_zoom_out"));
 	toolbar->add_child(tools[ZOOM_OUT]);
 	tools[ZOOM_OUT]->set_tooltip(TTR("Zoom Out"));
 	tools[ZOOM_1] = memnew(ToolButton);
-	tools[ZOOM_1]->connect_compat("pressed", this, "_zoom_reset");
+	tools[ZOOM_1]->connect("pressed", Callable(this, "_zoom_reset"));
 	toolbar->add_child(tools[ZOOM_1]);
 	tools[ZOOM_1]->set_tooltip(TTR("Zoom Reset"));
 	tools[ZOOM_IN] = memnew(ToolButton);
-	tools[ZOOM_IN]->connect_compat("pressed", this, "_zoom_in");
+	tools[ZOOM_IN]->connect("pressed", Callable(this, "_zoom_in"));
 	toolbar->add_child(tools[ZOOM_IN]);
 	tools[ZOOM_IN]->set_tooltip(TTR("Zoom In"));
 
@@ -607,13 +607,13 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	scroll->add_child(workspace_container);
 
 	workspace_overlay = memnew(Control);
-	workspace_overlay->connect_compat("draw", this, "_on_workspace_overlay_draw");
+	workspace_overlay->connect("draw", Callable(this, "_on_workspace_overlay_draw"));
 	workspace_container->add_child(workspace_overlay);
 
 	workspace = memnew(Control);
 	workspace->set_focus_mode(FOCUS_ALL);
-	workspace->connect_compat("draw", this, "_on_workspace_draw");
-	workspace->connect_compat("gui_input", this, "_on_workspace_input");
+	workspace->connect("draw", Callable(this, "_on_workspace_draw"));
+	workspace->connect("gui_input", Callable(this, "_on_workspace_input"));
 	workspace->set_draw_behind_parent(true);
 	workspace_overlay->add_child(workspace);
 
@@ -626,7 +626,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	//---------------
 	cd = memnew(ConfirmationDialog);
 	add_child(cd);
-	cd->connect_compat("confirmed", this, "_on_tileset_toolbar_confirm");
+	cd->connect("confirmed", Callable(this, "_on_tileset_toolbar_confirm"));
 
 	//---------------
 	err_dialog = memnew(AcceptDialog);
@@ -645,7 +645,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 		texture_dialog->add_filter("*." + E->get() + " ; " + E->get().to_upper());
 	}
 	add_child(texture_dialog);
-	texture_dialog->connect_compat("files_selected", this, "_on_textures_added");
+	texture_dialog->connect("files_selected", Callable(this, "_on_textures_added"));
 
 	//---------------
 	helper = memnew(TilesetEditorContext(this));
@@ -3548,11 +3548,11 @@ void TileSetEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		tileset_editor_button->show();
 		editor->make_bottom_panel_item_visible(tileset_editor);
-		get_tree()->connect_compat("idle_frame", tileset_editor, "_on_workspace_process");
+		get_tree()->connect("idle_frame", Callable(tileset_editor, "_on_workspace_process"));
 	} else {
 		editor->hide_bottom_panel();
 		tileset_editor_button->hide();
-		get_tree()->disconnect_compat("idle_frame", tileset_editor, "_on_workspace_process");
+		get_tree()->disconnect("idle_frame", Callable(tileset_editor, "_on_workspace_process"));
 	}
 }
 

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -127,7 +127,7 @@ void VersionControlEditorPlugin::_initialize_vcs() {
 	vcs_interface->set_script_and_instance(script, addon_script_instance);
 
 	EditorVCSInterface::set_singleton(vcs_interface);
-	EditorFileSystem::get_singleton()->connect_compat("filesystem_changed", this, "_refresh_stage_area");
+	EditorFileSystem::get_singleton()->connect("filesystem_changed", Callable(this, "_refresh_stage_area"));
 
 	String res_dir = OS::get_singleton()->get_resource_dir();
 
@@ -388,8 +388,8 @@ void VersionControlEditorPlugin::clear_stage_area() {
 void VersionControlEditorPlugin::shut_down() {
 
 	if (EditorVCSInterface::get_singleton()) {
-		if (EditorFileSystem::get_singleton()->is_connected_compat("filesystem_changed", this, "_refresh_stage_area")) {
-			EditorFileSystem::get_singleton()->disconnect_compat("filesystem_changed", this, "_refresh_stage_area");
+		if (EditorFileSystem::get_singleton()->is_connected("filesystem_changed", Callable(this, "_refresh_stage_area"))) {
+			EditorFileSystem::get_singleton()->disconnect("filesystem_changed", Callable(this, "_refresh_stage_area"));
 		}
 		EditorVCSInterface::get_singleton()->shut_down();
 		memdelete(EditorVCSInterface::get_singleton());
@@ -444,14 +444,14 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	set_up_choice = memnew(OptionButton);
 	set_up_choice->set_h_size_flags(HBoxContainer::SIZE_EXPAND_FILL);
-	set_up_choice->connect_compat("item_selected", this, "_selected_a_vcs");
+	set_up_choice->connect("item_selected", Callable(this, "_selected_a_vcs"));
 	set_up_hbc->add_child(set_up_choice);
 
 	set_up_init_settings = NULL;
 
 	set_up_init_button = memnew(Button);
 	set_up_init_button->set_text(TTR("Initialize"));
-	set_up_init_button->connect_compat("pressed", this, "_initialize_vcs");
+	set_up_init_button->connect("pressed", Callable(this, "_initialize_vcs"));
 	set_up_vbc->add_child(set_up_init_button);
 
 	version_control_actions->set_v_size_flags(PopupMenu::SIZE_EXPAND_FILL);
@@ -479,7 +479,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	refresh_button->set_tooltip(TTR("Detect new changes"));
 	refresh_button->set_text(TTR("Refresh"));
 	refresh_button->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("Reload", "EditorIcons"));
-	refresh_button->connect_compat("pressed", this, "_refresh_stage_area");
+	refresh_button->connect("pressed", Callable(this, "_refresh_stage_area"));
 	stage_tools->add_child(refresh_button);
 
 	stage_files = memnew(Tree);
@@ -492,7 +492,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	stage_files->set_allow_rmb_select(true);
 	stage_files->set_select_mode(Tree::SelectMode::SELECT_MULTI);
 	stage_files->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
-	stage_files->connect_compat("cell_selected", this, "_view_file_diff");
+	stage_files->connect("cell_selected", Callable(this, "_view_file_diff"));
 	stage_files->create_item();
 	stage_files->set_hide_root(true);
 	commit_box_vbc->add_child(stage_files);
@@ -516,12 +516,12 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	stage_selected_button = memnew(Button);
 	stage_selected_button->set_h_size_flags(Button::SIZE_EXPAND_FILL);
 	stage_selected_button->set_text(TTR("Stage Selected"));
-	stage_selected_button->connect_compat("pressed", this, "_stage_selected");
+	stage_selected_button->connect("pressed", Callable(this, "_stage_selected"));
 	stage_buttons->add_child(stage_selected_button);
 
 	stage_all_button = memnew(Button);
 	stage_all_button->set_text(TTR("Stage All"));
-	stage_all_button->connect_compat("pressed", this, "_stage_all");
+	stage_all_button->connect("pressed", Callable(this, "_stage_all"));
 	stage_buttons->add_child(stage_all_button);
 
 	commit_box_vbc->add_child(memnew(HSeparator));
@@ -537,7 +537,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	commit_button = memnew(Button);
 	commit_button->set_text(TTR("Commit Changes"));
-	commit_button->connect_compat("pressed", this, "_send_commit_msg");
+	commit_button->connect("pressed", Callable(this, "_send_commit_msg"));
 	commit_box_vbc->add_child(commit_button);
 
 	commit_status = memnew(Label);
@@ -571,7 +571,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	diff_refresh_button = memnew(Button);
 	diff_refresh_button->set_tooltip(TTR("Detect changes in file diff"));
 	diff_refresh_button->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("Reload", "EditorIcons"));
-	diff_refresh_button->connect_compat("pressed", this, "_refresh_file_diff");
+	diff_refresh_button->connect("pressed", Callable(this, "_refresh_file_diff"));
 	diff_hbc->add_child(diff_refresh_button);
 
 	diff = memnew(RichTextLabel);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -72,14 +72,14 @@ void VisualShaderEditor::edit(VisualShader *p_visual_shader) {
 			}
 		}
 		visual_shader = Ref<VisualShader>(p_visual_shader);
-		if (!visual_shader->is_connected_compat("changed", this, "_update_preview")) {
-			visual_shader->connect_compat("changed", this, "_update_preview");
+		if (!visual_shader->is_connected("changed", Callable(this, "_update_preview"))) {
+			visual_shader->connect("changed", Callable(this, "_update_preview"));
 		}
 		visual_shader->set_graph_offset(graph->get_scroll_ofs() / EDSCALE);
 	} else {
 		if (visual_shader.is_valid()) {
-			if (visual_shader->is_connected_compat("changed", this, "")) {
-				visual_shader->disconnect_compat("changed", this, "_update_preview");
+			if (visual_shader->is_connected("changed", Callable(this, ""))) {
+				visual_shader->disconnect("changed", Callable(this, "_update_preview"));
 			}
 		}
 		visual_shader.unref();
@@ -498,7 +498,7 @@ void VisualShaderEditor::_update_graph() {
 			size = group_node->get_size();
 
 			node->set_resizable(true);
-			node->connect_compat("resize_request", this, "_node_resized", varray((int)type, nodes[n_i]));
+			node->connect("resize_request", Callable(this, "_node_resized"), varray((int)type, nodes[n_i]));
 		}
 		if (is_expression) {
 			expression = expression_node->get_expression();
@@ -515,10 +515,10 @@ void VisualShaderEditor::_update_graph() {
 
 		if (nodes[n_i] >= 2) {
 			node->set_show_close_button(true);
-			node->connect_compat("close_request", this, "_delete_request", varray(nodes[n_i]), CONNECT_DEFERRED);
+			node->connect("close_request", Callable(this, "_delete_request"), varray(nodes[n_i]), CONNECT_DEFERRED);
 		}
 
-		node->connect_compat("dragged", this, "_node_dragged", varray(nodes[n_i]));
+		node->connect("dragged", Callable(this, "_node_dragged"), varray(nodes[n_i]));
 
 		Control *custom_editor = NULL;
 		int port_offset = 0;
@@ -536,8 +536,8 @@ void VisualShaderEditor::_update_graph() {
 			LineEdit *uniform_name = memnew(LineEdit);
 			uniform_name->set_text(uniform->get_uniform_name());
 			node->add_child(uniform_name);
-			uniform_name->connect_compat("text_entered", this, "_line_edit_changed", varray(uniform_name, nodes[n_i]));
-			uniform_name->connect_compat("focus_exited", this, "_line_edit_focus_out", varray(uniform_name, nodes[n_i]));
+			uniform_name->connect("text_entered", Callable(this, "_line_edit_changed"), varray(uniform_name, nodes[n_i]));
+			uniform_name->connect("focus_exited", Callable(this, "_line_edit_focus_out"), varray(uniform_name, nodes[n_i]));
 
 			if (vsnode->get_input_port_count() == 0 && vsnode->get_output_port_count() == 1 && vsnode->get_output_port_name(0) == "") {
 				//shortcut
@@ -581,14 +581,14 @@ void VisualShaderEditor::_update_graph() {
 
 				Button *add_input_btn = memnew(Button);
 				add_input_btn->set_text(TTR("Add Input"));
-				add_input_btn->connect_compat("pressed", this, "_add_input_port", varray(nodes[n_i], group_node->get_free_input_port_id(), VisualShaderNode::PORT_TYPE_VECTOR, "input" + itos(group_node->get_free_input_port_id())), CONNECT_DEFERRED);
+				add_input_btn->connect("pressed", Callable(this, "_add_input_port"), varray(nodes[n_i], group_node->get_free_input_port_id(), VisualShaderNode::PORT_TYPE_VECTOR, "input" + itos(group_node->get_free_input_port_id())), CONNECT_DEFERRED);
 				hb2->add_child(add_input_btn);
 
 				hb2->add_spacer();
 
 				Button *add_output_btn = memnew(Button);
 				add_output_btn->set_text(TTR("Add Output"));
-				add_output_btn->connect_compat("pressed", this, "_add_output_port", varray(nodes[n_i], group_node->get_free_output_port_id(), VisualShaderNode::PORT_TYPE_VECTOR, "output" + itos(group_node->get_free_output_port_id())), CONNECT_DEFERRED);
+				add_output_btn->connect("pressed", Callable(this, "_add_output_port"), varray(nodes[n_i], group_node->get_free_output_port_id(), VisualShaderNode::PORT_TYPE_VECTOR, "output" + itos(group_node->get_free_output_port_id())), CONNECT_DEFERRED);
 				hb2->add_child(add_output_btn);
 
 				node->add_child(hb2);
@@ -636,13 +636,13 @@ void VisualShaderEditor::_update_graph() {
 			if (default_value.get_type() != Variant::NIL) { // only a label
 				Button *button = memnew(Button);
 				hb->add_child(button);
-				button->connect_compat("pressed", this, "_edit_port_default_input", varray(button, nodes[n_i], i));
+				button->connect("pressed", Callable(this, "_edit_port_default_input"), varray(button, nodes[n_i], i));
 
 				switch (default_value.get_type()) {
 
 					case Variant::COLOR: {
 						button->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
-						button->connect_compat("draw", this, "_draw_color_over_button", varray(button, default_value));
+						button->connect("draw", Callable(this, "_draw_color_over_button"), varray(button, default_value));
 					} break;
 					case Variant::BOOL: {
 						button->set_text(((bool)default_value) ? "true" : "false");
@@ -677,20 +677,20 @@ void VisualShaderEditor::_update_graph() {
 						type_box->add_item(TTR("Sampler"));
 						type_box->select(group_node->get_input_port_type(i));
 						type_box->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-						type_box->connect_compat("item_selected", this, "_change_input_port_type", varray(nodes[n_i], i), CONNECT_DEFERRED);
+						type_box->connect("item_selected", Callable(this, "_change_input_port_type"), varray(nodes[n_i], i), CONNECT_DEFERRED);
 
 						LineEdit *name_box = memnew(LineEdit);
 						hb->add_child(name_box);
 						name_box->set_custom_minimum_size(Size2(65 * EDSCALE, 0));
 						name_box->set_h_size_flags(SIZE_EXPAND_FILL);
 						name_box->set_text(name_left);
-						name_box->connect_compat("text_entered", this, "_change_input_port_name", varray(name_box, nodes[n_i], i));
-						name_box->connect_compat("focus_exited", this, "_port_name_focus_out", varray(name_box, nodes[n_i], i, false));
+						name_box->connect("text_entered", Callable(this, "_change_input_port_name"), varray(name_box, nodes[n_i], i));
+						name_box->connect("focus_exited", Callable(this, "_port_name_focus_out"), varray(name_box, nodes[n_i], i, false));
 
 						Button *remove_btn = memnew(Button);
 						remove_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("Remove", "EditorIcons"));
 						remove_btn->set_tooltip(TTR("Remove") + " " + name_left);
-						remove_btn->connect_compat("pressed", this, "_remove_input_port", varray(nodes[n_i], i), CONNECT_DEFERRED);
+						remove_btn->connect("pressed", Callable(this, "_remove_input_port"), varray(nodes[n_i], i), CONNECT_DEFERRED);
 						hb->add_child(remove_btn);
 					} else {
 
@@ -719,7 +719,7 @@ void VisualShaderEditor::_update_graph() {
 						Button *remove_btn = memnew(Button);
 						remove_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("Remove", "EditorIcons"));
 						remove_btn->set_tooltip(TTR("Remove") + " " + name_left);
-						remove_btn->connect_compat("pressed", this, "_remove_output_port", varray(nodes[n_i], i), CONNECT_DEFERRED);
+						remove_btn->connect("pressed", Callable(this, "_remove_output_port"), varray(nodes[n_i], i), CONNECT_DEFERRED);
 						hb->add_child(remove_btn);
 
 						LineEdit *name_box = memnew(LineEdit);
@@ -727,8 +727,8 @@ void VisualShaderEditor::_update_graph() {
 						name_box->set_custom_minimum_size(Size2(65 * EDSCALE, 0));
 						name_box->set_h_size_flags(SIZE_EXPAND_FILL);
 						name_box->set_text(name_right);
-						name_box->connect_compat("text_entered", this, "_change_output_port_name", varray(name_box, nodes[n_i], i));
-						name_box->connect_compat("focus_exited", this, "_port_name_focus_out", varray(name_box, nodes[n_i], i, true));
+						name_box->connect("text_entered", Callable(this, "_change_output_port_name"), varray(name_box, nodes[n_i], i));
+						name_box->connect("focus_exited", Callable(this, "_port_name_focus_out"), varray(name_box, nodes[n_i], i, true));
 
 						OptionButton *type_box = memnew(OptionButton);
 						hb->add_child(type_box);
@@ -738,7 +738,7 @@ void VisualShaderEditor::_update_graph() {
 						type_box->add_item(TTR("Transform"));
 						type_box->select(group_node->get_output_port_type(i));
 						type_box->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-						type_box->connect_compat("item_selected", this, "_change_output_port_type", varray(nodes[n_i], i), CONNECT_DEFERRED);
+						type_box->connect("item_selected", Callable(this, "_change_output_port_type"), varray(nodes[n_i], i), CONNECT_DEFERRED);
 					} else {
 						Label *label = memnew(Label);
 						label->set_text(name_right);
@@ -759,7 +759,7 @@ void VisualShaderEditor::_update_graph() {
 					preview->set_pressed(true);
 				}
 
-				preview->connect_compat("pressed", this, "_preview_select_port", varray(nodes[n_i], i), CONNECT_DEFERRED);
+				preview->connect("pressed", Callable(this, "_preview_select_port"), varray(nodes[n_i], i), CONNECT_DEFERRED);
 				hb->add_child(preview);
 			}
 
@@ -832,7 +832,7 @@ void VisualShaderEditor::_update_graph() {
 			expression_box->set_context_menu_enabled(false);
 			expression_box->set_show_line_numbers(true);
 
-			expression_box->connect_compat("focus_exited", this, "_expression_focus_out", varray(expression_box, nodes[n_i]));
+			expression_box->connect("focus_exited", Callable(this, "_expression_focus_out"), varray(expression_box, nodes[n_i]));
 		}
 
 		if (!uniform.is_valid()) {
@@ -2296,17 +2296,17 @@ VisualShaderEditor::VisualShaderEditor() {
 	graph->add_valid_right_disconnect_type(VisualShaderNode::PORT_TYPE_SAMPLER);
 	//graph->add_valid_left_disconnect_type(0);
 	graph->set_v_size_flags(SIZE_EXPAND_FILL);
-	graph->connect_compat("connection_request", this, "_connection_request", varray(), CONNECT_DEFERRED);
-	graph->connect_compat("disconnection_request", this, "_disconnection_request", varray(), CONNECT_DEFERRED);
-	graph->connect_compat("node_selected", this, "_node_selected");
-	graph->connect_compat("scroll_offset_changed", this, "_scroll_changed");
-	graph->connect_compat("duplicate_nodes_request", this, "_duplicate_nodes");
-	graph->connect_compat("copy_nodes_request", this, "_copy_nodes");
-	graph->connect_compat("paste_nodes_request", this, "_paste_nodes");
-	graph->connect_compat("delete_nodes_request", this, "_on_nodes_delete");
-	graph->connect_compat("gui_input", this, "_graph_gui_input");
-	graph->connect_compat("connection_to_empty", this, "_connection_to_empty");
-	graph->connect_compat("connection_from_empty", this, "_connection_from_empty");
+	graph->connect("connection_request", Callable(this, "_connection_request"), varray(), CONNECT_DEFERRED);
+	graph->connect("disconnection_request", Callable(this, "_disconnection_request"), varray(), CONNECT_DEFERRED);
+	graph->connect("node_selected", Callable(this, "_node_selected"));
+	graph->connect("scroll_offset_changed", Callable(this, "_scroll_changed"));
+	graph->connect("duplicate_nodes_request", Callable(this, "_duplicate_nodes"));
+	graph->connect("copy_nodes_request", Callable(this, "_copy_nodes"));
+	graph->connect("paste_nodes_request", Callable(this, "_paste_nodes"));
+	graph->connect("delete_nodes_request", Callable(this, "_on_nodes_delete"));
+	graph->connect("gui_input", Callable(this, "_graph_gui_input"));
+	graph->connect("connection_to_empty", Callable(this, "_connection_to_empty"));
+	graph->connect("connection_from_empty", Callable(this, "_connection_from_empty"));
 	graph->add_valid_connection_type(VisualShaderNode::PORT_TYPE_SCALAR, VisualShaderNode::PORT_TYPE_SCALAR);
 	graph->add_valid_connection_type(VisualShaderNode::PORT_TYPE_SCALAR, VisualShaderNode::PORT_TYPE_VECTOR);
 	graph->add_valid_connection_type(VisualShaderNode::PORT_TYPE_SCALAR, VisualShaderNode::PORT_TYPE_BOOLEAN);
@@ -2328,7 +2328,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	edit_type->add_item(TTR("Fragment"));
 	edit_type->add_item(TTR("Light"));
 	edit_type->select(1);
-	edit_type->connect_compat("item_selected", this, "_mode_selected");
+	edit_type->connect("item_selected", Callable(this, "_mode_selected"));
 	graph->get_zoom_hbox()->add_child(edit_type);
 	graph->get_zoom_hbox()->move_child(edit_type, 0);
 
@@ -2336,13 +2336,13 @@ VisualShaderEditor::VisualShaderEditor() {
 	graph->get_zoom_hbox()->add_child(add_node);
 	add_node->set_text(TTR("Add Node..."));
 	graph->get_zoom_hbox()->move_child(add_node, 0);
-	add_node->connect_compat("pressed", this, "_show_members_dialog", varray(false));
+	add_node->connect("pressed", Callable(this, "_show_members_dialog"), varray(false));
 
 	preview_shader = memnew(ToolButton);
 	preview_shader->set_toggle_mode(true);
 	preview_shader->set_tooltip(TTR("Show resulted shader code."));
 	graph->get_zoom_hbox()->add_child(preview_shader);
-	preview_shader->connect_compat("pressed", this, "_show_preview_text");
+	preview_shader->connect("pressed", Callable(this, "_show_preview_text"));
 
 	///////////////////////////////////////
 	// PREVIEW PANEL
@@ -2376,15 +2376,15 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	node_filter = memnew(LineEdit);
 	filter_hb->add_child(node_filter);
-	node_filter->connect_compat("text_changed", this, "_member_filter_changed");
-	node_filter->connect_compat("gui_input", this, "_sbox_input");
+	node_filter->connect("text_changed", Callable(this, "_member_filter_changed"));
+	node_filter->connect("gui_input", Callable(this, "_sbox_input"));
 	node_filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	node_filter->set_placeholder(TTR("Search"));
 
 	tools = memnew(MenuButton);
 	filter_hb->add_child(tools);
 	tools->set_tooltip(TTR("Options"));
-	tools->get_popup()->connect_compat("id_pressed", this, "_tools_menu_option");
+	tools->get_popup()->connect("id_pressed", Callable(this, "_tools_menu_option"));
 	tools->get_popup()->add_item(TTR("Expand All"), EXPAND_ALL);
 	tools->get_popup()->add_item(TTR("Collapse All"), COLLAPSE_ALL);
 
@@ -2397,9 +2397,9 @@ VisualShaderEditor::VisualShaderEditor() {
 	members->set_allow_reselect(true);
 	members->set_hide_folding(false);
 	members->set_custom_minimum_size(Size2(180 * EDSCALE, 200 * EDSCALE));
-	members->connect_compat("item_activated", this, "_member_create");
-	members->connect_compat("item_selected", this, "_member_selected");
-	members->connect_compat("nothing_selected", this, "_member_unselected");
+	members->connect("item_activated", Callable(this, "_member_create"));
+	members->connect("item_selected", Callable(this, "_member_selected"));
+	members->connect("nothing_selected", Callable(this, "_member_unselected"));
 
 	HBoxContainer *desc_hbox = memnew(HBoxContainer);
 	members_vb->add_child(desc_hbox);
@@ -2427,11 +2427,11 @@ VisualShaderEditor::VisualShaderEditor() {
 	members_dialog->set_title(TTR("Create Shader Node"));
 	members_dialog->add_child(members_vb);
 	members_dialog->get_ok()->set_text(TTR("Create"));
-	members_dialog->get_ok()->connect_compat("pressed", this, "_member_create");
+	members_dialog->get_ok()->connect("pressed", Callable(this, "_member_create"));
 	members_dialog->get_ok()->set_disabled(true);
 	members_dialog->set_resizable(true);
 	members_dialog->set_as_minsize();
-	members_dialog->connect_compat("hide", this, "_member_cancel");
+	members_dialog->connect("hide", Callable(this, "_member_cancel"));
 	add_child(members_dialog);
 
 	alert = memnew(AcceptDialog);
@@ -2810,7 +2810,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	property_editor = memnew(CustomPropertyEditor);
 	add_child(property_editor);
 
-	property_editor->connect_compat("variant_changed", this, "_port_edited");
+	property_editor->connect("variant_changed", Callable(this, "_port_edited"));
 }
 
 void VisualShaderEditorPlugin::edit(Object *p_object) {
@@ -2871,7 +2871,7 @@ protected:
 public:
 	void _notification(int p_what) {
 		if (p_what == NOTIFICATION_READY) {
-			connect_compat("item_selected", this, "_item_selected");
+			connect("item_selected", Callable(this, "_item_selected"));
 		}
 	}
 
@@ -3000,16 +3000,16 @@ public:
 
 			bool res_prop = Object::cast_to<EditorPropertyResource>(p_properties[i]);
 			if (res_prop) {
-				p_properties[i]->connect_compat("resource_selected", this, "_resource_selected");
+				p_properties[i]->connect("resource_selected", Callable(this, "_resource_selected"));
 			}
 
-			properties[i]->connect_compat("property_changed", this, "_property_changed");
+			properties[i]->connect("property_changed", Callable(this, "_property_changed"));
 			properties[i]->set_object_and_property(node.ptr(), p_names[i]);
 			properties[i]->update_property();
 			properties[i]->set_name_split_ratio(0);
 		}
-		node->connect_compat("changed", this, "_node_changed");
-		node->connect_compat("editor_refresh_request", this, "_refresh_request", varray(), CONNECT_DEFERRED);
+		node->connect("changed", Callable(this, "_node_changed"));
+		node->connect("editor_refresh_request", Callable(this, "_refresh_request"), varray(), CONNECT_DEFERRED);
 	}
 
 	static void _bind_methods() {
@@ -3175,7 +3175,7 @@ EditorPropertyShaderMode::EditorPropertyShaderMode() {
 	options->set_clip_text(true);
 	add_child(options);
 	add_focusable(options);
-	options->connect_compat("item_selected", this, "_option_selected");
+	options->connect("item_selected", Callable(this, "_option_selected"));
 }
 
 bool EditorInspectorShaderModePlugin::can_handle(Object *p_object) {
@@ -3248,7 +3248,7 @@ void VisualShaderNodePortPreview::_shader_changed() {
 void VisualShaderNodePortPreview::setup(const Ref<VisualShader> &p_shader, VisualShader::Type p_type, int p_node, int p_port) {
 
 	shader = p_shader;
-	shader->connect_compat("changed", this, "_shader_changed");
+	shader->connect("changed", Callable(this, "_shader_changed"));
 	type = p_type;
 	port = p_port;
 	node = p_node;

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -264,5 +264,5 @@ ProgressDialog::ProgressDialog() {
 	cancel_hb->add_child(cancel);
 	cancel->set_text(TTR("Cancel"));
 	cancel_hb->add_spacer();
-	cancel->connect_compat("pressed", this, "_cancel_pressed");
+	cancel->connect("pressed", Callable(this, "_cancel_pressed"));
 }

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -53,7 +53,7 @@ void ProjectExportDialog::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			duplicate_preset->set_icon(get_icon("Duplicate", "EditorIcons"));
 			delete_preset->set_icon(get_icon("Remove", "EditorIcons"));
-			connect_compat("confirmed", this, "_export_pck_zip");
+			connect("confirmed", Callable(this, "_export_pck_zip"));
 			custom_feature_display->get_parent_control()->add_style_override("panel", get_stylebox("bg", "Tree"));
 		} break;
 		case NOTIFICATION_POPUP_HIDE: {
@@ -913,10 +913,10 @@ void ProjectExportDialog::_validate_export_path(const String &p_path) {
 
 	if (invalid_path) {
 		export_project->get_ok()->set_disabled(true);
-		export_project->get_line_edit()->disconnect_compat("text_entered", export_project, "_file_entered");
+		export_project->get_line_edit()->disconnect("text_entered", Callable(export_project, "_file_entered"));
 	} else {
 		export_project->get_ok()->set_disabled(false);
-		export_project->get_line_edit()->connect_compat("text_entered", export_project, "_file_entered");
+		export_project->get_line_edit()->connect("text_entered", Callable(export_project, "_file_entered"));
 	}
 }
 
@@ -946,9 +946,9 @@ void ProjectExportDialog::_export_project() {
 	}
 
 	// Ensure that signal is connected if previous attempt left it disconnected with _validate_export_path
-	if (!export_project->get_line_edit()->is_connected_compat("text_entered", export_project, "_file_entered")) {
+	if (!export_project->get_line_edit()->is_connected("text_entered", Callable(export_project, "_file_entered"))) {
 		export_project->get_ok()->set_disabled(false);
-		export_project->get_line_edit()->connect_compat("text_entered", export_project, "_file_entered");
+		export_project->get_line_edit()->connect("text_entered", Callable(export_project, "_file_entered"));
 	}
 
 	export_project->set_mode(EditorFileDialog::MODE_SAVE_FILE);
@@ -1085,7 +1085,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	add_preset = memnew(MenuButton);
 	add_preset->set_text(TTR("Add..."));
-	add_preset->get_popup()->connect_compat("index_pressed", this, "_add_preset");
+	add_preset->get_popup()->connect("index_pressed", Callable(this, "_add_preset"));
 	preset_hb->add_child(add_preset);
 	MarginContainer *mc = memnew(MarginContainer);
 	preset_vb->add_child(mc);
@@ -1093,13 +1093,13 @@ ProjectExportDialog::ProjectExportDialog() {
 	presets = memnew(ItemList);
 	presets->set_drag_forwarding(this);
 	mc->add_child(presets);
-	presets->connect_compat("item_selected", this, "_edit_preset");
+	presets->connect("item_selected", Callable(this, "_edit_preset"));
 	duplicate_preset = memnew(ToolButton);
 	preset_hb->add_child(duplicate_preset);
-	duplicate_preset->connect_compat("pressed", this, "_duplicate_preset");
+	duplicate_preset->connect("pressed", Callable(this, "_duplicate_preset"));
 	delete_preset = memnew(ToolButton);
 	preset_hb->add_child(delete_preset);
-	delete_preset->connect_compat("pressed", this, "_delete_preset");
+	delete_preset->connect("pressed", Callable(this, "_delete_preset"));
 
 	// Preset settings.
 
@@ -1109,11 +1109,11 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	name = memnew(LineEdit);
 	settings_vb->add_margin_child(TTR("Name:"), name);
-	name->connect_compat("text_changed", this, "_name_changed");
+	name->connect("text_changed", Callable(this, "_name_changed"));
 	runnable = memnew(CheckButton);
 	runnable->set_text(TTR("Runnable"));
 	runnable->set_tooltip(TTR("If checked, the preset will be available for use in one-click deploy.\nOnly one preset per platform may be marked as runnable."));
-	runnable->connect_compat("pressed", this, "_runnable_pressed");
+	runnable->connect("pressed", Callable(this, "_runnable_pressed"));
 	settings_vb->add_child(runnable);
 
 	export_path = memnew(EditorPropertyPath);
@@ -1121,7 +1121,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_path->set_label(TTR("Export Path"));
 	export_path->set_object_and_property(this, "export_path");
 	export_path->set_save_mode();
-	export_path->connect_compat("property_changed", this, "_export_path_changed");
+	export_path->connect("property_changed", Callable(this, "_export_path_changed"));
 
 	// Subsections.
 
@@ -1137,7 +1137,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	sections->add_child(parameters);
 	parameters->set_name(TTR("Options"));
 	parameters->set_v_size_flags(SIZE_EXPAND_FILL);
-	parameters->connect_compat("property_edited", this, "_update_parameters");
+	parameters->connect("property_edited", Callable(this, "_update_parameters"));
 
 	// Resources export parameters.
 
@@ -1150,7 +1150,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_filter->add_item(TTR("Export selected scenes (and dependencies)"));
 	export_filter->add_item(TTR("Export selected resources (and dependencies)"));
 	resources_vb->add_margin_child(TTR("Export Mode:"), export_filter);
-	export_filter->connect_compat("item_selected", this, "_export_type_changed");
+	export_filter->connect("item_selected", Callable(this, "_export_type_changed"));
 
 	include_label = memnew(Label);
 	include_label->set_text(TTR("Resources to export:"));
@@ -1161,19 +1161,19 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	include_files = memnew(Tree);
 	include_margin->add_child(include_files);
-	include_files->connect_compat("item_edited", this, "_tree_changed");
+	include_files->connect("item_edited", Callable(this, "_tree_changed"));
 
 	include_filters = memnew(LineEdit);
 	resources_vb->add_margin_child(
 			TTR("Filters to export non-resource files/folders\n(comma-separated, e.g: *.json, *.txt, docs/*)"),
 			include_filters);
-	include_filters->connect_compat("text_changed", this, "_filter_changed");
+	include_filters->connect("text_changed", Callable(this, "_filter_changed"));
 
 	exclude_filters = memnew(LineEdit);
 	resources_vb->add_margin_child(
 			TTR("Filters to exclude files/folders from project\n(comma-separated, e.g: *.json, *.txt, docs/*)"),
 			exclude_filters);
-	exclude_filters->connect_compat("text_changed", this, "_filter_changed");
+	exclude_filters->connect("text_changed", Callable(this, "_filter_changed"));
 
 	// Patch packages.
 
@@ -1190,8 +1190,8 @@ ProjectExportDialog::ProjectExportDialog() {
 	patch_vb->add_child(patches);
 	patches->set_v_size_flags(SIZE_EXPAND_FILL);
 	patches->set_hide_root(true);
-	patches->connect_compat("button_pressed", this, "_patch_button_pressed");
-	patches->connect_compat("item_edited", this, "_patch_edited");
+	patches->connect("button_pressed", Callable(this, "_patch_button_pressed"));
+	patches->connect("item_edited", Callable(this, "_patch_edited"));
 	patches->set_drag_forwarding(this);
 	patches->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
 
@@ -1206,12 +1206,12 @@ ProjectExportDialog::ProjectExportDialog() {
 	patch_dialog = memnew(EditorFileDialog);
 	patch_dialog->add_filter("*.pck ; " + TTR("Pack File"));
 	patch_dialog->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-	patch_dialog->connect_compat("file_selected", this, "_patch_selected");
+	patch_dialog->connect("file_selected", Callable(this, "_patch_selected"));
 	add_child(patch_dialog);
 
 	patch_erase = memnew(ConfirmationDialog);
 	patch_erase->get_ok()->set_text(TTR("Delete"));
-	patch_erase->connect_compat("confirmed", this, "_patch_deleted");
+	patch_erase->connect("confirmed", Callable(this, "_patch_deleted"));
 	add_child(patch_erase);
 
 	// Feature tags.
@@ -1219,7 +1219,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	VBoxContainer *feature_vb = memnew(VBoxContainer);
 	feature_vb->set_name(TTR("Features"));
 	custom_features = memnew(LineEdit);
-	custom_features->connect_compat("text_changed", this, "_custom_features_changed");
+	custom_features->connect("text_changed", Callable(this, "_custom_features_changed"));
 	feature_vb->add_margin_child(TTR("Custom (comma-separated):"), custom_features);
 	Panel *features_panel = memnew(Panel);
 	custom_feature_display = memnew(RichTextLabel);
@@ -1240,9 +1240,9 @@ ProjectExportDialog::ProjectExportDialog() {
 	script_mode->add_item(TTR("Text"), (int)EditorExportPreset::MODE_SCRIPT_TEXT);
 	script_mode->add_item(TTR("Compiled"), (int)EditorExportPreset::MODE_SCRIPT_COMPILED);
 	script_mode->add_item(TTR("Encrypted (Provide Key Below)"), (int)EditorExportPreset::MODE_SCRIPT_ENCRYPTED);
-	script_mode->connect_compat("item_selected", this, "_script_export_mode_changed");
+	script_mode->connect("item_selected", Callable(this, "_script_export_mode_changed"));
 	script_key = memnew(LineEdit);
-	script_key->connect_compat("text_changed", this, "_script_encryption_key_changed");
+	script_key->connect("text_changed", Callable(this, "_script_encryption_key_changed"));
 	script_key_error = memnew(Label);
 	script_key_error->set_text("- " + TTR("Invalid Encryption Key (must be 64 characters long)"));
 	script_key_error->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("error_color", "Editor"));
@@ -1250,7 +1250,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	script_vb->add_child(script_key_error);
 	sections->add_child(script_vb);
 
-	sections->connect_compat("tab_changed", this, "_tab_changed");
+	sections->connect("tab_changed", Callable(this, "_tab_changed"));
 
 	// Disable by default.
 	name->set_editable(false);
@@ -1267,7 +1267,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	delete_confirm = memnew(ConfirmationDialog);
 	add_child(delete_confirm);
 	delete_confirm->get_ok()->set_text(TTR("Delete"));
-	delete_confirm->connect_compat("confirmed", this, "_delete_preset_confirm");
+	delete_confirm->connect("confirmed", Callable(this, "_delete_preset_confirm"));
 
 	// Export buttons, dialogs and errors.
 
@@ -1276,7 +1276,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	get_cancel()->set_text(TTR("Close"));
 	get_ok()->set_text(TTR("Export PCK/Zip"));
 	export_button = add_button(TTR("Export Project"), !OS::get_singleton()->get_swap_ok_cancel(), "export");
-	export_button->connect_compat("pressed", this, "_export_project");
+	export_button->connect("pressed", Callable(this, "_export_project"));
 	// Disable initially before we select a valid preset
 	export_button->set_disabled(true);
 	get_ok()->set_disabled(true);
@@ -1288,10 +1288,10 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_all_dialog->get_ok()->hide();
 	export_all_dialog->add_button(TTR("Debug"), true, "debug");
 	export_all_dialog->add_button(TTR("Release"), true, "release");
-	export_all_dialog->connect_compat("custom_action", this, "_export_all_dialog_action");
+	export_all_dialog->connect("custom_action", Callable(this, "_export_all_dialog_action"));
 
 	export_all_button = add_button(TTR("Export All"), !OS::get_singleton()->get_swap_ok_cancel(), "export");
-	export_all_button->connect_compat("pressed", this, "_export_all_dialog");
+	export_all_button->connect("pressed", Callable(this, "_export_all_dialog"));
 	export_all_button->set_disabled(true);
 
 	export_pck_zip = memnew(EditorFileDialog);
@@ -1300,7 +1300,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_pck_zip->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	export_pck_zip->set_mode(EditorFileDialog::MODE_SAVE_FILE);
 	add_child(export_pck_zip);
-	export_pck_zip->connect_compat("file_selected", this, "_export_pck_zip_selected");
+	export_pck_zip->connect("file_selected", Callable(this, "_export_pck_zip_selected"));
 
 	export_error = memnew(Label);
 	main_vb->add_child(export_error);
@@ -1326,13 +1326,13 @@ ProjectExportDialog::ProjectExportDialog() {
 	download_templates->set_text(TTR("Manage Export Templates"));
 	download_templates->set_v_size_flags(SIZE_SHRINK_CENTER);
 	export_templates_error->add_child(download_templates);
-	download_templates->connect_compat("pressed", this, "_open_export_template_manager");
+	download_templates->connect("pressed", Callable(this, "_open_export_template_manager"));
 
 	export_project = memnew(EditorFileDialog);
 	export_project->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	add_child(export_project);
-	export_project->connect_compat("file_selected", this, "_export_project_to_path");
-	export_project->get_line_edit()->connect_compat("text_changed", this, "_validate_export_path");
+	export_project->connect("file_selected", Callable(this, "_export_project_to_path"));
+	export_project->get_line_edit()->connect("text_changed", Callable(this, "_validate_export_path"));
 
 	export_debug = memnew(CheckBox);
 	export_debug->set_text(TTR("Export With Debug"));

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -811,7 +811,7 @@ public:
 		create_dir = memnew(Button);
 		pnhb->add_child(create_dir);
 		create_dir->set_text(TTR("Create Folder"));
-		create_dir->connect_compat("pressed", this, "_create_folder");
+		create_dir->connect("pressed", Callable(this, "_create_folder"));
 
 		path_container = memnew(VBoxContainer);
 		vb->add_child(path_container);
@@ -848,7 +848,7 @@ public:
 
 		browse = memnew(Button);
 		browse->set_text(TTR("Browse"));
-		browse->connect_compat("pressed", this, "_browse_path");
+		browse->connect("pressed", Callable(this, "_browse_path"));
 		pphb->add_child(browse);
 
 		// install status icon
@@ -858,7 +858,7 @@ public:
 
 		install_browse = memnew(Button);
 		install_browse->set_text(TTR("Browse"));
-		install_browse->connect_compat("pressed", this, "_browse_install_path");
+		install_browse->connect("pressed", Callable(this, "_browse_install_path"));
 		iphb->add_child(install_browse);
 
 		msg = memnew(Label);
@@ -928,13 +928,13 @@ public:
 		fdialog_install->set_access(FileDialog::ACCESS_FILESYSTEM);
 		add_child(fdialog);
 		add_child(fdialog_install);
-		project_name->connect_compat("text_changed", this, "_text_changed");
-		project_path->connect_compat("text_changed", this, "_path_text_changed");
-		install_path->connect_compat("text_changed", this, "_path_text_changed");
-		fdialog->connect_compat("dir_selected", this, "_path_selected");
-		fdialog->connect_compat("file_selected", this, "_file_selected");
-		fdialog_install->connect_compat("dir_selected", this, "_install_path_selected");
-		fdialog_install->connect_compat("file_selected", this, "_install_path_selected");
+		project_name->connect("text_changed", Callable(this, "_text_changed"));
+		project_path->connect("text_changed", Callable(this, "_path_text_changed"));
+		install_path->connect("text_changed", Callable(this, "_path_text_changed"));
+		fdialog->connect("dir_selected", Callable(this, "_path_selected"));
+		fdialog->connect("file_selected", Callable(this, "_file_selected"));
+		fdialog_install->connect("dir_selected", Callable(this, "_install_path_selected"));
+		fdialog_install->connect("file_selected", Callable(this, "_install_path_selected"));
 
 		set_hide_on_ok(false);
 		mode = MODE_NEW;
@@ -1320,8 +1320,8 @@ void ProjectList::create_project_item_control(int p_index) {
 	Color font_color = get_color("font_color", "Tree");
 
 	ProjectListItemControl *hb = memnew(ProjectListItemControl);
-	hb->connect_compat("draw", this, "_panel_draw", varray(hb));
-	hb->connect_compat("gui_input", this, "_panel_input", varray(hb));
+	hb->connect("draw", Callable(this, "_panel_draw"), varray(hb));
+	hb->connect("gui_input", Callable(this, "_panel_input"), varray(hb));
 	hb->add_constant_override("separation", 10 * EDSCALE);
 	hb->set_tooltip(item.description);
 
@@ -1332,7 +1332,7 @@ void ProjectList::create_project_item_control(int p_index) {
 	favorite->set_normal_texture(favorite_icon);
 	// This makes the project's "hover" style display correctly when hovering the favorite icon
 	favorite->set_mouse_filter(MOUSE_FILTER_PASS);
-	favorite->connect_compat("pressed", this, "_favorite_pressed", varray(hb));
+	favorite->connect("pressed", Callable(this, "_favorite_pressed"), varray(hb));
 	favorite_box->add_child(favorite);
 	favorite_box->set_alignment(BoxContainer::ALIGN_CENTER);
 	hb->add_child(favorite_box);
@@ -1380,7 +1380,7 @@ void ProjectList::create_project_item_control(int p_index) {
 	path_hb->add_child(show);
 
 	if (!item.missing) {
-		show->connect_compat("pressed", this, "_show_project", varray(item.path));
+		show->connect("pressed", Callable(this, "_show_project"), varray(item.path));
 		show->set_tooltip(TTR("Show in File Manager"));
 	} else {
 		show->set_tooltip(TTR("Error: Project is missing on the filesystem."));
@@ -2358,8 +2358,8 @@ void ProjectManager::_files_dropped(PackedStringArray p_files, int p_screen) {
 			memdelete(dir);
 		}
 		if (confirm) {
-			multi_scan_ask->get_ok()->disconnect_compat("pressed", this, "_scan_multiple_folders");
-			multi_scan_ask->get_ok()->connect_compat("pressed", this, "_scan_multiple_folders", varray(folders));
+			multi_scan_ask->get_ok()->disconnect("pressed", Callable(this, "_scan_multiple_folders"));
+			multi_scan_ask->get_ok()->connect("pressed", Callable(this, "_scan_multiple_folders"), varray(folders));
 			multi_scan_ask->set_text(
 					vformat(TTR("Are you sure to scan %s folders for existing Godot projects?\nThis could take a while."), folders.size()));
 			multi_scan_ask->popup_centered_minsize();
@@ -2524,7 +2524,7 @@ ProjectManager::ProjectManager() {
 	project_order_filter->_setup_filters(sort_filter_titles);
 	project_order_filter->set_filter_size(150);
 	sort_filters->add_child(project_order_filter);
-	project_order_filter->connect_compat("filter_changed", this, "_on_order_option_changed");
+	project_order_filter->connect("filter_changed", Callable(this, "_on_order_option_changed"));
 	project_order_filter->set_custom_minimum_size(Size2(180, 10) * EDSCALE);
 
 	int projects_sorting_order = (int)EditorSettings::get_singleton()->get("project_manager/sorting_order");
@@ -2534,7 +2534,7 @@ ProjectManager::ProjectManager() {
 
 	project_filter = memnew(ProjectListFilter);
 	project_filter->add_search_box();
-	project_filter->connect_compat("filter_changed", this, "_on_filter_option_changed");
+	project_filter->connect("filter_changed", Callable(this, "_on_filter_option_changed"));
 	project_filter->set_custom_minimum_size(Size2(280, 10) * EDSCALE);
 	sort_filters->add_child(project_filter);
 
@@ -2546,8 +2546,8 @@ ProjectManager::ProjectManager() {
 	pc->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	_project_list = memnew(ProjectList);
-	_project_list->connect_compat(ProjectList::SIGNAL_SELECTION_CHANGED, this, "_update_project_buttons");
-	_project_list->connect_compat(ProjectList::SIGNAL_PROJECT_ASK_OPEN, this, "_open_selected_projects_ask");
+	_project_list->connect(ProjectList::SIGNAL_SELECTION_CHANGED, Callable(this, "_update_project_buttons"));
+	_project_list->connect(ProjectList::SIGNAL_PROJECT_ASK_OPEN, Callable(this, "_open_selected_projects_ask"));
 	pc->add_child(_project_list);
 	_project_list->set_enable_h_scroll(false);
 
@@ -2557,13 +2557,13 @@ ProjectManager::ProjectManager() {
 	Button *open = memnew(Button);
 	open->set_text(TTR("Edit"));
 	tree_vb->add_child(open);
-	open->connect_compat("pressed", this, "_open_selected_projects_ask");
+	open->connect("pressed", Callable(this, "_open_selected_projects_ask"));
 	open_btn = open;
 
 	Button *run = memnew(Button);
 	run->set_text(TTR("Run"));
 	tree_vb->add_child(run);
-	run->connect_compat("pressed", this, "_run_project");
+	run->connect("pressed", Callable(this, "_run_project"));
 	run_btn = run;
 
 	tree_vb->add_child(memnew(HSeparator));
@@ -2571,7 +2571,7 @@ ProjectManager::ProjectManager() {
 	Button *scan = memnew(Button);
 	scan->set_text(TTR("Scan"));
 	tree_vb->add_child(scan);
-	scan->connect_compat("pressed", this, "_scan_projects");
+	scan->connect("pressed", Callable(this, "_scan_projects"));
 
 	tree_vb->add_child(memnew(HSeparator));
 
@@ -2581,34 +2581,34 @@ ProjectManager::ProjectManager() {
 	scan_dir->set_title(TTR("Select a Folder to Scan")); // must be after mode or it's overridden
 	scan_dir->set_current_dir(EditorSettings::get_singleton()->get("filesystem/directories/default_project_path"));
 	gui_base->add_child(scan_dir);
-	scan_dir->connect_compat("dir_selected", this, "_scan_begin");
+	scan_dir->connect("dir_selected", Callable(this, "_scan_begin"));
 
 	Button *create = memnew(Button);
 	create->set_text(TTR("New Project"));
 	tree_vb->add_child(create);
-	create->connect_compat("pressed", this, "_new_project");
+	create->connect("pressed", Callable(this, "_new_project"));
 
 	Button *import = memnew(Button);
 	import->set_text(TTR("Import"));
 	tree_vb->add_child(import);
-	import->connect_compat("pressed", this, "_import_project");
+	import->connect("pressed", Callable(this, "_import_project"));
 
 	Button *rename = memnew(Button);
 	rename->set_text(TTR("Rename"));
 	tree_vb->add_child(rename);
-	rename->connect_compat("pressed", this, "_rename_project");
+	rename->connect("pressed", Callable(this, "_rename_project"));
 	rename_btn = rename;
 
 	Button *erase = memnew(Button);
 	erase->set_text(TTR("Remove"));
 	tree_vb->add_child(erase);
-	erase->connect_compat("pressed", this, "_erase_project");
+	erase->connect("pressed", Callable(this, "_erase_project"));
 	erase_btn = erase;
 
 	Button *erase_missing = memnew(Button);
 	erase_missing->set_text(TTR("Remove Missing"));
 	tree_vb->add_child(erase_missing);
-	erase_missing->connect_compat("pressed", this, "_erase_missing_projects");
+	erase_missing->connect("pressed", Callable(this, "_erase_missing_projects"));
 	erase_missing_btn = erase_missing;
 
 	tree_vb->add_spacer();
@@ -2617,7 +2617,7 @@ ProjectManager::ProjectManager() {
 		asset_library = memnew(EditorAssetLibrary(true));
 		asset_library->set_name(TTR("Templates"));
 		tabs->add_child(asset_library);
-		asset_library->connect_compat("install_asset", this, "_install_project");
+		asset_library->connect("install_asset", Callable(this, "_install_project"));
 	} else {
 		WARN_PRINT("Asset Library not available, as it requires SSL to work.");
 	}
@@ -2664,7 +2664,7 @@ ProjectManager::ProjectManager() {
 	language_btn->set_icon(get_icon("Environment", "EditorIcons"));
 
 	settings_hb->add_child(language_btn);
-	language_btn->connect_compat("item_selected", this, "_language_selected");
+	language_btn->connect("item_selected", Callable(this, "_language_selected"));
 
 	center_box->add_child(settings_hb);
 	settings_hb->set_anchors_and_margins_preset(Control::PRESET_TOP_RIGHT);
@@ -2673,28 +2673,28 @@ ProjectManager::ProjectManager() {
 
 	language_restart_ask = memnew(ConfirmationDialog);
 	language_restart_ask->get_ok()->set_text(TTR("Restart Now"));
-	language_restart_ask->get_ok()->connect_compat("pressed", this, "_restart_confirm");
+	language_restart_ask->get_ok()->connect("pressed", Callable(this, "_restart_confirm"));
 	language_restart_ask->get_cancel()->set_text(TTR("Continue"));
 	gui_base->add_child(language_restart_ask);
 
 	erase_missing_ask = memnew(ConfirmationDialog);
 	erase_missing_ask->get_ok()->set_text(TTR("Remove All"));
-	erase_missing_ask->get_ok()->connect_compat("pressed", this, "_erase_missing_projects_confirm");
+	erase_missing_ask->get_ok()->connect("pressed", Callable(this, "_erase_missing_projects_confirm"));
 	gui_base->add_child(erase_missing_ask);
 
 	erase_ask = memnew(ConfirmationDialog);
 	erase_ask->get_ok()->set_text(TTR("Remove"));
-	erase_ask->get_ok()->connect_compat("pressed", this, "_erase_project_confirm");
+	erase_ask->get_ok()->connect("pressed", Callable(this, "_erase_project_confirm"));
 	gui_base->add_child(erase_ask);
 
 	multi_open_ask = memnew(ConfirmationDialog);
 	multi_open_ask->get_ok()->set_text(TTR("Edit"));
-	multi_open_ask->get_ok()->connect_compat("pressed", this, "_open_selected_projects");
+	multi_open_ask->get_ok()->connect("pressed", Callable(this, "_open_selected_projects"));
 	gui_base->add_child(multi_open_ask);
 
 	multi_run_ask = memnew(ConfirmationDialog);
 	multi_run_ask->get_ok()->set_text(TTR("Run"));
-	multi_run_ask->get_ok()->connect_compat("pressed", this, "_run_project_confirm");
+	multi_run_ask->get_ok()->connect("pressed", Callable(this, "_run_project_confirm"));
 	gui_base->add_child(multi_run_ask);
 
 	multi_scan_ask = memnew(ConfirmationDialog);
@@ -2702,7 +2702,7 @@ ProjectManager::ProjectManager() {
 	gui_base->add_child(multi_scan_ask);
 
 	ask_update_settings = memnew(ConfirmationDialog);
-	ask_update_settings->get_ok()->connect_compat("pressed", this, "_confirm_update_settings");
+	ask_update_settings->get_ok()->connect("pressed", Callable(this, "_confirm_update_settings"));
 	gui_base->add_child(ask_update_settings);
 
 	OS::get_singleton()->set_low_processor_usage_mode(true);
@@ -2710,8 +2710,8 @@ ProjectManager::ProjectManager() {
 	npdialog = memnew(ProjectDialog);
 	gui_base->add_child(npdialog);
 
-	npdialog->connect_compat("projects_updated", this, "_on_projects_updated");
-	npdialog->connect_compat("project_created", this, "_on_project_created");
+	npdialog->connect("projects_updated", Callable(this, "_on_projects_updated"));
+	npdialog->connect("project_created", Callable(this, "_on_project_created"));
 
 	_load_recent_projects();
 
@@ -2719,8 +2719,8 @@ ProjectManager::ProjectManager() {
 		_scan_begin(EditorSettings::get_singleton()->get("filesystem/directories/autoscan_project_path"));
 	}
 
-	SceneTree::get_singleton()->connect_compat("files_dropped", this, "_files_dropped");
-	SceneTree::get_singleton()->connect_compat("global_menu_action", this, "_global_menu_action");
+	SceneTree::get_singleton()->connect("files_dropped", Callable(this, "_files_dropped"));
+	SceneTree::get_singleton()->connect("global_menu_action", Callable(this, "_global_menu_action"));
 
 	run_error_diag = memnew(AcceptDialog);
 	gui_base->add_child(run_error_diag);
@@ -2732,7 +2732,7 @@ ProjectManager::ProjectManager() {
 	open_templates = memnew(ConfirmationDialog);
 	open_templates->set_text(TTR("You currently don't have any projects.\nWould you like to explore official example projects in the Asset Library?"));
 	open_templates->get_ok()->set_text(TTR("Open Asset Library"));
-	open_templates->connect_compat("confirmed", this, "_open_asset_library");
+	open_templates->connect("confirmed", Callable(this, "_open_asset_library"));
 	add_child(open_templates);
 }
 
@@ -2793,14 +2793,14 @@ void ProjectListFilter::_bind_methods() {
 void ProjectListFilter::add_filter_option() {
 	filter_option = memnew(OptionButton);
 	filter_option->set_clip_text(true);
-	filter_option->connect_compat("item_selected", this, "_filter_option_selected");
+	filter_option->connect("item_selected", Callable(this, "_filter_option_selected"));
 	add_child(filter_option);
 }
 
 void ProjectListFilter::add_search_box() {
 	search_box = memnew(LineEdit);
 	search_box->set_placeholder(TTR("Search"));
-	search_box->connect_compat("text_changed", this, "_search_text_changed");
+	search_box->connect("text_changed", Callable(this, "_search_text_changed"));
 	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	add_child(search_box);
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -108,7 +108,7 @@ void ProjectSettingsEditor::_notification(int p_what) {
 
 			action_add_error->add_color_override("font_color", get_color("error_color", "Editor"));
 
-			translation_list->connect_compat("button_pressed", this, "_translation_delete");
+			translation_list->connect("button_pressed", Callable(this, "_translation_delete"));
 			_update_actions();
 			popup_add->add_icon_item(get_icon("Keyboard", "EditorIcons"), TTR("Key "), INPUT_KEY); //"Key " - because the word 'key' has already been used as a key animation
 			popup_add->add_icon_item(get_icon("JoyButton", "EditorIcons"), TTR("Joy Button"), INPUT_JOY_BUTTON);
@@ -1805,7 +1805,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	search_button->set_pressed(false);
 	search_button->set_text(TTR("Search"));
 	hbc->add_child(search_button);
-	search_button->connect_compat("toggled", this, "_toggle_search_bar");
+	search_button->connect("toggled", Callable(this, "_toggle_search_bar"));
 
 	hbc->add_child(memnew(VSeparator));
 
@@ -1820,7 +1820,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	category = memnew(LineEdit);
 	category->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	add_prop_bar->add_child(category);
-	category->connect_compat("text_entered", this, "_item_adds");
+	category->connect("text_entered", Callable(this, "_item_adds"));
 
 	l = memnew(Label);
 	add_prop_bar->add_child(l);
@@ -1829,7 +1829,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	property = memnew(LineEdit);
 	property->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	add_prop_bar->add_child(property);
-	property->connect_compat("text_entered", this, "_item_adds");
+	property->connect("text_entered", Callable(this, "_item_adds"));
 
 	l = memnew(Label);
 	add_prop_bar->add_child(l);
@@ -1847,7 +1847,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	Button *add = memnew(Button);
 	add_prop_bar->add_child(add);
 	add->set_text(TTR("Add"));
-	add->connect_compat("pressed", this, "_item_add");
+	add->connect("pressed", Callable(this, "_item_add"));
 
 	search_bar = memnew(HBoxContainer);
 	search_bar->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -1863,14 +1863,14 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	globals_editor->get_inspector()->set_undo_redo(EditorNode::get_singleton()->get_undo_redo());
 	globals_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	globals_editor->register_search_box(search_box);
-	globals_editor->get_inspector()->connect_compat("property_selected", this, "_item_selected");
-	globals_editor->get_inspector()->connect_compat("property_edited", this, "_settings_prop_edited");
-	globals_editor->get_inspector()->connect_compat("restart_requested", this, "_editor_restart_request");
+	globals_editor->get_inspector()->connect("property_selected", Callable(this, "_item_selected"));
+	globals_editor->get_inspector()->connect("property_edited", Callable(this, "_settings_prop_edited"));
+	globals_editor->get_inspector()->connect("restart_requested", Callable(this, "_editor_restart_request"));
 
 	Button *del = memnew(Button);
 	hbc->add_child(del);
 	del->set_text(TTR("Delete"));
-	del->connect_compat("pressed", this, "_item_del");
+	del->connect("pressed", Callable(this, "_item_del"));
 
 	add_prop_bar->add_child(memnew(VSeparator));
 
@@ -1879,8 +1879,8 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	popup_copy_to_feature->set_disabled(true);
 	add_prop_bar->add_child(popup_copy_to_feature);
 
-	popup_copy_to_feature->get_popup()->connect_compat("id_pressed", this, "_copy_to_platform");
-	popup_copy_to_feature->get_popup()->connect_compat("about_to_show", this, "_copy_to_platform_about_to_show");
+	popup_copy_to_feature->get_popup()->connect("id_pressed", Callable(this, "_copy_to_platform"));
+	popup_copy_to_feature->get_popup()->connect("about_to_show", Callable(this, "_copy_to_platform_about_to_show"));
 
 	get_ok()->set_text(TTR("Close"));
 	set_hide_on_ok(true);
@@ -1897,11 +1897,11 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	restart_hb->add_child(restart_label);
 	restart_hb->add_spacer();
 	Button *restart_button = memnew(Button);
-	restart_button->connect_compat("pressed", this, "_editor_restart");
+	restart_button->connect("pressed", Callable(this, "_editor_restart"));
 	restart_hb->add_child(restart_button);
 	restart_button->set_text(TTR("Save & Restart"));
 	restart_close_button = memnew(ToolButton);
-	restart_close_button->connect_compat("pressed", this, "_editor_restart_close");
+	restart_close_button->connect("pressed", Callable(this, "_editor_restart_close"));
 	restart_hb->add_child(restart_close_button);
 	restart_container->hide();
 
@@ -1929,8 +1929,8 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	action_name = memnew(LineEdit);
 	action_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	hbc->add_child(action_name);
-	action_name->connect_compat("text_entered", this, "_action_adds");
-	action_name->connect_compat("text_changed", this, "_action_check");
+	action_name->connect("text_entered", Callable(this, "_action_adds"));
+	action_name->connect("text_changed", Callable(this, "_action_check"));
 
 	action_add_error = memnew(Label);
 	hbc->add_child(action_add_error);
@@ -1940,7 +1940,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	hbc->add_child(add);
 	add->set_text(TTR("Add"));
 	add->set_disabled(true);
-	add->connect_compat("pressed", this, "_action_add");
+	add->connect("pressed", Callable(this, "_action_add"));
 	action_add = add;
 
 	input_editor = memnew(Tree);
@@ -1954,15 +1954,15 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	input_editor->set_column_min_width(1, 80 * EDSCALE);
 	input_editor->set_column_expand(2, false);
 	input_editor->set_column_min_width(2, 50 * EDSCALE);
-	input_editor->connect_compat("item_edited", this, "_action_edited");
-	input_editor->connect_compat("item_activated", this, "_action_activated");
-	input_editor->connect_compat("cell_selected", this, "_action_selected");
-	input_editor->connect_compat("button_pressed", this, "_action_button_pressed");
+	input_editor->connect("item_edited", Callable(this, "_action_edited"));
+	input_editor->connect("item_activated", Callable(this, "_action_activated"));
+	input_editor->connect("cell_selected", Callable(this, "_action_selected"));
+	input_editor->connect("button_pressed", Callable(this, "_action_button_pressed"));
 	input_editor->set_drag_forwarding(this);
 
 	popup_add = memnew(PopupMenu);
 	add_child(popup_add);
-	popup_add->connect_compat("id_pressed", this, "_add_item");
+	popup_add->connect("id_pressed", Callable(this, "_add_item"));
 
 	press_a_key = memnew(ConfirmationDialog);
 	press_a_key->set_focus_mode(FOCUS_ALL);
@@ -1977,13 +1977,13 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	press_a_key->get_ok()->set_disabled(true);
 	press_a_key_label = l;
 	press_a_key->add_child(l);
-	press_a_key->connect_compat("gui_input", this, "_wait_for_key");
-	press_a_key->connect_compat("confirmed", this, "_press_a_key_confirm");
+	press_a_key->connect("gui_input", Callable(this, "_wait_for_key"));
+	press_a_key->connect("confirmed", Callable(this, "_press_a_key_confirm"));
 
 	device_input = memnew(ConfirmationDialog);
 	add_child(device_input);
 	device_input->get_ok()->set_text(TTR("Add"));
-	device_input->connect_compat("confirmed", this, "_device_input_add");
+	device_input->connect("confirmed", Callable(this, "_device_input_add"));
 
 	hbc = memnew(HBoxContainer);
 	device_input->add_child(hbc);
@@ -2034,7 +2034,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		thb->add_child(memnew(Label(TTR("Translations:"))));
 		thb->add_spacer();
 		Button *addtr = memnew(Button(TTR("Add...")));
-		addtr->connect_compat("pressed", this, "_translation_file_open");
+		addtr->connect("pressed", Callable(this, "_translation_file_open"));
 		thb->add_child(addtr);
 		VBoxContainer *tmc = memnew(VBoxContainer);
 		tvb->add_child(tmc);
@@ -2046,7 +2046,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		translation_file_open = memnew(EditorFileDialog);
 		add_child(translation_file_open);
 		translation_file_open->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-		translation_file_open->connect_compat("file_selected", this, "_translation_add");
+		translation_file_open->connect("file_selected", Callable(this, "_translation_add"));
 	}
 
 	{
@@ -2058,28 +2058,28 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		thb->add_child(memnew(Label(TTR("Resources:"))));
 		thb->add_spacer();
 		Button *addtr = memnew(Button(TTR("Add...")));
-		addtr->connect_compat("pressed", this, "_translation_res_file_open");
+		addtr->connect("pressed", Callable(this, "_translation_res_file_open"));
 		thb->add_child(addtr);
 		VBoxContainer *tmc = memnew(VBoxContainer);
 		tvb->add_child(tmc);
 		tmc->set_v_size_flags(SIZE_EXPAND_FILL);
 		translation_remap = memnew(Tree);
 		translation_remap->set_v_size_flags(SIZE_EXPAND_FILL);
-		translation_remap->connect_compat("cell_selected", this, "_translation_res_select");
+		translation_remap->connect("cell_selected", Callable(this, "_translation_res_select"));
 		tmc->add_child(translation_remap);
-		translation_remap->connect_compat("button_pressed", this, "_translation_res_delete");
+		translation_remap->connect("button_pressed", Callable(this, "_translation_res_delete"));
 
 		translation_res_file_open = memnew(EditorFileDialog);
 		add_child(translation_res_file_open);
 		translation_res_file_open->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-		translation_res_file_open->connect_compat("file_selected", this, "_translation_res_add");
+		translation_res_file_open->connect("file_selected", Callable(this, "_translation_res_add"));
 
 		thb = memnew(HBoxContainer);
 		tvb->add_child(thb);
 		thb->add_child(memnew(Label(TTR("Remaps by Locale:"))));
 		thb->add_spacer();
 		addtr = memnew(Button(TTR("Add...")));
-		addtr->connect_compat("pressed", this, "_translation_res_option_file_open");
+		addtr->connect("pressed", Callable(this, "_translation_res_option_file_open"));
 		translation_res_option_add_button = addtr;
 		thb->add_child(addtr);
 		tmc = memnew(VBoxContainer);
@@ -2096,13 +2096,13 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		translation_remap_options->set_column_expand(0, true);
 		translation_remap_options->set_column_expand(1, false);
 		translation_remap_options->set_column_min_width(1, 200);
-		translation_remap_options->connect_compat("item_edited", this, "_translation_res_option_changed");
-		translation_remap_options->connect_compat("button_pressed", this, "_translation_res_option_delete");
+		translation_remap_options->connect("item_edited", Callable(this, "_translation_res_option_changed"));
+		translation_remap_options->connect("button_pressed", Callable(this, "_translation_res_option_delete"));
 
 		translation_res_option_file_open = memnew(EditorFileDialog);
 		add_child(translation_res_option_file_open);
 		translation_res_option_file_open->set_mode(EditorFileDialog::MODE_OPEN_FILE);
-		translation_res_option_file_open->connect_compat("file_selected", this, "_translation_res_option_add");
+		translation_res_option_file_open->connect("file_selected", Callable(this, "_translation_res_option_add"));
 	}
 
 	{
@@ -2118,20 +2118,20 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		translation_locale_filter_mode->add_item(TTR("Show Selected Locales Only"), SHOW_ONLY_SELECTED_LOCALES);
 		translation_locale_filter_mode->select(0);
 		tmc->add_margin_child(TTR("Filter mode:"), translation_locale_filter_mode);
-		translation_locale_filter_mode->connect_compat("item_selected", this, "_translation_filter_mode_changed");
+		translation_locale_filter_mode->connect("item_selected", Callable(this, "_translation_filter_mode_changed"));
 
 		translation_filter = memnew(Tree);
 		translation_filter->set_v_size_flags(SIZE_EXPAND_FILL);
 		translation_filter->set_columns(1);
 		tmc->add_child(memnew(Label(TTR("Locales:"))));
 		tmc->add_child(translation_filter);
-		translation_filter->connect_compat("item_edited", this, "_translation_filter_option_changed");
+		translation_filter->connect("item_edited", Callable(this, "_translation_filter_option_changed"));
 	}
 
 	autoload_settings = memnew(EditorAutoloadSettings);
 	autoload_settings->set_name(TTR("AutoLoad"));
 	tab_container->add_child(autoload_settings);
-	autoload_settings->connect_compat("autoload_changed", this, "_settings_changed");
+	autoload_settings->connect("autoload_changed", Callable(this, "_settings_changed"));
 
 	plugin_settings = memnew(EditorPluginSettings);
 	plugin_settings->set_name(TTR("Plugins"));
@@ -2139,7 +2139,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	timer = memnew(Timer);
 	timer->set_wait_time(1.5);
-	timer->connect_compat("timeout", ProjectSettings::get_singleton(), "save");
+	timer->connect("timeout", Callable(ProjectSettings::get_singleton(), "save"));
 	timer->set_one_shot(true);
 	add_child(timer);
 

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -589,7 +589,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 
 				if (!create_dialog) {
 					create_dialog = memnew(CreateDialog);
-					create_dialog->connect_compat("create", this, "_create_dialog_callback");
+					create_dialog->connect("create", Callable(this, "_create_dialog_callback"));
 					add_child(create_dialog);
 				}
 
@@ -608,7 +608,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 #define MAKE_PROPSELECT                                                                 \
 	if (!property_select) {                                                             \
 		property_select = memnew(PropertySelector);                                     \
-		property_select->connect_compat("selected", this, "_create_selected_property"); \
+		property_select->connect("selected", Callable(this, "_create_selected_property")); \
 		add_child(property_select);                                                     \
 	}                                                                                   \
 	hide();
@@ -865,7 +865,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				color_picker->set_deferred_mode(true);
 				add_child(color_picker);
 				color_picker->hide();
-				color_picker->connect_compat("color_changed", this, "_color_changed");
+				color_picker->connect("color_changed", Callable(this, "_color_changed"));
 
 				// get default color picker mode from editor settings
 				int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
@@ -1902,9 +1902,9 @@ CustomPropertyEditor::CustomPropertyEditor() {
 		add_child(value_label[i]);
 		value_editor[i]->hide();
 		value_label[i]->hide();
-		value_editor[i]->connect_compat("text_entered", this, "_modified");
-		value_editor[i]->connect_compat("focus_entered", this, "_focus_enter");
-		value_editor[i]->connect_compat("focus_exited", this, "_focus_exit");
+		value_editor[i]->connect("text_entered", Callable(this, "_modified"));
+		value_editor[i]->connect("focus_entered", Callable(this, "_focus_enter"));
+		value_editor[i]->connect("focus_exited", Callable(this, "_focus_exit"));
 	}
 	focused_value_editor = -1;
 
@@ -1934,7 +1934,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 		checks20[i]->set_focus_mode(FOCUS_NONE);
 		checks20gc->add_child(checks20[i]);
 		checks20[i]->hide();
-		checks20[i]->connect_compat("pressed", this, "_action_pressed", make_binds(i));
+		checks20[i]->connect("pressed", Callable(this, "_action_pressed"), make_binds(i));
 		checks20[i]->set_tooltip(vformat(TTR("Bit %d, val %d."), i, 1 << i));
 	}
 
@@ -1944,7 +1944,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 	text_edit->set_margin(MARGIN_BOTTOM, -30);
 
 	text_edit->hide();
-	text_edit->connect_compat("text_changed", this, "_text_edit_changed");
+	text_edit->connect("text_changed", Callable(this, "_text_edit_changed"));
 
 	for (int i = 0; i < MAX_ACTION_BUTTONS; i++) {
 
@@ -1953,7 +1953,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 		add_child(action_buttons[i]);
 		Vector<Variant> binds;
 		binds.push_back(i);
-		action_buttons[i]->connect_compat("pressed", this, "_action_pressed", binds);
+		action_buttons[i]->connect("pressed", Callable(this, "_action_pressed"), binds);
 		action_buttons[i]->set_flat(true);
 	}
 
@@ -1964,8 +1964,8 @@ CustomPropertyEditor::CustomPropertyEditor() {
 	add_child(file);
 	file->hide();
 
-	file->connect_compat("file_selected", this, "_file_selected");
-	file->connect_compat("dir_selected", this, "_file_selected");
+	file->connect("file_selected", Callable(this, "_file_selected"));
+	file->connect("dir_selected", Callable(this, "_file_selected"));
 
 	error = memnew(ConfirmationDialog);
 	error->set_title(TTR("Error!"));
@@ -1973,7 +1973,7 @@ CustomPropertyEditor::CustomPropertyEditor() {
 
 	scene_tree = memnew(SceneTreeDialog);
 	add_child(scene_tree);
-	scene_tree->connect_compat("selected", this, "_node_path_selected");
+	scene_tree->connect("selected", Callable(this, "_node_path_selected"));
 	scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
 
 	texture_preview = memnew(TextureRect);
@@ -1983,31 +1983,31 @@ CustomPropertyEditor::CustomPropertyEditor() {
 	easing_draw = memnew(Control);
 	add_child(easing_draw);
 	easing_draw->hide();
-	easing_draw->connect_compat("draw", this, "_draw_easing");
-	easing_draw->connect_compat("gui_input", this, "_drag_easing");
+	easing_draw->connect("draw", Callable(this, "_draw_easing"));
+	easing_draw->connect("gui_input", Callable(this, "_drag_easing"));
 	easing_draw->set_default_cursor_shape(Control::CURSOR_MOVE);
 
 	type_button = memnew(MenuButton);
 	add_child(type_button);
 	type_button->hide();
-	type_button->get_popup()->connect_compat("id_pressed", this, "_type_create_selected");
+	type_button->get_popup()->connect("id_pressed", Callable(this, "_type_create_selected"));
 
 	menu = memnew(PopupMenu);
 	menu->set_pass_on_modal_close_click(false);
 	add_child(menu);
-	menu->connect_compat("id_pressed", this, "_menu_option");
+	menu->connect("id_pressed", Callable(this, "_menu_option"));
 
 	evaluator = NULL;
 
 	spinbox = memnew(SpinBox);
 	add_child(spinbox);
 	spinbox->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 5);
-	spinbox->connect_compat("value_changed", this, "_range_modified");
+	spinbox->connect("value_changed", Callable(this, "_range_modified"));
 
 	slider = memnew(HSlider);
 	add_child(slider);
 	slider->set_anchors_and_margins_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 5);
-	slider->connect_compat("value_changed", this, "_range_modified");
+	slider->connect("value_changed", Callable(this, "_range_modified"));
 
 	create_dialog = NULL;
 	property_select = NULL;

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -393,9 +393,9 @@ void PropertySelector::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		connect_compat("confirmed", this, "_confirmed");
+		connect("confirmed", Callable(this, "_confirmed"));
 	} else if (p_what == NOTIFICATION_EXIT_TREE) {
-		disconnect_compat("confirmed", this, "_confirmed");
+		disconnect("confirmed", Callable(this, "_confirmed"));
 	}
 }
 
@@ -557,21 +557,21 @@ PropertySelector::PropertySelector() {
 	//set_child_rect(vbc);
 	search_box = memnew(LineEdit);
 	vbc->add_margin_child(TTR("Search:"), search_box);
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_changed", Callable(this, "_text_changed"));
+	search_box->connect("gui_input", Callable(this, "_sbox_input"));
 	search_options = memnew(Tree);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 	get_ok()->set_text(TTR("Open"));
 	get_ok()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect_compat("item_activated", this, "_confirmed");
-	search_options->connect_compat("cell_selected", this, "_item_selected");
+	search_options->connect("item_activated", Callable(this, "_confirmed"));
+	search_options->connect("cell_selected", Callable(this, "_item_selected"));
 	search_options->set_hide_root(true);
 	search_options->set_hide_folding(true);
 	virtuals_only = false;
 
 	help_bit = memnew(EditorHelpBit);
 	vbc->add_margin_child(TTR("Description:"), help_bit);
-	help_bit->connect_compat("request_hide", this, "_closed");
+	help_bit->connect("request_hide", Callable(this, "_closed"));
 }

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -257,7 +257,7 @@ void EditorQuickOpen::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			connect_compat("confirmed", this, "_confirmed");
+			connect("confirmed", Callable(this, "_confirmed"));
 
 			search_box->set_clear_button_enabled(true);
 			[[fallthrough]];
@@ -266,7 +266,7 @@ void EditorQuickOpen::_notification(int p_what) {
 			search_box->set_right_icon(get_icon("Search", "EditorIcons"));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			disconnect_compat("confirmed", this, "_confirmed");
+			disconnect("confirmed", Callable(this, "_confirmed"));
 		} break;
 	}
 }
@@ -291,15 +291,15 @@ EditorQuickOpen::EditorQuickOpen() {
 	add_child(vbc);
 	search_box = memnew(LineEdit);
 	vbc->add_margin_child(TTR("Search:"), search_box);
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_changed", Callable(this, "_text_changed"));
+	search_box->connect("gui_input", Callable(this, "_sbox_input"));
 	search_options = memnew(Tree);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 	get_ok()->set_text(TTR("Open"));
 	get_ok()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect_compat("item_activated", this, "_confirmed");
+	search_options->connect("item_activated", Callable(this, "_confirmed"));
 	search_options->set_hide_root(true);
 	search_options->set_hide_folding(true);
 	search_options->add_constant_override("draw_guides", 1);

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -144,7 +144,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_name->set_text("NAME");
 	but_insert_name->set_tooltip(String("${NAME}\n") + TTR("Node name"));
 	but_insert_name->set_focus_mode(FOCUS_NONE);
-	but_insert_name->connect_compat("pressed", this, "_insert_text", make_binds("${NAME}"));
+	but_insert_name->connect("pressed", Callable(this, "_insert_text"), make_binds("${NAME}"));
 	but_insert_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_name);
 
@@ -154,7 +154,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_parent->set_text("PARENT");
 	but_insert_parent->set_tooltip(String("${PARENT}\n") + TTR("Node's parent name, if available"));
 	but_insert_parent->set_focus_mode(FOCUS_NONE);
-	but_insert_parent->connect_compat("pressed", this, "_insert_text", make_binds("${PARENT}"));
+	but_insert_parent->connect("pressed", Callable(this, "_insert_text"), make_binds("${PARENT}"));
 	but_insert_parent->set_h_size_flags(SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_parent);
 
@@ -164,7 +164,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_type->set_text("TYPE");
 	but_insert_type->set_tooltip(String("${TYPE}\n") + TTR("Node type"));
 	but_insert_type->set_focus_mode(FOCUS_NONE);
-	but_insert_type->connect_compat("pressed", this, "_insert_text", make_binds("${TYPE}"));
+	but_insert_type->connect("pressed", Callable(this, "_insert_text"), make_binds("${TYPE}"));
 	but_insert_type->set_h_size_flags(SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_type);
 
@@ -174,7 +174,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_scene->set_text("SCENE");
 	but_insert_scene->set_tooltip(String("${SCENE}\n") + TTR("Current scene name"));
 	but_insert_scene->set_focus_mode(FOCUS_NONE);
-	but_insert_scene->connect_compat("pressed", this, "_insert_text", make_binds("${SCENE}"));
+	but_insert_scene->connect("pressed", Callable(this, "_insert_text"), make_binds("${SCENE}"));
 	but_insert_scene->set_h_size_flags(SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_scene);
 
@@ -184,7 +184,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_root->set_text("ROOT");
 	but_insert_root->set_tooltip(String("${ROOT}\n") + TTR("Root node name"));
 	but_insert_root->set_focus_mode(FOCUS_NONE);
-	but_insert_root->connect_compat("pressed", this, "_insert_text", make_binds("${ROOT}"));
+	but_insert_root->connect("pressed", Callable(this, "_insert_text"), make_binds("${ROOT}"));
 	but_insert_root->set_h_size_flags(SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_root);
 
@@ -194,7 +194,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	but_insert_count->set_text("COUNTER");
 	but_insert_count->set_tooltip(String("${COUNTER}\n") + TTR("Sequential integer counter.\nCompare counter options."));
 	but_insert_count->set_focus_mode(FOCUS_NONE);
-	but_insert_count->connect_compat("pressed", this, "_insert_text", make_binds("${COUNTER}"));
+	but_insert_count->connect("pressed", Callable(this, "_insert_text"), make_binds("${COUNTER}"));
 	but_insert_count->set_h_size_flags(SIZE_EXPAND_FILL);
 	grd_substitute->add_child(but_insert_count);
 
@@ -306,35 +306,35 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	// ---- Connections
 
-	cbut_collapse_features->connect_compat("toggled", this, "_features_toggled");
+	cbut_collapse_features->connect("toggled", Callable(this, "_features_toggled"));
 
 	// Substitite Buttons
 
-	lne_search->connect_compat("focus_entered", this, "_update_substitute");
-	lne_search->connect_compat("focus_exited", this, "_update_substitute");
-	lne_replace->connect_compat("focus_entered", this, "_update_substitute");
-	lne_replace->connect_compat("focus_exited", this, "_update_substitute");
-	lne_prefix->connect_compat("focus_entered", this, "_update_substitute");
-	lne_prefix->connect_compat("focus_exited", this, "_update_substitute");
-	lne_suffix->connect_compat("focus_entered", this, "_update_substitute");
-	lne_suffix->connect_compat("focus_exited", this, "_update_substitute");
+	lne_search->connect("focus_entered", Callable(this, "_update_substitute"));
+	lne_search->connect("focus_exited", Callable(this, "_update_substitute"));
+	lne_replace->connect("focus_entered", Callable(this, "_update_substitute"));
+	lne_replace->connect("focus_exited", Callable(this, "_update_substitute"));
+	lne_prefix->connect("focus_entered", Callable(this, "_update_substitute"));
+	lne_prefix->connect("focus_exited", Callable(this, "_update_substitute"));
+	lne_suffix->connect("focus_entered", Callable(this, "_update_substitute"));
+	lne_suffix->connect("focus_exited", Callable(this, "_update_substitute"));
 
 	// Preview
 
-	lne_prefix->connect_compat("text_changed", this, "_update_preview");
-	lne_suffix->connect_compat("text_changed", this, "_update_preview");
-	lne_search->connect_compat("text_changed", this, "_update_preview");
-	lne_replace->connect_compat("text_changed", this, "_update_preview");
-	spn_count_start->connect_compat("value_changed", this, "_update_preview_int");
-	spn_count_step->connect_compat("value_changed", this, "_update_preview_int");
-	spn_count_padding->connect_compat("value_changed", this, "_update_preview_int");
-	opt_style->connect_compat("item_selected", this, "_update_preview_int");
-	opt_case->connect_compat("item_selected", this, "_update_preview_int");
-	cbut_substitute->connect_compat("pressed", this, "_update_preview", varray(""));
-	cbut_regex->connect_compat("pressed", this, "_update_preview", varray(""));
-	cbut_process->connect_compat("pressed", this, "_update_preview", varray(""));
+	lne_prefix->connect("text_changed", Callable(this, "_update_preview"));
+	lne_suffix->connect("text_changed", Callable(this, "_update_preview"));
+	lne_search->connect("text_changed", Callable(this, "_update_preview"));
+	lne_replace->connect("text_changed", Callable(this, "_update_preview"));
+	spn_count_start->connect("value_changed", Callable(this, "_update_preview_int"));
+	spn_count_step->connect("value_changed", Callable(this, "_update_preview_int"));
+	spn_count_padding->connect("value_changed", Callable(this, "_update_preview_int"));
+	opt_style->connect("item_selected", Callable(this, "_update_preview_int"));
+	opt_case->connect("item_selected", Callable(this, "_update_preview_int"));
+	cbut_substitute->connect("pressed", Callable(this, "_update_preview"), varray(""));
+	cbut_regex->connect("pressed", Callable(this, "_update_preview"), varray(""));
+	cbut_process->connect("pressed", Callable(this, "_update_preview"), varray(""));
 
-	but_reset->connect_compat("pressed", this, "reset");
+	but_reset->connect("pressed", Callable(this, "reset"));
 
 	reset();
 	_features_toggled(false);

--- a/editor/reparent_dialog.cpp
+++ b/editor/reparent_dialog.cpp
@@ -38,12 +38,12 @@ void ReparentDialog::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		connect_compat("confirmed", this, "_reparent");
+		connect("confirmed", Callable(this, "_reparent"));
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 
-		disconnect_compat("confirmed", this, "_reparent");
+		disconnect("confirmed", Callable(this, "_reparent"));
 	}
 
 	if (p_what == NOTIFICATION_DRAW) {
@@ -93,7 +93,7 @@ ReparentDialog::ReparentDialog() {
 
 	vbc->add_margin_child(TTR("Reparent Location (Select new Parent):"), tree, true);
 
-	tree->get_scene_tree()->connect_compat("item_activated", this, "_reparent");
+	tree->get_scene_tree()->connect("item_activated", Callable(this, "_reparent"));
 
 	//Label *label = memnew( Label );
 	//label->set_position( Point2( 15,8) );

--- a/editor/run_settings_dialog.cpp
+++ b/editor/run_settings_dialog.cpp
@@ -81,7 +81,7 @@ RunSettingsDialog::RunSettingsDialog() {
 	vbc->add_margin_child(TTR("Run Mode:"), run_mode);
 	run_mode->add_item(TTR("Current Scene"));
 	run_mode->add_item(TTR("Main Scene"));
-	run_mode->connect_compat("item_selected", this, "_run_mode_changed");
+	run_mode->connect("item_selected", Callable(this, "_run_mode_changed"));
 	arguments = memnew(LineEdit);
 	vbc->add_margin_child(TTR("Main Scene Arguments:"), arguments);
 	arguments->set_editable(false);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1046,18 +1046,18 @@ void SceneTreeDock::_notification(int p_what) {
 				break;
 			first_enter = false;
 
-			EditorFeatureProfileManager::get_singleton()->connect_compat("current_feature_profile_changed", this, "_feature_profile_changed");
+			EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", Callable(this, "_feature_profile_changed"));
 
 			CanvasItemEditorPlugin *canvas_item_plugin = Object::cast_to<CanvasItemEditorPlugin>(editor_data->get_editor("2D"));
 			if (canvas_item_plugin) {
-				canvas_item_plugin->get_canvas_item_editor()->connect_compat("item_lock_status_changed", scene_tree, "_update_tree");
-				canvas_item_plugin->get_canvas_item_editor()->connect_compat("item_group_status_changed", scene_tree, "_update_tree");
-				scene_tree->connect_compat("node_changed", canvas_item_plugin->get_canvas_item_editor()->get_viewport_control(), "update");
+				canvas_item_plugin->get_canvas_item_editor()->connect("item_lock_status_changed", Callable(scene_tree, "_update_tree"));
+				canvas_item_plugin->get_canvas_item_editor()->connect("item_group_status_changed", Callable(scene_tree, "_update_tree"));
+				scene_tree->connect("node_changed", Callable(canvas_item_plugin->get_canvas_item_editor()->get_viewport_control(), "update"));
 			}
 
 			SpatialEditorPlugin *spatial_editor_plugin = Object::cast_to<SpatialEditorPlugin>(editor_data->get_editor("3D"));
-			spatial_editor_plugin->get_spatial_editor()->connect_compat("item_lock_status_changed", scene_tree, "_update_tree");
-			spatial_editor_plugin->get_spatial_editor()->connect_compat("item_group_status_changed", scene_tree, "_update_tree");
+			spatial_editor_plugin->get_spatial_editor()->connect("item_lock_status_changed", Callable(scene_tree, "_update_tree"));
+			spatial_editor_plugin->get_spatial_editor()->connect("item_group_status_changed", Callable(scene_tree, "_update_tree"));
 
 			button_add->set_icon(get_icon("Add", "EditorIcons"));
 			button_instance->set_icon(get_icon("Instance", "EditorIcons"));
@@ -1067,8 +1067,8 @@ void SceneTreeDock::_notification(int p_what) {
 			filter->set_right_icon(get_icon("Search", "EditorIcons"));
 			filter->set_clear_button_enabled(true);
 
-			EditorNode::get_singleton()->get_editor_selection()->connect_compat("selection_changed", this, "_selection_changed");
-			scene_tree->get_scene_tree()->connect_compat("item_collapsed", this, "_node_collapsed");
+			EditorNode::get_singleton()->get_editor_selection()->connect("selection_changed", Callable(this, "_selection_changed"));
+			scene_tree->get_scene_tree()->connect("item_collapsed", Callable(this, "_node_collapsed"));
 
 			// create_root_dialog
 			HBoxContainer *top_row = memnew(HBoxContainer);
@@ -1083,7 +1083,7 @@ void SceneTreeDock::_notification(int p_what) {
 			node_shortcuts_toggle->set_toggle_mode(true);
 			node_shortcuts_toggle->set_pressed(EDITOR_GET("_use_favorites_root_selection"));
 			node_shortcuts_toggle->set_anchors_and_margins_preset(Control::PRESET_CENTER_RIGHT);
-			node_shortcuts_toggle->connect_compat("pressed", this, "_update_create_root_dialog");
+			node_shortcuts_toggle->connect("pressed", Callable(this, "_update_create_root_dialog"));
 			top_row->add_child(node_shortcuts_toggle);
 
 			create_root_dialog->add_child(top_row);
@@ -1099,18 +1099,18 @@ void SceneTreeDock::_notification(int p_what) {
 			beginner_node_shortcuts->add_child(button_2d);
 			button_2d->set_text(TTR("2D Scene"));
 			button_2d->set_icon(get_icon("Node2D", "EditorIcons"));
-			button_2d->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_CREATE_2D_SCENE, false));
+			button_2d->connect("pressed", Callable(this, "_tool_selected"), make_binds(TOOL_CREATE_2D_SCENE, false));
 			button_3d = memnew(Button);
 			beginner_node_shortcuts->add_child(button_3d);
 			button_3d->set_text(TTR("3D Scene"));
 			button_3d->set_icon(get_icon("Spatial", "EditorIcons"));
-			button_3d->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_CREATE_3D_SCENE, false));
+			button_3d->connect("pressed", Callable(this, "_tool_selected"), make_binds(TOOL_CREATE_3D_SCENE, false));
 
 			Button *button_ui = memnew(Button);
 			beginner_node_shortcuts->add_child(button_ui);
 			button_ui->set_text(TTR("User Interface"));
 			button_ui->set_icon(get_icon("Control", "EditorIcons"));
-			button_ui->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_CREATE_USER_INTERFACE, false));
+			button_ui->connect("pressed", Callable(this, "_tool_selected"), make_binds(TOOL_CREATE_USER_INTERFACE, false));
 
 			VBoxContainer *favorite_node_shortcuts = memnew(VBoxContainer);
 			favorite_node_shortcuts->set_name("FavoriteNodeShortcuts");
@@ -1120,7 +1120,7 @@ void SceneTreeDock::_notification(int p_what) {
 			node_shortcuts->add_child(button_custom);
 			button_custom->set_text(TTR("Other Node"));
 			button_custom->set_icon(get_icon("Add", "EditorIcons"));
-			button_custom->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_NEW, false));
+			button_custom->connect("pressed", Callable(this, "_tool_selected"), make_binds(TOOL_NEW, false));
 
 			node_shortcuts->add_spacer();
 			create_root_dialog->add_child(node_shortcuts);
@@ -1128,11 +1128,11 @@ void SceneTreeDock::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-			clear_inherit_confirm->connect_compat("confirmed", this, "_tool_selected", varray(TOOL_SCENE_CLEAR_INHERITANCE_CONFIRM));
+			clear_inherit_confirm->connect("confirmed", Callable(this, "_tool_selected"), varray(TOOL_SCENE_CLEAR_INHERITANCE_CONFIRM));
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			clear_inherit_confirm->disconnect_compat("confirmed", this, "_tool_selected");
+			clear_inherit_confirm->disconnect("confirmed", Callable(this, "_tool_selected"));
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			button_add->set_icon(get_icon("Add", "EditorIcons"));
@@ -1738,7 +1738,7 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 }
 
 void SceneTreeDock::_script_creation_closed() {
-	script_create_dialog->disconnect_compat("script_created", this, "_script_created");
+	script_create_dialog->disconnect("script_created", Callable(this, "_script_created"));
 }
 
 void SceneTreeDock::_toggle_editable_children_from_selection() {
@@ -2113,7 +2113,7 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 			Object::Connection &c = F->get();
 			if (!(c.flags & Object::CONNECT_PERSIST))
 				continue;
-			newnode->connect_compat(c.signal.get_name(), c.callable.get_object(), c.callable.get_method(), c.binds, Object::CONNECT_PERSIST);
+			newnode->connect(c.signal.get_name(), Callable(c.callable.get_object(), c.callable.get_method()), c.binds, Object::CONNECT_PERSIST);
 		}
 	}
 
@@ -2616,8 +2616,8 @@ void SceneTreeDock::attach_script_to_selected(bool p_extend) {
 		}
 	}
 
-	script_create_dialog->connect_compat("script_created", this, "_script_created");
-	script_create_dialog->connect_compat("popup_hide", this, "_script_creation_closed", varray(), CONNECT_ONESHOT);
+	script_create_dialog->connect("script_created", Callable(this, "_script_created"));
+	script_create_dialog->connect("popup_hide", Callable(this, "_script_creation_closed"), varray(), CONNECT_ONESHOT);
 	script_create_dialog->set_inheritance_base_type("Node");
 	script_create_dialog->config(inherits, path);
 	script_create_dialog->popup_centered();
@@ -2719,7 +2719,7 @@ void SceneTreeDock::_update_create_root_dialog() {
 					if (ScriptServer::is_global_class(name))
 						name = ScriptServer::get_global_class_native_base(name);
 					button->set_icon(EditorNode::get_singleton()->get_class_icon(name));
-					button->connect_compat("pressed", this, "_favorite_root_selected", make_binds(l));
+					button->connect("pressed", Callable(this, "_favorite_root_selected"), make_binds(l));
 				}
 			}
 
@@ -2850,13 +2850,13 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	ED_SHORTCUT("scene_tree/delete", TTR("Delete"), KEY_DELETE);
 
 	button_add = memnew(ToolButton);
-	button_add->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_NEW, false));
+	button_add->connect("pressed", Callable(this, "_tool_selected"), make_binds(TOOL_NEW, false));
 	button_add->set_tooltip(TTR("Add/Create a New Node."));
 	button_add->set_shortcut(ED_GET_SHORTCUT("scene_tree/add_child_node"));
 	filter_hbc->add_child(button_add);
 
 	button_instance = memnew(ToolButton);
-	button_instance->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_INSTANCE, false));
+	button_instance->connect("pressed", Callable(this, "_tool_selected"), make_binds(TOOL_INSTANCE, false));
 	button_instance->set_tooltip(TTR("Instance a scene file as a Node. Creates an inherited scene if no root node exists."));
 	button_instance->set_shortcut(ED_GET_SHORTCUT("scene_tree/instance_scene"));
 	filter_hbc->add_child(button_instance);
@@ -2867,17 +2867,17 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	filter->set_placeholder(TTR("Filter nodes"));
 	filter_hbc->add_child(filter);
 	filter->add_constant_override("minimum_spaces", 0);
-	filter->connect_compat("text_changed", this, "_filter_changed");
+	filter->connect("text_changed", Callable(this, "_filter_changed"));
 
 	button_create_script = memnew(ToolButton);
-	button_create_script->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_ATTACH_SCRIPT, false));
+	button_create_script->connect("pressed", Callable(this, "_tool_selected"), make_binds(TOOL_ATTACH_SCRIPT, false));
 	button_create_script->set_tooltip(TTR("Attach a new or existing script for the selected node."));
 	button_create_script->set_shortcut(ED_GET_SHORTCUT("scene_tree/attach_script"));
 	filter_hbc->add_child(button_create_script);
 	button_create_script->hide();
 
 	button_clear_script = memnew(ToolButton);
-	button_clear_script->connect_compat("pressed", this, "_tool_selected", make_binds(TOOL_CLEAR_SCRIPT, false));
+	button_clear_script->connect("pressed", Callable(this, "_tool_selected"), make_binds(TOOL_CLEAR_SCRIPT, false));
 	button_clear_script->set_tooltip(TTR("Clear a script for the selected node."));
 	button_clear_script->set_shortcut(ED_GET_SHORTCUT("scene_tree/clear_script"));
 	filter_hbc->add_child(button_clear_script);
@@ -2891,14 +2891,14 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	edit_remote->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit_remote->set_text(TTR("Remote"));
 	edit_remote->set_toggle_mode(true);
-	edit_remote->connect_compat("pressed", this, "_remote_tree_selected");
+	edit_remote->connect("pressed", Callable(this, "_remote_tree_selected"));
 
 	edit_local = memnew(ToolButton);
 	button_hb->add_child(edit_local);
 	edit_local->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit_local->set_text(TTR("Local"));
 	edit_local->set_toggle_mode(true);
-	edit_local->connect_compat("pressed", this, "_local_tree_selected");
+	edit_local->connect("pressed", Callable(this, "_local_tree_selected"));
 
 	remote_tree = NULL;
 	button_hb->hide();
@@ -2911,19 +2911,19 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	vbc->add_child(scene_tree);
 	scene_tree->set_v_size_flags(SIZE_EXPAND | SIZE_FILL);
-	scene_tree->connect_compat("rmb_pressed", this, "_tree_rmb");
+	scene_tree->connect("rmb_pressed", Callable(this, "_tree_rmb"));
 
-	scene_tree->connect_compat("node_selected", this, "_node_selected", varray(), CONNECT_DEFERRED);
-	scene_tree->connect_compat("node_renamed", this, "_node_renamed", varray(), CONNECT_DEFERRED);
-	scene_tree->connect_compat("node_prerename", this, "_node_prerenamed");
-	scene_tree->connect_compat("open", this, "_load_request");
-	scene_tree->connect_compat("open_script", this, "_script_open_request");
-	scene_tree->connect_compat("nodes_rearranged", this, "_nodes_dragged");
-	scene_tree->connect_compat("files_dropped", this, "_files_dropped");
-	scene_tree->connect_compat("script_dropped", this, "_script_dropped");
-	scene_tree->connect_compat("nodes_dragged", this, "_nodes_drag_begin");
+	scene_tree->connect("node_selected", Callable(this, "_node_selected"), varray(), CONNECT_DEFERRED);
+	scene_tree->connect("node_renamed", Callable(this, "_node_renamed"), varray(), CONNECT_DEFERRED);
+	scene_tree->connect("node_prerename", Callable(this, "_node_prerenamed"));
+	scene_tree->connect("open", Callable(this, "_load_request"));
+	scene_tree->connect("open_script", Callable(this, "_script_open_request"));
+	scene_tree->connect("nodes_rearranged", Callable(this, "_nodes_dragged"));
+	scene_tree->connect("files_dropped", Callable(this, "_files_dropped"));
+	scene_tree->connect("script_dropped", Callable(this, "_script_dropped"));
+	scene_tree->connect("nodes_dragged", Callable(this, "_nodes_drag_begin"));
 
-	scene_tree->get_scene_tree()->connect_compat("item_double_clicked", this, "_focus_node");
+	scene_tree->get_scene_tree()->connect("item_double_clicked", Callable(this, "_focus_node"));
 
 	scene_tree->set_undo_redo(&editor_data->get_undo_redo());
 	scene_tree->set_editor_selection(editor_selection);
@@ -2931,8 +2931,8 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	create_dialog = memnew(CreateDialog);
 	create_dialog->set_base_type("Node");
 	add_child(create_dialog);
-	create_dialog->connect_compat("create", this, "_create");
-	create_dialog->connect_compat("favorites_updated", this, "_update_create_root_dialog");
+	create_dialog->connect("create", Callable(this, "_create"));
+	create_dialog->connect("favorites_updated", Callable(this, "_update_create_root_dialog"));
 
 	rename_dialog = memnew(RenameDialog(scene_tree, &editor_data->get_undo_redo()));
 	add_child(rename_dialog);
@@ -2943,44 +2943,44 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	reparent_dialog = memnew(ReparentDialog);
 	add_child(reparent_dialog);
-	reparent_dialog->connect_compat("reparent", this, "_node_reparent");
+	reparent_dialog->connect("reparent", Callable(this, "_node_reparent"));
 
 	accept = memnew(AcceptDialog);
 	add_child(accept);
 
 	quick_open = memnew(EditorQuickOpen);
 	add_child(quick_open);
-	quick_open->connect_compat("quick_open", this, "_quick_open");
+	quick_open->connect("quick_open", Callable(this, "_quick_open"));
 	set_process_unhandled_key_input(true);
 
 	delete_dialog = memnew(ConfirmationDialog);
 	add_child(delete_dialog);
-	delete_dialog->connect_compat("confirmed", this, "_delete_confirm");
+	delete_dialog->connect("confirmed", Callable(this, "_delete_confirm"));
 
 	editable_instance_remove_dialog = memnew(ConfirmationDialog);
 	add_child(editable_instance_remove_dialog);
-	editable_instance_remove_dialog->connect_compat("confirmed", this, "_toggle_editable_children_from_selection");
+	editable_instance_remove_dialog->connect("confirmed", Callable(this, "_toggle_editable_children_from_selection"));
 
 	placeholder_editable_instance_remove_dialog = memnew(ConfirmationDialog);
 	add_child(placeholder_editable_instance_remove_dialog);
-	placeholder_editable_instance_remove_dialog->connect_compat("confirmed", this, "_toggle_placeholder_from_selection");
+	placeholder_editable_instance_remove_dialog->connect("confirmed", Callable(this, "_toggle_placeholder_from_selection"));
 
 	import_subscene_dialog = memnew(EditorSubScene);
 	add_child(import_subscene_dialog);
-	import_subscene_dialog->connect_compat("subscene_selected", this, "_import_subscene");
+	import_subscene_dialog->connect("subscene_selected", Callable(this, "_import_subscene"));
 
 	new_scene_from_dialog = memnew(EditorFileDialog);
 	new_scene_from_dialog->set_mode(EditorFileDialog::MODE_SAVE_FILE);
 	add_child(new_scene_from_dialog);
-	new_scene_from_dialog->connect_compat("file_selected", this, "_new_scene_from");
+	new_scene_from_dialog->connect("file_selected", Callable(this, "_new_scene_from"));
 
 	menu = memnew(PopupMenu);
 	add_child(menu);
-	menu->connect_compat("id_pressed", this, "_tool_selected");
+	menu->connect("id_pressed", Callable(this, "_tool_selected"));
 	menu->set_hide_on_window_lose_focus(true);
 	menu_subresources = memnew(PopupMenu);
 	menu_subresources->set_name("Sub-Resources");
-	menu_subresources->connect_compat("id_pressed", this, "_tool_selected");
+	menu_subresources->connect("id_pressed", Callable(this, "_tool_selected"));
 	menu->add_child(menu_subresources);
 	first_enter = true;
 	restore_script_editor_on_drag = false;

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -323,8 +323,8 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 
 	if (can_open_instance && undo_redo) { //Show buttons only when necessary(SceneTreeDock) to avoid crashes
 
-		if (!p_node->is_connected_compat("script_changed", this, "_node_script_changed"))
-			p_node->connect_compat("script_changed", this, "_node_script_changed", varray(p_node));
+		if (!p_node->is_connected("script_changed", Callable(this, "_node_script_changed")))
+			p_node->connect("script_changed", Callable(this, "_node_script_changed"), varray(p_node));
 
 		Ref<Script> script = p_node->get_script();
 		if (!script.is_null()) {
@@ -350,8 +350,8 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 			else
 				item->add_button(0, get_icon("GuiVisibilityHidden", "EditorIcons"), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
 
-			if (!p_node->is_connected_compat("visibility_changed", this, "_node_visibility_changed"))
-				p_node->connect_compat("visibility_changed", this, "_node_visibility_changed", varray(p_node));
+			if (!p_node->is_connected("visibility_changed", Callable(this, "_node_visibility_changed")))
+				p_node->connect("visibility_changed", Callable(this, "_node_visibility_changed"), varray(p_node));
 
 			_update_visibility_color(p_node, item);
 		} else if (p_node->is_class("Spatial")) {
@@ -370,8 +370,8 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 			else
 				item->add_button(0, get_icon("GuiVisibilityHidden", "EditorIcons"), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
 
-			if (!p_node->is_connected_compat("visibility_changed", this, "_node_visibility_changed"))
-				p_node->connect_compat("visibility_changed", this, "_node_visibility_changed", varray(p_node));
+			if (!p_node->is_connected("visibility_changed", Callable(this, "_node_visibility_changed")))
+				p_node->connect("visibility_changed", Callable(this, "_node_visibility_changed"), varray(p_node));
 
 			_update_visibility_color(p_node, item);
 		} else if (p_node->is_class("AnimationPlayer")) {
@@ -495,12 +495,12 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 	if (EditorNode::get_singleton()->is_exiting())
 		return; //speed up exit
 
-	if (p_node->is_connected_compat("script_changed", this, "_node_script_changed"))
-		p_node->disconnect_compat("script_changed", this, "_node_script_changed");
+	if (p_node->is_connected("script_changed", Callable(this, "_node_script_changed")))
+		p_node->disconnect("script_changed", Callable(this, "_node_script_changed"));
 
 	if (p_node->is_class("Spatial") || p_node->is_class("CanvasItem")) {
-		if (p_node->is_connected_compat("visibility_changed", this, "_node_visibility_changed"))
-			p_node->disconnect_compat("visibility_changed", this, "_node_visibility_changed");
+		if (p_node->is_connected("visibility_changed", Callable(this, "_node_visibility_changed")))
+			p_node->disconnect("visibility_changed", Callable(this, "_node_visibility_changed"));
 	}
 
 	if (p_node == selected) {
@@ -640,22 +640,22 @@ void SceneTreeEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 
-			get_tree()->connect_compat("tree_changed", this, "_tree_changed");
-			get_tree()->connect_compat("node_removed", this, "_node_removed");
-			get_tree()->connect_compat("node_renamed", this, "_node_renamed");
-			get_tree()->connect_compat("node_configuration_warning_changed", this, "_warning_changed");
+			get_tree()->connect("tree_changed", Callable(this, "_tree_changed"));
+			get_tree()->connect("node_removed", Callable(this, "_node_removed"));
+			get_tree()->connect("node_renamed", Callable(this, "_node_renamed"));
+			get_tree()->connect("node_configuration_warning_changed", Callable(this, "_warning_changed"));
 
-			tree->connect_compat("item_collapsed", this, "_cell_collapsed");
+			tree->connect("item_collapsed", Callable(this, "_cell_collapsed"));
 
 			_update_tree();
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 
-			get_tree()->disconnect_compat("tree_changed", this, "_tree_changed");
-			get_tree()->disconnect_compat("node_removed", this, "_node_removed");
-			get_tree()->disconnect_compat("node_renamed", this, "_node_renamed");
-			tree->disconnect_compat("item_collapsed", this, "_cell_collapsed");
-			get_tree()->disconnect_compat("node_configuration_warning_changed", this, "_warning_changed");
+			get_tree()->disconnect("tree_changed", Callable(this, "_tree_changed"));
+			get_tree()->disconnect("node_removed", Callable(this, "_node_removed"));
+			get_tree()->disconnect("node_renamed", Callable(this, "_node_renamed"));
+			tree->disconnect("item_collapsed", Callable(this, "_cell_collapsed"));
+			get_tree()->disconnect("node_configuration_warning_changed", Callable(this, "_warning_changed"));
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 
@@ -836,7 +836,7 @@ void SceneTreeEditor::set_editor_selection(EditorSelection *p_selection) {
 	editor_selection = p_selection;
 	tree->set_select_mode(Tree::SELECT_MULTI);
 	tree->set_cursor_can_exit_tree(false);
-	editor_selection->connect_compat("selection_changed", this, "_selection_changed");
+	editor_selection->connect("selection_changed", Callable(this, "_selection_changed"));
 }
 
 void SceneTreeEditor::_update_selection(TreeItem *item) {
@@ -1163,15 +1163,15 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	tree->set_drag_forwarding(this);
 	if (p_can_rename) {
 		tree->set_allow_rmb_select(true);
-		tree->connect_compat("item_rmb_selected", this, "_rmb_select");
-		tree->connect_compat("empty_tree_rmb_selected", this, "_rmb_select");
+		tree->connect("item_rmb_selected", Callable(this, "_rmb_select"));
+		tree->connect("empty_tree_rmb_selected", Callable(this, "_rmb_select"));
 	}
 
-	tree->connect_compat("cell_selected", this, "_selected_changed");
-	tree->connect_compat("item_edited", this, "_renamed", varray(), CONNECT_DEFERRED);
-	tree->connect_compat("multi_selected", this, "_cell_multi_selected");
-	tree->connect_compat("button_pressed", this, "_cell_button_pressed");
-	tree->connect_compat("nothing_selected", this, "_deselect_items");
+	tree->connect("cell_selected", Callable(this, "_selected_changed"));
+	tree->connect("item_edited", Callable(this, "_renamed"), varray(), CONNECT_DEFERRED);
+	tree->connect("multi_selected", Callable(this, "_cell_multi_selected"));
+	tree->connect("button_pressed", Callable(this, "_cell_button_pressed"));
+	tree->connect("nothing_selected", Callable(this, "_deselect_items"));
 	//tree->connect("item_edited", this,"_renamed",Vector<Variant>(),true);
 
 	error = memnew(AcceptDialog);
@@ -1189,7 +1189,7 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	blocked = 0;
 
 	update_timer = memnew(Timer);
-	update_timer->connect_compat("timeout", this, "_update_tree");
+	update_timer->connect("timeout", Callable(this, "_update_tree"));
 	update_timer->set_one_shot(true);
 	update_timer->set_wait_time(0.5);
 	add_child(update_timer);
@@ -1209,12 +1209,12 @@ void SceneTreeDialog::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			connect_compat("confirmed", this, "_select");
+			connect("confirmed", Callable(this, "_select"));
 			filter->set_right_icon(get_icon("Search", "EditorIcons"));
 			filter->set_clear_button_enabled(true);
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			disconnect_compat("confirmed", this, "_select");
+			disconnect("confirmed", Callable(this, "_select"));
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible_in_tree())
@@ -1259,12 +1259,12 @@ SceneTreeDialog::SceneTreeDialog() {
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	filter->set_placeholder(TTR("Filter nodes"));
 	filter->add_constant_override("minimum_spaces", 0);
-	filter->connect_compat("text_changed", this, "_filter_changed");
+	filter->connect("text_changed", Callable(this, "_filter_changed"));
 	vbc->add_child(filter);
 
 	tree = memnew(SceneTreeEditor(false, false, true));
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
-	tree->get_scene_tree()->connect_compat("item_activated", this, "_select");
+	tree->get_scene_tree()->connect("item_activated", Callable(this, "_select"));
 	vbc->add_child(tree);
 }
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -804,7 +804,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	language_menu->select(default_language);
 	current_language = default_language;
 
-	language_menu->connect_compat("item_selected", this, "_lang_changed");
+	language_menu->connect("item_selected", Callable(this, "_lang_changed"));
 
 	/* Inherits */
 
@@ -813,16 +813,16 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	hb = memnew(HBoxContainer);
 	hb->set_h_size_flags(SIZE_EXPAND_FILL);
 	parent_name = memnew(LineEdit);
-	parent_name->connect_compat("text_changed", this, "_parent_name_changed");
+	parent_name->connect("text_changed", Callable(this, "_parent_name_changed"));
 	parent_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	hb->add_child(parent_name);
 	parent_search_button = memnew(Button);
 	parent_search_button->set_flat(true);
-	parent_search_button->connect_compat("pressed", this, "_browse_class_in_tree");
+	parent_search_button->connect("pressed", Callable(this, "_browse_class_in_tree"));
 	hb->add_child(parent_search_button);
 	parent_browse_button = memnew(Button);
 	parent_browse_button->set_flat(true);
-	parent_browse_button->connect_compat("pressed", this, "_browse_path", varray(true, false));
+	parent_browse_button->connect("pressed", Callable(this, "_browse_path"), varray(true, false));
 	hb->add_child(parent_browse_button);
 	gc->add_child(memnew(Label(TTR("Inherits:"))));
 	gc->add_child(hb);
@@ -831,7 +831,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	/* Class Name */
 
 	class_name = memnew(LineEdit);
-	class_name->connect_compat("text_changed", this, "_class_name_changed");
+	class_name->connect("text_changed", Callable(this, "_class_name_changed"));
 	class_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	gc->add_child(memnew(Label(TTR("Class Name:"))));
 	gc->add_child(class_name);
@@ -841,28 +841,28 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	template_menu = memnew(OptionButton);
 	gc->add_child(memnew(Label(TTR("Template:"))));
 	gc->add_child(template_menu);
-	template_menu->connect_compat("item_selected", this, "_template_changed");
+	template_menu->connect("item_selected", Callable(this, "_template_changed"));
 
 	/* Built-in Script */
 
 	internal = memnew(CheckBox);
 	internal->set_text(TTR("On"));
-	internal->connect_compat("pressed", this, "_built_in_pressed");
+	internal->connect("pressed", Callable(this, "_built_in_pressed"));
 	gc->add_child(memnew(Label(TTR("Built-in Script:"))));
 	gc->add_child(internal);
 
 	/* Path */
 
 	hb = memnew(HBoxContainer);
-	hb->connect_compat("sort_children", this, "_path_hbox_sorted");
+	hb->connect("sort_children", Callable(this, "_path_hbox_sorted"));
 	file_path = memnew(LineEdit);
-	file_path->connect_compat("text_changed", this, "_path_changed");
-	file_path->connect_compat("text_entered", this, "_path_entered");
+	file_path->connect("text_changed", Callable(this, "_path_changed"));
+	file_path->connect("text_entered", Callable(this, "_path_entered"));
 	file_path->set_h_size_flags(SIZE_EXPAND_FILL);
 	hb->add_child(file_path);
 	path_button = memnew(Button);
 	path_button->set_flat(true);
-	path_button->connect_compat("pressed", this, "_browse_path", varray(false, true));
+	path_button->connect("pressed", Callable(this, "_browse_path"), varray(false, true));
 	hb->add_child(path_button);
 	gc->add_child(memnew(Label(TTR("Path:"))));
 	gc->add_child(hb);
@@ -871,11 +871,11 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	/* Dialog Setup */
 
 	select_class = memnew(CreateDialog);
-	select_class->connect_compat("create", this, "_create");
+	select_class->connect("create", Callable(this, "_create"));
 	add_child(select_class);
 
 	file_browse = memnew(EditorFileDialog);
-	file_browse->connect_compat("file_selected", this, "_file_selected");
+	file_browse->connect("file_selected", Callable(this, "_file_selected"));
 	file_browse->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 	add_child(file_browse);
 	get_ok()->set_text(TTR("Create"));

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -411,7 +411,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 
 	tabs = memnew(TabContainer);
 	tabs->set_tab_align(TabContainer::ALIGN_LEFT);
-	tabs->connect_compat("tab_changed", this, "_tabs_tab_changed");
+	tabs->connect("tab_changed", Callable(this, "_tabs_tab_changed"));
 	add_child(tabs);
 
 	// General Tab
@@ -434,8 +434,8 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector->get_inspector()->set_undo_redo(undo_redo);
 	tab_general->add_child(inspector);
-	inspector->get_inspector()->connect_compat("property_edited", this, "_settings_property_edited");
-	inspector->get_inspector()->connect_compat("restart_requested", this, "_editor_restart_request");
+	inspector->get_inspector()->connect("property_edited", Callable(this, "_settings_property_edited"));
+	inspector->get_inspector()->connect("restart_requested", Callable(this, "_editor_restart_request"));
 
 	restart_container = memnew(PanelContainer);
 	tab_general->add_child(restart_container);
@@ -449,11 +449,11 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	restart_hb->add_child(restart_label);
 	restart_hb->add_spacer();
 	Button *restart_button = memnew(Button);
-	restart_button->connect_compat("pressed", this, "_editor_restart");
+	restart_button->connect("pressed", Callable(this, "_editor_restart"));
 	restart_hb->add_child(restart_button);
 	restart_button->set_text(TTR("Save & Restart"));
 	restart_close_button = memnew(ToolButton);
-	restart_close_button->connect_compat("pressed", this, "_editor_restart_close");
+	restart_close_button->connect("pressed", Callable(this, "_editor_restart_close"));
 	restart_hb->add_child(restart_close_button);
 	restart_container->hide();
 
@@ -470,7 +470,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	shortcut_search_box = memnew(LineEdit);
 	shortcut_search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hbc->add_child(shortcut_search_box);
-	shortcut_search_box->connect_compat("text_changed", this, "_filter_shortcuts");
+	shortcut_search_box->connect("text_changed", Callable(this, "_filter_shortcuts"));
 
 	shortcuts = memnew(Tree);
 	tab_shortcuts->add_child(shortcuts, true);
@@ -480,7 +480,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	shortcuts->set_column_titles_visible(true);
 	shortcuts->set_column_title(0, TTR("Name"));
 	shortcuts->set_column_title(1, TTR("Binding"));
-	shortcuts->connect_compat("button_pressed", this, "_shortcut_button_pressed");
+	shortcuts->connect("button_pressed", Callable(this, "_shortcut_button_pressed"));
 
 	press_a_key = memnew(ConfirmationDialog);
 	press_a_key->set_focus_mode(FOCUS_ALL);
@@ -494,17 +494,17 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	l->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_BEGIN, 30);
 	press_a_key_label = l;
 	press_a_key->add_child(l);
-	press_a_key->connect_compat("gui_input", this, "_wait_for_key");
-	press_a_key->connect_compat("confirmed", this, "_press_a_key_confirm");
+	press_a_key->connect("gui_input", Callable(this, "_wait_for_key"));
+	press_a_key->connect("confirmed", Callable(this, "_press_a_key_confirm"));
 
 	set_hide_on_ok(true);
 
 	timer = memnew(Timer);
 	timer->set_wait_time(1.5);
-	timer->connect_compat("timeout", this, "_settings_save");
+	timer->connect("timeout", Callable(this, "_settings_save"));
 	timer->set_one_shot(true);
 	add_child(timer);
-	EditorSettings::get_singleton()->connect_compat("settings_changed", this, "_settings_changed");
+	EditorSettings::get_singleton()->connect("settings_changed", Callable(this, "_settings_changed"));
 	get_ok()->set_text(TTR("Close"));
 
 	updating = false;

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -898,12 +898,12 @@ void CSGMesh::set_mesh(const Ref<Mesh> &p_mesh) {
 	if (mesh == p_mesh)
 		return;
 	if (mesh.is_valid()) {
-		mesh->disconnect_compat("changed", this, "_mesh_changed");
+		mesh->disconnect("changed", Callable(this, "_mesh_changed"));
 	}
 	mesh = p_mesh;
 
 	if (mesh.is_valid()) {
-		mesh->connect_compat("changed", this, "_mesh_changed");
+		mesh->connect("changed", Callable(this, "_mesh_changed"));
 	}
 
 	_make_dirty();
@@ -1812,15 +1812,15 @@ CSGBrush *CSGPolygon::_build_brush() {
 
 		if (path != path_cache) {
 			if (path_cache) {
-				path_cache->disconnect_compat("tree_exited", this, "_path_exited");
-				path_cache->disconnect_compat("curve_changed", this, "_path_changed");
+				path_cache->disconnect("tree_exited", Callable(this, "_path_exited"));
+				path_cache->disconnect("curve_changed", Callable(this, "_path_changed"));
 				path_cache = NULL;
 			}
 
 			path_cache = path;
 
-			path_cache->connect_compat("tree_exited", this, "_path_exited");
-			path_cache->connect_compat("curve_changed", this, "_path_changed");
+			path_cache->connect("tree_exited", Callable(this, "_path_exited"));
+			path_cache->connect("curve_changed", Callable(this, "_path_changed"));
 			path_cache = NULL;
 		}
 		curve = path->get_curve();
@@ -2236,8 +2236,8 @@ CSGBrush *CSGPolygon::_build_brush() {
 void CSGPolygon::_notification(int p_what) {
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 		if (path_cache) {
-			path_cache->disconnect_compat("tree_exited", this, "_path_exited");
-			path_cache->disconnect_compat("curve_changed", this, "_path_changed");
+			path_cache->disconnect("tree_exited", Callable(this, "_path_exited"));
+			path_cache->disconnect("curve_changed", Callable(this, "_path_changed"));
 			path_cache = NULL;
 		}
 	}

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -359,7 +359,7 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 		filter_list->set_item_checked(idx, true);
 		idx += 1;
 	}
-	filter_list->connect_compat("index_pressed", this, "_on_filter_selected");
+	filter_list->connect("index_pressed", Callable(this, "_on_filter_selected"));
 
 	tree = memnew(Tree);
 	container->add_child(tree);
@@ -374,16 +374,16 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 	tree->set_column_title(2, TTR("Dependencies"));
 	tree->set_column_expand(3, false);
 	tree->set_column_min_width(3, int(110 * EDSCALE));
-	tree->connect_compat("button_pressed", this, "_on_item_button");
-	tree->connect_compat("item_collapsed", this, "_on_item_collapsed");
-	tree->connect_compat("item_activated", this, "_on_item_activated");
+	tree->connect("button_pressed", Callable(this, "_on_item_button"));
+	tree->connect("item_collapsed", Callable(this, "_on_item_collapsed"));
+	tree->connect("item_activated", Callable(this, "_on_item_activated"));
 
 	file_dialog = memnew(EditorFileDialog);
 	file_dialog->set_access(EditorFileDialog::ACCESS_RESOURCES);
 	file_dialog->set_resizable(true);
 	add_child(file_dialog);
-	file_dialog->connect_compat("file_selected", this, "_on_library_selected");
-	file_dialog->connect_compat("files_selected", this, "_on_dependencies_selected");
+	file_dialog->connect("file_selected", Callable(this, "_on_library_selected"));
+	file_dialog->connect("files_selected", Callable(this, "_on_dependencies_selected"));
 
 	new_architecture_dialog = memnew(ConfirmationDialog);
 	add_child(new_architecture_dialog);
@@ -392,7 +392,7 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 	new_architecture_dialog->add_child(new_architecture_input);
 	new_architecture_dialog->set_custom_minimum_size(Vector2(300, 80) * EDSCALE);
 	new_architecture_input->set_anchors_and_margins_preset(PRESET_HCENTER_WIDE, PRESET_MODE_MINSIZE, 5 * EDSCALE);
-	new_architecture_dialog->get_ok()->connect_compat("pressed", this, "_on_create_new_entry");
+	new_architecture_dialog->get_ok()->connect("pressed", Callable(this, "_on_create_new_entry"));
 }
 
 void GDNativeLibraryEditorPlugin::edit(Object *p_node) {

--- a/modules/gdnative/gdnative_library_singleton_editor.cpp
+++ b/modules/gdnative/gdnative_library_singleton_editor.cpp
@@ -207,8 +207,8 @@ GDNativeLibrarySingletonEditor::GDNativeLibrarySingletonEditor() {
 	libraries->set_hide_root(true);
 	add_margin_child(TTR("Libraries: "), libraries, true);
 	updating = false;
-	libraries->connect_compat("item_edited", this, "_item_edited");
-	EditorFileSystem::get_singleton()->connect_compat("filesystem_changed", this, "_discover_singletons");
+	libraries->connect("item_edited", Callable(this, "_item_edited"));
+	EditorFileSystem::get_singleton()->connect("filesystem_changed", Callable(this, "_discover_singletons"));
 }
 
 #endif // TOOLS_ENABLED

--- a/modules/gdnavigation/navigation_mesh_editor_plugin.cpp
+++ b/modules/gdnavigation/navigation_mesh_editor_plugin.cpp
@@ -107,13 +107,13 @@ NavigationMeshEditor::NavigationMeshEditor() {
 	bake_hbox->add_child(button_bake);
 	button_bake->set_toggle_mode(true);
 	button_bake->set_text(TTR("Bake NavMesh"));
-	button_bake->connect_compat("pressed", this, "_bake_pressed");
+	button_bake->connect("pressed", Callable(this, "_bake_pressed"));
 
 	button_reset = memnew(ToolButton);
 	bake_hbox->add_child(button_reset);
 	// No button text, we only use a revert icon which is set when entering the tree.
 	button_reset->set_tooltip(TTR("Clear the navigation mesh."));
-	button_reset->connect_compat("pressed", this, "_clear_pressed");
+	button_reset->connect("pressed", Callable(this, "_clear_pressed"));
 
 	bake_info = memnew(Label);
 	bake_hbox->add_child(bake_info);

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1332,7 +1332,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						OPCODE_BREAK;
 					}
 
-					Error err = obj->connect_compat(signal, gdfs.ptr(), "_signal_callback", varray(gdfs), Object::CONNECT_ONESHOT);
+					Error err = obj->connect(signal, Callable(gdfs.ptr(), "_signal_callback"), varray(gdfs), Object::CONNECT_ONESHOT);
 					if (err != OK) {
 						err_text = "Error connecting to signal: " + signal + " during yield().";
 						OPCODE_BREAK;
@@ -1341,7 +1341,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					Object *obj = argobj->operator Object *();
 					String signal = argname->operator String();
 
-					obj->connect_compat(signal, gdfs.ptr(), "_signal_callback", varray(gdfs), Object::CONNECT_ONESHOT);
+					obj->connect(signal, Callable(gdfs.ptr(), "_signal_callback"), varray(gdfs), Object::CONNECT_ONESHOT);
 #endif
 				}
 

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -954,7 +954,7 @@ void GridMapEditor::update_palette() {
 
 void GridMapEditor::edit(GridMap *p_gridmap) {
 	if (!p_gridmap && node)
-		node->disconnect_compat("cell_size_changed", this, "_draw_grids");
+		node->disconnect("cell_size_changed", Callable(this, "_draw_grids"));
 
 	node = p_gridmap;
 
@@ -988,7 +988,7 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 	update_grid();
 	_update_clip();
 
-	node->connect_compat("cell_size_changed", this, "_draw_grids");
+	node->connect("cell_size_changed", Callable(this, "_draw_grids"));
 }
 
 void GridMapEditor::_update_clip() {
@@ -1077,8 +1077,8 @@ void GridMapEditor::_notification(int p_what) {
 	switch (p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
-			get_tree()->connect_compat("node_removed", this, "_node_removed");
-			mesh_library_palette->connect_compat("item_selected", this, "_item_selected_cbk");
+			get_tree()->connect("node_removed", Callable(this, "_node_removed"));
+			mesh_library_palette->connect("item_selected", Callable(this, "_item_selected_cbk"));
 			for (int i = 0; i < 3; i++) {
 
 				grid[i] = VS::get_singleton()->mesh_create();
@@ -1094,7 +1094,7 @@ void GridMapEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			get_tree()->disconnect_compat("node_removed", this, "_node_removed");
+			get_tree()->disconnect("node_removed", Callable(this, "_node_removed"));
 			_clear_clipboard_data();
 
 			for (int i = 0; i < 3; i++) {
@@ -1241,9 +1241,9 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	floor->get_line_edit()->add_constant_override("minimum_spaces", 16);
 
 	spatial_editor_hb->add_child(floor);
-	floor->connect_compat("value_changed", this, "_floor_changed");
-	floor->connect_compat("mouse_exited", this, "_floor_mouse_exited");
-	floor->get_line_edit()->connect_compat("mouse_exited", this, "_floor_mouse_exited");
+	floor->connect("value_changed", Callable(this, "_floor_changed"));
+	floor->connect("mouse_exited", Callable(this, "_floor_mouse_exited"));
+	floor->get_line_edit()->connect("mouse_exited", Callable(this, "_floor_mouse_exited"));
 
 	spatial_editor_hb->add_child(memnew(VSeparator));
 
@@ -1300,7 +1300,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	settings_vbc->add_margin_child(TTR("Pick Distance:"), settings_pick_distance);
 
 	clip_mode = CLIP_DISABLED;
-	options->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	options->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_child(hb);
@@ -1310,22 +1310,22 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	search_box->set_placeholder(TTR("Filter meshes"));
 	hb->add_child(search_box);
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_changed", Callable(this, "_text_changed"));
+	search_box->connect("gui_input", Callable(this, "_sbox_input"));
 
 	mode_thumbnail = memnew(ToolButton);
 	mode_thumbnail->set_toggle_mode(true);
 	mode_thumbnail->set_pressed(true);
 	mode_thumbnail->set_icon(p_editor->get_gui_base()->get_icon("FileThumbnail", "EditorIcons"));
 	hb->add_child(mode_thumbnail);
-	mode_thumbnail->connect_compat("pressed", this, "_set_display_mode", varray(DISPLAY_THUMBNAIL));
+	mode_thumbnail->connect("pressed", Callable(this, "_set_display_mode"), varray(DISPLAY_THUMBNAIL));
 
 	mode_list = memnew(ToolButton);
 	mode_list->set_toggle_mode(true);
 	mode_list->set_pressed(false);
 	mode_list->set_icon(p_editor->get_gui_base()->get_icon("FileList", "EditorIcons"));
 	hb->add_child(mode_list);
-	mode_list->connect_compat("pressed", this, "_set_display_mode", varray(DISPLAY_LIST));
+	mode_list->connect("pressed", Callable(this, "_set_display_mode"), varray(DISPLAY_LIST));
 
 	size_slider = memnew(HSlider);
 	size_slider->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1333,7 +1333,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	size_slider->set_max(4.0f);
 	size_slider->set_step(0.1f);
 	size_slider->set_value(1.0f);
-	size_slider->connect_compat("value_changed", this, "_icon_size_changed");
+	size_slider->connect("value_changed", Callable(this, "_icon_size_changed"));
 	add_child(size_slider);
 
 	EDITOR_DEF("editors/grid_map/preview_size", 64);
@@ -1343,7 +1343,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	mesh_library_palette = memnew(ItemList);
 	add_child(mesh_library_palette);
 	mesh_library_palette->set_v_size_flags(SIZE_EXPAND_FILL);
-	mesh_library_palette->connect_compat("gui_input", this, "_mesh_library_palette_input");
+	mesh_library_palette->connect("gui_input", Callable(this, "_mesh_library_palette_input"));
 
 	info_message = memnew(Label);
 	info_message->set_text(TTR("Give a MeshLibrary resource to this GridMap to use its meshes."));

--- a/modules/mono/signal_awaiter_utils.cpp
+++ b/modules/mono/signal_awaiter_utils.cpp
@@ -51,8 +51,7 @@ Error connect_signal_awaiter(Object *p_source, const String &p_signal, Object *p
 	Vector<Variant> binds;
 	binds.push_back(sa_con);
 
-	Error err = p_source->connect_compat(p_signal, sa_con.ptr(),
-			CSharpLanguage::get_singleton()->get_string_names()._signal_callback,
+	Error err = p_source->connect(p_signal, Callable(Callable(sa_con.ptr(), CSharpLanguage::get_singleton())->get_string_names()._signal_callback),
 			binds, Object::CONNECT_ONESHOT);
 
 	if (err != OK) {

--- a/modules/opensimplex/noise_texture.cpp
+++ b/modules/opensimplex/noise_texture.cpp
@@ -184,11 +184,11 @@ void NoiseTexture::set_noise(Ref<OpenSimplexNoise> p_noise) {
 	if (p_noise == noise)
 		return;
 	if (noise.is_valid()) {
-		noise->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_queue_update");
+		noise->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_queue_update"));
 	}
 	noise = p_noise;
 	if (noise.is_valid()) {
-		noise->connect_compat(CoreStringNames::get_singleton()->changed, this, "_queue_update");
+		noise->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_queue_update"));
 	}
 	_queue_update();
 }

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -198,7 +198,7 @@ void VisualScript::remove_function(const StringName &p_name) {
 
 	for (Map<int, Function::NodeData>::Element *E = functions[p_name].nodes.front(); E; E = E->next()) {
 
-		E->get().node->disconnect_compat("ports_changed", this, "_node_ports_changed");
+		E->get().node->disconnect("ports_changed", Callable(this, "_node_ports_changed"));
 		E->get().node->scripts_used.erase(this);
 	}
 
@@ -340,7 +340,7 @@ void VisualScript::add_node(const StringName &p_func, int p_id, const Ref<Visual
 	nd.pos = p_pos;
 
 	Ref<VisualScriptNode> vsn = p_node;
-	vsn->connect_compat("ports_changed", this, "_node_ports_changed", varray(p_id));
+	vsn->connect("ports_changed", Callable(this, "_node_ports_changed"), varray(p_id));
 	vsn->scripts_used.insert(this);
 	vsn->validate_input_default_values(); // Validate when fully loaded
 
@@ -389,7 +389,7 @@ void VisualScript::remove_node(const StringName &p_func, int p_id) {
 		func.function_id = -1; //revert to invalid
 	}
 
-	func.nodes[p_id].node->disconnect_compat("ports_changed", this, "_node_ports_changed");
+	func.nodes[p_id].node->disconnect("ports_changed", Callable(this, "_node_ports_changed"));
 	func.nodes[p_id].node->scripts_used.erase(this);
 
 	func.nodes.erase(p_id);
@@ -2463,7 +2463,7 @@ void VisualScriptFunctionState::connect_to_signal(Object *p_obj, const String &p
 		binds.push_back(p_binds[i]);
 	}
 	binds.push_back(Ref<VisualScriptFunctionState>(this)); //add myself on the back to avoid dying from unreferencing
-	p_obj->connect_compat(p_signal, this, "_signal_callback", binds, CONNECT_ONESHOT);
+	p_obj->connect(p_signal, Callable(this, "_signal_callback"), binds, CONNECT_ONESHOT);
 }
 
 bool VisualScriptFunctionState::is_valid() const {

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -556,8 +556,8 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 
 			gnode->set_meta("__vnode", node);
 			gnode->set_name(itos(E->get()));
-			gnode->connect_compat("dragged", this, "_node_moved", varray(E->get()));
-			gnode->connect_compat("close_request", this, "_remove_node", varray(E->get()), CONNECT_DEFERRED);
+			gnode->connect("dragged", Callable(this, "_node_moved"), varray(E->get()));
+			gnode->connect("close_request", Callable(this, "_remove_node"), varray(E->get()), CONNECT_DEFERRED);
 
 			if (E->get() != script->get_function_node_id(F->get())) {
 				//function can't be erased
@@ -575,7 +575,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					Button *btn = memnew(Button);
 					btn->set_text(TTR("Add Input Port"));
 					hbnc->add_child(btn);
-					btn->connect_compat("pressed", this, "_add_input_port", varray(E->get()), CONNECT_DEFERRED);
+					btn->connect("pressed", Callable(this, "_add_input_port"), varray(E->get()), CONNECT_DEFERRED);
 				}
 				if (nd_list->is_output_port_editable()) {
 					if (nd_list->is_input_port_editable())
@@ -584,7 +584,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 					Button *btn = memnew(Button);
 					btn->set_text(TTR("Add Output Port"));
 					hbnc->add_child(btn);
-					btn->connect_compat("pressed", this, "_add_output_port", varray(E->get()), CONNECT_DEFERRED);
+					btn->connect("pressed", Callable(this, "_add_output_port"), varray(E->get()), CONNECT_DEFERRED);
 				}
 				gnode->add_child(hbnc);
 			} else if (Object::cast_to<VisualScriptExpression>(node.ptr())) {
@@ -594,7 +594,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 				line_edit->set_expand_to_text_length(true);
 				line_edit->add_font_override("font", get_font("source", "EditorFonts"));
 				gnode->add_child(line_edit);
-				line_edit->connect_compat("text_changed", this, "_expression_text_changed", varray(E->get()));
+				line_edit->connect("text_changed", Callable(this, "_expression_text_changed"), varray(E->get()));
 			} else {
 				String text = node->get_text();
 				if (!text.empty()) {
@@ -610,7 +610,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 				gnode->set_comment(true);
 				gnode->set_resizable(true);
 				gnode->set_custom_minimum_size(vsc->get_size() * EDSCALE);
-				gnode->connect_compat("resize_request", this, "_comment_node_resized", varray(E->get()));
+				gnode->connect("resize_request", Callable(this, "_comment_node_resized"), varray(E->get()));
 			}
 
 			if (node_styles.has(node->get_category())) {
@@ -720,8 +720,8 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 							name_box->set_custom_minimum_size(Size2(60 * EDSCALE, 0));
 							name_box->set_text(left_name);
 							name_box->set_expand_to_text_length(true);
-							name_box->connect_compat("resized", this, "_update_node_size", varray(E->get()));
-							name_box->connect_compat("focus_exited", this, "_port_name_focus_out", varray(name_box, E->get(), i, true));
+							name_box->connect("resized", Callable(this, "_update_node_size"), varray(E->get()));
+							name_box->connect("focus_exited", Callable(this, "_port_name_focus_out"), varray(name_box, E->get(), i, true));
 						} else {
 							hbc->add_child(memnew(Label(left_name)));
 						}
@@ -734,13 +734,13 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 							opbtn->select(left_type);
 							opbtn->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 							hbc->add_child(opbtn);
-							opbtn->connect_compat("item_selected", this, "_change_port_type", varray(E->get(), i, true), CONNECT_DEFERRED);
+							opbtn->connect("item_selected", Callable(this, "_change_port_type"), varray(E->get(), i, true), CONNECT_DEFERRED);
 						}
 
 						Button *rmbtn = memnew(Button);
 						rmbtn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("Remove", "EditorIcons"));
 						hbc->add_child(rmbtn);
-						rmbtn->connect_compat("pressed", this, "_remove_input_port", varray(E->get(), i), CONNECT_DEFERRED);
+						rmbtn->connect("pressed", Callable(this, "_remove_input_port"), varray(E->get(), i), CONNECT_DEFERRED);
 					} else {
 						hbc->add_child(memnew(Label(left_name)));
 					}
@@ -760,7 +760,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 
 						if (left_type == Variant::COLOR) {
 							button->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
-							button->connect_compat("draw", this, "_draw_color_over_button", varray(button, value));
+							button->connect("draw", Callable(this, "_draw_color_over_button"), varray(button, value));
 						} else if (left_type == Variant::OBJECT && Ref<Resource>(value).is_valid()) {
 
 							Ref<Resource> res = value;
@@ -776,7 +776,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 
 							button->set_text(value);
 						}
-						button->connect_compat("pressed", this, "_default_value_edited", varray(button, E->get(), i));
+						button->connect("pressed", Callable(this, "_default_value_edited"), varray(button, E->get(), i));
 						hbc2->add_child(button);
 					}
 				} else {
@@ -802,7 +802,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 						Button *rmbtn = memnew(Button);
 						rmbtn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_icon("Remove", "EditorIcons"));
 						hbc->add_child(rmbtn);
-						rmbtn->connect_compat("pressed", this, "_remove_output_port", varray(E->get(), i), CONNECT_DEFERRED);
+						rmbtn->connect("pressed", Callable(this, "_remove_output_port"), varray(E->get(), i), CONNECT_DEFERRED);
 
 						if (nd_list->is_output_port_type_editable()) {
 							OptionButton *opbtn = memnew(OptionButton);
@@ -812,7 +812,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 							opbtn->select(right_type);
 							opbtn->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 							hbc->add_child(opbtn);
-							opbtn->connect_compat("item_selected", this, "_change_port_type", varray(E->get(), i, false), CONNECT_DEFERRED);
+							opbtn->connect("item_selected", Callable(this, "_change_port_type"), varray(E->get(), i, false), CONNECT_DEFERRED);
 						}
 
 						if (nd_list->is_output_port_name_editable()) {
@@ -821,8 +821,8 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 							name_box->set_custom_minimum_size(Size2(60 * EDSCALE, 0));
 							name_box->set_text(right_name);
 							name_box->set_expand_to_text_length(true);
-							name_box->connect_compat("resized", this, "_update_node_size", varray(E->get()));
-							name_box->connect_compat("focus_exited", this, "_port_name_focus_out", varray(name_box, E->get(), i, false));
+							name_box->connect("resized", Callable(this, "_update_node_size"), varray(E->get()));
+							name_box->connect("focus_exited", Callable(this, "_port_name_focus_out"), varray(name_box, E->get(), i, false));
 						} else {
 							hbc->add_child(memnew(Label(right_name)));
 						}
@@ -1225,7 +1225,7 @@ void VisualScriptEditor::_add_func_input() {
 	LineEdit *name_box = memnew(LineEdit);
 	name_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	name_box->set_text("input");
-	name_box->connect_compat("focus_entered", this, "_deselect_input_names");
+	name_box->connect("focus_entered", Callable(this, "_deselect_input_names"));
 	hbox->add_child(name_box);
 
 	Label *type_label = memnew(Label);
@@ -1252,7 +1252,7 @@ void VisualScriptEditor::_add_func_input() {
 	func_input_vbox->add_child(hbox);
 	hbox->set_meta("id", hbox->get_position_in_parent());
 
-	delete_button->connect_compat("pressed", this, "_remove_func_input", varray(hbox));
+	delete_button->connect("pressed", Callable(this, "_remove_func_input"), varray(hbox));
 
 	name_box->select_all();
 	name_box->grab_focus();
@@ -2408,7 +2408,7 @@ void VisualScriptEditor::set_edited_resource(const RES &p_res) {
 	variable_editor->script = script;
 	variable_editor->undo_redo = undo_redo;
 
-	script->connect_compat("node_ports_changed", this, "_node_ports_changed");
+	script->connect("node_ports_changed", Callable(this, "_node_ports_changed"));
 
 	default_func = script->get_default_func();
 
@@ -3904,8 +3904,8 @@ void VisualScriptEditor::_notification(int p_what) {
 
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			variable_editor->connect_compat("changed", this, "_update_members");
-			signal_editor->connect_compat("changed", this, "_update_members");
+			variable_editor->connect("changed", Callable(this, "_update_members"));
+			signal_editor->connect("changed", Callable(this, "_update_members"));
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
@@ -4697,7 +4697,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	edit_menu->get_popup()->add_separator();
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("visual_script_editor/create_function"), EDIT_CREATE_FUNCTION);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("visual_script_editor/refresh_nodes"), REFRESH_GRAPH);
-	edit_menu->get_popup()->connect_compat("id_pressed", this, "_menu_option");
+	edit_menu->get_popup()->connect("id_pressed", Callable(this, "_menu_option"));
 
 	members_section = memnew(VBoxContainer);
 	// Add but wait until done setting up this.
@@ -4707,7 +4707,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	CheckButton *tool_script_check = memnew(CheckButton);
 	tool_script_check->set_text(TTR("Make Tool:"));
 	members_section->add_child(tool_script_check);
-	tool_script_check->connect_compat("pressed", this, "_toggle_tool_script");
+	tool_script_check->connect("pressed", Callable(this, "_toggle_tool_script"));
 
 	///       Members        ///
 
@@ -4715,11 +4715,11 @@ VisualScriptEditor::VisualScriptEditor() {
 	members_section->add_margin_child(TTR("Members:"), members, true);
 	members->set_custom_minimum_size(Size2(0, 50 * EDSCALE));
 	members->set_hide_root(true);
-	members->connect_compat("button_pressed", this, "_member_button");
-	members->connect_compat("item_edited", this, "_member_edited");
-	members->connect_compat("cell_selected", this, "_member_selected", varray(), CONNECT_DEFERRED);
-	members->connect_compat("gui_input", this, "_members_gui_input");
-	members->connect_compat("item_rmb_selected", this, "_member_rmb_selected");
+	members->connect("button_pressed", Callable(this, "_member_button"));
+	members->connect("item_edited", Callable(this, "_member_edited"));
+	members->connect("cell_selected", Callable(this, "_member_selected"), varray(), CONNECT_DEFERRED);
+	members->connect("gui_input", Callable(this, "_members_gui_input"));
+	members->connect("item_rmb_selected", Callable(this, "_member_rmb_selected"));
 	members->set_allow_rmb_select(true);
 	members->set_allow_reselect(true);
 	members->set_hide_folding(true);
@@ -4727,13 +4727,13 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	member_popup = memnew(PopupMenu);
 	add_child(member_popup);
-	member_popup->connect_compat("id_pressed", this, "_member_option");
+	member_popup->connect("id_pressed", Callable(this, "_member_option"));
 
 	function_name_edit = memnew(PopupDialog);
 	function_name_box = memnew(LineEdit);
 	function_name_edit->add_child(function_name_box);
 	function_name_edit->set_h_size_flags(SIZE_EXPAND);
-	function_name_box->connect_compat("gui_input", this, "_fn_name_box_input");
+	function_name_box->connect("gui_input", Callable(this, "_fn_name_box_input"));
 	function_name_box->set_expand_to_text_length(true);
 	add_child(function_name_edit);
 
@@ -4743,15 +4743,15 @@ VisualScriptEditor::VisualScriptEditor() {
 	add_child(graph);
 	graph->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	graph->set_anchors_and_margins_preset(Control::PRESET_WIDE);
-	graph->connect_compat("node_selected", this, "_node_selected");
-	graph->connect_compat("_begin_node_move", this, "_begin_node_move");
-	graph->connect_compat("_end_node_move", this, "_end_node_move");
-	graph->connect_compat("delete_nodes_request", this, "_on_nodes_delete");
-	graph->connect_compat("duplicate_nodes_request", this, "_on_nodes_duplicate");
-	graph->connect_compat("gui_input", this, "_graph_gui_input");
+	graph->connect("node_selected", Callable(this, "_node_selected"));
+	graph->connect("_begin_node_move", Callable(this, "_begin_node_move"));
+	graph->connect("_end_node_move", Callable(this, "_end_node_move"));
+	graph->connect("delete_nodes_request", Callable(this, "_on_nodes_delete"));
+	graph->connect("duplicate_nodes_request", Callable(this, "_on_nodes_duplicate"));
+	graph->connect("gui_input", Callable(this, "_graph_gui_input"));
 	graph->set_drag_forwarding(this);
 	graph->hide();
-	graph->connect_compat("scroll_offset_changed", this, "_graph_ofs_changed");
+	graph->connect("scroll_offset_changed", Callable(this, "_graph_ofs_changed"));
 
 	/// Add Buttons to Top Bar/Zoom bar.
 	HBoxContainer *graph_hbc = graph->get_zoom_hbox();
@@ -4761,18 +4761,18 @@ VisualScriptEditor::VisualScriptEditor() {
 	graph_hbc->add_child(base_lbl);
 
 	base_type_select = memnew(Button);
-	base_type_select->connect_compat("pressed", this, "_change_base_type");
+	base_type_select->connect("pressed", Callable(this, "_change_base_type"));
 	graph_hbc->add_child(base_type_select);
 
 	Button *add_nds = memnew(Button);
 	add_nds->set_text(TTR("Add Nodes..."));
 	graph_hbc->add_child(add_nds);
-	add_nds->connect_compat("pressed", this, "_add_node_dialog");
+	add_nds->connect("pressed", Callable(this, "_add_node_dialog"));
 
 	Button *fn_btn = memnew(Button);
 	fn_btn->set_text(TTR("Add Function..."));
 	graph_hbc->add_child(fn_btn);
-	fn_btn->connect_compat("pressed", this, "_create_function_dialog");
+	fn_btn->connect("pressed", Callable(this, "_create_function_dialog"));
 
 	// Add Function Dialog.
 	VBoxContainer *function_vb = memnew(VBoxContainer);
@@ -4790,7 +4790,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	func_name_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	func_name_box->set_placeholder(TTR("function_name"));
 	func_name_box->set_text("");
-	func_name_box->connect_compat("focus_entered", this, "_deselect_input_names");
+	func_name_box->connect("focus_entered", Callable(this, "_deselect_input_names"));
 	func_name_hbox->add_child(func_name_box);
 
 	// Add minor setting for function if needed, here!
@@ -4800,7 +4800,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	Button *add_input_button = memnew(Button);
 	add_input_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	add_input_button->set_text(TTR("Add Input"));
-	add_input_button->connect_compat("pressed", this, "_add_func_input");
+	add_input_button->connect("pressed", Callable(this, "_add_func_input"));
 	function_vb->add_child(add_input_button);
 
 	func_input_scroll = memnew(ScrollContainer);
@@ -4816,7 +4816,7 @@ VisualScriptEditor::VisualScriptEditor() {
 	function_create_dialog->set_title(TTR("Create Function"));
 	function_create_dialog->add_child(function_vb);
 	function_create_dialog->get_ok()->set_text(TTR("Create"));
-	function_create_dialog->get_ok()->connect_compat("pressed", this, "_create_function");
+	function_create_dialog->get_ok()->connect("pressed", Callable(this, "_create_function"));
 	add_child(function_create_dialog);
 
 	select_func_text = memnew(Label);
@@ -4836,7 +4836,7 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	hint_text_timer = memnew(Timer);
 	hint_text_timer->set_wait_time(4);
-	hint_text_timer->connect_compat("timeout", this, "_hide_timer");
+	hint_text_timer->connect("timeout", Callable(this, "_hide_timer"));
 	add_child(hint_text_timer);
 
 	// Allowed casts (connections).
@@ -4854,9 +4854,9 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	graph->add_valid_left_disconnect_type(TYPE_SEQUENCE);
 
-	graph->connect_compat("connection_request", this, "_graph_connected");
-	graph->connect_compat("disconnection_request", this, "_graph_disconnected");
-	graph->connect_compat("connection_to_empty", this, "_graph_connect_to_empty");
+	graph->connect("connection_request", Callable(this, "_graph_connected"));
+	graph->connect("disconnection_request", Callable(this, "_graph_disconnected"));
+	graph->connect("connection_to_empty", Callable(this, "_graph_connect_to_empty"));
 
 	edit_signal_dialog = memnew(AcceptDialog);
 	edit_signal_dialog->get_ok()->set_text(TTR("Close"));
@@ -4880,7 +4880,7 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	select_base_type = memnew(CreateDialog);
 	select_base_type->set_base_type("Object"); // Anything goes.
-	select_base_type->connect_compat("create", this, "_change_base_type_callback");
+	select_base_type->connect("create", Callable(this, "_change_base_type_callback"));
 	add_child(select_base_type);
 
 	undo_redo = EditorNode::get_singleton()->get_undo_redo();
@@ -4892,22 +4892,22 @@ VisualScriptEditor::VisualScriptEditor() {
 
 	default_value_edit = memnew(CustomPropertyEditor);
 	add_child(default_value_edit);
-	default_value_edit->connect_compat("variant_changed", this, "_default_value_changed");
+	default_value_edit->connect("variant_changed", Callable(this, "_default_value_changed"));
 
 	method_select = memnew(VisualScriptPropertySelector);
 	add_child(method_select);
-	method_select->connect_compat("selected", this, "_selected_method");
+	method_select->connect("selected", Callable(this, "_selected_method"));
 	error_line = -1;
 
 	new_connect_node_select = memnew(VisualScriptPropertySelector);
 	add_child(new_connect_node_select);
 	new_connect_node_select->set_resizable(true);
-	new_connect_node_select->connect_compat("selected", this, "_selected_connect_node");
-	new_connect_node_select->get_cancel()->connect_compat("pressed", this, "_cancel_connect_node");
+	new_connect_node_select->connect("selected", Callable(this, "_selected_connect_node"));
+	new_connect_node_select->get_cancel()->connect("pressed", Callable(this, "_cancel_connect_node"));
 
 	new_virtual_method_select = memnew(VisualScriptPropertySelector);
 	add_child(new_virtual_method_select);
-	new_virtual_method_select->connect_compat("selected", this, "_selected_new_virtual_method");
+	new_virtual_method_select->connect("selected", Callable(this, "_selected_new_virtual_method"));
 }
 
 VisualScriptEditor::~VisualScriptEditor() {

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -3144,7 +3144,7 @@ void VisualScriptCustomNode::_bind_methods() {
 }
 
 VisualScriptCustomNode::VisualScriptCustomNode() {
-	connect_compat("script_changed", this, "_script_changed");
+	connect("script_changed", Callable(this, "_script_changed"));
 }
 
 //////////////////////////////////////////

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -520,7 +520,7 @@ void VisualScriptPropertySelector::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 
-		connect_compat("confirmed", this, "_confirmed");
+		connect("confirmed", Callable(this, "_confirmed"));
 	}
 }
 
@@ -703,23 +703,23 @@ VisualScriptPropertySelector::VisualScriptPropertySelector() {
 	//set_child_rect(vbc);
 	search_box = memnew(LineEdit);
 	vbc->add_margin_child(TTR("Search:"), search_box);
-	search_box->connect_compat("text_changed", this, "_text_changed");
-	search_box->connect_compat("gui_input", this, "_sbox_input");
+	search_box->connect("text_changed", Callable(this, "_text_changed"));
+	search_box->connect("gui_input", Callable(this, "_sbox_input"));
 	search_options = memnew(Tree);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 	get_ok()->set_text(TTR("Open"));
 	get_ok()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect_compat("item_activated", this, "_confirmed");
-	search_options->connect_compat("cell_selected", this, "_item_selected");
+	search_options->connect("item_activated", Callable(this, "_confirmed"));
+	search_options->connect("cell_selected", Callable(this, "_item_selected"));
 	search_options->set_hide_root(true);
 	search_options->set_hide_folding(true);
 	virtuals_only = false;
 	seq_connect = false;
 	help_bit = memnew(EditorHelpBit);
 	vbc->add_margin_child(TTR("Description:"), help_bit);
-	help_bit->connect_compat("request_hide", this, "_closed");
+	help_bit->connect("request_hide", Callable(this, "_closed"));
 	search_options->set_columns(3);
 	search_options->set_column_expand(1, false);
 	search_options->set_column_expand(2, false);

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -475,10 +475,10 @@ void AnimatedSprite::_notification(int p_what) {
 void AnimatedSprite::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 
 	if (frames.is_valid())
-		frames->disconnect_compat("changed", this, "_res_changed");
+		frames->disconnect("changed", Callable(this, "_res_changed"));
 	frames = p_frames;
 	if (frames.is_valid())
-		frames->connect_compat("changed", this, "_res_changed");
+		frames->connect("changed", Callable(this, "_res_changed"));
 
 	if (!frames.is_valid()) {
 		frame = 0;

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -171,8 +171,8 @@ void Area2D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 			E->get().rc = 0;
 			E->get().in_tree = node && node->is_inside_tree();
 			if (node) {
-				node->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree, make_binds(objid));
-				node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_body_enter_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_body_exit_tree, make_binds(objid));
 				if (E->get().in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->body_entered, node);
 				}
@@ -198,8 +198,8 @@ void Area2D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 		if (E->get().rc == 0) {
 
 			if (node) {
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_body_enter_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_body_exit_tree);
 				if (E->get().in_tree)
 					emit_signal(SceneStringNames::get_singleton()->body_exited, obj);
 			}
@@ -273,8 +273,8 @@ void Area2D::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, i
 			E->get().rc = 0;
 			E->get().in_tree = node && node->is_inside_tree();
 			if (node) {
-				node->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree, make_binds(objid));
-				node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_area_enter_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_area_exit_tree, make_binds(objid));
 				if (E->get().in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->area_entered, node);
 				}
@@ -300,8 +300,8 @@ void Area2D::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, i
 		if (E->get().rc == 0) {
 
 			if (node) {
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_area_enter_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_area_exit_tree);
 				if (E->get().in_tree)
 					emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
 			}
@@ -337,8 +337,8 @@ void Area2D::_clear_monitoring() {
 				continue;
 			//ERR_CONTINUE(!node);
 
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_body_enter_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_body_exit_tree);
 
 			if (!E->get().in_tree)
 				continue;
@@ -367,8 +367,8 @@ void Area2D::_clear_monitoring() {
 				continue;
 			//ERR_CONTINUE(!node);
 
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree);
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_area_enter_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_area_exit_tree);
 
 			if (!E->get().in_tree)
 				continue;

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -545,7 +545,7 @@ AudioStreamPlayer2D::AudioStreamPlayer2D() {
 	stream_paused = false;
 	stream_paused_fade_in = false;
 	stream_paused_fade_out = false;
-	AudioServer::get_singleton()->connect_compat("bus_layout_changed", this, "_bus_layout_changed");
+	AudioServer::get_singleton()->connect("bus_layout_changed", Callable(this, "_bus_layout_changed"));
 }
 
 AudioStreamPlayer2D::~AudioStreamPlayer2D() {

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -149,7 +149,7 @@ void CollisionShape2D::_notification(int p_what) {
 void CollisionShape2D::set_shape(const Ref<Shape2D> &p_shape) {
 
 	if (shape.is_valid())
-		shape->disconnect_compat("changed", this, "_shape_changed");
+		shape->disconnect("changed", Callable(this, "_shape_changed"));
 	shape = p_shape;
 	update();
 	if (parent) {
@@ -160,7 +160,7 @@ void CollisionShape2D::set_shape(const Ref<Shape2D> &p_shape) {
 	}
 
 	if (shape.is_valid())
-		shape->connect_compat("changed", this, "_shape_changed");
+		shape->connect("changed", Callable(this, "_shape_changed"));
 
 	update_configuration_warning();
 }

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -212,12 +212,12 @@ void CPUParticles2D::set_texture(const Ref<Texture2D> &p_texture) {
 		return;
 
 	if (texture.is_valid())
-		texture->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+		texture->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_texture_changed"));
 
 	texture = p_texture;
 
 	if (texture.is_valid())
-		texture->connect_compat(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+		texture->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_texture_changed"));
 
 	update();
 	_update_mesh_texture();
@@ -1053,13 +1053,13 @@ void CPUParticles2D::_set_redraw(bool p_redraw) {
 	update_mutex->lock();
 #endif
 	if (redraw) {
-		VS::get_singleton()->connect_compat("frame_pre_draw", this, "_update_render_thread");
+		VS::get_singleton()->connect("frame_pre_draw", Callable(this, "_update_render_thread"));
 		VS::get_singleton()->canvas_item_set_update_when_visible(get_canvas_item(), true);
 
 		VS::get_singleton()->multimesh_set_visible_instances(multimesh, -1);
 	} else {
-		if (VS::get_singleton()->is_connected_compat("frame_pre_draw", this, "_update_render_thread")) {
-			VS::get_singleton()->disconnect_compat("frame_pre_draw", this, "_update_render_thread");
+		if (VS::get_singleton()->is_connected("frame_pre_draw", Callable(this, "_update_render_thread"))) {
+			VS::get_singleton()->disconnect("frame_pre_draw", Callable(this, "_update_render_thread"));
 		}
 		VS::get_singleton()->canvas_item_set_update_when_visible(get_canvas_item(), false);
 

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -234,7 +234,7 @@ void LightOccluder2D::set_occluder_polygon(const Ref<OccluderPolygon2D> &p_polyg
 
 #ifdef DEBUG_ENABLED
 	if (occluder_polygon.is_valid())
-		occluder_polygon->disconnect_compat("changed", this, "_poly_changed");
+		occluder_polygon->disconnect("changed", Callable(this, "_poly_changed"));
 #endif
 	occluder_polygon = p_polygon;
 
@@ -245,7 +245,7 @@ void LightOccluder2D::set_occluder_polygon(const Ref<OccluderPolygon2D> &p_polyg
 
 #ifdef DEBUG_ENABLED
 	if (occluder_polygon.is_valid())
-		occluder_polygon->connect_compat("changed", this, "_poly_changed");
+		occluder_polygon->connect("changed", Callable(this, "_poly_changed"));
 	update();
 #endif
 }

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -101,14 +101,14 @@ float Line2D::get_width() const {
 void Line2D::set_curve(const Ref<Curve> &p_curve) {
 	// Cleanup previous connection if any
 	if (_curve.is_valid()) {
-		_curve->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_curve_changed");
+		_curve->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_curve_changed"));
 	}
 
 	_curve = p_curve;
 
 	// Connect to the curve so the line will update when it is changed
 	if (_curve.is_valid()) {
-		_curve->connect_compat(CoreStringNames::get_singleton()->changed, this, "_curve_changed");
+		_curve->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_curve_changed"));
 	}
 
 	update();
@@ -171,14 +171,14 @@ void Line2D::set_gradient(const Ref<Gradient> &p_gradient) {
 
 	// Cleanup previous connection if any
 	if (_gradient.is_valid()) {
-		_gradient->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_gradient_changed");
+		_gradient->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_gradient_changed"));
 	}
 
 	_gradient = p_gradient;
 
 	// Connect to the gradient so the line will update when the ColorRamp is changed
 	if (_gradient.is_valid()) {
-		_gradient->connect_compat(CoreStringNames::get_singleton()->changed, this, "_gradient_changed");
+		_gradient->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_gradient_changed"));
 	}
 
 	update();

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -503,14 +503,14 @@ void NavigationPolygonInstance::set_navigation_polygon(const Ref<NavigationPolyg
 	}
 
 	if (navpoly.is_valid()) {
-		navpoly->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_navpoly_changed");
+		navpoly->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_navpoly_changed"));
 	}
 
 	navpoly = p_navpoly;
 	Navigation2DServer::get_singleton()->region_set_navpoly(region, p_navpoly);
 
 	if (navpoly.is_valid()) {
-		navpoly->connect_compat(CoreStringNames::get_singleton()->changed, this, "_navpoly_changed");
+		navpoly->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_navpoly_changed"));
 	}
 	_navpoly_changed();
 

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -134,13 +134,13 @@ void Path2D::_curve_changed() {
 void Path2D::set_curve(const Ref<Curve2D> &p_curve) {
 
 	if (curve.is_valid()) {
-		curve->disconnect_compat("changed", this, "_curve_changed");
+		curve->disconnect("changed", Callable(this, "_curve_changed"));
 	}
 
 	curve = p_curve;
 
 	if (curve.is_valid()) {
-		curve->connect_compat("changed", this, "_curve_changed");
+		curve->connect("changed", Callable(this, "_curve_changed"));
 	}
 
 	_curve_changed();

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -192,14 +192,14 @@ real_t StaticBody2D::get_constant_angular_velocity() const {
 
 void StaticBody2D::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		if (physics_material_override->is_connected_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics"))
-			physics_material_override->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, Callable(this, "_reload_physics_characteristics")))
+			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_reload_physics_characteristics"));
 	}
 
 	physics_material_override = p_physics_material_override;
 
 	if (physics_material_override.is_valid()) {
-		physics_material_override->connect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		physics_material_override->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_reload_physics_characteristics"));
 	}
 	_reload_physics_characteristics();
 }
@@ -311,8 +311,8 @@ void RigidBody2D::_body_inout(int p_status, ObjectID p_instance, int p_body_shap
 			//E->get().rc=0;
 			E->get().in_scene = node && node->is_inside_tree();
 			if (node) {
-				node->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree, make_binds(objid));
-				node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_body_enter_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_body_exit_tree, make_binds(objid));
 				if (E->get().in_scene) {
 					emit_signal(SceneStringNames::get_singleton()->body_entered, node);
 				}
@@ -340,8 +340,8 @@ void RigidBody2D::_body_inout(int p_status, ObjectID p_instance, int p_body_shap
 		if (E->get().shapes.empty()) {
 
 			if (node) {
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_body_enter_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_body_exit_tree);
 				if (in_scene)
 					emit_signal(SceneStringNames::get_singleton()->body_exited, node);
 			}
@@ -545,14 +545,14 @@ real_t RigidBody2D::get_weight() const {
 
 void RigidBody2D::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		if (physics_material_override->is_connected_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics"))
-			physics_material_override->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, Callable(this, "_reload_physics_characteristics")))
+			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_reload_physics_characteristics"));
 	}
 
 	physics_material_override = p_physics_material_override;
 
 	if (physics_material_override.is_valid()) {
-		physics_material_override->connect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		physics_material_override->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_reload_physics_characteristics"));
 	}
 	_reload_physics_characteristics();
 }
@@ -775,8 +775,8 @@ void RigidBody2D::set_contact_monitor(bool p_enabled) {
 
 			if (node) {
 
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_body_enter_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_body_exit_tree);
 			}
 		}
 

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -120,11 +120,11 @@ void Polygon2D::_notification(int p_what) {
 			if (new_skeleton_id != current_skeleton_id) {
 				Object *old_skeleton = ObjectDB::get_instance(current_skeleton_id);
 				if (old_skeleton) {
-					old_skeleton->disconnect_compat("bone_setup_changed", this, "_skeleton_bone_setup_changed");
+					old_skeleton->disconnect("bone_setup_changed", Callable(this, "_skeleton_bone_setup_changed"));
 				}
 
 				if (skeleton_node) {
-					skeleton_node->connect_compat("bone_setup_changed", this, "_skeleton_bone_setup_changed");
+					skeleton_node->connect("bone_setup_changed", Callable(this, "_skeleton_bone_setup_changed"));
 				}
 
 				current_skeleton_id = new_skeleton_id;

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -142,12 +142,12 @@ void Sprite::set_texture(const Ref<Texture2D> &p_texture) {
 		return;
 
 	if (texture.is_valid())
-		texture->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+		texture->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_texture_changed"));
 
 	texture = p_texture;
 
 	if (texture.is_valid())
-		texture->connect_compat(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+		texture->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_texture_changed"));
 
 	update();
 	emit_signal("texture_changed");

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -177,7 +177,7 @@ void TileMap::_update_quadrant_transform() {
 void TileMap::set_tileset(const Ref<TileSet> &p_tileset) {
 
 	if (tile_set.is_valid()) {
-		tile_set->disconnect_compat("changed", this, "_recreate_quadrants");
+		tile_set->disconnect("changed", Callable(this, "_recreate_quadrants"));
 		tile_set->remove_change_receptor(this);
 	}
 
@@ -185,7 +185,7 @@ void TileMap::set_tileset(const Ref<TileSet> &p_tileset) {
 	tile_set = p_tileset;
 
 	if (tile_set.is_valid()) {
-		tile_set->connect_compat("changed", this, "_recreate_quadrants");
+		tile_set->connect("changed", Callable(this, "_recreate_quadrants"));
 		tile_set->add_change_receptor(this);
 	} else {
 		clear();

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -69,12 +69,12 @@ Ref<BitMap> TouchScreenButton::get_bitmask() const {
 void TouchScreenButton::set_shape(const Ref<Shape2D> &p_shape) {
 
 	if (shape.is_valid())
-		shape->disconnect_compat("changed", this, "update");
+		shape->disconnect("changed", Callable(this, "update"));
 
 	shape = p_shape;
 
 	if (shape.is_valid())
-		shape->connect_compat("changed", this, "update");
+		shape->connect("changed", Callable(this, "update"));
 
 	update();
 }

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -224,7 +224,7 @@ void VisibilityEnabler2D::_find_nodes(Node *p_node) {
 
 	if (add) {
 
-		p_node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, "_node_removed", varray(p_node), CONNECT_ONESHOT);
+		p_node->connect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, "_node_removed"), varray(p_node), CONNECT_ONESHOT);
 		nodes[p_node] = meta;
 		_change_node_state(p_node, false);
 	}
@@ -267,7 +267,7 @@ void VisibilityEnabler2D::_notification(int p_what) {
 
 			if (!visible)
 				_change_node_state(E->key(), true);
-			E->key()->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, "_node_removed");
+			E->key()->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, "_node_removed"));
 		}
 
 		nodes.clear();

--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -170,8 +170,8 @@ void Area::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, int
 			E->get().rc = 0;
 			E->get().in_tree = node && node->is_inside_tree();
 			if (node) {
-				node->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree, make_binds(objid));
-				node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_body_enter_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_body_exit_tree, make_binds(objid));
 				if (E->get().in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->body_entered, node);
 				}
@@ -197,8 +197,8 @@ void Area::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, int
 		if (E->get().rc == 0) {
 
 			if (node) {
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_body_enter_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_body_exit_tree);
 				if (E->get().in_tree)
 					emit_signal(SceneStringNames::get_singleton()->body_exited, obj);
 			}
@@ -244,8 +244,8 @@ void Area::_clear_monitoring() {
 
 			emit_signal(SceneStringNames::get_singleton()->body_exited, node);
 
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_body_enter_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_body_exit_tree);
 		}
 	}
 
@@ -274,8 +274,8 @@ void Area::_clear_monitoring() {
 
 			emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
 
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree);
-			node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_area_enter_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_area_exit_tree);
 		}
 	}
 }
@@ -363,8 +363,8 @@ void Area::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, int
 			E->get().rc = 0;
 			E->get().in_tree = node && node->is_inside_tree();
 			if (node) {
-				node->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree, make_binds(objid));
-				node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_area_enter_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_area_exit_tree, make_binds(objid));
 				if (E->get().in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->area_entered, node);
 				}
@@ -390,8 +390,8 @@ void Area::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, int
 		if (E->get().rc == 0) {
 
 			if (node) {
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_area_enter_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_area_exit_tree);
 				if (E->get().in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
 				}

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -1076,7 +1076,7 @@ AudioStreamPlayer3D::AudioStreamPlayer3D() {
 	stream_paused_fade_out = false;
 
 	velocity_tracker.instance();
-	AudioServer::get_singleton()->connect_compat("bus_layout_changed", this, "_bus_layout_changed");
+	AudioServer::get_singleton()->connect("bus_layout_changed", Callable(this, "_bus_layout_changed"));
 	set_disable_scale(true);
 }
 AudioStreamPlayer3D::~AudioStreamPlayer3D() {

--- a/scene/3d/collision_shape.cpp
+++ b/scene/3d/collision_shape.cpp
@@ -152,12 +152,12 @@ void CollisionShape::set_shape(const Ref<Shape> &p_shape) {
 
 	if (!shape.is_null()) {
 		shape->unregister_owner(this);
-		shape->disconnect_compat("changed", this, "_shape_changed");
+		shape->disconnect("changed", Callable(this, "_shape_changed"));
 	}
 	shape = p_shape;
 	if (!shape.is_null()) {
 		shape->register_owner(this);
-		shape->connect_compat("changed", this, "_shape_changed");
+		shape->connect("changed", Callable(this, "_shape_changed"));
 	}
 	update_gizmo();
 	if (parent) {

--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -1123,12 +1123,12 @@ void CPUParticles::_set_redraw(bool p_redraw) {
 	update_mutex->lock();
 #endif
 	if (redraw) {
-		VS::get_singleton()->connect_compat("frame_pre_draw", this, "_update_render_thread");
+		VS::get_singleton()->connect("frame_pre_draw", Callable(this, "_update_render_thread"));
 		VS::get_singleton()->instance_geometry_set_flag(get_instance(), VS::INSTANCE_FLAG_DRAW_NEXT_FRAME_IF_VISIBLE, true);
 		VS::get_singleton()->multimesh_set_visible_instances(multimesh, -1);
 	} else {
-		if (VS::get_singleton()->is_connected_compat("frame_pre_draw", this, "_update_render_thread")) {
-			VS::get_singleton()->disconnect_compat("frame_pre_draw", this, "_update_render_thread");
+		if (VS::get_singleton()->is_connected("frame_pre_draw", Callable(this, "_update_render_thread"))) {
+			VS::get_singleton()->disconnect("frame_pre_draw", Callable(this, "_update_render_thread"));
 		}
 		VS::get_singleton()->instance_geometry_set_flag(get_instance(), VS::INSTANCE_FLAG_DRAW_NEXT_FRAME_IF_VISIBLE, false);
 		VS::get_singleton()->multimesh_set_visible_instances(multimesh, 0);

--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -112,7 +112,7 @@ void MeshInstance::set_mesh(const Ref<Mesh> &p_mesh) {
 		return;
 
 	if (mesh.is_valid()) {
-		mesh->disconnect_compat(CoreStringNames::get_singleton()->changed, this, SceneStringNames::get_singleton()->_mesh_changed);
+		mesh->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, SceneStringNames::get_singleton())->_mesh_changed);
 		materials.clear();
 	}
 
@@ -129,7 +129,7 @@ void MeshInstance::set_mesh(const Ref<Mesh> &p_mesh) {
 			blend_shape_tracks["blend_shapes/" + String(mesh->get_blend_shape_name(i))] = mt;
 		}
 
-		mesh->connect_compat(CoreStringNames::get_singleton()->changed, this, SceneStringNames::get_singleton()->_mesh_changed);
+		mesh->connect(CoreStringNames::get_singleton()->changed, Callable(this, SceneStringNames::get_singleton())->_mesh_changed);
 		materials.resize(mesh->get_surface_count());
 
 		set_base(mesh->get_rid());

--- a/scene/3d/path.cpp
+++ b/scene/3d/path.cpp
@@ -59,13 +59,13 @@ void Path::_curve_changed() {
 void Path::set_curve(const Ref<Curve3D> &p_curve) {
 
 	if (curve.is_valid()) {
-		curve->disconnect_compat("changed", this, "_curve_changed");
+		curve->disconnect("changed", Callable(this, "_curve_changed"));
 	}
 
 	curve = p_curve;
 
 	if (curve.is_valid()) {
-		curve->connect_compat("changed", this, "_curve_changed");
+		curve->connect("changed", Callable(this, "_curve_changed"));
 	}
 	_curve_changed();
 }

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -180,14 +180,14 @@ PhysicsBody::PhysicsBody(PhysicsServer::BodyMode p_mode) :
 
 void StaticBody::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		if (physics_material_override->is_connected_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics"))
-			physics_material_override->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, Callable(this, "_reload_physics_characteristics")))
+			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_reload_physics_characteristics"));
 	}
 
 	physics_material_override = p_physics_material_override;
 
 	if (physics_material_override.is_valid()) {
-		physics_material_override->connect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		physics_material_override->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_reload_physics_characteristics"));
 	}
 	_reload_physics_characteristics();
 }
@@ -322,8 +322,8 @@ void RigidBody::_body_inout(int p_status, ObjectID p_instance, int p_body_shape,
 			//E->get().rc=0;
 			E->get().in_tree = node && node->is_inside_tree();
 			if (node) {
-				node->connect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree, make_binds(objid));
-				node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_body_enter_tree, make_binds(objid));
+				node->connect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_body_exit_tree, make_binds(objid));
 				if (E->get().in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->body_entered, node);
 				}
@@ -349,8 +349,8 @@ void RigidBody::_body_inout(int p_status, ObjectID p_instance, int p_body_shape,
 		if (E->get().shapes.empty()) {
 
 			if (node) {
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_body_enter_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_body_exit_tree);
 				if (in_tree)
 					emit_signal(SceneStringNames::get_singleton()->body_exited, node);
 			}
@@ -550,14 +550,14 @@ real_t RigidBody::get_weight() const {
 
 void RigidBody::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		if (physics_material_override->is_connected_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics"))
-			physics_material_override->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, Callable(this, "_reload_physics_characteristics")))
+			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_reload_physics_characteristics"));
 	}
 
 	physics_material_override = p_physics_material_override;
 
 	if (physics_material_override.is_valid()) {
-		physics_material_override->connect_compat(CoreStringNames::get_singleton()->changed, this, "_reload_physics_characteristics");
+		physics_material_override->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_reload_physics_characteristics"));
 	}
 	_reload_physics_characteristics();
 }
@@ -738,8 +738,8 @@ void RigidBody::set_contact_monitor(bool p_enabled) {
 
 			if (node) {
 
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-				node->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_entered, Callable(this, SceneStringNames::get_singleton())->_body_enter_tree);
+				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, SceneStringNames::get_singleton())->_body_exit_tree);
 			}
 		}
 

--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -871,7 +871,7 @@ Ref<SkinReference> Skeleton::register_skin(const Ref<Skin> &p_skin) {
 
 	skin_bindings.insert(skin_ref.operator->());
 
-	skin->connect_compat("changed", skin_ref.operator->(), "_skin_changed");
+	skin->connect("changed", Callable(skin_ref.operator->(), "_skin_changed"));
 
 	_make_dirty(); //skin needs to be updated, so update skeleton
 

--- a/scene/3d/soft_body.cpp
+++ b/scene/3d/soft_body.cpp
@@ -464,12 +464,12 @@ void SoftBody::prepare_physics_server() {
 
 		become_mesh_owner();
 		PhysicsServer::get_singleton()->soft_body_set_mesh(physics_rid, get_mesh());
-		VS::get_singleton()->connect_compat("frame_pre_draw", this, "_draw_soft_mesh");
+		VS::get_singleton()->connect("frame_pre_draw", Callable(this, "_draw_soft_mesh"));
 	} else {
 
 		PhysicsServer::get_singleton()->soft_body_set_mesh(physics_rid, NULL);
-		if (VS::get_singleton()->is_connected_compat("frame_pre_draw", this, "_draw_soft_mesh")) {
-			VS::get_singleton()->disconnect_compat("frame_pre_draw", this, "_draw_soft_mesh");
+		if (VS::get_singleton()->is_connected("frame_pre_draw", Callable(this, "_draw_soft_mesh"))) {
+			VS::get_singleton()->disconnect("frame_pre_draw", Callable(this, "_draw_soft_mesh"));
 		}
 	}
 }

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -531,11 +531,11 @@ void Sprite3D::set_texture(const Ref<Texture2D> &p_texture) {
 	if (p_texture == texture)
 		return;
 	if (texture.is_valid()) {
-		texture->disconnect_compat(CoreStringNames::get_singleton()->changed, this, SceneStringNames::get_singleton()->_queue_update);
+		texture->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, SceneStringNames::get_singleton())->_queue_update);
 	}
 	texture = p_texture;
 	if (texture.is_valid()) {
-		texture->connect_compat(CoreStringNames::get_singleton()->changed, this, SceneStringNames::get_singleton()->_queue_update);
+		texture->connect(CoreStringNames::get_singleton()->changed, Callable(this, SceneStringNames::get_singleton())->_queue_update);
 	}
 	_queue_update();
 }
@@ -952,10 +952,10 @@ void AnimatedSprite3D::_notification(int p_what) {
 void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 
 	if (frames.is_valid())
-		frames->disconnect_compat("changed", this, "_res_changed");
+		frames->disconnect("changed", Callable(this, "_res_changed"));
 	frames = p_frames;
 	if (frames.is_valid())
-		frames->connect_compat("changed", this, "_res_changed");
+		frames->connect("changed", Callable(this, "_res_changed"));
 
 	if (!frames.is_valid()) {
 		frame = 0;

--- a/scene/3d/visibility_notifier.cpp
+++ b/scene/3d/visibility_notifier.cpp
@@ -170,7 +170,7 @@ void VisibilityEnabler::_find_nodes(Node *p_node) {
 
 	if (add) {
 
-		p_node->connect_compat(SceneStringNames::get_singleton()->tree_exiting, this, "_node_removed", varray(p_node), CONNECT_ONESHOT);
+		p_node->connect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, "_node_removed"), varray(p_node), CONNECT_ONESHOT);
 		nodes[p_node] = meta;
 		_change_node_state(p_node, false);
 	}
@@ -208,7 +208,7 @@ void VisibilityEnabler::_notification(int p_what) {
 
 			if (!visible)
 				_change_node_state(E->key(), true);
-			E->key()->disconnect_compat(SceneStringNames::get_singleton()->tree_exiting, this, "_node_removed");
+			E->key()->disconnect(SceneStringNames::get_singleton()->tree_exiting, Callable(this, "_node_removed"));
 		}
 
 		nodes.clear();

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -118,7 +118,7 @@ void AnimationNodeBlendSpace1D::add_blend_point(const Ref<AnimationRootNode> &p_
 	blend_points[p_at_index].node = p_node;
 	blend_points[p_at_index].position = p_position;
 
-	blend_points[p_at_index].node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	blend_points[p_at_index].node->connect("tree_changed", Callable(this, "_tree_changed"), varray(), CONNECT_REFERENCE_COUNTED);
 
 	blend_points_used++;
 	emit_signal("tree_changed");
@@ -135,11 +135,11 @@ void AnimationNodeBlendSpace1D::set_blend_point_node(int p_point, const Ref<Anim
 	ERR_FAIL_COND(p_node.is_null());
 
 	if (blend_points[p_point].node.is_valid()) {
-		blend_points[p_point].node->disconnect_compat("tree_changed", this, "_tree_changed");
+		blend_points[p_point].node->disconnect("tree_changed", Callable(this, "_tree_changed"));
 	}
 
 	blend_points[p_point].node = p_node;
-	blend_points[p_point].node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	blend_points[p_point].node->connect("tree_changed", Callable(this, "_tree_changed"), varray(), CONNECT_REFERENCE_COUNTED);
 
 	emit_signal("tree_changed");
 }
@@ -158,7 +158,7 @@ void AnimationNodeBlendSpace1D::remove_blend_point(int p_point) {
 	ERR_FAIL_INDEX(p_point, blend_points_used);
 
 	ERR_FAIL_COND(blend_points[p_point].node.is_null());
-	blend_points[p_point].node->disconnect_compat("tree_changed", this, "_tree_changed");
+	blend_points[p_point].node->disconnect("tree_changed", Callable(this, "_tree_changed"));
 
 	for (int i = p_point; i < blend_points_used - 1; i++) {
 		blend_points[i] = blend_points[i + 1];

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -77,7 +77,7 @@ void AnimationNodeBlendSpace2D::add_blend_point(const Ref<AnimationRootNode> &p_
 	blend_points[p_at_index].node = p_node;
 	blend_points[p_at_index].position = p_position;
 
-	blend_points[p_at_index].node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	blend_points[p_at_index].node->connect("tree_changed", Callable(this, "_tree_changed"), varray(), CONNECT_REFERENCE_COUNTED);
 	blend_points_used++;
 
 	_queue_auto_triangles();
@@ -95,10 +95,10 @@ void AnimationNodeBlendSpace2D::set_blend_point_node(int p_point, const Ref<Anim
 	ERR_FAIL_COND(p_node.is_null());
 
 	if (blend_points[p_point].node.is_valid()) {
-		blend_points[p_point].node->disconnect_compat("tree_changed", this, "_tree_changed");
+		blend_points[p_point].node->disconnect("tree_changed", Callable(this, "_tree_changed"));
 	}
 	blend_points[p_point].node = p_node;
-	blend_points[p_point].node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	blend_points[p_point].node->connect("tree_changed", Callable(this, "_tree_changed"), varray(), CONNECT_REFERENCE_COUNTED);
 
 	emit_signal("tree_changed");
 }
@@ -114,7 +114,7 @@ void AnimationNodeBlendSpace2D::remove_blend_point(int p_point) {
 	ERR_FAIL_INDEX(p_point, blend_points_used);
 
 	ERR_FAIL_COND(blend_points[p_point].node.is_null());
-	blend_points[p_point].node->disconnect_compat("tree_changed", this, "_tree_changed");
+	blend_points[p_point].node->disconnect("tree_changed", Callable(this, "_tree_changed"));
 
 	for (int i = 0; i < triangles.size(); i++) {
 		bool erase = false;

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -884,8 +884,8 @@ void AnimationNodeBlendTree::add_node(const StringName &p_name, Ref<AnimationNod
 	emit_changed();
 	emit_signal("tree_changed");
 
-	p_node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
-	p_node->connect_compat("changed", this, "_node_changed", varray(p_name), CONNECT_REFERENCE_COUNTED);
+	p_node->connect("tree_changed", Callable(this, "_tree_changed"), varray(), CONNECT_REFERENCE_COUNTED);
+	p_node->connect("changed", Callable(this, "_node_changed"), varray(p_name), CONNECT_REFERENCE_COUNTED);
 }
 
 Ref<AnimationNode> AnimationNodeBlendTree::get_node(const StringName &p_name) const {
@@ -947,8 +947,8 @@ void AnimationNodeBlendTree::remove_node(const StringName &p_name) {
 
 	{
 		Ref<AnimationNode> node = nodes[p_name].node;
-		node->disconnect_compat("tree_changed", this, "_tree_changed");
-		node->disconnect_compat("changed", this, "_node_changed");
+		node->disconnect("tree_changed", Callable(this, "_tree_changed"));
+		node->disconnect("changed", Callable(this, "_node_changed"));
 	}
 
 	nodes.erase(p_name);
@@ -973,7 +973,7 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 	ERR_FAIL_COND(p_name == SceneStringNames::get_singleton()->output);
 	ERR_FAIL_COND(p_new_name == SceneStringNames::get_singleton()->output);
 
-	nodes[p_name].node->disconnect_compat("changed", this, "_node_changed");
+	nodes[p_name].node->disconnect("changed", Callable(this, "_node_changed"));
 
 	nodes[p_new_name] = nodes[p_name];
 	nodes.erase(p_name);
@@ -988,7 +988,7 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 		}
 	}
 	//connection must be done with new name
-	nodes[p_new_name].node->connect_compat("changed", this, "_node_changed", varray(p_new_name), CONNECT_REFERENCE_COUNTED);
+	nodes[p_new_name].node->connect("changed", Callable(this, "_node_changed"), varray(p_new_name), CONNECT_REFERENCE_COUNTED);
 
 	emit_signal("tree_changed");
 }

--- a/scene/animation/animation_cache.cpp
+++ b/scene/animation/animation_cache.cpp
@@ -56,7 +56,7 @@ void AnimationCache::_clear_cache() {
 
 	while (connected_nodes.size()) {
 
-		connected_nodes.front()->get()->disconnect_compat("tree_exiting", this, "_node_exit_tree");
+		connected_nodes.front()->get()->disconnect("tree_exiting", Callable(this, "_node_exit_tree"));
 		connected_nodes.erase(connected_nodes.front());
 	}
 	path_cache.clear();
@@ -174,7 +174,7 @@ void AnimationCache::_update_cache() {
 
 		if (!connected_nodes.has(path.node)) {
 			connected_nodes.insert(path.node);
-			path.node->connect_compat("tree_exiting", this, "_node_exit_tree", Node::make_binds(path.node), CONNECT_ONESHOT);
+			path.node->connect("tree_exiting", Callable(this, "_node_exit_tree"), Node::make_binds(path.node), CONNECT_ONESHOT);
 		}
 	}
 
@@ -313,12 +313,12 @@ void AnimationCache::set_animation(const Ref<Animation> &p_animation) {
 	_clear_cache();
 
 	if (animation.is_valid())
-		animation->disconnect_compat("changed", this, "_animation_changed");
+		animation->disconnect("changed", Callable(this, "_animation_changed"));
 
 	animation = p_animation;
 
 	if (animation.is_valid())
-		animation->connect_compat("changed", this, "_animation_changed");
+		animation->connect("changed", Callable(this, "_animation_changed"));
 }
 
 void AnimationCache::_bind_methods() {

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -562,7 +562,7 @@ void AnimationNodeStateMachine::add_node(const StringName &p_name, Ref<Animation
 	emit_changed();
 	emit_signal("tree_changed");
 
-	p_node->connect_compat("tree_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	p_node->connect("tree_changed", Callable(this, "_tree_changed"), varray(), CONNECT_REFERENCE_COUNTED);
 }
 
 Ref<AnimationNode> AnimationNodeStateMachine::get_node(const StringName &p_name) const {
@@ -611,7 +611,7 @@ void AnimationNodeStateMachine::remove_node(const StringName &p_name) {
 
 		ERR_FAIL_COND(node.is_null());
 
-		node->disconnect_compat("tree_changed", this, "_tree_changed");
+		node->disconnect("tree_changed", Callable(this, "_tree_changed"));
 	}
 
 	states.erase(p_name);
@@ -619,7 +619,7 @@ void AnimationNodeStateMachine::remove_node(const StringName &p_name) {
 
 	for (int i = 0; i < transitions.size(); i++) {
 		if (transitions[i].from == p_name || transitions[i].to == p_name) {
-			transitions.write[i].transition->disconnect_compat("advance_condition_changed", this, "_tree_changed");
+			transitions.write[i].transition->disconnect("advance_condition_changed", Callable(this, "_tree_changed"));
 			transitions.remove(i);
 			i--;
 		}
@@ -722,7 +722,7 @@ void AnimationNodeStateMachine::add_transition(const StringName &p_from, const S
 	tr.to = p_to;
 	tr.transition = p_transition;
 
-	tr.transition->connect_compat("advance_condition_changed", this, "_tree_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	tr.transition->connect("advance_condition_changed", Callable(this, "_tree_changed"), varray(), CONNECT_REFERENCE_COUNTED);
 
 	transitions.push_back(tr);
 }
@@ -750,7 +750,7 @@ void AnimationNodeStateMachine::remove_transition(const StringName &p_from, cons
 
 	for (int i = 0; i < transitions.size(); i++) {
 		if (transitions[i].from == p_from && transitions[i].to == p_to) {
-			transitions.write[i].transition->disconnect_compat("advance_condition_changed", this, "_tree_changed");
+			transitions.write[i].transition->disconnect("advance_condition_changed", Callable(this, "_tree_changed"));
 			transitions.remove(i);
 			return;
 		}
@@ -764,7 +764,7 @@ void AnimationNodeStateMachine::remove_transition(const StringName &p_from, cons
 void AnimationNodeStateMachine::remove_transition_by_index(int p_transition) {
 
 	ERR_FAIL_INDEX(p_transition, transitions.size());
-	transitions.write[p_transition].transition->disconnect_compat("advance_condition_changed", this, "_tree_changed");
+	transitions.write[p_transition].transition->disconnect("advance_condition_changed", Callable(this, "_tree_changed"));
 	transitions.remove(p_transition);
 	/*if (playing) {
 		path.clear();

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -263,8 +263,8 @@ void AnimationPlayer::_ensure_node_caches(AnimationData *p_anim) {
 		}
 
 		{
-			if (!child->is_connected_compat("tree_exiting", this, "_node_removed"))
-				child->connect_compat("tree_exiting", this, "_node_removed", make_binds(child), CONNECT_ONESHOT);
+			if (!child->is_connected("tree_exiting", Callable(this, "_node_removed")))
+				child->connect("tree_exiting", Callable(this, "_node_removed"), make_binds(child), CONNECT_ONESHOT);
 		}
 
 		TrackNodeCacheKey key;
@@ -1007,12 +1007,12 @@ void AnimationPlayer::remove_animation(const StringName &p_name) {
 
 void AnimationPlayer::_ref_anim(const Ref<Animation> &p_anim) {
 
-	Ref<Animation>(p_anim)->connect_compat(SceneStringNames::get_singleton()->tracks_changed, this, "_animation_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	Ref<Animation>(p_anim)->connect(SceneStringNames::get_singleton()->tracks_changed, Callable(this, "_animation_changed"), varray(), CONNECT_REFERENCE_COUNTED);
 }
 
 void AnimationPlayer::_unref_anim(const Ref<Animation> &p_anim) {
 
-	Ref<Animation>(p_anim)->disconnect_compat(SceneStringNames::get_singleton()->tracks_changed, this, "_animation_changed");
+	Ref<Animation>(p_anim)->disconnect(SceneStringNames::get_singleton()->tracks_changed, Callable(this, "_animation_changed"));
 }
 
 void AnimationPlayer::rename_animation(const StringName &p_name, const StringName &p_new_name) {

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -463,13 +463,13 @@ AnimationNode::AnimationNode() {
 void AnimationTree::set_tree_root(const Ref<AnimationNode> &p_root) {
 
 	if (root.is_valid()) {
-		root->disconnect_compat("tree_changed", this, "_tree_changed");
+		root->disconnect("tree_changed", Callable(this, "_tree_changed"));
 	}
 
 	root = p_root;
 
 	if (root.is_valid()) {
-		root->connect_compat("tree_changed", this, "_tree_changed");
+		root->connect("tree_changed", Callable(this, "_tree_changed"));
 	}
 
 	properties_dirty = true;
@@ -582,8 +582,8 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 					continue;
 				}
 
-				if (!child->is_connected_compat("tree_exited", this, "_node_removed")) {
-					child->connect_compat("tree_exited", this, "_node_removed", varray(child));
+				if (!child->is_connected("tree_exited", Callable(this, "_node_removed"))) {
+					child->connect("tree_exited", Callable(this, "_node_removed"), varray(child));
 				}
 
 				switch (track_type) {
@@ -778,12 +778,12 @@ void AnimationTree::_process_graph(float p_delta) {
 		if (last_animation_player.is_valid()) {
 			Object *old_player = ObjectDB::get_instance(last_animation_player);
 			if (old_player) {
-				old_player->disconnect_compat("caches_cleared", this, "_clear_caches");
+				old_player->disconnect("caches_cleared", Callable(this, "_clear_caches"));
 			}
 		}
 
 		if (player) {
-			player->connect_compat("caches_cleared", this, "_clear_caches");
+			player->connect("caches_cleared", Callable(this, "_clear_caches"));
 		}
 
 		last_animation_player = current_animation_player;
@@ -1300,7 +1300,7 @@ void AnimationTree::_notification(int p_what) {
 
 			Object *player = ObjectDB::get_instance(last_animation_player);
 			if (player) {
-				player->disconnect_compat("caches_cleared", this, "_clear_caches");
+				player->disconnect("caches_cleared", Callable(this, "_clear_caches"));
 			}
 		}
 	} else if (p_what == NOTIFICATION_ENTER_TREE) {
@@ -1308,7 +1308,7 @@ void AnimationTree::_notification(int p_what) {
 
 			Object *player = ObjectDB::get_instance(last_animation_player);
 			if (player) {
-				player->connect_compat("caches_cleared", this, "_clear_caches");
+				player->connect("caches_cleared", Callable(this, "_clear_caches"));
 			}
 		}
 	}

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -441,7 +441,7 @@ AudioStreamPlayer::AudioStreamPlayer() {
 	setstop = false;
 	use_fadeout = false;
 
-	AudioServer::get_singleton()->connect_compat("bus_layout_changed", this, "_bus_layout_changed");
+	AudioServer::get_singleton()->connect("bus_layout_changed", Callable(this, "_bus_layout_changed"));
 }
 
 AudioStreamPlayer::~AudioStreamPlayer() {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -615,7 +615,7 @@ void ColorPicker::_screen_pick_pressed() {
 		screen->set_as_toplevel(true);
 		screen->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 		screen->set_default_cursor_shape(CURSOR_POINTING_HAND);
-		screen->connect_compat("gui_input", this, "_screen_input");
+		screen->connect("gui_input", Callable(this, "_screen_input"));
 		// It immediately toggles off in the first press otherwise.
 		screen->call_deferred("connect", "hide", Callable(btn_pick, "set_pressed"), varray(false));
 	}
@@ -742,20 +742,20 @@ ColorPicker::ColorPicker() :
 
 	uv_edit = memnew(Control);
 	hb_edit->add_child(uv_edit);
-	uv_edit->connect_compat("gui_input", this, "_uv_input");
+	uv_edit->connect("gui_input", Callable(this, "_uv_input"));
 	uv_edit->set_mouse_filter(MOUSE_FILTER_PASS);
 	uv_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	uv_edit->set_v_size_flags(SIZE_EXPAND_FILL);
 	uv_edit->set_custom_minimum_size(Size2(get_constant("sv_width"), get_constant("sv_height")));
-	uv_edit->connect_compat("draw", this, "_hsv_draw", make_binds(0, uv_edit));
+	uv_edit->connect("draw", Callable(this, "_hsv_draw"), make_binds(0, uv_edit));
 
 	w_edit = memnew(Control);
 	hb_edit->add_child(w_edit);
 	w_edit->set_custom_minimum_size(Size2(get_constant("h_width"), 0));
 	w_edit->set_h_size_flags(SIZE_FILL);
 	w_edit->set_v_size_flags(SIZE_EXPAND_FILL);
-	w_edit->connect_compat("gui_input", this, "_w_input");
-	w_edit->connect_compat("draw", this, "_hsv_draw", make_binds(1, w_edit));
+	w_edit->connect("gui_input", Callable(this, "_w_input"));
+	w_edit->connect("draw", Callable(this, "_hsv_draw"), make_binds(1, w_edit));
 
 	HBoxContainer *hb_smpl = memnew(HBoxContainer);
 	add_child(hb_smpl);
@@ -763,13 +763,13 @@ ColorPicker::ColorPicker() :
 	sample = memnew(TextureRect);
 	hb_smpl->add_child(sample);
 	sample->set_h_size_flags(SIZE_EXPAND_FILL);
-	sample->connect_compat("draw", this, "_sample_draw");
+	sample->connect("draw", Callable(this, "_sample_draw"));
 
 	btn_pick = memnew(ToolButton);
 	hb_smpl->add_child(btn_pick);
 	btn_pick->set_toggle_mode(true);
 	btn_pick->set_tooltip(TTR("Pick a color from the editor window."));
-	btn_pick->connect_compat("pressed", this, "_screen_pick_pressed");
+	btn_pick->connect("pressed", Callable(this, "_screen_pick_pressed"));
 
 	VBoxContainer *vbl = memnew(VBoxContainer);
 	add_child(vbl);
@@ -797,14 +797,14 @@ ColorPicker::ColorPicker() :
 		values[i] = memnew(SpinBox);
 		scroll[i]->share(values[i]);
 		hbc->add_child(values[i]);
-		values[i]->get_line_edit()->connect_compat("focus_entered", this, "_focus_enter");
-		values[i]->get_line_edit()->connect_compat("focus_exited", this, "_focus_exit");
+		values[i]->get_line_edit()->connect("focus_entered", Callable(this, "_focus_enter"));
+		values[i]->get_line_edit()->connect("focus_exited", Callable(this, "_focus_exit"));
 
 		scroll[i]->set_min(0);
 		scroll[i]->set_page(0);
 		scroll[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 
-		scroll[i]->connect_compat("value_changed", this, "_value_changed");
+		scroll[i]->connect("value_changed", Callable(this, "_value_changed"));
 
 		vbr->add_child(hbc);
 	}
@@ -816,12 +816,12 @@ ColorPicker::ColorPicker() :
 	btn_hsv = memnew(CheckButton);
 	hhb->add_child(btn_hsv);
 	btn_hsv->set_text(TTR("HSV"));
-	btn_hsv->connect_compat("toggled", this, "set_hsv_mode");
+	btn_hsv->connect("toggled", Callable(this, "set_hsv_mode"));
 
 	btn_raw = memnew(CheckButton);
 	hhb->add_child(btn_raw);
 	btn_raw->set_text(TTR("Raw"));
-	btn_raw->connect_compat("toggled", this, "set_raw_mode");
+	btn_raw->connect("toggled", Callable(this, "set_raw_mode"));
 
 	text_type = memnew(Button);
 	hhb->add_child(text_type);
@@ -832,7 +832,7 @@ ColorPicker::ColorPicker() :
 #ifdef TOOLS_ENABLED
 		text_type->set_custom_minimum_size(Size2(28 * EDSCALE, 0)); // Adjust for the width of the "Script" icon.
 #endif
-		text_type->connect_compat("pressed", this, "_text_type_toggled");
+		text_type->connect("pressed", Callable(this, "_text_type_toggled"));
 	} else {
 
 		text_type->set_flat(true);
@@ -842,9 +842,9 @@ ColorPicker::ColorPicker() :
 	c_text = memnew(LineEdit);
 	hhb->add_child(c_text);
 	c_text->set_h_size_flags(SIZE_EXPAND_FILL);
-	c_text->connect_compat("text_entered", this, "_html_entered");
-	c_text->connect_compat("focus_entered", this, "_focus_enter");
-	c_text->connect_compat("focus_exited", this, "_html_focus_exit");
+	c_text->connect("text_entered", Callable(this, "_html_entered"));
+	c_text->connect("focus_entered", Callable(this, "_focus_enter"));
+	c_text->connect("focus_exited", Callable(this, "_html_focus_exit"));
 
 	_update_controls();
 	updating = false;
@@ -860,8 +860,8 @@ ColorPicker::ColorPicker() :
 
 	preset = memnew(TextureRect);
 	preset_container->add_child(preset);
-	preset->connect_compat("gui_input", this, "_preset_input");
-	preset->connect_compat("draw", this, "_update_presets");
+	preset->connect("gui_input", Callable(this, "_preset_input"));
+	preset->connect("draw", Callable(this, "_update_presets"));
 
 	preset_container2 = memnew(HBoxContainer);
 	preset_container2->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -869,7 +869,7 @@ ColorPicker::ColorPicker() :
 	bt_add_preset = memnew(Button);
 	preset_container2->add_child(bt_add_preset);
 	bt_add_preset->set_tooltip(TTR("Add current color as a preset."));
-	bt_add_preset->connect_compat("pressed", this, "_add_preset_pressed");
+	bt_add_preset->connect("pressed", Callable(this, "_add_preset_pressed"));
 }
 
 /////////////////
@@ -969,10 +969,10 @@ void ColorPickerButton::_update_picker() {
 		picker = memnew(ColorPicker);
 		popup->add_child(picker);
 		add_child(popup);
-		picker->connect_compat("color_changed", this, "_color_changed");
-		popup->connect_compat("modal_closed", this, "_modal_closed");
-		popup->connect_compat("about_to_show", this, "set_pressed", varray(true));
-		popup->connect_compat("popup_hide", this, "set_pressed", varray(false));
+		picker->connect("color_changed", Callable(this, "_color_changed"));
+		popup->connect("modal_closed", Callable(this, "_modal_closed"));
+		popup->connect("about_to_show", Callable(this, "set_pressed"), varray(true));
+		popup->connect("popup_hide", Callable(this, "set_pressed"), varray(false));
 		picker->set_pick_color(color);
 		picker->set_edit_alpha(edit_alpha);
 		emit_signal("picker_created");

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -48,9 +48,9 @@ void Container::add_child_notify(Node *p_child) {
 	if (!control)
 		return;
 
-	control->connect_compat("size_flags_changed", this, "queue_sort");
-	control->connect_compat("minimum_size_changed", this, "_child_minsize_changed");
-	control->connect_compat("visibility_changed", this, "_child_minsize_changed");
+	control->connect("size_flags_changed", Callable(this, "queue_sort"));
+	control->connect("minimum_size_changed", Callable(this, "_child_minsize_changed"));
+	control->connect("visibility_changed", Callable(this, "_child_minsize_changed"));
 
 	minimum_size_changed();
 	queue_sort();
@@ -75,9 +75,9 @@ void Container::remove_child_notify(Node *p_child) {
 	if (!control)
 		return;
 
-	control->disconnect_compat("size_flags_changed", this, "queue_sort");
-	control->disconnect_compat("minimum_size_changed", this, "_child_minsize_changed");
-	control->disconnect_compat("visibility_changed", this, "_child_minsize_changed");
+	control->disconnect("size_flags_changed", Callable(this, "queue_sort"));
+	control->disconnect("minimum_size_changed", Callable(this, "_child_minsize_changed"));
+	control->disconnect("visibility_changed", Callable(this, "_child_minsize_changed"));
 
 	minimum_size_changed();
 	queue_sort();

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -221,28 +221,28 @@ bool Control::_set(const StringName &p_name, const Variant &p_value) {
 		if (name.begins_with("custom_icons/")) {
 			String dname = name.get_slicec('/', 1);
 			if (data.icon_override.has(dname)) {
-				data.icon_override[dname]->disconnect_compat("changed", this, "_override_changed");
+				data.icon_override[dname]->disconnect("changed", Callable(this, "_override_changed"));
 			}
 			data.icon_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
 		} else if (name.begins_with("custom_shaders/")) {
 			String dname = name.get_slicec('/', 1);
 			if (data.shader_override.has(dname)) {
-				data.shader_override[dname]->disconnect_compat("changed", this, "_override_changed");
+				data.shader_override[dname]->disconnect("changed", Callable(this, "_override_changed"));
 			}
 			data.shader_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
 		} else if (name.begins_with("custom_styles/")) {
 			String dname = name.get_slicec('/', 1);
 			if (data.style_override.has(dname)) {
-				data.style_override[dname]->disconnect_compat("changed", this, "_override_changed");
+				data.style_override[dname]->disconnect("changed", Callable(this, "_override_changed"));
 			}
 			data.style_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
 		} else if (name.begins_with("custom_fonts/")) {
 			String dname = name.get_slicec('/', 1);
 			if (data.font_override.has(dname)) {
-				data.font_override[dname]->disconnect_compat("changed", this, "_override_changed");
+				data.font_override[dname]->disconnect("changed", Callable(this, "_override_changed"));
 			}
 			data.font_override.erase(dname);
 			notification(NOTIFICATION_THEME_CHANGED);
@@ -542,10 +542,10 @@ void Control::_notification(int p_notification) {
 
 				if (data.parent_canvas_item) {
 
-					data.parent_canvas_item->connect_compat("item_rect_changed", this, "_size_changed");
+					data.parent_canvas_item->connect("item_rect_changed", Callable(this, "_size_changed"));
 				} else {
 					//connect viewport
-					get_viewport()->connect_compat("size_changed", this, "_size_changed");
+					get_viewport()->connect("size_changed", Callable(this, "_size_changed"));
 				}
 			}
 
@@ -561,11 +561,11 @@ void Control::_notification(int p_notification) {
 
 			if (data.parent_canvas_item) {
 
-				data.parent_canvas_item->disconnect_compat("item_rect_changed", this, "_size_changed");
+				data.parent_canvas_item->disconnect("item_rect_changed", Callable(this, "_size_changed"));
 				data.parent_canvas_item = NULL;
 			} else if (!is_set_as_toplevel()) {
 				//disconnect viewport
-				get_viewport()->disconnect_compat("size_changed", this, "_size_changed");
+				get_viewport()->disconnect("size_changed", Callable(this, "_size_changed"));
 			}
 
 			if (data.MI) {
@@ -1883,7 +1883,7 @@ Rect2 Control::get_anchorable_rect() const {
 void Control::add_icon_override(const StringName &p_name, const Ref<Texture2D> &p_icon) {
 
 	if (data.icon_override.has(p_name)) {
-		data.icon_override[p_name]->disconnect_compat("changed", this, "_override_changed");
+		data.icon_override[p_name]->disconnect("changed", Callable(this, "_override_changed"));
 	}
 
 	// clear if "null" is passed instead of a icon
@@ -1892,7 +1892,7 @@ void Control::add_icon_override(const StringName &p_name, const Ref<Texture2D> &
 	} else {
 		data.icon_override[p_name] = p_icon;
 		if (data.icon_override[p_name].is_valid()) {
-			data.icon_override[p_name]->connect_compat("changed", this, "_override_changed", Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
+			data.icon_override[p_name]->connect("changed", Callable(this, "_override_changed"), Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
 		}
 	}
 	notification(NOTIFICATION_THEME_CHANGED);
@@ -1901,7 +1901,7 @@ void Control::add_icon_override(const StringName &p_name, const Ref<Texture2D> &
 void Control::add_shader_override(const StringName &p_name, const Ref<Shader> &p_shader) {
 
 	if (data.shader_override.has(p_name)) {
-		data.shader_override[p_name]->disconnect_compat("changed", this, "_override_changed");
+		data.shader_override[p_name]->disconnect("changed", Callable(this, "_override_changed"));
 	}
 
 	// clear if "null" is passed instead of a shader
@@ -1910,7 +1910,7 @@ void Control::add_shader_override(const StringName &p_name, const Ref<Shader> &p
 	} else {
 		data.shader_override[p_name] = p_shader;
 		if (data.shader_override[p_name].is_valid()) {
-			data.shader_override[p_name]->connect_compat("changed", this, "_override_changed", Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
+			data.shader_override[p_name]->connect("changed", Callable(this, "_override_changed"), Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
 		}
 	}
 	notification(NOTIFICATION_THEME_CHANGED);
@@ -1918,7 +1918,7 @@ void Control::add_shader_override(const StringName &p_name, const Ref<Shader> &p
 void Control::add_style_override(const StringName &p_name, const Ref<StyleBox> &p_style) {
 
 	if (data.style_override.has(p_name)) {
-		data.style_override[p_name]->disconnect_compat("changed", this, "_override_changed");
+		data.style_override[p_name]->disconnect("changed", Callable(this, "_override_changed"));
 	}
 
 	// clear if "null" is passed instead of a style
@@ -1927,7 +1927,7 @@ void Control::add_style_override(const StringName &p_name, const Ref<StyleBox> &
 	} else {
 		data.style_override[p_name] = p_style;
 		if (data.style_override[p_name].is_valid()) {
-			data.style_override[p_name]->connect_compat("changed", this, "_override_changed", Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
+			data.style_override[p_name]->connect("changed", Callable(this, "_override_changed"), Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
 		}
 	}
 	notification(NOTIFICATION_THEME_CHANGED);
@@ -1936,7 +1936,7 @@ void Control::add_style_override(const StringName &p_name, const Ref<StyleBox> &
 void Control::add_font_override(const StringName &p_name, const Ref<Font> &p_font) {
 
 	if (data.font_override.has(p_name)) {
-		data.font_override[p_name]->disconnect_compat("changed", this, "_override_changed");
+		data.font_override[p_name]->disconnect("changed", Callable(this, "_override_changed"));
 	}
 
 	// clear if "null" is passed instead of a font
@@ -1945,7 +1945,7 @@ void Control::add_font_override(const StringName &p_name, const Ref<Font> &p_fon
 	} else {
 		data.font_override[p_name] = p_font;
 		if (data.font_override[p_name].is_valid()) {
-			data.font_override[p_name]->connect_compat("changed", this, "_override_changed", Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
+			data.font_override[p_name]->connect("changed", Callable(this, "_override_changed"), Vector<Variant>(), CONNECT_REFERENCE_COUNTED);
 		}
 	}
 	notification(NOTIFICATION_THEME_CHANGED);
@@ -2262,7 +2262,7 @@ void Control::set_theme(const Ref<Theme> &p_theme) {
 		return;
 
 	if (data.theme.is_valid()) {
-		data.theme->disconnect_compat("changed", this, "_theme_changed");
+		data.theme->disconnect("changed", Callable(this, "_theme_changed"));
 	}
 
 	data.theme = p_theme;
@@ -2282,7 +2282,7 @@ void Control::set_theme(const Ref<Theme> &p_theme) {
 	}
 
 	if (data.theme.is_valid()) {
-		data.theme->connect_compat("changed", this, "_theme_changed", varray(), CONNECT_DEFERRED);
+		data.theme->connect("changed", Callable(this, "_theme_changed"), varray(), CONNECT_DEFERRED);
 	}
 }
 

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -347,7 +347,7 @@ WindowDialog::WindowDialog() {
 	resizable = false;
 	close_button = memnew(TextureButton);
 	add_child(close_button);
-	close_button->connect_compat("pressed", this, "_closed");
+	close_button->connect("pressed", Callable(this, "_closed"));
 
 #ifdef TOOLS_ENABLED
 	was_editor_dimmed = false;
@@ -446,7 +446,7 @@ void AcceptDialog::register_text_enter(Node *p_line_edit) {
 	ERR_FAIL_NULL(p_line_edit);
 	LineEdit *line_edit = Object::cast_to<LineEdit>(p_line_edit);
 	if (line_edit)
-		line_edit->connect_compat("text_entered", this, "_builtin_text_entered");
+		line_edit->connect("text_entered", Callable(this, "_builtin_text_entered"));
 }
 
 void AcceptDialog::_update_child_rects() {
@@ -531,7 +531,7 @@ Button *AcceptDialog::add_button(const String &p_text, bool p_right, const Strin
 	}
 
 	if (p_action != "") {
-		button->connect_compat("pressed", this, "_custom_action", varray(p_action));
+		button->connect("pressed", Callable(this, "_custom_action"), varray(p_action));
 	}
 
 	return button;
@@ -543,7 +543,7 @@ Button *AcceptDialog::add_cancel(const String &p_cancel) {
 	if (p_cancel == "")
 		c = RTR("Cancel");
 	Button *b = swap_ok_cancel ? add_button(c, true) : add_button(c);
-	b->connect_compat("pressed", this, "_closed");
+	b->connect("pressed", Callable(this, "_closed"));
 	return b;
 }
 
@@ -600,7 +600,7 @@ AcceptDialog::AcceptDialog() {
 	hbc->add_child(ok);
 	hbc->add_spacer();
 
-	ok->connect_compat("pressed", this, "_ok");
+	ok->connect("pressed", Callable(this, "_ok"));
 	set_as_toplevel(true);
 
 	hide_on_ok = true;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -900,11 +900,11 @@ FileDialog::FileDialog() {
 	dir_up = memnew(ToolButton);
 	dir_up->set_tooltip(RTR("Go to parent folder."));
 	hbc->add_child(dir_up);
-	dir_up->connect_compat("pressed", this, "_go_up");
+	dir_up->connect("pressed", Callable(this, "_go_up"));
 
 	drives = memnew(OptionButton);
 	hbc->add_child(drives);
-	drives->connect_compat("item_selected", this, "_select_drive");
+	drives->connect("item_selected", Callable(this, "_select_drive"));
 
 	hbc->add_child(memnew(Label(RTR("Path:"))));
 	dir = memnew(LineEdit);
@@ -913,19 +913,19 @@ FileDialog::FileDialog() {
 
 	refresh = memnew(ToolButton);
 	refresh->set_tooltip(RTR("Refresh files."));
-	refresh->connect_compat("pressed", this, "_update_file_list");
+	refresh->connect("pressed", Callable(this, "_update_file_list"));
 	hbc->add_child(refresh);
 
 	show_hidden = memnew(ToolButton);
 	show_hidden->set_toggle_mode(true);
 	show_hidden->set_pressed(is_showing_hidden_files());
 	show_hidden->set_tooltip(RTR("Toggle the visibility of hidden files."));
-	show_hidden->connect_compat("toggled", this, "set_show_hidden_files");
+	show_hidden->connect("toggled", Callable(this, "set_show_hidden_files"));
 	hbc->add_child(show_hidden);
 
 	makedir = memnew(Button);
 	makedir->set_text(RTR("Create Folder"));
-	makedir->connect_compat("pressed", this, "_make_dir");
+	makedir->connect("pressed", Callable(this, "_make_dir"));
 	hbc->add_child(makedir);
 	vbc->add_child(hbc);
 
@@ -950,20 +950,20 @@ FileDialog::FileDialog() {
 	access = ACCESS_RESOURCES;
 	_update_drives();
 
-	connect_compat("confirmed", this, "_action_pressed");
-	tree->connect_compat("multi_selected", this, "_tree_multi_selected", varray(), CONNECT_DEFERRED);
-	tree->connect_compat("cell_selected", this, "_tree_selected", varray(), CONNECT_DEFERRED);
-	tree->connect_compat("item_activated", this, "_tree_item_activated", varray());
-	tree->connect_compat("nothing_selected", this, "deselect_items");
-	dir->connect_compat("text_entered", this, "_dir_entered");
-	file->connect_compat("text_entered", this, "_file_entered");
-	filter->connect_compat("item_selected", this, "_filter_selected");
+	connect("confirmed", Callable(this, "_action_pressed"));
+	tree->connect("multi_selected", Callable(this, "_tree_multi_selected"), varray(), CONNECT_DEFERRED);
+	tree->connect("cell_selected", Callable(this, "_tree_selected"), varray(), CONNECT_DEFERRED);
+	tree->connect("item_activated", Callable(this, "_tree_item_activated"), varray());
+	tree->connect("nothing_selected", Callable(this, "deselect_items"));
+	dir->connect("text_entered", Callable(this, "_dir_entered"));
+	file->connect("text_entered", Callable(this, "_file_entered"));
+	filter->connect("item_selected", Callable(this, "_filter_selected"));
 
 	confirm_save = memnew(ConfirmationDialog);
 	confirm_save->set_as_toplevel(true);
 	add_child(confirm_save);
 
-	confirm_save->connect_compat("confirmed", this, "_save_confirm_pressed");
+	confirm_save->connect("confirmed", Callable(this, "_save_confirm_pressed"));
 
 	makedialog = memnew(ConfirmationDialog);
 	makedialog->set_title(RTR("Create Folder"));
@@ -974,7 +974,7 @@ FileDialog::FileDialog() {
 	makevb->add_margin_child(RTR("Name:"), makedirname);
 	add_child(makedialog);
 	makedialog->register_text_enter(makedirname);
-	makedialog->connect_compat("confirmed", this, "_make_dir_confirm");
+	makedialog->connect("confirmed", Callable(this, "_make_dir_confirm"));
 	mkdirerr = memnew(AcceptDialog);
 	mkdirerr->set_text(RTR("Could not create folder."));
 	add_child(mkdirerr);
@@ -1029,10 +1029,10 @@ LineEditFileChooser::LineEditFileChooser() {
 	button = memnew(Button);
 	button->set_text(" .. ");
 	add_child(button);
-	button->connect_compat("pressed", this, "_browse");
+	button->connect("pressed", Callable(this, "_browse"));
 	dialog = memnew(FileDialog);
 	add_child(dialog);
-	dialog->connect_compat("file_selected", this, "_chosen");
-	dialog->connect_compat("dir_selected", this, "_chosen");
-	dialog->connect_compat("files_selected", this, "_chosen");
+	dialog->connect("file_selected", Callable(this, "_chosen"));
+	dialog->connect("dir_selected", Callable(this, "_chosen"));
+	dialog->connect("files_selected", Callable(this, "_chosen"));
 }

--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -302,8 +302,8 @@ void GradientEdit::_gui_input(const Ref<InputEvent> &p_event) {
 void GradientEdit::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		if (!picker->is_connected_compat("color_changed", this, "_color_changed")) {
-			picker->connect_compat("color_changed", this, "_color_changed");
+		if (!picker->is_connected("color_changed", Callable(this, "_color_changed"))) {
+			picker->connect("color_changed", Callable(this, "_color_changed"));
 		}
 	}
 	if (p_what == NOTIFICATION_DRAW) {

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -257,9 +257,9 @@ void GraphEdit::add_child_notify(Node *p_child) {
 	GraphNode *gn = Object::cast_to<GraphNode>(p_child);
 	if (gn) {
 		gn->set_scale(Vector2(zoom, zoom));
-		gn->connect_compat("offset_changed", this, "_graph_node_moved", varray(gn));
-		gn->connect_compat("raise_request", this, "_graph_node_raised", varray(gn));
-		gn->connect_compat("item_rect_changed", connections_layer, "update");
+		gn->connect("offset_changed", Callable(this, "_graph_node_moved"), varray(gn));
+		gn->connect("raise_request", Callable(this, "_graph_node_raised"), varray(gn));
+		gn->connect("item_rect_changed", Callable(connections_layer, "update"));
 		_graph_node_moved(gn);
 		gn->set_mouse_filter(MOUSE_FILTER_PASS);
 	}
@@ -273,8 +273,8 @@ void GraphEdit::remove_child_notify(Node *p_child) {
 	}
 	GraphNode *gn = Object::cast_to<GraphNode>(p_child);
 	if (gn) {
-		gn->disconnect_compat("offset_changed", this, "_graph_node_moved");
-		gn->disconnect_compat("raise_request", this, "_graph_node_raised");
+		gn->disconnect("offset_changed", Callable(this, "_graph_node_moved"));
+		gn->disconnect("raise_request", Callable(this, "_graph_node_raised"));
 	}
 }
 
@@ -1341,12 +1341,12 @@ GraphEdit::GraphEdit() {
 	add_child(top_layer);
 	top_layer->set_mouse_filter(MOUSE_FILTER_PASS);
 	top_layer->set_anchors_and_margins_preset(Control::PRESET_WIDE);
-	top_layer->connect_compat("draw", this, "_top_layer_draw");
-	top_layer->connect_compat("gui_input", this, "_top_layer_input");
+	top_layer->connect("draw", Callable(this, "_top_layer_draw"));
+	top_layer->connect("gui_input", Callable(this, "_top_layer_input"));
 
 	connections_layer = memnew(Control);
 	add_child(connections_layer);
-	connections_layer->connect_compat("draw", this, "_connections_layer_draw");
+	connections_layer->connect("draw", Callable(this, "_connections_layer_draw"));
 	connections_layer->set_name("CLAYER");
 	connections_layer->set_disable_visibility_clip(true); // so it can draw freely and be offset
 	connections_layer->set_mouse_filter(MOUSE_FILTER_IGNORE);
@@ -1373,8 +1373,8 @@ GraphEdit::GraphEdit() {
 	v_scroll->set_min(-10000);
 	v_scroll->set_max(10000);
 
-	h_scroll->connect_compat("value_changed", this, "_scroll_moved");
-	v_scroll->connect_compat("value_changed", this, "_scroll_moved");
+	h_scroll->connect("value_changed", Callable(this, "_scroll_moved"));
+	v_scroll->connect("value_changed", Callable(this, "_scroll_moved"));
 
 	zoom = 1;
 
@@ -1385,25 +1385,25 @@ GraphEdit::GraphEdit() {
 	zoom_minus = memnew(ToolButton);
 	zoom_hb->add_child(zoom_minus);
 	zoom_minus->set_tooltip(RTR("Zoom Out"));
-	zoom_minus->connect_compat("pressed", this, "_zoom_minus");
+	zoom_minus->connect("pressed", Callable(this, "_zoom_minus"));
 	zoom_minus->set_focus_mode(FOCUS_NONE);
 
 	zoom_reset = memnew(ToolButton);
 	zoom_hb->add_child(zoom_reset);
 	zoom_reset->set_tooltip(RTR("Zoom Reset"));
-	zoom_reset->connect_compat("pressed", this, "_zoom_reset");
+	zoom_reset->connect("pressed", Callable(this, "_zoom_reset"));
 	zoom_reset->set_focus_mode(FOCUS_NONE);
 
 	zoom_plus = memnew(ToolButton);
 	zoom_hb->add_child(zoom_plus);
 	zoom_plus->set_tooltip(RTR("Zoom In"));
-	zoom_plus->connect_compat("pressed", this, "_zoom_plus");
+	zoom_plus->connect("pressed", Callable(this, "_zoom_plus"));
 	zoom_plus->set_focus_mode(FOCUS_NONE);
 
 	snap_button = memnew(ToolButton);
 	snap_button->set_toggle_mode(true);
 	snap_button->set_tooltip(RTR("Enable snap and show grid."));
-	snap_button->connect_compat("pressed", this, "_snap_toggled");
+	snap_button->connect("pressed", Callable(this, "_snap_toggled"));
 	snap_button->set_pressed(true);
 	snap_button->set_focus_mode(FOCUS_NONE);
 	zoom_hb->add_child(snap_button);
@@ -1413,7 +1413,7 @@ GraphEdit::GraphEdit() {
 	snap_amount->set_max(100);
 	snap_amount->set_step(1);
 	snap_amount->set_value(20);
-	snap_amount->connect_compat("value_changed", this, "_snap_value_changed");
+	snap_amount->connect("value_changed", Callable(this, "_snap_value_changed"));
 	zoom_hb->add_child(snap_amount);
 
 	setting_scroll_ofs = false;

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1599,7 +1599,7 @@ ItemList::ItemList() {
 	add_child(scroll_bar);
 
 	shape_changed = true;
-	scroll_bar->connect_compat("value_changed", this, "_scroll_changed");
+	scroll_bar->connect("value_changed", Callable(this, "_scroll_changed"));
 
 	set_focus_mode(FOCUS_ALL);
 	current_columns = 1;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -648,8 +648,8 @@ void LineEdit::_notification(int p_what) {
 				cursor_set_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
 				cursor_set_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
 
-				if (!EditorSettings::get_singleton()->is_connected_compat("settings_changed", this, "_editor_settings_changed")) {
-					EditorSettings::get_singleton()->connect_compat("settings_changed", this, "_editor_settings_changed");
+				if (!EditorSettings::get_singleton()->is_connected("settings_changed", Callable(this, "_editor_settings_changed"))) {
+					EditorSettings::get_singleton()->connect("settings_changed", Callable(this, "_editor_settings_changed"));
 				}
 			}
 		} break;
@@ -1870,7 +1870,7 @@ LineEdit::LineEdit() {
 	caret_blink_timer = memnew(Timer);
 	add_child(caret_blink_timer);
 	caret_blink_timer->set_wait_time(0.65);
-	caret_blink_timer->connect_compat("timeout", this, "_toggle_draw_caret");
+	caret_blink_timer->connect("timeout", Callable(this, "_toggle_draw_caret"));
 	cursor_set_blink_enabled(false);
 
 	context_menu_enabled = true;
@@ -1878,7 +1878,7 @@ LineEdit::LineEdit() {
 	add_child(menu);
 	editable = false; // Initialise to opposite first, so we get past the early-out in set_editable.
 	set_editable(true);
-	menu->connect_compat("id_pressed", this, "menu_option");
+	menu->connect("id_pressed", Callable(this, "menu_option"));
 	expand_to_text_length = false;
 }
 

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -137,8 +137,8 @@ MenuButton::MenuButton() {
 	popup->hide();
 	add_child(popup);
 	popup->set_pass_on_modal_close_click(false);
-	popup->connect_compat("about_to_show", this, "set_pressed", varray(true)); // For when switching from another MenuButton.
-	popup->connect_compat("popup_hide", this, "set_pressed", varray(false));
+	popup->connect("about_to_show", Callable(this, "set_pressed"), varray(true)); // For when switching from another MenuButton.
+	popup->connect("popup_hide", Callable(this, "set_pressed"), varray(false));
 }
 
 MenuButton::~MenuButton() {

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -363,9 +363,9 @@ OptionButton::OptionButton() {
 	popup->set_pass_on_modal_close_click(false);
 	popup->set_notify_transform(true);
 	popup->set_allow_search(true);
-	popup->connect_compat("index_pressed", this, "_selected");
-	popup->connect_compat("id_focused", this, "_focused");
-	popup->connect_compat("popup_hide", this, "set_pressed", varray(false));
+	popup->connect("index_pressed", Callable(this, "_selected"));
+	popup->connect("id_focused", Callable(this, "_focused"));
+	popup->connect("popup_hide", Callable(this, "set_pressed"), varray(false));
 }
 
 OptionButton::~OptionButton() {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1233,7 +1233,7 @@ void PopupMenu::_ref_shortcut(Ref<ShortCut> p_sc) {
 
 	if (!shortcut_refcount.has(p_sc)) {
 		shortcut_refcount[p_sc] = 1;
-		p_sc->connect_compat("changed", this, "update");
+		p_sc->connect("changed", Callable(this, "update"));
 	} else {
 		shortcut_refcount[p_sc] += 1;
 	}
@@ -1244,7 +1244,7 @@ void PopupMenu::_unref_shortcut(Ref<ShortCut> p_sc) {
 	ERR_FAIL_COND(!shortcut_refcount.has(p_sc));
 	shortcut_refcount[p_sc]--;
 	if (shortcut_refcount[p_sc] == 0) {
-		p_sc->disconnect_compat("changed", this, "update");
+		p_sc->disconnect("changed", Callable(this, "update"));
 		shortcut_refcount.erase(p_sc);
 	}
 }
@@ -1514,7 +1514,7 @@ PopupMenu::PopupMenu() {
 	submenu_timer = memnew(Timer);
 	submenu_timer->set_wait_time(0.3);
 	submenu_timer->set_one_shot(true);
-	submenu_timer->connect_compat("timeout", this, "_submenu_timeout");
+	submenu_timer->connect("timeout", Callable(this, "_submenu_timeout"));
 	add_child(submenu_timer);
 }
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2963,7 +2963,7 @@ RichTextLabel::RichTextLabel() {
 	vscroll->set_anchor_and_margin(MARGIN_TOP, ANCHOR_BEGIN, 0);
 	vscroll->set_anchor_and_margin(MARGIN_BOTTOM, ANCHOR_END, 0);
 	vscroll->set_anchor_and_margin(MARGIN_RIGHT, ANCHOR_END, 0);
-	vscroll->connect_compat("value_changed", this, "_scroll_changed");
+	vscroll->connect("value_changed", Callable(this, "_scroll_changed"));
 	vscroll->set_step(1);
 	vscroll->hide();
 	current_idx = 1;

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -296,15 +296,15 @@ void ScrollBar::_notification(int p_what) {
 		}
 
 		if (drag_node) {
-			drag_node->connect_compat("gui_input", this, "_drag_node_input");
-			drag_node->connect_compat("tree_exiting", this, "_drag_node_exit", varray(), CONNECT_ONESHOT);
+			drag_node->connect("gui_input", Callable(this, "_drag_node_input"));
+			drag_node->connect("tree_exiting", Callable(this, "_drag_node_exit"), varray(), CONNECT_ONESHOT);
 		}
 	}
 	if (p_what == NOTIFICATION_EXIT_TREE) {
 
 		if (drag_node) {
-			drag_node->disconnect_compat("gui_input", this, "_drag_node_input");
-			drag_node->disconnect_compat("tree_exiting", this, "_drag_node_exit");
+			drag_node->disconnect("gui_input", Callable(this, "_drag_node_input"));
+			drag_node->disconnect("tree_exiting", Callable(this, "_drag_node_exit"));
 		}
 
 		drag_node = NULL;
@@ -539,7 +539,7 @@ float ScrollBar::get_custom_step() const {
 void ScrollBar::_drag_node_exit() {
 
 	if (drag_node) {
-		drag_node->disconnect_compat("gui_input", this, "_drag_node_input");
+		drag_node->disconnect("gui_input", Callable(this, "_drag_node_input"));
 	}
 	drag_node = NULL;
 }
@@ -611,8 +611,8 @@ void ScrollBar::set_drag_node(const NodePath &p_path) {
 	if (is_inside_tree()) {
 
 		if (drag_node) {
-			drag_node->disconnect_compat("gui_input", this, "_drag_node_input");
-			drag_node->disconnect_compat("tree_exiting", this, "_drag_node_exit");
+			drag_node->disconnect("gui_input", Callable(this, "_drag_node_input"));
+			drag_node->disconnect("tree_exiting", Callable(this, "_drag_node_exit"));
 		}
 	}
 
@@ -627,8 +627,8 @@ void ScrollBar::set_drag_node(const NodePath &p_path) {
 		}
 
 		if (drag_node) {
-			drag_node->connect_compat("gui_input", this, "_drag_node_input");
-			drag_node->connect_compat("tree_exiting", this, "_drag_node_exit", varray(), CONNECT_ONESHOT);
+			drag_node->connect("gui_input", Callable(this, "_drag_node_input"));
+			drag_node->connect("tree_exiting", Callable(this, "_drag_node_exit"), varray(), CONNECT_ONESHOT);
 		}
 	}
 }

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -267,7 +267,7 @@ void ScrollContainer::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_READY) {
 
-		get_viewport()->connect_compat("gui_focus_changed", this, "_ensure_focused_visible");
+		get_viewport()->connect("gui_focus_changed", Callable(this, "_ensure_focused_visible"));
 	}
 
 	if (p_what == NOTIFICATION_SORT_CHILDREN) {
@@ -610,12 +610,12 @@ ScrollContainer::ScrollContainer() {
 	h_scroll = memnew(HScrollBar);
 	h_scroll->set_name("_h_scroll");
 	add_child(h_scroll);
-	h_scroll->connect_compat("value_changed", this, "_scroll_moved");
+	h_scroll->connect("value_changed", Callable(this, "_scroll_moved"));
 
 	v_scroll = memnew(VScrollBar);
 	v_scroll->set_name("_v_scroll");
 	add_child(v_scroll);
-	v_scroll->connect_compat("value_changed", this, "_scroll_moved");
+	v_scroll->connect("value_changed", Callable(this, "_scroll_moved"));
 
 	drag_speed = Vector2();
 	drag_touching = false;

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -297,12 +297,12 @@ SpinBox::SpinBox() {
 	line_edit->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	line_edit->set_mouse_filter(MOUSE_FILTER_PASS);
 	//connect("value_changed",this,"_value_changed");
-	line_edit->connect_compat("text_entered", this, "_text_entered", Vector<Variant>(), CONNECT_DEFERRED);
-	line_edit->connect_compat("focus_exited", this, "_line_edit_focus_exit", Vector<Variant>(), CONNECT_DEFERRED);
-	line_edit->connect_compat("gui_input", this, "_line_edit_input");
+	line_edit->connect("text_entered", Callable(this, "_text_entered"), Vector<Variant>(), CONNECT_DEFERRED);
+	line_edit->connect("focus_exited", Callable(this, "_line_edit_focus_exit"), Vector<Variant>(), CONNECT_DEFERRED);
+	line_edit->connect("gui_input", Callable(this, "_line_edit_input"));
 	drag.enabled = false;
 
 	range_click_timer = memnew(Timer);
-	range_click_timer->connect_compat("timeout", this, "_range_click_timeout");
+	range_click_timer->connect("timeout", Callable(this, "_range_click_timeout"));
 	add_child(range_click_timer);
 }

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -537,7 +537,7 @@ void TabContainer::add_child_notify(Node *p_child) {
 	c->set_margin(Margin(MARGIN_BOTTOM), c->get_margin(Margin(MARGIN_BOTTOM)) - sb->get_margin(Margin(MARGIN_BOTTOM)));
 
 	update();
-	p_child->connect_compat("renamed", this, "_child_renamed_callback");
+	p_child->connect("renamed", Callable(this, "_child_renamed_callback"));
 	if (first)
 		emit_signal("tab_changed", current);
 }
@@ -620,7 +620,7 @@ void TabContainer::remove_child_notify(Node *p_child) {
 
 	call_deferred("_update_current_tab");
 
-	p_child->disconnect_compat("renamed", this, "_child_renamed_callback");
+	p_child->disconnect("renamed", Callable(this, "_child_renamed_callback"));
 
 	update();
 }
@@ -1048,5 +1048,5 @@ TabContainer::TabContainer() {
 	tabs_rearrange_group = -1;
 	use_hidden_tabs_for_min_size = false;
 
-	connect_compat("mouse_exited", this, "_on_mouse_exited");
+	connect("mouse_exited", Callable(this, "_on_mouse_exited"));
 }

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -1034,5 +1034,5 @@ Tabs::Tabs() {
 	drag_to_rearrange_enabled = false;
 	tabs_rearrange_group = -1;
 
-	connect_compat("mouse_exited", this, "_on_mouse_exited");
+	connect("mouse_exited", Callable(this, "_on_mouse_exited"));
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7259,10 +7259,10 @@ TextEdit::TextEdit() {
 	updating_scrolls = false;
 	selection.active = false;
 
-	h_scroll->connect_compat("value_changed", this, "_scroll_moved");
-	v_scroll->connect_compat("value_changed", this, "_scroll_moved");
+	h_scroll->connect("value_changed", Callable(this, "_scroll_moved"));
+	v_scroll->connect("value_changed", Callable(this, "_scroll_moved"));
 
-	v_scroll->connect_compat("scrolling", this, "_v_scroll_input");
+	v_scroll->connect("scrolling", Callable(this, "_v_scroll_input"));
 
 	cursor_changed_dirty = false;
 	text_changed_dirty = false;
@@ -7279,7 +7279,7 @@ TextEdit::TextEdit() {
 	caret_blink_timer = memnew(Timer);
 	add_child(caret_blink_timer);
 	caret_blink_timer->set_wait_time(0.65);
-	caret_blink_timer->connect_compat("timeout", this, "_toggle_draw_caret");
+	caret_blink_timer->connect("timeout", Callable(this, "_toggle_draw_caret"));
 	cursor_set_blink_enabled(false);
 	right_click_moves_caret = true;
 
@@ -7287,12 +7287,12 @@ TextEdit::TextEdit() {
 	add_child(idle_detect);
 	idle_detect->set_one_shot(true);
 	idle_detect->set_wait_time(GLOBAL_GET("gui/timers/text_edit_idle_detect_sec"));
-	idle_detect->connect_compat("timeout", this, "_push_current_op");
+	idle_detect->connect("timeout", Callable(this, "_push_current_op"));
 
 	click_select_held = memnew(Timer);
 	add_child(click_select_held);
 	click_select_held->set_wait_time(0.05);
-	click_select_held->connect_compat("timeout", this, "_click_selection_held");
+	click_select_held->connect("timeout", Callable(this, "_click_selection_held"));
 
 	current_op.type = TextOperation::TYPE_NONE;
 	undo_enabled = true;
@@ -7350,7 +7350,7 @@ TextEdit::TextEdit() {
 	add_child(menu);
 	readonly = true; // Initialise to opposite first, so we get past the early-out in set_readonly.
 	set_readonly(false);
-	menu->connect_compat("id_pressed", this, "menu_option");
+	menu->connect("id_pressed", Callable(this, "menu_option"));
 	first_draw = true;
 
 	executing_line = -1;

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -160,13 +160,13 @@ void TextureRect::set_texture(const Ref<Texture2D> &p_tex) {
 	}
 
 	if (texture.is_valid()) {
-		texture->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+		texture->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_texture_changed"));
 	}
 
 	texture = p_tex;
 
 	if (texture.is_valid()) {
-		texture->connect_compat(CoreStringNames::get_singleton()->changed, this, "_texture_changed");
+		texture->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_texture_changed"));
 	}
 
 	update();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4043,15 +4043,15 @@ Tree::Tree() {
 	add_child(v_scroll);
 
 	range_click_timer = memnew(Timer);
-	range_click_timer->connect_compat("timeout", this, "_range_click_timeout");
+	range_click_timer->connect("timeout", Callable(this, "_range_click_timeout"));
 	add_child(range_click_timer);
 
-	h_scroll->connect_compat("value_changed", this, "_scroll_moved");
-	v_scroll->connect_compat("value_changed", this, "_scroll_moved");
-	text_editor->connect_compat("text_entered", this, "_text_editor_enter");
-	text_editor->connect_compat("modal_closed", this, "_text_editor_modal_close");
-	popup_menu->connect_compat("id_pressed", this, "_popup_select");
-	value_editor->connect_compat("value_changed", this, "_value_editor_changed");
+	h_scroll->connect("value_changed", Callable(this, "_scroll_moved"));
+	v_scroll->connect("value_changed", Callable(this, "_scroll_moved"));
+	text_editor->connect("text_entered", Callable(this, "_text_editor_enter"));
+	text_editor->connect("modal_closed", Callable(this, "_text_editor_modal_close"));
+	popup_menu->connect("id_pressed", Callable(this, "_popup_select"));
+	value_editor->connect("value_changed", Callable(this, "_value_editor_changed"));
 
 	value_editor->set_as_toplevel(true);
 	text_editor->set_as_toplevel(true);

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -589,7 +589,7 @@ HTTPRequest::HTTPRequest() {
 
 	timer = memnew(Timer);
 	timer->set_one_shot(true);
-	timer->connect_compat("timeout", this, "_timeout");
+	timer->connect("timeout", Callable(this, "_timeout"));
 	add_child(timer);
 	timeout = 0;
 }

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2353,8 +2353,8 @@ void Node::_duplicate_signals(const Node *p_original, Node *p_copy) const {
 			if (p_copy->has_node(ptarget))
 				copytarget = p_copy->get_node(ptarget);
 
-			if (copy && copytarget && !copy->is_connected_compat(E->get().signal.get_name(), copytarget, E->get().callable.get_method())) {
-				copy->connect_compat(E->get().signal.get_name(), copytarget, E->get().callable.get_method(), E->get().binds, E->get().flags);
+			if (copy && copytarget && !copy->is_connected(E->get().signal.get_name(), Callable(copytarget, E->get()).callable.get_method())) {
+				copy->connect(E->get().signal.get_name(), Callable(copytarget, E->get()).callable.get_method(), E->get().binds, E->get().flags);
 			}
 		}
 	}
@@ -2509,10 +2509,10 @@ void Node::_replace_connections_target(Node *p_new_target) {
 		Connection &c = E->get();
 
 		if (c.flags & CONNECT_PERSIST) {
-			c.signal.get_object()->disconnect_compat(c.signal.get_name(), this, c.callable.get_method());
+			c.signal.get_object()->disconnect(c.signal.get_name(), Callable(this, c.callable.get_method()));
 			bool valid = p_new_target->has_method(c.callable.get_method()) || Ref<Script>(p_new_target->get_script()).is_null() || Ref<Script>(p_new_target->get_script())->has_method(c.callable.get_method());
 			ERR_CONTINUE_MSG(!valid, "Attempt to connect signal '" + c.signal.get_object()->get_class() + "." + c.signal.get_name() + "' to nonexistent method '" + c.callable.get_object()->get_class() + "." + c.callable.get_method() + "'.");
-			c.signal.get_object()->connect_compat(c.signal.get_name(), p_new_target, c.callable.get_method(), c.binds, c.flags);
+			c.signal.get_object()->connect(c.signal.get_name(), Callable(p_new_target, c.callable.get_method()), c.binds, c.flags);
 		}
 	}
 }

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -88,7 +88,7 @@ void SceneTreeTimer::release_connections() {
 
 	for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
 		Connection const &connection = E->get();
-		disconnect_compat(connection.signal.get_name(), connection.callable.get_object(), connection.callable.get_method());
+		disconnect(connection.signal.get_name(), Callable(connection.callable.get_object(), connection.callable.get_method()));
 	}
 }
 
@@ -1393,21 +1393,21 @@ void SceneTree::set_multiplayer(Ref<MultiplayerAPI> p_multiplayer) {
 	ERR_FAIL_COND(!p_multiplayer.is_valid());
 
 	if (multiplayer.is_valid()) {
-		multiplayer->disconnect_compat("network_peer_connected", this, "_network_peer_connected");
-		multiplayer->disconnect_compat("network_peer_disconnected", this, "_network_peer_disconnected");
-		multiplayer->disconnect_compat("connected_to_server", this, "_connected_to_server");
-		multiplayer->disconnect_compat("connection_failed", this, "_connection_failed");
-		multiplayer->disconnect_compat("server_disconnected", this, "_server_disconnected");
+		multiplayer->disconnect("network_peer_connected", Callable(this, "_network_peer_connected"));
+		multiplayer->disconnect("network_peer_disconnected", Callable(this, "_network_peer_disconnected"));
+		multiplayer->disconnect("connected_to_server", Callable(this, "_connected_to_server"));
+		multiplayer->disconnect("connection_failed", Callable(this, "_connection_failed"));
+		multiplayer->disconnect("server_disconnected", Callable(this, "_server_disconnected"));
 	}
 
 	multiplayer = p_multiplayer;
 	multiplayer->set_root_node(root);
 
-	multiplayer->connect_compat("network_peer_connected", this, "_network_peer_connected");
-	multiplayer->connect_compat("network_peer_disconnected", this, "_network_peer_disconnected");
-	multiplayer->connect_compat("connected_to_server", this, "_connected_to_server");
-	multiplayer->connect_compat("connection_failed", this, "_connection_failed");
-	multiplayer->connect_compat("server_disconnected", this, "_server_disconnected");
+	multiplayer->connect("network_peer_connected", Callable(this, "_network_peer_connected"));
+	multiplayer->connect("network_peer_disconnected", Callable(this, "_network_peer_disconnected"));
+	multiplayer->connect("connected_to_server", Callable(this, "_connected_to_server"));
+	multiplayer->connect("connection_failed", Callable(this, "_connection_failed"));
+	multiplayer->connect("server_disconnected", Callable(this, "_server_disconnected"));
 }
 
 void SceneTree::set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_network_peer) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1124,7 +1124,7 @@ void Viewport::set_world(const Ref<World> &p_world) {
 		_propagate_exit_world(this);
 
 	if (own_world.is_valid() && world.is_valid()) {
-		world->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_own_world_changed");
+		world->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_own_world_changed"));
 	}
 
 	world = p_world;
@@ -1132,7 +1132,7 @@ void Viewport::set_world(const Ref<World> &p_world) {
 	if (own_world.is_valid()) {
 		if (world.is_valid()) {
 			own_world = world->duplicate();
-			world->connect_compat(CoreStringNames::get_singleton()->changed, this, "_own_world_changed");
+			world->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_own_world_changed"));
 		} else {
 			own_world = Ref<World>(memnew(World));
 		}
@@ -2473,7 +2473,7 @@ List<Control *>::Element *Viewport::_gui_add_root_control(Control *p_control) {
 
 List<Control *>::Element *Viewport::_gui_add_subwindow_control(Control *p_control) {
 
-	p_control->connect_compat("visibility_changed", this, "_subwindow_visibility_changed");
+	p_control->connect("visibility_changed", Callable(this, "_subwindow_visibility_changed"));
 
 	if (p_control->is_visible_in_tree()) {
 		gui.subwindow_order_dirty = true;
@@ -2568,7 +2568,7 @@ void Viewport::_gui_remove_subwindow_control(List<Control *>::Element *SI) {
 
 	Control *control = SI->get();
 
-	control->disconnect_compat("visibility_changed", this, "_subwindow_visibility_changed");
+	control->disconnect("visibility_changed", Callable(this, "_subwindow_visibility_changed"));
 
 	List<Control *>::Element *E = gui.subwindows.find(control);
 	if (E)
@@ -2850,12 +2850,12 @@ void Viewport::set_use_own_world(bool p_world) {
 	if (!p_world) {
 		own_world = Ref<World>();
 		if (world.is_valid()) {
-			world->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_own_world_changed");
+			world->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_own_world_changed"));
 		}
 	} else {
 		if (world.is_valid()) {
 			own_world = world->duplicate();
-			world->connect_compat(CoreStringNames::get_singleton()->changed, this, "_own_world_changed");
+			world->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_own_world_changed"));
 		} else {
 			own_world = Ref<World>(memnew(World));
 		}

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -197,7 +197,7 @@ void ShaderMaterial::set_shader(const Ref<Shader> &p_shader) {
 	// This can be a slow operation, and `_change_notify()` (which is called by `_shader_changed()`)
 	// does nothing in non-editor builds anyway. See GH-34741 for details.
 	if (shader.is_valid() && Engine::get_singleton()->is_editor_hint()) {
-		shader->disconnect_compat("changed", this, "_shader_changed");
+		shader->disconnect("changed", Callable(this, "_shader_changed"));
 	}
 
 	shader = p_shader;
@@ -207,7 +207,7 @@ void ShaderMaterial::set_shader(const Ref<Shader> &p_shader) {
 		rid = shader->get_rid();
 
 		if (Engine::get_singleton()->is_editor_hint()) {
-			shader->connect_compat("changed", this, "_shader_changed");
+			shader->connect("changed", Callable(this, "_shader_changed"));
 		}
 	}
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -331,7 +331,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 				binds.write[j] = props[c.binds[j]];
 		}
 
-		cfrom->connect_compat(snames[c.signal], cto, snames[c.method], binds, CONNECT_PERSIST | c.flags);
+		cfrom->connect(snames[c.signal], Callable(cto, snames[c.method]), binds, CONNECT_PERSIST | c.flags);
 	}
 
 	//Node *s = ret_nodes[0];

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1409,11 +1409,11 @@ void CurveTexture::ensure_default_setup(float p_min, float p_max) {
 void CurveTexture::set_curve(Ref<Curve> p_curve) {
 	if (_curve != p_curve) {
 		if (_curve.is_valid()) {
-			_curve->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_update");
+			_curve->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_update"));
 		}
 		_curve = p_curve;
 		if (_curve.is_valid()) {
-			_curve->connect_compat(CoreStringNames::get_singleton()->changed, this, "_update");
+			_curve->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_update"));
 		}
 		_update();
 	}
@@ -1514,11 +1514,11 @@ void GradientTexture::set_gradient(Ref<Gradient> p_gradient) {
 	if (p_gradient == gradient)
 		return;
 	if (gradient.is_valid()) {
-		gradient->disconnect_compat(CoreStringNames::get_singleton()->changed, this, "_update");
+		gradient->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_update"));
 	}
 	gradient = p_gradient;
 	if (gradient.is_valid()) {
-		gradient->connect_compat(CoreStringNames::get_singleton()->changed, this, "_update");
+		gradient->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_update"));
 	}
 	_update();
 	emit_changed();
@@ -1867,7 +1867,7 @@ AnimatedTexture::AnimatedTexture() {
 	fps = 4;
 	prev_ticks = 0;
 	current_frame = 0;
-	VisualServer::get_singleton()->connect_compat("frame_pre_draw", this, "_update_proxy");
+	VisualServer::get_singleton()->connect("frame_pre_draw", Callable(this, "_update_proxy"));
 
 #ifndef NO_THREADS
 	rw_lock = RWLock::create();

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -302,13 +302,13 @@ void Theme::set_default_theme_font(const Ref<Font> &p_default_font) {
 		return;
 
 	if (default_theme_font.is_valid()) {
-		default_theme_font->disconnect_compat("changed", this, "_emit_theme_changed");
+		default_theme_font->disconnect("changed", Callable(this, "_emit_theme_changed"));
 	}
 
 	default_theme_font = p_default_font;
 
 	if (default_theme_font.is_valid()) {
-		default_theme_font->connect_compat("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
+		default_theme_font->connect("changed", Callable(this, "_emit_theme_changed"), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	_change_notify();
@@ -366,13 +366,13 @@ void Theme::set_icon(const StringName &p_name, const StringName &p_type, const R
 	bool new_value = !icon_map.has(p_type) || !icon_map[p_type].has(p_name);
 
 	if (icon_map[p_type].has(p_name) && icon_map[p_type][p_name].is_valid()) {
-		icon_map[p_type][p_name]->disconnect_compat("changed", this, "_emit_theme_changed");
+		icon_map[p_type][p_name]->disconnect("changed", Callable(this, "_emit_theme_changed"));
 	}
 
 	icon_map[p_type][p_name] = p_icon;
 
 	if (p_icon.is_valid()) {
-		icon_map[p_type][p_name]->connect_compat("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
+		icon_map[p_type][p_name]->connect("changed", Callable(this, "_emit_theme_changed"), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	if (new_value) {
@@ -401,7 +401,7 @@ void Theme::clear_icon(const StringName &p_name, const StringName &p_type) {
 	ERR_FAIL_COND(!icon_map[p_type].has(p_name));
 
 	if (icon_map[p_type][p_name].is_valid()) {
-		icon_map[p_type][p_name]->disconnect_compat("changed", this, "_emit_theme_changed");
+		icon_map[p_type][p_name]->disconnect("changed", Callable(this, "_emit_theme_changed"));
 	}
 
 	icon_map[p_type].erase(p_name);
@@ -479,13 +479,13 @@ void Theme::set_stylebox(const StringName &p_name, const StringName &p_type, con
 	bool new_value = !style_map.has(p_type) || !style_map[p_type].has(p_name);
 
 	if (style_map[p_type].has(p_name) && style_map[p_type][p_name].is_valid()) {
-		style_map[p_type][p_name]->disconnect_compat("changed", this, "_emit_theme_changed");
+		style_map[p_type][p_name]->disconnect("changed", Callable(this, "_emit_theme_changed"));
 	}
 
 	style_map[p_type][p_name] = p_style;
 
 	if (p_style.is_valid()) {
-		style_map[p_type][p_name]->connect_compat("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
+		style_map[p_type][p_name]->connect("changed", Callable(this, "_emit_theme_changed"), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	if (new_value)
@@ -514,7 +514,7 @@ void Theme::clear_stylebox(const StringName &p_name, const StringName &p_type) {
 	ERR_FAIL_COND(!style_map[p_type].has(p_name));
 
 	if (style_map[p_type][p_name].is_valid()) {
-		style_map[p_type][p_name]->disconnect_compat("changed", this, "_emit_theme_changed");
+		style_map[p_type][p_name]->disconnect("changed", Callable(this, "_emit_theme_changed"));
 	}
 
 	style_map[p_type].erase(p_name);
@@ -554,13 +554,13 @@ void Theme::set_font(const StringName &p_name, const StringName &p_type, const R
 	bool new_value = !font_map.has(p_type) || !font_map[p_type].has(p_name);
 
 	if (font_map[p_type][p_name].is_valid()) {
-		font_map[p_type][p_name]->disconnect_compat("changed", this, "_emit_theme_changed");
+		font_map[p_type][p_name]->disconnect("changed", Callable(this, "_emit_theme_changed"));
 	}
 
 	font_map[p_type][p_name] = p_font;
 
 	if (p_font.is_valid()) {
-		font_map[p_type][p_name]->connect_compat("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
+		font_map[p_type][p_name]->connect("changed", Callable(this, "_emit_theme_changed"), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	if (new_value) {
@@ -589,7 +589,7 @@ void Theme::clear_font(const StringName &p_name, const StringName &p_type) {
 	ERR_FAIL_COND(!font_map[p_type].has(p_name));
 
 	if (font_map[p_type][p_name].is_valid()) {
-		font_map[p_type][p_name]->disconnect_compat("changed", this, "_emit_theme_changed");
+		font_map[p_type][p_name]->disconnect("changed", Callable(this, "_emit_theme_changed"));
 	}
 
 	font_map[p_type].erase(p_name);
@@ -722,7 +722,7 @@ void Theme::clear() {
 			while ((L = icon_map[*K].next(L))) {
 				Ref<Texture2D> icon = icon_map[*K][*L];
 				if (icon.is_valid()) {
-					icon->disconnect_compat("changed", this, "_emit_theme_changed");
+					icon->disconnect("changed", Callable(this, "_emit_theme_changed"));
 				}
 			}
 		}
@@ -735,7 +735,7 @@ void Theme::clear() {
 			while ((L = style_map[*K].next(L))) {
 				Ref<StyleBox> style = style_map[*K][*L];
 				if (style.is_valid()) {
-					style->disconnect_compat("changed", this, "_emit_theme_changed");
+					style->disconnect("changed", Callable(this, "_emit_theme_changed"));
 				}
 			}
 		}
@@ -748,7 +748,7 @@ void Theme::clear() {
 			while ((L = font_map[*K].next(L))) {
 				Ref<Font> font = font_map[*K][*L];
 				if (font.is_valid()) {
-					font->disconnect_compat("changed", this, "_emit_theme_changed");
+					font->disconnect("changed", Callable(this, "_emit_theme_changed"));
 				}
 			}
 		}

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -304,10 +304,10 @@ void VisualShader::add_node(Type p_type, const Ref<VisualShaderNode> &p_node, co
 	if (input.is_valid()) {
 		input->shader_mode = shader_mode;
 		input->shader_type = p_type;
-		input->connect_compat("input_type_changed", this, "_input_type_changed", varray(p_type, p_id));
+		input->connect("input_type_changed", Callable(this, "_input_type_changed"), varray(p_type, p_id));
 	}
 
-	n.node->connect_compat("changed", this, "_queue_update");
+	n.node->connect("changed", Callable(this, "_queue_update"));
 
 	Ref<VisualShaderNodeCustom> custom = n.node;
 	if (custom.is_valid()) {
@@ -374,10 +374,10 @@ void VisualShader::remove_node(Type p_type, int p_id) {
 
 	Ref<VisualShaderNodeInput> input = g->nodes[p_id].node;
 	if (input.is_valid()) {
-		input->disconnect_compat("input_type_changed", this, "_input_type_changed");
+		input->disconnect("input_type_changed", Callable(this, "_input_type_changed"));
 	}
 
-	g->nodes[p_id].node->disconnect_compat("changed", this, "_queue_update");
+	g->nodes[p_id].node->disconnect("changed", Callable(this, "_queue_update"));
 
 	g->nodes.erase(p_id);
 

--- a/thirdparty/bullet/BulletCollision/Gimpact/btGImpactShape.h
+++ b/thirdparty/bullet/BulletCollision/Gimpact/btGImpactShape.h
@@ -1,5 +1,5 @@
 /*! \file btGImpactShape.h
-\author Francisco Len Nßjera
+\author Francisco Len Nï¿½jera
 */
 /*
 This source file is part of GIMPACT Library.

--- a/thirdparty/bullet/BulletSoftBody/btSoftBody.cpp
+++ b/thirdparty/bullet/BulletSoftBody/btSoftBody.cpp
@@ -620,7 +620,7 @@ void btSoftBody::addAeroForceToNode(const btVector3& windVelocity, int nodeIndex
 					fDrag = 0.5f * kDG * medium.m_density * rel_v2 * tri_area * n_dot_v * (-rel_v_nrm);
 
 					// Check angle of attack
-					// cos(10º) = 0.98480
+					// cos(10ï¿½) = 0.98480
 					if (0 < n_dot_v && n_dot_v < 0.98480f)
 						fLift = 0.5f * kLF * medium.m_density * rel_v_len * tri_area * btSqrt(1.0f - n_dot_v * n_dot_v) * (nrm.cross(rel_v_nrm).cross(rel_v_nrm));
 
@@ -706,7 +706,7 @@ void btSoftBody::addAeroForceToFace(const btVector3& windVelocity, int faceIndex
 				fDrag = 0.5f * kDG * medium.m_density * rel_v2 * tri_area * n_dot_v * (-rel_v_nrm);
 
 				// Check angle of attack
-				// cos(10º) = 0.98480
+				// cos(10ï¿½) = 0.98480
 				if (0 < n_dot_v && n_dot_v < 0.98480f)
 					fLift = 0.5f * kLF * medium.m_density * rel_v_len * tri_area * btSqrt(1.0f - n_dot_v * n_dot_v) * (nrm.cross(rel_v_nrm).cross(rel_v_nrm));
 


### PR DESCRIPTION
I am not sure whether we will want this to be merged any time soon since it may break compatibility for many other Pull Requests. We should use it as a reference for the future.

Java Program to remove all `_compat`:

This code is written by me and is public domain
```java
public static final String GODOT_PATH = "/home/nathanfranke/workspace/godot"; // Please replace with your Godot source path

public static void main(String[] args) throws IOException {
	
	Pattern pattern = Pattern.compile("_compat\\((?<p1>.+?),\\s+(?<callable>.+?, .+?)(?<param>, .+)*\\)");
	
	Files.walk(new File(GODOT_PATH).toPath()).forEach(path -> {
		
		if(!path.toString().endsWith(".cpp") && !path.toString().endsWith(".h")) return;
		
		try {
			String data = new String(Files.readAllBytes(path));
			
			Matcher matcher = pattern.matcher(data);
			
			StringBuffer buffer = new StringBuffer(data.length());
			while(matcher.find()) {
				String param = matcher.group("param");
				String newCall = "(" + matcher.group("p1") + ", Callable(" + matcher.group("callable") + ")" + (param == null ? "" : param) + ")";
				System.out.println(newCall);
				matcher.appendReplacement(buffer, newCall.replace("$", "\\$"));
			}
			matcher.appendTail(buffer);
			
			Files.write(path, buffer.toString().getBytes());
		} catch (IOException e) {
			e.printStackTrace();
		}
		
	});
	
}
```

Manual modifications made:
`core/object.h`
`core/object.cpp`
`modules/mono/signal_awaiter_utils.cpp`