### PR TITLE
Fixed GraphNode port separation.

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -503,9 +503,7 @@ void GraphNode::_connpos_update() {
 			}
 		}
 
-		if (vofs > 0) {
-			vofs += sep;
-		}
+		vofs += sep;
 		vofs += size.y;
 		idx++;
 	}


### PR DESCRIPTION
This fixes the spacing of the Graphnode ports when using custom separation.

"fixes #32474"