### PR TITLE
Better damping implementation for Bullet rigid bodies

### DIFF
--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -204,6 +204,8 @@ if env["builtin_bullet"]:
     # if env['target'] == "debug" or env['target'] == "release_debug":
     #     env_bullet.Append(CPPDEFINES=['BT_DEBUG'])
 
+    env_bullet.Append(CPPDEFINES=["BT_USE_OLD_DAMPING_METHOD"])
+
     env_thirdparty = env_bullet.Clone()
     env_thirdparty.disable_warnings()
     env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -342,6 +342,8 @@ SpaceBullet::SpaceBullet() :
 		godotFilterCallback(nullptr),
 		gravityDirection(0, -1, 0),
 		gravityMagnitude(10),
+		linear_damp(0.0),
+		angular_damp(0.0),
 		contactDebugCount(0),
 		delta_time(0.) {
 
@@ -379,8 +381,11 @@ void SpaceBullet::set_param(PhysicsServer3D::AreaParameter p_param, const Varian
 			update_gravity();
 			break;
 		case PhysicsServer3D::AREA_PARAM_LINEAR_DAMP:
+			linear_damp = p_value;
+			break;
 		case PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP:
-			break; // No damp
+			angular_damp = p_value;
+			break;
 		case PhysicsServer3D::AREA_PARAM_PRIORITY:
 			// Priority is always 0, the lower
 			break;
@@ -401,8 +406,9 @@ Variant SpaceBullet::get_param(PhysicsServer3D::AreaParameter p_param) {
 		case PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR:
 			return gravityDirection;
 		case PhysicsServer3D::AREA_PARAM_LINEAR_DAMP:
+			return linear_damp;
 		case PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP:
-			return 0; // No damp
+			return angular_damp;
 		case PhysicsServer3D::AREA_PARAM_PRIORITY:
 			return 0; // Priority is always 0, the lower
 		case PhysicsServer3D::AREA_PARAM_GRAVITY_IS_POINT:

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -108,6 +108,9 @@ class SpaceBullet : public RIDBullet {
 	Vector3 gravityDirection;
 	real_t gravityMagnitude;
 
+	real_t linear_damp;
+	real_t angular_damp;
+
 	Vector<AreaBullet *> areas;
 
 	Vector<Vector3> contactDebug;
@@ -176,6 +179,9 @@ public:
 	real_t get_gravity_magnitude() const { return gravityMagnitude; }
 
 	void update_gravity();
+
+	real_t get_linear_damp() const { return linear_damp; }
+	real_t get_angular_damp() const { return angular_damp; }
 
 	bool test_body_motion(RigidBodyBullet *p_body, const Transform &p_from, const Vector3 &p_motion, bool p_infinite_inertia, PhysicsServer3D::MotionResult *r_result, bool p_exclude_raycast_shapes);
 	int test_ray_separation(RigidBodyBullet *p_body, const Transform &p_transform, bool p_infinite_inertia, Vector3 &r_recover_motion, PhysicsServer3D::SeparationResult *r_results, int p_result_max, float p_margin);


### PR DESCRIPTION
Apply linear and angular damping in `RigidBodyBullet` to replace the default implementation in Bullet, in order to make it easier to tweak and consistent with Godot Physics.

**Edit**: Implementation changed to use the old method for damping within bullet instead of re-implementing it on godot side.

Fixes #19182
Fixes #30991