### PR TITLE
[Windows] Add tablet driver selection.

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -678,6 +678,22 @@ String _OS::get_unique_id() const {
 	return OS::get_singleton()->get_unique_id();
 }
 
+int _OS::get_tablet_driver_count() const {
+	return OS::get_singleton()->get_tablet_driver_count();
+}
+
+String _OS::get_tablet_driver_name(int p_driver) const {
+	return OS::get_singleton()->get_tablet_driver_name(p_driver);
+}
+
+String _OS::get_current_tablet_driver() const {
+	return OS::get_singleton()->get_current_tablet_driver();
+}
+
+void _OS::set_current_tablet_driver(const String &p_driver) {
+	OS::get_singleton()->set_current_tablet_driver(p_driver);
+}
+
 _OS *_OS::singleton = nullptr;
 
 void _OS::_bind_methods() {
@@ -762,9 +778,15 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("request_permissions"), &_OS::request_permissions);
 	ClassDB::bind_method(D_METHOD("get_granted_permissions"), &_OS::get_granted_permissions);
 
+	ClassDB::bind_method(D_METHOD("get_tablet_driver_count"), &_OS::get_tablet_driver_count);
+	ClassDB::bind_method(D_METHOD("get_tablet_driver_name", "idx"), &_OS::get_tablet_driver_name);
+	ClassDB::bind_method(D_METHOD("get_current_tablet_driver"), &_OS::get_current_tablet_driver);
+	ClassDB::bind_method(D_METHOD("set_current_tablet_driver", "name"), &_OS::set_current_tablet_driver);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "exit_code"), "set_exit_code", "get_exit_code");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "low_processor_usage_mode"), "set_low_processor_usage_mode", "is_in_low_processor_usage_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "low_processor_usage_mode_sleep_usec"), "set_low_processor_usage_mode_sleep_usec", "get_low_processor_usage_mode_sleep_usec");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "tablet_driver"), "set_current_tablet_driver", "get_current_tablet_driver");
 
 	// Those default values need to be specified for the docs generator,
 	// to avoid using values from the documentation writer's own OS instance.

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -243,6 +243,11 @@ public:
 	bool request_permissions();
 	Vector<String> get_granted_permissions() const;
 
+	int get_tablet_driver_count() const;
+	String get_tablet_driver_name(int p_driver) const;
+	String get_current_tablet_driver() const;
+	void set_current_tablet_driver(const String &p_driver);
+
 	static _OS *get_singleton() { return singleton; }
 
 	_OS() { singleton = this; }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -58,7 +58,6 @@ class OS {
 	bool _allow_layered = false;
 	bool _use_vsync;
 	bool _vsync_via_compositor;
-	bool _disable_wintab;
 
 	char *last_error;
 
@@ -148,7 +147,11 @@ public:
 
 	bool is_layered_allowed() const { return _allow_layered; }
 	bool is_hidpi_allowed() const { return _allow_hidpi; }
-	bool is_wintab_disabled() const { return _disable_wintab; }
+
+	virtual int get_tablet_driver_count() const { return 0; };
+	virtual String get_tablet_driver_name(int p_driver) const { return ""; };
+	virtual String get_current_tablet_driver() const { return ""; };
+	virtual void set_current_tablet_driver(const String &p_driver){};
 
 	void ensure_user_data_dir();
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -268,6 +268,24 @@
 				Returns the epoch time of the operating system in seconds.
 			</description>
 		</method>
+		<method name="get_tablet_driver_count" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the total number of available tablet drivers.
+				[b]Note:[/b] This method is implemented on Windows.
+			</description>
+		</method>
+		<method name="get_tablet_driver_name" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<description>
+				Returns the tablet driver name for the given index.
+				[b]Note:[/b] This method is implemented on Windows.
+			</description>
+		</method>
 		<method name="get_ticks_msec" qualifiers="const">
 			<return type="int">
 			</return>
@@ -499,6 +517,9 @@
 		</member>
 		<member name="low_processor_usage_mode_sleep_usec" type="int" setter="set_low_processor_usage_mode_sleep_usec" getter="get_low_processor_usage_mode_sleep_usec" default="6900">
 			The amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU usage.
+		</member>
+		<member name="tablet_driver" type="String" setter="set_current_tablet_driver" getter="get_current_tablet_driver" default="&quot;wintab&quot;">
+			The current tablet drvier in use.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -414,9 +414,6 @@
 		<member name="display/mouse_cursor/tooltip_position_offset" type="Vector2" setter="" getter="" default="Vector2( 10, 10 )">
 			Position offset for tooltips, relative to the mouse cursor's hotspot.
 		</member>
-		<member name="display/window/disable_wintab_api" type="bool" setter="" getter="" default="false">
-			Disables WinTab API and always use Windows Ink API for the pen input (Windows only).
-		</member>
 		<member name="display/window/dpi/allow_hidpi" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], allows HiDPI display on Windows and macOS. This setting has no effect on desktop Linux, as DPI-awareness fallbacks are not supported there.
 		</member>
