### PR TITLE
Keeps the filename when marking scene as unsaved

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1420,7 +1420,6 @@ void EditorNode::_mark_unsaved_scenes() {
 		String path = node->get_filename();
 		if (!(path == String() || FileAccess::exists(path))) {
 
-			node->set_filename("");
 			if (i == editor_data.get_edited_scene())
 				set_current_version(-1);
 			else


### PR DESCRIPTION
This fixes #36894

To prevent accidental data loss, #9447 marks opened but filename-not-exist scenes as unsaved when there are file system changes.

In addition to mark-as-unsaved, it also clears the internal filename, so the FileDialog will appear when saving, leaving no clue what the original filename was. I think it's unnecessary. Editors around all keep the filename in this situation.