### PR TITLE
GDScript load() with relative path fixed

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -621,7 +621,6 @@
 				# Load a scene called main located in the root of the project directory.
 				var main = load("res://main.tscn")
 				[/codeblock]
-				[b]Important:[/b] The path must be absolute, a local path will just return [code]null[/code].
 			</description>
 		</method>
 		<method name="log">

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1163,6 +1163,17 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				Callable::CallError err;
 
+				if (func == GDScriptFunctions::RESOURCE_LOAD) {
+					if (argptrs[0]->get_type() == Variant::STRING) {
+						String path = *argptrs[0];
+						if (!path.is_abs_path() && p_instance->script.ptr()->path != "") {
+							path = p_instance->script.ptr()->path.get_base_dir().plus_file(path);
+							path = path.replace("///", "//").simplify_path();
+							Variant *const_override = const_cast<Variant *>(argptrs[0]);
+							*const_override = path;
+						}
+					}
+				}
 				GDScriptFunctions::call(func, (const Variant **)argptrs, argc, *dst, err);
 
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
Fix: #35832

![load-rel-path](https://user-images.githubusercontent.com/41085900/77678938-e92d9b80-6fb7-11ea-854d-bd7e1aa66937.JPG)
