### PR TITLE
Fix area calculation of Face3

### DIFF
--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -169,7 +169,7 @@ Vector3 Face3::get_median_point() const {
 }
 
 real_t Face3::get_area() const {
-	return vec3_cross(vertex[0] - vertex[1], vertex[0] - vertex[2]).length();
+	return vec3_cross(vertex[0] - vertex[1], vertex[0] - vertex[2]).length() * 0.5;
 }
 
 ClockDirection Face3::get_clock_dir() const {


### PR DESCRIPTION
Fixes #37048 

There seemed to be a bug in area calculation in Face3::get_area()-function. It returned the area of "imaginary" parallelogram instead of the triangle. Therefore the area returned was twice the real area. This manifested itself when using a hydro module for godot ( https://gitlab.com/ringtechsolutions/godot-tools/hydro/hydro ) causing the buoyancy to be two times the expected value.

"Reference": http://www.maths.usyd.edu.au/u/MOW/vectors/vectors-11/v-11-7.html