### PR TITLE
[Windows] Add quotes only to the command line arguments with special characters.

### DIFF
--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -99,6 +99,8 @@ protected:
 	virtual void finalize_core();
 	virtual String get_stdin_string(bool p_block);
 
+	String _quote_command_line_argument(const String &p_text) const;
+
 	struct ProcessInfo {
 		STARTUPINFO si;
 		PROCESS_INFORMATION pi;


### PR DESCRIPTION
Fixes #38803