### PR TITLE
Eliminates SpringArm update lag when changing SpringArm length

### DIFF
--- a/scene/3d/spring_arm.cpp
+++ b/scene/3d/spring_arm.cpp
@@ -90,10 +90,15 @@ float SpringArm::get_length() const {
 }
 
 void SpringArm::set_length(float p_length) {
+	if (p_length == spring_length) {
+		return;
+	}
+
 	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_collisions_hint()))
 		update_gizmo();
 
 	spring_length = p_length;
+	process_spring();
 }
 
 void SpringArm::set_shape(Ref<Shape> p_shape) {


### PR DESCRIPTION
**Desciption**
If the SpringArm's length is updated, its children won't update until the next frame because the process_spring() function won't be called again until the next frame. Any code that needs the position of its children to update in the same frame as the SpringArm length is updated won't get the values based on the updated length until the next frame.

The fix makes the set_length() function only change the SpringArm length when the new length is different than the current length and calls the process_spring() function to update the SpringArm and its children with the new length, which eliminates the lag.

**Before/After Example**
The zip file contains 1 second videos of where the bug occurs, before and after the fix (the videos are from 3.2, but affected code is also present in 3.1, 3.2, and 4.0).

The update lag is most apparent when the camera is rotating while the length changes. In the videos, when the camera rotates to its maximum rotation above the character, the SpringArm zooms out the camera a little after the rotation has stopped because the SpringArm's update lags doesn't update its children until 1 frame after the length is updated.

The effect of the update lag can be seen by looking at the shadow to the left of the character in both videos and comparing them. 

The update lag can also be seen in the output. The top value is the new length, and the next two values are two calculations of the length to a child object of the SpringArm. Because the SpringArm didn't update in the same frame the length was changed, the second and third values lag the first (in the before video).

[SpringArm_Update_Bug_Before_After_Fix.zip](https://github.com/godotengine/godot/files/4304513/SpringArm_Update_Bug_Before_After_Fix.zip)

**Affected Versions**
3.1, 3.2, and 4.0