### PR TITLE
Rename "button_release" signal to "button_released" in ARVRController

### DIFF
--- a/doc/classes/ARVRController.xml
+++ b/doc/classes/ARVRController.xml
@@ -86,7 +86,7 @@
 				Emitted when a button on this controller is pressed.
 			</description>
 		</signal>
-		<signal name="button_release">
+		<signal name="button_released">
 			<argument index="0" name="button" type="int">
 			</argument>
 			<description>

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -212,7 +212,7 @@ void ARVRController::_notification(int p_what) {
 							emit_signal("button_pressed", i);
 							button_states += mask;
 						} else if (was_pressed && !is_pressed) {
-							emit_signal("button_release", i);
+							emit_signal("button_released", i);
 							button_states -= mask;
 						};
 
@@ -258,7 +258,7 @@ void ARVRController::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_mesh"), &ARVRController::get_mesh);
 
 	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::INT, "button")));
-	ADD_SIGNAL(MethodInfo("button_release", PropertyInfo(Variant::INT, "button")));
+	ADD_SIGNAL(MethodInfo("button_released", PropertyInfo(Variant::INT, "button")));
 	ADD_SIGNAL(MethodInfo("mesh_updated", PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh")));
 };
 


### PR DESCRIPTION
One of the proposed renames from https://github.com/godotengine/godot/issues/16863