### PR TITLE
Fix: creating Node by double-click creates two copies

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -275,6 +275,7 @@ void Window::_clear_window() {
 
 	_update_from_window();
 
+	_drop_mouse_focus();
 	DisplayServer::get_singleton()->delete_sub_window(window_id);
 	window_id = DisplayServer::INVALID_WINDOW_ID;
 


### PR DESCRIPTION
Fix: #37331

when a the node creation window hides it calls `release_pressed_events()` which crates the node again.
```
DisplayServerWindows::WndProc(){
	...
	case WM_ACTIVATE:
	{
		...
		InputFilter::get_singleton()->release_pressed_events();
		_send_window_event(windows[window_id], WINDOW_EVENT_FOCUS_OUT);
		...
	}
}
```
