### PR TITLE
Add a project setting to control texture LOD bias

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1715,6 +1715,10 @@
 			Sets the maximum number of samples to take when using anisotropic filtering on textures (as a power of two). A higher sample count will result in sharper textures at oblique angles, but is more expensive to compute. A value of [code]0[/code] forcibly disables anisotropic filtering, even on materials where it is enabled.
 			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this setting at run-time.
 		</member>
+		<member name="rendering/quality/default_filters/mipmap_lod_bias" type="float" setter="" getter="" default="0.0">
+			Controls the LOD bias to use for [i]all[/i] mipmapped textures. Positive values will make mipmapped textures appear blurrier, whereas negative values will make mipmapped textures appear sharper. This can be used as a cheaper complement or alternative to anisotropic filtering, especially on platforms with low memory bandwidth such as integrated graphics or mobile platforms. However, a LOD bias that's too low will result in mipmapped textures having a grainy appearance. Recommended values are between [code]-1.0[/code] and [code]0.0[/code].
+			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this setting at run-time.
+		</member>
 		<member name="rendering/textures/default_filters/use_nearest_mipmap_filter" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], uses nearest-neighbor mipmap filtering when using mipmaps (also called "bilinear filtering"), which will result in visible seams appearing between mipmap stages. This may increase performance in mobile as less memory bandwidth is used. If [code]false[/code], linear mipmap filtering (also called "trilinear filtering") is used.
 			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this setting at run-time.

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -9135,6 +9135,7 @@ RendererStorageRD::RendererStorageRD() {
 					} else {
 						sampler_state.mip_filter = RD::SAMPLER_FILTER_LINEAR;
 					}
+					sampler_state.lod_bias = GLOBAL_GET("rendering/quality/default_filters/mipmap_lod_bias");
 				} break;
 				case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS: {
 					sampler_state.mag_filter = RD::SAMPLER_FILTER_LINEAR;
@@ -9144,6 +9145,7 @@ RendererStorageRD::RendererStorageRD() {
 					} else {
 						sampler_state.mip_filter = RD::SAMPLER_FILTER_LINEAR;
 					}
+					sampler_state.lod_bias = GLOBAL_GET("rendering/quality/default_filters/mipmap_lod_bias");
 
 				} break;
 				case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC: {
@@ -9156,6 +9158,7 @@ RendererStorageRD::RendererStorageRD() {
 					}
 					sampler_state.use_anisotropy = true;
 					sampler_state.anisotropy_max = 1 << int(GLOBAL_GET("rendering/textures/default_filters/anisotropic_filtering_level"));
+					sampler_state.lod_bias = GLOBAL_GET("rendering/quality/default_filters/mipmap_lod_bias");
 				} break;
 				case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC: {
 					sampler_state.mag_filter = RD::SAMPLER_FILTER_LINEAR;
@@ -9167,7 +9170,7 @@ RendererStorageRD::RendererStorageRD() {
 					}
 					sampler_state.use_anisotropy = true;
 					sampler_state.anisotropy_max = 1 << int(GLOBAL_GET("rendering/textures/default_filters/anisotropic_filtering_level"));
-
+					sampler_state.lod_bias = GLOBAL_GET("rendering/quality/default_filters/mipmap_lod_bias");
 				} break;
 				default: {
 				}
@@ -9177,7 +9180,6 @@ RendererStorageRD::RendererStorageRD() {
 					sampler_state.repeat_u = RD::SAMPLER_REPEAT_MODE_CLAMP_TO_EDGE;
 					sampler_state.repeat_v = RD::SAMPLER_REPEAT_MODE_CLAMP_TO_EDGE;
 					sampler_state.repeat_w = RD::SAMPLER_REPEAT_MODE_CLAMP_TO_EDGE;
-
 				} break;
 				case RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED: {
 					sampler_state.repeat_u = RD::SAMPLER_REPEAT_MODE_REPEAT;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2830,6 +2830,9 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF_RST("rendering/textures/default_filters/anisotropic_filtering_level", 2);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/textures/default_filters/anisotropic_filtering_level", PropertyInfo(Variant::INT, "rendering/textures/default_filters/anisotropic_filtering_level", PROPERTY_HINT_ENUM, "Disabled (Fastest),2x (Faster),4x (Fast),8x (Average),16x (Slow)"));
 
+	GLOBAL_DEF_RST("rendering/quality/default_filters/mipmap_lod_bias", 0.0);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/default_filters/mipmap_lod_bias", PropertyInfo(Variant::FLOAT, "rendering/quality/default_filters/mipmap_lod_bias", PROPERTY_HINT_RANGE, "-16,16,0.01"));
+
 	GLOBAL_DEF("rendering/camera/depth_of_field/depth_of_field_bokeh_shape", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/camera/depth_of_field/depth_of_field_bokeh_shape", PropertyInfo(Variant::INT, "rendering/camera/depth_of_field/depth_of_field_bokeh_shape", PROPERTY_HINT_ENUM, "Box (Fast),Hexagon (Average),Circle (Slowest)"));
 	GLOBAL_DEF("rendering/camera/depth_of_field/depth_of_field_bokeh_quality", 1);


### PR DESCRIPTION
This setting controls the LOD bias to use for mipmapped textures. Positive values will make mipmapped textures appear blurrier, whereas negative values will make mipmapped textures appear sharper.

This LOD bias can be used as a cheaper complement or alternative to anisotropic filtering, especially on platforms with low memory bandwidth such as integrated graphics or mobile platforms. However, a LOD bias that's too low will result in mipmapped textures having a grainy appearance.

## Preview

### LOD bias -1 (sharp)

![bias_-1](https://user-images.githubusercontent.com/180032/81413798-58191b00-9146-11ea-9b25-fa1887432c5d.png)

### LOD bias 0 (default)

![bias_0](https://user-images.githubusercontent.com/180032/81413801-594a4800-9146-11ea-9eec-b63f006dde8c.png)

### LOD bias 1 (blurry)

![bias_1](https://user-images.githubusercontent.com/180032/81413804-59e2de80-9146-11ea-8a1b-8ba3aa3da9c8.png)