### PR TITLE
Add the missing argument in files_dropped signal

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -909,7 +909,7 @@ void Window::_window_input_text(const String &p_text) {
 	input_text(p_text);
 }
 void Window::_window_drop_files(const Vector<String> &p_files) {
-	emit_signal("files_dropped", p_files);
+	emit_signal("files_dropped", p_files, current_screen);
 }
 
 Viewport *Window::get_parent_viewport() const {


### PR DESCRIPTION
The `files_dropped` signal seems to have a second argument for current screen, but it wasn't passed in the `emit_signal` call in Window. I noticed it when Project Manager failed to import dropped project.