### PR TITLE
Update visualscript graph nodes on visual script variable edit

### DIFF
--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -727,6 +727,26 @@ void VisualScript::rename_variable(const StringName &p_name, const StringName &p
 
 	variables[p_new_name] = variables[p_name];
 	variables.erase(p_name);
+
+	List<StringName> funcs;
+	get_function_list(&funcs);
+	for (List<StringName>::Element *F = funcs.front(); F; F = F->next()) { // loop through all the functions
+		List<int> ids;
+		get_node_list(F->get(), &ids);
+		for (List<int>::Element *E = ids.front(); E; E = E->next()) {
+			Ref<VisualScriptVariableGet> nodeget = get_node(F->get(), E->get());
+			if (nodeget.is_valid()) {
+				if (nodeget->get_variable() == p_name)
+					nodeget->set_variable(p_new_name);
+			} else {
+				Ref<VisualScriptVariableSet> nodeset = get_node(F->get(), E->get());
+				if (nodeset.is_valid()) {
+					if (nodeset->get_variable() == p_name)
+						nodeset->set_variable(p_new_name);
+				}
+			}
+		}
+	}
 }
 
 void VisualScript::add_custom_signal(const StringName &p_name) {

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -1155,6 +1155,8 @@ void VisualScriptEditor::_member_edited() {
 		undo_redo->add_undo_method(script.ptr(), "rename_variable", new_name, name);
 		undo_redo->add_do_method(this, "_update_members");
 		undo_redo->add_undo_method(this, "_update_members");
+		undo_redo->add_do_method(this, "_update_graph");
+		undo_redo->add_undo_method(this, "_update_graph");
 		undo_redo->add_do_method(this, "emit_signal", "edited_script_changed");
 		undo_redo->add_undo_method(this, "emit_signal", "edited_script_changed");
 		undo_redo->commit_action();
@@ -3917,7 +3919,9 @@ void VisualScriptEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
 			variable_editor->connect("changed", callable_mp(this, &VisualScriptEditor::_update_members));
+			variable_editor->connect("changed", callable_mp(this, &VisualScriptEditor::_update_graph), varray(-1), CONNECT_DEFERRED);
 			signal_editor->connect("changed", callable_mp(this, &VisualScriptEditor::_update_members));
+			signal_editor->connect("changed", callable_mp(this, &VisualScriptEditor::_update_graph), varray(-1), CONNECT_DEFERRED);
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
@@ -4629,6 +4633,7 @@ void VisualScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_input", &VisualScriptEditor::_input);
 
 	ClassDB::bind_method("_update_graph_connections", &VisualScriptEditor::_update_graph_connections);
+	ClassDB::bind_method("_update_members", &VisualScriptEditor::_update_members);
 
 	ClassDB::bind_method("_generic_search", &VisualScriptEditor::_generic_search);
 }


### PR DESCRIPTION
This maintains consistency of visual script variables with the getter and setter nodes placed in the graphs.
Fixes the issues of members not updating properly as well.