### PR TITLE
Renames autotile_coord to subtile_coordinate

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -35,7 +35,7 @@
 				Returns the tile index of the given cell. If no tile exists in the cell, returns [constant INVALID_CELL].
 			</description>
 		</method>
-		<method name="get_cell_autotile_coord" qualifiers="const">
+		<method name="get_cell_subtile_coordinate" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="x" type="int">
@@ -43,7 +43,7 @@
 			<argument index="1" name="y" type="int">
 			</argument>
 			<description>
-				Returns the coordinate (subtile column and row) of the autotile variation in the tileset. Returns a zero vector if the cell doesn't have autotiling.
+				Returns the coordinate (subtile column and row) of the tile variation in the tileset. Returns a [constant Vector2.INF] if the cell is [constant INVALID_CELL].
 			</description>
 		</method>
 		<method name="get_cellv" qualifiers="const">
@@ -156,20 +156,20 @@
 			</argument>
 			<argument index="5" name="transpose" type="bool" default="false">
 			</argument>
-			<argument index="6" name="autotile_coord" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="6" name="subtile_coordinate" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
 			<description>
 				Sets the tile index for the cell given by a Vector2.
 				An index of [code]-1[/code] clears the cell.
-				Optionally, the tile can also be flipped, transposed, or given autotile coordinates. The autotile coordinate refers to the column and row of the subtile.
+				Optionally, the tile can also be flipped, transposed, or given subtile coordinate. The subtile coordinate refers to the column and row of the subtile.
 				[b]Note:[/b] Data such as navigation polygons and collision shapes are not immediately updated for performance reasons.
 				If you need these to be immediately updated, you can call [method update_dirty_quadrants].
 				Overriding this method also overrides it internally, allowing custom logic to be implemented when tiles are placed/removed:
 				[codeblock]
-				func set_cell(x, y, tile, flip_x, flip_y, transpose, autotile_coord)
+				func set_cell(x, y, tile = false, flip_x = false, flip_y = false, transpose = false, subtile_coordinate = Vector2())
 				    # Write your custom logic here.
 				    # To call the default method:
-				    .set_cell(x, y, tile, flip_x, flip_y, transpose, autotile_coord)
+				    .set_cell(x, y, tile, flip_x, flip_y, transpose, subtile_coordinate)
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -10,30 +10,20 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_forward_atlas_subtile_selection" qualifiers="virtual">
-			<return type="Vector2">
-			</return>
-			<argument index="0" name="atlastile_id" type="int">
-			</argument>
-			<argument index="1" name="tilemap" type="Object">
-			</argument>
-			<argument index="2" name="tile_location" type="Vector2">
-			</argument>
-			<description>
-			</description>
-		</method>
 		<method name="_forward_subtile_selection" qualifiers="virtual">
 			<return type="Vector2">
 			</return>
-			<argument index="0" name="autotile_id" type="int">
+			<argument index="0" name="id" type="int">
 			</argument>
 			<argument index="1" name="bitmask" type="int">
 			</argument>
 			<argument index="2" name="tilemap" type="Object">
 			</argument>
-			<argument index="3" name="tile_location" type="Vector2">
+			<argument index="3" name="cell_position" type="Vector2">
 			</argument>
 			<description>
+				Forwards the subtile selection. Overriding this method allows you to create custom logic to select wich subtile to use when painting. Works with [constant AUTO_TILE] and [constant ATLAS_TILE], but when it is an atlas, [code]bitmask[/code] will always be zero.
+				[b]Note:[/b] For this method to be called by auto tile, the option "Disable Autotile" in the editor must be inactive and for atlas tile, the option "Enable Priority" must be active.
 			</description>
 		</method>
 		<method name="_is_tile_bound" qualifiers="virtual">
@@ -60,11 +50,17 @@
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
-			<argument index="1" name="coord" type="Vector2">
+			<argument index="1" name="subtile_coordinate" type="Vector2">
 			</argument>
 			<description>
 				Returns the bitmask of the subtile from an autotile given its coordinates.
 				The value is the sum of the values in [enum AutotileBindings] present in the subtile (e.g. a value of 5 means the bitmask has bindings in both the top left and top right).
+				[b]Note:[/b] The bitmask has 32 bits, the first 16 bits are the sum of the activated flags as described above and the last 16 bits are the sum of the wildcard/ignore flags (e.g. a value 131096 means the bitmask for "activated" has bindings in center and left and wildcard/ignore has binding for top), so if you are using wildcard/ignore flag and need to extract these masks, use this code below:
+				[codeblock]
+				var bitmask = autotile_get_bitmask(id, subtile_coordinate)
+				var activated_mask = bitmask &amp; 0xFFFF
+				var wildcard_mask = bitmask >> 16
+				[/codeblock]
 			</description>
 		</method>
 		<method name="autotile_get_bitmask_mode" qualifiers="const">
@@ -76,7 +72,7 @@
 				Returns the [enum BitmaskMode] of the autotile.
 			</description>
 		</method>
-		<method name="autotile_get_icon_coordinate" qualifiers="const">
+		<method name="subtile_get_icon_coordinate" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="id" type="int">
@@ -86,29 +82,29 @@
 				The subtile defined as the icon will be used as a fallback when the atlas/autotile's bitmask information is incomplete. It will also be used to represent it in the TileSet editor.
 			</description>
 		</method>
-		<method name="autotile_get_light_occluder" qualifiers="const">
+		<method name="subtile_get_light_occluder" qualifiers="const">
 			<return type="OccluderPolygon2D">
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
-			<argument index="1" name="coord" type="Vector2">
+			<argument index="1" name="subtile_coordinate" type="Vector2">
 			</argument>
 			<description>
 				Returns the light occluder of the subtile from an atlas/autotile given its coordinates.
 			</description>
 		</method>
-		<method name="autotile_get_navigation_polygon" qualifiers="const">
+		<method name="subtile_get_navigation_polygon" qualifiers="const">
 			<return type="NavigationPolygon">
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
-			<argument index="1" name="coord" type="Vector2">
+			<argument index="1" name="subtile_coordinate" type="Vector2">
 			</argument>
 			<description>
 				Returns the navigation polygon of the subtile from an atlas/autotile given its coordinates.
 			</description>
 		</method>
-		<method name="autotile_get_size" qualifiers="const">
+		<method name="subtile_get_size" qualifiers="const">
 			<return type="Vector2">
 			</return>
 			<argument index="0" name="id" type="int">
@@ -117,7 +113,7 @@
 				Returns the size of the subtiles in an atlas/autotile.
 			</description>
 		</method>
-		<method name="autotile_get_spacing" qualifiers="const">
+		<method name="subtile_get_spacing" qualifiers="const">
 			<return type="int">
 			</return>
 			<argument index="0" name="id" type="int">
@@ -131,19 +127,19 @@
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
-			<argument index="1" name="coord" type="Vector2">
+			<argument index="1" name="subtile_coordinate" type="Vector2">
 			</argument>
 			<description>
 				Returns the priority of the subtile from an autotile given its coordinates.
 				When more than one subtile has the same bitmask value, one of them will be picked randomly for drawing. Its priority will define how often it will be picked.
 			</description>
 		</method>
-		<method name="autotile_get_z_index">
+		<method name="subtile_get_z_index">
 			<return type="int">
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
-			<argument index="1" name="coord" type="Vector2">
+			<argument index="1" name="subtile_coordinate" type="Vector2">
 			</argument>
 			<description>
 				Returns the drawing index of the subtile from an atlas/autotile given its coordinates.
@@ -174,45 +170,45 @@
 				Sets the [enum BitmaskMode] of the autotile.
 			</description>
 		</method>
-		<method name="autotile_set_icon_coordinate">
+		<method name="subtile_set_icon_coordinate">
 			<return type="void">
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
-			<argument index="1" name="coord" type="Vector2">
+			<argument index="1" name="subtile_coordinate" type="Vector2">
 			</argument>
 			<description>
 				Sets the subtile that will be used as an icon in an atlas/autotile given its coordinates.
 				The subtile defined as the icon will be used as a fallback when the atlas/autotile's bitmask information is incomplete. It will also be used to represent it in the TileSet editor.
 			</description>
 		</method>
-		<method name="autotile_set_light_occluder">
+		<method name="subtile_set_light_occluder">
 			<return type="void">
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
 			<argument index="1" name="light_occluder" type="OccluderPolygon2D">
 			</argument>
-			<argument index="2" name="coord" type="Vector2">
+			<argument index="2" name="subtile_coordinate" type="Vector2">
 			</argument>
 			<description>
 				Sets the light occluder of the subtile from an atlas/autotile given its coordinates.
 			</description>
 		</method>
-		<method name="autotile_set_navigation_polygon">
+		<method name="subtile_set_navigation_polygon">
 			<return type="void">
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
 			<argument index="1" name="navigation_polygon" type="NavigationPolygon">
 			</argument>
-			<argument index="2" name="coord" type="Vector2">
+			<argument index="2" name="subtile_coordinate" type="Vector2">
 			</argument>
 			<description>
 				Sets the navigation polygon of the subtile from an atlas/autotile given its coordinates.
 			</description>
 		</method>
-		<method name="autotile_set_size">
+		<method name="subtile_set_size">
 			<return type="void">
 			</return>
 			<argument index="0" name="id" type="int">
@@ -223,7 +219,7 @@
 				Sets the size of the subtiles in an atlas/autotile.
 			</description>
 		</method>
-		<method name="autotile_set_spacing">
+		<method name="subtile_set_spacing">
 			<return type="void">
 			</return>
 			<argument index="0" name="id" type="int">
@@ -239,7 +235,7 @@
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
-			<argument index="1" name="coord" type="Vector2">
+			<argument index="1" name="subtile_coordinate" type="Vector2">
 			</argument>
 			<argument index="2" name="priority" type="int">
 			</argument>
@@ -248,12 +244,12 @@
 				When more than one subtile has the same bitmask value, one of them will be picked randomly for drawing. Its priority will define how often it will be picked.
 			</description>
 		</method>
-		<method name="autotile_set_z_index">
+		<method name="subtile_set_z_index">
 			<return type="void">
 			</return>
 			<argument index="0" name="id" type="int">
 			</argument>
-			<argument index="1" name="coord" type="Vector2">
+			<argument index="1" name="subtile_coordinate" type="Vector2">
 			</argument>
 			<argument index="2" name="z_index" type="int">
 			</argument>
@@ -320,7 +316,7 @@
 			</argument>
 			<argument index="3" name="one_way" type="bool" default="false">
 			</argument>
-			<argument index="4" name="autotile_coord" type="Vector2" default="Vector2( 0, 0 )">
+			<argument index="4" name="subtile_coordinate" type="Vector2" default="Vector2( 0, 0 )">
 			</argument>
 			<description>
 				Adds a shape to the tile.

