### PR TITLE
Style: Fix unnecessary semicolons that confused clang-format

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -94,10 +94,9 @@ uint64_t OS::get_system_time_msecs() const {
 	return 0;
 }
 
-void OS::debug_break(){
-
+void OS::debug_break() {
 	// something
-};
+}
 
 void OS::_set_logger(CompositeLogger *p_logger) {
 	if (_logger) {

--- a/core/safe_refcount.cpp
+++ b/core/safe_refcount.cpp
@@ -42,24 +42,27 @@
 	/* taken from boost */                                                             \
 	while (true) {                                                                     \
 		m_cpp_type tmp = static_cast<m_cpp_type const volatile &>(*(m_pw));            \
-		if (tmp == 0)                                                                  \
+		if (tmp == 0) {                                                                \
 			return 0; /* if zero, can't add to it anymore */                           \
-		if (m_win_cmpxchg((m_win_type volatile *)(m_pw), tmp + 1, tmp) == tmp)         \
+		}                                                                              \
+		if (m_win_cmpxchg((m_win_type volatile *)(m_pw), tmp + 1, tmp) == tmp) {       \
 			return tmp + 1;                                                            \
+		}                                                                              \
 	}
 
 #define ATOMIC_EXCHANGE_IF_GREATER_BODY(m_pw, m_val, m_win_type, m_win_cmpxchg, m_cpp_type) \
 	while (true) {                                                                          \
 		m_cpp_type tmp = static_cast<m_cpp_type const volatile &>(*(m_pw));                 \
-		if (tmp >= m_val)                                                                   \
+		if (tmp >= m_val) {                                                                 \
 			return tmp; /* already greater, or equal */                                     \
-		if (m_win_cmpxchg((m_win_type volatile *)(m_pw), m_val, tmp) == tmp)                \
+		}                                                                                   \
+		if (m_win_cmpxchg((m_win_type volatile *)(m_pw), m_val, tmp) == tmp) {              \
 			return m_val;                                                                   \
+		}                                                                                   \
 	}
 
-_ALWAYS_INLINE_ uint32_t _atomic_conditional_increment_impl(volatile uint32_t *pw){
-
-	ATOMIC_CONDITIONAL_INCREMENT_BODY(pw, LONG, InterlockedCompareExchange, uint32_t)
+_ALWAYS_INLINE_ uint32_t _atomic_conditional_increment_impl(volatile uint32_t *pw) {
+	ATOMIC_CONDITIONAL_INCREMENT_BODY(pw, LONG, InterlockedCompareExchange, uint32_t);
 }
 
 _ALWAYS_INLINE_ uint32_t _atomic_decrement_impl(volatile uint32_t *pw) {
@@ -78,14 +81,12 @@ _ALWAYS_INLINE_ uint32_t _atomic_add_impl(volatile uint32_t *pw, volatile uint32
 	return InterlockedAdd((LONG volatile *)pw, val);
 }
 
-_ALWAYS_INLINE_ uint32_t _atomic_exchange_if_greater_impl(volatile uint32_t *pw, volatile uint32_t val){
-
-	ATOMIC_EXCHANGE_IF_GREATER_BODY(pw, val, LONG, InterlockedCompareExchange, uint32_t)
+_ALWAYS_INLINE_ uint32_t _atomic_exchange_if_greater_impl(volatile uint32_t *pw, volatile uint32_t val) {
+	ATOMIC_EXCHANGE_IF_GREATER_BODY(pw, val, LONG, InterlockedCompareExchange, uint32_t);
 }
 
-_ALWAYS_INLINE_ uint64_t _atomic_conditional_increment_impl(volatile uint64_t *pw){
-
-	ATOMIC_CONDITIONAL_INCREMENT_BODY(pw, LONGLONG, InterlockedCompareExchange64, uint64_t)
+_ALWAYS_INLINE_ uint64_t _atomic_conditional_increment_impl(volatile uint64_t *pw) {
+	ATOMIC_CONDITIONAL_INCREMENT_BODY(pw, LONGLONG, InterlockedCompareExchange64, uint64_t);
 }
 
 _ALWAYS_INLINE_ uint64_t _atomic_decrement_impl(volatile uint64_t *pw) {
@@ -104,9 +105,8 @@ _ALWAYS_INLINE_ uint64_t _atomic_add_impl(volatile uint64_t *pw, volatile uint64
 	return InterlockedAdd64((LONGLONG volatile *)pw, val);
 }
 
-_ALWAYS_INLINE_ uint64_t _atomic_exchange_if_greater_impl(volatile uint64_t *pw, volatile uint64_t val){
-
-	ATOMIC_EXCHANGE_IF_GREATER_BODY(pw, val, LONGLONG, InterlockedCompareExchange64, uint64_t)
+_ALWAYS_INLINE_ uint64_t _atomic_exchange_if_greater_impl(volatile uint64_t *pw, volatile uint64_t val) {
+	ATOMIC_EXCHANGE_IF_GREATER_BODY(pw, val, LONGLONG, InterlockedCompareExchange64, uint64_t);
 }
 
 // The actual advertised functions; they'll call the right implementation

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -445,11 +445,6 @@ void RigidBodyBullet::assert_no_constraints() {
 	if (btBody->getNumConstraintRefs()) {
 		WARN_PRINT("A body with a joints is destroyed. Please check the implementation in order to destroy the joint before the body.");
 	}
-	/*for(int i = btBody->getNumConstraintRefs()-1; 0<=i; --i){
-        btTypedConstraint* btConst = btBody->getConstraintRef(i);
-        JointBullet* joint = static_cast<JointBullet*>( btConst->getUserConstraintPtr() );
-        space->removeConstraint(joint);
-    }*/
 }
 
 void RigidBodyBullet::set_activation_state(bool p_active) {

--- a/modules/camera/camera_win.cpp
+++ b/modules/camera/camera_win.cpp
@@ -53,9 +53,9 @@ public:
 	void deactivate_feed();
 };
 
-CameraFeedWindows::CameraFeedWindows(){
+CameraFeedWindows::CameraFeedWindows() {
 	///@TODO implement this, should store information about our available camera
-};
+}
 
 CameraFeedWindows::~CameraFeedWindows() {
 	// make sure we stop recording if we are!
@@ -75,24 +75,20 @@ bool CameraFeedWindows::activate_feed() {
 ///@TODO we should probably have a callback method here that is being called by the
 // camera API which provides frames and call back into the CameraServer to update our texture
 
-void CameraFeedWindows::deactivate_feed(){
+void CameraFeedWindows::deactivate_feed() {
 	///@TODO this should deactivate our camera and stop the process of capturing frames
-};
+}
 
 //////////////////////////////////////////////////////////////////////////
 // CameraWindows - Subclass for our camera server on windows
 
-void CameraWindows::add_active_cameras(){
+void CameraWindows::add_active_cameras() {
 	///@TODO scan through any active cameras and create CameraFeedWindows objects for them
-};
+}
 
 CameraWindows::CameraWindows() {
 	// Find cameras active right now
 	add_active_cameras();
 
 	// need to add something that will react to devices being connected/removed...
-};
-
-CameraWindows::~CameraWindows(){
-
 };

--- a/modules/camera/camera_win.h
+++ b/modules/camera/camera_win.h
@@ -40,7 +40,7 @@ private:
 
 public:
 	CameraWindows();
-	~CameraWindows();
+	~CameraWindows() {}
 };
 
 #endif /* CAMERAWIN_H */

--- a/modules/gdnavigation/nav_map.cpp
+++ b/modules/gdnavigation/nav_map.cpp
@@ -299,7 +299,6 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 					left = p->poly->points[prev].pos;
 					right = p->poly->points[prev_n].pos;
 
-					//if (CLOCK_TANGENT(apex_point,left,(left+right)*0.5).dot(up) < 0){
 					if (p->poly->clockwise) {
 						SWAP(left, right);
 					}

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -448,12 +448,6 @@ void MobileVRInterface::process() {
 	};
 };
 
-void MobileVRInterface::notification(int p_what){
-	_THREAD_SAFE_METHOD_
-
-	// nothing to do here, I guess we could pauze our sensors...
-}
-
 MobileVRInterface::MobileVRInterface() {
 	initialized = false;
 

--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -142,7 +142,7 @@ public:
 	virtual void commit_for_eye(XRInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect);
 
 	virtual void process();
-	virtual void notification(int p_what);
+	virtual void notification(int p_what) {}
 
 	MobileVRInterface();
 	~MobileVRInterface();

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -581,9 +581,8 @@ bool VideoStreamPlaybackTheora::is_paused() const {
 	return paused;
 };
 
-void VideoStreamPlaybackTheora::set_loop(bool p_enable){
-
-};
+void VideoStreamPlaybackTheora::set_loop(bool p_enable) {
+}
 
 bool VideoStreamPlaybackTheora::has_loop() const {
 	return false;
@@ -605,10 +604,8 @@ float VideoStreamPlaybackTheora::get_playback_position() const {
 	return get_time();
 };
 
-void VideoStreamPlaybackTheora::seek(float p_time){
-
-	// no
-};
+void VideoStreamPlaybackTheora::seek(float p_time) {
+}
 
 void VideoStreamPlaybackTheora::set_mix_callback(AudioMixCallback p_callback, void *p_userdata) {
 	mix_callback = p_callback;

--- a/platform/android/java/plugins/godotpayment/src/main/java/org/godotengine/godot/plugin/payment/PurchaseTask.java
+++ b/platform/android/java/plugins/godotpayment/src/main/java/org/godotengine/godot/plugin/payment/PurchaseTask.java
@@ -56,7 +56,7 @@ abstract public class PurchaseTask {
 		PaymentsCache pc = new PaymentsCache(context);
 		Boolean isBlocked = pc.getConsumableFlag("block", sku);
 		/*
-		if(isBlocked){
+		if(isBlocked) {
 			Log.d("XXX", "Is awaiting payment confirmation");
 			error("Awaiting payment confirmation");
 			return;

--- a/platform/uwp/thread_uwp.cpp
+++ b/platform/uwp/thread_uwp.cpp
@@ -59,11 +59,3 @@ void ThreadUWP::make_default() {
 	get_thread_id_func = get_thread_id_func_uwp;
 	wait_to_finish_func = wait_to_finish_func_uwp;
 };
-
-ThreadUWP::ThreadUWP(){
-
-};
-
-ThreadUWP::~ThreadUWP(){
-
-};

--- a/platform/uwp/thread_uwp.h
+++ b/platform/uwp/thread_uwp.h
@@ -44,16 +44,16 @@ class ThreadUWP : public Thread {
 	static ID get_thread_id_func_uwp();
 	static void wait_to_finish_func_uwp(Thread *p_thread);
 
-	ThreadUWP();
+	ThreadUWP() {}
 
 public:
 	virtual ID get_id() const;
 
 	static void make_default();
 
-	~ThreadUWP();
+	~ThreadUWP() {}
 };
 
-#endif
+#endif // UWP_ENABLED
 
-#endif
+#endif // THREAD_UWP_H

--- a/scene/3d/proximity_group_3d.cpp
+++ b/scene/3d/proximity_group_3d.cpp
@@ -179,14 +179,5 @@ void ProximityGroup3D::_bind_methods() {
 };
 
 ProximityGroup3D::ProximityGroup3D() {
-	group_version = 0;
-	dispatch_mode = MODE_PROXY;
-
-	cell_size = 1.0;
-	grid_radius = Vector3(1, 1, 1);
 	set_notify_transform(true);
-};
-
-ProximityGroup3D::~ProximityGroup3D(){
-
 };

--- a/scene/3d/proximity_group_3d.h
+++ b/scene/3d/proximity_group_3d.h
@@ -49,14 +49,14 @@ public:
 
 	void _notification(int p_what);
 
-	DispatchMode dispatch_mode;
+	DispatchMode dispatch_mode = MODE_PROXY;
 
 	Map<StringName, uint32_t> groups;
 	String group_name;
 
-	float cell_size;
-	Vector3 grid_radius;
-	uint32_t group_version;
+	float cell_size = 1.0;
+	Vector3 grid_radius = Vector3(1, 1, 1);
+	uint32_t group_version = 0;
 
 	void add_groups(int *p_cell, String p_base, int p_depth);
 	void _new_group(StringName p_name);
@@ -78,7 +78,7 @@ public:
 	void broadcast(String p_name, Variant p_params);
 
 	ProximityGroup3D();
-	~ProximityGroup3D();
+	~ProximityGroup3D() {}
 };
 
 VARIANT_ENUM_CAST(ProximityGroup3D::DispatchMode);

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "xr_nodes.h"
+
 #include "core/input/input.h"
 #include "servers/xr/xr_interface.h"
 #include "servers/xr_server.h"
@@ -166,14 +167,6 @@ Vector<Plane> XRCamera3D::get_frustum() const {
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 	CameraMatrix cm = xr_interface->get_projection_for_eye(XRInterface::EYE_MONO, viewport_size.aspect(), get_znear(), get_zfar());
 	return cm.get_projection_planes(get_camera_transform());
-};
-
-XRCamera3D::XRCamera3D(){
-	// nothing to do here yet for now..
-};
-
-XRCamera3D::~XRCamera3D(){
-	// nothing to do here yet for now..
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -382,16 +375,6 @@ String XRController3D::get_configuration_warning() const {
 	return String();
 };
 
-XRController3D::XRController3D() {
-	controller_id = 1;
-	is_active = true;
-	button_states = 0;
-};
-
-XRController3D::~XRController3D(){
-	// nothing to do here yet for now..
-};
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void XRAnchor3D::_notification(int p_what) {
@@ -522,15 +505,6 @@ Ref<Mesh> XRAnchor3D::get_mesh() const {
 	return mesh;
 }
 
-XRAnchor3D::XRAnchor3D() {
-	anchor_id = 1;
-	is_active = true;
-};
-
-XRAnchor3D::~XRAnchor3D(){
-	// nothing to do here yet for now..
-};
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 String XROrigin3D::get_configuration_warning() const {
@@ -614,12 +588,4 @@ void XROrigin3D::_notification(int p_what) {
 			interface->notification(p_what);
 		}
 	}
-};
-
-XROrigin3D::XROrigin3D() {
-	tracked_camera = nullptr;
-};
-
-XROrigin3D::~XROrigin3D(){
-	// nothing to do here yet for now..
 };

--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -57,8 +57,8 @@ public:
 	virtual Vector3 project_position(const Point2 &p_point, float p_z_depth) const;
 	virtual Vector<Plane> get_frustum() const;
 
-	XRCamera3D();
-	~XRCamera3D();
+	XRCamera3D() {}
+	~XRCamera3D() {}
 };
 
 /*
@@ -71,9 +71,9 @@ class XRController3D : public Node3D {
 	GDCLASS(XRController3D, Node3D);
 
 private:
-	int controller_id;
-	bool is_active;
-	int button_states;
+	int controller_id = 1;
+	bool is_active = true;
+	int button_states = 0;
 	Ref<Mesh> mesh;
 
 protected:
@@ -99,8 +99,8 @@ public:
 
 	String get_configuration_warning() const;
 
-	XRController3D();
-	~XRController3D();
+	XRController3D() {}
+	~XRController3D() {}
 };
 
 /*
@@ -112,8 +112,8 @@ class XRAnchor3D : public Node3D {
 	GDCLASS(XRAnchor3D, Node3D);
 
 private:
-	int anchor_id;
-	bool is_active;
+	int anchor_id = 1;
+	bool is_active = true;
 	Vector3 size;
 	Ref<Mesh> mesh;
 
@@ -135,8 +135,8 @@ public:
 
 	String get_configuration_warning() const;
 
-	XRAnchor3D();
-	~XRAnchor3D();
+	XRAnchor3D() {}
+	~XRAnchor3D() {}
 };
 
 /*
@@ -151,7 +151,7 @@ class XROrigin3D : public Node3D {
 	GDCLASS(XROrigin3D, Node3D);
 
 private:
-	XRCamera3D *tracked_camera;
+	XRCamera3D *tracked_camera = nullptr;
 
 protected:
 	void _notification(int p_what);
@@ -166,8 +166,8 @@ public:
 	float get_world_scale() const;
 	void set_world_scale(float p_world_scale);
 
-	XROrigin3D();
-	~XROrigin3D();
+	XROrigin3D() {}
+	~XROrigin3D() {}
 };
 
 #endif /* XR_NODES_H */

--- a/servers/audio/audio_driver_dummy.cpp
+++ b/servers/audio/audio_driver_dummy.cpp
@@ -114,11 +114,3 @@ void AudioDriverDummy::finish() {
 	memdelete(thread);
 	thread = nullptr;
 };
-
-AudioDriverDummy::AudioDriverDummy() {
-	thread = nullptr;
-};
-
-AudioDriverDummy::~AudioDriverDummy(){
-
-};

--- a/servers/audio/audio_driver_dummy.h
+++ b/servers/audio/audio_driver_dummy.h
@@ -37,7 +37,7 @@
 #include "core/os/thread.h"
 
 class AudioDriverDummy : public AudioDriver {
-	Thread *thread;
+	Thread *thread = nullptr;
 	Mutex mutex;
 
 	int32_t *samples_in;
@@ -67,8 +67,8 @@ public:
 	virtual void unlock();
 	virtual void finish();
 
-	AudioDriverDummy();
-	~AudioDriverDummy();
+	AudioDriverDummy() {}
+	~AudioDriverDummy() {}
 };
 
 #endif

--- a/servers/physics_2d/physics_server_2d_sw.cpp
+++ b/servers/physics_2d/physics_server_2d_sw.cpp
@@ -1344,7 +1344,3 @@ PhysicsServer2DSW::PhysicsServer2DSW() {
 	using_threads = int(ProjectSettings::get_singleton()->get("physics/2d/thread_model")) == 2;
 	flushing_queries = false;
 };
-
-PhysicsServer2DSW::~PhysicsServer2DSW(){
-
-};

--- a/servers/physics_2d/physics_server_2d_sw.h
+++ b/servers/physics_2d/physics_server_2d_sw.h
@@ -288,7 +288,7 @@ public:
 	int get_process_info(ProcessInfo p_info);
 
 	PhysicsServer2DSW();
-	~PhysicsServer2DSW();
+	~PhysicsServer2DSW() {}
 };
 
 #endif

--- a/servers/physics_3d/physics_server_3d_sw.cpp
+++ b/servers/physics_3d/physics_server_3d_sw.cpp
@@ -1320,10 +1320,6 @@ void PhysicsServer3DSW::step(real_t p_step) {
 #endif
 }
 
-void PhysicsServer3DSW::sync(){
-
-};
-
 void PhysicsServer3DSW::flush_queries() {
 #ifndef _3D_DISABLED
 
@@ -1450,8 +1446,4 @@ PhysicsServer3DSW::PhysicsServer3DSW() {
 
 	active = true;
 	flushing_queries = false;
-};
-
-PhysicsServer3DSW::~PhysicsServer3DSW(){
-
 };

--- a/servers/physics_3d/physics_server_3d_sw.h
+++ b/servers/physics_3d/physics_server_3d_sw.h
@@ -365,7 +365,7 @@ public:
 	virtual void set_active(bool p_active);
 	virtual void init();
 	virtual void step(real_t p_step);
-	virtual void sync();
+	virtual void sync() {}
 	virtual void flush_queries();
 	virtual void finish();
 
@@ -374,7 +374,7 @@ public:
 	int get_process_info(ProcessInfo p_info);
 
 	PhysicsServer3DSW();
-	~PhysicsServer3DSW();
+	~PhysicsServer3DSW() {}
 };
 
 #endif

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -134,9 +134,9 @@ bool XRInterface::get_anchor_detection_is_enabled() const {
 	return false;
 };
 
-void XRInterface::set_anchor_detection_is_enabled(bool p_enable){
+void XRInterface::set_anchor_detection_is_enabled(bool p_enable) {
 	// don't do anything here, this needs to be implemented on AR interface to enable/disable things like plane detection etc.
-};
+}
 
 int XRInterface::get_camera_feed_id() {
 	// don't do anything here, this needs to be implemented on AR interface to enable/disable things like plane detection etc.

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -232,7 +232,3 @@ XRPositionalTracker::XRPositionalTracker() {
 	hand = TRACKER_HAND_UNKNOWN;
 	rumble = 0.0;
 };
-
-XRPositionalTracker::~XRPositionalTracker(){
-
-};

--- a/servers/xr/xr_positional_tracker.h
+++ b/servers/xr/xr_positional_tracker.h
@@ -96,7 +96,7 @@ public:
 	Transform get_transform(bool p_adjust_by_reference_frame) const;
 
 	XRPositionalTracker();
-	~XRPositionalTracker();
+	~XRPositionalTracker() {}
 };
 
 VARIANT_ENUM_CAST(XRPositionalTracker::TrackerHand);


### PR DESCRIPTION
@BastiaanOlij `clang-format` doesn't like your habit to put semicolons everywhere ;)

If anyone knows a good tool to remove such stray semicolons, that'd be great. Mass search and replace is sadly not a good option as AFAIK enums, classes and structs still require them.