### PR TITLE
Git Hooks: Add support for GUI git clients.

### DIFF
--- a/misc/hooks/pre-commit-black
+++ b/misc/hooks/pre-commit-black
@@ -25,6 +25,15 @@ else
   READER=cat
 fi
 
+# Path to zenity
+ZENITY=`which zenity`
+
+# Path to xmessage
+XMSG=`which xmessage`
+
+# Path to powershell (Windows only)
+PWSH=`which powershell`
+
 ##################################################################
 # There should be no need to change anything below this line.
 
@@ -53,6 +62,19 @@ else
 fi
 
 if [ ! -x "$BLACK" ] ; then
+    if [ ! -t 1 ] ; then
+        if [ -x "$ZENITY" ] ; then
+            $ZENITY --error --title="Error" --text="Error: black executable not found."
+            exit 1
+        elif [ -x "$XMSG" ] ; then
+            $XMSG -center -title "Error" "Error: black executable not found."
+            exit 1
+        elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
+            winmessage="$(canonicalize_filename "./.git/hooks/winmessage.ps1")"
+            $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -center -title "Error" --text "Error: black executable not found."
+            exit 1
+        fi
+    fi
     printf "Error: black executable not found.\n"
     printf "Set the correct path in $(canonicalize_filename "$0").\n"
     exit 1
@@ -99,14 +121,62 @@ fi
 # a patch has been created, notify the user and exit
 printf "\nThe following differences were found between the code to commit "
 printf "and the black formatter rules:\n\n"
-$READER "$patch"
-printf "\n"
 
-# Allows us to read user input below, assigns stdin to keyboard
-exec < /dev/tty
+if [ -t 1 ] ; then
+    $READER "$patch"
+    printf "\n"
+    # Allows us to read user input below, assigns stdin to keyboard
+    exec < /dev/tty
+    terminal="1"
+else
+    cat "$patch"
+    printf "\n"
+    # Allows non zero zenity/powershell output
+    set +e
+    terminal="0"
+fi
 
 while true; do
-    read -p "Do you want to apply that patch (Y - Apply, N - Do not apply, S - Apply and stage files)? [Y/N/S] " yn
+    if [ $terminal = "0" ] ; then
+        if [ -x "$ZENITY" ] ; then
+            ans=$($ZENITY --text-info --filename="$patch" --width=800 --height=600 --title="Do you want to apply that patch?" --ok-label="Apply" --cancel-label="Do not apply" --extra-button="Apply and stage")
+            if [ "$?" = "0" ] ; then
+                yn="Y"
+            else
+                if [ "$ans" = "Apply and stage" ] ; then
+                    yn="S"
+                else
+                    yn="N"
+                fi
+            fi
+        elif [ -x "$XMSG" ] ; then
+            $XMSG -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
+            ans=$?
+            if [ "$ans" = "100" ] ; then
+                yn="Y"
+            elif [ "$ans" = "200" ] ; then
+                yn="S"
+            else
+                yn="N"
+            fi
+        elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
+            winmessage="$(canonicalize_filename "./.git/hooks/winmessage.ps1")"
+            $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
+            ans=$?
+            if [ "$ans" = "100" ] ; then
+                yn="Y"
+            elif [ "$ans" = "200" ] ; then
+                yn="S"
+            else
+                yn="N"
+            fi
+        else
+            printf "Error: zenity, xmessage, or powershell executable not found.\n"
+            exit 1
+        fi
+    else
+        read -p "Do you want to apply that patch (Y - Apply, N - Do not apply, S - Apply and stage files)? [Y/N/S] " yn
+    fi
     case $yn in
         [Yy] ) git apply $patch;
         printf "The patch was applied. You can now stage the changes and commit again.\n\n";

--- a/misc/hooks/pre-commit-clang-format
+++ b/misc/hooks/pre-commit-clang-format
@@ -38,6 +38,15 @@ else
   READER=cat
 fi
 
