### PR TITLE
Fix texture check in decal setup

### DIFF
--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -60,24 +60,24 @@ float Decal::get_emission_energy() const {
 	return emission_energy;
 }
 
-void Decal::set_albedo_mix(float p_energy) {
-	albedo_mix = p_energy;
+void Decal::set_albedo_mix(float p_mix) {
+	albedo_mix = p_mix;
 	RS::get_singleton()->decal_set_albedo_mix(decal, albedo_mix);
 }
 float Decal::get_albedo_mix() const {
 	return albedo_mix;
 }
 
-void Decal::set_upper_fade(float p_energy) {
-	upper_fade = p_energy;
+void Decal::set_upper_fade(float p_fade) {
+	upper_fade = p_fade;
 	RS::get_singleton()->decal_set_fade(decal, upper_fade, lower_fade);
 }
 float Decal::get_upper_fade() const {
 	return upper_fade;
 }
 
-void Decal::set_lower_fade(float p_energy) {
-	lower_fade = p_energy;
+void Decal::set_lower_fade(float p_fade) {
+	lower_fade = p_fade;
 	RS::get_singleton()->decal_set_fade(decal, upper_fade, lower_fade);
 }
 float Decal::get_lower_fade() const {

--- a/scene/3d/decal.h
+++ b/scene/3d/decal.h
@@ -75,7 +75,7 @@ public:
 	void set_emission_energy(float p_energy);
 	float get_emission_energy() const;
 
-	void set_albedo_mix(float p_energy);
+	void set_albedo_mix(float p_mix);
 	float get_albedo_mix() const;
 
 	void set_modulate(Color p_modulate);
@@ -84,10 +84,10 @@ public:
 	void set_upper_fade(float p_energy);
 	float get_upper_fade() const;
 
-	void set_lower_fade(float p_energy);
+	void set_lower_fade(float p_fade);
 	float get_lower_fade() const;
 
-	void set_normal_fade(float p_energy);
+	void set_normal_fade(float p_fade);
 	float get_normal_fade() const;
 
 	void set_enable_distance_fade(bool p_enable);

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -2007,6 +2007,7 @@ void RasterizerSceneHighEndRD::_setup_decals(const RID *p_decal_instances, int p
 		dd.normal_fade = storage->decal_get_normal_fade(decal);
 
 		RID albedo_tex = storage->decal_get_texture(decal, RS::DECAL_TEXTURE_ALBEDO);
+		RID emission_tex = storage->decal_get_texture(decal, RS::DECAL_TEXTURE_EMISSION);
 		if (albedo_tex.is_valid()) {
 			Rect2 rect = storage->decal_atlas_get_texture_rect(albedo_tex);
 			dd.albedo_rect[0] = rect.position.x;
@@ -2015,6 +2016,9 @@ void RasterizerSceneHighEndRD::_setup_decals(const RID *p_decal_instances, int p
 			dd.albedo_rect[3] = rect.size.y;
 		} else {
 
+			if (!emission_tex.is_valid()) {
+				continue; //no albedo, no emission, no decal.
+			}
 			dd.albedo_rect[0] = 0;
 			dd.albedo_rect[1] = 0;
 			dd.albedo_rect[2] = 0;
@@ -2022,7 +2026,6 @@ void RasterizerSceneHighEndRD::_setup_decals(const RID *p_decal_instances, int p
 		}
 
 		RID normal_tex = storage->decal_get_texture(decal, RS::DECAL_TEXTURE_NORMAL);
-		RID emission_tex = storage->decal_get_texture(decal, RS::DECAL_TEXTURE_EMISSION);
 
 		if (normal_tex.is_valid()) {
 			Rect2 rect = storage->decal_atlas_get_texture_rect(normal_tex);
@@ -2033,13 +2036,7 @@ void RasterizerSceneHighEndRD::_setup_decals(const RID *p_decal_instances, int p
 
 			Basis normal_xform = p_camera_inverse_xform.basis * xform.basis.orthonormalized();
 			store_basis_3x4(normal_xform, dd.normal_xform);
-
-			//store normal xform
 		} else {
-
-			if (!emission_tex.is_valid()) {
-				continue; //no albedo, no emission, no decal.
-			}
 			dd.normal_rect[0] = 0;
 			dd.normal_rect[1] = 0;
 			dd.normal_rect[2] = 0;


### PR DESCRIPTION
Fixes a small bug in the decal setup function and cleans up some parameter naming.

The bug was throwing out valid decals because they didn't specify normal textures. 