### PR TITLE
Fix an issue which may cause XCreateWindow fails

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -143,7 +143,7 @@ private:
 			install_status_rect->set_texture(new_icon);
 		}
 
-		set_size(Size2(500, 0) * EDSCALE);
+		set_size(Size2i(500, 500) * EDSCALE);
 	}
 
 	String _test_path() {
@@ -788,7 +788,7 @@ public:
 			_test_path();
 		}
 
-		popup_centered(Size2(500, 0) * EDSCALE);
+		popup_centered(Size2i(500, 500) * EDSCALE);
 	}
 
 	ProjectDialog() {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -831,7 +831,7 @@ void Window::popup_centered(const Size2 &p_minsize) {
 	}
 
 	Rect2 popup_rect;
-	if (p_minsize == Size2()) {
+	if (p_minsize.width <= UNIT_EPSILON || p_minsize.height <= UNIT_EPSILON) {
 		popup_rect.size = _get_contents_minimum_size();
 	} else {
 		popup_rect.size = p_minsize;


### PR DESCRIPTION
Hi, I just found a tiny issue when using the branch **display-server**.
It seems that 
at _scene/main/window.cpp:834_,
`	if (p_minsize == Size2()) {`
 you want to determine whether a rectangle size is zero by just comparing with `Size2()`.
That must be a mistake. And due to this issue, the following `XCreateWIndow` will have changes to receive a wrong argument, then a **BadValue** error will be emitted after.
Besides this, I found another 2 related problems on passing argument of window size and `Size2(500, 0) ` is certain not a valid window size.