### PR TITLE
Implement undo-redo feature for Parameter Paste in the Inspector

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -435,10 +435,14 @@ void EditorData::restore_editor_global_states() {
 
 void EditorData::paste_object_params(Object *p_object) {
 
+	ERR_FAIL_NULL(p_object);
+	undo_redo.create_action(TTR("Paste Params"));
 	for (List<PropertyData>::Element *E = clipboard.front(); E; E = E->next()) {
-
-		p_object->set(E->get().name, E->get().value);
+		String name = E->get().name;
+		undo_redo.add_do_property(p_object, name, E->get().value);
+		undo_redo.add_undo_property(p_object, name, p_object->get(name));
 	}
+	undo_redo.commit_action();
 }
 
 bool EditorData::call_build() {

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -76,7 +76,6 @@ void InspectorDock::_menu_option(int p_option) {
 			editor_data->apply_changes_in_editors();
 			if (current)
 				editor_data->paste_object_params(current);
-			editor_data->get_undo_redo().clear_history();
 		} break;
 
 		case OBJECT_UNIQUE_RESOURCES: {


### PR DESCRIPTION
Fixes #36610 

`EditorData::undo_redo.add_do_property` and `EditorData::undo_redo.add_undo_property` is used in `EditorData::paste_object_params` to implement this feature. 
It's action name is set to `"Paste Params"`

Changes made
* Removed the call for clearing the history on paste params case.
* Instead of directly setting the properties value, EditorData::undo_redo is used.