### PR TITLE
Updated editor spin slider to have better behaviour and adjusted control's size_flags_stretch_ratio value range

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -36,6 +36,9 @@
 #include "editor_scale.h"
 
 String EditorSpinSlider::get_tooltip(const Point2 &p_pos) const {
+	if (grabber->is_visible()) {
+		return rtos(get_value()) + "\n\n" + TTR("Hold Ctrl to round to integers. Hold Shift for more precise changes.");
+	}
 	return rtos(get_value());
 }
 
@@ -111,7 +114,21 @@ void EditorSpinSlider::_gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			if (grabbing_spinner) {
+				// Don't make the user scroll all the way back to 'in range' if they went off the end.
+				if (pre_grab_value < get_min() && !is_lesser_allowed()) {
+					pre_grab_value = get_min();
+				}
+				if (pre_grab_value > get_max() && !is_greater_allowed()) {
+					pre_grab_value = get_max();
+				}
+
 				if (mm->get_control()) {
+					// If control was just pressed, don't make the value do a huge jump in magnitude.
+					if (grabbing_spinner_dist_cache != 0) {
+						pre_grab_value += grabbing_spinner_dist_cache * get_step();
+						grabbing_spinner_dist_cache = 0;
+					}
+
 					set_value(Math::round(pre_grab_value + get_step() * grabbing_spinner_dist_cache * 10));
 				} else {
 					set_value(pre_grab_value + get_step() * grabbing_spinner_dist_cache);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2896,7 +2896,7 @@ void Control::_bind_methods() {
 	ADD_GROUP("Size Flags", "size_flags_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "size_flags_horizontal", PROPERTY_HINT_FLAGS, "Fill,Expand,Shrink Center,Shrink End"), "set_h_size_flags", "get_h_size_flags");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "size_flags_vertical", PROPERTY_HINT_FLAGS, "Fill,Expand,Shrink Center,Shrink End"), "set_v_size_flags", "get_v_size_flags");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "size_flags_stretch_ratio", PROPERTY_HINT_RANGE, "0,128,0.01"), "set_stretch_ratio", "get_stretch_ratio");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "size_flags_stretch_ratio", PROPERTY_HINT_RANGE, "0,20,0.01,or_greater"), "set_stretch_ratio", "get_stretch_ratio");
 	ADD_GROUP("Theme", "");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "theme", PROPERTY_HINT_RESOURCE_TYPE, "Theme"), "set_theme", "get_theme");
 	ADD_GROUP("", "");


### PR DESCRIPTION
Fixes #37786

A few changes

1. Updated range of stretch ratio and added `or_greater` to allow for values > max if required. Max of 20 was selected because it's still small enough to perform minor adjustments at lower numbers, and it is conceivable that someone would want a control to take 5% of the width/height reasonably often. (or should it be lower?)
2. Pressing 'control' makes the slider round to the nearest value... but previously it was making the value jump since the cached mouse drag distance went from being *1 to *10 instantly (see below). This no longer happens.
3. If you kept dragging below min or above max, you would have to drag your mouse alllllll the way back in order to get into range. Now, if you are at the minimum value, a change in direction of the mouse is all you need to go back to being in range, and seeing the value update.
4. Added documentation of the shift/control shortcuts... not sure if the class documentation is the right place for it, but there isn't really a "Editor tips and tricks" page afaik. Let me know if I should remove that from this PR.

**BEFORE**
You can see when I press control the value jumps by difference * 10, and back when I let go. When I am at zero for a while it is because I am scrolling far to the 'negative' and I have to keep scrolling in the positive to get back.
![nbNfDpH9Vb](https://user-images.githubusercontent.com/41730826/81073875-9a1a4500-8f2b-11ea-947b-8ce48d98fc91.gif)
**AFTER**
Neither of those issues here...
![dODSeL35YV](https://user-images.githubusercontent.com/41730826/81073860-94bcfa80-8f2b-11ea-8f4f-4f7e37368d0b.gif)