### PR TITLE
Fixed bug where spinbox would not update to it's actual value after non-numeric input

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -63,8 +63,8 @@ void SpinBox::_text_entered(const String &p_string) {
 	Variant value = expr->execute(Array(), nullptr, false);
 	if (value.get_type() != Variant::NIL) {
 		set_value(value);
-		_value_changed(0);
 	}
+	_value_changed(0);
 }
 
 LineEdit *SpinBox::get_line_edit() {


### PR DESCRIPTION
The issue is as follows:

After input of a non-numeric value into the line edit of a spinbox, the spinbax value would not update consistently:
![xLt7S5NJE0](https://user-images.githubusercontent.com/41730826/80307266-48770980-880b-11ea-94c7-1af365f30635.gif)

The sequence of events:
1. Input a numeric value (in this case, 1)
2. Input string value.
3. The value (the white number in the label below) does not update... but the line edit no longer reflects the actual value of the spinbox. It shows what the user input, not what the underlying value is.
4. If the random jargon string is put **after** the numeric value, the spinbox resets to correctly display it's actual numeric value.
5. If it is put **before**, it does not update.

The behaviour is now consistent, as below. Essentially, if the spinbox is for float or integer values only, why allow string values?
![Owv2fmsZNI](https://user-images.githubusercontent.com/41730826/80307326-ae639100-880b-11ea-8da5-eee3fde2ec06.gif)
