### PR TITLE
Make all String integer conversion methods be 64-bit

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -1062,7 +1062,7 @@ Error Expression::_get_token(Token &r_token) {
 					if (is_float) {
 						r_token.value = num.to_double();
 					} else {
-						r_token.value = num.to_int64();
+						r_token.value = num.to_int();
 					}
 					return OK;
 

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1618,49 +1618,7 @@ String::String(const StrRange &p_range) {
 	copy_from(p_range.c_str, p_range.len);
 }
 
-int String::hex_to_int(bool p_with_prefix) const {
-	if (p_with_prefix && length() < 3) {
-		return 0;
-	}
-
-	const CharType *s = ptr();
-
-	int sign = s[0] == '-' ? -1 : 1;
-
-	if (sign < 0) {
-		s++;
-	}
-
-	if (p_with_prefix) {
-		if (s[0] != '0' || s[1] != 'x') {
-			return 0;
-		}
-		s += 2;
-	}
-
-	int hex = 0;
-
-	while (*s) {
-		CharType c = LOWERCASE(*s);
-		int n;
-		if (c >= '0' && c <= '9') {
-			n = c - '0';
-		} else if (c >= 'a' && c <= 'f') {
-			n = (c - 'a') + 10;
-		} else {
-			return 0;
-		}
-
-		ERR_FAIL_COND_V_MSG(hex > INT32_MAX / 16, sign == 1 ? INT32_MAX : INT32_MIN, "Cannot represent " + *this + " as integer, provided value is " + (sign == 1 ? "too big." : "too small."));
-		hex *= 16;
-		hex += n;
-		s++;
-	}
-
-	return hex * sign;
-}
-
-int64_t String::hex_to_int64(bool p_with_prefix) const {
+int64_t String::hex_to_int(bool p_with_prefix) const {
 	if (p_with_prefix && length() < 3) {
 		return 0;
 	}
@@ -3813,7 +3771,7 @@ bool String::is_valid_ip_address() const {
 				continue;
 			}
 			if (n.is_valid_hex_number(false)) {
-				int nint = n.hex_to_int(false);
+				int64_t nint = n.hex_to_int(false);
 				if (nint < 0 || nint > 0xffff) {
 					return false;
 				}

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1660,7 +1660,7 @@ int64_t String::hex_to_int(bool p_with_prefix) const {
 	return hex * sign;
 }
 
-int64_t String::bin_to_int64(bool p_with_prefix) const {
+int64_t String::bin_to_int(bool p_with_prefix) const {
 	if (p_with_prefix && length() < 3) {
 		return 0;
 	}
@@ -1725,7 +1725,7 @@ int64_t String::to_int() const {
 	return integer * sign;
 }
 
-int String::to_int(const char *p_str, int p_len) {
+int64_t String::to_int(const char *p_str, int p_len) {
 	int to = 0;
 	if (p_len >= 0) {
 		to = p_len;
@@ -1735,13 +1735,13 @@ int String::to_int(const char *p_str, int p_len) {
 		}
 	}
 
-	int integer = 0;
-	int sign = 1;
+	int64_t integer = 0;
+	int64_t sign = 1;
 
 	for (int i = 0; i < to; i++) {
 		char c = p_str[i];
 		if (c >= '0' && c <= '9') {
-			ERR_FAIL_COND_V_MSG(integer > INT32_MAX / 10, sign == 1 ? INT32_MAX : INT32_MIN, "Cannot represent " + String(p_str).substr(0, to) + " as integer, provided value is " + (sign == 1 ? "too big." : "too small."));
+			ERR_FAIL_COND_V_MSG(integer > INT64_MAX / 10, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + String(p_str).substr(0, to) + " as an integer, provided value is " + (sign == 1 ? "too big." : "too small."));
 			integer *= 10;
 			integer += c - '0';
 

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1742,32 +1742,7 @@ int64_t String::bin_to_int64(bool p_with_prefix) const {
 	return binary * sign;
 }
 
-int String::to_int() const {
-	if (length() == 0) {
-		return 0;
-	}
-
-	int to = (find(".") >= 0) ? find(".") : length();
-
-	int integer = 0;
-	int sign = 1;
-
-	for (int i = 0; i < to; i++) {
-		CharType c = operator[](i);
-		if (c >= '0' && c <= '9') {
-			ERR_FAIL_COND_V_MSG(integer > INT32_MAX / 10, sign == 1 ? INT32_MAX : INT32_MIN, "Cannot represent " + *this + " as integer, provided value is " + (sign == 1 ? "too big." : "too small."));
-			integer *= 10;
-			integer += c - '0';
-
-		} else if (integer == 0 && c == '-') {
-			sign = -sign;
-		}
-	}
-
-	return integer * sign;
-}
-
-int64_t String::to_int64() const {
+int64_t String::to_int() const {
 	if (length() == 0) {
 		return 0;
 	}
@@ -1780,7 +1755,7 @@ int64_t String::to_int64() const {
 	for (int i = 0; i < to; i++) {
 		CharType c = operator[](i);
 		if (c >= '0' && c <= '9') {
-			ERR_FAIL_COND_V_MSG(integer > INT64_MAX / 10, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as 64-bit integer, provided value is " + (sign == 1 ? "too big." : "too small."));
+			ERR_FAIL_COND_V_MSG(integer > INT64_MAX / 10, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as an integer, provided value is " + (sign == 1 ? "too big." : "too small."));
 			integer *= 10;
 			integer += c - '0';
 

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -245,9 +245,8 @@ public:
 	bool is_numeric() const;
 	double to_double() const;
 	float to_float() const;
-	int hex_to_int(bool p_with_prefix = true) const;
 
-	int64_t hex_to_int64(bool p_with_prefix = true) const;
+	int64_t hex_to_int(bool p_with_prefix = true) const;
 	int64_t bin_to_int64(bool p_with_prefix = true) const;
 	int64_t to_int() const;
 	static int to_int(const char *p_str, int p_len = -1);

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -247,9 +247,9 @@ public:
 	float to_float() const;
 
 	int64_t hex_to_int(bool p_with_prefix = true) const;
-	int64_t bin_to_int64(bool p_with_prefix = true) const;
+	int64_t bin_to_int(bool p_with_prefix = true) const;
 	int64_t to_int() const;
-	static int to_int(const char *p_str, int p_len = -1);
+	static int64_t to_int(const char *p_str, int p_len = -1);
 	static double to_double(const char *p_str);
 	static double to_double(const CharType *p_str, const CharType **r_end = nullptr);
 	static int64_t to_int(const CharType *p_str, int p_len = -1, bool p_clamp = false);

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -246,11 +246,10 @@ public:
 	double to_double() const;
 	float to_float() const;
 	int hex_to_int(bool p_with_prefix = true) const;
-	int to_int() const;
 
 	int64_t hex_to_int64(bool p_with_prefix = true) const;
 	int64_t bin_to_int64(bool p_with_prefix = true) const;
-	int64_t to_int64() const;
+	int64_t to_int() const;
 	static int to_int(const char *p_str, int p_len = -1);
 	static double to_double(const char *p_str);
 	static double to_double(const CharType *p_str, const CharType **r_end = nullptr);

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1409,7 +1409,7 @@ Variant::operator int64_t() const {
 		case FLOAT:
 			return _data._float;
 		case STRING:
-			return operator String().to_int64();
+			return operator String().to_int();
 		default: {
 			return 0;
 		}

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -245,7 +245,7 @@ _FORCE_INLINE_ Error NetSocketPosix::_change_multicast_group(IP_Address p_ip, St
 			continue;
 		}
 
-		if_v6id = (uint32_t)c.index.to_int64();
+		if_v6id = (uint32_t)c.index.to_int();
 		if (type == IP::TYPE_IPV6) {
 			break; // IPv6 uses index.
 		}

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -233,9 +233,9 @@ void EditorFileSystem::_scan_filesystem() {
 
 				FileCache fc;
 				fc.type = split[1];
-				fc.modification_time = split[2].to_int64();
-				fc.import_modification_time = split[3].to_int64();
-				fc.import_valid = split[4].to_int64() != 0;
+				fc.modification_time = split[2].to_int();
+				fc.import_modification_time = split[3].to_int();
+				fc.import_valid = split[4].to_int() != 0;
 				fc.import_group_file = split[5].strip_edges();
 				fc.script_class_name = split[6].get_slice("<>", 0);
 				fc.script_class_extends = split[6].get_slice("<>", 1);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -376,13 +376,13 @@ void EditorPropertyMember::_property_select() {
 		selector->select_method_from_base_type(hint_text, current);
 
 	} else if (hint == MEMBER_METHOD_OF_INSTANCE) {
-		Object *instance = ObjectDB::get_instance(ObjectID(hint_text.to_int64()));
+		Object *instance = ObjectDB::get_instance(ObjectID(hint_text.to_int()));
 		if (instance) {
 			selector->select_method_from_instance(instance, current);
 		}
 
 	} else if (hint == MEMBER_METHOD_OF_SCRIPT) {
-		Object *obj = ObjectDB::get_instance(ObjectID(hint_text.to_int64()));
+		Object *obj = ObjectDB::get_instance(ObjectID(hint_text.to_int()));
 		if (Object::cast_to<Script>(obj)) {
 			selector->select_method_from_script(Object::cast_to<Script>(obj), current);
 		}
@@ -407,13 +407,13 @@ void EditorPropertyMember::_property_select() {
 		selector->select_property_from_base_type(hint_text, current);
 
 	} else if (hint == MEMBER_PROPERTY_OF_INSTANCE) {
-		Object *instance = ObjectDB::get_instance(ObjectID(hint_text.to_int64()));
+		Object *instance = ObjectDB::get_instance(ObjectID(hint_text.to_int()));
 		if (instance) {
 			selector->select_property_from_instance(instance, current);
 		}
 
 	} else if (hint == MEMBER_PROPERTY_OF_SCRIPT) {
-		Object *obj = ObjectDB::get_instance(ObjectID(hint_text.to_int64()));
+		Object *obj = ObjectDB::get_instance(ObjectID(hint_text.to_int()));
 		if (Object::cast_to<Script>(obj)) {
 			selector->select_property_from_script(Object::cast_to<Script>(obj), current);
 		}
@@ -487,7 +487,7 @@ void EditorPropertyEnum::setup(const Vector<String> &p_options) {
 	for (int i = 0; i < p_options.size(); i++) {
 		Vector<String> text_split = p_options[i].split(":");
 		if (text_split.size() != 1) {
-			current_val = text_split[1].to_int64();
+			current_val = text_split[1].to_int();
 		}
 		options->add_item(text_split[0]);
 		options->set_item_metadata(i, current_val);

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -110,7 +110,7 @@ void EditorResourcePreview::_preview_ready(const String &p_str, const Ref<Textur
 		uint64_t modified_time = 0;
 
 		if (p_str.begins_with("ID:")) {
-			hash = uint32_t(p_str.get_slicec(':', 2).to_int64());
+			hash = uint32_t(p_str.get_slicec(':', 2).to_int());
 			path = "ID:" + p_str.get_slicec(':', 1);
 		} else {
 			modified_time = FileAccess::get_modified_time(path);
@@ -257,9 +257,9 @@ void EditorResourcePreview::_thread() {
 						_generate_preview(texture, small_texture, item, cache_base);
 					} else {
 						uint64_t modtime = FileAccess::get_modified_time(item.path);
-						int tsize = f->get_line().to_int64();
+						int tsize = f->get_line().to_int();
 						bool has_small_texture = f->get_line().to_int();
-						uint64_t last_modtime = f->get_line().to_int64();
+						uint64_t last_modtime = f->get_line().to_int();
 
 						bool cache_valid = true;
 

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -594,7 +594,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			} else if (hint == PROPERTY_HINT_METHOD_OF_INSTANCE) {
 				MAKE_PROPSELECT
 
-				Object *instance = ObjectDB::get_instance(ObjectID(hint_text.to_int64()));
+				Object *instance = ObjectDB::get_instance(ObjectID(hint_text.to_int()));
 				if (instance) {
 					property_select->select_method_from_instance(instance, v);
 				}
@@ -604,7 +604,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			} else if (hint == PROPERTY_HINT_METHOD_OF_SCRIPT) {
 				MAKE_PROPSELECT
 
-				Object *obj = ObjectDB::get_instance(ObjectID(hint_text.to_int64()));
+				Object *obj = ObjectDB::get_instance(ObjectID(hint_text.to_int()));
 				if (Object::cast_to<Script>(obj)) {
 					property_select->select_method_from_script(Object::cast_to<Script>(obj), v);
 				}
@@ -643,7 +643,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			} else if (hint == PROPERTY_HINT_PROPERTY_OF_INSTANCE) {
 				MAKE_PROPSELECT
 
-				Object *instance = ObjectDB::get_instance(ObjectID(hint_text.to_int64()));
+				Object *instance = ObjectDB::get_instance(ObjectID(hint_text.to_int()));
 				if (instance) {
 					property_select->select_property_from_instance(instance, v);
 				}
@@ -654,7 +654,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			} else if (hint == PROPERTY_HINT_PROPERTY_OF_SCRIPT) {
 				MAKE_PROPSELECT
 
-				Object *obj = ObjectDB::get_instance(ObjectID(hint_text.to_int64()));
+				Object *obj = ObjectDB::get_instance(ObjectID(hint_text.to_int()));
 				if (Object::cast_to<Script>(obj)) {
 					property_select->select_property_from_script(Object::cast_to<Script>(obj), v);
 				}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -856,7 +856,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			}
 		} else if (I->get() == "--allow_focus_steal_pid") { // not exposed to user
 			if (I->next()) {
-				allow_focus_steal_pid = I->next()->get().to_int64();
+				allow_focus_steal_pid = I->next()->get().to_int();
 				N = I->next()->next();
 			} else {
 				OS::get_singleton()->print("Missing editor PID argument, aborting.\n");

--- a/main/tests/test_string.cpp
+++ b/main/tests/test_string.cpp
@@ -370,7 +370,7 @@ bool test_22() {
 	static const int num[4] = { 1237461283, -22, 0, -1123412 };
 
 	for (int i = 0; i < 4; i++) {
-		OS::get_singleton()->print("\tString: \"%s\" as Int is %i\n", nums[i], String(nums[i]).to_int());
+		OS::get_singleton()->print("\tString: \"%s\" as Int is %lli\n", nums[i], (long long)(String(nums[i]).to_int()));
 
 		if (String(nums[i]).to_int() != num[i]) {
 			return false;

--- a/modules/gdnative/gdnative/string.cpp
+++ b/modules/gdnative/gdnative/string.cpp
@@ -625,7 +625,7 @@ int64_t GDAPI godot_string_hex_to_int64_with_prefix(const godot_string *p_self) 
 int64_t GDAPI godot_string_to_int64(const godot_string *p_self) {
 	const String *self = (const String *)p_self;
 
-	return self->to_int64();
+	return self->to_int();
 }
 
 double GDAPI godot_string_unicode_char_to_double(const wchar_t *p_str, const wchar_t **r_end) {

--- a/modules/gdnative/gdnative/string.cpp
+++ b/modules/gdnative/gdnative/string.cpp
@@ -613,13 +613,13 @@ int64_t GDAPI godot_string_char_to_int64_with_len(const wchar_t *p_str, int p_le
 int64_t GDAPI godot_string_hex_to_int64(const godot_string *p_self) {
 	const String *self = (const String *)p_self;
 
-	return self->hex_to_int64(false);
+	return self->hex_to_int(false);
 }
 
 int64_t GDAPI godot_string_hex_to_int64_with_prefix(const godot_string *p_self) {
 	const String *self = (const String *)p_self;
 
-	return self->hex_to_int64();
+	return self->hex_to_int();
 }
 
 int64_t GDAPI godot_string_to_int64(const godot_string *p_self) {

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -961,7 +961,7 @@ void GDScriptTokenizerText::_advance() {
 						double val = str.to_double();
 						_make_constant(val);
 					} else {
-						int64_t val = str.to_int64();
+						int64_t val = str.to_int();
 						_make_constant(val);
 					}
 

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -955,7 +955,7 @@ void GDScriptTokenizerText::_advance() {
 						int64_t val = str.hex_to_int();
 						_make_constant(val);
 					} else if (bin_found) {
-						int64_t val = str.bin_to_int64();
+						int64_t val = str.bin_to_int();
 						_make_constant(val);
 					} else if (period_found || exponent_found) {
 						double val = str.to_double();

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -952,7 +952,7 @@ void GDScriptTokenizerText::_advance() {
 
 					INCPOS(i);
 					if (hexa_found) {
-						int64_t val = str.hex_to_int64();
+						int64_t val = str.hex_to_int();
 						_make_constant(val);
 					} else if (bin_found) {
 						int64_t val = str.bin_to_int64();

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -643,7 +643,7 @@ ShaderLanguage::Token ShaderLanguage::_get_token() {
 					}
 
 					if (hexa_found) {
-						tk.constant = (double)str.hex_to_int64(true);
+						tk.constant = (double)str.hex_to_int(true);
 					} else {
 						tk.constant = str.to_double();
 					}


### PR DESCRIPTION
Supersedes #27871.

The current 32-bit and 64-bit methods are identical to each other except for the size and limits of the data types. Godot 4.0 will target 64-bit systems as a priority. On a modern 64-bit CPU, these methods should perform identically, so there is no need for the 32-bit versions.

This PR removes the 32-bit versions, and removes the `64` suffix from the 64-bit versions.

Only the methods which parse strings and return integers are affected.

Test code:

```
func _ready():
	var text = "123456789123456789"
	prints("to_int :", text.to_int()) # Outputs "to_int : 123456789123456789"
```