### PR TITLE
tinyexr: Sync with upstream 4dbd05a + enable C++11 threaded loading

### DIFF
--- a/modules/tinyexr/SCsub
+++ b/modules/tinyexr/SCsub
@@ -15,6 +15,9 @@ thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
 env_tinyexr.Prepend(CPPPATH=[thirdparty_dir])
 
+# Enable threaded loading with C++11.
+env_tinyexr.Append(CPPDEFINES=["TINYEXR_USE_THREAD"])
+
 env_thirdparty = env_tinyexr.Clone()
 env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -533,7 +533,7 @@ comments and a patch is provided in the squish/ folder.
 ## tinyexr
 
 - Upstream: https://github.com/syoyo/tinyexr
-- Version: git (656bb61, 2019)
+- Version: git (4dbd05a22f51a2d7462311569b8b0cba0bbe2ac5, 2020)
 - License: BSD-3-Clause
 
 Files extracted from upstream source:


### PR DESCRIPTION
I enabled threaded loading as a separate commit so that we can revert it if it's problematic.
I haven't tested it yet to see how it behaves.