### PR TITLE
[3.x] Fix `WM_DELETE` flag being set too late

### DIFF
--- a/platform/x11/context_gl_x11.cpp
+++ b/platform/x11/context_gl_x11.cpp
@@ -84,7 +84,7 @@ static void set_class_hint(Display *p_display, Window p_window) {
 	XFree(classHint);
 }
 
-Error ContextGL_X11::initialize() {
+Error ContextGL_X11::initialize(Atom &wm_delete) {
 
 	//const char *extensions = glXQueryExtensionsString(x11_display, DefaultScreen(x11_display));
 
@@ -198,6 +198,8 @@ Error ContextGL_X11::initialize() {
 	ERR_FAIL_COND_V(!x11_window, ERR_UNCONFIGURED);
 	set_class_hint(x11_display, x11_window);
 	XMapWindow(x11_display, x11_window);
+
+	XSetWMProtocols(x11_display, x11_window, &wm_delete, 1);
 
 	XSync(x11_display, False);
 	XSetErrorHandler(oldHandler);

--- a/platform/x11/context_gl_x11.h
+++ b/platform/x11/context_gl_x11.h
@@ -69,7 +69,7 @@ public:
 	int get_window_width();
 	int get_window_height();
 
-	Error initialize();
+	Error initialize(Atom &wm_delete);
 
 	void set_use_vsync(bool p_use);
 	bool is_using_vsync() const;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -193,6 +193,7 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	}
 
 	xim = XOpenIM(x11_display, NULL, NULL, NULL);
+	wm_delete = XInternAtom(x11_display, "WM_DELETE_WINDOW", true);
 
 	if (xim == NULL) {
 		WARN_PRINT("XOpenIM failed");
@@ -301,7 +302,7 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 	while (!context_gl) {
 		context_gl = memnew(ContextGL_X11(x11_display, x11_window, current_videomode, opengl_api_type));
 
-		if (context_gl->initialize() != OK) {
+		if (context_gl->initialize(wm_delete) != OK) {
 			memdelete(context_gl);
 			context_gl = NULL;
 
@@ -474,9 +475,6 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	/* set the titlebar name */
 	XStoreName(x11_display, x11_window, "Godot");
-
-	wm_delete = XInternAtom(x11_display, "WM_DELETE_WINDOW", true);
-	XSetWMProtocols(x11_display, x11_window, &wm_delete, 1);
 
 	im_active = false;
 	im_position = Vector2();


### PR DESCRIPTION
Re-implementation of #37247 for the `3.2` branch.

The code structure is very different from the `master`, making it harder to implement *(because the window is being created in the `ContextGL_X11` and not `OS_X11`, and to fix this I need to have access to the `wm_delete` atom from `OS_X11`)*

I made it so this atom has to be passed to the `initialize` method. I don't yet know much about Godot's codestyle and/or how you solve problems like these, so feel free to modify the code to a more pleasant solution.