### PR TITLE
Add shader time scaling (3.2)

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -3453,6 +3453,16 @@
 				Sets the default clear color which is used when a specific clear color has not been selected.
 			</description>
 		</method>
+		<method name="set_shader_time_scale">
+			<return type="void">
+			</return>
+			<argument index="0" name="scale" type="float">
+			</argument>
+			<description>
+				Sets the scale to apply to the passage of time for the shaders' [code]TIME[/code] builtin.
+				The default value is [code]1.0[/code], which means [code]TIME[/code] will count the real time as it goes by, without narrowing or stretching it.
+			</description>
+		</method>
 		<method name="shader_create">
 			<return type="RID">
 			</return>

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -796,6 +796,7 @@ public:
 	RasterizerScene *get_scene() { return &scene; }
 
 	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) {}
+	void set_shader_time_scale(float p_scale) {}
 
 	void initialize() {}
 	void begin_frame(double frame_step) {}

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -270,7 +270,7 @@ void RasterizerGLES2::initialize() {
 }
 
 void RasterizerGLES2::begin_frame(double frame_step) {
-	time_total += frame_step;
+	time_total += frame_step * time_scale;
 
 	if (frame_step == 0) {
 		//to avoid hiccups
@@ -395,6 +395,11 @@ void RasterizerGLES2::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 	end_frame(true);
 }
 
+void RasterizerGLES2::set_shader_time_scale(float p_scale) {
+
+	time_scale = p_scale;
+}
+
 void RasterizerGLES2::blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen) {
 
 	ERR_FAIL_COND(storage->frame.current_rt);
@@ -490,6 +495,7 @@ RasterizerGLES2::RasterizerGLES2() {
 	storage->scene = scene;
 
 	time_total = 0;
+	time_scale = 1;
 }
 
 RasterizerGLES2::~RasterizerGLES2() {

--- a/drivers/gles2/rasterizer_gles2.h
+++ b/drivers/gles2/rasterizer_gles2.h
@@ -45,6 +45,7 @@ class RasterizerGLES2 : public Rasterizer {
 	RasterizerSceneGLES2 *scene;
 
 	double time_total;
+	float time_scale;
 
 public:
 	virtual RasterizerStorage *get_storage();
@@ -52,6 +53,7 @@ public:
 	virtual RasterizerScene *get_scene();
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true);
+	virtual void set_shader_time_scale(float p_scale);
 
 	virtual void initialize();
 	virtual void begin_frame(double frame_step);

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -194,7 +194,7 @@ void RasterizerGLES3::initialize() {
 
 void RasterizerGLES3::begin_frame(double frame_step) {
 
-	time_total += frame_step;
+	time_total += frame_step * time_scale;
 
 	if (frame_step == 0) {
 		//to avoid hiccups
@@ -331,6 +331,11 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 	end_frame(true);
 }
 
+void RasterizerGLES3::set_shader_time_scale(float p_scale) {
+
+	time_scale = p_scale;
+}
+
 void RasterizerGLES3::blit_render_target_to_screen(RID p_render_target, const Rect2 &p_screen_rect, int p_screen) {
 
 	ERR_FAIL_COND(storage->frame.current_rt);
@@ -420,6 +425,7 @@ RasterizerGLES3::RasterizerGLES3() {
 	storage->scene = scene;
 
 	time_total = 0;
+	time_scale = 1;
 }
 
 RasterizerGLES3::~RasterizerGLES3() {

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -45,6 +45,7 @@ class RasterizerGLES3 : public Rasterizer {
 	RasterizerSceneGLES3 *scene;
 
 	double time_total;
+	float time_scale;
 
 public:
 	virtual RasterizerStorage *get_storage();
@@ -52,6 +53,7 @@ public:
 	virtual RasterizerScene *get_scene();
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true);
+	virtual void set_shader_time_scale(float p_scale);
 
 	virtual void initialize();
 	virtual void begin_frame(double frame_step);

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1114,6 +1114,7 @@ public:
 	virtual RasterizerScene *get_scene() = 0;
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) = 0;
+	virtual void set_shader_time_scale(float p_scale) = 0;
 
 	virtual void initialize() = 0;
 	virtual void begin_frame(double frame_step) = 0;

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -174,6 +174,10 @@ void VisualServerRaster::set_default_clear_color(const Color &p_color) {
 	VSG::viewport->set_default_clear_color(p_color);
 }
 
+void VisualServerRaster::set_shader_time_scale(float p_scale) {
+	VSG::rasterizer->set_shader_time_scale(p_scale);
+}
+
 bool VisualServerRaster::has_feature(Features p_feature) const {
 
 	return false;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -692,6 +692,7 @@ public:
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true);
 	virtual void set_default_clear_color(const Color &p_color);
+	virtual void set_shader_time_scale(float p_scale);
 
 	virtual bool has_feature(Features p_feature) const;
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -615,6 +615,7 @@ public:
 
 	FUNC4(set_boot_image, const Ref<Image> &, const Color &, bool, bool)
 	FUNC1(set_default_clear_color, const Color &)
+	FUNC1(set_shader_time_scale, float)
 
 	FUNC0R(RID, get_test_cube)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2044,6 +2044,7 @@ void VisualServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_boot_image", "image", "color", "scale", "use_filter"), &VisualServer::set_boot_image, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("set_default_clear_color", "color"), &VisualServer::set_default_clear_color);
+	ClassDB::bind_method(D_METHOD("set_shader_time_scale", "scale"), &VisualServer::set_shader_time_scale);
 
 	ClassDB::bind_method(D_METHOD("has_feature", "feature"), &VisualServer::has_feature);
 	ClassDB::bind_method(D_METHOD("has_os_feature", "feature"), &VisualServer::has_os_feature);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1046,6 +1046,7 @@ public:
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) = 0;
 	virtual void set_default_clear_color(const Color &p_color) = 0;
+	virtual void set_shader_time_scale(float p_scale) = 0;
 
 	enum Features {
 		FEATURE_SHADERS,


### PR DESCRIPTION
Shaders' `TIME` will be affected by the new shader time scale, that is set via the new `VisualServer::set_time_scale()` method.

~~Another builtin `TIME_UNSCALED` is added, that contains the accumulated time unaffected by the scale.~~
**UPDATE:** This part has been removed at @reduz's request, the rationale being that the it's such a big change for a small benefit: there are other means (like uniforms) to alter the passage of time for the few cases of shaders that need not to be affected by the scale. And I agree.

Closes #27127. (See it for discussion.)

**No version of this branch for 4.0 is needed, since it introduces global shader variables, with which one can easily implement their own version of this.**