### PR TITLE
DocData: Keep Mono properties on non-Mono builds

### DIFF
--- a/editor/doc_data.cpp
+++ b/editor/doc_data.cpp
@@ -40,6 +40,9 @@
 #include "core/version.h"
 #include "scene/resources/theme.h"
 
+// Used for a hack preserving Mono properties on non-Mono builds.
+#include "modules/modules_enabled.gen.h"
+
 void DocData::merge_from(const DocData &p_data) {
 
 	for (Map<String, ClassDoc>::Element *E = class_list.front(); E; E = E->next()) {
@@ -154,6 +157,23 @@ void DocData::merge_from(const DocData &p_data) {
 				break;
 			}
 		}
+
+#ifndef MODULE_MONO_ENABLED
+		// The Mono module defines some properties that we want to keep when
+		// re-generating docs with a non-Mono build, to prevent pointless diffs
+		// (and loss of descriptions) depending on the config of the doc writer.
+		// We use a horrible hack to force keeping the relevant properties,
+		// hardcoded below. At least it's an ad hoc hack... ¯\_(ツ)_/¯
+		// Don't show this to your kids.
+		if (c.name == "@GlobalScope") {
+			// Retrieve GodotSharp singleton.
+			for (int j = 0; j < cf.properties.size(); j++) {
+				if (cf.properties[j].name == "GodotSharp") {
+					c.properties.push_back(cf.properties[j]);
+				}
+			}
+		}
+#endif
 	}
 }
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -55,6 +55,7 @@
 #include "main/splash.gen.h"
 #include "main/splash_editor.gen.h"
 #include "main/tests/test_main.h"
+#include "modules/modules_enabled.gen.h"
 #include "modules/register_module_types.h"
 #include "platform/register_platform_apis.h"
 #include "scene/main/scene_tree.h"
@@ -1599,6 +1600,19 @@ bool Main::start() {
 			DirAccessRef da = DirAccess::open(doc_tool);
 			ERR_FAIL_COND_V_MSG(!da, false, "Argument supplied to --doctool must be a base Godot build directory.");
 		}
+
+#ifndef MODULE_MONO_ENABLED
+		// Hack to define Mono-specific project settings even on non-Mono builds,
+		// so that we don't lose their descriptions and default values in DocData.
+		// Default values should be synced with mono_gd/gd_mono.cpp.
+		GLOBAL_DEF("mono/debugger_agent/port", 23685);
+		GLOBAL_DEF("mono/debugger_agent/wait_for_debugger", false);
+		GLOBAL_DEF("mono/debugger_agent/wait_timeout", 3000);
+		GLOBAL_DEF("mono/profiler/args", "log:calls,alloc,sample,output=output.mlpd");
+		GLOBAL_DEF("mono/profiler/enabled", false);
+		GLOBAL_DEF("mono/unhandled_exception_policy", 0);
+#endif
+
 		DocData doc;
 		doc.generate(doc_base);
 


### PR DESCRIPTION
This doesn't make much sense API-wise, but it's important for the documentation
workflow that the Mono and non-Mono builds produce the same output, otherwise
we keep having non-Mono builds removing Mono properties and losing their
descriptions.

This is a terrible hack but it's ad hoc, and should be OK for the time being.