### PR TITLE
Fix script bug for static functions inside other static functions

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -387,6 +387,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		}
 	}
 
+	static_ref = script;
+
 	String err_text;
 
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
A previous commit got rid of the initialization of the static_ref
for use in _get_variant in gdscript_function.cpp. This caused
nested static functions not to be called and produced a
"CALL_ERROR_INVALID_METHOD" error.

The issue was fixed by initializing the static_ref, now defined in gdscript_function.cpp, to be initialized to script, which would be the GDScript for the call. I'm open to other implementations if necessary.

Commit that introduced bug: https://github.com/godotengine/godot/commit/4d960efafc64f0f94f68158ca49ed7f3dd9742dc
Report of bug: https://github.com/godotengine/godot/issues/36765