### PR TITLE
Adding missing include guards to header files identified by LGTM

### DIFF
--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -28,12 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "servers/audio_server.h"
-
 #ifdef ALSA_ENABLED
+
+#ifndef AUDIO_DRIVER_ALSA_H
+#define AUDIO_DRIVER_ALSA_H
 
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
+#include "servers/audio_server.h"
 
 #include <alsa/asoundlib.h>
 
@@ -87,4 +89,6 @@ public:
 	~AudioDriverALSA();
 };
 
-#endif
+#endif // AUDIO_DRIVER_ALSA_H
+
+#endif // ALSA_ENABLED

--- a/modules/assimp/register_types.h
+++ b/modules/assimp/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef ASSIMP_REGISTER_TYPES_H
+#define ASSIMP_REGISTER_TYPES_H
+
 void register_assimp_types();
 void unregister_assimp_types();
+
+#endif // ASSIMP_REGISTER_TYPES_H

--- a/modules/basis_universal/register_types.h
+++ b/modules/basis_universal/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef BASIS_UNIVERSAL_REGISTER_TYPES_H
+#define BASIS_UNIVERSAL_REGISTER_TYPES_H
+
 void register_basis_universal_types();
 void unregister_basis_universal_types();
+
+#endif // BASIS_UNIVERSAL_REGISTER_TYPES_H

--- a/modules/bmp/register_types.h
+++ b/modules/bmp/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef BMP_REGISTER_TYPES_H
+#define BMP_REGISTER_TYPES_H
+
 void register_bmp_types();
 void unregister_bmp_types();
+
+#endif // BMP_REGISTER_TYPES_H

--- a/modules/csg/register_types.h
+++ b/modules/csg/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef CSG_REGISTER_TYPES_H
+#define CSG_REGISTER_TYPES_H
+
 void register_csg_types();
 void unregister_csg_types();
+
+#endif // CSG_REGISTER_TYPES_H

--- a/modules/cvtt/register_types.h
+++ b/modules/cvtt/register_types.h
@@ -29,6 +29,13 @@
 /*************************************************************************/
 
 #ifdef TOOLS_ENABLED
+
+#ifndef CVTT_REGISTER_TYPES_H
+#define CVTT_REGISTER_TYPES_H
+
 void register_cvtt_types();
 void unregister_cvtt_types();
-#endif
+
+#endif // CVTT_REGISTER_TYPES_H
+
+#endif // TOOLS_ENABLED

--- a/modules/dds/register_types.h
+++ b/modules/dds/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef DDS_REGISTER_TYPES_H
+#define DDS_REGISTER_TYPES_H
+
 void register_dds_types();
 void unregister_dds_types();
+
+#endif // DDS_REGISTER_TYPES_H

--- a/modules/enet/register_types.h
+++ b/modules/enet/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef ENET_REGISTER_TYPES_H
+#define ENET_REGISTER_TYPES_H
+
 void register_enet_types();
 void unregister_enet_types();
+
+#endif // ENET_REGISTER_TYPES_H

--- a/modules/etc/register_types.h
+++ b/modules/etc/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef ETC_REGISTER_TYPES_H
+#define ETC_REGISTER_TYPES_H
+
 void register_etc_types();
 void unregister_etc_types();
+
+#endif // ETC_REGISTER_TYPES_H

--- a/modules/freetype/register_types.h
+++ b/modules/freetype/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef FREETYPE_REGISTER_TYPES_H
+#define FREETYPE_REGISTER_TYPES_H
+
 void register_freetype_types();
 void unregister_freetype_types();
+
+#endif // FREETYPE_REGISTER_TYPES_H

--- a/modules/gdnative/arvr/register_types.h
+++ b/modules/gdnative/arvr/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef ARVR_REGISTER_TYPES_H
+#define ARVR_REGISTER_TYPES_H
+
 void register_arvr_types();
 void unregister_arvr_types();
+
+#endif // ARVR_REGISTER_TYPES_H

--- a/modules/gdnative/nativescript/register_types.h
+++ b/modules/gdnative/nativescript/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef NATIVESCRIPT_REGISTER_TYPES_H
+#define NATIVESCRIPT_REGISTER_TYPES_H
+
 void register_nativescript_types();
 void unregister_nativescript_types();
+
+#endif // NATIVESCRIPT_REGISTER_TYPES_H

