### PR TITLE
SCons: Format SCsub files with psf/black

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -341,16 +341,20 @@ if selected_platform in platform_list:
         # GCC 8 before 8.4 has a regression in the support of guaranteed copy elision
         # which causes a build failure: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86521
         if cc_version_major == 8 and cc_version_minor < 4:
-            print("Detected GCC 8 version < 8.4, which is not supported due to a "
-                  "regression in its C++17 guaranteed copy elision support. Use a "
-                  "newer GCC version, or Clang 6 or later by passing \"use_llvm=yes\" "
-                  "to the SCons command line.")
+            print(
+                "Detected GCC 8 version < 8.4, which is not supported due to a "
+                "regression in its C++17 guaranteed copy elision support. Use a "
+                'newer GCC version, or Clang 6 or later by passing "use_llvm=yes" '
+                "to the SCons command line."
+            )
             sys.exit(255)
         elif cc_version_major < 7:
-            print("Detected GCC version older than 7, which does not fully support "
-                  "C++17. Supported versions are GCC 7, 9 and later. Use a newer GCC "
-                  "version, or Clang 6 or later by passing \"use_llvm=yes\" to the "
-                  "SCons command line.")
+            print(
+                "Detected GCC version older than 7, which does not fully support "
+                "C++17. Supported versions are GCC 7, 9 and later. Use a newer GCC "
+                'version, or Clang 6 or later by passing "use_llvm=yes" to the '
+                "SCons command line."
+            )
             sys.exit(255)
     elif methods.using_clang(env):
         # Apple LLVM versions differ from upstream LLVM version \o/, compare
@@ -358,16 +362,22 @@ if selected_platform in platform_list:
         if env["platform"] == "osx" or env["platform"] == "iphone":
             vanilla = methods.is_vanilla_clang(env)
             if vanilla and cc_version_major < 6:
-                print("Detected Clang version older than 6, which does not fully support "
-                      "C++17. Supported versions are Clang 6 and later.")
+                print(
+                    "Detected Clang version older than 6, which does not fully support "
+                    "C++17. Supported versions are Clang 6 and later."
+                )
                 sys.exit(255)
             elif not vanilla and cc_version_major < 10:
-                print("Detected Apple Clang version older than 10, which does not fully "
-                      "support C++17. Supported versions are Apple Clang 10 and later.")
+                print(
+                    "Detected Apple Clang version older than 10, which does not fully "
+                    "support C++17. Supported versions are Apple Clang 10 and later."
+                )
                 sys.exit(255)
         elif cc_version_major < 6:
-            print("Detected Clang version older than 6, which does not fully support "
-                  "C++17. Supported versions are Clang 6 and later.")
+            print(
+                "Detected Clang version older than 6, which does not fully support "
+                "C++17. Supported versions are Clang 6 and later."
+            )
             sys.exit(255)
 
     # Configure compiler warnings
@@ -394,7 +404,7 @@ if selected_platform in platform_list:
 
         if methods.using_gcc(env):
             if cc_version_major >= 7:
-                shadow_local_warning = ['-Wshadow-local']
+                shadow_local_warning = ["-Wshadow-local"]
 
         if (env["warnings"] == 'extra'):
             env.Append(CCFLAGS=['-Wall', '-Wextra', '-Wno-unused-parameter']
@@ -405,9 +415,9 @@ if selected_platform in platform_list:
                     '-Wduplicated-branches', '-Wduplicated-cond',
                     '-Wstringop-overflow=4', '-Wlogical-op'])
                 # -Wnoexcept was removed temporarily due to GH-36325.
-                env.Append(CXXFLAGS=['-Wplacement-new=1'])
+                env.Append(CXXFLAGS=["-Wplacement-new=1"])
                 if cc_version_major >= 9:
-                    env.Append(CCFLAGS=['-Wattribute-alias=2'])
+                    env.Append(CCFLAGS=["-Wattribute-alias=2"])
             if methods.using_clang(env):
                 env.Append(CCFLAGS=['-Wimplicit-fallthrough'])
         elif (env["warnings"] == 'all'):


### PR DESCRIPTION
Configured for a max line length of 120 characters.

A max line length of 130 was used for SConstruct as 120 makes a mess of
our command line options.

---

This is a proposal to better format our Python code. We very loosely followed PEP-8 until now but with a lot of inconsistency. [Black](https://github.com/psf/black) is an opinionated code formatter that doesn't leave much room to configuration, which enforces a uniform style.

It does some stuff I'm not particularly fond of, but overall with long max line length, it's not too bad.

I have yet to convert the actual `.py` files, some work is needed to prepare them to have a good formatting once passed through `black`.