### PR TITLE
Renamed plane's d to distance

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -277,7 +277,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 			val.normal.x = decode_float(&buf[0]);
 			val.normal.y = decode_float(&buf[4]);
 			val.normal.z = decode_float(&buf[8]);
-			val.d = decode_float(&buf[12]);
+			val.distance = decode_float(&buf[12]);
 			r_variant = val;
 
 			if (r_len)
@@ -1140,7 +1140,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				encode_float(p.normal.x, &buf[0]);
 				encode_float(p.normal.y, &buf[4]);
 				encode_float(p.normal.z, &buf[8]);
-				encode_float(p.d, &buf[12]);
+				encode_float(p.distance, &buf[12]);
 			}
 
 			r_len += 4 * 4;

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -214,7 +214,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			v.normal.x = f->get_real();
 			v.normal.y = f->get_real();
 			v.normal.z = f->get_real();
-			v.d = f->get_real();
+			v.distance = f->get_real();
 			r_v = v;
 		} break;
 		case VARIANT_QUAT: {
@@ -1458,7 +1458,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(FileAccess *f, const Varia
 			f->store_real(val.normal.x);
 			f->store_real(val.normal.y);
 			f->store_real(val.normal.z);
-			f->store_real(val.d);
+			f->store_real(val.distance);
 
 		} break;
 		case Variant::QUAT: {

--- a/core/math/camera_matrix.cpp
+++ b/core/math/camera_matrix.cpp
@@ -59,10 +59,10 @@ Plane CameraMatrix::xform4(const Plane &p_vec4) const {
 
 	Plane ret;
 
-	ret.normal.x = matrix[0][0] * p_vec4.normal.x + matrix[1][0] * p_vec4.normal.y + matrix[2][0] * p_vec4.normal.z + matrix[3][0] * p_vec4.d;
-	ret.normal.y = matrix[0][1] * p_vec4.normal.x + matrix[1][1] * p_vec4.normal.y + matrix[2][1] * p_vec4.normal.z + matrix[3][1] * p_vec4.d;
-	ret.normal.z = matrix[0][2] * p_vec4.normal.x + matrix[1][2] * p_vec4.normal.y + matrix[2][2] * p_vec4.normal.z + matrix[3][2] * p_vec4.d;
-	ret.d = matrix[0][3] * p_vec4.normal.x + matrix[1][3] * p_vec4.normal.y + matrix[2][3] * p_vec4.normal.z + matrix[3][3] * p_vec4.d;
+	ret.normal.x = matrix[0][0] * p_vec4.normal.x + matrix[1][0] * p_vec4.normal.y + matrix[2][0] * p_vec4.normal.z + matrix[3][0] * p_vec4.distance;
+	ret.normal.y = matrix[0][1] * p_vec4.normal.x + matrix[1][1] * p_vec4.normal.y + matrix[2][1] * p_vec4.normal.z + matrix[3][1] * p_vec4.distance;
+	ret.normal.z = matrix[0][2] * p_vec4.normal.x + matrix[1][2] * p_vec4.normal.y + matrix[2][2] * p_vec4.normal.z + matrix[3][2] * p_vec4.distance;
+	ret.distance = matrix[0][3] * p_vec4.normal.x + matrix[1][3] * p_vec4.normal.y + matrix[2][3] * p_vec4.normal.z + matrix[3][3] * p_vec4.distance;
 	return ret;
 }
 
@@ -233,7 +233,7 @@ real_t CameraMatrix::get_z_far() const {
 	new_plane.normal = -new_plane.normal;
 	new_plane.normalize();
 
-	return new_plane.d;
+	return new_plane.distance;
 }
 real_t CameraMatrix::get_z_near() const {
 
@@ -244,7 +244,7 @@ real_t CameraMatrix::get_z_near() const {
 			-matrix[15] - matrix[14]);
 
 	new_plane.normalize();
-	return new_plane.d;
+	return new_plane.distance;
 }
 
 Vector2 CameraMatrix::get_viewport_half_extents() const {

--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -780,7 +780,7 @@ Geometry::MeshData Geometry::build_convex_mesh(const Vector<Plane> &p_planes) {
 					if (Math::is_zero_approx(den))
 						continue; // Point too short.
 
-					real_t dist = -(clip.normal.dot(edge0_A) - clip.d) / den;
+					real_t dist = -(clip.normal.dot(edge0_A) - clip.distance) / den;
 					Vector3 inters = edge0_A + rel * dist;
 					new_vertices.push_back(inters);
 				}
@@ -1199,7 +1199,7 @@ Vector<Vector3> Geometry::compute_convex_mesh_points(const Plane *p_planes, int 
 					for (int n = 0; n < p_plane_count; n++) {
 						if (n != i && n != j && n != k) {
 							real_t dp = p_planes[n].normal.dot(convex_shape_point);
-							if (dp - p_planes[n].d > CMP_EPSILON) {
+							if (dp - p_planes[n].distance > CMP_EPSILON) {
 								excluded = true;
 								break;
 							}

--- a/core/math/math_fieldwise.cpp
+++ b/core/math/math_fieldwise.cpp
@@ -89,7 +89,7 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 			/**/ TRY_TRANSFER_FIELD("x", normal.x)
 			else TRY_TRANSFER_FIELD("y", normal.y)
 			else TRY_TRANSFER_FIELD("z", normal.z)
-			else TRY_TRANSFER_FIELD("d", d)
+			else TRY_TRANSFER_FIELD("d", distance)
 
 			return target;
 		}

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -45,7 +45,7 @@ void Plane::normalize() {
 		return;
 	}
 	normal /= l;
-	d /= l;
+	distance /= l;
 }
 
 Plane Plane::normalized() const {
@@ -57,7 +57,7 @@ Plane Plane::normalized() const {
 
 Vector3 Plane::get_any_point() const {
 
-	return get_normal() * d;
+	return get_normal() * distance;
 }
 
 Vector3 Plane::get_any_perpendicular_normal() const {
@@ -92,9 +92,9 @@ bool Plane::intersect_3(const Plane &p_plane1, const Plane &p_plane2, Vector3 *r
 		return false;
 
 	if (r_result) {
-		*r_result = ((vec3_cross(normal1, normal2) * p_plane0.d) +
-							(vec3_cross(normal2, normal0) * p_plane1.d) +
-							(vec3_cross(normal0, normal1) * p_plane2.d)) /
+		*r_result = ((vec3_cross(normal1, normal2) * p_plane0.distance) +
+							(vec3_cross(normal2, normal0) * p_plane1.distance) +
+							(vec3_cross(normal0, normal1) * p_plane2.distance)) /
 					denom;
 	}
 
@@ -112,7 +112,7 @@ bool Plane::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 
 		return false;
 	}
 
-	real_t dist = (normal.dot(p_from) - d) / den;
+	real_t dist = (normal.dot(p_from) - distance) / den;
 	//printf("dist is %i\n",dist);
 
 	if (dist > CMP_EPSILON) { //this is a ray, before the emitting pos (p_from) doesn't exist
@@ -137,7 +137,7 @@ bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vec
 		return false;
 	}
 
-	real_t dist = (normal.dot(p_begin) - d) / den;
+	real_t dist = (normal.dot(p_begin) - distance) / den;
 	//printf("dist is %i\n",dist);
 
 	if (dist < -CMP_EPSILON || dist > (1.0 + CMP_EPSILON)) {
@@ -155,10 +155,10 @@ bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vec
 
 bool Plane::is_equal_approx(const Plane &p_plane) const {
 
-	return normal.is_equal_approx(p_plane.normal) && Math::is_equal_approx(d, p_plane.d);
+	return normal.is_equal_approx(p_plane.normal) && Math::is_equal_approx(distance, p_plane.distance);
 }
 
 Plane::operator String() const {
 
-	return normal.operator String() + ", " + rtos(d);
+	return normal.operator String() + ", " + rtos(distance);
 }

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -36,7 +36,7 @@
 class Plane {
 public:
 	Vector3 normal;
-	real_t d;
+	real_t distance;
 
 	void set_normal(const Vector3 &p_normal);
 	_FORCE_INLINE_ Vector3 get_normal() const { return normal; }; ///Point is coplanar, CMP_EPSILON for precision
@@ -46,7 +46,7 @@ public:
 
 	/* Plane-Point operations */
 
-	_FORCE_INLINE_ Vector3 center() const { return normal * d; }
+	_FORCE_INLINE_ Vector3 center() const { return normal * distance; }
 	Vector3 get_any_point() const;
 	Vector3 get_any_perpendicular_normal() const;
 
@@ -67,7 +67,7 @@ public:
 
 	/* misc */
 
-	Plane operator-() const { return Plane(-normal, -d); }
+	Plane operator-() const { return Plane(-normal, -distance); }
 	bool is_equal_approx(const Plane &p_plane) const;
 
 	_FORCE_INLINE_ bool operator==(const Plane &p_plane) const;
@@ -75,41 +75,41 @@ public:
 	operator String() const;
 
 	_FORCE_INLINE_ Plane() :
-			d(0) {}
+			distance(0) {}
 	_FORCE_INLINE_ Plane(real_t p_a, real_t p_b, real_t p_c, real_t p_d) :
 			normal(p_a, p_b, p_c),
-			d(p_d) {}
+			distance(p_d) {}
 
-	_FORCE_INLINE_ Plane(const Vector3 &p_normal, real_t p_d);
+	_FORCE_INLINE_ Plane(const Vector3 &p_normal, real_t p_distance);
 	_FORCE_INLINE_ Plane(const Vector3 &p_point, const Vector3 &p_normal);
 	_FORCE_INLINE_ Plane(const Vector3 &p_point1, const Vector3 &p_point2, const Vector3 &p_point3, ClockDirection p_dir = CLOCKWISE);
 };
 
 bool Plane::is_point_over(const Vector3 &p_point) const {
 
-	return (normal.dot(p_point) > d);
+	return (normal.dot(p_point) > distance);
 }
 
 real_t Plane::distance_to(const Vector3 &p_point) const {
 
-	return (normal.dot(p_point) - d);
+	return (normal.dot(p_point) - distance);
 }
 
 bool Plane::has_point(const Vector3 &p_point, real_t _epsilon) const {
 
-	real_t dist = normal.dot(p_point) - d;
+	real_t dist = normal.dot(p_point) - distance;
 	dist = ABS(dist);
 	return (dist <= _epsilon);
 }
 
-Plane::Plane(const Vector3 &p_normal, real_t p_d) :
+Plane::Plane(const Vector3 &p_normal, real_t p_distance) :
 		normal(p_normal),
-		d(p_d) {
+		distance(p_distance) {
 }
 
 Plane::Plane(const Vector3 &p_point, const Vector3 &p_normal) :
 		normal(p_normal),
-		d(p_normal.dot(p_point)) {
+		distance(p_normal.dot(p_point)) {
 }
 
 Plane::Plane(const Vector3 &p_point1, const Vector3 &p_point2, const Vector3 &p_point3, ClockDirection p_dir) {
@@ -120,17 +120,17 @@ Plane::Plane(const Vector3 &p_point1, const Vector3 &p_point2, const Vector3 &p_
 		normal = (p_point1 - p_point2).cross(p_point1 - p_point3);
 
 	normal.normalize();
-	d = normal.dot(p_point1);
+	distance = normal.dot(p_point1);
 }
 
 bool Plane::operator==(const Plane &p_plane) const {
 
-	return normal == p_plane.normal && d == p_plane.d;
+	return normal == p_plane.normal && distance == p_plane.distance;
 }
 
 bool Plane::operator!=(const Plane &p_plane) const {
 
-	return normal != p_plane.normal || d != p_plane.d;
+	return normal != p_plane.normal || distance != p_plane.distance;
 }
 
 #endif // PLANE_H

--- a/core/math/transform.h
+++ b/core/math/transform.h
@@ -132,7 +132,7 @@ _FORCE_INLINE_ Vector3 Transform::xform_inv(const Vector3 &p_vector) const {
 
 _FORCE_INLINE_ Plane Transform::xform(const Plane &p_plane) const {
 
-	Vector3 point = p_plane.normal * p_plane.d;
+	Vector3 point = p_plane.normal * p_plane.distance;
 	Vector3 point_dir = point + p_plane.normal;
 	point = xform(point);
 	point_dir = xform(point_dir);
@@ -145,7 +145,7 @@ _FORCE_INLINE_ Plane Transform::xform(const Plane &p_plane) const {
 }
 _FORCE_INLINE_ Plane Transform::xform_inv(const Plane &p_plane) const {
 
-	Vector3 point = p_plane.normal * p_plane.d;
+	Vector3 point = p_plane.normal * p_plane.distance;
 	Vector3 point_dir = point + p_plane.normal;
 	xform_inv(point);
 	xform_inv(point_dir);

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -3173,7 +3173,7 @@ uint32_t Variant::hash() const {
 			uint32_t hash = hash_djb2_one_float(reinterpret_cast<const Plane *>(_data._mem)->normal.x);
 			hash = hash_djb2_one_float(reinterpret_cast<const Plane *>(_data._mem)->normal.y, hash);
 			hash = hash_djb2_one_float(reinterpret_cast<const Plane *>(_data._mem)->normal.z, hash);
-			return hash_djb2_one_float(reinterpret_cast<const Plane *>(_data._mem)->d, hash);
+			return hash_djb2_one_float(reinterpret_cast<const Plane *>(_data._mem)->distance, hash);
 
 		} break;
 		/*
@@ -3521,7 +3521,7 @@ bool Variant::hash_compare(const Variant &p_variant) const {
 			const Plane *r = reinterpret_cast<const Plane *>(p_variant._data._mem);
 
 			return (hash_compare_vector3(l->normal, r->normal)) &&
-				   (hash_compare_scalar(l->d, r->d));
+				   (hash_compare_scalar(l->distance, r->distance));
 		} break;
 
 		case AABB: {

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -1550,7 +1550,7 @@ void Variant::set_named(const StringName &p_index, const Variant &p_value, bool 
 					v->normal.z = p_value._data._int;
 					valid = true;
 				} else if (p_index == CoreStringNames::singleton->d) {
-					v->d = p_value._data._int;
+					v->distance = p_value._data._int;
 					valid = true;
 				}
 			} else if (p_value.type == Variant::FLOAT) {
@@ -1565,7 +1565,7 @@ void Variant::set_named(const StringName &p_index, const Variant &p_value, bool 
 					v->normal.z = p_value._data._float;
 					valid = true;
 				} else if (p_index == CoreStringNames::singleton->d) {
-					v->d = p_value._data._float;
+					v->distance = p_value._data._float;
 					valid = true;
 				}
 
@@ -1851,7 +1851,7 @@ Variant Variant::get_named(const StringName &p_index, bool *r_valid) const {
 			} else if (p_index == CoreStringNames::singleton->z) {
 				return v->normal.z;
 			} else if (p_index == CoreStringNames::singleton->d) {
-				return v->d;
+				return v->distance;
 			} else if (p_index == CoreStringNames::singleton->normal) {
 				return v->normal;
 			}
@@ -2334,7 +2334,7 @@ void Variant::set(const Variant &p_index, const Variant &p_value, bool *r_valid)
 					return;
 				} else if (*str == "d") {
 					valid = true;
-					v->d = p_value;
+					v->distance = p_value;
 					return;
 				}
 			}
@@ -2841,7 +2841,7 @@ Variant Variant::get(const Variant &p_index, bool *r_valid) const {
 					return v->normal;
 				} else if (*str == "d") {
 					valid = true;
-					return v->d;
+					return v->distance;
 				}
 			}
 

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -1551,7 +1551,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 		case Variant::PLANE: {
 
 			Plane p = p_variant;
-			p_store_string_func(p_store_string_ud, "Plane( " + rtosfix(p.normal.x) + ", " + rtosfix(p.normal.y) + ", " + rtosfix(p.normal.z) + ", " + rtosfix(p.d) + " )");
+			p_store_string_func(p_store_string_ud, "Plane( " + rtosfix(p.normal.x) + ", " + rtosfix(p.normal.y) + ", " + rtosfix(p.normal.z) + ", " + rtosfix(p.distance) + " )");
 
 		} break;
 		case Variant::AABB: {

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -19,10 +19,10 @@
 			</argument>
 			<argument index="2" name="c" type="float">
 			</argument>
-			<argument index="3" name="d" type="float">
+			<argument index="3" name="distance" type="float">
 			</argument>
 			<description>
-				Creates a plane from the four parameters. The three components of the resulting plane's [member normal] are [code]a[/code], [code]b[/code] and [code]c[/code], and the plane has a distance of [code]d[/code] from the origin.
+				Creates a plane from the four parameters. The three components of the resulting plane's [member normal] are [code]a[/code], [code]b[/code] and [code]c[/code], and the plane has a distance of [code]distance[/code] from the origin.
 			</description>
 		</method>
 		<method name="Plane">
@@ -43,7 +43,7 @@
 			</return>
 			<argument index="0" name="normal" type="Vector3">
 			</argument>
-			<argument index="1" name="d" type="float">
+			<argument index="1" name="distance" type="float">
 			</argument>
 			<description>
 				Creates a plane from the normal and the plane's distance to the origin.

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1611,7 +1611,7 @@ void EditorPropertyPlane::_value_changed(double val, const String &p_name) {
 	p.normal.x = spin[0]->get_value();
 	p.normal.y = spin[1]->get_value();
 	p.normal.z = spin[2]->get_value();
-	p.d = spin[3]->get_value();
+	p.distance = spin[3]->get_value();
 	emit_changed(get_edited_property(), p, p_name);
 }
 
@@ -1621,7 +1621,7 @@ void EditorPropertyPlane::update_property() {
 	spin[0]->set_value(val.normal.x);
 	spin[1]->set_value(val.normal.y);
 	spin[2]->set_value(val.normal.z);
-	spin[3]->set_value(val.d);
+	spin[3]->set_value(val.distance);
 	setting = false;
 }
 void EditorPropertyPlane::_notification(int p_what) {

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -766,7 +766,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 						Vector3 tangent = Vector3(tangent_src->array[tangent_pos + 0], tangent_src->array[tangent_pos + 1], tangent_src->array[tangent_pos + 2]);
 
 						vertex.tangent.normal = tangent;
-						vertex.tangent.d = vertex.normal.cross(tangent).dot(binormal) > 0 ? 1 : -1;
+						vertex.tangent.distance = vertex.normal.cross(tangent).dot(binormal) > 0 ? 1 : -1;
 					}
 				}
 
@@ -794,7 +794,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 #ifndef NO_UP_AXIS_SWAP
 				if (collada.state.up_axis == Vector3::AXIS_Z) {
 
-					Vector3 bn = vertex.normal.cross(vertex.tangent.normal) * vertex.tangent.d;
+					Vector3 bn = vertex.normal.cross(vertex.tangent.normal) * vertex.tangent.distance;
 
 					SWAP(vertex.vertex.z, vertex.vertex.y);
 					vertex.vertex.z = -vertex.vertex.z;
@@ -805,7 +805,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ArrayMesh> &p_me
 					SWAP(bn.z, bn.y);
 					bn.z = -bn.z;
 
-					vertex.tangent.d = vertex.normal.cross(vertex.tangent.normal).dot(bn) > 0 ? 1 : -1;
+					vertex.tangent.distance = vertex.normal.cross(vertex.tangent.normal).dot(bn) > 0 ? 1 : -1;
 				}
 
 #endif

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -3724,10 +3724,10 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Vector3 n2 = p.normal.cross(n1).normalized();
 
 		Vector3 pface[4] = {
-			p.normal * p.d + n1 * 10.0 + n2 * 10.0,
-			p.normal * p.d + n1 * 10.0 + n2 * -10.0,
-			p.normal * p.d + n1 * -10.0 + n2 * -10.0,
-			p.normal * p.d + n1 * -10.0 + n2 * 10.0,
+			p.normal * p.distance + n1 * 10.0 + n2 * 10.0,
+			p.normal * p.distance + n1 * 10.0 + n2 * -10.0,
+			p.normal * p.distance + n1 * -10.0 + n2 * -10.0,
+			p.normal * p.distance + n1 * -10.0 + n2 * 10.0,
 		};
 
 		points.push_back(pface[0]);
@@ -3738,8 +3738,8 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		points.push_back(pface[3]);
 		points.push_back(pface[3]);
 		points.push_back(pface[0]);
-		points.push_back(p.normal * p.d);
-		points.push_back(p.normal * p.d + p.normal * 3);
+		points.push_back(p.normal * p.distance);
+		points.push_back(p.normal * p.distance + p.normal * 3);
 
 		p_gizmo->add_lines(points, material);
 		p_gizmo->add_collision_segments(points);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -682,11 +682,11 @@ void Node3DEditorViewport::_select_region() {
 	}
 
 	Plane near(cam_pos, -_get_camera_normal());
-	near.d -= get_znear();
+	near.distance -= get_znear();
 	frustum.push_back(near);
 
 	Plane far = -near;
-	far.d += get_zfar();
+	far.distance += get_zfar();
 	frustum.push_back(far);
 
 	Vector<ObjectID> instances = RenderingServer::get_singleton()->instances_cull_convex(frustum, get_tree()->get_root()->get_world_3d()->get_scenario());

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -752,7 +752,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			value_editor[0]->set_text(String::num(plane.normal.x));
 			value_editor[1]->set_text(String::num(plane.normal.y));
 			value_editor[2]->set_text(String::num(plane.normal.z));
-			value_editor[3]->set_text(String::num(plane.d));
+			value_editor[3]->set_text(String::num(plane.distance));
 
 		} break;
 		case Variant::QUAT: {
@@ -1598,7 +1598,7 @@ void CustomPropertyEditor::_modified(String p_string) {
 			pl.normal.x = _parse_real_expression(value_editor[0]->get_text());
 			pl.normal.y = _parse_real_expression(value_editor[1]->get_text());
 			pl.normal.z = _parse_real_expression(value_editor[2]->get_text());
-			pl.d = _parse_real_expression(value_editor[3]->get_text());
+			pl.distance = _parse_real_expression(value_editor[3]->get_text());
 			v = pl;
 			_emit_changed_whole_or_field();
 

--- a/main/tests/test_math.cpp
+++ b/main/tests/test_math.cpp
@@ -370,7 +370,7 @@ void test_vec(Plane p_vec) {
 	Plane v0 = cm.xform4(p_vec);
 
 	print_line("out: " + v0);
-	v0.normal.z = (v0.d / 100.0 * 2.0 - 1.0) * v0.d;
+	v0.normal.z = (v0.distance / 100.0 * 2.0 - 1.0) * v0.distance;
 	print_line("out_F: " + v0);
 }
 

--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -188,7 +188,7 @@ void PlaneShapeBullet::setup(const Plane &p_plane) {
 btCollisionShape *PlaneShapeBullet::create_bt_shape(const btVector3 &p_implicit_scale, real_t p_extra_edge) {
 	btVector3 btPlaneNormal;
 	G_TO_B(plane.normal, btPlaneNormal);
-	return prepare(PlaneShapeBullet::create_shape_plane(btPlaneNormal, plane.d));
+	return prepare(PlaneShapeBullet::create_shape_plane(btPlaneNormal, plane.distance));
 }
 
 /* Sphere */

--- a/modules/gdnative/gdnative/plane.cpp
+++ b/modules/gdnative/gdnative/plane.cpp
@@ -37,10 +37,10 @@
 extern "C" {
 #endif
 
-void GDAPI godot_plane_new_with_reals(godot_plane *r_dest, const godot_real p_a, const godot_real p_b, const godot_real p_c, const godot_real p_d) {
+void GDAPI godot_plane_new_with_reals(godot_plane *r_dest, const godot_real p_a, const godot_real p_b, const godot_real p_c, const godot_real p_distance) {
 
 	Plane *dest = (Plane *)r_dest;
-	*dest = Plane(p_a, p_b, p_c, p_d);
+	*dest = Plane(p_a, p_b, p_c, p_distance);
 }
 
 void GDAPI godot_plane_new_with_vectors(godot_plane *r_dest, const godot_vector3 *p_v1, const godot_vector3 *p_v2, const godot_vector3 *p_v3) {
@@ -162,14 +162,14 @@ godot_vector3 GDAPI godot_plane_get_normal(const godot_plane *p_self) {
 	return *v3;
 }
 
-godot_real GDAPI godot_plane_get_d(const godot_plane *p_self) {
+godot_real GDAPI godot_plane_get_distance(const godot_plane *p_self) {
 	const Plane *self = (const Plane *)p_self;
-	return self->d;
+	return self->distance;
 }
 
-void GDAPI godot_plane_set_d(godot_plane *p_self, const godot_real p_d) {
+void GDAPI godot_plane_set_distance(godot_plane *p_self, const godot_real p_distance) {
 	Plane *self = (Plane *)p_self;
-	self->d = p_d;
+	self->distance = p_distance;
 }
 
 #ifdef __cplusplus

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -3120,14 +3120,14 @@
         ]
       },
       {
-        "name": "godot_plane_get_d",
+        "name": "godot_plane_get_distance",
         "return_type": "godot_real",
         "arguments": [
           ["const godot_plane *", "p_self"]
         ]
       },
       {
-        "name": "godot_plane_set_d",
+        "name": "godot_plane_set_distance",
         "return_type": "void",
         "arguments": [
           ["godot_plane *", "p_self"],

--- a/modules/gdnative/include/gdnative/plane.h
+++ b/modules/gdnative/include/gdnative/plane.h
@@ -92,9 +92,9 @@ void GDAPI godot_plane_set_normal(godot_plane *p_self, const godot_vector3 *p_no
 
 godot_vector3 GDAPI godot_plane_get_normal(const godot_plane *p_self);
 
-godot_real GDAPI godot_plane_get_d(const godot_plane *p_self);
+godot_real GDAPI godot_plane_get_distance(const godot_plane *p_self);
 
-void GDAPI godot_plane_set_d(godot_plane *p_self, const godot_real p_d);
+void GDAPI godot_plane_set_distance(godot_plane *p_self, const godot_real p_distance);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnavigation/nav_map.cpp
+++ b/modules/gdnavigation/nav_map.cpp
@@ -783,7 +783,7 @@ void NavMap::clip_path(const std::vector<gd::NavigationPoly> &p_navigation_polys
 	if (cut_plane.normal == Vector3())
 		return;
 	cut_plane.normal.normalize();
-	cut_plane.d = cut_plane.normal.dot(from);
+	cut_plane.distance = cut_plane.normal.dot(from);
 
 	while (from_poly != p_to_poly) {
 

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -385,7 +385,7 @@ bool GridMapEditor::do_input_action(Camera3D *p_camera, const Point2 &p_point, b
 
 	Plane p;
 	p.normal[edit_axis] = 1.0;
-	p.d = edit_floor[edit_axis] * node->get_cell_size()[edit_axis];
+	p.distance = edit_floor[edit_axis] * node->get_cell_size()[edit_axis];
 
 	Vector3 inters;
 	if (!p.intersects_segment(from, from + normal * settings_pick_distance->get_value(), &inters))
@@ -1137,7 +1137,7 @@ void GridMapEditor::_notification(int p_what) {
 
 				Plane p;
 				p.normal[edit_axis] = 1.0;
-				p.d = edit_floor[edit_axis] * node->get_cell_size()[edit_axis];
+				p.distance = edit_floor[edit_axis] * node->get_cell_size()[edit_axis];
 				p = node->get_transform().xform(p); // plane to snap
 
 				Node3DEditorPlugin *sep = Object::cast_to<Node3DEditorPlugin>(editor->get_editor_plugin_screen());

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -56,29 +56,29 @@ namespace Godot
             }
         }
 
-        public real_t D { get; set; }
+        public real_t Distance { get; set; }
 
         public Vector3 Center
         {
             get
             {
-                return _normal * D;
+                return _normal * Distance;
             }
         }
 
         public real_t DistanceTo(Vector3 point)
         {
-            return _normal.Dot(point) - D;
+            return _normal.Dot(point) - Distance;
         }
 
         public Vector3 GetAnyPoint()
         {
-            return _normal * D;
+            return _normal * Distance;
         }
 
         public bool HasPoint(Vector3 point, real_t epsilon = Mathf.Epsilon)
         {
-            real_t dist = _normal.Dot(point) - D;
+            real_t dist = _normal.Dot(point) - Distance;
             return Mathf.Abs(dist) <= epsilon;
         }
 
@@ -89,9 +89,9 @@ namespace Godot
             if (Mathf.IsZeroApprox(denom))
                 return null;
 
-            Vector3 result = b._normal.Cross(c._normal) * D +
-                                c._normal.Cross(_normal) * b.D +
-                                _normal.Cross(b._normal) * c.D;
+            Vector3 result = b._normal.Cross(c._normal) * Distance +
+                                c._normal.Cross(_normal) * b.Distance +
+                                _normal.Cross(b._normal) * c.Distance;
 
             return result / denom;
         }
@@ -103,7 +103,7 @@ namespace Godot
             if (Mathf.IsZeroApprox(den))
                 return null;
 
-            real_t dist = (_normal.Dot(from) - D) / den;
+            real_t dist = (_normal.Dot(from) - Distance) / den;
 
             // This is a ray, before the emitting pos (from) does not exist
             if (dist > Mathf.Epsilon)
@@ -120,7 +120,7 @@ namespace Godot
             if (Mathf.IsZeroApprox(den))
                 return null;
 
-            real_t dist = (_normal.Dot(begin) - D) / den;
+            real_t dist = (_normal.Dot(begin) - Distance) / den;
 
             // Only allow dist to be in the range of 0 to 1, with tolerance.
             if (dist < -Mathf.Epsilon || dist > 1.0f + Mathf.Epsilon)
@@ -131,7 +131,7 @@ namespace Godot
 
         public bool IsPointOver(Vector3 point)
         {
-            return _normal.Dot(point) > D;
+            return _normal.Dot(point) > Distance;
         }
 
         public Plane Normalized()
@@ -141,7 +141,7 @@ namespace Godot
             if (len == 0)
                 return new Plane(0, 0, 0, 0);
 
-            return new Plane(_normal / len, D / len);
+            return new Plane(_normal / len, Distance / len);
         }
 
         public Vector3 Project(Vector3 point)
@@ -159,27 +159,27 @@ namespace Godot
         public static Plane PlaneXY { get { return _planeXY; } }
 
         // Constructors
-        public Plane(real_t a, real_t b, real_t c, real_t d)
+        public Plane(real_t a, real_t b, real_t c, real_t distance)
         {
             _normal = new Vector3(a, b, c);
-            this.D = d;
+            this.Distance = distance;
         }
-        public Plane(Vector3 normal, real_t d)
+        public Plane(Vector3 normal, real_t distance)
         {
             this._normal = normal;
-            this.D = d;
+            this.Distance = distance;
         }
 
         public Plane(Vector3 v1, Vector3 v2, Vector3 v3)
         {
             _normal = (v1 - v3).Cross(v1 - v2);
             _normal.Normalize();
-            D = _normal.Dot(v1);
+            Distance = _normal.Dot(v1);
         }
 
         public static Plane operator -(Plane plane)
         {
-            return new Plane(-plane._normal, -plane.D);
+            return new Plane(-plane._normal, -plane.Distance);
         }
 
         public static bool operator ==(Plane left, Plane right)
@@ -204,17 +204,17 @@ namespace Godot
 
         public bool Equals(Plane other)
         {
-            return _normal == other._normal && D == other.D;
+            return _normal == other._normal && Distance == other.Distance;
         }
 
         public bool IsEqualApprox(Plane other)
         {
-            return _normal.IsEqualApprox(other._normal) && Mathf.IsEqualApprox(D, other.D);
+            return _normal.IsEqualApprox(other._normal) && Mathf.IsEqualApprox(Distance, other.Distance);
         }
 
         public override int GetHashCode()
         {
-            return _normal.GetHashCode() ^ D.GetHashCode();
+            return _normal.GetHashCode() ^ Distance.GetHashCode();
         }
 
         public override string ToString()
@@ -222,7 +222,7 @@ namespace Godot
             return String.Format("({0}, {1})", new object[]
             {
                 _normal.ToString(),
-                D.ToString()
+                Distance.ToString()
             });
         }
 
@@ -231,7 +231,7 @@ namespace Godot
             return String.Format("({0}, {1})", new object[]
             {
                 _normal.ToString(format),
-                D.ToString(format)
+                Distance.ToString(format)
             });
         }
     }

--- a/modules/mono/mono_gd/gd_mono_marshal.h
+++ b/modules/mono/mono_gd/gd_mono_marshal.h
@@ -274,7 +274,7 @@ enum {
 
 	MATCHES_Plane = (MATCHES_Vector3 && MATCHES_real_t && (sizeof(Plane) == (sizeof(Vector3) + sizeof(real_t))) &&
 					 offsetof(Plane, normal) == 0 &&
-					 offsetof(Plane, d) == sizeof(Vector3))
+					 offsetof(Plane, distance) == sizeof(Vector3))
 };
 
 // In the future we may force this if we want to ref return these structs
@@ -466,14 +466,14 @@ struct M_Color {
 
 struct M_Plane {
 	M_Vector3 normal;
-	real_t d;
+	real_t distance;
 
 	static _FORCE_INLINE_ Plane convert_to(const M_Plane &p_from) {
-		return Plane(M_Vector3::convert_to(p_from.normal), p_from.d);
+		return Plane(M_Vector3::convert_to(p_from.normal), p_from.distance);
 	}
 
 	static _FORCE_INLINE_ M_Plane convert_from(const Plane &p_from) {
-		M_Plane ret = { M_Vector3::convert_from(p_from.normal), p_from.d };
+		M_Plane ret = { M_Vector3::convert_from(p_from.normal), p_from.distance };
 		return ret;
 	}
 };

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -376,7 +376,7 @@ Point2 Camera3D::unproject_position(const Vector3 &p_pos) const {
 	Plane p(get_camera_transform().xform_inv(p_pos), 1.0);
 
 	p = cm.xform4(p);
-	p.normal /= p.d;
+	p.normal /= p.distance;
 
 	Point2 res;
 	res.x = (p.normal.x * 0.5 + 0.5) * viewport_size.x;

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -111,7 +111,7 @@ Point2 XRCamera3D::unproject_position(const Vector3 &p_pos) const {
 	Plane p(get_camera_transform().xform_inv(p_pos), 1.0);
 
 	p = cm.xform4(p);
-	p.normal /= p.d;
+	p.normal /= p.distance;
 
 	Point2 res;
 	res.x = (p.normal.x * 0.5 + 0.5) * viewport_size.x;

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -1237,7 +1237,7 @@ void Curve3D::_bake() const {
 				p = mid;
 				Plane post;
 				post.normal = pos;
-				post.d = Math::lerp(points[i].tilt, points[i + 1].tilt, mid);
+				post.distance = Math::lerp(points[i].tilt, points[i + 1].tilt, mid);
 				pointlist.push_back(post);
 			} else {
 
@@ -1274,7 +1274,7 @@ void Curve3D::_bake() const {
 	for (List<Plane>::Element *E = pointlist.front(); E; E = E->next()) {
 
 		w[idx] = E->get().normal;
-		wt[idx] = E->get().d;
+		wt[idx] = E->get().distance;
 
 		if (!up_vector_enabled) {
 			idx++;

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1522,7 +1522,7 @@ Error ArrayMesh::lightmap_unwrap_cached(int *&r_cache_data, unsigned int &r_cach
 			if (lightmap_surfaces[surface].format & ARRAY_FORMAT_TANGENT) {
 				Plane t;
 				t.normal = v.tangent;
-				t.d = v.binormal.dot(v.normal.cross(v.tangent)) < 0 ? -1 : 1;
+				t.distance = v.binormal.dot(v.normal.cross(v.tangent)) < 0 ? -1 : 1;
 				surfaces_tools.write[surface]->add_tangent(t);
 			}
 			if (lightmap_surfaces[surface].format & ARRAY_FORMAT_BONES) {

--- a/scene/resources/mesh_data_tool.cpp
+++ b/scene/resources/mesh_data_tool.cpp
@@ -255,7 +255,7 @@ Error MeshDataTool::commit_to_surface(const Ref<ArrayMesh> &p_mesh) {
 				ta[i * 4 + 0] = vtx.tangent.normal.x;
 				ta[i * 4 + 1] = vtx.tangent.normal.y;
 				ta[i * 4 + 2] = vtx.tangent.normal.z;
-				ta[i * 4 + 3] = vtx.tangent.d;
+				ta[i * 4 + 3] = vtx.tangent.distance;
 			}
 			if (uv)
 				uv[i] = vtx.uv;

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -107,7 +107,7 @@ void SurfaceTool::add_vertex(const Vector3 &p_vertex) {
 	vtx.weights = last_weights;
 	vtx.bones = last_bones;
 	vtx.tangent = last_tangent.normal;
-	vtx.binormal = last_normal.cross(last_tangent.normal).normalized() * last_tangent.d;
+	vtx.binormal = last_normal.cross(last_tangent.normal).normalized() * last_tangent.distance;
 
 	const int expected_vertices = 4;
 
@@ -575,7 +575,7 @@ Vector<SurfaceTool::Vertex> SurfaceTool::create_vertex_array_from_triangle_array
 		if (lformat & RS::ARRAY_FORMAT_TANGENT) {
 			Plane p(tarr[i * 4 + 0], tarr[i * 4 + 1], tarr[i * 4 + 2], tarr[i * 4 + 3]);
 			v.tangent = p.normal;
-			v.binormal = p.normal.cross(v.tangent).normalized() * p.d;
+			v.binormal = p.normal.cross(v.tangent).normalized() * p.distance;
 		}
 		if (lformat & RS::ARRAY_FORMAT_COLOR)
 			v.color = carr[i];
@@ -658,7 +658,7 @@ void SurfaceTool::_create_list_from_arrays(Array arr, List<Vertex> *r_vertex, Li
 		if (lformat & RS::ARRAY_FORMAT_TANGENT) {
 			Plane p(tarr[i * 4 + 0], tarr[i * 4 + 1], tarr[i * 4 + 2], tarr[i * 4 + 3]);
 			v.tangent = p.normal;
-			v.binormal = p.normal.cross(v.tangent).normalized() * p.d;
+			v.binormal = p.normal.cross(v.tangent).normalized() * p.distance;
 		}
 		if (lformat & RS::ARRAY_FORMAT_COLOR)
 			v.color = carr[i];

--- a/scene/resources/world_margin_shape_3d.cpp
+++ b/scene/resources/world_margin_shape_3d.cpp
@@ -41,10 +41,10 @@ Vector<Vector3> WorldMarginShape3D::get_debug_mesh_lines() {
 	Vector3 n2 = p.normal.cross(n1).normalized();
 
 	Vector3 pface[4] = {
-		p.normal * p.d + n1 * 10.0 + n2 * 10.0,
-		p.normal * p.d + n1 * 10.0 + n2 * -10.0,
-		p.normal * p.d + n1 * -10.0 + n2 * -10.0,
-		p.normal * p.d + n1 * -10.0 + n2 * 10.0,
+		p.normal * p.distance + n1 * 10.0 + n2 * 10.0,
+		p.normal * p.distance + n1 * 10.0 + n2 * -10.0,
+		p.normal * p.distance + n1 * -10.0 + n2 * -10.0,
+		p.normal * p.distance + n1 * -10.0 + n2 * 10.0,
 	};
 
 	points.push_back(pface[0]);
@@ -55,8 +55,8 @@ Vector<Vector3> WorldMarginShape3D::get_debug_mesh_lines() {
 	points.push_back(pface[3]);
 	points.push_back(pface[3]);
 	points.push_back(pface[0]);
-	points.push_back(p.normal * p.d);
-	points.push_back(p.normal * p.d + p.normal * 3);
+	points.push_back(p.normal * p.distance);
+	points.push_back(p.normal * p.distance + p.normal * 3);
 
 	return points;
 }

--- a/servers/physics_3d/collision_solver_3d_sat.cpp
+++ b/servers/physics_3d/collision_solver_3d_sat.cpp
@@ -194,7 +194,7 @@ static void _generate_contacts_face_face(const Vector3 *p_points_A, int p_point_
 				// calculate intersection
 				Vector3 rel = edge1_A - edge0_A;
 				real_t den = clip.normal.dot(rel);
-				real_t dist = -(clip.normal.dot(edge0_A) - clip.d) / den;
+				real_t dist = -(clip.normal.dot(edge0_A) - clip.distance) / den;
 				Vector3 inters = edge0_A + rel * dist;
 
 				ERR_FAIL_COND(dst_idx >= max_clip);

--- a/servers/rendering/rasterizer_rd/rasterizer_effects_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_effects_rd.cpp
@@ -558,7 +558,7 @@ void RasterizerEffectsRD::sub_surface_scattering(RID p_diffuse, RID p_diffuse2, 
 	int32_t y_groups = (p_screen_size.height - 1) / 8 + 1;
 
 	Plane p = p_camera.xform4(Plane(1, 0, -1, 1));
-	p.normal /= p.d;
+	p.normal /= p.distance;
 	float unit_size = p.normal.x;
 
 	{ //scale color and depth to half

--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
@@ -1368,7 +1368,7 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 				gui[0] = v.normal.x;
 				gui[1] = v.normal.y;
 				gui[2] = v.normal.z;
-				gui[3] = v.d;
+				gui[3] = v.distance;
 			}
 		} break;
 		case ShaderLanguage::TYPE_MAT2: {
@@ -4929,7 +4929,7 @@ void RasterizerStorageRD::_global_variable_store_in_buffer(int32_t p_index, RS::
 			bv.x = v.normal.x;
 			bv.y = v.normal.y;
 			bv.z = v.normal.z;
-			bv.w = v.d;
+			bv.w = v.distance;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_COLOR: {
 			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];


### PR DESCRIPTION
Why?
1. D could stand for anything, its very undescriptive
2. Other classes and variables aren't named like this, it is position not p for example
3. Consistency with lineshape2d (see #38589)

Renamed internally, in gdscript and in mono.

@aaronfranke what do you think

In my opinion 4.0 is the time to rename a bunch of stuff, reorder method parameters etc so that everything becomes more intuitive and easier to understand. Breaking compatibility is worth it for a better engine.