--- a/modules/gdnative/net/register_types.h
+++ b/modules/gdnative/net/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef NET_REGISTER_TYPES_H
+#define NET_REGISTER_TYPES_H
+
 void register_net_types();
 void unregister_net_types();
+
+#endif // NET_REGISTER_TYPES_H

--- a/modules/gdnative/pluginscript/register_types.h
+++ b/modules/gdnative/pluginscript/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef PLUGINSCRIPT_REGISTER_TYPES_H
+#define PLUGINSCRIPT_REGISTER_TYPES_H
+
 void register_pluginscript_types();
 void unregister_pluginscript_types();
+
+#endif // PLUGINSCRIPT_REGISTER_TYPES_H

--- a/modules/gdnative/register_types.h
+++ b/modules/gdnative/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef GDNATIVE_REGISTER_TYPES_H
+#define GDNATIVE_REGISTER_TYPES_H
+
 void register_gdnative_types();
 void unregister_gdnative_types();
+
+#endif // GDNATIVE_REGISTER_TYPES_H

--- a/modules/gdnative/videodecoder/register_types.h
+++ b/modules/gdnative/videodecoder/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef VIDEODECODER_REGISTER_TYPES_H
+#define VIDEODECODER_REGISTER_TYPES_H
+
 void register_videodecoder_types();
 void unregister_videodecoder_types();
+
+#endif // VIDEODECODER_REGISTER_TYPES_H

--- a/modules/gdnavigation/register_types.h
+++ b/modules/gdnavigation/register_types.h
@@ -32,5 +32,10 @@
 	@author AndreaCatania
 */
 
+#ifndef GDNAVIGATION_REGISTER_TYPES_H
+#define GDNAVIGATION_REGISTER_TYPES_H
+
 void register_gdnavigation_types();
 void unregister_gdnavigation_types();
+
+#endif // GDNAVIGATION_REGISTER_TYPES_H

--- a/modules/gdscript/register_types.h
+++ b/modules/gdscript/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef GDSCRIPT_REGISTER_TYPES_H
+#define GDSCRIPT_REGISTER_TYPES_H
+
 void register_gdscript_types();
 void unregister_gdscript_types();
+
+#endif // GDSCRIPT_REGISTER_TYPES_H

--- a/modules/glslang/register_types.h
+++ b/modules/glslang/register_types.h
@@ -28,7 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef GLSLANG_REGISTER_TYPES_H
+#define GLSLANG_REGISTER_TYPES_H
+
 #define MODULE_GLSLANG_HAS_PREREGISTER
+
 void preregister_glslang_types();
 void register_glslang_types();
 void unregister_glslang_types();
+
+#endif // GLSLANG_REGISTER_TYPES_H

--- a/modules/gridmap/register_types.h
+++ b/modules/gridmap/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef GRIDMAP_REGISTER_TYPES_H
+#define GRIDMAP_REGISTER_TYPES_H
+
 void register_gridmap_types();
 void unregister_gridmap_types();
+
+#endif // GRIDMAP_REGISTER_TYPES_H

--- a/modules/hdr/register_types.h
+++ b/modules/hdr/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef HDR_REGISTER_TYPES_H
+#define HDR_REGISTER_TYPES_H
+
 void register_hdr_types();
 void unregister_hdr_types();
+
+#endif // HDR_REGISTER_TYPES_H

--- a/modules/jpg/register_types.h
+++ b/modules/jpg/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef JPG_REGISTER_TYPES_H
+#define JPG_REGISTER_TYPES_H
+
 void register_jpg_types();
 void unregister_jpg_types();
+
+#endif // JPG_REGISTER_TYPES_H

--- a/modules/jsonrpc/register_types.h
+++ b/modules/jsonrpc/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef JSONRPC_REGISTER_TYPES_H
+#define JSONRPC_REGISTER_TYPES_H
+
 void register_jsonrpc_types();
 void unregister_jsonrpc_types();
+
+#endif // JSONRPC_REGISTER_TYPES_H

--- a/modules/mbedtls/register_types.h
+++ b/modules/mbedtls/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef MBEDTLS_REGISTER_TYPES_H
+#define MBEDTLS_REGISTER_TYPES_H
+
 void register_mbedtls_types();
 void unregister_mbedtls_types();
+
+#endif // MBEDTLS_REGISTER_TYPES_H

--- a/modules/mobile_vr/register_types.h
+++ b/modules/mobile_vr/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef MOBILE_VR_REGISTER_TYPES_H
+#define MOBILE_VR_REGISTER_TYPES_H
+
 void register_mobile_vr_types();
 void unregister_mobile_vr_types();
