### PR TITLE
Fix: project manager don't consume Enter key #17620

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -307,7 +307,6 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 					if (OS::get_singleton()->has_virtual_keyboard())
 						OS::get_singleton()->hide_virtual_keyboard();
 
-					return;
 				} break;
 
 				case KEY_BACKSPACE: {


### PR DESCRIPTION
Fix: #17620

there was an unexpected return statement in the switch case which keeps the event from accepting.