### PR TITLE
Fix: printing empty string does nothing in editor output pannel

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -466,7 +466,7 @@ void RemoteDebugger::_print_handler(void *p_this, const String &p_string, bool p
 	String s = p_string;
 	int allowed_chars = MIN(MAX(rd->max_chars_per_second - rd->char_count, 0), s.length());
 
-	if (allowed_chars == 0)
+	if (allowed_chars == 0 && s.length() > 0)
 		return;
 
 	if (allowed_chars < s.length()) {


### PR DESCRIPTION
Fix: #38490