### PR TITLE
Add documentation for the VisualShader nodes

### DIFF
--- a/doc/classes/VisualShaderNodeInput.xml
+++ b/doc/classes/VisualShaderNodeInput.xml
@@ -4,8 +4,10 @@
 		Represents the input shader parameter within the visual shader graph.
 	</brief_description>
 	<description>
+		Gives access to input variables (built-ins) available for the shader. See the shading reference for the list of available built-ins for each shader type (check [code]Tutorials[/code] section for link).
 	</description>
 	<tutorials>
+		<link>https://docs.godotengine.org/en/stable/tutorials/shading/shading_reference/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_input_real_name" qualifiers="const">
@@ -18,7 +20,7 @@
 	</methods>
 	<members>
 		<member name="input_name" type="String" setter="set_input_name" getter="get_input_name" default="&quot;[None]&quot;">
-			One of the several input constants in lower-case style like: "vertex"([/code]VERTEX[code]) or "point_size"([code]POINT_SIZE[/code]).
+			One of the several input constants in lower-case style like: "vertex"([code]VERTEX[/code]) or "point_size"([code]POINT_SIZE[/code]).
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/VisualShaderNodeIs.xml
+++ b/doc/classes/VisualShaderNodeIs.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeIs" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		A boolean comparison operator to be used within the visual shader graph.
 	</brief_description>
 	<description>
+		Returns the boolean result of the comparison between [code]INF[/code] or [code]NaN[/code] and a scalar parameter.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,12 +12,15 @@
 	</methods>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeIs.Function" default="0">
+			The comparison function. See [enum Function] for options.
 		</member>
 	</members>
 	<constants>
 		<constant name="FUNC_IS_INF" value="0" enum="Function">
+			Comparison with [code]INF[/code] (Infinity).
 		</constant>
 		<constant name="FUNC_IS_NAN" value="1" enum="Function">
+			Comparison with [code]NaN[/code] (Not a Number; denotes invalid numeric results, e.g. division by zero).
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeOuterProduct.xml
+++ b/doc/classes/VisualShaderNodeOuterProduct.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeOuterProduct" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Calculates an outer product of two vectors within the visual shader graph.
 	</brief_description>
 	<description>
+		[code]OuterProduct[/code] treats the first parameter [code]c[/code] as a column vector (matrix with one column) and the second parameter [code]r[/code] as a row vector (matrix with one row) and does a linear algebraic matrix multiply [code]c * r[/code], yielding a matrix whose number of rows is the number of components in [code]c[/code] and whose number of columns is the number of components in [code]r[/code].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeOutput.xml
+++ b/doc/classes/VisualShaderNodeOutput.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeOutput" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Represents the output shader parameters within the visual shader graph.
 	</brief_description>
 	<description>
+		This visual shader node is present in all shader graphs in form of "Output" block with mutliple output value ports.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeScalarClamp.xml
+++ b/doc/classes/VisualShaderNodeScalarClamp.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeScalarClamp" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Clamps a scalar value within the visual shader graph.
 	</brief_description>
 	<description>
+		Constrains a value to lie between [code]min[/code] and [code]max[/code] values.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeScalarDerivativeFunc.xml
+++ b/doc/classes/VisualShaderNodeScalarDerivativeFunc.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeScalarDerivativeFunc" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Calculates a scalar derivative within the visual shader graph.
 	</brief_description>
 	<description>
+		This node is only available in [code]Fragment[/code] and [code]Light[/code] visual shaders.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,14 +12,18 @@
 	</methods>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeScalarDerivativeFunc.Function" default="0">
+			The derivative type. See [enum Function] for options.
 		</member>
 	</members>
 	<constants>
 		<constant name="FUNC_SUM" value="0" enum="Function">
+			Sum of absolute derivative in [code]x[/code] and [code]y[/code].
 		</constant>
 		<constant name="FUNC_X" value="1" enum="Function">
+			Derivative in [code]x[/code] using local differencing.
 		</constant>
 		<constant name="FUNC_Y" value="2" enum="Function">
+			Derivative in [code]y[/code] using local differencing.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeScalarInterp.xml
+++ b/doc/classes/VisualShaderNodeScalarInterp.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeScalarInterp" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Linearly interpolates between two scalars within the visual shader graph.
 	</brief_description>
 	<description>
