### PR TITLE
Use DOMRect's left and top instead of x and y.

### DIFF
--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -73,10 +73,10 @@ static bool is_canvas_focused() {
 
 static Point2 compute_position_in_canvas(int x, int y) {
 	int canvas_x = EM_ASM_INT({
-		return document.getElementById('canvas').getBoundingClientRect().x;
+		return document.getElementById('canvas').getBoundingClientRect().left;
 	});
 	int canvas_y = EM_ASM_INT({
-		return document.getElementById('canvas').getBoundingClientRect().y;
+		return document.getElementById('canvas').getBoundingClientRect().top;
 	});
 	int canvas_width;
 	int canvas_height;


### PR DESCRIPTION
Microsoft's Edge browser does not expose "x" and "y" properties in DOMRect. This results in "canvas_x" and "canvas_y" always being 0.

For non-fullscreen HTML5 builds, this results in wrong input coordinates.

This PR uses the more widely supported "left" and "top" properties instead, which fixes the issue for Edge.