### PR TITLE
Preserve RichTextLabel's text while modyfing Custom Effects

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2676,7 +2676,13 @@ void RichTextLabel::set_effects(const Vector<Variant> &effects) {
 		custom_effects.push_back(effect);
 	}
 
+	String text = get_text();
+
 	parse_bbcode(bbcode);
+
+	if (!is_using_bbcode()) {
+		set_text(text);
+	}
 }
 
 Vector<Variant> RichTextLabel::get_effects() {


### PR DESCRIPTION
Handling Text and BBCode's text in RichTextLabel is really complicated - one is dependent on the other (basically, top Text area in the Inspector can wok on its own, as long as you don't put anything into BBCode's text area - then it will replicate any text change to the top Text field) - that PR doesn't fix that, as it is bigger rework how that Control should work internally.

What that PR fixes, is - whenever there is a change to the Custom Effects array, then it'll preserve 'top' Text as it was entered before.

Fixes: #38284