### PR TITLE
Implement global and per instance shader uniforms.

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -64,6 +64,7 @@ private:
 	bool checked;
 	bool draw_red;
 	bool keying;
+	bool deletable;
 
 	Rect2 right_child_rect;
 	Rect2 bottom_child_rect;
@@ -74,6 +75,8 @@ private:
 	bool revert_hover;
 	Rect2 check_rect;
 	bool check_hover;
+	Rect2 delete_rect;
+	bool delete_hover;
 
 	bool can_revert;
 
@@ -133,6 +136,8 @@ public:
 	void set_keying(bool p_keying);
 	bool is_keying() const;
 
+	void set_deletable(bool p_enable);
+	bool is_deletable() const;
 	void add_focusable(Control *p_control);
 	void select(int p_focusable = -1);
 	void deselect();
@@ -190,7 +195,7 @@ public:
 	virtual bool can_handle(Object *p_object);
 	virtual void parse_begin(Object *p_object);
 	virtual void parse_category(Object *p_object, const String &p_parse_category);
-	virtual bool parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage);
+	virtual bool parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide = false);
 	virtual void parse_end();
 };
 
@@ -283,6 +288,8 @@ class EditorInspector : public ScrollContainer {
 	bool read_only;
 	bool keying;
 	bool sub_inspector;
+	bool wide_editors;
+	bool deletable_properties;
 
 	float refresh_countdown;
 	bool update_tree_pending;
@@ -307,6 +314,7 @@ class EditorInspector : public ScrollContainer {
 	void _multiple_properties_changed(Vector<String> p_paths, Array p_values);
 	void _property_keyed(const String &p_path, bool p_advance);
 	void _property_keyed_with_value(const String &p_path, const Variant &p_value, bool p_advance);
+	void _property_deleted(const String &p_path);
 
 	void _property_checked(const String &p_path, bool p_checked);
 
@@ -337,7 +345,7 @@ public:
 	static void remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
 	static void cleanup_plugins();
 
-	static EditorProperty *instantiate_property_editor(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage);
+	static EditorProperty *instantiate_property_editor(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide = false);
 
 	void set_undo_redo(UndoRedo *p_undo_redo);
 
@@ -380,7 +388,10 @@ public:
 	void set_object_class(const String &p_class);
 	String get_object_class() const;
 
+	void set_use_wide_editors(bool p_enable);
 	void set_sub_inspector(bool p_enable);
+
+	void set_use_deletable_properties(bool p_enabled);
 
 	EditorInspector();
 };

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -708,6 +708,11 @@ void EditorNode::_sources_changed(bool p_exist) {
 	if (waiting_for_first_scan) {
 		waiting_for_first_scan = false;
 
+		// Reload the global shader variables, but this time
+		// loading texures, as they are now properly imported.
+		print_line("done scanning, reload textures");
+		RenderingServer::get_singleton()->global_variables_load_settings(true);
+
 		// Start preview thread now that it's safe.
 		if (!singleton->cmdline_export_mode) {
 			EditorResourcePreview::get_singleton()->start();

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1150,12 +1150,15 @@ void EditorPropertyVector2::setup(double p_min, double p_max, double p_step, boo
 	}
 }
 
-EditorPropertyVector2::EditorPropertyVector2() {
+EditorPropertyVector2::EditorPropertyVector2(bool p_force_wide) {
 	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector2_editing");
 
 	BoxContainer *bc;
 
-	if (horizontal) {
+	if (p_force_wide) {
+		bc = memnew(HBoxContainer);
+		add_child(bc);
+	} else if (horizontal) {
 		bc = memnew(HBoxContainer);
 		add_child(bc);
 		set_bottom_editor(bc);
@@ -1231,13 +1234,16 @@ void EditorPropertyRect2::setup(double p_min, double p_max, double p_step, bool 
 	}
 }
 
-EditorPropertyRect2::EditorPropertyRect2() {
+EditorPropertyRect2::EditorPropertyRect2(bool p_force_wide) {
 
-	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
+	bool horizontal = !p_force_wide && bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
 
 	BoxContainer *bc;
 
-	if (horizontal) {
+	if (p_force_wide) {
+		bc = memnew(HBoxContainer);
+		add_child(bc);
+	} else if (horizontal) {
 		bc = memnew(HBoxContainer);
 		add_child(bc);
 		set_bottom_editor(bc);
@@ -1311,12 +1317,15 @@ void EditorPropertyVector3::setup(double p_min, double p_max, double p_step, boo
 	}
 }
 
-EditorPropertyVector3::EditorPropertyVector3() {
+EditorPropertyVector3::EditorPropertyVector3(bool p_force_wide) {
 	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
 
 	BoxContainer *bc;
 
-	if (horizontal) {
+	if (p_force_wide) {
+		bc = memnew(HBoxContainer);
+		add_child(bc);
+	} else if (horizontal) {
 		bc = memnew(HBoxContainer);
 		add_child(bc);
 		set_bottom_editor(bc);
@@ -1343,6 +1352,255 @@ EditorPropertyVector3::EditorPropertyVector3() {
 	}
 	setting = false;
 }
+
+///////////////////// VECTOR2i /////////////////////////
+
+void EditorPropertyVector2i::_value_changed(double val, const String &p_name) {
+	if (setting)
+		return;
+
+	Vector2i v2;
+	v2.x = spin[0]->get_value();
+	v2.y = spin[1]->get_value();
+	emit_changed(get_edited_property(), v2, p_name);
+}
+
+void EditorPropertyVector2i::update_property() {
+	Vector2i val = get_edited_object()->get(get_edited_property());
+	setting = true;
+	spin[0]->set_value(val.x);
+	spin[1]->set_value(val.y);
+	setting = false;
+}
+
+void EditorPropertyVector2i::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
+		Color base = get_theme_color("accent_color", "Editor");
+		for (int i = 0; i < 2; i++) {
+
+			Color c = base;
+			c.set_hsv(float(i) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
+			spin[i]->set_custom_label_color(true, c);
+		}
+	}
+}
+
+void EditorPropertyVector2i::_bind_methods() {
+}
+
+void EditorPropertyVector2i::setup(int p_min, int p_max, bool p_no_slider) {
+	for (int i = 0; i < 2; i++) {
+		spin[i]->set_min(p_min);
+		spin[i]->set_max(p_max);
+		spin[i]->set_step(1);
+		spin[i]->set_hide_slider(p_no_slider);
+		spin[i]->set_allow_greater(true);
+		spin[i]->set_allow_lesser(true);
+	}
+}
+
+EditorPropertyVector2i::EditorPropertyVector2i(bool p_force_wide) {
+	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector2_editing");
+
+	BoxContainer *bc;
+
+	if (p_force_wide) {
+		bc = memnew(HBoxContainer);
+		add_child(bc);
+	} else if (horizontal) {
+		bc = memnew(HBoxContainer);
+		add_child(bc);
+		set_bottom_editor(bc);
+	} else {
+		bc = memnew(VBoxContainer);
+		add_child(bc);
+	}
+
+	static const char *desc[2] = { "x", "y" };
+	for (int i = 0; i < 2; i++) {
+		spin[i] = memnew(EditorSpinSlider);
+		spin[i]->set_flat(true);
+		spin[i]->set_label(desc[i]);
+		bc->add_child(spin[i]);
+		add_focusable(spin[i]);
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyVector2i::_value_changed), varray(desc[i]));
+		if (horizontal) {
+			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+		}
+	}
+
+	if (!horizontal) {
+		set_label_reference(spin[0]); //show text and buttons around this
+	}
+	setting = false;
+}
+
+///////////////////// RECT2 /////////////////////////
+
+void EditorPropertyRect2i::_value_changed(double val, const String &p_name) {
+	if (setting)
+		return;
+
+	Rect2i r2;
+	r2.position.x = spin[0]->get_value();
+	r2.position.y = spin[1]->get_value();
+	r2.size.x = spin[2]->get_value();
+	r2.size.y = spin[3]->get_value();
+	emit_changed(get_edited_property(), r2, p_name);
+}
+
+void EditorPropertyRect2i::update_property() {
+	Rect2i val = get_edited_object()->get(get_edited_property());
+	setting = true;
+	spin[0]->set_value(val.position.x);
+	spin[1]->set_value(val.position.y);
+	spin[2]->set_value(val.size.x);
+	spin[3]->set_value(val.size.y);
+	setting = false;
+}
+void EditorPropertyRect2i::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
+		Color base = get_theme_color("accent_color", "Editor");
+		for (int i = 0; i < 4; i++) {
+
+			Color c = base;
+			c.set_hsv(float(i % 2) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
+			spin[i]->set_custom_label_color(true, c);
+		}
+	}
+}
+void EditorPropertyRect2i::_bind_methods() {
+}
+
+void EditorPropertyRect2i::setup(int p_min, int p_max, bool p_no_slider) {
+	for (int i = 0; i < 4; i++) {
+		spin[i]->set_min(p_min);
+		spin[i]->set_max(p_max);
+		spin[i]->set_step(1);
+		spin[i]->set_hide_slider(p_no_slider);
+		spin[i]->set_allow_greater(true);
+		spin[i]->set_allow_lesser(true);
+	}
+}
+
+EditorPropertyRect2i::EditorPropertyRect2i(bool p_force_wide) {
+
+	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
+
+	BoxContainer *bc;
+
+	if (p_force_wide) {
+		bc = memnew(HBoxContainer);
+		add_child(bc);
+	} else if (horizontal) {
+		bc = memnew(HBoxContainer);
+		add_child(bc);
+		set_bottom_editor(bc);
+	} else {
+		bc = memnew(VBoxContainer);
+		add_child(bc);
+	}
+
+	static const char *desc[4] = { "x", "y", "w", "h" };
+	for (int i = 0; i < 4; i++) {
+		spin[i] = memnew(EditorSpinSlider);
+		spin[i]->set_label(desc[i]);
+		spin[i]->set_flat(true);
+		bc->add_child(spin[i]);
+		add_focusable(spin[i]);
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyRect2i::_value_changed), varray(desc[i]));
+		if (horizontal) {
+			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+		}
+	}
+
+	if (!horizontal) {
+		set_label_reference(spin[0]); //show text and buttons around this
+	}
+	setting = false;
+}
+
+///////////////////// VECTOR3 /////////////////////////
+
+void EditorPropertyVector3i::_value_changed(double val, const String &p_name) {
+	if (setting)
+		return;
+
+	Vector3i v3;
+	v3.x = spin[0]->get_value();
+	v3.y = spin[1]->get_value();
+	v3.z = spin[2]->get_value();
+	emit_changed(get_edited_property(), v3, p_name);
+}
+
+void EditorPropertyVector3i::update_property() {
+	Vector3i val = get_edited_object()->get(get_edited_property());
+	setting = true;
+	spin[0]->set_value(val.x);
+	spin[1]->set_value(val.y);
+	spin[2]->set_value(val.z);
+	setting = false;
+}
+void EditorPropertyVector3i::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
+		Color base = get_theme_color("accent_color", "Editor");
+		for (int i = 0; i < 3; i++) {
+
+			Color c = base;
+			c.set_hsv(float(i) / 3.0 + 0.05, c.get_s() * 0.75, c.get_v());
+			spin[i]->set_custom_label_color(true, c);
+		}
+	}
+}
+void EditorPropertyVector3i::_bind_methods() {
+}
+
+void EditorPropertyVector3i::setup(int p_min, int p_max, bool p_no_slider) {
+	for (int i = 0; i < 3; i++) {
+		spin[i]->set_min(p_min);
+		spin[i]->set_max(p_max);
+		spin[i]->set_step(1);
+		spin[i]->set_hide_slider(p_no_slider);
+		spin[i]->set_allow_greater(true);
+		spin[i]->set_allow_lesser(true);
+	}
+}
+
+EditorPropertyVector3i::EditorPropertyVector3i(bool p_force_wide) {
+	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
+
+	BoxContainer *bc;
+	if (p_force_wide) {
+		bc = memnew(HBoxContainer);
+		add_child(bc);
+	} else if (horizontal) {
+		bc = memnew(HBoxContainer);
+		add_child(bc);
+		set_bottom_editor(bc);
+	} else {
+		bc = memnew(VBoxContainer);
+		add_child(bc);
+	}
+
+	static const char *desc[3] = { "x", "y", "z" };
+	for (int i = 0; i < 3; i++) {
+		spin[i] = memnew(EditorSpinSlider);
+		spin[i]->set_flat(true);
+		spin[i]->set_label(desc[i]);
+		bc->add_child(spin[i]);
+		add_focusable(spin[i]);
+		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyVector3i::_value_changed), varray(desc[i]));
+		if (horizontal) {
+			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+		}
+	}
+
+	if (!horizontal) {
+		set_label_reference(spin[0]); //show text and buttons around this
+	}
+	setting = false;
+}
+
 ///////////////////// PLANE /////////////////////////
 
 void EditorPropertyPlane::_value_changed(double val, const String &p_name) {
@@ -1391,13 +1649,16 @@ void EditorPropertyPlane::setup(double p_min, double p_max, double p_step, bool 
 	}
 }
 
-EditorPropertyPlane::EditorPropertyPlane() {
+EditorPropertyPlane::EditorPropertyPlane(bool p_force_wide) {
 
 	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
 
 	BoxContainer *bc;
 
-	if (horizontal) {
+	if (p_force_wide) {
+		bc = memnew(HBoxContainer);
+		add_child(bc);
+	} else if (horizontal) {
 		bc = memnew(HBoxContainer);
 		add_child(bc);
 		set_bottom_editor(bc);
@@ -2877,7 +3138,7 @@ void EditorInspectorDefaultPlugin::parse_begin(Object *p_object) {
 	//do none
 }
 
-bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage) {
+bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide) {
 
 	float default_float_step = EDITOR_GET("interface/inspector/default_float_step");
 
@@ -3083,7 +3344,7 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			// math types
 
 		case Variant::VECTOR2: {
-			EditorPropertyVector2 *editor = memnew(EditorPropertyVector2);
+			EditorPropertyVector2 *editor = memnew(EditorPropertyVector2(p_wide));
 			double min = -65535, max = 65535, step = default_float_step;
 			bool hide_slider = true;
 
@@ -3097,11 +3358,26 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			}
 
 			editor->setup(min, max, step, hide_slider);
+			add_property_editor(p_path, editor);
+
+		} break;
+		case Variant::VECTOR2I: {
+			EditorPropertyVector2i *editor = memnew(EditorPropertyVector2i(p_wide));
+			int min = -65535, max = 65535;
+			bool hide_slider = true;
+
+			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
+				min = p_hint_text.get_slice(",", 0).to_double();
+				max = p_hint_text.get_slice(",", 1).to_double();
+				hide_slider = false;
+			}
+
+			editor->setup(min, max, hide_slider);
 			add_property_editor(p_path, editor);
 
 		} break;
 		case Variant::RECT2: {
-			EditorPropertyRect2 *editor = memnew(EditorPropertyRect2);
+			EditorPropertyRect2 *editor = memnew(EditorPropertyRect2(p_wide));
 			double min = -65535, max = 65535, step = default_float_step;
 			bool hide_slider = true;
 
@@ -3117,8 +3393,22 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			editor->setup(min, max, step, hide_slider);
 			add_property_editor(p_path, editor);
 		} break;
+		case Variant::RECT2I: {
+			EditorPropertyRect2i *editor = memnew(EditorPropertyRect2i(p_wide));
+			int min = -65535, max = 65535;
+			bool hide_slider = true;
+
+			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
+				min = p_hint_text.get_slice(",", 0).to_double();
+				max = p_hint_text.get_slice(",", 1).to_double();
+				hide_slider = false;
+			}
+
+			editor->setup(min, max, hide_slider);
+			add_property_editor(p_path, editor);
+		} break;
 		case Variant::VECTOR3: {
-			EditorPropertyVector3 *editor = memnew(EditorPropertyVector3);
+			EditorPropertyVector3 *editor = memnew(EditorPropertyVector3(p_wide));
 			double min = -65535, max = 65535, step = default_float_step;
 			bool hide_slider = true;
 
@@ -3132,6 +3422,22 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			}
 
 			editor->setup(min, max, step, hide_slider);
+			add_property_editor(p_path, editor);
+
+		} break;
+		case Variant::VECTOR3I: {
+			EditorPropertyVector3i *editor = memnew(EditorPropertyVector3i(p_wide));
+			int min = -65535, max = 65535;
+			bool hide_slider = true;
+
+			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
+				min = p_hint_text.get_slice(",", 0).to_double();
+				max = p_hint_text.get_slice(",", 1).to_double();
+
+				hide_slider = false;
+			}
+
+			editor->setup(min, max, hide_slider);
 			add_property_editor(p_path, editor);
 
 		} break;
@@ -3154,7 +3460,7 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 
 		} break;
 		case Variant::PLANE: {
-			EditorPropertyPlane *editor = memnew(EditorPropertyPlane);
+			EditorPropertyPlane *editor = memnew(EditorPropertyPlane(p_wide));
 			double min = -65535, max = 65535, step = default_float_step;
 			bool hide_slider = true;
 

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -361,7 +361,7 @@ protected:
 public:
 	virtual void update_property();
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider);
-	EditorPropertyVector2();
+	EditorPropertyVector2(bool p_force_wide = false);
 };
 
 class EditorPropertyRect2 : public EditorProperty {
@@ -377,7 +377,7 @@ protected:
 public:
 	virtual void update_property();
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider);
-	EditorPropertyRect2();
+	EditorPropertyRect2(bool p_force_wide = false);
 };
 
 class EditorPropertyVector3 : public EditorProperty {
@@ -393,7 +393,55 @@ protected:
 public:
 	virtual void update_property();
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider);
-	EditorPropertyVector3();
+	EditorPropertyVector3(bool p_force_wide = false);
+};
+
+class EditorPropertyVector2i : public EditorProperty {
+	GDCLASS(EditorPropertyVector2i, EditorProperty);
+	EditorSpinSlider *spin[2];
+	bool setting;
+	void _value_changed(double p_val, const String &p_name);
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	virtual void update_property();
+	void setup(int p_min, int p_max, bool p_no_slider);
+	EditorPropertyVector2i(bool p_force_wide = false);
+};
+
+class EditorPropertyRect2i : public EditorProperty {
+	GDCLASS(EditorPropertyRect2i, EditorProperty);
+	EditorSpinSlider *spin[4];
+	bool setting;
+	void _value_changed(double p_val, const String &p_name);
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	virtual void update_property();
+	void setup(int p_min, int p_max, bool p_no_slider);
+	EditorPropertyRect2i(bool p_force_wide = false);
+};
+
+class EditorPropertyVector3i : public EditorProperty {
+	GDCLASS(EditorPropertyVector3i, EditorProperty);
+	EditorSpinSlider *spin[3];
+	bool setting;
+	void _value_changed(double p_val, const String &p_name);
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	virtual void update_property();
+	void setup(int p_min, int p_max, bool p_no_slider);
+	EditorPropertyVector3i(bool p_force_wide = false);
 };
 
 class EditorPropertyPlane : public EditorProperty {
@@ -409,7 +457,7 @@ protected:
 public:
 	virtual void update_property();
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider);
-	EditorPropertyPlane();
+	EditorPropertyPlane(bool p_force_wide = false);
 };
 
 class EditorPropertyQuat : public EditorProperty {
@@ -626,7 +674,7 @@ class EditorInspectorDefaultPlugin : public EditorInspectorPlugin {
 public:
 	virtual bool can_handle(Object *p_object);
 	virtual void parse_begin(Object *p_object);
-	virtual bool parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage);
+	virtual bool parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide = false);
 	virtual void parse_end();
 };
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -742,6 +742,13 @@ void EditorPropertyDictionary::update_property() {
 					prop = editor;
 
 				} break;
