### PR TITLE
Add `custom.py` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,9 @@ logs/
 *.sln
 *.vcxproj*
 
+# Custom SCons configuration override
+/custom.py
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/


### PR DESCRIPTION
The default `custom.py` can be created at the root of the Godot repository to initialize any SCons build options via file which are specific to user.

This was always supported, but probably a hidden feature for many Godot'ers to this day:
https://github.com/godotengine/godot/blob/d4599fff68c96e8a4f25927d1786491098a18d4e/SConstruct#L97-L108

For instance, you can disable most of the modules via a file, significantly improving the build times:
```python
# custom.py

module_arkit_enabled = "no"
module_assimp_enabled = "no"
module_bmp_enabled = "no"
module_bullet_enabled = "no"
module_camera_enabled = "no"
module_csg_enabled = "no"
module_cvtt_enabled = "no"
module_dds_enabled = "no"
module_enet_enabled = "no"
module_etc_enabled = "no"
module_gdnative_enabled = "no"
module_gridmap_enabled = "no"
module_hdr_enabled = "no"
module_jpg_enabled = "no"
module_jsonrpc_enabled = "no"
module_mobile_vr_enabled = "no"
module_mono_enabled = "no"
module_ogg_enabled = "no"
module_opensimplex_enabled = "no"
module_opus_enabled = "no"
module_pvr_enabled = "no"
module_recast_enabled = "no"
module_squish_enabled = "no"
module_stb_vorbis_enabled = "no"
module_tga_enabled = "no"
module_theora_enabled = "no"
module_tinyexr_enabled = "no"
module_upnp_enabled = "no"
module_vhacd_enabled = "no"
module_visual_script_enabled = "no"
module_vorbis_enabled = "no"
module_webm_enabled = "no"
module_webp_enabled = "no"
module_webrtc_enabled = "no"
module_websocket_enabled = "no"
module_xatlas_unwrap_enabled = "no"
```

This is also quite handy feature for the `custom_modules` option which doesn't have to be passed to the command line each time, see #36922 (already used by some Godot'ers, including myself);

```python
custom_modules = "/path/to/your/project/modules"
# Custom modules only detects modules and enables them by default
# so we have to explicitly disable modules which are not meant to be compiled
module_your_custom_a_enabled = "no"
module_your_custom_b_enabled = "no"
```

Also, another custom file can be specified explicitly with `scons profile=your_custom.py`, but having the default `custom.py` to be ignored by default removes the need to specify the `profile` option in the first place (don't get me wrong, both features are useful).

Moreover, `custom.py` is a Python script, so you can also conditionally setup build options, some silly example:
```python
# custom.py

import version

if version.major == 4:
    module_recast_enabled = "no"
elif version.major == 3:
    module_recast_enabled = "yes"
```

Sorry for the lengthy description for such a simple change, but I wanted to document this at some level, this can also be added to the documentation.

I want to create another PR for 3.2 if you don't mind.
