### PR TITLE
Improve consistency in file order

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -506,7 +506,7 @@ bool EditorFileSystem::_update_scan_actions() {
 			case ItemAction::ACTION_DIR_ADD: {
 				int idx = 0;
 				for (int i = 0; i < ia.dir->subdirs.size(); i++) {
-					if (ia.new_dir->name < ia.dir->subdirs[i]->name) {
+					if (ia.new_dir->name.naturalnocasecmp_to(ia.dir->subdirs[i]->name) < 0) {
 						break;
 					}
 					idx++;
@@ -528,7 +528,7 @@ bool EditorFileSystem::_update_scan_actions() {
 			case ItemAction::ACTION_FILE_ADD: {
 				int idx = 0;
 				for (int i = 0; i < ia.dir->files.size(); i++) {
-					if (ia.new_file->file < ia.dir->files[i]->file) {
+					if (ia.new_file->file.naturalnocasecmp_to(ia.dir->files[i]->file) < 0) {
 						break;
 					}
 					idx++;
@@ -713,7 +713,7 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, DirAccess
 
 				int idx2 = 0;
 				for (int i = 0; i < p_dir->subdirs.size(); i++) {
-					if (efd->name < p_dir->subdirs[i]->name) {
+					if (efd->name.naturalnocasecmp_to(p_dir->subdirs[i]->name) < 0) {
 						break;
 					}
 					idx2++;
@@ -1245,7 +1245,7 @@ bool EditorFileSystem::_find_file(const String &p_file, EditorFileSystemDirector
 
 			int idx2 = 0;
 			for (int j = 0; j < fs->get_subdir_count(); j++) {
-				if (efsd->name < fs->get_subdir(j)->get_name()) {
+				if (efsd->name.naturalnocasecmp_to(fs->get_subdir(j)->get_name()) < 0) {
 					break;
 				}
 				idx2++;
@@ -1481,7 +1481,7 @@ void EditorFileSystem::update_file(const String &p_file) {
 		String file_name = p_file.get_file();
 
 		for (int i = 0; i < fs->files.size(); i++) {
-			if (file_name < fs->files[i]->file) {
+			if (p_file.naturalnocasecmp_to(fs->files[i]->file) < 0) {
 				break;
 			}
 			idx++;

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -860,7 +860,6 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 				file_list.push_back(fi);
 			}
 		}
-		file_list.sort();
 	}
 
 	// Sort the file list if needed.

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1677,7 +1677,7 @@ struct _ScriptEditorItemData {
 			if (sort_key == id.sort_key) {
 				return index < id.index;
 			} else {
-				return sort_key < id.sort_key;
+				return sort_key.naturalnocasecmp_to(id.sort_key) < 0;
 			}
 		} else {
 			return category < id.category;


### PR DESCRIPTION
Fixes #37721 by ensuring that files in EditorFileSystem and ScriptEditor are sorted using NaturalNoCaseComparator. Since EditorFileSystem will always be correctly sorted, no additional sorting is required in i.e. FileSystemDock