### PR TITLE
GDScript callable constructor bug fix

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1594,6 +1594,7 @@ void Variant::get_constructor_list(Variant::Type p_type, List<MethodInfo> *p_lis
 		PropertyInfo pi;
 		pi.name = "from";
 		pi.type = Variant::Type(i);
+		pi.class_name = Variant::get_type_name(pi.type);
 		mi.arguments.push_back(pi);
 		mi.return_val.type = p_type;
 		p_list->push_back(mi);


### PR DESCRIPTION
partialy fix: #36444

fix: when the constructor argument is `self` it doesn't work

![callable-fix](https://user-images.githubusercontent.com/41085900/78858101-09923700-7a49-11ea-8113-58a4ed2ce499.JPG)