### PR TITLE
Added missing destructor for Navigation2D

### DIFF
--- a/scene/2d/navigation_2d.cpp
+++ b/scene/2d/navigation_2d.cpp
@@ -88,3 +88,7 @@ Navigation2D::Navigation2D() {
 	set_cell_size(10); // Ten pixels
 	set_edge_connection_margin(100);
 }
+
+Navigation2D::~Navigation2D() {
+	Navigation2DServer::get_singleton()->free(map);
+}

--- a/scene/2d/navigation_2d.h
+++ b/scene/2d/navigation_2d.h
@@ -66,6 +66,7 @@ public:
 	RID get_closest_point_owner(const Vector2 &p_point) const;
 
 	Navigation2D();
+	~Navigation2D();
 };
 
 #endif // NAVIGATION_2D_H


### PR DESCRIPTION
Although destructor call was missing, it still doesn't heal #36537 memory leaks. Further description how that might be overcome - in original bug report.

Partialy covers #36537