### PR TITLE
Fix resource preview in remote inspector

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -361,15 +361,6 @@ void SceneDebuggerObject::serialize(Array &r_arr, int p_max_size) {
 
 		RES res = var;
 
-		if (var.get_type() == Variant::OBJECT && var.is_ref()) {
-			REF r = var;
-			if (r.is_valid()) {
-				res = *r;
-			} else {
-				res = RES();
-			}
-		}
-
 		Array prop;
 		prop.push_back(pi.name);
 		prop.push_back(pi.type);


### PR DESCRIPTION
This change fixes a regression from #36532.

The specific case for object reference seems unnecessary, as `RES res = var;` already does the work. The case where REF is invalid is never hit in the case of already freed objects.

Tested with the repro projects from #36532 & #36486.

On 3.2 branch:
Fixes #37000 
The assignment `res = *r;` was causing the resource to be always invalidated. It also works by replacing this line with `res = r;` but it just always re-assigns the same object in this case.

On 4.0 branch:
This change is not required, but it removes some unnecessary code.

cc @Faless 