### PR TITLE
Rename the ".import" folder to ".godot/imported"

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -31,6 +31,7 @@
 #include "resource_importer.h"
 
 #include "core/os/os.h"
+#include "core/project_settings.h"
 #include "core/variant_parser.h"
 
 bool ResourceFormatImporter::SortImporterByName::operator()(const Ref<ResourceImporter> &p_a, const Ref<ResourceImporter> &p_b) const {
@@ -374,7 +375,7 @@ Ref<ResourceImporter> ResourceFormatImporter::get_importer_by_extension(const St
 }
 
 String ResourceFormatImporter::get_import_base_path(const String &p_for_file) const {
-	return "res://.import/" + p_for_file.get_file() + "-" + p_for_file.md5_text();
+	return ProjectSettings::IMPORTED_FILES_PATH.plus_file(p_for_file.get_file() + "-" + p_for_file.md5_text());
 }
 
 bool ResourceFormatImporter::are_import_settings_valid(const String &p_path) const {

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -53,6 +53,8 @@ String ProjectSettings::get_resource_path() const {
 	return resource_path;
 }
 
+const String ProjectSettings::IMPORTED_FILES_PATH("res://.godot/imported");
+
 String ProjectSettings::localize_path(const String &p_path) const {
 	if (resource_path == "") {
 		return p_path; //not initialized yet

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -41,6 +41,7 @@ class ProjectSettings : public Object {
 
 public:
 	typedef Map<String, Variant> CustomMap;
+	static const String IMPORTED_FILES_PATH;
 
 	enum {
 		//properties that are not for built in values begin from this value, so builtin ones are displayed first

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		EditorImportPlugins provide a way to extend the editor's resource import functionality. Use them to import resources from custom files or to provide alternatives to the editor's existing importers. Register your [EditorPlugin] with [method EditorPlugin.add_import_plugin].
-		EditorImportPlugins work by associating with specific file extensions and a resource type. See [method get_recognized_extensions] and [method get_resource_type]. They may optionally specify some import presets that affect the import process. EditorImportPlugins are responsible for creating the resources and saving them in the [code].import[/code] directory.
+		EditorImportPlugins work by associating with specific file extensions and a resource type. See [method get_recognized_extensions] and [method get_resource_type]. They may optionally specify some import presets that affect the import process. EditorImportPlugins are responsible for creating the resources and saving them in the [code].godot/imported[/code] directory.
 		Below is an example EditorImportPlugin that imports a [Mesh] from a file with the extension ".special" or ".spec":
 		[codeblock]
 		tool
@@ -136,7 +136,7 @@
 			<return type="String">
 			</return>
 			<description>
-				Gets the extension used to save this resource in the [code].import[/code] directory.
+				Gets the extension used to save this resource in the [code].godot/imported[/code] directory.
 			</description>
 		</method>
 		<method name="get_visible_name" qualifiers="virtual">

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -559,7 +559,7 @@ void EditorFileDialog::_item_list_item_rmb_selected(int p_item, const Vector2 &p
 			continue;
 		}
 		Dictionary item_meta = item_list->get_item_metadata(i);
-		if (item_meta["path"] == "res://.import") {
+		if (String(item_meta["path"]).begins_with("res://.godot")) {
 			allow_delete = false;
 			break;
 		}

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1865,13 +1865,14 @@ void EditorFileSystem::_find_group_files(EditorFileSystemDirectory *efd, Map<Str
 }
 
 void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
-	{ //check that .import folder exists
+	{
+		// Ensure that ProjectSettings::IMPORTED_FILES_PATH exists.
 		DirAccess *da = DirAccess::open("res://");
-		if (da->change_dir(".import") != OK) {
-			Error err = da->make_dir(".import");
-			if (err) {
+		if (da->change_dir(ProjectSettings::IMPORTED_FILES_PATH) != OK) {
+			Error err = da->make_dir_recursive(ProjectSettings::IMPORTED_FILES_PATH);
+			if (err || da->change_dir(ProjectSettings::IMPORTED_FILES_PATH) != OK) {
 				memdelete(da);
-				ERR_FAIL_MSG("Failed to create 'res://.import' folder.");
+				ERR_FAIL_MSG("Failed to create '" + ProjectSettings::IMPORTED_FILES_PATH + "' folder.");
 			}
 		}
 		memdelete(da);
@@ -2055,8 +2056,8 @@ EditorFileSystem::EditorFileSystem() {
 	scanning_changes_done = false;
 
 	DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	if (da->change_dir("res://.import") != OK) {
-		da->make_dir("res://.import");
+	if (da->change_dir(ProjectSettings::IMPORTED_FILES_PATH) != OK) {
+		da->make_dir(ProjectSettings::IMPORTED_FILES_PATH);
 	}
 	// This should probably also work on Unix and use the string it returns for FAT32 or exFAT
 	using_fat32_or_exfat = (da->get_filesystem_type() == "FAT32" || da->get_filesystem_type() == "exFAT");

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2093,7 +2093,8 @@ void ProjectManager::_run_project_confirm() {
 		const String &selected = selected_list[i].project_key;
 		String path = EditorSettings::get_singleton()->get("projects/" + selected);
 
-		if (!DirAccess::exists(path + "/.import")) {
+		// `.right(6)` on `IMPORTED_FILES_PATH` strips away the leading "res://".
+		if (!DirAccess::exists(path.plus_file(ProjectSettings::IMPORTED_FILES_PATH.right(6)))) {
 			run_error_diag->set_text(TTR("Can't run project: Assets need to be imported.\nPlease edit the project to trigger the initial import."));
 			run_error_diag->popup_centered();
 			return;


### PR DESCRIPTION
Fixes #23368, fixes https://github.com/godotengine/godot-proposals/issues/1521. This PR changes the path used for imported files to be constants in ~~`dir_access.h`~~ `project_settings.h`, rather than hard-coded. It also changes the value from `res://.import` to `res://.godot/imported`.

The plan is to make `res://.godot` a general-purpose folder that can be gitignored. We can also move `res://.mono` in here (as `res://.godot/mono`), and move translations here too, possibly also editor data, and any other data that needs to be saved but not committed.

It seems to work fine, I'm able to run test projects, and `.godot/imported` exists while `.import` doesn't, but this definitely needs more testing. I tried opening [sponza 4](https://github.com/Calinou/godot-sponza-4) and for me it behaves the same between master and this PR (in both cases everything is black).