### PR TITLE
Sync mouse_filter property in SpinBox with internal LineEdit

### DIFF
--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -412,7 +412,7 @@ public:
 
 	Control *get_focus_owner() const;
 
-	void set_mouse_filter(MouseFilter p_filter);
+	virtual void set_mouse_filter(MouseFilter p_filter);
 	MouseFilter get_mouse_filter() const;
 
 	void set_pass_on_modal_close_click(bool p_pass_on);

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -182,6 +182,21 @@ void SpinBox::_line_edit_focus_exit() {
 	_text_entered(line_edit->get_text());
 }
 
+void SpinBox::_set_line_edit_mouse_filter(MouseFilter p_filter) {
+	MouseFilter filter;
+	switch (p_filter) {
+		case MOUSE_FILTER_PASS:
+			filter = MOUSE_FILTER_PASS;
+			break;
+		case MOUSE_FILTER_STOP:
+			filter = MOUSE_FILTER_PASS;
+			break;
+		case MOUSE_FILTER_IGNORE:
+			filter = MOUSE_FILTER_IGNORE;
+	}
+	line_edit->set_mouse_filter(filter);
+}
+
 inline void SpinBox::_adjust_width_for_icon(const Ref<Texture2D> &icon) {
 
 	int w = icon->get_width();
@@ -259,6 +274,12 @@ bool SpinBox::is_editable() const {
 	return line_edit->is_editable();
 }
 
+void SpinBox::set_mouse_filter(MouseFilter p_filter) {
+
+	_set_line_edit_mouse_filter(p_filter);
+	Control::set_mouse_filter(p_filter);
+}
+
 void SpinBox::apply() {
 	_text_entered(line_edit->get_text());
 }
@@ -291,7 +312,7 @@ SpinBox::SpinBox() {
 	add_child(line_edit);
 
 	line_edit->set_anchors_and_margins_preset(Control::PRESET_WIDE);
-	line_edit->set_mouse_filter(MOUSE_FILTER_PASS);
+	_set_line_edit_mouse_filter(get_mouse_filter());
 	//connect("value_changed",this,"_value_changed");
 	line_edit->connect("text_entered", callable_mp(this, &SpinBox::_text_entered), Vector<Variant>(), CONNECT_DEFERRED);
 	line_edit->connect("focus_exited", callable_mp(this, &SpinBox::_line_edit_focus_exit), Vector<Variant>(), CONNECT_DEFERRED);

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -62,6 +62,8 @@ class SpinBox : public Range {
 
 	void _line_edit_focus_exit();
 
+	void _set_line_edit_mouse_filter(MouseFilter p_filter);
+
 	inline void _adjust_width_for_icon(const Ref<Texture2D> &icon);
 
 protected:
@@ -87,6 +89,8 @@ public:
 
 	void set_prefix(const String &p_prefix);
 	String get_prefix() const;
+
+	void set_mouse_filter(MouseFilter p_filter);
 
 	void apply();
 


### PR DESCRIPTION
Fixes #36632 

The `mouse_filter` property of `SpinBox` is synchronized with `SpinBox::line_edit`. It was implemented by overriding `Control::set_mouse_filter` setter in `SpinBox` and forwarding `p_filter` of `Setter::set_mouse_filter` to `SpinBox::set_line_edit_mouse_filter`

Changes made
* Change `Control::set_mouse_filter` to virtual method.
* Override `Control::set_mouse_filter` as `SpinBox::set_mouse_filter`
* Added `SpinBox::_set_line_edit_mouse_filter` and call it in `SpinBox::set_mouse_filter` and in `SpinBox::SpinBox`
