### PR TITLE
SCons: Optimize generation of help text for speed

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -553,19 +553,24 @@ if selected_platform in platform_list:
 
     Export('env')
 
-    # build subdirs, the build order is dependent on link order.
-
-    SConscript("core/SCsub")
-    SConscript("servers/SCsub")
-    SConscript("scene/SCsub")
-    SConscript("editor/SCsub")
-    SConscript("drivers/SCsub")
-
-    SConscript("platform/SCsub")
-    SConscript("modules/SCsub")
-    SConscript("main/SCsub")
-
-    SConscript("platform/" + selected_platform + "/SCsub")  # build selected platform
+    # Build subdirs, the build order is dependent on the link order.
+    subdirs = [
+        "core",
+        "servers",
+        "scene",
+        "editor",
+        "drivers",
+        "platform",
+        "modules",
+        "main",
+        "platform/" + selected_platform,
+    ]
+    for d in subdirs:
+        if GetOption("help") and d != "modules":
+            # Platform options are handled above. It's safe to skip everything
+            # except for the modules which can define their own options in SCsub.
+            continue
+        SConscript(d + "/SCsub")
 
     # Microsoft Visual Studio Project Generation
     if env['vsproj']:


### PR DESCRIPTION
The SConscripts are skipped for subdirectories which don't provide any options nor generate help text, saving the time it takes to generate the text with `scons --help`.

Modules are not skipped as some of them may append to help text generation while parsing the scripts (as seen in `mono` module #37112). This also applies to any custom module which is not part of Godot.

Platform-specific options are not skipped because they are not collected via `SConscript` calls (see `detect.get_opts()` method calls for each platform).

This is described as a typical optimization use case in the SCons user guide for the [`GetOption`](https://scons.org/doc/3.1.2/HTML/scons-user.html#idm2150) function.

## Perfomance gains

Without this PR: **~8** seconds.
With this PR: **~6** seconds.

So this saves **1-2** seconds on my machine for `scons --help` to print. If we skip modules, the gains are even more noticeable (additional 2 second gains). But in order to remain correctness, modules have to be parsed anyway, so we can't really optimize it here, and we also need to take into account that custom modules can define options in their `SCsub`s too.

## Principles

Correctness and Performance are part of [SCons Principles](https://www.scons.org/doc/HTML/scons-user/pr01.html#idm33) which state that:

> Given that the build is correct, we try to make SCons build software as quickly as possible. In particular, wherever we may have needed to slow down the default SCons behavior to guarantee a correct build, we also try to make it easy to speed up SCons through optimization options that let you trade off guaranteed correctness in all end cases for a speedier build in the usual cases.

So, if you feel like the correctness is more important, I don't really mind. The risk is that someone refactors the build system and the options get ignored (like if we move platform specific `detect.get_opts()` methods to each platform's `SCsub` or similar).