+
+#endif // MOBILE_VR_REGISTER_TYPES_H

--- a/modules/ogg/register_types.h
+++ b/modules/ogg/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef OGG_REGISTER_TYPES_H
+#define OGG_REGISTER_TYPES_H
+
 void register_ogg_types();
 void unregister_ogg_types();
+
+#endif // OGG_REGISTER_TYPES_H

--- a/modules/opensimplex/register_types.h
+++ b/modules/opensimplex/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef OPENSIMPLEX_REGISTER_TYPES_H
+#define OPENSIMPLEX_REGISTER_TYPES_H
+
 void register_opensimplex_types();
 void unregister_opensimplex_types();
+
+#endif // OPENSIMPLEX_REGISTER_TYPES_H

--- a/modules/opus/register_types.h
+++ b/modules/opus/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef OPUS_REGISTER_TYPES_H
+#define OPUS_REGISTER_TYPES_H
+
 void register_opus_types();
 void unregister_opus_types();
+
+#endif // OPUS_REGISTER_TYPES_H

--- a/modules/pvr/register_types.h
+++ b/modules/pvr/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef PVR_REGISTER_TYPES_H
+#define PVR_REGISTER_TYPES_H
+
 void register_pvr_types();
 void unregister_pvr_types();
+
+#endif // PVR_REGISTER_TYPES_H

--- a/modules/regex/register_types.h
+++ b/modules/regex/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef REGEX_REGISTER_TYPES_H
+#define REGEX_REGISTER_TYPES_H
+
 void register_regex_types();
 void unregister_regex_types();
+
+#endif // REGEX_REGISTER_TYPES_H

--- a/modules/squish/register_types.h
+++ b/modules/squish/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef SQUISH_REGISTER_TYPES_H
+#define SQUISH_REGISTER_TYPES_H
+
 void register_squish_types();
 void unregister_squish_types();
+
+#endif // SQUISH_REGISTER_TYPES_H

--- a/modules/stb_vorbis/register_types.h
+++ b/modules/stb_vorbis/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef STB_VORBIS_REGISTER_TYPES_H
+#define STB_VORBIS_REGISTER_TYPES_H
+
 void register_stb_vorbis_types();
 void unregister_stb_vorbis_types();
+
+#endif // STB_VORBIS_REGISTER_TYPES_H

--- a/modules/svg/register_types.h
+++ b/modules/svg/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef SVG_REGISTER_TYPES_H
+#define SVG_REGISTER_TYPES_H
+
 void register_svg_types();
 void unregister_svg_types();
+
+#endif // SVG_REGISTER_TYPES_H

--- a/modules/tga/register_types.h
+++ b/modules/tga/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef TGA_REGISTER_TYPES_H
+#define TGA_REGISTER_TYPES_H
+
 void register_tga_types();
 void unregister_tga_types();
+
+#endif // TGA_REGISTER_TYPES_H

--- a/modules/theora/register_types.h
+++ b/modules/theora/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef THEORA_REGISTER_TYPES_H
+#define THEORA_REGISTER_TYPES_H
+
 void register_theora_types();
 void unregister_theora_types();
+
+#endif // THEORA_REGISTER_TYPES_H

--- a/modules/tinyexr/register_types.h
+++ b/modules/tinyexr/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef TINYEXR_REGISTER_TYPES_H
+#define TINYEXR_REGISTER_TYPES_H
+
 void register_tinyexr_types();
 void unregister_tinyexr_types();
+
+#endif // TINYEXR_REGISTER_TYPES_H

--- a/modules/upnp/register_types.h
+++ b/modules/upnp/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef UPNP_REGISTER_TYPES_H
+#define UPNP_REGISTER_TYPES_H
+
 void register_upnp_types();
 void unregister_upnp_types();
+
+#endif // UPNP_REGISTER_TYPES_H

--- a/modules/vhacd/register_types.h
+++ b/modules/vhacd/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef VHACD_REGISTER_TYPES_H
+#define VHACD_REGISTER_TYPES_H
+
 void register_vhacd_types();
 void unregister_vhacd_types();
+
+#endif // VHACD_REGISTER_TYPES_H

--- a/modules/visual_script/register_types.h
+++ b/modules/visual_script/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef VISUAL_SCRIPT_REGISTER_TYPES_H
+#define VISUAL_SCRIPT_REGISTER_TYPES_H
+
 void register_visual_script_types();
 void unregister_visual_script_types();
