### PR TITLE
Clear line edit selection if focus is lost

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -698,6 +698,7 @@ void LineEdit::_notification(int p_what) {
 		case NOTIFICATION_DRAW: {
 
 			if ((!has_focus() && !menu->has_focus()) || !window_has_focus) {
+				deselect();
 				draw_caret = false;
 			}
 


### PR DESCRIPTION
Fixes #37788

This change affects all line edits, not just the ones for find/replace. Previously you could have text selected simultaneously in find/replace, inspector filter, scene tree filter, etc

![XJnwcAq9EP](https://user-images.githubusercontent.com/41730826/81064651-63d5c900-8f1d-11ea-8f30-55f860380947.gif)
