### PR TITLE
Remove BaseMaterial3D doc class link to tutorial.

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -7,7 +7,6 @@
 		This provides a default material with a wide variety of rendering features and properties without the need to write shader code. See the tutorial below for details.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/3d/spatial_material.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_feature" qualifiers="const">


### PR DESCRIPTION
~~This PR depends on https://github.com/godotengine/godot-docs/pull/3412, which updates the documentation to reflect the rename of `SpatialMaterial` to `BaseMaterial3D`. The rename includes renaming the file for the tutorial from `tutorials/3d/spatial_material.rst` to `tutorials/3d/base_material_3d.rst`.~~

~~This patch updates the BaseMaterial3D class documentation to reflect the filename change.~~

**Edit**: Updated to remove the tutorial link instead.