### PR TITLE
Using command + comma on macOS as default shortcut for editor settings

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6236,8 +6236,11 @@ EditorNode::EditorNode() {
 	left_menu_hb->add_child(settings_menu);
 
 	p = settings_menu->get_popup();
-
+#ifdef OSX_ENABLED
+	p->add_shortcut(ED_SHORTCUT("editor/editor_settings", TTR("Editor Settings..."), KEY_MASK_CMD + KEY_COMMA), SETTINGS_PREFERENCES);
+#else
 	p->add_shortcut(ED_SHORTCUT("editor/editor_settings", TTR("Editor Settings...")), SETTINGS_PREFERENCES);
+#endif
 	p->add_separator();
 
 	editor_layouts = memnew(PopupMenu);


### PR DESCRIPTION
This PR addresses a common shortcut on mac for preferences of any application, using the `Commad + ,` is a default behavior for mac users 

https://github.com/godotengine/godot/issues/7884