### PR TITLE
Changed default window style to be single window

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -341,7 +341,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/editor/unfocused_low_processor_mode_sleep_usec"] = PropertyInfo(Variant::FLOAT, "interface/editor/unfocused_low_processor_mode_sleep_usec", PROPERTY_HINT_RANGE, "1,100000,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/separate_distraction_mode", false);
 	_initial_set("interface/editor/automatically_open_screenshots", true);
-	_initial_set("interface/editor/single_window_mode", false);
+	_initial_set("interface/editor/single_window_mode", true);
 	hints["interface/editor/single_window_mode"] = PropertyInfo(Variant::BOOL, "interface/editor/single_window_mode", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/hide_console_window", false);
 	_initial_set("interface/editor/save_each_scene_on_quit", true); // Regression

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -121,7 +121,7 @@ static int audio_driver_idx = -1;
 
 // Engine config/tools
 
-static bool single_window = false;
+static bool single_window = true;
 static bool editor = false;
 static bool project_manager = false;
 static String locale;


### PR DESCRIPTION
Changes the default setting for the window style to be single window, which is current (pre-4.0) Godot workflow. I imagine it was a setting that just forgot to get changed back to true after work on it was completed.

https://twitter.com/reduzio/status/1235887984060362753