### PR TITLE
Rename InputFilter back to Input

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -33,7 +33,7 @@
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "core/script_language.h"
@@ -659,9 +659,9 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 
 	servers_profiler->skip_profile_frame = true; // Avoid frame time spike in debug.
 
-	InputFilter::MouseMode mouse_mode = InputFilter::get_singleton()->get_mouse_mode();
-	if (mouse_mode != InputFilter::MOUSE_MODE_VISIBLE)
-		InputFilter::get_singleton()->set_mouse_mode(InputFilter::MOUSE_MODE_VISIBLE);
+	Input::MouseMode mouse_mode = Input::get_singleton()->get_mouse_mode();
+	if (mouse_mode != Input::MOUSE_MODE_VISIBLE)
+		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
 
 	uint64_t loop_begin_usec = 0;
 	uint64_t loop_time_sec = 0;
@@ -779,8 +779,8 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 
 	send_message("debug_exit", Array());
 
-	if (mouse_mode != InputFilter::MOUSE_MODE_VISIBLE)
-		InputFilter::get_singleton()->set_mouse_mode(mouse_mode);
+	if (mouse_mode != Input::MOUSE_MODE_VISIBLE)
+		Input::get_singleton()->set_mouse_mode(mouse_mode);
 }
 
 void RemoteDebugger::poll_events(bool p_is_idle) {

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  input_filter.cpp                                                     */
+/*  input.cpp                                                            */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "input_filter.h"
+#include "input.h"
 
 #include "core/input/default_controller_mappings.h"
 #include "core/input/input_map.h"
@@ -39,71 +39,71 @@
 #include "editor/editor_settings.h"
 #endif
 
-InputFilter *InputFilter::singleton = nullptr;
+Input *Input::singleton = nullptr;
 
-void (*InputFilter::set_mouse_mode_func)(InputFilter::MouseMode) = nullptr;
-InputFilter::MouseMode (*InputFilter::get_mouse_mode_func)() = nullptr;
-void (*InputFilter::warp_mouse_func)(const Vector2 &p_to_pos) = nullptr;
-InputFilter::CursorShape (*InputFilter::get_current_cursor_shape_func)() = nullptr;
-void (*InputFilter::set_custom_mouse_cursor_func)(const RES &, InputFilter::CursorShape, const Vector2 &) = nullptr;
+void (*Input::set_mouse_mode_func)(Input::MouseMode) = nullptr;
+Input::MouseMode (*Input::get_mouse_mode_func)() = nullptr;
+void (*Input::warp_mouse_func)(const Vector2 &p_to_pos) = nullptr;
+Input::CursorShape (*Input::get_current_cursor_shape_func)() = nullptr;
+void (*Input::set_custom_mouse_cursor_func)(const RES &, Input::CursorShape, const Vector2 &) = nullptr;
 
-InputFilter *InputFilter::get_singleton() {
+Input *Input::get_singleton() {
 
 	return singleton;
 }
 
-void InputFilter::set_mouse_mode(MouseMode p_mode) {
+void Input::set_mouse_mode(MouseMode p_mode) {
 	ERR_FAIL_INDEX((int)p_mode, 4);
 	set_mouse_mode_func(p_mode);
 }
 
-InputFilter::MouseMode InputFilter::get_mouse_mode() const {
+Input::MouseMode Input::get_mouse_mode() const {
 
 	return get_mouse_mode_func();
 }
 
-void InputFilter::_bind_methods() {
+void Input::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("is_key_pressed", "keycode"), &InputFilter::is_key_pressed);
-	ClassDB::bind_method(D_METHOD("is_mouse_button_pressed", "button"), &InputFilter::is_mouse_button_pressed);
-	ClassDB::bind_method(D_METHOD("is_joy_button_pressed", "device", "button"), &InputFilter::is_joy_button_pressed);
-	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &InputFilter::is_action_pressed);
-	ClassDB::bind_method(D_METHOD("is_action_just_pressed", "action"), &InputFilter::is_action_just_pressed);
-	ClassDB::bind_method(D_METHOD("is_action_just_released", "action"), &InputFilter::is_action_just_released);
-	ClassDB::bind_method(D_METHOD("get_action_strength", "action"), &InputFilter::get_action_strength);
-	ClassDB::bind_method(D_METHOD("add_joy_mapping", "mapping", "update_existing"), &InputFilter::add_joy_mapping, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("remove_joy_mapping", "guid"), &InputFilter::remove_joy_mapping);
-	ClassDB::bind_method(D_METHOD("joy_connection_changed", "device", "connected", "name", "guid"), &InputFilter::joy_connection_changed);
-	ClassDB::bind_method(D_METHOD("is_joy_known", "device"), &InputFilter::is_joy_known);
-	ClassDB::bind_method(D_METHOD("get_joy_axis", "device", "axis"), &InputFilter::get_joy_axis);
-	ClassDB::bind_method(D_METHOD("get_joy_name", "device"), &InputFilter::get_joy_name);
-	ClassDB::bind_method(D_METHOD("get_joy_guid", "device"), &InputFilter::get_joy_guid);
-	ClassDB::bind_method(D_METHOD("get_connected_joypads"), &InputFilter::get_connected_joypads);
-	ClassDB::bind_method(D_METHOD("get_joy_vibration_strength", "device"), &InputFilter::get_joy_vibration_strength);
-	ClassDB::bind_method(D_METHOD("get_joy_vibration_duration", "device"), &InputFilter::get_joy_vibration_duration);
-	ClassDB::bind_method(D_METHOD("get_joy_button_string", "button_index"), &InputFilter::get_joy_button_string);
-	ClassDB::bind_method(D_METHOD("get_joy_button_index_from_string", "button"), &InputFilter::get_joy_button_index_from_string);
-	ClassDB::bind_method(D_METHOD("get_joy_axis_string", "axis_index"), &InputFilter::get_joy_axis_string);
-	ClassDB::bind_method(D_METHOD("get_joy_axis_index_from_string", "axis"), &InputFilter::get_joy_axis_index_from_string);
-	ClassDB::bind_method(D_METHOD("start_joy_vibration", "device", "weak_magnitude", "strong_magnitude", "duration"), &InputFilter::start_joy_vibration, DEFVAL(0));
-	ClassDB::bind_method(D_METHOD("stop_joy_vibration", "device"), &InputFilter::stop_joy_vibration);
-	ClassDB::bind_method(D_METHOD("vibrate_handheld", "duration_ms"), &InputFilter::vibrate_handheld, DEFVAL(500));
-	ClassDB::bind_method(D_METHOD("get_gravity"), &InputFilter::get_gravity);
-	ClassDB::bind_method(D_METHOD("get_accelerometer"), &InputFilter::get_accelerometer);
-	ClassDB::bind_method(D_METHOD("get_magnetometer"), &InputFilter::get_magnetometer);
-	ClassDB::bind_method(D_METHOD("get_gyroscope"), &InputFilter::get_gyroscope);
-	ClassDB::bind_method(D_METHOD("get_last_mouse_speed"), &InputFilter::get_last_mouse_speed);
-	ClassDB::bind_method(D_METHOD("get_mouse_button_mask"), &InputFilter::get_mouse_button_mask);
-	ClassDB::bind_method(D_METHOD("set_mouse_mode", "mode"), &InputFilter::set_mouse_mode);
-	ClassDB::bind_method(D_METHOD("get_mouse_mode"), &InputFilter::get_mouse_mode);
-	ClassDB::bind_method(D_METHOD("warp_mouse_position", "to"), &InputFilter::warp_mouse_position);
-	ClassDB::bind_method(D_METHOD("action_press", "action", "strength"), &InputFilter::action_press, DEFVAL(1.f));
-	ClassDB::bind_method(D_METHOD("action_release", "action"), &InputFilter::action_release);
-	ClassDB::bind_method(D_METHOD("set_default_cursor_shape", "shape"), &InputFilter::set_default_cursor_shape, DEFVAL(CURSOR_ARROW));
-	ClassDB::bind_method(D_METHOD("get_current_cursor_shape"), &InputFilter::get_current_cursor_shape);
-	ClassDB::bind_method(D_METHOD("set_custom_mouse_cursor", "image", "shape", "hotspot"), &InputFilter::set_custom_mouse_cursor, DEFVAL(CURSOR_ARROW), DEFVAL(Vector2()));
-	ClassDB::bind_method(D_METHOD("parse_input_event", "event"), &InputFilter::parse_input_event);
-	ClassDB::bind_method(D_METHOD("set_use_accumulated_input", "enable"), &InputFilter::set_use_accumulated_input);
+	ClassDB::bind_method(D_METHOD("is_key_pressed", "keycode"), &Input::is_key_pressed);
+	ClassDB::bind_method(D_METHOD("is_mouse_button_pressed", "button"), &Input::is_mouse_button_pressed);
+	ClassDB::bind_method(D_METHOD("is_joy_button_pressed", "device", "button"), &Input::is_joy_button_pressed);
+	ClassDB::bind_method(D_METHOD("is_action_pressed", "action"), &Input::is_action_pressed);
+	ClassDB::bind_method(D_METHOD("is_action_just_pressed", "action"), &Input::is_action_just_pressed);
+	ClassDB::bind_method(D_METHOD("is_action_just_released", "action"), &Input::is_action_just_released);
+	ClassDB::bind_method(D_METHOD("get_action_strength", "action"), &Input::get_action_strength);
+	ClassDB::bind_method(D_METHOD("add_joy_mapping", "mapping", "update_existing"), &Input::add_joy_mapping, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("remove_joy_mapping", "guid"), &Input::remove_joy_mapping);
+	ClassDB::bind_method(D_METHOD("joy_connection_changed", "device", "connected", "name", "guid"), &Input::joy_connection_changed);
+	ClassDB::bind_method(D_METHOD("is_joy_known", "device"), &Input::is_joy_known);
+	ClassDB::bind_method(D_METHOD("get_joy_axis", "device", "axis"), &Input::get_joy_axis);
+	ClassDB::bind_method(D_METHOD("get_joy_name", "device"), &Input::get_joy_name);
+	ClassDB::bind_method(D_METHOD("get_joy_guid", "device"), &Input::get_joy_guid);
+	ClassDB::bind_method(D_METHOD("get_connected_joypads"), &Input::get_connected_joypads);
+	ClassDB::bind_method(D_METHOD("get_joy_vibration_strength", "device"), &Input::get_joy_vibration_strength);
+	ClassDB::bind_method(D_METHOD("get_joy_vibration_duration", "device"), &Input::get_joy_vibration_duration);
+	ClassDB::bind_method(D_METHOD("get_joy_button_string", "button_index"), &Input::get_joy_button_string);
+	ClassDB::bind_method(D_METHOD("get_joy_button_index_from_string", "button"), &Input::get_joy_button_index_from_string);
+	ClassDB::bind_method(D_METHOD("get_joy_axis_string", "axis_index"), &Input::get_joy_axis_string);
+	ClassDB::bind_method(D_METHOD("get_joy_axis_index_from_string", "axis"), &Input::get_joy_axis_index_from_string);
+	ClassDB::bind_method(D_METHOD("start_joy_vibration", "device", "weak_magnitude", "strong_magnitude", "duration"), &Input::start_joy_vibration, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("stop_joy_vibration", "device"), &Input::stop_joy_vibration);
+	ClassDB::bind_method(D_METHOD("vibrate_handheld", "duration_ms"), &Input::vibrate_handheld, DEFVAL(500));
+	ClassDB::bind_method(D_METHOD("get_gravity"), &Input::get_gravity);
+	ClassDB::bind_method(D_METHOD("get_accelerometer"), &Input::get_accelerometer);
+	ClassDB::bind_method(D_METHOD("get_magnetometer"), &Input::get_magnetometer);
+	ClassDB::bind_method(D_METHOD("get_gyroscope"), &Input::get_gyroscope);
+	ClassDB::bind_method(D_METHOD("get_last_mouse_speed"), &Input::get_last_mouse_speed);
+	ClassDB::bind_method(D_METHOD("get_mouse_button_mask"), &Input::get_mouse_button_mask);
+	ClassDB::bind_method(D_METHOD("set_mouse_mode", "mode"), &Input::set_mouse_mode);
+	ClassDB::bind_method(D_METHOD("get_mouse_mode"), &Input::get_mouse_mode);
+	ClassDB::bind_method(D_METHOD("warp_mouse_position", "to"), &Input::warp_mouse_position);
+	ClassDB::bind_method(D_METHOD("action_press", "action", "strength"), &Input::action_press, DEFVAL(1.f));
+	ClassDB::bind_method(D_METHOD("action_release", "action"), &Input::action_release);
+	ClassDB::bind_method(D_METHOD("set_default_cursor_shape", "shape"), &Input::set_default_cursor_shape, DEFVAL(CURSOR_ARROW));
+	ClassDB::bind_method(D_METHOD("get_current_cursor_shape"), &Input::get_current_cursor_shape);
+	ClassDB::bind_method(D_METHOD("set_custom_mouse_cursor", "image", "shape", "hotspot"), &Input::set_custom_mouse_cursor, DEFVAL(CURSOR_ARROW), DEFVAL(Vector2()));
+	ClassDB::bind_method(D_METHOD("parse_input_event", "event"), &Input::parse_input_event);
+	ClassDB::bind_method(D_METHOD("set_use_accumulated_input", "enable"), &Input::set_use_accumulated_input);
 
 	BIND_ENUM_CONSTANT(MOUSE_MODE_VISIBLE);
 	BIND_ENUM_CONSTANT(MOUSE_MODE_HIDDEN);
@@ -131,7 +131,7 @@ void InputFilter::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("joy_connection_changed", PropertyInfo(Variant::INT, "device"), PropertyInfo(Variant::BOOL, "connected")));
 }
 
-void InputFilter::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+void Input::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 #ifdef TOOLS_ENABLED
 
 	const String quote_style = EDITOR_DEF("text_editor/completion/use_single_quotes", 0) ? "'" : "\"";
@@ -155,7 +155,7 @@ void InputFilter::get_argument_options(const StringName &p_function, int p_idx, 
 #endif
 }
 
-void InputFilter::SpeedTrack::update(const Vector2 &p_delta_p) {
+void Input::SpeedTrack::update(const Vector2 &p_delta_p) {
 
 	uint64_t tick = OS::get_singleton()->get_ticks_usec();
 	uint32_t tdiff = tick - last_tick;
@@ -179,26 +179,26 @@ void InputFilter::SpeedTrack::update(const Vector2 &p_delta_p) {
 	}
 }
 
-void InputFilter::SpeedTrack::reset() {
+void Input::SpeedTrack::reset() {
 	last_tick = OS::get_singleton()->get_ticks_usec();
 	speed = Vector2();
 	accum_t = 0;
 }
 
-InputFilter::SpeedTrack::SpeedTrack() {
+Input::SpeedTrack::SpeedTrack() {
 
 	min_ref_frame = 0.1;
 	max_ref_frame = 0.3;
 	reset();
 }
 
-bool InputFilter::is_key_pressed(int p_keycode) const {
+bool Input::is_key_pressed(int p_keycode) const {
 
 	_THREAD_SAFE_METHOD_
 	return keys_pressed.has(p_keycode);
 }
 
-bool InputFilter::is_mouse_button_pressed(int p_button) const {
+bool Input::is_mouse_button_pressed(int p_button) const {
 
 	_THREAD_SAFE_METHOD_
 	return (mouse_button_mask & (1 << (p_button - 1))) != 0;
@@ -209,18 +209,18 @@ static int _combine_device(int p_value, int p_device) {
 	return p_value | (p_device << 20);
 }
 
-bool InputFilter::is_joy_button_pressed(int p_device, int p_button) const {
+bool Input::is_joy_button_pressed(int p_device, int p_button) const {
 
 	_THREAD_SAFE_METHOD_
 	return joy_buttons_pressed.has(_combine_device(p_button, p_device));
 }
 
-bool InputFilter::is_action_pressed(const StringName &p_action) const {
+bool Input::is_action_pressed(const StringName &p_action) const {
 
 	return action_state.has(p_action) && action_state[p_action].pressed;
 }
 
-bool InputFilter::is_action_just_pressed(const StringName &p_action) const {
+bool Input::is_action_just_pressed(const StringName &p_action) const {
 
 	const Map<StringName, Action>::Element *E = action_state.find(p_action);
 	if (!E)
@@ -233,7 +233,7 @@ bool InputFilter::is_action_just_pressed(const StringName &p_action) const {
 	}
 }
 
-bool InputFilter::is_action_just_released(const StringName &p_action) const {
+bool Input::is_action_just_released(const StringName &p_action) const {
 
 	const Map<StringName, Action>::Element *E = action_state.find(p_action);
 	if (!E)
@@ -246,7 +246,7 @@ bool InputFilter::is_action_just_released(const StringName &p_action) const {
 	}
 }
 
-float InputFilter::get_action_strength(const StringName &p_action) const {
+float Input::get_action_strength(const StringName &p_action) const {
 	const Map<StringName, Action>::Element *E = action_state.find(p_action);
 	if (!E)
 		return 0.0f;
@@ -254,7 +254,7 @@ float InputFilter::get_action_strength(const StringName &p_action) const {
 	return E->get().strength;
 }
 
-float InputFilter::get_joy_axis(int p_device, int p_axis) const {
+float Input::get_joy_axis(int p_device, int p_axis) const {
 
 	_THREAD_SAFE_METHOD_
 	int c = _combine_device(p_axis, p_device);
@@ -265,13 +265,13 @@ float InputFilter::get_joy_axis(int p_device, int p_axis) const {
 	}
 }
 
-String InputFilter::get_joy_name(int p_idx) {
+String Input::get_joy_name(int p_idx) {
 
 	_THREAD_SAFE_METHOD_
 	return joy_names[p_idx].name;
 };
 
-Vector2 InputFilter::get_joy_vibration_strength(int p_device) {
+Vector2 Input::get_joy_vibration_strength(int p_device) {
 	if (joy_vibration.has(p_device)) {
 		return Vector2(joy_vibration[p_device].weak_magnitude, joy_vibration[p_device].strong_magnitude);
 	} else {
@@ -279,7 +279,7 @@ Vector2 InputFilter::get_joy_vibration_strength(int p_device) {
 	}
 }
 
-uint64_t InputFilter::get_joy_vibration_timestamp(int p_device) {
+uint64_t Input::get_joy_vibration_timestamp(int p_device) {
 	if (joy_vibration.has(p_device)) {
 		return joy_vibration[p_device].timestamp;
 	} else {
@@ -287,7 +287,7 @@ uint64_t InputFilter::get_joy_vibration_timestamp(int p_device) {
 	}
 }
 
-float InputFilter::get_joy_vibration_duration(int p_device) {
+float Input::get_joy_vibration_duration(int p_device) {
 	if (joy_vibration.has(p_device)) {
 		return joy_vibration[p_device].duration;
 	} else {
@@ -307,7 +307,7 @@ static String _hex_str(uint8_t p_byte) {
 	return ret;
 };
 
-void InputFilter::joy_connection_changed(int p_idx, bool p_connected, String p_name, String p_guid) {
+void Input::joy_connection_changed(int p_idx, bool p_connected, String p_name, String p_guid) {
 
 	_THREAD_SAFE_METHOD_
 	Joypad js;
@@ -349,36 +349,36 @@ void InputFilter::joy_connection_changed(int p_idx, bool p_connected, String p_n
 	emit_signal("joy_connection_changed", p_idx, p_connected);
 };
 
-Vector3 InputFilter::get_gravity() const {
+Vector3 Input::get_gravity() const {
 
 	_THREAD_SAFE_METHOD_
 	return gravity;
 }
 
-Vector3 InputFilter::get_accelerometer() const {
+Vector3 Input::get_accelerometer() const {
 
 	_THREAD_SAFE_METHOD_
 	return accelerometer;
 }
 
-Vector3 InputFilter::get_magnetometer() const {
+Vector3 Input::get_magnetometer() const {
 
 	_THREAD_SAFE_METHOD_
 	return magnetometer;
 }
 
-Vector3 InputFilter::get_gyroscope() const {
+Vector3 Input::get_gyroscope() const {
 
 	_THREAD_SAFE_METHOD_
 	return gyroscope;
 }
 
-void InputFilter::parse_input_event(const Ref<InputEvent> &p_event) {
+void Input::parse_input_event(const Ref<InputEvent> &p_event) {
 
 	_parse_input_event_impl(p_event, false);
 }
 
-void InputFilter::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_emulated) {
+void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_emulated) {
 
 	// Notes on mouse-touch emulation:
 	// - Emulated mouse events are parsed, that is, re-routed to this method, so they make the same effects
@@ -561,14 +561,14 @@ void InputFilter::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p
 		event_dispatch_function(p_event);
 }
 
-void InputFilter::set_joy_axis(int p_device, int p_axis, float p_value) {
+void Input::set_joy_axis(int p_device, int p_axis, float p_value) {
 
 	_THREAD_SAFE_METHOD_
 	int c = _combine_device(p_axis, p_device);
 	_joy_axis[c] = p_value;
 }
 
-void InputFilter::start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration) {
+void Input::start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration) {
 	_THREAD_SAFE_METHOD_
 	if (p_weak_magnitude < 0.f || p_weak_magnitude > 1.f || p_strong_magnitude < 0.f || p_strong_magnitude > 1.f) {
 		return;
@@ -581,7 +581,7 @@ void InputFilter::start_joy_vibration(int p_device, float p_weak_magnitude, floa
 	joy_vibration[p_device] = vibration;
 }
 
-void InputFilter::stop_joy_vibration(int p_device) {
+void Input::stop_joy_vibration(int p_device) {
 	_THREAD_SAFE_METHOD_
 	VibrationInfo vibration;
 	vibration.weak_magnitude = 0;
@@ -591,63 +591,63 @@ void InputFilter::stop_joy_vibration(int p_device) {
 	joy_vibration[p_device] = vibration;
 }
 
-void InputFilter::vibrate_handheld(int p_duration_ms) {
+void Input::vibrate_handheld(int p_duration_ms) {
 	OS::get_singleton()->vibrate_handheld(p_duration_ms);
 }
 
-void InputFilter::set_gravity(const Vector3 &p_gravity) {
+void Input::set_gravity(const Vector3 &p_gravity) {
 
 	_THREAD_SAFE_METHOD_
 
 	gravity = p_gravity;
 }
 
-void InputFilter::set_accelerometer(const Vector3 &p_accel) {
+void Input::set_accelerometer(const Vector3 &p_accel) {
 
 	_THREAD_SAFE_METHOD_
 
 	accelerometer = p_accel;
 }
 
-void InputFilter::set_magnetometer(const Vector3 &p_magnetometer) {
+void Input::set_magnetometer(const Vector3 &p_magnetometer) {
 
 	_THREAD_SAFE_METHOD_
 
 	magnetometer = p_magnetometer;
 }
 
-void InputFilter::set_gyroscope(const Vector3 &p_gyroscope) {
+void Input::set_gyroscope(const Vector3 &p_gyroscope) {
 
 	_THREAD_SAFE_METHOD_
 
 	gyroscope = p_gyroscope;
 }
 
-void InputFilter::set_mouse_position(const Point2 &p_posf) {
+void Input::set_mouse_position(const Point2 &p_posf) {
 
 	mouse_speed_track.update(p_posf - mouse_pos);
 	mouse_pos = p_posf;
 }
 
-Point2 InputFilter::get_mouse_position() const {
+Point2 Input::get_mouse_position() const {
 
 	return mouse_pos;
 }
-Point2 InputFilter::get_last_mouse_speed() const {
+Point2 Input::get_last_mouse_speed() const {
 
 	return mouse_speed_track.speed;
 }
 
-int InputFilter::get_mouse_button_mask() const {
+int Input::get_mouse_button_mask() const {
 
 	return mouse_button_mask; // do not trust OS implementation, should remove it - OS::get_singleton()->get_mouse_button_state();
 }
 
-void InputFilter::warp_mouse_position(const Vector2 &p_to) {
+void Input::warp_mouse_position(const Vector2 &p_to) {
 	warp_mouse_func(p_to);
 }
 
-Point2i InputFilter::warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect) {
+Point2i Input::warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect) {
 
 	// The relative distance reported for the next event after a warp is in the boundaries of the
 	// size of the rect on that axis, but it may be greater, in which case there's not problem as fmod()
@@ -673,10 +673,10 @@ Point2i InputFilter::warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motio
 	return rel_warped;
 }
 
-void InputFilter::iteration(float p_step) {
+void Input::iteration(float p_step) {
 }
 
-void InputFilter::action_press(const StringName &p_action, float p_strength) {
+void Input::action_press(const StringName &p_action, float p_strength) {
 
 	Action action;
 
@@ -688,7 +688,7 @@ void InputFilter::action_press(const StringName &p_action, float p_strength) {
 	action_state[p_action] = action;
 }
 
-void InputFilter::action_release(const StringName &p_action) {
+void Input::action_release(const StringName &p_action) {
 
 	Action action;
 
@@ -700,19 +700,19 @@ void InputFilter::action_release(const StringName &p_action) {
 	action_state[p_action] = action;
 }
 
-void InputFilter::set_emulate_touch_from_mouse(bool p_emulate) {
+void Input::set_emulate_touch_from_mouse(bool p_emulate) {
 
 	emulate_touch_from_mouse = p_emulate;
 }
 
-bool InputFilter::is_emulating_touch_from_mouse() const {
+bool Input::is_emulating_touch_from_mouse() const {
 
 	return emulate_touch_from_mouse;
 }
 
 // Calling this whenever the game window is focused helps unstucking the "touch mouse"
 // if the OS or its abstraction class hasn't properly reported that touch pointers raised
-void InputFilter::ensure_touch_mouse_raised() {
+void Input::ensure_touch_mouse_raised() {
 
 	if (mouse_from_touch_index != -1) {
 		mouse_from_touch_index = -1;
@@ -731,22 +731,22 @@ void InputFilter::ensure_touch_mouse_raised() {
 	}
 }
 
-void InputFilter::set_emulate_mouse_from_touch(bool p_emulate) {
+void Input::set_emulate_mouse_from_touch(bool p_emulate) {
 
 	emulate_mouse_from_touch = p_emulate;
 }
 
-bool InputFilter::is_emulating_mouse_from_touch() const {
+bool Input::is_emulating_mouse_from_touch() const {
 
 	return emulate_mouse_from_touch;
 }
 
-InputFilter::CursorShape InputFilter::get_default_cursor_shape() const {
+Input::CursorShape Input::get_default_cursor_shape() const {
 
 	return default_shape;
 }
 
-void InputFilter::set_default_cursor_shape(CursorShape p_shape) {
+void Input::set_default_cursor_shape(CursorShape p_shape) {
 
 	if (default_shape == p_shape)
 		return;
@@ -761,19 +761,19 @@ void InputFilter::set_default_cursor_shape(CursorShape p_shape) {
 	parse_input_event(mm);
 }
 
-InputFilter::CursorShape InputFilter::get_current_cursor_shape() const {
+Input::CursorShape Input::get_current_cursor_shape() const {
 
 	return get_current_cursor_shape_func();
 }
 
-void InputFilter::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
+void Input::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
 	if (Engine::get_singleton()->is_editor_hint())
 		return;
 
 	set_custom_mouse_cursor_func(p_cursor, p_shape, p_hotspot);
 }
 
-void InputFilter::accumulate_input_event(const Ref<InputEvent> &p_event) {
+void Input::accumulate_input_event(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	if (!use_accumulated_input) {
@@ -786,7 +786,7 @@ void InputFilter::accumulate_input_event(const Ref<InputEvent> &p_event) {
 
 	accumulated_events.push_back(p_event);
 }
-void InputFilter::flush_accumulated_events() {
+void Input::flush_accumulated_events() {
 
 	while (accumulated_events.front()) {
 		parse_input_event(accumulated_events.front()->get());
@@ -794,12 +794,12 @@ void InputFilter::flush_accumulated_events() {
 	}
 }
 
-void InputFilter::set_use_accumulated_input(bool p_enable) {
+void Input::set_use_accumulated_input(bool p_enable) {
 
 	use_accumulated_input = p_enable;
 }
 
-void InputFilter::release_pressed_events() {
+void Input::release_pressed_events() {
 
 	flush_accumulated_events(); // this is needed to release actions strengths
 
@@ -807,17 +807,17 @@ void InputFilter::release_pressed_events() {
 	joy_buttons_pressed.clear();
 	_joy_axis.clear();
 
-	for (Map<StringName, InputFilter::Action>::Element *E = action_state.front(); E; E = E->next()) {
+	for (Map<StringName, Input::Action>::Element *E = action_state.front(); E; E = E->next()) {
 		if (E->get().pressed)
 			action_release(E->key());
 	}
 }
 
-void InputFilter::set_event_dispatch_function(EventDispatchFunc p_function) {
+void Input::set_event_dispatch_function(EventDispatchFunc p_function) {
 	event_dispatch_function = p_function;
 }
 
-void InputFilter::joy_button(int p_device, int p_button, bool p_pressed) {
+void Input::joy_button(int p_device, int p_button, bool p_pressed) {
 
 	_THREAD_SAFE_METHOD_;
 	Joypad &joy = joy_names[p_device];
@@ -856,7 +856,7 @@ void InputFilter::joy_button(int p_device, int p_button, bool p_pressed) {
 	// no event?
 }
 
-void InputFilter::joy_axis(int p_device, int p_axis, const JoyAxis &p_value) {
+void Input::joy_axis(int p_device, int p_axis, const JoyAxis &p_value) {
 
 	_THREAD_SAFE_METHOD_;
 
@@ -971,7 +971,7 @@ void InputFilter::joy_axis(int p_device, int p_axis, const JoyAxis &p_value) {
 	//printf("invalid mapping\n");
 }
 
-void InputFilter::joy_hat(int p_device, int p_val) {
+void Input::joy_hat(int p_device, int p_val) {
 
 	_THREAD_SAFE_METHOD_;
 	const Joypad &joy = joy_names[p_device];
@@ -1003,7 +1003,7 @@ void InputFilter::joy_hat(int p_device, int p_val) {
 	joy_names[p_device].hat_current = p_val;
 }
 
-void InputFilter::_button_event(int p_device, int p_index, bool p_pressed) {
+void Input::_button_event(int p_device, int p_index, bool p_pressed) {
 
 	Ref<InputEventJoypadButton> ievent;
 	ievent.instance();
@@ -1014,7 +1014,7 @@ void InputFilter::_button_event(int p_device, int p_index, bool p_pressed) {
 	parse_input_event(ievent);
 }
 
-void InputFilter::_axis_event(int p_device, int p_axis, float p_value) {
+void Input::_axis_event(int p_device, int p_axis, float p_value) {
 
 	Ref<InputEventJoypadMotion> ievent;
 	ievent.instance();
@@ -1025,7 +1025,7 @@ void InputFilter::_axis_event(int p_device, int p_axis, float p_value) {
 	parse_input_event(ievent);
 };
 
-InputFilter::JoyEvent InputFilter::_find_to_event(String p_to) {
+Input::JoyEvent Input::_find_to_event(String p_to) {
 
 	// string names of the SDL buttons in the same order as input_event.h godot buttons
 	static const char *buttons[] = { "a", "b", "x", "y", "leftshoulder", "rightshoulder", "lefttrigger", "righttrigger", "leftstick", "rightstick", "back", "start", "dpup", "dpdown", "dpleft", "dpright", "guide", nullptr };
@@ -1063,7 +1063,7 @@ InputFilter::JoyEvent InputFilter::_find_to_event(String p_to) {
 	return ret;
 };
 
-void InputFilter::parse_mapping(String p_mapping) {
+void Input::parse_mapping(String p_mapping) {
 
 	_THREAD_SAFE_METHOD_;
 	JoyDeviceMapping mapping;
@@ -1128,7 +1128,7 @@ void InputFilter::parse_mapping(String p_mapping) {
 	//printf("added mapping with uuid %ls\n", mapping.uid.c_str());
 };
 
-void InputFilter::add_joy_mapping(String p_mapping, bool p_update_existing) {
+void Input::add_joy_mapping(String p_mapping, bool p_update_existing) {
 	parse_mapping(p_mapping);
 	if (p_update_existing) {
 		Vector<String> entry = p_mapping.split(",");
@@ -1141,7 +1141,7 @@ void InputFilter::add_joy_mapping(String p_mapping, bool p_update_existing) {
 	}
 }
 
-void InputFilter::remove_joy_mapping(String p_guid) {
+void Input::remove_joy_mapping(String p_guid) {
 	for (int i = map_db.size() - 1; i >= 0; i--) {
 		if (p_guid == map_db[i].uid) {
 			map_db.remove(i);
@@ -1154,7 +1154,7 @@ void InputFilter::remove_joy_mapping(String p_guid) {
 	}
 }
 
-void InputFilter::set_fallback_mapping(String p_guid) {
+void Input::set_fallback_mapping(String p_guid) {
 
 	for (int i = 0; i < map_db.size(); i++) {
 		if (map_db[i].uid == p_guid) {
@@ -1165,17 +1165,17 @@ void InputFilter::set_fallback_mapping(String p_guid) {
 }
 
 //platforms that use the remapping system can override and call to these ones
-bool InputFilter::is_joy_known(int p_device) {
+bool Input::is_joy_known(int p_device) {
 	int mapping = joy_names[p_device].mapping;
 	return mapping != -1 ? (mapping != fallback_mapping) : false;
 }
 
-String InputFilter::get_joy_guid(int p_device) const {
+String Input::get_joy_guid(int p_device) const {
 	ERR_FAIL_COND_V(!joy_names.has(p_device), "");
 	return joy_names[p_device].uid;
 }
 
-Array InputFilter::get_connected_joypads() {
+Array Input::get_connected_joypads() {
 	Array ret;
 	Map<int, Joypad>::Element *elem = joy_names.front();
 	while (elem) {
@@ -1219,12 +1219,12 @@ static const char *_axes[JOY_AXIS_MAX] = {
 	""
 };
 
-String InputFilter::get_joy_button_string(int p_button) {
+String Input::get_joy_button_string(int p_button) {
 	ERR_FAIL_INDEX_V(p_button, JOY_BUTTON_MAX, "");
 	return _buttons[p_button];
 }
 
-int InputFilter::get_joy_button_index_from_string(String p_button) {
+int Input::get_joy_button_index_from_string(String p_button) {
 	for (int i = 0; i < JOY_BUTTON_MAX; i++) {
 		if (p_button == _buttons[i]) {
 			return i;
@@ -1233,7 +1233,7 @@ int InputFilter::get_joy_button_index_from_string(String p_button) {
 	ERR_FAIL_V(-1);
 }
 
-int InputFilter::get_unused_joy_id() {
+int Input::get_unused_joy_id() {
 	for (int i = 0; i < JOYPADS_MAX; i++) {
 		if (!joy_names.has(i) || !joy_names[i].connected) {
 			return i;
@@ -1242,12 +1242,12 @@ int InputFilter::get_unused_joy_id() {
 	return -1;
 }
 
-String InputFilter::get_joy_axis_string(int p_axis) {
+String Input::get_joy_axis_string(int p_axis) {
 	ERR_FAIL_INDEX_V(p_axis, JOY_AXIS_MAX, "");
 	return _axes[p_axis];
 }
 
-int InputFilter::get_joy_axis_index_from_string(String p_axis) {
+int Input::get_joy_axis_index_from_string(String p_axis) {
 	for (int i = 0; i < JOY_AXIS_MAX; i++) {
 		if (p_axis == _axes[i]) {
 			return i;
@@ -1256,7 +1256,7 @@ int InputFilter::get_joy_axis_index_from_string(String p_axis) {
 	ERR_FAIL_V(-1);
 }
 
-InputFilter::InputFilter() {
+Input::Input() {
 
 	singleton = this;
 	use_accumulated_input = true;

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  input_filter.h                                                       */
+/*  input.h                                                              */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -35,12 +35,12 @@
 #include "core/object.h"
 #include "core/os/thread_safe.h"
 
-class InputFilter : public Object {
+class Input : public Object {
 
-	GDCLASS(InputFilter, Object);
+	GDCLASS(Input, Object);
 	_THREAD_SAFE_CLASS_
 
-	static InputFilter *singleton;
+	static Input *singleton;
 
 public:
 	enum MouseMode {
@@ -239,7 +239,7 @@ public:
 	MouseMode get_mouse_mode() const;
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;
 
-	static InputFilter *get_singleton();
+	static Input *get_singleton();
 
 	bool is_key_pressed(int p_keycode) const;
 	bool is_mouse_button_pressed(int p_button) const;
@@ -299,7 +299,7 @@ public:
 	CursorShape get_default_cursor_shape() const;
 	void set_default_cursor_shape(CursorShape p_shape);
 	CursorShape get_current_cursor_shape() const;
-	void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape = InputFilter::CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
+	void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape = Input::CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
 
 	void parse_mapping(String p_mapping);
 	void joy_button(int p_device, int p_button, bool p_pressed);
@@ -328,10 +328,10 @@ public:
 
 	void set_event_dispatch_function(EventDispatchFunc p_function);
 
-	InputFilter();
+	Input();
 };
 
-VARIANT_ENUM_CAST(InputFilter::MouseMode);
-VARIANT_ENUM_CAST(InputFilter::CursorShape);
+VARIANT_ENUM_CAST(Input::MouseMode);
+VARIANT_ENUM_CAST(Input::CursorShape);
 
 #endif // INPUT_H

--- a/core/os/midi_driver.cpp
+++ b/core/os/midi_driver.cpp
@@ -30,7 +30,7 @@
 
 #include "midi_driver.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/os.h"
 
 uint8_t MIDIDriver::last_received_message = 0x00;
@@ -117,7 +117,7 @@ void MIDIDriver::receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_
 			break;
 	}
 
-	InputFilter *id = InputFilter::get_singleton();
+	Input *id = Input::get_singleton();
 	id->parse_input_event(event);
 }
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -30,7 +30,7 @@
 
 #include "os.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/dir_access.h"
 #include "core/os/file_access.h"
 #include "core/os/midi_driver.h"

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -38,7 +38,7 @@
 #include "core/crypto/hashing_context.h"
 #include "core/engine.h"
 #include "core/func_ref.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/input/input_map.h"
 #include "core/io/config_file.h"
 #include "core/io/dtls_server.h"
@@ -249,7 +249,7 @@ void register_core_singletons() {
 	ClassDB::register_class<_ClassDB>();
 	ClassDB::register_class<_Marshalls>();
 	ClassDB::register_class<TranslationServer>();
-	ClassDB::register_virtual_class<InputFilter>();
+	ClassDB::register_virtual_class<Input>();
 	ClassDB::register_class<InputMap>();
 	ClassDB::register_class<_JSON>();
 	ClassDB::register_class<Expression>();
@@ -264,7 +264,7 @@ void register_core_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ClassDB", _classdb));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Marshalls", _Marshalls::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("TranslationServer", TranslationServer::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("Input", InputFilter::get_singleton()));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Input", Input::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("InputMap", InputMap::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("JSON", _JSON::get_singleton()));
 }

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -33,8 +33,8 @@
 		<member name="IP" type="IP" setter="" getter="">
 			The [IP] singleton.
 		</member>
-		<member name="Input" type="InputFilter" setter="" getter="">
-			The [InputFilter] singleton.
+		<member name="Input" type="Input" setter="" getter="">
+			The [Input] singleton.
 		</member>
 		<member name="InputMap" type="InputMap" setter="" getter="">
 			The [InputMap] singleton.

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="InputFilter" inherits="Object" version="4.0">
+<class name="Input" inherits="Object" version="4.0">
 	<brief_description>
 		A singleton that deals with inputs.
 	</brief_description>
@@ -68,7 +68,7 @@
 			</description>
 		</method>
 		<method name="get_current_cursor_shape" qualifiers="const">
-			<return type="int" enum="InputFilter.CursorShape">
+			<return type="int" enum="Input.CursorShape">
 			</return>
 			<description>
 				Returns the currently assigned cursor shape (see [enum CursorShape]).
@@ -193,7 +193,7 @@
 			</description>
 		</method>
 		<method name="get_mouse_mode" qualifiers="const">
-			<return type="int" enum="InputFilter.MouseMode">
+			<return type="int" enum="Input.MouseMode">
 			</return>
 			<description>
 				Returns the mouse mode. See the constants for more information.
@@ -277,7 +277,7 @@
 			<argument index="3" name="guid" type="String">
 			</argument>
 			<description>
-				Notifies the [InputFilter] singleton that a connection has changed, to update the state for the [code]device[/code] index.
+				Notifies the [Input] singleton that a connection has changed, to update the state for the [code]device[/code] index.
 				This is used internally and should not have to be called from user scripts. See [signal joy_connection_changed] for the signal emitted when this is triggered internally.
 			</description>
 		</method>
@@ -293,7 +293,7 @@
 				var a = InputEventAction.new()
 				a.action = "ui_cancel"
 				a.pressed = true
-				InputFilter.parse_input_event(a)
+				Input.parse_input_event(a)
 				[/codeblock]
 			</description>
 		</method>
@@ -311,7 +311,7 @@
 			</return>
 			<argument index="0" name="image" type="Resource">
 			</argument>
-			<argument index="1" name="shape" type="int" enum="InputFilter.CursorShape" default="0">
+			<argument index="1" name="shape" type="int" enum="Input.CursorShape" default="0">
 			</argument>
 			<argument index="2" name="hotspot" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
@@ -326,7 +326,7 @@
 		<method name="set_default_cursor_shape">
 			<return type="void">
 			</return>
-			<argument index="0" name="shape" type="int" enum="InputFilter.CursorShape" default="0">
+			<argument index="0" name="shape" type="int" enum="Input.CursorShape" default="0">
 			</argument>
 			<description>
 				Sets the default cursor shape to be used in the viewport instead of [constant CURSOR_ARROW].
@@ -337,7 +337,7 @@
 		<method name="set_mouse_mode">
 			<return type="void">
 			</return>
-			<argument index="0" name="mode" type="int" enum="InputFilter.MouseMode">
+			<argument index="0" name="mode" type="int" enum="Input.MouseMode">
 			</argument>
 			<description>
 				Sets the mouse mode. See the constants for more information.

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -31,7 +31,7 @@
 #include "animation_track_editor.h"
 
 #include "animation_track_editor_plugins.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "editor/animation_bezier_editor.h"
 #include "editor/plugins/animation_player_editor_plugin.h"
@@ -4103,7 +4103,7 @@ bool AnimationTrackEditor::is_selection_active() const {
 }
 
 bool AnimationTrackEditor::is_snap_enabled() const {
-	return snap->is_pressed() ^ InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL);
+	return snap->is_pressed() ^ Input::get_singleton()->is_key_pressed(KEY_CONTROL);
 }
 
 void AnimationTrackEditor::_update_tracks() {

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -30,7 +30,7 @@
 
 #include "code_editor.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "core/string_builder.h"
 #include "editor/editor_scale.h"
@@ -513,7 +513,7 @@ void FindReplaceBar::_search_text_changed(const String &p_text) {
 
 void FindReplaceBar::_search_text_entered(const String &p_text) {
 
-	if (InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 		search_prev();
 	} else {
 		search_next();
@@ -525,7 +525,7 @@ void FindReplaceBar::_replace_text_entered(const String &p_text) {
 	if (selection_only->is_pressed() && text_edit->is_selection_active()) {
 		_replace_all();
 		_hide_bar();
-	} else if (InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+	} else if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 		_replace();
 		search_prev();
 	} else {

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -30,7 +30,7 @@
 
 #include "editor_audio_buses.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/resource_saver.h"
 #include "core/os/keyboard.h"
 #include "editor_node.h"
@@ -325,7 +325,7 @@ void EditorAudioBus::_volume_changed(float p_normalized) {
 
 	const float p_db = this->_normalized_volume_to_scaled_db(p_normalized);
 
-	if (InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL)) {
+	if (Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 		// Snap the value when holding Ctrl for easier editing.
 		// To do so, it needs to be converted back to normalized volume (as the slider uses that unit).
 		slider->set_value(_scaled_db_to_normalized_volume(Math::round(p_db)));
@@ -386,7 +386,7 @@ float EditorAudioBus::_scaled_db_to_normalized_volume(float db) {
 void EditorAudioBus::_show_value(float slider_value) {
 
 	float db;
-	if (InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL)) {
+	if (Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 		// Display the correct (snapped) value when holding Ctrl
 		db = Math::round(_normalized_volume_to_scaled_db(slider_value));
 	} else {

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -30,7 +30,7 @@
 
 #include "editor_help.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "doc_data_compressed.gen.h"
 #include "editor/plugins/script_editor_plugin.h"
@@ -1844,7 +1844,7 @@ void FindBar::_search_text_changed(const String &p_text) {
 
 void FindBar::_search_text_entered(const String &p_text) {
 
-	if (InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 		search_prev();
 	} else {
 		search_next();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -32,7 +32,7 @@
 
 #include "core/bind/core_bind.h"
 #include "core/class_db.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/config_file.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_loader.h"
@@ -2366,7 +2366,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		case EDIT_UNDO: {
 
-			if (InputFilter::get_singleton()->get_mouse_button_mask() & 0x7) {
+			if (Input::get_singleton()->get_mouse_button_mask() & 0x7) {
 				log->add_message("Can't undo while mouse buttons are pressed.", EditorLog::MSG_TYPE_EDITOR);
 			} else {
 				String action = editor_data.get_undo_redo().get_current_action_name();
@@ -2380,7 +2380,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case EDIT_REDO: {
 
-			if (InputFilter::get_singleton()->get_mouse_button_mask() & 0x7) {
+			if (Input::get_singleton()->get_mouse_button_mask() & 0x7) {
 				log->add_message("Can't redo while mouse buttons are pressed.", EditorLog::MSG_TYPE_EDITOR);
 			} else {
 				if (!editor_data.get_undo_redo().redo()) {
@@ -5566,7 +5566,7 @@ int EditorNode::execute_and_show_output(const String &p_title, const String &p_p
 
 EditorNode::EditorNode() {
 
-	InputFilter::get_singleton()->set_use_accumulated_input(true);
+	Input::get_singleton()->set_use_accumulated_input(true);
 	Resource::_get_local_scene_func = _resource_get_edited_scene;
 
 	RenderingServer::get_singleton()->set_debug_generate_wireframes(true);
@@ -5582,7 +5582,7 @@ EditorNode::EditorNode() {
 	ResourceLoader::clear_translation_remaps(); //no remaps using during editor
 	ResourceLoader::clear_path_remaps();
 
-	InputFilter *id = InputFilter::get_singleton();
+	Input *id = Input::get_singleton();
 
 	if (id) {
 
@@ -5593,7 +5593,7 @@ EditorNode::EditorNode() {
 			}
 		}
 
-		if (!found_touchscreen && InputFilter::get_singleton()) {
+		if (!found_touchscreen && Input::get_singleton()) {
 			//only if no touchscreen ui hint, set emulation
 			id->set_emulate_touch_from_mouse(false); //just disable just in case
 		}

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -30,7 +30,7 @@
 
 #include "editor_spin_slider.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/math/expression.h"
 #include "editor_node.h"
 #include "editor_scale.h"
@@ -68,7 +68,7 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 					grabbing_spinner_dist_cache = 0;
 					pre_grab_value = get_value();
 					grabbing_spinner = false;
-					grabbing_spinner_mouse_pos = InputFilter::get_singleton()->get_mouse_position();
+					grabbing_spinner_mouse_pos = Input::get_singleton()->get_mouse_position();
 				}
 			} else {
 
@@ -76,8 +76,8 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 
 					if (grabbing_spinner) {
 
-						InputFilter::get_singleton()->set_mouse_mode(InputFilter::MOUSE_MODE_VISIBLE);
-						InputFilter::get_singleton()->warp_mouse_position(grabbing_spinner_mouse_pos);
+						Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+						Input::get_singleton()->warp_mouse_position(grabbing_spinner_mouse_pos);
 						update();
 					} else {
 						_focus_entered();
@@ -106,7 +106,7 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 			grabbing_spinner_dist_cache += diff_x;
 
 			if (!grabbing_spinner && ABS(grabbing_spinner_dist_cache) > 4 * EDSCALE) {
-				InputFilter::get_singleton()->set_mouse_mode(InputFilter::MOUSE_MODE_CAPTURED);
+				Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
 				grabbing_spinner = true;
 			}
 
@@ -181,7 +181,7 @@ void EditorSpinSlider::_notification(int p_what) {
 			p_what == NOTIFICATION_WM_FOCUS_IN ||
 			p_what == NOTIFICATION_EXIT_TREE) {
 		if (grabbing_spinner) {
-			InputFilter::get_singleton()->set_mouse_mode(InputFilter::MOUSE_MODE_VISIBLE);
+			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
 			grabbing_spinner = false;
 			grabbing_spinner_attempt = false;
 		}
@@ -298,7 +298,7 @@ void EditorSpinSlider::_notification(int p_what) {
 				grabber->set_position(get_global_position() + grabber_rect.position + grabber_rect.size * 0.5 - grabber->get_size() * 0.5);
 
 				if (mousewheel_over_grabber) {
-					InputFilter::get_singleton()->warp_mouse_position(grabber->get_position() + grabber_rect.size);
+					Input::get_singleton()->warp_mouse_position(grabber->get_position() + grabber_rect.size);
 				}
 
 				grabber_range = width;
@@ -317,7 +317,7 @@ void EditorSpinSlider::_notification(int p_what) {
 		update();
 	}
 	if (p_what == NOTIFICATION_FOCUS_ENTER) {
-		if ((InputFilter::get_singleton()->is_action_pressed("ui_focus_next") || InputFilter::get_singleton()->is_action_pressed("ui_focus_prev")) && !value_input_just_closed) {
+		if ((Input::get_singleton()->is_action_pressed("ui_focus_next") || Input::get_singleton()->is_action_pressed("ui_focus_prev")) && !value_input_just_closed) {
 			_focus_entered();
 		}
 		value_input_just_closed = false;

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -30,7 +30,7 @@
 
 #include "export_template_manager.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/json.h"
 #include "core/io/zip_io.h"
 #include "core/os/dir_access.h"
@@ -446,7 +446,7 @@ void ExportTemplateManager::_http_download_templates_completed(int p_status, int
 
 void ExportTemplateManager::_begin_template_download(const String &p_url) {
 
-	if (InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 		OS::get_singleton()->shell_open(p_url);
 		return;
 	}

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -30,7 +30,7 @@
 
 #include "animation_blend_space_2d_editor.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/resource_loader.h"
 #include "core/math/delaunay.h"
 #include "core/os/keyboard.h"

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "animation_blend_tree_editor_plugin.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/resource_loader.h"
 #include "core/os/keyboard.h"
 #include "core/project_settings.h"

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "animation_player_editor_plugin.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/os/keyboard.h"
@@ -488,7 +488,7 @@ double AnimationPlayerEditor::_get_editor_step() const {
 		ERR_FAIL_COND_V(!anim.is_valid(), 0.0);
 
 		// Use more precise snapping when holding Shift
-		return InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT) ? anim->get_step() * 0.25 : anim->get_step();
+		return Input::get_singleton()->is_key_pressed(KEY_SHIFT) ? anim->get_step() * 0.25 : anim->get_step();
 	}
 
 	return 0.0;

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -30,7 +30,7 @@
 
 #include "animation_state_machine_editor.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/resource_loader.h"
 #include "core/math/delaunay.h"
 #include "core/os/keyboard.h"

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -34,7 +34,7 @@
 #include "animation_blend_space_2d_editor.h"
 #include "animation_blend_tree_editor_plugin.h"
 #include "animation_state_machine_editor.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/resource_loader.h"
 #include "core/math/delaunay.h"
 #include "core/os/keyboard.h"

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "asset_library_editor_plugin.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/json.h"
 #include "core/os/keyboard.h"
 #include "core/version.h"

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "canvas_item_editor_plugin.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "core/print_string.h"
 #include "core/project_settings.h"
@@ -334,7 +334,7 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 	snap_target[0] = SNAP_TARGET_NONE;
 	snap_target[1] = SNAP_TARGET_NONE;
 
-	bool is_snap_active = smart_snap_active ^ InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL);
+	bool is_snap_active = smart_snap_active ^ Input::get_singleton()->is_key_pressed(KEY_CONTROL);
 
 	// Smart snap using the canvas position
 	Vector2 output = p_target;
@@ -462,7 +462,7 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 }
 
 float CanvasItemEditor::snap_angle(float p_target, float p_start) const {
-	if (((smart_snap_active || snap_rotation) ^ InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL)) && snap_rotation_step != 0) {
+	if (((smart_snap_active || snap_rotation) ^ Input::get_singleton()->is_key_pressed(KEY_CONTROL)) && snap_rotation_step != 0) {
 		if (snap_relative) {
 			return Math::stepify(p_target - snap_rotation_offset, snap_rotation_step) + snap_rotation_offset + (p_start - (int)(p_start / snap_rotation_step) * snap_rotation_step);
 		} else {
@@ -1284,7 +1284,7 @@ bool CanvasItemEditor::_gui_input_zoom_or_pan(const Ref<InputEvent> &p_event, bo
 			// Pan the viewport
 			Point2i relative;
 			if (bool(EditorSettings::get_singleton()->get("editors/2d/warped_mouse_panning"))) {
-				relative = InputFilter::get_singleton()->warp_mouse_motion(m, viewport->get_global_rect());
+				relative = Input::get_singleton()->warp_mouse_motion(m, viewport->get_global_rect());
 			} else {
 				relative = m->get_relative();
 			}
@@ -1912,7 +1912,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 			Transform2D simple_xform = (viewport->get_transform() * unscaled_transform).affine_inverse() * transform;
 
 			bool uniform = m->get_shift();
-			bool is_ctrl = InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL);
+			bool is_ctrl = Input::get_singleton()->is_key_pressed(KEY_CONTROL);
 
 			Point2 drag_from_local = simple_xform.xform(drag_from);
 			Point2 drag_to_local = simple_xform.xform(drag_to);
@@ -2214,10 +2214,10 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 	if (k.is_valid() && !k->is_pressed() && drag_type == DRAG_KEY_MOVE && tool == TOOL_SELECT &&
 			(k->get_keycode() == KEY_UP || k->get_keycode() == KEY_DOWN || k->get_keycode() == KEY_LEFT || k->get_keycode() == KEY_RIGHT)) {
 		// Confirm canvas items move by arrow keys
-		if ((!InputFilter::get_singleton()->is_key_pressed(KEY_UP)) &&
-				(!InputFilter::get_singleton()->is_key_pressed(KEY_DOWN)) &&
-				(!InputFilter::get_singleton()->is_key_pressed(KEY_LEFT)) &&
-				(!InputFilter::get_singleton()->is_key_pressed(KEY_RIGHT))) {
+		if ((!Input::get_singleton()->is_key_pressed(KEY_UP)) &&
+				(!Input::get_singleton()->is_key_pressed(KEY_DOWN)) &&
+				(!Input::get_singleton()->is_key_pressed(KEY_LEFT)) &&
+				(!Input::get_singleton()->is_key_pressed(KEY_RIGHT))) {
 			_commit_canvas_item_state(drag_selection, TTR("Move CanvasItem"), true);
 			drag_type = DRAG_NONE;
 		}
@@ -3310,8 +3310,8 @@ void CanvasItemEditor::_draw_selection() {
 			}
 
 			// Draw the move handles
-			bool is_ctrl = InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL);
-			bool is_alt = InputFilter::get_singleton()->is_key_pressed(KEY_ALT);
+			bool is_ctrl = Input::get_singleton()->is_key_pressed(KEY_CONTROL);
+			bool is_alt = Input::get_singleton()->is_key_pressed(KEY_ALT);
 			if (tool == TOOL_MOVE && show_transformation_gizmos) {
 				if (_is_node_movable(canvas_item)) {
 					Transform2D unscaled_transform = (xform * canvas_item->get_transform().affine_inverse() * canvas_item->_edit_get_transform()).orthonormalized();
@@ -3347,7 +3347,7 @@ void CanvasItemEditor::_draw_selection() {
 					Transform2D simple_xform = viewport->get_transform() * unscaled_transform;
 
 					Size2 scale_factor = Size2(SCALE_HANDLE_DISTANCE, SCALE_HANDLE_DISTANCE);
-					bool uniform = InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT);
+					bool uniform = Input::get_singleton()->is_key_pressed(KEY_SHIFT);
 					Point2 offset = (simple_xform.affine_inverse().xform(drag_to) - simple_xform.affine_inverse().xform(drag_from)) * zoom;
 
 					if (drag_type == DRAG_SCALE_X) {
@@ -6204,8 +6204,8 @@ bool CanvasItemEditorViewport::_only_packed_scenes_selected() const {
 }
 
 void CanvasItemEditorViewport::drop_data(const Point2 &p_point, const Variant &p_data) {
-	bool is_shift = InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT);
-	bool is_alt = InputFilter::get_singleton()->is_key_pressed(KEY_ALT);
+	bool is_shift = Input::get_singleton()->is_key_pressed(KEY_SHIFT);
+	bool is_alt = Input::get_singleton()->is_key_pressed(KEY_ALT);
 
 	selected_files.clear();
 	Dictionary d = p_data;

--- a/editor/plugins/collision_polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_3d_editor_plugin.cpp
@@ -31,7 +31,7 @@
 #include "collision_polygon_3d_editor_plugin.h"
 
 #include "canvas_item_editor_plugin.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/file_access.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_settings.h"
@@ -342,7 +342,7 @@ bool CollisionPolygon3DEditor::forward_spatial_gui_input(Camera3D *p_camera, con
 
 			Vector2 cpoint(spoint.x, spoint.y);
 
-			if (snap_ignore && !InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL)) {
+			if (snap_ignore && !Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 				snap_ignore = false;
 			}
 

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -32,7 +32,7 @@
 
 #include "canvas_item_editor_plugin.h"
 #include "core/core_string_names.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_scale.h"
 
@@ -210,7 +210,7 @@ void CurveEditor::on_gui_input(const Ref<InputEvent> &p_event) {
 					else
 						tangent = 9999 * (dir.y >= 0 ? 1 : -1);
 
-					bool link = !InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT);
+					bool link = !Input::get_singleton()->is_key_pressed(KEY_SHIFT);
 
 					if (_selected_tangent == TANGENT_LEFT) {
 						curve.set_point_left_tangent(_selected_point, tangent);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "node_3d_editor_plugin.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/math/camera_matrix.h"
 #include "core/os/keyboard.h"
 #include "core/print_string.h"
@@ -298,10 +298,10 @@ void Node3DEditorViewport::_update_camera(float p_interp_delta) {
 			float zoom_inertia = EDITOR_GET("editors/3d/navigation_feel/zoom_inertia");
 
 			//determine if being manipulated
-			bool manipulated = InputFilter::get_singleton()->get_mouse_button_mask() & (2 | 4);
-			manipulated |= InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT);
-			manipulated |= InputFilter::get_singleton()->is_key_pressed(KEY_ALT);
-			manipulated |= InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL);
+			bool manipulated = Input::get_singleton()->get_mouse_button_mask() & (2 | 4);
+			manipulated |= Input::get_singleton()->is_key_pressed(KEY_SHIFT);
+			manipulated |= Input::get_singleton()->is_key_pressed(KEY_ALT);
+			manipulated |= Input::get_singleton()->is_key_pressed(KEY_CONTROL);
 
 			float orbit_inertia = MAX(0.00001, manipulated ? manip_orbit_inertia : free_orbit_inertia);
 			float translation_inertia = MAX(0.0001, manipulated ? manip_translation_inertia : free_translation_inertia);
@@ -2260,7 +2260,7 @@ void Node3DEditorViewport::scale_freelook_speed(real_t scale) {
 Point2i Node3DEditorViewport::_get_warped_mouse_motion(const Ref<InputEventMouseMotion> &p_ev_mouse_motion) const {
 	Point2i relative;
 	if (bool(EDITOR_DEF("editors/3d/navigation/warped_mouse_panning", false))) {
-		relative = InputFilter::get_singleton()->warp_mouse_motion(p_ev_mouse_motion, surface->get_global_rect());
+		relative = Input::get_singleton()->warp_mouse_motion(p_ev_mouse_motion, surface->get_global_rect());
 	} else {
 		relative = p_ev_mouse_motion->get_relative();
 	}
@@ -2276,7 +2276,7 @@ static bool is_shortcut_pressed(const String &p_path) {
 	if (k == nullptr) {
 		return false;
 	}
-	const InputFilter &input = *InputFilter::get_singleton();
+	const Input &input = *Input::get_singleton();
 	int keycode = k->get_keycode();
 	return input.is_key_pressed(keycode);
 }
@@ -3828,7 +3828,7 @@ void Node3DEditorViewport::drop_data_fw(const Point2 &p_point, const Variant &p_
 	if (!can_drop_data_fw(p_point, p_data, p_from))
 		return;
 
-	bool is_shift = InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT);
+	bool is_shift = Input::get_singleton()->is_key_pressed(KEY_SHIFT);
 
 	selected_files.clear();
 	Dictionary d = p_data;
@@ -5785,7 +5785,7 @@ void Node3DEditor::_unhandled_key_input(Ref<InputEvent> p_event) {
 	if (!is_visible_in_tree())
 		return;
 
-	snap_key_enabled = InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL);
+	snap_key_enabled = Input::get_singleton()->is_key_pressed(KEY_CONTROL);
 }
 void Node3DEditor::_notification(int p_what) {
 
@@ -6446,7 +6446,7 @@ Vector3 Node3DEditor::snap_point(Vector3 p_target, Vector3 p_start) const {
 
 float Node3DEditor::get_translate_snap() const {
 	float snap_value;
-	if (InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 		snap_value = snap_translate->get_text().to_double() / 10.0;
 	} else {
 		snap_value = snap_translate->get_text().to_double();
@@ -6457,7 +6457,7 @@ float Node3DEditor::get_translate_snap() const {
 
 float Node3DEditor::get_rotate_snap() const {
 	float snap_value;
-	if (InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 		snap_value = snap_rotate->get_text().to_double() / 3.0;
 	} else {
 		snap_value = snap_rotate->get_text().to_double();
@@ -6468,7 +6468,7 @@ float Node3DEditor::get_rotate_snap() const {
 
 float Node3DEditor::get_scale_snap() const {
 	float snap_value;
-	if (InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 		snap_value = snap_scale->get_text().to_double() / 2.0;
 	} else {
 		snap_value = snap_scale->get_text().to_double();

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -31,7 +31,7 @@
 #include "polygon_2d_editor_plugin.h"
 
 #include "canvas_item_editor_plugin.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/file_access.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_scale.h"
@@ -810,7 +810,7 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 
 	if (mm.is_valid()) {
 
-		if ((mm->get_button_mask() & BUTTON_MASK_MIDDLE) || InputFilter::get_singleton()->is_key_pressed(KEY_SPACE)) {
+		if ((mm->get_button_mask() & BUTTON_MASK_MIDDLE) || Input::get_singleton()->is_key_pressed(KEY_SPACE)) {
 
 			Vector2 drag(mm->get_relative().x, mm->get_relative().y);
 			uv_hscroll->set_value(uv_hscroll->get_value() - drag.x);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "script_editor_plugin.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/resource_loader.h"
 #include "core/os/file_access.h"
 #include "core/os/keyboard.h"
@@ -1545,7 +1545,7 @@ void ScriptEditor::_help_overview_selected(int p_idx) {
 
 void ScriptEditor::_script_selected(int p_idx) {
 
-	grab_focus_block = !InputFilter::get_singleton()->is_mouse_button_pressed(1); //amazing hack, simply amazing
+	grab_focus_block = !Input::get_singleton()->is_mouse_button_pressed(1); //amazing hack, simply amazing
 
 	_go_to_tab(script_list->get_item_metadata(p_idx));
 	grab_focus_block = false;

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -31,7 +31,7 @@
 #include "texture_region_editor_plugin.h"
 
 #include "core/core_string_names.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_scale.h"
 #include "scene/gui/check_box.h"
@@ -307,7 +307,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					for (List<Rect2>::Element *E = autoslice_cache.front(); E; E = E->next()) {
 						if (E->get().has_point(point)) {
 							rect = E->get();
-							if (InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL) && !(InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT | KEY_ALT))) {
+							if (Input::get_singleton()->is_key_pressed(KEY_CONTROL) && !(Input::get_singleton()->is_key_pressed(KEY_SHIFT | KEY_ALT))) {
 								Rect2 r;
 								if (node_sprite)
 									r = node_sprite->get_region_rect();
@@ -449,7 +449,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 
 	if (mm.is_valid()) {
 
-		if (mm->get_button_mask() & BUTTON_MASK_MIDDLE || InputFilter::get_singleton()->is_key_pressed(KEY_SPACE)) {
+		if (mm->get_button_mask() & BUTTON_MASK_MIDDLE || Input::get_singleton()->is_key_pressed(KEY_SPACE)) {
 
 			Vector2 dragged(mm->get_relative().x / draw_zoom, mm->get_relative().y / draw_zoom);
 			hscroll->set_value(hscroll->get_value() - dragged.x);

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -31,7 +31,7 @@
 #include "tile_map_editor_plugin.h"
 
 #include "canvas_item_editor_plugin.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/math/math_funcs.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_scale.h"
@@ -997,7 +997,7 @@ bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 			if (mb->is_pressed()) {
 
-				if (InputFilter::get_singleton()->is_key_pressed(KEY_SPACE))
+				if (Input::get_singleton()->is_key_pressed(KEY_SPACE))
 					return false; // Drag.
 
 				if (tool == TOOL_NONE) {
@@ -1378,7 +1378,7 @@ bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 			return true;
 		}
-		if (tool == TOOL_PICKING && InputFilter::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT)) {
+		if (tool == TOOL_PICKING && Input::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT)) {
 
 			_pick_tile(over_tile);
 

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "tile_set_editor_plugin.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_scale.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
@@ -1113,7 +1113,7 @@ void TileSetEditor::_on_workspace_draw() {
 
 void TileSetEditor::_on_workspace_process() {
 
-	if (InputFilter::get_singleton()->is_key_pressed(KEY_ALT) || tools[VISIBLE_INFO]->is_pressed()) {
+	if (Input::get_singleton()->is_key_pressed(KEY_ALT) || tools[VISIBLE_INFO]->is_pressed()) {
 		if (!tile_names_visible) {
 			tile_names_visible = true;
 			workspace_overlay->update();
@@ -1395,7 +1395,7 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 							if ((mb->get_button_index() == BUTTON_RIGHT || mb->get_button_index() == BUTTON_LEFT) && current_tile_region.has_point(mb->get_position())) {
 								dragging = true;
 								erasing = (mb->get_button_index() == BUTTON_RIGHT);
-								alternative = InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT);
+								alternative = Input::get_singleton()->is_key_pressed(KEY_SHIFT);
 								Vector2 coord((int)((mb->get_position().x - current_tile_region.position.x) / (spacing + size.x)), (int)((mb->get_position().y - current_tile_region.position.y) / (spacing + size.y)));
 								Vector2 pos(coord.x * (spacing + size.x), coord.y * (spacing + size.y));
 								pos = mb->get_position() - (pos + current_tile_region.position);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "visual_shader_editor_plugin.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/resource_loader.h"
 #include "core/math/math_defs.h"
 #include "core/os/keyboard.h"
@@ -1635,7 +1635,7 @@ void VisualShaderEditor::_graph_gui_input(const Ref<InputEvent> &p_event) {
 			popup_menu->set_item_disabled(NodeMenuOptions::DELETE, to_change.empty());
 			popup_menu->set_item_disabled(NodeMenuOptions::DUPLICATE, to_change.empty());
 			menu_point = graph->get_local_mouse_position();
-			Point2 gpos = InputFilter::get_singleton()->get_mouse_position();
+			Point2 gpos = Input::get_singleton()->get_mouse_position();
 			popup_menu->set_position(gpos);
 			popup_menu->popup();
 		}
@@ -1648,7 +1648,7 @@ void VisualShaderEditor::_show_members_dialog(bool at_mouse_pos) {
 		saved_node_pos_dirty = true;
 		saved_node_pos = graph->get_local_mouse_position();
 
-		Point2 gpos = InputFilter::get_singleton()->get_mouse_position();
+		Point2 gpos = Input::get_singleton()->get_mouse_position();
 		members_dialog->popup();
 		members_dialog->set_position(gpos);
 	} else {

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -31,7 +31,7 @@
 #include "property_editor.h"
 
 #include "core/class_db.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/image_loader.h"
 #include "core/io/marshalls.h"
 #include "core/io/resource_loader.h"
@@ -1720,7 +1720,7 @@ real_t CustomPropertyEditor::_parse_real_expression(String text) {
 
 void CustomPropertyEditor::_emit_changed_whole_or_field() {
 
-	if (!InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+	if (!Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 		emit_signal("variant_changed");
 	} else {
 		emit_signal("variant_field_changed", field_names[focused_value_editor]);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -30,7 +30,7 @@
 
 #include "scene_tree_dock.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/resource_saver.h"
 #include "core/os/keyboard.h"
 #include "core/project_settings.h"
@@ -1030,7 +1030,7 @@ void SceneTreeDock::_node_collapsed(Object *p_obj) {
 	if (!ti)
 		return;
 
-	if (InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 		_set_collapsed_recursive(ti, ti->is_collapsed());
 	}
 }
@@ -2346,7 +2346,7 @@ void SceneTreeDock::_nodes_dragged(Array p_nodes, NodePath p_to, int p_type) {
 	int to_pos = -1;
 
 	_normalize_drop(to_node, to_pos, p_type);
-	_do_reparent(to_node, to_pos, nodes, !InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT));
+	_do_reparent(to_node, to_pos, nodes, !Input::get_singleton()->is_key_pressed(KEY_SHIFT));
 }
 
 void SceneTreeDock::_add_children_to_popup(Object *p_obj, int p_depth) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -32,7 +32,7 @@
 
 #include "core/crypto/crypto.h"
 #include "core/debugger/engine_debugger.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/input/input_map.h"
 #include "core/io/file_access_network.h"
 #include "core/io/file_access_pack.h"
@@ -90,7 +90,7 @@
 // Initialized in setup()
 static Engine *engine = nullptr;
 static ProjectSettings *globals = nullptr;
-static InputFilter *input = nullptr;
+static Input *input = nullptr;
 static InputMap *input_map = nullptr;
 static TranslationServer *translation_server = nullptr;
 static Performance *performance = nullptr;
@@ -1249,7 +1249,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	/* Initialize Input */
 
-	input = memnew(InputFilter);
+	input = memnew(Input);
 
 	/* Iniitalize Display Server */
 
@@ -1403,7 +1403,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	GLOBAL_DEF("application/config/windows_native_icon", String());
 	ProjectSettings::get_singleton()->set_custom_property_info("application/config/windows_native_icon", PropertyInfo(Variant::STRING, "application/config/windows_native_icon", PROPERTY_HINT_FILE, "*.ico"));
 
-	InputFilter *id = InputFilter::get_singleton();
+	Input *id = Input::get_singleton();
 	if (id) {
 		if (bool(GLOBAL_DEF("input_devices/pointing/emulate_touch_from_mouse", false)) && !(editor || project_manager)) {
 
@@ -1438,7 +1438,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		Ref<Texture2D> cursor = ResourceLoader::load(ProjectSettings::get_singleton()->get("display/mouse_cursor/custom_image"));
 		if (cursor.is_valid()) {
 			Vector2 hotspot = ProjectSettings::get_singleton()->get("display/mouse_cursor/custom_image_hotspot");
-			InputFilter::get_singleton()->set_custom_mouse_cursor(cursor, InputFilter::CURSOR_ARROW, hotspot);
+			Input::get_singleton()->set_custom_mouse_cursor(cursor, Input::CURSOR_ARROW, hotspot);
 		}
 	}
 #ifdef TOOLS_ENABLED

--- a/modules/arkit/arkit_interface.mm
+++ b/modules/arkit/arkit_interface.mm
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/os.h"
 #include "scene/resources/surface_tool.h"
 #include "servers/rendering/rendering_server_globals.h"

--- a/modules/gdnative/xr/xr_interface_gdnative.cpp
+++ b/modules/gdnative/xr/xr_interface_gdnative.cpp
@@ -29,7 +29,7 @@
 /*************************************************************************/
 
 #include "xr_interface_gdnative.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "servers/rendering/rendering_server_globals.h"
 #include "servers/xr/xr_positional_tracker.h"
 
@@ -306,7 +306,7 @@ godot_int GDAPI godot_xr_add_controller(char *p_device_name, godot_int p_hand, g
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, 0);
 
-	InputFilter *input = InputFilter::get_singleton();
+	Input *input = Input::get_singleton();
 	ERR_FAIL_NULL_V(input, 0);
 
 	XRPositionalTracker *new_tracker = memnew(XRPositionalTracker);
@@ -345,7 +345,7 @@ void GDAPI godot_xr_remove_controller(godot_int p_controller_id) {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL(xr_server);
 
-	InputFilter *input = InputFilter::get_singleton();
+	Input *input = Input::get_singleton();
 	ERR_FAIL_NULL(input);
 
 	XRPositionalTracker *remove_tracker = xr_server->find_by_type_and_id(XRServer::TRACKER_CONTROLLER, p_controller_id);
@@ -383,7 +383,7 @@ void GDAPI godot_xr_set_controller_button(godot_int p_controller_id, godot_int p
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL(xr_server);
 
-	InputFilter *input = InputFilter::get_singleton();
+	Input *input = Input::get_singleton();
 	ERR_FAIL_NULL(input);
 
 	XRPositionalTracker *tracker = xr_server->find_by_type_and_id(XRServer::TRACKER_CONTROLLER, p_controller_id);
@@ -399,14 +399,14 @@ void GDAPI godot_xr_set_controller_axis(godot_int p_controller_id, godot_int p_a
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL(xr_server);
 
-	InputFilter *input = InputFilter::get_singleton();
+	Input *input = Input::get_singleton();
 	ERR_FAIL_NULL(input);
 
 	XRPositionalTracker *tracker = xr_server->find_by_type_and_id(XRServer::TRACKER_CONTROLLER, p_controller_id);
 	if (tracker != nullptr) {
 		int joyid = tracker->get_joy_id();
 		if (joyid != -1) {
-			InputFilter::JoyAxis jx;
+			Input::JoyAxis jx;
 			jx.min = p_can_be_negative ? -1 : 0;
 			jx.value = p_value;
 			input->joy_axis(joyid, p_axis, jx);

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -29,7 +29,7 @@
 /*************************************************************************/
 
 #include "grid_map_editor_plugin.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/plugins/node_3d_editor_plugin.h"

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -29,7 +29,8 @@
 /*************************************************************************/
 
 #include "mobile_vr_interface.h"
-#include "core/input/input_filter.h"
+
+#include "core/input/input.h"
 #include "core/os/os.h"
 #include "servers/display_server.h"
 #include "servers/rendering/rendering_server_globals.h"
@@ -118,7 +119,7 @@ void MobileVRInterface::set_position_from_sensors() {
 	float delta_time = (double)ticks_elapsed / 1000000.0;
 
 	// few things we need
-	InputFilter *input = InputFilter::get_singleton();
+	Input *input = Input::get_singleton();
 	Vector3 down(0.0, -1.0, 0.0); // Down is Y negative
 	Vector3 north(0.0, 0.0, 1.0); // North is Z positive
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -30,7 +30,7 @@
 
 #include "visual_script_editor.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/object.h"
 #include "core/os/keyboard.h"
 #include "core/script_language.h"
@@ -1073,9 +1073,9 @@ void VisualScriptEditor::_member_selected() {
 	if (ti->get_parent() == members->get_root()->get_children()) {
 
 #ifdef OSX_ENABLED
-		bool held_ctrl = InputFilter::get_singleton()->is_key_pressed(KEY_META);
+		bool held_ctrl = Input::get_singleton()->is_key_pressed(KEY_META);
 #else
-		bool held_ctrl = InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL);
+		bool held_ctrl = Input::get_singleton()->is_key_pressed(KEY_CONTROL);
 #endif
 		if (held_ctrl) {
 			ERR_FAIL_COND(!script->has_function(selected));
@@ -1378,7 +1378,7 @@ void VisualScriptEditor::_member_button(Object *p_item, int p_column, int p_butt
 		}
 	} else if (ti->get_parent() == root->get_children()) {
 		selected = ti->get_text(0);
-		function_name_edit->set_position(InputFilter::get_singleton()->get_mouse_position() - Vector2(60, -10));
+		function_name_edit->set_position(Input::get_singleton()->get_mouse_position() - Vector2(60, -10));
 		function_name_edit->popup();
 		function_name_box->set_text(selected);
 		function_name_box->select_all();
@@ -1740,7 +1740,7 @@ void VisualScriptEditor::_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> key = p_event;
 
 	if (key.is_valid() && !key->is_pressed()) {
-		mouse_up_position = InputFilter::get_singleton()->get_mouse_position();
+		mouse_up_position = Input::get_singleton()->get_mouse_position();
 	}
 }
 
@@ -1750,7 +1750,7 @@ void VisualScriptEditor::_graph_gui_input(const Ref<InputEvent> &p_event) {
 	if (key.is_valid() && key->is_pressed() && key->get_button_mask() == BUTTON_RIGHT) {
 		saved_position = graph->get_local_mouse_position();
 
-		Point2 gpos = InputFilter::get_singleton()->get_mouse_position();
+		Point2 gpos = Input::get_singleton()->get_mouse_position();
 		_generic_search(script->get_instance_base_type(), gpos);
 	}
 }
@@ -2004,9 +2004,9 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 	if (String(d["type"]) == "visual_script_variable_drag") {
 
 #ifdef OSX_ENABLED
-		bool use_set = InputFilter::get_singleton()->is_key_pressed(KEY_META);
+		bool use_set = Input::get_singleton()->is_key_pressed(KEY_META);
 #else
-		bool use_set = InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL);
+		bool use_set = Input::get_singleton()->is_key_pressed(KEY_CONTROL);
 #endif
 		Vector2 ofs = graph->get_scroll_ofs() + p_point;
 		if (graph->is_using_snap()) {
@@ -2199,9 +2199,9 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 		}
 
 #ifdef OSX_ENABLED
-		bool use_node = InputFilter::get_singleton()->is_key_pressed(KEY_META);
+		bool use_node = Input::get_singleton()->is_key_pressed(KEY_META);
 #else
-		bool use_node = InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL);
+		bool use_node = Input::get_singleton()->is_key_pressed(KEY_CONTROL);
 #endif
 
 		Array nodes = d["nodes"];
@@ -2263,7 +2263,7 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 
 		Node *sn = _find_script_node(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root(), script);
 
-		if (!sn && !InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+		if (!sn && !Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 			EditorNode::get_singleton()->show_warning(vformat(TTR("Can't drop properties because script '%s' is not used in this scene.\nDrop holding 'Shift' to just copy the signature."), get_name()));
 			return;
 		}
@@ -2283,12 +2283,12 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 
 		ofs /= EDSCALE;
 #ifdef OSX_ENABLED
-		bool use_get = InputFilter::get_singleton()->is_key_pressed(KEY_META);
+		bool use_get = Input::get_singleton()->is_key_pressed(KEY_META);
 #else
-		bool use_get = InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL);
+		bool use_get = Input::get_singleton()->is_key_pressed(KEY_CONTROL);
 #endif
 
-		if (!node || InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+		if (!node || Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 
 			if (use_get)
 				undo_redo->create_action(TTR("Add Getter Property"));

--- a/modules/visual_script/visual_script_flow_control.cpp
+++ b/modules/visual_script/visual_script_flow_control.cpp
@@ -934,6 +934,6 @@ void register_visual_script_flow_control_nodes() {
 	VisualScriptLanguage::singleton->add_register_func("flow_control/iterator", create_node_generic<VisualScriptIterator>);
 	VisualScriptLanguage::singleton->add_register_func("flow_control/sequence", create_node_generic<VisualScriptSequence>);
 	VisualScriptLanguage::singleton->add_register_func("flow_control/switch", create_node_generic<VisualScriptSwitch>);
-	//VisualScriptLanguage::singleton->add_register_func("flow_control/input_filter", create_node_generic<VisualScriptInputFilter>);
+	//VisualScriptLanguage::singleton->add_register_func("flow_control/input", create_node_generic<VisualScriptInputFilter>);
 	VisualScriptLanguage::singleton->add_register_func("flow_control/type_cast", create_node_generic<VisualScriptTypeCast>);
 }

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -32,7 +32,7 @@
 
 #include "core/engine.h"
 #include "core/global_constants.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "scene/main/node.h"
@@ -3870,16 +3870,16 @@ public:
 
 		switch (mode) {
 			case VisualScriptInputAction::MODE_PRESSED: {
-				*p_outputs[0] = InputFilter::get_singleton()->is_action_pressed(action);
+				*p_outputs[0] = Input::get_singleton()->is_action_pressed(action);
 			} break;
 			case VisualScriptInputAction::MODE_RELEASED: {
-				*p_outputs[0] = !InputFilter::get_singleton()->is_action_pressed(action);
+				*p_outputs[0] = !Input::get_singleton()->is_action_pressed(action);
 			} break;
 			case VisualScriptInputAction::MODE_JUST_PRESSED: {
-				*p_outputs[0] = InputFilter::get_singleton()->is_action_just_pressed(action);
+				*p_outputs[0] = Input::get_singleton()->is_action_just_pressed(action);
 			} break;
 			case VisualScriptInputAction::MODE_JUST_RELEASED: {
-				*p_outputs[0] = InputFilter::get_singleton()->is_action_just_released(action);
+				*p_outputs[0] = Input::get_singleton()->is_action_just_released(action);
 			} break;
 		}
 

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -424,7 +424,7 @@ DisplayServerAndroid::DisplayServerAndroid(const String &p_rendering_driver, Dis
 	}
 #endif
 
-	InputFilter::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
+	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
 }
 
 DisplayServerAndroid::~DisplayServerAndroid() {
@@ -445,16 +445,16 @@ DisplayServerAndroid::~DisplayServerAndroid() {
 void DisplayServerAndroid::process_joy_event(DisplayServerAndroid::JoypadEvent p_event) {
 	switch (p_event.type) {
 		case JOY_EVENT_BUTTON:
-			InputFilter::get_singleton()->joy_button(p_event.device, p_event.index, p_event.pressed);
+			Input::get_singleton()->joy_button(p_event.device, p_event.index, p_event.pressed);
 			break;
 		case JOY_EVENT_AXIS:
-			InputFilter::JoyAxis value;
+			Input::JoyAxis value;
 			value.min = -1;
 			value.value = p_event.value;
-			InputFilter::get_singleton()->joy_axis(p_event.device, p_event.index, value);
+			Input::get_singleton()->joy_axis(p_event.device, p_event.index, value);
 			break;
 		case JOY_EVENT_HAT:
-			InputFilter::get_singleton()->joy_hat(p_event.device, p_event.hat);
+			Input::get_singleton()->joy_hat(p_event.device, p_event.hat);
 			break;
 		default:
 			return;
@@ -484,7 +484,7 @@ void DisplayServerAndroid::process_key_event(int p_keycode, int p_scancode, int 
 		OS_Android::get_singleton()->main_loop_request_go_back();
 	}
 
-	InputFilter::get_singleton()->parse_input_event(ev);
+	Input::get_singleton()->parse_input_event(ev);
 }
 
 void DisplayServerAndroid::process_touch(int p_what, int p_pointer, const Vector<DisplayServerAndroid::TouchPos> &p_points) {
@@ -499,7 +499,7 @@ void DisplayServerAndroid::process_touch(int p_what, int p_pointer, const Vector
 					ev->set_index(touch[i].id);
 					ev->set_pressed(false);
 					ev->set_position(touch[i].pos);
-					InputFilter::get_singleton()->parse_input_event(ev);
+					Input::get_singleton()->parse_input_event(ev);
 				}
 			}
 
@@ -517,7 +517,7 @@ void DisplayServerAndroid::process_touch(int p_what, int p_pointer, const Vector
 				ev->set_index(touch[i].id);
 				ev->set_pressed(true);
 				ev->set_position(touch[i].pos);
-				InputFilter::get_singleton()->parse_input_event(ev);
+				Input::get_singleton()->parse_input_event(ev);
 			}
 
 		} break;
@@ -545,7 +545,7 @@ void DisplayServerAndroid::process_touch(int p_what, int p_pointer, const Vector
 				ev->set_index(touch[i].id);
 				ev->set_position(p_points[idx].pos);
 				ev->set_relative(p_points[idx].pos - touch[i].pos);
-				InputFilter::get_singleton()->parse_input_event(ev);
+				Input::get_singleton()->parse_input_event(ev);
 				touch.write[i].pos = p_points[idx].pos;
 			}
 
@@ -560,7 +560,7 @@ void DisplayServerAndroid::process_touch(int p_what, int p_pointer, const Vector
 					ev->set_index(touch[i].id);
 					ev->set_pressed(false);
 					ev->set_position(touch[i].pos);
-					InputFilter::get_singleton()->parse_input_event(ev);
+					Input::get_singleton()->parse_input_event(ev);
 				}
 				touch.clear();
 			}
@@ -577,7 +577,7 @@ void DisplayServerAndroid::process_touch(int p_what, int p_pointer, const Vector
 					ev->set_index(tp.id);
 					ev->set_pressed(true);
 					ev->set_position(tp.pos);
-					InputFilter::get_singleton()->parse_input_event(ev);
+					Input::get_singleton()->parse_input_event(ev);
 
 					break;
 				}
@@ -592,7 +592,7 @@ void DisplayServerAndroid::process_touch(int p_what, int p_pointer, const Vector
 					ev->set_index(touch[i].id);
 					ev->set_pressed(false);
 					ev->set_position(touch[i].pos);
-					InputFilter::get_singleton()->parse_input_event(ev);
+					Input::get_singleton()->parse_input_event(ev);
 					touch.remove(i);
 
 					break;
@@ -613,7 +613,7 @@ void DisplayServerAndroid::process_hover(int p_type, Point2 p_pos) {
 			ev->set_position(p_pos);
 			ev->set_global_position(p_pos);
 			ev->set_relative(p_pos - hover_prev_pos);
-			InputFilter::get_singleton()->parse_input_event(ev);
+			Input::get_singleton()->parse_input_event(ev);
 			hover_prev_pos = p_pos;
 		} break;
 	}
@@ -626,7 +626,7 @@ void DisplayServerAndroid::process_double_tap(Point2 p_pos) {
 	ev->set_global_position(p_pos);
 	ev->set_pressed(false);
 	ev->set_doubleclick(true);
-	InputFilter::get_singleton()->parse_input_event(ev);
+	Input::get_singleton()->parse_input_event(ev);
 }
 
 void DisplayServerAndroid::process_scroll(Point2 p_pos) {
@@ -634,22 +634,22 @@ void DisplayServerAndroid::process_scroll(Point2 p_pos) {
 	ev.instance();
 	ev->set_position(p_pos);
 	ev->set_delta(p_pos - scroll_prev_pos);
-	InputFilter::get_singleton()->parse_input_event(ev);
+	Input::get_singleton()->parse_input_event(ev);
 	scroll_prev_pos = p_pos;
 }
 
 void DisplayServerAndroid::process_accelerometer(const Vector3 &p_accelerometer) {
-	InputFilter::get_singleton()->set_accelerometer(p_accelerometer);
+	Input::get_singleton()->set_accelerometer(p_accelerometer);
 }
 
 void DisplayServerAndroid::process_gravity(const Vector3 &p_gravity) {
-	InputFilter::get_singleton()->set_gravity(p_gravity);
+	Input::get_singleton()->set_gravity(p_gravity);
 }
 
 void DisplayServerAndroid::process_magnetometer(const Vector3 &p_magnetometer) {
-	InputFilter::get_singleton()->set_magnetometer(p_magnetometer);
+	Input::get_singleton()->set_magnetometer(p_magnetometer);
 }
 
 void DisplayServerAndroid::process_gyroscope(const Vector3 &p_gyroscope) {
-	InputFilter::get_singleton()->set_gyroscope(p_gyroscope);
+	Input::get_singleton()->set_gyroscope(p_gyroscope);
 }

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -38,7 +38,7 @@
 #include "api/jni_singleton.h"
 #include "audio_driver_jandroid.h"
 #include "core/engine.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/project_settings.h"
 #include "dir_access_jandroid.h"
 #include "display_server_android.h"
@@ -311,15 +311,15 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyhat(JNIEnv *env, j
 	int hat = 0;
 	if (p_hat_x != 0) {
 		if (p_hat_x < 0)
-			hat |= InputFilter::HAT_MASK_LEFT;
+			hat |= Input::HAT_MASK_LEFT;
 		else
-			hat |= InputFilter::HAT_MASK_RIGHT;
+			hat |= Input::HAT_MASK_RIGHT;
 	}
 	if (p_hat_y != 0) {
 		if (p_hat_y < 0)
-			hat |= InputFilter::HAT_MASK_UP;
+			hat |= Input::HAT_MASK_UP;
 		else
-			hat |= InputFilter::HAT_MASK_DOWN;
+			hat |= Input::HAT_MASK_DOWN;
 	}
 	jevent.hat = hat;
 
@@ -329,7 +329,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyhat(JNIEnv *env, j
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyconnectionchanged(JNIEnv *env, jclass clazz, jint p_device, jboolean p_connected, jstring p_name) {
 	if (os_android) {
 		String name = jstring_to_string(p_name, env);
-		InputFilter::get_singleton()->joy_connection_changed(p_device, p_connected, name);
+		Input::get_singleton()->joy_connection_changed(p_device, p_connected, name);
 	}
 }
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -88,7 +88,7 @@ void OS_Android::initialize() {
 }
 
 void OS_Android::initialize_joypads() {
-	InputFilter::get_singleton()->set_fallback_mapping(godot_java->get_input_fallback_mapping());
+	Input::get_singleton()->set_fallback_mapping(godot_java->get_input_fallback_mapping());
 
 	// This queries/updates the currently connected devices/joypads.
 	godot_java->init_input_devices();

--- a/platform/haiku/haiku_direct_window.h
+++ b/platform/haiku/haiku_direct_window.h
@@ -35,7 +35,7 @@
 
 #include <DirectWindow.h>
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/os.h"
 
 #include "haiku_gl_view.h"

--- a/platform/haiku/os_haiku.h
+++ b/platform/haiku/os_haiku.h
@@ -33,7 +33,7 @@
 
 #include "audio_driver_media_kit.h"
 #include "context_gl_haiku.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "drivers/unix/os_unix.h"
 #include "haiku_application.h"
 #include "haiku_direct_window.h"

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -33,7 +33,7 @@
 #ifndef OS_IPHONE_H
 #define OS_IPHONE_H
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "drivers/coreaudio/audio_driver_coreaudio.h"
 #include "drivers/unix/os_unix.h"
 #include "game_center.h"

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -32,7 +32,7 @@
 #define OS_JAVASCRIPT_H
 
 #include "audio_driver_javascript.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "drivers/unix/os_unix.h"
 #include "servers/audio_server.h"
 #include "servers/rendering/rasterizer.h"

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -208,7 +208,7 @@ void DisplayServerX11::_update_real_mouse_position(const WindowData &wd) {
 			last_mouse_pos.x = win_x;
 			last_mouse_pos.y = win_y;
 			last_mouse_pos_valid = true;
-			InputFilter::get_singleton()->set_mouse_position(last_mouse_pos);
+			Input::get_singleton()->set_mouse_position(last_mouse_pos);
 		}
 	}
 }
@@ -392,7 +392,7 @@ void DisplayServerX11::mouse_set_mode(MouseMode p_mode) {
 			XWarpPointer(x11_display, None, main_window.x11_window,
 					0, 0, 0, 0, (int)center.x, (int)center.y);
 
-			InputFilter::get_singleton()->set_mouse_position(center);
+			Input::get_singleton()->set_mouse_position(center);
 		}
 	} else {
 		do_mouse_warp = false;
@@ -2077,7 +2077,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 					k->set_shift(true);
 				}
 
-				InputFilter::get_singleton()->accumulate_input_event(k);
+				Input::get_singleton()->accumulate_input_event(k);
 			}
 			memfree(utf8string);
 			return;
@@ -2220,14 +2220,14 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 			k->set_metakey(false);
 	}
 
-	bool last_is_pressed = InputFilter::get_singleton()->is_key_pressed(k->get_keycode());
+	bool last_is_pressed = Input::get_singleton()->is_key_pressed(k->get_keycode());
 	if (k->is_pressed()) {
 		if (last_is_pressed) {
 			k->set_echo(true);
 		}
 	}
 
-	InputFilter::get_singleton()->accumulate_input_event(k);
+	Input::get_singleton()->accumulate_input_event(k);
 }
 
 void DisplayServerX11::_xim_destroy_callback(::XIM im, ::XPointer client_data,
@@ -2486,12 +2486,12 @@ void DisplayServerX11::process_events() {
 								// in a spurious mouse motion event being sent to Godot; remember it to be able to filter it out
 								xi.mouse_pos_to_filter = pos;
 							}
-							InputFilter::get_singleton()->accumulate_input_event(st);
+							Input::get_singleton()->accumulate_input_event(st);
 						} else {
 							if (!xi.state.has(index)) // Defensive
 								break;
 							xi.state.erase(index);
-							InputFilter::get_singleton()->accumulate_input_event(st);
+							Input::get_singleton()->accumulate_input_event(st);
 						}
 					} break;
 
@@ -2510,7 +2510,7 @@ void DisplayServerX11::process_events() {
 							sd->set_index(index);
 							sd->set_position(pos);
 							sd->set_relative(pos - curr_pos_elem->value());
-							InputFilter::get_singleton()->accumulate_input_event(sd);
+							Input::get_singleton()->accumulate_input_event(sd);
 
 							curr_pos_elem->value() = pos;
 						}
@@ -2580,7 +2580,7 @@ void DisplayServerX11::process_events() {
 
 			case FocusOut:
 				window_has_focus = false;
-				InputFilter::get_singleton()->release_pressed_events();
+				Input::get_singleton()->release_pressed_events();
 				_send_window_event(windows[window_id], WINDOW_EVENT_FOCUS_OUT);
 				window_focused = false;
 
@@ -2609,7 +2609,7 @@ void DisplayServerX11::process_events() {
 					st->set_index(E->key());
 					st->set_window_id(window_id);
 					st->set_position(E->get());
-					InputFilter::get_singleton()->accumulate_input_event(st);
+					Input::get_singleton()->accumulate_input_event(st);
 				}
 				xi.state.clear();
 #endif
@@ -2671,7 +2671,7 @@ void DisplayServerX11::process_events() {
 					}
 				}
 
-				InputFilter::get_singleton()->accumulate_input_event(mb);
+				Input::get_singleton()->accumulate_input_event(mb);
 
 			} break;
 			case MotionNotify: {
@@ -2773,8 +2773,8 @@ void DisplayServerX11::process_events() {
 				mm->set_button_mask(mouse_get_button_state());
 				mm->set_position(posi);
 				mm->set_global_position(posi);
-				InputFilter::get_singleton()->set_mouse_position(posi);
-				mm->set_speed(InputFilter::get_singleton()->get_last_mouse_speed());
+				Input::get_singleton()->set_mouse_position(posi);
+				mm->set_speed(Input::get_singleton()->get_last_mouse_speed());
 
 				mm->set_relative(rel);
 
@@ -2785,7 +2785,7 @@ void DisplayServerX11::process_events() {
 				// this is so that the relative motion doesn't get messed up
 				// after we regain focus.
 				if (window_has_focus || !mouse_mode_grab)
-					InputFilter::get_singleton()->accumulate_input_event(mm);
+					Input::get_singleton()->accumulate_input_event(mm);
 
 			} break;
 			case KeyPress:
@@ -2978,7 +2978,7 @@ void DisplayServerX11::process_events() {
 		*/
 	}
 
-	InputFilter::get_singleton()->flush_accumulated_events();
+	Input::get_singleton()->flush_accumulated_events();
 }
 
 void DisplayServerX11::release_rendering_thread() {
@@ -3373,7 +3373,7 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, u
 
 DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode p_mode, uint32_t p_flags, const Vector2i &p_resolution, Error &r_error) {
 
-	InputFilter::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
+	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
 
 	r_error = OK;
 

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -35,7 +35,7 @@
 
 #include "servers/display_server.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 
 #include "drivers/alsa/audio_driver_alsa.h"
 #include "drivers/alsamidi/midi_driver_alsamidi.h"

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -71,7 +71,7 @@ void JoypadLinux::Joypad::reset() {
 	dpad = 0;
 	fd = -1;
 
-	InputFilter::JoyAxis jx;
+	Input::JoyAxis jx;
 	jx.min = -1;
 	jx.value = 0.0f;
 	for (int i = 0; i < MAX_ABS; i++) {
@@ -80,7 +80,7 @@ void JoypadLinux::Joypad::reset() {
 	}
 }
 
-JoypadLinux::JoypadLinux(InputFilter *in) {
+JoypadLinux::JoypadLinux(Input *in) {
 	exit_udev = false;
 	input = in;
 	joy_thread = Thread::create(joy_thread_func, this);
@@ -436,11 +436,11 @@ void JoypadLinux::joypad_vibration_stop(int p_id, uint64_t p_timestamp) {
 	joy.ff_effect_timestamp = p_timestamp;
 }
 
-InputFilter::JoyAxis JoypadLinux::axis_correct(const input_absinfo *p_abs, int p_value) const {
+Input::JoyAxis JoypadLinux::axis_correct(const input_absinfo *p_abs, int p_value) const {
 
 	int min = p_abs->minimum;
 	int max = p_abs->maximum;
-	InputFilter::JoyAxis jx;
+	Input::JoyAxis jx;
 
 	if (min < 0) {
 		jx.min = -1;
@@ -492,11 +492,11 @@ void JoypadLinux::process_joypads() {
 							case ABS_HAT0X:
 								if (ev.value != 0) {
 									if (ev.value < 0)
-										joy->dpad |= InputFilter::HAT_MASK_LEFT;
+										joy->dpad |= Input::HAT_MASK_LEFT;
 									else
-										joy->dpad |= InputFilter::HAT_MASK_RIGHT;
+										joy->dpad |= Input::HAT_MASK_RIGHT;
 								} else
-									joy->dpad &= ~(InputFilter::HAT_MASK_LEFT | InputFilter::HAT_MASK_RIGHT);
+									joy->dpad &= ~(Input::HAT_MASK_LEFT | Input::HAT_MASK_RIGHT);
 
 								input->joy_hat(i, joy->dpad);
 								break;
@@ -504,11 +504,11 @@ void JoypadLinux::process_joypads() {
 							case ABS_HAT0Y:
 								if (ev.value != 0) {
 									if (ev.value < 0)
-										joy->dpad |= InputFilter::HAT_MASK_UP;
+										joy->dpad |= Input::HAT_MASK_UP;
 									else
-										joy->dpad |= InputFilter::HAT_MASK_DOWN;
+										joy->dpad |= Input::HAT_MASK_DOWN;
 								} else
-									joy->dpad &= ~(InputFilter::HAT_MASK_UP | InputFilter::HAT_MASK_DOWN);
+									joy->dpad &= ~(Input::HAT_MASK_UP | Input::HAT_MASK_DOWN);
 
 								input->joy_hat(i, joy->dpad);
 								break;
@@ -517,7 +517,7 @@ void JoypadLinux::process_joypads() {
 								if (ev.code >= MAX_ABS)
 									return;
 								if (joy->abs_map[ev.code] != -1 && joy->abs_info[ev.code]) {
-									InputFilter::JoyAxis value = axis_correct(joy->abs_info[ev.code], ev.value);
+									Input::JoyAxis value = axis_correct(joy->abs_info[ev.code], ev.value);
 									joy->curr_axis[joy->abs_map[ev.code]] = value;
 								}
 								break;

--- a/platform/linuxbsd/joypad_linux.h
+++ b/platform/linuxbsd/joypad_linux.h
@@ -33,7 +33,7 @@
 #define JOYPAD_LINUX_H
 
 #ifdef JOYDEV_ENABLED
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
 
@@ -41,7 +41,7 @@ struct input_absinfo;
 
 class JoypadLinux {
 public:
-	JoypadLinux(InputFilter *in);
+	JoypadLinux(Input *in);
 	~JoypadLinux();
 	void process_joypads();
 
@@ -53,7 +53,7 @@ private:
 	};
 
 	struct Joypad {
-		InputFilter::JoyAxis curr_axis[MAX_ABS];
+		Input::JoyAxis curr_axis[MAX_ABS];
 		int key_map[MAX_KEY];
 		int abs_map[MAX_ABS];
 		int dpad;
@@ -74,7 +74,7 @@ private:
 	bool exit_udev;
 	Mutex joy_mutex;
 	Thread *joy_thread;
-	InputFilter *input;
+	Input *input;
 	Joypad joypads[JOYPADS_MAX];
 	Vector<String> attached_devices;
 
@@ -95,7 +95,7 @@ private:
 	void joypad_vibration_start(int p_id, float p_weak_magnitude, float p_strong_magnitude, float p_duration, uint64_t p_timestamp);
 	void joypad_vibration_stop(int p_id, uint64_t p_timestamp);
 
-	InputFilter::JoyAxis axis_correct(const input_absinfo *p_abs, int p_value) const;
+	Input::JoyAxis axis_correct(const input_absinfo *p_abs, int p_value) const;
 };
 
 #endif

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -64,7 +64,7 @@ void OS_LinuxBSD::initialize() {
 void OS_LinuxBSD::initialize_joypads() {
 
 #ifdef JOYDEV_ENABLED
-	joypad = memnew(JoypadLinux(InputFilter::get_singleton()));
+	joypad = memnew(JoypadLinux(Input::get_singleton()));
 #endif
 }
 

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -31,7 +31,7 @@
 #ifndef OS_LINUXBSD_H
 #define OS_LINUXBSD_H
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "crash_handler_linuxbsd.h"
 #include "drivers/alsa/audio_driver_alsa.h"
 #include "drivers/alsamidi/midi_driver_alsamidi.h"

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -33,7 +33,7 @@
 
 #define BitMap _QDBitMap // Suppress deprecated QuickDraw definition.
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "servers/display_server.h"
 
 #if defined(OPENGL_ENABLED)

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -74,7 +74,7 @@ static Vector2i _get_mouse_pos(DisplayServerOSX::WindowData &p_wd, NSPoint p_loc
 	p_wd.mouse_pos.x = p.x * p_backingScaleFactor;
 	p_wd.mouse_pos.y = (contentRect.size.height - p.y) * p_backingScaleFactor;
 	DS_OSX->last_mouse_pos = p_wd.mouse_pos;
-	InputFilter::get_singleton()->set_mouse_position(p_wd.mouse_pos);
+	Input::get_singleton()->set_mouse_position(p_wd.mouse_pos);
 	return p_wd.mouse_pos;
 }
 
@@ -124,7 +124,7 @@ static NSCursor *_cursorFromSelector(SEL selector, SEL fallback = nil) {
 			k->set_physical_keycode(KEY_PERIOD);
 			k->set_echo([event isARepeat]);
 
-			InputFilter::get_singleton()->accumulate_input_event(k);
+			Input::get_singleton()->accumulate_input_event(k);
 		}
 	}
 
@@ -433,7 +433,7 @@ static NSCursor *_cursorFromSelector(SEL selector, SEL fallback = nil) {
 
 	const CGFloat backingScaleFactor = (OS::get_singleton()->is_hidpi_allowed()) ? [wd.window_view backingScaleFactor] : 1.0;
 	_get_mouse_pos(wd, [wd.window_object mouseLocationOutsideOfEventStream], backingScaleFactor);
-	InputFilter::get_singleton()->set_mouse_position(wd.mouse_pos);
+	Input::get_singleton()->set_mouse_position(wd.mouse_pos);
 
 	DS_OSX->window_focused = true;
 	DS_OSX->_send_window_event(wd, DisplayServerOSX::WINDOW_EVENT_FOCUS_IN);
@@ -759,7 +759,7 @@ static void _mouseDownEvent(DisplayServer::WindowID window_id, NSEvent *event, i
 		mb->set_doubleclick([event clickCount] == 2);
 	}
 
-	InputFilter::get_singleton()->accumulate_input_event(mb);
+	Input::get_singleton()->accumulate_input_event(mb);
 }
 
 - (void)mouseDown:(NSEvent *)event {
@@ -808,15 +808,15 @@ static void _mouseDownEvent(DisplayServer::WindowID window_id, NSEvent *event, i
 		mm->set_tilt(Vector2(p.x, p.y));
 	}
 	mm->set_global_position(pos);
-	mm->set_speed(InputFilter::get_singleton()->get_last_mouse_speed());
+	mm->set_speed(Input::get_singleton()->get_last_mouse_speed());
 	Vector2i relativeMotion = Vector2i();
 	relativeMotion.x = [event deltaX] * backingScaleFactor;
 	relativeMotion.y = [event deltaY] * backingScaleFactor;
 	mm->set_relative(relativeMotion);
 	_get_key_modifier_state([event modifierFlags], mm);
 
-	InputFilter::get_singleton()->set_mouse_position(wd.mouse_pos);
-	InputFilter::get_singleton()->accumulate_input_event(mm);
+	Input::get_singleton()->set_mouse_position(wd.mouse_pos);
+	Input::get_singleton()->accumulate_input_event(mm);
 }
 
 - (void)rightMouseDown:(NSEvent *)event {
@@ -891,7 +891,7 @@ static void _mouseDownEvent(DisplayServer::WindowID window_id, NSEvent *event, i
 	ev->set_position(_get_mouse_pos(wd, [event locationInWindow], backingScaleFactor));
 	ev->set_factor([event magnification] + 1.0);
 
-	InputFilter::get_singleton()->accumulate_input_event(ev);
+	Input::get_singleton()->accumulate_input_event(ev);
 }
 
 - (void)viewDidChangeBackingProperties {
@@ -1357,7 +1357,7 @@ inline void sendScrollEvent(DisplayServer::WindowID window_id, int button, doubl
 	DS_OSX->last_button_state |= mask;
 	sc->set_button_mask(DS_OSX->last_button_state);
 
-	InputFilter::get_singleton()->accumulate_input_event(sc);
+	Input::get_singleton()->accumulate_input_event(sc);
 
 	sc.instance();
 	sc->set_window_id(window_id);
@@ -1369,7 +1369,7 @@ inline void sendScrollEvent(DisplayServer::WindowID window_id, int button, doubl
 	DS_OSX->last_button_state &= ~mask;
 	sc->set_button_mask(DS_OSX->last_button_state);
 
-	InputFilter::get_singleton()->accumulate_input_event(sc);
+	Input::get_singleton()->accumulate_input_event(sc);
 }
 
 inline void sendPanEvent(DisplayServer::WindowID window_id, double dx, double dy, int modifierFlags) {
@@ -1384,7 +1384,7 @@ inline void sendPanEvent(DisplayServer::WindowID window_id, double dx, double dy
 	pg->set_position(wd.mouse_pos);
 	pg->set_delta(Vector2(-dx, -dy));
 
-	InputFilter::get_singleton()->accumulate_input_event(pg);
+	Input::get_singleton()->accumulate_input_event(pg);
 }
 
 - (void)scrollWheel:(NSEvent *)event {
@@ -3006,13 +3006,13 @@ DisplayServerOSX::LatinKeyboardVariant DisplayServerOSX::get_latin_keyboard_vari
 
 void DisplayServerOSX::_push_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEvent> ev = p_event;
-	InputFilter::get_singleton()->accumulate_input_event(ev);
+	Input::get_singleton()->accumulate_input_event(ev);
 }
 
 void DisplayServerOSX::_release_pressed_events() {
 	_THREAD_SAFE_METHOD_
-	if (InputFilter::get_singleton()) {
-		InputFilter::get_singleton()->release_pressed_events();
+	if (Input::get_singleton()) {
+		Input::get_singleton()->release_pressed_events();
 	}
 }
 
@@ -3088,7 +3088,7 @@ void DisplayServerOSX::process_events() {
 
 	if (!drop_events) {
 		_process_key_events();
-		InputFilter::get_singleton()->flush_accumulated_events();
+		Input::get_singleton()->flush_accumulated_events();
 	}
 
 	[autoreleasePool drain];
@@ -3397,7 +3397,7 @@ bool DisplayServerOSX::is_console_visible() const {
 }
 
 DisplayServerOSX::DisplayServerOSX(const String &p_rendering_driver, WindowMode p_mode, uint32_t p_flags, const Vector2i &p_resolution, Error &r_error) {
-	InputFilter::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
+	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
 
 	r_error = OK;
 	drop_events = false;

--- a/platform/osx/joypad_osx.cpp
+++ b/platform/osx/joypad_osx.cpp
@@ -395,38 +395,38 @@ bool joypad::check_ff_features() {
 static int process_hat_value(int p_min, int p_max, int p_value) {
 	int range = (p_max - p_min + 1);
 	int value = p_value - p_min;
-	int hat_value = InputFilter::HAT_MASK_CENTER;
+	int hat_value = Input::HAT_MASK_CENTER;
 	if (range == 4) {
 		value *= 2;
 	}
 
 	switch (value) {
 		case 0:
-			hat_value = InputFilter::HAT_MASK_UP;
+			hat_value = Input::HAT_MASK_UP;
 			break;
 		case 1:
-			hat_value = InputFilter::HAT_MASK_UP | InputFilter::HAT_MASK_RIGHT;
+			hat_value = Input::HAT_MASK_UP | Input::HAT_MASK_RIGHT;
 			break;
 		case 2:
-			hat_value = InputFilter::HAT_MASK_RIGHT;
+			hat_value = Input::HAT_MASK_RIGHT;
 			break;
 		case 3:
-			hat_value = InputFilter::HAT_MASK_DOWN | InputFilter::HAT_MASK_RIGHT;
+			hat_value = Input::HAT_MASK_DOWN | Input::HAT_MASK_RIGHT;
 			break;
 		case 4:
-			hat_value = InputFilter::HAT_MASK_DOWN;
+			hat_value = Input::HAT_MASK_DOWN;
 			break;
 		case 5:
-			hat_value = InputFilter::HAT_MASK_DOWN | InputFilter::HAT_MASK_LEFT;
+			hat_value = Input::HAT_MASK_DOWN | Input::HAT_MASK_LEFT;
 			break;
 		case 6:
-			hat_value = InputFilter::HAT_MASK_LEFT;
+			hat_value = Input::HAT_MASK_LEFT;
 			break;
 		case 7:
-			hat_value = InputFilter::HAT_MASK_UP | InputFilter::HAT_MASK_LEFT;
+			hat_value = Input::HAT_MASK_UP | Input::HAT_MASK_LEFT;
 			break;
 		default:
-			hat_value = InputFilter::HAT_MASK_CENTER;
+			hat_value = Input::HAT_MASK_CENTER;
 			break;
 	}
 	return hat_value;
@@ -438,8 +438,8 @@ void JoypadOSX::poll_joypads() const {
 	}
 }
 
-static const InputFilter::JoyAxis axis_correct(int p_value, int p_min, int p_max) {
-	InputFilter::JoyAxis jx;
+static const Input::JoyAxis axis_correct(int p_value, int p_min, int p_max) {
+	Input::JoyAxis jx;
 	if (p_min < 0) {
 		jx.min = -1;
 		if (p_value < 0) {
@@ -571,7 +571,7 @@ void JoypadOSX::config_hid_manager(CFArrayRef p_matching_array) const {
 	}
 }
 
-JoypadOSX::JoypadOSX(InputFilter *in) {
+JoypadOSX::JoypadOSX(Input *in) {
 	self = this;
 	input = in;
 

--- a/platform/osx/joypad_osx.h
+++ b/platform/osx/joypad_osx.h
@@ -40,7 +40,7 @@
 #include <ForceFeedback/ForceFeedbackConstants.h>
 #include <IOKit/hid/IOHIDLib.h>
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 
 struct rec_element {
 	IOHIDElementRef ref;
@@ -94,7 +94,7 @@ class JoypadOSX {
 	};
 
 private:
-	InputFilter *input;
+	Input *input;
 	IOHIDManagerRef hid_manager;
 
 	Vector<joypad> device_list;
@@ -118,7 +118,7 @@ public:
 	void _device_added(IOReturn p_res, IOHIDDeviceRef p_device);
 	void _device_removed(IOReturn p_res, IOHIDDeviceRef p_device);
 
-	JoypadOSX(InputFilter *in);
+	JoypadOSX(Input *in);
 	~JoypadOSX();
 };
 

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -31,7 +31,7 @@
 #ifndef OS_OSX_H
 #define OS_OSX_H
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "crash_handler_osx.h"
 #include "drivers/coreaudio/audio_driver_coreaudio.h"
 #include "drivers/coremidi/midi_driver_coremidi.h"

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -128,7 +128,7 @@ void OS_OSX::initialize_core() {
 }
 
 void OS_OSX::initialize_joypads() {
-	joypad_osx = memnew(JoypadOSX(InputFilter::get_singleton()));
+	joypad_osx = memnew(JoypadOSX(Input::get_singleton()));
 }
 
 void OS_OSX::initialize() {

--- a/platform/server/os_server.h
+++ b/platform/server/os_server.h
@@ -31,7 +31,7 @@
 #ifndef OS_SERVER_H
 #define OS_SERVER_H
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "drivers/dummy/texture_loader_dummy.h"
 #include "drivers/unix/os_unix.h"
 #ifdef __APPLE__

--- a/platform/uwp/joypad_uwp.h
+++ b/platform/uwp/joypad_uwp.h
@@ -31,7 +31,7 @@
 #ifndef JOYPAD_UWP_H
 #define JOYPAD_UWP_H
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 
 ref class JoypadUWP sealed {
 

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -32,7 +32,7 @@
 #define OS_UWP_H
 
 #include "context_egl_uwp.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/math/transform_2d.h"
 #include "core/os/os.h"
 #include "core/ustring.h"

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -666,7 +666,7 @@ void DisplayServerWindows::_update_real_mouse_position(WindowID p_window) {
 			old_x = mouse_pos.x;
 			old_y = mouse_pos.y;
 			old_invalid = false;
-			InputFilter::get_singleton()->set_mouse_position(Point2i(mouse_pos.x, mouse_pos.y));
+			Input::get_singleton()->set_mouse_position(Point2i(mouse_pos.x, mouse_pos.y));
 		}
 	}
 }
@@ -1511,7 +1511,7 @@ void DisplayServerWindows::process_events() {
 
 	if (!drop_events) {
 		_process_key_events();
-		InputFilter::get_singleton()->flush_accumulated_events();
+		Input::get_singleton()->flush_accumulated_events();
 	}
 }
 
@@ -1715,7 +1715,7 @@ void DisplayServerWindows::_touch_event(WindowID p_window, bool p_pressed, float
 	event->set_pressed(p_pressed);
 	event->set_position(Vector2(p_x, p_y));
 
-	InputFilter::get_singleton()->accumulate_input_event(event);
+	Input::get_singleton()->accumulate_input_event(event);
 }
 
 void DisplayServerWindows::_drag_event(WindowID p_window, float p_x, float p_y, int idx) {
@@ -1735,7 +1735,7 @@ void DisplayServerWindows::_drag_event(WindowID p_window, float p_x, float p_y, 
 	event->set_position(Vector2(p_x, p_y));
 	event->set_relative(Vector2(p_x, p_y) - curr->get());
 
-	InputFilter::get_singleton()->accumulate_input_event(event);
+	Input::get_singleton()->accumulate_input_event(event);
 
 	curr->get() = Vector2(p_x, p_y);
 }
@@ -1843,7 +1843,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				control_mem = false;
 				shift_mem = false;
 			} else { // WM_INACTIVE
-				InputFilter::get_singleton()->release_pressed_events();
+				Input::get_singleton()->release_pressed_events();
 				_send_window_event(windows[window_id], WINDOW_EVENT_FOCUS_OUT);
 				windows[window_id].window_focused = false;
 				alt_mem = false;
@@ -1940,7 +1940,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 				mm->set_position(c);
 				mm->set_global_position(c);
-				InputFilter::get_singleton()->set_mouse_position(c);
+				Input::get_singleton()->set_mouse_position(c);
 				mm->set_speed(Vector2(0, 0));
 
 				if (raw->data.mouse.usFlags == MOUSE_MOVE_RELATIVE) {
@@ -1973,7 +1973,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				}
 
 				if (windows[window_id].window_has_focus && mm->get_relative() != Vector2())
-					InputFilter::get_singleton()->accumulate_input_event(mm);
+					Input::get_singleton()->accumulate_input_event(mm);
 			}
 			delete[] lpb;
 		} break;
@@ -2001,7 +2001,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				break;
 			}
 
-			if (InputFilter::get_singleton()->is_emulating_mouse_from_touch()) {
+			if (Input::get_singleton()->is_emulating_mouse_from_touch()) {
 				// Universal translation enabled; ignore OS translation
 				LPARAM extra = GetMessageExtraInfo();
 				if (IsTouchEvent(extra)) {
@@ -2074,8 +2074,8 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				SetCursorPos(pos.x, pos.y);
 			}
 
-			InputFilter::get_singleton()->set_mouse_position(mm->get_position());
-			mm->set_speed(InputFilter::get_singleton()->get_last_mouse_speed());
+			Input::get_singleton()->set_mouse_position(mm->get_position());
+			mm->set_speed(Input::get_singleton()->get_last_mouse_speed());
 
 			if (old_invalid) {
 
@@ -2088,7 +2088,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			old_x = mm->get_position().x;
 			old_y = mm->get_position().y;
 			if (windows[window_id].window_has_focus) {
-				InputFilter::get_singleton()->parse_input_event(mm);
+				Input::get_singleton()->parse_input_event(mm);
 			}
 
 			return 0; //Pointer event handled return 0 to avoid duplicate WM_MOUSEMOVE event
@@ -2098,7 +2098,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				break;
 			}
 
-			if (InputFilter::get_singleton()->is_emulating_mouse_from_touch()) {
+			if (Input::get_singleton()->is_emulating_mouse_from_touch()) {
 				// Universal translation enabled; ignore OS translation
 				LPARAM extra = GetMessageExtraInfo();
 				if (IsTouchEvent(extra)) {
@@ -2161,8 +2161,8 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				SetCursorPos(pos.x, pos.y);
 			}
 
-			InputFilter::get_singleton()->set_mouse_position(mm->get_position());
-			mm->set_speed(InputFilter::get_singleton()->get_last_mouse_speed());
+			Input::get_singleton()->set_mouse_position(mm->get_position());
+			mm->set_speed(Input::get_singleton()->get_last_mouse_speed());
 
 			if (old_invalid) {
 
@@ -2175,12 +2175,12 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			old_x = mm->get_position().x;
 			old_y = mm->get_position().y;
 			if (windows[window_id].window_has_focus)
-				InputFilter::get_singleton()->accumulate_input_event(mm);
+				Input::get_singleton()->accumulate_input_event(mm);
 
 		} break;
 		case WM_LBUTTONDOWN:
 		case WM_LBUTTONUP:
-			if (InputFilter::get_singleton()->is_emulating_mouse_from_touch()) {
+			if (Input::get_singleton()->is_emulating_mouse_from_touch()) {
 				// Universal translation enabled; ignore OS translations for left button
 				LPARAM extra = GetMessageExtraInfo();
 				if (IsTouchEvent(extra)) {
@@ -2347,7 +2347,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 			mb->set_global_position(mb->get_position());
 
-			InputFilter::get_singleton()->accumulate_input_event(mb);
+			Input::get_singleton()->accumulate_input_event(mb);
 			if (mb->is_pressed() && mb->get_button_index() > 3 && mb->get_button_index() < 8) {
 				//send release for mouse wheel
 				Ref<InputEventMouseButton> mbd = mb->duplicate();
@@ -2355,7 +2355,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				last_button_state &= ~(1 << (mbd->get_button_index() - 1));
 				mbd->set_button_mask(last_button_state);
 				mbd->set_pressed(false);
-				InputFilter::get_singleton()->accumulate_input_event(mbd);
+				Input::get_singleton()->accumulate_input_event(mbd);
 			}
 
 		} break;
@@ -2444,7 +2444,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 		} break;
 
 		case WM_ENTERSIZEMOVE: {
-			InputFilter::get_singleton()->release_pressed_events();
+			Input::get_singleton()->release_pressed_events();
 			move_timer_id = SetTimer(windows[window_id].hWnd, 1, USER_TIMER_MINIMUM, (TIMERPROC) nullptr);
 		} break;
 		case WM_EXITSIZEMOVE: {
@@ -2652,7 +2652,7 @@ void DisplayServerWindows::_process_key_events() {
 					if (k->get_unicode() < 32)
 						k->set_unicode(0);
 
-					InputFilter::get_singleton()->accumulate_input_event(k);
+					Input::get_singleton()->accumulate_input_event(k);
 				}
 
 				//do nothing
@@ -2693,7 +2693,7 @@ void DisplayServerWindows::_process_key_events() {
 
 				k->set_echo((ke.uMsg == WM_KEYDOWN && (ke.lParam & (1 << 30))));
 
-				InputFilter::get_singleton()->accumulate_input_event(k);
+				Input::get_singleton()->accumulate_input_event(k);
 
 			} break;
 		}
@@ -2945,7 +2945,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	r_error = OK;
 
 	((OS_Windows *)OS::get_singleton())->set_main_window(windows[MAIN_WINDOW_ID].hWnd);
-	InputFilter::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
+	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
 }
 
 Vector<String> DisplayServerWindows::get_rendering_drivers_func() {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -33,7 +33,7 @@
 
 #include "servers/display_server.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "crash_handler_windows.h"

--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -54,7 +54,7 @@ JoypadWindows::JoypadWindows() {
 
 JoypadWindows::JoypadWindows(HWND *hwnd) {
 
-	input = InputFilter::get_singleton();
+	input = Input::get_singleton();
 	hWnd = hwnd;
 	joypad_count = 0;
 	dinput = nullptr;
@@ -436,46 +436,46 @@ void JoypadWindows::post_hat(int p_device, DWORD p_dpad) {
 	//  BOOL POVCentered = (LOWORD(dwPOV) == 0xFFFF);"
 	// https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ee416628(v%3Dvs.85)#remarks
 	if (LOWORD(p_dpad) == 0xFFFF) {
-		dpad_val = InputFilter::HAT_MASK_CENTER;
+		dpad_val = Input::HAT_MASK_CENTER;
 	}
 	if (p_dpad == 0) {
 
-		dpad_val = InputFilter::HAT_MASK_UP;
+		dpad_val = Input::HAT_MASK_UP;
 
 	} else if (p_dpad == 4500) {
 
-		dpad_val = (InputFilter::HAT_MASK_UP | InputFilter::HAT_MASK_RIGHT);
+		dpad_val = (Input::HAT_MASK_UP | Input::HAT_MASK_RIGHT);
 
 	} else if (p_dpad == 9000) {
 
-		dpad_val = InputFilter::HAT_MASK_RIGHT;
+		dpad_val = Input::HAT_MASK_RIGHT;
 
 	} else if (p_dpad == 13500) {
 
-		dpad_val = (InputFilter::HAT_MASK_RIGHT | InputFilter::HAT_MASK_DOWN);
+		dpad_val = (Input::HAT_MASK_RIGHT | Input::HAT_MASK_DOWN);
 
 	} else if (p_dpad == 18000) {
 
-		dpad_val = InputFilter::HAT_MASK_DOWN;
+		dpad_val = Input::HAT_MASK_DOWN;
 
 	} else if (p_dpad == 22500) {
 
-		dpad_val = (InputFilter::HAT_MASK_DOWN | InputFilter::HAT_MASK_LEFT);
+		dpad_val = (Input::HAT_MASK_DOWN | Input::HAT_MASK_LEFT);
 
 	} else if (p_dpad == 27000) {
 
-		dpad_val = InputFilter::HAT_MASK_LEFT;
+		dpad_val = Input::HAT_MASK_LEFT;
 
 	} else if (p_dpad == 31500) {
 
-		dpad_val = (InputFilter::HAT_MASK_LEFT | InputFilter::HAT_MASK_UP);
+		dpad_val = (Input::HAT_MASK_LEFT | Input::HAT_MASK_UP);
 	}
 	input->joy_hat(p_device, dpad_val);
 };
 
-InputFilter::JoyAxis JoypadWindows::axis_correct(int p_val, bool p_xinput, bool p_trigger, bool p_negate) const {
+Input::JoyAxis JoypadWindows::axis_correct(int p_val, bool p_xinput, bool p_trigger, bool p_negate) const {
 
-	InputFilter::JoyAxis jx;
+	Input::JoyAxis jx;
 	if (Math::abs(p_val) < MIN_JOY_AXIS) {
 		jx.min = p_trigger ? 0 : -1;
 		jx.value = 0.0f;

--- a/platform/windows/joypad_windows.h
+++ b/platform/windows/joypad_windows.h
@@ -117,7 +117,7 @@ private:
 	HWND *hWnd;
 	HANDLE xinput_dll;
 	LPDIRECTINPUT8 dinput;
-	InputFilter *input;
+	Input *input;
 
 	int id_to_change;
 	int joypad_count;
@@ -141,7 +141,7 @@ private:
 	void joypad_vibration_start_xinput(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration, uint64_t p_timestamp);
 	void joypad_vibration_stop_xinput(int p_device, uint64_t p_timestamp);
 
-	InputFilter::JoyAxis axis_correct(int p_val, bool p_xinput = false, bool p_trigger = false, bool p_negate = false) const;
+	Input::JoyAxis axis_correct(int p_val, bool p_xinput = false, bool p_trigger = false, bool p_negate = false) const;
 	XInputGetState_t xinput_get_state;
 	XInputSetState_t xinput_set_state;
 };

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -31,7 +31,7 @@
 #ifndef OS_WINDOWS_H
 #define OS_WINDOWS_H
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "crash_handler_windows.h"

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -30,7 +30,7 @@
 
 #include "touch_screen_button.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/input/input_map.h"
 #include "core/os/os.h"
 #include "scene/main/window.h"
@@ -290,7 +290,7 @@ void TouchScreenButton::_press(int p_finger_pressed) {
 
 	if (action != StringName()) {
 
-		InputFilter::get_singleton()->action_press(action);
+		Input::get_singleton()->action_press(action);
 		Ref<InputEventAction> iea;
 		iea.instance();
 		iea->set_action(action);
@@ -308,7 +308,7 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 
 	if (action != StringName()) {
 
-		InputFilter::get_singleton()->action_release(action);
+		Input::get_singleton()->action_release(action);
 		if (!p_exiting_tree) {
 
 			Ref<InputEventAction> iea;

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -29,7 +29,7 @@
 /*************************************************************************/
 
 #include "xr_nodes.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "servers/xr/xr_interface.h"
 #include "servers/xr_server.h"
 
@@ -206,7 +206,7 @@ void XRController3D::_notification(int p_what) {
 					// check button states
 					for (int i = 0; i < 16; i++) {
 						bool was_pressed = (button_states & mask) == mask;
-						bool is_pressed = InputFilter::get_singleton()->is_joy_button_pressed(joy_id, i);
+						bool is_pressed = Input::get_singleton()->is_joy_button_pressed(joy_id, i);
 
 						if (!was_pressed && is_pressed) {
 							emit_signal("button_pressed", i);
@@ -306,7 +306,7 @@ bool XRController3D::is_button_pressed(int p_button) const {
 		return false;
 	};
 
-	return InputFilter::get_singleton()->is_joy_button_pressed(joy_id, p_button);
+	return Input::get_singleton()->is_joy_button_pressed(joy_id, p_button);
 };
 
 float XRController3D::get_joystick_axis(int p_axis) const {
@@ -315,7 +315,7 @@ float XRController3D::get_joystick_axis(int p_axis) const {
 		return 0.0;
 	};
 
-	return InputFilter::get_singleton()->get_joy_axis(joy_id, p_axis);
+	return Input::get_singleton()->get_joy_axis(joy_id, p_axis);
 };
 
 real_t XRController3D::get_rumble() const {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -30,7 +30,7 @@
 
 #include "color_picker.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -30,7 +30,7 @@
 
 #include "graph_edit.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "scene/gui/box_container.h"
 
@@ -804,7 +804,7 @@ void GraphEdit::set_selected(Node *p_child) {
 void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 	Ref<InputEventMouseMotion> mm = p_ev;
-	if (mm.is_valid() && (mm->get_button_mask() & BUTTON_MASK_MIDDLE || (mm->get_button_mask() & BUTTON_MASK_LEFT && InputFilter::get_singleton()->is_key_pressed(KEY_SPACE)))) {
+	if (mm.is_valid() && (mm->get_button_mask() & BUTTON_MASK_MIDDLE || (mm->get_button_mask() & BUTTON_MASK_LEFT && Input::get_singleton()->is_key_pressed(KEY_SPACE)))) {
 		h_scroll->set_value(h_scroll->get_value() - mm->get_relative().x);
 		v_scroll->set_value(v_scroll->get_value() - mm->get_relative().y);
 	}
@@ -823,7 +823,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 				// Snapping can be toggled temporarily by holding down Ctrl.
 				// This is done here as to not toggle the grid when holding down Ctrl.
-				if (is_using_snap() ^ InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL)) {
+				if (is_using_snap() ^ Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 					const int snap = get_snap();
 					pos = pos.snapped(Vector2(snap, snap));
 				}
@@ -886,7 +886,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 		}
 
 		if (b->get_button_index() == BUTTON_LEFT && !b->is_pressed() && dragging) {
-			if (!just_selected && drag_accum == Vector2() && InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL)) {
+			if (!just_selected && drag_accum == Vector2() && Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 				//deselect current node
 				for (int i = get_child_count() - 1; i >= 0; i--) {
 					GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
@@ -948,7 +948,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 				drag_accum = Vector2();
 				drag_origin = get_local_mouse_position();
 				just_selected = !gn->is_selected();
-				if (!gn->is_selected() && !InputFilter::get_singleton()->is_key_pressed(KEY_CONTROL)) {
+				if (!gn->is_selected() && !Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 					for (int i = 0; i < get_child_count(); i++) {
 						GraphNode *o_gn = Object::cast_to<GraphNode>(get_child(i));
 						if (o_gn) {
@@ -976,7 +976,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 			} else {
 				if (_filter_input(b->get_position()))
 					return;
-				if (InputFilter::get_singleton()->is_key_pressed(KEY_SPACE))
+				if (Input::get_singleton()->is_key_pressed(KEY_SPACE))
 					return;
 
 				box_selecting = true;
@@ -1035,16 +1035,16 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 			//too difficult to get right
 			//set_zoom(zoom/ZOOM_SCALE);
 		}
-		if (b->get_button_index() == BUTTON_WHEEL_UP && !InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+		if (b->get_button_index() == BUTTON_WHEEL_UP && !Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 			v_scroll->set_value(v_scroll->get_value() - v_scroll->get_page() * b->get_factor() / 8);
 		}
-		if (b->get_button_index() == BUTTON_WHEEL_DOWN && !InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+		if (b->get_button_index() == BUTTON_WHEEL_DOWN && !Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 			v_scroll->set_value(v_scroll->get_value() + v_scroll->get_page() * b->get_factor() / 8);
 		}
-		if (b->get_button_index() == BUTTON_WHEEL_RIGHT || (b->get_button_index() == BUTTON_WHEEL_DOWN && InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT))) {
+		if (b->get_button_index() == BUTTON_WHEEL_RIGHT || (b->get_button_index() == BUTTON_WHEEL_DOWN && Input::get_singleton()->is_key_pressed(KEY_SHIFT))) {
 			h_scroll->set_value(h_scroll->get_value() + h_scroll->get_page() * b->get_factor() / 8);
 		}
-		if (b->get_button_index() == BUTTON_WHEEL_LEFT || (b->get_button_index() == BUTTON_WHEEL_UP && InputFilter::get_singleton()->is_key_pressed(KEY_SHIFT))) {
+		if (b->get_button_index() == BUTTON_WHEEL_LEFT || (b->get_button_index() == BUTTON_WHEEL_UP && Input::get_singleton()->is_key_pressed(KEY_SHIFT))) {
 			h_scroll->set_value(h_scroll->get_value() - h_scroll->get_page() * b->get_factor() / 8);
 		}
 	}

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -30,7 +30,7 @@
 
 #include "popup_menu.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/print_string.h"
@@ -594,7 +594,7 @@ void PopupMenu::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_POST_POPUP: {
 
-			initial_button_mask = InputFilter::get_singleton()->get_mouse_button_mask();
+			initial_button_mask = Input::get_singleton()->get_mouse_button_mask();
 			during_grabbed_click = (bool)initial_button_mask;
 		} break;
 		case NOTIFICATION_WM_SIZE_CHANGED: {

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -30,7 +30,7 @@
 
 #include "spin_box.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/math/expression.h"
 
 Size2 SpinBox::get_minimum_size() const {
@@ -77,7 +77,7 @@ void SpinBox::_line_edit_input(const Ref<InputEvent> &p_event) {
 
 void SpinBox::_range_click_timeout() {
 
-	if (!drag.enabled && InputFilter::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT)) {
+	if (!drag.enabled && Input::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT)) {
 
 		bool up = get_local_mouse_position().y < (get_size().height / 2);
 		set_value(get_value() + (up ? get_step() : -get_step()));
@@ -149,7 +149,7 @@ void SpinBox::_gui_input(const Ref<InputEvent> &p_event) {
 
 		if (drag.enabled) {
 			drag.enabled = false;
-			InputFilter::get_singleton()->set_mouse_mode(InputFilter::MOUSE_MODE_VISIBLE);
+			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
 			warp_mouse(drag.capture_pos);
 		}
 		drag.allowed = false;
@@ -166,7 +166,7 @@ void SpinBox::_gui_input(const Ref<InputEvent> &p_event) {
 			set_value(CLAMP(drag.base_val + get_step() * diff_y, get_min(), get_max()));
 		} else if (drag.allowed && drag.capture_pos.distance_to(mm->get_position()) > 2) {
 
-			InputFilter::get_singleton()->set_mouse_mode(InputFilter::MOUSE_MODE_CAPTURED);
+			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
 			drag.enabled = true;
 			drag.base_val = get_value();
 			drag.diff_y = 0;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -30,7 +30,7 @@
 
 #include "text_edit.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/message_queue.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
@@ -446,7 +446,7 @@ void TextEdit::_click_selection_held() {
 	// Warning: is_mouse_button_pressed(BUTTON_LEFT) returns false for double+ clicks, so this doesn't work for MODE_WORD
 	// and MODE_LINE. However, moving the mouse triggers _gui_input, which calls these functions too, so that's not a huge problem.
 	// I'm unsure if there's an actual fix that doesn't have a ton of side effects.
-	if (InputFilter::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT) && selection.selecting_mode != Selection::MODE_NONE) {
+	if (Input::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT) && selection.selecting_mode != Selection::MODE_NONE) {
 		switch (selection.selecting_mode) {
 			case Selection::MODE_POINTER: {
 				_update_selection_mode_pointer();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -30,7 +30,7 @@
 
 #include "tree.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/math/math_funcs.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
@@ -1425,7 +1425,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 					if (p_item->cells[i].custom_button) {
 						if (cache.hover_item == p_item && cache.hover_cell == i) {
-							if (InputFilter::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT)) {
+							if (Input::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT)) {
 								draw_style_box(cache.custom_button_pressed, ir);
 							} else {
 								draw_style_box(cache.custom_button_hover, ir);
@@ -1661,7 +1661,7 @@ Rect2 Tree::search_item_rect(TreeItem *p_from, TreeItem *p_item) {
 
 void Tree::_range_click_timeout() {
 
-	if (range_item_last && !range_drag_enabled && InputFilter::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT)) {
+	if (range_item_last && !range_drag_enabled && Input::get_singleton()->is_mouse_button_pressed(BUTTON_LEFT)) {
 
 		Point2 pos = get_local_mouse_position() - cache.bg->get_offset();
 		if (show_column_titles) {
@@ -2048,9 +2048,9 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 
 void Tree::_text_editor_modal_close() {
 
-	if (InputFilter::get_singleton()->is_key_pressed(KEY_ESCAPE) ||
-			InputFilter::get_singleton()->is_key_pressed(KEY_KP_ENTER) ||
-			InputFilter::get_singleton()->is_key_pressed(KEY_ENTER)) {
+	if (Input::get_singleton()->is_key_pressed(KEY_ESCAPE) ||
+			Input::get_singleton()->is_key_pressed(KEY_KP_ENTER) ||
+			Input::get_singleton()->is_key_pressed(KEY_ENTER)) {
 
 		return;
 	}
@@ -2532,7 +2532,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 					range_drag_enabled = true;
 					range_drag_capture_pos = cpos;
 					range_drag_base = popup_edited_item->get_range(popup_edited_item_col);
-					InputFilter::get_singleton()->set_mouse_mode(InputFilter::MOUSE_MODE_CAPTURED);
+					Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
 				}
 			} else {
 
@@ -2594,7 +2594,7 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 					if (range_drag_enabled) {
 
 						range_drag_enabled = false;
-						InputFilter::get_singleton()->set_mouse_mode(InputFilter::MOUSE_MODE_VISIBLE);
+						Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
 						warp_mouse(range_drag_capture_pos);
 					} else {
 						Rect2 rect = get_selected()->get_meta("__focus_rect");
@@ -3238,7 +3238,7 @@ void Tree::clear() {
 	if (pressing_for_editor) {
 		if (range_drag_enabled) {
 			range_drag_enabled = false;
-			InputFilter::get_singleton()->set_mouse_mode(InputFilter::MOUSE_MODE_VISIBLE);
+			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
 			warp_mouse(range_drag_capture_pos);
 		}
 		pressing_for_editor = false;

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -30,7 +30,7 @@
 
 #include "canvas_item.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/message_queue.h"
 #include "core/method_bind_ext.gen.inc"
 #include "scene/main/canvas_layer.h"

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -31,7 +31,7 @@
 #include "scene_tree.h"
 
 #include "core/debugger/engine_debugger.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/io/marshalls.h"
 #include "core/io/resource_loader.h"
 #include "core/message_queue.h"
@@ -576,7 +576,7 @@ void SceneTree::_main_window_go_back() {
 }
 
 void SceneTree::_main_window_focus_in() {
-	InputFilter *id = InputFilter::get_singleton();
+	Input *id = Input::get_singleton();
 	if (id) {
 		id->ensure_touch_mouse_raised();
 	}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -32,7 +32,7 @@
 
 #include "core/core_string_names.h"
 #include "core/debugger/engine_debugger.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "scene/2d/collision_object_2d.h"
@@ -582,7 +582,7 @@ void Viewport::_notification(int p_what) {
 				RS::get_singleton()->multimesh_set_visible_instances(contact_3d_debug_multimesh, point_count);
 			}
 
-			if (physics_object_picking && (to_screen_rect == Rect2i() || InputFilter::get_singleton()->get_mouse_mode() != InputFilter::MOUSE_MODE_CAPTURED)) {
+			if (physics_object_picking && (to_screen_rect == Rect2i() || Input::get_singleton()->get_mouse_mode() != Input::MOUSE_MODE_CAPTURED)) {
 
 #ifndef _3D_DISABLED
 				Vector2 last_pos(1e20, 1e20);
@@ -1517,7 +1517,7 @@ Vector2 Viewport::get_mouse_position() const {
 void Viewport::warp_mouse(const Vector2 &p_pos) {
 
 	Vector2 gpos = (get_final_transform().affine_inverse() * _get_input_pre_xform()).affine_inverse().xform(p_pos);
-	InputFilter::get_singleton()->warp_mouse_position(gpos);
+	Input::get_singleton()->warp_mouse_position(gpos);
 }
 
 void Viewport::_gui_sort_roots() {
@@ -2091,7 +2091,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 		gui.mouse_over = over;
 
-		DisplayServer::CursorShape ds_cursor_shape = (DisplayServer::CursorShape)InputFilter::get_singleton()->get_default_cursor_shape();
+		DisplayServer::CursorShape ds_cursor_shape = (DisplayServer::CursorShape)Input::get_singleton()->get_default_cursor_shape();
 
 		if (over) {
 
@@ -2411,7 +2411,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		if (from && p_event->is_pressed()) {
 			Control *next = nullptr;
 
-			InputFilter *input = InputFilter::get_singleton();
+			Input *input = Input::get_singleton();
 
 			if (p_event->is_action_pressed("ui_focus_next") && input->is_action_just_pressed("ui_focus_next")) {
 
@@ -3064,7 +3064,7 @@ void Viewport::unhandled_input(const Ref<InputEvent> &p_event, bool p_local_coor
 
 	if (physics_object_picking && !is_input_handled()) {
 
-		if (InputFilter::get_singleton()->get_mouse_mode() != InputFilter::MOUSE_MODE_CAPTURED &&
+		if (Input::get_singleton()->get_mouse_mode() != Input::MOUSE_MODE_CAPTURED &&
 				(Object::cast_to<InputEventMouseButton>(*ev) ||
 						Object::cast_to<InputEventMouseMotion>(*ev) ||
 						Object::cast_to<InputEventScreenDrag>(*ev) ||

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -30,7 +30,7 @@
 
 #include "display_server.h"
 
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "scene/resources/texture.h"
 
 DisplayServer *DisplayServer::singleton = nullptr;
@@ -164,7 +164,7 @@ float DisplayServer::screen_get_scale(int p_screen) const {
 
 bool DisplayServer::screen_is_touchscreen(int p_screen) const {
 	//return false;
-	return InputFilter::get_singleton() && InputFilter::get_singleton()->is_emulating_touch_from_mouse();
+	return Input::get_singleton() && Input::get_singleton()->is_emulating_touch_from_mouse();
 }
 
 void DisplayServer::screen_set_keep_on(bool p_enable) {
@@ -563,31 +563,31 @@ DisplayServer *DisplayServer::create(int p_index, const String &p_rendering_driv
 	return server_create_functions[p_index].create_function(p_rendering_driver, p_mode, p_flags, p_resolution, r_error);
 }
 
-void DisplayServer::_input_set_mouse_mode(InputFilter::MouseMode p_mode) {
+void DisplayServer::_input_set_mouse_mode(Input::MouseMode p_mode) {
 	singleton->mouse_set_mode(MouseMode(p_mode));
 }
-InputFilter::MouseMode DisplayServer::_input_get_mouse_mode() {
-	return InputFilter::MouseMode(singleton->mouse_get_mode());
+Input::MouseMode DisplayServer::_input_get_mouse_mode() {
+	return Input::MouseMode(singleton->mouse_get_mode());
 }
 
 void DisplayServer::_input_warp(const Vector2 &p_to_pos) {
 	singleton->mouse_warp_to_position(p_to_pos);
 }
 
-InputFilter::CursorShape DisplayServer::_input_get_current_cursor_shape() {
-	return (InputFilter::CursorShape)singleton->cursor_get_shape();
+Input::CursorShape DisplayServer::_input_get_current_cursor_shape() {
+	return (Input::CursorShape)singleton->cursor_get_shape();
 }
-void DisplayServer::_input_set_custom_mouse_cursor_func(const RES &p_image, InputFilter::CursorShape p_shape, const Vector2 &p_hostspot) {
+void DisplayServer::_input_set_custom_mouse_cursor_func(const RES &p_image, Input::CursorShape p_shape, const Vector2 &p_hostspot) {
 	singleton->cursor_set_custom_image(p_image, (CursorShape)p_shape, p_hostspot);
 }
 
 DisplayServer::DisplayServer() {
 	singleton = this;
-	InputFilter::set_mouse_mode_func = _input_set_mouse_mode;
-	InputFilter::get_mouse_mode_func = _input_get_mouse_mode;
-	InputFilter::warp_mouse_func = _input_warp;
-	InputFilter::get_current_cursor_shape_func = _input_get_current_cursor_shape;
-	InputFilter::set_custom_mouse_cursor_func = _input_set_custom_mouse_cursor_func;
+	Input::set_mouse_mode_func = _input_set_mouse_mode;
+	Input::get_mouse_mode_func = _input_get_mouse_mode;
+	Input::warp_mouse_func = _input_warp;
+	Input::get_current_cursor_shape_func = _input_get_current_cursor_shape;
+	Input::set_custom_mouse_cursor_func = _input_set_custom_mouse_cursor_func;
 }
 DisplayServer::~DisplayServer() {
 }

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -32,7 +32,7 @@
 #define DISPLAY_SERVER_H
 
 #include "core/callable.h"
-#include "core/input/input_filter.h"
+#include "core/input/input.h"
 #include "core/os/os.h"
 #include "core/resource.h"
 
@@ -61,11 +61,11 @@ public:
 	typedef Vector<String> (*GetRenderingDriversFunction)();
 
 private:
-	static void _input_set_mouse_mode(InputFilter::MouseMode p_mode);
-	static InputFilter::MouseMode _input_get_mouse_mode();
+	static void _input_set_mouse_mode(Input::MouseMode p_mode);
+	static Input::MouseMode _input_get_mouse_mode();
 	static void _input_warp(const Vector2 &p_to_pos);
-	static InputFilter::CursorShape _input_get_current_cursor_shape();
-	static void _input_set_custom_mouse_cursor_func(const RES &, InputFilter::CursorShape, const Vector2 &p_hostspot);
+	static Input::CursorShape _input_get_current_cursor_shape();
+	static void _input_set_custom_mouse_cursor_func(const RES &, Input::CursorShape, const Vector2 &p_hostspot);
 
 protected:
 	static void _bind_methods();

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -29,7 +29,8 @@
 /*************************************************************************/
 
 #include "xr_positional_tracker.h"
-#include "core/input/input_filter.h"
+
+#include "core/input/input.h"
 
 void XRPositionalTracker::_bind_methods() {
 	BIND_ENUM_CONSTANT(TRACKER_HAND_UNKNOWN);


### PR DESCRIPTION
It changed name as part of the DisplayServer and input refactoring
in #37317, with the rationale that input no longer goes through the
main loop, so the previous Input singleton now only does filtering.

But the gains in consistency are quite limited in the renaming, and
it breaks compatibility for all scripts and tutorials that access
the Input singleton via the scripting language. A temporary option
was suggested to keep the scripting singleton named `Input` even if
its type is `InputFilter`, but that adds inconsistency and breaks C#.

Fixes godotengine/godot-proposals#639.
Fixes #37319.
Fixes #37690.