### PR TITLE
Fix auto set_scale to (0,0)

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -581,6 +581,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/2d/simple_panning", false);
 	_initial_set("editors/2d/scroll_to_pan", false);
 	_initial_set("editors/2d/pan_speed", 20);
+	_initial_set("editors/2d/allow_zero_scale", false);
 
 	// Polygon editor
 	_initial_set("editors/poly_editor/point_grab_radius", 8);

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -35,6 +35,8 @@
 #include "scene/main/viewport.h"
 #include "servers/visual_server.h"
 
+#include "editor/editor_node.h"
+
 #ifdef TOOLS_ENABLED
 Dictionary Node2D::_edit_get_state() const {
 
@@ -174,9 +176,9 @@ void Node2D::set_scale(const Size2 &p_scale) {
 		((Node2D *)this)->_update_xform_values();
 	_scale = p_scale;
 	// Avoid having 0 scale values, can lead to errors in physics and rendering.
-	if (_scale.x == 0)
+	if (_scale.x == 0 && !EditorSettings::get_singleton()->get("editors/2d/allow_zero_scale"))
 		_scale.x = CMP_EPSILON;
-	if (_scale.y == 0)
+	if (_scale.y == 0 && !EditorSettings::get_singleton()->get("editors/2d/allow_zero_scale"))
 		_scale.y = CMP_EPSILON;
 	_update_transform();
 	_change_notify("scale");


### PR DESCRIPTION
This PR fixes #35081. Currently I have implemented a setting to prevent this automatic set_scale (see 71e23ed). I've marked this as a draft because I have not yet implemented functions that will prevent issues from happening when (0,0) is not auto set.
Fixes #36748 (duplicate of #35081)