### PR TITLE
Fix memory leak with light maps

### DIFF
--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -3410,6 +3410,8 @@ RasterizerSceneHighEndRD::~RasterizerSceneHighEndRD() {
 		memdelete_arr(scene_state.gi_probes);
 		memdelete_arr(scene_state.directional_lights);
 		memdelete_arr(scene_state.lights);
+		memdelete_arr(scene_state.lightmaps);
+		memdelete_arr(scene_state.lightmap_captures);
 		memdelete_arr(scene_state.reflections);
 		memdelete_arr(scene_state.decals);
 	}


### PR DESCRIPTION
Should fix leak(created with recent reduz commit):
```
WARNING: 2 RIDs of type 'StorageBuffer' were leaked.
     at: _free_rids (drivers/vulkan/rendering_device_vulkan.cpp:7185)


Direct leak of 49168 byte(s) in 1 object(s) allocated from:
    #0 0x7f61343e8517 in malloc (/lib/x86_64-linux-gnu/libasan.so.6+0xb0517)
    #1 0x116503bb in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:82
    #2 0x101005d2 in RasterizerSceneHighEndRD::LightmapData* memnew_arr_template<RasterizerSceneHighEndRD::LightmapData>(unsigned long, char const*) core/os/memory.h:150
    #3 0x100afe04 in RasterizerSceneHighEndRD::RasterizerSceneHighEndRD(RasterizerStorageRD*) servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp:3106
    #4 0x1000552a in RasterizerRD::RasterizerRD() servers/rendering/rasterizer_rd/rasterizer_rd.cpp:186
    #5 0x1a37f89 in RasterizerRD::_create_current() servers/rendering/rasterizer_rd/rasterizer_rd.h:83
    #6 0xf8fe9b2 in Rasterizer::create() servers/rendering/rasterizer.cpp:67
    #7 0xfa59cd4 in RenderingServerRaster::RenderingServerRaster() servers/rendering/rendering_server_raster.cpp:263
    #8 0x1a97b85 in Main::setup2(unsigned long) main/main.cpp:1299
    #9 0x1a926b2 in Main::setup(char const*, int, char**, bool) main/main.cpp:1200
    #10 0x19928aa in main platform/linuxbsd/godot_linuxbsd.cpp:49
    #11 0x7f61331ce0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)

```

I didn't check yet if it works(or even if compile), because my computer is busy now, but it should.