### PR TITLE
Fix array out of bounds access caused by uninitialised variables

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -261,6 +261,7 @@ HashMap<StringName, StringName> ClassDB::compat_classes;
 ClassDB::ClassInfo::ClassInfo() {
 
 	api = API_NONE;
+	class_ptr = nullptr;
 	creation_func = NULL;
 	inherits_ptr = NULL;
 	disabled = false;

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -2215,6 +2215,8 @@ Expression::Expression() :
 		root(NULL),
 		nodes(NULL),
 		execution_error(false) {
+	str_ofs = 0;
+	expression_dirty = false;
 }
 
 Expression::~Expression() {

--- a/modules/bullet/btRayShape.cpp
+++ b/modules/bullet/btRayShape.cpp
@@ -43,6 +43,7 @@ btRayShape::btRayShape(btScalar length) :
 		m_shapeAxis(0, 0, 1) {
 	m_shapeType = CUSTOM_CONVEX_SHAPE_TYPE;
 	setLength(length);
+	slipsOnSlope = false;
 }
 
 btRayShape::~btRayShape() {

--- a/modules/bullet/generic_6dof_joint_bullet.cpp
+++ b/modules/bullet/generic_6dof_joint_bullet.cpp
@@ -43,6 +43,12 @@
 Generic6DOFJointBullet::Generic6DOFJointBullet(RigidBodyBullet *rbA, RigidBodyBullet *rbB, const Transform &frameInA, const Transform &frameInB) :
 		JointBullet() {
 
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < PhysicsServer3D::G6DOF_JOINT_FLAG_MAX; j++) {
+			flags[i][j] = false;
+		}
+	}
+
 	Transform scaled_AFrame(frameInA.scaled(rbA->get_body_scale()));
 
 	scaled_AFrame.basis.rotref_posscale_decomposition(scaled_AFrame.basis);

--- a/modules/gdnative/videodecoder/video_stream_gdnative.h
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.h
@@ -194,7 +194,7 @@ public:
 	virtual void set_audio_track(int p_track);
 	virtual Ref<VideoStreamPlayback> instance_playback();
 
-	VideoStreamGDNative() {}
+	VideoStreamGDNative() { audio_track = 0; }
 };
 
 class ResourceFormatLoaderVideoStreamGDNative : public ResourceFormatLoader {

--- a/modules/webrtc/webrtc_multiplayer.cpp
+++ b/modules/webrtc/webrtc_multiplayer.cpp
@@ -371,6 +371,7 @@ WebRTCMultiplayer::WebRTCMultiplayer() {
 	unique_id = 0;
 	next_packet_peer = 0;
 	target_peer = 0;
+	client_count = 0;
 	transfer_mode = TRANSFER_MODE_RELIABLE;
 	refuse_connections = false;
 	connection_status = CONNECTION_DISCONNECTED;

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -3374,6 +3374,15 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 
 	r_error = OK;
 
+	current_cursor = CURSOR_ARROW;
+	mouse_mode = MOUSE_MODE_VISIBLE;
+
+	for (int i = 0; i < CURSOR_MAX; i++) {
+
+		cursors[i] = None;
+		img[i] = NULL;
+	}
+
 	last_button_state = 0;
 
 	xmbstring = NULL;
@@ -3649,14 +3658,6 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 		print_verbose("XcursorGetTheme could not get cursor theme");
 		cursor_theme = "default";
 	}
-
-	for (int i = 0; i < CURSOR_MAX; i++) {
-
-		cursors[i] = None;
-		img[i] = NULL;
-	}
-
-	current_cursor = CURSOR_ARROW;
 
 	for (int i = 0; i < CURSOR_MAX; i++) {
 

--- a/scene/3d/gi_probe.cpp
+++ b/scene/3d/gi_probe.cpp
@@ -293,6 +293,7 @@ GIProbeData::GIProbeData() {
 	propagation = 0.7;
 	anisotropy_strength = 0.5;
 	interior = false;
+	use_two_bounces = false;
 
 	probe = RS::get_singleton()->gi_probe_create();
 }

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -516,6 +516,11 @@ AnimationNodeStateMachinePlayback::AnimationNodeStateMachinePlayback() {
 	len_current = 0;
 	fading_time = 0;
 	stop_request = false;
+	len_total = 0.0;
+	pos_current = 0.0;
+	loops_current = 0;
+	fading_pos = 0.0;
+	start_request_travel = false;
 }
 
 ///////////////////////////////////////////////////////

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1514,6 +1514,7 @@ PopupMenu::PopupMenu() {
 	submenu_over = -1;
 	initial_button_mask = 0;
 	during_grabbed_click = false;
+	invalidated_click = false;
 
 	allow_search = false;
 	search_time_msec = 0;

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -122,6 +122,8 @@ private:
 			parent = NULL;
 			E = NULL;
 			line = 0;
+			index = 0;
+			type = ITEM_FRAME;
 		}
 		virtual ~Item() { _clear_children(); }
 	};

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -84,7 +84,10 @@ private:
 
 		float transition;
 		float time; // time in secs
-		Key() { transition = 1; }
+		Key() {
+			transition = 1;
+			time = 0;
+		}
 	};
 
 	// transform key holds either Vector3 or Quaternion

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -997,6 +997,7 @@ SelfList<DynamicFont>::List *DynamicFont::dynamic_fonts = NULL;
 DynamicFont::DynamicFont() :
 		font_list(this) {
 
+	valid = false;
 	cache_id.size = 16;
 	outline_cache_id.size = 16;
 	spacing_top = 0;

--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -363,4 +363,7 @@ AudioEffectPitchShift::AudioEffectPitchShift() {
 	pitch_scale = 1.0;
 	oversampling = 4;
 	fft_size = FFT_SIZE_2048;
+	wet = 0.0;
+	dry = 0.0;
+	filter = false;
 }

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_rd.h
@@ -571,7 +571,7 @@ private:
 			Rect2 atlas_rect;
 		};
 
-		RS::LightType light_type;
+		RS::LightType light_type = RS::LIGHT_DIRECTIONAL;
 
 		ShadowTransform shadow_transform[4];
 
@@ -581,7 +581,7 @@ private:
 
 		Vector3 light_vector;
 		Vector3 spot_vector;
-		float linear_att;
+		float linear_att = 0.0;
 
 		uint64_t shadow_pass = 0;
 		uint64_t last_scene_pass = 0;
@@ -590,7 +590,7 @@ private:
 		uint32_t light_index = 0;
 		uint32_t light_directional_index = 0;
 
-		uint32_t current_shadow_atlas_key;
+		uint32_t current_shadow_atlas_key = 0;
 
 		Vector2 dp;
 

--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
@@ -218,7 +218,7 @@ private:
 	struct Mesh {
 
 		struct Surface {
-			RS::PrimitiveType primitive;
+			RS::PrimitiveType primitive = RS::PRIMITIVE_POINTS;
 			uint32_t format = 0;
 
 			RID vertex_buffer;
@@ -232,8 +232,8 @@ private:
 			// cache-efficient structure.
 
 			struct Version {
-				uint32_t input_mask;
-				RD::VertexFormatID vertex_format;
+				uint32_t input_mask = 0;
+				RD::VertexFormatID vertex_format = 0;
 				RID vertex_array;
 			};
 
@@ -246,7 +246,7 @@ private:
 			uint32_t index_count = 0;
 
 			struct LOD {
-				float edge_length;
+				float edge_length = 0.0;
 				RID index_buffer;
 				RID index_array;
 			};
@@ -456,9 +456,9 @@ private:
 		RID color;
 
 		//used for retrieving from CPU
-		RD::DataFormat color_format;
-		RD::DataFormat color_format_srgb;
-		Image::Format image_format;
+		RD::DataFormat color_format = RD::DATA_FORMAT_R4G4_UNORM_PACK8;
+		RD::DataFormat color_format_srgb = RD::DATA_FORMAT_R4G4_UNORM_PACK8;
+		Image::Format image_format = Image::FORMAT_L8;
 
 		bool flags[RENDER_TARGET_FLAG_MAX];
 


### PR DESCRIPTION
Fixes #37321

Function _create_window 
https://github.com/godotengine/godot/blob/ff14d071ccfdf25b899ab49312ef639da7c71fd6/platform/linuxbsd/display_server_x11.cpp#L3598
use current_cursor and cursors[] which are declared a little after
https://github.com/godotengine/godot/blob/ff14d071ccfdf25b899ab49312ef639da7c71fd6/platform/linuxbsd/display_server_x11.cpp#L3653-L3659

Second part of PR, fix usage of uninitialized variables showed in Ubsan sanitizers and Valgrind.
I tried to use Clang Memory Sanitizer instead, but it generates 6GB log about uninitialised variables and I didn't even get working Project Manager(it still loading) 