### PR TITLE
Fixed uninitialised variable

### DIFF
--- a/core/callable_method_pointer.h
+++ b/core/callable_method_pointer.h
@@ -38,9 +38,9 @@
 #include "core/simple_type.h"
 
 class CallableCustomMethodPointerBase : public CallableCustom {
-	uint32_t *comp_ptr;
-	uint32_t comp_size;
-	uint32_t h;
+	uint32_t *comp_ptr = nullptr;
+	uint32_t comp_size = 0;
+	uint32_t h = 0;
 #ifdef DEBUG_METHODS_ENABLED
 	const char *text = "";
 #endif


### PR DESCRIPTION
The big change from before seems to have missed this.
Fix uninitialised variable in callable_method_pointer.h