### PR TITLE
Set correct RW locks in AnimatedTexture

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2692,7 +2692,7 @@ Ref<Texture2D> AnimatedTexture::get_frame_texture(int p_frame) const {
 void AnimatedTexture::set_frame_duration(int p_frame, float p_duration) {
 	ERR_FAIL_INDEX(p_frame, MAX_FRAMES);
 
-	RWLockRead r(rw_lock);
+	RWLockWrite r(rw_lock);
 
 	frames[p_frame].duration = p_duration;
 }
@@ -2707,6 +2707,8 @@ float AnimatedTexture::get_frame_duration(int p_frame) const {
 
 void AnimatedTexture::set_speed_scale(float p_scale) {
 	ERR_FAIL_COND(p_scale < -1000 || p_scale >= 1000);
+
+	RWLockWrite r(rw_lock);
 
 	speed_scale = p_scale;
 }


### PR DESCRIPTION
One method had incorrect type of lock, the other was missing it at all.
I am also wondering, whether `_update_proxy` shouldn't also be fixed with Write-type of lock, as there are updates to internals of `AnimatedTexture` in it

```c++
void AnimatedTexture::_update_proxy() {

	RWLockRead r(rw_lock); //<- is that one correct? 
                 //  Shouldn't it be RWLockWrite, as there are some modification of internal properties here

	float delta;
	if (prev_ticks == 0) {
		delta = 0;
		prev_ticks = OS::get_singleton()->get_ticks_usec(); //<- UPDATE HERE
	} else {
		uint64_t ticks = OS::get_singleton()->get_ticks_usec();
		delta = float(double(ticks - prev_ticks) / 1000000.0);
		prev_ticks = ticks; // <- UPDATE HERE
	}

	time += delta;  //<- UPDATE HERE

	float limit;

	if (fps == 0) {
		limit = 0;
	} else {
		limit = 1.0 / fps;
	}

	int iter_max = frame_count;
	while (iter_max) {
		float frame_limit = limit + frames[current_frame].delay_sec;

		if (time > frame_limit) {
			current_frame++;  //<- UPDATE HERE
			if (current_frame >= frame_count) {
				current_frame = 0;  //<- UPDATE HERE
			}
			time -= frame_limit;  //<- UPDATE HERE
		} else {
			break;
		}
		iter_max--;
	}

	if (frames[current_frame].texture.is_valid()) {
		VisualServer::get_singleton()->texture_proxy_update(proxy, frames[current_frame].texture->get_rid());
	}
}
```