### PR TITLE
OS.get_locale() fixed in windows && _OS::get_standardized_locale() implemented

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -562,6 +562,11 @@ String _OS::get_locale() const {
 	return OS::get_singleton()->get_locale();
 }
 
+String _OS::get_standardized_locale() const {
+
+	return get_locale().replace("-", "_");
+}
+
 String _OS::get_latin_keyboard_variant() const {
 	switch (OS::get_singleton()->get_latin_keyboard_variant()) {
 		case OS::LATIN_KEYBOARD_QWERTY: return "QWERTY";
@@ -1295,6 +1300,7 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_ticks_usec"), &_OS::get_ticks_usec);
 	ClassDB::bind_method(D_METHOD("get_splash_tick_msec"), &_OS::get_splash_tick_msec);
 	ClassDB::bind_method(D_METHOD("get_locale"), &_OS::get_locale);
+	ClassDB::bind_method(D_METHOD("get_standardized_locale"), &_OS::get_standardized_locale);
 	ClassDB::bind_method(D_METHOD("get_latin_keyboard_variant"), &_OS::get_latin_keyboard_variant);
 	ClassDB::bind_method(D_METHOD("get_model_name"), &_OS::get_model_name);
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -243,6 +243,7 @@ public:
 	Vector<String> get_cmdline_args();
 
 	String get_locale() const;
+	String get_standardized_locale() const;
 	String get_latin_keyboard_variant() const;
 
 	String get_model_name() const;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -268,6 +268,14 @@
 				Returns the host OS locale.
 			</description>
 		</method>
+		<method name="get_standardized_locale" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns the host OS locale as a string of the form [code]locale[_VARIANT][/code] (e.g. [code]en_US[/code] for American English). The returned String will not depend on the OS or user configuration. See [url=https://docs.godotengine.org/en/latest/tutorials/i18n/locales.html]this page[/url] for examples of locale codes that can be returned.
+				[b]Note:[/b] This method returns [code]en[/code] if the host OS locale can't be detected for any reason.
+			</description>
+		</method>
 		<method name="get_model_name" qualifiers="const">
 			<return type="String">
 			</return>

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -3019,7 +3019,7 @@ String OS_Windows::get_locale() const {
 	LANGID langid = GetUserDefaultUILanguage();
 	String neutral;
 	int lang = langid & ((1 << 9) - 1);
-	int sublang = langid & ~((1 << 9) - 1);
+	int sublang = langid >> 10;
 
 	while (wl->locale) {
 


### PR DESCRIPTION
Fix: #37203, #37207
Authored : @ippan  
Reference: [Microsoft Docs](https://docs.microsoft.com/en-us/windows/win32/intl/language-identifiers), winnt.h

```
+-------------------------+-------------------------+
|     SubLanguage ID      |   Primary Language ID   |
+-------------------------+-------------------------+
15                    10  9                         0   bit
```

sample case 1033 : "en-US"
1033 = 0b0000010000001001
 0-9  bits : 0b0000001001 = 9 => `#define LANG_ENGLISH 0x09` (winnt.h)
10-15 bits :  0b000001 = 1 => `#define SUBLANG_ENGLISH_US 0x01    // English (USA)`
