### PR TITLE
Script template should have a type requirement (Issue #36605)

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "gdscript.h"
 
+#include "core/class_db.h"
 #include "core/engine.h"
 #include "core/global_constants.h"
 #include "core/os/file_access.h"
@@ -87,17 +88,20 @@ Ref<Script> GDScriptLanguage::get_template(const String &p_class_name, const Str
 					   "\n"
 					   "# Declare member variables here. Examples:\n"
 					   "# var a%INT_TYPE% = 2\n"
-					   "# var b%STRING_TYPE% = \"text\"\n"
-					   "\n"
-					   "\n"
-					   "# Called when the node enters the scene tree for the first time.\n"
-					   "func _ready()%VOID_RETURN%:\n"
-					   "%TS%pass # Replace with function body.\n"
-					   "\n"
-					   "\n"
-					   "# Called every frame. 'delta' is the elapsed time since the previous frame.\n"
-					   "#func _process(delta%FLOAT_TYPE%)%VOID_RETURN%:\n"
-					   "#%TS%pass\n";
+					   "# var b%STRING_TYPE% = \"text\"\n";
+
+	if (ClassDB::is_parent_class(p_base_class_name, "Node")) {
+		_template = _template +
+					"\n"
+					"# Called when the node enters the scene tree for the first time.\n"
+					"func _ready()%VOID_RETURN%:\n"
+					"%TS%pass # Replace with function body.\n"
+					"\n"
+					"\n"
+					"# Called every frame. 'delta' is the elapsed time since the previous frame.\n"
+					"#func _process(delta%FLOAT_TYPE%)%VOID_RETURN%:\n"
+					"#%TS%pass\n";
+	}
 
 	_template = _get_processed_template(_template, p_base_class_name);
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -33,6 +33,7 @@
 #include <mono/metadata/threads.h>
 #include <stdint.h>
 
+#include "core/class_db.h"
 #include "core/io/json.h"
 #include "core/os/file_access.h"
 #include "core/os/mutex.h"
@@ -330,20 +331,25 @@ Ref<Script> CSharpLanguage::get_template(const String &p_class_name, const Strin
 							 "{\n"
 							 "    // Declare member variables here. Examples:\n"
 							 "    // private int a = 2;\n"
-							 "    // private string b = \"text\";\n"
-							 "\n"
-							 "    // Called when the node enters the scene tree for the first time.\n"
-							 "    public override void _Ready()\n"
-							 "    {\n"
-							 "        \n"
-							 "    }\n"
-							 "\n"
-							 "//  // Called every frame. 'delta' is the elapsed time since the previous frame.\n"
-							 "//  public override void _Process(float delta)\n"
-							 "//  {\n"
-							 "//      \n"
-							 "//  }\n"
-							 "}\n";
+							 "    // private string b = \"text\";\n";
+
+	if (ClassDB::is_parent_class(p_base_class_name, "Node")) {
+		script_template = script_template +
+						  "\n"
+						  "    // Called when the node enters the scene tree for the first time.\n"
+						  "    public override void _Ready()\n"
+						  "    {\n"
+						  "        \n"
+						  "    }\n"
+						  "\n"
+						  "//  // Called every frame. 'delta' is the elapsed time since the previous frame.\n"
+						  "//  public override void _Process(float delta)\n"
+						  "//  {\n"
+						  "//      \n"
+						  "//  }\n";
+	}
+
+	script_template = script_template + "}\n";
 
 	String base_class_name = get_base_class_name(p_base_class_name, p_class_name);
 	script_template = script_template.replace("%BASE%", base_class_name)


### PR DESCRIPTION
If a script doesn't inherit "Node", then functions _ready and _process will not be in the script template. (As pointed out [here](https://github.com/godotengine/godot/issues/36605#issuecomment-592949894) they are completely unnecessary)