### PR TITLE
Fix Engine get_target_fps() returning float instead of int.

### DIFF
--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -60,7 +60,7 @@ void Engine::set_target_fps(int p_fps) {
 	_target_fps = p_fps > 0 ? p_fps : 0;
 }
 
-float Engine::get_target_fps() const {
+int Engine::get_target_fps() const {
 	return _target_fps;
 }
 

--- a/core/engine.h
+++ b/core/engine.h
@@ -86,7 +86,7 @@ public:
 	float get_physics_jitter_fix() const;
 
 	virtual void set_target_fps(int p_fps);
-	virtual float get_target_fps() const;
+	virtual int get_target_fps() const;
 
 	virtual float get_frames_per_second() const { return _fps; }
 


### PR DESCRIPTION
`_target_fps` is an `int`, and it's only ever used as an `int`; so `get_target_fps()` should return an `int`.