### PR TITLE
Add set_frame, pause, and oneshot to AnimatedTexture

### DIFF
--- a/doc/classes/AnimatedTexture.xml
+++ b/doc/classes/AnimatedTexture.xml
@@ -61,12 +61,21 @@
 		</method>
 	</methods>
 	<members>
+		<member name="current_frame" type="int" setter="set_current_frame" getter="get_current_frame">
+			Sets the currently visible frame of the texture.
+		</member>
 		<member name="fps" type="float" setter="set_fps" getter="get_fps" default="4.0">
 			Animation speed in frames per second. This value defines the default time interval between two frames of the animation, and thus the overall duration of the animation loop based on the [member frames] property. A value of 0 means no predefined number of frames per second, the animation will play according to each frame's frame delay (see [method set_frame_delay]).
 			For example, an animation with 8 frames, no frame delay and a [code]fps[/code] value of 2 will run for 4 seconds, with each frame lasting 0.5 seconds.
 		</member>
 		<member name="frames" type="int" setter="set_frames" getter="get_frames" default="1">
 			Number of frames to use in the animation. While you can create the frames independently with [method set_frame_texture], you need to set this value for the animation to take new frames into account. The maximum number of frames is [constant MAX_FRAMES].
+		</member>
+		<member name="oneshot" type="bool" setter="set_oneshot" getter="get_oneshot" default="false">
+			If [code]true[/code], the animation will only play once and will not loop back to the first frame after reaching the end. Note that reaching the end will not set [member pause] to [code]true[/code].
+		</member>
+		<member name="pause" type="bool" setter="set_pause" getter="get_pause" default="false">
+			If [code]true[/code], the animation will pause where it currently is (i.e. at [member current_frame]). The animation will continue from where it was paused when changing this property to [code]false[/code]. 
 		</member>
 	</members>
 	<constants>

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1692,15 +1692,20 @@ void AnimatedTexture::_update_proxy() {
 	}
 
 	int iter_max = frame_count;
-	while (iter_max) {
+	while (iter_max && !pause) {
 		float frame_limit = limit + frames[current_frame].delay_sec;
 
 		if (time > frame_limit) {
 			current_frame++;
 			if (current_frame >= frame_count) {
-				current_frame = 0;
+				if (oneshot) {
+					current_frame = frame_count - 1;
+				} else {
+					current_frame = 0;
+				}
 			}
 			time -= frame_limit;
+			_change_notify("current_frame");
 		} else {
 			break;
 		}
@@ -1721,6 +1726,33 @@ void AnimatedTexture::set_frames(int p_frames) {
 }
 int AnimatedTexture::get_frames() const {
 	return frame_count;
+}
+
+void AnimatedTexture::set_current_frame(int p_frame) {
+	ERR_FAIL_COND(p_frame < 0 || p_frame >= frame_count);
+
+	RWLockWrite r(rw_lock);
+
+	current_frame = p_frame;
+}
+int AnimatedTexture::get_current_frame() const {
+	return current_frame;
+}
+
+void AnimatedTexture::set_pause(bool p_pause) {
+	RWLockWrite r(rw_lock);
+	pause = p_pause;
+}
+bool AnimatedTexture::get_pause() const {
+	return pause;
+}
+
+void AnimatedTexture::set_oneshot(bool p_oneshot) {
+	RWLockWrite r(rw_lock);
+	oneshot = p_oneshot;
+}
+bool AnimatedTexture::get_oneshot() const {
+	return oneshot;
 }
 
 void AnimatedTexture::set_frame_texture(int p_frame, const Ref<Texture2D> &p_texture) {
@@ -1833,6 +1865,15 @@ void AnimatedTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_frames", "frames"), &AnimatedTexture::set_frames);
 	ClassDB::bind_method(D_METHOD("get_frames"), &AnimatedTexture::get_frames);
 
+	ClassDB::bind_method(D_METHOD("set_current_frame", "frame"), &AnimatedTexture::set_current_frame);
+	ClassDB::bind_method(D_METHOD("get_current_frame"), &AnimatedTexture::get_current_frame);
+
+	ClassDB::bind_method(D_METHOD("set_pause", "pause"), &AnimatedTexture::set_pause);
+	ClassDB::bind_method(D_METHOD("get_pause"), &AnimatedTexture::get_pause);
+
+	ClassDB::bind_method(D_METHOD("set_oneshot", "oneshot"), &AnimatedTexture::set_oneshot);
+	ClassDB::bind_method(D_METHOD("get_oneshot"), &AnimatedTexture::get_oneshot);
+
 	ClassDB::bind_method(D_METHOD("set_fps", "fps"), &AnimatedTexture::set_fps);
 	ClassDB::bind_method(D_METHOD("get_fps"), &AnimatedTexture::get_fps);
 
@@ -1843,6 +1884,9 @@ void AnimatedTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_frame_delay", "frame"), &AnimatedTexture::get_frame_delay);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "frames", PROPERTY_HINT_RANGE, "1," + itos(MAX_FRAMES), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_frames", "get_frames");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_frame", PROPERTY_HINT_NONE, "", 0), "set_current_frame", "get_current_frame");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pause"), "set_pause", "get_pause");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "oneshot"), "set_oneshot", "get_oneshot");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fps", PROPERTY_HINT_RANGE, "0,1024,0.1"), "set_fps", "get_fps");
 
 	for (int i = 0; i < MAX_FRAMES; i++) {
@@ -1864,6 +1908,8 @@ AnimatedTexture::AnimatedTexture() {
 	fps = 4;
 	prev_ticks = 0;
 	current_frame = 0;
+	pause = false;
+	oneshot = false;
 	RenderingServer::get_singleton()->connect("frame_pre_draw", callable_mp(this, &AnimatedTexture::_update_proxy));
 
 #ifndef NO_THREADS

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -567,7 +567,8 @@ private:
 	Frame frames[MAX_FRAMES];
 	int frame_count;
 	int current_frame;
-
+	bool pause;
+	bool oneshot;
 	float fps;
 
 	float time;
@@ -583,6 +584,15 @@ protected:
 public:
 	void set_frames(int p_frames);
 	int get_frames() const;
+
+	void set_current_frame(int p_frame);
+	int get_current_frame() const;
+
+	void set_pause(bool p_pause);
+	bool get_pause() const;
+
+	void set_oneshot(bool p_oneshot);
+	bool get_oneshot() const;
 
 	void set_frame_texture(int p_frame, const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_frame_texture(int p_frame) const;


### PR DESCRIPTION
**Pull requested for godot-proposals** [#686](https://github.com/godotengine/godot-proposals/issues/686) 
I think the ability to control animations in AnimatedTexture, possibly via AnimationPlayer or other things, is a nice feature, it doesn't break any compatibility, and is very easy to write as well. I don't think it can possibly conflict with anything, really. 
I needed this for my project, and maybe there are others who need it as well, so I gave it some polishing and created this PR.