### PR TITLE
Change LINKFLAGS to FRAMEWORKS which is supported since Scons release 0.96.91

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -151,13 +151,13 @@ def configure(env):
 
     env.Prepend(CPPPATH=['#platform/osx'])
     env.Append(CPPDEFINES=['OSX_ENABLED', 'UNIX_ENABLED', 'APPLE_STYLE_KEYS', 'COREAUDIO_ENABLED', 'COREMIDI_ENABLED'])
-    env.Append(LINKFLAGS=['-framework', 'Cocoa', '-framework', 'Carbon', '-framework', 'AudioUnit', '-framework', 'CoreAudio', '-framework', 'CoreMIDI', '-framework', 'IOKit', '-framework', 'ForceFeedback', '-framework', 'CoreVideo', '-framework', 'AVFoundation', '-framework', 'CoreMedia'])
+    env.AppendUnique(FRAMEWORKS=['Cocoa', 'Carbon', 'AudioUnit', 'CoreAudio', 'CoreMIDI', 'IOKit', 'ForceFeedback', 'CoreVideo', 'AVFoundation', 'CoreMedia'])
     env.Append(LIBS=['pthread', 'z'])
 
     env.Append(CPPDEFINES=['VULKAN_ENABLED'])
-    env.Append(LINKFLAGS=['-framework', 'Metal', '-framework', 'QuartzCore', '-framework', 'IOSurface'])
+    env.AppendUnique(FRAMEWORKS=['Metal', 'QuartzCore', 'IOSurface'])
     if (env['use_static_mvk']):
-        env.Append(LINKFLAGS=['-framework', 'MoltenVK'])
+        env.AppendUnique(FRAMEWORKS=['MoltenVK'])
         env['builtin_vulkan'] = False
     elif not env['builtin_vulkan']:
         env.Append(LIBS=['vulkan'])


### PR DESCRIPTION
Fixes the link errors below

clang: error: no such file or directory: 'Carbon'
clang: error: no such file or directory: 'AudioUnit'
clang: error: no such file or directory: 'CoreAudio'
clang: error: no such file or directory: 'CoreMIDI'
clang: error: no such file or directory: 'IOKit'
clang: error: no such file or directory: 'ForceFeedback'
clang: error: no such file or directory: 'CoreVideo'
clang: error: no such file or directory: 'AVFoundation'
clang: error: no such file or directory: 'CoreMedia'
clang: error: no such file or directory: 'Metal'
clang: error: no such file or directory: 'QuartzCore'

Tested on
System Version: macOS 10.15.3 (19D76)

SCons by Steven Knight et al.:
script: v3.1.2.bee7caf9defd6e108fc2998a2520ddb36a967691, 2019-12-17 02:07:09, by bdeegan on octodog
engine: v3.1.2.bee7caf9defd6e108fc2998a2520ddb36a967691, 2019-12-17 02:07:09, by bdeegan on octodog
engine path: ['/usr/local/Cellar/scons/3.1.2_1/libexec/scons-local/SCons']

Xcode 11.3.1
Build version 11C504

Apple clang version 11.0.0 (clang-1100.0.33.17)
Target: x86_64-apple-darwin19.3.0

Closes #36720