### PR TITLE
Fix #38904 - XMLParser/_parse_comment - detect the end of comment

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -205,17 +205,20 @@ void XMLParser::_parse_comment() {
 
 	char *pCommentBegin = P;
 
-	int count = 1;
+	ERR_FAIL_COND_MSG(*P != '-', "Bad XML comment");
+	++P;
+	ERR_FAIL_COND_MSG(*P != '-', "Bad XML comment");
+	++P;
 
 	// move until end of comment reached
-	while (count) {
-		if (*P == '>') {
-			--count;
-		} else if (*P == '<') {
-			++count;
-		}
-
+	for (;;) {
+		while (*P != '-')
+			++P;
+		if (*P != '-')
+			continue;
 		++P;
+		if (*P == '>')
+			break;
 	}
 
 	P -= 3;


### PR DESCRIPTION
*Bugsquad edit:* Fixes #38904.