### PR TITLE
Windows: Appease capricious MSVC versions with moody headers

### DIFF
--- a/platform/windows/crash_handler_windows.cpp
+++ b/platform/windows/crash_handler_windows.cpp
@@ -38,10 +38,12 @@
 
 // Backtrace code code based on: https://stackoverflow.com/questions/6205981/windows-c-stack-trace-from-a-running-app
 
-#include <psapi.h>
 #include <algorithm>
 #include <iterator>
+#include <string>
 #include <vector>
+
+#include <psapi.h>
 
 #pragma comment(lib, "psapi.lib")
 #pragma comment(lib, "dbghelp.lib")

--- a/thirdparty/basis_universal/basisu_enc.h
+++ b/thirdparty/basis_universal/basisu_enc.h
@@ -22,6 +22,7 @@
 #include <functional>
 #include <thread>
 #include <unordered_map>
+#include <ostream>
 
 #if !defined(_WIN32) || defined(__MINGW32__)
 #include <libgen.h>


### PR DESCRIPTION
Fixes #37799.
Fixes #37986.

Not sure why those errors happen for @CROmartin when it seems to be fine for everyone else, but I guess it's different MSVC patch versions with STL headers moving around, so let's be explicit.

The basisu fix has been done upstream and will be superseded by #38070.