### PR TITLE
Exposed more queries to perform more motion tests on the kinematic body.

### DIFF
--- a/modules/bullet/bullet_physics_server.h
+++ b/modules/bullet/bullet_physics_server.h
@@ -254,6 +254,9 @@ public:
 	// this function only works on physics process, errors and returns null otherwise
 	virtual PhysicsDirectBodyState *body_get_direct_state(RID p_body);
 
+	virtual real_t body_test_motion_light(RID p_body, const Transform &p_transform, const Vector3 &p_motion, bool p_infinite_inertia, bool p_use_margin, LightMotionResult &r_result);
+	virtual bool body_test_motion_depenetrate(RID p_body, const Transform &p_transform, real_t p_depenetration_scale, bool p_infinite_inertia, real_t p_max_penetration, bool p_use_margin, Vector3 &r_delta_recover_movement, LightMotionResult *r_result = NULL);
+
 	virtual bool body_test_motion(RID p_body, const Transform &p_from, const Vector3 &p_motion, bool p_infinite_inertia, MotionResult *r_result = NULL, bool p_exclude_raycast_shapes = true);
 	virtual int body_test_ray_separation(RID p_body, const Transform &p_transform, bool p_infinite_inertia, Vector3 &r_recover_motion, SeparationResult *r_results, int p_result_max, float p_margin = 0.001);
 

--- a/modules/bullet/godot_result_callbacks.h
+++ b/modules/bullet/godot_result_callbacks.h
@@ -104,7 +104,11 @@ public:
 struct GodotKinClosestConvexResultCallback : public btCollisionWorld::ClosestConvexResultCallback {
 public:
 	const RigidBodyBullet *m_self_object;
-	const bool m_infinite_inertia;
+	bool m_infinite_inertia;
+	bool shape_id;
+
+	GodotKinClosestConvexResultCallback() :
+			btCollisionWorld::ClosestConvexResultCallback(btVector3(), btVector3()) { m_closestHitFraction = 1.0; }
 
 	GodotKinClosestConvexResultCallback(const btVector3 &convexFromWorld, const btVector3 &convexToWorld, const RigidBodyBullet *p_self_object, bool p_infinite_inertia) :
 			btCollisionWorld::ClosestConvexResultCallback(convexFromWorld, convexToWorld),

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -180,11 +180,7 @@ public:
 	bool test_body_motion(RigidBodyBullet *p_body, const Transform &p_from, const Vector3 &p_motion, bool p_infinite_inertia, PhysicsServer::MotionResult *r_result, bool p_exclude_raycast_shapes);
 	int test_ray_separation(RigidBodyBullet *p_body, const Transform &p_transform, bool p_infinite_inertia, Vector3 &r_recover_motion, PhysicsServer::SeparationResult *r_results, int p_result_max, float p_margin);
 
-private:
-	void create_empty_world(bool p_create_soft_world);
-	void destroy_world();
-	void check_ghost_overlaps();
-	void check_body_collision();
+	void sweep_test_multi_shapes(RigidBodyBullet *p_body, const btTransform &p_transform, const btVector3 &p_motion, bool p_infinite_inertia, bool p_use_margin, bool p_exclude_raycast_shapes, GodotKinClosestConvexResultCallback &r_lastHitResult);
 
 	struct RecoverResult {
 		bool hasPenetration;
@@ -205,15 +201,21 @@ private:
 				local_shape_most_recovered(0) {}
 	};
 
-	bool recover_from_penetration(RigidBodyBullet *p_body, const btTransform &p_body_position, btScalar p_recover_movement_scale, bool p_infinite_inertia, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result = NULL);
+	bool recover_from_penetration(RigidBodyBullet *p_body, const btTransform &p_body_position, btScalar p_recover_movement_scale, bool p_infinite_inertia, btScalar p_allowed_penetration, bool p_use_margin, bool p_exclude_ray_shape, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result = NULL);
 	/// This is an API that recover a kinematic object from penetration
 	/// This allow only Convex Convex test and it always use GJK algorithm, With this API we don't benefit of Bullet special accelerated functions
-	bool RFP_convex_convex_test(const btConvexShape *p_shapeA, const btConvexShape *p_shapeB, btCollisionObject *p_objectB, int p_shapeId_A, int p_shapeId_B, const btTransform &p_transformA, const btTransform &p_transformB, btScalar p_recover_movement_scale, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result = NULL);
+	bool RFP_convex_convex_test(const btConvexShape *p_shapeA, const btConvexShape *p_shapeB, btCollisionObject *p_objectB, int p_shapeId_A, int p_shapeId_B, const btTransform &p_transformA, const btTransform &p_transformB, btScalar p_recover_movement_scale, btScalar p_allowed_penetration, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result = NULL);
 	/// This is an API that recover a kinematic object from penetration
 	/// Using this we leave Bullet to select the best algorithm, For example GJK in case we have Convex Convex, or a Bullet accelerated algorithm
-	bool RFP_convex_world_test(const btConvexShape *p_shapeA, const btCollisionShape *p_shapeB, btCollisionObject *p_objectA, btCollisionObject *p_objectB, int p_shapeId_A, int p_shapeId_B, const btTransform &p_transformA, const btTransform &p_transformB, btScalar p_recover_movement_scale, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result = NULL);
+	bool RFP_convex_world_test(const btConvexShape *p_shapeA, const btCollisionShape *p_shapeB, btCollisionObject *p_objectA, btCollisionObject *p_objectB, int p_shapeId_A, int p_shapeId_B, const btTransform &p_transformA, const btTransform &p_transformB, btScalar p_recover_movement_scale, btScalar p_allowed_penetration, btVector3 &r_delta_recover_movement, RecoverResult *r_recover_result = NULL);
 
 	int add_separation_result(PhysicsServer::SeparationResult *r_results, const SpaceBullet::RecoverResult &p_recover_result, int p_shape_id, const btCollisionObject *p_other_object) const;
 	int recover_from_penetration_ray(RigidBodyBullet *p_body, const btTransform &p_body_position, btScalar p_recover_movement_scale, bool p_infinite_inertia, int p_result_max, btVector3 &r_delta_recover_movement, PhysicsServer::SeparationResult *r_results);
+
+private:
+	void create_empty_world(bool p_create_soft_world);
+	void destroy_world();
+	void check_ghost_overlaps();
+	void check_body_collision();
 };
 #endif

