### PR TITLE
Move wheel handlers from window to canvas element in HTML

### DIFF
--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -981,7 +981,7 @@ Error OS_JavaScript::initialize(const VideoMode &p_desired, int p_video_driver, 
 	SET_EM_CALLBACK(EMSCRIPTEN_EVENT_TARGET_WINDOW, mousemove, mousemove_callback)
 	SET_EM_CALLBACK(GODOT_CANVAS_SELECTOR, mousedown, mouse_button_callback)
 	SET_EM_CALLBACK(EMSCRIPTEN_EVENT_TARGET_WINDOW, mouseup, mouse_button_callback)
-	SET_EM_CALLBACK(EMSCRIPTEN_EVENT_TARGET_WINDOW, wheel, wheel_callback)
+	SET_EM_CALLBACK(GODOT_CANVAS_SELECTOR, wheel, wheel_callback)
 	SET_EM_CALLBACK(GODOT_CANVAS_SELECTOR, touchstart, touch_press_callback)
 	SET_EM_CALLBACK(GODOT_CANVAS_SELECTOR, touchmove, touchmove_callback)
 	SET_EM_CALLBACK(GODOT_CANVAS_SELECTOR, touchend, touch_press_callback)


### PR DESCRIPTION
Similar to https://github.com/godotengine/godot/pull/36557

At least in chrome, the following error is printed for each mouse wheel
rotation:
[Intervention] Unable to preventDefault inside passive event listener due to target being treated as passive. See https://www.chromestatus.com/features/6662647093133312

This PR moves the handler to the canvas and thereby fixes the error.

Tested on: Chrome and Firefox (MacOS), Firefox, Chrome(Android), Safari (IPad + MacOS)

*Bugsquad edit:* Fixes #31095.