### PR TITLE
etc2comp: Fix max iterations for RGBA channels

### DIFF
--- a/thirdparty/etc2comp/EtcBlock4x4Encoding_RGB8.cpp
+++ b/thirdparty/etc2comp/EtcBlock4x4Encoding_RGB8.cpp
@@ -508,7 +508,7 @@ namespace Etc
 		int iMaxRed1 = iColor1Red + (int)a_uiRadius;
 		if (iMaxRed1 > 15)
 		{
-			iMinRed1 = 15;
+			iMaxRed1 = 15;
 		}
 
 		int iMinGreen1 = iColor1Green - (int)a_uiRadius;
@@ -519,7 +519,7 @@ namespace Etc
 		int iMaxGreen1 = iColor1Green + (int)a_uiRadius;
 		if (iMaxGreen1 > 15)
 		{
-			iMinGreen1 = 15;
+			iMaxGreen1 = 15;
 		}
 
 		int iMinBlue1 = iColor1Blue - (int)a_uiRadius;
@@ -530,7 +530,7 @@ namespace Etc
 		int iMaxBlue1 = iColor1Blue + (int)a_uiRadius;
 		if (iMaxBlue1 > 15)
 		{
-			iMinBlue1 = 15;
+			iMaxBlue1 = 15;
 		}
 
 		int iColor2Red = m_frgbaOriginalColor2_TAndH.IntRed(15.0f);
@@ -545,7 +545,7 @@ namespace Etc
 		int iMaxRed2 = iColor2Red + (int)a_uiRadius;
 		if (iMaxRed2 > 15)
 		{
-			iMinRed2 = 15;
+			iMaxRed2 = 15;
 		}
 
 		int iMinGreen2 = iColor2Green - (int)a_uiRadius;
@@ -556,7 +556,7 @@ namespace Etc
 		int iMaxGreen2 = iColor2Green + (int)a_uiRadius;
 		if (iMaxGreen2 > 15)
 		{
-			iMinGreen2 = 15;
+			iMaxGreen2 = 15;
 		}
 
 		int iMinBlue2 = iColor2Blue - (int)a_uiRadius;
@@ -567,7 +567,7 @@ namespace Etc
 		int iMaxBlue2 = iColor2Blue + (int)a_uiRadius;
 		if (iMaxBlue2 > 15)
 		{
-			iMinBlue2 = 15;
+			iMaxBlue2 = 15;
 		}
 
 		for (unsigned int uiDistance = 0; uiDistance < TH_DISTANCES; uiDistance++)
@@ -761,7 +761,7 @@ namespace Etc
 		int iMaxRed1 = iColor1Red + (int)a_uiRadius;
 		if (iMaxRed1 > 15)
 		{
-			iMinRed1 = 15;
+			iMaxRed1 = 15;
 		}
 
 		int iMinGreen1 = iColor1Green - (int)a_uiRadius;
@@ -772,7 +772,7 @@ namespace Etc
 		int iMaxGreen1 = iColor1Green + (int)a_uiRadius;
 		if (iMaxGreen1 > 15)
 		{
-			iMinGreen1 = 15;
+			iMaxGreen1 = 15;
 		}
 
 		int iMinBlue1 = iColor1Blue - (int)a_uiRadius;
@@ -783,7 +783,7 @@ namespace Etc
 		int iMaxBlue1 = iColor1Blue + (int)a_uiRadius;
 		if (iMaxBlue1 > 15)
 		{
-			iMinBlue1 = 15;
+			iMaxBlue1 = 15;
 		}
 
 		int iColor2Red = m_frgbaOriginalColor2_TAndH.IntRed(15.0f);
@@ -798,7 +798,7 @@ namespace Etc
 		int iMaxRed2 = iColor2Red + (int)a_uiRadius;
 		if (iMaxRed2 > 15)
 		{
-			iMinRed2 = 15;
+			iMaxRed2 = 15;
 		}
 
 		int iMinGreen2 = iColor2Green - (int)a_uiRadius;
