### PR TITLE
Fix AudioStreamEditor playing wav files only once

### DIFF
--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -131,10 +131,12 @@ void AudioStreamEditor::_stop() {
 void AudioStreamEditor::_on_finished() {
 
 	_play_button->set_icon(get_icon("MainPlay", "EditorIcons"));
+	_current = _player->get_playback_position();
 	if (_current == _player->get_stream()->get_length()) {
 		_current = 0;
 		_indicator->update();
 	}
+	set_process(false);
 }
 
 void AudioStreamEditor::_draw_indicator() {


### PR DESCRIPTION
Fixes #36816

`AudioStreamEditor` was not updating `_current` when the playback finished, thus not resetting the position of the cursor.

I also called `set_process(false)` to avoid processing while nothing is playing anymore.