### PR TITLE
Operator overloading implemented in GDScript

### DIFF
--- a/core/variant.h
+++ b/core/variant.h
@@ -408,6 +408,9 @@ public:
 	};
 
 	static String get_operator_name(Operator p_op);
+	static StringName get_op_overload_name(Operator p_op);
+	static StringName get_op_reflection_name(Operator p_op);
+	static bool is_op_unary(Operator p_op);
 	static void evaluate(const Operator &p_op, const Variant &p_a, const Variant &p_b, Variant &r_ret, bool &r_valid);
 	static _FORCE_INLINE_ Variant evaluate(const Operator &p_op, const Variant &p_a, const Variant &p_b) {
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -756,6 +756,33 @@ void GDScript::_bind_methods() {
 	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "new", &GDScript::_new, MethodInfo("new"));
 
 	ClassDB::bind_method(D_METHOD("get_as_byte_code"), &GDScript::get_as_byte_code);
+
+	for (int i = 0; i < Variant::Operator::OP_MAX; i++) {
+		Variant::Operator op = (Variant::Operator)i;
+		bool is_unary = Variant::is_op_unary(op);
+		bool is_op_boolean = (op == Variant::OP_EQUAL ||
+							  op == Variant::OP_NOT_EQUAL ||
+							  op == Variant::OP_LESS ||
+							  op == Variant::OP_LESS_EQUAL ||
+							  op == Variant::OP_GREATER ||
+							  op == Variant::OP_GREATER_EQUAL ||
+							  op == Variant::OP_IN ||
+							  op == Variant::OP_AND ||
+							  op == Variant::OP_OR ||
+							  op == Variant::OP_XOR ||
+							  op == Variant::OP_NOT);
+		StringName overload_name = Variant::get_op_overload_name(op);
+
+		PropertyInfo ret_value;
+		ret_value.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
+		if (is_unary) {
+			BIND_VMETHOD(MethodInfo(ret_value, overload_name));
+		} else if (is_op_boolean) {
+			BIND_VMETHOD(MethodInfo(Variant::BOOL, overload_name, PropertyInfo()));
+		} else {
+			BIND_VMETHOD(MethodInfo(ret_value, overload_name, PropertyInfo()));
+		}
+	}
 }
 
 Vector<uint8_t> GDScript::get_as_byte_code() const {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -638,6 +638,7 @@ private:
 	Node *_get_default_value_for_type(const DataType &p_type, int p_line = -1);
 
 	DataType _reduce_node_type(Node *p_node);
+	DataType _reduce_binary_op_overload_type(const OperatorNode *p_op);
 	DataType _reduce_function_call_type(const OperatorNode *p_call);
 	DataType _reduce_identifier_type(const DataType *p_base_type, const StringName &p_identifier, int p_line, bool p_is_indexing);
 	void _check_class_level_types(ClassNode *p_class);


### PR DESCRIPTION
## Motivation
GDScript already have some operator overloading [setget](https://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_basics.html#setters-getters), [_to_string](https://docs.godotengine.org/en/latest/classes/class_object.html#class-object-method-to-string), [custom iterators](https://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_advanced.html#custom-iterators) but it's incomplete without overloading other basic operators. And having them is more object oriented way to provide a clean code base of godot.
 `a.multiply(b).add(a.divide(b))` can be written as `(a * b) + (a / b)`

## Detail
**EDIT: every overload behaves like in python 3 since my last commit**

If an operator ( binary or unaray ) is called with **at least one** `Variant::OBJECT` type it'll call the operator overloading method if exists, `o1 + o2`  is equivalent to `o1._add(o2)` like [python's magic methods](https://rszalski.github.io/magicmethods/). with the implementation I've included 2 concepts of overloading
**1. reflection:** 
 case `o1 + o2` -> it'll check `o1._add(o2)` if the method not exists check `o2._radd(o1)`
**2. delegance:**
 since the rich comparison removed from python 2.7 for some reason, I've removed it from my last commit and now it only use delegance for `==` and `!=` (`a != b` is equ `!(a==b)` and vice versa) just like python 3

## Parsing, Type checking & Error handling
Every comparison operator overloading returns boolean, and unaray operation can't contains any argument, binary operation must contain 2 arguments and the type, and return type could be dynamic variant or static type, if a it's a binary operation and not comparison try reflection for overload existence check. These grammars have added to the parser, and violation of the above rules makes parser errors.

## Usage
```gdscript
class Vect:
	var x:float = 0;
	var y:float = 0;
	
	static func new_vect(x:float, y:float)->Vect:
		var ret:Vect = Vect.new();
		ret.x = x; ret.y = y;
		return ret;

	func _to_string():
		return 'Vect(' + str(x) + ', ' + str(y) + ')'
	
	func _add(other:Vect)->Vect:
		return new_vect(x + other.x, y + other.y)
	
	func _mul(other:Vect)->Vect:
		return new_vect(x * other.x, y * other.y)
	
	func _negate()->Vect:
		return new_vect(-x, -y)

var v1 := Vect.new_vect(1, 2)
var v2 := Vect.new_vect(3, 4)

func _ready():
	print(' v1 = ', v1)
	print(' v2 = ', v2, '\n')
	print(' v1 + v2  = ', v1 + v2)
	print(' v1 * v2  = ', v1 * v2)
	print('-v1 + v2  = ', -v1 + v2)
```
output
```
--- Debugging process started ---
Godot Engine v4.0.dev.custom_build.385d17703 - https://godotengine.org
 
 v1 = Vect(1, 2)
 v2 = Vect(3, 4)

 v1 + v2  = Vect(4, 6)
 v1 * v2  = Vect(3, 8)
-v1 + v2  = Vect(2, 2)
```
