### PR TITLE
Add size warning to Viewport Node

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2948,12 +2948,14 @@ Control *Viewport::get_modal_stack_top() const {
 }
 
 String Viewport::get_configuration_warning() const {
-
 	/*if (get_parent() && !Object::cast_to<Control>(get_parent()) && !render_target) {
 
 		return TTR("This viewport is not set as render target. If you intend for it to display its contents directly to the screen, make it a child of a Control so it can obtain a size. Otherwise, make it a RenderTarget and assign its internal texture to some node for display.");
 	}*/
 
+	if (size.x == 0 || size.y == 0) {
+		return TTR("This viewport can't render anything.\nConsider increasing the size.");
+	}
 	return String();
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2954,7 +2954,7 @@ String Viewport::get_configuration_warning() const {
 	}*/
 
 	if (size.x == 0 || size.y == 0) {
-		return TTR("This viewport can't render anything.\nConsider increasing the size.");
+		return TTR("Viewport size must be greater than 0 to render anything.");
 	}
 	return String();
 }


### PR DESCRIPTION
Proposal: https://github.com/godotengine/godot-proposals/issues/590

This adds a configuration warning for invalid viewport sizes.
Cheers!