### PR TITLE
Added popup menu for some actions in visual shaders

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -81,6 +81,7 @@ class VisualShaderEditor : public VBoxContainer {
 	bool saved_node_pos_dirty;
 
 	ConfirmationDialog *members_dialog;
+	PopupMenu *popup_menu;
 	MenuButton *tools;
 
 	bool preview_showed;
@@ -88,6 +89,15 @@ class VisualShaderEditor : public VBoxContainer {
 	enum ToolsMenuOptions {
 		EXPAND_ALL,
 		COLLAPSE_ALL
+	};
+
+	enum NodeMenuOptions {
+		ADD,
+		SEPARATOR, // ignore
+		COPY,
+		DELETE,
+		DUPLICATE,
+		PASTE,
 	};
 
 	Tree *members;
@@ -216,7 +226,7 @@ class VisualShaderEditor : public VBoxContainer {
 
 	void _clear_buffer();
 	void _copy_nodes();
-	void _paste_nodes();
+	void _paste_nodes(bool p_use_custom_position = false, const Vector2 &p_custom_position = Vector2());
 
 	Vector<Ref<VisualShaderNodePlugin> > plugins;
 
@@ -249,6 +259,9 @@ class VisualShaderEditor : public VBoxContainer {
 	void _member_unselected();
 	void _member_create();
 	void _member_cancel();
+
+	Vector2 menu_point;
+	void _node_menu_id_pressed(int p_idx);
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;


### PR DESCRIPTION
I think it's a good idea to call that menu when the user pressed right-click. If the copy/paste/delete options are not available at the moment the standard member dialog will be shown.

![vs_popup_menu](https://user-images.githubusercontent.com/3036176/75431158-7b149b00-595d-11ea-8f46-5beaf5131c2a.gif)
