### PR TITLE
Define a default minimum window size to workaround rendering issues

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -649,6 +649,8 @@
 			<argument index="0" name="min_size" type="Vector2i" />
 			<argument index="1" name="window_id" type="int" default="0" />
 			<description>
+				Sets the minimum size for the given window to [code]min_size[/code] (in pixels).
+				[b]Note:[/b] By default, the main window has a minimum size of [code]Vector2i(64, 64)[/code]. This prevents issues that can arise when the window is resized to a near-zero size.
 			</description>
 		</method>
 		<method name="window_set_mode">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2242,6 +2242,10 @@ bool Main::start() {
 			DisplayServer::get_singleton()->window_set_title(appname);
 #endif
 
+			// Define a very small minimum window size to prevent bugs such as GH-37242.
+			// It can still be overridden by the user in a script.
+			DisplayServer::get_singleton()->window_set_min_size(Size2i(64, 64));
+
 			bool snap_controls = GLOBAL_DEF("gui/common/snap_controls_to_pixels", true);
 			sml->get_root()->set_snap_controls_to_pixels(snap_controls);
 


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/51973.

The minimum window size can still be set to `Vector2(0, 0)` in a script if needed.

This closes #37242.