### PR TITLE
Exposing Android JNIEnv, Activity to cpp modules. Exposing iOS UIView to cpp modules. 

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -18,6 +18,7 @@ android_files = [
     'jni_utils.cpp',
     'android_keys_utils.cpp',
     'plugin/godot_plugin_jni.cpp',
+    'android_proxy.cpp',
     #'power_android.cpp'
 ]
 

--- a/platform/android/android_proxy.cpp
+++ b/platform/android/android_proxy.cpp
@@ -1,0 +1,44 @@
+/*************************************************************************/
+/*  android_proxy.cpp                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include <jni.h>
+#include "platform/android/java_godot_wrapper.h"
+#include "platform/android/os_android.h"
+#include "platform/android/thread_jandroid.h"
+#include "android_proxy.h"
+
+
+jobject get_activity(){
+	GodotJavaWrapper *godot_java = ((OS_Android *)OS::get_singleton())->get_godot_java();
+	return godot_java->get_activity();
+}
+JNIEnv* get_env(){
+	return ThreadAndroid::get_env();
+}

--- a/platform/android/android_proxy.h
+++ b/platform/android/android_proxy.h
@@ -1,0 +1,40 @@
+/*************************************************************************/
+/*  android_proxy.h                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef ANDROID_PROXY_H
+#define ANDROID_PROXY_H
+
+#include <jni.h>
+
+jobject get_activity();
+JNIEnv* get_env();
+
+
+#endif /* ANDROID_PROXY_H */

--- a/platform/iphone/gl_view.mm
+++ b/platform/iphone/gl_view.mm
@@ -51,7 +51,9 @@ bool gles3_available = true;
 int gl_view_base_fb;
 static String keyboard_text;
 static GLView *_instance = NULL;
-
+id _get_view_instance(){
+	return _instance;
+};
 static bool video_found_error = false;
 static bool video_playing = false;
 static CMTime video_current_time;


### PR DESCRIPTION
**Android - Exposing JNIEnv and Activity to cpp modules.** 

Activity and JNIEnv access: 

```
#include <jni.h>
extern JNIEnv* get_env();
extern jobject get_activity();

```
------------

**Iphone - Exposing iOS UIView reference to cpp modules.**

Reference (id) access:

```
extern "C" {
#include <objc/objc.h>
}  // extern "C"

extern id _get_view_instance();

```