### PR TITLE
Make stack size on Windows match Linux and MacOS

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -1,6 +1,9 @@
 import methods
 import os
 
+# To match other platforms
+STACK_SIZE = 8388608
+
 
 def is_active():
     return True
@@ -259,6 +262,8 @@ def configure_msvc(env, manual_msvc_config):
     env['BUILDERS']['ProgramOriginal'] = env['BUILDERS']['Program']
     env['BUILDERS']['Program'] = methods.precious_program
 
+    env.AppendUnique(LINKFLAGS=['/STACK:' + str(STACK_SIZE)])
+
 def configure_mingw(env):
     # Workaround for MinGW. See:
     # http://www.scons.org/wiki/LongCmdLinesOnWin32
@@ -351,6 +356,7 @@ def configure_mingw(env):
                 env.Append(CCFLAGS=['-flto'])
                 env.Append(LINKFLAGS=['-flto'])
 
+    env.Append(LINKFLAGS=['-Wl,--stack,' + str(STACK_SIZE)])
 
     ## Compile flags
 


### PR DESCRIPTION
On Linux and MacOS, by default, the system allocates an 8 MiB stack, whereas on Windows (where the linker is the one that sets a size for it) linkers set 1 MiB by default.

This makes the behavior (i.e., reproducibility of stack overflow bugs) more similar across desktop platforms by assigning an 8 MiB stack on Windows as well. Since the memory for it is committed as needed it shouldn't have any negative impact.

---
**This code is generously donated by IMVU.**