### PR TITLE
Fix gamepad disconnection callback on macOS Catalina.

### DIFF
--- a/platform/osx/joypad_osx.h
+++ b/platform/osx/joypad_osx.h
@@ -103,6 +103,7 @@ private:
 	bool configure_joypad(IOHIDDeviceRef p_device_ref, joypad *p_joy);
 
 	int get_joy_index(int p_id) const;
+	int get_joy_ref(IOHIDDeviceRef p_device) const;
 
 	void poll_joypads() const;
 	void setup_joypad_objects();
@@ -115,7 +116,7 @@ public:
 	void process_joypads();
 
 	void _device_added(IOReturn p_res, IOHIDDeviceRef p_device);
-	void _device_removed(int p_id);
+	void _device_removed(IOReturn p_res, IOHIDDeviceRef p_device);
 
 	JoypadOSX();
 	~JoypadOSX();


### PR DESCRIPTION
Replace IOHIDDeviceRegisterRemovalCallback with IOHIDManagerRegisterDeviceRemovalCallback to fix gamepad disconnection callback on macOS Catalina.

https://github.com/spurious/SDL-mirror/commit/591bf09c87144f68d921c92699829dcf7176d3f3
https://forums.developer.apple.com/thread/124444

Fixes #35115