### PR TITLE
Fix possible EditorFolding crash when switching scenes

### DIFF
--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -133,6 +133,8 @@ void EditorFolding::_fill_folds(const Node *p_root, const Node *p_node, Array &p
 }
 void EditorFolding::save_scene_folding(const Node *p_scene, const String &p_path) {
 
+	ERR_FAIL_NULL(p_scene);
+
 	FileAccessRef file_check = FileAccess::create(FileAccess::ACCESS_RESOURCES);
 	if (!file_check->file_exists(p_path)) //This can happen when creating scene from FilesystemDock. It has path, but no file.
 		return;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3279,7 +3279,7 @@ void EditorNode::_clear_undo_history() {
 void EditorNode::set_current_scene(int p_idx) {
 
 	//Save the folding in case the scene gets reloaded.
-	if (editor_data.get_scene_path(p_idx) != "")
+	if (editor_data.get_scene_path(p_idx) != "" && editor_data.get_edited_scene_root(p_idx))
 		editor_folding.save_scene_folding(editor_data.get_edited_scene_root(p_idx), editor_data.get_scene_path(p_idx));
 
 	if (editor_data.check_and_update_scene(p_idx)) {


### PR DESCRIPTION
Fix: #36408

there is a possibility that scene which has a path might not have a root ( delete the root after it created ) -> handled 👌 