### PR TITLE
GDScript duplicate arguments bug fixed

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3809,6 +3809,12 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 						}
 
 						StringName argname = tokenizer->get_token_identifier();
+						for (int i = 0; i < arguments.size(); i++) {
+							if (arguments[i] == argname) {
+								_set_error("The argument name \"" + String(argname) + "\" is defined multiple times.");
+								return;
+							}
+						}
 						arguments.push_back(argname);
 #ifdef DEBUG_ENABLED
 						arguments_usage.push_back(0);


### PR DESCRIPTION
Fix: #35206
and there was a typo in `core/error_macros.h` after the PR #33391 also fixed

![gdscirpt-dupliate-args-fix](https://user-images.githubusercontent.com/41085900/75628289-7f5ee380-5bfd-11ea-87f5-bdc2435a6a6e.JPG)


