### PR TITLE
[DOC] Update description of Object.free() method

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -194,7 +194,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Deletes the object from memory. Any pre-existing reference to the freed object will now return [code]null[/code].
+				Deletes the object from memory. Any pre-existing reference to the freed object will become invalid, e.g. [code]is_instance_valid(object)[/code] will return [code]false[/code].
 			</description>
 		</method>
 		<method name="get" qualifiers="const">


### PR DESCRIPTION
Clarify that variables pointing to an object don't become `null` when that object is freed, it just makes them invalid.

Fixes #35534