### PR TITLE
Fix rename dialog size in 3.2

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -786,6 +786,9 @@ public:
 			_test_path();
 		}
 
+		// Reset the dialog to its initial size. Otherwise, the dialog window would be too large
+		// when opening a small dialog after closing a large dialog.
+		set_size(get_minimum_size());
 		popup_centered_minsize(Size2(500, 0) * EDSCALE);
 	}
 


### PR DESCRIPTION
Fixes #35008

This is a continuation of #36808 but only merging for 3.2 since this was already fixed in 4.0. [See my message here](https://github.com/godotengine/godot/pull/36808#issuecomment-627646453).

Code comment is from Hugo. Thanks :)