### PR TITLE
Load GDNative libraries for X11 as a fallback on the Server platform

### DIFF
--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -169,9 +169,13 @@ void GDNativeLibrary::set_config_file(Ref<ConfigFile> p_config_file) {
 
 			bool skip = false;
 			for (int i = 0; i < tags.size(); i++) {
-				bool has_feature = OS::get_singleton()->has_feature(tags[i]);
+				const bool has_feature = OS::get_singleton()->has_feature(tags[i]);
+				// Try looking for X11 libraries when running a server binary.
+				// This may not always succeed as server binaries can also be compiled for macOS,
+				// but in practice, most dedicated servers run Linux.
+				const bool has_server_x11_fallback = OS::get_singleton()->has_feature("Server") && tags[i] == "X11";
 
-				if (!has_feature) {
+				if (!has_feature && !has_server_x11_fallback) {
 					skip = true;
 					break;
 				}


### PR DESCRIPTION
This makes it possible to load GDNative libraries on a Linux server without having to edit the GDNativeLibrary resource.

See https://github.com/godotengine/godot-docs/pull/3557#issuecomment-630761914.