### PR TITLE
Request the dedicated GPU when starting Godot from the `.desktop` file

### DIFF
--- a/misc/dist/linux/org.godotengine.Godot.desktop
+++ b/misc/dist/linux/org.godotengine.Godot.desktop
@@ -5,6 +5,7 @@ Comment=Multi-platform 2D and 3D game engine with a feature-rich editor
 Exec=godot %f
 Icon=godot
 Terminal=false
+PrefersNonDefaultGPU=true
 Type=Application
 MimeType=application/x-godot-project;
 Categories=Development;IDE;


### PR DESCRIPTION
See <https://www.hadess.net/2020/05/dual-gpu-support-launch-on-discrete-gpu.html> for more information about this newly added `.desktop` entry property.