+		Translates to [code]mix(a, b, weight)[/code] in the shader language.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeScalarSmoothStep.xml
+++ b/doc/classes/VisualShaderNodeScalarSmoothStep.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeScalarSmoothStep" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Calculates a scalar SmoothStep function within the visual shader graph.
 	</brief_description>
 	<description>
+		Translates to [code]smoothstep(edge0, edge1, x)[/code] in the shader language.
+		Returns [code]0.0[/code] if [code]x[/code] is smaller than [code]edge0[/code] and [code]1.0[/code] if [code]x[/code] is larger than [code]edge1[/code]. Otherwise the return value is interpolated between [code]0.0[/code] and [code]1.0[/code] using Hermite polynomials.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeScalarSwitch.xml
+++ b/doc/classes/VisualShaderNodeScalarSwitch.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeScalarSwitch" inherits="VisualShaderNodeSwitch" version="4.0">
 	<brief_description>
+		A boolean/scalar function for use within the visual shader graph.
 	</brief_description>
 	<description>
+		Returns an associated scalar if the provided boolean value is [code]true[/code] or [code]false[/code].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeSwitch.xml
+++ b/doc/classes/VisualShaderNodeSwitch.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeSwitch" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		A boolean/vector function for use within the visual shader graph.
 	</brief_description>
 	<description>
+		Returns an associated vector if the provided boolean value is [code]true[/code] or [code]false[/code].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeTexture.xml
+++ b/doc/classes/VisualShaderNodeTexture.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeTexture" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Performs a texture lookup within the visual shader graph.
 	</brief_description>
 	<description>
+		Performs a lookup operation on the provided texture, with support for multiple texture sources to choose from.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,30 +12,42 @@
 	</methods>
 	<members>
 		<member name="source" type="int" setter="set_source" getter="get_source" enum="VisualShaderNodeTexture.Source" default="0">
+			Determines the source for the lookup. See [enum Source] for options.
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
+			The source texture, if needed for the selected [member source].
 		</member>
 		<member name="texture_type" type="int" setter="set_texture_type" getter="get_texture_type" enum="VisualShaderNodeTexture.TextureType" default="0">
+			Specifies the type of the texture if [member source] is set to [constant SOURCE_TEXTURE]. See [enum TextureType] for options.
 		</member>
 	</members>
 	<constants>
 		<constant name="SOURCE_TEXTURE" value="0" enum="Source">
+			Use the texture given as an argument for this function.
 		</constant>
 		<constant name="SOURCE_SCREEN" value="1" enum="Source">
+			Use the current viewport's texture as the source.
 		</constant>
 		<constant name="SOURCE_2D_TEXTURE" value="2" enum="Source">
+			Use the texture from this shader's texture built-in (e.g. a texture of a [Sprite2D]).
 		</constant>
 		<constant name="SOURCE_2D_NORMAL" value="3" enum="Source">
+			Use the texture from this shader's normal map built-in.
 		</constant>
 		<constant name="SOURCE_DEPTH" value="4" enum="Source">
+			Use the depth texture available for this shader.
 		</constant>
 		<constant name="SOURCE_PORT" value="5" enum="Source">
+			Use the texture provided in the input port for this function.
 		</constant>
 		<constant name="TYPE_DATA" value="0" enum="TextureType">
+			No hints are added to the uniform declaration.
 		</constant>
 		<constant name="TYPE_COLOR" value="1" enum="TextureType">
+			Adds [code]hint_albedo[/code] as hint to the uniform declaration for proper sRGB to linear conversion.
 		</constant>
 		<constant name="TYPE_NORMALMAP" value="2" enum="TextureType">
+			Adds [code]hint_normal[/code] as hint to the uniform declaration, which internally converts the texture for proper usage as normal map.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeTextureUniform.xml
+++ b/doc/classes/VisualShaderNodeTextureUniform.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeTextureUniform" inherits="VisualShaderNodeUniform" version="4.0">
 	<brief_description>
+		Performs a uniform texture lookup within the visual shader graph.
 	</brief_description>
 	<description>
+		Performs a lookup operation on the texture provided as a uniform for the shader.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,22 +12,30 @@
 	</methods>
 	<members>
 		<member name="color_default" type="int" setter="set_color_default" getter="get_color_default" enum="VisualShaderNodeTextureUniform.ColorDefault" default="0">
