### PR TITLE
Removed redundant class LineEditFileChooser from file_dialog

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1005,37 +1005,3 @@ FileDialog::~FileDialog() {
 		unregister_func(this);
 	memdelete(dir_access);
 }
-
-void LineEditFileChooser::_bind_methods() {
-
-	ClassDB::bind_method(D_METHOD("get_button"), &LineEditFileChooser::get_button);
-	ClassDB::bind_method(D_METHOD("get_line_edit"), &LineEditFileChooser::get_line_edit);
-	ClassDB::bind_method(D_METHOD("get_file_dialog"), &LineEditFileChooser::get_file_dialog);
-}
-
-void LineEditFileChooser::_chosen(const String &p_text) {
-
-	line_edit->set_text(p_text);
-	line_edit->emit_signal("text_entered", p_text);
-}
-
-void LineEditFileChooser::_browse() {
-
-	dialog->popup_centered_ratio();
-}
-
-LineEditFileChooser::LineEditFileChooser() {
-
-	line_edit = memnew(LineEdit);
-	add_child(line_edit);
-	line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	button = memnew(Button);
-	button->set_text(" .. ");
-	add_child(button);
-	button->connect("pressed", callable_mp(this, &LineEditFileChooser::_browse));
-	dialog = memnew(FileDialog);
-	add_child(dialog);
-	dialog->connect("file_selected", callable_mp(this, &LineEditFileChooser::_chosen));
-	dialog->connect("dir_selected", callable_mp(this, &LineEditFileChooser::_chosen));
-	dialog->connect("files_selected", callable_mp(this, &LineEditFileChooser::_chosen));
-}

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -177,27 +177,6 @@ public:
 	~FileDialog();
 };
 
-class LineEditFileChooser : public HBoxContainer {
-
-	GDCLASS(LineEditFileChooser, HBoxContainer);
-	Button *button;
-	LineEdit *line_edit;
-	FileDialog *dialog;
-
-	void _chosen(const String &p_text);
-	void _browse();
-
-protected:
-	static void _bind_methods();
-
-public:
-	Button *get_button() { return button; }
-	LineEdit *get_line_edit() { return line_edit; }
-	FileDialog *get_file_dialog() { return dialog; }
-
-	LineEditFileChooser();
-};
-
 VARIANT_ENUM_CAST(FileDialog::FileMode);
 VARIANT_ENUM_CAST(FileDialog::Access);
 


### PR DESCRIPTION
Removed redundant class LineEditFileChooser from file_dialog. It's been there since the beginning of Godot but I couldn't find any reference to its use.