### PR TITLE
i18n: Add support for translating the class reference

### DIFF
--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -33,7 +33,7 @@
 #include "core/os/file_access.h"
 #include "core/translation.h"
 
-RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const String &p_path) {
+RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 
 	enum Status {
 
@@ -67,7 +67,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const S
 
 			if (status == STATUS_READING_ID) {
 				memdelete(f);
-				ERR_FAIL_V_MSG(RES(), p_path + ":" + itos(line) + " Unexpected EOF while reading 'msgid' at file: ");
+				ERR_FAIL_V_MSG(RES(), f->get_path() + ":" + itos(line) + " Unexpected EOF while reading 'msgid' at file: ");
 			} else {
 				break;
 			}
@@ -78,7 +78,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const S
 			if (status == STATUS_READING_ID) {
 
 				memdelete(f);
-				ERR_FAIL_V_MSG(RES(), p_path + ":" + itos(line) + " Unexpected 'msgid', was expecting 'msgstr' while parsing: ");
+				ERR_FAIL_V_MSG(RES(), f->get_path() + ":" + itos(line) + " Unexpected 'msgid', was expecting 'msgstr' while parsing: ");
 			}
 
 			if (msg_id != "") {
@@ -100,7 +100,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const S
 			if (status != STATUS_READING_ID) {
 
 				memdelete(f);
-				ERR_FAIL_V_MSG(RES(), p_path + ":" + itos(line) + " Unexpected 'msgstr', was expecting 'msgid' while parsing: ");
+				ERR_FAIL_V_MSG(RES(), f->get_path() + ":" + itos(line) + " Unexpected 'msgstr', was expecting 'msgid' while parsing: ");
 			}
 
 			l = l.substr(6, l.length()).strip_edges();
@@ -115,7 +115,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const S
 			continue; //nothing to read or comment
 		}
 
-		ERR_FAIL_COND_V_MSG(!l.begins_with("\"") || status == STATUS_NONE, RES(), p_path + ":" + itos(line) + " Invalid line '" + l + "' while parsing: ");
+		ERR_FAIL_COND_V_MSG(!l.begins_with("\"") || status == STATUS_NONE, RES(), f->get_path() + ":" + itos(line) + " Invalid line '" + l + "' while parsing: ");
 
 		l = l.substr(1, l.length());
 		//find final quote
@@ -128,7 +128,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const S
 			}
 		}
 
-		ERR_FAIL_COND_V_MSG(end_pos == -1, RES(), p_path + ":" + itos(line) + " Expected '\"' at end of message while parsing file: ");
+		ERR_FAIL_COND_V_MSG(end_pos == -1, RES(), f->get_path() + ":" + itos(line) + " Expected '\"' at end of message while parsing file: ");
 
 		l = l.substr(0, end_pos);
 		l = l.c_unescape();
@@ -153,7 +153,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error, const S
 			config = msg_str;
 	}
 
