### PR TITLE
Fix some -Wmaybe-uninitialized warnings

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1680,7 +1680,7 @@ Error Image::generate_mipmap_roughness(RoughnessChannel p_roughness_channel, con
 				int pixel_ofs = y * w + x;
 				Color c = _get_color_at_ofs(ptr, pixel_ofs);
 
-				float roughness;
+				float roughness = 0;
 
 				switch (p_roughness_channel) {
 					case ROUGHNESS_CHANNEL_R: {

--- a/modules/basis_universal/register_types.cpp
+++ b/modules/basis_universal/register_types.cpp
@@ -174,7 +174,8 @@ static Ref<Image> basis_universal_unpacker(const Vector<uint8_t> &p_buffer) {
 				//format = basist::transcoder_texture_format::cTFETC1; // get this from renderer
 				//imgfmt = Image::FORMAT_RGTC_RG;
 			} else {
-				//decompress
+				// FIXME: There wasn't anything here, but then imgformat is used uninitialized.
+				ERR_FAIL_V(image);
 			}
 		} break;
 		case BASIS_DECOMPRESS_RGB: {

--- a/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -749,7 +749,6 @@ void RasterizerSceneHighEndRD::_render_list(RenderingDevice::DrawListID p_draw_l
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, default_vec4_xform_uniform_set, TRANSFORMS_UNIFORM_SET);
 
 	MaterialData *prev_material = nullptr;
-	//	ShaderData *prev_shader = nullptr;
 
 	RID prev_vertex_array_rd;
 	RID prev_index_array_rd;
@@ -809,12 +808,11 @@ void RasterizerSceneHighEndRD::_render_list(RenderingDevice::DrawListID p_draw_l
 			}
 		}
 
-		ShaderVersion shader_version = SHADER_VERSION_MAX;
+		ShaderVersion shader_version = SHADER_VERSION_MAX; // Assigned to silence wrong -Wmaybe-initialized.
 
 		switch (p_pass_mode) {
 			case PASS_MODE_COLOR:
 			case PASS_MODE_COLOR_TRANSPARENT: {
-
 				if (e->uses_lightmap) {
 					shader_version = SHADER_VERSION_LIGHTMAP_COLOR_PASS;
 				} else if (e->uses_vct) {
@@ -822,7 +820,6 @@ void RasterizerSceneHighEndRD::_render_list(RenderingDevice::DrawListID p_draw_l
 				} else {
 					shader_version = SHADER_VERSION_COLOR_PASS;
 				}
-
 			} break;
 			case PASS_MODE_COLOR_SPECULAR: {
 				if (e->uses_lightmap) {

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -617,6 +617,7 @@ Error VisualServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint32_
 			} break;
 			case VS::ARRAY_INDEX: {
 
+				ERR_FAIL_NULL_V(iw, ERR_INVALID_DATA);
 				ERR_FAIL_COND_V(p_index_array_len <= 0, ERR_INVALID_DATA);
 				ERR_FAIL_COND_V(p_arrays[ai].get_type() != Variant::PACKED_INT32_ARRAY, ERR_INVALID_PARAMETER);
 


### PR DESCRIPTION
Namely:
```
modules/basis_universal/register_types.cpp: In function 'Ref<Image> basis_universal_unpacker(const Vector<unsigned char>&)':
modules/basis_universal/register_types.cpp:266:15: warning: 'imgfmt' may be used uninitialized in this function [-Wmaybe-uninitialized]
  266 |  image->create(info.m_width, info.m_height, info.m_total_levels > 1, imgfmt, gpudata);
      |  ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
modules/basis_universal/register_types.cpp:255:39: warning: 'format' may be used uninitialized in this function [-Wmaybe-uninitialized]
  255 |    bool ret = tr.transcode_image_level(ptr, size, 0, i, dst + ofs, level.m_total_blocks - i, format);
      |               ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
servers/visual_server.cpp: In member function 'Error VisualServer::_surface_set_data(Array, uint32_t, uint32_t*, uint32_t, Vector<unsigned char>&, int, Vector<unsigned char>&, int, AABB&, Vector<AABB>&)':
servers/visual_server.cpp:636:15: warning: 'iw' may be used uninitialized in this function [-Wmaybe-uninitialized]
  636 |       copymem(&iw[i * 2], &v, 2);
      |               ^
```

```
./servers/visual/rasterizer_rd/render_pipeline_vertex_format_cache_rd.h: In member function 'void RasterizerSceneHighEndRD::_render_list(RenderingDevice::DrawListID, RenderingDevice::FramebufferFormatID, RasterizerSceneHighEndRD::RenderList::Element**, int, bool, RasterizerSceneHighEndRD::PassMode, bool, RID, RID)':
./servers/visual/rasterizer_rd/render_pipeline_vertex_format_cache_rd.h:83:73: warning: 'vertex_format' may be used uninitialized in this function [-Wmaybe-uninitialized]
   83 |   result = _generate_version(p_vertex_format_id, p_framebuffer_format_id);
      |                                                                         ^
servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp:858:22: note: 'vertex_format' was declared here
  858 |   RD::VertexFormatID vertex_format;
      |                      ^~~~~~~~~~~~~
servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp:812:17: warning: 'shader_version' may be used uninitialized in this function [-Wmaybe-uninitialized]
  812 |   ShaderVersion shader_version;
      |                 ^~~~~~~~~~~~~~
```

```
core/image.cpp: In member function 'Error Image::generate_mipmap_roughness(Image::RoughnessChannel, const Ref<Image>&)':
core/image.cpp:1683:11: warning: 'roughness' may be used uninitialized in this function [-Wmaybe-uninitialized]
 1683 |     float roughness;
      |           ^~~~~~~~~
```

----

The weird part is that those warnings aren't raised in all builds (and especially noted raised by our CI builds).

I got them when doing a build with `tools=no target=release_debug disable_3d=yes`:
```
/usr/bin/scons LINKFLAGS=-fuse-ld=gold -j7 p=linuxbsd warnings=extra disable_3d=yes tools=no target=release_debug 2>&1 | tee -a build.log
```

*Edit:* `disable_3d=yes` is not involved, the warnings appear without it too.

I also get more which appear to be false positives. Using GCC 9.3.0.

----

This and #37354 fix #37352.