### PR TITLE
AppVeyor: Upload compiled binary to transfer.sh for testing purposes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,3 +39,14 @@ before_build:
 
 build_script:
   - scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% %OPTIONS% %EXTRA_ARGS%
+
+  - git rev-parse --short=9 HEAD>VERSION_HASH.txt
+  - set /P VERSION_HASH=<VERSION_HASH.txt
+  - cd bin
+  - 7z a -mx9 godot.windows.opt.tools.64-%VERSION_HASH%.zip *.exe
+  - cd ..
+  - echo.
+  - "echo Download compiled editor binary for Windows 64-bit (link is valid for 14 days after this build was completed):"
+  # Upload the compiled binary to transfer.sh for testing purposes.
+  # The URL is valid for 14 days and can be viewed in the CI log.
+  - curl.exe --upload-file bin/godot.windows.opt.tools.64-%VERSION_HASH%.zip https://transfer.sh/godot.windows.opt.tools.64-%VERSION_HASH%.zip


### PR DESCRIPTION
This makes it easier for users to test pull requests, without having to fiddle with Git and compile the engine from source. Users can now download the executable referenced at the end of the CI log up to 14 days after the CI build was completed.

If the link expires, the job can be run again to compile a new build.

If people like the idea, I'll try to do this for other platforms as well.

[Example build log](https://ci.appveyor.com/project/Calinou/godot/builds/32424812)

[Example compiled build (64-bit Windows editor, `release_debug`)](https://transfer.sh/9peNE/godot.windows.opt.tools.64-efcff5abb.zip) (link valid until 2020-05-07)