### PR TITLE
Fixes tree selected item and selected column not updating on deselect

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3189,6 +3189,12 @@ void Tree::item_selected(int p_column, TreeItem *p_item) {
 }
 
 void Tree::item_deselected(int p_column, TreeItem *p_item) {
+  
+  if (selected_item == p_item)
+    selected_item = NULL;
+  
+  if (selected_col == p_column)
+    selected_col = -1;
 
 	if (select_mode == SELECT_MULTI || select_mode == SELECT_SINGLE) {
 		p_item->cells.write[p_column].selected = false;


### PR DESCRIPTION
When a selected TreeItem is deselected, the selected_item variable is updated to reflect that.

Fixes #25392