### PR TITLE
Delay colorpick eyedrop preview using a timer

### DIFF
--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -69,6 +69,9 @@ private:
 	bool text_is_constructor = false;
 	int presets_per_row = 0;
 
+	Timer *mouse_not_moving_timer;
+	Ref<InputEventMouseMotion> mouse_not_moving_pos;
+
 	Color color;
 	bool raw_mode_enabled = false;
 	bool hsv_mode_enabled = false;
@@ -104,6 +107,7 @@ private:
 	void _html_focus_exit();
 
 protected:
+	void _mouse_not_moving_timer_timeout();
 	void _notification(int);
 	static void _bind_methods();
 


### PR DESCRIPTION
This avoids recalculating the color of the selected pixel every time the mouse is moved.

Fixes #25358.