### PR TITLE
Signals: Fix some regressions from #36426

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1358,7 +1358,7 @@ void EditorInspector::_parse_added_editors(VBoxContainer *current_vbox, Ref<Edit
 		if (ep) {
 
 			ep->object = object;
-			ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed));
+			ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed), make_binds(StringName(), false));
 			ep->connect("property_keyed", callable_mp(this, &EditorInspector::_property_keyed));
 			ep->connect("property_keyed_with_value", callable_mp(this, &EditorInspector::_property_keyed_with_value));
 			ep->connect("property_checked", callable_mp(this, &EditorInspector::_property_checked));
@@ -1770,9 +1770,9 @@ void EditorInspector::update_tree() {
 
 				if (ep) {
 
-					ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed));
+					ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed), make_binds(StringName(), false));
 					if (p.usage & PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED) {
-						ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed_update_all), varray(), CONNECT_DEFERRED);
+						ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed_update_all), make_binds(StringName(), false), CONNECT_DEFERRED);
 					}
 					ep->connect("property_keyed", callable_mp(this, &EditorInspector::_property_keyed));
 					ep->connect("property_keyed_with_value", callable_mp(this, &EditorInspector::_property_keyed_with_value));
@@ -2052,16 +2052,16 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 	}
 }
 
-void EditorInspector::_property_changed(const String &p_path, const Variant &p_value, const String &p_name, bool changing) {
+void EditorInspector::_property_changed(const String &p_path, const Variant &p_value, const String &p_name, bool p_changing) {
 
 	// The "changing" variable must be true for properties that trigger events as typing occurs,
-	// like "text_changed" signal. eg: Text property of Label, Button, RichTextLabel, etc.
-	if (changing)
+	// like "text_changed" signal. E.g. text property of Label, Button, RichTextLabel, etc.
+	if (p_changing)
 		this->changing++;
 
 	_edit_set(p_path, p_value, false, p_name);
 
-	if (changing)
+	if (p_changing)
 		this->changing--;
 
 	if (restart_request_props.has(p_path)) {

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -302,7 +302,7 @@ class EditorInspector : public ScrollContainer {
 
 	void _edit_set(const String &p_name, const Variant &p_value, bool p_refresh_all, const String &p_changed_field);
 
-	void _property_changed(const String &p_path, const Variant &p_value, const String &p_name = "", bool changing = false);
+	void _property_changed(const String &p_path, const Variant &p_value, const String &p_name = "", bool p_changing = false);
 	void _property_changed_update_all(const String &p_path, const Variant &p_value, const String &p_name = "", bool p_changing = false);
 	void _multiple_properties_changed(Vector<String> p_paths, Array p_values);
 	void _property_keyed(const String &p_path, bool p_advance);

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -165,10 +165,10 @@ EditorPropertyDictionaryObject::EditorPropertyDictionaryObject() {
 
 ///////////////////// ARRAY ///////////////////////////
 
-void EditorPropertyArray::_property_changed(const String &p_prop, Variant p_value, const String &p_name, bool changing) {
+void EditorPropertyArray::_property_changed(const String &p_property, Variant p_value, const StringName &p_name, bool p_changing) {
 
-	if (p_prop.begins_with("indices")) {
-		int idx = p_prop.get_slice("/", 1).to_int();
+	if (p_property.begins_with("indices")) {
+		int idx = p_property.get_slice("/", 1).to_int();
 		Variant array = object->get_array();
 		array.set(idx, p_value);
 		emit_changed(get_edited_property(), array, "", true);
@@ -213,7 +213,7 @@ void EditorPropertyArray::_change_type_menu(int p_index) {
 	update_property();
 }
 
-void EditorPropertyArray::_object_id_selected(const String &p_property, ObjectID p_id) {
+void EditorPropertyArray::_object_id_selected(const StringName &p_property, ObjectID p_id) {
 	emit_signal("object_id_selected", p_property, p_id);
 }
 
@@ -359,7 +359,7 @@ void EditorPropertyArray::update_property() {
 			prop->set_object_and_property(object.ptr(), prop_name);
 			prop->set_label(itos(i + offset));
 			prop->set_selectable(false);
-			prop->connect("property_changed", callable_mp(this, &EditorPropertyArray::_property_changed));
+			prop->connect("property_changed", callable_mp(this, &EditorPropertyArray::_property_changed), make_binds(StringName(), false));
 			prop->connect("object_id_selected", callable_mp(this, &EditorPropertyArray::_object_id_selected));
 			prop->set_h_size_flags(SIZE_EXPAND_FILL);
 
@@ -528,16 +528,16 @@ EditorPropertyArray::EditorPropertyArray() {
 
 ///////////////////// DICTIONARY ///////////////////////////
 
-void EditorPropertyDictionary::_property_changed(const String &p_prop, Variant p_value, const String &p_name, bool changing) {
+void EditorPropertyDictionary::_property_changed(const String &p_property, Variant p_value, const StringName &p_name, bool p_changing) {
 
-	if (p_prop == "new_item_key") {
+	if (p_property == "new_item_key") {
 
 		object->set_new_item_key(p_value);
-	} else if (p_prop == "new_item_value") {
+	} else if (p_property == "new_item_value") {
 
 		object->set_new_item_value(p_value);
-	} else if (p_prop.begins_with("indices")) {
-		int idx = p_prop.get_slice("/", 1).to_int();
+	} else if (p_property.begins_with("indices")) {
+		int idx = p_property.get_slice("/", 1).to_int();
 		Dictionary dict = object->get_dict();
 		Variant key = dict.get_key_at_index(idx);
 		dict[key] = p_value;
@@ -932,7 +932,7 @@ void EditorPropertyDictionary::update_property() {
 			}
 
 			prop->set_selectable(false);
-			prop->connect("property_changed", callable_mp(this, &EditorPropertyDictionary::_property_changed));
+			prop->connect("property_changed", callable_mp(this, &EditorPropertyDictionary::_property_changed), make_binds(StringName(), false));
 			prop->connect("object_id_selected", callable_mp(this, &EditorPropertyDictionary::_object_id_selected));
 
 			HBoxContainer *hb = memnew(HBoxContainer);
@@ -969,7 +969,7 @@ void EditorPropertyDictionary::update_property() {
 	}
 }
 
-void EditorPropertyDictionary::_object_id_selected(const String &p_property, ObjectID p_id) {
+void EditorPropertyDictionary::_object_id_selected(const StringName &p_property, ObjectID p_id) {
 	emit_signal("object_id_selected", p_property, p_id);
 }
 

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -100,11 +100,11 @@ class EditorPropertyArray : public EditorProperty {
 	void _page_changed(double p_page);
 	void _length_changed(double p_page);
 	void _edit_pressed();
-	void _property_changed(const String &p_prop, Variant p_value, const String &p_name = String(), bool changing = false);
+	void _property_changed(const String &p_property, Variant p_value, const StringName &p_name = StringName(), bool p_changing = false);
 	void _change_type(Object *p_button, int p_index);
 	void _change_type_menu(int p_index);
 
-	void _object_id_selected(const String &p_property, ObjectID p_id);
+	void _object_id_selected(const StringName &p_property, ObjectID p_id);
 	void _remove_pressed(int p_index);
 
 protected:
@@ -135,12 +135,12 @@ class EditorPropertyDictionary : public EditorProperty {
 
 	void _page_changed(double p_page);
 	void _edit_pressed();
-	void _property_changed(const String &p_prop, Variant p_value, const String &p_name = String(), bool changing = false);
+	void _property_changed(const String &p_property, Variant p_value, const StringName &p_name = StringName(), bool p_changing = false);
 	void _change_type(Object *p_button, int p_index);
 	void _change_type_menu(int p_index);
 
 	void _add_key_value();
-	void _object_id_selected(const String &p_property, ObjectID p_id);
+	void _object_id_selected(const StringName &p_property, ObjectID p_id);
 
 protected:
 	static void _bind_methods();

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -117,7 +117,7 @@ private:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _add_property_info_bind(const Dictionary &p_info);
 
-	void _load_defaults(Ref<ConfigFile> p_extra_config = NULL);
+	void _load_defaults(Ref<ConfigFile> p_extra_config = Ref<ConfigFile>());
 	void _load_default_text_editor_theme();
 	bool _save_text_editor_theme(String p_file);
 	bool _is_default_text_editor_theme(String p_theme_name);

--- a/editor/editor_visual_profiler.cpp
+++ b/editor/editor_visual_profiler.cpp
@@ -824,7 +824,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	frame_delay->set_wait_time(0.1);
 	frame_delay->set_one_shot(true);
 	add_child(frame_delay);
-	frame_delay->connect("timeout", callable_mp(this, &EditorVisualProfiler::_update_frame));
+	frame_delay->connect("timeout", callable_mp(this, &EditorVisualProfiler::_update_frame), make_binds(false));
 
 	plot_delay = memnew(Timer);
 	plot_delay->set_wait_time(0.1);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -323,7 +323,7 @@ void FileSystemDock::_notification(int p_what) {
 			file_list_popup->connect("id_pressed", callable_mp(this, &FileSystemDock::_file_list_rmb_option));
 			tree_popup->connect("id_pressed", callable_mp(this, &FileSystemDock::_tree_rmb_option));
 
-			current_path->connect("text_entered", callable_mp(this, &FileSystemDock::_navigate_to_path));
+			current_path->connect("text_entered", callable_mp(this, &FileSystemDock::_navigate_to_path), make_binds(false));
 
 			always_show_folders = bool(EditorSettings::get_singleton()->get("docks/filesystem/always_show_folders"));
 
@@ -1406,8 +1406,8 @@ bool FileSystemDock::_check_existing() {
 	return true;
 }
 
-void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool overwrite) {
-	if (!overwrite) {
+void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_overwrite) {
+	if (!p_overwrite) {
 		to_move_path = p_to_path;
 		bool can_move = _check_existing();
 		if (!can_move) {
@@ -2620,7 +2620,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	move_dialog = memnew(EditorDirDialog);
 	move_dialog->get_ok()->set_text(TTR("Move"));
 	add_child(move_dialog);
-	move_dialog->connect("dir_selected", callable_mp(this, &FileSystemDock::_move_operation_confirm));
+	move_dialog->connect("dir_selected", callable_mp(this, &FileSystemDock::_move_operation_confirm), make_binds(false));
 
 	rename_dialog = memnew(ConfirmationDialog);
 	VBoxContainer *rename_dialog_vb = memnew(VBoxContainer);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -222,7 +222,7 @@ private:
 	void _duplicate_operation_confirm();
 	void _move_with_overwrite();
 	bool _check_existing();
-	void _move_operation_confirm(const String &p_to_path, bool overwrite = false);
+	void _move_operation_confirm(const String &p_to_path, bool p_overwrite = false);
 
 	void _tree_rmb_option(int p_option);
 	void _file_list_rmb_option(int p_option);

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -659,6 +659,7 @@ void GroupsEditor::_show_group_dialog() {
 }
 
 void GroupsEditor::_bind_methods() {
+	ClassDB::bind_method("update_tree", &GroupsEditor::update_tree);
 }
 
 GroupsEditor::GroupsEditor() {

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -105,7 +105,7 @@ class InspectorDock : public VBoxContainer {
 
 	void _warning_pressed();
 	void _resource_created();
-	void _resource_selected(const RES &p_res, const String &p_property = "");
+	void _resource_selected(const RES &p_res, const String &p_property);
 	void _edit_forward();
 	void _edit_back();
 	void _menu_collapseall();

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1360,7 +1360,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	filter->connect("text_entered", callable_mp(this, &EditorAssetLibrary::_search_text_entered));
 	search = memnew(Button(TTR("Search")));
-	search->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search));
+	search->connect("pressed", callable_mp(this, &EditorAssetLibrary::_search), make_binds(0));
 	search_hb->add_child(search);
 
 	if (!p_templates_only)

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -990,7 +990,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	empty2->connect("pressed", callable_mp(this, &SpriteFramesEditor::_empty2_pressed));
 	move_up->connect("pressed", callable_mp(this, &SpriteFramesEditor::_up_pressed));
 	move_down->connect("pressed", callable_mp(this, &SpriteFramesEditor::_down_pressed));
-	file->connect("files_selected", callable_mp(this, &SpriteFramesEditor::_file_load_request));
+	file->connect("files_selected", callable_mp(this, &SpriteFramesEditor::_file_load_request), make_binds(-1));
 	loading_scene = false;
 	sel = -1;
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2978,7 +2978,7 @@ class VisualShaderNodePluginDefaultEditor : public VBoxContainer {
 	Ref<Resource> parent_resource;
 
 public:
-	void _property_changed(const String &prop, const Variant &p_value, const String &p_field, bool p_changing = false) {
+	void _property_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field = StringName(), bool p_changing = false) {
 
 		if (p_changing)
 			return;
@@ -2986,13 +2986,13 @@ public:
 		UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 		updating = true;
-		undo_redo->create_action(TTR("Edit Visual Property") + ": " + prop, UndoRedo::MERGE_ENDS);
-		undo_redo->add_do_property(node.ptr(), prop, p_value);
-		undo_redo->add_undo_property(node.ptr(), prop, node->get(prop));
+		undo_redo->create_action(TTR("Edit Visual Property") + ": " + p_property, UndoRedo::MERGE_ENDS);
+		undo_redo->add_do_property(node.ptr(), p_property, p_value);
+		undo_redo->add_undo_property(node.ptr(), p_property, node->get(p_property));
 
 		if (p_value.get_type() == Variant::OBJECT) {
 
-			RES prev_res = node->get(prop);
+			RES prev_res = node->get(p_property);
 			RES curr_res = p_value;
 
 			if (curr_res.is_null()) {
@@ -3072,7 +3072,7 @@ public:
 				p_properties[i]->connect("resource_selected", callable_mp(this, &VisualShaderNodePluginDefaultEditor::_resource_selected));
 			}
 
-			properties[i]->connect("property_changed", callable_mp(this, &VisualShaderNodePluginDefaultEditor::_property_changed));
+			properties[i]->connect("property_changed", callable_mp(this, &VisualShaderNodePluginDefaultEditor::_property_changed), make_binds(StringName(), false));
 			properties[i]->set_object_and_property(node.ptr(), p_names[i]);
 			properties[i]->update_property();
 			properties[i]->set_name_split_ratio(0);

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -119,7 +119,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _item_del();
 	void _update_actions();
 	void _save();
-	void _add_item(int p_item, Ref<InputEvent> p_exiting_event = NULL);
+	void _add_item(int p_item, Ref<InputEvent> p_exiting_event = Ref<InputEvent>());
 	void _edit_item(Ref<InputEvent> p_exiting_event);
 
 	void _action_check(String p_action);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1127,7 +1127,7 @@ void SceneTreeDock::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-			clear_inherit_confirm->connect("confirmed", callable_mp(this, &SceneTreeDock::_tool_selected), varray(TOOL_SCENE_CLEAR_INHERITANCE_CONFIRM));
+			clear_inherit_confirm->connect("confirmed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_SCENE_CLEAR_INHERITANCE_CONFIRM, false));
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -2739,7 +2739,7 @@ void SceneTreeDock::_update_create_root_dialog() {
 
 void SceneTreeDock::_favorite_root_selected(const String &p_class) {
 	selected_favorite_root = p_class;
-	_tool_selected(TOOL_CREATE_FAVORITE, false);
+	_tool_selected(TOOL_CREATE_FAVORITE);
 }
 
 void SceneTreeDock::_feature_profile_changed() {


### PR DESCRIPTION
- Fix `callable_mp` bindings to methods which used to have default
  arguments passed to `bind_method`. We now have to re-specify them
  manually when connecting.
- Re-add `GroupsEditor::update_tree` binding. Fixes https://github.com/godotengine/godot/pull/36426#discussion_r386130975.
- Misc code quality changes along the way.

Fixes #36753.