### PR TITLE
Style: Harmonize header guards to style guide [Core]

### DIFF
--- a/core/color.h
+++ b/core/color.h
@@ -239,4 +239,4 @@ bool Color::operator<(const Color &p_color) const {
 		return r < p_color.r;
 }
 
-#endif
+#endif // COLOR_H

--- a/core/command_queue_mt.h
+++ b/core/command_queue_mt.h
@@ -508,4 +508,4 @@ public:
 #undef CMD_SYNC_TYPE
 #undef DECL_CMD_SYNC
 
-#endif
+#endif // COMMAND_QUEUE_MT_H

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -19,8 +19,8 @@ def make_certs_header(target, source, env):
     buf = zlib.compress(buf)
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-    g.write("#ifndef _CERTS_RAW_H\n")
-    g.write("#define _CERTS_RAW_H\n")
+    g.write("#ifndef CERTS_COMPRESSED_GEN_H\n")
+    g.write("#define CERTS_COMPRESSED_GEN_H\n")
 
     # System certs path. Editor will use them if defined. (for package maintainers)
     path = env['system_certs_path']
@@ -34,7 +34,7 @@ def make_certs_header(target, source, env):
         for i in range(len(buf)):
             g.write("\t" + byte_to_str(buf[i]) + ",\n")
         g.write("};\n")
-    g.write("#endif")
+    g.write("#endif // CERTS_COMPRESSED_GEN_H")
 
     g.close()
     f.close()
@@ -50,8 +50,8 @@ def make_authors_header(target, source, env):
     g = open_utf8(dst, "w")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-    g.write("#ifndef _EDITOR_AUTHORS_H\n")
-    g.write("#define _EDITOR_AUTHORS_H\n")
+    g.write("#ifndef AUTHORS_GEN_H\n")
+    g.write("#define AUTHORS_GEN_H\n")
 
     reading = False
 
@@ -78,7 +78,7 @@ def make_authors_header(target, source, env):
     if reading:
         close_section()
 
-    g.write("#endif\n")
+    g.write("#endif // AUTHORS_GEN_H\n")
 
     g.close()
     f.close()
@@ -96,8 +96,8 @@ def make_donors_header(target, source, env):
     g = open_utf8(dst, "w")
 
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-    g.write("#ifndef _EDITOR_DONORS_H\n")
-    g.write("#define _EDITOR_DONORS_H\n")
+    g.write("#ifndef DONORS_GEN_H\n")
+    g.write("#define DONORS_GEN_H\n")
 
     reading = False
 
@@ -124,7 +124,7 @@ def make_donors_header(target, source, env):
     if reading:
         close_section()
 
-    g.write("#endif\n")
+    g.write("#endif // DONORS_GEN_H\n")
 
     g.close()
     f.close()
@@ -193,8 +193,8 @@ def make_license_header(target, source, env):
     with open_utf8(dst, "w") as f:
 
         f.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-        f.write("#ifndef _EDITOR_LICENSE_H\n")
-        f.write("#define _EDITOR_LICENSE_H\n")
+        f.write("#ifndef LICENSE_GEN_H\n")
+        f.write("#define LICENSE_GEN_H\n")
         f.write("const char *const GODOT_LICENSE_TEXT =")
 
         with open_utf8(src_license, "r") as license_file:
@@ -262,7 +262,7 @@ def make_license_header(target, source, env):
             f.write("\t\"\",\n\n")
         f.write("};\n\n")
 
-        f.write("#endif\n")
+        f.write("#endif // LICENSE_GEN_H\n")
 
 
 if __name__ == '__main__':

--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -97,4 +97,4 @@ public:
 	StringName notification;
 };
 
-#endif // SCENE_STRING_NAMES_H
+#endif // CORE_STRING_NAMES_H

--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -28,14 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef COWDATA_H_
-#define COWDATA_H_
-
-#include <string.h>
+#ifndef COWDATA_H
+#define COWDATA_H
 
 #include "core/error_macros.h"
 #include "core/os/memory.h"
 #include "core/safe_refcount.h"
+
+#include <string.h>
 
 template <class T>
 class Vector;
