### PR TITLE
Silence mulitple may be used uninitialized warnings in RenderingDeviceVulkan::uniform_set_create()

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -4500,6 +4500,12 @@ RID RenderingDeviceVulkan::uniform_set_create(const Vector<Uniform> &p_uniforms,
 		write.pNext = nullptr;
 		write.dstSet = VK_NULL_HANDLE; //will assign afterwards when everything is valid
 		write.dstBinding = set_uniform.binding;
+		write.dstArrayElement = 0;
+		write.descriptorCount = 0;
+		write.descriptorType = VK_DESCRIPTOR_TYPE_MAX_ENUM; //Invalid value.
+		write.pImageInfo = nullptr;
+		write.pBufferInfo = nullptr;
+		write.pTexelBufferView = nullptr;
 		uint32_t type_size = 1;
 
 		switch (uniform.type) {


### PR DESCRIPTION
In addition, since there are still a few uniform types that have not been implemented, there is now an easy way to check for these using `(descriptorType == VK_DESCRIPTOR_TYPE_MAX_ENUM)`.

For example, this check can be inserted before adding the `VkWriteDescriptorSet` to the collection here:
https://github.com/godotengine/godot/blob/00949f0c5fcc6a4f8382a4a97d5591fd9ec380f8/drivers/vulkan/rendering_device_vulkan.cpp#L4739
Or simply before they are used.