### PR TITLE
Fix Container sorting not working when overriding _sort_children in gdscript

### DIFF
--- a/core/message_queue.cpp
+++ b/core/message_queue.cpp
@@ -155,6 +155,21 @@ Error MessageQueue::push_callable(const Callable &p_callable, const Variant **p_
 	return OK;
 }
 
+Error MessageQueue::push_callable(const Callable &p_callable, VARIANT_ARG_DECLARE) {
+	VARIANT_ARGPTRS;
+
+	int argc = 0;
+
+	for (int i = 0; i < VARIANT_ARG_MAX; i++) {
+		if (argptr[i]->get_type() == Variant::NIL) {
+			break;
+		}
+		argc++;
+	}
+
+	return push_callable(p_callable, argptr, argc);
+}
+
 void MessageQueue::statistics() {
 	Map<StringName, int> set_count;
 	Map<int, int> notify_count;

--- a/core/message_queue.h
+++ b/core/message_queue.h
@@ -79,6 +79,7 @@ public:
 	Error push_notification(ObjectID p_id, int p_notification);
 	Error push_set(ObjectID p_id, const StringName &p_prop, const Variant &p_value);
 	Error push_callable(const Callable &p_callable, const Variant **p_args, int p_argcount, bool p_show_error = false);
+	Error push_callable(const Callable &p_callable, VARIANT_ARG_LIST);
 
 	Error push_call(Object *p_object, const StringName &p_method, VARIANT_ARG_LIST);
 	Error push_notification(Object *p_object, int p_notification);

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -140,7 +140,7 @@ void Container::queue_sort() {
 		return;
 	}
 
-	MessageQueue::get_singleton()->push_call(this, "_sort_children");
+	MessageQueue::get_singleton()->push_callable(callable_mp(this, &Container::_sort_children));
 	pending_sort = true;
 }
 
@@ -177,8 +177,6 @@ String Container::get_configuration_warning() const {
 }
 
 void Container::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_sort_children"), &Container::_sort_children);
-
 	ClassDB::bind_method(D_METHOD("queue_sort"), &Container::queue_sort);
 	ClassDB::bind_method(D_METHOD("fit_child_in_rect", "child", "rect"), &Container::fit_child_in_rect);
 


### PR DESCRIPTION
**Remove _sort_children from script bindings**
Removed undocumented bound method `_sort_children` in `Container`, which can prevent sorting to work correctly if it's overridden in gdscript by mistake.

`_sort_children` is an internal method which shouldn't be exposed to scripts.

This change supersedes PR #31441 in 4.0, by simply using a callable instead of method binding when calling `_sort_children` internally.

**Add support for non-bound methods in MessageQueue**
So we can use deferred calls without exposing internal methods to scripts.
The changes in `MessageQueue` allow calling `push_callable` with variadic arguments, in order to easily replace the old calls to `push_call`.

**Add debug checks in CallableCustomMethodPointer**
Same checks we already do in `Variant` to catch invalidated objects.
Adding method pointer callables to the message queue was causing crashes in case an object was destroyed and the same memory was allocated for another one (this case does happen in the editor when selecting nodes in the scene tree). The new object had a valid object id but the call was erroneous.
Release will be fixed later, along with `Variant` which has the same problem and is also fixed for debug only.

Fixes #31408