### PR TITLE
Fix environment bgmode Canvas in GLES3

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4380,8 +4380,6 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 				glActiveTexture(GL_TEXTURE0);
 				glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->color);
 
-				storage->shaders.copy.set_conditional(CopyShaderGLES3::DISABLE_ALPHA, true);
-
 				storage->shaders.copy.set_conditional(CopyShaderGLES3::SRGB_TO_LINEAR, true);
 
 				storage->shaders.copy.bind();
@@ -4390,7 +4388,6 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 
 				//turn off everything used
 				storage->shaders.copy.set_conditional(CopyShaderGLES3::SRGB_TO_LINEAR, false);
-				storage->shaders.copy.set_conditional(CopyShaderGLES3::DISABLE_ALPHA, false);
 
 				//restore
 				glEnable(GL_BLEND);


### PR DESCRIPTION
Viewport textures are now copied with transparency, if Environment has background mode "Canvas".
Fixes #36817