### PR TITLE
Fix auto-keyframing to work with inspector properties

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -32,6 +32,8 @@
 
 #include "array_property_edit.h"
 #include "dictionary_property_edit.h"
+#include "editor/plugins/animation_player_editor_plugin.h"
+#include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor_feature_profile.h"
 #include "editor_node.h"
 #include "editor_scale.h"
@@ -2091,6 +2093,11 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		for (List<EditorProperty *>::Element *E = editor_property_map[p_name].front(); E; E = E->next()) {
 			E->get()->update_reload_status();
 		}
+	}
+
+	if (Object::cast_to<Node>(object) &&
+			CanvasItemEditor::singleton->key_auto_insert_button->is_pressed()) {
+		AnimationPlayerEditor::singleton->get_track_editor()->insert_node_value_key(Object::cast_to<Node>(object), p_name, p_value, true);
 	}
 }
 

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -84,6 +84,10 @@ public:
 		TOOL_MAX
 	};
 
+	Button *key_auto_insert_button;
+
+	static CanvasItemEditor *singleton;
+
 private:
 	EditorNode *editor;
 
@@ -384,7 +388,6 @@ private:
 	Button *key_rot_button;
 	Button *key_scale_button;
 	Button *key_insert_button;
-	Button *key_auto_insert_button;
 
 	PopupMenu *selection_menu;
 
@@ -596,8 +599,6 @@ protected:
 
 	template <class P, class C>
 	void space_selected_items();
-
-	static CanvasItemEditor *singleton;
 
 public:
 	enum SnapMode {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/36140 https://github.com/godotengine/godot/issues/6201 

**Rationale for opening this PR:**

I initially needed to fix https://github.com/godotengine/godot/issues/36140 because our artists were complaining about the state of the animation editor since they're used to the workflow of other engines (copy paste for keyframes is my next target).

However while doing that bugfix, I found it low-hanging fruit to go for https://github.com/godotengine/godot/issues/6201  as well which has been bothering us for over a year now (I commented on the issue in January of last year).

Comparing to other engines you can see that a Record button is a sensible proposition that makes artists' lives much easier.

Unity has a record button that allows you to switch between manual and auto keyframing:

![image](https://user-images.githubusercontent.com/43449832/77204155-2ea72000-6b03-11ea-9c5d-53bf50828cfb.png)

Cocos Creator has *only* one mode to edit animations, and that is auto keyframing:

![image](https://user-images.githubusercontent.com/43449832/77203952-c35d4e00-6b02-11ea-83d9-d98aa186736c.png)

I hope to get some feedback to know whether I am headed in the right direction. 

**Current State of PR**

Previously auto-keying only worked when node transforms were edited with gizmos. This PR fixes/expands the auto-keying behaviour to also work when values are modified in the inspector tab.

Now it also works for all properties, not only transforms, as long as a track for it already exists. Supports undo-redo with no extra effort.

The new auto-keyframing behaviour is currently toggled with the existing auto-key "Car" button in the canvas item editor:

![image](https://user-images.githubusercontent.com/43449832/77204683-5054d700-6b04-11ea-9457-44e48ce2e150.png)

The other toggles (loc, rot, and scl) still work as before i.e. they insert a keyframe if the canvas item was moved in the viewport.

**What this needs to become a full PR:**
- Potentially add a separate "Record mode" button, either in the top bar or down in the animation panel. 
- Potentially remove the "Car" icon from the canvas editor toolbar (and the loc, rot, scl icons beside it) if it becomes redudant.
- Either access the "auto-capture" boolean cleanly from inside the editor inspector without exposing protected variables _OR_ connect to a signal from outside the editor inspector class and handle the keyframing there (e.g. in the animation editor).



I'm already happy with this change and have compiled release binaries for our team, and I think it would take little work to make this PR up to the engine standards if we reach a consensus.

Binary ready for QA (based on the 3.2.x branch): https://mega.nz/#!QdVlyCIa!5is9G7FowZi9Xa89XvD2lNWKvELY2snBUjZ05NwJgyQ
