### PR TITLE
Continue tracing screen space reflection after encountering sky

### DIFF
--- a/servers/rendering/rasterizer_rd/shaders/screen_space_reflection.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/screen_space_reflection.glsl
@@ -157,18 +157,14 @@ void main() {
 
 		depth = imageLoad(source_depth, ivec2(pos - 0.5)).r;
 
-		if (-depth >= params.camera_z_far) { //went beyond camera
-			break;
-		}
-
 		z_from = z_to;
 		z_to = z / w;
 
 		if (depth > z_to) {
 			// if depth was surpassed
-			if (depth <= max(z_to, z_from) + params.depth_tolerance) {
-				// check the depth tolerance
-				//check that normal is valid
+			if (depth <= max(z_to, z_from) + params.depth_tolerance && -depth < params.camera_z_far) {
+				// check the depth tolerance and far clip
+				// check that normal is valid
 				found = true;
 			}
 			break;


### PR DESCRIPTION
Instead of breaking the whole trace when encountering the sky/camera far clip, continue tracing and check if "hits" are sky/far clip or not. Prevents some objects not being reflected due to gaps. 

Closes #38948

![Annotation 2020-05-22 000424](https://user-images.githubusercontent.com/48544263/82641408-25006e00-9bc1-11ea-948d-df0988853b2c.jpg)

Sky and far clip is still properly rejected.

![image](https://user-images.githubusercontent.com/48544263/82641728-a9eb8780-9bc1-11ea-9f9e-4a5364e8ca30.png)
