### PR TITLE
Fix overflow condition with QueryPerformanceCounter

### DIFF
--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -575,11 +575,28 @@ void OS_UWP::delay_usec(uint32_t p_usec) const {
 uint64_t OS_UWP::get_ticks_usec() const {
 
 	uint64_t ticks;
-	uint64_t time;
+
 	// This is the number of clock ticks since start
 	QueryPerformanceCounter((LARGE_INTEGER *)&ticks);
+
 	// Divide by frequency to get the time in seconds
-	time = ticks * 1000000L / ticks_per_second;
+	// original calculation shown below is subject to overflow
+	// with high ticks_per_second and a number of days since the last reboot.
+	// time = ticks * 1000000L / ticks_per_second;
+
+	// we can prevent this by either using 128 bit math
+	// or separating into a calculation for seconds, and the fraction
+	uint64_t seconds = ticks / ticks_per_second;
+
+	// compiler will optimize these two into one divide
+	uint64_t leftover = ticks % ticks_per_second;
+
+	// remainder
+	uint64_t time = (leftover * 1000000L) / ticks_per_second;
+
+	// seconds
+	time += seconds * 1000000L;
+
 	// Subtract the time at game start to get
 	// the time since the game started
 	time -= ticks_start;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -418,12 +418,29 @@ void OS_Windows::delay_usec(uint32_t p_usec) const {
 uint64_t OS_Windows::get_ticks_usec() const {
 
 	uint64_t ticks;
-	uint64_t time;
+
 	// This is the number of clock ticks since start
 	if (!QueryPerformanceCounter((LARGE_INTEGER *)&ticks))
 		ticks = (UINT64)timeGetTime();
+
 	// Divide by frequency to get the time in seconds
-	time = ticks * 1000000L / ticks_per_second;
+	// original calculation shown below is subject to overflow
+	// with high ticks_per_second and a number of days since the last reboot.
+	// time = ticks * 1000000L / ticks_per_second;
+
+	// we can prevent this by either using 128 bit math
+	// or separating into a calculation for seconds, and the fraction
+	uint64_t seconds = ticks / ticks_per_second;
+
+	// compiler will optimize these two into one divide
+	uint64_t leftover = ticks % ticks_per_second;
+
+	// remainder
+	uint64_t time = (leftover * 1000000L) / ticks_per_second;
+
+	// seconds
+	time += seconds * 1000000L;
+
 	// Subtract the time at game start to get
 	// the time since the game started
 	time -= ticks_start;


### PR DESCRIPTION
The previous code for OS_Windows::get_ticks_usec() multiplied the tick count by 1000000 before dividing by ticks_per_second. The ticks is counted in a 64 bit integer and is susceptible to overflow when a machine has been running for a long period of time (days) with a high frequency timer.

This PR separates the overall calculation into one for seconds and one for the remainder, removing the possibility of overflow due to the multiplier.

Original calculation was:
```
	time = ticks * 1000000L / ticks_per_second;
```
May (or may not!) fix- #38878.

### Notes
* Noticed this while looking at #38878, however it is difficult to pinpoint the cause as there is no reproduction project, and a number of things going on in the described scenario.
* We could alternatively do a 128 bit calculation, however that might need to be done in software and this method is probably simpler + more efficient.
* Unix version already separates seconds and nanoseconds.
* Might need the same doing for UWP platform.
* NEEDS TESTING - as I don't have a windows machine.

### Bug scenario
* QueryPerformanceCounter returns a signed 64 bit LARGE_INTEGER, probably since reboot but this is not guaranteed
* Largest tick value is thus 2^63 = 9.22x10e+18
* resolution dropped by multiply
2^63 / 1000000 = 9.22x10e12
* typical clock freq, 1.4 million
9.22x10e12 / 1.4 million = 6588000 seconds
* minutes = 109802
* hours = 1830
* days = 76

So with high frequency timers and a number of days of uptime there is a possibility of overflow.