### PR TITLE
Fix for marking assert lines as safe bug

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3358,15 +3358,10 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 				}
 
 				if (args.empty() || args.size() > 2) {
-					_set_error("Wrong number of arguments, expected 1 or 2");
+					_set_error("Wrong number of arguments, expected 1 or 2", assert_line);
 					return;
 				}
 
-#ifdef DEBUG_ENABLED
-				// Mark as safe, let type check mark as unsafe if needed
-				_mark_line_as_safe(assert_line);
-				_reduce_node_type(args[0]);
-#endif
 				AssertNode *an = alloc_node<AssertNode>();
 				an->condition = _reduce_expression(args[0], p_static);
 				an->line = assert_line;
@@ -3383,7 +3378,7 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 				p_block->statements.push_back(an);
 
 				if (!_end_statement()) {
-					_set_error("Expected end of statement after \"assert\".");
+					_set_error("Expected end of statement after \"assert\".", assert_line);
 					return;
 				}
 			} break;
@@ -8133,9 +8128,14 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 		Node *statement = E->get();
 		switch (statement->type) {
 			case Node::TYPE_NEWLINE:
-			case Node::TYPE_BREAKPOINT:
-			case Node::TYPE_ASSERT: {
+			case Node::TYPE_BREAKPOINT: {
 				// Nothing to do
+			} break;
+			case Node::TYPE_ASSERT: {
+				AssertNode *an = static_cast<AssertNode *>(statement);
+				_mark_line_as_safe(an->line);
+				_reduce_node_type(an->condition);
+				_reduce_node_type(an->message);
 			} break;
 			case Node::TYPE_LOCAL_VAR: {
 				LocalVarNode *lv = static_cast<LocalVarNode *>(statement);


### PR DESCRIPTION
Calling _reduce_node_type from GDScriptParser::_parse_block for assert
was using a current class with a scope that didn't include all
functions. Now calling in GDScriptParser::_check_block_types uses the
right class type. We also now check the assert node message. The assert
line was added to the set_errors associated with assert, since before
the error would be reported on the next line

Reported: #38270
This will need to be cherry picked to the 3.2 branch.
Any issues or questions let me know, thanks.