### PR TITLE
Improve shortcut formatting in docs

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -155,7 +155,7 @@
 			Tab key.
 		</constant>
 		<constant name="KEY_BACKTAB" value="16777219" enum="KeyList">
-			Shift+Tab key.
+			Shift + Tab key.
 		</constant>
 		<constant name="KEY_BACKSPACE" value="16777220" enum="KeyList">
 			Backspace key.

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -798,11 +798,11 @@
 			Tells Godot which node it should give keyboard focus to if the user presses the top arrow on the keyboard or top on a gamepad by default. You can change the key by editing the [code]ui_top[/code] input action. The node must be a [Control]. If this property is not set, Godot will give focus to the closest [Control] to the bottom of this one.
 		</member>
 		<member name="focus_next" type="NodePath" setter="set_focus_next" getter="get_focus_next" default="NodePath(&quot;&quot;)">
-			Tells Godot which node it should give keyboard focus to if the user presses Tab on a keyboard by default. You can change the key by editing the [code]ui_focus_next[/code] input action.
+			Tells Godot which node it should give keyboard focus to if the user presses [kbd]Tab[/kbd] on a keyboard by default. You can change the key by editing the [code]ui_focus_next[/code] input action.
 			If this property is not set, Godot will select a "best guess" based on surrounding nodes in the scene tree.
 		</member>
 		<member name="focus_previous" type="NodePath" setter="set_focus_previous" getter="get_focus_previous" default="NodePath(&quot;&quot;)">
-			Tells Godot which node it should give keyboard focus to if the user presses Shift+Tab on a keyboard by default. You can change the key by editing the [code]ui_focus_prev[/code] input action.
+			Tells Godot which node it should give keyboard focus to if the user presses [kbd]Shift + Tab[/kbd] on a keyboard by default. You can change the key by editing the [code]ui_focus_prev[/code] input action.
 			If this property is not set, Godot will select a "best guess" based on surrounding nodes in the scene tree.
 		</member>
 		<member name="grow_horizontal" type="int" setter="set_h_grow_direction" getter="get_h_grow_direction" enum="Control.GrowDirection" default="1">

--- a/doc/classes/EditorScript.xml
+++ b/doc/classes/EditorScript.xml
@@ -4,7 +4,7 @@
 		Base script that can be used to add extension functions to the editor.
 	</brief_description>
 	<description>
-		Scripts extending this class and implementing its [method _run] method can be executed from the Script Editor's [b]File &gt; Run[/b] menu option (or by pressing [code]Ctrl+Shift+X[/code]) while the editor is running. This is useful for adding custom in-editor functionality to Godot. For more complex additions, consider using [EditorPlugin]s instead.
+		Scripts extending this class and implementing its [method _run] method can be executed from the Script Editor's [b]File &gt; Run[/b] menu option (or by pressing [kbd]Ctrl + Shift + X[/kbd]) while the editor is running. This is useful for adding custom in-editor functionality to Godot. For more complex additions, consider using [EditorPlugin]s instead.
 		[b]Note:[/b] Extending scripts need to have [code]tool[/code] mode enabled.
 		[b]Example script:[/b]
 		[codeblock]

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -240,7 +240,7 @@
 		</signal>
 		<signal name="copy_nodes_request">
 			<description>
-				Emitted when the user presses [code]Ctrl + C[/code].
+				Emitted when the user presses [kbd]Ctrl + C[/kbd].
 			</description>
 		</signal>
 		<signal name="delete_nodes_request">
@@ -275,7 +275,7 @@
 		</signal>
 		<signal name="paste_nodes_request">
 			<description>
-				Emitted when the user presses [code]Ctrl + V[/code].
+				Emitted when the user presses [kbd]Ctrl + V[/kbd].
 			</description>
 		</signal>
 		<signal name="popup_request">

--- a/doc/classes/InputEventKey.xml
+++ b/doc/classes/InputEventKey.xml
@@ -14,7 +14,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the keycode combined with modifier keys such as [code]Shift[/code] or [code]Alt[/code]. See also [InputEventWithModifiers].
+				Returns the keycode combined with modifier keys such as [kbd]Shift[/kbd] or [kbd]Alt[/kbd]. See also [InputEventWithModifiers].
 				To get a human-readable representation of the [InputEventKey] with modifiers, use [code]OS.get_keycode_string(event.get_keycode_with_modifiers())[/code] where [code]event[/code] is the [InputEventKey].
 			</description>
 		</method>
