### PR TITLE
fix: Classes can't have pass 

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -5227,6 +5227,10 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 				}
 			} break;
 
+			case GDScriptTokenizer::TK_CF_PASS: {
+				tokenizer->advance();
+			} break;
+
 			default: {
 
 				_set_error(String() + "Unexpected token: " + tokenizer->get_token_name(tokenizer->get_token()) + ":" + tokenizer->get_token_identifier());


### PR DESCRIPTION
`pass` token can't be directly inside a class -> handled

![class pass](https://user-images.githubusercontent.com/41085900/75783643-e3f97a00-5d86-11ea-9dda-845e86cd3ff7.JPG)
