### PR TITLE
Improve cubemap importance sampling

### DIFF
--- a/servers/visual/rasterizer_rd/rasterizer_effects_rd.h
+++ b/servers/visual/rasterizer_rd/rasterizer_effects_rd.h
@@ -127,6 +127,8 @@ class RasterizerEffectsRD {
 		uint32_t sample_count;
 		float roughness;
 		uint32_t use_direct_write;
+		float face_size;
+		float pad[3];
 	};
 
 	struct CubemapRoughness {
@@ -134,7 +136,7 @@ class RasterizerEffectsRD {
 		CubemapRoughnessPushConstant push_constant;
 		CubemapRoughnessShaderRD shader;
 		RID shader_version;
-		RenderPipelineVertexFormatCacheRD pipelines[CUBEMAP_ROUGHNESS_SOURCE_MAX];
+		RID pipelines[CUBEMAP_ROUGHNESS_SOURCE_MAX];
 	} roughness;
 
 	struct SkyPushConstant {
@@ -418,7 +420,7 @@ public:
 	void gaussian_blur(RID p_source_rd_texture, RID p_framebuffer_half, RID p_rd_texture_half, RID p_dest_framebuffer, const Vector2 &p_pixel_size, const Rect2 &p_region);
 	void gaussian_glow(RID p_source_rd_texture, RID p_framebuffer_half, RID p_rd_texture_half, RID p_dest_framebuffer, const Vector2 &p_pixel_size, float p_strength = 1.0, bool p_first_pass = false, float p_luminance_cap = 16.0, float p_exposure = 1.0, float p_bloom = 0.0, float p_hdr_bleed_treshold = 1.0, float p_hdr_bleed_scale = 1.0, RID p_auto_exposure = RID(), float p_auto_exposure_grey = 1.0);
 
-	void cubemap_roughness(RID p_source_rd_texture, bool p_source_is_panorama, RID p_dest_framebuffer, uint32_t p_face_id, uint32_t p_sample_count, float p_roughness);
+	void cubemap_roughness(RID p_source_rd_texture, bool p_source_is_panorama, RID p_dest_framebuffer, uint32_t p_face_id, uint32_t p_sample_count, float p_roughness, float p_size);
 	void render_panorama(RD::DrawListID p_list, RenderingDevice::FramebufferFormatID p_fb_format, RID p_panorama, const CameraMatrix &p_camera, const Basis &p_orientation, float p_alpha, float p_multipler);
 	void make_mipmap(RID p_source_rd_texture, RID p_framebuffer_half, const Vector2 &p_pixel_size);
 	void copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_rect, float p_z_near, float p_z_far, float p_bias, bool p_dp_flip);

--- a/servers/visual/rasterizer_rd/rasterizer_scene_rd.h
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_rd.h
@@ -108,7 +108,7 @@ private:
 	void _clear_reflection_data(ReflectionData &rd);
 	void _update_reflection_data(ReflectionData &rd, int p_size, int p_mipmaps, bool p_use_array, RID p_base_cube, int p_base_layer, bool p_low_quality);
 	void _create_reflection_from_panorama(ReflectionData &rd, RID p_panorama, bool p_quality);
-	void _create_reflection_from_base_mipmap(ReflectionData &rd, bool p_use_arrays, bool p_quality, int p_cube_side);
+	void _create_reflection_from_base_mipmap(ReflectionData &rd, bool p_use_arrays, bool p_quality, int p_cube_side, int p_base_layer);
 	void _update_reflection_mipmaps(ReflectionData &rd, bool p_quality);
 
 	/* SKY */
@@ -165,6 +165,7 @@ private:
 
 		bool dirty = true;
 		bool rendering = false;
+		int processing_layer = 1;
 		int processing_side = 0;
 
 		uint32_t render_step = 0;


### PR DESCRIPTION
Ports the importance sampling implementation over to compute. This increases performance by about 10% and makes cubemap reflection computation way more flexible. 

Also changes the updated pattern for reflection probes set to ``UPDATE_ONCE``. Before it updated over 12 frames (capture each face in 1 frame, blur each face in 1 frame). Now it updates over 16 by default and it can change depending on roughness layers (capture each face in 1 frame, blur each face of the second mip level in 1 frame, then blue the entire cubemap for each layer of subsequent frames). The benefit of computing a layer at a time is that each layer can rely on the previous layer to blur much better.

A side effect of this change is that it is now fast enough to reset the reflection probe every 16 frames without affecting performance much (if you want 4 fps reflections). :)

I was going to substantially improve the importance sampling implementation, however after discussing with reduz, it became clear that my plans would conflict with the move to implementing sky shaders. So I will have to wait until after sky shaders are implemented before attempting any more. 