### PR TITLE
Remove overzealous check on package segment name

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -479,12 +479,6 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 				}
 				return false;
 			}
-			if (first && (c >= '0' && c <= '9')) {
-				if (r_error) {
-					*r_error = TTR("A digit cannot be the first character in a package segment.");
-				}
-				return false;
-			}
 			if (first && c == '_') {
 				if (r_error) {
 					*r_error = vformat(TTR("The character '%s' cannot be the first character in a package segment."), String::chr(c));


### PR DESCRIPTION
This check prevents using package names such as org.0xd0.motherclucker, because the domain starts with a digit. However, the 0xd0.org domain name is perfectly valid.