### PR TITLE
Use bound connect() for yield-to-signal and scene unpacking

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1307,10 +1307,11 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					}
 #endif
 
+					String signal = argname->operator String();
+					Array connect_args = Variant(varray(signal, Callable(gdfs.ptr(), "_signal_callback"), varray(gdfs), Object::CONNECT_ONESHOT));
 #ifdef DEBUG_ENABLED
 					bool was_freed;
 					Object *obj = argobj->get_validated_object_with_check(was_freed);
-					String signal = argname->operator String();
 
 					if (was_freed) {
 						err_text = "First argument of yield() is a previously freed instance.";
@@ -1327,16 +1328,15 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						OPCODE_BREAK;
 					}
 
-					Error err = obj->connect_compat(signal, gdfs.ptr(), "_signal_callback", varray(gdfs), Object::CONNECT_ONESHOT);
-					if (err != OK) {
+					Variant err = obj->callv("connect", connect_args);
+					if ((int)err != OK) {
 						err_text = "Error connecting to signal: " + signal + " during yield().";
 						OPCODE_BREAK;
 					}
 #else
 					Object *obj = argobj->operator Object *();
-					String signal = argname->operator String();
 
-					obj->connect_compat(signal, gdfs.ptr(), "_signal_callback", varray(gdfs), Object::CONNECT_ONESHOT);
+					obj->callv("connect", connect_args);
 #endif
 				}
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -331,7 +331,8 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 				binds.write[j] = props[c.binds[j]];
 		}
 
-		cfrom->connect(snames[c.signal], Callable(cto, snames[c.method]), binds, CONNECT_PERSIST | c.flags);
+		Array connect_args = Variant(varray(snames[c.signal], Callable(cto, snames[c.method]), binds, CONNECT_PERSIST | c.flags));
+		cfrom->callv("connect", connect_args);
 	}
 
 	//Node *s = ret_nodes[0];


### PR DESCRIPTION
Although it's quite a corner case, this patch improves the consistency of GDScript.

The thing is that you can override `connect()` in a script and it will work. However, the code that makes it possible to yield for a signal won't use the binding mechanism to call `connect()` under the hood, so your scripted overriding method won't be called. This patch is just a fix for that,

**UPDATE:** Added another case: `PackedScene`'s unpacking of connections.

**NOTE:** Since the change is not compatible with 3.2, a separate PR is submitted for it.

---
**This code is generously donated by IMVU.**