### PR TITLE
Core: Change _Marshall class from inherit Reference to Object

### DIFF
--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -581,9 +581,9 @@ private:
 	bool _list_skip_hidden;
 };
 
-class _Marshalls : public Reference {
+class _Marshalls : public Object {
 
-	GDCLASS(_Marshalls, Reference);
+	GDCLASS(_Marshalls, Object);
 
 	static _Marshalls *singleton;
 

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -53,7 +53,7 @@
 			The [JavaScript] singleton.
 			[b]Note:[/b] Only implemented on HTML5.
 		</member>
-		<member name="Marshalls" type="Reference" setter="" getter="">
+		<member name="Marshalls" type="Marshalls" setter="" getter="">
 			The [Marshalls] singleton.
 		</member>
 		<member name="Navigation2DServer" type="Navigation2DServer" setter="" getter="">

--- a/doc/classes/Marshalls.xml
+++ b/doc/classes/Marshalls.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="Marshalls" inherits="Reference" version="4.0">
+<class name="Marshalls" inherits="Object" version="4.0">
 	<brief_description>
 		Data transformation (marshalling) and encoding helpers.
 	</brief_description>


### PR DESCRIPTION
Fixes #36364
Fixes #35127
Closes #36365 because fix the same issue in another 'wrongly way'

> [13:20:21] Kuruk: reduz _Marshall inherit from Reference. I don't see any particular reason to do it. I think this need to be an object. I try to change to an Object and works fine. This is causing a crash when you close the editor (reason: https://github.com/godotengine/godot/issues/36364).
> [13:20:57] Kuruk: I simple asking, if you know it's a particular reason to be a Reference. Otherwise I will make a PR changing it.
> [13:21:30] reduz: yeah this seems wrong, Marshall should inherit from Object, like all the other singletons