### PR TITLE
[3.x] Add access to the viewport's G-buffers (and depth).

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -79,7 +79,6 @@ const char *Image::format_names[Image::FORMAT_MAX] = {
 	"ETC2_RGB8",
 	"ETC2_RGBA8",
 	"ETC2_RGB8A1",
-
 };
 
 SavePNGFunc Image::save_png_func = NULL;

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -87,7 +87,7 @@
 			<return type="ViewportTexture">
 			</return>
 			<description>
-				Returns the viewport's texture.
+				Returns the viewport's color texture.
 				[b]Note:[/b] Due to the way OpenGL works, the resulting [ViewportTexture] is flipped vertically. You can use [method Image.flip_y] on the result of [method Texture.get_data] to flip it back, for example:
 				[codeblock]
 				var img = get_viewport().get_texture().get_data()
@@ -234,6 +234,9 @@
 		</member>
 		<member name="disable_3d" type="bool" setter="set_disable_3d" getter="is_3d_disabled" default="false">
 			If [code]true[/code], the viewport will disable 3D rendering. For actual disabling use [code]usage[/code].
+		</member>
+		<member name="force_mrt" type="bool" setter="set_force_mrt" getter="is_force_mrt" default="false">
+			If [code]true[/code], the viewport will use multiple render targets even when effects like screen space reflections aren't enabled. This can be used to ensure that some buffers in a [ViewportTexture] stay available. It won't however work if the viewport were transparent, or if its usage is anything other than [enum Usage.3D].
 		</member>
 		<member name="global_canvas_transform" type="Transform2D" setter="set_global_canvas_transform" getter="get_global_canvas_transform">
 			The global canvas transform of the viewport. The canvas transform is relative to this.

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -235,8 +235,8 @@
 		<member name="disable_3d" type="bool" setter="set_disable_3d" getter="is_3d_disabled" default="false">
 			If [code]true[/code], the viewport will disable 3D rendering. For actual disabling use [code]usage[/code].
 		</member>
-		<member name="force_mrt" type="bool" setter="set_force_mrt" getter="is_force_mrt" default="false">
-			If [code]true[/code], the viewport will use multiple render targets even when effects like screen space reflections aren't enabled. This can be used to ensure that some buffers in a [ViewportTexture] stay available. It won't however work if the viewport were transparent, or if its usage is anything other than [constant USAGE_3D].
+		<member name="expose_gbuffer" type="bool" setter="set_expose_gbuffer" getter="is_expose_gbuffer" default="false">
+			If [code]true[/code], the viewport will expose its g-buffers (Diffuse, Specular, Normal and Subsurface) to any ViewportTexture that may use it. It won't however work if the viewport were transparent, or if its usage is anything other than [constant USAGE_3D]. It also won't work in GLES2.
 		</member>
 		<member name="global_canvas_transform" type="Transform2D" setter="set_global_canvas_transform" getter="get_global_canvas_transform">
 			The global canvas transform of the viewport. The canvas transform is relative to this.

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -236,7 +236,7 @@
 			If [code]true[/code], the viewport will disable 3D rendering. For actual disabling use [code]usage[/code].
 		</member>
 		<member name="force_mrt" type="bool" setter="set_force_mrt" getter="is_force_mrt" default="false">
-			If [code]true[/code], the viewport will use multiple render targets even when effects like screen space reflections aren't enabled. This can be used to ensure that some buffers in a [ViewportTexture] stay available. It won't however work if the viewport were transparent, or if its usage is anything other than [enum Usage.USAGE_3D].
+			If [code]true[/code], the viewport will use multiple render targets even when effects like screen space reflections aren't enabled. This can be used to ensure that some buffers in a [ViewportTexture] stay available. It won't however work if the viewport were transparent, or if its usage is anything other than [constant USAGE_3D].
 		</member>
 		<member name="global_canvas_transform" type="Transform2D" setter="set_global_canvas_transform" getter="get_global_canvas_transform">
 			The global canvas transform of the viewport. The canvas transform is relative to this.

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -236,7 +236,7 @@
 			If [code]true[/code], the viewport will disable 3D rendering. For actual disabling use [code]usage[/code].
 		</member>
 		<member name="force_mrt" type="bool" setter="set_force_mrt" getter="is_force_mrt" default="false">
-			If [code]true[/code], the viewport will use multiple render targets even when effects like screen space reflections aren't enabled. This can be used to ensure that some buffers in a [ViewportTexture] stay available. It won't however work if the viewport were transparent, or if its usage is anything other than [enum Usage.3D].
+			If [code]true[/code], the viewport will use multiple render targets even when effects like screen space reflections aren't enabled. This can be used to ensure that some buffers in a [ViewportTexture] stay available. It won't however work if the viewport were transparent, or if its usage is anything other than [enum Usage.USAGE_3D].
 		</member>
 		<member name="global_canvas_transform" type="Transform2D" setter="set_global_canvas_transform" getter="get_global_canvas_transform">
 			The global canvas transform of the viewport. The canvas transform is relative to this.

--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -17,6 +17,9 @@
 		<member name="viewport_path" type="NodePath" setter="set_viewport_path_in_scene" getter="get_viewport_path_in_scene" default="NodePath(&quot;&quot;)">
 			The path to the [Viewport] node to display. This is relative to the scene root, not to the node which uses the texture.
 		</member>
+		<member name="buffer_mode" type="int" setter="set_buffer_mode" getter="get_buffer_mode">
+			The kind of buffer the [ViewportTexture] will represent. Some buffers won't be available depending on the graphics driver, and the accosiated viewport's settings (see [enum ViewportTextureBuffer]).
+		</member>
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -18,7 +18,7 @@
 			The path to the [Viewport] node to display. This is relative to the scene root, not to the node which uses the texture.
 		</member>
 		<member name="buffer_mode" type="int" setter="set_buffer_mode" getter="get_buffer_mode">
-			The kind of buffer the [ViewportTexture] will represent. Some buffers won't be available depending on the graphics driver, and the accosiated viewport's settings (see [enum VisualServer.ViewportTextureBuffer]).
+			The kind of buffer the [ViewportTexture] will represent. Some buffers won't be available depending on the graphics driver, and whether the [Viewport]'s [member Viewport.expose_gbuffer] is enabled. Also see [enum VisualServer.ViewportTextureBuffer].
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -18,7 +18,7 @@
 			The path to the [Viewport] node to display. This is relative to the scene root, not to the node which uses the texture.
 		</member>
 		<member name="buffer_mode" type="int" setter="set_buffer_mode" getter="get_buffer_mode">
-			The kind of buffer the [ViewportTexture] will represent. Some buffers won't be available depending on the graphics driver, and the accosiated viewport's settings (see [enum ViewportTextureBuffer]).
+			The kind of buffer the [ViewportTexture] will represent. Some buffers won't be available depending on the graphics driver, and the accosiated viewport's settings (see [enum VisualServer.ViewportTextureBuffer]).
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -4047,7 +4047,7 @@
 			<argument index="1" name="force_mrt" type="bool">
 			</argument>
 			<description>
-				If [code]true[/code], then multiple render targets will be used by this [Viewport] no matter what. (See [Viewport.force_mrt]).
+				If [code]true[/code], then multiple render targets will be used by this [Viewport] no matter what. (See [member Viewport.force_mrt]).
 			</description>
 		</method>
 		<method name="viewport_set_global_canvas_transform">

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -4039,6 +4039,17 @@
 				If [code]true[/code], rendering of a viewport's environment is disabled.
 			</description>
 		</method>
+		<method name="viewport_set_force_mrt">
+			<return type="void">
+			</return>
+			<argument index="0" name="viewport" type="RID">
+			</argument>
+			<argument index="1" name="force_mrt" type="bool">
+			</argument>
+			<description>
+				If [code]true[/code], then multiple render targets will be used by this [Viewport] no matter what. (See [Viewport.force_mrt]).
+			</description>
+		</method>
 		<method name="viewport_set_global_canvas_transform">
 			<return type="void">
 			</return>
@@ -4609,6 +4620,24 @@
 		</constant>
 		<constant name="VIEWPORT_RENDER_INFO_MAX" value="8" enum="ViewportRenderInfo">
 			Represents the size of the [enum ViewportRenderInfo] enum.
