### PR TITLE
Fix: animation autocomplete bug fixed

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1543,7 +1543,7 @@ void AnimationPlayer::get_argument_options(const StringName &p_function, int p_i
 #endif
 
 	String pf = p_function;
-	if (p_function == "play" || p_function == "play_backwards" || p_function == "remove_animation" || p_function == "has_animation" || p_function == "queue") {
+	if (p_idx == 0 && (p_function == "play" || p_function == "play_backwards" || p_function == "remove_animation" || p_function == "has_animation" || p_function == "queue")) {
 		List<StringName> al;
 		get_animation_list(&al);
 		for (List<StringName>::Element *E = al.front(); E; E = E->next()) {


### PR DESCRIPTION
Fix: #36835

the auto complete options get method doesn't checked the argument index, fixed

![anim-autocomplete-bug-fix](https://user-images.githubusercontent.com/41085900/76140464-a9425b00-6080-11ea-9516-f4726eab880e.JPG)