@@ -809,7 +809,7 @@ namespace Etc
 		int iMaxGreen2 = iColor2Green + (int)a_uiRadius;
 		if (iMaxGreen2 > 15)
 		{
-			iMinGreen2 = 15;
+			iMaxGreen2 = 15;
 		}
 
 		int iMinBlue2 = iColor2Blue - (int)a_uiRadius;
@@ -820,7 +820,7 @@ namespace Etc
 		int iMaxBlue2 = iColor2Blue + (int)a_uiRadius;
 		if (iMaxBlue2 > 15)
 		{
-			iMinBlue2 = 15;
+			iMaxBlue2 = 15;
 		}
 
 		for (unsigned int uiDistance = 0; uiDistance < TH_DISTANCES; uiDistance++)

--- a/thirdparty/etc2comp/EtcBlock4x4Encoding_RGB8A1.cpp
+++ b/thirdparty/etc2comp/EtcBlock4x4Encoding_RGB8A1.cpp
@@ -847,7 +847,7 @@ namespace Etc
 		int iMaxRed1 = iColor1Red + (int)a_uiRadius;
 		if (iMaxRed1 > 15)
 		{
-			iMinRed1 = 15;
+			iMaxRed1 = 15;
 		}
 
 		int iMinGreen1 = iColor1Green - (int)a_uiRadius;
@@ -858,7 +858,7 @@ namespace Etc
 		int iMaxGreen1 = iColor1Green + (int)a_uiRadius;
 		if (iMaxGreen1 > 15)
 		{
-			iMinGreen1 = 15;
+			iMaxGreen1 = 15;
 		}
 
 		int iMinBlue1 = iColor1Blue - (int)a_uiRadius;
@@ -869,7 +869,7 @@ namespace Etc
 		int iMaxBlue1 = iColor1Blue + (int)a_uiRadius;
 		if (iMaxBlue1 > 15)
 		{
-			iMinBlue1 = 15;
+			iMaxBlue1 = 15;
 		}
 
 		int iColor2Red = m_frgbaOriginalColor2_TAndH.IntRed(15.0f);
@@ -884,7 +884,7 @@ namespace Etc
 		int iMaxRed2 = iColor2Red + (int)a_uiRadius;
 		if (iMaxRed2 > 15)
 		{
-			iMinRed2 = 15;
+			iMaxRed2 = 15;
 		}
 
 		int iMinGreen2 = iColor2Green - (int)a_uiRadius;
@@ -895,7 +895,7 @@ namespace Etc
 		int iMaxGreen2 = iColor2Green + (int)a_uiRadius;
 		if (iMaxGreen2 > 15)
 		{
-			iMinGreen2 = 15;
+			iMaxGreen2 = 15;
 		}
 
 		int iMinBlue2 = iColor2Blue - (int)a_uiRadius;
@@ -906,7 +906,7 @@ namespace Etc
 		int iMaxBlue2 = iColor2Blue + (int)a_uiRadius;
 		if (iMaxBlue2 > 15)
 		{
-			iMinBlue2 = 15;
+			iMaxBlue2 = 15;
 		}
 
 		for (unsigned int uiDistance = 0; uiDistance < TH_DISTANCES; uiDistance++)
@@ -1108,7 +1108,7 @@ namespace Etc
 		int iMaxRed1 = iColor1Red + (int)a_uiRadius;
 		if (iMaxRed1 > 15)
 		{
-			iMinRed1 = 15;
+			iMaxRed1 = 15;
 		}
 
 		int iMinGreen1 = iColor1Green - (int)a_uiRadius;
@@ -1119,7 +1119,7 @@ namespace Etc
 		int iMaxGreen1 = iColor1Green + (int)a_uiRadius;
 		if (iMaxGreen1 > 15)
 		{
-			iMinGreen1 = 15;
+			iMaxGreen1 = 15;
 		}
 
 		int iMinBlue1 = iColor1Blue - (int)a_uiRadius;
@@ -1130,7 +1130,7 @@ namespace Etc
 		int iMaxBlue1 = iColor1Blue + (int)a_uiRadius;
 		if (iMaxBlue1 > 15)
 		{
-			iMinBlue1 = 15;
+			iMaxBlue1 = 15;
 		}
 
 		int iColor2Red = m_frgbaOriginalColor2_TAndH.IntRed(15.0f);
