### PR TITLE
Packet tracking stats for 3.2

### DIFF
--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -139,7 +139,22 @@
 				Clear the packet sent/received stats.
 			</description>
 		</method>
-
+		<method name="set_track_packet_stats">
+			<return type="void">
+			</return>
+			<argument index="0" name="p_enable" type="bool">
+			</argument>
+			<description>
+				Enable or disable packet statistics tracking.
+			</description>
+		</method>
+		<method name="is_track_packet_stats_enabled">
+			<return type="bool">
+			</return>
+			<description>
+				Return if packet statistics tracking is enabled.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="always_ordered" type="bool" setter="set_always_ordered" getter="is_always_ordered" default="false">

--- a/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
+++ b/modules/enet/doc_classes/NetworkedMultiplayerENet.xml
@@ -104,6 +104,42 @@
 				The IP used when creating a server. This is set to the wildcard [code]"*"[/code] by default, which binds to all available interfaces. The given IP needs to be in IPv4 or IPv6 address format, for example: [code]"192.168.1.1"[/code].
 			</description>
 		</method>
+		<method name="get_num_packets_sent">
+			<return type="int">
+			</return>
+			<description>
+				Get the number of packets sent since the last clear.
+			</description>
+		</method>
+		<method name="get_num_packets_received">
+			<return type="int">
+			</return>
+			<description>
+				Get the number of packets received since the last clear.
+			</description>
+		</method>
+		<method name="get_num_bytes_sent">
+			<return type="int">
+			</return>
+			<description>
+				Get the number of bytes sent since the last clear.
+			</description>
+		</method>
+		<method name="get_num_bytes_received">
+			<return type="int">
+			</return>
+			<description>
+				Get the number of bytes received since the last clear.
+			</description>
+		</method>
+		<method name="clear_packet_stats">
+			<return type="void">
+			</return>
+			<description>
+				Clear the packet sent/received stats.
+			</description>
+		</method>
+
 	</methods>
 	<members>
 		<member name="always_ordered" type="bool" setter="set_always_ordered" getter="is_always_ordered" default="false">

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -355,7 +355,7 @@ void NetworkedMultiplayerENet::poll() {
 					uint32_t *id = (uint32_t *)event.peer->data;
 
 					ERR_CONTINUE(event.packet->dataLength < 8);
-					
+
 					if (track_packet_stats) {
 						num_packets_received++;
 						num_bytes_received += event.packet->dataLength - 8;

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -355,6 +355,11 @@ void NetworkedMultiplayerENet::poll() {
 					uint32_t *id = (uint32_t *)event.peer->data;
 
 					ERR_CONTINUE(event.packet->dataLength < 8);
+					
+					if (track_packet_stats) {
+						num_packets_received++;
+						num_bytes_received += event.packet->dataLength - 8;
+					}
 
 					uint32_t source = decode_uint32(&event.packet->data[0]);
 					int target = decode_uint32(&event.packet->data[4]);
@@ -524,11 +529,6 @@ Error NetworkedMultiplayerENet::get_packet(const uint8_t **r_buffer, int &r_buff
 
 	*r_buffer = (const uint8_t *)(&current_packet.packet->data[8]);
 	r_buffer_size = current_packet.packet->dataLength - 8;
-
-	if (track_packet_stats) {
-		num_packets_received++;
-		num_bytes_received += current_packet.packet->dataLength - 8;
-	}
 
 	return OK;
 }

--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -525,8 +525,10 @@ Error NetworkedMultiplayerENet::get_packet(const uint8_t **r_buffer, int &r_buff
 	*r_buffer = (const uint8_t *)(&current_packet.packet->data[8]);
 	r_buffer_size = current_packet.packet->dataLength - 8;
 
-	this->num_packets_received++;
-	this->num_bytes_received += current_packet.packet->dataLength - 8;
+	if (track_packet_stats) {
+		num_packets_received++;
+		num_bytes_received += current_packet.packet->dataLength - 8;
+	}
 
 	return OK;
 }
@@ -573,8 +575,10 @@ Error NetworkedMultiplayerENet::put_packet(const uint8_t *p_buffer, int p_buffer
 	encode_uint32(target_peer, &packet->data[4]); // Dest ID
 	copymem(&packet->data[8], p_buffer, p_buffer_size);
 
-	this->num_packets_sent++;
-	this->num_bytes_sent += p_buffer_size;
+	if (track_packet_stats) {
+		num_packets_sent++;
+		num_bytes_sent += p_buffer_size;
+	}
 
 	if (server) {
 
@@ -876,6 +880,14 @@ void NetworkedMultiplayerENet::clear_packet_stats() {
 	num_bytes_sent = 0;
 }
 
+void NetworkedMultiplayerENet::set_track_packet_stats(bool p_enable) {
+	track_packet_stats = p_enable;
+}
+
+bool NetworkedMultiplayerENet::is_track_packet_stats_enabled() {
+	return track_packet_stats;
+}
+
 void NetworkedMultiplayerENet::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("create_server", "port", "max_clients", "in_bandwidth", "out_bandwidth"), &NetworkedMultiplayerENet::create_server, DEFVAL(32), DEFVAL(0), DEFVAL(0));
@@ -904,6 +916,8 @@ void NetworkedMultiplayerENet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_num_packets_sent"), &NetworkedMultiplayerENet::get_num_packets_sent);
 	ClassDB::bind_method(D_METHOD("get_num_bytes_sent"), &NetworkedMultiplayerENet::get_num_bytes_sent);
 	ClassDB::bind_method(D_METHOD("clear_packet_stats"), &NetworkedMultiplayerENet::clear_packet_stats);
+	ClassDB::bind_method(D_METHOD("set_track_packet_stats"), &NetworkedMultiplayerENet::set_track_packet_stats);
+	ClassDB::bind_method(D_METHOD("is_track_packet_stats_enabled"), &NetworkedMultiplayerENet::is_track_packet_stats_enabled);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "compression_mode", PROPERTY_HINT_ENUM, "None,Range Coder,FastLZ,ZLib,ZStd"), "set_compression_mode", "get_compression_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "transfer_channel"), "set_transfer_channel", "get_transfer_channel");
@@ -940,6 +954,7 @@ NetworkedMultiplayerENet::NetworkedMultiplayerENet() {
 
 	bind_ip = IP_Address("*");
 
+	track_packet_stats = false;
 	clear_packet_stats();
 }
 

--- a/modules/enet/networked_multiplayer_enet.h
+++ b/modules/enet/networked_multiplayer_enet.h
@@ -77,6 +77,7 @@ private:
 	uint32_t num_bytes_received;
 	uint32_t num_packets_sent;
 	uint32_t num_bytes_sent;
+	bool track_packet_stats;
 
 	ENetEvent event;
 	ENetPeer *peer;
@@ -172,6 +173,8 @@ public:
 	uint32_t get_num_packets_sent() const;
 	uint32_t get_num_bytes_sent() const;
 	void clear_packet_stats();
+	void set_track_packet_stats(bool p_enable);
+	bool is_track_packet_stats_enabled();
 
 	NetworkedMultiplayerENet();
 	~NetworkedMultiplayerENet();

--- a/modules/enet/networked_multiplayer_enet.h
+++ b/modules/enet/networked_multiplayer_enet.h
@@ -73,6 +73,11 @@ private:
 	int channel_count;
 	bool always_ordered;
 
+	uint32_t num_packets_received;
+	uint32_t num_bytes_received;
+	uint32_t num_packets_sent;
+	uint32_t num_bytes_sent;
+
 	ENetEvent event;
 	ENetPeer *peer;
 	ENetHost *host;
@@ -161,6 +166,12 @@ public:
 	bool is_always_ordered() const;
 	void set_server_relay_enabled(bool p_enabled);
 	bool is_server_relay_enabled() const;
+
+	uint32_t get_num_packets_received() const;
+	uint32_t get_num_bytes_received() const;
+	uint32_t get_num_packets_sent() const;
+	uint32_t get_num_bytes_sent() const;
+	void clear_packet_stats();
 
 	NetworkedMultiplayerENet();
 	~NetworkedMultiplayerENet();


### PR DESCRIPTION
This PR adds additional functionality to the ENet module to enabled packet statistics tracking (packets sent/received, bytes sent/received) useful for debugging multiplayer games.