### PR TITLE
Fix `WM_DELETE` flag being set too late

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -267,6 +267,9 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	unsigned long valuemask = CWBorderPixel | CWColormap | CWEventMask;
 	x11_window = XCreateWindow(x11_display, RootWindow(x11_display, visualInfo->screen), 0, 0, OS::get_singleton()->get_video_mode().width, OS::get_singleton()->get_video_mode().height, 0, visualInfo->depth, InputOutput, visualInfo->visual, valuemask, &windowAttributes);
 
+	wm_delete = XInternAtom(x11_display, "WM_DELETE_WINDOW", true);
+	XSetWMProtocols(x11_display, x11_window, &wm_delete, 1);
+
 	//set_class_hint(x11_display, x11_window);
 	XMapWindow(x11_display, x11_window);
 	XFlush(x11_display);
@@ -475,9 +478,6 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	/* set the titlebar name */
 	XStoreName(x11_display, x11_window, "Godot");
-
-	wm_delete = XInternAtom(x11_display, "WM_DELETE_WINDOW", true);
-	XSetWMProtocols(x11_display, x11_window, &wm_delete, 1);
 
 	im_active = false;
 	im_position = Vector2();


### PR DESCRIPTION
Fixes #37206, and very likely #35490.

Even though the `WM_DELETE` flag was already being set, it wasn't being "picked up" by `bspwm`. Moving the code to just before the window flushing fixed it.

**Please bear in mind** that my experience with X11 API is next to zero, so I don't know the impact of my changes. I haven't tested this on more typical window managers, if someone can test this and see if it doesn't break anything major, it I'd be glad :stuck_out_tongue: