### PR TITLE
Move Debug menu logic to DebuggerEditorPlugin, allow 4 debug instances

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -67,6 +67,7 @@
 #include "servers/physics_2d_server.h"
 
 #include "editor/audio_stream_preview.h"
+#include "editor/debugger/editor_debugger_node.h"
 #include "editor/dependency_editor.h"
 #include "editor/editor_about.h"
 #include "editor/editor_audio_buses.h"
@@ -87,7 +88,6 @@
 #include "editor/editor_spin_slider.h"
 #include "editor/editor_themes.h"
 #include "editor/export_template_manager.h"
-#include "editor/fileserver/editor_file_server.h"
 #include "editor/filesystem_dock.h"
 #include "editor/import/editor_import_collada.h"
 #include "editor/import/editor_scene_importer_gltf.h"
@@ -413,8 +413,6 @@ void EditorNode::_notification(int p_what) {
 			} else {
 				_editor_select(EDITOR_3D);
 			}
-
-			_update_debug_options();
 
 			/* DO NOT LOAD SCENES HERE, WAIT FOR FILE SCANNING AND REIMPORT TO COMPLETE */
 		} break;
@@ -2050,12 +2048,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 	args = ProjectSettings::get_singleton()->get("editor/main_run_args");
 	skip_breakpoints = EditorDebuggerNode::get_singleton()->is_skip_breakpoints();
 
-	int instances = 1;
-	if (debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_TWO)))
-		instances = 2;
-
-	Error error = editor_run.run(run_filename, args, breakpoints, skip_breakpoints, instances);
-
+	Error error = editor_run.run(run_filename, args, breakpoints, skip_breakpoints);
 	if (error != OK) {
 
 		show_accept(TTR("Could not start subprocess!"), TTR("OK"));
@@ -2485,16 +2478,6 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 			run_settings_dialog->popup_run_settings();
 		} break;
-		case RUN_DEBUG_ONE: {
-			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_ONE), true);
-			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_TWO), false);
-
-		} break;
-		case RUN_DEBUG_TWO: {
-			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_TWO), true);
-			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_ONE), false);
-
-		} break;
 		case RUN_SETTINGS: {
 
 			project_settings->popup_project_settings();
@@ -2564,65 +2547,6 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				_save_all_scenes();
 			}
 			_discard_changes();
-		} break;
-		case RUN_FILE_SERVER: {
-
-			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_FILE_SERVER));
-
-			if (ischecked) {
-				file_server->stop();
-				run_native->set_deploy_dumb(false);
-			} else {
-				file_server->start();
-				run_native->set_deploy_dumb(true);
-			}
-
-			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_FILE_SERVER), !ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_file_server", !ischecked);
-		} break;
-		case RUN_LIVE_DEBUG: {
-
-			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_LIVE_DEBUG));
-
-			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_LIVE_DEBUG), !ischecked);
-			EditorDebuggerNode::get_singleton()->set_live_debugging(!ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_live_debug", !ischecked);
-
-		} break;
-		case RUN_DEPLOY_REMOTE_DEBUG: {
-
-			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEPLOY_REMOTE_DEBUG));
-			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEPLOY_REMOTE_DEBUG), !ischecked);
-			run_native->set_deploy_debug_remote(!ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_deploy_remote_debug", !ischecked);
-
-		} break;
-		case RUN_DEBUG_COLLISONS: {
-
-			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_COLLISONS));
-			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_COLLISONS), !ischecked);
-			run_native->set_debug_collisions(!ischecked);
-			editor_run.set_debug_collisions(!ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_collisons", !ischecked);
-
-		} break;
-		case RUN_DEBUG_NAVIGATION: {
-
-			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_NAVIGATION));
-			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_NAVIGATION), !ischecked);
-			run_native->set_debug_navigation(!ischecked);
-			editor_run.set_debug_navigation(!ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_navigation", !ischecked);
-
-		} break;
-		case RUN_RELOAD_SCRIPTS: {
-
-			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_RELOAD_SCRIPTS));
-			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_RELOAD_SCRIPTS), !ischecked);
-
-			ScriptEditor::get_singleton()->set_live_auto_reload_running_scripts(!ischecked);
-			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_reload_scripts", !ischecked);
-
 		} break;
 		case SETTINGS_UPDATE_CONTINUOUSLY: {
 
@@ -2867,23 +2791,6 @@ void EditorNode::_discard_changes(const String &p_str) {
 			ERR_FAIL_COND(err);
 		} break;
 	}
