### PR TITLE
Tilemap: Fix ATLAS tile bitmask not working outside of editor

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -339,9 +339,9 @@ void TileMapEditor::_set_cell(const Point2i &p_pos, Vector<int> p_values, bool p
 	if (manual_autotile || (p_value != -1 && node->get_tileset()->tile_get_tile_mode(p_value) == TileSet::ATLAS_TILE)) {
 		if (current != -1) {
 			node->set_cell_autotile_coord(p_pos.x, p_pos.y, position);
-		} else if (node->get_tileset()->tile_get_tile_mode(p_value) == TileSet::ATLAS_TILE && priority_atlastile) {
 			// BIND_CENTER is used to indicate that bitmask should not update for this tile cell.
 			node->get_tileset()->autotile_set_bitmask(p_value, Vector2(p_pos.x, p_pos.y), TileSet::BIND_CENTER);
+		} else if (node->get_tileset()->tile_get_tile_mode(p_value) == TileSet::ATLAS_TILE && priority_atlastile) {
 			node->update_cell_bitmask(p_pos.x, p_pos.y);
 		}
 	} else {

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1032,7 +1032,7 @@ void TileMap::update_cell_bitmask(int p_x, int p_y) {
 			E->get().autotile_coord_y = 0;
 		} else if (tile_set->tile_get_tile_mode(id) == TileSet::ATLAS_TILE) {
 
-			if (tile_set->autotile_get_bitmask(id, Vector2(p_x, p_y)) == TileSet::BIND_CENTER) {
+			if (tile_set->autotile_get_bitmask(id, Vector2(p_x, p_y)) != TileSet::BIND_CENTER) {
 				Vector2 coord = tile_set->atlastile_get_subtile_by_priority(id, this, Vector2(p_x, p_y));
 
 				E->get().autotile_coord_x = (int)coord.x;


### PR DESCRIPTION
This PR is related to #36972

With the actual solution for Tilemap "ATLAS Tile" the priority system works based on a priority flag inside the editor to enable the whole priority system / bitmask randomizer  (behind the scenes based on a "center bitmask flag"). This works like designed within the editor, **but** if the ATLAS tile is used via Tilemap by **code (i. e. GD-Script)** the complete priority system is **not usable**.

**Reason:** ATLAS Tileset by itself does not allow to set manual bitmasks via editor (which makes sense), but the bitmask code requires a "center bitmask flag" (as described above).

My simple solution to this issue, invert the check within "TileMap::update_cell_bitmask" and also invert the setting of this center bitmask in "TileMapEditor::_set_cell". With this change the original intention is still given, with the bonus, that it's now usable via code (i. e. GD-Script). 

**Additional Remark:**  _(not done change)_
I would also delete the following code in "TileMapEditor::_set_cell", as all ATLAS tile interactions are done based on the actual "cell", only in this case (which is deletion of tiles in the Tilemap Editor) it's updating the "bitmask_area" (3x3 field of cells), which causes also to reset all surrounding tiles. I don't think that this was the intention of the implementation and could also confuse users (only drawback I can see = it could have an impact on AUTO-TILES directly surrounding the deleted ATLAS tile). _Remark: no need to change to "update_cell_bitmask" as the cell is set to empty in this case (-1)._

```
	} else {
		node->update_bitmask_area(Point2(p_pos));
	}
```

Btw. also the comment within the code, indicates that the intention was opposite to the coded solution. With this change, the comment matches exactly.