### PR TITLE
Mark assert lines as safe in gdscript

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2785,6 +2785,7 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 					return;
 				}
 
+				_mark_line_as_safe(line);
 				NewLineNode *nl2 = alloc_node<NewLineNode>();
 				nl2->line = line;
 				p_block->statements.push_back(nl2);
@@ -3299,6 +3300,8 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 					return;
 				}
 
+				int assert_line = tokenizer->get_token_line();
+
 				tokenizer->advance();
 
 				Vector<Node *> args;
@@ -3312,8 +3315,14 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 					return;
 				}
 
+#ifdef DEBUG_ENABLED
+				// Mark as safe, let type check mark as unsafe if needed
+				_mark_line_as_safe(assert_line);
+				_reduce_node_type(args[0]);
+#endif
 				AssertNode *an = alloc_node<AssertNode>();
 				an->condition = _reduce_expression(args[0], p_static);
+				an->line = assert_line;
 
 				if (args.size() == 2) {
 					an->message = _reduce_expression(args[1], p_static);


### PR DESCRIPTION
It was reported at assert lines were not being marked as safe. If there's a reason for assert lines not to be marked safe, just let me know.

Fixes #37258