### PR TITLE
Fix for variables losing scope and disappearing from debugger

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1564,6 +1564,13 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 			} break;
 		}
 	}
+
+	// Set the correct end line for p_blocks that have one.
+	// Needed so varaibles within a p_block don't lose scope
+	// on the last line of the p_block for the debugger
+	if (p_block->end_line != -1) {
+		codegen.current_line = p_block->end_line;
+	}
 	codegen.pop_stack_identifiers();
 	return OK;
 }


### PR DESCRIPTION
When breaking on or stepping to the last line of a p_block, the local
variables declared in that scope would be removed from the debugger.
This was because the current_line for removal set in gdscript_compiler.h,
pop_stack_identifiers ended up being the last line of the block, not
the line after. Now we set the current_line to be the end_line of the
p_block, only if the end_line is not -1

Reported: #38206

If anyone sees any issues with this let me know. From what I've seen, the end_line of a p_block was either a valid line or -1, but I could be mistaken. Thank you.

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/53442