### PR TITLE
Fix search in project settings

### DIFF
--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -233,6 +233,8 @@ void SectionedInspector::update_category_list() {
 	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
 
 		PropertyInfo pi = E->get();
+		String property_prefix = pi.name.substr(0, pi.name.find_last("/"));
+		String settings_name = pi.name.substr(pi.name.find_last("/") + 1);
 
 		if (pi.usage & PROPERTY_USAGE_CATEGORY)
 			continue;
@@ -242,7 +244,7 @@ void SectionedInspector::update_category_list() {
 		if (pi.name.find(":") != -1 || pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene" || pi.name.begins_with("_global_script"))
 			continue;
 
-		if (!filter.empty() && !filter.is_subsequence_ofi(pi.name) && !filter.is_subsequence_ofi(pi.name.replace("/", " ").capitalize()))
+		if (!filter.empty() && !filter.is_subsequence_ofi(property_prefix) && !filter.is_subsequence_ofi(settings_name) && !filter.is_subsequence_ofi(property_prefix.replace("/", " ").capitalize()) && !filter.is_subsequence_ofi(settings_name.replace("/", " ").capitalize())) 
 			continue;
 
 		int sp = pi.name.find("/");
@@ -281,6 +283,7 @@ void SectionedInspector::update_category_list() {
 	}
 
 	if (section_map.has(selected_category)) {
+		print_line(selected_category);
 		section_map[selected_category]->select(0);
 	}
 

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -244,7 +244,7 @@ void SectionedInspector::update_category_list() {
 		if (pi.name.find(":") != -1 || pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene" || pi.name.begins_with("_global_script"))
 			continue;
 
-		if (!filter.empty() && !filter.is_subsequence_ofi(property_prefix) && !filter.is_subsequence_ofi(settings_name) && !filter.is_subsequence_ofi(property_prefix.replace("/", " ").capitalize()) && !filter.is_subsequence_ofi(settings_name.replace("/", " ").capitalize())) 
+		if (!filter.empty() && !filter.is_subsequence_ofi(property_prefix) && !filter.is_subsequence_ofi(settings_name) && !filter.is_subsequence_ofi(property_prefix.replace("/", " ").capitalize()) && !filter.is_subsequence_ofi(settings_name.replace("/", " ").capitalize()))
 			continue;
 
 		int sp = pi.name.find("/");
@@ -283,8 +283,16 @@ void SectionedInspector::update_category_list() {
 	}
 
 	if (section_map.has(selected_category)) {
-		print_line(selected_category);
 		section_map[selected_category]->select(0);
+	} else {
+		for (Map<String, TreeItem *>::Element *E = section_map.front(); E; E = E->next()) {
+			String section_name = E->key();
+			TreeItem *section = E->get();
+			if (!section_name.empty() && section->is_selectable(0)) {
+				section->select(0);
+				break;
+			}
+		}
 	}
 
 	inspector->update_tree();


### PR DESCRIPTION
Fixes #37424

![project_settings_fix](https://user-images.githubusercontent.com/35118557/79575007-5cab6000-80c1-11ea-80f1-536580ea5b28.gif)

* `editor_section_inspector` now looks for matches in property info's prefix and settings name separately - this matches with the filtering in `editor_inspector` and therefore, we get the same search results
* when receiving search results, it can occur that the `selected_category` up until now is not featured on the left anymore (technically it is not part of `section_map` anymore) - therefore, we have to select one of the available categories in order to show the found settings on the right side

Thank you for reviewing!