--- a/servers/physics/physics_server_sw.h
+++ b/servers/physics/physics_server_sw.h
@@ -237,6 +237,9 @@ public:
 	virtual void body_set_ray_pickable(RID p_body, bool p_enable);
 	virtual bool body_is_ray_pickable(RID p_body) const;
 
+	virtual real_t body_test_motion_light(RID p_body, const Transform &p_transform, const Vector3 &p_motion, bool p_infinite_inertia, bool p_use_margin, LightMotionResult &r_result) { return 0; }
+	virtual bool body_test_motion_depenetrate(RID p_body, const Transform &p_transform, real_t p_depenetration_scale, bool p_infinite_inertia, real_t p_max_penetration, bool p_use_margin, Vector3 &r_delta_recover_movement, LightMotionResult *r_result = NULL) { return false; }
+
 	virtual bool body_test_motion(RID p_body, const Transform &p_from, const Vector3 &p_motion, bool p_infinite_inertia, MotionResult *r_result = NULL, bool p_exclude_raycast_shapes = true);
 	virtual int body_test_ray_separation(RID p_body, const Transform &p_transform, bool p_infinite_inertia, Vector3 &r_recover_motion, SeparationResult *r_results, int p_result_max, float p_margin = 0.001);
 

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -480,6 +480,21 @@ public:
 	// this function only works on physics process, errors and returns null otherwise
 	virtual PhysicsDirectBodyState *body_get_direct_state(RID p_body) = 0;
 
+	struct LightMotionResult {
+		Vector3 collision_point;
+		Vector3 collision_normal;
+		int collision_local_shape;
+		ObjectID collider_id;
+		RID collider;
+		int collider_shape;
+	};
+
+	Dictionary _body_test_motion_light(RID p_body, Transform p_transform, Vector3 p_motion, bool p_infinite_inertia, bool p_use_margin);
+	Dictionary _body_test_motion_depenetrate(RID p_body, Transform p_transform, real_t p_depenetration_scale, bool p_infinite_inertia, real_t p_max_penetration, bool p_use_margin);
+
+	virtual real_t body_test_motion_light(RID p_body, const Transform &p_transform, const Vector3 &p_motion, bool p_infinite_inertia, bool p_use_margin, LightMotionResult &r_result) = 0;
+	virtual bool body_test_motion_depenetrate(RID p_body, const Transform &p_transform, real_t p_depenetration_scale, bool p_infinite_inertia, real_t p_max_penetration, bool p_use_margin, Vector3 &r_delta_recover_movement, LightMotionResult *r_result = NULL) = 0;
+
 	struct MotionResult {
 
 		Vector3 motion;


### PR DESCRIPTION
Added queries on the kinematic body (move test and de-penetration test) so to be able to perform the motion tests needed to integrate special movements like:
- Wall running.
- Wall climbing.
- Wall jumping.
- Teleport.
- Grapple motion.
- Projectile parabolic motion.
