### PR TITLE
Enum bug fixed

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -5120,7 +5120,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 
 						return;
 					} else { // tokenizer->is_token_literal(0, true)
-						StringName const_id = tokenizer->get_token_literal();
+						String const_id = tokenizer->get_token_literal();
 
 						tokenizer->advance();
 


### PR DESCRIPTION
Fix: #36672

![enum-fix](https://user-images.githubusercontent.com/41085900/75712023-4f8f0900-5ced-11ea-9fd0-bc0fcad3b446.JPG)

in godot/core/variant_op.cpp `get_property_list()`
```
...
case DICTIONARY: {

	const Dictionary *dic = reinterpret_cast<const Dictionary *>(_data._mem);
	List<Variant> keys;
	dic->get_key_list(&keys);
	for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
		if (E->get().get_type() == Variant::STRING) {
			p_list->push_back(PropertyInfo(Variant::STRING, E->get()));
		}
	}
} break;
```
if any value in a dictionary to be a property the key type must be Variant::STRING
but all those past versions enum keys are Variant::STRING_NAME and I've no idea how it worked in the past versions ( may be that was a bug, even though somehow it worked till the code refactor )

in godot/modules/gdscript/gdscript_parser.cpp `_parse_class()`
```
case GDScriptTokenizer::TK_CONSTANT: {
	if (tokenizer->get_token_constant().get_type() == Variant::STRING) {
		tokenizer->advance();
		// Ignore
	} else {
		_set_error(String() + "Unexpected constant of type: " + Variant::get_type_name(tokenizer->get_token_constant().get_type()));
		return;
	}
} break;
```
constant's type must be `Variant::STRING` not `Variant::STRING_NAME` so I've assumed enum name must be a String not StringName 

and now it works fine 👍 