### PR TITLE
Fix res:// trimmed to s:// on Windows (3.2)

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -209,8 +209,15 @@ String DirAccessWindows::get_current_dir() {
 String DirAccessWindows::get_current_dir_without_drive() {
 
 	String dir = get_current_dir();
-	int p = current_dir.find(":");
-	return p != -1 ? dir.right(p + 1) : dir;
+
+	if (_get_root_string() == "") {
+		int p = current_dir.find(":");
+		if (p != -1) {
+			dir = dir.right(p + 1);
+		}
+	}
+
+	return dir;
 }
 
 bool DirAccessWindows::file_exists(String p_file) {


### PR DESCRIPTION
This was affecting the drive-less current directory query, specially noticeable in the file dialog after the change for a better drive letters UX on Windows.

(There's a separate version of this PR for 4.0.)

---
**This code is generously donated by IMVU.**