### PR TITLE
Moved Debugger's "Step Over" button to the left

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -2307,17 +2307,17 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 		hbc->add_child(memnew(VSeparator));
 
-		step = memnew(ToolButton);
-		hbc->add_child(step);
-		step->set_tooltip(TTR("Step Into"));
-		step->set_shortcut(ED_GET_SHORTCUT("debugger/step_into"));
-		step->connect("pressed", this, "debug_step");
-
 		next = memnew(ToolButton);
 		hbc->add_child(next);
 		next->set_tooltip(TTR("Step Over"));
 		next->set_shortcut(ED_GET_SHORTCUT("debugger/step_over"));
 		next->connect("pressed", this, "debug_next");
+
+		step = memnew(ToolButton);
+		hbc->add_child(step);
+		step->set_tooltip(TTR("Step Into"));
+		step->set_shortcut(ED_GET_SHORTCUT("debugger/step_into"));
+		step->connect("pressed", this, "debug_step");
 
 		hbc->add_child(memnew(VSeparator));
 


### PR DESCRIPTION
Just to make them in the ascending order of FXX keys

![StepOverPos](https://user-images.githubusercontent.com/37383316/79706495-dd1fbb80-828f-11ea-9a18-2872a04b98f4.gif)
