### PR TITLE
add a precision about the intended use of the ConcavePolygonShape

### DIFF
--- a/doc/classes/ConcavePolygonShape.xml
+++ b/doc/classes/ConcavePolygonShape.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Concave polygon shape resource, which can be set into a [PhysicsBody] or area. This shape is created by feeding a list of triangles.
+		Note: when used for collision, [ConcavePolygonShape] is intended to work with static [PhysicsBody] nodes like [StaticBody] and will not work with [KinematicBody] or [RigidBody] with a mode other than Static.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
I add this precision for the case of users using a movable PhysicsBody like a RigidBody with a ConcavePolygonShape for collision and have inevitably the PhysicsBody going trough walls and floors, i hope reading this will help them understanding that it's not a bug.