### PR TITLE
Correct Dictionary addition of a key and the duplication of a variable name.

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -11,7 +11,7 @@
 		[codeblock]
 		var my_dir = {} # Creates an empty dictionary.
 		var points_dir = {"White": 50, "Yellow": 75, "Orange": 100}
-		var my_dir = {
+		var another_dir = {
 		    key1: value1,
 		    key2: value2,
 		    key3: value3,
@@ -34,7 +34,7 @@
 		To add a key to an existing dictionary, access it like an existing key and assign to it:
 		[codeblock]
 		var points_dir = {"White": 50, "Yellow": 75, "Orange": 100}
-		var points_dir["Blue"] = 150 # Add "Blue" as a key and assign 150 as its value.
+		points_dir["Blue"] = 150 # Add "Blue" as a key and assign 150 as its value.
 		[/codeblock]
 		Finally, dictionaries can contain different types of keys and values in the same dictionary:
 		[codeblock]


### PR DESCRIPTION
Corrects the addition of a key and the duplication of a variable name in Dictionary class documentation.

Credit to @flux, @octalus and others on matrix.