### PR TITLE
Scons Adding Project Sources/Objects Proposal

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -77,6 +77,9 @@ env_base.__class__.disable_module = methods.disable_module
 
 env_base.__class__.add_module_version_string = methods.add_module_version_string
 
+env_base.__class__.glob_files = methods.glob_files
+env_base.__class__.add_objects_from_sources = methods.add_objects_from_sources
+
 env_base.__class__.add_source_files = methods.add_source_files
 env_base.__class__.use_windows_spawn_fix = methods.use_windows_spawn_fix
 
@@ -85,6 +88,9 @@ env_base.__class__.add_library = methods.add_library
 env_base.__class__.add_program = methods.add_program
 env_base.__class__.CommandNoCache = methods.CommandNoCache
 env_base.__class__.disable_warnings = methods.disable_warnings
+
+env_base.__class__.project_sources = []
+env_base.__class__.add_project_sources = methods.add_project_sources
 
 env_base["x86_libtheora_opt_gcc"] = False
 env_base["x86_libtheora_opt_vc"] = False
@@ -274,31 +280,6 @@ if selected_platform in platform_list:
         env["verbose"] = True
         env["warnings"] = "extra"
         env["werror"] = True
-
-    if env["vsproj"]:
-        env.vs_incs = []
-        env.vs_srcs = []
-
-        def AddToVSProject(sources):
-            for x in sources:
-                if type(x) == type(""):
-                    fname = env.File(x).path
-                else:
-                    fname = env.File(x)[0].path
-                pieces = fname.split(".")
-                if len(pieces) > 0:
-                    basename = pieces[0]
-                    basename = basename.replace("\\\\", "/")
-                    if os.path.isfile(basename + ".h"):
-                        env.vs_incs = env.vs_incs + [basename + ".h"]
-                    elif os.path.isfile(basename + ".hpp"):
-                        env.vs_incs = env.vs_incs + [basename + ".hpp"]
-                    if os.path.isfile(basename + ".c"):
-                        env.vs_srcs = env.vs_srcs + [basename + ".c"]
-                    elif os.path.isfile(basename + ".cpp"):
-                        env.vs_srcs = env.vs_srcs + [basename + ".cpp"]
-
-        env.AddToVSProject = AddToVSProject
 
     env.extra_suffix = ""
 

--- a/core/SCsub
+++ b/core/SCsub
@@ -6,8 +6,7 @@ import core_builders
 import make_binders
 from platform_methods import run_in_subprocess
 
-env.core_sources = []
-
+env.core_objects = []
 
 # Generate AES256 script encryption key
 import os
@@ -48,31 +47,49 @@ env_thirdparty.disable_warnings()
 thirdparty_misc_dir = "#thirdparty/misc/"
 thirdparty_misc_sources = [
     # C sources
+    "fastlz.h",
     "fastlz.c",
+    "smaz.h",
     "smaz.c",
     # C++ sources
+    "hq2x.h",
     "hq2x.cpp",
+    "pcg.h",
     "pcg.cpp",
+    "triangulator.h",
     "triangulator.cpp",
+    "clipper.h",
     "clipper.cpp",
 ]
 thirdparty_misc_sources = [thirdparty_misc_dir + file for file in thirdparty_misc_sources]
-env_thirdparty.add_source_files(env.core_sources, thirdparty_misc_sources)
+env.add_project_sources(thirdparty_misc_sources)
+env_thirdparty.add_objects_from_sources(env.core_objects, thirdparty_misc_sources)
 
 # Zlib library, can be unbundled
 if env["builtin_zlib"]:
     thirdparty_zlib_dir = "#thirdparty/zlib/"
     thirdparty_zlib_sources = [
+        "adler32.h",
         "adler32.c",
+        "compress.h",
         "compress.c",
+        "crc32.h",
         "crc32.c",
+        "deflate.h",
         "deflate.c",
+        "infback.h",
         "infback.c",
+        "inffast.h",
         "inffast.c",
+        "inflate.h",
         "inflate.c",
+        "inftrees.h",
         "inftrees.c",
+        "trees.h",
         "trees.c",
+        "uncompr.h",
         "uncompr.c",
+        "zutil.h",
         "zutil.c",
     ]
     thirdparty_zlib_sources = [thirdparty_zlib_dir + file for file in thirdparty_zlib_sources]
