### PR TITLE
Fix Animation Playback Track not seeking properly

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -728,7 +728,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 					if (anim->has_loop()) {
 						at_anim_pos = Math::fposmod(p_time - pos, anim->get_length()); //seek to loop
 					} else {
-						at_anim_pos = MAX(anim->get_length(), p_time - pos); //seek to end
+						at_anim_pos = MIN(anim->get_length(), p_time - pos); //seek to end
 					}
 
 					if (player->is_playing() || p_seeked) {
@@ -757,6 +757,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 							}
 						} else {
 							player->play(anim_name);
+							player->seek(0.0, true);
 							nc->animation_playing = true;
 							playing_caches.insert(nc);
 						}


### PR DESCRIPTION
This fixes a bug where an Animation Playback Track would not update when the user scrubbed in the animation editor timeline, or when playing the animation not from the start.

Here is an example of the bug happening in the latest stable release of godot 3.2
![000032](https://user-images.githubusercontent.com/11552304/79902622-0ec09000-8412-11ea-95ef-0d226d961372.gif)

Here is the fix in the master branch
![000030](https://user-images.githubusercontent.com/11552304/79902708-3d3e6b00-8412-11ea-9b88-90d2a30d116c.gif)


