### PR TITLE
Fix scale calculation in VHACD Volume::Voxelize().

### DIFF
--- a/thirdparty/vhacd/0005-fix-scale-calculation.patch
+++ b/thirdparty/vhacd/0005-fix-scale-calculation.patch
@@ -1,0 +1,20 @@
+diff --git a/thirdparty/vhacd/inc/vhacdVolume.h b/thirdparty/vhacd/inc/vhacdVolume.h
+index 8c47fa1e2c..c445f20122 100644
+--- a/thirdparty/vhacd/inc/vhacdVolume.h
++++ b/thirdparty/vhacd/inc/vhacdVolume.h
+@@ -316,13 +316,13 @@ void Volume::Voxelize(const T* const points, const uint32_t stridePoints, const
+ 
+     double d[3] = { m_maxBB[0] - m_minBB[0], m_maxBB[1] - m_minBB[1], m_maxBB[2] - m_minBB[2] };
+     double r;
+-    if (d[0] > d[1] && d[0] > d[2]) {
++    if (d[0] >= d[1] && d[0] >= d[2]) {
+         r = d[0];
+         m_dim[0] = dim;
+         m_dim[1] = 2 + static_cast<size_t>(dim * d[1] / d[0]);
+         m_dim[2] = 2 + static_cast<size_t>(dim * d[2] / d[0]);
+     }
+-    else if (d[1] > d[0] && d[1] > d[2]) {
++    else if (d[1] >= d[0] && d[1] >= d[2]) {
+         r = d[1];
+         m_dim[1] = dim;
+         m_dim[0] = 2 + static_cast<size_t>(dim * d[0] / d[1]);

--- a/thirdparty/vhacd/inc/vhacdVolume.h
+++ b/thirdparty/vhacd/inc/vhacdVolume.h
@@ -316,13 +316,13 @@ void Volume::Voxelize(const T* const points, const uint32_t stridePoints, const 
 
     double d[3] = { m_maxBB[0] - m_minBB[0], m_maxBB[1] - m_minBB[1], m_maxBB[2] - m_minBB[2] };
     double r;
-    if (d[0] > d[1] && d[0] > d[2]) {
+    if (d[0] >= d[1] && d[0] >= d[2]) {
         r = d[0];
         m_dim[0] = dim;
         m_dim[1] = 2 + static_cast<size_t>(dim * d[1] / d[0]);
         m_dim[2] = 2 + static_cast<size_t>(dim * d[2] / d[0]);
     }
-    else if (d[1] > d[0] && d[1] > d[2]) {
+    else if (d[1] >= d[0] && d[1] >= d[2]) {
         r = d[1];
         m_dim[1] = dim;
         m_dim[0] = 2 + static_cast<size_t>(dim * d[0] / d[1]);


### PR DESCRIPTION
In VHACD's `Volume::Voxelize()` function, scale should use the maximum bounding box dimension. However, if the first two bounding box dimensions are equal, but greater than the third, scale is currently incorrectly calculated using the third.

A default `QuadMesh` results in the first two dimensions' bounding boxes being equal and the third dimension's bounding box being zero. The bug results in the scale being set to zero, and the inverse being set to `infinity` or `nan` (or crashing) depending on the OS and the compiler. If it doesn't crash, there is an unsigned integer (size_t) underflow, which causes an assert that checks whether all coordinates are within the bounding box to fail. This assert failure causes the crash described in #30687 and #37984.

This patch ensures that the largest bounding box dimension is used. It also includes the patch file should it be needed. The upstream PR request can be found [here](https://github.com/kmammou/v-hacd/pull/84).

Fixes #30687.
Fixes #37984.