### PR TITLE
Add a new configuration warning to CollisionShape

### DIFF
--- a/scene/3d/collision_shape.cpp
+++ b/scene/3d/collision_shape.cpp
@@ -123,6 +123,14 @@ String CollisionShape::get_configuration_warning() const {
 		return TTR("A shape must be provided for CollisionShape to function. Please create a shape resource for it.");
 	}
 
+	if (Object::cast_to<RigidBody>(get_parent())) {
+		if (Object::cast_to<ConcavePolygonShape>(*shape)) {
+			if (Object::cast_to<RigidBody>(get_parent())->get_mode() != RigidBody::MODE_STATIC) {
+				return TTR("ConcavePolygonShape doesn't support RigidBody in another mode than static.");
+			}
+		}
+	}
+
 	return String();
 }
 

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -518,6 +518,7 @@ void RigidBody::set_mode(Mode p_mode) {
 			PhysicsServer::get_singleton()->body_set_mode(get_rid(), PhysicsServer::BODY_MODE_KINEMATIC);
 		} break;
 	}
+	update_configuration_warning();
 }
 
 RigidBody::Mode RigidBody::get_mode() const {


### PR DESCRIPTION
New 3D users, may encounter the case where they use a RigidBody in Rigid mode with a ConcavePolygonShape as shape in a CollisionShape, try the game and see the RigidBody going trough the floor without colliding with it.

The problem is that they don't know why, there is no warning or error, they don't know what is happening and some may think that it's a bug.

In fact ConcavePolygonShape is intended to work with static PhysicsBody nodes like StaticBody and will not work with KinematicBody or RigidBody with a mode other than Static.

I have see this with @odino on IRC, at first it was also said to create a warning for KinematicBody, but an error is already printed in this case, see: [this](https://github.com/godotengine/godot/blob/master/modules/bullet/rigid_body_bullet.cpp#L243)

Here the result of the change in the editor:

![warning configuration](https://user-images.githubusercontent.com/60516608/75801294-2e74f980-5d7b-11ea-9fec-4c5fab659c3e.jpg)

I don't know if this is a good way to implement it, but I tested it and it seem to work.

I added update_configuration_warning() in RigidBody::set_mode() so that if the user change the mode of a RigidBody in Static mode rightfully used with a ConcavePolygonShape for another mode, the configuration warning appear immediately. 



