### PR TITLE
Fix: identical tab names set to its path

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -576,6 +576,10 @@ private:
 	void _thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
 	void _scene_tab_script_edited(int p_tab);
 
+public:
+	static void resolve_identical_tab_path(String &p_title1, const String &p_path1, String &p_title2, const String &p_path2, int p_level = 0);
+
+private:
 	Dictionary _get_main_scene_state();
 	void _set_main_scene_state(Dictionary p_state, Node *p_for_scene);
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1792,6 +1792,13 @@ void ScriptEditor::_update_script_names() {
 				name = se->get_name();
 			}
 
+			if (!built_in) {
+				for (int j = 0; j < sedata.size(); j++) {
+					_ScriptEditorItemData *sd_i = const_cast<_ScriptEditorItemData *>(&sedata[j]);
+					EditorNode::resolve_identical_tab_path(name, path, sd_i->name, sd_i->tooltip);
+				}
+			}
+
 			_ScriptEditorItemData sd;
 			sd.icon = icon;
 			sd.name = name;


### PR DESCRIPTION
Fix: #20029

![identical paths](https://user-images.githubusercontent.com/41085900/76550156-a946be80-64b7-11ea-963d-7ed051e42c1d.JPG)

EDIT:
https://github.com/godotengine/godot/pull/20930#issuecomment-412315763
![tab-name-levels](https://user-images.githubusercontent.com/41085900/76565381-752bc780-64d0-11ea-92f6-ce50ca3c346d.JPG)