+			Sets the default color if no texture is assigned to the uniform.
 		</member>
 		<member name="texture_type" type="int" setter="set_texture_type" getter="get_texture_type" enum="VisualShaderNodeTextureUniform.TextureType" default="0">
+			Defines the type of data provided by the source texture. See [enum TextureType] for options.
 		</member>
 	</members>
 	<constants>
 		<constant name="TYPE_DATA" value="0" enum="TextureType">
+			No hints are added to the uniform declaration.
 		</constant>
 		<constant name="TYPE_COLOR" value="1" enum="TextureType">
+			Adds [code]hint_albedo[/code] as hint to the uniform declaration for proper sRGB to linear conversion.
 		</constant>
 		<constant name="TYPE_NORMALMAP" value="2" enum="TextureType">
+			Adds [code]hint_normal[/code] as hint to the uniform declaration, which internally converts the texture for proper usage as normal map.
 		</constant>
 		<constant name="TYPE_ANISO" value="3" enum="TextureType">
+			Adds [code]hint_aniso[/code] as hint to the uniform declaration to use for a flowmap.
 		</constant>
 		<constant name="COLOR_DEFAULT_WHITE" value="0" enum="ColorDefault">
+			Defaults to white color.
 		</constant>
 		<constant name="COLOR_DEFAULT_BLACK" value="1" enum="ColorDefault">
+			Defaults to black color.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeTextureUniformTriplanar.xml
+++ b/doc/classes/VisualShaderNodeTextureUniformTriplanar.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeTextureUniformTriplanar" inherits="VisualShaderNodeTextureUniform" version="4.0">
 	<brief_description>
+		Performs a uniform texture lookup with triplanar within the visual shader graph.
 	</brief_description>
 	<description>
+		Performs a lookup operation on the texture provided as a uniform for the shader, with support for triplanar mapping.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeTransformCompose.xml
+++ b/doc/classes/VisualShaderNodeTransformCompose.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeTransformCompose" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Composes a [Transform] from four [Vector3]s within the visual shader graph.
 	</brief_description>
 	<description>
+		Creates a 4x4 transform matrix using four vectors of type [code]vec3[/code]. Each vector is one row in the matrix and the last column is a [code]vec4(0, 0, 0, 1)[/code].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeTransformConstant.xml
+++ b/doc/classes/VisualShaderNodeTransformConstant.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeTransformConstant" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		A [Transform] constant for use within the visual shader graph.
 	</brief_description>
 	<description>
+		A constant [Transform], which can be used as an input node.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 	</methods>
 	<members>
 		<member name="constant" type="Transform" setter="set_constant" getter="get_constant" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+			A [Transform] constant which represents the state of this node.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeTransformDecompose.xml
+++ b/doc/classes/VisualShaderNodeTransformDecompose.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeTransformDecompose" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Decomposes a [Transform] into four [Vector3]s within the visual shader graph.
 	</brief_description>
 	<description>
+		Takes a 4x4 transform matrix and decomposes it into four [code]vec3[/code] values, one from each row of the matrix.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeTransformFunc.xml
+++ b/doc/classes/VisualShaderNodeTransformFunc.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeTransformFunc" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Computes a [Transform] function within the visual shader graph.
 	</brief_description>
 	<description>
+		Computes an inverse or transpose function on the provided [Transform].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,12 +12,15 @@
 	</methods>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeTransformFunc.Function" default="0">
+			The function to be computed. See [enum Function] for options.
 		</member>
 	</members>
 	<constants>
 		<constant name="FUNC_INVERSE" value="0" enum="Function">
+			Perform the inverse operation on the [Transform] matrix.
 		</constant>
 		<constant name="FUNC_TRANSPOSE" value="1" enum="Function">
+			Perform the transpose operation on the [Transform] matrix.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeTransformMult.xml
+++ b/doc/classes/VisualShaderNodeTransformMult.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeTransformMult" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Multiplies [Transform] by [Transform] within the visual shader graph.
 	</brief_description>
 	<description>
+		A multiplication operation on two transforms (4x4 matrices), with support for different multiplication operators.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,16 +12,21 @@
 	</methods>
 	<members>
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeTransformMult.Operator" default="0">
+			The multiplication type to be performed on the transforms. See [enum Operator] for options.
 		</member>
 	</members>
 	<constants>
 		<constant name="OP_AxB" value="0" enum="Operator">
