### PR TITLE
Remove minimum size for shadow atlas

### DIFF
--- a/servers/visual/rasterizer_rd/rasterizer_scene_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_rd.cpp
@@ -886,7 +886,6 @@ void RasterizerSceneRD::shadow_atlas_set_size(RID p_atlas, int p_size) {
 	ERR_FAIL_COND(!shadow_atlas);
 	ERR_FAIL_COND(p_size < 0);
 	p_size = next_power_of_2(p_size);
-	p_size = MAX(p_size, 1 << roughness_layers); // TODO: use a number related to shadows rather than reflections
 
 	if (p_size == shadow_atlas->size)
 		return;


### PR DESCRIPTION
This fixes the 2 framebuffers leaked and 2 textures leaked error message when closing an empty project. Now there should be no leaks when opening and closing empty projects. There are still leaks from specific elements in projects though.

This was causing shadow atlases to be given a minimum size of 64x64. However, in order to properly free the atlases ``free()`` was calling ``shadow_atlas_set_size(shadow_atlas, 0)``. This resulted in an extra shadow atlas being created instead of removing the existing one. 

``roughness_layers`` is only used for reflections. I see no reason why it should be used to calculate a minimum size for shadows. 