### PR TITLE
Add PhysicalBone rotation, damping, axis lock & can sleep

### DIFF
--- a/doc/classes/PhysicalBone3D.xml
+++ b/doc/classes/PhysicalBone3D.xml
@@ -45,21 +45,62 @@
 		</method>
 	</methods>
 	<members>
+		<member name="angular_damp" type="float" setter="set_angular_damp" getter="get_angular_damp" default="-1.0">
+			Damps the body's rotation if greater than [code]0[/code].
+		</member>
+		<member name="axis_lock_angular_x" type="bool" setter="set_axis_lock" getter="get_axis_lock" default="false">
+			Lock the body's rotation in the X axis.
+		</member>
+		<member name="axis_lock_angular_y" type="bool" setter="set_axis_lock" getter="get_axis_lock" default="false">
+			Lock the body's rotation in the Y axis.
+		</member>
+		<member name="axis_lock_angular_z" type="bool" setter="set_axis_lock" getter="get_axis_lock" default="false">
+			Lock the body's rotation in the Z axis.
+		</member>
+		<member name="axis_lock_linear_x" type="bool" setter="set_axis_lock" getter="get_axis_lock" default="false">
+			Lock the body's movement in the X axis.
+		</member>
+		<member name="axis_lock_linear_y" type="bool" setter="set_axis_lock" getter="get_axis_lock" default="false">
+			Lock the body's movement in the Y axis.
+		</member>
+		<member name="axis_lock_linear_z" type="bool" setter="set_axis_lock" getter="get_axis_lock" default="false">
+			Lock the body's movement in the Z axis.
+		</member>
 		<member name="body_offset" type="Transform" setter="set_body_offset" getter="get_body_offset" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+			Sets the body's transform.
 		</member>
 		<member name="bounce" type="float" setter="set_bounce" getter="get_bounce" default="0.0">
+			The body's bounciness. Values range from [code]0[/code] (no bounce) to [code]1[/code] (full bounciness).
+		</member>
+		<member name="can_sleep" type="bool" setter="set_can_sleep" getter="is_able_to_sleep" default="true">
+			If [code]true[/code], the body is deactivated when there is no movement, so it will not take part in the simulation until it is awaken by an external force.
 		</member>
 		<member name="friction" type="float" setter="set_friction" getter="get_friction" default="1.0">
+			The body's friction, from [code]0[/code] (frictionless) to [code]1[/code] (max friction).
 		</member>
 		<member name="gravity_scale" type="float" setter="set_gravity_scale" getter="get_gravity_scale" default="1.0">
+			This is multiplied by the global 3D gravity setting found in [b]Project &gt; Project Settings &gt; Physics &gt; 3d[/b] to produce the body's gravity. For example, a value of 1 will be normal gravity, 2 will apply double gravity, and 0.5 will apply half gravity to this object.
 		</member>
 		<member name="joint_offset" type="Transform" setter="set_joint_offset" getter="get_joint_offset" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+			Sets the joint's transform.
+		</member>
+		<member name="joint_rotation" type="Vector3" setter="set_joint_rotation" getter="get_joint_rotation" default="Vector3( 0, 0, 0 )">
+			Sets the joint's rotation in radians.
+		</member>
+		<member name="joint_rotation_degrees" type="Vector3" setter="set_joint_rotation_degrees" getter="get_joint_rotation_degrees" default="Vector3( 0, 0, 0 )">
+			Sets the joint's rotation in degrees.
 		</member>
 		<member name="joint_type" type="int" setter="set_joint_type" getter="get_joint_type" enum="PhysicalBone3D.JointType" default="0">
+			Sets the joint type. See [enum JointType] for possible values.
+		</member>
+		<member name="linear_damp" type="float" setter="set_linear_damp" getter="get_linear_damp" default="-1.0">
+			Damps the body's movement if greater than [code]0[/code].
 		</member>
 		<member name="mass" type="float" setter="set_mass" getter="get_mass" default="1.0">
+			The body's mass.
 		</member>
 		<member name="weight" type="float" setter="set_weight" getter="get_weight" default="9.8">
+			The body's weight based on its mass and the global 3D gravity. Global values are set in [b]Project &gt; Project Settings &gt; Physics &gt; 3d[/b].
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -146,7 +146,7 @@
 			Lock the body's movement in the Z axis.
 		</member>
 		<member name="can_sleep" type="bool" setter="set_can_sleep" getter="is_able_to_sleep" default="true">
-			If [code]true[/code], the RigidBody3D will not calculate forces and will act as a static body while there is no movement. It will wake up when forces are applied through other collisions or when the [code]apply_impulse[/code] method is used.
+			If [code]true[/code], the body is deactivated when there is no movement, so it will not take part in the simulation until it is awaken by an external force.
 		</member>
 		<member name="contact_monitor" type="bool" setter="set_contact_monitor" getter="is_contact_monitor_enabled" default="false">
 			If [code]true[/code], the RigidBody3D will emit signals when it collides with another RigidBody3D.

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -562,6 +562,9 @@ private:
 	real_t mass;
 	real_t friction;
 	real_t gravity_scale;
+	real_t linear_damp;
+	real_t angular_damp;
+	bool can_sleep;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -575,6 +578,7 @@ protected:
 private:
 	static Skeleton3D *find_skeleton_parent(Node *p_parent);
 
+	void _update_joint_offset();
 	void _fix_joint_offset();
 	void _reload_joint();
 
@@ -598,6 +602,12 @@ public:
 
 	void set_joint_offset(const Transform &p_offset);
 	const Transform &get_joint_offset() const;
+
+	void set_joint_rotation(const Vector3 &p_euler_rad);
+	Vector3 get_joint_rotation() const;
+
+	void set_joint_rotation_degrees(const Vector3 &p_euler_deg);
+	Vector3 get_joint_rotation_degrees() const;
 
 	void set_body_offset(const Transform &p_offset);
 	const Transform &get_body_offset() const;
@@ -623,6 +633,18 @@ public:
 
 	void set_gravity_scale(real_t p_gravity_scale);
 	real_t get_gravity_scale() const;
+
+	void set_linear_damp(real_t p_linear_damp);
+	real_t get_linear_damp() const;
+
+	void set_angular_damp(real_t p_angular_damp);
+	real_t get_angular_damp() const;
+
+	void set_can_sleep(bool p_active);
+	bool is_able_to_sleep() const;
+
+	void set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool p_lock);
+	bool get_axis_lock(PhysicsServer3D::BodyAxis p_axis) const;
 
 	void apply_central_impulse(const Vector3 &p_impulse);
 	void apply_impulse(const Vector3 &p_pos, const Vector3 &p_impulse);


### PR DESCRIPTION
Added some properties to `PhysicalBone` that are required to properly setup joints, in particular when dealing with partial ragdolls.
Also updated the doc with a description for all properties, old and new.

`joint_rotation`: needed to be able to easily change hinge and cone joints rotation axes (otherwise you have to deal with setting matrix values directly, which is not trivial for rotations)
`linear_damping`: helps a lot with joint stabilization
`angular_damping`: helps a lot with joint stabilization
`axis_lock`: can be used in addition to damping to fix jittering on specific axes
`can_sleep`: needs to be set to `false` in most cases to fix bodies hanging in the air after they stop moving (a joint connection doesn't wake up children)