### PR TITLE
Style: Remove unnecessary semicolons from `core`

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -117,7 +117,7 @@ PackedStringArray _ResourceLoader::get_dependencies(const String &p_path) {
 	}
 
 	return ret;
-};
+}
 
 bool _ResourceLoader::has_cached(const String &p_path) {
 	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
@@ -224,7 +224,7 @@ Error _OS::shell_open(String p_uri) {
 		WARN_PRINT("Attempting to open an URL with the \"user://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_open()`.");
 	}
 	return OS::get_singleton()->shell_open(p_uri);
-};
+}
 
 int _OS::execute(const String &p_path, const Vector<String> &p_arguments, bool p_blocking, Array p_output, bool p_read_stderr) {
 	OS::ProcessID pid = -2;
@@ -252,7 +252,7 @@ Error _OS::kill(int p_pid) {
 
 int _OS::get_process_id() const {
 	return OS::get_singleton()->get_process_id();
-};
+}
 
 bool _OS::has_environment(const String &p_var) const {
 	return OS::get_singleton()->has_environment(p_var);
@@ -286,7 +286,7 @@ String _OS::get_model_name() const {
 
 Error _OS::set_thread_name(const String &p_name) {
 	return Thread::set_name(p_name);
-};
+}
 
 bool _OS::has_feature(const String &p_feature) const {
 	return OS::get_singleton()->has_feature(p_feature);
@@ -620,7 +620,7 @@ void _OS::print_resources_by_type(const Vector<String> &p_types) {
 
 		type_count[r->get_class()]++;
 	}
-};
+}
 
 void _OS::print_all_resources(const String &p_to_file) {
 	OS::get_singleton()->print_all_resources(p_to_file);
@@ -636,7 +636,7 @@ void _OS::dump_resources_to_file(const String &p_file) {
 
 String _OS::get_user_data_dir() const {
 	return OS::get_singleton()->get_user_data_dir();
-};
+}
 
 bool _OS::is_debug_build() const {
 #ifdef DEBUG_ENABLED
@@ -840,8 +840,8 @@ Variant _Geometry::segment_intersects_segment_2d(const Vector2 &p_from_a, const 
 		return result;
 	} else {
 		return Variant();
-	};
-};
+	}
+}
 
 Variant _Geometry::line_intersects_line_2d(const Vector2 &p_from_a, const Vector2 &p_dir_a, const Vector2 &p_from_b, const Vector2 &p_dir_b) {
 	Vector2 result;
@@ -1071,7 +1071,7 @@ Dictionary _Geometry::make_atlas(const Vector<Size2> &p_rects) {
 	Vector<Size2i> rects;
 	for (int i = 0; i < p_rects.size(); i++) {
 		rects.push_back(p_rects[i]);
-	};
+	}
 
 	Vector<Point2i> result;
 	Size2i size;
@@ -1082,13 +1082,13 @@ Dictionary _Geometry::make_atlas(const Vector<Size2> &p_rects) {
 	Vector<Point2> r_result;
 	for (int i = 0; i < result.size(); i++) {
 		r_result.push_back(result[i]);
-	};
+	}
 
 	ret["points"] = r_result;
 	ret["size"] = r_size;
 
 	return ret;
-};
+}
 
 int _Geometry::get_uv84_normal_bit(const Vector3 &p_vector) {
 	return Geometry::get_uv84_normal_bit(p_vector);
@@ -1436,13 +1436,13 @@ void _File::store_pascal_string(const String &p_string) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	f->store_pascal_string(p_string);
-};
+}
 
 String _File::get_pascal_string() {
 	ERR_FAIL_COND_V_MSG(!f, "", "File must be opened before use.");
 
 	return f->get_pascal_string();
-};
+}
 
 void _File::store_line(const String &p_string) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
@@ -1784,7 +1784,7 @@ String _Marshalls::variant_to_base64(const Variant &p_var, bool p_full_objects) 
 	ERR_FAIL_COND_V(ret == "", ret);
 
 	return ret;
-};
+}
 
 Variant _Marshalls::base64_to_variant(const String &p_str, bool p_allow_objects) {
 	int strlen = p_str.length();
@@ -1802,13 +1802,13 @@ Variant _Marshalls::base64_to_variant(const String &p_str, bool p_allow_objects)
 	ERR_FAIL_COND_V_MSG(err != OK, Variant(), "Error when trying to decode Variant.");
 
 	return v;
-};
+}
 
 String _Marshalls::raw_to_base64(const Vector<uint8_t> &p_arr) {
 	String ret = CryptoCore::b64_encode_str(p_arr.ptr(), p_arr.size());
 	ERR_FAIL_COND_V(ret == "", ret);
 	return ret;
-};
+}
 
 Vector<uint8_t> _Marshalls::base64_to_raw(const String &p_str) {
 	int strlen = p_str.length();
@@ -1825,14 +1825,14 @@ Vector<uint8_t> _Marshalls::base64_to_raw(const String &p_str) {
 	buf.resize(arr_len);
 
 	return buf;
-};
+}
 
 String _Marshalls::utf8_to_base64(const String &p_str) {
 	CharString cstr = p_str.utf8();
 	String ret = CryptoCore::b64_encode_str((unsigned char *)cstr.get_data(), cstr.length());
 	ERR_FAIL_COND_V(ret == "", ret);
 	return ret;
-};
+}
 
 String _Marshalls::base64_to_utf8(const String &p_str) {
 	int strlen = p_str.length();
@@ -1849,7 +1849,7 @@ String _Marshalls::base64_to_utf8(const String &p_str) {
 	String ret = String::utf8((char *)&w[0]);
 
 	return ret;
-};
+}
 
 void _Marshalls::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("variant_to_base64", "variant", "full_objects"), &_Marshalls::variant_to_base64, DEFVAL(false));
@@ -1860,7 +1860,7 @@ void _Marshalls::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("utf8_to_base64", "utf8_str"), &_Marshalls::utf8_to_base64);
 	ClassDB::bind_method(D_METHOD("base64_to_utf8", "base64_str"), &_Marshalls::base64_to_utf8);
-};
+}
 
 ////// _Semaphore //////
 

--- a/core/color.cpp
+++ b/core/color.cpp
@@ -588,7 +588,7 @@ void Color::operator/=(const real_t &rvalue) {
 		b = b / rvalue;
 		a = a / rvalue;
 	}
-};
+}
 
 Color Color::operator-() const {
 	return Color(

--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -161,10 +161,10 @@ public:
 		int len = size();
 		for (int i = p_index; i < len - 1; i++) {
 			p[i] = p[i + 1];
-		};
+		}
 
 		resize(len - 1);
-	};
+	}
 
 	Error insert(int p_pos, const T &p_val) {
 		ERR_FAIL_INDEX_V(p_pos, size() + 1, ERR_INVALID_PARAMETER);
@@ -175,7 +175,7 @@ public:
 		set(p_pos, p_val);
 
 		return OK;
-	};
+	}
 
 	int find(const T &p_val, int p_from = 0) const;
 

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -178,13 +178,13 @@ Error RemoteDebuggerPeerTCP::connect_to_host(const String &p_host, uint16_t p_po
 			const int ms = waits[i];
 			OS::get_singleton()->delay_usec(ms * 1000);
 			print_verbose("Remote Debugger: Connection failed with status: '" + String::num(tcp_client->get_status()) + "', retrying in " + String::num(ms) + " msec.");
-		};
-	};
+		}
+	}
 
 	if (tcp_client->get_status() != StreamPeerTCP::STATUS_CONNECTED) {
 		ERR_PRINT("Remote Debugger: Unable to connect. Status: " + String::num(tcp_client->get_status()) + ".");
 		return FAILED;
-	};
+	}
 	connected = true;
 #ifndef NO_THREADS
 	running = true;

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -188,11 +188,11 @@ Object *Engine::get_singleton_object(const String &p_name) const {
 	const Map<StringName, Object *>::Element *E = singleton_ptrs.find(p_name);
 	ERR_FAIL_COND_V_MSG(!E, nullptr, "Failed to retrieve non-existent singleton '" + p_name + "'.");
 	return E->get();
-};
+}
 
 bool Engine::has_singleton(const String &p_name) const {
 	return singleton_ptrs.has(p_name);
-};
+}
 
 void Engine::get_singletons(List<Singleton> *p_singletons) {
 	for (List<Singleton>::Element *E = singletons.front(); E; E = E->next()) {

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1399,7 +1399,7 @@ int Image::_get_dst_image_size(int p_width, int p_height, Format p_format, int &
 			h = MAX(minh, h >> 1);
 		}
 		mm++;
-	};
+	}
 
 	r_mipmaps = mm;
 	return size;
@@ -2031,7 +2031,7 @@ void Image::create(const char **p_xpm) {
 								case 5:
 									col_b |= v;
 									break;
-							};
+							}
 						}
 
 						// magenta mask

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -339,7 +339,7 @@ float Input::get_joy_axis(int p_device, int p_axis) const {
 String Input::get_joy_name(int p_idx) {
 	_THREAD_SAFE_METHOD_
 	return joy_names[p_idx].name;
-};
+}
 
 Vector2 Input::get_joy_vibration_strength(int p_device) {
 	if (joy_vibration.has(p_device)) {
@@ -374,7 +374,7 @@ static String _hex_str(uint8_t p_byte) {
 	ret[1] = dict[p_byte & 0xf];
 
 	return ret;
-};
+}
 
 void Input::joy_connection_changed(int p_idx, bool p_connected, String p_name, String p_guid) {
 	_THREAD_SAFE_METHOD_
@@ -388,8 +388,8 @@ void Input::joy_connection_changed(int p_idx, bool p_connected, String p_name, S
 			int uidlen = MIN(p_name.length(), 16);
 			for (int i = 0; i < uidlen; i++) {
 				uidname = uidname + _hex_str(p_name[i]);
-			};
-		};
+			}
+		}
 		js.uid = uidname;
 		js.connected = true;
 		int mapping = fallback_mapping;
