### PR TITLE
Cache Object Icons

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -899,17 +899,11 @@ String EditorData::script_class_get_icon_path(const String &p_class) const {
 		return String();
 	}
 
-	String current = p_class;
-	String ret = _script_class_icon_paths[current];
-	while (ret.empty()) {
-		current = script_class_get_base(current);
-		if (!ScriptServer::is_global_class(current)) {
-			return String();
-		}
-		ret = _script_class_icon_paths.has(current) ? _script_class_icon_paths[current] : String();
+	if (_script_class_icon_paths.has(p_class)) {
+		return _script_class_icon_paths[p_class];
 	}
 
-	return ret;
+	return script_class_get_icon_path(script_class_get_base(p_class));
 }
 
 StringName EditorData::script_class_get_name(const String &p_path) const {
@@ -950,8 +944,8 @@ void EditorData::script_class_load_icon_paths() {
 		d.get_key_list(&keys);
 
 		for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-			String name = E->get().operator String();
-			_script_class_icon_paths[name] = d[name];
+			String name = (String)E->get();
+			_script_class_icon_paths[name] = d.has(name) ? String(d[name]) : String();
 
 			String path = ScriptServer::get_global_class_path(name);
 			script_class_set_name(path, name);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -642,7 +642,7 @@ private:
 
 	void _feature_profile_changed();
 	bool _is_class_editor_disabled_by_feature_profile(const StringName &p_class);
-	Ref<ImageTexture> _load_custom_class_icon(const String &p_path) const;
+	Ref<ImageTexture> _load_custom_class_icon(const String &p_path);
 
 protected:
 	void _notification(int p_what);
@@ -773,8 +773,8 @@ public:
 	Ref<Theme> get_editor_theme() const { return theme; }
 	Ref<Script> get_object_custom_type_base(const Object *p_object) const;
 	StringName get_object_custom_type_name(const Object *p_object) const;
-	Ref<Texture2D> get_object_icon(const Object *p_object, const String &p_fallback = "Object") const;
-	Ref<Texture2D> get_class_icon(const String &p_class, const String &p_fallback = "Object") const;
+	Ref<Texture2D> get_object_icon(const Object *p_object, const String &p_fallback = "Object");
+	Ref<Texture2D> get_class_icon(const String &p_class, const String &p_fallback = "Object");
 
 	void show_accept(const String &p_text, const String &p_title);
 	void show_warning(const String &p_text, const String &p_title = TTR("Warning!"));


### PR DESCRIPTION
Draft: Wait for https://github.com/godotengine/godot/issues/44501 to be fixed.

---

Fixes #36981

Edit: This probably shouldn't be merged yet ~~since the cache will not update if the image data is changed. But if the path changes it will work fine.~~
The cache now works properly but it requires the icon is imported as Image which could be annoying.