### PR TITLE
Improve keyboard navigation for dropdown menus

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -213,48 +213,56 @@ void PopupMenu::_scroll(float p_factor, const Point2 &p_over) {
 	_gui_input(ie);
 }
 
+void PopupMenu::_move_selection(int p_from_position, int p_direction) {
+
+	int search_from = p_from_position + p_direction;
+	int direction = p_direction;
+	if (search_from >= items.size()) {
+		search_from = 0;
+		direction = -1;
+	} else if (search_from < 0) {
+		search_from = items.size() - 1;
+		direction = 1;
+	}
+
+	for (int i = search_from; i < items.size(); i += direction) {
+
+		if (i < 0 || i >= items.size())
+			continue;
+
+		if (!items[i].separator && !items[i].disabled) {
+
+			mouse_over = i;
+			emit_signal("id_focused", i);
+			int vseparation = get_constant("vseparation");
+			Ref<Font> font = get_font("font");
+			float dy = (vseparation + font->get_height()) * get_global_transform().get_scale().y;
+
+			Point2 new_selected_position = Point2(10, dy * mouse_over);
+			Point2 global_selected_position = (get_global_position() + new_selected_position) * get_global_transform().get_scale();
+			if (direction == 1 && global_selected_position.y + dy + vseparation > get_viewport_rect().size.y) {
+				set_position(Point2(get_position().x, get_viewport_rect().size.y - new_selected_position.y - dy - vseparation * 2));
+			} else if (direction == -1 && global_selected_position.y < 0) {
+				set_position(Point2(get_position().x, -new_selected_position.y));
+			}
+			update();
+			accept_event();
+
+			break;
+		}
+	}
+}
+
 void PopupMenu::_gui_input(const Ref<InputEvent> &p_event) {
 
 	if (p_event->is_action("ui_down") && p_event->is_pressed()) {
-
-		int search_from = mouse_over + 1;
-		if (search_from >= items.size())
-			search_from = 0;
-
-		for (int i = search_from; i < items.size(); i++) {
-
-			if (i < 0 || i >= items.size())
-				continue;
-
-			if (!items[i].separator && !items[i].disabled) {
-
-				mouse_over = i;
-				emit_signal("id_focused", i);
-				update();
-				accept_event();
-				break;
-			}
-		}
+		_move_selection(mouse_over, 1);
 	} else if (p_event->is_action("ui_up") && p_event->is_pressed()) {
-
-		int search_from = mouse_over - 1;
-		if (search_from < 0)
-			search_from = items.size() - 1;
-
-		for (int i = search_from; i >= 0; i--) {
-
-			if (i >= items.size())
-				continue;
-
-			if (!items[i].separator && !items[i].disabled) {
-
-				mouse_over = i;
-				emit_signal("id_focused", i);
-				update();
-				accept_event();
-				break;
-			}
-		}
+		_move_selection(mouse_over, -1);
+	} else if ((p_event->is_action("ui_page_down") || p_event->is_action("ui_end")) && p_event->is_pressed()) {
+		_move_selection(-1, -1);
+	} else if ((p_event->is_action("ui_page_up") || p_event->is_action("ui_home")) && p_event->is_pressed()) {
+		_move_selection(items.size(), 1);
 	} else if (p_event->is_action("ui_left") && p_event->is_pressed()) {
 
 		Node *n = get_parent();

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -89,6 +89,7 @@ class PopupMenu : public Popup {
 	int _get_mouse_over(const Point2 &p_over) const;
 	virtual Size2 get_minimum_size() const;
 	void _scroll(float p_factor, const Point2 &p_over);
+	void _move_selection(int p_from_position, int p_direction);
 	void _gui_input(const Ref<InputEvent> &p_event);
 	void _activate_submenu(int over);
 	void _submenu_timeout();


### PR DESCRIPTION
Now the cursor is always visible when navigating large popup menus with the keyboard, it doesn't move off screen.
You can now jump to the first / last position with home / end or pageup / pagedown.

**Showcase**:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/28286961/75615812-1f0e6a00-5b49-11ea-816d-316fbae46445.gif)
I am using arrow keys if the mouse is not moving, then I am using the home / end buttons.

The diff is a bit weird because I moved some duplicate code into a function.