### PR TITLE
Assign zero to range when ConvexPolygonShape2D is empty.

### DIFF
--- a/servers/physics_2d/shape_2d_sw.h
+++ b/servers/physics_2d/shape_2d_sw.h
@@ -465,7 +465,11 @@ public:
 	virtual Variant get_data() const;
 
 	_FORCE_INLINE_ void project_range(const Vector2 &p_normal, const Transform2D &p_transform, real_t &r_min, real_t &r_max) const {
-		// no matter the angle, the box is mirrored anyway
+
+		if (!points || point_count <= 0) {
+			r_min = r_max = 0;
+			return;
+		}
 
 		r_min = r_max = p_normal.dot(p_transform.xform(points[0].pos));
 		for (int i = 1; i < point_count; i++) {


### PR DESCRIPTION
Prevents a null pointer dereference and an array index out of bounds. Results in an empty `ConvexPolygonShape2D` being treated as an empty shape.

Fixes #36533
