### PR TITLE
Fix loss of precision in X11 device info.

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -254,10 +254,10 @@ bool DisplayServerX11::_refresh_device_info() {
 		bool absolute_mode = false;
 		int resolution_x = 0;
 		int resolution_y = 0;
-		int range_min_x = 0;
-		int range_min_y = 0;
-		int range_max_x = 0;
-		int range_max_y = 0;
+		double range_min_x = 0;
+		double range_min_y = 0;
+		double range_max_x = 0;
+		double range_max_y = 0;
 		int pressure_resolution = 0;
 		int tilt_resolution_x = 0;
 		int tilt_resolution_y = 0;


### PR DESCRIPTION
`range_min_x`, `range_min_y`, `range_max_x` and `range_max_y` are used to extract the `min` and `max` values from the `XIValuatorClass`es of a device. However, based on the `XIQueryDevice`'s [man page](https://linux.die.net/man/3/xiquerydevice), these values are `double`s not `int`s.

This is unlikely to be causing any issues, because, fortunately, they are currently only used to calculate a resolution in the unlikely event that the device doesn't report one:
https://github.com/godotengine/godot/blob/74d432117239d07d497bea5368600acee5ef5af4/platform/linuxbsd/display_server_x11.cpp#L299-L310
I doubt that this is a valid calculation, but that's for another day.
