### PR TITLE
Fix project.godot for projects with class_name

### DIFF
--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -1110,6 +1110,10 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 
 		value = token.value;
 		return OK;
+	} else if (token.type == TK_STRING_NAME) {
+
+		value = token.value;
+		return OK;
 	} else if (token.type == TK_COLOR) {
 
 		value = token.value;


### PR DESCRIPTION
Fixes #36438

Something to do with the StringName that reduz implemented broke this. It can be fixed by adding both `TK_STRING` and `TK_STRING_NAME` to the variant parser script.