### PR TITLE
Add const to InputEventMouseButton::get_factor

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -477,7 +477,7 @@ void InputEventMouseButton::set_factor(float p_factor) {
 	factor = p_factor;
 }
 
-float InputEventMouseButton::get_factor() {
+float InputEventMouseButton::get_factor() const {
 
 	return factor;
 }

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -349,7 +349,7 @@ protected:
 
 public:
 	void set_factor(float p_factor);
-	float get_factor();
+	float get_factor() const;
 
 	void set_button_index(int p_index);
 	int get_button_index() const;


### PR DESCRIPTION
Fixes mutability in generated bindings for `godot-rust`.