### PR TITLE
Added property_changed signal to editor_inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2182,6 +2182,8 @@ void EditorInspector::_property_changed(const String &p_path, const Variant &p_v
 	if (restart_request_props.has(p_path)) {
 		emit_signal("restart_requested");
 	}
+
+	emit_signal("property_changed", p_path);
 }
 
 void EditorInspector::_property_changed_update_all(const String &p_path, const Variant &p_value, const String &p_name, bool p_changing) {
@@ -2431,6 +2433,7 @@ void EditorInspector::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("property_selected", PropertyInfo(Variant::STRING, "property")));
 	ADD_SIGNAL(MethodInfo("property_keyed", PropertyInfo(Variant::STRING, "property")));
 	ADD_SIGNAL(MethodInfo("property_deleted", PropertyInfo(Variant::STRING, "property")));
+	ADD_SIGNAL(MethodInfo("property_changed", PropertyInfo(Variant::STRING, "property")));
 	ADD_SIGNAL(MethodInfo("resource_selected", PropertyInfo(Variant::OBJECT, "res"), PropertyInfo(Variant::STRING, "prop")));
 	ADD_SIGNAL(MethodInfo("object_id_selected", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("property_edited", PropertyInfo(Variant::STRING, "property")));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2835,6 +2835,12 @@ void EditorNode::_update_file_menu_closed() {
 	pop->set_item_disabled(pop->get_item_index(FILE_OPEN_PREV), false);
 }
 
+void EditorNode::_inspector_property_changed(const String &p_name) {
+	if (p_name == "script") {
+		node_dock->update_lists();
+	}
+}
+
 Control *EditorNode::get_viewport() {
 
 	return viewport;
@@ -6430,7 +6436,10 @@ EditorNode::EditorNode() {
 	// Instantiate and place editor docks
 
 	scene_tree_dock = memnew(SceneTreeDock(this, scene_root, editor_selection, editor_data));
+
 	inspector_dock = memnew(InspectorDock(this, editor_data));
+	get_inspector()->connect("property_changed", callable_mp(this, &EditorNode::_inspector_property_changed));
+
 	import_dock = memnew(ImportDock);
 	node_dock = memnew(NodeDock);
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -473,6 +473,8 @@ private:
 	void _show_messages();
 	void _vp_resized();
 
+	void _inspector_property_changed(const String &p_path = "");
+
 	int _save_external_resources();
 
 	bool _validate_scene_recursive(const String &p_filename, Node *p_node);


### PR DESCRIPTION
This allows for the editor_node to subscribe and update the node dock
when the script editor property has changed. Previously, the singals
list in the node dock would not be updated until you reselect the node
in the editor.

#37783 