### PR TITLE
Allow using integer vectors for iteration and make range() use them

### DIFF
--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -3458,8 +3458,8 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 			return _data._float > 0.0;
 		} break;
 		case VECTOR2: {
-			int64_t from = reinterpret_cast<const Vector2 *>(_data._mem)->x;
-			int64_t to = reinterpret_cast<const Vector2 *>(_data._mem)->y;
+			double from = reinterpret_cast<const Vector2 *>(_data._mem)->x;
+			double to = reinterpret_cast<const Vector2 *>(_data._mem)->y;
 
 			r_iter = from;
 
@@ -3474,9 +3474,9 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 			return from < to;
 		} break;
 		case VECTOR3: {
-			int64_t from = reinterpret_cast<const Vector3 *>(_data._mem)->x;
-			int64_t to = reinterpret_cast<const Vector3 *>(_data._mem)->y;
-			int64_t step = reinterpret_cast<const Vector3 *>(_data._mem)->z;
+			double from = reinterpret_cast<const Vector3 *>(_data._mem)->x;
+			double to = reinterpret_cast<const Vector3 *>(_data._mem)->y;
+			double step = reinterpret_cast<const Vector3 *>(_data._mem)->z;
 
 			r_iter = from;
 
@@ -3660,9 +3660,9 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case VECTOR2: {
-			int64_t to = reinterpret_cast<const Vector2 *>(_data._mem)->y;
+			double to = reinterpret_cast<const Vector2 *>(_data._mem)->y;
 
-			int64_t idx = r_iter;
+			double idx = r_iter;
 			idx++;
 
 			if (idx >= to)
@@ -3684,10 +3684,10 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case VECTOR3: {
-			int64_t to = reinterpret_cast<const Vector3 *>(_data._mem)->y;
-			int64_t step = reinterpret_cast<const Vector3 *>(_data._mem)->z;
+			double to = reinterpret_cast<const Vector3 *>(_data._mem)->y;
+			double step = reinterpret_cast<const Vector3 *>(_data._mem)->z;
 
-			int64_t idx = r_iter;
+			double idx = r_iter;
 			idx += step;
 
 			if (step < 0 && idx <= to)

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -78,38 +78,38 @@
 #define TYPE(PREFIX, OP, TYPE) &&PREFIX##_##OP##_##TYPE
 
 /* clang-format off */
-#define TYPES(PREFIX, OP) {                   \
-		TYPE(PREFIX, OP, NIL),                \
-		TYPE(PREFIX, OP, BOOL),               \
-		TYPE(PREFIX, OP, INT),                \
-		TYPE(PREFIX, OP, FLOAT),               \
-		TYPE(PREFIX, OP, STRING),             \
-		TYPE(PREFIX, OP, VECTOR2),            \
-		TYPE(PREFIX, OP, VECTOR2I),            \
-		TYPE(PREFIX, OP, RECT2),              \
-	TYPE(PREFIX, OP, RECT2I),              \
-		TYPE(PREFIX, OP, VECTOR3),            \
-	TYPE(PREFIX, OP, VECTOR3I),            \
-		TYPE(PREFIX, OP, TRANSFORM2D),        \
-		TYPE(PREFIX, OP, PLANE),              \
-		TYPE(PREFIX, OP, QUAT),               \
-		TYPE(PREFIX, OP, AABB),              \
-		TYPE(PREFIX, OP, BASIS),              \
-		TYPE(PREFIX, OP, TRANSFORM),          \
-		TYPE(PREFIX, OP, COLOR),              \
+#define TYPES(PREFIX, OP) {                     \
+		TYPE(PREFIX, OP, NIL),                  \
+		TYPE(PREFIX, OP, BOOL),                 \
+		TYPE(PREFIX, OP, INT),                  \
+		TYPE(PREFIX, OP, FLOAT),                \
+		TYPE(PREFIX, OP, STRING),               \
+		TYPE(PREFIX, OP, VECTOR2),              \
+		TYPE(PREFIX, OP, VECTOR2I),             \
+		TYPE(PREFIX, OP, RECT2),                \
+		TYPE(PREFIX, OP, RECT2I),               \
+		TYPE(PREFIX, OP, VECTOR3),              \
+		TYPE(PREFIX, OP, VECTOR3I),             \
+		TYPE(PREFIX, OP, TRANSFORM2D),          \
+		TYPE(PREFIX, OP, PLANE),                \
+		TYPE(PREFIX, OP, QUAT),                 \
+		TYPE(PREFIX, OP, AABB),                 \
+		TYPE(PREFIX, OP, BASIS),                \
+		TYPE(PREFIX, OP, TRANSFORM),            \
+		TYPE(PREFIX, OP, COLOR),                \
 		TYPE(PREFIX, OP, STRING_NAME),          \
-		TYPE(PREFIX, OP, NODE_PATH),          \
-		TYPE(PREFIX, OP, _RID),               \
-		TYPE(PREFIX, OP, OBJECT),             \
+		TYPE(PREFIX, OP, NODE_PATH),            \
+		TYPE(PREFIX, OP, _RID),                 \
+		TYPE(PREFIX, OP, OBJECT),               \
 		TYPE(PREFIX, OP, CALLABLE),             \
-		TYPE(PREFIX, OP, SIGNAL),             \
-		TYPE(PREFIX, OP, DICTIONARY),         \
-		TYPE(PREFIX, OP, ARRAY),              \
+		TYPE(PREFIX, OP, SIGNAL),               \
+		TYPE(PREFIX, OP, DICTIONARY),           \
+		TYPE(PREFIX, OP, ARRAY),                \
 		TYPE(PREFIX, OP, PACKED_BYTE_ARRAY),    \
-		TYPE(PREFIX, OP, PACKED_INT32_ARRAY),     \
-		TYPE(PREFIX, OP, PACKED_INT64_ARRAY),     \
-		TYPE(PREFIX, OP, PACKED_FLOAT32_ARRAY),    \
-		TYPE(PREFIX, OP, PACKED_FLOAT64_ARRAY),    \
+		TYPE(PREFIX, OP, PACKED_INT32_ARRAY),   \
+		TYPE(PREFIX, OP, PACKED_INT64_ARRAY),   \
+		TYPE(PREFIX, OP, PACKED_FLOAT32_ARRAY), \
+		TYPE(PREFIX, OP, PACKED_FLOAT64_ARRAY), \
 		TYPE(PREFIX, OP, PACKED_STRING_ARRAY),  \
 		TYPE(PREFIX, OP, PACKED_VECTOR2_ARRAY), \
 		TYPE(PREFIX, OP, PACKED_VECTOR3_ARRAY), \
@@ -3465,6 +3465,14 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 
 			return from < to;
 		} break;
+		case VECTOR2I: {
+			int64_t from = reinterpret_cast<const Vector2i *>(_data._mem)->x;
+			int64_t to = reinterpret_cast<const Vector2i *>(_data._mem)->y;
+
+			r_iter = from;
+
+			return from < to;
+		} break;
 		case VECTOR3: {
 			int64_t from = reinterpret_cast<const Vector3 *>(_data._mem)->x;
 			int64_t to = reinterpret_cast<const Vector3 *>(_data._mem)->y;
@@ -3476,10 +3484,22 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 				return false;
 			} else if (from < to) {
 				return step > 0;
-			} else {
-				return step < 0;
 			}
-			//return true;
+			return step < 0;
+		} break;
+		case VECTOR3I: {
+			int64_t from = reinterpret_cast<const Vector3i *>(_data._mem)->x;
+			int64_t to = reinterpret_cast<const Vector3i *>(_data._mem)->y;
+			int64_t step = reinterpret_cast<const Vector3i *>(_data._mem)->z;
+
+			r_iter = from;
+
+			if (from == to) {
+				return false;
+			} else if (from < to) {
+				return step > 0;
+			}
+			return step < 0;
 		} break;
 		case OBJECT: {
 
@@ -3651,9 +3671,37 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 			r_iter = idx;
 			return true;
 		} break;
+		case VECTOR2I: {
+			int64_t to = reinterpret_cast<const Vector2i *>(_data._mem)->y;
+
+			int64_t idx = r_iter;
+			idx++;
+
+			if (idx >= to)
+				return false;
+
+			r_iter = idx;
+			return true;
+		} break;
 		case VECTOR3: {
 			int64_t to = reinterpret_cast<const Vector3 *>(_data._mem)->y;
 			int64_t step = reinterpret_cast<const Vector3 *>(_data._mem)->z;
+
+			int64_t idx = r_iter;
+			idx += step;
+
+			if (step < 0 && idx <= to)
+				return false;
+
+			if (step > 0 && idx >= to)
+				return false;
+
+			r_iter = idx;
+			return true;
+		} break;
+		case VECTOR3I: {
+			int64_t to = reinterpret_cast<const Vector3i *>(_data._mem)->y;
+			int64_t step = reinterpret_cast<const Vector3i *>(_data._mem)->z;
 
 			int64_t idx = r_iter;
 			idx += step;
@@ -3844,7 +3892,15 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 
 			return r_iter;
 		} break;
+		case VECTOR2I: {
+
+			return r_iter;
+		} break;
 		case VECTOR3: {
+
+			return r_iter;
+		} break;
+		case VECTOR3I: {
 
 			return r_iter;
 		} break;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -8784,7 +8784,7 @@ int GDScriptParser::get_completion_argument_index() {
 	return completion_argument;
 }
 
-int GDScriptParser::get_completion_identifier_is_function() {
+bool GDScriptParser::get_completion_identifier_is_function() {
 
 	return completion_ident_is_call;
 }

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3171,9 +3171,9 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 
 								ConstantNode *cn = alloc_node<ConstantNode>();
 								switch (args.size()) {
-									case 1: cn->value = (int)constants[0]; break;
-									case 2: cn->value = Vector2(constants[0], constants[1]); break;
-									case 3: cn->value = Vector3(constants[0], constants[1], constants[2]); break;
+									case 1: cn->value = (int64_t)constants[0]; break;
+									case 2: cn->value = Vector2i(constants[0], constants[1]); break;
+									case 3: cn->value = Vector3i(constants[0], constants[1], constants[2]); break;
 								}
 								cn->datatype = _type_from_variant(cn->value);
 								container = cn;
@@ -3186,8 +3186,8 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 
 								switch (args.size()) {
 									case 1: tn->vtype = Variant::INT; break;
-									case 2: tn->vtype = Variant::VECTOR2; break;
-									case 3: tn->vtype = Variant::VECTOR3; break;
+									case 2: tn->vtype = Variant::VECTOR2I; break;
+									case 3: tn->vtype = Variant::VECTOR3I; break;
 								}
 
 								for (int i = 0; i < args.size(); i++) {
@@ -7802,7 +7802,7 @@ void GDScriptParser::_check_class_level_types(ClassNode *p_class) {
 
 					ConstantNode *tgt_type = alloc_node<ConstantNode>();
 					tgt_type->line = v.line;
-					tgt_type->value = (int)v.data_type.builtin_type;
+					tgt_type->value = (int64_t)v.data_type.builtin_type;
 
 					OperatorNode *convert_call = alloc_node<OperatorNode>();
 					convert_call->line = v.line;
@@ -8179,7 +8179,7 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 
 							ConstantNode *tgt_type = alloc_node<ConstantNode>();
 							tgt_type->line = lv->line;
-							tgt_type->value = (int)lv->datatype.builtin_type;
+							tgt_type->value = (int64_t)lv->datatype.builtin_type;
 							tgt_type->datatype = _type_from_variant(tgt_type->value);
 
 							OperatorNode *convert_call = alloc_node<OperatorNode>();

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -683,7 +683,7 @@ public:
 	BlockNode *get_completion_block();
 	FunctionNode *get_completion_function();
 	int get_completion_argument_index();
-	int get_completion_identifier_is_function();
+	bool get_completion_identifier_is_function();
 
 	const List<String> &get_dependencies() const { return dependencies; }
 


### PR DESCRIPTION
This fixes #34121. Since it causes failures with large values, and because floats aren't ideal for integer iteration anyway, we don't want to optimize range's parameters into Vector2/Vector3. Instead, let's use Vector2i/Vector3i which have a larger range (and might perform better).

Using Vector2i/Vector3i still has a limit at 2^31, which is lower than what normal GDScript ints allow (2^63), but I tried removing the optimization entirely and it still fails at 2^31 anyway. If it's ever desired to go above 2^31, that can wait for later, and I don't think I'll be the one doing that.

Using Vector2i/Vector3i as iterators also means that we can directly use them instead of the word "range", which may be useful if you want to store a range in a variable.

Here's some test code:

```gdscript
	for i in Vector2(16777213, 16777221):
		print(i) # Fails at the last value because 16777221 becomes 16777220.
		# At least, this will fail as long as real_t is float, but it would work when real_t is double.
	print("====")
	for i in Vector2i(16777213, 16777221):
		print(i) # Works.
	print("====")
	for i in range(16777213, 16777221):
		print(i) # Works.
	print("====")
```

I also changed a function that returns a `bool` value so that its return type is also `bool`, used `int64_t` in a few places where the end result becomes `int64_t` anyway, and I did a little formatting in the beginning of `variant_op.cpp` because it wasn't aligned before and it was ugly.