### PR TITLE
Vulkan: Use VK_NULL_HANDLE for handles, fixes 32-bit builds

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "rendering_device_vulkan.h"
+
 #include "core/hashfuncs.h"
 #include "core/os/file_access.h"
 #include "core/os/os.h"
@@ -1265,7 +1266,7 @@ Error RenderingDeviceVulkan::_buffer_free(Buffer *p_buffer) {
 	ERR_FAIL_COND_V(p_buffer->size == 0, ERR_INVALID_PARAMETER);
 
 	vmaDestroyBuffer(allocator, p_buffer->buffer, p_buffer->allocation);
-	p_buffer->buffer = nullptr;
+	p_buffer->buffer = VK_NULL_HANDLE;
 	p_buffer->allocation = nullptr;
 	p_buffer->size = 0;
 
@@ -4250,7 +4251,7 @@ RID RenderingDeviceVulkan::uniform_set_create(const Vector<Uniform> &p_uniforms,
 		VkWriteDescriptorSet write; //common header
 		write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
 		write.pNext = nullptr;
-		write.dstSet = nullptr; //will assign afterwards when everything is valid
+		write.dstSet = VK_NULL_HANDLE; //will assign afterwards when everything is valid
 		write.dstBinding = set_uniform.binding;
 		uint32_t type_size = 1;
 
@@ -4363,7 +4364,7 @@ RID RenderingDeviceVulkan::uniform_set_create(const Vector<Uniform> &p_uniforms,
 							"Texture (binding: " + itos(uniform.binding) + ", index " + itos(j) + ") needs the TEXTURE_USAGE_SAMPLING_BIT usage flag set in order to be used as uniform.");
 
 					VkDescriptorImageInfo img_info;
-					img_info.sampler = nullptr;
+					img_info.sampler = VK_NULL_HANDLE;
 					img_info.imageView = texture->view;
 
 					if (texture->usage_flags & (TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | TEXTURE_USAGE_RESOLVE_ATTACHMENT_BIT)) {
@@ -4416,7 +4417,7 @@ RID RenderingDeviceVulkan::uniform_set_create(const Vector<Uniform> &p_uniforms,
 							"Image (binding: " + itos(uniform.binding) + ", index " + itos(j) + ") needs the TEXTURE_USAGE_STORAGE_BIT usage flag set in order to be used as uniform.");
 
 					VkDescriptorImageInfo img_info;
-					img_info.sampler = nullptr;
+					img_info.sampler = VK_NULL_HANDLE;
 					img_info.imageView = texture->view;
 
 					if (texture->owner.is_valid()) {
@@ -5048,11 +5049,11 @@ RID RenderingDeviceVulkan::render_pipeline_create(RID p_shader, FramebufferForma
 	graphics_pipeline_create_info.renderPass = fb_format.render_pass;
 
 	graphics_pipeline_create_info.subpass = 0;
-	graphics_pipeline_create_info.basePipelineHandle = nullptr;
+	graphics_pipeline_create_info.basePipelineHandle = VK_NULL_HANDLE;
 	graphics_pipeline_create_info.basePipelineIndex = 0;
 
 	RenderPipeline pipeline;
-	VkResult err = vkCreateGraphicsPipelines(device, nullptr, 1, &graphics_pipeline_create_info, nullptr, &pipeline.pipeline);
+	VkResult err = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &graphics_pipeline_create_info, nullptr, &pipeline.pipeline);
 	ERR_FAIL_COND_V_MSG(err, RID(), "vkCreateGraphicsPipelines failed with error " + itos(err) + ".");
 
 	pipeline.set_formats = shader->set_formats;
@@ -5121,11 +5122,11 @@ RID RenderingDeviceVulkan::compute_pipeline_create(RID p_shader) {
 
 	compute_pipeline_create_info.stage = shader->pipeline_stages[0];
 	compute_pipeline_create_info.layout = shader->pipeline_layout;
-	compute_pipeline_create_info.basePipelineHandle = nullptr;
+	compute_pipeline_create_info.basePipelineHandle = VK_NULL_HANDLE;
 	compute_pipeline_create_info.basePipelineIndex = 0;
 
 	ComputePipeline pipeline;
-	VkResult err = vkCreateComputePipelines(device, nullptr, 1, &compute_pipeline_create_info, nullptr, &pipeline.pipeline);
+	VkResult err = vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &compute_pipeline_create_info, nullptr, &pipeline.pipeline);
 	ERR_FAIL_COND_V_MSG(err, RID(), "vkCreateComputePipelines failed with error " + itos(err) + ".");
 
 	pipeline.set_formats = shader->set_formats;

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -207,7 +207,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 		VkDescriptorBufferInfo buffer_info; //used for binding
 		Buffer() {
 			size = 0;
-			buffer = nullptr;
+			buffer = VK_NULL_HANDLE;
 			allocation = nullptr;
 		}
 	};

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -937,7 +937,7 @@ Error VulkanContext::_update_swap_chain(Window *window) {
 		/*compositeAlpha*/ compositeAlpha,
 		/*presentMode*/ swapchainPresentMode,
 		/*clipped*/ true,
-		/*oldSwapchain*/ nullptr,
+		/*oldSwapchain*/ VK_NULL_HANDLE,
 	};
 
 	err = fpCreateSwapchainKHR(device, &swapchain_ci, nullptr, &window->swapchain);


### PR DESCRIPTION
Some Vulkan types are defined as "non dispatchable handles" and use a
different typedef on 32-bit and 64-bit systems (struct pointer on
64-bit, `uint64_t` otherwise).

https://github.com/KhronosGroup/Vulkan-Headers/blob/0e78ffd1dcfc3e9f14a966b9660dbc59bd967c5c/include/vulkan/vulkan_core.h#L59-L65

Contrarily to `NULL`, `nullptr` can't be converted to `uint64_t` so
build was now failing on 32-bit after converting the codebase from
using `NULL` to `nullptr`.

Fixes #37620.