### PR TITLE
solved ctrl + alt + special character Issue #6851

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -569,7 +569,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 
 			if (handled) {
 				accept_event();
-			} else if (!k->get_command()) {
+			} else if (!k->get_command() || (k->get_command() && k->get_alt())) {
 				if (k->get_unicode() >= 32 && k->get_keycode() != KEY_DELETE) {
 
 					if (editable) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3762,7 +3762,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			return;
 		}
 
-		if (!keycode_handled && !k->get_command()) { // For German keyboards.
+		if (!keycode_handled && (!k->get_command() || (k->get_command() && k->get_alt()))) { // For German keyboards.
 
 			if (k->get_unicode() >= 32) {
 


### PR DESCRIPTION
Fixes #6851

If ctrl was pressed the unicode got ignored.
To solve this I added an additional condition to the If statement.

I may have missed some files that also need to be changed

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/29399.*