### PR TITLE
Allow searching with keyboard input by default in PopupMenu

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -334,9 +334,6 @@ OptionButton::OptionButton() {
 	popup = memnew(PopupMenu);
 	popup->hide();
 	add_child(popup);
-	//	popup->set_pass_on_modal_close_click(false);
-	//	popup->set_notify_transform(true);
-	popup->set_allow_search(true);
 	popup->connect("index_pressed", callable_mp(this, &OptionButton::_selected));
 	popup->connect("id_focused", callable_mp(this, &OptionButton::_focused));
 	popup->connect("popup_hide", callable_mp((BaseButton *)this, &BaseButton::set_pressed), varray(false));

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1442,7 +1442,7 @@ PopupMenu::PopupMenu() {
 	during_grabbed_click = false;
 	invalidated_click = false;
 
-	allow_search = false;
+	allow_search = true;
 	search_time_msec = 0;
 	search_string = "";
 


### PR DESCRIPTION
See discussion in https://github.com/godotengine/godot-proposals/issues/43.

Please test for any possible regressions; I've only done minimal testing so far.