### PR TITLE
Document how some editor classes should be accessed as singletons only

### DIFF
--- a/doc/classes/EditorFileSystem.xml
+++ b/doc/classes/EditorFileSystem.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This object holds information of all resources in the filesystem, their types, etc.
+		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorInterface.get_resource_filesystem].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		The editor inspector is by default located on the right-hand side of the editor. It's used to edit the properties of the selected node. For example, you can select a node such as the Sprite2D then edit its transform through the inspector tool. The editor inspector is an essential tool in the game development workflow.
+		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorInterface.get_inspector].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		EditorInterface gives you control over Godot editor's window. It allows customizing the window, saving and (re-)loading scenes, rendering mesh previews, inspecting and editing resources and objects, and provides access to [EditorSettings], [EditorFileSystem], [EditorResourcePreview], [ScriptEditor], the editor viewport, and information about scenes.
+		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorPlugin.get_editor_interface].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EditorResourcePreview.xml
+++ b/doc/classes/EditorResourcePreview.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This object is used to generate previews for resources of files.
+		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorInterface.get_resource_previewer].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EditorSelection.xml
+++ b/doc/classes/EditorSelection.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This object manages the SceneTree selection in the editor.
+		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorInterface.get_selection].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -11,6 +11,7 @@
 		settings.get(prop)
 		list_of_settings = settings.get_property_list()
 		[/codeblock]
+		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorInterface.get_editor_settings].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -4,6 +4,7 @@
 		Godot editor's script editor.
 	</brief_description>
 	<description>
+		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorInterface.get_script_editor].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
This closes #37687.

PS: We may consider renaming all those getter methods to always contain the "unaltered" class name. Right now, there are some inconsistencies: `get_inspector` returns an EditorInspector, `get_resource_filesystem` returns an EditorFileSystem, …