### PR TITLE
Changed the title of change node type dialog

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -38,7 +38,7 @@
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 
-void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_select_type) {
+void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_select_type, const String &p_select_name) {
 	_fill_type_list();
 
 	icon_fallback = search_options->has_theme_icon(base_type, SNAME("EditorIcons")) ? base_type : "Object";
@@ -57,7 +57,11 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 	_update_search();
 
 	if (p_replace_mode) {
-		set_title(vformat(TTR("Change %s Type"), base_type));
+		if (!p_select_name.is_empty()) {
+			set_title(vformat(TTR("Convert %s from %s"), p_select_name, p_select_type));
+		} else {
+			set_title(vformat(TTR("Convert %s"), p_select_type));
+		}
 		set_ok_button_text(TTR("Change"));
 	} else {
 		set_title(vformat(TTR("Create New %s"), base_type));

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -120,7 +120,7 @@ public:
 	void set_preferred_search_result_type(const String &p_preferred_type) { preferred_search_result_type = p_preferred_type; }
 	String get_preferred_search_result_type() { return preferred_search_result_type; }
 
-	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_select_type = "Node");
+	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_select_type = "Node", const String &p_select_name = "");
 
 	CreateDialog();
 };

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -510,9 +510,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			if (selected) {
-				create_dialog->popup_create(false, true, selected->get_class());
+				create_dialog->popup_create(false, true, selected->get_class(), selected->get_name());
 			}
-
 		} break;
 		case TOOL_EXTEND_SCRIPT: {
 			attach_script_to_selected(true);

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -2936,7 +2936,7 @@ Control *VisualScriptEditor::get_edit_menu() {
 }
 
 void VisualScriptEditor::_change_base_type() {
-	select_base_type->popup_create(true, true);
+	select_base_type->popup_create(true, true, script->get_instance_base_type());
 }
 
 void VisualScriptEditor::_toggle_tool_script() {


### PR DESCRIPTION
Fixes #36831
The title of 'change node type' dialog was ambiguous. Now it reads `Convert Node from NodeType`, where Node is the selected node's name and NodeType is the selected node's type. This title is much more clear than the previous one, which was `Change Node Type`. This way, users can have more clarity about the node and its type that they're changing/replacing.
**Code Modification:-**
A default parameter to store the selected node's name is added, whose default value is `""`(empty string), to the function `popup_create()` in the `CreateDialog` class. 
Looking at the call hierarchy of this function, this modification is consistent with the functions it is being called from.