### PR TITLE
Small refactor for atlas priority

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -158,18 +158,21 @@
 			</argument>
 			<argument index="6" name="autotile_coord" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
+			<argument index="7" name="atlas_priority" type="bool" default="true">
+			</argument>
 			<description>
 				Sets the tile index for the cell given by a Vector2.
 				An index of [code]-1[/code] clears the cell.
 				Optionally, the tile can also be flipped, transposed, or given autotile coordinates. The autotile coordinate refers to the column and row of the subtile.
 				[b]Note:[/b] Data such as navigation polygons and collision shapes are not immediately updated for performance reasons.
+				[b]Note:[/b] [code]autotile_coord[/code] is also used to define the column and row of [constant TileSet.ATLAS_TILE], for this you must pass [code]false[/code] to [code]atlas_priority[/code] to disable priority.
 				If you need these to be immediately updated, you can call [method update_dirty_quadrants].
 				Overriding this method also overrides it internally, allowing custom logic to be implemented when tiles are placed/removed:
 				[codeblock]
-				func set_cell(x, y, tile, flip_x, flip_y, transpose, autotile_coord)
+				func set_cell(x, y, tile, flip_x, flip_y, transpose, autotile_coord, atlas_priority)
 				    # Write your custom logic here.
 				    # To call the default method:
-				    .set_cell(x, y, tile, flip_x, flip_y, transpose, autotile_coord)
+				    .set_cell(x, y, tile, flip_x, flip_y, transpose, autotile_coord, atlas_priority)
 				[/codeblock]
 			</description>
 		</method>

--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -183,11 +183,11 @@ class TileMapEditor : public VBoxContainer {
 	void _palette_selected(int index);
 	void _palette_multi_selected(int index, bool selected);
 
-	Dictionary _create_cell_dictionary(int tile, bool flip_x, bool flip_y, bool transpose, Vector2 autotile_coord);
+	Dictionary _create_cell_dictionary(int tile, bool flip_x, bool flip_y, bool transpose, Vector2 autotile_coord, bool atlas_priority);
 	void _start_undo(const String &p_action);
 	void _finish_undo();
 	void _create_set_cell_undo_redo(const Vector2 &p_vec, const CellOp &p_cell_old, const CellOp &p_cell_new);
-	void _set_cell(const Point2i &p_pos, Vector<int> p_values, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false, const Point2i &p_autotile_coord = Point2());
+	void _set_cell(const Point2i &p_pos, Vector<int> p_values, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false, const Point2i &p_autotile_coord = Point2(), bool p_atlas_priority = true);
 
 	void _canvas_mouse_enter();
 	void _canvas_mouse_exit();

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -253,7 +253,7 @@ public:
 	void set_quadrant_size(int p_size);
 	int get_quadrant_size() const;
 
-	void set_cell(int p_x, int p_y, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false, Vector2 p_autotile_coord = Vector2());
+	void set_cell(int p_x, int p_y, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false, Vector2 p_autotile_coord = Vector2(), bool p_atlas_priority = true);
 	int get_cell(int p_x, int p_y) const;
 	bool is_cell_x_flipped(int p_x, int p_y) const;
 	bool is_cell_y_flipped(int p_x, int p_y) const;


### PR DESCRIPTION
- Remove hack of bitmask to use priority
- Allows priority to be used with gdscript
- Fix the atlas priority by randomly changing the surrounding tiles (https://github.com/godotengine/godot/issues/36972#issuecomment-625995506)
- Set atlas priority in gdscript to true by default (breaks compat when used with gdscript)

Fix #36972
Supersedes #38790, #38546

Breaks compatibility for games that create procedurally generated tilemaps with `ATLAS TILE` by code.