### PR TITLE
Added Node name to print() of all Nodes by making to_string() in Object virtual, so it can be overriden in C++.

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1822,6 +1822,18 @@ Node *Node::get_deepest_editable_node(Node *p_start_node) const {
 	return node;
 }
 
+String Node::to_string() {
+	if (get_script_instance()) {
+		bool valid;
+		String ret = get_script_instance()->to_string(&valid);
+		if (valid) {
+			return ret;
+		}
+	}
+
+	return (get_name() ? String(get_name()) + ":" : "") + Object::to_string();
+}
+
 void Node::set_scene_instance_state(const Ref<SceneState> &p_state) {
 	data.instance_state = p_state;
 }

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -329,6 +329,8 @@ public:
 	bool is_editable_instance(const Node *p_node) const;
 	Node *get_deepest_editable_node(Node *p_start_node) const;
 
+	virtual String to_string() override;
+
 	/* NOTIFICATIONS */
 
 	void propagate_notification(int p_notification);


### PR DESCRIPTION
Closes godotengine/godot-proposals#693
```gdscript
func _ready():
	var special_node = $MySpecialNode
	print(special_node)
	
	var node = Node2D.new()
	print(node)
	
	var node2: Node2D = null
	print(node2)
```
Outputs
```
MySpecialNode [Node2D:23370662652]
[Node2D:23454548333]
Null
```
I did not add position to Node2D/3D/Control as I wasn't sure if it was really need. Some people won't need it, and there is the question of whether to return local/global position (or other info).