### PR TITLE
Linux: Add Mesa 20 "Intel" to prime detection

### DIFF
--- a/platform/x11/detect_prime.cpp
+++ b/platform/x11/detect_prime.cpp
@@ -62,6 +62,7 @@ vendor vendormap[] = {
 	{ "NVIDIA Corporation", 30 },
 	{ "X.Org", 30 },
 	{ "Intel Open Source Technology Center", 20 },
+	{ "Intel", 20 },
 	{ "nouveau", 10 },
 	{ "Mesa Project", 0 },
 	{ NULL, 0 }


### PR DESCRIPTION
Diff in `glxinfo` between Mesa 19.3.4 and 20.0.1:
```diff
-OpenGL vendor string: Intel Open Source Technology Center
-OpenGL renderer string: Mesa DRI Intel(R) HD Graphics 630 (Kaby Lake GT2)
-OpenGL core profile version string: 4.6 (Core Profile) Mesa 19.3.4
+OpenGL vendor string: Intel
+OpenGL renderer string: Mesa Intel(R) HD Graphics 630 (KBL GT2)
+OpenGL core profile version string: 4.6 (Core Profile) Mesa 20.0.1
```