### PR TITLE
Removed unused code in android detect.py and SCsub

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-from detect import get_ndk_version
-from distutils.version import LooseVersion
-
 Import('env')
 
 android_files = [

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -164,7 +164,6 @@ def configure(env):
         env.Tool('gcc')
         env.use_windows_spawn_fix()
 
-    mt_link = True
     if (sys.platform.startswith("linux")):
         host_subpath = "linux-x86_64"
     elif (sys.platform.startswith("darwin")):
@@ -173,11 +172,7 @@ def configure(env):
         if (platform.machine().endswith('64')):
             host_subpath = "windows-x86_64"
         else:
-            mt_link = False
             host_subpath = "windows"
-
-    if env["android_arch"] == "arm64v8":
-        mt_link = False
 
     compiler_path = env["ANDROID_NDK_ROOT"] + "/toolchains/llvm/prebuilt/" + host_subpath + "/bin"
     gcc_toolchain_path = env["ANDROID_NDK_ROOT"] + "/toolchains/" + target_subpath + "/prebuilt/" + host_subpath


### PR DESCRIPTION
Removed unused code in android detect.py and SCsub.
These became useless after support for NDK < r15 was dropped in https://github.com/godotengine/godot/pull/30967.