### PR TITLE
Curve2D and Curve3D revert bug

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -162,7 +162,7 @@ void Path2D::_bind_methods() {
 
 Path2D::Path2D() {
 
-	set_curve(Ref<Curve2D>(memnew(Curve2D))); //create one by default
+	set_curve(Ref<Curve2D>());
 	set_self_modulate(Color(0.5, 0.6, 1.0, 0.7));
 }
 

--- a/scene/3d/path.cpp
+++ b/scene/3d/path.cpp
@@ -88,7 +88,7 @@ void Path::_bind_methods() {
 
 Path::Path() {
 
-	set_curve(Ref<Curve3D>(memnew(Curve3D))); //create one by default
+	set_curve(Ref<Curve3D>());
 }
 
 //////////////


### PR DESCRIPTION
It fixes #36372 and same type of bug in `curve` property of `Path` (latter is unreported).

Since both `Path2D` and `Path` use `Ref` to store the curve data, `ClassDB` caches those references as default value for those properties. 
When these properties get reverted then default reference is assigned so any changes made after the revert is applied to default cached value (reason for disappearance of revert button) 
If another path is reverted then modified cached path is used (reason for non empty path reversion)