### PR TITLE
Updated documentations on AnimatedSprites and SpriteFrames with more details

### DIFF
--- a/doc/classes/AnimatedSprite.xml
+++ b/doc/classes/AnimatedSprite.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimatedSprite" inherits="Node2D" version="4.0">
 	<brief_description>
-		Sprite node that can use multiple textures for animation.
+		Sprite node that contains multiple textures as frames to play for animation.
 	</brief_description>
 	<description>
-		Animations are created using a [SpriteFrames] resource, which can be configured in the editor via the SpriteFrames panel.
+		This node is similar to the Sprite node, except instead of the [TextureRegion] resource in the Bottom Panel it has the [SpriteFrames] resource. Animations are created using a [SpriteFrames] resource, where it allows you to import image files (or a folder containing said files) to provide the animation frames for the sprite. The [SpriteFrames] resource can be configured in the editor via the SpriteFrames panel.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -37,7 +37,7 @@
 	</methods>
 	<members>
 		<member name="animation" type="StringName" setter="set_animation" getter="get_animation" default="@&quot;default&quot;">
-			The current animation from the [code]frames[/code] resource. If this value changes, the [code]frame[/code] counter is reset.
+			The current animation from the [SpriteFrames] resource. If this value changes, the [code]frame[/code] counter is reset.
 		</member>
 		<member name="centered" type="bool" setter="set_centered" getter="is_centered" default="true">
 			If [code]true[/code], texture will be centered.
@@ -52,7 +52,7 @@
 			The displayed animation frame's index.
 		</member>
 		<member name="frames" type="SpriteFrames" setter="set_sprite_frames" getter="get_sprite_frames">
-			The [SpriteFrames] resource containing the animation(s).
+			The [SpriteFrames] resource containing the animation(s). Allows you the option to load, edit, clear, make unique and save the states of the [SpriteFrames] resource.
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2( 0, 0 )">
 			The texture's drawing offset.

--- a/doc/classes/AnimatedSprite.xml
+++ b/doc/classes/AnimatedSprite.xml
@@ -4,7 +4,7 @@
 		Sprite node that contains multiple textures as frames to play for animation.
 	</brief_description>
 	<description>
-		This node is similar to the Sprite node, except instead of the [TextureRegion] resource in the Bottom Panel it has the [SpriteFrames] resource. Animations are created using a [SpriteFrames] resource, where it allows you to import image files (or a folder containing said files) to provide the animation frames for the sprite. The [SpriteFrames] resource can be configured in the editor via the SpriteFrames panel.
+		This node is similar to the Sprite node, except it carries multiple textures as animation frames. Animations are created using a [SpriteFrames] resource, where it allows you to import image files (or a folder containing said files) to provide the animation frames for the sprite. The [SpriteFrames] resource can be configured in the editor via the SpriteFrames panel.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -4,7 +4,7 @@
 		Sprite frame library for AnimatedSprite.
 	</brief_description>
 	<description>
-		Sprite frame library for [AnimatedSprite]. Contains frames and animation data for playback.
+		Sprite frame library for [AnimatedSprite]. Contains frames and animation data for playback. You can use imported images (or folders containing compatible images) to be used as animation frames for the animation.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -4,7 +4,7 @@
 		Sprite frame library for AnimatedSprite.
 	</brief_description>
 	<description>
-		Sprite frame library for [AnimatedSprite]. Contains frames and animation data for playback. You can use imported images (or folders containing compatible images) to be used as animation frames for the animation.
+		Sprite frame library for [AnimatedSprite]. Contains frames and animation data for playback. 
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -4,7 +4,7 @@
 		Sprite frame library for AnimatedSprite.
 	</brief_description>
 	<description>
-		Sprite frame library for [AnimatedSprite]. Contains frames and animation data for playback. 
+		Sprite frame library for [AnimatedSprite]. Contains frames and animation data for playback. I've added more details that weren't in the AnimatedSprites doc, such as making the description more specific of its function. The same goes for the SpriteFrames doc.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
I've added more details that weren't in the AnimatedSprites doc, such as making the description more specific of its function. The same goes for the SpriteFrames doc.