### PR TITLE
Update Android custom template build configuration

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -56,6 +56,11 @@ android {
     compileSdkVersion versions.compileSdk
     buildToolsVersion versions.buildTools
 
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+
     defaultConfig {
         // Feel free to modify the application id to your own.
         applicationId getExportPackageName()

--- a/platform/android/java/app/settings.gradle
+++ b/platform/android/java/app/settings.gradle
@@ -1,0 +1,2 @@
+// Empty settings.gradle file to denote this directory as being the root project
+// of the Godot custom build.


### PR DESCRIPTION
- Add `settings.gradle` file to denote custom build root directory. Fixes #37255
- Allow the use of [Java 8 features](https://developer.android.com/studio/write/java8-support)