### PR TITLE
Calculate LineEdit selection with secret character

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1093,7 +1093,11 @@ void LineEdit::set_cursor_at_pixel_pos(int p_x) {
 
 		int char_w = 0;
 		if (font != NULL) {
-			char_w = font->get_char_size(text[ofs]).width;
+			if (is_secret()) {
+				char_w = font->get_char_size(secret_character[0]).width;
+			} else {
+				char_w = font->get_char_size(text[ofs]).width;
+			}
 		}
 		pixel_ofs += char_w;
 


### PR DESCRIPTION
If a LineEdit was set as "secret", the mouse selection calculation was incorrectly using the widths of the underlying text characters instead of the secret character.