### PR TITLE
Vulkan: Implement environment fog and exponential fog

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -98,6 +98,13 @@
 		<member name="fog_color" type="Color" setter="set_fog_color" getter="get_fog_color" default="Color( 0.5, 0.6, 0.7, 1 )">
 			The fog's [Color].
 		</member>
+		<member name="fog_exponential_enabled" type="bool" setter="set_fog_exponential_enabled" getter="is_fog_exponential_enabled" default="true">
+			If [code]true[/code], depth fog will use exponential attenuation instead of using the curve defined in [member fog_depth_curve]. This is more physically accurate, but it gives less artistic control to the user.
+			[b]Note:[/b] If exponential fog is enabled, [member fog_depth_begin] and [member fog_depth_end] are ignored. Instead, [member fog_exponential_density] controls how dense the depth fog is.
+		</member>
+		<member name="fog_exponential_density" type="float" setter="set_fog_exponential_density" getter="get_fog_exponential_density" default="0.01">
+			The fog's density when exponential fog is enabled (see [member fog_exponential_enabled]). This value is equivalent to the alpha value in fog's [Color] but allows the combination of both.
+		</member>
 		<member name="fog_depth_begin" type="float" setter="set_fog_depth_begin" getter="get_fog_depth_begin" default="10.0">
 			The fog's depth starting distance from the camera.
 		</member>

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -88,7 +88,7 @@ public:
 
 	void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, RID p_ramp) {}
 
-	void environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount) {}
+	void environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount, bool p_exponential_enable, float p_exponential_density) {}
 	void environment_set_fog_depth(RID p_env, bool p_enable, float p_depth_begin, float p_depth_end, float p_depth_curve, bool p_transmit, float p_transmit_curve) {}
 	void environment_set_fog_height(RID p_env, bool p_enable, float p_min_height, float p_max_height, float p_height_curve) {}
 

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -345,6 +345,9 @@ void Environment::_validate_property(PropertyInfo &property) const {
 		"ssao_",
 		"glow_",
 		"adjustment_",
+		"fog_height_",
+		"fog_depth_",
+		"fog_exponential_",
 		NULL
 
 	};
@@ -674,7 +677,7 @@ bool Environment::is_glow_bicubic_upscale_enabled() const {
 void Environment::set_fog_enabled(bool p_enabled) {
 
 	fog_enabled = p_enabled;
-	VS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount);
+	VS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount, fog_exponential_enabled, fog_exponential_density);
 	_change_notify();
 }
 
