### PR TITLE
Added 'Select Current' option when user is prompted to select main scene after clicking play

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3874,6 +3874,21 @@ Ref<ImageTexture> EditorNode::_load_custom_class_icon(const String &p_path) cons
 	return nullptr;
 }
 
+void EditorNode::_pick_main_scene_custom_action(const String &p_custom_action_name) {
+	if (p_custom_action_name == "select_current") {
+		Node *scene = editor_data.get_edited_scene_root();
+
+		if (!scene) {
+			show_accept(TTR("There is no defined scene to run."), TTR("OK"));
+			return;
+		}
+
+		pick_main_scene->hide();
+		current_option = SETTINGS_PICK_MAIN_SCENE;
+		_dialog_action(scene->get_filename());
+	}
+}
+
 Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String &p_fallback) const {
 	ERR_FAIL_COND_V(!p_object || !gui_base, nullptr);
 
@@ -4668,6 +4683,14 @@ bool EditorNode::ensure_main_scene(bool p_from_native) {
 		current_option = -1;
 		pick_main_scene->set_text(TTR("No main scene has ever been defined, select one?\nYou can change it later in \"Project Settings\" under the 'application' category."));
 		pick_main_scene->popup_centered();
+
+		if (editor_data.get_edited_scene_root()) {
+			select_current_scene_button->set_disabled(false);
+			select_current_scene_button->grab_focus();
+		} else {
+			select_current_scene_button->set_disabled(true);
+		}
+
 		return false;
 	}
 
@@ -6944,6 +6967,8 @@ EditorNode::EditorNode() {
 	gui_base->add_child(pick_main_scene);
 	pick_main_scene->get_ok_button()->set_text(TTR("Select"));
 	pick_main_scene->connect("confirmed", callable_mp(this, &EditorNode::_menu_option), varray(SETTINGS_PICK_MAIN_SCENE));
+	select_current_scene_button = pick_main_scene->add_button(TTR("Select Current"), true, "select_current");
+	pick_main_scene->connect("custom_action", callable_mp(this, &EditorNode::_pick_main_scene_custom_action));
 
 	for (int i = 0; i < _init_callbacks.size(); i++) {
 		_init_callbacks[i]();

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -301,6 +301,7 @@ private:
 	ConfirmationDialog *save_confirmation;
 	ConfirmationDialog *import_confirmation;
 	ConfirmationDialog *pick_main_scene;
+	Button *select_current_scene_button;
 	AcceptDialog *accept;
 	EditorAbout *about;
 	AcceptDialog *warning;
@@ -662,6 +663,8 @@ private:
 	void _feature_profile_changed();
 	bool _is_class_editor_disabled_by_feature_profile(const StringName &p_class);
 	Ref<ImageTexture> _load_custom_class_icon(const String &p_path) const;
+
+	void _pick_main_scene_custom_action(const String &p_custom_action_name);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
Took a shot at implementing "Automatically Set Main Scene" https://github.com/godotengine/godot-proposals/issues/720#issue-601871601

Let me know what you think. Still trying to learn the code base so any feedback on any decisions I made is appreciated.

Re-submitting PR because I messed up by rebase before.

![Br7PyK65RI](https://user-images.githubusercontent.com/41730826/79634791-2bf62400-81b0-11ea-92c9-d8c1036e9c6c.gif)

There are some weird interactions when the conditions below are met, however it is the way the editor currently behaves (even before the changes in this PR)... so I have not attempted to 'fix' it here.

1. No Main Scene set
2. Scene is open and unsaved
3. User clicks play

What happens is that the user is prompted to save the scene, but not set a main scene. If they do click yes to save the scene, the project runs, but without setting a main scene. If they click it again, then it will prompt them to set the main scene. I may submit an Issue about this... it is not very serious though as the workaround is "click play again next time and set the main scene then".

*Bugsquad edit:* Fixes https://github.com/godotengine/godot-proposals/issues/720.