### PR TITLE
GDScript compiler const optimization

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -612,7 +612,7 @@ private:
 	bool _parse_newline();
 	Node *_parse_expression(Node *p_parent, bool p_static, bool p_allow_assign = false, bool p_parsing_constant = false);
 	Node *_reduce_expression(Node *p_node, bool p_to_const = false);
-	Node *_parse_and_reduce_expression(Node *p_parent, bool p_static, bool p_reduce_const = false, bool p_allow_assign = false);
+	Node *_parse_and_reduce_expression(Node *p_parent, bool p_static, bool p_reduce_const = true, bool p_allow_assign = false);
 
 	PatternNode *_parse_pattern(bool p_static);
 	void _parse_pattern_block(BlockNode *p_block, Vector<PatternBranchNode *> &p_branches, bool p_static);


### PR DESCRIPTION
Fix: #7047 <- the code snippet from the issue ran **20 times faster** for ITERATIONS=10000000.

We have the optimization already, but we never used it except for const and enums. 

**Detail**
the `p_reduce_const` argument is a hint for the compiler, given when the expression must be a const (`const ...`, `enum ...`). though, if reduce a variable with `p_reduce_const=true` (or reduce this -> `const c = get_var()`), the compiler try to reduce the expression to constant and if that's not possible it'll return the expression as it was, which doesn't effect the compilation.

**Optimizations**
```gdscript
const C1 = 1
const C2 = 2
const C3 = C1 + C2  ## C3 = 3
var v1 = C1 + C2 ## runtime addition even thought C1, C2 are constants
var v2 = 1 + 2 + 3  ## compile time addition
var v3 = 1 + 2 + C1 ## runtime addition : C1 is an identifier, not reducing to const

const SCENE  = C_RES + C_PATH + C_TSCN ## constant string
var scene = C_RES + C_PATH + C_TSCN ## runtime (possible to determined at compile time)
var e_0 = SomeClass.InnerClass.InnerClass2.Enum.E_VALUE ## this could be replaced with 0
## at compile time
```

_the `_parse_and_reduce_expression()` method never need `p_reduce_const` argument and it always has to be true, for now I leave it here as this PR is a proof of concept_