### PR TITLE
Make Node3DEditorPlugin viewport always be an odd number in size

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4261,6 +4261,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 
 	spatial_editor = p_spatial_editor;
 	SubViewportContainer *c = memnew(SubViewportContainer);
+	c->odd_size_only = true;
 	subviewport_container = c;
 	c->set_stretch(true);
 	add_child(c);

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -102,7 +102,16 @@ void SubViewportContainer::_notification(int p_what) {
 				continue;
 			}
 
-			c->set_size(get_size() / shrink);
+			Size2 target_size = get_size();
+			if (unlikely(odd_size_only)) {
+				Size2 odd_size = (((Control *)get_parent())->get_size() / 2).round() * 2 - Vector2(1, 1);
+				if (odd_size != target_size) {
+					set_size(odd_size);
+				}
+				c->set_size(odd_size / shrink);
+			} else {
+				c->set_size(target_size / shrink);
+			}
 		}
 	}
 

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -44,6 +44,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	bool odd_size_only; // Only used by Node3DEditorPlugin.
 	void set_stretch(bool p_enable);
 	bool is_stretch_enabled() const;
 


### PR DESCRIPTION
Mitigates and/or fixes #37016. The code is written such that the SubViewportContainer behavior is the same as it is currently when `odd_size_only` is false.

There might be a better solution, but I'm not seeing one. In order to have a 1 pixel think line and have it be in the middle, the size needs to be an odd number so that there is a middle pixel.