### PR TITLE
Fix profiler frame number stops updating when window is minimized

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -318,7 +318,7 @@ struct RemoteDebugger::ServersProfiler {
 
 	void _send_frame_data(bool p_final) {
 		DebuggerMarshalls::ServersProfilerFrame frame;
-		frame.frame_number = Engine::get_singleton()->get_frames_drawn();
+		frame.frame_number = Engine::get_singleton()->get_idle_frames();
 		frame.frame_time = frame_time;
 		frame.idle_time = idle_time;
 		frame.physics_time = physics_time;


### PR DESCRIPTION
Fix #37341

I confirm this issue is happening in 3.2 too, but I'm making the change on master. I don't know if this is the right workflow, I can force push another commit if needed.