### PR TITLE
Change Basis is_equal_approx to use instance method

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -113,19 +113,22 @@ bool Basis::is_rotation() const {
 	return Math::is_equal_approx(determinant(), 1, UNIT_EPSILON) && is_orthogonal();
 }
 
+#ifdef MATH_CHECKS
+// This method is only used once, in diagonalize. If it's desired elsewhere, feel free to remove the #ifdef.
 bool Basis::is_symmetric() const {
-	if (!Math::is_equal_approx_ratio(elements[0][1], elements[1][0], UNIT_EPSILON)) {
+	if (!Math::is_equal_approx(elements[0][1], elements[1][0])) {
 		return false;
 	}
-	if (!Math::is_equal_approx_ratio(elements[0][2], elements[2][0], UNIT_EPSILON)) {
+	if (!Math::is_equal_approx(elements[0][2], elements[2][0])) {
 		return false;
 	}
-	if (!Math::is_equal_approx_ratio(elements[1][2], elements[2][1], UNIT_EPSILON)) {
+	if (!Math::is_equal_approx(elements[1][2], elements[2][1])) {
 		return false;
 	}
 
 	return true;
 }
+#endif
 
 Basis Basis::diagonalize() {
 //NOTE: only implemented for symmetric matrices
@@ -735,18 +738,6 @@ void Basis::set_euler_zyx(const Vector3 &p_euler) {
 
 bool Basis::is_equal_approx(const Basis &p_basis) const {
 	return elements[0].is_equal_approx(p_basis.elements[0]) && elements[1].is_equal_approx(p_basis.elements[1]) && elements[2].is_equal_approx(p_basis.elements[2]);
-}
-
-bool Basis::is_equal_approx_ratio(const Basis &a, const Basis &b, real_t p_epsilon) const {
-	for (int i = 0; i < 3; i++) {
-		for (int j = 0; j < 3; j++) {
-			if (!Math::is_equal_approx_ratio(a.elements[i][j], b.elements[i][j], p_epsilon)) {
-				return false;
-			}
-		}
-	}
-
-	return true;
 }
 
 bool Basis::operator==(const Basis &p_matrix) const {

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -146,8 +146,6 @@ public:
 	}
 
 	bool is_equal_approx(const Basis &p_basis) const;
-	// TODO: Break compatibility in 4.0 by getting rid of this so that it's only an instance method. See also TODO in variant_call.cpp
-	bool is_equal_approx(const Basis &a, const Basis &b) const { return a.is_equal_approx(b); }
 	bool is_equal_approx_ratio(const Basis &a, const Basis &b, real_t p_epsilon = UNIT_EPSILON) const;
 
 	bool operator==(const Basis &p_matrix) const;

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -146,7 +146,6 @@ public:
 	}
 
 	bool is_equal_approx(const Basis &p_basis) const;
-	bool is_equal_approx_ratio(const Basis &a, const Basis &b, real_t p_epsilon = UNIT_EPSILON) const;
 
 	bool operator==(const Basis &p_matrix) const;
 	bool operator!=(const Basis &p_matrix) const;
@@ -236,7 +235,9 @@ public:
 	void orthonormalize();
 	Basis orthonormalized() const;
 
+#ifdef MATH_CHECKS
 	bool is_symmetric() const;
+#endif
 	Basis diagonalize();
 
 	operator Quat() const { return get_quat(); }

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -291,18 +291,6 @@ public:
 	static float random(float from, float to);
 	static real_t random(int from, int to) { return (real_t)random((real_t)from, (real_t)to); }
 
-	static _ALWAYS_INLINE_ bool is_equal_approx_ratio(real_t a, real_t b, real_t epsilon = CMP_EPSILON, real_t min_epsilon = CMP_EPSILON) {
-		// this is an approximate way to check that numbers are close, as a ratio of their average size
-		// helps compare approximate numbers that may be very big or very small
-		real_t diff = abs(a - b);
-		if (diff == 0.0 || diff < min_epsilon) {
-			return true;
-		}
-		real_t avg_size = (abs(a) + abs(b)) / 2.0;
-		diff /= avg_size;
-		return diff < epsilon;
-	}
-
 	static _ALWAYS_INLINE_ bool is_equal_approx(real_t a, real_t b) {
 		// Check for exact equality first, required to handle "infinity" values.
 		if (a == b) {

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1035,7 +1035,7 @@ struct _VariantCall {
 	VCALL_PTR0R(Basis, get_orthogonal_index);
 	VCALL_PTR0R(Basis, orthonormalized);
 	VCALL_PTR2R(Basis, slerp);
-	VCALL_PTR2R(Basis, is_equal_approx); // TODO: Break compatibility in 4.0 to change this to an instance method (a.is_equal_approx(b) as VCALL_PTR1R) for consistency.
+	VCALL_PTR1R(Basis, is_equal_approx);
 	VCALL_PTR0R(Basis, get_rotation_quat);
 
 	VCALL_PTR0R(Transform, inverse);
@@ -2356,7 +2356,7 @@ void register_variant_methods() {
 	ADDFUNC1R(BASIS, VECTOR3, Basis, xform_inv, VECTOR3, "v", varray());
 	ADDFUNC0R(BASIS, INT, Basis, get_orthogonal_index, varray());
 	ADDFUNC2R(BASIS, BASIS, Basis, slerp, BASIS, "b", FLOAT, "t", varray());
-	ADDFUNC2R(BASIS, BOOL, Basis, is_equal_approx, BASIS, "b", FLOAT, "epsilon", varray(CMP_EPSILON)); // TODO: Replace in 4.0, see other TODO.
+	ADDFUNC1R(BASIS, BOOL, Basis, is_equal_approx, BASIS, "b", varray());
 	ADDFUNC0R(BASIS, QUAT, Basis, get_rotation_quat, varray());
 
 	ADDFUNC0R(TRANSFORM, TRANSFORM, Transform, inverse, varray());


### PR DESCRIPTION
Fixes #37390. I placed TODOs on this code as part of #32477 since this change breaks compat, but now we can fix this for 4.0. Test code:

```
	var a = Basis(Vector3(0.000004, 0, 1), Vector3(0, 1, 0), Vector3(-1, 0, 0.000004))
	var b = Basis(Vector3(0, 0, 1), Vector3(0, 1, 0), Vector3(-1, 0, 0))
	print(a.is_equal_approx(b)) # True
```

Also, since `is_equal_approx_ratio` is no longer used in any exposed API and serves no purpose, we can remove it, so I did. Also, I added `#ifdef MATH_CHECKS` for some code that is only used when `MATH_CHECKS` is defined. These changes are in the 2nd commit.