### PR TITLE
[macOS] Add missing global menu features, use native menu for editor.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -135,8 +135,83 @@
 			<argument index="0" name="menu_root" type="String" />
 			<argument index="1" name="label" type="String" />
 			<argument index="2" name="callback" type="Callable" />
-			<argument index="3" name="tag" type="Variant" default="null" />
+			<argument index="3" name="id" type="int" default="-1" />
+			<argument index="4" name="accel" type="int" enum="Key" default="0" />
+			<argument index="5" name="idx" type="int" default="-1" />
 			<description>
+				Adds a new checkable item with text [code]label[/code] to the global menu [code]menu_root[/code].
+				An [code]id[/code] can optionally be provided, as well as an accelerator ([code]accel[/code]). If no [code]id[/code] is provided, one will be created from the index. If no [code]accel[/code] is provided then the default [code]0[/code] will be assigned to it. See [method global_menu_get_item_accelerator] for more info on accelerators.
+				[b]Note:[/b] Checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method global_menu_set_item_checked] for more info on how to control it.
+				[b]Note:[/b] This method is implemented on macOS.
+				[b]Supported system menu names:[/b]
+				[codeblock]
+				"_main" - Main menu (macOS).
+				"_app" - Application menu (macOS).
+				"_dock" - Dock popup menu (macOS).
+				[/codeblock]
+			</description>
+		</method>
+		<method name="global_menu_add_icon_check_item">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="icon" type="Texture2D" />
+			<argument index="2" name="label" type="String" />
+			<argument index="3" name="callback" type="Callable" />
+			<argument index="4" name="id" type="int" default="-1" />
+			<argument index="5" name="accel" type="int" enum="Key" default="0" />
+			<argument index="6" name="idx" type="int" default="-1" />
+			<description>
+				Adds a new checkable item with text [code]label[/code] and icon [code]icon[/code] to the global menu [code]menu_root[/code].
+				An [code]id[/code] can optionally be provided, as well as an accelerator ([code]accel[/code]). If no [code]id[/code] is provided, one will be created from the index. If no [code]accel[/code] is provided then the default [code]0[/code] will be assigned to it. See [method global_menu_get_item_accelerator] for more info on accelerators.
+				[b]Note:[/b] Checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method global_menu_set_item_checked] for more info on how to control it.
+				[b]Note:[/b] This method is implemented on macOS.
+				[b]Supported system menu names:[/b]
+				[codeblock]
+				"_main" - Main menu (macOS).
+				"_app" - Application menu (macOS).
+				"_dock" - Dock popup menu (macOS).
+				[/codeblock]
+			</description>
+		</method>
+		<method name="global_menu_add_icon_item">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="icon" type="Texture2D" />
+			<argument index="2" name="label" type="String" />
+			<argument index="3" name="callback" type="Callable" />
+			<argument index="4" name="id" type="int" default="-1" />
+			<argument index="5" name="accel" type="int" enum="Key" default="0" />
+			<argument index="6" name="idx" type="int" default="-1" />
+			<description>
+				Adds a new item with text [code]label[/code] and icon [code]icon[/code] to the global menu [code]menu_root[/code].
+				An [code]id[/code] can optionally be provided, as well as an accelerator ([code]accel[/code]). If no [code]id[/code] is provided, one will be created from the index. If no [code]accel[/code] is provided then the default [code]0[/code] will be assigned to it. See [method global_menu_get_item_accelerator] for more info on accelerators.
+				[b]Note:[/b] This method is implemented on macOS.
+				[b]Supported system menu names:[/b]
+				[codeblock]
+				"_main" - Main menu (macOS).
+				"_app" - Application menu (macOS).
+				"_dock" - Dock popup menu (macOS).
+				[/codeblock]
+			</description>
+		</method>
+		<method name="global_menu_add_icon_radio_check_item">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="icon" type="Texture2D" />
+			<argument index="2" name="label" type="String" />
+			<argument index="3" name="callback" type="Callable" />
+			<argument index="4" name="id" type="int" default="-1" />
+			<argument index="5" name="accel" type="int" enum="Key" default="0" />
+			<argument index="6" name="idx" type="int" default="-1" />
+			<description>
+				Same as [method global_menu_add_icon_check_item], but uses a radio check button.
+				[b]Note:[/b] This method is implemented on macOS.
+				[b]Supported system menu names:[/b]
+				[codeblock]
+				"_main" - Main menu (macOS).
+				"_app" - Application menu (macOS).
+				"_dock" - Dock popup menu (macOS).
+				[/codeblock]
 			</description>
 		</method>
 		<method name="global_menu_add_item">
@@ -144,14 +219,78 @@
 			<argument index="0" name="menu_root" type="String" />
 			<argument index="1" name="label" type="String" />
 			<argument index="2" name="callback" type="Callable" />
-			<argument index="3" name="tag" type="Variant" default="null" />
+			<argument index="3" name="id" type="int" default="-1" />
+			<argument index="4" name="accel" type="int" enum="Key" default="0" />
+			<argument index="5" name="idx" type="int" default="-1" />
 			<description>
+				Adds a new item with text [code]label[/code] to the global menu [code]menu_root[/code].
+				An [code]id[/code] can optionally be provided, as well as an accelerator ([code]accel[/code]). If no [code]id[/code] is provided, one will be created from the index. If no [code]accel[/code] is provided then the default [code]0[/code] will be assigned to it. See [method global_menu_get_item_accelerator] for more info on accelerators.
+				[b]Note:[/b] This method is implemented on macOS.
+				[b]Supported system menu names:[/b]
+				[codeblock]
+				"_main" - Main menu (macOS).
+				"_app" - Application menu (macOS).
+				"_dock" - Dock popup menu (macOS).
+				[/codeblock]
+			</description>
+		</method>
+		<method name="global_menu_add_multistate_item">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="label" type="String" />
+			<argument index="2" name="max_states" type="int" />
+			<argument index="3" name="default_state" type="int" default="0" />
+			<argument index="4" name="callback" type="Callable" />
+			<argument index="5" name="id" type="int" default="-1" />
+			<argument index="6" name="accel" type="int" enum="Key" default="0" />
+			<argument index="7" name="idx" type="int" default="-1" />
+			<description>
+				Adds a new multistate item with text [code]label[/code] to the global menu [code]menu_root[/code].
+				Contrarily to normal binary items, multistate items can have more than two states, as defined by [code]max_states[/code]. Each press or activate of the item will increase the state by one. The default value is defined by [code]default_state[/code].
+				An [code]id[/code] can optionally be provided, as well as an accelerator ([code]accel[/code]). If no [code]id[/code] is provided, one will be created from the index. If no [code]accel[/code] is provided then the default [code]0[/code] will be assigned to it. See [method global_menu_get_item_accelerator] for more info on accelerators.
+				[b]Note:[/b] This method is implemented on macOS.
+				[b]Supported system menu names:[/b]
+				[codeblock]
+				"_main" - Main menu (macOS).
+				"_app" - Application menu (macOS).
+				"_dock" - Dock popup menu (macOS).
+				[/codeblock]
+			</description>
+		</method>
+		<method name="global_menu_add_radio_check_item">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="label" type="String" />
+			<argument index="2" name="callback" type="Callable" />
+			<argument index="3" name="id" type="int" default="-1" />
+			<argument index="4" name="accel" type="int" enum="Key" default="0" />
+			<argument index="5" name="idx" type="int" default="-1" />
+			<description>
+				Adds a new radio check button with text [code]label[/code] to the global menu [code]menu_root[/code].
+				An [code]id[/code] can optionally be provided, as well as an accelerator ([code]accel[/code]). If no [code]id[/code] is provided, one will be created from the index. If no [code]accel[/code] is provided then the default [code]0[/code] will be assigned to it. See [method global_menu_get_item_accelerator] for more info on accelerators.
+				[b]Note:[/b] Checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method global_menu_set_item_checked] for more info on how to control it.
+				[b]Note:[/b] This method is implemented on macOS.
+				[b]Supported system menu names:[/b]
+				[codeblock]
+				"_main" - Main menu (macOS).
+				"_app" - Application menu (macOS).
+				"_dock" - Dock popup menu (macOS).
+				[/codeblock]
 			</description>
 		</method>
 		<method name="global_menu_add_separator">
 			<return type="void" />
 			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" default="-1" />
 			<description>
+				Adds a separator between items to the global menu [code]menu_root[/code]. Separators also occupy an index.
+				[b]Note:[/b] This method is implemented on macOS.
+				[b]Supported system menu names:[/b]
+				[codeblock]
+				"_main" - Main menu (macOS).
+				"_app" - Application menu (macOS).
+				"_dock" - Dock popup menu (macOS).
+				[/codeblock]
 			</description>
 		</method>
 		<method name="global_menu_add_submenu_item">
