### PR TITLE
Use a different icon for the debugger tab with both warnings and errors

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -261,10 +261,12 @@ void EditorDebuggerNode::_notification(int p_what) {
 			debugger_button->set_icon(Ref<Texture2D>());
 		} else {
 			debugger_button->set_text(TTR("Debugger") + " (" + itos(error_count + warning_count) + ")");
-			if (error_count == 0) {
-				debugger_button->set_icon(get_theme_icon("Warning", "EditorIcons"));
-			} else {
+			if (error_count >= 1 && warning_count >= 1) {
+				debugger_button->set_icon(get_theme_icon("ErrorWarning", "EditorIcons"));
+			} else if (error_count >= 1) {
 				debugger_button->set_icon(get_theme_icon("Error", "EditorIcons"));
+			} else {
+				debugger_button->set_icon(get_theme_icon("Warning", "EditorIcons"));
 			}
 		}
 		last_error_count = error_count;

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -130,10 +130,12 @@ void ScriptEditorDebugger::update_tabs() {
 		tabs->set_tab_icon(errors_tab->get_index(), Ref<Texture2D>());
 	} else {
 		errors_tab->set_name(TTR("Errors") + " (" + itos(error_count + warning_count) + ")");
-		if (error_count == 0) {
-			tabs->set_tab_icon(errors_tab->get_index(), get_theme_icon("Warning", "EditorIcons"));
-		} else {
+		if (error_count >= 1 && warning_count >= 1) {
+			tabs->set_tab_icon(errors_tab->get_index(), get_theme_icon("ErrorWarning", "EditorIcons"));
+		} else if (error_count >= 1) {
 			tabs->set_tab_icon(errors_tab->get_index(), get_theme_icon("Error", "EditorIcons"));
+		} else {
+			tabs->set_tab_icon(errors_tab->get_index(), get_theme_icon("Warning", "EditorIcons"));
 		}
 	}
 }

--- a/editor/icons/ErrorWarning.svg
+++ b/editor/icons/ErrorWarning.svg
@@ -1,0 +1,1 @@
+<svg height="8" viewBox="0 0 8 8" width="8" xmlns="http://www.w3.org/2000/svg"><path d="m4 0c-2.216 0-4 1.784-4 4s1.784 4 4 4z" fill="#ff5d5d"/><path d="m4 .00000003c2.216 0 4 1.78399997 4 3.99999997s-1.784 4-4 4z" fill="#ffdd65"/></svg>


### PR DESCRIPTION
This makes it possible to see if both errors and warnings were pushed without having to open the tab.

## Preview

![Errors and warnings icon](https://user-images.githubusercontent.com/180032/81475079-0e920400-920a-11ea-8ff6-1924bc6c342f.png)