+# Path to zenity
+ZENITY=`which zenity`
+
+# Path to xmessage
+XMSG=`which xmessage`
+
+# Path to powershell (Windows only)
+PWSH=`which powershell`
+
 ##################################################################
 # There should be no need to change anything below this line.
 
@@ -66,6 +75,19 @@ else
 fi
 
 if [ ! -x "$CLANG_FORMAT" ] ; then
+    if [ ! -t 1 ] ; then
+        if [ -x "$ZENITY" ] ; then
+            $ZENITY --error --title="Error" --text="Error: clang-format executable not found."
+            exit 1
+        elif [ -x "$XMSG" ] ; then
+            $XMSG -center -title "Error" "Error: clang-format executable not found."
+            exit 1
+        elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
+            winmessage="$(canonicalize_filename "./.git/hooks/winmessage.ps1")"
+            $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -center -title "Error" --text "Error: clang-format executable not found."
+            exit 1
+        fi
+    fi
     printf "Error: clang-format executable not found.\n"
     printf "Set the correct path in $(canonicalize_filename "$0").\n"
     exit 1
@@ -117,14 +139,62 @@ fi
 # a patch has been created, notify the user and exit
 printf "\nThe following differences were found between the code to commit "
 printf "and the clang-format rules:\n\n"
-$READER "$patch"
-printf "\n"
 
-# Allows us to read user input below, assigns stdin to keyboard
-exec < /dev/tty
+if [ -t 1 ] ; then
+    $READER "$patch"
+    printf "\n"
+    # Allows us to read user input below, assigns stdin to keyboard
+    exec < /dev/tty
+    terminal="1"
+else
+    cat "$patch"
+    printf "\n"
+    # Allows non zero zenity/powershell output
+    set +e
+    terminal="0"
+fi
 
 while true; do
-    read -p "Do you want to apply that patch (Y - Apply, N - Do not apply, S - Apply and stage files)? [Y/N/S] " yn
+    if [ $terminal = "0" ] ; then
+        if [ -x "$ZENITY" ] ; then
+            ans=$($ZENITY --text-info --filename="$patch" --width=800 --height=600 --title="Do you want to apply that patch?" --ok-label="Apply" --cancel-label="Do not apply" --extra-button="Apply and stage")
+            if [ "$?" = "0" ] ; then
+                yn="Y"
+            else
+                if [ "$ans" = "Apply and stage" ] ; then
+                    yn="S"
+                else
+                    yn="N"
+                fi
+            fi
+        elif [ -x "$XMSG" ] ; then
+            $XMSG -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
+            ans=$?
+            if [ "$ans" = "100" ] ; then
+                yn="Y"
+            elif [ "$ans" = "200" ] ; then
+                yn="S"
+            else
+                yn="N"
+            fi
+        elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
+            winmessage="$(canonicalize_filename "./.git/hooks/winmessage.ps1")"
+            $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
+            ans=$?
+            if [ "$ans" = "100" ] ; then
+                yn="Y"
+            elif [ "$ans" = "200" ] ; then
+                yn="S"
+            else
+                yn="N"
+            fi
+        else
+            printf "Error: zenity, xmessage, or powershell executable not found.\n"
+            exit 1
+        fi
+    else
+        read -p "Do you want to apply that patch (Y - Apply, N - Do not apply, S - Apply and stage files)? [Y/N/S] " yn
+    fi
     case $yn in
         [Yy] ) git apply $patch;
         printf "The patch was applied. You can now stage the changes and commit again.\n\n";

