### PR TITLE
Initializes VulkanContext::queue_props to NULL

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -1514,6 +1514,7 @@ VkPhysicalDeviceLimits VulkanContext::get_device_limits() const {
 }
 
 VulkanContext::VulkanContext() {
+	queue_props = NULL;
 	command_buffer_count = 0;
 	instance_validation_layers = NULL;
 	use_validation_layers = true;


### PR DESCRIPTION
`VulkanContext::queue_props` was not initialized in the constructor.

If Vulkan initialization fails, the `free` call in the destructor accesses the wild pointer, resulting in a crash in some situations.

<details><summary>Crash Log & Backtrace</summary>

```
ERROR: No surface extension found, is a driver installed?
   at: _initialize_extensions (drivers/vulkan/vulkan_context.cpp:264)
handle_crash: Program crashed with signal 11
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] 1   libsystem_platform.dylib            0x00007fff64d4842d _sigtramp + 29
[2] 2   libobjc.A.dylib                     0x00007fff637d5000 objc_msgSend + 0
[3] 3   libclang_rt.asan_osx_dynamic.dylib  0x0000000115c33a12 wrap_free + 386
[4] VulkanContext::~VulkanContext() (in godot.osx.tools.64s) (vulkan_context.cpp:1535)
[5] VulkanContextOSX::~VulkanContextOSX() (in godot.osx.tools.64s) (vulkan_context_osx.mm:56)
[6] VulkanContextOSX::~VulkanContextOSX() (in godot.osx.tools.64s) (vulkan_context_osx.mm:56)
[7] void memdelete<VulkanContextOSX>(VulkanContextOSX*) (in godot.osx.tools.64s) (memory.h:117)
[8] OS_OSX::initialize(OS::VideoMode const&, int, int) (in godot.osx.tools.64s) (os_osx.mm:1598)
[9] Main::setup2(unsigned long long) (in godot.osx.tools.64s) (main.cpp:1186)
[10] Main::setup(char const*, int, char**, bool) (in godot.osx.tools.64s) (main.cpp:1128)
[11] main (in godot.osx.tools.64s) (godot_main_osx.mm:70)
[12] 12  libdyld.dylib                       0x00007fff64b4f7fd start + 1
[13] 13  ???                                 0x0000000000000001 0x0 + 1
-- END OF BACKTRACE --
Abort trap: 6
```

</details>