### PR TITLE
Fixed audio output latency inaccuracies

### DIFF
--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -246,6 +246,18 @@ int AudioDriverALSA::get_mix_rate() const {
 	return mix_rate;
 }
 
+int AudioDriverALSA::get_mix_buffer_size() const {
+
+	return (int)period_size;
+}
+
+float AudioDriverALSA::get_latency() {
+
+	if (mix_rate != 0)
+		return (float)period_size / (float)mix_rate;
+	return 0.f;
+}
+
 AudioDriver::SpeakerMode AudioDriverALSA::get_speaker_mode() const {
 
 	return speaker_mode;

--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -77,6 +77,7 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual Array get_device_list();
 	virtual String get_device();
@@ -84,6 +85,8 @@ public:
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
+
+	virtual float get_latency();
 
 	AudioDriverALSA();
 	~AudioDriverALSA();

--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -273,6 +273,11 @@ int AudioDriverCoreAudio::get_mix_rate() const {
 	return mix_rate;
 };
 
+int AudioDriverCoreAudio::get_mix_buffer_size() const {
+
+	return (int)buffer_frames;
+}
+
 AudioDriver::SpeakerMode AudioDriverCoreAudio::get_speaker_mode() const {
 	return get_speaker_mode_by_total_channels(channels);
 };
@@ -338,6 +343,13 @@ void AudioDriverCoreAudio::finish() {
 		audio_unit = nullptr;
 		unlock();
 	}
+}
+
+float AudioDriverCoreAudio::get_latency() {
+
+	if (mix_rate != 0)
+		return (float)buffer_frames / (float)mix_rate;
+	return 0.f;
 }
 
 Error AudioDriverCoreAudio::capture_init() {

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -95,11 +95,14 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
+
+	virtual float get_latency();
 
 	virtual Error capture_start();
 	virtual Error capture_stop();

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -533,6 +533,11 @@ int AudioDriverPulseAudio::get_mix_rate() const {
 	return mix_rate;
 }
 
+int AudioDriverPulseAudio::get_mix_buffer_size() const {
+
+	return buffer_frames;
+}
+
 AudioDriver::SpeakerMode AudioDriverPulseAudio::get_speaker_mode() const {
 
 	return get_speaker_mode_by_total_channels(channels);

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -102,6 +102,7 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 
 	virtual Array get_device_list();

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -416,6 +416,16 @@ int AudioDriverWASAPI::get_mix_rate() const {
 	return mix_rate;
 }
 
+int AudioDriverWASAPI::get_mix_buffer_size() const {
+
+	return buffer_frames;
+}
+
+float AudioDriverWASAPI::get_latency() {
+
+	return (float)buffer_frames / (float)mix_rate;
+}
+
 AudioDriver::SpeakerMode AudioDriverWASAPI::get_speaker_mode() const {
 
 	return get_speaker_mode_by_total_channels(channels);

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -109,6 +109,8 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
+	virtual float get_latency();
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual Array get_device_list();
 	virtual String get_device();

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -139,6 +139,11 @@ int AudioDriverXAudio2::get_mix_rate() const {
 	return mix_rate;
 }
 
+int AudioDriverXAudio2::get_mix_buffer_size() const {
+
+	return buffer_size;
+}
+
 AudioDriver::SpeakerMode AudioDriverXAudio2::get_speaker_mode() const {
 
 	return speaker_mode;

--- a/drivers/xaudio2/audio_driver_xaudio2.h
+++ b/drivers/xaudio2/audio_driver_xaudio2.h
@@ -97,6 +97,7 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual float get_latency();
 	virtual void lock();

--- a/platform/android/audio_driver_jandroid.cpp
+++ b/platform/android/audio_driver_jandroid.cpp
@@ -159,6 +159,11 @@ int AudioDriverAndroid::get_mix_rate() const {
 	return mix_rate;
 }
 
+int AudioDriverAndroid::get_mix_buffer_size() const {
+
+	return audioBufferFrames;
+}
+
 AudioDriver::SpeakerMode AudioDriverAndroid::get_speaker_mode() const {
 
 	return SPEAKER_MODE_STEREO;
@@ -186,6 +191,13 @@ void AudioDriverAndroid::finish() {
 	}
 
 	active = false;
+}
+
+float AudioDriverAndroid::get_latency() {
+
+	if (mix_rate != 0)
+		return (float)audioBufferFrames / (float)mix_rate;
+	return 0.f;
 }
 
 void AudioDriverAndroid::set_pause(bool p_pause) {

--- a/platform/android/audio_driver_jandroid.h
+++ b/platform/android/audio_driver_jandroid.h
@@ -63,10 +63,13 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
+
+	virtual float get_latency();
 
 	virtual void set_pause(bool p_pause);
 

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -321,6 +321,11 @@ int AudioDriverOpenSL::get_mix_rate() const {
 	return 44100; // hardcoded for Android, as selected by SL_SAMPLINGRATE_44_1
 }
 
+int AudioDriverOpenSL::get_mix_buffer_size() const {
+
+	return buffer_size;
+}
+
 AudioDriver::SpeakerMode AudioDriverOpenSL::get_speaker_mode() const {
 
 	return SPEAKER_MODE_STEREO;
@@ -341,6 +346,11 @@ void AudioDriverOpenSL::unlock() {
 void AudioDriverOpenSL::finish() {
 
 	(*sl)->Destroy(sl);
+}
+
+float AudioDriverOpenSL::get_latency() {
+
+	return (float)buffer_size / 44100.1f; // hardcoded for Android, as selected by SL_SAMPLINGRATE_44_1
 }
 
 void AudioDriverOpenSL::set_pause(bool p_pause) {

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -98,10 +98,13 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
+
+	virtual float get_latency();
 
 	virtual void set_pause(bool p_pause);
 

--- a/platform/haiku/audio_driver_media_kit.cpp
+++ b/platform/haiku/audio_driver_media_kit.cpp
@@ -99,6 +99,11 @@ int AudioDriverMediaKit::get_mix_rate() const {
 	return mix_rate;
 }
 
+int AudioDriverMediaKit::get_mix_buffer_size() const {
+
+	return buffer_size;
+}
+
 AudioDriverMediaKit::SpeakerMode AudioDriverMediaKit::get_speaker_mode() const {
 	return speaker_mode;
 }
@@ -123,6 +128,13 @@ void AudioDriverMediaKit::finish() {
 	if (samples_in) {
 		memdelete_arr(samples_in);
 	};
+}
+
+float AudioDriverMediaKit::get_latency() {
+
+	if (mix_rate != 0)
+		return (float)buffer_size / (float)mix_rate;
+	return 0.f;
 }
 
 AudioDriverMediaKit::AudioDriverMediaKit() {

--- a/platform/haiku/audio_driver_media_kit.h
+++ b/platform/haiku/audio_driver_media_kit.h
@@ -62,10 +62,13 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
+
+	virtual float get_latency();
 
 	AudioDriverMediaKit();
 	~AudioDriverMediaKit();

--- a/platform/javascript/audio_driver_javascript.cpp
+++ b/platform/javascript/audio_driver_javascript.cpp
@@ -173,6 +173,14 @@ int AudioDriverJavaScript::get_mix_rate() const {
 	/* clang-format on */
 }
 
+int AudioDriverJavascript::get_mix_buffer_size() const {
+
+	int channel_count = get_total_channels_by_speaker_mode(get_speaker_mode());
+	if (channel_count != 0)
+		return memarr_len(internal_buffer) / channel_count;
+	return DEFAULT_MIX_BUFFER_SIZE;
+}
+
 AudioDriver::SpeakerMode AudioDriverJavaScript::get_speaker_mode() const {
 
 	/* clang-format off */
@@ -203,6 +211,14 @@ void AudioDriverJavaScript::finish() {
 		internal_buffer = nullptr;
 	}
 	_driver_id = 0;
+}
+
+float AudioDriverjavascript::get_latency() {
+
+	int mix_rate = get_mix_rate();
+	if (mix_rate != 0)
+		return (float)buffer_length / (float)mix_rate;
+	return 0.f;
 }
 
 Error AudioDriverJavaScript::capture_start() {

--- a/platform/javascript/audio_driver_javascript.h
+++ b/platform/javascript/audio_driver_javascript.h
@@ -52,10 +52,13 @@ public:
 	virtual void start();
 	void resume();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
+
+	virtual float get_latency();
 
 	virtual Error capture_start();
 	virtual Error capture_stop();

--- a/servers/audio/audio_driver_dummy.cpp
+++ b/servers/audio/audio_driver_dummy.cpp
@@ -87,6 +87,11 @@ int AudioDriverDummy::get_mix_rate() const {
 	return mix_rate;
 };
 
+int AudioDriverDummy::get_mix_buffer_size() const {
+
+	return DEFAULT_MIX_BUFFER_SIZE;
+}
+
 AudioDriver::SpeakerMode AudioDriverDummy::get_speaker_mode() const {
 
 	return speaker_mode;
@@ -121,6 +126,13 @@ void AudioDriverDummy::finish() {
 	memdelete(thread);
 	thread = nullptr;
 };
+
+float AudioDriverDummy::get_latency() {
+
+	if (mix_rate != 0)
+		return (float)get_mix_buffer_size() / (float)mix_rate;
+	return 0.f;
+}
 
 AudioDriverDummy::AudioDriverDummy() {
 

--- a/servers/audio/audio_driver_dummy.h
+++ b/servers/audio/audio_driver_dummy.h
@@ -63,10 +63,13 @@ public:
 	virtual Error init();
 	virtual void start();
 	virtual int get_mix_rate() const;
+	virtual int get_mix_buffer_size() const;
 	virtual SpeakerMode get_speaker_mode() const;
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
+
+	virtual float get_latency();
 
 	AudioDriverDummy();
 	~AudioDriverDummy();

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -973,7 +973,14 @@ void AudioServer::init() {
 	channel_disable_threshold_db = GLOBAL_DEF_RST("audio/channel_disable_threshold_db", -60.0);
 	channel_disable_frames = float(GLOBAL_DEF_RST("audio/channel_disable_time", 2.0)) * get_mix_rate();
 	ProjectSettings::get_singleton()->set_custom_property_info("audio/channel_disable_time", PropertyInfo(Variant::FLOAT, "audio/channel_disable_time", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"));
-	buffer_size = 1024; //hardcoded for now
+	if (AudioDriver::get_singleton()) {
+		buffer_size = AudioDriver::get_singleton()->get_mix_buffer_size();
+	}
+
+	if (buffer_size < 1) {
+		WARN_PRINT("AudioServer: Invalid mix buffer size given by driver; falling back to " + itos(AudioDriver::DEFAULT_MIX_BUFFER_SIZE));
+		buffer_size = AudioDriver::DEFAULT_MIX_BUFFER_SIZE;
+	}
 
 	init_channels_and_buffers();
 

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -83,6 +83,7 @@ public:
 
 	static const int DEFAULT_MIX_RATE = 44100;
 	static const int DEFAULT_OUTPUT_LATENCY = 15;
+	static constexpr int DEFAULT_MIX_BUFFER_SIZE = (DEFAULT_OUTPUT_LATENCY * DEFAULT_MIX_RATE) / 1000;
 
 	static AudioDriver *get_singleton();
 	void set_singleton();
@@ -92,6 +93,7 @@ public:
 	virtual Error init() = 0;
 	virtual void start() = 0;
 	virtual int get_mix_rate() const = 0;
+	virtual int get_mix_buffer_size() const = 0;
 	virtual SpeakerMode get_speaker_mode() const = 0;
 	virtual Array get_device_list();
 	virtual String get_device();
@@ -106,7 +108,7 @@ public:
 	virtual String capture_get_device() { return "Default"; }
 	virtual Array capture_get_device_list(); // TODO: convert this and get_device_list to PackedStringArray
 
-	virtual float get_latency() { return 0; }
+	virtual float get_latency() = 0;
 
 	SpeakerMode get_speaker_mode_by_total_channels(int p_channels) const;
 	int get_total_channels_by_speaker_mode(SpeakerMode) const;


### PR DESCRIPTION
Fixed [issue #38215](https://github.com/godotengine/godot/issues/38215)

A couple of notes on the changes:
- AudioDriver::get_latency() was made pure virtual (instead of non-pure virtual). I did this because the only audio driver implementing this method was for PulseAudio, and the other 9 drivers used the default implementation (reporting 0 latency). My reasoning is that this is something all audio drivers should be forced to implement for correct behaviour and consistency across platforms. 
- Drivers may still select an actual latency that is different from the audio "output latency" setting, and on many platforms there is no way around this. For example the WASAPI driver currently has no control over it's buffer size due to limitations in WASAPI. Other drivers select the nearest allowed latency to the specified amount. Either way these drivers should report non-0 latency now.
- AudioDriver::get_mix_buffer_size() tells the AudioServer how larger the audio mixer buffers should be. This was implemented in every audio driver based on how many frames they pass to their audio_server_process(..) method so they may synchronize. It was named get_mix_buffer_size instead of get_buffer_size because the mixer _can_ run at a different buffer size if the audio driver would like it to - this could be useful in the future when improving inflexible audio drivers (like WASAPI) to allow for greater latency beyond what the native toolkit can provide.
- I have compiled and tested on Windows and Linux, but all other platforms are currently untested. Any testing would be thoroughly appreciated.
- There's a small conflict between this and [my pr #38210 for bad latency handling in WASAPI](https://github.com/godotengine/godot/pull/38210); if either is merged I'll update the other.
- I need use these changes in Godot 3.2 for a project of mine that requires low-latency audio, so I'll happily put in the work to cherry pick this.  