### PR TITLE
Error handling functions for GdScript

### DIFF
--- a/core/error/error_list.cpp
+++ b/core/error/error_list.cpp
@@ -1,0 +1,85 @@
+/*************************************************************************/
+/*  error_list.cpp                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "error_list.h"
+
+const char *error_names[] = {
+	"No error",
+	"Generic error",
+	"Requested operation is unsupported/unavailable",
+	"The object hasn't been set up properly",
+	"Missing credentials for requested resource",
+	"Parameter out of range",
+	"Out of memory",
+	"File not found",
+	"Bad drive",
+	"Bad path",
+	"Permission denied",
+	"Already in use",
+	"Can't open file",
+	"Can't write file",
+	"Can't read file",
+	"File unrecognized",
+	"File corrupt",
+	"Missing dependencies for file",
+	"Unexpected eof",
+	"Can't open resource/socket/file", // File too? What's the difference to ERR_FILE_CANT_OPEN
+	"Can't create", // What can't be created,
+	"Query failed", // What query,
+	"Already in use",
+	"Resource is locked",
+	"Timeout",
+	"Can't connect",
+	"Can't resolve hostname", // I guessed it's the hostname here.
+	"Connection error",
+	"Can't acquire resource",
+	"Can't fork",
+	"Invalid data",
+	"Invalid parameter",
+	"Item already exists",
+	"Item does not exist",
+	"Can't read from database", // Comments say, it's full? Is that correct?
+	"Can't write to database", // Is the database always full when this is raised?
+	"Compilation failed",
+	"Method not found",
+	"Link failed",
+	"Script failed",
+	"Cyclic link detected",
+	"Invalid declaration",
+	"Duplicate symbol",
+	"Parse error",
+	"Resource is busy",
+	"Skip error", // ???? What's this? String taken from the docs
+	"Help error", // More specific?
+	"Bug",
+	"Printer on fire",
+};
+
+static_assert(sizeof(error_names) / sizeof(*error_names) == ERR_MAX);

--- a/core/error/error_list.h
+++ b/core/error/error_list.h
@@ -88,6 +88,9 @@ enum Error {
 	ERR_HELP, ///< user requested help!!
 	ERR_BUG, ///< a bug in the software certainly happened, due to a double check failing or unexpected behavior.
 	ERR_PRINTER_ON_FIRE, /// the parallel port printer is engulfed in flames
+	ERR_MAX, // Not being returned, value represents the number of errors
 };
+
+extern const char *error_names[];
 
 #endif // ERROR_LIST_H

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -484,6 +484,14 @@ struct VariantUtilityFunctions {
 		return str;
 	}
 
+	static inline String error_string(Error error) {
+		if (error < 0 || error >= ERR_MAX) {
+			return String("(invalid error code)");
+		}
+
+		return String(error_names[error]);
+	}
+
 	static inline void print(const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
 		if (p_arg_count < 1) {
 			r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
@@ -1234,6 +1242,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDVR(weakref, sarray("obj"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDR(_typeof, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGS(str, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(error_string, sarray("error"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(print, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(printerr, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(printt, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -276,6 +276,15 @@
 				Easing function, based on exponent. The curve values are: 0 is constant, 1 is linear, 0 to 1 is ease-in, 1+ is ease out. Negative values are in-out/out in.
 			</description>
 		</method>
+		<method name="error_string">
+			<return type="String">
+			</return>
+			<argument index="0" name="error" type="int">
+			</argument>
+			<description>
+				Returns a human-readable name for the given error code.
+			</description>
+		</method>
 		<method name="exp">
 			<return type="float">
 			</return>


### PR DESCRIPTION
Many functions in GdScript can fail. But there are no functions to display the error to users or give a meaningful message in the console.

Therefore this Pull Request adds two functions:
 - `error_string(code: int)`:
    Returns a human readable string for the given error code.
    E.g. `error_string(ERR_UNAVAILABLE) == "Requested operation is unsupported/unavailable"`
 - `push_error_formatted(message: String, code: int)`:
    Convenience function.
    Inspired by the `perror` function from C.
    Actually just a shorthand for `push_error(message + ": " + error_string(code))`.

Some error codes were not clear to me from the comments in the source code or the documentation. I've added some comments to mark those strings and (hopefully) replace them with better messages during review

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/211.*