### PR TITLE
Remove the audio memory allocator, use regular one instead.

### DIFF
--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -481,7 +481,7 @@ void AudioStreamSample::set_data(const Vector<uint8_t> &p_data) {
 
 	AudioServer::get_singleton()->lock();
 	if (data) {
-		AudioServer::get_singleton()->audio_data_free(data);
+		memfree(data);
 		data = NULL;
 		data_bytes = 0;
 	}
@@ -491,7 +491,7 @@ void AudioStreamSample::set_data(const Vector<uint8_t> &p_data) {
 
 		const uint8_t *r = p_data.ptr();
 		int alloc_len = datalen + DATA_PAD * 2;
-		data = AudioServer::get_singleton()->audio_data_alloc(alloc_len); //alloc with some padding for interpolation
+		data = memalloc(alloc_len); //alloc with some padding for interpolation
 		zeromem(data, alloc_len);
 		uint8_t *dataptr = (uint8_t *)data;
 		copymem(dataptr + DATA_PAD, r, datalen);
@@ -660,7 +660,7 @@ AudioStreamSample::AudioStreamSample() {
 
 AudioStreamSample::~AudioStreamSample() {
 	if (data) {
-		AudioServer::get_singleton()->audio_data_free(data);
+		memfree(data);
 		data = NULL;
 		data_bytes = 0;
 	}

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1131,47 +1131,6 @@ double AudioServer::get_time_since_last_mix() const {
 
 AudioServer *AudioServer::singleton = NULL;
 
-void *AudioServer::audio_data_alloc(uint32_t p_data_len, const uint8_t *p_from_data) {
-
-	void *ad = memalloc(p_data_len);
-	ERR_FAIL_COND_V(!ad, NULL);
-	if (p_from_data) {
-		copymem(ad, p_from_data, p_data_len);
-	}
-
-	{
-		MutexLock lock(audio_data_lock);
-
-		audio_data[ad] = p_data_len;
-		audio_data_total_mem += p_data_len;
-		audio_data_max_mem = MAX(audio_data_total_mem, audio_data_max_mem);
-	}
-
-	return ad;
-}
-
-void AudioServer::audio_data_free(void *p_data) {
-
-	MutexLock lock(audio_data_lock);
-
-	if (!audio_data.has(p_data)) {
-		ERR_FAIL();
-	}
-
-	audio_data_total_mem -= audio_data[p_data];
-	audio_data.erase(p_data);
-	memfree(p_data);
-}
-
-size_t AudioServer::audio_data_get_total_memory_usage() const {
-
-	return audio_data_total_mem;
-}
-size_t AudioServer::audio_data_get_max_memory_usage() const {
-
-	return audio_data_max_mem;
-}
-
 void AudioServer::add_callback(AudioCallback p_callback, void *p_userdata) {
 	lock();
 	CallbackItem ci;
@@ -1400,8 +1359,6 @@ void AudioServer::_bind_methods() {
 AudioServer::AudioServer() {
 
 	singleton = this;
-	audio_data_total_mem = 0;
-	audio_data_max_mem = 0;
 	mix_frames = 0;
 	channel_count = 0;
 	to_mix = 0;

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -232,14 +232,6 @@ private:
 
 	static AudioServer *singleton;
 
-	// TODO create an audiodata pool to optimize memory
-
-	Map<void *, uint32_t> audio_data;
-	size_t audio_data_total_mem;
-	size_t audio_data_max_mem;
-
-	Mutex audio_data_lock;
-
 	void init_channels_and_buffers();
 
 	void _mix_step();
@@ -349,12 +341,6 @@ public:
 	virtual double get_output_latency() const;
 	virtual double get_time_to_next_mix() const;
 	virtual double get_time_since_last_mix() const;
-
-	void *audio_data_alloc(uint32_t p_data_len, const uint8_t *p_from_data = NULL);
-	void audio_data_free(void *p_data);
-
-	size_t audio_data_get_total_memory_usage() const;
-	size_t audio_data_get_max_memory_usage() const;
 
 	void add_callback(AudioCallback p_callback, void *p_userdata);
 	void remove_callback(AudioCallback p_callback, void *p_userdata);


### PR DESCRIPTION
This was required previously because of PoolVector and 32 bits systems, but it's useless now.
Removing and replacing with regular alloc/free.