### PR TITLE
Use the `keep` stretch aspect by default

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2193,7 +2193,7 @@ bool Main::start() {
 			//standard helpers that can be changed from main config
 
 			String stretch_mode = GLOBAL_DEF_BASIC("display/window/stretch/mode", "disabled");
-			String stretch_aspect = GLOBAL_DEF_BASIC("display/window/stretch/aspect", "ignore");
+			String stretch_aspect = GLOBAL_DEF_BASIC("display/window/stretch/aspect", "keep");
 			Size2i stretch_size = Size2i(GLOBAL_DEF_BASIC("display/window/size/width", 0),
 					GLOBAL_DEF_BASIC("display/window/size/height", 0));
 
@@ -2252,7 +2252,7 @@ bool Main::start() {
 							"display/window/stretch/mode",
 							PROPERTY_HINT_ENUM,
 							"disabled,canvas_items,viewport"));
-			GLOBAL_DEF_BASIC("display/window/stretch/aspect", "ignore");
+			GLOBAL_DEF_BASIC("display/window/stretch/aspect", "keep");
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/aspect",
 					PropertyInfo(Variant::STRING,
 							"display/window/stretch/aspect",


### PR DESCRIPTION
This makes Godot avoid distortion when resizing the window to an aspect ratio that doesn't match the project's base aspect ratio.

Since this setting has no effect when the stretch mode is `disabled` (the default), this won't impact projects not using the `canvas_items` or `viewport` stretch modes.

PS: I considered also changing the default stretch mode to `canvas_items` (formerly `2d`), but that might be a bit much as it requires UI anchors to be defined to work as expected. You would also pretty much always need to have a Camera2D in your scene for 2D games, even if the camera never moves. This would likely complicate tutorials a bit.

This closes https://github.com/godotengine/godot-proposals/issues/2701.