### PR TITLE
Make Editor Help text possible to be zoomed in/out

### DIFF
--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -118,6 +118,9 @@ class EditorHelp : public VBoxContainer {
 	Map<String, Map<String, int>> enum_values_line;
 	int description_line;
 
+	Timer *font_resize_timer;
+	int font_resize_val;
+
 	RichTextLabel *class_desc;
 	HSplitContainer *h_split;
 	static DocData *doc;
@@ -163,6 +166,15 @@ class EditorHelp : public VBoxContainer {
 	void _unhandled_key_input(const Ref<InputEvent> &p_ev);
 
 	String _fix_constant(const String &p_constant) const;
+
+	void _zoom_in();
+	void _zoom_out();
+	void _reset_zoom();
+	void _zoom_changed();
+	void _set_dafault_doc_font_size(const String &p_name, const String &p_config_path, int size);
+	void _resize_doc_font(const String &p_name, const String &p_config_path, int p_delta);
+	void _resize_magnify_doc_font(const String &p_name, const String &p_config_path, real_t magnify_factor);
+	void _font_resize_timeout();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
While regular code editor has posibility of text zooming in/out, help tabs didn't have similar functionality.
It is possible to change its size (for 3 different 'categories'/sections in help text area) - but only by going into editor properties, adjusting it manually, saving and observing how documentation text would look like.

With following PR, it's possible to use regular mouse scroll gestures (CTRL + whell up/down), keyboard shortcuts (CTRL + plus, CTRL + minus, CTRL + zero), and magnify gesture to control text size of documentation/help area

![help-scroll](https://user-images.githubusercontent.com/1110337/77214988-15f23680-6b12-11ea-96e6-1a22932cebdc.gif)

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/1914.*