### PR TITLE
Improve the `OS.get_locale()` documentation

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -265,7 +265,8 @@
 			<return type="String">
 			</return>
 			<description>
-				Returns the host OS locale.
+				Returns the host OS locale as a string of the form [code]locale[_VARIANT][/code] (e.g. [code]en_US[/code] for American English). Note that the variant may not always be returned depending on the OS and user configuration. See [url=https://docs.godotengine.org/en/latest/tutorials/i18n/locales.html]this page[/url] for examples of locale codes that can be returned.
+				[b]Note:[/b] This method returns [code]en[/code] if the host OS locale can't be detected for any reason.
 			</description>
 		</method>
 		<method name="get_model_name" qualifiers="const">


### PR DESCRIPTION
___

**Don't merge yet, as macOS will separate the variant with `-` instead of `_`. We should probably change this so users don't have to deal with OS-specific behavior.**

___

See #37203.