### PR TITLE
Fix object leaks caused by unfulfilled yields (3.2)

### DIFF
--- a/core/self_list.h
+++ b/core/self_list.h
@@ -120,6 +120,9 @@ private:
 
 public:
 	_FORCE_INLINE_ bool in_list() const { return _root; }
+	_FORCE_INLINE_ void remove_from_list() {
+		if (_root) _root->remove(this);
+	}
 	_FORCE_INLINE_ SelfList<T> *next() { return _next; }
 	_FORCE_INLINE_ SelfList<T> *prev() { return _prev; }
 	_FORCE_INLINE_ const SelfList<T> *next() const { return _next; }

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -114,6 +114,8 @@ class GDScript : public Script {
 	String fully_qualified_name;
 	SelfList<GDScript> script_list;
 
+	SelfList<GDScriptFunctionState>::List pending_func_states;
+
 	GDScriptInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_isref, Variant::CallError &r_error);
 
 	void _set_subclass_path(Ref<GDScript> &p_sc, const String &p_path);
@@ -235,6 +237,8 @@ class GDScriptInstance : public ScriptInstance {
 	Vector<Variant> members;
 	bool base_ref;
 
+	SelfList<GDScriptFunctionState>::List pending_func_states;
+
 	void _ml_call_reversed(GDScript *sptr, const StringName &p_method, const Variant **p_args, int p_argcount);
 
 public:
@@ -318,6 +322,8 @@ struct GDScriptWarning {
 #endif // DEBUG_ENABLED
 
 class GDScriptLanguage : public ScriptLanguage {
+
+	friend class GDScriptFunctionState;
 
 	static GDScriptLanguage *singleton;
 

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -294,12 +294,11 @@ public:
 	struct CallState {
 
 		GDScript *script;
-		ObjectID script_id;
+		GDScriptInstance *instance;
 #ifdef DEBUG_ENABLED
+		StringName function_name;
 		String script_path;
 #endif
-		GDScriptInstance *instance;
-		ObjectID instance_id;
 		Vector<uint8_t> stack;
 		int stack_size;
 		Variant self;
@@ -359,12 +358,18 @@ class GDScriptFunctionState : public Reference {
 	Variant _signal_callback(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 	Ref<GDScriptFunctionState> first_state;
 
+	SelfList<GDScriptFunctionState> scripts_list;
+	SelfList<GDScriptFunctionState> instances_list;
+
 protected:
 	static void _bind_methods();
 
 public:
 	bool is_valid(bool p_extended_check = false) const;
 	Variant resume(const Variant &p_arg = Variant());
+
+	void _clear_stack();
+
 	GDScriptFunctionState();
 	~GDScriptFunctionState();
 };


### PR DESCRIPTION
Now the stack saved in a `GDScriptFunctionState` is cleared as soon as the `yield()` operation is known not to be resumed because either the script, the instance or both are deleted.

This clears problems like leaked objects by eliminating cases of circular references between `GDScriptFunctionState`s preventing them and the objects they refer to in their saved stacks from being released. As an example, this makes using `SceneTreeTimer` safer.

Furthermore, with this change it's now possible to print early warnings about `yield()`s to released script/instances, as now we know they won't be successfully resumed as the condition for that happens. However, this PR doesn't add such messages, to keep the observed behavior the same for the time being.

Also, now a backup of the function name in `GDScriptFunctionState` is used, since the script may not be valid by the time the function name is needed for the resume-after-yield error messages.

**NOTE:** This is the version of #38481 for 3.2.

---
**This code is generously donated by IMVU.**