### PR TITLE
Rename `AStar.get_points()` to `AStar.get_point_ids()` for clarity

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -210,7 +210,7 @@ bool AStar::has_point(int p_id) const {
 	return points.has(p_id);
 }
 
-Array AStar::get_points() {
+Array AStar::get_point_ids() {
 	Array point_list;
 
 	for (OAHashMap<int, Point *>::Iterator it = points.iter(); it.valid; it = points.next_iter(it)) {
@@ -539,7 +539,7 @@ void AStar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_point", "id"), &AStar::remove_point);
 	ClassDB::bind_method(D_METHOD("has_point", "id"), &AStar::has_point);
 	ClassDB::bind_method(D_METHOD("get_point_connections", "id"), &AStar::get_point_connections);
-	ClassDB::bind_method(D_METHOD("get_points"), &AStar::get_points);
+	ClassDB::bind_method(D_METHOD("get_point_ids"), &AStar::get_point_ids);
 
 	ClassDB::bind_method(D_METHOD("set_point_disabled", "id", "disabled"), &AStar::set_point_disabled, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("is_point_disabled", "id"), &AStar::is_point_disabled);
@@ -606,8 +606,8 @@ Vector<int> AStar2D::get_point_connections(int p_id) {
 	return astar.get_point_connections(p_id);
 }
 
-Array AStar2D::get_points() {
-	return astar.get_points();
+Array AStar2D::get_point_ids() {
+	return astar.get_point_ids();
 }
 
 void AStar2D::set_point_disabled(int p_id, bool p_disabled) {
@@ -859,7 +859,7 @@ void AStar2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_point", "id"), &AStar2D::remove_point);
 	ClassDB::bind_method(D_METHOD("has_point", "id"), &AStar2D::has_point);
 	ClassDB::bind_method(D_METHOD("get_point_connections", "id"), &AStar2D::get_point_connections);
-	ClassDB::bind_method(D_METHOD("get_points"), &AStar2D::get_points);
+	ClassDB::bind_method(D_METHOD("get_point_ids"), &AStar2D::get_point_ids);
 
 	ClassDB::bind_method(D_METHOD("set_point_disabled", "id", "disabled"), &AStar2D::set_point_disabled, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("is_point_disabled", "id"), &AStar2D::is_point_disabled);

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -138,7 +138,7 @@ public:
 	void remove_point(int p_id);
 	bool has_point(int p_id) const;
 	Vector<int> get_point_connections(int p_id);
-	Array get_points();
+	Array get_point_ids();
 
 	void set_point_disabled(int p_id, bool p_disabled = true);
 	bool is_point_disabled(int p_id) const;
@@ -188,7 +188,7 @@ public:
 	void remove_point(int p_id);
 	bool has_point(int p_id) const;
 	Vector<int> get_point_connections(int p_id);
-	Array get_points();
+	Array get_point_ids();
 
 	void set_point_disabled(int p_id, bool p_disabled = true);
 	bool is_point_disabled(int p_id) const;

--- a/doc/classes/AStar.xml
+++ b/doc/classes/AStar.xml
@@ -244,6 +244,12 @@
 				Returns the number of points currently in the points pool.
 			</description>
 		</method>
+		<method name="get_point_ids">
+			<return type="Array" />
+			<description>
+				Returns an array of all point IDs.
+			</description>
+		</method>
 		<method name="get_point_path">
 			<return type="PackedVector3Array" />
 			<argument index="0" name="from_id" type="int" />
@@ -265,12 +271,6 @@
 			<argument index="0" name="id" type="int" />
 			<description>
 				Returns the weight scale of the point associated with the given [code]id[/code].
-			</description>
-		</method>
-		<method name="get_points">
-			<return type="Array" />
-			<description>
-				Returns an array of all points.
 			</description>
 		</method>
 		<method name="has_point" qualifiers="const">

--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -215,6 +215,12 @@
 				Returns the number of points currently in the points pool.
 			</description>
 		</method>
+		<method name="get_point_ids">
+			<return type="Array" />
+			<description>
+				Returns an array of all point IDs.
+			</description>
+		</method>
 		<method name="get_point_path">
 			<return type="PackedVector2Array" />
 			<argument index="0" name="from_id" type="int" />
@@ -236,12 +242,6 @@
 			<argument index="0" name="id" type="int" />
 			<description>
 				Returns the weight scale of the point associated with the given [code]id[/code].
-			</description>
-		</method>
-		<method name="get_points">
-			<return type="Array" />
-			<description>
-				Returns an array of all points.
 			</description>
 		</method>
 		<method name="has_point" qualifiers="const">


### PR DESCRIPTION
The same has been done for AStar2D as well.

If desired, I could open a PR against the `3.2` branch to update only the method descriptions.

This closes https://github.com/godotengine/godot-docs/issues/3515.