### PR TITLE
Fix res:// trimmed to s:// on Windows

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -206,7 +206,13 @@ String DirAccessWindows::get_current_dir(bool p_include_drive) {
 	if (p_include_drive) {
 		return current_dir;
 	} else {
-		return current_dir.right(current_dir.find(":") + 1);
+		if (_get_root_string() == "") {
+			int p = current_dir.find(":");
+			if (p != -1) {
+				return current_dir.right(p + 1);
+			}
+		}
+		return current_dir;
 	}
 }
 


### PR DESCRIPTION
This was affecting the drive-less current directory query, specially noticeable in the file dialog after the change for a better drive letters UX on Windows.

(There's a separate version of this PR for 3.2.)

---
**This code is generously donated by IMVU.**