### PR TITLE
Fix too eager GDScriptFunctionState stack cleanup

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1818,8 +1818,6 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 	state.result = Variant();
 
 	if (completed) {
-		_clear_stack();
-
 		if (first_state.is_valid()) {
 			first_state->emit_signal("completed", ret);
 		} else {


### PR DESCRIPTION
The philosophy of my recent improvements to yield() involved cleaning up the stack stored in a `GDScriptFunctionState` as early as possible.

It seems than one case was too eager: when a function that yielded did complete. Cleaning the stack of the stored state at that very point wasn’t right because it could make the `GDScriptFunctionState` be freed too soon; namely, when the disconnection logic for one-shot signals still needed to be run on that object.

`GDScriptFunctionState`'s destructor will do the cleanup anyway when it's ready to do so.

I've tested that this change doesn't revert the intent of the original change, so it should be fine.

---
**This code is generously donated by IMVU.**