### PR TITLE
GDScript: Add join method on String

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -262,6 +262,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM3R(String, split);
 	VCALL_LOCALMEM3R(String, rsplit);
 	VCALL_LOCALMEM2R(String, split_floats);
+	VCALL_LOCALMEM1R(String, join);
 	VCALL_LOCALMEM0R(String, to_upper);
 	VCALL_LOCALMEM0R(String, to_lower);
 	VCALL_LOCALMEM1R(String, left);
@@ -1731,6 +1732,7 @@ void register_variant_methods() {
 	ADDFUNC3R(STRING, PACKED_STRING_ARRAY, String, split, STRING, "delimiter", BOOL, "allow_empty", INT, "maxsplit", varray(true, 0));
 	ADDFUNC3R(STRING, PACKED_STRING_ARRAY, String, rsplit, STRING, "delimiter", BOOL, "allow_empty", INT, "maxsplit", varray(true, 0));
 	ADDFUNC2R(STRING, PACKED_FLOAT32_ARRAY, String, split_floats, STRING, "delimiter", BOOL, "allow_empty", varray(true));
+	ADDFUNC1R(STRING, STRING, String, join, PACKED_STRING_ARRAY, "parts", varray());
 
 	ADDFUNC0R(STRING, STRING, String, to_upper, varray());
 	ADDFUNC0R(STRING, STRING, String, to_lower, varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -837,6 +837,19 @@
 				Returns a copy of the string with characters removed from the right.
 			</description>
 		</method>
+		<method name="join">
+			<return type="String">
+			</return>
+			<argument index="0" name="parts" type="PackedStringArray">
+			</argument>
+			<description>
+				Return a [String] which is the concatenation of the [code]parts[/code]. The separator between elements is the string providing this method.
+				Example:
+				[codeblock]
+				print(", ".join(["One", "Two", "Three", "Four"]))
+				[/codeblock]
+			</description>
+		</method>
 		<method name="sha1_buffer">
 			<return type="PackedByteArray">
 			</return>


### PR DESCRIPTION
Fix #38526 

I saw in #36311 how Reduz changed the 'join' in the Engine syntax, so I think this syntax correctly.

 `String(delimiter).join(parts)`

Example code:
```
extends Node2D

const uppercase: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
const lowercase: String = "abcdefghijklmnopqrstuvwxyz"
const alphabetic: String = uppercase + lowercase
const numeric: String = "0123456789"
const alphanumeric: String = alphabetic + numeric

func _ready() :
	print(string(10))
	

# Generate fixed-sized string with charset symbols
func string(length: int, charset: String = alphanumeric) -> String:
	randomize()

	var output: PackedStringArray

	while output.size() < length:
		output.append(charset[randi() % charset.length()])

	return String("").join(output)
```

If this is approved, I'll make the documentation.

Note: This syntax is like Python
`"".join(output)` is valid too