### PR TITLE
GridMap: temporary hide cell under mouse cursor when painting

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -743,6 +743,43 @@ void GridMap::_update_visibility() {
 	}
 }
 
+void GridMap::set_cell_item_visibility(int p_x, int p_y, int p_z, bool p_visible) {
+	if (!is_inside_tree())
+		return;
+
+	IndexKey key;
+	key.x = p_x;
+	key.y = p_y;
+	key.z = p_z;
+
+	for (Map<OctantKey, Octant *>::Element *e = octant_map.front(); e; e = e->next()) {
+		Octant *octant = e->value();
+		for (int i = 0; i < octant->multimesh_instances.size(); i++) {
+			const Octant::MultimeshInstance &mi = octant->multimesh_instances[i];
+
+			for (int j = 0; j < mi.items.size(); j++) {
+				IndexKey instance_key = mi.items[j].key;
+
+				if (instance_key == key) {
+					Transform transform;
+
+					if (p_visible) {
+						transform = mi.items[j].transform;
+					} else {
+						// Move the multimesh instance far away to effectively hide it,
+						// as MultiMesh doesn't have an API to hide specific meshes yet.
+						real_t dimension = -10000000000;
+						transform.translate(dimension, dimension, dimension);
+					}
+
+					VS::get_singleton()->multimesh_instance_set_transform(mi.multimesh, mi.items[j].index, transform);
+					return;
+				}
+			}
+		}
+	}
+}
+
 void GridMap::_queue_octants_dirty() {
 
 	if (awaiting_update)

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -62,6 +62,11 @@ class GridMap : public Spatial {
 			return key < p_key.key;
 		}
 
+		_FORCE_INLINE_ bool operator==(const IndexKey &p_key) const {
+
+			return x == p_key.x && y == p_key.y && z == p_key.z;
+		}
+
 		IndexKey() { key = 0; }
 	};
 
@@ -246,6 +251,8 @@ public:
 	void set_cell_item(int p_x, int p_y, int p_z, int p_item, int p_rot = 0);
 	int get_cell_item(int p_x, int p_y, int p_z) const;
 	int get_cell_item_orientation(int p_x, int p_y, int p_z) const;
+
+	void set_cell_item_visibility(int p_x, int p_y, int p_z, bool p_visible);
 
 	Vector3 world_to_map(const Vector3 &p_world_pos) const;
 	Vector3 map_to_world(int p_x, int p_y, int p_z) const;

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -476,6 +476,15 @@ bool GridMapEditor::do_input_action(Camera *p_camera, const Point2 &p_point, boo
 		return true;
 	}
 
+	// Temporary hide cell under mouse cursor when painting to show brush item on top of it
+	if (cell[0] != last_pointed_cell[0] || cell[1] != last_pointed_cell[1] || cell[2] != last_pointed_cell[2]) {
+		node->set_cell_item_visibility(last_pointed_cell[0], last_pointed_cell[1], last_pointed_cell[2], true);
+		node->set_cell_item_visibility(cell[0], cell[1], cell[2], false);
+	}
+
+	for (int i = 0; i < 3; ++i)
+		last_pointed_cell[i] = cell[i];
+
 	return false;
 }
 
@@ -1358,6 +1367,9 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	edit_floor[0] = -1;
 	edit_floor[1] = -1;
 	edit_floor[2] = -1;
+
+	for (int i = 0; i < 3; i++)
+		last_pointed_cell[i] = -1;
 
 	cursor_visible = false;
 	selected_palette = -1;

--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -106,6 +106,8 @@ class GridMapEditor : public VBoxContainer {
 	int edit_floor[3];
 	Vector3 grid_ofs;
 
+	int last_pointed_cell[3];
+
 	RID grid[3];
 	RID grid_instance[3];
 	RID cursor_instance;


### PR DESCRIPTION
I took simple approach, when mouse cursor is moving on top of occupied cell, that cell is simple being transformed far far away, until another cell is pointed - then, first cell is being moved back to origin position. 

That's the simplest way of fixing that issue, without in-depth reworking of how **MultimeshInstances** works - there is currently no API to hide single instance in Multimesh.

Fixes #5526