@@ -452,6 +449,9 @@
 		</member>
 		<member name="display/window/size/width" type="int" setter="" getter="" default="1024">
 			Sets the game's main viewport width. On desktop platforms, this is the default window size. Stretch mode settings also use this as a reference when enabled.
+		</member>
+		<member name="display/window/tablet_driver" type="String" setter="" getter="" default="&quot;wintab&quot;">
+			Specifies the tablet driver to use. If left empty, the default driver will be used.
 		</member>
 		<member name="display/window/vsync/use_vsync" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], enables vertical synchronization. This eliminates tearing that may appear in moving scenes, at the cost of higher input latency and stuttering at lower framerates. If [code]false[/code], vertical synchronization will be disabled, however, many platforms will enforce it regardless (such as mobile platforms and HTML5).

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -256,6 +256,7 @@ class DisplayServerWindows : public DisplayServer {
 
 	_THREAD_SAFE_CLASS_
 
+public:
 	// WinTab API
 	static bool wintab_available;
 	static WTOpenPtr wintab_WTOpen;
@@ -265,9 +266,13 @@ class DisplayServerWindows : public DisplayServer {
 	static WTEnablePtr wintab_WTEnable;
 
 	// Windows Ink API
+	static bool winink_available;
 	static GetPointerTypePtr win8p_GetPointerType;
 	static GetPointerPenInfoPtr win8p_GetPointerPenInfo;
 
+	void _update_tablet_ctx(const String &p_old_driver, const String &p_new_driver);
+
+private:
 	void GetMaskBitmaps(HBITMAP hSourceBitmap, COLORREF clrTransparent, OUT HBITMAP &hAndMaskBitmap, OUT HBITMAP &hXorMaskBitmap);
 
 	enum {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -778,7 +778,69 @@ Error OS_Windows::move_to_trash(const String &p_path) {
 	return OK;
 }
 
+int OS_Windows::get_tablet_driver_count() const {
+	return tablet_drivers.size();
+}
+
+String OS_Windows::get_tablet_driver_name(int p_driver) const {
+	if (p_driver < 0 || p_driver >= tablet_drivers.size()) {
+		return "";
+	} else {
+		return tablet_drivers[p_driver].utf8().get_data();
+	}
+}
+
+String OS_Windows::get_current_tablet_driver() const {
+	return tablet_driver;
+}
+
+void OS_Windows::set_current_tablet_driver(const String &p_driver) {
+	bool found = false;
+	for (int i = 0; i < get_tablet_driver_count(); i++) {
+		if (p_driver == get_tablet_driver_name(i)) {
+			found = true;
+		}
+	}
+	if (found) {
+		if (DisplayServerWindows::get_singleton()) {
+			((DisplayServerWindows *)DisplayServerWindows::get_singleton())->_update_tablet_ctx(tablet_driver, p_driver);
+		}
+		tablet_driver = p_driver;
+	} else {
+		ERR_PRINT("Unknown tablet driver " + p_driver + ".");
+	}
+}
+
 OS_Windows::OS_Windows(HINSTANCE _hInstance) {
+	//Note: Wacom WinTab driver API for pen input, for devices incompatible with Windows Ink.
+	HMODULE wintab_lib = LoadLibraryW(L"wintab32.dll");
+	if (wintab_lib) {
+		DisplayServerWindows::wintab_WTOpen = (WTOpenPtr)GetProcAddress(wintab_lib, "WTOpenW");
+		DisplayServerWindows::wintab_WTClose = (WTClosePtr)GetProcAddress(wintab_lib, "WTClose");
+		DisplayServerWindows::wintab_WTInfo = (WTInfoPtr)GetProcAddress(wintab_lib, "WTInfoW");
+		DisplayServerWindows::wintab_WTPacket = (WTPacketPtr)GetProcAddress(wintab_lib, "WTPacket");
+		DisplayServerWindows::wintab_WTEnable = (WTEnablePtr)GetProcAddress(wintab_lib, "WTEnable");
+
+		DisplayServerWindows::wintab_available = DisplayServerWindows::wintab_WTOpen && DisplayServerWindows::wintab_WTClose && DisplayServerWindows::wintab_WTInfo && DisplayServerWindows::wintab_WTPacket && DisplayServerWindows::wintab_WTEnable;
+	}
+
+	if (DisplayServerWindows::wintab_available) {
+		tablet_drivers.push_back("wintab");
+	}
+
+	//Note: Windows Ink API for pen input, available on Windows 8+ only.
+	HMODULE user32_lib = LoadLibraryW(L"user32.dll");
+	if (user32_lib) {
+		DisplayServerWindows::win8p_GetPointerType = (GetPointerTypePtr)GetProcAddress(user32_lib, "GetPointerType");
+		DisplayServerWindows::win8p_GetPointerPenInfo = (GetPointerPenInfoPtr)GetProcAddress(user32_lib, "GetPointerPenInfo");
+
+		DisplayServerWindows::winink_available = DisplayServerWindows::win8p_GetPointerType && DisplayServerWindows::win8p_GetPointerPenInfo;
+	}
+
+	if (DisplayServerWindows::winink_available) {
+		tablet_drivers.push_back("winink");
+	}
+
 	force_quit = false;
 
 	hInstance = _hInstance;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -73,6 +73,9 @@ class OS_Windows : public OS {
 	HINSTANCE hInstance;
 	MainLoop *main_loop;
 
+	String tablet_driver;
+	Vector<String> tablet_drivers;
+
 #ifdef WASAPI_ENABLED
 	AudioDriverWASAPI driver_wasapi;
 #endif
@@ -115,6 +118,11 @@ public:
 	virtual MainLoop *get_main_loop() const;
 
 	virtual String get_name() const;
+
+	virtual int get_tablet_driver_count() const;
+	virtual String get_tablet_driver_name(int p_driver) const;
+	virtual String get_current_tablet_driver() const;
+	virtual void set_current_tablet_driver(const String &p_driver);
 
 	virtual void initialize_joypads() {}
 


### PR DESCRIPTION
Add tablet driver selection options, seems like WinTab and Windows Ink enable at the same time can cause conflicts:

Issue discussion from IRC:
```
23:00:10 | <sleepprogger> | I am experiencing some weird behaviour with windows ink like when drawing and pressing ctrl or shift it produces some super weird lines/mouse positions
23:03:11 | <Calinou> | sleepprogger: not sure, you'll have to ask bruvzg for that, I guess
23:06:29 | <sleepprogger> | Thanks will do
23:06:32 | <bruvzg[m]> | sleepprogger: WinTab should be selected by default, if it's supported (driver installed), you can disable it with `--disable-wintab` command line argument (or in project setting).
23:09:31 | <sleepprogger> | Hmm, thats strange. Because i see the exact same artefacts (when pressing ctrl) with the new version when windows ink is activated. All is good as soon as windows Ink is deactivated in the driver utils.
23:10:26 | <sleepprogger> | Now i am searching for a way to basically disable windows ink from godot itself, so the user don't have to go to their driver utils
23:10:41 | <sleepprogger> | Krita and TvPaint for example both have settings to switch between them
23:10:45 | <sleepprogger> | so it should be possible
-- | --
21:42:40 | <sleepprogger> | bruvzg, had to wait for a budy with windows, but i definetly get a mix of wintab and windows ink events when windows ink is enabled. (just threw some print_line into both sections)
```

Test project: [press_test.zip](https://github.com/godotengine/godot/files/4655028/press_test.zip)
