### PR TITLE
GLES3 - add counts for 2d drawcall and 2d items to performance monitor

### DIFF
--- a/drivers/gles2/rasterizer_canvas_base_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_base_gles2.cpp
@@ -471,6 +471,7 @@ void RasterizerCanvasBaseGLES2::_draw_polygon(const int *p_indices, int p_index_
 	if (storage->config.support_32_bits_indices) { //should check for
 		glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, sizeof(int) * p_index_count, p_indices);
 		glDrawElements(GL_TRIANGLES, p_index_count, GL_UNSIGNED_INT, 0);
+		storage->info.render._2d_draw_call_count++;
 	} else {
 		uint16_t *index16 = (uint16_t *)alloca(sizeof(uint16_t) * p_index_count);
 		for (int i = 0; i < p_index_count; i++) {
@@ -478,6 +479,7 @@ void RasterizerCanvasBaseGLES2::_draw_polygon(const int *p_indices, int p_index_
 		}
 		glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, sizeof(uint16_t) * p_index_count, index16);
 		glDrawElements(GL_TRIANGLES, p_index_count, GL_UNSIGNED_SHORT, 0);
+		storage->info.render._2d_draw_call_count++;
 	}
 
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -522,6 +524,7 @@ void RasterizerCanvasBaseGLES2::_draw_generic(GLuint p_primitive, int p_vertex_c
 	}
 
 	glDrawArrays(p_primitive, 0, p_vertex_count);
+	storage->info.render._2d_draw_call_count++;
 
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
@@ -573,6 +576,7 @@ void RasterizerCanvasBaseGLES2::_draw_generic_indices(GLuint p_primitive, const 
 	if (storage->config.support_32_bits_indices) { //should check for
 		glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, sizeof(int) * p_index_count, p_indices);
 		glDrawElements(p_primitive, p_index_count, GL_UNSIGNED_INT, 0);
+		storage->info.render._2d_draw_call_count++;
 	} else {
 		uint16_t *index16 = (uint16_t *)alloca(sizeof(uint16_t) * p_index_count);
 		for (int i = 0; i < p_index_count; i++) {
@@ -580,6 +584,7 @@ void RasterizerCanvasBaseGLES2::_draw_generic_indices(GLuint p_primitive, const 
 		}
 		glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, sizeof(uint16_t) * p_index_count, index16);
 		glDrawElements(p_primitive, p_index_count, GL_UNSIGNED_SHORT, 0);
+		storage->info.render._2d_draw_call_count++;
 	}
 
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -647,6 +652,7 @@ void RasterizerCanvasBaseGLES2::_draw_gui_primitive(int p_points, const Vector2 
 	}
 
 	glDrawArrays(prim[p_points], 0, p_points);
+	storage->info.render._2d_draw_call_count++;
 
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 }

--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -861,7 +861,6 @@ void RasterizerCanvasGLES2::render_batches(Item::Command *const *p_commands, Ite
 								}
 #endif
 							}
