### PR TITLE
Fix doctool misleading error message

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1509,7 +1509,7 @@ bool Main::start() {
 
 		{
 			DirAccessRef da = DirAccess::open(doc_tool);
-			ERR_FAIL_COND_V_MSG(!da, false, "Argument supplied to --doctool must be a base Godot build directory.");
+			ERR_FAIL_COND_V_MSG(!da, false, "Argument supplied to --doctool must be a valid directory path.");
 		}
 		DocData doc;
 		doc.generate(doc_base);


### PR DESCRIPTION
`godot --doctool <path>` can generate documentation at any directory path, not only the base Godot path.

See also PR godotengine/godot-docs#3006, namely [this diff](https://github.com/godotengine/godot-docs/pull/3006/files#diff-094c4c2b4900c640f3124e699519de02R499-R500).