### PR TITLE
Fix leaked objects when game ends with yields in progress

### DIFF
--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -293,13 +293,15 @@ private:
 public:
 	struct CallState {
 
+		ObjectID script_id;
+#ifdef DEBUG_ENABLED
+		String script_path;
+#endif
 		ObjectID instance_id;
-		GDScriptInstance *instance;
 		Vector<uint8_t> stack;
 		int stack_size;
 		Variant self;
 		uint32_t alloca_size;
-		Ref<GDScript> script;
 		int ip;
 		int line;
 		int defarg;


### PR DESCRIPTION
The rationale of this patch is that there's no actual need for `GDScriptFunctionState` to hold a reference to the script, since the `GDScriptInstance` already has one.

This clears the circular reference that was between both, preventing them to be released at exit.

Fixes #37188.

~~**UPDATE:** Some testing has arised that this still needs one fix.~~

**UPDATE:**
The problem found during testing has been fixed. In the case of static methods there's no class instance to hold a reference to the script, so in that case the instance id of the script must be checked. Given that instance id checks are very fast in _master_, this PR just goes back to the approach that existed some time ago: check both. 
For 3.2 the story is a bit different, so in the version of this PR for it, only either the script id or the instance id is checked, depending on whether it's a static method or not, respectively. I'd say that's the sweet spot for 3.2.

---
**This code is generously donated by IMVU.**