### PR TITLE
Remove unnecessary panel in EditorHelpBit

### DIFF
--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -192,9 +192,9 @@ public:
 	~EditorHelp();
 };
 
-class EditorHelpBit : public PanelContainer {
+class EditorHelpBit : public MarginContainer {
 
-	GDCLASS(EditorHelpBit, PanelContainer);
+	GDCLASS(EditorHelpBit, MarginContainer);
 
 	RichTextLabel *rich_text;
 	void _go_to_help(String p_what);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -977,8 +977,6 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("focus", "RichTextLabel", make_empty_stylebox());
 	theme->set_stylebox("normal", "RichTextLabel", style_tree_bg);
 
-	theme->set_stylebox("panel", "EditorHelpBit", make_flat_stylebox(dark_color_1, 6, 4, 6, 4));
-
 	theme->set_color("headline_color", "EditorHelp", mono_color);
 
 	// Panel


### PR DESCRIPTION
This fixes some visual problems with it, but there are others that I don't know the cause:
- It completely ignores the editor font size.
- In tooltips, font variants (bold, code, etc) aren't set.