### PR TITLE
Mono/C#: Allow exporting System.Array of type Godot.Object

### DIFF
--- a/modules/mono/mono_gd/gd_mono_field.cpp
+++ b/modules/mono/mono_gd/gd_mono_field.cpp
@@ -322,6 +322,13 @@ void GDMonoField::set_value_from_variant(MonoObject *p_object, const Variant &p_
 				break;
 			}
 
+			GDMonoClass *array_type_class = GDMono::get_singleton()->get_class(array_type->eklass);
+			if (CACHED_CLASS(GodotObject)->is_assignable_from(array_type_class)) {
+				MonoArray *managed = GDMonoMarshal::Array_to_mono_array(p_value.operator ::Array(), array_type_class);
+				mono_field_set_value(p_object, mono_field, managed);
+				break;
+			}
+
 			ERR_FAIL_MSG("Attempted to convert Variant to a managed array of unmarshallable element type.");
 		} break;
 

--- a/modules/mono/mono_gd/gd_mono_marshal.h
+++ b/modules/mono/mono_gd/gd_mono_marshal.h
@@ -126,6 +126,7 @@ String mono_object_to_variant_string(MonoObject *p_obj, MonoException **r_exc);
 // Array
 
 MonoArray *Array_to_mono_array(const Array &p_array);
+MonoArray *Array_to_mono_array(const Array &p_array, GDMonoClass *p_array_type_class);
 Array mono_array_to_Array(MonoArray *p_array);
 
 // PackedInt32Array


### PR DESCRIPTION
This is something I must have forgotten to support. It doesn't make sense to not support `Curve[]` if we can support `Godot.Collections.Array<Curve>`.
