### PR TITLE
Clarify that the SSL certificate setting overrides the default bundle

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -872,7 +872,8 @@
 			Page size used by remote filesystem (in bytes).
 		</member>
 		<member name="network/ssl/certificates" type="String" setter="" getter="" default="&quot;&quot;">
-			CA certificates bundle to use for SSL connections. If not defined, Godot's internal CA certificates are used.
+			The CA certificates bundle to use for SSL connections. If this is set to a non-empty value, this will [i]override[/i] Godot's default [url=https://github.com/godotengine/godot/blob/master/thirdparty/certs/ca-certificates.crt]Mozilla certificate bundle[/url]. If left empty, the default certificate bundle will be used.
+			If in doubt, leave this setting empty.
 		</member>
 		<member name="node/name_casing" type="int" setter="" getter="" default="0">
 			When creating node names automatically, set the type of casing in this project. This is mostly an editor setting.


### PR DESCRIPTION
Backwards-compatible follow-up to #38689.

See https://github.com/godotengine/godot-docs/issues/2531.