### PR TITLE
Handle huge path2d offset values

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -321,16 +321,14 @@ void PathFollow2D::set_offset(float p_offset) {
 
 	offset = p_offset;
 	if (path) {
-		if (path->get_curve().is_valid() && path->get_curve()->get_baked_length()) {
+		if (path->get_curve().is_valid()) {
 			float path_length = path->get_curve()->get_baked_length();
 
 			if (loop) {
-				while (offset > path_length)
-					offset -= path_length;
-
-				while (offset < 0)
-					offset += path_length;
-
+				offset = Math::fposmod(offset, path_length);
+				if (!Math::is_zero_approx(p_offset) && Math::is_zero_approx(offset)) {
+					offset = path_length;
+				}
 			} else {
 				offset = CLAMP(offset, 0, path_length);
 			}

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -316,16 +316,14 @@ void PathFollow3D::set_offset(float p_offset) {
 	offset = p_offset;
 
 	if (path) {
-		if (path->get_curve().is_valid() && path->get_curve()->get_baked_length()) {
+		if (path->get_curve().is_valid()) {
 			float path_length = path->get_curve()->get_baked_length();
 
 			if (loop) {
-				while (offset > path_length)
-					offset -= path_length;
-
-				while (offset < 0)
-					offset += path_length;
-
+				offset = Math::fposmod(offset, path_length);
+				if (!Math::is_zero_approx(p_offset) && Math::is_zero_approx(offset)) {
+					offset = path_length;
+				}
 			} else {
 				offset = CLAMP(offset, 0, path_length);
 			}


### PR DESCRIPTION
If `set_offset` is called with huge `p_offset` values, the game will freeze practically forever, since it's subtracting a small value from a huge value in a loop.

This issue was not present in 3.1.2.

After 3.1.2, it seems like the loop-handling was moved from `_update_transform` to `set_offset` and in the process the implementation changed from using `Math::fposmod` to a while-loop.

This commit fixes the underlying issue by using `Math::fposmod` again (i.e. the old way from 3.1.2).