### PR TITLE
Added ability for mouse buttons to be assigned as editor shortcuts

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -491,6 +491,21 @@ int InputEventMouseButton::get_button_index() const {
 	return button_index;
 }
 
+int InputEventMouseButton::get_button_index_with_modifiers() const {
+
+	uint32_t sc = button_index;
+	if (get_control())
+		sc |= KEY_MASK_CTRL;
+	if (get_alt())
+		sc |= KEY_MASK_ALT;
+	if (get_shift())
+		sc |= KEY_MASK_SHIFT;
+	if (get_metakey())
+		sc |= KEY_MASK_META;
+
+	return sc;
+}
+
 void InputEventMouseButton::set_pressed(bool p_pressed) {
 
 	pressed = p_pressed;
@@ -552,40 +567,68 @@ bool InputEventMouseButton::action_match(const Ref<InputEvent> &p_event, bool *p
 
 String InputEventMouseButton::as_text() const {
 
-	String button_index_string = "";
+	String button_event_string = "";
+
 	switch (get_button_index()) {
 		case BUTTON_LEFT:
-			button_index_string = "BUTTON_LEFT";
+			button_event_string = "LMB";
 			break;
 		case BUTTON_RIGHT:
-			button_index_string = "BUTTON_RIGHT";
+			button_event_string = "RMB";
 			break;
 		case BUTTON_MIDDLE:
-			button_index_string = "BUTTON_MIDDLE";
+			button_event_string = "MMB";
 			break;
 		case BUTTON_WHEEL_UP:
-			button_index_string = "BUTTON_WHEEL_UP";
+			button_event_string = "MWU";
 			break;
 		case BUTTON_WHEEL_DOWN:
-			button_index_string = "BUTTON_WHEEL_DOWN";
+			button_event_string = "MWD";
 			break;
 		case BUTTON_WHEEL_LEFT:
-			button_index_string = "BUTTON_WHEEL_LEFT";
+			button_event_string = "MWL";
 			break;
 		case BUTTON_WHEEL_RIGHT:
-			button_index_string = "BUTTON_WHEEL_RIGHT";
+			button_event_string = "MWR";
 			break;
 		case BUTTON_XBUTTON1:
-			button_index_string = "BUTTON_XBUTTON1";
+			button_event_string = "MBX1";
 			break;
 		case BUTTON_XBUTTON2:
-			button_index_string = "BUTTON_XBUTTON2";
+			button_event_string = "MBX2";
 			break;
 		default:
-			button_index_string = itos(get_button_index());
+			button_event_string = "MB" + itos(get_button_index());
 			break;
 	}
-	return "InputEventMouseButton : button_index=" + button_index_string + ", pressed=" + (pressed ? "true" : "false") + ", position=(" + String(get_position()) + "), button_mask=" + itos(get_button_mask()) + ", doubleclick=" + (doubleclick ? "true" : "false");
+
+	if (get_metakey()) {
+		button_event_string = find_keycode_name(KEY_META) + ("+" + button_event_string);
+	}
+	if (get_alt()) {
+		button_event_string = find_keycode_name(KEY_ALT) + ("+" + button_event_string);
+	}
+	if (get_shift()) {
+		button_event_string = find_keycode_name(KEY_SHIFT) + ("+" + button_event_string);
+	}
+	if (get_control()) {
+		button_event_string = find_keycode_name(KEY_CONTROL) + ("+" + button_event_string);
+	}
+
+	//return "InputEventMouseButton : button_index=" + button_index_string + ", pressed=" + (pressed ? "true" : "false") + ", position=(" + String(get_position()) + "), button_mask=" + itos(get_button_mask()) + ", doubleclick=" + (doubleclick ? "true" : "false");
+	return button_event_string;
+}
+
+bool InputEventMouseButton::shortcut_match(const Ref<InputEvent> &p_event) const {
+
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_null())
+		return false;
+
+	uint32_t button = get_button_index_with_modifiers();
+	uint32_t event_button = mb->get_button_index_with_modifiers();
+
+	return button == event_button;
 }
 
 void InputEventMouseButton::_bind_methods() {

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -354,6 +354,8 @@ public:
 	void set_button_index(int p_index);
 	int get_button_index() const;
 
+	int get_button_index_with_modifiers() const;
+
 	void set_pressed(bool p_pressed);
 	virtual bool is_pressed() const;
 
@@ -365,6 +367,8 @@ public:
 
 	virtual bool is_action_type() const { return true; }
 	virtual String as_text() const;
+
+	virtual bool shortcut_match(const Ref<InputEvent> &p_event) const;
 
 	InputEventMouseButton();
 };

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -473,18 +473,20 @@ float CanvasItemEditor::snap_angle(float p_target, float p_start) const {
 	}
 }
 
