### PR TITLE
Fix GDNative wrapper type sizes (RID, Variant, Packed*Array), add size checks.

### DIFF
--- a/modules/gdnative/gdnative/aabb.cpp
+++ b/modules/gdnative/gdnative/aabb.cpp
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_aabb) == sizeof(AABB), "AABB size mismatch");
+
 void GDAPI godot_aabb_new(godot_aabb *r_dest, const godot_vector3 *p_pos, const godot_vector3 *p_size) {
 	const Vector3 *pos = (const Vector3 *)p_pos;
 	const Vector3 *size = (const Vector3 *)p_size;

--- a/modules/gdnative/gdnative/array.cpp
+++ b/modules/gdnative/gdnative/array.cpp
@@ -41,6 +41,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_array) == sizeof(Array), "Array size mismatch");
+
 void GDAPI godot_array_new(godot_array *r_dest) {
 	Array *dest = (Array *)r_dest;
 	memnew_placement(dest, Array);

--- a/modules/gdnative/gdnative/basis.cpp
+++ b/modules/gdnative/gdnative/basis.cpp
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_basis) == sizeof(Basis), "Basis size mismatch");
+
 void GDAPI godot_basis_new_with_rows(godot_basis *r_dest, const godot_vector3 *p_x_axis, const godot_vector3 *p_y_axis, const godot_vector3 *p_z_axis) {
 	const Vector3 *x_axis = (const Vector3 *)p_x_axis;
 	const Vector3 *y_axis = (const Vector3 *)p_y_axis;

--- a/modules/gdnative/gdnative/color.cpp
+++ b/modules/gdnative/gdnative/color.cpp
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_color) == sizeof(Color), "Color size mismatch");
+
 void GDAPI godot_color_new_rgba(godot_color *r_dest, const godot_real p_r, const godot_real p_g, const godot_real p_b, const godot_real p_a) {
 	Color *dest = (Color *)r_dest;
 	*dest = Color(p_r, p_g, p_b, p_a);

--- a/modules/gdnative/gdnative/dictionary.cpp
+++ b/modules/gdnative/gdnative/dictionary.cpp
@@ -39,6 +39,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_dictionary) == sizeof(Dictionary), "Dictionary size mismatch");
+
 void GDAPI godot_dictionary_new(godot_dictionary *r_dest) {
 	Dictionary *dest = (Dictionary *)r_dest;
 	memnew_placement(dest, Dictionary);

--- a/modules/gdnative/gdnative/node_path.cpp
+++ b/modules/gdnative/gdnative/node_path.cpp
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_node_path) == sizeof(NodePath), "NodePath size mismatch");
+
 void GDAPI godot_node_path_new(godot_node_path *r_dest, const godot_string *p_from) {
 	NodePath *dest = (NodePath *)r_dest;
 	const String *from = (const String *)p_from;

--- a/modules/gdnative/gdnative/plane.cpp
+++ b/modules/gdnative/gdnative/plane.cpp
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_plane) == sizeof(Plane), "Plane size mismatch");
+
 void GDAPI godot_plane_new_with_reals(godot_plane *r_dest, const godot_real p_a, const godot_real p_b, const godot_real p_c, const godot_real p_d) {
 	Plane *dest = (Plane *)r_dest;
 	*dest = Plane(p_a, p_b, p_c, p_d);

--- a/modules/gdnative/gdnative/pool_arrays.cpp
+++ b/modules/gdnative/gdnative/pool_arrays.cpp
@@ -42,6 +42,14 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_packed_byte_array) == sizeof(Vector<uint8_t>), "Vector<uint8_t> size mismatch");
+static_assert(sizeof(godot_packed_int_array) == sizeof(Vector<godot_int>), "Vector<godot_int> size mismatch");
+static_assert(sizeof(godot_packed_real_array) == sizeof(Vector<godot_real>), "Vector<godot_real> size mismatch");
+static_assert(sizeof(godot_packed_string_array) == sizeof(Vector<String>), "Vector<String> size mismatch");
+static_assert(sizeof(godot_packed_vector2_array) == sizeof(Vector<Vector2>), "Vector<Vector2> size mismatch");
+static_assert(sizeof(godot_packed_vector3_array) == sizeof(Vector<Vector3>), "Vector<Vector3> size mismatch");
+static_assert(sizeof(godot_packed_color_array) == sizeof(Vector<Color>), "Vector<Color> size mismatch");
+
 #define memnew_placement_custom(m_placement, m_class, m_constr) _post_initialize(new (m_placement, sizeof(m_class), "") m_constr)
 
 // byte

