### PR TITLE
Signals: tab_changed now is emitted when it's on scene tree

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -538,7 +538,7 @@ void TabContainer::add_child_notify(Node *p_child) {
 
 	update();
 	p_child->connect_compat("renamed", this, "_child_renamed_callback");
-	if (first)
+	if (first && is_inside_tree())
 		emit_signal("tab_changed", current);
 }
 


### PR DESCRIPTION
This is actually a fix by @kuruk-mm from #36426, but since it's not directly depend on that WIP PR I'll pushing it as standalone. It fixes a bug where TabContainer's `add_child_notify` would emit a signal even if not in the scene tree, potentially triggering crashes in connected callbacks that assume that scene nodes are initialized.

The `callable_mp` changes in #36246 expose that issue.