### PR TITLE
Added option for spinbox to update it's value on line edit 'text_changed' rather than 'text_entered'

### DIFF
--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -55,6 +55,9 @@
 		<member name="suffix" type="String" setter="set_suffix" getter="get_suffix" default="&quot;&quot;">
 			Adds the specified [code]suffix[/code] string after the numerical value of the [SpinBox].
 		</member>
+		<member name="update_on_text_changed" type="bool" setter="set_update_on_text_changed" getter="get_update_on_text_changed" default="false">
+			Sets the value of the [Range] for this [SpinBox] when the [LineEdit] text is [i]changed[/i] instead of [i]submitted[/i]. See [signal LineEdit.text_changed] and [signal LineEdit.text_submitted].
+		</member>
 	</members>
 	<theme_items>
 		<theme_item name="updown" data_type="icon" type="Texture2D">

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -40,6 +40,7 @@ class SpinBox : public Range {
 
 	LineEdit *line_edit;
 	int last_w = 0;
+	bool update_on_text_changed = false;
 
 	Timer *range_click_timer;
 	void _range_click_timeout();
@@ -47,6 +48,8 @@ class SpinBox : public Range {
 
 	void _text_submitted(const String &p_string);
 	virtual void _value_changed(double) override;
+	void _text_changed(const String &p_string);
+
 	String prefix;
 	String suffix;
 
@@ -87,6 +90,9 @@ public:
 
 	void set_prefix(const String &p_prefix);
 	String get_prefix() const;
+
+	void set_update_on_text_changed(bool p_update);
+	bool get_update_on_text_changed() const;
 
 	void apply();
 


### PR DESCRIPTION
Having the spinbox update it's value on text_entered means that the control needs to lose focus for the value_changed signal to emit (or hit enter).

It can be helpful for the spinbox to update it's value _live_, so that things like validation can be done with faster feedback to the user. 

This is comparable to _onchange_ and _oninput_ in JavaScript.
![chBTPbYZJ7](https://user-images.githubusercontent.com/41730826/80362401-ec24f000-88c5-11ea-939e-00c09d1d974a.gif)

Note this is a toggleable option:
![godot windows tools 64_IFWeYCOHOO](https://user-images.githubusercontent.com/41730826/80362537-268e8d00-88c6-11ea-8474-ca48f8279ee6.png)
