### PR TITLE
GLSL: Change shader type specifier from [vertex] to #[vertex]

### DIFF
--- a/gles_builders.py
+++ b/gles_builders.py
@@ -36,14 +36,14 @@ def include_file_in_legacygl_header(filename, header_data, depth):
 
     while line:
 
-        if line.find("[vertex]") != -1:
+        if line.find("#[vertex]") != -1:
             header_data.reading = "vertex"
             line = fs.readline()
             header_data.line_offset += 1
             header_data.vertex_offset = header_data.line_offset
             continue
 
-        if line.find("[fragment]") != -1:
+        if line.find("#[fragment]") != -1:
             header_data.reading = "fragment"
             line = fs.readline()
             header_data.line_offset += 1
@@ -612,21 +612,21 @@ def include_file_in_rd_header(filename, header_data, depth):
 
     while line:
 
-        if line.find("[vertex]") != -1:
+        if line.find("#[vertex]") != -1:
             header_data.reading = "vertex"
             line = fs.readline()
             header_data.line_offset += 1
             header_data.vertex_offset = header_data.line_offset
             continue
 
-        if line.find("[fragment]") != -1:
+        if line.find("#[fragment]") != -1:
             header_data.reading = "fragment"
             line = fs.readline()
             header_data.line_offset += 1
             header_data.fragment_offset = header_data.line_offset
             continue
 
-        if line.find("[compute]") != -1:
+        if line.find("#[compute]") != -1:
             header_data.reading = "compute"
             line = fs.readline()
             header_data.line_offset += 1

--- a/modules/lightmapper_rd/lm_blendseams.glsl
+++ b/modules/lightmapper_rd/lm_blendseams.glsl
@@ -1,10 +1,9 @@
-/* clang-format off */
-[versions]
+#[versions]
 
-lines = "#define MODE_LINES"
-triangles = "#define MODE_TRIANGLES"
+lines = "#define MODE_LINES";
+triangles = "#define MODE_TRIANGLES";
 
-[vertex]
+#[vertex]
 
 #version 450
 
@@ -12,22 +11,20 @@ VERSION_DEFINES
 
 #include "lm_common_inc.glsl"
 
