### PR TITLE
Check for empty vectors before trying to access a pointer to the first element in Octree<T, use_pairs, AL>::cull_convex().

### DIFF
--- a/core/math/octree.h
+++ b/core/math/octree.h
@@ -1290,10 +1290,12 @@ void Octree<T, use_pairs, AL>::_cull_point(Octant *p_octant, const Vector3 &p_po
 template <class T, bool use_pairs, class AL>
 int Octree<T, use_pairs, AL>::cull_convex(const Vector<Plane> &p_convex, T **p_result_array, int p_result_max, uint32_t p_mask) {
 
-	if (!root)
+	if (!root || p_convex.size() == 0)
 		return 0;
 
 	Vector<Vector3> convex_points = Geometry::compute_convex_mesh_points(&p_convex[0], p_convex.size());
+	if (convex_points.size() == 0)
+		return 0;
 
 	int result_count = 0;
 	pass++;


### PR DESCRIPTION
Fixes #38457.