@@ -686,7 +689,7 @@ bool Environment::is_fog_enabled() const {
 void Environment::set_fog_color(const Color &p_color) {
 
 	fog_color = p_color;
-	VS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount);
+	VS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount, fog_exponential_enabled, fog_exponential_density);
 }
 Color Environment::get_fog_color() const {
 
@@ -696,7 +699,7 @@ Color Environment::get_fog_color() const {
 void Environment::set_fog_sun_color(const Color &p_color) {
 
 	fog_sun_color = p_color;
-	VS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount);
+	VS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount, fog_exponential_enabled, fog_exponential_density);
 }
 Color Environment::get_fog_sun_color() const {
 
@@ -706,7 +709,7 @@ Color Environment::get_fog_sun_color() const {
 void Environment::set_fog_sun_amount(float p_amount) {
 
 	fog_sun_amount = p_amount;
-	VS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount);
+	VS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount, fog_exponential_enabled, fog_exponential_density);
 }
 float Environment::get_fog_sun_amount() const {
 
@@ -717,6 +720,7 @@ void Environment::set_fog_depth_enabled(bool p_enabled) {
 
 	fog_depth_enabled = p_enabled;
 	VS::get_singleton()->environment_set_fog_depth(environment, fog_depth_enabled, fog_depth_begin, fog_depth_end, fog_depth_curve, fog_transmit_enabled, fog_transmit_curve);
+	_change_notify();
 }
 bool Environment::is_fog_depth_enabled() const {
 
@@ -778,6 +782,7 @@ void Environment::set_fog_height_enabled(bool p_enabled) {
 
 	fog_height_enabled = p_enabled;
 	VS::get_singleton()->environment_set_fog_height(environment, fog_height_enabled, fog_height_min, fog_height_max, fog_height_curve);
+	_change_notify();
 }
 bool Environment::is_fog_height_enabled() const {
 
@@ -812,6 +817,28 @@ void Environment::set_fog_height_curve(float p_distance) {
 float Environment::get_fog_height_curve() const {
 
 	return fog_height_curve;
+}
+
+void Environment::set_fog_exponential_enabled(bool p_enabled) {
+
+	fog_exponential_enabled = p_enabled;
+	VS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount, fog_exponential_enabled, fog_exponential_density);
+	_change_notify();
+}
+
+bool Environment::is_fog_exponential_enabled() const {
+
+	return fog_exponential_enabled;
+}
+
+void Environment::set_fog_exponential_density(float p_density) {
+
+	fog_exponential_density = p_density;
+	VS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount, fog_exponential_enabled, fog_exponential_density);
+}
+
+float Environment::get_fog_exponential_density() const {
+	return fog_exponential_density;
 }
 
 #ifndef DISABLE_DEPRECATED
@@ -926,11 +953,19 @@ void Environment::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fog_height_curve", "curve"), &Environment::set_fog_height_curve);
 	ClassDB::bind_method(D_METHOD("get_fog_height_curve"), &Environment::get_fog_height_curve);
 
+	ClassDB::bind_method(D_METHOD("set_fog_exponential_enabled", "enabled"), &Environment::set_fog_exponential_enabled);
+	ClassDB::bind_method(D_METHOD("is_fog_exponential_enabled"), &Environment::is_fog_exponential_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_fog_exponential_density", "density"), &Environment::set_fog_exponential_density);
+	ClassDB::bind_method(D_METHOD("get_fog_exponential_density"), &Environment::get_fog_exponential_density);
+
 	ADD_GROUP("Fog", "fog_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fog_enabled"), "set_fog_enabled", "is_fog_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "fog_color"), "set_fog_color", "get_fog_color");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "fog_sun_color"), "set_fog_sun_color", "get_fog_sun_color");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_sun_amount", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_fog_sun_amount", "get_fog_sun_amount");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fog_exponential_enabled"), "set_fog_exponential_enabled", "is_fog_exponential_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_exponential_density", PROPERTY_HINT_EXP_RANGE, "0,50,0.001"), "set_fog_exponential_density", "get_fog_exponential_density");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fog_depth_enabled"), "set_fog_depth_enabled", "is_fog_depth_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_depth_begin", PROPERTY_HINT_RANGE, "0,4000,0.1"), "set_fog_depth_begin", "get_fog_depth_begin");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_depth_end", PROPERTY_HINT_RANGE, "0,4000,0.1,or_greater"), "set_fog_depth_end", "get_fog_depth_end");
@@ -1222,13 +1257,16 @@ Environment::Environment() :
 	fog_depth_end = 100;
 	fog_depth_curve = 1;
 
-	fog_transmit_enabled = false;
+	fog_transmit_enabled = true;
 	fog_transmit_curve = 1;
 
 	fog_height_enabled = false;
 	fog_height_min = 10;
 	fog_height_max = 0;
 	fog_height_curve = 1;
+
+	fog_exponential_enabled = true;
+	fog_exponential_density = 0.01;
 
 	set_fog_color(Color(0.5, 0.6, 0.7));
 	set_fog_sun_color(Color(1.0, 0.9, 0.7));

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -166,6 +166,9 @@ private:
 	float fog_height_max;
 	float fog_height_curve;
 
+	float fog_exponential_enabled;
+	float fog_exponential_density;
+
 protected:
 	static void _bind_methods();
 	virtual void _validate_property(PropertyInfo &property) const;
@@ -362,6 +365,12 @@ public:
 
 	void set_fog_height_curve(float p_distance);
 	float get_fog_height_curve() const;
