### PR TITLE
Fix add_force in Godot Physics RigidBody

### DIFF
--- a/servers/physics_3d/body_3d_sw.h
+++ b/servers/physics_3d/body_3d_sw.h
@@ -257,7 +257,7 @@ public:
 	_FORCE_INLINE_ void add_force(const Vector3 &p_force, const Vector3 &p_pos) {
 
 		applied_force += p_force;
-		applied_torque += p_pos.cross(p_force);
+		applied_torque += (p_pos - center_of_mass).cross(p_force);
 	}
 
 	_FORCE_INLINE_ void add_torque(const Vector3 &p_torque) {


### PR DESCRIPTION
Now takes the center of mass into account for calculating the applied torque, like `apply_impulse` does.