### PR TITLE
Automatic remote debugger port assignment.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2029,16 +2029,16 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 
 	args = ProjectSettings::get_singleton()->get("editor/main_run_args");
 	skip_breakpoints = ScriptEditor::get_singleton()->get_debugger()->is_skip_breakpoints();
+	emit_signal("play_pressed");
 
 	Error error = editor_run.run(run_filename, args, breakpoints, skip_breakpoints);
 
 	if (error != OK) {
-
+		emit_signal("stop_pressed");
 		show_accept(TTR("Could not start subprocess!"), TTR("OK"));
 		return;
 	}
 
-	emit_signal("play_pressed");
 	if (p_current) {
 		play_scene_button->set_pressed(true);
 		play_scene_button->set_icon(gui_base->get_icon("Reload", "EditorIcons"));

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -30,6 +30,9 @@
 
 #include "editor_run.h"
 
+#include "plugins/script_editor_plugin.h"
+#include "script_editor_debugger.h"
+
 #include "core/project_settings.h"
 #include "editor_settings.h"
 
@@ -43,8 +46,6 @@ Error EditorRun::run(const String &p_scene, const String &p_custom_args, const L
 	List<String> args;
 
 	String resource_path = ProjectSettings::get_singleton()->get_resource_path();
-	String remote_host = EditorSettings::get_singleton()->get("network/debug/remote_host");
-	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 
 	if (resource_path != "") {
 		args.push_back("--path");
@@ -52,8 +53,15 @@ Error EditorRun::run(const String &p_scene, const String &p_custom_args, const L
 	}
 
 	args.push_back("--remote-debug");
-	args.push_back(remote_host + ":" + String::num(remote_port));
 
+	const String conn_string = ScriptEditor::get_singleton()->get_debugger()->get_connection_string();
+	if (!conn_string.empty()) {
+		args.push_back(ScriptEditor::get_singleton()->get_debugger()->get_connection_string());
+	} else { // Try anyway with default settings
+		const String remote_host = EditorSettings::get_singleton()->get("network/debug/remote_host");
+		const int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
+		args.push_back(remote_host + ":" + String::num(remote_port));
+	}
 	args.push_back("--allow_focus_steal_pid");
 	args.push_back(itos(OS::get_singleton()->get_process_id()));
 

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -121,6 +121,7 @@ private:
 	int last_warning_count;
 
 	bool hide_on_stop;
+	int remote_port;
 	bool enable_external_editor;
 
 	bool skip_breakpoints_value = false;
@@ -275,6 +276,7 @@ public:
 	void set_hide_on_stop(bool p_hide);
 
 	bool get_debug_with_external_editor() const;
+	String get_connection_string() const;
 	void set_debug_with_external_editor(bool p_enabled);
 
 	Ref<Script> get_dump_stack_script() const;


### PR DESCRIPTION
This is the continuation of #34651. This PR is only relevant to 3.2 as 4.0 has undergone many changes and it would require a different approach.

I'v made the changes requested by @Faless in #34651 and the game is now requesting the port from the debugger instead of saving/loading it.

![image](https://user-images.githubusercontent.com/1850856/76702785-564a5280-66d5-11ea-967c-20349f6e0e43.png)

