### PR TITLE
Fix detection logic for the Android sdk path

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1699,7 +1699,7 @@ public:
 				valid = false;
 			} else {
 				Error errn;
-				DirAccessRef da = DirAccess::open(sdk_path.plus_file("tools"), &errn);
+				DirAccessRef da = DirAccess::open(sdk_path.plus_file("platform-tools"), &errn);
 				if (errn != OK) {
 					err += TTR("Invalid Android SDK path for custom build in Editor Settings.") + "\n";
 					valid = false;


### PR DESCRIPTION
The previous logic used the `tools` directory within the Android sdk to validate it. That directory was recently deprecated and removed from the Android sdk folder (https://developer.android.com/studio/releases/sdk-tools)

*Bugsquad edit:* Fixes #38381.