### PR TITLE
WebSocket profiler for HTML5 platform [4.0]

### DIFF
--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -38,6 +38,7 @@
 #include "core/variant.h"
 #include "core/vector.h"
 
+class RemoteDebuggerPeer;
 class ScriptDebugger;
 
 class EngineDebugger {
@@ -45,7 +46,10 @@ public:
 	typedef void (*ProfilingToggle)(void *p_user, bool p_enable, const Array &p_opts);
 	typedef void (*ProfilingTick)(void *p_user, float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time);
 	typedef void (*ProfilingAdd)(void *p_user, const Array &p_arr);
+
 	typedef Error (*CaptureFunc)(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);
+
+	typedef RemoteDebuggerPeer *(*CreatePeerFunc)(const String &p_uri);
 
 	class Profiler {
 		friend class EngineDebugger;
@@ -94,6 +98,7 @@ protected:
 
 	static Map<StringName, Profiler> profilers;
 	static Map<StringName, Capture> captures;
+	static Map<String, CreatePeerFunc> protocols;
 
 public:
 	_FORCE_INLINE_ static EngineDebugger *get_singleton() { return singleton; }
@@ -112,6 +117,8 @@ public:
 	static void register_message_capture(const StringName &p_name, Capture p_func);
 	static void unregister_message_capture(const StringName &p_name);
 	static bool has_capture(const StringName &p_name);
+
+	static void register_uri_handler(const String &p_protocol, CreatePeerFunc p_func);
 
 	void iteration(uint64_t p_frame_ticks, uint64_t p_idle_ticks, uint64_t p_physics_ticks, float p_physics_frame_time);
 	void profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts = Array());

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -673,6 +673,9 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 
 	ERR_FAIL_COND_MSG(!is_peer_connected(), "Script Debugger failed to connect, but being used anyway.");
 
+	if (!peer->can_block())
+		return; // Peer does not support blocking IO. We could at least send the error though.
+
 	ScriptLanguage *script_lang = script_debugger->get_break_language();
 	const String error_str = script_lang ? script_lang->debug_get_error() : "";
 	Array msg;
@@ -884,13 +887,6 @@ Error RemoteDebugger::_profiler_capture(const String &p_cmd, const Array &p_data
 	r_captured = true;
 	profiler_enable(p_cmd, p_data[0], opts);
 	return OK;
-}
-
-RemoteDebugger *RemoteDebugger::create_for_uri(const String &p_uri) {
-	Ref<RemoteDebuggerPeer> peer = RemoteDebuggerPeer::create_from_uri(p_uri);
-	if (peer.is_valid())
-		return memnew(RemoteDebugger(peer));
-	return nullptr;
 }
 
 RemoteDebugger::RemoteDebugger(Ref<RemoteDebuggerPeer> p_peer) {

--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -108,8 +108,6 @@ private:
 	Error _try_capture(const String &p_name, const Array &p_data, bool &r_captured);
 
 public:
-	static RemoteDebugger *create_for_uri(const String &p_uri);
-
 	// Overrides
 	void poll_events(bool p_is_idle);
 	void send_message(const String &p_message, const Array &p_args);

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -218,9 +218,8 @@ void RemoteDebuggerPeerTCP::_poll() {
 	}
 }
 
-Ref<RemoteDebuggerPeer> RemoteDebuggerPeer::create_from_uri(const String p_uri) {
-	if (!p_uri.begins_with("tcp://"))
-		return Ref<RemoteDebuggerPeer>(); // Only TCP supported for now, more to come.
+RemoteDebuggerPeer *RemoteDebuggerPeerTCP::create(const String &p_uri) {
+	ERR_FAIL_COND_V(!p_uri.begins_with("tcp://"), nullptr);
 
 	String debug_host = p_uri.replace("tcp://", "");
 	uint16_t debug_port = 6007;
@@ -230,10 +229,13 @@ Ref<RemoteDebuggerPeer> RemoteDebuggerPeer::create_from_uri(const String p_uri) 
 		debug_port = debug_host.substr(sep_pos + 1).to_int();
 		debug_host = debug_host.substr(0, sep_pos);
 	}
-	Ref<RemoteDebuggerPeerTCP> peer = Ref<RemoteDebuggerPeer>(memnew(RemoteDebuggerPeerTCP));
+
+	RemoteDebuggerPeerTCP *peer = memnew(RemoteDebuggerPeerTCP);
 	Error err = peer->connect_to_host(debug_host, debug_port);
-	if (err != OK)
-		return Ref<RemoteDebuggerPeer>();
+	if (err != OK) {
+		memdelete(peer);
+		return nullptr;
+	}
 	return peer;
 }
 

--- a/core/debugger/remote_debugger_peer.h
+++ b/core/debugger/remote_debugger_peer.h
@@ -42,7 +42,6 @@ protected:
 	int max_queued_messages = 4096;
 
 public:
-	static Ref<RemoteDebuggerPeer> create_from_uri(const String p_uri);
 	virtual bool is_peer_connected() = 0;
 	virtual bool has_message() = 0;
 	virtual Error put_message(const Array &p_arr) = 0;
@@ -50,6 +49,7 @@ public:
 	virtual void close() = 0;
 	virtual void poll() = 0;
 	virtual int get_max_message_size() const = 0;
+	virtual bool can_block() const { return true; } // If blocking io is allowed on main thread (debug).
 
 	RemoteDebuggerPeer();
 };
