### PR TITLE
Use proper depth buffer format for rgba shadows

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -4045,7 +4045,7 @@ void RasterizerSceneGLES2::initialize() {
 			//maximum compatibility, renderbuffer and RGBA shadow
 			glGenRenderbuffers(1, &directional_shadow.depth);
 			glBindRenderbuffer(GL_RENDERBUFFER, directional_shadow.depth);
-			glRenderbufferStorage(GL_RENDERBUFFER, storage->config.depth_internalformat, directional_shadow.size, directional_shadow.size);
+			glRenderbufferStorage(GL_RENDERBUFFER, storage->config.depth_buffer_internalformat, directional_shadow.size, directional_shadow.size);
 			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, directional_shadow.depth);
 
 			glGenTextures(1, &directional_shadow.color);


### PR DESCRIPTION
Helps: #37975

This continues #33844. There is still an outstanding issue with DirectionalLights, but this fixes the issue with the other light types. 