+
+	void set_fog_exponential_enabled(bool p_enabled);
+	bool is_fog_exponential_enabled() const;
+
+	void set_fog_exponential_density(float p_density);
+	float get_fog_exponential_density() const;
 
 	virtual RID get_rid() const;
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -87,7 +87,7 @@ public:
 
 	virtual void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, RID p_ramp) = 0;
 
-	virtual void environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount) = 0;
+	virtual void environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount, bool p_exponential_enable, float p_exponential_density) = 0;
 	virtual void environment_set_fog_depth(RID p_env, bool p_enable, float p_depth_begin, float p_depth_end, float p_depth_curve, bool p_transmit, float p_transmit_curve) = 0;
 	virtual void environment_set_fog_height(RID p_env, bool p_enable, float p_min_height, float p_max_height, float p_height_curve) = 0;
 

--- a/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -1057,6 +1057,9 @@ void RasterizerSceneHighEndRD::_setup_environment(RID p_environment, const Camer
 		scene_state.ubo.fog_height_max = environment_get_fog_height_max(p_environment);
 		scene_state.ubo.fog_height_curve = environment_get_fog_height_curve(p_environment);
 
+		scene_state.ubo.fog_exponential_enabled = environment_get_fog_exponential_enabled(p_environment);
+		scene_state.ubo.fog_exponential_density = environment_get_fog_exponential_density(p_environment);
+
 	} else {
 
 		if (p_reflection_probe.is_valid() && storage->reflection_probe_is_interior(reflection_probe_instance_get_probe(p_reflection_probe))) {

--- a/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -1033,6 +1033,30 @@ void RasterizerSceneHighEndRD::_setup_environment(RID p_environment, const Camer
 		scene_state.ubo.ao_color[2] = ao_color.b;
 		scene_state.ubo.ao_color[3] = ao_color.a;
 
+		Color linear_fog = environment_get_fog_color(p_environment).to_linear();
+		scene_state.ubo.fog_color_enabled[0] = linear_fog.r;
+		scene_state.ubo.fog_color_enabled[1] = linear_fog.g;
+		scene_state.ubo.fog_color_enabled[2] = linear_fog.b;
+		scene_state.ubo.fog_color_enabled[3] = (!p_no_fog && environment_get_fog_enabled(p_environment)) ? 1.0 : 0.0;
+		scene_state.ubo.fog_density = linear_fog.a;
+
+		Color linear_sun = environment_get_fog_sun_color(p_environment).to_linear();
+		scene_state.ubo.fog_sun_color_amount[0] = linear_sun.r;
+		scene_state.ubo.fog_sun_color_amount[1] = linear_sun.g;
+		scene_state.ubo.fog_sun_color_amount[2] = linear_sun.b;
+		scene_state.ubo.fog_sun_color_amount[3] = environment_get_fog_sun_amount(p_environment);
+
+		scene_state.ubo.fog_depth_enabled = environment_get_fog_depth_enabled(p_environment);
+		scene_state.ubo.fog_depth_begin = environment_get_fog_depth_begin(p_environment);
+		scene_state.ubo.fog_depth_end = environment_get_fog_depth_end(p_environment);
+		scene_state.ubo.fog_depth_curve = environment_get_fog_depth_curve(p_environment);
+		scene_state.ubo.fog_transmit_enabled = environment_get_fog_transmit_enabled(p_environment);
+		scene_state.ubo.fog_transmit_curve = environment_get_fog_transmit_curve(p_environment);
+		scene_state.ubo.fog_height_enabled = environment_get_fog_height_enabled(p_environment);
+		scene_state.ubo.fog_height_min = environment_get_fog_height_min(p_environment);
+		scene_state.ubo.fog_height_max = environment_get_fog_height_max(p_environment);
+		scene_state.ubo.fog_height_curve = environment_get_fog_height_curve(p_environment);
+
 	} else {
 
 		if (p_reflection_probe.is_valid() && storage->reflection_probe_is_interior(reflection_probe_instance_get_probe(p_reflection_probe))) {
@@ -1049,6 +1073,8 @@ void RasterizerSceneHighEndRD::_setup_environment(RID p_environment, const Camer
 
 		scene_state.ubo.use_ambient_cubemap = false;
 		scene_state.ubo.use_reflection_cubemap = false;
+
+		scene_state.ubo.fog_color_enabled[3] = 0.0;
 	}
 
 	scene_state.ubo.roughness_limiter_enabled = p_opaque_render_buffers && screen_space_roughness_limiter_is_active();

--- a/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.h
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.h
@@ -314,6 +314,8 @@ class RasterizerSceneHighEndRD : public RasterizerSceneRD {
 
 	struct SceneState {
 		struct UBO {
+			//this is a std140 compatible struct. Please read the OpenGL 3.3 Specification spec before doing any changes
+
 			float projection_matrix[16];
 			float inv_projection_matrix[16];
 
@@ -352,6 +354,23 @@ class RasterizerSceneHighEndRD : public RasterizerSceneRD {
 			uint32_t roughness_limiter_enabled;
 
 			float ao_color[4];
+
+			float fog_color_enabled[4];
+			float fog_sun_color_amount[4];
+
+			uint32_t fog_depth_enabled;
+			float fog_depth_begin;
+			float fog_depth_end;
+			float fog_density;
+			float fog_depth_curve;
+			uint32_t fog_transmit_enabled;
+			float fog_transmit_curve;
+			uint32_t fog_height_enabled;
+			float fog_height_min;
+			float fog_height_max;
+			float fog_height_curve;
+			// make sure this struct is padded to be a multiple of 16 bytes for webgl
+			float pad;
 		};
 
 		UBO ubo;

--- a/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.h
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.h
@@ -369,8 +369,11 @@ class RasterizerSceneHighEndRD : public RasterizerSceneRD {
 			float fog_height_min;
 			float fog_height_max;
 			float fog_height_curve;
+			uint32_t fog_exponential_enabled;
+			float fog_exponential_density;
+
 			// make sure this struct is padded to be a multiple of 16 bytes for webgl
-			float pad;
+			float pad[3];
 		};
 
 		UBO ubo;

--- a/servers/visual/rasterizer_rd/rasterizer_scene_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_rd.cpp
@@ -553,6 +553,122 @@ void RasterizerSceneRD::environment_set_tonemap(RID p_env, VS::EnvironmentToneMa
 	env->auto_exp_scale = p_auto_exp_scale;
 }
 
+void RasterizerSceneRD::environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount) {
+
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND(!env);
+
+	env->fog_enabled = p_enable;
+	env->fog_color = p_color;
+	env->fog_sun_color = p_sun_color;
+	env->fog_sun_amount = p_sun_amount;
+}
+
+void RasterizerSceneRD::environment_set_fog_depth(RID p_env, bool p_enable, float p_depth_begin, float p_depth_end, float p_depth_curve, bool p_transmit, float p_transmit_curve) {
+
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND(!env);
+
+	env->fog_depth_enabled = p_enable;
+	env->fog_depth_begin = p_depth_begin;
+	env->fog_depth_end = p_depth_end;
+	env->fog_depth_curve = p_depth_curve;
+	env->fog_transmit_enabled = p_transmit;
+	env->fog_transmit_curve = p_transmit_curve;
+}
+
+void RasterizerSceneRD::environment_set_fog_height(RID p_env, bool p_enable, float p_min_height, float p_max_height, float p_height_curve) {
+
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND(!env);
+
+	env->fog_height_enabled = p_enable;
+	env->fog_height_min = p_min_height;
+	env->fog_height_max = p_max_height;
+	env->fog_height_curve = p_height_curve;
+}
+
+bool RasterizerSceneRD::environment_get_fog_enabled(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_enabled;
+}
+
+bool RasterizerSceneRD::environment_get_fog_depth_enabled(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_depth_enabled;
+}
+
+bool RasterizerSceneRD::environment_get_fog_height_enabled(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_height_enabled;
+}
+
+float RasterizerSceneRD::environment_get_fog_depth_end(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_depth_end;
+}
+
+Color RasterizerSceneRD::environment_get_fog_color(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, Color());
+	return env->fog_color;
+}
+
+Color RasterizerSceneRD::environment_get_fog_sun_color(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, Color());
+	return env->fog_sun_color;
+}
+
+bool RasterizerSceneRD::environment_get_fog_transmit_enabled(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_transmit_enabled;
+}
+
+float RasterizerSceneRD::environment_get_fog_transmit_curve(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_transmit_curve;
+}
+
+float RasterizerSceneRD::environment_get_fog_depth_begin(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_depth_begin;
+}
+
+float RasterizerSceneRD::environment_get_fog_depth_curve(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_depth_curve;
+}
+float RasterizerSceneRD::environment_get_fog_height_min(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_height_min;
+}
+float RasterizerSceneRD::environment_get_fog_height_max(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_height_max;
+}
+
+float RasterizerSceneRD::environment_get_fog_height_curve(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_height_curve;
+}
+float RasterizerSceneRD::environment_get_fog_sun_amount(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_sun_amount;
+}
+
 void RasterizerSceneRD::environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, VS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale) {
 
 	Environent *env = environment_owner.getornull(p_env);

--- a/servers/visual/rasterizer_rd/rasterizer_scene_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_rd.cpp
@@ -553,7 +553,7 @@ void RasterizerSceneRD::environment_set_tonemap(RID p_env, VS::EnvironmentToneMa
 	env->auto_exp_scale = p_auto_exp_scale;
 }
 
-void RasterizerSceneRD::environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount) {
+void RasterizerSceneRD::environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount, bool p_exponential_enable, float p_fog_exponential_density) {
 
 	Environent *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
@@ -562,6 +562,8 @@ void RasterizerSceneRD::environment_set_fog(RID p_env, bool p_enable, const Colo
 	env->fog_color = p_color;
 	env->fog_sun_color = p_sun_color;
 	env->fog_sun_amount = p_sun_amount;
+	env->fog_exponential_enabled = p_exponential_enable;
+	env->fog_exponential_density = p_fog_exponential_density;
 }
 
 void RasterizerSceneRD::environment_set_fog_depth(RID p_env, bool p_enable, float p_depth_begin, float p_depth_end, float p_depth_curve, bool p_transmit, float p_transmit_curve) {
@@ -667,6 +669,18 @@ float RasterizerSceneRD::environment_get_fog_sun_amount(RID p_env) const {
 	Environent *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND_V(!env, false);
 	return env->fog_sun_amount;
+}
+
+bool RasterizerSceneRD::environment_get_fog_exponential_enabled(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_exponential_enabled;
+}
+
+float RasterizerSceneRD::environment_get_fog_exponential_density(RID p_env) const {
+	Environent *env = environment_owner.getornull(p_env);
+	ERR_FAIL_COND_V(!env, false);
+	return env->fog_exponential_density;
 }
 
 void RasterizerSceneRD::environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, VS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale) {

--- a/servers/visual/rasterizer_rd/rasterizer_scene_rd.h
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_rd.h
@@ -513,6 +513,24 @@ private:
 		float ssao_ao_channel_affect = 0.0;
 		float ssao_blur_edge_sharpness = 4.0;
 		VS::EnvironmentSSAOBlur ssao_blur = VS::ENV_SSAO_BLUR_3x3;
+
+		/// Fog
+
+		bool fog_enabled = false;
+		Color fog_color = Color(0.5, 0.5, 0.5);
+		Color fog_sun_color = Color(0.8, 0.8, 0.0);
+		float fog_sun_amount = 0;
+
+		bool fog_depth_enabled = true;
+		float fog_depth_begin = 10;
+		float fog_depth_end = 0;
+		float fog_depth_curve = 1;
+		bool fog_transmit_enabled = true;
+		float fog_transmit_curve = 1;
+		bool fog_height_enabled = false;
+		float fog_height_min = 10;
+		float fog_height_max = 0;
+		float fog_height_curve = 1;
 	};
 
 	VS::EnvironmentSSAOQuality ssao_quality = VS::ENV_SSAO_QUALITY_MEDIUM;
@@ -697,9 +715,23 @@ public:
 	void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale);
 	void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, RID p_ramp) {}
 
-	void environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount) {}
-	void environment_set_fog_depth(RID p_env, bool p_enable, float p_depth_begin, float p_depth_end, float p_depth_curve, bool p_transmit, float p_transmit_curve) {}
-	void environment_set_fog_height(RID p_env, bool p_enable, float p_min_height, float p_max_height, float p_height_curve) {}
+	void environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount);
+	void environment_set_fog_depth(RID p_env, bool p_enable, float p_depth_begin, float p_depth_end, float p_depth_curve, bool p_transmit, float p_transmit_curve);
+	void environment_set_fog_height(RID p_env, bool p_enable, float p_min_height, float p_max_height, float p_height_curve);
+	bool environment_get_fog_enabled(RID p_env) const;
+	bool environment_get_fog_depth_enabled(RID p_env) const;
+	bool environment_get_fog_height_enabled(RID p_env) const;
+	float environment_get_fog_depth_end(RID p_env) const;
+	Color environment_get_fog_color(RID p_env) const;
+	Color environment_get_fog_sun_color(RID p_env) const;
+	bool environment_get_fog_transmit_enabled(RID p_env) const;
+	float environment_get_fog_transmit_curve(RID p_env) const;
+	float environment_get_fog_depth_begin(RID p_env) const;
+	float environment_get_fog_depth_curve(RID p_env) const;
+	float environment_get_fog_height_min(RID p_env) const;
+	float environment_get_fog_height_max(RID p_env) const;
+	float environment_get_fog_height_curve(RID p_env) const;
+	float environment_get_fog_sun_amount(RID p_env) const;
 
 	virtual RID camera_effects_create();
 

