### PR TITLE
jpgd: Fix detection of SSE2 support with MSVC

### DIFF
--- a/thirdparty/jpeg-compressor/jpgd.cpp
+++ b/thirdparty/jpeg-compressor/jpgd.cpp
@@ -37,16 +37,14 @@
 
 #ifndef JPGD_USE_SSE2
 
-	#if defined(__GNUC__) 
-
-		#if (defined(__x86_64__) || defined(_M_X64)) 
-			#if defined(__SSE2__)
-				#define JPGD_USE_SSE2 (1)
-			#endif
+	#if defined(__GNUC__)
+		#if defined(__SSE2__)
+			#define JPGD_USE_SSE2 (1)
 		#endif
-
-	#else
-		#define JPGD_USE_SSE2 (1)
+	#elif defined(_MSC_VER)
+		#if defined(_M_X64)
+			#define JPGD_USE_SSE2 (1)
+		#endif
 	#endif
 
 #endif

--- a/thirdparty/jpeg-compressor/patches/fix-msvc-sse2-detection.patch
+++ b/thirdparty/jpeg-compressor/patches/fix-msvc-sse2-detection.patch
@@ -1,0 +1,44 @@
+From ae74fa2fcdef8ec44b925a649f66e8cbefce8315 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Verschelde?= <rverschelde@gmail.com>
+Date: Thu, 7 May 2020 12:14:09 +0200
+Subject: [PATCH] Fix detection of SSE2 with Visual Studio
+
+The previous code assumed that SSE2 is available when building with
+Visual Studio, but that's not accurate on ARM with UWP.
+
+SSE2 could also be enabled on x86 if `_M_IX86_FP == 2`, but it requires
+checking first that it's not actually set to 2 for AVX, AVX2 or AVX512
+(see https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019),
+so I left it out for this quick fix.
+---
+ jpgd.cpp | 16 +++++++---------
+ 1 file changed, 7 insertions(+), 9 deletions(-)
+
+diff --git a/jpgd.cpp b/jpgd.cpp
+index 91e66ad..db1f3b4 100644
+--- a/jpgd.cpp
++++ b/jpgd.cpp
+@@ -37,16 +37,14 @@
+ 
+ #ifndef JPGD_USE_SSE2
+ 
+-	#if defined(__GNUC__) 
+-
+-		#if (defined(__x86_64__) || defined(_M_X64)) 
+-			#if defined(__SSE2__)
+-				#define JPGD_USE_SSE2 (1)
+-			#endif
++	#if defined(__GNUC__)
++		#if defined(__SSE2__)
++			#define JPGD_USE_SSE2 (1)
++		#endif
++	#elif defined(_MSC_VER)
++		#if defined(_M_X64)
++			#define JPGD_USE_SSE2 (1)
+ 		#endif
+-
+-	#else
+-		#define JPGD_USE_SSE2 (1)
+ 	#endif
+ 
+ #endif


### PR DESCRIPTION
The previous code would always use SSE2 intrinsics, which is not valid
on UWP ARM platforms (and likely not on some x86 platforms either).

The patch has been submitted upstream too:
https://github.com/richgel999/jpeg-compressor/pull/13