### PR TITLE
Add SCons option to not build C# solutions

### DIFF
--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -29,7 +29,7 @@ if env_mono["tools"] or env_mono["target"] != "release":
 
 mono_configure.configure(env, env_mono)
 
-if env_mono["tools"] and env_mono["mono_glue"]:
+if env_mono["tools"] and env_mono["mono_glue"] and env_mono["build_cil"]:
     # Build Godot API solution
     import build_scripts.api_solution_build as api_solution_build
 

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -30,6 +30,7 @@ def configure(env):
     )
     envvars.Add(BoolVariable("mono_static", "Statically link mono", default_mono_static))
     envvars.Add(BoolVariable("mono_glue", "Build with the mono glue sources", True))
+    envvars.Add(BoolVariable("build_cil", "Build C# solutions", True))
     envvars.Add(
         BoolVariable(
             "copy_mono_root", "Make a copy of the mono installation directory to bundle with the editor", False


### PR DESCRIPTION
We're having issues with Mono on our Ubuntu 14.04 containers when running MSBuild. We're switching to the .NET Core SDK instead on x86_64 but it's not available on x86 yet. As such we can't build the C# solutions on the linux-x86 container.
Since the resulting assemblies are the same for all platforms, this new option will allow us to disable the C# solutions builds on linux-x86 for now and re-use the assemblies from the other container.
