### PR TITLE
FastLZ: Update to upstream version 0.5.0

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -260,7 +260,7 @@ License: BSD-3-clause
 Files: ./thirdparty/misc/fastlz.c
  ./thirdparty/misc/fastlz.h
 Comment: FastLZ
-Copyright: 2005-2007, Ariya Hidayat
+Copyright: 2005-2020, Ariya Hidayat
 License: Expat
 
 Files: ./thirdparty/misc/hq2x.cpp

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -371,7 +371,7 @@ Collection of single-file libraries used in Godot components.
   * License: MIT
 - `fastlz.{c,h}`
   * Upstream: https://github.com/ariya/FastLZ
-  * Version: git (f121734, 2007)
+  * Version: 0.5.0 (4f20f54d46f5a6dd4fae4def134933369b7602d2, 2020)
   * License: MIT
 - `hq2x.{cpp,h}`
   * Upstream: https://github.com/brunexgeek/hqx

--- a/thirdparty/misc/fastlz.h
+++ b/thirdparty/misc/fastlz.h
@@ -1,9 +1,6 @@
 /*
-  FastLZ - lightning-fast lossless compression library
-
-  Copyright (C) 2007 Ariya Hidayat (ariya@kde.org)
-  Copyright (C) 2006 Ariya Hidayat (ariya@kde.org)
-  Copyright (C) 2005 Ariya Hidayat (ariya@kde.org)
+  FastLZ - Byte-aligned LZ77 compression library
+  Copyright (C) 2005-2020 Ariya Hidayat <ariya.hidayat@gmail.com>
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
@@ -27,47 +24,17 @@
 #ifndef FASTLZ_H
 #define FASTLZ_H
 
-#define FASTLZ_VERSION 0x000100
+#define FASTLZ_VERSION 0x000500
 
-#define FASTLZ_VERSION_MAJOR     0
-#define FASTLZ_VERSION_MINOR     0
-#define FASTLZ_VERSION_REVISION  0
+#define FASTLZ_VERSION_MAJOR 0
+#define FASTLZ_VERSION_MINOR 5
+#define FASTLZ_VERSION_REVISION 0
 
-#define FASTLZ_VERSION_STRING "0.1.0"
+#define FASTLZ_VERSION_STRING "0.5.0"
 
-#if defined (__cplusplus)
+#if defined(__cplusplus)
 extern "C" {
 #endif
-
-/**
-  Compress a block of data in the input buffer and returns the size of
-  compressed block. The size of input buffer is specified by length. The
-  minimum input buffer size is 16.
-
-  The output buffer must be at least 5% larger than the input buffer
-  and can not be smaller than 66 bytes.
-
-  If the input is not compressible, the return value might be larger than
-  length (input buffer size).
-
-  The input buffer and the output buffer can not overlap.
-*/
-
-int fastlz_compress(const void* input, int length, void* output);
-
-/**
-  Decompress a block of compressed data and returns the size of the
-  decompressed block. If error occurs, e.g. the compressed data is
-  corrupted or the output buffer is not large enough, then 0 (zero)
-  will be returned instead.
-
-  The input buffer and the output buffer can not overlap.
-
-  Decompression is memory safe and guaranteed not to write the output buffer
-  more than what is specified in maxout.
- */
-
-int fastlz_decompress(const void* input, int length, void* output, int maxout);
 
 /**
   Compress a block of data in the input buffer and returns the size of
@@ -88,12 +55,43 @@ int fastlz_decompress(const void* input, int length, void* output, int maxout);
   Level 2 is slightly slower but it gives better compression ratio.
 
   Note that the compressed data, regardless of the level, can always be
-  decompressed using the function fastlz_decompress above.
+  decompressed using the function fastlz_decompress below.
 */
 
-int fastlz_compress_level(int level, const void* input, int length, void* output);
+int fastlz_compress_level(int level, const void* input, int length,
+                          void* output);
 
-#if defined (__cplusplus)
+/**
+  Decompress a block of compressed data and returns the size of the
+  decompressed block. If error occurs, e.g. the compressed data is
+  corrupted or the output buffer is not large enough, then 0 (zero)
+  will be returned instead.
+
+  The input buffer and the output buffer can not overlap.
+
+  Decompression is memory safe and guaranteed not to write the output buffer
+  more than what is specified in maxout.
+
+  Note that the decompression will always work, regardless of the
+  compression level specified in fastlz_compress_level above (when
+  producing the compressed block).
+ */
+
+int fastlz_decompress(const void* input, int length, void* output, int maxout);
+
+/**
+  DEPRECATED.
+
+  This is similar to fastlz_compress_level above, but with the level
+  automatically chosen.
+
+  This function is deprecated and it will be completely removed in some future
+  version.
+*/
+
+int fastlz_compress(const void* input, int length, void* output);
+
+#if defined(__cplusplus)
 }
 #endif
 


### PR DESCRIPTION
Upstream development restarted after 13 years. Changes:

2020-02-02: Version 0.5.0

    Minor speed improvement on the decompressor.
    Prevent memory violation when decompressing corrupted input.

2020-01-10: Version 0.4.0

    Only code & infrastructure clean-up, no new functionality.

---

I'll opt against cherrypicking as I haven't tested that it behaves in a compatible way with the previous version (i.e. that it would be able to decompress stuff compressed by 2007 FastLZ, and also that compressed data output would be reproducible in both versions).