### PR TITLE
Iterate backwards over EditorPlugin's list of plugins in get_editor etc

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -262,7 +262,9 @@ EditorHistory::EditorHistory() {
 }
 
 EditorPlugin *EditorData::get_editor(Object *p_object) {
-	for (int i = 0; i < editor_plugins.size(); i++) {
+	// We need to iterate backwards so that we can check user-created plugins first.
+	// Otherwise, it would not be possible for plugins to handle CanvasItem and Spatial nodes.
+	for (int i = editor_plugins.size() - 1; i > -1; i--) {
 		if (editor_plugins[i]->has_main_screen() && editor_plugins[i]->handles(p_object)) {
 			return editor_plugins[i];
 		}
@@ -272,7 +274,7 @@ EditorPlugin *EditorData::get_editor(Object *p_object) {
 }
 
 EditorPlugin *EditorData::get_subeditor(Object *p_object) {
-	for (int i = 0; i < editor_plugins.size(); i++) {
+	for (int i = editor_plugins.size() - 1; i > -1; i--) {
 		if (!editor_plugins[i]->has_main_screen() && editor_plugins[i]->handles(p_object)) {
 			return editor_plugins[i];
 		}
@@ -283,7 +285,7 @@ EditorPlugin *EditorData::get_subeditor(Object *p_object) {
 
 Vector<EditorPlugin *> EditorData::get_subeditors(Object *p_object) {
 	Vector<EditorPlugin *> sub_plugins;
-	for (int i = 0; i < editor_plugins.size(); i++) {
+	for (int i = editor_plugins.size() - 1; i > -1; i--) {
 		if (!editor_plugins[i]->has_main_screen() && editor_plugins[i]->handles(p_object)) {
 			sub_plugins.push_back(editor_plugins[i]);
 		}
@@ -292,7 +294,7 @@ Vector<EditorPlugin *> EditorData::get_subeditors(Object *p_object) {
 }
 
 EditorPlugin *EditorData::get_editor(String p_name) {
-	for (int i = 0; i < editor_plugins.size(); i++) {
+	for (int i = editor_plugins.size() - 1; i > -1; i--) {
 		if (editor_plugins[i]->get_name() == p_name) {
 			return editor_plugins[i];
 		}


### PR DESCRIPTION
The current master iterates forwards through `EditorPlugin`s which gives priority to built-in plugins. Any `CanvasItem` node would always be handled by the `CanvasItemEditorPlugin`, and any `Spatial` node would always be handled by `SpatialEditorPlugin`. This means that you were very restricted in the types of nodes that a plugin could handle (only things that weren't `CanvasItem` or `Spatial` like `Timer` or `AudioStreamPlayer` or just `Node`). If you want to handle something `Node2D` derived, too bad, it can't be done in the current master.

This PR allows user-created editor plugins to handle any type by checking them first. With this change, for example, I can now handle Node25D nodes (which derive from `Node2D`) in the 2.5D editor plugin from the [2.5D demo project](https://github.com/godotengine/godot-demo-projects/tree/master/misc/2.5d) simply by adding this function to the `EditorPlugin` script:

```
func handles(obj):
	return obj is Node25D
```

Open question: I don't actually have a specific use case for doing this to `get_subeditor` and `get_subeditors`, but I think it's best to handle everything from the user first. Or is it?