+			Multiplies transform [code]a[/code] by the transform [code]b[/code].
 		</constant>
 		<constant name="OP_BxA" value="1" enum="Operator">
+			Multiplies transform [code]b[/code] by the transform [code]a[/code].
 		</constant>
 		<constant name="OP_AxB_COMP" value="2" enum="Operator">
+			Performs a component-wise multiplication of transform [code]a[/code] by the transform [code]b[/code].
 		</constant>
 		<constant name="OP_BxA_COMP" value="3" enum="Operator">
+			Performs a component-wise multiplication of transform [code]b[/code] by the transform [code]a[/code].
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeTransformUniform.xml
+++ b/doc/classes/VisualShaderNodeTransformUniform.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeTransformUniform" inherits="VisualShaderNodeUniform" version="4.0">
 	<brief_description>
+		A [Transform] uniform for use within the visual shader graph.
 	</brief_description>
 	<description>
+		Translated to [code]uniform mat4[/code] in the shader language.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeTransformVecMult.xml
+++ b/doc/classes/VisualShaderNodeTransformVecMult.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeTransformVecMult" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Multiplies a [Transform] and a [Vector3] within the visual shader graph.
 	</brief_description>
 	<description>
+		A multiplication operation on a transform (4x4 matrix) and a vector, with support for different multiplication operators.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,16 +12,21 @@
 	</methods>
 	<members>
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeTransformVecMult.Operator" default="0">
+			The multiplication type to be performed. See [enum Operator] for options.
 		</member>
 	</members>
 	<constants>
 		<constant name="OP_AxB" value="0" enum="Operator">
+			Multiplies transform [code]a[/code] by the vector [code]b[/code].
 		</constant>
 		<constant name="OP_BxA" value="1" enum="Operator">
+			Multiplies vector [code]b[/code] by the transform [code]a[/code].
 		</constant>
 		<constant name="OP_3x3_AxB" value="2" enum="Operator">
+			Multiplies transform [code]a[/code] by the vector [code]b[/code], skipping the last row and column of the transform.
 		</constant>
 		<constant name="OP_3x3_BxA" value="3" enum="Operator">
+			Multiplies vector [code]b[/code] by the transform [code]a[/code], skipping the last row and column of the transform.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeUniform.xml
+++ b/doc/classes/VisualShaderNodeUniform.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeUniform" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		A base type for the uniforms within the visual shader graph.
 	</brief_description>
 	<description>
+		A uniform represents a variable in the shader which is set externally, i.e. from the [ShaderMaterial]. Uniforms are exposed as properties in the [ShaderMaterial] and can be assigned from the inspector or from a script.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 	</methods>
 	<members>
 		<member name="uniform_name" type="String" setter="set_uniform_name" getter="get_uniform_name" default="&quot;&quot;">
+			Name of the uniform, by which it can be accessed through the [ShaderMaterial] properties.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeVec3Constant.xml
+++ b/doc/classes/VisualShaderNodeVec3Constant.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVec3Constant" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		A [Vector3] constant to be used within the visual shader graph.
 	</brief_description>
 	<description>
+		A constant [Vector3], which can be used as an input node.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 	</methods>
 	<members>
 		<member name="constant" type="Vector3" setter="set_constant" getter="get_constant" default="Vector3( 0, 0, 0 )">
+			A [Vector3] constant which represents the state of this node.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualShaderNodeVec3Uniform.xml
+++ b/doc/classes/VisualShaderNodeVec3Uniform.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVec3Uniform" inherits="VisualShaderNodeUniform" version="4.0">
 	<brief_description>
+		A [Vector3] uniform to be used within the visual shader graph.
 	</brief_description>
 	<description>
+		Translated to [code]uniform vec3[/code] in the shader language.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVectorClamp.xml
+++ b/doc/classes/VisualShaderNodeVectorClamp.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorClamp" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Clamps a vector value within the visual shader graph.
 	</brief_description>
 	<description>
+		Constrains a value to lie between [code]min[/code] and [code]max[/code] values. The operation is performed on each component of the vector individually.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVectorCompose.xml
+++ b/doc/classes/VisualShaderNodeVectorCompose.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorCompose" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Composes a [Vector3] from three scalars within the visual shader graph.
 	</brief_description>
 	<description>
