### PR TITLE
Add String.is_substring_of to check for consecutive match

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2759,12 +2759,22 @@ bool String::is_enclosed_in(const String &p_string) const {
 
 bool String::is_subsequence_of(const String &p_string) const {
 
-	return _base_is_subsequence_of(p_string, false);
+	return _base_is_subsequence_of(p_string, false, false);
 }
 
 bool String::is_subsequence_ofi(const String &p_string) const {
 
-	return _base_is_subsequence_of(p_string, true);
+	return _base_is_subsequence_of(p_string, true, false);
+}
+
+bool String::is_substring_of(const String &p_string) const {
+
+	return _base_is_subsequence_of(p_string, false, true);
+}
+
+bool String::is_substring_ofi(const String &p_string) const {
+
+	return _base_is_subsequence_of(p_string, true, true);
 }
 
 bool String::is_quoted() const {
@@ -2817,7 +2827,7 @@ int String::countn(const String &p_string, int p_from, int p_to) const {
 	return _count(p_string, p_from, p_to, true);
 }
 
-bool String::_base_is_subsequence_of(const String &p_string, bool case_insensitive) const {
+bool String::_base_is_subsequence_of(const String &p_string, bool case_insensitive, bool p_continuous) const {
 
 	int len = length();
 	if (len == 0) {
@@ -2828,6 +2838,8 @@ bool String::_base_is_subsequence_of(const String &p_string, bool case_insensiti
 	if (len > p_string.length()) {
 		return false;
 	}
+
+	bool was_matched = false;
 
 	const CharType *src = &operator[](0);
 	const CharType *tgt = &p_string[0];
@@ -2842,9 +2854,15 @@ bool String::_base_is_subsequence_of(const String &p_string, bool case_insensiti
 			match = *src == *tgt;
 		}
 		if (match) {
+			was_matched = true;
+
 			src++;
 			if (!*src) {
 				return true;
+			}
+		} else {
+			if (was_matched && p_continuous) {
+				return false;
 			}
 		}
 	}

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -132,7 +132,7 @@ class String {
 	void copy_from(const CharType *p_cstr, const int p_clip_to = -1);
 	void copy_from(const CharType &p_char);
 	void copy_from_unchecked(const CharType *p_char, const int p_length);
-	bool _base_is_subsequence_of(const String &p_string, bool case_insensitive) const;
+	bool _base_is_subsequence_of(const String &p_string, bool case_insensitive, bool p_continuous = false) const;
 	int _count(const String &p_string, int p_from, int p_to, bool p_case_insensitive) const;
 
 public:
@@ -215,6 +215,8 @@ public:
 	bool is_enclosed_in(const String &p_string) const;
 	bool is_subsequence_of(const String &p_string) const;
 	bool is_subsequence_ofi(const String &p_string) const;
+	bool is_substring_of(const String &p_string) const;
+	bool is_substring_ofi(const String &p_string) const;
 	bool is_quoted() const;
 	Vector<String> bigrams() const;
 	float similarity(const String &p_string) const;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -251,6 +251,8 @@ struct _VariantCall {
 	VCALL_LOCALMEM1R(String, ends_with);
 	VCALL_LOCALMEM1R(String, is_subsequence_of);
 	VCALL_LOCALMEM1R(String, is_subsequence_ofi);
+	VCALL_LOCALMEM1R(String, is_substring_of);
+	VCALL_LOCALMEM1R(String, is_substring_ofi);
 	VCALL_LOCALMEM0R(String, bigrams);
 	VCALL_LOCALMEM1R(String, similarity);
 	VCALL_LOCALMEM2R(String, format);
@@ -1724,6 +1726,8 @@ void register_variant_methods() {
 	ADDFUNC1R(STRING, BOOL, String, ends_with, STRING, "text", varray());
 	ADDFUNC1R(STRING, BOOL, String, is_subsequence_of, STRING, "text", varray());
 	ADDFUNC1R(STRING, BOOL, String, is_subsequence_ofi, STRING, "text", varray());
+	ADDFUNC1R(STRING, BOOL, String, is_substring_of, STRING, "text", varray());
+	ADDFUNC1R(STRING, BOOL, String, is_substring_ofi, STRING, "text", varray());
 	ADDFUNC0R(STRING, PACKED_STRING_ARRAY, String, bigrams, varray());
 	ADDFUNC1R(STRING, FLOAT, String, similarity, STRING, "text", varray());
 

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -556,7 +556,7 @@
 			<argument index="0" name="text" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] if this string is a subsequence of the given string.
+				Returns [code]true[/code] if this string is a subsequence of the given string. Gaps or interwoven characters are omitted during check (useful for example in "fuzzy" searches).
 			</description>
 		</method>
 		<method name="is_subsequence_ofi">
@@ -565,9 +565,27 @@
 			<argument index="0" name="text" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] if this string is a subsequence of the given string, without considering case.
+				Returns [code]true[/code] if this string is a subsequence of the given string, without considering case. Gaps or interwoven characters are omitted during check (useful for example in "fuzzy" searches).
 			</description>
 		</method>
+		<method name="is_substring_of">
+			<return type="bool">
+			</return>
+			<argument index="0" name="text" type="String">
+			</argument>
+			<description>
+				Returns [code]true[/code] if this string is a substring of the given string. Current String must be literal slice, without any gaps or interwoven characters, of [code]text[/code] in question to match.
+			</description>
+		</method>
+		<method name="is_substring_ofi">
+			<return type="bool">
+			</return>
+			<argument index="0" name="text" type="String">
+			</argument>
+			<description>
+				Returns [code]true[/code] if this string is a substring of the given string, without considering case. Current String must be literal slice, without any gaps or interwoven characters, of [code]text[/code] in question to match.
+			</description>
+		</method>		
 		<method name="is_valid_filename">
 			<return type="bool">
 			</return>

--- a/modules/gdnative/gdnative/string.cpp
+++ b/modules/gdnative/gdnative/string.cpp
@@ -346,6 +346,20 @@ godot_bool GDAPI godot_string_is_subsequence_ofi(const godot_string *p_self, con
 	return self->is_subsequence_ofi(*string);
 }
 
+godot_bool GDAPI godot_string_is_substring_of(const godot_string *p_self, const godot_string *p_string) {
+	const String *self = (const String *)p_self;
+	const String *string = (const String *)p_string;
+
+	return self->is_substring_of(*string);
+}
+
+godot_bool GDAPI godot_string_is_substring_ofi(const godot_string *p_self, const godot_string *p_string) {
+	const String *self = (const String *)p_self;
+	const String *string = (const String *)p_string;
+
+	return self->is_substring_ofi(*string);
+}
+
 godot_string GDAPI godot_string_lpad(const godot_string *p_self, godot_int p_min_length) {
 	const String *self = (const String *)p_self;
 	godot_string result;

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -4652,7 +4652,23 @@
           ["const godot_string *", "p_self"],
           ["const godot_string *", "p_string"]
         ]
+			},
+      {
+        "name": "godot_string_is_substring_of",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_string *", "p_self"],
+          ["const godot_string *", "p_string"]
+        ]
       },
+      {
+        "name": "godot_string_is_substring_ofi",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_string *", "p_self"],
+          ["const godot_string *", "p_string"]
+        ]
+      },			
       {
         "name": "godot_string_lpad",
         "return_type": "godot_string",

--- a/modules/gdnative/include/gdnative/string.h
+++ b/modules/gdnative/include/gdnative/string.h
@@ -121,6 +121,8 @@ godot_string GDAPI godot_string_insert(const godot_string *p_self, godot_int p_a
 godot_bool GDAPI godot_string_is_numeric(const godot_string *p_self);
 godot_bool GDAPI godot_string_is_subsequence_of(const godot_string *p_self, const godot_string *p_string);
 godot_bool GDAPI godot_string_is_subsequence_ofi(const godot_string *p_self, const godot_string *p_string);
+godot_bool GDAPI godot_string_is_substring_of(const godot_string *p_self, const godot_string *p_string);
+godot_bool GDAPI godot_string_is_substring_ofi(const godot_string *p_self, const godot_string *p_string);
 godot_string GDAPI godot_string_lpad(const godot_string *p_self, godot_int p_min_length);
 godot_string GDAPI godot_string_lpad_with_custom_character(const godot_string *p_self, godot_int p_min_length, const godot_string *p_character);
 godot_bool GDAPI godot_string_match(const godot_string *p_self, const godot_string *p_wildcard);


### PR DESCRIPTION
Non-breaking change - I've extended two methods in core ```ustring``` of additional parameter, though its default value retains current behaviour.

![image](https://user-images.githubusercontent.com/1110337/76699895-102fc780-66b2-11ea-819f-122df4fcb79a.png)


Fixes: #37063