### PR TITLE
Removed duplicated add_child

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1362,7 +1362,6 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	name_edit = memnew(LineEdit);
 	name_edit_popup->add_child(name_edit);
 	name_edit->set_anchors_and_margins_preset(PRESET_WIDE);
-	name_edit_popup->add_child(name_edit);
 	name_edit->connect("text_entered", callable_mp(this, &AnimationNodeStateMachineEditor::_name_edited));
 	name_edit->connect("focus_exited", callable_mp(this, &AnimationNodeStateMachineEditor::_name_edited_focus_out));
 


### PR DESCRIPTION
Fixed error when opening editor
```
ERROR: Can't add child '@@10594' to '@@10589', already has a parent '@@10589'.
   at: add_child (scene/main/node.cpp:1254)
```