### PR TITLE
[DOCS] minor description changes

### DIFF
--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Engine" inherits="Object" version="4.0">
 	<brief_description>
-		Access to basic engine properties.
+		Access to engine properties.
 	</brief_description>
 	<description>
-		The [Engine] class allows you to query and modify the project's run-time parameters, such as frames per second, time scale, and others.
+		The [Engine] singleton allows you to query and modify the project's run-time parameters, such as frames per second, time scale, and others.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -305,7 +305,7 @@
 			<return type="Node">
 			</return>
 			<description>
-				Returns the parent node of the current node, or an empty [Node] if the node lacks a parent.
+				Returns the parent node of the current node, or a [code]null instance[/code] if the node lacks a parent.
 			</description>
 		</method>
 		<method name="get_path" qualifiers="const">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -309,7 +309,7 @@
 			<argument index="0" name="by" type="Vector3">
 			</argument>
 			<description>
-				Returns a copy of the vector snapped to the lowest neared multiple.
+				Returns the vector snapped to a grid with the given size.
 			</description>
 		</method>
 		<method name="to_diagonal_matrix">


### PR DESCRIPTION
- Vector3: fixed odd wording on `snapped()`
- Engine: mention that it's a singleton, not an object you should create an instance of
- Node: `get_parent()` description was incorrect. Corrected to indicate it returns `null instance` (matching `get_node()` description).  Fixes godotengine/godot-docs#3471