### PR TITLE
Fix bug with AudioStreamPlayer3D audio position

### DIFF
--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -710,6 +710,11 @@ float AudioStreamPlayer3D::get_pitch_scale() const {
 
 void AudioStreamPlayer3D::play(float p_from_pos) {
 
+	if (!is_playing()) {
+		// Reset the prev_output_count if the stream is stopped
+		prev_output_count = 0;
+	}
+
 	if (stream_playback.is_valid()) {
 		active = true;
 		setplay = p_from_pos;


### PR DESCRIPTION
Applies https://github.com/godotengine/godot/commit/0c78a58b6472f704d473e0307c9ea83dfbde1811 to `AudioStreamPlayer3D::play`.