+				case Variant::VECTOR2I: {
+
+					EditorPropertyVector2i *editor = memnew(EditorPropertyVector2i);
+					editor->setup(-100000, 100000, true);
+					prop = editor;
+
+				} break;
 				case Variant::RECT2: {
 
 					EditorPropertyRect2 *editor = memnew(EditorPropertyRect2);
@@ -749,10 +756,24 @@ void EditorPropertyDictionary::update_property() {
 					prop = editor;
 
 				} break;
+				case Variant::RECT2I: {
+
+					EditorPropertyRect2i *editor = memnew(EditorPropertyRect2i);
+					editor->setup(-100000, 100000, true);
+					prop = editor;
+
+				} break;
 				case Variant::VECTOR3: {
 
 					EditorPropertyVector3 *editor = memnew(EditorPropertyVector3);
 					editor->setup(-100000, 100000, 0.001, true);
+					prop = editor;
+
+				} break;
+				case Variant::VECTOR3I: {
+
+					EditorPropertyVector3i *editor = memnew(EditorPropertyVector3i);
+					editor->setup(-100000, 100000, true);
 					prop = editor;
 
 				} break;

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -288,7 +288,7 @@ void EditorInspectorRootMotionPlugin::parse_begin(Object *p_object) {
 	//do none
 }
 
-bool EditorInspectorRootMotionPlugin::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage) {
+bool EditorInspectorRootMotionPlugin::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide) {
 
 	if (p_path == "root_motion_track" && p_object->is_class("AnimationTree") && p_type == Variant::NODE_PATH) {
 		EditorPropertyRootMotion *editor = memnew(EditorPropertyRootMotion);

--- a/editor/plugins/root_motion_editor_plugin.h
+++ b/editor/plugins/root_motion_editor_plugin.h
@@ -65,7 +65,7 @@ class EditorInspectorRootMotionPlugin : public EditorInspectorPlugin {
 public:
 	virtual bool can_handle(Object *p_object);
 	virtual void parse_begin(Object *p_object);
-	virtual bool parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage);
+	virtual bool parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide = false);
 	virtual void parse_end();
 };
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -193,6 +193,12 @@ void ShaderTextEditor::_check_shader_mode() {
 	}
 }
 
