### PR TITLE
Generate command line help text for the `mono` module

### DIFF
--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -9,7 +9,7 @@ def configure(env):
     env.use_ptrcall = True
     env.add_module_version_string('mono')
 
-    from SCons.Script import BoolVariable, PathVariable, Variables
+    from SCons.Script import BoolVariable, PathVariable, Variables, Help
 
     envvars = Variables()
     envvars.Add(PathVariable('mono_prefix', 'Path to the mono installation directory for the target platform and architecture', '', PathVariable.PathAccept))
@@ -18,6 +18,7 @@ def configure(env):
     envvars.Add(BoolVariable('copy_mono_root', 'Make a copy of the mono installation directory to bundle with the editor', False))
     envvars.Add(BoolVariable('xbuild_fallback', 'If MSBuild is not found, fallback to xbuild', False))
     envvars.Update(env)
+    Help(envvars.GenerateHelpText(env))
 
     if env['platform'] == 'javascript':
         # Mono wasm already has zlib builtin, so we need this workaround to avoid symbol collisions


### PR DESCRIPTION
According to https://scons.org/doc/3.1.2/HTML/scons-man.html#f-Help:
> If Help is called multiple times, the text is appended together in the order that Help is called.

So the help text generated in the root `Sconstruct` will not be overridden.

It can be made so that there's no need to manually generate help text for each module. Currently only the `mono` module exposes command line options like that, so [#7: Solutions must be local](http://docs.godotengine.org/en/latest/community/contributing/best_practices_for_engine_contributors.html#solutions-must-be-local). 😛

Can be tested with:
```
scons --help tools=yes target=release_debug module_mono_enabled=yes mono_glue=no
```
Example output:
```
mono_prefix: Path to the mono installation directory for the target platform and architecture ( /path/to/mono_prefix )
    default:
    actual:

mono_static: Statically link mono (yes|no)
    default: False
    actual: False

mono_glue: Build with the mono glue sources (yes|no)
    default: True
    actual: False

copy_mono_root: Make a copy of the mono installation directory to bundle with the editor (yes|no)
    default: False
    actual: False

xbuild_fallback: If MSBuild is not found, fallback to xbuild (yes|no)
    default: False
    actual: False
```