### PR TITLE
Check if screen space reflection has passed far clip

### DIFF
--- a/drivers/gles3/shaders/screen_space_reflection.glsl
+++ b/drivers/gles3/shaders/screen_space_reflection.glsl
@@ -159,8 +159,8 @@ void main() {
 
 		if (depth > z_to) {
 			// if depth was surpassed
-			if (depth <= max(z_to, z_from) + depth_tolerance) {
-				// check the depth tolerance
+			if ((depth <= max(z_to, z_from) + depth_tolerance) && (-depth < camera_z_far)) {
+				// check the depth tolerance and far clip
 				found = true;
 			}
 			break;


### PR DESCRIPTION
Mirrors (ha) similar check in master/4.0 branch. Before "accepting" the reflection, check if it's within our view (prevents tracing environment and creating artifacts).

Closes #38953

![image](https://user-images.githubusercontent.com/48544263/82646081-cb9c3d00-9bc8-11ea-97c9-37f6f5566b01.png)

![image](https://user-images.githubusercontent.com/48544263/82646094-d3f47800-9bc8-11ea-9aa1-4aebd9f42c8b.png)