-							storage->info.render._2d_draw_call_count++;
 						} break;
 
 						case Item::Command::TYPE_RECT: {
@@ -1001,6 +1000,7 @@ void RasterizerCanvasGLES2::render_batches(Item::Command *const *p_commands, Ite
 									state.canvas_shader.set_uniform(CanvasShaderGLES2::SRC_RECT, Color(0, 0, 1, 1));
 
 									glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+									storage->info.render._2d_draw_call_count++;
 								} else {
 
 									bool untile = false;
@@ -1043,6 +1043,7 @@ void RasterizerCanvasGLES2::render_batches(Item::Command *const *p_commands, Ite
 									state.canvas_shader.set_uniform(CanvasShaderGLES2::SRC_RECT, Color(src_rect.position.x, src_rect.position.y, src_rect.size.x, src_rect.size.y));
 
 									glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+									storage->info.render._2d_draw_call_count++;
 
 									if (untile) {
 										glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -1055,7 +1056,6 @@ void RasterizerCanvasGLES2::render_batches(Item::Command *const *p_commands, Ite
 							}
 
 							state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_FORCE_REPEAT, false);
-							storage->info.render._2d_draw_call_count++;
 
 						} break;
 
@@ -1263,7 +1263,6 @@ void RasterizerCanvasGLES2::render_batches(Item::Command *const *p_commands, Ite
 							_bind_canvas_texture(RID(), RID());
 
 							_draw_polygon(indices, num_points * 3, num_points + 1, points, NULL, &circle->color, true);
-							storage->info.render._2d_draw_call_count++;
 						} break;
 
 						case Item::Command::TYPE_POLYGON: {
@@ -1296,7 +1295,6 @@ void RasterizerCanvasGLES2::render_batches(Item::Command *const *p_commands, Ite
 								glDisable(GL_LINE_SMOOTH);
 							}
 #endif
-							storage->info.render._2d_draw_call_count++;
 						} break;
 						case Item::Command::TYPE_MESH: {
 
@@ -1536,7 +1534,6 @@ void RasterizerCanvasGLES2::render_batches(Item::Command *const *p_commands, Ite
 									glDisable(GL_LINE_SMOOTH);
 #endif
 							}
-							storage->info.render._2d_draw_call_count++;
 						} break;
 
 						case Item::Command::TYPE_PRIMITIVE: {
@@ -1566,7 +1563,6 @@ void RasterizerCanvasGLES2::render_batches(Item::Command *const *p_commands, Ite
 							}
 
 							_draw_gui_primitive(primitive->points.size(), primitive->points.ptr(), primitive->colors.ptr(), primitive->uvs.ptr());
-							storage->info.render._2d_draw_call_count++;
 						} break;
 
 						case Item::Command::TYPE_TRANSFORM: {

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1299,7 +1299,6 @@ public:
 
 		bool clear_request;
 		Color clear_request_color;
-		int canvas_draw_commands;
 		float time[4];
 		float delta;
 		uint64_t count;

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -410,7 +410,7 @@ void RasterizerCanvasGLES3::_draw_polygon(const int *p_indices, int p_index_coun
 	//draw the triangles.
 	glDrawElements(GL_TRIANGLES, p_index_count, GL_UNSIGNED_INT, 0);
 
-	storage->frame.canvas_draw_commands++;
+	storage->info.render._2d_draw_call_count++;
 
 	if (p_bones && p_weights) {
 		//not used so often, so disable when used
@@ -469,7 +469,7 @@ void RasterizerCanvasGLES3::_draw_generic(GLuint p_primitive, int p_vertex_count
 
 	glDrawArrays(p_primitive, 0, p_vertex_count);
 
-	storage->frame.canvas_draw_commands++;
+	storage->info.render._2d_draw_call_count++;
 
 	glBindVertexArray(0);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -542,7 +542,7 @@ void RasterizerCanvasGLES3::_draw_generic_indices(GLuint p_primitive, const int 
 	//draw the triangles.
 	glDrawElements(p_primitive, p_index_count, GL_UNSIGNED_INT, 0);
 
-	storage->frame.canvas_draw_commands++;
+	storage->info.render._2d_draw_call_count++;
 
 	glBindVertexArray(0);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -608,7 +608,7 @@ void RasterizerCanvasGLES3::_draw_gui_primitive(int p_points, const Vector2 *p_v
 	glBindVertexArray(0);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-	storage->frame.canvas_draw_commands++;
+	storage->info.render._2d_draw_call_count++;
 }
 
 static const GLenum gl_primitive[] = {
@@ -685,7 +685,6 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 					}
 #endif
 				}
-
 			} break;
 			case Item::Command::TYPE_POLYLINE: {
 
@@ -790,6 +789,7 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 					state.canvas_shader.set_uniform(CanvasShaderGLES3::CLIP_RECT_UV, rect->flags & CANVAS_RECT_CLIP_UV);
 
 					glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+					storage->info.render._2d_draw_call_count++;
 
 					if (untile) {
 						glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -812,9 +812,8 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 					state.canvas_shader.set_uniform(CanvasShaderGLES3::SRC_RECT, Color(0, 0, 1, 1));
 					state.canvas_shader.set_uniform(CanvasShaderGLES3::CLIP_RECT_UV, false);
 					glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+					storage->info.render._2d_draw_call_count++;
 				}
-
-				storage->frame.canvas_draw_commands++;
 
 			} break;
 
@@ -857,7 +856,7 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 
 				glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 
-				storage->frame.canvas_draw_commands++;
+				storage->info.render._2d_draw_call_count++;
 			} break;
 
 			case Item::Command::TYPE_PRIMITIVE: {
@@ -940,6 +939,7 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 						} else {
 							glDrawArrays(gl_primitive[s->primitive], 0, s->array_len);
 						}
+						storage->info.render._2d_draw_call_count++;
 
 						glBindVertexArray(0);
 					}
@@ -1057,6 +1057,7 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 					} else {
 						glDrawArraysInstanced(gl_primitive[s->primitive], 0, s->array_len, amount);
 					}
+					storage->info.render._2d_draw_call_count++;
 
 					glBindVertexArray(0);
 				}
@@ -1138,6 +1139,7 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 					glVertexAttribDivisor(12, 1);
 
 					glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, amount);
