### PR TITLE
[WIP] GLES2 rewrite USE_TEXTURE_RECT shader to prevent flicker

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -419,7 +419,7 @@ void RasterizerGLES2::blit_render_target_to_screen(RID p_render_target, const Re
 
 	// TODO normals
 
-	canvas->draw_generic_textured_rect(p_screen_rect, Rect2(0, 0, 1, -1));
+	canvas->draw_generic_textured_rect(p_screen_rect, Rect2(0, 1, 1, -1));
 
 	glBindTexture(GL_TEXTURE_2D, 0);
 	canvas->canvas_end();

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -130,22 +130,14 @@ void main() {
 #ifdef USE_TEXTURE_RECT
 
 	if (dst_rect.z < 0.0) { // Transpose is encoded as negative dst_rect.z
-		uv = src_rect.xy + abs(src_rect.zw) * vertex.yx;
+		uv = src_rect.xy + (src_rect.zw * vertex.yx);
 	} else {
-		uv = src_rect.xy + abs(src_rect.zw) * vertex;
+		uv = src_rect.xy + (src_rect.zw * vertex.xy);
 	}
 
 	vec4 outvec = vec4(0.0, 0.0, 0.0, 1.0);
+	outvec.xy = dst_rect.xy + (abs(dst_rect.zw) * vertex.xy);
 
-	// This is what is done in the GLES 3 bindings and should
-	// take care of flipped rects.
-	//
-	// But it doesn't.
-	// I don't know why, will need to investigate further.
-
-	outvec.xy = dst_rect.xy + abs(dst_rect.zw) * select(vertex, vec2(1.0, 1.0) - vertex, lessThan(src_rect.zw, vec2(0.0, 0.0)));
-
-	// outvec.xy = dst_rect.xy + abs(dst_rect.zw) * vertex;
 #else
 	vec4 outvec = vec4(vertex.xy, 0.0, 1.0);
 


### PR DESCRIPTION
The old 2d rect shader was producing flicker on some hardware. In this PR the shader is simplified and the calling code modified to work with it. This should reduce the possibility of floating point / precision error.

May fix #9913.

## Notes
* This needs testing by someone who gets flicker on their hardware, I have simplified the floating point calculations in the shader for less possibility of problems but I cannot guarantee it will work to fix the flicker
* If it is confirmed to work I can make similar modifications for GLES3
* If we are satisfied it works we can remove the nvidia workaround code, and call this version from the batching for single rects.

## Instructions for Testing
In order to test this, you will need to have a project that exhibits flicker in GLES2 (without batching). To test it you will need to compile the PR, turn off batching in your project, and turn off the nvidia workaround. If all those are off you will be using the _ye olde_ fast path which normally exhibits flicker.

Let me know if it fixes it or not. If not there is a couple of other ideas I can try.