### PR TITLE
Remove outdated comment?

### DIFF
--- a/core/vector.h
+++ b/core/vector.h
@@ -34,7 +34,7 @@
 /**
  * @class Vector
  * @author Juan Linietsky
- * Vector container. Regular Vector Container. Use with care and for smaller arrays when possible. Use Vector for large arrays.
+ * Vector container. Regular Vector Container.
 */
 
 #include "core/cowdata.h"


### PR DESCRIPTION
This advice appears to now be outdated & contain a search/replace error based on the recent change from PoolVector to Vector: https://github.com/godotengine/godot/commit/3205a92ad872f918c8322cdcd1434c231a1fd251#diff-e3b190dd79504a83af3fff42156517be

I may however be misinterpreting the advice. :)