### PR TITLE
Fixed issue with slider focus and scroll input

### DIFF
--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -73,8 +73,10 @@ void Slider::_gui_input(Ref<InputEvent> p_event) {
 			}
 		} else if (scrollable) {
 			if (mb->is_pressed() && mb->get_button_index() == BUTTON_WHEEL_UP) {
+				grab_focus();
 				set_value(get_value() + get_step());
 			} else if (mb->is_pressed() && mb->get_button_index() == BUTTON_WHEEL_DOWN) {
+				grab_focus();
 				set_value(get_value() - get_step());
 			}
 		}


### PR DESCRIPTION
Slider remained highlighted when you used scroll input to change another slider. Now the new slider grabs focus.
Before:
![iVveVUWTJV](https://user-images.githubusercontent.com/41730826/82555005-4e61cf80-9baa-11ea-8bf8-dcd5cee8f73c.gif)

After:
![bTpvqcKMxE](https://user-images.githubusercontent.com/41730826/82554950-35f1b500-9baa-11ea-855c-273e92e6f966.gif)

Also I noticed there are quite significant differences between ScrollBar and Slider, even though the functionality is basically the same. For example, Scrollbar has a hovered and a pressed state - slider only has the former. Their input handling code is very different, which confused me a bit - why is it like this? Should Slider be reworked to function the same, but be more similar to ScrollBar? As in, try and synchronise their code so they are as similar as possible for ease of maintenance?