### PR TITLE
add show scripts panel to editor options

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -461,6 +461,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["text_editor/appearance/line_length_guideline_column"] = PropertyInfo(Variant::INT, "text_editor/appearance/line_length_guideline_column", PROPERTY_HINT_RANGE, "20, 160, 1");
 
 	// Script list
+	_initial_set("text_editor/script_list/show_scripts_panel", true);
 	_initial_set("text_editor/script_list/show_members_overview", true);
 
 	// Files

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2342,6 +2342,8 @@ void ScriptEditor::_editor_settings_changed() {
 
 	members_overview_enabled = EditorSettings::get_singleton()->get("text_editor/script_list/show_members_overview");
 	help_overview_enabled = EditorSettings::get_singleton()->get("text_editor/help/show_help_index");
+	list_split->set_visible(EditorSettings::get_singleton()->get("text_editor/script_list/show_scripts_panel"));
+
 	_update_members_overview_visibility();
 	_update_help_overview_visibility();
 
@@ -3223,6 +3225,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	overview_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	list_split->add_child(overview_vbox);
+	list_split->set_visible(EditorSettings::get_singleton()->get("text_editor/script_list/show_scripts_panel"));
 	buttons_hbox = memnew(HBoxContainer);
 	overview_vbox->add_child(buttons_hbox);
 


### PR DESCRIPTION
Add's 'show scripts panel' option to editor settings, that allow to hide 'script panel' and free more space for code on screen.
When unchecked, scipt panel will be hidden on editor start, which free users who always close it, from neverending additional work to close it manualy.