### PR TITLE
Expose methods to play scenes from plugin code

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -72,6 +72,13 @@
 				Returns an [Array] with the file paths of the currently opened scenes.
 			</description>
 		</method>
+		<method name="get_playing_scene" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns the name of the scene that is being played. If no scene is currently being played, returns an empty string.
+			</description>
+		</method>
 		<method name="get_resource_filesystem">
 			<return type="EditorFileSystem">
 			</return>
@@ -117,6 +124,13 @@
 				Shows the given property on the given [code]object[/code] in the Editor's Inspector dock.
 			</description>
 		</method>
+		<method name="is_playing_scene" qualifiers="const">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code], if a scene is currently being played; [code]false[/code] otherwise. Paused scenes are considered as being played.
+			</description>
+		</method>
 		<method name="is_plugin_enabled" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -144,6 +158,29 @@
 			</argument>
 			<description>
 				Opens the scene at the given path.
+			</description>
+		</method>
+		<method name="play_current_scene">
+			<return type="void">
+			</return>
+			<description>
+				Plays the currently active scene.
+			</description>
+		</method>
+		<method name="play_custom_scene">
+			<return type="void">
+			</return>
+			<argument index="0" name="scene_filepath" type="String">
+			</argument>
+			<description>
+				Plays the scene specified by its filepath.
+			</description>
+		</method>
+		<method name="play_main_scene">
+			<return type="void">
+			</return>
+			<description>
+				Plays the main scene.
 			</description>
 		</method>
 		<method name="reload_scene_from_path">
@@ -199,6 +236,13 @@
 			</argument>
 			<description>
 				Sets the enabled status of a plugin. The plugin name is the same as its directory name.
+			</description>
+		</method>
+		<method name="stop_playing_scene">
+			<return type="void">
+			</return>
+			<description>
+				Stops the scene that is currently playing.
 			</description>
 		</method>
 	</methods>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2043,7 +2043,6 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 	play_custom_scene_button->set_pressed(false);
 	play_custom_scene_button->set_icon(gui_base->get_theme_icon("PlayCustom", "EditorIcons"));
 
-	String main_scene;
 	String run_filename;
 	String args;
 	bool skip_breakpoints;
@@ -2464,8 +2463,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		} break;
 		case RUN_PLAY: {
-			_menu_option_confirm(RUN_STOP, true);
-			_run(false);
+			run_play();
 
 		} break;
 		case RUN_PLAY_CUSTOM_SCENE: {
@@ -2476,8 +2474,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				play_custom_scene_button->set_pressed(false);
 			} else {
 				String last_custom_scene = run_custom_filename;
-				_menu_option_confirm(RUN_STOP, true);
-				_run(false, last_custom_scene);
+				run_play_custom(last_custom_scene);
 			}
 
 		} break;
@@ -2517,9 +2514,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 
 		case RUN_PLAY_SCENE: {
-			_save_default_environment();
-			_menu_option_confirm(RUN_STOP, true);
-			_run(true);
+			run_play_current();
 
 		} break;
 		case RUN_SCENE_SETTINGS: {
@@ -4524,8 +4519,33 @@ void EditorNode::run_play() {
 	_run(false);
 }
 
+void EditorNode::run_play_current() {
+	_save_default_environment();
+	_menu_option_confirm(RUN_STOP, true);
+	_run(true);
+}
+
+void EditorNode::run_play_custom(const String &p_custom) {
+	_menu_option_confirm(RUN_STOP, true);
+	_run(false, p_custom);
+}
+
 void EditorNode::run_stop() {
 	_menu_option_confirm(RUN_STOP, false);
+}
+
+bool EditorNode::is_run_playing() const {
+	EditorRun::Status status = editor_run.get_status();
+	return (status == EditorRun::STATUS_PLAY || status == EditorRun::STATUS_PAUSED);
+}
+
+String EditorNode::get_run_playing_scene() const {
+	String run_filename = editor_run.get_running_scene();
+	if (run_filename == "" && is_run_playing()) {
+		run_filename = GLOBAL_DEF("application/run/main_scene", ""); // Must be the main scene then.
+	}
+
+	return run_filename;
 }
 
 int EditorNode::get_current_tab() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -865,7 +865,11 @@ public:
 	bool ensure_main_scene(bool p_from_native);
 
 	void run_play();
+	void run_play_current();
+	void run_play_custom(const String &p_custom);
 	void run_stop();
+	bool is_run_playing() const;
+	String get_run_playing_scene() const;
 };
 
 struct EditorProgress {

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -176,6 +176,30 @@ void EditorInterface::reload_scene_from_path(const String &scene_path) {
 	EditorNode::get_singleton()->reload_scene(scene_path);
 }
 
+void EditorInterface::play_main_scene() {
+	EditorNode::get_singleton()->run_play();
+}
+
+void EditorInterface::play_current_scene() {
+	EditorNode::get_singleton()->run_play_current();
+}
+
+void EditorInterface::play_custom_scene(const String &scene_path) {
+	EditorNode::get_singleton()->run_play_custom(scene_path);
+}
+
+void EditorInterface::stop_playing_scene() {
+	EditorNode::get_singleton()->run_stop();
+}
+
+bool EditorInterface::is_playing_scene() const {
+	return EditorNode::get_singleton()->is_run_playing();
+}
+
+String EditorInterface::get_playing_scene() const {
+	return EditorNode::get_singleton()->get_run_playing_scene();
+}
+
 Node *EditorInterface::get_edited_scene_root() {
 	return EditorNode::get_singleton()->get_edited_scene();
 }
@@ -285,6 +309,12 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("edit_resource", "resource"), &EditorInterface::edit_resource);
 	ClassDB::bind_method(D_METHOD("open_scene_from_path", "scene_filepath"), &EditorInterface::open_scene_from_path);
 	ClassDB::bind_method(D_METHOD("reload_scene_from_path", "scene_filepath"), &EditorInterface::reload_scene_from_path);
