### PR TITLE
Travis: Use Python 3.8 alias instead of specific version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ before_install:
 
 install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      pyenv global 3.7.5 system;
+      pyenv global 3.8 system;
       pip3 install --user scons;
     fi
   - scons --version


### PR DESCRIPTION
Otherwise it breaks when they update the container to a new version,
like they did today with 3.7.6.