### PR TITLE
Fix visibility enabler flag toggling

### DIFF
--- a/doc/classes/VisibilityEnabler.xml
+++ b/doc/classes/VisibilityEnabler.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		The VisibilityEnabler will disable [RigidBody] and [AnimationPlayer] nodes when they are not visible. It will only affect other nodes within the same scene as the VisibilityEnabler itself.
+		Note that VisibilityEnabler will not affect nodes added after scene initialization.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisibilityEnabler2D.xml
+++ b/doc/classes/VisibilityEnabler2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		The VisibilityEnabler2D will disable [RigidBody2D], [AnimationPlayer], and other nodes when they are not visible. It will only affect nodes with the same root node as the VisibilityEnabler2D, and the root node itself.
+		Note that VisibilityEnabler2D will not affect nodes added after scene initialization.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -188,8 +188,7 @@ void VisibilityEnabler2D::_find_nodes(Node *p_node) {
 	bool add = false;
 	Variant meta;
 
-	if (enabler[ENABLER_FREEZE_BODIES]) {
-
+	{
 		RigidBody2D *rb2d = Object::cast_to<RigidBody2D>(p_node);
 		if (rb2d && ((rb2d->get_mode() == RigidBody2D::MODE_CHARACTER || rb2d->get_mode() == RigidBody2D::MODE_RIGID))) {
 
@@ -198,24 +197,21 @@ void VisibilityEnabler2D::_find_nodes(Node *p_node) {
 		}
 	}
 
-	if (enabler[ENABLER_PAUSE_ANIMATIONS]) {
-
+	{
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 		if (ap) {
 			add = true;
 		}
 	}
 
-	if (enabler[ENABLER_PAUSE_ANIMATED_SPRITES]) {
-
+	{
 		AnimatedSprite *as = Object::cast_to<AnimatedSprite>(p_node);
 		if (as) {
 			add = true;
 		}
 	}
 
-	if (enabler[ENABLER_PAUSE_PARTICLES]) {
-
+	{
 		Particles2D *ps = Object::cast_to<Particles2D>(p_node);
 		if (ps) {
 			add = true;
@@ -278,7 +274,7 @@ void VisibilityEnabler2D::_change_node_state(Node *p_node, bool p_enabled) {
 
 	ERR_FAIL_COND(!nodes.has(p_node));
 
-	{
+	if (enabler[ENABLER_FREEZE_BODIES]) {
 		RigidBody2D *rb = Object::cast_to<RigidBody2D>(p_node);
 		if (rb) {
 
@@ -286,7 +282,7 @@ void VisibilityEnabler2D::_change_node_state(Node *p_node, bool p_enabled) {
 		}
 	}
 
-	{
+	if (enabler[ENABLER_PAUSE_ANIMATIONS]) {
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 
 		if (ap) {
@@ -294,7 +290,8 @@ void VisibilityEnabler2D::_change_node_state(Node *p_node, bool p_enabled) {
 			ap->set_active(p_enabled);
 		}
 	}
-	{
+
+	if (enabler[ENABLER_PAUSE_ANIMATED_SPRITES]) {
 		AnimatedSprite *as = Object::cast_to<AnimatedSprite>(p_node);
 
 		if (as) {
@@ -306,7 +303,7 @@ void VisibilityEnabler2D::_change_node_state(Node *p_node, bool p_enabled) {
 		}
 	}
 
-	{
+	if (enabler[ENABLER_PAUSE_PARTICLES]) {
 		Particles2D *ps = Object::cast_to<Particles2D>(p_node);
 
 		if (ps) {

--- a/scene/3d/visibility_notifier.cpp
+++ b/scene/3d/visibility_notifier.cpp
@@ -150,8 +150,7 @@ void VisibilityEnabler::_find_nodes(Node *p_node) {
 	bool add = false;
 	Variant meta;
 
-	if (enabler[ENABLER_FREEZE_BODIES]) {
-
+	{
 		RigidBody *rb = Object::cast_to<RigidBody>(p_node);
 		if (rb && ((rb->get_mode() == RigidBody::MODE_CHARACTER || rb->get_mode() == RigidBody::MODE_RIGID))) {
 
@@ -160,8 +159,7 @@ void VisibilityEnabler::_find_nodes(Node *p_node) {
 		}
 	}
 
-	if (enabler[ENABLER_PAUSE_ANIMATIONS]) {
-
+	{
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 		if (ap) {
 			add = true;
@@ -219,14 +217,14 @@ void VisibilityEnabler::_change_node_state(Node *p_node, bool p_enabled) {
 
 	ERR_FAIL_COND(!nodes.has(p_node));
 
-	{
+	if (enabler[ENABLER_FREEZE_BODIES]) {
 		RigidBody *rb = Object::cast_to<RigidBody>(p_node);
 		if (rb)
 
 			rb->set_sleeping(!p_enabled);
 	}
 
-	{
+	if (enabler[ENABLER_PAUSE_ANIMATIONS]) {
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 
 		if (ap) {


### PR DESCRIPTION
Fixes #5630

I basically did what https://github.com/godotengine/godot/issues/5630#issuecomment-272749408 says - I add every compatible node to the list and only change their state when related enabler is enabled.

The behavior is still slightly flawed, because nodes added after scene creation are not affected, but I don't think there's an easy way to fix that, so I just added a note to docs.