### PR TITLE
Mention gotcha about how gizmos affect transform notifications

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -244,7 +244,7 @@
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
-				Sets whether the node notifies about its global and local transformation changes. [Node3D] will not propagate this by default.
+				Sets whether the node notifies about its global and local transformation changes. [Node3D] will not propagate this by default, unless it is in the editor context and it has a valid gizmo.
 			</description>
 		</method>
 		<method name="show">
@@ -336,7 +336,7 @@
 	<constants>
 		<constant name="NOTIFICATION_TRANSFORM_CHANGED" value="2000">
 			Node3D nodes receives this notification when their global transform changes. This means that either the current or a parent node changed its transform.
-			In order for [constant NOTIFICATION_TRANSFORM_CHANGED] to work, users first need to ask for it, with [method set_notify_transform].
+			In order for [constant NOTIFICATION_TRANSFORM_CHANGED] to work, users first need to ask for it, with [method set_notify_transform]. The notification is also sent if the node is in the editor context and it has a valid gizmo.
 		</constant>
 		<constant name="NOTIFICATION_ENTER_WORLD" value="41">
 			Node3D nodes receives this notification when they are registered to new [World3D] resource.


### PR DESCRIPTION
While looking into #37283, I discovered that 3D nodes propagate NOTIFICATION_TRANSFORM_CHANGED if either the user asked for it with `set_notify_transform_changed()` or if the node had a valid gizmo. I wanted to share this gotcha, which I think will help users understand why they may get endless transform notifications even if they set the node to not notify about transform changes.