### PR TITLE
Fixed crash caused by uninitialised variable

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3846,7 +3846,7 @@ void Node3DEditorViewport::drop_data_fw(const Point2 &p_point, const Variant &p_
 Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, EditorNode *p_editor, int p_index) {
 
 	cpu_time_history_index = 0;
-	cpu_time_history_index = 0;
+	gpu_time_history_index = 0;
 
 	_edit.mode = TRANSFORM_NONE;
 	_edit.plane = TRANSFORM_VIEW;


### PR DESCRIPTION
Crash happens when opening editor compiled with address sanitizer support.
uninitialised
https://github.com/godotengine/godot/blob/451d5bd49217e4b55221032e67a7e682e20dad67/editor/plugins/node_3d_editor_plugin.cpp#L2543

```
editor/plugins/node_3d_editor_plugin.cpp:2543:43: runtime error: index -1094795586 out of bounds for type 'float [20]'
handle_crash: Program crashed with signal 11
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] godots() [0x1758a1a] (/mnt/KubuntuWolne/godot/platform/linuxbsd/crash_handler_linuxbsd.cpp:54)
[2] /lib/x86_64-linux-gnu/libc.so.6(+0x46470) [0x7f6fc65a0470] (??:0)
[3] Node3DEditorViewport::_notification(int) (/mnt/KubuntuWolne/godot/editor/plugins/node_3d_editor_plugin.cpp:2543 (discriminator 3))
[4] Node3DEditorViewport::_notificationv(int, bool) (/mnt/KubuntuWolne/godot/editor/plugins/node_3d_editor_plugin.h:182 (discriminator 14))
[5] Object::notification(int, bool) (/mnt/KubuntuWolne/godot/core/object.cpp:915)
[6] SceneTree::_notify_group_pause(StringName const&, int) (/mnt/KubuntuWolne/godot/scene/main/scene_tree.cpp:842)
[7] SceneTree::idle(float) (/mnt/KubuntuWolne/godot/scene/main/scene_tree.cpp:457 (discriminator 2))
[8] Main::iteration() (/mnt/KubuntuWolne/godot/main/main.cpp:2151)
[9] OS_LinuxBSD::run() (/mnt/KubuntuWolne/godot/platform/linuxbsd/os_linuxbsd.cpp:259)
[10] godots(main+0x329) [0x17578df] (/mnt/KubuntuWolne/godot/platform/linuxbsd/godot_linuxbsd.cpp:57)
[11] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7f6fc65811e3] (??:0)
[12] godots(_start+0x2e) [0x17574fe] (??:?)
```