### PR TITLE
Add history navigation in the script editor using extra mouse buttons

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -411,6 +411,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/automatically_open_screenshots", true);
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/single_window_mode", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	_initial_set("interface/editor/hide_console_window", false);
+	_initial_set("interface/editor/mouse_extra_buttons_navigate_history", true);
 	_initial_set("interface/editor/save_each_scene_on_quit", true); // Regression
 
 	// Inspector

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2750,6 +2750,29 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 	}
 }
 
+void ScriptEditor::input(const Ref<InputEvent> &p_event) {
+	// This is implemented in `input()` rather than `unhandled_input()` to allow
+	// the shortcut to be used regardless of the click location.
+	// This feature can be disabled to avoid interfering with other uses of the additional
+	// mouse buttons, such as push-to-talk in a VoIP program.
+	if (EDITOR_GET("interface/editor/mouse_extra_buttons_navigate_history")) {
+		const Ref<InputEventMouseButton> mb = p_event;
+
+		// Navigate the script history using additional mouse buttons present on some mice.
+		// This must be hardcoded as the editor shortcuts dialog doesn't allow assigning
+		// more than one shortcut per action.
+		if (mb.is_valid() && mb->is_pressed() && is_visible_in_tree()) {
+			if (mb->get_button_index() == MOUSE_BUTTON_XBUTTON1) {
+				_history_back();
+			}
+
+			if (mb->get_button_index() == MOUSE_BUTTON_XBUTTON2) {
+				_history_forward();
+			}
+		}
+	}
+}
+
 void ScriptEditor::unhandled_key_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
@@ -3294,7 +3317,6 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_update_script_connections", &ScriptEditor::_update_script_connections);
 	ClassDB::bind_method("_help_class_open", &ScriptEditor::_help_class_open);
 	ClassDB::bind_method("_live_auto_reload_running_scripts", &ScriptEditor::_live_auto_reload_running_scripts);
-
 	ClassDB::bind_method("_update_members_overview", &ScriptEditor::_update_members_overview);
 	ClassDB::bind_method("_update_recent_scripts", &ScriptEditor::_update_recent_scripts);
 
@@ -3427,9 +3449,11 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	ED_SHORTCUT("script_editor/window_sort", TTR("Sort"));
 	ED_SHORTCUT("script_editor/window_move_up", TTR("Move Up"), KEY_MASK_SHIFT | KEY_MASK_ALT | KEY_UP);
 	ED_SHORTCUT("script_editor/window_move_down", TTR("Move Down"), KEY_MASK_SHIFT | KEY_MASK_ALT | KEY_DOWN);
-	ED_SHORTCUT("script_editor/next_script", TTR("Next Script"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_PERIOD); // these should be KEY_GREATER and KEY_LESS but those don't work
+	// FIXME: These should be `KEY_GREATER` and `KEY_LESS` but those don't work.
+	ED_SHORTCUT("script_editor/next_script", TTR("Next Script"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_PERIOD);
 	ED_SHORTCUT("script_editor/prev_script", TTR("Previous Script"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_COMMA);
-	set_process_unhandled_key_input(true);
+	set_process_input(true);
+	set_process_unhandled_input(true);
 
 	file_menu = memnew(MenuButton);
 	file_menu->set_text(TTR("File"));

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -418,6 +418,7 @@ class ScriptEditor : public PanelContainer {
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
+	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void unhandled_key_input(const Ref<InputEvent> &p_event) override;
 
 	void _script_list_gui_input(const Ref<InputEvent> &ev);


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/53067.

This adds history navigation in the script/documentation list. It works exactly like the current implementation using <kbd>Alt + Left</kbd> and <kbd>Alt + Right</kbd>, but this makes it accessible using the auxiliary mouse buttons present on some mice.

An editor setting allows disabling this feature in case you use the auxiliary mouse buttons for other things (such as push-to-talk in a VoIP program).