### PR TITLE
Set PopupPanel style margins to 0 (previously 8)

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -481,6 +481,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_popup->set_shadow_color(shadow_color);
 	style_popup->set_shadow_size(4 * EDSCALE);
 
+	Ref<StyleBoxFlat> style_popup_panel = style_popup->duplicate();
+	style_popup_panel->set_default_margin(MARGIN_LEFT, 0);
+	style_popup_panel->set_default_margin(MARGIN_TOP, 0);
+	style_popup_panel->set_default_margin(MARGIN_RIGHT, 0);
+	style_popup_panel->set_default_margin(MARGIN_BOTTOM, 0);
+
 	Ref<StyleBoxLine> style_popup_separator(memnew(StyleBoxLine));
 	style_popup_separator->set_color(separator_color);
 	style_popup_separator->set_grow_begin(popup_margin_size - MAX(EDSCALE, border_width));
@@ -1013,7 +1019,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("panel", "TooltipPanel", style_tooltip);
 
 	// PopupPanel
-	theme->set_stylebox("panel", "PopupPanel", style_popup);
+	theme->set_stylebox("panel", "PopupPanel", style_popup_panel);
 
 	// SpinBox
 	theme->set_icon("updown", "SpinBox", theme->get_icon("GuiSpinboxUpdown", "EditorIcons"));


### PR DESCRIPTION
This fixes part of #38817 where the rename popup styling had a regression.
The other bugs in the above issue still exist.

Before:
![FEOs3qZN1K](https://user-images.githubusercontent.com/41730826/82510964-4cb6ee00-9b4f-11ea-9c0d-67e7374077b4.gif)

After:
![yU5ZQlPZqZ](https://user-images.githubusercontent.com/41730826/82511013-77a14200-9b4f-11ea-8a66-518c594ea351.gif)

