### PR TITLE
Tweak the message queue maximum size property hint

### DIFF
--- a/core/message_queue.cpp
+++ b/core/message_queue.cpp
@@ -343,14 +343,14 @@ bool MessageQueue::is_flushing() const {
 
 MessageQueue::MessageQueue() {
 
-	ERR_FAIL_COND_MSG(singleton != NULL, "MessageQueue singleton already exist.");
+	ERR_FAIL_COND_MSG(singleton != NULL, "A MessageQueue singleton already exists.");
 	singleton = this;
 	flushing = false;
 
 	buffer_end = 0;
 	buffer_max_used = 0;
 	buffer_size = GLOBAL_DEF_RST("memory/limits/message_queue/max_size_kb", DEFAULT_QUEUE_SIZE_KB);
-	ProjectSettings::get_singleton()->set_custom_property_info("memory/limits/message_queue/max_size_kb", PropertyInfo(Variant::INT, "memory/limits/message_queue/max_size_kb", PROPERTY_HINT_RANGE, "0,2048,1,or_greater"));
+	ProjectSettings::get_singleton()->set_custom_property_info("memory/limits/message_queue/max_size_kb", PropertyInfo(Variant::INT, "memory/limits/message_queue/max_size_kb", PROPERTY_HINT_RANGE, "1024,4096,1,or_greater"));
 	buffer_size *= 1024;
 	buffer = memnew_arr(uint8_t, buffer_size);
 }


### PR DESCRIPTION
The minimum slider value no longer allows decreasing the value below the default, as this can cause things to break in the editor.

The maximum slider value was also increased to 4096 since it can safely be increased to that value (some add-ons may require it).

This closes #37052.