### PR TITLE
Fix virtual keyboard text not in sync with cursor position on LineEdit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -128,7 +128,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 			selection.doubleclick = false;
 
 			if (OS::get_singleton()->has_virtual_keyboard())
-				OS::get_singleton()->show_virtual_keyboard(text, get_global_rect(), max_length);
+				OS::get_singleton()->show_virtual_keyboard(text.substr(0, cursor_pos), get_global_rect(), max_length);
 		}
 
 		update();
@@ -904,7 +904,7 @@ void LineEdit::_notification(int p_what) {
 			OS::get_singleton()->set_ime_position(get_global_position() + cursor_pos);
 
 			if (OS::get_singleton()->has_virtual_keyboard())
-				OS::get_singleton()->show_virtual_keyboard(text, get_global_rect(), max_length);
+				OS::get_singleton()->show_virtual_keyboard(text.substr(0, get_cursor_position()), get_global_rect(), max_length);
 
 		} break;
 		case NOTIFICATION_FOCUS_EXIT: {


### PR DESCRIPTION
_Note : I'm making this PR against 3.2 branch. I can change to master if required._

Fixes #27065 

**PR description**
So the problem was that we were sending the whole LineEdit text to the virtual keyboard even if the cursor is at the middle of the LineEdit text. 
This makes modification behave erratically when the cursor is not at the end of LineEdit. 

For example, if we have 
ABC|DE 

The text we send to virtual keyboard : ABCDE
If we type 'u' in this case, virtual keyboard will add 'u' to the end of the text (based on [Android](https://github.com/godotengine/godot/blob/master/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java#L87) and [Iphone](https://github.com/godotengine/godot/blob/master/platform/iphone/gl_view.mm#L587) implementation), which results in ABCDEu
After that, ABCDEu will be sent back to the LineEdit at the cursor position, which results in ABCDEuDE.

I have changed it so that we send only the text until the cursor position to the virtual keyboard (which is the behaviour of my vk that I observe when I type with my phone.)
