### PR TITLE
Fixes memory leak with lightmap part 2

### DIFF
--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -3404,6 +3404,8 @@ RasterizerSceneHighEndRD::~RasterizerSceneHighEndRD() {
 		RD::get_singleton()->free(scene_state.gi_probe_buffer);
 		RD::get_singleton()->free(scene_state.directional_light_buffer);
 		RD::get_singleton()->free(scene_state.light_buffer);
+		RD::get_singleton()->free(scene_state.lightmap_buffer);
+		RD::get_singleton()->free(scene_state.lightmap_capture_buffer);
 		RD::get_singleton()->free(scene_state.reflection_buffer);
 		RD::get_singleton()->free(scene_state.decal_buffer);
 		memdelete_arr(scene_state.instances);


### PR DESCRIPTION
This is second part of #38676, because in previous PR I fixes only "real" leak, but this time also this message should not appear
```
WARNING: 2 RIDs of type 'StorageBuffer' were leaked.
     at: _free_rids (drivers/vulkan/rendering_device_vulkan.cpp:7185)
``` 
This memory isn't really leaking, because Godot finds that memory wasn't released, show warning and at the end release it.
