### PR TITLE
Improve the GIProbe editor contextual label

### DIFF
--- a/editor/plugins/gi_probe_editor_plugin.cpp
+++ b/editor/plugins/gi_probe_editor_plugin.cpp
@@ -70,22 +70,33 @@ void GIProbeEditorPlugin::_notification(int p_what) {
 			return;
 		}
 
-		String text;
-
-		Vector3i size = gi_probe->get_estimated_cell_size();
-		text = itos(size.x) + ", " + itos(size.y) + ", " + itos(size.z);
+		const Vector3i size = gi_probe->get_estimated_cell_size();
+		String text = vformat(String::utf8("%d × %d × %d"), size.x, size.y, size.z);
 		int data_size = 4;
 		if (GLOBAL_GET("rendering/quality/gi_probes/anisotropic")) {
 			data_size += 4;
 		}
-		text += " - VRAM Size: " + String::num(size.x * size.y * size.z * data_size / (1024.0 * 1024.0), 2) + " Mb.";
+		const double size_mb = size.x * size.y * size.z * data_size / (1024.0 * 1024.0);
+		text += " - " + vformat(TTR("VRAM Size: %s MB"), String::num(size_mb, 2));
 
 		if (bake_info->get_text() == text) {
 			return;
 		}
 
-		bake_info->add_color_override("font_color", bake_info->get_color("success_color", "Editor"));
+		// Color the label depending on the estimated performance level.
+		Color color;
+		if (size_mb <= 16.0 + CMP_EPSILON) {
+			// Fast.
+			color = bake_info->get_color("success_color", "Editor");
+		} else if (size_mb <= 64.0 + CMP_EPSILON) {
+			// Medium.
+			color = bake_info->get_color("warning_color", "Editor");
+		} else {
+			// Slow.
+			color = bake_info->get_color("error_color", "Editor");
+		}
 
+		bake_info->add_color_override("font_color", color);
 		bake_info->set_text(text);
 	}
 }


### PR DESCRIPTION
- Change the label color depending on the estimated performance (green = fast, yellow = average, red = slow).
- Use the Unicode multiplication symbol.
- Make the label translatable.

The thresholds may be a bit too aggressive. Feel free to suggest better values :slightly_smiling_face: 