### PR TITLE
Fix inverted use of Camera2D.offset_v

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -128,9 +128,9 @@ Transform2D Camera2D::get_camera_transform() {
 			} else {
 
 				if (v_ofs < 0) {
-					camera_pos.y = new_camera_pos.y + screen_size.y * 0.5 * drag_margin[MARGIN_TOP] * v_ofs;
-				} else {
 					camera_pos.y = new_camera_pos.y + screen_size.y * 0.5 * drag_margin[MARGIN_BOTTOM] * v_ofs;
+				} else {
+					camera_pos.y = new_camera_pos.y + screen_size.y * 0.5 * drag_margin[MARGIN_TOP] * v_ofs;
 				}
 
 				v_offset_changed = false;


### PR DESCRIPTION
The code above for horizontal movement uses the right margin (_positive_ x direction) when the offset is negative, but vertical movement uses the top margin (_negative_ y direction) when the offset is negative.

The resulting problem is easily seen in the editor — set the drag margins to be asymmetrical, turn on drawing the drag margins, and slide the offsets from -1 to 1 and back.  The horizontal offset moves the camera's center between the left and right margins, but the vertical offset gets them backwards and will move the camera outside the margins entirely.

Seems to have always been the case, and no one ever noticed  :)