### PR TITLE
Update the ExternalTexture documentation

### DIFF
--- a/doc/classes/ExternalTexture.xml
+++ b/doc/classes/ExternalTexture.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ExternalTexture" inherits="Texture" version="3.2">
 	<brief_description>
-		Adds support for external textures as defined by https://www.khronos.org/registry/OpenGL/extensions/OES/OES_EGL_image_external.txt
+		Enable OpenGL ES external texture extension.
 	</brief_description>
 	<description>
+		Enable support for the OpenGL ES external texture extension as defined by [url=https://www.khronos.org/registry/OpenGL/extensions/OES/OES_EGL_image_external.txt]OES_EGL_image_external[/url].
+		[b]Note:[/b] This is only supported for Android platforms.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Update the documentation for `ExternalTexture` to match the restriction on Android platforms.

See PR #38244