### PR TITLE
Expose the cell_size affecting VisibilityNotifier2D precision

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1169,6 +1169,9 @@
 		</member>
 		<member name="rendering/vulkan/staging_buffer/texture_upload_region_size_px" type="int" setter="" getter="" default="64">
 		</member>
+		<member name="world/2d/cell_size" type="int" setter="" getter="" default="100">
+			Cell size used for the 2D hash grid that [VisibilityNotifier2D] uses.
+		</member>
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/VisibilityEnabler2D.xml
+++ b/doc/classes/VisibilityEnabler2D.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		The VisibilityEnabler2D will disable [RigidBody2D], [AnimationPlayer], and other nodes when they are not visible. It will only affect nodes with the same root node as the VisibilityEnabler2D, and the root node itself.
-		[b]Note:[/b] VisibilityEnabler2D uses an approximate heuristic for performance reasons. If you need exact visibility checking, use another method such as adding an [Area2D] node as a child of a [Camera2D] node.
+		[b]Note:[/b] For performance reasons, VisibilityEnabler2D uses an approximate heuristic with precision determined by [member ProjectSettings.world/2d/cell_size]. If you need exact visibility checking, use another method such as adding an [Area2D] node as a child of a [Camera2D] node.
 		[b]Note:[/b] VisibilityEnabler2D will not affect nodes added after scene initialization.
 	</description>
 	<tutorials>

--- a/doc/classes/VisibilityNotifier2D.xml
+++ b/doc/classes/VisibilityNotifier2D.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		The VisibilityNotifier2D detects when it is visible on the screen. It also notifies when its bounding rectangle enters or exits the screen or a viewport.
-		[b]Note:[/b] VisibilityNotifier2D uses an approximate heuristic for performance reasons. If you need exact visibility checking, use another method such as adding an [Area2D] node as a child of a [Camera2D] node.
+		[b]Note:[/b] For performance reasons, VisibilityNotifier2D uses an approximate heuristic with precision determined by [member ProjectSettings.world/2d/cell_size]. If you need exact visibility checking, use another method such as adding an [Area2D] node as a child of a [Camera2D] node.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -314,7 +314,7 @@ struct SpatialIndexer2D {
 
 		pass = 0;
 		changed = false;
-		cell_size = 100; //should be configurable with GLOBAL_DEF("") i guess
+		cell_size = GLOBAL_DEF("world/2d/cell_size", 100);
 	}
 };
 


### PR DESCRIPTION
Having the cell size hardcoded means that pixelart games are unable to use VisibilityNotifier2D since their whole screen might be way less than 100 pixels, in which case the visibility notifier would report entering/exiting the screen a few screens away.

Refs #4803.