### PR TITLE
Consistent lesser/greater operators for Vector2 & Vector3

### DIFF
--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -116,10 +116,45 @@ struct Vector2 {
 	bool operator==(const Vector2 &p_vec2) const;
 	bool operator!=(const Vector2 &p_vec2) const;
 
-	bool operator<(const Vector2 &p_vec2) const { return Math::is_equal_approx(x, p_vec2.x) ? (y < p_vec2.y) : (x < p_vec2.x); }
-	bool operator>(const Vector2 &p_vec2) const { return Math::is_equal_approx(x, p_vec2.x) ? (y > p_vec2.y) : (x > p_vec2.x); }
-	bool operator<=(const Vector2 &p_vec2) const { return Math::is_equal_approx(x, p_vec2.x) ? (y <= p_vec2.y) : (x < p_vec2.x); }
-	bool operator>=(const Vector2 &p_vec2) const { return Math::is_equal_approx(x, p_vec2.x) ? (y >= p_vec2.y) : (x > p_vec2.x); }
+	bool operator<(const Vector2 &p_vec2) const {
+		if (Math::is_equal_approx(x, p_vec2.x)) {
+			if (Math::is_equal_approx(y, p_vec2.y)) {
+				return false;
+			}
+			return y < p_vec2.y;
+		}
+		return x < p_vec2.x;
+	}
+
+	bool operator>(const Vector2 &p_vec2) const {
+		if (Math::is_equal_approx(x, p_vec2.x)) {
+			if (Math::is_equal_approx(y, p_vec2.y)) {
+				return false;
+			}
+			return y > p_vec2.y;
+		}
+		return x > p_vec2.x;
+	}
+
+	bool operator<=(const Vector2 &p_vec2) const {
+		if (Math::is_equal_approx(x, p_vec2.x)) {
+			if (Math::is_equal_approx(y, p_vec2.y)) {
+				return true;
+			}
+			return y < p_vec2.y;
+		}
+		return x < p_vec2.x;
+	}
+
+	bool operator>=(const Vector2 &p_vec2) const {
+		if (Math::is_equal_approx(x, p_vec2.x)) {
+			if (Math::is_equal_approx(y, p_vec2.y)) {
+				return true;
+			}
+			return y > p_vec2.y;
+		}
+		return x > p_vec2.x;
+	}
 
 	real_t angle() const;
 

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -351,51 +351,55 @@ bool Vector3::operator!=(const Vector3 &p_v) const {
 }
 
 bool Vector3::operator<(const Vector3 &p_v) const {
-
 	if (Math::is_equal_approx(x, p_v.x)) {
-		if (Math::is_equal_approx(y, p_v.y))
+		if (Math::is_equal_approx(y, p_v.y)) {
+			if (Math::is_equal_approx(z, p_v.z)) {
+				return false;
+			}
 			return z < p_v.z;
-		else
-			return y < p_v.y;
-	} else {
-		return x < p_v.x;
+		}
+		return y < p_v.y;
 	}
+	return x < p_v.x;
 }
 
 bool Vector3::operator>(const Vector3 &p_v) const {
-
 	if (Math::is_equal_approx(x, p_v.x)) {
-		if (Math::is_equal_approx(y, p_v.y))
+		if (Math::is_equal_approx(y, p_v.y)) {
+			if (Math::is_equal_approx(z, p_v.z)) {
+				return false;
+			}
 			return z > p_v.z;
-		else
-			return y > p_v.y;
-	} else {
-		return x > p_v.x;
+		}
+		return y > p_v.y;
 	}
+	return x > p_v.x;
 }
 
 bool Vector3::operator<=(const Vector3 &p_v) const {
-
 	if (Math::is_equal_approx(x, p_v.x)) {
-		if (Math::is_equal_approx(y, p_v.y))
-			return z <= p_v.z;
-		else
-			return y < p_v.y;
-	} else {
-		return x < p_v.x;
+		if (Math::is_equal_approx(y, p_v.y)) {
+			if (Math::is_equal_approx(z, p_v.z)) {
+				return true;
+			}
+			return z < p_v.z;
+		}
+		return y < p_v.y;
 	}
+	return x < p_v.x;
 }
 
 bool Vector3::operator>=(const Vector3 &p_v) const {
-
 	if (Math::is_equal_approx(x, p_v.x)) {
-		if (Math::is_equal_approx(y, p_v.y))
-			return z >= p_v.z;
-		else
-			return y > p_v.y;
-	} else {
-		return x > p_v.x;
+		if (Math::is_equal_approx(y, p_v.y)) {
+			if (Math::is_equal_approx(z, p_v.z)) {
+				return true;
+			}
+			return z > p_v.z;
+		}
+		return y > p_v.y;
 	}
+	return x > p_v.x;
 }
 
 _FORCE_INLINE_ Vector3 vec3_cross(const Vector3 &p_a, const Vector3 &p_b) {


### PR DESCRIPTION
This change makes sure the equality checks are consistent for `<`,`>`,`<=` and `>=` operators in `Vector2` and `Vector3`.
In the current code, the equality check on the last coordinate is treated differently as the other ones (exact equality instead of `is_equal_approx`).

cc @aaronfranke: Does this make sense to you, or am I missing something?