### PR TITLE
Fix certain characters being recognized as special keys on Windows when using the us international layout

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2658,7 +2658,8 @@ void DisplayServerWindows::_process_key_events() {
 		KeyEvent &ke = key_event_buffer[i];
 		switch (ke.uMsg) {
 			case WM_CHAR: {
-				if ((i == 0 && ke.uMsg == WM_CHAR) || (i > 0 && key_event_buffer[i - 1].uMsg == WM_CHAR)) {
+				// extended keys should only be processed as WM_KEYDOWN message.
+				if (!KeyMappingWindows::is_extended_key(ke.wParam) && ((i == 0 && ke.uMsg == WM_CHAR) || (i > 0 && key_event_buffer[i - 1].uMsg == WM_CHAR))) {
 					Ref<InputEventKey> k;
 					k.instance();
 

--- a/platform/windows/key_mapping_windows.cpp
+++ b/platform/windows/key_mapping_windows.cpp
@@ -411,3 +411,16 @@ unsigned int KeyMappingWindows::get_scansym(unsigned int p_code, bool p_extended
 
 	return keycode;
 }
+
+bool KeyMappingWindows::is_extended_key(unsigned int p_code) {
+	return p_code == VK_INSERT ||
+		   p_code == VK_DELETE ||
+		   p_code == VK_HOME ||
+		   p_code == VK_END ||
+		   p_code == VK_PRIOR ||
+		   p_code == VK_NEXT ||
+		   p_code == VK_LEFT ||
+		   p_code == VK_UP ||
+		   p_code == VK_RIGHT ||
+		   p_code == VK_DOWN;
+}

--- a/platform/windows/key_mapping_windows.h
+++ b/platform/windows/key_mapping_windows.h
@@ -43,6 +43,7 @@ class KeyMappingWindows {
 public:
 	static unsigned int get_keysym(unsigned int p_code);
 	static unsigned int get_scansym(unsigned int p_code, bool p_extended);
+	static bool is_extended_key(unsigned int p_code);
 };
 
 #endif // KEY_MAPPING_WINDOWS_H


### PR DESCRIPTION
As supposed by the participants of #25548, the problem is that certain characters emit special key signals additionally. I found [this](https://stackoverflow.com/a/8181107) post on stackoverflow bringing some light into the darkness. 

I have implemented a simple check to see if a WM_CHAR message sends a special key signal, and if so, the message is discarded.

Fixes #25548