### PR TITLE
Fail loudly if materials use specular glossiness.

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -1432,6 +1432,13 @@ Error EditorSceneImporterGLTF::_parse_materials(GLTFState &state) {
 			}
 		}
 
+		if (d.has("extensions")) {
+			Dictionary extensions = d["extensions"];
+			if (extensions.has("KHR_materials_pbrSpecularGlossiness")) {
+				return FAILED;
+			}
+		}
+
 		if (d.has("normalTexture")) {
 			const Dictionary &bct = d["normalTexture"];
 			if (bct.has("index")) {


### PR DESCRIPTION
@JFonS Mentioned that he saw entirely white materials in a scene.

https://sketchfab.com/3d-models/bottle-maya-export-rotated-spec-gloss-4181a491bb4f42088011979a10e368af is my test scene.

We should fail loudly if specular gloss is used and reject the entire scene.

Alternatively, we can support only base color, and or glossiness inverted with specular trashed.

I have not tested the below code for default / empty texture robustness.

```c++
if (d.has("extensions")) {
	Dictionary extensions = d["extensions"];
	if (extensions.has("KHR_materials_pbrSpecularGlossiness")) {
		Dictionary sgm = extensions["KHR_materials_pbrSpecularGlossiness"];
		if (sgm.has("diffuseTexture")) {
			const Dictionary &diffuse_texture = sgm["diffuseTexture"];
			if (diffuse_texture.has("index")) {
				material->set_texture(SpatialMaterial::TEXTURE_ALBEDO, _get_texture(state, diffuse_texture["index"]));
			}
		}
		if (sgm.has("diffuseFactor")) {
			const Array &arr = sgm["diffuseFactor"];
			ERR_FAIL_COND_V(arr.size() != 4, ERR_PARSE_ERROR);
			const Color c = Color(arr[0], arr[1], arr[2], arr[3]).to_srgb();

			material->set_albedo(c);
		}
		if (sgm.has("glossinessFactor")) {
			float gloss = sgm["glossinessFactor"];
			material->set_roughness(1.0f - gloss);
		} else {
			material->set_roughness(0.0f);
		}
		if (sgm.has("specularGlossinessTexture")) {
			const Dictionary &spec_gloss_texture = sgm["specularGlossinessTexture"];
			if (spec_gloss_texture.has("index")) {
				const Ref<Texture> orig_texture = _get_texture(state, spec_gloss_texture["index"]);
				Ref<Image> orig_img = orig_texture->get_data();
				Ref<Image> roughness_img;
				roughness_img.instance();
				roughness_img->create(orig_img->get_width(), orig_img->get_height(), false, orig_img->get_format());
				if (orig_img.is_valid()) {
					orig_img->lock();
					roughness_img->lock();
					for (int32_t y = 0; y < orig_img->get_height(); y++) {
						for (int32_t x = 0; x < orig_img->get_width(); x++) {
							Color c;
							c.r = 1.0f - orig_img->get_pixel(x, y).a;
							c.g = 1.0f - orig_img->get_pixel(x, y).a;
							c.b = 1.0f - orig_img->get_pixel(x, y).a;
							roughness_img->set_pixel(x, y, c);
						}
					}
					orig_img->unlock();
					roughness_img->unlock();
				}
				roughness_img->generate_mipmaps();
				Ref<ImageTexture> image_texture;
				image_texture.instance();
				image_texture->create_from_image(roughness_img);
				material->set_texture(SpatialMaterial::TEXTURE_ROUGHNESS, image_texture);
				material->set_roughness_texture_channel(SpatialMaterial::TEXTURE_CHANNEL_GREEN);
				if (!sgm.has("glossinessFactor")) {
					material->set_roughness(0.0f);
				}
			}
		}
	}
}
```
