### PR TITLE
Add more verbosity for property overrides in RST documentation

### DIFF
--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -412,7 +412,7 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
             type_rst = property_def.type_name.to_rst(state)
             default = property_def.default_value
             if property_def.overridden:
-                ml.append((type_rst, property_def.name, "**O:** " + default))
+                ml.append((type_rst, property_def.name, default + " *(parent override)*"))
             else:
                 ref = ":ref:`{0}<class_{1}_property_{0}>`".format(property_def.name, class_name)
                 ml.append((type_rst, ref, default))


### PR DESCRIPTION
Fixes godotengine/godot-docs#3302.

Currently in online documentation property overrides are marked by a bold letter "O", which tells readers nothing:
![image](https://user-images.githubusercontent.com/11782833/77907031-a1e22c00-7291-11ea-82db-d4ee99dd67d4.png)

This changes it to a more verbose "parent override" message:
![image](https://user-images.githubusercontent.com/11782833/77907108-bde5cd80-7291-11ea-8fd7-82efc1ac54e5.png)

This is a minor improvement, but at least clears up the confusion from the linked issue. Ideally, we should link to the exact parent class that defines this property, as it may not be the direct parent. I assume, this would require adding an attribute to property tag in XML classref?