### PR TITLE
Othographic camera in-editor now uses Z near/far instead of hardcoded value

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -345,7 +345,7 @@ void SpatialEditorViewport::_update_camera(float p_interp_delta) {
 		if (orthogonal) {
 			float half_fov = Math::deg2rad(get_fov()) / 2.0;
 			float height = 2.0 * cursor.distance * Math::tan(half_fov);
-			camera->set_orthogonal(height, 0.1, 8192);
+			camera->set_orthogonal(height, get_znear(), get_zfar());
 		} else {
 			camera->set_perspective(get_fov(), get_znear(), get_zfar());
 		}
@@ -362,7 +362,7 @@ Transform SpatialEditorViewport::to_camera_transform(const Cursor &p_cursor) con
 	camera_transform.basis.rotate(Vector3(0, 1, 0), -p_cursor.y_rot);
 
 	if (orthogonal)
-		camera_transform.translate(0, 0, 4096);
+		camera_transform.translate(0, 0, (get_zfar() - get_znear()) / 2.0);
 	else
 		camera_transform.translate(0, 0, p_cursor.distance);
 


### PR DESCRIPTION
Fixes #18809.

The in-editor ortho camera used a far clipping plane of 8192 units, and was
placed 4096 units away from the camera cursor.

This was far enough to cause culling issues from floating point precision loss
on objects smaller than one unit.

This change modifies the near/far clipping planes of the ortho camera to use
those specified in the editor (and currently used by the perspective camera).
The frustum is still centered around the camera cursor location, as it was
before.