### PR TITLE
Fix missing null check in Mono Binding of GD.print

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -83,7 +83,7 @@ namespace Godot
 
         public static void Print(params object[] what)
         {
-            godot_icall_GD_print(Array.ConvertAll(what, x => x.ToString()));
+            godot_icall_GD_print(Array.ConvertAll(what, x => x?.ToString()));
         }
 
         public static void PrintStack()


### PR DESCRIPTION
I noticed every other printing method had a null check but it was missing in `Print`.

For reference, the other null checks were added in PR #34142 to fix #34136.