### PR TITLE
Fix some bugs spotted by asan in editor debugger.

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -91,6 +91,7 @@ EditorDebuggerInspector::EditorDebuggerInspector() {
 }
 
 EditorDebuggerInspector::~EditorDebuggerInspector() {
+	clear_cache();
 	memdelete(variables);
 }
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1423,7 +1423,7 @@ void ScriptEditorDebugger::_clear_errors_list() {
 	error_tree->clear();
 	error_count = 0;
 	warning_count = 0;
-	_notification(NOTIFICATION_PROCESS);
+	update_tabs();
 }
 
 // Right click on specific file(s) or folder(s).
@@ -1834,7 +1834,5 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 ScriptEditorDebugger::~ScriptEditorDebugger() {
 
 	ppeer->set_stream_peer(Ref<StreamPeer>());
-
-	inspector->clear_cache();
 	memdelete(scene_tree);
 }


### PR DESCRIPTION
EditorDebuggerInspector is in tree, so it gets automatically deleted,
when clearing errors the debugger should not fake a process notification.

Fixes #36797 .