### PR TITLE
SCons: Use the `release_debug` target by default for builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -112,7 +112,7 @@ opts.Add("arch", "Platform-dependent architecture (arm/arm64/x86/x64/mips/...)",
 opts.Add(EnumVariable("bits", "Target platform bits", "default", ("default", "32", "64")))
 opts.Add("p", "Platform (alias for 'platform')", "")
 opts.Add("platform", "Target platform (%s)" % ("|".join(platform_list),), "")
-opts.Add(EnumVariable("target", "Compilation target", "debug", ("debug", "release_debug", "release")))
+opts.Add(EnumVariable("target", "Compilation target", "release_debug", ("debug", "release_debug", "release")))
 opts.Add(EnumVariable("optimize", "Optimization type", "speed", ("speed", "size")))
 
 opts.Add(BoolVariable("tools", "Build the tools (a.k.a. the Godot editor)", True))


### PR DESCRIPTION
Most people building Godot don't need to run a debugger over it, so this lets them benefit from a significantly faster and smaller binary. I've seen dozens of people forget about `target=release_debug` and complain about low performance over the years, so this is probably worth it.

To get a binary with full debugging information, pass `target=debug` on the SCons command line.

Build scripts will need to be updated to follow this change.