### PR TITLE
Add missing LinkButton colors in Editor Theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -997,6 +997,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// LinkButton
 	theme->set_stylebox("focus", "LinkButton", style_empty);
 	theme->set_color("font_color", "LinkButton", font_color);
+	theme->set_color("font_color_hover", "LinkButton", font_color_hl);
+	theme->set_color("font_color_pressed", "LinkButton", accent_color);
+	theme->set_color("font_color_disabled", "LinkButton", font_color_disabled);
 
 	// TooltipPanel
 	Ref<StyleBoxFlat> style_tooltip = style_popup->duplicate();


### PR DESCRIPTION
`LinkButton` control, used by Asset Library and Export Template Manager, is missing some of the color definitions in Editor Theme. This adds them, using the same colors as defined for other controls.

There is only default and hover style, disabled is missing a color and pressed is falling back to default:
![godot windows tools 64_2020-04-05_22-22-20](https://user-images.githubusercontent.com/11782833/78508671-53e98e80-7791-11ea-944d-a83d67dc2b85.png)

I've added pressed and disabled, and also defined hover directly on `LinkButton`:
![godot windows tools 64_2020-04-05_22-29-25](https://user-images.githubusercontent.com/11782833/78508673-551abb80-7791-11ea-9228-65ebaa26888d.png)

Edit: I've used an editor plugin to test it, because neither AssetLib nor export templates are available for 4.0 yet.