### PR TITLE
Ignore process serial number argument passed by macOS Gatekeeper.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -478,6 +478,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	I = args.front();
 	while (I) {
+#ifdef OSX_ENABLED
+		// Ignore the process serial number argument passed by macOS Gatekeeper.
+		// Otherwise, Godot would try to open a non-existent project on the first start and abort.
+		if (I->get().begins_with("-psn_")) {
+			I = I->next();
+			continue;
+		}
+#endif
 
 		List<String>::Element *N = I->next();
 


### PR DESCRIPTION
Ignore process serial number (`-psn_...`) command line argument passed by macOS Gatekeeper.

PSN is only passed on the first start of the downloaded app (.app bundle with `com.apple.quarantine` extended file attribute), confuses Godot, causing it to load non-existent project instead of project manager.

Fixes #37713
Probably fixes #37446, fixes #35383 and fixes #36616?