### PR TITLE
Mark "Indented block expected" error after function declaration

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4033,7 +4033,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 
 				if (!_enter_indent_block(block)) {
 
-					_set_error("Indented block expected.");
+					_set_error(vformat("Indented block expected after declaration of \"%s\" function.", function->name));
 					return;
 				}
 


### PR DESCRIPTION
Currently, when a function doesn't have an indented block, an "Intended block expected" error is marked on the last line that _could_ contain that block:

![blank_stock](https://user-images.githubusercontent.com/1078569/80432397-f389d080-88a8-11ea-8122-09800b97ddeb.png)

While this is technically correct, I find it a bit confusing and potentially misleading; the scary red line is pointing at another function, and that function isn't doing anything wrong.

This changes the error to be marked on the line immediately after the function declaration:

![blank_new](https://user-images.githubusercontent.com/1078569/80432481-36e43f00-88a9-11ea-9ea1-dcce3a878e85.png)

This seems clearer to me, as I'm likely to start writing my function body after its declaration, rather than before the declaration of the next function.

The difference is clearer when using the default template for a script:

<p align="center">
<img src="https://user-images.githubusercontent.com/1078569/80432572-80348e80-88a9-11ea-8003-44133d5ee567.png" width="48%"/> <img src="https://user-images.githubusercontent.com/1078569/80432575-8165bb80-88a9-11ea-954e-158fa069aef5.png" width="48%"/>
Before  /  After
</p>

Disclaimer: I'm new to Godot. There could definitely be edge cases I'm missing here, though I wasn't able to "break" it in my testing.