### PR TITLE
Fix custom w component being uninitialized on CPU particles.

### DIFF
--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -69,6 +69,7 @@ void CPUParticles3D::set_amount(int p_amount) {
 
 		for (int i = 0; i < p_amount; i++) {
 			w[i].active = false;
+			w[i].custom[3] = 0.0; // Make sure w component isn't garbage data
 		}
 	}
 


### PR DESCRIPTION
In CPU particles, the custom w component can be uninitialized, resulting in strange behavior with custom material shaders on particles.  Probably won't affect most people, but it broke something for me, so I figured I'd do a pull request.