### PR TITLE
Fix Android templates size regression

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -76,7 +76,9 @@ android {
     packagingOptions {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
-        doNotStrip '**/*.so'
+
+        // Should be uncommented for development purpose within Android Studio
+        // doNotStrip '**/*.so'
     }
 
     // Both signing and zip-aligning will be done at export time

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -26,7 +26,9 @@ android {
     packagingOptions {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
-        doNotStrip '**/*.so'
+
+        // Should be uncommented for development purpose within Android Studio
+        // doNotStrip '**/*.so'
     }
 
     sourceSets {


### PR DESCRIPTION
The issue was caused by PR #36906 which changes prevented the generated shared libraries from being stripped.
Since the change is only needed for development (debugging) purposes, it's commented out by default.

Fixes #38068