### PR TITLE
Docs: Ignore OS specific values (constants, project settings, properties)

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -781,6 +781,7 @@ void _OS::_bind_methods() {
 
 	// Those default values need to be specified for the docs generator,
 	// to avoid using values from the documentation writer's own OS instance.
+	ADD_PROPERTY_DEFAULT("tablet_driver", "");
 	ADD_PROPERTY_DEFAULT("exit_code", 0);
 	ADD_PROPERTY_DEFAULT("low_processor_usage_mode", false);
 	ADD_PROPERTY_DEFAULT("low_processor_usage_mode_sleep_usec", 6900);

--- a/core/global_constants.cpp
+++ b/core/global_constants.cpp
@@ -38,6 +38,7 @@
 struct _GlobalConstant {
 #ifdef DEBUG_METHODS_ENABLED
 	StringName enum_name;
+	bool ignore_value_in_docs;
 #endif
 	const char *name;
 	int value;
@@ -45,8 +46,9 @@ struct _GlobalConstant {
 	_GlobalConstant() {}
 
 #ifdef DEBUG_METHODS_ENABLED
-	_GlobalConstant(const StringName &p_enum_name, const char *p_name, int p_value) :
+	_GlobalConstant(const StringName &p_enum_name, const char *p_name, int p_value, bool p_ignore_value_in_docs = false) :
 			enum_name(p_enum_name),
+			ignore_value_in_docs(p_ignore_value_in_docs),
 			name(p_name),
 			value(p_value) {
 	}
@@ -71,6 +73,15 @@ static Vector<_GlobalConstant> _global_constants;
 #define BIND_GLOBAL_ENUM_CONSTANT_CUSTOM(m_custom_name, m_constant) \
 	_global_constants.push_back(_GlobalConstant(__constant_get_enum_name(m_constant, #m_constant), m_custom_name, m_constant));
 
+#define BIND_GLOBAL_CONSTANT_NO_VAL(m_constant) \
+	_global_constants.push_back(_GlobalConstant(StringName(), #m_constant, m_constant, true));
+
+#define BIND_GLOBAL_ENUM_CONSTANT_NO_VAL(m_constant) \
+	_global_constants.push_back(_GlobalConstant(__constant_get_enum_name(m_constant, #m_constant), #m_constant, m_constant, true));
+
+#define BIND_GLOBAL_ENUM_CONSTANT_CUSTOM_NO_VAL(m_custom_name, m_constant) \
+	_global_constants.push_back(_GlobalConstant(__constant_get_enum_name(m_constant, #m_constant), m_custom_name, m_constant, true));
+
 #else
 
 #define BIND_GLOBAL_CONSTANT(m_constant) \
@@ -80,6 +91,15 @@ static Vector<_GlobalConstant> _global_constants;
 	_global_constants.push_back(_GlobalConstant(#m_constant, m_constant));
 
 #define BIND_GLOBAL_ENUM_CONSTANT_CUSTOM(m_custom_name, m_constant) \
+	_global_constants.push_back(_GlobalConstant(m_custom_name, m_constant));
+
+#define BIND_GLOBAL_CONSTANT_NO_VAL(m_constant) \
+	_global_constants.push_back(_GlobalConstant(#m_constant, m_constant));
+
+#define BIND_GLOBAL_ENUM_CONSTANT_NO_VAL(m_constant) \
+	_global_constants.push_back(_GlobalConstant(#m_constant, m_constant));
+
+#define BIND_GLOBAL_ENUM_CONSTANT_CUSTOM_NO_VAL(m_custom_name, m_constant) \
 	_global_constants.push_back(_GlobalConstant(m_custom_name, m_constant));
 
 #endif
@@ -368,7 +388,7 @@ void register_global_constants() {
 	BIND_GLOBAL_ENUM_CONSTANT(KEY_MASK_ALT);
 	BIND_GLOBAL_ENUM_CONSTANT(KEY_MASK_META);
 	BIND_GLOBAL_ENUM_CONSTANT(KEY_MASK_CTRL);
-	BIND_GLOBAL_ENUM_CONSTANT(KEY_MASK_CMD);
+	BIND_GLOBAL_ENUM_CONSTANT_NO_VAL(KEY_MASK_CMD);
 	BIND_GLOBAL_ENUM_CONSTANT(KEY_MASK_KPAD);
 	BIND_GLOBAL_ENUM_CONSTANT(KEY_MASK_GROUP_SWITCH);
 
@@ -648,9 +668,17 @@ int GlobalConstants::get_global_constant_count() {
 StringName GlobalConstants::get_global_constant_enum(int p_idx) {
 	return _global_constants[p_idx].enum_name;
 }
+
+bool GlobalConstants::get_ignore_value_in_docs(int p_idx) {
+	return _global_constants[p_idx].ignore_value_in_docs;
+}
 #else
 StringName GlobalConstants::get_global_constant_enum(int p_idx) {
 	return StringName();
+}
+
+bool GlobalConstants::get_ignore_value_in_docs(int p_idx) {
+	return false;
 }
 #endif
 

--- a/core/global_constants.h
+++ b/core/global_constants.h
@@ -37,6 +37,7 @@ class GlobalConstants {
 public:
 	static int get_global_constant_count();
 	static StringName get_global_constant_enum(int p_idx);
+	static bool get_ignore_value_in_docs(int p_idx);
 	static const char *get_global_constant_name(int p_idx);
 	static int get_global_constant_value(int p_idx);
 };

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -122,6 +122,22 @@ void ProjectSettings::set_restart_if_changed(const String &p_name, bool p_restar
 	props[p_name].restart_if_changed = p_restart;
 }
 
+void ProjectSettings::set_ignore_value_in_docs(const String &p_name, bool p_ignore) {
+	ERR_FAIL_COND_MSG(!props.has(p_name), "Request for nonexistent project setting: " + p_name + ".");
+#ifdef DEBUG_METHODS_ENABLED
+	props[p_name].ignore_value_in_docs = p_ignore;
+#endif
+}
+
+bool ProjectSettings::get_ignore_value_in_docs(const String &p_name) const {
+	ERR_FAIL_COND_V_MSG(!props.has(p_name), false, "Request for nonexistent project setting: " + p_name + ".");
+#ifdef DEBUG_METHODS_ENABLED
+	return props[p_name].ignore_value_in_docs;
+#else
+	return false;
+#endif
+}
+
 String ProjectSettings::globalize_path(const String &p_path) const {
 	if (p_path.begins_with("res://")) {
 		if (resource_path != "") {
@@ -876,7 +892,7 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 	}
 }
 
-Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed) {
+Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed, bool p_ignore_value_in_docs) {
 	Variant ret;
 	if (!ProjectSettings::get_singleton()->has_setting(p_var)) {
 		ProjectSettings::get_singleton()->set(p_var, p_default);
@@ -886,6 +902,7 @@ Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restar
 	ProjectSettings::get_singleton()->set_initial_value(p_var, p_default);
 	ProjectSettings::get_singleton()->set_builtin_order(p_var);
 	ProjectSettings::get_singleton()->set_restart_if_changed(p_var, p_restart_if_changed);
+	ProjectSettings::get_singleton()->set_ignore_value_in_docs(p_var, p_ignore_value_in_docs);
 	return ret;
 }
 

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -62,6 +62,9 @@ protected:
 		bool hide_from_editor = false;
 		bool overridden = false;
 		bool restart_if_changed = false;
+#ifdef DEBUG_METHODS_ENABLED
+		bool ignore_value_in_docs = false;
+#endif
 
 		VariantContainer() {}
 
@@ -125,6 +128,9 @@ public:
 
 	void set_initial_value(const String &p_name, const Variant &p_value);
 	void set_restart_if_changed(const String &p_name, bool p_restart);
+	void set_ignore_value_in_docs(const String &p_name, bool p_ignore);
+	bool get_ignore_value_in_docs(const String &p_name) const;
+
 	bool property_can_revert(const String &p_name);
 	Variant property_get_revert(const String &p_name);
 
@@ -167,9 +173,11 @@ public:
 };
 
 //not a macro any longer
-Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false);
+Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false);
 #define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value)
 #define GLOBAL_DEF_RST(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
+#define GLOBAL_DEF_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true)
+#define GLOBAL_DEF_RST_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true)
 #define GLOBAL_GET(m_var) ProjectSettings::get_singleton()->get(m_var)
 
 #endif // PROJECT_SETTINGS_H

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1025,6 +1025,9 @@ String String::chr(CharType p_char) {
 }
 
 String String::num(double p_num, int p_decimals) {
+	if (Math::is_nan(p_num)) {
+		return "nan";
+	}
 #ifndef NO_USE_STDLIB
 
 	if (p_decimals > 16) {
@@ -1313,6 +1316,9 @@ String String::num_real(double p_num) {
 }
 
 String String::num_scientific(double p_num) {
+	if (Math::is_nan(p_num)) {
+		return "nan";
+	}
 #ifndef NO_USE_STDLIB
 
 	char buf[256];

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -898,7 +898,7 @@
 		<constant name="KEY_MASK_CTRL" value="268435456" enum="KeyModifierMask">
 			Ctrl key mask.
 		</constant>
-		<constant name="KEY_MASK_CMD" value="268435456" enum="KeyModifierMask">
+		<constant name="KEY_MASK_CMD" value="platform-dependent" enum="KeyModifierMask">
 			Command key mask. On macOS, this is equivalent to [constant KEY_MASK_META]. On other platforms, this is equivalent to [constant KEY_MASK_CTRL]. This mask should be preferred to [constant KEY_MASK_META] or [constant KEY_MASK_CTRL] for system shortcuts as it handles all platforms correctly.
 		</constant>
 		<constant name="KEY_MASK_KPAD" value="536870912" enum="KeyModifierMask">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -244,7 +244,7 @@
 		<member name="audio/default_bus_layout" type="String" setter="" getter="" default="&quot;res://default_bus_layout.tres&quot;">
 			Default [AudioBusLayout] resource file to use in the project, unless overridden by the scene.
 		</member>
-		<member name="audio/driver" type="String" setter="" getter="" default="&quot;PulseAudio&quot;">
+		<member name="audio/driver" type="String" setter="" getter="">
 			Specifies the audio driver to use. This setting is platform-dependent as each platform supports different audio drivers. If left empty, the default audio driver will be used.
 		</member>
 		<member name="audio/enable_audio_input" type="bool" setter="" getter="" default="false">
@@ -453,7 +453,7 @@
 		<member name="display/window/size/width" type="int" setter="" getter="" default="1024">
 			Sets the game's main viewport width. On desktop platforms, this is the default window size. Stretch mode settings also use this as a reference when enabled.
 		</member>
-		<member name="display/window/tablet_driver" type="String" setter="" getter="" default="&quot;&quot;">
+		<member name="display/window/tablet_driver" type="String" setter="" getter="">
 			Specifies the tablet driver to use. If left empty, the default driver will be used.
 		</member>
 		<member name="display/window/vsync/use_vsync" type="bool" setter="" getter="" default="true">
@@ -472,7 +472,7 @@
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">
 			Default value for [member ScrollContainer.scroll_deadzone], which will be used for all [ScrollContainer]s unless overridden.
 		</member>
-		<member name="gui/common/swap_cancel_ok" type="bool" setter="" getter="" default="false">
+		<member name="gui/common/swap_cancel_ok" type="bool" setter="" getter="">
 			If [code]true[/code], swaps Cancel and OK buttons in dialogs on Windows and UWP to follow interface conventions.
 		</member>
 		<member name="gui/common/text_edit_undo_stack_max_size" type="int" setter="" getter="" default="1024">

--- a/editor/doc_data.cpp
+++ b/editor/doc_data.cpp
@@ -321,12 +321,13 @@ void DocData::generate(bool p_basic_types) {
 					continue;
 				}
 				if (E->get().usage & PROPERTY_USAGE_EDITOR) {
-					default_value = ProjectSettings::get_singleton()->property_get_revert(E->get().name);
-					default_value_valid = true;
+					if (!ProjectSettings::get_singleton()->get_ignore_value_in_docs(E->get().name)) {
+						default_value = ProjectSettings::get_singleton()->property_get_revert(E->get().name);
+						default_value_valid = true;
+					}
 				}
 			} else {
 				default_value = get_documentation_default_value(name, E->get().name, default_value_valid);
-
 				if (inherited) {
 					bool base_default_value_valid = false;
 					Variant base_default_value = get_documentation_default_value(ClassDB::get_parent_class(name), E->get().name, base_default_value_valid);
@@ -478,6 +479,7 @@ void DocData::generate(bool p_basic_types) {
 			ConstantDoc constant;
 			constant.name = E->get();
 			constant.value = itos(ClassDB::get_integer_constant(name, E->get()));
+			constant.is_value_valid = true;
 			constant.enumeration = ClassDB::get_integer_constant_enum(name, E->get());
 			c.constants.push_back(constant);
 		}
@@ -620,6 +622,7 @@ void DocData::generate(bool p_basic_types) {
 			constant.name = E->get();
 			Variant value = Variant::get_constant_value(Variant::Type(i), E->get());
 			constant.value = value.get_type() == Variant::INT ? itos(value) : value.get_construct_string();
+			constant.is_value_valid = true;
 			c.constants.push_back(constant);
 		}
 	}
@@ -635,7 +638,12 @@ void DocData::generate(bool p_basic_types) {
 		for (int i = 0; i < GlobalConstants::get_global_constant_count(); i++) {
 			ConstantDoc cd;
 			cd.name = GlobalConstants::get_global_constant_name(i);
-			cd.value = itos(GlobalConstants::get_global_constant_value(i));
+			if (!GlobalConstants::get_ignore_value_in_docs(i)) {
+				cd.value = itos(GlobalConstants::get_global_constant_value(i));
+				cd.is_value_valid = true;
+			} else {
+				cd.is_value_valid = false;
+			}
 			cd.enumeration = GlobalConstants::get_global_constant_enum(i);
 			c.constants.push_back(cd);
 		}
@@ -715,6 +723,7 @@ void DocData::generate(bool p_basic_types) {
 				ConstantDoc cd;
 				cd.name = E->get().first;
 				cd.value = E->get().second;
+				cd.is_value_valid = true;
 				c.constants.push_back(cd);
 			}
 
@@ -989,6 +998,7 @@ Error DocData::_load(Ref<XMLParser> parser) {
 								constant2.name = parser->get_attribute_value("name");
 								ERR_FAIL_COND_V(!parser->has_attribute("value"), ERR_FILE_CORRUPT);
 								constant2.value = parser->get_attribute_value("value");
+								constant2.is_value_valid = true;
 								if (parser->has_attribute("enum")) {
 									constant2.enumeration = parser->get_attribute_value("enum");
 								}
@@ -1178,10 +1188,18 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 
 		for (int i = 0; i < c.constants.size(); i++) {
 			const ConstantDoc &k = c.constants[i];
-			if (k.enumeration != String()) {
-				_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value + "\" enum=\"" + k.enumeration + "\">");
+			if (k.is_value_valid) {
+				if (k.enumeration != String()) {
+					_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value + "\" enum=\"" + k.enumeration + "\">");
+				} else {
+					_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value + "\">");
+				}
 			} else {
-				_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value + "\">");
+				if (k.enumeration != String()) {
+					_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"platform-dependent\" enum=\"" + k.enumeration + "\">");
+				} else {
+					_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"platform-dependent\">");
+				}
 			}
 			_write_string(f, 3, k.description.strip_edges().xml_escape());
 			_write_string(f, 2, "</constant>");

--- a/editor/doc_data.h
+++ b/editor/doc_data.h
@@ -62,6 +62,7 @@ public:
 	struct ConstantDoc {
 		String name;
 		String value;
+		bool is_value_valid;
 		String enumeration;
 		String description;
 		bool operator<(const ConstantDoc &p_const) const {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1091,7 +1091,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	OS::get_singleton()->_vsync_via_compositor = window_vsync_via_compositor;
 
 	if (tablet_driver == "") { // specified in project.godot
-		tablet_driver = GLOBAL_DEF_RST("display/window/tablet_driver", OS::get_singleton()->get_tablet_driver_name(0));
+		tablet_driver = GLOBAL_DEF_RST_NOVAL("display/window/tablet_driver", OS::get_singleton()->get_tablet_driver_name(0));
 	}
 
 	for (int i = 0; i < OS::get_singleton()->get_tablet_driver_count(); i++) {
@@ -1145,7 +1145,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (audio_driver == "") { // specified in project.godot
-		audio_driver = GLOBAL_DEF_RST("audio/driver", AudioDriverManager::get_driver(0)->get_name());
+		audio_driver = GLOBAL_DEF_RST_NOVAL("audio/driver", AudioDriverManager::get_driver(0)->get_name());
 	}
 
 	for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -372,7 +372,7 @@ void register_scene_types() {
 
 	OS::get_singleton()->yield(); //may take time to init
 
-	AcceptDialog::set_swap_cancel_ok(GLOBAL_DEF("gui/common/swap_cancel_ok", bool(DisplayServer::get_singleton()->get_swap_cancel_ok())));
+	AcceptDialog::set_swap_cancel_ok(GLOBAL_DEF_NOVAL("gui/common/swap_cancel_ok", bool(DisplayServer::get_singleton()->get_swap_cancel_ok())));
 #endif
 
 	/* REGISTER 3D */


### PR DESCRIPTION
- Add "nan" checks in the float to string functions (*nix sprintf always print it as "nan", Windows can print NaNs as "1#.IND" or "nan(ind)" depending on the runtime version).
- Add options to ignore default values of the global constants, project settings and properties.
- Sync docs to apply these changes.

Fixes #30038 (the rest of it, not fixed by #38891).