@@ -1145,7 +1145,7 @@ namespace Etc
 		int iMaxRed2 = iColor2Red + (int)a_uiRadius;
 		if (iMaxRed2 > 15)
 		{
-			iMinRed2 = 15;
+			iMaxRed2 = 15;
 		}
 
 		int iMinGreen2 = iColor2Green - (int)a_uiRadius;
@@ -1156,7 +1156,7 @@ namespace Etc
 		int iMaxGreen2 = iColor2Green + (int)a_uiRadius;
 		if (iMaxGreen2 > 15)
 		{
-			iMinGreen2 = 15;
+			iMaxGreen2 = 15;
 		}
 
 		int iMinBlue2 = iColor2Blue - (int)a_uiRadius;
@@ -1167,7 +1167,7 @@ namespace Etc
 		int iMaxBlue2 = iColor2Blue + (int)a_uiRadius;
 		if (iMaxBlue2 > 15)
 		{
-			iMinBlue2 = 15;
+			iMaxBlue2 = 15;
 		}
 
 		for (unsigned int uiDistance = 0; uiDistance < TH_DISTANCES; uiDistance++)

--- a/thirdparty/etc2comp/patches/fix-rgba8-max-channels.patch
+++ b/thirdparty/etc2comp/patches/fix-rgba8-max-channels.patch
@@ -1,0 +1,224 @@
+diff --git a/thirdparty/etc2comp/EtcBlock4x4Encoding_RGB8.cpp b/thirdparty/etc2comp/EtcBlock4x4Encoding_RGB8.cpp
+index 5656556db9..5c7ebed788 100644
+--- a/thirdparty/etc2comp/EtcBlock4x4Encoding_RGB8.cpp
++++ b/thirdparty/etc2comp/EtcBlock4x4Encoding_RGB8.cpp
+@@ -508,7 +508,7 @@ namespace Etc
+ 		int iMaxRed1 = iColor1Red + (int)a_uiRadius;
+ 		if (iMaxRed1 > 15)
+ 		{
+-			iMinRed1 = 15;
++			iMaxRed1 = 15;
+ 		}
+ 
+ 		int iMinGreen1 = iColor1Green - (int)a_uiRadius;
+@@ -519,7 +519,7 @@ namespace Etc
+ 		int iMaxGreen1 = iColor1Green + (int)a_uiRadius;
+ 		if (iMaxGreen1 > 15)
+ 		{
+-			iMinGreen1 = 15;
++			iMaxGreen1 = 15;
+ 		}
+ 
+ 		int iMinBlue1 = iColor1Blue - (int)a_uiRadius;
+@@ -530,7 +530,7 @@ namespace Etc
+ 		int iMaxBlue1 = iColor1Blue + (int)a_uiRadius;
+ 		if (iMaxBlue1 > 15)
+ 		{
+-			iMinBlue1 = 15;
++			iMaxBlue1 = 15;
+ 		}
+ 
+ 		int iColor2Red = m_frgbaOriginalColor2_TAndH.IntRed(15.0f);
+@@ -545,7 +545,7 @@ namespace Etc
+ 		int iMaxRed2 = iColor2Red + (int)a_uiRadius;
+ 		if (iMaxRed2 > 15)
+ 		{
+-			iMinRed2 = 15;
++			iMaxRed2 = 15;
+ 		}
+ 
+ 		int iMinGreen2 = iColor2Green - (int)a_uiRadius;
+@@ -556,7 +556,7 @@ namespace Etc
+ 		int iMaxGreen2 = iColor2Green + (int)a_uiRadius;
+ 		if (iMaxGreen2 > 15)
+ 		{
+-			iMinGreen2 = 15;
++			iMaxGreen2 = 15;
+ 		}
+ 
+ 		int iMinBlue2 = iColor2Blue - (int)a_uiRadius;
+@@ -567,7 +567,7 @@ namespace Etc
+ 		int iMaxBlue2 = iColor2Blue + (int)a_uiRadius;
+ 		if (iMaxBlue2 > 15)
+ 		{
+-			iMinBlue2 = 15;
++			iMaxBlue2 = 15;
+ 		}
+ 
+ 		for (unsigned int uiDistance = 0; uiDistance < TH_DISTANCES; uiDistance++)
+@@ -761,7 +761,7 @@ namespace Etc
+ 		int iMaxRed1 = iColor1Red + (int)a_uiRadius;
+ 		if (iMaxRed1 > 15)
+ 		{
+-			iMinRed1 = 15;
++			iMaxRed1 = 15;
+ 		}
+ 
+ 		int iMinGreen1 = iColor1Green - (int)a_uiRadius;
+@@ -772,7 +772,7 @@ namespace Etc
+ 		int iMaxGreen1 = iColor1Green + (int)a_uiRadius;
+ 		if (iMaxGreen1 > 15)
+ 		{
+-			iMinGreen1 = 15;
++			iMaxGreen1 = 15;
+ 		}
+ 
+ 		int iMinBlue1 = iColor1Blue - (int)a_uiRadius;
+@@ -783,7 +783,7 @@ namespace Etc
+ 		int iMaxBlue1 = iColor1Blue + (int)a_uiRadius;
+ 		if (iMaxBlue1 > 15)
+ 		{
+-			iMinBlue1 = 15;
++			iMaxBlue1 = 15;
+ 		}
+ 
+ 		int iColor2Red = m_frgbaOriginalColor2_TAndH.IntRed(15.0f);
+@@ -798,7 +798,7 @@ namespace Etc
+ 		int iMaxRed2 = iColor2Red + (int)a_uiRadius;
+ 		if (iMaxRed2 > 15)
+ 		{
+-			iMinRed2 = 15;
++			iMaxRed2 = 15;
+ 		}
+ 
+ 		int iMinGreen2 = iColor2Green - (int)a_uiRadius;
+@@ -809,7 +809,7 @@ namespace Etc
+ 		int iMaxGreen2 = iColor2Green + (int)a_uiRadius;
+ 		if (iMaxGreen2 > 15)
+ 		{
+-			iMinGreen2 = 15;
++			iMaxGreen2 = 15;
+ 		}
+ 
+ 		int iMinBlue2 = iColor2Blue - (int)a_uiRadius;
+@@ -820,7 +820,7 @@ namespace Etc
+ 		int iMaxBlue2 = iColor2Blue + (int)a_uiRadius;
+ 		if (iMaxBlue2 > 15)
+ 		{
+-			iMinBlue2 = 15;
++			iMaxBlue2 = 15;
+ 		}
+ 
+ 		for (unsigned int uiDistance = 0; uiDistance < TH_DISTANCES; uiDistance++)
+diff --git a/thirdparty/etc2comp/EtcBlock4x4Encoding_RGB8A1.cpp b/thirdparty/etc2comp/EtcBlock4x4Encoding_RGB8A1.cpp
+index ba2b42fb05..b94b64e68c 100644
+--- a/thirdparty/etc2comp/EtcBlock4x4Encoding_RGB8A1.cpp
++++ b/thirdparty/etc2comp/EtcBlock4x4Encoding_RGB8A1.cpp
+@@ -847,7 +847,7 @@ namespace Etc
+ 		int iMaxRed1 = iColor1Red + (int)a_uiRadius;
+ 		if (iMaxRed1 > 15)
+ 		{
+-			iMinRed1 = 15;
++			iMaxRed1 = 15;
+ 		}
+ 
+ 		int iMinGreen1 = iColor1Green - (int)a_uiRadius;
+@@ -858,7 +858,7 @@ namespace Etc
+ 		int iMaxGreen1 = iColor1Green + (int)a_uiRadius;
+ 		if (iMaxGreen1 > 15)
+ 		{
+-			iMinGreen1 = 15;
++			iMaxGreen1 = 15;
+ 		}
+ 
+ 		int iMinBlue1 = iColor1Blue - (int)a_uiRadius;
+@@ -869,7 +869,7 @@ namespace Etc
+ 		int iMaxBlue1 = iColor1Blue + (int)a_uiRadius;
+ 		if (iMaxBlue1 > 15)
+ 		{
+-			iMinBlue1 = 15;
++			iMaxBlue1 = 15;
+ 		}
+ 
+ 		int iColor2Red = m_frgbaOriginalColor2_TAndH.IntRed(15.0f);
+@@ -884,7 +884,7 @@ namespace Etc
+ 		int iMaxRed2 = iColor2Red + (int)a_uiRadius;
+ 		if (iMaxRed2 > 15)
+ 		{
+-			iMinRed2 = 15;
++			iMaxRed2 = 15;
+ 		}
+ 
+ 		int iMinGreen2 = iColor2Green - (int)a_uiRadius;
+@@ -895,7 +895,7 @@ namespace Etc
+ 		int iMaxGreen2 = iColor2Green + (int)a_uiRadius;
+ 		if (iMaxGreen2 > 15)
+ 		{
+-			iMinGreen2 = 15;
++			iMaxGreen2 = 15;
+ 		}
+ 
+ 		int iMinBlue2 = iColor2Blue - (int)a_uiRadius;
+@@ -906,7 +906,7 @@ namespace Etc
+ 		int iMaxBlue2 = iColor2Blue + (int)a_uiRadius;
+ 		if (iMaxBlue2 > 15)
+ 		{
+-			iMinBlue2 = 15;
++			iMaxBlue2 = 15;
+ 		}
+ 
+ 		for (unsigned int uiDistance = 0; uiDistance < TH_DISTANCES; uiDistance++)
+@@ -1108,7 +1108,7 @@ namespace Etc
+ 		int iMaxRed1 = iColor1Red + (int)a_uiRadius;
+ 		if (iMaxRed1 > 15)
+ 		{
+-			iMinRed1 = 15;
++			iMaxRed1 = 15;
+ 		}
+ 
+ 		int iMinGreen1 = iColor1Green - (int)a_uiRadius;
+@@ -1119,7 +1119,7 @@ namespace Etc
+ 		int iMaxGreen1 = iColor1Green + (int)a_uiRadius;
+ 		if (iMaxGreen1 > 15)
+ 		{
+-			iMinGreen1 = 15;
++			iMaxGreen1 = 15;
+ 		}
+ 
+ 		int iMinBlue1 = iColor1Blue - (int)a_uiRadius;
+@@ -1130,7 +1130,7 @@ namespace Etc
+ 		int iMaxBlue1 = iColor1Blue + (int)a_uiRadius;
+ 		if (iMaxBlue1 > 15)
+ 		{
+-			iMinBlue1 = 15;
++			iMaxBlue1 = 15;
+ 		}
+ 
+ 		int iColor2Red = m_frgbaOriginalColor2_TAndH.IntRed(15.0f);
+@@ -1145,7 +1145,7 @@ namespace Etc
+ 		int iMaxRed2 = iColor2Red + (int)a_uiRadius;
+ 		if (iMaxRed2 > 15)
+ 		{
+-			iMinRed2 = 15;
++			iMaxRed2 = 15;
+ 		}
+ 
+ 		int iMinGreen2 = iColor2Green - (int)a_uiRadius;
+@@ -1156,7 +1156,7 @@ namespace Etc
+ 		int iMaxGreen2 = iColor2Green + (int)a_uiRadius;
+ 		if (iMaxGreen2 > 15)
+ 		{
+-			iMinGreen2 = 15;
++			iMaxGreen2 = 15;
+ 		}
+ 
+ 		int iMinBlue2 = iColor2Blue - (int)a_uiRadius;
+@@ -1167,7 +1167,7 @@ namespace Etc
+ 		int iMaxBlue2 = iColor2Blue + (int)a_uiRadius;
+ 		if (iMaxBlue2 > 15)
+ 		{
+-			iMinBlue2 = 15;
++			iMaxBlue2 = 15;
+ 		}
+ 
+ 		for (unsigned int uiDistance = 0; uiDistance < TH_DISTANCES; uiDistance++)


### PR DESCRIPTION
Those checks were *very likely* meant to clamp the max value,
not the min one.

Fixes https://github.com/godotengine/godot/issues/10059#issuecomment-606993001.

I have yet to do tests to check if etc2 import still seems to work properly.

CC @jitspoe