### PR TITLE
Fix segmentation fault when loading project

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3074,18 +3074,6 @@ DisplayServerWindows::~DisplayServerWindows() {
 
 	cursors_cache.clear();
 
-#if defined(VULKAN_ENABLED)
-	if (rendering_driver == "vulkan") {
-		if (rendering_device_vulkan) {
-			rendering_device_vulkan->finalize();
-			memdelete(rendering_device_vulkan);
-		}
-
-		if (context_vulkan)
-			memdelete(context_vulkan);
-	}
-#endif
-
 	if (user_proc) {
 		SetWindowLongPtr(windows[MAIN_WINDOW_ID].hWnd, GWLP_WNDPROC, (LONG_PTR)user_proc);
 	};
@@ -3102,4 +3090,16 @@ DisplayServerWindows::~DisplayServerWindows() {
 		}
 		DestroyWindow(windows[MAIN_WINDOW_ID].hWnd);
 	}
+
+#if defined(VULKAN_ENABLED)
+	if (rendering_driver == "vulkan") {
+		if (rendering_device_vulkan) {
+			rendering_device_vulkan->finalize();
+			memdelete(rendering_device_vulkan);
+		}
+
+		if (context_vulkan)
+			memdelete(context_vulkan);
+	}
+#endif
 }


### PR DESCRIPTION
Branch: master
Platform: windows
Target: debug

I tried to debug godot with gdb and got stuck at a segmentation fault when loading a project. I think it's caused by "context_vulkan->window_destroy(MAIN_WINDOW_ID);" after the memdelete of context_vulkan in the DisplayServerWindows destructor.

With this fix I was able to use gdb and open a new project without a segmentation fault.
