### PR TITLE
Use Math_TAU and deg2rad/etc in more places and optimize code

### DIFF
--- a/core/math/camera_matrix.cpp
+++ b/core/math/camera_matrix.cpp
@@ -80,7 +80,7 @@ void CameraMatrix::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_
 	}
 
 	real_t sine, cotangent, deltaZ;
-	real_t radians = p_fovy_degrees / 2.0 * Math_PI / 180.0;
+	real_t radians = Math::deg2rad(p_fovy_degrees / 2.0);
 
 	deltaZ = p_z_far - p_z_near;
 	sine = Math::sin(radians);
@@ -107,7 +107,7 @@ void CameraMatrix::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_
 
 	real_t left, right, modeltranslation, ymax, xmax, frustumshift;
 
-	ymax = p_z_near * tan(p_fovy_degrees * Math_PI / 360.0f);
+	ymax = p_z_near * tan(Math::deg2rad(p_fovy_degrees / 2.0));
 	xmax = ymax * p_aspect;
 	frustumshift = (p_intraocular_dist / 2.0) * p_z_near / p_convergence_dist;
 

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -777,10 +777,11 @@ Vector<Plane> Geometry3D::build_box_planes(const Vector3 &p_extents) {
 Vector<Plane> Geometry3D::build_cylinder_planes(real_t p_radius, real_t p_height, int p_sides, Vector3::Axis p_axis) {
 	Vector<Plane> planes;
 
+	const double sides_step = Math_TAU / p_sides;
 	for (int i = 0; i < p_sides; i++) {
 		Vector3 normal;
-		normal[(p_axis + 1) % 3] = Math::cos(i * (2.0 * Math_PI) / p_sides);
-		normal[(p_axis + 2) % 3] = Math::sin(i * (2.0 * Math_PI) / p_sides);
+		normal[(p_axis + 1) % 3] = Math::cos(i * sides_step);
+		normal[(p_axis + 2) % 3] = Math::sin(i * sides_step);
 
 		planes.push_back(Plane(normal, p_radius));
 	}
@@ -805,10 +806,11 @@ Vector<Plane> Geometry3D::build_sphere_planes(real_t p_radius, int p_lats, int p
 	axis_neg[(p_axis + 2) % 3] = 1.0;
 	axis_neg[p_axis] = -1.0;
 
+	const double lon_step = Math_TAU / p_lons;
 	for (int i = 0; i < p_lons; i++) {
 		Vector3 normal;
-		normal[(p_axis + 1) % 3] = Math::cos(i * (2.0 * Math_PI) / p_lons);
-		normal[(p_axis + 2) % 3] = Math::sin(i * (2.0 * Math_PI) / p_lons);
+		normal[(p_axis + 1) % 3] = Math::cos(i * lon_step);
+		normal[(p_axis + 2) % 3] = Math::sin(i * lon_step);
 
 		planes.push_back(Plane(normal, p_radius));
 
@@ -835,10 +837,11 @@ Vector<Plane> Geometry3D::build_capsule_planes(real_t p_radius, real_t p_height,
 	axis_neg[(p_axis + 2) % 3] = 1.0;
 	axis_neg[p_axis] = -1.0;
 
+	const double sides_step = Math_TAU / p_sides;
 	for (int i = 0; i < p_sides; i++) {
 		Vector3 normal;
-		normal[(p_axis + 1) % 3] = Math::cos(i * (2.0 * Math_PI) / p_sides);
-		normal[(p_axis + 2) % 3] = Math::sin(i * (2.0 * Math_PI) / p_sides);
+		normal[(p_axis + 1) % 3] = Math::cos(i * sides_step);
+		normal[(p_axis + 2) % 3] = Math::sin(i * sides_step);
 
 		planes.push_back(Plane(normal, p_radius));
 

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -223,11 +223,11 @@ public:
 		return value;
 	}
 
-	static _ALWAYS_INLINE_ double deg2rad(double p_y) { return p_y * Math_PI / 180.0; }
-	static _ALWAYS_INLINE_ float deg2rad(float p_y) { return p_y * Math_PI / 180.0; }
+	static _ALWAYS_INLINE_ double deg2rad(double p_y) { return p_y * (Math_PI / 180.0); }
+	static _ALWAYS_INLINE_ float deg2rad(float p_y) { return p_y * (Math_PI / 180.0); }
 
-	static _ALWAYS_INLINE_ double rad2deg(double p_y) { return p_y * 180.0 / Math_PI; }
-	static _ALWAYS_INLINE_ float rad2deg(float p_y) { return p_y * 180.0 / Math_PI; }
+	static _ALWAYS_INLINE_ double rad2deg(double p_y) { return p_y * (180.0 / Math_PI); }
+	static _ALWAYS_INLINE_ float rad2deg(float p_y) { return p_y * (180.0 / Math_PI); }
 
 	static _ALWAYS_INLINE_ double lerp(double p_from, double p_to, double p_weight) { return p_from + (p_to - p_from) * p_weight; }
 	static _ALWAYS_INLINE_ float lerp(float p_from, float p_to, float p_weight) { return p_from + (p_to - p_from) * p_weight; }

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -844,7 +844,7 @@ static float _find_closest_angle_to_half_pi_arc(const Vector3 &p_from, const Vec
 
 	//min_p = p_arc_xform.affine_inverse().xform(min_p);
 	float a = (Math_PI * 0.5) - Vector2(min_p.x, -min_p.z).angle();
-	return a * 180.0 / Math_PI;
+	return Math::rad2deg(a);
 }
 
 void Light3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int p_idx, Camera3D *p_camera, const Point2 &p_point) {
@@ -1033,12 +1033,9 @@ void Light3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		p_gizmo->add_lines(points_primary, material_primary, false, color);
 		p_gizmo->add_lines(points_secondary, material_secondary, false, color);
 
-		const float ra = 16 * Math_PI * 2.0 / 64.0;
-		const Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * w;
-
 		Vector<Vector3> handles;
 		handles.push_back(Vector3(0, 0, -r));
-		handles.push_back(Vector3(a.x, a.y, -d));
+		handles.push_back(Vector3(w, 0, -d));
 
 		p_gizmo->add_handles(handles, get_material("handles"));
 		p_gizmo->add_unscaled_billboard(icon, 0.05, color);
@@ -1095,8 +1092,8 @@ void AudioStreamPlayer3DGizmoPlugin::set_handle(EditorNode3DGizmo *p_gizmo, int 
 	float closest_angle = 1e20;
 
 	for (int i = 0; i < 180; i++) {
-		float a = i * Math_PI / 180.0;
-		float an = (i + 1) * Math_PI / 180.0;
+		float a = Math::deg2rad((float)i);
+		float an = Math::deg2rad((float)(i + 1));
 
 		Vector3 from(Math::sin(a), 0, -Math::cos(a));
 		Vector3 to(Math::sin(an), 0, -Math::cos(an));
@@ -1145,9 +1142,10 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Vector<Vector3> points_primary;
 		points_primary.resize(200);
 
+		real_t step = Math_TAU / 100.0;
 		for (int i = 0; i < 100; i++) {
-			const float a = i * 2.0 * Math_PI / 100.0;
-			const float an = (i + 1) * 2.0 * Math_PI / 100.0;
+			const float a = i * step;
+			const float an = (i + 1) * step;
 
 			const Vector3 from(Math::sin(a) * radius, Math::cos(a) * radius, ofs);
 			const Vector3 to(Math::sin(an) * radius, Math::cos(an) * radius, ofs);
@@ -1163,7 +1161,7 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		points_secondary.resize(16);
 
 		for (int i = 0; i < 8; i++) {
-			const float a = i * 2.0 * Math_PI / 8.0;
+			const float a = i * (Math_TAU / 8.0);
 			const Vector3 from(Math::sin(a) * radius, Math::cos(a) * radius, ofs);
 
 			points_secondary.write[i * 2 + 0] = from;
@@ -2616,8 +2614,8 @@ void GPUParticlesCollision3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Vector<Vector3> collision_segments;
 
 		for (int i = 0; i < 64; i++) {
-			float ra = i * Math_PI * 2.0 / 64.0;
-			float rb = (i + 1) * Math_PI * 2.0 / 64.0;
+			float ra = i * (Math_TAU / 64.0);
+			float rb = (i + 1) * (Math_TAU / 64.0);
 			Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * r;
 			Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * r;
 
@@ -3317,7 +3315,7 @@ void BakedLightmapGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	int stack_count = 8;
 	int sector_count = 16;
 
-	float sector_step = 2 * Math_PI / sector_count;
+	float sector_step = (Math_PI * 2.0) / sector_count;
 	float stack_step = Math_PI / stack_count;
 
 	Vector<Vector3> vertices;
@@ -3454,7 +3452,7 @@ void LightmapProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	int stack_count = 8;
 	int sector_count = 16;
 
-	float sector_step = 2 * Math_PI / sector_count;
+	float sector_step = (Math_PI * 2.0) / sector_count;
 	float stack_step = Math_PI / stack_count;
 
 	Vector<Vector3> vertices;
@@ -3854,8 +3852,8 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Vector<Vector3> collision_segments;
 
 		for (int i = 0; i < 64; i++) {
-			float ra = i * Math_PI * 2.0 / 64.0;
-			float rb = (i + 1) * Math_PI * 2.0 / 64.0;
+			float ra = i * (Math_TAU / 64.0);
+			float rb = (i + 1) * (Math_TAU / 64.0);
 			Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * r;
 			Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * r;
 
@@ -3939,8 +3937,8 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Vector<Vector3> collision_segments;
 
 		for (int i = 0; i < 64; i++) {
-			float ra = i * Math_PI * 2.0 / 64.0;
-			float rb = (i + 1) * Math_PI * 2.0 / 64.0;
+			float ra = i * (Math_TAU / 64.0);
+			float rb = (i + 1) * (Math_TAU / 64.0);
 			Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * radius;
 			Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * radius;
 
@@ -4002,8 +4000,8 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Vector<Vector3> collision_segments;
 
 		for (int i = 0; i < 64; i++) {
-			float ra = i * Math_PI * 2.0 / 64.0;
-			float rb = (i + 1) * Math_PI * 2.0 / 64.0;
+			float ra = i * (Math_TAU / 64.0);
+			float rb = (i + 1) * (Math_TAU / 64.0);
 			Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * radius;
 			Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * radius;
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -216,8 +216,8 @@ public:
 		grid_step_x->set_value(p_grid_step.x);
 		grid_step_y->set_value(p_grid_step.y);
 		primary_grid_steps->set_value(p_primary_grid_steps);
-		rotation_offset->set_value(p_rotation_offset * (180 / Math_PI));
-		rotation_step->set_value(p_rotation_step * (180 / Math_PI));
+		rotation_offset->set_value(Math::rad2deg(p_rotation_offset));
+		rotation_step->set_value(Math::rad2deg(p_rotation_step));
 		scale_step->set_value(p_scale_step);
 	}
 
@@ -225,8 +225,8 @@ public:
 		p_grid_offset = Point2(grid_offset_x->get_value(), grid_offset_y->get_value());
 		p_grid_step = Point2(grid_step_x->get_value(), grid_step_y->get_value());
 		p_primary_grid_steps = int(primary_grid_steps->get_value());
-		p_rotation_offset = rotation_offset->get_value() / (180 / Math_PI);
-		p_rotation_step = rotation_step->get_value() / (180 / Math_PI);
+		p_rotation_offset = Math::deg2rad(rotation_offset->get_value());
+		p_rotation_step = Math::deg2rad(rotation_step->get_value());
 		p_scale_step = scale_step->get_value();
 	}
 };
@@ -5638,7 +5638,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	primary_grid_steps = 8; // A power-of-two value works better as a default
 	grid_step_multiplier = 0;
 	snap_rotation_offset = 0;
-	snap_rotation_step = 15 / (180 / Math_PI);
+	snap_rotation_step = Math::deg2rad(15.0);
 	snap_scale_step = 0.1f;
 	smart_snap_active = false;
 	grid_snap_active = false;

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -382,7 +382,9 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 
 	int lats = 32;
 	int lons = 32;
-	float radius = 1.0;
+	const double lat_step = Math_TAU / lats;
+	const double lon_step = Math_TAU / lons;
+	real_t radius = 1.0;
 
 	Vector<Vector3> vertices;
 	Vector<Vector3> normals;
@@ -391,20 +393,20 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 	Basis tt = Basis(Vector3(0, 1, 0), Math_PI * 0.5);
 
 	for (int i = 1; i <= lats; i++) {
-		double lat0 = Math_PI * (-0.5 + (double)(i - 1) / lats);
+		double lat0 = lat_step * (i - 1) - Math_TAU / 4;
 		double z0 = Math::sin(lat0);
 		double zr0 = Math::cos(lat0);
 
-		double lat1 = Math_PI * (-0.5 + (double)i / lats);
+		double lat1 = lat_step * i - Math_TAU / 4;
 		double z1 = Math::sin(lat1);
 		double zr1 = Math::cos(lat1);
 
 		for (int j = lons; j >= 1; j--) {
-			double lng0 = 2 * Math_PI * (double)(j - 1) / lons;
+			double lng0 = lon_step * (j - 1);
 			double x0 = Math::cos(lng0);
 			double y0 = Math::sin(lng0);
 
-			double lng1 = 2 * Math_PI * (double)(j) / lons;
+			double lng1 = lon_step * j;
 			double x1 = Math::cos(lng1);
 			double y1 = Math::sin(lng1);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5314,9 +5314,10 @@ void Node3DEditor::_init_indicators() {
 
 				int arrow_sides = 16;
 
+				const real_t arrow_sides_step = Math_TAU / arrow_sides;
 				for (int k = 0; k < arrow_sides; k++) {
-					Basis ma(ivec, Math_PI * 2 * float(k) / arrow_sides);
-					Basis mb(ivec, Math_PI * 2 * float(k + 1) / arrow_sides);
+					Basis ma(ivec, k * arrow_sides_step);
+					Basis mb(ivec, (k + 1) * arrow_sides_step);
 
 					for (int j = 0; j < arrow_points - 1; j++) {
 						Vector3 points[4] = {
@@ -5391,13 +5392,14 @@ void Node3DEditor::_init_indicators() {
 				int n = 128; // number of circle segments
 				int m = 6; // number of thickness segments
 
+				real_t step = Math_TAU / n;
 				for (int j = 0; j < n; ++j) {
-					Basis basis = Basis(ivec, (Math_PI * 2.0f * j) / n);
+					Basis basis = Basis(ivec, j * step);
 
 					Vector3 vertex = basis.xform(ivec2 * GIZMO_CIRCLE_SIZE);
 
 					for (int k = 0; k < m; ++k) {
-						Vector2 ofs = Vector2(Math::cos((Math_PI * 2.0 * k) / m), Math::sin((Math_PI * 2.0 * k) / m));
+						Vector2 ofs = Vector2(Math::cos((Math_TAU * k) / m), Math::sin((Math_TAU * k) / m));
 						Vector3 normal = ivec * ofs.x + ivec2 * ofs.y;
 
 						surftool->set_normal(basis.xform(normal));
@@ -5524,9 +5526,10 @@ void Node3DEditor::_init_indicators() {
 
 				int arrow_sides = 4;
 
+				const real_t arrow_sides_step = Math_TAU / arrow_sides;
 				for (int k = 0; k < 4; k++) {
-					Basis ma(ivec, Math_PI * 2 * float(k) / arrow_sides);
-					Basis mb(ivec, Math_PI * 2 * float(k + 1) / arrow_sides);
+					Basis ma(ivec, k * arrow_sides_step);
+					Basis mb(ivec, (k + 1) * arrow_sides_step);
 
 					for (int j = 0; j < arrow_points - 1; j++) {
 						Vector3 points[4] = {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -927,25 +927,27 @@ CSGBrush *CSGSphere3D::_build_brush() {
 		bool *invertw = invert.ptrw();
 
 		int face = 0;
+		const double lat_step = Math_TAU / rings;
+		const double lon_step = Math_TAU / radial_segments;
 
 		for (int i = 1; i <= rings; i++) {
-			double lat0 = Math_PI * (-0.5 + (double)(i - 1) / rings);
+			double lat0 = lat_step * (i - 1) - Math_TAU / 4;
 			double z0 = Math::sin(lat0);
 			double zr0 = Math::cos(lat0);
 			double u0 = double(i - 1) / rings;
 
-			double lat1 = Math_PI * (-0.5 + (double)i / rings);
+			double lat1 = lat_step * i - Math_TAU / 4;
 			double z1 = Math::sin(lat1);
 			double zr1 = Math::cos(lat1);
 			double u1 = double(i) / rings;
 
 			for (int j = radial_segments; j >= 1; j--) {
-				double lng0 = 2 * Math_PI * (double)(j - 1) / radial_segments;
+				double lng0 = lon_step * (j - 1);
 				double x0 = Math::cos(lng0);
 				double y0 = Math::sin(lng0);
 				double v0 = double(i - 1) / radial_segments;
 
-				double lng1 = 2 * Math_PI * (double)(j) / radial_segments;
+				double lng1 = lon_step * j;
 				double x1 = Math::cos(lng1);
 				double y1 = Math::sin(lng1);
 				double v1 = double(i) / radial_segments;
@@ -1266,8 +1268,8 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 				float inc = float(i) / sides;
 				float inc_n = float((i + 1)) / sides;
 
-				float ang = inc * Math_PI * 2.0;
-				float ang_n = inc_n * Math_PI * 2.0;
+				float ang = inc * Math_TAU;
+				float ang_n = inc_n * Math_TAU;
 
 				Vector3 base(Math::cos(ang), 0, Math::sin(ang));
 				Vector3 base_n(Math::cos(ang_n), 0, Math::sin(ang_n));
@@ -1508,8 +1510,8 @@ CSGBrush *CSGTorus3D::_build_brush() {
 				float inci = float(i) / sides;
 				float inci_n = float((i + 1)) / sides;
 
-				float angi = inci * Math_PI * 2.0;
-				float angi_n = inci_n * Math_PI * 2.0;
+				float angi = inci * Math_TAU;
+				float angi_n = inci_n * Math_TAU;
 
 				Vector3 normali = Vector3(Math::cos(angi), 0, Math::sin(angi));
 				Vector3 normali_n = Vector3(Math::cos(angi_n), 0, Math::sin(angi_n));
@@ -1518,8 +1520,8 @@ CSGBrush *CSGTorus3D::_build_brush() {
 					float incj = float(j) / ring_sides;
 					float incj_n = float((j + 1)) / ring_sides;
 
-					float angj = incj * Math_PI * 2.0;
-					float angj_n = incj_n * Math_PI * 2.0;
+					float angj = incj * Math_TAU;
+					float angj_n = incj_n * Math_TAU;
 
 					Vector2 normalj = Vector2(Math::cos(angj), Math::sin(angj)) * radius + Vector2(min_radius + radius, 0);
 					Vector2 normalj_n = Vector2(Math::cos(angj_n), Math::sin(angj_n)) * radius + Vector2(min_radius + radius, 0);
@@ -1891,8 +1893,8 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 					float inci = float(i) / spin_sides;
 					float inci_n = float((i + 1)) / spin_sides;
 
-					float angi = -(inci * spin_degrees / 360.0) * Math_PI * 2.0;
-					float angi_n = -(inci_n * spin_degrees / 360.0) * Math_PI * 2.0;
+					float angi = -Math::deg2rad(inci * spin_degrees);
+					float angi_n = -Math::deg2rad(inci_n * spin_degrees);
 
 					Vector3 normali = Vector3(Math::cos(angi), 0, Math::sin(angi));
 					Vector3 normali_n = Vector3(Math::cos(angi_n), 0, Math::sin(angi_n));

--- a/modules/opensimplex/open_simplex_noise.cpp
+++ b/modules/opensimplex/open_simplex_noise.cpp
@@ -131,10 +131,10 @@ Ref<Image> OpenSimplexNoise::get_seamless_image(int p_size) const {
 			float ii = (float)i / (float)p_size;
 			float jj = (float)j / (float)p_size;
 
-			ii *= 2.0 * Math_PI;
-			jj *= 2.0 * Math_PI;
+			ii *= Math_TAU;
+			jj *= Math_TAU;
 
-			float radius = p_size / (2.0 * Math_PI);
+			float radius = p_size / Math_TAU;
 
 			float x = radius * Math::sin(jj);
 			float y = radius * Math::cos(jj);

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -700,7 +700,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			p.hue_rot_rand = Math::randf();
 			p.anim_offset_rand = Math::randf();
 
-			float angle1_rad = Math::atan2(direction.y, direction.x) + (Math::randf() * 2.0 - 1.0) * Math_PI * spread / 180.0;
+			float angle1_rad = Math::atan2(direction.y, direction.x) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
 			Vector2 rot = Vector2(Math::cos(angle1_rad), Math::sin(angle1_rad));
 			p.velocity = rot * parameters[PARAM_INITIAL_LINEAR_VELOCITY] * Math::lerp(1.0f, float(Math::randf()), randomness[PARAM_INITIAL_LINEAR_VELOCITY]);
 
@@ -721,7 +721,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 					//do none
 				} break;
 				case EMISSION_SHAPE_SPHERE: {
-					float s = Math::randf(), t = 2.0 * Math_PI * Math::randf();
+					float s = Math::randf(), t = Math_TAU * Math::randf();
 					float radius = emission_sphere_radius * Math::sqrt(1.0 - s * s);
 					p.transform[2] = Vector2(Math::cos(t), Math::sin(t)) * radius;
 				} break;
@@ -837,7 +837,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			//orbit velocity
 			float orbit_amount = (parameters[PARAM_ORBIT_VELOCITY] + tex_orbit_velocity) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_ORBIT_VELOCITY]);
 			if (orbit_amount != 0.0) {
-				float ang = orbit_amount * local_delta * Math_PI * 2.0;
+				float ang = orbit_amount * local_delta * Math_TAU;
 				// Not sure why the ParticlesMaterial code uses a clockwise rotation matrix,
 				// but we use -ang here to reproduce its behavior.
 				Transform2D rot = Transform2D(-ang, Vector2());
@@ -877,7 +877,7 @@ void CPUParticles2D::_particles_process(float p_delta) {
 			tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->interpolate(p.custom[1]);
 		}
 
-		float hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_PI * 2.0 * Math::lerp(1.0f, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
+		float hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_TAU * Math::lerp(1.0f, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
 		float hue_rot_c = Math::cos(hue_rot_angle);
 		float hue_rot_s = Math::sin(hue_rot_angle);
 

--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -554,7 +554,7 @@ void LineBuilder::new_arc(Vector2 center, Vector2 vbegin, float angle_delta, Col
 	float t = Vector2(1, 0).angle_to(vbegin);
 	float end_angle = t + angle_delta;
 	Vector2 rpos(0, 0);
-	float tt_begin = -Math_PI / 2.f;
+	float tt_begin = -Math_PI / 2.0f;
 	float tt = tt_begin;
 
 	// Center vertice

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -676,13 +676,13 @@ void CPUParticles3D::_particles_process(float p_delta) {
 			p.anim_offset_rand = Math::randf();
 
 			if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-				float angle1_rad = Math::atan2(direction.y, direction.x) + (Math::randf() * 2.0 - 1.0) * Math_PI * spread / 180.0;
+				float angle1_rad = Math::atan2(direction.y, direction.x) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
 				Vector3 rot = Vector3(Math::cos(angle1_rad), Math::sin(angle1_rad), 0.0);
 				p.velocity = rot * parameters[PARAM_INITIAL_LINEAR_VELOCITY] * Math::lerp(1.0f, float(Math::randf()), randomness[PARAM_INITIAL_LINEAR_VELOCITY]);
 			} else {
 				//initiate velocity spread in 3D
-				float angle1_rad = Math::atan2(direction.x, direction.z) + (Math::randf() * 2.0 - 1.0) * Math_PI * spread / 180.0;
-				float angle2_rad = Math::atan2(direction.y, Math::abs(direction.z)) + (Math::randf() * 2.0 - 1.0) * (1.0 - flatness) * Math_PI * spread / 180.0;
+				float angle1_rad = Math::atan2(direction.x, direction.z) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
+				float angle2_rad = Math::atan2(direction.y, Math::abs(direction.z)) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * (1.0 - flatness) * spread);
 
 				Vector3 direction_xz = Vector3(Math::sin(angle1_rad), 0, Math::cos(angle1_rad));
 				Vector3 direction_yz = Vector3(0, Math::sin(angle2_rad), Math::cos(angle2_rad));
@@ -706,8 +706,9 @@ void CPUParticles3D::_particles_process(float p_delta) {
 					//do none
 				} break;
 				case EMISSION_SHAPE_SPHERE: {
-					float s = 2.0 * Math::randf() - 1.0, t = 2.0 * Math_PI * Math::randf();
-					float radius = emission_sphere_radius * Math::sqrt(1.0 - s * s);
+					real_t s = 2.0 * Math::randf() - 1.0;
+					real_t t = Math_TAU * Math::randf();
+					real_t radius = emission_sphere_radius * Math::sqrt(1.0 - s * s);
 					p.transform.origin = Vector3(radius * Math::cos(t), radius * Math::sin(t), emission_sphere_radius * s);
 				} break;
 				case EMISSION_SHAPE_BOX: {
@@ -855,7 +856,7 @@ void CPUParticles3D::_particles_process(float p_delta) {
 			if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 				float orbit_amount = (parameters[PARAM_ORBIT_VELOCITY] + tex_orbit_velocity) * Math::lerp(1.0f, rand_from_seed(alt_seed), randomness[PARAM_ORBIT_VELOCITY]);
 				if (orbit_amount != 0.0) {
-					float ang = orbit_amount * local_delta * Math_PI * 2.0;
+					float ang = orbit_amount * local_delta * Math_TAU;
 					// Not sure why the ParticlesMaterial code uses a clockwise rotation matrix,
 					// but we use -ang here to reproduce its behavior.
 					Transform2D rot = Transform2D(-ang, Vector2());
@@ -895,7 +896,7 @@ void CPUParticles3D::_particles_process(float p_delta) {
 			tex_hue_variation = curve_parameters[PARAM_HUE_VARIATION]->interpolate(p.custom[1]);
 		}
 
-		float hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_PI * 2.0 * Math::lerp(1.0f, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
+		float hue_rot_angle = (parameters[PARAM_HUE_VARIATION] + tex_hue_variation) * Math_TAU * Math::lerp(1.0f, p.hue_rot_rand * 2.0f - 1.0f, randomness[PARAM_HUE_VARIATION]);
 		float hue_rot_c = Math::cos(hue_rot_angle);
 		float hue_rot_s = Math::sin(hue_rot_angle);
 

--- a/scene/3d/immediate_geometry_3d.cpp
+++ b/scene/3d/immediate_geometry_3d.cpp
@@ -87,21 +87,24 @@ Vector<Face3> ImmediateGeometry3D::get_faces(uint32_t p_usage_flags) const {
 }
 
 void ImmediateGeometry3D::add_sphere(int p_lats, int p_lons, float p_radius, bool p_add_uv) {
+	const double lat_step = Math_TAU / p_lats;
+	const double lon_step = Math_TAU / p_lons;
+
 	for (int i = 1; i <= p_lats; i++) {
-		double lat0 = Math_PI * (-0.5 + (double)(i - 1) / p_lats);
+		double lat0 = lat_step * (i - 1) - Math_TAU / 4;
 		double z0 = Math::sin(lat0);
 		double zr0 = Math::cos(lat0);
 
-		double lat1 = Math_PI * (-0.5 + (double)i / p_lats);
+		double lat1 = lat_step * i - Math_TAU / 4;
 		double z1 = Math::sin(lat1);
 		double zr1 = Math::cos(lat1);
 
 		for (int j = p_lons; j >= 1; j--) {
-			double lng0 = 2 * Math_PI * (double)(j - 1) / p_lons;
+			double lng0 = lon_step * (j - 1);
 			double x0 = Math::cos(lng0);
 			double y0 = Math::sin(lng0);
 
-			double lng1 = 2 * Math_PI * (double)(j) / p_lons;
+			double lng1 = lon_step * j;
 			double x1 = Math::cos(lng1);
 			double y1 = Math::sin(lng1);
 

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -330,7 +330,7 @@ void Node3D::set_rotation(const Vector3 &p_euler_rad) {
 }
 
 void Node3D::set_rotation_degrees(const Vector3 &p_euler_deg) {
-	set_rotation(p_euler_deg * Math_PI / 180.0);
+	set_rotation(p_euler_deg * (Math_PI / 180.0));
 }
 
 void Node3D::set_scale(const Vector3 &p_scale) {
@@ -364,7 +364,7 @@ Vector3 Node3D::get_rotation() const {
 }
 
 Vector3 Node3D::get_rotation_degrees() const {
-	return get_rotation() * 180.0 / Math_PI;
+	return get_rotation() * (180.0 / Math_PI);
 }
 
 Vector3 Node3D::get_scale() const {

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -2381,11 +2381,11 @@ Vector3 PhysicalBone3D::get_joint_rotation() const {
 }
 
 void PhysicalBone3D::set_joint_rotation_degrees(const Vector3 &p_euler_deg) {
-	set_joint_rotation(p_euler_deg * Math_PI / 180.0);
+	set_joint_rotation(p_euler_deg * (Math_PI / 180.0));
 }
 
 Vector3 PhysicalBone3D::get_joint_rotation_degrees() const {
-	return get_joint_rotation() * 180.0 / Math_PI;
+	return get_joint_rotation() * (180.0 / Math_PI);
 }
 
 const Transform &PhysicalBone3D::get_body_offset() const {

--- a/scene/resources/capsule_shape_2d.cpp
+++ b/scene/resources/capsule_shape_2d.cpp
@@ -36,12 +36,13 @@
 
 Vector<Vector2> CapsuleShape2D::_get_points() const {
 	Vector<Vector2> points;
+	const real_t turn_step = Math_TAU / 24.0;
 	for (int i = 0; i < 24; i++) {
 		Vector2 ofs = Vector2(0, (i > 6 && i <= 18) ? -get_height() * 0.5 : get_height() * 0.5);
 
-		points.push_back(Vector2(Math::sin(i * Math_PI * 2 / 24.0), Math::cos(i * Math_PI * 2 / 24.0)) * get_radius() + ofs);
+		points.push_back(Vector2(Math::sin(i * turn_step), Math::cos(i * turn_step)) * get_radius() + ofs);
 		if (i == 6 || i == 18) {
-			points.push_back(Vector2(Math::sin(i * Math_PI * 2 / 24.0), Math::cos(i * Math_PI * 2 / 24.0)) * get_radius() - ofs);
+			points.push_back(Vector2(Math::sin(i * turn_step), Math::cos(i * turn_step)) * get_radius() - ofs);
 		}
 	}
 

--- a/scene/resources/circle_shape_2d.cpp
+++ b/scene/resources/circle_shape_2d.cpp
@@ -71,8 +71,9 @@ real_t CircleShape2D::get_enclosing_radius() const {
 
 void CircleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Vector2> points;
+	const real_t turn_step = Math_TAU / 24.0;
 	for (int i = 0; i < 24; i++) {
-		points.push_back(Vector2(Math::cos(i * Math_PI * 2 / 24.0), Math::sin(i * Math_PI * 2 / 24.0)) * get_radius());
+		points.push_back(Vector2(Math::cos(i * turn_step), Math::sin(i * turn_step)) * get_radius());
 	}
 
 	Vector<Color> col;

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -304,8 +304,8 @@ void CapsuleMesh::_create_mesh_array(Array &p_arr) const {
 			u = i;
 			u /= radial_segments;
 
-			x = -sin(u * (Math_PI * 2.0));
-			z = cos(u * (Math_PI * 2.0));
+			x = -sin(u * Math_TAU);
+			z = cos(u * Math_TAU);
 
 			Vector3 p = Vector3(x * radius * w, y, -z * radius * w);
 			points.push_back(p + Vector3(0.0, 0.5 * mid_height, 0.0));
@@ -343,8 +343,8 @@ void CapsuleMesh::_create_mesh_array(Array &p_arr) const {
 			u = i;
 			u /= radial_segments;
 
-			x = -sin(u * (Math_PI * 2.0));
-			z = cos(u * (Math_PI * 2.0));
+			x = -sin(u * Math_TAU);
+			z = cos(u * Math_TAU);
 
 			Vector3 p = Vector3(x * radius, y, -z * radius);
 			points.push_back(p);
@@ -383,8 +383,8 @@ void CapsuleMesh::_create_mesh_array(Array &p_arr) const {
 			float u2 = i;
 			u2 /= radial_segments;
 
-			x = -sin(u2 * (Math_PI * 2.0));
-			z = cos(u2 * (Math_PI * 2.0));
+			x = -sin(u2 * Math_TAU);
+			z = cos(u2 * Math_TAU);
 
 			Vector3 p = Vector3(x * radius * w, y, -z * radius * w);
 			points.push_back(p + Vector3(0.0, -0.5 * mid_height, 0.0));
@@ -769,8 +769,8 @@ void CylinderMesh::_create_mesh_array(Array &p_arr) const {
 			u = i;
 			u /= radial_segments;
 
-			x = sin(u * (Math_PI * 2.0));
-			z = cos(u * (Math_PI * 2.0));
+			x = sin(u * Math_TAU);
+			z = cos(u * Math_TAU);
 
 			Vector3 p = Vector3(x * radius, y, z * radius);
 			points.push_back(p);
@@ -809,8 +809,8 @@ void CylinderMesh::_create_mesh_array(Array &p_arr) const {
 			float r = i;
 			r /= radial_segments;
 
-			x = sin(r * (Math_PI * 2.0));
-			z = cos(r * (Math_PI * 2.0));
+			x = sin(r * Math_TAU);
+			z = cos(r * Math_TAU);
 
 			u = ((x + 1.0) * 0.25);
 			v = 0.5 + ((z + 1.0) * 0.25);
@@ -845,8 +845,8 @@ void CylinderMesh::_create_mesh_array(Array &p_arr) const {
 			float r = i;
 			r /= radial_segments;
 
-			x = sin(r * (Math_PI * 2.0));
-			z = cos(r * (Math_PI * 2.0));
+			x = sin(r * Math_TAU);
+			z = cos(r * Math_TAU);
 
 			u = 0.5 + ((x + 1.0) * 0.25);
 			v = 1.0 - ((z + 1.0) * 0.25);
@@ -1458,8 +1458,8 @@ void SphereMesh::_create_mesh_array(Array &p_arr) const {
 			float u = i;
 			u /= radial_segments;
 
-			x = sin(u * (Math_PI * 2.0));
-			z = cos(u * (Math_PI * 2.0));
+			x = sin(u * Math_TAU);
+			z = cos(u * Math_TAU);
 
 			if (is_hemisphere && y < 0.0) {
 				points.push_back(Vector3(x * radius * w, 0.0, z * radius * w));

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -576,8 +576,8 @@ inline void draw_ring(Vector<Vector2> &verts, Vector<int> &indices, Vector<Color
 					color = outer_color;
 					corner_point = outer_points[corner_index];
 				}
-				float x = radius * (float)cos((double)corner_index * Math_PI / 2.0 + (double)detail / (double)adapted_corner_detail * Math_PI / 2.0 + Math_PI) + corner_point.x;
-				float y = radius * (float)sin((double)corner_index * Math_PI / 2.0 + (double)detail / (double)adapted_corner_detail * Math_PI / 2.0 + Math_PI) + corner_point.y;
+				real_t x = radius * (real_t)cos((corner_index + detail / (double)adapted_corner_detail) * (Math_TAU / 4.0) + Math_PI) + corner_point.x;
+				real_t y = radius * (real_t)sin((corner_index + detail / (double)adapted_corner_detail) * (Math_TAU / 4.0) + Math_PI) + corner_point.y;
 				verts.push_back(Vector2(x, y));
 				colors.push_back(color);
 			}

--- a/servers/audio/audio_filter_sw.cpp
+++ b/servers/audio/audio_filter_sw.cpp
@@ -58,7 +58,7 @@ void AudioFilterSW::prepare_coefficients(Coeffs *p_coeffs) {
 		final_cutoff = 1; //don't allow less than this
 	}
 
-	double omega = 2.0 * Math_PI * final_cutoff / sampling_rate;
+	double omega = Math_TAU * final_cutoff / sampling_rate;
 
 	double sin_v = Math::sin(omega);
 	double cos_v = Math::cos(omega);
@@ -132,7 +132,7 @@ void AudioFilterSW::prepare_coefficients(Coeffs *p_coeffs) {
 			double hicutoff = resonance;
 			double centercutoff = (cutoff + resonance) / 2.0;
 			double bandwidth = (Math::log(centercutoff) - Math::log(hicutoff)) / Math::log((double)2);
-			omega = 2.0 * Math_PI * centercutoff / sampling_rate;
+			omega = Math_TAU * centercutoff / sampling_rate;
 			alpha = Math::sin(omega) * Math::sinh(Math::log((double)2) / 2 * bandwidth * omega / Math::sin(omega));
 			a0 = 1 + alpha;
 
@@ -197,7 +197,7 @@ void AudioFilterSW::set_stages(int p_stages) { //adjust for multiple stages
 /* Fouriertransform kernel to obtain response */
 
 float AudioFilterSW::get_response(float p_freq, Coeffs *p_coeffs) {
-	float freq = p_freq / sampling_rate * Math_PI * 2.0f;
+	float freq = p_freq / sampling_rate * Math_TAU;
 
 	float cx = p_coeffs->b0, cy = 0.0;
 

--- a/servers/audio/effects/audio_effect_chorus.cpp
+++ b/servers/audio/effects/audio_effect_chorus.cpp
@@ -84,7 +84,7 @@ void AudioEffectChorusInstance::_process_chunk(const AudioFrame *p_src_frames, A
 		if (v.cutoff == 0) {
 			continue;
 		}
-		float auxlp = expf(-2.0 * Math_PI * v.cutoff / mix_rate);
+		float auxlp = expf(-Math_TAU * v.cutoff / mix_rate);
 		float c1 = 1.0 - auxlp;
 		float c2 = auxlp;
 		AudioFrame h = filter_h[vc];
@@ -104,7 +104,7 @@ void AudioEffectChorusInstance::_process_chunk(const AudioFrame *p_src_frames, A
 
 			float phase = (float)(local_cycles & AudioEffectChorus::CYCLES_MASK) / (float)(1 << AudioEffectChorus::CYCLES_FRAC);
 
-			float wave_delay = sinf(phase * 2.0 * Math_PI) * max_depth_frames;
+			float wave_delay = sinf(phase * Math_TAU) * max_depth_frames;
 
 			int wave_delay_frames = lrint(floor(wave_delay));
 			float wave_delay_frac = wave_delay - (float)wave_delay_frames;

--- a/servers/audio/effects/audio_effect_delay.cpp
+++ b/servers/audio/effects/audio_effect_delay.cpp
@@ -75,7 +75,7 @@ void AudioEffectDelayInstance::_process_chunk(const AudioFrame *p_src_frames, Au
 	tap2_vol.r *= CLAMP(1.0 + base->tap_2_pan, 0, 1);
 
 	// feedback lowpass here
-	float lpf_c = expf(-2.0 * Math_PI * base->feedback_lowpass / mix_rate); // 0 .. 10khz
+	float lpf_c = expf(-Math_TAU * base->feedback_lowpass / mix_rate); // 0 .. 10khz
 	float lpf_ic = 1.0 - lpf_c;
 
 	const AudioFrame *src = p_src_frames;

--- a/servers/audio/effects/audio_effect_distortion.cpp
+++ b/servers/audio/effects/audio_effect_distortion.cpp
@@ -36,8 +36,8 @@ void AudioEffectDistortionInstance::process(const AudioFrame *p_src_frames, Audi
 	const float *src = (const float *)p_src_frames;
 	float *dst = (float *)p_dst_frames;
 
-	//float lpf_c=expf(-2.0*Math_PI*keep_hf_hz.get()/(mix_rate*(float)OVERSAMPLE));
-	float lpf_c = expf(-2.0 * Math_PI * base->keep_hf_hz / (AudioServer::get_singleton()->get_mix_rate()));
+	//float lpf_c=expf(-Math_TAU*keep_hf_hz.get()/(mix_rate*(float)OVERSAMPLE));
+	float lpf_c = expf(-Math_TAU * base->keep_hf_hz / (AudioServer::get_singleton()->get_mix_rate()));
 	float lpf_ic = 1.0 - lpf_c;
 
 	float drive_f = base->drive;

--- a/servers/audio/effects/audio_effect_phaser.cpp
+++ b/servers/audio/effects/audio_effect_phaser.cpp
@@ -38,13 +38,13 @@ void AudioEffectPhaserInstance::process(const AudioFrame *p_src_frames, AudioFra
 	float dmin = base->range_min / (sampling_rate / 2.0);
 	float dmax = base->range_max / (sampling_rate / 2.0);
 
-	float increment = 2.f * Math_PI * (base->rate / sampling_rate);
+	float increment = Math_TAU * (base->rate / sampling_rate);
 
 	for (int i = 0; i < p_frame_count; i++) {
 		phase += increment;
 
-		while (phase >= Math_PI * 2.f) {
-			phase -= Math_PI * 2.f;
+		while (phase >= Math_TAU) {
+			phase -= Math_TAU;
 		}
 
 		float d = dmin + (dmax - dmin) * ((sin(phase) + 1.f) / 2.f);

--- a/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
+++ b/servers/audio/effects/audio_effect_spectrum_analyzer.cpp
@@ -110,10 +110,11 @@ void AudioEffectSpectrumAnalyzerInstance::process(const AudioFrame *p_src_frames
 	while (p_frame_count) {
 		int to_fill = fft_size * 2 - temporal_fft_pos;
 		to_fill = MIN(to_fill, p_frame_count);
+		const double to_fill_step = Math_TAU / (double)fft_size;
 
 		float *fftw = temporal_fft.ptrw();
 		for (int i = 0; i < to_fill; i++) { //left and right buffers
-			float window = -0.5 * Math::cos(2.0 * Math_PI * (double)temporal_fft_pos / (double)fft_size) + 0.5;
+			float window = -0.5 * Math::cos(to_fill_step * (double)temporal_fft_pos) + 0.5;
 			fftw[temporal_fft_pos * 2] = window * p_src_frames->l;
 			fftw[temporal_fft_pos * 2 + 1] = 0;
 			fftw[(temporal_fft_pos + fft_size * 2) * 2] = window * p_src_frames->r;

--- a/servers/audio/effects/eq.cpp
+++ b/servers/audio/effects/eq.cpp
@@ -89,8 +89,8 @@ void EQ::recalculate_band_coefficients() {
 		double frq_l = round(frq / pow(2.0, octave_size / 2.0));
 
 		double side_gain2 = POW2(Math_SQRT12);
-		double th = 2.0 * Math_PI * frq / mix_rate;
-		double th_l = 2.0 * Math_PI * frq_l / mix_rate;
+		double th = Math_TAU * frq / mix_rate;
+		double th_l = Math_TAU * frq_l / mix_rate;
 
 		double c2a = side_gain2 * POW2(cos(th)) - 2.0 * side_gain2 * cos(th_l) * cos(th) + side_gain2 - POW2(sin(th_l));
 

--- a/servers/audio/effects/reverb.cpp
+++ b/servers/audio/effects/reverb.cpp
@@ -91,7 +91,7 @@ void Reverb::process(float *p_src, float *p_dst, int p_frames) {
 	}
 
 	if (params.hpf > 0) {
-		float hpaux = expf(-2.0 * Math_PI * params.hpf * 6000 / params.mix_rate);
+		float hpaux = expf(-Math_TAU * params.hpf * 6000 / params.mix_rate);
 		float hp_a1 = (1.0 + hpaux) / 2.0;
 		float hp_a2 = -(1.0 + hpaux) / 2.0;
 		float hp_b1 = hpaux;
@@ -293,7 +293,7 @@ void Reverb::update_parameters() {
 		float auxdmp = params.damp / 2.0 + 0.5; //only half the range (0.5 .. 1.0  is enough)
 		auxdmp *= auxdmp;
 
-		c.damp = expf(-2.0 * Math_PI * auxdmp * 10000 / params.mix_rate); // 0 .. 10khz
+		c.damp = expf(-Math_TAU * auxdmp * 10000 / params.mix_rate); // 0 .. 10khz
 	}
 }
 

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -1328,7 +1328,7 @@ Space2DSW::Space2DSW() {
 
 	constraint_bias = 0.2;
 	body_linear_velocity_sleep_threshold = GLOBAL_DEF("physics/2d/sleep_threshold_linear", 2.0);
-	body_angular_velocity_sleep_threshold = GLOBAL_DEF("physics/2d/sleep_threshold_angular", (8.0 / 180.0 * Math_PI));
+	body_angular_velocity_sleep_threshold = GLOBAL_DEF("physics/2d/sleep_threshold_angular", Math::deg2rad(8.0));
 	body_time_to_sleep = GLOBAL_DEF("physics/2d/time_before_sleep", 0.5);
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/time_before_sleep", PropertyInfo(Variant::FLOAT, "physics/2d/time_before_sleep", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"));
 

--- a/servers/physics_3d/joints/cone_twist_joint_3d_sw.cpp
+++ b/servers/physics_3d/joints/cone_twist_joint_3d_sw.cpp
@@ -92,9 +92,9 @@ ConeTwistJoint3DSW::ConeTwistJoint3DSW(Body3DSW *rbA, Body3DSW *rbB, const Trans
 	m_rbAFrame = rbAFrame;
 	m_rbBFrame = rbBFrame;
 
-	m_swingSpan1 = Math_PI / 4.0;
-	m_swingSpan2 = Math_PI / 4.0;
-	m_twistSpan = Math_PI * 2;
+	m_swingSpan1 = Math_TAU / 8.0;
+	m_swingSpan2 = Math_TAU / 8.0;
+	m_twistSpan = Math_TAU;
 	m_biasFactor = 0.3f;
 	m_relaxationFactor = 1.0f;
 

--- a/servers/physics_3d/space_3d_sw.cpp
+++ b/servers/physics_3d/space_3d_sw.cpp
@@ -1211,7 +1211,7 @@ Space3DSW::Space3DSW() {
 
 	constraint_bias = 0.01;
 	body_linear_velocity_sleep_threshold = GLOBAL_DEF("physics/3d/sleep_threshold_linear", 0.1);
-	body_angular_velocity_sleep_threshold = GLOBAL_DEF("physics/3d/sleep_threshold_angular", (8.0 / 180.0 * Math_PI));
+	body_angular_velocity_sleep_threshold = GLOBAL_DEF("physics/3d/sleep_threshold_angular", Math::deg2rad(8.0));
 	body_time_to_sleep = GLOBAL_DEF("physics/3d/time_before_sleep", 0.5);
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/time_before_sleep", PropertyInfo(Variant::FLOAT, "physics/3d/time_before_sleep", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"));
 	body_angular_velocity_damp_ratio = 10;

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -721,8 +721,10 @@ void RendererCanvasCull::canvas_item_add_circle(RID p_item, const Point2 &p_pos,
 	static const int circle_points = 64;
 
 	points.resize(circle_points);
+	const real_t circle_point_step = Math_TAU / circle_points;
+
 	for (int i = 0; i < circle_points; i++) {
-		float angle = (i / float(circle_points)) * 2 * Math_PI;
+		float angle = i * circle_point_step;
 		points.write[i].x = Math::cos(angle) * p_radius;
 		points.write[i].y = Math::sin(angle) * p_radius;
 		points.write[i] += p_pos;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1622,7 +1622,7 @@ void RendererCanvasRenderRD::light_update_shadow(RID p_rid, int p_shadow_index, 
 			projection.set_frustum(xmin, xmax, ymin, ymax, nearp, farp);
 		}
 
-		Vector3 cam_target = Basis(Vector3(0, 0, Math_PI * 2 * ((i + 3) / 4.0))).xform(Vector3(0, 1, 0));
+		Vector3 cam_target = Basis(Vector3(0, 0, Math_TAU * ((i + 3) / 4.0))).xform(Vector3(0, 1, 0));
 		projection = projection * CameraMatrix(Transform().looking_at(cam_target, Vector3(0, 0, -1)).affine_inverse());
 
 		ShadowRenderPushConstant push_constant;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -4877,7 +4877,7 @@ void RendererSceneRenderRD::_debug_sdfgi_probes(RID p_render_buffers, RD::DrawLi
 	push_constant.band_power = 4;
 	push_constant.sections_in_band = ((band_points / 2) - 1);
 	push_constant.band_mask = band_points - 2;
-	push_constant.section_arc = (Math_PI * 2.0) / float(push_constant.sections_in_band);
+	push_constant.section_arc = Math_TAU / float(push_constant.sections_in_band);
 	push_constant.y_mult = rb->sdfgi->y_mult;
 
 	uint32_t total_points = push_constant.sections_in_band * band_points;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -242,22 +242,24 @@ RID RenderingServer::_make_test_cube() {
 RID RenderingServer::make_sphere_mesh(int p_lats, int p_lons, float p_radius) {
 	Vector<Vector3> vertices;
 	Vector<Vector3> normals;
+	const double lat_step = Math_TAU / p_lats;
+	const double lon_step = Math_TAU / p_lons;
 
 	for (int i = 1; i <= p_lats; i++) {
-		double lat0 = Math_PI * (-0.5 + (double)(i - 1) / p_lats);
+		double lat0 = lat_step * (i - 1) - Math_TAU / 4;
 		double z0 = Math::sin(lat0);
 		double zr0 = Math::cos(lat0);
 
-		double lat1 = Math_PI * (-0.5 + (double)i / p_lats);
+		double lat1 = lat_step * i - Math_TAU / 4;
 		double z1 = Math::sin(lat1);
 		double zr1 = Math::cos(lat1);
 
 		for (int j = p_lons; j >= 1; j--) {
-			double lng0 = 2 * Math_PI * (double)(j - 1) / p_lons;
+			double lng0 = lon_step * (j - 1);
 			double x0 = Math::cos(lng0);
 			double y0 = Math::sin(lng0);
 
-			double lng1 = 2 * Math_PI * (double)(j) / p_lons;
+			double lng1 = lon_step * j;
 			double x1 = Math::cos(lng1);
 			double y1 = Math::sin(lng1);
 


### PR DESCRIPTION
This PR has many related changes to many parts of the code that work with angles or turns.

Floating-point math is not guaranteed to be associative, so in order for these pieces of code to be optimized, you either need to include parenthesis, calculate things in advance, or use [`-ffast-math`](https://stackoverflow.com/questions/7420665/what-does-gccs-ffast-math-actually-do), or else the compiler can't optimize these. Godot does not use that compile option, so we need to be explicit to have better performance.

* Pre-calculate step sizes in many places where `for` loops are used (Ctrl+F -> `_step`). This will improve performance quite a bit, since the code is executed many times in a row. It also improves readability in my opinion, since the old code had very complex lines.

* Add parenthesis to `Math::deg2rad` and `Math::rad2deg` around the constants. This allows the compiler to optimize this to a single multiplication (it can't do this automatically unless we use `-ffast-math`).

* Use `Math::deg2rad` and `Math::rad2deg` where applicable instead of `* Math_PI / 180` etc. This should reduce code duplication, improve readability, and improve performance (just adding parenthesis would improve the performance, but using the method improves readability at the same time).

* Replace many occurrences of `Math_PI` multiplied by 2 with `Math_TAU`. This improves readability (including by avoiding parenthesis).

* Optimize some very ugly code in `editor/node_3d_editor_gizmos.cpp` at line 1074.

* Group constant calculations together. This improves performance and readability.

* Remove some unnecessary casts.