### PR TITLE
Fix Android export throwing Unicode errors.

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1179,14 +1179,32 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 	static String _parse_string(const uint8_t *p_bytes, bool p_utf8) {
 
 		uint32_t offset = 0;
-		uint32_t len = decode_uint16(&p_bytes[offset]);
+		uint32_t len = 0;
 
 		if (p_utf8) {
-			//don't know how to read extended utf8, this will have to be for now
-			len >>= 8;
+			uint8_t byte = p_bytes[offset];
+			if (byte & 0x80)
+				offset += 2;
+			else
+				offset += 1;
+			byte = p_bytes[offset];
+			offset++;
+			if (byte & 0x80) {
+				len = byte & 0x7F;
+				len = (len << 8) + p_bytes[offset];
+				offset++;
+			} else {
+				len = byte;
+			}
+		} else {
+			len = decode_uint16(&p_bytes[offset]);
+			offset += 2;
+			if (len & 0x8000) {
+				len &= 0x7FFF;
+				len = (len << 16) + decode_uint16(&p_bytes[offset]);
+				offset += 2;
+			}
 		}
-		offset += 2;
-		//printf("len %i, unicode: %i\n",len,int(p_utf8));
 
 		if (p_utf8) {
 


### PR DESCRIPTION
When exporting to Android a number of Unicode errors are thrown:
```
Unicode error: invalid skip
Unicode error: invalid skip
Unicode error: invalid skip
Unicode error: invalid skip
Unicode error: invalid skip
Unicode error: no space left
```
This is due to not determining the string's correct header length, passing header bytes as part of the string, and not determining the correct length of the string.

This patch, which is based on code found [here](https://github.com/cmeiyuan/ArscEditor/blob/master/src/com/cmy/parser/utils/ArscUtils.java), correctly determines the string's header length and string length.