### PR TITLE
Add an `Array.pop_at()` method to pop an element at an arbitrary index

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -535,8 +535,8 @@ void Array::push_front(const Variant &p_value) {
 
 Variant Array::pop_back() {
 	if (!_p->array.is_empty()) {
-		int n = _p->array.size() - 1;
-		Variant ret = _p->array.get(n);
+		const int n = _p->array.size() - 1;
+		const Variant ret = _p->array.get(n);
 		_p->array.resize(n);
 		return ret;
 	}
@@ -545,11 +545,36 @@ Variant Array::pop_back() {
 
 Variant Array::pop_front() {
 	if (!_p->array.is_empty()) {
-		Variant ret = _p->array.get(0);
+		const Variant ret = _p->array.get(0);
 		_p->array.remove(0);
 		return ret;
 	}
 	return Variant();
+}
+
+Variant Array::pop_at(int p_pos) {
+	if (_p->array.is_empty()) {
+		// Return `null` without printing an error to mimic `pop_back()` and `pop_front()` behavior.
+		return Variant();
+	}
+
+	if (p_pos < 0) {
+		// Relative offset from the end
+		p_pos = _p->array.size() + p_pos;
+	}
+
+	ERR_FAIL_INDEX_V_MSG(
+			p_pos,
+			_p->array.size(),
+			Variant(),
+			vformat(
+					"The calculated index %s is out of bounds (the array has %s elements). Leaving the array untouched and returning `null`.",
+					p_pos,
+					_p->array.size()));
+
+	const Variant ret = _p->array.get(p_pos);
+	_p->array.remove(p_pos);
+	return ret;
 }
 
 Variant Array::min() const {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -97,6 +97,7 @@ public:
 	void push_front(const Variant &p_value);
 	Variant pop_back();
 	Variant pop_front();
+	Variant pop_at(int p_pos);
 
 	Array duplicate(bool p_deep = false) const;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1807,6 +1807,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Array, has, sarray("value"), varray());
 	bind_method(Array, pop_back, sarray(), varray());
 	bind_method(Array, pop_front, sarray(), varray());
+	bind_method(Array, pop_at, sarray("position"), varray());
 	bind_method(Array, sort, sarray(), varray());
 	bind_method(Array, sort_custom, sarray("func"), varray());
 	bind_method(Array, shuffle, sarray(), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -393,6 +393,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="pop_at">
+			<return type="Variant" />
+			<argument index="0" name="position" type="int" />
+			<description>
+				Removes and returns the element of the array at index [code]position[/code]. If negative, [code]position[/code] is considered relative to the end of the array. Leaves the array untouched and returns [code]null[/code] if the array is empty or if it's accessed out of bounds. An error message is printed when the array is accessed out of bounds, but not when the array is empty.
+				[b]Note:[/b] On large arrays, this method can be slower than [method pop_back] as it will reindex the array's elements that are located after the removed element. The larger the array and the lower the index of the removed element, the slower [method pop_at] will be.
+			</description>
+		</method>
 		<method name="pop_back">
 			<return type="Variant" />
 			<description>


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/52143.

Negative indices are supported to pop an element relative from the end.

## Example

```gdscript
func _ready():
	var array = [2, 4, 6, 8, 10]
	print("Original array: ", array)
	print(array.pop_at(2), ". Array is now ", array)
	print(array.pop_at(2), ". Array is now ", array)
	# Pop the last element.
	print(array.pop_at(-1), ". Array is now ", array)	
	# This is invalid since the array only has 3 elements at this point.
	# This will print an error and return `null`.
	print(array.pop_at(-15), ". Array is now ", array)
	print(array.pop_at(0), ". Array is now ", array)
	print(array.pop_at(0), ". Array is now ", array)
	# This will return `null` without printing an error.
	print("Trying to pop empty array. ", array.pop_at(24), ". Array is now ", array)
```

```text
Original array: [2, 4, 6, 8, 10]
6. Array is now [2, 4, 8, 10]
8. Array is now [2, 4, 10]
10. Array is now [2, 4]
Null. Array is now [2, 4]
2. Array is now [4]
4. Array is now []
Trying to pop empty array. Null. Array is now []
```

This closes https://github.com/godotengine/godot-proposals/issues/562.

~~PS: Should we print an error when trying to pop an empty array, or is the current behavior fine?~~

**Edit:** Not displaying an error is fine, for consistency with `pop_back()` and `pop_front()`'s behavior.