### PR TITLE
C#: Save copy of sln and csproj before applying fixes

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.Core/FileUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/FileUtils.cs
@@ -1,0 +1,27 @@
+using System.IO;
+
+namespace GodotTools.Core
+{
+    public static class FileUtils
+    {
+        public static void SaveBackupCopy(string filePath)
+        {
+            string backupPathBase = filePath + ".old";
+            string backupPath = backupPathBase;
+
+            const int maxAttempts = 5;
+            int attempt = 1;
+
+            while (File.Exists(backupPath) && attempt <= maxAttempts)
+            {
+                backupPath = backupPathBase + "." + (attempt);
+                attempt++;
+            }
+
+            if (attempt > maxAttempts + 1)
+                return;
+
+            File.Copy(filePath, backupPath, overwrite: true);
+        }
+    }
+}

--- a/modules/mono/editor/GodotTools/GodotTools.Core/GodotTools.Core.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/GodotTools.Core.csproj
@@ -31,6 +31,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FileUtils.cs" />
     <Compile Include="ProcessExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StringExtensions.cs" />

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/DotNetSolution.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/DotNetSolution.cs
@@ -153,7 +153,12 @@ EndProject";
             var result = regex.Replace(input,m => dict[m.Value]);
 
             if (result != input)
+            {
+                // Save a copy of the solution before replacing it
+                FileUtils.SaveBackupCopy(slnPath);
+
                 File.WriteAllText(slnPath, result);
+            }
         }
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -1,4 +1,5 @@
 using Godot;
+using GodotTools.Core;
 using GodotTools.Export;
 using GodotTools.Utils;
 using System;
@@ -442,13 +443,27 @@ namespace GodotTools
                 {
                     // Migrate solution from old configuration names to: Debug, ExportDebug and ExportRelease
                     DotNetSolution.MigrateFromOldConfigNames(GodotSharpDirs.ProjectSlnPath);
-                    // Migrate csproj from old configuration names to: Debug, ExportDebug and ExportRelease
-                    ProjectUtils.MigrateFromOldConfigNames(GodotSharpDirs.ProjectCsProjPath);
 
-                    // Apply the other fixes after configurations are migrated
+                    var msbuildProject = ProjectUtils.Open(GodotSharpDirs.ProjectCsProjPath)
+                                         ?? throw new Exception("Cannot open C# project");
+
+                    // NOTE: The order in which changes are made to the project is important
+
+                    // Migrate csproj from old configuration names to: Debug, ExportDebug and ExportRelease
+                    ProjectUtils.MigrateFromOldConfigNames(msbuildProject);
+
+                    // Apply the other fixes only after configurations have been migrated
 
                     // Make sure the existing project has Api assembly references configured correctly
-                    ProjectUtils.FixApiHintPath(GodotSharpDirs.ProjectCsProjPath);
+                    ProjectUtils.FixApiHintPath(msbuildProject);
+
+                    if (msbuildProject.HasUnsavedChanges)
+                    {
+                        // Save a copy of the project before replacing it
+                        FileUtils.SaveBackupCopy(GodotSharpDirs.ProjectCsProjPath);
+
+                        msbuildProject.Save();
+                    }
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
This way user can revert in case something goes wrong with the fixes.
