### PR TITLE
Small fix for AUTO_TILE

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -324,8 +324,12 @@ void TileMapEditor::_set_cell(const Point2i &p_pos, Vector<int> p_values, bool p
 			node->set_cell_autotile_coord(p_pos.x, p_pos.y, position);
 		} else if (node->get_tileset()->tile_get_tile_mode(p_value) == TileSet::ATLAS_TILE && priority_atlastile) {
 			// BIND_CENTER is used to indicate that bitmask should not update for this tile cell.
+			// This is a hack, as the ATLAS_TILE has no bitmask, it is being used only to avoid the
+			// update, enforcing an autotile_coord to this cell inside TileMap::update_cell_bitmask.
 			node->get_tileset()->autotile_set_bitmask(p_value, Vector2(p_pos.x, p_pos.y), TileSet::BIND_CENTER);
 			node->update_cell_bitmask(p_pos.x, p_pos.y);
+			// Clearing the bitmask. As it is no longer necessary.
+			node->get_tileset()->autotile_set_bitmask(p_value, Vector2(p_pos.x, p_pos.y), 0);
 		}
 	} else {
 		node->update_bitmask_area(Point2(p_pos));


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/36972#issuecomment-625995506
![after_2 mp4](https://user-images.githubusercontent.com/1387165/82127771-88873780-978c-11ea-973d-fd9bacf8faeb.gif)

Also fix `AUTO_TILE` without priority. The bitmask must be reset after the update, otherwise, when cleaning the cells that were placed manually, it will behave as if the `enable_priority` was on.

Before (without priority):
![before mp4](https://user-images.githubusercontent.com/1387165/82127125-abfbb380-9787-11ea-8d3e-cbfb3750031d.gif)
After (without priority):
![after mp4](https://user-images.githubusercontent.com/1387165/82127127-ae5e0d80-9787-11ea-8e57-660de53e5593.gif)

