### PR TITLE
Allowing SpinBox & LineEdit contents to be selected while grabbing focus

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -108,6 +108,8 @@ public:
 		grid_offset_x->set_allow_greater(true);
 		grid_offset_x->set_suffix("px");
 		grid_offset_x->set_h_size_flags(SIZE_EXPAND_FILL);
+		grid_offset_x->set_select_all_on_focus(true);
+		grid_offset_x->set_focus_mode(FOCUS_ALL);
 		child_container->add_child(grid_offset_x);
 
 		grid_offset_y = memnew(SpinBox);
@@ -117,6 +119,8 @@ public:
 		grid_offset_y->set_allow_greater(true);
 		grid_offset_y->set_suffix("px");
 		grid_offset_y->set_h_size_flags(SIZE_EXPAND_FILL);
+		grid_offset_y->set_select_all_on_focus(true);
+		grid_offset_y->set_focus_mode(FOCUS_ALL);
 		child_container->add_child(grid_offset_y);
 
 		label = memnew(Label);
@@ -130,6 +134,8 @@ public:
 		grid_step_x->set_allow_greater(true);
 		grid_step_x->set_suffix("px");
 		grid_step_x->set_h_size_flags(SIZE_EXPAND_FILL);
+		grid_step_x->set_select_all_on_focus(true);
+		grid_step_x->set_focus_mode(FOCUS_ALL);
 		child_container->add_child(grid_step_x);
 
 		grid_step_y = memnew(SpinBox);
@@ -138,6 +144,8 @@ public:
 		grid_step_y->set_allow_greater(true);
 		grid_step_y->set_suffix("px");
 		grid_step_y->set_h_size_flags(SIZE_EXPAND_FILL);
+		grid_step_y->set_select_all_on_focus(true);
+		grid_step_y->set_focus_mode(FOCUS_ALL);
 		child_container->add_child(grid_step_y);
 
 		child_container = memnew(GridContainer);
@@ -156,6 +164,8 @@ public:
 		primary_grid_steps->set_allow_greater(true);
 		primary_grid_steps->set_suffix(TTR("steps"));
 		primary_grid_steps->set_h_size_flags(SIZE_EXPAND_FILL);
+		primary_grid_steps->set_select_all_on_focus(true);
+		primary_grid_steps->set_focus_mode(FOCUS_ALL);
 		child_container->add_child(primary_grid_steps);
 
 		container->add_child(memnew(HSeparator));
@@ -176,6 +186,8 @@ public:
 		rotation_offset->set_max(SPIN_BOX_ROTATION_RANGE);
 		rotation_offset->set_suffix("deg");
 		rotation_offset->set_h_size_flags(SIZE_EXPAND_FILL);
+		rotation_offset->set_select_all_on_focus(true);
+		rotation_offset->set_focus_mode(FOCUS_ALL);
 		child_container->add_child(rotation_offset);
 
 		label = memnew(Label);
@@ -188,6 +200,8 @@ public:
 		rotation_step->set_max(SPIN_BOX_ROTATION_RANGE);
 		rotation_step->set_suffix("deg");
 		rotation_step->set_h_size_flags(SIZE_EXPAND_FILL);
+		rotation_step->set_select_all_on_focus(true);
+		rotation_step->set_focus_mode(FOCUS_ALL);
 		child_container->add_child(rotation_step);
 
 		container->add_child(memnew(HSeparator));
@@ -206,6 +220,8 @@ public:
 		scale_step->set_allow_greater(true);
 		scale_step->set_h_size_flags(SIZE_EXPAND_FILL);
 		scale_step->set_step(0.01f);
+		scale_step->set_select_all_on_focus(true);
+		scale_step->set_focus_mode(FOCUS_ALL);
 		child_container->add_child(scale_step);
 	}
 

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -6203,12 +6203,15 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	snap_dialog->add_child(snap_dialog_vbc);
 
 	snap_translate = memnew(LineEdit);
+	snap_translate->set_select_all_on_focus(true);
 	snap_dialog_vbc->add_margin_child(TTR("Translate Snap:"), snap_translate);
 
 	snap_rotate = memnew(LineEdit);
+	snap_rotate->set_select_all_on_focus(true);
 	snap_dialog_vbc->add_margin_child(TTR("Rotate Snap (deg.):"), snap_rotate);
 
 	snap_scale = memnew(LineEdit);
+	snap_scale->set_select_all_on_focus(true);
 	snap_dialog_vbc->add_margin_child(TTR("Scale Snap (%):"), snap_scale);
 
 	_snap_update();
@@ -6227,6 +6230,8 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	settings_fov->set_min(MIN_FOV);
 	settings_fov->set_step(0.01);
 	settings_fov->set_value(EDITOR_DEF("editors/3d/default_fov", 70.0));
+	settings_fov->set_select_all_on_focus(true);
+	settings_fov->set_focus_mode(FOCUS_ALL);
 	settings_vbc->add_margin_child(TTR("Perspective FOV (deg.):"), settings_fov);
 
 	settings_znear = memnew(SpinBox);
@@ -6234,6 +6239,8 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	settings_znear->set_min(MIN_Z);
 	settings_znear->set_step(0.01);
 	settings_znear->set_value(EDITOR_DEF("editors/3d/default_z_near", 0.05));
+	settings_znear->set_select_all_on_focus(true);
+	settings_znear->set_focus_mode(FOCUS_ALL);
 	settings_vbc->add_margin_child(TTR("View Z-Near:"), settings_znear);
 
 	settings_zfar = memnew(SpinBox);
@@ -6241,6 +6248,8 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	settings_zfar->set_min(MIN_Z);
 	settings_zfar->set_step(0.01);
 	settings_zfar->set_value(EDITOR_DEF("editors/3d/default_z_far", 1500));
