### PR TITLE
Fix: 'use onready var' error message implemented for .get_child() .get_parent()

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4834,9 +4834,10 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 						OperatorNode *op = static_cast<OperatorNode *>(subexpr);
 						if (op->op == OperatorNode::OP_CALL && op->arguments[0]->type == Node::TYPE_SELF && op->arguments[1]->type == Node::TYPE_IDENTIFIER) {
 							IdentifierNode *id = static_cast<IdentifierNode *>(op->arguments[1]);
-							if (id->name == "get_node") {
+							if (id->name == "get_node" || id->name == "get_child" || id->name == "get_parent") {
 
-								_set_error("Use \"onready var " + String(member.identifier) + " = get_node(...)\" instead.");
+								_set_error("Use \"onready var " + String(member.identifier) + " = " + id->name + "(...)\" instead.");
+								error_line = op->line;
 								return;
 							}
 						}


### PR DESCRIPTION
Fix: #36832
EDIT: error message corrected for each method (old image)
![1](https://user-images.githubusercontent.com/41085900/76150101-acfbcf00-60cc-11ea-91cf-341366abf388.JPG)

also fixed incorrect highlighting error line 
![2](https://user-images.githubusercontent.com/41085900/76150116-cc92f780-60cc-11ea-802b-791af41a8ea5.JPG)
