### PR TITLE
Using the common behaviour when use command+shift on text line for osx

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -277,10 +277,14 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 				} break;
 #ifdef APPLE_STYLE_KEYS
 				case (KEY_LEFT): { // Go to start of text - like HOME key.
+					shift_selection_check_pre(k->get_shift());
 					set_cursor_position(0);
+					shift_selection_check_post(k->get_shift());
 				} break;
 				case (KEY_RIGHT): { // Go to end of text - like END key.
+					shift_selection_check_pre(k->get_shift());
 					set_cursor_position(text.length());
+					shift_selection_check_post(k->get_shift());
 				} break;
 #endif
 				default: {


### PR DESCRIPTION
* On press left+command+shift or right+command+shift it should behave like shift+home or shift+end and select the text
* Using home and end events as reference

![2020-05-05 13 27 58](https://user-images.githubusercontent.com/582516/81090701-868fbf80-8ed4-11ea-8ef8-7e6a3b147b38.gif)

