### PR TITLE
Change the "remove missing" button to disabled rather than hidden

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1859,7 +1859,7 @@ void ProjectManager::_update_project_buttons() {
 	rename_btn->set_disabled(empty_selection || is_missing_project_selected);
 	run_btn->set_disabled(empty_selection || is_missing_project_selected);
 
-	erase_missing_btn->set_visible(_project_list->is_any_project_missing());
+	erase_missing_btn->set_disabled(!_project_list->is_any_project_missing());
 }
 
 void ProjectManager::_unhandled_input(const Ref<InputEvent> &p_ev) {
@@ -2472,6 +2472,7 @@ ProjectManager::ProjectManager() {
 	{
 		// Project tab side bar
 		VBoxContainer *tree_vb = memnew(VBoxContainer);
+		tree_vb->set_custom_minimum_size(Size2(120, 120));
 		projects_hb->add_child(tree_vb);
 
 		Button *create = memnew(Button);


### PR DESCRIPTION
EDIT: Now sets the "Remove missing" button to disabled instead of hiding it.

Since the "Remove Missing" button is wider than the others and also it sometimes doesn't appear, this means that currently the size of these buttons varies, which is a bit strange. This PR sets a minimum size so that the column of buttons will never get thinner than if "Remove Missing" was present.

![Preview](https://user-images.githubusercontent.com/1646875/77293062-f4cb4a80-6cb7-11ea-8ea7-a419666f48fd.png)

The button width might still change for other languages, but there's not much we can do about that.
