### PR TITLE
Exposing get_tracker_id for ARVRPositionalTracker to GDScript

### DIFF
--- a/doc/classes/ARVRPositionalTracker.xml
+++ b/doc/classes/ARVRPositionalTracker.xml
@@ -54,6 +54,13 @@
 				Returns the world-space controller position.
 			</description>
 		</method>
+		<method name="get_tracker_id" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the internal tracker ID. This uniquely identifies the tracker per tracker type and matches the ID you need to specify for nodes such as the [ARVRController] and [ARVRAnchor] nodes.
+			</description>
+		</method>
 		<method name="get_tracks_orientation" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/servers/arvr/arvr_positional_tracker.cpp
+++ b/servers/arvr/arvr_positional_tracker.cpp
@@ -38,6 +38,7 @@ void ARVRPositionalTracker::_bind_methods() {
 
 	// this class is read only from GDScript, so we only have access to getters..
 	ClassDB::bind_method(D_METHOD("get_type"), &ARVRPositionalTracker::get_type);
+	ClassDB::bind_method(D_METHOD("get_tracker_id"), &ARVRPositionalTracker::get_tracker_id);
 	ClassDB::bind_method(D_METHOD("get_name"), &ARVRPositionalTracker::get_name);
 	ClassDB::bind_method(D_METHOD("get_joy_id"), &ARVRPositionalTracker::get_joy_id);
 	ClassDB::bind_method(D_METHOD("get_tracks_orientation"), &ARVRPositionalTracker::get_tracks_orientation);


### PR DESCRIPTION
Not sure how I missed this all that time but this method on ARVRPositionalTracker was never exposed to the classdb. 

get_tracker_id gives us access to the unique (per tracker type) id that is assigned when a tracker is added to the system. It is this id that is used as the controller_id on ARVRController and as the anchor_id on ARVRAnchor so it is kind of handy to have it exposed. 

It would be good to cherry pick this for the next 3.2 patch as well.