### PR TITLE
Proper surface reset when resuming app on Android

### DIFF
--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -367,6 +367,25 @@ void DisplayServerAndroid::register_android_driver() {
 	register_create_function("android", create_func, get_rendering_drivers_func);
 }
 
+void DisplayServerAndroid::reset_window() {
+#if defined(VULKAN_ENABLED)
+	if (rendering_driver == "vulkan") {
+		ANativeWindow *native_window = OS_Android::get_singleton()->get_native_window();
+		ERR_FAIL_COND(!native_window);
+
+		ERR_FAIL_COND(!context_vulkan);
+		context_vulkan->window_destroy(MAIN_WINDOW_ID);
+
+		Size2i display_size = OS_Android::get_singleton()->get_display_size();
+		if (context_vulkan->window_create(native_window, display_size.width, display_size.height) == -1) {
+			memdelete(context_vulkan);
+			context_vulkan = nullptr;
+			ERR_FAIL_MSG("Failed to reset Vulkan window.");
+		}
+	}
+#endif
+}
+
 DisplayServerAndroid::DisplayServerAndroid(const String &p_rendering_driver, DisplayServer::WindowMode p_mode, uint32_t p_flags, const Vector2i &p_resolution, Error &r_error) {
 	rendering_driver = p_rendering_driver;
 

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -166,6 +166,8 @@ public:
 	static Vector<String> get_rendering_drivers_func();
 	static void register_android_driver();
 
+	void reset_window();
+
 	DisplayServerAndroid(const String &p_rendering_driver, WindowMode p_mode, uint32_t p_flags, const Vector2i &p_resolution, Error &r_error);
 	~DisplayServerAndroid();
 };

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotLib.java
@@ -66,11 +66,12 @@ public class GodotLib {
 
 	/**
 	 * Invoked on the GL thread when the underlying Android surface has changed size.
-	 * @param width
-	 * @param height
+	 * @param p_surface
+	 * @param p_width
+	 * @param p_height
 	 * @see android.opengl.GLSurfaceView.Renderer#onSurfaceChanged(GL10, int, int)
 	 */
-	public static native void resize(int width, int height);
+	public static native void resize(Surface p_surface, int p_width, int p_height);
 
 	/**
 	 * Invoked on the render thread when the underlying Android surface is created or recreated.

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotRenderer.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotRenderer.java
@@ -64,7 +64,7 @@ class GodotRenderer implements GLSurfaceView.Renderer {
 	}
 
 	public void onSurfaceChanged(GL10 gl, int width, int height) {
-		GodotLib.resize(width, height);
+		GodotLib.resize(null, width, height);
 		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
 			plugin.onGLSurfaceChanged(gl, width, height);
 		}

--- a/platform/android/java/lib/src/org/godotengine/godot/vulkan/VkRenderer.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/vulkan/VkRenderer.kt
@@ -59,9 +59,7 @@ internal class VkRenderer {
 	 * Called when the surface is created and signals the beginning of rendering.
 	 */
 	fun onVkSurfaceCreated(surface: Surface) {
-		// TODO: properly implement surface re-creation:
-		// GodotLib.newcontext should be called here once it's done.
-		//GodotLib.newcontext(surface, false)
+		GodotLib.newcontext(surface, false)
 
 		for (plugin in pluginRegistry.getAllPlugins()) {
 			plugin.onVkSurfaceCreated(surface)
@@ -72,12 +70,7 @@ internal class VkRenderer {
 	 * Called after the surface is created and whenever its size changes.
 	 */
 	fun onVkSurfaceChanged(surface: Surface, width: Int, height: Int) {
-		GodotLib.resize(width, height)
-		
-		// TODO: properly implement surface re-creation:
-		// Update the native renderer instead of restarting the app.
-		// GodotLib.newcontext should not be called here once it's done.
-		GodotLib.newcontext(surface, false)
+		GodotLib.resize(surface, width, height)
 		
 		for (plugin in pluginRegistry.getAllPlugins()) {
 			plugin.onVkSurfaceChanged(surface, width, height)

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -164,9 +164,20 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setup(JNIEnv *env, jc
 	ClassDB::register_class<JNISingleton>();
 }
 
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_resize(JNIEnv *env, jclass clazz, jint width, jint height) {
-	if (os_android)
-		os_android->set_display_size(Size2i(width, height));
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_resize(JNIEnv *env, jclass clazz, jobject p_surface, jint p_width, jint p_height) {
+	if (os_android) {
+		os_android->set_display_size(Size2i(p_width, p_height));
+
+		// No need to reset the surface during startup
+		if (step > 0) {
+			if (p_surface) {
+				ANativeWindow *native_window = ANativeWindow_fromSurface(env, p_surface);
+				os_android->set_native_window(native_window);
+
+				DisplayServerAndroid::get_singleton()->reset_window();
+			}
+		}
+	}
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_newcontext(JNIEnv *env, jclass clazz, jobject p_surface, jboolean p_32_bits) {

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -40,7 +40,7 @@ extern "C" {
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *env, jclass clazz, jobject activity, jobject p_asset_manager, jboolean p_use_apk_expansion);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ondestroy(JNIEnv *env, jclass clazz, jobject activity);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setup(JNIEnv *env, jclass clazz, jobjectArray p_cmdline);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_resize(JNIEnv *env, jclass clazz, jint width, jint height);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_resize(JNIEnv *env, jclass clazz, jobject p_surface, jint p_width, jint p_height);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_newcontext(JNIEnv *env, jclass clazz, jobject p_surface, jboolean p_32_bits);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_back(JNIEnv *env, jclass clazz);


### PR DESCRIPTION
Just re-creating the window instead of restarting the app entirely after pausing and resuming.

Addresses remaining issue listed in #36919:
Properly handle `onVkSurfaceChanged` event to update the rendering system