@@ -397,8 +397,8 @@ void Input::joy_connection_changed(int p_idx, bool p_connected, String p_name, S
 			if (js.uid == map_db[i].uid) {
 				mapping = i;
 				js.name = map_db[i].name;
-			};
-		};
+			}
+		}
 		js.mapping = mapping;
 	} else {
 		js.connected = false;
@@ -409,11 +409,11 @@ void Input::joy_connection_changed(int p_idx, bool p_connected, String p_name, S
 		for (int i = 0; i < JOY_AXIS_MAX; i++) {
 			set_joy_axis(p_idx, i, 0.0f);
 		}
-	};
+	}
 	joy_names[p_idx] = js;
 
 	emit_signal("joy_connection_changed", p_idx, p_connected);
-};
+}
 
 Vector3 Input::get_gravity() const {
 	_THREAD_SAFE_METHOD_
@@ -918,7 +918,7 @@ void Input::joy_axis(int p_device, int p_axis, const JoyAxis &p_value) {
 	if (joy.mapping == -1) {
 		_axis_event(p_device, p_axis, val);
 		return;
-	};
+	}
 
 	JoyEvent map = _get_mapped_axis_event(map_db[joy.mapping], p_axis, p_value);
 
@@ -1003,7 +1003,7 @@ void Input::joy_hat(int p_device, int p_val) {
 
 	if (joy.mapping != -1) {
 		_get_mapped_hat_events(map_db[joy.mapping], 0, map);
-	};
+	}
 
 	int cur_val = joy_names[p_device].hat_current;
 
@@ -1042,7 +1042,7 @@ void Input::_axis_event(int p_device, int p_axis, float p_value) {
 	ievent->set_axis_value(p_value);
 
 	parse_input_event(ievent);
-};
+}
 
 Input::JoyEvent Input::_get_mapped_button_event(const JoyDeviceMapping &mapping, int p_button) {
 	JoyEvent event;
@@ -1274,10 +1274,10 @@ void Input::parse_mapping(String p_mapping) {
 		}
 
 		mapping.bindings.push_back(binding);
-	};
+	}
 
 	map_db.push_back(mapping);
-};
+}
 
 void Input::add_joy_mapping(String p_mapping, bool p_update_existing) {
 	parse_mapping(p_mapping);

--- a/core/io/file_access_buffered_fa.h
+++ b/core/io/file_access_buffered_fa.h
@@ -58,35 +58,35 @@ class FileAccessBufferedFA : public FileAccessBuffered {
 			f.get_buffer(cache.buffer.ptrw(), p_size);
 
 			return p_size;
-		};
-	};
+		}
+	}
 
 	static FileAccess *create() {
 		return memnew(FileAccessBufferedFA<T>());
-	};
+	}
 
 protected:
 	virtual void _set_access_type(AccessType p_access) {
 		f._set_access_type(p_access);
 		FileAccessBuffered::_set_access_type(p_access);
-	};
+	}
 
 public:
 	void flush() {
 		f.flush();
-	};
+	}
 
 	void store_8(uint8_t p_dest) {
 		f.store_8(p_dest);
-	};
+	}
 
 	void store_buffer(const uint8_t *p_src, int p_length) {
 		f.store_buffer(p_src, p_length);
-	};
+	}
 
 	bool file_exists(const String &p_name) {
 		return f.file_exists(p_name);
-	};
+	}
 
 	Error _open(const String &p_path, int p_mode_flags) {
 		close();
@@ -106,7 +106,7 @@ public:
 		cache.offset = 0;
 
 		return set_error(OK);
-	};
+	}
 
 	void close() {
 		f.close();
@@ -119,7 +119,7 @@ public:
 		cache.buffer.resize(0);
 		cache.offset = 0;
 		set_error(OK);
-	};
+	}
 
 	virtual uint64_t _get_modified_time(const String &p_file) {
 		return f._get_modified_time(p_file);

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -145,7 +145,7 @@ int FileAccessMemory::get_buffer(uint8_t *p_dst, int p_length) const {
 
 	if (read < p_length) {
 		WARN_PRINT("Reading less data than requested");
-	};
+	}
 
 	copymem(p_dst, &data[pos], read);
 	pos += p_length;

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -38,11 +38,11 @@ Error PackedData::add_pack(const String &p_path, bool p_replace_files) {
 	for (int i = 0; i < sources.size(); i++) {
 		if (sources[i]->try_open_pack(p_path, p_replace_files)) {
 			return OK;
-		};
-	};
+		}
+	}
 
 	return ERR_FILE_UNRECOGNIZED;
-};
+}
 
 void PackedData::add_path(const String &pkg_path, const String &path, uint64_t ofs, uint64_t size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files) {
 	PathMD5 pmd5(path.md5_buffer());
@@ -96,7 +96,7 @@ void PackedData::add_pack_source(PackSource *p_source) {
 	if (p_source != nullptr) {
 		sources.push_back(p_source);
 	}
-};
+}
 
 PackedData *PackedData::singleton = nullptr;
 
@@ -192,16 +192,16 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files) 
 		uint8_t md5[16];
 		f->get_buffer(md5, 16);
 		PackedData::get_singleton()->add_path(p_path, path, ofs, size, md5, this, p_replace_files);
-	};
+	}
 
 	f->close();
 	memdelete(f);
 	return true;
-};
+}
 
 FileAccess *PackedSourcePCK::get_file(const String &p_path, PackedData::PackedFile *p_file) {
 	return memnew(FileAccessPack(p_path, *p_file));
-};
+}
 
 //////////////////////////////////////////////////////////////////
 

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -79,7 +79,7 @@ private:
 
 		bool operator==(const PathMD5 &p_md5) const {
 			return a == p_md5.a && b == p_md5.b;
-		};
+		}
 
 		PathMD5() {}
 

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -54,7 +54,7 @@ struct _IP_ResolverPrivate {
 
 		QueueItem() {
 			clear();
-		};
+		}
 	};
 
 	QueueItem queue[IP::RESOLVER_MAX_QUERIES];

--- a/core/io/ip_address.cpp
+++ b/core/io/ip_address.cpp
@@ -58,7 +58,7 @@ IP_Address::operator String() const {
 		}
 		uint16_t num = (field8[i * 2] << 8) + field8[i * 2 + 1];
 		ret = ret + String::num_int64(num, 16);
-	};
+	}
 
 	return ret;
 }
@@ -68,7 +68,7 @@ static void _parse_hex(const String &p_string, int p_start, uint8_t *p_dst) {
 	for (int i = p_start; i < p_start + 4; i++) {
 		if (i >= p_string.length()) {
 			break;
-		};
+		}
 
 		int n = 0;
 		CharType c = p_string[i];
@@ -82,14 +82,14 @@ static void _parse_hex(const String &p_string, int p_start, uint8_t *p_dst) {
 			break;
 		} else {
 			ERR_FAIL_MSG("Invalid character in IPv6 address: " + p_string + ".");
-		};
+		}
 		ret = ret << 4;
 		ret += n;
-	};
+	}
 
 	p_dst[0] = ret >> 8;
 	p_dst[1] = ret & 0xff;
-};
+}
 
 void IP_Address::_parse_ipv6(const String &p_string) {
 	static const int parts_total = 8;
@@ -105,11 +105,11 @@ void IP_Address::_parse_ipv6(const String &p_string) {
 		if (c == ':') {
 			if (i == 0) {
 				continue; // next must be a ":"
-			};
+			}
 			if (!part_found) {
 				part_skip = true;
 				parts[parts_idx++] = -1;
-			};
+			}
 			part_found = false;
 		} else if (c == '.') {
 			part_ipv4 = true;
@@ -119,33 +119,33 @@ void IP_Address::_parse_ipv6(const String &p_string) {
 				parts[parts_idx++] = i;
 				part_found = true;
 				++parts_count;
-			};
+			}
 		} else {
 			ERR_FAIL_MSG("Invalid character in IPv6 address: " + p_string + ".");
-		};
-	};
+		}
+	}
 
 	int parts_extra = 0;
 	if (part_skip) {
 		parts_extra = parts_total - parts_count;
-	};
+	}
 
 	int idx = 0;
 	for (int i = 0; i < parts_idx; i++) {
 		if (parts[i] == -1) {
 			for (int j = 0; j < parts_extra; j++) {
 				field16[idx++] = 0;
-			};
+			}
 			continue;
-		};
+		}
 
 		if (part_ipv4 && i == parts_idx - 1) {
 			_parse_ipv4(p_string, parts[i], (uint8_t *)&field16[idx]); // should be the last one
 		} else {
 			_parse_hex(p_string, parts[i], (uint8_t *)&(field16[idx++]));
-		};
-	};
-};
+		}
+	}
+}
 
 void IP_Address::_parse_ipv4(const String &p_string, int p_start, uint8_t *p_ret) {
 	String ip;
@@ -153,20 +153,20 @@ void IP_Address::_parse_ipv4(const String &p_string, int p_start, uint8_t *p_ret
 		ip = p_string.substr(p_start, p_string.length() - p_start);
 	} else {
 		ip = p_string;
-	};
+	}
 
 	int slices = ip.get_slice_count(".");
 	ERR_FAIL_COND_MSG(slices != 4, "Invalid IP address string: " + ip + ".");
 	for (int i = 0; i < 4; i++) {
 		p_ret[i] = ip.get_slicec('.', i).to_int();
 	}
