### PR TITLE
Fix debugger crash inspecting freed object.

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -347,12 +347,16 @@ void SceneDebuggerObject::serialize(Array &r_arr, int p_max_size) {
 		const PropertyInfo &pi = properties[i].first;
 		Variant &var = properties[i].second;
 
-		WeakRef *ref = Object::cast_to<WeakRef>(var);
-		if (ref) {
-			var = ref->get_ref();
-		}
-
 		RES res = var;
+
+		if (var.get_type() == Variant::OBJECT && var.is_ref()) {
+			REF r = var;
+			if (r.is_valid()) {
+				res = *r;
+			} else {
+				res = RES();
+			}
+		}
 
 		Array prop;
 		prop.push_back(pi.name);


### PR DESCRIPTION
This seems to be the correct way to validate a reference.
Why is cast_to failing? Is this the correct way of checking if the object is valid? (@reduz ).

Fixes #36486
Likely fixes #29533

Minimal reproduction project: [proj_dbg_crash.zip](https://github.com/godotengine/godot/files/4250415/proj_dbg_crash.zip)
Just run the project, wait till you get a breakpoint (after 4 secs) and while breaked open the remote tree tab. You will get the crash without this PR. Should work normally with this patch.