@@ -371,4 +371,4 @@ CowData<T>::~CowData() {
 	_unref(_ptr);
 }
 
-#endif /* COW_H_ */
+#endif // COWDATA_H

--- a/core/debugger/script_debugger.h
+++ b/core/debugger/script_debugger.h
@@ -77,4 +77,4 @@ public:
 	ScriptDebugger() {}
 };
 
-#endif
+#endif // SCRIPT_DEBUGGER_H

--- a/core/error_list.h
+++ b/core/error_list.h
@@ -90,4 +90,4 @@ enum Error {
 	ERR_PRINTER_ON_FIRE, /// the parallel port printer is engulfed in flames
 };
 
-#endif
+#endif // ERROR_LIST_H

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -623,4 +623,4 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 	} else                                                                                                      \
 		((void)0)
 
-#endif
+#endif // ERROR_MACROS_H

--- a/core/hash_map.h
+++ b/core/hash_map.h
@@ -599,4 +599,4 @@ public:
 	}
 };
 
-#endif
+#endif // HASH_MAP_H

--- a/core/hashfuncs.h
+++ b/core/hashfuncs.h
@@ -38,6 +38,7 @@
 #include "core/string_name.h"
 #include "core/typedefs.h"
 #include "core/ustring.h"
+
 /**
  * Hashing functions
  */
@@ -171,4 +172,4 @@ struct HashMapComparatorDefault {
 	}
 };
 
-#endif
+#endif // HASHFUNCS_H

--- a/core/image.h
+++ b/core/image.h
@@ -396,4 +396,4 @@ VARIANT_ENUM_CAST(Image::UsedChannels)
 VARIANT_ENUM_CAST(Image::AlphaMode)
 VARIANT_ENUM_CAST(Image::RoughnessChannel)
 
-#endif
+#endif // IMAGE_H

--- a/core/int_types.h
+++ b/core/int_types.h
@@ -28,6 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef INT_TYPES_H
+#define INT_TYPES_H
+
 #ifdef _MSC_VER
 
 typedef signed __int8 int8_t;
@@ -54,4 +57,6 @@ typedef unsigned long long uint64_t;
 #include <stdint.h>
 #endif
 
-#endif
+#endif // _MSC_VER
+
+#endif // INT_TYPES_H

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -79,4 +79,4 @@ public:
 	virtual String get_resource_type(const String &p_path) const;
 };
 
-#endif
+#endif // IMAGE_LOADER_H

--- a/core/io/logger.h
+++ b/core/io/logger.h
@@ -107,4 +107,4 @@ public:
 	virtual ~CompositeLogger();
 };
 
-#endif
+#endif // LOGGER_H

--- a/core/io/marshalls.h
+++ b/core/io/marshalls.h
@@ -202,4 +202,4 @@ public:
 Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len = NULL, bool p_allow_objects = false);
 Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bool p_full_objects = false);
 
-#endif
+#endif // MARSHALLS_H

--- a/core/io/multiplayer_api.h
+++ b/core/io/multiplayer_api.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef MULTIPLAYER_PROTOCOL_H
-#define MULTIPLAYER_PROTOCOL_H
+#ifndef MULTIPLAYER_API_H
+#define MULTIPLAYER_API_H
 
 #include "core/io/networked_multiplayer_peer.h"
 #include "core/reference.h"
@@ -148,4 +148,4 @@ public:
 
 VARIANT_ENUM_CAST(MultiplayerAPI::RPCMode);
 
-#endif // MULTIPLAYER_PROTOCOL_H
+#endif // MULTIPLAYER_API_H

--- a/core/io/networked_multiplayer_peer.h
+++ b/core/io/networked_multiplayer_peer.h
@@ -80,4 +80,4 @@ public:
 VARIANT_ENUM_CAST(NetworkedMultiplayerPeer::TransferMode)
 VARIANT_ENUM_CAST(NetworkedMultiplayerPeer::ConnectionStatus)
 
-#endif // NetworkedMultiplayerPeer_H
+#endif // NETWORKED_MULTIPLAYER_PEER_H

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -200,4 +200,4 @@ public:
 	static void finalize();
 };
 
