### PR TITLE
SplitContainer fixes.

### DIFF
--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -59,6 +59,7 @@ private:
 	Control *_getch(int p_idx) const;
 
 	void _resort();
+	int _get_separation() const;
 
 protected:
 	void _gui_input(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
SplitContainer fixes:
- non-use of 'bg' custom style. (Close #37215)
- wrong drawing of custom icon.