### PR TITLE
Bring back and improve comments clarifying the new bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,13 +6,24 @@ labels: ''
 assignees: ''
 
 ---
+<!-- Please search existing issues for potential duplicates before filing yours:	
+https://github.com/godotengine/godot/issues?q=is%3Aissue	
+-->
 
 **Godot version:**
+<!-- Specify commit hash if using non-official build. -->
+
 
 **OS/device including version:**
+<!-- Specify GPU model, drivers, and the backend (GLES2, GLES3, Vulkan) if graphics-related. -->
+
 
 **Issue description:**
+<!-- What happened, and what was expected. -->
+
 
 **Steps to reproduce:**
 
+
 **Minimal reproduction project:**
+<!-- A small Godot project which reproduces the issue. Drag and drop a zip archive to upload it. -->


### PR DESCRIPTION
I've noticed that people can't seem to understand some questions and I wondered why so? For instance: #37942

> **Minimal reproduction project:** I don't exactly understand what this means

That's because the comments clarifying the questions were accidentally removed in c8e92b802c16f8f9d120bf01bc5923c702a3c3ff while migrating to the bug/feature templates workflow.

Note that it might be not necessary to include the "search for duplicates" suggestion because GitHub has a new feature of suggesting duplicate issues built-in now (might be beta feature though). Anyways, I just copied all the previous comments as is.

While we're at it, consider #35724.