+		</constant>
+		<constant name="VIEWPORT_TEXTURE_BUFFER_COLOR" value="0" enum="ViewportTextureBuffer">
+			The color buffer of the [Viewport].
+		</constant>
+		<constant name="VIEWPORT_TEXTURE_BUFFER_DEPTH" value="1" enum="ViewportTextureBuffer">
+			The depth buffer of the [Viewport]. It is currently not possible to read it's data.
+		</constant>
+		<constant name="VIEWPORT_TEXTURE_BUFFER_DIFFUSE" value="2" enum="ViewportTextureBuffer">
+			The diffuse buffer of the [Viewport]. More specifically, it contains emission, diffuse and ambient light combined in the RGB channels, and ambient contribution in the alpha channel for SSAO. [b]GLES3 only.[/b]
+		</constant>
+		<constant name="VIEWPORT_TEXTURE_BUFFER_SPECULAR" value="3" enum="ViewportTextureBuffer">
+			The specular buffer of the [Viewport]. The RGB channels contain the specular color, and the alpha channel contains the metalness. [b]GLES3 only.[/b]
+		</constant>
+		<constant name="VIEWPORT_TEXTURE_BUFFER_NORMAL_ROUGH" value="4" enum="ViewportTextureBuffer">
+			The normal and roughness buffer of the [Viewport]. The RGB channels contain the normals in view space, and the alpha channel contains the roughness. [b]GLES3 only.[/b]
+		</constant>
+		<constant name="VIEWPORT_TEXTURE_BUFFER_SUBSURFACE" value="5" enum="ViewportTextureBuffer">
+			The subsurface scattering buffer of the [Viewport]. It's used for subsurface scattering effects. [b]GLES3 only.[/b]
 		</constant>
 		<constant name="VIEWPORT_DEBUG_DRAW_DISABLED" value="0" enum="ViewportDebugDraw">
 			Debug draw is disabled. Default setting.

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -4039,15 +4039,15 @@
 				If [code]true[/code], rendering of a viewport's environment is disabled.
 			</description>
 		</method>
-		<method name="viewport_set_force_mrt">
+		<method name="viewport_set_expose_gbuffer">
 			<return type="void">
 			</return>
 			<argument index="0" name="viewport" type="RID">
 			</argument>
-			<argument index="1" name="force_mrt" type="bool">
+			<argument index="1" name="expose_gbuffer" type="bool">
 			</argument>
 			<description>
-				If [code]true[/code], then multiple render targets will be used by this [Viewport] no matter what. (See [member Viewport.force_mrt]).
+				If [code]true[/code], then the g-buffers will be accessible by any [ViewportTexture] that use this [Viewport]. (See [member Viewport.expose_gbuffer]).
 			</description>
 		</method>
 		<method name="viewport_set_global_canvas_transform">

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -700,12 +700,13 @@ public:
 	RID render_target_create() { return RID(); }
 	void render_target_set_position(RID p_render_target, int p_x, int p_y) {}
 	void render_target_set_size(RID p_render_target, int p_width, int p_height) {}
-	RID render_target_get_texture(RID p_render_target) const { return RID(); }
+	RID render_target_get_texture(RID p_render_target, VS::ViewportTextureBuffer p_buffer) const { return RID(); }
 	void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) {}
 	void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) {}
 	bool render_target_was_used(RID p_render_target) { return false; }
 	void render_target_clear_used(RID p_render_target) {}
 	void render_target_set_msaa(RID p_render_target, VS::ViewportMSAA p_msaa) {}
+	void render_target_set_force_mrt(RID p_render_target, bool p_force_mrt) {}
 
 	/* CANVAS SHADOW */
 

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -706,7 +706,7 @@ public:
 	bool render_target_was_used(RID p_render_target) { return false; }
 	void render_target_clear_used(RID p_render_target) {}
 	void render_target_set_msaa(RID p_render_target, VS::ViewportMSAA p_msaa) {}
-	void render_target_set_force_mrt(RID p_render_target, bool p_force_mrt) {}
+	void render_target_set_expose_gbuffer(RID p_render_target, bool p_expose_gbuffer) {}
 
 	/* CANVAS SHADOW */
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5208,7 +5208,7 @@ RID RasterizerStorageGLES2::render_target_get_texture(RID p_render_target, VS::V
 		case VS::VIEWPORT_TEXTURE_BUFFER_DEPTH:
 			return rt->depth_texture;
 		default:
-			//printf("The buffer ", p_buffer, " is not available in GLES2.");
+			WARN_PRINT(String("The buffer " + itos(p_buffer) + " is not available in GLES2.").utf8().get_data());
 			return RID();
 	}
 }
@@ -5404,7 +5404,7 @@ void RasterizerStorageGLES2::render_target_set_msaa(RID p_render_target, VS::Vie
 	_render_target_allocate(rt);
 }
 
-void RasterizerStorageGLES2::render_target_set_force_mrt(RID p_render_target, bool p_force_mrt) {
+void RasterizerStorageGLES2::render_target_set_expose_gbuffer(RID p_render_target, bool p_expose_gbuffer) {
 	// Only available in GLES3.
 }
 

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1259,7 +1259,7 @@ public:
 	virtual bool render_target_was_used(RID p_render_target);
 	virtual void render_target_clear_used(RID p_render_target);
 	virtual void render_target_set_msaa(RID p_render_target, VS::ViewportMSAA p_msaa);
-	virtual void render_target_set_force_mrt(RID p_render_target, bool p_force_mrt);
+	virtual void render_target_set_expose_gbuffer(RID p_render_target, bool p_expose_gbuffer);
 
 	/* CANVAS SHADOW */
 

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1216,6 +1216,7 @@ public:
 		VS::ViewportMSAA msaa;
 
 		RID texture;
+		RID depth_texture;
 
 		bool used_dof_blur_near;
 		bool mip_maps_allocated;
@@ -1251,13 +1252,14 @@ public:
 	virtual RID render_target_create();
 	virtual void render_target_set_position(RID p_render_target, int p_x, int p_y);
 	virtual void render_target_set_size(RID p_render_target, int p_width, int p_height);
-	virtual RID render_target_get_texture(RID p_render_target) const;
+	virtual RID render_target_get_texture(RID p_render_target, VS::ViewportTextureBuffer p_buffer) const;
 	virtual void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id);
 
 	virtual void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value);
 	virtual bool render_target_was_used(RID p_render_target);
 	virtual void render_target_clear_used(RID p_render_target);
 	virtual void render_target_set_msaa(RID p_render_target, VS::ViewportMSAA p_msaa);
+	virtual void render_target_set_force_mrt(RID p_render_target, bool p_force_mrt);
 
 	/* CANVAS SHADOW */
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4554,7 +4554,7 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture_owner->getornull(rt->buffers.sss_texture)->tex_id, 0);
 			glBlitFramebuffer(0, 0, rt->width, rt->height, 0, 0, rt->width, rt->height, GL_COLOR_BUFFER_BIT, GL_LINEAR);
 		}
-		
+
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->color, 0);
 		glReadBuffer(GL_COLOR_ATTACHMENT0);
 		glBindFramebuffer(GL_FRAMEBUFFER, rt->buffers.fbo);

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -1379,10 +1379,6 @@ void RasterizerStorageGLES3::texture_set_flags(RID p_texture, uint32_t p_flags) 
 
 	Texture *texture = texture_owner.get(p_texture);
 	ERR_FAIL_COND(!texture);
-	if (texture->render_target) {
-
-		p_flags &= VS::TEXTURE_FLAG_FILTER; //can change only filter
-	}
 
 	bool had_mipmaps = texture->flags & VS::TEXTURE_FLAG_MIPMAPS;
 
