### PR TITLE
fix InputFilter not being static in C#

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -264,7 +264,7 @@ void register_core_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ClassDB", _classdb));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Marshalls", _Marshalls::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("TranslationServer", TranslationServer::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("Input", InputFilter::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("InputFilter", InputFilter::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("InputMap", InputMap::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("JSON", _JSON::get_singleton()));
 }


### PR DESCRIPTION
fixes #37690
This would remove `Input` from GDScript, use `InputFilter` instead.