@@ -22,7 +22,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Returns the physical keycode combined with modifier keys such as [code]Shift[/code] or [code]Alt[/code]. See also [InputEventWithModifiers].
+				Returns the physical keycode combined with modifier keys such as [kbd]Shift[/kbd] or [kbd]Alt[/kbd]. See also [InputEventWithModifiers].
 				To get a human-readable representation of the [InputEventKey] with modifiers, use [code]OS.get_keycode_string(event.get_physical_keycode_with_modifiers())[/code] where [code]event[/code] is the [InputEventKey].
 			</description>
 		</method>

--- a/doc/classes/InputEventWithModifiers.xml
+++ b/doc/classes/InputEventWithModifiers.xml
@@ -4,7 +4,7 @@
 		Base class for keys events with modifiers.
 	</brief_description>
 	<description>
-		Contains keys events information with modifiers support like [code]Shift[/code] or [code]Alt[/code]. See [method Node._input].
+		Contains keys events information with modifiers support like [kbd]Shift[/kbd] or [kbd]Alt[/kbd]. See [method Node._input].
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html</link>
@@ -13,19 +13,19 @@
 	</methods>
 	<members>
 		<member name="alt" type="bool" setter="set_alt" getter="get_alt" default="false">
-			State of the [code]Alt[/code] modifier.
+			State of the [kbd]Alt[/kbd] modifier.
 		</member>
 		<member name="command" type="bool" setter="set_command" getter="get_command" default="false">
-			State of the [code]Command[/code] modifier.
+			State of the [kbd]Cmd[/kbd] modifier.
 		</member>
 		<member name="control" type="bool" setter="set_control" getter="get_control" default="false">
-			State of the [code]Ctrl[/code] modifier.
+			State of the [kbd]Ctrl[/kbd] modifier.
 		</member>
 		<member name="meta" type="bool" setter="set_metakey" getter="get_metakey" default="false">
-			State of the [code]Meta[/code] modifier.
+			State of the [kbd]Meta[/kbd] modifier.
 		</member>
 		<member name="shift" type="bool" setter="set_shift" getter="get_shift" default="false">
-			State of the [code]Shift[/code] modifier.
+			State of the [kbd]Shift[/kbd] modifier.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		This control provides a selectable list of items that may be in a single (or multiple columns) with option of text, icons, or both text and icon. Tooltips are supported and may be different for every item in the list.
-		Selectable items in the list may be selected or deselected and multiple selection may be enabled. Selection with right mouse button may also be enabled to allow use of popup context menus. Items may also be "activated" by double-clicking them or by pressing Enter.
+		Selectable items in the list may be selected or deselected and multiple selection may be enabled. Selection with right mouse button may also be enabled to allow use of popup context menus. Items may also be "activated" by double-clicking them or by pressing [kbd]Enter[/kbd].
 		Item text only supports single-line strings, newline characters (e.g. [code]\n[/code]) in the string won't produce a newline. Text wrapping is enabled in [constant ICON_MODE_TOP] mode, but column's width is adjusted to fully fit its content by default. You need to set [member fixed_column_width] greater than zero to wrap the text.
 	</description>
 	<tutorials>
@@ -278,7 +278,7 @@
 			</argument>
 			<description>
 				Disables (or enables) the item at the specified index.
-				Disabled items cannot be selected and do not trigger activation signals (when double-clicking or pressing Enter).
+				Disabled items cannot be selected and do not trigger activation signals (when double-clicking or pressing [kbd]Enter[/kbd]).
 			</description>
 		</method>
 		<method name="set_item_icon">
@@ -452,7 +452,7 @@
 			<argument index="0" name="index" type="int">
 			</argument>
 			<description>
-				Triggered when specified list item is activated via double-clicking or by pressing Enter.
+				Triggered when specified list item is activated via double-clicking or by pressing [kbd]Enter[/kbd].
 			</description>
 		</signal>
 		<signal name="item_rmb_selected">
@@ -508,7 +508,7 @@
 			Only allow selecting a single item.
 		</constant>
 		<constant name="SELECT_MULTI" value="1" enum="SelectMode">
-			Allows selecting multiple items by holding Ctrl or Shift.
+			Allows selecting multiple items by holding [kbd]Ctrl[/kbd] or [kbd]Shift[/kbd].
 		</constant>
 	</constants>
 	<theme_items>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -5,27 +5,27 @@
 	</brief_description>
 	<description>
 		LineEdit provides a single-line string editor, used for text fields.
