### PR TITLE
Searching editor help centers around the found text (optional)

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2491,7 +2491,7 @@ void RichTextLabel::set_selection_enabled(bool p_enabled) {
 	}
 }
 
-bool RichTextLabel::search(const String &p_string, bool p_from_selection, bool p_search_previous) {
+bool RichTextLabel::search(const String &p_string, bool p_from_selection, bool p_search_previous, bool p_center_result) {
 
 	ERR_FAIL_COND_V(!selection.enabled, false);
 	Item *it = main;
@@ -2534,7 +2534,15 @@ bool RichTextLabel::search(const String &p_string, bool p_from_selection, bool p
 					}
 					item = item->parent;
 				}
-				vscroll->set_value(offset - fh);
+
+				real_t margin;
+
+				if (p_center_result)
+					margin = get_size().height / 2.0f;
+				else
+					margin = fh;
+
+				vscroll->set_value(offset - margin);
 
 				return true;
 			}

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -454,7 +454,7 @@ public:
 	void set_tab_size(int p_spaces);
 	int get_tab_size() const;
 
-	bool search(const String &p_string, bool p_from_selection = false, bool p_search_previous = false);
+	bool search(const String &p_string, bool p_from_selection = false, bool p_search_previous = false, bool p_center_result = true);
 
 	void scroll_to_line(int p_line);
 	int get_line_count() const;


### PR DESCRIPTION
Fortunately (or not?), editor help uses one big RichTextLabel to render items, instead of TextEdit as the Script canvas. 
Thanks to that, fix is based on content height divided in half.

Fixes: #36861