--- a/servers/visual/rasterizer_rd/rasterizer_scene_rd.h
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_rd.h
@@ -531,6 +531,8 @@ private:
 		float fog_height_min = 10;
 		float fog_height_max = 0;
 		float fog_height_curve = 1;
+		bool fog_exponential_enabled = true;
+		float fog_exponential_density = 0.01;
 	};
 
 	VS::EnvironmentSSAOQuality ssao_quality = VS::ENV_SSAO_QUALITY_MEDIUM;
@@ -715,7 +717,7 @@ public:
 	void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale);
 	void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, RID p_ramp) {}
 
-	void environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount);
+	void environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount, bool p_exponential_enable, float p_fog_exponential_density);
 	void environment_set_fog_depth(RID p_env, bool p_enable, float p_depth_begin, float p_depth_end, float p_depth_curve, bool p_transmit, float p_transmit_curve);
 	void environment_set_fog_height(RID p_env, bool p_enable, float p_min_height, float p_max_height, float p_height_curve);
 	bool environment_get_fog_enabled(RID p_env) const;
@@ -732,6 +734,8 @@ public:
 	float environment_get_fog_height_max(RID p_env) const;
 	float environment_get_fog_height_curve(RID p_env) const;
 	float environment_get_fog_sun_amount(RID p_env) const;
