### PR TITLE
Delete DummyMesh when RasterizerStorageDummy is Freed

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -861,6 +861,13 @@ public:
 			texture_owner.free(p_rid);
 			memdelete(texture);
 		}
+
+		if (mesh_owner.owns(p_rid)) {
+			// delete the mesh
+			DummyMesh *mesh = mesh_owner.getornull(p_rid);
+			mesh_owner.free(p_rid);
+			memdelete(mesh);
+		}
 		return true;
 	}
 


### PR DESCRIPTION
I came across this little bug while playing around with `OS_Server` on the 3.2.1 and it appears to still be valid on master (although I must admit the server code does not appear to be stable currently on master so I was only able to test against the `3.2.1` tag). Basically, when you run an executable such as:

```c++
#include "main/main.h"
#include "os_server.h"
#include "scene/resources/primitive_meshes.h"

int main(int argc, char *argv[]) {
	OS_Server os;

	Error err = Main::setup(argv[0], argc - 1, &argv[1]);
	if (err != OK)
		return 255;

	{
		Ref<SphereMesh> sphere_mesh;
		sphere_mesh.instance();
		Array arrays = sphere_mesh->surface_get_arrays(0);
	}

	Main::cleanup();

	return os.get_exit_code();
}
```

upon `Main::cleanup()` you get the warning:

```
ERROR: cleanup: There are still MemoryPool allocs in use at exit!
```

I was able to trace these lingering allocation to the `RasterizerStorageDummy`'s `mesh_owner` (specifically the mesh's vertex and index arrays https://github.com/godotengine/godot/blob/0b8cb945cf0d65a9061dee7c780a405d4b26ef00/drivers/dummy/rasterizer_dummy.h#L390-L392) which doesn't appear to be getting freed in `RasterizerStorageDummy`'s `free` method.

This is just a small PR to free the `mesh_owner` and mesh similar to what we're already doing for `texture_owner` in this class. This appears to resolve the MemoryPool allocation leak.