### PR TITLE
Hide editor_spin_slider grabber when closing Editor's windows

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -186,6 +186,7 @@ void EditorSpinSlider::_notification(int p_what) {
 			p_what == NOTIFICATION_WM_FOCUS_IN ||
 			p_what == NOTIFICATION_EXIT_TREE) {
 		if (grabbing_spinner) {
+			grabber->hide();
 			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
 			grabbing_spinner = false;
 			grabbing_spinner_attempt = false;


### PR DESCRIPTION
Fixes: #38740

I was able to reproduce that ONCE, then I did the change - the bug disappeared.
But then - I've reverted code to original state (without my change) - aaaannnddd....bug was still gone :thinking: 
Weirdest bug ever :smile: 