### PR TITLE
Calculate strike-through y-position correctly (RichTexteLabel)

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -608,7 +608,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 						} else if (strikethrough) {
 							Color uc = color;
 							uc.a *= 0.5;
-							int uy = y + lh / 2 - line_descent + 2;
+							int uy = y + lh - (line_ascent + line_descent) / 2;
 							float strikethrough_width = 1.0;
 #ifdef TOOLS_ENABLED
 							strikethrough_width *= EDSCALE;


### PR DESCRIPTION
Fixes: #37637

![rich-text](https://user-images.githubusercontent.com/1110337/78602287-7e514f80-7856-11ea-8e72-4450aa5f0e57.gif)
