### PR TITLE
Fix error with 'params' when import dock doesn't define any parameter

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -441,7 +441,9 @@ void ImportDock::_reimport() {
 		} else {
 			//override entirely
 			config->set_value("remap", "importer", importer_name);
-			config->erase_section("params");
+			if (config->has_section("params")) {
+				config->erase_section("params");
+			}
 
 			for (List<PropertyInfo>::Element *E = params->properties.front(); E; E = E->next()) {
 				config->set_value("params", E->get().name, params->values[E->get().name]);


### PR DESCRIPTION
Not much to say.  
I've looked at other calls to `erase_section` but this is the only one that seemed problematic to me.

As always thanks to everybody for all the hard work on Godot.