### PR TITLE
Increase the default Camera3D field of view to 75

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -183,8 +183,13 @@
 		<member name="far" type="float" setter="set_zfar" getter="get_zfar" default="100.0">
 			The distance to the far culling boundary for this camera relative to its local Z axis.
 		</member>
-		<member name="fov" type="float" setter="set_fov" getter="get_fov" default="70.0">
+		<member name="fov" type="float" setter="set_fov" getter="get_fov" default="75.0">
 			The camera's field of view angle (in degrees). Only applicable in perspective mode. Since [member keep_aspect] locks one axis, [code]fov[/code] sets the other axis' field of view angle.
+			For reference, the default vertical field of view value ([code]75.0[/code]) is equivalent to an horizontal FOV of:
+			- ~91.31 degrees in a 4:3 viewport
+			- ~101.67 degrees in a 16:10 viewport
+			- ~107.51 degrees in a 16:9 viewport
+			- ~121.63 degrees in a 21:9 viewport
 		</member>
 		<member name="frustum_offset" type="Vector2" setter="set_frustum_offset" getter="get_frustum_offset" default="Vector2( 0, 0 )">
 			The camera's frustum offset. This can be changed from the default to create "tilted frustum" effects such as [url=https://zdoom.org/wiki/Y-shearing]Y-shearing[/url].

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -689,7 +689,7 @@ Camera3D::Camera3D() {
 	viewport = nullptr;
 	force_change = false;
 	mode = PROJECTION_PERSPECTIVE;
-	set_perspective(70.0, 0.05, 100.0);
+	set_perspective(75.0, 0.05, 100.0);
 	keep_aspect = KEEP_HEIGHT;
 	layers = 0xfffff;
 	v_offset = 0;

--- a/servers/rendering/rendering_server_scene.h
+++ b/servers/rendering/rendering_server_scene.h
@@ -82,7 +82,7 @@ public:
 		Camera() {
 
 			visible_layers = 0xFFFFFFFF;
-			fov = 70;
+			fov = 75;
 			type = PERSPECTIVE;
 			znear = 0.05;
 			zfar = 100;


### PR DESCRIPTION
A vertical FOV of 74 degrees is roughly equivalent to a 90 degree horizontal FOV on a 4:3 display (~106.26 degrees on 16:9), which is the typical default FOV used in PC games. Low FOV values can result in motion sickness among some players, so it makes sense to default to the most sensible value on desktop platforms.

Note that this doesn't apply to the in-editor camera which keeps its FOV to 70. This is because it doesn't display in fullscreen; its viewport only displays in the center of the editor (roughly). This means the viewport won't cover the viewer's eyes as much. Therefore, the editor camera FOV should be slightly lower to account for this.

Since this changes the default value, this may break existing projects slightly.

For the record, this was already done in https://github.com/godotengine/godot-demo-projects/pull/260 for the official demo projects.