### PR TITLE
Remove unused argument in Theme method and expose missing methods

### DIFF
--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -120,6 +120,13 @@
 				Returns all the [Color]s as a [PackedStringArray] filled with each [Color]'s name, for use in [method get_color], if the theme has [code]node_type[/code].
 			</description>
 		</method>
+		<method name="get_color_type_list" qualifiers="const">
+			<return type="PackedStringArray">
+			</return>
+			<description>
+				Returns all the [Color] types as a [PackedStringArray] filled with unique type names, for use in [method get_color] and/or [method get_color_list].
+			</description>
+		</method>
 		<method name="get_constant" qualifiers="const">
 			<return type="int">
 			</return>
@@ -138,6 +145,13 @@
 			</argument>
 			<description>
 				Returns all the constants as a [PackedStringArray] filled with each constant's name, for use in [method get_constant], if the theme has [code]node_type[/code].
+			</description>
+		</method>
+		<method name="get_constant_type_list" qualifiers="const">
+			<return type="PackedStringArray">
+			</return>
+			<description>
+				Returns all the constant types as a [PackedStringArray] filled with unique type names, for use in [method get_constant] and/or [method get_constant_list].
 			</description>
 		</method>
 		<method name="get_font" qualifiers="const">
@@ -180,6 +194,13 @@
 				Returns all the font sizes as a [PackedStringArray] filled with each font size name, for use in [method get_font_size], if the theme has [code]node_type[/code].
 			</description>
 		</method>
+		<method name="get_font_type_list" qualifiers="const">
+			<return type="PackedStringArray">
+			</return>
+			<description>
+				Returns all the [Font] types as a [PackedStringArray] filled with unique type names, for use in [method get_font] and/or [method get_font_list].
+			</description>
+		</method>
 		<method name="get_icon" qualifiers="const">
 			<return type="Texture2D">
 			</return>
@@ -198,6 +219,13 @@
 			</argument>
 			<description>
 				Returns all the icons as a [PackedStringArray] filled with each [Texture2D]'s name, for use in [method get_icon], if the theme has [code]node_type[/code].
+			</description>
+		</method>
+		<method name="get_icon_type_list" qualifiers="const">
+			<return type="PackedStringArray">
+			</return>
+			<description>
+				Returns all the icon types as a [PackedStringArray] filled with unique type names, for use in [method get_icon] and/or [method get_icon_list].
 			</description>
 		</method>
 		<method name="get_stylebox" qualifiers="const">
@@ -220,20 +248,18 @@
 				Returns all the [StyleBox]s as a [PackedStringArray] filled with each [StyleBox]'s name, for use in [method get_stylebox], if the theme has [code]node_type[/code].
 			</description>
 		</method>
-		<method name="get_stylebox_types" qualifiers="const">
+		<method name="get_stylebox_type_list" qualifiers="const">
 			<return type="PackedStringArray">
 			</return>
 			<description>
-				Returns all the [StyleBox] types as a [PackedStringArray] filled with each [StyleBox]'s type, for use in [method get_stylebox] and/or [method get_stylebox_list], if the theme has [code]node_type[/code].
+				Returns all the [StyleBox] types as a [PackedStringArray] filled with unique type names, for use in [method get_stylebox] and/or [method get_stylebox_list].
 			</description>
 		</method>
 		<method name="get_type_list" qualifiers="const">
 			<return type="PackedStringArray">
 			</return>
-			<argument index="0" name="node_type" type="String">
-			</argument>
 			<description>
-				Returns all the types in [code]node_type[/code] as a [PackedStringArray] for use in any of the [code]get_*[/code] functions, if the theme has [code]node_type[/code].
+				Returns all the theme types as a [PackedStringArray] filled with unique type names, for use in other [code]get_*[/code] functions of this theme.
 			</description>
 		</method>
 		<method name="has_color" qualifiers="const">

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -51,6 +51,21 @@ Vector<String> Theme::_get_icon_list(const String &p_node_type) const {
 	return ilret;
 }
 
