### PR TITLE
SCons: Fix get_compiler_version() to return ints

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -333,39 +333,39 @@ if selected_platform in platform_list:
         env.Prepend(CCFLAGS=['/std:c++17', '/permissive-'])
 
     # Enforce our minimal compiler version requirements
-    version = methods.get_compiler_version(env)
-    if version is not None and methods.using_gcc(env):
-        major = int(version[0])
-        minor = int(version[1])
+    cc_version = methods.get_compiler_version(env) or [-1, -1]
+    cc_version_major = cc_version[0]
+    cc_version_minor = cc_version[1]
+
+    if methods.using_gcc(env):
         # GCC 8 before 8.4 has a regression in the support of guaranteed copy elision
         # which causes a build failure: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86521
-        if major == 8 and minor < 4:
+        if cc_version_major == 8 and cc_version_minor < 4:
             print("Detected GCC 8 version < 8.4, which is not supported due to a "
                   "regression in its C++17 guaranteed copy elision support. Use a "
                   "newer GCC version, or Clang 6 or later by passing \"use_llvm=yes\" "
                   "to the SCons command line.")
             sys.exit(255)
-        elif major < 7:
+        elif cc_version_major < 7:
             print("Detected GCC version older than 7, which does not fully support "
                   "C++17. Supported versions are GCC 7, 9 and later. Use a newer GCC "
                   "version, or Clang 6 or later by passing \"use_llvm=yes\" to the "
                   "SCons command line.")
             sys.exit(255)
-    elif version is not None and methods.using_clang(env):
-        major = int(version[0])
+    elif methods.using_clang(env):
         # Apple LLVM versions differ from upstream LLVM version \o/, compare
         # in https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
         if env["platform"] == "osx" or env["platform"] == "iphone":
             vanilla = methods.is_vanilla_clang(env)
-            if vanilla and major < 6:
+            if vanilla and cc_version_major < 6:
                 print("Detected Clang version older than 6, which does not fully support "
                       "C++17. Supported versions are Clang 6 and later.")
                 sys.exit(255)
-            elif not vanilla and major < 10:
+            elif not vanilla and cc_version_major < 10:
                 print("Detected Apple Clang version older than 10, which does not fully "
                       "support C++17. Supported versions are Apple Clang 10 and later.")
                 sys.exit(255)
-        elif major < 6:
+        elif cc_version_major < 6:
             print("Detected Clang version older than 6, which does not fully support "
                   "C++17. Supported versions are Clang 6 and later.")
             sys.exit(255)
@@ -393,8 +393,7 @@ if selected_platform in platform_list:
         all_plus_warnings = ['-Wwrite-strings']
 
         if methods.using_gcc(env):
-            version = methods.get_compiler_version(env)
-            if version != None and version[0] >= '7':
+            if cc_version_major >= 7:
                 shadow_local_warning = ['-Wshadow-local']
 
         if (env["warnings"] == 'extra'):
@@ -407,8 +406,7 @@ if selected_platform in platform_list:
                     '-Wstringop-overflow=4', '-Wlogical-op'])
                 # -Wnoexcept was removed temporarily due to GH-36325.
                 env.Append(CXXFLAGS=['-Wplacement-new=1'])
-                version = methods.get_compiler_version(env)
-                if version != None and version[0] >= '9':
+                if cc_version_major >= 9:
                     env.Append(CCFLAGS=['-Wattribute-alias=2'])
             if methods.using_clang(env):
                 env.Append(CCFLAGS=['-Wimplicit-fallthrough'])

--- a/methods.py
+++ b/methods.py
@@ -558,19 +558,18 @@ def is_vanilla_clang(env):
 
 def get_compiler_version(env):
     """
-    Returns an array of version numbers as strings: [major, minor, patch].
+    Returns an array of version numbers as ints: [major, minor, patch].
     The return array should have at least two values (major, minor).
     """
-    if using_gcc(env):
-        version = decode_utf8(subprocess.check_output([env['CXX'], '-dumpversion']).strip())
-    elif using_clang(env):
-        # Not using -dumpversion as it used to return 4.2.1: https://reviews.llvm.org/D56803
+    if not env.msvc:
+        # Not using -dumpversion as some GCC distros only return major, and
+        # Clang used to return hardcoded 4.2.1: # https://reviews.llvm.org/D56803
         version = decode_utf8(subprocess.check_output([env['CXX'], '--version']).strip())
     else:  # TODO: Implement for MSVC
         return None
-    match = re.search('[0-9]+\.[0-9.]*', version)
+    match = re.search('[0-9]+\.[0-9.]+', version)
     if match is not None:
-        return match.group().split('.')
+        return list(map(int, match.group().split('.')))
     else:
         return None
 

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -179,18 +179,10 @@ def configure(env):
     env.Append(CCFLAGS=['-pipe'])
     env.Append(LINKFLAGS=['-pipe'])
 
-    # Check for gcc version >= 6 before adding -no-pie
-    if using_gcc(env):
-        version = get_compiler_version(env)
-        if version != None and version[0] >= '6':
-            env.Append(CCFLAGS=['-fpie'])
-            env.Append(LINKFLAGS=['-no-pie'])
-    # Do the same for clang should be fine with Clang 4 and higher
-    if using_clang(env):
-        version = get_compiler_version(env)
-        if version != None and version[0] >= '4':
-            env.Append(CCFLAGS=['-fpie'])
-            env.Append(LINKFLAGS=['-no-pie'])
+    # -fpie and -no-pie is supported on GCC 6+ and Clang 4+, both below our
+    # minimal requirements.
+    env.Append(CCFLAGS=['-fpie'])
+    env.Append(LINKFLAGS=['-no-pie'])
 
     ## Dependencies
 


### PR DESCRIPTION
Otherwise comparisons would fail for compiler versions above 10.
Also simplified code somewhat to avoid using subprocess too much
needlessly.