### PR TITLE
TextEdit search returns Dictionary instead of Vector

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -299,7 +299,7 @@
 			</description>
 		</method>
 		<method name="search" qualifiers="const">
-			<return type="PackedInt32Array">
+			<return type="Dictionary">
 			</return>
 			<argument index="0" name="key" type="String">
 			</argument>
@@ -311,13 +311,13 @@
 			</argument>
 			<description>
 				Perform a search inside the text. Search flags can be specified in the [enum SearchFlags] enum.
-				Returns an empty [code]PackedInt32Array[/code] if no result was found. Otherwise, the result line and column can be accessed at indices specified in the [enum SearchResult] enum, e.g:
+				Returns an empty [code]Dictionary[/code] if no result was found. Otherwise, returns a [code]Dictionary[/code] containing [code]line[/code] and [code]column[/code] entries, e.g:
 				[codeblock]
 				var result = search(key, flags, line, column)
-				if result.size() &gt; 0:
+				if !result.empty():
 				    # Result found.
-				    var res_line = result[TextEdit.SEARCH_RESULT_LINE]
-				    var res_column = result[TextEdit.SEARCH_RESULT_COLUMN]
+				    var line_number = result.line
+				    var column_number = result.column
 				[/codeblock]
 			</description>
 		</method>
@@ -535,12 +535,6 @@
 		</constant>
 		<constant name="SEARCH_BACKWARDS" value="4" enum="SearchFlags">
 			Search from end to beginning.
-		</constant>
-		<constant name="SEARCH_RESULT_COLUMN" value="0" enum="SearchResult">
-			Used to access the result column from [method search].
-		</constant>
-		<constant name="SEARCH_RESULT_LINE" value="1" enum="SearchResult">
-			Used to access the result line from [method search].
 		</constant>
 		<constant name="MENU_CUT" value="0" enum="MenuItems">
 			Cuts (copies and clears) the selected text.

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5447,17 +5447,16 @@ int TextEdit::_get_column_pos_of_word(const String &p_key, const String &p_searc
 	return col;
 }
 
-Vector<int> TextEdit::_search_bind(const String &p_key, uint32_t p_search_flags, int p_from_line, int p_from_column) const {
+Dictionary TextEdit::_search_bind(const String &p_key, uint32_t p_search_flags, int p_from_line, int p_from_column) const {
 	int col, line;
 	if (search(p_key, p_search_flags, p_from_line, p_from_column, line, col)) {
-		Vector<int> result;
-		result.resize(2);
-		result.set(SEARCH_RESULT_COLUMN, col);
-		result.set(SEARCH_RESULT_LINE, line);
+		Dictionary result;
+		result["line"] = line;
+		result["column"] = col;
 		return result;
 
 	} else {
-		return Vector<int>();
+		return Dictionary();
 	}
 }
 
@@ -6979,9 +6978,6 @@ void TextEdit::_bind_methods() {
 	BIND_ENUM_CONSTANT(SEARCH_MATCH_CASE);
 	BIND_ENUM_CONSTANT(SEARCH_WHOLE_WORDS);
 	BIND_ENUM_CONSTANT(SEARCH_BACKWARDS);
-
-	BIND_ENUM_CONSTANT(SEARCH_RESULT_COLUMN);
-	BIND_ENUM_CONSTANT(SEARCH_RESULT_LINE);
 
 	/*
 	ClassDB::bind_method(D_METHOD("delete_char"),&TextEdit::delete_char);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -508,7 +508,7 @@ private:
 
 	int _get_column_pos_of_word(const String &p_key, const String &p_search, uint32_t p_search_flags, int p_from_column);
 
-	Vector<int> _search_bind(const String &p_key, uint32_t p_search_flags, int p_from_line, int p_from_column) const;
+	Dictionary _search_bind(const String &p_key, uint32_t p_search_flags, int p_from_line, int p_from_column) const;
 
 	PopupMenu *menu;
 
@@ -559,11 +559,6 @@ public:
 		SEARCH_MATCH_CASE = 1,
 		SEARCH_WHOLE_WORDS = 2,
 		SEARCH_BACKWARDS = 4
-	};
-
-	enum SearchResult {
-		SEARCH_RESULT_COLUMN,
-		SEARCH_RESULT_LINE,
 	};
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const;
@@ -826,7 +821,6 @@ public:
 
 VARIANT_ENUM_CAST(TextEdit::MenuItems);
 VARIANT_ENUM_CAST(TextEdit::SearchFlags);
-VARIANT_ENUM_CAST(TextEdit::SearchResult);
 
 class SyntaxHighlighter {
 protected:


### PR DESCRIPTION
Following up on https://github.com/godotengine/godot/pull/33202#issuecomment-548399254

`Dictionary` is easier to use than accessing elements in a `Vector` using indices given by an enum.
Breaks compatibility on existing scripts using this functionality.