### PR TITLE
fix: dict2inst crash when constructor has arguments

### DIFF
--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1200,6 +1200,11 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 
 			r_ret = gdscr->_new(nullptr, 0, r_error);
 
+			if (r_error.error != Callable::CallError::CALL_OK) {
+				r_ret = Variant();
+				return;
+			}
+
 			GDScriptInstance *ins = static_cast<GDScriptInstance *>(static_cast<Object *>(r_ret)->get_script_instance());
 			Ref<GDScript> gd_ref = ins->get_script();
 


### PR DESCRIPTION
Fix: #30572

not sure godot must support parameter less deserialization or not, however doesn't have to crash