### PR TITLE
Avoid copy PackedDataContainer::_iter_init_ofs

### DIFF
--- a/core/packed_data_container.cpp
+++ b/core/packed_data_container.cpp
@@ -49,12 +49,10 @@ int PackedDataContainer::size() const {
 
 Variant PackedDataContainer::_iter_init_ofs(const Array &p_iter, uint32_t p_offset) {
 
-	Array ref = p_iter;
 	uint32_t size = _size(p_offset);
-	if (size == 0 || ref.size() != 1)
+	if (size == 0 || p_iter.size() != 1)
 		return false;
 	else {
-		ref[0] = 0;
 		return true;
 	}
 }


### PR DESCRIPTION
I am pretty sure the local variable `ref` is not needed. It also performs a useless assignment operation.