### PR TITLE
Fixed shuffling editor help tabs

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1866,6 +1866,10 @@ void ScriptEditor::_update_script_names() {
 			if (new_cur_tab == -1 && sedata[i].index == cur_tab) {
 				new_cur_tab = i;
 			}
+			// Update index of sd entries for sorted order
+			_ScriptEditorItemData sd = sedata[i];
+			sd.index = i;
+			sedata.set(i, sd);
 		}
 		tab_container->set_current_tab(new_prev_tab);
 		tab_container->set_current_tab(new_cur_tab);


### PR DESCRIPTION
The indexes for the ScriptEditorItemData entries were not getting
updated after sorting. This would cause a page to be open but with a
different tab selected. Whenever _update_script_names was called next,
it would correct this indexing. Now we correct it immediately following
the tab sort

Reported: #38079.