### PR TITLE
Document that SpringArm exclusions only work with PhysicsBody objects

### DIFF
--- a/doc/classes/SpringArm.xml
+++ b/doc/classes/SpringArm.xml
@@ -18,14 +18,14 @@
 			<argument index="0" name="RID" type="RID">
 			</argument>
 			<description>
-				Adds the object with the given [RID] to the list of objects excluded from the collision check.
+				Adds the [PhysicsBody] object with the given [RID] to the list of [PhysicsBody] objects excluded from the collision check.
 			</description>
 		</method>
 		<method name="clear_excluded_objects">
 			<return type="void">
 			</return>
 			<description>
-				Clears the list of objects excluded from the collision check.
+				Clears the list of [PhysicsBody] objects excluded from the collision check.
 			</description>
 		</method>
 		<method name="get_hit_length">
@@ -41,7 +41,7 @@
 			<argument index="0" name="RID" type="RID">
 			</argument>
 			<description>
-				Removes the given [RID] from the list of objects excluded from the collision check.
+				Removes the given [RID] from the list of [PhysicsBody] objects excluded from the collision check.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
I was very confused when using SpringArm, since I was trying to exclude objects with code like this: `$MyCollisionShape.shape.get_rid()`, but this silently fails because SpringArm's exclusion system needs the RID of a PhysicsBody node e.g. `$MyPhysicsBody.get_rid()` rather than the individual colliders. So, I've added this to the documentation.