### PR TITLE
Avoid copying vector in constructor of PathMD5

### DIFF
--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -83,7 +83,7 @@ private:
 
 		PathMD5() {}
 
-		PathMD5(const Vector<uint8_t> p_buf) {
+		PathMD5(const Vector<uint8_t> &p_buf) {
 			a = *((uint64_t *)&p_buf[0]);
 			b = *((uint64_t *)&p_buf[8]);
 		}


### PR DESCRIPTION
Copying the vector is unnecessary here.