### PR TITLE
Style: Set clang-format Standard to Cpp11

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -112,11 +112,11 @@ UseTab:          Always
 ---
 ### C++ specific config ###
 Language:        Cpp
-Standard:        Cpp03
+Standard:        Cpp11
 ---
 ### ObjC specific config ###
 Language:        ObjC
-Standard:        Cpp03
+Standard:        Cpp11
 ObjCBlockIndentWidth: 4
 # ObjCSpaceAfterProperty: false
 # ObjCSpaceBeforeProtocolList: true

--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -964,10 +964,10 @@ void _OS::print_all_textures_by_size() {
 	List<_OSCoreBindImg> imgs;
 	int total = 0;
 	{
-		List<Ref<Resource> > rsrc;
+		List<Ref<Resource>> rsrc;
 		ResourceCache::get_cached_resources(&rsrc);
 
-		for (List<Ref<Resource> >::Element *E = rsrc.front(); E; E = E->next()) {
+		for (List<Ref<Resource>>::Element *E = rsrc.front(); E; E = E->next()) {
 
 			if (!E->get()->is_class("ImageTexture"))
 				continue;
@@ -998,13 +998,13 @@ void _OS::print_resources_by_type(const Vector<String> &p_types) {
 
 	Map<String, int> type_count;
 
-	List<Ref<Resource> > resources;
+	List<Ref<Resource>> resources;
 	ResourceCache::get_cached_resources(&resources);
 
-	List<Ref<Resource> > rsrc;
+	List<Ref<Resource>> rsrc;
 	ResourceCache::get_cached_resources(&rsrc);
 
-	for (List<Ref<Resource> >::Element *E = rsrc.front(); E; E = E->next()) {
+	for (List<Ref<Resource>>::Element *E = rsrc.front(); E; E = E->next()) {
 
 		Ref<Resource> r = E->get();
 
@@ -1633,7 +1633,7 @@ Vector<Vector3> _Geometry::clip_polygon(const Vector<Vector3> &p_points, const P
 
 Array _Geometry::merge_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
 
-	Vector<Vector<Point2> > polys = Geometry::merge_polygons_2d(p_polygon_a, p_polygon_b);
+	Vector<Vector<Point2>> polys = Geometry::merge_polygons_2d(p_polygon_a, p_polygon_b);
 
 	Array ret;
 
@@ -1645,7 +1645,7 @@ Array _Geometry::merge_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vec
 
 Array _Geometry::clip_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
 
-	Vector<Vector<Point2> > polys = Geometry::clip_polygons_2d(p_polygon_a, p_polygon_b);
+	Vector<Vector<Point2>> polys = Geometry::clip_polygons_2d(p_polygon_a, p_polygon_b);
 
 	Array ret;
 
@@ -1657,7 +1657,7 @@ Array _Geometry::clip_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vect
 
 Array _Geometry::intersect_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
 
-	Vector<Vector<Point2> > polys = Geometry::intersect_polygons_2d(p_polygon_a, p_polygon_b);
+	Vector<Vector<Point2>> polys = Geometry::intersect_polygons_2d(p_polygon_a, p_polygon_b);
 
 	Array ret;
 
@@ -1669,7 +1669,7 @@ Array _Geometry::intersect_polygons_2d(const Vector<Vector2> &p_polygon_a, const
 
 Array _Geometry::exclude_polygons_2d(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
 
-	Vector<Vector<Point2> > polys = Geometry::exclude_polygons_2d(p_polygon_a, p_polygon_b);
+	Vector<Vector<Point2>> polys = Geometry::exclude_polygons_2d(p_polygon_a, p_polygon_b);
 
 	Array ret;
 
@@ -1681,7 +1681,7 @@ Array _Geometry::exclude_polygons_2d(const Vector<Vector2> &p_polygon_a, const V
 
 Array _Geometry::clip_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
 
-	Vector<Vector<Point2> > polys = Geometry::clip_polyline_with_polygon_2d(p_polyline, p_polygon);
+	Vector<Vector<Point2>> polys = Geometry::clip_polyline_with_polygon_2d(p_polyline, p_polygon);
 
 	Array ret;
 
@@ -1693,7 +1693,7 @@ Array _Geometry::clip_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline
 
 Array _Geometry::intersect_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
 
-	Vector<Vector<Point2> > polys = Geometry::intersect_polyline_with_polygon_2d(p_polyline, p_polygon);
+	Vector<Vector<Point2>> polys = Geometry::intersect_polyline_with_polygon_2d(p_polyline, p_polygon);
 
 	Array ret;
 
@@ -1705,7 +1705,7 @@ Array _Geometry::intersect_polyline_with_polygon_2d(const Vector<Vector2> &p_pol
 
 Array _Geometry::offset_polygon_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type) {
 
-	Vector<Vector<Point2> > polys = Geometry::offset_polygon_2d(p_polygon, p_delta, Geometry::PolyJoinType(p_join_type));
+	Vector<Vector<Point2>> polys = Geometry::offset_polygon_2d(p_polygon, p_delta, Geometry::PolyJoinType(p_join_type));
 
 	Array ret;
 
@@ -1717,7 +1717,7 @@ Array _Geometry::offset_polygon_2d(const Vector<Vector2> &p_polygon, real_t p_de
 
 Array _Geometry::offset_polyline_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
 
-	Vector<Vector<Point2> > polys = Geometry::offset_polyline_2d(p_polygon, p_delta, Geometry::PolyJoinType(p_join_type), Geometry::PolyEndType(p_end_type));
+	Vector<Vector<Point2>> polys = Geometry::offset_polyline_2d(p_polygon, p_delta, Geometry::PolyJoinType(p_join_type), Geometry::PolyEndType(p_end_type));
 
 	Array ret;
 

--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -1401,7 +1401,7 @@ void ClassDB::get_extensions_for_type(const StringName &p_class, List<String> *p
 	}
 }
 
-HashMap<StringName, HashMap<StringName, Variant> > ClassDB::default_values;
+HashMap<StringName, HashMap<StringName, Variant>> ClassDB::default_values;
 Set<StringName> ClassDB::default_values_cached;
 
 Variant ClassDB::class_get_default_property_value(const StringName &p_class, const StringName &p_property, bool *r_valid) {

--- a/core/class_db.h
+++ b/core/class_db.h
@@ -119,7 +119,7 @@ public:
 		void *class_ptr;
 		HashMap<StringName, MethodBind *> method_map;
 		HashMap<StringName, int> constant_map;
-		HashMap<StringName, List<StringName> > enum_map;
+		HashMap<StringName, List<StringName>> enum_map;
 		HashMap<StringName, MethodInfo> signal_map;
 		List<PropertyInfo> property_list;
 #ifdef DEBUG_METHODS_ENABLED
@@ -160,7 +160,7 @@ public:
 
 	static void _add_class2(const StringName &p_class, const StringName &p_inherits);
 
-	static HashMap<StringName, HashMap<StringName, Variant> > default_values;
+	static HashMap<StringName, HashMap<StringName, Variant>> default_values;
 	static Set<StringName> default_values_cached;
 
 public:

--- a/core/compressed_translation.cpp
+++ b/core/compressed_translation.cpp
@@ -50,8 +50,8 @@ void PHashTranslation::generate(const Ref<Translation> &p_from) {
 
 	int size = Math::larger_prime(keys.size());
 
-	Vector<Vector<Pair<int, CharString> > > buckets;
-	Vector<Map<uint32_t, int> > table;
+	Vector<Vector<Pair<int, CharString>>> buckets;
+	Vector<Map<uint32_t, int>> table;
 	Vector<uint32_t> hfunc_table;
 	Vector<_PHashTranslationCmp> compressed;
 
@@ -109,7 +109,7 @@ void PHashTranslation::generate(const Ref<Translation> &p_from) {
 
 	for (int i = 0; i < size; i++) {
 
-		const Vector<Pair<int, CharString> > &b = buckets[i];
+		const Vector<Pair<int, CharString>> &b = buckets[i];
 		Map<uint32_t, int> &t = table.write[i];
 
 		if (b.size() == 0)

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -262,14 +262,14 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 
 			if (line.get_slice_count(" ") <= 1) {
 
-				const Map<int, Set<StringName> > &breakpoints = script_debugger->get_breakpoints();
+				const Map<int, Set<StringName>> &breakpoints = script_debugger->get_breakpoints();
 				if (breakpoints.size() == 0) {
 					print_line("No Breakpoints.");
 					continue;
 				}
 
 				print_line("Breakpoint(s): " + itos(breakpoints.size()));
-				for (Map<int, Set<StringName> >::Element *E = breakpoints.front(); E; E = E->next()) {
+				for (Map<int, Set<StringName>>::Element *E = breakpoints.front(); E; E = E->next()) {
 					print_line("\t" + String(E->value().front()->get()) + ":" + itos(E->key()));
 				}
 

--- a/core/debugger/script_debugger.h
+++ b/core/debugger/script_debugger.h
@@ -45,7 +45,7 @@ class ScriptDebugger {
 	int depth = -1;
 	bool skip_breakpoints = false;
 
-	Map<int, Set<StringName> > breakpoints;
+	Map<int, Set<StringName>> breakpoints;
 
 	ScriptLanguage *break_lang = NULL;
 	Vector<StackInfo> error_stack_info;
@@ -67,7 +67,7 @@ public:
 	bool is_breakpoint(int p_line, const StringName &p_source) const;
 	bool is_breakpoint_line(int p_line) const;
 	void clear_breakpoints();
-	const Map<int, Set<StringName> > &get_breakpoints() const { return breakpoints; }
+	const Map<int, Set<StringName>> &get_breakpoints() const { return breakpoints; }
 
 	void debug(ScriptLanguage *p_lang, bool p_can_continue = true, bool p_is_error_breakpoint = false);
 	ScriptLanguage *get_break_language() const;

--- a/core/input_map.cpp
+++ b/core/input_map.cpp
@@ -99,9 +99,9 @@ List<StringName> InputMap::get_actions() const {
 	return actions;
 }
 
-List<Ref<InputEvent> >::Element *InputMap::_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength) const {
+List<Ref<InputEvent>>::Element *InputMap::_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength) const {
 
-	for (List<Ref<InputEvent> >::Element *E = p_action.inputs.front(); E; E = E->next()) {
+	for (List<Ref<InputEvent>>::Element *E = p_action.inputs.front(); E; E = E->next()) {
 
 		const Ref<InputEvent> e = E->get();
 
@@ -151,7 +151,7 @@ void InputMap::action_erase_event(const StringName &p_action, const Ref<InputEve
 
 	ERR_FAIL_COND_MSG(!input_map.has(p_action), "Request for nonexistent InputMap action '" + String(p_action) + "'.");
 
-	List<Ref<InputEvent> >::Element *E = _find_event(input_map[p_action], p_event);
+	List<Ref<InputEvent>>::Element *E = _find_event(input_map[p_action], p_event);
 	if (E)
 		input_map[p_action].inputs.erase(E);
 }
@@ -166,9 +166,9 @@ void InputMap::action_erase_events(const StringName &p_action) {
 Array InputMap::_get_action_list(const StringName &p_action) {
 
 	Array ret;
-	const List<Ref<InputEvent> > *al = get_action_list(p_action);
+	const List<Ref<InputEvent>> *al = get_action_list(p_action);
 	if (al) {
-		for (const List<Ref<InputEvent> >::Element *E = al->front(); E; E = E->next()) {
+		for (const List<Ref<InputEvent>>::Element *E = al->front(); E; E = E->next()) {
 
 			ret.push_back(E->get());
 		}
@@ -177,7 +177,7 @@ Array InputMap::_get_action_list(const StringName &p_action) {
 	return ret;
 }
 
-const List<Ref<InputEvent> > *InputMap::get_action_list(const StringName &p_action) {
+const List<Ref<InputEvent>> *InputMap::get_action_list(const StringName &p_action) {
 
 	const Map<StringName, Action>::Element *E = input_map.find(p_action);
 	if (!E)
@@ -205,7 +205,7 @@ bool InputMap::event_get_action_status(const Ref<InputEvent> &p_event, const Str
 
 	bool pressed;
 	float strength;
-	List<Ref<InputEvent> >::Element *event = _find_event(E->get(), p_event, &pressed, &strength);
+	List<Ref<InputEvent>>::Element *event = _find_event(E->get(), p_event, &pressed, &strength);
 	if (event != NULL) {
 		if (p_pressed != NULL)
 			*p_pressed = pressed;

--- a/core/input_map.h
+++ b/core/input_map.h
@@ -47,7 +47,7 @@ public:
 	struct Action {
 		int id;
 		float deadzone;
-		List<Ref<InputEvent> > inputs;
+		List<Ref<InputEvent>> inputs;
 	};
 
 private:
@@ -55,7 +55,7 @@ private:
 
 	mutable Map<StringName, Action> input_map;
 
-	List<Ref<InputEvent> >::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool *p_pressed = NULL, float *p_strength = NULL) const;
+	List<Ref<InputEvent>>::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool *p_pressed = NULL, float *p_strength = NULL) const;
 
 	Array _get_action_list(const StringName &p_action);
 	Array _get_actions();
@@ -77,7 +77,7 @@ public:
 	void action_erase_event(const StringName &p_action, const Ref<InputEvent> &p_event);
 	void action_erase_events(const StringName &p_action);
 
-	const List<Ref<InputEvent> > *get_action_list(const StringName &p_action);
+	const List<Ref<InputEvent>> *get_action_list(const StringName &p_action);
 	bool event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action) const;
 	bool event_get_action_status(const Ref<InputEvent> &p_event, const StringName &p_action, bool *p_pressed = NULL, float *p_strength = NULL) const;
 

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -107,7 +107,7 @@ bool ConfigFile::has_section_key(const String &p_section, const String &p_key) c
 
 void ConfigFile::get_sections(List<String> *r_sections) const {
 
-	for (OrderedHashMap<String, OrderedHashMap<String, Variant> >::ConstElement E = values.front(); E; E = E.next()) {
+	for (OrderedHashMap<String, OrderedHashMap<String, Variant>>::ConstElement E = values.front(); E; E = E.next()) {
 		r_sections->push_back(E.key());
 	}
 }
@@ -187,7 +187,7 @@ Error ConfigFile::save_encrypted_pass(const String &p_path, const String &p_pass
 
 Error ConfigFile::_internal_save(FileAccess *file) {
 
-	for (OrderedHashMap<String, OrderedHashMap<String, Variant> >::Element E = values.front(); E; E = E.next()) {
+	for (OrderedHashMap<String, OrderedHashMap<String, Variant>>::Element E = values.front(); E; E = E.next()) {
 
 		if (E != values.front())
 			file->store_string("\n");

--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -40,7 +40,7 @@ class ConfigFile : public Reference {
 
 	GDCLASS(ConfigFile, Reference);
 
-	OrderedHashMap<String, OrderedHashMap<String, Variant> > values;
+	OrderedHashMap<String, OrderedHashMap<String, Variant>> values;
 
 	PackedStringArray _get_sections() const;
 	PackedStringArray _get_section_keys(const String &p_section) const;

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -35,12 +35,12 @@
 #include "core/os/dir_access.h"
 #include "core/project_settings.h"
 
-static Map<String, Vector<uint8_t> > *files = NULL;
+static Map<String, Vector<uint8_t>> *files = NULL;
 
 void FileAccessMemory::register_file(String p_name, Vector<uint8_t> p_data) {
 
 	if (!files) {
-		files = memnew((Map<String, Vector<uint8_t> >));
+		files = memnew((Map<String, Vector<uint8_t>>));
 	}
 
 	String name;
@@ -89,7 +89,7 @@ Error FileAccessMemory::_open(const String &p_path, int p_mode_flags) {
 	String name = fix_path(p_path);
 	//name = DirAccess::normalize_path(name);
 
-	Map<String, Vector<uint8_t> >::Element *E = files->find(name);
+	Map<String, Vector<uint8_t>>::Element *E = files->find(name);
 	ERR_FAIL_COND_V_MSG(!E, ERR_FILE_NOT_FOUND, "Can't find file '" + p_path + "'.");
 
 	data = E->get().ptrw();

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -350,7 +350,7 @@ Error HTTPClient::poll() {
 							handshaking = true;
 						} else {
 							// We are already handshaking, which means we can use your already active SSL connection
-							ssl = static_cast<Ref<StreamPeerSSL> >(connection);
+							ssl = static_cast<Ref<StreamPeerSSL>>(connection);
 							if (ssl.is_null()) {
 								close();
 								status = STATUS_SSL_HANDSHAKE_ERROR;

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -362,7 +362,7 @@ Ref<ResourceImporter> ResourceFormatImporter::get_importer_by_name(const String 
 	return Ref<ResourceImporter>();
 }
 
-void ResourceFormatImporter::get_importers_for_extension(const String &p_extension, List<Ref<ResourceImporter> > *r_importers) {
+void ResourceFormatImporter::get_importers_for_extension(const String &p_extension, List<Ref<ResourceImporter>> *r_importers) {
 
 	for (int i = 0; i < importers.size(); i++) {
 		List<String> local_exts;
@@ -423,7 +423,7 @@ bool ResourceFormatImporter::are_import_settings_valid(const String &p_path) con
 
 String ResourceFormatImporter::get_import_settings_hash() const {
 
-	Vector<Ref<ResourceImporter> > sorted_importers = importers;
+	Vector<Ref<ResourceImporter>> sorted_importers = importers;
 
 	sorted_importers.sort_custom<SortImporterByName>();
 

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -54,7 +54,7 @@ class ResourceFormatImporter : public ResourceFormatLoader {
 		bool operator()(const Ref<ResourceImporter> &p_a, const Ref<ResourceImporter> &p_b) const;
 	};
 
-	Vector<Ref<ResourceImporter> > importers;
+	Vector<Ref<ResourceImporter>> importers;
 
 public:
 	static ResourceFormatImporter *get_singleton() { return singleton; }
@@ -83,7 +83,7 @@ public:
 	void remove_importer(const Ref<ResourceImporter> &p_importer) { importers.erase(p_importer); }
 	Ref<ResourceImporter> get_importer_by_name(const String &p_name) const;
 	Ref<ResourceImporter> get_importer_by_extension(const String &p_extension) const;
-	void get_importers_for_extension(const String &p_extension, List<Ref<ResourceImporter> > *r_importers);
+	void get_importers_for_extension(const String &p_extension, List<Ref<ResourceImporter>> *r_importers);
 
 	bool are_import_settings_valid(const String &p_path) const;
 	String get_import_settings_hash() const;
@@ -125,7 +125,7 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = NULL, Variant *r_metadata = NULL) = 0;
 
-	virtual Error import_group_file(const String &p_group_file, const Map<String, Map<StringName, Variant> > &p_source_file_options, const Map<String, String> &p_base_paths) { return ERR_UNAVAILABLE; }
+	virtual Error import_group_file(const String &p_group_file, const Map<String, Map<StringName, Variant>> &p_source_file_options, const Map<String, String> &p_base_paths) { return ERR_UNAVAILABLE; }
 	virtual bool are_import_settings_valid(const String &p_path) const { return true; }
 	virtual String get_import_settings_string() const { return String(); }
 };

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1113,7 +1113,7 @@ void ResourceLoader::add_custom_loaders() {
 
 void ResourceLoader::remove_custom_loaders() {
 
-	Vector<Ref<ResourceFormatLoader> > custom_loaders;
+	Vector<Ref<ResourceFormatLoader>> custom_loaders;
 	for (int i = 0; i < loader_count; ++i) {
 		if (loader[i]->get_script_instance()) {
 			custom_loaders.push_back(loader[i]);
@@ -1159,7 +1159,7 @@ int ResourceLoader::thread_suspended_count = 0;
 int ResourceLoader::thread_load_max = 0;
 
 SelfList<Resource>::List ResourceLoader::remapped_list;
-HashMap<String, Vector<String> > ResourceLoader::translation_remaps;
+HashMap<String, Vector<String>> ResourceLoader::translation_remaps;
 HashMap<String, String> ResourceLoader::path_remaps;
 
 ResourceLoaderImport ResourceLoader::import = NULL;

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -90,7 +90,7 @@ private:
 	static void *dep_err_notify_ud;
 	static DependencyErrorNotify dep_err_notify;
 	static bool abort_on_missing_resource;
-	static HashMap<String, Vector<String> > translation_remaps;
+	static HashMap<String, Vector<String>> translation_remaps;
 	static HashMap<String, String> path_remaps;
 
 	static String _path_remap(const String &p_path, bool *r_translation_remapped = NULL);

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -256,7 +256,7 @@ void ResourceSaver::add_custom_savers() {
 
 void ResourceSaver::remove_custom_savers() {
 
-	Vector<Ref<ResourceFormatSaver> > custom_savers;
+	Vector<Ref<ResourceFormatSaver>> custom_savers;
 	for (int i = 0; i < saver_count; ++i) {
 		if (saver[i]->get_script_instance()) {
 			custom_savers.push_back(saver[i]);

--- a/core/list.h
+++ b/core/list.h
@@ -576,7 +576,7 @@ public:
 
 	void sort() {
 
-		sort_custom<Comparator<T> >();
+		sort_custom<Comparator<T>>();
 	}
 
 	template <class C>
@@ -657,7 +657,7 @@ public:
 			idx++;
 		}
 
-		SortArray<Element *, AuxiliaryComparator<C> > sort;
+		SortArray<Element *, AuxiliaryComparator<C>> sort;
 		sort.sort(aux_buffer, s);
 
 		_data->first = aux_buffer[0];

--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -214,9 +214,9 @@ static bool _group_face(_FaceClassify *p_faces, int len, int p_index, int p_grou
 	return true;
 }
 
-Vector<Vector<Face3> > Geometry::separate_objects(Vector<Face3> p_array) {
+Vector<Vector<Face3>> Geometry::separate_objects(Vector<Face3> p_array) {
 
-	Vector<Vector<Face3> > objects;
+	Vector<Vector<Face3>> objects;
 
 	int len = p_array.size();
 
@@ -235,7 +235,7 @@ Vector<Vector<Face3> > Geometry::separate_objects(Vector<Face3> p_array) {
 
 	bool error = _connect_faces(_fcptr, len, -1);
 
-	ERR_FAIL_COND_V_MSG(error, Vector<Vector<Face3> >(), "Invalid geometry.");
+	ERR_FAIL_COND_V_MSG(error, Vector<Vector<Face3>>(), "Invalid geometry.");
 
 	// Group connected faces in separate objects.
 
@@ -679,8 +679,8 @@ Vector<Face3> Geometry::wrap_geometry(Vector<Face3> p_array, real_t *p_error) {
 	return wrapped_faces;
 }
 
-Vector<Vector<Vector2> > Geometry::decompose_polygon_in_convex(Vector<Point2> polygon) {
-	Vector<Vector<Vector2> > decomp;
+Vector<Vector<Vector2>> Geometry::decompose_polygon_in_convex(Vector<Point2> polygon) {
+	Vector<Vector<Vector2>> decomp;
 	List<TriangulatorPoly> in_poly, out_poly;
 
 	TriangulatorPoly inp;
@@ -1076,7 +1076,7 @@ void Geometry::make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_resu
 	r_size = Size2(results[best].max_w, results[best].max_h);
 }
 
-Vector<Vector<Point2> > Geometry::_polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Point2> &p_polypath_a, const Vector<Point2> &p_polypath_b, bool is_a_open) {
+Vector<Vector<Point2>> Geometry::_polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Point2> &p_polypath_a, const Vector<Point2> &p_polypath_b, bool is_a_open) {
 
 	using namespace ClipperLib;
 
@@ -1111,7 +1111,7 @@ Vector<Vector<Point2> > Geometry::_polypaths_do_operation(PolyBooleanOperation p
 		clp.Execute(op, paths); // Works on closed polygons only.
 	}
 	// Have to scale points down now.
-	Vector<Vector<Point2> > polypaths;
+	Vector<Vector<Point2>> polypaths;
 
 	for (Paths::size_type i = 0; i < paths.size(); ++i) {
 		Vector<Vector2> polypath;
@@ -1128,7 +1128,7 @@ Vector<Vector<Point2> > Geometry::_polypaths_do_operation(PolyBooleanOperation p
 	return polypaths;
 }
 
-Vector<Vector<Point2> > Geometry::_polypath_offset(const Vector<Point2> &p_polypath, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
+Vector<Vector<Point2>> Geometry::_polypath_offset(const Vector<Point2> &p_polypath, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
 
 	using namespace ClipperLib;
 
@@ -1162,7 +1162,7 @@ Vector<Vector<Point2> > Geometry::_polypath_offset(const Vector<Point2> &p_polyp
 	co.Execute(paths, p_delta * SCALE_FACTOR); // Inflate/deflate.
 
 	// Have to scale points down now.
-	Vector<Vector<Point2> > polypaths;
+	Vector<Vector<Point2>> polypaths;
 
 	for (Paths::size_type i = 0; i < paths.size(); ++i) {
 		Vector<Vector2> polypath;

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -790,44 +790,44 @@ public:
 		END_ROUND
 	};
 
-	static Vector<Vector<Point2> > merge_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
+	static Vector<Vector<Point2>> merge_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
 
 		return _polypaths_do_operation(OPERATION_UNION, p_polygon_a, p_polygon_b);
 	}
 
-	static Vector<Vector<Point2> > clip_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
+	static Vector<Vector<Point2>> clip_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
 
 		return _polypaths_do_operation(OPERATION_DIFFERENCE, p_polygon_a, p_polygon_b);
 	}
 
-	static Vector<Vector<Point2> > intersect_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
+	static Vector<Vector<Point2>> intersect_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
 
 		return _polypaths_do_operation(OPERATION_INTERSECTION, p_polygon_a, p_polygon_b);
 	}
 
-	static Vector<Vector<Point2> > exclude_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
+	static Vector<Vector<Point2>> exclude_polygons_2d(const Vector<Point2> &p_polygon_a, const Vector<Point2> &p_polygon_b) {
 
 		return _polypaths_do_operation(OPERATION_XOR, p_polygon_a, p_polygon_b);
 	}
 
-	static Vector<Vector<Point2> > clip_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
+	static Vector<Vector<Point2>> clip_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
 
 		return _polypaths_do_operation(OPERATION_DIFFERENCE, p_polyline, p_polygon, true);
 	}
 
-	static Vector<Vector<Point2> > intersect_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
+	static Vector<Vector<Point2>> intersect_polyline_with_polygon_2d(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
 
 		return _polypaths_do_operation(OPERATION_INTERSECTION, p_polyline, p_polygon, true);
 	}
 
-	static Vector<Vector<Point2> > offset_polygon_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type) {
+	static Vector<Vector<Point2>> offset_polygon_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type) {
 
 		return _polypath_offset(p_polygon, p_delta, p_join_type, END_POLYGON);
 	}
 
-	static Vector<Vector<Point2> > offset_polyline_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
+	static Vector<Vector<Point2>> offset_polyline_2d(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
 
-		ERR_FAIL_COND_V_MSG(p_end_type == END_POLYGON, Vector<Vector<Point2> >(), "Attempt to offset a polyline like a polygon (use offset_polygon_2d instead).");
+		ERR_FAIL_COND_V_MSG(p_end_type == END_POLYGON, Vector<Vector<Point2>>(), "Attempt to offset a polyline like a polygon (use offset_polygon_2d instead).");
 
 		return _polypath_offset(p_polygon, p_delta, p_join_type, p_end_type);
 	}
@@ -899,7 +899,7 @@ public:
 		return (intersections & 1);
 	}
 
-	static Vector<Vector<Face3> > separate_objects(Vector<Face3> p_array);
+	static Vector<Vector<Face3>> separate_objects(Vector<Face3> p_array);
 
 	// Create a "wrap" that encloses the given geometry.
 	static Vector<Face3> wrap_geometry(Vector<Face3> p_array, real_t *p_error = NULL);
@@ -1004,7 +1004,7 @@ public:
 		H.resize(k);
 		return H;
 	}
-	static Vector<Vector<Vector2> > decompose_polygon_in_convex(Vector<Point2> polygon);
+	static Vector<Vector<Vector2>> decompose_polygon_in_convex(Vector<Point2> polygon);
 
 	static MeshData build_convex_mesh(const Vector<Plane> &p_planes);
 	static Vector<Plane> build_sphere_planes(real_t p_radius, int p_lats, int p_lons, Vector3::Axis p_axis = Vector3::AXIS_Z);
@@ -1015,8 +1015,8 @@ public:
 	static void make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_result, Size2i &r_size);
 
 private:
-	static Vector<Vector<Point2> > _polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Point2> &p_polypath_a, const Vector<Point2> &p_polypath_b, bool is_a_open = false);
-	static Vector<Vector<Point2> > _polypath_offset(const Vector<Point2> &p_polypath, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type);
+	static Vector<Vector<Point2>> _polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Point2> &p_polypath_a, const Vector<Point2> &p_polypath_b, bool is_a_open = false);
+	static Vector<Vector<Point2>> _polypath_offset(const Vector<Point2> &p_polypath, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type);
 };
 
 #endif

--- a/core/method_ptrcall.h
+++ b/core/method_ptrcall.h
@@ -192,7 +192,7 @@ struct PtrToArg<ObjectID> {
 
 #define MAKE_VECARG(m_type)                                                              \
 	template <>                                                                          \
-	struct PtrToArg<Vector<m_type> > {                                                   \
+	struct PtrToArg<Vector<m_type>> {                                                    \
 		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {                \
 			const Vector<m_type> *dvs = reinterpret_cast<const Vector<m_type> *>(p_ptr); \
 			Vector<m_type> ret;                                                          \
@@ -237,7 +237,7 @@ struct PtrToArg<ObjectID> {
 
 #define MAKE_VECARG_ALT(m_type, m_type_alt)                                              \
 	template <>                                                                          \
-	struct PtrToArg<Vector<m_type_alt> > {                                               \
+	struct PtrToArg<Vector<m_type_alt>> {                                                \
 		_FORCE_INLINE_ static Vector<m_type_alt> convert(const void *p_ptr) {            \
 			const Vector<m_type> *dvs = reinterpret_cast<const Vector<m_type> *>(p_ptr); \
 			Vector<m_type_alt> ret;                                                      \
@@ -293,7 +293,7 @@ MAKE_VECARG_ALT(String, StringName);
 //for stuff that gets converted to Array vectors
 #define MAKE_VECARR(m_type)                                                    \
 	template <>                                                                \
-	struct PtrToArg<Vector<m_type> > {                                         \
+	struct PtrToArg<Vector<m_type>> {                                          \
 		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {      \
 			const Array *arr = reinterpret_cast<const Array *>(p_ptr);         \
 			Vector<m_type> ret;                                                \
@@ -333,7 +333,7 @@ MAKE_VECARR(Plane);
 
 #define MAKE_DVECARR(m_type)                                                   \
 	template <>                                                                \
-	struct PtrToArg<Vector<m_type> > {                                         \
+	struct PtrToArg<Vector<m_type>> {                                          \
 		_FORCE_INLINE_ static Vector<m_type> convert(const void *p_ptr) {      \
 			const Array *arr = reinterpret_cast<const Array *>(p_ptr);         \
 			Vector<m_type> ret;                                                \
@@ -402,7 +402,7 @@ MAKE_VECARR(Plane);
 MAKE_STRINGCONV_BY_REFERENCE(IP_Address);
 
 template <>
-struct PtrToArg<Vector<Face3> > {
+struct PtrToArg<Vector<Face3>> {
 	_FORCE_INLINE_ static Vector<Face3> convert(const void *p_ptr) {
 		const Vector<Vector3> *dvs = reinterpret_cast<const Vector<Vector3> *>(p_ptr);
 		Vector<Face3> ret;

--- a/core/oa_hash_map.h
+++ b/core/oa_hash_map.h
@@ -48,7 +48,7 @@
  */
 template <class TKey, class TValue,
 		class Hasher = HashMapHasherDefault,
-		class Comparator = HashMapComparatorDefault<TKey> >
+		class Comparator = HashMapComparatorDefault<TKey>>
 class OAHashMap {
 
 private:

--- a/core/ordered_hash_map.h
+++ b/core/ordered_hash_map.h
@@ -45,7 +45,7 @@
  */
 template <class K, class V, class Hasher = HashMapHasherDefault, class Comparator = HashMapComparatorDefault<K>, uint8_t MIN_HASH_TABLE_POWER = 3, uint8_t RELATIONSHIP = 8>
 class OrderedHashMap {
-	typedef List<Pair<const K *, V> > InternalList;
+	typedef List<Pair<const K *, V>> InternalList;
 	typedef HashMap<K, typename InternalList::Element *, Hasher, Comparator, MIN_HASH_TABLE_POWER, RELATIONSHIP> InternalMap;
 
 	InternalList list;

--- a/core/os/mutex.cpp
+++ b/core/os/mutex.cpp
@@ -44,7 +44,7 @@ void _global_unlock() {
 
 template class MutexImpl<std::recursive_mutex>;
 template class MutexImpl<std::mutex>;
-template class MutexLock<MutexImpl<std::recursive_mutex> >;
-template class MutexLock<MutexImpl<std::mutex> >;
+template class MutexLock<MutexImpl<std::recursive_mutex>>;
+template class MutexLock<MutexImpl<std::mutex>>;
 
 #endif

--- a/core/os/mutex.h
+++ b/core/os/mutex.h
@@ -76,8 +76,8 @@ using BinaryMutex = MutexImpl<std::mutex>; // Non-recursive, handle with care
 
 extern template class MutexImpl<std::recursive_mutex>;
 extern template class MutexImpl<std::mutex>;
-extern template class MutexLock<MutexImpl<std::recursive_mutex> >;
-extern template class MutexLock<MutexImpl<std::mutex> >;
+extern template class MutexLock<MutexImpl<std::recursive_mutex>>;
+extern template class MutexLock<MutexImpl<std::mutex>>;
 
 #else
 

--- a/core/os/threaded_array_processor.h
+++ b/core/os/threaded_array_processor.h
@@ -80,7 +80,7 @@ void thread_process_array(uint32_t p_elements, C *p_instance, M p_method, U p_us
 	threads.resize(OS::get_singleton()->get_processor_count());
 
 	for (int i = 0; i < threads.size(); i++) {
-		threads.write[i] = Thread::create(process_array_thread<ThreadArrayProcessData<C, U> >, &data);
+		threads.write[i] = Thread::create(process_array_thread<ThreadArrayProcessData<C, U>>, &data);
 	}
 
 	for (int i = 0; i < threads.size(); i++) {

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -652,7 +652,7 @@ Error ProjectSettings::save() {
 	return save_custom(get_resource_path().plus_file("project.godot"));
 }
 
-Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<String, List<String> > &props, const CustomMap &p_custom, const String &p_custom_features) {
+Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<String, List<String>> &props, const CustomMap &p_custom, const String &p_custom_features) {
 
 	Error err;
 	FileAccess *file = FileAccess::open(p_file, FileAccess::WRITE, &err);
@@ -663,7 +663,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<Str
 
 	int count = 0;
 
-	for (Map<String, List<String> >::Element *E = props.front(); E; E = E->next()) {
+	for (Map<String, List<String>>::Element *E = props.front(); E; E = E->next()) {
 
 		for (List<String>::Element *F = E->get().front(); F; F = F->next()) {
 
@@ -700,7 +700,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<Str
 		file->store_32(count); //store how many properties are saved
 	}
 
-	for (Map<String, List<String> >::Element *E = props.front(); E; E = E->next()) {
+	for (Map<String, List<String>>::Element *E = props.front(); E; E = E->next()) {
 
 		for (List<String>::Element *F = E->get().front(); F; F = F->next()) {
 
@@ -740,7 +740,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<Str
 	return OK;
 }
 
-Error ProjectSettings::_save_settings_text(const String &p_file, const Map<String, List<String> > &props, const CustomMap &p_custom, const String &p_custom_features) {
+Error ProjectSettings::_save_settings_text(const String &p_file, const Map<String, List<String>> &props, const CustomMap &p_custom, const String &p_custom_features) {
 
 	Error err;
 	FileAccess *file = FileAccess::open(p_file, FileAccess::WRITE, &err);
@@ -761,7 +761,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 		file->store_string("custom_features=\"" + p_custom_features + "\"\n");
 	file->store_string("\n");
 
-	for (Map<String, List<String> >::Element *E = props.front(); E; E = E->next()) {
+	for (Map<String, List<String>>::Element *E = props.front(); E; E = E->next()) {
 
 		if (E != props.front())
 			file->store_string("\n");
@@ -838,7 +838,7 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 		vclist.insert(vc);
 	}
 
-	Map<String, List<String> > props;
+	Map<String, List<String>> props;
 
 	for (Set<_VCSort>::Element *E = vclist.front(); E; E = E->next()) {
 

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -97,8 +97,8 @@ protected:
 	Error _load_settings_binary(const String &p_path);
 	Error _load_settings_text_or_binary(const String &p_text_path, const String &p_bin_path);
 
-	Error _save_settings_text(const String &p_file, const Map<String, List<String> > &props, const CustomMap &p_custom = CustomMap(), const String &p_custom_features = String());
-	Error _save_settings_binary(const String &p_file, const Map<String, List<String> > &props, const CustomMap &p_custom = CustomMap(), const String &p_custom_features = String());
+	Error _save_settings_text(const String &p_file, const Map<String, List<String>> &props, const CustomMap &p_custom = CustomMap(), const String &p_custom_features = String());
+	Error _save_settings_binary(const String &p_file, const Map<String, List<String>> &props, const CustomMap &p_custom = CustomMap(), const String &p_custom_features = String());
 
 	Error _save_custom_bnd(const String &p_file);
 

--- a/core/reference.h
+++ b/core/reference.h
@@ -285,7 +285,7 @@ public:
 #ifdef PTRCALL_ENABLED
 
 template <class T>
-struct PtrToArg<Ref<T> > {
+struct PtrToArg<Ref<T>> {
 
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
 
@@ -312,7 +312,7 @@ struct PtrToArg<const Ref<T> &> {
 #ifdef DEBUG_METHODS_ENABLED
 
 template <class T>
-struct GetTypeInfo<Ref<T> > {
+struct GetTypeInfo<Ref<T>> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 

--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -149,7 +149,7 @@ void Resource::reload_from_file() {
 	}
 }
 
-Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, Ref<Resource> > &remap_cache) {
+Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, Ref<Resource>> &remap_cache) {
 
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
@@ -190,7 +190,7 @@ Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Res
 	return res;
 }
 
-void Resource::configure_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, Ref<Resource> > &remap_cache) {
+void Resource::configure_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, Ref<Resource>> &remap_cache) {
 
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
@@ -455,7 +455,7 @@ Resource::~Resource() {
 
 HashMap<String, Resource *> ResourceCache::resources;
 #ifdef TOOLS_ENABLED
-HashMap<String, HashMap<String, int> > ResourceCache::resource_path_cache;
+HashMap<String, HashMap<String, int>> ResourceCache::resource_path_cache;
 #endif
 
 RWLock *ResourceCache::lock = NULL;
@@ -512,7 +512,7 @@ Resource *ResourceCache::get(const String &p_path) {
 	return *res;
 }
 
-void ResourceCache::get_cached_resources(List<Ref<Resource> > *p_resources) {
+void ResourceCache::get_cached_resources(List<Ref<Resource>> *p_resources) {
 
 	lock->read_lock();
 	const String *K = NULL;

--- a/core/resource.h
+++ b/core/resource.h
@@ -103,8 +103,8 @@ public:
 	int get_subindex() const;
 
 	virtual Ref<Resource> duplicate(bool p_subresources = false) const;
-	Ref<Resource> duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, Ref<Resource> > &remap_cache);
-	void configure_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, Ref<Resource> > &remap_cache);
+	Ref<Resource> duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, Ref<Resource>> &remap_cache);
+	void configure_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, Ref<Resource>> &remap_cache);
 
 	void set_local_to_scene(bool p_enable);
 	bool is_local_to_scene() const;
@@ -150,7 +150,7 @@ class ResourceCache {
 	static RWLock *lock;
 	static HashMap<String, Resource *> resources;
 #ifdef TOOLS_ENABLED
-	static HashMap<String, HashMap<String, int> > resource_path_cache; // each tscn has a set of resource paths and IDs
+	static HashMap<String, HashMap<String, int>> resource_path_cache; // each tscn has a set of resource paths and IDs
 	static RWLock *path_cache_lock;
 #endif // TOOLS_ENABLED
 	friend void unregister_core_types();
@@ -163,7 +163,7 @@ public:
 	static bool has(const String &p_path);
 	static Resource *get(const String &p_path);
 	static void dump(const char *p_file = NULL, bool p_short = false);
-	static void get_cached_resources(List<Ref<Resource> > *p_resources);
+	static void get_cached_resources(List<Ref<Resource>> *p_resources);
 	static int get_cached_resource_count();
 };
 

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -284,7 +284,7 @@ void ScriptServer::save_global_classes() {
 }
 
 ////////////////////
-void ScriptInstance::get_property_state(List<Pair<StringName, Variant> > &state) {
+void ScriptInstance::get_property_state(List<Pair<StringName, Variant>> &state) {
 
 	List<PropertyInfo> pinfo;
 	get_property_list(&pinfo);

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -192,7 +192,7 @@ public:
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = NULL) const = 0;
 
 	virtual Object *get_owner() { return NULL; }
-	virtual void get_property_state(List<Pair<StringName, Variant> > &state);
+	virtual void get_property_state(List<Pair<StringName, Variant>> &state);
 
 	virtual void get_method_list(List<MethodInfo> *p_list) const = 0;
 	virtual bool has_method(const StringName &p_method) const = 0;
@@ -375,7 +375,7 @@ public:
 
 	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const = 0;
-	virtual void get_public_constants(List<Pair<String, Variant> > *p_constants) const = 0;
+	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const = 0;
 
 	struct ProfilingInfo {
 		StringName signature;

--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -995,7 +995,7 @@ String TranslationServer::get_locale_name(const String &p_locale) const {
 
 Array TranslationServer::get_loaded_locales() const {
 	Array locales;
-	for (const Set<Ref<Translation> >::Element *E = translations.front(); E; E = E->next()) {
+	for (const Set<Ref<Translation>>::Element *E = translations.front(); E; E = E->next()) {
 
 		const Ref<Translation> &t = E->get();
 		ERR_FAIL_COND_V(t.is_null(), Array());
@@ -1072,7 +1072,7 @@ StringName TranslationServer::translate(const StringName &p_message) const {
 	String lang = get_language_code(locale);
 	bool near_match = false;
 
-	for (const Set<Ref<Translation> >::Element *E = translations.front(); E; E = E->next()) {
+	for (const Set<Ref<Translation>>::Element *E = translations.front(); E; E = E->next()) {
 		const Ref<Translation> &t = E->get();
 		ERR_FAIL_COND_V(t.is_null(), p_message);
 		String l = t->get_locale();
@@ -1105,7 +1105,7 @@ StringName TranslationServer::translate(const StringName &p_message) const {
 		String fallback_lang = get_language_code(fallback);
 		near_match = false;
 
-		for (const Set<Ref<Translation> >::Element *E = translations.front(); E; E = E->next()) {
+		for (const Set<Ref<Translation>>::Element *E = translations.front(); E; E = E->next()) {
 			const Ref<Translation> &t = E->get();
 			ERR_FAIL_COND_V(t.is_null(), p_message);
 			String l = t->get_locale();

--- a/core/translation.h
+++ b/core/translation.h
@@ -71,7 +71,7 @@ class TranslationServer : public Object {
 	String locale;
 	String fallback;
 
-	Set<Ref<Translation> > translations;
+	Set<Ref<Translation>> translations;
 	Ref<Translation> tool_translation;
 
 	Map<String, String> locale_name_map;

--- a/core/type_info.h
+++ b/core/type_info.h
@@ -201,7 +201,7 @@ struct GetTypeInfo<const Variant &> {
 
 #define MAKE_TEMPLATE_TYPE_INFO(m_template, m_type, m_var_type)                       \
 	template <>                                                                       \
-	struct GetTypeInfo<m_template<m_type> > {                                         \
+	struct GetTypeInfo<m_template<m_type>> {                                          \
 		static const Variant::Type VARIANT_TYPE = m_var_type;                         \
 		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE; \
 		static inline PropertyInfo get_class_info() {                                 \

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -2325,31 +2325,31 @@ inline DA _convert_array_from_variant(const Variant &p_variant) {
 			return _convert_array<DA, Array>(p_variant.operator Array());
 		}
 		case Variant::PACKED_BYTE_ARRAY: {
-			return _convert_array<DA, Vector<uint8_t> >(p_variant.operator Vector<uint8_t>());
+			return _convert_array<DA, Vector<uint8_t>>(p_variant.operator Vector<uint8_t>());
 		}
 		case Variant::PACKED_INT32_ARRAY: {
-			return _convert_array<DA, Vector<int32_t> >(p_variant.operator Vector<int32_t>());
+			return _convert_array<DA, Vector<int32_t>>(p_variant.operator Vector<int32_t>());
 		}
 		case Variant::PACKED_INT64_ARRAY: {
-			return _convert_array<DA, Vector<int64_t> >(p_variant.operator Vector<int64_t>());
+			return _convert_array<DA, Vector<int64_t>>(p_variant.operator Vector<int64_t>());
 		}
 		case Variant::PACKED_FLOAT32_ARRAY: {
-			return _convert_array<DA, Vector<float> >(p_variant.operator Vector<float>());
+			return _convert_array<DA, Vector<float>>(p_variant.operator Vector<float>());
 		}
 		case Variant::PACKED_FLOAT64_ARRAY: {
-			return _convert_array<DA, Vector<double> >(p_variant.operator Vector<double>());
+			return _convert_array<DA, Vector<double>>(p_variant.operator Vector<double>());
 		}
 		case Variant::PACKED_STRING_ARRAY: {
-			return _convert_array<DA, Vector<String> >(p_variant.operator Vector<String>());
+			return _convert_array<DA, Vector<String>>(p_variant.operator Vector<String>());
 		}
 		case Variant::PACKED_VECTOR2_ARRAY: {
-			return _convert_array<DA, Vector<Vector2> >(p_variant.operator Vector<Vector2>());
+			return _convert_array<DA, Vector<Vector2>>(p_variant.operator Vector<Vector2>());
 		}
 		case Variant::PACKED_VECTOR3_ARRAY: {
-			return _convert_array<DA, Vector<Vector3> >(p_variant.operator Vector<Vector3>());
+			return _convert_array<DA, Vector<Vector3>>(p_variant.operator Vector<Vector3>());
 		}
 		case Variant::PACKED_COLOR_ARRAY: {
-			return _convert_array<DA, Vector<Color> >(p_variant.operator Vector<Color>());
+			return _convert_array<DA, Vector<Color>>(p_variant.operator Vector<Color>());
 		}
 		default: {
 			return DA();
@@ -2370,21 +2370,21 @@ Variant::operator Vector<uint8_t>() const {
 	if (type == PACKED_BYTE_ARRAY)
 		return static_cast<PackedArrayRef<uint8_t> *>(_data.packed_array)->array;
 	else
-		return _convert_array_from_variant<Vector<uint8_t> >(*this);
+		return _convert_array_from_variant<Vector<uint8_t>>(*this);
 }
 Variant::operator Vector<int32_t>() const {
 
 	if (type == PACKED_INT32_ARRAY)
 		return static_cast<PackedArrayRef<int32_t> *>(_data.packed_array)->array;
 	else
-		return _convert_array_from_variant<Vector<int> >(*this);
+		return _convert_array_from_variant<Vector<int>>(*this);
 }
 Variant::operator Vector<int64_t>() const {
 
 	if (type == PACKED_INT64_ARRAY)
 		return static_cast<PackedArrayRef<int64_t> *>(_data.packed_array)->array;
 	else
-		return _convert_array_from_variant<Vector<int64_t> >(*this);
+		return _convert_array_from_variant<Vector<int64_t>>(*this);
 }
 
 Variant::operator Vector<float>() const {
@@ -2392,7 +2392,7 @@ Variant::operator Vector<float>() const {
 	if (type == PACKED_FLOAT32_ARRAY)
 		return static_cast<PackedArrayRef<float> *>(_data.packed_array)->array;
 	else
-		return _convert_array_from_variant<Vector<float> >(*this);
+		return _convert_array_from_variant<Vector<float>>(*this);
 }
 
 Variant::operator Vector<double>() const {
@@ -2400,7 +2400,7 @@ Variant::operator Vector<double>() const {
 	if (type == PACKED_FLOAT64_ARRAY)
 		return static_cast<PackedArrayRef<double> *>(_data.packed_array)->array;
 	else
-		return _convert_array_from_variant<Vector<double> >(*this);
+		return _convert_array_from_variant<Vector<double>>(*this);
 }
 
 Variant::operator Vector<String>() const {
@@ -2408,21 +2408,21 @@ Variant::operator Vector<String>() const {
 	if (type == PACKED_STRING_ARRAY)
 		return static_cast<PackedArrayRef<String> *>(_data.packed_array)->array;
 	else
-		return _convert_array_from_variant<Vector<String> >(*this);
+		return _convert_array_from_variant<Vector<String>>(*this);
 }
 Variant::operator Vector<Vector3>() const {
 
 	if (type == PACKED_VECTOR3_ARRAY)
 		return static_cast<PackedArrayRef<Vector3> *>(_data.packed_array)->array;
 	else
-		return _convert_array_from_variant<Vector<Vector3> >(*this);
+		return _convert_array_from_variant<Vector<Vector3>>(*this);
 }
 Variant::operator Vector<Vector2>() const {
 
 	if (type == PACKED_VECTOR2_ARRAY)
 		return static_cast<PackedArrayRef<Vector2> *>(_data.packed_array)->array;
 	else
-		return _convert_array_from_variant<Vector<Vector2> >(*this);
+		return _convert_array_from_variant<Vector<Vector2>>(*this);
 }
 
 Variant::operator Vector<Color>() const {
@@ -2430,7 +2430,7 @@ Variant::operator Vector<Color>() const {
 	if (type == PACKED_COLOR_ARRAY)
 		return static_cast<PackedArrayRef<Color> *>(_data.packed_array)->array;
 	else
-		return _convert_array_from_variant<Vector<Color> >(*this);
+		return _convert_array_from_variant<Vector<Color>>(*this);
 }
 
 /* helpers */

--- a/core/vector.h
+++ b/core/vector.h
@@ -103,7 +103,7 @@ public:
 
 	void sort() {
 
-		sort_custom<_DefaultComparator<T> >();
+		sort_custom<_DefaultComparator<T>>();
 	}
 
 	void ordered_insert(const T &p_val) {

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -23,8 +23,7 @@
 			<argument index="4" name="tooltip" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Adds a button with [Texture2D] [code]button[/code] at column [code]column[/code]. The [code]button_idx[/code] index is used to identify the button when calling other methods. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately after this method. Optionally, the button can be [code]disabled[/code] and have a [code]tooltip
-				[/code].
+				Adds a button with [Texture2D] [code]button[/code] at column [code]column[/code]. The [code]button_idx[/code] index is used to identify the button when calling other methods. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately after this method. Optionally, the button can be [code]disabled[/code] and have a [code]tooltip[/code].
 			</description>
 		</method>
 		<method name="call_recursive" qualifiers="vararg">

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -167,7 +167,7 @@ public:
 		Vector<uint8_t> index_array;
 		int index_count;
 		AABB aabb;
-		Vector<Vector<uint8_t> > blend_shapes;
+		Vector<Vector<uint8_t>> blend_shapes;
 		Vector<AABB> bone_aabbs;
 	};
 
@@ -181,8 +181,8 @@ public:
 	mutable RID_PtrOwner<DummyMesh> mesh_owner;
 
 	virtual RID texture_2d_create(const Ref<Image> &p_image) { return RID(); }
-	virtual RID texture_2d_layered_create(const Vector<Ref<Image> > &p_layers, VS::TextureLayeredType p_layered_type) { return RID(); }
-	virtual RID texture_3d_create(const Vector<Ref<Image> > &p_slices) { return RID(); }
+	virtual RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, VS::TextureLayeredType p_layered_type) { return RID(); }
+	virtual RID texture_3d_create(const Vector<Ref<Image>> &p_slices) { return RID(); }
 	virtual RID texture_proxy_create(RID p_base) { return RID(); }
 
 	virtual void texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) {}

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -2270,7 +2270,7 @@ static Vector<uint8_t> _unpack_half_floats(const Vector<uint8_t> &array, uint32_
 	return ret;
 }
 
-void RasterizerStorageGLES2::mesh_add_surface(RID p_mesh, uint32_t p_format, VS::PrimitiveType p_primitive, const Vector<uint8_t> &p_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<Vector<uint8_t> > &p_blend_shapes, const Vector<AABB> &p_bone_aabbs) {
+void RasterizerStorageGLES2::mesh_add_surface(RID p_mesh, uint32_t p_format, VS::PrimitiveType p_primitive, const Vector<uint8_t> &p_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<Vector<uint8_t>> &p_blend_shapes, const Vector<AABB> &p_bone_aabbs) {
 
 	Mesh *mesh = mesh_owner.getornull(p_mesh);
 	ERR_FAIL_COND(!mesh);
@@ -2737,10 +2737,10 @@ AABB RasterizerStorageGLES2::mesh_surface_get_aabb(RID p_mesh, int p_surface) co
 	return mesh->surfaces[p_surface]->aabb;
 }
 
-Vector<Vector<uint8_t> > RasterizerStorageGLES2::mesh_surface_get_blend_shapes(RID p_mesh, int p_surface) const {
+Vector<Vector<uint8_t>> RasterizerStorageGLES2::mesh_surface_get_blend_shapes(RID p_mesh, int p_surface) const {
 	const Mesh *mesh = mesh_owner.getornull(p_mesh);
-	ERR_FAIL_COND_V(!mesh, Vector<Vector<uint8_t> >());
-	ERR_FAIL_INDEX_V(p_surface, mesh->surfaces.size(), Vector<Vector<uint8_t> >());
+	ERR_FAIL_COND_V(!mesh, Vector<Vector<uint8_t>>());
+	ERR_FAIL_INDEX_V(p_surface, mesh->surfaces.size(), Vector<Vector<uint8_t>>());
 #ifndef TOOLS_ENABLED
 	ERR_PRINT("OpenGL ES 2.0 does not allow retrieving mesh array data");
 #endif

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -275,7 +275,7 @@ public:
 
 		RenderTarget *render_target;
 
-		Vector<Ref<Image> > images;
+		Vector<Ref<Image>> images;
 
 		bool redraw_if_visible;
 
@@ -541,7 +541,7 @@ public:
 		Map<StringName, Variant> params;
 		SelfList<Material> list;
 		SelfList<Material> dirty_list;
-		Vector<Pair<StringName, RID> > textures;
+		Vector<Pair<StringName, RID>> textures;
 		float line_width;
 		int render_priority;
 
@@ -650,7 +650,7 @@ public:
 
 		Vector<uint8_t> data;
 		Vector<uint8_t> index_data;
-		Vector<Vector<uint8_t> > blend_shape_data;
+		Vector<Vector<uint8_t>> blend_shape_data;
 
 		int total_data_size;
 
@@ -702,7 +702,7 @@ public:
 
 	virtual RID mesh_create();
 
-	virtual void mesh_add_surface(RID p_mesh, uint32_t p_format, VS::PrimitiveType p_primitive, const Vector<uint8_t> &p_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<Vector<uint8_t> > &p_blend_shapes = Vector<Vector<uint8_t> >(), const Vector<AABB> &p_bone_aabbs = Vector<AABB>());
+	virtual void mesh_add_surface(RID p_mesh, uint32_t p_format, VS::PrimitiveType p_primitive, const Vector<uint8_t> &p_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<Vector<uint8_t>> &p_blend_shapes = Vector<Vector<uint8_t>>(), const Vector<AABB> &p_bone_aabbs = Vector<AABB>());
 
 	virtual void mesh_set_blend_shape_count(RID p_mesh, int p_amount);
 	virtual int mesh_get_blend_shape_count(RID p_mesh) const;
@@ -725,7 +725,7 @@ public:
 	virtual VS::PrimitiveType mesh_surface_get_primitive_type(RID p_mesh, int p_surface) const;
 
 	virtual AABB mesh_surface_get_aabb(RID p_mesh, int p_surface) const;
-	virtual Vector<Vector<uint8_t> > mesh_surface_get_blend_shapes(RID p_mesh, int p_surface) const;
+	virtual Vector<Vector<uint8_t>> mesh_surface_get_blend_shapes(RID p_mesh, int p_surface) const;
 	virtual Vector<AABB> mesh_surface_get_skeleton_aabb(RID p_mesh, int p_surface) const;
 
 	virtual void mesh_remove_surface(RID p_mesh, int p_surface);

--- a/drivers/gles2/shader_compiler_gles2.h
+++ b/drivers/gles2/shader_compiler_gles2.h
@@ -41,7 +41,7 @@ class ShaderCompilerGLES2 {
 public:
 	struct IdentifierActions {
 
-		Map<StringName, Pair<int *, int> > render_mode_values;
+		Map<StringName, Pair<int *, int>> render_mode_values;
 		Map<StringName, bool *> render_mode_flags;
 		Map<StringName, bool *> usage_flag_pointers;
 		Map<StringName, bool *> write_flag_pointers;

--- a/drivers/gles2/shader_gles2.h
+++ b/drivers/gles2/shader_gles2.h
@@ -179,7 +179,7 @@ private:
 
 	int max_image_units;
 
-	Map<StringName, Pair<ShaderLanguage::DataType, Vector<ShaderLanguage::ConstantNode::Value> > > uniform_values;
+	Map<StringName, Pair<ShaderLanguage::DataType, Vector<ShaderLanguage::ConstantNode::Value>>> uniform_values;
 
 protected:
 	_FORCE_INLINE_ int _get_uniform(int p_which) const;

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -57,7 +57,7 @@ void RenderingDeviceVulkan::_free_dependencies(RID p_id) {
 
 	//direct dependencies must be freed
 
-	Map<RID, Set<RID> >::Element *E = dependency_map.find(p_id);
+	Map<RID, Set<RID>>::Element *E = dependency_map.find(p_id);
 	if (E) {
 
 		while (E->get().size()) {
@@ -72,7 +72,7 @@ void RenderingDeviceVulkan::_free_dependencies(RID p_id) {
 	if (E) {
 
 		for (Set<RID>::Element *F = E->get().front(); F; F = F->next()) {
-			Map<RID, Set<RID> >::Element *G = dependency_map.find(F->get());
+			Map<RID, Set<RID>>::Element *G = dependency_map.find(F->get());
 			ERR_CONTINUE(!G);
 			ERR_CONTINUE(!G->get().has(p_id));
 			G->get().erase(p_id);
@@ -1555,7 +1555,7 @@ void RenderingDeviceVulkan::_buffer_memory_barrier(VkBuffer buffer, uint64_t p_f
 /**** TEXTURE ****/
 /*****************/
 
-RID RenderingDeviceVulkan::texture_create(const TextureFormat &p_format, const TextureView &p_view, const Vector<Vector<uint8_t> > &p_data) {
+RID RenderingDeviceVulkan::texture_create(const TextureFormat &p_format, const TextureView &p_view, const Vector<Vector<uint8_t>> &p_data) {
 
 	_THREAD_SAFE_METHOD_
 
@@ -3568,8 +3568,8 @@ bool RenderingDeviceVulkan::_uniform_add_binding(Vector<Vector<VkDescriptorSetLa
 RID RenderingDeviceVulkan::shader_create(const Vector<ShaderStageData> &p_stages) {
 
 	//descriptor layouts
-	Vector<Vector<VkDescriptorSetLayoutBinding> > set_bindings;
-	Vector<Vector<UniformInfo> > uniform_info;
+	Vector<Vector<VkDescriptorSetLayoutBinding>> set_bindings;
+	Vector<Vector<UniformInfo>> uniform_info;
 	Shader::PushConstant push_constant;
 	push_constant.push_constant_size = 0;
 	push_constant.push_constants_vk_stage = 0;
@@ -4223,9 +4223,9 @@ RID RenderingDeviceVulkan::uniform_set_create(const Vector<Uniform> &p_uniforms,
 	DescriptorPoolKey pool_key;
 
 	//to keep them alive until update call
-	List<Vector<VkDescriptorBufferInfo> > buffer_infos;
-	List<Vector<VkBufferView> > buffer_views;
-	List<Vector<VkDescriptorImageInfo> > image_infos;
+	List<Vector<VkDescriptorBufferInfo>> buffer_infos;
+	List<Vector<VkBufferView>> buffer_views;
+	List<Vector<VkDescriptorImageInfo>> image_infos;
 	//used for verification to make sure a uniform set does not use a framebuffer bound texture
 	Vector<RID> attachable_textures;
 	Vector<Texture *> mutable_sampled_textures;

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -98,8 +98,8 @@ class RenderingDeviceVulkan : public RenderingDevice {
 
 	VkDevice device;
 
-	Map<RID, Set<RID> > dependency_map; //IDs to IDs that depend on it
-	Map<RID, Set<RID> > reverse_dependency_map; //same as above, but in reverse
+	Map<RID, Set<RID>> dependency_map; //IDs to IDs that depend on it
+	Map<RID, Set<RID>> reverse_dependency_map; //same as above, but in reverse
 
 	void _add_dependency(RID p_id, RID p_depends_on);
 	void _free_dependencies(RID p_id);
@@ -602,7 +602,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 		uint32_t usage;
 	};
 
-	Map<DescriptorPoolKey, Set<DescriptorPool *> > descriptor_pools;
+	Map<DescriptorPoolKey, Set<DescriptorPool *>> descriptor_pools;
 	uint32_t max_descriptors_per_pool;
 
 	DescriptorPool *_descriptor_pool_allocate(const DescriptorPoolKey &p_key);
@@ -968,7 +968,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 	void _free_rids(T &p_owner, const char *p_type);
 
 public:
-	virtual RID texture_create(const TextureFormat &p_format, const TextureView &p_view, const Vector<Vector<uint8_t> > &p_data = Vector<Vector<uint8_t> >());
+	virtual RID texture_create(const TextureFormat &p_format, const TextureView &p_view, const Vector<Vector<uint8_t>> &p_data = Vector<Vector<uint8_t>>());
 	virtual RID texture_create_shared(const TextureView &p_view, RID p_with_texture);
 
 	virtual RID texture_create_shared_from_slice(const TextureView &p_view, RID p_with_texture, uint32_t p_layer, uint32_t p_mipmap, TextureSliceType p_slice_type = TEXTURE_SLICE_2D);

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -1076,7 +1076,7 @@ void AnimationBezierTrackEdit::duplicate_selection() {
 
 	undo_redo->create_action(TTR("Anim Duplicate Keys"));
 
-	List<Pair<int, float> > new_selection_values;
+	List<Pair<int, float>> new_selection_values;
 
 	for (Set<int>::Element *E = selection.back(); E; E = E->prev()) {
 
@@ -1103,7 +1103,7 @@ void AnimationBezierTrackEdit::duplicate_selection() {
 	//reselect duplicated
 
 	selection.clear();
-	for (List<Pair<int, float> >::Element *E = new_selection_values.front(); E; E = E->next()) {
+	for (List<Pair<int, float>>::Element *E = new_selection_values.front(); E; E = E->next()) {
 
 		int track = E->get().first;
 		float time = E->get().second;

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -752,7 +752,7 @@ public:
 		if (animation != p_anim)
 			return;
 
-		for (Map<int, List<float> >::Element *E = key_ofs_map.front(); E; E = E->next()) {
+		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
 
 			for (List<float>::Element *F = E->value().front(); F; F = F->next()) {
 
@@ -777,7 +777,7 @@ public:
 
 		bool update_obj = false;
 		bool change_notify_deserved = false;
-		for (Map<int, List<float> >::Element *E = key_ofs_map.front(); E; E = E->next()) {
+		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
 
 			int track = E->key();
 			for (List<float>::Element *F = E->value().front(); F; F = F->next()) {
@@ -1060,7 +1060,7 @@ public:
 
 	bool _get(const StringName &p_name, Variant &r_ret) const {
 
-		for (Map<int, List<float> >::Element *E = key_ofs_map.front(); E; E = E->next()) {
+		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
 
 			int track = E->key();
 			for (List<float>::Element *F = E->value().front(); F; F = F->next()) {
@@ -1208,7 +1208,7 @@ public:
 		bool show_time = true;
 		bool same_track_type = true;
 		bool same_key_type = true;
-		for (Map<int, List<float> >::Element *E = key_ofs_map.front(); E; E = E->next()) {
+		for (Map<int, List<float>>::Element *E = key_ofs_map.front(); E; E = E->next()) {
 
 			int track = E->key();
 			ERR_FAIL_INDEX(track, animation->get_track_count());
@@ -1362,7 +1362,7 @@ public:
 
 	Ref<Animation> animation;
 
-	Map<int, List<float> > key_ofs_map;
+	Map<int, List<float>> key_ofs_map;
 	Map<int, NodePath> base_map;
 	PropertyInfo hint;
 
@@ -4892,7 +4892,7 @@ void AnimationTrackEditor::_update_key_edit() {
 		multi_key_edit = memnew(AnimationMultiTrackKeyEdit);
 		multi_key_edit->animation = animation;
 
-		Map<int, List<float> > key_ofs_map;
+		Map<int, List<float>> key_ofs_map;
 		Map<int, NodePath> base_map;
 		int first_track = -1;
 		for (Map<SelectedKey, KeyInfo>::Element *E = selection.front(); E; E = E->next()) {
@@ -5186,7 +5186,7 @@ void AnimationTrackEditor::_anim_duplicate_keys(bool transpose) {
 
 		undo_redo->create_action(TTR("Anim Duplicate Keys"));
 
-		List<Pair<int, float> > new_selection_values;
+		List<Pair<int, float>> new_selection_values;
 
 		for (Map<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 
@@ -5224,7 +5224,7 @@ void AnimationTrackEditor::_anim_duplicate_keys(bool transpose) {
 		//reselect duplicated
 
 		Map<SelectedKey, KeyInfo> new_selection;
-		for (List<Pair<int, float> >::Element *E = new_selection_values.front(); E; E = E->next()) {
+		for (List<Pair<int, float>>::Element *E = new_selection_values.front(); E; E = E->next()) {
 
 			int track = E->get().first;
 			float time = E->get().second;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -430,7 +430,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	Rect2 box_select_rect;
 	void _scroll_input(const Ref<InputEvent> &p_event);
 
-	Vector<Ref<AnimationTrackEditPlugin> > track_edit_plugins;
+	Vector<Ref<AnimationTrackEditPlugin>> track_edit_plugins;
 
 	void _cancel_bezier_edit();
 	void _bezier_edit(int p_for_track);

--- a/editor/collada/collada.cpp
+++ b/editor/collada/collada.cpp
@@ -1773,12 +1773,12 @@ void Collada::_parse_animation(XMLParser &parser) {
 		return;
 	}
 
-	Map<String, Vector<float> > float_sources;
-	Map<String, Vector<String> > string_sources;
+	Map<String, Vector<float>> float_sources;
+	Map<String, Vector<String>> string_sources;
 	Map<String, int> source_strides;
-	Map<String, Map<String, String> > samplers;
-	Map<String, Vector<String> > source_param_names;
-	Map<String, Vector<String> > source_param_types;
+	Map<String, Map<String, String>> samplers;
+	Map<String, Vector<String>> source_param_names;
+	Map<String, Vector<String>> source_param_types;
 
 	String id = "";
 	if (parser.has_attribute("id"))

--- a/editor/collada/collada.h
+++ b/editor/collada/collada.h
@@ -570,8 +570,8 @@ public:
 
 		Vector<AnimationClip> animation_clips;
 		Vector<AnimationTrack> animation_tracks;
-		Map<String, Vector<int> > referenced_tracks;
-		Map<String, Vector<int> > by_id_tracks;
+		Map<String, Vector<int>> referenced_tracks;
+		Map<String, Vector<int>> by_id_tracks;
 
 		float animation_length;
 

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -977,7 +977,7 @@ void ConnectionsDock::update_tree() {
 				String descr;
 				bool found = false;
 
-				Map<StringName, Map<StringName, String> >::Element *G = descr_cache.find(base);
+				Map<StringName, Map<StringName, String>>::Element *G = descr_cache.find(base);
 				if (G) {
 					Map<StringName, String>::Element *F = G->get().find(signal_name);
 					if (F) {

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -173,7 +173,7 @@ class ConnectionsDock : public VBoxContainer {
 	PopupMenu *slot_menu;
 	UndoRedo *undo_redo;
 
-	Map<StringName, Map<StringName, String> > descr_cache;
+	Map<StringName, Map<StringName, String>> descr_cache;
 
 	void _make_or_edit_connection();
 	void _connect(ConnectDialog::ConnectionData cToMake);

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -132,7 +132,7 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 	const String filter = EditorNode::get_singleton()->get_scene_tree_dock()->get_filter();
 
 	// Nodes are in a flatten list, depth first. Use a stack of parents, avoid recursion.
-	List<Pair<TreeItem *, int> > parents;
+	List<Pair<TreeItem *, int>> parents;
 	for (int i = 0; i < p_tree->nodes.size(); i++) {
 		TreeItem *parent = NULL;
 		if (parents.size()) { // Find last parent.

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -611,8 +611,8 @@ bool EditorProfiler::is_profiling() {
 	return activate->is_pressed();
 }
 
-Vector<Vector<String> > EditorProfiler::get_data_as_csv() const {
-	Vector<Vector<String> > res;
+Vector<Vector<String>> EditorProfiler::get_data_as_csv() const {
+	Vector<Vector<String>> res;
 
 	if (frame_metrics.empty()) {
 		return res;

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -169,7 +169,7 @@ public:
 
 	void clear();
 
-	Vector<Vector<String> > get_data_as_csv() const;
+	Vector<Vector<String>> get_data_as_csv() const;
 
 	EditorProfiler();
 };

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -678,8 +678,8 @@ bool EditorVisualProfiler::is_profiling() {
 	return activate->is_pressed();
 }
 
-Vector<Vector<String> > EditorVisualProfiler::get_data_as_csv() const {
-	Vector<Vector<String> > res;
+Vector<Vector<String>> EditorVisualProfiler::get_data_as_csv() const {
+	Vector<Vector<String>> res;
 #if 0
 	if (frame_metrics.empty()) {
 		return res;

--- a/editor/debugger/editor_visual_profiler.h
+++ b/editor/debugger/editor_visual_profiler.h
@@ -146,7 +146,7 @@ public:
 
 	void clear();
 
-	Vector<Vector<String> > get_data_as_csv() const;
+	Vector<Vector<String>> get_data_as_csv() const;
 
 	EditorVisualProfiler();
 };

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -165,7 +165,7 @@ void ScriptEditorDebugger::_file_selected(const String &p_file) {
 	file->store_csv_line(line);
 
 	// values
-	List<Vector<float> >::Element *E = perf_history.back();
+	List<Vector<float>>::Element *E = perf_history.back();
 	while (E) {
 
 		Vector<float> &perf_data = E->get();
@@ -178,7 +178,7 @@ void ScriptEditorDebugger::_file_selected(const String &p_file) {
 	}
 	file->store_string("\n");
 
-	Vector<Vector<String> > profiler_data = profiler->get_data_as_csv();
+	Vector<Vector<String>> profiler_data = profiler->get_data_as_csv();
 	for (int i = 0; i < profiler_data.size(); i++) {
 		file->store_csv_line(profiler_data[i]);
 	}
@@ -728,7 +728,7 @@ void ScriptEditorDebugger::_performance_draw() {
 		float spacing = point_sep / float(cols);
 		float from = r.size.width;
 
-		List<Vector<float> >::Element *E = perf_history.front();
+		List<Vector<float>>::Element *E = perf_history.front();
 		float prev = -1;
 		while (from >= 0 && E) {
 

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -109,7 +109,7 @@ private:
 	// Each debugger should have it's tree in the future I guess.
 	const Tree *editor_remote_tree = NULL;
 
-	List<Vector<float> > perf_history;
+	List<Vector<float>> perf_history;
 	Vector<float> perf_max;
 	Vector<TreeItem *> perf_items;
 

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -63,7 +63,7 @@ void DependencyEditor::_load_pressed(Object *p_item, int p_cell, int p_button) {
 	search->popup_centered_ratio(0.65); // So it doesn't completely cover the dialog below it.
 }
 
-void DependencyEditor::_fix_and_find(EditorFileSystemDirectory *efsd, Map<String, Map<String, String> > &candidates) {
+void DependencyEditor::_fix_and_find(EditorFileSystemDirectory *efsd, Map<String, Map<String, String>> &candidates) {
 
 	for (int i = 0; i < efsd->get_subdir_count(); i++) {
 		_fix_and_find(efsd->get_subdir(i), candidates);
@@ -124,7 +124,7 @@ void DependencyEditor::_fix_all() {
 	if (!EditorFileSystem::get_singleton()->get_filesystem())
 		return;
 
-	Map<String, Map<String, String> > candidates;
+	Map<String, Map<String, String>> candidates;
 
 	for (List<String>::Element *E = missing.front(); E; E = E->next()) {
 
@@ -140,7 +140,7 @@ void DependencyEditor::_fix_all() {
 
 	Map<String, String> remaps;
 
-	for (Map<String, Map<String, String> >::Element *E = candidates.front(); E; E = E->next()) {
+	for (Map<String, Map<String, String>>::Element *E = candidates.front(); E; E = E->next()) {
 
 		for (Map<String, String>::Element *F = E->get().front(); F; F = F->next()) {
 

--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -52,7 +52,7 @@ class DependencyEditor : public AcceptDialog {
 	String editing;
 	List<String> missing;
 
-	void _fix_and_find(EditorFileSystemDirectory *efsd, Map<String, Map<String, String> > &candidates);
+	void _fix_and_find(EditorFileSystemDirectory *efsd, Map<String, Map<String, String>> &candidates);
 
 	void _searched(const String &p_path);
 	void _load_pressed(Object *p_item, int p_cell, int p_button);

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -687,10 +687,10 @@ void DocData::generate(bool p_basic_types) {
 				c.methods.push_back(md);
 			}
 
-			List<Pair<String, Variant> > cinfo;
+			List<Pair<String, Variant>> cinfo;
 			lang->get_public_constants(&cinfo);
 
-			for (List<Pair<String, Variant> >::Element *E = cinfo.front(); E; E = E->next()) {
+			for (List<Pair<String, Variant>>::Element *E = cinfo.front(); E; E = E->next()) {
 
 				ConstantDoc cd;
 				cd.name = E->get().first;

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -110,7 +110,7 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 		ret = unzGoToNextFile(pkg);
 	}
 
-	Map<String, Ref<Texture2D> > extension_guess;
+	Map<String, Ref<Texture2D>> extension_guess;
 	{
 		extension_guess["png"] = get_icon("ImageTexture", "EditorIcons");
 		extension_guess["jpg"] = get_icon("ImageTexture", "EditorIcons");

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -521,7 +521,7 @@ Object *EditorData::instance_custom_type(const String &p_type, const String &p_i
 
 void EditorData::remove_custom_type(const String &p_type) {
 
-	for (Map<String, Vector<CustomType> >::Element *E = custom_types.front(); E; E = E->next()) {
+	for (Map<String, Vector<CustomType>>::Element *E = custom_types.front(); E; E = E->next()) {
 
 		for (int i = 0; i < E->get().size(); i++) {
 			if (E->get()[i].name == p_type) {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -135,7 +135,7 @@ private:
 		String name;
 		Variant value;
 	};
-	Map<String, Vector<CustomType> > custom_types;
+	Map<String, Vector<CustomType>> custom_types;
 
 	List<PropertyData> clipboard;
 	UndoRedo undo_redo;
@@ -181,7 +181,7 @@ public:
 	void add_custom_type(const String &p_type, const String &p_inherits, const Ref<Script> &p_script, const Ref<Texture2D> &p_icon);
 	Object *instance_custom_type(const String &p_type, const String &p_inherits);
 	void remove_custom_type(const String &p_type);
-	const Map<String, Vector<CustomType> > &get_custom_types() const { return custom_types; }
+	const Map<String, Vector<CustomType>> &get_custom_types() const { return custom_types; }
 
 	int add_edited_scene(int p_at_pos);
 	void move_edited_scene_index(int p_idx, int p_to_idx);

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -664,7 +664,7 @@ EditorExportPlatform::FeatureContainers EditorExportPlatform::get_feature_contai
 
 EditorExportPlatform::ExportNotifier::ExportNotifier(EditorExportPlatform &p_platform, const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
 	FeatureContainers features = p_platform.get_feature_containers(p_preset);
-	Vector<Ref<EditorExportPlugin> > export_plugins = EditorExport::get_singleton()->get_export_plugins();
+	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	//initial export plugin callback
 	for (int i = 0; i < export_plugins.size(); i++) {
 		if (export_plugins[i]->get_script_instance()) { //script based
@@ -676,7 +676,7 @@ EditorExportPlatform::ExportNotifier::ExportNotifier(EditorExportPlatform &p_pla
 }
 
 EditorExportPlatform::ExportNotifier::~ExportNotifier() {
-	Vector<Ref<EditorExportPlugin> > export_plugins = EditorExport::get_singleton()->get_export_plugins();
+	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	for (int i = 0; i < export_plugins.size(); i++) {
 		if (export_plugins[i]->get_script_instance()) {
 			export_plugins.write[i]->_export_end_script();
@@ -712,7 +712,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	_edit_filter_list(paths, p_preset->get_include_filter(), false);
 	_edit_filter_list(paths, p_preset->get_exclude_filter(), true);
 
-	Vector<Ref<EditorExportPlugin> > export_plugins = EditorExport::get_singleton()->get_export_plugins();
+	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	for (int i = 0; i < export_plugins.size(); i++) {
 
 		export_plugins.write[i]->set_export_preset(p_preset);
@@ -1284,7 +1284,7 @@ void EditorExport::remove_export_plugin(const Ref<EditorExportPlugin> &p_plugin)
 	export_plugins.erase(p_plugin);
 }
 
-Vector<Ref<EditorExportPlugin> > EditorExport::get_export_plugins() {
+Vector<Ref<EditorExportPlugin>> EditorExport::get_export_plugins() {
 
 	return export_plugins;
 }

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -347,9 +347,9 @@ public:
 class EditorExport : public Node {
 	GDCLASS(EditorExport, Node);
 
-	Vector<Ref<EditorExportPlatform> > export_platforms;
-	Vector<Ref<EditorExportPreset> > export_presets;
-	Vector<Ref<EditorExportPlugin> > export_plugins;
+	Vector<Ref<EditorExportPlatform>> export_platforms;
+	Vector<Ref<EditorExportPreset>> export_presets;
+	Vector<Ref<EditorExportPlugin>> export_plugins;
 
 	Timer *save_timer;
 	bool block_save;
@@ -379,7 +379,7 @@ public:
 
 	void add_export_plugin(const Ref<EditorExportPlugin> &p_plugin);
 	void remove_export_plugin(const Ref<EditorExportPlugin> &p_plugin);
-	Vector<Ref<EditorExportPlugin> > get_export_plugins();
+	Vector<Ref<EditorExportPlugin>> get_export_plugins();
 
 	void load_config();
 

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -153,7 +153,7 @@ Error EditorFeatureProfile::save_to_file(const String &p_path) {
 
 	Array dis_props;
 
-	for (Map<StringName, Set<StringName> >::Element *E = disabled_properties.front(); E; E = E->next()) {
+	for (Map<StringName, Set<StringName>>::Element *E = disabled_properties.front(); E; E = E->next()) {
 		for (Set<StringName>::Element *F = E->get().front(); F; F = F->next()) {
 			dis_props.push_back(String(E->key()) + ":" + String(F->get()));
 		}

--- a/editor/editor_feature_profile.h
+++ b/editor/editor_feature_profile.h
@@ -58,7 +58,7 @@ public:
 private:
 	Set<StringName> disabled_classes;
 	Set<StringName> disabled_editors;
-	Map<StringName, Set<StringName> > disabled_properties;
+	Map<StringName, Set<StringName>> disabled_properties;
 
 	bool features_disabled[FEATURE_MAX];
 	static const char *feature_names[FEATURE_MAX];

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1558,7 +1558,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 
 	String importer_name;
 
-	Map<String, Map<StringName, Variant> > source_file_options;
+	Map<String, Map<StringName, Variant>> source_file_options;
 	Map<String, String> base_paths;
 	for (int i = 0; i < p_files.size(); i++) {
 
@@ -1610,7 +1610,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 	Error err = importer->import_group_file(p_group_file, source_file_options, base_paths);
 
 	//all went well, overwrite config files with proper remaps and md5s
-	for (Map<String, Map<StringName, Variant> >::Element *E = source_file_options.front(); E; E = E->next()) {
+	for (Map<String, Map<StringName, Variant>>::Element *E = source_file_options.front(); E; E = E->next()) {
 
 		const String &file = E->key();
 		String base_path = ResourceFormatImporter::get_singleton()->get_import_base_path(file);
@@ -1921,7 +1921,7 @@ void EditorFileSystem::_reimport_file(const String &p_file) {
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
 }
 
-void EditorFileSystem::_find_group_files(EditorFileSystemDirectory *efd, Map<String, Vector<String> > &group_files, Set<String> &groups_to_reimport) {
+void EditorFileSystem::_find_group_files(EditorFileSystemDirectory *efd, Map<String, Vector<String>> &group_files, Set<String> &groups_to_reimport) {
 
 	int fc = efd->files.size();
 	const EditorFileSystemDirectory::FileInfo *const *files = efd->files.ptr();
@@ -1998,9 +1998,9 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 	//reimport groups
 
 	if (groups_to_reimport.size()) {
-		Map<String, Vector<String> > group_files;
+		Map<String, Vector<String>> group_files;
 		_find_group_files(filesystem, group_files, groups_to_reimport);
-		for (Map<String, Vector<String> >::Element *E = group_files.front(); E; E = E->next()) {
+		for (Map<String, Vector<String>>::Element *E = group_files.front(); E; E = E->next()) {
 
 			Error err = _reimport_group(E->key(), E->get());
 			if (err == OK) {

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -240,7 +240,7 @@ class EditorFileSystem : public Node {
 
 	bool using_fat32_or_exfat; // Workaround for projects in FAT32 or exFAT filesystem (pendrives, most of the time)
 
-	void _find_group_files(EditorFileSystemDirectory *efd, Map<String, Vector<String> > &group_files, Set<String> &groups_to_reimport);
+	void _find_group_files(EditorFileSystemDirectory *efd, Map<String, Vector<String>> &group_files, Set<String> &groups_to_reimport);
 
 	void _move_group_files(EditorFileSystemDirectory *efd, const String &p_group_file, const String &p_new_location);
 

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -812,7 +812,7 @@ void EditorHelp::_update_doc() {
 	// Constants and enums
 	if (cd.constants.size()) {
 
-		Map<String, Vector<DocData::ConstantDoc> > enums;
+		Map<String, Vector<DocData::ConstantDoc>> enums;
 		Vector<DocData::ConstantDoc> constants;
 
 		for (int i = 0; i < cd.constants.size(); i++) {
@@ -842,7 +842,7 @@ void EditorHelp::_update_doc() {
 
 			class_desc->add_newline();
 
-			for (Map<String, Vector<DocData::ConstantDoc> >::Element *E = enums.front(); E; E = E->next()) {
+			for (Map<String, Vector<DocData::ConstantDoc>>::Element *E = enums.front(); E; E = E->next()) {
 
 				enum_line[E->key()] = class_desc->get_line_count() - 2;
 
@@ -1188,7 +1188,7 @@ void EditorHelp::_help_callback(const String &p_topic) {
 		if (constant_line.has(name))
 			line = constant_line[name];
 		else {
-			Map<String, Map<String, int> >::Element *iter = enum_values_line.front();
+			Map<String, Map<String, int>>::Element *iter = enum_values_line.front();
 			while (true) {
 				if (iter->value().has(name)) {
 					line = iter->value()[name];
@@ -1489,8 +1489,8 @@ void EditorHelp::go_to_class(const String &p_class, int p_scroll) {
 	_goto_desc(p_class, p_scroll);
 }
 
-Vector<Pair<String, int> > EditorHelp::get_sections() {
-	Vector<Pair<String, int> > sections;
+Vector<Pair<String, int>> EditorHelp::get_sections() {
+	Vector<Pair<String, int>> sections;
 
 	for (int i = 0; i < section_line.size(); i++) {
 		sections.push_back(Pair<String, int>(section_line[i].first, i));

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -108,14 +108,14 @@ class EditorHelp : public VBoxContainer {
 
 	String edited_class;
 
-	Vector<Pair<String, int> > section_line;
+	Vector<Pair<String, int>> section_line;
 	Map<String, int> method_line;
 	Map<String, int> signal_line;
 	Map<String, int> property_line;
 	Map<String, int> theme_property_line;
 	Map<String, int> constant_line;
 	Map<String, int> enum_line;
-	Map<String, Map<String, int> > enum_values_line;
+	Map<String, Map<String, int>> enum_values_line;
 	int description_line;
 
 	RichTextLabel *class_desc;
@@ -175,7 +175,7 @@ public:
 	void go_to_help(const String &p_help);
 	void go_to_class(const String &p_class, int p_scroll = 0);
 
-	Vector<Pair<String, int> > get_sections();
+	Vector<Pair<String, int>> get_sections();
 	void scroll_to_section(int p_section_index);
 
 	void popup_search();

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1454,7 +1454,7 @@ void EditorInspector::update_tree() {
 	if (!object)
 		return;
 
-	List<Ref<EditorInspectorPlugin> > valid_plugins;
+	List<Ref<EditorInspectorPlugin>> valid_plugins;
 
 	for (int i = inspector_plugin_count - 1; i >= 0; i--) { //start by last, so lastly added can override newly added
 		if (!inspector_plugins[i]->can_handle(object))
@@ -1490,7 +1490,7 @@ void EditorInspector::update_tree() {
 
 	Color sscolor = get_color("prop_subsection", "Editor");
 
-	for (List<Ref<EditorInspectorPlugin> >::Element *E = valid_plugins.front(); E; E = E->next()) {
+	for (List<Ref<EditorInspectorPlugin>>::Element *E = valid_plugins.front(); E; E = E->next()) {
 		Ref<EditorInspectorPlugin> ped = E->get();
 		ped->parse_begin(object);
 		_parse_added_editors(main_vbox, ped);
@@ -1557,7 +1557,7 @@ void EditorInspector::update_tree() {
 				category->set_tooltip(p.name + "::" + (class_descr_cache[type2] == "" ? "" : class_descr_cache[type2]));
 			}
 
-			for (List<Ref<EditorInspectorPlugin> >::Element *E = valid_plugins.front(); E; E = E->next()) {
+			for (List<Ref<EditorInspectorPlugin>>::Element *E = valid_plugins.front(); E; E = E->next()) {
 				Ref<EditorInspectorPlugin> ped = E->get();
 				ped->parse_category(object, p.name);
 				_parse_added_editors(main_vbox, ped);
@@ -1688,7 +1688,7 @@ void EditorInspector::update_tree() {
 			String descr;
 			bool found = false;
 
-			Map<StringName, Map<StringName, String> >::Element *E = descr_cache.find(classname);
+			Map<StringName, Map<StringName, String>>::Element *E = descr_cache.find(classname);
 			if (E) {
 				Map<StringName, String>::Element *F = E->get().find(propname);
 				if (F) {
@@ -1719,7 +1719,7 @@ void EditorInspector::update_tree() {
 			doc_hint = descr;
 		}
 
-		for (List<Ref<EditorInspectorPlugin> >::Element *E = valid_plugins.front(); E; E = E->next()) {
+		for (List<Ref<EditorInspectorPlugin>>::Element *E = valid_plugins.front(); E; E = E->next()) {
 			Ref<EditorInspectorPlugin> ped = E->get();
 			bool exclusive = ped->parse_property(object, p.type, p.name, p.hint, p.hint_string, p.usage);
 
@@ -1802,7 +1802,7 @@ void EditorInspector::update_tree() {
 		}
 	}
 
-	for (List<Ref<EditorInspectorPlugin> >::Element *E = valid_plugins.front(); E; E = E->next()) {
+	for (List<Ref<EditorInspectorPlugin>>::Element *E = valid_plugins.front(); E; E = E->next()) {
 		Ref<EditorInspectorPlugin> ped = E->get();
 		ped->parse_end();
 		_parse_added_editors(main_vbox, ped);
@@ -1933,7 +1933,7 @@ void EditorInspector::collapse_all_folding() {
 		E->get()->fold();
 	}
 
-	for (Map<StringName, List<EditorProperty *> >::Element *F = editor_property_map.front(); F; F = F->next()) {
+	for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
 		for (List<EditorProperty *>::Element *E = F->get().front(); E; E = E->next()) {
 			E->get()->collapse_all_folding();
 		}
@@ -1944,7 +1944,7 @@ void EditorInspector::expand_all_folding() {
 	for (List<EditorInspectorSection *>::Element *E = sections.front(); E; E = E->next()) {
 		E->get()->unfold();
 	}
-	for (Map<StringName, List<EditorProperty *> >::Element *F = editor_property_map.front(); F; F = F->next()) {
+	for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
 		for (List<EditorProperty *>::Element *E = F->get().front(); E; E = E->next()) {
 			E->get()->expand_all_folding();
 		}
@@ -2154,7 +2154,7 @@ void EditorInspector::_property_selected(const String &p_path, int p_focusable) 
 	property_selected = p_path;
 	property_focusable = p_focusable;
 	//deselect the others
-	for (Map<StringName, List<EditorProperty *> >::Element *F = editor_property_map.front(); F; F = F->next()) {
+	for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
 		if (F->key() == property_selected)
 			continue;
 		for (List<EditorProperty *>::Element *E = F->get().front(); E; E = E->next()) {
@@ -2217,7 +2217,7 @@ void EditorInspector::_notification(int p_what) {
 		if (refresh_countdown > 0) {
 			refresh_countdown -= get_process_delta_time();
 			if (refresh_countdown <= 0) {
-				for (Map<StringName, List<EditorProperty *> >::Element *F = editor_property_map.front(); F; F = F->next()) {
+				for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
 					for (List<EditorProperty *>::Element *E = F->get().front(); E; E = E->next()) {
 						E->get()->update_property();
 						E->get()->update_reload_status();

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -261,7 +261,7 @@ class EditorInspector : public ScrollContainer {
 	VBoxContainer *main_vbox;
 
 	//map use to cache the instanced editors
-	Map<StringName, List<EditorProperty *> > editor_property_map;
+	Map<StringName, List<EditorProperty *>> editor_property_map;
 	List<EditorInspectorSection *> sections;
 	Set<StringName> pending;
 
@@ -291,7 +291,7 @@ class EditorInspector : public ScrollContainer {
 	int property_focusable;
 	int update_scroll_request;
 
-	Map<StringName, Map<StringName, String> > descr_cache;
+	Map<StringName, Map<StringName, String>> descr_cache;
 	Map<StringName, String> class_descr_cache;
 	Set<StringName> restart_request_props;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -547,7 +547,7 @@ void EditorNode::_on_plugin_ready(Object *p_script, const String &p_activate_nam
 
 void EditorNode::_resources_changed(const Vector<String> &p_resources) {
 
-	List<Ref<Resource> > changed;
+	List<Ref<Resource>> changed;
 
 	int rc = p_resources.size();
 	for (int i = 0; i < rc; i++) {
@@ -573,7 +573,7 @@ void EditorNode::_resources_changed(const Vector<String> &p_resources) {
 	}
 
 	if (changed.size()) {
-		for (List<Ref<Resource> >::Element *E = changed.front(); E; E = E->next()) {
+		for (List<Ref<Resource>>::Element *E = changed.front(); E; E = E->next()) {
 			E->get()->reload_from_file();
 		}
 	}
@@ -1210,7 +1210,7 @@ bool EditorNode::_validate_scene_recursive(const String &p_filename, Node *p_nod
 	return false;
 }
 
-static bool _find_edited_resources(const Ref<Resource> &p_resource, Set<Ref<Resource> > &edited_resources) {
+static bool _find_edited_resources(const Ref<Resource> &p_resource, Set<Ref<Resource>> &edited_resources) {
 
 	if (p_resource->is_edited()) {
 		edited_resources.insert(p_resource);
@@ -1247,11 +1247,11 @@ int EditorNode::_save_external_resources() {
 		flg |= ResourceSaver::FLAG_COMPRESS;
 	flg |= ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS;
 
-	Set<Ref<Resource> > edited_subresources;
+	Set<Ref<Resource>> edited_subresources;
 	int saved = 0;
-	List<Ref<Resource> > cached;
+	List<Ref<Resource>> cached;
 	ResourceCache::get_cached_resources(&cached);
-	for (List<Ref<Resource> >::Element *E = cached.front(); E; E = E->next()) {
+	for (List<Ref<Resource>>::Element *E = cached.front(); E; E = E->next()) {
 
 		Ref<Resource> res = E->get();
 		if (!res->get_path().is_resource_file())
@@ -1266,7 +1266,7 @@ int EditorNode::_save_external_resources() {
 	// clear later, because user may have put the same subresource in two different resources,
 	// which will be shared until the next reload
 
-	for (Set<Ref<Resource> >::Element *E = edited_subresources.front(); E; E = E->next()) {
+	for (Set<Ref<Resource>>::Element *E = edited_subresources.front(); E; E = E->next()) {
 		Ref<Resource> res = E->get();
 		res->set_edited(false);
 	}
@@ -3333,7 +3333,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 
 	dependency_errors.erase(lpath); //at least not self path
 
-	for (Map<String, Set<String> >::Element *E = dependency_errors.front(); E; E = E->next()) {
+	for (Map<String, Set<String>>::Element *E = dependency_errors.front(); E; E = E->next()) {
 
 		String txt = vformat(TTR("Scene '%s' has broken dependencies:"), E->key()) + "\n";
 		for (Set<String>::Element *F = E->get().front(); F; F = F->next()) {
@@ -3787,8 +3787,8 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 		return icon;
 	}
 
-	const Map<String, Vector<EditorData::CustomType> > &p_map = EditorNode::get_editor_data().get_custom_types();
-	for (const Map<String, Vector<EditorData::CustomType> >::Element *E = p_map.front(); E; E = E->next()) {
+	const Map<String, Vector<EditorData::CustomType>> &p_map = EditorNode::get_editor_data().get_custom_types();
+	for (const Map<String, Vector<EditorData::CustomType>>::Element *E = p_map.front(); E; E = E->next()) {
 		const Vector<EditorData::CustomType> &ct = E->value();
 		for (int i = 0; i < ct.size(); ++i) {
 			if (ct[i].name == p_class) {
@@ -5120,10 +5120,10 @@ void EditorNode::reload_scene(const String &p_path) {
 
 	//first of all, reload internal textures, materials, meshes, etc. as they might have changed on disk
 
-	List<Ref<Resource> > cached;
+	List<Ref<Resource>> cached;
 	ResourceCache::get_cached_resources(&cached);
-	List<Ref<Resource> > to_clear; //clear internal resources from previous scene from being used
-	for (List<Ref<Resource> >::Element *E = cached.front(); E; E = E->next()) {
+	List<Ref<Resource>> to_clear; //clear internal resources from previous scene from being used
+	for (List<Ref<Resource>>::Element *E = cached.front(); E; E = E->next()) {
 
 		if (E->get()->get_path().begins_with(p_path + "::")) { //subresources of existing scene
 			to_clear.push_back(E->get());
@@ -5254,9 +5254,9 @@ void EditorNode::remove_resource_conversion_plugin(const Ref<EditorResourceConve
 	resource_conversion_plugins.erase(p_plugin);
 }
 
-Vector<Ref<EditorResourceConversionPlugin> > EditorNode::find_resource_conversion_plugin(const Ref<Resource> &p_for_resource) {
+Vector<Ref<EditorResourceConversionPlugin>> EditorNode::find_resource_conversion_plugin(const Ref<Resource> &p_for_resource) {
 
-	Vector<Ref<EditorResourceConversionPlugin> > ret;
+	Vector<Ref<EditorResourceConversionPlugin>> ret;
 
 	for (int i = 0; i < resource_conversion_plugins.size(); i++) {
 		if (resource_conversion_plugins[i].is_valid() && resource_conversion_plugins[i]->handles(p_for_resource)) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -513,7 +513,7 @@ private:
 	Set<FileDialog *> file_dialogs;
 	Set<EditorFileDialog *> editor_file_dialogs;
 
-	Map<String, Ref<Texture2D> > icon_type_cache;
+	Map<String, Ref<Texture2D>> icon_type_cache;
 	void _build_icon_type_cache();
 
 	bool _initializing_addons;
@@ -536,7 +536,7 @@ private:
 	void _find_node_types(Node *p_node, int &count_2d, int &count_3d);
 	void _save_scene_with_preview(String p_file, int p_idx = -1);
 
-	Map<String, Set<String> > dependency_errors;
+	Map<String, Set<String>> dependency_errors;
 
 	static void _dependency_error_report(void *ud, const String &p_path, const String &p_dep, const String &p_type) {
 		EditorNode *en = (EditorNode *)ud;
@@ -622,7 +622,7 @@ private:
 
 	void _update_update_spinner();
 
-	Vector<Ref<EditorResourceConversionPlugin> > resource_conversion_plugins;
+	Vector<Ref<EditorResourceConversionPlugin>> resource_conversion_plugins;
 
 	PrintHandlerList print_handler;
 	static void _print_handler(void *p_this, const String &p_string, bool p_error);
@@ -844,7 +844,7 @@ public:
 
 	void add_resource_conversion_plugin(const Ref<EditorResourceConversionPlugin> &p_plugin);
 	void remove_resource_conversion_plugin(const Ref<EditorResourceConversionPlugin> &p_plugin);
-	Vector<Ref<EditorResourceConversionPlugin> > find_resource_conversion_plugin(const Ref<Resource> &p_for_resource);
+	Vector<Ref<EditorResourceConversionPlugin>> find_resource_conversion_plugin(const Ref<Resource> &p_for_resource);
 
 	static void add_init_callback(EditorNodeInitCallback p_callback) { _init_callbacks.push_back(p_callback); }
 	static void add_build_callback(EditorBuildCallback p_callback);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -45,13 +45,13 @@
 
 Array EditorInterface::_make_mesh_previews(const Array &p_meshes, int p_preview_size) {
 
-	Vector<Ref<Mesh> > meshes;
+	Vector<Ref<Mesh>> meshes;
 
 	for (int i = 0; i < p_meshes.size(); i++) {
 		meshes.push_back(p_meshes[i]);
 	}
 
-	Vector<Ref<Texture2D> > textures = make_mesh_previews(meshes, NULL, p_preview_size);
+	Vector<Ref<Texture2D>> textures = make_mesh_previews(meshes, NULL, p_preview_size);
 	Array ret;
 	for (int i = 0; i < textures.size(); i++) {
 		ret.push_back(textures[i]);
@@ -60,7 +60,7 @@ Array EditorInterface::_make_mesh_previews(const Array &p_meshes, int p_preview_
 	return ret;
 }
 
-Vector<Ref<Texture2D> > EditorInterface::make_mesh_previews(const Vector<Ref<Mesh> > &p_meshes, Vector<Transform> *p_transforms, int p_preview_size) {
+Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform> *p_transforms, int p_preview_size) {
 
 	int size = p_preview_size;
 
@@ -86,7 +86,7 @@ Vector<Ref<Texture2D> > EditorInterface::make_mesh_previews(const Vector<Ref<Mes
 
 	EditorProgress ep("mlib", TTR("Creating Mesh Previews"), p_meshes.size());
 
-	Vector<Ref<Texture2D> > textures;
+	Vector<Ref<Texture2D>> textures;
 
 	for (int i = 0; i < p_meshes.size(); i++) {
 

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -98,7 +98,7 @@ public:
 	Error save_scene();
 	void save_scene_as(const String &p_scene, bool p_with_preview = true);
 
-	Vector<Ref<Texture2D> > make_mesh_previews(const Vector<Ref<Mesh> > &p_meshes, Vector<Transform> *p_transforms, int p_preview_size);
+	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform> *p_transforms, int p_preview_size);
 
 	void set_main_screen_editor(const String &p_name);
 	void set_distraction_free_mode(bool p_enter);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2121,7 +2121,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 
 			List<PropertyInfo> property_list;
 			res_orig->get_property_list(&property_list);
-			List<Pair<String, Variant> > propvalues;
+			List<Pair<String, Variant>> propvalues;
 
 			for (List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
 
@@ -2144,7 +2144,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 
 			ERR_FAIL_COND(res.is_null());
 
-			for (List<Pair<String, Variant> >::Element *E = propvalues.front(); E; E = E->next()) {
+			for (List<Pair<String, Variant>>::Element *E = propvalues.front(); E; E = E->next()) {
 
 				Pair<String, Variant> &p = E->get();
 				res->set(p.first, p.second);
@@ -2206,7 +2206,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 
 				int to_type = p_which - CONVERT_BASE_ID;
 
-				Vector<Ref<EditorResourceConversionPlugin> > conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(res);
+				Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(res);
 
 				ERR_FAIL_INDEX(to_type, conversions.size());
 
@@ -2438,7 +2438,7 @@ void EditorPropertyResource::_update_menu_items() {
 
 	if (!res.is_null()) {
 
-		Vector<Ref<EditorResourceConversionPlugin> > conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(res);
+		Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(res);
 		if (conversions.size()) {
 			menu->add_separator();
 		}

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -94,7 +94,7 @@ class EditorResourcePreview : public Node {
 	static void _thread_func(void *ud);
 	void _thread();
 
-	Vector<Ref<EditorResourcePreviewGenerator> > preview_generators;
+	Vector<Ref<EditorResourcePreviewGenerator>> preview_generators;
 
 protected:
 	static void _bind_methods();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -125,7 +125,7 @@ bool EditorSettings::_get(const StringName &p_name, Variant &r_ret) const {
 	if (p_name.operator String() == "shortcuts") {
 
 		Array arr;
-		for (const Map<String, Ref<ShortCut> >::Element *E = shortcuts.front(); E; E = E->next()) {
+		for (const Map<String, Ref<ShortCut>>::Element *E = shortcuts.front(); E; E = E->next()) {
 
 			Ref<ShortCut> sc = E->get();
 
@@ -1476,7 +1476,7 @@ void EditorSettings::add_shortcut(const String &p_name, Ref<ShortCut> &p_shortcu
 
 bool EditorSettings::is_shortcut(const String &p_name, const Ref<InputEvent> &p_event) const {
 
-	const Map<String, Ref<ShortCut> >::Element *E = shortcuts.find(p_name);
+	const Map<String, Ref<ShortCut>>::Element *E = shortcuts.find(p_name);
 	ERR_FAIL_COND_V_MSG(!E, false, "Unknown Shortcut: " + p_name + ".");
 
 	return E->get()->is_shortcut(p_event);
@@ -1484,7 +1484,7 @@ bool EditorSettings::is_shortcut(const String &p_name, const Ref<InputEvent> &p_
 
 Ref<ShortCut> EditorSettings::get_shortcut(const String &p_name) const {
 
-	const Map<String, Ref<ShortCut> >::Element *E = shortcuts.find(p_name);
+	const Map<String, Ref<ShortCut>>::Element *E = shortcuts.find(p_name);
 	if (!E)
 		return Ref<ShortCut>();
 
@@ -1493,7 +1493,7 @@ Ref<ShortCut> EditorSettings::get_shortcut(const String &p_name) const {
 
 void EditorSettings::get_shortcut_list(List<String> *r_shortcuts) {
 
-	for (const Map<String, Ref<ShortCut> >::Element *E = shortcuts.front(); E; E = E->next()) {
+	for (const Map<String, Ref<ShortCut>>::Element *E = shortcuts.front(); E; E = E->next()) {
 
 		r_shortcuts->push_back(E->key());
 	}

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -95,7 +95,7 @@ private:
 	int last_order;
 
 	Ref<Resource> clipboard;
-	Map<String, Ref<ShortCut> > shortcuts;
+	Map<String, Ref<ShortCut>> shortcuts;
 
 	String resource_path;
 	String settings_dir;

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1085,10 +1085,10 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 
 void FileSystemDock::_update_resource_paths_after_move(const Map<String, String> &p_renames) const {
 	// Rename all resources loaded, be it subresources or actual resources.
-	List<Ref<Resource> > cached;
+	List<Ref<Resource>> cached;
 	ResourceCache::get_cached_resources(&cached);
 
-	for (List<Ref<Resource> >::Element *E = cached.front(); E; E = E->next()) {
+	for (List<Ref<Resource>>::Element *E = cached.front(); E; E = E->next()) {
 		Ref<Resource> r = E->get();
 
 		String base_path = r->get_path();

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -49,7 +49,7 @@ struct ColladaImport {
 	Collada collada;
 	Spatial *scene;
 
-	Vector<Ref<Animation> > animations;
+	Vector<Ref<Animation>> animations;
 
 	struct NodeMap {
 		//String path;
@@ -73,12 +73,12 @@ struct ColladaImport {
 
 	Map<String, NodeMap> node_map; //map from collada node to engine node
 	Map<String, String> node_name_map; //map from collada node to engine node
-	Map<String, Ref<ArrayMesh> > mesh_cache;
-	Map<String, Ref<Curve3D> > curve_cache;
-	Map<String, Ref<Material> > material_cache;
+	Map<String, Ref<ArrayMesh>> mesh_cache;
+	Map<String, Ref<Curve3D>> curve_cache;
+	Map<String, Ref<Material>> material_cache;
 	Map<Collada::Node *, Skeleton *> skeleton_map;
 
-	Map<Skeleton *, Map<String, int> > skeleton_bone_map;
+	Map<Skeleton *, Map<String, int>> skeleton_bone_map;
 
 	Set<String> valid_animated_nodes;
 	Vector<int> valid_animated_properties;
@@ -89,7 +89,7 @@ struct ColladaImport {
 	Error _create_scene(Collada::Node *p_node, Spatial *p_parent);
 	Error _create_resources(Collada::Node *p_node, bool p_use_compression);
 	Error _create_material(const String &p_target);
-	Error _create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_mesh, const Map<String, Collada::NodeGeometry::Material> &p_material_map, const Collada::MeshData &meshdata, const Transform &p_local_xform, const Vector<int> &bone_remap, const Collada::SkinControllerData *p_skin_controller, const Collada::MorphControllerData *p_morph_data, Vector<Ref<ArrayMesh> > p_morph_meshes = Vector<Ref<ArrayMesh> >(), bool p_use_compression = false, bool p_use_mesh_material = false);
+	Error _create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_mesh, const Map<String, Collada::NodeGeometry::Material> &p_material_map, const Collada::MeshData &meshdata, const Transform &p_local_xform, const Vector<int> &bone_remap, const Collada::SkinControllerData *p_skin_controller, const Collada::MorphControllerData *p_morph_data, Vector<Ref<ArrayMesh>> p_morph_meshes = Vector<Ref<ArrayMesh>>(), bool p_use_compression = false, bool p_use_mesh_material = false);
 	Error load(const String &p_path, int p_flags, bool p_force_make_tangents = false, bool p_use_compression = false);
 	void _fix_param_animation_tracks();
 	void create_animation(int p_clip, bool p_make_tracks_in_all_bones, bool p_import_value_tracks);
@@ -489,7 +489,7 @@ Error ColladaImport::_create_material(const String &p_target) {
 	return OK;
 }
 
-Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_mesh, const Map<String, Collada::NodeGeometry::Material> &p_material_map, const Collada::MeshData &meshdata, const Transform &p_local_xform, const Vector<int> &bone_remap, const Collada::SkinControllerData *p_skin_controller, const Collada::MorphControllerData *p_morph_data, Vector<Ref<ArrayMesh> > p_morph_meshes, bool p_use_compression, bool p_use_mesh_material) {
+Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_mesh, const Map<String, Collada::NodeGeometry::Material> &p_material_map, const Collada::MeshData &meshdata, const Transform &p_local_xform, const Vector<int> &bone_remap, const Collada::SkinControllerData *p_skin_controller, const Collada::MorphControllerData *p_morph_data, Vector<Ref<ArrayMesh>> p_morph_meshes, bool p_use_compression, bool p_use_mesh_material) {
 
 	bool local_xform_mirror = p_local_xform.basis.determinant() < 0;
 
@@ -608,7 +608,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 		/* ADD WEIGHTS IF EXIST */
 		/************************/
 
-		Map<int, Vector<Collada::Vertex::Weight> > pre_weights;
+		Map<int, Vector<Collada::Vertex::Weight>> pre_weights;
 
 		bool has_weights = false;
 
@@ -1096,7 +1096,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 			String meshid;
 			Transform apply_xform;
 			Vector<int> bone_remap;
-			Vector<Ref<ArrayMesh> > morphs;
+			Vector<Ref<ArrayMesh>> morphs;
 
 			if (ng2->controller) {
 
@@ -1173,7 +1173,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 									Ref<ArrayMesh> mesh = Ref<ArrayMesh>(memnew(ArrayMesh));
 									const Collada::MeshData &meshdata = collada.state.mesh_data_map[meshid2];
 									mesh->set_name(meshdata.name);
-									Error err = _create_mesh_surfaces(false, mesh, ng2->material_map, meshdata, apply_xform, bone_remap, skin, NULL, Vector<Ref<ArrayMesh> >(), false);
+									Error err = _create_mesh_surfaces(false, mesh, ng2->material_map, meshdata, apply_xform, bone_remap, skin, NULL, Vector<Ref<ArrayMesh>>(), false);
 									ERR_FAIL_COND_V(err, err);
 
 									morphs.push_back(mesh);

--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -1838,7 +1838,7 @@ Error EditorSceneImporterGLTF::_determine_skeletons(GLTFState &state) {
 		skeleton_sets.get_representatives(groups_representatives);
 
 		Vector<GLTFNodeIndex> highest_group_members;
-		Vector<Vector<GLTFNodeIndex> > groups;
+		Vector<Vector<GLTFNodeIndex>> groups;
 		for (int i = 0; i < groups_representatives.size(); ++i) {
 			Vector<GLTFNodeIndex> group;
 			skeleton_sets.get_members(group, groups_representatives[i]);

--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -284,7 +284,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 			Channel<Vector3> translation_track;
 			Channel<Quat> rotation_track;
 			Channel<Vector3> scale_track;
-			Vector<Channel<float> > weight_tracks;
+			Vector<Channel<float>> weight_tracks;
 		};
 
 		String name;
@@ -302,18 +302,18 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 		bool use_named_skin_binds;
 
 		Vector<GLTFNode *> nodes;
-		Vector<Vector<uint8_t> > buffers;
+		Vector<Vector<uint8_t>> buffers;
 		Vector<GLTFBufferView> buffer_views;
 		Vector<GLTFAccessor> accessors;
 
 		Vector<GLTFMesh> meshes; //meshes are loaded directly, no reason not to.
-		Vector<Ref<Material> > materials;
+		Vector<Ref<Material>> materials;
 
 		String scene_name;
 		Vector<int> root_nodes;
 
 		Vector<GLTFTexture> textures;
-		Vector<Ref<Texture2D> > images;
+		Vector<Ref<Texture2D>> images;
 
 		Vector<GLTFSkin> skins;
 		Vector<GLTFCamera> cameras;

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -96,7 +96,7 @@ Error ResourceImporterCSVTranslation::import(const String &p_source_file, const 
 	ERR_FAIL_COND_V(line.size() <= 1, ERR_PARSE_ERROR);
 
 	Vector<String> locales;
-	Vector<Ref<Translation> > translations;
+	Vector<Ref<Translation>> translations;
 
 	for (int i = 1; i < line.size(); i++) {
 

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -42,7 +42,7 @@ uint32_t EditorOBJImporter::get_import_flags() const {
 	return IMPORT_SCENE;
 }
 
-static Error _parse_material_library(const String &p_path, Map<String, Ref<StandardMaterial3D> > &material_map, List<String> *r_missing_deps) {
+static Error _parse_material_library(const String &p_path, Map<String, Ref<StandardMaterial3D>> &material_map, List<String> *r_missing_deps) {
 
 	FileAccessRef f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(!f, ERR_CANT_OPEN, vformat("Couldn't open MTL file '%s', it may not exist or not be readable.", p_path));
@@ -203,7 +203,7 @@ static Error _parse_material_library(const String &p_path, Map<String, Ref<Stand
 	return OK;
 }
 
-static Error _parse_obj(const String &p_path, List<Ref<Mesh> > &r_meshes, bool p_single_mesh, bool p_generate_tangents, bool p_optimize, Vector3 p_scale_mesh, Vector3 p_offset_mesh, List<String> *r_missing_deps) {
+static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_single_mesh, bool p_generate_tangents, bool p_optimize, Vector3 p_scale_mesh, Vector3 p_offset_mesh, List<String> *r_missing_deps) {
 
 	FileAccessRef f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(!f, ERR_CANT_OPEN, vformat("Couldn't open OBJ file '%s', it may not exist or not be readable.", p_path));
@@ -221,7 +221,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh> > &r_meshes, bool p
 	Vector<Vector2> uvs;
 	String name;
 
-	Map<String, Map<String, Ref<StandardMaterial3D> > > material_map;
+	Map<String, Map<String, Ref<StandardMaterial3D>>> material_map;
 
 	Ref<SurfaceTool> surf_tool = memnew(SurfaceTool);
 	surf_tool->begin(Mesh::PRIMITIVE_TRIANGLES);
@@ -397,7 +397,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh> > &r_meshes, bool p
 
 			current_material_library = l.replace("mtllib", "").strip_edges();
 			if (!material_map.has(current_material_library)) {
-				Map<String, Ref<StandardMaterial3D> > lib;
+				Map<String, Ref<StandardMaterial3D>> lib;
 				Error err = _parse_material_library(current_material_library, lib, r_missing_deps);
 				if (err == ERR_CANT_OPEN) {
 					String dir = p_path.get_base_dir();
@@ -420,7 +420,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh> > &r_meshes, bool p
 
 Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, int p_bake_fps, List<String> *r_missing_deps, Error *r_err) {
 
-	List<Ref<Mesh> > meshes;
+	List<Ref<Mesh>> meshes;
 
 	Error err = _parse_obj(p_path, meshes, false, p_flags & IMPORT_GENERATE_TANGENT_ARRAYS, p_flags & IMPORT_USE_COMPRESSION, Vector3(1, 1, 1), Vector3(0, 0, 0), r_missing_deps);
 
@@ -433,7 +433,7 @@ Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, in
 
 	Spatial *scene = memnew(Spatial);
 
-	for (List<Ref<Mesh> >::Element *E = meshes.front(); E; E = E->next()) {
+	for (List<Ref<Mesh>>::Element *E = meshes.front(); E; E = E->next()) {
 
 		MeshInstance *mi = memnew(MeshInstance);
 		mi->set_mesh(E->get());
@@ -500,7 +500,7 @@ bool ResourceImporterOBJ::get_option_visibility(const String &p_option, const Ma
 
 Error ResourceImporterOBJ::import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 
-	List<Ref<Mesh> > meshes;
+	List<Ref<Mesh>> meshes;
 
 	Error err = _parse_obj(p_source_file, meshes, true, p_options["generate_tangents"], p_options["optimize_mesh"], p_options["scale_mesh"], p_options["offset_mesh"], NULL);
 

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -170,7 +170,7 @@ String ResourceImporterScene::get_visible_name() const {
 
 void ResourceImporterScene::get_recognized_extensions(List<String> *p_extensions) const {
 
-	for (Set<Ref<EditorSceneImporter> >::Element *E = importers.front(); E; E = E->next()) {
+	for (Set<Ref<EditorSceneImporter>>::Element *E = importers.front(); E; E = E->next()) {
 		E->get()->get_extensions(p_extensions);
 	}
 }
@@ -276,7 +276,7 @@ static String _fixstr(const String &p_what, const String &p_str) {
 	return what;
 }
 
-static void _gen_shape_list(const Ref<Mesh> &mesh, List<Ref<Shape> > &r_shape_list, bool p_convex) {
+static void _gen_shape_list(const Ref<Mesh> &mesh, List<Ref<Shape>> &r_shape_list, bool p_convex) {
 
 	if (!p_convex) {
 
@@ -284,7 +284,7 @@ static void _gen_shape_list(const Ref<Mesh> &mesh, List<Ref<Shape> > &r_shape_li
 		r_shape_list.push_back(shape);
 	} else {
 
-		Vector<Ref<Shape> > cd = mesh->convex_decompose();
+		Vector<Ref<Shape>> cd = mesh->convex_decompose();
 		if (cd.size()) {
 			for (int i = 0; i < cd.size(); i++) {
 				r_shape_list.push_back(cd[i]);
@@ -293,7 +293,7 @@ static void _gen_shape_list(const Ref<Mesh> &mesh, List<Ref<Shape> > &r_shape_li
 	}
 }
 
-Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>, List<Ref<Shape> > > &collision_map, LightBakeMode p_light_bake_mode) {
+Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>, List<Ref<Shape>>> &collision_map, LightBakeMode p_light_bake_mode) {
 
 	// children first
 	for (int i = 0; i < p_node->get_child_count(); i++) {
@@ -382,7 +382,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 			Ref<Mesh> mesh = mi->get_mesh();
 
 			if (mesh.is_valid()) {
-				List<Ref<Shape> > shapes;
+				List<Ref<Shape>> shapes;
 				String fixed_name;
 				if (collision_map.has(mesh)) {
 					shapes = collision_map[mesh];
@@ -412,7 +412,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 					p_node = col;
 
 					int idx = 0;
-					for (List<Ref<Shape> >::Element *E = shapes.front(); E; E = E->next()) {
+					for (List<Ref<Shape>>::Element *E = shapes.front(); E; E = E->next()) {
 
 						CollisionShape *cshape = memnew(CollisionShape);
 						cshape->set_shape(E->get());
@@ -468,7 +468,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 		Ref<Mesh> mesh = mi->get_mesh();
 
 		if (mesh.is_valid()) {
-			List<Ref<Shape> > shapes;
+			List<Ref<Shape>> shapes;
 			if (collision_map.has(mesh)) {
 				shapes = collision_map[mesh];
 			} else {
@@ -486,7 +486,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 			mi->set_owner(rigid_body->get_owner());
 
 			int idx = 0;
-			for (List<Ref<Shape> >::Element *E = shapes.front(); E; E = E->next()) {
+			for (List<Ref<Shape>>::Element *E = shapes.front(); E; E = E->next()) {
 
 				CollisionShape *cshape = memnew(CollisionShape);
 				cshape->set_shape(E->get());
@@ -505,7 +505,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 		Ref<Mesh> mesh = mi->get_mesh();
 
 		if (mesh.is_valid()) {
-			List<Ref<Shape> > shapes;
+			List<Ref<Shape>> shapes;
 			String fixed_name;
 			if (collision_map.has(mesh)) {
 				shapes = collision_map[mesh];
@@ -536,7 +536,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 				col->set_owner(mi->get_owner());
 
 				int idx = 0;
-				for (List<Ref<Shape> >::Element *E = shapes.front(); E; E = E->next()) {
+				for (List<Ref<Shape>>::Element *E = shapes.front(); E; E = E->next()) {
 
 					CollisionShape *cshape = memnew(CollisionShape);
 					cshape->set_shape(E->get());
@@ -618,7 +618,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 		Ref<ArrayMesh> mesh = mi->get_mesh();
 		if (!mesh.is_null()) {
 
-			List<Ref<Shape> > shapes;
+			List<Ref<Shape>> shapes;
 			if (collision_map.has(mesh)) {
 				shapes = collision_map[mesh];
 			} else if (_teststr(mesh->get_name(), "col")) {
@@ -638,7 +638,7 @@ Node *ResourceImporterScene::_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>
 				col->set_owner(p_node->get_owner());
 
 				int idx = 0;
-				for (List<Ref<Shape> >::Element *E = shapes.front(); E; E = E->next()) {
+				for (List<Ref<Shape>>::Element *E = shapes.front(); E; E = E->next()) {
 
 					CollisionShape *cshape = memnew(CollisionShape);
 					cshape->set_shape(E->get());
@@ -957,7 +957,7 @@ void ResourceImporterScene::_find_meshes(Node *p_node, Map<Ref<ArrayMesh>, Trans
 	}
 }
 
-void ResourceImporterScene::_make_external_resources(Node *p_node, const String &p_base_path, bool p_make_animations, bool p_animations_as_text, bool p_keep_animations, bool p_make_materials, bool p_materials_as_text, bool p_keep_materials, bool p_make_meshes, bool p_meshes_as_text, Map<Ref<Animation>, Ref<Animation> > &p_animations, Map<Ref<Material>, Ref<Material> > &p_materials, Map<Ref<ArrayMesh>, Ref<ArrayMesh> > &p_meshes) {
+void ResourceImporterScene::_make_external_resources(Node *p_node, const String &p_base_path, bool p_make_animations, bool p_animations_as_text, bool p_keep_animations, bool p_make_materials, bool p_materials_as_text, bool p_keep_materials, bool p_make_meshes, bool p_meshes_as_text, Map<Ref<Animation>, Ref<Animation>> &p_animations, Map<Ref<Material>, Ref<Material>> &p_materials, Map<Ref<ArrayMesh>, Ref<ArrayMesh>> &p_meshes) {
 
 	List<PropertyInfo> pi;
 
@@ -1209,7 +1209,7 @@ Node *ResourceImporterScene::import_scene_from_other_importer(EditorSceneImporte
 	Ref<EditorSceneImporter> importer;
 	String ext = p_path.get_extension().to_lower();
 
-	for (Set<Ref<EditorSceneImporter> >::Element *E = importers.front(); E; E = E->next()) {
+	for (Set<Ref<EditorSceneImporter>>::Element *E = importers.front(); E; E = E->next()) {
 
 		if (E->get().ptr() == p_exception)
 			continue;
@@ -1241,7 +1241,7 @@ Ref<Animation> ResourceImporterScene::import_animation_from_other_importer(Edito
 	Ref<EditorSceneImporter> importer;
 	String ext = p_path.get_extension().to_lower();
 
-	for (Set<Ref<EditorSceneImporter> >::Element *E = importers.front(); E; E = E->next()) {
+	for (Set<Ref<EditorSceneImporter>>::Element *E = importers.front(); E; E = E->next()) {
 
 		if (E->get().ptr() == p_exception)
 			continue;
@@ -1276,7 +1276,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	EditorProgress progress("import", TTR("Import Scene"), 104);
 	progress.step(TTR("Importing Scene..."), 0);
 
-	for (Set<Ref<EditorSceneImporter> >::Element *E = importers.front(); E; E = E->next()) {
+	for (Set<Ref<EditorSceneImporter>>::Element *E = importers.front(); E; E = E->next()) {
 
 		List<String> extensions;
 		E->get()->get_extensions(&extensions);
@@ -1368,7 +1368,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	float anim_optimizer_maxang = p_options["animation/optimizer/max_angle"];
 	int light_bake_mode = p_options["meshes/light_baking"];
 
-	Map<Ref<Mesh>, List<Ref<Shape> > > collision_map;
+	Map<Ref<Mesh>, List<Ref<Shape>>> collision_map;
 
 	scene = _fix_node(scene, scene, collision_map, LightBakeMode(light_bake_mode));
 
@@ -1456,9 +1456,9 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	}
 
 	if (external_animations || external_materials || external_meshes) {
-		Map<Ref<Animation>, Ref<Animation> > anim_map;
-		Map<Ref<Material>, Ref<Material> > mat_map;
-		Map<Ref<ArrayMesh>, Ref<ArrayMesh> > mesh_map;
+		Map<Ref<Animation>, Ref<Animation>> anim_map;
+		Map<Ref<Material>, Ref<Material>> mat_map;
+		Map<Ref<ArrayMesh>, Ref<ArrayMesh>> mesh_map;
 
 		bool keep_materials = bool(p_options["materials/keep_on_reimport"]);
 

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -93,7 +93,7 @@ public:
 class ResourceImporterScene : public ResourceImporter {
 	GDCLASS(ResourceImporterScene, ResourceImporter);
 
-	Set<Ref<EditorSceneImporter> > importers;
+	Set<Ref<EditorSceneImporter>> importers;
 
 	static ResourceImporterScene *singleton;
 
@@ -125,7 +125,7 @@ class ResourceImporterScene : public ResourceImporter {
 public:
 	static ResourceImporterScene *get_singleton() { return singleton; }
 
-	const Set<Ref<EditorSceneImporter> > &get_importers() const { return importers; }
+	const Set<Ref<EditorSceneImporter>> &get_importers() const { return importers; }
 
 	void add_importer(Ref<EditorSceneImporter> p_importer) { importers.insert(p_importer); }
 	void remove_importer(Ref<EditorSceneImporter> p_importer) { importers.erase(p_importer); }
@@ -145,9 +145,9 @@ public:
 
 	void _find_meshes(Node *p_node, Map<Ref<ArrayMesh>, Transform> &meshes);
 
-	void _make_external_resources(Node *p_node, const String &p_base_path, bool p_make_animations, bool p_animations_as_text, bool p_keep_animations, bool p_make_materials, bool p_materials_as_text, bool p_keep_materials, bool p_make_meshes, bool p_meshes_as_text, Map<Ref<Animation>, Ref<Animation> > &p_animations, Map<Ref<Material>, Ref<Material> > &p_materials, Map<Ref<ArrayMesh>, Ref<ArrayMesh> > &p_meshes);
+	void _make_external_resources(Node *p_node, const String &p_base_path, bool p_make_animations, bool p_animations_as_text, bool p_keep_animations, bool p_make_materials, bool p_materials_as_text, bool p_keep_materials, bool p_make_meshes, bool p_meshes_as_text, Map<Ref<Animation>, Ref<Animation>> &p_animations, Map<Ref<Material>, Ref<Material>> &p_materials, Map<Ref<ArrayMesh>, Ref<ArrayMesh>> &p_meshes);
 
-	Node *_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>, List<Ref<Shape> > > &collision_map, LightBakeMode p_light_bake_mode);
+	Node *_fix_node(Node *p_node, Node *p_root, Map<Ref<Mesh>, List<Ref<Shape>>> &collision_map, LightBakeMode p_light_bake_mode);
 
 	void _create_clips(Node *scene, const Array &p_clips, bool p_bake_all);
 	void _filter_anim_tracks(Ref<Animation> anim, Set<String> &keep);

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -192,7 +192,7 @@ static void _plot_triangle(Vector2 *vertices, const Vector2 &p_offset, bool p_tr
 	}
 }
 
-Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file, const Map<String, Map<StringName, Variant> > &p_source_file_options, const Map<String, String> &p_base_paths) {
+Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file, const Map<String, Map<StringName, Variant>> &p_source_file_options, const Map<String, String> &p_base_paths) {
 
 	ERR_FAIL_COND_V(p_source_file_options.size() == 0, ERR_BUG); //should never happen
 
@@ -202,7 +202,7 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 	pack_data_files.resize(p_source_file_options.size());
 
 	int idx = 0;
-	for (const Map<String, Map<StringName, Variant> >::Element *E = p_source_file_options.front(); E; E = E->next(), idx++) {
+	for (const Map<String, Map<StringName, Variant>>::Element *E = p_source_file_options.front(); E; E = E->next(), idx++) {
 
 		PackData &pack_data = pack_data_files.write[idx];
 		const String &source = E->key();
@@ -251,7 +251,7 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 			Ref<BitMap> bit_map;
 			bit_map.instance();
 			bit_map->create_from_image_alpha(image);
-			Vector<Vector<Vector2> > polygons = bit_map->clip_opaque_to_polygons(Rect2(0, 0, image->get_width(), image->get_height()));
+			Vector<Vector<Vector2>> polygons = bit_map->clip_opaque_to_polygons(Rect2(0, 0, image->get_width(), image->get_height()));
 
 			for (int j = 0; j < polygons.size(); j++) {
 
@@ -323,7 +323,7 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 
 	//save the images
 	idx = 0;
-	for (const Map<String, Map<StringName, Variant> >::Element *E = p_source_file_options.front(); E; E = E->next(), idx++) {
+	for (const Map<String, Map<StringName, Variant>>::Element *E = p_source_file_options.front(); E; E = E->next(), idx++) {
 
 		PackData &pack_data = pack_data_files.write[idx];
 

--- a/editor/import/resource_importer_texture_atlas.h
+++ b/editor/import/resource_importer_texture_atlas.h
@@ -40,7 +40,7 @@ class ResourceImporterTextureAtlas : public ResourceImporter {
 		Rect2 region;
 		bool is_mesh;
 		Vector<int> chart_pieces; //one for region, many for mesh
-		Vector<Vector<Vector2> > chart_vertices; //for mesh
+		Vector<Vector<Vector2>> chart_vertices; //for mesh
 		Ref<Image> image;
 	};
 
@@ -64,7 +64,7 @@ public:
 	virtual String get_option_group_file() const;
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = NULL, Variant *r_metadata = NULL);
-	virtual Error import_group_file(const String &p_group_file, const Map<String, Map<StringName, Variant> > &p_source_file_options, const Map<String, String> &p_base_paths);
+	virtual Error import_group_file(const String &p_group_file, const Map<String, Map<StringName, Variant>> &p_source_file_options, const Map<String, String> &p_base_paths);
 
 	ResourceImporterTextureAtlas();
 };

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -112,19 +112,19 @@ void ImportDock::set_edit_path(const String &p_path) {
 
 	_update_options(config);
 
-	List<Ref<ResourceImporter> > importers;
+	List<Ref<ResourceImporter>> importers;
 	ResourceFormatImporter::get_singleton()->get_importers_for_extension(p_path.get_extension(), &importers);
-	List<Pair<String, String> > importer_names;
+	List<Pair<String, String>> importer_names;
 
-	for (List<Ref<ResourceImporter> >::Element *E = importers.front(); E; E = E->next()) {
+	for (List<Ref<ResourceImporter>>::Element *E = importers.front(); E; E = E->next()) {
 		importer_names.push_back(Pair<String, String>(E->get()->get_visible_name(), E->get()->get_importer_name()));
 	}
 
-	importer_names.sort_custom<PairSort<String, String> >();
+	importer_names.sort_custom<PairSort<String, String>>();
 
 	import_as->clear();
 
-	for (List<Pair<String, String> >::Element *E = importer_names.front(); E; E = E->next()) {
+	for (List<Pair<String, String>>::Element *E = importer_names.front(); E; E = E->next()) {
 		import_as->add_item(E->get().first);
 		import_as->set_item_metadata(import_as->get_item_count() - 1, E->get().second);
 		if (E->get().second == params->importer->get_importer_name()) {
@@ -240,19 +240,19 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 
 	params->update();
 
-	List<Ref<ResourceImporter> > importers;
+	List<Ref<ResourceImporter>> importers;
 	ResourceFormatImporter::get_singleton()->get_importers_for_extension(p_paths[0].get_extension(), &importers);
-	List<Pair<String, String> > importer_names;
+	List<Pair<String, String>> importer_names;
 
-	for (List<Ref<ResourceImporter> >::Element *E = importers.front(); E; E = E->next()) {
+	for (List<Ref<ResourceImporter>>::Element *E = importers.front(); E; E = E->next()) {
 		importer_names.push_back(Pair<String, String>(E->get()->get_visible_name(), E->get()->get_importer_name()));
 	}
 
-	importer_names.sort_custom<PairSort<String, String> >();
+	importer_names.sort_custom<PairSort<String, String>>();
 
 	import_as->clear();
 
-	for (List<Pair<String, String> >::Element *E = importer_names.front(); E; E = E->next()) {
+	for (List<Pair<String, String>>::Element *E = importer_names.front(); E; E = E->next()) {
 		import_as->add_item(E->get().first);
 		import_as->set_item_metadata(import_as->get_item_count() - 1, E->get().second);
 		if (E->get().second == params->importer->get_importer_name()) {

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -536,7 +536,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 	updating = true;
 
 	Set<String> paths;
-	HashMap<String, Set<String> > types;
+	HashMap<String, Set<String>> types;
 	{
 		List<StringName> animations;
 		player->get_animation_list(&animations);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2028,7 +2028,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 		if (m.is_valid()) {
 
 			// Save the ik chain for reapplying before IK solve
-			Vector<List<Dictionary> > all_bones_ik_states;
+			Vector<List<Dictionary>> all_bones_ik_states;
 			for (List<CanvasItem *>::Element *E = drag_selection.front(); E; E = E->next()) {
 				List<Dictionary> bones_ik_states;
 				_save_canvas_item_ik_chain(E->get(), NULL, &bones_ik_states);
@@ -2130,7 +2130,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 		if (drag_selection.size() > 0) {
 
 			// Save the ik chain for reapplying before IK solve
-			Vector<List<Dictionary> > all_bones_ik_states;
+			Vector<List<Dictionary>> all_bones_ik_states;
 			for (List<CanvasItem *>::Element *E = drag_selection.front(); E; E = E->next()) {
 				List<Dictionary> bones_ik_states;
 				_save_canvas_item_ik_chain(E->get(), NULL, &bones_ik_states);

--- a/editor/plugins/mesh_instance_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_editor_plugin.cpp
@@ -196,7 +196,7 @@ void MeshInstanceEditor::_menu_option(int p_option) {
 				return;
 			}
 
-			Vector<Ref<Shape> > shapes = mesh->convex_decompose();
+			Vector<Ref<Shape>> shapes = mesh->convex_decompose();
 
 			if (!shapes.size()) {
 				err_dialog->set_text(TTR("Couldn't create any collision shapes."));

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -170,7 +170,7 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 
 	if (1) {
 
-		Vector<Ref<Mesh> > meshes;
+		Vector<Ref<Mesh>> meshes;
 		Vector<Transform> transforms;
 		Vector<int> ids = p_library->get_item_list();
 		for (int i = 0; i < ids.size(); i++) {
@@ -182,7 +182,7 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 			}
 		}
 
-		Vector<Ref<Texture2D> > textures = EditorInterface::get_singleton()->make_mesh_previews(meshes, &transforms, EditorSettings::get_singleton()->get("editors/grid_map/preview_size"));
+		Vector<Ref<Texture2D>> textures = EditorInterface::get_singleton()->make_mesh_previews(meshes, &transforms, EditorSettings::get_singleton()->get("editors/grid_map/preview_size"));
 		int j = 0;
 		for (int i = 0; i < ids.size(); i++) {
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -969,7 +969,7 @@ Ref<Script> ScriptEditor::_get_current_script() {
 Array ScriptEditor::_get_open_scripts() const {
 
 	Array ret;
-	Vector<Ref<Script> > scripts = get_open_scripts();
+	Vector<Ref<Script>> scripts = get_open_scripts();
 	int scrits_amount = scripts.size();
 	for (int idx_script = 0; idx_script < scrits_amount; idx_script++) {
 		ret.push_back(scripts[idx_script]);
@@ -1571,7 +1571,7 @@ void ScriptEditor::ensure_select_current() {
 	_update_selected_editor_menu();
 }
 
-void ScriptEditor::_find_scripts(Node *p_base, Node *p_current, Set<Ref<Script> > &used) {
+void ScriptEditor::_find_scripts(Node *p_base, Node *p_current, Set<Ref<Script>> &used) {
 	if (p_current != p_base && p_current->get_owner() != p_base)
 		return;
 
@@ -1704,7 +1704,7 @@ void ScriptEditor::_update_help_overview() {
 		return;
 	}
 
-	Vector<Pair<String, int> > sections = se->get_sections();
+	Vector<Pair<String, int>> sections = se->get_sections();
 	for (int i = 0; i < sections.size(); i++) {
 		help_overview->add_item(sections[i].first);
 		help_overview->set_item_metadata(i, sections[i].second);
@@ -1757,7 +1757,7 @@ void ScriptEditor::_update_script_names() {
 	if (restoring_layout)
 		return;
 
-	Set<Ref<Script> > used;
+	Set<Ref<Script>> used;
 	Node *edited = EditorNode::get_singleton()->get_edited_scene();
 	if (edited) {
 		_find_scripts(edited, edited, used);
@@ -2861,9 +2861,9 @@ void ScriptEditor::_history_back() {
 	}
 }
 
-Vector<Ref<Script> > ScriptEditor::get_open_scripts() const {
+Vector<Ref<Script>> ScriptEditor::get_open_scripts() const {
 
-	Vector<Ref<Script> > out_scripts = Vector<Ref<Script> >();
+	Vector<Ref<Script>> out_scripts = Vector<Ref<Script>>();
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -351,7 +351,7 @@ class ScriptEditor : public PanelContainer {
 	void _update_help_overview();
 	void _help_overview_selected(int p_idx);
 
-	void _find_scripts(Node *p_base, Node *p_current, Set<Ref<Script> > &used);
+	void _find_scripts(Node *p_base, Node *p_current, Set<Ref<Script>> &used);
 
 	void _tree_changed();
 
@@ -429,7 +429,7 @@ public:
 	void get_window_layout(Ref<ConfigFile> p_layout);
 
 	void set_scene_root_script(Ref<Script> p_script);
-	Vector<Ref<Script> > get_open_scripts() const;
+	Vector<Ref<Script>> get_open_scripts() const;
 
 	bool script_goto_method(Ref<Script> p_script, const String &p_method);
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -759,7 +759,7 @@ static Node *_find_node_for_script(Node *p_base, Node *p_current, const Ref<Scri
 	return NULL;
 }
 
-static void _find_changed_scripts_for_external_editor(Node *p_base, Node *p_current, Set<Ref<Script> > &r_scripts) {
+static void _find_changed_scripts_for_external_editor(Node *p_base, Node *p_current, Set<Ref<Script>> &r_scripts) {
 
 	if (p_current->get_owner() != p_base && p_base != p_current)
 		return;
@@ -780,14 +780,14 @@ void ScriptEditor::_update_modified_scripts_for_external_editor(Ref<Script> p_fo
 
 	ERR_FAIL_COND(!get_tree());
 
-	Set<Ref<Script> > scripts;
+	Set<Ref<Script>> scripts;
 
 	Node *base = get_tree()->get_edited_scene_root();
 	if (base) {
 		_find_changed_scripts_for_external_editor(base, base, scripts);
 	}
 
-	for (Set<Ref<Script> >::Element *E = scripts.front(); E; E = E->next()) {
+	for (Set<Ref<Script>>::Element *E = scripts.front(); E; E = E->next()) {
 
 		Ref<Script> script = E->get();
 

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -496,7 +496,7 @@ ObjectID SpatialEditorViewport::_select_ray(const Point2 &p_pos, bool p_append, 
 	Vector2 shrinked_pos = p_pos / viewport_container->get_stretch_shrink();
 
 	Vector<ObjectID> instances = VisualServer::get_singleton()->instances_cull_ray(pos, ray, get_tree()->get_root()->get_world()->get_scenario());
-	Set<Ref<EditorSpatialGizmo> > found_gizmos;
+	Set<Ref<EditorSpatialGizmo>> found_gizmos;
 
 	Node *edited_scene = get_tree()->get_edited_scene_root();
 	ObjectID closest;
@@ -563,7 +563,7 @@ void SpatialEditorViewport::_find_items_at_pos(const Point2 &p_pos, bool &r_incl
 	Vector3 pos = _get_ray_pos(p_pos);
 
 	Vector<ObjectID> instances = VisualServer::get_singleton()->instances_cull_ray(pos, ray, get_tree()->get_root()->get_world()->get_scenario());
-	Set<Ref<EditorSpatialGizmo> > found_gizmos;
+	Set<Ref<EditorSpatialGizmo>> found_gizmos;
 
 	r_includes_current = false;
 
@@ -3477,7 +3477,7 @@ Vector3 SpatialEditorViewport::_get_instance_position(const Point2 &p_pos) const
 	Vector3 world_pos = _get_ray_pos(p_pos);
 
 	Vector<ObjectID> instances = VisualServer::get_singleton()->instances_cull_ray(world_pos, world_ray, get_tree()->get_root()->get_world()->get_scenario());
-	Set<Ref<EditorSpatialGizmo> > found_gizmos;
+	Set<Ref<EditorSpatialGizmo>> found_gizmos;
 
 	float closest_dist = MAX_DISTANCE;
 
@@ -6471,7 +6471,7 @@ void EditorSpatialGizmoPlugin::create_material(const String &p_name, const Color
 
 	Color instanced_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/instanced", Color(0.7, 0.7, 0.7, 0.6));
 
-	Vector<Ref<StandardMaterial3D> > mats;
+	Vector<Ref<StandardMaterial3D>> mats;
 
 	for (int i = 0; i < 4; i++) {
 		bool selected = i % 2 == 1;
@@ -6513,7 +6513,7 @@ void EditorSpatialGizmoPlugin::create_icon_material(const String &p_name, const 
 
 	Color instanced_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/instanced", Color(0.7, 0.7, 0.7, 0.6));
 
-	Vector<Ref<StandardMaterial3D> > icons;
+	Vector<Ref<StandardMaterial3D>> icons;
 
 	for (int i = 0; i < 4; i++) {
 		bool selected = i % 2 == 1;
@@ -6568,12 +6568,12 @@ void EditorSpatialGizmoPlugin::create_handle_material(const String &p_name, bool
 		handle_material->set_on_top_of_alpha();
 	}
 
-	materials[p_name] = Vector<Ref<StandardMaterial3D> >();
+	materials[p_name] = Vector<Ref<StandardMaterial3D>>();
 	materials[p_name].push_back(handle_material);
 }
 
 void EditorSpatialGizmoPlugin::add_material(const String &p_name, Ref<StandardMaterial3D> p_material) {
-	materials[p_name] = Vector<Ref<StandardMaterial3D> >();
+	materials[p_name] = Vector<Ref<StandardMaterial3D>>();
 	materials[p_name].push_back(p_material);
 }
 

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -712,8 +712,8 @@ private:
 	static SpatialEditor *singleton;
 
 	void _node_removed(Node *p_node);
-	Vector<Ref<EditorSpatialGizmoPlugin> > gizmo_plugins_by_priority;
-	Vector<Ref<EditorSpatialGizmoPlugin> > gizmo_plugins_by_name;
+	Vector<Ref<EditorSpatialGizmoPlugin>> gizmo_plugins_by_priority;
+	Vector<Ref<EditorSpatialGizmoPlugin>> gizmo_plugins_by_name;
 
 	void _register_all_gizmos();
 
@@ -840,7 +840,7 @@ public:
 private:
 	int current_state;
 	List<EditorSpatialGizmo *> current_gizmos;
-	HashMap<String, Vector<Ref<StandardMaterial3D> > > materials;
+	HashMap<String, Vector<Ref<StandardMaterial3D>>> materials;
 
 protected:
 	static void _bind_methods();

--- a/editor/plugins/sprite_editor_plugin.cpp
+++ b/editor/plugins/sprite_editor_plugin.cpp
@@ -204,7 +204,7 @@ void SpriteEditor::_update_mesh_data() {
 
 	float epsilon = simplification->get_value();
 
-	Vector<Vector<Vector2> > lines = bm->clip_opaque_to_polygons(rect, epsilon);
+	Vector<Vector<Vector2>> lines = bm->clip_opaque_to_polygons(rect, epsilon);
 
 	uv_lines.clear();
 

--- a/editor/plugins/sprite_editor_plugin.h
+++ b/editor/plugins/sprite_editor_plugin.h
@@ -60,8 +60,8 @@ class SpriteEditor : public Control {
 	ConfirmationDialog *debug_uv_dialog;
 	Control *debug_uv;
 	Vector<Vector2> uv_lines;
-	Vector<Vector<Vector2> > outline_lines;
-	Vector<Vector<Vector2> > computed_outline_lines;
+	Vector<Vector<Vector2>> outline_lines;
+	Vector<Vector<Vector2>> computed_outline_lines;
 	Vector<Vector2> computed_vertices;
 	Vector<Vector2> computed_uv;
 	Vector<int> computed_indices;

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -249,7 +249,7 @@ void SpriteFramesEditor::_file_load_request(const Vector<String> &p_path, int p_
 
 	ERR_FAIL_COND(!frames->has_animation(edited_anim));
 
-	List<Ref<Texture2D> > resources;
+	List<Ref<Texture2D>> resources;
 
 	for (int i = 0; i < p_path.size(); i++) {
 
@@ -278,7 +278,7 @@ void SpriteFramesEditor::_file_load_request(const Vector<String> &p_path, int p_
 
 	int count = 0;
 
-	for (List<Ref<Texture2D> >::Element *E = resources.front(); E; E = E->next()) {
+	for (List<Ref<Texture2D>>::Element *E = resources.front(); E; E = E->next()) {
 
 		undo_redo->add_do_method(frames, "add_frame", edited_anim, E->get(), p_at_pos == -1 ? -1 : p_at_pos + count);
 		undo_redo->add_undo_method(frames, "remove_frame", edited_anim, p_at_pos == -1 ? fc : p_at_pos);

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -94,7 +94,7 @@ class TextureRegionEditor : public VBoxContainer {
 	Rect2 rect_prev;
 	float prev_margin;
 	int edited_margin;
-	Map<RID, List<Rect2> > cache_map;
+	Map<RID, List<Rect2>> cache_map;
 	List<Rect2> autoslice_cache;
 	bool autoslice_is_dirty;
 

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -120,12 +120,12 @@ struct _TECategory {
 		bool operator<(const Item<T> &p) const { return name < p.name; }
 	};
 
-	Set<RefItem<StyleBox> > stylebox_items;
-	Set<RefItem<Font> > font_items;
-	Set<RefItem<Texture2D> > icon_items;
+	Set<RefItem<StyleBox>> stylebox_items;
+	Set<RefItem<Font>> font_items;
+	Set<RefItem<Texture2D>> icon_items;
 
-	Set<Item<Color> > color_items;
-	Set<Item<int> > constant_items;
+	Set<Item<Color>> color_items;
+	Set<Item<int>> constant_items;
 };
 
 void ThemeEditor::_save_template_cbk(String fname) {
@@ -275,7 +275,7 @@ void ThemeEditor::_save_template_cbk(String fname) {
 		if (tc.stylebox_items.size())
 			file->store_line("\n; StyleBox Items:\n");
 
-		for (Set<_TECategory::RefItem<StyleBox> >::Element *F = tc.stylebox_items.front(); F; F = F->next()) {
+		for (Set<_TECategory::RefItem<StyleBox>>::Element *F = tc.stylebox_items.front(); F; F = F->next()) {
 
 			file->store_line(E->key() + "." + F->get().name + " = default");
 		}
@@ -283,7 +283,7 @@ void ThemeEditor::_save_template_cbk(String fname) {
 		if (tc.font_items.size())
 			file->store_line("\n; Font Items:\n");
 
-		for (Set<_TECategory::RefItem<Font> >::Element *F = tc.font_items.front(); F; F = F->next()) {
+		for (Set<_TECategory::RefItem<Font>>::Element *F = tc.font_items.front(); F; F = F->next()) {
 
 			file->store_line(E->key() + "." + F->get().name + " = default");
 		}
@@ -291,7 +291,7 @@ void ThemeEditor::_save_template_cbk(String fname) {
 		if (tc.icon_items.size())
 			file->store_line("\n; Icon Items:\n");
 
-		for (Set<_TECategory::RefItem<Texture2D> >::Element *F = tc.icon_items.front(); F; F = F->next()) {
+		for (Set<_TECategory::RefItem<Texture2D>>::Element *F = tc.icon_items.front(); F; F = F->next()) {
 
 			file->store_line(E->key() + "." + F->get().name + " = default");
 		}
@@ -299,7 +299,7 @@ void ThemeEditor::_save_template_cbk(String fname) {
 		if (tc.color_items.size())
 			file->store_line("\n; Color Items:\n");
 
-		for (Set<_TECategory::Item<Color> >::Element *F = tc.color_items.front(); F; F = F->next()) {
+		for (Set<_TECategory::Item<Color>>::Element *F = tc.color_items.front(); F; F = F->next()) {
 
 			file->store_line(E->key() + "." + F->get().name + " = default");
 		}
@@ -307,7 +307,7 @@ void ThemeEditor::_save_template_cbk(String fname) {
 		if (tc.constant_items.size())
 			file->store_line("\n; Constant Items:\n");
 
-		for (Set<_TECategory::Item<int> >::Element *F = tc.constant_items.front(); F; F = F->next()) {
+		for (Set<_TECategory::Item<int>>::Element *F = tc.constant_items.front(); F; F = F->next()) {
 
 			file->store_line(E->key() + "." + F->get().name + " = default");
 		}

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -2350,12 +2350,12 @@ void TileSetEditor::_undo_tile_removal(int p_id) {
 		undo_redo->add_undo_method(tileset.ptr(), "tile_set_light_occluder", p_id, tileset->tile_get_light_occluder(p_id));
 		undo_redo->add_undo_method(tileset.ptr(), "tile_set_navigation_polygon", p_id, tileset->tile_get_navigation_polygon(p_id));
 	} else {
-		Map<Vector2, Ref<OccluderPolygon2D> > oclusion_map = tileset->autotile_get_light_oclusion_map(p_id);
-		for (Map<Vector2, Ref<OccluderPolygon2D> >::Element *E = oclusion_map.front(); E; E = E->next()) {
+		Map<Vector2, Ref<OccluderPolygon2D>> oclusion_map = tileset->autotile_get_light_oclusion_map(p_id);
+		for (Map<Vector2, Ref<OccluderPolygon2D>>::Element *E = oclusion_map.front(); E; E = E->next()) {
 			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_light_occluder", p_id, E->value(), E->key());
 		}
-		Map<Vector2, Ref<NavigationPolygon> > navigation_map = tileset->autotile_get_navigation_map(p_id);
-		for (Map<Vector2, Ref<NavigationPolygon> >::Element *E = navigation_map.front(); E; E = E->next()) {
+		Map<Vector2, Ref<NavigationPolygon>> navigation_map = tileset->autotile_get_navigation_map(p_id);
+		for (Map<Vector2, Ref<NavigationPolygon>>::Element *E = navigation_map.front(); E; E = E->next()) {
 			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_navigation_polygon", p_id, E->value(), E->key());
 		}
 		Map<Vector2, uint32_t> bitmask_map = tileset->autotile_get_bitmask_map(p_id);
@@ -2693,8 +2693,8 @@ void TileSetEditor::draw_polygon_shapes() {
 					}
 				}
 			} else {
-				Map<Vector2, Ref<OccluderPolygon2D> > map = tileset->autotile_get_light_oclusion_map(t_id);
-				for (Map<Vector2, Ref<OccluderPolygon2D> >::Element *E = map.front(); E; E = E->next()) {
+				Map<Vector2, Ref<OccluderPolygon2D>> map = tileset->autotile_get_light_oclusion_map(t_id);
+				for (Map<Vector2, Ref<OccluderPolygon2D>>::Element *E = map.front(); E; E = E->next()) {
 					Vector2 coord = E->key();
 					Vector2 anchor = tileset->autotile_get_size(t_id);
 					anchor.x += tileset->autotile_get_spacing(t_id);
@@ -2781,8 +2781,8 @@ void TileSetEditor::draw_polygon_shapes() {
 					}
 				}
 			} else {
-				Map<Vector2, Ref<NavigationPolygon> > map = tileset->autotile_get_navigation_map(t_id);
-				for (Map<Vector2, Ref<NavigationPolygon> >::Element *E = map.front(); E; E = E->next()) {
+				Map<Vector2, Ref<NavigationPolygon>> map = tileset->autotile_get_navigation_map(t_id);
+				for (Map<Vector2, Ref<NavigationPolygon>>::Element *E = map.front(); E; E = E->next()) {
 					Vector2 coord = E->key();
 					Vector2 anchor = tileset->autotile_get_size(t_id);
 					anchor.x += tileset->autotile_get_spacing(t_id);

--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -114,7 +114,7 @@ class TileSetEditor : public HSplitContainer {
 	int option;
 	ToolButton *tileset_toolbar_buttons[TOOL_TILESET_MAX];
 	MenuButton *tileset_toolbar_tools;
-	Map<RID, Ref<Texture2D> > texture_map;
+	Map<RID, Ref<Texture2D>> texture_map;
 
 	bool creating_shape;
 	int dragging_point;

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -228,7 +228,7 @@ class VisualShaderEditor : public VBoxContainer {
 	void _copy_nodes();
 	void _paste_nodes(bool p_use_custom_position = false, const Vector2 &p_custom_position = Vector2());
 
-	Vector<Ref<VisualShaderNodePlugin> > plugins;
+	Vector<Ref<VisualShaderNodePlugin>> plugins;
 
 	void _mode_selected(int p_id);
 	void _rebuild();

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -199,7 +199,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 
 					List<PropertyInfo> property_list;
 					res_orig->get_property_list(&property_list);
-					List<Pair<String, Variant> > propvalues;
+					List<Pair<String, Variant>> propvalues;
 
 					for (List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
 
@@ -222,7 +222,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 
 					ERR_FAIL_COND(res.is_null());
 
-					for (List<Pair<String, Variant> >::Element *E = propvalues.front(); E; E = E->next()) {
+					for (List<Pair<String, Variant>>::Element *E = propvalues.front(); E; E = E->next()) {
 
 						Pair<String, Variant> &p = E->get();
 						res->set(p.first, p.second);
@@ -270,7 +270,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 
 						int to_type = p_which - CONVERT_BASE_ID;
 
-						Vector<Ref<EditorResourceConversionPlugin> > conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(RES(v));
+						Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(RES(v));
 
 						ERR_FAIL_INDEX(to_type, conversions.size());
 
@@ -1016,7 +1016,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 
 			if (!RES(v).is_null()) {
 
-				Vector<Ref<EditorResourceConversionPlugin> > conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(RES(v));
+				Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(RES(v));
 				if (conversions.size()) {
 					menu->add_separator();
 				}
@@ -1421,7 +1421,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 
 				List<PropertyInfo> property_list;
 				res_orig->get_property_list(&property_list);
-				List<Pair<String, Variant> > propvalues;
+				List<Pair<String, Variant>> propvalues;
 
 				for (List<PropertyInfo>::Element *E = property_list.front(); E; E = E->next()) {
 
@@ -1440,7 +1440,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 
 				ERR_FAIL_COND(res.is_null());
 
-				for (List<Pair<String, Variant> >::Element *E = propvalues.front(); E; E = E->next()) {
+				for (List<Pair<String, Variant>>::Element *E = propvalues.front(); E; E = E->next()) {
 
 					Pair<String, Variant> &p = E->get();
 					res->set(p.first, p.second);

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -122,7 +122,7 @@ float EditorQuickOpen::_path_cmp(String search, String path) const {
 	return path.to_lower().similarity(search.to_lower());
 }
 
-void EditorQuickOpen::_parse_fs(EditorFileSystemDirectory *efsd, Vector<Pair<String, Ref<Texture2D> > > &list) {
+void EditorQuickOpen::_parse_fs(EditorFileSystemDirectory *efsd, Vector<Pair<String, Ref<Texture2D>>> &list) {
 
 	if (!add_directories) {
 		for (int i = 0; i < efsd->get_subdir_count(); i++) {
@@ -140,7 +140,7 @@ void EditorQuickOpen::_parse_fs(EditorFileSystemDirectory *efsd, Vector<Pair<Str
 		if (path != "res://") {
 			path = path.substr(6, path.length());
 			if (search_text.is_subsequence_ofi(path)) {
-				Pair<String, Ref<Texture2D> > pair;
+				Pair<String, Ref<Texture2D>> pair;
 				pair.first = path;
 				pair.second = get_icon("folder", "FileDialog");
 
@@ -169,7 +169,7 @@ void EditorQuickOpen::_parse_fs(EditorFileSystemDirectory *efsd, Vector<Pair<Str
 		file = file.substr(6, file.length());
 
 		if (ClassDB::is_parent_class(efsd->get_file_type(i), base_type) && (search_text.is_subsequence_ofi(file))) {
-			Pair<String, Ref<Texture2D> > pair;
+			Pair<String, Ref<Texture2D>> pair;
 			pair.first = file;
 			pair.second = get_icon((has_icon(efsd->get_file_type(i), ei) ? efsd->get_file_type(i) : ot), ei);
 			list.push_back(pair);
@@ -184,10 +184,10 @@ void EditorQuickOpen::_parse_fs(EditorFileSystemDirectory *efsd, Vector<Pair<Str
 	}
 }
 
-Vector<Pair<String, Ref<Texture2D> > > EditorQuickOpen::_sort_fs(Vector<Pair<String, Ref<Texture2D> > > &list) {
+Vector<Pair<String, Ref<Texture2D>>> EditorQuickOpen::_sort_fs(Vector<Pair<String, Ref<Texture2D>>> &list) {
 
 	String search_text = search_box->get_text();
-	Vector<Pair<String, Ref<Texture2D> > > sorted_list;
+	Vector<Pair<String, Ref<Texture2D>>> sorted_list;
 
 	if (search_text == String() || list.size() == 0)
 		return list;
@@ -223,7 +223,7 @@ void EditorQuickOpen::_update_search() {
 	search_options->clear();
 	TreeItem *root = search_options->create_item();
 	EditorFileSystemDirectory *efsd = EditorFileSystem::get_singleton()->get_filesystem();
-	Vector<Pair<String, Ref<Texture2D> > > list;
+	Vector<Pair<String, Ref<Texture2D>>> list;
 
 	_parse_fs(efsd, list);
 	list = _sort_fs(list);

--- a/editor/quick_open.h
+++ b/editor/quick_open.h
@@ -49,8 +49,8 @@ class EditorQuickOpen : public ConfirmationDialog {
 	void _update_search();
 
 	void _sbox_input(const Ref<InputEvent> &p_ie);
-	void _parse_fs(EditorFileSystemDirectory *efsd, Vector<Pair<String, Ref<Texture2D> > > &list);
-	Vector<Pair<String, Ref<Texture2D> > > _sort_fs(Vector<Pair<String, Ref<Texture2D> > > &list);
+	void _parse_fs(EditorFileSystemDirectory *efsd, Vector<Pair<String, Ref<Texture2D>>> &list);
+	Vector<Pair<String, Ref<Texture2D>>> _sort_fs(Vector<Pair<String, Ref<Texture2D>>> &list);
 	float _path_cmp(String search, String path) const;
 
 	void _confirmed();

--- a/editor/rename_dialog.h
+++ b/editor/rename_dialog.h
@@ -96,7 +96,7 @@ class RenameDialog : public ConfirmationDialog {
 	Label *lbl_preview_title;
 	Label *lbl_preview;
 
-	List<Pair<NodePath, String> > to_rename;
+	List<Pair<NodePath, String>> to_rename;
 	Node *preview_node;
 	bool lock_preview_update;
 	ErrorHandlerList eh;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1229,7 +1229,7 @@ void SceneTreeDock::_set_owners(Node *p_owner, const Array &p_nodes) {
 	}
 }
 
-void SceneTreeDock::_fill_path_renames(Vector<StringName> base_path, Vector<StringName> new_base_path, Node *p_node, List<Pair<NodePath, NodePath> > *p_renames) {
+void SceneTreeDock::_fill_path_renames(Vector<StringName> base_path, Vector<StringName> new_base_path, Node *p_node, List<Pair<NodePath, NodePath>> *p_renames) {
 
 	base_path.push_back(p_node->get_name());
 	if (new_base_path.size())
@@ -1252,7 +1252,7 @@ void SceneTreeDock::_fill_path_renames(Vector<StringName> base_path, Vector<Stri
 	}
 }
 
-void SceneTreeDock::fill_path_renames(Node *p_node, Node *p_new_parent, List<Pair<NodePath, NodePath> > *p_renames) {
+void SceneTreeDock::fill_path_renames(Node *p_node, Node *p_new_parent, List<Pair<NodePath, NodePath>> *p_renames) {
 
 	if (!bool(EDITOR_DEF("editors/animation/autorename_animation_tracks", true)))
 		return;
@@ -1279,9 +1279,9 @@ void SceneTreeDock::fill_path_renames(Node *p_node, Node *p_new_parent, List<Pai
 	_fill_path_renames(base_path, new_base_path, p_node, p_renames);
 }
 
-void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodePath> > *p_renames, Map<Ref<Animation>, Set<int> > *r_rem_anims) {
+void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodePath>> *p_renames, Map<Ref<Animation>, Set<int>> *r_rem_anims) {
 
-	Map<Ref<Animation>, Set<int> > rem_anims;
+	Map<Ref<Animation>, Set<int>> rem_anims;
 
 	if (!r_rem_anims)
 		r_rem_anims = &rem_anims;
@@ -1311,7 +1311,7 @@ void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodeP
 				if (p.get_type() == Variant::NODE_PATH) {
 
 					// Goes through all paths to check if its matching
-					for (List<Pair<NodePath, NodePath> >::Element *F = p_renames->front(); F; F = F->next()) {
+					for (List<Pair<NodePath, NodePath>>::Element *F = p_renames->front(); F; F = F->next()) {
 
 						NodePath root_path = p_base->get_path();
 
@@ -1353,7 +1353,7 @@ void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodeP
 			NodePath root_path = root->get_path();
 			NodePath new_root_path = root_path;
 
-			for (List<Pair<NodePath, NodePath> >::Element *E = p_renames->front(); E; E = E->next()) {
+			for (List<Pair<NodePath, NodePath>>::Element *E = p_renames->front(); E; E = E->next()) {
 
 				if (E->get().first == root_path) {
 					new_root_path = E->get().second;
@@ -1392,7 +1392,7 @@ void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodeP
 						if (!ran.has(i))
 							continue; //channel was removed
 
-						for (List<Pair<NodePath, NodePath> >::Element *F = p_renames->front(); F; F = F->next()) {
+						for (List<Pair<NodePath, NodePath>>::Element *F = p_renames->front(); F; F = F->next()) {
 
 							if (F->get().first == old_np) {
 
@@ -1443,7 +1443,7 @@ void SceneTreeDock::perform_node_renames(Node *p_base, List<Pair<NodePath, NodeP
 
 void SceneTreeDock::_node_prerenamed(Node *p_node, const String &p_new_name) {
 
-	List<Pair<NodePath, NodePath> > path_renames;
+	List<Pair<NodePath, NodePath>> path_renames;
 
 	Vector<StringName> base_path;
 	Node *n = p_node->get_parent();
@@ -1554,7 +1554,7 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 
 	editor_data->get_undo_redo().create_action(TTR("Reparent Node"));
 
-	List<Pair<NodePath, NodePath> > path_renames;
+	List<Pair<NodePath, NodePath>> path_renames;
 	Vector<StringName> former_names;
 
 	int inc = 0;
@@ -1814,7 +1814,7 @@ void SceneTreeDock::_delete_confirm() {
 	} else {
 
 		remove_list.sort_custom<Node::Comparator>(); //sort nodes to keep positions
-		List<Pair<NodePath, NodePath> > path_renames;
+		List<Pair<NodePath, NodePath>> path_renames;
 
 		//delete from animation
 		for (List<Node *>::Element *E = remove_list.front(); E; E = E->next()) {

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -205,7 +205,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _update_script_button();
 	Node *_get_selection_group_tail(Node *p_node, List<Node *> p_list);
 
-	void _fill_path_renames(Vector<StringName> base_path, Vector<StringName> new_base_path, Node *p_node, List<Pair<NodePath, NodePath> > *p_renames);
+	void _fill_path_renames(Vector<StringName> base_path, Vector<StringName> new_base_path, Node *p_node, List<Pair<NodePath, NodePath>> *p_renames);
 
 	void _normalize_drop(Node *&to_node, int &to_pos, int p_type);
 
@@ -249,8 +249,8 @@ public:
 	void instance(const String &p_file);
 	void instance_scenes(const Vector<String> &p_files, Node *p_parent = NULL);
 	void set_selected(Node *p_node, bool p_emit_selected = false);
-	void fill_path_renames(Node *p_node, Node *p_new_parent, List<Pair<NodePath, NodePath> > *p_renames);
-	void perform_node_renames(Node *p_base, List<Pair<NodePath, NodePath> > *p_renames, Map<Ref<Animation>, Set<int> > *r_rem_anims = NULL);
+	void fill_path_renames(Node *p_node, Node *p_new_parent, List<Pair<NodePath, NodePath>> *p_renames);
+	void perform_node_renames(Node *p_base, List<Pair<NodePath, NodePath>> *p_renames, Map<Ref<Animation>, Set<int>> *r_rem_anims = NULL);
 	SceneTreeEditor *get_tree_editor() { return scene_tree; }
 	EditorData *get_editor_data() { return editor_data; }
 

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -905,7 +905,7 @@ Variant SceneTreeEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from
 		return Variant(); //not editable tree
 
 	Vector<Node *> selected;
-	Vector<Ref<Texture2D> > icons;
+	Vector<Ref<Texture2D>> icons;
 	TreeItem *next = tree->get_next_selected(NULL);
 	while (next) {
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -419,7 +419,7 @@ void ScriptCreateDialog::_lang_changed(int l) {
 			templates[i].id = new_id;
 		}
 		// Disable overridden
-		for (Map<String, Vector<int> >::Element *E = template_overrides.front(); E; E = E->next()) {
+		for (Map<String, Vector<int>>::Element *E = template_overrides.front(); E; E = E->next()) {
 			const Vector<int> &overrides = E->get();
 
 			if (overrides.size() == 1) {

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -93,7 +93,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 
 	String script_template;
 	Vector<ScriptTemplateInfo> template_list;
-	Map<String, Vector<int> > template_overrides; // name : indices
+	Map<String, Vector<int>> template_overrides; // name : indices
 
 	void _update_script_templates(const String &p_extension);
 

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -183,7 +183,7 @@ private:
 
 	void _parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_emulated);
 
-	List<Ref<InputEvent> > accumulated_events;
+	List<Ref<InputEvent>> accumulated_events;
 	bool use_accumulated_input;
 
 public:

--- a/main/tests/test_ordered_hash_map.cpp
+++ b/main/tests/test_ordered_hash_map.cpp
@@ -84,7 +84,7 @@ bool test_iteration() {
 	map.insert(123485, 1238888);
 	map.insert(123, 111111);
 
-	Vector<Pair<int, int> > expected;
+	Vector<Pair<int, int>> expected;
 	expected.push_back(Pair<int, int>(42, 84));
 	expected.push_back(Pair<int, int>(123, 111111));
 	expected.push_back(Pair<int, int>(0, 12934));
@@ -101,7 +101,7 @@ bool test_iteration() {
 }
 
 bool test_const_iteration(const OrderedHashMap<int, int> &map) {
-	Vector<Pair<int, int> > expected;
+	Vector<Pair<int, int>> expected;
 	expected.push_back(Pair<int, int>(42, 84));
 	expected.push_back(Pair<int, int>(123, 111111));
 	expected.push_back(Pair<int, int>(0, 12934));

--- a/main/tests/test_physics.cpp
+++ b/main/tests/test_physics.cpp
@@ -222,7 +222,7 @@ protected:
 
 	void make_grid(int p_width, int p_height, float p_cellsize, float p_cellheight, const Transform &p_xform = Transform()) {
 
-		Vector<Vector<float> > grid;
+		Vector<Vector<float>> grid;
 
 		grid.resize(p_width);
 

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -872,7 +872,7 @@ EditorSceneImporterAssimp::_generate_mesh_from_surface_indices(ImportState &stat
 		const unsigned int mesh_idx = p_surface_indices[i];
 		const aiMesh *ai_mesh = state.assimp_scene->mMeshes[mesh_idx];
 
-		Map<uint32_t, Vector<BoneInfo> > vertex_weights;
+		Map<uint32_t, Vector<BoneInfo>> vertex_weights;
 
 		if (ai_mesh->mNumBones > 0) {
 			for (size_t b = 0; b < ai_mesh->mNumBones; b++) {

--- a/modules/assimp/import_state.h
+++ b/modules/assimp/import_state.h
@@ -61,15 +61,15 @@ struct ImportState {
 	const aiScene *assimp_scene;
 	uint32_t max_bone_weights;
 
-	Map<String, Ref<Mesh> > mesh_cache;
-	Map<int, Ref<Material> > material_cache;
+	Map<String, Ref<Mesh>> mesh_cache;
+	Map<int, Ref<Material>> material_cache;
 	Map<String, int> light_cache;
 	Map<String, int> camera_cache;
 
 	// very useful for when you need to ask assimp for the bone mesh
 
 	Map<const aiNode *, Node *> assimp_node_map;
-	Map<String, Ref<Image> > path_to_image_cache;
+	Map<String, Ref<Image>> path_to_image_cache;
 
 	// Generation 3 - determinisitic iteration
 	// to lower potential recursion errors

--- a/modules/assimp/import_utils.h
+++ b/modules/assimp/import_utils.h
@@ -341,7 +341,7 @@ public:
 	  */
 	static Ref<Image> load_image(ImportState &state, const aiScene *p_scene, String p_path) {
 
-		Map<String, Ref<Image> >::Element *match = state.path_to_image_cache.find(p_path);
+		Map<String, Ref<Image>>::Element *match = state.path_to_image_cache.find(p_path);
 
 		// if our cache contains this image then don't bother
 		if (match) {

--- a/modules/bullet/soft_body_bullet.h
+++ b/modules/bullet/soft_body_bullet.h
@@ -59,7 +59,7 @@ class SoftBodyBullet : public CollisionObjectBullet {
 
 private:
 	btSoftBody *bt_soft_body;
-	Vector<Vector<int> > indices_table;
+	Vector<Vector<int>> indices_table;
 	btSoftBody::Material *mat0; // This is just a copy of pointer managed by btSoftBody
 	bool isScratched;
 

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -179,7 +179,7 @@ void CSGBrush::_regen_face_aabbs() {
 	}
 }
 
-void CSGBrush::build_from_faces(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<bool> &p_smooth, const Vector<Ref<Material> > &p_materials, const Vector<bool> &p_invert_faces) {
+void CSGBrush::build_from_faces(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials, const Vector<bool> &p_invert_faces) {
 
 	faces.clear();
 

--- a/modules/csg/csg.h
+++ b/modules/csg/csg.h
@@ -55,12 +55,12 @@ struct CSGBrush {
 	};
 
 	Vector<Face> faces;
-	Vector<Ref<Material> > materials;
+	Vector<Ref<Material>> materials;
 
 	inline void _regen_face_aabbs();
 
 	// Create a brush from faces.
-	void build_from_faces(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<bool> &p_smooth, const Vector<Ref<Material> > &p_materials, const Vector<bool> &p_invert_faces);
+	void build_from_faces(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uvs, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials, const Vector<bool> &p_invert_faces);
 	void copy_from(const CSGBrush &p_brush, const Transform &p_xform);
 };
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -665,7 +665,7 @@ CSGCombiner::CSGCombiner() {
 
 /////////////////////
 
-CSGBrush *CSGPrimitive::_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<bool> &p_smooth, const Vector<Ref<Material> > &p_materials) {
+CSGBrush *CSGPrimitive::_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials) {
 
 	CSGBrush *brush = memnew(CSGBrush);
 
@@ -717,7 +717,7 @@ CSGBrush *CSGMesh::_build_brush() {
 
 	Vector<Vector3> vertices;
 	Vector<bool> smooth;
-	Vector<Ref<Material> > materials;
+	Vector<Ref<Material>> materials;
 	Vector<Vector2> uvs;
 	Ref<Material> material = get_material();
 
@@ -927,7 +927,7 @@ CSGBrush *CSGSphere::_build_brush() {
 	Vector<Vector3> faces;
 	Vector<Vector2> uvs;
 	Vector<bool> smooth;
-	Vector<Ref<Material> > materials;
+	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
 	faces.resize(face_count * 3);
@@ -1130,7 +1130,7 @@ CSGBrush *CSGBox::_build_brush() {
 	Vector<Vector3> faces;
 	Vector<Vector2> uvs;
 	Vector<bool> smooth;
-	Vector<Ref<Material> > materials;
+	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
 	faces.resize(face_count * 3);
@@ -1308,7 +1308,7 @@ CSGBrush *CSGCylinder::_build_brush() {
 	Vector<Vector3> faces;
 	Vector<Vector2> uvs;
 	Vector<bool> smooth;
-	Vector<Ref<Material> > materials;
+	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
 	faces.resize(face_count * 3);
@@ -1557,7 +1557,7 @@ CSGBrush *CSGTorus::_build_brush() {
 	Vector<Vector3> faces;
 	Vector<Vector2> uvs;
 	Vector<bool> smooth;
-	Vector<Ref<Material> > materials;
+	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
 	faces.resize(face_count * 3);
@@ -1851,7 +1851,7 @@ CSGBrush *CSGPolygon::_build_brush() {
 	Vector<Vector3> faces;
 	Vector<Vector2> uvs;
 	Vector<bool> smooth;
-	Vector<Ref<Material> > materials;
+	Vector<Ref<Material>> materials;
 	Vector<bool> invert;
 
 	faces.resize(face_count * 3);

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -172,7 +172,7 @@ private:
 	bool invert_faces;
 
 protected:
-	CSGBrush *_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<bool> &p_smooth, const Vector<Ref<Material> > &p_materials);
+	CSGBrush *_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials);
 	static void _bind_methods();
 
 public:

--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -48,7 +48,7 @@ static const bool default_reloadable = true;
 // Defined in gdnative_api_struct.gen.cpp
 extern const godot_gdnative_core_api_struct api_struct;
 
-Map<String, Vector<Ref<GDNative> > > GDNativeLibrary::loaded_libraries;
+Map<String, Vector<Ref<GDNative>>> GDNativeLibrary::loaded_libraries;
 
 GDNativeLibrary::GDNativeLibrary() {
 	config_file.instance();
@@ -373,7 +373,7 @@ bool GDNative::initialize() {
 	initialized = true;
 
 	if (library->should_load_once() && !GDNativeLibrary::loaded_libraries.has(lib_path)) {
-		Vector<Ref<GDNative> > gdnatives;
+		Vector<Ref<GDNative>> gdnatives;
 		gdnatives.resize(1);
 		gdnatives.write[0] = Ref<GDNative>(this);
 		GDNativeLibrary::loaded_libraries.insert(lib_path, gdnatives);
@@ -390,7 +390,7 @@ bool GDNative::terminate() {
 	}
 
 	if (library->should_load_once()) {
-		Vector<Ref<GDNative> > *gdnatives = &GDNativeLibrary::loaded_libraries[library->get_current_library_path()];
+		Vector<Ref<GDNative>> *gdnatives = &GDNativeLibrary::loaded_libraries[library->get_current_library_path()];
 		if (gdnatives->size() > 1) {
 			// there are other GDNative's still using this library, so we actually don't terminate
 			gdnatives->erase(Ref<GDNative>(this));

--- a/modules/gdnative/gdnative.h
+++ b/modules/gdnative/gdnative.h
@@ -47,7 +47,7 @@ class GDNative;
 class GDNativeLibrary : public Resource {
 	GDCLASS(GDNativeLibrary, Resource);
 
-	static Map<String, Vector<Ref<GDNative> > > loaded_libraries;
+	static Map<String, Vector<Ref<GDNative>>> loaded_libraries;
 
 	friend class GDNativeLibraryResourceLoader;
 	friend class GDNative;

--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -98,7 +98,7 @@ struct SignalAPI {
 
 struct EnumAPI {
 	String name;
-	List<Pair<int, String> > values;
+	List<Pair<int, String>> values;
 };
 
 struct ClassAPI {
@@ -395,7 +395,7 @@ List<ClassAPI> generate_c_api_classes() {
 					int int_val = ClassDB::get_integer_constant(class_name, val_e->get(), NULL);
 					enum_api.values.push_back(Pair<int, String>(int_val, val_e->get()));
 				}
-				enum_api.values.sort_custom<PairSort<int, String> >();
+				enum_api.values.sort_custom<PairSort<int, String>>();
 				class_api.enums.push_back(enum_api);
 			}
 		}
@@ -497,7 +497,7 @@ static List<String> generate_c_api_json(const List<ClassAPI> &p_api) {
 			source.push_back("\t\t\t{\n");
 			source.push_back("\t\t\t\t\"name\": \"" + e->get().name + "\",\n");
 			source.push_back("\t\t\t\t\"values\": {\n");
-			for (List<Pair<int, String> >::Element *val_e = e->get().values.front(); val_e; val_e = val_e->next()) {
+			for (List<Pair<int, String>>::Element *val_e = e->get().values.front(); val_e; val_e = val_e->next()) {
 				source.push_back("\t\t\t\t\t\"" + val_e->get().second + "\": " + itos(val_e->get().first));
 				source.push_back(String((val_e->next() ? "," : "")) + "\n");
 			}

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1139,16 +1139,16 @@ NativeScriptLanguage *NativeScriptLanguage::singleton;
 
 void NativeScriptLanguage::_unload_stuff(bool p_reload) {
 
-	Map<String, Ref<GDNative> > erase_and_unload;
+	Map<String, Ref<GDNative>> erase_and_unload;
 
-	for (Map<String, Map<StringName, NativeScriptDesc> >::Element *L = library_classes.front(); L; L = L->next()) {
+	for (Map<String, Map<StringName, NativeScriptDesc>>::Element *L = library_classes.front(); L; L = L->next()) {
 
 		String lib_path = L->key();
 		Map<StringName, NativeScriptDesc> classes = L->get();
 
 		if (p_reload) {
 
-			Map<String, Ref<GDNative> >::Element *E = library_gdnatives.find(lib_path);
+			Map<String, Ref<GDNative>>::Element *E = library_gdnatives.find(lib_path);
 			Ref<GDNative> gdn;
 
 			if (E) {
@@ -1169,7 +1169,7 @@ void NativeScriptLanguage::_unload_stuff(bool p_reload) {
 			}
 		}
 
-		Map<String, Ref<GDNative> >::Element *E = library_gdnatives.find(lib_path);
+		Map<String, Ref<GDNative>>::Element *E = library_gdnatives.find(lib_path);
 		Ref<GDNative> gdn;
 
 		if (E) {
@@ -1204,7 +1204,7 @@ void NativeScriptLanguage::_unload_stuff(bool p_reload) {
 		erase_and_unload.insert(lib_path, gdn);
 	}
 
-	for (Map<String, Ref<GDNative> >::Element *E = erase_and_unload.front(); E; E = E->next()) {
+	for (Map<String, Ref<GDNative>>::Element *E = erase_and_unload.front(); E; E = E->next()) {
 		String lib_path = E->key();
 		Ref<GDNative> gdn = E->get();
 
@@ -1247,7 +1247,7 @@ NativeScriptLanguage::NativeScriptLanguage() {
 
 NativeScriptLanguage::~NativeScriptLanguage() {
 
-	for (Map<String, Ref<GDNative> >::Element *L = NSL->library_gdnatives.front(); L; L = L->next()) {
+	for (Map<String, Ref<GDNative>>::Element *L = NSL->library_gdnatives.front(); L; L = L->next()) {
 
 		Ref<GDNative> lib = L->get();
 		// only shut down valid libs, duh!
@@ -1385,7 +1385,7 @@ void NativeScriptLanguage::get_recognized_extensions(List<String> *p_extensions)
 void NativeScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const {
 }
 
-void NativeScriptLanguage::get_public_constants(List<Pair<String, Variant> > *p_constants) const {
+void NativeScriptLanguage::get_public_constants(List<Pair<String, Variant>> *p_constants) const {
 }
 
 void NativeScriptLanguage::profiling_start() {
@@ -1679,7 +1679,7 @@ void NativeScriptLanguage::init_library(const Ref<GDNativeLibrary> &lib) {
 	// See if this library was "registered" already.
 	const String &lib_path = lib->get_current_library_path();
 	ERR_FAIL_COND_MSG(lib_path.length() == 0, lib->get_name() + " does not have a library for the current platform.");
-	Map<String, Ref<GDNative> >::Element *E = library_gdnatives.find(lib_path);
+	Map<String, Ref<GDNative>>::Element *E = library_gdnatives.find(lib_path);
 
 	if (!E) {
 		Ref<GDNative> gdn;
@@ -1719,7 +1719,7 @@ void NativeScriptLanguage::register_script(NativeScript *script) {
 void NativeScriptLanguage::unregister_script(NativeScript *script) {
 	MutexLock lock(mutex);
 
-	Map<String, Set<NativeScript *> >::Element *S = library_script_users.find(script->lib_path);
+	Map<String, Set<NativeScript *>>::Element *S = library_script_users.find(script->lib_path);
 	if (S) {
 		S->get().erase(script);
 		if (S->get().size() == 0) {
@@ -1733,7 +1733,7 @@ void NativeScriptLanguage::unregister_script(NativeScript *script) {
 
 void NativeScriptLanguage::call_libraries_cb(const StringName &name) {
 	// library_gdnatives is modified only from the main thread, so it's safe not to use mutex here
-	for (Map<String, Ref<GDNative> >::Element *L = library_gdnatives.front(); L; L = L->next()) {
+	for (Map<String, Ref<GDNative>>::Element *L = library_gdnatives.front(); L; L = L->next()) {
 
 		if (L->get().is_null()) {
 			continue;
@@ -1755,7 +1755,7 @@ void NativeScriptLanguage::frame() {
 #ifndef NO_THREADS
 	if (has_objects_to_register) {
 		MutexLock lock(mutex);
-		for (Set<Ref<GDNativeLibrary> >::Element *L = libs_to_init.front(); L; L = L->next()) {
+		for (Set<Ref<GDNativeLibrary>>::Element *L = libs_to_init.front(); L; L = L->next()) {
 			init_library(L->get());
 		}
 		libs_to_init.clear();
@@ -1834,7 +1834,7 @@ void NativeReloadNode::_notification(int p_what) {
 			MutexLock lock(NSL->mutex);
 			NSL->_unload_stuff(true);
 
-			for (Map<String, Ref<GDNative> >::Element *L = NSL->library_gdnatives.front(); L; L = L->next()) {
+			for (Map<String, Ref<GDNative>>::Element *L = NSL->library_gdnatives.front(); L; L = L->next()) {
 
 				Ref<GDNative> gdn = L->get();
 
@@ -1869,7 +1869,7 @@ void NativeReloadNode::_notification(int p_what) {
 			MutexLock lock(NSL->mutex);
 
 			Set<StringName> libs_to_remove;
-			for (Map<String, Ref<GDNative> >::Element *L = NSL->library_gdnatives.front(); L; L = L->next()) {
+			for (Map<String, Ref<GDNative>>::Element *L = NSL->library_gdnatives.front(); L; L = L->next()) {
 
 				Ref<GDNative> gdn = L->get();
 
@@ -1904,7 +1904,7 @@ void NativeReloadNode::_notification(int p_what) {
 					((void (*)(void *))proc_ptr)((void *)&L->key());
 				}
 
-				for (Map<String, Set<NativeScript *> >::Element *U = NSL->library_script_users.front(); U; U = U->next()) {
+				for (Map<String, Set<NativeScript *>>::Element *U = NSL->library_script_users.front(); U; U = U->next()) {
 					for (Set<NativeScript *>::Element *S = U->get().front(); S; S = S->next()) {
 						NativeScript *script = S->get();
 

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -263,7 +263,7 @@ private:
 
 	Mutex mutex;
 #ifndef NO_THREADS
-	Set<Ref<GDNativeLibrary> > libs_to_init;
+	Set<Ref<GDNativeLibrary>> libs_to_init;
 	Set<NativeScript *> scripts_to_register;
 	volatile bool has_objects_to_register; // so that we don't lock mutex every frame - it's rarely needed
 	void defer_init_library(Ref<GDNativeLibrary> lib, NativeScript *script);
@@ -275,10 +275,10 @@ private:
 
 	void call_libraries_cb(const StringName &name);
 
-	Vector<Pair<bool, godot_instance_binding_functions> > binding_functions;
+	Vector<Pair<bool, godot_instance_binding_functions>> binding_functions;
 	Set<Vector<void *> *> binding_instances;
 
-	Map<int, HashMap<StringName, const void *> > global_type_tags;
+	Map<int, HashMap<StringName, const void *>> global_type_tags;
 
 	struct ProfileData {
 		StringName signature;
@@ -298,10 +298,10 @@ private:
 
 public:
 	// These two maps must only be touched on the main thread
-	Map<String, Map<StringName, NativeScriptDesc> > library_classes;
-	Map<String, Ref<GDNative> > library_gdnatives;
+	Map<String, Map<StringName, NativeScriptDesc>> library_classes;
+	Map<String, Ref<GDNative>> library_gdnatives;
 
-	Map<String, Set<NativeScript *> > library_script_users;
+	Map<String, Set<NativeScript *>> library_script_users;
 
 	StringName _init_call_type;
 	StringName _init_call_name;
@@ -362,7 +362,7 @@ public:
 	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const;
-	virtual void get_public_constants(List<Pair<String, Variant> > *p_constants) const;
+	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const;
 	virtual void profiling_start();
 	virtual void profiling_stop();
 	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max);

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -210,7 +210,7 @@ void PluginScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) c
 	}
 }
 
-void PluginScriptLanguage::get_public_constants(List<Pair<String, Variant> > *p_constants) const {
+void PluginScriptLanguage::get_public_constants(List<Pair<String, Variant>> *p_constants) const {
 	// TODO: provide this statically in `godot_pluginscript_language_desc` ?
 	if (_desc.get_public_constants) {
 		Dictionary constants;

--- a/modules/gdnative/pluginscript/pluginscript_language.h
+++ b/modules/gdnative/pluginscript/pluginscript_language.h
@@ -112,7 +112,7 @@ public:
 
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const;
-	virtual void get_public_constants(List<Pair<String, Variant> > *p_constants) const;
+	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const;
 
 	virtual void profiling_start();
 	virtual void profiling_stop();

--- a/modules/gdnative/register_types.cpp
+++ b/modules/gdnative/register_types.cpp
@@ -214,7 +214,7 @@ static godot_variant cb_standard_varcall(void *p_procedure_handle, godot_array *
 
 GDNativeCallRegistry *GDNativeCallRegistry::singleton;
 
-Vector<Ref<GDNative> > singleton_gdnatives;
+Vector<Ref<GDNative>> singleton_gdnatives;
 
 Ref<GDNativeLibraryResourceLoader> resource_loader_gdnlib;
 Ref<GDNativeLibraryResourceSaver> resource_saver_gdnlib;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -522,7 +522,7 @@ void GDScript::update_exports() {
 void GDScript::_set_subclass_path(Ref<GDScript> &p_sc, const String &p_path) {
 
 	p_sc->path = p_path;
-	for (Map<StringName, Ref<GDScript> >::Element *E = p_sc->subclasses.front(); E; E = E->next()) {
+	for (Map<StringName, Ref<GDScript>>::Element *E = p_sc->subclasses.front(); E; E = E->next()) {
 
 		_set_subclass_path(E->get(), p_path);
 	}
@@ -592,7 +592,7 @@ Error GDScript::reload(bool p_keep_state) {
 
 	valid = true;
 
-	for (Map<StringName, Ref<GDScript> >::Element *E = subclasses.front(); E; E = E->next()) {
+	for (Map<StringName, Ref<GDScript>>::Element *E = subclasses.front(); E; E = E->next()) {
 
 		_set_subclass_path(E->get(), path);
 	}
@@ -715,7 +715,7 @@ bool GDScript::_get(const StringName &p_name, Variant &r_ret) const {
 			}
 
 			{
-				const Map<StringName, Ref<GDScript> >::Element *E = subclasses.find(p_name);
+				const Map<StringName, Ref<GDScript>>::Element *E = subclasses.find(p_name);
 				if (E) {
 
 					r_ret = E->get();
@@ -831,7 +831,7 @@ Error GDScript::load_byte_code(const String &p_path) {
 
 	valid = true;
 
-	for (Map<StringName, Ref<GDScript> >::Element *E = subclasses.front(); E; E = E->next()) {
+	for (Map<StringName, Ref<GDScript>>::Element *E = subclasses.front(); E; E = E->next()) {
 
 		_set_subclass_path(E->get(), path);
 	}
@@ -910,7 +910,7 @@ bool GDScript::has_script_signal(const StringName &p_signal) const {
 }
 void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
 
-	for (const Map<StringName, Vector<StringName> >::Element *E = _signals.front(); E; E = E->next()) {
+	for (const Map<StringName, Vector<StringName>>::Element *E = _signals.front(); E; E = E->next()) {
 
 		MethodInfo mi;
 		mi.name = E->key();
@@ -963,7 +963,7 @@ void GDScript::_save_orphaned_subclasses() {
 	};
 	Vector<ClassRefWithName> weak_subclasses;
 	// collect subclasses ObjectID and name
-	for (Map<StringName, Ref<GDScript> >::Element *E = subclasses.front(); E; E = E->next()) {
+	for (Map<StringName, Ref<GDScript>>::Element *E = subclasses.front(); E; E = E->next()) {
 		E->get()->_owner = NULL; //bye, you are no longer owned cause I died
 		ClassRefWithName subclass;
 		subclass.id = E->get()->get_instance_id();
@@ -997,7 +997,7 @@ void GDScript::_init_rpc_methods_properties() {
 	}
 
 	GDScript *cscript = this;
-	Map<StringName, Ref<GDScript> >::Element *sub_E = subclasses.front();
+	Map<StringName, Ref<GDScript>>::Element *sub_E = subclasses.front();
 	while (cscript) {
 		// RPC Methods
 		for (Map<StringName, GDScriptFunction *>::Element *E = cscript->member_functions.front(); E; E = E->next()) {
@@ -1661,7 +1661,7 @@ void GDScriptLanguage::reload_all_scripts() {
 
 #ifdef DEBUG_ENABLED
 	print_verbose("GDScript: Reloading all scripts");
-	List<Ref<GDScript> > scripts;
+	List<Ref<GDScript>> scripts;
 	{
 		MutexLock lock(this->lock);
 
@@ -1679,7 +1679,7 @@ void GDScriptLanguage::reload_all_scripts() {
 
 	scripts.sort_custom<GDScriptDepSort>(); //update in inheritance dependency order
 
-	for (List<Ref<GDScript> >::Element *E = scripts.front(); E; E = E->next()) {
+	for (List<Ref<GDScript>>::Element *E = scripts.front(); E; E = E->next()) {
 
 		print_verbose("GDScript: Reloading: " + E->get()->get_path());
 		E->get()->load_source_code(E->get()->get_path());
@@ -1692,7 +1692,7 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 
 #ifdef DEBUG_ENABLED
 
-	List<Ref<GDScript> > scripts;
+	List<Ref<GDScript>> scripts;
 	{
 		MutexLock lock(this->lock);
 
@@ -1708,30 +1708,30 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 
 	//when someone asks you why dynamically typed languages are easier to write....
 
-	Map<Ref<GDScript>, Map<ObjectID, List<Pair<StringName, Variant> > > > to_reload;
+	Map<Ref<GDScript>, Map<ObjectID, List<Pair<StringName, Variant>>>> to_reload;
 
 	//as scripts are going to be reloaded, must proceed without locking here
 
 	scripts.sort_custom<GDScriptDepSort>(); //update in inheritance dependency order
 
-	for (List<Ref<GDScript> >::Element *E = scripts.front(); E; E = E->next()) {
+	for (List<Ref<GDScript>>::Element *E = scripts.front(); E; E = E->next()) {
 
 		bool reload = E->get() == p_script || to_reload.has(E->get()->get_base());
 
 		if (!reload)
 			continue;
 
-		to_reload.insert(E->get(), Map<ObjectID, List<Pair<StringName, Variant> > >());
+		to_reload.insert(E->get(), Map<ObjectID, List<Pair<StringName, Variant>>>());
 
 		if (!p_soft_reload) {
 
 			//save state and remove script from instances
-			Map<ObjectID, List<Pair<StringName, Variant> > > &map = to_reload[E->get()];
+			Map<ObjectID, List<Pair<StringName, Variant>>> &map = to_reload[E->get()];
 
 			while (E->get()->instances.front()) {
 				Object *obj = E->get()->instances.front()->get();
 				//save instance info
-				List<Pair<StringName, Variant> > state;
+				List<Pair<StringName, Variant>> state;
 				if (obj->get_script_instance()) {
 
 					obj->get_script_instance()->get_property_state(state);
@@ -1749,8 +1749,8 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 				//save instance info
 				if (obj->get_script_instance()) {
 
-					map.insert(obj->get_instance_id(), List<Pair<StringName, Variant> >());
-					List<Pair<StringName, Variant> > &state = map[obj->get_instance_id()];
+					map.insert(obj->get_instance_id(), List<Pair<StringName, Variant>>());
+					List<Pair<StringName, Variant>> &state = map[obj->get_instance_id()];
 					obj->get_script_instance()->get_property_state(state);
 					obj->set_script(Variant());
 				} else {
@@ -1761,21 +1761,21 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 
 #endif
 
-			for (Map<ObjectID, List<Pair<StringName, Variant> > >::Element *F = E->get()->pending_reload_state.front(); F; F = F->next()) {
+			for (Map<ObjectID, List<Pair<StringName, Variant>>>::Element *F = E->get()->pending_reload_state.front(); F; F = F->next()) {
 				map[F->key()] = F->get(); //pending to reload, use this one instead
 			}
 		}
 	}
 
-	for (Map<Ref<GDScript>, Map<ObjectID, List<Pair<StringName, Variant> > > >::Element *E = to_reload.front(); E; E = E->next()) {
+	for (Map<Ref<GDScript>, Map<ObjectID, List<Pair<StringName, Variant>>>>::Element *E = to_reload.front(); E; E = E->next()) {
 
 		Ref<GDScript> scr = E->key();
 		scr->reload(p_soft_reload);
 
 		//restore state if saved
-		for (Map<ObjectID, List<Pair<StringName, Variant> > >::Element *F = E->get().front(); F; F = F->next()) {
+		for (Map<ObjectID, List<Pair<StringName, Variant>>>::Element *F = E->get().front(); F; F = F->next()) {
 
-			List<Pair<StringName, Variant> > &saved_state = F->get();
+			List<Pair<StringName, Variant>> &saved_state = F->get();
 
 			Object *obj = ObjectDB::get_instance(F->key());
 			if (!obj)
@@ -1799,11 +1799,11 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 
 			if (script_instance->is_placeholder() && scr->is_placeholder_fallback_enabled()) {
 				PlaceHolderScriptInstance *placeholder = static_cast<PlaceHolderScriptInstance *>(script_instance);
-				for (List<Pair<StringName, Variant> >::Element *G = saved_state.front(); G; G = G->next()) {
+				for (List<Pair<StringName, Variant>>::Element *G = saved_state.front(); G; G = G->next()) {
 					placeholder->property_set_fallback(G->get().first, G->get().second);
 				}
 			} else {
-				for (List<Pair<StringName, Variant> >::Element *G = saved_state.front(); G; G = G->next()) {
+				for (List<Pair<StringName, Variant>>::Element *G = saved_state.front(); G; G = G->next()) {
 					script_instance->set(G->get().first, G->get().second);
 				}
 			}

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -84,8 +84,8 @@ class GDScript : public Script {
 	Map<StringName, Variant> constants;
 	Map<StringName, GDScriptFunction *> member_functions;
 	Map<StringName, MemberInfo> member_indices; //members are just indices to the instanced script.
-	Map<StringName, Ref<GDScript> > subclasses;
-	Map<StringName, Vector<StringName> > _signals;
+	Map<StringName, Ref<GDScript>> subclasses;
+	Map<StringName, Vector<StringName>> _signals;
 	Vector<ScriptNetData> rpc_functions;
 	Vector<ScriptNetData> rpc_variables;
 
@@ -129,7 +129,7 @@ class GDScript : public Script {
 
 #ifdef DEBUG_ENABLED
 
-	Map<ObjectID, List<Pair<StringName, Variant> > > pending_reload_state;
+	Map<ObjectID, List<Pair<StringName, Variant>>> pending_reload_state;
 
 #endif
 
@@ -151,7 +151,7 @@ protected:
 public:
 	virtual bool is_valid() const { return valid; }
 
-	const Map<StringName, Ref<GDScript> > &get_subclasses() const { return subclasses; }
+	const Map<StringName, Ref<GDScript>> &get_subclasses() const { return subclasses; }
 	const Map<StringName, Variant> &get_constants() const { return constants; }
 	const Set<StringName> &get_members() const { return members; }
 	const GDScriptDataType &get_member_type(const StringName &p_member) const {
@@ -519,7 +519,7 @@ public:
 	virtual void frame();
 
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const;
-	virtual void get_public_constants(List<Pair<String, Variant> > *p_constants) const;
+	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const;
 
 	virtual void profiling_start();
 	virtual void profiling_stop();

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2111,7 +2111,7 @@ Error GDScriptCompiler::_parse_class_blocks(GDScript *p_script, const GDScriptPa
 
 void GDScriptCompiler::_make_scripts(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state) {
 
-	Map<StringName, Ref<GDScript> > old_subclasses;
+	Map<StringName, Ref<GDScript>> old_subclasses;
 
 	if (p_keep_state) {
 		old_subclasses = p_script->subclasses;

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -48,11 +48,11 @@ class GDScriptCompiler {
 		const GDScriptParser::FunctionNode *function_node;
 		bool debug_stack;
 
-		List<Map<StringName, int> > stack_id_stack;
+		List<Map<StringName, int>> stack_id_stack;
 		Map<StringName, int> stack_identifiers;
 
 		List<GDScriptFunction::StackDebug> stack_debug;
-		List<Map<StringName, int> > block_identifier_stack;
+		List<Map<StringName, int>> block_identifier_stack;
 		Map<StringName, int> block_identifiers;
 
 		void add_stack_identifier(const StringName &p_id, int p_stackpos) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -299,10 +299,10 @@ void GDScriptLanguage::debug_get_stack_level_locals(int p_level, List<String> *p
 
 	GDScriptFunction *f = _call_stack[l].function;
 
-	List<Pair<StringName, int> > locals;
+	List<Pair<StringName, int>> locals;
 
 	f->debug_get_stack_member_state(*_call_stack[l].line, &locals);
-	for (List<Pair<StringName, int> >::Element *E = locals.front(); E; E = E->next()) {
+	for (List<Pair<StringName, int>>::Element *E = locals.front(); E; E = E->next()) {
 
 		p_locals->push_back(E->get().first);
 		p_values->push_back(_call_stack[l].stack[E->get().second]);
@@ -351,7 +351,7 @@ void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> 
 	const Map<StringName, int> &name_idx = GDScriptLanguage::get_singleton()->get_global_map();
 	const Variant *globals = GDScriptLanguage::get_singleton()->get_global_array();
 
-	List<Pair<String, Variant> > cinfo;
+	List<Pair<String, Variant>> cinfo;
 	get_public_constants(&cinfo);
 
 	for (const Map<StringName, int>::Element *E = name_idx.front(); E; E = E->next()) {
@@ -360,7 +360,7 @@ void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> 
 			continue;
 
 		bool is_script_constant = false;
-		for (List<Pair<String, Variant> >::Element *CE = cinfo.front(); CE; CE = CE->next()) {
+		for (List<Pair<String, Variant>>::Element *CE = cinfo.front(); CE; CE = CE->next()) {
 			if (CE->get().first == E->key()) {
 				is_script_constant = true;
 				break;
@@ -434,7 +434,7 @@ void GDScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const
 	}
 }
 
-void GDScriptLanguage::get_public_constants(List<Pair<String, Variant> > *p_constants) const {
+void GDScriptLanguage::get_public_constants(List<Pair<String, Variant>> *p_constants) const {
 
 	Pair<String, Variant> pi;
 	pi.first = "PI";
@@ -1972,7 +1972,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionContext &p_context
 						}
 					}
 					if (!p_only_functions) {
-						for (const Map<StringName, Ref<GDScript> >::Element *E = script->get_subclasses().front(); E; E = E->next()) {
+						for (const Map<StringName, Ref<GDScript>>::Element *E = script->get_subclasses().front(); E; E = E->next()) {
 							ScriptCodeCompletionOption option(E->key().operator String(), ScriptCodeCompletionOption::KIND_CLASS);
 							r_result.insert(option.display, option);
 						}

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1707,7 +1707,7 @@ struct _GDFKCS {
 	}
 };
 
-void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<StringName, int> > *r_stackvars) const {
+void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<StringName, int>> *r_stackvars) const {
 
 	int oc = 0;
 	Map<StringName, _GDFKC> sdmap;

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -321,7 +321,7 @@ public:
 	GDScript *get_script() const { return _script; }
 	StringName get_source() const { return source; }
 
-	void debug_get_stack_member_state(int p_line, List<Pair<StringName, int> > *r_stackvars) const;
+	void debug_get_stack_member_state(int p_line, List<Pair<StringName, int>> *r_stackvars) const;
 
 	_FORCE_INLINE_ bool is_empty() const { return _code_size == 0; }
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -8534,7 +8534,7 @@ Error GDScriptParser::_parse(const String &p_base_path) {
 #ifdef DEBUG_ENABLED
 
 	// Resolve warning ignores
-	Vector<Pair<int, String> > warning_skips = tokenizer->get_warning_skips();
+	Vector<Pair<int, String>> warning_skips = tokenizer->get_warning_skips();
 	bool warning_is_error = GLOBAL_GET("debug/gdscript/warnings/treat_warnings_as_errors").booleanize();
 	for (List<GDScriptWarning>::Element *E = warnings.front(); E;) {
 		GDScriptWarning &w = E->get();

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -170,7 +170,7 @@ public:
 	virtual String get_token_error(int p_offset = 0) const = 0;
 	virtual void advance(int p_amount = 1) = 0;
 #ifdef DEBUG_ENABLED
-	virtual const Vector<Pair<int, String> > &get_warning_skips() const = 0;
+	virtual const Vector<Pair<int, String>> &get_warning_skips() const = 0;
 	virtual const Set<String> &get_warning_global_skips() const = 0;
 	virtual bool is_ignoring_warnings() const = 0;
 #endif // DEBUG_ENABLED
@@ -223,7 +223,7 @@ class GDScriptTokenizerText : public GDScriptTokenizer {
 	bool error_flag;
 
 #ifdef DEBUG_ENABLED
-	Vector<Pair<int, String> > warning_skips;
+	Vector<Pair<int, String>> warning_skips;
 	Set<String> warning_global_skips;
 	bool ignore_warnings;
 #endif // DEBUG_ENABLED
@@ -244,7 +244,7 @@ public:
 	virtual String get_token_error(int p_offset = 0) const;
 	virtual void advance(int p_amount = 1);
 #ifdef DEBUG_ENABLED
-	virtual const Vector<Pair<int, String> > &get_warning_skips() const { return warning_skips; }
+	virtual const Vector<Pair<int, String>> &get_warning_skips() const { return warning_skips; }
 	virtual const Set<String> &get_warning_global_skips() const { return warning_global_skips; }
 	virtual bool is_ignoring_warnings() const { return ignore_warnings; }
 #endif // DEBUG_ENABLED
@@ -283,8 +283,8 @@ public:
 	virtual String get_token_error(int p_offset = 0) const;
 	virtual void advance(int p_amount = 1);
 #ifdef DEBUG_ENABLED
-	virtual const Vector<Pair<int, String> > &get_warning_skips() const {
-		static Vector<Pair<int, String> > v;
+	virtual const Vector<Pair<int, String>> &get_warning_skips() const {
+		static Vector<Pair<int, String>> v;
 		return v;
 	}
 	virtual const Set<String> &get_warning_global_skips() const {

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -68,7 +68,7 @@ private:
 
 	static GDScriptLanguageProtocol *singleton;
 
-	HashMap<int, Ref<LSPeer> > clients;
+	HashMap<int, Ref<LSPeer>> clients;
 	Ref<TCP_Server> server;
 	int latest_client_id;
 	int next_client_id;

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -447,7 +447,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 	 * and set said multimesh bounding box to one containing all cells which have this item
 	 */
 
-	Map<int, List<Pair<Transform, IndexKey> > > multimesh_items;
+	Map<int, List<Pair<Transform, IndexKey>>> multimesh_items;
 
 	for (Set<IndexKey>::Element *E = g.cells.front(); E; E = E->next()) {
 
@@ -468,7 +468,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 		if (baked_meshes.size() == 0) {
 			if (mesh_library->get_item_mesh(c.item).is_valid()) {
 				if (!multimesh_items.has(c.item)) {
-					multimesh_items[c.item] = List<Pair<Transform, IndexKey> >();
+					multimesh_items[c.item] = List<Pair<Transform, IndexKey>>();
 				}
 
 				Pair<Transform, IndexKey> p;
@@ -510,7 +510,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 	//update multimeshes, only if not baked
 	if (baked_meshes.size() == 0) {
 
-		for (Map<int, List<Pair<Transform, IndexKey> > >::Element *E = multimesh_items.front(); E; E = E->next()) {
+		for (Map<int, List<Pair<Transform, IndexKey>>>::Element *E = multimesh_items.front(); E; E = E->next()) {
 			Octant::MultimeshInstance mmi;
 
 			RID mm = VS::get_singleton()->multimesh_create();
@@ -518,7 +518,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 			VS::get_singleton()->multimesh_set_mesh(mm, mesh_library->get_item_mesh(E->key())->get_rid());
 
 			int idx = 0;
-			for (List<Pair<Transform, IndexKey> >::Element *F = E->get().front(); F; F = F->next()) {
+			for (List<Pair<Transform, IndexKey>>::Element *F = E->get().front(); F; F = F->next()) {
 				VS::get_singleton()->multimesh_instance_set_transform(mm, idx, F->get().first);
 #ifdef TOOLS_ENABLED
 
@@ -988,7 +988,7 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 		return;
 
 	//generate
-	Map<OctantKey, Map<Ref<Material>, Ref<SurfaceTool> > > surface_map;
+	Map<OctantKey, Map<Ref<Material>, Ref<SurfaceTool>>> surface_map;
 
 	for (Map<IndexKey, Cell>::Element *E = cell_map.front(); E; E = E->next()) {
 
@@ -1017,10 +1017,10 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 		ok.z = key.z / octant_size;
 
 		if (!surface_map.has(ok)) {
-			surface_map[ok] = Map<Ref<Material>, Ref<SurfaceTool> >();
+			surface_map[ok] = Map<Ref<Material>, Ref<SurfaceTool>>();
 		}
 
-		Map<Ref<Material>, Ref<SurfaceTool> > &mat_map = surface_map[ok];
+		Map<Ref<Material>, Ref<SurfaceTool>> &mat_map = surface_map[ok];
 
 		for (int i = 0; i < mesh->get_surface_count(); i++) {
 
@@ -1040,11 +1040,11 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 		}
 	}
 
-	for (Map<OctantKey, Map<Ref<Material>, Ref<SurfaceTool> > >::Element *E = surface_map.front(); E; E = E->next()) {
+	for (Map<OctantKey, Map<Ref<Material>, Ref<SurfaceTool>>>::Element *E = surface_map.front(); E; E = E->next()) {
 
 		Ref<ArrayMesh> mesh;
 		mesh.instance();
-		for (Map<Ref<Material>, Ref<SurfaceTool> >::Element *F = E->get().front(); F; F = F->next()) {
+		for (Map<Ref<Material>, Ref<SurfaceTool>>::Element *F = E->get().front(); F; F = F->next()) {
 			F->get()->commit(mesh);
 		}
 

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -234,7 +234,7 @@ Ref<CryptoKey> CryptoMbedTLS::generate_rsa(int p_bytes) {
 }
 
 Ref<X509Certificate> CryptoMbedTLS::generate_self_signed_certificate(Ref<CryptoKey> p_key, String p_issuer_name, String p_not_before, String p_not_after) {
-	Ref<CryptoKeyMbedTLS> key = static_cast<Ref<CryptoKeyMbedTLS> >(p_key);
+	Ref<CryptoKeyMbedTLS> key = static_cast<Ref<CryptoKeyMbedTLS>>(p_key);
 	ERR_FAIL_COND_V_MSG(key.is_null(), NULL, "Invalid private key argument.");
 	mbedtls_x509write_cert crt;
 	mbedtls_x509write_crt_init(&crt);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -763,7 +763,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 
 	// There is no soft reloading with Mono. It's always hard reloading.
 
-	List<Ref<CSharpScript> > scripts;
+	List<Ref<CSharpScript>> scripts;
 
 	{
 		MutexLock lock(script_instances_mutex);
@@ -774,10 +774,10 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 		}
 	}
 
-	List<Ref<CSharpScript> > to_reload;
+	List<Ref<CSharpScript>> to_reload;
 
 	// We need to keep reference instances alive during reloading
-	List<Ref<Reference> > ref_instances;
+	List<Ref<Reference>> ref_instances;
 
 	for (Map<Object *, CSharpScriptBinding>::Element *E = script_bindings.front(); E; E = E->next()) {
 		CSharpScriptBinding &script_binding = E->value();
@@ -791,7 +791,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 
 	scripts.sort_custom<CSharpScriptDepSort>(); // Update in inheritance dependency order
 
-	for (List<Ref<CSharpScript> >::Element *E = scripts.front(); E; E = E->next()) {
+	for (List<Ref<CSharpScript>>::Element *E = scripts.front(); E; E = E->next()) {
 		Ref<CSharpScript> &script = E->get();
 
 		to_reload.push_back(script);
@@ -851,7 +851,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 	}
 
 	// After the state of all instances is saved, clear scripts and script instances
-	for (List<Ref<CSharpScript> >::Element *E = scripts.front(); E; E = E->next()) {
+	for (List<Ref<CSharpScript>>::Element *E = scripts.front(); E; E = E->next()) {
 		Ref<CSharpScript> &script = E->get();
 
 		while (script->instances.front()) {
@@ -866,7 +866,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 	if (gdmono->reload_scripts_domain() != OK) {
 		// Failed to reload the scripts domain
 		// Make sure to add the scripts back to their owners before returning
-		for (List<Ref<CSharpScript> >::Element *E = to_reload.front(); E; E = E->next()) {
+		for (List<Ref<CSharpScript>>::Element *E = to_reload.front(); E; E = E->next()) {
 			Ref<CSharpScript> scr = E->get();
 
 			for (const Map<ObjectID, CSharpScript::StateBackup>::Element *F = scr->pending_reload_state.front(); F; F = F->next()) {
@@ -891,7 +891,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 #endif
 
 				// Restore Variant properties state, it will be kept by the placeholder until the next script reloading
-				for (List<Pair<StringName, Variant> >::Element *G = scr->pending_reload_state[obj_id].properties.front(); G; G = G->next()) {
+				for (List<Pair<StringName, Variant>>::Element *G = scr->pending_reload_state[obj_id].properties.front(); G; G = G->next()) {
 					placeholder->property_set_fallback(G->get().first, G->get().second, NULL);
 				}
 
@@ -902,9 +902,9 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 		return;
 	}
 
-	List<Ref<CSharpScript> > to_reload_state;
+	List<Ref<CSharpScript>> to_reload_state;
 
-	for (List<Ref<CSharpScript> >::Element *E = to_reload.front(); E; E = E->next()) {
+	for (List<Ref<CSharpScript>>::Element *E = to_reload.front(); E; E = E->next()) {
 		Ref<CSharpScript> script = E->get();
 
 		if (!script->get_path().empty()) {
@@ -1012,7 +1012,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 		to_reload_state.push_back(script);
 	}
 
-	for (List<Ref<CSharpScript> >::Element *E = to_reload_state.front(); E; E = E->next()) {
+	for (List<Ref<CSharpScript>>::Element *E = to_reload_state.front(); E; E = E->next()) {
 		Ref<CSharpScript> script = E->get();
 
 		for (Set<ObjectID>::Element *F = script->pending_reload_instances.front(); F; F = F->next()) {
@@ -1030,7 +1030,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 
 			CSharpScript::StateBackup &state_backup = script->pending_reload_state[obj_id];
 
-			for (List<Pair<StringName, Variant> >::Element *G = state_backup.properties.front(); G; G = G->next()) {
+			for (List<Pair<StringName, Variant>>::Element *G = state_backup.properties.front(); G; G = G->next()) {
 				obj->get_script_instance()->set(G->get().first, G->get().second);
 			}
 
@@ -1585,7 +1585,7 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 	return false;
 }
 
-void CSharpInstance::get_properties_state_for_reloading(List<Pair<StringName, Variant> > &r_state) {
+void CSharpInstance::get_properties_state_for_reloading(List<Pair<StringName, Variant>> &r_state) {
 
 	List<PropertyInfo> pinfo;
 	get_property_list(&pinfo);
@@ -3294,7 +3294,7 @@ bool CSharpScript::has_script_signal(const StringName &p_signal) const {
 }
 
 void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
-	for (const Map<StringName, Vector<Argument> >::Element *E = _signals.front(); E; E = E->next()) {
+	for (const Map<StringName, Vector<Argument>>::Element *E = _signals.front(); E; E = E->next()) {
 		MethodInfo mi;
 
 		mi.name = E->key();

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -91,7 +91,7 @@ class CSharpScript : public Script {
 		// TODO
 		// Replace with buffer containing the serialized state of managed scripts.
 		// Keep variant state backup to use only with script instance placeholders.
-		List<Pair<StringName, Variant> > properties;
+		List<Pair<StringName, Variant>> properties;
 	};
 
 	Set<ObjectID> pending_reload_instances;
@@ -110,7 +110,7 @@ class CSharpScript : public Script {
 		Variant::Type type;
 	};
 
-	Map<StringName, Vector<Argument> > _signals;
+	Map<StringName, Vector<Argument>> _signals;
 	bool signals_invalidated;
 
 	Vector<ScriptNetData> rpc_functions;
@@ -249,7 +249,7 @@ class CSharpInstance : public ScriptInstance {
 
 	void _call_multilevel(MonoObject *p_mono_object, const StringName &p_method, const Variant **p_args, int p_argcount);
 
-	void get_properties_state_for_reloading(List<Pair<StringName, Variant> > &r_state);
+	void get_properties_state_for_reloading(List<Pair<StringName, Variant>> &r_state);
 
 public:
 	MonoObject *get_mono_object() const;
@@ -458,7 +458,7 @@ public:
 	virtual void frame();
 
 	/* TODO? */ virtual void get_public_functions(List<MethodInfo> *p_functions) const {}
-	/* TODO? */ virtual void get_public_constants(List<Pair<String, Variant> > *p_constants) const {}
+	/* TODO? */ virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const {}
 
 	virtual void reload_all_scripts();
 	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload);

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2484,7 +2484,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 		List<String> constants;
 		ClassDB::get_integer_constant_list(type_cname, &constants, true);
 
-		const HashMap<StringName, List<StringName> > &enum_map = class_info->enum_map;
+		const HashMap<StringName, List<StringName>> &enum_map = class_info->enum_map;
 		const StringName *k = NULL;
 
 		while ((k = enum_map.next(k))) {

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -510,7 +510,7 @@ class BindingsGenerator {
 	List<InternalCall> core_custom_icalls;
 	List<InternalCall> editor_custom_icalls;
 
-	Map<StringName, List<StringName> > blacklisted_methods;
+	Map<StringName, List<StringName>> blacklisted_methods;
 
 	void _initialize_blacklisted_methods();
 

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -105,7 +105,7 @@ private:
 	MonoDomain *root_domain;
 	MonoDomain *scripts_domain;
 
-	HashMap<uint32_t, HashMap<String, GDMonoAssembly *> > assemblies;
+	HashMap<uint32_t, HashMap<String, GDMonoAssembly *>> assemblies;
 
 	GDMonoAssembly *corlib_assembly;
 	GDMonoAssembly *project_assembly;

--- a/modules/upnp/upnp.h
+++ b/modules/upnp/upnp.h
@@ -46,7 +46,7 @@ private:
 	int discover_local_port;
 	bool discover_ipv6;
 
-	Vector<Ref<UPNPDevice> > devices;
+	Vector<Ref<UPNPDevice>> devices;
 
 	bool is_common_device(const String &dev) const;
 	void add_device_to_list(UPNPDev *dev, UPNPDev *devlist);

--- a/modules/vhacd/register_types.cpp
+++ b/modules/vhacd/register_types.cpp
@@ -32,7 +32,7 @@
 #include "scene/resources/mesh.h"
 #include "thirdparty/vhacd/public/VHACD.h"
 
-static Vector<Vector<Face3> > convex_decompose(const Vector<Face3> &p_faces) {
+static Vector<Vector<Face3>> convex_decompose(const Vector<Face3> &p_faces) {
 
 	Vector<float> vertices;
 	vertices.resize(p_faces.size() * 9);
@@ -54,7 +54,7 @@ static Vector<Vector<Face3> > convex_decompose(const Vector<Face3> &p_faces) {
 
 	int hull_count = decomposer->GetNConvexHulls();
 
-	Vector<Vector<Face3> > ret;
+	Vector<Vector<Face3>> ret;
 
 	for (int i = 0; i < hull_count; i++) {
 		Vector<Face3> triangles;

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -827,7 +827,7 @@ void VisualScript::rename_custom_signal(const StringName &p_name, const StringNa
 
 void VisualScript::get_custom_signal_list(List<StringName> *r_custom_signals) const {
 
-	for (const Map<StringName, Vector<Argument> >::Element *E = custom_signals.front(); E; E = E->next()) {
+	for (const Map<StringName, Vector<Argument>>::Element *E = custom_signals.front(); E; E = E->next()) {
 		r_custom_signals->push_back(E->key());
 	}
 
@@ -981,7 +981,7 @@ bool VisualScript::has_script_signal(const StringName &p_signal) const {
 
 void VisualScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
 
-	for (const Map<StringName, Vector<Argument> >::Element *E = custom_signals.front(); E; E = E->next()) {
+	for (const Map<StringName, Vector<Argument>>::Element *E = custom_signals.front(); E; E = E->next()) {
 
 		MethodInfo mi;
 		mi.name = E->key();
@@ -1302,7 +1302,7 @@ Dictionary VisualScript::_get_data() const {
 	d["variables"] = vars;
 
 	Array sigs;
-	for (const Map<StringName, Vector<Argument> >::Element *E = custom_signals.front(); E; E = E->next()) {
+	for (const Map<StringName, Vector<Argument>>::Element *E = custom_signals.front(); E; E = E->next()) {
 
 		Dictionary cs;
 		cs["name"] = E->key();
@@ -2779,7 +2779,7 @@ void VisualScriptLanguage::get_recognized_extensions(List<String> *p_extensions)
 }
 void VisualScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const {
 }
-void VisualScriptLanguage::get_public_constants(List<Pair<String, Variant> > *p_constants) const {
+void VisualScriptLanguage::get_public_constants(List<Pair<String, Variant>> *p_constants) const {
 }
 
 void VisualScriptLanguage::profiling_start() {

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -246,7 +246,7 @@ private:
 
 	Map<StringName, Function> functions;
 	Map<StringName, Variable> variables;
-	Map<StringName, Vector<Argument> > custom_signals;
+	Map<StringName, Vector<Argument>> custom_signals;
 	Vector<ScriptNetData> rpc_functions;
 	Vector<ScriptNetData> rpc_variables;
 
@@ -623,7 +623,7 @@ public:
 
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const;
-	virtual void get_public_constants(List<Pair<String, Variant> > *p_constants) const;
+	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const;
 
 	virtual void profiling_start();
 	virtual void profiling_stop();

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -1458,7 +1458,7 @@ void VisualScriptEditor::_remove_output_port(int p_id, int p_port) {
 	List<VisualScript::DataConnection> data_connections;
 	script->get_data_connection_list(func, &data_connections);
 
-	HashMap<int, Set<int> > conn_map;
+	HashMap<int, Set<int>> conn_map;
 	for (const List<VisualScript::DataConnection>::Element *E = data_connections.front(); E; E = E->next()) {
 		if (E->get().from_node == p_id && E->get().from_port == p_port) {
 			// push into the connections map
@@ -3078,8 +3078,8 @@ void VisualScriptEditor::_graph_disconnected(const String &p_from, int p_from_sl
 void VisualScriptEditor::_move_nodes_with_rescan(const StringName &p_func_from, const StringName &p_func_to, int p_id) {
 
 	Set<int> nodes_to_move;
-	HashMap<int, Map<int, int> > seqconns_to_move; // from => List(outp, to)
-	HashMap<int, Map<int, Pair<int, int> > > dataconns_to_move; // to => List(inp_p => from, outp)
+	HashMap<int, Map<int, int>> seqconns_to_move; // from => List(outp, to)
+	HashMap<int, Map<int, Pair<int, int>>> dataconns_to_move; // to => List(inp_p => from, outp)
 
 	nodes_to_move.insert(p_id);
 	Set<int> sequence_connections;
@@ -3087,7 +3087,7 @@ void VisualScriptEditor::_move_nodes_with_rescan(const StringName &p_func_from, 
 		List<VisualScript::SequenceConnection> sequence_conns;
 		script->get_sequence_connection_list(p_func_from, &sequence_conns);
 
-		HashMap<int, Map<int, int> > seqcons; // from => List(out_p => to)
+		HashMap<int, Map<int, int>> seqcons; // from => List(out_p => to)
 
 		for (List<VisualScript::SequenceConnection>::Element *E = sequence_conns.front(); E; E = E->next()) {
 			int from = E->get().from_node;
@@ -3102,7 +3102,7 @@ void VisualScriptEditor::_move_nodes_with_rescan(const StringName &p_func_from, 
 
 		int conn = p_id;
 		List<int> stack;
-		HashMap<int, Set<int> > seen; // from, outp
+		HashMap<int, Set<int>> seen; // from, outp
 		while (seqcons.has(conn)) {
 			for (auto E = seqcons[conn].front(); E; E = E->next()) {
 				if (seen.has(conn) && seen[conn].has(E->key())) {
@@ -3139,7 +3139,7 @@ void VisualScriptEditor::_move_nodes_with_rescan(const StringName &p_func_from, 
 		List<VisualScript::DataConnection> data_connections;
 		script->get_data_connection_list(p_func_from, &data_connections);
 
-		HashMap<int, Map<int, Pair<int, int> > > connections;
+		HashMap<int, Map<int, Pair<int, int>>> connections;
 
 		for (List<VisualScript::DataConnection>::Element *E = data_connections.front(); E; E = E->next()) {
 			int from = E->get().from_node;
@@ -3148,14 +3148,14 @@ void VisualScriptEditor::_move_nodes_with_rescan(const StringName &p_func_from, 
 			int in_p = E->get().to_port;
 
 			if (!connections.has(to))
-				connections.set(to, Map<int, Pair<int, int> >());
+				connections.set(to, Map<int, Pair<int, int>>());
 			connections[to].insert(in_p, Pair<int, int>(from, out_p));
 		}
 
 		// go through the HashMap and do all sorts of crazy ass stuff now...
 		Set<int> nodes_to_be_added;
 		for (Set<int>::Element *F = nodes_to_move.front(); F; F = F->next()) {
-			HashMap<int, Set<int> > seen;
+			HashMap<int, Set<int>> seen;
 			List<int> stack;
 			int id = F->get();
 			while (connections.has(id)) {
@@ -3190,7 +3190,7 @@ void VisualScriptEditor::_move_nodes_with_rescan(const StringName &p_func_from, 
 					seen[id].insert(E->key());
 					stack.push_back(id);
 					if (!dataconns_to_move.has(id))
-						dataconns_to_move.set(id, Map<int, Pair<int, int> >());
+						dataconns_to_move.set(id, Map<int, Pair<int, int>>());
 					dataconns_to_move[id].insert(E->key(), Pair<int, int>(E->get().first, E->get().second));
 					id = E->get().first;
 					nodes_to_be_added.insert(id);
@@ -3261,7 +3261,7 @@ void VisualScriptEditor::_move_nodes_with_rescan(const StringName &p_func_from, 
 	dataconns_to_move.get_key_list(&keys);
 	for (List<int>::Element *E = keys.front(); E; E = E->next()) {
 		int to_node = E->get(); // to_node
-		for (Map<int, Pair<int, int> >::Element *F = dataconns_to_move[E->get()].front(); F; F = F->next()) {
+		for (Map<int, Pair<int, int>>::Element *F = dataconns_to_move[E->get()].front(); F; F = F->next()) {
 			int inp_p = F->key();
 			Pair<int, int> fro = F->get();
 
@@ -3933,7 +3933,7 @@ void VisualScriptEditor::_notification(int p_what) {
 
 			bool dark_theme = tm->get_constant("dark_theme", "Editor");
 
-			List<Pair<String, Color> > colors;
+			List<Pair<String, Color>> colors;
 			if (dark_theme) {
 				colors.push_back(Pair<String, Color>("flow_control", Color(0.96, 0.96, 0.96)));
 				colors.push_back(Pair<String, Color>("functions", Color(0.96, 0.52, 0.51)));
@@ -3950,7 +3950,7 @@ void VisualScriptEditor::_notification(int p_what) {
 				colors.push_back(Pair<String, Color>("constants", Color(0.94, 0.18, 0.49)));
 			}
 
-			for (List<Pair<String, Color> >::Element *E = colors.front(); E; E = E->next()) {
+			for (List<Pair<String, Color>>::Element *E = colors.front(); E; E = E->next()) {
 				Ref<StyleBoxFlat> sb = tm->get_stylebox("frame", "GraphNode");
 				if (!sb.is_null()) {
 					Ref<StyleBoxFlat> frame_style = sb->duplicate();
@@ -4149,7 +4149,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 				}
 			}
 
-			for (Map<int, Ref<VisualScriptNode> >::Element *E = clipboard->nodes.front(); E; E = E->next()) {
+			for (Map<int, Ref<VisualScriptNode>>::Element *E = clipboard->nodes.front(); E; E = E->next()) {
 
 				Ref<VisualScriptNode> node = E->get()->duplicate();
 
@@ -4196,7 +4196,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 		case EDIT_CREATE_FUNCTION: {
 
 			StringName function = "";
-			Map<int, Ref<VisualScriptNode> > nodes;
+			Map<int, Ref<VisualScriptNode>> nodes;
 			Set<int> selections;
 			for (int i = 0; i < graph->get_child_count(); i++) {
 				GraphNode *gn = Object::cast_to<GraphNode>(graph->get_child(i));
@@ -4252,7 +4252,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 					// the user wants to connect the nodes
 					int top_nd = -1;
 					Vector2 top;
-					for (Map<int, Ref<VisualScriptNode> >::Element *E = nodes.front(); E; E = E->next()) {
+					for (Map<int, Ref<VisualScriptNode>>::Element *E = nodes.front(); E; E = E->next()) {
 						Ref<VisualScriptNode> nd = script->get_node(function, E->key());
 						if (nd.is_valid() && nd->has_input_sequence_port()) {
 							if (top_nd < 0) {
@@ -4316,7 +4316,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 			}
 
 			List<Variant::Type> inputs; // input types
-			List<Pair<int, int> > input_connections;
+			List<Pair<int, int>> input_connections;
 			{
 				List<VisualScript::DataConnection> dats;
 				script->get_data_connection_list(function, &dats);
@@ -4359,7 +4359,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 
 			// Move the nodes
 
-			for (Map<int, Ref<VisualScriptNode> >::Element *E = nodes.front(); E; E = E->next()) {
+			for (Map<int, Ref<VisualScriptNode>>::Element *E = nodes.front(); E; E = E->next()) {
 				undo_redo->add_do_method(script.ptr(), "remove_node", function, E->key());
 				undo_redo->add_do_method(script.ptr(), "add_node", new_fn, E->key(), E->get(), script->get_node_position(function, E->key()));
 
@@ -4414,7 +4414,7 @@ void VisualScriptEditor::_menu_option(int p_what) {
 
 			// * might make the system more intelligent by checking port from info.
 			int i = 0;
-			List<Pair<int, int> >::Element *F = input_connections.front();
+			List<Pair<int, int>>::Element *F = input_connections.front();
 			for (List<Variant::Type>::Element *E = inputs.front(); E && F; E = E->next(), F = F->next()) {
 				func_node->add_argument(E->get(), "arg_" + String::num_int64(i), i);
 				undo_redo->add_do_method(script.ptr(), "data_connect", new_fn, fn_id, i, F->get().first, F->get().second);

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -133,10 +133,10 @@ class VisualScriptEditor : public ScriptEditorBase {
 		String name;
 		Variant::Type ret;
 		bool ret_variant;
-		Vector<Pair<Variant::Type, String> > args;
+		Vector<Pair<Variant::Type, String>> args;
 	};
 
-	HashMap<StringName, Ref<StyleBox> > node_styles;
+	HashMap<StringName, Ref<StyleBox>> node_styles;
 	StringName edited_func;
 	StringName default_func;
 
@@ -153,7 +153,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	struct Clipboard {
 
-		Map<int, Ref<VisualScriptNode> > nodes;
+		Map<int, Ref<VisualScriptNode>> nodes;
 		Map<int, Vector2> nodes_positions;
 
 		Set<VisualScript::SequenceConnection> sequence_connections;

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -3519,7 +3519,7 @@ VisualScriptConstructor::VisualScriptConstructor() {
 	type = Variant::NIL;
 }
 
-static Map<String, Pair<Variant::Type, MethodInfo> > constructor_map;
+static Map<String, Pair<Variant::Type, MethodInfo>> constructor_map;
 
 static Ref<VisualScriptNode> create_constructor_node(const String &p_name) {
 

--- a/modules/webrtc/webrtc_multiplayer.cpp
+++ b/modules/webrtc/webrtc_multiplayer.cpp
@@ -70,7 +70,7 @@ void WebRTCMultiplayer::poll() {
 
 	List<int> remove;
 	List<int> add;
-	for (Map<int, Ref<ConnectedPeer> >::Element *E = peer_map.front(); E; E = E->next()) {
+	for (Map<int, Ref<ConnectedPeer>>::Element *E = peer_map.front(); E; E = E->next()) {
 		Ref<ConnectedPeer> peer = E->get();
 		peer->connection->poll();
 		// Check peer state
@@ -89,7 +89,7 @@ void WebRTCMultiplayer::poll() {
 		}
 		// Check channels state
 		int ready = 0;
-		for (List<Ref<WebRTCDataChannel> >::Element *C = peer->channels.front(); C && C->get().is_valid(); C = C->next()) {
+		for (List<Ref<WebRTCDataChannel>>::Element *C = peer->channels.front(); C && C->get().is_valid(); C = C->next()) {
 			Ref<WebRTCDataChannel> ch = C->get();
 			switch (ch->get_ready_state()) {
 				case WebRTCDataChannel::STATE_CONNECTING:
@@ -130,7 +130,7 @@ void WebRTCMultiplayer::poll() {
 			emit_signal("peer_connected", TARGET_PEER_SERVER);
 			emit_signal("connection_succeeded");
 			// Notify of all previously connected peers
-			for (Map<int, Ref<ConnectedPeer> >::Element *F = peer_map.front(); F; F = F->next()) {
+			for (Map<int, Ref<ConnectedPeer>>::Element *F = peer_map.front(); F; F = F->next()) {
 				if (F->key() != 1 && F->get()->connected)
 					emit_signal("peer_connected", F->key());
 			}
@@ -143,11 +143,11 @@ void WebRTCMultiplayer::poll() {
 }
 
 void WebRTCMultiplayer::_find_next_peer() {
-	Map<int, Ref<ConnectedPeer> >::Element *E = peer_map.find(next_packet_peer);
+	Map<int, Ref<ConnectedPeer>>::Element *E = peer_map.find(next_packet_peer);
 	if (E) E = E->next();
 	// After last.
 	while (E) {
-		for (List<Ref<WebRTCDataChannel> >::Element *F = E->get()->channels.front(); F; F = F->next()) {
+		for (List<Ref<WebRTCDataChannel>>::Element *F = E->get()->channels.front(); F; F = F->next()) {
 			if (F->get()->get_available_packet_count()) {
 				next_packet_peer = E->key();
 				return;
@@ -158,7 +158,7 @@ void WebRTCMultiplayer::_find_next_peer() {
 	E = peer_map.front();
 	// Before last
 	while (E) {
-		for (List<Ref<WebRTCDataChannel> >::Element *F = E->get()->channels.front(); F; F = F->next()) {
+		for (List<Ref<WebRTCDataChannel>>::Element *F = E->get()->channels.front(); F; F = F->next()) {
 			if (F->get()->get_available_packet_count()) {
 				next_packet_peer = E->key();
 				return;
@@ -204,7 +204,7 @@ int WebRTCMultiplayer::get_unique_id() const {
 
 void WebRTCMultiplayer::_peer_to_dict(Ref<ConnectedPeer> p_connected_peer, Dictionary &r_dict) {
 	Array channels;
-	for (List<Ref<WebRTCDataChannel> >::Element *F = p_connected_peer->channels.front(); F; F = F->next()) {
+	for (List<Ref<WebRTCDataChannel>>::Element *F = p_connected_peer->channels.front(); F; F = F->next()) {
 		channels.push_back(F->get());
 	}
 	r_dict["connection"] = p_connected_peer->connection;
@@ -225,7 +225,7 @@ Dictionary WebRTCMultiplayer::get_peer(int p_peer_id) {
 
 Dictionary WebRTCMultiplayer::get_peers() {
 	Dictionary out;
-	for (Map<int, Ref<ConnectedPeer> >::Element *E = peer_map.front(); E; E = E->next()) {
+	for (Map<int, Ref<ConnectedPeer>>::Element *E = peer_map.front(); E; E = E->next()) {
 		Dictionary d;
 		_peer_to_dict(E->get(), d);
 		out[E->key()] = d;
@@ -288,7 +288,7 @@ Error WebRTCMultiplayer::get_packet(const uint8_t **r_buffer, int &r_buffer_size
 		_find_next_peer();
 		ERR_FAIL_V(ERR_UNAVAILABLE);
 	}
-	for (List<Ref<WebRTCDataChannel> >::Element *E = peer_map[next_packet_peer]->channels.front(); E; E = E->next()) {
+	for (List<Ref<WebRTCDataChannel>>::Element *E = peer_map[next_packet_peer]->channels.front(); E; E = E->next()) {
 		if (E->get()->get_available_packet_count()) {
 			Error err = E->get()->get_packet(r_buffer, r_buffer_size);
 			_find_next_peer();
@@ -316,7 +316,7 @@ Error WebRTCMultiplayer::put_packet(const uint8_t *p_buffer, int p_buffer_size) 
 			break;
 	}
 
-	Map<int, Ref<ConnectedPeer> >::Element *E = NULL;
+	Map<int, Ref<ConnectedPeer>>::Element *E = NULL;
 
 	if (target_peer > 0) {
 
@@ -330,7 +330,7 @@ Error WebRTCMultiplayer::put_packet(const uint8_t *p_buffer, int p_buffer_size) 
 	} else {
 		int exclude = -target_peer;
 
-		for (Map<int, Ref<ConnectedPeer> >::Element *F = peer_map.front(); F; F = F->next()) {
+		for (Map<int, Ref<ConnectedPeer>>::Element *F = peer_map.front(); F; F = F->next()) {
 
 			// Exclude packet. If target_peer == 0 then don't exclude any packets
 			if (target_peer != 0 && F->key() == exclude)
@@ -347,8 +347,8 @@ int WebRTCMultiplayer::get_available_packet_count() const {
 	if (next_packet_peer == 0)
 		return 0; // To be sure next call to get_packet works if size > 0 .
 	int size = 0;
-	for (Map<int, Ref<ConnectedPeer> >::Element *E = peer_map.front(); E; E = E->next()) {
-		for (List<Ref<WebRTCDataChannel> >::Element *F = E->get()->channels.front(); F; F = F->next()) {
+	for (Map<int, Ref<ConnectedPeer>>::Element *E = peer_map.front(); E; E = E->next()) {
+		for (List<Ref<WebRTCDataChannel>>::Element *F = E->get()->channels.front(); F; F = F->next()) {
 			size += F->get()->get_available_packet_count();
 		}
 	}

--- a/modules/webrtc/webrtc_multiplayer.h
+++ b/modules/webrtc/webrtc_multiplayer.h
@@ -53,7 +53,7 @@ private:
 
 	public:
 		Ref<WebRTCPeerConnection> connection;
-		List<Ref<WebRTCDataChannel> > channels;
+		List<Ref<WebRTCDataChannel>> channels;
 		bool connected;
 
 		ConnectedPeer() {
@@ -72,7 +72,7 @@ private:
 	int next_packet_peer;
 	bool server_compat;
 
-	Map<int, Ref<ConnectedPeer> > peer_map;
+	Map<int, Ref<ConnectedPeer>> peer_map;
 
 	void _peer_to_dict(Ref<ConnectedPeer> p_connected_peer, Dictionary &r_dict);
 	void _find_next_peer();

--- a/modules/websocket/emws_client.cpp
+++ b/modules/websocket/emws_client.cpp
@@ -181,7 +181,7 @@ Error EMWSClient::connect_to_host(String p_host, String p_path, uint16_t p_port,
 	if (peer_sock == -1)
 		return FAILED;
 
-	static_cast<Ref<EMWSPeer> >(_peer)->set_sock(peer_sock, _in_buf_size, _in_pkt_size);
+	static_cast<Ref<EMWSPeer>>(_peer)->set_sock(peer_sock, _in_buf_size, _in_pkt_size);
 
 	return OK;
 };

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -209,7 +209,7 @@ void WebSocketMultiplayerPeer::_send_add(int32_t p_peer_id) {
 	// Then send the server peer (which will trigger connection_succeded in client)
 	_send_sys(get_peer(p_peer_id), SYS_ADD, 1);
 
-	for (Map<int, Ref<WebSocketPeer> >::Element *E = _peer_map.front(); E; E = E->next()) {
+	for (Map<int, Ref<WebSocketPeer>>::Element *E = _peer_map.front(); E; E = E->next()) {
 		int32_t id = E->key();
 		if (p_peer_id == id)
 			continue; // Skip the newwly added peer (already confirmed)
@@ -222,7 +222,7 @@ void WebSocketMultiplayerPeer::_send_add(int32_t p_peer_id) {
 }
 
 void WebSocketMultiplayerPeer::_send_del(int32_t p_peer_id) {
-	for (Map<int, Ref<WebSocketPeer> >::Element *E = _peer_map.front(); E; E = E->next()) {
+	for (Map<int, Ref<WebSocketPeer>>::Element *E = _peer_map.front(); E; E = E->next()) {
 		int32_t id = E->key();
 		if (p_peer_id != id)
 			_send_sys(get_peer(id), SYS_DEL, p_peer_id);
@@ -247,7 +247,7 @@ Error WebSocketMultiplayerPeer::_server_relay(int32_t p_from, int32_t p_to, cons
 
 	} else if (p_to == 0) {
 
-		for (Map<int, Ref<WebSocketPeer> >::Element *E = _peer_map.front(); E; E = E->next()) {
+		for (Map<int, Ref<WebSocketPeer>>::Element *E = _peer_map.front(); E; E = E->next()) {
 			if (E->key() != p_from)
 				E->get()->put_packet(p_buffer, p_buffer_size);
 		}
@@ -255,7 +255,7 @@ Error WebSocketMultiplayerPeer::_server_relay(int32_t p_from, int32_t p_to, cons
 
 	} else if (p_to < 0) {
 
-		for (Map<int, Ref<WebSocketPeer> >::Element *E = _peer_map.front(); E; E = E->next()) {
+		for (Map<int, Ref<WebSocketPeer>>::Element *E = _peer_map.front(); E; E = E->next()) {
 			if (E->key() != p_from && E->key() != -p_to)
 				E->get()->put_packet(p_buffer, p_buffer_size);
 		}

--- a/modules/websocket/websocket_multiplayer_peer.h
+++ b/modules/websocket/websocket_multiplayer_peer.h
@@ -63,7 +63,7 @@ protected:
 	};
 
 	List<Packet> _incoming_packets;
-	Map<int, Ref<WebSocketPeer> > _peer_map;
+	Map<int, Ref<WebSocketPeer>> _peer_map;
 	Packet _current_packet;
 
 	bool _is_multiplayer;

--- a/modules/websocket/wsl_client.cpp
+++ b/modules/websocket/wsl_client.cpp
@@ -253,7 +253,7 @@ void WSLClient::poll() {
 					}
 					_connection = ssl;
 				} else {
-					ssl = static_cast<Ref<StreamPeerSSL> >(_connection);
+					ssl = static_cast<Ref<StreamPeerSSL>>(_connection);
 					ERR_FAIL_COND(ssl.is_null()); // Bug?
 					ssl->poll();
 				}

--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -103,7 +103,7 @@ Error WSLServer::PendingPeer::do_handshake(const Vector<String> p_protocols) {
 	if (OS::get_singleton()->get_ticks_msec() - time > WSL_SERVER_TIMEOUT)
 		return ERR_TIMEOUT;
 	if (use_ssl) {
-		Ref<StreamPeerSSL> ssl = static_cast<Ref<StreamPeerSSL> >(connection);
+		Ref<StreamPeerSSL> ssl = static_cast<Ref<StreamPeerSSL>>(connection);
 		if (ssl.is_null())
 			return FAILED;
 		ssl->poll();
@@ -171,7 +171,7 @@ Error WSLServer::listen(int p_port, const Vector<String> p_protocols, bool gd_mp
 void WSLServer::poll() {
 
 	List<int> remove_ids;
-	for (Map<int, Ref<WebSocketPeer> >::Element *E = _peer_map.front(); E; E = E->next()) {
+	for (Map<int, Ref<WebSocketPeer>>::Element *E = _peer_map.front(); E; E = E->next()) {
 		Ref<WSLPeer> peer = (WSLPeer *)E->get().ptr();
 		peer->poll();
 		if (!peer->is_connected_to_host()) {
@@ -184,8 +184,8 @@ void WSLServer::poll() {
 	}
 	remove_ids.clear();
 
-	List<Ref<PendingPeer> > remove_peers;
-	for (List<Ref<PendingPeer> >::Element *E = _pending.front(); E; E = E->next()) {
+	List<Ref<PendingPeer>> remove_peers;
+	for (List<Ref<PendingPeer>>::Element *E = _pending.front(); E; E = E->next()) {
 		Ref<PendingPeer> ppeer = E->get();
 		Error err = ppeer->do_handshake(_protocols);
 		if (err == ERR_BUSY) {
@@ -212,7 +212,7 @@ void WSLServer::poll() {
 		remove_peers.push_back(ppeer);
 		_on_connect(id, ppeer->protocol);
 	}
-	for (List<Ref<PendingPeer> >::Element *E = remove_peers.front(); E; E = E->next()) {
+	for (List<Ref<PendingPeer>>::Element *E = remove_peers.front(); E; E = E->next()) {
 		_pending.erase(E->get());
 	}
 	remove_peers.clear();
@@ -251,7 +251,7 @@ int WSLServer::get_max_packet_size() const {
 
 void WSLServer::stop() {
 	_server->stop();
-	for (Map<int, Ref<WebSocketPeer> >::Element *E = _peer_map.front(); E; E = E->next()) {
+	for (Map<int, Ref<WebSocketPeer>>::Element *E = _peer_map.front(); E; E = E->next()) {
 		Ref<WSLPeer> peer = (WSLPeer *)E->get().ptr();
 		peer->close_now();
 	}

--- a/modules/websocket/wsl_server.h
+++ b/modules/websocket/wsl_server.h
@@ -76,7 +76,7 @@ private:
 	int _out_buf_size;
 	int _out_pkt_size;
 
-	List<Ref<PendingPeer> > _pending;
+	List<Ref<PendingPeer>> _pending;
 	Ref<TCP_Server> _server;
 	Vector<String> _protocols;
 

--- a/platform/android/api/java_class_wrapper.h
+++ b/platform/android/api/java_class_wrapper.h
@@ -163,7 +163,7 @@ class JavaClass : public Reference {
 	bool _call_method(JavaObject *p_instance, const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error, Variant &ret);
 
 	friend class JavaClassWrapper;
-	Map<StringName, List<MethodInfo> > methods;
+	Map<StringName, List<MethodInfo>> methods;
 	jclass _class;
 #endif
 
@@ -198,7 +198,7 @@ class JavaClassWrapper : public Object {
 	GDCLASS(JavaClassWrapper, Object);
 
 #ifdef ANDROID_ENABLED
-	Map<String, Ref<JavaClass> > class_cache;
+	Map<String, Ref<JavaClass>> class_cache;
 	friend class JavaClass;
 	jclass activityClass;
 	jmethodID findClass;

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -34,7 +34,7 @@
 
 bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error, Variant &ret) {
 
-	Map<StringName, List<MethodInfo> >::Element *M = methods.find(p_method);
+	Map<StringName, List<MethodInfo>>::Element *M = methods.find(p_method);
 	if (!M)
 		return false;
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -91,7 +91,7 @@ void OS_Android::initialize_core() {
 		FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_RESOURCES);
 	else {
 #ifdef USE_JAVA_FILE_ACCESS
-		FileAccess::make_default<FileAccessBufferedFA<FileAccessJAndroid> >(FileAccess::ACCESS_RESOURCES);
+		FileAccess::make_default<FileAccessBufferedFA<FileAccessJAndroid>>(FileAccess::ACCESS_RESOURCES);
 #else
 		//FileAccess::make_default<FileAccessBufferedFA<FileAccessAndroid> >(FileAccess::ACCESS_RESOURCES);
 		FileAccess::make_default<FileAccessAndroid>(FileAccess::ACCESS_RESOURCES);

--- a/platform/iphone/app_delegate.h
+++ b/platform/iphone/app_delegate.h
@@ -36,9 +36,11 @@
 
 #import <CoreMotion/CoreMotion.h>
 
-#if defined(OPENGL_ENABLED)
-@interface AppDelegate : NSObject <UIApplicationDelegate, GLViewDelegate> {
-#endif
+// FIXME: Add support for both GLES2 and Vulkan when GLES2 is implemented again,
+// so it can't be done with compilation time branching.
+//#if defined(OPENGL_ENABLED)
+//@interface AppDelegate : NSObject <UIApplicationDelegate, GLViewDelegate> {
+//#endif
 #if defined(VULKAN_ENABLED)
 @interface AppDelegate : NSObject <UIApplicationDelegate> {
 #endif

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -648,7 +648,6 @@ static int frame_count = 0;
 	view_controller = [[ViewController alloc] init];
 	view_controller.view = glView;
 
-
 	_set_keep_screen_on(bool(GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true)) ? YES : NO);
 	glView.useCADisplayLink =
 			bool(GLOBAL_DEF("display.iOS/use_cadisplaylink", true)) ? YES : NO;

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -410,7 +410,7 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 }
 
 String EditorExportPlatformIOS::_get_additional_plist_content() {
-	Vector<Ref<EditorExportPlugin> > export_plugins = EditorExport::get_singleton()->get_export_plugins();
+	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	String result;
 	for (int i = 0; i < export_plugins.size(); ++i) {
 		result += export_plugins[i]->get_ios_plist_content();
@@ -419,7 +419,7 @@ String EditorExportPlatformIOS::_get_additional_plist_content() {
 }
 
 String EditorExportPlatformIOS::_get_linker_flags() {
-	Vector<Ref<EditorExportPlugin> > export_plugins = EditorExport::get_singleton()->get_export_plugins();
+	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	String result;
 	for (int i = 0; i < export_plugins.size(); ++i) {
 		String flags = export_plugins[i]->get_ios_linker_flags();
@@ -434,7 +434,7 @@ String EditorExportPlatformIOS::_get_linker_flags() {
 }
 
 String EditorExportPlatformIOS::_get_cpp_code() {
-	Vector<Ref<EditorExportPlugin> > export_plugins = EditorExport::get_singleton()->get_export_plugins();
+	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	String result;
 	for (int i = 0; i < export_plugins.size(); ++i) {
 		result += export_plugins[i]->get_ios_cpp_code();
@@ -776,7 +776,7 @@ struct ExportLibsData {
 };
 
 void EditorExportPlatformIOS::_add_assets_to_project(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &p_project_data, const Vector<IOSExportAsset> &p_additional_assets) {
-	Vector<Ref<EditorExportPlugin> > export_plugins = EditorExport::get_singleton()->get_export_plugins();
+	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	Vector<String> frameworks;
 	for (int i = 0; i < export_plugins.size(); ++i) {
 		Vector<String> plugin_frameworks = export_plugins[i]->get_ios_frameworks();
@@ -920,7 +920,7 @@ Error EditorExportPlatformIOS::_export_additional_assets(const String &p_out_dir
 }
 
 Error EditorExportPlatformIOS::_export_additional_assets(const String &p_out_dir, const Vector<SharedObject> &p_libraries, Vector<IOSExportAsset> &r_exported_assets) {
-	Vector<Ref<EditorExportPlugin> > export_plugins = EditorExport::get_singleton()->get_export_plugins();
+	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	for (int i = 0; i < export_plugins.size(); i++) {
 		Vector<String> frameworks = export_plugins[i]->get_ios_frameworks();
 		Error err = _export_additional_assets(p_out_dir, frameworks, true, r_exported_assets);

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -470,7 +470,7 @@ void OS_JavaScript::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_s
 
 	if (p_cursor.is_valid()) {
 
-		Map<CursorShape, Vector<Variant> >::Element *cursor_c = cursors_cache.find(p_shape);
+		Map<CursorShape, Vector<Variant>>::Element *cursor_c = cursors_cache.find(p_shape);
 
 		if (cursor_c) {
 			if (cursor_c->get()[0] == p_cursor && cursor_c->get()[1] == p_hotspot) {
@@ -887,7 +887,7 @@ int OS_JavaScript::get_current_video_driver() const {
 void OS_JavaScript::initialize_core() {
 
 	OS_Unix::initialize_core();
-	FileAccess::make_default<FileAccessBufferedFA<FileAccessUnix> >(FileAccess::ACCESS_RESOURCES);
+	FileAccess::make_default<FileAccessBufferedFA<FileAccessUnix>>(FileAccess::ACCESS_RESOURCES);
 }
 
 Error OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, int p_audio_driver) {

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -52,7 +52,7 @@ class OS_JavaScript : public OS_Unix {
 	Ref<InputEventKey> deferred_key_event;
 	CursorShape cursor_shape;
 	String cursors[CURSOR_MAX];
-	Map<CursorShape, Vector<Variant> > cursors_cache;
+	Map<CursorShape, Vector<Variant>> cursors_cache;
 	Point2 touches[32];
 
 	Point2i last_click_pos;

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -124,7 +124,7 @@ public:
 
 	CursorShape cursor_shape;
 	NSCursor *cursors[CURSOR_MAX];
-	Map<CursorShape, Vector<Variant> > cursors_cache;
+	Map<CursorShape, Vector<Variant>> cursors_cache;
 	MouseMode mouse_mode;
 
 	String title;
@@ -180,7 +180,7 @@ public:
 		}
 	};
 
-	Map<String, Vector<GlobalMenuItem> > global_menus;
+	Map<String, Vector<GlobalMenuItem>> global_menus;
 
 	void _update_global_menu();
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1365,7 +1365,7 @@ void OS_OSX::_update_global_menu() {
 	for (int i = 1; i < [main_menu numberOfItems]; i++) {
 		[main_menu removeItemAtIndex:i];
 	}
-	for (Map<String, Vector<GlobalMenuItem> >::Element *E = global_menus.front(); E; E = E->next()) {
+	for (Map<String, Vector<GlobalMenuItem>>::Element *E = global_menus.front(); E; E = E->next()) {
 		if (E->key() != "_dock") {
 			NSMenu *menu = [[[NSMenu alloc] initWithTitle:[NSString stringWithUTF8String:E->key().utf8().get_data()]] autorelease];
 			for (int i = 0; i < E->get().size(); i++) {
@@ -1835,7 +1835,7 @@ void OS_OSX::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 
 	if (p_cursor.is_valid()) {
 
-		Map<CursorShape, Vector<Variant> >::Element *cursor_c = cursors_cache.find(p_shape);
+		Map<CursorShape, Vector<Variant>>::Element *cursor_c = cursors_cache.find(p_shape);
 
 		if (cursor_c) {
 			if (cursor_c->get()[0] == p_cursor && cursor_c->get()[1] == p_hotspot) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2518,7 +2518,7 @@ void OS_Windows::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shap
 
 	if (p_cursor.is_valid()) {
 
-		Map<CursorShape, Vector<Variant> >::Element *cursor_c = cursors_cache.find(p_shape);
+		Map<CursorShape, Vector<Variant>>::Element *cursor_c = cursors_cache.find(p_shape);
 
 		if (cursor_c) {
 			if (cursor_c->get()[0] == p_cursor && cursor_c->get()[1] == p_hotspot) {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -232,7 +232,7 @@ class OS_Windows : public OS {
 
 	HCURSOR cursors[CURSOR_MAX] = { NULL };
 	CursorShape cursor_shape;
-	Map<CursorShape, Vector<Variant> > cursors_cache;
+	Map<CursorShape, Vector<Variant>> cursors_cache;
 
 	InputDefault *input;
 	JoypadWindows *joypad;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -3034,7 +3034,7 @@ void OS_X11::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, c
 
 	if (p_cursor.is_valid()) {
 
-		Map<CursorShape, Vector<Variant> >::Element *cursor_c = cursors_cache.find(p_shape);
+		Map<CursorShape, Vector<Variant>>::Element *cursor_c = cursors_cache.find(p_shape);
 
 		if (cursor_c) {
 			if (cursor_c->get()[0] == p_cursor && cursor_c->get()[1] == p_hotspot) {

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -179,7 +179,7 @@ class OS_X11 : public OS_Unix {
 	Cursor cursors[CURSOR_MAX];
 	Cursor null_cursor;
 	CursorShape current_cursor;
-	Map<CursorShape, Vector<Variant> > cursors_cache;
+	Map<CursorShape, Vector<Variant>> cursors_cache;
 
 	InputDefault *input;
 

--- a/scene/2d/animated_sprite.h
+++ b/scene/2d/animated_sprite.h
@@ -42,7 +42,7 @@ class SpriteFrames : public Resource {
 
 		float speed;
 		bool loop;
-		Vector<Ref<Texture2D> > frames;
+		Vector<Ref<Texture2D>> frames;
 
 		Anim() {
 			loop = true;

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -50,7 +50,7 @@ void CollisionPolygon2D::_build_polygon() {
 
 		//here comes the sun, lalalala
 		//decompose concave into multiple convex polygons and add them
-		Vector<Vector<Vector2> > decomp = _decompose_in_convex();
+		Vector<Vector<Vector2>> decomp = _decompose_in_convex();
 		for (int i = 0; i < decomp.size(); i++) {
 			Ref<ConvexPolygonShape2D> convex = memnew(ConvexPolygonShape2D);
 			convex->set_points(decomp[i]);
@@ -76,8 +76,8 @@ void CollisionPolygon2D::_build_polygon() {
 	}
 }
 
-Vector<Vector<Vector2> > CollisionPolygon2D::_decompose_in_convex() {
-	Vector<Vector<Vector2> > decomp = Geometry::decompose_polygon_in_convex(polygon);
+Vector<Vector<Vector2>> CollisionPolygon2D::_decompose_in_convex() {
+	Vector<Vector<Vector2>> decomp = Geometry::decompose_polygon_in_convex(polygon);
 	return decomp;
 }
 
@@ -148,7 +148,7 @@ void CollisionPolygon2D::_notification(int p_what) {
 #define DEBUG_DECOMPOSE
 #if defined(TOOLS_ENABLED) && defined(DEBUG_DECOMPOSE)
 
-			Vector<Vector<Vector2> > decomp = _decompose_in_convex();
+			Vector<Vector<Vector2>> decomp = _decompose_in_convex();
 
 			Color c(0.4, 0.9, 0.1);
 			for (int i = 0; i < decomp.size(); i++) {

--- a/scene/2d/collision_polygon_2d.h
+++ b/scene/2d/collision_polygon_2d.h
@@ -56,7 +56,7 @@ protected:
 	bool one_way_collision;
 	float one_way_collision_margin;
 
-	Vector<Vector<Vector2> > _decompose_in_convex();
+	Vector<Vector<Vector2>> _decompose_in_convex();
 
 	void _build_polygon();
 

--- a/scene/2d/navigation_polygon.h
+++ b/scene/2d/navigation_polygon.h
@@ -43,7 +43,7 @@ class NavigationPolygon : public Resource {
 		Vector<int> indices;
 	};
 	Vector<Polygon> polygons;
-	Vector<Vector<Vector2> > outlines;
+	Vector<Vector<Vector2>> outlines;
 
 	mutable Rect2 item_rect;
 	mutable bool rect_cache_dirty;

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -300,7 +300,7 @@ private:
 	bool sync_to_physics;
 
 	Vector<Collision> colliders;
-	Vector<Ref<KinematicCollision2D> > slide_colliders;
+	Vector<Ref<KinematicCollision2D>> slide_colliders;
 	Ref<KinematicCollision2D> motion_cache;
 
 	_FORCE_INLINE_ bool _ignores_mode(Physics2DServer::BodyMode) const;

--- a/scene/3d/collision_polygon.cpp
+++ b/scene/3d/collision_polygon.cpp
@@ -44,7 +44,7 @@ void CollisionPolygon::_build_polygon() {
 	if (polygon.size() == 0)
 		return;
 
-	Vector<Vector<Vector2> > decomp = Geometry::decompose_polygon_in_convex(polygon);
+	Vector<Vector<Vector2>> decomp = Geometry::decompose_polygon_in_convex(polygon);
 	if (decomp.size() == 0)
 		return;
 

--- a/scene/3d/gi_probe.h
+++ b/scene/3d/gi_probe.h
@@ -135,7 +135,7 @@ private:
 
 	struct PlotMesh {
 		Ref<Material> override_material;
-		Vector<Ref<Material> > instance_materials;
+		Vector<Ref<Material>> instance_materials;
 		Ref<Mesh> mesh;
 		Transform local_xform;
 	};

--- a/scene/3d/immediate_geometry.h
+++ b/scene/3d/immediate_geometry.h
@@ -41,7 +41,7 @@ class ImmediateGeometry : public GeometryInstance {
 	RID im;
 	//a list of textures drawn need to be kept, to avoid references
 	// in VisualServer from becoming invalid if the texture is no longer used
-	List<Ref<Texture2D> > cached_textures;
+	List<Ref<Texture2D>> cached_textures;
 	bool empty;
 	AABB aabb;
 

--- a/scene/3d/mesh_instance.h
+++ b/scene/3d/mesh_instance.h
@@ -58,7 +58,7 @@ protected:
 	};
 
 	Map<StringName, BlendShapeTrack> blend_shape_tracks;
-	Vector<Ref<Material> > materials;
+	Vector<Ref<Material>> materials;
 
 	void _mesh_changed();
 	void _resolve_skeleton_path();

--- a/scene/3d/particles.h
+++ b/scene/3d/particles.h
@@ -69,7 +69,7 @@ private:
 
 	DrawOrder draw_order;
 
-	Vector<Ref<Mesh> > draw_passes;
+	Vector<Ref<Mesh>> draw_passes;
 
 protected:
 	static void _bind_methods();

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -293,7 +293,7 @@ private:
 	bool on_ceiling;
 	bool on_wall;
 	Vector<Collision> colliders;
-	Vector<Ref<KinematicCollision> > slide_colliders;
+	Vector<Ref<KinematicCollision>> slide_colliders;
 	Ref<KinematicCollision> motion_cache;
 
 	_FORCE_INLINE_ bool _ignores_mode(PhysicsServer::BodyMode) const;

--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -186,7 +186,7 @@ void RayCast::_notification(int p_what) {
 			_update_raycast_state();
 			if (prev_collision_state != collided && get_tree()->is_debugging_collisions_hint()) {
 				if (debug_material.is_valid()) {
-					Ref<StandardMaterial3D> line_material = static_cast<Ref<StandardMaterial3D> >(debug_material);
+					Ref<StandardMaterial3D> line_material = static_cast<Ref<StandardMaterial3D>>(debug_material);
 					line_material->set_albedo(collided ? Color(1.0, 0, 0) : Color(1.0, 0.8, 0.6));
 				}
 			}
@@ -335,7 +335,7 @@ void RayCast::_create_debug_shape() {
 	if (!debug_material.is_valid()) {
 		debug_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
 
-		Ref<StandardMaterial3D> line_material = static_cast<Ref<StandardMaterial3D> >(debug_material);
+		Ref<StandardMaterial3D> line_material = static_cast<Ref<StandardMaterial3D>>(debug_material);
 		line_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 		line_material->set_albedo(Color(1.0, 0.8, 0.6));
 	}

--- a/scene/3d/soft_body.cpp
+++ b/scene/3d/soft_body.cpp
@@ -479,7 +479,7 @@ void SoftBody::become_mesh_owner() {
 	if (!mesh_owner) {
 		mesh_owner = true;
 
-		Vector<Ref<Material> > copy_materials;
+		Vector<Ref<Material>> copy_materials;
 		copy_materials.append_array(materials);
 
 		ERR_FAIL_COND(!mesh->get_surface_count());

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -569,7 +569,7 @@ Voxelizer::MaterialCache Voxelizer::_get_material_cache(Ref<Material> p_material
 	return mc;
 }
 
-void Voxelizer::plot_mesh(const Transform &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material> > &p_materials, const Ref<Material> &p_override_material) {
+void Voxelizer::plot_mesh(const Transform &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material) {
 
 	for (int i = 0; i < p_mesh->get_surface_count(); i++) {
 

--- a/scene/3d/voxelizer.h
+++ b/scene/3d/voxelizer.h
@@ -125,7 +125,7 @@ private:
 
 public:
 	void begin_bake(int p_subdiv, const AABB &p_bounds);
-	void plot_mesh(const Transform &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material> > &p_materials, const Ref<Material> &p_override_material);
+	void plot_mesh(const Transform &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material);
 	void end_bake();
 
 	int get_gi_probe_octree_depth() const;

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -285,7 +285,7 @@ private:
 	void _tree_changed();
 	void _update_properties();
 	List<PropertyInfo> properties;
-	HashMap<StringName, HashMap<StringName, StringName> > property_parent_map;
+	HashMap<StringName, HashMap<StringName, StringName>> property_parent_map;
 	HashMap<StringName, Variant> property_map;
 
 	struct Activity {
@@ -293,7 +293,7 @@ private:
 		float activity;
 	};
 
-	HashMap<StringName, Vector<Activity> > input_activity_map;
+	HashMap<StringName, Vector<Activity>> input_activity_map;
 	HashMap<StringName, Vector<Activity> *> input_activity_map_get;
 
 	void _update_properties_for_node(const String &p_base_path, Ref<AnimationNode> node);

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -230,8 +230,8 @@ void SceneDebugger::remove_from_cache(const String &p_filename, Node *p_node) {
 	if (!debugger)
 		return;
 
-	Map<String, Set<Node *> > &edit_cache = debugger->live_scene_edit_cache;
-	Map<String, Set<Node *> >::Element *E = edit_cache.find(p_filename);
+	Map<String, Set<Node *>> &edit_cache = debugger->live_scene_edit_cache;
+	Map<String, Set<Node *>>::Element *E = edit_cache.find(p_filename);
 	if (E) {
 		E->get().erase(p_node);
 		if (E->get().size() == 0) {
@@ -239,8 +239,8 @@ void SceneDebugger::remove_from_cache(const String &p_filename, Node *p_node) {
 		}
 	}
 
-	Map<Node *, Map<ObjectID, Node *> > &remove_list = debugger->live_edit_remove_list;
-	Map<Node *, Map<ObjectID, Node *> >::Element *F = remove_list.find(p_node);
+	Map<Node *, Map<ObjectID, Node *>> &remove_list = debugger->live_edit_remove_list;
+	Map<Node *, Map<ObjectID, Node *>>::Element *F = remove_list.find(p_node);
 	if (F) {
 		for (Map<ObjectID, Node *>::Element *G = F->get().front(); G; G = G->next()) {
 
@@ -293,8 +293,8 @@ SceneDebuggerObject::SceneDebuggerObject(ObjectID p_id) {
 }
 
 void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInstance *p_instance) {
-	typedef Map<const Script *, Set<StringName> > ScriptMemberMap;
-	typedef Map<const Script *, Map<StringName, Variant> > ScriptConstantsMap;
+	typedef Map<const Script *, Set<StringName>> ScriptMemberMap;
+	typedef Map<const Script *, Map<StringName, Variant>> ScriptConstantsMap;
 
 	ScriptMemberMap members;
 	if (p_instance) {
@@ -519,7 +519,7 @@ void LiveEditor::_node_set_func(int p_id, const StringName &p_prop, const Varian
 	if (scene_tree->root->has_node(live_edit_root))
 		base = scene_tree->root->get_node(live_edit_root);
 
-	Map<String, Set<Node *> >::Element *E = live_scene_edit_cache.find(live_edit_scene);
+	Map<String, Set<Node *>>::Element *E = live_scene_edit_cache.find(live_edit_scene);
 	if (!E)
 		return; //scene not editable
 
@@ -557,7 +557,7 @@ void LiveEditor::_node_call_func(int p_id, const StringName &p_method, VARIANT_A
 	if (scene_tree->root->has_node(live_edit_root))
 		base = scene_tree->root->get_node(live_edit_root);
 
-	Map<String, Set<Node *> >::Element *E = live_scene_edit_cache.find(live_edit_scene);
+	Map<String, Set<Node *>>::Element *E = live_scene_edit_cache.find(live_edit_scene);
 	if (!E)
 		return; //scene not editable
 
@@ -630,7 +630,7 @@ void LiveEditor::_create_node_func(const NodePath &p_parent, const String &p_typ
 	if (scene_tree->root->has_node(live_edit_root))
 		base = scene_tree->root->get_node(live_edit_root);
 
-	Map<String, Set<Node *> >::Element *E = live_scene_edit_cache.find(live_edit_scene);
+	Map<String, Set<Node *>>::Element *E = live_scene_edit_cache.find(live_edit_scene);
 	if (!E)
 		return; //scene not editable
 
@@ -668,7 +668,7 @@ void LiveEditor::_instance_node_func(const NodePath &p_parent, const String &p_p
 	if (scene_tree->root->has_node(live_edit_root))
 		base = scene_tree->root->get_node(live_edit_root);
 
-	Map<String, Set<Node *> >::Element *E = live_scene_edit_cache.find(live_edit_scene);
+	Map<String, Set<Node *>>::Element *E = live_scene_edit_cache.find(live_edit_scene);
 	if (!E)
 		return; //scene not editable
 
@@ -701,7 +701,7 @@ void LiveEditor::_remove_node_func(const NodePath &p_at) {
 	if (scene_tree->root->has_node(live_edit_root))
 		base = scene_tree->root->get_node(live_edit_root);
 
-	Map<String, Set<Node *> >::Element *E = live_scene_edit_cache.find(live_edit_scene);
+	Map<String, Set<Node *>>::Element *E = live_scene_edit_cache.find(live_edit_scene);
 	if (!E)
 		return; //scene not editable
 
@@ -732,7 +732,7 @@ void LiveEditor::_remove_and_keep_node_func(const NodePath &p_at, ObjectID p_kee
 	if (scene_tree->root->has_node(live_edit_root))
 		base = scene_tree->root->get_node(live_edit_root);
 
-	Map<String, Set<Node *> >::Element *E = live_scene_edit_cache.find(live_edit_scene);
+	Map<String, Set<Node *>>::Element *E = live_scene_edit_cache.find(live_edit_scene);
 	if (!E)
 		return; //scene not editable
 
@@ -766,7 +766,7 @@ void LiveEditor::_restore_node_func(ObjectID p_id, const NodePath &p_at, int p_a
 	if (scene_tree->root->has_node(live_edit_root))
 		base = scene_tree->root->get_node(live_edit_root);
 
-	Map<String, Set<Node *> >::Element *E = live_scene_edit_cache.find(live_edit_scene);
+	Map<String, Set<Node *>>::Element *E = live_scene_edit_cache.find(live_edit_scene);
 	if (!E)
 		return; //scene not editable
 
@@ -783,7 +783,7 @@ void LiveEditor::_restore_node_func(ObjectID p_id, const NodePath &p_at, int p_a
 			continue;
 		Node *n2 = n->get_node(p_at);
 
-		Map<Node *, Map<ObjectID, Node *> >::Element *EN = live_edit_remove_list.find(n);
+		Map<Node *, Map<ObjectID, Node *>>::Element *EN = live_edit_remove_list.find(n);
 
 		if (!EN)
 			continue;
@@ -812,7 +812,7 @@ void LiveEditor::_duplicate_node_func(const NodePath &p_at, const String &p_new_
 	if (scene_tree->root->has_node(live_edit_root))
 		base = scene_tree->root->get_node(live_edit_root);
 
-	Map<String, Set<Node *> >::Element *E = live_scene_edit_cache.find(live_edit_scene);
+	Map<String, Set<Node *>>::Element *E = live_scene_edit_cache.find(live_edit_scene);
 	if (!E)
 		return; //scene not editable
 
@@ -845,7 +845,7 @@ void LiveEditor::_reparent_node_func(const NodePath &p_at, const NodePath &p_new
 	if (scene_tree->root->has_node(live_edit_root))
 		base = scene_tree->root->get_node(live_edit_root);
 
-	Map<String, Set<Node *> >::Element *E = live_scene_edit_cache.find(live_edit_scene);
+	Map<String, Set<Node *>>::Element *E = live_scene_edit_cache.find(live_edit_scene);
 	if (!E)
 		return; //scene not editable
 

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -113,8 +113,8 @@ private:
 	NodePath live_edit_root;
 	String live_edit_scene;
 
-	Map<String, Set<Node *> > live_scene_edit_cache;
-	Map<Node *, Map<ObjectID, Node *> > live_edit_remove_list;
+	Map<String, Set<Node *>> live_scene_edit_cache;
+	Map<Node *, Map<ObjectID, Node *>> live_edit_remove_list;
 
 	void _send_tree();
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -198,10 +198,10 @@ private:
 		NodePath focus_next;
 		NodePath focus_prev;
 
-		HashMap<StringName, Ref<Texture2D> > icon_override;
-		HashMap<StringName, Ref<Shader> > shader_override;
-		HashMap<StringName, Ref<StyleBox> > style_override;
-		HashMap<StringName, Ref<Font> > font_override;
+		HashMap<StringName, Ref<Texture2D>> icon_override;
+		HashMap<StringName, Ref<Shader>> shader_override;
+		HashMap<StringName, Ref<StyleBox>> style_override;
+		HashMap<StringName, Ref<Font>> font_override;
 		HashMap<StringName, Color> color_override;
 		HashMap<StringName, int> constant_override;
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -330,7 +330,7 @@ private:
 	ItemMeta *meta_hovering;
 	Variant current_meta;
 
-	Vector<Ref<RichTextEffect> > custom_effects;
+	Vector<Ref<RichTextEffect>> custom_effects;
 
 	void _invalidate_current_line(ItemFrame *p_frame);
 	void _validate_line_caches(ItemFrame *p_frame);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -268,7 +268,7 @@ private:
 	} cache;
 
 	Map<int, int> color_region_cache;
-	Map<int, Map<int, HighlighterInfo> > syntax_highlighting_cache;
+	Map<int, Map<int, HighlighterInfo>> syntax_highlighting_cache;
 
 	struct TextOperation {
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -172,7 +172,7 @@ void SceneTree::_flush_ugc() {
 
 	while (unique_group_calls.size()) {
 
-		Map<UGCall, Vector<Variant> >::Element *E = unique_group_calls.front();
+		Map<UGCall, Vector<Variant>>::Element *E = unique_group_calls.front();
 
 		Variant v[VARIANT_ARG_MAX];
 		for (int i = 0; i < E->get().size(); i++)
@@ -546,11 +546,11 @@ bool SceneTree::idle(float p_time) {
 
 	//go through timers
 
-	List<Ref<SceneTreeTimer> >::Element *L = timers.back(); //last element
+	List<Ref<SceneTreeTimer>>::Element *L = timers.back(); //last element
 
-	for (List<Ref<SceneTreeTimer> >::Element *E = timers.front(); E;) {
+	for (List<Ref<SceneTreeTimer>>::Element *E = timers.front(); E;) {
 
-		List<Ref<SceneTreeTimer> >::Element *N = E->next();
+		List<Ref<SceneTreeTimer>>::Element *N = E->next();
 		if (pause && !E->get()->is_pause_mode_process()) {
 			if (E == L) {
 				break; //break on last, so if new timers were added during list traversal, ignore them.
@@ -625,7 +625,7 @@ void SceneTree::finish() {
 	}
 
 	// cleanup timers
-	for (List<Ref<SceneTreeTimer> >::Element *E = timers.front(); E; E = E->next()) {
+	for (List<Ref<SceneTreeTimer>>::Element *E = timers.front(); E; E = E->next()) {
 		E->get()->release_connections();
 	}
 	timers.clear();

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -157,7 +157,7 @@ private:
 
 	List<ObjectID> delete_queue;
 
-	Map<UGCall, Vector<Variant> > unique_group_calls;
+	Map<UGCall, Vector<Variant>> unique_group_calls;
 	bool ugc_locked;
 	void _flush_ugc();
 
@@ -181,7 +181,7 @@ private:
 	void _change_scene(Node *p_to);
 	//void _call_group(uint32_t p_call_flags,const StringName& p_group,const StringName& p_function,const Variant& p_arg1,const Variant& p_arg2);
 
-	List<Ref<SceneTreeTimer> > timers;
+	List<Ref<SceneTreeTimer>> timers;
 
 	///network///
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -422,7 +422,7 @@ void Viewport::_notification(int p_what) {
 					// if no mouse event exists, create a motion one. This is necessary because objects or camera may have moved.
 					// while this extra event is sent, it is checked if both camera and last object and last ID did not move. If nothing changed, the event is discarded to avoid flooding with unnecessary motion events every frame
 					bool has_mouse_event = false;
-					for (List<Ref<InputEvent> >::Element *E = physics_picking_events.front(); E; E = E->next()) {
+					for (List<Ref<InputEvent>>::Element *E = physics_picking_events.front(); E; E = E->next()) {
 						Ref<InputEventMouse> m = E->get();
 						if (m.is_valid()) {
 							has_mouse_event = true;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -235,7 +235,7 @@ private:
 	bool snap_controls_to_pixels;
 
 	bool physics_object_picking;
-	List<Ref<InputEvent> > physics_picking_events;
+	List<Ref<InputEvent>> physics_picking_events;
 	ObjectID physics_object_capture;
 	ObjectID physics_object_over;
 	Transform physics_last_object_transform;

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1705,7 +1705,7 @@ float Animation::_cubic_interpolate(const float &p_pre_a, const float &p_a, cons
 }
 
 template <class T>
-T Animation::_interpolate(const Vector<TKey<T> > &p_keys, float p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok) const {
+T Animation::_interpolate(const Vector<TKey<T>> &p_keys, float p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok) const {
 
 	int len = _find(p_keys, length) + 1; // try to find last key (there may be more past the end)
 

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -105,7 +105,7 @@ private:
 
 	struct TransformTrack : public Track {
 
-		Vector<TKey<TransformKey> > transforms;
+		Vector<TKey<TransformKey>> transforms;
 
 		TransformTrack() { type = TYPE_TRANSFORM; }
 	};
@@ -116,7 +116,7 @@ private:
 
 		UpdateMode update_mode;
 		bool update_on_seek;
-		Vector<TKey<Variant> > values;
+		Vector<TKey<Variant>> values;
 
 		ValueTrack() {
 			type = TYPE_VALUE;
@@ -148,7 +148,7 @@ private:
 
 	struct BezierTrack : public Track {
 
-		Vector<TKey<BezierKey> > values;
+		Vector<TKey<BezierKey>> values;
 
 		BezierTrack() {
 			type = TYPE_BEZIER;
@@ -169,7 +169,7 @@ private:
 
 	struct AudioTrack : public Track {
 
-		Vector<TKey<AudioKey> > values;
+		Vector<TKey<AudioKey>> values;
 
 		AudioTrack() {
 			type = TYPE_AUDIO;
@@ -180,7 +180,7 @@ private:
 
 	struct AnimationTrack : public Track {
 
-		Vector<TKey<StringName> > values;
+		Vector<TKey<StringName>> values;
 
 		AnimationTrack() {
 			type = TYPE_ANIMATION;
@@ -216,7 +216,7 @@ private:
 	_FORCE_INLINE_ float _cubic_interpolate(const float &p_pre_a, const float &p_a, const float &p_b, const float &p_post_b, float p_c) const;
 
 	template <class T>
-	_FORCE_INLINE_ T _interpolate(const Vector<TKey<T> > &p_keys, float p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok) const;
+	_FORCE_INLINE_ T _interpolate(const Vector<TKey<T>> &p_keys, float p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok) const;
 
 	template <class T>
 	_FORCE_INLINE_ void _track_get_key_indices_in_range(const Vector<T> &p_array, float from_time, float to_time, List<int> *p_indices) const;

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -493,7 +493,7 @@ static void fill_bits(const BitMap *p_src, Ref<BitMap> &p_map, const Point2i &p_
 	print_verbose("BitMap: Max stack size: " + itos(stack.size()));
 }
 
-Vector<Vector<Vector2> > BitMap::clip_opaque_to_polygons(const Rect2 &p_rect, float p_epsilon) const {
+Vector<Vector<Vector2>> BitMap::clip_opaque_to_polygons(const Rect2 &p_rect, float p_epsilon) const {
 
 	Rect2i r = Rect2i(0, 0, width, height).clip(p_rect);
 	print_verbose("BitMap: Rect: " + r);
@@ -503,7 +503,7 @@ Vector<Vector<Vector2> > BitMap::clip_opaque_to_polygons(const Rect2 &p_rect, fl
 	fill.instance();
 	fill->create(get_size());
 
-	Vector<Vector<Vector2> > polygons;
+	Vector<Vector<Vector2>> polygons;
 	for (int i = r.position.y; i < r.position.y + r.size.height; i++) {
 		for (int j = r.position.x; j < r.position.x + r.size.width; j++) {
 			if (!fill->get_bit(Point2(j, i)) && get_bit(Point2(j, i))) {
@@ -591,7 +591,7 @@ void BitMap::shrink_mask(int p_pixels, const Rect2 &p_rect) {
 
 Array BitMap::_opaque_to_polygons_bind(const Rect2 &p_rect, float p_epsilon) const {
 
-	Vector<Vector<Vector2> > result = clip_opaque_to_polygons(p_rect, p_epsilon);
+	Vector<Vector<Vector2>> result = clip_opaque_to_polygons(p_rect, p_epsilon);
 
 	// Convert result to bindable types
 

--- a/scene/resources/bit_map.h
+++ b/scene/resources/bit_map.h
@@ -72,7 +72,7 @@ public:
 	void blit(const Vector2 &p_pos, const Ref<BitMap> &p_bitmap);
 	Ref<Image> convert_to_image() const;
 
-	Vector<Vector<Vector2> > clip_opaque_to_polygons(const Rect2 &p_rect, float p_epsilon = 2.0) const;
+	Vector<Vector<Vector2>> clip_opaque_to_polygons(const Rect2 &p_rect, float p_epsilon = 2.0) const;
 
 	BitMap();
 };

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -941,7 +941,7 @@ PackedVector2Array Curve2D::tessellate(int p_max_stages, float p_tolerance) cons
 	if (points.size() == 0) {
 		return tess;
 	}
-	Vector<Map<float, Vector2> > midpoints;
+	Vector<Map<float, Vector2>> midpoints;
 
 	midpoints.resize(points.size() - 1);
 
@@ -1615,7 +1615,7 @@ PackedVector3Array Curve3D::tessellate(int p_max_stages, float p_tolerance) cons
 	if (points.size() == 0) {
 		return tess;
 	}
-	Vector<Map<float, Vector3> > midpoints;
+	Vector<Map<float, Vector3>> midpoints;
 
 	midpoints.resize(points.size() - 1);
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -38,7 +38,7 @@
 #include "font_hidpi.inc"
 #include "font_lodpi.inc"
 
-typedef Map<const void *, Ref<ImageTexture> > TexCacheMap;
+typedef Map<const void *, Ref<ImageTexture>> TexCacheMap;
 
 static TexCacheMap *tex_cache;
 static float scale = 1;

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -115,7 +115,7 @@ DynamicFontData::~DynamicFontData() {
 }
 
 ////////////////////
-HashMap<String, Vector<uint8_t> > DynamicFontAtSize::_fontdata;
+HashMap<String, Vector<uint8_t>> DynamicFontAtSize::_fontdata;
 
 Error DynamicFontAtSize::_load() {
 
@@ -243,7 +243,7 @@ float DynamicFontAtSize::get_descent() const {
 	return descent;
 }
 
-const Pair<const DynamicFontAtSize::Character *, DynamicFontAtSize *> DynamicFontAtSize::_find_char_with_font(CharType p_char, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks) const {
+const Pair<const DynamicFontAtSize::Character *, DynamicFontAtSize *> DynamicFontAtSize::_find_char_with_font(CharType p_char, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks) const {
 	const Character *chr = char_map.getptr(p_char);
 	ERR_FAIL_COND_V(!chr, (Pair<const Character *, DynamicFontAtSize *>(NULL, NULL)));
 
@@ -275,7 +275,7 @@ const Pair<const DynamicFontAtSize::Character *, DynamicFontAtSize *> DynamicFon
 	return Pair<const Character *, DynamicFontAtSize *>(chr, const_cast<DynamicFontAtSize *>(this));
 }
 
-Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks) const {
+Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks) const {
 
 	if (!valid)
 		return Size2(1, 1);
@@ -294,7 +294,7 @@ Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const V
 	return ret;
 }
 
-float DynamicFontAtSize::draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next, const Color &p_modulate, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks, bool p_advance_only, bool p_outline) const {
+float DynamicFontAtSize::draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next, const Color &p_modulate, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks, bool p_advance_only, bool p_outline) const {
 
 	if (!valid)
 		return 0;
@@ -850,7 +850,7 @@ float DynamicFont::draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_
 	if (!font_at_size.is_valid())
 		return 0;
 
-	const Vector<Ref<DynamicFontAtSize> > &fallbacks = p_outline && outline_cache_id.outline_size > 0 ? fallback_outline_data_at_size : fallback_data_at_size;
+	const Vector<Ref<DynamicFontAtSize>> &fallbacks = p_outline && outline_cache_id.outline_size > 0 ? fallback_outline_data_at_size : fallback_data_at_size;
 	Color color = p_outline && outline_cache_id.outline_size > 0 ? p_modulate * outline_color : p_modulate;
 
 	// If requested outline draw, but no outline is present, simply return advance without drawing anything
@@ -1025,7 +1025,7 @@ void DynamicFont::finish_dynamic_fonts() {
 
 void DynamicFont::update_oversampling() {
 
-	Vector<Ref<DynamicFont> > changed;
+	Vector<Ref<DynamicFont>> changed;
 	{
 		MutexLock lock(dynamic_font_mutex);
 

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -161,7 +161,7 @@ class DynamicFontAtSize : public Reference {
 		int y;
 	};
 
-	const Pair<const Character *, DynamicFontAtSize *> _find_char_with_font(CharType p_char, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks) const;
+	const Pair<const Character *, DynamicFontAtSize *> _find_char_with_font(CharType p_char, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks) const;
 	Character _make_outline_char(CharType p_char);
 	TexturePosition _find_texture_pos_for_glyph(int p_color_size, Image::Format p_image_format, int p_width, int p_height);
 	Character _bitmap_to_character(FT_Bitmap bitmap, int yofs, int xofs, float advance);
@@ -177,7 +177,7 @@ class DynamicFontAtSize : public Reference {
 	Ref<DynamicFontData> font;
 	DynamicFontData::CacheID id;
 
-	static HashMap<String, Vector<uint8_t> > _fontdata;
+	static HashMap<String, Vector<uint8_t>> _fontdata;
 	Error _load();
 
 public:
@@ -188,9 +188,9 @@ public:
 	float get_ascent() const;
 	float get_descent() const;
 
-	Size2 get_char_size(CharType p_char, CharType p_next, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks) const;
+	Size2 get_char_size(CharType p_char, CharType p_next, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks) const;
 
-	float draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next, const Color &p_modulate, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks, bool p_advance_only = false, bool p_outline = false) const;
+	float draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next, const Color &p_modulate, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks, bool p_advance_only = false, bool p_outline = false) const;
 
 	void set_texture_flags(uint32_t p_flags);
 	void update_oversampling();
@@ -218,9 +218,9 @@ private:
 	Ref<DynamicFontAtSize> data_at_size;
 	Ref<DynamicFontAtSize> outline_data_at_size;
 
-	Vector<Ref<DynamicFontData> > fallbacks;
-	Vector<Ref<DynamicFontAtSize> > fallback_data_at_size;
-	Vector<Ref<DynamicFontAtSize> > fallback_outline_data_at_size;
+	Vector<Ref<DynamicFontData>> fallbacks;
+	Vector<Ref<DynamicFontAtSize>> fallback_data_at_size;
+	Vector<Ref<DynamicFontAtSize>> fallback_outline_data_at_size;
 
 	DynamicFontData::CacheID cache_id;
 	DynamicFontData::CacheID outline_cache_id;

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -108,7 +108,7 @@ class BitmapFont : public Font {
 	GDCLASS(BitmapFont, Font);
 	RES_BASE_EXTENSION("font");
 
-	Vector<Ref<Texture2D> > textures;
+	Vector<Ref<Texture2D>> textures;
 
 public:
 	struct Character {

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -541,15 +541,15 @@ void Mesh::clear_cache() const {
 	debug_lines.clear();
 }
 
-Vector<Ref<Shape> > Mesh::convex_decompose() const {
+Vector<Ref<Shape>> Mesh::convex_decompose() const {
 
-	ERR_FAIL_COND_V(!convex_composition_function, Vector<Ref<Shape> >());
+	ERR_FAIL_COND_V(!convex_composition_function, Vector<Ref<Shape>>());
 
 	const Vector<Face3> faces = get_faces();
 
-	Vector<Vector<Face3> > decomposed = convex_composition_function(faces);
+	Vector<Vector<Face3>> decomposed = convex_composition_function(faces);
 
-	Vector<Ref<Shape> > ret;
+	Vector<Ref<Shape>> ret;
 
 	for (int i = 0; i < decomposed.size(); i++) {
 		Set<Vector3> points;
@@ -788,7 +788,7 @@ bool ArrayMesh::_set(const StringName &p_name, const Variant &p_value) {
 			if (d.has("index_count"))
 				index_count = d["index_count"];
 
-			Vector<Vector<uint8_t> > blend_shapes;
+			Vector<Vector<uint8_t>> blend_shapes;
 
 			if (d.has("blend_shape_data")) {
 				Array blend_shape_data = d["blend_shape_data"];
@@ -910,7 +910,7 @@ void ArrayMesh::_create_if_empty() const {
 void ArrayMesh::_set_surfaces(const Array &p_surfaces) {
 
 	Vector<VS::SurfaceData> surface_data;
-	Vector<Ref<Material> > surface_materials;
+	Vector<Ref<Material>> surface_materials;
 	Vector<String> surface_names;
 	Vector<bool> surface_2d;
 
@@ -1102,7 +1102,7 @@ void ArrayMesh::_recompute_aabb() {
 #ifndef _MSC_VER
 #warning need to add binding to add_surface using future MeshSurfaceData object
 #endif
-void ArrayMesh::add_surface(uint32_t p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<Vector<uint8_t> > &p_blend_shapes, const Vector<AABB> &p_bone_aabb, const Vector<VS::SurfaceData::LOD> &p_lods) {
+void ArrayMesh::add_surface(uint32_t p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<Vector<uint8_t>> &p_blend_shapes, const Vector<AABB> &p_bone_aabb, const Vector<VS::SurfaceData::LOD> &p_lods) {
 
 	_create_if_empty();
 
@@ -1341,7 +1341,7 @@ void ArrayMesh::regen_normalmaps() {
 	if (surfaces.size() == 0) {
 		return;
 	}
-	Vector<Ref<SurfaceTool> > surfs;
+	Vector<Ref<SurfaceTool>> surfs;
 	for (int i = 0; i < get_surface_count(); i++) {
 
 		Ref<SurfaceTool> st = memnew(SurfaceTool);
@@ -1379,7 +1379,7 @@ Error ArrayMesh::lightmap_unwrap(const Transform &p_base_transform, float p_texe
 	Vector<int> indices;
 	Vector<int> face_materials;
 	Vector<float> uv;
-	Vector<Pair<int, int> > uv_index;
+	Vector<Pair<int, int>> uv_index;
 
 	Vector<ArrayMeshLightmapSurface> surfaces;
 	for (int i = 0; i < get_surface_count(); i++) {
@@ -1472,7 +1472,7 @@ Error ArrayMesh::lightmap_unwrap(const Transform &p_base_transform, float p_texe
 	clear_surfaces();
 
 	//create surfacetools for each surface..
-	Vector<Ref<SurfaceTool> > surfaces_tools;
+	Vector<Ref<SurfaceTool>> surfaces_tools;
 
 	for (int i = 0; i < surfaces.size(); i++) {
 		Ref<SurfaceTool> st;

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -142,11 +142,11 @@ public:
 	Size2 get_lightmap_size_hint() const;
 	void clear_cache() const;
 
-	typedef Vector<Vector<Face3> > (*ConvexDecompositionFunc)(const Vector<Face3> &);
+	typedef Vector<Vector<Face3>> (*ConvexDecompositionFunc)(const Vector<Face3> &);
 
 	static ConvexDecompositionFunc convex_composition_function;
 
-	Vector<Ref<Shape> > convex_decompose() const;
+	Vector<Ref<Shape>> convex_decompose() const;
 
 	Mesh();
 };
@@ -193,7 +193,7 @@ protected:
 public:
 	void add_surface_from_arrays(PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), uint32_t p_flags = ARRAY_COMPRESS_DEFAULT);
 
-	void add_surface(uint32_t p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<Vector<uint8_t> > &p_blend_shapes = Vector<Vector<uint8_t> >(), const Vector<AABB> &p_bone_aabbs = Vector<AABB>(), const Vector<VS::SurfaceData::LOD> &p_lods = Vector<VS::SurfaceData::LOD>());
+	void add_surface(uint32_t p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<Vector<uint8_t>> &p_blend_shapes = Vector<Vector<uint8_t>>(), const Vector<AABB> &p_bone_aabbs = Vector<AABB>(), const Vector<VS::SurfaceData::LOD> &p_lods = Vector<VS::SurfaceData::LOD>());
 
 	Array surface_get_arrays(int p_surface) const;
 	Array surface_get_blend_shape_arrays(int p_surface) const;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -82,7 +82,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 
 	bool gen_node_path_cache = p_edit_state != GEN_EDIT_STATE_DISABLED && node_path_cache.empty();
 
-	Map<Ref<Resource>, Ref<Resource> > resources_local_to_scene;
+	Map<Ref<Resource>, Ref<Resource>> resources_local_to_scene;
 
 	for (int i = 0; i < nc; i++) {
 
@@ -201,7 +201,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 						//https://github.com/godotengine/godot/issues/2958
 
 						//store old state
-						List<Pair<StringName, Variant> > old_state;
+						List<Pair<StringName, Variant>> old_state;
 						if (node->get_script_instance()) {
 							node->get_script_instance()->get_property_state(old_state);
 						}
@@ -209,7 +209,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 						node->set(snames[nprops[j].name], props[nprops[j].value], &valid);
 
 						//restore old state for new script, if exists
-						for (List<Pair<StringName, Variant> >::Element *E = old_state.front(); E; E = E->next()) {
+						for (List<Pair<StringName, Variant>>::Element *E = old_state.front(); E; E = E->next()) {
 							node->set(E->get().first, E->get().second);
 						}
 					} else {
@@ -222,7 +222,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 							if (res.is_valid()) {
 								if (res->is_local_to_scene()) {
 
-									Map<Ref<Resource>, Ref<Resource> >::Element *E = resources_local_to_scene.find(res);
+									Map<Ref<Resource>, Ref<Resource>>::Element *E = resources_local_to_scene.find(res);
 
 									if (E) {
 										value = E->get();
@@ -302,7 +302,7 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 		}
 	}
 
-	for (Map<Ref<Resource>, Ref<Resource> >::Element *E = resources_local_to_scene.front(); E; E = E->next()) {
+	for (Map<Ref<Resource>, Ref<Resource>>::Element *E = resources_local_to_scene.front(); E; E = E->next()) {
 
 		E->get()->setup_local_to_scene();
 	}

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -121,7 +121,7 @@ Ref<Texture2D> Shader::get_default_texture_param(const StringName &p_param) cons
 
 void Shader::get_default_texture_param_list(List<StringName> *r_textures) const {
 
-	for (const Map<StringName, Ref<Texture2D> >::Element *E = default_textures.front(); E; E = E->next()) {
+	for (const Map<StringName, Ref<Texture2D>>::Element *E = default_textures.front(); E; E = E->next()) {
 
 		r_textures->push_back(E->key());
 	}

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -59,7 +59,7 @@ private:
 	// conversion fast and save memory.
 	mutable bool params_cache_dirty;
 	mutable Map<StringName, StringName> params_cache; //map a shader param to a material param..
-	Map<StringName, Ref<Texture2D> > default_textures;
+	Map<StringName, Ref<Texture2D>> default_textures;
 
 	virtual void _update_shader() const; //used for visual shader
 protected:

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -370,7 +370,7 @@ Ref<Image> StreamTexture::load_image_from_file(FileAccess *f, int p_size_limit) 
 		int sh = h;
 
 		//mipmaps need to be read independently, they will be later combined
-		Vector<Ref<Image> > mipmap_images;
+		Vector<Ref<Image>> mipmap_images;
 		int total_size = 0;
 
 		bool first = true;
@@ -1899,7 +1899,7 @@ uint32_t TextureLayered::get_layers() const {
 }
 
 Error TextureLayered::_create_from_images(const Array &p_images) {
-	Vector<Ref<Image> > images;
+	Vector<Ref<Image>> images;
 	for (int i = 0; i < p_images.size(); i++) {
 		Ref<Image> img = p_images[i];
 		ERR_FAIL_COND_V(img.is_null(), ERR_INVALID_PARAMETER);
@@ -1917,7 +1917,7 @@ Array TextureLayered::_get_images() const {
 	return images;
 }
 
-Error TextureLayered::create_from_images(Vector<Ref<Image> > p_images) {
+Error TextureLayered::create_from_images(Vector<Ref<Image>> p_images) {
 
 	int new_layers = p_images.size();
 	ERR_FAIL_COND_V(new_layers == 0, ERR_INVALID_PARAMETER);
@@ -2077,7 +2077,7 @@ RES ResourceFormatLoaderTextureLayered::load(const String &p_path, const String 
 	Image::Format format = Image::Format(f->get_32());
 	uint32_t compression = f->get_32(); // 0 - lossless (PNG), 1 - vram, 2 - uncompressed
 
-	Vector<Ref<Image> > images;
+	Vector<Ref<Image>> images;
 	for (int layer = 0; layer < td; layer++) {
 
 		Ref<Image> image;
@@ -2087,7 +2087,7 @@ RES ResourceFormatLoaderTextureLayered::load(const String &p_path, const String 
 			//look for a PNG file inside
 
 			int mipmaps = f->get_32();
-			Vector<Ref<Image> > mipmap_images;
+			Vector<Ref<Image>> mipmap_images;
 
 			for (int i = 0; i < mipmaps; i++) {
 				uint32_t size = f->get_32();

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -376,7 +376,7 @@ public:
 	uint32_t get_layers() const;
 	bool has_mipmaps() const;
 
-	Error create_from_images(Vector<Ref<Image> > p_images);
+	Error create_from_images(Vector<Ref<Image>> p_images);
 	void update_layer(const Ref<Image> &p_image, int p_layer);
 	Ref<Image> get_layer_data(int p_layer) const;
 

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -45,12 +45,12 @@ class Theme : public Resource {
 
 	void _emit_theme_changed();
 
-	HashMap<StringName, HashMap<StringName, Ref<Texture2D> > > icon_map;
-	HashMap<StringName, HashMap<StringName, Ref<StyleBox> > > style_map;
-	HashMap<StringName, HashMap<StringName, Ref<Font> > > font_map;
-	HashMap<StringName, HashMap<StringName, Ref<Shader> > > shader_map;
-	HashMap<StringName, HashMap<StringName, Color> > color_map;
-	HashMap<StringName, HashMap<StringName, int> > constant_map;
+	HashMap<StringName, HashMap<StringName, Ref<Texture2D>>> icon_map;
+	HashMap<StringName, HashMap<StringName, Ref<StyleBox>>> style_map;
+	HashMap<StringName, HashMap<StringName, Ref<Font>>> font_map;
+	HashMap<StringName, HashMap<StringName, Ref<Shader>>> shader_map;
+	HashMap<StringName, HashMap<StringName, Color>> color_map;
+	HashMap<StringName, HashMap<StringName, int>> constant_map;
 
 	Vector<String> _get_icon_list(const String &p_type) const;
 	Vector<String> _get_stylebox_list(const String &p_type) const;

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -252,14 +252,14 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 			r_ret = p;
 		} else if (what == "occluder_map") {
 			Array p;
-			for (Map<Vector2, Ref<OccluderPolygon2D> >::Element *E = tile_map[id].autotile_data.occluder_map.front(); E; E = E->next()) {
+			for (Map<Vector2, Ref<OccluderPolygon2D>>::Element *E = tile_map[id].autotile_data.occluder_map.front(); E; E = E->next()) {
 				p.push_back(E->key());
 				p.push_back(E->value());
 			}
 			r_ret = p;
 		} else if (what == "navpoly_map") {
 			Array p;
-			for (Map<Vector2, Ref<NavigationPolygon> >::Element *E = tile_map[id].autotile_data.navpoly_map.front(); E; E = E->next()) {
+			for (Map<Vector2, Ref<NavigationPolygon>>::Element *E = tile_map[id].autotile_data.navpoly_map.front(); E; E = E->next()) {
 				p.push_back(E->key());
 				p.push_back(E->value());
 			}
@@ -903,9 +903,9 @@ Ref<NavigationPolygon> TileSet::tile_get_navigation_polygon(int p_id) const {
 	return tile_map[p_id].navigation_polygon;
 }
 
-const Map<Vector2, Ref<OccluderPolygon2D> > &TileSet::autotile_get_light_oclusion_map(int p_id) const {
+const Map<Vector2, Ref<OccluderPolygon2D>> &TileSet::autotile_get_light_oclusion_map(int p_id) const {
 
-	static Map<Vector2, Ref<OccluderPolygon2D> > dummy;
+	static Map<Vector2, Ref<OccluderPolygon2D>> dummy;
 	ERR_FAIL_COND_V(!tile_map.has(p_id), dummy);
 	return tile_map[p_id].autotile_data.occluder_map;
 }
@@ -932,9 +932,9 @@ Ref<NavigationPolygon> TileSet::autotile_get_navigation_polygon(int p_id, const 
 	}
 }
 
-const Map<Vector2, Ref<NavigationPolygon> > &TileSet::autotile_get_navigation_map(int p_id) const {
+const Map<Vector2, Ref<NavigationPolygon>> &TileSet::autotile_get_navigation_map(int p_id) const {
 
-	static Map<Vector2, Ref<NavigationPolygon> > dummy;
+	static Map<Vector2, Ref<NavigationPolygon>> dummy;
 	ERR_FAIL_COND_V(!tile_map.has(p_id), dummy);
 	return tile_map[p_id].autotile_data.navpoly_map;
 }
@@ -1077,7 +1077,7 @@ void TileSet::_decompose_convex_shape(Ref<Shape2D> p_shape) {
 	Ref<ConvexPolygonShape2D> convex = p_shape;
 	if (!convex.is_valid())
 		return;
-	Vector<Vector<Vector2> > decomp = Geometry::decompose_polygon_in_convex(convex->get_points());
+	Vector<Vector<Vector2>> decomp = Geometry::decompose_polygon_in_convex(convex->get_points());
 	if (decomp.size() > 1) {
 		Array sub_shapes;
 		for (int i = 0; i < decomp.size(); i++) {

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -97,8 +97,8 @@ public:
 		int spacing;
 		Vector2 icon_coord;
 		Map<Vector2, uint32_t> flags;
-		Map<Vector2, Ref<OccluderPolygon2D> > occluder_map;
-		Map<Vector2, Ref<NavigationPolygon> > navpoly_map;
+		Map<Vector2, Ref<OccluderPolygon2D>> occluder_map;
+		Map<Vector2, Ref<NavigationPolygon>> navpoly_map;
 		Map<Vector2, int> priority_map;
 		Map<Vector2, int> z_index_map;
 
@@ -233,7 +233,7 @@ public:
 
 	void autotile_set_light_occluder(int p_id, const Ref<OccluderPolygon2D> &p_light_occluder, const Vector2 &p_coord);
 	Ref<OccluderPolygon2D> autotile_get_light_occluder(int p_id, const Vector2 &p_coord) const;
-	const Map<Vector2, Ref<OccluderPolygon2D> > &autotile_get_light_oclusion_map(int p_id) const;
+	const Map<Vector2, Ref<OccluderPolygon2D>> &autotile_get_light_oclusion_map(int p_id) const;
 
 	void tile_set_navigation_polygon_offset(int p_id, const Vector2 &p_offset);
 	Vector2 tile_get_navigation_polygon_offset(int p_id) const;
@@ -243,7 +243,7 @@ public:
 
 	void autotile_set_navigation_polygon(int p_id, const Ref<NavigationPolygon> &p_navigation_polygon, const Vector2 &p_coord);
 	Ref<NavigationPolygon> autotile_get_navigation_polygon(int p_id, const Vector2 &p_coord) const;
-	const Map<Vector2, Ref<NavigationPolygon> > &autotile_get_navigation_map(int p_id) const;
+	const Map<Vector2, Ref<NavigationPolygon>> &autotile_get_navigation_map(int p_id) const;
 
 	void tile_set_z_index(int p_id, int p_z_index);
 	int tile_get_z_index(int p_id) const;

--- a/servers/arvr_server.h
+++ b/servers/arvr_server.h
@@ -76,7 +76,7 @@ public:
 	};
 
 private:
-	Vector<Ref<ARVRInterface> > interfaces;
+	Vector<Ref<ARVRInterface>> interfaces;
 	Vector<ARVRPositionalTracker *> trackers;
 
 	Ref<ARVRInterface> primary_interface; /* we'll identify one interface as primary, this will be used by our viewports */

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.h
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.h
@@ -48,7 +48,7 @@ private:
 	friend class AudioEffectSpectrumAnalyzer;
 	Ref<AudioEffectSpectrumAnalyzer> base;
 
-	Vector<Vector<AudioFrame> > fft_history;
+	Vector<Vector<AudioFrame>> fft_history;
 	Vector<float> temporal_fft;
 	int temporal_fft_pos;
 	int fft_size;

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -198,7 +198,7 @@ private:
 			bool active;
 			AudioFrame peak_volume;
 			Vector<AudioFrame> buffer;
-			Vector<Ref<AudioEffectInstance> > effect_instances;
+			Vector<Ref<AudioEffectInstance>> effect_instances;
 			uint64_t last_mix_with_audio;
 			Channel() {
 				last_mix_with_audio = 0;
@@ -224,7 +224,7 @@ private:
 		int index_cache;
 	};
 
-	Vector<Vector<AudioFrame> > temp_buffer; //temp_buffer for each level
+	Vector<Vector<AudioFrame>> temp_buffer; //temp_buffer for each level
 	Vector<Bus *> buses;
 	Map<StringName, Bus *> bus_map;
 

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -65,7 +65,7 @@ private:
 protected:
 	static CreateFunc create_func;
 
-	Vector<Ref<CameraFeed> > feeds;
+	Vector<Ref<CameraFeed>> feeds;
 
 	static CameraServer *singleton;
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -178,7 +178,7 @@ public:
 		}
 
 		void clean_up_dependencies() {
-			List<Pair<InstanceDependency *, Map<InstanceBase *, uint32_t>::Element *> > to_clean_up;
+			List<Pair<InstanceDependency *, Map<InstanceBase *, uint32_t>::Element *>> to_clean_up;
 			for (Set<InstanceDependency *>::Element *E = dependencies.front(); E; E = E->next()) {
 				InstanceDependency *dep = E->get();
 				Map<InstanceBase *, uint32_t>::Element *F = dep->instances.find(this);
@@ -277,8 +277,8 @@ public:
 	/* TEXTURE API */
 
 	virtual RID texture_2d_create(const Ref<Image> &p_image) = 0;
-	virtual RID texture_2d_layered_create(const Vector<Ref<Image> > &p_layers, VS::TextureLayeredType p_layered_type) = 0;
-	virtual RID texture_3d_create(const Vector<Ref<Image> > &p_slices) = 0; //all slices, then all the mipmaps, must be coherent
+	virtual RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, VS::TextureLayeredType p_layered_type) = 0;
+	virtual RID texture_3d_create(const Vector<Ref<Image>> &p_slices) = 0; //all slices, then all the mipmaps, must be coherent
 	virtual RID texture_proxy_create(RID p_base) = 0; //all slices, then all the mipmaps, must be coherent
 
 	virtual void texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0; //mostly used for video and streaming

--- a/servers/visual/rasterizer_rd/rasterizer_storage_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_storage_rd.cpp
@@ -585,7 +585,7 @@ RID RasterizerStorageRD::texture_2d_create(const Ref<Image> &p_image) {
 		rd_view.swizzle_a = ret_format.swizzle_a;
 	}
 	Vector<uint8_t> data = image->get_data(); //use image data
-	Vector<Vector<uint8_t> > data_slices;
+	Vector<Vector<uint8_t>> data_slices;
 	data_slices.push_back(data);
 	texture.rd_texture = RD::get_singleton()->texture_create(rd_format, rd_view, data_slices);
 	ERR_FAIL_COND_V(texture.rd_texture.is_null(), RID());
@@ -608,11 +608,11 @@ RID RasterizerStorageRD::texture_2d_create(const Ref<Image> &p_image) {
 	return texture_owner.make_rid(texture);
 }
 
-RID RasterizerStorageRD::texture_2d_layered_create(const Vector<Ref<Image> > &p_layers, VS::TextureLayeredType p_layered_type) {
+RID RasterizerStorageRD::texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, VS::TextureLayeredType p_layered_type) {
 
 	return RID();
 }
-RID RasterizerStorageRD::texture_3d_create(const Vector<Ref<Image> > &p_slices) {
+RID RasterizerStorageRD::texture_3d_create(const Vector<Ref<Image>> &p_slices) {
 
 	return RID();
 }
@@ -3597,7 +3597,7 @@ void RasterizerStorageRD::gi_probe_allocate(RID p_gi_probe, const Transform &p_t
 			tf.depth = gi_probe->octree_size.z;
 			tf.type = RD::TEXTURE_TYPE_3D;
 			tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
-			Vector<Vector<uint8_t> > s;
+			Vector<Vector<uint8_t>> s;
 			s.push_back(p_distance_field);
 			gi_probe->sdf_texture = RD::get_singleton()->texture_create(tf, RD::TextureView(), s);
 		}
@@ -4473,7 +4473,7 @@ RasterizerStorageRD::RasterizerStorageRD() {
 		}
 
 		{
-			Vector<Vector<uint8_t> > vpv;
+			Vector<Vector<uint8_t>> vpv;
 			vpv.push_back(pv);
 			default_rd_textures[DEFAULT_RD_TEXTURE_WHITE] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
@@ -4486,7 +4486,7 @@ RasterizerStorageRD::RasterizerStorageRD() {
 		}
 
 		{
-			Vector<Vector<uint8_t> > vpv;
+			Vector<Vector<uint8_t>> vpv;
 			vpv.push_back(pv);
 			default_rd_textures[DEFAULT_RD_TEXTURE_BLACK] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
@@ -4499,7 +4499,7 @@ RasterizerStorageRD::RasterizerStorageRD() {
 		}
 
 		{
-			Vector<Vector<uint8_t> > vpv;
+			Vector<Vector<uint8_t>> vpv;
 			vpv.push_back(pv);
 			default_rd_textures[DEFAULT_RD_TEXTURE_NORMAL] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
@@ -4512,7 +4512,7 @@ RasterizerStorageRD::RasterizerStorageRD() {
 		}
 
 		{
-			Vector<Vector<uint8_t> > vpv;
+			Vector<Vector<uint8_t>> vpv;
 			vpv.push_back(pv);
 			default_rd_textures[DEFAULT_RD_TEXTURE_ANISO] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
@@ -4547,7 +4547,7 @@ RasterizerStorageRD::RasterizerStorageRD() {
 		}
 
 		{
-			Vector<Vector<uint8_t> > vpv;
+			Vector<Vector<uint8_t>> vpv;
 			for (int i = 0; i < 6; i++) {
 				vpv.push_back(pv);
 			}
@@ -4575,7 +4575,7 @@ RasterizerStorageRD::RasterizerStorageRD() {
 		}
 
 		{
-			Vector<Vector<uint8_t> > vpv;
+			Vector<Vector<uint8_t>> vpv;
 			for (int i = 0; i < 6; i++) {
 				vpv.push_back(pv);
 			}
@@ -4603,7 +4603,7 @@ RasterizerStorageRD::RasterizerStorageRD() {
 		}
 
 		{
-			Vector<Vector<uint8_t> > vpv;
+			Vector<Vector<uint8_t>> vpv;
 			vpv.push_back(pv);
 			default_rd_textures[DEFAULT_RD_TEXTURE_3D_WHITE] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}

--- a/servers/visual/rasterizer_rd/rasterizer_storage_rd.h
+++ b/servers/visual/rasterizer_rd/rasterizer_storage_rd.h
@@ -497,8 +497,8 @@ public:
 	/* TEXTURE API */
 
 	virtual RID texture_2d_create(const Ref<Image> &p_image);
-	virtual RID texture_2d_layered_create(const Vector<Ref<Image> > &p_layers, VS::TextureLayeredType p_layered_type);
-	virtual RID texture_3d_create(const Vector<Ref<Image> > &p_slices); //all slices, then all the mipmaps, must be coherent
+	virtual RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, VS::TextureLayeredType p_layered_type);
+	virtual RID texture_3d_create(const Vector<Ref<Image>> &p_slices); //all slices, then all the mipmaps, must be coherent
 	virtual RID texture_proxy_create(RID p_base);
 
 	virtual void _texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer, bool p_immediate);

--- a/servers/visual/rasterizer_rd/shader_compiler_rd.h
+++ b/servers/visual/rasterizer_rd/shader_compiler_rd.h
@@ -40,7 +40,7 @@ class ShaderCompilerRD {
 public:
 	struct IdentifierActions {
 
-		Map<StringName, Pair<int *, int> > render_mode_values;
+		Map<StringName, Pair<int *, int>> render_mode_values;
 		Map<StringName, bool *> render_mode_flags;
 		Map<StringName, bool *> usage_flag_pointers;
 		Map<StringName, bool *> write_flag_pointers;

--- a/servers/visual/rendering_device.h
+++ b/servers/visual/rendering_device.h
@@ -407,7 +407,7 @@ public:
 		}
 	};
 
-	virtual RID texture_create(const TextureFormat &p_format, const TextureView &p_view, const Vector<Vector<uint8_t> > &p_data = Vector<Vector<uint8_t> >()) = 0;
+	virtual RID texture_create(const TextureFormat &p_format, const TextureView &p_view, const Vector<Vector<uint8_t>> &p_data = Vector<Vector<uint8_t>>()) = 0;
 	virtual RID texture_create_shared(const TextureView &p_view, RID p_with_texture) = 0;
 
 	enum TextureSliceType {

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -3038,7 +3038,7 @@ bool ShaderLanguage::_propagate_function_call_sampler_uniform_settings(StringNam
 				arg->tex_argument_check = true;
 				arg->tex_argument_filter = p_filter;
 				arg->tex_argument_repeat = p_repeat;
-				for (Map<StringName, Set<int> >::Element *E = arg->tex_argument_connect.front(); E; E = E->next()) {
+				for (Map<StringName, Set<int>>::Element *E = arg->tex_argument_connect.front(); E; E = E->next()) {
 					for (Set<int>::Element *F = E->get().front(); F; F = F->next()) {
 						if (!_propagate_function_call_sampler_uniform_settings(E->key(), F->get(), p_filter, p_repeat)) {
 							return false;
@@ -3073,7 +3073,7 @@ bool ShaderLanguage::_propagate_function_call_sampler_builtin_reference(StringNa
 				arg->tex_builtin_check = true;
 				arg->tex_builtin = p_builtin;
 
-				for (Map<StringName, Set<int> >::Element *E = arg->tex_argument_connect.front(); E; E = E->next()) {
+				for (Map<StringName, Set<int>>::Element *E = arg->tex_argument_connect.front(); E; E = E->next()) {
 					for (Set<int>::Element *F = E->get().front(); F; F = F->next()) {
 						if (!_propagate_function_call_sampler_builtin_reference(E->key(), F->get(), p_builtin)) {
 							return false;

--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -576,7 +576,7 @@ public:
 			bool tex_builtin_check;
 			StringName tex_builtin;
 
-			Map<StringName, Set<int> > tex_argument_connect;
+			Map<StringName, Set<int>> tex_argument_connect;
 		};
 
 		StringName name;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -151,8 +151,8 @@ public:
 
 	//these go pass-through, as they can be called from any thread
 	BIND1R(RID, texture_2d_create, const Ref<Image> &)
-	BIND2R(RID, texture_2d_layered_create, const Vector<Ref<Image> > &, TextureLayeredType)
-	BIND1R(RID, texture_3d_create, const Vector<Ref<Image> > &)
+	BIND2R(RID, texture_2d_layered_create, const Vector<Ref<Image>> &, TextureLayeredType)
+	BIND1R(RID, texture_3d_create, const Vector<Ref<Image>> &)
 	BIND1R(RID, texture_proxy_create, RID)
 
 	//goes pass-through

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -312,7 +312,7 @@ void VisualServerViewport::draw_viewports() {
 	//sort viewports
 	active_viewports.sort_custom<ViewportSort>();
 
-	Map<int, Vector<Rasterizer::BlitToScreen> > blit_to_screen_list;
+	Map<int, Vector<Rasterizer::BlitToScreen>> blit_to_screen_list;
 	//draw viewports
 	RENDER_TIMESTAMP(">Render Viewports");
 
@@ -415,7 +415,7 @@ void VisualServerViewport::draw_viewports() {
 	//this needs to be called to make screen swapping more efficient
 	VSG::rasterizer->prepare_for_blitting_render_targets();
 
-	for (Map<int, Vector<Rasterizer::BlitToScreen> >::Element *E = blit_to_screen_list.front(); E; E = E->next()) {
+	for (Map<int, Vector<Rasterizer::BlitToScreen>>::Element *E = blit_to_screen_list.front(); E; E = E->next()) {
 		VSG::rasterizer->blit_render_targets_to_screen(E->key(), E->get().ptr(), E->get().size());
 	}
 }

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -79,8 +79,8 @@ public:
 
 	//these go pass-through, as they can be called from any thread
 	virtual RID texture_2d_create(const Ref<Image> &p_image) { return visual_server->texture_2d_create(p_image); }
-	virtual RID texture_2d_layered_create(const Vector<Ref<Image> > &p_layers, TextureLayeredType p_layered_type) { return visual_server->texture_2d_layered_create(p_layers, p_layered_type); }
-	virtual RID texture_3d_create(const Vector<Ref<Image> > &p_slices) { return visual_server->texture_3d_create(p_slices); }
+	virtual RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, TextureLayeredType p_layered_type) { return visual_server->texture_2d_layered_create(p_layers, p_layered_type); }
+	virtual RID texture_3d_create(const Vector<Ref<Image>> &p_slices) { return visual_server->texture_3d_create(p_slices); }
 	virtual RID texture_proxy_create(RID p_base) { return visual_server->texture_proxy_create(p_base); }
 
 	//goes pass-through

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1020,7 +1020,7 @@ Error VisualServer::mesh_create_surface_data_from_arrays(SurfaceData *r_surface_
 	Error err = _surface_set_data(p_arrays, format, offsets, total_elem_size, vertex_array, array_len, index_array, index_array_len, aabb, bone_aabb);
 	ERR_FAIL_COND_V_MSG(err != OK, ERR_INVALID_DATA, "Invalid array format for surface.");
 
-	Vector<Vector<uint8_t> > blend_shape_data;
+	Vector<Vector<uint8_t>> blend_shape_data;
 
 	for (int i = 0; i < p_blend_shapes.size(); i++) {
 
@@ -1517,7 +1517,7 @@ Array VisualServer::mesh_surface_get_blend_shape_arrays(RID p_mesh, int p_surfac
 	SurfaceData sd = mesh_get_surface(p_mesh, p_surface);
 	ERR_FAIL_COND_V(sd.vertex_count == 0, Array());
 
-	Vector<Vector<uint8_t> > blend_shape_data = sd.blend_shapes;
+	Vector<Vector<uint8_t>> blend_shape_data = sd.blend_shapes;
 
 	if (blend_shape_data.size() > 0) {
 		int vertex_len = sd.vertex_count;

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -94,8 +94,8 @@ public:
 	};
 
 	virtual RID texture_2d_create(const Ref<Image> &p_image) = 0;
-	virtual RID texture_2d_layered_create(const Vector<Ref<Image> > &p_layers, TextureLayeredType p_layered_type) = 0;
-	virtual RID texture_3d_create(const Vector<Ref<Image> > &p_slices) = 0; //all slices, then all the mipmaps, must be coherent
+	virtual RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, TextureLayeredType p_layered_type) = 0;
+	virtual RID texture_3d_create(const Vector<Ref<Image>> &p_slices) = 0; //all slices, then all the mipmaps, must be coherent
 	virtual RID texture_proxy_create(RID p_base) = 0;
 
 	virtual void texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0; //mostly used for video and streaming
@@ -262,7 +262,7 @@ public:
 		Vector<LOD> lods;
 		Vector<AABB> bone_aabbs;
 
-		Vector<Vector<uint8_t> > blend_shapes;
+		Vector<Vector<uint8_t>> blend_shapes;
 
 		RID material;
 	};


### PR DESCRIPTION
For us, it practically only changes the fact that `A<A<int>>` is now
used instead of the C++03 compatible `A<A<int> >`.

Note: clang-format 10+ changed the `Standard` arguments to fully
specified `c++11`, `c++14`, etc. versions, but we can't use `c++17`
now if we want to preserve compatibility with clang-format 8 and 9.
`Cpp11` is still supported as deprecated alias for `Latest`.