@@ -159,13 +298,41 @@
 			<argument index="0" name="menu_root" type="String" />
 			<argument index="1" name="label" type="String" />
 			<argument index="2" name="submenu" type="String" />
+			<argument index="3" name="idx" type="int" default="-1" />
 			<description>
+				Adds an item that will act as a submenu of the global menu [code]menu_root[/code]. The [code]submenu[/code] argument is the name of the global menu root that will be shown when the item is clicked.
+				An [code]id[/code] can optionally be provided. If no [code]id[/code] is provided, one will be created from the index.
+				[b]Note:[/b] This method is implemented on macOS.
+				[b]Supported system menu names:[/b]
+				[codeblock]
+				"_main" - Main menu (macOS).
+				"_app" - Application menu (macOS).
+				"_dock" - Dock popup menu (macOS).
+				[/codeblock]
 			</description>
 		</method>
 		<method name="global_menu_clear">
 			<return type="void" />
 			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="restore_default" type="bool" default="true" />
 			<description>
+				Removes all items from the global menu [code]menu_root[/code] and restores default menu items if [code]restore_default[/code] is true.
+				[b]Note:[/b] This method is implemented on macOS.
+				[b]Supported system menu names:[/b]
+				[codeblock]
+				"_main" - Main menu (macOS).
+				"_app" - Application menu (macOS).
+				"_dock" - Dock popup menu (macOS).
+				[/codeblock]
+			</description>
+		</method>
+		<method name="global_menu_get_item_accelerator">
+			<return type="int" enum="Key" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<description>
+				Returns the accelerator of the item at index [code]idx[/code]. Accelerators are special combinations of keys that activate the item, no matter which control is focused.
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_callback">
@@ -173,6 +340,71 @@
 			<argument index="0" name="menu_root" type="String" />
 			<argument index="1" name="idx" type="int" />
 			<description>
+				Returns the callback of the item at index [code]idx[/code].
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_get_item_icon" qualifiers="const">
+			<return type="Texture2D" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<description>
+				Returns the icon of the item at index [code]idx[/code].
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_get_item_id">
+			<return type="int" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<description>
+				Returns the id of the item at index [code]idx[/code]. [code]id[/code] can be manually assigned, while index can not.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_get_item_idx_from_text" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="text" type="String" />
+			<description>
+				Returns the index of the item with the specified [code]text[/code]. Index is automatically assigned to each item by the engine. Index can not be set manually.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_get_item_index" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="id" type="int" />
+			<description>
+				Returns the index of the item containing the specified [code]id[/code]. Index is automatically assigned to each item by the engine. Index can not be set manually.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_get_item_max_states" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<description>
+				Returns number of states of an multistate item. See [method global_menu_add_multistate_item] for details.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_get_item_metadata" qualifiers="const">
+			<return type="Variant" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<description>
+				Returns the metadata of the specified item, which might be of any type. You can set it with [method global_menu_set_item_metadata], which provides a simple way of assigning context data to items.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_get_item_state" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<description>
+				Returns the state of an multistate item. See [method global_menu_add_multistate_item] for details.
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_submenu">
@@ -180,13 +412,8 @@
 			<argument index="0" name="menu_root" type="String" />
 			<argument index="1" name="idx" type="int" />
 			<description>
-			</description>
-		</method>
-		<method name="global_menu_get_item_tag">
-			<return type="Variant" />
-			<argument index="0" name="menu_root" type="String" />
-			<argument index="1" name="idx" type="int" />
-			<description>
+				Returns the submenu name of the item at index [code]idx[/code]. See [method global_menu_add_submenu_item] for more info on how to add a submenu.
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_text">
@@ -194,6 +421,17 @@
 			<argument index="0" name="menu_root" type="String" />
 			<argument index="1" name="idx" type="int" />
 			<description>
+				Returns the text of the item at index [code]idx[/code].
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_get_item_tooltip">
+			<return type="String" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<description>
+				Returns the tooltip associated with the specified index index [code]idx[/code].
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="global_menu_is_item_checkable" qualifiers="const">
@@ -201,6 +439,9 @@
 			<argument index="0" name="menu_root" type="String" />
 			<argument index="1" name="idx" type="int" />
 			<description>
+				Returns [code]true[/code] if the item at index [code]idx[/code] is checkable in some way, i.e. if it has a checkbox or radio button.
+				[b]Note:[/b] Checkable items just display a checkmark or radio button, but don't have any built-in checking behavior and must be checked/unchecked manually.
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="global_menu_is_item_checked" qualifiers="const">
@@ -208,6 +449,28 @@
 			<argument index="0" name="menu_root" type="String" />
 			<argument index="1" name="idx" type="int" />
 			<description>
+				Returns [code]true[/code] if the item at index [code]idx[/code] is checked.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_is_item_disabled" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<description>
+				Returns [code]true[/code] if the item at index [code]idx[/code] is disabled. When it is disabled it can't be selected, or its action invoked.
+				See [method global_menu_set_item_disabled] for more info on how to disable an item.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_is_item_radio_checkable" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<description>
+				Returns [code]true[/code] if the item at index [code]idx[/code] has radio button-style checkability.
+				[b]Note:[/b] This is purely cosmetic; you must add the logic for checking/unchecking items in radio groups.
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="global_menu_remove_item">
@@ -215,6 +478,19 @@
 			<argument index="0" name="menu_root" type="String" />
 			<argument index="1" name="idx" type="int" />
 			<description>
+				Removes the item at index [code]idx[/code] from the global menu [code]menu_root[/code].
+				[b]Note:[/b] The indices of items after the removed item will be shifted by one.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_set_item_accelerator">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<argument index="2" name="accelerator" type="int" enum="Key" />
+			<description>
+				Sets the accelerator of the item at index [code]idx[/code].
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_callback">
@@ -223,6 +499,8 @@
 			<argument index="1" name="idx" type="int" />
 			<argument index="2" name="callback" type="Callable" />
 			<description>
+				Sets the callback of the item at index [code]idx[/code]. Callback is emitted when an item is pressed or its accelerator is activated.
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_checkable">
@@ -231,6 +509,9 @@
 			<argument index="1" name="idx" type="int" />
 			<argument index="2" name="checkable" type="bool" />
 			<description>
+				Sets whether the item at index [code]idx[/code] has a checkbox. If [code]false[/code], sets the type of the item to plain text.
+				[b]Note:[/b] Checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually.
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_checked">
@@ -239,6 +520,79 @@
 			<argument index="1" name="idx" type="int" />
 			<argument index="2" name="checked" type="bool" />
 			<description>
+				Sets the checkstate status of the item at index [code]idx[/code].
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_set_item_disabled">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<argument index="2" name="disabled" type="bool" />
+			<description>
+				Enables/disables the item at index [code]idx[/code]. When it is disabled, it can't be selected and its action can't be invoked.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_set_item_icon">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<argument index="2" name="icon" type="Texture2D" />
+			<description>
+				Replaces the [Texture2D] icon of the specified [code]idx[/code].
+				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is not supported by macOS "_dock" menu items.
+			</description>
+		</method>
+		<method name="global_menu_set_item_id">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<argument index="2" name="id" type="int" />
+			<description>
+				Sets the [code]id[/code] of the item at index [code]idx[/code].
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_set_item_max_states">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<argument index="2" name="max_states" type="int" />
+			<description>
+				Sets number of state of an multistate item. See [method global_menu_add_multistate_item] for details.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_set_item_metadata">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<argument index="2" name="metadata" type="Variant" />
+			<description>
+				Sets the metadata of an item, which may be of any type. You can later get it with [method global_menu_get_item_metadata], which provides a simple way of assigning context data to items.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_set_item_radio_checkable">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<argument index="2" name="checkable" type="bool" />
+			<description>
+				Sets the type of the item at the specified index [code]idx[/code] to radio button. If [code]false[/code], sets the type of the item to plain text
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_set_item_state">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<argument index="2" name="state" type="int" />
+			<description>
+				Sets the state of an multistate item. See [method global_menu_add_multistate_item] for details.
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_submenu">
@@ -247,14 +601,8 @@
 			<argument index="1" name="idx" type="int" />
 			<argument index="2" name="submenu" type="String" />
 			<description>
-			</description>
-		</method>
-		<method name="global_menu_set_item_tag">
-			<return type="void" />
-			<argument index="0" name="menu_root" type="String" />
-			<argument index="1" name="idx" type="int" />
-			<argument index="2" name="tag" type="Variant" />
-			<description>
+				Sets the submenu of the item at index [code]idx[/code]. The submenu is the name of a global menu root that would be shown when the item is clicked.
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_text">
@@ -263,6 +611,18 @@
 			<argument index="1" name="idx" type="int" />
 			<argument index="2" name="text" type="String" />
 			<description>
