### PR TITLE
Warn when setting a scale that has a negative X component in 2D

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1232,6 +1232,8 @@ ProjectSettings::ProjectSettings() {
 
 	GLOBAL_DEF("debug/settings/profiler/max_functions", 16384);
 	custom_prop_info["debug/settings/profiler/max_functions"] = PropertyInfo(Variant::INT, "debug/settings/profiler/max_functions", PROPERTY_HINT_RANGE, "128,65535,1");
+	GLOBAL_DEF("debug/settings/warnings/invalid_scale_set", true);
+	custom_prop_info["debug/settings/warnings/invalid_scale_set"] = PropertyInfo(Variant::BOOL, "debug/settings/warnings/invalid_scale_set");
 
 	GLOBAL_DEF("compression/formats/zstd/long_distance_matching", Compression::zstd_long_distance_matching);
 	custom_prop_info["compression/formats/zstd/long_distance_matching"] = PropertyInfo(Variant::BOOL, "compression/formats/zstd/long_distance_matching");

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -479,6 +479,9 @@
 		<member name="debug/settings/visual_script/max_call_stack" type="int" setter="" getter="" default="1024">
 			Maximum call stack in visual scripting, to avoid infinite recursion.
 		</member>
+		<member name="debug/settings/warnings/invalid_scale_set" type="bool" setter="" getter="" default="true">
+			Negative X scales in 2D are not decomposable from the transformation matrix and are often not desired. If enabled, a warning will be displayed when the X scale set to a negative value.
+		</member>
 		<member name="debug/shapes/collision/contact_color" type="Color" setter="" getter="" default="Color(1, 0.2, 0.1, 0.8)">
 			Color of the contact points between collision shapes, visible when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -30,6 +30,10 @@
 
 #include "node_2d.h"
 
+#ifdef DEBUG_ENABLED
+#include "core/config/project_settings.h"
+#endif // DEBUG_ENABLED
+
 #ifdef TOOLS_ENABLED
 Dictionary Node2D::_edit_get_state() const {
 	Dictionary state;
@@ -156,6 +160,15 @@ void Node2D::set_skew(real_t p_radians) {
 }
 
 void Node2D::set_scale(const Size2 &p_scale) {
+#ifdef DEBUG_ENABLED
+	if (p_scale.x < 0 && bool(GLOBAL_GET("debug/settings/warnings/invalid_scale_set"))) {
+		WARN_PRINT("Due to the way scale is represented with transformation "
+				   "matrices in Godot, negative scales on the X axis will be "
+				   "changed to negative scales on the Y axis plus a rotation "
+				   "of 180 degrees when decomposed. "
+				   "This warning can be disabled in project settings.");
+	}
+#endif // DEBUG_ENABLED
 	if (_xform_dirty) {
 		const_cast<Node2D *>(this)->_update_xform_values();
 	}


### PR DESCRIPTION
Due to the way scale is represented with Transform2D, negative scales on the X axis will be changed to negative scales on the Y axis plus a rotation of 180 degrees when decomposed.

Because of this, we should show a warning. Fixes #17405 and its duplicates #21020, #21849, and #42219.