### PR TITLE
Tree and TreeItem folding helpers and improvements

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -254,6 +254,14 @@
 				Causes the [Tree] to jump to the specified [TreeItem].
 			</description>
 		</method>
+		<method name="set_collapsed_all">
+			<return type="void" />
+			<argument index="0" name="collapsed" type="bool" />
+			<argument index="1" name="ignore_active_branches" type="bool" />
+			<description>
+				Collapses or uncollapses every [TreeItem] in the [Tree], recursively, starting from the root. If ignore_active_branches is [code]true[/code], the branch containing the currently selected TreeItem will be left in its current state.
+			</description>
+		</method>
 		<method name="set_column_clip_content">
 			<return type="void" />
 			<argument index="0" name="column" type="int" />

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -336,6 +336,12 @@
 				Returns the [Tree] that owns this TreeItem.
 			</description>
 		</method>
+		<method name="has_expanded_child">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the [TreeItem] has at least one child which is not collapsed and has at least one child of it's own.
+			</description>
+		</method>
 		<method name="is_button_disabled" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="column" type="int" />
@@ -362,6 +368,12 @@
 			<argument index="0" name="column" type="int" />
 			<description>
 				Returns [code]true[/code] if column [code]column[/code] is editable.
+			</description>
+		</method>
+		<method name="is_in_active_branch">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the [TreeItem] or at least one of it's descendent have at least one column selected.
 			</description>
 		</method>
 		<method name="is_indeterminate" qualifiers="const">
@@ -455,6 +467,17 @@
 			<argument index="1" name="checked" type="bool" />
 			<description>
 				If [code]true[/code], the column [code]column[/code] is checked. Clears column's indeterminate status.
+			</description>
+		</method>
+		<method name="set_collapsed_recursive">
+			<return type="void" />
+			<argument index="0" name="enable" type="bool" />
+			<argument index="1" name="ignore_active_branches" type="bool" />
+			<argument index="2" name="ignore_self" type="bool" />
+			<description>
+				Recursively collapse this [TreeItem] and all its descendants when [code]enable[/code] is [code]true[/code], otherwise expanding them.
+				If [code]ignore_active_branches[/code] is [code]true[/code], branches which contains a selected [TreeItem] will be ignored.
+				If [code]ignore_self[/code] is [code]true[/code], only descendants are affected.
 			</description>
 		</method>
 		<method name="set_custom_as_button">
@@ -671,9 +694,18 @@
 				Sets the given column's tooltip text.
 			</description>
 		</method>
+		<method name="toggle_collapsed_recursive">
+			<return type="void" />
+			<description>
+				If the [TreeItem] is already collapsed, expands it and all of its children recursively.
+				If the [TreeItem] is expanded and has at least one expanded child, collapses all children recursively without collapsing the current [TreeItem].
+				If the [TreeItem] is expanded and all children are collapsed, collapses the [TreeItem].
+			</description>
+		</method>
 		<method name="uncollapse_tree">
 			<return type="void" />
 			<description>
+				Uncollapses the [TreeItem] and all of it's ancestor.
 			</description>
 		</method>
 	</methods>

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1439,29 +1439,11 @@ void ScriptEditorDebugger::_error_selected() {
 }
 
 void ScriptEditorDebugger::_expand_errors_list() {
-	TreeItem *root = error_tree->get_root();
-	if (!root) {
-		return;
-	}
-
-	TreeItem *item = root->get_first_child();
-	while (item) {
-		item->set_collapsed(false);
-		item = item->get_next();
-	}
+	error_tree->set_collapsed_all(false, false);
 }
 
 void ScriptEditorDebugger::_collapse_errors_list() {
-	TreeItem *root = error_tree->get_root();
-	if (!root) {
-		return;
-	}
-
-	TreeItem *item = root->get_first_child();
-	while (item) {
-		item->set_collapsed(true);
-		item = item->get_next();
-	}
+	error_tree->set_collapsed_all(true, false);
 }
 
 void ScriptEditorDebugger::_clear_errors_list() {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4356,31 +4356,10 @@ void VisualShaderEditor::_tools_menu_option(int p_idx) {
 
 	switch (p_idx) {
 		case EXPAND_ALL:
-
-			while (category) {
-				category->set_collapsed(false);
-				TreeItem *sub_category = category->get_first_child();
-				while (sub_category) {
-					sub_category->set_collapsed(false);
-					sub_category = sub_category->get_next();
-				}
-				category = category->get_next();
-			}
-
+			category->set_collapsed_recursive(false, false, false);
 			break;
-
 		case COLLAPSE_ALL:
-
-			while (category) {
-				category->set_collapsed(true);
-				TreeItem *sub_category = category->get_first_child();
-				while (sub_category) {
-					sub_category->set_collapsed(true);
-					sub_category = sub_category->get_next();
-				}
-				category = category->get_next();
-			}
-
+			category->set_collapsed_recursive(true, false, false);
 			break;
 		default:
 			break;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -438,8 +438,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				}
 			}
 
-			bool collapsed = _is_collapsed_recursive(selected_item);
-			_set_collapsed_recursive(selected_item, !collapsed);
+			bool collapse = selected_item->has_expanded_child();
+			selected_item->set_collapsed_recursive(collapse, false, false);
 
 			tree->ensure_cursor_is_visible();
 
@@ -1175,17 +1175,6 @@ void SceneTreeDock::add_root_node(Node *p_node) {
 	editor_data->get_undo_redo().commit_action();
 }
 
-void SceneTreeDock::_node_collapsed(Object *p_obj) {
-	TreeItem *ti = Object::cast_to<TreeItem>(p_obj);
-	if (!ti) {
-		return;
-	}
-
-	if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
-		_set_collapsed_recursive(ti, ti->is_collapsed());
-	}
-}
-
 void SceneTreeDock::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
