### PR TITLE
Use a right-click context menu for editor log actions

### DIFF
--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -31,15 +31,15 @@
 #ifndef EDITOR_LOG_H
 #define EDITOR_LOG_H
 
-#include "scene/gui/control.h"
-#include "scene/gui/label.h"
-#include "scene/gui/rich_text_label.h"
-#include "scene/gui/texture_button.h"
-//#include "scene/gui/empty_control.h"
 #include "core/os/thread.h"
 #include "pane_drag.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/control.h"
+#include "scene/gui/label.h"
 #include "scene/gui/panel_container.h"
+#include "scene/gui/popup_menu.h"
+#include "scene/gui/rich_text_label.h"
+#include "scene/gui/texture_button.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tool_button.h"
 
@@ -47,12 +47,9 @@ class EditorLog : public VBoxContainer {
 
 	GDCLASS(EditorLog, VBoxContainer);
 
-	Button *clearbutton;
-	Button *copybutton;
 	Label *title;
 	RichTextLabel *log;
-	HBoxContainer *title_hb;
-	//PaneDrag *pd;
+	PopupMenu *context_menu;
 	ToolButton *tool_button;
 
 	static void _error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, ErrorHandlerType p_type);
@@ -61,10 +58,11 @@ class EditorLog : public VBoxContainer {
 
 	Thread::ID current;
 
-	//void _dragged(const Point2& p_ofs);
 	void _clear_request();
 	void _copy_request();
 	static void _undo_redo_cbk(void *p_self, const String &p_name);
+	void _gui_input(const Ref<InputEvent> &p_event);
+	void _on_context_menu_item_selected(int action_id);
 
 protected:
 	static void _bind_methods();
@@ -76,6 +74,11 @@ public:
 		MSG_TYPE_ERROR,
 		MSG_TYPE_WARNING,
 		MSG_TYPE_EDITOR
+	};
+
+	enum ContextAction {
+		CONTEXT_COPY = 0,
+		CONTEXT_CLEAR,
 	};
 
 	void add_message(const String &p_msg, MessageType p_type = MSG_TYPE_STD);


### PR DESCRIPTION
This makes it possible to remove the top "Output:" line, increasing the space available to display the output (or the editor viewport).

The Clear shortcut isn't working anymore, I don't know why. I tried making it "global" by setting the last parameter of `add_shortcut()` to `true` to no avail. Any pointers?

## Preview

### Before

![Editor Output panel](https://user-images.githubusercontent.com/180032/81477228-f379c100-9216-11ea-9e24-9bff596c7a00.png)

### After

![Editor Output panel](https://user-images.githubusercontent.com/180032/81477227-f2e12a80-9216-11ea-8478-d64b4a4de1ea.png)