### PR TITLE
recursive inst2dict() dict2inst() implemented for subclasses

### DIFF
--- a/modules/gdscript/gdscript_functions.h
+++ b/modules/gdscript/gdscript_functions.h
@@ -133,6 +133,10 @@ public:
 	static void call(Function p_func, const Variant **p_args, int p_arg_count, Variant &r_ret, Variant::CallError &r_error);
 	static bool is_deterministic(Function p_func);
 	static MethodInfo get_info(Function p_func);
+
+private:
+	static Variant _inst2dict(const Variant &p_arg, Variant::CallError &r_error);
+	static Variant _dict2inst(const Dictionary &p_arg, Variant::CallError &r_error);
 };
 
 #endif // GDSCRIPT_FUNCTIONS_H


### PR DESCRIPTION
Fix: #6533 recursively serialize/deserialize objects

this fix will work on current master (959ffd5) too(Variant -> Callable), but since the dictionary is broken in current master it can't be tested. should I also have to create another pr for master or create this pr against master ??

test case
```gdscript
extends Node2D


class A:
	var var_a
	var inst_b
	## d is not instance of A.B.C, but a Dictionary
	var dict = {'@path':'res://Node2D.gd', '@subpath':'A/B/C', 'var_c':'dict'}
	var spr = Sprite.new() ## this won't serialize
	
	class B:
		var var_b
		var inst_c
		
		class C:
			var var_c


func serialize():
	var inst_a = A.new()
	inst_a.var_a = 'a'
	inst_a.inst_b = A.B.new()
	
	inst_a.inst_b.var_b = 'b'
	inst_a.inst_b.inst_c = A.B.C.new()
	
	inst_a.inst_b.inst_c.var_c = 'c'
	
	print(inst2dict(inst_a))
	pass

func deserialize():
	var dict = {
		'@path':'res://Node2D.gd', '@subpath':'A', 
			'd':{'@path':'res://Node2D.gd', '@subpath':'A/B/C', 'var_c':'not inst'}, 
			'inst_b': {'@path':'res://Node2D.gd', '@subpath':'A/B', 
				'inst_c':{'@path':'res://Node2D.gd', '@subpath':'A/B/C', 'var_c':'c'},
				'var_b':'b'}, 
			'var_a':'a'
		}

	var a :A = dict2inst(dict)
	print(inst2dict(a))
	print(a.dict['var_c']) ## d deserialize as a dictionary
	print(a.inst_b.inst_c.var_c) ## deserialize as a class
	pass

func _ready():
	serialize()
	deserialize()
	pass
```

output
```gdscript
{@path:res://Node2D.gd, @subpath:A, dict:{@path:res://Node2D.gd, @subpath:A/B/C, var_c:dict},
inst_b:{@path:res://Node2D.gd, @subpath:A/B, inst_c:{@path:res://Node2D.gd, @subpath:A/B/C,
var_c:c}, var_b:b}, var_a:a}
```
