### PR TITLE
Add new (and rename changed) core types to GDNative API.

### DIFF
--- a/modules/gdnative/gdnative/array.cpp
+++ b/modules/gdnative/gdnative/array.cpp
@@ -102,9 +102,9 @@ void GDAPI godot_array_new_packed_string_array(godot_array *r_dest, const godot_
 	}
 }
 
-void GDAPI godot_array_new_packed_real_array(godot_array *r_dest, const godot_packed_real_array *p_pra) {
+void GDAPI godot_array_new_packed_float32_array(godot_array *r_dest, const godot_packed_float32_array *p_pra) {
 	Array *dest = (Array *)r_dest;
-	Vector<godot_real> *pca = (Vector<godot_real> *)p_pra;
+	Vector<float> *pca = (Vector<float> *)p_pra;
 	memnew_placement(dest, Array);
 	dest->resize(pca->size());
 
@@ -114,9 +114,33 @@ void GDAPI godot_array_new_packed_real_array(godot_array *r_dest, const godot_pa
 	}
 }
 
-void GDAPI godot_array_new_packed_int_array(godot_array *r_dest, const godot_packed_int_array *p_pia) {
+void GDAPI godot_array_new_packed_float64_array(godot_array *r_dest, const godot_packed_float64_array *p_pra) {
 	Array *dest = (Array *)r_dest;
-	Vector<godot_int> *pca = (Vector<godot_int> *)p_pia;
+	Vector<double> *pca = (Vector<double> *)p_pra;
+	memnew_placement(dest, Array);
+	dest->resize(pca->size());
+
+	for (int i = 0; i < dest->size(); i++) {
+		Variant v = pca->operator[](i);
+		dest->operator[](i) = v;
+	}
+}
+
+void GDAPI godot_array_new_packed_int32_array(godot_array *r_dest, const godot_packed_int32_array *p_pia) {
+	Array *dest = (Array *)r_dest;
+	Vector<int32_t> *pca = (Vector<int32_t> *)p_pia;
+	memnew_placement(dest, Array);
+	dest->resize(pca->size());
+
+	for (int i = 0; i < dest->size(); i++) {
+		Variant v = pca->operator[](i);
+		dest->operator[](i) = v;
+	}
+}
+
+void GDAPI godot_array_new_packed_int64_array(godot_array *r_dest, const godot_packed_int64_array *p_pia) {
+	Array *dest = (Array *)r_dest;
+	Vector<int64_t> *pca = (Vector<int64_t> *)p_pia;
 	memnew_placement(dest, Array);
 	dest->resize(pca->size());
 

--- a/modules/gdnative/gdnative/callable.cpp
+++ b/modules/gdnative/gdnative/callable.cpp
@@ -1,0 +1,252 @@
+/*************************************************************************/
+/*  callable.cpp                                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gdnative/callable.h"
+
+#include "core/callable.h"
+#include "core/resource.h"
+#include "core/variant.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static_assert(sizeof(godot_callable) == sizeof(Callable), "Callable size mismatch");
+static_assert(sizeof(godot_signal) == sizeof(Signal), "Signal size mismatch");
+
+// Callable
+
+void GDAPI godot_callable_new_with_object(godot_callable *r_dest, const godot_object *p_object, const godot_string_name *p_method) {
+	Callable *dest = (Callable *)r_dest;
+	const Object *object = (const Object *)p_object;
+	const StringName *method = (const StringName *)p_method;
+	memnew_placement(dest, Callable(object, *method));
+}
+
+void GDAPI godot_callable_new_with_object_id(godot_callable *r_dest, uint64_t p_objectid, const godot_string_name *p_method) {
+	Callable *dest = (Callable *)r_dest;
+	const StringName *method = (const StringName *)p_method;
+	memnew_placement(dest, Callable(ObjectID(p_objectid), *method));
+}
+
+void GDAPI godot_callable_new_copy(godot_callable *r_dest, const godot_callable *p_src) {
+	Callable *dest = (Callable *)r_dest;
+	const Callable *src = (const Callable *)p_src;
+	memnew_placement(dest, Callable(*src));
+}
+
+void GDAPI godot_callable_destroy(godot_callable *p_self) {
+	Callable *self = (Callable *)p_self;
+	self->~Callable();
+}
+
+godot_int GDAPI godot_callable_call(const godot_callable *p_self, const godot_variant **p_arguments, godot_int p_argcount, godot_variant *r_return_value) {
+	const Callable *self = (const Callable *)p_self;
+	const Variant **arguments = (const Variant **)p_arguments;
+	Variant *return_value = (Variant *)r_return_value;
+	Variant ret;
+	Callable::CallError err;
+	self->call(arguments, p_argcount, ret, err);
+	if (return_value)
+		(*return_value) = ret;
+	return (godot_int)err.error;
+}
+
+void GDAPI godot_callable_call_deferred(const godot_callable *p_self, const godot_variant **p_arguments, godot_int p_argcount) {
+	const Callable *self = (const Callable *)p_self;
+	const Variant **arguments = (const Variant **)p_arguments;
+	self->call_deferred(arguments, p_argcount);
+}
+
+godot_bool GDAPI godot_callable_is_null(const godot_callable *p_self) {
+	const Callable *self = (const Callable *)p_self;
+	return self->is_null();
+}
+
+godot_bool GDAPI godot_callable_is_custom(const godot_callable *p_self) {
+	const Callable *self = (const Callable *)p_self;
+	return self->is_custom();
+}
+
+godot_bool GDAPI godot_callable_is_standard(const godot_callable *p_self) {
+	const Callable *self = (const Callable *)p_self;
+	return self->is_standard();
+}
+
+godot_object GDAPI *godot_callable_get_object(const godot_callable *p_self) {
+	const Callable *self = (const Callable *)p_self;
+	return (godot_object *)self->get_object();
+}
+
+uint64_t GDAPI godot_callable_get_object_id(const godot_callable *p_self) {
+	const Callable *self = (const Callable *)p_self;
+	return (uint64_t)self->get_object_id();
+}
+
+godot_string_name GDAPI godot_callable_get_method(const godot_callable *p_self) {
+	godot_string_name raw_dest;
+	const Callable *self = (const Callable *)p_self;
+	StringName *dest = (StringName *)&raw_dest;
+	memnew_placement(dest, StringName(self->get_method()));
+	return raw_dest;
+}
+
+uint32_t GDAPI godot_callable_hash(const godot_callable *p_self) {
+	const Callable *self = (const Callable *)p_self;
+	return self->hash();
+}
+
+godot_string GDAPI godot_callable_as_string(const godot_callable *p_self) {
+	godot_string ret;
+	const Callable *self = (const Callable *)p_self;
+	memnew_placement(&ret, String(*self));
+	return ret;
+}
+
+godot_bool GDAPI godot_callable_operator_equal(const godot_callable *p_self, const godot_callable *p_other) {
+	const Callable *self = (const Callable *)p_self;
+	const Callable *other = (const Callable *)p_other;
+	return *self == *other;
+}
+
+godot_bool GDAPI godot_callable_operator_less(const godot_callable *p_self, const godot_callable *p_other) {
+	const Callable *self = (const Callable *)p_self;
+	const Callable *other = (const Callable *)p_other;
+	return *self < *other;
+}
+
+// Signal
+
+void GDAPI godot_signal_new_with_object(godot_signal *r_dest, const godot_object *p_object, const godot_string_name *p_name) {
+	Signal *dest = (Signal *)r_dest;
+	const Object *object = (const Object *)p_object;
+	const StringName *name = (const StringName *)p_name;
+	memnew_placement(dest, Signal(object, *name));
+}
+
+void GDAPI godot_signal_new_with_object_id(godot_signal *r_dest, uint64_t p_objectid, const godot_string_name *p_name) {
+	Signal *dest = (Signal *)r_dest;
+	const StringName *name = (const StringName *)p_name;
+	memnew_placement(dest, Signal(ObjectID(p_objectid), *name));
+}
+
+void GDAPI godot_signal_new_copy(godot_signal *r_dest, const godot_signal *p_src) {
+	Signal *dest = (Signal *)r_dest;
+	const Signal *src = (const Signal *)p_src;
+	memnew_placement(dest, Signal(*src));
+}
+
+void GDAPI godot_signal_destroy(godot_signal *p_self) {
+	Signal *self = (Signal *)p_self;
+	self->~Signal();
+}
+
+godot_int GDAPI godot_signal_emit(const godot_signal *p_self, const godot_variant **p_arguments, godot_int p_argcount) {
+	const Signal *self = (const Signal *)p_self;
+	const Variant **arguments = (const Variant **)p_arguments;
+	return (godot_int)self->emit(arguments, p_argcount);
+}
+
+godot_int GDAPI godot_signal_connect(godot_signal *p_self, const godot_callable *p_callable, const godot_array *p_binds, uint32_t p_flags) {
+	Signal *self = (Signal *)p_self;
+	const Callable *callable = (const Callable *)p_callable;
+	const Array *binds_ar = (const Array *)p_binds;
+	Vector<Variant> binds;
+	for (int i = 0; i < binds_ar->size(); i++) {
+		binds.push_back(binds_ar->get(i));
+	}
+	return (godot_int)self->connect(*callable, binds, p_flags);
+}
+
+void GDAPI godot_signal_disconnect(godot_signal *p_self, const godot_callable *p_callable) {
+	Signal *self = (Signal *)p_self;
+	const Callable *callable = (const Callable *)p_callable;
+	self->disconnect(*callable);
+}
+
+godot_bool GDAPI godot_signal_is_null(const godot_signal *p_self) {
+	const Signal *self = (const Signal *)p_self;
+	return self->is_null();
+}
+
+godot_bool GDAPI godot_signal_is_connected(const godot_signal *p_self, const godot_callable *p_callable) {
+	const Signal *self = (const Signal *)p_self;
+	const Callable *callable = (const Callable *)p_callable;
+	return self->is_connected(*callable);
+}
+
+godot_array GDAPI godot_signal_get_connections(const godot_signal *p_self) {
+	godot_array raw_dest;
+	const Signal *self = (const Signal *)p_self;
+	Array *dest = (Array *)&raw_dest;
+	memnew_placement(dest, Array(self->get_connections()));
+	return raw_dest;
+}
+
+godot_object GDAPI *godot_signal_get_object(const godot_signal *p_self) {
+	const Signal *self = (const Signal *)p_self;
+	return (godot_object *)self->get_object();
+}
+
+uint64_t GDAPI godot_signal_get_object_id(const godot_signal *p_self) {
+	const Signal *self = (const Signal *)p_self;
+	return (uint64_t)self->get_object_id();
+}
+
+godot_string_name GDAPI godot_signal_get_name(const godot_signal *p_self) {
+	godot_string_name raw_dest;
+	const Signal *self = (const Signal *)p_self;
+	StringName *dest = (StringName *)&raw_dest;
+	memnew_placement(dest, StringName(self->get_name()));
+	return raw_dest;
+}
+
+godot_string GDAPI godot_signal_as_string(const godot_signal *p_self) {
+	godot_string ret;
+	const Signal *self = (const Signal *)p_self;
+	memnew_placement(&ret, String(*self));
+	return ret;
+}
+
+godot_bool GDAPI godot_signal_operator_equal(const godot_signal *p_self, const godot_signal *p_other) {
+	const Signal *self = (const Signal *)p_self;
+	const Signal *other = (const Signal *)p_other;
+	return *self == *other;
+}
+
+godot_bool GDAPI godot_signal_operator_less(const godot_signal *p_self, const godot_signal *p_other) {
+	const Signal *self = (const Signal *)p_self;
+	const Signal *other = (const Signal *)p_other;
+	return *self < *other;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/modules/gdnative/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative/gdnative.cpp
@@ -165,7 +165,7 @@ void _gdnative_report_loading_error(const godot_object *p_library, const char *p
 	_err_print_error("gdnative_init", library->get_current_library_path().utf8().ptr(), 0, message.utf8().ptr());
 }
 
-godot_object GDAPI *godot_instance_from_id(godot_int p_instance_id) {
+godot_object GDAPI *godot_instance_from_id(uint64_t p_instance_id) {
 	return (godot_object *)ObjectDB::get_instance(ObjectID(p_instance_id));
 }
 
@@ -182,6 +182,11 @@ godot_object *godot_object_cast_to(const godot_object *p_object, void *p_class_t
 	Object *o = (Object *)p_object;
 
 	return o->is_class_ptr(p_class_tag) ? (godot_object *)o : nullptr;
+}
+
+uint64_t GDAPI godot_object_get_instance_id(const godot_object *p_object) {
+	const Object *o = (const Object *)p_object;
+	return (uint64_t)o->get_instance_id();
 }
 
 #ifdef __cplusplus

--- a/modules/gdnative/gdnative/packed_arrays.cpp
+++ b/modules/gdnative/gdnative/packed_arrays.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  pool_arrays.cpp                                                      */
+/*  packed_arrays.cpp                                                    */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "gdnative/pool_arrays.h"
+#include "gdnative/packed_arrays.h"
 
 #include "core/array.h"
 
@@ -43,8 +43,10 @@ extern "C" {
 #endif
 
 static_assert(sizeof(godot_packed_byte_array) == sizeof(Vector<uint8_t>), "Vector<uint8_t> size mismatch");
-static_assert(sizeof(godot_packed_int_array) == sizeof(Vector<godot_int>), "Vector<godot_int> size mismatch");
-static_assert(sizeof(godot_packed_real_array) == sizeof(Vector<godot_real>), "Vector<godot_real> size mismatch");
+static_assert(sizeof(godot_packed_int32_array) == sizeof(Vector<int32_t>), "Vector<int32_t> size mismatch");
+static_assert(sizeof(godot_packed_int64_array) == sizeof(Vector<int64_t>), "Vector<int64_t> size mismatch");
+static_assert(sizeof(godot_packed_float32_array) == sizeof(Vector<float>), "Vector<float> size mismatch");
+static_assert(sizeof(godot_packed_float64_array) == sizeof(Vector<double>), "Vector<double> size mismatch");
 static_assert(sizeof(godot_packed_string_array) == sizeof(Vector<String>), "Vector<String> size mismatch");
 static_assert(sizeof(godot_packed_vector2_array) == sizeof(Vector<Vector2>), "Vector<Vector2> size mismatch");
 static_assert(sizeof(godot_packed_vector3_array) == sizeof(Vector<Vector3>), "Vector<Vector3> size mismatch");
@@ -136,23 +138,23 @@ void GDAPI godot_packed_byte_array_destroy(godot_packed_byte_array *p_self) {
 	((Vector<uint8_t> *)p_self)->~Vector();
 }
 
-// int
+// int32
 
-void GDAPI godot_packed_int_array_new(godot_packed_int_array *r_dest) {
-	Vector<godot_int> *dest = (Vector<godot_int> *)r_dest;
-	memnew_placement(dest, Vector<godot_int>);
+void GDAPI godot_packed_int32_array_new(godot_packed_int32_array *r_dest) {
+	Vector<int32_t> *dest = (Vector<int32_t> *)r_dest;
+	memnew_placement(dest, Vector<int32_t>);
 }
 
-void GDAPI godot_packed_int_array_new_copy(godot_packed_int_array *r_dest, const godot_packed_int_array *p_src) {
-	Vector<godot_int> *dest = (Vector<godot_int> *)r_dest;
-	const Vector<godot_int> *src = (const Vector<godot_int> *)p_src;
-	memnew_placement(dest, Vector<godot_int>(*src));
+void GDAPI godot_packed_int32_array_new_copy(godot_packed_int32_array *r_dest, const godot_packed_int32_array *p_src) {
+	Vector<int32_t> *dest = (Vector<int32_t> *)r_dest;
+	const Vector<int32_t> *src = (const Vector<int32_t> *)p_src;
+	memnew_placement(dest, Vector<int32_t>(*src));
 }
 
-void GDAPI godot_packed_int_array_new_with_array(godot_packed_int_array *r_dest, const godot_array *p_a) {
-	Vector<godot_int> *dest = (Vector<godot_int> *)r_dest;
+void GDAPI godot_packed_int32_array_new_with_array(godot_packed_int32_array *r_dest, const godot_array *p_a) {
+	Vector<int32_t> *dest = (Vector<int32_t> *)r_dest;
 	Array *a = (Array *)p_a;
-	memnew_placement(dest, Vector<godot_int>);
+	memnew_placement(dest, Vector<int32_t>);
 
 	dest->resize(a->size());
 	for (int i = 0; i < a->size(); i++) {
@@ -160,83 +162,83 @@ void GDAPI godot_packed_int_array_new_with_array(godot_packed_int_array *r_dest,
 	}
 }
 
-void GDAPI godot_packed_int_array_append(godot_packed_int_array *p_self, const godot_int p_data) {
-	Vector<godot_int> *self = (Vector<godot_int> *)p_self;
+void GDAPI godot_packed_int32_array_append(godot_packed_int32_array *p_self, const int32_t p_data) {
+	Vector<int32_t> *self = (Vector<int32_t> *)p_self;
 	self->push_back(p_data);
 }
 
-void GDAPI godot_packed_int_array_append_array(godot_packed_int_array *p_self, const godot_packed_int_array *p_array) {
-	Vector<godot_int> *self = (Vector<godot_int> *)p_self;
-	Vector<godot_int> *array = (Vector<godot_int> *)p_array;
+void GDAPI godot_packed_int32_array_append_array(godot_packed_int32_array *p_self, const godot_packed_int32_array *p_array) {
+	Vector<int32_t> *self = (Vector<int32_t> *)p_self;
+	Vector<int32_t> *array = (Vector<int32_t> *)p_array;
 	self->append_array(*array);
 }
 
-godot_error GDAPI godot_packed_int_array_insert(godot_packed_int_array *p_self, const godot_int p_idx, const godot_int p_data) {
-	Vector<godot_int> *self = (Vector<godot_int> *)p_self;
+godot_error GDAPI godot_packed_int32_array_insert(godot_packed_int32_array *p_self, const godot_int p_idx, const int32_t p_data) {
+	Vector<int32_t> *self = (Vector<int32_t> *)p_self;
 	return (godot_error)self->insert(p_idx, p_data);
 }
 
-void GDAPI godot_packed_int_array_invert(godot_packed_int_array *p_self) {
-	Vector<godot_int> *self = (Vector<godot_int> *)p_self;
+void GDAPI godot_packed_int32_array_invert(godot_packed_int32_array *p_self) {
+	Vector<int32_t> *self = (Vector<int32_t> *)p_self;
 	self->invert();
 }
 
-void GDAPI godot_packed_int_array_push_back(godot_packed_int_array *p_self, const godot_int p_data) {
-	Vector<godot_int> *self = (Vector<godot_int> *)p_self;
+void GDAPI godot_packed_int32_array_push_back(godot_packed_int32_array *p_self, const int32_t p_data) {
+	Vector<int32_t> *self = (Vector<int32_t> *)p_self;
 	self->push_back(p_data);
 }
 
-void GDAPI godot_packed_int_array_remove(godot_packed_int_array *p_self, const godot_int p_idx) {
-	Vector<godot_int> *self = (Vector<godot_int> *)p_self;
+void GDAPI godot_packed_int32_array_remove(godot_packed_int32_array *p_self, const godot_int p_idx) {
+	Vector<int32_t> *self = (Vector<int32_t> *)p_self;
 	self->remove(p_idx);
 }
 
-void GDAPI godot_packed_int_array_resize(godot_packed_int_array *p_self, const godot_int p_size) {
-	Vector<godot_int> *self = (Vector<godot_int> *)p_self;
+void GDAPI godot_packed_int32_array_resize(godot_packed_int32_array *p_self, const godot_int p_size) {
+	Vector<int32_t> *self = (Vector<int32_t> *)p_self;
 	self->resize(p_size);
 }
 
-void GDAPI godot_packed_int_array_set(godot_packed_int_array *p_self, const godot_int p_idx, const godot_int p_data) {
-	Vector<godot_int> *self = (Vector<godot_int> *)p_self;
+void GDAPI godot_packed_int32_array_set(godot_packed_int32_array *p_self, const godot_int p_idx, const int32_t p_data) {
+	Vector<int32_t> *self = (Vector<int32_t> *)p_self;
 	self->set(p_idx, p_data);
 }
 
-godot_int GDAPI godot_packed_int_array_get(const godot_packed_int_array *p_self, const godot_int p_idx) {
-	const Vector<godot_int> *self = (const Vector<godot_int> *)p_self;
+int32_t GDAPI godot_packed_int32_array_get(const godot_packed_int32_array *p_self, const godot_int p_idx) {
+	const Vector<int32_t> *self = (const Vector<int32_t> *)p_self;
 	return self->get(p_idx);
 }
 
-godot_int GDAPI godot_packed_int_array_size(const godot_packed_int_array *p_self) {
-	const Vector<godot_int> *self = (const Vector<godot_int> *)p_self;
+godot_int GDAPI godot_packed_int32_array_size(const godot_packed_int32_array *p_self) {
+	const Vector<int32_t> *self = (const Vector<int32_t> *)p_self;
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_int_array_empty(const godot_packed_int_array *p_self) {
-	const Vector<godot_int> *self = (const Vector<godot_int> *)p_self;
+godot_bool GDAPI godot_packed_int32_array_empty(const godot_packed_int32_array *p_self) {
+	const Vector<int32_t> *self = (const Vector<int32_t> *)p_self;
 	return self->empty();
 }
 
-void GDAPI godot_packed_int_array_destroy(godot_packed_int_array *p_self) {
-	((Vector<godot_int> *)p_self)->~Vector();
+void GDAPI godot_packed_int32_array_destroy(godot_packed_int32_array *p_self) {
+	((Vector<int32_t> *)p_self)->~Vector();
 }
 
-// real
+// int64
 
-void GDAPI godot_packed_real_array_new(godot_packed_real_array *r_dest) {
-	Vector<godot_real> *dest = (Vector<godot_real> *)r_dest;
-	memnew_placement(dest, Vector<godot_real>);
+void GDAPI godot_packed_int64_array_new(godot_packed_int64_array *r_dest) {
+	Vector<int64_t> *dest = (Vector<int64_t> *)r_dest;
+	memnew_placement(dest, Vector<int64_t>);
 }
 
-void GDAPI godot_packed_real_array_new_copy(godot_packed_real_array *r_dest, const godot_packed_real_array *p_src) {
-	Vector<godot_real> *dest = (Vector<godot_real> *)r_dest;
-	const Vector<godot_real> *src = (const Vector<godot_real> *)p_src;
-	memnew_placement(dest, Vector<godot_real>(*src));
+void GDAPI godot_packed_int64_array_new_copy(godot_packed_int64_array *r_dest, const godot_packed_int64_array *p_src) {
+	Vector<int64_t> *dest = (Vector<int64_t> *)r_dest;
+	const Vector<int64_t> *src = (const Vector<int64_t> *)p_src;
+	memnew_placement(dest, Vector<int64_t>(*src));
 }
 
-void GDAPI godot_packed_real_array_new_with_array(godot_packed_real_array *r_dest, const godot_array *p_a) {
-	Vector<godot_real> *dest = (Vector<godot_real> *)r_dest;
+void GDAPI godot_packed_int64_array_new_with_array(godot_packed_int64_array *r_dest, const godot_array *p_a) {
+	Vector<int64_t> *dest = (Vector<int64_t> *)r_dest;
 	Array *a = (Array *)p_a;
-	memnew_placement(dest, Vector<godot_real>);
+	memnew_placement(dest, Vector<int64_t>);
 
 	dest->resize(a->size());
 	for (int i = 0; i < a->size(); i++) {
@@ -244,64 +246,232 @@ void GDAPI godot_packed_real_array_new_with_array(godot_packed_real_array *r_des
 	}
 }
 
-void GDAPI godot_packed_real_array_append(godot_packed_real_array *p_self, const godot_real p_data) {
-	Vector<godot_real> *self = (Vector<godot_real> *)p_self;
+void GDAPI godot_packed_int64_array_append(godot_packed_int64_array *p_self, const int64_t p_data) {
+	Vector<int64_t> *self = (Vector<int64_t> *)p_self;
 	self->push_back(p_data);
 }
 
-void GDAPI godot_packed_real_array_append_array(godot_packed_real_array *p_self, const godot_packed_real_array *p_array) {
-	Vector<godot_real> *self = (Vector<godot_real> *)p_self;
-	Vector<godot_real> *array = (Vector<godot_real> *)p_array;
+void GDAPI godot_packed_int64_array_append_array(godot_packed_int64_array *p_self, const godot_packed_int64_array *p_array) {
+	Vector<int64_t> *self = (Vector<int64_t> *)p_self;
+	Vector<int64_t> *array = (Vector<int64_t> *)p_array;
 	self->append_array(*array);
 }
 
-godot_error GDAPI godot_packed_real_array_insert(godot_packed_real_array *p_self, const godot_int p_idx, const godot_real p_data) {
-	Vector<godot_real> *self = (Vector<godot_real> *)p_self;
+godot_error GDAPI godot_packed_int64_array_insert(godot_packed_int64_array *p_self, const godot_int p_idx, const int64_t p_data) {
+	Vector<int64_t> *self = (Vector<int64_t> *)p_self;
 	return (godot_error)self->insert(p_idx, p_data);
 }
 
-void GDAPI godot_packed_real_array_invert(godot_packed_real_array *p_self) {
-	Vector<godot_real> *self = (Vector<godot_real> *)p_self;
+void GDAPI godot_packed_int64_array_invert(godot_packed_int64_array *p_self) {
+	Vector<int64_t> *self = (Vector<int64_t> *)p_self;
 	self->invert();
 }
 
-void GDAPI godot_packed_real_array_push_back(godot_packed_real_array *p_self, const godot_real p_data) {
-	Vector<godot_real> *self = (Vector<godot_real> *)p_self;
+void GDAPI godot_packed_int64_array_push_back(godot_packed_int64_array *p_self, const int64_t p_data) {
+	Vector<int64_t> *self = (Vector<int64_t> *)p_self;
 	self->push_back(p_data);
 }
 
-void GDAPI godot_packed_real_array_remove(godot_packed_real_array *p_self, const godot_int p_idx) {
-	Vector<godot_real> *self = (Vector<godot_real> *)p_self;
+void GDAPI godot_packed_int64_array_remove(godot_packed_int64_array *p_self, const godot_int p_idx) {
+	Vector<int64_t> *self = (Vector<int64_t> *)p_self;
 	self->remove(p_idx);
 }
 
-void GDAPI godot_packed_real_array_resize(godot_packed_real_array *p_self, const godot_int p_size) {
-	Vector<godot_real> *self = (Vector<godot_real> *)p_self;
+void GDAPI godot_packed_int64_array_resize(godot_packed_int64_array *p_self, const godot_int p_size) {
+	Vector<int64_t> *self = (Vector<int64_t> *)p_self;
 	self->resize(p_size);
 }
 
-void GDAPI godot_packed_real_array_set(godot_packed_real_array *p_self, const godot_int p_idx, const godot_real p_data) {
-	Vector<godot_real> *self = (Vector<godot_real> *)p_self;
+void GDAPI godot_packed_int64_array_set(godot_packed_int64_array *p_self, const godot_int p_idx, const int64_t p_data) {
+	Vector<int64_t> *self = (Vector<int64_t> *)p_self;
 	self->set(p_idx, p_data);
 }
 
-godot_real GDAPI godot_packed_real_array_get(const godot_packed_real_array *p_self, const godot_int p_idx) {
-	const Vector<godot_real> *self = (const Vector<godot_real> *)p_self;
+int64_t GDAPI godot_packed_int64_array_get(const godot_packed_int64_array *p_self, const godot_int p_idx) {
+	const Vector<int64_t> *self = (const Vector<int64_t> *)p_self;
 	return self->get(p_idx);
 }
 
-godot_int GDAPI godot_packed_real_array_size(const godot_packed_real_array *p_self) {
-	const Vector<godot_real> *self = (const Vector<godot_real> *)p_self;
+godot_int GDAPI godot_packed_int64_array_size(const godot_packed_int64_array *p_self) {
+	const Vector<int64_t> *self = (const Vector<int64_t> *)p_self;
 	return self->size();
 }
 
-godot_bool GDAPI godot_packed_real_array_empty(const godot_packed_real_array *p_self) {
-	const Vector<godot_real> *self = (const Vector<godot_real> *)p_self;
+godot_bool GDAPI godot_packed_int64_array_empty(const godot_packed_int64_array *p_self) {
+	const Vector<int64_t> *self = (const Vector<int64_t> *)p_self;
 	return self->empty();
 }
 
-void GDAPI godot_packed_real_array_destroy(godot_packed_real_array *p_self) {
-	((Vector<godot_real> *)p_self)->~Vector();
+void GDAPI godot_packed_int64_array_destroy(godot_packed_int64_array *p_self) {
+	((Vector<int64_t> *)p_self)->~Vector();
+}
+
+// float32
+
+void GDAPI godot_packed_float32_array_new(godot_packed_float32_array *r_dest) {
+	Vector<float> *dest = (Vector<float> *)r_dest;
+	memnew_placement(dest, Vector<float>);
+}
+
+void GDAPI godot_packed_float32_array_new_copy(godot_packed_float32_array *r_dest, const godot_packed_float32_array *p_src) {
+	Vector<float> *dest = (Vector<float> *)r_dest;
+	const Vector<float> *src = (const Vector<float> *)p_src;
+	memnew_placement(dest, Vector<float>(*src));
+}
+
+void GDAPI godot_packed_float32_array_new_with_array(godot_packed_float32_array *r_dest, const godot_array *p_a) {
+	Vector<float> *dest = (Vector<float> *)r_dest;
+	Array *a = (Array *)p_a;
+	memnew_placement(dest, Vector<float>);
+
+	dest->resize(a->size());
+	for (int i = 0; i < a->size(); i++) {
+		dest->set(i, (*a)[i]);
+	}
+}
+
+void GDAPI godot_packed_float32_array_append(godot_packed_float32_array *p_self, const float p_data) {
+	Vector<float> *self = (Vector<float> *)p_self;
+	self->push_back(p_data);
+}
+
+void GDAPI godot_packed_float32_array_append_array(godot_packed_float32_array *p_self, const godot_packed_float32_array *p_array) {
+	Vector<float> *self = (Vector<float> *)p_self;
+	Vector<float> *array = (Vector<float> *)p_array;
+	self->append_array(*array);
+}
+
+godot_error GDAPI godot_packed_float32_array_insert(godot_packed_float32_array *p_self, const godot_int p_idx, const float p_data) {
+	Vector<float> *self = (Vector<float> *)p_self;
+	return (godot_error)self->insert(p_idx, p_data);
+}
+
+void GDAPI godot_packed_float32_array_invert(godot_packed_float32_array *p_self) {
+	Vector<float> *self = (Vector<float> *)p_self;
+	self->invert();
+}
+
+void GDAPI godot_packed_float32_array_push_back(godot_packed_float32_array *p_self, const float p_data) {
+	Vector<float> *self = (Vector<float> *)p_self;
+	self->push_back(p_data);
+}
+
+void GDAPI godot_packed_float32_array_remove(godot_packed_float32_array *p_self, const godot_int p_idx) {
+	Vector<float> *self = (Vector<float> *)p_self;
+	self->remove(p_idx);
+}
+
+void GDAPI godot_packed_float32_array_resize(godot_packed_float32_array *p_self, const godot_int p_size) {
+	Vector<float> *self = (Vector<float> *)p_self;
+	self->resize(p_size);
+}
+
+void GDAPI godot_packed_float32_array_set(godot_packed_float32_array *p_self, const godot_int p_idx, const float p_data) {
+	Vector<float> *self = (Vector<float> *)p_self;
+	self->set(p_idx, p_data);
+}
+
+float GDAPI godot_packed_float32_array_get(const godot_packed_float32_array *p_self, const godot_int p_idx) {
+	const Vector<float> *self = (const Vector<float> *)p_self;
+	return self->get(p_idx);
+}
+
+godot_int GDAPI godot_packed_float32_array_size(const godot_packed_float32_array *p_self) {
+	const Vector<float> *self = (const Vector<float> *)p_self;
+	return self->size();
+}
+
+godot_bool GDAPI godot_packed_float32_array_empty(const godot_packed_float32_array *p_self) {
+	const Vector<float> *self = (const Vector<float> *)p_self;
+	return self->empty();
+}
+
+void GDAPI godot_packed_float32_array_destroy(godot_packed_float32_array *p_self) {
+	((Vector<float> *)p_self)->~Vector();
+}
+
+// float64
+
+void GDAPI godot_packed_float64_array_new(godot_packed_float64_array *r_dest) {
+	Vector<double> *dest = (Vector<double> *)r_dest;
+	memnew_placement(dest, Vector<double>);
+}
+
+void GDAPI godot_packed_float64_array_new_copy(godot_packed_float64_array *r_dest, const godot_packed_float64_array *p_src) {
+	Vector<double> *dest = (Vector<double> *)r_dest;
+	const Vector<double> *src = (const Vector<double> *)p_src;
+	memnew_placement(dest, Vector<double>(*src));
+}
+
+void GDAPI godot_packed_float64_array_new_with_array(godot_packed_float64_array *r_dest, const godot_array *p_a) {
+	Vector<double> *dest = (Vector<double> *)r_dest;
+	Array *a = (Array *)p_a;
+	memnew_placement(dest, Vector<double>);
+
+	dest->resize(a->size());
+	for (int i = 0; i < a->size(); i++) {
+		dest->set(i, (*a)[i]);
+	}
+}
+
+void GDAPI godot_packed_float64_array_append(godot_packed_float64_array *p_self, const double p_data) {
+	Vector<double> *self = (Vector<double> *)p_self;
+	self->push_back(p_data);
+}
+
+void GDAPI godot_packed_float64_array_append_array(godot_packed_float64_array *p_self, const godot_packed_float64_array *p_array) {
+	Vector<double> *self = (Vector<double> *)p_self;
+	Vector<double> *array = (Vector<double> *)p_array;
+	self->append_array(*array);
+}
+
+godot_error GDAPI godot_packed_float64_array_insert(godot_packed_float64_array *p_self, const godot_int p_idx, const double p_data) {
+	Vector<double> *self = (Vector<double> *)p_self;
+	return (godot_error)self->insert(p_idx, p_data);
+}
+
+void GDAPI godot_packed_float64_array_invert(godot_packed_float64_array *p_self) {
+	Vector<double> *self = (Vector<double> *)p_self;
+	self->invert();
+}
+
+void GDAPI godot_packed_float64_array_push_back(godot_packed_float64_array *p_self, const double p_data) {
+	Vector<double> *self = (Vector<double> *)p_self;
+	self->push_back(p_data);
+}
+
+void GDAPI godot_packed_float64_array_remove(godot_packed_float64_array *p_self, const godot_int p_idx) {
+	Vector<double> *self = (Vector<double> *)p_self;
+	self->remove(p_idx);
+}
+
+void GDAPI godot_packed_float64_array_resize(godot_packed_float64_array *p_self, const godot_int p_size) {
+	Vector<double> *self = (Vector<double> *)p_self;
+	self->resize(p_size);
+}
+
+void GDAPI godot_packed_float64_array_set(godot_packed_float64_array *p_self, const godot_int p_idx, const double p_data) {
+	Vector<double> *self = (Vector<double> *)p_self;
+	self->set(p_idx, p_data);
+}
+
+double GDAPI godot_packed_float64_array_get(const godot_packed_float64_array *p_self, const godot_int p_idx) {
+	const Vector<double> *self = (const Vector<double> *)p_self;
+	return self->get(p_idx);
+}
+
+godot_int GDAPI godot_packed_float64_array_size(const godot_packed_float64_array *p_self) {
+	const Vector<double> *self = (const Vector<double> *)p_self;
+	return self->size();
+}
+
+godot_bool GDAPI godot_packed_float64_array_empty(const godot_packed_float64_array *p_self) {
+	const Vector<double> *self = (const Vector<double> *)p_self;
+	return self->empty();
+}
+
+void GDAPI godot_packed_float64_array_destroy(godot_packed_float64_array *p_self) {
+	((Vector<double> *)p_self)->~Vector();
 }
 
 // string

--- a/modules/gdnative/gdnative/rect2.cpp
+++ b/modules/gdnative/gdnative/rect2.cpp
@@ -38,6 +38,9 @@ extern "C" {
 #endif
 
 static_assert(sizeof(godot_rect2) == sizeof(Rect2), "Rect2 size mismatch");
+static_assert(sizeof(godot_rect2i) == sizeof(Rect2i), "Rect2i size mismatch");
+
+// Rect2
 
 void GDAPI godot_rect2_new_with_position_and_size(godot_rect2 *r_dest, const godot_vector2 *p_pos, const godot_vector2 *p_size) {
 	const Vector2 *position = (const Vector2 *)p_pos;
@@ -56,6 +59,13 @@ godot_string GDAPI godot_rect2_as_string(const godot_rect2 *p_self) {
 	const Rect2 *self = (const Rect2 *)p_self;
 	memnew_placement(&ret, String(*self));
 	return ret;
+}
+
+godot_rect2i GDAPI godot_rect2_as_rect2i(const godot_rect2 *p_self) {
+	godot_rect2i dest;
+	const Rect2 *self = (const Rect2 *)p_self;
+	*((Rect2i *)&dest) = Rect2i(*self);
+	return dest;
 }
 
 godot_real GDAPI godot_rect2_get_area(const godot_rect2 *p_self) {
@@ -170,6 +180,149 @@ void GDAPI godot_rect2_set_position(godot_rect2 *p_self, const godot_vector2 *p_
 void GDAPI godot_rect2_set_size(godot_rect2 *p_self, const godot_vector2 *p_size) {
 	Rect2 *self = (Rect2 *)p_self;
 	const Vector2 *size = (const Vector2 *)p_size;
+	self->set_size(*size);
+}
+
+// Rect2i
+
+void GDAPI godot_rect2i_new_with_position_and_size(godot_rect2i *r_dest, const godot_vector2i *p_pos, const godot_vector2i *p_size) {
+	const Vector2i *position = (const Vector2i *)p_pos;
+	const Vector2i *size = (const Vector2i *)p_size;
+	Rect2i *dest = (Rect2i *)r_dest;
+	*dest = Rect2i(*position, *size);
+}
+
+void GDAPI godot_rect2i_new(godot_rect2i *r_dest, const godot_int p_x, const godot_int p_y, const godot_int p_width, const godot_int p_height) {
+	Rect2i *dest = (Rect2i *)r_dest;
+	*dest = Rect2i(p_x, p_y, p_width, p_height);
+}
+
+godot_string GDAPI godot_rect2i_as_string(const godot_rect2i *p_self) {
+	godot_string ret;
+	const Rect2i *self = (const Rect2i *)p_self;
+	memnew_placement(&ret, String(*self));
+	return ret;
+}
+
+godot_rect2 GDAPI godot_rect2i_as_rect2(const godot_rect2i *p_self) {
+	godot_rect2 dest;
+	const Rect2i *self = (const Rect2i *)p_self;
+	*((Rect2 *)&dest) = Rect2(*self);
+	return dest;
+}
+
+godot_int GDAPI godot_rect2i_get_area(const godot_rect2i *p_self) {
+	const Rect2i *self = (const Rect2i *)p_self;
+	return self->get_area();
+}
+
+godot_bool GDAPI godot_rect2i_intersects(const godot_rect2i *p_self, const godot_rect2i *p_b) {
+	const Rect2i *self = (const Rect2i *)p_self;
+	const Rect2i *b = (const Rect2i *)p_b;
+	return self->intersects(*b);
+}
+
+godot_bool GDAPI godot_rect2i_encloses(const godot_rect2i *p_self, const godot_rect2i *p_b) {
+	const Rect2i *self = (const Rect2i *)p_self;
+	const Rect2i *b = (const Rect2i *)p_b;
+	return self->encloses(*b);
+}
+
+godot_bool GDAPI godot_rect2i_has_no_area(const godot_rect2i *p_self) {
+	const Rect2i *self = (const Rect2i *)p_self;
+	return self->has_no_area();
+}
+
+godot_rect2i GDAPI godot_rect2i_clip(const godot_rect2i *p_self, const godot_rect2i *p_b) {
+	godot_rect2i dest;
+	const Rect2i *self = (const Rect2i *)p_self;
+	const Rect2i *b = (const Rect2i *)p_b;
+	*((Rect2i *)&dest) = self->clip(*b);
+	return dest;
+}
+
+godot_rect2i GDAPI godot_rect2i_merge(const godot_rect2i *p_self, const godot_rect2i *p_b) {
+	godot_rect2i dest;
+	const Rect2i *self = (const Rect2i *)p_self;
+	const Rect2i *b = (const Rect2i *)p_b;
+	*((Rect2i *)&dest) = self->merge(*b);
+	return dest;
+}
+
+godot_bool GDAPI godot_rect2i_has_point(const godot_rect2i *p_self, const godot_vector2i *p_point) {
+	const Rect2i *self = (const Rect2i *)p_self;
+	const Vector2i *point = (const Vector2i *)p_point;
+	return self->has_point(*point);
+}
+
+godot_rect2i GDAPI godot_rect2i_grow(const godot_rect2i *p_self, const godot_int p_by) {
+	godot_rect2i dest;
+	const Rect2i *self = (const Rect2i *)p_self;
+
+	*((Rect2i *)&dest) = self->grow(p_by);
+	return dest;
+}
+
+godot_rect2i GDAPI godot_rect2i_grow_individual(const godot_rect2i *p_self, const godot_int p_left, const godot_int p_top, const godot_int p_right, const godot_int p_bottom) {
+	godot_rect2i dest;
+	const Rect2i *self = (const Rect2i *)p_self;
+	*((Rect2i *)&dest) = self->grow_individual(p_left, p_top, p_right, p_bottom);
+	return dest;
+}
+
+godot_rect2i GDAPI godot_rect2i_grow_margin(const godot_rect2i *p_self, const godot_int p_margin, const godot_int p_by) {
+	godot_rect2i dest;
+	const Rect2i *self = (const Rect2i *)p_self;
+	*((Rect2i *)&dest) = self->grow_margin((Margin)p_margin, p_by);
+	return dest;
+}
+
+godot_rect2i GDAPI godot_rect2i_abs(const godot_rect2i *p_self) {
+	godot_rect2i dest;
+	const Rect2i *self = (const Rect2i *)p_self;
+	*((Rect2i *)&dest) = self->abs();
+	return dest;
+}
+
+godot_rect2i GDAPI godot_rect2i_expand(const godot_rect2i *p_self, const godot_vector2i *p_to) {
+	godot_rect2i dest;
+	const Rect2i *self = (const Rect2i *)p_self;
+	const Vector2i *to = (const Vector2i *)p_to;
+	*((Rect2i *)&dest) = self->expand(*to);
+	return dest;
+}
+
+godot_bool GDAPI godot_rect2i_operator_equal(const godot_rect2i *p_self, const godot_rect2i *p_b) {
+	const Rect2i *self = (const Rect2i *)p_self;
+	const Rect2i *b = (const Rect2i *)p_b;
+	return *self == *b;
+}
+
+godot_vector2i GDAPI godot_rect2i_get_position(const godot_rect2i *p_self) {
+	godot_vector2i dest;
+	Vector2i *d = (Vector2i *)&dest;
+	const Rect2i *self = (const Rect2i *)p_self;
+	*d = self->get_position();
+	return dest;
+}
+
+godot_vector2i GDAPI godot_rect2i_get_size(const godot_rect2i *p_self) {
+	godot_vector2i dest;
+	Vector2i *d = (Vector2i *)&dest;
+	const Rect2i *self = (const Rect2i *)p_self;
+	*d = self->get_size();
+	return dest;
+}
+
+void GDAPI godot_rect2i_set_position(godot_rect2i *p_self, const godot_vector2i *p_pos) {
+	Rect2i *self = (Rect2i *)p_self;
+	const Vector2i *position = (const Vector2i *)p_pos;
+	self->set_position(*position);
+}
+
+void GDAPI godot_rect2i_set_size(godot_rect2i *p_self, const godot_vector2i *p_size) {
+	Rect2i *self = (Rect2i *)p_self;
+	const Vector2i *size = (const Vector2i *)p_size;
 	self->set_size(*size);
 }
 

--- a/modules/gdnative/gdnative/variant.cpp
+++ b/modules/gdnative/gdnative/variant.cpp
@@ -99,9 +99,21 @@ void GDAPI godot_variant_new_string(godot_variant *r_dest, const godot_string *p
 	memnew_placement_custom(dest, Variant, Variant(*s));
 }
 
+void GDAPI godot_variant_new_string_name(godot_variant *r_dest, const godot_string_name *p_s) {
+	Variant *dest = (Variant *)r_dest;
+	StringName *s = (StringName *)p_s;
+	memnew_placement_custom(dest, Variant, Variant(*s));
+}
+
 void GDAPI godot_variant_new_vector2(godot_variant *r_dest, const godot_vector2 *p_v2) {
 	Variant *dest = (Variant *)r_dest;
 	Vector2 *v2 = (Vector2 *)p_v2;
+	memnew_placement_custom(dest, Variant, Variant(*v2));
+}
+
+void GDAPI godot_variant_new_vector2i(godot_variant *r_dest, const godot_vector2i *p_v2) {
+	Variant *dest = (Variant *)r_dest;
+	Vector2i *v2 = (Vector2i *)p_v2;
 	memnew_placement_custom(dest, Variant, Variant(*v2));
 }
 
@@ -111,9 +123,21 @@ void GDAPI godot_variant_new_rect2(godot_variant *r_dest, const godot_rect2 *p_r
 	memnew_placement_custom(dest, Variant, Variant(*rect2));
 }
 
+void GDAPI godot_variant_new_rect2i(godot_variant *r_dest, const godot_rect2i *p_rect2) {
+	Variant *dest = (Variant *)r_dest;
+	Rect2i *rect2 = (Rect2i *)p_rect2;
+	memnew_placement_custom(dest, Variant, Variant(*rect2));
+}
+
 void GDAPI godot_variant_new_vector3(godot_variant *r_dest, const godot_vector3 *p_v3) {
 	Variant *dest = (Variant *)r_dest;
 	Vector3 *v3 = (Vector3 *)p_v3;
+	memnew_placement_custom(dest, Variant, Variant(*v3));
+}
+
+void GDAPI godot_variant_new_vector3i(godot_variant *r_dest, const godot_vector3i *p_v3) {
+	Variant *dest = (Variant *)r_dest;
+	Vector3i *v3 = (Vector3i *)p_v3;
 	memnew_placement_custom(dest, Variant, Variant(*v3));
 }
 
@@ -171,6 +195,18 @@ void GDAPI godot_variant_new_rid(godot_variant *r_dest, const godot_rid *p_rid) 
 	memnew_placement_custom(dest, Variant, Variant(*rid));
 }
 
+void GDAPI godot_variant_new_callable(godot_variant *r_dest, const godot_callable *p_cb) {
+	Variant *dest = (Variant *)r_dest;
+	Callable *cb = (Callable *)p_cb;
+	memnew_placement_custom(dest, Variant, Variant(*cb));
+}
+
+void GDAPI godot_variant_new_signal(godot_variant *r_dest, const godot_signal *p_signal) {
+	Variant *dest = (Variant *)r_dest;
+	Signal *signal = (Signal *)p_signal;
+	memnew_placement_custom(dest, Variant, Variant(*signal));
+}
+
 void GDAPI godot_variant_new_object(godot_variant *r_dest, const godot_object *p_obj) {
 	Variant *dest = (Variant *)r_dest;
 	Object *obj = (Object *)p_obj;
@@ -209,15 +245,27 @@ void GDAPI godot_variant_new_packed_byte_array(godot_variant *r_dest, const godo
 	memnew_placement_custom(dest, Variant, Variant(*pba));
 }
 
-void GDAPI godot_variant_new_packed_int_array(godot_variant *r_dest, const godot_packed_int_array *p_pia) {
+void GDAPI godot_variant_new_packed_int32_array(godot_variant *r_dest, const godot_packed_int32_array *p_pia) {
 	Variant *dest = (Variant *)r_dest;
 	PackedInt32Array *pia = (PackedInt32Array *)p_pia;
 	memnew_placement_custom(dest, Variant, Variant(*pia));
 }
 
-void GDAPI godot_variant_new_packed_real_array(godot_variant *r_dest, const godot_packed_real_array *p_pra) {
+void GDAPI godot_variant_new_packed_int64_array(godot_variant *r_dest, const godot_packed_int64_array *p_pia) {
+	Variant *dest = (Variant *)r_dest;
+	PackedInt64Array *pia = (PackedInt64Array *)p_pia;
+	memnew_placement_custom(dest, Variant, Variant(*pia));
+}
+
+void GDAPI godot_variant_new_packed_float32_array(godot_variant *r_dest, const godot_packed_float32_array *p_pra) {
 	Variant *dest = (Variant *)r_dest;
 	PackedFloat32Array *pra = (PackedFloat32Array *)p_pra;
+	memnew_placement_custom(dest, Variant, Variant(*pra));
+}
+
+void GDAPI godot_variant_new_packed_float64_array(godot_variant *r_dest, const godot_packed_float64_array *p_pra) {
+	Variant *dest = (Variant *)r_dest;
+	PackedFloat64Array *pra = (PackedFloat64Array *)p_pra;
 	memnew_placement_custom(dest, Variant, Variant(*pra));
 }
 
@@ -273,10 +321,26 @@ godot_string GDAPI godot_variant_as_string(const godot_variant *p_self) {
 	return raw_dest;
 }
 
+godot_string_name GDAPI godot_variant_as_string_name(const godot_variant *p_self) {
+	godot_string_name raw_dest;
+	const Variant *self = (const Variant *)p_self;
+	StringName *dest = (StringName *)&raw_dest;
+	memnew_placement(dest, StringName(self->operator StringName())); // operator = is overloaded by StringName
+	return raw_dest;
+}
+
 godot_vector2 GDAPI godot_variant_as_vector2(const godot_variant *p_self) {
 	godot_vector2 raw_dest;
 	const Variant *self = (const Variant *)p_self;
 	Vector2 *dest = (Vector2 *)&raw_dest;
+	*dest = *self;
+	return raw_dest;
+}
+
+godot_vector2i GDAPI godot_variant_as_vector2i(const godot_variant *p_self) {
+	godot_vector2i raw_dest;
+	const Variant *self = (const Variant *)p_self;
+	Vector2i *dest = (Vector2i *)&raw_dest;
 	*dest = *self;
 	return raw_dest;
 }
@@ -289,10 +353,26 @@ godot_rect2 GDAPI godot_variant_as_rect2(const godot_variant *p_self) {
 	return raw_dest;
 }
 
+godot_rect2i GDAPI godot_variant_as_rect2i(const godot_variant *p_self) {
+	godot_rect2i raw_dest;
+	const Variant *self = (const Variant *)p_self;
+	Rect2i *dest = (Rect2i *)&raw_dest;
+	*dest = *self;
+	return raw_dest;
+}
+
 godot_vector3 GDAPI godot_variant_as_vector3(const godot_variant *p_self) {
 	godot_vector3 raw_dest;
 	const Variant *self = (const Variant *)p_self;
 	Vector3 *dest = (Vector3 *)&raw_dest;
+	*dest = *self;
+	return raw_dest;
+}
+
+godot_vector3i GDAPI godot_variant_as_vector3i(const godot_variant *p_self) {
+	godot_vector3i raw_dest;
+	const Variant *self = (const Variant *)p_self;
+	Vector3i *dest = (Vector3i *)&raw_dest;
 	*dest = *self;
 	return raw_dest;
 }
@@ -369,6 +449,22 @@ godot_rid GDAPI godot_variant_as_rid(const godot_variant *p_self) {
 	return raw_dest;
 }
 
+godot_callable GDAPI godot_variant_as_callable(const godot_variant *p_self) {
+	godot_callable raw_dest;
+	const Variant *self = (const Variant *)p_self;
+	Callable *dest = (Callable *)&raw_dest;
+	*dest = *self;
+	return raw_dest;
+}
+
+godot_signal GDAPI godot_variant_as_signal(const godot_variant *p_self) {
+	godot_signal raw_dest;
+	const Variant *self = (const Variant *)p_self;
+	Signal *dest = (Signal *)&raw_dest;
+	*dest = *self;
+	return raw_dest;
+}
+
 godot_object GDAPI *godot_variant_as_object(const godot_variant *p_self) {
 	const Variant *self = (const Variant *)p_self;
 	Object *dest;
@@ -401,8 +497,8 @@ godot_packed_byte_array GDAPI godot_variant_as_packed_byte_array(const godot_var
 	return raw_dest;
 }
 
-godot_packed_int_array GDAPI godot_variant_as_packed_int_array(const godot_variant *p_self) {
-	godot_packed_int_array raw_dest;
+godot_packed_int32_array GDAPI godot_variant_as_packed_int32_array(const godot_variant *p_self) {
+	godot_packed_int32_array raw_dest;
 	const Variant *self = (const Variant *)p_self;
 	PackedInt32Array *dest = (PackedInt32Array *)&raw_dest;
 	memnew_placement(dest, PackedInt32Array(self->operator PackedInt32Array())); // operator = is overloaded by PackedInt32Array
@@ -410,11 +506,29 @@ godot_packed_int_array GDAPI godot_variant_as_packed_int_array(const godot_varia
 	return raw_dest;
 }
 
-godot_packed_real_array GDAPI godot_variant_as_packed_real_array(const godot_variant *p_self) {
-	godot_packed_real_array raw_dest;
+godot_packed_int64_array GDAPI godot_variant_as_packed_int64_array(const godot_variant *p_self) {
+	godot_packed_int64_array raw_dest;
+	const Variant *self = (const Variant *)p_self;
+	PackedInt64Array *dest = (PackedInt64Array *)&raw_dest;
+	memnew_placement(dest, PackedInt64Array(self->operator PackedInt64Array())); // operator = is overloaded by PackedInt64Array
+	*dest = *self;
+	return raw_dest;
+}
+
+godot_packed_float32_array GDAPI godot_variant_as_packed_float32_array(const godot_variant *p_self) {
+	godot_packed_float32_array raw_dest;
 	const Variant *self = (const Variant *)p_self;
 	PackedFloat32Array *dest = (PackedFloat32Array *)&raw_dest;
 	memnew_placement(dest, PackedFloat32Array(self->operator PackedFloat32Array())); // operator = is overloaded by PackedFloat32Array
+	*dest = *self;
+	return raw_dest;
+}
+
+godot_packed_float64_array GDAPI godot_variant_as_packed_float64_array(const godot_variant *p_self) {
+	godot_packed_float64_array raw_dest;
+	const Variant *self = (const Variant *)p_self;
+	PackedFloat64Array *dest = (PackedFloat64Array *)&raw_dest;
+	memnew_placement(dest, PackedFloat64Array(self->operator PackedFloat64Array())); // operator = is overloaded by PackedFloat64Array
 	*dest = *self;
 	return raw_dest;
 }
@@ -487,6 +601,11 @@ godot_bool GDAPI godot_variant_operator_less(const godot_variant *p_self, const 
 	const Variant *self = (const Variant *)p_self;
 	const Variant *other = (const Variant *)p_other;
 	return self->operator<(*other);
+}
+
+uint32_t GDAPI godot_variant_hash(const godot_variant *p_self) {
+	const Variant *self = (const Variant *)p_self;
+	return self->hash();
 }
 
 godot_bool GDAPI godot_variant_hash_compare(const godot_variant *p_self, const godot_variant *p_other) {

--- a/modules/gdnative/gdnative/vector2.cpp
+++ b/modules/gdnative/gdnative/vector2.cpp
@@ -38,6 +38,9 @@ extern "C" {
 #endif
 
 static_assert(sizeof(godot_vector2) == sizeof(Vector2), "Vector2 size mismatch");
+static_assert(sizeof(godot_vector2i) == sizeof(Vector2i), "Vector2i size mismatch");
+
+// Vector2
 
 void GDAPI godot_vector2_new(godot_vector2 *r_dest, const godot_real p_x, const godot_real p_y) {
 	Vector2 *dest = (Vector2 *)r_dest;
@@ -49,6 +52,13 @@ godot_string GDAPI godot_vector2_as_string(const godot_vector2 *p_self) {
 	const Vector2 *self = (const Vector2 *)p_self;
 	memnew_placement(&ret, String(*self));
 	return ret;
+}
+
+godot_vector2i GDAPI godot_vector2_as_vector2i(const godot_vector2 *p_self) {
+	godot_vector2i dest;
+	const Vector2 *self = (const Vector2 *)p_self;
+	*((Vector2i *)&dest) = Vector2i(*self);
+	return dest;
 }
 
 godot_vector2 GDAPI godot_vector2_normalized(const godot_vector2 *p_self) {
@@ -155,6 +165,13 @@ godot_vector2 GDAPI godot_vector2_floor(const godot_vector2 *p_self) {
 	godot_vector2 dest;
 	const Vector2 *self = (const Vector2 *)p_self;
 	*((Vector2 *)&dest) = self->floor();
+	return dest;
+}
+
+godot_vector2 GDAPI godot_vector2_sign(const godot_vector2 *p_self) {
+	godot_vector2 dest;
+	const Vector2 *self = (const Vector2 *)p_self;
+	*((Vector2 *)&dest) = self->sign();
 	return dest;
 }
 
@@ -305,6 +322,138 @@ godot_real GDAPI godot_vector2_get_x(const godot_vector2 *p_self) {
 
 godot_real GDAPI godot_vector2_get_y(const godot_vector2 *p_self) {
 	const Vector2 *self = (const Vector2 *)p_self;
+	return self->y;
+}
+
+// Vector2i
+
+void GDAPI godot_vector2i_new(godot_vector2i *r_dest, const godot_int p_x, const godot_int p_y) {
+	Vector2i *dest = (Vector2i *)r_dest;
+	*dest = Vector2i(p_x, p_y);
+}
+
+godot_string GDAPI godot_vector2i_as_string(const godot_vector2i *p_self) {
+	godot_string ret;
+	const Vector2i *self = (const Vector2i *)p_self;
+	memnew_placement(&ret, String(*self));
+	return ret;
+}
+
+godot_vector2 GDAPI godot_vector2i_as_vector2(const godot_vector2i *p_self) {
+	godot_vector2 dest;
+	const Vector2i *self = (const Vector2i *)p_self;
+	*((Vector2 *)&dest) = Vector2(*self);
+	return dest;
+}
+
+godot_real GDAPI godot_vector2i_aspect(const godot_vector2i *p_self) {
+	const Vector2i *self = (const Vector2i *)p_self;
+	return self->aspect();
+}
+
+godot_vector2i GDAPI godot_vector2i_abs(const godot_vector2i *p_self) {
+	godot_vector2i dest;
+	const Vector2i *self = (const Vector2i *)p_self;
+	*((Vector2i *)&dest) = self->abs();
+	return dest;
+}
+
+godot_vector2i GDAPI godot_vector2i_sign(const godot_vector2i *p_self) {
+	godot_vector2i dest;
+	const Vector2i *self = (const Vector2i *)p_self;
+	*((Vector2i *)&dest) = self->sign();
+	return dest;
+}
+
+godot_vector2i GDAPI godot_vector2i_operator_add(const godot_vector2i *p_self, const godot_vector2i *p_b) {
+	godot_vector2i raw_dest;
+	Vector2i *dest = (Vector2i *)&raw_dest;
+	const Vector2i *self = (const Vector2i *)p_self;
+	const Vector2i *b = (const Vector2i *)p_b;
+	*dest = *self + *b;
+	return raw_dest;
+}
+
+godot_vector2i GDAPI godot_vector2i_operator_subtract(const godot_vector2i *p_self, const godot_vector2i *p_b) {
+	godot_vector2i raw_dest;
+	Vector2i *dest = (Vector2i *)&raw_dest;
+	const Vector2i *self = (const Vector2i *)p_self;
+	const Vector2i *b = (const Vector2i *)p_b;
+	*dest = *self - *b;
+	return raw_dest;
+}
+
+godot_vector2i GDAPI godot_vector2i_operator_multiply_vector(const godot_vector2i *p_self, const godot_vector2i *p_b) {
+	godot_vector2i raw_dest;
+	Vector2i *dest = (Vector2i *)&raw_dest;
+	const Vector2i *self = (const Vector2i *)p_self;
+	const Vector2i *b = (const Vector2i *)p_b;
+	*dest = *self * *b;
+	return raw_dest;
+}
+
+godot_vector2i GDAPI godot_vector2i_operator_multiply_scalar(const godot_vector2i *p_self, const godot_int p_b) {
+	godot_vector2i raw_dest;
+	Vector2i *dest = (Vector2i *)&raw_dest;
+	const Vector2i *self = (const Vector2i *)p_self;
+	*dest = *self * p_b;
+	return raw_dest;
+}
+
+godot_vector2i GDAPI godot_vector2i_operator_divide_vector(const godot_vector2i *p_self, const godot_vector2i *p_b) {
+	godot_vector2i raw_dest;
+	Vector2i *dest = (Vector2i *)&raw_dest;
+	const Vector2i *self = (const Vector2i *)p_self;
+	const Vector2i *b = (const Vector2i *)p_b;
+	*dest = *self / *b;
+	return raw_dest;
+}
+
+godot_vector2i GDAPI godot_vector2i_operator_divide_scalar(const godot_vector2i *p_self, const godot_int p_b) {
+	godot_vector2i raw_dest;
+	Vector2i *dest = (Vector2i *)&raw_dest;
+	const Vector2i *self = (const Vector2i *)p_self;
+	*dest = *self / p_b;
+	return raw_dest;
+}
+
+godot_bool GDAPI godot_vector2i_operator_equal(const godot_vector2i *p_self, const godot_vector2i *p_b) {
+	const Vector2i *self = (const Vector2i *)p_self;
+	const Vector2i *b = (const Vector2i *)p_b;
+	return *self == *b;
+}
+
+godot_bool GDAPI godot_vector2i_operator_less(const godot_vector2i *p_self, const godot_vector2i *p_b) {
+	const Vector2i *self = (const Vector2i *)p_self;
+	const Vector2i *b = (const Vector2i *)p_b;
+	return *self < *b;
+}
+
+godot_vector2i GDAPI godot_vector2i_operator_neg(const godot_vector2i *p_self) {
+	godot_vector2i raw_dest;
+	Vector2i *dest = (Vector2i *)&raw_dest;
+	const Vector2i *self = (const Vector2i *)p_self;
+	*dest = -(*self);
+	return raw_dest;
+}
+
+void GDAPI godot_vector2i_set_x(godot_vector2i *p_self, const godot_int p_x) {
+	Vector2i *self = (Vector2i *)p_self;
+	self->x = p_x;
+}
+
+void GDAPI godot_vector2i_set_y(godot_vector2i *p_self, const godot_int p_y) {
+	Vector2i *self = (Vector2i *)p_self;
+	self->y = p_y;
+}
+
+godot_int GDAPI godot_vector2i_get_x(const godot_vector2i *p_self) {
+	const Vector2i *self = (const Vector2i *)p_self;
+	return self->x;
+}
+
+godot_int GDAPI godot_vector2i_get_y(const godot_vector2i *p_self) {
+	const Vector2i *self = (const Vector2i *)p_self;
 	return self->y;
 }
 

--- a/modules/gdnative/gdnative/vector3.cpp
+++ b/modules/gdnative/gdnative/vector3.cpp
@@ -38,6 +38,9 @@ extern "C" {
 #endif
 
 static_assert(sizeof(godot_vector3) == sizeof(Vector3), "Vector3 size mismatch");
+static_assert(sizeof(godot_vector3i) == sizeof(Vector3i), "Vector3i size mismatch");
+
+// Vector3
 
 void GDAPI godot_vector3_new(godot_vector3 *r_dest, const godot_real p_x, const godot_real p_y, const godot_real p_z) {
 	Vector3 *dest = (Vector3 *)r_dest;
@@ -49,6 +52,13 @@ godot_string GDAPI godot_vector3_as_string(const godot_vector3 *p_self) {
 	const Vector3 *self = (const Vector3 *)p_self;
 	memnew_placement(&ret, String(*self));
 	return ret;
+}
+
+godot_vector3i GDAPI godot_vector3_as_vector3i(const godot_vector3 *p_self) {
+	godot_vector3i dest;
+	const Vector3 *self = (const Vector3 *)p_self;
+	*((Vector3i *)&dest) = Vector3i(*self);
+	return dest;
 }
 
 godot_int GDAPI godot_vector3_min_axis(const godot_vector3 *p_self) {
@@ -166,6 +176,13 @@ godot_vector3 GDAPI godot_vector3_abs(const godot_vector3 *p_self) {
 	godot_vector3 dest;
 	const Vector3 *self = (const Vector3 *)p_self;
 	*((Vector3 *)&dest) = self->abs();
+	return dest;
+}
+
+godot_vector3 GDAPI godot_vector3_sign(const godot_vector3 *p_self) {
+	godot_vector3 dest;
+	const Vector3 *self = (const Vector3 *)p_self;
+	*((Vector3 *)&dest) = self->sign();
 	return dest;
 }
 
@@ -312,6 +329,133 @@ void GDAPI godot_vector3_set_axis(godot_vector3 *p_self, const godot_vector3_axi
 
 godot_real GDAPI godot_vector3_get_axis(const godot_vector3 *p_self, const godot_vector3_axis p_axis) {
 	const Vector3 *self = (const Vector3 *)p_self;
+	return self->get_axis(p_axis);
+}
+
+// Vector3i
+
+void GDAPI godot_vector3i_new(godot_vector3i *r_dest, const godot_int p_x, const godot_int p_y, const godot_int p_z) {
+	Vector3i *dest = (Vector3i *)r_dest;
+	*dest = Vector3i(p_x, p_y, p_z);
+}
+
+godot_string GDAPI godot_vector3i_as_string(const godot_vector3i *p_self) {
+	godot_string ret;
+	const Vector3i *self = (const Vector3i *)p_self;
+	memnew_placement(&ret, String(*self));
+	return ret;
+}
+
+godot_vector3 GDAPI godot_vector3i_as_vector3(const godot_vector3i *p_self) {
+	godot_vector3 dest;
+	const Vector3i *self = (const Vector3i *)p_self;
+	*((Vector3 *)&dest) = Vector3(*self);
+	return dest;
+}
+
+godot_int GDAPI godot_vector3i_min_axis(const godot_vector3i *p_self) {
+	const Vector3i *self = (const Vector3i *)p_self;
+	return self->min_axis();
+}
+
+godot_int GDAPI godot_vector3i_max_axis(const godot_vector3i *p_self) {
+	const Vector3i *self = (const Vector3i *)p_self;
+	return self->max_axis();
+}
+
+godot_vector3i GDAPI godot_vector3i_abs(const godot_vector3i *p_self) {
+	godot_vector3i dest;
+	const Vector3i *self = (const Vector3i *)p_self;
+	*((Vector3i *)&dest) = self->abs();
+	return dest;
+}
+
+godot_vector3i GDAPI godot_vector3i_sign(const godot_vector3i *p_self) {
+	godot_vector3i dest;
+	const Vector3i *self = (const Vector3i *)p_self;
+	*((Vector3i *)&dest) = self->sign();
+	return dest;
+}
+
+godot_vector3i GDAPI godot_vector3i_operator_add(const godot_vector3i *p_self, const godot_vector3i *p_b) {
+	godot_vector3i raw_dest;
+	Vector3i *dest = (Vector3i *)&raw_dest;
+	Vector3i *self = (Vector3i *)p_self;
+	const Vector3i *b = (const Vector3i *)p_b;
+	*dest = *self + *b;
+	return raw_dest;
+}
+
+godot_vector3i GDAPI godot_vector3i_operator_subtract(const godot_vector3i *p_self, const godot_vector3i *p_b) {
+	godot_vector3i raw_dest;
+	Vector3i *dest = (Vector3i *)&raw_dest;
+	Vector3i *self = (Vector3i *)p_self;
+	const Vector3i *b = (const Vector3i *)p_b;
+	*dest = *self - *b;
+	return raw_dest;
+}
+
+godot_vector3i GDAPI godot_vector3i_operator_multiply_vector(const godot_vector3i *p_self, const godot_vector3i *p_b) {
+	godot_vector3i raw_dest;
+	Vector3i *dest = (Vector3i *)&raw_dest;
+	Vector3i *self = (Vector3i *)p_self;
+	const Vector3i *b = (const Vector3i *)p_b;
+	*dest = *self * *b;
+	return raw_dest;
+}
+
+godot_vector3i GDAPI godot_vector3i_operator_multiply_scalar(const godot_vector3i *p_self, const godot_int p_b) {
+	godot_vector3i raw_dest;
+	Vector3i *dest = (Vector3i *)&raw_dest;
+	Vector3i *self = (Vector3i *)p_self;
+	*dest = *self * p_b;
+	return raw_dest;
+}
+
+godot_vector3i GDAPI godot_vector3i_operator_divide_vector(const godot_vector3i *p_self, const godot_vector3i *p_b) {
+	godot_vector3i raw_dest;
+	Vector3i *dest = (Vector3i *)&raw_dest;
+	Vector3i *self = (Vector3i *)p_self;
+	const Vector3i *b = (const Vector3i *)p_b;
+	*dest = *self / *b;
+	return raw_dest;
+}
+
+godot_vector3i GDAPI godot_vector3i_operator_divide_scalar(const godot_vector3i *p_self, const godot_int p_b) {
+	godot_vector3i raw_dest;
+	Vector3i *dest = (Vector3i *)&raw_dest;
+	Vector3i *self = (Vector3i *)p_self;
+	*dest = *self / p_b;
+	return raw_dest;
+}
+
+godot_bool GDAPI godot_vector3i_operator_equal(const godot_vector3i *p_self, const godot_vector3i *p_b) {
+	Vector3i *self = (Vector3i *)p_self;
+	const Vector3i *b = (const Vector3i *)p_b;
+	return *self == *b;
+}
+
+godot_bool GDAPI godot_vector3i_operator_less(const godot_vector3i *p_self, const godot_vector3i *p_b) {
+	Vector3i *self = (Vector3i *)p_self;
+	const Vector3i *b = (const Vector3i *)p_b;
+	return *self < *b;
+}
+
+godot_vector3i GDAPI godot_vector3i_operator_neg(const godot_vector3i *p_self) {
+	godot_vector3i raw_dest;
+	Vector3i *dest = (Vector3i *)&raw_dest;
+	const Vector3i *self = (const Vector3i *)p_self;
+	*dest = -(*self);
+	return raw_dest;
+}
+
+void GDAPI godot_vector3i_set_axis(godot_vector3i *p_self, const godot_vector3_axis p_axis, const godot_int p_val) {
+	Vector3i *self = (Vector3i *)p_self;
+	self->set_axis(p_axis, p_val);
+}
+
+godot_int GDAPI godot_vector3i_get_axis(const godot_vector3i *p_self, const godot_vector3_axis p_axis) {
+	const Vector3i *self = (const Vector3i *)p_self;
 	return self->get_axis(p_axis);
 }
 

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -17,7 +17,1125 @@
           "major": 1,
           "minor": 2
         },
-        "next": null,
+        "next": {
+          "type": "CORE",
+          "version": {
+            "major": 1,
+            "minor": 3
+          },
+          "next": null,
+          "api": [
+            {
+              "name": "godot_object_get_instance_id",
+              "return_type": "uint64_t",
+              "arguments": [
+                ["const godot_object *", "p_object"]
+              ]
+            },
+            {
+              "name": "godot_array_new_packed_float64_array",
+              "return_type": "void",
+              "arguments": [
+                ["godot_array *", "r_dest"],
+                ["const godot_packed_float64_array *", "p_pra"]
+              ]
+            },
+            {
+              "name": "godot_array_new_packed_int64_array",
+              "return_type": "void",
+              "arguments": [
+                ["godot_array *", "r_dest"],
+                ["const godot_packed_int64_array *", "p_pia"]
+              ]
+            },
+            {
+              "name": "godot_callable_new_with_object",
+              "return_type": "void",
+              "arguments": [
+                ["godot_callable *", "r_dest"],
+                ["const godot_object *", "p_object"],
+                ["const godot_string_name *", "p_method"]
+              ]
+            },
+            {
+              "name": "godot_callable_new_with_object_id",
+              "return_type": "void",
+              "arguments": [
+                ["godot_callable *", "r_dest"],
+                ["uint64_t", "p_objectid"],
+                ["const godot_string_name *", "p_method"]
+              ]
+            },
+            {
+              "name": "godot_callable_new_copy",
+              "return_type": "void",
+              "arguments": [
+                ["godot_callable *", "r_dest"],
+                ["const godot_callable *", "p_src"]
+              ]
+            },
+            {
+              "name": "godot_callable_destroy",
+              "return_type": "void",
+              "arguments": [
+                ["godot_callable *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_callable_call",
+              "return_type": "godot_int",
+              "arguments": [
+                ["const godot_callable *", "p_self"],
+                ["const godot_variant **", "p_arguments"],
+                ["godot_int", "p_argcount"],
+                ["godot_variant *", "r_return_value"]
+              ]
+            },
+            {
+              "name": "godot_callable_call_deferred",
+              "return_type": "void",
+              "arguments": [
+                ["const godot_callable *", "p_self"],
+                ["const godot_variant **", "p_arguments"],
+                ["godot_int", "p_argcount"]
+              ]
+            },  
+            {
+              "name": "godot_callable_is_null",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_callable *", "p_self"]
+              ]
+            },  
+            {
+              "name": "godot_callable_is_custom",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_callable *", "p_self"]
+              ]
+            },  
+            {
+              "name": "godot_callable_is_standard",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_callable *", "p_self"]
+              ]
+            },    
+            {
+              "name": "godot_callable_get_object",
+              "return_type": "godot_object *",
+              "arguments": [
+                ["const godot_callable *", "p_self"]
+              ]
+            },    
+            {
+              "name": "godot_callable_get_object_id",
+              "return_type": "uint64_t",
+              "arguments": [
+                ["const godot_callable *", "p_self"]
+              ]
+            },    
+            {
+              "name": "godot_callable_get_method",
+              "return_type": "godot_string_name",
+              "arguments": [
+                ["const godot_callable *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_callable_hash",
+              "return_type": "uint32_t",
+              "arguments": [
+                ["const godot_callable *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_callable_as_string",
+              "return_type": "godot_string",
+              "arguments": [
+                ["const godot_callable *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_callable_operator_equal",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_callable *", "p_self"],
+                ["const godot_callable *", "p_other"]
+              ]
+            },
+            {
+              "name": "godot_callable_operator_less",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_callable *", "p_self"],
+                ["const godot_callable *", "p_other"]
+              ]
+            },
+            {
+              "name": "godot_signal_new_with_object",
+              "return_type": "void",
+              "arguments": [
+                ["godot_signal *", "r_dest"],
+                ["const godot_object *", "p_object"],
+                ["const godot_string_name *", "p_method"]
+              ]
+            },
+            {
+              "name": "godot_signal_new_with_object_id",
+              "return_type": "void",
+              "arguments": [
+                ["godot_signal *", "r_dest"],
+                ["uint64_t", "p_objectid"],
+                ["const godot_string_name *", "p_method"]
+              ]
+            },
+            {
+              "name": "godot_signal_new_copy",
+              "return_type": "void",
+              "arguments": [
+                ["godot_signal *", "r_dest"],
+                ["const godot_signal *", "p_src"]
+              ]
+            },
+            {
+              "name": "godot_signal_destroy",
+              "return_type": "void",
+              "arguments": [
+                ["godot_signal *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_signal_emit",
+              "return_type": "godot_int",
+              "arguments": [
+                ["const godot_signal *", "p_self"],
+                ["const godot_variant **", "p_arguments"],
+                ["godot_int", "p_argcount"]
+              ]
+            },
+            {
+              "name": "godot_signal_connect",
+              "return_type": "godot_int",
+              "arguments": [
+                ["godot_signal *", "p_self"],
+                ["const godot_callable *", "p_callable"],
+                ["const godot_array *", "p_binds"],
+                ["uint32_t", "p_flags"]
+              ]
+            },
+            {
+              "name": "godot_signal_disconnect",
+              "return_type": "void",
+              "arguments": [
+                ["godot_signal *", "p_self"],
+                ["const godot_callable *", "p_callable"]
+              ]
+            },
+            {
+              "name": "godot_signal_is_null",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_signal *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_signal_is_connected",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_signal *", "p_self"],
+                ["const godot_callable *", "p_callable"]
+              ]
+            },
+            {
+              "name": "godot_signal_get_connections",
+              "return_type": "godot_array",
+              "arguments": [
+                ["const godot_signal *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_signal_get_object",
+              "return_type": "godot_object *",
+              "arguments": [
+                ["const godot_signal *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_signal_get_object_id",
+              "return_type": "uint64_t",
+              "arguments": [
+                ["const godot_signal *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_signal_get_name",
+              "return_type": "godot_string_name",
+              "arguments": [
+                ["const godot_signal *", "p_self"]
+              ]
+            },  
+            {
+              "name": "godot_signal_as_string",
+              "return_type": "godot_string",
+              "arguments": [
+                ["const godot_signal *", "p_self"]
+              ]
+            },  
+            {
+              "name": "godot_signal_operator_equal",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_signal *", "p_self"],
+                ["const godot_signal *", "p_other"]
+              ]
+            },  
+            {
+              "name": "godot_signal_operator_less",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_signal *", "p_self"],
+                ["const godot_signal *", "p_other"]
+              ]
+            },  
+            {
+              "name": "godot_packed_int64_array_new",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_int64_array *", "r_dest"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_new_copy",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_int64_array *", "r_dest"],
+                ["const godot_packed_int64_array *", "p_src"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_new_with_array",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_int64_array *", "r_dest"],
+                ["const godot_array *", "p_a"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_append",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_int64_array *", "p_self"],
+                ["const int64_t", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_append_array",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_int64_array *", "p_self"],
+                ["const godot_packed_int64_array *", "p_array"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_insert",
+              "return_type": "godot_error",
+              "arguments": [
+                ["godot_packed_int64_array *", "p_self"],
+                ["const godot_int", "p_idx"],
+                ["const int64_t", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_invert",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_int64_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_push_back",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_int64_array *", "p_self"],
+                ["const int64_t", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_remove",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_int64_array *", "p_self"],
+                ["const godot_int", "p_idx"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_resize",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_int64_array *", "p_self"],
+                ["const godot_int", "p_size"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_set",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_int64_array *", "p_self"],
+                ["const godot_int", "p_idx"],
+                ["const int64_t", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_get",
+              "return_type": "int64_t",
+              "arguments": [
+                ["const godot_packed_int64_array *", "p_self"],
+                ["const godot_int", "p_idx"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_size",
+              "return_type": "godot_int",
+              "arguments": [
+                ["const godot_packed_int64_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_destroy",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_int64_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_new",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_float64_array *", "r_dest"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_new_copy",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_float64_array *", "r_dest"],
+                ["const godot_packed_float64_array *", "p_src"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_new_with_array",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_float64_array *", "r_dest"],
+                ["const godot_array *", "p_a"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_append",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_float64_array *", "p_self"],
+                ["const double", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_append_array",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_float64_array *", "p_self"],
+                ["const godot_packed_float64_array *", "p_array"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_insert",
+              "return_type": "godot_error",
+              "arguments": [
+                ["godot_packed_float64_array *", "p_self"],
+                ["const godot_int", "p_idx"],
+                ["const double", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_invert",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_float64_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_push_back",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_float64_array *", "p_self"],
+                ["const double", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_remove",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_float64_array *", "p_self"],
+                ["const godot_int", "p_idx"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_resize",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_float64_array *", "p_self"],
+                ["const godot_int", "p_size"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_set",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_float64_array *", "p_self"],
+                ["const godot_int", "p_idx"],
+                ["const double", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_get",
+              "return_type": "double",
+              "arguments": [
+                ["const godot_packed_float64_array *", "p_self"],
+                ["const godot_int", "p_idx"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_size",
+              "return_type": "godot_int",
+              "arguments": [
+                ["const godot_packed_float64_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_destroy",
+              "return_type": "void",
+              "arguments": [
+                ["godot_packed_float64_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_rect2_as_rect2i",
+              "return_type": "godot_rect2i",
+              "arguments": [
+                ["const godot_rect2 *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_new_with_position_and_size",
+              "return_type": "void",
+              "arguments": [
+                ["godot_rect2i *", "r_dest"],
+                ["const godot_vector2i *", "p_pos"],
+                ["const godot_vector2i *", "p_size"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_new",
+              "return_type": "void",
+              "arguments": [
+                ["godot_rect2i *", "r_dest"],
+                ["const godot_int", "p_x"],
+                ["const godot_int", "p_y"],
+                ["const godot_int", "p_width"],
+                ["const godot_int", "p_height"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_as_string",
+              "return_type": "godot_string",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_as_rect2",
+              "return_type": "godot_rect2",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_get_area",
+              "return_type": "godot_int",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_intersects",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"],
+                ["const godot_rect2i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_encloses",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"],
+                ["const godot_rect2i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_has_no_area",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_clip",
+              "return_type": "godot_rect2i",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"],
+                ["const godot_rect2i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_merge",
+              "return_type": "godot_rect2i",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"],
+                ["const godot_rect2i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_has_point",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"],
+                ["const godot_vector2i *", "p_point"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_grow",
+              "return_type": "godot_rect2i",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"],
+                ["const godot_int", "p_by"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_grow_individual",
+              "return_type": "godot_rect2i",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"],
+                ["const godot_int", "p_left"],
+                ["const godot_int", "p_top"],
+                ["const godot_int", "p_right"],
+                ["const godot_int", "p_bottom"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_grow_margin",
+              "return_type": "godot_rect2i",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"],
+                ["const godot_int", "p_margin"],
+                ["const godot_int", "p_by"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_abs",
+              "return_type": "godot_rect2i",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_expand",
+              "return_type": "godot_rect2i",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"],
+                ["const godot_vector2i *", "p_to"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_operator_equal",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"],
+                ["const godot_rect2i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_get_position",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_get_size",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_rect2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_set_position",
+              "return_type": "void",
+              "arguments": [
+                ["godot_rect2i *", "p_self"],
+                ["const godot_vector2i *", "p_pos"]
+              ]
+            },
+            {
+              "name": "godot_rect2i_set_size",
+              "return_type": "void",
+              "arguments": [
+                ["godot_rect2i *", "p_self"],
+                ["const godot_vector2i *", "p_size"]
+              ]
+            },
+            {
+              "name": "godot_variant_new_string_name",
+              "return_type": "void",
+              "arguments": [
+                ["godot_variant *", "r_dest"],
+                ["const godot_string_name *", "p_s"]
+              ]
+            },
+            {
+              "name": "godot_variant_new_vector2i",
+              "return_type": "void",
+              "arguments": [
+                ["godot_variant *", "r_dest"],
+                ["const godot_vector2i *", "p_v2"]
+              ]
+            },
+            {
+              "name": "godot_variant_new_rect2i",
+              "return_type": "void",
+              "arguments": [
+                ["godot_variant *", "r_dest"],
+                ["const godot_rect2i *", "p_rect2"]
+              ]
+            },
+            {
+              "name": "godot_variant_new_vector3i",
+              "return_type": "void",
+              "arguments": [
+                ["godot_variant *", "r_dest"],
+                ["const godot_vector3i *", "p_v3"]
+              ]
+            },
+            {
+              "name": "godot_variant_new_callable",
+              "return_type": "void",
+              "arguments": [
+                ["godot_variant *", "r_dest"],
+                ["const godot_callable *", "p_cb"]
+              ]
+            },
+            {
+              "name": "godot_variant_new_signal",
+              "return_type": "void",
+              "arguments": [
+                ["godot_variant *", "r_dest"],
+                ["const godot_signal *", "p_signal"]
+              ]
+            },
+            {
+              "name": "godot_variant_new_packed_int64_array",
+              "return_type": "void",
+              "arguments": [
+                ["godot_variant *", "r_dest"],
+                ["const godot_packed_int64_array *", "p_pia"]
+              ]
+            },
+            {
+              "name": "godot_variant_new_packed_float64_array",
+              "return_type": "void",
+              "arguments": [
+                ["godot_variant *", "r_dest"],
+                ["const godot_packed_float64_array *", "p_pra"]
+              ]
+            },
+            {
+              "name": "godot_variant_as_string_name",
+              "return_type": "godot_string_name",
+              "arguments": [
+                ["const godot_variant *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_variant_as_vector2i",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_variant *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_variant_as_rect2i",
+              "return_type": "godot_rect2i",
+              "arguments": [
+                ["const godot_variant *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_variant_as_vector3i",
+              "return_type": "godot_vector3i",
+              "arguments": [
+                ["const godot_variant *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_variant_as_callable",
+              "return_type": "godot_callable",
+              "arguments": [
+                ["const godot_variant *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_variant_as_signal",
+              "return_type": "godot_signal",
+              "arguments": [
+                ["const godot_variant *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_variant_as_packed_int64_array",
+              "return_type": "godot_packed_int64_array",
+              "arguments": [
+                ["const godot_variant *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_variant_as_packed_float64_array",
+              "return_type": "godot_packed_float64_array",
+              "arguments": [
+                ["const godot_variant *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_variant_hash",
+              "return_type": "uint32_t",
+              "arguments": [
+                ["const godot_variant *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector2_as_vector2i",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_vector2 *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector2_sign",
+              "return_type": "godot_vector2",
+              "arguments": [
+                ["const godot_vector2 *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_new",
+              "return_type": "void",
+              "arguments": [
+                ["godot_vector2i *", "r_dest"],
+                ["const godot_int", "p_x"],
+                ["const godot_int", "p_y"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_as_string",
+              "return_type": "godot_string",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_as_vector2",
+              "return_type": "godot_vector2",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_aspect",
+              "return_type": "godot_real",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_abs",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_sign",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_operator_add",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"],
+                ["const godot_vector2i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_operator_subtract",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"],
+                ["const godot_vector2i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_operator_multiply_vector",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"],
+                ["const godot_vector2i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_operator_multiply_scalar",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"],
+                ["const godot_int", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_operator_divide_vector",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"],
+                ["const godot_vector2i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_operator_divide_scalar",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"],
+                ["const godot_int", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_operator_equal",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"],
+                ["const godot_vector2i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_operator_less",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"],
+                ["const godot_vector2i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_operator_neg",
+              "return_type": "godot_vector2i",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_set_x",
+              "return_type": "void",
+              "arguments": [
+                ["godot_vector2i *", "p_self"],
+                ["const godot_int", "p_x"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_set_y",
+              "return_type": "void",
+              "arguments": [
+                ["godot_vector2i *", "p_self"],
+                ["const godot_int", "p_y"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_get_x",
+              "return_type": "godot_int",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector2i_get_y",
+              "return_type": "godot_int",
+              "arguments": [
+                ["const godot_vector2i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector3_as_vector3i",
+              "return_type": "godot_vector3i",
+              "arguments": [
+                ["const godot_vector3 *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector3_sign",
+              "return_type": "godot_vector3",
+              "arguments": [
+                ["const godot_vector3 *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_new",
+              "return_type": "void",
+              "arguments": [
+                ["godot_vector3i *", "r_dest"],
+                ["const godot_int", "p_x"],
+                ["const godot_int", "p_y"],
+                ["const godot_int", "p_z"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_as_string",
+              "return_type": "godot_string",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_as_vector3",
+              "return_type": "godot_vector3",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_min_axis",
+              "return_type": "godot_int",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_max_axis",
+              "return_type": "godot_int",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_abs",
+              "return_type": "godot_vector3i",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_sign",
+              "return_type": "godot_vector3i",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_operator_add",
+              "return_type": "godot_vector3i",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"],
+                ["const godot_vector3i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_operator_subtract",
+              "return_type": "godot_vector3i",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"],
+                ["const godot_vector3i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_operator_multiply_vector",
+              "return_type": "godot_vector3i",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"],
+                ["const godot_vector3i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_operator_multiply_scalar",
+              "return_type": "godot_vector3i",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"],
+                ["const godot_int", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_operator_divide_vector",
+              "return_type": "godot_vector3i",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"],
+                ["const godot_vector3i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_operator_divide_scalar",
+              "return_type": "godot_vector3i",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"],
+                ["const godot_int", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_operator_equal",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"],
+                ["const godot_vector3i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_operator_less",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"],
+                ["const godot_vector3i *", "p_b"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_operator_neg",
+              "return_type": "godot_vector3i",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_set_axis",
+              "return_type": "void",
+              "arguments": [
+                ["godot_vector3i *", "p_self"],
+                ["const godot_vector3_axis", "p_axis"],
+                ["const godot_int", "p_val"]
+              ]
+            },
+            {
+              "name": "godot_vector3i_get_axis",
+              "return_type": "godot_int",
+              "arguments": [
+                ["const godot_vector3i *", "p_self"],
+                ["const godot_vector3_axis", "p_axis"]
+              ]
+            }          
+          ]
+        },
         "api": [
           {
             "name": "godot_dictionary_duplicate",
@@ -100,17 +1218,17 @@
             ]
           },
           {
-            "name": "godot_packed_int_array_empty",
+            "name": "godot_packed_int32_array_empty",
             "return_type": "godot_bool",
             "arguments": [
-              ["const godot_packed_int_array *", "p_self"]
+              ["const godot_packed_int32_array *", "p_self"]
             ]
           },
           {
-            "name": "godot_packed_real_array_empty",
+            "name": "godot_packed_float32_array_empty",
             "return_type": "godot_bool",
             "arguments": [
-              ["const godot_packed_real_array *", "p_self"]
+              ["const godot_packed_float32_array *", "p_self"]
             ]
           },
           {
@@ -160,7 +1278,7 @@
             "name": "godot_instance_from_id",
             "return_type": "godot_object *",
             "arguments": [
-              ["godot_int", "p_instance_id"]
+              ["uint64_t", "p_instance_id"]
             ]
           }
         ]
@@ -1767,223 +2885,223 @@
         ]
       },
       {
-        "name": "godot_packed_int_array_new",
+        "name": "godot_packed_int32_array_new",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_int_array *", "r_dest"]
+          ["godot_packed_int32_array *", "r_dest"]
         ]
       },
       {
-        "name": "godot_packed_int_array_new_copy",
+        "name": "godot_packed_int32_array_new_copy",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_int_array *", "r_dest"],
-          ["const godot_packed_int_array *", "p_src"]
+          ["godot_packed_int32_array *", "r_dest"],
+          ["const godot_packed_int32_array *", "p_src"]
         ]
       },
       {
-        "name": "godot_packed_int_array_new_with_array",
+        "name": "godot_packed_int32_array_new_with_array",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_int_array *", "r_dest"],
+          ["godot_packed_int32_array *", "r_dest"],
           ["const godot_array *", "p_a"]
         ]
       },
       {
-        "name": "godot_packed_int_array_append",
+        "name": "godot_packed_int32_array_append",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_int_array *", "p_self"],
-          ["const godot_int", "p_data"]
+          ["godot_packed_int32_array *", "p_self"],
+          ["const int32_t", "p_data"]
         ]
       },
       {
-        "name": "godot_packed_int_array_append_array",
+        "name": "godot_packed_int32_array_append_array",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_int_array *", "p_self"],
-          ["const godot_packed_int_array *", "p_array"]
+          ["godot_packed_int32_array *", "p_self"],
+          ["const godot_packed_int32_array *", "p_array"]
         ]
       },
       {
-        "name": "godot_packed_int_array_insert",
+        "name": "godot_packed_int32_array_insert",
         "return_type": "godot_error",
         "arguments": [
-          ["godot_packed_int_array *", "p_self"],
+          ["godot_packed_int32_array *", "p_self"],
           ["const godot_int", "p_idx"],
-          ["const godot_int", "p_data"]
+          ["const int32_t", "p_data"]
         ]
       },
       {
-        "name": "godot_packed_int_array_invert",
+        "name": "godot_packed_int32_array_invert",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_int_array *", "p_self"]
+          ["godot_packed_int32_array *", "p_self"]
         ]
       },
       {
-        "name": "godot_packed_int_array_push_back",
+        "name": "godot_packed_int32_array_push_back",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_int_array *", "p_self"],
-          ["const godot_int", "p_data"]
+          ["godot_packed_int32_array *", "p_self"],
+          ["const int32_t", "p_data"]
         ]
       },
       {
-        "name": "godot_packed_int_array_remove",
+        "name": "godot_packed_int32_array_remove",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_int_array *", "p_self"],
+          ["godot_packed_int32_array *", "p_self"],
           ["const godot_int", "p_idx"]
         ]
       },
       {
-        "name": "godot_packed_int_array_resize",
+        "name": "godot_packed_int32_array_resize",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_int_array *", "p_self"],
+          ["godot_packed_int32_array *", "p_self"],
           ["const godot_int", "p_size"]
         ]
       },
       {
-        "name": "godot_packed_int_array_set",
+        "name": "godot_packed_int32_array_set",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_int_array *", "p_self"],
+          ["godot_packed_int32_array *", "p_self"],
           ["const godot_int", "p_idx"],
-          ["const godot_int", "p_data"]
+          ["const int32_t", "p_data"]
         ]
       },
       {
-        "name": "godot_packed_int_array_get",
-        "return_type": "godot_int",
+        "name": "godot_packed_int32_array_get",
+        "return_type": "int32_t",
         "arguments": [
-          ["const godot_packed_int_array *", "p_self"],
+          ["const godot_packed_int32_array *", "p_self"],
           ["const godot_int", "p_idx"]
         ]
       },
       {
-        "name": "godot_packed_int_array_size",
+        "name": "godot_packed_int32_array_size",
         "return_type": "godot_int",
         "arguments": [
-          ["const godot_packed_int_array *", "p_self"]
+          ["const godot_packed_int32_array *", "p_self"]
         ]
       },
       {
-        "name": "godot_packed_int_array_destroy",
+        "name": "godot_packed_int32_array_destroy",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_int_array *", "p_self"]
+          ["godot_packed_int32_array *", "p_self"]
         ]
       },
       {
-        "name": "godot_packed_real_array_new",
+        "name": "godot_packed_float32_array_new",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_real_array *", "r_dest"]
+          ["godot_packed_float32_array *", "r_dest"]
         ]
       },
       {
-        "name": "godot_packed_real_array_new_copy",
+        "name": "godot_packed_float32_array_new_copy",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_real_array *", "r_dest"],
-          ["const godot_packed_real_array *", "p_src"]
+          ["godot_packed_float32_array *", "r_dest"],
+          ["const godot_packed_float32_array *", "p_src"]
         ]
       },
       {
-        "name": "godot_packed_real_array_new_with_array",
+        "name": "godot_packed_float32_array_new_with_array",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_real_array *", "r_dest"],
+          ["godot_packed_float32_array *", "r_dest"],
           ["const godot_array *", "p_a"]
         ]
       },
       {
-        "name": "godot_packed_real_array_append",
+        "name": "godot_packed_float32_array_append",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_real_array *", "p_self"],
-          ["const godot_real", "p_data"]
+          ["godot_packed_float32_array *", "p_self"],
+          ["const float", "p_data"]
         ]
       },
       {
-        "name": "godot_packed_real_array_append_array",
+        "name": "godot_packed_float32_array_append_array",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_real_array *", "p_self"],
-          ["const godot_packed_real_array *", "p_array"]
+          ["godot_packed_float32_array *", "p_self"],
+          ["const godot_packed_float32_array *", "p_array"]
         ]
       },
       {
-        "name": "godot_packed_real_array_insert",
+        "name": "godot_packed_float32_array_insert",
         "return_type": "godot_error",
         "arguments": [
-          ["godot_packed_real_array *", "p_self"],
+          ["godot_packed_float32_array *", "p_self"],
           ["const godot_int", "p_idx"],
-          ["const godot_real", "p_data"]
+          ["const float", "p_data"]
         ]
       },
       {
-        "name": "godot_packed_real_array_invert",
+        "name": "godot_packed_float32_array_invert",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_real_array *", "p_self"]
+          ["godot_packed_float32_array *", "p_self"]
         ]
       },
       {
-        "name": "godot_packed_real_array_push_back",
+        "name": "godot_packed_float32_array_push_back",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_real_array *", "p_self"],
-          ["const godot_real", "p_data"]
+          ["godot_packed_float32_array *", "p_self"],
+          ["const float", "p_data"]
         ]
       },
       {
-        "name": "godot_packed_real_array_remove",
+        "name": "godot_packed_float32_array_remove",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_real_array *", "p_self"],
+          ["godot_packed_float32_array *", "p_self"],
           ["const godot_int", "p_idx"]
         ]
       },
       {
-        "name": "godot_packed_real_array_resize",
+        "name": "godot_packed_float32_array_resize",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_real_array *", "p_self"],
+          ["godot_packed_float32_array *", "p_self"],
           ["const godot_int", "p_size"]
         ]
       },
       {
-        "name": "godot_packed_real_array_set",
+        "name": "godot_packed_float32_array_set",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_real_array *", "p_self"],
+          ["godot_packed_float32_array *", "p_self"],
           ["const godot_int", "p_idx"],
-          ["const godot_real", "p_data"]
+          ["const float", "p_data"]
         ]
       },
       {
-        "name": "godot_packed_real_array_get",
-        "return_type": "godot_real",
+        "name": "godot_packed_float32_array_get",
+        "return_type": "float",
         "arguments": [
-          ["const godot_packed_real_array *", "p_self"],
+          ["const godot_packed_float32_array *", "p_self"],
           ["const godot_int", "p_idx"]
         ]
       },
       {
-        "name": "godot_packed_real_array_size",
+        "name": "godot_packed_float32_array_size",
         "return_type": "godot_int",
         "arguments": [
-          ["const godot_packed_real_array *", "p_self"]
+          ["const godot_packed_float32_array *", "p_self"]
         ]
       },
       {
-        "name": "godot_packed_real_array_destroy",
+        "name": "godot_packed_float32_array_destroy",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_real_array *", "p_self"]
+          ["godot_packed_float32_array *", "p_self"]
         ]
       },
       {
@@ -2474,19 +3592,19 @@
         ]
       },
       {
-        "name": "godot_array_new_packed_real_array",
+        "name": "godot_array_new_packed_float32_array",
         "return_type": "void",
         "arguments": [
           ["godot_array *", "r_dest"],
-          ["const godot_packed_real_array *", "p_pra"]
+          ["const godot_packed_float32_array *", "p_pra"]
         ]
       },
       {
-        "name": "godot_array_new_packed_int_array",
+        "name": "godot_array_new_packed_int32_array",
         "return_type": "void",
         "arguments": [
           ["godot_array *", "r_dest"],
-          ["const godot_packed_int_array *", "p_pia"]
+          ["const godot_packed_int32_array *", "p_pia"]
         ]
       },
       {
@@ -4059,19 +5177,19 @@
         ]
       },
       {
-        "name": "godot_variant_new_packed_int_array",
+        "name": "godot_variant_new_packed_int32_array",
         "return_type": "void",
         "arguments": [
           ["godot_variant *", "r_dest"],
-          ["const godot_packed_int_array *", "p_pia"]
+          ["const godot_packed_int32_array *", "p_pia"]
         ]
       },
       {
-        "name": "godot_variant_new_packed_real_array",
+        "name": "godot_variant_new_packed_float32_array",
         "return_type": "void",
         "arguments": [
           ["godot_variant *", "r_dest"],
-          ["const godot_packed_real_array *", "p_pra"]
+          ["const godot_packed_float32_array *", "p_pra"]
         ]
       },
       {
@@ -4254,15 +5372,15 @@
         ]
       },
       {
-        "name": "godot_variant_as_packed_int_array",
-        "return_type": "godot_packed_int_array",
+        "name": "godot_variant_as_packed_int32_array",
+        "return_type": "godot_packed_int32_array",
         "arguments": [
           ["const godot_variant *", "p_self"]
         ]
       },
       {
-        "name": "godot_variant_as_packed_real_array",
-        "return_type": "godot_packed_real_array",
+        "name": "godot_variant_as_packed_float32_array",
+        "return_type": "godot_packed_float32_array",
         "arguments": [
           ["const godot_variant *", "p_self"]
         ]
@@ -5869,7 +6987,7 @@
           "arguments": [
             ["void *", "p_gdnative_handle"],
             ["const char *", "p_name"],
-            ["const godot_signal *", "p_signal"]
+            ["const godot_nativescript_signal *", "p_signal"]
           ]
         },
         {

--- a/modules/gdnative/include/gdnative/array.h
+++ b/modules/gdnative/include/gdnative/array.h
@@ -51,7 +51,7 @@ typedef struct {
 }
 #endif
 
-#include <gdnative/pool_arrays.h>
+#include <gdnative/packed_arrays.h>
 #include <gdnative/variant.h>
 
 #include <gdnative/gdnative.h>
@@ -66,8 +66,10 @@ void GDAPI godot_array_new_packed_color_array(godot_array *r_dest, const godot_p
 void GDAPI godot_array_new_packed_vector3_array(godot_array *r_dest, const godot_packed_vector3_array *p_pv3a);
 void GDAPI godot_array_new_packed_vector2_array(godot_array *r_dest, const godot_packed_vector2_array *p_pv2a);
 void GDAPI godot_array_new_packed_string_array(godot_array *r_dest, const godot_packed_string_array *p_psa);
-void GDAPI godot_array_new_packed_real_array(godot_array *r_dest, const godot_packed_real_array *p_pra);
-void GDAPI godot_array_new_packed_int_array(godot_array *r_dest, const godot_packed_int_array *p_pia);
+void GDAPI godot_array_new_packed_float32_array(godot_array *r_dest, const godot_packed_float32_array *p_pra);
+void GDAPI godot_array_new_packed_float64_array(godot_array *r_dest, const godot_packed_float64_array *p_pra);
+void GDAPI godot_array_new_packed_int32_array(godot_array *r_dest, const godot_packed_int32_array *p_pia);
+void GDAPI godot_array_new_packed_int64_array(godot_array *r_dest, const godot_packed_int64_array *p_pia);
 void GDAPI godot_array_new_packed_byte_array(godot_array *r_dest, const godot_packed_byte_array *p_pba);
 
 void GDAPI godot_array_set(godot_array *p_self, const godot_int p_idx, const godot_variant *p_value);

--- a/modules/gdnative/include/gdnative/callable.h
+++ b/modules/gdnative/include/gdnative/callable.h
@@ -1,0 +1,126 @@
+/*************************************************************************/
+/*  callable.h                                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GODOT_CALLABLE_H
+#define GODOT_CALLABLE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#define GODOT_CALLABLE_SIZE (16)
+
+#ifndef GODOT_CORE_API_GODOT_CALLABLE_TYPE_DEFINED
+#define GODOT_CORE_API_GODOT_CALLABLE_TYPE_DEFINED
+typedef struct {
+	uint8_t _dont_touch_that[GODOT_CALLABLE_SIZE];
+} godot_callable;
+#endif
+
+#define GODOT_SIGNAL_SIZE (16)
+
+#ifndef GODOT_CORE_API_GODOT_SIGNAL_TYPE_DEFINED
+#define GODOT_CORE_API_GODOT_SIGNAL_TYPE_DEFINED
+typedef struct {
+	uint8_t _dont_touch_that[GODOT_SIGNAL_SIZE];
+} godot_signal;
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <gdnative/gdnative.h>
+#include <gdnative/string_name.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Callable
+
+void GDAPI godot_callable_new_with_object(godot_callable *r_dest, const godot_object *p_object, const godot_string_name *p_method);
+void GDAPI godot_callable_new_with_object_id(godot_callable *r_dest, uint64_t p_objectid, const godot_string_name *p_method);
+void GDAPI godot_callable_new_copy(godot_callable *r_dest, const godot_callable *p_src);
+
+void GDAPI godot_callable_destroy(godot_callable *p_self);
+
+godot_int GDAPI godot_callable_call(const godot_callable *p_self, const godot_variant **p_arguments, godot_int p_argcount, godot_variant *r_return_value);
+void GDAPI godot_callable_call_deferred(const godot_callable *p_self, const godot_variant **p_arguments, godot_int p_argcount);
+
+godot_bool GDAPI godot_callable_is_null(const godot_callable *p_self);
+godot_bool GDAPI godot_callable_is_custom(const godot_callable *p_self);
+godot_bool GDAPI godot_callable_is_standard(const godot_callable *p_self);
+
+godot_object GDAPI *godot_callable_get_object(const godot_callable *p_self);
+uint64_t GDAPI godot_callable_get_object_id(const godot_callable *p_self);
+godot_string_name GDAPI godot_callable_get_method(const godot_callable *p_self);
+
+uint32_t GDAPI godot_callable_hash(const godot_callable *p_self);
+
+godot_string GDAPI godot_callable_as_string(const godot_callable *p_self);
+
+godot_bool GDAPI godot_callable_operator_equal(const godot_callable *p_self, const godot_callable *p_other);
+godot_bool GDAPI godot_callable_operator_less(const godot_callable *p_self, const godot_callable *p_other);
+
+// Signal
+
+void GDAPI godot_signal_new_with_object(godot_signal *r_dest, const godot_object *p_object, const godot_string_name *p_name);
+void GDAPI godot_signal_new_with_object_id(godot_signal *r_dest, uint64_t p_objectid, const godot_string_name *p_name);
+void GDAPI godot_signal_new_copy(godot_signal *r_dest, const godot_signal *p_src);
+
+void GDAPI godot_signal_destroy(godot_signal *p_self);
+
+godot_int GDAPI godot_signal_emit(const godot_signal *p_self, const godot_variant **p_arguments, godot_int p_argcount);
+
+godot_int GDAPI godot_signal_connect(godot_signal *p_self, const godot_callable *p_callable, const godot_array *p_binds, uint32_t p_flags);
+void GDAPI godot_signal_disconnect(godot_signal *p_self, const godot_callable *p_callable);
+
+godot_bool GDAPI godot_signal_is_null(const godot_signal *p_self);
+godot_bool GDAPI godot_signal_is_connected(const godot_signal *p_self, const godot_callable *p_callable);
+
+godot_array GDAPI godot_signal_get_connections(const godot_signal *p_self);
+
+godot_object GDAPI *godot_signal_get_object(const godot_signal *p_self);
+uint64_t GDAPI godot_signal_get_object_id(const godot_signal *p_self);
+godot_string_name GDAPI godot_signal_get_name(const godot_signal *p_self);
+
+godot_string GDAPI godot_signal_as_string(const godot_signal *p_self);
+
+godot_bool GDAPI godot_signal_operator_equal(const godot_signal *p_self, const godot_signal *p_other);
+godot_bool GDAPI godot_signal_operator_less(const godot_signal *p_self, const godot_signal *p_other);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/modules/gdnative/include/gdnative/gdnative.h
+++ b/modules/gdnative/include/gdnative/gdnative.h
@@ -144,15 +144,15 @@ typedef void godot_object;
 
 #include <gdnative/string_name.h>
 
-////// Vector2
+////// Vector2 & Vector2i
 
 #include <gdnative/vector2.h>
 
-////// Rect2
+////// Rect2 & Rect2i
 
 #include <gdnative/rect2.h>
 
-////// Vector3
+////// Vector3 & Vector3i
 
 #include <gdnative/vector3.h>
 
@@ -192,6 +192,10 @@ typedef void godot_object;
 
 #include <gdnative/rid.h>
 
+/////// Callable & Signal
+
+#include <gdnative/callable.h>
+
 /////// Dictionary
 
 #include <gdnative/dictionary.h>
@@ -200,8 +204,8 @@ typedef void godot_object;
 
 #include <gdnative/array.h>
 
-// single API file for Pool*Array
-#include <gdnative/pool_arrays.h>
+// single API file for Packed*Array
+#include <gdnative/packed_arrays.h>
 
 void GDAPI godot_object_destroy(godot_object *p_o);
 
@@ -289,7 +293,9 @@ void GDAPI *godot_get_class_tag(const godot_string_name *p_class);
 godot_object GDAPI *godot_object_cast_to(const godot_object *p_object, void *p_class_tag);
 
 // equivalent of GDScript's instance_from_id
-godot_object GDAPI *godot_instance_from_id(godot_int p_instance_id);
+godot_object GDAPI *godot_instance_from_id(uint64_t p_instance_id);
+
+uint64_t GDAPI godot_object_get_instance_id(const godot_object *p_object);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/include/gdnative/packed_arrays.h
+++ b/modules/gdnative/include/gdnative/packed_arrays.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  pool_arrays.h                                                        */
+/*  packed_arrays.h                                                        */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_POOL_ARRAYS_H
-#define GODOT_POOL_ARRAYS_H
+#ifndef GODOT_PACKED_ARRAYS_H
+#define GODOT_PACKED_ARRAYS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,24 +50,46 @@ typedef struct {
 
 /////// PackedInt32Array
 
-#define GODOT_PACKED_INT_ARRAY_SIZE (2 * sizeof(void *))
+#define GODOT_PACKED_INT32_ARRAY_SIZE (2 * sizeof(void *))
 
-#ifndef GODOT_CORE_API_GODOT_PACKED_INT_ARRAY_TYPE_DEFINED
-#define GODOT_CORE_API_GODOT_PACKED_INT_ARRAY_TYPE_DEFINED
+#ifndef GODOT_CORE_API_GODOT_PACKED_INT32_ARRAY_TYPE_DEFINED
+#define GODOT_CORE_API_GODOT_PACKED_INT32_ARRAY_TYPE_DEFINED
 typedef struct {
-	uint8_t _dont_touch_that[GODOT_PACKED_INT_ARRAY_SIZE];
-} godot_packed_int_array;
+	uint8_t _dont_touch_that[GODOT_PACKED_INT32_ARRAY_SIZE];
+} godot_packed_int32_array;
+#endif
+
+/////// PackedInt64Array
+
+#define GODOT_PACKED_INT64_ARRAY_SIZE (2 * sizeof(void *))
+
+#ifndef GODOT_CORE_API_GODOT_PACKED_INT64_ARRAY_TYPE_DEFINED
+#define GODOT_CORE_API_GODOT_PACKED_INT64_ARRAY_TYPE_DEFINED
+typedef struct {
+	uint8_t _dont_touch_that[GODOT_PACKED_INT64_ARRAY_SIZE];
+} godot_packed_int64_array;
 #endif
 
 /////// PackedFloat32Array
 
-#define GODOT_PACKED_REAL_ARRAY_SIZE (2 * sizeof(void *))
+#define GODOT_PACKED_FLOAT32_ARRAY_SIZE (2 * sizeof(void *))
 
-#ifndef GODOT_CORE_API_GODOT_PACKED_REAL_ARRAY_TYPE_DEFINED
-#define GODOT_CORE_API_GODOT_PACKED_REAL_ARRAY_TYPE_DEFINED
+#ifndef GODOT_CORE_API_GODOT_PACKED_FLOAT32_ARRAY_TYPE_DEFINED
+#define GODOT_CORE_API_GODOT_PACKED_FLOAT32_ARRAY_TYPE_DEFINED
 typedef struct {
-	uint8_t _dont_touch_that[GODOT_PACKED_REAL_ARRAY_SIZE];
-} godot_packed_real_array;
+	uint8_t _dont_touch_that[GODOT_PACKED_FLOAT32_ARRAY_SIZE];
+} godot_packed_float32_array;
+#endif
+
+/////// PackedFloat64Array
+
+#define GODOT_PACKED_FLOAT64_ARRAY_SIZE (2 * sizeof(void *))
+
+#ifndef GODOT_CORE_API_GODOT_PACKED_FLOAT64_ARRAY_TYPE_DEFINED
+#define GODOT_CORE_API_GODOT_PACKED_FLOAT64_ARRAY_TYPE_DEFINED
+typedef struct {
+	uint8_t _dont_touch_that[GODOT_PACKED_FLOAT64_ARRAY_SIZE];
+} godot_packed_float64_array;
 #endif
 
 /////// PackedStringArray
@@ -159,63 +181,121 @@ godot_bool GDAPI godot_packed_byte_array_empty(const godot_packed_byte_array *p_
 
 void GDAPI godot_packed_byte_array_destroy(godot_packed_byte_array *p_self);
 
-// int
+// int32
 
-void GDAPI godot_packed_int_array_new(godot_packed_int_array *r_dest);
-void GDAPI godot_packed_int_array_new_copy(godot_packed_int_array *r_dest, const godot_packed_int_array *p_src);
-void GDAPI godot_packed_int_array_new_with_array(godot_packed_int_array *r_dest, const godot_array *p_a);
+void GDAPI godot_packed_int32_array_new(godot_packed_int32_array *r_dest);
+void GDAPI godot_packed_int32_array_new_copy(godot_packed_int32_array *r_dest, const godot_packed_int32_array *p_src);
+void GDAPI godot_packed_int32_array_new_with_array(godot_packed_int32_array *r_dest, const godot_array *p_a);
 
-void GDAPI godot_packed_int_array_append(godot_packed_int_array *p_self, const godot_int p_data);
+void GDAPI godot_packed_int32_array_append(godot_packed_int32_array *p_self, const int32_t p_data);
 
-void GDAPI godot_packed_int_array_append_array(godot_packed_int_array *p_self, const godot_packed_int_array *p_array);
+void GDAPI godot_packed_int32_array_append_array(godot_packed_int32_array *p_self, const godot_packed_int32_array *p_array);
 
-godot_error GDAPI godot_packed_int_array_insert(godot_packed_int_array *p_self, const godot_int p_idx, const godot_int p_data);
+godot_error GDAPI godot_packed_int32_array_insert(godot_packed_int32_array *p_self, const godot_int p_idx, const int32_t p_data);
 
-void GDAPI godot_packed_int_array_invert(godot_packed_int_array *p_self);
+void GDAPI godot_packed_int32_array_invert(godot_packed_int32_array *p_self);
 
-void GDAPI godot_packed_int_array_push_back(godot_packed_int_array *p_self, const godot_int p_data);
+void GDAPI godot_packed_int32_array_push_back(godot_packed_int32_array *p_self, const int32_t p_data);
 
-void GDAPI godot_packed_int_array_remove(godot_packed_int_array *p_self, const godot_int p_idx);
+void GDAPI godot_packed_int32_array_remove(godot_packed_int32_array *p_self, const godot_int p_idx);
 
-void GDAPI godot_packed_int_array_resize(godot_packed_int_array *p_self, const godot_int p_size);
+void GDAPI godot_packed_int32_array_resize(godot_packed_int32_array *p_self, const godot_int p_size);
 
-void GDAPI godot_packed_int_array_set(godot_packed_int_array *p_self, const godot_int p_idx, const godot_int p_data);
-godot_int GDAPI godot_packed_int_array_get(const godot_packed_int_array *p_self, const godot_int p_idx);
+void GDAPI godot_packed_int32_array_set(godot_packed_int32_array *p_self, const godot_int p_idx, const int32_t p_data);
+int32_t GDAPI godot_packed_int32_array_get(const godot_packed_int32_array *p_self, const godot_int p_idx);
 
-godot_int GDAPI godot_packed_int_array_size(const godot_packed_int_array *p_self);
+godot_int GDAPI godot_packed_int32_array_size(const godot_packed_int32_array *p_self);
 
-godot_bool GDAPI godot_packed_int_array_empty(const godot_packed_int_array *p_self);
+godot_bool GDAPI godot_packed_int32_array_empty(const godot_packed_int32_array *p_self);
 
-void GDAPI godot_packed_int_array_destroy(godot_packed_int_array *p_self);
+void GDAPI godot_packed_int32_array_destroy(godot_packed_int32_array *p_self);
 
-// real
+// int64
 
-void GDAPI godot_packed_real_array_new(godot_packed_real_array *r_dest);
-void GDAPI godot_packed_real_array_new_copy(godot_packed_real_array *r_dest, const godot_packed_real_array *p_src);
-void GDAPI godot_packed_real_array_new_with_array(godot_packed_real_array *r_dest, const godot_array *p_a);
+void GDAPI godot_packed_int64_array_new(godot_packed_int64_array *r_dest);
+void GDAPI godot_packed_int64_array_new_copy(godot_packed_int64_array *r_dest, const godot_packed_int64_array *p_src);
+void GDAPI godot_packed_int64_array_new_with_array(godot_packed_int64_array *r_dest, const godot_array *p_a);
 
-void GDAPI godot_packed_real_array_append(godot_packed_real_array *p_self, const godot_real p_data);
+void GDAPI godot_packed_int64_array_append(godot_packed_int64_array *p_self, const int64_t p_data);
 
-void GDAPI godot_packed_real_array_append_array(godot_packed_real_array *p_self, const godot_packed_real_array *p_array);
+void GDAPI godot_packed_int64_array_append_array(godot_packed_int64_array *p_self, const godot_packed_int64_array *p_array);
 
-godot_error GDAPI godot_packed_real_array_insert(godot_packed_real_array *p_self, const godot_int p_idx, const godot_real p_data);
+godot_error GDAPI godot_packed_int64_array_insert(godot_packed_int64_array *p_self, const godot_int p_idx, const int64_t p_data);
 
-void GDAPI godot_packed_real_array_invert(godot_packed_real_array *p_self);
+void GDAPI godot_packed_int64_array_invert(godot_packed_int64_array *p_self);
 
-void GDAPI godot_packed_real_array_push_back(godot_packed_real_array *p_self, const godot_real p_data);
+void GDAPI godot_packed_int64_array_push_back(godot_packed_int64_array *p_self, const int64_t p_data);
 
-void GDAPI godot_packed_real_array_remove(godot_packed_real_array *p_self, const godot_int p_idx);
+void GDAPI godot_packed_int64_array_remove(godot_packed_int64_array *p_self, const godot_int p_idx);
 
-void GDAPI godot_packed_real_array_resize(godot_packed_real_array *p_self, const godot_int p_size);
+void GDAPI godot_packed_int64_array_resize(godot_packed_int64_array *p_self, const godot_int p_size);
 
-void GDAPI godot_packed_real_array_set(godot_packed_real_array *p_self, const godot_int p_idx, const godot_real p_data);
-godot_real GDAPI godot_packed_real_array_get(const godot_packed_real_array *p_self, const godot_int p_idx);
+void GDAPI godot_packed_int64_array_set(godot_packed_int64_array *p_self, const godot_int p_idx, const int64_t p_data);
+int64_t GDAPI godot_packed_int64_array_get(const godot_packed_int64_array *p_self, const godot_int p_idx);
 
-godot_int GDAPI godot_packed_real_array_size(const godot_packed_real_array *p_self);
+godot_int GDAPI godot_packed_int64_array_size(const godot_packed_int64_array *p_self);
 
-godot_bool GDAPI godot_packed_real_array_empty(const godot_packed_real_array *p_self);
+godot_bool GDAPI godot_packed_int64_array_empty(const godot_packed_int64_array *p_self);
 
-void GDAPI godot_packed_real_array_destroy(godot_packed_real_array *p_self);
+void GDAPI godot_packed_int64_array_destroy(godot_packed_int64_array *p_self);
+
+// float32
+
+void GDAPI godot_packed_float32_array_new(godot_packed_float32_array *r_dest);
+void GDAPI godot_packed_float32_array_new_copy(godot_packed_float32_array *r_dest, const godot_packed_float32_array *p_src);
+void GDAPI godot_packed_float32_array_new_with_array(godot_packed_float32_array *r_dest, const godot_array *p_a);
+
+void GDAPI godot_packed_float32_array_append(godot_packed_float32_array *p_self, const float p_data);
+
+void GDAPI godot_packed_float32_array_append_array(godot_packed_float32_array *p_self, const godot_packed_float32_array *p_array);
+
+godot_error GDAPI godot_packed_float32_array_insert(godot_packed_float32_array *p_self, const godot_int p_idx, const float p_data);
+
+void GDAPI godot_packed_float32_array_invert(godot_packed_float32_array *p_self);
+
+void GDAPI godot_packed_float32_array_push_back(godot_packed_float32_array *p_self, const float p_data);
+
+void GDAPI godot_packed_float32_array_remove(godot_packed_float32_array *p_self, const godot_int p_idx);
+
+void GDAPI godot_packed_float32_array_resize(godot_packed_float32_array *p_self, const godot_int p_size);
+
+void GDAPI godot_packed_float32_array_set(godot_packed_float32_array *p_self, const godot_int p_idx, const float p_data);
+float GDAPI godot_packed_float32_array_get(const godot_packed_float32_array *p_self, const godot_int p_idx);
+
+godot_int GDAPI godot_packed_float32_array_size(const godot_packed_float32_array *p_self);
+
+godot_bool GDAPI godot_packed_float32_array_empty(const godot_packed_float32_array *p_self);
+
+void GDAPI godot_packed_float32_array_destroy(godot_packed_float32_array *p_self);
+
+// float64
+
+void GDAPI godot_packed_float64_array_new(godot_packed_float64_array *r_dest);
+void GDAPI godot_packed_float64_array_new_copy(godot_packed_float64_array *r_dest, const godot_packed_float64_array *p_src);
+void GDAPI godot_packed_float64_array_new_with_array(godot_packed_float64_array *r_dest, const godot_array *p_a);
+
+void GDAPI godot_packed_float64_array_append(godot_packed_float64_array *p_self, const double p_data);
+
+void GDAPI godot_packed_float64_array_append_array(godot_packed_float64_array *p_self, const godot_packed_float64_array *p_array);
+
+godot_error GDAPI godot_packed_float64_array_insert(godot_packed_float64_array *p_self, const godot_int p_idx, const double p_data);
+
+void GDAPI godot_packed_float64_array_invert(godot_packed_float64_array *p_self);
+
+void GDAPI godot_packed_float64_array_push_back(godot_packed_float64_array *p_self, const double p_data);
+
+void GDAPI godot_packed_float64_array_remove(godot_packed_float64_array *p_self, const godot_int p_idx);
+
+void GDAPI godot_packed_float64_array_resize(godot_packed_float64_array *p_self, const godot_int p_size);
+
+void GDAPI godot_packed_float64_array_set(godot_packed_float64_array *p_self, const godot_int p_idx, const double p_data);
+double GDAPI godot_packed_float64_array_get(const godot_packed_float64_array *p_self, const godot_int p_idx);
+
+godot_int GDAPI godot_packed_float64_array_size(const godot_packed_float64_array *p_self);
+
+godot_bool GDAPI godot_packed_float64_array_empty(const godot_packed_float64_array *p_self);
+
+void GDAPI godot_packed_float64_array_destroy(godot_packed_float64_array *p_self);
 
 // string
 

--- a/modules/gdnative/include/gdnative/rect2.h
+++ b/modules/gdnative/include/gdnative/rect2.h
@@ -44,6 +44,13 @@ typedef struct godot_rect2 {
 } godot_rect2;
 #endif
 
+#ifndef GODOT_CORE_API_GODOT_RECT2I_TYPE_DEFINED
+#define GODOT_CORE_API_GODOT_RECT2I_TYPE_DEFINED
+typedef struct godot_rect2i {
+	uint8_t _dont_touch_that[16];
+} godot_rect2i;
+#endif
+
 // reduce extern "C" nesting for VS2013
 #ifdef __cplusplus
 }
@@ -56,10 +63,14 @@ typedef struct godot_rect2 {
 extern "C" {
 #endif
 
+// Rect2
+
 void GDAPI godot_rect2_new_with_position_and_size(godot_rect2 *r_dest, const godot_vector2 *p_pos, const godot_vector2 *p_size);
 void GDAPI godot_rect2_new(godot_rect2 *r_dest, const godot_real p_x, const godot_real p_y, const godot_real p_width, const godot_real p_height);
 
 godot_string GDAPI godot_rect2_as_string(const godot_rect2 *p_self);
+
+godot_rect2i GDAPI godot_rect2_as_rect2i(const godot_rect2 *p_self);
 
 godot_real GDAPI godot_rect2_get_area(const godot_rect2 *p_self);
 
@@ -94,6 +105,49 @@ godot_vector2 GDAPI godot_rect2_get_size(const godot_rect2 *p_self);
 void GDAPI godot_rect2_set_position(godot_rect2 *p_self, const godot_vector2 *p_pos);
 
 void GDAPI godot_rect2_set_size(godot_rect2 *p_self, const godot_vector2 *p_size);
+
+// Rect2I
+
+void GDAPI godot_rect2i_new_with_position_and_size(godot_rect2i *r_dest, const godot_vector2i *p_pos, const godot_vector2i *p_size);
+void GDAPI godot_rect2i_new(godot_rect2i *r_dest, const godot_int p_x, const godot_int p_y, const godot_int p_width, const godot_int p_height);
+
+godot_string GDAPI godot_rect2i_as_string(const godot_rect2i *p_self);
+
+godot_rect2 GDAPI godot_rect2i_as_rect2(const godot_rect2i *p_self);
+
+godot_int GDAPI godot_rect2i_get_area(const godot_rect2i *p_self);
+
+godot_bool GDAPI godot_rect2i_intersects(const godot_rect2i *p_self, const godot_rect2i *p_b);
+
+godot_bool GDAPI godot_rect2i_encloses(const godot_rect2i *p_self, const godot_rect2i *p_b);
+
+godot_bool GDAPI godot_rect2i_has_no_area(const godot_rect2i *p_self);
+
+godot_rect2i GDAPI godot_rect2i_clip(const godot_rect2i *p_self, const godot_rect2i *p_b);
+
+godot_rect2i GDAPI godot_rect2i_merge(const godot_rect2i *p_self, const godot_rect2i *p_b);
+
+godot_bool GDAPI godot_rect2i_has_point(const godot_rect2i *p_self, const godot_vector2i *p_point);
+
+godot_rect2i GDAPI godot_rect2i_grow(const godot_rect2i *p_self, const godot_int p_by);
+
+godot_rect2i GDAPI godot_rect2i_grow_individual(const godot_rect2i *p_self, const godot_int p_left, const godot_int p_top, const godot_int p_right, const godot_int p_bottom);
+
+godot_rect2i GDAPI godot_rect2i_grow_margin(const godot_rect2i *p_self, const godot_int p_margin, const godot_int p_by);
+
+godot_rect2i GDAPI godot_rect2i_abs(const godot_rect2i *p_self);
+
+godot_rect2i GDAPI godot_rect2i_expand(const godot_rect2i *p_self, const godot_vector2i *p_to);
+
+godot_bool GDAPI godot_rect2i_operator_equal(const godot_rect2i *p_self, const godot_rect2i *p_b);
+
+godot_vector2i GDAPI godot_rect2i_get_position(const godot_rect2i *p_self);
+
+godot_vector2i GDAPI godot_rect2i_get_size(const godot_rect2i *p_self);
+
+void GDAPI godot_rect2i_set_position(godot_rect2i *p_self, const godot_vector2i *p_pos);
+
+void GDAPI godot_rect2i_set_size(godot_rect2i *p_self, const godot_vector2i *p_size);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -71,16 +71,21 @@ typedef enum godot_variant_type {
 
 	// misc types
 	GODOT_VARIANT_TYPE_COLOR,
+	GODOT_VARIANT_TYPE_STRING_NAME,
 	GODOT_VARIANT_TYPE_NODE_PATH,
 	GODOT_VARIANT_TYPE_RID,
 	GODOT_VARIANT_TYPE_OBJECT,
+	GODOT_VARIANT_TYPE_CALLABLE,
+	GODOT_VARIANT_TYPE_SIGNAL,
 	GODOT_VARIANT_TYPE_DICTIONARY,
 	GODOT_VARIANT_TYPE_ARRAY,
 
 	// arrays
 	GODOT_VARIANT_TYPE_PACKED_BYTE_ARRAY,
-	GODOT_VARIANT_TYPE_PACKED_INT_ARRAY,
-	GODOT_VARIANT_TYPE_PACKED_REAL_ARRAY,
+	GODOT_VARIANT_TYPE_PACKED_INT32_ARRAY,
+	GODOT_VARIANT_TYPE_PACKED_INT64_ARRAY,
+	GODOT_VARIANT_TYPE_PACKED_FLOAT32_ARRAY,
+	GODOT_VARIANT_TYPE_PACKED_FLOAT64_ARRAY,
 	GODOT_VARIANT_TYPE_PACKED_STRING_ARRAY,
 	GODOT_VARIANT_TYPE_PACKED_VECTOR2_ARRAY,
 	GODOT_VARIANT_TYPE_PACKED_VECTOR3_ARRAY,
@@ -149,15 +154,17 @@ typedef enum godot_variant_operator {
 #include <gdnative/aabb.h>
 #include <gdnative/array.h>
 #include <gdnative/basis.h>
+#include <gdnative/callable.h>
 #include <gdnative/color.h>
 #include <gdnative/dictionary.h>
 #include <gdnative/node_path.h>
+#include <gdnative/packed_arrays.h>
 #include <gdnative/plane.h>
-#include <gdnative/pool_arrays.h>
 #include <gdnative/quat.h>
 #include <gdnative/rect2.h>
 #include <gdnative/rid.h>
 #include <gdnative/string.h>
+#include <gdnative/string_name.h>
 #include <gdnative/transform.h>
 #include <gdnative/transform2d.h>
 #include <gdnative/variant.h>
@@ -181,9 +188,13 @@ void GDAPI godot_variant_new_uint(godot_variant *r_dest, const uint64_t p_i);
 void GDAPI godot_variant_new_int(godot_variant *r_dest, const int64_t p_i);
 void GDAPI godot_variant_new_real(godot_variant *r_dest, const double p_r);
 void GDAPI godot_variant_new_string(godot_variant *r_dest, const godot_string *p_s);
+void GDAPI godot_variant_new_string_name(godot_variant *r_dest, const godot_string_name *p_s);
 void GDAPI godot_variant_new_vector2(godot_variant *r_dest, const godot_vector2 *p_v2);
+void GDAPI godot_variant_new_vector2i(godot_variant *r_dest, const godot_vector2i *p_v2);
 void GDAPI godot_variant_new_rect2(godot_variant *r_dest, const godot_rect2 *p_rect2);
+void GDAPI godot_variant_new_rect2i(godot_variant *r_dest, const godot_rect2i *p_rect2);
 void GDAPI godot_variant_new_vector3(godot_variant *r_dest, const godot_vector3 *p_v3);
+void GDAPI godot_variant_new_vector3i(godot_variant *r_dest, const godot_vector3i *p_v3);
 void GDAPI godot_variant_new_transform2d(godot_variant *r_dest, const godot_transform2d *p_t2d);
 void GDAPI godot_variant_new_plane(godot_variant *r_dest, const godot_plane *p_plane);
 void GDAPI godot_variant_new_quat(godot_variant *r_dest, const godot_quat *p_quat);
@@ -193,12 +204,16 @@ void GDAPI godot_variant_new_transform(godot_variant *r_dest, const godot_transf
 void GDAPI godot_variant_new_color(godot_variant *r_dest, const godot_color *p_color);
 void GDAPI godot_variant_new_node_path(godot_variant *r_dest, const godot_node_path *p_np);
 void GDAPI godot_variant_new_rid(godot_variant *r_dest, const godot_rid *p_rid);
+void GDAPI godot_variant_new_callable(godot_variant *r_dest, const godot_callable *p_callable);
+void GDAPI godot_variant_new_signal(godot_variant *r_dest, const godot_signal *p_signal);
 void GDAPI godot_variant_new_object(godot_variant *r_dest, const godot_object *p_obj);
 void GDAPI godot_variant_new_dictionary(godot_variant *r_dest, const godot_dictionary *p_dict);
 void GDAPI godot_variant_new_array(godot_variant *r_dest, const godot_array *p_arr);
 void GDAPI godot_variant_new_packed_byte_array(godot_variant *r_dest, const godot_packed_byte_array *p_pba);
-void GDAPI godot_variant_new_packed_int_array(godot_variant *r_dest, const godot_packed_int_array *p_pia);
-void GDAPI godot_variant_new_packed_real_array(godot_variant *r_dest, const godot_packed_real_array *p_pra);
+void GDAPI godot_variant_new_packed_int32_array(godot_variant *r_dest, const godot_packed_int32_array *p_pia);
+void GDAPI godot_variant_new_packed_int64_array(godot_variant *r_dest, const godot_packed_int64_array *p_pia);
+void GDAPI godot_variant_new_packed_float32_array(godot_variant *r_dest, const godot_packed_float32_array *p_pra);
+void GDAPI godot_variant_new_packed_float64_array(godot_variant *r_dest, const godot_packed_float64_array *p_pra);
 void GDAPI godot_variant_new_packed_string_array(godot_variant *r_dest, const godot_packed_string_array *p_psa);
 void GDAPI godot_variant_new_packed_vector2_array(godot_variant *r_dest, const godot_packed_vector2_array *p_pv2a);
 void GDAPI godot_variant_new_packed_vector3_array(godot_variant *r_dest, const godot_packed_vector3_array *p_pv3a);
@@ -209,9 +224,13 @@ uint64_t GDAPI godot_variant_as_uint(const godot_variant *p_self);
 int64_t GDAPI godot_variant_as_int(const godot_variant *p_self);
 double GDAPI godot_variant_as_real(const godot_variant *p_self);
 godot_string GDAPI godot_variant_as_string(const godot_variant *p_self);
+godot_string_name GDAPI godot_variant_as_string_name(const godot_variant *p_self);
 godot_vector2 GDAPI godot_variant_as_vector2(const godot_variant *p_self);
+godot_vector2i GDAPI godot_variant_as_vector2i(const godot_variant *p_self);
 godot_rect2 GDAPI godot_variant_as_rect2(const godot_variant *p_self);
+godot_rect2i GDAPI godot_variant_as_rect2i(const godot_variant *p_self);
 godot_vector3 GDAPI godot_variant_as_vector3(const godot_variant *p_self);
+godot_vector3i GDAPI godot_variant_as_vector3i(const godot_variant *p_self);
 godot_transform2d GDAPI godot_variant_as_transform2d(const godot_variant *p_self);
 godot_plane GDAPI godot_variant_as_plane(const godot_variant *p_self);
 godot_quat GDAPI godot_variant_as_quat(const godot_variant *p_self);
@@ -221,12 +240,16 @@ godot_transform GDAPI godot_variant_as_transform(const godot_variant *p_self);
 godot_color GDAPI godot_variant_as_color(const godot_variant *p_self);
 godot_node_path GDAPI godot_variant_as_node_path(const godot_variant *p_self);
 godot_rid GDAPI godot_variant_as_rid(const godot_variant *p_self);
+godot_callable GDAPI godot_variant_as_callable(const godot_variant *p_self);
+godot_signal GDAPI godot_variant_as_signal(const godot_variant *p_self);
 godot_object GDAPI *godot_variant_as_object(const godot_variant *p_self);
 godot_dictionary GDAPI godot_variant_as_dictionary(const godot_variant *p_self);
 godot_array GDAPI godot_variant_as_array(const godot_variant *p_self);
 godot_packed_byte_array GDAPI godot_variant_as_packed_byte_array(const godot_variant *p_self);
-godot_packed_int_array GDAPI godot_variant_as_packed_int_array(const godot_variant *p_self);
-godot_packed_real_array GDAPI godot_variant_as_packed_real_array(const godot_variant *p_self);
+godot_packed_int32_array GDAPI godot_variant_as_packed_int32_array(const godot_variant *p_self);
+godot_packed_int64_array GDAPI godot_variant_as_packed_int64_array(const godot_variant *p_self);
+godot_packed_float32_array GDAPI godot_variant_as_packed_float32_array(const godot_variant *p_self);
+godot_packed_float64_array GDAPI godot_variant_as_packed_float64_array(const godot_variant *p_self);
 godot_packed_string_array GDAPI godot_variant_as_packed_string_array(const godot_variant *p_self);
 godot_packed_vector2_array GDAPI godot_variant_as_packed_vector2_array(const godot_variant *p_self);
 godot_packed_vector3_array GDAPI godot_variant_as_packed_vector3_array(const godot_variant *p_self);
@@ -239,6 +262,7 @@ godot_bool GDAPI godot_variant_has_method(const godot_variant *p_self, const god
 godot_bool GDAPI godot_variant_operator_equal(const godot_variant *p_self, const godot_variant *p_other);
 godot_bool GDAPI godot_variant_operator_less(const godot_variant *p_self, const godot_variant *p_other);
 
+uint32_t GDAPI godot_variant_hash(const godot_variant *p_self);
 godot_bool GDAPI godot_variant_hash_compare(const godot_variant *p_self, const godot_variant *p_other);
 
 godot_bool GDAPI godot_variant_booleanize(const godot_variant *p_self);

--- a/modules/gdnative/include/gdnative/vector2.h
+++ b/modules/gdnative/include/gdnative/vector2.h
@@ -46,6 +46,15 @@ typedef struct {
 } godot_vector2;
 #endif
 
+#define GODOT_VECTOR2I_SIZE 8
+
+#ifndef GODOT_CORE_API_GODOT_VECTOR2I_TYPE_DEFINED
+#define GODOT_CORE_API_GODOT_VECTOR2I_TYPE_DEFINED
+typedef struct {
+	uint8_t _dont_touch_that[GODOT_VECTOR2I_SIZE];
+} godot_vector2i;
+#endif
+
 // reduce extern "C" nesting for VS2013
 #ifdef __cplusplus
 }
@@ -57,9 +66,13 @@ typedef struct {
 extern "C" {
 #endif
 
+// Vector2
+
 void GDAPI godot_vector2_new(godot_vector2 *r_dest, const godot_real p_x, const godot_real p_y);
 
 godot_string GDAPI godot_vector2_as_string(const godot_vector2 *p_self);
+
+godot_vector2i GDAPI godot_vector2_as_vector2i(const godot_vector2 *p_self);
 
 godot_vector2 GDAPI godot_vector2_normalized(const godot_vector2 *p_self);
 
@@ -92,6 +105,8 @@ godot_vector2 GDAPI godot_vector2_rotated(const godot_vector2 *p_self, const god
 godot_vector2 GDAPI godot_vector2_tangent(const godot_vector2 *p_self);
 
 godot_vector2 GDAPI godot_vector2_floor(const godot_vector2 *p_self);
+
+godot_vector2 GDAPI godot_vector2_sign(const godot_vector2 *p_self);
 
 godot_vector2 GDAPI godot_vector2_snapped(const godot_vector2 *p_self, const godot_vector2 *p_by);
 
@@ -134,6 +149,46 @@ void GDAPI godot_vector2_set_y(godot_vector2 *p_self, const godot_real p_y);
 godot_real GDAPI godot_vector2_get_x(const godot_vector2 *p_self);
 
 godot_real GDAPI godot_vector2_get_y(const godot_vector2 *p_self);
+
+// Vector2i
+
+void GDAPI godot_vector2i_new(godot_vector2i *r_dest, const godot_int p_x, const godot_int p_y);
+
+godot_string GDAPI godot_vector2i_as_string(const godot_vector2i *p_self);
+
+godot_vector2 GDAPI godot_vector2i_as_vector2(const godot_vector2i *p_self);
+
+godot_real GDAPI godot_vector2i_aspect(const godot_vector2i *p_self);
+
+godot_vector2i GDAPI godot_vector2i_abs(const godot_vector2i *p_self);
+
+godot_vector2i GDAPI godot_vector2i_sign(const godot_vector2i *p_self);
+
+godot_vector2i GDAPI godot_vector2i_operator_add(const godot_vector2i *p_self, const godot_vector2i *p_b);
+
+godot_vector2i GDAPI godot_vector2i_operator_subtract(const godot_vector2i *p_self, const godot_vector2i *p_b);
+
+godot_vector2i GDAPI godot_vector2i_operator_multiply_vector(const godot_vector2i *p_self, const godot_vector2i *p_b);
+
+godot_vector2i GDAPI godot_vector2i_operator_multiply_scalar(const godot_vector2i *p_self, const godot_int p_b);
+
+godot_vector2i GDAPI godot_vector2i_operator_divide_vector(const godot_vector2i *p_self, const godot_vector2i *p_b);
+
+godot_vector2i GDAPI godot_vector2i_operator_divide_scalar(const godot_vector2i *p_self, const godot_int p_b);
+
+godot_bool GDAPI godot_vector2i_operator_equal(const godot_vector2i *p_self, const godot_vector2i *p_b);
+
+godot_bool GDAPI godot_vector2i_operator_less(const godot_vector2i *p_self, const godot_vector2i *p_b);
+
+godot_vector2i GDAPI godot_vector2i_operator_neg(const godot_vector2i *p_self);
+
+void GDAPI godot_vector2i_set_x(godot_vector2i *p_self, const godot_int p_x);
+
+void GDAPI godot_vector2i_set_y(godot_vector2i *p_self, const godot_int p_y);
+
+godot_int GDAPI godot_vector2i_get_x(const godot_vector2i *p_self);
+
+godot_int GDAPI godot_vector2i_get_y(const godot_vector2i *p_self);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/include/gdnative/vector3.h
+++ b/modules/gdnative/include/gdnative/vector3.h
@@ -46,6 +46,15 @@ typedef struct {
 } godot_vector3;
 #endif
 
+#define GODOT_VECTOR3I_SIZE 12
+
+#ifndef GODOT_CORE_API_GODOT_VECTOR3I_TYPE_DEFINED
+#define GODOT_CORE_API_GODOT_VECTOR3I_TYPE_DEFINED
+typedef struct {
+	uint8_t _dont_touch_that[GODOT_VECTOR3I_SIZE];
+} godot_vector3i;
+#endif
+
 // reduce extern "C" nesting for VS2013
 #ifdef __cplusplus
 }
@@ -64,9 +73,13 @@ typedef enum {
 	GODOT_VECTOR3_AXIS_Z,
 } godot_vector3_axis;
 
+// Vector3
+
 void GDAPI godot_vector3_new(godot_vector3 *r_dest, const godot_real p_x, const godot_real p_y, const godot_real p_z);
 
 godot_string GDAPI godot_vector3_as_string(const godot_vector3 *p_self);
+
+godot_vector3i GDAPI godot_vector3_as_vector3i(const godot_vector3 *p_self);
 
 godot_int GDAPI godot_vector3_min_axis(const godot_vector3 *p_self);
 
@@ -101,6 +114,8 @@ godot_basis GDAPI godot_vector3_outer(const godot_vector3 *p_self, const godot_v
 godot_basis GDAPI godot_vector3_to_diagonal_matrix(const godot_vector3 *p_self);
 
 godot_vector3 GDAPI godot_vector3_abs(const godot_vector3 *p_self);
+
+godot_vector3 GDAPI godot_vector3_sign(const godot_vector3 *p_self);
 
 godot_vector3 GDAPI godot_vector3_floor(const godot_vector3 *p_self);
 
@@ -141,6 +156,44 @@ godot_vector3 GDAPI godot_vector3_operator_neg(const godot_vector3 *p_self);
 void GDAPI godot_vector3_set_axis(godot_vector3 *p_self, const godot_vector3_axis p_axis, const godot_real p_val);
 
 godot_real GDAPI godot_vector3_get_axis(const godot_vector3 *p_self, const godot_vector3_axis p_axis);
+
+// Vector3i
+
+void GDAPI godot_vector3i_new(godot_vector3i *r_dest, const godot_int p_x, const godot_int p_y, const godot_int p_z);
+
+godot_string GDAPI godot_vector3i_as_string(const godot_vector3i *p_self);
+
+godot_vector3 GDAPI godot_vector3i_as_vector3(const godot_vector3i *p_self);
+
+godot_int GDAPI godot_vector3i_min_axis(const godot_vector3i *p_self);
+
+godot_int GDAPI godot_vector3i_max_axis(const godot_vector3i *p_self);
+
+godot_vector3i GDAPI godot_vector3i_abs(const godot_vector3i *p_self);
+
+godot_vector3i GDAPI godot_vector3i_sign(const godot_vector3i *p_self);
+
+godot_vector3i GDAPI godot_vector3i_operator_add(const godot_vector3i *p_self, const godot_vector3i *p_b);
+
+godot_vector3i GDAPI godot_vector3i_operator_subtract(const godot_vector3i *p_self, const godot_vector3i *p_b);
+
+godot_vector3i GDAPI godot_vector3i_operator_multiply_vector(const godot_vector3i *p_self, const godot_vector3i *p_b);
+
+godot_vector3i GDAPI godot_vector3i_operator_multiply_scalar(const godot_vector3i *p_self, const godot_int p_b);
+
+godot_vector3i GDAPI godot_vector3i_operator_divide_vector(const godot_vector3i *p_self, const godot_vector3i *p_b);
+
+godot_vector3i GDAPI godot_vector3i_operator_divide_scalar(const godot_vector3i *p_self, const godot_int p_b);
+
+godot_bool GDAPI godot_vector3i_operator_equal(const godot_vector3i *p_self, const godot_vector3i *p_b);
+
+godot_bool GDAPI godot_vector3i_operator_less(const godot_vector3i *p_self, const godot_vector3i *p_b);
+
+godot_vector3i GDAPI godot_vector3i_operator_neg(const godot_vector3i *p_self);
+
+void GDAPI godot_vector3i_set_axis(godot_vector3i *p_self, const godot_vector3_axis p_axis, const godot_int p_val);
+
+godot_int GDAPI godot_vector3i_get_axis(const godot_vector3i *p_self, const godot_vector3_axis p_axis);
 
 #ifdef __cplusplus
 }

--- a/modules/gdnative/include/nativescript/godot_nativescript.h
+++ b/modules/gdnative/include/nativescript/godot_nativescript.h
@@ -172,17 +172,17 @@ typedef struct {
 	godot_string hint_string;
 	godot_property_usage_flags usage;
 	godot_variant default_value;
-} godot_signal_argument;
+} godot_nativescript_signal_argument;
 
 typedef struct {
 	godot_string name;
 	int num_args;
-	godot_signal_argument *args;
+	godot_nativescript_signal_argument *args;
 	int num_default_args;
 	godot_variant *default_args;
-} godot_signal;
+} godot_nativescript_signal;
 
-void GDAPI godot_nativescript_register_signal(void *p_gdnative_handle, const char *p_name, const godot_signal *p_signal);
+void GDAPI godot_nativescript_register_signal(void *p_gdnative_handle, const char *p_name, const godot_nativescript_signal *p_signal);
 
 void GDAPI *godot_nativescript_get_userdata(godot_object *p_instance);
 

--- a/modules/gdnative/nativescript/godot_nativescript.cpp
+++ b/modules/gdnative/nativescript/godot_nativescript.cpp
@@ -159,7 +159,7 @@ void GDAPI godot_nativescript_register_property(void *p_gdnative_handle, const c
 	E->get().properties.insert(p_path, property);
 }
 
-void GDAPI godot_nativescript_register_signal(void *p_gdnative_handle, const char *p_name, const godot_signal *p_signal) {
+void GDAPI godot_nativescript_register_signal(void *p_gdnative_handle, const char *p_name, const godot_nativescript_signal *p_signal) {
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
@@ -171,7 +171,7 @@ void GDAPI godot_nativescript_register_signal(void *p_gdnative_handle, const cha
 	for (int i = 0; i < p_signal->num_args; i++) {
 		PropertyInfo info;
 
-		godot_signal_argument arg = p_signal->args[i];
+		godot_nativescript_signal_argument arg = p_signal->args[i];
 
 		info.hint = (PropertyHint)arg.hint;
 		info.hint_string = *(String *)&arg.hint_string;
@@ -184,7 +184,7 @@ void GDAPI godot_nativescript_register_signal(void *p_gdnative_handle, const cha
 
 	for (int i = 0; i < p_signal->num_default_args; i++) {
 		Variant *v;
-		godot_signal_argument attrib = p_signal->args[i];
+		godot_nativescript_signal_argument attrib = p_signal->args[i];
 
 		v = (Variant *)&attrib.default_value;
 


### PR DESCRIPTION
- Add `godot_vector2i`, `godot_rect2i`, `godot_vector3i`, `godot_callable`, `godot_signal`, `godot_packed_int64_array`, `godot_packed_float64_array` and new `godot_variant` functions for these types.

- Rename `godot_packed_int_array` to `godot_packed_int32_array` and `godot_packed_real_array` to `godot_packed_float32_array`

*Update:* Tested `Callable`, `Signal` and some of the `Vector?i`, `Rect2i` and `Packed*Array` functions (these should be mostly identical to existing types) to work from [C GDNative library](https://gist.github.com/bruvzg/c52d95132c5e8d4b0f792bc88b8dc7f5).