### PR TITLE
Allocates StringName::mutex on heap

### DIFF
--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -75,7 +75,7 @@ class StringName {
 	friend void register_core_types();
 	friend void unregister_core_types();
 	friend class Main;
-	static Mutex mutex;
+	static Mutex *mutex;
 	static void setup();
 	static void cleanup();
 	static bool configured;


### PR DESCRIPTION
The initialization/destruction order of static objects is indeterminate. And the current `StringName::mutex` is a static object.

On my macOS machine, Godot crashes on exit because:

1. The global `StringName::mutex` is destructed first.
2. Then, the global `_global_constants` vector is destructed.
    1. The elements in this vector is of type `_GlobalConstant`, which contains a `StringName` member `enum_name`
    2. The `enum_name` object got destructed
        1. `StringName`'s destructor tries to lock the already destructed `StringName::mutex` (in `StringName::unref`)
        2. So a `std::system_error` with "Invalid Argument" is thrown
3. Godot crashes due to this unhandled exception.

This PR changes the `StringName::mutex` to a pointer, allocates in `setup()` and deletes in `cleanup()`.

<details><summary>Crash Log & Backtrace</summary>

This log crashes at destructing the `Engine` singleton inside the `_global_constants`. It has a  `StringName` member, the cause of the crash is the same.

```
ERROR: No surface extension found, is a driver installed?
   at: _initialize_extensions (drivers/vulkan/vulkan_context.cpp:264)
ERROR: Method/Function Failed, returning: ERR_UNAVAILABLE
   at: initialize (platform/osx/os_osx.mm:1600)
libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: recursive_mutex lock failed: Invalid argument
Abort trap: 6

* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
  * frame #0: 0x00007fff61cb63ec libc++abi.dylib`__cxa_throw
    frame #1: 0x00007fff61ca82db libc++.1.dylib`std::__1::__throw_system_error(int, char const*) + 77
    frame #2: 0x00007fff61c68c35 libc++.1.dylib`std::__1::recursive_mutex::lock() + 29
    frame #3: 0x0000000109b5fbdd godot.osx.tools.64s`StringName::unref() [inlined] MutexImpl<std::__1::recursive_mutex>::lock(this=0x000000010d49da40) const at mutex.h:47:9
    frame #4: 0x0000000109b5fbd8 godot.osx.tools.64s`StringName::unref() [inlined] MutexLock<MutexImpl<std::__1::recursive_mutex> >::MutexLock(this=0x00007ffeefbff360, p_mutex=0x000000010d49da40) at mutex.h:66
    frame #5: 0x0000000109b5fb47 godot.osx.tools.64s`StringName::unref() [inlined] MutexLock<MutexImpl<std::__1::recursive_mutex> >::MutexLock(this=0x00007ffeefbff360, p_mutex=0x000000010d49da40) at mutex.h:65
    frame #6: 0x0000000109b5fb2b godot.osx.tools.64s`StringName::unref(this=0x00006290003a2258) at string_name.cpp:96
    frame #7: 0x0000000109b666f5 godot.osx.tools.64s`StringName::~StringName(this=0x00006290003a2258) at string_name.cpp:398:2
    frame #8: 0x0000000109b66735 godot.osx.tools.64s`StringName::~StringName(this=0x00006290003a2258) at string_name.cpp:396:27
    frame #9: 0x00000001000e04c5 godot.osx.tools.64s`Engine::Singleton::~Singleton() + 21
    frame #10: 0x00000001000c6675 godot.osx.tools.64s`Engine::Singleton::~Singleton() + 21
    frame #11: 0x00000001098f192a godot.osx.tools.64s`CowData<_GlobalConstant>::_unref(this=0x000000010d4c1568, p_data=0x00006290003a2210) at cowdata.h:208:13
    frame #12: 0x00000001098f17ab godot.osx.tools.64s`CowData<_GlobalConstant>::~CowData(this=0x000000010d4c1568) at cowdata.h:370:2
    frame #13: 0x00000001098f1755 godot.osx.tools.64s`CowData<_GlobalConstant>::~CowData(this=0x000000010d4c1568) at cowdata.h:368:24
    frame #14: 0x00000001098f1739 godot.osx.tools.64s`Vector<_GlobalConstant>::~Vector(this=0x000000010d4c1560) at vector.h:151:28
    frame #15: 0x00000001098b70e5 godot.osx.tools.64s`Vector<_GlobalConstant>::~Vector(this=0x000000010d4c1560) at vector.h:151:27
    frame #16: 0x00007fff64bf8446 libsystem_c.dylib`__cxa_finalize_ranges + 319
    frame #17: 0x00007fff64bf871c libsystem_c.dylib`exit + 55
    frame #18: 0x00007fff64b4f804 libdyld.dylib`start + 8
    frame #19: 0x00007fff64b4f7fd libdyld.dylib`start + 1
```

</details>