### PR TITLE
Fix default editor font.

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -231,7 +231,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	// Default font
 	MAKE_DEFAULT_FONT(df, default_font_size);
-	p_theme->set_default_theme_font(df);
+	p_theme->set_font("font", "Node", df); // Default theme font
 	p_theme->set_font("main", "EditorFonts", df);
 
 	// Bold font

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1331,7 +1331,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("popup_on_parent", "parent_rect"), &Window::popup_on_parent);
 	ClassDB::bind_method(D_METHOD("popup_centered_ratio", "ratio"), &Window::popup_centered_ratio, DEFVAL(0.8));
 	ClassDB::bind_method(D_METHOD("popup_centered", "minsize"), &Window::popup_centered, DEFVAL(Size2i()));
-	ClassDB::bind_method(D_METHOD("popup_centered_clamped", "minsize", "fallback_ratio"), &Window::popup_centered, DEFVAL(Size2i()), DEFVAL(0.75));
+	ClassDB::bind_method(D_METHOD("popup_centered_clamped", "minsize", "fallback_ratio"), &Window::popup_centered_clamped, DEFVAL(Size2i()), DEFVAL(0.75));
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "title"), "set_title", "get_title");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "position"), "set_position", "get_position");


### PR DESCRIPTION
- Fix default editor font.

- Fix `popup_centered_clamped` definition typo.

Fixes #37332 and editor scaling.