### PR TITLE
Basic implementation of async transfer

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -221,6 +221,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 
 	Error _buffer_allocate(Buffer *p_buffer, uint32_t p_size, uint32_t p_usage, VmaMemoryUsage p_mapping);
 	Error _buffer_free(Buffer *p_buffer);
+	Error _buffer_transfer(Buffer *p_buffer, const uint8_t *p_data, size_t p_data_size);
 	Error _buffer_update(Buffer *p_buffer, size_t p_offset, const uint8_t *p_data, size_t p_data_size, bool p_use_draw_command_buffer = false, uint32_t p_required_align = 32);
 
 	void _full_barrier(bool p_sync_with_draw);

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -103,6 +103,13 @@ private:
 	bool separate_present_queue = false;
 	VkQueue graphics_queue = VK_NULL_HANDLE;
 	VkQueue present_queue = VK_NULL_HANDLE;
+
+	uint32_t transfer_queue_family_index = 0;
+	bool separate_transfer_queue = false;
+	VkCommandPool transfer_command_pool = VK_NULL_HANDLE;
+	VkCommandBuffer transfer_command_buffer = VK_NULL_HANDLE;
+	VkQueue transfer_queue = VK_NULL_HANDLE;
+
 	VkColorSpaceKHR color_space;
 	VkFormat format;
 	VkSemaphore draw_complete_semaphores[FRAME_LAG];
@@ -246,6 +253,10 @@ public:
 	int get_swapchain_image_count() const;
 	VkQueue get_graphics_queue() const;
 	uint32_t get_graphics_queue_family_index() const;
+	uint32_t get_transfer_queue() const;
+	void submit_transfer_queue();
+	bool is_using_separate_transfer_queue() const;
+	VkCommandBuffer get_transfer_command_buffer() const;
 
 	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height);
 	int window_get_width(DisplayServer::WindowID p_window = 0);


### PR DESCRIPTION
This PR moves the creation of textures and buffers to the transfer queue (when available) instead of handling it on the graphics queue with the staging buffer. The transfer queue is guaranteed to be at least as fast as the graphics queue for transfer operations (and is usually faster) and can run in parellel to the graphics queue. 

This is a base implementation for @reduz to improve on. My knowledge of Vulkan and the multithreaded implementation of the Rendering Device is much to limited to produce a final version. 

Notably, mutexes will need to be added to ``_buffer_transfer()`` and ``texture_create()``. Further, I think we may want to explore creating a command_buffer for each thread, rather than one global command buffer (reduz suggested created a new command_pool and command_buffer for each call to ``texture_create()`` or ``_buffer_transfer``