### PR TITLE
[macOS] Fix popup positions on multiple screens.

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1024,6 +1024,15 @@ void Window::popup(const Rect2i &p_screen_rect) {
 		set_size(adjust.size);
 	}
 
+	int scr = DisplayServer::get_singleton()->get_screen_count();
+	for (int i = 0; i < scr; i++) {
+		Rect2i r = DisplayServer::get_singleton()->screen_get_usable_rect(i);
+		if (r.has_point(position)) {
+			current_screen = i;
+			break;
+		}
+	}
+
 	set_transient(true);
 	set_visible(true);
 	_post_popup();


### PR DESCRIPTION
Fix popup position on multiple screens on macOS (and maybe on other OSs).

This PR don't fix popup position issue when multiple displays have different scaling, macOS APIs return "looks like" screen rects (eg. 4K display with 2.0 scale will be treated as 1920x1080), probably some DisplyServer API changes will be necessary to avoid overlapping or gaps in the screen positions.
