### PR TITLE
Added navigation mesh merging error.

### DIFF
--- a/modules/gdnavigation/nav_map.cpp
+++ b/modules/gdnavigation/nav_map.cpp
@@ -657,6 +657,7 @@ void NavMap::sync() {
 					connection->get().B->edges[connection->get().B_edge].other_edge = connection->get().A_edge;
 				} else {
 					// The edge is already connected with another edge, skip.
+					ERR_PRINT("Attempted to merge a navigation mesh triangle edge with another already-merged edge. This happens when the Navigation's `cell_size` is different from the one used to generate the navigation mesh. This will cause navigation problem.");
 				}
 			}
 		}


### PR DESCRIPTION
Added error to notify that the Navigation triangle merging failed due to incorrect parameter.

supersede: https://github.com/godotengine/godot/pull/36853