### PR TITLE
FIX CodeTextEditor not respecting focus in _input

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -657,7 +657,7 @@ FindReplaceBar::FindReplaceBar() {
 // be handled too late if they weren't handled here.
 void CodeTextEditor::_input(const Ref<InputEvent> &event) {
 	const Ref<InputEventKey> key_event = event;
-	if (!key_event.is_valid() || !key_event->is_pressed()) {
+	if (!key_event.is_valid() || !key_event->is_pressed() || !text_editor->has_focus()) {
 		return;
 	}
 


### PR DESCRIPTION
fixes #37807 by checking if the code editor has keyboard focus before initiating actions based on code editor shortcuts.