### PR TITLE
Added to .gitignore - Cppcheck folder and Gcov, Lcov code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -346,3 +346,23 @@ compile_commands.json
 
 # Cppcheck
 *.cppcheck
+cppcheck-cppcheck-build-dir/
+
+# Gcov and Lcov code coverage
+*.gcno
+*.gcda
+*.gcov.html
+*.func.html
+*.func-sort-c.html
+*index-sort-f.html
+*index-sort-l.html
+*index.html
+MachineIndependent/
+godot.info
+amber.png
+emerald.png
+glass.png
+ruby.png
+snow.png
+updown.png
+gcov.css


### PR DESCRIPTION
Lcov create really strange files like `snow.png` or `amber.png`