--- a/misc/hooks/winmessage.ps1
+++ b/misc/hooks/winmessage.ps1
@@ -1,0 +1,103 @@
+Param (
+	[string]$file = "",
+	[string]$text = "",
+	[string]$buttons = "OK:0",
+	[string]$default = "",
+	[switch]$nearmouse = $false,
+	[switch]$center = $false,
+	[string]$geometry = "",
+	[int32]$timeout = 0,
+	[string]$title = "Message"
+)
+Add-Type -assembly System.Windows.Forms
+
+$global:Result = 0
+
+$main_form = New-Object System.Windows.Forms.Form
+$main_form.Text = $title
+
+$geometry_data = $geometry.Split("+")
+if ($geometry_data.Length -ge 1) {
+	$size_data = $geometry_data[0].Split("x")
+	if ($size_data.Length -eq 2) {
+		$main_form.Width = $size_data[0]
+		$main_form.Height = $size_data[1]
+	}
+}
+if ($geometry_data.Length -eq 3) {
+	$main_form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+	$main_form.Location = New-Object System.Drawing.Point($geometry_data[1], $geometry_data[2])
+}
+if ($nearmouse) {
+	$main_form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+	$main_form.Location = System.Windows.Forms.Cursor.Position
+}
+if ($center) {
+	$main_form.StartPosition = [System.Windows.Forms.FormStartPosition]::CenterScreen
+}
+
+$main_form.SuspendLayout()
+
+$button_panel = New-Object System.Windows.Forms.FlowLayoutPanel
+$button_panel.SuspendLayout()
+$button_panel.FlowDirection = [System.Windows.Forms.FlowDirection]::RightToLeft
+$button_panel.Dock = [System.Windows.Forms.DockStyle]::Bottom
+$button_panel.Autosize = $true
+
+if ($file -ne "") {
+	$text = [IO.File]::ReadAllText($file).replace("`n", "`r`n")
+}
+
+if ($text -ne "") {
+	$text_box = New-Object System.Windows.Forms.TextBox
+	$text_box.Multiline = $true
+	$text_box.ReadOnly = $true
+	$text_box.Autosize = $true
+	$text_box.Text = $text
+	$text_box.Select(0,0)
+	$text_box.Dock = [System.Windows.Forms.DockStyle]::Fill
+	$main_form.Controls.Add($text_box)
+}
+
+$buttons_array = $buttons.Split(",")
+foreach ($button in $buttons_array) {
+	$button_data = $button.Split(":")
+	$button_ctl = New-Object System.Windows.Forms.Button
+	if ($button_data.Length -eq 2) {
+		$button_ctl.Tag = $button_data[1]
+	} else {
+		$button_ctl.Tag = 100 + $buttons_array.IndexOf($button)
+	}
+	if ($default -eq $button_data[0]) {
+		$main_form.AcceptButton = $button_ctl
+	}
+	$button_ctl.Autosize = $true
+	$button_ctl.Text = $button_data[0]
+	$button_ctl.Add_Click(
+		{
+			Param($sender)
+			$global:Result = $sender.Tag
+			$main_form.Close()
+		}
+	)
+	$button_panel.Controls.Add($button_ctl)
+}
+$main_form.Controls.Add($button_panel)
+
+$button_panel.ResumeLayout($false)
+$main_form.ResumeLayout($false)
+
+if ($timeout -gt 0) {
+	$timer = New-Object System.Windows.Forms.Timer
+	$timer.Add_Tick(
+		{
+			$global:Result = 0
+			$main_form.Close()
+		}
+	)
+	$timer.Interval = $timeout
+	$timer.Start()
+}
+$dlg_res = $main_form.ShowDialog()
+
+[Environment]::Exit($global:Result)


### PR DESCRIPTION
GUI git clients unable to handle user input for the terminal and fail/hang on `exec < /dev/tty` call.

This PR:
* Adds `zenity`/`xmessage` and custom `Powershell` script based input dialogs for the hooks started from GUI clients, for hooks started from terminal input is unchanged.
* Forces plain text `cat` use for the GUI client logs, since escape codes aren't supported by most git GUI clients. 

<img width="943" alt="Screenshot 2020-04-14 at 16 37 18" src="https://user-images.githubusercontent.com/7645683/79231147-4ce80d80-7e6e-11ea-888f-50db4acb0223.png">

Tested with `Git Cola` and `QGit` clients on Linux, `Sourcetree` on macOS, `Git Extensions` on Windows, and terminal git on Linux, macOS and Windows.