### PR TITLE
[3.2] Update the naming scheme for the GodotPlugin's methods

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -291,12 +291,12 @@ public abstract class Godot extends FragmentActivity implements SensorEventListe
 	};
 
 	/**
-	 * Invoked on the GL thread when the Godot main loop has started.
+	 * Invoked on the render thread when the Godot main loop has started.
 	 */
 	@CallSuper
-	protected void onGLGodotMainLoopStarted() {
+	protected void onGodotMainLoopStarted() {
 		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
-			plugin.onGLGodotMainLoopStarted();
+			plugin.onGodotMainLoopStarted();
 		}
 	}
 
@@ -343,7 +343,7 @@ public abstract class Godot extends FragmentActivity implements SensorEventListe
 
 				// Must occur after GodotLib.setup has completed.
 				for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
-					plugin.onGLRegisterPluginWithGodotNative();
+					plugin.onRegisterPluginWithGodotNative();
 				}
 
 				setKeepScreenOn("True".equals(GodotLib.getGlobal("display/window/energy_saving/keep_screen_on")));
@@ -912,11 +912,11 @@ public abstract class Godot extends FragmentActivity implements SensorEventListe
 	}
 
 	/**
-	 * Queue a runnable to be run on the GL thread.
+	 * Queue a runnable to be run on the render thread.
 	 * <p>
-	 * This must be called after the GL thread has started.
+	 * This must be called after the render thread has started.
 	 */
-	public final void runOnGLThread(@NonNull Runnable action) {
+	public final void runOnRenderThread(@NonNull Runnable action) {
 		if (mView != null) {
 			mView.queueEvent(action);
 		}

--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPlugin.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPlugin.java
@@ -84,8 +84,10 @@ public abstract class GodotPlugin {
 
 	/**
 	 * Register the plugin with Godot native code.
+	 *
+	 * This method is invoked on the render thread.
 	 */
-	public final void onGLRegisterPluginWithGodotNative() {
+	public final void onRegisterPluginWithGodotNative() {
 		nativeRegisterSingleton(getPluginName(), this);
 
 		Class clazz = getClass();
@@ -169,9 +171,9 @@ public abstract class GodotPlugin {
 	public boolean onMainBackPressed() { return false; }
 
 	/**
-	 * Invoked on the GL thread when the Godot main loop has started.
+	 * Invoked on the render thread when the Godot main loop has started.
 	 */
-	public void onGLGodotMainLoopStarted() {}
+	public void onGodotMainLoopStarted() {}
 
 	/**
 	 * Invoked once per frame on the GL thread after the frame is drawn.
@@ -225,12 +227,12 @@ public abstract class GodotPlugin {
 	}
 
 	/**
-	 * Queue the specified action to be run on the GL thread.
+	 * Queue the specified action to be run on the render thread.
 	 *
-	 * @param action the action to run on the GL thread
+	 * @param action the action to run on the render thread
 	 */
-	protected void runOnGLThread(Runnable action) {
-		godot.runOnGLThread(action);
+	protected void runOnRenderThread(Runnable action) {
+		godot.runOnRenderThread(action);
 	}
 
 	/**

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -248,7 +248,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jcl
 		}
 
 		os_android->main_loop_begin();
-		godot_java->on_gl_godot_main_loop_started(env);
+		godot_java->on_godot_main_loop_started(env);
 		++step;
 	}
 

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -66,7 +66,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_instance) {
 	_is_activity_resumed = p_env->GetMethodID(cls, "isActivityResumed", "()Z");
 	_vibrate = p_env->GetMethodID(cls, "vibrate", "(I)V");
 	_get_input_fallback_mapping = p_env->GetMethodID(cls, "getInputFallbackMapping", "()Ljava/lang/String;");
-	_on_gl_godot_main_loop_started = p_env->GetMethodID(cls, "onGLGodotMainLoopStarted", "()V");
+	_on_godot_main_loop_started = p_env->GetMethodID(cls, "onGodotMainLoopStarted", "()V");
 }
 
 GodotJavaWrapper::~GodotJavaWrapper() {
@@ -115,13 +115,13 @@ void GodotJavaWrapper::on_video_init(JNIEnv *p_env) {
 	p_env->CallVoidMethod(godot_instance, _on_video_init);
 }
 
-void GodotJavaWrapper::on_gl_godot_main_loop_started(JNIEnv *p_env) {
-	if (_on_gl_godot_main_loop_started) {
+void GodotJavaWrapper::on_godot_main_loop_started(JNIEnv *p_env) {
+	if (_on_godot_main_loop_started) {
 		if (p_env == NULL) {
 			p_env = ThreadAndroid::get_env();
 		}
 	}
-	p_env->CallVoidMethod(godot_instance, _on_gl_godot_main_loop_started);
+	p_env->CallVoidMethod(godot_instance, _on_godot_main_loop_started);
 }
 
 void GodotJavaWrapper::restart(JNIEnv *p_env) {

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -61,7 +61,7 @@ private:
 	jmethodID _is_activity_resumed = 0;
 	jmethodID _vibrate = 0;
 	jmethodID _get_input_fallback_mapping = 0;
-	jmethodID _on_gl_godot_main_loop_started = 0;
+	jmethodID _on_godot_main_loop_started = 0;
 
 public:
 	GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_instance);
@@ -74,7 +74,7 @@ public:
 
 	void gfx_init(bool gl2);
 	void on_video_init(JNIEnv *p_env = NULL);
-	void on_gl_godot_main_loop_started(JNIEnv *p_env = NULL);
+	void on_godot_main_loop_started(JNIEnv *p_env = NULL);
 	void restart(JNIEnv *p_env = NULL);
 	void force_quit(JNIEnv *p_env = NULL);
 	void set_keep_screen_on(bool p_enabled);


### PR DESCRIPTION
This is done to make the methods' names more generics to maintain plugin compatibility when Godot 4.0 is ready.

See https://github.com/godotengine/godot/pull/36919#discussion_r395338984 for context.

**Note:** This PR is slightly different from #37174 since the 3.2 branch doesn't include any vulkan logic/callbacks, hence why a separate PR instead of a cherry-pick.