### PR TITLE
GDScript parser sets error when _init() receive any arguments

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -7961,6 +7961,10 @@ void GDScriptParser::_check_function_types(FunctionNode *p_function) {
 			_set_error("The constructor can't return a value.", p_function->line);
 			return;
 		}
+		if (p_function->arguments.size() != 0) {
+			_set_error("The constructor can't receive any arguments.", p_function->line);
+			return;
+		}
 	}
 
 	if (p_function->return_type.has_type && (p_function->return_type.kind != DataType::BUILTIN || p_function->return_type.builtin_type != Variant::NIL)) {


### PR DESCRIPTION
see: https://github.com/godotengine/godot/issues/37907#issuecomment-614336557

![_init(args)](https://user-images.githubusercontent.com/41085900/79400211-31caea00-7fa3-11ea-9dae-af2931e55ec6.JPG)
