### PR TITLE
Change the AudioServer default peak_volume to (-200, -200)

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -406,7 +406,7 @@ void AudioServer::_mix_step() {
 
 			AudioFrame *buf = bus->channels.write[k].buffer.ptrw();
 
-			AudioFrame peak = AudioFrame(0, 0);
+			AudioFrame peak = AudioFrame(-200, -200);
 
 			float volume = Math::db2linear(bus->volume_db);
 

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -199,7 +199,7 @@ private:
 				last_mix_with_audio = 0;
 				used = false;
 				active = false;
-				peak_volume = AudioFrame(0, 0);
+				peak_volume = AudioFrame(-200, -200);
 			}
 		};
 


### PR DESCRIPTION
This change was made in response to #37562. It doesn't fix the problem as described, but it does make the behavior more consistent. A better fix can be applied later if someone wants to make one.