### PR TITLE
Added collision impulse value to 2D contact monitoring

### DIFF
--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -112,6 +112,7 @@ class Body2DSW : public CollisionObject2DSW {
 		ObjectID collider_instance_id;
 		RID collider;
 		Vector2 collider_velocity_at_pos;
+		Vector2 impulse;
 	};
 
 	Vector<Contact> contacts; //no contacts by default
@@ -164,7 +165,7 @@ public:
 	_FORCE_INLINE_ int get_max_contacts_reported() const { return contacts.size(); }
 
 	_FORCE_INLINE_ bool can_report_contacts() const { return !contacts.empty(); }
-	_FORCE_INLINE_ void add_contact(const Vector2 &p_local_pos, const Vector2 &p_local_normal, real_t p_depth, int p_local_shape, const Vector2 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector2 &p_collider_velocity_at_pos);
+	_FORCE_INLINE_ void add_contact(const Vector2 &p_local_pos, const Vector2 &p_local_normal, real_t p_depth, int p_local_shape, const Vector2 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector2 &p_collider_velocity_at_pos, const Vector2 &p_impulse);
 
 	_FORCE_INLINE_ void add_exception(const RID &p_exception) { exceptions.insert(p_exception); }
 	_FORCE_INLINE_ void remove_exception(const RID &p_exception) { exceptions.erase(p_exception); }
@@ -297,7 +298,7 @@ public:
 
 //add contact inline
 
-void Body2DSW::add_contact(const Vector2 &p_local_pos, const Vector2 &p_local_normal, real_t p_depth, int p_local_shape, const Vector2 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector2 &p_collider_velocity_at_pos) {
+void Body2DSW::add_contact(const Vector2 &p_local_pos, const Vector2 &p_local_normal, real_t p_depth, int p_local_shape, const Vector2 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector2 &p_collider_velocity_at_pos, const Vector2 &p_impulse) {
 
 	int c_max = contacts.size();
 
@@ -339,6 +340,7 @@ void Body2DSW::add_contact(const Vector2 &p_local_pos, const Vector2 &p_local_no
 	c[idx].collider_instance_id = p_collider_instance_id;
 	c[idx].collider = p_collider;
 	c[idx].collider_velocity_at_pos = p_collider_velocity_at_pos;
+	c[idx].impulse = p_impulse;
 }
 
 class Physics2DDirectBodyStateSW : public Physics2DDirectBodyState {
@@ -412,6 +414,10 @@ public:
 	virtual Vector2 get_contact_collider_velocity_at_position(int p_contact_idx) const {
 		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, Vector2());
 		return body->contacts[p_contact_idx].collider_velocity_at_pos;
+	}
+	virtual Vector2 get_contact_impulse(int p_contact_idx) const {
+		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, Vector2());
+		return body->contacts[p_contact_idx].impulse;
 	}
 
 	virtual Physics2DDirectSpaceState *get_space_state();

--- a/servers/physics_2d_server.cpp
+++ b/servers/physics_2d_server.cpp
@@ -114,6 +114,7 @@ void Physics2DDirectBodyState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_contact_collider_shape", "contact_idx"), &Physics2DDirectBodyState::get_contact_collider_shape);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_shape_metadata", "contact_idx"), &Physics2DDirectBodyState::get_contact_collider_shape_metadata);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_velocity_at_position", "contact_idx"), &Physics2DDirectBodyState::get_contact_collider_velocity_at_position);
+	ClassDB::bind_method(D_METHOD("get_contact_impulse", "contact_idx"), &Physics2DDirectBodyState::get_contact_impulse);
 	ClassDB::bind_method(D_METHOD("get_step"), &Physics2DDirectBodyState::get_step);
 	ClassDB::bind_method(D_METHOD("integrate_forces"), &Physics2DDirectBodyState::integrate_forces);
 	ClassDB::bind_method(D_METHOD("get_space_state"), &Physics2DDirectBodyState::get_space_state);

--- a/servers/physics_2d_server.h
+++ b/servers/physics_2d_server.h
@@ -84,6 +84,7 @@ public:
 	virtual int get_contact_collider_shape(int p_contact_idx) const = 0;
 	virtual Variant get_contact_collider_shape_metadata(int p_contact_idx) const = 0;
 	virtual Vector2 get_contact_collider_velocity_at_position(int p_contact_idx) const = 0;
+	virtual Vector2 get_contact_impulse(int p_contact_idx) const = 0;
 
 	virtual real_t get_step() const = 0;
 	virtual void integrate_forces();


### PR DESCRIPTION
This implements [feature request #409](https://github.com/godotengine/godot-proposals/issues/409). 

This implementation adds a collision impulse calculation (ignoring bias impulse and accumulated impulse) in the setup phase where contacts are reported to bodies. The full impulse calculation is still done separately in the solve phase.

This solution may not be ideal as it adds computation time to bodies with contact monitoring enabled, but it completely avoids modifying the collision solve implementation.