### PR TITLE
Clarifies 'icon_separation' in TabContainer (instead of 'hseparation')

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -204,8 +204,8 @@
 		<theme_item name="font_color_fg" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Font color of the currently selected tab.
 		</theme_item>
-		<theme_item name="hseparation" type="int" default="4">
-			Horizontal separation between tabs.
+		<theme_item name="icon_separation" type="int" default="4">
+			Space between tab's name and its icon.
 		</theme_item>
 		<theme_item name="increment" type="Texture2D">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the last tab is visible) it appears semi-transparent.

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -278,7 +278,7 @@ void TabContainer::_notification(int p_what) {
 			Color font_color_bg = get_theme_color("font_color_bg");
 			Color font_color_disabled = get_theme_color("font_color_disabled");
 			int side_margin = get_theme_constant("side_margin");
-			int icon_text_distance = get_theme_constant("hseparation");
+			int icon_text_distance = get_theme_constant("icon_separation");
 
 			// Find out start and width of the header area.
 			int header_x = side_margin;
@@ -465,7 +465,7 @@ int TabContainer::_get_tab_width(int p_index) const {
 		if (icon.is_valid()) {
 			width += icon->get_width();
 			if (text != "") {
-				width += get_theme_constant("hseparation");
+				width += get_theme_constant("icon_separation");
 			}
 		}
 	}

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -681,7 +681,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_color_disabled", "TabContainer", control_font_color_disabled);
 
 	theme->set_constant("side_margin", "TabContainer", 8 * scale);
-	theme->set_constant("hseparation", "TabContainer", 4 * scale);
+	theme->set_constant("icon_separation", "TabContainer", 4 * scale);
 
 	// Tabs
 


### PR DESCRIPTION
Fixes: #38911

That MIGHT be a breaking-compat-change, as property's name is about to change.