### PR TITLE
Reimplement Array.Slice() to fix indexing

### DIFF
--- a/core/array.h
+++ b/core/array.h
@@ -44,8 +44,7 @@ class Array {
 	void _ref(const Array &p_from) const;
 	void _unref() const;
 
-	int _clamp_index(int p_index) const;
-	static int _fix_slice_index(int p_index, int p_arr_len, int p_top_mod);
+	int _adjust_slice_index(int p_length, int *p_begin, int *p_end, int p_step) const;
 
 public:
 	Variant &operator[](int p_idx);

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -360,7 +360,7 @@
 			<argument index="3" name="deep" type="bool" default="false">
 			</argument>
 			<description>
-				Duplicates the subset described in the function and returns it in an array, deeply copying the array if [code]deep[/code] is [code]true[/code]. Lower and upper index are inclusive, with the [code]step[/code] describing the change between indices while slicing.
+				Returns a copy of the array from index [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), incremented by [code]step[/code].  Array is deeply copied if [code]deep[/code] is [code]true[/code].
 			</description>
 		</method>
 		<method name="sort">


### PR DESCRIPTION
This addresses indexing and slice length issues with Array.Slice()
This also changes the upper bound to be exclusive for consistency
with other scripting languages and the GDScript Range() function.

Further discussion in the issue thread.

Fixes: #34284