-#endif
+#endif // RESOURCE_LOADER_H

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -90,4 +90,4 @@ public:
 	static void remove_custom_savers();
 };
 
-#endif
+#endif // RESOURCE_SAVER_H

--- a/core/io/stream_peer_tcp.h
+++ b/core/io/stream_peer_tcp.h
@@ -93,4 +93,4 @@ public:
 
 VARIANT_ENUM_CAST(StreamPeerTCP::Status);
 
-#endif
+#endif // STREAM_PEER_TCP_H

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -121,4 +121,4 @@ public:
 	~XMLParser();
 };
 
-#endif
+#endif // XML_PARSER_H

--- a/core/list.h
+++ b/core/list.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GLOBALS_LIST_H
-#define GLOBALS_LIST_H
+#ifndef LIST_H
+#define LIST_H
 
 #include "core/error_macros.h"
 #include "core/os/memory.h"
@@ -708,4 +708,4 @@ public:
 	};
 };
 
-#endif
+#endif // LIST_H

--- a/core/map.h
+++ b/core/map.h
@@ -682,4 +682,4 @@ public:
 	}
 };
 
-#endif
+#endif // MAP_H

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef ASTAR_H
-#define ASTAR_H
+#ifndef A_STAR_H
+#define A_STAR_H
 
 #include "core/oa_hash_map.h"
 #include "core/reference.h"
@@ -210,4 +210,4 @@ public:
 	~AStar2D();
 };
 
-#endif // ASTAR_H
+#endif // A_STAR_H

--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOFRAME_H
-#define AUDIOFRAME_H
+#ifndef AUDIO_FRAME_H
+#define AUDIO_FRAME_H
 
 #include "core/math/vector2.h"
 #include "core/typedefs.h"
@@ -140,4 +140,4 @@ struct AudioFrame {
 	_ALWAYS_INLINE_ AudioFrame() {}
 };
 
-#endif
+#endif // AUDIO_FRAME_H

--- a/core/math/camera_matrix.h
+++ b/core/math/camera_matrix.h
@@ -124,4 +124,4 @@ Vector3 CameraMatrix::xform(const Vector3 &p_vec3) const {
 	return ret / w;
 }
 
-#endif
+#endif // CAMERA_MATRIX_H

--- a/core/math/disjoint_set.h
+++ b/core/math/disjoint_set.h
@@ -152,4 +152,4 @@ void DisjointSet<T, C, AL>::get_members(Vector<T> &out_members, T representative
 	}
 }
 
-#endif
+#endif // DISJOINT_SET_H

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -1019,4 +1019,4 @@ private:
 	static Vector<Vector<Point2>> _polypath_offset(const Vector<Point2> &p_polypath, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type);
 };
 
-#endif
+#endif // GEOMETRY_H

--- a/core/math/octree.h
+++ b/core/math/octree.h
@@ -1375,4 +1375,4 @@ Octree<T, use_pairs, AL>::Octree(real_t p_unit_size) {
 	unpair_callback_userdata = NULL;
 }
 
-#endif
+#endif // OCTREE_H

--- a/core/math/quat.h
+++ b/core/math/quat.h
@@ -231,4 +231,4 @@ bool Quat::operator!=(const Quat &p_quat) const {
 	return x != p_quat.x || y != p_quat.y || z != p_quat.z || w != p_quat.w;
 }
 
-#endif
+#endif // QUAT_H

--- a/core/math/triangulate.h
+++ b/core/math/triangulate.h
@@ -58,4 +58,4 @@ private:
 	static bool snip(const Vector<Vector2> &p_contour, int u, int v, int w, int n, const Vector<int> &V, bool relaxed);
 };
 
-#endif
+#endif // TRIANGULATE_H

--- a/core/method_bind.h
+++ b/core/method_bind.h
@@ -405,4 +405,4 @@ class __UnexistingClass;
 
 #include "method_bind.gen.inc"
 
-#endif
+#endif // METHOD_BIND_H

--- a/core/node_path.h
+++ b/core/node_path.h
@@ -97,4 +97,4 @@ public:
 	~NodePath();
 };
 
