### PR TITLE
Bind Shape2D draw method

### DIFF
--- a/doc/classes/Shape2D.xml
+++ b/doc/classes/Shape2D.xml
@@ -74,6 +74,17 @@
 				This method needs the transformation matrix for this shape ([code]local_xform[/code]), the movement to test on this shape ([code]local_motion[/code]), the shape to check collisions with ([code]with_shape[/code]), the transformation matrix of that shape ([code]shape_xform[/code]), and the movement to test onto the other object ([code]shape_motion[/code]).
 			</description>
 		</method>
+		<method name="draw">
+			<return type="void">
+			</return>
+			<argument index="0" name="canvas_item" type="RID">
+			</argument>
+			<argument index="1" name="color" type="Color">
+			</argument>
+			<description>
+				Draws a solid shape onto a [CanvasItem] with the [RenderingServer] API filled with the specified [code]color[/code]. The exact drawing method is specific for each shape and cannot be configured.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="custom_solver_bias" type="float" setter="set_custom_solver_bias" getter="get_custom_solver_bias" default="0.0">

--- a/scene/resources/shape_2d.cpp
+++ b/scene/resources/shape_2d.cpp
@@ -104,6 +104,7 @@ void Shape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("collide_with_motion", "local_xform", "local_motion", "with_shape", "shape_xform", "shape_motion"), &Shape2D::collide_with_motion);
 	ClassDB::bind_method(D_METHOD("collide_and_get_contacts", "local_xform", "with_shape", "shape_xform"), &Shape2D::collide_and_get_contacts);
 	ClassDB::bind_method(D_METHOD("collide_with_motion_and_get_contacts", "local_xform", "local_motion", "with_shape", "shape_xform", "shape_motion"), &Shape2D::collide_with_motion_and_get_contacts);
+	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "color"), &Shape2D::draw);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_solver_bias", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_custom_solver_bias", "get_custom_solver_bias");
 }


### PR DESCRIPTION
Sort of closes #6750. The method was not exposed to scripting so it wasn't actually possible to make a plugin to draw shapes out of `Shape2D` resources. If this is merged, then #16483 can be implemented via GDScript without much hassle.

The gist of drawing with script:
```gdscript
extends Node2D

var shape: Shape2D

func _draw():
	shape.draw(get_canvas_item(), color)
```

I have also a `ShapeCast` node proposal which could benefit from this (if done via script): godotengine/godot-proposals#710.

Also note that there's no 3D related drawing methods available for `Shape3D` (likely uses some other technique for drawing).

Also worth cherry-picking this to 3.2.