### PR TITLE
Visual Script Fixes

### DIFF
--- a/modules/visual_script/register_types.cpp
+++ b/modules/visual_script/register_types.cpp
@@ -116,6 +116,7 @@ void register_visual_script_types() {
 #ifdef TOOLS_ENABLED
 	ClassDB::set_current_api(ClassDB::API_EDITOR);
 	ClassDB::register_class<_VisualScriptEditor>();
+	ClassDB::register_class<VisualScriptEditor>();
 	ClassDB::set_current_api(ClassDB::API_CORE);
 	vs_editor_singleton = memnew(_VisualScriptEditor);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("VisualScriptEditor", _VisualScriptEditor::get_singleton()));

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -343,6 +343,7 @@ void VisualScript::add_node(const StringName &p_func, int p_id, const Ref<Visual
 	vsn->connect("ports_changed", callable_mp(this, &VisualScript::_node_ports_changed), varray(p_id));
 	vsn->scripts_used.insert(this);
 	vsn->validate_input_default_values(); // Validate when fully loaded
+	vsn->on_enter_graph(); // Enters the graph after validation
 
 	func.nodes[p_id] = nd;
 }

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -61,6 +61,7 @@ protected:
 
 public:
 	Ref<VisualScript> get_visual_script() const;
+	virtual void on_enter_graph(){ /* nothing */ };
 
 	virtual int get_output_sequence_port_count() const = 0;
 	virtual bool has_input_sequence_port() const = 0;

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -4631,6 +4631,8 @@ void VisualScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_update_graph_connections", &VisualScriptEditor::_update_graph_connections);
 
 	ClassDB::bind_method("_generic_search", &VisualScriptEditor::_generic_search);
+
+	ClassDB::bind_method("_update_members", &VisualScriptEditor::_update_members);
 }
 
 VisualScriptEditor::VisualScriptEditor() {

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -751,6 +751,7 @@ PropertyInfo VisualScriptComposeArray::get_output_value_port_info(int p_idx) con
 }
 
 String VisualScriptComposeArray::get_caption() const {
+
 	return "Compose Array";
 }
 String VisualScriptComposeArray::get_text() const {
@@ -1224,9 +1225,10 @@ PropertyInfo VisualScriptVariableGet::get_input_value_port_info(int p_idx) const
 PropertyInfo VisualScriptVariableGet::get_output_value_port_info(int p_idx) const {
 
 	PropertyInfo pinfo;
-	pinfo.name = "value";
+	pinfo.name = "Unconnected";
 	if (get_visual_script().is_valid() && get_visual_script()->has_variable(variable)) {
 		PropertyInfo vinfo = get_visual_script()->get_variable_info(variable);
+		pinfo.name = variable;
 		pinfo.type = vinfo.type;
 		pinfo.hint = vinfo.hint;
 		pinfo.hint_string = vinfo.hint_string;
@@ -1235,7 +1237,6 @@ PropertyInfo VisualScriptVariableGet::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptVariableGet::get_caption() const {
-
 	return "Get " + variable;
 }
 void VisualScriptVariableGet::set_variable(StringName p_variable) {
@@ -1277,6 +1278,19 @@ void VisualScriptVariableGet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_variable"), &VisualScriptVariableGet::get_variable);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "var_name"), "set_variable", "get_variable");
+}
+
+void VisualScriptVariableGet::on_enter_graph() {
+	// If the node doesn't have a variable set, set it to the first variable in the list
+	if (variable.operator String().empty()) {
+		Ref<VisualScript> vs = get_visual_script();
+		if (vs.is_valid()) {
+			List<StringName> vars;
+			vs->get_variable_list(&vars);
+			if (vars.size())
+				variable = vars.front()->get();
+		}
+	}
 }
 
 class VisualScriptNodeInstanceVariableGet : public VisualScriptNodeInstance {
@@ -1338,9 +1352,10 @@ String VisualScriptVariableSet::get_output_sequence_port_text(int p_port) const 
 PropertyInfo VisualScriptVariableSet::get_input_value_port_info(int p_idx) const {
 
 	PropertyInfo pinfo;
-	pinfo.name = "set";
+	pinfo.name = "Unconnected";
 	if (get_visual_script().is_valid() && get_visual_script()->has_variable(variable)) {
 		PropertyInfo vinfo = get_visual_script()->get_variable_info(variable);
+		pinfo.name = "Set " + variable;
 		pinfo.type = vinfo.type;
 		pinfo.hint = vinfo.hint;
 		pinfo.hint_string = vinfo.hint_string;
@@ -1397,6 +1412,19 @@ void VisualScriptVariableSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_variable"), &VisualScriptVariableSet::get_variable);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "var_name"), "set_variable", "get_variable");
+}
+
+void VisualScriptVariableSet::on_enter_graph() {
+	// If the node doesn't have a variable set, set it to the first variable in the list
+	if (variable.operator String().empty()) {
+		Ref<VisualScript> vs = get_visual_script();
+		if (vs.is_valid()) {
+			List<StringName> vars;
+			vs->get_variable_list(&vars);
+			if (vars.size())
+				variable = vars.front()->get();
+		}
+	}
 }
 
 class VisualScriptNodeInstanceVariableSet : public VisualScriptNodeInstance {

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -280,6 +280,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual void on_enter_graph();
+
 	virtual int get_output_sequence_port_count() const;
 	virtual bool has_input_sequence_port() const;
 
@@ -313,6 +315,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual void on_enter_graph();
+
 	virtual int get_output_sequence_port_count() const;
 	virtual bool has_input_sequence_port() const;
 


### PR DESCRIPTION
1) Fixed bug causing variable setters/getters added from the add node menu to be unusable when only one variable is present.
2) Updated setter/gettter port naming to make the node's state more clear.
3) Fixed regression causing script members to not update.