### PR TITLE
[3.x] Add blend_premul_alpha support to scene shaders.

### DIFF
--- a/doc/classes/Material3D.xml
+++ b/doc/classes/Material3D.xml
@@ -497,6 +497,9 @@
 		<constant name="BLEND_MODE_MUL" value="3" enum="BlendMode">
 			The color of the object is multiplied by the background.
 		</constant>
+		<constant name="BLEND_MODE_PMALPHA" value="4" enum="BlendMode">
+			The color of the object is added to the background and the alpha channel is used to mask out the background.  This is effectively a hybrid of blend and add mode, useful for FX like fire where you want the flame to add but the smoke to mix.
+		</constant>
 		<constant name="DEPTH_DRAW_OPAQUE_ONLY" value="0" enum="DepthDrawMode">
 			Default depth draw mode. Depth is drawn only for opaque objects.
 		</constant>

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2441,6 +2441,10 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 						}
 
 					} break;
+					case RasterizerStorageGLES2::Shader::Spatial::BLEND_MODE_PMALPHA: {
+						glBlendEquation(GL_FUNC_ADD);
+						glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+					} break;
 				}
 
 				prev_blend_mode = blend_mode;

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1475,6 +1475,7 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 			shaders.actions_scene.render_mode_values["blend_mix"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_MIX);
 			shaders.actions_scene.render_mode_values["blend_sub"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_SUB);
 			shaders.actions_scene.render_mode_values["blend_mul"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_MUL);
+			shaders.actions_scene.render_mode_values["blend_premul_alpha"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_PMALPHA);
 
 			shaders.actions_scene.render_mode_values["depth_draw_opaque"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_OPAQUE);
 			shaders.actions_scene.render_mode_values["depth_draw_always"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_ALWAYS);

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -476,6 +476,7 @@ public:
 				BLEND_MODE_ADD,
 				BLEND_MODE_SUB,
 				BLEND_MODE_MUL,
+				BLEND_MODE_PMALPHA,
 			};
 
 			int blend_mode;

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2149,6 +2149,15 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 							}
 
 						} break;
+						case RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_PMALPHA: {
+							glBlendEquation(GL_FUNC_ADD);
+							if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]) {
+								glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+							} else {
+								glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+							}
+
+						} break;
 					}
 
 					current_blend_mode = desired_blend_mode;

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2265,6 +2265,7 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 			shaders.actions_scene.render_mode_values["blend_mix"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_MIX);
 			shaders.actions_scene.render_mode_values["blend_sub"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_SUB);
 			shaders.actions_scene.render_mode_values["blend_mul"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_MUL);
+			shaders.actions_scene.render_mode_values["blend_premul_alpha"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_PMALPHA);
 
 			shaders.actions_scene.render_mode_values["depth_draw_opaque"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_OPAQUE);
 			shaders.actions_scene.render_mode_values["depth_draw_always"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_ALWAYS);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -490,6 +490,7 @@ public:
 				BLEND_MODE_ADD,
 				BLEND_MODE_SUB,
 				BLEND_MODE_MUL,
+				BLEND_MODE_PMALPHA,
 			};
 
 			int blend_mode;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -405,6 +405,9 @@ void Material3D::_update_shader() {
 		case BLEND_MODE_MUL:
 			code += "blend_mul";
 			break;
+		case BLEND_MODE_PMALPHA:
+			code += "blend_premul_alpha";
+			break;
 	}
 
 	DepthDrawMode ddm = depth_draw_mode;
@@ -1080,6 +1083,11 @@ void Material3D::_update_shader() {
 			} break;
 			case BLEND_MODE_MUL: {
 				code += "\tvec3 detail = mix(ALBEDO.rgb,ALBEDO.rgb*detail_tex.rgb,detail_tex.a);\n";
+			} break;
+			case BLEND_MODE_PMALPHA: {
+				// This is unlikely to ever be used for detail textures, and in order for it to function in the editor, another bit must be used in MaterialKey,
+				// but there are only 5 bits left, so I'm going to leave this disabled unless it's actually requested.
+				//code += "\tvec3 detail = (1.0-detail_tex.a)*ALBEDO.rgb+detail_tex.rgb;\n";
 			} break;
 		}
 
@@ -2128,7 +2136,7 @@ void Material3D::_bind_methods() {
 	ADD_GROUP("Parameters", "params_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_diffuse_mode", PROPERTY_HINT_ENUM, "Burley,Lambert,Lambert Wrap,Oren Nayar,Toon"), "set_diffuse_mode", "get_diffuse_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_specular_mode", PROPERTY_HINT_ENUM, "SchlickGGX,Blinn,Phong,Toon,Disabled"), "set_specular_mode", "get_specular_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Sub,Mul"), "set_blend_mode", "get_blend_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Sub,Mul,Premul"), "set_blend_mode", "get_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_cull_mode", PROPERTY_HINT_ENUM, "Back,Front,Disabled"), "set_cull_mode", "get_cull_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_depth_draw_mode", PROPERTY_HINT_ENUM, "Opaque Only,Always,Never,Opaque Pre-Pass"), "set_depth_draw_mode", "get_depth_draw_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "params_line_width", PROPERTY_HINT_RANGE, "0.1,128,0.1"), "set_line_width", "get_line_width");
@@ -2294,6 +2302,7 @@ void Material3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(BLEND_MODE_ADD);
 	BIND_ENUM_CONSTANT(BLEND_MODE_SUB);
 	BIND_ENUM_CONSTANT(BLEND_MODE_MUL);
+	BIND_ENUM_CONSTANT(BLEND_MODE_PMALPHA);
 
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_OPAQUE_ONLY);
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_ALWAYS);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -156,6 +156,7 @@ public:
 		BLEND_MODE_ADD,
 		BLEND_MODE_SUB,
 		BLEND_MODE_MUL,
+		BLEND_MODE_PMALPHA,
 	};
 
 	enum DepthDrawMode {
@@ -249,7 +250,7 @@ private:
 		struct {
 			uint64_t feature_mask : 12;
 			uint64_t detail_uv : 1;
-			uint64_t blend_mode : 2;
+			uint64_t blend_mode : 3;
 			uint64_t depth_draw_mode : 2;
 			uint64_t cull_mode : 2;
 			uint64_t flags : 20;
@@ -265,7 +266,7 @@ private:
 			uint64_t emission_op : 1;
 			uint64_t texture_metallic : 1;
 			uint64_t texture_roughness : 1;
-			//uint64_t reserved : 6;
+			//uint64_t reserved : 5;
 		};
 
 		uint64_t key;

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -171,6 +171,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_add");
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_sub");
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_mul");
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_premul_alpha");
 
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("depth_draw_opaque");
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("depth_draw_always");


### PR DESCRIPTION
This was previously only supported by 2D shaders, but can be pretty useful in 3D as well.  For example, I'm using it for lasers where I don't want to use pure additive blending, because they lose visibility with bright backgrounds, but a normal alpha blend doesn't look good, either, so I make them mostly additive with some slight alpha to ensure visibility on brighter areas.

I'm making this pull request directly into 3.2 because the gles3 renderer was removed and I can't make the pull request in master and have it merged back to 3.2.  (Also, can't compile master due to some internal compiler error, so I'll have to figure that out and make a different pull request for master to support vulkan after I figure that out, if this goes through).

*Bugsquad edit: This addresses https://github.com/godotengine/godot-proposals/issues/3431 for `3.x`.*