### PR TITLE
[3.2.2] Fix incorrect initialize notification in language server

### DIFF
--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -486,7 +486,7 @@ struct TextDocumentSyncOptions {
 	 * If present save notifications are sent to the server. If omitted the notification should not be
 	 * sent.
 	 */
-	SaveOptions save;
+	bool save = false;
 
 	Dictionary to_json() {
 		Dictionary dict;
@@ -494,7 +494,7 @@ struct TextDocumentSyncOptions {
 		dict["willSave"] = willSave;
 		dict["openClose"] = openClose;
 		dict["change"] = change;
-		dict["save"] = save.to_json();
+		dict["save"] = save;
 		return dict;
 	}
 };
@@ -1642,7 +1642,7 @@ struct ServerCapabilities {
 
 	_FORCE_INLINE_ Dictionary to_json() {
 		Dictionary dict;
-		dict["textDocumentSync"] = (int)textDocumentSync.change;
+		dict["textDocumentSync"] = textDocumentSync.to_json();
 		dict["completionProvider"] = completionProvider.to_json();
 		signatureHelpProvider.triggerCharacters.push_back(",");
 		signatureHelpProvider.triggerCharacters.push_back("(");

--- a/modules/jsonrpc/jsonrpc.cpp
+++ b/modules/jsonrpc/jsonrpc.cpp
@@ -120,7 +120,7 @@ Variant JSONRPC::process_action(const Variant &p_action, bool p_process_arr_elem
 		}
 
 		if (object == NULL || !object->has_method(method)) {
-			ret = make_response_error(JSONRPC::METHOD_NOT_FOUND, "Method not found", id);
+			ret = make_response_error(JSONRPC::METHOD_NOT_FOUND, "Method not found: " + method, id);
 		} else {
 			Variant call_ret = object->callv(method, args);
 			if (id.get_type() != Variant::NIL) {


### PR DESCRIPTION
Fixes #38766 
This PR fixes the currently incorrect initialize notification sent by the language server to accurately reflect the capabilities of the server.  Additionally, I have added a minor improvement to the JSONRPC module's error reporting to improve the quality of later bug reports related to the language server.