### PR TITLE
Add ability to export debugger's VRAM usage report (3.2)

### DIFF
--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -110,7 +110,8 @@ private:
 
 	EditorFileDialog *file_dialog;
 	enum FileDialogMode {
-		SAVE_CSV,
+		SAVE_MONITORS_CSV,
+		SAVE_VRAM_CSV,
 		SAVE_NODE,
 	};
 	FileDialogMode file_dialog_mode;
@@ -151,6 +152,7 @@ private:
 
 	Tree *vmem_tree;
 	Button *vmem_refresh;
+	Button *vmem_export;
 	LineEdit *vmem_total;
 
 	Tree *stack_dump;
@@ -196,6 +198,7 @@ private:
 	int _update_scene_tree(TreeItem *parent, const Array &nodes, int current_index);
 
 	void _video_mem_request();
+	void _video_mem_export();
 
 	int _get_node_path_cache(const NodePath &p_path);
 


### PR DESCRIPTION
~~The data rows of the table are exported as tab-delimited lines in a text file.~~ Changed to CSV.

---
**This code is generously donated by IMVU.**