### PR TITLE
Use QuickOpen to load resources in the inspector.

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -135,6 +135,10 @@ void EditorResourcePicker::_file_selected(const String &p_path) {
 	_update_resource();
 }
 
+void EditorResourcePicker::_file_quick_selected() {
+	_file_selected(quick_open->get_selected());
+}
+
 void EditorResourcePicker::_update_menu() {
 	_update_menu_items();
 
@@ -153,7 +157,10 @@ void EditorResourcePicker::_update_menu_items() {
 	// Add options for creating specific subtypes of the base resource type.
 	set_create_options(edit_menu);
 
-	// Add an option to load a resource from a file.
+	// Add an option to load a resource from a file using the QuickOpen dialog.
+	edit_menu->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Quick Load"), OBJ_MENU_QUICKLOAD);
+
+	// Add an option to load a resource from a file using the regular file dialog.
 	edit_menu->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Load"), OBJ_MENU_LOAD);
 
 	// Add options for changing existing value of the resource.
@@ -244,6 +251,17 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			}
 
 			file_dialog->popup_file_dialog();
+		} break;
+
+		case OBJ_MENU_QUICKLOAD: {
+			if (!quick_open) {
+				quick_open = memnew(EditorQuickOpen);
+				add_child(quick_open);
+				quick_open->connect("quick_open", callable_mp(this, &EditorResourcePicker::_file_quick_selected));
+			}
+
+			quick_open->popup_dialog(base_type);
+			quick_open->set_title(TTR("Resource"));
 		} break;
 
 		case OBJ_MENU_EDIT: {

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -32,6 +32,7 @@
 #define EDITOR_RESOURCE_PICKER_H
 
 #include "editor_file_dialog.h"
+#include "quick_open.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/popup_menu.h"
@@ -54,9 +55,11 @@ class EditorResourcePicker : public HBoxContainer {
 	TextureRect *preview_rect;
 	Button *edit_button;
 	EditorFileDialog *file_dialog = nullptr;
+	EditorQuickOpen *quick_open = nullptr;
 
 	enum MenuOption {
 		OBJ_MENU_LOAD,
+		OBJ_MENU_QUICKLOAD,
 		OBJ_MENU_EDIT,
 		OBJ_MENU_CLEAR,
 		OBJ_MENU_MAKE_UNIQUE,
@@ -75,6 +78,7 @@ class EditorResourcePicker : public HBoxContainer {
 	void _update_resource_preview(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, ObjectID p_obj);
 
 	void _resource_selected();
+	void _file_quick_selected();
 	void _file_selected(const String &p_path);
 
 	void _update_menu();


### PR DESCRIPTION
When you click the "Load" button to populate a Resource field in the
inspector dock, the editor currently creates a file dialog. Navigating
through folders to find the file you want is tedious.

This replaces the file dialog with the same QuickOpen dialog used for
the "Quick Run" and "Quick Open" scene actions. The result list is
filtered to only resources of the appropriate type, and you can type
I find that this is much faster and more intuitive than the file dialog.

As far as I'm aware, the only "feature" you lose compared to the old
FileDialog is the ability to show all types of files by changing the
extension filter to "All Files" in the lower right. This seems like an
unnecessary feature anyways, as selecting a file that is not of the
appropriate resource type would just result in an error like so:

```
The selected resource (StreamTexture) does not match any type expected for this property (AudioStream).
```

Relates to godotengine/godot-proposals#346.

The old way:
![filedialog](https://user-images.githubusercontent.com/2496231/77250922-96ec2380-6c21-11ea-8566-8e4cab1e0dd4.gif)

The new way:
![quickopen](https://user-images.githubusercontent.com/2496231/77250923-9784ba00-6c21-11ea-8c82-6e39f6d7d19b.gif)