-};
+}
 
 void IP_Address::clear() {
 	memset(&field8[0], 0, sizeof(field8));
 	valid = false;
 	wildcard = false;
-};
+}
 
 bool IP_Address::is_ipv4() const {
 	return (field32[0] == 0 && field32[1] == 0 && field16[4] == 0 && field16[5] == 0xffff);
@@ -224,7 +224,7 @@ _FORCE_INLINE_ static void _32_to_buf(uint8_t *p_dst, uint32_t p_n) {
 	p_dst[1] = (p_n >> 16) & 0xff;
 	p_dst[2] = (p_n >> 8) & 0xff;
 	p_dst[3] = (p_n >> 0) & 0xff;
-};
+}
 
 IP_Address::IP_Address(uint32_t p_a, uint32_t p_b, uint32_t p_c, uint32_t p_d, bool is_v6) {
 	clear();

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -91,7 +91,7 @@ String JSON::_print_var(const Variant &p_var, const String &p_indent, int p_cur_
 			}
 			s += end_statement + _make_indent(p_indent, p_cur_indent) + "]";
 			return s;
-		};
+		}
 		case Variant::DICTIONARY: {
 			String s = "{";
 			s += end_statement;
@@ -115,7 +115,7 @@ String JSON::_print_var(const Variant &p_var, const String &p_indent, int p_cur_
 
 			s += end_statement + _make_indent(p_indent, p_cur_indent) + "}";
 			return s;
-		};
+		}
 		default:
 			return "\"" + String(p_var).json_escape() + "\"";
 	}
@@ -132,7 +132,7 @@ Error JSON::_get_token(const CharType *p_str, int &index, int p_len, Token &r_to
 				line++;
 				index++;
 				break;
-			};
+			}
 			case 0: {
 				r_token.type = TK_EOF;
 				return OK;
@@ -141,32 +141,32 @@ Error JSON::_get_token(const CharType *p_str, int &index, int p_len, Token &r_to
 				r_token.type = TK_CURLY_BRACKET_OPEN;
 				index++;
 				return OK;
-			};
+			}
 			case '}': {
 				r_token.type = TK_CURLY_BRACKET_CLOSE;
 				index++;
 				return OK;
-			};
+			}
 			case '[': {
 				r_token.type = TK_BRACKET_OPEN;
 				index++;
 				return OK;
-			};
+			}
 			case ']': {
 				r_token.type = TK_BRACKET_CLOSE;
 				index++;
 				return OK;
-			};
+			}
 			case ':': {
 				r_token.type = TK_COLON;
 				index++;
 				return OK;
-			};
+			}
 			case ',': {
 				r_token.type = TK_COMMA;
 				index++;
 				return OK;
-			};
+			}
 			case '"': {
 				index++;
 				String str;

--- a/core/io/marshalls.h
+++ b/core/io/marshalls.h
@@ -106,7 +106,7 @@ static inline int encode_cstring(const char *p_string, uint8_t *p_data) {
 		}
 		p_string++;
 		len++;
-	};
+	}
 
 	if (p_data) {
 		*p_data = 0;

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -147,7 +147,7 @@ void PacketPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_encode_buffer_max_size", "max_size"), &PacketPeer::set_encode_buffer_max_size);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "encode_buffer_max_size"), "set_encode_buffer_max_size", "get_encode_buffer_max_size");
-};
+}
 
 /***************/
 
@@ -267,7 +267,7 @@ void PacketPeerStream::set_stream_peer(const Ref<StreamPeer> &p_peer) {
 
 	if (p_peer.ptr() != peer.ptr()) {
 		ring_buffer.advance_read(ring_buffer.data_left()); // reset the ring buffer
-	};
+	}
 
 	peer = p_peer;
 }

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -45,19 +45,19 @@ static uint64_t _align(uint64_t p_n, int p_alignment) {
 	} else {
 		return p_n + (p_alignment - rest);
 	}
-};
+}
 
 static void _pad(FileAccess *p_file, int p_bytes) {
 	for (int i = 0; i < p_bytes; i++) {
 		p_file->store_8(0);
-	};
-};
+	}
+}
 
 void PCKPacker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("pck_start", "pck_name", "alignment"), &PCKPacker::pck_start, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("add_file", "pck_path", "source_path"), &PCKPacker::add_file);
 	ClassDB::bind_method(D_METHOD("flush", "verbose"), &PCKPacker::flush, DEFVAL(false));
-};
+}
 
 Error PCKPacker::pck_start(const String &p_file, int p_alignment) {
 	if (file != nullptr) {
@@ -78,18 +78,18 @@ Error PCKPacker::pck_start(const String &p_file, int p_alignment) {
 
 	for (int i = 0; i < 16; i++) {
 		file->store_32(0); // reserved
-	};
+	}
 
 	files.clear();
 
 	return OK;
-};
+}
 
 Error PCKPacker::add_file(const String &p_file, const String &p_src) {
 	FileAccess *f = FileAccess::open(p_src, FileAccess::READ);
 	if (!f) {
 		return ERR_FILE_CANT_OPEN;
-	};
+	}
 
 	File pf;
 	pf.path = p_file;
@@ -103,7 +103,7 @@ Error PCKPacker::add_file(const String &p_file, const String &p_src) {
 	memdelete(f);
 
 	return OK;
-};
+}
 
 Error PCKPacker::flush(bool p_verbose) {
 	ERR_FAIL_COND_V_MSG(!file, ERR_INVALID_PARAMETER, "File must be opened before use.");
@@ -123,7 +123,7 @@ Error PCKPacker::flush(bool p_verbose) {
 		file->store_32(0);
 		file->store_32(0);
 		file->store_32(0);
-	};
+	}
 
 	uint64_t ofs = file->get_position();
 	ofs = _align(ofs, alignment);
@@ -141,7 +141,7 @@ Error PCKPacker::flush(bool p_verbose) {
 			int read = src->get_buffer(buf, MIN(to_write, buf_max));
 			file->store_buffer(buf, read);
 			to_write -= read;
-		};
+		}
 
 		uint64_t pos = file->get_position();
 		file->seek(files[i].offset_offset); // go back to store the file's offset
@@ -158,9 +158,9 @@ Error PCKPacker::flush(bool p_verbose) {
 			if (count % 100 == 0) {
 				printf("%i/%i (%.2f)\r", count, files.size(), float(count) / files.size() * 100);
 				fflush(stdout);
-			};
-		};
-	};
+			}
+		}
+	}
 
 	if (p_verbose) {
 		printf("\n");
@@ -170,11 +170,11 @@ Error PCKPacker::flush(bool p_verbose) {
 	memdelete_arr(buf);
 
 	return OK;
-};
+}
 
 PCKPacker::~PCKPacker() {
 	if (file != nullptr) {
 		memdelete(file);
-	};
+	}
 	file = nullptr;
-};
+}

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -361,7 +361,7 @@ void XMLParser::_parse_current_node() {
 
 uint64_t XMLParser::get_node_offset() const {
 	return node_offset;
-};
+}
 
 Error XMLParser::seek(uint64_t p_pos) {
 	ERR_FAIL_COND_V(!data, ERR_FILE_EOF);
@@ -370,7 +370,7 @@ Error XMLParser::seek(uint64_t p_pos) {
 	P = data + p_pos;
 
 	return read();
-};
+}
 
 void XMLParser::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("read"), &XMLParser::read);
@@ -398,7 +398,7 @@ void XMLParser::_bind_methods() {
 	BIND_ENUM_CONSTANT(NODE_COMMENT);
 	BIND_ENUM_CONSTANT(NODE_CDATA);
 	BIND_ENUM_CONSTANT(NODE_UNKNOWN);
-};
+}
 
 Error XMLParser::read() {
 	// if not end reached, parse the node

--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -80,7 +80,7 @@ long zipio_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
 			break;
 		default:
 			break;
-	};
+	}
 
 	f->seek(pos);
 	return 0;

