### PR TITLE
Add caching the lightmap unwrapping on import

### DIFF
--- a/modules/xatlas_unwrap/register_types.cpp
+++ b/modules/xatlas_unwrap/register_types.cpp
@@ -32,14 +32,91 @@
 
 #include "core/error_macros.h"
 
+#include "core/crypto/crypto_core.h"
+
 #include "thirdparty/xatlas/xatlas.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 
-extern bool (*array_mesh_lightmap_unwrap_callback)(float p_texel_size, const float *p_vertices, const float *p_normals, int p_vertex_count, const int *p_indices, const int *p_face_materials, int p_index_count, float **r_uv, int **r_vertex, int *r_vertex_count, int **r_index, int *r_index_count, int *r_size_hint_x, int *r_size_hint_y);
+extern bool (*array_mesh_lightmap_unwrap_callback)(float p_texel_size, const float *p_vertices, const float *p_normals, int p_vertex_count, const int *p_indices, int p_index_count, float **r_uv, int **r_vertex, int *r_vertex_count, int **r_index, int *r_index_count, int *r_size_hint_x, int *r_size_hint_y, int *&r_cache_data, unsigned int &r_cache_size, bool &r_used_cache);
 
-bool xatlas_mesh_lightmap_unwrap_callback(float p_texel_size, const float *p_vertices, const float *p_normals, int p_vertex_count, const int *p_indices, const int *p_face_materials, int p_index_count, float **r_uv, int **r_vertex, int *r_vertex_count, int **r_index, int *r_index_count, int *r_size_hint_x, int *r_size_hint_y) {
+bool xatlas_mesh_lightmap_unwrap_callback(float p_texel_size, const float *p_vertices, const float *p_normals, int p_vertex_count, const int *p_indices, int p_index_count, float **r_uvs, int **r_vertices, int *r_vertex_count, int **r_indices, int *r_index_count, int *r_size_hint_x, int *r_size_hint_y, int *&r_cache_data, unsigned int &r_cache_size, bool &r_used_cache) {
+
+	CryptoCore::MD5Context ctx;
+	ctx.start();
+
+	ctx.update((unsigned char *)&p_texel_size, sizeof(float));
+	ctx.update((unsigned char *)p_indices, sizeof(int) * p_index_count);
+	ctx.update((unsigned char *)p_vertices, sizeof(float) * p_vertex_count);
+	ctx.update((unsigned char *)p_normals, sizeof(float) * p_vertex_count);
+
+	unsigned char hash[16];
+	ctx.finish(hash);
+
+	bool cached = false;
+	unsigned int cache_idx = 0;
+
+	if (r_used_cache && r_cache_size) {
+		//Check if hash is in cache data
+
+		int *cache_data = r_cache_data;
+		int n_entries = cache_data[0];
+		unsigned int r_idx = 1;
+		for (int i = 0; i < n_entries; ++i) {
+			if (memcmp(&cache_data[r_idx], hash, 16) == 0) {
+				cached = true;
+				cache_idx = r_idx;
+				break;
+			}
+
+			r_idx += 4; // hash
+			r_idx += 2; // size hint
+
+			int vertex_count = cache_data[r_idx];
+			r_idx += 1; // vertex count
+			r_idx += vertex_count; // vertex
+			r_idx += vertex_count * 2; // uvs
+
+			int index_count = cache_data[r_idx];
+			r_idx += 1; // index count
+			r_idx += index_count; // indices
+		}
+	}
+
+	if (r_used_cache && cached) {
+		int *cache_data = r_cache_data;
+
+		// Return cache data pointer to the caller
+		r_cache_data = &cache_data[cache_idx];
+
+		cache_idx += 4;
+
+		// Load size
+		*r_size_hint_x = cache_data[cache_idx];
+		*r_size_hint_y = cache_data[cache_idx + 1];
+		cache_idx += 2;
+
+		// Load vertices
+		*r_vertex_count = cache_data[cache_idx];
+		cache_idx++;
+		*r_vertices = &cache_data[cache_idx];
+		cache_idx += *r_vertex_count;
+
+		// Load UVs
+		*r_uvs = (float *)&cache_data[cache_idx];
+		cache_idx += *r_vertex_count * 2;
+
+		// Load indices
+		*r_index_count = cache_data[cache_idx];
+		cache_idx++;
+		*r_indices = &cache_data[cache_idx];
+
+		// Return cache data size to the caller
+		r_cache_size = sizeof(int) * (4 + 2 + 1 + *r_vertex_count + (*r_vertex_count * 2) + 1 + *r_index_count); // hash + size hint + vertex_count + vertices + uvs + index_count + indices
+		r_used_cache = true;
+		return true;
+	}
 
 	//set up input mesh
 	xatlas::MeshDecl input_mesh;
@@ -82,16 +159,16 @@ bool xatlas_mesh_lightmap_unwrap_callback(float p_texel_size, const float *p_ver
 
 	const xatlas::Mesh &output = atlas->meshes[0];
 
-	*r_vertex = (int *)malloc(sizeof(int) * output.vertexCount);
-	*r_uv = (float *)malloc(sizeof(float) * output.vertexCount * 2);
-	*r_index = (int *)malloc(sizeof(int) * output.indexCount);
+	*r_vertices = (int *)malloc(sizeof(int) * output.vertexCount);
+	*r_uvs = (float *)malloc(sizeof(float) * output.vertexCount * 2);
+	*r_indices = (int *)malloc(sizeof(int) * output.indexCount);
 
 	float max_x = 0;
 	float max_y = 0;
 	for (uint32_t i = 0; i < output.vertexCount; i++) {
-		(*r_vertex)[i] = output.vertexArray[i].xref;
-		(*r_uv)[i * 2 + 0] = output.vertexArray[i].uv[0] / w;
-		(*r_uv)[i * 2 + 1] = output.vertexArray[i].uv[1] / h;
+		(*r_vertices)[i] = output.vertexArray[i].xref;
+		(*r_uvs)[i * 2 + 0] = output.vertexArray[i].uv[0] / w;
+		(*r_uvs)[i * 2 + 1] = output.vertexArray[i].uv[1] / h;
 		max_x = MAX(max_x, output.vertexArray[i].uv[0]);
 		max_y = MAX(max_y, output.vertexArray[i].uv[1]);
 	}
@@ -100,13 +177,54 @@ bool xatlas_mesh_lightmap_unwrap_callback(float p_texel_size, const float *p_ver
 	*r_vertex_count = output.vertexCount;
 
 	for (uint32_t i = 0; i < output.indexCount; i++) {
-		(*r_index)[i] = output.indexArray[i];
+		(*r_indices)[i] = output.indexArray[i];
 	}
 
 	*r_index_count = output.indexCount;
 
 	xatlas::Destroy(atlas);
-	printf("Done\n");
+
+	if (r_used_cache) {
+		unsigned int new_cache_size = 4 + 2 + 1 + *r_vertex_count + (*r_vertex_count * 2) + 1 + *r_index_count; // hash + size hint + vertex_count + vertices + uvs + index_count + indices
+		new_cache_size *= sizeof(int);
+		int *new_cache_data = (int *)memalloc(new_cache_size);
+		unsigned int new_cache_idx = 0;
+
+		// hash
+		memcpy(&new_cache_data[new_cache_idx], hash, 16);
+		new_cache_idx += 4;
+
+		// size hint
+		new_cache_data[new_cache_idx] = *r_size_hint_x;
+		new_cache_data[new_cache_idx + 1] = *r_size_hint_y;
+		new_cache_idx += 2;
+
+		// vertex count
+		new_cache_data[new_cache_idx] = *r_vertex_count;
+		new_cache_idx++;
+
+		// vertices
+		memcpy(&new_cache_data[new_cache_idx], *r_vertices, sizeof(int) * *r_vertex_count);
+		new_cache_idx += *r_vertex_count;
+
+		// uvs
+		memcpy(&new_cache_data[new_cache_idx], *r_uvs, sizeof(float) * *r_vertex_count * 2);
+		new_cache_idx += *r_vertex_count * 2;
+
+		// index count
+		new_cache_data[new_cache_idx] = *r_index_count;
+		new_cache_idx++;
+
+		// indices
+		memcpy(&new_cache_data[new_cache_idx], *r_indices, sizeof(int) * *r_index_count);
+		new_cache_idx += *r_index_count;
+
+		// Return cache data to the caller
+		r_cache_data = new_cache_data;
+		r_cache_size = new_cache_size;
+		r_used_cache = false;
+	}
+
 	return true;
 }
 

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -238,6 +238,7 @@ public:
 	void regen_normalmaps();
 
 	Error lightmap_unwrap(const Transform &p_base_transform = Transform(), float p_texel_size = 0.05);
+	Error lightmap_unwrap_cached(int *&r_cache_data, unsigned int &r_cache_size, bool &r_used_cache, const Transform &p_base_transform = Transform(), float p_texel_size = 0.05);
 
 	virtual void reload_from_file();
 


### PR DESCRIPTION
This commit adds caching to the lightmap mesh unwraps generated on
import. This speeds up re-imports of meshes that haven't changed and
also makes sure that the unwraps are consistent across imports.

The unwrapping process is not deterministic, so one could end up with
a different mapping every time the scene was imported, breaking any
previously baked lightmaps. The changes in this commit prevent that
from happening.