### PR TITLE
Add to_global_basis/to_local_basis methods to Node2D/Node3D

### DIFF
--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -95,6 +95,15 @@
 				Transforms the provided local position into a position in global coordinate space. The input is expected to be local relative to the [Node2D] it is called on. e.g. Applying this method to the positions of child nodes will correctly transform their positions into the global coordinate space, but applying it to a node's own position will give an incorrect result, as it will incorporate the node's own transformation into its global position.
 			</description>
 		</method>
+		<method name="to_global_basis" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="local_direction" type="Vector2">
+			</argument>
+			<description>
+				Transforms the provided local direction into a direction in global coordinate space.
+			</description>
+		</method>
 		<method name="to_local" qualifiers="const">
 			<return type="Vector2">
 			</return>
@@ -102,6 +111,15 @@
 			</argument>
 			<description>
 				Transforms the provided global position into a position in local coordinate space. The output will be local relative to the [Node2D] it is called on. e.g. It is appropriate for determining the positions of child nodes, but it is not appropriate for determining its own position relative to its parent.
+			</description>
+		</method>
+		<method name="to_local_basis" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="global_direction" type="Vector2">
+			</argument>
+			<description>
+				Transforms the provided global direction into a direction in local coordinate space.
 			</description>
 		</method>
 		<method name="translate">

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -263,6 +263,15 @@
 				Transforms [code]local_point[/code] from this node's local space to world space.
 			</description>
 		</method>
+		<method name="to_global_basis" qualifiers="const">
+			<return type="Vector3">
+			</return>
+			<argument index="0" name="local_direction" type="Vector3">
+			</argument>
+			<description>
+				Transforms [code]local_direction[/code] from this node's local space to world space.
+			</description>
+		</method>
 		<method name="to_local" qualifiers="const">
 			<return type="Vector3">
 			</return>
@@ -270,6 +279,15 @@
 			</argument>
 			<description>
 				Transforms [code]global_point[/code] from world space to this node's local space.
+			</description>
+		</method>
+		<method name="to_local_basis" qualifiers="const">
+			<return type="Vector3">
+			</return>
+			<argument index="0" name="global_direction" type="Vector3">
+			</argument>
+			<description>
+				Transforms [code]global_direction[/code] from world space to this node's local space.
 			</description>
 		</method>
 		<method name="translate">

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -408,6 +408,14 @@ Point2 Node2D::to_global(Point2 p_local) const {
 	return get_global_transform().xform(p_local);
 }
 
+Point2 Node2D::to_local_basis(Point2 p_global) const {
+	return get_global_transform().basis_xform_inv(p_global);
+}
+
+Point2 Node2D::to_global_basis(Point2 p_local) const {
+	return get_global_transform().basis_xform(p_local);
+}
+
 void Node2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_position", "position"), &Node2D::set_position);
 	ClassDB::bind_method(D_METHOD("set_rotation", "radians"), &Node2D::set_rotation);
@@ -447,6 +455,8 @@ void Node2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("to_local", "global_point"), &Node2D::to_local);
 	ClassDB::bind_method(D_METHOD("to_global", "local_point"), &Node2D::to_global);
+	ClassDB::bind_method(D_METHOD("to_local_basis", "global_direction"), &Node2D::to_local_basis);
+	ClassDB::bind_method(D_METHOD("to_global_basis", "local_direction"), &Node2D::to_global_basis);
 
 	ClassDB::bind_method(D_METHOD("set_z_index", "z_index"), &Node2D::set_z_index);
 	ClassDB::bind_method(D_METHOD("get_z_index"), &Node2D::get_z_index);

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -113,6 +113,8 @@ public:
 
 	Point2 to_local(Point2 p_global) const;
 	Point2 to_global(Point2 p_local) const;
+	Point2 to_local_basis(Point2 p_global) const;
+	Point2 to_global_basis(Point2 p_local) const;
 
 	void set_z_as_relative(bool p_enabled);
 	bool is_z_relative() const;

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -674,6 +674,13 @@ Vector3 Node3D::to_global(Vector3 p_local) const {
 	return get_global_transform().xform(p_local);
 }
 
+Vector3 Node3D::to_local_basis(Vector3 p_global) const {
+	return get_global_transform().get_basis().xform_inv(p_global);
+}
+
+Vector3 Node3D::to_global_basis(Vector3 p_local) const {
+	return get_global_transform().get_basis().xform(p_local);
+}
 void Node3D::set_notify_transform(bool p_enable) {
 	data.notify_transform = p_enable;
 }
@@ -760,6 +767,8 @@ void Node3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("to_local", "global_point"), &Node3D::to_local);
 	ClassDB::bind_method(D_METHOD("to_global", "local_point"), &Node3D::to_global);
+	ClassDB::bind_method(D_METHOD("to_local_basis", "global_direction"), &Node3D::to_local_basis);
+	ClassDB::bind_method(D_METHOD("to_global_basis", "local_direction"), &Node3D::to_global_basis);
 
 	BIND_CONSTANT(NOTIFICATION_TRANSFORM_CHANGED);
 	BIND_CONSTANT(NOTIFICATION_ENTER_WORLD);

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -179,6 +179,8 @@ public:
 
 	Vector3 to_local(Vector3 p_global) const;
 	Vector3 to_global(Vector3 p_local) const;
+	Vector3 to_local_basis(Vector3 p_global) const;
+	Vector3 to_global_basis(Vector3 p_local) const;
 
 	void set_notify_transform(bool p_enable);
 	bool is_transform_notification_enabled() const;


### PR DESCRIPTION
This adds convenience functions to rotate vectors from global to local space (and the other way around), [as proposed here](https://github.com/godotengine/godot-proposals/issues/857).

I would mainly like to get opinions about the 2D version as I wasn't entirely sure about how I should name the methods.

Note that this can be backported easily to 3.2 by adding this to Spatial instead of Node3D.