--- a/core/list.h
+++ b/core/list.h
@@ -63,70 +63,70 @@ public:
 		 */
 		_FORCE_INLINE_ const Element *next() const {
 			return next_ptr;
-		};
+		}
 		/**
 		 * Get NEXT Element iterator,
 		 */
 		_FORCE_INLINE_ Element *next() {
 			return next_ptr;
-		};
+		}
 
 		/**
 		 * Get PREV Element iterator, for constant lists.
 		 */
 		_FORCE_INLINE_ const Element *prev() const {
 			return prev_ptr;
-		};
+		}
 		/**
 		 * Get PREV Element iterator,
 		 */
 		_FORCE_INLINE_ Element *prev() {
 			return prev_ptr;
-		};
+		}
 
 		/**
 		 * * operator, for using as *iterator, when iterators are defined on stack.
 		 */
 		_FORCE_INLINE_ const T &operator*() const {
 			return value;
-		};
+		}
 		/**
 		 * operator->, for using as iterator->, when iterators are defined on stack, for constant lists.
 		 */
 		_FORCE_INLINE_ const T *operator->() const {
 			return &value;
-		};
+		}
 		/**
 		 * * operator, for using as *iterator, when iterators are defined on stack,
 		 */
 		_FORCE_INLINE_ T &operator*() {
 			return value;
-		};
+		}
 		/**
 		 * operator->, for using as iterator->, when iterators are defined on stack, for constant lists.
 		 */
 		_FORCE_INLINE_ T *operator->() {
 			return &value;
-		};
+		}
 
 		/**
 		 * get the value stored in this element.
 		 */
 		_FORCE_INLINE_ T &get() {
 			return value;
-		};
+		}
 		/**
 		 * get the value stored in this element, for constant lists
 		 */
 		_FORCE_INLINE_ const T &get() const {
 			return value;
-		};
+		}
 		/**
 		 * set the value stored in this element.
 		 */
 		_FORCE_INLINE_ void set(const T &p_value) {
 			value = (T &)p_value;
-		};
+		}
 
 		void erase() {
 			data->erase(this);
@@ -147,7 +147,7 @@ private:
 
 			if (first == p_I) {
 				first = p_I->next_ptr;
-			};
+			}
 
 			if (last == p_I) {
 				last = p_I->prev_ptr;
@@ -176,28 +176,28 @@ public:
 	*/
 	_FORCE_INLINE_ const Element *front() const {
 		return _data ? _data->first : nullptr;
-	};
+	}
 
 	/**
 	* return an iterator to the beginning of the list.
 	*/
 	_FORCE_INLINE_ Element *front() {
 		return _data ? _data->first : nullptr;
-	};
+	}
 
 	/**
  	* return a const iterator to the last member of the list.
 	*/
 	_FORCE_INLINE_ const Element *back() const {
 		return _data ? _data->last : nullptr;
-	};
+	}
 
 	/**
  	* return an iterator to the last member of the list.
 	*/
 	_FORCE_INLINE_ Element *back() {
 		return _data ? _data->last : nullptr;
-	};
+	}
 
 	/**
 	 * store a new element at the end of the list
@@ -230,7 +230,7 @@ public:
 		_data->size_cache++;
 
 		return n;
-	};
+	}
 
 	void pop_back() {
 		if (_data && _data->last) {
@@ -268,7 +268,7 @@ public:
 		_data->size_cache++;
 
 		return n;
-	};
+	}
 
 	void pop_front() {
 		if (_data && _data->first) {
@@ -339,10 +339,10 @@ public:
 				return it;
 			}
 			it = it->next();
-		};
+		}
 
 		return nullptr;
-	};
+	}
 
 	/**
 	 * erase an element in the list, by iterator pointing to it. Return true if it was found/erased.
@@ -360,7 +360,7 @@ public:
 		}
 
 		return false;
-	};
+	}
 
 	/**
 	 * erase the first element in the list, that contains value
@@ -368,7 +368,7 @@ public:
 	bool erase(const T &value) {
 		Element *I = find(value);
 		return erase(I);
-	};
+	}
 
 	/**
 	 * return whether the list is empty
@@ -383,8 +383,8 @@ public:
 	void clear() {
 		while (front()) {
 			erase(front());
-		};
-	};
+		}
+	}
 
 	_FORCE_INLINE_ int size() const {
 		return _data ? _data->size_cache : 0;
@@ -464,7 +464,7 @@ public:
 
 		if (_data->first == p_I) {
 			_data->first = p_I->next_ptr;
-		};
+		}
 
 		if (_data->last == p_I) {
 			_data->last = p_I->prev_ptr;
@@ -501,7 +501,7 @@ public:
 
 		if (_data->first == p_I) {
 			_data->first = p_I->next_ptr;
-		};
+		}
 
 		if (_data->last == p_I) {
 			_data->last = p_I->prev_ptr;
@@ -536,7 +536,7 @@ public:
 			value->prev_ptr = _data->last;
 			_data->last = value;
 			return;
-		};
+		}
 
 		value->prev_ptr = where->prev_ptr;
 
@@ -544,10 +544,10 @@ public:
 			where->prev_ptr->next_ptr = value;
 		} else {
 			_data->first = value;
-		};
+		}
 
 		where->prev_ptr = value;
-	};
+	}
 
 	/**
 	 * simple insertion sort
@@ -672,7 +672,7 @@ public:
 			ERR_FAIL_COND(_data->size_cache);
 			memdelete_allocator<_Data, A>(_data);
 		}
-	};
+	}
 };
 
 #endif // LIST_H

--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -185,8 +185,8 @@ public:
 		for (i = 0; i < count; i++) {
 			if (p_val < data[i]) {
 				break;
-			};
-		};
+			}
+		}
 		insert(i, p_val);
 	}
 

--- a/core/make_binders.py
+++ b/core/make_binders.py
@@ -75,7 +75,7 @@ public:
 #endif
 
 		$ifret _set_returns(true); $
-	};
+	}
 };
 
 template<class T $ifret ,class R$ $ifargs ,$ $arg, class P@$>
@@ -170,7 +170,7 @@ public:
 		$ifret _set_returns(true); $
 
 
-	};
+	}
 };
 
 template<class T $ifret ,class R$ $ifargs ,$ $arg, class P@$>
@@ -266,7 +266,7 @@ public:
 #endif
 
 		$ifret _set_returns(true); $
-	};
+	}
 };
 
 template<class T $ifret ,class R$ $ifargs ,$ $arg, class P@$>

--- a/core/map.h
+++ b/core/map.h
@@ -74,19 +74,19 @@ public:
 		}
 		const K &key() const {
 			return _key;
-		};
+		}
 		V &value() {
 			return _value;
-		};
+		}
 		const V &value() const {
 			return _value;
-		};
+		}
 		V &get() {
 			return _value;
-		};
+		}
 		const V &get() const {
 			return _value;
-		};
+		}
 		Element() {}
 	};
 

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -198,7 +198,7 @@ Vector3 AABB::get_endpoint(int p_point) const {
 			return Vector3(position.x + size.x, position.y + size.y, position.z);
 		case 7:
 			return Vector3(position.x + size.x, position.y + size.y, position.z + size.z);
-	};
+	}
 
 	ERR_FAIL_V(Vector3());
 }

--- a/core/math/camera_matrix.cpp
+++ b/core/math/camera_matrix.cpp
@@ -116,18 +116,18 @@ void CameraMatrix::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_
 			left = -xmax + frustumshift;
 			right = xmax + frustumshift;
 			modeltranslation = p_intraocular_dist / 2.0;
-		}; break;
+		} break;
 		case 2: { // right eye
 			left = -xmax - frustumshift;
 			right = xmax - frustumshift;
 			modeltranslation = -p_intraocular_dist / 2.0;
-		}; break;
+		} break;
 		default: { // mono, should give the same result as set_perspective(p_fovy_degrees,p_aspect,p_z_near,p_z_far,p_flip_fov)
 			left = -xmax;
 			right = xmax;
 			modeltranslation = 0.0;
-		}; break;
-	};
+		} break;
+	}
 
 	set_frustum(left, right, -ymax, ymax, p_z_near, p_z_far);
 
@@ -157,14 +157,14 @@ void CameraMatrix::set_for_hmd(int p_eye, real_t p_aspect, real_t p_intraocular_
 	switch (p_eye) {
 		case 1: { // left eye
 			set_frustum(-f2 * p_z_near, f1 * p_z_near, -f3 * p_z_near, f3 * p_z_near, p_z_near, p_z_far);
-		}; break;
+		} break;
 		case 2: { // right eye
 			set_frustum(-f1 * p_z_near, f2 * p_z_near, -f3 * p_z_near, f3 * p_z_near, p_z_near, p_z_far);
-		}; break;
+		} break;
 		default: { // mono, does not apply here!
-		}; break;
-	};
-};
+		} break;
+	}
+}
 
 void CameraMatrix::set_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar) {
 	set_identity();

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -753,39 +753,39 @@ Error Expression::_get_token(Token &r_token) {
 			case 0: {
 				r_token.type = TK_EOF;
 				return OK;
-			};
+			}
 			case '{': {
 				r_token.type = TK_CURLY_BRACKET_OPEN;
 				return OK;
-			};
+			}
 			case '}': {
 				r_token.type = TK_CURLY_BRACKET_CLOSE;
 				return OK;
-			};
+			}
 			case '[': {
 				r_token.type = TK_BRACKET_OPEN;
 				return OK;
-			};
+			}
 			case ']': {
 				r_token.type = TK_BRACKET_CLOSE;
 				return OK;
-			};
+			}
 			case '(': {
 				r_token.type = TK_PARENTHESIS_OPEN;
 				return OK;
-			};
+			}
 			case ')': {
 				r_token.type = TK_PARENTHESIS_CLOSE;
 				return OK;
-			};
+			}
 			case ',': {
 				r_token.type = TK_COMMA;
 				return OK;
-			};
+			}
 			case ':': {
 				r_token.type = TK_COLON;
 				return OK;
-			};
+			}
 			case '$': {
 				r_token.type = TK_INPUT;
 				int index = 0;
@@ -803,7 +803,7 @@ Error Expression::_get_token(Token &r_token) {
 
 				r_token.value = index;
 				return OK;
-			};
+			}
 			case '=': {
 				cchar = GET_CHAR();
 				if (cchar == '=') {
@@ -814,7 +814,7 @@ Error Expression::_get_token(Token &r_token) {
 					return ERR_PARSE_ERROR;
 				}
 				return OK;
-			};
+			}
 			case '!': {
 				if (expression[str_ofs] == '=') {
 					r_token.type = TK_OP_NOT_EQUAL;
@@ -823,7 +823,7 @@ Error Expression::_get_token(Token &r_token) {
 					r_token.type = TK_OP_NOT;
 				}
 				return OK;
-			};
+			}
 			case '>': {
 				if (expression[str_ofs] == '=') {
 					r_token.type = TK_OP_GREATER_EQUAL;
@@ -835,7 +835,7 @@ Error Expression::_get_token(Token &r_token) {
 					r_token.type = TK_OP_GREATER;
 				}
 				return OK;
-			};
+			}
 			case '<': {
 				if (expression[str_ofs] == '=') {
 					r_token.type = TK_OP_LESS_EQUAL;
@@ -847,27 +847,27 @@ Error Expression::_get_token(Token &r_token) {
 					r_token.type = TK_OP_LESS;
 				}
 				return OK;
-			};
+			}
 			case '+': {
 				r_token.type = TK_OP_ADD;
 				return OK;
-			};
+			}
 			case '-': {
 				r_token.type = TK_OP_SUB;
 				return OK;
-			};
+			}
 			case '/': {
 				r_token.type = TK_OP_DIV;
 				return OK;
-			};
+			}
 			case '*': {
 				r_token.type = TK_OP_MUL;
 				return OK;
-			};
+			}
 			case '%': {
 				r_token.type = TK_OP_MOD;
 				return OK;
-			};
+			}
 			case '&': {
 				if (expression[str_ofs] == '&') {
 					r_token.type = TK_OP_AND;
@@ -876,7 +876,7 @@ Error Expression::_get_token(Token &r_token) {
 					r_token.type = TK_OP_BIT_AND;
 				}
 				return OK;
-			};
+			}
 			case '|': {
 				if (expression[str_ofs] == '|') {
 					r_token.type = TK_OP_OR;
@@ -885,17 +885,17 @@ Error Expression::_get_token(Token &r_token) {
 					r_token.type = TK_OP_BIT_OR;
 				}
 				return OK;
-			};
+			}
 			case '^': {
 				r_token.type = TK_OP_BIT_XOR;
 
 				return OK;
-			};
+			}
 			case '~': {
 				r_token.type = TK_OP_BIT_INVERT;
 
 				return OK;
-			};
+			}
 			case '"': {
 				String str;
 				while (true) {
@@ -1666,7 +1666,7 @@ Expression::ENode *Expression::_parse_expression() {
 				op = Variant::OP_BIT_NEGATE;
 				break;
 			default: {
-			};
+			}
 		}
 
 		if (op == Variant::OP_MAX) { //stop appending stuff

--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -42,16 +42,15 @@
 // This implementation is very inefficient, commenting unless bugs happen. See the other one.
 /*
 bool Geometry::is_point_in_polygon(const Vector2 &p_point, const Vector<Vector2> &p_polygon) {
-
 	Vector<int> indices = Geometry::triangulate_polygon(p_polygon);
 	for (int j = 0; j + 3 <= indices.size(); j += 3) {
 		int i1 = indices[j], i2 = indices[j + 1], i3 = indices[j + 2];
-		if (Geometry::is_point_in_triangle(p_point, p_polygon[i1], p_polygon[i2], p_polygon[i3]))
+		if (Geometry::is_point_in_triangle(p_point, p_polygon[i1], p_polygon[i2], p_polygon[i3])) {
 			return true;
+		}
 	}
 	return false;
 }
-
 */
 
 void Geometry::MeshData::optimize_vertices() {

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -156,7 +156,7 @@ struct Rect2 {
 		new_rect.size = new_rect.size - new_rect.position; //make relative again
 
 		return new_rect;
-	};
+	}
 	inline bool has_point(const Point2 &p_point) const {
 		if (p_point.x < position.x) {
 			return false;
@@ -323,7 +323,7 @@ struct Rect2i {
 		new_rect.size = new_rect.size - new_rect.position; //make relative again
 
 		return new_rect;
-	};
+	}
 	bool has_point(const Point2 &p_point) const {
 		if (p_point.x < position.x) {
 			return false;

--- a/core/math/triangulate.cpp
+++ b/core/math/triangulate.cpp
@@ -79,7 +79,7 @@ bool Triangulate::is_inside_triangle(real_t Ax, real_t Ay,
 	} else {
 		return ((aCROSSbp >= 0.0) && (bCROSScp >= 0.0) && (cCROSSap >= 0.0));
 	}
-};
+}
 
 bool Triangulate::snip(const Vector<Vector2> &p_contour, int u, int v, int w, int n, const Vector<int> &V, bool relaxed) {
 	int p;

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -209,28 +209,29 @@ void Vector2i::operator-=(const Vector2i &p_v) {
 
 Vector2i Vector2i::operator*(const Vector2i &p_v1) const {
 	return Vector2i(x * p_v1.x, y * p_v1.y);
-};
+}
 
 Vector2i Vector2i::operator*(const int &rvalue) const {
 	return Vector2i(x * rvalue, y * rvalue);
-};
+}
+
 void Vector2i::operator*=(const int &rvalue) {
 	x *= rvalue;
 	y *= rvalue;
-};
+}
 
 Vector2i Vector2i::operator/(const Vector2i &p_v1) const {
 	return Vector2i(x / p_v1.x, y / p_v1.y);
-};
+}
 
 Vector2i Vector2i::operator/(const int &rvalue) const {
 	return Vector2i(x / rvalue, y / rvalue);
-};
+}
 
 void Vector2i::operator/=(const int &rvalue) {
 	x /= rvalue;
 	y /= rvalue;
-};
+}
 
 Vector2i Vector2i::operator-() const {
 	return Vector2i(-x, -y);

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -174,28 +174,29 @@ _FORCE_INLINE_ void Vector2::operator-=(const Vector2 &p_v) {
 
 _FORCE_INLINE_ Vector2 Vector2::operator*(const Vector2 &p_v1) const {
 	return Vector2(x * p_v1.x, y * p_v1.y);
-};
+}
 
 _FORCE_INLINE_ Vector2 Vector2::operator*(const real_t &rvalue) const {
 	return Vector2(x * rvalue, y * rvalue);
-};
+}
+
 _FORCE_INLINE_ void Vector2::operator*=(const real_t &rvalue) {
 	x *= rvalue;
 	y *= rvalue;
-};
+}
 
 _FORCE_INLINE_ Vector2 Vector2::operator/(const Vector2 &p_v1) const {
 	return Vector2(x / p_v1.x, y / p_v1.y);
-};
+}
 
 _FORCE_INLINE_ Vector2 Vector2::operator/(const real_t &rvalue) const {
 	return Vector2(x / rvalue, y / rvalue);
-};
+}
 
 _FORCE_INLINE_ void Vector2::operator/=(const real_t &rvalue) {
 	x /= rvalue;
 	y /= rvalue;
-};
+}
 
 _FORCE_INLINE_ Vector2 Vector2::operator-() const {
 	return Vector2(-x, -y);

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1000,7 +1000,7 @@ void Object::set_meta(const String &p_name, const Variant &p_value) {
 	if (p_value.get_type() == Variant::NIL) {
 		metadata.erase(p_name);
 		return;
-	};
+	}
 
 	metadata[p_name] = p_value;
 }

