### PR TITLE
C++: Apply some `modernize-*` checks from clang-tidy (nullptr, bool literals, void args)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,modernize-use-default-member-init'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,modernize-use-default-member-init,modernize-use-nullptr'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,modernize-use-default-member-init,modernize-use-nullptr'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-nullptr'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
@@ -32,8 +32,10 @@ CheckOptions:
     value:           llvm
   - key:             modernize-replace-auto-ptr.IncludeStyle
     value:           llvm
+  - key:             modernize-use-bool-literals.IgnoreMacros
+    value:           '0'
   - key:             modernize-use-default-member-init.IgnoreMacros
-    value:           '1'
+    value:           '0'
   - key:             modernize-use-default-member-init.UseAssignment
     value:           '1'
   - key:             modernize-use-nullptr.NullMacros

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-nullptr'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-*,modernize-redundant-void-arg,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-nullptr'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/core/callable.h
+++ b/core/callable.h
@@ -75,7 +75,7 @@ public:
 		return method == StringName() && object == 0;
 	}
 	_FORCE_INLINE_ bool is_custom() const {
-		return method == StringName() && custom != 0;
+		return method == StringName() && custom != nullptr;
 	}
 	_FORCE_INLINE_ bool is_standard() const {
 		return method != StringName();

--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -132,7 +132,7 @@ public:
 	}
 
 	_FORCE_INLINE_ void clear() { resize(0); }
-	_FORCE_INLINE_ bool empty() const { return _ptr == 0; }
+	_FORCE_INLINE_ bool empty() const { return _ptr == nullptr; }
 
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) {
 

--- a/core/hash_map.h
+++ b/core/hash_map.h
@@ -107,7 +107,7 @@ private:
 		hash_table_power = MIN_HASH_TABLE_POWER;
 		elements = 0;
 		for (int i = 0; i < (1 << MIN_HASH_TABLE_POWER); i++)
-			hash_table[i] = 0;
+			hash_table[i] = nullptr;
 	}
 
 	void erase_hash_table() {
@@ -115,7 +115,7 @@ private:
 		ERR_FAIL_COND_MSG(elements, "Cannot erase hash table if there are still elements inside.");
 
 		memdelete_arr(hash_table);
-		hash_table = 0;
+		hash_table = nullptr;
 		hash_table_power = 0;
 		elements = 0;
 	}
@@ -155,7 +155,7 @@ private:
 
 		for (int i = 0; i < (1 << new_hash_table_power); i++) {
 
-			new_hash_table[i] = 0;
+			new_hash_table[i] = nullptr;
 		}
 
 		if (hash_table) {
@@ -541,7 +541,7 @@ public:
 			memdelete_arr(hash_table);
 		}
 
