### PR TITLE
Add magnified() to Vector2/3 (setting its length)

### DIFF
--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -126,6 +126,14 @@ Vector2 Vector2::rotated(real_t p_by) const {
 	return v;
 }
 
+Vector2 Vector2::magnified(real_t p_by) const {
+
+	Vector2 v = *this;
+	v.normalize();
+	v *= p_by;
+	return v;
+}
+
 Vector2 Vector2::posmod(const real_t p_mod) const {
 	return Vector2(Math::fposmod(x, p_mod), Math::fposmod(y, p_mod));
 }

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -135,6 +135,7 @@ struct Vector2 {
 	}
 
 	Vector2 rotated(real_t p_by) const;
+	Vector2 magnified(real_t p_by) const;
 	Vector2 tangent() const {
 
 		return Vector2(y, -x);

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -73,6 +73,7 @@ struct Vector3 {
 
 	_FORCE_INLINE_ real_t length() const;
 	_FORCE_INLINE_ real_t length_squared() const;
+	_FORCE_INLINE_ Vector3 magnified(real_t p_by) const;
 
 	_FORCE_INLINE_ void normalize();
 	_FORCE_INLINE_ Vector3 normalized() const;
@@ -424,6 +425,14 @@ real_t Vector3::length_squared() const {
 	real_t z2 = z * z;
 
 	return x2 + y2 + z2;
+}
+
+Vector3 Vector3::magnified(real_t p_by) const {
+
+	Vector3 v = *this;
+	v.normalize();
+	v *= p_by;
+	return v;
 }
 
 void Vector3::normalize() {

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -367,6 +367,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM4R(Vector2, cubic_interpolate);
 	VCALL_LOCALMEM2R(Vector2, move_toward);
 	VCALL_LOCALMEM1R(Vector2, rotated);
+	VCALL_LOCALMEM1R(Vector2, magnified);
 	VCALL_LOCALMEM0R(Vector2, tangent);
 	VCALL_LOCALMEM0R(Vector2, floor);
 	VCALL_LOCALMEM0R(Vector2, ceil);
@@ -426,6 +427,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(Vector3, inverse);
 	VCALL_LOCALMEM1R(Vector3, snapped);
 	VCALL_LOCALMEM2R(Vector3, rotated);
+	VCALL_LOCALMEM1R(Vector3, magnified);
 	VCALL_LOCALMEM2R(Vector3, linear_interpolate);
 	VCALL_LOCALMEM2R(Vector3, slerp);
 	VCALL_LOCALMEM4R(Vector3, cubic_interpolate);
@@ -1814,6 +1816,7 @@ void register_variant_methods() {
 	ADDFUNC4R(VECTOR2, VECTOR2, Vector2, cubic_interpolate, VECTOR2, "b", VECTOR2, "pre_a", VECTOR2, "post_b", FLOAT, "t", varray());
 	ADDFUNC2R(VECTOR2, VECTOR2, Vector2, move_toward, VECTOR2, "to", FLOAT, "delta", varray());
 	ADDFUNC1R(VECTOR2, VECTOR2, Vector2, rotated, FLOAT, "phi", varray());
+	ADDFUNC1R(VECTOR2, VECTOR2, Vector2, magnified, FLOAT, "length", varray());
 	ADDFUNC0R(VECTOR2, VECTOR2, Vector2, tangent, varray());
 	ADDFUNC0R(VECTOR2, VECTOR2, Vector2, floor, varray());
 	ADDFUNC0R(VECTOR2, VECTOR2, Vector2, ceil, varray());
@@ -1874,6 +1877,7 @@ void register_variant_methods() {
 	ADDFUNC0R(VECTOR3, VECTOR3, Vector3, inverse, varray());
 	ADDFUNC1R(VECTOR3, VECTOR3, Vector3, snapped, VECTOR3, "by", varray());
 	ADDFUNC2R(VECTOR3, VECTOR3, Vector3, rotated, VECTOR3, "axis", FLOAT, "phi", varray());
+	ADDFUNC1R(VECTOR3, VECTOR3, Vector3, magnified, FLOAT, "length", varray());
 	ADDFUNC2R(VECTOR3, VECTOR3, Vector3, linear_interpolate, VECTOR3, "b", FLOAT, "t", varray());
 	ADDFUNC2R(VECTOR3, VECTOR3, Vector3, slerp, VECTOR3, "b", FLOAT, "t", varray());
 	ADDFUNC4R(VECTOR3, VECTOR3, Vector3, cubic_interpolate, VECTOR3, "b", VECTOR3, "pre_a", VECTOR3, "post_b", FLOAT, "t", varray());


### PR DESCRIPTION
This doesn't solve any blocking issue for a project, but it doesn't bloat and definitely has a very common use case when writing game logic involving vectors.

One of countless applications would be: You calculate the strength with which an enemy entity is being knocked back, and then you want to update its velocity vector with that strength. Just being able to set the vectors length, also referred to as magnitude, with one method is a much nicer workflow than having to think about a more or less abstract calculation.

It is true that this can be worked around with a small amount of script code, however the sames goes for normalized(), rotated(), and so on, and needing to set a vector's length is no less common. It belongs to the set of functions that already are in the current API. I imagine users coming to Godot that have used other vector libs are easily confused as to why a function for setting the angle is there, but one to set the length is missing.

Correlated issue:
#9206 