### PR TITLE
Fix dialog spam when inspecting MeshInstance from model file

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -153,12 +153,9 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 				if (path.find("::") != -1) {
 					// built-in resource
 					String base_path = path.get_slice("::", 0);
-					if (ResourceLoader::get_resource_type(base_path) == "PackedScene") {
-						if (!EditorNode::get_singleton()->is_scene_open(base_path)) {
-							EditorNode::get_singleton()->load_scene(base_path);
-						}
-					} else {
-						EditorNode::get_singleton()->load_resource(base_path);
+					RES dependency = ResourceLoader::load(base_path);
+					if (dependency.is_valid()) {
+						remote_dependencies.insert(dependency);
 					}
 				}
 				var = ResourceLoader::load(path);
@@ -211,6 +208,7 @@ void EditorDebuggerInspector::clear_cache() {
 		memdelete(E->value());
 	}
 	remote_objects.clear();
+	remote_dependencies.clear();
 }
 
 Object *EditorDebuggerInspector::get_object(ObjectID p_id) {

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -69,6 +69,7 @@ class EditorDebuggerInspector : public EditorInspector {
 private:
 	ObjectID inspected_object_id;
 	Map<ObjectID, EditorDebuggerRemoteObject *> remote_objects;
+	Set<RES> remote_dependencies;
 	EditorDebuggerRemoteObject *variables;
 
 	void _object_selected(ObjectID p_object);


### PR DESCRIPTION
Avoid load_scene for built-in resources to make sure we don't open a scene tab and prompt for model file editing.

Load scene as regular resource instead and store the reference to keep the dependency until the remote inspector cache is cleared.

Fixes #37298