### PR TITLE
Add CONNECT_DISCARD_EXTRA connection flag

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1190,6 +1190,25 @@ Error Object::emit_signal(const StringName &p_name, const Variant **p_args, int 
 			argc = bind_mem.size();
 		}
 
+		if (c.flags & CONNECT_DISCARD_EXTRA) {
+			List<MethodInfo> object_methods;
+			c.callable.get_object()->get_method_list(&object_methods);
+			int method_arg_count = -1;
+			for (List<MethodInfo>::Element *E = object_methods.front(); E; E = E->next()) {
+				if (E->get().name == c.callable.get_method()) {
+					method_arg_count = E->get().arguments.size();
+					break;
+				}
+			}
+
+			if (method_arg_count > -1) {
+				if (argc > method_arg_count) {
+					bind_mem.resize(method_arg_count);
+					argc = method_arg_count;
+				}
+			}
+		}
+
 		if (c.flags & CONNECT_DEFERRED) {
 			MessageQueue::get_singleton()->push_callable(c.callable, args, argc, true);
 		} else {
@@ -1762,6 +1781,7 @@ void Object::_bind_methods() {
 	BIND_ENUM_CONSTANT(CONNECT_PERSIST);
 	BIND_ENUM_CONSTANT(CONNECT_ONESHOT);
 	BIND_ENUM_CONSTANT(CONNECT_REFERENCE_COUNTED);
+	BIND_ENUM_CONSTANT(CONNECT_DISCARD_EXTRA);
 }
 
 void Object::call_deferred(const StringName &p_method, VARIANT_ARG_DECLARE) {

--- a/core/object.h
+++ b/core/object.h
@@ -408,6 +408,7 @@ public:
 		CONNECT_PERSIST = 2, // hint for scene to save this connection
 		CONNECT_ONESHOT = 4,
 		CONNECT_REFERENCE_COUNTED = 8,
+		CONNECT_DISCARD_EXTRA = 16,
 	};
 
 	struct Connection {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/762

Basically the flag makes any excess argument discarded, so that "Too many arguments" error doesn't appear. It works, you can test it with this code:
```
func _ready() -> void:
	$AnimationPlayer.animation_finished.connect(queue_free, [], CONNECT_DISCARD_EXTRA)
```
`queue_free()` isn't called without `CONNECT_DISCARD_EXTRA`.

HOWEVER, the "Too many arguments" error still appears despite successful call, so I have to fix it. Also the flag isn't available in connection dialog yet.