### PR TITLE
Add Camera2D Rotation Smoothing

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -171,6 +171,13 @@
 		<member name="rotating" type="bool" setter="set_rotating" getter="is_rotating" default="false">
 			If [code]true[/code], the camera rotates with the target.
 		</member>
+		<member name="rotation_smoothing_enabled" type="bool" setter="set_enable_rotation_smoothing" getter="is_rotation_smoothing_enabled" default="false">
+			If [code]true[/code], the camera smoothly rotates to align with the target at [member rotation_smoothing_speed].
+			Requires [member rotating] to be enabled for rotation smoothing to work.
+		</member>
+		<member name="rotation_smoothing_speed" type="float" setter="set_rotation_smoothing" getter="get_rotation_smoothing" default="5.0">
+			Angular speed in radians per second of the camera's rotation smoothing effect when [member rotation_smoothing_enabled] is [code]true[/code].
+		</member>
 		<member name="smoothing_enabled" type="bool" setter="set_enable_follow_smoothing" getter="is_follow_smoothing_enabled" default="false">
 			If [code]true[/code], the camera smoothly moves towards the target at [member smoothing_speed].
 		</member>

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -66,8 +66,14 @@ protected:
 	AnchorMode anchor_mode;
 	bool rotating;
 	bool current;
-	float smoothing;
-	bool smoothing_enabled;
+
+	float follow_smoothing;
+	bool follow_smoothing_enabled;
+
+	float camera_angle;
+	float rotation_smoothing;
+	bool rotation_smoothing_enabled;
+
 	int limit[4];
 	bool limit_smoothing_enabled;
 	float drag_margin[4];
@@ -86,6 +92,8 @@ protected:
 
 	void _make_current(Object *p_which);
 	void _set_current(bool p_current);
+
+	void _enable_process_internal_if_needed_for_smoothing();
 
 	void _set_old_smoothing(float p_enable);
 
@@ -136,6 +144,12 @@ public:
 
 	void set_follow_smoothing(float p_speed);
 	float get_follow_smoothing() const;
+
+	void set_rotation_smoothing(float p_speed);
+	float get_rotation_smoothing() const;
+
+	void set_enable_rotation_smoothing(bool p_enabled);
+	bool is_rotation_smoothing_enabled() const;
 
 	void set_process_mode(Camera2DProcessMode p_mode);
 	Camera2DProcessMode get_process_mode() const;


### PR DESCRIPTION
`Camera2D` has follow smoothing to interpolate towards a target position, but no rotation smoothing to align with the target rotation. 

This adds rotation smoothing directly into the `Camera2D` API by  having two new properties: 
- `smoothing_rotation_enabled`
- `smoothing_rotation_speed`

Possible issue: confusion by having two similar properties show in the editor: `Rotating` and` Smoothing/Rotation Enabled`. I am open to suggestions to improve this. 

Note that rotational smoothing only works if `Rotating` is enabled.

![image](https://user-images.githubusercontent.com/7874807/80435111-e7a60a80-88b8-11ea-8afb-c228b02a9b16.png)

[Camera2D Smooth Rotation Video](https://www.reddit.com/r/godot/comments/g8ov6q/got_rotation_smoothing_built_directly_into/?utm_source=share&utm_medium=web2x)
