### PR TITLE
Allow building godot with Clang on WIndows

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -340,8 +340,8 @@ def configure_mingw(env):
         env["CC"] = mingw_prefix + "clang"
         env['AS'] = mingw_prefix + "as"
         env["CXX"] = mingw_prefix + "clang++"
-        env['AR'] = mingw_prefix + "ar"
-        env['RANLIB'] = mingw_prefix + "ranlib"
+        env['AR'] = mingw_prefix + "llvm-ar"
+        env['RANLIB'] = mingw_prefix + "llvm-ranlib"
         env["LINK"] = mingw_prefix + "clang++"
     else:
         env["CC"] = mingw_prefix + "gcc"

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -401,6 +401,11 @@ def configure(env):
         setup_mingw(env)
         env.msvc = False
 
+    if env['use_llvm']:
+        if env['use_thinlto']:
+            # A convenience so you don't need to write use_lto too when using SCons
+            env['use_lto'] = True
+
     # Now set compiler/linker flags
     if env.msvc:
         configure_msvc(env, manual_msvc_config)


### PR DESCRIPTION
Tested on 3.2-stable

Related to https://github.com/godotengine/godot/issues/6560

Now we can build godot on WIndows with clang and WIndows SDK. 

Also the `scons p=windows tools=yes use_mingw=yes use_llvm=yes bits=64 use_thinlto=yes target=release_debug -j8` in https://github.com/godotengine/godot/issues/11340 doesn't make sense since `use_thinlto` has to be used with `use_lto` previously. And the build failed when I enable them all. This PR enable `use_lto` automatically when `use_thinlto=yes`, and fix the failed build by using llvm tools instead of mingw tools.


mingw + llvm build: `scons platform=windows target=release_debug bits=64 use_mingw=yes use_llvm=yes use_thinlto=yes`

For some reasons, I have to use https://github.com/mstorsjo/llvm-mingw instead of the llvm packages in msys2 in order to compile the mingw + llvm build.


windowsSDK + llvm build: `scons platform=windows target=release_debug bits=64 use_llvm=yes use_thinlto=yes` 

I have also created a guide on using llvm and GIt Bash to compile Godot, see https://github.com/Adriankhl/llvm-git-bash . It may not be necessary to extract the environment variables from developer powershell since scons seems to be able to extract that automatically? I know cmake need that but I am not sure for scons.
