### PR TITLE
Improve doc clarity/detail for extra spacing properties

### DIFF
--- a/doc/classes/DynamicFont.xml
+++ b/doc/classes/DynamicFont.xml
@@ -96,10 +96,12 @@
 			Extra spacing at the bottom in pixels.
 		</member>
 		<member name="extra_spacing_char" type="int" setter="set_spacing" getter="get_spacing" default="0">
-			Extra character spacing in pixels.
+			Extra spacing for each character in pixels.
+			This can be a negative number to make the distance between characters smaller.
 		</member>
 		<member name="extra_spacing_space" type="int" setter="set_spacing" getter="get_spacing" default="0">
-			Extra space spacing in pixels.
+			Extra spacing for the space character (in addition to [member extra_spacing_char]) in pixels.
+			This can be a negative number to make the distance between words smaller.
 		</member>
 		<member name="extra_spacing_top" type="int" setter="set_spacing" getter="get_spacing" default="0">
 			Extra spacing at the top in pixels.
@@ -126,10 +128,10 @@
 			Spacing at the bottom.
 		</constant>
 		<constant name="SPACING_CHAR" value="2" enum="SpacingType">
-			Character spacing.
+			Spacing for each character.
 		</constant>
 		<constant name="SPACING_SPACE" value="3" enum="SpacingType">
-			Space spacing.
+			Spacing for the space character.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
Ideally I'd also:

 * Link "extra character spacing" to `extra_spacing_char`.

 * Follow "space character" with `' '`.

But I'm editing this through the web IDE & don't want to accidentally break the doc generation parsing. :)

----

Re: Space spacing being in addition to character spacing see:

 * <https://github.com/godotengine/godot/blob/d7b85fbaa1fc438effe406c9d7f973749eb4e527/scene/resources/dynamic_font.cpp#L858-L859>

Re: Value being able to be negative see example here:

 * <https://github.com/godotengine/godot/issues/38630>

But also note that nodes other than `Label` may not currently render extra space spacing correctly.