--- a/core/ordered_hash_map.h
+++ b/core/ordered_hash_map.h
@@ -106,27 +106,27 @@ public:
 		const K &key() const {
 			CRASH_COND(!list_element);
 			return *(list_element->get().first);
-		};
+		}
 
 		V &value() {
 			CRASH_COND(!list_element);
 			return list_element->get().second;
-		};
+		}
 
 		const V &value() const {
 			CRASH_COND(!list_element);
 			return list_element->get().second;
-		};
+		}
 
 		V &get() {
 			CRASH_COND(!list_element);
 			return list_element->get().second;
-		};
+		}
 
 		const V &get() const {
 			CRASH_COND(!list_element);
 			return list_element->get().second;
-		};
+		}
 	};
 
 	class ConstElement {
@@ -172,17 +172,17 @@ public:
 		const K &key() const {
 			CRASH_COND(!list_element);
 			return *(list_element->get().first);
-		};
+		}
 
 		const V &value() const {
 			CRASH_COND(!list_element);
 			return list_element->get().second;
-		};
+		}
 
 		const V &get() const {
 			CRASH_COND(!list_element);
 			return list_element->get().second;
-		};
+		}
 	};
 
 	ConstElement find(const K &p_key) const {

--- a/core/os/dir_access.cpp
+++ b/core/os/dir_access.cpp
@@ -131,7 +131,7 @@ Error DirAccess::erase_contents_recursive() {
 Error DirAccess::make_dir_recursive(String p_dir) {
 	if (p_dir.length() < 1) {
 		return OK;
-	};
+	}
 
 	String full_dir;
 
@@ -185,7 +185,7 @@ String DirAccess::fix_path(String p_path) const {
 					String resource_path = ProjectSettings::get_singleton()->get_resource_path();
 					if (resource_path != "") {
 						return p_path.replace_first("res:/", resource_path);
-					};
+					}
 					return p_path.replace_first("res://", "");
 				}
 			}
@@ -196,7 +196,7 @@ String DirAccess::fix_path(String p_path) const {
 				String data_dir = OS::get_singleton()->get_user_data_dir();
 				if (data_dir != "") {
 					return p_path.replace_first("user:/", data_dir);
-				};
+				}
 				return p_path.replace_first("user://", "");
 			}
 
@@ -249,7 +249,7 @@ DirAccess *DirAccess::create(AccessType p_access) {
 	}
 
 	return da;