--- a/modules/gdnative/gdnative/quat.cpp
+++ b/modules/gdnative/gdnative/quat.cpp
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_quat) == sizeof(Quat), "Quat size mismatch");
+
 void GDAPI godot_quat_new(godot_quat *r_dest, const godot_real p_x, const godot_real p_y, const godot_real p_z, const godot_real p_w) {
 	Quat *dest = (Quat *)r_dest;
 	*dest = Quat(p_x, p_y, p_z, p_w);

--- a/modules/gdnative/gdnative/rect2.cpp
+++ b/modules/gdnative/gdnative/rect2.cpp
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_rect2) == sizeof(Rect2), "Rect2 size mismatch");
+
 void GDAPI godot_rect2_new_with_position_and_size(godot_rect2 *r_dest, const godot_vector2 *p_pos, const godot_vector2 *p_size) {
 	const Vector2 *position = (const Vector2 *)p_pos;
 	const Vector2 *size = (const Vector2 *)p_size;

--- a/modules/gdnative/gdnative/rid.cpp
+++ b/modules/gdnative/gdnative/rid.cpp
@@ -38,6 +38,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_rid) == sizeof(RID), "RID size mismatch");
+
 void GDAPI godot_rid_new(godot_rid *r_dest) {
 	RID *dest = (RID *)r_dest;
 	memnew_placement(dest, RID);

--- a/modules/gdnative/gdnative/string.cpp
+++ b/modules/gdnative/gdnative/string.cpp
@@ -40,6 +40,10 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_char_string) == sizeof(CharString), "CharString size mismatch");
+static_assert(sizeof(godot_string) == sizeof(String), "String size mismatch");
+static_assert(sizeof(godot_char_type) == sizeof(CharType), "CharType size mismatch");
+
 godot_int GDAPI godot_char_string_length(const godot_char_string *p_cs) {
 	const CharString *cs = (const CharString *)p_cs;
 

--- a/modules/gdnative/gdnative/string_name.cpp
+++ b/modules/gdnative/gdnative/string_name.cpp
@@ -39,6 +39,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_string_name) == sizeof(StringName), "StringName size mismatch");
+
 void GDAPI godot_string_name_new(godot_string_name *r_dest, const godot_string *p_name) {
 	StringName *dest = (StringName *)r_dest;
 	const String *name = (const String *)p_name;

--- a/modules/gdnative/gdnative/transform.cpp
+++ b/modules/gdnative/gdnative/transform.cpp
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_transform) == sizeof(Transform), "Transform size mismatch");
+
 void GDAPI godot_transform_new_with_axis_origin(godot_transform *r_dest, const godot_vector3 *p_x_axis, const godot_vector3 *p_y_axis, const godot_vector3 *p_z_axis, const godot_vector3 *p_origin) {
 	const Vector3 *x_axis = (const Vector3 *)p_x_axis;
 	const Vector3 *y_axis = (const Vector3 *)p_y_axis;

--- a/modules/gdnative/gdnative/transform2d.cpp
+++ b/modules/gdnative/gdnative/transform2d.cpp
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_transform2d) == sizeof(Transform2D), "Transform2D size mismatch");
+
 void GDAPI godot_transform2d_new(godot_transform2d *r_dest, const godot_real p_rot, const godot_vector2 *p_pos) {
 	const Vector2 *pos = (const Vector2 *)p_pos;
 	Transform2D *dest = (Transform2D *)r_dest;

--- a/modules/gdnative/gdnative/variant.cpp
+++ b/modules/gdnative/gdnative/variant.cpp
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_variant) == sizeof(Variant), "Variant size mismatch");
+
 // Workaround GCC ICE on armv7hl which was affected GCC 6.0 up to 8.0 (GH-16100).
 // It was fixed upstream in 8.1, and a fix was backported to 7.4.
 // This can be removed once no supported distro ships with versions older than 7.4.

