### PR TITLE
Change MATH_POSMOD return type back to INT

### DIFF
--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -506,7 +506,9 @@ PropertyInfo VisualScriptBuiltinFunc::get_output_value_port_info(int p_idx) cons
 		case MATH_CEIL: {
 			t = Variant::FLOAT;
 		} break;
-		case MATH_POSMOD:
+		case MATH_POSMOD: {
+			t = Variant::INT;
+		} break;
 		case MATH_ROUND: {
 			t = Variant::FLOAT;
 		} break;


### PR DESCRIPTION
* Pull #37851 switched MATH_POSMOD's output value type info to float due to switch/case fallthrough as described in @bojidar-bg 's comment. This changes it back to int.