-#endif
+#endif // NODE_PATH_H

--- a/core/oa_hash_map.h
+++ b/core/oa_hash_map.h
@@ -369,4 +369,4 @@ public:
 	}
 };
 
-#endif
+#endif // OA_HASH_MAP_H

--- a/core/object.h
+++ b/core/object.h
@@ -817,4 +817,4 @@ public:
 //needed by macros
 #include "core/class_db.h"
 
-#endif
+#endif // OBJECT_H

--- a/core/os/copymem.h
+++ b/core/os/copymem.h
@@ -47,4 +47,4 @@
 
 #endif
 
-#endif
+#endif // COPYMEM_H

--- a/core/os/dir_access.h
+++ b/core/os/dir_access.h
@@ -149,4 +149,4 @@ struct DirAccessRef {
 	}
 };
 
-#endif
+#endif // DIR_ACCESS_H

--- a/core/os/file_access.h
+++ b/core/os/file_access.h
@@ -196,4 +196,4 @@ struct FileAccessRef {
 	}
 };
 
-#endif
+#endif // FILE_ACCESS_H

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -622,4 +622,4 @@ public:
 	InputEventMIDI();
 };
 
-#endif
+#endif // INPUT_EVENT_H

--- a/core/os/keyboard.h
+++ b/core/os/keyboard.h
@@ -325,4 +325,4 @@ int keycode_get_count();
 int keycode_get_value_by_index(int p_index);
 const char *keycode_get_name_by_index(int p_index);
 
-#endif
+#endif // KEYBOARD_H

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -81,4 +81,4 @@ public:
 	virtual ~MainLoop();
 };
 
-#endif
+#endif // MAIN_LOOP_H

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -206,4 +206,4 @@ struct _GlobalNilClass {
 	static _GlobalNil _nil;
 };
 
-#endif
+#endif // MEMORY_H

--- a/core/os/midi_driver.h
+++ b/core/os/midi_driver.h
@@ -58,4 +58,4 @@ public:
 	virtual ~MIDIDriver() {}
 };
 
-#endif
+#endif // MIDI_DRIVER_H

--- a/core/os/mutex.h
+++ b/core/os/mutex.h
@@ -105,4 +105,4 @@ using BinaryMutex = MutexImpl<FakeMutex>; // Non-recursive, handle with care
 
 #endif // !NO_THREADS
 
-#endif
+#endif // MUTEX_H

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -527,4 +527,4 @@ public:
 	virtual ~OS();
 };
 
-#endif
+#endif // OS_H

--- a/core/os/rw_lock.h
+++ b/core/os/rw_lock.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RWLOCK_H
-#define RWLOCK_H
+#ifndef RW_LOCK_H
+#define RW_LOCK_H
 
 #include "core/error_list.h"
 
@@ -79,4 +79,4 @@ public:
 	}
 };
 
-#endif // RWLOCK_H
+#endif // RW_LOCK_H

--- a/core/os/semaphore.h
+++ b/core/os/semaphore.h
@@ -80,4 +80,4 @@ public:
 
 #endif
 
-#endif
+#endif // SEMAPHORE_H

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -77,4 +77,4 @@ public:
 	virtual ~Thread();
 };
 
-#endif
+#endif // THREAD_H

--- a/core/os/thread_dummy.h
+++ b/core/os/thread_dummy.h
@@ -61,4 +61,4 @@ public:
 	static void make_default();
 };
 
-#endif
+#endif // THREAD_DUMMY_H

--- a/core/os/thread_safe.h
+++ b/core/os/thread_safe.h
@@ -38,4 +38,4 @@
 #define _THREAD_SAFE_LOCK_ _thread_safe_.lock();
 #define _THREAD_SAFE_UNLOCK_ _thread_safe_.unlock();
 
-#endif
+#endif // THREAD_SAFE_H

--- a/core/pool_allocator.h
+++ b/core/pool_allocator.h
@@ -148,4 +148,4 @@ public:
 	virtual ~PoolAllocator();
 };
 
-#endif
+#endif // POOL_ALLOCATOR_H

