### PR TITLE
Add make_local_canvas_position_global, the inverse to make_canvas_position_local

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -533,7 +533,17 @@
 			<argument index="0" name="screen_point" type="Vector2">
 			</argument>
 			<description>
-				Assigns [code]screen_point[/code] as this node's new local transform.
+				Transforms [code]screen_point[/code] to this node's local transform.
+			</description>
+		</method>
+		<method name="make_local_canvas_position" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="local_point" type="Vector2">
+			</argument>
+			<description>
+				Transforms [code]local_point[/code] to a screen point. 
+				Basically the reverse of [code] make_canvas_position_local [/code]
 			</description>
 		</method>
 		<method name="make_input_local" qualifiers="const">

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -1059,7 +1059,7 @@ Vector2 CanvasItem::make_canvas_position_local(const Vector2 &screen_point) cons
 	return global_to_local_matrix.xform(screen_point);
 }
 
-Vector2 CanvasItem::make_local_canvas_position(const Vector2 &local_point) const {
+Vector2 CanvasItem::make_local_canvas_position_global(const Vector2 &local_point) const {
 
 	ERR_FAIL_COND_V(!is_inside_tree(), local_point);
 
@@ -1201,7 +1201,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("force_update_transform"), &CanvasItem::force_update_transform);
 
 	ClassDB::bind_method(D_METHOD("make_canvas_position_local", "screen_point"), &CanvasItem::make_canvas_position_local);
-	ClassDB::bind_method(D_METHOD("make_local_canvas_position", "local_postion"), &CanvasItem::make_local_canvas_position);
+	ClassDB::bind_method(D_METHOD("make_local_canvas_position_global", "local_postion"), &CanvasItem::make_local_canvas_position_global);
 	ClassDB::bind_method(D_METHOD("make_input_local", "event"), &CanvasItem::make_input_local);
 
 	ClassDB::bind_method(D_METHOD("set_texture_filter", "mode"), &CanvasItem::set_texture_filter);

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -1054,9 +1054,18 @@ Vector2 CanvasItem::make_canvas_position_local(const Vector2 &screen_point) cons
 
 	ERR_FAIL_COND_V(!is_inside_tree(), screen_point);
 
-	Transform2D local_matrix = (get_canvas_transform() * get_global_transform()).affine_inverse();
+	Transform2D global_to_local_matrix = (get_canvas_transform() * get_global_transform()).affine_inverse();
 
-	return local_matrix.xform(screen_point);
+	return global_to_local_matrix.xform(screen_point);
+}
+
+Vector2 CanvasItem::make_local_canvas_position(const Vector2 &local_point) const {
+
+	ERR_FAIL_COND_V(!is_inside_tree(), local_point);
+
+	Transform2D local_to_global_matrix = (get_canvas_transform() * get_global_transform());
+
+	return local_to_global_matrix.xform(local_point);
 }
 
 Ref<InputEvent> CanvasItem::make_input_local(const Ref<InputEvent> &p_event) const {
@@ -1192,6 +1201,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("force_update_transform"), &CanvasItem::force_update_transform);
 
 	ClassDB::bind_method(D_METHOD("make_canvas_position_local", "screen_point"), &CanvasItem::make_canvas_position_local);
+	ClassDB::bind_method(D_METHOD("make_local_canvas_position", "local_postion"), &CanvasItem::make_local_canvas_position);
 	ClassDB::bind_method(D_METHOD("make_input_local", "event"), &CanvasItem::make_input_local);
 
 	ClassDB::bind_method(D_METHOD("set_texture_filter", "mode"), &CanvasItem::set_texture_filter);

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -389,7 +389,7 @@ public:
 
 	Ref<InputEvent> make_input_local(const Ref<InputEvent> &p_event) const;
 	Vector2 make_canvas_position_local(const Vector2 &screen_point) const;
-	Vector2 make_local_canvas_position(const Vector2 &local_point) const;
+	Vector2 make_local_canvas_position_global(const Vector2 &local_point) const;
 
 	Vector2 get_global_mouse_position() const;
 	Vector2 get_local_mouse_position() const;

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -389,6 +389,7 @@ public:
 
 	Ref<InputEvent> make_input_local(const Ref<InputEvent> &p_event) const;
 	Vector2 make_canvas_position_local(const Vector2 &screen_point) const;
+	Vector2 make_local_canvas_position(const Vector2 &local_point) const;
 
 	Vector2 get_global_mouse_position() const;
 	Vector2 get_local_mouse_position() const;


### PR DESCRIPTION
Make a local canvas position transformed to global space. 

 - Just the inverse of 	`Vector2 make_canvas_position_local(const Vector2 &screen_point) const;`

Finally a follow up to https://github.com/godotengine/godot/pull/4854 , you know... 4 years later. :)


Test project: https://github.com/Razzlegames/GodotCanvasLocalToGlobalTest