### PR TITLE
Fix for loop range bug: #37358

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3113,7 +3113,6 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 								}
 							} else {
 								constant = false;
-								break;
 							}
 						}
 


### PR DESCRIPTION
Fix: #37358

the break, prevent the following line from executing, which makes the parser thinks there is only one argument (though there are 2)
```
args.push_back(op->arguments[i]);
```