### PR TITLE
[3.2] Add SCons option to not build C# solutions

### DIFF
--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -31,7 +31,7 @@ env_mono = conf.Finish()
 
 mono_configure.configure(env, env_mono)
 
-if env_mono['tools'] and env_mono['mono_glue']:
+if env_mono['tools'] and env_mono['mono_glue'] and env_mono['build_cil']:
     # Build Godot API solution
     import build_scripts.api_solution_build as api_solution_build
     api_sln_cmd = api_solution_build.build(env_mono)

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -31,6 +31,7 @@ def configure(env):
     )
     envvars.Add(BoolVariable("mono_static", "Statically link mono", default_mono_static))
     envvars.Add(BoolVariable("mono_glue", "Build with the mono glue sources", True))
+    envvars.Add(BoolVariable("build_cil", "Build C# solutions", True))
     envvars.Add(
         BoolVariable(
             "copy_mono_root", "Make a copy of the mono installation directory to bundle with the editor", False


### PR DESCRIPTION
Manual backport of #38962 because there are conflicts from the double quotes change.