### PR TITLE
Improve the editor feature profiles UX

### DIFF
--- a/editor/editor_feature_profile.h
+++ b/editor/editor_feature_profile.h
@@ -121,8 +121,11 @@ class EditorFeatureProfileManager : public AcceptDialog {
 
 	HSplitContainer *h_split;
 
+	VBoxContainer *class_list_vbc;
 	Tree *class_list;
+	VBoxContainer *property_list_vbc;
 	Tree *property_list;
+	Label *no_profile_selected_help;
 
 	EditorFileDialog *import_profiles;
 	EditorFileDialog *export_profile;


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/49643.

- Add an help message when no profile is selected.
  - This replaces the class/property trees which are now hidden when no profile is selected.
- Display `(none)` as the current profile when no profile is currently active.
- Make the newly created/imported profile the current if it's the first profile to be added to the list.
- Make more strings localizable.

These changes should hopefully clear up [some confusion](https://godotengine.org/qa/63892/godot-manage-editor-feature-profiles-is-empty-is-this-normal) related to the editor feature profiles UI :slightly_smiling_face:

## Preview

*No profile has been created yet (freshly opened dialog).*

![image](https://user-images.githubusercontent.com/180032/77260370-d4839780-6c87-11ea-9697-083494c5354f.png)

This closes #39022.