### PR TITLE
[3.x] Enable setting of collision iterations in Physics2DServer

### DIFF
--- a/doc/classes/Physics2DServer.xml
+++ b/doc/classes/Physics2DServer.xml
@@ -1002,6 +1002,15 @@
 				Activates or deactivates the 2D physics engine.
 			</description>
 		</method>
+		<method name="set_collision_iterations">
+			<return type="void">
+			</return>
+			<argument index="0" name="iterations" type="int">
+			</argument>
+			<description>
+				Sets the amount of iterations for calculating velocities of colliding bodies. The greater the amount, the more accurate the collisions, but with a performance loss.
+			</description>
+		</method>
 		<method name="shape_get_data" qualifiers="const">
 			<return type="Variant">
 			</return>

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -1315,6 +1315,10 @@ void Physics2DServerSW::set_active(bool p_active) {
 	active = p_active;
 };
 
+void Physics2DServerSW::set_collision_iterations(int p_iterations) {
+	iterations = p_iterations;
+};
+
 void Physics2DServerSW::init() {
 
 	doing_sync = false;

--- a/servers/physics_2d/physics_2d_server_sw.h
+++ b/servers/physics_2d/physics_2d_server_sw.h
@@ -284,6 +284,8 @@ public:
 	virtual void end_sync();
 	virtual void finish();
 
+	virtual void set_collision_iterations(int p_iterations);
+
 	virtual bool is_flushing_queries() const { return flushing_queries; }
 
 	int get_process_info(ProcessInfo p_info);

--- a/servers/physics_2d/physics_2d_server_wrap_mt.h
+++ b/servers/physics_2d/physics_2d_server_wrap_mt.h
@@ -304,6 +304,7 @@ public:
 
 	FUNC1(free, RID);
 	FUNC1(set_active, bool);
+	FUNC1(set_collision_iterations, int);
 
 	virtual void init();
 	virtual void step(real_t p_step);

--- a/servers/physics_2d_server.cpp
+++ b/servers/physics_2d_server.cpp
@@ -684,6 +684,8 @@ void Physics2DServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &Physics2DServer::set_active);
 
+	ClassDB::bind_method(D_METHOD("set_collision_iterations", "iterations"), &Physics2DServer::set_collision_iterations);
+
 	ClassDB::bind_method(D_METHOD("get_process_info", "process_info"), &Physics2DServer::get_process_info);
 
 	BIND_ENUM_CONSTANT(SPACE_PARAM_CONTACT_RECYCLE_RADIUS);

--- a/servers/physics_2d_server.h
+++ b/servers/physics_2d_server.h
@@ -593,6 +593,8 @@ public:
 
 	virtual bool is_flushing_queries() const = 0;
 
+	virtual void set_collision_iterations(int iterations) = 0;
+
 	enum ProcessInfo {
 
 		INFO_ACTIVE_OBJECTS,


### PR DESCRIPTION
This allows fine-tuning of collision iterations for more accurate collision physics with a performance cost.

Reading through the physics code it seems to be using sequential impulses, so even with higher iterations it's not guaranteed to be completely reliable, but it will help especially if you know your scenes will have a high number of stacking collisions.

Mitigates #2092. Found that the current iteration number of 8 leads to the bug immediately on load, setting it to 12 with `Physics2DServer.set_collision_iterations(12)` makes it not collapse immediately on my machine.

May help with #38339.

3.x version of #48827