### PR TITLE
Expose `Image.save_png_to_buffer` method

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -3018,6 +3018,7 @@ void Image::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("load", "path"), &Image::load);
 	ClassDB::bind_method(D_METHOD("save_png", "path"), &Image::save_png);
+	ClassDB::bind_method(D_METHOD("save_png_to_buffer"), &Image::save_png_to_buffer);
 	ClassDB::bind_method(D_METHOD("save_exr", "path", "grayscale"), &Image::save_exr, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("detect_alpha"), &Image::detect_alpha);


### PR DESCRIPTION
Closes godotengine/godot-proposals#859.

There are other formats of course, but no apparent support within the engine for those yet.

Successfully save to buffer and then save with `File`:

```gdscript
extends Node2D

func _ready():
	var image = load("res://icon.png").get_data()
	var buffer = image.save_png_to_buffer()
	var file = File.new()
	file.open("res://icon_out.png", File.WRITE)
	file.store_buffer(buffer)
	file.close()
```

`Image.save_png()` could be used, yet this is mainly for networking purposes rather than local storage.