+	ClassDB::bind_method(D_METHOD("play_main_scene"), &EditorInterface::play_main_scene);
+	ClassDB::bind_method(D_METHOD("play_current_scene"), &EditorInterface::play_current_scene);
+	ClassDB::bind_method(D_METHOD("play_custom_scene", "scene_filepath"), &EditorInterface::play_custom_scene);
+	ClassDB::bind_method(D_METHOD("stop_playing_scene"), &EditorInterface::stop_playing_scene);
+	ClassDB::bind_method(D_METHOD("is_playing_scene"), &EditorInterface::is_playing_scene);
+	ClassDB::bind_method(D_METHOD("get_playing_scene"), &EditorInterface::get_playing_scene);
 	ClassDB::bind_method(D_METHOD("get_open_scenes"), &EditorInterface::get_open_scenes);
 	ClassDB::bind_method(D_METHOD("get_edited_scene_root"), &EditorInterface::get_edited_scene_root);
 	ClassDB::bind_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -73,6 +73,13 @@ public:
 	void open_scene_from_path(const String &scene_path);
 	void reload_scene_from_path(const String &scene_path);
 
+	void play_main_scene();
+	void play_current_scene();
+	void play_custom_scene(const String &scene_path);
+	void stop_playing_scene();
+	bool is_playing_scene() const;
+	String get_playing_scene() const;
+
 	Node *get_edited_scene_root();
 	Array get_open_scenes() const;
 	ScriptEditor *get_script_editor();

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -38,6 +38,10 @@ EditorRun::Status EditorRun::get_status() const {
 	return status;
 }
 
+String EditorRun::get_running_scene() const {
+	return running_scene;
+}
+
 Error EditorRun::run(const String &p_scene, const String &p_custom_args, const List<String> &p_breakpoints, const bool &p_skip_breakpoints) {
 	List<String> args;
 
@@ -203,6 +207,9 @@ Error EditorRun::run(const String &p_scene, const String &p_custom_args, const L
 	}
 
 	status = STATUS_PLAY;
+	if (p_scene != "") {
+		running_scene = p_scene;
+	}
 
 	return OK;
 }
@@ -231,8 +238,10 @@ void EditorRun::stop() {
 	}
 
 	status = STATUS_STOP;
+	running_scene = "";
 }
 
 EditorRun::EditorRun() {
 	status = STATUS_STOP;
+	running_scene = "";
 }

--- a/editor/editor_run.h
+++ b/editor/editor_run.h
@@ -46,9 +46,11 @@ public:
 
 private:
 	Status status;
+	String running_scene;
 
 public:
 	Status get_status() const;
+	String get_running_scene() const;
 	Error run(const String &p_scene, const String &p_custom_args, const List<String> &p_breakpoints, const bool &p_skip_breakpoints = false);
 	void run_native_notify() { status = STATUS_PLAY; }
 	void stop();


### PR DESCRIPTION
This PR exposes `EditorNode`'s functionality for playing and stopping scenes.

Certain plugins, such as internal game editors, can benefit from having a direct API to run scenes. While technically it is possible to run any saved scene currently, it requires [a lengthy hack](https://gist.github.com/pycbouh/b8b508922c1d947c53bd77936e31d80f) to do so.

I think that we can just expose those functions to the plugin API via `EditorInterface`. With this PR these methods are available:
```swift
	plugin_instance.get_editor_interface().play_main_scene()
	plugin_instance.get_editor_interface().play_current_scene()
	plugin_instance.get_editor_interface().play_custom_scene("res://YourCustomScene.tscn")
	plugin_instance.get_editor_interface().stop_playing_scene()
	plugin_instance.get_editor_interface().is_playing_scene() # True
	plugin_instance.get_editor_interface().get_playing_scene() # res://YourCustomScene.tscn
```

It should be 3.2 compatible.