### PR TITLE
Animation Editor: Add options for displaying function call keys

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2287,20 +2287,23 @@ void AnimationTrackEdit::draw_key(int p_index, float p_pixels_sec, int p_x, bool
 		Dictionary d = animation->track_get_key_value(track, p_index);
 		String text;
 
-		if (d.has("method"))
+		if (d.has("method") && function_text_mode > 0)
 			text += String(d["method"]);
-		text += "(";
-		Vector<Variant> args;
-		if (d.has("args"))
-			args = d["args"];
-		for (int i = 0; i < args.size(); i++) {
 
-			if (i > 0)
-				text += ", ";
-			text += String(args[i]);
+		if (function_text_mode > 1) {
+			text += "(";
+			Vector<Variant> args;
+			if (d.has("args"))
+				args = d["args"];
+			for (int i = 0; i < args.size(); i++) {
+
+				if (i > 0)
+					text += ", ";
+				text += String(args[i]);
+			}
+			text += ")";
 		}
-		text += ")";
-
+		
 		int limit = MAX(0, p_clip_right - p_x - icon_to_draw->get_width());
 		if (limit > 0) {
 			draw_string(font, Vector2(p_x + icon_to_draw->get_width(), int(get_size().height - font->get_height()) / 2 + font->get_ascent()), text, color, limit);
@@ -3035,6 +3038,11 @@ void AnimationTrackEdit::cancel_drop() {
 		update();
 	}
 }
+
+void AnimationTrackEdit::set_function_text_mode(int p_value) {
+	function_text_mode = p_value;
+}
+
 void AnimationTrackEdit::set_in_group(bool p_enable) {
 	in_group = p_enable;
 	update();
@@ -3272,6 +3280,7 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim) {
 		step->set_read_only(false);
 		snap->set_disabled(false);
 		snap_mode->set_disabled(false);
+		function_text_mode_button->set_disabled(false);
 
 		imported_anim_warning->hide();
 		for (int i = 0; i < animation->get_track_count(); i++) {
@@ -3290,6 +3299,7 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim) {
 		step->set_read_only(true);
 		snap->set_disabled(true);
 		snap_mode->set_disabled(true);
+		function_text_mode_button->set_disabled(true);
 	}
 }
 
@@ -3337,6 +3347,7 @@ bool AnimationTrackEditor::has_keying() const {
 }
 Dictionary AnimationTrackEditor::get_state() const {
 	Dictionary state;
+	state["function_text_mode"] = function_text_mode;
 	state["fps_mode"] = timeline->is_using_fps();
 	state["zoom"] = zoom->get_value();
 	state["offset"] = timeline->get_value();
@@ -3344,6 +3355,14 @@ Dictionary AnimationTrackEditor::get_state() const {
 	return state;
 }
 void AnimationTrackEditor::set_state(const Dictionary &p_state) {
+	if (p_state.has("function_text_mode")) {
+		int text_mode = p_state["function_text_mode"];
+		_function_text_mode_changed(text_mode);
+		function_text_mode_button->select(text_mode);
+	} else {
+		_function_text_mode_changed(2);
+		function_text_mode_button->select(2);
+	}
 	if (p_state.has("fps_mode")) {
 		bool fps_mode = p_state["fps_mode"];
 		if (fps_mode) {
@@ -4201,6 +4220,8 @@ void AnimationTrackEditor::_update_tracks() {
 
 		track_edits.push_back(track_edit);
 
+		track_edit->set_function_text_mode(function_text_mode);
+
 		if (use_grouping) {
 			String base_path = animation->track_get_path(i);
 			base_path = base_path.get_slice(":", 0); // Remove sub-path.
@@ -4296,6 +4317,11 @@ void AnimationTrackEditor::_snap_mode_changed(int p_mode) {
 		key_edit->set_use_fps(p_mode == 1);
 	}
 	_update_step_spinbox();
+}
+
+void AnimationTrackEditor::_function_text_mode_changed(int p_mode) {
+	function_text_mode = p_mode;
+	_update_tracks();
 }
 
 void AnimationTrackEditor::_update_step_spinbox() {
@@ -5840,6 +5866,21 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	view_group->set_tooltip(TTR("Group tracks by node or display them as plain list."));
 
 	bottom_hb->add_child(view_group);
+
+	bottom_hb->add_child(memnew(VSeparator));
+
+	function_text_mode_label = memnew(Label);
+	function_text_mode_label->set_text(TTR("Function calls:") + " ");
+	bottom_hb->add_child(function_text_mode_label);
+
+	function_text_mode_button = memnew(OptionButton);
+	function_text_mode_button->add_item(TTR("None"));
+	function_text_mode_button->add_item(TTR("Name only"));
+	function_text_mode_button->add_item(TTR("Name and arguments"));
+	bottom_hb->add_child(function_text_mode_button);
+	function_text_mode_button->connect("item_selected", callable_mp(this, &AnimationTrackEditor::_function_text_mode_changed));
+	function_text_mode_button->set_disabled(true);
+
 	bottom_hb->add_child(memnew(VSeparator));
 
 	snap = memnew(ToolButton);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2303,7 +2303,7 @@ void AnimationTrackEdit::draw_key(int p_index, float p_pixels_sec, int p_x, bool
 			}
 			text += ")";
 		}
-		
+
 		int limit = MAX(0, p_clip_right - p_x - icon_to_draw->get_width());
 		if (limit > 0) {
 			draw_string(font, Vector2(p_x + icon_to_draw->get_width(), int(get_size().height - font->get_height()) / 2 + font->get_ascent()), text, color, limit);
@@ -5870,13 +5870,13 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	bottom_hb->add_child(memnew(VSeparator));
 
 	function_text_mode_label = memnew(Label);
-	function_text_mode_label->set_text(TTR("Function calls:") + " ");
+	function_text_mode_label->set_text(TTR("Function Calls:") + " ");
 	bottom_hb->add_child(function_text_mode_label);
 
 	function_text_mode_button = memnew(OptionButton);
 	function_text_mode_button->add_item(TTR("None"));
-	function_text_mode_button->add_item(TTR("Name only"));
-	function_text_mode_button->add_item(TTR("Name and arguments"));
+	function_text_mode_button->add_item(TTR("Name"));
+	function_text_mode_button->add_item(TTR("Name and Arguments"));
 	bottom_hb->add_child(function_text_mode_button);
 	function_text_mode_button->connect("item_selected", callable_mp(this, &AnimationTrackEditor::_function_text_mode_changed));
 	function_text_mode_button->set_disabled(true);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -183,6 +183,8 @@ class AnimationTrackEdit : public Control {
 	bool moving_selection;
 	float moving_selection_from_ofs;
 
+	int function_text_mode;
+
 	bool in_group;
 	AnimationTrackEditor *editor;
 
@@ -229,6 +231,8 @@ public:
 	void set_play_position(float p_pos);
 	void update_play_position();
 	void cancel_drop();
+
+	void set_function_text_mode(int p_value);
 
 	void set_in_group(bool p_enable);
 	void append_to_selection(const Rect2 &p_box, bool p_deselection);
@@ -312,11 +316,15 @@ class AnimationTrackEditor : public VBoxContainer {
 	TextureRect *zoom_icon;
 	ToolButton *snap;
 	OptionButton *snap_mode;
+	Label *function_text_mode_label;
+	OptionButton *function_text_mode_button;
+	int function_text_mode;
 
 	Button *imported_anim_warning;
 	void _show_imported_anim_warning();
 
 	void _snap_mode_changed(int p_mode);
+	void _function_text_mode_changed(int p_mode);
 	Vector<AnimationTrackEdit *> track_edits;
 	Vector<AnimationTrackEditGroup *> groups;
 


### PR DESCRIPTION
Adds an extra OptionButton to the AnimationTrackEditor bottom panel that gives three options for displaying the text on function call keys. Keys can show the full function call and arguments, just the function name, or no text at all.
This improves readability in the animation editor when large amounts of function call keys are being used.
![image](https://user-images.githubusercontent.com/3895119/75719823-4caefc80-5c8a-11ea-9839-31bef6e9a98c.png)
![image](https://user-images.githubusercontent.com/3895119/75719724-238e6c00-5c8a-11ea-870c-7ff45898976a.png)
![image](https://user-images.githubusercontent.com/3895119/75719765-3143f180-5c8a-11ea-8f3a-3bd4ea478fbb.png)
![image](https://user-images.githubusercontent.com/3895119/75719788-3acd5980-5c8a-11ea-8c57-4ff9ffa294cf.png)