### PR TITLE
Improve error message for ViewportTexture.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -67,7 +67,7 @@ void ViewportTexture::setup_local_to_scene() {
 	}
 
 	Node *vpn = local_scene->get_node(path);
-	ERR_FAIL_COND_MSG(!vpn, "ViewportTexture: Path to node is invalid. If the path seems valid, move the node using the texture after the viewport.");
+	ERR_FAIL_COND_MSG(!vpn, "ViewportTexture: Path to node is invalid. If the path seems valid, move the node using the ViewportTexture so that it is placed after the Viewport in the scene tree.");
 
 	vp = Object::cast_to<Viewport>(vpn);
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -67,7 +67,7 @@ void ViewportTexture::setup_local_to_scene() {
 	}
 
 	Node *vpn = local_scene->get_node(path);
-	ERR_FAIL_COND_MSG(!vpn, "ViewportTexture: Path to node is invalid.");
+	ERR_FAIL_COND_MSG(!vpn, "ViewportTexture: Path to node is invalid. If the path seems valid, move the node using the texture after the viewport.");
 
 	vp = Object::cast_to<Viewport>(vpn);
 


### PR DESCRIPTION
The "ViewportTexture: Path to node is invalid" error can sometimes be
fixed just by ordering the viewport before the node using the texture.

Relates to #27790.