+					storage->info.render._2d_draw_call_count++;
 				} else {
 					//split
 					int split = int(Math::ceil(particles->phase * particles->amount));
@@ -1160,6 +1162,7 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 						glVertexAttribDivisor(12, 1);
 
 						glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, amount - split);
+						storage->info.render._2d_draw_call_count++;
 					}
 
 					if (split > 0) {
@@ -1180,6 +1183,7 @@ void RasterizerCanvasGLES3::_canvas_item_render_commands(Item *p_item, Item *cur
 						glVertexAttribDivisor(12, 1);
 
 						glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, split);
+						storage->info.render._2d_draw_call_count++;
 					}
 				}
 
@@ -1359,6 +1363,7 @@ void RasterizerCanvasGLES3::canvas_render_items(Item *p_item_list, int p_z, cons
 	while (p_item_list) {
 
 		Item *ci = p_item_list;
+		storage->info.render._2d_item_count++;
 
 		if (prev_distance_field != ci->distance_field) {
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -8141,6 +8141,8 @@ void RasterizerStorageGLES3::render_info_end_capture() {
 	info.snap.surface_switch_count = info.render.surface_switch_count - info.snap.surface_switch_count;
 	info.snap.shader_rebind_count = info.render.shader_rebind_count - info.snap.shader_rebind_count;
 	info.snap.vertices_count = info.render.vertices_count - info.snap.vertices_count;
+	info.snap._2d_item_count = info.render._2d_item_count - info.snap._2d_item_count;
+	info.snap._2d_draw_call_count = info.render._2d_draw_call_count - info.snap._2d_draw_call_count;
 }
 
 int RasterizerStorageGLES3::get_captured_render_info(VS::RenderInfo p_info) {
@@ -8166,6 +8168,12 @@ int RasterizerStorageGLES3::get_captured_render_info(VS::RenderInfo p_info) {
 		case VS::INFO_DRAW_CALLS_IN_FRAME: {
 			return info.snap.draw_call_count;
 		} break;
+		case VS::INFO_2D_ITEMS_IN_FRAME: {
+			return info.snap._2d_item_count;
+		} break;
+		case VS::INFO_2D_DRAW_CALLS_IN_FRAME: {
+			return info.snap._2d_draw_call_count;
+		} break;
 		default: {
 			return get_render_info(p_info);
 		}
@@ -8187,6 +8195,10 @@ int RasterizerStorageGLES3::get_render_info(VS::RenderInfo p_info) {
 			return info.render_final.surface_switch_count;
 		case VS::INFO_DRAW_CALLS_IN_FRAME:
 			return info.render_final.draw_call_count;
+		case VS::INFO_2D_ITEMS_IN_FRAME:
+			return info.render_final._2d_item_count;
+		case VS::INFO_2D_DRAW_CALLS_IN_FRAME:
+			return info.render_final._2d_draw_call_count;
 		case VS::INFO_USAGE_VIDEO_MEM_TOTAL:
 			return 0; //no idea
 		case VS::INFO_VIDEO_MEM_USED:

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -154,6 +154,8 @@ public:
 			uint32_t surface_switch_count;
 			uint32_t shader_rebind_count;
 			uint32_t vertices_count;
+			uint32_t _2d_item_count;
+			uint32_t _2d_draw_call_count;
 
 			void reset() {
 				object_count = 0;
@@ -162,6 +164,8 @@ public:
 				surface_switch_count = 0;
 				shader_rebind_count = 0;
 				vertices_count = 0;
+				_2d_item_count = 0;
+				_2d_draw_call_count = 0;
 			}
 		} render, render_final, snap;
 
@@ -1450,7 +1454,6 @@ public:
 
 		bool clear_request;
 		Color clear_request_color;
-		int canvas_draw_commands;
 		float time[4];
 		float delta;
 		uint64_t count;


### PR DESCRIPTION
This had already been implemented for GLES2 but not GLES3.

* I've removed the mysterious `storage->frame.canvas_draw_commands` which was incremented but didn't seem to do anything (probably historical counter).
* I've improved the counts in GLES2 a little, they should be more accurate now.