@@ -7016,12 +7012,19 @@ void RasterizerStorageGLES3::_render_target_clear(RenderTarget *rt) {
 		glDeleteFramebuffers(1, &rt->buffers.fbo);
 		glDeleteRenderbuffers(1, &rt->buffers.depth);
 		glDeleteRenderbuffers(1, &rt->buffers.diffuse);
+
+		glDeleteTextures(1, &texture_owner.getornull(rt->buffers.diffuse_texture)->tex_id);
+
 		if (rt->buffers.effects_active) {
 			glDeleteRenderbuffers(1, &rt->buffers.specular);
 			glDeleteRenderbuffers(1, &rt->buffers.normal_rough);
 			glDeleteRenderbuffers(1, &rt->buffers.sss);
 			glDeleteFramebuffers(1, &rt->buffers.effect_fbo);
 			glDeleteTextures(1, &rt->buffers.effect);
+
+			glDeleteTextures(1, &texture_owner.getornull(rt->buffers.specular_texture)->tex_id);
+			glDeleteTextures(1, &texture_owner.getornull(rt->buffers.normal_rough_texture)->tex_id);
+			glDeleteTextures(1, &texture_owner.getornull(rt->buffers.sss_texture)->tex_id);
 		}
 
 		rt->buffers.effects_active = false;
@@ -7072,13 +7075,17 @@ void RasterizerStorageGLES3::_render_target_clear(RenderTarget *rt) {
 
 		rt->external.fbo = 0;
 	}
+	RID *rt_textures[6]{ &(rt->texture), &(rt->depth_texture), &(rt->buffers.diffuse_texture),
+		&(rt->buffers.specular_texture), &(rt->buffers.normal_rough_texture), &(rt->buffers.sss_texture) };
 
-	Texture *tex = texture_owner.get(rt->texture);
-	tex->alloc_height = 0;
-	tex->alloc_width = 0;
-	tex->width = 0;
-	tex->height = 0;
-	tex->active = false;
+	for (int i = 0; i < 6; i++) {
+		Texture *tex = texture_owner.get(*rt_textures[i]);
+		tex->alloc_height = 0;
+		tex->alloc_width = 0;
+		tex->width = 0;
+		tex->height = 0;
+		tex->active = false;
+	}
 
 	for (int i = 0; i < 2; i++) {
 		if (rt->effects.mip_maps[i].color) {
@@ -7148,20 +7155,18 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 
 		glGenTextures(1, &rt->depth);
 		glBindTexture(GL_TEXTURE_2D, rt->depth);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, rt->width, rt->height, 0,
-				GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, rt->width, rt->height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
 
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-				GL_TEXTURE_2D, rt->depth, 0);
-
+		GLint swizzleMask[] = { GL_RED, GL_RED, GL_RED, GL_ONE };
+		glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMask);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
+		
 		glGenTextures(1, &rt->color);
 		glBindTexture(GL_TEXTURE_2D, rt->color);
-
 		glTexImage2D(GL_TEXTURE_2D, 0, color_internal_format, rt->width, rt->height, 0, color_format, color_type, NULL);
 
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -7192,6 +7197,20 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 		tex->active = true;
 
 		texture_set_flags(rt->texture, tex->flags);
+
+		Texture *depth_tex = texture_owner.get(rt->depth_texture);
+		depth_tex->format = Image::FORMAT_RF;
+		depth_tex->gl_format_cache = GL_DEPTH_COMPONENT;
+		depth_tex->gl_type_cache = GL_UNSIGNED_INT;
+		depth_tex->gl_internal_format_cache = GL_DEPTH_COMPONENT24;
+		depth_tex->tex_id = rt->depth;
+		depth_tex->width = rt->width;
+		depth_tex->alloc_width = rt->width;
+		depth_tex->height = rt->height;
+		depth_tex->alloc_height = rt->height;
+		depth_tex->active = true;
+
+		texture_set_flags(rt->depth_texture, depth_tex->flags);
 	}
 
 	/* BACK FBO */
@@ -7216,6 +7235,7 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 
 		glGenRenderbuffers(1, &rt->buffers.depth);
 		glBindRenderbuffer(GL_RENDERBUFFER, rt->buffers.depth);
+
 		if (msaa == 0)
 			glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, rt->width, rt->height);
 		else
@@ -7233,6 +7253,30 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 
 		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rt->buffers.diffuse);
 
+		GLuint diffuse;
+		glGenTextures(1, &diffuse);
+		glBindTexture(GL_TEXTURE_2D, diffuse);
+		glTexImage2D(GL_TEXTURE_2D, 0, color_internal_format, rt->width, rt->height, 0, color_format, color_type, NULL);
+
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+		Texture *diffuse_tex = texture_owner.get(rt->buffers.diffuse_texture);
+		diffuse_tex->format = image_format;
+		diffuse_tex->gl_format_cache = color_format;
+		diffuse_tex->gl_type_cache = color_type;
+		diffuse_tex->gl_internal_format_cache = color_internal_format;
+		diffuse_tex->tex_id = diffuse;
+		diffuse_tex->width = rt->width;
+		diffuse_tex->alloc_width = rt->width;
+		diffuse_tex->height = rt->height;
+		diffuse_tex->alloc_height = rt->height;
+		diffuse_tex->active = true;
+
+		texture_set_flags(rt->buffers.diffuse_texture, diffuse_tex->flags);
+
 		if (!rt->flags[RENDER_TARGET_NO_3D_EFFECTS]) {
 
 			rt->buffers.effects_active = true;
@@ -7246,6 +7290,30 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 
 			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_RENDERBUFFER, rt->buffers.specular);
 
+			GLuint specular;
+			glGenTextures(1, &specular);
+			glBindTexture(GL_TEXTURE_2D, specular);
+			glTexImage2D(GL_TEXTURE_2D, 0, color_internal_format, rt->width, rt->height, 0, color_format, color_type, NULL);
+
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+			Texture *specular_tex = texture_owner.get(rt->buffers.specular_texture);
+			specular_tex->format = image_format;
+			specular_tex->gl_format_cache = color_format;
+			specular_tex->gl_type_cache = color_type;
+			specular_tex->gl_internal_format_cache = color_internal_format;
+			specular_tex->tex_id = specular;
+			specular_tex->width = rt->width;
+			specular_tex->alloc_width = rt->width;
+			specular_tex->height = rt->height;
+			specular_tex->alloc_height = rt->height;
+			specular_tex->active = true;
+
+			texture_set_flags(rt->buffers.specular_texture, specular_tex->flags);
+
 			glGenRenderbuffers(1, &rt->buffers.normal_rough);
 			glBindRenderbuffer(GL_RENDERBUFFER, rt->buffers.normal_rough);
 
@@ -7256,6 +7324,30 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 
 			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT2, GL_RENDERBUFFER, rt->buffers.normal_rough);
 
+			GLuint normal_rough;
+			glGenTextures(1, &normal_rough);
+			glBindTexture(GL_TEXTURE_2D, normal_rough);
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, rt->width, rt->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+			Texture *normal_rough_tex = texture_owner.get(rt->buffers.normal_rough_texture);
+			normal_rough_tex->format = Image::FORMAT_RGBA8;
+			normal_rough_tex->gl_format_cache = GL_RGBA;
+			normal_rough_tex->gl_type_cache = GL_UNSIGNED_BYTE;
+			normal_rough_tex->gl_internal_format_cache = GL_RGBA8;
+			normal_rough_tex->tex_id = normal_rough;
+			normal_rough_tex->width = rt->width;
+			normal_rough_tex->alloc_width = rt->width;
+			normal_rough_tex->height = rt->height;
+			normal_rough_tex->alloc_height = rt->height;
+			normal_rough_tex->active = true;
+
+			texture_set_flags(rt->buffers.normal_rough_texture, normal_rough_tex->flags);
+
 			glGenRenderbuffers(1, &rt->buffers.sss);
 			glBindRenderbuffer(GL_RENDERBUFFER, rt->buffers.sss);
 
@@ -7265,6 +7357,30 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 				glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa, GL_R8, rt->width, rt->height);
 
 			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT3, GL_RENDERBUFFER, rt->buffers.sss);
+
+			GLuint ss;
+			glGenTextures(1, &ss);
+			glBindTexture(GL_TEXTURE_2D, ss);
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, rt->width, rt->height, 0, GL_RED, GL_UNSIGNED_BYTE, NULL);
+
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+			Texture *ss_tex = texture_owner.get(rt->buffers.sss_texture);
+			ss_tex->format = Image::FORMAT_R8;
+			ss_tex->gl_format_cache = GL_RED;
+			ss_tex->gl_type_cache = GL_UNSIGNED_BYTE;
+			ss_tex->gl_internal_format_cache = GL_R8;
+			ss_tex->tex_id = ss;
+			ss_tex->width = rt->width;
+			ss_tex->alloc_width = rt->width;
+			ss_tex->height = rt->height;
+			ss_tex->alloc_height = rt->height;
+			ss_tex->active = true;
+
+			texture_set_flags(rt->buffers.sss_texture, ss_tex->flags);
 
 			GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 			glBindFramebuffer(GL_FRAMEBUFFER, RasterizerStorageGLES3::system_fbo);
@@ -7481,30 +7597,35 @@ RID RasterizerStorageGLES3::render_target_create() {
 
 	RenderTarget *rt = memnew(RenderTarget);
 
-	Texture *t = memnew(Texture);
+	RID *rt_textures[6]{ &(rt->texture), &(rt->depth_texture), &(rt->buffers.diffuse_texture),
+		&(rt->buffers.specular_texture), &(rt->buffers.normal_rough_texture), &(rt->buffers.sss_texture) };
 
-	t->type = VS::TEXTURE_TYPE_2D;
-	t->flags = 0;
-	t->width = 0;
-	t->height = 0;
-	t->alloc_height = 0;
-	t->alloc_width = 0;
-	t->format = Image::FORMAT_R8;
-	t->target = GL_TEXTURE_2D;
-	t->gl_format_cache = 0;
-	t->gl_internal_format_cache = 0;
-	t->gl_type_cache = 0;
-	t->data_size = 0;
-	t->compressed = false;
-	t->srgb = false;
-	t->total_data_size = 0;
-	t->ignore_mipmaps = false;
-	t->mipmaps = 1;
-	t->active = true;
-	t->tex_id = 0;
-	t->render_target = rt;
+	for (int i = 0; i < 6; i++) {
+		Texture *t = memnew(Texture);
 
-	rt->texture = texture_owner.make_rid(t);
+		t->type = VS::TEXTURE_TYPE_2D;
+		t->flags = 0;
+		t->width = 0;
+		t->height = 0;
+		t->alloc_height = 0;
+		t->alloc_width = 0;
+		t->format = Image::FORMAT_R8;
+		t->target = GL_TEXTURE_2D;
+		t->gl_format_cache = 0;
+		t->gl_internal_format_cache = 0;
+		t->gl_type_cache = 0;
+		t->data_size = 0;
+		t->compressed = false;
+		t->srgb = false;
+		t->total_data_size = 0;
+		t->ignore_mipmaps = false;
+		t->mipmaps = 1;
+		t->active = true;
+		t->tex_id = 0;
+		t->render_target = rt;
+
+		*rt_textures[i] = texture_owner.make_rid(t);
+	}
 
 	return render_target_owner.make_rid(rt);
 }
