### PR TITLE
[WIP] Editor Android Port 

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -610,6 +610,7 @@ void EditorNode::_notification(int p_what) {
 			get_tree()->get_root()->set_snap_2d_transforms_to_pixel(false);
 			get_tree()->get_root()->set_snap_2d_vertices_to_pixel(false);
 			get_tree()->set_auto_accept_quit(false);
+			get_tree()->set_quit_on_go_back(false);
 			get_tree()->get_root()->connect("files_dropped", callable_mp(this, &EditorNode::_dropped_files));
 
 			command_palette->register_shortcuts_as_command();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2251,9 +2251,10 @@ bool Main::start() {
 
 		bool embed_subwindows = GLOBAL_DEF("display/window/subwindows/embed_subwindows", true);
 
-		if (OS::get_singleton()->is_single_window() || (!project_manager && !editor && embed_subwindows)) {
+		if (OS::get_singleton()->is_single_window() || (!project_manager && !editor && embed_subwindows) || !DisplayServer::get_singleton()->has_feature(DisplayServer::Feature::FEATURE_SUBWINDOWS)) {
 			sml->get_root()->set_embed_subwindows_hint(true);
 		}
+
 		ResourceLoader::add_custom_loaders();
 		ResourceSaver::add_custom_savers();
 

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -45,6 +45,7 @@ dependencies {
         // Custom build mode. In this scenario this project is the only one around and the Godot
         // library is available through the pre-generated godot-lib.*.aar android archive files.
         debugImplementation fileTree(dir: 'libs/debug', include: ['*.jar', '*.aar'])
+        releaseDebugmIplementation fileTree(dir: 'libs/debug', include: ['*.jar', '*.aar'])
         releaseImplementation fileTree(dir: 'libs/release', include: ['*.jar', '*.aar'])
     }
 
@@ -66,6 +67,7 @@ dependencies {
 android {
     compileSdkVersion versions.compileSdk
     buildToolsVersion versions.buildTools
+    ndkVersion versions.ndkVersion
 
     compileOptions {
         sourceCompatibility versions.javaVersion
@@ -93,6 +95,10 @@ android {
         versionName getExportVersionName()
         minSdkVersion getExportMinSdkVersion()
         targetSdkVersion getExportTargetSdkVersion()
+    }
+
+    buildTypes {
+        release_debug {}
     }
 
     lintOptions {
@@ -167,6 +173,7 @@ android {
             assets.srcDirs = ['assets']
         }
         debug.jniLibs.srcDirs = ['libs/debug', 'libs/debug/vulkan_validation_layers']
+        release_debug.jniLibs.srcDirs = ['libs/debug']
         release.jniLibs.srcDirs = ['libs/release']
     }
 

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -22,7 +22,7 @@ allprojects {
 
 ext {
     supportedAbis = ["armv7", "arm64v8", "x86", "x86_64"]
-    supportedTargets = ["release", "debug"]
+    supportedTargets = ["release", "release_debug", "debug"]
 
     // Used by gradle to specify which architecture to build for by default when running `./gradlew build`.
     // This command is usually used by Android Studio.
@@ -30,6 +30,9 @@ ext {
     // `./gradlew generateGodotTemplates` build command instead after running the `scons` command.
     // The defaultAbi must be one of the {supportedAbis} values.
     defaultAbi = "arm64v8"
+
+	//default for building on Android Studio so editor would be built as well
+	tools=true
 }
 
 def rootDir = "../../.."

--- a/platform/android/java/editor/AndroidManifest.xml
+++ b/platform/android/java/editor/AndroidManifest.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="org.godotengine.editor"
+    android:installLocation="auto"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+    <supports-screens
+        android:largeScreens="true"
+        android:normalScreens="true"
+        android:smallScreens="true"
+        android:xlargeScreens="true" />
+
+    <uses-feature
+        android:glEsVersion="0x00020000"
+        android:required="true" />
+
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
+
+    <application
+        android:allowBackup="false"
+        android:icon="@mipmap/icon"
+        android:label="@string/godot_editor_name_string"
+        tools:ignore="GoogleAppIndexingWarning"
+        android:requestLegacyExternalStorage="true">
+
+        <activity
+            android:name=".GodotProjects"
+            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
+            android:label="@string/godot_editor_name_string"
+            android:launchMode="singleTask"
+            android:resizeableActivity="false"
+            android:screenOrientation="landscape"
+            android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
+            android:process=":GodotProject"
+            tools:ignore="UnusedAttribute">
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".GodotEditor"
+            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
+            android:label="@string/godot_project_name_string"
+            android:process=":GodotEditor"
+            android:launchMode="singleTask"
+            android:resizeableActivity="false"
+            android:screenOrientation="landscape"
+            android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
+        </activity>
+
+        <activity
+            android:name=".GodotGame"
+            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
+            android:label="@string/godot_project_name_string"
+            android:process=":GodotGame"
+            android:launchMode="singleTask"
+            android:resizeableActivity="false"
+            android:screenOrientation="landscape"
+            android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
+        </activity>
+
+
+    </application>
+
+</manifest>

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -1,0 +1,63 @@
+// Gradle build config for Godot Engine's Android port.
+apply plugin: 'com.android.application'
+
+dependencies {
+    implementation libraries.kotlinStdLib
+    implementation libraries.androidxFragment
+    implementation project(":lib")
+}
+
+android {
+    compileSdkVersion versions.compileSdk
+    buildToolsVersion versions.buildTools
+    ndkVersion versions.ndkVersion
+
+    defaultConfig {
+        applicationId "org.godotengine.editor"
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
+    }
+
+    compileOptions {
+        sourceCompatibility versions.javaVersion
+        targetCompatibility versions.javaVersion
+    }
+
+    buildTypes {
+        release_debug {}
+    }
+
+    lintOptions {
+        abortOnError false
+        disable 'MissingTranslation', 'UnusedResources'
+    }
+
+    packagingOptions {
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/NOTICE'
+
+        // 'doNotStrip' is enabled for development within Android Studio
+        if (shouldNotStrip()) {
+            doNotStrip '**/*.so'
+        }
+    }
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            res.srcDirs = ['res']
+            aidl.srcDirs = ['aidl']
+            assets.srcDirs = ['assets']
+        }
+        debug.jniLibs.srcDirs = ['libs/debug']
+        release_debug.jniLibs.srcDirs = ['libs/debug']
+        release.jniLibs.srcDirs = ['libs/release']
+    }
+
+    applicationVariants.all { variant ->
+        variant.outputs.all { output ->
+            output.outputFileName = "android_editor_${variant.name}.apk"
+        }
+    }
+}

--- a/platform/android/java/editor/res/values/strings.xml
+++ b/platform/android/java/editor/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="godot_editor_name_string">Godot Editor</string>
+</resources>

--- a/platform/android/java/editor/src/org/godotengine/editor/GodotEditor.java
+++ b/platform/android/java/editor/src/org/godotengine/editor/GodotEditor.java
@@ -1,0 +1,36 @@
+/*************************************************************************/
+/*  GodotEditor.java                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+package org.godotengine.editor;
+
+import org.godotengine.godot.FullScreenGodotApp;
+
+public class GodotEditor extends FullScreenGodotApp {
+}

--- a/platform/android/java/editor/src/org/godotengine/editor/GodotGame.java
+++ b/platform/android/java/editor/src/org/godotengine/editor/GodotGame.java
@@ -1,0 +1,36 @@
+/*************************************************************************/
+/*  GodotGame.java                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+package org.godotengine.editor;
+
+import org.godotengine.godot.FullScreenGodotApp;
+
+public class GodotGame extends FullScreenGodotApp {
+}

--- a/platform/android/java/editor/src/org/godotengine/editor/GodotProjects.java
+++ b/platform/android/java/editor/src/org/godotengine/editor/GodotProjects.java
@@ -1,0 +1,52 @@
+/*************************************************************************/
+/*  GodotProjects.java                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+package org.godotengine.editor;
+import org.godotengine.godot.FullScreenGodotApp;
+
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Environment;
+import android.provider.Settings;
+
+/**
+ * Activity for Godot projects.
+ */
+public class GodotProjects extends FullScreenGodotApp {
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		getGodotFragment().requestPermissions();
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
+			startActivity(new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION));
+		}
+	}
+}

--- a/platform/android/java/gradle.properties
+++ b/platform/android/java/gradle.properties
@@ -14,7 +14,7 @@ android.useAndroidX=true
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4536m
+org.gradle.jvmargs=-Xmx8536m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -11,7 +11,6 @@ def pathToRootDir = "../../../../"
 android {
     compileSdkVersion versions.compileSdk
     buildToolsVersion versions.buildTools
-
     ndkVersion versions.ndkVersion
 
     defaultConfig {
@@ -24,6 +23,10 @@ android {
     compileOptions {
         sourceCompatibility versions.javaVersion
         targetCompatibility versions.javaVersion
+    }
+
+    buildTypes {
+        release_debug {}
     }
 
     lintOptions {
@@ -50,6 +53,7 @@ android {
             assets.srcDirs = ['assets']
         }
         debug.jniLibs.srcDirs = ['libs/debug']
+        release_debug.jniLibs.srcDirs = ['libs/debug']
         release.jniLibs.srcDirs = ['libs/release']
     }
 
@@ -105,7 +109,7 @@ android {
         def taskName = getSconsTaskName(buildType)
         tasks.create(name: taskName, type: Exec) {
             executable sconsExecutableFile.absolutePath
-            args "--directory=${pathToRootDir}", "platform=android", "target=${releaseTarget}", "android_arch=${defaultAbi}", "-j" + Runtime.runtime.availableProcessors()
+            args "tools=${tools}", "--directory=${pathToRootDir}", "platform=android", "target=${releaseTarget}", "android_arch=${defaultAbi}", "-j" + Runtime.runtime.availableProcessors()
         }
 
         // Schedule the tasks so the generated libs are present before the aar file is packaged.

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -357,6 +357,8 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		return deviceInfo.reqGlEsVersion;
 	}
 
+	private String COMMAND_LINE_INTENT_NAME = "command line args";
+
 	@CallSuper
 	protected String[] getCommandLine() {
 		String[] original = parseCommandLine();
@@ -375,6 +377,12 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 
 	private String[] parseCommandLine() {
 		InputStream is;
+		String[] activityCommandLine = getActivity().getIntent().getStringArrayExtra(COMMAND_LINE_INTENT_NAME);
+		int activityCommandLineCount = 0;
+		if (activityCommandLine != null) {
+			activityCommandLineCount = activityCommandLine.length;
+		}
+
 		try {
 			is = getActivity().getAssets().open("_cl_");
 			byte[] len = new byte[4];
@@ -383,7 +391,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 				return new String[0];
 			}
 			int argc = ((int)(len[3] & 0xFF) << 24) | ((int)(len[2] & 0xFF) << 16) | ((int)(len[1] & 0xFF) << 8) | ((int)(len[0] & 0xFF));
-			String[] cmdline = new String[argc];
+			String[] cmdline = new String[argc + activityCommandLineCount];
 
 			for (int i = 0; i < argc; i++) {
 				r = is.read(len);
@@ -400,10 +408,19 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 					cmdline[i] = new String(arg, "UTF-8");
 				}
 			}
+
+			if (activityCommandLine != null) {
+				System.arraycopy(activityCommandLine, 0, cmdline, argc, activityCommandLine.length);
+			}
+
 			return cmdline;
 		} catch (Exception e) {
 			e.printStackTrace();
-			return new String[0];
+			if (activityCommandLine != null) {
+				return activityCommandLine;
+			} else {
+				return new String[0];
+			}
 		}
 	}
 
@@ -1006,6 +1023,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		mProgressFraction.setText(Helpers.getDownloadProgressString(progress.mOverallProgress,
 				progress.mOverallTotal));
 	}
+
 	public void initInputDevices() {
 		mRenderView.initInputDevices();
 	}
@@ -1013,5 +1031,13 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	@Keep
 	private GodotRenderView getRenderView() { // used by native side to get renderView
 		return mRenderView;
+	}
+
+	@Keep
+	private void callIntentWithCommandLineArgs(String intentName, String[] args) throws ClassNotFoundException {
+		Class<?> c = Class.forName(intentName);
+		Intent intent = new Intent(getActivity(), c);
+		intent.putExtra(COMMAND_LINE_INTENT_NAME, args);
+		startActivity(intent);
 	}
 }

--- a/platform/android/java/nativeSrcsConfigs/CMakeLists.txt
+++ b/platform/android/java/nativeSrcsConfigs/CMakeLists.txt
@@ -17,3 +17,5 @@ target_include_directories(${PROJECT_NAME}
         SYSTEM PUBLIC
         ${GODOT_ROOT_DIR}
         ${GODOT_ROOT_DIR}/modules/gdnative/include)
+
+add_definitions(-DUNIX_ENABLED -DVULKAN_ENABLED -DTOOLS_ENABLED)

--- a/platform/android/java/nativeSrcsConfigs/build.gradle
+++ b/platform/android/java/nativeSrcsConfigs/build.gradle
@@ -6,6 +6,7 @@ plugins {
 android {
     compileSdkVersion versions.compileSdk
     buildToolsVersion versions.buildTools
+    ndkVersion versions.ndkVersion
 
     defaultConfig {
         minSdkVersion versions.minSdk

--- a/platform/android/java/settings.gradle
+++ b/platform/android/java/settings.gradle
@@ -4,6 +4,7 @@ rootProject.name = "Godot"
 include ':app'
 include ':lib'
 include ':nativeSrcsConfigs'
+include ':editor'
 
 include ':assetPacks:installTime'
 project(':assetPacks:installTime').projectDir = file("app/assetPacks/installTime")

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -76,6 +76,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_
 	_get_input_fallback_mapping = p_env->GetMethodID(godot_class, "getInputFallbackMapping", "()Ljava/lang/String;");
 	_on_godot_setup_completed = p_env->GetMethodID(godot_class, "onGodotSetupCompleted", "()V");
 	_on_godot_main_loop_started = p_env->GetMethodID(godot_class, "onGodotMainLoopStarted", "()V");
+	_call_intent_with_command_line_args = p_env->GetMethodID(godot_class, "callIntentWithCommandLineArgs", "(Ljava/lang/String;[Ljava/lang/String;)V");
 
 	// get some Activity method pointers...
 	_get_class_loader = p_env->GetMethodID(activity_class, "getClassLoader", "()Ljava/lang/ClassLoader;");
@@ -329,5 +330,17 @@ void GodotJavaWrapper::vibrate(int p_duration_ms) {
 		ERR_FAIL_COND(env == nullptr);
 
 		env->CallVoidMethod(godot_instance, _vibrate, p_duration_ms);
+	}
+}
+
+void GodotJavaWrapper::call_intent_with_command_line_args(String intent, List<String> args) {
+	if (_call_intent_with_command_line_args) {
+		JNIEnv *env = get_jni_env();
+		jstring jStrIntent = env->NewStringUTF(intent.utf8().get_data());
+		jobjectArray jargs = env->NewObjectArray(args.size(), env->FindClass("java/lang/String"), env->NewStringUTF(""));
+		for (int i = 0; i < args.size(); i++) {
+			env->SetObjectArrayElement(jargs, i, env->NewStringUTF(args[i].utf8().get_data()));
+		}
+		env->CallVoidMethod(godot_instance, _call_intent_with_command_line_args, jStrIntent, jargs);
 	}
 }

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -37,6 +37,7 @@
 #include <android/log.h>
 #include <jni.h>
 
+#include "core/templates/list.h"
 #include "java_godot_view_wrapper.h"
 #include "string_android.h"
 
@@ -69,6 +70,7 @@ private:
 	jmethodID _on_godot_setup_completed = 0;
 	jmethodID _on_godot_main_loop_started = 0;
 	jmethodID _get_class_loader = 0;
+	jmethodID _call_intent_with_command_line_args = 0;
 
 public:
 	GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_godot_instance);
@@ -100,6 +102,7 @@ public:
 	bool is_activity_resumed();
 	void vibrate(int p_duration_ms);
 	String get_input_fallback_mapping();
+	void call_intent_with_command_line_args(String intent, List<String> args);
 };
 
 #endif /* !JAVA_GODOT_WRAPPER_H */

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -121,6 +121,10 @@ public:
 
 	void vibrate_handheld(int p_duration_ms) override;
 
+	virtual String get_config_path() const override;
+
+	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id) override;
+
 	virtual bool _check_internal_feature_support(const String &p_feature) override;
 	OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_godot_io_java, bool p_use_apk_expansion);
 	~OS_Android();


### PR DESCRIPTION
with the headstart of @fahrstuhl and my stubbornness android port is starting to look like it getting somewhere

Issue discussing this feature https://github.com/godotengine/godot/issues/267
Proposal for this feature: https://github.com/godotengine/godot-proposals/issues/3931

currently in wip because

- [x] Messy code (and hacky code), would like to get comments on it
- [x] The editor expect double click, which double tap is not (and I"m pretty sure double tap is not in the api)
- [x] Can't work on master because it's broken for android (or at least to tools build on android, didn't test without tools true) (opend on 3.2 so we can see the actual changes)
- [x] gradle way to detect normal build vs android studio build so normal build will add `no sign` to gradle build task and will not build with tools
- [ ] And more real life testing

Build instruction https://github.com/godotengine/godot/pull/36776#issuecomment-645644153

[Android Editor apk if you want to test it for yourself (arm64v8)](https://mega.nz/folder/u6IHQI4R#OLMeA8tqwWL_2T8vEo6CRQ)

EDIT: replaced apk with release_debug version, with directory bug fixed
EDIT2: recompiled over newer master commit (5d880bf7db7f46b1509bbe3ed704ea8acbf8e151)
EDIT3: uploaded a new version and now link set to build folder where I will upload newer versions instead of editing the link everytime