### PR TITLE
Fix uninitialized memory in CPUParticles2D

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -53,9 +53,11 @@ void CPUParticles2D::set_amount(int p_amount) {
 	{
 		PoolVector<Particle>::Write w = particles.write();
 
-		for (int i = 0; i < p_amount; i++) {
-			w[i].active = false;
-		}
+		// each particle must be set to false
+		// zeroing the data also prevents uninitialized memory being sent to GPU
+		zeromem(static_cast<void *>(&w[0]), p_amount * sizeof(Particle));
+		// cast to prevent compiler warning .. note this relies on Particle not containing any complex types.
+		// an alternative is to use some zero method per item but the generated code will be far less efficient.
 	}
 
 	particle_data.resize((8 + 4 + 1) * p_amount);
@@ -1020,21 +1022,21 @@ void CPUParticles2D::_update_particle_data_buffer() {
 				ptr[6] = 0;
 				ptr[7] = t.elements[2][1];
 
+				Color c = r[idx].color;
+				uint8_t *data8 = (uint8_t *)&ptr[8];
+				data8[0] = CLAMP(c.r * 255.0, 0, 255);
+				data8[1] = CLAMP(c.g * 255.0, 0, 255);
+				data8[2] = CLAMP(c.b * 255.0, 0, 255);
+				data8[3] = CLAMP(c.a * 255.0, 0, 255);
+
+				ptr[9] = r[idx].custom[0];
+				ptr[10] = r[idx].custom[1];
+				ptr[11] = r[idx].custom[2];
+				ptr[12] = r[idx].custom[3];
+
 			} else {
-				zeromem(ptr, sizeof(float) * 8);
+				zeromem(ptr, sizeof(float) * 13);
 			}
-
-			Color c = r[idx].color;
-			uint8_t *data8 = (uint8_t *)&ptr[8];
-			data8[0] = CLAMP(c.r * 255.0, 0, 255);
-			data8[1] = CLAMP(c.g * 255.0, 0, 255);
-			data8[2] = CLAMP(c.b * 255.0, 0, 255);
-			data8[3] = CLAMP(c.a * 255.0, 0, 255);
-
-			ptr[9] = r[idx].custom[0];
-			ptr[10] = r[idx].custom[1];
-			ptr[11] = r[idx].custom[2];
-			ptr[12] = r[idx].custom[3];
 
 			ptr += 13;
 		}

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -81,6 +81,8 @@ public:
 private:
 	bool emitting;
 
+	// warning - beware of adding non-trivial types
+	// to this structure as it is zeroed to initialize in set_amount()
 	struct Particle {
 		Transform2D transform;
 		Color color;


### PR DESCRIPTION
Calls to set_amount can increase the size of the particle array, but do not zero the memory, they only set the active flag to false. This uninitialized memory can be sent to the GPU, possibly as NaNs.

## Why is this of interest
Me and @clayjohn have been working to solve a bug in iOS where particles display incorrectly with batching, which may be a pre-existing bug occurring with ninepatchrects and a number of situations:
#38318
#32837

This has led us to look at the GLstate and particles (multimesh) with a fine toothed comb.

## The problem
Inspired by #38346 I did some checking for a similar problem in CPUParticles2D, and indeed there is uninitialized memory after calling `set_amount`. This could either by initialized as something like `bAAdfOOd` in some cases, be zeroed, or simply be random, and contain NaNs.

A test using memory purposefully set to 255 shows that this garbage memory is stored in the particle buffer in `_update_particle_data_buffer`. This could be problematic if transferred to the GPU, especially if this range of the VB is used for rendering (I suspect that we are just drawing the whole VB, and relying on the positions to be zero to avoid having something on screen, I don't know this area of code though).

## Solutions
I'm trying to include a few solutions in here so that @reduz can have a look and let me know which will be best. I'll put some notes on the source code.

This PR is made against 3.2 because that is what we are primarily interested in for the beta, but can be done for 4.x too. The answers here may also be applied to the PRs for the 3d particle systems.