### PR TITLE
change an exclamation mark to a dot

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -240,7 +240,7 @@ void RigidBodyBullet::KinematicUtilities::copyAllOwnerShapes() {
 				shapes.write[i].shape = static_cast<btConvexShape *>(shape_wrapper->shape->create_bt_shape(owner_scale * shape_wrapper->scale, safe_margin));
 			} break;
 			default:
-				WARN_PRINT("This shape is not supported to be kinematic!");
+				WARN_PRINT("This shape is not supported for kinematic collision.");
 				shapes.write[i].shape = NULL;
 		}
 	}


### PR DESCRIPTION
Godot is kind to it's users and don't want to add stress with an exclamation mark, the warning message is sufficient by himself. 