### PR TITLE
Clarify Dictionary duplicate parameters in docs

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -78,7 +78,7 @@
 			<argument index="0" name="deep" type="bool" default="false">
 			</argument>
 			<description>
-				Creates a copy of the dictionary, and returns it.
+				Creates a copy of the dictionary, and returns it. The [code]deep[/code] parameter causes inner dictionaries and arrays to be copied recursively, but does not apply to objects.
 			</description>
 		</method>
 		<method name="empty">


### PR DESCRIPTION
Added additional clarification for the function of the `deep`
parameter in the Dictionary's `duplicate` method documentation.

fixes #37162 