### PR TITLE
Improve the Vector2 rotated code

### DIFF
--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -119,11 +119,11 @@ Vector2 Vector2::round() const {
 }
 
 Vector2 Vector2::rotated(real_t p_by) const {
-
-	Vector2 v;
-	v.set_rotation(angle() + p_by);
-	v *= length();
-	return v;
+	real_t sine = Math::sin(p_by);
+	real_t cosi = Math::cos(p_by);
+	return Vector2(
+			x * cosi - y * sine,
+			x * sine + y * cosi);
 }
 
 Vector2 Vector2::posmod(const real_t p_mod) const {

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -123,12 +123,6 @@ struct Vector2 {
 
 	real_t angle() const;
 
-	void set_rotation(real_t p_radians) {
-
-		x = Math::cos(p_radians);
-		y = Math::sin(p_radians);
-	}
-
 	_FORCE_INLINE_ Vector2 abs() const {
 
 		return Vector2(Math::abs(x), Math::abs(y));


### PR DESCRIPTION
The old code was prone to floating point errors (and likely not as performant as it could be), since it had an unnecessary step of grabbing the existing angle.

This PR changes the code to returning a new Vector2 constructed from the existing components multiplied by a rotation matrix of sin and cos (but not in a transform or anything, just some numbers). Also, `set_rotation` was a (misleading) internal method only used here, so I removed it.

Fixes #38059