### PR TITLE
Android: Downgrade gradle plugin to 3.5.3

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,5 +1,5 @@
 ext.versions = [
-    androidGradlePlugin: '3.6.0',
+    androidGradlePlugin: '3.5.3',
     compileSdk         : 29,
     minSdk             : 18,
     targetSdk          : 29,


### PR DESCRIPTION
With the NDK installed locally, gradle plugin 3.6.0 seems to enforce
a specific older NDK version, and will fail building if you don't have
it installed with:

```
No version of NDK matched the requested version 20.0.5594570.
Versions available locally: 21.0.6113669
```

Upstream issue: https://github.com/gradle/gradle/issues/12440