### PR TITLE
Allow using Rider MSBuild on Windows, when Rider is selected as external editor

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Godot;
+using GodotTools.Ides.Rider;
 using GodotTools.Internals;
 using Directory = System.IO.Directory;
 using Environment = System.Environment;
@@ -54,6 +55,12 @@ namespace GodotTools.Build
 
                         return msbuildPath;
                     }
+                    case BuildManager.BuildTool.JetBrainsMsBuild:
+                        var editorPath = (string)editorSettings.GetSetting(RiderPathManager.EditorPathSettingName);
+                        if (!File.Exists(editorPath))
+                            throw new FileNotFoundException($"Cannot find Rider executable. Tried with path: {editorPath}");
+                        var riderDir = new FileInfo(editorPath).Directory.Parent;
+                        return Path.Combine(riderDir.FullName, @"tools\MSBuild\Current\Bin\MSBuild.exe");
                     default:
                         throw new IndexOutOfRangeException("Invalid build tool in editor settings");
                 }

--- a/modules/mono/editor/GodotTools/GodotTools/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/BuildManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using GodotTools.Build;
+using GodotTools.Ides.Rider;
 using GodotTools.Internals;
 using GodotTools.Utils;
 using static GodotTools.Internals.Globals;
@@ -16,6 +17,7 @@ namespace GodotTools
 
         public const string PropNameMsbuildMono = "MSBuild (Mono)";
         public const string PropNameMsbuildVs = "MSBuild (VS Build Tools)";
+        public const string PropNameMsbuildJetBrains = "MSBuild (JetBrains Rider)";
 
         public const string MsBuildIssuesFileName = "msbuild_issues.csv";
         public const string MsBuildLogFileName = "msbuild_log.txt";
@@ -23,7 +25,8 @@ namespace GodotTools
         public enum BuildTool
         {
             MsBuildMono,
-            MsBuildVs
+            MsBuildVs,
+            JetBrainsMsBuild
         }
 
         private static void RemoveOldIssuesFile(BuildInfo buildInfo)
@@ -181,7 +184,7 @@ namespace GodotTools
                 var buildInfo = new BuildInfo(GodotSharpDirs.ProjectSlnPath, config);
 
                 // Add Godot defines
-                string constants = buildTool == BuildTool.MsBuildVs ? "GodotDefineConstants=\"" : "GodotDefineConstants=\\\"";
+                string constants = buildTool != BuildTool.MsBuildMono ? "GodotDefineConstants=\"" : "GodotDefineConstants=\\\"";
 
                 foreach (var godotDefine in godotDefines)
                     constants += $"GODOT_{godotDefine.ToUpper().Replace("-", "_").Replace(" ", "_").Replace(";", "_")};";
@@ -189,7 +192,7 @@ namespace GodotTools
                 if (Internal.GodotIsRealTDouble())
                     constants += "GODOT_REAL_T_IS_DOUBLE;";
 
-                constants += buildTool == BuildTool.MsBuildVs ? "\"" : "\\\"";
+                constants += buildTool != BuildTool.MsBuildMono ? "\"" : "\\\"";
 
                 buildInfo.CustomProperties.Add(constants);
 
