### PR TITLE
Inputs should no longer release on viewport exit

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -814,8 +814,7 @@ void Viewport::_notification(int p_what) {
 			}
 
 		} break;
-		case NOTIFICATION_WM_MOUSE_EXIT:
-		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
+		case SceneTree::NOTIFICATION_WM_FOCUS_OUT: {
 			_drop_physics_mouseover();
 
 			if (gui.mouse_focus && !gui.forced_mouse_focus) {


### PR DESCRIPTION
Fixes #35185

This bug also caused issues in the editor where you can drag a sprite off screen, release mouse, then go back onto screen where it will continue to be dragged

**New behaviour**:
![48dafc37](https://user-images.githubusercontent.com/14253836/76173049-cd2d9b80-6169-11ea-8ba4-79f531c1e85d.gif)