### PR TITLE
doc: Fix parsing typed arrays in makerst.py

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -21,6 +21,9 @@
 		<member name="ClassDB" type="ClassDB" setter="" getter="">
 			The [ClassDB] singleton.
 		</member>
+		<member name="DisplayServer" type="DisplayServer" setter="" getter="">
+			The [DisplayServer] singleton.
+		</member>
 		<member name="Engine" type="Engine" setter="" getter="">
 			The [Engine] singleton.
 		</member>

--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -29,14 +29,14 @@
 			</description>
 		</method>
 		<method name="get_overlapping_areas" qualifiers="const">
-			<return type="Array">
+			<return type="Area2D[]">
 			</return>
 			<description>
 				Returns a list of intersecting [Area2D]s. For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
 			</description>
 		</method>
 		<method name="get_overlapping_bodies" qualifiers="const">
-			<return type="Array">
+			<return type="Node2D[]">
 			</return>
 			<description>
 				Returns a list of intersecting [PhysicsBody2D]s. For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.

--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -28,14 +28,14 @@
 			</description>
 		</method>
 		<method name="get_overlapping_areas" qualifiers="const">
-			<return type="Array">
+			<return type="Area3D[]">
 			</return>
 			<description>
 				Returns a list of intersecting [Area3D]s. For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
 			</description>
 		</method>
 		<method name="get_overlapping_bodies" qualifiers="const">
-			<return type="Array">
+			<return type="Node3D[]">
 			</return>
 			<description>
 				Returns a list of intersecting [PhysicsBody3D]s. For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.

--- a/doc/classes/EditorSelection.xml
+++ b/doc/classes/EditorSelection.xml
@@ -27,7 +27,7 @@
 			</description>
 		</method>
 		<method name="get_selected_nodes">
-			<return type="Array">
+			<return type="Node[]">
 			</return>
 			<description>
 				Gets the list of selected nodes.

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -221,7 +221,7 @@
 			</description>
 		</method>
 		<method name="get_children" qualifiers="const">
-			<return type="Array">
+			<return type="Node[]">
 			</return>
 			<description>
 				Returns an array of references to node's children.

--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -20,7 +20,7 @@
 			</description>
 		</method>
 		<method name="get_collision_exceptions">
-			<return type="Array">
+			<return type="PhysicsBody2D[]">
 			</return>
 			<description>
 				Returns an array of nodes that were added as collision exceptions for this body.

--- a/doc/classes/PhysicsBody3D.xml
+++ b/doc/classes/PhysicsBody3D.xml
@@ -20,7 +20,7 @@
 			</description>
 		</method>
 		<method name="get_collision_exceptions">
-			<return type="Array">
+			<return type="PhysicsBody3D[]">
 			</return>
 			<description>
 				Returns an array of nodes that were added as collision exceptions for this body.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -806,6 +806,18 @@
 		<member name="memory/limits/multithreaded_server/rid_pool_prealloc" type="int" setter="" getter="" default="60">
 			This is used by servers when used in multi-threading mode (servers and visual). RIDs are preallocated to avoid stalling the server requesting them on threads. If servers get stalled too often when loading resources in a thread, increase this number.
 		</member>
+		<member name="mono/debugger_agent/port" type="int" setter="" getter="" default="23685">
+		</member>
+		<member name="mono/debugger_agent/wait_for_debugger" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="mono/debugger_agent/wait_timeout" type="int" setter="" getter="" default="3000">
+		</member>
+		<member name="mono/profiler/args" type="String" setter="" getter="" default="&quot;log:calls,alloc,sample,output=output.mlpd&quot;">
+		</member>
+		<member name="mono/profiler/enabled" type="bool" setter="" getter="" default="false">
+		</member>
+		<member name="mono/unhandled_exception_policy" type="int" setter="" getter="" default="0">
+		</member>
 		<member name="network/limits/debugger/max_chars_per_second" type="int" setter="" getter="" default="32768">
 			Maximum amount of characters allowed to send as output from the debugger. Over this value, content is dropped. This helps not to stall the debugger connection.
 		</member>

--- a/doc/classes/RDPipelineColorBlendState.xml
+++ b/doc/classes/RDPipelineColorBlendState.xml
@@ -7,40 +7,10 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="add_attachment">
-			<return type="void">
-			</return>
-			<argument index="0" name="atachment" type="RDPipelineColorBlendStateAttachment">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="add_blend_mix_attachment">
-			<return type="void">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="add_no_blend_attachment">
-			<return type="void">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="clear_attachments">
-			<return type="void">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_attachments" qualifiers="const">
-			<return type="Array">
-			</return>
-			<description>
-			</description>
-		</method>
 	</methods>
 	<members>
+		<member name="attachments" type="RDPipelineColorBlendStateAttachment[]" setter="set_attachments" getter="get_attachments" default="[  ]">
+		</member>
 		<member name="blend_constant" type="Color" setter="set_blend_constant" getter="get_blend_constant" default="Color( 0, 0, 0, 1 )">
 		</member>
 		<member name="enable_logic_op" type="bool" setter="set_enable_logic_op" getter="get_enable_logic_op" default="false">

