### PR TITLE
Handle TextEdit's 'Select all text' event properly to prevent 'Add Child Node' action from being fired instead

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2589,8 +2589,16 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 		}
 
-		if (!k->is_pressed())
+		if (!k->is_pressed()) {
+
+			// On key-release, stop propagation of CTRL+A shortcut, also used for Add Child Node action
+			if (k->get_control() && k->get_keycode() == KEY_A) {
+
+				accept_event();
+			}
+
 			return;
+		}
 
 		if (completion_active) {
 			if (readonly)


### PR DESCRIPTION
That shortuct is already being handled in 'unhandled_input' - which is good, as it should be handled after/if all GUI-related inputs were processed.
It was mistakenly added to 'Add Node' button in scene dock which caused propagation of CTRL+A event, from Viewport to the button itself, thus preventing firing CTRL+A on any of Editor's GUI nodes, like TextBoxes.

Fixes #37054