### PR TITLE
Mark `*.tza` files as binary in `.gitattributes` for old Git versions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,4 @@ thirdparty/* linguist-vendored
 *.jar binary
 *.png binary
 *.ttf binary
+*.tza binary


### PR DESCRIPTION
This prevents `thirdparty/oidn/weights/rtlightmap_hdr.tza` from always being considered as modified when using an old Git version (such as the one on Ubuntu 16.04).

**Note:** Not eligible for cherry-picking into 3.2 as OpenImageDenoise was added in the `master` branch only.