### PR TITLE
Update Joint gizmos automatically

### DIFF
--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -4219,6 +4219,21 @@ Joint3DGizmoPlugin::Joint3DGizmoPlugin() {
 	create_material("joint_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/joint", Color(0.5, 0.8, 1)));
 	create_material("joint_body_a_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/joint_body_a", Color(0.6, 0.8, 1)));
 	create_material("joint_body_b_material", EDITOR_DEF("editors/3d_gizmos/gizmo_colors/joint_body_b", Color(0.6, 0.9, 1)));
+
+	update_timer = memnew(Timer);
+	update_timer->set_name("JointGizmoUpdateTimer");
+	update_timer->set_wait_time(1.0 / 120.0);
+	update_timer->connect("timeout", callable_mp(this, &Joint3DGizmoPlugin::incremental_update_gizmos));
+	update_timer->set_autostart(true);
+	EditorNode::get_singleton()->call_deferred("add_child", update_timer);
+}
+
+void Joint3DGizmoPlugin::incremental_update_gizmos() {
+	if (!current_gizmos.empty()) {
+		update_idx++;
+		update_idx = update_idx % current_gizmos.size();
+		redraw(current_gizmos[update_idx]);
+	}
 }
 
 bool Joint3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {

--- a/editor/node_3d_editor_gizmos.h
+++ b/editor/node_3d_editor_gizmos.h
@@ -409,6 +409,11 @@ class Joint3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 	GDCLASS(Joint3DGizmoPlugin, EditorNode3DGizmoPlugin);
 
+	Timer *update_timer;
+	uint64_t update_idx = 0;
+
+	void incremental_update_gizmos();
+
 public:
 	bool has_gizmo(Node3D *p_spatial);
 	String get_name() const;

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -856,12 +856,11 @@ public:
 	static const int HIDDEN = 1;
 	static const int ON_TOP = 2;
 
-private:
+protected:
 	int current_state;
 	List<EditorNode3DGizmo *> current_gizmos;
 	HashMap<String, Vector<Ref<StandardMaterial3D>>> materials;
 
-protected:
 	static void _bind_methods();
 	virtual bool has_gizmo(Node3D *p_spatial);
 	virtual Ref<EditorNode3DGizmo> create_gizmo(Node3D *p_spatial);


### PR DESCRIPTION
Constantly update Joint gizmos. It only updates a couple of gizmos per frame so the editor doesn't stall when there are a lot of Joint nodes in the scene.

Fixes #18549.