### PR TITLE
Allow sending `null` as the last argument to be recognizable in `UndoRedo` methods

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -871,16 +871,14 @@ Variant Object::call(const StringName &p_method, const Variant **p_args, int p_a
 		ret = script_instance->call(p_method, p_args, p_argcount, r_error);
 		//force jumptable
 		switch (r_error.error) {
-			case Callable::CallError::CALL_OK:
-				return ret;
 			case Callable::CallError::CALL_ERROR_INVALID_METHOD:
+			case Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL:
 				break;
+			case Callable::CallError::CALL_OK:
 			case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT:
 			case Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS:
 			case Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS:
 				return ret;
-			case Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL: {
-			}
 		}
 	}
 

--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -274,14 +274,19 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E) {
 			case Operation::TYPE_METHOD: {
 				Vector<const Variant *> argptrs;
 				argptrs.resize(VARIANT_ARG_MAX);
-				int argc = 0;
-
-				for (int i = 0; i < VARIANT_ARG_MAX; i++) {
-					if (op.args[i].get_type() == Variant::NIL) {
-						break;
+				int argc = (argument_count.find(op.name)) ? argument_count[op.name] : 0;
+				if (argc == 0) {
+					for (int i = 0; i < VARIANT_ARG_MAX; i++) {
+						if (op.args[i].get_type() == Variant::NIL) {
+							break;
+						}
+						argptrs.write[i] = &op.args[i];
+						argc++;
 					}
-					argptrs.write[i] = &op.args[i];
-					argc++;
+				} else {
+					for (int i = 0; i < argc; i++) {
+						argptrs.write[i] = &op.args[i];
+					}
 				}
 				argptrs.resize(argc);
 

--- a/core/undo_redo.h
+++ b/core/undo_redo.h
@@ -128,6 +128,8 @@ public:
 
 	UndoRedo() {}
 	~UndoRedo();
+
+	Map<String, int> argument_count;
 };
 
 VARIANT_ENUM_CAST(UndoRedo::MergeMode);

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -3438,23 +3438,31 @@ String Variant::get_construct_string() const {
 String Variant::get_call_error_text(Object *p_base, const StringName &p_method, const Variant **p_argptrs, int p_argcount, const Callable::CallError &ce) {
 	String err_text;
 
-	if (ce.error == Callable::CallError::CALL_ERROR_INVALID_ARGUMENT) {
-		int errorarg = ce.argument;
-		if (p_argptrs) {
-			err_text = "Cannot convert argument " + itos(errorarg + 1) + " from " + Variant::get_type_name(p_argptrs[errorarg]->get_type()) + " to " + Variant::get_type_name(Variant::Type(ce.expected)) + ".";
-		} else {
-			err_text = "Cannot convert argument " + itos(errorarg + 1) + " from [missing argptr, type unknown] to " + Variant::get_type_name(Variant::Type(ce.expected)) + ".";
+	switch (ce.error) {
+		case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT: {
+			int errorarg = ce.argument;
+			if (p_argptrs) {
+				err_text = "Cannot convert argument " + itos(errorarg + 1) +
+						   " from " + Variant::get_type_name(p_argptrs[errorarg]->get_type()) +
+						   " to " + Variant::get_type_name(Variant::Type(ce.expected)) + ".";
+			} else {
+				err_text = "Cannot convert argument " + itos(errorarg + 1) +
+						   " from [missing argptr, type unknown] to " + Variant::get_type_name(Variant::Type(ce.expected)) + ".";
+			}
+		} break;
+		case Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS:
+		case Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS: {
+			err_text = "Method expected " + itos(ce.argument) + " arguments, but called with " + itos(p_argcount) + ".";
+		} break;
+		case Callable::CallError::CALL_ERROR_INVALID_METHOD: {
+			err_text = "Method not found.";
+		} break;
+		case Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL: {
+			err_text = "Instance is null.";
+		} break;
+		default: { //Callable::CallError::CALL_OK
+			return "Call OK.";
 		}
-	} else if (ce.error == Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS) {
-		err_text = "Method expected " + itos(ce.argument) + " arguments, but called with " + itos(p_argcount) + ".";
-	} else if (ce.error == Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS) {
-		err_text = "Method expected " + itos(ce.argument) + " arguments, but called with " + itos(p_argcount) + ".";
-	} else if (ce.error == Callable::CallError::CALL_ERROR_INVALID_METHOD) {
-		err_text = "Method not found.";
-	} else if (ce.error == Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL) {
-		err_text = "Instance is null";
-	} else if (ce.error == Callable::CallError::CALL_OK) {
-		return "Call OK";
 	}
 
 	String class_name = p_base->get_class();

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1557,6 +1557,8 @@ void ScriptEditor::_update_members_overview() {
 	for (int i = 0; i < functions.size(); i++) {
 		String filter = filter_methods->get_text();
 		String name = functions[i].get_slice(":", 0);
+		String argc = functions[i].get_slice(":", 2);
+		EditorNode::get_undo_redo()->argument_count[name] = (argc == "") ? 0 : argc.to_int();
 		if (filter == "" || filter.is_subsequence_ofi(name)) {
 			members_overview->add_item(name);
 			members_overview->set_item_metadata(members_overview->get_item_count() - 1, functions[i].get_slice(":", 1).to_int() - 1);

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1709,8 +1709,9 @@ void NativeScriptLanguage::init_library(const Ref<GDNativeLibrary> &lib) {
 		gdn.instance();
 		gdn->set_library(lib);
 
-		// TODO check the return value?
-		gdn->initialize();
+		if (!gdn->initialize()) {
+			ERR_PRINT("Cannot initialize gdn library.");
+		}
 
 		library_gdnatives.insert(lib_path, gdn);
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -143,24 +143,24 @@ bool GDScriptLanguage::validate(const String &p_script, int &r_line_error, int &
 		const GDScriptParser::ClassNode *cl = static_cast<const GDScriptParser::ClassNode *>(root);
 		Map<int, String> funcs;
 		for (int i = 0; i < cl->functions.size(); i++) {
-			funcs[cl->functions[i]->line] = cl->functions[i]->name;
+			funcs[cl->functions[i]->line] = String(cl->functions[i]->name) + ":" + itos(cl->functions[i]->arguments.size());
 		}
 
 		for (int i = 0; i < cl->static_functions.size(); i++) {
-			funcs[cl->static_functions[i]->line] = cl->static_functions[i]->name;
+			funcs[cl->static_functions[i]->line] = String(cl->static_functions[i]->name) + ":" + itos(cl->static_functions[i]->arguments.size());
 		}
 
 		for (int i = 0; i < cl->subclasses.size(); i++) {
 			for (int j = 0; j < cl->subclasses[i]->functions.size(); j++) {
-				funcs[cl->subclasses[i]->functions[j]->line] = String(cl->subclasses[i]->name) + "." + cl->subclasses[i]->functions[j]->name;
+				funcs[cl->subclasses[i]->functions[j]->line] = String(cl->subclasses[i]->name) + "." + cl->subclasses[i]->functions[j]->name + ":" + itos(cl->subclasses[i]->functions[j]->arguments.size());
 			}
 			for (int j = 0; j < cl->subclasses[i]->static_functions.size(); j++) {
-				funcs[cl->subclasses[i]->static_functions[j]->line] = String(cl->subclasses[i]->name) + "." + cl->subclasses[i]->static_functions[j]->name;
+				funcs[cl->subclasses[i]->static_functions[j]->line] = String(cl->subclasses[i]->name) + "." + cl->subclasses[i]->static_functions[j]->name + ":" + itos(cl->subclasses[i]->static_functions[j]->arguments.size());
 			}
 		}
 
 		for (Map<int, String>::Element *E = funcs.front(); E; E = E->next()) {
-			r_functions->push_back(E->get() + ":" + itos(E->key()));
+			r_functions->push_back(E->get().split(":")[0] + ":" + itos(E->key()) + ":" + E->get().split(":")[1]);
 		}
 	}
 


### PR DESCRIPTION
Previously the number of arguments for functions for EditorPlugin has been determined by checking for the first null value argument, which meant one could not pass null as value to a function. Now UndoRedo call has map storing function name and argument count, which is updated after each reloading of a script, so if a function is present in the map the correct argc is obtained.

*Bugsquad edit: This closes #36895.*