### PR TITLE
Enables passing out built-in parameter from parent function in shaders

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -2198,6 +2198,14 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, OperatorNode *p
 										valid = true;
 										break;
 									}
+									if (b->parent_function) {
+										for (int i = 0; i < b->parent_function->arguments.size(); i++) {
+											if (b->parent_function->arguments[i].name == var_name) {
+												valid = true;
+												break;
+											}
+										}
+									}
 									b = b->parent_block;
 								}
 


### PR DESCRIPTION
Fix parsing valid code like:

> void test(inout float t)
> {
> 	modf(t, t);
> }