### PR TITLE
Fix growMargin() not returning modified Rect2/Rect2i in Mono

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -127,7 +127,7 @@ namespace Godot
         {
             var g = this;
 
-            g.GrowIndividual(Margin.Left == margin ? by : 0,
+            g = g.GrowIndividual(Margin.Left == margin ? by : 0,
                     Margin.Top == margin ? by : 0,
                     Margin.Right == margin ? by : 0,
                     Margin.Bottom == margin ? by : 0);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
@@ -122,7 +122,7 @@ namespace Godot
         {
             var g = this;
 
-            g.GrowIndividual(Margin.Left == margin ? by : 0,
+            g = g.GrowIndividual(Margin.Left == margin ? by : 0,
                     Margin.Top == margin ? by : 0,
                     Margin.Right == margin ? by : 0,
                     Margin.Bottom == margin ? by : 0);


### PR DESCRIPTION
Changed growMargin() in both Rect2.cs and Rect2i.cs to return the modifications made to the passed value, in Mono.

This fixes #38217 .