-};
+}
 
 String DirAccess::get_full_path(const String &p_path, AccessType p_access) {
 	DirAccess *d = DirAccess::create(p_access);

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -65,7 +65,7 @@ bool FileAccess::exists(const String &p_name) {
 
 void FileAccess::_set_access_type(AccessType p_access) {
 	_access_type = p_access;
-};
+}
 
 FileAccess *FileAccess::create_for_path(const String &p_path) {
 	FileAccess *ret = nullptr;
@@ -83,7 +83,7 @@ FileAccess *FileAccess::create_for_path(const String &p_path) {
 
 Error FileAccess::reopen(const String &p_path, int p_mode_flags) {
 	return _open(p_path, p_mode_flags);
-};
+}
 
 FileAccess *FileAccess::open(const String &p_path, int p_mode_flags, Error *r_error) {
 	//try packed data first
@@ -115,7 +115,7 @@ FileAccess *FileAccess::open(const String &p_path, int p_mode_flags, Error *r_er
 
 FileAccess::CreateFunc FileAccess::get_create_func(AccessType p_access) {
 	return create_func[p_access];
-};
+}
 
 String FileAccess::fix_path(const String &p_path) const {
 	//helper used by file accesses that use a single filesystem
@@ -129,7 +129,7 @@ String FileAccess::fix_path(const String &p_path) const {
 					String resource_path = ProjectSettings::get_singleton()->get_resource_path();
 					if (resource_path != "") {
 						return r_path.replace("res:/", resource_path);
-					};
+					}
 					return r_path.replace("res://", "");
 				}
 			}
@@ -140,7 +140,7 @@ String FileAccess::fix_path(const String &p_path) const {
 				String data_dir = OS::get_singleton()->get_user_data_dir();
 				if (data_dir != "") {
 					return r_path.replace("user:/", data_dir);
-				};
+				}
 				return r_path.replace("user://", "");
 			}
 
@@ -215,7 +215,7 @@ float FileAccess::get_float() const {
 	MarshallFloat m;
 	m.i = get_32();
 	return m.f;
-};
+}
 
 real_t FileAccess::get_real() const {
 	if (real_is_double) {
@@ -229,7 +229,7 @@ double FileAccess::get_double() const {
 	MarshallDouble m;
 	m.l = get_64();
 	return m.d;
-};
+}
 
 String FileAccess::get_token() const {
 	CharString token;
@@ -447,13 +447,13 @@ void FileAccess::store_float(float p_dest) {
 	MarshallFloat m;
 	m.f = p_dest;
 	store_32(m.i);
-};
+}
 
 void FileAccess::store_double(double p_dest) {
 	MarshallDouble m;
 	m.d = p_dest;
 	store_64(m.l);
-};
+}
 
 uint64_t FileAccess::get_modified_time(const String &p_file) {
 	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && PackedData::get_singleton()->has_path(p_file)) {
@@ -503,7 +503,7 @@ void FileAccess::store_pascal_string(const String &p_string) {
 	CharString cs = p_string.utf8();
 	store_32(cs.length());
 	store_buffer((uint8_t *)&cs[0], cs.length());
-};
+}
 
 String FileAccess::get_pascal_string() {
 	uint32_t sl = get_32();
@@ -516,7 +516,7 @@ String FileAccess::get_pascal_string() {
 	ret.parse_utf8(cs.ptr());
 
 	return ret;
-};
+}
 
 void FileAccess::store_line(const String &p_line) {
 	store_string(p_line);

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -85,7 +85,8 @@ uint64_t OS::get_splash_tick_msec() const {
 
 uint64_t OS::get_unix_time() const {
 	return 0;
-};
+}
+
 uint64_t OS::get_system_time_secs() const {
 	return 0;
 }
@@ -126,7 +127,7 @@ void OS::print(const char *p_format, ...) {
 	_logger->logv(p_format, argp, false);
 
 	va_end(argp);
-};
+}
 
 void OS::printerr(const char *p_format, ...) {
 	va_list argp;
@@ -135,7 +136,7 @@ void OS::printerr(const char *p_format, ...) {
 	_logger->logv(p_format, argp, true);
 
 	va_end(argp);
-};
+}
 
 void OS::set_low_processor_usage_mode(bool p_enabled) {
 	low_processor_usage_mode = p_enabled;
@@ -159,7 +160,7 @@ String OS::get_executable_path() const {
 
 int OS::get_process_id() const {
 	return -1;
-};
+}
 
 void OS::vibrate_handheld(int p_duration_ms) {
 	WARN_PRINT("vibrate_handheld() only works with Android and iOS");
@@ -281,12 +282,12 @@ String OS::get_cache_path() const {
 // Path to macOS .app bundle resources
 String OS::get_bundle_resource_dir() const {
 	return ".";
-};
+}
 
 // OS specific path for user://
 String OS::get_user_data_dir() const {
 	return ".";
-};
+}
 
 // Absolute path to res://
 String OS::get_resource_dir() const {
@@ -300,7 +301,7 @@ String OS::get_system_dir(SystemDir p_dir) const {
 
 Error OS::shell_open(String p_uri) {
 	return ERR_UNAVAILABLE;
-};
+}
 
 // implement these with the canvas?
 
@@ -345,7 +346,7 @@ String OS::get_model_name() const {
 void OS::set_cmdline(const char *p_execpath, const List<String> &p_args) {
 	_execpath = p_execpath;
 	_cmdline = p_args;
-};
+}
 
 String OS::get_unique_id() const {
 	ERR_FAIL_V("");

--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -63,4 +63,4 @@ Error Thread::set_name(const String &p_name) {
 	}
 
 	return ERR_UNAVAILABLE;
-};
+}

--- a/core/os/thread_dummy.cpp
+++ b/core/os/thread_dummy.cpp
@@ -34,16 +34,16 @@
 
 Thread *ThreadDummy::create(ThreadCreateCallback p_callback, void *p_user, const Thread::Settings &p_settings) {
 	return memnew(ThreadDummy);
-};
+}
 
 void ThreadDummy::make_default() {
 	Thread::create_func = &ThreadDummy::create;
-};
+}
 
 RWLock *RWLockDummy::create() {
 	return memnew(RWLockDummy);
-};
+}
 
 void RWLockDummy::make_default() {
 	RWLock::create_func = &RWLockDummy::create;
-};
+}

--- a/core/packed_data_container.cpp
+++ b/core/packed_data_container.cpp
@@ -44,7 +44,7 @@ Variant PackedDataContainer::getvar(const Variant &p_key, bool *r_valid) const {
 
 int PackedDataContainer::size() const {
 	return _size(0);
-};
+}
 
 Variant PackedDataContainer::_iter_init_ofs(const Array &p_iter, uint32_t p_offset) {
 	Array ref = p_iter;
@@ -124,7 +124,7 @@ uint32_t PackedDataContainer::_type_at_ofs(uint32_t p_ofs) const {
 	uint32_t type = decode_uint32(r);
 
 	return type;
-};
+}
 
 int PackedDataContainer::_size(uint32_t p_ofs) const {
 	const uint8_t *rd = data.ptr();
@@ -139,10 +139,10 @@ int PackedDataContainer::_size(uint32_t p_ofs) const {
 	} else if (type == TYPE_DICT) {
 		uint32_t len = decode_uint32(r + 4);
 		return len;
-	};
+	}
 
 	return -1;
-};
+}
 
 Variant PackedDataContainer::_key_at_ofs(uint32_t p_ofs, const Variant &p_key, bool &err) const {
 	const uint8_t *rd = data.ptr();
@@ -368,7 +368,7 @@ Variant PackedDataContainerRef::_iter_get(const Variant &p_iter) {
 
 bool PackedDataContainerRef::_is_dictionary() const {
 	return from->_type_at_ofs(offset) == PackedDataContainer::TYPE_DICT;
-};
+}
 
 void PackedDataContainerRef::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("size"), &PackedDataContainerRef::size);
@@ -389,4 +389,4 @@ Variant PackedDataContainerRef::getvar(const Variant &p_key, bool *r_valid) cons
 
 int PackedDataContainerRef::size() const {
 	return from->_size(offset);
-};
+}

--- a/core/pool_allocator.cpp
+++ b/core/pool_allocator.cpp
@@ -341,7 +341,7 @@ Error PoolAllocator::resize(ID p_mem, int p_new_size) {
 	if (uint32_t(_free + aligned(e->len)) < alloc_size) {
 		mt_unlock();
 		ERR_FAIL_V(ERR_OUT_OF_MEMORY);
-	};
+	}
 
 	EntryIndicesPos entry_indices_pos;
 
@@ -358,7 +358,7 @@ Error PoolAllocator::resize(ID p_mem, int p_new_size) {
 		next_pos = pool_size; // - static_area_size;
 	} else {
 		next_pos = entry_array[entry_indices[entry_indices_pos + 1]].pos;
-	};
+	}
 
 	if ((next_pos - e->pos) > alloc_size) {
 		free_mem += aligned(e->len);
@@ -564,8 +564,8 @@ PoolAllocator::PoolAllocator(void *p_mem, int p_size, int p_align, bool p_needs_
 			mem8 += p_align - (ofs % p_align);
 			p_size -= dif;
 			p_mem = (void *)mem8;
-		};
-	};
+		}
+	}
 
 	create_pool(p_mem, p_size, p_max_entries);
 	needs_locking = p_needs_locking;

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -51,7 +51,7 @@ ProjectSettings *ProjectSettings::get_singleton() {
 
 String ProjectSettings::get_resource_path() const {
 	return resource_path;
-};
+}
 
 String ProjectSettings::localize_path(const String &p_path) const {
 	if (resource_path == "") {
@@ -87,7 +87,7 @@ String ProjectSettings::localize_path(const String &p_path) const {
 
 		if (!cwd.begins_with(res_path)) {
 			return p_path;
-		};
+		}
 
 		return cwd.replace_first(res_path, "res://");
 	} else {
@@ -96,20 +96,20 @@ String ProjectSettings::localize_path(const String &p_path) const {
 		int sep = path.find_last("/");
 		if (sep == -1) {
 			return "res://" + path;
-		};
+		}
 
 		String parent = path.substr(0, sep);
 
 		String plocal = localize_path(parent);
 		if (plocal == "") {
 			return "";
-		};
+		}
 		// Only strip the starting '/' from 'path' if its parent ('plocal') ends with '/'
 		if (plocal[plocal.length() - 1] == '/') {
 			sep += 1;
 		}
 		return plocal + path.substr(sep, path.size() - sep);
-	};
+	}
 }
 
 void ProjectSettings::set_initial_value(const String &p_name, const Variant &p_value) {
@@ -126,13 +126,13 @@ String ProjectSettings::globalize_path(const String &p_path) const {
 	if (p_path.begins_with("res://")) {
 		if (resource_path != "") {
 			return p_path.replace("res:/", resource_path);
-		};
+		}
 		return p_path.replace("res://", "");
 	} else if (p_path.begins_with("user://")) {
 		String data_dir = OS::get_singleton()->get_user_data_dir();
 		if (data_dir != "") {
 			return p_path.replace("user:/", data_dir);
-		};
+		}
 		return p_path.replace("user://", "");
 	}
 
@@ -759,7 +759,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 Error ProjectSettings::_save_custom_bnd(const String &p_file) { // add other params as dictionary and array?
 
 	return save_custom(p_file);
-};
+}
 
 Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_custom, const Vector<String> &p_custom_features, bool p_merge_with_current) {
 	ERR_FAIL_COND_V_MSG(p_path == "", ERR_INVALID_PARAMETER, "Project settings save path cannot be empty.");

--- a/core/ring_buffer.h
+++ b/core/ring_buffer.h
@@ -45,13 +45,13 @@ class RingBuffer {
 		p_var += p_size;
 		p_var = p_var & size_mask;
 		return ret;
-	};
+	}
 
 public:
 	T read() {
 		ERR_FAIL_COND_V(space_left() < 1, T());
 		return data.ptr()[inc(read_pos, 1)];
-	};
+	}
 
 	int read(T *p_buf, int p_size, bool p_advance = true) {
 		int left = data_left();
@@ -66,15 +66,15 @@ public:
 			const T *read = data.ptr();
 			for (int i = 0; i < total; i++) {
 				p_buf[dst++] = read[pos + i];
-			};
+			}
 			to_read -= total;
 			pos = 0;
-		};
+		}
 		if (p_advance) {
 			inc(read_pos, p_size);
-		};
+		}
 		return p_size;
-	};
+	}
 
 	int copy(T *p_buf, int p_offset, int p_size) const {
 		int left = data_left();
@@ -95,12 +95,12 @@ public:
 			int total = end - pos;
 			for (int i = 0; i < total; i++) {
 				p_buf[dst++] = data[pos + i];
-			};
+			}
 			to_read -= total;
 			pos = 0;
