### PR TITLE
Fix typo in light3d (Texture -> Texture2D)

### DIFF
--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -166,7 +166,7 @@ Light3D::BakeMode Light3D::get_bake_mode() const {
 	return bake_mode;
 }
 
-void Light3D::set_projector(const Ref<Texture> &p_texture) {
+void Light3D::set_projector(const Ref<Texture2D> &p_texture) {
 
 	projector = p_texture;
 	RID tex_id = projector.is_valid() ? projector->get_rid() : RID();

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -126,7 +126,7 @@ public:
 	void set_bake_mode(BakeMode p_mode);
 	BakeMode get_bake_mode() const;
 
-	void set_projector(const Ref<Texture> &p_texture);
+	void set_projector(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_projector() const;
 
 	virtual AABB get_aabb() const;


### PR DESCRIPTION
When generating mono glue, godot complains that `set_projector` and `get_projector` have different types although they're setters and getters. Is this correct?