@@ -83,18 +100,23 @@ if env["builtin_zlib"]:
     if env["target"] == "debug":
         env_thirdparty.Append(CPPDEFINES=["ZLIB_DEBUG"])
 
-    env_thirdparty.add_source_files(env.core_sources, thirdparty_zlib_sources)
+    env.add_project_sources(thirdparty_zlib_sources)
+    env_thirdparty.add_objects_from_sources(env.core_objects, thirdparty_zlib_sources)
 
 # Minizip library, could be unbundled in theory
 # However, our version has some custom modifications, so it won't compile with the system one
 thirdparty_minizip_dir = "#thirdparty/minizip/"
 thirdparty_minizip_sources = [
+    "ioapi.h",
     "ioapi.c",
+    "unzip.h",
     "unzip.c",
+    "zip.h",
     "zip.c",
 ]
 thirdparty_minizip_sources = [thirdparty_minizip_dir + file for file in thirdparty_minizip_sources]
-env_thirdparty.add_source_files(env.core_sources, thirdparty_minizip_sources)
+env.add_project_sources(thirdparty_minizip_sources)
+env_thirdparty.add_objects_from_sources(env.core_objects, thirdparty_minizip_sources)
 
 # Zstd library, can be unbundled in theory
 # though we currently use some private symbols
@@ -102,29 +124,53 @@ env_thirdparty.add_source_files(env.core_sources, thirdparty_minizip_sources)
 if env["builtin_zstd"]:
     thirdparty_zstd_dir = "#thirdparty/zstd/"
     thirdparty_zstd_sources = [
+        "common/debug.h",
         "common/debug.c",
+        "common/entropy_common.h",
         "common/entropy_common.c",
+        "common/error_private.h",
         "common/error_private.c",
+        "common/fse_decompress.h",
         "common/fse_decompress.c",
+        "common/pool.h",
         "common/pool.c",
+        "common/threading.h",
         "common/threading.c",
+        "common/xxhash.h",
         "common/xxhash.c",
+        "common/zstd_common.h",
         "common/zstd_common.c",
+        "compress/fse_compress.h",
         "compress/fse_compress.c",
+        "compress/hist.h",
         "compress/hist.c",
+        "compress/huf_compress.h",
         "compress/huf_compress.c",
+        "compress/zstd_compress.h",
         "compress/zstd_compress.c",
+        "compress/zstd_double_fast.h",
         "compress/zstd_double_fast.c",
+        "compress/zstd_fast.h",
         "compress/zstd_fast.c",
+        "compress/zstd_lazy.h",
         "compress/zstd_lazy.c",
+        "compress/zstd_ldm.h",
         "compress/zstd_ldm.c",
+        "compress/zstd_opt.h",
         "compress/zstd_opt.c",
+        "compress/zstdmt_compress.h",
         "compress/zstdmt_compress.c",
+        "compress/zstd_compress_literals.h",
         "compress/zstd_compress_literals.c",
+        "compress/zstd_compress_sequences.h",
         "compress/zstd_compress_sequences.c",
+        "decompress/huf_decompress.h",
         "decompress/huf_decompress.c",
+        "decompress/zstd_ddict.h",
         "decompress/zstd_ddict.c",
+        "decompress/zstd_decompress_block.h",
         "decompress/zstd_decompress_block.c",
+        "decompress/zstd_decompress.h",
         "decompress/zstd_decompress.c",
     ]
     thirdparty_zstd_sources = [thirdparty_zstd_dir + file for file in thirdparty_zstd_sources]
@@ -135,11 +181,14 @@ if env["builtin_zstd"]:
     # Also needed in main env includes will trigger warnings
     env.Append(CPPDEFINES=["ZSTD_STATIC_LINKING_ONLY"])
 
-    env_thirdparty.add_source_files(env.core_sources, thirdparty_zstd_sources)
+    env.add_project_sources(thirdparty_zstd_sources)
+    env_thirdparty.add_objects_from_sources(env.core_objects, thirdparty_zstd_sources)
 
 
 # Godot's own sources
