### PR TITLE
Fixes incorrectly joining batch items from earlier z_index layers

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.h
+++ b/drivers/gles2/rasterizer_canvas_gles2.h
@@ -200,6 +200,7 @@ class RasterizerCanvasGLES2 : public RasterizerCanvasBaseGLES2 {
 
 		// used for joining items only
 		BItemJoined *joined_item;
+		bool join_batch_break;
 
 		// 'item group' is data over a single call to canvas_render_items
 		int item_group_z;


### PR DESCRIPTION
Batching across z_index layers was not preserving the batch_break flag, which determines whether to not join the previous item. This is fixed by storing the flag in RenderItemState and preserving it across canvas_render_items calls.

Fixes #38013, fixes #38014.