-		It features many built-in shortcuts which will always be available ([code]Ctrl[/code] here maps to [code]Command[/code] on macOS):
-		- Ctrl + C: Copy
-		- Ctrl + X: Cut
-		- Ctrl + V or Ctrl + Y: Paste/"yank"
-		- Ctrl + Z: Undo
-		- Ctrl + Shift + Z: Redo
-		- Ctrl + U: Delete text from the cursor position to the beginning of the line
-		- Ctrl + K: Delete text from the cursor position to the end of the line
-		- Ctrl + A: Select all text
-		- Up/Down arrow: Move the cursor to the beginning/end of the line
+		It features many built-in shortcuts which will always be available ([kbd]Ctrl[/kbd] here maps to [kbd]Cmd[/kbd] on macOS):
+		- [kbd]Ctrl + C[/kbd]: Copy
+		- [kbd]Ctrl + X[/kbd]: Cut
+		- [kbd]Ctrl + V[/kbd] or [kbd]Ctrl + Y[/kbd]: Paste/"yank"
+		- [kbd]Ctrl + Z[/kbd]: Undo
+		- [kbd]Ctrl + Shift + Z[/kbd]: Redo
+		- [kbd]Ctrl + U[/kbd]: Delete text from the cursor position to the beginning of the line
+		- [kbd]Ctrl + K[/kbd]: Delete text from the cursor position to the end of the line
+		- [kbd]Ctrl + A[/kbd]: Select all text
+		- [kbd]Up Arrow[/kbd]/[kbd]Down Arrow[/kbd]: Move the cursor to the beginning/end of the line
 		On macOS, some extra keyboard shortcuts are available:
-		- Ctrl + F: Like the right arrow key, move the cursor one character right
-		- Ctrl + B: Like the left arrow key, move the cursor one character left
-		- Ctrl + P: Like the up arrow key, move the cursor to the previous line
-		- Ctrl + N: Like the down arrow key, move the cursor to the next line
-		- Ctrl + D: Like the Delete key, delete the character on the right side of cursor
-		- Ctrl + H: Like the Backspace key, delete the character on the left side of the cursor
-		- Ctrl + A: Like the Home key, move the cursor to the beginning of the line
-		- Ctrl + E: Like the End key, move the cursor to the end of the line
-		- Command + Left arrow: Like the Home key, move the cursor to the beginning of the line
-		- Command + Right arrow: Like the End key, move the cursor to the end of the line
+		- [kbd]Ctrl + F[/kbd]: Same as [kbd]Right Arrow[/kbd], move the cursor one character right
+		- [kbd]Ctrl + B[/kbd]: Same as [kbd]Left Arrow[/kbd], move the cursor one character left
+		- [kbd]Ctrl + P[/kbd]: Same as [kbd]Up Arrow[/kbd], move the cursor to the previous line
+		- [kbd]Ctrl + N[/kbd]: Same as [kbd]Down Arrow[/kbd], move the cursor to the next line
+		- [kbd]Ctrl + D[/kbd]: Same as [kbd]Delete[/kbd], delete the character on the right side of cursor
+		- [kbd]Ctrl + H[/kbd]: Same as [kbd]Backspace[/kbd], delete the character on the left side of the cursor
+		- [kbd]Ctrl + A[/kbd]: Same as [kbd]Home[/kbd], move the cursor to the beginning of the line
+		- [kbd]Ctrl + E[/kbd]: Same as [kbd]End[/kbd], move the cursor to the end of the line
+		- [kbd]Cmd + Left Arrow[/kbd]: Same as [kbd]Home[/kbd], move the cursor to the beginning of the line
+		- [kbd]Cmd + Right Arrow[/kbd]: Same as [kbd]End[/kbd], move the cursor to the end of the line
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -932,7 +932,7 @@
 			Implemented on all platforms.
 		</constant>
 		<constant name="NOTIFICATION_WM_CLOSE_REQUEST" value="1006">
-			Notification received from the OS when a close request is sent (e.g. closing the window with a "Close" button or Alt+F4).
+			Notification received from the OS when a close request is sent (e.g. closing the window with a "Close" button or [kbd]Alt + F4[/kbd]).
 			Implemented on desktop platforms.
 		</constant>
 		<constant name="NOTIFICATION_WM_GO_BACK_REQUEST" value="1007">

