### PR TITLE
Enable Android Studio debugging

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -71,6 +71,7 @@ android {
     packagingOptions {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
+        doNotStrip '**/*.so'
     }
 
     // Both signing and zip-aligning will be done at export time

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -25,7 +25,7 @@ ext {
     sconsExt = org.gradle.internal.os.OperatingSystem.current().isWindows() ? ".bat" : ""
 
     supportedAbis = ["armv7", "arm64v8", "x86", "x86_64"]
-    supportedTargets = ['release': "release", 'debug': "release_debug"]
+    supportedTargets = ["release", "debug"]
 
     // Used by gradle to specify which architecture to build for by default when running `./gradlew build`.
     // This command is usually used by Android Studio.
@@ -136,14 +136,14 @@ task zipCustomBuild(type: Zip) {
  */
 task generateGodotTemplates(type: GradleBuild) {
     // We exclude these gradle tasks so we can run the scons command manually.
-    for (String buildType : supportedTargets.keySet()) {
+    for (String buildType : supportedTargets) {
         startParameter.excludedTaskNames += ":lib:" + getSconsTaskName(buildType)
     }
 
     tasks = ["copyGodotPaymentPluginToAppModule"]
 
     // Only build the apks and aar files for which we have native shared libraries.
-    for (String target : supportedTargets.keySet()) {
+    for (String target : supportedTargets) {
         File targetLibs = new File("lib/libs/" + target)
         if (targetLibs != null
             && targetLibs.isDirectory()

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -26,6 +26,7 @@ android {
     packagingOptions {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
+        doNotStrip '**/*.so'
     }
 
     sourceSets {
@@ -56,7 +57,7 @@ android {
         // files is only setup for editing support.
         gradle.startParameter.excludedTaskNames += taskPrefix + "externalNativeBuild" + buildType
 
-        def releaseTarget = supportedTargets[buildType.toLowerCase()]
+        def releaseTarget = buildType.toLowerCase()
         if (releaseTarget == null || releaseTarget == "") {
             throw new GradleException("Invalid build type: " + buildType)
         }


### PR DESCRIPTION
Updates the gradle build configuration to enable debugging of the Godot codebase using Android Studio.
Fixes #36863.

**Note**: 
- The changes **do not** affect the generation of the release (`release`, `release_debug`, `android_source.zip`, etc) Godot templates.

- The `doNotStrip` packaging option does not affect the size of the generated Godot templates.