### PR TITLE
Display collision shapes of tile map in the editor

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -316,6 +316,9 @@
 		<member name="occluder_light_mask" type="int" setter="set_occluder_light_mask" getter="get_occluder_light_mask" default="1">
 			The light mask assigned to all light occluders in the TileMap. The TileSet's light occluders will cast shadows only from Light2D(s) that have the same light mask(s).
 		</member>
+		<member name="show_collision" type="bool" setter="set_show_collision" getter="is_show_collision_enabled" default="true">
+			If [code]true[/code], it shows collision shape in-editor and in-game. It requires show collision shape option to be on in debug menu to work in-game.  
+		</member>
 		<member name="tile_set" type="TileSet" setter="set_tileset" getter="get_tileset">
 			The assigned [TileSet].
 		</member>

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -326,7 +326,8 @@ void TileMap::update_dirty_quadrants() {
 	Color debug_collision_color;
 	Color debug_navigation_color;
 
-	bool debug_shapes = st && st->is_debugging_collisions_hint();
+	bool debug_shapes = show_collision && (Engine::get_singleton()->is_editor_hint() || (st && st->is_debugging_collisions_hint()));
+
 	if (debug_shapes) {
 		debug_collision_color = st->get_debug_collisions_color();
 	}
@@ -1723,6 +1724,15 @@ String TileMap::get_configuration_warning() const {
 	return warning;
 }
 
+void TileMap::set_show_collision(bool p_value) {
+	show_collision = p_value;
+	_recreate_quadrants();
+}
+
+bool TileMap::is_show_collision_enabled() {
+	return show_collision;
+}
+
 void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tileset", "tileset"), &TileMap::set_tileset);
 	ClassDB::bind_method(D_METHOD("get_tileset"), &TileMap::get_tileset);
@@ -1756,6 +1766,9 @@ void TileMap::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_compatibility_mode", "enable"), &TileMap::set_compatibility_mode);
 	ClassDB::bind_method(D_METHOD("is_compatibility_mode_enabled"), &TileMap::is_compatibility_mode_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_show_collision", "enable"), &TileMap::set_show_collision);
+	ClassDB::bind_method(D_METHOD("is_show_collision_enabled"), &TileMap::is_show_collision_enabled);
 
 	ClassDB::bind_method(D_METHOD("set_centered_textures", "enable"), &TileMap::set_centered_textures);
 	ClassDB::bind_method(D_METHOD("is_centered_textures_enabled"), &TileMap::is_centered_textures_enabled);
@@ -1827,6 +1840,7 @@ void TileMap::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cell_half_offset", PROPERTY_HINT_ENUM, "Offset X,Offset Y,Disabled,Offset Negative X,Offset Negative Y"), "set_half_offset", "get_half_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cell_tile_origin", PROPERTY_HINT_ENUM, "Top Left,Center,Bottom Left"), "set_tile_origin", "get_tile_origin");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cell_y_sort"), "set_y_sort_enabled", "is_y_sort_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_collision"), "set_show_collision", "is_show_collision_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "compatibility_mode"), "set_compatibility_mode", "is_compatibility_mode_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "centered_textures"), "set_centered_textures", "is_centered_textures_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cell_clip_uv"), "set_clip_uv", "get_clip_uv");

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -79,6 +79,7 @@ private:
 	CollisionObject2D *collision_parent = nullptr;
 	bool use_kinematic = false;
 	Navigation2D *navigation = nullptr;
+	bool show_collision = true;
 
 	union PosKey {
 		struct {
@@ -270,6 +271,9 @@ public:
 	void update_dirty_bitmask();
 
 	void update_dirty_quadrants();
+
+	void set_show_collision(bool p_value);
+	bool is_show_collision_enabled();
 
 	void set_collision_layer(uint32_t p_layer);
 	uint32_t get_collision_layer() const;


### PR DESCRIPTION
Fixes #19858

This pr introduce a new variable `show_collision` to control the visibility of collision shapes for both in-game and in-editor.

To draw collision shapes in-editor, only `show_collision` set to be true. while for in-game, both `show_collision` and `is_debugging_collisions_hint` set to be true. The default value of `show_collision` is true so it won't change the current default behaviour. 