### PR TITLE
Improved go-to definition (Ctrl + Click)

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1042,6 +1042,7 @@ void EditorHelp::_update_doc() {
 				class_desc->pop(); // color
 				class_desc->pop(); // font
 				class_desc->pop(); // cell
+				method_line[cd.properties[i].setter] = property_line[cd.properties[i].name];
 			}
 
 			if (cd.properties[i].getter != "") {
@@ -1059,6 +1060,7 @@ void EditorHelp::_update_doc() {
 				class_desc->pop(); //color
 				class_desc->pop(); //font
 				class_desc->pop(); //cell
+				method_line[cd.properties[i].getter] = property_line[cd.properties[i].name];
 			}
 
 			class_desc->pop(); // table

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -977,6 +977,26 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 				emit_signal("go_to_help", "class_global:" + result.class_name + ":" + result.class_member);
 			} break;
 		}
+	} else if (ProjectSettings::get_singleton()->has_setting("autoload/" + p_symbol)) {
+		//check for Autoload scenes
+		String path = ProjectSettings::get_singleton()->get("autoload/" + p_symbol);
+		if (path.begins_with("*")) {
+			path = path.substr(1, path.length());
+			EditorNode::get_singleton()->load_scene(path);
+		}
+	} else if (p_symbol.is_rel_path()) {
+		// Every symbol other than absolute path is relative path so keep this condition at last.
+		String path = _get_absolute_path(p_symbol);
+		if (FileAccess::exists(path)) {
+			List<String> scene_extensions;
+			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &scene_extensions);
+
+			if (scene_extensions.find(path.get_extension())) {
+				EditorNode::get_singleton()->load_scene(path);
+			} else {
+				EditorNode::get_singleton()->load_resource(path);
+			}
+		}
 	}
 }
 
@@ -990,11 +1010,26 @@ void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 	}
 
 	ScriptLanguage::LookupResult result;
-	if (ScriptServer::is_global_class(p_symbol) || p_symbol.is_resource_file() || script->get_language()->lookup_code(code_editor->get_text_edit()->get_text_for_lookup_completion(), p_symbol, script->get_path(), base, result) == OK) {
+	if (ScriptServer::is_global_class(p_symbol) || p_symbol.is_resource_file() || script->get_language()->lookup_code(code_editor->get_text_edit()->get_text_for_lookup_completion(), p_symbol, script->get_path(), base, result) == OK || ProjectSettings::get_singleton()->has_setting("autoload/" + p_symbol)) {
 		text_edit->set_highlighted_word(p_symbol);
+	} else if (p_symbol.is_rel_path()) {
+
+		String path = _get_absolute_path(p_symbol);
+		if (FileAccess::exists(path)) {
+			text_edit->set_highlighted_word(p_symbol);
+		} else {
+			text_edit->set_highlighted_word(String());
+		}
+
 	} else {
 		text_edit->set_highlighted_word(String());
 	}
+}
+
+String ScriptTextEditor::_get_absolute_path(const String &rel_path) {
+	String base_path = script->get_path().get_base_dir();
+	String path = base_path.plus_file(rel_path);
+	return path.replace("///", "//").simplify_path();
 }
 
 void ScriptTextEditor::update_toggle_scripts_button() {

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -188,6 +188,8 @@ protected:
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
+	String _get_absolute_path(const String &rel_path);
+
 public:
 	void _update_connected_methods();
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1425,6 +1425,7 @@ static bool _guess_identifier_type_from_base(GDScriptCompletionContext &p_contex
 									// Variable used in the same expression
 									return false;
 								}
+
 								if (_guess_expression_type(p_context, m.expression, r_type)) {
 									return true;
 								}
@@ -3482,6 +3483,17 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 			GDScriptParser::DataType base_type = context._class->base_type;
 
 			if (_lookup_symbol_from_base(base_type, p_symbol, true, r_result) == OK) {
+				return OK;
+			}
+		} break;
+		case GDScriptParser::COMPLETION_TYPE_HINT: {
+
+			GDScriptParser::DataType base_type = context._class->base_type;
+			base_type.has_type = true;
+			base_type.kind = GDScriptParser::DataType::CLASS;
+			base_type.class_type = const_cast<GDScriptParser::ClassNode *>(context._class);
+
+			if (_lookup_symbol_from_base(base_type, p_symbol, false, r_result) == OK) {
 				return OK;
 			}
 		} break;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -8497,7 +8497,13 @@ Error GDScriptParser::_parse(const String &p_base_path) {
 		_set_error("Parse error: " + tokenizer->get_token_error());
 	}
 
-	if (error_set && !for_completion) {
+	bool for_completion_error_set = false;
+	if (error_set && for_completion) {
+		for_completion_error_set = true;
+		error_set = false;
+	}
+
+	if (error_set) {
 		return ERR_PARSE_ERROR;
 	}
 
@@ -8526,6 +8532,10 @@ Error GDScriptParser::_parse(const String &p_base_path) {
 
 	// Resolve the function blocks
 	_check_class_blocks_types(main_class);
+
+	if (for_completion_error_set) {
+		error_set = true;
+	}
 
 	if (error_set) {
 		return ERR_PARSE_ERROR;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1158,7 +1158,7 @@ void TextEdit::_notification(int p_what) {
 						highlighted_text_col = _get_column_pos_of_word(highlighted_text, str, SEARCH_MATCH_CASE | SEARCH_WHOLE_WORDS, 0);
 
 					if (select_identifiers_enabled && highlighted_word.length() != 0) {
-						if (_is_char(highlighted_word[0])) {
+						if (_is_char(highlighted_word[0]) || highlighted_word[0] == '.') {
 							highlighted_word_col = _get_column_pos_of_word(highlighted_word, fullstr, SEARCH_MATCH_CASE | SEARCH_WHOLE_WORDS, 0);
 						}
 					}


### PR DESCRIPTION
There is a tracker for Go to definition (#33898)

This pr fixes
- [x] Relative paths
- [x] Preloaded script used as a type
- [x] Property accessors
- [x] Typed onready variables
- [x] Members of custom class' properties (thanks to @bojidar-bg)
- [x] Methods from custom classes used as argument types (thanks to @bojidar-bg)
- [x] Autoload singletons with built-in scripts

~~There is an issue that paths starting with "." are not highlighting but ctrl+click works.~~

*Bugsquad edit:* Fixes #33898. Fixes #33859.