### PR TITLE
Disable exporting csv when project is running

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -881,6 +881,7 @@ void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
 	tabs->set_current_tab(0);
 	_set_reason_text(TTR("Debug session started."), MESSAGE_SUCCESS);
 	_update_buttons_state();
+	export_csv->set_disabled(true);
 }
 
 void ScriptEditorDebugger::_update_buttons_state() {
@@ -925,6 +926,7 @@ void ScriptEditorDebugger::stop() {
 
 	inspector->edit(NULL);
 	_update_buttons_state();
+	export_csv->set_disabled(false);
 }
 
 void ScriptEditorDebugger::_profiler_activate(bool p_enable, int p_type) {


### PR DESCRIPTION
Temporary fix for #34640 

I dived into the backtrace to understand how the crash happened. The data which we get from [RemoteDebuggerTCP](https://github.com/godotengine/godot/blob/master/core/debugger/remote_debugger_peer.cpp) (which in turn gets from a StreamPeerTCP) sometimes contain more values than usual, from a server or maybe more. During my test it was from physics2d server, maybe because I was in a 2d test scene.
It might be possible to find out how these extra values get added and prevent it. It gets quite complicated at this point.



