### PR TITLE
PopupMenu.get_current_index() bound to ClassDB

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1079,6 +1079,11 @@ bool PopupMenu::is_item_shortcut_disabled(int p_idx) const {
 	return items[p_idx].shortcut_is_disabled;
 }
 
+int PopupMenu::get_current_index() const {
+
+	return mouse_over;
+}
+
 int PopupMenu::get_item_count() const {
 
 	return items.size();
@@ -1457,6 +1462,7 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_tooltip", "idx"), &PopupMenu::get_item_tooltip);
 	ClassDB::bind_method(D_METHOD("get_item_shortcut", "idx"), &PopupMenu::get_item_shortcut);
 
+	ClassDB::bind_method(D_METHOD("get_current_index"), &PopupMenu::get_current_index);
 	ClassDB::bind_method(D_METHOD("get_item_count"), &PopupMenu::get_item_count);
 
 	ClassDB::bind_method(D_METHOD("remove_item", "idx"), &PopupMenu::remove_item);

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -178,6 +178,7 @@ public:
 	Ref<ShortCut> get_item_shortcut(int p_idx) const;
 	int get_item_state(int p_idx) const;
 
+	int get_current_index() const;
 	int get_item_count() const;
 
 	bool activate_item_by_event(const Ref<InputEvent> &p_event, bool p_for_global_only = false);


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot-proposals/issues/790.  Retrieves current index mouse_over from PopupMenu and exposes it to the user.

This is the version compared against the master branch.  The version compared to 3.2 is at https://github.com/godotengine/godot/pull/38462.