### PR TITLE
Block WM_MOUSEMOVE during Windows Ink pen handling.

### DIFF
--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -229,6 +229,14 @@ typedef struct tagPOINTER_PEN_INFO {
 #define WM_POINTERUPDATE 0x0245
 #endif
 
+#ifndef WM_POINTERENTER
+#define WM_POINTERENTER 0x0249
+#endif
+
+#ifndef WM_POINTERLEAVE
+#define WM_POINTERLEAVE 0x024A
+#endif
+
 typedef BOOL(WINAPI *GetPointerTypePtr)(uint32_t p_id, POINTER_INPUT_TYPE *p_type);
 typedef BOOL(WINAPI *GetPointerPenInfoPtr)(uint32_t p_id, POINTER_PEN_INFO *p_pen_info);
 
@@ -333,6 +341,7 @@ private:
 		int min_pressure;
 		int max_pressure;
 		bool tilt_supported;
+		bool block_mm = false;
 
 		int last_pressure_update;
 		float last_pressure;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -786,7 +786,7 @@ String OS_Windows::get_tablet_driver_name(int p_driver) const {
 	if (p_driver < 0 || p_driver >= tablet_drivers.size()) {
 		return "";
 	} else {
-		return tablet_drivers[p_driver].utf8().get_data();
+		return tablet_drivers[p_driver];
 	}
 }
 


### PR DESCRIPTION
Block mouse move events while Windows Ink pen is active, to prevent cursor from jumping around if mouse move is generated by other source (Windows spam mouse move even when unrelated things happens, e.g. Control is hold).

cc @SleepProgger