### PR TITLE
Improve shader time roll over

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -277,9 +277,8 @@ void RasterizerGLES2::begin_frame(double frame_step) {
 		frame_step = 0.001;
 	}
 
-	// double time_roll_over = GLOBAL_GET("rendering/limits/time/time_rollover_secs");
-	// if (time_total > time_roll_over)
-	//	time_total = 0; //roll over every day (should be customz
+	double time_roll_over = GLOBAL_GET("rendering/limits/time/time_rollover_secs");
+	time_total = Math::fmod(time_total, time_roll_over);
 
 	storage->frame.time[0] = time_total;
 	storage->frame.time[1] = Math::fmod(time_total, 3600);

--- a/servers/rendering/rasterizer_rd/rasterizer_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_rd.cpp
@@ -30,6 +30,8 @@
 
 #include "rasterizer_rd.h"
 
+#include "core/project_settings.h"
+
 void RasterizerRD::prepare_for_blitting_render_targets() {
 	RD::get_singleton()->prepare_screen_for_drawing();
 }
@@ -78,6 +80,10 @@ void RasterizerRD::blit_render_targets_to_screen(DisplayServer::WindowID p_scree
 void RasterizerRD::begin_frame(double frame_step) {
 	frame++;
 	time += frame_step;
+
+	double time_roll_over = GLOBAL_GET("rendering/limits/time/time_rollover_secs");
+	time = Math::fmod(time, time_roll_over);
+
 	canvas->set_time(time);
 	scene->set_time(time, frame_step);
 }

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2400,6 +2400,9 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF_RST("rendering/vram_compression/import_etc2", true);
 	GLOBAL_DEF_RST("rendering/vram_compression/import_pvrtc", false);
 
+	GLOBAL_DEF("rendering/limits/time/time_rollover_secs", 3600);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/time/time_rollover_secs", PropertyInfo(Variant::FLOAT, "rendering/limits/time/time_rollover_secs", PROPERTY_HINT_RANGE, "0,10000,1,or_greater"));
+
 	GLOBAL_DEF("rendering/quality/directional_shadow/size", 4096);
 	GLOBAL_DEF("rendering/quality/directional_shadow/size.mobile", 2048);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/directional_shadow/size", PropertyInfo(Variant::INT, "rendering/quality/directional_shadow/size", PROPERTY_HINT_RANGE, "256,16384"));


### PR DESCRIPTION
- Resurrect it for GL ES 2
- Add it to the Vulkan rasterizer
- Expose the setting from the `RenderingServer`, since it does not belong in any specific rasterizer