### PR TITLE
Cleared forces at end of body_2D integrate_forces

### DIFF
--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -530,6 +530,9 @@ void Body2DSW::integrate_forces(real_t p_step) {
 
 	//motion=linear_velocity*p_step;
 
+	applied_force = Vector2();
+	applied_torque = 0.0f;
+
 	first_integration = false;
 	biased_angular_velocity = 0;
 	biased_linear_velocity = Vector2();


### PR DESCRIPTION
Cleared forces at end of body_2D integrate_forces for consistency with 3D version. Could not find where to fix in bullet implementation.

Fixes #38646 