### PR TITLE
Fixes a crash on startup

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -63,7 +63,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanContext::_debug_messenger_callback(VkDebugU
 	if (strstr(pCallbackData->pMessage, "wrong ELF class: ELFCLASS32") != NULL) {
 		return VK_FALSE;
 	}
-	if (strstr(pCallbackData->pMessageIdName, "UNASSIGNED-CoreValidation-DrawState-ClearCmdBeforeDraw") != NULL) {
+	if (pCallbackData->pMessageIdName && strstr(pCallbackData->pMessageIdName, "UNASSIGNED-CoreValidation-DrawState-ClearCmdBeforeDraw") != NULL) {
 		return VK_FALSE;
 	}
 


### PR DESCRIPTION
This adds a null check of `pCallbackData->pMessageIdName` in the debug callback of vulkan context.

---

Godot at the current master (https://github.com/godotengine/godot/commit/8ffa35e44f93321d618b81ec48817f5de8668a83)  always crashes on startup. (macOS 10.15.3 with homebrewed MoltenVK 1.0.40)

<details><summary>The Backtrace</summary>

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x00007fff64d46931 libsystem_platform.dylib`_platform_strstr + 42
    frame #1: 0x00000001013cf43d godot.osx.tools.64`__libcpp_strstr(__s1=0x0000000000000000, __s2="UNASSIGNED-CoreValidation-DrawState-ClearCmdBeforeDraw") at string.h:102:74
    frame #2: 0x00000001013c952d godot.osx.tools.64`strstr(__s1=0x0000000000000000, __s2="UNASSIGNED-CoreValidation-DrawState-ClearCmdBeforeDraw") [enable_if:true] at string.h:104:64
  * frame #3: 0x00000001013c8367 godot.osx.tools.64`VulkanContext::_debug_messenger_callback(messageSeverity=VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, messageType=2147483647, pCallbackData=0x00007ffeefbf8858, pUserData=0x000000010a8cf810) at vulkan_context.cpp:66:6
    frame #4: 0x0000000111026f3c libMoltenVK.dylib`MVKInstance::debugUtilsMessage(VkDebugUtilsMessageSeverityFlagBitsEXT, unsigned int, VkDebugUtilsMessengerCallbackDataEXT const*) + 156
    frame #5: 0x0000000111027172 libMoltenVK.dylib`MVKInstance::debugReportMessage(MVKVulkanAPIObject*, int, char const*) + 402
    frame #6: 0x000000011101801a libMoltenVK.dylib`MVKBaseObject::reportMessage(MVKBaseObject*, int, char const*, __va_list_tag*) + 650
    frame #7: 0x000000011101826f libMoltenVK.dylib`MVKBaseObject::reportError(MVKBaseObject*, VkResult, char const*, __va_list_tag*) + 159
    frame #8: 0x00000001110181b2 libMoltenVK.dylib`MVKBaseObject::reportError(VkResult, char const*, ...) + 130
    frame #9: 0x00000001110cd9a3 libMoltenVK.dylib`MVKMetalCompiler::handleError() + 131
    frame #10: 0x00000001110cd849 libMoltenVK.dylib`MVKMetalCompiler::compile(std::__1::unique_lock<std::__1::mutex>&, void () block_pointer) + 665
    frame #11: 0x00000001110c8e74 libMoltenVK.dylib`MVKShaderLibraryCompiler::newMTLLibrary(NSString*) + 100
    frame #12: 0x00000001110c8d28 libMoltenVK.dylib`MVKShaderLibrary::MVKShaderLibrary(MVKVulkanAPIDeviceObject*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mvk::SPIRVToMSLConversionResults const&) + 536
    frame #13: 0x00000001110c9939 libMoltenVK.dylib`MVKShaderLibraryCache::addShaderLibrary(mvk::SPIRVToMSLConversionConfiguration*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mvk::SPIRVToMSLConversionResults const&) + 57
    frame #14: 0x00000001110c9f97 libMoltenVK.dylib`MVKShaderModule::getMTLFunction(mvk::SPIRVToMSLConversionConfiguration*, VkSpecializationInfo const*, MVKPipelineCache*) + 615
    frame #15: 0x000000011109236a libMoltenVK.dylib`MVKComputePipeline::getMTLFunction(VkComputePipelineCreateInfo const*) + 378
    frame #16: 0x0000000111091e87 libMoltenVK.dylib`MVKComputePipeline::MVKComputePipeline(MVKDevice*, MVKPipelineCache*, MVKPipeline*, VkComputePipelineCreateInfo const*) + 263
    frame #17: 0x000000011107de69 libMoltenVK.dylib`VkResult MVKDevice::createPipelines<MVKComputePipeline, VkComputePipelineCreateInfo>(VkPipelineCache_T*, unsigned int, VkComputePipelineCreateInfo const*, VkAllocationCallbacks const*, VkPipeline_T**) + 137
    frame #18: 0x000000011101a0b5 libMoltenVK.dylib`vkCreateComputePipelines + 85
    frame #19: 0x00000001014032d3 godot.osx.tools.64`vkCreateComputePipelines(device=0x000000010b008a18, pipelineCache=0x0000000000000000, createInfoCount=1, pCreateInfos=0x00007ffeefbf9920, pAllocator=0x0000000000000000, pPipelines=0x00007ffeefbf9910) at trampoline.c:1287:12
    frame #20: 0x0000000101384a0e godot.osx.tools.64`RenderingDeviceVulkan::compute_pipeline_create(this=0x000000010988a410, p_shader=(_id = 365072220206)) at rendering_device_vulkan.cpp:5139:17
    frame #21: 0x00000001032895b0 godot.osx.tools.64`RasterizerEffectsRD::RasterizerEffectsRD(this=0x000000010b00eda0) at rasterizer_effects_rd.cpp:1022:47
    frame #22: 0x000000010328a1b5 godot.osx.tools.64`RasterizerEffectsRD::RasterizerEffectsRD(this=0x000000010b00eda0) at rasterizer_effects_rd.cpp:804:44
    frame #23: 0x00000001032f3770 godot.osx.tools.64`RasterizerStorageRD::RasterizerStorageRD(this=0x000000010b00e810) at rasterizer_storage_rd.cpp:4448:22
    frame #24: 0x00000001032f6105 godot.osx.tools.64`RasterizerStorageRD::RasterizerStorageRD(this=0x000000010b00e810) at rasterizer_storage_rd.cpp:4448:44
    frame #25: 0x000000010328d895 godot.osx.tools.64`RasterizerRD::RasterizerRD(this=0x000000010960ad00) at rasterizer_rd.cpp:174:12
    frame #26: 0x000000010328da55 godot.osx.tools.64`RasterizerRD::RasterizerRD(this=0x000000010960ad00) at rasterizer_rd.cpp:170:30
    frame #27: 0x0000000100016155 godot.osx.tools.64`RasterizerRD::_create_current() at rasterizer_rd.h:81:10
    frame #28: 0x000000010317b5ea godot.osx.tools.64`Rasterizer::create() at rasterizer.cpp:67:9
    frame #29: 0x00000001031e31f0 godot.osx.tools.64`VisualServerRaster::VisualServerRaster(this=0x00000001094ca500) at visual_server_raster.cpp:252:20
    frame #30: 0x00000001031e3395 godot.osx.tools.64`VisualServerRaster::VisualServerRaster(this=0x00000001094ca500) at visual_server_raster.cpp:247:42
    frame #31: 0x000000010000a80e godot.osx.tools.64`OS_OSX::initialize(this=0x00007ffeefbfe3e8, p_desired=0x0000000104d63e58, p_video_driver=0, p_audio_driver=0) at os_osx.mm:1620:18
    frame #32: 0x0000000100045155 godot.osx.tools.64`Main::setup2(p_main_tid_override=0) at main.cpp:1224:35
    frame #33: 0x0000000100044591 godot.osx.tools.64`Main::setup(execpath="/Users/timothy/repos/godot/bin/godot.osx.tools.64", argc=0, argv=0x00007ffeefbff768, p_second_phase=true) at main.cpp:1166:10
    frame #34: 0x000000010001de9d godot.osx.tools.64`main(argc=1, argv=0x00007ffeefbff760) at godot_main_osx.mm:70:9
    frame #35: 0x00007fff64b4f7fd libdyld.dylib`start + 1
```

</details>

The `strstr` call here uses `pMessageIdName` directly without a null check:
https://github.com/godotengine/godot/blob/8ffa35e44f93321d618b81ec48817f5de8668a83/drivers/vulkan/vulkan_context.cpp#L66-L68

According to [this man page](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessengerCallbackDataEXT.html#VUID-VkDebugUtilsMessengerCallbackDataEXT-pMessageIdName-parameter), `pMessageIdName` may be `NULL` (and `pMessage` is always not-null, so a null check is not necessary):

> * If `pMessageIdName` is not `NULL`, `pMessageIdName` must be a null-terminated UTF-8 string
> * `pMessage` must be a null-terminated UTF-8 string