### PR TITLE
On/off VSync support for vulkan

### DIFF
--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -46,6 +46,8 @@ class VulkanContext {
 
 	bool use_validation_layers;
 
+	bool use_vsync;
+
 	VkInstance inst;
 	VkSurfaceKHR surface;
 	VkPhysicalDevice gpu;
@@ -80,6 +82,15 @@ class VulkanContext {
 	} SwapchainImageResources;
 
 	struct Window {
+		static constexpr int ratedPresModesSize = 4;
+		static constexpr VkPresentModeKHR vSyncRatedPresentModes[ratedPresModesSize] = {
+			VK_PRESENT_MODE_FIFO_KHR, ///< VSync On
+			VK_PRESENT_MODE_MAILBOX_KHR,
+			VK_PRESENT_MODE_FIFO_RELAXED_KHR,
+			VK_PRESENT_MODE_IMMEDIATE_KHR, ///< VSync Off
+			// VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR ///< Only Android, disabled for now
+			// VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR  ///< Only Android, disabled for now
+		};
 
 		bool is_minimzed;
 		VkSurfaceKHR surface;
@@ -204,6 +215,9 @@ public:
 	Error prepare_buffers();
 	Error swap_buffers();
 	Error initialize();
+
+	void set_use_vsync(bool p_use);
+	bool is_using_vsync() const;
 
 	VulkanContext();
 	virtual ~VulkanContext();

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1468,6 +1468,9 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 			context_vulkan = NULL;
 			ERR_FAIL_V(ERR_UNAVAILABLE);
 		}
+
+		context_vulkan->set_use_vsync(get_video_mode().use_vsync);
+
 		if (context_vulkan->window_create(hWnd, hInstance, get_video_mode().width, get_video_mode().height) == -1) {
 			memdelete(context_vulkan);
 			context_vulkan = NULL;
@@ -3326,6 +3329,13 @@ void OS_Windows::_set_use_vsync(bool p_enable) {
 	if (video_driver_index == VIDEO_DRIVER_GLES2) {
 		if (context_gles2)
 			context_gles2->set_use_vsync(p_enable);
+	}
+#endif
+
+#if defined(VULKAN_ENABLED)
+	if (video_driver_index == VIDEO_DRIVER_VULKAN) {
+		if (context_vulkan)
+			context_vulkan->set_use_vsync(p_enable);
 	}
 #endif
 }

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -350,6 +350,9 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 			context_vulkan = NULL;
 			ERR_FAIL_V(ERR_UNAVAILABLE);
 		}
+
+		context_vulkan->set_use_vsync(get_video_mode().use_vsync);
+
 		if (context_vulkan->window_create(x11_window, x11_display, get_video_mode().width, get_video_mode().height) == -1) {
 			memdelete(context_vulkan);
 			context_vulkan = NULL;
@@ -3352,6 +3355,13 @@ void OS_X11::_set_use_vsync(bool p_enable) {
 	if (video_driver_index == VIDEO_DRIVER_GLES2) {
 		if (context_gles2)
 			context_gles2->set_use_vsync(p_enable);
+	}
+#endif
+
+#if defined(VULKAN_ENABLED)
+	if (video_driver_index == VIDEO_DRIVER_VULKAN) {
+		if (context_vulkan)
+			context_vulkan->set_use_vsync(p_enable);
 	}
 #endif
 }


### PR DESCRIPTION
Being a boolean setting, the code will choose the best available present mode to fit user's choice.
Presentation modes are ordered from no tearing to non-sync modes (will probably have tearing).

Fixes #36467.