### PR TITLE
Fix audio pops when playing an AudioStreamPlaybackResampled after calling AudioStreamPlayer[2D/3D]::set_stream()

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -315,7 +315,7 @@ void AudioStreamPlayer2D::play(float p_from_pos) {
 	}
 
 	if (stream_playback.is_valid()) {
-		active = true;
+		//active = true; // setseek needs set *before* active, but that is done in the physics thread
 		setplay = p_from_pos;
 		output_ready = false;
 		set_physics_process_internal(true);

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -687,7 +687,7 @@ void AudioStreamPlayer3D::play(float p_from_pos) {
 	}
 
 	if (stream_playback.is_valid()) {
-		active = true;
+		//active = true; // setseek needs set *before* active, but that is done in the physics thread
 		setplay = p_from_pos;
 		output_ready = false;
 		set_physics_process_internal(true);


### PR DESCRIPTION
`AudioStreamPlayer2D` and `AudioStreamPlayer3D` use `setplay` to communicate with the physics thread instead of setting `setseek` directly, but they were setting `active` in the `play()` function, which, depending on thread scheduling, could cause the audio thread to see the player as active, and try to read data without calling `stream_playback->start()`. This only surfaced for subclasses of `AudioStreamPlaybackResampled` (such as `AudioStreamPlaybackOGGVorbis`) because they use an internal buffer which starts uninitialized, while other stream types read the data directly. 

This fixes the other serious popping issue mentioned by Jitspoe in https://github.com/godotengine/godot/issues/22016, but does *not* address either the "calling stop() on a looping sound" issue (which he says he worked around anyway), *or* calling `set_stream()` *while* a sound is still playing (which is obviously kind of a bad idea anyway, but was fixed for `AudioStreamPlayer` as mentioned in https://github.com/godotengine/godot/issues/25087 and https://github.com/godotengine/godot/issues/30827).