### PR TITLE
Signals: Don't pass default binds to EditorProperty property_changed

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "editor_inspector.h"
+
 #include "array_property_edit.h"
 #include "dictionary_property_edit.h"
 #include "editor_feature_profile.h"
@@ -1358,7 +1359,7 @@ void EditorInspector::_parse_added_editors(VBoxContainer *current_vbox, Ref<Edit
 		if (ep) {
 
 			ep->object = object;
-			ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed), make_binds(StringName(), false));
+			ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed));
 			ep->connect("property_keyed", callable_mp(this, &EditorInspector::_property_keyed));
 			ep->connect("property_keyed_with_value", callable_mp(this, &EditorInspector::_property_keyed_with_value));
 			ep->connect("property_checked", callable_mp(this, &EditorInspector::_property_checked));
@@ -1770,9 +1771,9 @@ void EditorInspector::update_tree() {
 
 				if (ep) {
 
-					ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed), make_binds(StringName(), false));
+					ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed));
 					if (p.usage & PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED) {
-						ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed_update_all), make_binds(StringName(), false), CONNECT_DEFERRED);
+						ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed_update_all), varray(), CONNECT_DEFERRED);
 					}
 					ep->connect("property_keyed", callable_mp(this, &EditorInspector::_property_keyed));
 					ep->connect("property_keyed_with_value", callable_mp(this, &EditorInspector::_property_keyed_with_value));

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -165,7 +165,7 @@ EditorPropertyDictionaryObject::EditorPropertyDictionaryObject() {
 
 ///////////////////// ARRAY ///////////////////////////
 
-void EditorPropertyArray::_property_changed(const String &p_property, Variant p_value, const StringName &p_name, bool p_changing) {
+void EditorPropertyArray::_property_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
 
 	if (p_property.begins_with("indices")) {
 		int idx = p_property.get_slice("/", 1).to_int();
@@ -359,7 +359,7 @@ void EditorPropertyArray::update_property() {
 			prop->set_object_and_property(object.ptr(), prop_name);
 			prop->set_label(itos(i + offset));
 			prop->set_selectable(false);
-			prop->connect("property_changed", callable_mp(this, &EditorPropertyArray::_property_changed), make_binds(StringName(), false));
+			prop->connect("property_changed", callable_mp(this, &EditorPropertyArray::_property_changed));
 			prop->connect("object_id_selected", callable_mp(this, &EditorPropertyArray::_object_id_selected));
 			prop->set_h_size_flags(SIZE_EXPAND_FILL);
 
@@ -528,7 +528,7 @@ EditorPropertyArray::EditorPropertyArray() {
 
 ///////////////////// DICTIONARY ///////////////////////////
 
-void EditorPropertyDictionary::_property_changed(const String &p_property, Variant p_value, const StringName &p_name, bool p_changing) {
+void EditorPropertyDictionary::_property_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
 
 	if (p_property == "new_item_key") {
 
@@ -932,7 +932,7 @@ void EditorPropertyDictionary::update_property() {
 			}
 
 			prop->set_selectable(false);
-			prop->connect("property_changed", callable_mp(this, &EditorPropertyDictionary::_property_changed), make_binds(StringName(), false));
+			prop->connect("property_changed", callable_mp(this, &EditorPropertyDictionary::_property_changed));
 			prop->connect("object_id_selected", callable_mp(this, &EditorPropertyDictionary::_object_id_selected));
 
 			HBoxContainer *hb = memnew(HBoxContainer);

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -100,7 +100,7 @@ class EditorPropertyArray : public EditorProperty {
 	void _page_changed(double p_page);
 	void _length_changed(double p_page);
 	void _edit_pressed();
-	void _property_changed(const String &p_property, Variant p_value, const StringName &p_name = StringName(), bool p_changing = false);
+	void _property_changed(const String &p_property, Variant p_value, const String &p_name = "", bool p_changing = false);
 	void _change_type(Object *p_button, int p_index);
 	void _change_type_menu(int p_index);
 
@@ -135,7 +135,7 @@ class EditorPropertyDictionary : public EditorProperty {
 
 	void _page_changed(double p_page);
 	void _edit_pressed();
-	void _property_changed(const String &p_property, Variant p_value, const StringName &p_name = StringName(), bool p_changing = false);
+	void _property_changed(const String &p_property, Variant p_value, const String &p_name = "", bool p_changing = false);
 	void _change_type(Object *p_button, int p_index);
 	void _change_type_menu(int p_index);
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2978,7 +2978,7 @@ class VisualShaderNodePluginDefaultEditor : public VBoxContainer {
 	Ref<Resource> parent_resource;
 
 public:
-	void _property_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field = StringName(), bool p_changing = false) {
+	void _property_changed(const String &p_property, const Variant &p_value, const String &p_field = "", bool p_changing = false) {
 
 		if (p_changing)
 			return;
@@ -3072,7 +3072,7 @@ public:
 				p_properties[i]->connect("resource_selected", callable_mp(this, &VisualShaderNodePluginDefaultEditor::_resource_selected));
 			}
 
-			properties[i]->connect("property_changed", callable_mp(this, &VisualShaderNodePluginDefaultEditor::_property_changed), make_binds(StringName(), false));
+			properties[i]->connect("property_changed", callable_mp(this, &VisualShaderNodePluginDefaultEditor::_property_changed));
 			properties[i]->set_object_and_property(node.ptr(), p_names[i]);
 			properties[i]->update_property();
 			properties[i]->set_name_split_ratio(0);


### PR DESCRIPTION
This was done by mistake in #36758, but it's not necessary and actual
causes a bug.

`property_changed` is only emitted via `emit_changed()`, which already
has default values for `p_field` and `p_changing`.

Also reverted to using `String` for now to be on the safe side, even if
it's inconsistent with `emit_changed()`. I had only changed it
partially in #36758 so it was inconsistent. It probably does make sense
to port `EditorInspector` and related property editors to use
`StringName` where relevant, but that's for a dedicated PR.

Fixes #36799.