### PR TITLE
Trim the whitespace around the plugins names

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -42,7 +42,7 @@ ext.getGodotPluginsBinaries = { ->
         String pluginsList = project.property("custom_template_plugins")
         if (pluginsList != null && !pluginsList.trim().isEmpty()) {
             for (String plugin : pluginsList.split(",")) {
-                binDeps += plugin + "*.aar"
+                binDeps += plugin.trim() + "*.aar"
             }
         }
     }

--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPluginRegistry.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPluginRegistry.java
@@ -139,7 +139,10 @@ public final class GodotPluginRegistry {
 					return;
 				}
 
-				enabledPluginsSet = new HashSet<>(Arrays.asList(enabledPluginsList));
+				enabledPluginsSet = new HashSet<>();
+				for (String enabledPlugin : enabledPluginsList) {
+					enabledPluginsSet.add(enabledPlugin.trim());
+				}
 			} else {
 				enabledPluginsSet = null;
 			}
@@ -148,7 +151,7 @@ public final class GodotPluginRegistry {
 			for (String metaDataName : metaData.keySet()) {
 				// Parse the meta-data looking for entry with the Godot plugin name prefix.
 				if (metaDataName.startsWith(GODOT_PLUGIN_V1_NAME_PREFIX)) {
-					String pluginName = metaDataName.substring(godotPluginV1NamePrefixLength);
+					String pluginName = metaDataName.substring(godotPluginV1NamePrefixLength).trim();
 					if (enabledPluginsSet != null && !enabledPluginsSet.contains(pluginName)) {
 						Log.w(TAG, "Plugin " + pluginName + " is listed in the dependencies but is not enabled.");
 						continue;


### PR DESCRIPTION
Having whitespace around the plugin's name causes its initialization to fail since the logic is doing a strict equality check.

The fix has already been added to #36336, so no need for a cherry-pick.