### PR TITLE
Add "undo_max_stack_size" property to TextEdit [3.2]

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7193,7 +7193,7 @@ void TextEdit::_bind_methods() {
 
 	GLOBAL_DEF("gui/timers/text_edit_idle_detect_sec", 3);
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/timers/text_edit_idle_detect_sec", PropertyInfo(Variant::REAL, "gui/timers/text_edit_idle_detect_sec", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater")); // No negative numbers.
-	GLOBAL_DEF("gui/common/text_edit_undo_stack_max_size", 128);
+	GLOBAL_DEF("gui/common/text_edit_undo_stack_max_size", 1024);
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/common/text_edit_undo_stack_max_size", PropertyInfo(Variant::INT, "gui/common/text_edit_undo_stack_max_size", PROPERTY_HINT_RANGE, "0,10000,1,or_greater")); // No negative numbers.
 }
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6222,6 +6222,17 @@ void TextEdit::set_undo_stack_max_size(int p_size) {
 	if (p_size < 0) {
 		p_size = 0;
 	}
+
+	// Pop front until undo stack no longer exceeds p_size.
+	while (undo_stack.size() > p_size) {
+		// Clear history if we're too far back.
+		if (undo_stack.front() == undo_stack_pos) {
+			clear_undo_history();
+			break;
+		}
+		undo_stack.pop_front();
+	}
+
 	undo_stack_max_size = p_size;
 }
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6212,6 +6212,21 @@ void TextEdit::_push_current_op() {
 	current_op.type = TextOperation::TYPE_NONE;
 	current_op.text = "";
 	current_op.chain_forward = false;
+
+	if (undo_stack.size() > undo_stack_max_size) {
+		undo_stack.pop_front();
+	}
+}
+
+void TextEdit::set_undo_stack_max_size(int p_size) {
+	if (p_size < 0) {
+		p_size = 0;
+	}
+	undo_stack_max_size = p_size;
+}
+
+int TextEdit::get_undo_stack_max_size() const {
+	return undo_stack_max_size;
 }
 
 void TextEdit::set_indent_using_spaces(const bool p_use_spaces) {
@@ -7079,6 +7094,8 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("undo"), &TextEdit::undo);
 	ClassDB::bind_method(D_METHOD("redo"), &TextEdit::redo);
 	ClassDB::bind_method(D_METHOD("clear_undo_history"), &TextEdit::clear_undo_history);
+	ClassDB::bind_method(D_METHOD("set_undo_stack_max_size", "size"), &TextEdit::set_undo_stack_max_size);
+	ClassDB::bind_method(D_METHOD("get_undo_stack_max_size"), &TextEdit::get_undo_stack_max_size);
 
 	ClassDB::bind_method(D_METHOD("set_show_line_numbers", "enable"), &TextEdit::set_show_line_numbers);
 	ClassDB::bind_method(D_METHOD("is_show_line_numbers_enabled"), &TextEdit::is_show_line_numbers_enabled);
@@ -7160,6 +7177,9 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "wrap_enabled"), "set_wrap_enabled", "is_wrap_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "scroll_vertical"), "set_v_scroll", "get_v_scroll");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "scroll_horizontal"), "set_h_scroll", "get_h_scroll");
+
+	ADD_GROUP("Undo", "undo_");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "undo_stack_max_size"), "set_undo_stack_max_size", "get_undo_stack_max_size");
 
 	ADD_GROUP("Minimap", "minimap_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "minimap_draw"), "draw_minimap", "is_drawing_minimap");
@@ -7268,6 +7288,7 @@ TextEdit::TextEdit() {
 
 	current_op.type = TextOperation::TYPE_NONE;
 	undo_enabled = true;
+	undo_stack_max_size = 64;
 	undo_stack_pos = NULL;
 	setting_text = false;
 	last_dblclk = 0;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -306,6 +306,7 @@ private:
 
 	List<TextOperation> undo_stack;
 	List<TextOperation>::Element *undo_stack_pos;
+	int undo_stack_max_size;
 
 	void _clear_redo();
 	void _do_text_op(const TextOperation &p_op, bool p_reverse);
@@ -712,6 +713,8 @@ public:
 	void undo();
 	void redo();
 	void clear_undo_history();
+	void set_undo_stack_max_size(int p_size);
+	int get_undo_stack_max_size() const;
 
 	void set_indent_using_spaces(const bool p_use_spaces);
 	bool is_indent_using_spaces() const;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -713,8 +713,6 @@ public:
 	void undo();
 	void redo();
 	void clear_undo_history();
-	void set_undo_stack_max_size(int p_size);
-	int get_undo_stack_max_size() const;
 
 	void set_indent_using_spaces(const bool p_use_spaces);
 	bool is_indent_using_spaces() const;


### PR DESCRIPTION
Previously, there was no memory limit on TextEdit's undo stack. This PR adds "undo_max_stack_size" as a property to TextEdit to prevent potential memory leaks.

This fixes #37838 on the 3.2 branch.