### PR TITLE
Avoid material rebinds when using skeletons

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2501,16 +2501,16 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 		RasterizerStorageGLES2::Skeleton *skeleton = storage->skeleton_owner.getornull(e->instance->skeleton);
 
 		if (skeleton != prev_skeleton) {
-
-			if (skeleton) {
-				state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON, true);
-				state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON_SOFTWARE, storage->config.use_skeleton_software);
-			} else {
-				state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON, false);
-				state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON_SOFTWARE, false);
+			if ((prev_skeleton == nullptr) != (skeleton == nullptr)) {
+				if (skeleton) {
+					state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON, true);
+					state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON_SOFTWARE, storage->config.use_skeleton_software);
+				} else {
+					state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON, false);
+					state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON_SOFTWARE, false);
+				}
+				rebind = true;
 			}
-
-			rebind = true;
 		}
 
 		if (e->owner != prev_owner || e->geometry != prev_geometry || skeleton != prev_skeleton) {


### PR DESCRIPTION
Fixes #37660 For 4.0. Because of the ``nullptr`` change, I have made another PR for 3.2

Changes to use the same logic as GLES3 

https://github.com/godotengine/godot/blob/df87601c8818b9978ae7718c71d614eed3f5959b/drivers/gles3/rasterizer_scene_gles3.cpp#L2190-L2200

Previously, every time a valid skeleton was used, a rebind would occur. Now, a rebind on occurs when the previous skeleton was null and the current is valid or vice versa (i.e. state changes only when state needs to change).

I am not sure why ``(prev_skeleton != skeleton)`` evaluates to ``true`` every frame, but I assume it has to do with how GLES2 treats skeletons, it seems to make a slightly different skeleton for each mesh instead of sharing one across many.