@@ -7527,16 +7648,31 @@ void RasterizerStorageGLES3::render_target_set_size(RID p_render_target, int p_w
 	_render_target_allocate(rt);
 }
 
-RID RasterizerStorageGLES3::render_target_get_texture(RID p_render_target) const {
+RID RasterizerStorageGLES3::render_target_get_texture(RID p_render_target, VS::ViewportTextureBuffer p_buffer) const {
 
 	RenderTarget *rt = render_target_owner.getornull(p_render_target);
 	ERR_FAIL_COND_V(!rt, RID());
 
-	if (rt->external.fbo == 0) {
-		return rt->texture;
-	} else {
-		return rt->external.texture;
+	switch (p_buffer) {
+		case VS::VIEWPORT_TEXTURE_BUFFER_COLOR:
+			if (rt->external.fbo == 0) {
+				return rt->texture;
+			} else {
+				return rt->external.texture;
+			}
+		case VS::VIEWPORT_TEXTURE_BUFFER_DEPTH:
+			return rt->depth_texture;
+		case VS::VIEWPORT_TEXTURE_BUFFER_DIFFUSE:
+			return rt->buffers.diffuse_texture;
+		case VS::VIEWPORT_TEXTURE_BUFFER_SPECULAR:
+			return rt->buffers.specular_texture;
+		case VS::VIEWPORT_TEXTURE_BUFFER_NORMAL_ROUGH:
+			return rt->buffers.normal_rough_texture;
+		case VS::VIEWPORT_TEXTURE_BUFFER_SUBSURFACE:
+			return rt->buffers.sss_texture;
 	}
+
+	return RID();
 }
 
 void RasterizerStorageGLES3::render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) {
@@ -7675,6 +7811,14 @@ void RasterizerStorageGLES3::render_target_set_msaa(RID p_render_target, VS::Vie
 	_render_target_clear(rt);
 	rt->msaa = p_msaa;
 	_render_target_allocate(rt);
+}
+
+void RasterizerStorageGLES3::render_target_set_force_mrt(RID p_render_target, bool p_force_mrt) {
+
+	RenderTarget *rt = render_target_owner.getornull(p_render_target);
+	ERR_FAIL_COND(!rt);
+
+	rt->force_mrt = p_force_mrt;
 }
 
 /* CANVAS SHADOW */
@@ -7879,10 +8023,37 @@ bool RasterizerStorageGLES3::free(RID p_rid) {
 	if (render_target_owner.owns(p_rid)) {
 
 		RenderTarget *rt = render_target_owner.getornull(p_rid);
+		bool buffers_active = rt->buffers.active;
+		bool buffer_effects_active = rt->buffers.effects_active;
 		_render_target_clear(rt);
+		/*RID *rt_textures[6]{ &(rt->texture), &(rt->depth_texture), &(rt->buffers.diffuse_texture),
+			&(rt->buffers.specular_texture), &(rt->buffers.normal_rough_texture), &(rt->buffers.sss_texture) };*/
+
 		Texture *t = texture_owner.get(rt->texture);
 		texture_owner.free(rt->texture);
 		memdelete(t);
+		Texture *dt = texture_owner.get(rt->depth_texture);
+		texture_owner.free(rt->depth_texture);
+		memdelete(dt);
+		if (buffers_active) {
+			Texture *ddt = texture_owner.get(rt->buffers.diffuse_texture);
+			texture_owner.free(rt->buffers.diffuse_texture);
+			memdelete(ddt);
+
+			if (buffer_effects_active) {
+				Texture *st = texture_owner.get(rt->buffers.specular_texture);
+				texture_owner.free(rt->buffers.specular_texture);
+				memdelete(st);
+
+				Texture *nrt = texture_owner.get(rt->buffers.normal_rough_texture);
+				texture_owner.free(rt->buffers.normal_rough_texture);
+				memdelete(nrt);
+
+				Texture *sst = texture_owner.get(rt->buffers.sss_texture);
+				texture_owner.free(rt->buffers.sss_texture);
+				memdelete(sst);
+			}
+		}
 		render_target_owner.free(p_rid);
 		memdelete(rt);
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -7164,7 +7164,7 @@ void RasterizerStorageGLES3::_render_target_allocate(RenderTarget *rt) {
 		GLint swizzleMask[] = { GL_RED, GL_RED, GL_RED, GL_ONE };
 		glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, swizzleMask);
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
-		
+
 		glGenTextures(1, &rt->color);
 		glBindTexture(GL_TEXTURE_2D, rt->color);
 		glTexImage2D(GL_TEXTURE_2D, 0, color_internal_format, rt->width, rt->height, 0, color_format, color_type, NULL);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1303,7 +1303,7 @@ public:
 
 			RID specular_texture;
 			RID diffuse_texture;
-			RID normal_rough_texture;
+			RID normal_texture;
 			RID sss_texture;
 		} buffers;
 
@@ -1374,7 +1374,7 @@ public:
 
 		bool used_in_frame;
 		VS::ViewportMSAA msaa;
-		bool force_mrt;
+		bool expose_gbuffer;
 
 		RID texture;
 		RID depth_texture;
@@ -1387,7 +1387,7 @@ public:
 				height(0),
 				used_in_frame(false),
 				msaa(VS::VIEWPORT_MSAA_DISABLED),
-				force_mrt(false) {
+				expose_gbuffer(false) {
 			exposure.fbo = 0;
 			buffers.fbo = 0;
 			external.fbo = 0;
@@ -1415,7 +1415,7 @@ public:
 	virtual bool render_target_was_used(RID p_render_target);
 	virtual void render_target_clear_used(RID p_render_target);
 	virtual void render_target_set_msaa(RID p_render_target, VS::ViewportMSAA p_msaa);
-	virtual void render_target_set_force_mrt(RID p_render_target, bool p_force_mrt);
+	virtual void render_target_set_expose_gbuffer(RID p_render_target, bool p_expose_gbuffer);
 
 	/* CANVAS SHADOW */
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1301,6 +1301,10 @@ public:
 			GLuint effect_fbo;
 			GLuint effect;
 
+			RID specular_texture;
+			RID diffuse_texture;
+			RID normal_rough_texture;
+			RID sss_texture;
 		} buffers;
 
 		struct Effects {
@@ -1370,8 +1374,10 @@ public:
 
 		bool used_in_frame;
 		VS::ViewportMSAA msaa;
+		bool force_mrt;
 
 		RID texture;
+		RID depth_texture;
 
 		RenderTarget() :
 				fbo(0),
@@ -1380,7 +1386,8 @@ public:
 				width(0),
 				height(0),
 				used_in_frame(false),
-				msaa(VS::VIEWPORT_MSAA_DISABLED) {
+				msaa(VS::VIEWPORT_MSAA_DISABLED),
+				force_mrt(false) {
 			exposure.fbo = 0;
 			buffers.fbo = 0;
 			external.fbo = 0;
@@ -1401,13 +1408,14 @@ public:
 	virtual RID render_target_create();
 	virtual void render_target_set_position(RID p_render_target, int p_x, int p_y);
 	virtual void render_target_set_size(RID p_render_target, int p_width, int p_height);
-	virtual RID render_target_get_texture(RID p_render_target) const;
+	virtual RID render_target_get_texture(RID p_render_target, VS::ViewportTextureBuffer p_buffer) const;
 	virtual void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id);
 
 	virtual void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value);
 	virtual bool render_target_was_used(RID p_render_target);
 	virtual void render_target_clear_used(RID p_render_target);
 	virtual void render_target_set_msaa(RID p_render_target, VS::ViewportMSAA p_msaa);
+	virtual void render_target_set_force_mrt(RID p_render_target, bool p_force_mrt);
 
 	/* CANVAS SHADOW */
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -73,7 +73,7 @@ Vector<Ref<Texture> > EditorInterface::make_mesh_previews(const Vector<Ref<Mesh>
 	VS::get_singleton()->viewport_set_size(viewport, size, size);
 	VS::get_singleton()->viewport_set_transparent_background(viewport, true);
 	VS::get_singleton()->viewport_set_active(viewport, true);
-	RID viewport_texture = VS::get_singleton()->viewport_get_texture(viewport);
+	RID viewport_texture = VS::get_singleton()->viewport_get_texture(viewport, VS::VIEWPORT_TEXTURE_BUFFER_COLOR);
 
 	RID camera = VS::get_singleton()->camera_create();
 	VS::get_singleton()->viewport_attach_camera(viewport, camera);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -951,7 +951,7 @@ void AnimationPlayerEditor::forward_canvas_force_draw_over_viewport(Control *p_o
 
 			if (onion.captures_valid[cidx]) {
 				VS::get_singleton()->canvas_item_add_texture_rect_region(
-						ci, dst_rect, VS::get_singleton()->viewport_get_texture(onion.captures[cidx]), src_rect, Color(1, 1, 1, alpha));
+						ci, dst_rect, VS::get_singleton()->viewport_get_texture(onion.captures[cidx], VS::VIEWPORT_TEXTURE_BUFFER_COLOR), src_rect, Color(1, 1, 1, alpha));
 			}
 
 			cidx++;
@@ -965,7 +965,7 @@ void AnimationPlayerEditor::forward_canvas_force_draw_over_viewport(Control *p_o
 
 			if (onion.captures_valid[cidx]) {
 				VS::get_singleton()->canvas_item_add_texture_rect_region(
-						ci, dst_rect, VS::get_singleton()->viewport_get_texture(onion.captures[cidx]), src_rect, Color(1, 1, 1, alpha));
+						ci, dst_rect, VS::get_singleton()->viewport_get_texture(onion.captures[cidx], VS::VIEWPORT_TEXTURE_BUFFER_COLOR), src_rect, Color(1, 1, 1, alpha));
 			}
 
 			cidx++;
@@ -1444,7 +1444,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 	VS::get_singleton()->canvas_item_set_material(onion.capture.canvas_item, onion.capture.material->get_rid());
 	onion.capture.material->set_shader_param("bkg_color", GLOBAL_GET("rendering/environment/default_clear_color"));
 	onion.capture.material->set_shader_param("differences_only", onion.differences_only);
-	onion.capture.material->set_shader_param("present", onion.differences_only ? VS::get_singleton()->viewport_get_texture(present_rid) : RID());
+	onion.capture.material->set_shader_param("present", onion.differences_only ? VS::get_singleton()->viewport_get_texture(present_rid, VS::VIEWPORT_TEXTURE_BUFFER_COLOR) : RID());
 
 	int step_off_a = onion.past ? -onion.steps : 0;
 	int step_off_b = onion.future ? onion.steps : 0;

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -370,7 +370,7 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 	VS::get_singleton()->viewport_set_transparent_background(viewport, true);
 	VS::get_singleton()->viewport_set_active(viewport, true);
 	VS::get_singleton()->viewport_set_vflip(viewport, true);
-	viewport_texture = VS::get_singleton()->viewport_get_texture(viewport);
+	viewport_texture = VS::get_singleton()->viewport_get_texture(viewport, VS::VIEWPORT_TEXTURE_BUFFER_COLOR);
 
 	camera = VS::get_singleton()->camera_create();
 	VS::get_singleton()->viewport_attach_camera(viewport, camera);
@@ -777,7 +777,7 @@ EditorMeshPreviewPlugin::EditorMeshPreviewPlugin() {
 	VS::get_singleton()->viewport_set_size(viewport, 128, 128);
 	VS::get_singleton()->viewport_set_transparent_background(viewport, true);
 	VS::get_singleton()->viewport_set_active(viewport, true);
-	viewport_texture = VS::get_singleton()->viewport_get_texture(viewport);
+	viewport_texture = VS::get_singleton()->viewport_get_texture(viewport, VS::VIEWPORT_TEXTURE_BUFFER_COLOR);
 
 	camera = VS::get_singleton()->camera_create();
 	VS::get_singleton()->viewport_attach_camera(viewport, camera);
@@ -906,7 +906,7 @@ EditorFontPreviewPlugin::EditorFontPreviewPlugin() {
 	VS::get_singleton()->viewport_set_vflip(viewport, true);
 	VS::get_singleton()->viewport_set_size(viewport, 128, 128);
 	VS::get_singleton()->viewport_set_active(viewport, true);
-	viewport_texture = VS::get_singleton()->viewport_get_texture(viewport);
+	viewport_texture = VS::get_singleton()->viewport_get_texture(viewport, VS::VIEWPORT_TEXTURE_BUFFER_COLOR);
 
 	canvas = VS::get_singleton()->canvas_create();
 	canvas_item = VS::get_singleton()->canvas_item_create();

--- a/modules/gdnative/arvr/arvr_interface_gdnative.cpp
+++ b/modules/gdnative/arvr/arvr_interface_gdnative.cpp
@@ -296,7 +296,7 @@ godot_int GDAPI godot_arvr_get_texid(godot_rid *p_render_target) {
 	// This is a handy function to expose that.
 	RID *render_target = (RID *)p_render_target;
 
-	RID eye_texture = VSG::storage->render_target_get_texture(*render_target);
+	RID eye_texture = VSG::storage->render_target_get_texture(*render_target, VS::VIEWPORT_TEXTURE_BUFFER_COLOR);
 	uint32_t texid = VS::get_singleton()->texture_get_texid(eye_texture);
 
 	return texid;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -162,7 +162,7 @@ void ViewportTexture::set_buffer_mode(BufferMode p_buffer_mode) {
 		case BUFFER_SPECULAR:
 			buffer_rid = vp->specular_texture_rid;
 			break;
-		case BUFFER_NORMAL_ROUGH:
+		case BUFFER_NORMAL:
 			buffer_rid = vp->normal_rough_texture_rid;
 			break;
 		case BUFFER_SUBSURFACE:
@@ -187,13 +187,13 @@ void ViewportTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_viewport_path_in_scene"), &ViewportTexture::get_viewport_path_in_scene);
 
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "viewport_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Viewport", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NODE_PATH_FROM_SCENE_ROOT), "set_viewport_path_in_scene", "get_viewport_path_in_scene");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "buffer_mode", PROPERTY_HINT_ENUM, "Color,Depth,Diffuse,Specular,Normal Roughness, Subsurface"), "set_buffer_mode", "get_buffer_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "buffer_mode", PROPERTY_HINT_ENUM, "Color,Depth,Diffuse,Specular,Normal,Subsurface"), "set_buffer_mode", "get_buffer_mode");
 
 	BIND_ENUM_CONSTANT(BUFFER_COLOR);
 	BIND_ENUM_CONSTANT(BUFFER_DEPTH);
 	BIND_ENUM_CONSTANT(BUFFER_DIFFUSE);
 	BIND_ENUM_CONSTANT(BUFFER_SPECULAR);
-	BIND_ENUM_CONSTANT(BUFFER_NORMAL_ROUGH);
+	BIND_ENUM_CONSTANT(BUFFER_NORMAL);
 	BIND_ENUM_CONSTANT(BUFFER_SUBSURFACE);
 }
 
@@ -3062,17 +3062,17 @@ Viewport::MSAA Viewport::get_msaa() const {
 	return msaa;
 }
 
-void Viewport::set_force_mrt(bool p_force_mrt) {
+void Viewport::set_expose_gbuffer(bool p_expose_gbuffer) {
 
-	if (force_mrt == p_force_mrt)
+	if (expose_gbuffer == p_expose_gbuffer)
 		return;
-	force_mrt = p_force_mrt;
-	VS::get_singleton()->viewport_set_force_mrt(viewport, p_force_mrt);
+	expose_gbuffer = p_expose_gbuffer;
+	VS::get_singleton()->viewport_set_expose_gbuffer(viewport, p_expose_gbuffer);
 }
 
-bool Viewport::is_force_mrt() const {
+bool Viewport::is_expose_gbuffer() const {
 
-	return force_mrt;
+	return expose_gbuffer;
 }
 
 void Viewport::set_hdr(bool p_hdr) {
@@ -3210,8 +3210,8 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_msaa", "msaa"), &Viewport::set_msaa);
 	ClassDB::bind_method(D_METHOD("get_msaa"), &Viewport::get_msaa);
 
-	ClassDB::bind_method(D_METHOD("set_force_mrt", "mrt"), &Viewport::set_force_mrt);
-	ClassDB::bind_method(D_METHOD("is_force_mrt"), &Viewport::is_force_mrt);
+	ClassDB::bind_method(D_METHOD("set_expose_gbuffer", "mrt"), &Viewport::set_expose_gbuffer);
+	ClassDB::bind_method(D_METHOD("is_expose_gbuffer"), &Viewport::is_expose_gbuffer);
 
 	ClassDB::bind_method(D_METHOD("set_hdr", "enable"), &Viewport::set_hdr);
 	ClassDB::bind_method(D_METHOD("get_hdr"), &Viewport::get_hdr);
@@ -3301,7 +3301,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "handle_input_locally"), "set_handle_input_locally", "is_handling_input_locally");
 	ADD_GROUP("Rendering", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "msaa", PROPERTY_HINT_ENUM, "Disabled,2x,4x,8x,16x,AndroidVR 2x,AndroidVR 4x"), "set_msaa", "get_msaa");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "force_mrt"), "set_force_mrt", "is_force_mrt");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expose_gbuffer"), "set_expose_gbuffer", "is_expose_gbuffer");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hdr"), "set_hdr", "get_hdr");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_3d"), "set_disable_3d", "is_3d_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_3d_linear"), "set_keep_3d_linear", "get_keep_3d_linear");
@@ -3393,7 +3393,7 @@ Viewport::Viewport() {
 	depth_texture_rid = VisualServer::get_singleton()->viewport_get_texture(viewport, VS::ViewportTextureBuffer(ViewportTexture::BUFFER_DEPTH));
 	diffuse_texture_rid = VisualServer::get_singleton()->viewport_get_texture(viewport, VS::ViewportTextureBuffer(ViewportTexture::BUFFER_DIFFUSE));
 	specular_texture_rid = VisualServer::get_singleton()->viewport_get_texture(viewport, VS::ViewportTextureBuffer(ViewportTexture::BUFFER_SPECULAR));
-	normal_rough_texture_rid = VisualServer::get_singleton()->viewport_get_texture(viewport, VS::ViewportTextureBuffer(ViewportTexture::BUFFER_NORMAL_ROUGH));
+	normal_rough_texture_rid = VisualServer::get_singleton()->viewport_get_texture(viewport, VS::ViewportTextureBuffer(ViewportTexture::BUFFER_NORMAL));
 	subsurface_texture_rid = VisualServer::get_singleton()->viewport_get_texture(viewport, VS::ViewportTextureBuffer(ViewportTexture::BUFFER_SUBSURFACE));
 
 	texture_flags = 0;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3395,7 +3395,7 @@ Viewport::Viewport() {
 	specular_texture_rid = VisualServer::get_singleton()->viewport_get_texture(viewport, VS::ViewportTextureBuffer(ViewportTexture::BUFFER_SPECULAR));
 	normal_rough_texture_rid = VisualServer::get_singleton()->viewport_get_texture(viewport, VS::ViewportTextureBuffer(ViewportTexture::BUFFER_NORMAL_ROUGH));
 	subsurface_texture_rid = VisualServer::get_singleton()->viewport_get_texture(viewport, VS::ViewportTextureBuffer(ViewportTexture::BUFFER_SUBSURFACE));
-	
+
 	texture_flags = 0;
 
 	render_direct_to_screen = false;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -59,7 +59,7 @@ public:
 		BUFFER_DEPTH,
 		BUFFER_DIFFUSE,
 		BUFFER_SPECULAR,
-		BUFFER_NORMAL_ROUGH,
+		BUFFER_NORMAL,
 		BUFFER_SUBSURFACE
 	};
 
@@ -305,7 +305,7 @@ private:
 	ShadowAtlasQuadrantSubdiv shadow_atlas_quadrant_subdiv[4];
 
 	MSAA msaa;
-	bool force_mrt;
+	bool expose_gbuffer;
 	bool hdr;
 
 	Ref<ViewportTexture> default_texture;
@@ -519,8 +519,8 @@ public:
 	void set_msaa(MSAA p_msaa);
 	MSAA get_msaa() const;
 
-	void set_force_mrt(bool p_force_mrt);
-	bool is_force_mrt() const;
+	void set_expose_gbuffer(bool p_force_mrt);
+	bool is_expose_gbuffer() const;
 
 	void set_hdr(bool p_hdr);
 	bool get_hdr() const;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -79,7 +79,6 @@ protected:
 	static void _bind_methods();
 
 public:
-
 	void set_viewport_path_in_scene(const NodePath &p_path);
 	NodePath get_viewport_path_in_scene() const;
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -53,18 +53,33 @@ class ViewportTexture : public Texture {
 
 	GDCLASS(ViewportTexture, Texture);
 
+public:
+	enum BufferMode {
+		BUFFER_COLOR,
+		BUFFER_DEPTH,
+		BUFFER_DIFFUSE,
+		BUFFER_SPECULAR,
+		BUFFER_NORMAL_ROUGH,
+		BUFFER_SUBSURFACE
+	};
+
+private:
 	NodePath path;
 
 	friend class Viewport;
 	Viewport *vp;
 	uint32_t flags;
 
+	BufferMode buffer_mode;
+
 	RID proxy;
+	RID buffer_rid;
 
 protected:
 	static void _bind_methods();
 
 public:
+
 	void set_viewport_path_in_scene(const NodePath &p_path);
 	NodePath get_viewport_path_in_scene() const;
 
@@ -81,6 +96,9 @@ public:
 	virtual uint32_t get_flags() const;
 
 	virtual Ref<Image> get_data() const;
+
+	virtual void set_buffer_mode(BufferMode p_buffer_mode);
+	virtual BufferMode get_buffer_mode() const;
 
 	ViewportTexture();
 	~ViewportTexture();
@@ -107,7 +125,6 @@ public:
 		SHADOW_ATLAS_QUADRANT_SUBDIV_256,
 		SHADOW_ATLAS_QUADRANT_SUBDIV_1024,
 		SHADOW_ATLAS_QUADRANT_SUBDIV_MAX,
-
 	};
 
 	enum MSAA {
@@ -271,7 +288,14 @@ private:
 	bool disable_3d;
 	bool keep_3d_linear;
 	UpdateMode update_mode;
-	RID texture_rid;
+
+	RID color_texture_rid;
+	RID depth_texture_rid;
+	RID diffuse_texture_rid;
+	RID specular_texture_rid;
+	RID normal_rough_texture_rid;
+	RID subsurface_texture_rid;
+
 	uint32_t texture_flags;
 
 	DebugDraw debug_draw;
@@ -282,6 +306,7 @@ private:
 	ShadowAtlasQuadrantSubdiv shadow_atlas_quadrant_subdiv[4];
 
 	MSAA msaa;
+	bool force_mrt;
 	bool hdr;
 
 	Ref<ViewportTexture> default_texture;
@@ -495,6 +520,9 @@ public:
 	void set_msaa(MSAA p_msaa);
 	MSAA get_msaa() const;
 
+	void set_force_mrt(bool p_force_mrt);
+	bool is_force_mrt() const;
+
 	void set_hdr(bool p_hdr);
 	bool get_hdr() const;
 
@@ -562,6 +590,8 @@ public:
 	Viewport();
 	~Viewport();
 };
+
+VARIANT_ENUM_CAST(ViewportTexture::BufferMode);
 
 VARIANT_ENUM_CAST(Viewport::UpdateMode);
 VARIANT_ENUM_CAST(Viewport::ShadowAtlasQuadrantSubdiv);

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -562,15 +562,16 @@ public:
 	virtual RID render_target_create() = 0;
 	virtual void render_target_set_position(RID p_render_target, int p_x, int p_y) = 0;
 	virtual void render_target_set_size(RID p_render_target, int p_width, int p_height) = 0;
-	virtual RID render_target_get_texture(RID p_render_target) const = 0;
+	virtual RID render_target_get_texture(RID p_render_target, VS::ViewportTextureBuffer p_buffer) const = 0;
 	virtual void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) = 0;
 	virtual void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) = 0;
 	virtual bool render_target_was_used(RID p_render_target) = 0;
 	virtual void render_target_clear_used(RID p_render_target) = 0;
 	virtual void render_target_set_msaa(RID p_render_target, VS::ViewportMSAA p_msaa) = 0;
+	virtual void render_target_set_force_mrt(RID p_render_target, bool p_force_mrt) = 0;
 
 	/* CANVAS SHADOW */
-
+	
 	virtual RID canvas_light_shadow_buffer_create(int p_width) = 0;
 
 	/* LIGHT SHADOW MAPPING */

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -568,7 +568,7 @@ public:
 	virtual bool render_target_was_used(RID p_render_target) = 0;
 	virtual void render_target_clear_used(RID p_render_target) = 0;
 	virtual void render_target_set_msaa(RID p_render_target, VS::ViewportMSAA p_msaa) = 0;
-	virtual void render_target_set_force_mrt(RID p_render_target, bool p_force_mrt) = 0;
+	virtual void render_target_set_expose_gbuffer(RID p_render_target, bool p_expose_gbuffer) = 0;
 
 	/* CANVAS SHADOW */
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -571,7 +571,7 @@ public:
 	virtual void render_target_set_force_mrt(RID p_render_target, bool p_force_mrt) = 0;
 
 	/* CANVAS SHADOW */
-	
+
 	virtual RID canvas_light_shadow_buffer_create(int p_width) = 0;
 
 	/* LIGHT SHADOW MAPPING */

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -484,7 +484,7 @@ public:
 	BIND2(viewport_set_shadow_atlas_size, RID, int)
 	BIND3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
 	BIND2(viewport_set_msaa, RID, ViewportMSAA)
-	BIND2(viewport_set_force_mrt, RID, bool)
+	BIND2(viewport_set_expose_gbuffer, RID, bool)
 	BIND2(viewport_set_hdr, RID, bool)
 	BIND2(viewport_set_usage, RID, ViewportUsage)
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -463,7 +463,7 @@ public:
 	BIND2(viewport_set_update_mode, RID, ViewportUpdateMode)
 	BIND2(viewport_set_vflip, RID, bool)
 
-	BIND1RC(RID, viewport_get_texture, RID)
+	BIND2RC(RID, viewport_get_texture, RID, ViewportTextureBuffer)
 
 	BIND2(viewport_set_hide_scenario, RID, bool)
 	BIND2(viewport_set_hide_canvas, RID, bool)
@@ -484,6 +484,7 @@ public:
 	BIND2(viewport_set_shadow_atlas_size, RID, int)
 	BIND3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
 	BIND2(viewport_set_msaa, RID, ViewportMSAA)
+	BIND2(viewport_set_force_mrt, RID, bool)
 	BIND2(viewport_set_hdr, RID, bool)
 	BIND2(viewport_set_usage, RID, ViewportUsage)
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -502,12 +502,11 @@ void VisualServerViewport::viewport_set_vflip(RID p_viewport, bool p_enable) {
 	VSG::storage->render_target_set_flag(viewport->render_target, RasterizerStorage::RENDER_TARGET_VFLIP, p_enable);
 }
 
-RID VisualServerViewport::viewport_get_texture(RID p_viewport) const {
-
+RID VisualServerViewport::viewport_get_texture(RID p_viewport, VS::ViewportTextureBuffer p_buffer) const {
 	const Viewport *viewport = viewport_owner.getornull(p_viewport);
 	ERR_FAIL_COND_V(!viewport, RID());
 
-	return VSG::storage->render_target_get_texture(viewport->render_target);
+	return VSG::storage->render_target_get_texture(viewport->render_target, p_buffer);
 }
 
 void VisualServerViewport::viewport_set_hide_scenario(RID p_viewport, bool p_hide) {
@@ -650,6 +649,14 @@ void VisualServerViewport::viewport_set_msaa(RID p_viewport, VS::ViewportMSAA p_
 	ERR_FAIL_COND(!viewport);
 
 	VSG::storage->render_target_set_msaa(viewport->render_target, p_msaa);
+}
+
+void VisualServerViewport::viewport_set_force_mrt(RID p_viewport, bool p_force_mrt) {
+	
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND(!viewport);
+
+	VSG::storage->render_target_set_force_mrt(viewport->render_target, p_force_mrt);
 }
 
 void VisualServerViewport::viewport_set_hdr(RID p_viewport, bool p_enabled) {

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -652,7 +652,7 @@ void VisualServerViewport::viewport_set_msaa(RID p_viewport, VS::ViewportMSAA p_
 }
 
 void VisualServerViewport::viewport_set_force_mrt(RID p_viewport, bool p_force_mrt) {
-	
+
 	Viewport *viewport = viewport_owner.getornull(p_viewport);
 	ERR_FAIL_COND(!viewport);
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -651,12 +651,12 @@ void VisualServerViewport::viewport_set_msaa(RID p_viewport, VS::ViewportMSAA p_
 	VSG::storage->render_target_set_msaa(viewport->render_target, p_msaa);
 }
 
-void VisualServerViewport::viewport_set_force_mrt(RID p_viewport, bool p_force_mrt) {
+void VisualServerViewport::viewport_set_expose_gbuffer(RID p_viewport, bool p_expose_gbuffer) {
 
 	Viewport *viewport = viewport_owner.getornull(p_viewport);
 	ERR_FAIL_COND(!viewport);
 
-	VSG::storage->render_target_set_force_mrt(viewport->render_target, p_force_mrt);
+	VSG::storage->render_target_set_expose_gbuffer(viewport->render_target, p_expose_gbuffer);
 }
 
 void VisualServerViewport::viewport_set_hdr(RID p_viewport, bool p_enabled) {

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -166,9 +166,9 @@ public:
 	void viewport_set_update_mode(RID p_viewport, VS::ViewportUpdateMode p_mode);
 	void viewport_set_vflip(RID p_viewport, bool p_enable);
 
-	void viewport_set_clear_mode(RID p_viewport, VS::ViewportClearMode p_clear_mode);
+	RID viewport_get_texture(RID p_viewport, VS::ViewportTextureBuffer p_buffer) const;
 
-	RID viewport_get_texture(RID p_viewport) const;
+	void viewport_set_clear_mode(RID p_viewport, VS::ViewportClearMode p_clear_mode);
 
 	void viewport_set_hide_scenario(RID p_viewport, bool p_hide);
 	void viewport_set_hide_canvas(RID p_viewport, bool p_hide);
@@ -190,6 +190,7 @@ public:
 	void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv);
 
 	void viewport_set_msaa(RID p_viewport, VS::ViewportMSAA p_msaa);
+	void viewport_set_force_mrt(RID p_viewport, bool p_force_mrt);
 	void viewport_set_hdr(RID p_viewport, bool p_enabled);
 	void viewport_set_usage(RID p_viewport, VS::ViewportUsage p_usage);
 

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -190,7 +190,7 @@ public:
 	void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv);
 
 	void viewport_set_msaa(RID p_viewport, VS::ViewportMSAA p_msaa);
-	void viewport_set_force_mrt(RID p_viewport, bool p_force_mrt);
+	void viewport_set_expose_gbuffer(RID p_viewport, bool p_expose_gbuffer);
 	void viewport_set_hdr(RID p_viewport, bool p_enabled);
 	void viewport_set_usage(RID p_viewport, VS::ViewportUsage p_usage);
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -411,7 +411,7 @@ public:
 	FUNC2(viewport_set_shadow_atlas_size, RID, int)
 	FUNC3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
 	FUNC2(viewport_set_msaa, RID, ViewportMSAA)
-	FUNC2(viewport_set_force_mrt, RID, bool)
+	FUNC2(viewport_set_expose_gbuffer, RID, bool)
 	FUNC2(viewport_set_hdr, RID, bool)
 	FUNC2(viewport_set_usage, RID, ViewportUsage)
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -390,7 +390,7 @@ public:
 	FUNC2(viewport_set_update_mode, RID, ViewportUpdateMode)
 	FUNC2(viewport_set_vflip, RID, bool)
 
-	FUNC1RC(RID, viewport_get_texture, RID)
+	FUNC2RC(RID, viewport_get_texture, RID, ViewportTextureBuffer)
 
 	FUNC2(viewport_set_hide_scenario, RID, bool)
 	FUNC2(viewport_set_hide_canvas, RID, bool)
@@ -411,6 +411,7 @@ public:
 	FUNC2(viewport_set_shadow_atlas_size, RID, int)
 	FUNC3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
 	FUNC2(viewport_set_msaa, RID, ViewportMSAA)
+	FUNC2(viewport_set_force_mrt, RID, bool)
 	FUNC2(viewport_set_hdr, RID, bool)
 	FUNC2(viewport_set_usage, RID, ViewportUsage)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1890,7 +1890,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_size", "viewport", "size"), &VisualServer::viewport_set_shadow_atlas_size);
 	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_quadrant_subdivision", "viewport", "quadrant", "subdivision"), &VisualServer::viewport_set_shadow_atlas_quadrant_subdivision);
 	ClassDB::bind_method(D_METHOD("viewport_set_msaa", "viewport", "msaa"), &VisualServer::viewport_set_msaa);
-	ClassDB::bind_method(D_METHOD("viewport_set_force_mrt", "viewport", "force_mrt"), &VisualServer::viewport_set_force_mrt);
+	ClassDB::bind_method(D_METHOD("viewport_set_expose_gbuffer", "viewport", "expose_gbuffer"), &VisualServer::viewport_set_expose_gbuffer);
 	ClassDB::bind_method(D_METHOD("viewport_set_hdr", "viewport", "enabled"), &VisualServer::viewport_set_hdr);
 	ClassDB::bind_method(D_METHOD("viewport_set_usage", "viewport", "usage"), &VisualServer::viewport_set_usage);
 	ClassDB::bind_method(D_METHOD("viewport_get_render_info", "viewport", "info"), &VisualServer::viewport_get_render_info);
@@ -2170,7 +2170,7 @@ void VisualServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(VIEWPORT_TEXTURE_BUFFER_DEPTH);
 	BIND_ENUM_CONSTANT(VIEWPORT_TEXTURE_BUFFER_DIFFUSE);
 	BIND_ENUM_CONSTANT(VIEWPORT_TEXTURE_BUFFER_SPECULAR);
-	BIND_ENUM_CONSTANT(VIEWPORT_TEXTURE_BUFFER_NORMAL_ROUGH);
+	BIND_ENUM_CONSTANT(VIEWPORT_TEXTURE_BUFFER_NORMAL);
 	BIND_ENUM_CONSTANT(VIEWPORT_TEXTURE_BUFFER_SUBSURFACE);
 
 	BIND_ENUM_CONSTANT(VIEWPORT_CLEAR_ALWAYS);

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1874,7 +1874,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_update_mode", "viewport", "update_mode"), &VisualServer::viewport_set_update_mode);
 	ClassDB::bind_method(D_METHOD("viewport_set_vflip", "viewport", "enabled"), &VisualServer::viewport_set_vflip);
 	ClassDB::bind_method(D_METHOD("viewport_set_clear_mode", "viewport", "clear_mode"), &VisualServer::viewport_set_clear_mode);
-	ClassDB::bind_method(D_METHOD("viewport_get_texture", "viewport"), &VisualServer::viewport_get_texture);
+	ClassDB::bind_method(D_METHOD("viewport_get_texture", "viewport", "buffer"), &VisualServer::viewport_get_texture);
 	ClassDB::bind_method(D_METHOD("viewport_set_hide_scenario", "viewport", "hidden"), &VisualServer::viewport_set_hide_scenario);
 	ClassDB::bind_method(D_METHOD("viewport_set_hide_canvas", "viewport", "hidden"), &VisualServer::viewport_set_hide_canvas);
 	ClassDB::bind_method(D_METHOD("viewport_set_disable_environment", "viewport", "disabled"), &VisualServer::viewport_set_disable_environment);
@@ -1890,6 +1890,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_size", "viewport", "size"), &VisualServer::viewport_set_shadow_atlas_size);
 	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_quadrant_subdivision", "viewport", "quadrant", "subdivision"), &VisualServer::viewport_set_shadow_atlas_quadrant_subdivision);
 	ClassDB::bind_method(D_METHOD("viewport_set_msaa", "viewport", "msaa"), &VisualServer::viewport_set_msaa);
+	ClassDB::bind_method(D_METHOD("viewport_set_force_mrt", "viewport", "force_mrt"), &VisualServer::viewport_set_force_mrt);
 	ClassDB::bind_method(D_METHOD("viewport_set_hdr", "viewport", "enabled"), &VisualServer::viewport_set_hdr);
 	ClassDB::bind_method(D_METHOD("viewport_set_usage", "viewport", "usage"), &VisualServer::viewport_set_usage);
 	ClassDB::bind_method(D_METHOD("viewport_get_render_info", "viewport", "info"), &VisualServer::viewport_get_render_info);
@@ -2164,6 +2165,13 @@ void VisualServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(VIEWPORT_UPDATE_ONCE);
 	BIND_ENUM_CONSTANT(VIEWPORT_UPDATE_WHEN_VISIBLE);
 	BIND_ENUM_CONSTANT(VIEWPORT_UPDATE_ALWAYS);
+
+	BIND_ENUM_CONSTANT(VIEWPORT_TEXTURE_BUFFER_COLOR);
+	BIND_ENUM_CONSTANT(VIEWPORT_TEXTURE_BUFFER_DEPTH);
+	BIND_ENUM_CONSTANT(VIEWPORT_TEXTURE_BUFFER_DIFFUSE);
+	BIND_ENUM_CONSTANT(VIEWPORT_TEXTURE_BUFFER_SPECULAR);
+	BIND_ENUM_CONSTANT(VIEWPORT_TEXTURE_BUFFER_NORMAL_ROUGH);
+	BIND_ENUM_CONSTANT(VIEWPORT_TEXTURE_BUFFER_SUBSURFACE);
 
 	BIND_ENUM_CONSTANT(VIEWPORT_CLEAR_ALWAYS);
 	BIND_ENUM_CONSTANT(VIEWPORT_CLEAR_NEVER);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -638,7 +638,16 @@ public:
 
 	virtual void viewport_set_clear_mode(RID p_viewport, ViewportClearMode p_clear_mode) = 0;
 
-	virtual RID viewport_get_texture(RID p_viewport) const = 0;
+	enum ViewportTextureBuffer {
+		VIEWPORT_TEXTURE_BUFFER_COLOR,
+		VIEWPORT_TEXTURE_BUFFER_DEPTH,
+		VIEWPORT_TEXTURE_BUFFER_DIFFUSE,
+		VIEWPORT_TEXTURE_BUFFER_SPECULAR,
+		VIEWPORT_TEXTURE_BUFFER_NORMAL_ROUGH,
+		VIEWPORT_TEXTURE_BUFFER_SUBSURFACE
+	};
+
+	virtual RID viewport_get_texture(RID p_viewport, ViewportTextureBuffer p_buffer) const = 0;
 
 	virtual void viewport_set_hide_scenario(RID p_viewport, bool p_hide) = 0;
 	virtual void viewport_set_hide_canvas(RID p_viewport, bool p_hide) = 0;
@@ -670,7 +679,8 @@ public:
 	};
 
 	virtual void viewport_set_msaa(RID p_viewport, ViewportMSAA p_msaa) = 0;
-
+	virtual void viewport_set_force_mrt(RID p_viewport, bool p_force_mrt) = 0;
+	
 	enum ViewportUsage {
 		VIEWPORT_USAGE_2D,
 		VIEWPORT_USAGE_2D_NO_SAMPLING,
@@ -1077,6 +1087,7 @@ VARIANT_ENUM_CAST(VisualServer::BlendShapeMode);
 VARIANT_ENUM_CAST(VisualServer::LightType);
 VARIANT_ENUM_CAST(VisualServer::LightParam);
 VARIANT_ENUM_CAST(VisualServer::ViewportUpdateMode);
+VARIANT_ENUM_CAST(VisualServer::ViewportTextureBuffer);
 VARIANT_ENUM_CAST(VisualServer::ViewportClearMode);
 VARIANT_ENUM_CAST(VisualServer::ViewportMSAA);
 VARIANT_ENUM_CAST(VisualServer::ViewportUsage);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -643,7 +643,7 @@ public:
 		VIEWPORT_TEXTURE_BUFFER_DEPTH,
 		VIEWPORT_TEXTURE_BUFFER_DIFFUSE,
 		VIEWPORT_TEXTURE_BUFFER_SPECULAR,
-		VIEWPORT_TEXTURE_BUFFER_NORMAL_ROUGH,
+		VIEWPORT_TEXTURE_BUFFER_NORMAL,
 		VIEWPORT_TEXTURE_BUFFER_SUBSURFACE
 	};
 
@@ -679,7 +679,7 @@ public:
 	};
 
 	virtual void viewport_set_msaa(RID p_viewport, ViewportMSAA p_msaa) = 0;
-	virtual void viewport_set_force_mrt(RID p_viewport, bool p_force_mrt) = 0;
+	virtual void viewport_set_expose_gbuffer(RID p_viewport, bool p_expose_gbuffer) = 0;
 
 	enum ViewportUsage {
 		VIEWPORT_USAGE_2D,

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -680,7 +680,7 @@ public:
 
 	virtual void viewport_set_msaa(RID p_viewport, ViewportMSAA p_msaa) = 0;
 	virtual void viewport_set_force_mrt(RID p_viewport, bool p_force_mrt) = 0;
-	
+
 	enum ViewportUsage {
 		VIEWPORT_USAGE_2D,
 		VIEWPORT_USAGE_2D_NO_SAMPLING,


### PR DESCRIPTION
With this addition, the G buffers in viewports, and the depth buffer, are now accessible textures that can be used in shaders.

Using the new `buffer_mode` property in `ViewportTexture`, the following buffers are now accessible, including the default `Color` buffer.
- Depth
- Diffuse + Ambient Factor
- Specular + Metallic
- Normal + Roughness
- Subsurface

It is now possible to do various mid-processing effects, such as this.
![temp_annotation](https://user-images.githubusercontent.com/34734122/82576852-d1097100-9b4f-11ea-917a-ac1c23d2d80e.png)

There is also an `expose_gbuffer` variable in `Viewport` that enables access to the G-buffers, with some exceptions.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/798.*
