### PR TITLE
Improve the plugin editor UX

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -542,7 +542,7 @@ void EditorNode::_on_plugin_ready(Object *p_script, const String &p_activate_nam
 	if (p_activate_name.length()) {
 		set_addon_plugin_enabled(p_activate_name, true);
 	}
-	project_settings->update_plugins();
+	project_settings->refresh_plugins();
 	project_settings->hide();
 	push_item(script.operator->());
 }

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -41,14 +41,14 @@
 void EditorPluginSettings::_notification(int p_what) {
 
 	if (p_what == MainLoop::NOTIFICATION_WM_FOCUS_IN) {
-		update_plugins();
+		refresh_plugins();
 	} else if (p_what == Node::NOTIFICATION_READY) {
 		plugin_config_dialog->connect_compat("plugin_ready", EditorNode::get_singleton(), "_on_plugin_ready");
 		plugin_list->connect("button_pressed", callable_mp(this, &EditorPluginSettings::_cell_button_pressed));
 	}
 }
 
-void EditorPluginSettings::update_plugins() {
+void EditorPluginSettings::refresh_plugins() {
 
 	plugin_list->clear();
 
@@ -216,9 +216,9 @@ EditorPluginSettings::EditorPluginSettings() {
 	create_plugin = memnew(Button(TTR("Create")));
 	create_plugin->connect("pressed", callable_mp(this, &EditorPluginSettings::_create_clicked));
 	title_hb->add_child(create_plugin);
-	update_list = memnew(Button(TTR("Update")));
-	update_list->connect("pressed", callable_mp(this, &EditorPluginSettings::update_plugins));
-	title_hb->add_child(update_list);
+	refresh_list = memnew(Button(TTR("Refresh")));
+	refresh_list->connect("pressed", callable_mp(this, &EditorPluginSettings::refresh_plugins));
+	title_hb->add_child(refresh_list);
 	add_child(title_hb);
 
 	plugin_list = memnew(Tree);

--- a/editor/editor_plugin_settings.h
+++ b/editor/editor_plugin_settings.h
@@ -47,7 +47,7 @@ class EditorPluginSettings : public VBoxContainer {
 
 	PluginConfigDialog *plugin_config_dialog;
 	Button *create_plugin;
-	Button *update_list;
+	Button *refresh_list;
 	Tree *plugin_list;
 	bool updating;
 
@@ -61,7 +61,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void update_plugins();
+	void refresh_plugins();
 
 	EditorPluginSettings();
 };

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -820,12 +820,12 @@ void ProjectSettingsEditor::popup_project_settings() {
 	globals_editor->update_category_list();
 	_update_translations();
 	autoload_settings->update_autoload();
-	plugin_settings->update_plugins();
+	plugin_settings->refresh_plugins();
 	set_process_unhandled_input(true);
 }
 
-void ProjectSettingsEditor::update_plugins() {
-	plugin_settings->update_plugins();
+void ProjectSettingsEditor::refresh_plugins() {
+	plugin_settings->refresh_plugins();
 }
 
 void ProjectSettingsEditor::_item_selected(const String &p_path) {

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -191,7 +191,7 @@ public:
 	static ProjectSettingsEditor *get_singleton() { return singleton; }
 	void popup_project_settings();
 	void set_plugins_page();
-	void update_plugins();
+	void refresh_plugins();
 
 	EditorAutoloadSettings *get_autoload_settings() { return autoload_settings; }
 


### PR DESCRIPTION
- Make the subfolder path and script path optional.
  - If empty, the default subfolder path will be the plugin name converted to `snake_case`.
  - If empty, the script path will be `plugin.<ext>` where `<ext>` is the extension of the script language chosen.
- Add tooltips to all fields.
- Align labels to the right to be closer to the text fields.
- Rename the "Update" button to "Refresh" in the plugin list as it doesn't actually update plugins, just refresh the list.

Creating plugins has never been faster. Now, you just need to fill in the **Plugin Name** field and you're good to go :slightly_smiling_face: 

See #36636.

## Preview

![image](https://user-images.githubusercontent.com/180032/75612685-38ea8580-5b26-11ea-9810-cef6047770b1.png)