+				Sets the text of the item at index [code]idx[/code].
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_set_item_tooltip">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="idx" type="int" />
+			<argument index="2" name="tooltip" type="String" />
+			<description>
+				Sets the [String] tooltip of the item at the specified index [code]idx[/code].
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="has_feature" qualifiers="const">

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -174,6 +174,16 @@
 				An [code]id[/code] can optionally be provided. If no [code]id[/code] is provided, one will be created from the index.
 			</description>
 		</method>
+		<method name="attach_to_global_menu">
+			<return type="void" />
+			<argument index="0" name="menu_root" type="String" />
+			<argument index="1" name="label" type="String" />
+			<argument index="2" name="menu_name" type="String" default="&quot;&quot;" />
+			<description>
+				Adds [PopupMenu] to the global menu as a submenu of [code]menu_root[/code]. If [code]menu_name[/code] is not specified, [code]label[/code] will be used instead. [code]menu_name[/code] must be unique.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
 		<method name="clear">
 			<return type="void" />
 			<description>
@@ -185,6 +195,13 @@
 			<argument index="0" name="index" type="int" />
 			<description>
 				Removes all OpenType features form the item's text.
+			</description>
+		</method>
+		<method name="detach_from_global_menu">
+			<return type="void" />
+			<description>
+				Removes [PopupMenu] from the global menu.
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="get_current_index" qualifiers="const">
@@ -228,11 +245,25 @@
 				Returns item's text language code.
 			</description>
 		</method>
+		<method name="get_item_max_states" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns number of states of an multistate item. See [method add_multistate_item] for details.
+			</description>
+		</method>
 		<method name="get_item_metadata" qualifiers="const">
 			<return type="Variant" />
 			<argument index="0" name="index" type="int" />
 			<description>
 				Returns the metadata of the specified item, which might be of any type. You can set it with [method set_item_metadata], which provides a simple way of assigning context data to items.
+			</description>
+		</method>
+		<method name="get_item_multistate" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the state of a multistate item. See [method add_multistate_item] for details.
 			</description>
 		</method>
 		<method name="get_item_opentype_feature" qualifiers="const">
@@ -276,6 +307,13 @@
 			<argument index="0" name="index" type="int" />
 			<description>
 				Returns the tooltip associated with the item at the given [code]index[/code].
+			</description>
+		</method>
+		<method name="is_attached_to_global_menu" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if [PopupMenu] is attached to the global menu.
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="is_item_checkable" qualifiers="const">
@@ -403,6 +441,14 @@
 			<argument index="1" name="language" type="String" />
 			<description>
 				Sets language code of item's text used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
