### PR TITLE
Fix one way collisions for KinematicBody2D

### DIFF
--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -35,7 +35,7 @@
 #define POSITION_CORRECTION
 #define ACCUMULATE_IMPULSES
 
-void BodyPair2DSW::_add_contact(const Vector2 &p_point_A, const Vector2 &p_point_B, void *p_self) {
+void BodyPair2DSW::_add_contact(const Vector2 &p_point_A, const Vector2 &p_point_B, const Vector2 &normal, void *p_self) {
 
 	BodyPair2DSW *self = (BodyPair2DSW *)p_self;
 

--- a/servers/physics_2d/body_pair_2d_sw.h
+++ b/servers/physics_2d/body_pair_2d_sw.h
@@ -82,7 +82,7 @@ class BodyPair2DSW : public Constraint2DSW {
 
 	bool _test_ccd(real_t p_step, Body2DSW *p_A, int p_shape_A, const Transform2D &p_xform_A, Body2DSW *p_B, int p_shape_B, const Transform2D &p_xform_B, bool p_swap_result = false);
 	void _validate_contacts();
-	static void _add_contact(const Vector2 &p_point_A, const Vector2 &p_point_B, void *p_self);
+	static void _add_contact(const Vector2 &p_point_A, const Vector2 &p_point_B, const Vector2 &normal, void *p_self);
 	_FORCE_INLINE_ void _contact_added_callback(const Vector2 &p_point_A, const Vector2 &p_point_B);
 
 public:

--- a/servers/physics_2d/collision_solver_2d_sat.cpp
+++ b/servers/physics_2d/collision_solver_2d_sat.cpp
@@ -48,9 +48,9 @@ struct _CollectorCallback2D {
 			return;
 		*/
 		if (swap)
-			callback(p_point_B, p_point_A, userdata);
+			callback(p_point_B, p_point_A, -normal, userdata);
 		else
-			callback(p_point_A, p_point_B, userdata);
+			callback(p_point_A, p_point_B, normal, userdata);
 	}
 };
 

--- a/servers/physics_2d/collision_solver_2d_sat.h
+++ b/servers/physics_2d/collision_solver_2d_sat.h
@@ -33,6 +33,6 @@
 
 #include "collision_solver_2d_sw.h"
 
-bool sat_2d_calculate_penetration(const Shape2DSW *p_shape_A, const Transform2D &p_transform_A, const Vector2 &p_motion_A, const Shape2DSW *p_shape_B, const Transform2D &p_transform_B, const Vector2 &p_motion_B, CollisionSolver2DSW::CallbackResult p_result_callback, void *p_userdata, bool p_swap = false, Vector2 *sep_axis = NULL, real_t p_margin_A = 0, real_t p_margin_B = 0);
+bool sat_2d_calculate_penetration(const Shape2DSW *p_shape_A, const Transform2D &p_transform_A, const Vector2 &p_motion_A, const Shape2DSW *p_shape_B, const Transform2D &p_transform_B, const Vector2 &p_motion_B, CollisionSolver2DSW::CallbackResult p_result_callback, void *p_userdata, bool p_swap = false, Vector2 *sep_axis = NULL, real_t p_margin_A = 0, real_t p_margin_B = 0, const Vector2 &p_one_way_axis = Vector2());
 
 #endif // COLLISION_SOLVER_2D_SAT_H

--- a/servers/physics_2d/collision_solver_2d_sw.cpp
+++ b/servers/physics_2d/collision_solver_2d_sw.cpp
@@ -193,7 +193,7 @@ bool CollisionSolver2DSW::solve_concave(const Shape2DSW *p_shape_A, const Transf
 	return cinfo.collided;
 }
 
-bool CollisionSolver2DSW::solve(const Shape2DSW *p_shape_A, const Transform2D &p_transform_A, const Vector2 &p_motion_A, const Shape2DSW *p_shape_B, const Transform2D &p_transform_B, const Vector2 &p_motion_B, CallbackResult p_result_callback, void *p_userdata, Vector2 *sep_axis, real_t p_margin_A, real_t p_margin_B) {
+bool CollisionSolver2DSW::solve(const Shape2DSW *p_shape_A, const Transform2D &p_transform_A, const Vector2 &p_motion_A, const Shape2DSW *p_shape_B, const Transform2D &p_transform_B, const Vector2 &p_motion_B, CallbackResult p_result_callback, void *p_userdata, Vector2 *sep_axis, real_t p_margin_A, real_t p_margin_B, const Vector2 &p_one_way_axis) {
 
 	Physics2DServer::ShapeType type_A = p_shape_A->get_type();
 	Physics2DServer::ShapeType type_B = p_shape_B->get_type();
@@ -247,6 +247,6 @@ bool CollisionSolver2DSW::solve(const Shape2DSW *p_shape_A, const Transform2D &p
 
 	} else {
 
-		return collision_solver(p_shape_A, p_transform_A, p_motion_A, p_shape_B, p_transform_B, p_motion_B, p_result_callback, p_userdata, false, sep_axis, margin_A, margin_B);
+		return collision_solver(p_shape_A, p_transform_A, p_motion_A, p_shape_B, p_transform_B, p_motion_B, p_result_callback, p_userdata, false, sep_axis, margin_A, margin_B, p_one_way_axis);
 	}
 }

--- a/servers/physics_2d/collision_solver_2d_sw.cpp
+++ b/servers/physics_2d/collision_solver_2d_sw.cpp
@@ -63,9 +63,9 @@ bool CollisionSolver2DSW::solve_static_line(const Shape2DSW *p_shape_A, const Tr
 
 		if (p_result_callback) {
 			if (p_swap_result)
-				p_result_callback(supports[i], support_A, p_userdata);
+				p_result_callback(supports[i], support_A, Vector2(), p_userdata);
 			else
-				p_result_callback(support_A, supports[i], p_userdata);
+				p_result_callback(support_A, supports[i], Vector2(), p_userdata);
 		}
 	}
 
@@ -107,9 +107,9 @@ bool CollisionSolver2DSW::solve_raycast(const Shape2DSW *p_shape_A, const Vector
 
 	if (p_result_callback) {
 		if (p_swap_result)
-			p_result_callback(support_B, support_A, p_userdata);
+			p_result_callback(support_B, support_A, Vector2(), p_userdata);
 		else
-			p_result_callback(support_A, support_B, p_userdata);
+			p_result_callback(support_A, support_B, Vector2(), p_userdata);
 	}
 	return true;
 }

--- a/servers/physics_2d/collision_solver_2d_sw.h
+++ b/servers/physics_2d/collision_solver_2d_sw.h
@@ -44,7 +44,7 @@ private:
 	static bool solve_raycast(const Shape2DSW *p_shape_A, const Vector2 &p_motion_A, const Transform2D &p_transform_A, const Shape2DSW *p_shape_B, const Transform2D &p_transform_B, CallbackResult p_result_callback, void *p_userdata, bool p_swap_result, Vector2 *sep_axis = NULL);
 
 public:
-	static bool solve(const Shape2DSW *p_shape_A, const Transform2D &p_transform_A, const Vector2 &p_motion_A, const Shape2DSW *p_shape_B, const Transform2D &p_transform_B, const Vector2 &p_motion_B, CallbackResult p_result_callback, void *p_userdata, Vector2 *sep_axis = NULL, real_t p_margin_A = 0, real_t p_margin_B = 0);
+	static bool solve(const Shape2DSW *p_shape_A, const Transform2D &p_transform_A, const Vector2 &p_motion_A, const Shape2DSW *p_shape_B, const Transform2D &p_transform_B, const Vector2 &p_motion_B, CallbackResult p_result_callback, void *p_userdata, Vector2 *sep_axis = NULL, real_t p_margin_A = 0, real_t p_margin_B = 0, const Vector2 &p_one_way_axis = Vector2());
 };
 
 #endif // COLLISION_SOLVER_2D_SW_H

--- a/servers/physics_2d/collision_solver_2d_sw.h
+++ b/servers/physics_2d/collision_solver_2d_sw.h
@@ -35,7 +35,7 @@
 
 class CollisionSolver2DSW {
 public:
-	typedef void (*CallbackResult)(const Vector2 &p_point_A, const Vector2 &p_point_B, void *p_userdata);
+	typedef void (*CallbackResult)(const Vector2 &p_point_A, const Vector2 &p_point_B, const Vector2 &normal, void *p_userdata);
 
 private:
 	static bool solve_static_line(const Shape2DSW *p_shape_A, const Transform2D &p_transform_A, const Shape2DSW *p_shape_B, const Transform2D &p_transform_B, CallbackResult p_result_callback, void *p_userdata, bool p_swap_result);

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -160,7 +160,7 @@ real_t Physics2DServerSW::shape_get_custom_solver_bias(RID p_shape) const {
 	return shape->get_custom_bias();
 }
 
-void Physics2DServerSW::_shape_col_cbk(const Vector2 &p_point_A, const Vector2 &p_point_B, void *p_userdata) {
+void Physics2DServerSW::_shape_col_cbk(const Vector2 &p_point_A, const Vector2 &p_point_B, const Vector2 &normal, void *p_userdata) {
 
 	CollCbkData *cbk = (CollCbkData *)p_userdata;
 
@@ -168,22 +168,19 @@ void Physics2DServerSW::_shape_col_cbk(const Vector2 &p_point_A, const Vector2 &
 		return;
 
 	if (cbk->valid_dir != Vector2()) {
-		if (p_point_A.distance_squared_to(p_point_B) > cbk->valid_depth * cbk->valid_depth) {
+		Vector2 valid_dir = cbk->valid_dir.normalized();
+		Vector2 rel_dir = p_point_A - p_point_B;
+
+		// Don't collide if the length of the intersecting vector is greater than the valid depth
+		if (rel_dir.length() > cbk->valid_depth) {
 			cbk->invalid_by_dir++;
 			return;
 		}
-		Vector2 rel_dir = (p_point_A - p_point_B).normalized();
 
-		if (cbk->valid_dir.dot(rel_dir) < Math_SQRT12) { //sqrt(2)/2.0 - 45 degrees
+		// Don't collide if the intersection normal is within 90 degrees of the valid direction
+		Vector2 normal_to_check = normal != Vector2() ? normal.normalized() : -rel_dir.normalized();
+		if (valid_dir.dot(normal_to_check) > -CMP_EPSILON) {
 			cbk->invalid_by_dir++;
-
-			/*
-			print_line("A: "+p_point_A);
-			print_line("B: "+p_point_B);
-			print_line("discard too angled "+rtos(cbk->valid_dir.dot((p_point_A-p_point_B))));
-			print_line("resnorm: "+(p_point_A-p_point_B).normalized());
-			print_line("distance: "+rtos(p_point_A.distance_to(p_point_B)));
-			*/
 			return;
 		}
 	}

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -183,6 +183,19 @@ void Physics2DServerSW::_shape_col_cbk(const Vector2 &p_point_A, const Vector2 &
 			cbk->invalid_by_dir++;
 			return;
 		}
+
+		// Don't collide if the test object isn't moving towards the collision edge
+		// and the collision object isn't trying to catch up and collide with
+		// the test object by moving towards its collision edge faster
+		// Unless trying to unstick, if so, consider for collision if
+		// the relative velocity between the two objects is zero
+		if (cbk->check_motion && cbk->p_motion.normalized().dot(normal_to_check) > -CMP_EPSILON) {
+			real_t motion_dot = (cbk->p_motion - cbk->obj_motion).normalized().dot(normal_to_check);
+			if (motion_dot >= CMP_EPSILON || (!cbk->unstick && Math::abs(motion_dot) < CMP_EPSILON)) {
+				cbk->invalid_by_dir++;
+				return;
+			}
+		}
 	}
 
 	if (cbk->amount == cbk->max) {

--- a/servers/physics_2d/physics_2d_server_sw.h
+++ b/servers/physics_2d/physics_2d_server_sw.h
@@ -97,7 +97,7 @@ public:
 	virtual RID convex_polygon_shape_create();
 	virtual RID concave_polygon_shape_create();
 
-	static void _shape_col_cbk(const Vector2 &p_point_A, const Vector2 &p_point_B, void *p_userdata);
+	static void _shape_col_cbk(const Vector2 &p_point_A, const Vector2 &p_point_B, const Vector2 &normal, void *p_userdata);
 
 	virtual void shape_set_data(RID p_shape, const Variant &p_data);
 	virtual void shape_set_custom_solver_bias(RID p_shape, real_t p_bias);

--- a/servers/physics_2d/physics_2d_server_sw.h
+++ b/servers/physics_2d/physics_2d_server_sw.h
@@ -86,6 +86,10 @@ public:
 		int passed;
 		int invalid_by_dir;
 		Vector2 *ptr;
+		Vector2 p_motion;
+		Vector2 obj_motion;
+		bool check_motion;
+		bool unstick;
 	};
 
 	virtual RID line_shape_create();

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -974,7 +974,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 					cbk.valid_depth = 10e20;
 
 					Vector2 sep = mnormal; //important optimization for this to work fast enough
-					bool collided = CollisionSolver2DSW::solve(body_shape, body_shape_xform, p_motion * (hi + contact_max_allowed_penetration), col_obj->get_shape(col_shape_idx), col_obj_shape_xform, Vector2(), Physics2DServerSW::_shape_col_cbk, &cbk, &sep, 0);
+					bool collided = CollisionSolver2DSW::solve(body_shape, body_shape_xform, p_motion * (hi + contact_max_allowed_penetration), col_obj->get_shape(col_shape_idx), col_obj_shape_xform, Vector2(), Physics2DServerSW::_shape_col_cbk, &cbk, &sep, 0, 0, cbk.valid_dir);
 					if (!collided || cbk.amount == 0) {
 						continue;
 					}
@@ -1081,7 +1081,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 				rcd.object = col_obj;
 				rcd.shape = shape_idx;
 				rcd.local_shape = j;
-				bool sc = CollisionSolver2DSW::solve(body_shape, body_shape_xform, Vector2(), against_shape, col_obj_shape_xform, Vector2(), _rest_cbk_result, &rcd, NULL, p_margin);
+				bool sc = CollisionSolver2DSW::solve(body_shape, body_shape_xform, Vector2(), against_shape, col_obj_shape_xform, Vector2(), _rest_cbk_result, &rcd, NULL, p_margin, 0, rcd.valid_dir);
 				if (!sc)
 					continue;
 			}


### PR DESCRIPTION
Several fixes detailed in the commit messages, but essentially takes the motion of the body into account when determining whether the body collides with the one way colliding body, as well as making sure any collision axes are not perpendicular to the one way axis.

Updated version of #38345 

Fixes #25967
Fixes #28895
Fixes #42914
Fixes #42916
Fixes #43266
Fixes #43346
Fixes #43973

~~Uses part of the code from #36280~~