### PR TITLE
Fix leak with Vulkan allocator

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -7048,6 +7048,7 @@ void RenderingDeviceVulkan::finalize() {
 	for (int i = 0; i < staging_buffer_blocks.size(); i++) {
 		vmaDestroyBuffer(allocator, staging_buffer_blocks[i].buffer, staging_buffer_blocks[i].allocation);
 	}
+	vmaDestroyAllocator(allocator);
 
 	//all these should be clear at this point
 	ERR_FAIL_COND(descriptor_pools.size());


### PR DESCRIPTION
I'm not sure about fix, but seems to fix this leak
```
Indirect leak of 4848 byte(s) in 1 object(s) allocated from:
    #0 0x7fec4c5f36d5 in __interceptor_aligned_alloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10e6d5)
    #1 0x64471ce in VmaMalloc thirdparty/vulkan/vk_mem_alloc.h:4234
    #2 0x64eb3a6 in VmaAllocate<VmaAllocator_T> thirdparty/vulkan/vk_mem_alloc.h:4254
    #3 0x64e16db in vmaCreateAllocator thirdparty/vulkan/vk_mem_alloc.h:16373
    #4 0x6282e87 in RenderingDeviceVulkan::initialize(VulkanContext*) drivers/vulkan/rendering_device_vulkan.cpp:6747
    #5 0x17edff6 in DisplayServerX11::DisplayServerX11(String const&, DisplayServer::WindowMode, unsigned int, Vector2i const&, Error&) platform/linuxbsd/display_server_x11.cpp:3620
    #6 0x17dd503 in DisplayServerX11::create_func(String const&, DisplayServer::WindowMode, unsigned int, Vector2i const&, Error&) platform/linuxbsd/display_server_x11.cpp:3138
    #7 0xdc9821a in DisplayServer::create(int, String const&, DisplayServer::WindowMode, unsigned int, Vector2i const&, Error&) servers/display_server.cpp:563
    #8 0x1860fe2 in Main::setup2(unsigned long) main/main.cpp:1250
    #9 0x185c2c3 in Main::setup(char const*, int, char**, bool) main/main.cpp:1177
    #10 0x17577e0 in main platform/linuxbsd/godot_linuxbsd.cpp:49
    #11 0x7fec4b36c1e2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x271e2)
```
