### PR TITLE
Increase the default DirectionalLight3D and OmniLight3D shadow biases

### DIFF
--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -424,9 +424,11 @@ DirectionalLight3D::DirectionalLight3D() :
 		Light3D(RenderingServer::LIGHT_DIRECTIONAL) {
 	set_param(PARAM_SHADOW_MAX_DISTANCE, 100);
 	set_param(PARAM_SHADOW_FADE_START, 0.8);
+	// Increase the default shadow bias to better suit most scenes.
+	// Leave normal bias untouched as it doesn't benefit DirectionalLight3D as much as OmniLight3D.
+	set_param(PARAM_SHADOW_BIAS, 0.05);
 	set_shadow_mode(SHADOW_PARALLEL_4_SPLITS);
 	set_shadow_depth_range(SHADOW_DEPTH_RANGE_STABLE);
-
 	blend_splits = false;
 }
 
@@ -468,6 +470,9 @@ void OmniLight3D::_bind_methods() {
 OmniLight3D::OmniLight3D() :
 		Light3D(RenderingServer::LIGHT_OMNI) {
 	set_shadow_mode(SHADOW_CUBE);
+	// Increase the default shadow biases to better suit most scenes.
+	set_param(PARAM_SHADOW_BIAS, 0.1);
+	set_param(PARAM_SHADOW_NORMAL_BIAS, 2.0);
 }
 
 String SpotLight3D::get_configuration_warning() const {


### PR DESCRIPTION
This should decrease the amount of visible shadow acne by default. There's still some acne in some cases, but we can't fully prevent it in all cases without introducing noticeable peter panning. It's recommended to tweak biases on a per-light basis if you still have visible shadow acne.

**Note:** Not eligible for cherry-picking to the `3.2` branch as shadow rendering was refactored in the `master` branch.

## Preview

### Before (OmniLight bias 0.02)

![Before](https://i.imgur.com/ntEBaQ6.png)

### After (OmniLight bias 0.05)

*Note: I increased the default bias to 0.1 now, so the screenshot below doesn't reflect the current PR status.*

![After](https://i.imgur.com/I737PD9.png)