### PR TITLE
SCons: Expand env variables to check compiler version

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1,5 +1,4 @@
 import os
-import os.path
 import re
 import glob
 import subprocess
@@ -564,7 +563,11 @@ def get_compiler_version(env):
     if not env.msvc:
         # Not using -dumpversion as some GCC distros only return major, and
         # Clang used to return hardcoded 4.2.1: # https://reviews.llvm.org/D56803
-        version = decode_utf8(subprocess.check_output([env['CXX'], '--version']).strip())
+        try:
+            version = decode_utf8(subprocess.check_output([env.subst(env['CXX']), '--version']).strip())
+        except (subprocess.CalledProcessError, OSError):
+            print("Couldn't parse CXX environment variable to infer compiler version.")
+            return None
     else:  # TODO: Implement for MSVC
         return None
     match = re.search('[0-9]+\.[0-9.]+', version)

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -1,7 +1,7 @@
 import os
 import platform
 import sys
-from methods import get_compiler_version, using_gcc, using_clang
+from methods import using_gcc, using_clang
 
 
 def is_active():


### PR DESCRIPTION
Scons' `Environment.subst()` does that, and was already used in the
other place where we query an env variable (`env["LINK"]` in x11 code).

Fixes `3.2` iOS build after cherry-pick of #36559 (previously it only
ran for GCC code, not iOS's Clang), and the same issue would likely
affect `master` if iOS builds were enabled right now.