### PR TITLE
Fix error when moving animation timeline cursor in capture mode

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -417,7 +417,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 
 				if (update_mode == Animation::UPDATE_CAPTURE) {
 
-					if (p_started) {
+					if (p_started || pa->capture.get_type() == Variant::NIL) {
 						pa->capture = pa->object->get_indexed(pa->subpath);
 					}
 


### PR DESCRIPTION
Fixes #32529

On Capture Mode, processing animation seems to be _Capturing_ the starting state (from where to begin the blending) right before playback is started (clicking play button for instance). If playback hasn't been started before, capture is null. I added a check that allow to update the capture value if nothing has been captured before.

As this check is done in _animation_process_animation it has a consistent behavior when a user open the scene, because it's going to load the captured state with the frame that was selected as current when it was saved.

When objects are instantiated in the actual game, seems that the only way to run process animation is when animation is played, so this error doesn't appear.