### PR TITLE
[MoltenVK] Fix "redefinition of 'ssr' with a different type" shader compile error.

### DIFF
--- a/servers/rendering/rasterizer_rd/shaders/specular_merge.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/specular_merge.glsl
@@ -48,8 +48,8 @@ void main() {
 	frag_color.a = 0.0;
 #ifdef MODE_SSR
 
-	vec4 ssr = texture(ssr, uv_interp);
-	frag_color.rgb = mix(frag_color.rgb, ssr.rgb, ssr.a);
+	vec4 ssr_color = texture(ssr, uv_interp);
+	frag_color.rgb = mix(frag_color.rgb, ssr_color.rgb, ssr_color.a);
 #endif
 
 #ifdef MODE_MERGE


### PR DESCRIPTION
Variable name 'ssr' (`vec4`) conflicts with the previously defined uniform 'ssr' (`sampler2D`), causing shader compilation to fail with following error:

```
VK_ERROR_INITIALIZATION_FAILED: Shader library compile failed (Error code 3):

program_source:22:12: error: redefinition of 'ssr' with a different type: 'float4' (vector of 4 'float' values) vs 'texture2d<float>'
```