+	bool environment_get_fog_exponential_enabled(RID p_env) const;
+	float environment_get_fog_exponential_density(RID p_env) const;
 
 	virtual RID camera_effects_create();
 

--- a/servers/visual/rasterizer_rd/shaders/scene_high_end_inc.glsl
+++ b/servers/visual/rasterizer_rd/shaders/scene_high_end_inc.glsl
@@ -72,9 +72,6 @@ layout(set = 0, binding = 3, std140) uniform SceneData {
 	vec4 ambient_light_color;
 	vec4 bg_color;
 
-	vec4 fog_color_enabled;
-	vec4 fog_sun_color_amount;
-
 	float ambient_energy;
 	float bg_energy;
 #endif
@@ -83,12 +80,14 @@ layout(set = 0, binding = 3, std140) uniform SceneData {
 	vec2 shadow_atlas_pixel_size;
 	vec2 directional_shadow_pixel_size;
 
-	float z_far;
-
 	float subsurface_scatter_width;
 	float ambient_occlusion_affect_light;
 	float ambient_occlusion_affect_ao_channel;
 	float opaque_prepass_threshold;
+#endif
+
+	vec4 fog_color_enabled;
+	vec4 fog_sun_color_amount;
 
 	bool fog_depth_enabled;
 	float fog_depth_begin;
@@ -101,7 +100,6 @@ layout(set = 0, binding = 3, std140) uniform SceneData {
 	float fog_height_min;
 	float fog_height_max;
 	float fog_height_curve;
-#endif
 }
 scene_data;
 

--- a/servers/visual/rasterizer_rd/shaders/scene_high_end_inc.glsl
+++ b/servers/visual/rasterizer_rd/shaders/scene_high_end_inc.glsl
@@ -100,6 +100,8 @@ layout(set = 0, binding = 3, std140) uniform SceneData {
 	float fog_height_min;
 	float fog_height_max;
 	float fog_height_curve;
+	bool fog_exponential_enabled;
+	float fog_exponential_density;
 }
 scene_data;
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -534,7 +534,7 @@ public:
 
 	BIND6(environment_set_adjustment, RID, bool, float, float, float, RID)
 
-	BIND5(environment_set_fog, RID, bool, const Color &, const Color &, float)
+	BIND7(environment_set_fog, RID, bool, const Color &, const Color &, float, bool, float)
 	BIND7(environment_set_fog_depth, RID, bool, float, float, float, bool, float)
 	BIND5(environment_set_fog_height, RID, bool, float, float, float)
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -449,7 +449,7 @@ public:
 
 	FUNC6(environment_set_adjustment, RID, bool, float, float, float, RID)
 
-	FUNC5(environment_set_fog, RID, bool, const Color &, const Color &, float)
+	FUNC7(environment_set_fog, RID, bool, const Color &, const Color &, float, bool, float)
 	FUNC7(environment_set_fog_depth, RID, bool, float, float, float, bool, float)
 	FUNC5(environment_set_fog_height, RID, bool, float, float, float)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1806,7 +1806,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_set_adjustment", "env", "enable", "brightness", "contrast", "saturation", "ramp"), &VisualServer::environment_set_adjustment);
 	ClassDB::bind_method(D_METHOD("environment_set_ssr", "env", "enable", "max_steps", "fade_in", "fade_out", "depth_tolerance", "roughness"), &VisualServer::environment_set_ssr);
 	ClassDB::bind_method(D_METHOD("environment_set_ssao", "env", "enable", "radius", "intensity", "bias", "light_affect", "ao_channel_affect", "blur", "bilateral_sharpness"), &VisualServer::environment_set_ssao);
-	ClassDB::bind_method(D_METHOD("environment_set_fog", "env", "enable", "color", "sun_color", "sun_amount"), &VisualServer::environment_set_fog);
+	ClassDB::bind_method(D_METHOD("environment_set_fog", "env", "enable", "color", "sun_color", "sun_amount", "exponential_enable", "exponential_density"), &VisualServer::environment_set_fog);
 
 	ClassDB::bind_method(D_METHOD("environment_set_fog_depth", "env", "enable", "depth_begin", "depth_end", "depth_curve", "transmit", "transmit_curve"), &VisualServer::environment_set_fog_depth);
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -763,7 +763,7 @@ public:
 
 	virtual void environment_set_ssao_quality(EnvironmentSSAOQuality p_quality, bool p_half_size) = 0;
 
-	virtual void environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount) = 0;
+	virtual void environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount, bool p_exponential_enable, float p_exponential_density) = 0;
 	virtual void environment_set_fog_depth(RID p_env, bool p_enable, float p_depth_begin, float p_depth_end, float p_depth_curve, bool p_transmit, float p_transmit_curve) = 0;
 	virtual void environment_set_fog_height(RID p_env, bool p_enable, float p_min_height, float p_max_height, float p_height_curve) = 0;
 


### PR DESCRIPTION
Shader code was taken from GLES3 implementation and 3.2 branch.
The sun direction is now the direction of the first directional light (if there's any).

The commit Introduces a new parameter, exponential fog density, which allows a default for exponential fog while preserving fog's alpha color channel to specify fog density.
The commit also adds missing hide_prefixes[] for height and depth fog properties.

Exponential fog is enabled by default.

Fixes #36654.
Fixes #24596.

EDIT: Last push should fix CI build. 