### PR TITLE
Fix text_entered signal when max_length is used in LineEdit on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
@@ -110,8 +110,13 @@ public class GodotTextInputWrapper implements TextWatcher, OnEditorActionListene
 			@Override
 			public void run() {
 				for (int i = 0; i < count; ++i) {
-					GodotLib.key(0, 0, newChars[i], true);
-					GodotLib.key(0, 0, newChars[i], false);
+					int key = newChars[i];
+					if (key == '\n') {
+						// Return keys are handled through action events
+						continue;
+					}
+					GodotLib.key(0, 0, key, true);
+					GodotLib.key(0, 0, key, false);
 				}
 			}
 		});
@@ -134,8 +139,13 @@ public class GodotTextInputWrapper implements TextWatcher, OnEditorActionListene
 			});
 		}
 
-		if (pActionID == EditorInfo.IME_ACTION_DONE) {
+		if (pActionID == EditorInfo.IME_NULL) {
+			// Enter key has been pressed
+			GodotLib.key(KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_ENTER, 0, true);
+			GodotLib.key(KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_ENTER, 0, false);
+
 			this.mView.requestFocus();
+			return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
Fixes #35954 based on @MadEqua's suggestion:
https://github.com/godotengine/godot/issues/35954#issuecomment-583073566

*Note:* Done events were not handled in `onEditorAction()` before because the action id for enter key events is actually `IME_NULL`, not `IME_ACTION_DONE`.

From [OnEditorActionListener documentation](https://developer.android.com/reference/android/widget/TextView.OnEditorActionListener):
> actionId
> int: Identifier of the action. This will be either the identifier you supplied, or EditorInfo#IME_NULL if being called due to the enter key being pressed.