### PR TITLE
Remove '/permissive-' flag from Windows MSVC build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -330,7 +330,7 @@ if selected_platform in platform_list:
     else:
         # MSVC doesn't have clear C standard support, /std only covers C++.
         # We apply it to CCFLAGS (both C and C++ code) in case it impacts C features.
-        env.Prepend(CCFLAGS=['/std:c++17', '/permissive-'])
+        env.Prepend(CCFLAGS=['/std:c++17'])
 
     # Enforce our minimal compiler version requirements
     cc_version = methods.get_compiler_version(env) or [-1, -1]


### PR DESCRIPTION
This flag is causing compilation issues with headers from older versions of Windows SDK (before 10.0.16299.0).

Follow-up from https://github.com/godotengine/godot/pull/36685#issuecomment-594445616
@akien-mga 

Fixes #36671