### PR TITLE
Check for errors when saving in the ResourceSaver example documentation

### DIFF
--- a/doc/classes/EditorFeatureProfile.xml
+++ b/doc/classes/EditorFeatureProfile.xml
@@ -72,7 +72,7 @@
 			<argument index="0" name="path" type="String">
 			</argument>
 			<description>
-				Saves the editor feature profile to a file in JSON format. It can then be imported using the feature profile manager's [b]Import[/b] button or the [method load_from_file] button.
+				Saves the editor feature profile to a file in JSON format. It can then be imported using the feature profile manager's [b]Import[/b] button or the [method load_from_file] button.
 			</description>
 		</method>
 		<method name="set_disable_class">

--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -9,23 +9,25 @@
 		[b]Note:[/b] The node doesn't need to own itself.
 		[b]Example of saving a node with different owners:[/b] The following example creates 3 objects: [code]Node2D[/code] ([code]node[/code]), [code]RigidBody2D[/code] ([code]rigid[/code]) and [code]CollisionObject2D[/code] ([code]collision[/code]). [code]collision[/code] is a child of [code]rigid[/code] which is a child of [code]node[/code]. Only [code]rigid[/code] is owned by [code]node[/code] and [code]pack[/code] will therefore only save those two nodes, but not [code]collision[/code].
 		[codeblock]
-		# Create the objects
+		# Create the objects.
 		var node = Node2D.new()
 		var rigid = RigidBody2D.new()
 		var collision = CollisionShape2D.new()
 
-		# Create the object hierarchy
+		# Create the object hierarchy.
 		rigid.add_child(collision)
 		node.add_child(rigid)
 
-		# Change owner of rigid, but not of collision
+		# Change owner of `rigid`, but not of `collision`.
 		rigid.owner = node
 
 		var scene = PackedScene.new()
-		# Only node and rigid are now packed
+		# Only `node` and `rigid` are now packed.
 		var result = scene.pack(node)
 		if result == OK:
-		    ResourceSaver.save("res://path/name.scn", scene) # Or "user://..."
+		    var error = ResourceSaver.save("res://path/name.scn", scene)  # Or "user://..."
+		    if error != OK:
+		        push_error("An error occurred while saving the scene to disk.")
 		[/codeblock]
 	</description>
 	<tutorials>


### PR DESCRIPTION
This also replaces a non-breaking space that was accidentally added in the EditorFeatureProfile documentation.

This closes #31393.