### PR TITLE
add viewport.get_camera_2d()

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -21,13 +21,6 @@
 				Aligns the camera to the tracked node.
 			</description>
 		</method>
-		<method name="clear_current">
-			<return type="void">
-			</return>
-			<description>
-				Removes any [Camera2D] from the ancestor [Viewport]'s internal currently-assigned camera.
-			</description>
-		</method>
 		<method name="force_update_scroll">
 			<return type="void">
 			</return>
@@ -67,13 +60,6 @@
 				Returns the camera limit for the specified [enum Side]. See also [member limit_bottom], [member limit_top], [member limit_left], and [member limit_right].
 			</description>
 		</method>
-		<method name="make_current">
-			<return type="void">
-			</return>
-			<description>
-				Make this the current 2D camera for the scene (viewport and layer), in case there are many cameras in the scene.
-			</description>
-		</method>
 		<method name="reset_smoothing">
 			<return type="void">
 			</return>
@@ -109,7 +95,7 @@
 		<member name="anchor_mode" type="int" setter="set_anchor_mode" getter="get_anchor_mode" enum="Camera2D.AnchorMode" default="1">
 			The Camera2D's anchor point. See [enum AnchorMode] constants.
 		</member>
-		<member name="current" type="bool" setter="_set_current" getter="is_current" default="false">
+		<member name="current" type="bool" setter="set_current" getter="is_current" default="false">
 			If [code]true[/code], the camera is the active camera for the current scene. Only one camera can be current, so setting a different camera [code]current[/code] will disable this one.
 		</member>
 		<member name="custom_viewport" type="Node" setter="set_custom_viewport" getter="get_custom_viewport">

--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -176,8 +176,8 @@
 				[codeblock]
 				# This code block is part of a script that inherits from Node3D.
 				# `control` is a reference to a node inheriting from Control.
-				control.visible = not get_viewport().get_camera().is_position_behind(global_transform.origin)
-				control.rect_position = get_viewport().get_camera().unproject_position(global_transform.origin)
+				control.visible = not get_viewport().get_camera_3d().is_position_behind(global_transform.origin)
+				control.rect_position = get_viewport().get_camera_3d().unproject_position(global_transform.origin)
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -36,11 +36,18 @@
 				Returns the 3D world of the viewport, or if none the world of the parent viewport.
 			</description>
 		</method>
-		<method name="get_camera" qualifiers="const">
+		<method name="get_camera_2d" qualifiers="const">
+			<return type="Camera2D">
+			</return>
+			<description>
+				Returns the currently active 2D camera. Returns null if there are no active cameras.
+			</description>
+		</method>
+		<method name="get_camera_3d" qualifiers="const">
 			<return type="Camera3D">
 			</return>
 			<description>
