### PR TITLE
Use RGBA notation for HTML color codes instead of ARGB

### DIFF
--- a/core/color.cpp
+++ b/core/color.cpp
@@ -311,6 +311,7 @@ Color Color::html(const String &p_color) {
 		color = color.substr(1, color.length() - 1);
 	}
 	if (color.length() == 3 || color.length() == 4) {
+		// Color code is a short form like `#1234`, convert it to `#11223344`.
 		String exp_color;
 		for (int i = 0; i < color.length(); i++) {
 			exp_color += color[i];
@@ -329,20 +330,18 @@ Color Color::html(const String &p_color) {
 		ERR_FAIL_V_MSG(Color(), "Invalid color code: " + p_color + ".");
 	}
 
+	int r = _parse_col(color, 0);
+	ERR_FAIL_COND_V_MSG(r < 0, Color(), "Invalid color code: " + p_color + ".");
+	int g = _parse_col(color, 2);
+	ERR_FAIL_COND_V_MSG(g < 0, Color(), "Invalid color code: " + p_color + ".");
+	int b = _parse_col(color, 4);
+	ERR_FAIL_COND_V_MSG(b < 0, Color(), "Invalid color code: " + p_color + ".");
+
 	int a = 255;
 	if (alpha) {
-		a = _parse_col(color, 0);
+		a = _parse_col(color, 6);
 		ERR_FAIL_COND_V_MSG(a < 0, Color(), "Invalid color code: " + p_color + ".");
 	}
-
-	int from = alpha ? 2 : 0;
-
-	int r = _parse_col(color, from + 0);
-	ERR_FAIL_COND_V_MSG(r < 0, Color(), "Invalid color code: " + p_color + ".");
-	int g = _parse_col(color, from + 2);
-	ERR_FAIL_COND_V_MSG(g < 0, Color(), "Invalid color code: " + p_color + ".");
-	int b = _parse_col(color, from + 4);
-	ERR_FAIL_COND_V_MSG(b < 0, Color(), "Invalid color code: " + p_color + ".");
 
 	return Color(r / 255.0, g / 255.0, b / 255.0, a / 255.0);
 }
@@ -367,26 +366,23 @@ bool Color::html_is_valid(const String &p_color) {
 		return false;
 	}
 
-	if (alpha) {
-		int a = _parse_col(color, 0);
-		if (a < 0) {
-			return false;
-		}
-	}
-
-	int from = alpha ? 2 : 0;
-
-	int r = _parse_col(color, from + 0);
+	int r = _parse_col(color, 0);
 	if (r < 0) {
 		return false;
 	}
-	int g = _parse_col(color, from + 2);
+	int g = _parse_col(color, 2);
 	if (g < 0) {
 		return false;
 	}
-	int b = _parse_col(color, from + 4);
+	int b = _parse_col(color, 4);
 	if (b < 0) {
 		return false;
+	}
+	if (alpha) {
+		int a = _parse_col(color, 6);
+		if (a < 0) {
+			return false;
+		}
 	}
 
 	return true;
@@ -433,13 +429,11 @@ String _to_hex(float p_val) {
 }
 
 String Color::to_html(bool p_alpha) const {
-	String txt;
-	txt += _to_hex(r);
-	txt += _to_hex(g);
-	txt += _to_hex(b);
+	String txt = _to_hex(r) + _to_hex(g) + _to_hex(b);
 	if (p_alpha) {
-		txt = _to_hex(a) + txt;
+		txt += _to_hex(a);
 	}
+
 	return txt;
 }
 

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Color" version="4.0">
 	<brief_description>
-		Color in RGBA format with some support for ARGB format.
+		Color in RGBA format with some support for HSV, ARGB and ABGR formats.
 	</brief_description>
 	<description>
 		A color is represented by red, green, and blue [code](r, g, b)[/code] components. Additionally, [code]a[/code] represents the alpha component, often used for transparency. Values are in floating-point and usually range from 0 to 1. Some properties (such as [member CanvasItem.modulate]) may accept values greater than 1.
@@ -17,11 +17,11 @@
 			<argument index="0" name="from" type="String">
 			</argument>
 			<description>
-				Constructs a color from an HTML hexadecimal color string in ARGB or RGB format. See also [method @GDScript.ColorN].
+				Constructs a color from an HTML hexadecimal color string in RGB or RGBA format. The leading [code]#[/code] symbol is optional. See also [method @GDScript.ColorN].
 				[codeblock]
 				# Each of the following creates the same color RGBA(178, 217, 10, 255).
-				var c1 = Color("#ffb2d90a") # ARGB format with "#".
-				var c2 = Color("ffb2d90a") # ARGB format.
+				var c1 = Color("#b2d90aff") # RGBA format with "#".
+				var c2 = Color("b2d90aff") # RGBA format.
 				var c3 = Color("#b2d90a") # RGB format with "#".
 				var c4 = Color("b2d90a") # RGB format.
 				[/codeblock]
@@ -242,11 +242,11 @@
 			<argument index="0" name="with_alpha" type="bool" default="true">
 			</argument>
 			<description>
-				Returns the color's HTML hexadecimal color string in ARGB format (ex: [code]ff34f822[/code]).
-				Setting [code]with_alpha[/code] to [code]false[/code] excludes alpha from the hexadecimal string.
+				Returns the color's HTML hexadecimal color string in RGBA format (ex: [code]ff34f822[/code]). No leading [code]#[/code] is added, so you will have to prepend it yourself if you need one.
+				If [code]with_alpha[/code] is [code]false[/code], the alpha component will be excluded from the hexadecimal string.
 				[codeblock]
 				var c = Color(1, 1, 1, 0.5)
-				var s1 = c.to_html() # Returns "7fffffff"
+				var s1 = c.to_html() # Returns "ffffff80"
 				var s2 = c.to_html(false) # Returns "ffffff"
 				[/codeblock]
 			</description>


### PR DESCRIPTION
This follows the now widely-supported CSS standard: https://drafts.csswg.org/css-color/#hex-notation

Another upside is that text editors like Visual Studio Code will now highlight the color as expected:

![image](https://user-images.githubusercontent.com/180032/76462111-6a463980-63e1-11ea-9992-1c917dadad5d.png)

Existing HTML color codes with alpha will have to be changed (e.g. in text editor themes and RichTextLabel BBCodes), so this is a breaking change.