-}
-
-void EditorNode::_update_debug_options() {
-
-	bool check_deploy_remote = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_deploy_remote_debug", false);
-	bool check_file_server = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_file_server", false);
-	bool check_debug_collisons = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisons", false);
-	bool check_debug_navigation = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_navigation", false);
-	bool check_live_debug = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_live_debug", false);
-	bool check_reload_scripts = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_reload_scripts", false);
-
-	if (check_deploy_remote) _menu_option_confirm(RUN_DEPLOY_REMOTE_DEBUG, true);
-	if (check_file_server) _menu_option_confirm(RUN_FILE_SERVER, true);
-	if (check_debug_collisons) _menu_option_confirm(RUN_DEBUG_COLLISONS, true);
-	if (check_debug_navigation) _menu_option_confirm(RUN_DEBUG_NAVIGATION, true);
-	if (check_live_debug) _menu_option_confirm(RUN_LIVE_DEBUG, true);
-	if (check_reload_scripts) _menu_option_confirm(RUN_RELOAD_SCRIPTS, true);
 }
 
 void EditorNode::_update_file_menu_opened() {
@@ -6190,42 +6097,13 @@ EditorNode::EditorNode() {
 	main_editor_button_vb = memnew(HBoxContainer);
 	menu_hb->add_child(main_editor_button_vb);
 
+	// Options are added and handled by DebuggerEditorPlugin
 	debug_menu = memnew(MenuButton);
 	debug_menu->set_flat(false);
 	debug_menu->set_switch_on_hover(true);
 	debug_menu->set_text(TTR("Debug"));
 	debug_menu->add_style_override("hover", gui_base->get_stylebox("MenuHover", "EditorStyles"));
 	left_menu_hb->add_child(debug_menu);
-
-	p = debug_menu->get_popup();
-	p->set_hide_on_window_lose_focus(true);
-	p->set_hide_on_checkable_item_selection(false);
-	p->add_check_shortcut(ED_SHORTCUT("editor/deploy_with_remote_debug", TTR("Deploy with Remote Debug")), RUN_DEPLOY_REMOTE_DEBUG);
-	p->set_item_tooltip(p->get_item_count() - 1, TTR("When exporting or deploying, the resulting executable will attempt to connect to the IP of this computer in order to be debugged."));
-	p->add_check_shortcut(ED_SHORTCUT("editor/small_deploy_with_network_fs", TTR("Small Deploy with Network FS")), RUN_FILE_SERVER);
-	p->set_item_tooltip(p->get_item_count() - 1, TTR("When this option is enabled, export or deploy will produce a minimal executable.\nThe filesystem will be provided from the project by the editor over the network.\nOn Android, deploy will use the USB cable for faster performance. This option speeds up testing for games with a large footprint."));
-	p->add_separator();
-	p->add_check_shortcut(ED_SHORTCUT("editor/visible_collision_shapes", TTR("Visible Collision Shapes")), RUN_DEBUG_COLLISONS);
-	p->set_item_tooltip(p->get_item_count() - 1, TTR("Collision shapes and raycast nodes (for 2D and 3D) will be visible on the running game if this option is turned on."));
-	p->add_check_shortcut(ED_SHORTCUT("editor/visible_navigation", TTR("Visible Navigation")), RUN_DEBUG_NAVIGATION);
-	p->set_item_tooltip(p->get_item_count() - 1, TTR("Navigation meshes and polygons will be visible on the running game if this option is turned on."));
-	p->add_separator();
-	//those are now on by default, since they are harmless
-	p->add_check_shortcut(ED_SHORTCUT("editor/sync_scene_changes", TTR("Sync Scene Changes")), RUN_LIVE_DEBUG);
-	p->set_item_tooltip(p->get_item_count() - 1, TTR("When this option is turned on, any changes made to the scene in the editor will be replicated in the running game.\nWhen used remotely on a device, this is more efficient with network filesystem."));
-	p->set_item_checked(p->get_item_count() - 1, true);
-	p->add_check_shortcut(ED_SHORTCUT("editor/sync_script_changes", TTR("Sync Script Changes")), RUN_RELOAD_SCRIPTS);
-	p->set_item_tooltip(p->get_item_count() - 1, TTR("When this option is turned on, any script that is saved will be reloaded on the running game.\nWhen used remotely on a device, this is more efficient with network filesystem."));
-	p->set_item_checked(p->get_item_count() - 1, true);
-
-	// Multi-instance, start/stop
-	p->add_separator();
-	p->add_radio_check_item(TTR("Debug 1 instance"), RUN_DEBUG_ONE);
-	p->add_radio_check_item(TTR("Debug 2 instances"), RUN_DEBUG_TWO);
-	p->set_item_checked(p->get_item_index(RUN_DEBUG_ONE), true);
-
-	p->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
-
 	menu_hb->add_spacer();
 
 	settings_menu = memnew(MenuButton);
@@ -6607,9 +6485,7 @@ EditorNode::EditorNode() {
 	add_child(preview_gen);
 	//plugin stuff
 
-	file_server = memnew(EditorFileServer);
-
-	add_editor_plugin(memnew(DebuggerEditorPlugin(this)));
+	add_editor_plugin(memnew(DebuggerEditorPlugin(this, debug_menu)));
 	add_editor_plugin(memnew(AnimationPlayerEditorPlugin(this)));
 	add_editor_plugin(memnew(CanvasItemEditorPlugin(this)));
 	add_editor_plugin(memnew(SpatialEditorPlugin(this)));
@@ -6841,7 +6717,6 @@ EditorNode::~EditorNode() {
 	memdelete(editor_plugins_over);
 	memdelete(editor_plugins_force_over);
 	memdelete(editor_plugins_force_input_forwarding);
-	memdelete(file_server);
 	memdelete(progress_hb);
 
 	EditorSettings::destroy();

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -162,17 +162,9 @@ private:
 		RUN_PLAY_NATIVE,
 		RUN_PLAY_CUSTOM_SCENE,
 		RUN_SCENE_SETTINGS,
-		RUN_DEBUG_ONE,
-		RUN_DEBUG_TWO,
 		RUN_SETTINGS,
 		RUN_PROJECT_DATA_FOLDER,
 		RUN_PROJECT_MANAGER,
-		RUN_FILE_SERVER,
-		RUN_LIVE_DEBUG,
-		RUN_DEBUG_COLLISONS,
-		RUN_DEBUG_NAVIGATION,
-		RUN_DEPLOY_REMOTE_DEBUG,
-		RUN_RELOAD_SCRIPTS,
 		RUN_VCS_SETTINGS,
 		RUN_VCS_SHUT_DOWN,
 		SETTINGS_UPDATE_CONTINUOUSLY,
@@ -412,8 +404,6 @@ private:
 	EditorResourcePreview *resource_preview;
 	EditorFolding editor_folding;
 
-	EditorFileServer *file_server;
-
 	struct BottomPanelItem {
 		String name;
 		Control *control;
@@ -455,7 +445,6 @@ private:
 	void _save_screenshot(NodePath p_path);
 
 	void _tool_menu_option(int p_idx);
-	void _update_debug_options();
 	void _update_file_menu_opened();
 	void _update_file_menu_closed();
 

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -38,7 +38,7 @@ EditorRun::Status EditorRun::get_status() const {
 	return status;
 }
 
-Error EditorRun::run(const String &p_scene, const String &p_custom_args, const List<String> &p_breakpoints, const bool &p_skip_breakpoints, const int &p_instances) {
+Error EditorRun::run(const String &p_scene, const String &p_custom_args, const List<String> &p_breakpoints, const bool &p_skip_breakpoints) {
 
 	List<String> args;
 
@@ -57,6 +57,8 @@ Error EditorRun::run(const String &p_scene, const String &p_custom_args, const L
 	args.push_back("--allow_focus_steal_pid");
 	args.push_back(itos(OS::get_singleton()->get_process_id()));
 
+	bool debug_collisions = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisons", false);
+	bool debug_navigation = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_navigation", false);
 	if (debug_collisions) {
 		args.push_back("--debug-collisions");
 	}
@@ -187,7 +189,8 @@ Error EditorRun::run(const String &p_scene, const String &p_custom_args, const L
 	};
 	printf("\n");
 
-	for (int i = 0; i < p_instances; i++) {
+	int instances = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_instances", 1);
+	for (int i = 0; i < instances; i++) {
 		OS::ProcessID pid = 0;
 		Error err = OS::get_singleton()->execute(exec, args, false, &pid);
 		ERR_FAIL_COND_V(err, err);
@@ -226,29 +229,7 @@ void EditorRun::stop() {
 	status = STATUS_STOP;
 }
 
-void EditorRun::set_debug_collisions(bool p_debug) {
-
-	debug_collisions = p_debug;
-}
-
-bool EditorRun::get_debug_collisions() const {
-
-	return debug_collisions;
-}
-
-void EditorRun::set_debug_navigation(bool p_debug) {
-
-	debug_navigation = p_debug;
-}
-
-bool EditorRun::get_debug_navigation() const {
-
-	return debug_navigation;
-}
-
 EditorRun::EditorRun() {
 
 	status = STATUS_STOP;
-	debug_collisions = false;
-	debug_navigation = false;
 }

--- a/editor/editor_run.h
+++ b/editor/editor_run.h
@@ -45,25 +45,17 @@ public:
 	List<OS::ProcessID> pids;
 
 private:
-	bool debug_collisions;
-	bool debug_navigation;
 	Status status;
 
 public:
 	Status get_status() const;
-	Error run(const String &p_scene, const String &p_custom_args, const List<String> &p_breakpoints, const bool &p_skip_breakpoints = false, const int &p_instances = 1);
+	Error run(const String &p_scene, const String &p_custom_args, const List<String> &p_breakpoints, const bool &p_skip_breakpoints = false);
 	void run_native_notify() { status = STATUS_PLAY; }
 	void stop();
 
 	void stop_child_process(OS::ProcessID p_pid);
 	bool has_child_process(OS::ProcessID p_pid) const;
 	int get_child_process_count() const { return pids.size(); }
-
-	void set_debug_collisions(bool p_debug);
-	bool get_debug_collisions() const;
-
-	void set_debug_navigation(bool p_debug);
-	bool get_debug_navigation() const;
 
 	EditorRun();
 };

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -136,6 +136,12 @@ void EditorRunNative::_run_native(int p_idx, int p_platform) {
 	emit_signal("native_run");
 
 	int flags = 0;
+
+	bool deploy_debug_remote = is_deploy_debug_remote_enabled();
+	bool deploy_dumb = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_file_server", false);
+	bool debug_collisions = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisons", false);
+	bool debug_navigation = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_navigation", false);
+
 	if (deploy_debug_remote)
 		flags |= EditorExportPlatform::DEBUG_FLAG_REMOTE_DEBUG;
 	if (deploy_dumb)
@@ -157,53 +163,14 @@ void EditorRunNative::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("native_run"));
 }
 
-void EditorRunNative::set_deploy_dumb(bool p_enabled) {
-
-	deploy_dumb = p_enabled;
-}
-
-bool EditorRunNative::is_deploy_dumb_enabled() const {
-
-	return deploy_dumb;
-}
-
-void EditorRunNative::set_deploy_debug_remote(bool p_enabled) {
-
-	deploy_debug_remote = p_enabled;
-}
-
 bool EditorRunNative::is_deploy_debug_remote_enabled() const {
 
-	return deploy_debug_remote;
-}
-
-void EditorRunNative::set_debug_collisions(bool p_debug) {
-
-	debug_collisions = p_debug;
-}
-
-bool EditorRunNative::get_debug_collisions() const {
-
-	return debug_collisions;
-}
-
-void EditorRunNative::set_debug_navigation(bool p_debug) {
-
-	debug_navigation = p_debug;
-}
-
-bool EditorRunNative::get_debug_navigation() const {
-
-	return debug_navigation;
+	return EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_deploy_remote_debug", false);
 }
 
 EditorRunNative::EditorRunNative() {
 	set_process(true);
 	first = true;
-	deploy_dumb = false;
-	deploy_debug_remote = false;
-	debug_collisions = false;
-	debug_navigation = false;
 	resume_idx = 0;
 	resume_platform = 0;
 }

--- a/editor/editor_run_native.h
+++ b/editor/editor_run_native.h
@@ -40,10 +40,6 @@ class EditorRunNative : public HBoxContainer {
 
 	Map<int, MenuButton *> menus;
 	bool first;
-	bool deploy_dumb;
-	bool deploy_debug_remote;
-	bool debug_collisions;
-	bool debug_navigation;
 
 	int resume_idx;
 	int resume_platform;
@@ -55,17 +51,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void set_deploy_dumb(bool p_enabled);
-	bool is_deploy_dumb_enabled() const;
-
-	void set_deploy_debug_remote(bool p_enabled);
 	bool is_deploy_debug_remote_enabled() const;
-
-	void set_debug_collisions(bool p_debug);
-	bool get_debug_collisions() const;
-
-	void set_debug_navigation(bool p_debug);
-	bool get_debug_navigation() const;
 
 	void resume_run_native();
 

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -32,8 +32,11 @@
 
 #include "core/os/keyboard.h"
 #include "editor/debugger/editor_debugger_node.h"
+#include "editor/editor_node.h"
+#include "editor/fileserver/editor_file_server.h"
+#include "scene/gui/menu_button.h"
 
-DebuggerEditorPlugin::DebuggerEditorPlugin(EditorNode *p_editor) {
+DebuggerEditorPlugin::DebuggerEditorPlugin(EditorNode *p_editor, MenuButton *p_debug_menu) {
 	ED_SHORTCUT("debugger/step_into", TTR("Step Into"), KEY_F11);
 	ED_SHORTCUT("debugger/step_over", TTR("Step Over"), KEY_F10);
 	ED_SHORTCUT("debugger/break", TTR("Break"));
@@ -41,11 +44,149 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(EditorNode *p_editor) {
 	ED_SHORTCUT("debugger/keep_debugger_open", TTR("Keep Debugger Open"));
 	ED_SHORTCUT("debugger/debug_with_external_editor", TTR("Debug with External Editor"));
 
+	// File Server for deploy with remote fs.
+	file_server = memnew(EditorFileServer);
+
 	EditorDebuggerNode *debugger = memnew(EditorDebuggerNode);
 	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger);
 	debugger->set_tool_button(db);
+
+	// Main editor debug menu.
+	debug_menu = p_debug_menu;
+	PopupMenu *p = debug_menu->get_popup();
+	p->set_hide_on_window_lose_focus(true);
+	p->set_hide_on_checkable_item_selection(false);
+	p->add_check_shortcut(ED_SHORTCUT("editor/deploy_with_remote_debug", TTR("Deploy with Remote Debug")), RUN_DEPLOY_REMOTE_DEBUG);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("When exporting or deploying, the resulting executable will attempt to connect to the IP of this computer in order to be debugged."));
+	p->add_check_shortcut(ED_SHORTCUT("editor/small_deploy_with_network_fs", TTR("Small Deploy with Network FS")), RUN_FILE_SERVER);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("When this option is enabled, export or deploy will produce a minimal executable.\nThe filesystem will be provided from the project by the editor over the network.\nOn Android, deploy will use the USB cable for faster performance. This option speeds up testing for games with a large footprint."));
+	p->add_separator();
+	p->add_check_shortcut(ED_SHORTCUT("editor/visible_collision_shapes", TTR("Visible Collision Shapes")), RUN_DEBUG_COLLISONS);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("Collision shapes and raycast nodes (for 2D and 3D) will be visible on the running game if this option is turned on."));
+	p->add_check_shortcut(ED_SHORTCUT("editor/visible_navigation", TTR("Visible Navigation")), RUN_DEBUG_NAVIGATION);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("Navigation meshes and polygons will be visible on the running game if this option is turned on."));
+	p->add_separator();
+	//those are now on by default, since they are harmless
+	p->add_check_shortcut(ED_SHORTCUT("editor/sync_scene_changes", TTR("Sync Scene Changes")), RUN_LIVE_DEBUG);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("When this option is turned on, any changes made to the scene in the editor will be replicated in the running game.\nWhen used remotely on a device, this is more efficient with network filesystem."));
+	p->set_item_checked(p->get_item_count() - 1, true);
+	p->add_check_shortcut(ED_SHORTCUT("editor/sync_script_changes", TTR("Sync Script Changes")), RUN_RELOAD_SCRIPTS);
+	p->set_item_tooltip(p->get_item_count() - 1, TTR("When this option is turned on, any script that is saved will be reloaded on the running game.\nWhen used remotely on a device, this is more efficient with network filesystem."));
+	p->set_item_checked(p->get_item_count() - 1, true);
+
+	// Multi-instance, start/stop
+	p->add_separator();
+	p->add_radio_check_item(TTR("Debug 1 instance"), RUN_DEBUG_ONE);
+	p->add_radio_check_item(TTR("Debug 2 instances"), RUN_DEBUG_TWO);
+	p->set_item_checked(p->get_item_index(RUN_DEBUG_ONE), true);
+
+	p->connect("id_pressed", callable_mp(this, &DebuggerEditorPlugin::_menu_option));
 }
 
 DebuggerEditorPlugin::~DebuggerEditorPlugin() {
+	memdelete(file_server);
 	// Should delete debugger?
+}
+
+void DebuggerEditorPlugin::_menu_option(int p_option) {
+	switch (p_option) {
+		case RUN_DEBUG_ONE: {
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_ONE), true);
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_TWO), false);
+			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_instances", 1);
+
+		} break;
+		case RUN_DEBUG_TWO: {
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_TWO), true);
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_ONE), false);
+			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_instances", 2);
+
+		} break;
+		case RUN_FILE_SERVER: {
+
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_FILE_SERVER));
+
+			if (ischecked) {
+				file_server->stop();
+			} else {
+				file_server->start();
+			}
+
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_FILE_SERVER), !ischecked);
+			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_file_server", !ischecked);
+		} break;
+		case RUN_LIVE_DEBUG: {
+
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_LIVE_DEBUG));
+
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_LIVE_DEBUG), !ischecked);
+			EditorDebuggerNode::get_singleton()->set_live_debugging(!ischecked);
+			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_live_debug", !ischecked);
+
+		} break;
+		case RUN_DEPLOY_REMOTE_DEBUG: {
+
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEPLOY_REMOTE_DEBUG));
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEPLOY_REMOTE_DEBUG), !ischecked);
+
+		} break;
+		case RUN_DEBUG_COLLISONS: {
+
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_COLLISONS));
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_COLLISONS), !ischecked);
+			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_collisons", !ischecked);
+
+		} break;
+		case RUN_DEBUG_NAVIGATION: {
+
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_NAVIGATION));
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_NAVIGATION), !ischecked);
+			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_navigation", !ischecked);
+
+		} break;
+		case RUN_RELOAD_SCRIPTS: {
+
+			bool ischecked = debug_menu->get_popup()->is_item_checked(debug_menu->get_popup()->get_item_index(RUN_RELOAD_SCRIPTS));
+			debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_RELOAD_SCRIPTS), !ischecked);
+
+			ScriptEditor::get_singleton()->set_live_auto_reload_running_scripts(!ischecked);
+			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_reload_scripts", !ischecked);
+
+		} break;
+	}
+}
+
+void DebuggerEditorPlugin::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_READY:
+			_update_debug_options();
+			break;
+		default:
+			break;
+	}
+}
+
+void DebuggerEditorPlugin::_update_debug_options() {
+	bool check_deploy_remote = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_deploy_remote_debug", false);
+	bool check_file_server = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_file_server", false);
+	bool check_debug_collisions = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisons", false);
+	bool check_debug_navigation = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_navigation", false);
+	bool check_live_debug = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_live_debug", false);
+	bool check_reload_scripts = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_reload_scripts", false);
+	int instances = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_instances", 1);
+
+	if (check_deploy_remote) _menu_option(RUN_DEPLOY_REMOTE_DEBUG);
+	if (check_file_server) _menu_option(RUN_FILE_SERVER);
+	if (check_debug_collisions) _menu_option(RUN_DEBUG_COLLISONS);
+	if (check_debug_navigation) _menu_option(RUN_DEBUG_NAVIGATION);
+	if (check_live_debug) _menu_option(RUN_LIVE_DEBUG);
+	if (check_reload_scripts) _menu_option(RUN_RELOAD_SCRIPTS);
+	int one = false;
+	int two = false;
+	if (instances == 2)
+		two = true;
+	else
+		one = true;
+	debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_ONE), one);
+	debug_menu->get_popup()->set_item_checked(debug_menu->get_popup()->get_item_index(RUN_DEBUG_TWO), two);
 }

