### PR TITLE
Warn when trying to open `res://` or `user://` with `OS.shell_open()`

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -237,6 +237,11 @@ String _OS::get_executable_path() const {
 
 Error _OS::shell_open(String p_uri) {
 
+	if (p_uri.begins_with("res://")) {
+		WARN_PRINT("Attempting to open an URL with the \"res://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_open()`.");
+	} else if (p_uri.begins_with("user://")) {
+		WARN_PRINT("Attempting to open an URL with the \"user://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_open()`.");
+	}
 	return OS::get_singleton()->shell_open(p_uri);
 };
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -484,6 +484,7 @@
 				- [code]OS.shell_open("C:\\Users\name\Downloads")[/code] on Windows opens the file explorer at the user's Downloads folder.
 				- [code]OS.shell_open("https://godotengine.org")[/code] opens the default web browser on the official Godot website.
 				- [code]OS.shell_open("mailto:example@example.com")[/code] opens the default email client with the "To" field set to [code]example@example.com[/code]. See [url=https://blog.escapecreative.com/customizing-mailto-links/]Customizing [code]mailto:[/code] Links[/url] for a list of fields that can be added.
+				Use [method ProjectSettings.globalize_path] to convert a [code]res://[/code] or [code]user://[/code] path into a system path for use with this method.
 				[b]Note:[/b] This method is implemented on Android, iOS, HTML5, Linux, macOS and Windows.
 			</description>
 		</method>


### PR DESCRIPTION
`OS.shell_open()` will pass on the path directly to the OS' shell handler (which can handle file paths or URLs). It can't handle Godot-specific paths, so these need to be converted with `ProjectSettings.globalize_path()` first.