### PR TITLE
fix #36480

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2314,10 +2314,6 @@ void CSharpScript::_update_member_info_no_exports() {
 
 bool CSharpScript::_update_exports() {
 
-#ifdef TOOLS_ENABLED
-	if (!Engine::get_singleton()->is_editor_hint())
-		return false;
-
 	placeholder_fallback_enabled = true; // until proven otherwise
 
 	if (!valid)
@@ -2466,8 +2462,6 @@ bool CSharpScript::_update_exports() {
 	}
 
 	return changed;
-#endif
-	return false;
 }
 
 void CSharpScript::load_script_signals(GDMonoClass *p_class, GDMonoClass *p_native_class) {


### PR DESCRIPTION
This fixes issue #36480 (which is the same bug as #37581).
The parent properties of a C# class were not fetched properly because it relies on CSharpInstance::get_property_list method, which fetches the field information from CSharpInstance::script->member_info, and CSharpScript::member_info is updated in methods CSharpScript::_update_exports and CSharpScript::_update_member_info_no_exports, the latter not declared if TOOLS_ENABLED is not set. The update to CSharpScript::member_info is not executed in the former method if TOOLS_ENABLED is not set, and by removing the restriction CSharpScript::member_info is correctly set up when method CSharpScript::_update_exports is called from CSharpScript::reload.