### PR TITLE
Add support for projectors in spot and omni lights.

### DIFF
--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -81,6 +81,7 @@ private:
 	bool editor_only;
 	void _update_visibility();
 	BakeMode bake_mode;
+	Ref<Texture2D> projector;
 
 	// bind helpers
 
@@ -124,6 +125,9 @@ public:
 
 	void set_bake_mode(BakeMode p_mode);
 	BakeMode get_bake_mode() const;
+
+	void set_projector(const Ref<Texture> &p_texture);
+	Ref<Texture2D> get_projector() const;
 
 	virtual AABB get_aabb() const;
 	virtual Vector<Face3> get_faces(uint32_t p_usage_flags) const;
@@ -195,6 +199,8 @@ protected:
 public:
 	void set_shadow_mode(ShadowMode p_mode);
 	ShadowMode get_shadow_mode() const;
+
+	virtual String get_configuration_warning() const;
 
 	OmniLight3D();
 };

--- a/servers/rendering/rasterizer.h
+++ b/servers/rendering/rasterizer.h
@@ -327,8 +327,8 @@ public:
 
 	virtual Size2 texture_size_with_proxy(RID p_proxy) = 0;
 
-	virtual void texture_add_to_decal_atlas(RID p_texture) = 0;
-	virtual void texture_remove_from_decal_atlas(RID p_texture) = 0;
+	virtual void texture_add_to_decal_atlas(RID p_texture, bool p_panorama_to_dp = false) = 0;
+	virtual void texture_remove_from_decal_atlas(RID p_texture, bool p_panorama_to_dp = false) = 0;
 
 	/* SHADER API */
 

--- a/servers/rendering/rasterizer_rd/rasterizer_effects_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_effects_rd.cpp
@@ -204,7 +204,7 @@ RID RasterizerEffectsRD::_get_compute_uniform_set_from_image_pair(RID p_texture1
 	return uniform_set;
 }
 
-void RasterizerEffectsRD::copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_uv_rect, RD::DrawListID p_draw_list, bool p_flip_y) {
+void RasterizerEffectsRD::copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_uv_rect, RD::DrawListID p_draw_list, bool p_flip_y, bool p_panorama) {
 
 	zeromem(&copy_to_fb.push_constant, sizeof(CopyToFbPushConstant));
 
@@ -219,7 +219,7 @@ void RasterizerEffectsRD::copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_f
 	}
 
 	RD::DrawListID draw_list = p_draw_list;
-	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, copy_to_fb.pipelines[COPY_TO_FB_COPY].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(p_dest_framebuffer)));
+	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, copy_to_fb.pipelines[p_panorama ? COPY_TO_FB_COPY_PANORAMA_TO_DP : COPY_TO_FB_COPY].get_render_pipeline(RD::INVALID_ID, RD::get_singleton()->framebuffer_get_format(p_dest_framebuffer)));
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, _get_uniform_set_from_texture(p_source_rd_texture), 0);
 	RD::get_singleton()->draw_list_bind_index_array(draw_list, index_array);
 	RD::get_singleton()->draw_list_set_push_constant(draw_list, &copy_to_fb.push_constant, sizeof(CopyToFbPushConstant));
