### PR TITLE
Avoid duplicating shader defines in GLES2

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -488,12 +488,15 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 
 			if (p_default_actions.usage_defines.has(var_node->name) && !used_name_defines.has(var_node->name)) {
 				String define = p_default_actions.usage_defines[var_node->name];
+				String node_name = define.substr(1, define.length());
 
 				if (define.begins_with("@")) {
-					define = p_default_actions.usage_defines[define.substr(1, define.length())];
+					define = p_default_actions.usage_defines[node_name];
 				}
 
-				r_gen_code.custom_defines.push_back(define.utf8());
+				if (!used_name_defines.has(node_name)) {
+					r_gen_code.custom_defines.push_back(define.utf8());
+				}
 				used_name_defines.insert(var_node->name);
 			}
 
@@ -550,12 +553,15 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 
 			if (p_default_actions.usage_defines.has(arr_node->name) && !used_name_defines.has(arr_node->name)) {
 				String define = p_default_actions.usage_defines[arr_node->name];
+				String node_name = define.substr(1, define.length());
 
 				if (define.begins_with("@")) {
-					define = p_default_actions.usage_defines[define.substr(1, define.length())];
+					define = p_default_actions.usage_defines[node_name];
 				}
 
-				r_gen_code.custom_defines.push_back(define.utf8());
+				if (!used_name_defines.has(node_name)) {
+					r_gen_code.custom_defines.push_back(define.utf8());
+				}
 				used_name_defines.insert(arr_node->name);
 			}
 
@@ -726,12 +732,15 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 
 					if (p_default_actions.usage_defines.has(var_node->name) && !used_name_defines.has(var_node->name)) {
 						String define = p_default_actions.usage_defines[var_node->name];
+						String node_name = define.substr(1, define.length());
 
 						if (define.begins_with("@")) {
-							define = p_default_actions.usage_defines[define.substr(1, define.length())];
+							define = p_default_actions.usage_defines[node_name];
 						}
 
-						r_gen_code.custom_defines.push_back(define.utf8());
+						if (!used_name_defines.has(node_name)) {
+							r_gen_code.custom_defines.push_back(define.utf8());
+						}
 						used_name_defines.insert(var_node->name);
 					}
 


### PR DESCRIPTION
Fixes: #38248

This code block only checked for when the underlying node was used in usage defines, it didn't check if the referenced node was used in usage defines leading to duplicating usage defines when there are multiple nodes that share the same usage define. Normally this is fine, but in certain low-end mobile systems the multiple defines lead to a shader error. 

Note GLES3 uses the same logic, but I don't believe that the error arises on any GLES3 capable devices, so it is best to use the simpler logic for GLES3 and allow the multiple definitions. 