### PR TITLE
Update the permission string for Oculus hand tracking

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -962,8 +962,8 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 								feature_required_list.push_back(hand_tracking_index == 2);
 								feature_versions.push_back(-1); // no version attribute should be added.
 
-								if (perms.find("oculus.permission.handtracking") == -1) {
-									perms.push_back("oculus.permission.handtracking");
+								if (perms.find("com.oculus.permission.HAND_TRACKING") == -1) {
+									perms.push_back("com.oculus.permission.HAND_TRACKING");
 								}
 							}
 						}


### PR DESCRIPTION
Update the permission string for Oculus hand tracking to match the [latest api update](https://developer.oculus.com/downloads/package/oculus-mobile-sdk/1.32.0/)

Fixes https://github.com/GodotVR/godot_oculus_mobile/issues/101