### PR TITLE
thirdparty: Cleanup after #38386, document provenance and copyright

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -303,6 +303,11 @@ Comment: NanoSVG
 Copyright: 2013-2014, Mikko Mononen
 License: Zlib
 
+Files: ./thirdparty/oidn/
+Comment: Intel Open Image Denoise
+Copyright: 2009-2020, Intel Corporation
+License: Apache-2.0
+
 Files: ./thirdparty/opus/
 Comment: Opus
 Copyright: 2001-2011, Xiph.Org, Skype Limited, Octasic,

--- a/core/SCsub
+++ b/core/SCsub
@@ -49,6 +49,7 @@ thirdparty_misc_dir = "#thirdparty/misc/"
 thirdparty_misc_sources = [
     # C sources
     "fastlz.c",
+    "r128.c",
     "smaz.c",
     # C++ sources
     "hq2x.cpp",

--- a/core/math/delaunay_2d.h
+++ b/core/math/delaunay_2d.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  delaunay.h                                                           */
+/*  delaunay_2d.h                                                        */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef DELAUNAY_H
-#define DELAUNAY_H
+#ifndef DELAUNAY_2D_H
+#define DELAUNAY_2D_H
 
 #include "core/math/rect2.h"
 
@@ -170,4 +170,4 @@ public:
 	}
 };
 
-#endif // DELAUNAY_H
+#endif // DELAUNAY_2D_H

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -10,7 +10,8 @@
 #include "core/print_string.h"
 #include "core/variant.h"
 #include "core/vector.h"
