### PR TITLE
Added alignment options to icons on buttons.  They can now be centered and right-aligned.

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -85,6 +85,9 @@
 		<member name="icon" type="Texture2D" setter="set_button_icon" getter="get_button_icon">
 			Button's icon, if text is present the icon will be placed before the text.
 		</member>
+		<member name="icon_align" type="int" setter="set_icon_align" getter="get_icon_align" enum="Button.TextAlign" default="0">
+			Specifies if the icon should be aligned to the left, right, or center of a button. Uses the same [enum TextAlign] constants as the text alignment. If centered, text will draw on top of the icon.
+		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 		</member>

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -58,6 +58,7 @@ private:
 	bool expand_icon = false;
 	bool clip_text = false;
 	TextAlign align = ALIGN_CENTER;
+	TextAlign icon_align = ALIGN_LEFT;
 	float _internal_margin[4] = {};
 
 	void _shape();
@@ -101,6 +102,9 @@ public:
 
 	void set_text_align(TextAlign p_align);
 	TextAlign get_text_align() const;
+
+	void set_icon_align(TextAlign p_align);
+	TextAlign get_icon_align() const;
 
 	Button(const String &p_text = String());
 	~Button();


### PR DESCRIPTION
Icons now have the same alignment options as text on buttons.  Icons can be aligned on the left, right, or centered.  Left is the same as the current behavior.  Right is basically the same, but on the other side.  Centered centers the icon and draws the text (if any) on top.  Very useful if you want to have menu buttons that can sometimes have text OR an icon and you want them justified in the same way.

Fixes https://github.com/godotengine/godot/issues/11380