### PR TITLE
GDScript::_owner type changed from GDScript* to Ref<GDScript>

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -940,7 +940,7 @@ GDScript::GDScript() :
 	subclass_count = 0;
 	initializer = nullptr;
 	_base = nullptr;
-	_owner = nullptr;
+	_owner.unref();
 	tool = false;
 #ifdef TOOLS_ENABLED
 	source_changed_cache = false;
@@ -964,7 +964,7 @@ void GDScript::_save_orphaned_subclasses() {
 	Vector<ClassRefWithName> weak_subclasses;
 	// collect subclasses ObjectID and name
 	for (Map<StringName, Ref<GDScript>>::Element *E = subclasses.front(); E; E = E->next()) {
-		E->get()->_owner = nullptr; //bye, you are no longer owned cause I died
+		E->get()->_owner.unref(); //bye, you are no longer owned cause I died
 		ClassRefWithName subclass;
 		subclass.id = E->get()->get_instance_id();
 		subclass.fully_qualified_name = E->get()->fully_qualified_name;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -78,7 +78,7 @@ class GDScript : public Script {
 	Ref<GDScriptNativeClass> native;
 	Ref<GDScript> base;
 	GDScript *_base; //fast pointer access
-	GDScript *_owner; //for subclasses
+	Ref<GDScript> _owner; //for subclasses
 
 	Set<StringName> members; //members are just indices to the instanced script.
 	Map<StringName, Variant> constants;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -302,7 +302,7 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 					}
 				}
 
-				owner = owner->_owner;
+				owner = owner->_owner.ptr();
 			}
 
 			if (GDScriptLanguage::get_singleton()->get_global_map().has(identifier)) {
@@ -1824,12 +1824,12 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 
 	if (p_class->owner && p_class->owner->owner) {
 		// Owner is not root
-		if (!parsed_classes.has(p_script->_owner)) {
-			if (parsing_classes.has(p_script->_owner)) {
+		if (!parsed_classes.has(p_script->_owner.ptr())) {
+			if (parsing_classes.has(p_script->_owner.ptr())) {
 				_set_error("Cyclic class reference for '" + String(p_class->name) + "'.", p_class);
 				return ERR_PARSE_ERROR;
 			}
-			Error err = _parse_class_level(p_script->_owner, p_class->owner, p_keep_state);
+			Error err = _parse_class_level(p_script->_owner.ptr(), p_class->owner, p_keep_state);
 			if (err) {
 				return err;
 			}
@@ -2136,7 +2136,7 @@ void GDScriptCompiler::_make_scripts(GDScript *p_script, const GDScriptParser::C
 			}
 		}
 
-		subclass->_owner = p_script;
+		subclass->_owner.reference_ptr(p_script);
 		subclass->fully_qualified_name = fully_qualified_name;
 		p_script->subclasses.insert(name, subclass);
 
@@ -2162,7 +2162,7 @@ Error GDScriptCompiler::compile(const GDScriptParser *p_parser, GDScript *p_scri
 	// Create scripts for subclasses beforehand so they can be referenced
 	_make_scripts(p_script, static_cast<const GDScriptParser::ClassNode *>(root), p_keep_state);
 
-	p_script->_owner = nullptr;
+	p_script->_owner.unref();
 	Error err = _parse_class_level(p_script, static_cast<const GDScriptParser::ClassNode *>(root), p_keep_state);
 
 	if (err)

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -81,7 +81,7 @@ Variant *GDScriptFunction::_get_variant(int p_address, GDScriptInstance *p_insta
 					if (E) {
 						return &E->get();
 					}
-					o = o->_owner;
+					o = o->_owner.ptr();
 				}
 				s = s->_base;
 			}

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1097,10 +1097,10 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 					GDScript *p = base.ptr();
 					Vector<StringName> sname;
 
-					while (p->_owner) {
+					while (p->_owner.ptr()) {
 
 						sname.push_back(p->name);
-						p = p->_owner;
+						p = p->_owner.ptr();
 					}
 					sname.invert();
 


### PR DESCRIPTION
Fix: #35857
Fix: #5843
Fix: #5726

fix explained in the comments of the code below
```gdscript
## Node2D.gd
extends Node2D

const SUB_CLASS_REF = preload("res://new_script.gd").SubClass
## now the "new_script.gd" (GDScript resource) is deleted 
## but SubClass has reference so it's not deleted
## and SubClass (GDScript) `_owner` is now `NULL` (deleted)

func _init():
	var sub_class_instance = SUB_CLASS_REF.new()
```

```gdscript
## new_script.gd
extends Node

const CONSTANT_STRING = 'CONST STRING'

class SubClass:
	## after the "new_script.gd" (GDScript) deleted 
	## there will be no `_owner` for this class/script 
	## and no `_owner.constants` which has CONSTANT_STRING 
	## so the below constant is invalid (BUG!!!)
	var const_str = CONSTANT_STRING

```


**EDIT**
another possible scenario
```gdscript
## vect.gd
extends Node

class Vect:
	static func new_vect(x:float, y:float):
		return Vect.new()
```

```gdscript
## node2d.gd
extends Node2D

const Vect = preload("res://vect.gd").Vect
var v1 = Vect.new_vect(1, 1) ## internal script error report please
```


 
