### PR TITLE
Fix SSS affecting Sky

### DIFF
--- a/servers/rendering/rasterizer_rd/shaders/sky.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/sky.glsl
@@ -178,4 +178,10 @@ FRAGMENT_SHADER_CODE
 
 	frag_color.rgb = color * params.position_multiplier.w;
 	frag_color.a = alpha;
+
+	// Blending is disabled for Sky, so alpha doesn't blend
+	// alpha is used for subsurface scattering so make sure it doesn't get applied to Sky
+	if (!AT_CUBEMAP_PASS && !AT_HALF_RES_PASS && !AT_QUARTER_RES_PASS) {
+		frag_color.a = 0.0;
+	}
 }


### PR DESCRIPTION
Fixes: #37597

SSS uses the alpha channel of the renderbuffer for storing strength. A value of ``1`` is full strength, sky by default was storing ``1.0`` in ``ALPHA``. This change forces ``ALPHA`` to ``0.0`` when rendering to the main renderbuffer, and then allows writing to ``ALPHA`` otherwise.