-env.add_source_files(env.core_sources, "*.cpp")
+local_sources = env.glob_files('*.cpp') + env.glob_files('*.h')
+env.add_project_sources(local_sources)
+env.add_objects_from_sources(env.core_objects, local_sources)
 
 # Certificates
 env.Depends(
@@ -151,6 +200,7 @@ env.CommandNoCache(
     "#thirdparty/certs/ca-certificates.crt",
     run_in_subprocess(core_builders.make_certs_header),
 )
+env.add_project_sources(["#core/io/certs_compressed.gen.h"])
 
 # Make binders
 env.CommandNoCache(
@@ -158,6 +208,7 @@ env.CommandNoCache(
     "make_binders.py",
     run_in_subprocess(make_binders.run),
 )
+env.add_project_sources(["method_bind.gen.inc", "method_bind_ext.gen.inc", "method_bind_free_func.gen.inc"])
 
 # Authors
 env.Depends("#core/authors.gen.h", "../AUTHORS.md")
@@ -184,5 +235,5 @@ SConscript("bind/SCsub")
 
 
 # Build it all as a library
-lib = env.add_library("core", env.core_sources)
+lib = env.add_library("core", env.core_objects)
 env.Prepend(LIBS=[lib])

--- a/core/bind/SCsub
+++ b/core/bind/SCsub
@@ -2,4 +2,6 @@
 
 Import("env")
 
-env.add_source_files(env.core_sources, "*.cpp")
+local_sources = env.glob_files('*.cpp') + env.glob_files('*.h')
+env.add_project_sources(local_sources)
+env.add_objects_from_sources(env.core_objects, local_sources)

--- a/core/crypto/SCsub
+++ b/core/crypto/SCsub
@@ -27,14 +27,24 @@ if not has_module:
     )
     thirdparty_mbedtls_dir = "#thirdparty/mbedtls/library/"
     thirdparty_mbedtls_sources = [
+        "aes.h"
         "aes.c",
+        "base64.h"
         "base64.c",
+        "md5.h",
         "md5.c",
+        "sha1.h",
         "sha1.c",
+        "sha256.h",
         "sha256.c",
+        "godot_core_mbedtls_platform.h",
         "godot_core_mbedtls_platform.c",
     ]
     thirdparty_mbedtls_sources = [thirdparty_mbedtls_dir + file for file in thirdparty_mbedtls_sources]
-    env_thirdparty.add_source_files(env.core_sources, thirdparty_mbedtls_sources)
+    env.add_project_sources(thirdparty_mbedtls_sources)
+    env.add_objects_from_sources(env.core_sources, thirdparty_mbedtls_sources)
 
-env_crypto.add_source_files(env.core_sources, "*.cpp")
+
+local_sources = env.glob_files('*.h') + env.glob_files('*.cpp')
+env.add_project_sources(local_sources)
+env_crypto.add_objects_from_sources(env.core_objects, local_sources)

--- a/core/debugger/SCsub
+++ b/core/debugger/SCsub
@@ -2,4 +2,6 @@
 
 Import("env")
 
-env.add_source_files(env.core_sources, "*.cpp")
+local_sources = env.glob_files('*.cpp') + env.glob_files('*.h')
+env.add_project_sources(local_sources)
+env.add_objects_from_sources(env.core_objects, local_sources)

--- a/core/input/SCsub
+++ b/core/input/SCsub
@@ -21,8 +21,12 @@ env.CommandNoCache(
     run_in_subprocess(input_builders.make_default_controller_mappings),
 )
 
-env.add_source_files(env.core_sources, "*.cpp")
+local_sources = env.glob_files('*.cpp') + env.glob_files('*.h')
+env.add_project_sources(local_sources)
+env.add_objects_from_sources(env.core_objects, local_sources)
 
 # Don't warn about duplicate entry here, we need it registered manually for first build,
 # even if later builds will pick it up twice due to above *.cpp globbing.
-env.add_source_files(env.core_sources, "#core/input/default_controller_mappings.gen.cpp", warn_duplicates=False)
+mappings_gen_files = ["#core/input/default_controller_mappings.gen.cpp"]
+env.add_project_sources(mappings_gen_files)
+env.add_objects_from_sources(env.core_objects, mappings_gen_files, warn_duplicates=False)

--- a/core/io/SCsub
+++ b/core/io/SCsub
@@ -2,4 +2,6 @@
 
 Import("env")
 
-env.add_source_files(env.core_sources, "*.cpp")
+local_sources = env.glob_files('*.cpp') + env.glob_files('*.h')
+env.add_project_sources(local_sources)
+env.add_objects_from_sources(env.core_objects, local_sources)

--- a/core/math/SCsub
+++ b/core/math/SCsub
@@ -2,6 +2,6 @@
 
 Import("env")
 
-env_math = env.Clone()
-
-env_math.add_source_files(env.core_sources, "*.cpp")
+local_sources = env.glob_files('*.cpp') + env.glob_files('*.h')
+env.add_project_sources(local_sources)
+env.add_objects_from_sources(env.core_objects, local_sources)

--- a/core/os/SCsub
+++ b/core/os/SCsub
@@ -2,4 +2,6 @@
 
 Import("env")
 
-env.add_source_files(env.core_sources, "*.cpp")
+local_sources = env.glob_files('*.cpp') + env.glob_files('*.h')
+env.add_project_sources(local_sources)
+env.add_objects_from_sources(env.core_objects, local_sources)

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -40,7 +40,8 @@ if env["vsproj"]:
     path = os.getcwd()
     # Change directory so the path resolves correctly in the function call.
     os.chdir("..")
-    env.AddToVSProject(env.drivers_sources)
+    # This shouldn't be here...
+    #env.AddToVSProject(env.drivers_sources)
     os.chdir(path)
 
 env.add_source_files(env.drivers_sources, "*.cpp")

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -25,11 +25,11 @@ res_obj = env.RES(res_target, res_file)
 prog = env.add_program("#bin/godot", common_win + res_obj, PROGSUFFIX=env["PROGSUFFIX"])
 
 # Microsoft Visual Studio Project Generation
-if env["vsproj"]:
-    env.vs_srcs = env.vs_srcs + ["platform/windows/" + res_file]
-    env.vs_srcs = env.vs_srcs + ["platform/windows/godot.natvis"]
-    for x in common_win:
-        env.vs_srcs = env.vs_srcs + ["platform/windows/" + str(x)]
+#if env["vsproj"]:
+    #env.vs_srcs = env.vs_srcs + ["platform/windows/" + res_file]
+    #env.vs_srcs = env.vs_srcs + ["platform/windows/godot.natvis"]
+    #for x in common_win:
+        #env.vs_srcs = env.vs_srcs + ["platform/windows/" + str(x)]
 
 if not os.getenv("VCINSTALLDIR"):
     if (env["debug_symbols"] == "full" or env["debug_symbols"] == "yes") and env["separate_debug_symbols"]:


### PR DESCRIPTION
I spent some time trying to solve the issue with header files not appearing in Visual Studio in PR #34416, but after further investigation I found the solution to be "dirty", as it was solving the issue in a way that really didn't make sense.

This PR is more of a "demo" of changes I would like to propose to how the project file tracking and object file generation for godot libs are handled, as in my opinion they were very unclear (it took me a while to figure out how everything works together), and it seems like the current way the files for Windows Visual Studio project files being discovered was really a band-aid.

I say "band-aid" because the way the "Project Files" were determined before was from modifying the resulting generated .obj's by scons and adding in the .cpp and .h files manually if they existed, missing many headers entirely.

This PR Demo attempts to solve the Visual Studio header files by introducing some more structure to how object files are generated for libs, and separating out the "project sources" from the required object files required for building libraries.

I applied the functionality to `core` as an example

Benefits:
* You can explicitly add/remove/hide source files from appearing in the project_sources (which at this point only affect visual studio, but it could be extended for Clion support, or other build systems)
* Project sources are a separate entity from the object files required to build libraries
* More explicit SCsub files - You add project_sources, and you add object_files explicitly
* File globbing isn't built into the old 'add_source_files'

Downsides:
* More lines in SCsub files (?)

(?) - Figuring out some method of adding in header files for vs projects would result in some additional SCsub length overhead anyways, so I really don't think this is much of an issue.