--- a/editor/plugins/debugger_editor_plugin.h
+++ b/editor/plugins/debugger_editor_plugin.h
@@ -31,19 +31,40 @@
 #ifndef DEBUGGER_EDITOR_PLUGIN_H
 #define DEBUGGER_EDITOR_PLUGIN_H
 
-#include "editor/debugger/editor_debugger_node.h"
-#include "editor/editor_node.h"
 #include "editor/editor_plugin.h"
+
+class EditorNode;
+class EditorFileServer;
+class MenuButton;
 
 class DebuggerEditorPlugin : public EditorPlugin {
 
 	GDCLASS(DebuggerEditorPlugin, EditorPlugin);
 
+private:
+	MenuButton *debug_menu;
+	EditorFileServer *file_server;
+
+	enum MenuOptions {
+		RUN_DEBUG_ONE,
+		RUN_DEBUG_TWO,
+		RUN_FILE_SERVER,
+		RUN_LIVE_DEBUG,
+		RUN_DEBUG_COLLISONS,
+		RUN_DEBUG_NAVIGATION,
+		RUN_DEPLOY_REMOTE_DEBUG,
+		RUN_RELOAD_SCRIPTS,
+	};
+
+	void _update_debug_options();
+	void _notification(int p_what);
+
 public:
+	void _menu_option(int p_option);
 	virtual String get_name() const { return "Debugger"; }
 	bool has_main_screen() const { return false; }
 
-	DebuggerEditorPlugin(EditorNode *p_node);
+	DebuggerEditorPlugin(EditorNode *p_node, MenuButton *p_menu);
 	~DebuggerEditorPlugin();
 };
 

