### PR TITLE
GLES2 Batching fix canvas texscreen (SCREEN_TEXTURE)

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -2492,6 +2492,10 @@ void RasterizerCanvasGLES2::render_joined_item(const BItemJoined &p_bij, RenderI
 	}
 #endif
 
+	// this must be reset for each joined item,
+	// it only exists to prevent capturing the screen more than once per item
+	state.canvas_texscreen_used = false;
+
 	// all the joined items will share the same state with the first item
 	Item *ci = bdata.item_refs[p_bij.first_item_ref].item;
 


### PR DESCRIPTION
When reading SCREEN_TEXTURE in a shader, this previously only worked successfully for the first read of the screen, because state.canvas_texscreen_used was never getting reset. This PR resets state.canvas_texscreen_used at the beginning of each joined item, so that further screen reads can happen.

Fixes @anthonyromano issue in #38004.