### PR TITLE
Make it clear that PhysicsDirectSpaceState is only available from within _physics_process().

### DIFF
--- a/doc/classes/World2D.xml
+++ b/doc/classes/World2D.xml
@@ -16,7 +16,7 @@
 			The [RID] of this world's canvas resource. Used by the [RenderingServer] for 2D drawing.
 		</member>
 		<member name="direct_space_state" type="PhysicsDirectSpaceState2D" setter="" getter="get_direct_space_state">
-			The state of this world's physics space. This allows arbitrary querying for collision.
+			Direct access to the world's physics 2D space state. Used for querying current and potential collisions. Must only be accessed from the main thread within [code]_physics_process(delta)[/code].
 		</member>
 		<member name="space" type="RID" setter="" getter="get_space">
 			The [RID] of this world's physics space resource. Used by the [PhysicsServer2D] for 2D physics, treating it as both a space and an area.

--- a/doc/classes/World3D.xml
+++ b/doc/classes/World3D.xml
@@ -15,7 +15,7 @@
 		<member name="camera_effects" type="CameraEffects" setter="set_camera_effects" getter="get_camera_effects">
 		</member>
 		<member name="direct_space_state" type="PhysicsDirectSpaceState3D" setter="" getter="get_direct_space_state">
-			The World3D's physics direct space state, used for making various queries. Might be used only during [code]_physics_process[/code].
+			Direct access to the world's physics 3D space state. Used for querying current and potential collisions. Must only be accessed from within [code]_physics_process(delta)[/code].
 		</member>
 		<member name="environment" type="Environment" setter="set_environment" getter="get_environment">
 			The World3D's [Environment].


### PR DESCRIPTION
Driven by #38653.

Also makes the 2D and 3D versions consistent and clarifies that the 2D version is only available from within the main thread.