--- a/editor/plugins/debugger_editor_plugin.h
+++ b/editor/plugins/debugger_editor_plugin.h
@@ -36,6 +36,7 @@
 class EditorNode;
 class EditorFileServer;
 class MenuButton;
+class PopupMenu;
 
 class DebuggerEditorPlugin : public EditorPlugin {
 
@@ -44,10 +45,9 @@ class DebuggerEditorPlugin : public EditorPlugin {
 private:
 	MenuButton *debug_menu;
 	EditorFileServer *file_server;
+	PopupMenu *instances_menu;
 
 	enum MenuOptions {
-		RUN_DEBUG_ONE,
-		RUN_DEBUG_TWO,
 		RUN_FILE_SERVER,
 		RUN_LIVE_DEBUG,
 		RUN_DEBUG_COLLISONS,
@@ -58,9 +58,10 @@ private:
 
 	void _update_debug_options();
 	void _notification(int p_what);
+	void _select_run_count(int p_index);
+	void _menu_option(int p_option);
 
 public:
-	void _menu_option(int p_option);
 	virtual String get_name() const { return "Debugger"; }
 	bool has_main_screen() const { return false; }
 


### PR DESCRIPTION
In this PR:
- Move Debug menu logic to DebuggerEditorPlugin (editor run [native] now use settings to read the props).
- Small refactor to "Debug" menu to allow up to 4 instances (closes godotengine/godot-proposals#560 , closes #7008 )
- Properly remember last selected "run multiple" option .

![multiple](https://user-images.githubusercontent.com/1687918/76171804-9e2a2080-618f-11ea-80bc-53e89b628db1.png)
