### PR TITLE
Fix osx compilation with OSXCross

### DIFF
--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -36,6 +36,7 @@
 #include "core/os/keyboard.h"
 #include "main/main.h"
 #include "scene/resources/texture.h"
+#include "version.h"
 
 #include <Carbon/Carbon.h>
 #include <Cocoa/Cocoa.h>

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -35,6 +35,7 @@
 #include "dir_access_osx.h"
 #include "display_server_osx.h"
 #include "main/main.h"
+#include "version.h"
 
 #include <dlfcn.h>
 #include <libproc.h>

--- a/platform/osx/version.h
+++ b/platform/osx/version.h
@@ -1,0 +1,41 @@
+/*************************************************************************/
+/*  version.h                                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef OSX_VERSION_H
+#define OSX_VERSION_H
+
+#ifndef NSAppKitVersionNumber10_12
+#define NSAppKitVersionNumber10_12 1504
+#endif
+#ifndef NSAppKitVersionNumber10_14
+#define NSAppKitVersionNumber10_14 1671
+#endif
+
+#endif


### PR DESCRIPTION
This change restores a fix from PR #23822 for osx compilation using OSXCross.

In my use case, I was getting `undeclared identifier` error on `NSAppKitVersionNumber10_14` when compiling on Ubuntu using Xcode 10.2.1.

cc @bruvzg to validate this is the proper fix.