### PR TITLE
[macOS] Prevent recursive `_dispatch_input_event` calls, improve window focus regain.

### DIFF
--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -148,6 +148,7 @@ public:
 
 	void _push_input(const Ref<InputEvent> &p_event);
 	void _process_key_events();
+	void _release_pressed_events();
 
 	String rendering_driver;
 
@@ -165,6 +166,7 @@ public:
 
 	bool window_focused;
 	bool drop_events;
+	bool in_dispatch_input_event = false;
 
 public:
 	virtual bool has_feature(Feature p_feature) const;


### PR DESCRIPTION
- Prevents recursive `_dispatch_input_event` calls, input events can be flushed when window gain/lose focus or created/destroyed inside of input event callback (e.g. popup opened on click).

- Returns focus to the parent window when child is closed (or to the main window if it's the only one left).