### PR TITLE
Remove get_local_mouse_position() hack in GraphEdit

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -768,9 +768,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 	if (mm.is_valid() && dragging) {
 		just_selected = true;
-		// TODO: Remove local mouse pos hack if/when InputEventMouseMotion is fixed to support floats
-		//drag_accum+=Vector2(mm->get_relative().x,mm->get_relative().y);
-		drag_accum = get_local_mouse_position() - drag_origin;
+		drag_accum += mm->get_relative();
 		for (int i = get_child_count() - 1; i >= 0; i--) {
 			GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 			if (gn && gn->is_selected()) {
@@ -789,7 +787,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 	}
 
 	if (mm.is_valid() && box_selecting) {
-		box_selecting_to = get_local_mouse_position();
+		box_selecting_to = mm->get_position();
 
 		box_selecting_rect = Rect2(MIN(box_selecting_from.x, box_selecting_to.x),
 				MIN(box_selecting_from.y, box_selecting_to.y),
@@ -849,7 +847,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 					if (gn) {
 						Rect2 r = gn->get_rect();
 						r.size *= zoom;
-						if (r.has_point(get_local_mouse_position())) {
+						if (r.has_point(b->get_position())) {
 							gn->set_selected(false);
 						}
 					}
@@ -887,7 +885,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 						continue;
 					}
 
-					if (gn_selected->has_point(gn_selected->get_local_mouse_position())) {
+					if (gn_selected->has_point(b->get_position() - gn_selected->get_position())) {
 						gn = gn_selected;
 						break;
 					}
@@ -901,7 +899,6 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 				dragging = true;
 				drag_accum = Vector2();
-				drag_origin = get_local_mouse_position();
 				just_selected = !gn->is_selected();
 				if (!gn->is_selected() && !Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
 					for (int i = 0; i < get_child_count(); i++) {
@@ -939,7 +936,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 				}
 
 				box_selecting = true;
-				box_selecting_from = get_local_mouse_position();
+				box_selecting_from = b->get_position();
 				if (b->get_control()) {
 					box_selection_mode_additive = true;
 					previus_selected.clear();

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -97,7 +97,6 @@ private:
 	bool dragging;
 	bool just_selected;
 	Vector2 drag_accum;
-	Point2 drag_origin; // Workaround for GH-5907
 
 	float zoom;
 


### PR DESCRIPTION
This PR removes a temporary hack (added back in 2016!) where GraphEdit handled drag selection and positioning of GraphNodes using get_local_mouse_position(). This unfortunately causes bugs when the mouse is not the primary input device.

This is true in my use case; I'm building a VR app where a "display panel" has a viewport-rendered texture of a 2D scene that includes a GraphEdit, and I'm using [NeoSpark314's Oculus Quest Toolkit](https://github.com/NeoSpark314/godot_oculus_quest_toolkit) which injects custom mouse events to the scene based on a raycast collision from the VR controller. Without this change, the actual select box is drawn my mouse cursor and not from the VR controller's position. 

As mentioned in #5907, mouse motion has used float for the last several years - so this hack is no longer needed. I experimentally confirmed drag-select and click-and-drag on a GraphNode works both in a 2D scene and in my 3D VR scene.