### PR TITLE
Remove `SceneTree.change_scene()` in favor of `change_scene_to()`

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -37,22 +37,20 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="change_scene">
-			<return type="int" enum="Error" />
-			<argument index="0" name="path" type="String" />
-			<description>
-				Changes the running scene to the one at the given [code]path[/code], after loading it into a [PackedScene] and creating a new instance.
-				Returns [constant OK] on success, [constant ERR_CANT_OPEN] if the [code]path[/code] cannot be loaded into a [PackedScene], or [constant ERR_CANT_CREATE] if that scene cannot be instantiated.
-				[b]Note:[/b] The scene change is deferred, which means that the new scene node is added on the next idle frame. You won't be able to access it immediately after the [method change_scene] call.
-			</description>
-		</method>
 		<method name="change_scene_to">
 			<return type="int" enum="Error" />
 			<argument index="0" name="packed_scene" type="PackedScene" />
 			<description>
 				Changes the running scene to a new instance of the given [PackedScene].
 				Returns [constant OK] on success or [constant ERR_CANT_CREATE] if the scene cannot be instantiated.
-				[b]Note:[/b] The scene change is deferred, which means that the new scene node is added on the next idle frame. You won't be able to access it immediately after the [method change_scene_to] call.
+				[codeblock]
+				# Loads the scene when the game reaches this line of code.
+				get_tree().change_scene_to(load("res://my_scene.tscn"))
+
+				# Loads the scene when this script is compiled. May not always work due to
+				# cyclic reference issues. If in doubt, use `load()`.
+				get_tree().change_scene_to(preload("res://my_scene.tscn"))
+				[/codeblock]
 			</description>
 		</method>
 		<method name="create_timer">

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -315,7 +315,6 @@ public:
 
 	void set_current_scene(Node *p_scene);
 	Node *get_current_scene() const;
-	Error change_scene(const String &p_path);
 	Error change_scene_to(const Ref<PackedScene> &p_scene);
 	Error reload_current_scene();
 
@@ -327,8 +326,6 @@ public:
 	void add_current_scene(Node *p_current);
 
 	static SceneTree *get_singleton() { return singleton; }
-
-	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 
 	//network API
 


### PR DESCRIPTION
`change_scene()` was removed because it's stringly-typed, which means there is no way to display an error message until the project is run and the line is reached.

The same result can be obtained in a safe manner by using:

```gdscript
get_tree().change_scene_to(load("res://my_scene.tscn"))
```

This breaks compatibility with many existing projects, but the added safety is likely worth the trouble. It makes sense to do this for Godot 4.0 as we're trying to move away from stringly-typed APIs when reasonably feasible.

This change also makes it possible to remove some bespoke autocompletion code, since we now rely on `load()`/`preload()` autocompletion instead.

This closes #27640. This closes #31941.