### PR TITLE
Mono/C#: Don't try to load project assembly in project manager

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -424,6 +424,9 @@ void GDMono::initialize_load_assemblies() {
 	CRASH_COND_MSG(!tool_assemblies_loaded, "Mono: Failed to load '" TOOLS_ASM_NAME "' assemblies.");
 #endif
 
+	if (Main::is_project_manager())
+		return;
+
 	// Load the project's main assembly. This doesn't necessarily need to succeed.
 	// The game may not be using .NET at all, or if the project does use .NET and
 	// we're running in the editor, it may just happen to be it wasn't built yet.


### PR DESCRIPTION
This was causing an error message when launching the manager,
because there is no project assembly to load.
