### PR TITLE
More details in Rigid Body add_force documentation

### DIFF
--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -28,7 +28,7 @@
 			<argument index="0" name="force" type="Vector3">
 			</argument>
 			<description>
-				Adds a constant directional force without affecting rotation.
+				Adds a constant directional force (i.e. acceleration) without affecting rotation.
 				This is equivalent to [code]add_force(force, Vector3(0,0,0))[/code].
 			</description>
 		</method>
@@ -40,7 +40,8 @@
 			<argument index="1" name="position" type="Vector3">
 			</argument>
 			<description>
-				Adds a constant force (i.e. acceleration).
+				Adds a constant directional force (i.e. acceleration).
+				The position uses the rotation of the global coordinate system, but is centered at the object's origin.
 			</description>
 		</method>
 		<method name="add_torque">


### PR DESCRIPTION
Specifies that `add_force` position is in local space among other details.

Documentation is now similar for `add_force`, `add_central_force`, `apply_impulse`, `apply_central_impulse`.