### PR TITLE
Added mapping for KEY_MENU to VK_APPS (0x5d) so context menu's triggered by the keyboard menu button work

### DIFF
--- a/platform/windows/key_mapping_windows.cpp
+++ b/platform/windows/key_mapping_windows.cpp
@@ -130,7 +130,7 @@ static _WinTranslatePair _vk_to_keycode[] = {
 
 	{ KEY_MASK_META, VK_LWIN }, //(0x5B)
 	{ KEY_MASK_META, VK_RWIN }, //(0x5C)
-	//VK_APPS (0x5D)
+	{ KEY_MENU, VK_APPS }, //(0x5D)
 	{ KEY_STANDBY, VK_SLEEP }, //(0x5F)
 	{ KEY_KP_0, VK_NUMPAD0 }, //(0x60)
 	{ KEY_KP_1, VK_NUMPAD1 }, //(0x61)


### PR DESCRIPTION
Menu key (https://en.wikipedia.org/wiki/Menu_key) maps to 0x5d (VK_APPS), but was not mapped for Windows, so thus would not work. Now the event is properly triggered when this button is pressed. 

Easiest way to test is with a LineEdit.