-	ERR_FAIL_COND_V_MSG(config == "", RES(), "No config found in file: " + p_path + ".");
+	ERR_FAIL_COND_V_MSG(config == "", RES(), "No config found in file: " + f->get_path() + ".");
 
 	Vector<String> configs = config.split("\n");
 	for (int i = 0; i < configs.size(); i++) {

--- a/core/io/translation_loader_po.h
+++ b/core/io/translation_loader_po.h
@@ -37,7 +37,7 @@
 
 class TranslationLoaderPO : public ResourceFormatLoader {
 public:
-	static RES load_translation(FileAccess *f, Error *r_error, const String &p_path = String());
+	static RES load_translation(FileAccess *f, Error *r_error = NULL);
 	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = NULL, bool p_use_sub_threads = false, float *r_progress = nullptr);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;

--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -1176,7 +1176,6 @@ void TranslationServer::setup() {
 		set_locale(OS::get_singleton()->get_locale());
 	fallback = GLOBAL_DEF("locale/fallback", "en");
 #ifdef TOOLS_ENABLED
-
 	{
 		String options = "";
 		int idx = 0;
@@ -1189,7 +1188,6 @@ void TranslationServer::setup() {
 		ProjectSettings::get_singleton()->set_custom_property_info("locale/fallback", PropertyInfo(Variant::STRING, "locale/fallback", PROPERTY_HINT_ENUM, options));
 	}
 #endif
-	//load translations
 }
 
 void TranslationServer::set_tool_translation(const Ref<Translation> &p_translation) {
@@ -1197,15 +1195,26 @@ void TranslationServer::set_tool_translation(const Ref<Translation> &p_translati
 }
 
 StringName TranslationServer::tool_translate(const StringName &p_message) const {
-
 	if (tool_translation.is_valid()) {
 		StringName r = tool_translation->get_message(p_message);
-
 		if (r) {
 			return r;
 		}
 	}
+	return p_message;
+}
 
+void TranslationServer::set_doc_translation(const Ref<Translation> &p_translation) {
+	doc_translation = p_translation;
+}
+
+StringName TranslationServer::doc_translate(const StringName &p_message) const {
+	if (doc_translation.is_valid()) {
+		StringName r = doc_translation->get_message(p_message);
+		if (r) {
+			return r;
+		}
+	}
 	return p_message;
 }
 

--- a/core/translation.h
+++ b/core/translation.h
@@ -73,6 +73,7 @@ class TranslationServer : public Object {
 
 	Set<Ref<Translation>> translations;
 	Ref<Translation> tool_translation;
+	Ref<Translation> doc_translation;
 
 	Map<String, String> locale_name_map;
 
@@ -109,6 +110,8 @@ public:
 
 	void set_tool_translation(const Ref<Translation> &p_translation);
 	StringName tool_translate(const StringName &p_message) const;
+	void set_doc_translation(const Ref<Translation> &p_translation);
+	StringName doc_translate(const StringName &p_message) const;
 
 	void setup();
 

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -4412,7 +4412,6 @@ String String::unquote() const {
 
 #ifdef TOOLS_ENABLED
 String TTR(const String &p_text) {
-
 	if (TranslationServer::get_singleton()) {
 		return TranslationServer::get_singleton()->tool_translate(p_text);
 	}
@@ -4420,10 +4419,18 @@ String TTR(const String &p_text) {
 	return p_text;
 }
 
+String DTR(const String &p_text) {
+	if (TranslationServer::get_singleton()) {
+		// Comes straight from the XML, so remove indentation and any trailing whitespace.
+		const String text = p_text.dedent().strip_edges();
+		return TranslationServer::get_singleton()->doc_translate(text);
+	}
+
+	return p_text;
+}
 #endif
 
 String RTR(const String &p_text) {
-
 	if (TranslationServer::get_singleton()) {
 		String rtr = TranslationServer::get_singleton()->tool_translate(p_text);
 		if (rtr == String() || rtr == p_text) {

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -415,25 +415,25 @@ _FORCE_INLINE_ bool is_str_less(const L *l_ptr, const R *r_ptr) {
 
 /* end of namespace */
 
-//tool translate
+// Tool translate (TTR and variants) for the editor UI,
+// and doc translate for the class reference (DTR).
 #ifdef TOOLS_ENABLED
-
-//gets parsed
+// Gets parsed.
 String TTR(const String &);
-//use for C strings
+String DTR(const String &);
+// Use for C strings.
 #define TTRC(m_value) (m_value)
-//use to avoid parsing (for use later with C strings)
+// Use to avoid parsing (for use later with C strings).
 #define TTRGET(m_value) TTR(m_value)
 
 #else
-
 #define TTR(m_value) (String())
+#define DTR(m_value) (String())
 #define TTRC(m_value) (m_value)
 #define TTRGET(m_value) (m_value)
-
 #endif
 
-//tool or regular translate
+// Runtime translate for the public node API.
 String RTR(const String &);
 
 bool is_symbol(CharType c);

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -66,10 +66,15 @@ if env['tools']:
 
     path = env.Dir('.').abspath
 
-    # Translations
+    # Editor translations
     tlist = glob.glob(path + "/translations/*.po")
-    env.Depends('#editor/translations.gen.h', tlist)
-    env.CommandNoCache('#editor/translations.gen.h', tlist, run_in_subprocess(editor_builders.make_translations_header))
+    env.Depends('#editor/editor_translations.gen.h', tlist)
+    env.CommandNoCache('#editor/editor_translations.gen.h', tlist, run_in_subprocess(editor_builders.make_editor_translations_header))
+
+    # Documentation translations
+    tlist = glob.glob(env.Dir("#doc").abspath + "/translations/*.po")
+    env.Depends('#editor/doc_translations.gen.h', tlist)
+    env.CommandNoCache('#editor/doc_translations.gen.h', tlist, run_in_subprocess(editor_builders.make_doc_translations_header))
 
     # Fonts
     flist = glob.glob(path + "/../thirdparty/fonts/*.ttf")

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -992,7 +992,7 @@ void ConnectionsDock::update_tree() {
 					while (F && descr == String()) {
 						for (int i = 0; i < F->get().signals.size(); i++) {
 							if (F->get().signals[i].name == signal_name.operator String()) {
-								descr = F->get().signals[i].description.strip_edges();
+								descr = DTR(F->get().signals[i].description.strip_edges());
 								break;
 							}
 						}

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -248,7 +248,7 @@ void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p
 		item->set_collapsed(collapse);
 	}
 
-	const String &description = EditorHelp::get_doc_data()->class_list[p_type].brief_description;
+	const String &description = DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description);
 	item->set_tooltip(0, description);
 
 	item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, base_type));
@@ -556,7 +556,7 @@ void CreateDialog::_item_selected() {
 	if (!EditorHelp::get_doc_data()->class_list.has(name))
 		return;
 
-	help_bit->set_text(EditorHelp::get_doc_data()->class_list[name].brief_description);
+	help_bit->set_text(DTR(EditorHelp::get_doc_data()->class_list[name].brief_description));
 
 	get_ok()->set_disabled(false);
 }

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -73,15 +73,15 @@ def make_fonts_header(target, source, env):
     g.close()
 
 
-def make_translations_header(target, source, env):
+def make_translations_header(target, source, env, category):
 
     dst = target[0]
 
     g = open_utf8(dst, "w")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-    g.write("#ifndef _EDITOR_TRANSLATIONS_H\n")
-    g.write("#define _EDITOR_TRANSLATIONS_H\n")
+    g.write("#ifndef _{}_TRANSLATIONS_H\n".format(category.upper()))
+    g.write("#define _{}_TRANSLATIONS_H\n".format(category.upper()))
 
     import zlib
     import os.path
@@ -96,7 +96,7 @@ def make_translations_header(target, source, env):
         buf = zlib.compress(buf)
         name = os.path.splitext(os.path.basename(sorted_paths[i]))[0]
 
-        g.write("static const unsigned char _translation_" + name + "_compressed[] = {\n")
+        g.write("static const unsigned char _{}_translation_{}_compressed[] = {{\n".format(category, name))
         for j in range(len(buf)):
             g.write("\t" + byte_to_str(buf[j]) + ",\n")
 
@@ -104,21 +104,30 @@ def make_translations_header(target, source, env):
 
         xl_names.append([name, len(buf), str(decomp_size)])
 
-    g.write("struct EditorTranslationList {\n")
+    g.write("struct {}TranslationList {{\n".format(category.capitalize()))
     g.write("\tconst char* lang;\n")
     g.write("\tint comp_size;\n")
     g.write("\tint uncomp_size;\n")
     g.write("\tconst unsigned char* data;\n")
     g.write("};\n\n")
-    g.write("static EditorTranslationList _editor_translations[] = {\n")
+    g.write("static {}TranslationList _{}_translations[] = {{\n".format(category.capitalize(), category))
     for x in xl_names:
-        g.write("\t{ \"" + x[0] + "\", " + str(x[1]) + ", " + str(x[2]) + ", _translation_" + x[0] + "_compressed},\n")
+        g.write("\t{{ \"{}\", {}, {}, _{}_translation_{}_compressed }},\n".format(x[0], str(x[1]), str(x[2]), category, x[0]))
     g.write("\t{NULL, 0, 0, NULL}\n")
     g.write("};\n")
 
     g.write("#endif")
 
     g.close()
+
+
+def make_editor_translations_header(target, source, env):
+    make_translations_header(target, source, env, "editor")
+
+
+def make_doc_translations_header(target, source, env):
+    make_translations_header(target, source, env, "doc")
+
 
 if __name__ == '__main__':
     subprocess_main(globals())

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -433,7 +433,7 @@ void EditorHelp::_update_doc() {
 		class_desc->push_color(text_color);
 		class_desc->push_font(doc_bold_font);
 		class_desc->push_indent(1);
-		_add_text(cd.brief_description);
+		_add_text(DTR(cd.brief_description));
 		class_desc->pop();
 		class_desc->pop();
 		class_desc->pop();
@@ -458,7 +458,7 @@ void EditorHelp::_update_doc() {
 		class_desc->push_color(text_color);
 		class_desc->push_font(doc_font);
 		class_desc->push_indent(1);
-		_add_text(cd.description);
+		_add_text(DTR(cd.description));
 		class_desc->pop();
 		class_desc->pop();
 		class_desc->pop();
@@ -480,7 +480,7 @@ void EditorHelp::_update_doc() {
 		class_desc->add_newline();
 
 		for (int i = 0; i < cd.tutorials.size(); i++) {
-			const String link = cd.tutorials[i];
+			const String link = DTR(cd.tutorials[i]);
 			String linktxt = link;
 			const int seppos = linktxt.find("//");
 			if (seppos != -1) {
@@ -726,7 +726,7 @@ void EditorHelp::_update_doc() {
 				class_desc->push_font(doc_font);
 				class_desc->add_text("  ");
 				class_desc->push_color(comment_color);
-				_add_text(cd.theme_properties[i].description);
+				_add_text(DTR(cd.theme_properties[i].description));
 				class_desc->pop();
 				class_desc->pop();
 			}
@@ -796,7 +796,7 @@ void EditorHelp::_update_doc() {
 				class_desc->push_font(doc_font);
 				class_desc->push_color(comment_color);
 				class_desc->push_indent(1);
-				_add_text(cd.signals[i].description);
+				_add_text(DTR(cd.signals[i].description));
 				class_desc->pop(); // indent
 				class_desc->pop();
 				class_desc->pop(); // font
@@ -893,7 +893,7 @@ void EditorHelp::_update_doc() {
 						//class_desc->add_text("  ");
 						class_desc->push_indent(1);
 						class_desc->push_color(comment_color);
-						_add_text(enum_list[i].description);
+						_add_text(DTR(enum_list[i].description));
 						class_desc->pop();
 						class_desc->pop();
 						class_desc->pop(); // indent
@@ -959,7 +959,7 @@ void EditorHelp::_update_doc() {
 					class_desc->push_font(doc_font);
 					class_desc->push_indent(1);
 					class_desc->push_color(comment_color);
-					_add_text(constants[i].description);
+					_add_text(DTR(constants[i].description));
 					class_desc->pop();
 					class_desc->pop();
 					class_desc->pop(); // indent
@@ -1070,7 +1070,7 @@ void EditorHelp::_update_doc() {
 			class_desc->push_font(doc_font);
 			class_desc->push_indent(1);
 			if (cd.properties[i].description.strip_edges() != String()) {
-				_add_text(cd.properties[i].description);
+				_add_text(DTR(cd.properties[i].description));
 			} else {
 				class_desc->add_image(get_icon("Error", "EditorIcons"));
 				class_desc->add_text(" ");
@@ -1123,7 +1123,7 @@ void EditorHelp::_update_doc() {
 				class_desc->push_font(doc_font);
 				class_desc->push_indent(1);
 				if (methods_filtered[i].description.strip_edges() != String()) {
-					_add_text(methods_filtered[i].description);
+					_add_text(DTR(methods_filtered[i].description));
 				} else {
 					class_desc->add_image(get_icon("Error", "EditorIcons"));
 					class_desc->add_text(" ");
@@ -1449,7 +1449,6 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 }
 
 void EditorHelp::_add_text(const String &p_bbcode) {
-
 	_add_text_to_rt(p_bbcode, class_desc);
 }
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1551,7 +1551,7 @@ void EditorInspector::update_tree() {
 					if (E) {
 						descr = E->get().brief_description;
 					}
-					class_descr_cache[type2] = descr;
+					class_descr_cache[type2] = DTR(descr);
 				}
 
 				category->set_tooltip(p.name + "::" + (class_descr_cache[type2] == "" ? "" : class_descr_cache[type2]));
@@ -1703,7 +1703,7 @@ void EditorInspector::update_tree() {
 				while (F && descr == String()) {
 					for (int i = 0; i < F->get().properties.size(); i++) {
 						if (F->get().properties[i].name == propname.operator String()) {
-							descr = F->get().properties[i].description.strip_edges();
+							descr = DTR(F->get().properties[i].description.strip_edges());
 							break;
 						}
 					}
@@ -1713,7 +1713,7 @@ void EditorInspector::update_tree() {
 						// Likely a theme property.
 						for (int i = 0; i < F->get().theme_properties.size(); i++) {
 							if (F->get().theme_properties[i].name == slices[1]) {
-								descr = F->get().theme_properties[i].description.strip_edges();
+								descr = DTR(F->get().theme_properties[i].description.strip_edges());
 								break;
 							}
 						}

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -44,8 +44,9 @@
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "core/version.h"
+#include "editor/doc_translations.gen.h"
 #include "editor/editor_node.h"
-#include "editor/translations.gen.h"
+#include "editor/editor_translations.gen.h"
 #include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/viewport.h"
@@ -982,14 +983,12 @@ void EditorSettings::setup_language() {
 
 	String lang = get("interface/editor/editor_language");
 	if (lang == "en")
-		return; //none to do
+		return; // Default, nothing to do.
 
+	// Load editor translation for configured/detected locale.
 	EditorTranslationList *etl = _editor_translations;
-
 	while (etl->data) {
-
 		if (etl->lang == lang) {
-
 			Vector<uint8_t> data;
 			data.resize(etl->uncomp_size);
 			Compression::decompress(data.ptrw(), etl->uncomp_size, etl->data, etl->comp_size, Compression::MODE_DEFLATE);
@@ -997,7 +996,7 @@ void EditorSettings::setup_language() {
 			FileAccessMemory *fa = memnew(FileAccessMemory);
 			fa->open_custom(data.ptr(), data.size());
 
-			Ref<Translation> tr = TranslationLoaderPO::load_translation(fa, NULL, "translation_" + String(etl->lang));
+			Ref<Translation> tr = TranslationLoaderPO::load_translation(fa);
 
 			if (tr.is_valid()) {
 				tr->set_locale(etl->lang);
@@ -1007,6 +1006,29 @@ void EditorSettings::setup_language() {
 		}
 
 		etl++;
+	}
+
+	// Load class reference translation.
+	DocTranslationList *dtl = _doc_translations;
+	while (dtl->data) {
+		if (dtl->lang == lang) {
+			Vector<uint8_t> data;
+			data.resize(dtl->uncomp_size);
+			Compression::decompress(data.ptrw(), dtl->uncomp_size, dtl->data, dtl->comp_size, Compression::MODE_DEFLATE);
+
+			FileAccessMemory *fa = memnew(FileAccessMemory);
+			fa->open_custom(data.ptr(), data.size());
+
+			Ref<Translation> tr = TranslationLoaderPO::load_translation(fa);
+
+			if (tr.is_valid()) {
+				tr->set_locale(dtl->lang);
+				TranslationServer::get_singleton()->set_doc_translation(tr);
+				break;
+			}
+		}
+
+		dtl++;
 	}
 }
 


### PR DESCRIPTION
- Parse `.po` files from `doc/translations/*.po` like already done
  with `editor/translations/*.po`.
- Add logic to register a doc translation mapping in `TranslationServer`
  and `EditorSettings`.
- Add `DTR()` to lookup the doc translation mapping (similar to `TTR()`).
- Use `DTR()` to translate relevant strings in `EditorHelp`.
- Small simplification to `TranslationLoaderPO`, the path argument was
  not really meaningful.

Depends on #37114 to actually generate the translation catalog and start collecting doc translations on Weblate.

![Screenshot_20200319_135713](https://user-images.githubusercontent.com/4701338/77069898-8a7d8600-69e9-11ea-901d-0ce48a6be592.png)