### PR TITLE
GLES2 polyline drawn as GL_LINE_STRIP to match GLES3

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -1526,7 +1526,7 @@ void RasterizerCanvasGLES2::render_batches(Item::Command *const *p_commands, Ite
 										offset += to_draw * 2;
 									}
 								} else {
-									_draw_generic(GL_LINES, pline->lines.size(), pline->lines.ptr(), NULL, pline->line_colors.ptr(), pline->line_colors.size() == 1);
+									_draw_generic(GL_LINE_STRIP, pline->lines.size(), pline->lines.ptr(), NULL, pline->line_colors.ptr(), pline->line_colors.size() == 1);
 								}
 
 #ifdef GLES_OVER_GL


### PR DESCRIPTION
The behaviour of TYPE_POLYLINE appeared incorrect in GLES2, and inconsistent with GLES3 and the docs, which state that `draw_polyline` 'Draws interconnected line segments'. Also when drawing with triangles GLES2 draws interconnected segments.

This PR simply changes the primitive from GL_LINES to GL_LINE_STRIP as in GLES3.

Fixes #38703.

## Notes
Although this is 'correct', we should also consider that it is a breaking change, that may affect people who have been relying on the bugged behaviour. Do we have a `drawlines` methods they can change to that does multiple line segments?

It seems Item::Command::TYPE_LINE is for single lines. Maybe we could have some kind of variation of `draw_polyline` that allows separate segments?