### PR TITLE
Allow to rename animation just after it was duplicated in Editor

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -433,7 +433,9 @@ void AnimationPlayerEditor::_animation_remove() {
 	if (animation->get_item_count() == 0)
 		return;
 
-	delete_dialog->set_text(TTR("Delete Animation?"));
+	String current = animation->get_item_text(animation->get_selected());
+
+	delete_dialog->set_text(TTR("Delete Animation '" + current + "'?"));
 	delete_dialog->popup_centered();
 }
 
@@ -1135,7 +1137,9 @@ void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 		case TOOL_DUPLICATE_ANIM: {
 
 			_animation_duplicate();
-		} break;
+
+			[[fallthrough]]; // Allow immediate rename after animation is duplicated
+		}
 		case TOOL_RENAME_ANIM: {
 
 			_animation_rename();


### PR DESCRIPTION
What I am proposing are two very tiny quality-of-life improvements over AnimationPlayer EditorPlugin.

- right after 'Duplicate' is chosen, user is presented with dialog box where it's possible to rename that duplicate - instead of setting duplicate's name as: 'anim (copy)' and going again into that menu to pick 'Rename animation' option. 
I can't count how many times I was doing that while setting animations in Godot - so it may be valuable to other users too.

- when 'Delete' is picked under animation - it adds animation name to the dialog, just to visually confirm which animation user is about to delete

![animation](https://user-images.githubusercontent.com/1110337/78840808-07ee5200-79fc-11ea-8e98-0440a434e940.gif)
