### PR TITLE
TileMap: Added "set_line" and "get_line" to batch update tiles

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -857,6 +857,14 @@ void TileMap::_set_celld(const Vector2 &p_pos, const Dictionary &p_data) {
 	call("set_cell", args, 7, ce);
 }
 
+void TileMap::set_line(const PoolIntArray &p_array, int p_y, bool p_flip_x, bool p_flip_y, bool p_transpose) {
+
+	for (int x = 0; x < p_array._p->array.size(); x++) {
+		set_cell(x, p_y, p_array[x], p_flip_x, p_flip_y, p_transpose);
+	 }
+
+}
+
 void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_y, bool p_transpose, Vector2 p_autotile_coord) {
 
 	PosKey pk(p_x, p_y);

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -857,11 +857,23 @@ void TileMap::_set_celld(const Vector2 &p_pos, const Dictionary &p_data) {
 	call("set_cell", args, 7, ce);
 }
 
-void TileMap::set_line(const PoolIntArray &p_array, int p_y, bool p_flip_x, bool p_flip_y, bool p_transpose) {
+void TileMap::set_line(int p_x, int p_y, const Vector<int> &p_ids, bool p_flip_x, bool p_flip_y, bool p_transpose) {
 
-	for (int x = 0; x < p_array._p->array.size(); x++) {
-		set_cell(x, p_y, p_array[x], p_flip_x, p_flip_y, p_transpose);
+	for (int x = p_x; x < p_ids.size() + p_x; x++) {
+		set_cell(x, p_y, p_ids[x], p_flip_x, p_flip_y, p_transpose);
 	 }
+
+}
+
+Vector<int> TileMap::get_line(int p_from_x, int p_to_x, int p_y) {
+
+	Vector<int> p_ids;
+
+	for (int x = p_from_x; x < p_to_x; x++) {
+		get_cell(x, p_y);
+	 }
+
+	return p_ids;
 
 }
 
@@ -1877,6 +1889,9 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_cell_x_flipped", "x", "y"), &TileMap::is_cell_x_flipped);
 	ClassDB::bind_method(D_METHOD("is_cell_y_flipped", "x", "y"), &TileMap::is_cell_y_flipped);
 	ClassDB::bind_method(D_METHOD("is_cell_transposed", "x", "y"), &TileMap::is_cell_transposed);
+
+	ClassDB::bind_method(D_METHOD("set_line", "x", "y", "tiles", "flip_x", "flip_y", "transpose"), &TileMap::set_line, DEFVAL(false), DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_line", "from_x", "to_x","y"), &TileMap::get_line);
 
 	ClassDB::bind_method(D_METHOD("get_cell_autotile_coord", "x", "y"), &TileMap::get_cell_autotile_coord);
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -861,8 +861,7 @@ void TileMap::set_line(int p_x, int p_y, const Vector<int> &p_ids, bool p_flip_x
 
 	for (int x = p_x; x < p_ids.size() + p_x; x++) {
 		set_cell(x, p_y, p_ids[x], p_flip_x, p_flip_y, p_transpose);
-	 }
-
+	}
 }
 
 Vector<int> TileMap::get_line(int p_from_x, int p_to_x, int p_y) {
@@ -871,10 +870,9 @@ Vector<int> TileMap::get_line(int p_from_x, int p_to_x, int p_y) {
 
 	for (int x = p_from_x; x < p_to_x; x++) {
 		p_ids.push_back(get_cell(x, p_y));
-	 }
+	}
 
 	return p_ids;
-
 }
 
 void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_y, bool p_transpose, Vector2 p_autotile_coord) {
@@ -1891,7 +1889,7 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_cell_transposed", "x", "y"), &TileMap::is_cell_transposed);
 
 	ClassDB::bind_method(D_METHOD("set_line", "x", "y", "tiles", "flip_x", "flip_y", "transpose"), &TileMap::set_line, DEFVAL(false), DEFVAL(false), DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("get_line", "from_x", "to_x","y"), &TileMap::get_line);
+	ClassDB::bind_method(D_METHOD("get_line", "from_x", "to_x", "y"), &TileMap::get_line);
 
 	ClassDB::bind_method(D_METHOD("get_cell_autotile_coord", "x", "y"), &TileMap::get_cell_autotile_coord);
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -870,7 +870,7 @@ Vector<int> TileMap::get_line(int p_from_x, int p_to_x, int p_y) {
 	Vector<int> p_ids;
 
 	for (int x = p_from_x; x < p_to_x; x++) {
-		get_cell(x, p_y);
+		p_ids.push_back(get_cell(x, p_y));
 	 }
 
 	return p_ids;

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -269,7 +269,8 @@ public:
 	void set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false);
 	int get_cellv(const Vector2 &p_pos) const;
 
-	void set_line(const PoolIntArray &p_array, int p_y, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false);
+	void set_line(int p_x, int p_y, const Vector<int> &p_ids, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false);
+	Vector<int> get_line(int p_from_x, int p_to_x, int p_y);
 
 	void make_bitmask_area_dirty(const Vector2 &p_pos);
 	void update_bitmask_area(const Vector2 &p_pos);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -269,6 +269,8 @@ public:
 	void set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false);
 	int get_cellv(const Vector2 &p_pos) const;
 
+	void set_line(const PoolIntArray &p_array, int p_y, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false);
+
 	void make_bitmask_area_dirty(const Vector2 &p_pos);
 	void update_bitmask_area(const Vector2 &p_pos);
 	void update_bitmask_region(const Vector2 &p_start = Vector2(), const Vector2 &p_end = Vector2());


### PR DESCRIPTION
At first, this is my first pull request and I'm not really a C++ dev … sorry for any mistakes :)

This PR is related to the performance enhancement request #31020.

Basicly it's a C++ loop of set_cell for a batch of tiles (based on PoolIntArray).
This gets a huge performance boost in case of big tilemaps / and frequent tilemap updates for the standard GD-Script user. Target was to keep it as flexible as possible (therefore also a start x) and only line wise loop -> the outer loop (columns = y) of the usually needed double-loop can stay in GD-Script without big performance disadvantages.

Example:
In case of an 1000x1000 Tilemap previously the full 1.000.000 loops with "set_cell" had to be executed in GD-Script (double-loop). With this change, only 1000 loops of "set_line" are done in GD-Script, the most part of the other loops (=999.000) will be done in C++.