### PR TITLE
Fixes misprints, duplicated value assignments, possible usage of null pointers

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -409,8 +409,9 @@ struct RemoteDebugger::PerformanceProfiler {
 			if (!monitor_value.is_num()) {
 				ERR_PRINT("Value of custom monitor '" + String(custom_monitor_names[i]) + "' is not a number");
 				arr[i + max] = Variant();
+			} else {
+				arr[i + max] = monitor_value;
 			}
-			arr[i + max] = monitor_value;
 		}
 
 		EngineDebugger::get_singleton()->send_message("performance:profile_frame", arr);

--- a/core/input/input_builders.py
+++ b/core/input/input_builders.py
@@ -45,7 +45,7 @@ def make_default_controller_mappings(target, source, env):
                 platform_mappings[current_platform][guid] = line
 
     platform_variables = {
-        "Linux": "#if X11_ENABLED",
+        "Linux": "#ifdef X11_ENABLED",
         "Windows": "#ifdef WINDOWS_ENABLED",
         "Mac OS X": "#ifdef OSX_ENABLED",
         "Android": "#if defined(__ANDROID__)",

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -1528,7 +1528,7 @@ Error RenderingDeviceVulkan::_staging_buffer_allocate(uint32_t p_amount, uint32_
 			//this is an old block, which was already processed, let's reuse
 			staging_buffer_blocks.write[staging_buffer_current].frame_used = frames_drawn;
 			staging_buffer_blocks.write[staging_buffer_current].fill_amount = 0;
-		} else if (staging_buffer_blocks[staging_buffer_current].frame_used > frames_drawn - frame_count) {
+		} else {
 			//this block may still be in use, let's not touch it unless we have to, so.. can we create a new one?
 			if ((uint64_t)staging_buffer_blocks.size() * staging_buffer_block_size < staging_buffer_max_size) {
 				//we are still allowed to create a new block, so let's do that and insert it for current pos
@@ -4321,7 +4321,6 @@ RID RenderingDeviceVulkan::shader_create(const Vector<ShaderStageData> &p_stages
 					layout_binding.pImmutableSamplers = nullptr; //no support for this yet
 
 					info.stages = 1 << stage;
-					info.binding = info.binding;
 
 					if (set >= (uint32_t)set_bindings.size()) {
 						set_bindings.resize(set + 1);

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -202,7 +202,7 @@ void ResourceImporterTexture::get_import_options(List<ImportOption> *r_options, 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/normal_map", PROPERTY_HINT_ENUM, "Detect,Enable,Disabled"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/channel_pack", PROPERTY_HINT_ENUM, "sRGB Friendly,Optimized"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "compress/streamed"), false));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "mipmaps/generate"), (p_preset == PRESET_3D ? true : false)));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "mipmaps/generate"), (p_preset == PRESET_3D)));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "mipmaps/limit", PROPERTY_HINT_RANGE, "-1,256"), -1));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "roughness/mode", PROPERTY_HINT_ENUM, "Detect,Disabled,Red,Green,Blue,Alpha,Gray"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "roughness/src_normal", PROPERTY_HINT_FILE, "*.bmp,*.dds,*.exr,*.jpeg,*.jpg,*.hdr,*.png,*.svg,*.svgz,*.tga,*.webp"), ""));

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -920,7 +920,6 @@ void NativeScriptInstance::get_property_list(List<PropertyInfo> *p_properties) c
 
 		script_data = script_data->base_data;
 	}
