### PR TITLE
Mono/C#: Remove script load error about not a Godot.Object

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -3240,9 +3240,7 @@ Error CSharpScript::reload(bool p_keep_state) {
 			ERR_FAIL_NULL_V(namespace_, ERR_BUG);
 			ERR_FAIL_NULL_V(class_name, ERR_BUG);
 			GDMonoClass *klass = project_assembly->get_class(namespace_->operator String(), class_name->operator String());
-			if (klass) {
-				bool obj_type = CACHED_CLASS(GodotObject)->is_assignable_from(klass);
-				ERR_FAIL_COND_V(!obj_type, ERR_BUG);
+			if (klass && CACHED_CLASS(GodotObject)->is_assignable_from(klass)) {
 				script_class = klass;
 			}
 		} else {


### PR DESCRIPTION
Any C# file can be loaded as script and at load
time we don't yet know if it's actually meant to
be used as a script. As such, such an check can
result in a lot of false errors.

If the file is really meant to be used as a
script, an error would be printed later when
attempting to instantiate it any way.