### PR TITLE
Mono/C#: Add missing parameters to 'ResourceLoader.Load<T>()'

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ResourceLoaderExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ResourceLoaderExtensions.cs
@@ -2,9 +2,9 @@ namespace Godot
 {
     public static partial class ResourceLoader
     {
-        public static T Load<T>(string path) where T : class
+        public static T Load<T>(string path, string typeHint = null, bool noCache = false) where T : class
         {
-            return (T)(object)Load(path);
+            return (T)(object)Load(path, typeHint, noCache);
         }
     }
 }


### PR DESCRIPTION
#20600 added a convenient generic method 'ResourceLoader.Load<T>()'. Unfortunately, it didn't expose all the parameters of the original function, meaning it couldn't be used in some cases. This PR adds the missing parameters.