### PR TITLE
Document the Cubemap class

### DIFF
--- a/doc/classes/Cubemap.xml
+++ b/doc/classes/Cubemap.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Cubemap" inherits="TextureLayered" version="4.0">
 	<brief_description>
+		6-sided texture typically used in 3D rendering.
 	</brief_description>
 	<description>
+		A cubemap is a 6-sided texture typically used for faking reflections in 3D rendering. It can be used to make an object look as if it's reflecting its surroundings. This usually delivers much better performance than other reflection methods.
+		This resource is typically used as a uniform in custom shaders. Few core Godot methods make use of Cubemap resources.
+		[b]Note:[/b] Godot doesn't support using cubemaps as a [PanoramaSkyMaterial]. You can use [url=https://danilw.github.io/GLSL-howto/cubemap_to_panorama_js/cubemap_to_panorama.html]this tool[/url] to convert a cube map to an equirectangular sky map.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
The documentation was partly ported over from Godot 3.2. I also added a note about skies, for those looking to use cubemap skies (as it may appear in the class reference search).

**Note:** Not eligible for cherry-picking, as Cubemap was added in 4.0.