-				Returns the active 3D camera.
+				Returns the currently active 3D camera.
 			</description>
 		</method>
 		<method name="get_final_transform" qualifiers="const">

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -793,7 +793,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 				} else if (camera_override >= CameraOverride::OVERRIDE_3D_1) {
 					int viewport_idx = camera_override - CameraOverride::OVERRIDE_3D_1;
 					Node3DEditorViewport *viewport = Node3DEditor::get_singleton()->get_editor_viewport(viewport_idx);
-					Camera3D *const cam = viewport->get_camera();
+					Camera3D *const cam = viewport->get_camera_3d();
 
 					Array msg;
 					msg.push_back(cam->get_camera_transform());

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2418,7 +2418,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 		Node *scene_root = editor->get_scene_tree_dock()->get_editor_data()->get_edited_scene_root();
 		if (previewing_cinema && scene_root != nullptr) {
-			Camera3D *cam = scene_root->get_viewport()->get_camera();
+			Camera3D *cam = scene_root->get_viewport()->get_camera_3d();
 			if (cam != nullptr && cam != previewing) {
 				//then switch the viewport's camera to the scene's viewport camera
 				if (previewing != nullptr) {

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -494,7 +494,7 @@ public:
 			AcceptDialog *p_accept);
 
 	SubViewport *get_viewport_node() { return viewport; }
-	Camera3D *get_camera() { return camera; } // return the default camera object.
+	Camera3D *get_camera_3d() { return camera; } // return the default camera object.
 
 	Node3DEditorViewport(Node3DEditor *p_spatial_editor, EditorNode *p_editor, int p_index);
 	~Node3DEditorViewport();

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -83,7 +83,7 @@ protected:
 	void _update_scroll();
 
 	void _make_current(Object *p_which);
-	void _set_current(bool p_current);
+	void set_current(bool p_current);
 
 	void _set_old_smoothing(real_t p_enable);
 

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -85,14 +85,14 @@ void Camera3D::_update_camera() {
 	// here goes listener stuff
 	/*
 	if (viewport_ptr && is_inside_scene() && is_current())
-		get_viewport()->_camera_transform_changed_notify();
+		get_viewport()->_camera_3d_transform_changed_notify();
 	*/
 
 	if (get_tree()->is_node_being_edited(this) || !is_current()) {
 		return;
 	}
 
-	get_viewport()->_camera_transform_changed_notify();
+	get_viewport()->_camera_3d_transform_changed_notify();
 }
 
 void Camera3D::_notification(int p_what) {
@@ -104,9 +104,9 @@ void Camera3D::_notification(int p_what) {
 			viewport = get_viewport();
 			ERR_FAIL_COND(!viewport);
 
-			bool first_camera = viewport->_camera_add(this);
+			bool first_camera = viewport->_camera_3d_add(this);
 			if (current || first_camera) {
-				viewport->_camera_set(this);
+				viewport->_camera_3d_set(this);
 			}
 
 		} break;
@@ -128,7 +128,7 @@ void Camera3D::_notification(int p_what) {
 			}
 
 			if (viewport) {
-				viewport->_camera_remove(this);
+				viewport->_camera_3d_remove(this);
 				viewport = nullptr;
 			}
 
@@ -220,7 +220,7 @@ void Camera3D::make_current() {
 		return;
 	}
 
-	get_viewport()->_camera_set(this);
+	get_viewport()->_camera_3d_set(this);
 
 	//get_scene()->call_group(SceneMainLoop::GROUP_CALL_REALTIME,camera_group,"_camera_make_current",this);
 }
@@ -231,11 +231,11 @@ void Camera3D::clear_current(bool p_enable_next) {
 		return;
 	}
 
-	if (get_viewport()->get_camera() == this) {
-		get_viewport()->_camera_set(nullptr);
+	if (get_viewport()->get_camera_3d() == this) {
+		get_viewport()->_camera_3d_set(nullptr);
 
 		if (p_enable_next) {
-			get_viewport()->_camera_make_next_current(this);
+			get_viewport()->_camera_3d_make_next_current(this);
 		}
 	}
 }
@@ -250,7 +250,7 @@ void Camera3D::set_current(bool p_current) {
 
 bool Camera3D::is_current() const {
 	if (is_inside_tree() && !get_tree()->is_node_being_edited(this)) {
-		return get_viewport()->get_camera() == this;
+		return get_viewport()->get_camera_3d() == this;
 	} else {
 		return current;
 	}

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1007,7 +1007,7 @@ void CPUParticles3D::_update_particle_data_buffer() {
 			sorter.sort(order, pc);
 		} else if (draw_order == DRAW_ORDER_VIEW_DEPTH) {
 			ERR_FAIL_NULL(get_viewport());
-			Camera3D *c = get_viewport()->get_camera();
+			Camera3D *c = get_viewport()->get_camera_3d();
 			if (c) {
 				Vector3 dir = c->get_global_transform().basis.get_axis(2); //far away to close
 

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -596,7 +596,7 @@ void GPUParticlesCollisionHeightField::_notification(int p_what) {
 		}
 
 		if (follow_camera_mode && get_viewport()) {
-			Camera3D *cam = get_viewport()->get_camera();
+			Camera3D *cam = get_viewport()->get_camera_3d();
 			if (cam) {
 				Transform3D xform = get_global_transform();
 				Vector3 x_axis = xform.basis.get_axis(Vector3::AXIS_X).normalized();

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -213,7 +213,8 @@ private:
 		}
 	} camera_override;
 
-	Camera3D *camera = nullptr;
+	Camera3D *camera_3d = nullptr;
+	Camera2D *camera_2d = nullptr;
 	Set<Camera3D *> cameras;
 	Set<CanvasLayer *> canvas_layers;
 
@@ -444,11 +445,14 @@ private:
 	void _listener_make_next_current(Listener3D *p_exclude);
 
 	friend class Camera3D;
-	void _camera_transform_changed_notify();
-	void _camera_set(Camera3D *p_camera);
-	bool _camera_add(Camera3D *p_camera); //true if first
-	void _camera_remove(Camera3D *p_camera);
-	void _camera_make_next_current(Camera3D *p_exclude);
+	void _camera_3d_transform_changed_notify();
+	void _camera_3d_set(Camera3D *p_camera);
+	bool _camera_3d_add(Camera3D *p_camera); //true if first
+	void _camera_3d_remove(Camera3D *p_camera);
+	void _camera_3d_make_next_current(Camera3D *p_exclude);
+
+	friend class Camera2D;
+	void _camera_2d_set(Camera2D *p_camera_2d);
 
 	friend class CanvasLayer;
 	void _canvas_layer_add(CanvasLayer *p_canvas_layer);
@@ -491,7 +495,8 @@ public:
 	uint64_t get_processed_events_count() const { return event_count; }
 
 	Listener3D *get_listener() const;
-	Camera3D *get_camera() const;
+	Camera3D *get_camera_3d() const;
+	Camera2D *get_camera_2d() const;
 
 	void enable_camera_override(bool p_enable);
 	bool is_camera_override_enabled() const;


### PR DESCRIPTION
Fixes #5411
First time contributor, still learning how things fit together, so I'd be happy to make any adjustments needed. :slightly_smiling_face: 

The `viewport.get_camera()` functionality already exists in 3d, so I just mimicked how 3d keeps track of things and added it to 2d. I added a `Camera2D` pointer in the viewport class and it gets updated it as 2d cameras are set as current/turned off.

Unlike 3d, in 2d, it is not required for a camera to be current. If this is the case, `get_camera_2d()` just returns null (just like what calling `get_camera()` in 2d does).