### PR TITLE
Fix popup window size calculation in popup_centered_ratio by using Rect2

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -992,7 +992,7 @@ void Window::popup_centered_ratio(float p_ratio) {
 	ERR_FAIL_COND(!is_inside_tree());
 	ERR_FAIL_COND_MSG(window_id == DisplayServer::MAIN_WINDOW_ID, "Can't popup the main window.");
 
-	Rect2i parent_rect;
+	Rect2 parent_rect;
 
 	if (is_embedded()) {
 		parent_rect = get_parent_viewport()->get_visible_rect();


### PR DESCRIPTION
This is to prevent https://github.com/godotengine/godot/blob/163687d17a8a11da3cf1a3595c511a5f8fc94571/scene/main/window.cpp#L1007 from turning 0,0.
Seems like a typo from https://github.com/godotengine/godot/commit/197cb4e7718034aba35832a547477dfc858a7280.
Affects and fixes parts of issues like Issue1 of #37401, fixes #38726.
Completely fixes Quick Open dialogs, Orphan Resource Explorer and lots of other stuff that use popup_centered_ratio().

Note: This PR only does not fix file_dialog when the Project Manager is the main window(but that's a different issue caused by wrong parent window size being reported).