-		};
+		}
 		return p_size;
-	};
+	}
 
 	int find(const T &t, int p_offset, int p_max_size) const {
 		int left = data_left();
@@ -122,7 +122,7 @@ public:
 				if (data[pos + i] == t) {
 					return i + (p_max_size - to_read);
 				}
-			};
+			}
 			to_read -= total;
 			pos = 0;
 		}
@@ -133,7 +133,7 @@ public:
 		p_n = MIN(p_n, data_left());
 		inc(read_pos, p_n);
 		return p_n;
-	};
+	}
 
 	inline int decrease_write(int p_n) {
 		p_n = MIN(p_n, data_left());
@@ -145,7 +145,7 @@ public:
 		ERR_FAIL_COND_V(space_left() < 1, FAILED);
 		data.write[inc(write_pos, 1)] = p_v;
 		return OK;
-	};
+	}
 
 	int write(const T *p_buf, int p_size) {
 		int left = space_left();
@@ -161,32 +161,32 @@ public:
 
 			for (int i = 0; i < total; i++) {
 				data.write[pos + i] = p_buf[src++];
-			};
+			}
 			to_write -= total;
 			pos = 0;
-		};
+		}
 
 		inc(write_pos, p_size);
 		return p_size;
-	};
+	}
 
 	inline int space_left() const {
 		int left = read_pos - write_pos;
 		if (left < 0) {
 			return size() + left - 1;
-		};
+		}
 		if (left == 0) {
 			return size() - 1;
-		};
+		}
 		return left - 1;
-	};
+	}
 	inline int data_left() const {
 		return size() - space_left() - 1;
-	};
+	}
 
 	inline int size() const {
 		return data.size();
-	};
+	}
 
 	inline void clear() {
 		read_pos = 0;
@@ -201,19 +201,19 @@ public:
 		if (old_size < new_size && read_pos > write_pos) {
 			for (int i = 0; i < write_pos; i++) {
 				data.write[(old_size + i) & mask] = data[i];
-			};
+			}
 			write_pos = (old_size + write_pos) & mask;
 		} else {
 			read_pos = read_pos & mask;
 			write_pos = write_pos & mask;
-		};
+		}
 
 		size_mask = mask;
-	};
+	}
 
 	RingBuffer<T>(int p_power = 0) {
 		resize(p_power);
-	};
+	}
 	~RingBuffer<T>() {}
 };
 

--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -873,7 +873,7 @@ void Translation::get_message_list(List<StringName> *r_messages) const {
 
 int Translation::get_message_count() const {
 	return translation_map.size();
-};
+}
 
 void Translation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_locale", "locale"), &Translation::set_locale);
@@ -1022,7 +1022,7 @@ void TranslationServer::remove_translation(const Ref<Translation> &p_translation
 
 void TranslationServer::clear() {
 	translations.clear();
-};
+}
 
 StringName TranslationServer::translate(const StringName &p_message) const {
 	// Match given message against the translation catalog for the project locale.

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -247,15 +247,6 @@ String String::operator+(const String &p_str) const {
 	return res;
 }
 
-/*
-String String::operator+(CharType p_chr)  const {
-
-	String res=*this;
-	res+=p_chr;
-	return res;
-}
-
-*/
 String &String::operator+=(const String &p_str) {
 	if (empty()) {
 		*this = p_str;
@@ -1371,7 +1362,7 @@ String String::utf8(const char *p_utf8, int p_len) {
 	ret.parse_utf8(p_utf8, p_len);
 
 	return ret;
-};
+}
 
 bool String::parse_utf8(const char *p_utf8, int p_len) {
 #define _UNICERROR(m_err) print_line("Unicode parsing error: " + String(m_err) + ". Is the string valid UTF-8?");
@@ -1608,6 +1599,7 @@ String::String(CharType p_char) {
 	copy_from(p_char);
 }
 
+
 */
 
 String::String(const char *p_str) {
@@ -1833,7 +1825,7 @@ int String::to_int(const char *p_str, int p_len) {
 bool String::is_numeric() const {
 	if (length() == 0) {
 		return false;
-	};
+	}
 
 	int s = 0;
 	if (operator[](0) == '-') {
@@ -1845,16 +1837,16 @@ bool String::is_numeric() const {
 		if (c == '.') {
 			if (dot) {
 				return false;
-			};
+			}
 			dot = true;
 		}
 		if (c < '0' || c > '9') {
 			return false;
-		};
-	};
+		}
+	}
 
 	return true; // TODO: Use the parser below for this instead
-};
+}
 
 template <class C>
 static double built_in_strtod(const C *string, /* A decimal ASCII floating-point number,
@@ -2278,7 +2270,7 @@ Vector<uint8_t> String::md5_buffer() const {
 		ret.write[i] = hash[i];
 	}
 	return ret;
-};
+}
 
 Vector<uint8_t> String::sha1_buffer() const {
 	CharString cs = utf8();
@@ -2387,7 +2379,7 @@ int String::find(const String &p_str, int p_from) const {
 			if (read_pos >= len) {
 				ERR_PRINT("read_pos>=len");
 				return -1;
-			};
+			}
 
 			if (src[read_pos] != str[j]) {
 				found = false;
@@ -2439,7 +2431,7 @@ int String::find(const char *p_str, int p_from) const {
 				if (read_pos >= len) {
 					ERR_PRINT("read_pos>=len");
 					return -1;
-				};
+				}
 
 				if (src[read_pos] != p_str[j]) {
 					found = false;
@@ -2495,7 +2487,7 @@ int String::findmk(const Vector<String> &p_keys, int p_from, int *r_key) const {
 				if (read_pos >= len) {
 					found = false;
 					break;
-				};
+				}
 
 				if (src[read_pos] != cmp[j]) {
 					found = false;
@@ -2536,7 +2528,7 @@ int String::findn(const String &p_str, int p_from) const {
 			if (read_pos >= length()) {
 				ERR_PRINT("read_pos>=length()");
 				return -1;
-			};
+			}
 
 			CharType src = _find_lower(srcd[read_pos]);
 			CharType dst = _find_lower(p_str[j]);
@@ -2586,7 +2578,7 @@ int String::rfind(const String &p_str, int p_from) const {
 			if (read_pos >= len) {
 				ERR_PRINT("read_pos>=len");
 				return -1;
-			};
+			}
 
 			if (src[read_pos] != p_str[j]) {
 				found = false;
@@ -2633,7 +2625,7 @@ int String::rfindn(const String &p_str, int p_from) const {
 			if (read_pos >= len) {
 				ERR_PRINT("read_pos>=len");
 				return -1;
-			};
+			}
 
 			CharType srcc = _find_lower(src[read_pos]);
 			CharType dstc = _find_lower(p_str[j]);
@@ -3691,7 +3683,7 @@ bool String::is_valid_hex_number(bool p_with_prefix) const {
 	}
 
 	return true;
-};
+}
 
 bool String::is_valid_float() const {
 	int len = length();
@@ -3851,11 +3843,11 @@ bool String::is_valid_ip_address() const {
 					return false;
 				}
 				continue;
-			};
+			}
 			if (!n.is_valid_ip_address()) {
 				return false;
 			}
-		};
+		}
 
 	} else {
 		Vector<String> ip = split(".");
@@ -3872,7 +3864,7 @@ bool String::is_valid_ip_address() const {
 				return false;
 			}
 		}
-	};
+	}
 
 	return true;
 }

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -191,7 +191,7 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 
 	if (p_type_from == NIL) {
 		return (p_type_to == OBJECT);
-	};
+	}
 
 	const Type *valid_types = nullptr;
 	const Type *invalid_types = nullptr;
@@ -498,7 +498,7 @@ bool Variant::can_convert_strict(Variant::Type p_type_from, Variant::Type p_type
 
 	if (p_type_from == NIL) {
 		return (p_type_to == OBJECT);
-	};
+	}
 
 	const Type *valid_types = nullptr;
 
@@ -870,11 +870,6 @@ bool Variant::is_zero() const {
 			return *reinterpret_cast<const Plane *>(_data._mem) == Plane();
 
 		} break;
-		/*
-		case QUAT: {
-
-
-		} break;*/
 		case AABB: {
 			return *_data._aabb == ::AABB();
 		} break;
@@ -1284,7 +1279,7 @@ void Variant::clear() {
 		COLOR,
 		VECTOR2,
 		RECT2
-	*/
+		*/
 		case TRANSFORM2D: {
 			memdelete(_data._transform2d);
 		} break;
@@ -1421,26 +1416,6 @@ Variant::operator int64_t() const {
 	}
 }
 
-/*
-Variant::operator long unsigned int() const {
-
-	switch( type ) {
-
-		case NIL: return 0;
-		case BOOL: return _data._bool ? 1 : 0;
-		case INT: return _data._int;
-		case FLOAT: return _data._real;
-		case STRING: return operator String().to_int();
-		default: {
-
-			return 0;
-		}
-	}
-
-	return 0;
-};
-*/
-
 Variant::operator uint64_t() const {
 	switch (type) {
 		case NIL:
@@ -1488,7 +1463,7 @@ Variant::operator signed long() const {
 	}
 
 	return 0;
-};
+}
 
 Variant::operator unsigned long() const {
 	switch (type) {
@@ -1508,7 +1483,7 @@ Variant::operator unsigned long() const {
 	}
 
 	return 0;
-};
+}
 #endif
 
 Variant::operator signed short() const {
@@ -1858,7 +1833,7 @@ String Variant::stringify(List<const void *> &stack) const {
 			if (_get_obj().obj) {
 				if (!_get_obj().id.is_reference() && ObjectDB::get_instance(_get_obj().id) == nullptr) {
 					return "[Freed Object]";
-				};
+				}
 
 				return _get_obj().obj->to_string();
 			} else {
@@ -2075,7 +2050,7 @@ Variant::operator RID() const {
 #ifdef DEBUG_ENABLED
 		if (EngineDebugger::is_active()) {
 			ERR_FAIL_COND_V_MSG(ObjectDB::get_instance(_get_obj().id) == nullptr, RID(), "Invalid pointer (object was freed).");
-		};
+		}
 #endif
 		Callable::CallError ce;
 		Variant ret = _get_obj().obj->call(CoreStringNames::get_singleton()->get_rid, nullptr, 0, ce);
@@ -2386,14 +2361,6 @@ Variant::Variant(bool p_bool) {
 	type = BOOL;
 	_data._bool = p_bool;
 }
-
-/*
-Variant::Variant(long unsigned int p_long) {
-
-	type=INT;
-	_data._int=p_long;
-};
-*/
 
 Variant::Variant(signed int p_int) {
 	type = INT;
@@ -2939,11 +2906,6 @@ uint32_t Variant::hash() const {
 			return hash_djb2_one_float(reinterpret_cast<const Plane *>(_data._mem)->d, hash);
 
 		} break;
-		/*
-			case QUAT: {
-
-
-			} break;*/
 		case AABB: {
 			uint32_t hash = 5831;
 			for (int i = 0; i < 3; i++) {

--- a/core/variant.h
+++ b/core/variant.h
@@ -219,10 +219,10 @@ public:
 	bool is_ref() const;
 	_FORCE_INLINE_ bool is_num() const {
 		return type == INT || type == FLOAT;
-	};
+	}
 	_FORCE_INLINE_ bool is_array() const {
 		return type >= ARRAY;
-	};
+	}
 	bool is_shared() const;
 	bool is_zero() const;
 	bool is_one() const;

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -189,7 +189,7 @@ bool Variant::booleanize() const {
 			_RETURN(p_a._data.m_type m_op p_b._data._float);      \
                                                                   \
 		_RETURN_FAIL                                              \
-	};
+	}
 
 #define DEFAULT_OP_NUM_NULL(m_prefix, m_op_name, m_name, m_op, m_type) \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                           \
@@ -201,7 +201,7 @@ bool Variant::booleanize() const {
 			_RETURN(!(p_b.type m_op NIL));                             \
                                                                        \
 		_RETURN_FAIL                                                   \
-	};
+	}
 
 #ifdef DEBUG_ENABLED
 #define DEFAULT_OP_NUM_DIV(m_prefix, m_op_name, m_name, m_type) \
@@ -222,7 +222,7 @@ bool Variant::booleanize() const {
 		}                                                       \
                                                                 \
 		_RETURN_FAIL                                            \
-	};
+	}
 #else
 #define DEFAULT_OP_NUM_DIV(m_prefix, m_op_name, m_name, m_type) \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                    \
@@ -232,18 +232,18 @@ bool Variant::booleanize() const {
 			_RETURN(p_a._data.m_type / p_b._data._float);       \
                                                                 \
 		_RETURN_FAIL                                            \
-	};
+	}
 #endif
 
 #define DEFAULT_OP_NUM_NEG(m_prefix, m_op_name, m_name, m_type) \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                    \
 		_RETURN(-p_a._data.m_type);                             \
