### PR TITLE
Add fill direction to progress bar

### DIFF
--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -61,24 +61,23 @@ void ProgressBar::_notification(int p_what) {
 		float r = get_as_ratio();
 
 
-		if(fill == FILL_LEFT_TO_RIGHT || fill == FILL_RIGHT_TO_LEFT){
+		if (fill == FILL_LEFT_TO_RIGHT || fill == FILL_RIGHT_TO_LEFT) {
 			int mp = fg->get_minimum_size().width;
 			int p = r * (get_size().width - mp);
 			if (p > 0) {
-				if(fill == FILL_LEFT_TO_RIGHT){
+				if (fill == FILL_LEFT_TO_RIGHT) {
 					draw_style_box(fg, Rect2(Point2(), Size2(p + fg->get_minimum_size().width, get_size().height)));
-				}else{
+				} else {
 					draw_style_box(fg, Rect2(Point2(get_size().width - (p + fg->get_minimum_size().width), 0), Size2(p + fg->get_minimum_size().width, get_size().height)));
 				}
 			}
-		}else{
+		} else {
 			int mp = fg->get_minimum_size().height;
 			int p = r * (get_size().height - mp);
 			if (p > 0) {
-				if(fill == FILL_BOTTOM_TO_TOP){
+				if (fill == FILL_BOTTOM_TO_TOP) {
 					draw_style_box(fg, Rect2(Point2(), Size2(get_size().width, p + fg->get_minimum_size().height)));
-				}
-				else{
+				} else {
 					draw_style_box(fg, Rect2(Point2(0, get_size().height - (p + fg->get_minimum_size().height)), Size2(get_size().width, p + fg->get_minimum_size().height)));
 				}
 			}

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -56,14 +56,29 @@ void ProgressBar::_notification(int p_what) {
 		Ref<StyleBox> fg = get_stylebox("fg");
 		Ref<Font> font = get_font("font");
 		Color font_color = get_color("font_color");
-
 		draw_style_box(bg, Rect2(Point2(), get_size()));
 		float r = get_as_ratio();
-		int mp = fg->get_minimum_size().width;
-		int p = r * (get_size().width - mp);
-		if (p > 0) {
 
-			draw_style_box(fg, Rect2(Point2(), Size2(p + fg->get_minimum_size().width, get_size().height)));
+		if (fill == FILL_RIGHT || fill == FILL_LEFT) {
+			int mp = fg->get_minimum_size().width;
+			int p = r * (get_size().width - mp);
+			if (p > 0) {
+				if (fill == FILL_RIGHT) {
+					draw_style_box(fg, Rect2(Point2(), Size2(p + fg->get_minimum_size().width, get_size().height)));
+				} else {
+					draw_style_box(fg, Rect2(Point2(get_size().width - (p + fg->get_minimum_size().width), 0), Size2(p + fg->get_minimum_size().width, get_size().height)));
+				}
+			}
+		} else {
+			int mp = fg->get_minimum_size().height;
+			int p = r * (get_size().height - mp);
+			if (p > 0) {
+				if (fill == FILL_DOWN) {
+					draw_style_box(fg, Rect2(Point2(), Size2(get_size().width, p + fg->get_minimum_size().height)));
+				} else {
+					draw_style_box(fg, Rect2(Point2(0, get_size().height - (p + fg->get_minimum_size().height)), Size2(get_size().width, p + fg->get_minimum_size().height)));
+				}
+			}
 		}
 
 		if (percent_visible) {
@@ -84,17 +99,40 @@ bool ProgressBar::is_percent_visible() const {
 	return percent_visible;
 }
 
+void ProgressBar::set_fill_mode(FillMode p_fill) {
+
+	fill = p_fill;
+	update();
+}
+
+ProgressBar::FillMode ProgressBar::get_fill_mode() const {
+
+	return fill;
+}
+
 void ProgressBar::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_percent_visible", "visible"), &ProgressBar::set_percent_visible);
 	ClassDB::bind_method(D_METHOD("is_percent_visible"), &ProgressBar::is_percent_visible);
+
+	ClassDB::bind_method(D_METHOD("get_fill_mode"), &ProgressBar::get_fill_mode);
+	ClassDB::bind_method(D_METHOD("set_fill_mode", "fill_direction"), &ProgressBar::set_fill_mode);
+
 	ADD_GROUP("Percent", "percent_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "percent_visible"), "set_percent_visible", "is_percent_visible");
+
+	BIND_ENUM_CONSTANT(FILL_UP);
+	BIND_ENUM_CONSTANT(FILL_DOWN);
+	BIND_ENUM_CONSTANT(FILL_LEFT);
+	BIND_ENUM_CONSTANT(FILL_RIGHT);
+
+	ADD_GROUP("Fill Direction", "fill_");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "fill_direction", PROPERTY_HINT_ENUM, "Up,Down,Left,Right"), "set_fill_mode", "get_fill_mode");
 }
 
 ProgressBar::ProgressBar() {
-
 	set_v_size_flags(0);
 	set_step(0.01);
 	percent_visible = true;
+	fill = FILL_RIGHT;
 }

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -56,26 +56,29 @@ void ProgressBar::_notification(int p_what) {
 		Ref<StyleBox> fg = get_stylebox("fg");
 		Ref<Font> font = get_font("font");
 		Color font_color = get_color("font_color");
+
 		draw_style_box(bg, Rect2(Point2(), get_size()));
 		float r = get_as_ratio();
 
-		if (fill == FILL_RIGHT || fill == FILL_LEFT) {
+
+		if(fill == FILL_LEFT_TO_RIGHT || fill == FILL_RIGHT_TO_LEFT){
 			int mp = fg->get_minimum_size().width;
 			int p = r * (get_size().width - mp);
 			if (p > 0) {
-				if (fill == FILL_RIGHT) {
+				if(fill == FILL_LEFT_TO_RIGHT){
 					draw_style_box(fg, Rect2(Point2(), Size2(p + fg->get_minimum_size().width, get_size().height)));
-				} else {
+				}else{
 					draw_style_box(fg, Rect2(Point2(get_size().width - (p + fg->get_minimum_size().width), 0), Size2(p + fg->get_minimum_size().width, get_size().height)));
 				}
 			}
-		} else {
+		}else{
 			int mp = fg->get_minimum_size().height;
 			int p = r * (get_size().height - mp);
 			if (p > 0) {
-				if (fill == FILL_DOWN) {
+				if(fill == FILL_BOTTOM_TO_TOP){
 					draw_style_box(fg, Rect2(Point2(), Size2(get_size().width, p + fg->get_minimum_size().height)));
-				} else {
+				}
+				else{
 					draw_style_box(fg, Rect2(Point2(0, get_size().height - (p + fg->get_minimum_size().height)), Size2(get_size().width, p + fg->get_minimum_size().height)));
 				}
 			}
@@ -100,15 +103,14 @@ bool ProgressBar::is_percent_visible() const {
 }
 
 void ProgressBar::set_fill_mode(FillMode p_fill) {
-
 	fill = p_fill;
 	update();
 }
 
 ProgressBar::FillMode ProgressBar::get_fill_mode() const {
-
 	return fill;
 }
+
 
 void ProgressBar::_bind_methods() {
 
@@ -120,19 +122,18 @@ void ProgressBar::_bind_methods() {
 
 	ADD_GROUP("Percent", "percent_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "percent_visible"), "set_percent_visible", "is_percent_visible");
-
-	BIND_ENUM_CONSTANT(FILL_UP);
-	BIND_ENUM_CONSTANT(FILL_DOWN);
-	BIND_ENUM_CONSTANT(FILL_LEFT);
-	BIND_ENUM_CONSTANT(FILL_RIGHT);
+	BIND_ENUM_CONSTANT(FILL_LEFT_TO_RIGHT);
+	BIND_ENUM_CONSTANT(FILL_RIGHT_TO_LEFT);
+	BIND_ENUM_CONSTANT(FILL_BOTTOM_TO_TOP);
+	BIND_ENUM_CONSTANT(FILL_TOP_TO_BOTTOM);
 
 	ADD_GROUP("Fill Direction", "fill_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "fill_direction", PROPERTY_HINT_ENUM, "Up,Down,Left,Right"), "set_fill_mode", "get_fill_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "fill_direction", PROPERTY_HINT_ENUM, "Left to Right,Right to Left,Bottom to Top,Top to Bottom"), "set_fill_mode", "get_fill_mode");
 }
 
 ProgressBar::ProgressBar() {
 	set_v_size_flags(0);
 	set_step(0.01);
 	percent_visible = true;
-	fill = FILL_RIGHT;
+	fill = FILL_LEFT_TO_RIGHT;
 }

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -131,7 +131,7 @@ void ProgressBar::_bind_methods() {
 }
 
 ProgressBar::ProgressBar() {
-	
+
 	set_v_size_flags(0);
 	set_step(0.01);
 	percent_visible = true;

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -60,7 +60,6 @@ void ProgressBar::_notification(int p_what) {
 		draw_style_box(bg, Rect2(Point2(), get_size()));
 		float r = get_as_ratio();
 
-
 		if (fill == FILL_LEFT_TO_RIGHT || fill == FILL_RIGHT_TO_LEFT) {
 			int mp = fg->get_minimum_size().width;
 			int p = r * (get_size().width - mp);
@@ -102,14 +101,15 @@ bool ProgressBar::is_percent_visible() const {
 }
 
 void ProgressBar::set_fill_mode(FillMode p_fill) {
+
 	fill = p_fill;
 	update();
 }
 
 ProgressBar::FillMode ProgressBar::get_fill_mode() const {
+
 	return fill;
 }
-
 
 void ProgressBar::_bind_methods() {
 
@@ -131,6 +131,7 @@ void ProgressBar::_bind_methods() {
 }
 
 ProgressBar::ProgressBar() {
+	
 	set_v_size_flags(0);
 	set_step(0.01);
 	percent_visible = true;

--- a/scene/gui/progress_bar.h
+++ b/scene/gui/progress_bar.h
@@ -36,7 +36,6 @@
 class ProgressBar : public Range {
 
 	GDCLASS(ProgressBar, Range);
-
 	bool percent_visible;
 
 protected:

--- a/scene/gui/progress_bar.h
+++ b/scene/gui/progress_bar.h
@@ -36,6 +36,7 @@
 class ProgressBar : public Range {
 
 	GDCLASS(ProgressBar, Range);
+
 	bool percent_visible;
 
 protected:
@@ -43,20 +44,20 @@ protected:
 	static void _bind_methods();
 
 public:
-	enum FillMode {
-		FILL_UP,
-		FILL_DOWN,
-		FILL_LEFT,
-		FILL_RIGHT
+    enum FillMode {
+		FILL_LEFT_TO_RIGHT,
+		FILL_RIGHT_TO_LEFT,
+		FILL_TOP_TO_BOTTOM,
+		FILL_BOTTOM_TO_TOP
 	};
-
+    
 private:
-	FillMode fill;
-
+    FillMode fill;
+    
 public:
-	void set_fill_mode(FillMode p_fill);
+    void set_fill_mode(FillMode p_fill);
 	FillMode get_fill_mode() const;
-
+    
 	void set_percent_visible(bool p_visible);
 	bool is_percent_visible() const;
 

--- a/scene/gui/progress_bar.h
+++ b/scene/gui/progress_bar.h
@@ -44,20 +44,20 @@ protected:
 	static void _bind_methods();
 
 public:
-    enum FillMode {
+	enum FillMode {
 		FILL_LEFT_TO_RIGHT,
 		FILL_RIGHT_TO_LEFT,
 		FILL_TOP_TO_BOTTOM,
 		FILL_BOTTOM_TO_TOP
 	};
-    
+
 private:
-    FillMode fill;
-    
+	FillMode fill;
+
 public:
-    void set_fill_mode(FillMode p_fill);
+	void set_fill_mode(FillMode p_fill);
 	FillMode get_fill_mode() const;
-    
+
 	void set_percent_visible(bool p_visible);
 	bool is_percent_visible() const;
 

--- a/scene/gui/progress_bar.h
+++ b/scene/gui/progress_bar.h
@@ -36,7 +36,6 @@
 class ProgressBar : public Range {
 
 	GDCLASS(ProgressBar, Range);
-
 	bool percent_visible;
 
 protected:
@@ -44,11 +43,27 @@ protected:
 	static void _bind_methods();
 
 public:
+	enum FillMode {
+		FILL_UP,
+		FILL_DOWN,
+		FILL_LEFT,
+		FILL_RIGHT
+	};
+
+private:
+	FillMode fill;
+
+public:
+	void set_fill_mode(FillMode p_fill);
+	FillMode get_fill_mode() const;
+
 	void set_percent_visible(bool p_visible);
 	bool is_percent_visible() const;
 
 	Size2 get_minimum_size() const;
 	ProgressBar();
 };
+
+VARIANT_ENUM_CAST(ProgressBar::FillMode);
 
 #endif // PROGRESS_BAR_H


### PR DESCRIPTION
As the title says, I needed this a quite a few times in my own project. And thought I would share it with the rest.

It simply adds fill directions to the progress bar. So that you don't have to rotate the node anymore to get the same effect. And you can still use the percentage display as well. 

Anyway, a picture to show what it does:
![progress](https://user-images.githubusercontent.com/10586460/75429765-97f3a300-594a-11ea-9a3c-6e7c006a813b.png)

It adds an ENUM with a default value of fill_right. Meaning that any already existing progress bars will keep the same behaviour. 

 