### PR TITLE
Enable range coder compression by default in NetworkedMultiplayerENet

### DIFF
--- a/modules/enet/doc_classes/ENetMultiplayerPeer.xml
+++ b/modules/enet/doc_classes/ENetMultiplayerPeer.xml
@@ -155,8 +155,9 @@
 		<member name="channel_count" type="int" setter="set_channel_count" getter="get_channel_count" default="3">
 			The number of channels to be used by ENet. Channels are used to separate different kinds of data. In reliable or ordered mode, for example, the packet delivery order is ensured on a per-channel basis. This is done to combat latency and reduces ordering restrictions on packets. The delivery status of a packet in one channel won't stall the delivery of other packets in another channel.
 		</member>
-		<member name="compression_mode" type="int" setter="set_compression_mode" getter="get_compression_mode" enum="ENetMultiplayerPeer.CompressionMode" default="0">
+		<member name="compression_mode" type="int" setter="set_compression_mode" getter="get_compression_mode" enum="ENetMultiplayerPeer.CompressionMode" default="1">
 			The compression method used for network packets. These have different tradeoffs of compression speed versus bandwidth, you may need to test which one works best for your use case if you use compression at all.
+			[b]Note:[/b] Most games' network design involve sending many small packets frequently (smaller than 4 KB each). If in doubt, it is recommended to keep the default compression algorithm as it works best on these small packets.
 		</member>
 		<member name="dtls_verify" type="bool" setter="set_dtls_verify_enabled" getter="is_dtls_verify_enabled" default="true">
 			Enable or disable certificate verification when [member use_dtls] [code]true[/code].
@@ -176,10 +177,10 @@
 	</members>
 	<constants>
 		<constant name="COMPRESS_NONE" value="0" enum="CompressionMode">
-			No compression. This uses the most bandwidth, but has the upside of requiring the fewest CPU resources.
+			No compression. This uses the most bandwidth, but has the upside of requiring the fewest CPU resources. This option may also be used to make network debugging using tools like Wireshark easier.
 		</constant>
 		<constant name="COMPRESS_RANGE_CODER" value="1" enum="CompressionMode">
-			ENet's built-in range encoding.
+			ENet's built-in range encoding. Works well on small packets, but is not the most efficient algorithm on packets larger than 4 KB.
 		</constant>
 		<constant name="COMPRESS_FASTLZ" value="2" enum="CompressionMode">
 			[url=http://fastlz.org/]FastLZ[/url] compression. This option uses less CPU resources compared to [constant COMPRESS_ZLIB], at the expense of using more bandwidth.
@@ -188,7 +189,7 @@
 			[url=https://www.zlib.net/]Zlib[/url] compression. This option uses less bandwidth compared to [constant COMPRESS_FASTLZ], at the expense of using more CPU resources.
 		</constant>
 		<constant name="COMPRESS_ZSTD" value="4" enum="CompressionMode">
-			[url=https://facebook.github.io/zstd/]Zstandard[/url] compression.
+			[url=https://facebook.github.io/zstd/]Zstandard[/url] compression. Note that this algorithm is not very efficient on packets smaller than 4 KB. Therefore, it's recommended to use other compression algorithms in most cases.
 		</constant>
 	</constants>
 </class>

--- a/modules/enet/enet_multiplayer_peer.h
+++ b/modules/enet/enet_multiplayer_peer.h
@@ -90,7 +90,7 @@ private:
 		int channel = 0;
 	};
 
-	CompressionMode compression_mode = COMPRESS_NONE;
+	CompressionMode compression_mode = COMPRESS_RANGE_CODER;
 
 	List<Packet> incoming_packets;
 


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/51525.

From empirical testing, this seems to provide the best compression compared to other compression algorithms when used in the Multiplayer Bomber demo.

Other algorithms may provide better compression ratios for more complex games, but some compression is probably better than no compression.

Zstandard was also not very efficient in my testing, so I added a note in the documentation.

To measure bandwidth usage, I started a server and 2 clients, ran `sudo iftop -i lo -B -t` and let it running for about 1 minute for each algorithm. These are the results I got:

```text
No compression: 76.3 KB per 2 seconds
     Zstandard: 75.1 KB per 2 seconds
        FastLZ: 74.3 KB per 2 seconds
          zlib: 73.2 KB per 2 seconds
   Range coder: 68.8 KB per 2 seconds
```