+		Creates a [code]vec3[/code] using three scalar values that can be provided from separate inputs.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVectorDecompose.xml
+++ b/doc/classes/VisualShaderNodeVectorDecompose.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorDecompose" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Decomposes a [Vector3] into three scalars within the visual shader graph.
 	</brief_description>
 	<description>
+		Takes a [code]vec3[/code] and decomposes it into three scalar values that can be used as separate inputs.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVectorDerivativeFunc.xml
+++ b/doc/classes/VisualShaderNodeVectorDerivativeFunc.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorDerivativeFunc" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Calculates a vector derivative within the visual shader graph.
 	</brief_description>
 	<description>
+		This node is only available in [code]Fragment[/code] and [code]Light[/code] visual shaders.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,14 +12,18 @@
 	</methods>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeVectorDerivativeFunc.Function" default="0">
+			A derivative type. See [enum Function] for options.
 		</member>
 	</members>
 	<constants>
 		<constant name="FUNC_SUM" value="0" enum="Function">
+			Sum of absolute derivative in [code]x[/code] and [code]y[/code].
 		</constant>
 		<constant name="FUNC_X" value="1" enum="Function">
+			Derivative in [code]x[/code] using local differencing.
 		</constant>
 		<constant name="FUNC_Y" value="2" enum="Function">
+			Derivative in [code]y[/code] using local differencing.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVectorDistance.xml
+++ b/doc/classes/VisualShaderNodeVectorDistance.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorDistance" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Returns the distance between two points. To be used within the visual shader graph.
 	</brief_description>
 	<description>
+		Calculates distance from point represented by vector [code]p0[/code] to vector [code]p1[/code].
+		Translated to [code]distance(p0, p1)[/code] in the shader language.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVectorFunc.xml
+++ b/doc/classes/VisualShaderNodeVectorFunc.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorFunc" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		A vector function to be used within the visual shader graph.
 	</brief_description>
 	<description>
+		A visual shader node able to perform different functions using vectors.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,78 +12,114 @@
 	</methods>
 	<members>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeVectorFunc.Function" default="0">
+			The function to be performed. See [enum Function] for options.
 		</member>
 	</members>
 	<constants>
 		<constant name="FUNC_NORMALIZE" value="0" enum="Function">
+			Normalizes the vector so that it has a length of [code]1[/code] but points in the same direction.
 		</constant>
 		<constant name="FUNC_SATURATE" value="1" enum="Function">
+			Clamps the value between [code]0.0[/code] and [code]1.0[/code].
 		</constant>
 		<constant name="FUNC_NEGATE" value="2" enum="Function">
+			Returns the opposite value of the parameter.
 		</constant>
 		<constant name="FUNC_RECIPROCAL" value="3" enum="Function">
+			Returns [code]1/vector[/code].
 		</constant>
 		<constant name="FUNC_RGB2HSV" value="4" enum="Function">
+			Converts RGB vector to HSV equivalent.
 		</constant>
 		<constant name="FUNC_HSV2RGB" value="5" enum="Function">
+			Converts HSV vector to RGB equivalent.
 		</constant>
 		<constant name="FUNC_ABS" value="6" enum="Function">
+			Returns the absolute value of the parameter.
 		</constant>
 		<constant name="FUNC_ACOS" value="7" enum="Function">
+			Returns the arc-cosine of the parameter.
 		</constant>
 		<constant name="FUNC_ACOSH" value="8" enum="Function">
+			Returns the inverse hyperbolic cosine of the parameter.
 		</constant>
 		<constant name="FUNC_ASIN" value="9" enum="Function">
+			Returns the arc-sine of the parameter.
 		</constant>
 		<constant name="FUNC_ASINH" value="10" enum="Function">
+			Returns the inverse hyperbolic sine of the parameter.
 		</constant>
 		<constant name="FUNC_ATAN" value="11" enum="Function">
+			Returns the arc-tangent of the parameter.
 		</constant>
 		<constant name="FUNC_ATANH" value="12" enum="Function">
+			Returns the inverse hyperbolic tangent of the parameter.
 		</constant>
 		<constant name="FUNC_CEIL" value="13" enum="Function">
+			Finds the nearest integer that is greater than or equal to the parameter.
 		</constant>
 		<constant name="FUNC_COS" value="14" enum="Function">
+			Returns the cosine of the parameter.
 		</constant>
 		<constant name="FUNC_COSH" value="15" enum="Function">
