### PR TITLE
Fix file dialog filename cleared when selecting favorites

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1122,7 +1122,6 @@ void EditorFileDialog::_update_drives() {
 
 void EditorFileDialog::_favorite_selected(int p_idx) {
 	dir_access->change_dir(favorites->get_item_metadata(p_idx));
-	file->set_text("");
 	update_dir();
 	invalidate();
 	_push_history();


### PR DESCRIPTION
There is a UX bug when I click to navigate to one of my favorite locations the filename gets cleared.
This doesn't happen when changing folders or picking an item from recent and I think favorites should work the same (see screenshots).

![image](https://user-images.githubusercontent.com/1426316/82742613-3d12f180-9d69-11ea-9bc2-6f9394391f5b.png)
![image](https://user-images.githubusercontent.com/1426316/82742623-47cd8680-9d69-11ea-8568-a6a2aa87c5c8.png)
