### PR TITLE
Don't focus the selection after using Align Transform With View

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2882,7 +2882,6 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 				undo_redo->add_undo_method(sp, "set_global_transform", sp->get_global_gizmo_transform());
 			}
 			undo_redo->commit_action();
-			focus_selection();
 
 		} break;
 		case VIEW_ALIGN_ROTATION_WITH_VIEW: {


### PR DESCRIPTION
It made minor adjustments difficult as the camera moved every time Align Transform With View was used. For the record, this was added in 4a218b9862b73b643ade6e8b0f5c205e9fbc9ca4.

This closes #36738.