+
+#endif // VISUAL_SCRIPT_REGISTER_TYPES_H

--- a/modules/vorbis/register_types.h
+++ b/modules/vorbis/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef VORBIS_REGISTER_TYPES_H
+#define VORBIS_REGISTER_TYPES_H
+
 void register_vorbis_types();
 void unregister_vorbis_types();
+
+#endif // VORBIS_REGISTER_TYPES_H

--- a/modules/webm/register_types.h
+++ b/modules/webm/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef WEBM_REGISTER_TYPES_H
+#define WEBM_REGISTER_TYPES_H
+
 void register_webm_types();
 void unregister_webm_types();
+
+#endif // WEBM_REGISTER_TYPES_H

--- a/modules/webp/register_types.h
+++ b/modules/webp/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef WEBP_REGISTER_TYPES_H
+#define WEBP_REGISTER_TYPES_H
+
 void register_webp_types();
 void unregister_webp_types();
+
+#endif // WEBP_REGISTER_TYPES_H

--- a/modules/webrtc/register_types.h
+++ b/modules/webrtc/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef WEBRTC_REGISTER_TYPES_H
+#define WEBRTC_REGISTER_TYPES_H
+
 void register_webrtc_types();
 void unregister_webrtc_types();
+
+#endif // WEBRTC_REGISTER_TYPES_H

--- a/modules/websocket/register_types.h
+++ b/modules/websocket/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef WEBSOCKET_REGISTER_TYPES_H
+#define WEBSOCKET_REGISTER_TYPES_H
+
 void register_websocket_types();
 void unregister_websocket_types();
+
+#endif // WEBSOCKET_REGISTER_TYPES_H

--- a/modules/xatlas_unwrap/register_types.h
+++ b/modules/xatlas_unwrap/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef XATLAS_UNWRAP_REGISTER_TYPES_H
+#define XATLAS_UNWRAP_REGISTER_TYPES_H
+
 void register_xatlas_unwrap_types();
 void unregister_xatlas_unwrap_types();
+
+#endif // XATLAS_UNWRAP_REGISTER_TYPES_H

--- a/platform/android/api/api.h
+++ b/platform/android/api/api.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef ANDROID_API_H
+#define ANDROID_API_H
+
 void register_android_api();
 void unregister_android_api();
+
+#endif // ANDROID_API_H

--- a/platform/android/export/export.h
+++ b/platform/android/export/export.h
@@ -28,4 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef ANDROID_EXPORT_H
+#define ANDROID_EXPORT_H
+
 void register_android_exporter();
+
+#endif // ANDROID_EXPORT_H

--- a/platform/iphone/export/export.h
+++ b/platform/iphone/export/export.h
@@ -28,4 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef IPHONE_EXPORT_H
+#define IPHONE_EXPORT_H
+
 void register_iphone_exporter();
+
+#endif // IPHONE_EXPORT_H

--- a/platform/javascript/api/api.h
+++ b/platform/javascript/api/api.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef JAVASCRIPT_API_H
+#define JAVASCRIPT_API_H
+
 void register_javascript_api();
 void unregister_javascript_api();
+
+#endif // JAVASCRIPT_API_H

--- a/platform/osx/export/export.h
+++ b/platform/osx/export/export.h
@@ -28,4 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef OSX_EXPORT_H
+#define OSX_EXPORT_H
+
 void register_osx_exporter();
+
+#endif // OSX_EXPORT_H

--- a/platform/uwp/export/export.h
+++ b/platform/uwp/export/export.h
@@ -28,4 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef UWP_EXPORT_H
+#define UWP_EXPORT_H
+
 void register_uwp_exporter();
+
+#endif // UWP_EXPORT_H

--- a/platform/x11/export/export.h
+++ b/platform/x11/export/export.h
@@ -28,4 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef X11_EXPORT_H
+#define X11_EXPORT_H
+
 void register_x11_exporter();
+
+#endif // X11_EXPORT_H


### PR DESCRIPTION
This addresses the issue godotengine/godot#37143 (Missing header guards in a lot of files).

LGTM was used to identify missing include guards. This PR is adding those guards.

As noted in the issue: 
Missing both #pragma once and #include guard seems to be a more concerning matter compared to choosing between them. If and when we do decide to change it, we can just use guardonce tools to convert between them.