### PR TITLE
Store build as artifact in appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,3 +39,11 @@ before_build:
 
 build_script:
   - scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% %OPTIONS% %EXTRA_ARGS%
+
+after_build:
+  - 7z a godot_build.zip bin\*.exe
+  
+artifacts:
+  - path: godot_build.zip
+    name: Build
+    type: zip


### PR DESCRIPTION
7z is already available in path in appveyor
zip the build .exe files and store them ( appveyor retains for ~6 months)