### PR TITLE
Play audio automatically when double-clicking audio file

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -36,6 +36,7 @@
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
+#include "editor/plugins/audio_stream_editor_plugin.h"
 #include "editor_feature_profile.h"
 #include "editor_node.h"
 #include "editor_resource_preview.h"
@@ -831,6 +832,15 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 			editor->open_request(fpath);
 		} else {
 			editor->load_resource(fpath);
+			if (ResourceLoader::get_resource_type(fpath).begins_with("AudioStream")) {
+				for (int i = 0; i < EditorNode::get_editor_data().get_editor_plugin_count(); i++) {
+					AudioStreamEditorPlugin *ep = Object::cast_to<AudioStreamEditorPlugin>(EditorNode::get_editor_data().get_editor_plugin(i));
+					if (ep != nullptr) {
+						ep->play();
+						break;
+					}
+				}
+			}
 		}
 	}
 	_navigate_to_path(fpath, p_select_in_favorites);

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -106,7 +106,7 @@ void AudioStreamEditor::_changed_callback(Object *p_changed, const char *p_prop)
 	update();
 }
 
-void AudioStreamEditor::_play() {
+void AudioStreamEditor::play() {
 
 	if (_player->is_playing()) {
 		_player->stop();
@@ -231,7 +231,7 @@ AudioStreamEditor::AudioStreamEditor() {
 	_play_button = memnew(ToolButton);
 	hbox->add_child(_play_button);
 	_play_button->set_focus_mode(Control::FOCUS_NONE);
-	_play_button->connect("pressed", callable_mp(this, &AudioStreamEditor::_play));
+	_play_button->connect("pressed", callable_mp(this, &AudioStreamEditor::play));
 
 	_stop_button = memnew(ToolButton);
 	hbox->add_child(_stop_button);
@@ -275,6 +275,10 @@ AudioStreamEditorPlugin::AudioStreamEditorPlugin(EditorNode *p_node) {
 	audio_editor = memnew(AudioStreamEditor);
 	add_control_to_container(CONTAINER_PROPERTY_EDITOR_BOTTOM, audio_editor);
 	audio_editor->hide();
+}
+
+void AudioStreamEditorPlugin::play() {
+	audio_editor->play();
 }
 
 AudioStreamEditorPlugin::~AudioStreamEditorPlugin() {

--- a/editor/plugins/audio_stream_editor_plugin.h
+++ b/editor/plugins/audio_stream_editor_plugin.h
@@ -57,7 +57,6 @@ class AudioStreamEditor : public ColorRect {
 protected:
 	void _notification(int p_what);
 	void _preview_changed(ObjectID p_which);
-	void _play();
 	void _stop();
 	void _on_finished();
 	void _draw_preview();
@@ -68,6 +67,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	void play();
 	void edit(Ref<AudioStream> p_stream);
 	AudioStreamEditor();
 };
@@ -85,6 +85,7 @@ public:
 	virtual void edit(Object *p_object);
 	virtual bool handles(Object *p_object) const;
 	virtual void make_visible(bool p_visible);
+	void play();
 
 	AudioStreamEditorPlugin(EditorNode *p_node);
 	~AudioStreamEditorPlugin();


### PR DESCRIPTION
Close godotengine/godot-proposals#556

Update : play audio automatically only when double-clicking on file system panel, not opening it by resouce in inspector panel.