@@ -245,18 +248,22 @@ namespace GodotTools
         public static void Initialize()
         {
             // Build tool settings
-
-            EditorDef("mono/builds/build_tool", OS.IsWindows ? BuildTool.MsBuildVs : BuildTool.MsBuildMono);
-
             var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+            var msbuild = BuildTool.MsBuildMono;
+            if (OS.IsWindows)
+                msbuild = RiderPathManager.IsRider((string) editorSettings.GetSetting(RiderPathManager.EditorPathSettingName))
+                        ? BuildTool.JetBrainsMsBuild
+                        : BuildTool.MsBuildVs;
 
+            EditorDef("mono/builds/build_tool", msbuild);
+            
             editorSettings.AddPropertyInfo(new Godot.Collections.Dictionary
             {
                 ["type"] = Godot.Variant.Type.Int,
                 ["name"] = "mono/builds/build_tool",
                 ["hint"] = Godot.PropertyHint.Enum,
                 ["hint_string"] = OS.IsWindows ?
-                    $"{PropNameMsbuildMono},{PropNameMsbuildVs}" :
+                    $"{PropNameMsbuildMono},{PropNameMsbuildVs},{PropNameMsbuildJetBrains}" :
                     $"{PropNameMsbuildMono}"
             });
 

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
@@ -9,13 +9,13 @@ namespace GodotTools.Ides.Rider
 {
     public static class RiderPathManager
     {
-        private static readonly string editorPathSettingName = "mono/editor/editor_path_optional";
+        public static readonly string EditorPathSettingName = "mono/editor/editor_path_optional";
 
         private static string GetRiderPathFromSettings()
         {
             var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
-            if (editorSettings.HasSetting(editorPathSettingName))
-                return (string)editorSettings.GetSetting(editorPathSettingName);
+            if (editorSettings.HasSetting(EditorPathSettingName))
+                return (string)editorSettings.GetSetting(EditorPathSettingName);
             return null;
         }
 
@@ -25,22 +25,22 @@ namespace GodotTools.Ides.Rider
             var editor = (ExternalEditorId)editorSettings.GetSetting("mono/editor/external_editor");
             if (editor == ExternalEditorId.Rider)
             {
-                if (!editorSettings.HasSetting(editorPathSettingName))
+                if (!editorSettings.HasSetting(EditorPathSettingName))
                 {
-                    Globals.EditorDef(editorPathSettingName, "Optional");
+                    Globals.EditorDef(EditorPathSettingName, "Optional");
                     editorSettings.AddPropertyInfo(new Godot.Collections.Dictionary
                     {
                         ["type"] = Variant.Type.String,
-                        ["name"] = editorPathSettingName,
+                        ["name"] = EditorPathSettingName,
                         ["hint"] = PropertyHint.File,
                         ["hint_string"] = ""
                     });
                 }
 
-                var riderPath = (string)editorSettings.GetSetting(editorPathSettingName);
+                var riderPath = (string)editorSettings.GetSetting(EditorPathSettingName);
                 if (IsRiderAndExists(riderPath))
                 {
-                    Globals.EditorDef(editorPathSettingName, riderPath);
+                    Globals.EditorDef(EditorPathSettingName, riderPath);
                     return;
                 }
 
@@ -50,17 +50,15 @@ namespace GodotTools.Ides.Rider
                     return;
 
                 var newPath = paths.Last().Path;
-                Globals.EditorDef(editorPathSettingName, newPath);
-                editorSettings.SetSetting(editorPathSettingName, newPath);
+                Globals.EditorDef(EditorPathSettingName, newPath);
+                editorSettings.SetSetting(EditorPathSettingName, newPath);
             }
         }
 
-        private static bool IsRider(string path)
+        public static bool IsRider(string path)
         {
             if (string.IsNullOrEmpty(path))
-            {
                 return false;
-            }
 
             var fileInfo = new FileInfo(path);
             var filename = fileInfo.Name.ToLowerInvariant();
@@ -81,8 +79,8 @@ namespace GodotTools.Ides.Rider
                 return null;
 
             var newPath = paths.Last().Path;
-            editorSettings.SetSetting(editorPathSettingName, newPath);
-            Globals.EditorDef(editorPathSettingName, newPath);
+            editorSettings.SetSetting(EditorPathSettingName, newPath);
+            Globals.EditorDef(EditorPathSettingName, newPath);
             return newPath;
         }
 


### PR DESCRIPTION
JetBrains MSBuild is preferable over Microsoft one, because MS one has a requirement for a valid Visual Studio license. See more https://blog.jetbrains.com/dotnet/2018/04/13/introducing-jetbrains-redistributable-msbuild/