### PR TITLE
When a KinematicBody is stuck, set the unsafe proportion to the minimum instead of zero.

### DIFF
--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -989,7 +989,8 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 			if (stuck) {
 
 				safe = 0;
-				unsafe = 0;
+				// Set unsafe to the minimum after eight steps = 1/2^8.
+				unsafe = 1.0 / (1 << 8);
 				best_shape = body_shape_idx; //sadly it's the best
 				break;
 			}

--- a/servers/physics_3d/space_3d_sw.cpp
+++ b/servers/physics_3d/space_3d_sw.cpp
@@ -900,7 +900,8 @@ bool Space3DSW::test_body_motion(Body3DSW *p_body, const Transform &p_from, cons
 			if (stuck) {
 
 				safe = 0;
-				unsafe = 0;
+				// Set unsafe to the minimum after eight steps = 1/2^8.
+				unsafe = 1.0 / (1 << 8);
 				best_shape = j; //sadly it's the best
 				break;
 			}


### PR DESCRIPTION
When a `KinematicBody` is stuck, setting the unsafe proportion to the minimum instead of zero, ensures that collision information is extracted even if the penetration causing the body to be stuck is less than the `test_motion_min_contact_depth`. More importantly, this ensures that a collision is reported and doesn't allow the body to tunnel. Furthermore, it also ensures that the collision information is extracted from the `CollisionShape` in the direction of motion not the `CollisionShape` that happens to be closest or first.

Note: The minimum is 1/2^8 because there are (an arbitrary) eight steps in the binary search.

Fixes #37798.

PS See [my comment](https://github.com/godotengine/godot/issues/37798#issuecomment-625178701) in #37798 for a more in depth analysis.



