### PR TITLE
Fix -Wshadow=local warning in EngineDebugger

### DIFF
--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -146,8 +146,8 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, Ve
 		return;
 
 	// There is a debugger, parse breakpoints.
-	ScriptDebugger *script_debugger = singleton->get_script_debugger();
-	script_debugger->set_skip_breakpoints(p_skip_breakpoints);
+	ScriptDebugger *singleton_script_debugger = singleton->get_script_debugger();
+	singleton_script_debugger->set_skip_breakpoints(p_skip_breakpoints);
 
 	for (int i = 0; i < p_breakpoints.size(); i++) {
 
@@ -155,7 +155,7 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, Ve
 		int sp = bp.find_last(":");
 		ERR_CONTINUE_MSG(sp == -1, "Invalid breakpoint: '" + bp + "', expected file:line format.");
 
-		script_debugger->insert_breakpoint(bp.substr(sp + 1, bp.length()).to_int(), bp.substr(0, sp));
+		singleton_script_debugger->insert_breakpoint(bp.substr(sp + 1, bp.length()).to_int(), bp.substr(0, sp));
 	}
 }
 


### PR DESCRIPTION
Fixes:
```
core/debugger/engine_debugger.cpp: In static member function 'static void EngineDebugger::initialize(const String&, bool, Vector<String>)':
core/debugger/engine_debugger.cpp:149:18: error: declaration of 'script_debugger' shadows a previous local [-Werror=shadow=local]
  ScriptDebugger *script_debugger = singleton->get_script_debugger();
                  ^~~~~~~~~~~~~~~
core/debugger/engine_debugger.cpp:39:17: note: shadowed declaration is here
 ScriptDebugger *EngineDebugger::script_debugger = NULL;
                 ^~~~~~~~~~~~~~
```

Not sure why CI checks didn't fail in the original PR.