+	settings_zfar->set_select_all_on_focus(true);
+	settings_zfar->set_focus_mode(FOCUS_ALL);
 	settings_vbc->add_margin_child(TTR("View Z-Far:"), settings_zfar);
 
 	/* XFORM DIALOG */
@@ -6262,6 +6271,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	for (int i = 0; i < 3; i++) {
 
 		xform_translate[i] = memnew(LineEdit);
+		xform_translate[i]->set_select_all_on_focus(true);
 		xform_translate[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		xform_hbc->add_child(xform_translate[i]);
 	}
@@ -6275,6 +6285,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 
 	for (int i = 0; i < 3; i++) {
 		xform_rotate[i] = memnew(LineEdit);
+		xform_rotate[i]->set_select_all_on_focus(true);
 		xform_rotate[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		xform_hbc->add_child(xform_rotate[i]);
 	}
@@ -6288,6 +6299,7 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 
 	for (int i = 0; i < 3; i++) {
 		xform_scale[i] = memnew(LineEdit);
+		xform_scale[i]->set_select_all_on_focus(true);
 		xform_scale[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		xform_hbc->add_child(xform_scale[i]);
 	}

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -934,6 +934,9 @@ void LineEdit::_notification(int p_what) {
 			if (OS::get_singleton()->has_virtual_keyboard())
 				OS::get_singleton()->show_virtual_keyboard(text, get_global_rect(), max_length);
 
+			if (select_all_on_focus) {
+				select_all();
+			}
 		} break;
 		case NOTIFICATION_FOCUS_EXIT: {
 
@@ -949,6 +952,9 @@ void LineEdit::_notification(int p_what) {
 			if (OS::get_singleton()->has_virtual_keyboard())
 				OS::get_singleton()->hide_virtual_keyboard();
 
+			if (select_all_on_focus) {
+				deselect();
+			}
 		} break;
 		case MainLoop::NOTIFICATION_OS_IME_UPDATE: {
 
@@ -1441,6 +1447,16 @@ void LineEdit::deselect() {
 	update();
 }
 
+void LineEdit::set_select_all_on_focus(bool p_select) {
+
+	select_all_on_focus = p_select;
+}
+
+bool LineEdit::is_select_all_on_focus() const {
+
+	return select_all_on_focus;
+}
+
 void LineEdit::selection_delete() {
 
 	if (selection.enabled)
@@ -1877,6 +1893,7 @@ LineEdit::LineEdit() {
 	clear_button_status.pressing_inside = false;
 	shortcut_keys_enabled = true;
 	selecting_enabled = true;
+	select_all_on_focus = false;
 
 	deselect();
 	set_focus_mode(FOCUS_ALL);

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -76,6 +76,7 @@ private:
 	Point2 ime_selection;
 
 	bool selecting_enabled;
+	bool select_all_on_focus;
 
 	bool context_menu_enabled;
 	PopupMenu *menu;
@@ -181,6 +182,9 @@ public:
 	void select_all();
 	void selection_delete();
 	void deselect();
+
+	void set_select_all_on_focus(bool p_select);
+	bool is_select_all_on_focus() const;
 
 	void delete_char();
 	void delete_text(int p_from_column, int p_to_column);

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -204,9 +204,13 @@ void SpinBox::_notification(int p_what) {
 
 		updown->draw(ci, Point2i(size.width - updown->get_width(), (size.height - updown->get_height()) / 2));
 
-	} else if (p_what == NOTIFICATION_FOCUS_EXIT) {
+	} else if (p_what == NOTIFICATION_FOCUS_ENTER) {
 
-		//_value_changed(0);
+		if (select_all_on_focus) {
+			line_edit->select_all();
+		}
+
+		line_edit->grab_focus();
 	} else if (p_what == NOTIFICATION_ENTER_TREE) {
 
 		_adjust_width_for_icon(get_icon("updown"));
@@ -248,6 +252,16 @@ void SpinBox::set_prefix(const String &p_prefix) {
 String SpinBox::get_prefix() const {
 
 	return prefix;
+}
+
+void SpinBox::set_select_all_on_focus(bool p_select) {
+
+	select_all_on_focus = p_select;
+}
+
+bool SpinBox::is_select_all_on_focus() const {
+
+	return select_all_on_focus;
 }
 
 void SpinBox::set_editable(bool p_editable) {
@@ -301,4 +315,6 @@ SpinBox::SpinBox() {
 	range_click_timer = memnew(Timer);
 	range_click_timer->connect("timeout", callable_mp(this, &SpinBox::_range_click_timeout));
 	add_child(range_click_timer);
+
+	select_all_on_focus = false;
 }

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -50,6 +50,8 @@ class SpinBox : public Range {
 	String prefix;
 	String suffix;
 
+	bool select_all_on_focus;
+
 	void _line_edit_input(const Ref<InputEvent> &p_event);
 
 	struct Drag {
@@ -87,6 +89,9 @@ public:
 
 	void set_prefix(const String &p_prefix);
 	String get_prefix() const;
+
+	void set_select_all_on_focus(bool p_select);
+	bool is_select_all_on_focus() const;
 
 	void apply();
 


### PR DESCRIPTION
I took an opportunity to modify and unify how not only Snap Settings behave (original issue) but - others utility popups accessible from 2D and 3D views submenus as well.

The change is non-intrusive for the Controls itself - it doesn't affect how SpinBox and LineEdit works out-of-the-box - there needs to be intention of enabling functionality of 'selecting content'.

Or - actually - if that behaviour is how the controls should work normally - I can enable 'selecting content' while changing focus on them as a default.

Fixes: #37011