--- a/core/print_string.h
+++ b/core/print_string.h
@@ -60,4 +60,4 @@ extern void print_line(String p_string);
 extern void print_error(String p_string);
 extern void print_verbose(String p_string);
 
-#endif
+#endif // PRINT_STRING_H

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GLOBAL_CONFIG_H
-#define GLOBAL_CONFIG_H
+#ifndef PROJECT_SETTINGS_H
+#define PROJECT_SETTINGS_H
 
 #include "core/object.h"
 #include "core/os/thread_safe.h"
@@ -166,4 +166,4 @@ Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restar
 #define GLOBAL_DEF_RST(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
 #define GLOBAL_GET(m_var) ProjectSettings::get_singleton()->get(m_var)
 
-#endif
+#endif // PROJECT_SETTINGS_H

--- a/core/register_core_types.h
+++ b/core/register_core_types.h
@@ -36,4 +36,4 @@ void register_core_settings();
 void register_core_singletons();
 void unregister_core_types();
 
-#endif
+#endif // REGISTER_CORE_TYPES_H

--- a/core/resource.h
+++ b/core/resource.h
@@ -167,4 +167,4 @@ public:
 	static int get_cached_resource_count();
 };
 
-#endif
+#endif // RESOURCE_H

--- a/core/rid.h
+++ b/core/rid.h
@@ -75,4 +75,4 @@ public:
 	}
 };
 
-#endif
+#endif // RID_H

--- a/core/ring_buffer.h
+++ b/core/ring_buffer.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RINGBUFFER_H
-#define RINGBUFFER_H
+#ifndef RING_BUFFER_H
+#define RING_BUFFER_H
 
 #include "core/vector.h"
 
@@ -221,4 +221,4 @@ public:
 	~RingBuffer<T>(){};
 };
 
-#endif
+#endif // RING_BUFFER_H

--- a/core/safe_refcount.h
+++ b/core/safe_refcount.h
@@ -208,4 +208,4 @@ public:
 	}
 };
 
-#endif
+#endif // SAFE_REFCOUNT_H

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -459,4 +459,5 @@ public:
 	PlaceHolderScriptInstance(ScriptLanguage *p_language, Ref<Script> p_script, Object *p_owner);
 	~PlaceHolderScriptInstance();
 };
-#endif
+
+#endif // SCRIPT_LANGUAGE_H

--- a/core/set.h
+++ b/core/set.h
@@ -634,4 +634,4 @@ public:
 	}
 };
 
-#endif
+#endif // SET_H

--- a/core/simple_type.h
+++ b/core/simple_type.h
@@ -51,4 +51,4 @@ struct GetSimpleTypeT<T const> {
 	typedef T type_t;
 };
 
-#endif
+#endif // SIMPLE_TYPE_H

--- a/core/string_buffer.h
+++ b/core/string_buffer.h
@@ -163,4 +163,4 @@ int64_t StringBuffer<SHORT_BUFFER_SIZE>::as_int() {
 	return String::to_int(current_buffer_ptr());
 }
 
-#endif
+#endif // STRING_BUFFER_H

--- a/core/type_info.h
+++ b/core/type_info.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GET_TYPE_INFO_H
-#define GET_TYPE_INFO_H
+#ifndef TYPE_INFO_H
+#define TYPE_INFO_H
 
 #ifdef DEBUG_METHODS_ENABLED
 
