### PR TITLE
Fix 3.2 compilation issue

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPlugin.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/GodotPlugin.java
@@ -288,7 +288,7 @@ public abstract class GodotPlugin {
 				}
 			}
 
-			runOnGLThread(new Runnable() {
+			runOnRenderThread(new Runnable() {
 				@Override
 				public void run() {
 					nativeEmitSignal(getPluginName(), signalName, signalArgs);


### PR DESCRIPTION
Fix 3.2 compilation issue by updating a call to `runOnGLThread` that was missed by PR #37175