### PR TITLE
Improve the shader error console output

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -647,13 +647,13 @@ String String::camelcase_to_underscore(bool lowercase) const {
 }
 
 String String::get_with_code_lines() const {
-	Vector<String> lines = split("\n");
+	const Vector<String> lines = split("\n");
 	String ret;
 	for (int i = 0; i < lines.size(); i++) {
 		if (i > 0) {
 			ret += "\n";
 		}
-		ret += itos(i + 1) + " " + lines[i];
+		ret += vformat("%4d | %s", i + 1, lines[i]);
 	}
 	return ret;
 }


### PR DESCRIPTION
This makes the line gutter look more like an actual line gutter, which makes it less confusing.

## Preview

(The syntax error is on line 8.)

### Before

```text
ERROR: code:
1 
2 #version 450
3 
4 
5 #define MODE_CUBE_TO_DP
6 
7 
8 layout(location =xx 0) out vec2 uv_interp;
9 /* clang-format on */
10 
11 void main() {
12 
13      vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
14      uv_interp = base_arr[gl_VertexIndex];
15 
16      gl_Position = vec4(uv_interp * 2.0 - 1.0, 0.0, 1.0);
17 }
18 
19 /* clang-format off */
20 
```

### After

```text
ERROR: code:
   1 | 
   2 | #version 450
   3 | 
   4 | 
   5 | #define MODE_CUBE_TO_DP
   6 | 
   7 | 
   8 | layout(location =xx 0) out vec2 uv_interp;
   9 | /* clang-format on */
  10 | 
  11 | void main() {
  12 | 
  13 |  vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
  14 |  uv_interp = base_arr[gl_VertexIndex];
  15 | 
  16 |  gl_Position = vec4(uv_interp * 2.0 - 1.0, 0.0, 1.0);
  17 | }
  18 | 
  19 | /* clang-format off */
  20 | 
```