### PR TITLE
Fix Camera2D incorrect preview bounds 

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -347,8 +347,6 @@ void EditorNode::_notification(int p_what) {
 
 			editor_selection->update();
 
-			//scene_root->set_size_override(true, Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height")));
-
 			{ //TODO should only happen on settings changed
 				int current_filter = GLOBAL_GET("rendering/canvas_textures/default_texture_filter");
 				if (current_filter != scene_root->get_default_canvas_item_texture_filter()) {

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -32,6 +32,7 @@
 
 #include "core/engine.h"
 #include "core/math/math_funcs.h"
+#include "editor/editor_node.h"
 #include "scene/scene_string_names.h"
 #include "servers/rendering_server.h"
 
@@ -56,7 +57,7 @@ void Camera2D::_update_scroll() {
 
 		viewport->set_canvas_transform(xform);
 
-		Size2 screen_size = viewport->get_visible_rect().size;
+		Size2 screen_size = get_camera_screen_size();
 		Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5) : Point2());
 
 		get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, group_name, "_camera_moved", xform, screen_offset);
@@ -97,7 +98,7 @@ Transform2D Camera2D::get_camera_transform() {
 
 	ERR_FAIL_COND_V(custom_viewport && !ObjectDB::get_instance(custom_viewport_id), Transform2D());
 
-	Size2 screen_size = viewport->get_visible_rect().size;
+	Size2 screen_size = get_camera_screen_size();
 
 	Point2 new_camera_pos = get_global_transform().get_origin();
 	Point2 ret_camera_pos;
@@ -281,7 +282,7 @@ void Camera2D::_notification(int p_what) {
 				}
 
 				Transform2D inv_camera_transform = get_camera_transform().affine_inverse();
-				Size2 screen_size = get_viewport_rect().size;
+				Size2 screen_size = get_camera_screen_size();
 
 				Vector2 screen_endpoints[4] = {
 					inv_camera_transform.xform(Vector2(0, 0)),
@@ -328,7 +329,7 @@ void Camera2D::_notification(int p_what) {
 				}
 
 				Transform2D inv_camera_transform = get_camera_transform().affine_inverse();
-				Size2 screen_size = get_viewport_rect().size;
+				Size2 screen_size = get_camera_screen_size();
 
 				Vector2 margin_endpoints[4] = {
 					inv_camera_transform.xform(Vector2((screen_size.width / 2) - ((screen_size.width / 2) * drag_margin[MARGIN_LEFT]), (screen_size.height / 2) - ((screen_size.height / 2) * drag_margin[MARGIN_TOP]))),
@@ -494,7 +495,7 @@ void Camera2D::align() {
 
 	ERR_FAIL_COND(custom_viewport && !ObjectDB::get_instance(custom_viewport_id));
 
-	Size2 screen_size = viewport->get_visible_rect().size;
+	Size2 screen_size = get_camera_screen_size();
 
 	Point2 current_camera_pos = get_global_transform().get_origin();
 	if (anchor_mode == ANCHOR_MODE_DRAG_CENTER) {
@@ -533,6 +534,14 @@ float Camera2D::get_follow_smoothing() const {
 Point2 Camera2D::get_camera_screen_center() const {
 
 	return camera_screen_center;
+}
+
+Size2 Camera2D::get_camera_screen_size() const {
+	// special case if the camera2D is in the root viewport
+	if (Engine::get_singleton()->is_editor_hint() && get_viewport() == EditorNode::get_singleton()->get_scene_root()) {
+		return Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height"));
+	}
+	return get_viewport_rect().size;
 }
 
 void Camera2D::set_h_drag_enabled(bool p_enabled) {

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -148,6 +148,7 @@ public:
 	Vector2 get_zoom() const;
 
 	Point2 get_camera_screen_center() const;
+	Size2 get_camera_screen_size() const;
 
 	void set_custom_viewport(Node *p_viewport);
 	Node *get_custom_viewport() const;


### PR DESCRIPTION
Fixes #38316 

Problem was that the preview box behavior depended on set_size_2d_override for the root viewport. In 3.2, there was a special call to this every frame, but it got commented out for some reason.

Uncommenting it and updating the function name doesn't seem to have broken anything and fixes the issue. Looks like @reduz himself was the one who commented it out at first, so maybe he can comment on it...

If for some reason setting the viewport size override breaks other 4.0 stuff, maybe we could add a special case for camera2D to just pull the size values from the settings if the viewport it's dealing with is the scene root?