@@ -1901,48 +1890,6 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 	perform_node_renames(nullptr, &path_renames);
 
 	editor_data->get_undo_redo().commit_action();
-}
-
-bool SceneTreeDock::_is_collapsed_recursive(TreeItem *p_item) const {
-	bool is_branch_collapsed = false;
-
-	List<TreeItem *> needs_check;
-	needs_check.push_back(p_item);
-
-	while (!needs_check.is_empty()) {
-		TreeItem *item = needs_check.back()->get();
-		needs_check.pop_back();
-
-		TreeItem *child = item->get_first_child();
-		is_branch_collapsed = item->is_collapsed() && child;
-
-		if (is_branch_collapsed) {
-			break;
-		}
-		while (child) {
-			needs_check.push_back(child);
-			child = child->get_next();
-		}
-	}
-	return is_branch_collapsed;
-}
-
-void SceneTreeDock::_set_collapsed_recursive(TreeItem *p_item, bool p_collapsed) {
-	List<TreeItem *> to_collapse;
-	to_collapse.push_back(p_item);
-
-	while (!to_collapse.is_empty()) {
-		TreeItem *item = to_collapse.back()->get();
-		to_collapse.pop_back();
-
-		item->set_collapsed(p_collapsed);
-
-		TreeItem *child = item->get_first_child();
-		while (child) {
-			to_collapse.push_back(child);
-			child = child->get_next();
-		}
-	}
 }
 
 void SceneTreeDock::_script_created(Ref<Script> p_script) {
@@ -3465,7 +3412,6 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	scene_tree->connect("nodes_dragged", callable_mp(this, &SceneTreeDock::_nodes_drag_begin));
 
 	scene_tree->get_scene_tree()->connect("item_double_clicked", callable_mp(this, &SceneTreeDock::_focus_node));
-	scene_tree->get_scene_tree()->connect("item_collapsed", callable_mp(this, &SceneTreeDock::_node_collapsed));
 
 	editor_selection->connect("selection_changed", callable_mp(this, &SceneTreeDock::_selection_changed));
 

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -133,7 +133,6 @@ class SceneTreeDock : public VBoxContainer {
 	HBoxContainer *tool_hbc = nullptr;
 	void _tool_selected(int p_tool, bool p_confirm_override = false);
 	void _property_selected(int p_idx);
-	void _node_collapsed(Object *p_obj);
 
 	Node *property_drop_node = nullptr;
 	String resource_drop_path;
@@ -183,9 +182,6 @@ class SceneTreeDock : public VBoxContainer {
 
 	void _node_reparent(NodePath p_path, bool p_keep_global_xform);
 	void _do_reparent(Node *p_new_parent, int p_position_in_parent, Vector<Node *> p_nodes, bool p_keep_global_xform);
-
-	bool _is_collapsed_recursive(TreeItem *p_item) const;
-	void _set_collapsed_recursive(TreeItem *p_item, bool p_collapsed);
 
 	void _set_owners(Node *p_owner, const Array &p_nodes);
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -275,12 +275,14 @@ public:
 	void set_custom_draw(int p_column, Object *p_object, const StringName &p_callback);
 
 	void set_collapsed(bool p_collapsed);
+	void set_collapsed_recursive(bool p_collapsed, bool p_ignore_active_branches, bool p_ignore_self);
+	void toggle_collapsed_recursive();
+	void uncollapse_tree();
 	bool is_collapsed();
+	bool has_expanded_child();
 
 	void set_visible(bool p_visible);
 	bool is_visible();
-
-	void uncollapse_tree();
 
 	void set_custom_minimum_height(int p_height);
 	int get_custom_minimum_height() const;
@@ -289,6 +291,7 @@ public:
 	bool is_selectable(int p_column) const;
 
 	bool is_selected(int p_column);
+	bool is_in_active_branch();
 	void select(int p_column);
 	void deselect(int p_column);
 	void set_as_cursor(int p_column);
@@ -718,6 +721,8 @@ public:
 
 	void set_allow_reselect(bool p_allow);
 	bool get_allow_reselect() const;
+
+	void set_collapsed_all(bool p_collapsed, bool p_ignore_active_branches);
 
 	Size2 get_minimum_size() const override;
 


### PR DESCRIPTION
A few small changes to the Tree and TreeItem classes.

The goal is to reduce clutter in many classes that each have their own (different) implementation of the same logic, while giving new and old behaviors of the UI trees better consistency across the editor.

**For the discussion and details, see** #33984.

This was separated from the #33984 PR, as the refactor is pretty big and is going to take a while to complete, but I think I pretty much nailed down the global changes needed to make everything compatible and consistent. I think some of these changes would help some other propositions and PR too. #33984 will be kept just to keep track of the refactor, but separating this will allow each part of the refactor to be it's own PR.

I completed the Tree and TreeItem documentation, and opened this PR for the changes to the Tree and TreeItem, including doc for the new methods. It already makes the click, alt-click and folding consistent to all trees by default. 