### PR TITLE
SpriteFrames::add_spritesheet_animation() implemented

### DIFF
--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -31,6 +31,23 @@
 				Adds a frame to the given animation.
 			</description>
 		</method>
+		<method name="add_spritesheet_animation">
+			<return type="void">
+			</return>
+			<argument index="0" name="anim" type="StringName">
+			</argument>
+			<argument index="1" name="texture" type="Texture2D">
+			</argument>
+			<argument index="2" name="hframe" type="int">
+			</argument>
+			<argument index="3" name="vframe" type="int">
+			</argument>
+			<argument index="4" name="selected_frames" type="Array">
+			</argument>
+			<description>
+				Adds an animation by spliting the texture (hframe * vframe), and adds all selected frames to the animation.
+			</description>
+		</method>
 		<method name="clear">
 			<return type="void">
 			</return>

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -115,6 +115,29 @@ void SpriteFrames::add_frame(const StringName &p_anim, const Ref<Texture2D> &p_f
 	emit_changed();
 }
 
+void SpriteFrames::add_spritesheet_animation(const StringName &p_anim, const Ref<Texture2D> &p_texture, int p_hframe, int p_vframe, const Array &p_selected_frames) {
+
+	add_animation(p_anim);
+
+	for (int i = 0; i < p_selected_frames.size(); i++) {
+
+		int idx = p_selected_frames[i];
+		int width = p_texture.ptr()->get_size().width / p_hframe;
+		int height = p_texture.ptr()->get_size().height / p_vframe;
+		int xp = idx % p_hframe;
+		int yp = (idx - xp) / p_hframe;
+		int x = xp * width;
+		int y = yp * height;
+
+		Ref<AtlasTexture> at;
+		at.instance();
+		at->set_atlas(p_texture);
+		at->set_region(Rect2(x, y, width, height));
+
+		add_frame(p_anim, at, -1);
+	}
+}
+
 int SpriteFrames::get_frame_count(const StringName &p_anim) const {
 	const Map<StringName, Anim>::Element *E = animations.find(p_anim);
 	ERR_FAIL_COND_V_MSG(!E, 0, "Animation '" + String(p_anim) + "' doesn't exist.");
@@ -305,6 +328,7 @@ void SpriteFrames::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_animation_loop", "anim"), &SpriteFrames::get_animation_loop);
 
 	ClassDB::bind_method(D_METHOD("add_frame", "anim", "frame", "at_position"), &SpriteFrames::add_frame, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("add_spritesheet_animation", "anim", "texture", "hframe", "vframe", "selected_frames"), &SpriteFrames::add_spritesheet_animation);
 	ClassDB::bind_method(D_METHOD("get_frame_count", "anim"), &SpriteFrames::get_frame_count);
 	ClassDB::bind_method(D_METHOD("get_frame", "anim", "idx"), &SpriteFrames::get_frame);
 	ClassDB::bind_method(D_METHOD("set_frame", "anim", "idx", "txt"), &SpriteFrames::set_frame);

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -85,6 +85,7 @@ public:
 	bool get_animation_loop(const StringName &p_anim) const;
 
 	void add_frame(const StringName &p_anim, const Ref<Texture2D> &p_frame, int p_at_pos = -1);
+	void add_spritesheet_animation(const StringName &p_anim, const Ref<Texture2D> &p_texture, int p_hframe, int p_vframe, const Array &p_selected_frames);
 	int get_frame_count(const StringName &p_anim) const;
 	_FORCE_INLINE_ Ref<Texture2D> get_frame(const StringName &p_anim, int p_idx) const {
 


### PR DESCRIPTION
The animated sprite is all about sprite sheet frame animation, but It's only possible to add frames from a single sprite sheet texture by the animated sprite editor plugin (add frame from a sprite sheet), using gdscript to animate a sprite sheet with animated sprite seems a bit harder, so I've implemented a method to do so.

![spritesheet](https://user-images.githubusercontent.com/41085900/77979543-8bd07c00-7322-11ea-9e24-1a4ff7b7822e.jpg)

![animated-sprite-gdscript](https://user-images.githubusercontent.com/41085900/77979737-1b762a80-7323-11ea-99fb-58f8288b499f.JPG)

![animated_sprite](https://user-images.githubusercontent.com/41085900/77979756-2cbf3700-7323-11ea-9a58-e56e28b5fa82.gif)

