### PR TITLE
Add method picker to signal connect dialog

### DIFF
--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -88,6 +88,7 @@ private:
 	Node *source;
 	StringName signal;
 	LineEdit *dst_method;
+	MenuButton *method_pick_button;
 	ConnectDialogBinds *cdbinds;
 	bool bEditMode;
 	NodePath dst_path;
@@ -106,11 +107,14 @@ private:
 	void ok_pressed();
 	void _cancel_pressed();
 	void _item_activated();
+	void _text_changed(const String &_text);
 	void _text_entered(const String &_text);
 	void _tree_node_selected();
 	void _add_bind();
 	void _remove_bind();
 	void _advanced_pressed();
+	void _method_selected(int p_index);
+	void _update_method_picker();
 	void _update_ok_enabled();
 
 protected:


### PR DESCRIPTION
Thought I'd take a stab at resolving #9644 / [#239](https://github.com/godotengine/godot-proposals/issues/239).

As this is my first real PR to the engine, I am particularly interested in constructive feedback and any discussion on the changes, the UX choices made, and any mistakes in code style that don't line up with the expectations of the project.

I am also interested in what process there is for backporting such a change to the stable branch, as there shouldn't be anything in this PR to my limited knowledge that depends on 4.0.

The change is rather simple and leverages the existing setup of the connect dialog (selecting a method in the tree simply inputs that method name into the receiver method text field).

Changes:
- A new method tree is added to the signal connect dialog
  - Appears in basic and advanced mode
  - Tree is broken down by class in the hierarchy of the selected node
  - If a script is attached, those methods appear at the top of the tree
  - Search input updates the tree removing all entries that do not contain the searched string
  - Classes with no methods after search has been applied are de-emphasized
- Removal of the attached script check in basic mode (and the error when no nodes have attached scripts)
  - As the new method list appears in basic mode, it didn't make sense for this behavior to remain
- Move basic/advanced toggle to top alongside signal name
  - Originally did this as I wasn't certain about whether I would show the receiver method input when the tree was visible (was considering putting the tree in advanced). It doesn't have to stay up there and can be reverted.

Updated screenshot:
![image](https://user-images.githubusercontent.com/1129772/80322234-1dba9e80-8867-11ea-8f2c-fb7189b2940f.png)

Advanced mode:
![image](https://user-images.githubusercontent.com/1129772/80322815-d46c4e00-886a-11ea-9d20-10706835e3e9.png)



