### PR TITLE
Automatically fix name clashes on instantiation in editor

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -271,16 +271,22 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 					if (parent) {
 						// check name of node: parent instance might have added a node with the
 						// same name since the last time this scene was opened (Fixes #26390)
-						if (Engine::get_singleton()->is_editor_hint()) {
-							parent->add_child(node, true);
-							if (snames[n.name] != node->get_name()) {
-								// The node got renamed
+						parent->_validate_child_name(node, Engine::get_singleton()->is_editor_hint());
+
+						if (snames[n.name] != node->get_name()) {
+							// The name is already taken by a different child
+							if (Engine::get_singleton()->is_editor_hint()) {
 								ERR_PRINT(vformat("Duplicate names: Node '%s' already has a child with name '%s'. The duplicate child has been renamed to '%s'.",
 										parent->get_name(), snames[n.name], node->get_name()));
+							} else {
+								ERR_PRINT(vformat("Duplicate names: Node '%s' already has a child with name '%s'.",
+										parent->get_name(), snames[n.name]));
 							}
-						} else {
-							parent->_add_child_nocheck(node, snames[n.name]);
 						}
+						// only rename node if in editor, else use stored name
+						StringName actual_name = Engine::get_singleton()->is_editor_hint() ? node->get_name() : snames[n.name];
+						parent->_add_child_nocheck(node, actual_name);
+
 						if (n.index >= 0 && n.index < parent->get_child_count() - 1)
 							parent->move_child(node, n.index);
 					} else {


### PR DESCRIPTION
This is a very basic fix for #26390.

When instancing dependent scenes in the editor the clashing names are now automatically changed and an error is logged. The renaming is done during PackedScene/SceneState::instance but only when the scene is opened in the editor. I currently did this only for the editior, as I think that automatic renaming while in-game would cause even more confusion to the user. (Compared to the current state of having multiple nodes with the same path/name.)

### Caveats

It is not very obvious to the user that renaming took place as this is only logged as an error in the console and the scene is not displayed as modified [(*) marking in scene tab is missing]. 
The renaming needs to be implemented somewhere else to solve these issues.

### Different Approaches
While trying to fix the issue my first intuition was to check for name clashes while loading the scene through ResourceLoader. During resource loading dependency errors can occur. These dependency errors are currently all 'missing dependency'-error. These can be resolved using the DependencyEditor, if they occur during loading. As the name duplication also is some type of dependency error - a 'name clash with dependency'-error - my idea was to generalize the notion of dependency errors and extend the DependencyEditor with a way to resolve name clashes.

However, this approach has two complications:
1. ResourceLoaders only create a PackedScene with SceneState in which it is very difficult to detect name clashes. As SceneStates only have a representation of the serialized scene, no nodes are instanced. Hence the node hierarchy is not immediately traversable, since all nodes are just `int` identifiers with another int-id referencing their parents. Finding name clashes would require to reimplement a node tree traversal on the level of SceneStates/PackedScenes.

2. This approach would not show effects when the dependent scene is currently opened. When switching to the dependent scene (as done e.g. in #28133) the editor uses `EditorData::check_and_update_scene(int p_idx)` to refresh the scene and show the newly added node. This is done by packing and reinstancing the current scene:
https://github.com/godotengine/godot/blob/080b5df6256a368fcd767aec96dd2200194542c8/editor/editor_data.cpp#L642-L645
Hence the resource loader is not involved there and the check would not be performed when implemented in the resource loaders. Thus the solution must be implemented in the instantiation too (code duplication) or else we need to change the way the scene is updated. The last one might be possible by writing the packed scene to a temporary file and load from this instead. But this in turn could have other side effects which need to be considered and handled.

So this approach is probably too much work.

Here is another idea: Implementing more detailed error handling for PackedScene instancing.
I noticed that the ResourceLoader class has static callbacks to inform about errors during loading:
https://github.com/godotengine/godot/blob/080b5df6256a368fcd767aec96dd2200194542c8/core/io/resource_loader.h#L162-L176

As far as I can tell `notify_load_error/err_notify` is used nowhere and `notify_dependency_error/dep_err_notify` is only set by the EditorNode. This allows the engine to show the DependencyEditor to fix dependencies when in-editor and letting loading fail immediately with a (logged) error when in-game. Implementing a similar approach for PackedScene/SceneState on instancing of scenes would allow the editor to provide better guidance for the user in case of problems (like name clashes introduced by dependencies) while still simply failing (with a logged error) in-game.

While requiring more in-depth work on SceneState, EditorNode and the creation of a NameClashResolver (similar to DependencyEditor) I think that this approach would give the best user experience. One might also be able to use it to make other editor errors more prominent to the user.

Another way to solve the problem would be moving the automatic renaming into the EditorNode where it is performed as part of loading and updating of scenes. Here it can be implemented as a series of undo/redo operations and hence correctly show the scene as modified. However this still does not solve the problem of properly informing the user about the renaming.

I would like to hear your opinions on the possible solutions.

Fixes #26390
_Bugsquad edit:_ Fixes #14680 too