### PR TITLE
Tilemap: Fix performance issue in fallback of update_bitmask_region 

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -940,13 +940,10 @@ void TileMap::update_bitmask_area(const Vector2 &p_pos) {
 void TileMap::update_bitmask_region(const Vector2 &p_start, const Vector2 &p_end) {
 
 	if ((p_end.x < p_start.x || p_end.y < p_start.y) || (p_end.x == p_start.x && p_end.y == p_start.y)) {
-		int i;
 		Array a = get_used_cells();
-		for (i = 0; i < a.size(); i++) {
-			// update_bitmask_area() in order to update cells adjacent to the
-			// current cell, since ordering in array may not be reliable
+		for (int i = 0; i < a.size(); i++) {
 			Vector2 vector = (Vector2)a[i];
-			update_bitmask_area(Vector2(vector.x, vector.y));
+			update_cell_bitmask(vector.x, vector.y);
 		}
 		return;
 	}


### PR DESCRIPTION
This PR is related to the point 1 described in the issue #25731 

My assumption, which is the base for this PR:
The "update_bitmask_area()" in the fallback makes no sense (it will update the cell + all adjacent cells), but with "get_used_cells()" we will anyhow get all cells which have a tile used and also the ordering is irrelevant, as "update_cell_bitmask()" is not affected by the ordering of the array. Breaking it down, the use of "update_bitmask_area()" is unnecessarily updating plenty of cells mutliple times -> therefore the high computing time!

For testing, there is also a test project in the issue mentioned above.