### PR TITLE
Add option to draw lines as rects instead of GL_LINES

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -818,7 +818,7 @@ void RasterizerCanvasGLES2::render_batches(Item::Command *const *p_commands, Ite
 
 							state.canvas_shader.set_uniform(CanvasShaderGLES2::MODELVIEW_MATRIX, state.uniforms.modelview_matrix);
 
-							if (line->width <= 1) {
+							if ((line->width <= 1) && (!draw_lines_as_rects)) {
 								Vector2 verts[2] = {
 									Vector2(line->from.x, line->from.y),
 									Vector2(line->to.x, line->to.y)
@@ -846,7 +846,7 @@ void RasterizerCanvasGLES2::render_batches(Item::Command *const *p_commands, Ite
 
 								_draw_gui_primitive(4, verts, NULL, NULL);
 #ifdef GLES_OVER_GL
-								if (line->antialiased) {
+								if ((line->antialiased) && (!draw_lines_as_rects)) {
 									glEnable(GL_LINE_SMOOTH);
 									for (int j = 0; j < 4; j++) {
 										Vector2 vertsl[2] = {
@@ -1995,6 +1995,10 @@ void RasterizerCanvasGLES2::canvas_end() {
 #endif
 
 	RasterizerCanvasBaseGLES2::canvas_end();
+}
+
+void RasterizerCanvasGLES2::set_editor_settings(const VisualServer::EditorSettings &p_settings) {
+	draw_lines_as_rects = p_settings.high_quality_lines == false;
 }
 
 void RasterizerCanvasGLES2::canvas_begin() {
@@ -3488,4 +3492,5 @@ void RasterizerCanvasGLES2::initialize() {
 RasterizerCanvasGLES2::RasterizerCanvasGLES2() {
 
 	bdata.settings_use_batching = false;
+	draw_lines_as_rects = false;
 }

--- a/drivers/gles2/rasterizer_canvas_gles2.h
+++ b/drivers/gles2/rasterizer_canvas_gles2.h
@@ -287,12 +287,15 @@ class RasterizerCanvasGLES2 : public RasterizerCanvasBaseGLES2 {
 		Transform2D transform_combined; // final * extra
 	};
 
+	bool draw_lines_as_rects;
+
 public:
 	virtual void canvas_render_items_begin(const Color &p_modulate, Light *p_light, const Transform2D &p_base_transform);
 	virtual void canvas_render_items_end();
 	virtual void canvas_render_items(Item *p_item_list, int p_z, const Color &p_modulate, Light *p_light, const Transform2D &p_base_transform);
 	virtual void canvas_begin();
 	virtual void canvas_end();
+	virtual void set_editor_settings(const VisualServer::EditorSettings &p_settings);
 
 private:
 	// legacy codepath .. to remove after testing

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -269,6 +269,10 @@ void RasterizerGLES2::initialize() {
 	scene->initialize();
 }
 
+void RasterizerGLES2::set_editor_settings(const VisualServer::EditorSettings &p_settings) {
+	canvas->set_editor_settings(p_settings);
+}
+
 void RasterizerGLES2::begin_frame(double frame_step) {
 	time_total += frame_step;
 

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -52,6 +52,7 @@ public:
 	virtual RasterizerScene *get_scene();
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true);
+	virtual void set_editor_settings(const VisualServer::EditorSettings &p_settings);
 
 	virtual void initialize();
 	virtual void begin_frame(double frame_step);

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -142,8 +142,11 @@ void RasterizerCanvasGLES3::light_internal_free(RID p_rid) {
 	memdelete(li);
 }
 
-void RasterizerCanvasGLES3::canvas_begin() {
+void RasterizerCanvasGLES3::set_editor_settings(const VisualServer::EditorSettings &p_settings) {
+	draw_lines_as_rects = p_settings.high_quality_lines == false;
+}
 
+void RasterizerCanvasGLES3::canvas_begin() {
 	if (storage->frame.current_rt && storage->frame.clear_request) {
 		// a clear request may be pending, so do it
 		bool transparent = storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT];
@@ -640,7 +643,7 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 
 				glVertexAttrib4f(VS::ARRAY_COLOR, line->color.r, line->color.g, line->color.b, line->color.a);
 
-				if (line->width <= 1) {
+				if ((line->width <= 1) && (!draw_lines_as_rects)) {
 					Vector2 verts[2] = {
 						Vector2(line->from.x, line->from.y),
 						Vector2(line->to.x, line->to.y)
@@ -672,7 +675,7 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 					//glLineWidth(line->width);
 					_draw_gui_primitive(4, verts, NULL, NULL);
 #ifdef GLES_OVER_GL
-					if (line->antialiased) {
+					if ((line->antialiased) && (!draw_lines_as_rects)) {
 						glEnable(GL_LINE_SMOOTH);
 						for (int j = 0; j < 4; j++) {
 							Vector2 vertsl[2] = {
@@ -2260,4 +2263,5 @@ void RasterizerCanvasGLES3::finalize() {
 }
 
 RasterizerCanvasGLES3::RasterizerCanvasGLES3() {
+	draw_lines_as_rects = false;
 }

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -117,6 +117,8 @@ public:
 		GLuint ubo;
 	};
 
+	bool draw_lines_as_rects;
+
 	RID_Owner<LightInternal> light_internal_owner;
 
 	virtual RID light_internal_create();
@@ -125,6 +127,7 @@ public:
 
 	virtual void canvas_begin();
 	virtual void canvas_end();
+	virtual void set_editor_settings(const VisualServer::EditorSettings &p_settings);
 
 	_FORCE_INLINE_ void _set_texture_rect_mode(bool p_enable, bool p_ninepatch = false);
 	_FORCE_INLINE_ RasterizerStorageGLES3::Texture *_bind_canvas_texture(const RID &p_texture, const RID &p_normal_map, bool p_force = false);

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -271,6 +271,10 @@ void RasterizerGLES3::clear_render_target(const Color &p_color) {
 	storage->frame.clear_request_color = p_color;
 }
 
+void RasterizerGLES3::set_editor_settings(const VisualServer::EditorSettings &p_settings) {
+	canvas->set_editor_settings(p_settings);
+}
+
 void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {
 
 	if (p_image.is_null() || p_image->empty())

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -52,6 +52,7 @@ public:
 	virtual RasterizerScene *get_scene();
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true);
+	virtual void set_editor_settings(const VisualServer::EditorSettings &p_settings);
 
 	virtual void initialize();
 	virtual void begin_frame(double frame_step);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -334,6 +334,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/code_font", "");
 	hints["interface/editor/code_font"] = PropertyInfo(Variant::STRING, "interface/editor/code_font", PROPERTY_HINT_GLOBAL_FILE, "*.ttf,*.otf", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/editor/dim_editor_on_dialog_popup", true);
+	_initial_set("interface/editor/high_quality_lines", true);
 	_initial_set("interface/editor/low_processor_mode_sleep_usec", 6900); // ~144 FPS
 	hints["interface/editor/low_processor_mode_sleep_usec"] = PropertyInfo(Variant::REAL, "interface/editor/low_processor_mode_sleep_usec", PROPERTY_HINT_RANGE, "1,100000,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/unfocused_low_processor_mode_sleep_usec", 50000); // 20 FPS
@@ -950,6 +951,7 @@ void EditorSettings::create() {
 		singleton->setup_network();
 		singleton->load_favorites();
 		singleton->list_text_editor_themes();
+		singleton->_send_settings_to_visual_server();
 
 		return;
 	}
@@ -976,6 +978,7 @@ fail:
 	singleton->setup_language();
 	singleton->setup_network();
 	singleton->list_text_editor_themes();
+	singleton->_send_settings_to_visual_server();
 }
 
 void EditorSettings::setup_language() {
@@ -1580,6 +1583,15 @@ void EditorSettings::notify_changes() {
 		return;
 	}
 	root->propagate_notification(NOTIFICATION_EDITOR_SETTINGS_CHANGED);
+
+	_send_settings_to_visual_server();
+}
+
+void EditorSettings::_send_settings_to_visual_server() {
+	// pass relevant settings to the visual server + rasterizer
+	VisualServer::EditorSettings settings;
+	settings.high_quality_lines = get("interface/editor/high_quality_lines");
+	VisualServer::get_singleton()->set_editor_settings(settings);
 }
 
 void EditorSettings::_bind_methods() {

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -121,6 +121,7 @@ private:
 	void _load_default_text_editor_theme();
 	bool _save_text_editor_theme(String p_file);
 	bool _is_default_text_editor_theme(String p_theme_name);
+	void _send_settings_to_visual_server();
 
 protected:
 	static void _bind_methods();

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1114,6 +1114,7 @@ public:
 	virtual RasterizerScene *get_scene() = 0;
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) = 0;
+	virtual void set_editor_settings(const VisualServer::EditorSettings &p_settings) {}
 
 	virtual void initialize() = 0;
 	virtual void begin_frame(double frame_step) = 0;

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -163,6 +163,12 @@ String VisualServerRaster::get_video_adapter_vendor() const {
 	return VSG::storage->get_video_adapter_vendor();
 }
 
+/* PASSING EDITOR SETTINGS */
+
+void VisualServerRaster::set_editor_settings(const EditorSettings &p_settings) {
+	VSG::rasterizer->set_editor_settings(p_settings);
+}
+
 /* TESTING */
 
 void VisualServerRaster::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -688,6 +688,10 @@ public:
 
 	virtual RID get_test_cube();
 
+	/* PASSING EDITOR SETTINGS */
+
+	virtual void set_editor_settings(const EditorSettings &p_settings);
+
 	/* TESTING */
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -616,6 +616,8 @@ public:
 	FUNC4(set_boot_image, const Ref<Image> &, const Color &, bool, bool)
 	FUNC1(set_default_clear_color, const Color &)
 
+	FUNC1(set_editor_settings, const EditorSettings &)
+
 	FUNC0R(RID, get_test_cube)
 
 	FUNC1(set_debug_generate_wireframes, bool)

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1032,6 +1032,13 @@ public:
 
 	/* Materials for 2D on 3D */
 
+	/* PASSING EDITOR SETTINGS */
+	struct EditorSettings {
+		bool high_quality_lines;
+	};
+
+	virtual void set_editor_settings(const EditorSettings &p_settings) = 0;
+
 	/* TESTING */
 
 	virtual RID get_test_cube() = 0;


### PR DESCRIPTION
GL_LINES may be slow on some hardware or even use a software fallback path. This PR adds an editor setting to force the use of the rectangle path to draw lines instead of GL_LINES.

#### Notes
* This is now an editor setting, `high_quality_lines`, which defaults to true.

May fix #17584.