### PR TITLE
Fixes transform gizmo position when node has default transform

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2419,9 +2419,10 @@ void SpatialEditorViewport::_notification(int p_what) {
 			Transform t = sp->get_global_gizmo_transform();
 
 			exist = true;
-			if (se->last_xform == t)
+			if (se->last_xform == t && !se->last_xform_dirty)
 				continue;
 			changed = true;
+			se->last_xform_dirty = false;
 			se->last_xform = t;
 
 			VisualInstance *vi = Object::cast_to<VisualInstance>(sp);

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -482,10 +482,14 @@ public:
 	Transform original; // original location when moving
 	Transform original_local;
 	Transform last_xform; // last transform
+	bool last_xform_dirty;
 	Spatial *sp;
 	RID sbox_instance;
 
-	SpatialEditorSelectedItem() { sp = NULL; }
+	SpatialEditorSelectedItem() {
+		sp = NULL;
+		last_xform_dirty = true;
+	}
 	~SpatialEditorSelectedItem();
 };
 


### PR DESCRIPTION
Fixes #37138
`SpatialEditorSelectedItem`'s `last_xform` is default on initialization so `SpatialEditorViewport` skips the selected node because it has default value of transform.
This PR added an extra dirty flag `last_xform_dirty` that makes `SpatialEditorViewport` to not skip the selected node when `last_xform` is at initialized value.