### PR TITLE
Prevent joypad button input dropdown going out of dialog

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -2006,6 +2006,8 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	device_index_label = l;
 
 	device_index = memnew(OptionButton);
+	device_index->set_clip_text(true);
+
 	vbc_right->add_child(device_index);
 
 	setting = false;


### PR DESCRIPTION
Fixes #37096

Prevent Joypad button name going outside dialog when editing button index for a device in Project settings.