### PR TITLE
C#: Fix uses of old Configuration names

### DIFF
--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -49,13 +49,13 @@ namespace GodotSharpDirs {
 
 String _get_expected_build_config() {
 #ifdef TOOLS_ENABLED
-	return "Tools";
+	return "Debug";
 #else
 
 #ifdef DEBUG_ENABLED
-	return "Debug";
+	return "ExportDebug";
 #else
-	return "Release";
+	return "ExportRelease";
 #endif
 
 #endif

--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -78,7 +78,7 @@ void GDMonoAssembly::fill_search_dirs(Vector<String> &r_search_dirs, const Strin
 	if (p_custom_config.empty()) {
 		r_search_dirs.push_back(GodotSharpDirs::get_res_assemblies_dir());
 	} else {
-		String api_config = p_custom_config == "Release" ? "Release" : "Debug";
+		String api_config = p_custom_config == "ExportRelease" ? "Release" : "Debug";
 		r_search_dirs.push_back(GodotSharpDirs::get_res_assemblies_base_dir().plus_file(api_config));
 	}
 


### PR DESCRIPTION
Looks like I forgot to replace these in 1b634785b50a8be5ff6f06feeb13726750115615, even though I could swear I did :confused: 

Fixes #37128
