### PR TITLE
Warn about built-in script limitations in the script creation dialog

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -689,6 +689,8 @@ void ScriptCreateDialog::_update_dialog() {
 
 	// Is Script created or loaded from existing file?
 
+	builtin_warning_label->set_visible(is_built_in);
+
 	if (is_built_in) {
 		get_ok()->set_text(TTR("Create"));
 		parent_name->set_editable(true);
@@ -755,6 +757,13 @@ ScriptCreateDialog::ScriptCreateDialog() {
 
 	path_error_label = memnew(Label);
 	vb->add_child(path_error_label);
+
+	builtin_warning_label = memnew(Label);
+	builtin_warning_label->set_text(
+			TTR("Note: Built-in scripts have some limitations and can't be edited using an external editor."));
+	vb->add_child(builtin_warning_label);
+	builtin_warning_label->set_autowrap(true);
+	builtin_warning_label->hide();
 
 	status_panel = memnew(PanelContainer);
 	status_panel->set_h_size_flags(Control::SIZE_FILL);

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -49,6 +49,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	LineEdit *class_name;
 	Label *error_label;
 	Label *path_error_label;
+	Label *builtin_warning_label;
 	PanelContainer *status_panel;
 	LineEdit *parent_name;
 	Button *parent_browse_button;


### PR DESCRIPTION
This partially addresses #31758.

## Preview

![Script editor creation dialog with note](https://user-images.githubusercontent.com/180032/78448682-6b822380-767a-11ea-82c3-01dfb5120e2b.png)