### PR TITLE
replace selected text with empty string bug fixed

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -226,6 +226,10 @@ void FindReplaceBar::_replace_all() {
 
 	text_edit->begin_complex_operation();
 
+	if (selection_enabled && is_selection_only()) {
+		text_edit->cursor_set_line(selection_begin.width);
+		text_edit->cursor_set_column(selection_begin.height);
+	}
 	if (search_current()) {
 		do {
 			// replace area
@@ -243,7 +247,7 @@ void FindReplaceBar::_replace_all() {
 
 			if (selection_enabled && is_selection_only()) {
 				if (match_from < selection_begin || match_to > selection_end) {
-					continue;
+					break; // Done.
 				}
 
 				// Replace but adjust selection bounds.
@@ -288,6 +292,10 @@ void FindReplaceBar::_get_search_from(int &r_line, int &r_col) {
 
 	r_line = text_edit->cursor_get_line();
 	r_col = text_edit->cursor_get_column();
+
+	if (text_edit->is_selection_active() && is_selection_only()) {
+		return;
+	}
 
 	if (r_line == result_line && r_col >= result_col && r_col <= result_col + get_search_text().length()) {
 		r_col = result_col;


### PR DESCRIPTION
Fix: #37416

The bug was an infinite loop because the search string is empty so the search column doesn't increase it's position ( or increase by 0 ).