### PR TITLE
Added missing modal_closed signal

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1015,6 +1015,7 @@ void ColorPickerButton::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("color_changed", PropertyInfo(Variant::COLOR, "color")));
 	ADD_SIGNAL(MethodInfo("popup_closed"));
 	ADD_SIGNAL(MethodInfo("picker_created"));
+	ADD_SIGNAL(MethodInfo("modal_closed"));
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_pick_color", "get_pick_color");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "edit_alpha"), "set_edit_alpha", "is_editing_alpha");
 }


### PR DESCRIPTION
Fixes error
```
 In Object of type 'PopupPanel': Attempt to connect nonexistent signal 'modal_closed' to callable 'ColorPickerButton::_modal_closed'.
```