### PR TITLE
Prevent CapsuleShape2D height from being less than zero.

### DIFF
--- a/scene/resources/capsule_shape_2d.cpp
+++ b/scene/resources/capsule_shape_2d.cpp
@@ -72,6 +72,9 @@ real_t CapsuleShape2D::get_radius() const {
 void CapsuleShape2D::set_height(real_t p_height) {
 
 	height = p_height;
+	if (height < 0)
+		height = 0;
+
 	_update_shape();
 }
 


### PR DESCRIPTION
Fixes #38514.