### PR TITLE
SCons: Treat all warnings as errors

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -126,7 +126,7 @@ opts.Add(BoolVariable("xaudio2", "Enable the XAudio2 audio driver", False))
 opts.Add(BoolVariable("verbose", "Enable verbose output for the compilation", False))
 opts.Add(BoolVariable("progress", "Show a progress indicator during compilation", True))
 opts.Add(EnumVariable("warnings", "Level of compilation warnings", "all", ("extra", "all", "moderate", "no")))
-opts.Add(BoolVariable("werror", "Treat compiler warnings as errors", False))
+opts.Add(BoolVariable("werror", "Treat compiler warnings as errors", True))
 opts.Add(BoolVariable("dev", "If yes, alias for verbose=yes warnings=extra werror=yes", False))
 opts.Add("extra_suffix", "Custom extra suffix added to the base filename of all generated binary files", "")
 opts.Add(BoolVariable("vsproj", "Generate a Visual Studio solution", False))
@@ -448,6 +448,8 @@ if selected_platform in platform_list:
             # FIXME: Temporary workaround after the Vulkan merge, remove once warnings are fixed.
             if methods.using_gcc(env):
                 env.Append(CXXFLAGS=["-Wno-error=cpp"])
+                if cc_version_major == 7:  # Bogus warning fixed in 8+.
+                    env.Append(CCFLAGS=["-Wno-error=strict-overflow"])
             else:
                 env.Append(CXXFLAGS=["-Wno-error=#warnings"])
         else:  # always enable those errors

--- a/modules/basis_universal/register_types.cpp
+++ b/modules/basis_universal/register_types.cpp
@@ -158,8 +158,8 @@ static Ref<Image> basis_universal_unpacker(const Vector<uint8_t> &p_buffer) {
 	const uint8_t *ptr = r;
 	int size = p_buffer.size();
 
-	basist::transcoder_texture_format format;
-	Image::Format imgfmt;
+	basist::transcoder_texture_format format = basist::transcoder_texture_format::cTFTotalTextureFormats;
+	Image::Format imgfmt = Image::FORMAT_MAX;
 
 	switch (*(uint32_t *)(ptr)) {
 		case BASIS_DECOMPRESS_RG: {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -742,18 +742,14 @@ CSGBrush *CSGMesh3D::_build_brush() {
 
 		Vector<Vector3> anormals = arrays[Mesh::ARRAY_NORMAL];
 		const Vector3 *nr = NULL;
-		bool nr_used = false;
 		if (anormals.size()) {
 			nr = anormals.ptr();
-			nr_used = true;
 		}
 
 		Vector<Vector2> auvs = arrays[Mesh::ARRAY_TEX_UV];
 		const Vector2 *uvr = NULL;
-		bool uvr_used = false;
 		if (auvs.size()) {
 			uvr = auvs.ptr();
-			uvr_used = true;
 		}
 
 		Ref<Material> mat;
@@ -789,10 +785,10 @@ CSGBrush *CSGMesh3D::_build_brush() {
 				for (int k = 0; k < 3; k++) {
 					int idx = ir[j + k];
 					vertex[k] = vr[idx];
-					if (nr_used) {
+					if (nr) {
 						normal[k] = nr[idx];
 					}
-					if (uvr_used) {
+					if (uvr) {
 						uv[k] = uvr[idx];
 					}
 				}
@@ -832,10 +828,10 @@ CSGBrush *CSGMesh3D::_build_brush() {
 
 				for (int k = 0; k < 3; k++) {
 					vertex[k] = vr[j + k];
-					if (nr_used) {
+					if (nr) {
 						normal[k] = nr[j + k];
 					}
-					if (uvr_used) {
+					if (uvr) {
 						uv[k] = uvr[j + k];
 					}
 				}

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "audio_stream_player_3d.h"
+
 #include "core/engine.h"
 #include "scene/3d/area_3d.h"
 #include "scene/3d/camera_3d.h"
@@ -96,7 +97,7 @@ static const Vector3 speaker_directions[7] = {
 };
 
 void AudioStreamPlayer3D::_calc_output_vol(const Vector3 &source_dir, real_t tightness, AudioStreamPlayer3D::Output &output) {
-	unsigned int speaker_count; // only main speakers (no LFE)
+	unsigned int speaker_count = 0; // only main speakers (no LFE)
 	switch (AudioServer::get_singleton()->get_speaker_mode()) {
 		case AudioServer::SPEAKER_MODE_STEREO:
 			speaker_count = 2;


### PR DESCRIPTION
After an effort spanning several years, we should now be warning-free
on all major compilers, so we can set `-Werror` to ensure that we don't
introduce warnings in new code.

---

I did not remove the explicit `werror=yes` from the CI configuration yet, in case we decide to revert this change in the near future for some reason.