--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -901,6 +901,12 @@ def rstize_text(text, state):  # type: (str, State) -> str
                 tag_text = "``"
                 tag_depth += 1
                 inside_code = True
+            elif cmd == "kbd":
+                tag_text = ":kbd:`"
+                tag_depth += 1
+            elif cmd == "/kbd":
+                tag_text = "`"
+                tag_depth -= 1
             elif cmd.startswith("enum "):
                 tag_text = make_enum(cmd[5:], state)
                 escape_post = True

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -247,10 +247,12 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	MAKE_BOLD_FONT(df_doc_bold, int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
 	MAKE_BOLD_FONT(df_doc_title, int(EDITOR_GET("text_editor/help/help_title_font_size")) * EDSCALE);
 	MAKE_SOURCE_FONT(df_doc_code, int(EDITOR_GET("text_editor/help/help_source_font_size")) * EDSCALE);
+	MAKE_SOURCE_FONT(df_doc_kbd, (int(EDITOR_GET("text_editor/help/help_source_font_size")) - 1) * EDSCALE);
 	p_theme->set_font("doc", "EditorFonts", df_doc);
 	p_theme->set_font("doc_bold", "EditorFonts", df_doc_bold);
 	p_theme->set_font("doc_title", "EditorFonts", df_doc_title);
 	p_theme->set_font("doc_source", "EditorFonts", df_doc_code);
+	p_theme->set_font("doc_keyboard", "EditorFonts", df_doc_kbd);
 
 	// Ruler font
 	MAKE_DEFAULT_FONT(df_rulers, 8 * EDSCALE);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1210,11 +1210,14 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 	Ref<Font> doc_font = p_rt->get_theme_font("doc", "EditorFonts");
 	Ref<Font> doc_bold_font = p_rt->get_theme_font("doc_bold", "EditorFonts");
 	Ref<Font> doc_code_font = p_rt->get_theme_font("doc_source", "EditorFonts");
+	Ref<Font> doc_kbd_font = p_rt->get_theme_font("doc_keyboard", "EditorFonts");
 
 	Color font_color_hl = p_rt->get_theme_color("headline_color", "EditorHelp");
 	Color accent_color = p_rt->get_theme_color("accent_color", "Editor");
+	Color property_color = p_rt->get_theme_color("property_color", "Editor");
 	Color link_color = accent_color.linear_interpolate(font_color_hl, 0.8);
 	Color code_color = accent_color.linear_interpolate(font_color_hl, 0.6);
+	Color kbd_color = accent_color.linear_interpolate(property_color, 0.6);
 
 	String bbcode = p_bbcode.dedent().replace("\t", "").replace("\r", "").strip_edges();
 
@@ -1323,6 +1326,14 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			p_rt->push_font(doc_code_font);
 			p_rt->push_color(code_color);
 			code_tag = true;
+			pos = brk_end + 1;
+			tag_stack.push_front(tag);
+		} else if (tag == "kbd") {
+
+			//use keyboard font with custom color
+			p_rt->push_font(doc_kbd_font);
+			p_rt->push_color(kbd_color);
+			code_tag = true; // though not strictly a code tag, logic is similar
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 		} else if (tag == "center") {

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -566,8 +566,12 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			code_tag = true;
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
+		} else if (tag == "kbd") {
+			// keyboard combinations are not supported in xml comments
+			pos = brk_end + 1;
+			tag_stack.push_front(tag);
 		} else if (tag == "center") {
-			// center is alignment not supported in xml comments
+			// center alignment is not supported in xml comments
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 		} else if (tag == "br") {


### PR DESCRIPTION
Followup to godotengine/godot-docs#3257.

Added a new `[kbd]` tag for docs, similar to `<kbd>` tag here on GitHub. It translates into ` :kbd:`` ` when generating RST-files. For built-in docs a style similar to `[code]` was chosen, but the font is one point smaller and has a different color. I think, if #35608 is merged, the `[kbd]` tag should be then made more visible with a darker background color.

Here is the worst example for built-in help:
![image](https://user-images.githubusercontent.com/11782833/76305216-c9b72300-62d5-11ea-9385-20eaf8b24171.png)

I've decided not to add this tag in some cases, like the `KEY_` constants in `@GlobalScope`. I don't think that it would help readability there and some of the key names are very descriptive or specific. Can be easily corrected though, now that we have a tag.

-----
If I'm understanding the purpose of the `modules/mono/editor/bindings_generator.cpp` file correctly, this new tag is also excluded from XML docs in C# API bindings as unsupported.