-	return;
 }
 
 Variant::Type NativeScriptInstance::get_property_type(const StringName &p_name, bool *r_is_valid) const {

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -187,7 +187,6 @@ void PluginScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int
 	if (_desc.auto_indent_code) {
 		_desc.auto_indent_code(_data, (godot_string *)&p_code, p_from_line, p_to_line);
 	}
-	return;
 }
 
 void PluginScriptLanguage::add_global_constant(const StringName &p_variable, const Variant &p_value) {

--- a/modules/gdnavigation/rvo_agent.cpp
+++ b/modules/gdnavigation/rvo_agent.cpp
@@ -71,6 +71,7 @@ void RvoAgent::dispatch_callback() {
 	Object *obj = ObjectDB::get_instance(callback.id);
 	if (obj == nullptr) {
 		callback.id = ObjectID();
+		return;
 	}
 
 	Callable::CallError responseCallError;

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -45,7 +45,7 @@ Error GDScriptLanguageProtocol::LSPeer::handle_data() {
 		while (true) {
 			if (req_pos >= LSP_MAX_BUFFER_SIZE) {
 				req_pos = 0;
-				ERR_FAIL_COND_V_MSG(true, ERR_OUT_OF_MEMORY, "Response header too big");
+				ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Response header too big");
 			}
 			Error err = connection->get_partial_data(&req_buf[req_pos], 1, read);
 			if (err != OK) {
@@ -74,7 +74,7 @@ Error GDScriptLanguageProtocol::LSPeer::handle_data() {
 			if (req_pos >= LSP_MAX_BUFFER_SIZE) {
 				req_pos = 0;
 				has_header = false;
-				ERR_FAIL_COND_V_MSG(req_pos >= LSP_MAX_BUFFER_SIZE, ERR_OUT_OF_MEMORY, "Response content too big");
+				ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Response content too big");
 			}
 			Error err = connection->get_partial_data(&req_buf[req_pos], 1, read);
 			if (err != OK) {

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -4291,6 +4291,7 @@ DisplayServerX11::~DisplayServerX11() {
 	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
 #ifdef VULKAN_ENABLED
 		if (rendering_driver == "vulkan") {
+			ERR_FAIL_NULL(context_vulkan);
 			context_vulkan->window_destroy(E->key());
 		}
 #endif

--- a/platform/osx/joypad_osx.cpp
+++ b/platform/osx/joypad_osx.cpp
@@ -286,8 +286,9 @@ bool JoypadOSX::configure_joypad(IOHIDDeviceRef p_device_ref, joypad *p_joy) {
 	}
 	if ((!refCF) || (!CFStringGetCString((CFStringRef)refCF, c_name, sizeof(c_name), kCFStringEncodingUTF8))) {
 		name = "Unidentified Joypad";
+	} else {
+		name = c_name;
 	}
-	name = c_name;
 
 	int id = input->get_unused_joy_id();
 	ERR_FAIL_COND_V(id == -1, false);

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -693,7 +693,6 @@ float AnimationNodeTransition::process(float p_time, bool p_seek) {
 		prev = prev_current;
 		prev_xfading = xfade;
 		time = 0;
-		switched = true;
 	}
 
 	if (current < 0 || current >= enabled_inputs || prev >= enabled_inputs) {

--- a/servers/rendering/renderer_rd/cluster_builder_rd.h
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.h
@@ -235,7 +235,7 @@ public:
 		Transform xform = view_xform * p_transform;
 
 		float radius = xform.basis.get_uniform_scale();
-		if (radius > 0.98 || radius < 1.02) {
+		if (radius > 0.98 && radius < 1.02) {
 			xform.basis.orthonormalize();
 		}
 

--- a/servers/rendering/renderer_rd/effects_rd.cpp
+++ b/servers/rendering/renderer_rd/effects_rd.cpp
@@ -1056,6 +1056,8 @@ void EffectsRD::generate_ssao(RID p_depth_buffer, RID p_normal_buffer, RID p_dep
 		ssao.gather_push_constant.half_screen_pixel_size_x025[0] = ssao.gather_push_constant.half_screen_pixel_size[0] * 0.25;
 		ssao.gather_push_constant.half_screen_pixel_size_x025[1] = ssao.gather_push_constant.half_screen_pixel_size[1] * 0.25;
 
+		ssao.gather_push_constant.radius = p_settings.radius;
+
 		float radius_near_limit = (p_settings.radius * 1.2f);
 		if (p_settings.quality <= RS::ENV_SSAO_QUALITY_LOW) {
 			radius_near_limit *= 1.50f;
@@ -1068,7 +1070,6 @@ void EffectsRD::generate_ssao(RID p_depth_buffer, RID p_normal_buffer, RID p_dep
 			}
 		}
 		radius_near_limit /= tan_half_fov_y;
-		ssao.gather_push_constant.radius = p_settings.radius;
 		ssao.gather_push_constant.intensity = p_settings.intensity;
 		ssao.gather_push_constant.shadow_power = p_settings.power;
 		ssao.gather_push_constant.shadow_clamp = 0.98;
@@ -1198,8 +1199,9 @@ void EffectsRD::generate_ssao(RID p_depth_buffer, RID p_normal_buffer, RID p_dep
 			if (p_settings.quality > RS::ENV_SSAO_QUALITY_VERY_LOW) {
 				if (pass < blur_passes - 2) {
 					blur_pipeline = SSAO_BLUR_PASS_WIDE;
+				} else {
+					blur_pipeline = SSAO_BLUR_PASS_SMART;
 				}
-				blur_pipeline = SSAO_BLUR_PASS_SMART;
 			}
 
 			for (int i = 0; i < 4; i++) {

--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
@@ -794,7 +794,6 @@ void RendererSceneGIRD::SDFGI::update(RendererSceneEnvironmentRD *p_env, const V
 		cascade.dirty_regions = Vector3i();
 
 		Vector3 probe_half_size = Vector3(1, 1, 1) * cascade.cell_size * float(cascade_size / SDFGI::PROBE_DIVISOR) * 0.5;
-		probe_half_size = Vector3(0, 0, 0);
 
 		Vector3 world_position = p_world_position;
 		world_position.y *= y_mult;


### PR DESCRIPTION
Most of changes remove duplicated assignments value to variables:
```
var = 1
...
... Code which not using `var`
...
var = 1
```
In `rvo_agent.cpp` and `display_server_x11.cpp` the pointers were used without checking if they are `nullptr` but in other parts of code were checked.
