### PR TITLE
Editor 2D: Change pixel alignment strategy, fix jittering in high zoom

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4306,10 +4306,20 @@ void CanvasItemEditor::_zoom_on_position(float p_zoom, Point2 p_position) {
 
 	float prev_zoom = zoom;
 	zoom = p_zoom;
-	Point2 ofs = p_position;
-	ofs = ofs / prev_zoom - ofs / zoom;
-	view_offset.x = Math::round(view_offset.x + ofs.x);
-	view_offset.y = Math::round(view_offset.y + ofs.y);
+
+	view_offset += p_position / prev_zoom - p_position / zoom;
+
+	// We want to align in-scene pixels to screen pixels, this prevents blurry rendering
+	// in small details (texts, lines).
+	// This correction adds a jitter movement when zooming, so we correct only when the
+	// zoom factor is an integer. (in the other cases, all pixels won't be aligned anyway)
+	float closest_zoom_factor = Math::round(zoom);
+	if (Math::is_zero_approx(zoom - closest_zoom_factor)) {
+		// make sure scene pixel at view_offset is aligned on a screen pixel
+		Vector2 view_offset_int = view_offset.floor();
+		Vector2 view_offset_frac = view_offset - view_offset_int;
+		view_offset = view_offset_int + (view_offset_frac * closest_zoom_factor).round() / closest_zoom_factor;
+	}
 
 	_update_zoom_label();
 	update_viewport();


### PR DESCRIPTION

There is a small jittering on the camera position when we zoom on the 2D editor.
The cause is the rounding of the viewport offset done to align scene pixels to screen pixels.
In other words, a scene pixel is always aligned on the top left screen pixel.
At high zoom, it represents a huge correction in the order of half the zoom factor in pixel, so ~50 px at max scale.
 
This alignment correction was added to the zoom algo to prevent the situation where text is blurry at 100% because of a subpixel offset (screen pixel doesn't match a scene pixel). but it introduced that jittering.

I propose this changes that allow a scene pixel to land on the closest screen pixel, not only the top left pixel of the viewport.

By doing so, the pixel correction is still there, but always smaller than 0.5 pixel on all axis, which drastically reduce the jitterring at high zoom.
Now, the zoom is really centered on the mouse, not moving around, which is nice :)

_commit:_
> Alignment of scene pixels on screen pixel ensure a crisp rendering of small features (such as text). Unfortunately, alignment of top left pixel on screen adds a lot of jittering when zooming at high zoom factor.
> 
> This change allow to snap the top left scene pixel on the closest screen pixel (not only the top-left most), and we do so only when the scale factor is an integer.
