### PR TITLE
Invert how `global_rate_scale` value works, and rename it to `playback_speed_scale`

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -311,8 +311,8 @@
 		<member name="device" type="String" setter="set_device" getter="get_device" default="&quot;Default&quot;">
 			Name of the current device for audio output (see [method get_device_list]).
 		</member>
-		<member name="global_rate_scale" type="float" setter="set_global_rate_scale" getter="get_global_rate_scale" default="1.0">
-			Scales the rate at which audio is played (i.e. setting it to [code]0.5[/code] will make the audio be played twice as fast).
+		<member name="playback_speed_scale" type="float" setter="set_playback_speed_scale" getter="get_playback_speed_scale" default="1.0">
+			Scales the rate at which audio is played (i.e. setting it to [code]0.5[/code] will make the audio be played at half its speed).
 		</member>
 	</members>
 	<signals>

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -261,11 +261,11 @@ void AudioStreamPlaybackSample::mix(AudioFrame *p_buffer, float p_rate_scale, in
 		sign = -1;
 	}
 
-	float global_rate_scale = AudioServer::get_singleton()->get_global_rate_scale();
-	float base_rate = AudioServer::get_singleton()->get_mix_rate() * global_rate_scale;
+	float base_rate = AudioServer::get_singleton()->get_mix_rate();
 	float srate = base->mix_rate;
 	srate *= p_rate_scale;
-	float fincrement = srate / base_rate;
+	float playback_speed_scale = AudioServer::get_singleton()->get_playback_speed_scale();
+	float fincrement = (srate * playback_speed_scale) / base_rate;
 	int32_t increment = int32_t(MAX(fincrement * MIX_FRAC_LEN, 1));
 	increment *= sign;
 

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -48,9 +48,9 @@ void AudioStreamPlaybackResampled::_begin_resample() {
 
 void AudioStreamPlaybackResampled::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
 	float target_rate = AudioServer::get_singleton()->get_mix_rate();
-	float global_rate_scale = AudioServer::get_singleton()->get_global_rate_scale();
+	float playback_speed_scale = AudioServer::get_singleton()->get_playback_speed_scale();
 
-	uint64_t mix_increment = uint64_t(((get_stream_sampling_rate() * p_rate_scale) / double(target_rate * global_rate_scale)) * double(FP_LEN));
+	uint64_t mix_increment = uint64_t(((get_stream_sampling_rate() * p_rate_scale * playback_speed_scale) / double(target_rate)) * double(FP_LEN));
 
 	for (int i = 0; i < p_frames; i++) {
 		uint32_t idx = CUBIC_INTERP_HISTORY + uint32_t(mix_offset >> FP_BITS);

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -913,14 +913,14 @@ bool AudioServer::is_bus_channel_active(int p_bus, int p_channel) const {
 	return buses[p_bus]->channels[p_channel].active;
 }
 
-void AudioServer::set_global_rate_scale(float p_scale) {
+void AudioServer::set_playback_speed_scale(float p_scale) {
 	ERR_FAIL_COND(p_scale <= 0);
 
-	global_rate_scale = p_scale;
+	playback_speed_scale = p_scale;
 }
 
-float AudioServer::get_global_rate_scale() const {
-	return global_rate_scale;
+float AudioServer::get_playback_speed_scale() const {
+	return playback_speed_scale;
 }
 
 void AudioServer::init_channels_and_buffers() {
@@ -1277,8 +1277,8 @@ void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_bus_peak_volume_left_db", "bus_idx", "channel"), &AudioServer::get_bus_peak_volume_left_db);
 	ClassDB::bind_method(D_METHOD("get_bus_peak_volume_right_db", "bus_idx", "channel"), &AudioServer::get_bus_peak_volume_right_db);
 
-	ClassDB::bind_method(D_METHOD("set_global_rate_scale", "scale"), &AudioServer::set_global_rate_scale);
-	ClassDB::bind_method(D_METHOD("get_global_rate_scale"), &AudioServer::get_global_rate_scale);
+	ClassDB::bind_method(D_METHOD("set_playback_speed_scale", "scale"), &AudioServer::set_playback_speed_scale);
+	ClassDB::bind_method(D_METHOD("get_playback_speed_scale"), &AudioServer::get_playback_speed_scale);
 
 	ClassDB::bind_method(D_METHOD("lock"), &AudioServer::lock);
 	ClassDB::bind_method(D_METHOD("unlock"), &AudioServer::unlock);
@@ -1302,7 +1302,7 @@ void AudioServer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bus_count"), "set_bus_count", "get_bus_count");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "device"), "set_device", "get_device");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "global_rate_scale"), "set_global_rate_scale", "get_global_rate_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_speed_scale"), "set_playback_speed_scale", "get_playback_speed_scale");
 
 	ADD_SIGNAL(MethodInfo("bus_layout_changed"));
 
@@ -1322,7 +1322,7 @@ AudioServer::AudioServer() {
 #endif
 	mix_time = 0;
 	mix_size = 0;
-	global_rate_scale = 1;
+	playback_speed_scale = 1;
 }
 
 AudioServer::~AudioServer() {

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -177,7 +177,7 @@ private:
 	int channel_count;
 	int to_mix;
 
-	float global_rate_scale;
+	float playback_speed_scale;
 
 	struct Bus {
 		StringName name;
@@ -316,8 +316,8 @@ public:
 
 	bool is_bus_channel_active(int p_bus, int p_channel) const;
 
-	void set_global_rate_scale(float p_scale);
-	float get_global_rate_scale() const;
+	void set_playback_speed_scale(float p_scale);
+	float get_playback_speed_scale() const;
 
 	virtual void init();
 	virtual void finish();


### PR DESCRIPTION
Currently, setting `global_rate_scale` to low value makes the audio go faster and vice-versa. This commit inverses it, so a high value makes it go faster and vice-versa. Which I think makes more sense and is easier to understand.