### PR TITLE
Fix hanging with large offsets and small path lengths in PathFollow and PathFollow2D

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -325,12 +325,13 @@ void PathFollow2D::set_offset(float p_offset) {
 			float path_length = path->get_curve()->get_baked_length();
 
 			if (loop) {
-				while (offset > path_length)
-					offset -= path_length;
+				real_t wrapped_offset = Math::fposmod(offset, path_length);
 
-				while (offset < 0)
-					offset += path_length;
+				if (offset > 0 && wrapped_offset == 0) {
+					wrapped_offset = path_length;
+				}
 
+				offset = wrapped_offset;
 			} else {
 				offset = CLAMP(offset, 0, path_length);
 			}

--- a/scene/3d/path.cpp
+++ b/scene/3d/path.cpp
@@ -320,12 +320,13 @@ void PathFollow::set_offset(float p_offset) {
 			float path_length = path->get_curve()->get_baked_length();
 
 			if (loop) {
-				while (offset > path_length)
-					offset -= path_length;
+				real_t wrapped_offset = Math::fposmod(offset, path_length);
 
-				while (offset < 0)
-					offset += path_length;
+				if (offset > 0 && wrapped_offset == 0) {
+					wrapped_offset = path_length;
+				}
 
+				offset = wrapped_offset;
 			} else {
 				offset = CLAMP(offset, 0, path_length);
 			}


### PR DESCRIPTION
If the offset of a PathFollow or PathFollow2D is very large, the current while loop implementation can cause the engine to become unresponsive while the offset is adjusted to be between 0 and the path length. To fix this, I've replaced the while loops with a constant time implementation.