### PR TITLE
Doctool and core: Fix return type in docs for some Variant methods...

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1526,8 +1526,11 @@ void Variant::get_method_list(List<MethodInfo> *p_list) const {
 		PropertyInfo ret;
 #ifdef DEBUG_ENABLED
 		ret.type = fd.return_type;
-		if (fd.returns)
+		if (fd.returns) {
 			ret.name = "ret";
+			if (fd.return_type == Variant::NIL)
+				ret.usage = PROPERTY_USAGE_NIL_IS_VARIANT;
+		}
 		mi.return_val = ret;
 #endif
 


### PR DESCRIPTION
… assigning PROPERTY_USAGE_NIL_IS_VARIANT to MethodInfo usage when we have something to return

Fixes #36453 

> **Issue description:**
> As seen in #36452, syncing docs today shows changes to the return value of some Variant methods, and some of those changes are bogus, namely the ones changing a valid `Variant` return value to `void`.

The reason of this is in `return_doc_from_retinfo` we don't get the information **properly** to know if a method returns a Variant or void
https://github.com/godotengine/godot/blob/78adce833bce49ef1bf1503956a6162a1c6dd8b2/editor/doc/doc_data.cpp#L167-L185

We can check with `p_retinfo.name == "ret"` to know if a return value has return because is assigned when we construct the MethodInfo List on `Variant::get_method_list`.

But we can also assign PROPERTY_USAGE_NIL_IS_VARIANT in the return PropertyInfo of the MethodInfo

### Explanation

Using as example `back` and `front` of array:

We add those to the `_VariantCall::type_func` (global for mapping functions) with these macros:

https://github.com/godotengine/godot/blob/78adce833bce49ef1bf1503956a6162a1c6dd8b2/core/variant_call.cpp#L1994-L1995

Who are expanded as:

```
_VariantCall::addfunc(true, Variant::ARRAY, Variant::NIL, true /* p_has_return */, _scs_create("front"), VCALL(Array, front), varray());
_VariantCall::addfunc(true, Variant::ARRAY, Variant::NIL, true /* p_has_return */, _scs_create("back"), VCALL(Array, back), varray());
```
(observe this addfunc is telling there are a return data, and the return data is Variant::NIL type)

So our FuncData as the information to know if that func return a value, and we only assign the return name when the docs ask to the MethodInfo List on:

https://github.com/godotengine/godot/blob/78adce833bce49ef1bf1503956a6162a1c6dd8b2/core/variant_call.cpp#L1528-L1531

On conclusion, we can also add PROPERTY_USAGE_NIL_IS_VARIANT for Variant::NIL to the MethodInfo.