### PR TITLE
Alias `platform=x11` to `platform=linuxbsd` in SCons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -251,6 +251,14 @@ else:
         print("Automatically detected platform: " + selected_platform)
         env_base["platform"] = selected_platform
 
+if selected_platform in ["linux", "bsd", "x11"]:
+    if selected_platform == "x11":
+        # Deprecated alias kept for compatibility.
+        print('Platform "x11" has been renamed to "linuxbsd" in Godot 4.0. '
+              'Building for platform "linuxbsd".')
+    # Alias for convenience.
+    selected_platform = "linuxbsd"
+
 if selected_platform in platform_list:
     tmppath = "./platform/" + selected_platform
     sys.path.insert(0, tmppath)


### PR DESCRIPTION
This makes it possible for users to follow outdated documentation and still get a working binary.

PS: We might want to do the opposite in the `3.2` branch (alias `linuxbsd` to `x11`). This way, people can also follow documentation intended for 4.0 to build Godot 3.2. I expect that to be quite common if we update the [Compiling for X11](https://docs.godotengine.org/en/latest/development/compiling/compiling_for_x11.html) page in the `master` branch…

**Edit:** This now aliases `linux` and `bsd` to `linuxbsd` for convenience as well.

This closes #37367.