### PR TITLE
Fixed leak with vertex_formats

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -7049,6 +7049,13 @@ void RenderingDeviceVulkan::finalize() {
 		vmaDestroyBuffer(allocator, staging_buffer_blocks[i].buffer, staging_buffer_blocks[i].allocation);
 	}
 
+	while (vertex_formats.size()) {
+		Map<VertexFormatID, VertexDescriptionCache>::Element *temp = vertex_formats.front();
+		memdelete_arr(temp->get().bindings);
+		memdelete_arr(temp->get().attributes);
+		vertex_formats.erase(temp);
+	}
+
 	//all these should be clear at this point
 	ERR_FAIL_COND(descriptor_pools.size());
 	ERR_FAIL_COND(dependency_map.size());


### PR DESCRIPTION
Fixes point 1 from  https://github.com/godotengine/godot/issues/36597#issuecomment-609076021