### PR TITLE
Fix Animation Playback Track not seeking properly

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -737,7 +737,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 					if (anim->has_loop()) {
 						at_anim_pos = Math::fposmod(p_time - pos, (double)anim->get_length()); //seek to loop
 					} else {
-						at_anim_pos = MAX((double)anim->get_length(), p_time - pos); //seek to end
+						at_anim_pos = MIN((double)anim->get_length(), p_time - pos); //seek to end
 					}
 
 					if (player->is_playing() || p_seeked) {
@@ -765,6 +765,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 							}
 						} else {
 							player->play(anim_name);
+							player->seek(0.0, true);
 							nc->animation_playing = true;
 							playing_caches.insert(nc);
 						}


### PR DESCRIPTION
This is a fix for the issue https://github.com/godotengine/godot/issues/38093
This fix has been tested in both the master and the 3.2 branch.

The fix is in two parts :
1. A typo where a MAX function was used instead of a MIN function
2. Forcing the animation to play from the start when the first Key of the animation is encountered

*Bugsquad edit:* Fixes #38093.