-void CanvasItemEditor::_unhandled_key_input(const Ref<InputEvent> &p_ev) {
+void CanvasItemEditor::_input(const Ref<InputEvent> &p_ev) {
 
 	Ref<InputEventKey> k = p_ev;
 
 	if (!is_visible_in_tree())
 		return;
 
-	if (k->get_keycode() == KEY_CONTROL || k->get_keycode() == KEY_ALT || k->get_keycode() == KEY_SHIFT) {
+	if (k.is_valid() && (k->is_pressed() && (k->get_keycode() == KEY_CONTROL || k->get_keycode() == KEY_ALT || k->get_keycode() == KEY_SHIFT))) {
 		viewport->update();
 	}
 
-	if (k->is_pressed() && !k->get_control() && !k->is_echo()) {
+	Ref<InputEventMouseButton> mb = p_ev;
+
+	if ((k.is_valid() && (k->is_pressed() && !k->get_control() && !k->is_echo())) || (mb.is_valid() && mb->is_pressed())) {
 		if ((grid_snap_active || show_grid) && multiply_grid_step_shortcut.is_valid() && multiply_grid_step_shortcut->is_shortcut(p_ev)) {
 			// Multiply the grid size
 			grid_step_multiplier = MIN(grid_step_multiplier + 1, 12);
@@ -1256,8 +1258,9 @@ bool CanvasItemEditor::_gui_input_zoom_or_pan(const Ref<InputEvent> &p_event, bo
 		}
 	}
 
+	// TODO: Check
 	Ref<InputEventKey> k = p_event;
-	if (k.is_valid()) {
+	if (k.is_valid() || b.is_valid()) {
 		bool is_pan_key = pan_view_shortcut.is_valid() && pan_view_shortcut->is_shortcut(p_event);
 
 		if (is_pan_key && (EditorSettings::get_singleton()->get("editors/2d/simple_panning") || drag_type != DRAG_NONE)) {
@@ -5093,7 +5096,7 @@ void CanvasItemEditor::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_update_override_camera_button", "game_running"), &CanvasItemEditor::_update_override_camera_button);
 	ClassDB::bind_method("_get_editor_data", &CanvasItemEditor::_get_editor_data);
-	ClassDB::bind_method("_unhandled_key_input", &CanvasItemEditor::_unhandled_key_input);
+	ClassDB::bind_method("_input", &CanvasItemEditor::_input);
 	ClassDB::bind_method("_queue_update_bone_list", &CanvasItemEditor::_update_bone_list);
 	ClassDB::bind_method("_update_bone_list", &CanvasItemEditor::_update_bone_list);
 	ClassDB::bind_method(D_METHOD("set_state"), &CanvasItemEditor::set_state);
@@ -5807,7 +5810,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	skeleton_menu->get_popup()->set_item_checked(skeleton_menu->get_popup()->get_item_index(SKELETON_SHOW_BONES), true);
 	singleton = this;
 
-	set_process_unhandled_key_input(true);
+	set_process_input(true);
 
 	// Update the menus' checkboxes
 	call_deferred("set_state", get_state());

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -463,7 +463,7 @@ private:
 
 	void _keying_changed();
 
-	void _unhandled_key_input(const Ref<InputEvent> &p_ev);
+	void _input(const Ref<InputEvent> &p_ev);
 
 	void _draw_text_at_position(Point2 p_position, String p_string, Margin p_side);
 	void _draw_margin_at_position(int p_value, Point2 p_position, Margin p_side);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -71,9 +71,6 @@ void SceneTreeDock::_input(Ref<InputEvent> p_event) {
 	if (mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
 		restore_script_editor_on_drag = false; //lost chance
 	}
-}
-
-void SceneTreeDock::_unhandled_key_input(Ref<InputEvent> p_event) {
 
 	if (get_focus_owner() && get_focus_owner()->is_text_field())
 		return;
@@ -2772,7 +2769,6 @@ void SceneTreeDock::_feature_profile_changed() {
 void SceneTreeDock::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_set_owners"), &SceneTreeDock::_set_owners);
-	ClassDB::bind_method(D_METHOD("_unhandled_key_input"), &SceneTreeDock::_unhandled_key_input);
 	ClassDB::bind_method(D_METHOD("_input"), &SceneTreeDock::_input);
 	ClassDB::bind_method(D_METHOD("_update_script_button"), &SceneTreeDock::_update_script_button);
 
@@ -2921,7 +2917,6 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	quick_open = memnew(EditorQuickOpen);
 	add_child(quick_open);
 	quick_open->connect("quick_open", callable_mp(this, &SceneTreeDock::_quick_open));
-	set_process_unhandled_key_input(true);
 
 	delete_dialog = memnew(ConfirmationDialog);
 	add_child(delete_dialog);

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -194,7 +194,6 @@ class SceneTreeDock : public VBoxContainer {
 
 	void _nodes_drag_begin();
 	void _input(Ref<InputEvent> p_event);
-	void _unhandled_key_input(Ref<InputEvent> p_event);
 
 	void _import_subscene();
 

--- a/editor/settings_config_dialog.h
+++ b/editor/settings_config_dialog.h
@@ -61,7 +61,7 @@ class EditorSettingsDialog : public AcceptDialog {
 
 	ConfirmationDialog *press_a_key;
 	Label *press_a_key_label;
-	Ref<InputEventKey> last_wait_for_key;
+	Ref<InputEvent> last_wait_for_input;
 	String shortcut_configured;
 	String shortcut_filter;
 

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -346,14 +346,14 @@ bool BaseButton::is_keep_pressed_outside() const {
 void BaseButton::set_shortcut(const Ref<ShortCut> &p_shortcut) {
 
 	shortcut = p_shortcut;
-	set_process_unhandled_input(shortcut.is_valid());
+	set_process_input(shortcut.is_valid());
 }
 
 Ref<ShortCut> BaseButton::get_shortcut() const {
 	return shortcut;
 }
 
-void BaseButton::_unhandled_input(Ref<InputEvent> p_event) {
+void BaseButton::_input(Ref<InputEvent> p_event) {
 
 	if (!is_disabled() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->is_shortcut(p_event)) {
 
@@ -397,7 +397,7 @@ Ref<ButtonGroup> BaseButton::get_button_group() const {
 void BaseButton::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_gui_input"), &BaseButton::_gui_input);
-	ClassDB::bind_method(D_METHOD("_unhandled_input"), &BaseButton::_unhandled_input);
+	ClassDB::bind_method(D_METHOD("_input"), &BaseButton::_input);
 	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &BaseButton::set_pressed);
 	ClassDB::bind_method(D_METHOD("is_pressed"), &BaseButton::is_pressed);
 	ClassDB::bind_method(D_METHOD("is_hovered"), &BaseButton::is_hovered);

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -78,7 +78,7 @@ protected:
 	virtual void toggled(bool p_pressed);
 	static void _bind_methods();
 	virtual void _gui_input(Ref<InputEvent> p_event);
-	virtual void _unhandled_input(Ref<InputEvent> p_event);
+	virtual void _input(Ref<InputEvent> p_event);
 	void _notification(int p_what);
 
 public:

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -33,12 +33,12 @@
 #include "core/os/keyboard.h"
 #include "scene/main/window.h"
 
-void MenuButton::_unhandled_key_input(Ref<InputEvent> p_event) {
+void MenuButton::_input(Ref<InputEvent> p_event) {
 
 	if (disable_shortcuts)
 		return;
 
-	if (p_event->is_pressed() && !p_event->is_echo() && (Object::cast_to<InputEventKey>(p_event.ptr()) || Object::cast_to<InputEventJoypadButton>(p_event.ptr()) || Object::cast_to<InputEventAction>(*p_event))) {
+	if (p_event->is_pressed() && !p_event->is_echo() && (Object::cast_to<InputEventKey>(p_event.ptr()) || Object::cast_to<InputEventMouseButton>(p_event.ptr()) || Object::cast_to<InputEventJoypadButton>(p_event.ptr()) || Object::cast_to<InputEventAction>(*p_event))) {
 
 		if (!get_parent() || !is_visible_in_tree() || is_disabled())
 			return;
@@ -117,7 +117,7 @@ void MenuButton::_notification(int p_what) {
 void MenuButton::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_popup"), &MenuButton::get_popup);
-	ClassDB::bind_method(D_METHOD("_unhandled_key_input"), &MenuButton::_unhandled_key_input);
+	ClassDB::bind_method(D_METHOD("_input"), &MenuButton::_input);
 	ClassDB::bind_method(D_METHOD("_set_items"), &MenuButton::_set_items);
 	ClassDB::bind_method(D_METHOD("_get_items"), &MenuButton::_get_items);
 	ClassDB::bind_method(D_METHOD("set_switch_on_hover", "enable"), &MenuButton::set_switch_on_hover);
@@ -142,7 +142,7 @@ MenuButton::MenuButton() {
 	set_toggle_mode(true);
 	set_disable_shortcuts(false);
 	set_enabled_focus_mode(FOCUS_NONE);
-	set_process_unhandled_key_input(true);
+	set_process_input(true);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 
 	popup = memnew(PopupMenu);

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -43,7 +43,7 @@ class MenuButton : public Button {
 	bool disable_shortcuts;
 	PopupMenu *popup;
 
-	void _unhandled_key_input(Ref<InputEvent> p_event);
+	void _input(Ref<InputEvent> p_event);
 	Array _get_items() const;
 	void _set_items(const Array &p_items);
 


### PR DESCRIPTION
Closes #38326 along with several related issues which were mentioned in that thread.

Changes had to be made not only to the way inputs were set as shortcuts, but also how they were checked on buttons and in menus. Most shortcut checks were done on `_unhandled_key_input` which is obviously no good for mouse events, so a few controls needed to have `process_unhandled_key_input` set to false, and `process_input` set to true. Why not just `unhandled_input`? The viewport code sets `input_as_handled = true` if the event is a mouse button since it send's to to the gui (`_gui_input`). I didn't want to mess with the viewport code.

The only exception to the current implementation is in the 3D editor free look (below). This is because the shortcut check in this function compares the input directly to the input singleton, rather than handling an input event like other cases. Incidentally, this seems to also prohibit freelook shortcuts from having modifiers. I don't think this is a big issue but it is solvable with a few changes.
https://github.com/godotengine/godot/blob/ad28d41a21e72c899aa3f6176d3504d0ea415c64/editor/plugins/node_3d_editor_plugin.cpp#L2266-L2278

I tested this implementation with shortcuts for the script editor, scene treedock , tilemap editor and a few others. However, since handling of shortcuts is a bit non-uniform I may have missed some edge cases, but I did my best to search the code base for all shortcut-related methods.

![wclSOLAd85](https://user-images.githubusercontent.com/41730826/80782225-8f248500-8bb8-11ea-9e42-2511bb30c083.gif)
![godot windows tools 64_Yqmto5LEii](https://user-images.githubusercontent.com/41730826/80782213-8764e080-8bb8-11ea-9f90-117d80660639.png)
![godot windows tools 64_wv4NJ3TkUm](https://user-images.githubusercontent.com/41730826/80782221-8cc22b00-8bb8-11ea-8b07-60ba2c9717c9.png)
