### PR TITLE
Rename Lineshape's d to distance

### DIFF
--- a/doc/classes/LineShape2D.xml
+++ b/doc/classes/LineShape2D.xml
@@ -11,7 +11,7 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="d" type="float" setter="set_d" getter="get_d" default="0.0">
+		<member name="distance" type="float" setter="set_distance" getter="get_distance" default="0.0">
 			The line's distance from the origin.
 		</member>
 		<member name="normal" type="Vector2" setter="set_normal" getter="get_normal" default="Vector2( 0, 1 )">

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -81,7 +81,7 @@ Variant CollisionShape2DEditor::get_handle_value(int idx) const {
 			Ref<LineShape2D> line = node->get_shape();
 
 			if (idx == 0) {
-				return line->get_d();
+				return line->get_distance();
 			} else {
 				return line->get_normal();
 			}
@@ -162,7 +162,7 @@ void CollisionShape2DEditor::set_handle(int idx, Point2 &p_point) {
 				Ref<LineShape2D> line = node->get_shape();
 
 				if (idx == 0) {
-					line->set_d(p_point.length());
+					line->set_distance(p_point.length());
 				} else {
 					line->set_normal(p_point.normalized());
 				}
@@ -260,9 +260,9 @@ void CollisionShape2DEditor::commit_handle(int idx, Variant &p_org) {
 			Ref<LineShape2D> line = node->get_shape();
 
 			if (idx == 0) {
-				undo_redo->add_do_method(line.ptr(), "set_d", line->get_d());
+				undo_redo->add_do_method(line.ptr(), "set_distance", line->get_distance());
 				undo_redo->add_do_method(canvas_item_editor, "update_viewport");
-				undo_redo->add_undo_method(line.ptr(), "set_d", p_org);
+				undo_redo->add_undo_method(line.ptr(), "set_distance", p_org);
 				undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
 			} else {
 				undo_redo->add_do_method(line.ptr(), "set_normal", line->get_normal());
@@ -485,8 +485,8 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 			Ref<LineShape2D> shape = node->get_shape();
 
 			handles.resize(2);
-			handles.write[0] = shape->get_normal() * shape->get_d();
-			handles.write[1] = shape->get_normal() * (shape->get_d() + 30.0);
+			handles.write[0] = shape->get_normal() * shape->get_distance();
+			handles.write[1] = shape->get_normal() * (shape->get_distance() + 30.0);
 
 			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
 			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);

--- a/scene/resources/line_shape_2d.cpp
+++ b/scene/resources/line_shape_2d.cpp
@@ -35,7 +35,7 @@
 
 bool LineShape2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
 
-	Vector2 point = get_d() * get_normal();
+	Vector2 point = get_distance() * get_normal();
 	Vector2 l[2][2] = { { point - get_normal().tangent() * 100, point + get_normal().tangent() * 100 }, { point, point + get_normal() * 30 } };
 
 	for (int i = 0; i < 2; i++) {
@@ -51,7 +51,7 @@ void LineShape2D::_update_shape() {
 
 	Array arr;
 	arr.push_back(normal);
-	arr.push_back(d);
+	arr.push_back(distance);
 	PhysicsServer2D::get_singleton()->shape_set_data(get_rid(), arr);
 	emit_changed();
 }
@@ -62,9 +62,9 @@ void LineShape2D::set_normal(const Vector2 &p_normal) {
 	_update_shape();
 }
 
-void LineShape2D::set_d(real_t p_d) {
+void LineShape2D::set_distance(real_t p_distance) {
 
-	d = p_d;
+	distance = p_distance;
 	_update_shape();
 }
 
@@ -72,14 +72,14 @@ Vector2 LineShape2D::get_normal() const {
 
 	return normal;
 }
-real_t LineShape2D::get_d() const {
+real_t LineShape2D::get_distance() const {
 
-	return d;
+	return distance;
 }
 
 void LineShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 
-	Vector2 point = get_d() * get_normal();
+	Vector2 point = get_distance() * get_normal();
 
 	Vector2 l1[2] = { point - get_normal().tangent() * 100, point + get_normal().tangent() * 100 };
 	RS::get_singleton()->canvas_item_add_line(p_to_rid, l1[0], l1[1], p_color, 3);
@@ -88,7 +88,7 @@ void LineShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 }
 Rect2 LineShape2D::get_rect() const {
 
-	Vector2 point = get_d() * get_normal();
+	Vector2 point = get_distance() * get_normal();
 
 	Vector2 l1[2] = { point - get_normal().tangent() * 100, point + get_normal().tangent() * 100 };
 	Vector2 l2[2] = { point, point + get_normal() * 30 };
@@ -101,7 +101,7 @@ Rect2 LineShape2D::get_rect() const {
 }
 
 real_t LineShape2D::get_enclosing_radius() const {
-	return d;
+	return distance;
 }
 
 void LineShape2D::_bind_methods() {
@@ -109,17 +109,17 @@ void LineShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_normal", "normal"), &LineShape2D::set_normal);
 	ClassDB::bind_method(D_METHOD("get_normal"), &LineShape2D::get_normal);
 
-	ClassDB::bind_method(D_METHOD("set_d", "d"), &LineShape2D::set_d);
-	ClassDB::bind_method(D_METHOD("get_d"), &LineShape2D::get_d);
+	ClassDB::bind_method(D_METHOD("set_distance", "distance"), &LineShape2D::set_distance);
+	ClassDB::bind_method(D_METHOD("get_distance"), &LineShape2D::get_distance);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "normal"), "set_normal", "get_normal");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "d"), "set_d", "get_d");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "distance"), "set_distance", "get_distance");
 }
 
 LineShape2D::LineShape2D() :
 		Shape2D(PhysicsServer2D::get_singleton()->line_shape_create()) {
 
 	normal = Vector2(0, 1);
-	d = 0;
+	distance = 0;
 	_update_shape();
 }

--- a/scene/resources/line_shape_2d.h
+++ b/scene/resources/line_shape_2d.h
@@ -37,7 +37,7 @@ class LineShape2D : public Shape2D {
 	GDCLASS(LineShape2D, Shape2D);
 
 	Vector2 normal;
-	real_t d;
+	real_t distance;
 
 	void _update_shape();
 
@@ -48,10 +48,10 @@ public:
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
 
 	void set_normal(const Vector2 &p_normal);
-	void set_d(real_t p_d);
+	void set_distance(real_t p_distance);
 
 	Vector2 get_normal() const;
-	real_t get_d() const;
+	real_t get_distance() const;
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color);
 	virtual Rect2 get_rect() const;


### PR DESCRIPTION
Why?
1. D could stand for anything, its very undescriptive
2. Other classes and variables aren't named like this, it is position not p for example

I updated docs as well to match. Yes it probably breaks compact but it's 4.0 so this is the right time :P