### PR TITLE
Properly free many Vulkan resources

### DIFF
--- a/servers/visual/rasterizer_rd/rasterizer_effects_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_effects_rd.cpp
@@ -974,6 +974,17 @@ RasterizerEffectsRD::RasterizerEffectsRD() {
 
 RasterizerEffectsRD::~RasterizerEffectsRD() {
 	RD::get_singleton()->free(default_sampler);
-	blur.shader.version_free(blur.shader_version);
+	RD::get_singleton()->free(default_mipmap_sampler);
 	RD::get_singleton()->free(index_buffer); //array gets freed as dependency
+	blur.shader.version_free(blur.shader_version);
+	roughness.shader.version_free(roughness.shader_version);
+	sky.shader.version_free(sky.shader_version);
+	tonemap.shader.version_free(tonemap.shader_version);
+	luminance_reduce.shader.version_free(luminance_reduce.shader_version);
+	copy.shader.version_free(copy.shader_version);
+	bokeh.shader.version_free(bokeh.shader_version);
+	ssao.minify_shader.version_free(ssao.minify_shader_version);
+	ssao.gather_shader.version_free(ssao.gather_shader_version);
+	ssao.blur_shader.version_free(ssao.blur_shader_version);
+	roughness_limiter.shader.version_free(roughness_limiter.shader_version);
 }

--- a/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -2693,6 +2693,11 @@ RasterizerSceneHighEndRD::~RasterizerSceneHighEndRD() {
 		RD::get_singleton()->free(view_dependant_uniform_set);
 	}
 
+	RD::get_singleton()->free(default_render_buffers_uniform_set);
+	RD::get_singleton()->free(default_radiance_uniform_set);
+	RD::get_singleton()->free(default_vec4_xform_buffer);
+	RD::get_singleton()->free(shadow_sampler);
+
 	storage->free(wireframe_material_shader);
 	storage->free(overdraw_material_shader);
 	storage->free(default_shader);
@@ -2702,6 +2707,11 @@ RasterizerSceneHighEndRD::~RasterizerSceneHighEndRD() {
 	storage->free(default_material);
 
 	{
+		RD::get_singleton()->free(scene_state.uniform_buffer);
+		RD::get_singleton()->free(scene_state.instance_buffer);
+		RD::get_singleton()->free(scene_state.gi_probe_buffer);
+		RD::get_singleton()->free(scene_state.directional_light_buffer);
+		RD::get_singleton()->free(scene_state.light_buffer);
 		RD::get_singleton()->free(scene_state.reflection_buffer);
 		memdelete_arr(scene_state.instances);
 		memdelete_arr(scene_state.gi_probes);

--- a/servers/visual/rasterizer_rd/rasterizer_scene_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_rd.cpp
@@ -3130,5 +3130,7 @@ RasterizerSceneRD::~RasterizerSceneRD() {
 	}
 
 	RD::get_singleton()->free(gi_probe_lights_uniform);
+	giprobe_debug_shader.version_free(giprobe_debug_shader_version);
+	giprobe_shader.version_free(giprobe_lighting_shader_version);
 	memdelete_arr(gi_probe_lights);
 }

--- a/servers/visual/rasterizer_rd/rasterizer_storage_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_storage_rd.cpp
@@ -4814,4 +4814,5 @@ RasterizerStorageRD::~RasterizerStorageRD() {
 	for (int i = 0; i < DEFAULT_RD_BUFFER_MAX; i++) {
 		RD::get_singleton()->free(mesh_default_rd_buffers[i]);
 	}
+	giprobe_sdf_shader.version_free(giprobe_sdf_shader_version);
 }


### PR DESCRIPTION
This PR frees all of the shaders and many of the resources that are reported in #36597

There are many more depending on the configuration of the scene. But these are the ones that crop up no matter what type of scene you have. This should allow us to identify particular elements that lead to leakage. 