### PR TITLE
mbedtls: Re-add patch to disable VIA padlock

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -312,6 +312,9 @@ File extracted from upstream release tarball (`-apache.tgz` variant):
 - LICENSE and apache-2.0.txt files
 - Applied the patch in `thirdparty/mbedtls/patches/1453.diff` (PR 1453).
   Soon to be merged upstream. Check it out at next update.
+- Applied the patch in `thirdparty/mbedtls/patches/padlock.diff`. This disables
+  VIA padlock support which defines a symbol `unsupported` which clashes with
+  a pre-defined symbol.
 - Added 2 files `godot_core_mbedtls_platform.{c,h}` providing configuration
   for light bundling with core.
 

--- a/thirdparty/mbedtls/include/mbedtls/config.h
+++ b/thirdparty/mbedtls/include/mbedtls/config.h
@@ -2542,7 +2542,9 @@
  *
  * This modules adds support for the VIA PadLock on x86.
  */
-#define MBEDTLS_PADLOCK_C
+// -- GODOT start --
+// #define MBEDTLS_PADLOCK_C
+// -- GODOT end --
 
 /**
  * \def MBEDTLS_PEM_PARSE_C

--- a/thirdparty/mbedtls/patches/padlock.diff
+++ b/thirdparty/mbedtls/patches/padlock.diff
@@ -1,0 +1,13 @@
+--- a/thirdparty/mbedtls/include/mbedtls/config.h
++++ b/thirdparty/mbedtls/include/mbedtls/config.h
+@@ -2477,7 +2477,9 @@
+  *
+  * This modules adds support for the VIA PadLock on x86.
+  */
+-#define MBEDTLS_PADLOCK_C
++// -- GODOT start --
++// #define MBEDTLS_PADLOCK_C
++// -- GODOT end --
+ 
+ /**
+  * \def MBEDTLS_PEM_PARSE_C


### PR DESCRIPTION
The comment mentioned a conflict with libwebsockets, but we actually
still get this conflict even now that we don't use libwebsockets.
Not sure what component is clashing but we should basically just keep
this patch.

Follow-up to #36823.

---

I removed it in the previous PR as it mentioned libwebsockets, but obviously that was not the whole story :)

@hpvb @Faless It would likely be good to report this upstream so that they can see if they want to make a proper fix. I'm clueless about ASM and why the symbol conflict is happening though :)

There's no real need to cherry-pick for 3.1 as I kept the patch there, but I'll just cherry-picking the README.md edit for consistency.