### PR TITLE
Fix initialization of the GodotPayment plugin

### DIFF
--- a/platform/android/java/plugins/godotpayment/src/main/java/org/godotengine/godot/plugin/payment/GodotPayment.java
+++ b/platform/android/java/plugins/godotpayment/src/main/java/org/godotengine/godot/plugin/payment/GodotPayment.java
@@ -55,7 +55,6 @@ public class GodotPayment extends GodotPlugin implements GodotPaymentInterface {
 
 	public GodotPayment(Godot godot) {
 		super(godot);
-		onGLRegisterPluginWithGodotNative();
 		mPaymentManager = godot.getPaymentsManager();
 		mPaymentManager.setBaseSingleton(this);
 	}


### PR DESCRIPTION
The `onGLRegisterPluginWithGodotNative()` method is supposed to be invoked only by `Godot`.