### PR TITLE
More robust and verbose error handling when uncompressing assets

### DIFF
--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -234,7 +234,9 @@ void EditorAssetInstaller::ok_pressed() {
 		//get filename
 		unz_file_info info;
 		char fname[16384];
-		ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
+		
+		if (unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0) != UNZ_OK)
+			break;
 
 		String name = fname;
 


### PR DESCRIPTION
All these operations may fail, we should report them and continue with the next files.