-	};
+	}
 
 #define DEFAULT_OP_NUM_POS(m_prefix, m_op_name, m_name, m_type) \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                    \
 		_RETURN(p_a._data.m_type);                              \
-	};
+	}
 
 #define DEFAULT_OP_NUM_VEC(m_prefix, m_op_name, m_name, m_op, m_type)                          \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                   \
@@ -261,7 +261,7 @@ bool Variant::booleanize() const {
 			_RETURN(p_a._data.m_type m_op *reinterpret_cast<const Vector3 *>(p_b._data._mem)); \
                                                                                                \
 		_RETURN_FAIL                                                                           \
-	};
+	}
 
 #define DEFAULT_OP_STR_REV(m_prefix, m_op_name, m_name, m_op, m_type)                                                              \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                       \
@@ -273,7 +273,7 @@ bool Variant::booleanize() const {
 			_RETURN(*reinterpret_cast<const m_type *>(p_b._data._mem) m_op *reinterpret_cast<const NodePath *>(p_a._data._mem));   \
                                                                                                                                    \
 		_RETURN_FAIL                                                                                                               \
-	};
+	}
 
 #define DEFAULT_OP_STR(m_prefix, m_op_name, m_name, m_op, m_type)                                                                  \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                       \
@@ -285,7 +285,7 @@ bool Variant::booleanize() const {
 			_RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op *reinterpret_cast<const NodePath *>(p_b._data._mem));   \
                                                                                                                                    \
 		_RETURN_FAIL                                                                                                               \
-	};
+	}
 
 #define DEFAULT_OP_STR_NULL(m_prefix, m_op_name, m_name, m_op, m_type)                                                             \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                       \
@@ -299,7 +299,7 @@ bool Variant::booleanize() const {
 			_RETURN(!(p_b.type m_op NIL));                                                                                         \
                                                                                                                                    \
 		_RETURN_FAIL                                                                                                               \
-	};
+	}
 
 #define DEFAULT_OP_STR_NULL_NP(m_prefix, m_op_name, m_name, m_op, m_type)                                                        \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                     \
@@ -311,7 +311,7 @@ bool Variant::booleanize() const {
 			_RETURN(!(p_b.type m_op NIL));                                                                                       \
                                                                                                                                  \
 		_RETURN_FAIL                                                                                                             \
-	};
+	}
 
 #define DEFAULT_OP_STR_NULL_SN(m_prefix, m_op_name, m_name, m_op, m_type)                                                          \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                       \
@@ -323,7 +323,7 @@ bool Variant::booleanize() const {
 			_RETURN(!(p_b.type m_op NIL));                                                                                         \
                                                                                                                                    \
 		_RETURN_FAIL                                                                                                               \
-	};
+	}
 
 #define DEFAULT_OP_LOCALMEM_REV(m_prefix, m_op_name, m_name, m_op, m_type)                                                     \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                   \
@@ -331,7 +331,7 @@ bool Variant::booleanize() const {
 			_RETURN(*reinterpret_cast<const m_type *>(p_b._data._mem) m_op *reinterpret_cast<const m_type *>(p_a._data._mem)); \
                                                                                                                                \
 		_RETURN_FAIL                                                                                                           \
-	};
+	}
 
 #define DEFAULT_OP_LOCALMEM(m_prefix, m_op_name, m_name, m_op, m_type)                                                         \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                   \
@@ -339,7 +339,7 @@ bool Variant::booleanize() const {
 			_RETURN(*reinterpret_cast<const m_type *>(p_a._data._mem) m_op *reinterpret_cast<const m_type *>(p_b._data._mem)); \
                                                                                                                                \
 		_RETURN_FAIL                                                                                                           \
-	};
+	}
 
 #define DEFAULT_OP_LOCALMEM_NULL(m_prefix, m_op_name, m_name, m_op, m_type)                                                    \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                                                                                   \
@@ -349,7 +349,7 @@ bool Variant::booleanize() const {
 			_RETURN(!(p_b.type m_op NIL));                                                                                     \
                                                                                                                                \
 		_RETURN_FAIL                                                                                                           \
-	};
+	}
 
 #define DEFAULT_OP_LOCALMEM_NEG(m_prefix, m_op_name, m_name, m_type) \
 	CASE_TYPE(m_prefix, m_op_name, m_name) {                         \

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -110,7 +110,7 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 			case '\n': {
 				line++;
 				break;
-			};
+			}
 			case 0: {
 				r_token.type = TK_EOF;
 				return OK;
@@ -118,31 +118,31 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 			case '{': {
 				r_token.type = TK_CURLY_BRACKET_OPEN;
 				return OK;
-			};
+			}
 			case '}': {
 				r_token.type = TK_CURLY_BRACKET_CLOSE;
 				return OK;
-			};
+			}
 			case '[': {
 				r_token.type = TK_BRACKET_OPEN;
 				return OK;
-			};
+			}
 			case ']': {
 				r_token.type = TK_BRACKET_CLOSE;
 				return OK;
-			};
+			}
 			case '(': {
 				r_token.type = TK_PARENTHESIS_OPEN;
 				return OK;
-			};
+			}
 			case ')': {
 				r_token.type = TK_PARENTHESIS_CLOSE;
 				return OK;
-			};
+			}
 			case ':': {
 				r_token.type = TK_COLON;
 				return OK;
-			};
+			}
 			case ';': {
 				while (true) {
 					CharType ch = p_stream->get_char();
@@ -156,19 +156,19 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 				}
 
 				break;
-			};
+			}
 			case ',': {
 				r_token.type = TK_COMMA;
 				return OK;
-			};
+			}
 			case '.': {
 				r_token.type = TK_PERIOD;
 				return OK;
-			};
+			}
 			case '=': {
 				r_token.type = TK_EQUAL;
 				return OK;
-			};
+			}
 			case '#': {
 				StringBuffer<> color_str;
 				color_str += '#';
@@ -189,7 +189,7 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 				r_token.value = Color::html(color_str.as_string());
 				r_token.type = TK_COLOR;
 				return OK;
-			};
+			}
 			case '@': {
 				cchar = p_stream->get_char();
 				if (cchar != '"') {

--- a/core/vector.h
+++ b/core/vector.h
@@ -113,8 +113,8 @@ public:
 		for (i = 0; i < _cowdata.size(); i++) {
 			if (p_val < operator[](i)) {
 				break;
-			};
-		};
+			}
+		}
 		insert(i, p_val);
 	}
 


### PR DESCRIPTION
Semicolons are not necessary after function definitions or control flow
blocks, and having some code use them makes things inconsistent (and
occasionally can mess up `clang-format`'s formatting).

Removing them is tedious work though, I had to do this manually (regex
\+ manual review) as I couldn't find a tool for that. All other code
folders would need to get the same treatment.

----

Method used if anyone wants to give it a try or find a better system:
```
cd core/
sed -i $(rg "\t};" -l) -e "s/\t};/\t}/g"
sed -i $(rg "^};" -l) -e "s/^};/}/g"
git diff
# cry
git add -p
# review all changes one by one, accepting only the ones that seem correct (not changing an enum, struct, or brace initialization of array)
git checkout .
# compile and fix the files where you made mistakes when evaluating the changes in half a second and partial context
```