### PR TITLE
Format remote printerr properly in script debugger output

### DIFF
--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -40,6 +40,11 @@
 #include "core/ustring.h"
 
 class RemoteDebugger : public EngineDebugger {
+public:
+	enum MessageType {
+		MESSAGE_TYPE_LOG,
+		MESSAGE_TYPE_ERROR,
+	};
 
 private:
 	typedef DebuggerMarshalls::OutputError ErrorMessage;
@@ -57,7 +62,11 @@ private:
 
 	Ref<RemoteDebuggerPeer> peer;
 
-	List<String> output_strings;
+	struct OutputString {
+		String message;
+		MessageType type;
+	};
+	List<OutputString> output_strings;
 	List<ErrorMessage> errors;
 
 	int n_messages_dropped = 0;

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -31,6 +31,7 @@
 #include "script_editor_debugger.h"
 
 #include "core/debugger/debugger_marshalls.h"
+#include "core/debugger/remote_debugger.h"
 #include "core/io/marshalls.h"
 #include "core/project_settings.h"
 #include "core/ustring.h"
@@ -396,10 +397,33 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		inspector->add_stack_variable(p_data);
 
 	} else if (p_msg == "output") {
-		ERR_FAIL_COND(p_data.size() < 1);
+		ERR_FAIL_COND(p_data.size() != 2);
+
 		ERR_FAIL_COND(p_data[0].get_type() != Variant::PACKED_STRING_ARRAY);
-		Vector<String> strings = p_data[0];
-		EditorNode::get_log()->add_message(String("\n").join(strings));
+		Vector<String> output_strings = p_data[0];
+
+		ERR_FAIL_COND(p_data[1].get_type() != Variant::PACKED_INT32_ARRAY);
+		Vector<int> output_types = p_data[1];
+
+		ERR_FAIL_COND(output_strings.size() != output_types.size());
+
+		for (int i = 0; i < output_strings.size(); i++) {
+			RemoteDebugger::MessageType type = (RemoteDebugger::MessageType)(int)(output_types[i]);
+			EditorLog::MessageType msg_type;
+			switch (type) {
+				case RemoteDebugger::MESSAGE_TYPE_LOG: {
+					msg_type = EditorLog::MSG_TYPE_STD;
+				} break;
+				case RemoteDebugger::MESSAGE_TYPE_ERROR: {
+					msg_type = EditorLog::MSG_TYPE_ERROR;
+				} break;
+				default: {
+					WARN_PRINT("Unhandled script debugger message type: " + itos(type));
+					msg_type = EditorLog::MSG_TYPE_STD;
+				} break;
+			}
+			EditorNode::get_log()->add_message(output_strings[i], msg_type);
+		}
 	} else if (p_msg == "performance:profile_frame") {
 		Vector<float> p;
 		p.resize(p_data.size());


### PR DESCRIPTION
The information about an output message being an error or simple log is now sent over the remote debugging session.

This is a new version of PR #33998 compatible with 4.0. I'm keeping the other PR for now since it was marked as cherry-pick for 3.2.

cc @Faless for review

Fixes #33324