### PR TITLE
Compilation fixes on Android

### DIFF
--- a/core/rid_owner.h
+++ b/core/rid_owner.h
@@ -298,7 +298,11 @@ public:
 			if (description) {
 				print_error("ERROR: " + itos(alloc_count) + " RID allocations of type '" + description + "' were leaked at exit.");
 			} else {
+#ifdef NO_SAFE_CAST
+				print_error("ERROR: " + itos(alloc_count) + " RID allocations of type 'unknown' were leaked at exit.");
+#else
 				print_error("ERROR: " + itos(alloc_count) + " RID allocations of type '" + typeid(T).name() + "' were leaked at exit.");
+#endif
 			}
 
 			for (size_t i = 0; i < max_alloc; i++) {

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -328,13 +328,13 @@ AudioDriver::SpeakerMode AudioDriverOpenSL::get_speaker_mode() const {
 
 void AudioDriverOpenSL::lock() {
 
-	if (active && mutex)
+	if (active)
 		mutex.lock();
 }
 
 void AudioDriverOpenSL::unlock() {
 
-	if (active && mutex)
+	if (active)
 		mutex.unlock();
 }
 

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -205,7 +205,6 @@ def configure(env):
 
     env.Append(CPPFLAGS=["-isystem", env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/llvm-libc++/include"])
     env.Append(CPPFLAGS=["-isystem", env["ANDROID_NDK_ROOT"] + "/sources/cxx-stl/llvm-libc++abi/include"])
-    env.Append(CXXFLAGS=["-std=gnu++14"])
 
     # Disable exceptions and rtti on non-tools (template) builds
     if env['tools']:

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -187,7 +187,7 @@ jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_a
 			Vector<int> array = *p_arg;
 			jintArray arr = env->NewIntArray(array.size());
 			const int *r = array.ptr();
-			env->SetIntArrayRegion(arr, 0, array.size(), r.ptr());
+			env->SetIntArrayRegion(arr, 0, array.size(), r);
 			v.val.l = arr;
 			v.obj = arr;
 
@@ -196,7 +196,7 @@ jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_a
 			Vector<uint8_t> array = *p_arg;
 			jbyteArray arr = env->NewByteArray(array.size());
 			const uint8_t *r = array.ptr();
-			env->SetByteArrayRegion(arr, 0, array.size(), reinterpret_cast<const signed char *>(r.ptr()));
+			env->SetByteArrayRegion(arr, 0, array.size(), reinterpret_cast<const signed char *>(r));
 			v.val.l = arr;
 			v.obj = arr;
 
@@ -206,7 +206,7 @@ jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_a
 			Vector<float> array = *p_arg;
 			jfloatArray arr = env->NewFloatArray(array.size());
 			const float *r = array.ptr();
-			env->SetFloatArrayRegion(arr, 0, array.size(), r.ptr());
+			env->SetFloatArrayRegion(arr, 0, array.size(), r);
 			v.val.l = arr;
 			v.obj = arr;
 
@@ -293,8 +293,7 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 		sarr.resize(fCount);
 
 		int *w = sarr.ptrw();
-		env->GetIntArrayRegion(arr, 0, fCount, w.ptr());
-		w.release();
+		env->GetIntArrayRegion(arr, 0, fCount, w);
 		return sarr;
 	};
 
@@ -306,8 +305,7 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 		sarr.resize(fCount);
 
 		uint8_t *w = sarr.ptrw();
-		env->GetByteArrayRegion(arr, 0, fCount, reinterpret_cast<signed char *>(w.ptr()));
-		w.release();
+		env->GetByteArrayRegion(arr, 0, fCount, reinterpret_cast<signed char *>(w));
 		return sarr;
 	};
 
@@ -332,7 +330,7 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 
 			double n;
 			env->GetDoubleArrayRegion(arr, i, 1, &n);
-			w.ptr()[i] = n;
+			w[i] = n;
 		};
 		return sarr;
 	};
