### PR TITLE
Fix #include <windows.h> for case-senstive cross-compilation.

### DIFF
--- a/thirdparty/oidn/0001-window.h-case-sensitive.patch
+++ b/thirdparty/oidn/0001-window.h-case-sensitive.patch
@@ -1,0 +1,13 @@
+diff --git a/thirdparty/oidn/common/platform.h b/thirdparty/oidn/common/platform.h
+index 205ac8981d..9373b617b5 100644
+--- a/thirdparty/oidn/common/platform.h
++++ b/thirdparty/oidn/common/platform.h
+@@ -19,7 +19,7 @@
+ #if defined(_WIN32)
+   #define WIN32_LEAN_AND_MEAN
+   #define NOMINMAX
+-  #include <Windows.h>
++  #include <windows.h>
+ #elif defined(__APPLE__)
+   #include <sys/sysctl.h>
+ #endif

--- a/thirdparty/oidn/common/platform.h
+++ b/thirdparty/oidn/common/platform.h
@@ -19,7 +19,7 @@
 #if defined(_WIN32)
   #define WIN32_LEAN_AND_MEAN
   #define NOMINMAX
-  #include <Windows.h>
+  #include <windows.h>
 #elif defined(__APPLE__)
   #include <sys/sysctl.h>
 #endif


### PR DESCRIPTION
Fixes "common/platform.h:22:12: fatal error: Windows.h: No such file or directory" error when trying to cross-compile for Windows using mingw-64 compiler on Linux, because on Linux filenames are case-sensitive.

Includes the patch file should it be needed. The upstream PR request can be found [here](https://github.com/OpenImageDenoise/oidn/pull/72).