### PR TITLE
Fix bad uses of mutex causing deadlocks

### DIFF
--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -109,9 +109,10 @@ void EditorResourcePreview::_thread_func(void *ud) {
 
 void EditorResourcePreview::_preview_ready(const String &p_str, const Ref<Texture2D> &p_texture, const Ref<Texture2D> &p_small_texture, ObjectID id, const StringName &p_func, const Variant &p_ud) {
 
-	MutexLock lock(preview_mutex);
 	String path = p_str;
 	{
+		MutexLock lock(preview_mutex);
+
 		uint32_t hash = 0;
 		uint64_t modified_time = 0;
 
@@ -364,7 +365,6 @@ void EditorResourcePreview::queue_edited_resource_preview(const Ref<Resource> &p
 
 			cache[path_id].order = order++;
 			p_receiver->call(p_receiver_func, path_id, cache[path_id].preview, cache[path_id].small_preview, p_userdata);
-			preview_mutex.unlock();
 			return;
 		}
 
@@ -391,7 +391,6 @@ void EditorResourcePreview::queue_resource_preview(const String &p_path, Object 
 		if (cache.has(p_path)) {
 			cache[p_path].order = order++;
 			p_receiver->call(p_receiver_func, p_path, cache[p_path].preview, cache[p_path].small_preview, p_userdata);
-			preview_mutex.unlock();
 			return;
 		}
 
@@ -436,9 +435,10 @@ void EditorResourcePreview::_bind_methods() {
 
 void EditorResourcePreview::check_for_invalidation(const String &p_path) {
 
-	MutexLock lock(preview_mutex);
 	bool call_invalidated = false;
 	{
+		MutexLock lock(preview_mutex);
+
 		if (cache.has(p_path)) {
 
 			uint64_t modified_time = FileAccess::get_modified_time(p_path);


### PR DESCRIPTION
When I translated old-style uses of `Mutex` I did it wrong in some cases.

This fixes a few cases I found that causes the editor to freeze on saving a scene.