### PR TITLE
Small naming and tooltip tweaks

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3363,9 +3363,9 @@ void AnimationTrackEditor::_query_insert(const InsertData &p_id) {
 			}
 
 			if (num_tracks == 1) {
-				insert_confirm_text->set_text(vformat(TTR("Create NEW track for %s and insert key?"), p_id.query));
+				insert_confirm_text->set_text(vformat(TTR("Create new track for %s and insert key?"), p_id.query));
 			} else {
-				insert_confirm_text->set_text(vformat(TTR("Create %d NEW tracks and insert keys?"), num_tracks));
+				insert_confirm_text->set_text(vformat(TTR("Create %d new tracks and insert keys?"), num_tracks));
 			}
 
 			insert_confirm_bezier->set_visible(all_bezier);

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -707,6 +707,7 @@ CreateDialog::CreateDialog() {
 	favorite = memnew(Button);
 	favorite->set_flat(true);
 	favorite->set_toggle_mode(true);
+	favorite->set_tooltip(TTR("(Un)favorite selected item."));
 	favorite->connect("pressed", callable_mp(this, &CreateDialog::_favorite_toggled));
 	search_hb->add_child(favorite);
 	vbc->add_margin_child(TTR("Search:"), search_hb);

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -440,7 +440,7 @@ void EditorFileDialog::_action_pressed() {
 		}
 
 		if (dir_access->file_exists(f) && !disable_overwrite_warning) {
-			confirm_save->set_text(TTR("File Exists, Overwrite?"));
+			confirm_save->set_text(TTR("File exists, overwrite?"));
 			confirm_save->popup_centered(Size2(200, 80));
 		} else {
 			_save_to_recent();

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -79,7 +79,7 @@ void AnimationTreeEditor::_update_path() {
 	group.instance();
 
 	Button *b = memnew(Button);
-	b->set_text("root");
+	b->set_text("Root");
 	b->set_toggle_mode(true);
 	b->set_button_group(group);
 	b->set_pressed(true);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -828,7 +828,7 @@ ThemeEditor::ThemeEditor() {
 	type_hbc->add_child(type_edit);
 	type_menu = memnew(MenuButton);
 	type_menu->set_flat(false);
-	type_menu->set_text("..");
+	type_menu->set_text("...");
 	type_hbc->add_child(type_menu);
 
 	type_menu->get_popup()->connect("id_pressed", callable_mp(this, &ThemeEditor::_type_menu_cbk));
@@ -846,7 +846,7 @@ ThemeEditor::ThemeEditor() {
 	name_hbc->add_child(name_edit);
 	name_menu = memnew(MenuButton);
 	type_menu->set_flat(false);
-	name_menu->set_text("..");
+	name_menu->set_text("...");
 	name_hbc->add_child(name_menu);
 
 	name_menu->get_popup()->connect("about_to_popup", callable_mp(this, &ThemeEditor::_name_menu_about_to_show));

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -141,7 +141,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	but_insert_name = memnew(Button);
 	but_insert_name->set_text("NAME");
-	but_insert_name->set_tooltip(String("${NAME}\n") + TTR("Node name"));
+	but_insert_name->set_tooltip(String("${NAME}\n") + TTR("Node name."));
 	but_insert_name->set_focus_mode(Control::FOCUS_NONE);
 	but_insert_name->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${NAME}"));
 	but_insert_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -151,7 +151,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	but_insert_parent = memnew(Button);
 	but_insert_parent->set_text("PARENT");
-	but_insert_parent->set_tooltip(String("${PARENT}\n") + TTR("Node's parent name, if available"));
+	but_insert_parent->set_tooltip(String("${PARENT}\n") + TTR("Node's parent name, if available."));
 	but_insert_parent->set_focus_mode(Control::FOCUS_NONE);
 	but_insert_parent->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${PARENT}"));
 	but_insert_parent->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -161,7 +161,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	but_insert_type = memnew(Button);
 	but_insert_type->set_text("TYPE");
-	but_insert_type->set_tooltip(String("${TYPE}\n") + TTR("Node type"));
+	but_insert_type->set_tooltip(String("${TYPE}\n") + TTR("Node type."));
 	but_insert_type->set_focus_mode(Control::FOCUS_NONE);
 	but_insert_type->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${TYPE}"));
 	but_insert_type->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -171,7 +171,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	but_insert_scene = memnew(Button);
 	but_insert_scene->set_text("SCENE");
-	but_insert_scene->set_tooltip(String("${SCENE}\n") + TTR("Current scene name"));
+	but_insert_scene->set_tooltip(String("${SCENE}\n") + TTR("Current scene name."));
 	but_insert_scene->set_focus_mode(Control::FOCUS_NONE);
 	but_insert_scene->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${SCENE}"));
 	but_insert_scene->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -181,7 +181,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	but_insert_root = memnew(Button);
 	but_insert_root->set_text("ROOT");
-	but_insert_root->set_tooltip(String("${ROOT}\n") + TTR("Root node name"));
+	but_insert_root->set_tooltip(String("${ROOT}\n") + TTR("Root node name."));
 	but_insert_root->set_focus_mode(Control::FOCUS_NONE);
 	but_insert_root->connect("pressed", callable_mp(this, &RenameDialog::_insert_text), make_binds("${ROOT}"));
 	but_insert_root->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -199,7 +199,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	chk_per_level_counter = memnew(CheckBox);
 	chk_per_level_counter->set_text(TTR("Per-level Counter"));
-	chk_per_level_counter->set_tooltip(TTR("If set the counter restarts for each group of child nodes"));
+	chk_per_level_counter->set_tooltip(TTR("If set the counter restarts for each group of child nodes."));
 	vbc_substitute->add_child(chk_per_level_counter);
 
 	HBoxContainer *hbc_count_options = memnew(HBoxContainer);
@@ -207,22 +207,22 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 
 	Label *lbl_count_start = memnew(Label);
 	lbl_count_start->set_text(TTR("Start"));
-	lbl_count_start->set_tooltip(TTR("Initial value for the counter"));
+	lbl_count_start->set_tooltip(TTR("Initial value for the counter."));
 	hbc_count_options->add_child(lbl_count_start);
 
 	spn_count_start = memnew(SpinBox);
-	spn_count_start->set_tooltip(TTR("Initial value for the counter"));
+	spn_count_start->set_tooltip(TTR("Initial value for the counter."));
 	spn_count_start->set_step(1);
 	spn_count_start->set_min(0);
 	hbc_count_options->add_child(spn_count_start);
 
 	Label *lbl_count_step = memnew(Label);
 	lbl_count_step->set_text(TTR("Step"));
-	lbl_count_step->set_tooltip(TTR("Amount by which counter is incremented for each node"));
+	lbl_count_step->set_tooltip(TTR("Amount by which counter is incremented for each node."));
 	hbc_count_options->add_child(lbl_count_step);
 
 	spn_count_step = memnew(SpinBox);
-	spn_count_step->set_tooltip(TTR("Amount by which counter is incremented for each node"));
+	spn_count_step->set_tooltip(TTR("Amount by which counter is incremented for each node."));
 	spn_count_step->set_step(1);
 	hbc_count_options->add_child(spn_count_step);
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1100,6 +1100,7 @@ void SceneTreeDock::_notification(int p_what) {
 			node_shortcuts_toggle->set_name("NodeShortcutsToggle");
 			node_shortcuts_toggle->set_icon(get_theme_icon("Favorites", "EditorIcons"));
 			node_shortcuts_toggle->set_toggle_mode(true);
+			node_shortcuts_toggle->set_tooltip(TTR("Switch to Favorite Nodes"));
 			node_shortcuts_toggle->set_pressed(EDITOR_GET("_use_favorites_root_selection"));
 			node_shortcuts_toggle->set_anchors_and_margins_preset(Control::PRESET_CENTER_RIGHT);
 			node_shortcuts_toggle->connect("pressed", callable_mp(this, &SceneTreeDock::_update_create_root_dialog));

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -272,7 +272,7 @@ void FileDialog::_action_pressed() {
 		}
 
 		if (dir_access->file_exists(f)) {
-			confirm_save->set_text(RTR("File Exists, Overwrite?"));
+			confirm_save->set_text(RTR("File exists, overwrite?"));
 			confirm_save->popup_centered(Size2(200, 80));
 		} else {
 			emit_signal("file_selected", f);


### PR DESCRIPTION
Added end periods to some tooltips, and capitalized both instances of "root", namely, the root node.