### PR TITLE
[3.x] Editor Debugger: auto scrolling is activated at every log start.

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -193,5 +193,9 @@ void EditorLog::deinit() {
 	remove_error_handler(&eh);
 }
 
+void EditorLog::set_scroll_follow(bool p_follow) {
+	log->set_scroll_follow(p_follow);
+}
+
 EditorLog::~EditorLog() {
 }

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -81,6 +81,7 @@ public:
 	void add_message(const String &p_msg, MessageType p_type = MSG_TYPE_STD);
 	void set_tool_button(ToolButton *p_tool_button);
 	void deinit();
+	void set_scroll_follow(bool p_follow);
 
 	void clear();
 	void copy();

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1309,6 +1309,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 					if (connection.is_null())
 						break;
 
+					EditorNode::get_log()->set_scroll_follow(true);
 					EditorNode::get_log()->add_message("--- Debugging process started ---", EditorLog::MSG_TYPE_EDITOR);
 
 					ppeer->set_stream_peer(connection);


### PR DESCRIPTION
Fix #37476

**Note**: for the master branch I can't test if it works (godot crashes at the start) and the changes are not entirely compatible, given the different structure of the current debugger.