### PR TITLE
Stop trying to revert to script/class default values when script implementation of property_can_revert exists

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -501,18 +501,20 @@ bool EditorPropertyRevert::can_property_revert(Object *p_object, const StringNam
 		}
 	}
 
-	if (p_object->call("property_can_revert", p_property).operator bool()) {
-
-		has_revert = true;
-	}
-
-	if (!has_revert && !p_object->get_script().is_null()) {
-		Ref<Script> scr = p_object->get_script();
-		if (scr.is_valid()) {
-			Variant orig_value;
-			if (scr->get_property_default_value(p_property, orig_value)) {
-				if (orig_value != p_object->get(p_property)) {
-					has_revert = true;
+	// If the object implements property_can_revert, rely on that completely
+	// (i.e. don't then try to revert to default value - the property_get_revert implementation
+	// can do that if so desired)
+	if (p_object->has_method("property_can_revert")) {
+		has_revert = p_object->call("property_can_revert", p_property).operator bool();
+	} else {
+		if (!has_revert && !p_object->get_script().is_null()) {
+			Ref<Script> scr = p_object->get_script();
+			if (scr.is_valid()) {
+				Variant orig_value;
+				if (scr->get_property_default_value(p_property, orig_value)) {
+					if (orig_value != p_object->get(p_property)) {
+						has_revert = true;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This allows users greater control over what values _exactly_ a property can revert to.

Previously there was no way of stopping a value trying to revert to it's script/class default, even if you had a `property_can_revert()` defined so that it could only revert to specific values.