@@ -1238,6 +1238,7 @@ RasterizerEffectsRD::RasterizerEffectsRD() {
 	{
 		Vector<String> copy_modes;
 		copy_modes.push_back("\n");
+		copy_modes.push_back("\n#define MODE_PANORAMA_TO_DP\n");
 
 		copy_to_fb.shader.initialize(copy_modes);
 

--- a/servers/rendering/rasterizer_rd/rasterizer_effects_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_effects_rd.h
@@ -113,6 +113,7 @@ class RasterizerEffectsRD {
 
 	enum CopyToFBMode {
 		COPY_TO_FB_COPY,
+		COPY_TO_FB_COPY_PANORAMA_TO_DP,
 		COPY_TO_FB_MAX,
 
 	};
@@ -565,7 +566,7 @@ public:
 	void copy_to_rect(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_all_source = false, bool p_8_bit_dst = false);
 	void copy_depth_to_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false);
 	void copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y, float p_z_near, float p_z_far);
-	void copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_uv_rect, RD::DrawListID p_draw_list, bool p_flip_y = false);
+	void copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_uv_rect, RD::DrawListID p_draw_list, bool p_flip_y = false, bool p_panorama = false);
 	void gaussian_blur(RID p_source_rd_texture, RID p_texture, RID p_back_texture, const Rect2i &p_region, bool p_8bit_dst = false);
 	void gaussian_glow(RID p_source_rd_texture, RID p_texture, RID p_back_texture, const Size2i &p_size, float p_strength = 1.0, bool p_first_pass = false, float p_luminance_cap = 16.0, float p_exposure = 1.0, float p_bloom = 0.0, float p_hdr_bleed_treshold = 1.0, float p_hdr_bleed_scale = 1.0, RID p_auto_exposure = RID(), float p_auto_exposure_grey = 1.0);
 

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.h
@@ -279,6 +279,7 @@ class RasterizerSceneHighEndRD : public RasterizerSceneRD {
 		float soft_shadow_scale;
 		uint32_t mask;
 		uint32_t pad[2];
+		float projector_rect[4];
 	};
 
 	struct DirectionalLightData {

--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
@@ -178,6 +178,7 @@ private:
 	struct DecalAtlas {
 		struct Texture {
 
+			int panorama_to_dp_users;
 			int users;
 			Rect2 uv_rect;
 		};
@@ -599,8 +600,8 @@ public:
 
 	virtual Size2 texture_size_with_proxy(RID p_proxy);
 
-	virtual void texture_add_to_decal_atlas(RID p_texture);
-	virtual void texture_remove_from_decal_atlas(RID p_texture);
+	virtual void texture_add_to_decal_atlas(RID p_texture, bool p_panorama_to_dp = false);
+	virtual void texture_remove_from_decal_atlas(RID p_texture, bool p_panorama_to_dp = false);
 
 	RID decal_atlas_get_texture() const;
 	RID decal_atlas_get_texture_srgb() const;
@@ -962,6 +963,14 @@ public:
 		ERR_FAIL_COND_V(!light, 0);
 
 		return light->param[p_param];
+	}
+
+	_FORCE_INLINE_ RID light_get_projector(RID p_light) {
+
+		const Light *light = light_owner.getornull(p_light);
+		ERR_FAIL_COND_V(!light, RID());
+
+		return light->projector;
 	}
 
 	_FORCE_INLINE_ Color light_get_color(RID p_light) {

--- a/servers/rendering/rasterizer_rd/shaders/copy_to_fb.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/copy_to_fb.glsl
@@ -65,6 +65,34 @@ layout(location = 0) out vec4 frag_color;
 void main() {
 
 	vec2 uv = uv_interp;
+
+#ifdef MODE_PANORAMA_TO_DP
+
+	//obtain normal from dual paraboloid uv
+#define M_PI 3.14159265359
+
+	float side;
+	uv.y = modf(uv.y * 2.0, side);
+	side = side * 2.0 - 1.0;
+	vec3 normal = vec3(uv * 2.0 - 1.0, 0.0);
+	normal.z = 0.5 - 0.5 * ((normal.x * normal.x) + (normal.y * normal.y));
+	normal *= -side;
+	normal = normalize(normal);
+
+	//now convert normal to panorama uv
+
+	vec2 st = vec2(atan(normal.x, normal.z), acos(normal.y));
+
+	if (st.x < 0.0)
+		st.x += M_PI * 2.0;
+
+	uv = st / vec2(M_PI * 2.0, M_PI);
+
+	if (side < 0.0) {
+		//uv.y = 1.0 - uv.y;
+		uv = 1.0 - uv;
+	}
+#endif
 	vec4 color = textureLod(source_color, uv, 0.0);
 	if (params.force_luminance) {
 		color.rgb = vec3(max(max(color.r, color.g), color.b));

--- a/servers/rendering/rasterizer_rd/shaders/scene_high_end_inc.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/scene_high_end_inc.glsl
@@ -153,7 +153,7 @@ struct LightData { //this structure needs to be as packed as possible
 	uint color_specular; //rgb color, a specular (8 bit unorm)
 	uint cone_attenuation_angle; // attenuation and angle, (16bit float)
 	uint shadow_color_enabled; //shadow rgb color, a>0.5 enabled (8bit unorm)
-	vec4 atlas_rect; // used for spot
+	vec4 atlas_rect; // rect in the shadow atlas
 	mat4 shadow_matrix;
 	float shadow_bias;
 	float shadow_normal_bias;
@@ -162,6 +162,7 @@ struct LightData { //this structure needs to be as packed as possible
 	float soft_shadow_scale; // scales the shadow kernel for blurrier shadows
 	uint mask;
 	uint pad[2];
+	vec4 projector_rect; //projector rect in srgb decal atlas
 };
 
 layout(set = 0, binding = 5, std430) restrict readonly buffer Lights {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6265307/79269320-a2beb480-7e72-11ea-8d23-18faeea7c8db.png)

For omni lights, a panorama texture must be used, so generate it with another tool.

_bugsquad edit:_ closes https://github.com/godotengine/godot-proposals/issues/451