### PR TITLE
Fix: export var type reduce() implemented

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2022,6 +2022,38 @@ GDScriptParser::Node *GDScriptParser::_parse_and_reduce_expression(Node *p_paren
 	return expr;
 }
 
+bool GDScriptParser::_reduce_export_var_type(Variant &p_value, int p_line) {
+
+	if (p_value.get_type() == Variant::ARRAY) {
+		Array arr = p_value;
+		for (int i = 0; i < arr.size(); i++) {
+			if (!_reduce_export_var_type(arr[i], p_line)) return false;
+		}
+		return true;
+	}
+
+	if (p_value.get_type() == Variant::DICTIONARY) {
+		Dictionary dict = p_value;
+		for (int i = 0; i < dict.size(); i++) {
+			Variant value = dict.get_value_at_index(i);
+			if (!_reduce_export_var_type(value, p_line)) return false;
+		}
+		return true;
+	}
+
+	// validate type
+	DataType type = _type_from_variant(p_value);
+	if (type.kind == DataType::BUILTIN) {
+		return true;
+	} else if (type.kind == DataType::NATIVE) {
+		if (ClassDB::is_parent_class(type.native_type, "Resource")) {
+			return true;
+		}
+	}
+	_set_error("Invalid export type. Only built-in and native resource types can be exported.", p_line);
+	return false;
+}
+
 bool GDScriptParser::_recover_from_completion() {
 
 	if (!completion_found) {
@@ -4863,6 +4895,9 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 							_set_error("Can't accept a null constant expression for inferring export type.");
 							return;
 						}
+
+						if (!_reduce_export_var_type(cn->value, member.line)) return;
+
 						member._export.type = cn->value.get_type();
 						member._export.usage |= PROPERTY_USAGE_SCRIPT_VARIABLE;
 						if (cn->value.get_type() == Variant::OBJECT) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -613,6 +613,7 @@ private:
 	Node *_parse_expression(Node *p_parent, bool p_static, bool p_allow_assign = false, bool p_parsing_constant = false);
 	Node *_reduce_expression(Node *p_node, bool p_to_const = false);
 	Node *_parse_and_reduce_expression(Node *p_parent, bool p_static, bool p_reduce_const = false, bool p_allow_assign = false);
+	bool _reduce_export_var_type(Variant &p_value, int p_line = 0);
 
 	PatternNode *_parse_pattern(bool p_static);
 	void _parse_pattern_block(BlockNode *p_block, Vector<PatternBranchNode *> &p_branches, bool p_static);


### PR DESCRIPTION
Fix: #36899

when exporting a var the parser checks if the type is supported and for array and dictionary, they are supported but if they contain any variant which doesn't supported -> BUG!!
setting an unsupported type value and saving the scene will also write invalid text to `*.tscn` file which will leads to an error `Error while parsing *.tscn`
```gdscript
## *.tscn file
dictionary = {
0: SubResource( 1 ), ## some value assigned from inspector
1: Object(GDScriptNativeClass,"script":null) ## no value assigned -> writing invalid text
}
```

fix: validate type recursively (for array and dictionary) to ensure that all types inside are supported.

![export var type reduce](https://user-images.githubusercontent.com/41085900/76173115-6ab4b980-61c2-11ea-8169-64e018c968a0.JPG)