@@ -77,6 +77,8 @@ private:
 	void _read_in();
 
 public:
+	static RemoteDebuggerPeer *create(const String &p_uri);
+
 	Error connect_to_host(const String &p_host, uint16_t p_port);
 
 	void poll();

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -173,7 +173,7 @@ ScriptEditorDebugger *EditorDebuggerNode::get_default_debugger() const {
 	return Object::cast_to<ScriptEditorDebugger>(tabs->get_tab_control(0));
 }
 
-Error EditorDebuggerNode::start() {
+Error EditorDebuggerNode::start(const String &p_protocol) {
 	stop();
 	if (EDITOR_GET("run/output/always_open_output_on_play")) {
 		EditorNode::get_singleton()->make_bottom_panel_item_visible(EditorNode::get_log());
@@ -181,7 +181,7 @@ Error EditorDebuggerNode::start() {
 		EditorNode::get_singleton()->make_bottom_panel_item_visible(this);
 	}
 
-	server = Ref<EditorDebuggerServer>(EditorDebuggerServer::create_default());
+	server = Ref<EditorDebuggerServer>(EditorDebuggerServer::create(p_protocol));
 	const Error err = server->start();
 	if (err != OK) {
 		return err;
@@ -213,14 +213,6 @@ void EditorDebuggerNode::stop() {
 
 void EditorDebuggerNode::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			EditorNode::get_singleton()->connect("play_pressed", callable_mp(this, &EditorDebuggerNode::start));
-			EditorNode::get_singleton()->connect("stop_pressed", callable_mp(this, &EditorDebuggerNode::stop));
-		} break;
-		case NOTIFICATION_EXIT_TREE: {
-			EditorNode::get_singleton()->disconnect("play_pressed", callable_mp(this, &EditorDebuggerNode::start));
-			EditorNode::get_singleton()->disconnect("stop_pressed", callable_mp(this, &EditorDebuggerNode::stop));
-		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (tabs->get_tab_count() > 1) {
 				add_theme_constant_override("margin_left", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox("BottomPanelDebuggerOverride", "EditorStyles")->get_margin(MARGIN_LEFT));

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -183,7 +183,7 @@ public:
 	void set_camera_override(CameraOverride p_override) { camera_override = p_override; }
 	CameraOverride get_camera_override() { return camera_override; }
 
-	Error start();
+	Error start(const String &p_protocol = "tcp://");
 
 	void stop();
 };

--- a/editor/debugger/editor_debugger_server.cpp
+++ b/editor/debugger/editor_debugger_server.cpp
@@ -44,6 +44,7 @@ private:
 	Ref<TCP_Server> server;
 
 public:
+	static EditorDebuggerServer *create(const String &p_protocol);
 	virtual void poll() {}
 	virtual Error start();
 	virtual void stop();
@@ -53,6 +54,11 @@ public:
 
 	EditorDebuggerServerTCP();
 };
+
+EditorDebuggerServer *EditorDebuggerServerTCP::create(const String &p_protocol) {
+	ERR_FAIL_COND_V(p_protocol != "tcp://", nullptr);
+	return memnew(EditorDebuggerServerTCP);
+}
 
 EditorDebuggerServerTCP::EditorDebuggerServerTCP() {
 	server.instance();
@@ -85,6 +91,23 @@ Ref<RemoteDebuggerPeer> EditorDebuggerServerTCP::take_connection() {
 	return memnew(RemoteDebuggerPeerTCP(server->take_connection()));
 }
 
-EditorDebuggerServer *EditorDebuggerServer::create_default() {
-	return memnew(EditorDebuggerServerTCP);
+/// EditorDebuggerServer
+Map<StringName, EditorDebuggerServer::CreateServerFunc> EditorDebuggerServer::protocols;
+
+EditorDebuggerServer *EditorDebuggerServer::create(const String &p_protocol) {
+	ERR_FAIL_COND_V(!protocols.has(p_protocol), nullptr);
+	return protocols[p_protocol](p_protocol);
+}
+
+void EditorDebuggerServer::register_protocol_handler(const String &p_protocol, CreateServerFunc p_func) {
+	ERR_FAIL_COND(protocols.has(p_protocol));
+	protocols[p_protocol] = p_func;
+}
+
+void EditorDebuggerServer::initialize() {
+	register_protocol_handler("tcp://", EditorDebuggerServerTCP::create);
+}
+
+void EditorDebuggerServer::deinitialize() {
+	protocols.clear();
 }

--- a/editor/debugger/editor_debugger_server.h
+++ b/editor/debugger/editor_debugger_server.h
@@ -37,7 +37,17 @@
 class EditorDebuggerServer : public Reference {
 
 public:
-	static EditorDebuggerServer *create_default();
+	typedef EditorDebuggerServer *(*CreateServerFunc)(const String &p_uri);
+
+private:
+	static Map<StringName, CreateServerFunc> protocols;
+
+public:
+	static void initialize();
+	static void deinitialize();
+
+	static void register_protocol_handler(const String &p_protocol, CreateServerFunc p_func);
+	static EditorDebuggerServer *create(const String &p_protocol);
 	virtual void poll() = 0;
 	virtual Error start() = 0;
 	virtual void stop() = 0;

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -846,6 +846,8 @@ void ScriptEditorDebugger::_notification(int p_what) {
 
 			if (is_session_active()) {
 
+				peer->poll();
+
 				if (camera_override == CameraOverride::OVERRIDE_2D) {
 					CanvasItemEditor *editor = CanvasItemEditor::get_singleton();
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -284,7 +284,7 @@ void EditorExportPlatform::gen_debug_flags(Vector<String> &r_flags, int p_flags)
 
 		r_flags.push_back("--remote-debug");
 
-		r_flags.push_back(host + ":" + String::num(remote_port));
+		r_flags.push_back(get_debug_protocol() + host + ":" + String::num(remote_port));
 
 		List<String> breakpoints;
 		ScriptEditor::get_singleton()->get_breakpoints(&breakpoints);
@@ -1127,7 +1127,7 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 
 		r_flags.push_back("--remote-debug");
 
-		r_flags.push_back(host + ":" + String::num(remote_port));
+		r_flags.push_back(get_debug_protocol() + host + ":" + String::num(remote_port));
 
 		List<String> breakpoints;
 		ScriptEditor::get_singleton()->get_breakpoints(&breakpoints);

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -270,6 +270,7 @@ public:
 	virtual Error export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
 	virtual void get_platform_features(List<String> *r_features) = 0;
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) = 0;
+	virtual String get_debug_protocol() const { return "tcp://"; }
 
 	EditorExportPlatform();
 };

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -32,6 +32,7 @@
 #define EDITOR_NODE_H
 
 #include "editor/editor_data.h"
+#include "editor/editor_export.h"
 #include "editor/editor_folding.h"
 #include "editor/editor_run.h"
 #include "editor/inspector_dock.h"
@@ -161,7 +162,6 @@ private:
 
 		RUN_STOP,
 		RUN_PLAY_SCENE,
-		RUN_PLAY_NATIVE,
 		RUN_PLAY_CUSTOM_SCENE,
 		RUN_SCENE_SETTINGS,
 		RUN_SETTINGS,
@@ -492,6 +492,7 @@ private:
 	void _quick_run();
 
 	void _run(bool p_current = false, const String &p_custom = "");
+	void _run_native(const Ref<EditorExportPreset> &p_preset);
 
 	void _save_optimized();
 	void _import_action(const String &p_action);

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -53,7 +53,7 @@ Error EditorRun::run(const String &p_scene, const String &p_custom_args, const L
 	}
 
 	args.push_back("--remote-debug");
-	args.push_back(remote_host + ":" + String::num(remote_port));
+	args.push_back("tcp://" + remote_host + ":" + String::num(remote_port));
 
 	args.push_back("--allow_focus_steal_pid");
 	args.push_back(itos(OS::get_singleton()->get_process_id()));

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -133,7 +133,7 @@ void EditorRunNative::_run_native(int p_idx, int p_platform) {
 		return;
 	}
 
-	emit_signal("native_run");
+	emit_signal("native_run", preset);
 
 	int flags = 0;
 
@@ -160,7 +160,7 @@ void EditorRunNative::resume_run_native() {
 
 void EditorRunNative::_bind_methods() {
 
-	ADD_SIGNAL(MethodInfo("native_run"));
+	ADD_SIGNAL(MethodInfo("native_run", PropertyInfo(Variant::OBJECT, "preset", PROPERTY_HINT_RESOURCE_TYPE, "EditorExportPreset")));
 }
 
 bool EditorRunNative::is_deploy_debug_remote_enabled() const {

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -32,11 +32,14 @@
 
 #include "core/os/keyboard.h"
 #include "editor/debugger/editor_debugger_node.h"
+#include "editor/debugger/editor_debugger_server.h"
 #include "editor/editor_node.h"
 #include "editor/fileserver/editor_file_server.h"
 #include "scene/gui/menu_button.h"
 
 DebuggerEditorPlugin::DebuggerEditorPlugin(EditorNode *p_editor, MenuButton *p_debug_menu) {
+	EditorDebuggerServer::initialize();
+
 	ED_SHORTCUT("debugger/step_into", TTR("Step Into"), KEY_F11);
 	ED_SHORTCUT("debugger/step_over", TTR("Step Over"), KEY_F10);
 	ED_SHORTCUT("debugger/break", TTR("Break"));
@@ -96,6 +99,7 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(EditorNode *p_editor, MenuButton *p_d
 }
 
 DebuggerEditorPlugin::~DebuggerEditorPlugin() {
+	EditorDebuggerServer::deinitialize();
 	memdelete(file_server);
 }
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -324,7 +324,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  -b, --breakpoints                Breakpoint list as source::line comma-separated pairs, no spaces (use %%20 instead).\n");
 	OS::get_singleton()->print("  --profiling                      Enable profiling in the script debugger.\n");
 	OS::get_singleton()->print("  --gpu-abort                      Abort on GPU errors (usually validation layer errors), may help see the problem if your system freezes.\n");
-	OS::get_singleton()->print("  --remote-debug <address>         Remote debug (<host/IP>:<port> address).\n");
+	OS::get_singleton()->print("  --remote-debug <uri>             Remote debug (<protocol>://<host/IP>[:<port>], e.g. tcp://127.0.0.1:6007).\n");
 #if defined(DEBUG_ENABLED) && !defined(SERVER_ENABLED)
 	OS::get_singleton()->print("  --debug-collisions               Show collision shapes when running the scene.\n");
 	OS::get_singleton()->print("  --debug-navigation               Show navigation polygons when running the scene.\n");
@@ -844,11 +844,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			if (I->next()) {
 
 				debug_uri = I->next()->get();
-				if (debug_uri.find(":") == -1) { // wrong address
-					OS::get_singleton()->print("Invalid debug host address, it should be of the form <host/IP>:<port>.\n");
+				if (debug_uri.find("://") == -1) { // wrong address
+					OS::get_singleton()->print("Invalid debug host address, it should be of the form <protocol>://<host/IP>:<port>.\n");
 					goto error;
 				}
-				debug_uri = "tcp://" + debug_uri; // will support multiple protocols eventually.
 				N = I->next()->next();
 			} else {
 				OS::get_singleton()->print("Missing remote debug host address, aborting.\n");

--- a/misc/dist/html/fixed-size.html
+++ b/misc/dist/html/fixed-size.html
@@ -232,6 +232,7 @@ $GODOT_HEAD_INCLUDE
 
 			const EXECUTABLE_NAME = '$GODOT_BASENAME';
 			const MAIN_PACK = '$GODOT_BASENAME.pck';
+			const EXTRA_ARGS = JSON.parse('$GODOT_ARGS');
 			const DEBUG_ENABLED = $GODOT_DEBUG_ENABLED;
 			const INDETERMINATE_STATUS_STEP_MS = 100;
 
@@ -382,7 +383,7 @@ $GODOT_HEAD_INCLUDE
 			} else {
 				setStatusMode('indeterminate');
 				engine.setCanvas(canvas);
-				engine.startGame(EXECUTABLE_NAME, MAIN_PACK).then(() => {
+				engine.startGame(EXECUTABLE_NAME, MAIN_PACK, EXTRA_ARGS).then(() => {
 					setStatusMode('hidden');
 					initializing = false;
 				}, displayFailureNotice);

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -145,6 +145,7 @@ $GODOT_HEAD_INCLUDE
 
 			const EXECUTABLE_NAME = '$GODOT_BASENAME';
 			const MAIN_PACK = '$GODOT_BASENAME.pck';
+			const EXTRA_ARGS = JSON.parse('$GODOT_ARGS');
 			const INDETERMINATE_STATUS_STEP_MS = 100;
 
 			var canvas = document.getElementById('canvas');
@@ -254,7 +255,7 @@ $GODOT_HEAD_INCLUDE
 			} else {
 				setStatusMode('indeterminate');
 				engine.setCanvas(canvas);
-				engine.startGame(EXECUTABLE_NAME, MAIN_PACK).then(() => {
+				engine.startGame(EXECUTABLE_NAME, MAIN_PACK, EXTRA_ARGS).then(() => {
 					setStatusMode('hidden');
 					initializing = false;
 				}, displayFailureNotice);

--- a/modules/websocket/editor_debugger_server_websocket.cpp
+++ b/modules/websocket/editor_debugger_server_websocket.cpp
@@ -1,0 +1,92 @@
+/*************************************************************************/
+/*  script_editor_debugger_websocket.cpp                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor_debugger_server_websocket.h"
+
+#include "core/project_settings.h"
+#include "editor/editor_settings.h"
+#include "modules/websocket/remote_debugger_peer_websocket.h"
+
+void EditorDebuggerServerWebSocket::_peer_connected(int p_id, String _protocol) {
+	pending_peers.push_back(p_id);
+}
+
+void EditorDebuggerServerWebSocket::_peer_disconnected(int p_id, bool p_was_clean) {
+	if (pending_peers.find(p_id))
+		pending_peers.erase(p_id);
+}
+
+void EditorDebuggerServerWebSocket::poll() {
+	server->poll();
+}
+
+Error EditorDebuggerServerWebSocket::start() {
+	int remote_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
+	Vector<String> protocols;
+	protocols.push_back("binary"); // compatibility with EMSCRIPTEN TCP-to-WebSocket layer.
+	return server->listen(remote_port, protocols);
+}
+
+void EditorDebuggerServerWebSocket::stop() {
+	server->stop();
+	pending_peers.clear();
+}
+
+bool EditorDebuggerServerWebSocket::is_active() const {
+	return server->is_listening();
+}
+
+bool EditorDebuggerServerWebSocket::is_connection_available() const {
+	return pending_peers.size() > 0;
+}
+
+Ref<RemoteDebuggerPeer> EditorDebuggerServerWebSocket::take_connection() {
+	ERR_FAIL_COND_V(!is_connection_available(), Ref<RemoteDebuggerPeer>());
+	RemoteDebuggerPeer *peer = memnew(RemoteDebuggerPeerWebSocket(server->get_peer(pending_peers[0])));
+	pending_peers.pop_front();
+	return peer;
+}
+
+EditorDebuggerServerWebSocket::EditorDebuggerServerWebSocket() {
+	server = Ref<WebSocketServer>(WebSocketServer::create());
+	int max_pkts = (int)GLOBAL_GET("network/limits/debugger/max_queued_messages");
+	server->set_buffers(8192, max_pkts, 8192, max_pkts);
+	server->connect("client_connected", callable_mp(this, &EditorDebuggerServerWebSocket::_peer_connected));
+	server->connect("client_disconnected", callable_mp(this, &EditorDebuggerServerWebSocket::_peer_disconnected));
+}
+
+EditorDebuggerServerWebSocket::~EditorDebuggerServerWebSocket() {
+	stop();
+}
+
+EditorDebuggerServer *EditorDebuggerServerWebSocket::create(const String &p_protocol) {
+	ERR_FAIL_COND_V(p_protocol != "ws://", NULL);
+	return memnew(EditorDebuggerServerWebSocket);
+}

--- a/modules/websocket/emws_client.cpp
+++ b/modules/websocket/emws_client.cpp
@@ -231,8 +231,9 @@ Error EMWSClient::set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffe
 }
 
 EMWSClient::EMWSClient() {
-	_in_buf_size = nearest_shift((int)GLOBAL_GET(WSC_IN_BUF) - 1) + 10;
-	_in_pkt_size = nearest_shift((int)GLOBAL_GET(WSC_IN_PKT) - 1);
+	_in_buf_size = DEF_BUF_SHIFT;
+	_in_pkt_size = DEF_PKT_SHIFT;
+
 	_is_connecting = false;
 	_peer = Ref<EMWSPeer>(memnew(EMWSPeer));
 	/* clang-format off */

--- a/modules/websocket/register_types.cpp
+++ b/modules/websocket/register_types.cpp
@@ -42,22 +42,6 @@
 #endif
 
 void register_websocket_types() {
-#define _SET_HINT(NAME, _VAL_, _MAX_) \
-	GLOBAL_DEF(NAME, _VAL_);          \
-	ProjectSettings::get_singleton()->set_custom_property_info(NAME, PropertyInfo(Variant::INT, NAME, PROPERTY_HINT_RANGE, "2," #_MAX_ ",1,or_greater"));
-
-	// Client buffers project settings
-	_SET_HINT(WSC_IN_BUF, 64, 4096);
-	_SET_HINT(WSC_IN_PKT, 1024, 16384);
-	_SET_HINT(WSC_OUT_BUF, 64, 4096);
-	_SET_HINT(WSC_OUT_PKT, 1024, 16384);
-
-	// Server buffers project settings
-	_SET_HINT(WSS_IN_BUF, 64, 4096);
-	_SET_HINT(WSS_IN_PKT, 1024, 16384);
-	_SET_HINT(WSS_OUT_BUF, 64, 4096);
-	_SET_HINT(WSS_OUT_PKT, 1024, 16384);
-
 #ifdef JAVASCRIPT_ENABLED
 	EMWSPeer::make_default();
 	EMWSClient::make_default();

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -1,0 +1,134 @@
+/*************************************************************************/
+/*  script_debugger_websocket.cpp                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "remote_debugger_peer_websocket.h"
+
+#include "core/project_settings.h"
+
+Error RemoteDebuggerPeerWebSocket::connect_to_host(const String &p_uri) {
+
+	Vector<String> protocols;
+	protocols.push_back("binary"); // Compatibility for emscripten TCP-to-WebSocket.
+
+	ws_client->connect_to_url(p_uri, protocols);
+	ws_client->poll();
+
+	if (ws_client->get_connection_status() == WebSocketClient::CONNECTION_DISCONNECTED) {
+
+		ERR_PRINT("Remote Debugger: Unable to connect. Status: " + String::num(ws_client->get_connection_status()) + ".");
+		return FAILED;
+	}
+
+	ws_peer = ws_client->get_peer(1);
+
+	return OK;
+}
+
+bool RemoteDebuggerPeerWebSocket::is_peer_connected() {
+	return ws_peer.is_valid() && ws_peer->is_connected_to_host();
+}
+
+void RemoteDebuggerPeerWebSocket::poll() {
+	ws_client->poll();
+
+	while (ws_peer->is_connected_to_host() && ws_peer->get_available_packet_count() > 0 && in_queue.size() < max_queued_messages) {
+		Variant var;
+		Error err = ws_peer->get_var(var);
+		ERR_CONTINUE(err != OK);
+		ERR_CONTINUE(var.get_type() != Variant::ARRAY);
+		in_queue.push_back(var);
+	}
+
+	while (ws_peer->is_connected_to_host() && out_queue.size() > 0) {
+		Array var = out_queue[0];
+		Error err = ws_peer->put_var(var);
+		ERR_BREAK(err != OK); // Peer buffer full?
+		out_queue.pop_front();
+	}
+}
+
+int RemoteDebuggerPeerWebSocket::get_max_message_size() const {
+	return 8 << 20; // 8 Mib
+}
+
+bool RemoteDebuggerPeerWebSocket::has_message() {
+	return in_queue.size() > 0;
+}
+
+Array RemoteDebuggerPeerWebSocket::get_message() {
+	ERR_FAIL_COND_V(in_queue.size() < 1, Array());
+	Array msg = in_queue[0];
+	in_queue.pop_front();
+	return msg;
+}
+
+Error RemoteDebuggerPeerWebSocket::put_message(const Array &p_arr) {
+	if (out_queue.size() >= max_queued_messages)
+		return ERR_OUT_OF_MEMORY;
+	out_queue.push_back(p_arr);
+	return OK;
+}
+
+void RemoteDebuggerPeerWebSocket::close() {
+	if (ws_peer.is_valid()) {
+		ws_peer.unref();
+	}
+	ws_client->disconnect_from_host();
+}
+
+bool RemoteDebuggerPeerWebSocket::can_block() const {
+#ifdef JAVASCRIPT_ENABLED
+	return false;
+#else
+	return true;
+#endif
+}
+
+RemoteDebuggerPeerWebSocket::RemoteDebuggerPeerWebSocket(Ref<WebSocketPeer> p_peer) {
+#ifdef JAVASCRIPT_ENABLED
+	ws_client = Ref<WebSocketClient>(memnew(EMWSClient));
+#else
+	ws_client = Ref<WebSocketClient>(memnew(WSLClient));
+#endif
+	max_queued_messages = (int)GLOBAL_GET("network/limits/debugger/max_queued_messages");
+	ws_client->set_buffers(8192, max_queued_messages, 8192, max_queued_messages);
+	ws_peer = p_peer;
+}
+
+RemoteDebuggerPeer *RemoteDebuggerPeerWebSocket::create(const String &p_uri) {
+	ERR_FAIL_COND_V(!p_uri.begins_with("ws://") && !p_uri.begins_with("wss://"), NULL);
+	RemoteDebuggerPeerWebSocket *peer = memnew(RemoteDebuggerPeerWebSocket);
+	Error err = peer->connect_to_host(p_uri);
+	if (err != OK) {
+		memdelete(peer);
+		return NULL;
+	}
+	return peer;
+}

--- a/modules/websocket/websocket_macros.h
+++ b/modules/websocket/websocket_macros.h
@@ -31,15 +31,9 @@
 #ifndef WEBSOCKETMACTOS_H
 #define WEBSOCKETMACTOS_H
 
-#define WSC_IN_BUF "network/limits/websocket_client/max_in_buffer_kb"
-#define WSC_IN_PKT "network/limits/websocket_client/max_in_packets"
-#define WSC_OUT_BUF "network/limits/websocket_client/max_out_buffer_kb"
-#define WSC_OUT_PKT "network/limits/websocket_client/max_out_packets"
-
-#define WSS_IN_BUF "network/limits/websocket_server/max_in_buffer_kb"
-#define WSS_IN_PKT "network/limits/websocket_server/max_in_packets"
-#define WSS_OUT_BUF "network/limits/websocket_server/max_out_buffer_kb"
-#define WSS_OUT_PKT "network/limits/websocket_server/max_out_packets"
+// Defaults per peer buffers, 1024 packets with a shared 65536 bytes payload.
+#define DEF_PKT_SHIFT 10
+#define DEF_BUF_SHIFT 16
 
 /* clang-format off */
 #define GDCICLASS(CNAME) \

--- a/modules/websocket/wsl_client.cpp
+++ b/modules/websocket/wsl_client.cpp
@@ -336,10 +336,10 @@ Error WSLClient::set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer
 }
 
 WSLClient::WSLClient() {
-	_in_buf_size = nearest_shift((int)GLOBAL_GET(WSC_IN_BUF) - 1) + 10;
-	_in_pkt_size = nearest_shift((int)GLOBAL_GET(WSC_IN_PKT) - 1);
-	_out_buf_size = nearest_shift((int)GLOBAL_GET(WSC_OUT_BUF) - 1) + 10;
-	_out_pkt_size = nearest_shift((int)GLOBAL_GET(WSC_OUT_PKT) - 1);
+	_in_buf_size = DEF_BUF_SHIFT;
+	_in_pkt_size = DEF_PKT_SHIFT;
+	_out_buf_size = DEF_BUF_SHIFT;
+	_out_pkt_size = DEF_PKT_SHIFT;
 
 	_peer.instance();
 	_tcp.instance();

--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -298,10 +298,10 @@ Error WSLServer::set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer
 }
 
 WSLServer::WSLServer() {
-	_in_buf_size = nearest_shift((int)GLOBAL_GET(WSS_IN_BUF) - 1) + 10;
-	_in_pkt_size = nearest_shift((int)GLOBAL_GET(WSS_IN_PKT) - 1);
-	_out_buf_size = nearest_shift((int)GLOBAL_GET(WSS_OUT_BUF) - 1) + 10;
-	_out_pkt_size = nearest_shift((int)GLOBAL_GET(WSS_OUT_PKT) - 1);
+	_in_buf_size = DEF_BUF_SHIFT;
+	_in_pkt_size = DEF_PKT_SHIFT;
+	_out_buf_size = DEF_BUF_SHIFT;
+	_out_pkt_size = DEF_PKT_SHIFT;
 	_server.instance();
 }
 

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -28,6 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#include "core/io/json.h"
 #include "core/io/tcp_server.h"
 #include "core/io/zip_io.h"
 #include "editor/editor_export.h"
@@ -198,7 +199,7 @@ class EditorExportPlatformJavaScript : public EditorExportPlatform {
 	Ref<ImageTexture> stop_icon;
 	int menu_options;
 
-	void _fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug);
+	void _fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, int p_flags);
 
 private:
 	Ref<EditorHTTPServer> server;
@@ -238,15 +239,21 @@ public:
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) {
 	}
 
+	String get_debug_protocol() const { return "ws://"; }
+
 	EditorExportPlatformJavaScript();
 	~EditorExportPlatformJavaScript();
 };
 
-void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug) {
+void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t> &p_html, const Ref<EditorExportPreset> &p_preset, const String &p_name, bool p_debug, int p_flags) {
 
 	String str_template = String::utf8(reinterpret_cast<const char *>(p_html.ptr()), p_html.size());
 	String str_export;
 	Vector<String> lines = str_template.split("\n");
+	Vector<String> flags;
+	String flags_json;
+	gen_export_flags(flags, p_flags);
+	flags_json = JSON::print(flags);
 
 	for (int i = 0; i < lines.size(); i++) {
 
@@ -255,6 +262,7 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t> &p_html, const Re
 		current_line = current_line.replace("$GODOT_PROJECT_NAME", ProjectSettings::get_singleton()->get_setting("application/config/name"));
 		current_line = current_line.replace("$GODOT_HEAD_INCLUDE", p_preset->get("html/head_include"));
 		current_line = current_line.replace("$GODOT_DEBUG_ENABLED", p_debug ? "true" : "false");
+		current_line = current_line.replace("$GODOT_ARGS", flags_json);
 		str_export += current_line + "\n";
 	}
 
@@ -430,7 +438,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 			if (!custom_html.empty()) {
 				continue;
 			}
-			_fix_html(data, p_preset, p_path.get_file().get_basename(), p_debug);
+			_fix_html(data, p_preset, p_path.get_file().get_basename(), p_debug, p_flags);
 			file = p_path.get_file();
 
 		} else if (file == "godot.js") {
@@ -469,7 +477,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 		buf.resize(f->get_len());
 		f->get_buffer(buf.ptrw(), buf.size());
 		memdelete(f);
-		_fix_html(buf, p_preset, p_path.get_file().get_basename(), p_debug);
+		_fix_html(buf, p_preset, p_path.get_file().get_basename(), p_debug, p_flags);
 
 		f = FileAccess::open(p_path, FileAccess::WRITE);
 		if (!f) {

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -30,12 +30,18 @@
 
 #include "os_javascript.h"
 
+#include "core/debugger/engine_debugger.h"
 #include "core/io/file_access_buffered_fa.h"
 #include "core/io/json.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
 #include "main/main.h"
+#include "modules/modules_enabled.gen.h"
 #include "platform/javascript/display_server_javascript.h"
+
+#ifdef MODULE_WEBSOCKET_ENABLED
+#include "modules/websocket/remote_debugger_peer_websocket.h"
+#endif
 
 #include <emscripten.h>
 #include <stdlib.h>
@@ -67,6 +73,11 @@ void OS_JavaScript::initialize() {
 	OS_Unix::initialize_core();
 	FileAccess::make_default<FileAccessBufferedFA<FileAccessUnix>>(FileAccess::ACCESS_RESOURCES);
 	DisplayServerJavaScript::register_javascript_driver();
+
+#ifdef MODULE_WEBSOCKET_ENABLED
+	EngineDebugger::register_uri_handler("ws://", RemoteDebuggerPeerWebSocket::create);
+	EngineDebugger::register_uri_handler("wss://", RemoteDebuggerPeerWebSocket::create);
+#endif
 
 	char locale_ptr[16];
 	/* clang-format off */


### PR DESCRIPTION
Closes #33925 . Much cleaner after the refactor.

In this PR:

-  Remove WebSocket defaults from project settings.
   Can already be manually set, let's not pollute them further (and it was giving troubles with this PR due to the fact that modules project settings are inited too late).
- Platforms can now register additional URI/protocol handlers for debugging. (see `EngineDebugger::register_uri_handler` and `EditorDebuggerServer::register_protocol_handler`)
- `EditorExportPlatform` can now specify the debug protocol (so both the editor and the exported game can match the desired protocol).
- Add new `RemoteDebuggerPeerWebSocket` and `EditorDebuggerServerWebsocket` implementation for debugging (a bit less performant than the regular one as it does not use threads but can be used in HTML5).
- HTML5 exports now support additional flags (command line) to be passed via `startGame`.

@punto- this should allow to create an implementation for `iOS` as we discussed at GodotCon, let me know if you see there are still limitations.

Note: to enable debug for HTML5 native run, check the `deploy with remote debug` option in the `debug` menu.