### PR TITLE
Document EditorPlugin get_plugin_icon and get_plugin_name

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -267,15 +267,27 @@
 			</description>
 		</method>
 		<method name="get_plugin_icon" qualifiers="virtual">
-			<return type="Object">
+			<return type="Texture2D">
 			</return>
 			<description>
+				Override this method in your plugin to return a [Texture2D] in order to give it an icon.
+				For main screen plugins, this appears at the top of the screen, to the right of the "2D", "3D", "Script", and "AssetLib" buttons.
+				Ideally, the plugin icon should be white with a transparent background and 16x16 pixels in size.
+				[codeblock]
+				func get_plugin_icon():
+				    # You can use a custom icon:
+				    return preload("res://addons/my_plugin/my_plugin_icon.svg")
+				    # Or use a built-in icon:
+				    return get_editor_interface().get_base_control().get_icon("Node", "EditorIcons")
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_plugin_name" qualifiers="virtual">
 			<return type="String">
 			</return>
 			<description>
+				Override this method in your plugin to provide the name of the plugin when displayed in the Godot editor.
+				For main screen plugins, this appears at the top of the screen, to the right of the "2D", "3D", "Script", and "AssetLib" buttons.
 			</description>
 		</method>
 		<method name="get_script_create_dialog">

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -862,7 +862,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_canvas_force_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_spatial_gui_input", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_plugin_name"));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::OBJECT, "get_plugin_icon"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "get_plugin_icon"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "has_main_screen"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("make_visible", PropertyInfo(Variant::BOOL, "visible")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("edit", PropertyInfo(Variant::OBJECT, "object")));


### PR DESCRIPTION
Documents the `get_plugin_icon` feature added in #14348 as well as documenting `get_plugin_name`. Also, the return value's type hint for `get_plugin_icon` is now accurate.