### PR TITLE
Fixed the auto-completion bug in gdscript_editor

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2150,7 +2150,7 @@ static void _find_identifiers(const GDScriptCompletionContext &p_context, bool p
 	}
 
 	const GDScriptParser::ClassNode *clss = p_context._class;
-	bool _static = !p_context.function || p_context.function->_static;
+	bool _static = p_context.function && p_context.function->_static;
 
 	while (clss) {
 		GDScriptCompletionContext c = p_context;


### PR DESCRIPTION
Issue referenced #37119 
**Bug:-**  `properties` wouldn't appear in auto-complete list when typing was done outside a function.
The reason was `bool _static` in `gdscript_editor` was calculated by checking if the `parser` node was inside a `function` . But this condition failed when the `parser` was outside a `function` , leading to wrong `bool` value in `_static`.
**Fix:-** Now the value for `_static` is calculated considering if the `parser` is inside a `function` or not.
**Result:-** `properties` are now listed in auto-complete list when typing outside a function.

*Bugsquad edit:* Fixes #37119.