--- a/doc/classes/RDPipelineColorBlendStateAttachment.xml
+++ b/doc/classes/RDPipelineColorBlendStateAttachment.xml
@@ -7,6 +7,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="set_as_mix">
+			<return type="void">
+			</return>
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="alpha_blend_op" type="int" setter="set_alpha_blend_op" getter="get_alpha_blend_op" enum="RenderingDevice.BlendOperation" default="0">

--- a/doc/classes/RDPipelineMultisampleState.xml
+++ b/doc/classes/RDPipelineMultisampleState.xml
@@ -7,26 +7,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="add_sample_mask">
-			<return type="void">
-			</return>
-			<argument index="0" name="mask" type="int">
-			</argument>
-			<description>
-			</description>
-		</method>
-		<method name="clear_sample_masks">
-			<return type="void">
-			</return>
-			<description>
-			</description>
-		</method>
-		<method name="get_sample_masks" qualifiers="const">
-			<return type="PackedInt64Array">
-			</return>
-			<description>
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="enable_alpha_to_coverage" type="bool" setter="set_enable_alpha_to_coverage" getter="get_enable_alpha_to_coverage" default="false">
@@ -38,6 +18,8 @@
 		<member name="min_sample_shading" type="float" setter="set_min_sample_shading" getter="get_min_sample_shading" default="0.0">
 		</member>
 		<member name="sample_count" type="int" setter="set_sample_count" getter="get_sample_count" enum="RenderingDevice.TextureSamples" default="0">
+		</member>
+		<member name="sample_masks" type="int[]" setter="set_sample_masks" getter="get_sample_masks" default="[  ]">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/RDVertexAttribute.xml
+++ b/doc/classes/RDVertexAttribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="RDVertexDescription" inherits="Reference" version="4.0">
+<class name="RDVertexAttribute" inherits="Reference" version="4.0">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -296,7 +296,7 @@
 		<method name="framebuffer_format_create">
 			<return type="int">
 			</return>
-			<argument index="0" name="attachments" type="Array">
+			<argument index="0" name="attachments" type="RDAttachmentFormat[]">
 			</argument>
 			<description>
 			</description>
@@ -386,9 +386,9 @@
 			</argument>
 			<argument index="1" name="format" type="int" enum="RenderingDevice.IndexBufferFormat">
 			</argument>
-			<argument index="2" name="data" type="PackedByteArray">
+			<argument index="2" name="data" type="PackedByteArray" default="PackedByteArray(  )">
 			</argument>
-			<argument index="3" name="arg3" type="bool" default="PackedByteArray(  )">
+			<argument index="3" name="arg3" type="bool" default="false">
 			</argument>
 			<description>
 			</description>
@@ -576,7 +576,7 @@
 			</argument>
 			<argument index="1" name="view" type="RDTextureView">
 			</argument>
-			<argument index="2" name="data" type="Array" default="[  ]">
+			<argument index="2" name="data" type="PackedByteArray[]" default="[  ]">
 			</argument>
 			<description>
 			</description>
@@ -712,7 +712,7 @@
 		<method name="vertex_format_create">
 			<return type="int">
 			</return>
-			<argument index="0" name="vertex_descriptions" type="Array">
+			<argument index="0" name="vertex_descriptions" type="RDVertexAttribute[]">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -81,7 +81,7 @@
 			</description>
 		</method>
 		<method name="get_colliding_bodies" qualifiers="const">
-			<return type="Array">
+			<return type="Node2D[]">
 			</return>
 			<description>
 				Returns a list of the bodies colliding with this one. Use [member contacts_reported] to set the maximum number reported. You must also set [member contact_monitor] to [code]true[/code].

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -157,7 +157,7 @@
 		<method name="physical_bones_start_simulation">
 			<return type="void">
 			</return>
-			<argument index="0" name="bones" type="Array" default="[  ]">
+			<argument index="0" name="bones" type="StringName[]" default="[  ]">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -74,14 +74,14 @@
 			</description>
 		</method>
 		<method name="get_used_cells" qualifiers="const">
-			<return type="Array">
+			<return type="Vector2i[]">
 			</return>
 			<description>
 				Returns a [Vector2] array with the positions of all cells containing a tile from the tileset (i.e. a tile index different from [code]-1[/code]).
 			</description>
 		</method>
 		<method name="get_used_cells_by_id" qualifiers="const">
-			<return type="Array">
+			<return type="Vector2i[]">
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>

--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -973,11 +973,14 @@ def format_table(f, data, remove_empty_columns=False):  # type: (TextIO, Iterabl
     f.write("\n")
 
 
-def make_type(t, state):  # type: (str, State) -> str
-    if t in state.classes:
-        return ":ref:`{0}<class_{0}>`".format(t)
-    print_error("Unresolved type '{}', file: {}".format(t, state.current_class), state)
-    return t
+def make_type(klass, state):  # type: (str, State) -> str
+    link_type = klass
+    if link_type.endswith("[]"):  # Typed array, strip [] to link to contained type.
+        link_type = link_type[:-2]
+    if link_type in state.classes:
+        return ":ref:`{}<class_{}>`".format(klass, link_type)
+    print_error("Unresolved type '{}', file: {}".format(klass, state.current_class), state)
+    return klass
 
 
 def make_enum(t, state):  # type: (str, State) -> str


### PR DESCRIPTION
`Type[]` typed arrays will link to `Type`, as it's likely the most
interesting information for the user.

And sync classref with current source.