### PR TITLE
Take correct part of extension with File Dialog

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -691,7 +691,7 @@ void EditorFileDialog::update_file_name() {
 		String base_name = file_str.get_basename();
 		Vector<String> filter_substr = filter_str.split(";");
 		if (filter_substr.size() >= 2) {
-			file_str = base_name + "." + filter_substr[1].strip_edges().to_lower();
+			file_str = base_name + "." + filter_substr[0].strip_edges().lstrip("*.").to_lower();
 		} else {
 			file_str = base_name + "." + filter_str.get_extension().strip_edges().to_lower();
 		}


### PR DESCRIPTION
It might be hard to believe, but Godot was never using correct part of Extension specifier while showing Save File Dialog in editor!
It was due to bug/typo - when the second part, after ';' was always used, instead of first (or zeroth) part - with actual literal of extension.

It actually was happening with more parts of the editor, mostly those which specify free-form String as a description to the extension, for example:

```c++
template_open->add_filter("*.tpz ; " + TTR("Godot Export Templates"));

fdialog->add_filter(vformat("project.godot ; %s %s", VERSION_NAME, TTR("Project")));

asset_open->add_filter("*.zip ; " + TTR("Assets ZIP File"));

file_templates->add_filter("*.tpz ; " + TTR("Template Package"));

and so on...
```

Thanks @AureaFUNSoft for finding that ancient bug, I am mostly amazed nobody noticed that before :)

Fixes #36697