-		hash_table = 0;
+		hash_table = nullptr;
 		hash_table_power = 0;
 		elements = 0;
 	}

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -474,7 +474,7 @@ void Image::convert(Format p_new_format) {
 	} else if (format > FORMAT_RGBA8 || p_new_format > FORMAT_RGBA8) {
 
 		//use put/set pixel which is slower but works with non byte formats
-		Image new_img(width, height, 0, p_new_format);
+		Image new_img(width, height, false, p_new_format);
 
 		for (int i = 0; i < width; i++) {
 			for (int j = 0; j < height; j++) {
@@ -492,7 +492,7 @@ void Image::convert(Format p_new_format) {
 		return;
 	}
 
-	Image new_img(width, height, 0, p_new_format);
+	Image new_img(width, height, false, p_new_format);
 
 	const uint8_t *rptr = data.ptr();
 	uint8_t *wptr = new_img.data.ptrw();
@@ -991,7 +991,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 	if (p_width == width && p_height == height)
 		return;
 
-	Image dst(p_width, p_height, 0, format);
+	Image dst(p_width, p_height, false, format);
 
 	// Setup mipmap-aware scaling
 	Image dst2;
@@ -1011,7 +1011,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 	}
 	bool interpolate_mipmaps = mipmap_aware && mip1 != mip2;
 	if (interpolate_mipmaps) {
-		dst2.create(p_width, p_height, 0, format);
+		dst2.create(p_width, p_height, false, format);
 	}
 
 	bool had_mipmaps = mipmaps;
@@ -1304,7 +1304,7 @@ void Image::crop_from_point(int p_x, int p_y, int p_width, int p_height) {
 	uint8_t pdata[16]; //largest is 16
 	uint32_t pixel_size = get_format_pixel_size(format);
 
-	Image dst(p_width, p_height, 0, format);
+	Image dst(p_width, p_height, false, format);
 
 	{
 		const uint8_t *r = data.ptr();
@@ -2157,7 +2157,7 @@ void Image::create(const char **p_xpm) {
 				if (line == colormap_size) {
 
 					status = READING_PIXELS;
-					create(size_width, size_height, 0, has_alpha ? FORMAT_RGBA8 : FORMAT_RGB8);
+					create(size_width, size_height, false, has_alpha ? FORMAT_RGBA8 : FORMAT_RGB8);
 					w = data.ptrw();
 					pixel_size = has_alpha ? 4 : 3;
 				}
@@ -3329,7 +3329,7 @@ Ref<Image> Image::rgbe_to_srgb() {
 
 	Ref<Image> new_image;
 	new_image.instance();
-	new_image->create(width, height, 0, Image::FORMAT_RGB8);
+	new_image->create(width, height, false, Image::FORMAT_RGB8);
 
 	for (int row = 0; row < height; row++) {
 		for (int col = 0; col < width; col++) {

--- a/core/io/file_access_buffered.h
+++ b/core/io/file_access_buffered.h
@@ -66,7 +66,7 @@ protected:
 		int offset;
 	} cache;
 
-	virtual int read_data_block(int p_offset, int p_size, uint8_t *p_dest = 0) const = 0;
+	virtual int read_data_block(int p_offset, int p_size, uint8_t *p_dest = nullptr) const = 0;
 
 	void set_cache_size(int p_size);
 	int get_cache_size();

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -283,7 +283,7 @@ void HTTPClient::close() {
 	body_size = -1;
 	body_left = 0;
 	chunk_left = 0;
-	chunk_trailer_part = 0;
+	chunk_trailer_part = false;
 	read_until_eof = false;
 	response_num = 0;
 	handshaking = false;

--- a/core/list.h
+++ b/core/list.h
@@ -182,14 +182,14 @@ public:
 	*/
 	_FORCE_INLINE_ const Element *front() const {
 
-		return _data ? _data->first : 0;
+		return _data ? _data->first : nullptr;
 	};
 
 	/**
 	* return an iterator to the beginning of the list.
 	*/
 	_FORCE_INLINE_ Element *front() {
-		return _data ? _data->first : 0;
+		return _data ? _data->first : nullptr;
 	};
 
 	/**
@@ -197,7 +197,7 @@ public:
 	*/
 	_FORCE_INLINE_ const Element *back() const {
 
-		return _data ? _data->last : 0;
+		return _data ? _data->last : nullptr;
 	};
 
 	/**
@@ -205,7 +205,7 @@ public:
 	*/
 	_FORCE_INLINE_ Element *back() {
 
-		return _data ? _data->last : 0;
+		return _data ? _data->last : nullptr;
 	};
 
 	/**
@@ -225,7 +225,7 @@ public:
 		n->value = (T &)value;
 
 		n->prev_ptr = _data->last;
-		n->next_ptr = 0;
+		n->next_ptr = nullptr;
 		n->data = _data;
 
 		if (_data->last) {
@@ -264,7 +264,7 @@ public:
 
 		Element *n = memnew_allocator(Element, A);
 		n->value = (T &)value;
-		n->prev_ptr = 0;
+		n->prev_ptr = nullptr;
 		n->next_ptr = _data->first;
 		n->data = _data;
 

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -69,8 +69,8 @@ public:
 	Vector3 get_median_point() const;
 	Vector3 get_closest_point_to(const Vector3 &p_point) const;
 
-	bool intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *p_intersection = 0) const;
-	bool intersects_segment(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *p_intersection = 0) const;
+	bool intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *p_intersection = nullptr) const;
+	bool intersects_segment(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *p_intersection = nullptr) const;
 
 	ClockDirection get_clock_dir() const; ///< todo, test if this is returning the proper clockwisity
 

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -190,7 +190,7 @@ public:
 		return dP.length(); // Return the closest distance.
 	}
 
-	static inline bool ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2, Vector3 *r_res = 0) {
+	static inline bool ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2, Vector3 *r_res = nullptr) {
 		Vector3 e1 = p_v1 - p_v0;
 		Vector3 e2 = p_v2 - p_v0;
 		Vector3 h = p_dir.cross(e2);
@@ -225,7 +225,7 @@ public:
 			return false;
 	}
 
-	static inline bool segment_intersects_triangle(const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2, Vector3 *r_res = 0) {
+	static inline bool segment_intersects_triangle(const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2, Vector3 *r_res = nullptr) {
 
 		Vector3 rel = p_to - p_from;
 		Vector3 e1 = p_v1 - p_v0;
@@ -262,7 +262,7 @@ public:
 			return false;
 	}
 
-	static inline bool segment_intersects_sphere(const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_sphere_pos, real_t p_sphere_radius, Vector3 *r_res = 0, Vector3 *r_norm = 0) {
+	static inline bool segment_intersects_sphere(const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_sphere_pos, real_t p_sphere_radius, Vector3 *r_res = nullptr, Vector3 *r_norm = nullptr) {
 
 		Vector3 sphere_pos = p_sphere_pos - p_from;
 		Vector3 rel = (p_to - p_from);
@@ -298,7 +298,7 @@ public:
 		return true;
 	}
 
-	static inline bool segment_intersects_cylinder(const Vector3 &p_from, const Vector3 &p_to, real_t p_height, real_t p_radius, Vector3 *r_res = 0, Vector3 *r_norm = 0) {
+	static inline bool segment_intersects_cylinder(const Vector3 &p_from, const Vector3 &p_to, real_t p_height, real_t p_radius, Vector3 *r_res = nullptr, Vector3 *r_norm = nullptr) {
 
 		Vector3 rel = (p_to - p_from);
 		real_t rel_l = rel.length();

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -56,7 +56,7 @@ public:
 
 	/* intersections */
 
-	bool intersect_3(const Plane &p_plane1, const Plane &p_plane2, Vector3 *r_result = 0) const;
+	bool intersect_3(const Plane &p_plane1, const Plane &p_plane2, Vector3 *r_result = nullptr) const;
 	bool intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *p_intersection) const;
 	bool intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 *p_intersection) const;
 

--- a/core/oa_hash_map.h
+++ b/core/oa_hash_map.h
@@ -90,7 +90,7 @@ private:
 		uint32_t pos = hash % capacity;
 		uint32_t distance = 0;
 
-		while (42) {
+		while (true) {
 			if (hashes[pos] == EMPTY_HASH) {
 				return false;
 			}
@@ -118,7 +118,7 @@ private:
 		TKey key = p_key;
 		TValue value = p_value;
 
-		while (42) {
+		while (true) {
 			if (hashes[pos] == EMPTY_HASH) {
 				_construct(pos, hash, key, value);
 

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -142,13 +142,13 @@ template <typename T>
 T *memnew_arr_template(size_t p_elements, const char *p_descr = "") {
 
 	if (p_elements == 0)
-		return 0;
+		return nullptr;
 	/** overloading operator new[] cannot be done , because it may not return the real allocated address (it may pad the 'element count' before the actual array). Because of that, it must be done by hand. This is the
 	same strategy used by std::vector, and the Vector class, so it should be safe.*/
 
 	size_t len = sizeof(T) * p_elements;
 	uint64_t *mem = (uint64_t *)Memory::alloc_static(len, true);
-	T *failptr = 0; //get rid of a warning
+	T *failptr = nullptr; //get rid of a warning
 	ERR_FAIL_COND_V(!mem, failptr);
 	*(mem - 1) = p_elements;
 

--- a/core/string_name.h
+++ b/core/string_name.h
@@ -85,7 +85,7 @@ class StringName {
 	StringName(_Data *p_data) { _data = p_data; }
 
 public:
-	operator const void *() const { return (_data && (_data->cname || !_data->name.empty())) ? (void *)1 : 0; }
+	operator const void *() const { return (_data && (_data->cname || !_data->name.empty())) ? (void *)1 : nullptr; }
 
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;

--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -115,7 +115,7 @@ Error png_to_image(const uint8_t *p_source, size_t p_size, Ref<Image> p_image) {
 	ERR_FAIL_COND_V(!success, ERR_FILE_CORRUPT);
 
 	//print_line("png width: "+itos(png_img.width)+" height: "+itos(png_img.height));
-	p_image->create(png_img.width, png_img.height, 0, dest_format, buffer);
+	p_image->create(png_img.width, png_img.height, false, dest_format, buffer);
 
 	return OK;
 }

--- a/drivers/unix/net_socket_posix.h
+++ b/drivers/unix/net_socket_posix.h
@@ -47,7 +47,7 @@
 class NetSocketPosix : public NetSocket {
 
 private:
-	SOCKET_TYPE _sock;
+	SOCKET_TYPE _sock; // NOLINT - the default value is defined in the .cpp
 	IP::Type _ip_type = IP::TYPE_NONE;
 	bool _is_stream = false;
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5955,7 +5955,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	insert_confirm_bezier->set_text(TTR("Use Bezier Curves"));
 	icvb->add_child(insert_confirm_bezier);
 	keying = false;
-	moving_selection = 0;
+	moving_selection = false;
 	key_edit = nullptr;
 	multi_key_edit = nullptr;
 

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -344,7 +344,7 @@ void EditorProfiler::_update_plot() {
 
 	Ref<Image> img;
 	img.instance();
-	img->create(w, h, 0, Image::FORMAT_RGBA8, graph_image);
+	img->create(w, h, false, Image::FORMAT_RGBA8, graph_image);
 
 	if (reset_texture) {
 

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -307,7 +307,7 @@ void EditorVisualProfiler::_update_plot() {
 
 	Ref<Image> img;
 	img.instance();
-	img->create(w, h, 0, Image::FORMAT_RGBA8, graph_image);
+	img->create(w, h, false, Image::FORMAT_RGBA8, graph_image);
 
 	if (reset_texture) {
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -864,7 +864,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 
 	ProjectSettings::CustomMap custom_map;
 	if (path_remaps.size()) {
-		if (1) { //new remap mode, use always as it's friendlier with multiple .pck exports
+		if (true) { //new remap mode, use always as it's friendlier with multiple .pck exports
 			for (int i = 0; i < path_remaps.size(); i += 2) {
 				String from = path_remaps[i];
 				String to = path_remaps[i + 1];

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -526,7 +526,7 @@ void EditorHelp::_update_doc() {
 		class_desc->push_font(doc_code_font);
 		class_desc->push_indent(1);
 		class_desc->push_table(2);
-		class_desc->set_table_column_expand(1, 1);
+		class_desc->set_table_column_expand(1, true);
 
 		for (int i = 0; i < cd.properties.size(); i++) {
 			property_line[cd.properties[i].name] = class_desc->get_line_count() - 2; //gets overridden if description
@@ -629,7 +629,7 @@ void EditorHelp::_update_doc() {
 		class_desc->push_font(doc_code_font);
 		class_desc->push_indent(1);
 		class_desc->push_table(2);
-		class_desc->set_table_column_expand(1, 1);
+		class_desc->set_table_column_expand(1, true);
 
 		bool any_previous = false;
 		for (int pass = 0; pass < 2; pass++) {
@@ -698,7 +698,7 @@ void EditorHelp::_update_doc() {
 
 		class_desc->push_indent(1);
 		class_desc->push_table(2);
-		class_desc->set_table_column_expand(1, 1);
+		class_desc->set_table_column_expand(1, true);
 
 		for (int i = 0; i < cd.theme_properties.size(); i++) {
 
@@ -1005,7 +1005,7 @@ void EditorHelp::_update_doc() {
 			property_line[cd.properties[i].name] = class_desc->get_line_count() - 2;
 
 			class_desc->push_table(2);
-			class_desc->set_table_column_expand(1, 1);
+			class_desc->set_table_column_expand(1, true);
 
 			class_desc->push_cell();
 			class_desc->push_font(doc_code_font);

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -797,7 +797,7 @@ Ref<Texture2D> CurvePreviewGenerator::generate(const Ref<Resource> &p_from, cons
 	img_ref.instance();
 	Image &im = **img_ref;
 
-	im.create(thumbnail_size, thumbnail_size / 2, 0, Image::FORMAT_RGBA8);
+	im.create(thumbnail_size, thumbnail_size / 2, false, Image::FORMAT_RGBA8);
 
 	Color bg_color(0.1, 0.1, 0.1, 1.0);
 	for (int i = 0; i < thumbnail_size; i++) {

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -223,7 +223,7 @@ Ref<Texture2D> EditorBitmapPreviewPlugin::generate(const RES &p_from, const Size
 
 	Ref<Image> img;
 	img.instance();
-	img->create(bm->get_size().width, bm->get_size().height, 0, Image::FORMAT_L8, data);
+	img->create(bm->get_size().width, bm->get_size().height, false, Image::FORMAT_L8, data);
 
 	if (img->is_compressed()) {
 		if (img->decompress() != OK)
@@ -511,7 +511,7 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 	Ref<Image> img;
 	img.instance();
 	int thumbnail_size = MAX(p_size.x, p_size.y);
-	img->create(thumbnail_size, thumbnail_size, 0, Image::FORMAT_RGBA8);
+	img->create(thumbnail_size, thumbnail_size, false, Image::FORMAT_RGBA8);
 
 	Color bg_color = EditorSettings::get_singleton()->get("text_editor/highlighting/background_color");
 	Color keyword_color = EditorSettings::get_singleton()->get("text_editor/highlighting/keyword_color");

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -168,7 +168,7 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 
 	//generate previews!
 
-	if (1) {
+	if (true) {
 
 		Vector<Ref<Mesh>> meshes;
 		Vector<Transform> transforms;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3885,7 +3885,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	_edit.mode = TRANSFORM_NONE;
 	_edit.plane = TRANSFORM_VIEW;
 	_edit.edited_gizmo = 0;
-	_edit.snap = 1;
+	_edit.snap = true;
 	_edit.gizmo_handle = 0;
 
 	index = p_index;

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -477,6 +477,6 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 	interface->connect("var_changed", Callable(this, "_changed"));
 }
 ShaderGlobalsEditor::~ShaderGlobalsEditor() {
-	inspector->edit(NULL);
+	inspector->edit(nullptr);
 	memdelete(interface);
 }

--- a/main/tests/test_astar.cpp
+++ b/main/tests/test_astar.cpp
@@ -352,7 +352,7 @@ bool test_solutions() {
 	return true;
 }
 
-typedef bool (*TestFunc)(void);
+typedef bool (*TestFunc)();
 
 TestFunc test_funcs[] = {
 	test_abc,

--- a/main/tests/test_ordered_hash_map.cpp
+++ b/main/tests/test_ordered_hash_map.cpp
@@ -130,7 +130,7 @@ bool test_const_iteration() {
 	return test_const_iteration(map);
 }
 
-typedef bool (*TestFunc)(void);
+typedef bool (*TestFunc)();
 
 TestFunc test_funcs[] = {
 

--- a/main/tests/test_shader_lang.cpp
+++ b/main/tests/test_shader_lang.cpp
@@ -363,7 +363,7 @@ MainLoop *test() {
 	Set<String> types;
 	types.insert("spatial");
 
-	Error err = sl.compile(code, dt, rm, types, NULL);
+	Error err = sl.compile(code, dt, rm, types, nullptr);
 
 	if (err) {
 

--- a/main/tests/test_string.cpp
+++ b/main/tests/test_string.cpp
@@ -1129,7 +1129,7 @@ bool test_35() {
 	return state;
 }
 
-typedef bool (*TestFunc)(void);
+typedef bool (*TestFunc)();
 
 TestFunc test_funcs[] = {
 

--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -153,7 +153,7 @@ Error ImageLoaderBMP::convert_to_image(Ref<Image> p_image,
 
 		if (p_color_buffer == nullptr || color_table_size == 0) { // regular pixels
 
-			p_image->create(width, height, 0, Image::FORMAT_RGBA8, data);
+			p_image->create(width, height, false, Image::FORMAT_RGBA8, data);
 
 		} else { // data is in indexed format, extend it
 
@@ -193,7 +193,7 @@ Error ImageLoaderBMP::convert_to_image(Ref<Image> p_image,
 
 				dest += 4;
 			}
-			p_image->create(width, height, 0, Image::FORMAT_RGBA8, extended_data);
+			p_image->create(width, height, false, Image::FORMAT_RGBA8, extended_data);
 		}
 	}
 	return err;

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -205,7 +205,7 @@ bool BulletPhysicsDirectSpaceState::cast_motion(const RID &p_shape, const Transf
 /// Returns the list of contacts pairs in this order: Local contact, other body contact
 bool BulletPhysicsDirectSpaceState::collide_shape(RID p_shape, const Transform &p_shape_xform, float p_margin, Vector3 *r_results, int p_result_max, int &r_result_count, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas) {
 	if (p_result_max <= 0)
-		return 0;
+		return false;
 
 	ShapeBullet *shape = space->get_physics_server()->get_shape_owner()->getornull(p_shape);
 
@@ -213,7 +213,7 @@ bool BulletPhysicsDirectSpaceState::collide_shape(RID p_shape, const Transform &
 	if (!btShape->isConvex()) {
 		bulletdelete(btShape);
 		ERR_PRINT("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));
-		return 0;
+		return false;
 	}
 	btConvexShape *btConvex = static_cast<btConvexShape *>(btShape);
 
@@ -245,7 +245,7 @@ bool BulletPhysicsDirectSpaceState::rest_info(RID p_shape, const Transform &p_sh
 	if (!btShape->isConvex()) {
 		bulletdelete(btShape);
 		ERR_PRINT("The shape is not a convex shape, then is not supported: shape type: " + itos(shape->get_type()));
-		return 0;
+		return false;
 	}
 	btConvexShape *btConvex = static_cast<btConvexShape *>(btShape);
 

--- a/modules/gdnative/include/videodecoder/godot_videodecoder.h
+++ b/modules/gdnative/include/videodecoder/godot_videodecoder.h
@@ -46,7 +46,7 @@ typedef struct
 	void *next;
 	void *(*constructor)(godot_object *);
 	void (*destructor)(void *);
-	const char *(*get_plugin_name)(void);
+	const char *(*get_plugin_name)();
 	const char **(*get_supported_extensions)(int *count);
 	godot_bool (*open_file)(void *, void *); // data struct, and a FileAccess pointer
 	godot_real (*get_length)(const void *);

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1289,7 +1289,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						gdfs->state.instance = p_instance;
 						p_instance->pending_func_states.add(&gdfs->instances_list);
 					} else {
-						gdfs->state.instance = NULL;
+						gdfs->state.instance = nullptr;
 					}
 				}
 #ifdef DEBUG_ENABLED

--- a/modules/glslang/register_types.cpp
+++ b/modules/glslang/register_types.cpp
@@ -130,15 +130,15 @@ static const TBuiltInResource default_builtin_resource = {
 	/*maxTaskWorkGroupSizeZ_NV*/ 0,
 	/*maxMeshViewCountNV*/ 0,
 	/*limits*/ {
-			/*nonInductiveForLoops*/ 1,
-			/*whileLoops*/ 1,
-			/*doWhileLoops*/ 1,
-			/*generalUniformIndexing*/ 1,
-			/*generalAttributeMatrixVectorIndexing*/ 1,
-			/*generalVaryingIndexing*/ 1,
-			/*generalSamplerIndexing*/ 1,
-			/*generalVariableIndexing*/ 1,
-			/*generalConstantMatrixVectorIndexing*/ 1,
+			/*nonInductiveForLoops*/ true,
+			/*whileLoops*/ true,
+			/*doWhileLoops*/ true,
+			/*generalUniformIndexing*/ true,
+			/*generalAttributeMatrixVectorIndexing*/ true,
+			/*generalVaryingIndexing*/ true,
+			/*generalSamplerIndexing*/ true,
+			/*generalVariableIndexing*/ true,
+			/*generalConstantMatrixVectorIndexing*/ true,
 	}
 };
 

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -1405,8 +1405,8 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 			Vector3 points[4];
 			for (int j = 0; j < 4; j++) {
 
-				static const bool orderx[4] = { 0, 1, 1, 0 };
-				static const bool ordery[4] = { 0, 0, 1, 1 };
+				static const bool orderx[4] = { false, true, true, false };
+				static const bool ordery[4] = { false, false, true, true };
 
 				Vector3 sp;
 				if (orderx[j]) {

--- a/modules/jpg/image_loader_jpegd.cpp
+++ b/modules/jpg/image_loader_jpegd.cpp
@@ -96,7 +96,7 @@ Error jpeg_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p
 	else
 		fmt = Image::FORMAT_RGB8;
 
-	p_image->create(image_width, image_height, 0, fmt, data);
+	p_image->create(image_width, image_height, false, fmt, data);
 
 	return OK;
 }

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -295,7 +295,7 @@ void CSharpLanguage::get_reserved_words(List<String> *p_words) const {
 		"when",
 		"where",
 		"yield",
-		0
+		nullptr
 	};
 
 	const char **w = _reserved_words;

--- a/modules/mono/editor/godotsharp_export.cpp
+++ b/modules/mono/editor/godotsharp_export.cpp
@@ -78,7 +78,7 @@ Error get_assembly_dependencies(GDMonoAssembly *p_assembly, const Vector<String>
 		if (r_assembly_dependencies.has(ref_name))
 			continue;
 
-		GDMonoAssembly *ref_assembly = NULL;
+		GDMonoAssembly *ref_assembly = nullptr;
 
 		{
 			MonoAssemblyName *ref_aname = mono_assembly_name_new("A"); // We can't allocate an empty MonoAssemblyName, hence "A"

--- a/modules/pvr/texture_loader_pvr.cpp
+++ b/modules/pvr/texture_loader_pvr.cpp
@@ -261,9 +261,9 @@ struct PVRTCBlock {
 _FORCE_INLINE_ bool is_po2(uint32_t p_input) {
 
 	if (p_input == 0)
-		return 0;
+		return false;
 	uint32_t minus1 = p_input - 1;
-	return ((p_input | minus1) == (p_input ^ minus1)) ? 1 : 0;
+	return ((p_input | minus1) == (p_input ^ minus1)) ? true : false;
 }
 
 static void unpack_5554(const PVRTCBlock *p_block, int p_ab_colors[2][4]) {

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -199,7 +199,7 @@ Error ImageLoaderTGA::convert_to_image(Ref<Image> p_image, const uint8_t *p_buff
 		}
 	}
 
-	p_image->create(width, height, 0, Image::FORMAT_RGBA8, image_data);
+	p_image->create(width, height, false, Image::FORMAT_RGBA8, image_data);
 
 	return OK;
 }

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -80,7 +80,7 @@ int VideoStreamPlaybackTheora::queue_page(ogg_page *page) {
 	return 0;
 }
 
-void VideoStreamPlaybackTheora::video_write(void) {
+void VideoStreamPlaybackTheora::video_write() {
 	th_ycbcr_buffer yuv;
 	th_decode_ycbcr_out(td, yuv);
 

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -63,7 +63,7 @@ class VideoStreamPlaybackTheora : public VideoStreamPlayback {
 
 	int buffer_data();
 	int queue_page(ogg_page *page);
-	void video_write(void);
+	void video_write();
 	float get_time() const;
 
 	bool theora_eos;

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -172,7 +172,7 @@ void VisualScriptPropertySelector::_update_search() {
 					item->set_metadata(0, F->get().name);
 					item->set_icon(0, type_icons[F->get().type]);
 					item->set_metadata(1, "get");
-					item->set_collapsed(1);
+					item->set_collapsed(true);
 					item->set_selectable(0, true);
 					item->set_selectable(1, false);
 					item->set_selectable(2, false);
@@ -257,7 +257,7 @@ void VisualScriptPropertySelector::_update_search() {
 			item->set_selectable(0, true);
 
 			item->set_metadata(1, "method");
-			item->set_collapsed(1);
+			item->set_collapsed(true);
 			item->set_selectable(1, false);
 
 			item->set_selectable(2, false);
@@ -320,7 +320,7 @@ void VisualScriptPropertySelector::create_visualscript_item(const String &name, 
 		item->set_metadata(0, name);
 		item->set_metadata(1, "action");
 		item->set_selectable(0, true);
-		item->set_collapsed(1);
+		item->set_collapsed(true);
 		item->set_selectable(1, false);
 		item->set_selectable(2, false);
 		item->set_metadata(2, connecting);

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -135,7 +135,7 @@ Error webp_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p
 
 	ERR_FAIL_COND_V_MSG(errdec, ERR_FILE_CORRUPT, "Failed decoding WebP image.");
 
-	p_image->create(features.width, features.height, 0, features.has_alpha ? Image::FORMAT_RGBA8 : Image::FORMAT_RGB8, dst_image);
+	p_image->create(features.width, features.height, false, features.has_alpha ? Image::FORMAT_RGBA8 : Image::FORMAT_RGB8, dst_image);
 
 	return OK;
 }

--- a/modules/websocket/editor_debugger_server_websocket.cpp
+++ b/modules/websocket/editor_debugger_server_websocket.cpp
@@ -87,6 +87,6 @@ EditorDebuggerServerWebSocket::~EditorDebuggerServerWebSocket() {
 }
 
 EditorDebuggerServer *EditorDebuggerServerWebSocket::create(const String &p_protocol) {
-	ERR_FAIL_COND_V(p_protocol != "ws://", NULL);
+	ERR_FAIL_COND_V(p_protocol != "ws://", nullptr);
 	return memnew(EditorDebuggerServerWebSocket);
 }

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -123,12 +123,12 @@ RemoteDebuggerPeerWebSocket::RemoteDebuggerPeerWebSocket(Ref<WebSocketPeer> p_pe
 }
 
 RemoteDebuggerPeer *RemoteDebuggerPeerWebSocket::create(const String &p_uri) {
-	ERR_FAIL_COND_V(!p_uri.begins_with("ws://") && !p_uri.begins_with("wss://"), NULL);
+	ERR_FAIL_COND_V(!p_uri.begins_with("ws://") && !p_uri.begins_with("wss://"), nullptr);
 	RemoteDebuggerPeerWebSocket *peer = memnew(RemoteDebuggerPeerWebSocket);
 	Error err = peer->connect_to_host(p_uri);
 	if (err != OK) {
 		memdelete(peer);
-		return NULL;
+		return nullptr;
 	}
 	return peer;
 }

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -723,7 +723,7 @@ void Polygon2D::_bind_methods() {
 
 Polygon2D::Polygon2D() {
 
-	invert = 0;
+	invert = false;
 	invert_border = 100;
 	antialiased = false;
 	tex_rot = 0;

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -269,11 +269,11 @@ void XRController3D::set_controller_id(int p_controller_id) {
 	update_configuration_warning();
 };
 
-int XRController3D::get_controller_id(void) const {
+int XRController3D::get_controller_id() const {
 	return controller_id;
 };
 
-String XRController3D::get_controller_name(void) const {
+String XRController3D::get_controller_name() const {
 	// get our XRServer
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, String());
@@ -465,7 +465,7 @@ void XRAnchor3D::set_anchor_id(int p_anchor_id) {
 	update_configuration_warning();
 };
 
-int XRAnchor3D::get_anchor_id(void) const {
+int XRAnchor3D::get_anchor_id() const {
 	return anchor_id;
 };
 
@@ -473,7 +473,7 @@ Vector3 XRAnchor3D::get_size() const {
 	return size;
 };
 
-String XRAnchor3D::get_anchor_name(void) const {
+String XRAnchor3D::get_anchor_name() const {
 	// get our XRServer
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, String());

--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -84,8 +84,8 @@ protected:
 
 public:
 	void set_controller_id(int p_controller_id);
-	int get_controller_id(void) const;
-	String get_controller_name(void) const;
+	int get_controller_id() const;
+	String get_controller_name() const;
 
 	int get_joystick_id() const;
 	bool is_button_pressed(int p_button) const;
@@ -97,7 +97,7 @@ public:
 	bool get_is_active() const;
 	XRPositionalTracker::TrackerHand get_hand() const;
 
-	Ref<Mesh> get_mesh(void) const;
+	Ref<Mesh> get_mesh() const;
 
 	String get_configuration_warning() const;
 
@@ -125,15 +125,15 @@ protected:
 
 public:
 	void set_anchor_id(int p_anchor_id);
-	int get_anchor_id(void) const;
-	String get_anchor_name(void) const;
+	int get_anchor_id() const;
+	String get_anchor_name() const;
 
 	bool get_is_active() const;
 	Vector3 get_size() const;
 
 	Plane get_plane() const;
 
-	Ref<Mesh> get_mesh(void) const;
+	Ref<Mesh> get_mesh() const;
 
 	String get_configuration_warning() const;
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -544,7 +544,7 @@ public:
 
 	void clear();
 
-	TreeItem *create_item(TreeItem *p_parent = 0, int p_idx = -1);
+	TreeItem *create_item(TreeItem *p_parent = nullptr, int p_idx = -1);
 	TreeItem *get_root();
 	TreeItem *get_last_item();
 

--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -206,7 +206,7 @@ void ShaderGlobalsOverride::_get_property_list(List<PropertyInfo> *p_list) const
 			Override o;
 			o.in_use = false;
 			Callable::CallError ce;
-			o.override = Variant::construct(pinfo.type, NULL, 0, ce);
+			o.override = Variant::construct(pinfo.type, nullptr, 0, ce);
 			overrides[variables[i]] = o;
 		}
 

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -164,7 +164,7 @@ float Environment::get_ambient_light_sky_contribution() const {
 
 	return ambient_sky_contribution;
 }
-int Environment::get_camera_feed_id(void) const {
+int Environment::get_camera_feed_id() const {
 
 	return camera_feed_id;
 }

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -200,7 +200,7 @@ public:
 	Color get_ambient_light_color() const;
 	float get_ambient_light_energy() const;
 	float get_ambient_light_sky_contribution() const;
-	int get_camera_feed_id(void) const;
+	int get_camera_feed_id() const;
 
 	void set_tonemapper(ToneMapper p_tone_mapper);
 	ToneMapper get_tonemapper() const;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2690,7 +2690,7 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 	depth_draw_mode = DEPTH_DRAW_OPAQUE_ONLY;
 	cull_mode = CULL_BACK;
 	for (int i = 0; i < FLAG_MAX; i++) {
-		flags[i] = 0;
+		flags[i] = false;
 	}
 	flags[FLAG_USE_TEXTURE_REPEAT] = true;
 

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -69,7 +69,7 @@ Vector<String> Theme::_get_stylebox_list(const String &p_type) const {
 	return ilret;
 }
 
-Vector<String> Theme::_get_stylebox_types(void) const {
+Vector<String> Theme::_get_stylebox_types() const {
 
 	Vector<String> ilret;
 	List<StringName> il;

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -54,7 +54,7 @@ class Theme : public Resource {
 
 	Vector<String> _get_icon_list(const String &p_type) const;
 	Vector<String> _get_stylebox_list(const String &p_type) const;
-	Vector<String> _get_stylebox_types(void) const;
+	Vector<String> _get_stylebox_types() const;
 	Vector<String> _get_font_list(const String &p_type) const;
 	Vector<String> _get_color_list(const String &p_type) const;
 	Vector<String> _get_constant_list(const String &p_type) const;

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -311,7 +311,7 @@ bool PhysicsDirectSpaceState2DSW::cast_motion(const RID &p_shape, const Transfor
 bool PhysicsDirectSpaceState2DSW::collide_shape(RID p_shape, const Transform2D &p_shape_xform, const Vector2 &p_motion, real_t p_margin, Vector2 *r_results, int p_result_max, int &r_result_count, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas) {
 
 	if (p_result_max <= 0)
-		return 0;
+		return false;
 
 	Shape2DSW *shape = PhysicsServer2DSW::singletonsw->shape_owner.getornull(p_shape);
 	ERR_FAIL_COND_V(!shape, 0);

--- a/servers/physics_3d/joints/generic_6dof_joint_3d_sw.cpp
+++ b/servers/physics_3d/joints/generic_6dof_joint_3d_sw.cpp
@@ -688,5 +688,5 @@ bool Generic6DOFJoint3DSW::get_flag(Vector3::Axis p_axis, PhysicsServer3D::G6DOF
 			break; // Can't happen, but silences warning
 	}
 
-	return 0;
+	return false;
 }

--- a/servers/physics_3d/joints/generic_6dof_joint_3d_sw.cpp
+++ b/servers/physics_3d/joints/generic_6dof_joint_3d_sw.cpp
@@ -411,7 +411,7 @@ real_t Generic6DOFJoint3DSW::getAngle(int axis_index) const {
 	return m_calculatedAxisAngleDiff[axis_index];
 }
 
-void Generic6DOFJoint3DSW::calcAnchorPos(void) {
+void Generic6DOFJoint3DSW::calcAnchorPos() {
 	real_t imA = A->get_inv_mass();
 	real_t imB = B->get_inv_mass();
 	real_t weight;

--- a/servers/physics_3d/joints/generic_6dof_joint_3d_sw.h
+++ b/servers/physics_3d/joints/generic_6dof_joint_3d_sw.h
@@ -389,7 +389,7 @@ public:
 		return B;
 	}
 
-	virtual void calcAnchorPos(void); // overridable
+	virtual void calcAnchorPos(); // overridable
 
 	void set_param(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisParam p_param, real_t p_value);
 	real_t get_param(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisParam p_param) const;

--- a/servers/physics_3d/joints/slider_joint_3d_sw.cpp
+++ b/servers/physics_3d/joints/slider_joint_3d_sw.cpp
@@ -304,7 +304,7 @@ void SliderJoint3DSW::solve(real_t p_step) {
 
 //-----------------------------------------------------------------------------
 
-void SliderJoint3DSW::calculateTransforms(void) {
+void SliderJoint3DSW::calculateTransforms() {
 	m_calculatedTransformA = A->get_transform() * m_frameInA;
 	m_calculatedTransformB = B->get_transform() * m_frameInB;
 	m_realPivotAInW = m_calculatedTransformA.origin;
@@ -323,7 +323,7 @@ void SliderJoint3DSW::calculateTransforms(void) {
 
 //-----------------------------------------------------------------------------
 
-void SliderJoint3DSW::testLinLimits(void) {
+void SliderJoint3DSW::testLinLimits() {
 	m_solveLinLim = false;
 	m_linPos = m_depth[0];
 	if (m_lowerLinLimit <= m_upperLinLimit) {
@@ -343,7 +343,7 @@ void SliderJoint3DSW::testLinLimits(void) {
 
 //-----------------------------------------------------------------------------
 
-void SliderJoint3DSW::testAngLimits(void) {
+void SliderJoint3DSW::testAngLimits() {
 	m_angDepth = real_t(0.);
 	m_solveAngLim = false;
 	if (m_lowerAngLimit <= m_upperAngLimit) {
@@ -363,7 +363,7 @@ void SliderJoint3DSW::testAngLimits(void) {
 
 //-----------------------------------------------------------------------------
 
-Vector3 SliderJoint3DSW::getAncorInA(void) {
+Vector3 SliderJoint3DSW::getAncorInA() {
 	Vector3 ancorInA;
 	ancorInA = m_realPivotAInW + (m_lowerLinLimit + m_upperLinLimit) * real_t(0.5) * m_sliderAxis;
 	ancorInA = A->get_transform().inverse().xform(ancorInA);
@@ -372,7 +372,7 @@ Vector3 SliderJoint3DSW::getAncorInA(void) {
 
 //-----------------------------------------------------------------------------
 
-Vector3 SliderJoint3DSW::getAncorInB(void) {
+Vector3 SliderJoint3DSW::getAncorInB() {
 	Vector3 ancorInB;
 	ancorInB = m_frameInB.origin;
 	return ancorInB;

--- a/servers/physics_3d/joints/slider_joint_3d_sw.h
+++ b/servers/physics_3d/joints/slider_joint_3d_sw.h
@@ -230,12 +230,12 @@ public:
 	bool getSolveAngLimit() { return m_solveAngLim; }
 	real_t getAngDepth() { return m_angDepth; }
 	// shared code used by ODE solver
-	void calculateTransforms(void);
-	void testLinLimits(void);
-	void testAngLimits(void);
+	void calculateTransforms();
+	void testLinLimits();
+	void testAngLimits();
 	// access for PE Solver
-	Vector3 getAncorInA(void);
-	Vector3 getAncorInB(void);
+	Vector3 getAncorInA();
+	Vector3 getAncorInB();
 
 	void set_param(PhysicsServer3D::SliderJointParam p_param, real_t p_value);
 	real_t get_param(PhysicsServer3D::SliderJointParam p_param) const;

--- a/servers/physics_3d/physics_server_3d_sw.h
+++ b/servers/physics_3d/physics_server_3d_sw.h
@@ -307,7 +307,7 @@ public:
 
 	virtual void soft_body_remove_all_pinned_points(RID p_body) {}
 	virtual void soft_body_pin_point(RID p_body, int p_point_index, bool p_pin) {}
-	virtual bool soft_body_is_point_pinned(RID p_body, int p_point_index) { return 0; }
+	virtual bool soft_body_is_point_pinned(RID p_body, int p_point_index) { return false; }
 
 	/* JOINT API */
 

--- a/servers/physics_3d/space_3d_sw.cpp
+++ b/servers/physics_3d/space_3d_sw.cpp
@@ -331,7 +331,7 @@ bool PhysicsDirectSpaceState3DSW::cast_motion(const RID &p_shape, const Transfor
 bool PhysicsDirectSpaceState3DSW::collide_shape(RID p_shape, const Transform &p_shape_xform, real_t p_margin, Vector3 *r_results, int p_result_max, int &r_result_count, const Set<RID> &p_exclude, uint32_t p_collision_mask, bool p_collide_with_bodies, bool p_collide_with_areas) {
 
 	if (p_result_max <= 0)
-		return 0;
+		return false;
 
 	Shape3DSW *shape = static_cast<PhysicsServer3DSW *>(PhysicsServer3D::get_singleton())->shape_owner.getornull(p_shape);
 	ERR_FAIL_COND_V(!shape, 0);

--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
@@ -4896,7 +4896,7 @@ void RasterizerStorageRD::_update_decal_atlas() {
 		Vector<DecalAtlas::SortItem> itemsv;
 		itemsv.resize(decal_atlas.textures.size());
 		int base_size = 8;
-		const RID *K = NULL;
+		const RID *K = nullptr;
 
 		int idx = 0;
 		while ((K = decal_atlas.textures.next(K))) {
@@ -5050,7 +5050,7 @@ void RasterizerStorageRD::_update_decal_atlas() {
 
 				RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(mm.fb, RD::INITIAL_ACTION_CLEAR, RD::FINAL_ACTION_READ, RD::INITIAL_ACTION_DROP, RD::FINAL_ACTION_DISCARD, cc);
 
-				const RID *K = NULL;
+				const RID *K = nullptr;
 				while ((K = decal_atlas.textures.next(K))) {
 					DecalAtlas::Texture *t = decal_atlas.textures.getptr(*K);
 					Texture *src_tex = texture_owner.getornull(*K);
@@ -5459,7 +5459,7 @@ Vector<StringName> RasterizerStorageRD::global_variable_get_list() const {
 		ERR_FAIL_V_MSG(Vector<StringName>(), "This function should never be used outside the editor, it can severely damage performance.");
 	}
 
-	const StringName *K = NULL;
+	const StringName *K = nullptr;
 	Vector<StringName> names;
 	while ((K = global_variables.variables.next(K))) {
 		names.push_back(*K);

--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
@@ -2732,7 +2732,7 @@ void RasterizerStorageRD::_multimesh_make_local(MultiMesh *multimesh) const {
 	uint32_t data_cache_dirty_region_count = (multimesh->instances - 1) / MULTIMESH_DIRTY_REGION_SIZE + 1;
 	multimesh->data_cache_dirty_regions = memnew_arr(bool, data_cache_dirty_region_count);
 	for (uint32_t i = 0; i < data_cache_dirty_region_count; i++) {
-		multimesh->data_cache_dirty_regions[i] = 0;
+		multimesh->data_cache_dirty_regions[i] = false;
 	}
 	multimesh->data_cache_used_dirty_regions = 0;
 }


### PR DESCRIPTION
Follow-up to #38697.

See available checks at https://clang.llvm.org/extra/clang-tidy/checks/list.html

I also tried:
- [modernize-deprecated-headers](https://clang.llvm.org/extra/clang-tidy/checks/modernize-deprecated-headers.html) but it breaks the codebase, as we use some code like `is_inf`, and Clang on my distro can't even find `cstdint` by default.
- [modernize-raw-string-literal](https://clang.llvm.org/extra/clang-tidy/checks/modernize-raw-string-literal.html) is nice, but it breaks our logic to extract strings with `TTR()`, so `editor/translations/extract.py` would have to be fixed (and the raw string would have to be re-escaped in Python before outputting the POT file for gettext).

There's a few more that we may want to evaluate:
- https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-equals-default.html
- https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-equals-delete.html
- https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-override.html
- https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-using.html