### PR TITLE
Fix: colorpicker margin bug fixed

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -66,7 +66,7 @@ void ColorPicker::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_PARENTED: {
 			for (int i = 0; i < 4; i++) {
-				set_margin((Margin)i, get_theme_constant("margin"));
+				set_margin((Margin)i, get_margin((Margin)i) + get_theme_constant("margin"));
 			}
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {


### PR DESCRIPTION
the position of the color picker not working because the margin was overridden by the custom_constants/margin property of the colorpicker fixed.

![color-picker-margin-bug-fix](https://user-images.githubusercontent.com/41085900/76754168-ab569900-67a7-11ea-9300-1de4b2cc3c01.gif)

_Bugsquad edit:_ Fixes #33367