### PR TITLE
control node global rect scale fix

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1756,14 +1756,14 @@ Size2 Control::get_size() const {
 
 Rect2 Control::get_global_rect() const {
 
-	return Rect2(get_global_position(), get_size());
+	return Rect2(get_global_position(), get_size() * get_global_transform().get_scale());
 }
 
 Rect2 Control::get_screen_rect() const {
 
 	ERR_FAIL_COND_V(!is_inside_tree(), Rect2());
 
-	Rect2 r(get_global_position(), get_size());
+	Rect2 r(get_global_position(), get_size() * get_global_transform().get_scale());
 
 	Window *w = Object::cast_to<Window>(get_viewport());
 	if (w && !w->is_embedding_subwindows()) {


### PR DESCRIPTION
fix: https://godotengine.org/qa/66963/how-get-the-scaled-rect-of-control-node-the-child-of-node2d-is control node `get_global_rect()` returns global position and local size

steps to reproduce:
- create scene tree like in the picture
- set `Node2D2` scale to `.5, .5`
- attach the script to both color rect
```gdscript
func _ready():
	print( name, ' local_size  : ', get_rect().size )
	print( name, ' global_size : ', get_global_rect().size )
```
![rect size](https://user-images.githubusercontent.com/41085900/79011004-bae7b880-7b80-11ea-8e7c-faa5cf7d3039.JPG)