+static ShaderLanguage::DataType _get_global_variable_type(const StringName &p_variable) {
+
+	RS::GlobalVariableType gvt = RS::get_singleton()->global_variable_get_type(p_variable);
+	return RS::global_variable_type_get_shader_datatype(gvt);
+}
+
 void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptCodeCompletionOption> *r_options) {
 
 	_check_shader_mode();
@@ -200,7 +206,7 @@ void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptCo
 	ShaderLanguage sl;
 	String calltip;
 
-	sl.complete(p_code, ShaderTypes::get_singleton()->get_functions(RenderingServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_types(), r_options, calltip);
+	sl.complete(p_code, ShaderTypes::get_singleton()->get_functions(RenderingServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_types(), _get_global_variable_type, r_options, calltip);
 
 	get_text_edit()->set_code_hint(calltip);
 }
@@ -215,7 +221,7 @@ void ShaderTextEditor::_validate_script() {
 
 	ShaderLanguage sl;
 
-	Error err = sl.compile(code, ShaderTypes::get_singleton()->get_functions(RenderingServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_types());
+	Error err = sl.compile(code, ShaderTypes::get_singleton()->get_functions(RenderingServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(shader->get_mode())), ShaderTypes::get_singleton()->get_types(), _get_global_variable_type);
 
 	if (err != OK) {
 		String error_text = "error(" + itos(sl.get_error_line()) + "): " + sl.get_error_text();

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -45,7 +45,7 @@ void EditorInspectorPluginStyleBox::parse_begin(Object *p_object) {
 	preview->edit(sb);
 	add_custom_control(preview);
 }
-bool EditorInspectorPluginStyleBox::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage) {
+bool EditorInspectorPluginStyleBox::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide) {
 	return false; //do not want
 }
 void EditorInspectorPluginStyleBox::parse_end() {

--- a/editor/plugins/style_box_editor_plugin.h
+++ b/editor/plugins/style_box_editor_plugin.h
@@ -62,7 +62,7 @@ class EditorInspectorPluginStyleBox : public EditorInspectorPlugin {
 public:
 	virtual bool can_handle(Object *p_object);
 	virtual void parse_begin(Object *p_object);
-	virtual bool parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage);
+	virtual bool parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide = false);
 	virtual void parse_end();
 };
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2261,6 +2261,12 @@ void VisualShaderEditor::_show_preview_text() {
 	}
 }
 
+static ShaderLanguage::DataType _get_global_variable_type(const StringName &p_variable) {
+
+	RS::GlobalVariableType gvt = RS::get_singleton()->global_variable_get_type(p_variable);
+	return RS::global_variable_type_get_shader_datatype(gvt);
+}
+
 void VisualShaderEditor::_update_preview() {
 
 	if (!preview_showed) {
@@ -2274,7 +2280,7 @@ void VisualShaderEditor::_update_preview() {
 
 	ShaderLanguage sl;
 
-	Error err = sl.compile(code, ShaderTypes::get_singleton()->get_functions(RenderingServer::ShaderMode(visual_shader->get_mode())), ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(visual_shader->get_mode())), ShaderTypes::get_singleton()->get_types());
+	Error err = sl.compile(code, ShaderTypes::get_singleton()->get_functions(RenderingServer::ShaderMode(visual_shader->get_mode())), ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(visual_shader->get_mode())), ShaderTypes::get_singleton()->get_types(), _get_global_variable_type);
 
 	for (int i = 0; i < preview_text->get_line_count(); i++) {
 		preview_text->set_line_as_marked(i, false);
@@ -3291,7 +3297,7 @@ void EditorInspectorShaderModePlugin::parse_begin(Object *p_object) {
 	//do none
 }
 
-bool EditorInspectorShaderModePlugin::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage) {
+bool EditorInspectorShaderModePlugin::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide) {
 
 	if (p_path == "mode" && p_object->is_class("VisualShader") && p_type == Variant::INT) {
 

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -338,7 +338,7 @@ class EditorInspectorShaderModePlugin : public EditorInspectorPlugin {
 public:
 	virtual bool can_handle(Object *p_object);
 	virtual void parse_begin(Object *p_object);
-	virtual bool parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage);
+	virtual bool parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage, bool p_wide = false);
 	virtual void parse_end();
 };
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -2135,6 +2135,11 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	tab_container->add_child(autoload_settings);
 	autoload_settings->connect("autoload_changed", callable_mp(this, &ProjectSettingsEditor::_settings_changed));
 
+	shaders_global_variables_editor = memnew(ShaderGlobalsEditor);
+	shaders_global_variables_editor->set_name(TTR("Shader Globals"));
+	tab_container->add_child(shaders_global_variables_editor);
+	shaders_global_variables_editor->connect("globals_changed", callable_mp(this, &ProjectSettingsEditor::_settings_changed));
+
 	plugin_settings = memnew(EditorPluginSettings);
 	plugin_settings->set_name(TTR("Plugins"));
 	tab_container->add_child(plugin_settings);

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -36,6 +36,7 @@
 #include "editor/editor_data.h"
 #include "editor/editor_plugin_settings.h"
 #include "editor/editor_sectioned_inspector.h"
+#include "editor/shader_globals_editor.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/tab_container.h"
 
@@ -85,6 +86,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	OptionButton *device_index;
 	Label *device_index_label;
 	MenuButton *popup_copy_to_feature;
+	ShaderGlobalsEditor *shaders_global_variables_editor;
 
 	LineEdit *action_name;
 	Button *action_add;

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -1,0 +1,452 @@
+#include "shader_globals_editor.h"
+#include "editor_node.h"
+
+static const char *global_var_type_names[RS::GLOBAL_VAR_TYPE_MAX] = {
+	"bool",
+	"bvec2",
+	"bvec3",
+	"bvec4",
+	"int",
+	"ivec2",
+	"ivec3",
+	"ivec4",
+	"rect2i",
+	"uint",
+	"uvec2",
+	"uvec3",
+	"uvec4",
+	"float",
+	"vec2",
+	"vec3",
+	"vec4",
+	"color",
+	"rect2",
+	"mat2",
+	"mat3",
+	"mat4",
+	"transform_2d",
+	"transform",
+	"sampler2D",
+	"sampler2DArray",
+	"sampler3D",
+	"samplerCube",
+};
+
+class ShaderGlobalsEditorInterface : public Object {
+	GDCLASS(ShaderGlobalsEditorInterface, Object)
+
+	void _var_changed() {
+		emit_signal("var_changed");
+	}
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method("_var_changed", &ShaderGlobalsEditorInterface::_var_changed);
+		ADD_SIGNAL(MethodInfo("var_changed"));
+	}
+
+	bool _set(const StringName &p_name, const Variant &p_value) {
+		Variant existing = RS::get_singleton()->global_variable_get(p_name);
+
+		if (existing.get_type() == Variant::NIL) {
+			return false;
+		}
+
+		UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
+
+		undo_redo->create_action("Set Shader Global Variable");
+		undo_redo->add_do_method(RS::get_singleton(), "global_variable_set", p_name, p_value);
+		undo_redo->add_undo_method(RS::get_singleton(), "global_variable_set", p_name, existing);
+		RS::GlobalVariableType type = RS::get_singleton()->global_variable_get_type(p_name);
+		Dictionary gv;
+		gv["type"] = global_var_type_names[type];
+		if (type >= RS::GLOBAL_VAR_TYPE_SAMPLER2D) {
+			RES res = p_value;
+			if (res.is_valid()) {
+				gv["value"] = res->get_path();
+			} else {
+				gv["value"] = "";
+			}
+		} else {
+			gv["value"] = p_value;
+		}
+
+		String path = "shader_globals/" + String(p_name);
+		undo_redo->add_do_property(ProjectSettings::get_singleton(), path, gv);
+		undo_redo->add_undo_property(ProjectSettings::get_singleton(), path, ProjectSettings::get_singleton()->get(path));
+		undo_redo->add_do_method(this, "_var_changed");
+		undo_redo->add_undo_method(this, "_var_changed");
+		block_update = true;
+		undo_redo->commit_action();
+		block_update = false;
+
+		print_line("all good?");
+		return true;
+	}
+
+	bool _get(const StringName &p_name, Variant &r_ret) const {
+		r_ret = RS::get_singleton()->global_variable_get(p_name);
+		return r_ret.get_type() != Variant::NIL;
+	}
+	void _get_property_list(List<PropertyInfo> *p_list) const {
+		Vector<StringName> variables;
+		variables = RS::get_singleton()->global_variable_get_list();
+		for (int i = 0; i < variables.size(); i++) {
+			PropertyInfo pinfo;
+			pinfo.name = variables[i];
+
+			switch (RS::get_singleton()->global_variable_get_type(variables[i])) {
+				case RS::GLOBAL_VAR_TYPE_BOOL: {
+					pinfo.type = Variant::BOOL;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_BVEC2: {
+					pinfo.type = Variant::INT;
+					pinfo.hint = PROPERTY_HINT_FLAGS;
+					pinfo.hint_string = "x,y";
+				} break;
+				case RS::GLOBAL_VAR_TYPE_BVEC3: {
+					pinfo.type = Variant::INT;
+					pinfo.hint = PROPERTY_HINT_FLAGS;
+					pinfo.hint_string = "x,y,z";
+				} break;
+				case RS::GLOBAL_VAR_TYPE_BVEC4: {
+					pinfo.type = Variant::INT;
+					pinfo.hint = PROPERTY_HINT_FLAGS;
+					pinfo.hint_string = "x,y,z,w";
+				} break;
+				case RS::GLOBAL_VAR_TYPE_INT: {
+					pinfo.type = Variant::INT;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_IVEC2: {
+					pinfo.type = Variant::VECTOR2I;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_IVEC3: {
+					pinfo.type = Variant::VECTOR3I;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_IVEC4: {
+					pinfo.type = Variant::PACKED_INT32_ARRAY;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_RECT2I: {
+					pinfo.type = Variant::RECT2I;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_UINT: {
+					pinfo.type = Variant::INT;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_UVEC2: {
+					pinfo.type = Variant::VECTOR2I;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_UVEC3: {
+					pinfo.type = Variant::VECTOR3I;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_UVEC4: {
+					pinfo.type = Variant::PACKED_INT32_ARRAY;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_FLOAT: {
+					pinfo.type = Variant::FLOAT;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_VEC2: {
+					pinfo.type = Variant::VECTOR2;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_VEC3: {
+					pinfo.type = Variant::VECTOR3;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_VEC4: {
+					pinfo.type = Variant::PLANE;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_RECT2: {
+					pinfo.type = Variant::RECT2;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_COLOR: {
+					pinfo.type = Variant::COLOR;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_MAT2: {
+					pinfo.type = Variant::PACKED_INT32_ARRAY;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_MAT3: {
+					pinfo.type = Variant::BASIS;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_TRANSFORM_2D: {
+					pinfo.type = Variant::TRANSFORM2D;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_TRANSFORM: {
+					pinfo.type = Variant::TRANSFORM;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_MAT4: {
+					pinfo.type = Variant::PACKED_INT32_ARRAY;
+				} break;
+				case RS::GLOBAL_VAR_TYPE_SAMPLER2D: {
+					pinfo.type = Variant::OBJECT;
+					pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
+					pinfo.hint_string = "Texture2D";
+				} break;
+				case RS::GLOBAL_VAR_TYPE_SAMPLER2DARRAY: {
+					pinfo.type = Variant::OBJECT;
+					pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
+					pinfo.hint_string = "Texture2DArray";
+				} break;
+				case RS::GLOBAL_VAR_TYPE_SAMPLER3D: {
+					pinfo.type = Variant::OBJECT;
+					pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
+					pinfo.hint_string = "Texture3D";
+				} break;
+				case RS::GLOBAL_VAR_TYPE_SAMPLERCUBE: {
+					pinfo.type = Variant::OBJECT;
+					pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
+					pinfo.hint_string = "Cubemap";
+				} break;
+				default: {
+
+				} break;
+			}
+
+			p_list->push_back(pinfo);
+		}
+	}
+
+public:
+	bool block_update = false;
+
+	ShaderGlobalsEditorInterface() {
+	}
+};
+
+static Variant create_var(RS::GlobalVariableType p_type) {
+	switch (p_type) {
+		case RS::GLOBAL_VAR_TYPE_BOOL: {
+			return false;
+		}
+		case RS::GLOBAL_VAR_TYPE_BVEC2: {
+			return 0; //bits
+		}
+		case RS::GLOBAL_VAR_TYPE_BVEC3: {
+			return 0; //bits
+		}
+		case RS::GLOBAL_VAR_TYPE_BVEC4: {
+			return 0; //bits
+		}
+		case RS::GLOBAL_VAR_TYPE_INT: {
+			return 0; //bits
+		}
+		case RS::GLOBAL_VAR_TYPE_IVEC2: {
+			return Vector2i();
+		}
+		case RS::GLOBAL_VAR_TYPE_IVEC3: {
+			return Vector3i();
+		}
+		case RS::GLOBAL_VAR_TYPE_IVEC4: {
+			Vector<int> v4;
+			v4.resize(4);
+			v4.write[0] = 0;
+			v4.write[1] = 0;
+			v4.write[2] = 0;
+			v4.write[3] = 0;
+			return v4;
+		}
+		case RS::GLOBAL_VAR_TYPE_RECT2I: {
+			return Rect2i();
+		}
+		case RS::GLOBAL_VAR_TYPE_UINT: {
+			return 0;
+		}
+		case RS::GLOBAL_VAR_TYPE_UVEC2: {
+			return Vector2i();
+		}
+		case RS::GLOBAL_VAR_TYPE_UVEC3: {
+			return Vector3i();
+		}
+		case RS::GLOBAL_VAR_TYPE_UVEC4: {
+			return Rect2i();
+		}
+		case RS::GLOBAL_VAR_TYPE_FLOAT: {
+			return 0.0;
+		}
+		case RS::GLOBAL_VAR_TYPE_VEC2: {
+			return Vector2();
+		}
+		case RS::GLOBAL_VAR_TYPE_VEC3: {
+			return Vector3();
+		}
+		case RS::GLOBAL_VAR_TYPE_VEC4: {
+			return Plane();
+		}
+		case RS::GLOBAL_VAR_TYPE_RECT2: {
+			return Rect2();
+		}
+		case RS::GLOBAL_VAR_TYPE_COLOR: {
+			return Color();
+		}
+		case RS::GLOBAL_VAR_TYPE_MAT2: {
+			Vector<real_t> xform;
+			xform.resize(4);
+			xform.write[0] = 1;
+			xform.write[1] = 0;
+			xform.write[2] = 0;
+			xform.write[3] = 1;
+			return xform;
+		}
+		case RS::GLOBAL_VAR_TYPE_MAT3: {
+			return Basis();
+		}
+		case RS::GLOBAL_VAR_TYPE_TRANSFORM_2D: {
+			return Transform2D();
+		}
+		case RS::GLOBAL_VAR_TYPE_TRANSFORM: {
+			return Transform();
+		}
+		case RS::GLOBAL_VAR_TYPE_MAT4: {
+			Vector<real_t> xform;
+			xform.resize(4);
+			xform.write[0] = 1;
+			xform.write[1] = 0;
+			xform.write[2] = 0;
+			xform.write[3] = 0;
+
+			xform.write[4] = 0;
+			xform.write[5] = 1;
+			xform.write[6] = 0;
+			xform.write[7] = 0;
+
+			xform.write[8] = 0;
+			xform.write[9] = 0;
+			xform.write[10] = 1;
+			xform.write[11] = 0;
+
+			xform.write[12] = 0;
+			xform.write[13] = 0;
+			xform.write[14] = 0;
+			xform.write[15] = 1;
+
+			return xform;
+		}
+		case RS::GLOBAL_VAR_TYPE_SAMPLER2D: {
+			return "";
+		}
+		case RS::GLOBAL_VAR_TYPE_SAMPLER2DARRAY: {
+			return "";
+		}
+		case RS::GLOBAL_VAR_TYPE_SAMPLER3D: {
+			return "";
+		}
+		case RS::GLOBAL_VAR_TYPE_SAMPLERCUBE: {
+			return "";
+		}
+		default: {
+			return Variant();
+		}
+	}
+}
+
+void ShaderGlobalsEditor::_variable_added() {
+
+	String var = variable_name->get_text().strip_edges();
+	if (var == "" || !var.is_valid_identifier()) {
+		EditorNode::get_singleton()->show_warning(TTR("Please specify a valid variable identifier name."));
+		return;
+	}
+
+	if (RenderingServer::get_singleton()->global_variable_get(var).get_type() != Variant::NIL) {
+		EditorNode::get_singleton()->show_warning(vformat(TTR("Global variable '%s' already exists'"), var));
+		return;
+	}
+
+	List<String> keywords;
+	ShaderLanguage::get_keyword_list(&keywords);
+
+	if (keywords.find(var) != nullptr || var == "script") {
+		EditorNode::get_singleton()->show_warning(vformat(TTR("Name '%s' is a reserved shader language keyword."), var));
+		return;
+	}
+
+	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
+
+	Variant value = create_var(RS::GlobalVariableType(variable_type->get_selected()));
+
+	undo_redo->create_action("Add Shader Global Variable");
+	undo_redo->add_do_method(RS::get_singleton(), "global_variable_add", var, RS::GlobalVariableType(variable_type->get_selected()), value);
+	undo_redo->add_undo_method(RS::get_singleton(), "global_variable_remove", var);
+	Dictionary gv;
+	gv["type"] = global_var_type_names[variable_type->get_selected()];
+	gv["value"] = value;
+
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "shader_globals/" + var, gv);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "shader_globals/" + var, Variant());
+	undo_redo->add_do_method(this, "_changed");
+	undo_redo->add_undo_method(this, "_changed");
+	undo_redo->commit_action();
+}
+
+void ShaderGlobalsEditor::_variable_deleted(const String &p_variable) {
+
+	print_line("deleted " + p_variable);
+	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
+
+	undo_redo->create_action("Add Shader Global Variable");
+	undo_redo->add_do_method(RS::get_singleton(), "global_variable_remove", p_variable);
+	undo_redo->add_undo_method(RS::get_singleton(), "global_variable_add", p_variable, RS::get_singleton()->global_variable_get_type(p_variable), RS::get_singleton()->global_variable_get(p_variable));
+
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "shader_globals/" + p_variable, Variant());
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "shader_globals/" + p_variable, ProjectSettings::get_singleton()->get("shader_globals/" + p_variable));
+	undo_redo->add_do_method(this, "_changed");
+	undo_redo->add_undo_method(this, "_changed");
+	undo_redo->commit_action();
+}
+
+void ShaderGlobalsEditor::_changed() {
+	emit_signal("globals_changed");
+	if (!interface->block_update) {
+		interface->_change_notify();
+	}
+}
+
+void ShaderGlobalsEditor::_bind_methods() {
+	ClassDB::bind_method("_changed", &ShaderGlobalsEditor::_changed);
+	ADD_SIGNAL(MethodInfo("globals_changed"));
+}
+
+void ShaderGlobalsEditor::_notification(int p_what) {
+	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+		if (is_visible_in_tree()) {
+			print_line("OK load settings in globalseditor");
+			inspector->edit(interface);
+		}
+	}
+}
+
+ShaderGlobalsEditor::ShaderGlobalsEditor() {
+
+	HBoxContainer *add_menu_hb = memnew(HBoxContainer);
+	add_child(add_menu_hb);
+
+	add_menu_hb->add_child(memnew(Label(TTR("Name:"))));
+	variable_name = memnew(LineEdit);
+	variable_name->set_h_size_flags(SIZE_EXPAND_FILL);
+	add_menu_hb->add_child(variable_name);
+
+	add_menu_hb->add_child(memnew(Label(TTR("Type:"))));
+	variable_type = memnew(OptionButton);
+	variable_type->set_h_size_flags(SIZE_EXPAND_FILL);
+	add_menu_hb->add_child(variable_type);
+
+	for (int i = 0; i < RS::GLOBAL_VAR_TYPE_MAX; i++) {
+		variable_type->add_item(global_var_type_names[i]);
+	}
+
+	variable_add = memnew(Button(TTR("Add")));
+	add_menu_hb->add_child(variable_add);
+	variable_add->connect("pressed", callable_mp(this, &ShaderGlobalsEditor::_variable_added));
+
+	inspector = memnew(EditorInspector);
+	inspector->set_v_size_flags(SIZE_EXPAND_FILL);
+	add_child(inspector);
+	inspector->set_use_wide_editors(true);
+	inspector->set_enable_capitalize_paths(false);
+	inspector->set_use_deletable_properties(true);
+	inspector->connect("property_deleted", callable_mp(this, &ShaderGlobalsEditor::_variable_deleted), varray(), CONNECT_DEFERRED);
+
+	interface = memnew(ShaderGlobalsEditorInterface);
+	interface->connect("var_changed", Callable(this, "_changed"));
+}
+ShaderGlobalsEditor::~ShaderGlobalsEditor() {
+	inspector->edit(NULL);
+	memdelete(interface);
+}

--- a/editor/shader_globals_editor.h
+++ b/editor/shader_globals_editor.h
@@ -1,0 +1,38 @@
+#ifndef SHADER_GLOBALS_EDITOR_H
+#define SHADER_GLOBALS_EDITOR_H
+
+#include "core/undo_redo.h"
+#include "editor/editor_autoload_settings.h"
+#include "editor/editor_data.h"
+#include "editor/editor_plugin_settings.h"
+#include "editor/editor_sectioned_inspector.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/tab_container.h"
+
+class ShaderGlobalsEditorInterface;
+
+class ShaderGlobalsEditor : public VBoxContainer {
+
+	GDCLASS(ShaderGlobalsEditor, VBoxContainer)
+
+	ShaderGlobalsEditorInterface *interface;
+	EditorInspector *inspector;
+
+	LineEdit *variable_name;
+	OptionButton *variable_type;
+	Button *variable_add;
+
+	void _variable_added();
+	void _variable_deleted(const String &p_variable);
+	void _changed();
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	ShaderGlobalsEditor();
+	~ShaderGlobalsEditor();
+};
+
+#endif // SHADER_GLOBALS_EDITOR_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1481,6 +1481,15 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		// We could add more, and make the CLI arg require a comma-separated list of profilers.
 		EngineDebugger::get_singleton()->profiler_enable("scripts", true);
 	}
+
+	if (!project_manager) {
+		// If not running the project manager, and now that the engine is
+		// able to load resources, load the global shader variables.
+		// If running on editor, dont load the textures because the editor
+		// may want to import them first. Editor will reload those later.
+		rendering_server->global_variables_load_settings(!editor);
+	}
+
 	_start_success = true;
 	locale = String();
 
@@ -2279,6 +2288,9 @@ void Main::cleanup() {
 
 	// Sync pending commands that may have been queued from a different thread during ScriptServer finalization
 	RenderingServer::get_singleton()->sync();
+
+	//clear global shader variables before scene and other graphics stuff is deinitialized.
+	rendering_server->global_variables_clear();
 
 #ifdef TOOLS_ENABLED
 	EditorNode::unregister_editor_types();

--- a/main/tests/test_shader_lang.cpp
+++ b/main/tests/test_shader_lang.cpp
@@ -342,7 +342,7 @@ MainLoop *test() {
 	Set<String> types;
 	types.insert("spatial");
 
-	Error err = sl.compile(code, dt, rm, types);
+	Error err = sl.compile(code, dt, rm, types, NULL);
 
 	if (err) {
 

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -108,9 +108,18 @@ private:
 	float lod_min_hysteresis;
 	float lod_max_hysteresis;
 
+	mutable HashMap<StringName, Variant> instance_uniforms;
+	mutable HashMap<StringName, StringName> instance_uniform_property_remap;
+
 	float extra_cull_margin;
 
+	const StringName *_instance_uniform_get_remap(const StringName p_name) const;
+
 protected:
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
 	void _notification(int p_what);
 	static void _bind_methods();
 
@@ -138,6 +147,9 @@ public:
 
 	void set_extra_cull_margin(float p_margin);
 	float get_extra_cull_margin() const;
+
+	void set_shader_instance_uniform(const StringName &p_uniform, const Variant &p_value);
+	Variant get_shader_instance_uniform(const StringName &p_uniform) const;
 
 	void set_custom_aabb(AABB aabb);
 

--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -1,0 +1,257 @@
+#include "shader_globals_override.h"
+
+#include "core/core_string_names.h"
+#include "scene/main/window.h"
+#include "scene/scene_string_names.h"
+
+StringName *ShaderGlobalsOverride::_remap(const StringName &p_name) const {
+
+	StringName *r = param_remaps.getptr(p_name);
+	if (!r) {
+		//not cached, do caching
+		String p = p_name;
+		if (p.begins_with("params/")) {
+			String q = p.replace_first("params/", "");
+			param_remaps[p] = q;
+			r = param_remaps.getptr(q);
+		}
+	}
+
+	return r;
+}
+bool ShaderGlobalsOverride::_set(const StringName &p_name, const Variant &p_value) {
+
+	StringName *r = _remap(p_name);
+
+	if (r) {
+		Override *o = overrides.getptr(*r);
+		if (!o) {
+			Override ov;
+			ov.in_use = false;
+			overrides[*r] = ov;
+			o = overrides.getptr(*r);
+		}
+		if (o) {
+			o->override = p_value;
+			if (active) {
+				RS::get_singleton()->global_variable_set_override(*r, p_value);
+			}
+			o->in_use = p_value.get_type() != Variant::NIL;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool ShaderGlobalsOverride::_get(const StringName &p_name, Variant &r_ret) const {
+
+	StringName *r = _remap(p_name);
+
+	if (r) {
+		const Override *o = overrides.getptr(*r);
+		if (o) {
+			r_ret = o->override;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void ShaderGlobalsOverride::_get_property_list(List<PropertyInfo> *p_list) const {
+
+	Vector<StringName> variables;
+	variables = RS::get_singleton()->global_variable_get_list();
+	for (int i = 0; i < variables.size(); i++) {
+		PropertyInfo pinfo;
+		pinfo.name = "params/" + variables[i];
+		pinfo.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
+
+		switch (RS::get_singleton()->global_variable_get_type(variables[i])) {
+			case RS::GLOBAL_VAR_TYPE_BOOL: {
+				pinfo.type = Variant::BOOL;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_BVEC2: {
+				pinfo.type = Variant::INT;
+				pinfo.hint = PROPERTY_HINT_FLAGS;
+				pinfo.hint_string = "x,y";
+			} break;
+			case RS::GLOBAL_VAR_TYPE_BVEC3: {
+				pinfo.type = Variant::INT;
+				pinfo.hint = PROPERTY_HINT_FLAGS;
+				pinfo.hint_string = "x,y,z";
+			} break;
+			case RS::GLOBAL_VAR_TYPE_BVEC4: {
+				pinfo.type = Variant::INT;
+				pinfo.hint = PROPERTY_HINT_FLAGS;
+				pinfo.hint_string = "x,y,z,w";
+			} break;
+			case RS::GLOBAL_VAR_TYPE_INT: {
+				pinfo.type = Variant::INT;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_IVEC2: {
+				pinfo.type = Variant::VECTOR2I;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_IVEC3: {
+				pinfo.type = Variant::VECTOR3I;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_IVEC4: {
+				pinfo.type = Variant::PACKED_INT32_ARRAY;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_RECT2I: {
+				pinfo.type = Variant::RECT2I;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_UINT: {
+				pinfo.type = Variant::INT;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_UVEC2: {
+				pinfo.type = Variant::VECTOR2I;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_UVEC3: {
+				pinfo.type = Variant::VECTOR3I;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_UVEC4: {
+				pinfo.type = Variant::PACKED_INT32_ARRAY;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_FLOAT: {
+				pinfo.type = Variant::FLOAT;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_VEC2: {
+				pinfo.type = Variant::VECTOR2;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_VEC3: {
+				pinfo.type = Variant::VECTOR3;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_VEC4: {
+				pinfo.type = Variant::PLANE;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_RECT2: {
+				pinfo.type = Variant::RECT2;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_COLOR: {
+				pinfo.type = Variant::COLOR;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_MAT2: {
+				pinfo.type = Variant::PACKED_INT32_ARRAY;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_MAT3: {
+				pinfo.type = Variant::BASIS;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_TRANSFORM_2D: {
+				pinfo.type = Variant::TRANSFORM2D;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_TRANSFORM: {
+				pinfo.type = Variant::TRANSFORM;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_MAT4: {
+				pinfo.type = Variant::PACKED_INT32_ARRAY;
+			} break;
+			case RS::GLOBAL_VAR_TYPE_SAMPLER2D: {
+				pinfo.type = Variant::OBJECT;
+				pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
+				pinfo.hint_string = "Texture2D";
+			} break;
+			case RS::GLOBAL_VAR_TYPE_SAMPLER2DARRAY: {
+				pinfo.type = Variant::OBJECT;
+				pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
+				pinfo.hint_string = "Texture2DArray";
+			} break;
+			case RS::GLOBAL_VAR_TYPE_SAMPLER3D: {
+				pinfo.type = Variant::OBJECT;
+				pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
+				pinfo.hint_string = "Texture3D";
+			} break;
+			case RS::GLOBAL_VAR_TYPE_SAMPLERCUBE: {
+				pinfo.type = Variant::OBJECT;
+				pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
+				pinfo.hint_string = "Cubemap";
+			} break;
+			default: {
+
+			} break;
+		}
+
+		if (!overrides.has(variables[i])) {
+			Override o;
+			o.in_use = false;
+			Callable::CallError ce;
+			o.override = Variant::construct(pinfo.type, NULL, 0, ce);
+			overrides[variables[i]] = o;
+		}
+
+		Override *o = overrides.getptr(variables[i]);
+		if (o->in_use && o->override.get_type() != Variant::NIL) {
+			pinfo.usage |= PROPERTY_USAGE_CHECKED;
+			pinfo.usage |= PROPERTY_USAGE_STORAGE;
+		}
+
+		p_list->push_back(pinfo);
+	}
+}
+
+void ShaderGlobalsOverride::_activate() {
+
+	List<Node *> nodes;
+	get_tree()->get_nodes_in_group(SceneStringNames::get_singleton()->shader_overrides_group_active, &nodes);
+	if (nodes.size() == 0) {
+		//good we are the only override, enable all
+		active = true;
+		add_to_group(SceneStringNames::get_singleton()->shader_overrides_group_active);
+
+		const StringName *K = nullptr;
+		while ((K = overrides.next(K))) {
+			Override *o = overrides.getptr(*K);
+			if (o->in_use && o->override.get_type() != Variant::NIL) {
+				RS::get_singleton()->global_variable_set_override(*K, o->override);
+			}
+		}
+
+		update_configuration_warning(); //may have activated
+	}
+}
+
+void ShaderGlobalsOverride::_notification(int p_what) {
+
+	if (p_what == Node3D::NOTIFICATION_ENTER_TREE) {
+
+		add_to_group(SceneStringNames::get_singleton()->shader_overrides_group);
+		_activate();
+
+	} else if (p_what == Node3D::NOTIFICATION_EXIT_TREE) {
+
+		if (active) {
+			//remove overrides
+			const StringName *K = nullptr;
+			while ((K = overrides.next(K))) {
+				Override *o = overrides.getptr(*K);
+				if (o->in_use) {
+					RS::get_singleton()->global_variable_set_override(*K, Variant());
+				}
+			}
+		}
+
+		remove_from_group(SceneStringNames::get_singleton()->shader_overrides_group_active);
+		remove_from_group(SceneStringNames::get_singleton()->shader_overrides_group);
+		get_tree()->call_group(SceneStringNames::get_singleton()->shader_overrides_group, "_activate"); //another may want to activate when this is removed
+		active = false;
+	}
+}
+
+String ShaderGlobalsOverride::get_configuration_warning() const {
+
+	if (!active) {
+		return TTR("ShaderGlobalsOverride is not active because another node of the same type is in the scene.");
+	}
+
+	return String();
+}
+
+void ShaderGlobalsOverride::_bind_methods() {
+
+	ClassDB::bind_method(D_METHOD("_activate"), &ShaderGlobalsOverride::_activate);
+}
+
+ShaderGlobalsOverride::ShaderGlobalsOverride() {
+	active = false;
+}

--- a/scene/main/shader_globals_override.h
+++ b/scene/main/shader_globals_override.h
@@ -1,0 +1,37 @@
+#ifndef SHADER_GLOBALS_OVERRIDE_H
+#define SHADER_GLOBALS_OVERRIDE_H
+
+#include "scene/3d/node_3d.h"
+
+class ShaderGlobalsOverride : public Node {
+
+	GDCLASS(ShaderGlobalsOverride, Node);
+
+	struct Override {
+		bool in_use = false;
+		Variant override;
+	};
+
+	StringName *_remap(const StringName &p_name) const;
+
+	bool active;
+	mutable HashMap<StringName, Override> overrides;
+	mutable HashMap<StringName, StringName> param_remaps;
+
+	void _activate();
+
+protected:
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	String get_configuration_warning() const;
+
+	ShaderGlobalsOverride();
+};
+
+#endif // SHADER_GLOBALS_OVERRIDE_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -177,6 +177,8 @@
 #include "scene/3d/node_3d.h"
 #include "scene/3d/skeleton_3d.h"
 
+#include "scene/main/shader_globals_override.h"
+
 #ifndef _3D_DISABLED
 #include "scene/3d/area_3d.h"
 #include "scene/3d/audio_stream_player_3d.h"
@@ -402,6 +404,8 @@ void register_scene_types() {
 	ClassDB::register_class<AnimationNodeTimeScale>();
 	ClassDB::register_class<AnimationNodeTimeSeek>();
 	ClassDB::register_class<AnimationNodeTransition>();
+
+	ClassDB::register_class<ShaderGlobalsOverride>(); //can be used in any shader
 
 	OS::get_singleton()->yield(); //may take time to init
 

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -202,4 +202,7 @@ SceneStringNames::SceneStringNames() {
 	parameters_base_path = "parameters/";
 
 	tracks_changed = "tracks_changed";
+
+	shader_overrides_group = StaticCString::create("_shader_overrides_group_");
+	shader_overrides_group_active = StaticCString::create("_shader_overrides_group_active_");
 }

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -207,6 +207,8 @@ public:
 	StringName window_input;
 
 	StringName theme_changed;
+	StringName shader_overrides_group;
+	StringName shader_overrides_group_active;
 
 	enum {
 		MAX_MATERIALS = 32

--- a/servers/rendering/rasterizer.h
+++ b/servers/rendering/rasterizer.h
@@ -167,6 +167,17 @@ public:
 		AABB aabb;
 		AABB transformed_aabb;
 
+		struct InstanceShaderParameter {
+			int32_t index = -1;
+			Variant value;
+			Variant default_value;
+			PropertyInfo info;
+		};
+
+		Map<StringName, InstanceShaderParameter> instance_shader_parameters;
+		bool instance_allocated_shader_parameters = false;
+		int32_t instance_allocated_shader_parameters_offset = -1;
+
 		virtual void dependency_deleted(RID p_dependency) = 0;
 		virtual void dependency_changed(bool p_aabb, bool p_dependencies) = 0;
 
@@ -356,6 +367,14 @@ public:
 
 	virtual bool material_is_animated(RID p_material) = 0;
 	virtual bool material_casts_shadows(RID p_material) = 0;
+
+	struct InstanceShaderParam {
+		PropertyInfo info;
+		int index;
+		Variant default_value;
+	};
+
+	virtual void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) = 0;
 
 	virtual void material_update_dependency(RID p_material, RasterizerScene::InstanceBase *p_instance) = 0;
 
@@ -634,6 +653,24 @@ public:
 
 	virtual int particles_get_draw_passes(RID p_particles) const = 0;
 	virtual RID particles_get_draw_pass_mesh(RID p_particles, int p_pass) const = 0;
+
+	/* GLOBAL VARIABLES */
+
+	virtual void global_variable_add(const StringName &p_name, RS::GlobalVariableType p_type, const Variant &p_value) = 0;
+	virtual void global_variable_remove(const StringName &p_name) = 0;
+	virtual Vector<StringName> global_variable_get_list() const = 0;
+
+	virtual void global_variable_set(const StringName &p_name, const Variant &p_value) = 0;
+	virtual void global_variable_set_override(const StringName &p_name, const Variant &p_value) = 0;
+	virtual Variant global_variable_get(const StringName &p_name) const = 0;
+	virtual RS::GlobalVariableType global_variable_get_type(const StringName &p_name) const = 0;
+
+	virtual void global_variables_load_settings(bool p_load_textures = true) = 0;
+	virtual void global_variables_clear() = 0;
+
+	virtual int32_t global_variables_instance_allocate(RID p_instance) = 0;
+	virtual void global_variables_instance_free(RID p_instance) = 0;
+	virtual void global_variables_instance_update(RID p_instance, int p_index, const Variant &p_value) = 0;
 
 	/* RENDER TARGET */
 

--- a/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.h
@@ -185,6 +185,8 @@ class RasterizerCanvasRD : public RasterizerCanvas {
 		virtual void set_code(const String &p_Code);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture);
 		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+		virtual void get_instance_param_list(List<RasterizerStorage::InstanceShaderParam> *p_param_list) const;
+
 		virtual bool is_param_texture(const StringName &p_param) const;
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -378,6 +378,10 @@ void RasterizerSceneHighEndRD::ShaderData::get_param_list(List<PropertyInfo> *p_
 
 	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = uniforms.front(); E; E = E->next()) {
 
+		if (E->get().scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_LOCAL) {
+			continue;
+		}
+
 		if (E->get().texture_order >= 0) {
 			order[E->get().texture_order + 100000] = E->key();
 		} else {
@@ -390,6 +394,23 @@ void RasterizerSceneHighEndRD::ShaderData::get_param_list(List<PropertyInfo> *p_
 		PropertyInfo pi = ShaderLanguage::uniform_to_property_info(uniforms[E->get()]);
 		pi.name = E->get();
 		p_param_list->push_back(pi);
+	}
+}
+
+void RasterizerSceneHighEndRD::ShaderData::get_instance_param_list(List<RasterizerStorage::InstanceShaderParam> *p_param_list) const {
+
+	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = uniforms.front(); E; E = E->next()) {
+
+		if (E->get().scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
+			continue;
+		}
+
+		RasterizerStorage::InstanceShaderParam p;
+		p.info = ShaderLanguage::uniform_to_property_info(E->get());
+		p.info.name = E->key(); //supply name
+		p.index = E->get().instance_index;
+		p.default_value = ShaderLanguage::constant_value_to_variant(E->get().default_value, E->get().type, E->get().hint);
+		p_param_list->push_back(p);
 	}
 }
 
@@ -828,6 +849,7 @@ void RasterizerSceneHighEndRD::_fill_instances(RenderList::Element **p_elements,
 		store_transform(Transform(e->instance->transform.basis.inverse().transposed()), id.normal_transform);
 		id.flags = 0;
 		id.mask = e->instance->layer_mask;
+		id.instance_uniforms_ofs = e->instance->instance_allocated_shader_parameters_offset >= 0 ? e->instance->instance_allocated_shader_parameters_offset : 0;
 
 		if (e->instance->base_type == RS::INSTANCE_MULTIMESH) {
 			id.flags |= INSTANCE_DATA_FLAG_MULTIMESH;
@@ -2701,6 +2723,14 @@ void RasterizerSceneHighEndRD::_update_render_base_uniform_set() {
 			uniforms.push_back(u);
 		}
 
+		{
+			RD::Uniform u;
+			u.type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
+			u.binding = 16;
+			u.ids.push_back(storage->global_variables_get_storage_buffer());
+			uniforms.push_back(u);
+		}
+
 		render_base_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, default_shader_rd, SCENE_UNIFORM_SET);
 	}
 }
@@ -3077,6 +3107,8 @@ RasterizerSceneHighEndRD::RasterizerSceneHighEndRD(RasterizerStorageRD *p_storag
 
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
+		actions.global_buffer_array_variable = "global_variables.data";
+		actions.instance_uniform_index_variable = "instances.data[instance_index].instance_uniforms_ofs";
 
 		shader.compiler.initialize(actions);
 	}

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.h
@@ -152,6 +152,8 @@ class RasterizerSceneHighEndRD : public RasterizerSceneRD {
 		virtual void set_code(const String &p_Code);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture);
 		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+		void get_instance_param_list(List<RasterizerStorage::InstanceShaderParam> *p_param_list) const;
+
 		virtual bool is_param_texture(const StringName &p_param) const;
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;
@@ -361,7 +363,7 @@ class RasterizerSceneHighEndRD : public RasterizerSceneRD {
 		float transform[16];
 		float normal_transform[16];
 		uint32_t flags;
-		uint32_t instance_ofs; //instance_offset in instancing/skeleton buffer
+		uint32_t instance_uniforms_ofs; //instance_offset in instancing/skeleton buffer
 		uint32_t gi_offset; //GI information when using lightmapping (VCT or lightmap)
 		uint32_t mask;
 	};

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_rd.h
@@ -189,6 +189,7 @@ private:
 		virtual void set_code(const String &p_Code);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture);
 		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+		virtual void get_instance_param_list(List<RasterizerStorage::InstanceShaderParam> *p_param_list) const;
 		virtual bool is_param_texture(const StringName &p_param) const;
 		virtual bool is_animated() const;
 		virtual bool casts_shadows() const;

--- a/servers/rendering/rasterizer_rd/shader_compiler_rd.h
+++ b/servers/rendering/rasterizer_rd/shader_compiler_rd.h
@@ -57,6 +57,7 @@ public:
 			ShaderLanguage::ShaderNode::Uniform::Hint hint;
 			ShaderLanguage::TextureFilter filter;
 			ShaderLanguage::TextureRepeat repeat;
+			bool global;
 		};
 
 		Vector<Texture> texture_uniforms;
@@ -70,6 +71,7 @@ public:
 		String fragment;
 		String light;
 
+		bool uses_global_textures;
 		bool uses_fragment_time;
 		bool uses_vertex_time;
 	};
@@ -86,6 +88,8 @@ public:
 		int base_texture_binding_index = 0;
 		int texture_layout_set = 0;
 		String base_uniform_string;
+		String global_buffer_array_variable;
+		String instance_uniform_index_variable;
 		uint32_t base_varying_index = 0;
 	};
 
@@ -112,6 +116,8 @@ private:
 	Set<StringName> internal_functions;
 
 	DefaultIdentifierActions actions;
+
+	static ShaderLanguage::DataType _get_variable_type(const StringName &p_type);
 
 public:
 	Error compile(RS::ShaderMode p_mode, const String &p_code, IdentifierActions *p_actions, const String &p_path, GeneratedCode &r_gen_code);

--- a/servers/rendering/rasterizer_rd/shaders/canvas_uniforms_inc.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/canvas_uniforms_inc.glsl
@@ -132,6 +132,11 @@ layout(set = 2, binding = 6) uniform sampler shadow_sampler;
 
 #endif
 
+layout(set = 2, binding = 7, std430) restrict readonly buffer GlobalVariableData {
+	vec4 data[];
+}
+global_variables;
+
 /* SET3: Render Target Data */
 
 #ifdef SCREEN_TEXTURE_USED

--- a/servers/rendering/rasterizer_rd/shaders/scene_high_end_inc.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/scene_high_end_inc.glsl
@@ -134,7 +134,7 @@ struct InstanceData {
 	mat4 transform;
 	mat4 normal_transform;
 	uint flags;
-	uint instance_ofs; //instance_offset in instancing/skeleton buffer
+	uint instance_uniforms_ofs; //base offset in global buffer for instance variables
 	uint gi_offset; //GI information when using lightmapping (VCT or lightmap)
 	uint layer_mask;
 };
@@ -286,6 +286,11 @@ layout(set = 0, binding = 14, std430) restrict readonly buffer ClusterData {
 cluster_data;
 
 layout(set = 0, binding = 15) uniform texture2D directional_shadow_atlas;
+
+layout(set = 0, binding = 16, std430) restrict readonly buffer GlobalVariableData {
+	vec4 data[];
+}
+global_variables;
 
 // decal atlas
 

--- a/servers/rendering/rasterizer_rd/shaders/sky.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/sky.glsl
@@ -58,6 +58,11 @@ params;
 
 layout(set = 0, binding = 0) uniform sampler material_samplers[12];
 
+layout(set = 0, binding = 1, std430) restrict readonly buffer GlobalVariableData {
+	vec4 data[];
+}
+global_variables;
+
 #ifdef USE_MATERIAL_UNIFORMS
 layout(set = 1, binding = 0, std140) uniform MaterialUniforms{
 	/* clang-format off */

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1025,7 +1025,6 @@ public:
 	virtual uint32_t get_frame_delay() const = 0;
 
 	static RenderingDevice *get_singleton();
-
 	RenderingDevice();
 };
 

--- a/servers/rendering/rendering_server_raster.h
+++ b/servers/rendering/rendering_server_raster.h
@@ -98,6 +98,8 @@ public:
 
 #define BIND0R(m_r, m_name) \
 	m_r m_name() { return BINDBASE->m_name(); }
+#define BIND0RC(m_r, m_name) \
+	m_r m_name() const { return BINDBASE->m_name(); }
 #define BIND1R(m_r, m_name, m_type1) \
 	m_r m_name(m_type1 arg1) { return BINDBASE->m_name(arg1); }
 #define BIND1RC(m_r, m_name, m_type1) \
@@ -111,8 +113,12 @@ public:
 #define BIND4RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4) \
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) const { return BINDBASE->m_name(arg1, arg2, arg3, arg4); }
 
+#define BIND0(m_name) \
+	void m_name() { DISPLAY_CHANGED BINDBASE->m_name(); }
 #define BIND1(m_name, m_type1) \
 	void m_name(m_type1 arg1) { DISPLAY_CHANGED BINDBASE->m_name(arg1); }
+#define BIND1C(m_name, m_type1) \
+	void m_name(m_type1 arg1) const { DISPLAY_CHANGED BINDBASE->m_name(arg1); }
 #define BIND2(m_name, m_type1, m_type2) \
 	void m_name(m_type1 arg1, m_type2 arg2) { DISPLAY_CHANGED BINDBASE->m_name(arg1, arg2); }
 #define BIND2C(m_name, m_type1, m_type2) \
@@ -620,6 +626,11 @@ public:
 	BIND5(instance_geometry_set_draw_range, RID, float, float, float, float)
 	BIND2(instance_geometry_set_as_instance_lod, RID, RID)
 
+	BIND3(instance_geometry_set_shader_parameter, RID, const StringName &, const Variant &)
+	BIND2RC(Variant, instance_geometry_get_shader_parameter, RID, const StringName &)
+	BIND2RC(Variant, instance_geometry_get_shader_parameter_default_value, RID, const StringName &)
+	BIND2C(instance_geometry_get_shader_parameter_list, RID, List<PropertyInfo> *)
+
 #undef BINDBASE
 //from now on, calls forwarded to this singleton
 #define BINDBASE RSG::canvas
@@ -716,6 +727,23 @@ public:
 	BIND2(canvas_occluder_polygon_set_shape_as_lines, RID, const Vector<Vector2> &)
 
 	BIND2(canvas_occluder_polygon_set_cull_mode, RID, CanvasOccluderPolygonCullMode)
+
+	/* GLOBAL VARIABLES */
+
+#undef BINDBASE
+//from now on, calls forwarded to this singleton
+#define BINDBASE RSG::storage
+
+	BIND3(global_variable_add, const StringName &, GlobalVariableType, const Variant &)
+	BIND1(global_variable_remove, const StringName &)
+	BIND0RC(Vector<StringName>, global_variable_get_list)
+	BIND2(global_variable_set, const StringName &, const Variant &)
+	BIND2(global_variable_set_override, const StringName &, const Variant &)
+	BIND1RC(GlobalVariableType, global_variable_get_type, const StringName &)
+	BIND1RC(Variant, global_variable_get, const StringName &)
+
+	BIND1(global_variables_load_settings, bool)
+	BIND0(global_variables_clear)
 
 	/* BLACK BARS */
 

--- a/servers/rendering/rendering_server_scene.h
+++ b/servers/rendering/rendering_server_scene.h
@@ -435,6 +435,13 @@ public:
 	virtual void instance_geometry_set_draw_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin);
 	virtual void instance_geometry_set_as_instance_lod(RID p_instance, RID p_as_lod_of_instance);
 
+	void _update_instance_shader_parameters_from_material(Map<StringName, RasterizerScene::InstanceBase::InstanceShaderParameter> &isparams, const Map<StringName, RasterizerScene::InstanceBase::InstanceShaderParameter> &existing_isparams, RID p_material);
+
+	virtual void instance_geometry_set_shader_parameter(RID p_instance, const StringName &p_parameter, const Variant &p_value);
+	virtual void instance_geometry_get_shader_parameter_list(RID p_instance, List<PropertyInfo> *p_parameters) const;
+	virtual Variant instance_geometry_get_shader_parameter(RID p_instance, const StringName &p_parameter) const;
+	virtual Variant instance_geometry_get_shader_parameter_default_value(RID p_instance, const StringName &p_parameter) const;
+
 	_FORCE_INLINE_ void _update_instance(Instance *p_instance);
 	_FORCE_INLINE_ void _update_instance_aabb(Instance *p_instance);
 	_FORCE_INLINE_ void _update_dirty_instance(Instance *p_instance);

--- a/servers/rendering/rendering_server_wrap_mt.h
+++ b/servers/rendering/rendering_server_wrap_mt.h
@@ -532,6 +532,11 @@ public:
 	FUNC5(instance_geometry_set_draw_range, RID, float, float, float, float)
 	FUNC2(instance_geometry_set_as_instance_lod, RID, RID)
 
+	FUNC3(instance_geometry_set_shader_parameter, RID, const StringName &, const Variant &)
+	FUNC2RC(Variant, instance_geometry_get_shader_parameter, RID, const StringName &)
+	FUNC2RC(Variant, instance_geometry_get_shader_parameter_default_value, RID, const StringName &)
+	FUNC2SC(instance_geometry_get_shader_parameter_list, RID, List<PropertyInfo> *)
+
 	/* CANVAS (2D) */
 
 	FUNCRID(canvas)
@@ -624,6 +629,18 @@ public:
 	FUNC2(canvas_occluder_polygon_set_shape_as_lines, RID, const Vector<Vector2> &)
 
 	FUNC2(canvas_occluder_polygon_set_cull_mode, RID, CanvasOccluderPolygonCullMode)
+
+	/* GLOBAL VARIABLES */
+
+	FUNC3(global_variable_add, const StringName &, GlobalVariableType, const Variant &)
+	FUNC1(global_variable_remove, const StringName &)
+	FUNC0RC(Vector<StringName>, global_variable_get_list)
+	FUNC2(global_variable_set, const StringName &, const Variant &)
+	FUNC2(global_variable_set_override, const StringName &, const Variant &)
+	FUNC1RC(GlobalVariableType, global_variable_get_type, const StringName &)
+	FUNC1RC(Variant, global_variable_get, const StringName &)
+	FUNC1(global_variables_load_settings, bool)
+	FUNC0(global_variables_clear)
 
 	/* BLACK BARS */
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1565,6 +1565,42 @@ Array RenderingServer::_mesh_surface_get_skeleton_aabb_bind(RID p_mesh, int p_su
 	return arr;
 }
 #endif
+
+ShaderLanguage::DataType RenderingServer::global_variable_type_get_shader_datatype(GlobalVariableType p_type) {
+
+	switch (p_type) {
+		case RS::GLOBAL_VAR_TYPE_BOOL: return ShaderLanguage::TYPE_BOOL;
+		case RS::GLOBAL_VAR_TYPE_BVEC2: return ShaderLanguage::TYPE_BVEC2;
+		case RS::GLOBAL_VAR_TYPE_BVEC3: return ShaderLanguage::TYPE_BVEC3;
+		case RS::GLOBAL_VAR_TYPE_BVEC4: return ShaderLanguage::TYPE_BVEC4;
+		case RS::GLOBAL_VAR_TYPE_INT: return ShaderLanguage::TYPE_INT;
+		case RS::GLOBAL_VAR_TYPE_IVEC2: return ShaderLanguage::TYPE_IVEC2;
+		case RS::GLOBAL_VAR_TYPE_IVEC3: return ShaderLanguage::TYPE_IVEC3;
+		case RS::GLOBAL_VAR_TYPE_IVEC4: return ShaderLanguage::TYPE_IVEC4;
+		case RS::GLOBAL_VAR_TYPE_RECT2I: return ShaderLanguage::TYPE_IVEC4;
+		case RS::GLOBAL_VAR_TYPE_UINT: return ShaderLanguage::TYPE_UINT;
+		case RS::GLOBAL_VAR_TYPE_UVEC2: return ShaderLanguage::TYPE_UVEC2;
+		case RS::GLOBAL_VAR_TYPE_UVEC3: return ShaderLanguage::TYPE_UVEC3;
+		case RS::GLOBAL_VAR_TYPE_UVEC4: return ShaderLanguage::TYPE_UVEC4;
+		case RS::GLOBAL_VAR_TYPE_FLOAT: return ShaderLanguage::TYPE_FLOAT;
+		case RS::GLOBAL_VAR_TYPE_VEC2: return ShaderLanguage::TYPE_VEC2;
+		case RS::GLOBAL_VAR_TYPE_VEC3: return ShaderLanguage::TYPE_VEC3;
+		case RS::GLOBAL_VAR_TYPE_VEC4: return ShaderLanguage::TYPE_VEC4;
+		case RS::GLOBAL_VAR_TYPE_COLOR: return ShaderLanguage::TYPE_VEC4;
+		case RS::GLOBAL_VAR_TYPE_RECT2: return ShaderLanguage::TYPE_VEC4;
+		case RS::GLOBAL_VAR_TYPE_MAT2: return ShaderLanguage::TYPE_MAT2;
+		case RS::GLOBAL_VAR_TYPE_MAT3: return ShaderLanguage::TYPE_MAT3;
+		case RS::GLOBAL_VAR_TYPE_MAT4: return ShaderLanguage::TYPE_MAT4;
+		case RS::GLOBAL_VAR_TYPE_TRANSFORM_2D: return ShaderLanguage::TYPE_MAT3;
+		case RS::GLOBAL_VAR_TYPE_TRANSFORM: return ShaderLanguage::TYPE_MAT4;
+		case RS::GLOBAL_VAR_TYPE_SAMPLER2D: return ShaderLanguage::TYPE_SAMPLER2D;
+		case RS::GLOBAL_VAR_TYPE_SAMPLER2DARRAY: return ShaderLanguage::TYPE_SAMPLER2DARRAY;
+		case RS::GLOBAL_VAR_TYPE_SAMPLER3D: return ShaderLanguage::TYPE_SAMPLER3D;
+		case RS::GLOBAL_VAR_TYPE_SAMPLERCUBE: return ShaderLanguage::TYPE_SAMPLERCUBE;
+		default: return ShaderLanguage::TYPE_MAX; //invalid or not found
+	}
+}
+
 void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("force_sync"), &RenderingServer::sync);
@@ -1921,6 +1957,13 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_occluder_polygon_set_shape_as_lines", "occluder_polygon", "shape"), &RenderingServer::canvas_occluder_polygon_set_shape_as_lines);
 	ClassDB::bind_method(D_METHOD("canvas_occluder_polygon_set_cull_mode", "occluder_polygon", "mode"), &RenderingServer::canvas_occluder_polygon_set_cull_mode);
 
+	ClassDB::bind_method(D_METHOD("global_variable_add", "name", "type", "default_value"), &RenderingServer::global_variable_add);
+	ClassDB::bind_method(D_METHOD("global_variable_remove", "name"), &RenderingServer::global_variable_remove);
+	ClassDB::bind_method(D_METHOD("global_variable_get_list"), &RenderingServer::global_variable_get_list);
+	ClassDB::bind_method(D_METHOD("global_variable_set", "name", "value"), &RenderingServer::global_variable_set);
+	ClassDB::bind_method(D_METHOD("global_variable_get", "name"), &RenderingServer::global_variable_get);
+	ClassDB::bind_method(D_METHOD("global_variable_get_type", "name"), &RenderingServer::global_variable_get_type);
+
 	ClassDB::bind_method(D_METHOD("black_bars_set_margins", "left", "top", "right", "bottom"), &RenderingServer::black_bars_set_margins);
 	ClassDB::bind_method(D_METHOD("black_bars_set_images", "left", "top", "right", "bottom"), &RenderingServer::black_bars_set_images);
 
@@ -2206,6 +2249,36 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(CANVAS_OCCLUDER_POLYGON_CULL_CLOCKWISE);
 	BIND_ENUM_CONSTANT(CANVAS_OCCLUDER_POLYGON_CULL_COUNTER_CLOCKWISE);
 
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_BOOL);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_BVEC2);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_BVEC3);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_BVEC4);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_INT);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_IVEC2);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_IVEC3);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_IVEC4);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_RECT2I);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_UINT);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_UVEC2);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_UVEC3);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_UVEC4);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_FLOAT);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_VEC2);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_VEC3);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_VEC4);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_COLOR);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_RECT2);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_MAT2);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_MAT3);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_MAT4);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_TRANSFORM_2D);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_TRANSFORM);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_SAMPLER2D);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_SAMPLER2DARRAY);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_SAMPLER3D);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_SAMPLERCUBE);
+	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_MAX);
+
 	BIND_ENUM_CONSTANT(INFO_OBJECTS_IN_FRAME);
 	BIND_ENUM_CONSTANT(INFO_VERTICES_IN_FRAME);
 	BIND_ENUM_CONSTANT(INFO_MATERIAL_CHANGES_IN_FRAME);
@@ -2370,6 +2443,8 @@ RenderingServer::RenderingServer() {
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/subsurface_scattering/subsurface_scattering_scale", PropertyInfo(Variant::FLOAT, "rendering/quality/subsurface_scattering/subsurface_scattering_scale", PROPERTY_HINT_RANGE, "0.001,1,0.001"));
 	GLOBAL_DEF("rendering/quality/subsurface_scattering/subsurface_scattering_depth_scale", 0.01);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/subsurface_scattering/subsurface_scattering_depth_scale", PropertyInfo(Variant::FLOAT, "rendering/quality/subsurface_scattering/subsurface_scattering_depth_scale", PROPERTY_HINT_RANGE, "0.001,1,0.001"));
+
+	GLOBAL_DEF("rendering/high_end/global_shader_variables_buffer_size", 65536);
 }
 
 RenderingServer::~RenderingServer() {

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -38,6 +38,7 @@
 #include "core/rid.h"
 #include "core/variant.h"
 #include "servers/display_server.h"
+#include "servers/rendering/shader_language.h"
 
 class RenderingServer : public Object {
 
@@ -950,6 +951,11 @@ public:
 	virtual void instance_geometry_set_draw_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin) = 0;
 	virtual void instance_geometry_set_as_instance_lod(RID p_instance, RID p_as_lod_of_instance) = 0;
 
+	virtual void instance_geometry_set_shader_parameter(RID p_instance, const StringName &, const Variant &p_value) = 0;
+	virtual Variant instance_geometry_get_shader_parameter(RID p_instance, const StringName &) const = 0;
+	virtual Variant instance_geometry_get_shader_parameter_default_value(RID p_instance, const StringName &) const = 0;
+	virtual void instance_geometry_get_shader_parameter_list(RID p_instance, List<PropertyInfo> *p_parameters) const = 0;
+
 	/* CANVAS (2D) */
 
 	virtual RID canvas_create() = 0;
@@ -1090,6 +1096,55 @@ public:
 	};
 	virtual void canvas_occluder_polygon_set_cull_mode(RID p_occluder_polygon, CanvasOccluderPolygonCullMode p_mode) = 0;
 
+	/* GLOBAL VARIABLES */
+
+	enum GlobalVariableType {
+		GLOBAL_VAR_TYPE_BOOL,
+		GLOBAL_VAR_TYPE_BVEC2,
+		GLOBAL_VAR_TYPE_BVEC3,
+		GLOBAL_VAR_TYPE_BVEC4,
+		GLOBAL_VAR_TYPE_INT,
+		GLOBAL_VAR_TYPE_IVEC2,
+		GLOBAL_VAR_TYPE_IVEC3,
+		GLOBAL_VAR_TYPE_IVEC4,
+		GLOBAL_VAR_TYPE_RECT2I,
+		GLOBAL_VAR_TYPE_UINT,
+		GLOBAL_VAR_TYPE_UVEC2,
+		GLOBAL_VAR_TYPE_UVEC3,
+		GLOBAL_VAR_TYPE_UVEC4,
+		GLOBAL_VAR_TYPE_FLOAT,
+		GLOBAL_VAR_TYPE_VEC2,
+		GLOBAL_VAR_TYPE_VEC3,
+		GLOBAL_VAR_TYPE_VEC4,
+		GLOBAL_VAR_TYPE_COLOR,
+		GLOBAL_VAR_TYPE_RECT2,
+		GLOBAL_VAR_TYPE_MAT2,
+		GLOBAL_VAR_TYPE_MAT3,
+		GLOBAL_VAR_TYPE_MAT4,
+		GLOBAL_VAR_TYPE_TRANSFORM_2D,
+		GLOBAL_VAR_TYPE_TRANSFORM,
+		GLOBAL_VAR_TYPE_SAMPLER2D,
+		GLOBAL_VAR_TYPE_SAMPLER2DARRAY,
+		GLOBAL_VAR_TYPE_SAMPLER3D,
+		GLOBAL_VAR_TYPE_SAMPLERCUBE,
+		GLOBAL_VAR_TYPE_MAX
+	};
+
+	virtual void global_variable_add(const StringName &p_name, GlobalVariableType p_type, const Variant &p_value) = 0;
+	virtual void global_variable_remove(const StringName &p_name) = 0;
+	virtual Vector<StringName> global_variable_get_list() const = 0;
+
+	virtual void global_variable_set(const StringName &p_name, const Variant &p_value) = 0;
+	virtual void global_variable_set_override(const StringName &p_name, const Variant &p_value) = 0;
+
+	virtual Variant global_variable_get(const StringName &p_name) const = 0;
+	virtual GlobalVariableType global_variable_get_type(const StringName &p_name) const = 0;
+
+	virtual void global_variables_load_settings(bool p_load_textures) = 0;
+	virtual void global_variables_clear() = 0;
+
+	static ShaderLanguage::DataType global_variable_type_get_shader_datatype(GlobalVariableType p_type);
+
 	/* BLACK BARS */
 
 	virtual void black_bars_set_margins(int p_left, int p_top, int p_right, int p_bottom) = 0;
@@ -1217,6 +1272,7 @@ VARIANT_ENUM_CAST(RenderingServer::CanvasItemTextureRepeat);
 VARIANT_ENUM_CAST(RenderingServer::CanvasLightMode);
 VARIANT_ENUM_CAST(RenderingServer::CanvasLightShadowFilter);
 VARIANT_ENUM_CAST(RenderingServer::CanvasOccluderPolygonCullMode);
+VARIANT_ENUM_CAST(RenderingServer::GlobalVariableType);
 VARIANT_ENUM_CAST(RenderingServer::RenderInfo);
 VARIANT_ENUM_CAST(RenderingServer::Features);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6265307/79527308-9e92c280-803d-11ea-888c-53dc72916cb6.png)
![image](https://user-images.githubusercontent.com/6265307/79527283-8cb11f80-803d-11ea-8cb6-be971591b79d.png)



Adds two keywords to shader language for uniforms:
-'global'
-'instance'

This allows them to reference values outside the material.

*Bugsquad edit: closes https://github.com/godotengine/godot-proposals/issues/257, closes #18848, closes #30375*