### PR TITLE
Change non-existent World to World3D

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1746,7 +1746,7 @@ void EditorNode::push_item(Object *p_object, const String &p_property, bool p_in
 
 void EditorNode::_save_default_environment() {
 
-	Ref<Environment> fallback = get_tree()->get_root()->get_world()->get_fallback_environment();
+	Ref<Environment> fallback = get_tree()->get_root()->get_world_3d()->get_fallback_environment();
 
 	if (fallback.is_valid() && fallback->get_path().is_resource_file()) {
 		Map<RES, bool> processed;

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -169,7 +169,7 @@ void EditorNode3DGizmo::set_spatial_node(Node3D *p_node) {
 
 void EditorNode3DGizmo::Instance::create_instance(Node3D *p_base, bool p_hidden) {
 
-	instance = RS::get_singleton()->instance_create2(mesh->get_rid(), p_base->get_world()->get_scenario());
+	instance = RS::get_singleton()->instance_create2(mesh->get_rid(), p_base->get_world_3d()->get_scenario());
 	RS::get_singleton()->instance_attach_object_instance_id(instance, p_base->get_instance_id());
 	if (skin_reference.is_valid()) {
 		RS::get_singleton()->instance_attach_skeleton(instance, skin_reference->get_skeleton());

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -117,9 +117,9 @@ MaterialEditor::MaterialEditor() {
 	add_child(vc);
 	vc->set_anchors_and_margins_preset(PRESET_WIDE);
 	viewport = memnew(SubViewport);
-	Ref<World3D> world;
-	world.instance();
-	viewport->set_world(world); //use own world
+	Ref<World3D> world_3d;
+	world_3d.instance();
+	viewport->set_world_3d(world_3d); //use own world
 	vc->add_child(viewport);
 	viewport->set_disable_input(true);
 	viewport->set_transparent_background(true);

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -116,9 +116,9 @@ void MeshEditor::_bind_methods() {
 MeshEditor::MeshEditor() {
 
 	viewport = memnew(SubViewport);
-	Ref<World3D> world;
-	world.instance();
-	viewport->set_world(world); //use own world
+	Ref<World3D> world_3d;
+	world_3d.instance();
+	viewport->set_world_3d(world_3d); //use own world
 	add_child(viewport);
 	viewport->set_disable_input(true);
 	viewport->set_msaa(Viewport::MSAA_2X);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -496,7 +496,7 @@ ObjectID Node3DEditorViewport::_select_ray(const Point2 &p_pos, bool p_append, b
 	Vector3 pos = _get_ray_pos(p_pos);
 	Vector2 shrinked_pos = p_pos / subviewport_container->get_stretch_shrink();
 
-	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_ray(pos, ray, get_tree()->get_root()->get_world()->get_scenario());
+	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_ray(pos, ray, get_tree()->get_root()->get_world_3d()->get_scenario());
 	Set<Ref<EditorNode3DGizmo>> found_gizmos;
 
 	Node *edited_scene = get_tree()->get_edited_scene_root();
@@ -563,7 +563,7 @@ void Node3DEditorViewport::_find_items_at_pos(const Point2 &p_pos, bool &r_inclu
 	Vector3 ray = _get_ray(p_pos);
 	Vector3 pos = _get_ray_pos(p_pos);
 
-	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_ray(pos, ray, get_tree()->get_root()->get_world()->get_scenario());
+	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_ray(pos, ray, get_tree()->get_root()->get_world_3d()->get_scenario());
 	Set<Ref<EditorNode3DGizmo>> found_gizmos;
 
 	r_includes_current = false;
@@ -686,7 +686,7 @@ void Node3DEditorViewport::_select_region() {
 		frustum.push_back(far);
 	}
 
-	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_convex(frustum, get_tree()->get_root()->get_world()->get_scenario());
+	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_convex(frustum, get_tree()->get_root()->get_world_3d()->get_scenario());
 	Vector<Node *> selected;
 
 	Node *edited_scene = get_tree()->get_edited_scene_root();
@@ -3123,35 +3123,35 @@ void Node3DEditorViewport::_init_gizmo_instance(int p_idx) {
 	for (int i = 0; i < 3; i++) {
 		move_gizmo_instance[i] = RS::get_singleton()->instance_create();
 		RS::get_singleton()->instance_set_base(move_gizmo_instance[i], spatial_editor->get_move_gizmo(i)->get_rid());
-		RS::get_singleton()->instance_set_scenario(move_gizmo_instance[i], get_tree()->get_root()->get_world()->get_scenario());
+		RS::get_singleton()->instance_set_scenario(move_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_visible(move_gizmo_instance[i], false);
 		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(move_gizmo_instance[i], RS::SHADOW_CASTING_SETTING_OFF);
 		RS::get_singleton()->instance_set_layer_mask(move_gizmo_instance[i], layer);
 
 		move_plane_gizmo_instance[i] = RS::get_singleton()->instance_create();
 		RS::get_singleton()->instance_set_base(move_plane_gizmo_instance[i], spatial_editor->get_move_plane_gizmo(i)->get_rid());
-		RS::get_singleton()->instance_set_scenario(move_plane_gizmo_instance[i], get_tree()->get_root()->get_world()->get_scenario());
+		RS::get_singleton()->instance_set_scenario(move_plane_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_visible(move_plane_gizmo_instance[i], false);
 		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(move_plane_gizmo_instance[i], RS::SHADOW_CASTING_SETTING_OFF);
 		RS::get_singleton()->instance_set_layer_mask(move_plane_gizmo_instance[i], layer);
 
 		rotate_gizmo_instance[i] = RS::get_singleton()->instance_create();
 		RS::get_singleton()->instance_set_base(rotate_gizmo_instance[i], spatial_editor->get_rotate_gizmo(i)->get_rid());
-		RS::get_singleton()->instance_set_scenario(rotate_gizmo_instance[i], get_tree()->get_root()->get_world()->get_scenario());
+		RS::get_singleton()->instance_set_scenario(rotate_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_visible(rotate_gizmo_instance[i], false);
 		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(rotate_gizmo_instance[i], RS::SHADOW_CASTING_SETTING_OFF);
 		RS::get_singleton()->instance_set_layer_mask(rotate_gizmo_instance[i], layer);
 
 		scale_gizmo_instance[i] = RS::get_singleton()->instance_create();
 		RS::get_singleton()->instance_set_base(scale_gizmo_instance[i], spatial_editor->get_scale_gizmo(i)->get_rid());
-		RS::get_singleton()->instance_set_scenario(scale_gizmo_instance[i], get_tree()->get_root()->get_world()->get_scenario());
+		RS::get_singleton()->instance_set_scenario(scale_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_visible(scale_gizmo_instance[i], false);
 		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(scale_gizmo_instance[i], RS::SHADOW_CASTING_SETTING_OFF);
 		RS::get_singleton()->instance_set_layer_mask(scale_gizmo_instance[i], layer);
 
 		scale_plane_gizmo_instance[i] = RS::get_singleton()->instance_create();
 		RS::get_singleton()->instance_set_base(scale_plane_gizmo_instance[i], spatial_editor->get_scale_plane_gizmo(i)->get_rid());
-		RS::get_singleton()->instance_set_scenario(scale_plane_gizmo_instance[i], get_tree()->get_root()->get_world()->get_scenario());
+		RS::get_singleton()->instance_set_scenario(scale_plane_gizmo_instance[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_visible(scale_plane_gizmo_instance[i], false);
 		RS::get_singleton()->instance_geometry_set_cast_shadows_setting(scale_plane_gizmo_instance[i], RS::SHADOW_CASTING_SETTING_OFF);
 		RS::get_singleton()->instance_set_layer_mask(scale_plane_gizmo_instance[i], layer);
@@ -3517,7 +3517,7 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos) const 
 	Vector3 world_ray = _get_ray(p_pos);
 	Vector3 world_pos = _get_ray_pos(p_pos);
 
-	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_ray(world_pos, world_ray, get_tree()->get_root()->get_world()->get_scenario());
+	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_ray(world_pos, world_ray, get_tree()->get_root()->get_world_3d()->get_scenario());
 	Set<Ref<EditorNode3DGizmo>> found_gizmos;
 
 	float closest_dist = MAX_DISTANCE;
@@ -4530,7 +4530,7 @@ Object *Node3DEditor::_get_editor_data(Object *p_what) {
 	Node3DEditorSelectedItem *si = memnew(Node3DEditorSelectedItem);
 
 	si->sp = sp;
-	si->sbox_instance = RenderingServer::get_singleton()->instance_create2(selection_box->get_rid(), sp->get_world()->get_scenario());
+	si->sbox_instance = RenderingServer::get_singleton()->instance_create2(selection_box->get_rid(), sp->get_world_3d()->get_scenario());
 	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(si->sbox_instance, RS::SHADOW_CASTING_SETTING_OFF);
 
 	return si;
@@ -5184,7 +5184,7 @@ void Node3DEditor::_init_indicators() {
 		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(origin, RenderingServer::PRIMITIVE_LINES, d);
 		RenderingServer::get_singleton()->mesh_surface_set_material(origin, 0, indicator_mat->get_rid());
 
-		origin_instance = RenderingServer::get_singleton()->instance_create2(origin, get_tree()->get_root()->get_world()->get_scenario());
+		origin_instance = RenderingServer::get_singleton()->instance_create2(origin, get_tree()->get_root()->get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_layer_mask(origin_instance, 1 << Node3DEditorViewport::GIZMO_GRID_LAYER);
 
 		RenderingServer::get_singleton()->instance_geometry_set_cast_shadows_setting(origin_instance, RS::SHADOW_CASTING_SETTING_OFF);
@@ -5559,7 +5559,7 @@ void Node3DEditor::_init_grid() {
 		d[RenderingServer::ARRAY_COLOR] = grid_colors[i];
 		RenderingServer::get_singleton()->mesh_add_surface_from_arrays(grid[i], RenderingServer::PRIMITIVE_LINES, d);
 		RenderingServer::get_singleton()->mesh_surface_set_material(grid[i], 0, indicator_mat->get_rid());
-		grid_instance[i] = RenderingServer::get_singleton()->instance_create2(grid[i], get_tree()->get_root()->get_world()->get_scenario());
+		grid_instance[i] = RenderingServer::get_singleton()->instance_create2(grid[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 
 		RenderingServer::get_singleton()->instance_set_visible(grid_instance[i], grid_visible[i]);
 		RenderingServer::get_singleton()->instance_geometry_set_cast_shadows_setting(grid_instance[i], RS::SHADOW_CASTING_SETTING_OFF);
@@ -5704,7 +5704,7 @@ void Node3DEditor::snap_selected_nodes_to_floor() {
 		}
 	}
 
-	PhysicsDirectSpaceState3D *ss = get_tree()->get_root()->get_world()->get_direct_space_state();
+	PhysicsDirectSpaceState3D *ss = get_tree()->get_root()->get_world_3d()->get_direct_space_state();
 	PhysicsDirectSpaceState3D::RayResult result;
 
 	Array keys = snap_data.keys();

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -46,7 +46,7 @@ void CSGShape3D::set_use_collision(bool p_enable) {
 		root_collision_instance = PhysicsServer3D::get_singleton()->body_create(PhysicsServer3D::BODY_MODE_STATIC);
 		PhysicsServer3D::get_singleton()->body_set_state(root_collision_instance, PhysicsServer3D::BODY_STATE_TRANSFORM, get_global_transform());
 		PhysicsServer3D::get_singleton()->body_add_shape(root_collision_instance, root_collision_shape->get_rid());
-		PhysicsServer3D::get_singleton()->body_set_space(root_collision_instance, get_world()->get_space());
+		PhysicsServer3D::get_singleton()->body_set_space(root_collision_instance, get_world_3d()->get_space());
 		PhysicsServer3D::get_singleton()->body_attach_object_instance_id(root_collision_instance, get_instance_id());
 		set_collision_layer(collision_layer);
 		set_collision_mask(collision_mask);
@@ -509,7 +509,7 @@ void CSGShape3D::_notification(int p_what) {
 			root_collision_instance = PhysicsServer3D::get_singleton()->body_create(PhysicsServer3D::BODY_MODE_STATIC);
 			PhysicsServer3D::get_singleton()->body_set_state(root_collision_instance, PhysicsServer3D::BODY_STATE_TRANSFORM, get_global_transform());
 			PhysicsServer3D::get_singleton()->body_add_shape(root_collision_instance, root_collision_shape->get_rid());
-			PhysicsServer3D::get_singleton()->body_set_space(root_collision_instance, get_world()->get_space());
+			PhysicsServer3D::get_singleton()->body_set_space(root_collision_instance, get_world_3d()->get_space());
 			PhysicsServer3D::get_singleton()->body_attach_object_instance_id(root_collision_instance, get_instance_id());
 			set_collision_layer(collision_layer);
 			set_collision_mask(collision_mask);

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -80,7 +80,7 @@ bool GridMap::_set(const StringName &p_name, const Variant &p_value) {
 			RS::get_singleton()->get_singleton()->instance_set_base(bm.instance, bm.mesh->get_rid());
 			RS::get_singleton()->instance_attach_object_instance_id(bm.instance, get_instance_id());
 			if (is_inside_tree()) {
-				RS::get_singleton()->instance_set_scenario(bm.instance, get_world()->get_scenario());
+				RS::get_singleton()->instance_set_scenario(bm.instance, get_world_3d()->get_scenario());
 				RS::get_singleton()->instance_set_transform(bm.instance, get_global_transform());
 			}
 			baked_meshes.push_back(bm);
@@ -536,7 +536,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 			RS::get_singleton()->instance_set_base(instance, mm);
 
 			if (is_inside_tree()) {
-				RS::get_singleton()->instance_set_scenario(instance, get_world()->get_scenario());
+				RS::get_singleton()->instance_set_scenario(instance, get_world_3d()->get_scenario());
 				RS::get_singleton()->instance_set_transform(instance, get_global_transform());
 			}
 
@@ -577,15 +577,15 @@ void GridMap::_octant_enter_world(const OctantKey &p_key) {
 	ERR_FAIL_COND(!octant_map.has(p_key));
 	Octant &g = *octant_map[p_key];
 	PhysicsServer3D::get_singleton()->body_set_state(g.static_body, PhysicsServer3D::BODY_STATE_TRANSFORM, get_global_transform());
-	PhysicsServer3D::get_singleton()->body_set_space(g.static_body, get_world()->get_space());
+	PhysicsServer3D::get_singleton()->body_set_space(g.static_body, get_world_3d()->get_space());
 
 	if (g.collision_debug_instance.is_valid()) {
-		RS::get_singleton()->instance_set_scenario(g.collision_debug_instance, get_world()->get_scenario());
+		RS::get_singleton()->instance_set_scenario(g.collision_debug_instance, get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_transform(g.collision_debug_instance, get_global_transform());
 	}
 
 	for (int i = 0; i < g.multimesh_instances.size(); i++) {
-		RS::get_singleton()->instance_set_scenario(g.multimesh_instances[i].instance, get_world()->get_scenario());
+		RS::get_singleton()->instance_set_scenario(g.multimesh_instances[i].instance, get_world_3d()->get_scenario());
 		RS::get_singleton()->instance_set_transform(g.multimesh_instances[i].instance, get_global_transform());
 	}
 
@@ -684,7 +684,7 @@ void GridMap::_notification(int p_what) {
 			}
 
 			for (int i = 0; i < baked_meshes.size(); i++) {
-				RS::get_singleton()->instance_set_scenario(baked_meshes[i].instance, get_world()->get_scenario());
+				RS::get_singleton()->instance_set_scenario(baked_meshes[i].instance, get_world_3d()->get_scenario());
 				RS::get_singleton()->instance_set_transform(baked_meshes[i].instance, get_global_transform());
 			}
 
@@ -1054,7 +1054,7 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 		RS::get_singleton()->get_singleton()->instance_set_base(bm.instance, bm.mesh->get_rid());
 		RS::get_singleton()->instance_attach_object_instance_id(bm.instance, get_instance_id());
 		if (is_inside_tree()) {
-			RS::get_singleton()->instance_set_scenario(bm.instance, get_world()->get_scenario());
+			RS::get_singleton()->instance_set_scenario(bm.instance, get_world_3d()->get_scenario());
 			RS::get_singleton()->instance_set_transform(bm.instance, get_global_transform());
 		}
 

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -556,7 +556,7 @@ void GridMapEditor::_set_clipboard_data() {
 				item.cell_item = itm;
 				item.grid_offset = Vector3(i, j, k) - selection.begin;
 				item.orientation = node->get_cell_item_orientation(i, j, k);
-				item.instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), get_tree()->get_root()->get_world()->get_scenario());
+				item.instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), get_tree()->get_root()->get_world_3d()->get_scenario());
 
 				clipboard_items.push_back(item);
 			}
@@ -1083,12 +1083,12 @@ void GridMapEditor::_notification(int p_what) {
 			for (int i = 0; i < 3; i++) {
 
 				grid[i] = RS::get_singleton()->mesh_create();
-				grid_instance[i] = RS::get_singleton()->instance_create2(grid[i], get_tree()->get_root()->get_world()->get_scenario());
-				selection_level_instance[i] = RenderingServer::get_singleton()->instance_create2(selection_level_mesh[i], get_tree()->get_root()->get_world()->get_scenario());
+				grid_instance[i] = RS::get_singleton()->instance_create2(grid[i], get_tree()->get_root()->get_world_3d()->get_scenario());
+				selection_level_instance[i] = RenderingServer::get_singleton()->instance_create2(selection_level_mesh[i], get_tree()->get_root()->get_world_3d()->get_scenario());
 			}
 
-			selection_instance = RenderingServer::get_singleton()->instance_create2(selection_mesh, get_tree()->get_root()->get_world()->get_scenario());
-			paste_instance = RenderingServer::get_singleton()->instance_create2(paste_mesh, get_tree()->get_root()->get_world()->get_scenario());
+			selection_instance = RenderingServer::get_singleton()->instance_create2(selection_mesh, get_tree()->get_root()->get_world_3d()->get_scenario());
+			paste_instance = RenderingServer::get_singleton()->instance_create2(paste_mesh, get_tree()->get_root()->get_world_3d()->get_scenario());
 
 			_update_selection_transform();
 			_update_paste_indicator();
@@ -1168,7 +1168,7 @@ void GridMapEditor::_update_cursor_instance() {
 			Ref<Mesh> mesh = node->get_mesh_library()->get_item_mesh(selected_palette);
 			if (!mesh.is_null() && mesh->get_rid().is_valid()) {
 
-				cursor_instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), get_tree()->get_root()->get_world()->get_scenario());
+				cursor_instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), get_tree()->get_root()->get_world_3d()->get_scenario());
 				RenderingServer::get_singleton()->instance_set_transform(cursor_instance, cursor_transform);
 			}
 		}

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -385,8 +385,8 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 				linear_velocity = velocity_tracker->get_tracked_linear_velocity();
 			}
 
-			Ref<World3D> world = get_world();
-			ERR_FAIL_COND(world.is_null());
+			Ref<World3D> world_3d = get_world_3d();
+			ERR_FAIL_COND(world_3d.is_null());
 
 			int new_output_count = 0;
 
@@ -396,7 +396,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 
 			//check if any area is diverting sound into a bus
 
-			PhysicsDirectSpaceState3D *space_state = PhysicsServer3D::get_singleton()->space_get_direct_state(world->get_space());
+			PhysicsDirectSpaceState3D *space_state = PhysicsServer3D::get_singleton()->space_get_direct_state(world_3d->get_space());
 
 			PhysicsDirectSpaceState3D::ShapeResult sr[MAX_INTERSECT_AREAS];
 
@@ -419,7 +419,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 			}
 
 			List<Camera3D *> cameras;
-			world->get_camera_list(&cameras);
+			world_3d->get_camera_list(&cameras);
 
 			for (List<Camera3D *>::Element *E = cameras.front(); E; E = E->next()) {
 

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -95,8 +95,8 @@ void Camera3D::_update_camera() {
 
 	get_viewport()->_camera_transform_changed_notify();
 
-	if (get_world().is_valid()) {
-		get_world()->_update_camera(this);
+	if (get_world_3d().is_valid()) {
+		get_world_3d()->_update_camera(this);
 	}
 }
 
@@ -144,12 +144,12 @@ void Camera3D::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_BECAME_CURRENT: {
 			if (viewport) {
-				viewport->find_world()->_register_camera(this);
+				viewport->find_world_3d()->_register_camera(this);
 			}
 		} break;
 		case NOTIFICATION_LOST_CURRENT: {
 			if (viewport) {
-				viewport->find_world()->_remove_camera(this);
+				viewport->find_world_3d()->_remove_camera(this);
 			}
 		} break;
 	}
@@ -743,7 +743,7 @@ void ClippedCamera3D::_notification(int p_what) {
 			return;
 		}
 
-		PhysicsDirectSpaceState3D *dspace = get_world()->get_direct_space_state();
+		PhysicsDirectSpaceState3D *dspace = get_world_3d()->get_direct_space_state();
 		ERR_FAIL_COND(!dspace); // most likely physics set to threads
 
 		Vector3 cam_fw = -get_global_transform().basis.get_axis(Vector3::AXIS_Z).normalized();

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -44,7 +44,7 @@ void CollisionObject3D::_notification(int p_what) {
 			else
 				PhysicsServer3D::get_singleton()->body_set_state(rid, PhysicsServer3D::BODY_STATE_TRANSFORM, get_global_transform());
 
-			RID space = get_world()->get_space();
+			RID space = get_world_3d()->get_space();
 			if (area) {
 				PhysicsServer3D::get_singleton()->area_set_space(rid, space);
 			} else

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -507,12 +507,12 @@ bool Node3D::is_set_as_toplevel() const {
 	return data.toplevel;
 }
 
-Ref<World3D> Node3D::get_world() const {
+Ref<World3D> Node3D::get_world_3d() const {
 
 	ERR_FAIL_COND_V(!is_inside_world(), Ref<World3D>());
 	ERR_FAIL_COND_V(!data.viewport, Ref<World3D>());
 
-	return data.viewport->find_world();
+	return data.viewport->find_world_3d();
 }
 
 void Node3D::_propagate_visibility_changed() {
@@ -756,7 +756,7 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_set_as_toplevel"), &Node3D::is_set_as_toplevel);
 	ClassDB::bind_method(D_METHOD("set_disable_scale", "disable"), &Node3D::set_disable_scale);
 	ClassDB::bind_method(D_METHOD("is_scale_disabled"), &Node3D::is_scale_disabled);
-	ClassDB::bind_method(D_METHOD("get_world"), &Node3D::get_world);
+	ClassDB::bind_method(D_METHOD("get_world_3d"), &Node3D::get_world_3d);
 
 	ClassDB::bind_method(D_METHOD("force_update_transform"), &Node3D::force_update_transform);
 

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -124,7 +124,7 @@ public:
 
 	Node3D *get_parent_spatial() const;
 
-	Ref<World3D> get_world() const;
+	Ref<World3D> get_world_3d() const;
 
 	void set_translation(const Vector3 &p_translation);
 	void set_rotation(const Vector3 &p_euler_rad);

--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -196,7 +196,7 @@ void RayCast3D::_notification(int p_what) {
 }
 
 void RayCast3D::_update_raycast_state() {
-	Ref<World3D> w3d = get_world();
+	Ref<World3D> w3d = get_world_3d();
 	ERR_FAIL_COND(w3d.is_null());
 
 	PhysicsDirectSpaceState3D *dss = PhysicsServer3D::get_singleton()->space_get_direct_state(w3d->get_space());

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -270,7 +270,7 @@ void SoftBody3D::_notification(int p_what) {
 				add_change_receptor(this);
 			}
 
-			RID space = get_world()->get_space();
+			RID space = get_world_3d()->get_space();
 			PhysicsServer3D::get_singleton()->soft_body_set_space(physics_rid, space);
 			prepare_physics_server();
 		} break;

--- a/scene/3d/spring_arm_3d.cpp
+++ b/scene/3d/spring_arm_3d.cpp
@@ -147,7 +147,7 @@ void SpringArm3D::process_spring() {
 	if (shape.is_null()) {
 		motion = Vector3(cast_direction * (spring_length));
 		PhysicsDirectSpaceState3D::RayResult r;
-		bool intersected = get_world()->get_direct_space_state()->intersect_ray(get_global_transform().origin, get_global_transform().origin + motion, r, excluded_objects, mask);
+		bool intersected = get_world_3d()->get_direct_space_state()->intersect_ray(get_global_transform().origin, get_global_transform().origin + motion, r, excluded_objects, mask);
 		if (intersected) {
 			float dist = get_global_transform().origin.distance_to(r.position);
 			dist -= margin;
@@ -155,7 +155,7 @@ void SpringArm3D::process_spring() {
 		}
 	} else {
 		motion = Vector3(cast_direction * spring_length);
-		get_world()->get_direct_space_state()->cast_motion(shape->get_rid(), get_global_transform(), motion, 0, motion_delta, motion_delta_unsafe, excluded_objects, mask);
+		get_world_3d()->get_direct_space_state()->cast_motion(shape->get_rid(), get_global_transform(), motion, 0, motion_delta, motion_delta_unsafe, excluded_objects, mask);
 	}
 
 	current_spring_length = spring_length * motion_delta;

--- a/scene/3d/visibility_notifier_3d.cpp
+++ b/scene/3d/visibility_notifier_3d.cpp
@@ -68,7 +68,7 @@ void VisibilityNotifier3D::set_aabb(const AABB &p_aabb) {
 	aabb = p_aabb;
 
 	if (is_inside_world()) {
-		get_world()->_update_notifier(this, get_global_transform().xform(aabb));
+		get_world_3d()->_update_notifier(this, get_global_transform().xform(aabb));
 	}
 
 	_change_notify("aabb");
@@ -85,15 +85,15 @@ void VisibilityNotifier3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_WORLD: {
 
-			get_world()->_register_notifier(this, get_global_transform().xform(aabb));
+			get_world_3d()->_register_notifier(this, get_global_transform().xform(aabb));
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 
-			get_world()->_update_notifier(this, get_global_transform().xform(aabb));
+			get_world_3d()->_update_notifier(this, get_global_transform().xform(aabb));
 		} break;
 		case NOTIFICATION_EXIT_WORLD: {
 
-			get_world()->_remove_notifier(this);
+			get_world_3d()->_remove_notifier(this);
 		} break;
 	}
 }

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -60,8 +60,8 @@ void VisualInstance3D::_notification(int p_what) {
 			if (skeleton)
 				RenderingServer::get_singleton()->instance_attach_skeleton( instance, skeleton->get_skeleton() );
 			*/
-			ERR_FAIL_COND(get_world().is_null());
-			RenderingServer::get_singleton()->instance_set_scenario(instance, get_world()->get_scenario());
+			ERR_FAIL_COND(get_world_3d().is_null());
+			RenderingServer::get_singleton()->instance_set_scenario(instance, get_world_3d()->get_scenario());
 			_update_visibility();
 
 		} break;

--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -36,50 +36,50 @@ void WorldEnvironment::_notification(int p_what) {
 	if (p_what == Node3D::NOTIFICATION_ENTER_WORLD || p_what == Node3D::NOTIFICATION_ENTER_TREE) {
 
 		if (environment.is_valid()) {
-			if (get_viewport()->find_world()->get_environment().is_valid()) {
+			if (get_viewport()->find_world_3d()->get_environment().is_valid()) {
 				WARN_PRINT("World already has an environment (Another WorldEnvironment?), overriding.");
 			}
-			get_viewport()->find_world()->set_environment(environment);
-			add_to_group("_world_environment_" + itos(get_viewport()->find_world()->get_scenario().get_id()));
+			get_viewport()->find_world_3d()->set_environment(environment);
+			add_to_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
 		}
 
 		if (camera_effects.is_valid()) {
-			if (get_viewport()->find_world()->get_camera_effects().is_valid()) {
+			if (get_viewport()->find_world_3d()->get_camera_effects().is_valid()) {
 				WARN_PRINT("World already has a camera effects (Another WorldEnvironment?), overriding.");
 			}
-			get_viewport()->find_world()->set_camera_effects(camera_effects);
-			add_to_group("_world_camera_effects_" + itos(get_viewport()->find_world()->get_scenario().get_id()));
+			get_viewport()->find_world_3d()->set_camera_effects(camera_effects);
+			add_to_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
 		}
 
 	} else if (p_what == Node3D::NOTIFICATION_EXIT_WORLD || p_what == Node3D::NOTIFICATION_EXIT_TREE) {
 
-		if (environment.is_valid() && get_viewport()->find_world()->get_environment() == environment) {
-			get_viewport()->find_world()->set_environment(Ref<Environment>());
-			remove_from_group("_world_environment_" + itos(get_viewport()->find_world()->get_scenario().get_id()));
+		if (environment.is_valid() && get_viewport()->find_world_3d()->get_environment() == environment) {
+			get_viewport()->find_world_3d()->set_environment(Ref<Environment>());
+			remove_from_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
 		}
 
-		if (camera_effects.is_valid() && get_viewport()->find_world()->get_camera_effects() == camera_effects) {
-			get_viewport()->find_world()->set_camera_effects(Ref<CameraEffects>());
-			remove_from_group("_world_camera_effects_" + itos(get_viewport()->find_world()->get_scenario().get_id()));
+		if (camera_effects.is_valid() && get_viewport()->find_world_3d()->get_camera_effects() == camera_effects) {
+			get_viewport()->find_world_3d()->set_camera_effects(Ref<CameraEffects>());
+			remove_from_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
 		}
 	}
 }
 
 void WorldEnvironment::set_environment(const Ref<Environment> &p_environment) {
 
-	if (is_inside_tree() && environment.is_valid() && get_viewport()->find_world()->get_environment() == environment) {
-		get_viewport()->find_world()->set_environment(Ref<Environment>());
-		remove_from_group("_world_environment_" + itos(get_viewport()->find_world()->get_scenario().get_id()));
+	if (is_inside_tree() && environment.is_valid() && get_viewport()->find_world_3d()->get_environment() == environment) {
+		get_viewport()->find_world_3d()->set_environment(Ref<Environment>());
+		remove_from_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
 		//clean up
 	}
 
 	environment = p_environment;
 	if (is_inside_tree() && environment.is_valid()) {
-		if (get_viewport()->find_world()->get_environment().is_valid()) {
+		if (get_viewport()->find_world_3d()->get_environment().is_valid()) {
 			WARN_PRINT("World already has an environment (Another WorldEnvironment?), overriding.");
 		}
-		get_viewport()->find_world()->set_environment(environment);
-		add_to_group("_world_environment_" + itos(get_viewport()->find_world()->get_scenario().get_id()));
+		get_viewport()->find_world_3d()->set_environment(environment);
+		add_to_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
 	}
 
 	update_configuration_warning();
@@ -92,19 +92,19 @@ Ref<Environment> WorldEnvironment::get_environment() const {
 
 void WorldEnvironment::set_camera_effects(const Ref<CameraEffects> &p_camera_effects) {
 
-	if (is_inside_tree() && camera_effects.is_valid() && get_viewport()->find_world()->get_camera_effects() == camera_effects) {
-		get_viewport()->find_world()->set_camera_effects(Ref<CameraEffects>());
-		remove_from_group("_world_camera_effects_" + itos(get_viewport()->find_world()->get_scenario().get_id()));
+	if (is_inside_tree() && camera_effects.is_valid() && get_viewport()->find_world_3d()->get_camera_effects() == camera_effects) {
+		get_viewport()->find_world_3d()->set_camera_effects(Ref<CameraEffects>());
+		remove_from_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
 		//clean up
 	}
 
 	camera_effects = p_camera_effects;
 	if (is_inside_tree() && camera_effects.is_valid()) {
-		if (get_viewport()->find_world()->get_camera_effects().is_valid()) {
+		if (get_viewport()->find_world_3d()->get_camera_effects().is_valid()) {
 			WARN_PRINT("World already has an camera_effects (Another WorldEnvironment?), overriding.");
 		}
-		get_viewport()->find_world()->set_camera_effects(camera_effects);
-		add_to_group("_world_camera_effects_" + itos(get_viewport()->find_world()->get_scenario().get_id()));
+		get_viewport()->find_world_3d()->set_camera_effects(camera_effects);
+		add_to_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
 	}
 
 	update_configuration_warning();
@@ -125,7 +125,7 @@ String WorldEnvironment::get_configuration_warning() const {
 		return String();
 
 	List<Node *> nodes;
-	get_tree()->get_nodes_in_group("_world_environment_" + itos(get_viewport()->find_world()->get_scenario().get_id()), &nodes);
+	get_tree()->get_nodes_in_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()), &nodes);
 
 	if (nodes.size() > 1) {
 		return TTR("Only one WorldEnvironment is allowed per scene (or set of instanced scenes).");

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -504,7 +504,7 @@ bool SceneTree::idle(float p_time) {
 		String env_path = ProjectSettings::get_singleton()->get("rendering/environment/default_environment");
 		env_path = env_path.strip_edges(); //user may have added a space or two
 		String cpath;
-		Ref<Environment> fallback = get_root()->get_world()->get_fallback_environment();
+		Ref<Environment> fallback = get_root()->get_world_3d()->get_fallback_environment();
 		if (fallback.is_valid()) {
 			cpath = fallback->get_path();
 		}
@@ -519,7 +519,7 @@ bool SceneTree::idle(float p_time) {
 			} else {
 				fallback.unref();
 			}
-			get_root()->get_world()->set_fallback_environment(fallback);
+			get_root()->get_world_3d()->set_fallback_environment(fallback);
 		}
 	}
 
@@ -1409,8 +1409,8 @@ SceneTree::SceneTree() {
 
 	root = memnew(Window);
 	root->set_name("root");
-	if (!root->get_world().is_valid())
-		root->set_world(Ref<World3D>(memnew(World3D)));
+	if (!root->get_world_3d().is_valid())
+		root->set_world_3d(Ref<World3D>(memnew(World3D)));
 
 	// Initialize network state
 	multiplayer_poll = true;
@@ -1447,7 +1447,7 @@ SceneTree::SceneTree() {
 		if (env_path != String()) {
 			Ref<Environment> env = ResourceLoader::load(env_path);
 			if (env.is_valid()) {
-				root->get_world()->set_fallback_environment(env);
+				root->get_world_3d()->set_fallback_environment(env);
 			} else {
 				if (Engine::get_singleton()->is_editor_hint()) {
 					//file was erased, clear the field.

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -254,8 +254,8 @@ private:
 	Map<ObjectID, uint64_t> physics_2d_mouseover;
 
 	Ref<World2D> world_2d;
-	Ref<World3D> world;
-	Ref<World3D> own_world;
+	Ref<World3D> world_3d;
+	Ref<World3D> own_world_3d;
 
 	Rect2i to_screen_rect;
 	StringName input_group;
@@ -431,7 +431,7 @@ private:
 
 	void _gui_set_root_order_dirty();
 
-	void _own_world_changed();
+	void _own_world_3d_changed();
 
 	friend class Window;
 
@@ -478,10 +478,10 @@ public:
 	Rect2 get_visible_rect() const;
 	RID get_viewport_rid() const;
 
-	void set_world(const Ref<World3D> &p_world);
+	void set_world_3d(const Ref<World3D> &p_world_3d);
 	void set_world_2d(const Ref<World2D> &p_world_2d);
-	Ref<World3D> get_world() const;
-	Ref<World3D> find_world() const;
+	Ref<World3D> get_world_3d() const;
+	Ref<World3D> find_world_3d() const;
 
 	Ref<World2D> get_world_2d() const;
 	Ref<World2D> find_world_2d() const;
@@ -520,8 +520,8 @@ public:
 	Vector2 get_camera_coords(const Vector2 &p_viewport_coords) const;
 	Vector2 get_camera_rect_size() const;
 
-	void set_use_own_world(bool p_world);
-	bool is_using_own_world() const;
+	void set_use_own_world_3d(bool p_world_3d);
+	bool is_using_own_world_3d() const;
 
 	void input_text(const String &p_text);
 	void input(const Ref<InputEvent> &p_event, bool p_local_coords = false);


### PR DESCRIPTION
Prevent from errors when clicking at Viewport node
```
Cannot get class 'World'.
```
also changed occurrences of ..world() to ...world_3d()