### PR TITLE
Remove update condition from LineEdit::update_placeholder_width

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1710,13 +1710,11 @@ void LineEdit::update_cached_width() {
 }
 
 void LineEdit::update_placeholder_width() {
-	if ((max_length <= 0) || (placeholder_translated.length() <= max_length)) {
-		Ref<Font> font = get_font("font");
-		cached_placeholder_width = 0;
-		if (font != NULL) {
-			for (int i = 0; i < placeholder_translated.length(); i++) {
-				cached_placeholder_width += font->get_char_size(placeholder_translated[i]).width;
-			}
+	Ref<Font> font = get_font("font");
+	cached_placeholder_width = 0;
+	if (font != NULL) {
+		for (int i = 0; i < placeholder_translated.length(); i++) {
+			cached_placeholder_width += font->get_char_size(placeholder_translated[i]).width;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #37120 
Placeholder with length greater than `max_length` are allowed, so there is no reason for those update condition.
It fixes the odd alignment of placeholder when it's length is greater than `max_length`
* Before
![before](https://user-images.githubusercontent.com/37181756/76900777-ff54a100-68bf-11ea-90d3-a79368a13705.png)
* After
![after](https://user-images.githubusercontent.com/37181756/76900799-0b406300-68c0-11ea-9abd-82ec0aa74a5b.png)

