### PR TITLE
Mono: Fix detection of Apple platforms in build script

### DIFF
--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -163,7 +163,7 @@ def configure(env, env_mono):
 
             copy_file(mono_bin_path, '#bin', mono_dll_name + '.dll')
     else:
-        is_apple = (sys.platform == 'darwin' or "osxcross" in env)
+        is_apple = env['platform'] in ['osx', 'iphone']
 
         sharedlib_ext = '.dylib' if is_apple else '.so'
 


### PR DESCRIPTION
As advised by @neikeq in https://github.com/godotengine/godot/issues/36692#issuecomment-593158144

Fixes #36508.