### PR TITLE
Autocomplete for .get() .set() implemented

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2258,6 +2258,14 @@ static void _find_call_arguments(const GDScriptCompletionContext &p_context, con
 					}
 				}
 
+				if ((p_method == "set" || p_method == "get") && p_argidx == 0) {
+					for (int i = 0; i < base_type.class_type->variables.size(); i++) {
+						ScriptCodeCompletionOption option(base_type.class_type->variables[i].identifier.operator String(), ScriptCodeCompletionOption::KIND_MEMBER);
+						option.insert_text = quote_style + option.display + quote_style;
+						r_result.insert(option.display, option);
+					}
+				}
+
 				base_type = base_type.class_type->base_type;
 			} break;
 			case GDScriptParser::DataType::GDSCRIPT: {


### PR DESCRIPTION
possible Fix: #24460

auto complete property name as string just like `.connect()`

![autocomplete-get-set](https://user-images.githubusercontent.com/41085900/75773080-287b1a80-5d73-11ea-8359-51575a33f32a.JPG)
