### PR TITLE
Document the Camera3D's `effects` property

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -176,6 +176,7 @@
 			If not [constant DOPPLER_TRACKING_DISABLED], this camera will simulate the [url=https://en.wikipedia.org/wiki/Doppler_effect]Doppler effect[/url] for objects changed in particular [code]_process[/code] methods. See [enum DopplerTracking] for possible values.
 		</member>
 		<member name="effects" type="CameraEffects" setter="set_effects" getter="get_effects">
+			The [CameraEffects] to use for this camera.
 		</member>
 		<member name="environment" type="Environment" setter="set_environment" getter="get_environment">
 			The [Environment] to use for this camera.


### PR DESCRIPTION
This makes the Camera3D documentation 100% complete.

**Note:** Not eligible for cherry-picking to the `3.2` branch, as Camera3D and CameraEffects were added in 4.0.