### PR TITLE
Stop ViewportTexture error spam

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -87,7 +87,8 @@ void ViewportTexture::set_viewport_path_in_scene(const NodePath &p_path) {
 	path = p_path;
 
 	if (get_local_scene()) {
-		setup_local_to_scene();
+		//Refresh texture. Call deferred because node path could be invalid during instantiation
+		call_deferred("setup_local_to_scene");
 	}
 }
 


### PR DESCRIPTION
The viewport path property in ViewportTexture can sometimes be invalid due to the viewport not yet being initialized. This causes an error, but the texture will still work. Thus, texture is now refreshed via call_deffered(), ensuring the viewport is initialized before refreshing the texture.

Fixes #27790 