### PR TITLE
Use doubles for time everywhere in Timer/SceneTree

### DIFF
--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -66,7 +66,7 @@ void MainLoop::initialize() {
 	}
 }
 
-bool MainLoop::physics_process(float p_time) {
+bool MainLoop::physics_process(double p_time) {
 	if (get_script_instance()) {
 		return get_script_instance()->call("_physics_process", p_time);
 	}
@@ -74,7 +74,7 @@ bool MainLoop::physics_process(float p_time) {
 	return false;
 }
 
-bool MainLoop::process(float p_time) {
+bool MainLoop::process(double p_time) {
 	if (get_script_instance()) {
 		return get_script_instance()->call("_process", p_time);
 	}

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -60,8 +60,8 @@ public:
 	};
 
 	virtual void initialize();
-	virtual bool physics_process(float p_time);
-	virtual bool process(float p_time);
+	virtual bool physics_process(double p_time);
+	virtual bool process(double p_time);
 	virtual void finalize();
 
 	void set_initialize_script(const Ref<Script> &p_initialize_script);

--- a/main/main_timer_sync.h
+++ b/main/main_timer_sync.h
@@ -34,11 +34,11 @@
 #include "core/config/engine.h"
 
 struct MainFrameTime {
-	float process_step; // delta time to advance during process()
+	double process_step; // delta time to advance during process()
 	int physics_steps; // number of times to iterate the physics engine
-	float interpolation_fraction; // fraction through the current physics tick
+	double interpolation_fraction; // fraction through the current physics tick
 
-	void clamp_process_step(float min_process_step, float max_process_step);
+	void clamp_process_step(double min_process_step, double max_process_step);
 };
 
 class MainTimerSync {
@@ -47,10 +47,10 @@ class MainTimerSync {
 	uint64_t current_cpu_ticks_usec = 0;
 
 	// logical game time since last physics timestep
-	float time_accum = 0;
+	double time_accum = 0;
 
 	// current difference between wall clock time and reported sum of process_steps
-	float time_deficit = 0;
+	double time_deficit = 0;
 
 	// number of frames back for keeping accumulated physics steps roughly constant.
 	// value of 12 chosen because that is what is required to make 144 Hz monitors
@@ -70,20 +70,20 @@ protected:
 	// returns the fraction of p_physics_step required for the timer to overshoot
 	// before advance_core considers changing the physics_steps return from
 	// the typical values as defined by typical_physics_steps
-	float get_physics_jitter_fix();
+	double get_physics_jitter_fix();
 
 	// gets our best bet for the average number of physics steps per render frame
 	// return value: number of frames back this data is consistent
-	int get_average_physics_steps(float &p_min, float &p_max);
+	int get_average_physics_steps(double &p_min, double &p_max);
 
 	// advance physics clock by p_process_step, return appropriate number of steps to simulate
-	MainFrameTime advance_core(float p_physics_step, int p_physics_fps, float p_process_step);
+	MainFrameTime advance_core(double p_physics_step, int p_physics_fps, double p_process_step);
 
 	// calls advance_core, keeps track of deficit it adds to animaption_step, make sure the deficit sum stays close to zero
-	MainFrameTime advance_checked(float p_physics_step, int p_physics_fps, float p_process_step);
+	MainFrameTime advance_checked(double p_physics_step, int p_physics_fps, double p_process_step);
 
 	// determine wall clock step since last iteration
-	float get_cpu_process_step();
+	double get_cpu_process_step();
 
 public:
 	MainTimerSync();
@@ -96,7 +96,7 @@ public:
 	void set_fixed_fps(int p_fixed_fps);
 
 	// advance one frame, return timesteps to take
-	MainFrameTime advance(float p_physics_step, int p_physics_fps);
+	MainFrameTime advance(double p_physics_step, int p_physics_fps);
 };
 
 #endif // MAIN_TIMER_SYNC_H

--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -77,7 +77,7 @@ void Performance::_bind_methods() {
 	BIND_ENUM_CONSTANT(MONITOR_MAX);
 }
 
-float Performance::_get_node_count() const {
+int Performance::_get_node_count() const {
 	MainLoop *ml = OS::get_singleton()->get_main_loop();
 	SceneTree *sml = Object::cast_to<SceneTree>(ml);
 	if (!sml) {
@@ -118,7 +118,7 @@ String Performance::get_monitor_name(Monitor p_monitor) const {
 	return names[p_monitor];
 }
 
-float Performance::get_monitor(Monitor p_monitor) const {
+double Performance::get_monitor(Monitor p_monitor) const {
 	switch (p_monitor) {
 		case TIME_FPS:
 			return Engine::get_singleton()->get_frames_per_second();
@@ -207,11 +207,11 @@ Performance::MonitorType Performance::get_monitor_type(Monitor p_monitor) const 
 	return types[p_monitor];
 }
 
-void Performance::set_process_time(float p_pt) {
+void Performance::set_process_time(double p_pt) {
 	_process_time = p_pt;
 }
 
-void Performance::set_physics_process_time(float p_pt) {
+void Performance::set_physics_process_time(double p_pt) {
 	_physics_process_time = p_pt;
 }
 

--- a/main/performance.h
+++ b/main/performance.h
@@ -43,10 +43,10 @@ class Performance : public Object {
 	static Performance *singleton;
 	static void _bind_methods();
 
-	float _get_node_count() const;
+	int _get_node_count() const;
 
-	float _process_time;
-	float _physics_process_time;
+	double _process_time;
+	double _physics_process_time;
 
 	class MonitorCall {
 		Callable _callable;
@@ -96,13 +96,13 @@ public:
 		MONITOR_TYPE_TIME
 	};
 
-	float get_monitor(Monitor p_monitor) const;
+	double get_monitor(Monitor p_monitor) const;
 	String get_monitor_name(Monitor p_monitor) const;
 
 	MonitorType get_monitor_type(Monitor p_monitor) const;
 
-	void set_process_time(float p_pt);
-	void set_physics_process_time(float p_pt);
+	void set_process_time(double p_pt);
+	void set_physics_process_time(double p_pt);
 
 	void add_custom_monitor(const StringName &p_id, const Callable &p_callable, const Vector<Variant> &p_args);
 	void remove_custom_monitor(const StringName &p_id);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -66,11 +66,11 @@ void SceneTreeTimer::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("timeout"));
 }
 
-void SceneTreeTimer::set_time_left(float p_time) {
+void SceneTreeTimer::set_time_left(double p_time) {
 	time_left = p_time;
 }
 
-float SceneTreeTimer::get_time_left() const {
+double SceneTreeTimer::get_time_left() const {
 	return time_left;
 }
 
@@ -403,7 +403,7 @@ void SceneTree::initialize() {
 	MainLoop::initialize();
 }
 
-bool SceneTree::physics_process(float p_time) {
+bool SceneTree::physics_process(double p_time) {
 	root_lock++;
 
 	current_frame++;
@@ -432,7 +432,7 @@ bool SceneTree::physics_process(float p_time) {
 	return _quit;
 }
 
-bool SceneTree::process(float p_time) {
+bool SceneTree::process(double p_time) {
 	root_lock++;
 
 	MainLoop::process(p_time);
@@ -474,7 +474,7 @@ bool SceneTree::process(float p_time) {
 			continue;
 		}
 
-		float time_left = E->get()->get_time_left();
+		double time_left = E->get()->get_time_left();
 		if (E->get()->is_ignore_time_scale()) {
 			time_left -= Engine::get_singleton()->get_process_step();
 		} else {
@@ -1124,7 +1124,7 @@ void SceneTree::add_current_scene(Node *p_current) {
 	root->add_child(p_current);
 }
 
-Ref<SceneTreeTimer> SceneTree::create_timer(float p_delay_sec, bool p_process_always) {
+Ref<SceneTreeTimer> SceneTree::create_timer(double p_delay_sec, bool p_process_always) {
 	Ref<SceneTreeTimer> stt;
 	stt.instantiate();
 	stt->set_process_always(p_process_always);

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -52,7 +52,7 @@ class Tween;
 class SceneTreeTimer : public RefCounted {
 	GDCLASS(SceneTreeTimer, RefCounted);
 
-	float time_left = 0.0;
+	double time_left = 0.0;
 	bool process_always = true;
 	bool ignore_time_scale = false;
 
@@ -60,8 +60,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_time_left(float p_time);
-	float get_time_left() const;
+	void set_time_left(double p_time);
+	double get_time_left() const;
 
 	void set_process_always(bool p_process_always);
 	bool is_process_always();
@@ -91,8 +91,8 @@ private:
 	Window *root = nullptr;
 
 	uint64_t tree_version = 1;
-	float physics_process_time = 1.0;
-	float process_time = 1.0;
+	double physics_process_time = 1.0;
+	double process_time = 1.0;
 	bool accept_quit = true;
 	bool quit_on_go_back = true;
 
@@ -237,8 +237,8 @@ public:
 
 	virtual void initialize() override;
 
-	virtual bool physics_process(float p_time) override;
-	virtual bool process(float p_time) override;
+	virtual bool physics_process(double p_time) override;
+	virtual bool process(double p_time) override;
 
 	virtual void finalize() override;
 
@@ -247,8 +247,8 @@ public:
 
 	void quit(int p_exit_code = EXIT_SUCCESS);
 
-	_FORCE_INLINE_ float get_physics_process_time() const { return physics_process_time; }
-	_FORCE_INLINE_ float get_process_time() const { return process_time; }
+	_FORCE_INLINE_ double get_physics_process_time() const { return physics_process_time; }
+	_FORCE_INLINE_ double get_process_time() const { return process_time; }
 
 #ifdef TOOLS_ENABLED
 	bool is_node_being_edited(const Node *p_node) const;
@@ -317,7 +317,7 @@ public:
 	Error change_scene_to(const Ref<PackedScene> &p_scene);
 	Error reload_current_scene();
 
-	Ref<SceneTreeTimer> create_timer(float p_delay_sec, bool p_process_always = true);
+	Ref<SceneTreeTimer> create_timer(double p_delay_sec, bool p_process_always = true);
 	Ref<Tween> create_tween();
 	Array get_processed_tweens();
 

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -81,12 +81,12 @@ void Timer::_notification(int p_what) {
 	}
 }
 
-void Timer::set_wait_time(float p_time) {
+void Timer::set_wait_time(double p_time) {
 	ERR_FAIL_COND_MSG(p_time <= 0, "Time should be greater than zero.");
 	wait_time = p_time;
 }
 
-float Timer::get_wait_time() const {
+double Timer::get_wait_time() const {
 	return wait_time;
 }
 
@@ -106,7 +106,7 @@ bool Timer::has_autostart() const {
 	return autostart;
 }
 
-void Timer::start(float p_time) {
+void Timer::start(double p_time) {
 	ERR_FAIL_COND_MSG(!is_inside_tree(), "Timer was not added to the SceneTree. Either add it or set autostart to true.");
 
 	if (p_time > 0) {
@@ -139,7 +139,7 @@ bool Timer::is_stopped() const {
 	return get_time_left() <= 0;
 }
 
-float Timer::get_time_left() const {
+double Timer::get_time_left() const {
 	return time_left > 0 ? time_left : 0;
 }
 

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -36,7 +36,7 @@
 class Timer : public Node {
 	GDCLASS(Timer, Node);
 
-	float wait_time = 1.0;
+	double wait_time = 1.0;
 	bool one_shot = false;
 	bool autostart = false;
 	bool processing = false;
@@ -54,8 +54,8 @@ public:
 		TIMER_PROCESS_IDLE,
 	};
 
-	void set_wait_time(float p_time);
-	float get_wait_time() const;
+	void set_wait_time(double p_time);
+	double get_wait_time() const;
 
 	void set_one_shot(bool p_one_shot);
 	bool is_one_shot() const;
@@ -63,7 +63,7 @@ public:
 	void set_autostart(bool p_start);
 	bool has_autostart() const;
 
-	void start(float p_time = -1);
+	void start(double p_time = -1);
 	void stop();
 
 	void set_paused(bool p_paused);
@@ -71,7 +71,7 @@ public:
 
 	bool is_stopped() const;
 
-	float get_time_left() const;
+	double get_time_left() const;
 
 	void set_timer_process_callback(TimerProcessCallback p_callback);
 	TimerProcessCallback get_timer_process_callback() const;

--- a/tests/test_physics_2d.cpp
+++ b/tests/test_physics_2d.cpp
@@ -386,7 +386,7 @@ public:
 		//_add_plane(Vector2(-1,0).normalized(),-600);
 	}
 
-	virtual bool process(float p_time) override {
+	virtual bool process(double p_time) override {
 		return false;
 	}
 	virtual void finalize() override {

--- a/tests/test_physics_3d.cpp
+++ b/tests/test_physics_3d.cpp
@@ -313,7 +313,7 @@ public:
 		test_fall();
 		quit = false;
 	}
-	virtual bool physics_process(float p_time) override {
+	virtual bool physics_process(double p_time) override {
 		if (mover.is_valid()) {
 			static real_t joy_speed = 10;
 			PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
@@ -399,7 +399,7 @@ public:
 		create_static_plane(Plane(Vector3(0, 1, 0), -1));
 	}
 
-	virtual bool process(float p_time) override {
+	virtual bool process(double p_time) override {
 		return false;
 	}
 

--- a/tests/test_render.cpp
+++ b/tests/test_render.cpp
@@ -199,7 +199,7 @@ public:
 		ofs = 0;
 		quit = false;
 	}
-	virtual bool iteration(float p_time) {
+	virtual bool iteration(double p_time) {
 		RenderingServer *vs = RenderingServer::get_singleton();
 		//Transform3D t;
 		//t.rotate(Vector3(0, 1, 0), ofs);
@@ -223,7 +223,7 @@ public:
 		return quit;
 	}
 
-	virtual bool idle(float p_time) {
+	virtual bool idle(double p_time) {
 		return quit;
 	}
 


### PR DESCRIPTION
Single-precision floats should never be used for time, because it fails after a few days.

With doubles, Timer should work for about 4.7 million years before failing, assuming 60 FPS.

EDIT: Here's a cool video that shows how Team Fortress 2 breaks due to how it uses single-precision floats for time: https://www.youtube.com/watch?v=RdTJHVG_IdU