-				/* clang-format on */
-
-				layout(push_constant, binding = 0, std430) uniform Params {
-					uint base_index;
-					uint slice;
-					vec2 uv_offset;
-					bool debug;
-					float blend;
-					uint pad[2];
-				} params;
+layout(push_constant, binding = 0, std430) uniform Params {
+	uint base_index;
+	uint slice;
+	vec2 uv_offset;
+	bool debug;
+	float blend;
+	uint pad[2];
+}
+params;
 
 layout(location = 0) out vec3 uv_interp;
 
 void main() {
 #ifdef MODE_TRIANGLES
-
 	uint triangle_idx = params.base_index + gl_VertexIndex / 3;
 	uint triangle_subidx = gl_VertexIndex % 3;
 
@@ -42,7 +39,6 @@ void main() {
 
 	uv_interp = vec3(uv, float(params.slice));
 	gl_Position = vec4((uv + params.uv_offset) * 2.0 - 1.0, 0.0001, 1.0);
-
 #endif
 
 #ifdef MODE_LINES
@@ -71,12 +67,10 @@ void main() {
 
 	uv_interp = vec3(src_uv, float(params.slice));
 	gl_Position = vec4(dst_uv * 2.0 - 1.0, 0.0001, 1.0);
-	;
 #endif
 }
 
-/* clang-format off */
-[fragment]
+#[fragment]
 
 #version 450
 
@@ -84,16 +78,15 @@ VERSION_DEFINES
 
 #include "lm_common_inc.glsl"
 
-				/* clang-format on */
-
-				layout(push_constant, binding = 0, std430) uniform Params {
-					uint base_index;
-					uint slice;
-					vec2 uv_offset;
-					bool debug;
-					float blend;
-					uint pad[2];
-				} params;
+layout(push_constant, binding = 0, std430) uniform Params {
+	uint base_index;
+	uint slice;
+	vec2 uv_offset;
+	bool debug;
+	float blend;
+	uint pad[2];
+}
+params;
 
 layout(location = 0) in vec3 uv_interp;
 

--- a/modules/lightmapper_rd/lm_common_inc.glsl
+++ b/modules/lightmapper_rd/lm_common_inc.glsl
@@ -11,7 +11,6 @@ struct Vertex {
 layout(set = 0, binding = 1, std430) restrict readonly buffer Vertices {
 	Vertex data[];
 }
-
 vertices;
 
 struct Triangle {
@@ -22,7 +21,6 @@ struct Triangle {
 layout(set = 0, binding = 2, std430) restrict readonly buffer Triangles {
 	Triangle data[];
 }
-
 triangles;
 
 struct Box {
@@ -35,13 +33,11 @@ struct Box {
 layout(set = 0, binding = 3, std430) restrict readonly buffer Boxes {
 	Box data[];
 }
-
 boxes;
 
 layout(set = 0, binding = 4, std430) restrict readonly buffer GridIndices {
 	uint data[];
 }
-
 grid_indices;
 
 #define LIGHT_TYPE_DIRECTIONAL 0
@@ -70,7 +66,6 @@ struct Light {
 layout(set = 0, binding = 5, std430) restrict readonly buffer Lights {
 	Light data[];
 }
-
 lights;
 
 struct Seam {
@@ -81,13 +76,11 @@ struct Seam {
 layout(set = 0, binding = 6, std430) restrict readonly buffer Seams {
 	Seam data[];
 }
-
 seams;
 
 layout(set = 0, binding = 7, std430) restrict readonly buffer Probes {
 	vec4 data[];
 }
-
 probe_positions;
 
 layout(set = 0, binding = 8) uniform utexture3D grid;

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -1,13 +1,12 @@
-/* clang-format off */
-[versions]
+#[versions]
 
-primary = "#define MODE_DIRECT_LIGHT"
-secondary = "#define MODE_BOUNCE_LIGHT"
-dilate = "#define MODE_DILATE"
-unocclude = "#define MODE_UNOCCLUDE"
-light_probes = "#define MODE_LIGHT_PROBES"
+primary = "#define MODE_DIRECT_LIGHT";
+secondary = "#define MODE_BOUNCE_LIGHT";
+dilate = "#define MODE_DILATE";
+unocclude = "#define MODE_UNOCCLUDE";
+light_probes = "#define MODE_LIGHT_PROBES";
 
-[compute]
+#[compute]
 
 #version 450
 
@@ -29,14 +28,11 @@ layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
 #include "lm_common_inc.glsl"
 
-/* clang-format on */
-
 #ifdef MODE_LIGHT_PROBES
 
 layout(set = 1, binding = 0, std430) restrict buffer LightProbeData {
 	vec4 data[];
 }
-
 light_probes;
 
 layout(set = 1, binding = 1) uniform texture2DArray source_light;
@@ -94,7 +90,6 @@ layout(push_constant, binding = 0, std430) uniform Params {
 
 	mat3x4 env_transform;
 }
-
 params;
 
 //check it, but also return distance and barycentric coords (for uv lookup)
@@ -123,7 +118,6 @@ bool trace_ray(vec3 p_from, vec3 p_to
 		out float r_distance, out vec3 r_normal
 #endif
 ) {
-
 	/* world coords */
 
 	vec3 rel = p_to - p_from;
@@ -149,7 +143,6 @@ bool trace_ray(vec3 p_from, vec3 p_to
 	while (all(greaterThanEqual(icell, ivec3(0))) && all(lessThan(icell, ivec3(params.grid_size))) && iters < 1000) {
 		uvec2 cell_data = texelFetch(usampler3D(grid, linear_sampler), icell, 0).xy;
 		if (cell_data.x > 0) { //triangles here
-
 			bool hit = false;
 #if defined(MODE_UNOCCLUDE)
 			bool hit_backface = false;
@@ -211,7 +204,6 @@ bool trace_ray(vec3 p_from, vec3 p_to
 						r_triangle = tidx;
 						r_barycentric = barycentric;
 					}
-
 #endif
 				}
 			}

--- a/modules/lightmapper_rd/lm_raster.glsl
+++ b/modules/lightmapper_rd/lm_raster.glsl
@@ -1,5 +1,4 @@
-/* clang-format off */
-[vertex]
+#[vertex]
 
 #version 450
 
@@ -7,9 +6,7 @@ VERSION_DEFINES
 
 #include "lm_common_inc.glsl"
 
-				/* clang-format on */
-
-				layout(location = 0) out vec3 vertex_interp;
+layout(location = 0) out vec3 vertex_interp;
 layout(location = 1) out vec3 normal_interp;
 layout(location = 2) out vec2 uv_interp;
 layout(location = 3) out vec3 barycentric;
@@ -26,10 +23,7 @@ layout(push_constant, binding = 0, std430) uniform Params {
 	ivec3 grid_size;
 	uint pad2;
 }
-
 params;
-
-/* clang-format on */
 
 void main() {
 	uint triangle_idx = params.base_triangle + gl_VertexIndex / 3;
@@ -56,19 +50,15 @@ void main() {
 	face_normal = -normalize(cross((vertices.data[vertex_indices.x].position - vertices.data[vertex_indices.y].position), (vertices.data[vertex_indices.x].position - vertices.data[vertex_indices.z].position)));
 
 	gl_Position = vec4((uv_interp + params.uv_offset) * 2.0 - 1.0, 0.0001, 1.0);
-	;
 }
 
-/* clang-format off */
-
-[fragment]
+#[fragment]
 
 #version 450
 
 VERSION_DEFINES
 
 #include "lm_common_inc.glsl"
-
 
 layout(push_constant, binding = 0, std430) uniform Params {
 	vec2 atlas_size;
@@ -79,9 +69,8 @@ layout(push_constant, binding = 0, std430) uniform Params {
 	float bias;
 	ivec3 grid_size;
 	uint pad2;
-} params;
-
-/* clang-format on */
+}
+params;
 
 layout(location = 0) in vec3 vertex_interp;
 layout(location = 1) in vec3 normal_interp;
@@ -100,7 +89,6 @@ void main() {
 	{
 		// smooth out vertex position by interpolating its projection in the 3 normal planes (normal plane is created by vertex pos and normal)
 		// because we don't want to interpolate inwards, normals found pointing inwards are pushed out.
-
 		vec3 pos_a = vertices.data[vertex_indices.x].position;
 		vec3 pos_b = vertices.data[vertex_indices.y].position;
 		vec3 pos_c = vertices.data[vertex_indices.z].position;

--- a/servers/rendering/rasterizer_rd/shaders/bokeh_dof.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/bokeh_dof.glsl
@@ -1,5 +1,4 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
@@ -8,7 +7,6 @@ VERSION_DEFINES
 #define BLOCK_SIZE 8
 
 layout(local_size_x = BLOCK_SIZE, local_size_y = BLOCK_SIZE, local_size_z = 1) in;
-/* clang-format on */
 
 #ifdef MODE_GEN_BLUR_SIZE
 layout(rgba16f, set = 0, binding = 0) uniform restrict image2D color_image;
@@ -51,7 +49,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	float jitter_seed;
 	uint pad[2];
 }
-
 params;
 
 //used to work around downsampling filter

--- a/servers/rendering/rasterizer_rd/shaders/canvas.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/canvas.glsl
@@ -1,5 +1,4 @@
-/* clang-format off */
-[vertex]
+#[vertex]
 
 #version 450
 
@@ -7,7 +6,6 @@ VERSION_DEFINES
 
 #ifdef USE_ATTRIBUTES
 layout(location = 0) in vec2 vertex_attrib;
-/* clang-format on */
 layout(location = 3) in vec4 color_attrib;
 layout(location = 4) in vec2 uv_attrib;
 
@@ -87,7 +85,6 @@ void main() {
 
 #if 0
 	if (draw_data.flags & FLAGS_INSTANCING_ENABLED) {
-
 		uint offset = draw_data.flags & FLAGS_INSTANCING_STRIDE_MASK;
 		offset *= gl_InstanceIndex;
 		mat4 instance_xform = mat4(
@@ -158,7 +155,6 @@ VERTEX_SHADER_CODE
 #if 0
 	if (bool(draw_data.flags & FLAGS_USE_SKELETON) && bone_weights != vec4(0.0)) { //must be a valid bone
 		//skeleton transform
-
 		ivec4 bone_indicesi = ivec4(bone_indices);
 
 		uvec2 tex_ofs = bone_indicesi.x * 2;
@@ -209,8 +205,7 @@ VERTEX_SHADER_CODE
 #endif
 }
 
-/* clang-format off */
-[fragment]
+#[fragment]
 
 #version 450
 
@@ -219,7 +214,6 @@ VERSION_DEFINES
 #include "canvas_uniforms_inc.glsl"
 
 layout(location = 0) in vec2 uv_interp;
-/* clang-format on */
 layout(location = 1) in vec4 color_interp;
 layout(location = 2) in vec2 vertex_interp;
 
@@ -342,7 +336,6 @@ void main() {
 	vec3 normal;
 
 #if defined(NORMAL_USED)
-
 	bool normal_used = true;
 #else
 	bool normal_used = false;

--- a/servers/rendering/rasterizer_rd/shaders/canvas_occlusion.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/canvas_occlusion.glsl
@@ -1,10 +1,8 @@
-/* clang-format off */
-[vertex]
+#[vertex]
 
 #version 450
 
 layout(location = 0) in highp vec3 vertex;
-/* clang-format on */
 
 layout(push_constant, binding = 0, std430) uniform Constants {
 	mat4 projection;
@@ -12,7 +10,6 @@ layout(push_constant, binding = 0, std430) uniform Constants {
 	vec2 direction;
 	vec2 pad;
 }
-
 constants;
 
 layout(location = 0) out highp float depth;
@@ -24,13 +21,11 @@ void main() {
 	gl_Position = constants.projection * vtx;
 }
 
-/* clang-format off */
-[fragment]
+#[fragment]
 
 #version 450
 
 layout(location = 0) in highp float depth;
-/* clang-format on */
 layout(location = 0) out highp float distance_buf;
 
 void main() {

--- a/servers/rendering/rasterizer_rd/shaders/canvas_uniforms_inc.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/canvas_uniforms_inc.glsl
@@ -51,7 +51,6 @@ layout(push_constant, binding = 0, std430) uniform DrawData {
 	vec2 color_texture_pixel_size;
 	uint lights[4];
 }
-
 draw_data;
 
 // The values passed per draw primitives are cached within it
@@ -83,7 +82,6 @@ layout(set = 2, binding = 0, std140) uniform CanvasData {
 	float time_pad;
 	//uint light_count;
 }
-
 canvas_data;
 
 layout(set = 2, binding = 1) uniform textureBuffer skeleton_buffer;
@@ -92,7 +90,6 @@ layout(set = 2, binding = 2, std140) uniform SkeletonData {
 	mat4 skeleton_transform; //in world coordinates
 	mat4 skeleton_transform_inverse;
 }
-
 skeleton_data;
 
 #ifdef USE_LIGHTING
@@ -126,7 +123,6 @@ struct Light {
 layout(set = 2, binding = 3, std140) uniform LightData {
 	Light data[MAX_LIGHTS];
 }
-
 light_array;
 
 layout(set = 2, binding = 4) uniform texture2D light_textures[MAX_LIGHT_TEXTURES];
@@ -139,7 +135,6 @@ layout(set = 2, binding = 6) uniform sampler shadow_sampler;
 layout(set = 2, binding = 7, std430) restrict readonly buffer GlobalVariableData {
 	vec4 data[];
 }
-
 global_variables;
 
 /* SET3: Render Target Data */

--- a/servers/rendering/rasterizer_rd/shaders/copy.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/copy.glsl
@@ -1,12 +1,10 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
-/* clang-format on */
 
 #define FLAG_HORIZONTAL (1 << 0)
 #define FLAG_USE_BLUR_SECTION (1 << 1)
@@ -37,7 +35,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	float camera_z_near;
 	uint pad2[2];
 }
-
 params;
 
 #ifdef MODE_CUBEMAP_ARRAY_TO_PANORAMA

--- a/servers/rendering/rasterizer_rd/shaders/copy_to_fb.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/copy_to_fb.glsl
@@ -1,12 +1,10 @@
-/* clang-format off */
-[vertex]
+#[vertex]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(location = 0) out vec2 uv_interp;
-/* clang-format on */
 
 layout(push_constant, binding = 1, std430) uniform Params {
 	vec4 section;
@@ -17,7 +15,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	bool force_luminance;
 	uint pad[3];
 }
-
 params;
 
 void main() {
@@ -36,8 +33,7 @@ void main() {
 	}
 }
 
-/* clang-format off */
-[fragment]
+#[fragment]
 
 #version 450
 
@@ -52,11 +48,10 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	bool force_luminance;
 	bool alpha_to_zero;
 	uint pad[2];
-} params;
-
+}
+params;
 
 layout(location = 0) in vec2 uv_interp;
-/* clang-format on */
 
 layout(set = 0, binding = 0) uniform sampler2D source_color;
 
@@ -82,8 +77,9 @@ void main() {
 
 	vec2 st = vec2(atan(normal.x, normal.z), acos(normal.y));
 
-	if (st.x < 0.0)
+	if (st.x < 0.0) {
 		st.x += M_PI * 2.0;
+	}
 
 	uv = st / vec2(M_PI * 2.0, M_PI);
 

--- a/servers/rendering/rasterizer_rd/shaders/cube_to_dp.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/cube_to_dp.glsl
@@ -1,12 +1,10 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
-/* clang-format on */
 
 layout(set = 0, binding = 0) uniform samplerCube source_cube;
 
@@ -18,7 +16,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	float z_near;
 	bool z_flip;
 }
-
 params;
 
 layout(r32f, set = 1, binding = 0) uniform restrict writeonly image2D depth_buffer;

--- a/servers/rendering/rasterizer_rd/shaders/cubemap_downsampler.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/cubemap_downsampler.glsl
@@ -18,8 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
@@ -28,7 +27,6 @@ VERSION_DEFINES
 #define BLOCK_SIZE 8
 
 layout(local_size_x = BLOCK_SIZE, local_size_y = BLOCK_SIZE, local_size_z = 1) in;
-/* clang-format on */
 
 layout(set = 0, binding = 0) uniform samplerCube source_cubemap;
 
@@ -37,7 +35,6 @@ layout(rgba16f, set = 1, binding = 0) uniform restrict writeonly imageCube dest_
 layout(push_constant, binding = 1, std430) uniform Params {
 	uint face_size;
 }
-
 params;
 
 #define M_PI 3.14159265359

--- a/servers/rendering/rasterizer_rd/shaders/cubemap_filter.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/cubemap_filter.glsl
@@ -18,8 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
@@ -28,7 +27,6 @@ VERSION_DEFINES
 #define GROUP_SIZE 64
 
 layout(local_size_x = GROUP_SIZE, local_size_y = 1, local_size_z = 1) in;
-/* clang-format on */
 
 layout(set = 0, binding = 0) uniform samplerCube source_cubemap;
 layout(rgba16f, set = 2, binding = 0) uniform restrict writeonly imageCube dest_cubemap0;
@@ -51,13 +49,11 @@ layout(rgba16f, set = 2, binding = 6) uniform restrict writeonly imageCube dest_
 layout(set = 1, binding = 0, std430) buffer restrict readonly Data {
 	vec4[7][5][3][24] coeffs;
 }
-
 data;
 #else
 layout(set = 1, binding = 0, std430) buffer restrict readonly Data {
 	vec4[7][5][6] coeffs;
 }
-
 data;
 #endif
 

--- a/servers/rendering/rasterizer_rd/shaders/cubemap_roughness.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/cubemap_roughness.glsl
@@ -1,5 +1,4 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
@@ -8,7 +7,6 @@ VERSION_DEFINES
 #define GROUP_SIZE 8
 
 layout(local_size_x = GROUP_SIZE, local_size_y = GROUP_SIZE, local_size_z = 1) in;
-/* clang-format on */
 
 layout(set = 0, binding = 0) uniform samplerCube source_cube;
 
@@ -21,7 +19,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	bool use_direct_write;
 	float face_size;
 }
-
 params;
 
 #define M_PI 3.14159265359

--- a/servers/rendering/rasterizer_rd/shaders/giprobe.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/giprobe.glsl
@@ -1,5 +1,4 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
@@ -10,7 +9,6 @@ layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 #else
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 #endif
-/* clang-format on */
 
 #ifndef MODE_DYNAMIC
 
@@ -24,7 +22,6 @@ struct CellChildren {
 layout(set = 0, binding = 1, std430) buffer CellChildrenBuffer {
 	CellChildren data[];
 }
-
 cell_children;
 
 struct CellData {
@@ -37,7 +34,6 @@ struct CellData {
 layout(set = 0, binding = 2, std430) buffer CellDataBuffer {
 	CellData data[];
 }
-
 cell_data;
 
 #endif // MODE DYNAMIC
@@ -67,7 +63,6 @@ struct Light {
 layout(set = 0, binding = 3, std140) uniform Lights {
 	Light data[MAX_LIGHTS];
 }
-
 lights;
 
 #endif // MODE COMPUTE LIGHT
@@ -99,13 +94,11 @@ layout(push_constant, binding = 0, std430) uniform Params {
 	float aniso_strength;
 	uint pad;
 }
-
 params;
 
 layout(set = 0, binding = 4, std430) buffer Outputs {
 	vec4 data[];
 }
-
 outputs;
 
 #endif // MODE DYNAMIC
@@ -148,7 +141,6 @@ layout(push_constant, binding = 0, std430) uniform Params {
 	float propagation;
 	float pad[3];
 }
-
 params;
 
 #ifdef MODE_DYNAMIC_LIGHTING

--- a/servers/rendering/rasterizer_rd/shaders/giprobe_debug.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/giprobe_debug.glsl
@@ -1,5 +1,4 @@
-/* clang-format off */
-[vertex]
+#[vertex]
 
 #version 450
 
@@ -11,12 +10,10 @@ struct CellData {
 	uint emission; //rgb normalized with e as multiplier
 	uint normal; //RGB normal encoded
 };
-/* clang-format on */
 
 layout(set = 0, binding = 1, std140) buffer CellDataBuffer {
 	CellData data[];
 }
-
 cell_data;
 
 layout(set = 0, binding = 2) uniform texture3D color_tex;
@@ -37,7 +34,6 @@ layout(push_constant, binding = 0, std430) uniform Params {
 	ivec3 bounds;
 	uint pad;
 }
-
 params;
 
 layout(location = 0) out vec4 color_interp;
@@ -172,15 +168,13 @@ void main() {
 #endif
 }
 
-/* clang-format off */
-[fragment]
+#[fragment]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(location = 0) in vec4 color_interp;
-/* clang-format on */
 layout(location = 0) out vec4 frag_color;
 
 void main() {

--- a/servers/rendering/rasterizer_rd/shaders/giprobe_sdf.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/giprobe_sdf.glsl
@@ -1,12 +1,10 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(local_size_x = 4, local_size_y = 4, local_size_z = 4) in;
-/* clang-format on */
 
 #define MAX_DISTANCE 100000
 
@@ -20,7 +18,6 @@ struct CellChildren {
 layout(set = 0, binding = 1, std430) buffer CellChildrenBuffer {
 	CellChildren data[];
 }
-
 cell_children;
 
 struct CellData {
@@ -33,7 +30,6 @@ struct CellData {
 layout(set = 0, binding = 2, std430) buffer CellDataBuffer {
 	CellData data[];
 }
-
 cell_data;
 
 layout(r8ui, set = 0, binding = 3) uniform restrict writeonly uimage3D sdf_tex;
@@ -44,7 +40,6 @@ layout(push_constant, binding = 0, std430) uniform Params {
 	uint pad0;
 	uint pad1;
 }
-
 params;
 
 void main() {
@@ -73,20 +68,17 @@ void main() {
 
 #if 0
 layout(push_constant, binding = 0, std430) uniform Params {
-
 	ivec3 limits;
 	uint stack_size;
-} params;
+}
+params;
 
 float distance_to_aabb(ivec3 pos, ivec3 aabb_pos, ivec3 aabb_size) {
-
 	vec3 delta = vec3(max(ivec3(0), max(aabb_pos - pos, pos - (aabb_pos + aabb_size - ivec3(1)))));
 	return length(delta);
 }
 
-
 void main() {
-
 	ivec3 pos = ivec3(gl_GlobalInvocationID);
 
 	uint stack[10] = uint[](0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -110,7 +102,6 @@ void main() {
 	int stack_pos = 0;
 
 	while (true) {
-
 		uint index = stack_indices[stack_pos] >> 24;
 
 		if (index == 8) {

--- a/servers/rendering/rasterizer_rd/shaders/giprobe_write.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/giprobe_write.glsl
@@ -1,12 +1,10 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
-/* clang-format on */
 
 #define NO_CHILDREN 0xFFFFFFFF
 #define GREY_VEC vec3(0.33333, 0.33333, 0.33333)
@@ -18,7 +16,6 @@ struct CellChildren {
 layout(set = 0, binding = 1, std430) buffer CellChildrenBuffer {
 	CellChildren data[];
 }
-
 cell_children;
 
 struct CellData {
@@ -31,7 +28,6 @@ struct CellData {
 layout(set = 0, binding = 2, std430) buffer CellDataBuffer {
 	CellData data[];
 }
-
 cell_data;
 
 #define LIGHT_TYPE_DIRECTIONAL 0
@@ -59,7 +55,6 @@ struct Light {
 layout(set = 0, binding = 3, std140) uniform Lights {
 	Light data[MAX_LIGHTS];
 }
-
 lights;
 
 #endif
@@ -77,13 +72,11 @@ layout(push_constant, binding = 0, std430) uniform Params {
 	uint cell_count;
 	uint pad[2];
 }
-
 params;
 
 layout(set = 0, binding = 4, std140) uniform Outputs {
 	vec4 data[];
 }
-
 output;
 
 #ifdef MODE_COMPUTE_LIGHT
@@ -94,7 +87,6 @@ uint raymarch(float distance, float distance_adv, vec3 from, vec3 direction) {
 	ivec3 size = ivec3(max(max(params.limits.x, params.limits.y), params.limits.z));
 
 	while (distance > -distance_adv) { //use this to avoid precision errors
-
 		uint cell = 0;
 
 		ivec3 pos = ivec3(from);
@@ -120,8 +112,9 @@ uint raymarch(float distance, float distance_adv, vec3 from, vec3 direction) {
 				}
 
 				cell = cell_children.data[cell].children[child];
-				if (cell == NO_CHILDREN)
+				if (cell == NO_CHILDREN) {
 					break;
+				}
 
 				half_size >>= ivec3(1);
 			}
@@ -142,7 +135,6 @@ bool compute_light_vector(uint light, uint cell, vec3 pos, out float attenuation
 	if (lights.data[light].type == LIGHT_TYPE_DIRECTIONAL) {
 		light_pos = pos - lights.data[light].direction * length(vec3(params.limits));
 		attenuation = 1.0;
-
 	} else {
 		light_pos = lights.data[light].position;
 		float distance = length(pos - light_pos);

--- a/servers/rendering/rasterizer_rd/shaders/luminance_reduce.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/luminance_reduce.glsl
@@ -1,5 +1,4 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
@@ -8,7 +7,6 @@ VERSION_DEFINES
 #define BLOCK_SIZE 8
 
 layout(local_size_x = BLOCK_SIZE, local_size_y = BLOCK_SIZE, local_size_z = 1) in;
-/* clang-format on */
 
 shared float tmp_data[BLOCK_SIZE * BLOCK_SIZE];
 
@@ -37,7 +35,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	float exposure_adjust;
 	float pad[3];
 }
-
 params;
 
 void main() {
@@ -68,7 +65,6 @@ void main() {
 		barrier();
 
 		size >>= 1;
-
 	} while (size >= 1);
 
 	if (t == 0) {

--- a/servers/rendering/rasterizer_rd/shaders/roughness_limiter.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/roughness_limiter.glsl
@@ -1,12 +1,10 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
-/* clang-format on */
 
 layout(set = 0, binding = 0) uniform sampler2D source_normal;
 layout(r8, set = 1, binding = 0) uniform restrict writeonly image2D dest_roughness;
@@ -16,7 +14,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	float curve;
 	uint pad;
 }
-
 params;
 
 #define HALF_PI 1.5707963267948966
@@ -53,14 +50,14 @@ void main() {
 		float kappa = (3.0f * r - r * r2) / (1.0f - r2);
 		float variance = 0.25f / kappa;
 		limit = sqrt(min(2.0f * variance, threshold * threshold));
-//*/
+		*/
 		/*
 		//Formula based on probability distribution graph
 
 		float width = acos(max(0.0,r)); // convert to angle (width)
 		float roughness = pow(width,1.7)*0.854492; //approximate (crappy) formula to convert to roughness
 		limit = min(sqrt(roughness), threshold); //convert to perceptual roughness and apply threshold
-//*/
+		*/
 
 		limit = min(sqrt(pow(acos(max(0.0, r)) / HALF_PI, params.curve)), threshold); //convert to perceptual roughness and apply threshold
 

--- a/servers/rendering/rasterizer_rd/shaders/scene_high_end.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/scene_high_end.glsl
@@ -1,5 +1,4 @@
-/* clang-format off */
-[vertex]
+#[vertex]
 
 #version 450
 
@@ -10,7 +9,6 @@ VERSION_DEFINES
 /* INPUT ATTRIBS */
 
 layout(location = 0) in vec3 vertex_attrib;
-/* clang-format on */
 layout(location = 1) in vec3 normal_attrib;
 #if defined(TANGENT_USED) || defined(NORMALMAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 layout(location = 2) in vec4 tangent_attrib;
@@ -62,8 +60,6 @@ VERTEX_SHADER_GLOBALS
 
 /* clang-format on */
 
-// FIXME: This triggers a Mesa bug that breaks rendering, so disabled for now.
-// See GH-13450 and https://bugs.freedesktop.org/show_bug.cgi?id=100316
 invariant gl_Position;
 
 layout(location = 7) flat out uint instance_index;
@@ -272,8 +268,7 @@ VERTEX_SHADER_CODE
 #endif
 }
 
-/* clang-format off */
-[fragment]
+#[fragment]
 
 #version 450
 
@@ -284,7 +279,6 @@ VERSION_DEFINES
 /* Varyings */
 
 layout(location = 0) in vec3 vertex_interp;
-/* clang-format on */
 layout(location = 1) in vec3 normal_interp;
 
 #if defined(COLOR_USED)

--- a/servers/rendering/rasterizer_rd/shaders/scene_high_end_inc.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/scene_high_end_inc.glsl
@@ -6,7 +6,6 @@ layout(push_constant, binding = 0, std430) uniform DrawCall {
 	uint pad; //16 bits minimum size
 	vec2 bake_uv2_offset; //used for bake to uv2, ignored otherwise
 }
-
 draw_call;
 
 /* Set 0 Scene data that never changes, ever */
@@ -148,7 +147,6 @@ struct InstanceData {
 layout(set = 0, binding = 4, std430) restrict readonly buffer Instances {
 	InstanceData data[];
 }
-
 instances;
 
 struct LightData { //this structure needs to be as packed as possible
@@ -175,7 +173,6 @@ struct LightData { //this structure needs to be as packed as possible
 layout(set = 0, binding = 5, std430) restrict readonly buffer Lights {
 	LightData data[];
 }
-
 lights;
 
 struct ReflectionData {
@@ -192,7 +189,6 @@ struct ReflectionData {
 layout(set = 0, binding = 6, std140) uniform ReflectionProbeData {
 	ReflectionData data[MAX_REFLECTION_DATA_STRUCTS];
 }
-
 reflections;
 
 struct DirectionalLightData {
@@ -231,7 +227,6 @@ struct DirectionalLightData {
 layout(set = 0, binding = 7, std140) uniform DirectionalLights {
 	DirectionalLightData data[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
 }
-
 directional_lights;
 
 struct GIProbeData {
@@ -253,7 +248,6 @@ struct GIProbeData {
 layout(set = 0, binding = 8, std140) uniform GIProbes {
 	GIProbeData data[MAX_GI_PROBES];
 }
-
 gi_probes;
 
 layout(set = 0, binding = 9) uniform texture3D gi_probe_textures[MAX_GI_PROBE_TEXTURES];
@@ -268,7 +262,6 @@ struct Lightmap {
 layout(set = 0, binding = 10, std140) restrict readonly buffer Lightmaps {
 	Lightmap data[];
 }
-
 lightmaps;
 
 layout(set = 0, binding = 11) uniform texture2DArray lightmap_textures[MAX_LIGHTMAP_TEXTURES];
@@ -280,7 +273,6 @@ struct LightmapCapture {
 layout(set = 0, binding = 12, std140) restrict readonly buffer LightmapCaptures {
 	LightmapCapture data[];
 }
-
 lightmap_captures;
 
 #define CLUSTER_COUNTER_SHIFT 20
@@ -311,7 +303,6 @@ struct DecalData {
 layout(set = 0, binding = 15, std430) restrict readonly buffer Decals {
 	DecalData data[];
 }
-
 decals;
 
 layout(set = 0, binding = 16) uniform utexture3D cluster_texture;
@@ -319,7 +310,6 @@ layout(set = 0, binding = 16) uniform utexture3D cluster_texture;
 layout(set = 0, binding = 17, std430) restrict readonly buffer ClusterData {
 	uint indices[];
 }
-
 cluster_data;
 
 layout(set = 0, binding = 18) uniform texture2D directional_shadow_atlas;
@@ -327,7 +317,6 @@ layout(set = 0, binding = 18) uniform texture2D directional_shadow_atlas;
 layout(set = 0, binding = 19, std430) restrict readonly buffer GlobalVariableData {
 	vec4 data[];
 }
-
 global_variables;
 
 // decal atlas
@@ -363,7 +352,6 @@ layout(set = 3, binding = 4) uniform texture2D ao_buffer;
 layout(set = 4, binding = 0, std430) restrict readonly buffer Transforms {
 	vec4 data[];
 }
-
 transforms;
 
 /* Set 5 User Material */

--- a/servers/rendering/rasterizer_rd/shaders/screen_space_reflection.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/screen_space_reflection.glsl
@@ -1,15 +1,10 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
 VERSION_DEFINES
 
-
-
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
-
-/* clang-format on */
 
 layout(rgba16f, set = 0, binding = 0) uniform restrict readonly image2D source_diffuse;
 layout(r32f, set = 0, binding = 1) uniform restrict readonly image2D source_depth;
@@ -42,7 +37,6 @@ layout(push_constant, binding = 2, std430) uniform Params {
 
 	mat4 projection;
 }
-
 params;
 
 vec2 view_to_screen(vec3 view_pos, out float w) {

--- a/servers/rendering/rasterizer_rd/shaders/screen_space_reflection_filter.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/screen_space_reflection_filter.glsl
@@ -1,15 +1,10 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
 VERSION_DEFINES
 
-
-
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
-
-/* clang-format on */
 
 layout(rgba16f, set = 0, binding = 0) uniform restrict readonly image2D source_ssr;
 layout(r8, set = 0, binding = 1) uniform restrict readonly image2D source_radius;
@@ -33,7 +28,6 @@ layout(push_constant, binding = 2, std430) uniform Params {
 	bool vertical;
 	uint steps;
 }
-
 params;
 
 #define GAUSS_TABLE_SIZE 15

--- a/servers/rendering/rasterizer_rd/shaders/screen_space_reflection_scale.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/screen_space_reflection_scale.glsl
@@ -1,14 +1,10 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
 VERSION_DEFINES
 
-
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
-
-/* clang-format on */
 
 layout(set = 0, binding = 0) uniform sampler2D source_ssr;
 layout(set = 1, binding = 0) uniform sampler2D source_depth;
@@ -26,7 +22,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	bool filtered;
 	uint pad[2];
 }
-
 params;
 
 void main() {
@@ -72,7 +67,6 @@ void main() {
 		color /= 4.0;
 		depth /= 4.0;
 		normal = normalize(normal / 4.0) * 0.5 + 0.5;
-
 	} else {
 		color = texelFetch(source_ssr, ssC << 1, 0);
 		depth = texelFetch(source_depth, ssC << 1, 0).r;

--- a/servers/rendering/rasterizer_rd/shaders/sky.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/sky.glsl
@@ -1,12 +1,10 @@
-/* clang-format off */
-[vertex]
+#[vertex]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(location = 0) out vec2 uv_interp;
-/* clang-format on */
 
 layout(push_constant, binding = 1, std430) uniform Params {
 	mat3 orientation;
@@ -14,7 +12,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	vec4 position_multiplier;
 	float time;
 }
-
 params;
 
 void main() {
@@ -23,8 +20,7 @@ void main() {
 	gl_Position = vec4(uv_interp, 1.0, 1.0);
 }
 
-/* clang-format off */
-[fragment]
+#[fragment]
 
 #version 450
 
@@ -33,7 +29,6 @@ VERSION_DEFINES
 #define M_PI 3.14159265359
 
 layout(location = 0) in vec2 uv_interp;
-/* clang-format on */
 
 layout(push_constant, binding = 1, std430) uniform Params {
 	mat3 orientation;
@@ -41,7 +36,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	vec4 position_multiplier;
 	float time; //TODO consider adding vec2 screen res, and float radiance size
 }
-
 params;
 
 #define SAMPLER_NEAREST_CLAMP 0
@@ -62,7 +56,6 @@ layout(set = 0, binding = 0) uniform sampler material_samplers[12];
 layout(set = 0, binding = 1, std430) restrict readonly buffer GlobalVariableData {
 	vec4 data[];
 }
-
 global_variables;
 
 #ifdef USE_MATERIAL_UNIFORMS

--- a/servers/rendering/rasterizer_rd/shaders/specular_merge.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/specular_merge.glsl
@@ -1,12 +1,10 @@
-/* clang-format off */
-[vertex]
+#[vertex]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(location = 0) out vec2 uv_interp;
-/* clang-format on */
 
 void main() {
 	vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
@@ -15,15 +13,13 @@ void main() {
 	gl_Position = vec4(uv_interp * 2.0 - 1.0, 0.0, 1.0);
 }
 
-/* clang-format off */
-[fragment]
+#[fragment]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(location = 0) in vec2 uv_interp;
-/* clang-format on */
 
 layout(set = 0, binding = 0) uniform sampler2D specular;
 

--- a/servers/rendering/rasterizer_rd/shaders/ssao.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/ssao.glsl
@@ -1,12 +1,10 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
-/* clang-format on */
 
 #define TWO_PI 6.283185307179586476925286766559
 
@@ -49,7 +47,6 @@ const int ROTATIONS[] = int[](
 		29, 21, 19, 27, 31, 29, 21, 18, 17, 29,
 		31, 31, 23, 18, 25, 26, 25, 23, 19, 34,
 		19, 27, 21, 25, 39, 29, 17, 21, 27);
-/* clang-format on */
 
 //#define NUM_SPIRAL_TURNS (7)
 const int NUM_SPIRAL_TURNS = ROTATIONS[NUM_SAMPLES - 1];
@@ -78,7 +75,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	float proj_scale;
 	uint pad;
 }
-
 params;
 
 vec3 reconstructCSPosition(vec2 S, float z) {

--- a/servers/rendering/rasterizer_rd/shaders/ssao_blur.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/ssao_blur.glsl
@@ -1,12 +1,10 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
-/* clang-format on */
 
 layout(set = 0, binding = 0) uniform sampler2D source_ssao;
 layout(set = 1, binding = 0) uniform sampler2D source_depth;
@@ -31,7 +29,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	ivec2 axis; /** (1, 0) or (0, 1) */
 	ivec2 screen_size;
 }
-
 params;
 
 /** Filter radius in pixels. This will be multiplied by SCALE. */

--- a/servers/rendering/rasterizer_rd/shaders/ssao_minify.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/ssao_minify.glsl
@@ -1,12 +1,10 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
-/* clang-format on */
 
 layout(push_constant, binding = 1, std430) uniform Params {
 	vec2 pixel_size;
@@ -16,7 +14,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	bool orthogonal;
 	uint pad;
 }
-
 params;
 
 #ifdef MINIFY_START

--- a/servers/rendering/rasterizer_rd/shaders/subsurface_scattering.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/subsurface_scattering.glsl
@@ -1,15 +1,10 @@
-/* clang-format off */
-[compute]
+#[compute]
 
 #version 450
 
 VERSION_DEFINES
 
-
-
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
-
-/* clang-format on */
 
 #ifdef USE_25_SAMPLES
 const int kernel_size = 13;
@@ -105,7 +100,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	float depth_scale;
 	uint pad[3];
 }
-
 params;
 
 layout(set = 0, binding = 0) uniform sampler2D source_image;

--- a/servers/rendering/rasterizer_rd/shaders/tonemap.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/tonemap.glsl
@@ -1,12 +1,10 @@
-/* clang-format off */
-[vertex]
+#[vertex]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(location = 0) out vec2 uv_interp;
-/* clang-format on */
 
 void main() {
 	vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
@@ -14,15 +12,13 @@ void main() {
 	gl_Position = vec4(uv_interp * 2.0 - 1.0, 0.0, 1.0);
 }
 
-/* clang-format off */
-[fragment]
+#[fragment]
 
 #version 450
 
 VERSION_DEFINES
 
 layout(location = 0) in vec2 uv_interp;
-/* clang-format on */
 
 layout(set = 0, binding = 0) uniform sampler2D source_color;
 layout(set = 1, binding = 0) uniform sampler2D source_auto_exposure;
@@ -52,7 +48,6 @@ layout(push_constant, binding = 1, std430) uniform Params {
 	bool use_fxaa;
 	uint pad;
 }
-
 params;
 
 layout(location = 0) out vec4 frag_color;
@@ -297,10 +292,11 @@ vec3 do_fxaa(vec3 color, float exposure, vec2 uv_interp) {
 											textureLod(source_color, uv_interp + dir * 0.5, 0.0).xyz * exposure);
 
 	float lumaB = dot(rgbB, luma);
-	if ((lumaB < lumaMin) || (lumaB > lumaMax))
+	if ((lumaB < lumaMin) || (lumaB > lumaMax)) {
 		return rgbA;
-	else
+	} else {
 		return rgbB;
+	}
 }
 
 void main() {


### PR DESCRIPTION
The added `#` prevents clang-format from misinterpreting the meaning
of this statement and thus messing up the formatting of the next
lines up until the first `layout` statement.

Similarly, a semicolon is now enforced on `versions` defines to
prevent clang-format from messing up formatting and putting them
all on a single line. Note: In its current state the code will
ignore chained statements on a single line separated by a semicolon.

Also removed some extraneous lines missed in previous style changes
or added by mistake with said changes (e.g. after uniform definitions
that clang-format messes up somewhat too, but we live with it).