### PR TITLE
Expose 'Embedded Windows Mode' as Editor and Project Settings

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -426,6 +426,9 @@
 		<member name="display/window/ios/hide_home_indicator" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], the home indicator is hidden automatically. This only affects iOS devices without a physical home button.
 		</member>
+		<member name="display/window/subwindows/embed_subwindows" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], uses subwindows (windows rendered entirely by engine) instead of OS-specific windows.
+		</member>
 		<member name="display/window/size/always_on_top" type="bool" setter="" getter="" default="false">
 			Force the window to be always on top.
 		</member>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -341,6 +341,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/editor/unfocused_low_processor_mode_sleep_usec"] = PropertyInfo(Variant::FLOAT, "interface/editor/unfocused_low_processor_mode_sleep_usec", PROPERTY_HINT_RANGE, "1,100000,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/separate_distraction_mode", false);
 	_initial_set("interface/editor/automatically_open_screenshots", true);
+	_initial_set("interface/editor/single_window_mode", false);
+	hints["interface/editor/single_window_mode"] = PropertyInfo(Variant::BOOL, "interface/editor/single_window_mode", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/hide_console_window", false);
 	_initial_set("interface/editor/save_each_scene_on_quit", true); // Regression
 	_initial_set("interface/editor/quit_confirmation", true);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1723,7 +1723,9 @@ bool Main::start() {
 		}
 #endif
 
-		if (single_window) {
+		bool embed_subwindows = GLOBAL_DEF("display/window/subwindows/embed_subwindows", false);
+
+		if (single_window || (!project_manager && !editor && embed_subwindows)) {
 			sml->get_root()->set_embed_subwindows_hint(true);
 		}
 		ResourceLoader::add_custom_loaders();
@@ -1941,6 +1943,12 @@ bool Main::start() {
 
 #ifdef TOOLS_ENABLED
 			if (editor) {
+
+				bool editor_embed_subwindows = EditorSettings::get_singleton()->get_setting("interface/editor/single_window_mode");
+
+				if (editor_embed_subwindows) {
+					sml->get_root()->set_embed_subwindows_hint(true);
+				}
 
 				if (game_path != GLOBAL_GET("application/run/main_scene") || !editor_node->has_scenes_in_session()) {
 					Error serr = editor_node->load_scene(local_game_path);


### PR DESCRIPTION
Exposing a bool property `interface/editor/embedded_windows_mode` which allows to toggle between OS-Native and Embedded windows - used to speed up process of setting that feature instead of appending `--single-window` in command line (many of users might not be aware of that command property yet).