### PR TITLE
Animation Curves: moving the timeline requires redrawing the bezier editor

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3385,6 +3385,11 @@ void AnimationTrackEditor::cleanup() {
 }
 
 void AnimationTrackEditor::_name_limit_changed() {
+	// called from conditional (dragging_hsize) at AnimationTimelineEdit::_gui_input through signals
+	if (bezier_edit->is_visible()) {
+		bezier_edit->update();
+		bezier_edit->update_play_position();
+	}
 
 	for (int i = 0; i < track_edits.size(); i++) {
 		track_edits[i]->update();


### PR DESCRIPTION
The timeline could be dragged and resized but the bezier editor didn't answer to the movement redrawing the contents and the current time play bar.

Fixes #36403.