### PR TITLE
Refactor Octree<T, use_pairs, AL>::cull_convex() and Geometry::compute_convex_mesh_points()

### DIFF
--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -74,8 +74,8 @@ public:
 	bool intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *r_clip = nullptr, Vector3 *r_normal = nullptr) const;
 	_FORCE_INLINE_ bool smits_intersect_ray(const Vector3 &p_from, const Vector3 &p_dir, real_t t0, real_t t1) const;
 
-	_FORCE_INLINE_ bool intersects_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count) const;
-	_FORCE_INLINE_ bool inside_convex_shape(const Plane *p_planes, int p_plane_count) const;
+	_FORCE_INLINE_ bool intersects_convex_shape(const Vector<Plane> &p_planes, const Vector<Vector3> &p_points) const;
+	_FORCE_INLINE_ bool inside_convex_shape(const Vector<Plane> &p_planes) const;
 	bool intersects_plane(const Plane &p_plane) const;
 
 	_FORCE_INLINE_ bool has_point(const Vector3 &p_point) const;
@@ -203,11 +203,11 @@ Vector3 AABB::get_endpoint(int p_point) const {
 	ERR_FAIL_V(Vector3());
 }
 
-bool AABB::intersects_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count) const {
+bool AABB::intersects_convex_shape(const Vector<Plane> &p_planes, const Vector<Vector3> &p_points) const {
 	Vector3 half_extents = size * 0.5;
 	Vector3 ofs = position + half_extents;
 
-	for (int i = 0; i < p_plane_count; i++) {
+	for (int i = 0; i < p_planes.size(); i++) {
 		const Plane &p = p_planes[i];
 		Vector3 point(
 				(p.normal.x > 0) ? -half_extents.x : half_extents.x,
@@ -225,7 +225,7 @@ bool AABB::intersects_convex_shape(const Plane *p_planes, int p_plane_count, con
 	int bad_point_counts_negative[3] = { 0 };
 
 	for (int k = 0; k < 3; k++) {
-		for (int i = 0; i < p_point_count; i++) {
+		for (int i = 0; i < p_points.size(); i++) {
 			if (p_points[i].coord[k] > ofs.coord[k] + half_extents.coord[k]) {
 				bad_point_counts_positive[k]++;
 			}
@@ -234,10 +234,10 @@ bool AABB::intersects_convex_shape(const Plane *p_planes, int p_plane_count, con
 			}
 		}
 
-		if (bad_point_counts_negative[k] == p_point_count) {
+		if (bad_point_counts_negative[k] == p_points.size()) {
 			return false;
 		}
-		if (bad_point_counts_positive[k] == p_point_count) {
+		if (bad_point_counts_positive[k] == p_points.size()) {
 			return false;
 		}
 	}
@@ -245,11 +245,11 @@ bool AABB::intersects_convex_shape(const Plane *p_planes, int p_plane_count, con
 	return true;
 }
 
-bool AABB::inside_convex_shape(const Plane *p_planes, int p_plane_count) const {
+bool AABB::inside_convex_shape(const Vector<Plane> &p_planes) const {
 	Vector3 half_extents = size * 0.5;
 	Vector3 ofs = position + half_extents;
 
-	for (int i = 0; i < p_plane_count; i++) {
+	for (int i = 0; i < p_planes.size(); i++) {
 		const Plane &p = p_planes[i];
 		Vector3 point(
 				(p.normal.x < 0) ? -half_extents.x : half_extents.x,

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -855,11 +855,11 @@ Vector<Plane> Geometry3D::build_capsule_planes(real_t p_radius, real_t p_height,
 	return planes;
 }
 
-Vector<Vector3> Geometry3D::compute_convex_mesh_points(const Plane *p_planes, int p_plane_count) {
+Vector<Vector3> Geometry3D::compute_convex_mesh_points(const Vector<Plane> &p_planes) {
 	Vector<Vector3> points;
 
 	// Iterate through every unique combination of any three planes.
-	for (int i = p_plane_count - 1; i >= 0; i--) {
+	for (int i = p_planes.size() - 1; i >= 0; i--) {
 		for (int j = i - 1; j >= 0; j--) {
 			for (int k = j - 1; k >= 0; k--) {
 				// Find the point where these planes all cross over (if they
@@ -869,7 +869,7 @@ Vector<Vector3> Geometry3D::compute_convex_mesh_points(const Plane *p_planes, in
 					// See if any *other* plane excludes this point because it's
 					// on the wrong side.
 					bool excluded = false;
-					for (int n = 0; n < p_plane_count; n++) {
+					for (int n = 0; n < p_planes.size(); n++) {
 						if (n != i && n != j && n != k) {
 							real_t dp = p_planes[n].normal.dot(convex_shape_point);
 							if (dp - p_planes[n].d > CMP_EPSILON) {

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -690,7 +690,7 @@ public:
 	static Vector<Plane> build_cylinder_planes(real_t p_radius, real_t p_height, int p_sides, Vector3::Axis p_axis = Vector3::AXIS_Z);
 	static Vector<Plane> build_capsule_planes(real_t p_radius, real_t p_height, int p_sides, int p_lats, Vector3::Axis p_axis = Vector3::AXIS_Z);
 
-	static Vector<Vector3> compute_convex_mesh_points(const Plane *p_planes, int p_plane_count);
+	static Vector<Vector3> compute_convex_mesh_points(const Vector<Plane> &p_planes);
 
 #define FINDMINMAX(x0, x1, x2, min, max) \
 	min = max = x0;                      \

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -466,7 +466,7 @@ bool TriangleMesh::intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, V
 	return inters;
 }
 
-bool TriangleMesh::intersect_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count) const {
+bool TriangleMesh::intersect_convex_shape(const Vector<Plane> &p_planes, const Vector<Vector3> &p_points) const {
 	uint32_t *stack = (uint32_t *)alloca(sizeof(int) * max_depth);
 
 	//p_fully_inside = true;
@@ -498,7 +498,7 @@ bool TriangleMesh::intersect_convex_shape(const Plane *p_planes, int p_plane_cou
 
 		switch (stack[level] >> VISITED_BIT_SHIFT) {
 			case TEST_AABB_BIT: {
-				bool valid = b.aabb.intersects_convex_shape(p_planes, p_plane_count, p_points, p_point_count);
+				bool valid = b.aabb.intersects_convex_shape(p_planes, p_points);
 				if (!valid) {
 					stack[level] = (VISIT_DONE_BIT << VISITED_BIT_SHIFT) | node;
 
@@ -511,12 +511,12 @@ bool TriangleMesh::intersect_convex_shape(const Plane *p_planes, int p_plane_cou
 							const Vector3 &next_point = vertexptr[s.indices[(j + 1) % 3]];
 							Vector3 res;
 							bool over = true;
-							for (int i = 0; i < p_plane_count; i++) {
+							for (int i = 0; i < p_planes.size(); i++) {
 								const Plane &p = p_planes[i];
 
 								if (p.intersects_segment(point, next_point, &res)) {
 									bool inisde = true;
-									for (int k = 0; k < p_plane_count; k++) {
+									for (int k = 0; k < p_planes.size(); k++) {
 										if (k == i) {
 											continue;
 										}
@@ -580,7 +580,7 @@ bool TriangleMesh::intersect_convex_shape(const Plane *p_planes, int p_plane_cou
 	return false;
 }
 
-bool TriangleMesh::inside_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count, Vector3 p_scale) const {
+bool TriangleMesh::inside_convex_shape(const Vector<Plane> &p_planes, const Vector<Vector3> &p_points, Vector3 p_scale) const {
 	uint32_t *stack = (uint32_t *)alloca(sizeof(int) * max_depth);
 
 	enum {
@@ -612,12 +612,12 @@ bool TriangleMesh::inside_convex_shape(const Plane *p_planes, int p_plane_count,
 
 		switch (stack[level] >> VISITED_BIT_SHIFT) {
 			case TEST_AABB_BIT: {
-				bool intersects = scale.xform(b.aabb).intersects_convex_shape(p_planes, p_plane_count, p_points, p_point_count);
+				bool intersects = scale.xform(b.aabb).intersects_convex_shape(p_planes, p_points);
 				if (!intersects) {
 					return false;
 				}
 
-				bool inside = scale.xform(b.aabb).inside_convex_shape(p_planes, p_plane_count);
+				bool inside = scale.xform(b.aabb).inside_convex_shape(p_planes);
 				if (inside) {
 					stack[level] = (VISIT_DONE_BIT << VISITED_BIT_SHIFT) | node;
 
@@ -626,7 +626,7 @@ bool TriangleMesh::inside_convex_shape(const Plane *p_planes, int p_plane_count,
 						const Triangle &s = triangleptr[b.face_index];
 						for (int j = 0; j < 3; ++j) {
 							Vector3 point = scale.xform(vertexptr[s.indices[j]]);
-							for (int i = 0; i < p_plane_count; i++) {
+							for (int i = 0; i < p_planes.size(); i++) {
 								const Plane &p = p_planes[i];
 								if (p.is_point_over(point)) {
 									return false;

--- a/core/math/triangle_mesh.h
+++ b/core/math/triangle_mesh.h
@@ -81,8 +81,8 @@ public:
 	bool is_valid() const;
 	bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_point, Vector3 &r_normal) const;
 	bool intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal) const;
-	bool intersect_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count) const;
-	bool inside_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count, Vector3 p_scale = Vector3(1, 1, 1)) const;
+	bool intersect_convex_shape(const Vector<Plane> &p_planes, const Vector<Vector3> &p_points) const;
+	bool inside_convex_shape(const Vector<Plane> &p_planes, const Vector<Vector3> &p_points, Vector3 p_scale = Vector3(1, 1, 1)) const;
 	Vector3 get_area_normal(const AABB &p_aabb) const;
 	Vector<Face3> get_faces() const;
 

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -483,8 +483,9 @@ bool EditorNode3DGizmo::intersect_frustum(const Camera3D *p_camera, const Vector
 			transformed_frustum.push_back(it.xform(p_frustum[i]));
 		}
 
-		Vector<Vector3> convex_points = Geometry3D::compute_convex_mesh_points(p_frustum.ptr(), p_frustum.size());
-		if (collision_mesh->inside_convex_shape(transformed_frustum.ptr(), transformed_frustum.size(), convex_points.ptr(), convex_points.size(), mesh_scale)) {
+		Vector<Vector3> convex_points = Geometry3D::compute_convex_mesh_points(p_frustum);
+
+		if (collision_mesh->inside_convex_shape(transformed_frustum, convex_points, mesh_scale)) {
 			return true;
 		}
 	}


### PR DESCRIPTION
#38465 provided a quick fix for #38457, but the real problem is that `Vectors` are being passed as pointers to their first elements. This is relying on a specific implementation of `Vector`: specifically that the address of the first element of a `Vector` is also the address of the `Vector`.

This PR removes that assumption for `Octree<T, use_pairs, AL>::cull_convex()` and `Geometry::compute_convex_mesh_points()` by passing the `Vectors` by reference and cascading this to all functions called. This also simplifies the functions, because `Vector` knows its size, the count doesn't need to be passed as a separate parameter.

Note: I've extended this to the `Vector<Plane>` parameter that has existed since 0b806ee0f, and which #37863 (and #38344) was, I assume, copying.

This also enables removing the checks added in #38465, which may or may not have had an impact on the culling function.

PS A 3.2 version is available if wanted.