### PR TITLE
Add reference of Color8 function to Color class documentation

### DIFF
--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -5,7 +5,8 @@
 	</brief_description>
 	<description>
 		A color is represented by red, green, and blue [code](r, g, b)[/code] components. Additionally, [code]a[/code] represents the alpha component, often used for transparency. Values are in floating-point and usually range from 0 to 1. Some properties (such as [member CanvasItem.modulate]) may accept values greater than 1.
-		You can also create a color from standardized color names by using [method @GDScript.ColorN] or directly using the color constants defined here. The standardized color set is based on the [url=https://en.wikipedia.org/wiki/X11_color_names]X11 color names[/url].
+		You can also create a color from standardized color names by using [method @GDScript.ColorN] or directly using the color constants defined here. The standardized color set is based on the [url=https://en.wikipedia.org/wiki/X11_color_names]X11 color names[/url]. 
+		If you want to supply values in a range of 0 to 255, you should use [method @GDScript.Color8].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Responding to an issue made in the godot'docs repo
https://github.com/godotengine/godot-docs/issues/3314

Adding a reference acknowledging the existence of the Color8 function to the Color class documentation, in the same way ColorN is referenced.

*Bugsquad edit: This closes https://github.com/godotengine/godot-docs/issues/3314.*