### PR TITLE
Check Windows SDK version to use '/permissive-' flag only when supported

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -330,7 +330,13 @@ if selected_platform in platform_list:
     else:
         # MSVC doesn't have clear C standard support, /std only covers C++.
         # We apply it to CCFLAGS (both C and C++ code) in case it impacts C features.
-        env.Prepend(CCFLAGS=['/std:c++17', '/permissive-'])
+        sdk_version = os.getenv("WindowsSDKVersion")
+        if (not sdk_version) or (methods.compare_version(sdk_version, "10.0.16299.0") >= 0):
+            env.Prepend(CCFLAGS=['/std:c++17', '/permissive-'])
+        else:
+            print("The current Windows SDK version doesn't support '/permissive-' flag, "
+                  "it will be disabled.")
+            env.Prepend(CCFLAGS=['/std:c++17'])
 
     # Enforce our minimal compiler version requirements
     cc_version = methods.get_compiler_version(env) or [-1, -1]

--- a/methods.py
+++ b/methods.py
@@ -573,6 +573,17 @@ def get_compiler_version(env):
     else:
         return None
 
+def compare_version(ver1, ver2):
+    """
+    Takes two strings that represent version numbers of any size, separated with dots.
+    Returns 1 if ver1 > ver2, -1 if ver1 < ver2, and 0 if ver1 == ver2.
+    """
+    def normalize(v):
+        return [int(re.sub(r'[^0-9]', '', x)) for x in re.sub(r'(\.0+)*$','', v).split(".")]
+    def cmp(a, b):
+        return (a > b) - (a < b) 
+    return cmp(normalize(ver1), normalize(ver2))
+
 def using_gcc(env):
     return 'gcc' in os.path.basename(env["CC"])
 


### PR DESCRIPTION
When building on Windows, this change makes sure we don't set '/permissive-' flag with older Windows SDK that don't support it and cause compilation errors in some sdk headers.

Fixes #36671