### PR TITLE
parser error for static func access non-static variables

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -7571,6 +7571,10 @@ GDScriptParser::DataType GDScriptParser::_reduce_identifier_type(const DataType 
 	}
 
 	if (_get_member_type(base_type, p_identifier, member_type)) {
+		if (!p_base_type && current_function && current_function->_static) {
+			_set_error("Can't access member variable (\"" + p_identifier.operator String() + "\") from a static function.", p_line);
+			return DataType();
+		}
 		return member_type;
 	}
 


### PR DESCRIPTION
Fix: #38408

**EDIT :**  the error message changed to `Can't access member variable ("_name") from a static function.`

![non-static-var-access](https://user-images.githubusercontent.com/41085900/80862246-24934800-8c91-11ea-933a-3871102a5b56.JPG)
