### PR TITLE
Reveals Button "icon_color" style properties to the user

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -139,6 +139,21 @@
 		<theme_item name="hseparation" type="int" default="2">
 			The horizontal space between [Button]'s icon and text.
 		</theme_item>
+		<theme_item name="icon_disabled_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			Icon modulate [Color] used when the [Button] is disabled.
+		</theme_item>
+		<theme_item name="icon_hover_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			Icon modulate [Color] used when the [Button] is being hovered.
+		</theme_item>
+		<theme_item name="icon_hover_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			Icon modulate [Color] used when the [Button] is being hovered and pressed.
+		</theme_item>
+		<theme_item name="icon_normal_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			Default icon [Color] of the [Button].
+		</theme_item>
+		<theme_item name="icon_pressed_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			Icon modulate [Color] used when the [Button] is being pressed.
+		</theme_item>
 		<theme_item name="normal" type="StyleBox">
 			Default [StyleBox] for the [Button].
 		</theme_item>

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -191,6 +191,12 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_disabled_color", "Button", control_font_disabled_color);
 	theme->set_color("font_outline_color", "Button", Color(1, 1, 1));
 
+	theme->set_color("icon_normal_color", "Button", Color(1, 1, 1, 1));
+	theme->set_color("icon_pressed_color", "Button", Color(1, 1, 1, 1));
+	theme->set_color("icon_hover_color", "Button", Color(1, 1, 1, 1));
+	theme->set_color("icon_hover_pressed_color", "Button", Color(1, 1, 1, 1));
+	theme->set_color("icon_disabled_color", "Button", Color(1, 1, 1, 1));
+
 	theme->set_constant("hseparation", "Button", 2 * scale);
 
 	// LinkButton


### PR DESCRIPTION
Reveals several Button styles which are currently hidden from the user:
![image](https://user-images.githubusercontent.com/3036176/81376254-d1474c80-910b-11ea-8b06-2b5304982f04.png)
