### PR TITLE
Expose Animation::value_track_interpolate to GDscript

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -692,6 +692,17 @@
 				Sets the update mode (see [enum UpdateMode]) of a value track.
 			</description>
 		</method>
+		<method name="value_track_interpolate" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="track_idx" type="int">
+			</argument>
+			<argument index="1" name="time_sec" type="float">
+			</argument>
+			<description>
+				Returns the interpolated value at the given time (in seconds). The [code]track_idx[/code] must be the index of a value track.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="length" type="float" setter="set_length" getter="get_length" default="1.0">

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2633,6 +2633,7 @@ void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("value_track_get_update_mode", "track_idx"), &Animation::value_track_get_update_mode);
 
 	ClassDB::bind_method(D_METHOD("value_track_get_key_indices", "track_idx", "time_sec", "delta"), &Animation::_value_track_get_key_indices);
+	ClassDB::bind_method(D_METHOD("value_track_interpolate", "track_idx", "time_sec"), &Animation::value_track_interpolate);
 
 	ClassDB::bind_method(D_METHOD("method_track_get_key_indices", "track_idx", "time_sec", "delta"), &Animation::_method_track_get_key_indices);
 	ClassDB::bind_method(D_METHOD("method_track_get_name", "track_idx", "key_idx"), &Animation::method_track_get_name);


### PR DESCRIPTION
`bezier_track_interpolate` and `transform_track_interpolate` are already exposed, so not sure why this was missing.
I added the entry to the class reference.

This is my first PR, so I hope I did everything right.