### PR TITLE
Fix wrong selection on cloning a line down in the editor

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1267,7 +1267,7 @@ void CodeTextEditor::clone_lines_down() {
 	text_editor->cursor_set_line(cursor_new_line);
 	text_editor->cursor_set_column(cursor_new_column);
 	if (selection_active) {
-		text_editor->select(to_line, to_column, 2 * to_line - from_line, 2 * to_column - from_column);
+		text_editor->select(to_line, to_column, 2 * to_line - from_line, to_line == from_line ? 2 * to_column - from_column : to_column);
 	}
 
 	text_editor->end_complex_operation();


### PR DESCRIPTION
Fixes #36282, the selection was wrong because the column being selected for the end of the selection was using some weird formula (it looks like the one used in finding the line the selection should be moved to).