### PR TITLE
[DOCS] Clarify CollisionShape disabled usage

### DIFF
--- a/doc/classes/CollisionShape.xml
+++ b/doc/classes/CollisionShape.xml
@@ -30,6 +30,10 @@
 	<members>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
 			A disabled collision shape has no effect in the world.
+			Note: If you attempt to change this value during physics processing, it will fail with the following error: "Can't change this state while flushing queries. Use call_deferred() or set_deferred() to change monitoring state instead". Use [method]Object.set_deferred[/method] instead.
+			[codeblock]
+				$CollisionShape2D.set_deferred("disabled", false)
+			[/codeblock]
 		</member>
 		<member name="shape" type="Shape" setter="set_shape" getter="get_shape">
 			The actual shape owned by this collision shape.

--- a/doc/classes/CollisionShape2D.xml
+++ b/doc/classes/CollisionShape2D.xml
@@ -14,9 +14,13 @@
 	<members>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
 			A disabled collision shape has no effect in the world.
+			Note: If you attempt to change this value during physics processing, it will fail with the following error: "Can't change this state while flushing queries. Use call_deferred() or set_deferred() to change monitoring state instead". Use [method]Object.set_deferred[/method] instead.
+			[codeblock]
+				$CollisionShape2D.set_deferred("disabled", false)
+			[/codeblock]
 		</member>
 		<member name="one_way_collision" type="bool" setter="set_one_way_collision" getter="is_one_way_collision_enabled" default="false">
-			Sets whether this collision shape should only detect collision on one side (top or bottom).
+			If [code]true[/code], the shape only detects collisions on one side (top or bottom).
 		</member>
 		<member name="one_way_collision_margin" type="float" setter="set_one_way_collision_margin" getter="get_one_way_collision_margin" default="1.0">
 			The margin used for one-way collision (in pixels). Higher values will make the shape thicker, and work better for colliders that enter the shape at a high velocity.

--- a/doc/classes/PinJoint2D.xml
+++ b/doc/classes/PinJoint2D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PinJoint2D" inherits="Joint2D" version="4.0">
 	<brief_description>
-		Pin Joint for 2D shapes.
+		Pin joint for 2D bodies.
 	</brief_description>
 	<description>
-		Pin Joint for 2D rigid bodies. It pins two bodies (rigid or static) together.
+		Pin joint for 2D bodies. It pins two bodies (rigid or static) together.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -6,7 +6,7 @@
 	<description>
 		RandomNumberGenerator is a class for generating pseudo-random numbers. It currently uses [url=http://www.pcg-random.org/]PCG32[/url].
 		[b]Note:[/b] The underlying algorithm is an implementation detail. As a result, it should not be depended upon for reproducible random streams across Godot versions.
-		To generate a random float number (within a given range) based on a time-dependant seed:
+		To generate a random float number (within a given range) based on a time-dependent seed:
 		[codeblock]
 		var rng = RandomNumberGenerator.new()
 		func _ready():
@@ -68,7 +68,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Setups a time-based seed to generator.
+				Randomizes the seed of the random number generator.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Added examples using `set_deferred()` when disabling collision shapes - a common occurrence.

Also fixed a couple of minor typos in RandomNumberGenerator and PinJoint2D