### PR TITLE
Fixes leaks in ResourceCache, Vulkan and X11

### DIFF
--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -477,6 +477,9 @@ void ResourceCache::clear() {
 
 	resources.clear();
 	memdelete(lock);
+#ifdef TOOLS_ENABLED
+	memdelete(path_cache_lock);
+#endif
 }
 
 void ResourceCache::reload_externals() {

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -7274,6 +7274,11 @@ void RenderingDeviceVulkan::finalize() {
 		vertex_formats.erase(temp);
 	}
 
+	for (int i = 0; i < framebuffer_formats.size(); i++) {
+		vkDestroyRenderPass(device, framebuffer_formats[i].render_pass, nullptr);
+	}
+	framebuffer_formats.clear();
+
 	//all these should be clear at this point
 	ERR_FAIL_COND(descriptor_pools.size());
 	ERR_FAIL_COND(dependency_map.size());

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -1503,6 +1503,15 @@ VulkanContext::~VulkanContext() {
 	if (queue_props) {
 		free(queue_props);
 	}
+	for (uint32_t i = 0; i < FRAME_LAG; i++) {
+		vkDestroyFence(device, fences[i], nullptr);
+		vkDestroySemaphore(device, image_acquired_semaphores[i], nullptr);
+		vkDestroySemaphore(device, draw_complete_semaphores[i], nullptr);
+		if (separate_present_queue) {
+			vkDestroySemaphore(device, image_ownership_semaphores[i], nullptr);
+		}
+	}
+	DestroyDebugUtilsMessengerEXT(inst, dbg_messenger, nullptr);
 	vkDestroyDevice(device, nullptr);
 	vkDestroyInstance(inst, nullptr);
 }

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -1471,8 +1471,11 @@ DisplayServer::WindowMode DisplayServerX11::window_get_mode(WindowID p_window) c
 
 		if (result == Success && data) {
 			long *state = (long *)data;
-			if (state[0] == WM_IconicState)
+			if (state[0] == WM_IconicState) {
+				XFree(data);
 				return WINDOW_MODE_MINIMIZED;
+			}
+			XFree(data);
 		}
 	}
 


### PR DESCRIPTION
Fixes point 5 from #37885 when opening empty editor.

Seems that other points may be caused by leaks in thirdparty libraries, but I will check this later after upgrading to Ubuntu 20.04 with newer versions of libraries