### PR TITLE
Fix being able to create invalid shapes with Capsule Shape 2D

### DIFF
--- a/scene/resources/capsule_shape_2d.cpp
+++ b/scene/resources/capsule_shape_2d.cpp
@@ -61,6 +61,12 @@ void CapsuleShape2D::_update_shape() {
 void CapsuleShape2D::set_radius(real_t p_radius) {
 
 	radius = p_radius;
+
+	// Prevent invalid shape
+	if (radius > height) {
+		radius = height;
+	}
+
 	_update_shape();
 }
 
@@ -72,6 +78,12 @@ real_t CapsuleShape2D::get_radius() const {
 void CapsuleShape2D::set_height(real_t p_height) {
 
 	height = p_height;
+
+	// Prevent invalid shape
+	if (radius > height) {
+		radius = height;
+	}
+
 	_update_shape();
 }
 


### PR DESCRIPTION
Fixes #38514 by preventing the radius from ever being greater than the height.