### PR TITLE
Clarify docs for Thread.start() godotengine#36032

### DIFF
--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -36,7 +36,7 @@
 			<argument index="3" name="priority" type="int" enum="Thread.Priority" default="1">
 			</argument>
 			<description>
-				Starts a new [Thread] that runs [code]method[/code] on object [code]instance[/code] with [code]userdata[/code] passed as an argument. The [code]priority[/code] of the [Thread] can be changed by passing a value from the [enum Priority] enum.
+				Starts a new [Thread] that runs [code]method[/code] on object [code]instance[/code] with [code]userdata[/code] passed as an argument. Even if no userdata is passed, [code]method[/code] must accept one argument and it will be null. The [code]priority[/code] of the [Thread] can be changed by passing a value from the [enum Priority] enum.
 				Returns [constant OK] on success, or [constant ERR_CANT_CREATE] on failure.
 			</description>
 		</method>


### PR DESCRIPTION
Updated docs for Thread.start() to specify that the method argument must accept one parameter. This was not previously mentioned and led to some confusion.

Fixes #36032