### PR TITLE
VisualScript callable nodes method_cache update fix

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2828,34 +2828,6 @@ void VisualScriptEditor::_remove_node(int p_id) {
 void VisualScriptEditor::_node_ports_changed(const String &p_func, int p_id) {
 
 	_update_graph(p_id);
-
-	//Updates the callable nodes of the selected function node
-	Ref<VisualScriptNode> node = script->get_node(p_func, p_id);
-
-	if (Object::cast_to<VisualScriptFunction>(node.ptr())) {
-
-		Ref<VisualScriptFunction> vsf = node;
-		List<StringName> funcs;
-		script->get_function_list(&funcs);
-
-		for (List<StringName>::Element *F = funcs.front(); F; F = F->next()) {
-
-			List<int> ids;
-			script->get_node_list(F->get(), &ids);
-
-			for (List<int>::Element *E = ids.front(); E; E = E->next()) {
-				Ref<VisualScriptNode> vsn = script->get_node(F->get(), E->get());
-				if (Object::cast_to<VisualScriptFunctionCall>(vsn.ptr())) {
-					Ref<VisualScriptFunctionCall> vsfc = vsn;
-					if (vsfc->get_function() == p_func) {
-						vsfc->_update_method_cache();
-						vsfc->_change_notify();
-						vsfc->emit_signal("ports_changed");
-					}
-				}
-			}
-		}
-	}
 }
 
 bool VisualScriptEditor::node_has_sequence_connections(const StringName &p_func, int p_id) {

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2828,6 +2828,34 @@ void VisualScriptEditor::_remove_node(int p_id) {
 void VisualScriptEditor::_node_ports_changed(const String &p_func, int p_id) {
 
 	_update_graph(p_id);
+
+	//Updates the callable nodes of the selected function node
+	Ref<VisualScriptNode> node = script->get_node(p_func, p_id);
+
+	if (Object::cast_to<VisualScriptFunction>(node.ptr())) {
+
+		Ref<VisualScriptFunction> vsf = node;
+		List<StringName> funcs;
+		script->get_function_list(&funcs);
+
+		for (List<StringName>::Element *F = funcs.front(); F; F = F->next()) {
+
+			List<int> ids;
+			script->get_node_list(F->get(), &ids);
+
+			for (List<int>::Element *E = ids.front(); E; E = E->next()) {
+				Ref<VisualScriptNode> vsn = script->get_node(F->get(), E->get());
+				if (Object::cast_to<VisualScriptFunctionCall>(vsn.ptr())) {
+					Ref<VisualScriptFunctionCall> vsfc = vsn;
+					if (vsfc->get_function() == p_func) {
+						vsfc->_update_method_cache();
+						vsfc->_change_notify();
+						vsfc->emit_signal("ports_changed");
+					}
+				}
+			}
+		}
+	}
 }
 
 bool VisualScriptEditor::node_has_sequence_connections(const StringName &p_func, int p_id) {

--- a/modules/visual_script/visual_script_func_nodes.h
+++ b/modules/visual_script/visual_script_func_nodes.h
@@ -70,7 +70,6 @@ private:
 	StringName _get_base_type() const;
 
 	MethodInfo method_cache;
-	void _update_method_cache();
 
 	void _set_argument_cache(const Dictionary &p_cache);
 	Dictionary _get_argument_cache() const;
@@ -125,6 +124,8 @@ public:
 
 	void set_rpc_call_mode(RPCCallMode p_mode);
 	RPCCallMode get_rpc_call_mode() const;
+
+	void _update_method_cache();
 
 	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance);
 

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -37,6 +37,7 @@
 #include "core/project_settings.h"
 #include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
+#include "visual_script_func_nodes.h"
 
 //////////////////////////////////////////
 ////////////////FUNCTION//////////////////
@@ -59,6 +60,7 @@ bool VisualScriptFunction::_set(const StringName &p_name, const Variant &p_value
 		}
 		ports_changed_notify();
 		_change_notify();
+		_update_callable_nodes();
 		return true;
 	}
 	if (String(p_name).begins_with("argument_")) {
@@ -70,6 +72,7 @@ bool VisualScriptFunction::_set(const StringName &p_name, const Variant &p_value
 			Variant::Type new_type = Variant::Type(int(p_value));
 			arguments.write[idx].type = new_type;
 			ports_changed_notify();
+			_update_callable_nodes();
 
 			return true;
 		}
@@ -78,6 +81,7 @@ bool VisualScriptFunction::_set(const StringName &p_name, const Variant &p_value
 
 			arguments.write[idx].name = p_value;
 			ports_changed_notify();
+			_update_callable_nodes();
 			return true;
 		}
 	}
@@ -100,6 +104,7 @@ bool VisualScriptFunction::_set(const StringName &p_name, const Variant &p_value
 	if (p_name == "sequenced/sequenced") {
 		sequenced = p_value;
 		ports_changed_notify();
+		_update_callable_nodes();
 		return true;
 	}
 
@@ -353,6 +358,34 @@ void VisualScriptFunction::set_stack_size(int p_size) {
 int VisualScriptFunction::get_stack_size() const {
 
 	return stack_size;
+}
+
+void VisualScriptFunction::_update_callable_nodes() {
+	Ref<VisualScript> vs = get_visual_script();
+
+	if (vs.ptr()) {
+		List<StringName> funcs;
+		vs->get_function_list(&funcs);
+
+		for (List<StringName>::Element *F = funcs.front(); F; F = F->next()) { // loop through all the functions
+
+			List<int> ids;
+			vs->get_node_list(F->get(), &ids);
+
+			for (List<int>::Element *E = ids.front(); E; E = E->next()) {
+				Ref<VisualScriptNode> node = vs->get_node(F->get(), E->get());
+
+				if (Object::cast_to<VisualScriptFunctionCall>(node.ptr())) {
+					Ref<VisualScriptFunctionCall> vsfc = node;
+					if (true) { //Only update this node's callable nodes
+						vsfc->_update_method_cache();
+						vsfc->_change_notify();
+						vsfc->emit_signal("ports_changed");
+					}
+				}
+			}
+		}
+	}
 }
 
 //////////////////////////////////////////

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -89,6 +89,8 @@ public:
 	void set_stack_size(int p_size);
 	int get_stack_size() const;
 
+	void _update_callable_nodes();
+
 	void set_return_type_enabled(bool p_returns);
 	bool is_return_type_enabled() const;
 


### PR DESCRIPTION
Issue referenced:  #37173 
**Bug:**- VisualScript callable nodes were not getting updated when the properties
 of their corresponding visualscript function nodes were changed.

**Reason**:- `method_cache` of the callable nodes was not getting updated when their corresponding function node was updated.

**Results after the fix**:-
![Demo](https://user-images.githubusercontent.com/41969735/79230181-d5bc7480-7e81-11ea-9173-13fec50065f3.gif)
