### PR TITLE
VisualScript callable nodes not getting updated- Fix

### DIFF
--- a/modules/visual_script/visual_script_func_nodes.h
+++ b/modules/visual_script/visual_script_func_nodes.h
@@ -70,7 +70,6 @@ private:
 	StringName _get_base_type() const;
 
 	MethodInfo method_cache;
-	void _update_method_cache();
 
 	void _set_argument_cache(const Dictionary &p_cache);
 	Dictionary _get_argument_cache() const;
@@ -125,6 +124,8 @@ public:
 
 	void set_rpc_call_mode(RPCCallMode p_mode);
 	RPCCallMode get_rpc_call_mode() const;
+
+	void _update_method_cache();
 
 	virtual VisualScriptNodeInstance *instance(VisualScriptInstance *p_instance);
 

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -89,6 +89,8 @@ public:
 	void set_stack_size(int p_size);
 	int get_stack_size() const;
 
+	void _update_callable_nodes();
+
 	void set_return_type_enabled(bool p_returns);
 	bool is_return_type_enabled() const;
 


### PR DESCRIPTION
Fixes #37173

**Bug**:- VisualScript callable nodes were not getting updated when the properties
of their corresponding visualscript function nodes were changed.
**Reason**:- method_cache of the callable nodes was not getting updated when their corresponding function node was updated.

Based on PR:-  #37872
In this PR, I've refactored the code, making it easier to debug.

**Results:**
![git_upload](https://user-images.githubusercontent.com/41969735/82762105-bd465f00-9e1c-11ea-8b7f-6dfd8688b906.gif)
