### PR TITLE
Added code coverage support to Godot

### DIFF
--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -32,6 +32,7 @@ def get_opts():
     return [
         BoolVariable('use_llvm', 'Use the LLVM compiler', False),
         BoolVariable('use_static_cpp', 'Link libgcc and libstdc++ statically for better portability', False),
+        BoolVariable('use_coverage', 'Test Godot coverage', False),
         BoolVariable('use_ubsan', 'Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)', False),
         BoolVariable('use_asan', 'Use LLVM/GCC compiler address sanitizer (ASAN))', False),
         BoolVariable('use_lsan', 'Use LLVM/GCC compiler leak sanitizer (LSAN))', False),
@@ -99,6 +100,9 @@ def configure(env):
         env.Append(CPPDEFINES=['TYPED_METHOD_BIND'])
         env.extra_suffix = ".llvm" + env.extra_suffix
 
+    if env['use_coverage']:
+        env.Append(CCFLAGS=['-ftest-coverage', '-fprofile-arcs'])
+        env.Append(LINKFLAGS=['-ftest-coverage', '-fprofile-arcs'])
 
     if env['use_ubsan'] or env['use_asan'] or env['use_lsan'] or env['use_tsan']:
         env.extra_suffix += "s"

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -61,6 +61,7 @@ def get_opts():
         BoolVariable('use_lld', 'Use the LLD linker', False),
         BoolVariable('use_thinlto', 'Use ThinLTO', False),
         BoolVariable('use_static_cpp', 'Link libgcc and libstdc++ statically for better portability', False),
+        BoolVariable('use_coverage', 'Test Godot coverage', False),
         BoolVariable('use_ubsan', 'Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)', False),
         BoolVariable('use_asan', 'Use LLVM/GCC compiler address sanitizer (ASAN))', False),
         BoolVariable('use_lsan', 'Use LLVM/GCC compiler leak sanitizer (LSAN))', False),
@@ -140,6 +141,10 @@ def configure(env):
         else:
             print("Using LLD with GCC is not supported yet, try compiling with 'use_llvm=yes'.")
             sys.exit(255)
+
+    if env['use_coverage']:
+        env.Append(CCFLAGS=['-ftest-coverage', '-fprofile-arcs'])
+        env.Append(LINKFLAGS=['-ftest-coverage', '-fprofile-arcs'])
 
     if env['use_ubsan'] or env['use_asan'] or env['use_lsan'] or env['use_tsan']:
         env.extra_suffix += "s"


### PR DESCRIPTION
Code Coverage is a simple and easy method to find unreachable code and optimize functions  which are called the most.

**Required Tools**
The only needed tools are(tested only on Linux, I'm not sure if macOS  or Windows  can run this):
gcc or clang
gcov
lcov
`sudo apt install gcc gcov lcov clang`

**Usage**
Go to Godot directory `cd ~/godot`
Compile Godot with coverage support - `scons p=x11 -j6 use_coverage=yes`
Run project/editor with compiled version of Godot etc.  - `bin/godot.x11.tools.64 --path ~/Projekty/Godot-Project`
Exit project
Run  lcov capture command - `lcov --directory ./ --capture --output-file godot.info`
Generate HTML  - `genhtml godot.info --ignore-errors source`
Run index.html from folder

to clear  results  execute `lcov --zerocounters`

HTML file with code coverage of core/class_db.cpp when I runned The Worst Godot Project(remove .txt  and open in browser) - [lcov.html.txt](https://github.com/godotengine/godot/files/4257608/lcov.html.txt)
 

Report look like this:
![Zrzut ekranu z 2020-02-26 19-32-06](https://user-images.githubusercontent.com/41945903/75377085-6db1cf00-58d1-11ea-9f4b-70debe76e329.png)
