### PR TITLE
Fixes sync issue between position_offset and rect_position in GraphNode

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -31,6 +31,9 @@
 #include "graph_node.h"
 
 #include "core/string/translation.h"
+#ifdef TOOLS_ENABLED
+#include "graph_edit.h"
+#endif
 
 struct _MinSizeCache {
 	int min_size;
@@ -457,6 +460,27 @@ void GraphNode::_shape() {
 	}
 	title_buf->add_string(title, font, font_size, opentype_features, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
 }
+
+#ifdef TOOLS_ENABLED
+void GraphNode::_edit_set_position(const Point2 &p_position) {
+	GraphEdit *graph = Object::cast_to<GraphEdit>(get_parent());
+	if (graph) {
+		Point2 offset = (p_position + graph->get_scroll_ofs()) * graph->get_zoom();
+		set_position_offset(offset);
+	}
+	set_position(p_position);
+}
+
+void GraphNode::_validate_property(PropertyInfo &property) const {
+	Control::_validate_property(property);
+	GraphEdit *graph = Object::cast_to<GraphEdit>(get_parent());
+	if (graph) {
+		if (property.name == "rect_position") {
+			property.usage |= PROPERTY_USAGE_READ_ONLY;
+		}
+	}
+}
+#endif
 
 void GraphNode::set_slot(int p_idx, bool p_enable_left, int p_type_left, const Color &p_color_left, bool p_enable_right, int p_type_right, const Color &p_color_right, const Ref<Texture2D> &p_custom_left, const Ref<Texture2D> &p_custom_right) {
 	ERR_FAIL_COND_MSG(p_idx < 0, vformat("Cannot set slot with p_idx (%d) lesser than zero.", p_idx));

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -98,6 +98,11 @@ private:
 
 	Overlay overlay = OVERLAY_DISABLED;
 
+#ifdef TOOLS_ENABLED
+	void _edit_set_position(const Point2 &p_position) override;
+	void _validate_property(PropertyInfo &property) const override;
+#endif
+
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_ev) override;
 	void _notification(int p_what);


### PR DESCRIPTION
Fixes #37780 

**Issue**:  `offset` of the graph node wouldn't update and change in the property inspector, when it was moved in editor, only the `position` of `Rect`(property of `Control`) of the graph node changed. As a result, when the scene was played with the graph node in it, the graph node would be positioned according to the unmodified `offset` value.

**Fix**: It turns out when editing in the editor, on moving the graph node, only the `position` was changing, when the `offset` should also have been changing as well. So, I overrode the `_edit_set_position()` method in `Control` class, which is called when `position` of `rect` is changed, and modified it such that it would update the `offset` and notify the change so that the new value of offset will appear in the property inspector as well.

**Results**:
![Godot Engine - New Game Project - Control tscn (_) 2020-05-02 18-22-21_Trim](https://user-images.githubusercontent.com/41969735/80865219-8493e980-8ca5-11ea-9624-e673c9df52c5.gif)

Now the value of the `offset` changes as the graph node is moved/dragged in the editor, along with the change in `position`. And the graph node is positioned according the updated value of offset when the scene is played.