+			Returns the hyperbolic cosine of the parameter.
 		</constant>
 		<constant name="FUNC_DEGREES" value="16" enum="Function">
+			Converts a quantity in radians to degrees.
 		</constant>
 		<constant name="FUNC_EXP" value="17" enum="Function">
+			Base-e Exponential.
 		</constant>
 		<constant name="FUNC_EXP2" value="18" enum="Function">
+			Base-2 Exponential.
 		</constant>
 		<constant name="FUNC_FLOOR" value="19" enum="Function">
+			Finds the nearest integer less than or equal to the parameter.
 		</constant>
 		<constant name="FUNC_FRAC" value="20" enum="Function">
+			Computes the fractional part of the argument.
 		</constant>
 		<constant name="FUNC_INVERSE_SQRT" value="21" enum="Function">
+			Returns the inverse of the square root of the parameter.
 		</constant>
 		<constant name="FUNC_LOG" value="22" enum="Function">
+			Natural logarithm.
 		</constant>
 		<constant name="FUNC_LOG2" value="23" enum="Function">
+			Base-2 logarithm.
 		</constant>
 		<constant name="FUNC_RADIANS" value="24" enum="Function">
+			Converts a quantity in degrees to radians.
 		</constant>
 		<constant name="FUNC_ROUND" value="25" enum="Function">
+			Finds the nearest integer to the parameter.
 		</constant>
 		<constant name="FUNC_ROUNDEVEN" value="26" enum="Function">
+			Finds the nearest even integer to the parameter.
 		</constant>
 		<constant name="FUNC_SIGN" value="27" enum="Function">
+			Extracts the sign of the parameter, i.e. returns [code]-1[/code] if the parameter is negative, [code]1[/code] if it's positive and [code]0[/code] otherwise.
 		</constant>
 		<constant name="FUNC_SIN" value="28" enum="Function">
+			Returns the sine of the parameter.
 		</constant>
 		<constant name="FUNC_SINH" value="29" enum="Function">
+			Returns the hyperbolic sine of the parameter.
 		</constant>
 		<constant name="FUNC_SQRT" value="30" enum="Function">
+			Returns the square root of the parameter.
 		</constant>
 		<constant name="FUNC_TAN" value="31" enum="Function">
+			Returns the tangent of the parameter.
 		</constant>
 		<constant name="FUNC_TANH" value="32" enum="Function">
+			Returns the hyperbolic tangent of the parameter.
 		</constant>
 		<constant name="FUNC_TRUNC" value="33" enum="Function">
+			Returns a value equal to the nearest integer to the parameter whose absolute value is not larger than the absolute value of the parameter.
 		</constant>
 		<constant name="FUNC_ONEMINUS" value="34" enum="Function">
+			Returns [code]1.0 - vector[/code].
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVectorInterp.xml
+++ b/doc/classes/VisualShaderNodeVectorInterp.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorInterp" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Linearly interpolates between two vectors within the visual shader graph.
 	</brief_description>
 	<description>
+		Translates to [code]mix(a, b, weight)[/code] in the shader language, where [code]weight[/code] is a [Vector3] with weights for each component.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVectorLen.xml
+++ b/doc/classes/VisualShaderNodeVectorLen.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorLen" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Returns the length of a [Vector3] within the visual shader graph.
 	</brief_description>
 	<description>
+		Translated to [code]length(p0)[/code] in the shader language.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVectorOp.xml
+++ b/doc/classes/VisualShaderNodeVectorOp.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorOp" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		A vector operator to be used within the visual shader graph.
 	</brief_description>
 	<description>
+		A visual shader node for use of vector operators. Operates on vector [code]a[/code] and vector [code]b[/code].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,32 +12,45 @@
 	</methods>
 	<members>
 		<member name="operator" type="int" setter="set_operator" getter="get_operator" enum="VisualShaderNodeVectorOp.Operator" default="0">
+			The operator to be used. See [enum Operator] for options.
 		</member>
 	</members>
 	<constants>
 		<constant name="OP_ADD" value="0" enum="Operator">
+			Adds two vectors.
 		</constant>
 		<constant name="OP_SUB" value="1" enum="Operator">
+			Subtracts a vector from a vector.
 		</constant>
 		<constant name="OP_MUL" value="2" enum="Operator">
