### PR TITLE
Fixed errors in makerst pre-commit hook

### DIFF
--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -353,7 +353,7 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
     class_name = class_def.name
 
     if dry_run:
-        f = open(os.devnull, "w")
+        f = open(os.devnull, "w", encoding="utf-8")
     else:
         f = open(os.path.join(output_dir, "class_" + class_name.lower() + ".rst"), "w", encoding="utf-8")
 

--- a/misc/hooks/pre-commit-makerst
+++ b/misc/hooks/pre-commit-makerst
@@ -2,4 +2,11 @@
 
 # Git pre-commit hook that checks the class reference syntax using makerst.py.
 
-doc/tools/makerst.py doc/classes modules --dry-run
+# Workaround because we can't execute the .py file directly on windows
+PYTHON=python
+py_ver=$($PYTHON -c "import sys; print(sys.version_info.major)")
+if [[ "$py_ver" != "3" ]]; then
+  PYTHON+=3
+fi
+
+$PYTHON doc/tools/makerst.py doc/classes modules --dry-run


### PR DESCRIPTION
Fixes 2 errors described in https://github.com/godotengine/godot/issues/37431#issuecomment-606224542.

I'm not sure if they are Windows specific, but I wasn't able to run the pre-commit hooks without these fixes on Windows 10.

- `/usr/bin/env: 'python3': No such file or directory`
The Python script doesn't run properly without `python` command.

- `UnicodeEncodeError: 'charmap' codec can't encode character '\u03bc' in position 35: character maps to <undefined>`
The option to support utf-8 was missing in the dry-run version, which was causing errors with μ characters.