### PR TITLE
Autocompleting with indexing for builtin types added

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2098,7 +2098,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionContext &p_context
 
 				if (!p_only_functions) {
 					List<PropertyInfo> members;
-					p_base.value.get_property_list(&members);
+					tmp.get_property_list(&members);
 
 					for (List<PropertyInfo>::Element *E = members.front(); E; E = E->next()) {
 						if (String(E->get().name).find("/") == -1) {


### PR DESCRIPTION
Fix: #37768 
only methods were added (properties ignored)
https://github.com/godotengine/godot/blob/30ab5c9baae1cad3e157d906395a4eb8cef77e42/modules/gdscript/gdscript_editor.cpp#L2112
 
![indexing-autocomplete-native-types](https://user-images.githubusercontent.com/41085900/79540230-67f09280-80a5-11ea-8cbc-d1a311970214.JPG)