--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -111,7 +111,7 @@ class TileMapEditor : public VBoxContainer {
 	bool flip_h;
 	bool flip_v;
 	bool transpose;
-	Point2i autotile_coord;
+	Point2i subtile_coordinate;
 
 	Point2i rectangle_begin;
 	Rect2i rectangle;
@@ -142,7 +142,7 @@ class TileMapEditor : public VBoxContainer {
 		bool flip_h = false;
 		bool flip_v = false;
 		bool transpose = false;
-		Point2i autotile_coord;
+		Point2i subtile_coordinate;
 
 		TileData() {}
 	};
@@ -162,8 +162,8 @@ class TileMapEditor : public VBoxContainer {
 	void _select(const Point2i &p_from, const Point2i &p_to);
 	void _erase_selection();
 
-	void _draw_cell(Control *p_viewport, int p_cell, const Point2i &p_point, bool p_flip_h, bool p_flip_v, bool p_transpose, const Point2i &p_autotile_coord, const Transform2D &p_xform);
-	void _draw_fill_preview(Control *p_viewport, int p_cell, const Point2i &p_point, bool p_flip_h, bool p_flip_v, bool p_transpose, const Point2i &p_autotile_coord, const Transform2D &p_xform);
+	void _draw_cell(Control *p_viewport, int p_cell, const Point2i &p_point, bool p_flip_h, bool p_flip_v, bool p_transpose, const Point2i &p_subtile_coordinate, const Transform2D &p_xform);
+	void _draw_fill_preview(Control *p_viewport, int p_cell, const Point2i &p_point, bool p_flip_h, bool p_flip_v, bool p_transpose, const Point2i &p_subtile_coordinate, const Transform2D &p_xform);
 	void _clear_bucket_cache();
 
 	void _update_copydata();
@@ -183,11 +183,11 @@ class TileMapEditor : public VBoxContainer {
 	void _palette_selected(int index);
 	void _palette_multi_selected(int index, bool selected);
 
-	Dictionary _create_cell_dictionary(int tile, bool flip_x, bool flip_y, bool transpose, Vector2 autotile_coord);
+	Dictionary _create_cell_dictionary(int tile, bool flip_x, bool flip_y, bool transpose, Vector2 subtile_coordinate);
 	void _start_undo(const String &p_action);
 	void _finish_undo();
 	void _create_set_cell_undo_redo(const Vector2 &p_vec, const CellOp &p_cell_old, const CellOp &p_cell_new);
-	void _set_cell(const Point2i &p_pos, Vector<int> p_values, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false, const Point2i &p_autotile_coord = Point2());
+	void _set_cell(const Point2i &p_pos, Vector<int> p_values, bool p_flip_h = false, bool p_flip_v = false, bool p_transpose = false, const Point2i &p_subtile_coordinate = Point2());
 
 	void _canvas_mouse_enter();
 	void _canvas_mouse_exit();

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -900,13 +900,13 @@ void TileSetEditor::_on_workspace_draw() {
 
 	draw_grid_snap();
 	if (get_current_tile() >= 0) {
-		int spacing = tileset->autotile_get_spacing(get_current_tile());
-		Vector2 size = tileset->autotile_get_size(get_current_tile());
+		int spacing = tileset->subtile_get_spacing(get_current_tile());
+		Vector2 size = tileset->subtile_get_size(get_current_tile());
 		Rect2i region = tileset->tile_get_region(get_current_tile());
 
 		switch (edit_mode) {
 			case EDITMODE_ICON: {
-				Vector2 coord = tileset->autotile_get_icon_coordinate(get_current_tile());
+				Vector2 coord = tileset->subtile_get_icon_coordinate(get_current_tile());
 				draw_highlight_subtile(coord);
 			} break;
 			case EDITMODE_BITMASK: {
@@ -1029,7 +1029,7 @@ void TileSetEditor::_on_workspace_draw() {
 				draw_highlight_subtile(edited_shape_coord, queue_others);
 			} break;
 			case EDITMODE_Z_INDEX: {
-				spin_z_index->set_value(tileset->autotile_get_z_index(get_current_tile(), edited_shape_coord));
+				spin_z_index->set_value(tileset->subtile_get_z_index(get_current_tile(), edited_shape_coord));
 				draw_highlight_subtile(edited_shape_coord);
 			} break;
 			default: {
@@ -1316,8 +1316,8 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 						undo_redo->add_do_method(tileset.ptr(), "tile_set_region", t_id, edited_region);
 						undo_redo->add_do_method(tileset.ptr(), "tile_set_name", t_id, get_current_texture()->get_path().get_file() + " " + String::num(t_id, 0));
 						if (workspace_mode != WORKSPACE_CREATE_SINGLE) {
-							undo_redo->add_do_method(tileset.ptr(), "autotile_set_size", t_id, snap_step);
-							undo_redo->add_do_method(tileset.ptr(), "autotile_set_spacing", t_id, snap_separation.x);
+							undo_redo->add_do_method(tileset.ptr(), "subtile_set_size", t_id, snap_step);
+							undo_redo->add_do_method(tileset.ptr(), "subtile_set_spacing", t_id, snap_separation.x);
 							undo_redo->add_do_method(tileset.ptr(), "tile_set_tile_mode", t_id, workspace_mode == WORKSPACE_CREATE_AUTOTILE ? TileSet::AUTO_TILE : TileSet::ATLAS_TILE);
 						}
 
@@ -1368,16 +1368,16 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 
 	if (workspace_mode == WORKSPACE_EDIT) {
 		if (get_current_tile() >= 0) {
-			int spacing = tileset->autotile_get_spacing(get_current_tile());
-			Vector2 size = tileset->autotile_get_size(get_current_tile());
+			int spacing = tileset->subtile_get_spacing(get_current_tile());
+			Vector2 size = tileset->subtile_get_size(get_current_tile());
 			switch (edit_mode) {
 				case EDITMODE_ICON: {
 					if (mb.is_valid()) {
 						if (mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT && current_tile_region.has_point(mb->get_position())) {
 							Vector2 coord((int)((mb->get_position().x - current_tile_region.position.x) / (spacing + size.x)), (int)((mb->get_position().y - current_tile_region.position.y) / (spacing + size.y)));
 							undo_redo->create_action(TTR("Set Tile Icon"));
-							undo_redo->add_do_method(tileset.ptr(), "autotile_set_icon_coordinate", get_current_tile(), coord);
-							undo_redo->add_undo_method(tileset.ptr(), "autotile_set_icon_coordinate", get_current_tile(), tileset->autotile_get_icon_coordinate(get_current_tile()));
+							undo_redo->add_do_method(tileset.ptr(), "subtile_set_icon_coordinate", get_current_tile(), coord);
+							undo_redo->add_undo_method(tileset.ptr(), "subtile_set_icon_coordinate", get_current_tile(), tileset->subtile_get_icon_coordinate(get_current_tile()));
 							undo_redo->add_do_method(workspace, "update");
 							undo_redo->add_undo_method(workspace, "update");
 							undo_redo->commit_action();
@@ -1866,8 +1866,8 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 							undo_redo->add_do_method(tileset.ptr(), "tile_set_light_occluder", get_current_tile(), Ref<OccluderPolygon2D>());
 							undo_redo->add_undo_method(tileset.ptr(), "tile_set_light_occluder", get_current_tile(), tileset->tile_get_light_occluder(get_current_tile()));
 						} else {
-							undo_redo->add_do_method(tileset.ptr(), "autotile_set_light_occluder", get_current_tile(), Ref<OccluderPolygon2D>(), edited_shape_coord);
-							undo_redo->add_undo_method(tileset.ptr(), "autotile_set_light_occluder", get_current_tile(), tileset->autotile_get_light_occluder(get_current_tile(), edited_shape_coord), edited_shape_coord);
+							undo_redo->add_do_method(tileset.ptr(), "subtile_set_light_occluder", get_current_tile(), Ref<OccluderPolygon2D>(), edited_shape_coord);
+							undo_redo->add_undo_method(tileset.ptr(), "subtile_set_light_occluder", get_current_tile(), tileset->subtile_get_light_occluder(get_current_tile(), edited_shape_coord), edited_shape_coord);
 						}
 						undo_redo->add_do_method(this, "_select_edited_shape_coord");
 						undo_redo->add_undo_method(this, "_select_edited_shape_coord");
@@ -1881,8 +1881,8 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 							undo_redo->add_do_method(tileset.ptr(), "tile_set_navigation_polygon", get_current_tile(), Ref<NavigationPolygon>());
 							undo_redo->add_undo_method(tileset.ptr(), "tile_set_navigation_polygon", get_current_tile(), tileset->tile_get_navigation_polygon(get_current_tile()));
 						} else {
-							undo_redo->add_do_method(tileset.ptr(), "autotile_set_navigation_polygon", get_current_tile(), Ref<NavigationPolygon>(), edited_shape_coord);
-							undo_redo->add_undo_method(tileset.ptr(), "autotile_set_navigation_polygon", get_current_tile(), tileset->autotile_get_navigation_polygon(get_current_tile(), edited_shape_coord), edited_shape_coord);
+							undo_redo->add_do_method(tileset.ptr(), "subtile_set_navigation_polygon", get_current_tile(), Ref<NavigationPolygon>(), edited_shape_coord);
+							undo_redo->add_undo_method(tileset.ptr(), "subtile_set_navigation_polygon", get_current_tile(), tileset->subtile_get_navigation_polygon(get_current_tile(), edited_shape_coord), edited_shape_coord);
 						}
 						undo_redo->add_do_method(this, "_select_edited_shape_coord");
 						undo_redo->add_undo_method(this, "_select_edited_shape_coord");
@@ -1917,13 +1917,13 @@ void TileSetEditor::_on_priority_changed(float val) {
 }
 
 void TileSetEditor::_on_z_index_changed(float val) {
-	if ((int)val == tileset->autotile_get_z_index(get_current_tile(), edited_shape_coord)) {
+	if ((int)val == tileset->subtile_get_z_index(get_current_tile(), edited_shape_coord)) {
 		return;
 	}
 
 	undo_redo->create_action(TTR("Edit Tile Z Index"));
-	undo_redo->add_do_method(tileset.ptr(), "autotile_set_z_index", get_current_tile(), edited_shape_coord, (int)val);
-	undo_redo->add_undo_method(tileset.ptr(), "autotile_set_z_index", get_current_tile(), edited_shape_coord, tileset->autotile_get_z_index(get_current_tile(), edited_shape_coord));
+	undo_redo->add_do_method(tileset.ptr(), "subtile_set_z_index", get_current_tile(), edited_shape_coord, (int)val);
+	undo_redo->add_undo_method(tileset.ptr(), "subtile_set_z_index", get_current_tile(), edited_shape_coord, tileset->subtile_get_z_index(get_current_tile(), edited_shape_coord));
 	undo_redo->add_do_method(workspace, "update");
 	undo_redo->add_undo_method(workspace, "update");
 	undo_redo->commit_action();
@@ -1989,19 +1989,19 @@ void TileSetEditor::_update_tile_data() {
 		data.occlusion_shape = tileset->tile_get_light_occluder(get_current_tile());
 		current_tile_data[Vector2i()] = data;
 	} else {
-		int spacing = tileset->autotile_get_spacing(get_current_tile());
+		int spacing = tileset->subtile_get_spacing(get_current_tile());
 		Vector2 size = tileset->tile_get_region(get_current_tile()).size;
-		Vector2 cell_count = (size / (tileset->autotile_get_size(get_current_tile()) + Vector2(spacing, spacing))).floor();
+		Vector2 cell_count = (size / (tileset->subtile_get_size(get_current_tile()) + Vector2(spacing, spacing))).floor();
 		for (int y = 0; y < cell_count.y; y++) {
 			for (int x = 0; x < cell_count.x; x++) {
 				SubtileData data;
 				Vector2i coord(x, y);
 				for (int i = 0; i < sd.size(); i++) {
-					if (sd[i].autotile_coord == coord) {
+					if (sd[i].subtile_coordinate == coord) {
 						data.collisions.push_back(sd[i].shape);
 					}
 				}
-				data.navigation_shape = tileset->autotile_get_navigation_polygon(get_current_tile(), coord);
+				data.navigation_shape = tileset->subtile_get_navigation_polygon(get_current_tile(), coord);
 				data.occlusion_shape = tileset->tile_get_light_occluder(get_current_tile());
 				current_tile_data[coord] = data;
 			}
@@ -2091,9 +2091,9 @@ void TileSetEditor::_select_previous_tile() {
 			case EDITMODE_NAVIGATION:
 			case EDITMODE_PRIORITY:
 			case EDITMODE_Z_INDEX: {
-				int spacing = tileset->autotile_get_spacing(get_current_tile());
+				int spacing = tileset->subtile_get_spacing(get_current_tile());
 				Vector2 size = tileset->tile_get_region(get_current_tile()).size;
-				Vector2 cell_count = (size / (tileset->autotile_get_size(get_current_tile()) + Vector2(spacing, spacing))).floor();
+				Vector2 cell_count = (size / (tileset->subtile_get_size(get_current_tile()) + Vector2(spacing, spacing))).floor();
 				cell_count -= Vector2(1, 1);
 				edited_shape_coord = cell_count;
 				_select_edited_shape_coord();
@@ -2148,9 +2148,9 @@ void TileSetEditor::_select_next_subtile() {
 	} else if (edit_mode == EDITMODE_REGION || edit_mode == EDITMODE_BITMASK || edit_mode == EDITMODE_ICON) {
 		_select_next_tile();
 	} else {
-		int spacing = tileset->autotile_get_spacing(get_current_tile());
+		int spacing = tileset->subtile_get_spacing(get_current_tile());
 		Vector2 size = tileset->tile_get_region(get_current_tile()).size;
-		Vector2 cell_count = (size / (tileset->autotile_get_size(get_current_tile()) + Vector2(spacing, spacing))).floor();
+		Vector2 cell_count = (size / (tileset->subtile_get_size(get_current_tile()) + Vector2(spacing, spacing))).floor();
 		if (edited_shape_coord.x >= cell_count.x - 1 && edited_shape_coord.y >= cell_count.y - 1) {
 			_select_next_tile();
 		} else {
@@ -2174,9 +2174,9 @@ void TileSetEditor::_select_previous_subtile() {
 	} else if (edit_mode == EDITMODE_REGION || edit_mode == EDITMODE_BITMASK || edit_mode == EDITMODE_ICON) {
 		_select_previous_tile();
 	} else {
-		int spacing = tileset->autotile_get_spacing(get_current_tile());
+		int spacing = tileset->subtile_get_spacing(get_current_tile());
 		Vector2 size = tileset->tile_get_region(get_current_tile()).size;
-		Vector2 cell_count = (size / (tileset->autotile_get_size(get_current_tile()) + Vector2(spacing, spacing))).floor();
+		Vector2 cell_count = (size / (tileset->subtile_get_size(get_current_tile()) + Vector2(spacing, spacing))).floor();
 		if (edited_shape_coord.x <= 0 && edited_shape_coord.y <= 0) {
 			_select_previous_tile();
 		} else {
@@ -2217,8 +2217,8 @@ void TileSetEditor::_select_next_shape() {
 		Rect2 current_tile_region = tileset->tile_get_region(get_current_tile());
 		current_tile_region.position += WORKSPACE_MARGIN;
 
-		int spacing = tileset->autotile_get_spacing(get_current_tile());
-		Vector2 size = tileset->autotile_get_size(get_current_tile());
+		int spacing = tileset->subtile_get_spacing(get_current_tile());
+		Vector2 size = tileset->subtile_get_size(get_current_tile());
 		Vector2 shape_anchor = edited_shape_coord;
 		shape_anchor.x *= (size.x + spacing);
 		shape_anchor.y *= (size.y + spacing);
@@ -2279,8 +2279,8 @@ void TileSetEditor::_select_previous_shape() {
 		Rect2 current_tile_region = tileset->tile_get_region(get_current_tile());
 		current_tile_region.position += WORKSPACE_MARGIN;
 
-		int spacing = tileset->autotile_get_spacing(get_current_tile());
-		Vector2 size = tileset->autotile_get_size(get_current_tile());
+		int spacing = tileset->subtile_get_spacing(get_current_tile());
+		Vector2 size = tileset->subtile_get_size(get_current_tile());
 		Vector2 shape_anchor = edited_shape_coord;
 		shape_anchor.x *= (size.x + spacing);
 		shape_anchor.y *= (size.y + spacing);
@@ -2350,13 +2350,13 @@ void TileSetEditor::_undo_tile_removal(int p_id) {
 		undo_redo->add_undo_method(tileset.ptr(), "tile_set_light_occluder", p_id, tileset->tile_get_light_occluder(p_id));
 		undo_redo->add_undo_method(tileset.ptr(), "tile_set_navigation_polygon", p_id, tileset->tile_get_navigation_polygon(p_id));
 	} else {
-		Map<Vector2, Ref<OccluderPolygon2D>> oclusion_map = tileset->autotile_get_light_oclusion_map(p_id);
+		Map<Vector2, Ref<OccluderPolygon2D>> oclusion_map = tileset->subtile_get_light_oclusion_map(p_id);
 		for (Map<Vector2, Ref<OccluderPolygon2D>>::Element *E = oclusion_map.front(); E; E = E->next()) {
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_light_occluder", p_id, E->value(), E->key());
+			undo_redo->add_undo_method(tileset.ptr(), "subtile_set_light_occluder", p_id, E->value(), E->key());
 		}
-		Map<Vector2, Ref<NavigationPolygon>> navigation_map = tileset->autotile_get_navigation_map(p_id);
+		Map<Vector2, Ref<NavigationPolygon>> navigation_map = tileset->subtile_get_navigation_map(p_id);
 		for (Map<Vector2, Ref<NavigationPolygon>>::Element *E = navigation_map.front(); E; E = E->next()) {
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_navigation_polygon", p_id, E->value(), E->key());
+			undo_redo->add_undo_method(tileset.ptr(), "subtile_set_navigation_polygon", p_id, E->value(), E->key());
 		}
 		Map<Vector2, uint32_t> bitmask_map = tileset->autotile_get_bitmask_map(p_id);
 		for (Map<Vector2, uint32_t>::Element *E = bitmask_map.front(); E; E = E->next()) {
@@ -2366,14 +2366,14 @@ void TileSetEditor::_undo_tile_removal(int p_id) {
 		for (Map<Vector2, int>::Element *E = priority_map.front(); E; E = E->next()) {
 			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_subtile_priority", p_id, E->key(), E->value());
 		}
-		undo_redo->add_undo_method(tileset.ptr(), "autotile_set_icon_coordinate", p_id, tileset->autotile_get_icon_coordinate(p_id));
-		Map<Vector2, int> z_map = tileset->autotile_get_z_index_map(p_id);
+		undo_redo->add_undo_method(tileset.ptr(), "subtile_set_icon_coordinate", p_id, tileset->subtile_get_icon_coordinate(p_id));
+		Map<Vector2, int> z_map = tileset->subtile_get_z_index_map(p_id);
 		for (Map<Vector2, int>::Element *E = z_map.front(); E; E = E->next()) {
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_z_index", p_id, E->key(), E->value());
+			undo_redo->add_undo_method(tileset.ptr(), "subtile_set_z_index", p_id, E->key(), E->value());
 		}
 		undo_redo->add_undo_method(tileset.ptr(), "tile_set_tile_mode", p_id, tileset->tile_get_tile_mode(p_id));
-		undo_redo->add_undo_method(tileset.ptr(), "autotile_set_size", p_id, tileset->autotile_get_size(p_id));
-		undo_redo->add_undo_method(tileset.ptr(), "autotile_set_spacing", p_id, tileset->autotile_get_spacing(p_id));
+		undo_redo->add_undo_method(tileset.ptr(), "subtile_set_size", p_id, tileset->subtile_get_size(p_id));
+		undo_redo->add_undo_method(tileset.ptr(), "subtile_set_spacing", p_id, tileset->subtile_get_spacing(p_id));
 		undo_redo->add_undo_method(tileset.ptr(), "autotile_set_bitmask_mode", p_id, tileset->autotile_get_bitmask_mode(p_id));
 	}
 }
@@ -2434,8 +2434,8 @@ void TileSetEditor::draw_highlight_current_tile() {
 
 void TileSetEditor::draw_highlight_subtile(Vector2 coord, const Vector<Vector2> &other_highlighted) {
 	Color shadow_color = Color(0.3, 0.3, 0.3, 0.3);
-	Vector2 size = tileset->autotile_get_size(get_current_tile());
-	int spacing = tileset->autotile_get_spacing(get_current_tile());
+	Vector2 size = tileset->subtile_get_size(get_current_tile());
+	int spacing = tileset->subtile_get_spacing(get_current_tile());
 	Rect2 region = tileset->tile_get_region(get_current_tile());
 	coord.x *= (size.x + spacing);
 	coord.y *= (size.y + spacing);
@@ -2472,8 +2472,8 @@ void TileSetEditor::draw_tile_subdivision(int p_id, Color p_color) const {
 	Color c = p_color;
 	if (tileset->tile_get_tile_mode(p_id) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(p_id) == TileSet::ATLAS_TILE) {
 		Rect2 region = tileset->tile_get_region(p_id);
-		Size2 size = tileset->autotile_get_size(p_id);
-		int spacing = tileset->autotile_get_spacing(p_id);
+		Size2 size = tileset->subtile_get_size(p_id);
+		int spacing = tileset->subtile_get_spacing(p_id);
 		float j = size.x;
 
 		while (j < region.size.x) {
@@ -2505,8 +2505,8 @@ void TileSetEditor::draw_edited_region_subdivision() const {
 
 	if (workspace_mode == WORKSPACE_EDIT) {
 		int p_id = get_current_tile();
-		size = tileset->autotile_get_size(p_id);
-		spacing = tileset->autotile_get_spacing(p_id);
+		size = tileset->subtile_get_size(p_id);
+		spacing = tileset->subtile_get_spacing(p_id);
 		draw = tileset->tile_get_tile_mode(p_id) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(p_id) == TileSet::ATLAS_TILE;
 	} else {
 		size = snap_step;
@@ -2598,10 +2598,10 @@ void TileSetEditor::draw_polygon_shapes() {
 				Vector2 coord = Vector2(0, 0);
 				Vector2 anchor = Vector2(0, 0);
 				if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
-					coord = sd[i].autotile_coord;
-					anchor = tileset->autotile_get_size(t_id);
-					anchor.x += tileset->autotile_get_spacing(t_id);
-					anchor.y += tileset->autotile_get_spacing(t_id);
+					coord = sd[i].subtile_coordinate;
+					anchor = tileset->subtile_get_size(t_id);
+					anchor.x += tileset->subtile_get_spacing(t_id);
+					anchor.y += tileset->subtile_get_spacing(t_id);
 					anchor.x *= coord.x;
 					anchor.y *= coord.y;
 				}
@@ -2702,12 +2702,12 @@ void TileSetEditor::draw_polygon_shapes() {
 					}
 				}
 			} else {
-				Map<Vector2, Ref<OccluderPolygon2D>> map = tileset->autotile_get_light_oclusion_map(t_id);
+				Map<Vector2, Ref<OccluderPolygon2D>> map = tileset->subtile_get_light_oclusion_map(t_id);
 				for (Map<Vector2, Ref<OccluderPolygon2D>>::Element *E = map.front(); E; E = E->next()) {
 					Vector2 coord = E->key();
-					Vector2 anchor = tileset->autotile_get_size(t_id);
-					anchor.x += tileset->autotile_get_spacing(t_id);
-					anchor.y += tileset->autotile_get_spacing(t_id);
+					Vector2 anchor = tileset->subtile_get_size(t_id);
+					anchor.x += tileset->subtile_get_spacing(t_id);
+					anchor.y += tileset->subtile_get_spacing(t_id);
 					anchor.x *= coord.x;
 					anchor.y *= coord.y;
 					anchor += WORKSPACE_MARGIN;
@@ -2790,12 +2790,12 @@ void TileSetEditor::draw_polygon_shapes() {
 					}
 				}
 			} else {
-				Map<Vector2, Ref<NavigationPolygon>> map = tileset->autotile_get_navigation_map(t_id);
+				Map<Vector2, Ref<NavigationPolygon>> map = tileset->subtile_get_navigation_map(t_id);
 				for (Map<Vector2, Ref<NavigationPolygon>>::Element *E = map.front(); E; E = E->next()) {
 					Vector2 coord = E->key();
-					Vector2 anchor = tileset->autotile_get_size(t_id);
-					anchor.x += tileset->autotile_get_spacing(t_id);
-					anchor.y += tileset->autotile_get_spacing(t_id);
+					Vector2 anchor = tileset->subtile_get_size(t_id);
+					anchor.x += tileset->subtile_get_spacing(t_id);
+					anchor.y += tileset->subtile_get_spacing(t_id);
 					anchor.x *= coord.x;
 					anchor.y *= coord.y;
 					anchor += WORKSPACE_MARGIN;
@@ -2920,8 +2920,8 @@ void TileSetEditor::close_shape(const Vector2 &shape_anchor) {
 
 		undo_redo->create_action(TTR("Create Occlusion Polygon"));
 		if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
-			undo_redo->add_do_method(tileset.ptr(), "autotile_set_light_occluder", get_current_tile(), shape, edited_shape_coord);
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_light_occluder", get_current_tile(), tileset->autotile_get_light_occluder(get_current_tile(), edited_shape_coord), edited_shape_coord);
+			undo_redo->add_do_method(tileset.ptr(), "subtile_set_light_occluder", get_current_tile(), shape, edited_shape_coord);
+			undo_redo->add_undo_method(tileset.ptr(), "subtile_set_light_occluder", get_current_tile(), tileset->subtile_get_light_occluder(get_current_tile(), edited_shape_coord), edited_shape_coord);
 		} else {
 			undo_redo->add_do_method(tileset.ptr(), "tile_set_light_occluder", get_current_tile(), shape);
 			undo_redo->add_undo_method(tileset.ptr(), "tile_set_light_occluder", get_current_tile(), tileset->tile_get_light_occluder(get_current_tile()));
@@ -2948,8 +2948,8 @@ void TileSetEditor::close_shape(const Vector2 &shape_anchor) {
 
 		undo_redo->create_action(TTR("Create Navigation Polygon"));
 		if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
-			undo_redo->add_do_method(tileset.ptr(), "autotile_set_navigation_polygon", get_current_tile(), shape, edited_shape_coord);
-			undo_redo->add_undo_method(tileset.ptr(), "autotile_set_navigation_polygon", get_current_tile(), tileset->autotile_get_navigation_polygon(get_current_tile(), edited_shape_coord), edited_shape_coord);
+			undo_redo->add_do_method(tileset.ptr(), "subtile_set_navigation_polygon", get_current_tile(), shape, edited_shape_coord);
+			undo_redo->add_undo_method(tileset.ptr(), "subtile_set_navigation_polygon", get_current_tile(), tileset->subtile_get_navigation_polygon(get_current_tile(), edited_shape_coord), edited_shape_coord);
 		} else {
 			undo_redo->add_do_method(tileset.ptr(), "tile_set_navigation_polygon", get_current_tile(), shape);
 			undo_redo->add_undo_method(tileset.ptr(), "tile_set_navigation_polygon", get_current_tile(), tileset->tile_get_navigation_polygon(get_current_tile()));
@@ -3010,7 +3010,7 @@ void TileSetEditor::select_coord(const Vector2 &coord) {
 		Vector<TileSet::ShapeData> sd = tileset->tile_get_shapes(get_current_tile());
 		bool found_collision_shape = false;
 		for (int i = 0; i < sd.size(); i++) {
-			if (sd[i].autotile_coord == coord) {
+			if (sd[i].subtile_coordinate == coord) {
 				if (edited_collision_shape != sd[i].shape) {
 					_set_edited_collision_shape(sd[i].shape);
 				}
@@ -3021,15 +3021,15 @@ void TileSetEditor::select_coord(const Vector2 &coord) {
 		if (!found_collision_shape) {
 			_set_edited_collision_shape(Ref<ConvexPolygonShape2D>(nullptr));
 		}
-		if (edited_occlusion_shape != tileset->autotile_get_light_occluder(get_current_tile(), coord)) {
-			edited_occlusion_shape = tileset->autotile_get_light_occluder(get_current_tile(), coord);
+		if (edited_occlusion_shape != tileset->subtile_get_light_occluder(get_current_tile(), coord)) {
+			edited_occlusion_shape = tileset->subtile_get_light_occluder(get_current_tile(), coord);
 		}
-		if (edited_navigation_shape != tileset->autotile_get_navigation_polygon(get_current_tile(), coord)) {
-			edited_navigation_shape = tileset->autotile_get_navigation_polygon(get_current_tile(), coord);
+		if (edited_navigation_shape != tileset->subtile_get_navigation_polygon(get_current_tile(), coord)) {
+			edited_navigation_shape = tileset->subtile_get_navigation_polygon(get_current_tile(), coord);
 		}
 
-		int spacing = tileset->autotile_get_spacing(get_current_tile());
-		Vector2 size = tileset->autotile_get_size(get_current_tile());
+		int spacing = tileset->subtile_get_spacing(get_current_tile());
+		Vector2 size = tileset->subtile_get_size(get_current_tile());
 		Vector2 shape_anchor = coord;
 		shape_anchor.x *= (size.x + spacing);
 		shape_anchor.y *= (size.y + spacing);
@@ -3068,8 +3068,8 @@ void TileSetEditor::select_coord(const Vector2 &coord) {
 Vector2 TileSetEditor::snap_point(const Vector2 &point) {
 	Vector2 p = point;
 	Vector2 coord = edited_shape_coord;
-	Vector2 tile_size = tileset->autotile_get_size(get_current_tile());
-	int spacing = tileset->autotile_get_spacing(get_current_tile());
+	Vector2 tile_size = tileset->subtile_get_size(get_current_tile());
+	int spacing = tileset->subtile_get_spacing(get_current_tile());
 	Vector2 anchor = coord;
 	anchor.x *= (tile_size.x + spacing);
 	anchor.y *= (tile_size.y + spacing);
@@ -3246,7 +3246,7 @@ void TileSetEditor::update_workspace_tile_mode() {
 		tool_editmode[EDITMODE_Z_INDEX]->hide();
 	} else if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE) {
 		if (edit_mode == EDITMODE_ICON) {
-			select_coord(tileset->autotile_get_icon_coordinate(get_current_tile()));
+			select_coord(tileset->subtile_get_icon_coordinate(get_current_tile()));
 		} else {
 			_select_edited_shape_coord();
 		}
@@ -3256,7 +3256,7 @@ void TileSetEditor::update_workspace_tile_mode() {
 			edit_mode = EDITMODE_COLLISION;
 		}
 		if (edit_mode == EDITMODE_ICON) {
-			select_coord(tileset->autotile_get_icon_coordinate(get_current_tile()));
+			select_coord(tileset->subtile_get_icon_coordinate(get_current_tile()));
 		} else {
 			_select_edited_shape_coord();
 		}

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -393,7 +393,7 @@ void TileMap::update_dirty_quadrants() {
 
 			if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE ||
 					tile_set->tile_get_tile_mode(c.id) == TileSet::ATLAS_TILE) {
-				z_index += tile_set->autotile_get_z_index(c.id, Vector2(c.autotile_coord_x, c.autotile_coord_y));
+				z_index += tile_set->subtile_get_z_index(c.id, Vector2(c.subtile_coordinate_x, c.subtile_coordinate_y));
 			}
 
 			RID canvas_item;
@@ -436,9 +436,9 @@ void TileMap::update_dirty_quadrants() {
 
 			Rect2 r = tile_set->tile_get_region(c.id);
 			if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE || tile_set->tile_get_tile_mode(c.id) == TileSet::ATLAS_TILE) {
-				int spacing = tile_set->autotile_get_spacing(c.id);
-				r.size = tile_set->autotile_get_size(c.id);
-				r.position += (r.size + Vector2(spacing, spacing)) * Vector2(c.autotile_coord_x, c.autotile_coord_y);
+				int spacing = tile_set->subtile_get_spacing(c.id);
+				r.size = tile_set->subtile_get_size(c.id);
+				r.position += (r.size + Vector2(spacing, spacing)) * Vector2(c.subtile_coordinate_x, c.subtile_coordinate_y);
 			}
 
 			Size2 s;
@@ -542,7 +542,7 @@ void TileMap::update_dirty_quadrants() {
 			for (int j = 0; j < shapes.size(); j++) {
 				Ref<Shape2D> shape = shapes[j].shape;
 				if (shape.is_valid()) {
-					if (tile_set->tile_get_tile_mode(c.id) == TileSet::SINGLE_TILE || (shapes[j].autotile_coord.x == c.autotile_coord_x && shapes[j].autotile_coord.y == c.autotile_coord_y)) {
+					if (tile_set->tile_get_tile_mode(c.id) == TileSet::SINGLE_TILE || (shapes[j].subtile_coordinate.x == c.subtile_coordinate_x && shapes[j].subtile_coordinate.y == c.subtile_coordinate_y)) {
 						Transform2D xform;
 						xform.set_origin(offset.floor());
 
@@ -584,7 +584,7 @@ void TileMap::update_dirty_quadrants() {
 				Ref<NavigationPolygon> navpoly;
 				Vector2 npoly_ofs;
 				if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE || tile_set->tile_get_tile_mode(c.id) == TileSet::ATLAS_TILE) {
-					navpoly = tile_set->autotile_get_navigation_polygon(c.id, Vector2(c.autotile_coord_x, c.autotile_coord_y));
+					navpoly = tile_set->subtile_get_navigation_polygon(c.id, Vector2(c.subtile_coordinate_x, c.subtile_coordinate_y));
 					npoly_ofs = Vector2();
 				} else {
 					navpoly = tile_set->tile_get_navigation_polygon(c.id);
@@ -657,7 +657,7 @@ void TileMap::update_dirty_quadrants() {
 
 			Ref<OccluderPolygon2D> occluder;
 			if (tile_set->tile_get_tile_mode(c.id) == TileSet::AUTO_TILE || tile_set->tile_get_tile_mode(c.id) == TileSet::ATLAS_TILE) {
-				occluder = tile_set->autotile_get_light_occluder(c.id, Vector2(c.autotile_coord_x, c.autotile_coord_y));
+				occluder = tile_set->subtile_get_light_occluder(c.id, Vector2(c.subtile_coordinate_x, c.subtile_coordinate_y));
 			} else {
 				occluder = tile_set->tile_get_light_occluder(c.id);
 			}
@@ -828,13 +828,13 @@ void TileMap::set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x, bool p_
 }
 
 void TileMap::_set_celld(const Vector2 &p_pos, const Dictionary &p_data) {
-	Variant v_pos_x = p_pos.x, v_pos_y = p_pos.y, v_tile = p_data["id"], v_flip_h = p_data["flip_h"], v_flip_v = p_data["flip_y"], v_transpose = p_data["transpose"], v_autotile_coord = p_data["auto_coord"];
-	const Variant *args[7] = { &v_pos_x, &v_pos_y, &v_tile, &v_flip_h, &v_flip_v, &v_transpose, &v_autotile_coord };
+	Variant v_pos_x = p_pos.x, v_pos_y = p_pos.y, v_tile = p_data["id"], v_flip_h = p_data["flip_h"], v_flip_v = p_data["flip_y"], v_transpose = p_data["transpose"], v_subtile_coordinate = p_data["subtile_coordinate"];
+	const Variant *args[7] = { &v_pos_x, &v_pos_y, &v_tile, &v_flip_h, &v_flip_v, &v_transpose, &v_subtile_coordinate };
 	Callable::CallError ce;
 	call("set_cell", args, 7, ce);
 }
 
-void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_y, bool p_transpose, Vector2 p_autotile_coord) {
+void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_y, bool p_transpose, Vector2 p_subtile_coordinate) {
 	PosKey pk(p_x, p_y);
 
 	Map<PosKey, Cell>::Element *E = tile_map.find(pk);
@@ -872,7 +872,7 @@ void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_
 	} else {
 		ERR_FAIL_COND(!Q); // quadrant should exist...
 
-		if (E->get().id == p_tile && E->get().flip_h == p_flip_x && E->get().flip_v == p_flip_y && E->get().transpose == p_transpose && E->get().autotile_coord_x == (uint16_t)p_autotile_coord.x && E->get().autotile_coord_y == (uint16_t)p_autotile_coord.y) {
+		if (E->get().id == p_tile && E->get().flip_h == p_flip_x && E->get().flip_v == p_flip_y && E->get().transpose == p_transpose && E->get().subtile_coordinate_x == (uint16_t)p_subtile_coordinate.x && E->get().subtile_coordinate_y == (uint16_t)p_subtile_coordinate.y) {
 			return; //nothing changed
 		}
 	}
@@ -883,8 +883,8 @@ void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_
 	c.flip_h = p_flip_x;
 	c.flip_v = p_flip_y;
 	c.transpose = p_transpose;
-	c.autotile_coord_x = (uint16_t)p_autotile_coord.x;
-	c.autotile_coord_y = (uint16_t)p_autotile_coord.y;
+	c.subtile_coordinate_x = (uint16_t)p_subtile_coordinate.x;
+	c.subtile_coordinate_y = (uint16_t)p_subtile_coordinate.y;
 
 	_make_quadrant_dirty(Q);
 	used_size_cache_dirty = true;
@@ -993,22 +993,22 @@ void TileMap::update_cell_bitmask(int p_x, int p_y) {
 				}
 			}
 			Vector2 coord = tile_set->autotile_get_subtile_for_bitmask(id, mask, this, Vector2(p_x, p_y));
-			E->get().autotile_coord_x = (int)coord.x;
-			E->get().autotile_coord_y = (int)coord.y;
+			E->get().subtile_coordinate_x = (int)coord.x;
+			E->get().subtile_coordinate_y = (int)coord.y;
 
 			PosKey qk = p.to_quadrant(_get_quadrant_size());
 			Map<PosKey, Quadrant>::Element *Q = quadrant_map.find(qk);
 			_make_quadrant_dirty(Q);
 
 		} else if (tile_set->tile_get_tile_mode(id) == TileSet::SINGLE_TILE) {
-			E->get().autotile_coord_x = 0;
-			E->get().autotile_coord_y = 0;
+			E->get().subtile_coordinate_x = 0;
+			E->get().subtile_coordinate_y = 0;
 		} else if (tile_set->tile_get_tile_mode(id) == TileSet::ATLAS_TILE) {
 			if (tile_set->autotile_get_bitmask(id, Vector2(p_x, p_y)) == TileSet::BIND_CENTER) {
 				Vector2 coord = tile_set->atlastile_get_subtile_by_priority(id, this, Vector2(p_x, p_y));
 
-				E->get().autotile_coord_x = (int)coord.x;
-				E->get().autotile_coord_y = (int)coord.y;
+				E->get().subtile_coordinate_x = (int)coord.x;
+				E->get().subtile_coordinate_y = (int)coord.y;
 			}
 		}
 	}
@@ -1078,7 +1078,7 @@ bool TileMap::is_cell_transposed(int p_x, int p_y) const {
 	return E->get().transpose;
 }
 
-void TileMap::set_cell_autotile_coord(int p_x, int p_y, const Vector2 &p_coord) {
+void TileMap::set_cell_subtile_coordinate(int p_x, int p_y, const Vector2 &p_subtile_coordinate) {
 	PosKey pk(p_x, p_y);
 
 	const Map<PosKey, Cell>::Element *E = tile_map.find(pk);
@@ -1088,8 +1088,8 @@ void TileMap::set_cell_autotile_coord(int p_x, int p_y, const Vector2 &p_coord) 
 	}
 
 	Cell c = E->get();
-	c.autotile_coord_x = p_coord.x;
-	c.autotile_coord_y = p_coord.y;
+	c.subtile_coordinate_x = p_subtile_coordinate.x;
+	c.subtile_coordinate_y = p_subtile_coordinate.y;
 	tile_map[pk] = c;
 
 	PosKey qk = pk.to_quadrant(_get_quadrant_size());
@@ -1102,16 +1102,16 @@ void TileMap::set_cell_autotile_coord(int p_x, int p_y, const Vector2 &p_coord) 
 	_make_quadrant_dirty(Q);
 }
 
-Vector2 TileMap::get_cell_autotile_coord(int p_x, int p_y) const {
+Vector2 TileMap::get_cell_subtile_coordinate(int p_x, int p_y) const {
 	PosKey pk(p_x, p_y);
 
 	const Map<PosKey, Cell>::Element *E = tile_map.find(pk);
 
 	if (!E) {
-		return Vector2();
+		return Vector2(Math_INF, Math_INF);
 	}
 
-	return Vector2(E->get().autotile_coord_x, E->get().autotile_coord_y);
+	return Vector2(E->get().subtile_coordinate_x, E->get().subtile_coordinate_y);
 }
 
 void TileMap::_recreate_quadrants() {
@@ -1237,8 +1237,8 @@ Vector<int> TileMap::_get_tile_data() const {
 			val |= (1 << 31);
 		}
 		encode_uint32(val, &ptr[4]);
-		encode_uint16(E->get().autotile_coord_x, &ptr[8]);
-		encode_uint16(E->get().autotile_coord_y, &ptr[10]);
+		encode_uint16(E->get().subtile_coordinate_x, &ptr[8]);
+		encode_uint16(E->get().subtile_coordinate_y, &ptr[10]);
 		idx += 3;
 	}
 
@@ -1764,7 +1764,7 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_occluder_light_mask", "mask"), &TileMap::set_occluder_light_mask);
 	ClassDB::bind_method(D_METHOD("get_occluder_light_mask"), &TileMap::get_occluder_light_mask);
 
-	ClassDB::bind_method(D_METHOD("set_cell", "x", "y", "tile", "flip_x", "flip_y", "transpose", "autotile_coord"), &TileMap::set_cell, DEFVAL(false), DEFVAL(false), DEFVAL(false), DEFVAL(Vector2()));
+	ClassDB::bind_method(D_METHOD("set_cell", "x", "y", "tile", "flip_x", "flip_y", "transpose", "subtile_coordinate"), &TileMap::set_cell, DEFVAL(false), DEFVAL(false), DEFVAL(false), DEFVAL(Vector2()));
 	ClassDB::bind_method(D_METHOD("set_cellv", "position", "tile", "flip_x", "flip_y", "transpose"), &TileMap::set_cellv, DEFVAL(false), DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("_set_celld", "position", "data"), &TileMap::_set_celld);
 	ClassDB::bind_method(D_METHOD("get_cell", "x", "y"), &TileMap::get_cell);
@@ -1773,7 +1773,7 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_cell_y_flipped", "x", "y"), &TileMap::is_cell_y_flipped);
 	ClassDB::bind_method(D_METHOD("is_cell_transposed", "x", "y"), &TileMap::is_cell_transposed);
 
-	ClassDB::bind_method(D_METHOD("get_cell_autotile_coord", "x", "y"), &TileMap::get_cell_autotile_coord);
+	ClassDB::bind_method(D_METHOD("get_cell_subtile_coordinate", "x", "y"), &TileMap::get_cell_subtile_coordinate);
 
 	ClassDB::bind_method(D_METHOD("fix_invalid_tiles"), &TileMap::fix_invalid_tiles);
 	ClassDB::bind_method(D_METHOD("clear"), &TileMap::clear);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -115,8 +115,8 @@ private:
 			bool flip_h : 1;
 			bool flip_v : 1;
 			bool transpose : 1;
-			int16_t autotile_coord_x : 16;
-			int16_t autotile_coord_y : 16;
+			int16_t subtile_coordinate_x : 16;
+			int16_t subtile_coordinate_y : 16;
 		};
 
 		uint64_t _u64t;
@@ -253,13 +253,13 @@ public:
 	void set_quadrant_size(int p_size);
 	int get_quadrant_size() const;
 
-	void set_cell(int p_x, int p_y, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false, Vector2 p_autotile_coord = Vector2());
+	void set_cell(int p_x, int p_y, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false, Vector2 p_subtile_coordinate = Vector2());
 	int get_cell(int p_x, int p_y) const;
 	bool is_cell_x_flipped(int p_x, int p_y) const;
 	bool is_cell_y_flipped(int p_x, int p_y) const;
 	bool is_cell_transposed(int p_x, int p_y) const;
-	void set_cell_autotile_coord(int p_x, int p_y, const Vector2 &p_coord);
-	Vector2 get_cell_autotile_coord(int p_x, int p_y) const;
+	void set_cell_subtile_coordinate(int p_x, int p_y, const Vector2 &p_subtile_coordinate);
+	Vector2 get_cell_subtile_coordinate(int p_x, int p_y) const;
 
 	void _set_celld(const Vector2 &p_pos, const Dictionary &p_data);
 	void set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false);

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -73,11 +73,11 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 		if (what == "bitmask_mode") {
 			autotile_set_bitmask_mode(id, (BitmaskMode)((int)p_value));
 		} else if (what == "icon_coordinate") {
-			autotile_set_icon_coordinate(id, p_value);
+			subtile_set_icon_coordinate(id, p_value);
 		} else if (what == "tile_size") {
-			autotile_set_size(id, p_value);
+			subtile_set_size(id, p_value);
 		} else if (what == "spacing") {
-			autotile_set_spacing(id, p_value);
+			subtile_set_spacing(id, p_value);
 		} else if (what == "bitmask_flags") {
 			tile_map[id].autotile_data.flags.clear();
 			if (p_value.is_array()) {
@@ -100,7 +100,7 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 				if (p[0].get_type() == Variant::VECTOR2) {
 					last_coord = p[0];
 				} else if (p[0].get_type() == Variant::OBJECT) {
-					autotile_set_light_occluder(id, p[0], last_coord);
+					subtile_set_light_occluder(id, p[0], last_coord);
 				}
 				p.pop_front();
 			}
@@ -112,7 +112,7 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 				if (p[0].get_type() == Variant::VECTOR2) {
 					last_coord = p[0];
 				} else if (p[0].get_type() == Variant::OBJECT) {
-					autotile_set_navigation_polygon(id, p[0], last_coord);
+					subtile_set_navigation_polygon(id, p[0], last_coord);
 				}
 				p.pop_front();
 			}
@@ -241,11 +241,11 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 		if (what == "bitmask_mode") {
 			r_ret = autotile_get_bitmask_mode(id);
 		} else if (what == "icon_coordinate") {
-			r_ret = autotile_get_icon_coordinate(id);
+			r_ret = subtile_get_icon_coordinate(id);
 		} else if (what == "tile_size") {
-			r_ret = autotile_get_size(id);
+			r_ret = subtile_get_size(id);
 		} else if (what == "spacing") {
-			r_ret = autotile_get_spacing(id);
+			r_ret = subtile_get_spacing(id);
 		} else if (what == "bitmask_flags") {
 			Array p;
 			for (Map<Vector2, uint32_t>::Element *E = tile_map[id].autotile_data.flags.front(); E; E = E->next()) {
@@ -469,36 +469,36 @@ TileSet::TileMode TileSet::tile_get_tile_mode(int p_id) const {
 	return tile_map[p_id].tile_mode;
 }
 
-void TileSet::autotile_set_icon_coordinate(int p_id, Vector2 coord) {
+void TileSet::subtile_set_icon_coordinate(int p_id, const Vector2 &p_icon_coordinate) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
-	tile_map[p_id].autotile_data.icon_coord = coord;
+	tile_map[p_id].autotile_data.icon_coordinate = p_icon_coordinate;
 	emit_changed();
 }
 
-Vector2 TileSet::autotile_get_icon_coordinate(int p_id) const {
+Vector2 TileSet::subtile_get_icon_coordinate(int p_id) const {
 	ERR_FAIL_COND_V(!tile_map.has(p_id), Vector2());
-	return tile_map[p_id].autotile_data.icon_coord;
+	return tile_map[p_id].autotile_data.icon_coordinate;
 }
 
-void TileSet::autotile_set_spacing(int p_id, int p_spacing) {
+void TileSet::subtile_set_spacing(int p_id, int p_spacing) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	ERR_FAIL_COND(p_spacing < 0);
 	tile_map[p_id].autotile_data.spacing = p_spacing;
 	emit_changed();
 }
 
-int TileSet::autotile_get_spacing(int p_id) const {
+int TileSet::subtile_get_spacing(int p_id) const {
 	ERR_FAIL_COND_V(!tile_map.has(p_id), 0);
 	return tile_map[p_id].autotile_data.spacing;
 }
 
-void TileSet::autotile_set_size(int p_id, Size2 p_size) {
+void TileSet::subtile_set_size(int p_id, Size2 p_size) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	ERR_FAIL_COND(p_size.x <= 0 || p_size.y <= 0);
 	tile_map[p_id].autotile_data.size = p_size;
 }
 
-Size2 TileSet::autotile_get_size(int p_id) const {
+Size2 TileSet::subtile_get_size(int p_id) const {
 	ERR_FAIL_COND_V(!tile_map.has(p_id), Size2());
 	return tile_map[p_id].autotile_data.size;
 }
@@ -508,16 +508,16 @@ void TileSet::autotile_clear_bitmask_map(int p_id) {
 	tile_map[p_id].autotile_data.flags.clear();
 }
 
-void TileSet::autotile_set_subtile_priority(int p_id, const Vector2 &p_coord, int p_priority) {
+void TileSet::autotile_set_subtile_priority(int p_id, const Vector2 &p_subtile_coordinate, int p_priority) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	ERR_FAIL_COND(p_priority <= 0);
-	tile_map[p_id].autotile_data.priority_map[p_coord] = p_priority;
+	tile_map[p_id].autotile_data.priority_map[p_subtile_coordinate] = p_priority;
 }
 
-int TileSet::autotile_get_subtile_priority(int p_id, const Vector2 &p_coord) {
+int TileSet::autotile_get_subtile_priority(int p_id, const Vector2 &p_subtile_coordinate) {
 	ERR_FAIL_COND_V(!tile_map.has(p_id), 1);
-	if (tile_map[p_id].autotile_data.priority_map.has(p_coord)) {
-		return tile_map[p_id].autotile_data.priority_map[p_coord];
+	if (tile_map[p_id].autotile_data.priority_map.has(p_subtile_coordinate)) {
+		return tile_map[p_id].autotile_data.priority_map[p_subtile_coordinate];
 	}
 	//When not custom priority set return the default value
 	return 1;
@@ -529,44 +529,44 @@ const Map<Vector2, int> &TileSet::autotile_get_priority_map(int p_id) const {
 	return tile_map[p_id].autotile_data.priority_map;
 }
 
-void TileSet::autotile_set_z_index(int p_id, const Vector2 &p_coord, int p_z_index) {
+void TileSet::subtile_set_z_index(int p_id, const Vector2 &p_subtile_coordinate, int p_z_index) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
-	tile_map[p_id].autotile_data.z_index_map[p_coord] = p_z_index;
+	tile_map[p_id].autotile_data.z_index_map[p_subtile_coordinate] = p_z_index;
 	emit_changed();
 }
 
-int TileSet::autotile_get_z_index(int p_id, const Vector2 &p_coord) {
+int TileSet::subtile_get_z_index(int p_id, const Vector2 &p_subtile_coordinate) {
 	ERR_FAIL_COND_V(!tile_map.has(p_id), 1);
-	if (tile_map[p_id].autotile_data.z_index_map.has(p_coord)) {
-		return tile_map[p_id].autotile_data.z_index_map[p_coord];
+	if (tile_map[p_id].autotile_data.z_index_map.has(p_subtile_coordinate)) {
+		return tile_map[p_id].autotile_data.z_index_map[p_subtile_coordinate];
 	}
 	//When not custom z index set return the default value
 	return 0;
 }
 
-const Map<Vector2, int> &TileSet::autotile_get_z_index_map(int p_id) const {
+const Map<Vector2, int> &TileSet::subtile_get_z_index_map(int p_id) const {
 	static Map<Vector2, int> dummy;
 	ERR_FAIL_COND_V(!tile_map.has(p_id), dummy);
 	return tile_map[p_id].autotile_data.z_index_map;
 }
 
-void TileSet::autotile_set_bitmask(int p_id, Vector2 p_coord, uint32_t p_flag) {
+void TileSet::autotile_set_bitmask(int p_id, Vector2 p_subtile_coordinate, uint32_t p_flag) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	if (p_flag == 0) {
-		if (tile_map[p_id].autotile_data.flags.has(p_coord)) {
-			tile_map[p_id].autotile_data.flags.erase(p_coord);
+		if (tile_map[p_id].autotile_data.flags.has(p_subtile_coordinate)) {
+			tile_map[p_id].autotile_data.flags.erase(p_subtile_coordinate);
 		}
 	} else {
-		tile_map[p_id].autotile_data.flags[p_coord] = p_flag;
+		tile_map[p_id].autotile_data.flags[p_subtile_coordinate] = p_flag;
 	}
 }
 
-uint32_t TileSet::autotile_get_bitmask(int p_id, Vector2 p_coord) {
+uint32_t TileSet::autotile_get_bitmask(int p_id, Vector2 p_subtile_coordinate) {
 	ERR_FAIL_COND_V(!tile_map.has(p_id), 0);
-	if (!tile_map[p_id].autotile_data.flags.has(p_coord)) {
+	if (!tile_map[p_id].autotile_data.flags.has(p_subtile_coordinate)) {
 		return 0;
 	}
-	return tile_map[p_id].autotile_data.flags[p_coord];
+	return tile_map[p_id].autotile_data.flags[p_subtile_coordinate];
 }
 
 const Map<Vector2, uint32_t> &TileSet::autotile_get_bitmask_map(int p_id) {
@@ -576,8 +576,8 @@ const Map<Vector2, uint32_t> &TileSet::autotile_get_bitmask_map(int p_id) {
 	if (tile_get_tile_mode(p_id) == ATLAS_TILE) {
 		dummy_atlas = Map<Vector2, uint32_t>();
 		Rect2 region = tile_get_region(p_id);
-		Size2 size = autotile_get_size(p_id);
-		float spacing = autotile_get_spacing(p_id);
+		Size2 size = subtile_get_size(p_id);
+		float spacing = subtile_get_spacing(p_id);
 		for (int x = 0; x < (region.size.x / (size.x + spacing)); x++) {
 			for (int y = 0; y < (region.size.y / (size.y + spacing)); y++) {
 				dummy_atlas.insert(Vector2(x, y), 0);
@@ -589,13 +589,13 @@ const Map<Vector2, uint32_t> &TileSet::autotile_get_bitmask_map(int p_id) {
 	}
 }
 
-Vector2 TileSet::autotile_get_subtile_for_bitmask(int p_id, uint16_t p_bitmask, const Node *p_tilemap_node, const Vector2 &p_tile_location) {
+Vector2 TileSet::autotile_get_subtile_for_bitmask(int p_id, uint16_t p_bitmask, const Node *p_tilemap_node, const Vector2 &p_cell_position) {
 	ERR_FAIL_COND_V(!tile_map.has(p_id), Vector2());
 	//First try to forward selection to script
 	if (p_tilemap_node->get_class_name() == "TileMap") {
 		if (get_script_instance() != nullptr) {
 			if (get_script_instance()->has_method("_forward_subtile_selection")) {
-				Variant ret = get_script_instance()->call("_forward_subtile_selection", p_id, p_bitmask, p_tilemap_node, p_tile_location);
+				Variant ret = get_script_instance()->call("_forward_subtile_selection", p_id, p_bitmask, p_tilemap_node, p_cell_position);
 				if (ret.get_type() == Variant::VECTOR2) {
 					return ret;
 				}
@@ -627,7 +627,7 @@ Vector2 TileSet::autotile_get_subtile_for_bitmask(int p_id, uint16_t p_bitmask, 
 	}
 
 	if (coords.size() == 0) {
-		return autotile_get_icon_coordinate(p_id);
+		return subtile_get_icon_coordinate(p_id);
 	} else {
 		uint32_t picked_value = Math::rand() % priority_sum;
 		uint32_t upper_bound;
@@ -650,19 +650,19 @@ Vector2 TileSet::autotile_get_subtile_for_bitmask(int p_id, uint16_t p_bitmask, 
 	}
 }
 
-Vector2 TileSet::atlastile_get_subtile_by_priority(int p_id, const Node *p_tilemap_node, const Vector2 &p_tile_location) {
+Vector2 TileSet::atlastile_get_subtile_by_priority(int p_id, const Node *p_tilemap_node, const Vector2 &p_cell_position) {
 	ERR_FAIL_COND_V(!tile_map.has(p_id), Vector2());
 	//First try to forward selection to script
 	if (get_script_instance() != nullptr) {
-		if (get_script_instance()->has_method("_forward_atlas_subtile_selection")) {
-			Variant ret = get_script_instance()->call("_forward_atlas_subtile_selection", p_id, p_tilemap_node, p_tile_location);
+		if (get_script_instance()->has_method("_forward_subtile_selection")) {
+			Variant ret = get_script_instance()->call("_forward_subtile_selection", p_id, 0, p_tilemap_node, p_cell_position);
 			if (ret.get_type() == Variant::VECTOR2) {
 				return ret;
 			}
 		}
 	}
 
-	Vector2 coord = tile_get_region(p_id).size / autotile_get_size(p_id);
+	Vector2 coord = tile_get_region(p_id).size / subtile_get_size(p_id);
 
 	List<Vector2> coords;
 	for (int x = 0; x < coord.x; x++) {
@@ -673,7 +673,7 @@ Vector2 TileSet::atlastile_get_subtile_by_priority(int p_id, const Node *p_tilem
 		}
 	}
 	if (coords.size() == 0) {
-		return autotile_get_icon_coordinate(p_id);
+		return subtile_get_icon_coordinate(p_id);
 	} else {
 		return coords[Math::random(0, (int)coords.size())];
 	}
@@ -696,14 +696,14 @@ void TileSet::tile_clear_shapes(int p_id) {
 	tile_map[p_id].shapes_data.clear();
 }
 
-void TileSet::tile_add_shape(int p_id, const Ref<Shape2D> &p_shape, const Transform2D &p_transform, bool p_one_way, const Vector2 &p_autotile_coord) {
+void TileSet::tile_add_shape(int p_id, const Ref<Shape2D> &p_shape, const Transform2D &p_transform, bool p_one_way, const Vector2 &p_subtile_coordinate) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 
 	ShapeData new_data = ShapeData();
 	new_data.shape = p_shape;
 	new_data.shape_transform = p_transform;
 	new_data.one_way_collision = p_one_way;
-	new_data.autotile_coord = p_autotile_coord;
+	new_data.subtile_coordinate = p_subtile_coordinate;
 
 	tile_map[p_id].shapes_data.push_back(new_data);
 }
@@ -822,24 +822,24 @@ Ref<OccluderPolygon2D> TileSet::tile_get_light_occluder(int p_id) const {
 	return tile_map[p_id].occluder;
 }
 
-void TileSet::autotile_set_light_occluder(int p_id, const Ref<OccluderPolygon2D> &p_light_occluder, const Vector2 &p_coord) {
+void TileSet::subtile_set_light_occluder(int p_id, const Ref<OccluderPolygon2D> &p_light_occluder, const Vector2 &p_subtile_coordinate) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	if (p_light_occluder.is_null()) {
-		if (tile_map[p_id].autotile_data.occluder_map.has(p_coord)) {
-			tile_map[p_id].autotile_data.occluder_map.erase(p_coord);
+		if (tile_map[p_id].autotile_data.occluder_map.has(p_subtile_coordinate)) {
+			tile_map[p_id].autotile_data.occluder_map.erase(p_subtile_coordinate);
 		}
 	} else {
-		tile_map[p_id].autotile_data.occluder_map[p_coord] = p_light_occluder;
+		tile_map[p_id].autotile_data.occluder_map[p_subtile_coordinate] = p_light_occluder;
 	}
 }
 
-Ref<OccluderPolygon2D> TileSet::autotile_get_light_occluder(int p_id, const Vector2 &p_coord) const {
+Ref<OccluderPolygon2D> TileSet::subtile_get_light_occluder(int p_id, const Vector2 &p_subtile_coordinate) const {
 	ERR_FAIL_COND_V(!tile_map.has(p_id), Ref<OccluderPolygon2D>());
 
-	if (!tile_map[p_id].autotile_data.occluder_map.has(p_coord)) {
+	if (!tile_map[p_id].autotile_data.occluder_map.has(p_subtile_coordinate)) {
 		return Ref<OccluderPolygon2D>();
 	} else {
-		return tile_map[p_id].autotile_data.occluder_map[p_coord];
+		return tile_map[p_id].autotile_data.occluder_map[p_subtile_coordinate];
 	}
 }
 
@@ -863,33 +863,33 @@ Ref<NavigationPolygon> TileSet::tile_get_navigation_polygon(int p_id) const {
 	return tile_map[p_id].navigation_polygon;
 }
 
-const Map<Vector2, Ref<OccluderPolygon2D>> &TileSet::autotile_get_light_oclusion_map(int p_id) const {
+const Map<Vector2, Ref<OccluderPolygon2D>> &TileSet::subtile_get_light_oclusion_map(int p_id) const {
 	static Map<Vector2, Ref<OccluderPolygon2D>> dummy;
 	ERR_FAIL_COND_V(!tile_map.has(p_id), dummy);
 	return tile_map[p_id].autotile_data.occluder_map;
 }
 
-void TileSet::autotile_set_navigation_polygon(int p_id, const Ref<NavigationPolygon> &p_navigation_polygon, const Vector2 &p_coord) {
+void TileSet::subtile_set_navigation_polygon(int p_id, const Ref<NavigationPolygon> &p_navigation_polygon, const Vector2 &p_subtile_coordinate) {
 	ERR_FAIL_COND(!tile_map.has(p_id));
 	if (p_navigation_polygon.is_null()) {
-		if (tile_map[p_id].autotile_data.navpoly_map.has(p_coord)) {
-			tile_map[p_id].autotile_data.navpoly_map.erase(p_coord);
+		if (tile_map[p_id].autotile_data.navpoly_map.has(p_subtile_coordinate)) {
+			tile_map[p_id].autotile_data.navpoly_map.erase(p_subtile_coordinate);
 		}
 	} else {
-		tile_map[p_id].autotile_data.navpoly_map[p_coord] = p_navigation_polygon;
+		tile_map[p_id].autotile_data.navpoly_map[p_subtile_coordinate] = p_navigation_polygon;
 	}
 }
 
-Ref<NavigationPolygon> TileSet::autotile_get_navigation_polygon(int p_id, const Vector2 &p_coord) const {
+Ref<NavigationPolygon> TileSet::subtile_get_navigation_polygon(int p_id, const Vector2 &p_subtile_coordinate) const {
 	ERR_FAIL_COND_V(!tile_map.has(p_id), Ref<NavigationPolygon>());
-	if (!tile_map[p_id].autotile_data.navpoly_map.has(p_coord)) {
+	if (!tile_map[p_id].autotile_data.navpoly_map.has(p_subtile_coordinate)) {
 		return Ref<NavigationPolygon>();
 	} else {
-		return tile_map[p_id].autotile_data.navpoly_map[p_coord];
+		return tile_map[p_id].autotile_data.navpoly_map[p_subtile_coordinate];
 	}
 }
 
-const Map<Vector2, Ref<NavigationPolygon>> &TileSet::autotile_get_navigation_map(int p_id) const {
+const Map<Vector2, Ref<NavigationPolygon>> &TileSet::subtile_get_navigation_map(int p_id) const {
 	static Map<Vector2, Ref<NavigationPolygon>> dummy;
 	ERR_FAIL_COND_V(!tile_map.has(p_id), dummy);
 	return tile_map[p_id].autotile_data.navpoly_map;
@@ -936,7 +936,7 @@ void TileSet::_tile_set_shapes(int p_id, const Array &p_shapes) {
 	Vector<ShapeData> shapes_data;
 	Transform2D default_transform = tile_get_shape_transform(p_id, 0);
 	bool default_one_way = tile_get_shape_one_way(p_id, 0);
-	Vector2 default_autotile_coord = Vector2();
+	Vector2 default_subtile_coordinate = Vector2();
 	for (int i = 0; i < p_shapes.size(); i++) {
 		ShapeData s = ShapeData();
 
@@ -949,7 +949,7 @@ void TileSet::_tile_set_shapes(int p_id, const Array &p_shapes) {
 			s.shape = shape;
 			s.shape_transform = default_transform;
 			s.one_way_collision = default_one_way;
-			s.autotile_coord = default_autotile_coord;
+			s.subtile_coordinate = default_subtile_coordinate;
 		} else if (p_shapes[i].get_type() == Variant::DICTIONARY) {
 			Dictionary d = p_shapes[i];
 
@@ -980,10 +980,10 @@ void TileSet::_tile_set_shapes(int p_id, const Array &p_shapes) {
 				s.one_way_collision_margin = 1.0;
 			}
 
-			if (d.has("autotile_coord") && d["autotile_coord"].get_type() == Variant::VECTOR2) {
-				s.autotile_coord = d["autotile_coord"];
+			if (d.has("subtile_coordinate") && d["subtile_coordinate"].get_type() == Variant::VECTOR2) {
+				s.subtile_coordinate = d["subtile_coordinate"];
 			} else {
-				s.autotile_coord = default_autotile_coord;
+				s.subtile_coordinate = default_subtile_coordinate;
 			}
 
 		} else {
@@ -1008,7 +1008,7 @@ Array TileSet::_tile_get_shapes(int p_id) const {
 		shape_data["shape_transform"] = data[i].shape_transform;
 		shape_data["one_way"] = data[i].one_way_collision;
 		shape_data["one_way_margin"] = data[i].one_way_collision_margin;
-		shape_data["autotile_coord"] = data[i].autotile_coord;
+		shape_data["subtile_coordinate"] = data[i].subtile_coordinate;
 		arr.push_back(shape_data);
 	}
 
@@ -1104,24 +1104,24 @@ void TileSet::clear() {
 void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_tile", "id"), &TileSet::create_tile);
 	ClassDB::bind_method(D_METHOD("autotile_clear_bitmask_map", "id"), &TileSet::autotile_clear_bitmask_map);
-	ClassDB::bind_method(D_METHOD("autotile_set_icon_coordinate", "id", "coord"), &TileSet::autotile_set_icon_coordinate);
-	ClassDB::bind_method(D_METHOD("autotile_get_icon_coordinate", "id"), &TileSet::autotile_get_icon_coordinate);
-	ClassDB::bind_method(D_METHOD("autotile_set_subtile_priority", "id", "coord", "priority"), &TileSet::autotile_set_subtile_priority);
-	ClassDB::bind_method(D_METHOD("autotile_get_subtile_priority", "id", "coord"), &TileSet::autotile_get_subtile_priority);
-	ClassDB::bind_method(D_METHOD("autotile_set_z_index", "id", "coord", "z_index"), &TileSet::autotile_set_z_index);
-	ClassDB::bind_method(D_METHOD("autotile_get_z_index", "id", "coord"), &TileSet::autotile_get_z_index);
-	ClassDB::bind_method(D_METHOD("autotile_set_light_occluder", "id", "light_occluder", "coord"), &TileSet::autotile_set_light_occluder);
-	ClassDB::bind_method(D_METHOD("autotile_get_light_occluder", "id", "coord"), &TileSet::autotile_get_light_occluder);
-	ClassDB::bind_method(D_METHOD("autotile_set_navigation_polygon", "id", "navigation_polygon", "coord"), &TileSet::autotile_set_navigation_polygon);
-	ClassDB::bind_method(D_METHOD("autotile_get_navigation_polygon", "id", "coord"), &TileSet::autotile_get_navigation_polygon);
+	ClassDB::bind_method(D_METHOD("subtile_set_icon_coordinate", "id", "icon_coordinate"), &TileSet::subtile_set_icon_coordinate);
+	ClassDB::bind_method(D_METHOD("subtile_get_icon_coordinate", "id"), &TileSet::subtile_get_icon_coordinate);
+	ClassDB::bind_method(D_METHOD("autotile_set_subtile_priority", "id", "subtile_coordinate", "priority"), &TileSet::autotile_set_subtile_priority);
+	ClassDB::bind_method(D_METHOD("autotile_get_subtile_priority", "id", "subtile_coordinate"), &TileSet::autotile_get_subtile_priority);
+	ClassDB::bind_method(D_METHOD("subtile_set_z_index", "id", "subtile_coordinate", "z_index"), &TileSet::subtile_set_z_index);
+	ClassDB::bind_method(D_METHOD("subtile_get_z_index", "id", "subtile_coordinate"), &TileSet::subtile_get_z_index);
+	ClassDB::bind_method(D_METHOD("subtile_set_light_occluder", "id", "light_occluder", "subtile_coordinate"), &TileSet::subtile_set_light_occluder);
+	ClassDB::bind_method(D_METHOD("subtile_get_light_occluder", "id", "subtile_coordinate"), &TileSet::subtile_get_light_occluder);
+	ClassDB::bind_method(D_METHOD("subtile_set_navigation_polygon", "id", "navigation_polygon", "subtile_coordinate"), &TileSet::subtile_set_navigation_polygon);
+	ClassDB::bind_method(D_METHOD("subtile_get_navigation_polygon", "id", "subtile_coordinate"), &TileSet::subtile_get_navigation_polygon);
 	ClassDB::bind_method(D_METHOD("autotile_set_bitmask", "id", "bitmask", "flag"), &TileSet::autotile_set_bitmask);
-	ClassDB::bind_method(D_METHOD("autotile_get_bitmask", "id", "coord"), &TileSet::autotile_get_bitmask);
+	ClassDB::bind_method(D_METHOD("autotile_get_bitmask", "id", "subtile_coordinate"), &TileSet::autotile_get_bitmask);
 	ClassDB::bind_method(D_METHOD("autotile_set_bitmask_mode", "id", "mode"), &TileSet::autotile_set_bitmask_mode);
 	ClassDB::bind_method(D_METHOD("autotile_get_bitmask_mode", "id"), &TileSet::autotile_get_bitmask_mode);
-	ClassDB::bind_method(D_METHOD("autotile_set_spacing", "id", "spacing"), &TileSet::autotile_set_spacing);
-	ClassDB::bind_method(D_METHOD("autotile_get_spacing", "id"), &TileSet::autotile_get_spacing);
-	ClassDB::bind_method(D_METHOD("autotile_set_size", "id", "size"), &TileSet::autotile_set_size);
-	ClassDB::bind_method(D_METHOD("autotile_get_size", "id"), &TileSet::autotile_get_size);
+	ClassDB::bind_method(D_METHOD("subtile_set_spacing", "id", "spacing"), &TileSet::subtile_set_spacing);
+	ClassDB::bind_method(D_METHOD("subtile_get_spacing", "id"), &TileSet::subtile_get_spacing);
+	ClassDB::bind_method(D_METHOD("subtile_set_size", "id", "size"), &TileSet::subtile_set_size);
+	ClassDB::bind_method(D_METHOD("subtile_get_size", "id"), &TileSet::subtile_get_size);
 	ClassDB::bind_method(D_METHOD("tile_set_name", "id", "name"), &TileSet::tile_set_name);
 	ClassDB::bind_method(D_METHOD("tile_get_name", "id"), &TileSet::tile_get_name);
 	ClassDB::bind_method(D_METHOD("tile_set_texture", "id", "texture"), &TileSet::tile_set_texture);
@@ -1146,7 +1146,7 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("tile_get_shape_one_way", "id", "shape_id"), &TileSet::tile_get_shape_one_way);
 	ClassDB::bind_method(D_METHOD("tile_set_shape_one_way_margin", "id", "shape_id", "one_way"), &TileSet::tile_set_shape_one_way_margin);
 	ClassDB::bind_method(D_METHOD("tile_get_shape_one_way_margin", "id", "shape_id"), &TileSet::tile_get_shape_one_way_margin);
-	ClassDB::bind_method(D_METHOD("tile_add_shape", "id", "shape", "shape_transform", "one_way", "autotile_coord"), &TileSet::tile_add_shape, DEFVAL(false), DEFVAL(Vector2()));
+	ClassDB::bind_method(D_METHOD("tile_add_shape", "id", "shape", "shape_transform", "one_way", "subtile_coordinate"), &TileSet::tile_add_shape, DEFVAL(false), DEFVAL(Vector2()));
 	ClassDB::bind_method(D_METHOD("tile_get_shape_count", "id"), &TileSet::tile_get_shape_count);
 	ClassDB::bind_method(D_METHOD("tile_set_shapes", "id", "shapes"), &TileSet::_tile_set_shapes);
 	ClassDB::bind_method(D_METHOD("tile_get_shapes", "id"), &TileSet::_tile_get_shapes);
@@ -1170,8 +1170,7 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tiles_ids"), &TileSet::_get_tiles_ids);
 
 	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_is_tile_bound", PropertyInfo(Variant::INT, "drawn_id"), PropertyInfo(Variant::INT, "neighbor_id")));
-	BIND_VMETHOD(MethodInfo(Variant::VECTOR2, "_forward_subtile_selection", PropertyInfo(Variant::INT, "autotile_id"), PropertyInfo(Variant::INT, "bitmask"), PropertyInfo(Variant::OBJECT, "tilemap", PROPERTY_HINT_NONE, "TileMap"), PropertyInfo(Variant::VECTOR2, "tile_location")));
-	BIND_VMETHOD(MethodInfo(Variant::VECTOR2, "_forward_atlas_subtile_selection", PropertyInfo(Variant::INT, "atlastile_id"), PropertyInfo(Variant::OBJECT, "tilemap", PROPERTY_HINT_NONE, "TileMap"), PropertyInfo(Variant::VECTOR2, "tile_location")));
+	BIND_VMETHOD(MethodInfo(Variant::VECTOR2, "_forward_subtile_selection", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::INT, "bitmask"), PropertyInfo(Variant::OBJECT, "tilemap", PROPERTY_HINT_NONE, "TileMap"), PropertyInfo(Variant::VECTOR2, "cell_position")));
 
 	BIND_ENUM_CONSTANT(BITMASK_2X2);
 	BIND_ENUM_CONSTANT(BITMASK_3X3_MINIMAL);

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -46,7 +46,7 @@ public:
 	struct ShapeData {
 		Ref<Shape2D> shape;
 		Transform2D shape_transform;
-		Vector2 autotile_coord;
+		Vector2 subtile_coordinate;
 		bool one_way_collision = false;
 		float one_way_collision_margin = 1.0;
 
@@ -91,7 +91,7 @@ public:
 		BitmaskMode bitmask_mode = BITMASK_2X2;
 		// Default size to prevent invalid value
 		Size2 size = Size2(64, 64);
-		Vector2 icon_coord = Vector2(0, 0);
+		Vector2 icon_coordinate = Vector2(0, 0);
 		int spacing = 0;
 		Map<Vector2, uint32_t> flags;
 		Map<Vector2, Ref<OccluderPolygon2D>> occluder_map;
@@ -161,29 +161,29 @@ public:
 	void tile_set_tile_mode(int p_id, TileMode p_tile_mode);
 	TileMode tile_get_tile_mode(int p_id) const;
 
-	void autotile_set_icon_coordinate(int p_id, Vector2 coord);
-	Vector2 autotile_get_icon_coordinate(int p_id) const;
+	void subtile_set_icon_coordinate(int p_id, const Vector2 &p_icon_coordinate);
+	Vector2 subtile_get_icon_coordinate(int p_id) const;
 
-	void autotile_set_spacing(int p_id, int p_spacing);
-	int autotile_get_spacing(int p_id) const;
+	void subtile_set_spacing(int p_id, int p_spacing);
+	int subtile_get_spacing(int p_id) const;
 
-	void autotile_set_size(int p_id, Size2 p_size);
-	Size2 autotile_get_size(int p_id) const;
+	void subtile_set_size(int p_id, Size2 p_size);
+	Size2 subtile_get_size(int p_id) const;
 
 	void autotile_clear_bitmask_map(int p_id);
-	void autotile_set_subtile_priority(int p_id, const Vector2 &p_coord, int p_priority);
-	int autotile_get_subtile_priority(int p_id, const Vector2 &p_coord);
+	void autotile_set_subtile_priority(int p_id, const Vector2 &p_subtile_coordinate, int p_priority);
+	int autotile_get_subtile_priority(int p_id, const Vector2 &p_subtile_coordinate);
 	const Map<Vector2, int> &autotile_get_priority_map(int p_id) const;
 
-	void autotile_set_z_index(int p_id, const Vector2 &p_coord, int p_z_index);
-	int autotile_get_z_index(int p_id, const Vector2 &p_coord);
-	const Map<Vector2, int> &autotile_get_z_index_map(int p_id) const;
+	void subtile_set_z_index(int p_id, const Vector2 &p_subtile_coordinate, int p_z_index);
+	int subtile_get_z_index(int p_id, const Vector2 &p_subtile_coordinate);
+	const Map<Vector2, int> &subtile_get_z_index_map(int p_id) const;
 
-	void autotile_set_bitmask(int p_id, Vector2 p_coord, uint32_t p_flag);
-	uint32_t autotile_get_bitmask(int p_id, Vector2 p_coord);
+	void autotile_set_bitmask(int p_id, Vector2 p_subtile_coordinate, uint32_t p_flag);
+	uint32_t autotile_get_bitmask(int p_id, Vector2 p_subtile_coordinate);
 	const Map<Vector2, uint32_t> &autotile_get_bitmask_map(int p_id);
-	Vector2 autotile_get_subtile_for_bitmask(int p_id, uint16_t p_bitmask, const Node *p_tilemap_node = nullptr, const Vector2 &p_tile_location = Vector2());
-	Vector2 atlastile_get_subtile_by_priority(int p_id, const Node *p_tilemap_node = nullptr, const Vector2 &p_tile_location = Vector2());
+	Vector2 autotile_get_subtile_for_bitmask(int p_id, uint16_t p_bitmask, const Node *p_tilemap_node = nullptr, const Vector2 &p_cell_position = Vector2());
+	Vector2 atlastile_get_subtile_by_priority(int p_id, const Node *p_tilemap_node = nullptr, const Vector2 &p_cell_position = Vector2());
 
 	void tile_set_shape(int p_id, int p_shape_id, const Ref<Shape2D> &p_shape);
 	Ref<Shape2D> tile_get_shape(int p_id, int p_shape_id) const;
@@ -201,7 +201,7 @@ public:
 	float tile_get_shape_one_way_margin(int p_id, int p_shape_id) const;
 
 	void tile_clear_shapes(int p_id);
-	void tile_add_shape(int p_id, const Ref<Shape2D> &p_shape, const Transform2D &p_transform, bool p_one_way = false, const Vector2 &p_autotile_coord = Vector2());
+	void tile_add_shape(int p_id, const Ref<Shape2D> &p_shape, const Transform2D &p_transform, bool p_one_way = false, const Vector2 &p_subtile_coordinate = Vector2());
 	int tile_get_shape_count(int p_id) const;
 
 	void tile_set_shapes(int p_id, const Vector<ShapeData> &p_shapes);
@@ -219,9 +219,9 @@ public:
 	void tile_set_light_occluder(int p_id, const Ref<OccluderPolygon2D> &p_light_occluder);
 	Ref<OccluderPolygon2D> tile_get_light_occluder(int p_id) const;
 
-	void autotile_set_light_occluder(int p_id, const Ref<OccluderPolygon2D> &p_light_occluder, const Vector2 &p_coord);
-	Ref<OccluderPolygon2D> autotile_get_light_occluder(int p_id, const Vector2 &p_coord) const;
-	const Map<Vector2, Ref<OccluderPolygon2D>> &autotile_get_light_oclusion_map(int p_id) const;
+	void subtile_set_light_occluder(int p_id, const Ref<OccluderPolygon2D> &p_light_occluder, const Vector2 &p_subtile_coordinate);
+	Ref<OccluderPolygon2D> subtile_get_light_occluder(int p_id, const Vector2 &p_subtile_coordinate) const;
+	const Map<Vector2, Ref<OccluderPolygon2D>> &subtile_get_light_oclusion_map(int p_id) const;
 
 	void tile_set_navigation_polygon_offset(int p_id, const Vector2 &p_offset);
 	Vector2 tile_get_navigation_polygon_offset(int p_id) const;
@@ -229,9 +229,9 @@ public:
 	void tile_set_navigation_polygon(int p_id, const Ref<NavigationPolygon> &p_navigation_polygon);
 	Ref<NavigationPolygon> tile_get_navigation_polygon(int p_id) const;
 
-	void autotile_set_navigation_polygon(int p_id, const Ref<NavigationPolygon> &p_navigation_polygon, const Vector2 &p_coord);
-	Ref<NavigationPolygon> autotile_get_navigation_polygon(int p_id, const Vector2 &p_coord) const;
-	const Map<Vector2, Ref<NavigationPolygon>> &autotile_get_navigation_map(int p_id) const;
+	void subtile_set_navigation_polygon(int p_id, const Ref<NavigationPolygon> &p_navigation_polygon, const Vector2 &p_subtile_coordinate);
+	Ref<NavigationPolygon> subtile_get_navigation_polygon(int p_id, const Vector2 &p_subtile_coordinate) const;
+	const Map<Vector2, Ref<NavigationPolygon>> &subtile_get_navigation_map(int p_id) const;
 
 	void tile_set_z_index(int p_id, int p_z_index);
 	int tile_get_z_index(int p_id) const;


### PR DESCRIPTION
- Renames `autotile_coord` to `subtile_coordinate`.
  - As I suggested here https://github.com/godotengine/godot/issues/16863#issuecomment-629812730.

Also:
- Changes default return of `TileMap::get_cell_subtile_coordinate`.
  - The method reference said: "Returns a zero vector if the cell doesn't have autotiling", but this is not entirely true because `Vector.ZERO` it's still a valid coordinate for auto tile, so I changed for `Vector.INF`.
-  [TileSet] Merges `_forward_atlas_subtile_selection` with `_forward_subtile_selection`.
   - This is my suggestion. Makes the API clearer I hope.
-  Renames `coord` to `subtile_coordinate`.

I'm planning to create (and/or update) a "continued" page for Tilemap document to explain the hidden features like bitmasks, wildcards, explain the concept of tiles and subtiles, differences from 3x3 minimal and 3x3, priority for atlas, _forward_subtile_selection, etc. (the docs now don't even mention autotile)

**Update:** I changed from `tile_coordinate` to `subtile_coordinate` because makes more sense.

**Update:** I decided to change the methods that starts with `autotile_` to `subtile_` that are used for both atlas and autotile as well. Complete list below:
```
autotile_[set|get]_icon_coordinate -> subtile_[set|get]_icon_coordinate
autotile_[set|get]_spacing -> subtile_[set|get]_spacing
autotile_[set|get]_size -> subtile_[set|get]_size
autotile_[set|get]_z_index -> subtile_[set|get]_z_index
autotile_get_z_index_map -> subtile_get_z_index_map
autotile_[set|get]_light_occluder -> subtile_[set|get]_light_occluder
autotile_get_light_oclusion_map -> subtile_get_light_oclusion_map
autotile_[set|get]_navigation_polygon -> subtile_[set|get]_navigation_polygon
autotile_get_navigation_map -> subtile_get_navigation_map
```

**Update:** Renames `tile_locaiton` of `_forward_subtile_selection` to `cell_position`.