### PR TITLE
Makes shader 'TIME' available in custom functions by default

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -6284,6 +6284,12 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 					builtin_types = p_functions[name].built_ins;
 				}
 
+				if (p_functions.has("global")) { // Adds global variables: 'TIME'
+					for (Map<StringName, BuiltInInfo>::Element *E = p_functions["global"].built_ins.front(); E; E = E->next()) {
+						builtin_types.insert(E->key(), E->value());
+					}
+				}
+
 				ShaderNode::Function function;
 
 				function.callable = !p_functions.has(name);

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -56,6 +56,8 @@ ShaderTypes::ShaderTypes() {
 
 	/*************** SPATIAL ***********************/
 
+	shader_modes[VS::SHADER_SPATIAL].functions["global"].built_ins["TIME"] = constt(ShaderLanguage::TYPE_FLOAT);
+
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["VERTEX"] = ShaderLanguage::TYPE_VEC3;
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["NORMAL"] = ShaderLanguage::TYPE_VEC3;
 	shader_modes[VS::SHADER_SPATIAL].functions["vertex"].built_ins["TANGENT"] = ShaderLanguage::TYPE_VEC3;
@@ -200,6 +202,8 @@ ShaderTypes::ShaderTypes() {
 
 	/************ CANVAS ITEM **************************/
 
+	shader_modes[VS::SHADER_CANVAS_ITEM].functions["global"].built_ins["TIME"] = constt(ShaderLanguage::TYPE_FLOAT);
+
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["VERTEX"] = ShaderLanguage::TYPE_VEC2;
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["UV"] = ShaderLanguage::TYPE_VEC2;
 	shader_modes[VS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["COLOR"] = ShaderLanguage::TYPE_VEC4;
@@ -267,6 +271,7 @@ ShaderTypes::ShaderTypes() {
 
 	/************ PARTICLES **************************/
 
+	shader_modes[VS::SHADER_PARTICLES].functions["global"].built_ins["TIME"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[VS::SHADER_PARTICLES].functions["vertex"].built_ins["COLOR"] = ShaderLanguage::TYPE_VEC4;
 	shader_modes[VS::SHADER_PARTICLES].functions["vertex"].built_ins["VELOCITY"] = ShaderLanguage::TYPE_VEC3;
 	shader_modes[VS::SHADER_PARTICLES].functions["vertex"].built_ins["MASS"] = ShaderLanguage::TYPE_FLOAT;


### PR DESCRIPTION
Makes TIME available in custom shader functions without passing it as a parameter.

![image](https://user-images.githubusercontent.com/3036176/77081605-f07b0500-6a0b-11ea-97c9-ba2a0550f7a0.png)

I think this also would significantly decrease the time for adapting shaders from ShaderToy 😃 