### PR TITLE
Fix extra warnings in Android build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
 
     - name: Android export template (release_debug, Clang)
       stage: build
-      env: PLATFORM=android TOOLS=no TARGET=release_debug CACHE_NAME=${PLATFORM}-clang EXTRA_ARGS="werror=yes"
+      env: PLATFORM=android TOOLS=no TARGET=release_debug CACHE_NAME=${PLATFORM}-clang EXTRA_ARGS="warnings=extra werror=yes"
       os: linux
       compiler: clang
       addons:

--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -14,6 +14,14 @@ if env["platform"] == "android":
         thirdparty_dir + "/layers/generated",
     ]
     env.Prepend(CPPPATH=thirdparty_includes)
+
+    # Build Vulkan memory allocator
+    env_thirdparty = env.Clone()
+    env_thirdparty.disable_warnings()
+
+    thirdparty_dir = "#thirdparty/vulkan"
+    vma_sources = [thirdparty_dir + "/android/vk_mem_alloc.cpp"]
+    env_thirdparty.add_source_files(env.drivers_sources, vma_sources)
 elif env["builtin_vulkan"]:
     # Use bundled Vulkan headers
     thirdparty_dir = "#thirdparty/vulkan"

--- a/platform/android/vulkan/vulkan_context_android.cpp
+++ b/platform/android/vulkan/vulkan_context_android.cpp
@@ -31,14 +31,6 @@
 #include "vulkan_context_android.h"
 #include <vulkan/vulkan_android.h>
 
-#define VMA_IMPLEMENTATION
-#ifdef DEBUG_ENABLED
-#ifndef _DEBUG
-#define _DEBUG
-#endif
-#endif
-#include <vk_mem_alloc.h>
-
 const char *VulkanContextAndroid::_get_platform_surface_extension() const {
 	return VK_KHR_ANDROID_SURFACE_EXTENSION_NAME;
 }

--- a/thirdparty/vulkan/android/vk_mem_alloc.cpp
+++ b/thirdparty/vulkan/android/vk_mem_alloc.cpp
@@ -1,0 +1,8 @@
+#define VMA_IMPLEMENTATION
+#ifdef DEBUG_ENABLED
+#ifndef _DEBUG
+#define _DEBUG
+#endif
+#endif
+// Include memory allocator from Android NDK
+#include <vk_mem_alloc.h>


### PR DESCRIPTION
Disable some warnings in Vulkan include from NDK and re-enable `warnings=extra` in Travis build.

Based on https://github.com/godotengine/godot/pull/37729#discussion_r406477853
@akien-mga 