### PR TITLE
Better file naming for AppVeyor artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,9 +41,13 @@ build_script:
   - scons platform=%GD_PLATFORM% target=%TARGET% tools=%TOOLS% %OPTIONS% %EXTRA_ARGS%
 
 after_build:
-  - 7z a godot_build.zip bin\*.exe
+  - git rev-parse --short=9 HEAD > VERSION_HASH.txt
+  - set /P VERSION_HASH= < VERSION_HASH.txt
+  - cd bin
+  - mv godot.windows.opt.tools.64.exe godot_%APPVEYOR_REPO_BRANCH%-%VERSION_HASH%_win64.exe
+  - 7z a -mx9 godot_%APPVEYOR_REPO_BRANCH%-%VERSION_HASH%_win64.zip *.exe
   
 artifacts:
-  - path: godot_build.zip
-    name: Build
+  - path: bin/godot_${APPVEYOR_REPO_BRANCH}-${VERSION_HASH}_win64.zip
+    name: Win64 release_debug editor build
     type: zip


### PR DESCRIPTION
This builds upon https://github.com/godotengine/godot/pull/38625 and improves the file name format as mentioned in https://github.com/godotengine/godot/pull/38189#issuecomment-626585363

The resulting file stored has the name `godot.windows.opt.tools.64-$(VERSION_HASH).zip` where `VERSION_HASH` is obtained from `it rev-parse --short=9 HEAD` , the zip file contains the built exe file.