### PR TITLE
Mono: Use msbuild instead of nuget.exe for restoring

### DIFF
--- a/modules/mono/build_scripts/godot_tools_build.py
+++ b/modules/mono/build_scripts/godot_tools_build.py
@@ -13,13 +13,9 @@ def build_godot_tools(source, target, env):
     solution_path = os.path.join(module_dir, "editor/GodotTools/GodotTools.sln")
     build_config = "Debug" if env["target"] == "debug" else "Release"
 
-    # Custom build target to make sure output is always copied to the data dir.
-    extra_build_args = ["/Target:Build;GodotTools:BuildAlwaysCopyToDataDir"]
+    from .solution_builder import build_solution
 
-    from .solution_builder import build_solution, nuget_restore
-
-    nuget_restore(env, solution_path)
-    build_solution(env, solution_path, build_config, extra_build_args)
+    build_solution(env, solution_path, build_config, restore=True)
     # No need to copy targets. The GodotTools csproj takes care of copying them.
 
 

--- a/modules/mono/build_scripts/solution_builder.py
+++ b/modules/mono/build_scripts/solution_builder.py
@@ -4,91 +4,19 @@ import os
 verbose = False
 
 
-def find_nuget_unix():
-    import os
-
-    if "NUGET_PATH" in os.environ:
-        hint_path = os.environ["NUGET_PATH"]
-        if os.path.isfile(hint_path) and os.access(hint_path, os.X_OK):
-            return hint_path
-        hint_path = os.path.join(hint_path, "nuget")
-        if os.path.isfile(hint_path) and os.access(hint_path, os.X_OK):
-            return hint_path
-
-    import os.path
-    import sys
-
-    hint_dirs = ["/opt/novell/mono/bin"]
-    if sys.platform == "darwin":
-        hint_dirs = [
-            "/Library/Frameworks/Mono.framework/Versions/Current/bin",
-            "/usr/local/var/homebrew/linked/mono/bin",
-        ] + hint_dirs
-
-    for hint_dir in hint_dirs:
-        hint_path = os.path.join(hint_dir, "nuget")
-        if os.path.isfile(hint_path):
-            return hint_path
-        elif os.path.isfile(hint_path + ".exe"):
-            return hint_path + ".exe"
-
-    for hint_dir in os.environ["PATH"].split(os.pathsep):
-        hint_dir = hint_dir.strip('"')
-        hint_path = os.path.join(hint_dir, "nuget")
-        if os.path.isfile(hint_path) and os.access(hint_path, os.X_OK):
-            return hint_path
-        if os.path.isfile(hint_path + ".exe") and os.access(hint_path + ".exe", os.X_OK):
-            return hint_path + ".exe"
-
-    return None
-
-
-def find_nuget_windows(env):
-    import os
-
-    if "NUGET_PATH" in os.environ:
-        hint_path = os.environ["NUGET_PATH"]
-        if os.path.isfile(hint_path) and os.access(hint_path, os.X_OK):
-            return hint_path
-        hint_path = os.path.join(hint_path, "nuget.exe")
-        if os.path.isfile(hint_path) and os.access(hint_path, os.X_OK):
-            return hint_path
-
-    from .mono_reg_utils import find_mono_root_dir
-
-    mono_root = env["mono_prefix"] or find_mono_root_dir(env["bits"])
-
-    if mono_root:
-        mono_bin_dir = os.path.join(mono_root, "bin")
-        nuget_mono = os.path.join(mono_bin_dir, "nuget.bat")
-
-        if os.path.isfile(nuget_mono):
-            return nuget_mono
-
-    # Standalone NuGet
-
-    for hint_dir in os.environ["PATH"].split(os.pathsep):
-        hint_dir = hint_dir.strip('"')
-        hint_path = os.path.join(hint_dir, "nuget.exe")
-        if os.path.isfile(hint_path) and os.access(hint_path, os.X_OK):
-            return hint_path
-
-    return None
-
-
 def find_msbuild_unix(filename):
     import os.path
     import sys
 
-    hint_dirs = ["/opt/novell/mono/bin"]
+    hint_dirs = []
     if sys.platform == "darwin":
-        hint_dirs = [
+        hint_dirs[:0] = [
             "/Library/Frameworks/Mono.framework/Versions/Current/bin",
             "/usr/local/var/homebrew/linked/mono/bin",
-        ] + hint_dirs
+        ]
 
     for hint_dir in hint_dirs:
-        hint_path = os.path.join(hint_dir, filename)
+        hint_path = os.path.join(hint_dir, "msbuild")
         if os.path.isfile(hint_path):
             return hint_path
         elif os.path.isfile(hint_path + ".exe"):
@@ -96,7 +24,7 @@ def find_msbuild_unix(filename):
 
     for hint_dir in os.environ["PATH"].split(os.pathsep):
         hint_dir = hint_dir.strip('"')
-        hint_path = os.path.join(hint_dir, filename)
+        hint_path = os.path.join(hint_dir, "msbuild")
         if os.path.isfile(hint_path) and os.access(hint_path, os.X_OK):
             return hint_path
         if os.path.isfile(hint_path + ".exe") and os.access(hint_path + ".exe", os.X_OK):
@@ -162,18 +90,11 @@ def nuget_restore(env, *args):
     global verbose
     verbose = env["verbose"]
 
