### PR TITLE
Fix the crash during recording

### DIFF
--- a/servers/audio/effects/audio_effect_record.h
+++ b/servers/audio/effects/audio_effect_record.h
@@ -33,12 +33,14 @@
 
 #include "core/io/marshalls.h"
 #include "core/os/file_access.h"
+#include "core/os/mutex.h"
 #include "core/os/os.h"
 #include "core/os/thread.h"
 #include "editor/import/resource_importer_wav.h"
 #include "scene/resources/audio_stream_sample.h"
 #include "servers/audio/audio_effect.h"
 #include "servers/audio_server.h"
+#include <mutex>
 
 class AudioEffectRecord;
 
@@ -53,6 +55,7 @@ class AudioEffectRecordInstance : public AudioEffectInstance {
 
 	Vector<AudioFrame> ring_buffer;
 	Vector<float> recording_data;
+	mutable Mutex *recording_data_mutex;
 
 	unsigned int ring_buffer_pos;
 	unsigned int ring_buffer_mask;
@@ -72,7 +75,9 @@ public:
 	virtual bool process_silence() const;
 
 	AudioEffectRecordInstance() :
-			thread_active(false) {}
+			thread_active(false),
+			recording_data_mutex(Mutex::create(false)) {
+	}
 	~AudioEffectRecordInstance();
 };
 


### PR DESCRIPTION
This fix addresses the following issue: Invalid read in audio demo #34494

Protect recording_data with a mutex to prevent racing.

Tested with my crashing project for 5 minutes. No crashes.