### PR TITLE
Android: Check for use of deprecated GodotPaymentV3 module, direct to new plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@ local.properties
 .idea
 .gradletasknamecache
 project.properties
-platform/android/java/libs/*
 platform/android/java/app/libs/*
+platform/android/java/libs/*
+platform/android/java/lib/.cxx/
 
 # General c++ generated files
 *.lib

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -99,7 +99,7 @@
 			<argument index="0" name="name" type="String">
 			</argument>
 			<description>
-				Returns a global singleton with given [code]name[/code]. Often used for plugins, e.g. GodotPayments.
+				Returns a global singleton with given [code]name[/code]. Often used for plugins, e.g. [code]GodotPayment[/code] on Android.
 			</description>
 		</method>
 		<method name="get_version_info" qualifiers="const">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -180,7 +180,8 @@
 	</methods>
 	<members>
 		<member name="android/modules" type="String" setter="" getter="" default="&quot;&quot;">
-			Comma-separated list of custom Android modules (which must have been built in the Android export templates) using their Java package path, e.g. [code]org/godotengine/org/GodotPaymentV3,org/godotengine/godot/MyCustomSingleton"[/code].
+			Comma-separated list of custom Android modules (which must have been built in the Android export templates) using their Java package path, e.g. [code]"org/godotengine/godot/MyCustomSingleton,com/example/foo/FrenchFriesFactory"[/code].
+			[b]Note:[/b] Since Godot 3.2.2, the [code]org/godotengine/godot/GodotPaymentV3[/code] module was deprecated and replaced by the [code]GodotPayment[/code] plugin which should be enabled in the Android export preset by adding [code]GodotPayment[/code] to the [code]custom_template/plugins[/code] option. The singleton to access in code was also renamed to [code]GodotPayment[/code].
 		</member>
 		<member name="application/boot_splash/bg_color" type="Color" setter="" getter="" default="Color( 0.14, 0.14, 0.14, 1 )">
 			Background color for the boot splash.

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1777,6 +1777,20 @@ public:
 			err += etc_error;
 		}
 
+		// The GodotPaymentV3 module was converted to the GodotPayment plugin in Godot 3.2.2,
+		// this check helps users to notice the change to ensure that they change their settings.
+		String modules = ProjectSettings::get_singleton()->get("android/modules");
+		if (modules.find("org/godotengine/godot/GodotPaymentV3") != -1) {
+			String plugins = p_preset->get("custom_template/plugins");
+			if (plugins.split(",", false).find("GodotPayment") == -1) {
+				valid = false;
+				err += TTR("Invalid \"GodotPaymentV3\" module included in the \"android/modules\" project setting (changed in Godot 3.2.2).\n"
+						   "Replace it by the \"GodotPayment\" plugin, which should be listed in the \"custom_template/plugins\" preset option.\n"
+						   "Note that the singleton was also renamed from \"GodotPayments\" to \"GodotPayment\".");
+				err += "\n";
+			}
+		}
+
 		r_error = err;
 		return valid;
 	}

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -91,6 +91,13 @@ static void _initialize_java_modules() {
 
 			String m = mods[i];
 
+			// Deprecated in Godot 3.2.2, it's now a plugin to enable in export preset.
+			if (m == "org/godotengine/godot/GodotPaymentV3") {
+				WARN_PRINT("GodotPaymentV3 is deprecated and is replaced by the 'GodotPayment' plugin, which should be enabled in the Android export preset.");
+				print_line("Skipping Android module: " + m);
+				continue;
+			}
+
 			print_line("Loading Android module: " + m);
 			jstring strClassName = env->NewStringUTF(m.utf8().get_data());
 			jclass singletonClass = (jclass)env->CallObjectMethod(cls, findClass, strClassName);


### PR DESCRIPTION
Previous changes broke compatibility in the 3.2 branch for projects using `org/godotengine/godot/GodotPaymentV3`, leading to crashes when using Godot 3.2.2.

This should ensure that affected users notice the change and are prevented from exporting their project to Android until they do the necessary migration.

Fixes #38581.

----

Note: I have yet to test the changes myself.

*Edit:* Tested now, seem to work OK.