### PR TITLE
Correction to RichTextLabel Tabulation (Bug 37081)

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -582,13 +582,14 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 									} else {
 										cw = drawer.draw_char(ci, p_ofs + Point2(align_ofs + pofs, y + lh - line_descent) + fx_offset, fx_char, c[i + 1], fx_color);
 									}
-								} else if (previously_visible) {
+								} else if (previously_visible && c[i] != '\t') {
 									backtrack += font->get_char_size(fx_char, c[i + 1]).x;
 								}
 
 								p_char_count++;
 								if (c[i] == '\t') {
 									cw = tab_size * font->get_char_size(' ').width;
+									backtrack = MAX(0, backtrack - cw);
 								}
 
 								ofs += cw;


### PR DESCRIPTION
Correct backtrack to prevent tabulation errors. Worth noting for others that tabulation is treated differently in RichTextLabel than other characters because of custom user-asignable tab variable which creates problems with dynamic fonts specifically. Not understanding this is what created this regression, my apologies. This should correct #37081 but I would like some more testing on various hidden character / special character types to make sure there aren't any other unknown regressions.

By the by, normally I would rebase my branch onto master, but I've been having difficulties on my work computer (Manjaro-Gnome-linuxbsd) with Godot's new window system that made testing this patch difficult (Specifically, I had difficulties making DynamicFont resources because windows would instantaneously close). Because of this, I opted to build this on top of my previous branch. This means I'm quite a few commits behind master. If anyone else can assist me by testing this after rebasing to master to make sure it works as expected, that would be useful.  