--- a/modules/gdnative/gdnative/vector2.cpp
+++ b/modules/gdnative/gdnative/vector2.cpp
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_vector2) == sizeof(Vector2), "Vector2 size mismatch");
+
 void GDAPI godot_vector2_new(godot_vector2 *r_dest, const godot_real p_x, const godot_real p_y) {
 	Vector2 *dest = (Vector2 *)r_dest;
 	*dest = Vector2(p_x, p_y);

--- a/modules/gdnative/gdnative/vector3.cpp
+++ b/modules/gdnative/gdnative/vector3.cpp
@@ -37,6 +37,8 @@
 extern "C" {
 #endif
 
+static_assert(sizeof(godot_vector3) == sizeof(Vector3), "Vector3 size mismatch");
+
 void GDAPI godot_vector3_new(godot_vector3 *r_dest, const godot_real p_x, const godot_real p_y, const godot_real p_z) {
 	Vector3 *dest = (Vector3 *)r_dest;
 	*dest = Vector3(p_x, p_y, p_z);

--- a/modules/gdnative/include/gdnative/pool_arrays.h
+++ b/modules/gdnative/include/gdnative/pool_arrays.h
@@ -39,7 +39,7 @@ extern "C" {
 
 /////// PackedByteArray
 
-#define GODOT_PACKED_BYTE_ARRAY_SIZE sizeof(void *)
+#define GODOT_PACKED_BYTE_ARRAY_SIZE (2 * sizeof(void *))
 
 #ifndef GODOT_CORE_API_GODOT_PACKED_BYTE_ARRAY_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_PACKED_BYTE_ARRAY_TYPE_DEFINED
@@ -50,7 +50,7 @@ typedef struct {
 
 /////// PackedInt32Array
 
-#define GODOT_PACKED_INT_ARRAY_SIZE sizeof(void *)
+#define GODOT_PACKED_INT_ARRAY_SIZE (2 * sizeof(void *))
 
 #ifndef GODOT_CORE_API_GODOT_PACKED_INT_ARRAY_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_PACKED_INT_ARRAY_TYPE_DEFINED
@@ -61,7 +61,7 @@ typedef struct {
 
 /////// PackedFloat32Array
 
-#define GODOT_PACKED_REAL_ARRAY_SIZE sizeof(void *)
+#define GODOT_PACKED_REAL_ARRAY_SIZE (2 * sizeof(void *))
 
 #ifndef GODOT_CORE_API_GODOT_PACKED_REAL_ARRAY_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_PACKED_REAL_ARRAY_TYPE_DEFINED
@@ -72,7 +72,7 @@ typedef struct {
 
 /////// PackedStringArray
 
-#define GODOT_PACKED_STRING_ARRAY_SIZE sizeof(void *)
+#define GODOT_PACKED_STRING_ARRAY_SIZE (2 * sizeof(void *))
 
 #ifndef GODOT_CORE_API_GODOT_PACKED_STRING_ARRAY_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_PACKED_STRING_ARRAY_TYPE_DEFINED
@@ -83,7 +83,7 @@ typedef struct {
 
 /////// PackedVector2Array
 
-#define GODOT_PACKED_VECTOR2_ARRAY_SIZE sizeof(void *)
+#define GODOT_PACKED_VECTOR2_ARRAY_SIZE (2 * sizeof(void *))
 
 #ifndef GODOT_CORE_API_GODOT_PACKED_VECTOR2_ARRAY_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_PACKED_VECTOR2_ARRAY_TYPE_DEFINED
@@ -94,7 +94,7 @@ typedef struct {
 
 /////// PackedVector3Array
 
-#define GODOT_PACKED_VECTOR3_ARRAY_SIZE sizeof(void *)
+#define GODOT_PACKED_VECTOR3_ARRAY_SIZE (2 * sizeof(void *))
 
 #ifndef GODOT_CORE_API_GODOT_PACKED_VECTOR3_ARRAY_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_PACKED_VECTOR3_ARRAY_TYPE_DEFINED
@@ -105,7 +105,7 @@ typedef struct {
 
 /////// PackedColorArray
 
-#define GODOT_PACKED_COLOR_ARRAY_SIZE sizeof(void *)
+#define GODOT_PACKED_COLOR_ARRAY_SIZE (2 * sizeof(void *))
 
 #ifndef GODOT_CORE_API_GODOT_PACKED_COLOR_ARRAY_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_PACKED_COLOR_ARRAY_TYPE_DEFINED

--- a/modules/gdnative/include/gdnative/rid.h
+++ b/modules/gdnative/include/gdnative/rid.h
@@ -37,7 +37,7 @@ extern "C" {
 
 #include <stdint.h>
 
-#define GODOT_RID_SIZE sizeof(void *)
+#define GODOT_RID_SIZE sizeof(uint64_t)
 
 #ifndef GODOT_CORE_API_GODOT_RID_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_RID_TYPE_DEFINED

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -37,7 +37,7 @@ extern "C" {
 
 #include <stdint.h>
 
-#define GODOT_VARIANT_SIZE (16 + sizeof(void *))
+#define GODOT_VARIANT_SIZE (16 + sizeof(int64_t))
 
 #ifndef GODOT_CORE_API_GODOT_VARIANT_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_VARIANT_TYPE_DEFINED


### PR DESCRIPTION
**Adds static asserts to check GDNative type sizes.**

**Fixes size of the following types:**
- `Packed*Array`s → was not changed after moving from PollVector (was 1 * `void*`), now contains extra write object (2 * `void*`).
- `RID` → is 64-bit unsigned integer on all platforms (was `void*`, too small on 32-bit platforms).
- `Variant` → type (16-bit) + union of pointer and 64-bit integer (was 16 + `void*`, too small on 32-platforms).

Fixes: #38748 (except possibly redundant assignments).