+Vector<String> Theme::_get_icon_type_list() const {
+	Vector<String> ilret;
+	List<StringName> il;
+
+	get_icon_type_list(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	String *w = ilret.ptrw();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
 Vector<String> Theme::_get_stylebox_list(const String &p_node_type) const {
 	Vector<String> ilret;
 	List<StringName> il;
@@ -66,11 +81,11 @@ Vector<String> Theme::_get_stylebox_list(const String &p_node_type) const {
 	return ilret;
 }
 
-Vector<String> Theme::_get_stylebox_types() const {
+Vector<String> Theme::_get_stylebox_type_list() const {
 	Vector<String> ilret;
 	List<StringName> il;
 
-	get_stylebox_types(&il);
+	get_stylebox_type_list(&il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -86,6 +101,21 @@ Vector<String> Theme::_get_font_list(const String &p_node_type) const {
 	List<StringName> il;
 
 	get_font_list(p_node_type, &il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	String *w = ilret.ptrw();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+Vector<String> Theme::_get_font_type_list() const {
+	Vector<String> ilret;
+	List<StringName> il;
+
+	get_font_type_list(&il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -126,6 +156,21 @@ Vector<String> Theme::_get_color_list(const String &p_node_type) const {
 	return ilret;
 }
 
+Vector<String> Theme::_get_color_type_list() const {
+	Vector<String> ilret;
+	List<StringName> il;
+
+	get_color_type_list(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	String *w = ilret.ptrw();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
 Vector<String> Theme::_get_constant_list(const String &p_node_type) const {
 	Vector<String> ilret;
 	List<StringName> il;
@@ -141,7 +186,22 @@ Vector<String> Theme::_get_constant_list(const String &p_node_type) const {
 	return ilret;
 }
 
-Vector<String> Theme::_get_type_list(const String &p_node_type) const {
+Vector<String> Theme::_get_constant_type_list() const {
+	Vector<String> ilret;
+	List<StringName> il;
+
+	get_constant_type_list(&il);
+	ilret.resize(il.size());
+
+	int i = 0;
+	String *w = ilret.ptrw();
+	for (List<StringName>::Element *E = il.front(); E; E = E->next(), i++) {
+		w[i] = E->get();
+	}
+	return ilret;
+}
+
+Vector<String> Theme::_get_type_list() const {
 	Vector<String> ilret;
 	List<StringName> il;
 
@@ -421,6 +481,15 @@ void Theme::get_icon_list(StringName p_node_type, List<StringName> *p_list) cons
 	}
 }
 
+void Theme::get_icon_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = icon_map.next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
 void Theme::set_stylebox(const StringName &p_name, const StringName &p_node_type, const Ref<StyleBox> &p_style) {
 	//ERR_FAIL_COND(p_style.is_null());
 
@@ -482,7 +551,7 @@ void Theme::get_stylebox_list(StringName p_node_type, List<StringName> *p_list) 
 	}
 }
 
-void Theme::get_stylebox_types(List<StringName> *p_list) const {
+void Theme::get_stylebox_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
 	const StringName *key = nullptr;
@@ -549,6 +618,15 @@ void Theme::get_font_list(StringName p_node_type, List<StringName> *p_list) cons
 	const StringName *key = nullptr;
 
 	while ((key = font_map[p_node_type].next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+void Theme::get_font_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = font_map.next(key))) {
 		p_list->push_back(*key);
 	}
 }
@@ -647,6 +725,15 @@ void Theme::get_color_list(StringName p_node_type, List<StringName> *p_list) con
 	}
 }
 
+void Theme::get_color_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = color_map.next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
 void Theme::set_constant(const StringName &p_name, const StringName &p_node_type, int p_constant) {
 	bool new_value = !constant_map.has(p_node_type) || !constant_map[p_node_type].has(p_name);
 	constant_map[p_node_type][p_name] = p_constant;
@@ -688,6 +775,15 @@ void Theme::get_constant_list(StringName p_node_type, List<StringName> *p_list) 
 	const StringName *key = nullptr;
 
 	while ((key = constant_map[p_node_type].next(key))) {
+		p_list->push_back(*key);
+	}
+}
+
+void Theme::get_constant_type_list(List<StringName> *p_list) const {
+	ERR_FAIL_NULL(p_list);
+
+	const StringName *key = nullptr;
+	while ((key = constant_map.next(key))) {
 		p_list->push_back(*key);
 	}
 }
@@ -840,19 +936,21 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_icon", "name", "node_type"), &Theme::has_icon);
 	ClassDB::bind_method(D_METHOD("clear_icon", "name", "node_type"), &Theme::clear_icon);
 	ClassDB::bind_method(D_METHOD("get_icon_list", "node_type"), &Theme::_get_icon_list);
+	ClassDB::bind_method(D_METHOD("get_icon_type_list"), &Theme::_get_icon_type_list);
 
 	ClassDB::bind_method(D_METHOD("set_stylebox", "name", "node_type", "texture"), &Theme::set_stylebox);
 	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "node_type"), &Theme::get_stylebox);
 	ClassDB::bind_method(D_METHOD("has_stylebox", "name", "node_type"), &Theme::has_stylebox);
 	ClassDB::bind_method(D_METHOD("clear_stylebox", "name", "node_type"), &Theme::clear_stylebox);
 	ClassDB::bind_method(D_METHOD("get_stylebox_list", "node_type"), &Theme::_get_stylebox_list);
-	ClassDB::bind_method(D_METHOD("get_stylebox_types"), &Theme::_get_stylebox_types);
+	ClassDB::bind_method(D_METHOD("get_stylebox_type_list"), &Theme::_get_stylebox_type_list);
 
 	ClassDB::bind_method(D_METHOD("set_font", "name", "node_type", "font"), &Theme::set_font);
 	ClassDB::bind_method(D_METHOD("get_font", "name", "node_type"), &Theme::get_font);
 	ClassDB::bind_method(D_METHOD("has_font", "name", "node_type"), &Theme::has_font);
 	ClassDB::bind_method(D_METHOD("clear_font", "name", "node_type"), &Theme::clear_font);
 	ClassDB::bind_method(D_METHOD("get_font_list", "node_type"), &Theme::_get_font_list);
+	ClassDB::bind_method(D_METHOD("get_font_type_list"), &Theme::_get_font_type_list);
 
 	ClassDB::bind_method(D_METHOD("set_font_size", "name", "node_type", "font_size"), &Theme::set_font_size);
 	ClassDB::bind_method(D_METHOD("get_font_size", "name", "node_type"), &Theme::get_font_size);
@@ -865,12 +963,14 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_color", "name", "node_type"), &Theme::has_color);
 	ClassDB::bind_method(D_METHOD("clear_color", "name", "node_type"), &Theme::clear_color);
 	ClassDB::bind_method(D_METHOD("get_color_list", "node_type"), &Theme::_get_color_list);
+	ClassDB::bind_method(D_METHOD("get_color_type_list"), &Theme::_get_color_type_list);
 
 	ClassDB::bind_method(D_METHOD("set_constant", "name", "node_type", "constant"), &Theme::set_constant);
 	ClassDB::bind_method(D_METHOD("get_constant", "name", "node_type"), &Theme::get_constant);
 	ClassDB::bind_method(D_METHOD("has_constant", "name", "node_type"), &Theme::has_constant);
 	ClassDB::bind_method(D_METHOD("clear_constant", "name", "node_type"), &Theme::clear_constant);
 	ClassDB::bind_method(D_METHOD("get_constant_list", "node_type"), &Theme::_get_constant_list);
+	ClassDB::bind_method(D_METHOD("get_constant_type_list"), &Theme::_get_constant_type_list);
 
 	ClassDB::bind_method(D_METHOD("clear"), &Theme::clear);
 
@@ -880,7 +980,7 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_default_font_size", "font_size"), &Theme::set_default_theme_font_size);
 	ClassDB::bind_method(D_METHOD("get_default_font_size"), &Theme::get_default_theme_font_size);
 
-	ClassDB::bind_method(D_METHOD("get_type_list", "node_type"), &Theme::_get_type_list);
+	ClassDB::bind_method(D_METHOD("get_type_list"), &Theme::_get_type_list);
 
 	ClassDB::bind_method("copy_default_theme", &Theme::copy_default_theme);
 	ClassDB::bind_method(D_METHOD("copy_theme", "other"), &Theme::copy_theme);

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -51,13 +51,17 @@ class Theme : public Resource {
 	HashMap<StringName, HashMap<StringName, int>> constant_map;
 
 	Vector<String> _get_icon_list(const String &p_node_type) const;
+	Vector<String> _get_icon_type_list() const;
 	Vector<String> _get_stylebox_list(const String &p_node_type) const;
-	Vector<String> _get_stylebox_types() const;
+	Vector<String> _get_stylebox_type_list() const;
 	Vector<String> _get_font_list(const String &p_node_type) const;
+	Vector<String> _get_font_type_list() const;
 	Vector<String> _get_font_size_list(const String &p_node_type) const;
 	Vector<String> _get_color_list(const String &p_node_type) const;
+	Vector<String> _get_color_type_list() const;
 	Vector<String> _get_constant_list(const String &p_node_type) const;
-	Vector<String> _get_type_list(const String &p_node_type) const;
+	Vector<String> _get_constant_type_list() const;
+	Vector<String> _get_type_list() const;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -99,19 +103,21 @@ public:
 	bool has_icon(const StringName &p_name, const StringName &p_node_type) const;
 	void clear_icon(const StringName &p_name, const StringName &p_node_type);
 	void get_icon_list(StringName p_node_type, List<StringName> *p_list) const;
+	void get_icon_type_list(List<StringName> *p_list) const;
 
 	void set_stylebox(const StringName &p_name, const StringName &p_node_type, const Ref<StyleBox> &p_style);
 	Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_stylebox(const StringName &p_name, const StringName &p_node_type) const;
 	void clear_stylebox(const StringName &p_name, const StringName &p_node_type);
 	void get_stylebox_list(StringName p_node_type, List<StringName> *p_list) const;
-	void get_stylebox_types(List<StringName> *p_list) const;
+	void get_stylebox_type_list(List<StringName> *p_list) const;
 
 	void set_font(const StringName &p_name, const StringName &p_node_type, const Ref<Font> &p_font);
 	Ref<Font> get_font(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_font(const StringName &p_name, const StringName &p_node_type) const;
 	void clear_font(const StringName &p_name, const StringName &p_node_type);
 	void get_font_list(StringName p_node_type, List<StringName> *p_list) const;
+	void get_font_type_list(List<StringName> *p_list) const;
 
 	void set_font_size(const StringName &p_name, const StringName &p_node_type, int p_font_size);
 	int get_font_size(const StringName &p_name, const StringName &p_node_type) const;
@@ -124,12 +130,14 @@ public:
 	bool has_color(const StringName &p_name, const StringName &p_node_type) const;
 	void clear_color(const StringName &p_name, const StringName &p_node_type);
 	void get_color_list(StringName p_node_type, List<StringName> *p_list) const;
+	void get_color_type_list(List<StringName> *p_list) const;
 
 	void set_constant(const StringName &p_name, const StringName &p_node_type, int p_constant);
 	int get_constant(const StringName &p_name, const StringName &p_node_type) const;
 	bool has_constant(const StringName &p_name, const StringName &p_node_type) const;
 	void clear_constant(const StringName &p_name, const StringName &p_node_type);
 	void get_constant_list(StringName p_node_type, List<StringName> *p_list) const;
+	void get_constant_type_list(List<StringName> *p_list) const;
 
 	void get_type_list(List<StringName> *p_list) const;
 


### PR DESCRIPTION
Fixed #36880. Breaks compatibility.

**Changed signature:**
* `Theme.get_type_list(String type)` -> `Theme.get_type_list()`

**Renamed:**
* `Theme.get_stylebox_types()` -> `Theme.get_stylebox_type_list()`

**Added:**
* `Theme.get_color_type_list()`
* `Theme.get_constant_type_list()`
* `Theme.get_font_type_list()`
* `Theme.get_icon_type_list()`

As the `type` argument is never used in `get_type_list`, I've removed it, and fixed the documentation as well. I've also noticed, that there is a separate method to get types of styleboxes, but there are no methods for other entities. I've introduced them and named all of them to match `get_type_list`, for consistency. New methods are new to the engine as well and can be used internally, if one requires them.

Due to the removed argument and the renamed function this is a breaking change.

<details>
<summary>Test script</summary>

```swift
tool
extends EditorScript

func _run():
	var theme = Theme.new()
	theme.set_color("red_color", "FirstType", Color.red)
	theme.set_color("green_color", "FirstType", Color.green)
	theme.set_color("blue_color", "SecondType", Color.blue)
	
	theme.set_constant("what_const", "FirstType", 3)
	theme.set_constant("this_const", "ThirdType", 4)
	
	theme.set_font("some_font", "FontType", null)
	
	theme.set_icon("default_icon", "", null)
	theme.set_icon("custom_icon", "IconsType", null)
	
	theme.set_stylebox("panel_style", "Panels", StyleBoxFlat.new())
	theme.set_stylebox("box_style", "Panels", StyleBoxEmpty.new())
	
	var theme_types = theme.get_type_list()
	print("found theme types: ", theme_types.size())
	for type in theme_types:
		printt("type: ", type)
	
	var color_types = theme.get_color_type_list()
	print("found color types: ", color_types.size())
	for type in color_types:
		printt("type: ", type)
	
	var constant_types = theme.get_constant_type_list()
	print("found constant types: ", constant_types.size())
	for type in constant_types:
		printt("type: ", type)
	
	var font_types = theme.get_font_type_list()
	print("found font types: ", font_types.size())
	for type in font_types:
		printt("type: ", type)
	
	var icon_types = theme.get_icon_type_list()
	print("found icon types: ", icon_types.size())
	for type in icon_types:
		printt("type: ", type)
	
	var stylebox_types = theme.get_stylebox_type_list()
	print("found stylebox types: ", stylebox_types.size())
	for type in stylebox_types:
		printt("type: ", type)
```
</details>

<details>
<summary>Test output (formatted for readability)</summary>

> found theme types: 7
type: 	
type: 	IconsType
type: 	FirstType
type: 	SecondType
type: 	ThirdType
type: 	FontType
type: 	Panels

> found color types: 2
type:	SecondType
type:	FirstType

> found constant types: 2
type: 	ThirdType
type: 	FirstType

> found font types: 1
type: 	FontType

> found icon types: 2
type: 	
type: 	IconsType

> found stylebox types: 1
type: 	Panels
</details>