+			</description>
+		</method>
+		<method name="set_item_max_states">
+			<return type="void" />
+			<argument index="0" name="index" type="int" />
+			<argument index="1" name="max_states" type="int" />
+			<description>
+				Sets number of states of an multistate item. See [method add_multistate_item] for details.
 			</description>
 		</method>
 		<method name="set_item_metadata">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6298,6 +6298,7 @@ EditorNode::EditorNode() {
 	file_menu->set_switch_on_hover(true);
 	file_menu->set_text(TTR("Scene"));
 	file_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+	file_menu->get_popup()->attach_to_global_menu("_main", TTR("Scene"));
 	left_menu_hb->add_child(file_menu);
 
 	prev_scene = memnew(Button);
@@ -6414,6 +6415,7 @@ EditorNode::EditorNode() {
 	project_menu->set_tooltip(TTR("Miscellaneous project or scene-wide tools."));
 	project_menu->set_text(TTR("Project"));
 	project_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+	project_menu->get_popup()->attach_to_global_menu("_main", TTR("Project"));
 	left_menu_hb->add_child(project_menu);
 
 	p = project_menu->get_popup();
@@ -6464,6 +6466,7 @@ EditorNode::EditorNode() {
 	debug_menu->set_switch_on_hover(true);
 	debug_menu->set_text(TTR("Debug"));
 	debug_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+	debug_menu->get_popup()->attach_to_global_menu("_main", TTR("Debug"));
 	left_menu_hb->add_child(debug_menu);
 
 	menu_hb->add_spacer();
@@ -6473,6 +6476,7 @@ EditorNode::EditorNode() {
 	settings_menu->set_switch_on_hover(true);
 	settings_menu->set_text(TTR("Editor"));
 	settings_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+	settings_menu->get_popup()->attach_to_global_menu("_main", TTR("Editor"));
 	left_menu_hb->add_child(settings_menu);
 
 	p = settings_menu->get_popup();
@@ -6526,6 +6530,7 @@ EditorNode::EditorNode() {
 	help_menu->set_switch_on_hover(true);
 	help_menu->set_text(TTR("Help"));
 	help_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+	help_menu->get_popup()->attach_to_global_menu("_main", TTR("Help"));
 	left_menu_hb->add_child(help_menu);
 
 	p = help_menu->get_popup();

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -76,6 +76,8 @@ public:
 
 	NSMenu *apple_menu = nullptr;
 	NSMenu *dock_menu = nullptr;
+	NSMenu *window_menu = nullptr;
+	NSMenu *help_menu = nullptr;
 	Map<String, NSMenu *> submenu;
 
 	struct KeyEvent {
@@ -178,33 +180,60 @@ public:
 	bool drop_events;
 	bool in_dispatch_input_event = false;
 
+	void _fill_apple_menu();
+	void _fill_window_menu();
+
 public:
 	virtual bool has_feature(Feature p_feature) const override;
 	virtual String get_name() const override;
 
-	virtual void global_menu_add_item(const String &p_menu_root, const String &p_label, const Callable &p_callback, const Variant &p_tag = Variant()) override;
-	virtual void global_menu_add_check_item(const String &p_menu_root, const String &p_label, const Callable &p_callback, const Variant &p_tag = Variant()) override;
-	virtual void global_menu_add_submenu_item(const String &p_menu_root, const String &p_label, const String &p_submenu) override;
-	virtual void global_menu_add_separator(const String &p_menu_root) override;
+	virtual void global_menu_add_item(const String &p_menu_root, const String &p_label, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1) override;
+	virtual void global_menu_add_check_item(const String &p_menu_root, const String &p_label, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1) override;
+	virtual void global_menu_add_icon_item(const String &p_menu_root, const Ref<Texture2D> &p_icon, const String &p_label, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1) override;
+	virtual void global_menu_add_icon_check_item(const String &p_menu_root, const Ref<Texture2D> &p_icon, const String &p_label, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1) override;
+	virtual void global_menu_add_radio_check_item(const String &p_menu_root, const String &p_label, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1) override;
+	virtual void global_menu_add_icon_radio_check_item(const String &p_menu_root, const Ref<Texture2D> &p_icon, const String &p_label, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1) override;
+	virtual void global_menu_add_multistate_item(const String &p_menu_root, const String &p_label, int p_max_states, int p_default_state = 0, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1) override;
+	virtual void global_menu_add_submenu_item(const String &p_menu_root, const String &p_label, const String &p_submenu, int p_idx = -1) override;
+	virtual void global_menu_add_separator(const String &p_menu_root, int p_idx = -1) override;
+
+	virtual int global_menu_get_item_idx_from_text(const String &p_menu_root, const String &p_text) const override;
+	virtual int global_menu_get_item_index(const String &p_menu_root, int p_id) const override;
 
 	virtual bool global_menu_is_item_checked(const String &p_menu_root, int p_idx) const override;
 	virtual bool global_menu_is_item_checkable(const String &p_menu_root, int p_idx) const override;
+	virtual bool global_menu_is_item_radio_checkable(const String &p_menu_root, int p_idx) const override;
 	virtual Callable global_menu_get_item_callback(const String &p_menu_root, int p_idx) override;
-	virtual Variant global_menu_get_item_tag(const String &p_menu_root, int p_idx) override;
+	virtual int global_menu_get_item_id(const String &p_menu_root, int p_idx) override;
 	virtual String global_menu_get_item_text(const String &p_menu_root, int p_idx) override;
 	virtual String global_menu_get_item_submenu(const String &p_menu_root, int p_idx) override;
+	virtual Key global_menu_get_item_accelerator(const String &p_menu_root, int p_idx) override;
+	virtual bool global_menu_is_item_disabled(const String &p_menu_root, int p_idx) const override;
+	virtual String global_menu_get_item_tooltip(const String &p_menu_root, int p_idx) override;
+	virtual int global_menu_get_item_state(const String &p_menu_root, int p_idx) const override;
+	virtual int global_menu_get_item_max_states(const String &p_menu_root, int p_idx) const override;
+	virtual Variant global_menu_get_item_metadata(const String &p_menu_root, int p_idx) const override;
+	virtual Ref<Texture2D> global_menu_get_item_icon(const String &p_menu_root, int p_idx) const override;
 
 	virtual void global_menu_set_item_checked(const String &p_menu_root, int p_idx, bool p_checked) override;
 	virtual void global_menu_set_item_checkable(const String &p_menu_root, int p_idx, bool p_checkable) override;
+	virtual void global_menu_set_item_radio_checkable(const String &p_menu_root, int p_idx, bool p_checkable) override;
 	virtual void global_menu_set_item_callback(const String &p_menu_root, int p_idx, const Callable &p_callback) override;
-	virtual void global_menu_set_item_tag(const String &p_menu_root, int p_idx, const Variant &p_tag) override;
+	virtual void global_menu_set_item_id(const String &p_menu_root, int p_idx, int p_id) override;
 	virtual void global_menu_set_item_text(const String &p_menu_root, int p_idx, const String &p_text) override;
 	virtual void global_menu_set_item_submenu(const String &p_menu_root, int p_idx, const String &p_submenu) override;
+	virtual void global_menu_set_item_accelerator(const String &p_menu_root, int p_idx, Key p_keycode) override;
+	virtual void global_menu_set_item_disabled(const String &p_menu_root, int p_idx, bool p_disabled) override;
+	virtual void global_menu_set_item_tooltip(const String &p_menu_root, int p_idx, const String &p_tooltip) override;
+	virtual void global_menu_set_item_state(const String &p_menu_root, int p_idx, int p_state) override;
+	virtual void global_menu_set_item_max_states(const String &p_menu_root, int p_idx, int p_max_states) override;
+	virtual void global_menu_set_item_metadata(const String &p_menu_root, int p_idx, const Variant &p_meta) override;
+	virtual void global_menu_set_item_icon(const String &p_menu_root, int p_idx, const Ref<Texture2D> &p_icon) override;
 
 	virtual int global_menu_get_item_count(const String &p_menu_root) const override;
 
 	virtual void global_menu_remove_item(const String &p_menu_root, int p_idx) override;
-	virtual void global_menu_clear(const String &p_menu_root) override;
+	virtual void global_menu_clear(const String &p_menu_root, bool p_restore_default = true) override;
 
 	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) override;
 	virtual Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) override;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -133,7 +133,7 @@
 
 - (NSMenu *)applicationDockMenu:(NSApplication *)sender {
 	if (DS_OSX) {
-		return DS_OSX->_get_dock_menu();
+		return DS_OSX->dock_menu;
 	} else {
 		return nullptr;
 	}

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -728,6 +728,7 @@ void PopupMenu::_notification(int p_what) {
 				items.write[i].dirty = true;
 				_shape_item(i);
 			}
+			_update_global_menu();
 
 			child_controls_changed();
 			control->update();
@@ -818,6 +819,7 @@ void PopupMenu::add_item(const String &p_label, int p_id, Key p_accel) {
 	ITEM_SETUP_WITH_ACCEL(p_label, p_id, p_accel);
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 	notify_property_list_changed();
@@ -829,6 +831,7 @@ void PopupMenu::add_icon_item(const Ref<Texture2D> &p_icon, const String &p_labe
 	item.icon = p_icon;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 	notify_property_list_changed();
@@ -840,6 +843,7 @@ void PopupMenu::add_check_item(const String &p_label, int p_id, Key p_accel) {
 	item.checkable_type = Item::CHECKABLE_TYPE_CHECK_BOX;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -851,6 +855,7 @@ void PopupMenu::add_icon_check_item(const Ref<Texture2D> &p_icon, const String &
 	item.checkable_type = Item::CHECKABLE_TYPE_CHECK_BOX;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -861,6 +866,7 @@ void PopupMenu::add_radio_check_item(const String &p_label, int p_id, Key p_acce
 	item.checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -872,6 +878,7 @@ void PopupMenu::add_icon_radio_check_item(const Ref<Texture2D> &p_icon, const St
 	item.checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -883,6 +890,7 @@ void PopupMenu::add_multistate_item(const String &p_label, int p_max_states, int
 	item.state = p_default_state;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -901,6 +909,7 @@ void PopupMenu::add_shortcut(const Ref<Shortcut> &p_shortcut, int p_id, bool p_g
 	ITEM_SETUP_WITH_SHORTCUT(p_shortcut, p_id, p_global);
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -911,6 +920,7 @@ void PopupMenu::add_icon_shortcut(const Ref<Texture2D> &p_icon, const Ref<Shortc
 	item.icon = p_icon;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -921,6 +931,7 @@ void PopupMenu::add_check_shortcut(const Ref<Shortcut> &p_shortcut, int p_id, bo
 	item.checkable_type = Item::CHECKABLE_TYPE_CHECK_BOX;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -932,6 +943,7 @@ void PopupMenu::add_icon_check_shortcut(const Ref<Texture2D> &p_icon, const Ref<
 	item.checkable_type = Item::CHECKABLE_TYPE_CHECK_BOX;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -942,6 +954,7 @@ void PopupMenu::add_radio_check_shortcut(const Ref<Shortcut> &p_shortcut, int p_
 	item.checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -953,6 +966,7 @@ void PopupMenu::add_icon_radio_check_shortcut(const Ref<Texture2D> &p_icon, cons
 	item.checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -965,6 +979,7 @@ void PopupMenu::add_submenu_item(const String &p_label, const String &p_submenu,
 	item.submenu = p_submenu;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -979,6 +994,7 @@ void PopupMenu::set_item_text(int p_idx, const String &p_text) {
 	items.write[p_idx].text = p_text;
 	items.write[p_idx].xl_text = atr(p_text);
 	_shape_item(p_idx);
+	_update_global_menu();
 
 	control->update();
 	child_controls_changed();
@@ -1023,6 +1039,7 @@ void PopupMenu::set_item_language(int p_item, const String &p_language) {
 void PopupMenu::set_item_icon(int p_idx, const Ref<Texture2D> &p_icon) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].icon = p_icon;
+	_update_global_menu();
 
 	control->update();
 	child_controls_changed();
@@ -1032,6 +1049,7 @@ void PopupMenu::set_item_checked(int p_idx, bool p_checked) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 
 	items.write[p_idx].checked = p_checked;
+	_update_global_menu();
 
 	control->update();
 	child_controls_changed();
@@ -1040,6 +1058,7 @@ void PopupMenu::set_item_checked(int p_idx, bool p_checked) {
 void PopupMenu::set_item_id(int p_idx, int p_id) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].id = p_id;
+	_update_global_menu();
 
 	control->update();
 	child_controls_changed();
@@ -1049,6 +1068,7 @@ void PopupMenu::set_item_accelerator(int p_idx, Key p_accel) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].accel = p_accel;
 	items.write[p_idx].dirty = true;
+	_update_global_menu();
 
 	control->update();
 	child_controls_changed();
@@ -1057,6 +1077,8 @@ void PopupMenu::set_item_accelerator(int p_idx, Key p_accel) {
 void PopupMenu::set_item_metadata(int p_idx, const Variant &p_meta) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].metadata = p_meta;
+	_update_global_menu();
+
 	control->update();
 	child_controls_changed();
 }
@@ -1064,6 +1086,8 @@ void PopupMenu::set_item_metadata(int p_idx, const Variant &p_meta) {
 void PopupMenu::set_item_disabled(int p_idx, bool p_disabled) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].disabled = p_disabled;
+	_update_global_menu();
+
 	control->update();
 	child_controls_changed();
 }
@@ -1071,6 +1095,8 @@ void PopupMenu::set_item_disabled(int p_idx, bool p_disabled) {
 void PopupMenu::set_item_submenu(int p_idx, const String &p_submenu) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].submenu = p_submenu;
+	_update_global_menu();
+
 	control->update();
 	child_controls_changed();
 }
@@ -1078,6 +1104,8 @@ void PopupMenu::set_item_submenu(int p_idx, const String &p_submenu) {
 void PopupMenu::toggle_item_checked(int p_idx) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].checked = !items[p_idx].checked;
+	_update_global_menu();
+
 	control->update();
 	child_controls_changed();
 }
@@ -1176,9 +1204,16 @@ int PopupMenu::get_item_state(int p_idx) const {
 	return items[p_idx].state;
 }
 
+int PopupMenu::get_item_max_states(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, items.size(), -1);
+	return items[p_idx].max_states;
+}
+
 void PopupMenu::set_item_as_separator(int p_idx, bool p_separator) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].separator = p_separator;
+	_update_global_menu();
+
 	control->update();
 }
 
@@ -1190,18 +1225,24 @@ bool PopupMenu::is_item_separator(int p_idx) const {
 void PopupMenu::set_item_as_checkable(int p_idx, bool p_checkable) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].checkable_type = p_checkable ? Item::CHECKABLE_TYPE_CHECK_BOX : Item::CHECKABLE_TYPE_NONE;
+	_update_global_menu();
+
 	control->update();
 }
 
 void PopupMenu::set_item_as_radio_checkable(int p_idx, bool p_radio_checkable) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].checkable_type = p_radio_checkable ? Item::CHECKABLE_TYPE_RADIO_BUTTON : Item::CHECKABLE_TYPE_NONE;
+	_update_global_menu();
+
 	control->update();
 }
 
 void PopupMenu::set_item_tooltip(int p_idx, const String &p_tooltip) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].tooltip = p_tooltip;
+	_update_global_menu();
+
 	control->update();
 }
 
@@ -1213,6 +1254,7 @@ void PopupMenu::set_item_shortcut(int p_idx, const Ref<Shortcut> &p_shortcut, bo
 	items.write[p_idx].shortcut = p_shortcut;
 	items.write[p_idx].shortcut_is_global = p_global;
 	items.write[p_idx].dirty = true;
+	_update_global_menu();
 
 	if (items[p_idx].shortcut.is_valid()) {
 		_ref_shortcut(items[p_idx].shortcut);
@@ -1224,6 +1266,7 @@ void PopupMenu::set_item_shortcut(int p_idx, const Ref<Shortcut> &p_shortcut, bo
 void PopupMenu::set_item_h_offset(int p_idx, int p_offset) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].h_ofs = p_offset;
+
 	control->update();
 	child_controls_changed();
 }
@@ -1231,12 +1274,27 @@ void PopupMenu::set_item_h_offset(int p_idx, int p_offset) {
 void PopupMenu::set_item_multistate(int p_idx, int p_state) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].state = p_state;
+	_update_global_menu();
+
+	control->update();
+}
+
+void PopupMenu::set_item_max_states(int p_idx, int p_max_states) {
+	ERR_FAIL_INDEX(p_idx, items.size());
+	items.write[p_idx].max_states = p_max_states;
+	if (items.write[p_idx].state > p_max_states) {
+		items.write[p_idx].state = p_max_states;
+	}
+	_update_global_menu();
+
 	control->update();
 }
 
 void PopupMenu::set_item_shortcut_disabled(int p_idx, bool p_disabled) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].shortcut_is_disabled = p_disabled;
+	_update_global_menu();
+
 	control->update();
 }
 
@@ -1250,6 +1308,7 @@ void PopupMenu::toggle_item_multistate(int p_idx) {
 	if (items.write[p_idx].max_states <= items[p_idx].state) {
 		items.write[p_idx].state = 0;
 	}
+	_update_global_menu();
 
 	control->update();
 }
@@ -1404,6 +1463,7 @@ void PopupMenu::remove_item(int p_idx) {
 	}
 
 	items.remove_at(p_idx);
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 }
@@ -1417,6 +1477,7 @@ void PopupMenu::add_separator(const String &p_text, int p_id) {
 		sep.xl_text = atr(p_text);
 	}
 	items.push_back(sep);
+	_update_global_menu();
 	control->update();
 }
 
@@ -1428,9 +1489,15 @@ void PopupMenu::clear() {
 	}
 	items.clear();
 	mouse_over = -1;
+	_update_global_menu();
 	control->update();
 	child_controls_changed();
 	notify_property_list_changed();
+}
+
+void PopupMenu::_update_menu() {
+	_update_global_menu();
+	control->update();
 }
 
 void PopupMenu::_ref_shortcut(Ref<Shortcut> p_sc) {
@@ -1707,6 +1774,7 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_tooltip", "index", "tooltip"), &PopupMenu::set_item_tooltip);
 	ClassDB::bind_method(D_METHOD("set_item_shortcut", "index", "shortcut", "global"), &PopupMenu::set_item_shortcut, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_item_multistate", "index", "state"), &PopupMenu::set_item_multistate);
+	ClassDB::bind_method(D_METHOD("set_item_max_states", "index", "max_states"), &PopupMenu::set_item_max_states);
 	ClassDB::bind_method(D_METHOD("set_item_shortcut_disabled", "index", "disabled"), &PopupMenu::set_item_shortcut_disabled);
 
 	ClassDB::bind_method(D_METHOD("toggle_item_checked", "index"), &PopupMenu::toggle_item_checked);
@@ -1731,6 +1799,8 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_item_shortcut_disabled", "index"), &PopupMenu::is_item_shortcut_disabled);
 	ClassDB::bind_method(D_METHOD("get_item_tooltip", "index"), &PopupMenu::get_item_tooltip);
 	ClassDB::bind_method(D_METHOD("get_item_shortcut", "index"), &PopupMenu::get_item_shortcut);
+	ClassDB::bind_method(D_METHOD("get_item_multistate", "index"), &PopupMenu::get_item_state);
+	ClassDB::bind_method(D_METHOD("get_item_max_states", "index"), &PopupMenu::get_item_max_states);
 
 	ClassDB::bind_method(D_METHOD("get_current_index"), &PopupMenu::get_current_index);
 	ClassDB::bind_method(D_METHOD("set_item_count", "count"), &PopupMenu::set_item_count);
@@ -1756,6 +1826,10 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_allow_search", "allow"), &PopupMenu::set_allow_search);
 	ClassDB::bind_method(D_METHOD("get_allow_search"), &PopupMenu::get_allow_search);
 
+	ClassDB::bind_method(D_METHOD("attach_to_global_menu", "menu_root", "label", "menu_name"), &PopupMenu::attach_to_global_menu, DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("detach_from_global_menu"), &PopupMenu::detach_from_global_menu);
+	ClassDB::bind_method(D_METHOD("is_attached_to_global_menu"), &PopupMenu::is_attached_to_global_menu);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_item_selection"), "set_hide_on_item_selection", "is_hide_on_item_selection");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_checkable_item_selection"), "set_hide_on_checkable_item_selection", "is_hide_on_checkable_item_selection");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_state_item_selection"), "set_hide_on_state_item_selection", "is_hide_on_state_item_selection");
@@ -1767,6 +1841,110 @@ void PopupMenu::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("id_pressed", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("id_focused", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("index_pressed", PropertyInfo(Variant::INT, "index")));
+}
+
+bool PopupMenu::is_attached_to_global_menu() const {
+	if (!DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU)) {
+		return false; // Not supported.
+	}
+
+	return (_global_menu_name != String());
+}
+
+void PopupMenu::detach_from_global_menu() {
+	if (!DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU)) {
+		return; // Not supported.
+	}
+
+	if (_global_menu_name != String() && _global_menu_root != String()) {
+		for (int i = 0; i < items.size(); i++) {
+			if (items[i].submenu != String()) {
+				Node *n = get_node(items[i].submenu);
+				ERR_FAIL_COND_MSG(!n, "Item subnode does not exist: " + items[i].submenu + ".");
+				PopupMenu *pm = Object::cast_to<PopupMenu>(n);
+				ERR_FAIL_COND_MSG(!pm, "Item subnode is not a PopupMenu: " + items[i].submenu + ".");
+				pm->detach_from_global_menu();
+			}
+		}
+		for (int i = 0; i < DisplayServer::get_singleton()->global_menu_get_item_count(_global_menu_root); i++) {
+			if (DisplayServer::get_singleton()->global_menu_get_item_submenu(_global_menu_root, i) == _global_menu_name) {
+				DisplayServer::get_singleton()->global_menu_remove_item(_global_menu_root, i);
+				break;
+			}
+		}
+		DisplayServer::get_singleton()->global_menu_clear(_global_menu_name);
+		_global_menu_root = String();
+		_global_menu_name = String();
+	}
+}
+
+void PopupMenu::_update_global_menu() {
+	if (!DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU)) {
+		return; // Not supported.
+	}
+	if (_global_menu_name == String() || _global_menu_root == String()) {
+		return; // Not attached.
+	}
+
+	// Remove items.
+	DisplayServer::get_singleton()->global_menu_clear(_global_menu_name, false);
+
+	// Add items.
+	for (int i = 0; i < items.size(); i++) {
+		if (items[i].separator) {
+			DisplayServer::get_singleton()->global_menu_add_separator(_global_menu_name);
+		} else if (items[i].submenu != String()) {
+			Node *n = get_node(items[i].submenu);
+			ERR_FAIL_COND_MSG(!n, "Item subnode does not exist: " + items[i].submenu + ".");
+			PopupMenu *pm = Object::cast_to<PopupMenu>(n);
+			ERR_FAIL_COND_MSG(!pm, "Item subnode is not a PopupMenu: " + items[i].submenu + ".");
+			pm->attach_to_global_menu(_global_menu_name, items[i].xl_text, _global_menu_name + "/" + items[i].submenu);
+		} else {
+			DisplayServer::get_singleton()->global_menu_add_item(_global_menu_name, items[i].xl_text, callable_mp(this, &PopupMenu::activate_item), i);
+
+			DisplayServer::get_singleton()->global_menu_set_item_checkable(_global_menu_name, i, items[i].checkable_type);
+			DisplayServer::get_singleton()->global_menu_set_item_checked(_global_menu_name, i, items[i].checked);
+			DisplayServer::get_singleton()->global_menu_set_item_disabled(_global_menu_name, i, items[i].disabled);
+			DisplayServer::get_singleton()->global_menu_set_item_max_states(_global_menu_name, i, items[i].max_states);
+			DisplayServer::get_singleton()->global_menu_set_item_icon(_global_menu_name, i, items[i].icon);
+			DisplayServer::get_singleton()->global_menu_set_item_state(_global_menu_name, i, items[i].state);
+			DisplayServer::get_singleton()->global_menu_set_item_metadata(_global_menu_name, i, items[i].metadata);
+			DisplayServer::get_singleton()->global_menu_set_item_tooltip(_global_menu_name, i, items[i].tooltip);
+			if (!items[i].shortcut_is_disabled && !items[i].shortcut_is_global && items[i].shortcut.is_valid() && items[i].shortcut->has_valid_event()) {
+				Array events = items[i].shortcut->get_events();
+				for (int j = 0; j < events.size(); j++) {
+					Ref<InputEventKey> ie = events[j];
+					if (ie.is_valid()) {
+						DisplayServer::get_singleton()->global_menu_set_item_accelerator(_global_menu_name, i, ie->get_keycode_with_modifiers());
+						break;
+					}
+				}
+			} else if (items[i].accel != Key::NONE) {
+				DisplayServer::get_singleton()->global_menu_set_item_accelerator(_global_menu_name, i, items[i].accel);
+			}
+		}
+	}
+}
+
+void PopupMenu::attach_to_global_menu(const String &p_menu_root, const String &p_label, const String &p_submenu_name) {
+	if (!DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU)) {
+		return; // Not supported.
+	}
+
+	if (p_label == String() || p_menu_root == String()) {
+		return;
+	}
+
+	detach_from_global_menu();
+
+	String menu_name = (p_submenu_name != String()) ? p_submenu_name : p_label;
+
+	_global_menu_root = p_menu_root;
+	_global_menu_name = menu_name;
+
+	_update_global_menu();
+
+	DisplayServer::get_singleton()->global_menu_add_submenu_item(p_menu_root, p_label, menu_name);
 }
 
 void PopupMenu::popup(const Rect2 &p_bounds) {

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -130,6 +130,12 @@ class PopupMenu : public Popup {
 	ScrollContainer *scroll_container;
 	Control *control;
 
+	String _global_menu_root;
+	String _global_menu_name;
+
+	void _update_menu();
+	void _update_global_menu();
+
 	void _draw_items();
 	void _draw_background();
 
@@ -186,6 +192,7 @@ public:
 	void set_item_shortcut(int p_idx, const Ref<Shortcut> &p_shortcut, bool p_global = false);
 	void set_item_h_offset(int p_idx, int p_offset);
 	void set_item_multistate(int p_idx, int p_state);
+	void set_item_max_states(int p_idx, int p_max_states);
 	void toggle_item_multistate(int p_idx);
 	void set_item_shortcut_disabled(int p_idx, bool p_disabled);
 
@@ -211,6 +218,7 @@ public:
 	String get_item_tooltip(int p_idx) const;
 	Ref<Shortcut> get_item_shortcut(int p_idx) const;
 	int get_item_state(int p_idx) const;
+	int get_item_max_states(int p_idx) const;
 
 	int get_current_index() const;
 
@@ -251,6 +259,10 @@ public:
 	bool get_allow_search() const;
 
 	virtual void popup(const Rect2 &p_bounds = Rect2());
+
+	virtual void attach_to_global_menu(const String &p_menu_root, const String &p_label, const String &p_submenu_name = String());
+	virtual void detach_from_global_menu();
+	virtual bool is_attached_to_global_menu() const;
 
 	void take_mouse_focus();
 

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -44,20 +44,50 @@ DisplayServer::DisplayServerCreate DisplayServer::server_create_functions[Displa
 
 int DisplayServer::server_create_count = 1;
 
-void DisplayServer::global_menu_add_item(const String &p_menu_root, const String &p_label, const Callable &p_callback, const Variant &p_tag) {
+void DisplayServer::global_menu_add_item(const String &p_menu_root, const String &p_label, const Callable &p_callback, int p_id, Key p_accel, int p_idx) {
 	WARN_PRINT("Global menus not supported by this display server.");
 }
 
-void DisplayServer::global_menu_add_check_item(const String &p_menu_root, const String &p_label, const Callable &p_callback, const Variant &p_tag) {
+void DisplayServer::global_menu_add_check_item(const String &p_menu_root, const String &p_label, const Callable &p_callback, int p_id, Key p_accel, int p_idx) {
 	WARN_PRINT("Global menus not supported by this display server.");
 }
 
-void DisplayServer::global_menu_add_submenu_item(const String &p_menu_root, const String &p_label, const String &p_submenu) {
+void DisplayServer::global_menu_add_icon_item(const String &p_menu_root, const Ref<Texture2D> &p_icon, const String &p_label, const Callable &p_callback, int p_id, Key p_accel, int p_idx) {
 	WARN_PRINT("Global menus not supported by this display server.");
 }
 
-void DisplayServer::global_menu_add_separator(const String &p_menu_root) {
+void DisplayServer::global_menu_add_icon_check_item(const String &p_menu_root, const Ref<Texture2D> &p_icon, const String &p_label, const Callable &p_callback, int p_id, Key p_accel, int p_idx) {
 	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_add_radio_check_item(const String &p_menu_root, const String &p_label, const Callable &p_callback, int p_id, Key p_accel, int p_idx) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_add_icon_radio_check_item(const String &p_menu_root, const Ref<Texture2D> &p_icon, const String &p_label, const Callable &p_callback, int p_id, Key p_accel, int p_idx) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_add_multistate_item(const String &p_menu_root, const String &p_label, int p_max_states, int p_default_state, const Callable &p_callback, int p_id, Key p_accel, int p_idx) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_add_submenu_item(const String &p_menu_root, const String &p_label, const String &p_submenu, int p_idx) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_add_separator(const String &p_menu_root, int p_idx) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+int DisplayServer::global_menu_get_item_idx_from_text(const String &p_menu_root, const String &p_text) const {
+	WARN_PRINT("Global menus not supported by this display server.");
+	return -1;
+}
+
+int DisplayServer::global_menu_get_item_index(const String &p_menu_root, int p_id) const {
+	WARN_PRINT("Global menus not supported by this display server.");
+	return -1;
 }
 
 void DisplayServer::global_menu_set_item_callback(const String &p_menu_root, int p_idx, const Callable &p_callback) {
@@ -74,12 +104,17 @@ bool DisplayServer::global_menu_is_item_checkable(const String &p_menu_root, int
 	return false;
 }
 
+bool DisplayServer::global_menu_is_item_radio_checkable(const String &p_menu_root, int p_idx) const {
+	WARN_PRINT("Global menus not supported by this display server.");
+	return false;
+}
+
 Callable DisplayServer::global_menu_get_item_callback(const String &p_menu_root, int p_idx) {
 	WARN_PRINT("Global menus not supported by this display server.");
 	return Callable();
 }
 
-Variant DisplayServer::global_menu_get_item_tag(const String &p_menu_root, int p_idx) {
+int DisplayServer::global_menu_get_item_id(const String &p_menu_root, int p_idx) {
 	WARN_PRINT("Global menus not supported by this display server.");
 	return Variant();
 }
@@ -94,6 +129,41 @@ String DisplayServer::global_menu_get_item_submenu(const String &p_menu_root, in
 	return String();
 }
 
+Key DisplayServer::global_menu_get_item_accelerator(const String &p_menu_root, int p_idx) {
+	WARN_PRINT("Global menus not supported by this display server.");
+	return Key::NONE;
+}
+
+bool DisplayServer::global_menu_is_item_disabled(const String &p_menu_root, int p_idx) const {
+	WARN_PRINT("Global menus not supported by this display server.");
+	return false;
+}
+
+String DisplayServer::global_menu_get_item_tooltip(const String &p_menu_root, int p_idx) {
+	WARN_PRINT("Global menus not supported by this display server.");
+	return String();
+}
+
+int DisplayServer::global_menu_get_item_state(const String &p_menu_root, int p_idx) const {
+	WARN_PRINT("Global menus not supported by this display server.");
+	return 0;
+}
+
+int DisplayServer::global_menu_get_item_max_states(const String &p_menu_root, int p_idx) const {
+	WARN_PRINT("Global menus not supported by this display server.");
+	return 0;
+}
+
+Variant DisplayServer::global_menu_get_item_metadata(const String &p_menu_root, int p_idx) const {
+	WARN_PRINT("Global menus not supported by this display server.");
+	return Variant();
+}
+
+Ref<Texture2D> DisplayServer::global_menu_get_item_icon(const String &p_menu_root, int p_idx) const {
+	WARN_PRINT("Global menus not supported by this display server.");
+	return Ref<Texture2D>();
+}
+
 void DisplayServer::global_menu_set_item_checked(const String &p_menu_root, int p_idx, bool p_checked) {
 	WARN_PRINT("Global menus not supported by this display server.");
 }
@@ -102,7 +172,11 @@ void DisplayServer::global_menu_set_item_checkable(const String &p_menu_root, in
 	WARN_PRINT("Global menus not supported by this display server.");
 }
 
-void DisplayServer::global_menu_set_item_tag(const String &p_menu_root, int p_idx, const Variant &p_tag) {
+void DisplayServer::global_menu_set_item_radio_checkable(const String &p_menu_root, int p_idx, bool p_checkable) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_set_item_id(const String &p_menu_root, int p_idx, int p_id) {
 	WARN_PRINT("Global menus not supported by this display server.");
 }
 
@@ -111,6 +185,34 @@ void DisplayServer::global_menu_set_item_text(const String &p_menu_root, int p_i
 }
 
 void DisplayServer::global_menu_set_item_submenu(const String &p_menu_root, int p_idx, const String &p_submenu) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_set_item_accelerator(const String &p_menu_root, int p_idx, Key p_keycode) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_set_item_disabled(const String &p_menu_root, int p_idx, bool p_disabled) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_set_item_tooltip(const String &p_menu_root, int p_idx, const String &p_tooltip) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_set_item_state(const String &p_menu_root, int p_idx, int p_state) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_set_item_max_states(const String &p_menu_root, int p_idx, int p_max_states) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_set_item_metadata(const String &p_menu_root, int p_idx, const Variant &p_meta) {
+	WARN_PRINT("Global menus not supported by this display server.");
+}
+
+void DisplayServer::global_menu_set_item_icon(const String &p_menu_root, int p_idx, const Ref<Texture2D> &p_icon) {
 	WARN_PRINT("Global menus not supported by this display server.");
 }
 
@@ -123,7 +225,7 @@ void DisplayServer::global_menu_remove_item(const String &p_menu_root, int p_idx
 	WARN_PRINT("Global menus not supported by this display server.");
 }
 
-void DisplayServer::global_menu_clear(const String &p_menu_root) {
+void DisplayServer::global_menu_clear(const String &p_menu_root, bool p_restore_default) {
 	WARN_PRINT("Global menus not supported by this display server.");
 }
 
@@ -340,27 +442,51 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_feature", "feature"), &DisplayServer::has_feature);
 	ClassDB::bind_method(D_METHOD("get_name"), &DisplayServer::get_name);
 
-	ClassDB::bind_method(D_METHOD("global_menu_add_item", "menu_root", "label", "callback", "tag"), &DisplayServer::global_menu_add_item, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("global_menu_add_check_item", "menu_root", "label", "callback", "tag"), &DisplayServer::global_menu_add_check_item, DEFVAL(Variant()));
-	ClassDB::bind_method(D_METHOD("global_menu_add_submenu_item", "menu_root", "label", "submenu"), &DisplayServer::global_menu_add_submenu_item);
-	ClassDB::bind_method(D_METHOD("global_menu_add_separator", "menu_root"), &DisplayServer::global_menu_add_separator);
+	ClassDB::bind_method(D_METHOD("global_menu_add_item", "menu_root", "label", "callback", "id", "accel", "idx"), &DisplayServer::global_menu_add_item, DEFVAL(Callable()), DEFVAL(-1), DEFVAL(0), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("global_menu_add_check_item", "menu_root", "label", "callback", "id", "accel", "idx"), &DisplayServer::global_menu_add_check_item, DEFVAL(Callable()), DEFVAL(-1), DEFVAL(0), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("global_menu_add_icon_item", "menu_root", "icon", "label", "callback", "id", "accel", "idx"), &DisplayServer::global_menu_add_icon_item, DEFVAL(Callable()), DEFVAL(-1), DEFVAL(0), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("global_menu_add_icon_check_item", "menu_root", "icon", "label", "callback", "id", "accel", "idx"), &DisplayServer::global_menu_add_icon_check_item, DEFVAL(Callable()), DEFVAL(-1), DEFVAL(0), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("global_menu_add_radio_check_item", "menu_root", "label", "callback", "id", "accel", "idx"), &DisplayServer::global_menu_add_radio_check_item, DEFVAL(Callable()), DEFVAL(-1), DEFVAL(0), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("global_menu_add_icon_radio_check_item", "menu_root", "icon", "label", "callback", "id", "accel", "idx"), &DisplayServer::global_menu_add_icon_radio_check_item, DEFVAL(Callable()), DEFVAL(-1), DEFVAL(0), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("global_menu_add_multistate_item", "menu_root", "label", "max_states", "default_state", "callback", "id", "accel", "idx"), &DisplayServer::global_menu_add_multistate_item, DEFVAL(0), DEFVAL(Callable()), DEFVAL(-1), DEFVAL(0), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("global_menu_add_submenu_item", "menu_root", "label", "submenu", "idx"), &DisplayServer::global_menu_add_submenu_item, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("global_menu_add_separator", "menu_root", "idx"), &DisplayServer::global_menu_add_separator, DEFVAL(-1));
+
+	ClassDB::bind_method(D_METHOD("global_menu_get_item_idx_from_text", "menu_root", "text"), &DisplayServer::global_menu_get_item_idx_from_text);
+	ClassDB::bind_method(D_METHOD("global_menu_get_item_index", "menu_root", "id"), &DisplayServer::global_menu_get_item_index);
 
 	ClassDB::bind_method(D_METHOD("global_menu_is_item_checked", "menu_root", "idx"), &DisplayServer::global_menu_is_item_checked);
 	ClassDB::bind_method(D_METHOD("global_menu_is_item_checkable", "menu_root", "idx"), &DisplayServer::global_menu_is_item_checkable);
+	ClassDB::bind_method(D_METHOD("global_menu_is_item_radio_checkable", "menu_root", "idx"), &DisplayServer::global_menu_is_item_radio_checkable);
 	ClassDB::bind_method(D_METHOD("global_menu_get_item_callback", "menu_root", "idx"), &DisplayServer::global_menu_get_item_callback);
-	ClassDB::bind_method(D_METHOD("global_menu_get_item_tag", "menu_root", "idx"), &DisplayServer::global_menu_get_item_tag);
+	ClassDB::bind_method(D_METHOD("global_menu_get_item_id", "menu_root", "idx"), &DisplayServer::global_menu_get_item_id);
 	ClassDB::bind_method(D_METHOD("global_menu_get_item_text", "menu_root", "idx"), &DisplayServer::global_menu_get_item_text);
 	ClassDB::bind_method(D_METHOD("global_menu_get_item_submenu", "menu_root", "idx"), &DisplayServer::global_menu_get_item_submenu);
+	ClassDB::bind_method(D_METHOD("global_menu_get_item_accelerator", "menu_root", "idx"), &DisplayServer::global_menu_get_item_accelerator);
+	ClassDB::bind_method(D_METHOD("global_menu_is_item_disabled", "menu_root", "idx"), &DisplayServer::global_menu_is_item_disabled);
+	ClassDB::bind_method(D_METHOD("global_menu_get_item_tooltip", "menu_root", "idx"), &DisplayServer::global_menu_get_item_tooltip);
+	ClassDB::bind_method(D_METHOD("global_menu_get_item_state", "menu_root", "idx"), &DisplayServer::global_menu_get_item_state);
+	ClassDB::bind_method(D_METHOD("global_menu_get_item_max_states", "menu_root", "idx"), &DisplayServer::global_menu_get_item_max_states);
+	ClassDB::bind_method(D_METHOD("global_menu_get_item_metadata", "menu_root", "idx"), &DisplayServer::global_menu_get_item_metadata);
+	ClassDB::bind_method(D_METHOD("global_menu_get_item_icon", "menu_root", "idx"), &DisplayServer::global_menu_get_item_icon);
 
 	ClassDB::bind_method(D_METHOD("global_menu_set_item_checked", "menu_root", "idx", "checked"), &DisplayServer::global_menu_set_item_checked);
 	ClassDB::bind_method(D_METHOD("global_menu_set_item_checkable", "menu_root", "idx", "checkable"), &DisplayServer::global_menu_set_item_checkable);
+	ClassDB::bind_method(D_METHOD("global_menu_set_item_radio_checkable", "menu_root", "idx", "checkable"), &DisplayServer::global_menu_set_item_radio_checkable);
 	ClassDB::bind_method(D_METHOD("global_menu_set_item_callback", "menu_root", "idx", "callback"), &DisplayServer::global_menu_set_item_callback);
-	ClassDB::bind_method(D_METHOD("global_menu_set_item_tag", "menu_root", "idx", "tag"), &DisplayServer::global_menu_set_item_tag);
+	ClassDB::bind_method(D_METHOD("global_menu_set_item_id", "menu_root", "idx", "id"), &DisplayServer::global_menu_set_item_id);
 	ClassDB::bind_method(D_METHOD("global_menu_set_item_text", "menu_root", "idx", "text"), &DisplayServer::global_menu_set_item_text);
 	ClassDB::bind_method(D_METHOD("global_menu_set_item_submenu", "menu_root", "idx", "submenu"), &DisplayServer::global_menu_set_item_submenu);
+	ClassDB::bind_method(D_METHOD("global_menu_set_item_accelerator", "menu_root", "idx", "accelerator"), &DisplayServer::global_menu_set_item_accelerator);
+	ClassDB::bind_method(D_METHOD("global_menu_set_item_disabled", "menu_root", "idx", "disabled"), &DisplayServer::global_menu_set_item_disabled);
+	ClassDB::bind_method(D_METHOD("global_menu_set_item_tooltip", "menu_root", "idx", "tooltip"), &DisplayServer::global_menu_set_item_tooltip);
+	ClassDB::bind_method(D_METHOD("global_menu_set_item_state", "menu_root", "idx", "state"), &DisplayServer::global_menu_set_item_state);
+	ClassDB::bind_method(D_METHOD("global_menu_set_item_max_states", "menu_root", "idx", "max_states"), &DisplayServer::global_menu_set_item_max_states);
+	ClassDB::bind_method(D_METHOD("global_menu_set_item_metadata", "menu_root", "idx", "metadata"), &DisplayServer::global_menu_set_item_metadata);
+	ClassDB::bind_method(D_METHOD("global_menu_set_item_icon", "menu_root", "idx", "icon"), &DisplayServer::global_menu_set_item_icon);
 
 	ClassDB::bind_method(D_METHOD("global_menu_remove_item", "menu_root", "idx"), &DisplayServer::global_menu_remove_item);
-	ClassDB::bind_method(D_METHOD("global_menu_clear", "menu_root"), &DisplayServer::global_menu_clear);
+	ClassDB::bind_method(D_METHOD("global_menu_clear", "menu_root", "restore_default"), &DisplayServer::global_menu_clear, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("mouse_set_mode", "mouse_mode"), &DisplayServer::mouse_set_mode);
 	ClassDB::bind_method(D_METHOD("mouse_get_mode"), &DisplayServer::mouse_get_mode);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -120,29 +120,53 @@ public:
 	virtual bool has_feature(Feature p_feature) const = 0;
 	virtual String get_name() const = 0;
 
-	virtual void global_menu_add_item(const String &p_menu_root, const String &p_label, const Callable &p_callback, const Variant &p_tag = Variant());
-	virtual void global_menu_add_check_item(const String &p_menu_root, const String &p_label, const Callable &p_callback, const Variant &p_tag = Variant());
-	virtual void global_menu_add_submenu_item(const String &p_menu_root, const String &p_label, const String &p_submenu);
-	virtual void global_menu_add_separator(const String &p_menu_root);
+	virtual void global_menu_add_item(const String &p_menu_root, const String &p_label, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1);
+	virtual void global_menu_add_check_item(const String &p_menu_root, const String &p_label, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1);
+	virtual void global_menu_add_icon_item(const String &p_menu_root, const Ref<Texture2D> &p_icon, const String &p_label, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1);
+	virtual void global_menu_add_icon_check_item(const String &p_menu_root, const Ref<Texture2D> &p_icon, const String &p_label, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1);
+	virtual void global_menu_add_radio_check_item(const String &p_menu_root, const String &p_label, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1);
+	virtual void global_menu_add_icon_radio_check_item(const String &p_menu_root, const Ref<Texture2D> &p_icon, const String &p_label, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1);
+	virtual void global_menu_add_multistate_item(const String &p_menu_root, const String &p_label, int p_max_states, int p_default_state = 0, const Callable &p_callback = Callable(), int p_id = -1, Key p_accel = Key::NONE, int p_idx = -1);
+	virtual void global_menu_add_submenu_item(const String &p_menu_root, const String &p_label, const String &p_submenu, int p_idx = -1);
+	virtual void global_menu_add_separator(const String &p_menu_root, int p_idx = -1);
+
+	virtual int global_menu_get_item_idx_from_text(const String &p_menu_root, const String &p_text) const;
+	virtual int global_menu_get_item_index(const String &p_menu_root, int p_id) const;
 
 	virtual bool global_menu_is_item_checked(const String &p_menu_root, int p_idx) const;
 	virtual bool global_menu_is_item_checkable(const String &p_menu_root, int p_idx) const;
+	virtual bool global_menu_is_item_radio_checkable(const String &p_menu_root, int p_idx) const;
 	virtual Callable global_menu_get_item_callback(const String &p_menu_root, int p_idx);
-	virtual Variant global_menu_get_item_tag(const String &p_menu_root, int p_idx);
+	virtual int global_menu_get_item_id(const String &p_menu_root, int p_idx);
 	virtual String global_menu_get_item_text(const String &p_menu_root, int p_idx);
 	virtual String global_menu_get_item_submenu(const String &p_menu_root, int p_idx);
+	virtual Key global_menu_get_item_accelerator(const String &p_menu_root, int p_idx);
+	virtual bool global_menu_is_item_disabled(const String &p_menu_root, int p_idx) const;
+	virtual String global_menu_get_item_tooltip(const String &p_menu_root, int p_idx);
+	virtual int global_menu_get_item_state(const String &p_menu_root, int p_idx) const;
+	virtual int global_menu_get_item_max_states(const String &p_menu_root, int p_idx) const;
+	virtual Variant global_menu_get_item_metadata(const String &p_menu_root, int p_idx) const;
+	virtual Ref<Texture2D> global_menu_get_item_icon(const String &p_menu_root, int p_idx) const;
 
 	virtual void global_menu_set_item_checked(const String &p_menu_root, int p_idx, bool p_checked);
 	virtual void global_menu_set_item_checkable(const String &p_menu_root, int p_idx, bool p_checkable);
+	virtual void global_menu_set_item_radio_checkable(const String &p_menu_root, int p_idx, bool p_checkable);
 	virtual void global_menu_set_item_callback(const String &p_menu_root, int p_idx, const Callable &p_callback);
-	virtual void global_menu_set_item_tag(const String &p_menu_root, int p_idx, const Variant &p_tag);
+	virtual void global_menu_set_item_id(const String &p_menu_root, int p_idx, int p_id);
 	virtual void global_menu_set_item_text(const String &p_menu_root, int p_idx, const String &p_text);
 	virtual void global_menu_set_item_submenu(const String &p_menu_root, int p_idx, const String &p_submenu);
+	virtual void global_menu_set_item_accelerator(const String &p_menu_root, int p_idx, Key p_keycode);
+	virtual void global_menu_set_item_disabled(const String &p_menu_root, int p_idx, bool p_disabled);
+	virtual void global_menu_set_item_tooltip(const String &p_menu_root, int p_idx, const String &p_tooltip);
+	virtual void global_menu_set_item_state(const String &p_menu_root, int p_idx, int p_state);
+	virtual void global_menu_set_item_max_states(const String &p_menu_root, int p_idx, int p_max_states);
+	virtual void global_menu_set_item_metadata(const String &p_menu_root, int p_idx, const Variant &p_meta);
+	virtual void global_menu_set_item_icon(const String &p_menu_root, int p_idx, const Ref<Texture2D> &p_icon);
 
 	virtual int global_menu_get_item_count(const String &p_menu_root) const;
 
 	virtual void global_menu_remove_item(const String &p_menu_root, int p_idx);
-	virtual void global_menu_clear(const String &p_menu_root);
+	virtual void global_menu_clear(const String &p_menu_root, bool p_restore_default = true);
 
 	enum MouseMode {
 		MOUSE_MODE_VISIBLE,


### PR DESCRIPTION
**Adds missing global menu features:**
 - [x] Multi-State / Radio check items.
 - [x] Metadata.
 - [x] ToolTips.
 - [x] Enabled/Disabled items.
 - [x] Shortcuts.
 - [x] Icons (due to OS limitations not support in dock menus).

**Adds option to use existing `PopupMenu`s in global menu.**
Global menu tracks `PopupMenu` changes and submenus and send back item activation events.

**Duplicates editor main menu as macOS native menu.**

<img width="1062" alt="editor_screenshot" src="https://user-images.githubusercontent.com/7645683/79966900-c4352700-8496-11ea-9943-7360503974a8.png">

Demo project (live menu editor): [menu_test.zip](https://github.com/godotengine/godot/files/4515213/menu_test.zip)

<img width="1062" alt="menu_test_screenshot" src="https://user-images.githubusercontent.com/7645683/79966697-7ae4d780-8496-11ea-9e73-3ed5e34c74ab.png">
