### PR TITLE
Implement Ref<T>::operator=(T*)

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -230,7 +230,7 @@ Ref<RemoteDebuggerPeer> RemoteDebuggerPeer::create_from_uri(const String p_uri) 
 		debug_port = debug_host.substr(sep_pos + 1).to_int();
 		debug_host = debug_host.substr(0, sep_pos);
 	}
-	Ref<RemoteDebuggerPeerTCP> peer = Ref<RemoteDebuggerPeer>(memnew(RemoteDebuggerPeerTCP));
+	Ref<RemoteDebuggerPeerTCP> peer = memnew(RemoteDebuggerPeerTCP);
 	Error err = peer->connect_to_host(debug_host, debug_port);
 	if (err != OK)
 		return Ref<RemoteDebuggerPeer>();

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -51,7 +51,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 	if (r_error)
 		*r_error = ERR_FILE_CORRUPT;
 
-	Ref<Translation> translation = Ref<Translation>(memnew(Translation));
+	Ref<Translation> translation = memnew(Translation);
 	int line = 1;
 	bool skip_this = false;
 	bool skip_next = false;

--- a/core/packed_data_container.cpp
+++ b/core/packed_data_container.cpp
@@ -106,7 +106,7 @@ Variant PackedDataContainer::_get_at_ofs(uint32_t p_ofs, const uint8_t *p_buf, b
 	if (type == TYPE_ARRAY || type == TYPE_DICT) {
 
 		Ref<PackedDataContainerRef> pdcr = memnew(PackedDataContainerRef);
-		Ref<PackedDataContainer> pdc = Ref<PackedDataContainer>((PackedDataContainer *)this);
+		Ref<PackedDataContainer> pdc = (PackedDataContainer *)this;
 
 		pdcr->from = pdc;
 		pdcr->offset = p_ofs;

--- a/core/reference.h
+++ b/core/reference.h
@@ -175,6 +175,23 @@ public:
 		}
 	}
 
