### PR TITLE
fix: editor reset button share same reference between objects

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -695,7 +695,14 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 
 			Variant default_value = ClassDB::class_get_default_property_value(object->get_class_name(), property);
 			if (default_value != Variant()) {
-				emit_changed(property, default_value);
+				Object *obj = default_value.operator Object *();
+				Resource *res = Object::cast_to<Resource>(obj);
+				if (res) {
+					emit_changed(property, res->duplicate(true));
+				} else {
+					emit_changed(property, default_value);
+				}
+
 				update_property();
 				return;
 			}


### PR DESCRIPTION
when reset button at the Inspector dock pressed and if the default_value (at ClassDB::default_value) Type is OBJECT, not null -> the resource is **Referenced** by the property. It leads multiple nodes which have been resetted have the same reference, also After the reset button pressed first time ever the property has the reference of resetting resource -> so no more resets

Fix: #36372
Fix: #36650