### PR TITLE
Tweak the built-in script naming for resources with custom names

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1783,9 +1783,11 @@ void ScriptEditor::_update_script_names() {
 			if (built_in) {
 
 				name = path.get_file();
-				String resource_name = se->get_edited_resource()->get_name();
+				const String &resource_name = se->get_edited_resource()->get_name();
 				if (resource_name != "") {
-					name = name.substr(0, name.find("::", 0) + 2) + resource_name;
+					// If the built-in script has a custom resource name defined,
+					// display the built-in script name as follows: `ResourceName (scene_file.tscn)`
+					name = vformat("%s (%s)", resource_name, name.substr(0, name.find("::", 0)));
 				}
 			} else {
 


### PR DESCRIPTION
This makes the script name appear before the scene file name, which ensures it's always visible even if the list of scripts is too narrow to display the full name.

This only impacts built-in scripts with custom resource names. Unnamed resources will still use `<scene_file>::<id>` naming in the list of scripts.

This closes https://github.com/godotengine/godot-proposals/issues/524.

## Preview

![image](https://user-images.githubusercontent.com/180032/76564884-bfe61900-64a9-11ea-83ca-4306d84abdc8.png)

@KoBeWi Should we also apply this change to unnamed resources? It might look a bit strange, I don't know.