### PR TITLE
GLES2 disable half-float project setting

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5950,12 +5950,15 @@ void RasterizerStorageGLES2::initialize() {
 	config.support_write_depth = config.extensions.has("GL_EXT_frag_depth");
 #endif
 
+	config.support_half_float_vertices = true;
+//every platform should support this except web, iOS has issues with their support, so add option to disable
 #ifdef JAVASCRIPT_ENABLED
 	config.support_half_float_vertices = false;
-#else
-	//every other platform, be it mobile or desktop, supports this (even if not in the GLES2 spec).
-	config.support_half_float_vertices = true;
 #endif
+	bool disable_half_float = GLOBAL_GET("rendering/gles2/batching/disable_half_float");
+	if (disable_half_float) {
+		config.support_half_float_vertices = false;
+	}
 
 	config.rgtc_supported = config.extensions.has("GL_EXT_texture_compression_rgtc") || config.extensions.has("GL_ARB_texture_compression_rgtc") || config.extensions.has("EXT_texture_compression_rgtc");
 	config.bptc_supported = config.extensions.has("GL_ARB_texture_compression_bptc") || config.extensions.has("EXT_texture_compression_bptc");

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2430,6 +2430,7 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/gles2/debug/flash_batching", false);
 	GLOBAL_DEF("rendering/gles2/debug/diagnose_frame", false);
 	GLOBAL_DEF_RST("rendering/gles2/debug/use_batching_in_editor", true);
+	GLOBAL_DEF("rendering/gles2/debug/disable_half_float", false);
 
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/gles2/batching/max_join_item_commands", PropertyInfo(Variant::INT, "rendering/gles2/batching/max_join_item_commands", PROPERTY_HINT_RANGE, "0,65535"));
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/gles2/batching/colored_vertex_format_threshold", PropertyInfo(Variant::REAL, "rendering/gles2/batching/colored_vertex_format_threshold", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"));


### PR DESCRIPTION
It seems that particles (and some other features) do not work correctly on iOS in GLES2 because either many of the devices do not support half float compression, or the GL constant used to reference it from Godot is incorrect.

This PR adds a project setting in rendering/gles2/ to disable half-float compression on iOS.

See #38441

May fix - #38318, #38211, #32837, #27191, #31907

## Notes
* This is a hacky approach intended for testing in beta - users can turn it on and off
* If it solves the problem we can hard code it for iOS / add detection code etc

Also, I'm not sure the whole approach (also currently used in web) of compressing to half float in the visual server then decompressing in the renderer is a good idea. It would be better to set some flags or something in the visual server to disable compression happening at all. But maybe it only happens as a once off during mesh creation, not sure yet, in which case it isn't so bad.