-    # Find NuGet
-    nuget_path = find_nuget_windows(env) if os.name == "nt" else find_nuget_unix()
-    if nuget_path is None:
-        raise RuntimeError("Cannot find NuGet executable")
-
-    print("NuGet path: " + nuget_path)
-
     # Do NuGet restore
     run_command(nuget_path, ["restore"] + list(args), name="nuget restore")
 
 
-def build_solution(env, solution_path, build_config, extra_msbuild_args=[]):
+def build_solution(env, solution_path, build_config, extra_msbuild_args=[], restore=False):
     global verbose
     verbose = env["verbose"]
 
@@ -193,28 +114,17 @@ def build_solution(env, solution_path, build_config, extra_msbuild_args=[]):
     else:
         msbuild_path = find_msbuild_unix("msbuild")
         if msbuild_path is None:
-            xbuild_fallback = env["xbuild_fallback"]
-
-            if xbuild_fallback and os.name == "nt":
-                print("Option 'xbuild_fallback' not supported on Windows")
-                xbuild_fallback = False
-
-            if xbuild_fallback:
-                print("Cannot find MSBuild executable, trying with xbuild")
-                print("Warning: xbuild is deprecated")
-
-                msbuild_path = find_msbuild_unix("xbuild")
-
-                if msbuild_path is None:
-                    raise RuntimeError("Cannot find xbuild executable")
-            else:
-                raise RuntimeError("Cannot find MSBuild executable")
+            raise RuntimeError("Cannot find MSBuild executable")
 
     print("MSBuild path: " + msbuild_path)
 
     # Build solution
 
-    msbuild_args = [solution_path, "/p:Configuration=" + build_config]
+    targets = ["Build"]
+    if restore:
+        targets.insert(0, "Restore")
+
+    msbuild_args = [solution_path, "/t:%s" % ",".join(targets), "/p:Configuration=" + build_config]
     msbuild_args += extra_msbuild_args
 
     run_command(msbuild_path, msbuild_args, env_override=msbuild_env, name="msbuild")

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -35,7 +35,6 @@ def configure(env):
             "copy_mono_root", "Make a copy of the mono installation directory to bundle with the editor", False
         )
     )
-    envvars.Add(BoolVariable("xbuild_fallback", "If MSBuild is not found, fallback to xbuild", False))
 
     # TODO: It would be great if this could be detected automatically instead
     envvars.Add(

--- a/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
@@ -8,16 +8,21 @@
     <RootNamespace>GodotTools</RootNamespace>
     <AssemblyName>GodotTools</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <GodotSourceRootPath>$(SolutionDir)/../../../../</GodotSourceRootPath>
-    <DataDirToolsOutputPath>$(GodotSourceRootPath)/bin/GodotSharp/Tools</DataDirToolsOutputPath>
-    <GodotApiConfiguration>Debug</GodotApiConfiguration>
     <LangVersion>7</LangVersion>
+    <GodotApiConfiguration>Debug</GodotApiConfiguration> <!-- The Godot editor uses the Debug Godot API assemblies -->
+    <GodotSourceRootPath>$(SolutionDir)/../../../../</GodotSourceRootPath>
+    <GodotOutputDataDir>$(GodotSourceRootPath)/bin/GodotSharp</GodotOutputDataDir>
+    <GodotApiAssembliesDir>$(GodotOutputDataDir)/Api/$(GodotApiConfiguration)</GodotApiAssembliesDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" Exists('$(GodotApiAssembliesDir)/GodotSharp.dll') ">
+    <!-- The project is part of the Godot source tree -->
+    <!-- Use the Godot source tree output folder instead of '$(ProjectDir)/bin' -->
+    <OutputPath>$(GodotOutputDataDir)/Tools</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,7 +30,6 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -41,11 +45,11 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="GodotSharp">
-      <HintPath>$(GodotSourceRootPath)/bin/GodotSharp/Api/$(GodotApiConfiguration)/GodotSharp.dll</HintPath>
+      <HintPath>$(GodotApiAssembliesDir)/GodotSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="GodotSharpEditor">
-      <HintPath>$(GodotSourceRootPath)/bin/GodotSharp/Api/$(GodotApiConfiguration)/GodotSharpEditor.dll</HintPath>
+      <HintPath>$(GodotApiAssembliesDir)/GodotSharpEditor.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -103,21 +107,5 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <Target Name="CopyToDataDir" AfterTargets="Build">
-    <ItemGroup>
-      <GodotToolsCopy Include="$(OutputPath)\GodotTools*.dll" />
-      <GodotToolsCopy Include="$(OutputPath)\Newtonsoft.Json.dll" />
-      <GodotToolsCopy Include="$(OutputPath)\DotNet.Glob.dll" />
-    </ItemGroup>
-    <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
-      <GodotToolsCopy Include="$(OutputPath)\GodotTools*.pdb" />
-    </ItemGroup>
-    <Copy SourceFiles="@(GodotToolsCopy)" DestinationFolder="$(DataDirToolsOutputPath)" ContinueOnError="false" />
-  </Target>
-  <Target Name="BuildAlwaysCopyToDataDir">
-    <!-- Custom target run by SCons to make sure the CopyToDataDir target is always executed, without having to use DisableFastUpToDateCheck -->
-    <CallTarget Targets="Build" />
-    <CallTarget Targets="CopyToDataDir" />
-  </Target>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
- Use msbuild instead of nuget.exe for restoring.
- Make GodotTools output directly to the SCons output directory.
- Removed xbuild_fallback from the build system.
