### PR TITLE
Allow for easier editing of rect CollisionShape2D

### DIFF
--- a/editor/plugins/collision_shape_2d_editor_plugin.h
+++ b/editor/plugins/collision_shape_2d_editor_plugin.h
@@ -52,6 +52,17 @@ class CollisionShape2DEditor : public Control {
 		SEGMENT_SHAPE
 	};
 
+	const Point2 RECT_HANDLES[8] = {
+		Point2(1, 0),
+		Point2(1, 1),
+		Point2(0, 1),
+		Point2(-1, 1),
+		Point2(-1, 0),
+		Point2(-1, -1),
+		Point2(0, -1),
+		Point2(1, -1),
+	};
+
 	EditorNode *editor;
 	UndoRedo *undo_redo;
 	CanvasItemEditor *canvas_item_editor;
@@ -63,6 +74,8 @@ class CollisionShape2DEditor : public Control {
 	int edit_handle;
 	bool pressed;
 	Variant original;
+	Transform2D original_transform;
+	Point2 last_point;
 
 	Variant get_handle_value(int idx) const;
 	void set_handle(int idx, Point2 &p_point);


### PR DESCRIPTION
Closes the 2D part of https://github.com/godotengine/godot-proposals/issues/452
![Y5gobqoTVe](https://user-images.githubusercontent.com/2223172/79002203-3e3ce600-7b50-11ea-92bc-25ea7d75e7ab.gif)
You can get old behavior with Alt.