### PR TITLE
Fix input event being dispatched multiple times on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1695,6 +1695,12 @@ void DisplayServerWindows::_dispatch_input_events(const Ref<InputEvent> &p_event
 }
 
 void DisplayServerWindows::_dispatch_input_event(const Ref<InputEvent> &p_event) {
+	_THREAD_SAFE_METHOD_
+	if (in_dispatch_input_event) {
+		return;
+	}
+
+	in_dispatch_input_event = true;
 	Variant ev = p_event;
 	Variant *evp = &ev;
 	Variant ret;
@@ -1706,6 +1712,7 @@ void DisplayServerWindows::_dispatch_input_event(const Ref<InputEvent> &p_event)
 		ERR_FAIL_COND(!windows.has(event_from_window->get_window_id()));
 		Callable callable = windows[event_from_window->get_window_id()].input_event_callback;
 		if (callable.is_null()) {
+			in_dispatch_input_event = false;
 			return;
 		}
 		callable.call((const Variant **)&evp, 1, ret, ce);
@@ -1719,6 +1726,8 @@ void DisplayServerWindows::_dispatch_input_event(const Ref<InputEvent> &p_event)
 			callable.call((const Variant **)&evp, 1, ret, ce);
 		}
 	}
+
+	in_dispatch_input_event = false;
 }
 
 LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -388,6 +388,7 @@ class DisplayServerWindows : public DisplayServer {
 	uint32_t last_button_state = 0;
 	bool use_raw_input = false;
 	bool drop_events = false;
+	bool in_dispatch_input_event = false;
 	bool console_visible = false;
 
 	WNDCLASSEXW wc;


### PR DESCRIPTION
fixes #37425 
fixes #37322  
fixes #37331
fixes #37329
fixes #38781 (as of https://github.com/godotengine/godot/pull/37519#issuecomment-629649872)
implemented comparable to #37339

~~I am a little bit unsure about this patch not only being symptom fixing. According to that [call stack](https://gist.github.com/HaSa1002/ed9106637d1c04ee9964d96e7eda27a4) the recursion occurs at the [window creation](https://gist.github.com/HaSa1002/ed9106637d1c04ee9964d96e7eda27a4#file-call-stack-L8)~~

Edit: Fixed input deadlock