### PR TITLE
GLES2 Batching - Builtins prevent baking in unshaded shaders

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -2285,7 +2285,7 @@ bool RasterizerCanvasGLES2::try_join_item(Item *p_ci, RenderItemState &r_ris, bo
 
 	// does the shader contain BUILTINs which should break the batching?
 	bdata.joined_item_batch_flags = 0;
-	if (r_ris.shader_cache && !unshaded) {
+	if (r_ris.shader_cache) {
 
 		unsigned int and_flags = r_ris.shader_cache->canvas_item.batch_flags & (RasterizerStorageGLES2::Shader::CanvasItem::PREVENT_COLOR_BAKING | RasterizerStorageGLES2::Shader::CanvasItem::PREVENT_VERTEX_BAKING);
 		if (and_flags) {


### PR DESCRIPTION
Builtins that should prevent baking colors and vertex positions were incorrectly only active in shaders that were not unshaded. This was a terminology misunderstanding on my part :blush: - unshaded materials can still use shaders so should have the same test to prevent baking.

Fixes #38664.