@@ -273,4 +273,4 @@ inline StringName __constant_get_enum_name(T param, const String &p_constant) {
 
 #endif // DEBUG_METHODS_ENABLED
 
-#endif // GET_TYPE_INFO_H
+#endif // TYPE_INFO_H

--- a/core/ucaps.h
+++ b/core/ucaps.h
@@ -1413,4 +1413,5 @@ static int _find_lower(int ch) {
 
 	return ch;
 }
-#endif
+
+#endif // UCAPS_H

--- a/core/variant.h
+++ b/core/variant.h
@@ -516,4 +516,5 @@ const Variant::ObjData &Variant::_get_obj() const {
 }
 
 String vformat(const String &p_text, const Variant &p1 = Variant(), const Variant &p2 = Variant(), const Variant &p3 = Variant(), const Variant &p4 = Variant(), const Variant &p5 = Variant());
-#endif
+
+#endif // VARIANT_H

--- a/core/vector.h
+++ b/core/vector.h
@@ -181,4 +181,4 @@ bool Vector<T>::push_back(T p_elem) {
 	return false;
 }
 
-#endif
+#endif // VECTOR_H

--- a/core/version.h
+++ b/core/version.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_VERSION_H
-#define GODOT_VERSION_H
+#ifndef VERSION_H
+#define VERSION_H
 
 #include "core/version_generated.gen.h"
 
@@ -68,4 +68,4 @@
 // Example: "Godot v3.1.4.stable.official.mono"
 #define VERSION_FULL_NAME "" VERSION_NAME " v" VERSION_FULL_BUILD
 
-#endif // GODOT_VERSION_H
+#endif // VERSION_H

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PROJECT_SETTINGS_H
-#define PROJECT_SETTINGS_H
+#ifndef PROJECT_SETTINGS_EDITOR_H
+#define PROJECT_SETTINGS_EDITOR_H
 
 #include "core/undo_redo.h"
 #include "editor/editor_autoload_settings.h"
@@ -204,4 +204,4 @@ public:
 	ProjectSettingsEditor(EditorData *p_data);
 };
 
-#endif // PROJECT_SETTINGS_H
+#endif // PROJECT_SETTINGS_EDITOR_H

--- a/methods.py
+++ b/methods.py
@@ -62,6 +62,9 @@ def update_version(module_version_string=""):
 
     # NOTE: It is safe to generate this file here, since this is still executed serially
     f = open("core/version_generated.gen.h", "w")
+    f.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+    f.write("#ifndef VERSION_GENERATED_GEN_H\n")
+    f.write("#define VERSION_GENERATED_GEN_H\n")
     f.write("#define VERSION_SHORT_NAME \"" + str(version.short_name) + "\"\n")
     f.write("#define VERSION_NAME \"" + str(version.name) + "\"\n")
     f.write("#define VERSION_MAJOR " + str(version.major) + "\n")
@@ -72,10 +75,14 @@ def update_version(module_version_string=""):
     f.write("#define VERSION_MODULE_CONFIG \"" + str(version.module_config) + module_version_string + "\"\n")
     f.write("#define VERSION_YEAR " + str(version.year) + "\n")
     f.write("#define VERSION_WEBSITE \"" + str(version.website) + "\"\n")
+    f.write("#endif // VERSION_GENERATED_GEN_H\n")
     f.close()
 
     # NOTE: It is safe to generate this file here, since this is still executed serially
     fhash = open("core/version_hash.gen.h", "w")
+    fhash.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+    fhash.write("#ifndef VERSION_HASH_GEN_H\n")
+    fhash.write("#define VERSION_HASH_GEN_H\n")
     githash = ""
     gitfolder = ".git"
 
@@ -93,7 +100,8 @@ def update_version(module_version_string=""):
         else:
             githash = head
 
-    fhash.write("#define VERSION_HASH \"" + githash + "\"")
+    fhash.write("#define VERSION_HASH \"" + githash + "\"\n")
+    fhash.write("#endif // VERSION_HASH_GEN_H\n")
     fhash.close()
 
 


### PR DESCRIPTION
Reviewed all `core/` headers to ensure that they have header guards that match their file name, and and that the last `#endif` includes the name of the guard as comment, as in our guidelines: http://docs.godotengine.org/en/latest/community/contributing/code_style_guidelines.html#header-includes

I'll leave the rest of the codebase for another contributor to have a look at, but instead of doing it manually, I would suggest writing a script that we can use periodically to parse and fix the codebase, as we do with `misc/scripts/fix_headers.py`. Some special cases need to be handled too as those added in #37143 (i.e. guards which don't directly match their file name to avoid duplicates).

---

To review header guards for all headers:
```
find -name thirdparty -prune -o -name "*.h" | sort > headers
for file in $(cat headers); do echo -e "\n$file"; grep "#ifndef .*_H" $file; done > output
```