### PR TITLE
Fix divison by zero issue in audio

### DIFF
--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -258,7 +258,7 @@ void AudioStreamPlaybackSample::mix(AudioFrame *p_buffer, float p_rate_scale, in
 	float srate = base->mix_rate;
 	srate *= p_rate_scale;
 	float fincrement = srate / base_rate;
-	int32_t increment = int32_t(fincrement * MIX_FRAC_LEN);
+	int32_t increment = int32_t(MAX(fincrement * MIX_FRAC_LEN, 1));
 	increment *= sign;
 
 	//looping


### PR DESCRIPTION
Fixes #36988 

On certain circumstances, it's possible for `fincrement * MIX_FRAC_LEN` to have a value lower than 1.0, and converting that value to an int becomes 0.0, causing a crash later on. I've added a simple safe-guard to prevent `increment` from being less than 1.