### PR TITLE
Rebind material when skeleton changes in GLES2

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2370,6 +2370,7 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 			if (vertex_lit != prev_vertex_lit) {
 				state.scene_shader.set_conditional(SceneShaderGLES2::USE_VERTEX_LIGHTING, vertex_lit);
 				prev_vertex_lit = vertex_lit;
+				rebind = true;
 			}
 
 			if (!unshaded && !accum_pass && e->refprobe_0_index != RenderList::MAX_REFLECTION_PROBES) {
@@ -2459,8 +2460,8 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 					state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON, false);
 					state.scene_shader.set_conditional(SceneShaderGLES2::USE_SKELETON_SOFTWARE, false);
 				}
-				rebind = true;
 			}
+			rebind = true;
 		}
 
 		if (e->owner != prev_owner || e->geometry != prev_geometry || skeleton != prev_skeleton) {


### PR DESCRIPTION
Fixes: #38094

Turns out the material needs to be re-bound every time the skeleton changes, not just when changing from null to non-null. I also fixed a potential bug where the shader wasn't being changed when going from vertex-lit to non-vertex lit. 