### PR TITLE
Add option to toggle editable children for multiple nodes at once

### DIFF
--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -185,7 +185,8 @@ class SceneTreeDock : public VBoxContainer {
 
 	void _delete_confirm();
 
-	void _toggle_editable_children_from_selection();
+	void _toggle_editable_children_off_from_selection();
+	void _toggle_editable_children_on_from_selection();
 	void _toggle_editable_children(Node *p_node);
 
 	void _toggle_placeholder_from_selection();


### PR DESCRIPTION
As suggested in [#21033](https://github.com/godotengine/godot/issues/21033) it would be helpful in some cases being able to toggle multiples nodes as editable children.

I changed just a little bit the behavior of toggle editable children action to check wether current selection contains only nodes that can become editable, and toggle editable on only for those that are currently off. If all of them are already editable, the warning will show up an after confirmation they will be toggled off.

Fixes #21033