### PR TITLE
Prevent atlas from being set recursively in AtlasTexture and fix typo…

### DIFF
--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -524,7 +524,7 @@ Size2 Font::get_wordwrap_string_size(const String &p_string, float p_width) cons
 
 void BitmapFont::set_fallback(const Ref<BitmapFont> &p_fallback) {
 	for (Ref<BitmapFont> fallback_child = p_fallback; fallback_child != nullptr; fallback_child = fallback_child->get_fallback()) {
-		ERR_FAIL_COND_MSG(fallback_child == this, "Can't set as fallback one of its parents to prevent crashes due to recursive loop.");
+		ERR_FAIL_COND_MSG(fallback_child == this, "Can't set fallback as one of its parents or self to prevent crashes due to recursive loop.");
 	}
 
 	fallback = p_fallback;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1136,7 +1136,12 @@ bool AtlasTexture::has_alpha() const {
 }
 
 void AtlasTexture::set_atlas(const Ref<Texture2D> &p_atlas) {
-	ERR_FAIL_COND(p_atlas == this);
+	const AtlasTexture *p_atlas_child = Object::cast_to<AtlasTexture>(*p_atlas);
+	while (p_atlas_child != nullptr) {
+		ERR_FAIL_COND_MSG(p_atlas_child == this, "Can't set atlas as one of its parents or self to prevent crashes due to recursive loop.");
+		p_atlas_child = Object::cast_to<AtlasTexture>(*p_atlas_child->get_atlas());
+	}
+
 	if (atlas == p_atlas) {
 		return;
 	}


### PR DESCRIPTION
… in the similar error message of font.cpp.
Thx to @Zylann for helping me use implicit conversion.
Fixes #26939's 2nd half.