### PR TITLE
Add a practical example for `@GDScript.linear2db()`

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -596,7 +596,13 @@
 			<argument index="0" name="nrg" type="float">
 			</argument>
 			<description>
-				Converts from linear energy to decibels (audio).
+				Converts from linear energy to decibels (audio). This can be used to implement volume sliders that behave as expected (since volume isn't linear). Example:
+				[codeblock]
+				# "Slider" refers to a node that inherits Range such as HSlider or VSlider.
+				# Its range must be configured to go from 0 to 1.
+				# Change the bus name if you'd like to change the volume of a specific bus only.
+				AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear2db($Slider.value))
+				[/codeblock]
 			</description>
 		</method>
 		<method name="load">


### PR DESCRIPTION
One of its most common applications in games is for volume sliders.

See https://www.dr-lex.be/info-stuff/volumecontrols.html for more information.