-#include "thirdparty/r128/r128.h"
+
+#include "thirdparty/misc/r128.h"
 
 class Delaunay3D {
 	struct Simplex;

--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -31,10 +31,11 @@
 #include "geometry.h"
 
 #include "core/print_string.h"
+
 #include "thirdparty/misc/clipper.hpp"
 #include "thirdparty/misc/triangulator.h"
 #define STB_RECT_PACK_IMPLEMENTATION
-#include "thirdparty/stb_rect_pack/stb_rect_pack.h"
+#include "thirdparty/misc/stb_rect_pack.h"
 
 #define SCALE_FACTOR 100000.0 // Based on CMP_EPSILON.
 

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -31,13 +31,12 @@
 #ifndef GEOMETRY_H
 #define GEOMETRY_H
 
-#include "core/math/delaunay.h"
+#include "core/math/delaunay_2d.h"
 #include "core/math/face3.h"
 #include "core/math/rect2.h"
 #include "core/math/triangulate.h"
 #include "core/math/vector3.h"
 #include "core/object.h"
-
 #include "core/print_string.h"
 #include "core/vector.h"
 

--- a/core/math/r128.cpp
+++ b/core/math/r128.cpp
@@ -1,2 +1,0 @@
-#define R128_IMPLEMENTATION
-#include "thirdparty/r128/r128.h"

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -32,7 +32,7 @@
 
 #include "core/input/input.h"
 #include "core/io/resource_loader.h"
-#include "core/math/delaunay.h"
+#include "core/math/delaunay_2d.h"
 #include "core/os/keyboard.h"
 #include "core/project_settings.h"
 #include "editor/editor_scale.h"

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -32,7 +32,7 @@
 
 #include "core/input/input.h"
 #include "core/io/resource_loader.h"
-#include "core/math/delaunay.h"
+#include "core/math/delaunay_2d.h"
 #include "core/os/keyboard.h"
 #include "core/project_settings.h"
 #include "editor/editor_scale.h"

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -36,7 +36,7 @@
 #include "animation_state_machine_editor.h"
 #include "core/input/input.h"
 #include "core/io/resource_loader.h"
-#include "core/math/delaunay.h"
+#include "core/math/delaunay_2d.h"
 #include "core/os/keyboard.h"
 #include "core/project_settings.h"
 #include "editor/editor_scale.h"

--- a/modules/denoise/SCsub
+++ b/modules/denoise/SCsub
@@ -17,7 +17,7 @@ thirdparty_sources = [
     "core/network.cpp",
     "core/autoencoder.cpp",
     "core/transfer_function.cpp",
-    "weights/rtlightmap_hdr.cpp",
+    "weights/rtlightmap_hdr.gen.cpp",
     "mkl-dnn/src/common/batch_normalization.cpp",
     "mkl-dnn/src/common/concat.cpp",
     "mkl-dnn/src/common/convolution.cpp",
@@ -110,7 +110,7 @@ env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 
 weights_in_path = thirdparty_dir + "weights/rtlightmap_hdr.tza"
-weights_out_path = thirdparty_dir + "weights/rtlightmap_hdr.cpp"
+weights_out_path = thirdparty_dir + "weights/rtlightmap_hdr.gen.cpp"
 
 env_thirdparty.Depends(weights_out_path, weights_in_path)
 env_thirdparty.CommandNoCache(weights_out_path, weights_in_path, resource_to_cpp.tza_to_cpp)

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -29,7 +29,8 @@
 /*************************************************************************/
 
 #include "animation_blend_space_2d.h"
-#include "core/math/delaunay.h"
+
+#include "core/math/delaunay_2d.h"
 
 void AnimationNodeBlendSpace2D::get_parameter_list(List<PropertyInfo> *r_list) const {
 	r_list->push_back(PropertyInfo(Variant::VECTOR2, blend_position));

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -384,11 +384,19 @@ Collection of single-file libraries used in Godot components.
   * Upstream: http://www.pcg-random.org
   * Version: minimal C implementation, http://www.pcg-random.org/download.html
   * License: Apache 2.0
+- `r128.h`
+  * Upstream: https://github.com/fahickman/r128
+  * Version: 1.4.3 (2019)
+  * License: Public Domain
 - `smaz.{c,h}`
   * Upstream: https://github.com/antirez/smaz
   * Version: git (150e125cbae2e8fd20dd332432776ce13395d4d4, 2009)
   * License: BSD-3-Clause
   * Modifications: use `const char*` instead of `char*` for input string
+- `stb_rect_pack.h`
+  * Upstream: https://github.com/nothings/stb
+  * Version: 1.00 (2019)
+  * License: Public Domain (Unlicense) or MIT
 - `triangulator.{cpp,h}`
   * Upstream: https://github.com/ivanfratric/polypartition (`src/polypartition.cpp`)
   * Version: TBD, class was renamed
@@ -435,6 +443,17 @@ Files extracted from the upstream source:
 
 - All .h files in `src/`
 - LICENSE.txt
+
+
+## oidn
+
+- Upstream: https://github.com/OpenImageDenoise/oidn
+- Version: TBD
+- License: Apache 2.0
+
+Files extracted from upstream source:
+
+- TBD
 
 
 ## opus

--- a/thirdparty/misc/r128.c
+++ b/thirdparty/misc/r128.c
@@ -1,0 +1,2 @@
+#define R128_IMPLEMENTATION
+#include "r128.h"

--- a/thirdparty/misc/r128.h
+++ b/thirdparty/misc/r128.h
@@ -77,7 +77,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 #  define R128_S32 int32_t
 #  define R128_U32 uint32_t
 #  define R128_S64 int64_t
-#  define R128_U64 long long unsigned int
+#  define R128_U64 uint64_t
 #  define R128_LIT_S64(x) x##ll
 #  define R128_LIT_U64(x) x##ull
 #endif
@@ -703,12 +703,12 @@ static R128_U32 r128__udiv64(R128_U32 nlo, R128_U32 nhi, R128_U32 d, R128_U32 *r
 }
 #elif !defined(_M_X64) || defined(R128_STDC_ONLY)
 #define r128__umul64(a, b) ((a) * (R128_U64)(b))
-/*static R128_U32 r128__udiv64(R128_U32 nlo, R128_U32 nhi, R128_U32 d, R128_U32 *rem)
+static R128_U32 r128__udiv64(R128_U32 nlo, R128_U32 nhi, R128_U32 d, R128_U32 *rem)
 {
    R128_U64 n64 = ((R128_U64)nhi << 32) | nlo;
    *rem = (R128_U32)(n64 % d);
    return (R128_U32)(n64 / d);
-}*/
+}
 #endif   //!R128_64BIT
 
 static void r128__neg(R128 *dst, const R128 *src)
@@ -1188,7 +1188,7 @@ static int r128__format(char *dst, size_t dstSize, const R128 *v, const R128ToSt
       // print a maximum of 20 digits
       fullPrecision = 0;
       precision = 20;
-   } else if (precision > (int)sizeof(buf) - 21) {
+   } else if (precision > sizeof(buf) - 21) {
       trail = precision - (sizeof(buf) - 21);
       precision -= trail;
    }
@@ -2121,4 +2121,3 @@ void r128Ceil(R128 *dst, const R128 *v)
 }
 
 #endif   //R128_IMPLEMENTATION
-

--- a/thirdparty/misc/stb_rect_pack.h
+++ b/thirdparty/misc/stb_rect_pack.h
@@ -626,4 +626,3 @@ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ------------------------------------------------------------------------------
 */
-

--- a/thirdparty/oidn/.gitignore
+++ b/thirdparty/oidn/.gitignore
@@ -1,1 +1,0 @@
-weights/rtlightmap_hdr.cpp

--- a/thirdparty/oidn/LICENSE.txt
+++ b/thirdparty/oidn/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Also renamed `delaunay.h` to `delaunay_2d.h` to match the class name.

@JFonS I will need your help to document the OpenImageDenoise version used, and what should be copied from upstream when syncing.
It would also be good to update to the current stable version (1.2.0) which is newer than the commit we track currently (which seems to be from 2019).