### PR TITLE
Fix various -Wmaybe-uninitialized (#37352).

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -741,7 +741,7 @@ CSGBrush *CSGMesh::_build_brush() {
 		const Vector3 *vr = avertices.ptr();
 
 		Vector<Vector3> anormals = arrays[Mesh::ARRAY_NORMAL];
-		const Vector3 *nr;
+		const Vector3 *nr = NULL;
 		bool nr_used = false;
 		if (anormals.size()) {
 			nr = anormals.ptr();
@@ -749,7 +749,7 @@ CSGBrush *CSGMesh::_build_brush() {
 		}
 
 		Vector<Vector2> auvs = arrays[Mesh::ARRAY_TEX_UV];
-		const Vector2 *uvr;
+		const Vector2 *uvr = NULL;
 		bool uvr_used = false;
 		if (auvs.size()) {
 			uvr = auvs.ptr();

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -372,7 +372,7 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 	ERR_FAIL_COND_V(arrays.size() != ARRAY_MAX, Ref<ArrayMesh>());
 
 	{
-		int *ir;
+		int *ir = NULL;
 		Vector<int> indices = arrays[ARRAY_INDEX];
 		bool has_indices = false;
 		Vector<Vector3> vertices = arrays[ARRAY_VERTEX];

--- a/scene/resources/mesh_data_tool.cpp
+++ b/scene/resources/mesh_data_tool.cpp
@@ -58,30 +58,30 @@ Error MeshDataTool::create_from_surface(const Ref<ArrayMesh> &p_mesh, int p_surf
 
 	const Vector3 *vr = varray.ptr();
 
-	const Vector3 *nr;
+	const Vector3 *nr = NULL;
 	if (arrays[Mesh::ARRAY_NORMAL].get_type() != Variant::NIL)
 		nr = arrays[Mesh::ARRAY_NORMAL].operator Vector<Vector3>().ptr();
 
-	const real_t *ta;
+	const real_t *ta = NULL;
 	if (arrays[Mesh::ARRAY_TANGENT].get_type() != Variant::NIL)
 		ta = arrays[Mesh::ARRAY_TANGENT].operator Vector<real_t>().ptr();
 
-	const Vector2 *uv;
+	const Vector2 *uv = NULL;
 	if (arrays[Mesh::ARRAY_TEX_UV].get_type() != Variant::NIL)
 		uv = arrays[Mesh::ARRAY_TEX_UV].operator Vector<Vector2>().ptr();
-	const Vector2 *uv2;
+	const Vector2 *uv2 = NULL;
 	if (arrays[Mesh::ARRAY_TEX_UV2].get_type() != Variant::NIL)
 		uv2 = arrays[Mesh::ARRAY_TEX_UV2].operator Vector<Vector2>().ptr();
 
-	const Color *col;
+	const Color *col = NULL;
 	if (arrays[Mesh::ARRAY_COLOR].get_type() != Variant::NIL)
 		col = arrays[Mesh::ARRAY_COLOR].operator Vector<Color>().ptr();
 
-	const int *bo;
+	const int *bo = NULL;
 	if (arrays[Mesh::ARRAY_BONES].get_type() != Variant::NIL)
 		bo = arrays[Mesh::ARRAY_BONES].operator Vector<int>().ptr();
 
-	const real_t *we;
+	const real_t *we = NULL;
 	if (arrays[Mesh::ARRAY_WEIGHTS].get_type() != Variant::NIL)
 		we = arrays[Mesh::ARRAY_WEIGHTS].operator Vector<real_t>().ptr();
 
@@ -202,43 +202,43 @@ Error MeshDataTool::commit_to_surface(const Ref<ArrayMesh> &p_mesh) {
 		v.resize(vcount);
 		Vector3 *vr = v.ptrw();
 
-		Vector3 *nr;
+		Vector3 *nr = NULL;
 		if (format & Mesh::ARRAY_FORMAT_NORMAL) {
 			n.resize(vcount);
 			nr = n.ptrw();
 		}
 
-		real_t *ta;
+		real_t *ta = NULL;
 		if (format & Mesh::ARRAY_FORMAT_TANGENT) {
 			t.resize(vcount * 4);
 			ta = t.ptrw();
 		}
 
-		Vector2 *uv;
+		Vector2 *uv = NULL;
 		if (format & Mesh::ARRAY_FORMAT_TEX_UV) {
 			u.resize(vcount);
 			uv = u.ptrw();
 		}
 
-		Vector2 *uv2;
+		Vector2 *uv2 = NULL;
 		if (format & Mesh::ARRAY_FORMAT_TEX_UV2) {
 			u2.resize(vcount);
 			uv2 = u2.ptrw();
 		}
 
-		Color *col;
+		Color *col = NULL;
 		if (format & Mesh::ARRAY_FORMAT_COLOR) {
 			c.resize(vcount);
 			col = c.ptrw();
 		}
 
-		int *bo;
+		int *bo = NULL;
 		if (format & Mesh::ARRAY_FORMAT_BONES) {
 			b.resize(vcount * 4);
 			bo = b.ptrw();
 		}
 
-		real_t *we;
+		real_t *we = NULL;
 		if (format & Mesh::ARRAY_FORMAT_WEIGHTS) {
 			w.resize(vcount * 4);
 			we = w.ptrw();

--- a/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/visual/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -809,7 +809,7 @@ void RasterizerSceneHighEndRD::_render_list(RenderingDevice::DrawListID p_draw_l
 			}
 		}
 
-		ShaderVersion shader_version;
+		ShaderVersion shader_version = SHADER_VERSION_MAX;
 
 		switch (p_pass_mode) {
 			case PASS_MODE_COLOR:
@@ -855,7 +855,7 @@ void RasterizerSceneHighEndRD::_render_list(RenderingDevice::DrawListID p_draw_l
 
 		pipeline = &shader->pipelines[cull_variant][primitive][shader_version];
 
-		RD::VertexFormatID vertex_format;
+		RD::VertexFormatID vertex_format = -1;
 		RID vertex_array_rd;
 		RID index_array_rd;
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -333,7 +333,7 @@ Error VisualServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint32_
 
 	uint8_t *vw = r_vertex_array.ptrw();
 
-	uint8_t *iw;
+	uint8_t *iw = NULL;
 	if (r_index_array.size()) {
 		iw = r_index_array.ptrw();
 	}


### PR DESCRIPTION
Few comments about fixes:

- `scene/resources/mesh_data_tool.cpp` - these warnings are valid as you do:
```c++
	const Vector3 *nr;
	if (arrays[Mesh::ARRAY_NORMAL].get_type() != Variant::NIL)
		nr = arrays[Mesh::ARRAY_NORMAL].operator Vector<Vector3>().ptr();
...
		if (nr)
			v.normal = nr[i];
```
You check for non-null, but that value can be uninitialized (have any value).

- `ShaderVersion shader_version = SHADER_VERSION_MAX;`
This can be improved by putting `__builtin_unreachable` to `switch (p_pass_mode) {` switch
- `		RID vertex_array_rd;` - likewise here