### PR TITLE
Improving code around "Change Type" tool to better respect scripts.

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2005,6 +2005,8 @@ void SceneTreeDock::_create() {
 		UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 		ur->create_action(TTR("Change type of node(s)"));
 
+		List<Node *> replaced;
+
 		for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
 			Node *n = E->get();
 			ERR_FAIL_COND(!n);
@@ -2015,13 +2017,24 @@ void SceneTreeDock::_create() {
 			Node *newnode = Object::cast_to<Node>(c);
 			ERR_FAIL_COND(!newnode);
 
+			if (!n->get_script().is_null() && newnode->get_script().is_null())
+				newnode->set_script(n->get_script());
+
 			ur->add_do_method(this, "replace_node", n, newnode, true, false);
 			ur->add_do_reference(newnode);
 			ur->add_undo_method(this, "replace_node", newnode, n, false, false);
 			ur->add_undo_reference(n);
+
+			replaced.push_back(newnode);
 		}
 
 		ur->commit_action();
+
+		editor_selection->clear();
+		for (List<Node *>::Element *E = replaced.front(); E; E = E->next()) {
+			editor_selection->add_node(E->get());
+		}
+
 	} else if (current_option == TOOL_REPARENT_TO_NEW_NODE) {
 		List<Node *> selection = editor_selection->get_selected_node_list();
 		ERR_FAIL_COND(selection.size() <= 0);
@@ -2078,45 +2091,8 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 	Node *n = p_node;
 	Node *newnode = p_by_node;
 
-	if (p_keep_properties) {
-		Node *default_oldnode = Object::cast_to<Node>(ClassDB::instance(n->get_class()));
-		List<PropertyInfo> pinfo;
-		n->get_property_list(&pinfo);
-
-		for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
-			if (!(E->get().usage & PROPERTY_USAGE_STORAGE))
-				continue;
-			if (E->get().name == "__meta__" || E->get().name == "script")
-				continue;
-			if (default_oldnode->get(E->get().name) != n->get(E->get().name)) {
-				newnode->set(E->get().name, n->get(E->get().name));
-			}
-		}
-
-		memdelete(default_oldnode);
-	}
-
 	editor->push_item(nullptr);
-
-	//reconnect signals
-	List<MethodInfo> sl;
-
-	n->get_signal_list(&sl);
-	for (List<MethodInfo>::Element *E = sl.front(); E; E = E->next()) {
-
-		List<Object::Connection> cl;
-		n->get_signal_connection_list(E->get().name, &cl);
-
-		for (List<Object::Connection>::Element *F = cl.front(); F; F = F->next()) {
-
-			Object::Connection &c = F->get();
-			if (!(c.flags & Object::CONNECT_PERSIST))
-				continue;
-			newnode->connect(c.signal.get_name(), c.callable, c.binds, Object::CONNECT_PERSIST);
-		}
-	}
-
-	String newname = n->get_name();
+	String oldname = n->get_name();
 
 	List<Node *> to_erase;
 	for (int i = 0; i < n->get_child_count(); i++) {
@@ -2125,10 +2101,7 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 		}
 	}
 
-	//for better or worse, the contents of Node::replace_by's "p_keep_data" parameter are replicated in the code above...
-	//the above appears to be a workaround for the scene replacing things that it has made subtle edits to (for example meta and script types)
-	//this also preserves across undo correctly
-	n->replace_by(newnode, false);
+	n->replace_by(newnode, p_keep_properties);
 
 	if (n == edited_scene) {
 		edited_scene = newnode;
@@ -2141,10 +2114,12 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 		Node *c = newnode->get_child(i);
 		c->call("set_transform", c->call("get_transform"));
 	}
+
 	//p_remove_old was added to support undo
 	if (p_remove_old)
 		editor_data->get_undo_redo().clear_history();
-	newnode->set_name(newname);
+
+	newnode->set_name(oldname);
 
 	editor->push_item(newnode);
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2086,7 +2086,7 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 		for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
 			if (!(E->get().usage & PROPERTY_USAGE_STORAGE))
 				continue;
-			if (E->get().name == "__meta__")
+			if (E->get().name == "__meta__" || E->get().name == "script")
 				continue;
 			if (default_oldnode->get(E->get().name) != n->get(E->get().name)) {
 				newnode->set(E->get().name, n->get(E->get().name));
@@ -2124,7 +2124,11 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 			to_erase.push_back(n->get_child(i));
 		}
 	}
-	n->replace_by(newnode, true);
+
+	//for better or worse, the contents of Node::replace_by's "p_keep_data" parameter are replicated in the code above...
+	//the above appears to be a workaround for the scene replacing things that it has made subtle edits to (for example meta and script types)
+	//this also preserves across undo correctly
+	n->replace_by(newnode, false);
 
 	if (n == edited_scene) {
 		edited_scene = newnode;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2440,18 +2440,27 @@ void Node::replace_by(Node *p_node, bool p_keep_data) {
 	List<_NodeReplaceByPair> replace_data;
 
 	if (p_keep_data) {
-
+		Node *default_oldnode = Object::cast_to<Node>(ClassDB::instance(get_class()));
 		List<PropertyInfo> plist;
 		get_property_list(&plist);
 
 		for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
-
 			_NodeReplaceByPair rd;
 			if (!(E->get().usage & PROPERTY_USAGE_STORAGE))
 				continue;
+
 			rd.name = E->get().name;
+			if (rd.name == "__meta__" || rd.name == "script")
+				continue;
+
 			rd.value = get(rd.name);
+			if (default_oldnode->get(rd.name) == rd.value)
+				continue;
+
+			replace_data.push_back(rd);
 		}
+
+		memdelete(default_oldnode);
 
 		List<GroupInfo> groups;
 		get_groups(&groups);


### PR DESCRIPTION
An improved fix for #37479 (Change Type does nothing for script "classes")

A portion of the code in `Node::replace_by` is vestigial and does not actually do anything (besides looping over all properties and calling `get`), both it and the other portion is identical to what was in `SceneTreeDock::replace_node`. I have refactored the working code of `replace_node` in to `replace_by`. I suspect this duplication/copy code should actually be moved even further down the tree into Object (because it is responsible for properties, and the skipping scripts and metadata would make sense in the class responsible for those things).

I then elevated the concern of what script the resulting node should have to the "Change Type" code of SceneTreeDock, this seems like the more relevant location to make that decision. The decision is straight forward, if the new type has a script it uses that, if the old node has a script it uses that, then it gives up and uses nothing. This seems to give the best behavior for common use cases.