### PR TITLE
Tweak the invalid Unicode error message to be more descriptive

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1402,7 +1402,7 @@ String String::utf8(const char *p_utf8, int p_len) {
 
 bool String::parse_utf8(const char *p_utf8, int p_len) {
 
-#define _UNICERROR(m_err) print_line("Unicode error: " + String(m_err));
+#define _UNICERROR(m_err) print_line("Unicode parsing error: " + String(m_err) + ". Is the string valid UTF-8?");
 
 	if (!p_utf8)
 		return true;


### PR DESCRIPTION
I'm not sure if we can make it more descriptive than that, specifically for imported translations. Maybe we could try parsing the entire translation CSV file as UTF-8 to check whether it's valid and report back?

This closes #28503. The translation encoding recommendations were also updated in https://github.com/godotengine/godot-docs/pull/3211.