+	void operator=(T *p_from) {
+
+		if (p_from == reference) {
+			return;
+		}
+
+		unref();
+
+		if (!p_from) {
+			return;
+		}
+
+		if (p_from->reference()) {
+			reference = p_from;
+		}
+	}
+
 	template <class T_Other>
 	void reference_ptr(T_Other *p_ptr) {
 		if (reference == p_ptr) {

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -533,7 +533,7 @@ void EditorAudioBus::_effect_add(int p_which) {
 	ERR_FAIL_COND(!fx);
 	AudioEffect *afx = Object::cast_to<AudioEffect>(fx);
 	ERR_FAIL_COND(!afx);
-	Ref<AudioEffect> afxr = Ref<AudioEffect>(afx);
+	Ref<AudioEffect> afxr = afx;
 
 	afxr->set_name(effect_options->get_item_text(p_which));
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3372,7 +3372,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 
 	if (ResourceCache::has(lpath)) {
 		//used from somewhere else? no problem! update state and replace sdata
-		Ref<PackedScene> ps = Ref<PackedScene>(Object::cast_to<PackedScene>(ResourceCache::get(lpath)));
+		Ref<PackedScene> ps = Object::cast_to<PackedScene>(ResourceCache::get(lpath));
 		if (ps.is_valid()) {
 			ps->replace_state(sdata->get_state());
 			ps->set_last_modified_time(sdata->get_last_modified_time());
@@ -5024,7 +5024,7 @@ Variant EditorNode::drag_resource(const Ref<Resource> &p_res, Control *p_from) {
 		Ref<Image> img = pic->get_data();
 		img = img->duplicate();
 		img->resize(48, 48); //meh
-		Ref<ImageTexture> resized_pic = Ref<ImageTexture>(memnew(ImageTexture));
+		Ref<ImageTexture> resized_pic = memnew(ImageTexture);
 		resized_pic->create_from_image(img);
 		preview = resized_pic;
 	}

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2401,7 +2401,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 
 			Object *inst = ClassDB::instance(orig_type);
 
-			Ref<Resource> res = Ref<Resource>(Object::cast_to<Resource>(inst));
+			Ref<Resource> res = Object::cast_to<Resource>(inst);
 
 			ERR_FAIL_COND(res.is_null());
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -256,7 +256,7 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 
 Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
-	Ref<Theme> theme = Ref<Theme>(memnew(Theme));
+	Ref<Theme> theme = memnew(Theme);
 
 	const float default_contrast = 0.25;
 

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1170,7 +1170,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 
 								String meshid2 = names[i];
 								if (collada.state.mesh_data_map.has(meshid2)) {
-									Ref<ArrayMesh> mesh = Ref<ArrayMesh>(memnew(ArrayMesh));
+									Ref<ArrayMesh> mesh = memnew(ArrayMesh);
 									const Collada::MeshData &meshdata = collada.state.mesh_data_map[meshid2];
 									mesh->set_name(meshdata.name);
 									Error err = _create_mesh_surfaces(false, mesh, ng2->material_map, meshdata, apply_xform, bone_remap, skin, nullptr, Vector<Ref<ArrayMesh>>(), false);
@@ -1435,7 +1435,7 @@ void ColladaImport::create_animations(bool p_make_tracks_in_all_bones, bool p_im
 
 void ColladaImport::create_animation(int p_clip, bool p_make_tracks_in_all_bones, bool p_import_value_tracks) {
 
-	Ref<Animation> animation = Ref<Animation>(memnew(Animation));
+	Ref<Animation> animation = memnew(Animation);
 
 	if (p_clip == -1) {
 		animation->set_name("default");

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -533,7 +533,7 @@ void AnimationPlayerEditor::_animation_name_edited() {
 
 	} else {
 
-		Ref<Animation> new_anim = Ref<Animation>(memnew(Animation));
+		Ref<Animation> new_anim = memnew(Animation);
 		new_anim->set_name(new_name);
 
 		undo_redo->create_action(TTR("Add Animation"));

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -727,7 +727,7 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PackedB
 
 		int len = image_data.size();
 		const uint8_t *r = image_data.ptr();
-		Ref<Image> image = Ref<Image>(memnew(Image));
+		Ref<Image> image = memnew(Image);
 
 		uint8_t png_signature[8] = { 137, 80, 78, 71, 13, 10, 26, 10 };
 		uint8_t jpg_signature[3] = { 255, 216, 255 };

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5898,7 +5898,7 @@ void CanvasItemEditorViewport::_create_preview(const Vector<String> &files) cons
 		RES res = ResourceLoader::load(path);
 		ERR_FAIL_COND(res.is_null());
 		Ref<Texture2D> texture = Ref<Texture2D>(Object::cast_to<Texture2D>(*res));
-		Ref<PackedScene> scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*res));
+		Ref<PackedScene> scene = Object::cast_to<PackedScene>(*res);
 		if (texture != nullptr || scene != nullptr) {
 			if (texture != nullptr) {
 				Sprite2D *sprite = memnew(Sprite2D);
@@ -6076,7 +6076,7 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 		if (res.is_null()) {
 			continue;
 		}
-		Ref<PackedScene> scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*res));
+		Ref<PackedScene> scene = Object::cast_to<PackedScene>(*res);
 		if (scene != nullptr && scene.is_valid()) {
 			if (!target_node) {
 				// Without root node act the same as "Load Inherited Scene"
@@ -6140,7 +6140,7 @@ bool CanvasItemEditorViewport::can_drop_data(const Point2 &p_point, const Varian
 				}
 				String type = res->get_class();
 				if (type == "PackedScene") {
-					Ref<PackedScene> sdata = Ref<PackedScene>(Object::cast_to<PackedScene>(*res));
+					Ref<PackedScene> sdata = Object::cast_to<PackedScene>(*res);
 					Node *instanced_scene = sdata->instance(PackedScene::GEN_EDIT_STATE_INSTANCE);
 					if (!instanced_scene) {
 						continue;

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -839,7 +839,7 @@ Ref<Texture2D> CurvePreviewGenerator::generate(const Ref<Resource> &p_from, cons
 		prev_y = y;
 	}
 
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
+	Ref<ImageTexture> ptex = memnew(ImageTexture);
 
 	ptex->create_from_image(img_ref);
 	return ptex;

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -131,7 +131,7 @@ Ref<Texture2D> EditorTexturePreviewPlugin::generate(const RES &p_from, const Siz
 
 	post_process_preview(img);
 
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
+	Ref<ImageTexture> ptex = memnew(ImageTexture);
 
 	ptex->create_from_image(img);
 	return ptex;
@@ -243,7 +243,7 @@ Ref<Texture2D> EditorBitmapPreviewPlugin::generate(const RES &p_from, const Size
 
 	post_process_preview(img);
 
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
+	Ref<ImageTexture> ptex = memnew(ImageTexture);
 
 	ptex->create_from_image(img);
 	return ptex;
@@ -286,7 +286,7 @@ Ref<Texture2D> EditorPackedScenePreviewPlugin::generate_from_path(const String &
 	Error err = img->load(path);
 	if (err == OK) {
 
-		Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
+		Ref<ImageTexture> ptex = memnew(ImageTexture);
 
 		post_process_preview(img);
 		ptex->create_from_image(img);
@@ -348,7 +348,7 @@ Ref<Texture2D> EditorMaterialPreviewPlugin::generate(const RES &p_from, const Si
 		int thumbnail_size = MAX(p_size.x, p_size.y);
 		img->resize(thumbnail_size, thumbnail_size, Image::INTERPOLATE_CUBIC);
 		post_process_preview(img);
-		Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
+		Ref<ImageTexture> ptex = memnew(ImageTexture);
 		ptex->create_from_image(img);
 		return ptex;
 	}
@@ -589,7 +589,7 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 
 	post_process_preview(img);
 
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
+	Ref<ImageTexture> ptex = memnew(ImageTexture);
 
 	ptex->create_from_image(img);
 	return ptex;
@@ -674,7 +674,7 @@ Ref<Texture2D> EditorAudioStreamPreviewPlugin::generate(const RES &p_from, const
 
 	//post_process_preview(img);
 
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
+	Ref<ImageTexture> ptex = memnew(ImageTexture);
 	Ref<Image> image;
 	image.instance();
 	image->create(w, h, false, Image::FORMAT_RGB8, img);
@@ -752,7 +752,7 @@ Ref<Texture2D> EditorMeshPreviewPlugin::generate(const RES &p_from, const Size2 
 
 	post_process_preview(img);
 
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
+	Ref<ImageTexture> ptex = memnew(ImageTexture);
 	ptex->create_from_image(img);
 	return ptex;
 }
@@ -874,7 +874,7 @@ Ref<Texture2D> EditorFontPreviewPlugin::generate_from_path(const String &p_path,
 
 	post_process_preview(img);
 
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
+	Ref<ImageTexture> ptex = memnew(ImageTexture);
 	ptex->create_from_image(img);
 
 	return ptex;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3623,10 +3623,10 @@ void Node3DEditorViewport::_create_preview(const Vector<String> &files) const {
 		String path = files[i];
 		RES res = ResourceLoader::load(path);
 		ERR_CONTINUE(res.is_null());
-		Ref<PackedScene> scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*res));
-		Ref<Mesh> mesh = Ref<Mesh>(Object::cast_to<Mesh>(*res));
-		if (mesh != nullptr || scene != nullptr) {
-			if (mesh != nullptr) {
+		Ref<PackedScene> scene = Object::cast_to<PackedScene>(*res);
+		Ref<Mesh> mesh = Object::cast_to<Mesh>(*res);
+		if (mesh.is_valid() || scene.is_valid()) {
+			if (mesh.is_valid()) {
 				MeshInstance3D *mesh_instance = memnew(MeshInstance3D);
 				mesh_instance->set_mesh(mesh);
 				preview_node->add_child(mesh_instance);
@@ -3674,13 +3674,13 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 	RES res = ResourceLoader::load(path);
 	ERR_FAIL_COND_V(res.is_null(), false);
 
-	Ref<PackedScene> scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*res));
-	Ref<Mesh> mesh = Ref<Mesh>(Object::cast_to<Mesh>(*res));
+	Ref<PackedScene> scene = Object::cast_to<PackedScene>(*res);
+	Ref<Mesh> mesh = Object::cast_to<Mesh>(*res);
 
 	Node *instanced_scene = nullptr;
 
-	if (mesh != nullptr || scene != nullptr) {
-		if (mesh != nullptr) {
+	if (mesh.is_valid() || scene.is_valid()) {
+		if (mesh.is_valid()) {
 			MeshInstance3D *mesh_instance = memnew(MeshInstance3D);
 			mesh_instance->set_mesh(mesh);
 			mesh_instance->set_name(path.get_file().get_basename());
@@ -3744,9 +3744,9 @@ void Node3DEditorViewport::_perform_drop_data() {
 		if (res.is_null()) {
 			continue;
 		}
-		Ref<PackedScene> scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*res));
-		Ref<Mesh> mesh = Ref<Mesh>(Object::cast_to<Mesh>(*res));
-		if (mesh != nullptr || scene != nullptr) {
+		Ref<PackedScene> scene = Object::cast_to<PackedScene>(*res);
+		Ref<Mesh> mesh = Object::cast_to<Mesh>(*res);
+		if (mesh.is_valid() || scene.is_valid()) {
 			bool success = _create_instance(target_node, path, drop_pos);
 			if (!success) {
 				error_files.push_back(path);

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -39,7 +39,7 @@ bool EditorInspectorPluginStyleBox::can_handle(Object *p_object) {
 
 void EditorInspectorPluginStyleBox::parse_begin(Object *p_object) {
 
-	Ref<StyleBox> sb = Ref<StyleBox>(Object::cast_to<StyleBox>(p_object));
+	Ref<StyleBox> sb = Object::cast_to<StyleBox>(p_object);
 
 	StyleBoxPreview *preview = memnew(StyleBoxPreview);
 	preview->edit(sb);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -220,7 +220,7 @@ void VisualShaderEditor::update_custom_nodes() {
 			Ref<Resource> res = ResourceLoader::load(script_path);
 			ERR_FAIL_COND(res.is_null());
 			ERR_FAIL_COND(!res->is_class("Script"));
-			Ref<Script> script = Ref<Script>(res);
+			Ref<Script> script = res;
 
 			Ref<VisualShaderNodeCustom> ref;
 			ref.instance();
@@ -1560,7 +1560,7 @@ void VisualShaderEditor::_connection_from_empty(const String &p_to, int p_to_slo
 void VisualShaderEditor::_delete_request(int which) {
 
 	VisualShader::Type type = VisualShader::Type(edit_type->get_selected());
-	Ref<VisualShaderNode> node = Ref<VisualShaderNode>(visual_shader->get_node(type, which));
+	Ref<VisualShaderNode> node = visual_shader->get_node(type, which);
 
 	undo_redo->create_action(TTR("Delete Node"));
 	undo_redo->add_do_method(visual_shader.ptr(), "remove_node", type, which);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -213,7 +213,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 
 					Object *inst = ClassDB::instance(orig_type);
 
-					Ref<Resource> res = Ref<Resource>(Object::cast_to<Resource>(inst));
+					Ref<Resource> res = Object::cast_to<Resource>(inst);
 
 					ERR_FAIL_COND(res.is_null());
 
@@ -1413,7 +1413,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 					propvalues.push_back(p);
 				}
 
-				Ref<Resource> res = Ref<Resource>(ClassDB::instance(res_orig->get_class()));
+				Ref<Resource> res(ClassDB::instance(res_orig->get_class()));
 
 				ERR_FAIL_COND(res.is_null());
 

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -189,7 +189,7 @@ Ref<Script> NativeScript::get_base_script() const {
 		return Ref<Script>();
 
 	NativeScript *script = (NativeScript *)NSL->create_script();
-	Ref<NativeScript> ns = Ref<NativeScript>(script);
+	Ref<NativeScript> ns = script;
 	ERR_FAIL_COND_V(!ns.is_valid(), Ref<Script>());
 
 	ns->set_class_name(script_data->base);

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -99,7 +99,7 @@ void PluginScriptLanguage::get_string_delimiters(List<String> *p_delimiters) con
 
 Ref<Script> PluginScriptLanguage::get_template(const String &p_class_name, const String &p_base_class_name) const {
 	Script *ns = create_script();
-	Ref<Script> script = Ref<Script>(ns);
+	Ref<Script> script = ns;
 	if (_desc.get_template_source_code) {
 		godot_string src = _desc.get_template_source_code(_data, (godot_string *)&p_class_name, (godot_string *)&p_base_class_name);
 		script->set_source_code(*(String *)&src);

--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -384,7 +384,7 @@ RES ResourceFormatLoaderVideoStreamGDNative::load(const String &p_path, const St
 	memdelete(f);
 	VideoStreamGDNative *stream = memnew(VideoStreamGDNative);
 	stream->set_file(p_path);
-	Ref<VideoStreamGDNative> ogv_stream = Ref<VideoStreamGDNative>(stream);
+	Ref<VideoStreamGDNative> ogv_stream = stream;
 	if (r_error) {
 		*r_error = OK;
 	}

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -147,7 +147,7 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 				class_type = class_type->owner;
 			}
 
-			Ref<GDScript> script = Ref<GDScript>(main_script);
+			Ref<GDScript> script = main_script;
 			while (names.back()) {
 				if (!script->subclasses.has(names.back()->get())) {
 					ERR_PRINT("Parser bug: Cannot locate datatype class.");

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -411,7 +411,7 @@ Node *GDScriptWorkspace::_get_owner_scene_node(String p_path) {
 		NodePath owner_path = owners[i];
 		RES owner_res = ResourceLoader::load(owner_path);
 		if (Object::cast_to<PackedScene>(owner_res.ptr())) {
-			Ref<PackedScene> owner_packed_scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*owner_res));
+			Ref<PackedScene> owner_packed_scene = Object::cast_to<PackedScene>(*owner_res);
 			owner_scene_node = owner_packed_scene->instance();
 			break;
 		}

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -738,7 +738,7 @@ RES ResourceFormatLoaderTheora::load(const String &p_path, const String &p_origi
 	VideoStreamTheora *stream = memnew(VideoStreamTheora);
 	stream->set_file(p_path);
 
-	Ref<VideoStreamTheora> ogv_stream = Ref<VideoStreamTheora>(stream);
+	Ref<VideoStreamTheora> ogv_stream = stream;
 
 	if (r_error) {
 		*r_error = OK;

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -487,7 +487,7 @@ RES ResourceFormatLoaderWebm::load(const String &p_path, const String &p_origina
 	VideoStreamWebm *stream = memnew(VideoStreamWebm);
 	stream->set_file(p_path);
 
-	Ref<VideoStreamWebm> webm_stream = Ref<VideoStreamWebm>(stream);
+	Ref<VideoStreamWebm> webm_stream = stream;
 
 	if (r_error) {
 		*r_error = OK;

--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -227,7 +227,7 @@ void WSLServer::poll() {
 
 		Ref<PendingPeer> peer = memnew(PendingPeer);
 		if (private_key.is_valid() && ssl_cert.is_valid()) {
-			Ref<StreamPeerSSL> ssl = Ref<StreamPeerSSL>(StreamPeerSSL::create());
+			Ref<StreamPeerSSL> ssl = StreamPeerSSL::create();
 			ssl->set_blocking_handshake_enabled(false);
 			ssl->accept_stream(conn, private_key, ssl_cert, ca_chain);
 			peer->connection = ssl;

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -2359,6 +2359,6 @@ void register_android_exporter() {
 	EDITOR_DEF("export/android/timestamping_authority_url", "");
 	EDITOR_DEF("export/android/shutdown_adb_on_exit", true);
 
-	Ref<EditorExportPlatformAndroid> exporter = Ref<EditorExportPlatformAndroid>(memnew(EditorExportPlatformAndroid));
+	Ref<EditorExportPlatformAndroid> exporter = memnew(EditorExportPlatformAndroid);
 	EditorExport::get_singleton()->add_export_platform(exporter);
 }

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2675,7 +2675,7 @@ float RichTextLabel::get_percent_visible() const {
 void RichTextLabel::set_effects(const Vector<Variant> &effects) {
 	custom_effects.clear();
 	for (int i = 0; i < effects.size(); i++) {
-		Ref<RichTextEffect> effect = Ref<RichTextEffect>(effects[i]);
+		Ref<RichTextEffect> effect = effects[i];
 		custom_effects.push_back(effect);
 	}
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -691,7 +691,7 @@ Ref<Material> SceneTree::get_debug_navigation_material() {
 	if (navigation_material.is_valid())
 		return navigation_material;
 
-	Ref<StandardMaterial3D> line_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	Ref<StandardMaterial3D> line_material = memnew(StandardMaterial3D);
 	line_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 	line_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
 	line_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
@@ -708,7 +708,7 @@ Ref<Material> SceneTree::get_debug_navigation_disabled_material() {
 	if (navigation_disabled_material.is_valid())
 		return navigation_disabled_material;
 
-	Ref<StandardMaterial3D> line_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	Ref<StandardMaterial3D> line_material = memnew(StandardMaterial3D);
 	line_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 	line_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
 	line_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
@@ -724,7 +724,7 @@ Ref<Material> SceneTree::get_debug_collision_material() {
 	if (collision_material.is_valid())
 		return collision_material;
 
-	Ref<StandardMaterial3D> line_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	Ref<StandardMaterial3D> line_material = memnew(StandardMaterial3D);
 	line_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 	line_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
 	line_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
@@ -743,7 +743,7 @@ Ref<ArrayMesh> SceneTree::get_debug_contact_mesh() {
 
 	debug_contact_mesh = Ref<ArrayMesh>(memnew(ArrayMesh));
 
-	Ref<StandardMaterial3D> mat = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	Ref<StandardMaterial3D> mat = memnew(StandardMaterial3D);
 	mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 	mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
 	mat->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1395,7 +1395,7 @@ int CurveTexture::get_width() const {
 
 void CurveTexture::ensure_default_setup(float p_min, float p_max) {
 	if (_curve.is_null()) {
-		Ref<Curve> curve = Ref<Curve>(memnew(Curve));
+		Ref<Curve> curve = memnew(Curve);
 		curve->add_point(Vector2(0, 1));
 		curve->add_point(Vector2(1, 1));
 		curve->set_min_value(p_min);


### PR DESCRIPTION
There are 4 ways to create a Ref:
```

Ref<T> myref;
my_ref.instance()

```
`Ref<T> my_ref(memnew(T));`

`Ref<T> my_ref = memnew(T);`

`Ref<T> my_ref = Ref<T>(memnew(T));`

All 4 are used in the source code but they do different things.
The first straight forward but requires 2 lines.
The 4th one is verbose and requires extra ref and unref.
The 3rd one is shorter than the 4th but is not as efficent as
we don't define operator=(T *from) so it tries to cast the pointer.

This PR creates that operator and changes the 4th from to th 3rd
in order to have a more compact Ref definition without unneeded
casting.