+			Multiplies two vectors.
 		</constant>
 		<constant name="OP_DIV" value="3" enum="Operator">
+			Divides vector by vector.
 		</constant>
 		<constant name="OP_MOD" value="4" enum="Operator">
+			Returns the remainder of the two vectors.
 		</constant>
 		<constant name="OP_POW" value="5" enum="Operator">
+			Returns the value of the first parameter raised to the power of the second, for each component of the vectors.
 		</constant>
 		<constant name="OP_MAX" value="6" enum="Operator">
+			Returns the greater of two values, for each component of the vectors.
 		</constant>
 		<constant name="OP_MIN" value="7" enum="Operator">
+			Returns the lesser of two values, for each component of the vectors.
 		</constant>
 		<constant name="OP_CROSS" value="8" enum="Operator">
+			Calculates the cross product of two vectors.
 		</constant>
 		<constant name="OP_ATAN2" value="9" enum="Operator">
+			Returns the arc-tangent of the parameters.
 		</constant>
 		<constant name="OP_REFLECT" value="10" enum="Operator">
+			Returns the vector that points in the direction of reflection. [code]a[/code] is incident vector and [code]b[/code] is the normal vector.
 		</constant>
 		<constant name="OP_STEP" value="11" enum="Operator">
+			Vector step operator. Returns [code]0.0[/code] if [code]a[/code] is smaller than [code]b[/code] and [code]1.0[/code] otherwise.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVectorRefract.xml
+++ b/doc/classes/VisualShaderNodeVectorRefract.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorRefract" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Returns the [Vector3] that points in the direction of refraction. For use within the visual shader graph.
 	</brief_description>
 	<description>
+		Translated to [code]refract(I, N, eta)[/code] in the shader language, where [code]I[/code] is the incident vector, [code]N[/code] is the normal vector and [code]eta[/code] is the ratio of the indicies of the refraction.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVectorScalarMix.xml
+++ b/doc/classes/VisualShaderNodeVectorScalarMix.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorScalarMix" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Linearly interpolates between two vectors using a scalar. For use within the visual shader graph.
 	</brief_description>
 	<description>
+		Translates to [code]mix(a, b, weight)[/code] in the shader language, where [code]a[/code] and [code]b[/code] are vectors and [code]weight[/code] is a scalar.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVectorScalarSmoothStep.xml
+++ b/doc/classes/VisualShaderNodeVectorScalarSmoothStep.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorScalarSmoothStep" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Calculates a vector SmoothStep function using scalar within the visual shader graph.
 	</brief_description>
 	<description>
+		Translates to [code]smoothstep(edge0, edge1, x)[/code] in the shader language, where [code]x[/code] is a scalar.
+		Returns [code]0.0[/code] if [code]x[/code] is smaller than [code]edge0[/code] and [code]1.0[/code] if [code]x[/code] is larger than [code]edge1[/code]. Otherwise the return value is interpolated between [code]0.0[/code] and [code]1.0[/code] using Hermite polynomials.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVectorScalarStep.xml
+++ b/doc/classes/VisualShaderNodeVectorScalarStep.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorScalarStep" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Calculates a vector Step function within the visual shader graph.
 	</brief_description>
 	<description>
+		Translates to [code]step(edge, x)[/code] in the shader language.
+		Returns [code]0.0[/code] if [code]x[/code] is smaller than [code]edge[/code] and [code]1.0[/code] otherwise.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVectorSmoothStep.xml
+++ b/doc/classes/VisualShaderNodeVectorSmoothStep.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVectorSmoothStep" inherits="VisualShaderNode" version="4.0">
 	<brief_description>
+		Calculates a vector SmoothStep function within the visual shader graph.
 	</brief_description>
 	<description>
+		Translates to [code]smoothstep(edge0, edge1, x)[/code] in the shader language, where [code]x[/code] is a vector.
+		Returns [code]0.0[/code] if [code]x[/code] is smaller than [code]edge0[/code] and [code]1.0[/code] if [code]x[/code] is larger than [code]edge1[/code]. Otherwise the return value is interpolated between [code]0.0[/code] and [code]1.0[/code] using Hermite polynomials.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
This adds documentation to all remaining VisualShader classes. Many of the descriptions are copy-paste from Visual Shader edtior plugin.

Submitting as draft right now, because I didn't do any checking and there are some inconsistencies.