### PR TITLE
Make zoom limits and step adjustable in `GraphEdit`

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -197,6 +197,9 @@
 		<member name="scroll_offset" type="Vector2" setter="set_scroll_ofs" getter="get_scroll_ofs" default="Vector2( 0, 0 )">
 			The scroll offset.
 		</member>
+		<member name="show_zoom_label" type="bool" setter="set_show_zoom_label" getter="is_showing_zoom_label" default="false">
+			If [code]true[/code], makes a label with the current zoom level visible. The zoom value is displayed in percents.
+		</member>
 		<member name="snap_distance" type="int" setter="set_snap" getter="get_snap" default="20">
 			The snapping distance in pixels.
 		</member>
@@ -205,6 +208,15 @@
 		</member>
 		<member name="zoom" type="float" setter="set_zoom" getter="get_zoom" default="1.0">
 			The current zoom value.
+		</member>
+		<member name="zoom_max" type="float" setter="set_zoom_max" getter="get_zoom_max" default="2.0736">
+			The upper zoom limit.
+		</member>
+		<member name="zoom_min" type="float" setter="set_zoom_min" getter="get_zoom_min" default="0.232568">
+			The lower zoom limit.
+		</member>
+		<member name="zoom_step" type="float" setter="set_zoom_step" getter="get_zoom_step" default="1.2">
+			The step of each zoom level.
 		</member>
 	</members>
 	<signals>

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -34,6 +34,7 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/graph_node.h"
+#include "scene/gui/label.h"
 #include "scene/gui/scroll_bar.h"
 #include "scene/gui/slider.h"
 #include "scene/gui/spin_box.h"
@@ -105,6 +106,7 @@ public:
 	};
 
 private:
+	Label *zoom_label;
 	Button *zoom_minus;
 	Button *zoom_reset;
 	Button *zoom_plus;
@@ -113,10 +115,6 @@ private:
 	SpinBox *snap_amount;
 
 	Button *minimap_button;
-
-	void _zoom_minus();
-	void _zoom_reset();
-	void _zoom_plus();
 
 	HScrollBar *h_scroll;
 	VScrollBar *v_scroll;
@@ -144,6 +142,14 @@ private:
 	Vector2 drag_accum;
 
 	float zoom = 1.0;
+	float zoom_step = 1.2;
+	float zoom_min;
+	float zoom_max;
+
+	void _zoom_minus();
+	void _zoom_reset();
+	void _zoom_plus();
+	void _update_zoom_label();
 
 	bool box_selecting = false;
 	bool box_selection_mode_additive = false;
@@ -246,6 +252,18 @@ public:
 	void set_zoom(float p_zoom);
 	void set_zoom_custom(float p_zoom, const Vector2 &p_center);
 	float get_zoom() const;
+
+	void set_zoom_min(float p_zoom_min);
+	float get_zoom_min() const;
+
+	void set_zoom_max(float p_zoom_max);
+	float get_zoom_max() const;
+
+	void set_zoom_step(float p_zoom_step);
+	float get_zoom_step() const;
+
+	void set_show_zoom_label(bool p_enable);
+	bool is_showing_zoom_label() const;
 
 	void set_minimap_size(Vector2 p_size);
 	Vector2 get_minimap_size() const;


### PR DESCRIPTION
Closes #38249. 

This also adds an optional label to the toolbar of the GraphEdit to display current zoom level (in percent).

*Note: Earlier version of this PR featured a linear zoom option that was removed*


https://user-images.githubusercontent.com/11782833/122230790-a01a7d80-cec2-11eb-9d06-9ca77258cde0.mp4


New settings are neatly grouped. I've also gone ahead and grouped connection lines related settings.

![godot windows tools 64_2021-06-16_16-13-10](https://user-images.githubusercontent.com/11782833/122226141-55970200-cebe-11eb-99eb-e0f55992f51c.png)

