### PR TITLE
Remove friend reference to non-existing class RefBase

### DIFF
--- a/core/reference.h
+++ b/core/reference.h
@@ -38,7 +38,6 @@
 class Reference : public Object {
 
 	GDCLASS(Reference, Object);
-	friend class RefBase;
 	SafeRefCount refcount;
 	SafeRefCount refcount_init;
 


### PR DESCRIPTION
Commit 7ad14e7a3e6f87ddc450f7e34621eb5200808451 removed RefBase class - but still there is hanging reference in....Reference :) class (no pun intended).

It brings a little confusion to the reader as he is expecting finding that class somewhere.