### PR TITLE
Fix CSG vertex normal calculation.

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -296,20 +296,18 @@ void CSGShape::_update_shape() {
 		int mat = n->faces[i].material;
 		ERR_CONTINUE(mat < -1 || mat >= face_count.size());
 		int idx = mat == -1 ? face_count.size() - 1 : mat;
-		if (n->faces[i].smooth) {
 
-			Plane p(n->faces[i].vertices[0], n->faces[i].vertices[1], n->faces[i].vertices[2]);
+		Plane p(n->faces[i].vertices[0], n->faces[i].vertices[1], n->faces[i].vertices[2]);
 
-			for (int j = 0; j < 3; j++) {
-				Vector3 v = n->faces[i].vertices[j];
-				Vector3 add;
-				if (vec_map.lookup(v, add)) {
-					add += p.normal;
-				} else {
-					add = p.normal;
-				}
-				vec_map.set(v, add);
+		for (int j = 0; j < 3; j++) {
+			Vector3 v = n->faces[i].vertices[j];
+			Vector3 add;
+			if (vec_map.lookup(v, add)) {
+				add += p.normal;
+			} else {
+				add = p.normal;
 			}
+			vec_map.set(v, add);
 		}
 
 		face_count.write[idx]++;


### PR DESCRIPTION
While investigating #24111, I noticed that when calculating the vertex's normal, the current implementation excludes faces not marked as smooth.

Whether or not a face's vertices should use the face's normal or the average normal for all faces attached to the vertex should not affect the calculation of the average normal for all the faces attached to the vertex.

Note: vertices of faces not marked as smooth are correctly assigned their faces' normal here:
https://github.com/godotengine/godot/blob/3b1c04550f9341856b1e94cda05a50eaebb3d35e/modules/csg/csg_shape.cpp#L380-L390
So faces not marked as smooth ignore this calculation.