### PR TITLE
Fixes unnecessary change in animation length property while using the slider

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1416,6 +1416,9 @@ void AnimationTimelineEdit::_anim_length_changed(double p_new_len) {
 	if (editing)
 		return;
 
+	if (length->is_grabbing())
+		return;
+
 	p_new_len = MAX(0.001, p_new_len);
 	if (use_fps && animation->get_step() > 0) {
 		p_new_len *= animation->get_step();

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -75,14 +75,15 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 
 					if (grabbing_spinner) {
 
+						grabbing_spinner = false;
 						Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
 						Input::get_singleton()->warp_mouse_position(grabbing_spinner_mouse_pos);
 						update();
+						_ungrabbed();
 					} else {
 						_focus_entered();
 					}
 
-					grabbing_spinner = false;
 					grabbing_spinner_attempt = false;
 				}
 			}
@@ -153,6 +154,7 @@ void EditorSpinSlider::_grabber_gui_input(const Ref<InputEvent> &p_event) {
 		if (mb->is_pressed()) {
 
 			grabbing_grabber = true;
+			pre_grab_value = get_value();
 			if (!mousewheel_over_grabber) {
 				grabbing_ratio = get_as_ratio();
 				grabbing_from = grabber->get_transform().xform(mb->get_position()).x;
@@ -160,6 +162,7 @@ void EditorSpinSlider::_grabber_gui_input(const Ref<InputEvent> &p_event) {
 		} else {
 			grabbing_grabber = false;
 			mousewheel_over_grabber = false;
+			_ungrabbed();
 		}
 	}
 
@@ -372,6 +375,13 @@ void EditorSpinSlider::_evaluate_input_text() {
 	set_value(v);
 }
 
+void EditorSpinSlider::_ungrabbed() {
+	if (get_value() != pre_grab_value) {
+		emit_signal("value_changed", get_value());
+		pre_grab_value = get_value();
+	}
+}
+
 //text_entered signal
 void EditorSpinSlider::_value_input_entered(const String &p_text) {
 	value_input_just_closed = true;
@@ -467,6 +477,10 @@ void EditorSpinSlider::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "label"), "set_label", "get_label");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "read_only"), "set_read_only", "is_read_only");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flat"), "set_flat", "is_flat");
+}
+
+bool EditorSpinSlider::is_grabbing() {
+	return grabbing_grabber || grabbing_spinner;
 }
 
 EditorSpinSlider::EditorSpinSlider() {

--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -77,6 +77,8 @@ class EditorSpinSlider : public Range {
 
 	void _evaluate_input_text();
 
+	void _ungrabbed();
+
 protected:
 	void _notification(int p_what);
 	void _gui_input(const Ref<InputEvent> &p_event);
@@ -107,6 +109,9 @@ public:
 	LineEdit *get_line_edit() { return value_input; }
 
 	virtual Size2 get_minimum_size() const;
+
+	bool is_grabbing();
+
 	EditorSpinSlider();
 };
 


### PR DESCRIPTION
Fixes #37072
After this fix the length of animation updates only when the values are finally changed (either a mouse release event of slider/grabber or confirmation of keyboard input)
Changes made:
* Added `EditorSpinSlider::is_grabbing` to check the grabbing status of `EditorSpinSlider`
* Added `EditorSpinSlider::_ungrabbed` to trigger signals when mouse is released after grabbing
* `value_changed` is triggered at mouse release event.
* `EditorSpinSlider::pre_grab_value` is also updated for changes through grabber
* `AnimationTimelineEdit::_anim_length_changed` skips changes if slider is grabbed, in this way the issue is fixed