### PR TITLE
GLES2 Batching - Prevent baking colors with COLOR writes

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.h
+++ b/drivers/gles2/rasterizer_canvas_gles2.h
@@ -135,7 +135,10 @@ class RasterizerCanvasGLES2 : public RasterizerCanvasBaseGLES2 {
 
 		// note the z_index  may only be correct for the first of the joined item references
 		// this has implications for light culling with z ranged lights.
-		int z_index;
+		int16_t z_index;
+
+		// these are defined in RasterizerStorageGLES2::Shader::CanvasItem::BatchFlags
+		uint16_t flags;
 
 		// we are always splitting items with lots of commands,
 		// and items with unhandled primitives (default)
@@ -205,7 +208,7 @@ class RasterizerCanvasGLES2 : public RasterizerCanvasBaseGLES2 {
 		// if the shader is reading VERTEX, we prevent baking vertex positions with extra matrices etc
 		// to prevent the read position being incorrect.
 		// These flags are defined in RasterizerStorageGLES2::Shader::CanvasItem::BatchFlags
-		unsigned int joined_item_batch_flags;
+		uint32_t joined_item_batch_flags;
 
 		// measured in pixels, recalculated each frame
 		float scissor_threshold_area;

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1425,7 +1425,7 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 			p_shader->canvas_item.uses_screen_uv = false;
 			p_shader->canvas_item.uses_time = false;
 			p_shader->canvas_item.uses_modulate = false;
-			p_shader->canvas_item.reads_color = false;
+			p_shader->canvas_item.uses_color = false;
 			p_shader->canvas_item.reads_vertex = false;
 			p_shader->canvas_item.batch_flags = 0;
 
@@ -1443,8 +1443,8 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 			shaders.actions_canvas.usage_flag_pointers["SCREEN_TEXTURE"] = &p_shader->canvas_item.uses_screen_texture;
 			shaders.actions_canvas.usage_flag_pointers["TIME"] = &p_shader->canvas_item.uses_time;
 			shaders.actions_canvas.usage_flag_pointers["MODULATE"] = &p_shader->canvas_item.uses_modulate;
+			shaders.actions_canvas.usage_flag_pointers["COLOR"] = &p_shader->canvas_item.uses_color;
 
-			shaders.actions_canvas.read_flag_pointers["COLOR"] = &p_shader->canvas_item.reads_color;
 			shaders.actions_canvas.read_flag_pointers["VERTEX"] = &p_shader->canvas_item.reads_vertex;
 
 			actions = &shaders.actions_canvas;
@@ -1535,7 +1535,7 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 
 	// some logic for batching
 	if (p_shader->mode == VS::SHADER_CANVAS_ITEM) {
-		if (p_shader->canvas_item.uses_modulate | p_shader->canvas_item.reads_color) {
+		if (p_shader->canvas_item.uses_modulate | p_shader->canvas_item.uses_color) {
 			p_shader->canvas_item.batch_flags |= Shader::CanvasItem::PREVENT_COLOR_BAKING;
 		}
 		if (p_shader->canvas_item.reads_vertex) {

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -447,20 +447,20 @@ public:
 
 			int light_mode;
 
+			// these flags are specifically for batching
+			// some of the logic is thus in rasterizer_storage.cpp
+			// we could alternatively set bitflags for each 'uses' and test on the fly
 			enum BatchFlags {
 				PREVENT_COLOR_BAKING = 1 << 0,
 				PREVENT_VERTEX_BAKING = 1 << 1,
 			};
-			// these flags are specifically for batching
-			// some of the logic is thus in rasterizer_storage.cpp
-			// we could alternatively set bitflags for each 'uses' and test on the fly
 			unsigned int batch_flags;
 
 			bool uses_screen_texture;
 			bool uses_screen_uv;
 			bool uses_time;
 			bool uses_modulate;
-			bool reads_color;
+			bool uses_color;
 			bool reads_vertex;
 
 		} canvas_item;


### PR DESCRIPTION
Writing to COLOR in a custom shader can result in incorrect results if colors are baked (vertex color and modulate). This PR now prevents baking with COLOR input AND output (rather than just input as before), except under the special circumstances that final modulate is (1, 1, 1, 1), in which case the result will be correct. This should still allow color baking in many scenarios with custom shaders.

## Notes
* I've been going through the shader builtins systematically to try and identify ones that will interact with the batching, rather than relying on issues.
* As I suspected COLOR writes (as well as the existing detection for COLOR reads) also create wrong behaviour when final modulate is used. I didn't put it in initially because I was concerned it would break batching on all shaders as nearly everything writes to color. In practice detection only occurs in custom shaders, and there is no need to prevent baking when final modulate is white.
* Transforms are also possibles to add to the break batching, but in practice I can't see how they would be used without the vertex input (which would break batching). Although if we do see a problem they are easy enough to detect too.
* Ultimately I'd like to have an additional optional vertex format with separate color and vertex modulate, which will allow batching in these circumstances, but fixing visual regressions is first priority and will do for now.