### PR TITLE
Silence EQ::Band::c1, c2 and c3 may be used uninitialized warnings.

### DIFF
--- a/servers/audio/effects/eq.cpp
+++ b/servers/audio/effects/eq.cpp
@@ -125,6 +125,7 @@ void EQ::set_preset_band_mode(Preset p_preset) {
 	for (int i = 0; i < m_bands; i++) { \
 		Band b;                         \
 		b.freq = bands[i];              \
+		b.c1 = b.c2 = b.c3 = 0;         \
 		band.push_back(b);              \
 	}
 


### PR DESCRIPTION
Initialises EQ::Band::c1, c2 and c3 to 0 to silence the
- b.EQ::Band::c1' may be used uninitialized
- b.EQ::Band::c2' may be used uninitialized
- b.EQ::Band::c3' may be used uninitialized

warnings in servers/audio/effects/eq.cpp.

Note: They are initialised later before being used in `recalculate_band_coefficients()` here:
https://github.com/godotengine/godot/blob/6ceed8ef273d4ea5d4904a52d211f5b730c45b12/servers/audio/effects/eq.cpp#L113-L115
