### PR TITLE
Remove unnecessary check for zero determinant in Basis::orthonormalize().

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -77,10 +77,6 @@ void Basis::invert() {
 
 void Basis::orthonormalize() {
 
-#ifdef MATH_CHECKS
-	ERR_FAIL_COND(determinant() == 0);
-#endif
-
 	// Gram-Schmidt Process
 
 	Vector3 x = get_axis(0);


### PR DESCRIPTION
Basis::orthonormalize() doesn't require the determinant to be non-zero; so this check is unnecessary here.

Fixes #14864.