### PR TITLE
Expression: Fix parsing integers as 32-bit

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -1161,7 +1161,7 @@ Error Expression::_get_token(Token &r_token) {
 					if (is_float)
 						r_token.value = num.to_double();
 					else
-						r_token.value = num.to_int();
+						r_token.value = num.to_int64();
 					return OK;
 
 				} else if ((cchar >= 'A' && cchar <= 'Z') || (cchar >= 'a' && cchar <= 'z') || cchar == '_') {


### PR DESCRIPTION
There are still issues as in the inspector text input without a dot will be handled as 64-bit even if it's meant to be a 32-bit integer or float (e.g. with `PackedInt32Array` added in #36456).

That will need digging further to figure out how to handle this better, but in the meantime it's correct to parse as `int64_t` and `double` by default in `Expression`.