### PR TITLE
Added visual indentation line guides for text editors

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -885,6 +885,8 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_auto_indent(EditorSettings::get_singleton()->get("text_editor/indent/auto_indent"));
 	text_editor->set_draw_tabs(EditorSettings::get_singleton()->get("text_editor/indent/draw_tabs"));
 	text_editor->set_draw_spaces(EditorSettings::get_singleton()->get("text_editor/indent/draw_spaces"));
+	text_editor->set_draw_indent_guides(EditorSettings::get_singleton()->get("text_editor/indent/draw_indent_guides"));
+	text_editor->set_highlight_active_indent_guide(EditorSettings::get_singleton()->get("text_editor/indent/highlight_active_indent_guide"));
 	text_editor->set_smooth_scroll_enabled(EditorSettings::get_singleton()->get("text_editor/navigation/smooth_scrolling"));
 	text_editor->set_v_scroll_speed(EditorSettings::get_singleton()->get("text_editor/navigation/v_scroll_speed"));
 	text_editor->set_draw_minimap(EditorSettings::get_singleton()->get("text_editor/navigation/show_minimap"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -433,6 +433,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/indent/auto_indent", true);
 	_initial_set("text_editor/indent/convert_indent_on_save", true);
 	_initial_set("text_editor/indent/draw_tabs", true);
+	_initial_set("text_editor/indent/draw_indent_guides", true);
+	_initial_set("text_editor/indent/highlight_active_indent_guide", true);
 	_initial_set("text_editor/indent/draw_spaces", false);
 
 	// Navigation
@@ -678,6 +680,8 @@ void EditorSettings::_load_default_text_editor_theme() {
 	_initial_set("text_editor/highlighting/brace_mismatch_color", Color(1, 0.2, 0.2));
 	_initial_set("text_editor/highlighting/current_line_color", Color(0.3, 0.5, 0.8, 0.15));
 	_initial_set("text_editor/highlighting/line_length_guideline_color", Color(0.3, 0.5, 0.8, 0.1));
+	_initial_set("text_editor/highlighting/indent_guide_color", Color(0.8, 0.8, 0.8, 0.1));
+	_initial_set("text_editor/highlighting/indent_active_guide_color", Color(0.8, 0.8, 0.8, 0.25));
 	_initial_set("text_editor/highlighting/word_highlighted_color", Color(0.8, 0.9, 0.9, 0.15));
 	_initial_set("text_editor/highlighting/number_color", Color(0.92, 0.58, 0.2));
 	_initial_set("text_editor/highlighting/function_color", Color(0.4, 0.64, 0.81));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1179,6 +1179,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color brace_mismatch_color = error_color;
 	const Color current_line_color = alpha1;
 	const Color line_length_guideline_color = dark_theme ? base_color : background_color;
+	const Color indent_guide_color = mono_color * Color(1, 1, 1, 0.3);
+	const Color indent_active_guide_color = mono_color * Color(1, 1, 1, 0.6);
 	const Color word_highlighted_color = alpha1;
 	const Color number_color = basetype_color.lerp(mono_color, dark_theme ? 0.5 : 0.3);
 	const Color function_color = main_color;
@@ -1217,6 +1219,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		setting->set_initial_value("text_editor/highlighting/brace_mismatch_color", brace_mismatch_color, true);
 		setting->set_initial_value("text_editor/highlighting/current_line_color", current_line_color, true);
 		setting->set_initial_value("text_editor/highlighting/line_length_guideline_color", line_length_guideline_color, true);
+		setting->set_initial_value("text_editor/highlighting/indent_guide_color", indent_guide_color, true);
+		setting->set_initial_value("text_editor/highlighting/indent_active_guide_color", indent_active_guide_color, true);
 		setting->set_initial_value("text_editor/highlighting/word_highlighted_color", word_highlighted_color, true);
 		setting->set_initial_value("text_editor/highlighting/number_color", number_color, true);
 		setting->set_initial_value("text_editor/highlighting/function_color", function_color, true);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -209,6 +209,8 @@ void ScriptTextEditor::_load_theme_settings() {
 	Color brace_mismatch_color = EDITOR_GET("text_editor/highlighting/brace_mismatch_color");
 	Color current_line_color = EDITOR_GET("text_editor/highlighting/current_line_color");
 	Color line_length_guideline_color = EDITOR_GET("text_editor/highlighting/line_length_guideline_color");
+	Color indent_guide_color = EDITOR_GET("text_editor/highlighting/indent_guide_color");
+	Color indent_active_guide_color = EDITOR_GET("text_editor/highlighting/indent_active_guide_color");
 	Color word_highlighted_color = EDITOR_GET("text_editor/highlighting/word_highlighted_color");
 	Color number_color = EDITOR_GET("text_editor/highlighting/number_color");
 	Color function_color = EDITOR_GET("text_editor/highlighting/function_color");
@@ -244,6 +246,8 @@ void ScriptTextEditor::_load_theme_settings() {
 	text_edit->add_theme_color_override("brace_mismatch_color", brace_mismatch_color);
 	text_edit->add_theme_color_override("current_line_color", current_line_color);
 	text_edit->add_theme_color_override("line_length_guideline_color", line_length_guideline_color);
+	text_edit->add_theme_color_override("indent_guide_color", indent_guide_color);
+	text_edit->add_theme_color_override("indent_active_guide_color", indent_active_guide_color);
 	text_edit->add_theme_color_override("word_highlighted_color", word_highlighted_color);
 	text_edit->add_theme_color_override("number_color", number_color);
 	text_edit->add_theme_color_override("function_color", function_color);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -100,6 +100,8 @@ void ShaderTextEditor::_load_theme_settings() {
 	Color brace_mismatch_color = EDITOR_GET("text_editor/highlighting/brace_mismatch_color");
 	Color current_line_color = EDITOR_GET("text_editor/highlighting/current_line_color");
 	Color line_length_guideline_color = EDITOR_GET("text_editor/highlighting/line_length_guideline_color");
+	Color indent_guide_color = EDITOR_GET("text_editor/highlighting/indent_guide_color");
+	Color indent_active_guide_color = EDITOR_GET("text_editor/highlighting/indent_active_guide_color");
 	Color word_highlighted_color = EDITOR_GET("text_editor/highlighting/word_highlighted_color");
 	Color number_color = EDITOR_GET("text_editor/highlighting/number_color");
 	Color function_color = EDITOR_GET("text_editor/highlighting/function_color");
@@ -130,6 +132,8 @@ void ShaderTextEditor::_load_theme_settings() {
 	get_text_edit()->add_theme_color_override("brace_mismatch_color", brace_mismatch_color);
 	get_text_edit()->add_theme_color_override("current_line_color", current_line_color);
 	get_text_edit()->add_theme_color_override("line_length_guideline_color", line_length_guideline_color);
+	get_text_edit()->add_theme_color_override("indent_guide_color", indent_guide_color);
+	get_text_edit()->add_theme_color_override("indent_active_guide_color", indent_active_guide_color);
 	get_text_edit()->add_theme_color_override("word_highlighted_color", word_highlighted_color);
 	get_text_edit()->add_theme_color_override("number_color", number_color);
 	get_text_edit()->add_theme_color_override("function_color", function_color);

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -88,6 +88,8 @@ void TextEditor::_load_theme_settings() {
 	Color brace_mismatch_color = EDITOR_GET("text_editor/highlighting/brace_mismatch_color");
 	Color current_line_color = EDITOR_GET("text_editor/highlighting/current_line_color");
 	Color line_length_guideline_color = EDITOR_GET("text_editor/highlighting/line_length_guideline_color");
+	Color indent_guide_color = EDITOR_GET("text_editor/highlighting/indent_guide_color");
+	Color indent_active_guide_color = EDITOR_GET("text_editor/highlighting/indent_active_guide_color");
 	Color word_highlighted_color = EDITOR_GET("text_editor/highlighting/word_highlighted_color");
 	Color number_color = EDITOR_GET("text_editor/highlighting/number_color");
 	Color function_color = EDITOR_GET("text_editor/highlighting/function_color");
@@ -121,6 +123,8 @@ void TextEditor::_load_theme_settings() {
 	text_edit->add_theme_color_override("brace_mismatch_color", brace_mismatch_color);
 	text_edit->add_theme_color_override("current_line_color", current_line_color);
 	text_edit->add_theme_color_override("line_length_guideline_color", line_length_guideline_color);
+	text_edit->add_theme_color_override("indent_guide_color", indent_guide_color);
+	text_edit->add_theme_color_override("indent_active_guide_color", indent_active_guide_color);
 	text_edit->add_theme_color_override("word_highlighted_color", word_highlighted_color);
 	text_edit->add_theme_color_override("number_color", number_color);
 	text_edit->add_theme_color_override("function_color", function_color);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -236,6 +236,8 @@ private:
 		Color code_folding_color;
 		Color current_line_color;
 		Color line_length_guideline_color;
+		Color indent_guide_color;
+		Color indent_active_guide_color;
 		Color brace_mismatch_color;
 		Color word_highlighted_color;
 		Color search_result_color;
@@ -357,6 +359,8 @@ private:
 	bool setting_row;
 	bool draw_tabs;
 	bool draw_spaces;
+	bool draw_indent_guides;
+	bool highlight_active_indent_guide;
 	bool override_selected_font_color;
 	bool cursor_changed_dirty;
 	bool text_changed_dirty;
@@ -616,6 +620,8 @@ public:
 	void fold_line(int p_line);
 	void unfold_line(int p_line);
 	void toggle_fold_line(int p_line);
+	int get_line_parent_fold(int p_line);
+	int get_fold_last_line(int p_start_line);
 
 	String get_text();
 	String get_line(int line) const;
@@ -717,6 +723,10 @@ public:
 	bool is_drawing_tabs() const;
 	void set_draw_spaces(bool p_draw);
 	bool is_drawing_spaces() const;
+	void set_draw_indent_guides(bool p_draw);
+	bool is_drawing_indent_guides(bool p_draw);
+	void set_highlight_active_indent_guide(bool p_draw);
+	bool get_highlight_active_indent_guide();
 	void set_override_selected_font_color(bool p_override_selected_font_color);
 	bool is_overriding_selected_font_color() const;
 


### PR DESCRIPTION
I have found it a bit difficult to know exactly in which indentation 'context' I am in when working on code (especially long code blocks, sometimes spanning more than 1 "page"). This attempts to resolve that issue. I know you can draw tabs (and spaces) but it does not 100% solve the issue, and I find that drawing tabs makes too much visual clutter.

This give a solution found in most common IDE applications. There are editor settings for
* On/off indent guides
* On/off Highlight active indent guide
* Colors

Where/when to draw lines is based on the 'folding' mechanism already in the editor.

My first time adding editor settings so please check I did it right :) Thanks

**Showcase**
![Pyt7xW4JcJ](https://user-images.githubusercontent.com/41730826/82215007-09475e80-995a-11ea-90c2-c87ac58772c0.gif)

**Before**
![godot windows tools 64_UZQPI83uSq](https://user-images.githubusercontent.com/41730826/82214997-0187ba00-995a-11ea-8e82-50641c10094f.png)

