### PR TITLE
DisplayServer: Fix registration of GetRenderingDriversFunction

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -271,16 +271,22 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --render-thread <mode>           Render thread mode ('unsafe', 'safe', 'separate').\n");
 	OS::get_singleton()->print("  --remote-fs <address>            Remote filesystem (<host/IP>[:<port>] address).\n");
 	OS::get_singleton()->print("  --remote-fs-password <password>  Password for remote filesystem.\n");
-	OS::get_singleton()->print("  --audio-driver <driver>          Audio driver (");
+
+	OS::get_singleton()->print("  --audio-driver <driver>          Audio driver [");
 	for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
-		if (i != 0)
+		if (i > 0) {
 			OS::get_singleton()->print(", ");
+		}
 		OS::get_singleton()->print("'%s'", AudioDriverManager::get_driver(i)->get_name());
 	}
-	OS::get_singleton()->print(").\n");
-	OS::get_singleton()->print("  --display-driver <driver>          Display driver (and rendering driver):\n");
+	OS::get_singleton()->print("].\n");
+
+	OS::get_singleton()->print("  --display-driver <driver>        Display driver (and rendering driver) [");
 	for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
-		OS::get_singleton()->print("\t\t'%s' (", DisplayServer::get_create_function_name(i));
+		if (i > 0) {
+			OS::get_singleton()->print(", ");
+		}
+		OS::get_singleton()->print("'%s' (", DisplayServer::get_create_function_name(i));
 		Vector<String> rd = DisplayServer::get_create_function_rendering_drivers(i);
 		for (int j = 0; j < rd.size(); j++) {
 			if (j > 0) {
@@ -288,9 +294,11 @@ void Main::print_help(const char *p_binary) {
 			}
 			OS::get_singleton()->print("'%s'", rd[j].utf8().get_data());
 		}
-		OS::get_singleton()->print(")\n");
+		OS::get_singleton()->print(")");
 	}
-	OS::get_singleton()->print("  --rendering-driver <driver>          Rendering driver (depends on display driver).\n");
+	OS::get_singleton()->print("].\n");
+	OS::get_singleton()->print("  --rendering-driver <driver>      Rendering driver (depends on display driver).\n");
+	OS::get_singleton()->print("\n");
 
 #ifndef SERVER_ENABLED
 	OS::get_singleton()->print("Display options:\n");
@@ -340,7 +348,7 @@ void Main::print_help(const char *p_binary) {
 #ifdef DEBUG_METHODS_ENABLED
 	OS::get_singleton()->print("  --gdnative-generate-json-api     Generate JSON dump of the Godot API for GDNative bindings.\n");
 #endif
-	OS::get_singleton()->print("  --test <test>                    Run a unit test (");
+	OS::get_singleton()->print("  --test <test>                    Run a unit test [");
 	const char **test_names = tests_get_names();
 	const char *comma = "";
 	while (*test_names) {
@@ -348,7 +356,7 @@ void Main::print_help(const char *p_binary) {
 		test_names++;
 		comma = ", ";
 	}
-	OS::get_singleton()->print(").\n");
+	OS::get_singleton()->print("].\n");
 #endif
 }
 

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -540,15 +540,18 @@ void DisplayServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(WINDOW_EVENT_DPI_CHANGE);
 }
 
-void DisplayServer::register_create_function(const char *p_name, CreateFunction p_function, GetVideoDriversFunction p_get_drivers) {
+void DisplayServer::register_create_function(const char *p_name, CreateFunction p_function, GetRenderingDriversFunction p_get_drivers) {
 	ERR_FAIL_COND(server_create_count == MAX_SERVERS);
-	server_create_functions[server_create_count].create_function = p_function;
 	server_create_functions[server_create_count].name = p_name;
+	server_create_functions[server_create_count].create_function = p_function;
+	server_create_functions[server_create_count].get_rendering_drivers_function = p_get_drivers;
 	server_create_count++;
 }
+
 int DisplayServer::get_create_function_count() {
 	return server_create_count;
 }
+
 const char *DisplayServer::get_create_function_name(int p_index) {
 	ERR_FAIL_INDEX_V(p_index, server_create_count, nullptr);
 	return server_create_functions[p_index].name;

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -57,8 +57,9 @@ public:
 		WINDOW_MODE_FULLSCREEN
 	};
 
-	typedef DisplayServer *(*CreateFunction)(const String &, WindowMode, uint32_t, const Size2i &, Error &r_error); //video driver, window mode, resolution
-	typedef Vector<String> (*GetVideoDriversFunction)(); //video driver, window mode, resolution
+	typedef DisplayServer *(*CreateFunction)(const String &, WindowMode, uint32_t, const Size2i &, Error &r_error);
+	typedef Vector<String> (*GetRenderingDriversFunction)();
+
 private:
 	static void _input_set_mouse_mode(InputFilter::MouseMode p_mode);
 	static InputFilter::MouseMode _input_get_mouse_mode();
@@ -68,14 +69,15 @@ private:
 
 protected:
 	static void _bind_methods();
+
 	enum {
 		MAX_SERVERS = 64
 	};
 
 	struct DisplayServerCreate {
 		const char *name;
-		GetVideoDriversFunction get_rendering_drivers_function;
 		CreateFunction create_function;
+		GetRenderingDriversFunction get_rendering_drivers_function;
 	};
 
 	static DisplayServerCreate server_create_functions[MAX_SERVERS];
@@ -361,7 +363,7 @@ public:
 
 	virtual void set_context(Context p_context);
 
-	static void register_create_function(const char *p_name, CreateFunction p_function, GetVideoDriversFunction p_get_drivers);
+	static void register_create_function(const char *p_name, CreateFunction p_function, GetRenderingDriversFunction p_get_drivers);
 	static int get_create_function_count();
 	static const char *get_create_function_name(int p_index);
 	static Vector<String> get_create_function_rendering_drivers(int p_index);


### PR DESCRIPTION
Fixes segfault running `godot --help` as it couldn't retrieve the valid rendering drivers.