@@ -350,7 +348,7 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 
 			float n;
 			env->GetFloatArrayRegion(arr, i, 1, &n);
-			w.ptr()[i] = n;
+			w[i] = n;
 		};
 		return sarr;
 	};
@@ -518,8 +516,7 @@ public:
 				sarr.resize(fCount);
 
 				int *w = sarr.ptrw();
-				env->GetIntArrayRegion(arr, 0, fCount, w.ptr());
-				w.release();
+				env->GetIntArrayRegion(arr, 0, fCount, w);
 				ret = sarr;
 				env->DeleteLocalRef(arr);
 			} break;
@@ -532,8 +529,7 @@ public:
 				sarr.resize(fCount);
 
 				float *w = sarr.ptrw();
-				env->GetFloatArrayRegion(arr, 0, fCount, w.ptr());
-				w.release();
+				env->GetFloatArrayRegion(arr, 0, fCount, w);
 				ret = sarr;
 				env->DeleteLocalRef(arr);
 			} break;
@@ -1354,7 +1350,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_method(JNIEnv *env, j
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_callobject(JNIEnv *env, jobject p_obj, jint ID, jstring method, jobjectArray params) {
 
-	Object *obj = ObjectDB::get_instance(ID);
+	Object *obj = ObjectDB::get_instance(ObjectID((uint64_t)ID));
 	ERR_FAIL_COND(!obj);
 
 	int res = env->PushLocalFrame(16);
@@ -1386,7 +1382,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_callobject(JNIEnv *en
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_calldeferred(JNIEnv *env, jobject p_obj, jint ID, jstring method, jobjectArray params) {
 
-	Object *obj = ObjectDB::get_instance(ID);
+	Object *obj = ObjectDB::get_instance(ObjectID((uint64_t)ID));
 	ERR_FAIL_COND(!obj);
 
 	int res = env->PushLocalFrame(16);


### PR DESCRIPTION
Several compilation fixes on Android platform.

NB: Some changes around Vulkan support are still needed for the codebase to compile and link.

List of fixed errors:
- typeid usage with compilation flag `-fno-rtti`
```
core/rid_owner.h:301:80: error: use of typeid requires -frtti
    print_error("ERROR: " + itos(alloc_count) + " RID allocations of type '" + typeid(T).name() + "' were leaked at exit.");
```

- GLES2 initialization code when OpenGL is disabled
```
drivers/gles2/rasterizer_storage_gles2.h:41:10: fatal error: 'shaders/copy.glsl.gen.h' file not found
    #include "shaders/copy.glsl.gen.h"
```

- Mutex changes (requires c++17 for template argument deduction)
```
servers/visual/visual_server_wrap_mt.h:122:2: error: use of class template 'MutexLock' requires template arguments
    FUNCRID(shader)
servers/server_wrap_mt_common.h:60:4: note: expanded from macro 'FUNCRID'
    MutexLock lock(alloc_mutex);
core/os/mutex.h:60:7: note: template is declared here
    class MutexLock {
```

- Vector changes
```
platform/android/java_godot_lib_jni.cpp:190:50: error: member reference base type 'const int *' is not a structure or union
    env->SetIntArrayRegion(arr, 0, array.size(), r.ptr());      
platform/android/java_godot_lib_jni.cpp:310:4: error: member reference base type 'uint8_t *' (aka 'unsigned char *') is not a structure or union
    w.release();
```

- ObjectDB changes
```
platform/android/java_godot_lib_jni.cpp:1353:39: error: no viable conversion from 'jint' (aka 'int') to 'ObjectID'
    Object *obj = ObjectDB::get_instance(ID);
core/object_id.h:41:7: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'jint' (aka 'int') to 'const ObjectID &' for 1st argument
    class ObjectID {
core/object_id.h:41:7: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'jint' (aka 'int') to 'ObjectID &&' for 1st argument
core/object.h:790:55: note: passing argument to parameter 'p_instance_id' here
    _ALWAYS_INLINE_ static Object *get_instance(ObjectID p_instance_id) {
```