### PR TITLE
Print a notice when compiling with `target=debug`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -551,11 +551,10 @@ if selected_platform in platform_list:
 
     if env["target"] == "release":
         if env["tools"]:
-            print("Tools can only be built with targets 'debug' and 'release_debug'.")
+            print("Error: The editor can only be built with `target=debug` or `target=release_debug`.")
             Exit(255)
         suffix += ".opt"
         env.Append(CPPDEFINES=["NDEBUG"])
-
     elif env["target"] == "release_debug":
         if env["tools"]:
             suffix += ".opt.tools"
@@ -563,8 +562,14 @@ if selected_platform in platform_list:
             suffix += ".opt.debug"
     else:
         if env["tools"]:
+            print(
+                "Note: Building a debug binary (which will run slowly). Use `target=release_debug` to build an optimized release binary."
+            )
             suffix += ".tools"
         else:
+            print(
+                "Note: Building a debug binary (which will run slowly). Use `target=release` to build an optimized release binary."
+            )
             suffix += ".debug"
 
     if env["arch"] != "":


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/56965.

Debug builds are considerably slower than release builds or even release_debug builds. `target=debug` is still the default SCons target option, so unsuspecting users may be compiling unoptimized debug builds for their personal use.