### PR TITLE
Force mipmaps off when importing RGBA4444 textures

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1458,6 +1458,8 @@ Error Image::generate_mipmaps(bool p_renormalize) {
 
 	ERR_FAIL_COND_V_MSG(!_can_modify(format), ERR_UNAVAILABLE, "Cannot generate mipmaps in compressed or custom image formats.");
 
+	ERR_FAIL_COND_V_MSG(format == FORMAT_RGBA4444, ERR_UNAVAILABLE, "Cannot generate mipmaps from RGBA4444 format.");
+
 	ERR_FAIL_COND_V_MSG(width == 0 || height == 0, ERR_UNCONFIGURED, "Cannot generate mipmaps with width or height equal to 0.");
 
 	int mmcount;

--- a/modules/etc/image_etc.cpp
+++ b/modules/etc/image_etc.cpp
@@ -106,9 +106,15 @@ static void _compress_etc(Image *p_img, float p_lossy_quality, bool force_etc1_f
 		// If VRAM compression is using ETC, but image has alpha, convert to RGBA4444 or LA8
 		// This saves space while maintaining the alpha channel
 		if (detected_channels == Image::USED_CHANNELS_RGBA) {
+			
+			if (p_img->has_mipmaps()) {
+				// Image doesn't support mipmaps with RGBA4444 textures
+				p_img->clear_mipmaps();
+			}
 			p_img->convert(Image::FORMAT_RGBA4444);
 			return;
 		} else if (detected_channels == Image::USE_CHANNELS_LA) {
+
 			p_img->convert(Image::FORMAT_LA8);
 			return;
 		}


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/36694, but for the master branch.

I left the entire section commented out. We can un-comment it when porting GLES2 and then the entire section will be available at once.

**Description:**
The issue here is that Image::generate_mipmaps() assumes that pixel data is in uint8 format. Because RGBA4444 uses only 4 bits per-channel, it cant use uint8. So when mipmaps are generated, they are generated with corrupted data.

This PR checks if mipmaps are selected when importing the texture and forces them off before converting to RGBA4444. I have also added an error message warning for the future.

I will make a follow up shortly for 4.0.

PR graciously donated by Gamblify. :)