### PR TITLE
Use sky properly for ambient and reflections

### DIFF
--- a/servers/rendering/rasterizer_rd/rasterizer_scene_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_rd.cpp
@@ -1179,12 +1179,12 @@ Color RasterizerSceneRD::environment_get_ambient_light_color(RID p_env) const {
 	ERR_FAIL_COND_V(!env, Color());
 	return env->ambient_light;
 }
-RS::EnvironmentAmbientSource RasterizerSceneRD::environment_get_ambient_light_ambient_source(RID p_env) const {
+RS::EnvironmentAmbientSource RasterizerSceneRD::environment_get_ambient_source(RID p_env) const {
 	Environent *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND_V(!env, RS::ENV_AMBIENT_SOURCE_BG);
 	return env->ambient_source;
 }
-float RasterizerSceneRD::environment_get_ambient_light_ambient_energy(RID p_env) const {
+float RasterizerSceneRD::environment_get_ambient_light_energy(RID p_env) const {
 	Environent *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND_V(!env, 0);
 	return env->ambient_light_energy;

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_rd.h
@@ -866,8 +866,8 @@ public:
 	float environment_get_bg_energy(RID p_env) const;
 	int environment_get_canvas_max_layer(RID p_env) const;
 	Color environment_get_ambient_light_color(RID p_env) const;
-	RS::EnvironmentAmbientSource environment_get_ambient_light_ambient_source(RID p_env) const;
-	float environment_get_ambient_light_ambient_energy(RID p_env) const;
+	RS::EnvironmentAmbientSource environment_get_ambient_source(RID p_env) const;
+	float environment_get_ambient_light_energy(RID p_env) const;
 	float environment_get_ambient_sky_contribution(RID p_env) const;
 	RS::EnvironmentReflectionSource environment_get_reflection_source(RID p_env) const;
 	Color environment_get_ao_color(RID p_env) const;


### PR DESCRIPTION
This fixes an unreported bug where the sky would not be used even when ``ambient_source`` or ``reflection_source`` was set to "Sky" but ``background`` was not. This effectively rendered the "Sky" setting useless for ``ambient_source`` and ``reflection_source``. 

I also renamed ``environment_get_ambient_light_ambient_source()`` -> ``environment_get_ambient_source()`` and ``environment_get_ambient_light_ambient_energy()`` -> ``environment_get_ambient_light_energy()`` as I assumed the previous names were copy-paste typos. 

This change just allows ``Sky``s to be updated and used even when they are not being used as a background. 