### PR TITLE
Improve the text appearance in the script editor warnings panel

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -609,6 +609,18 @@ void ScriptTextEditor::_validate_script() {
 	for (List<ScriptLanguage::Warning>::Element *E = warnings.front(); E; E = E->next()) {
 		ScriptLanguage::Warning w = E->get();
 
+		Dictionary ignore_meta;
+		ignore_meta["line"] = w.line;
+		ignore_meta["code"] = w.string_code.to_lower();
+		warnings_panel->push_cell();
+		warnings_panel->push_meta(ignore_meta);
+		warnings_panel->push_color(
+				warnings_panel->get_theme_color("accent_color", "Editor").lerp(warnings_panel->get_theme_color("mono_color", "Editor"), 0.5));
+		warnings_panel->add_text(TTR("[Ignore]"));
+		warnings_panel->pop(); // Color.
+		warnings_panel->pop(); // Meta ignore.
+		warnings_panel->pop(); // Cell.
+
 		warnings_panel->push_cell();
 		warnings_panel->push_meta(w.line - 1);
 		warnings_panel->push_color(warnings_panel->get_theme_color("warning_color", "Editor"));
@@ -620,15 +632,6 @@ void ScriptTextEditor::_validate_script() {
 
 		warnings_panel->push_cell();
 		warnings_panel->add_text(w.message);
-		warnings_panel->pop(); // Cell.
-
-		Dictionary ignore_meta;
-		ignore_meta["line"] = w.line;
-		ignore_meta["code"] = w.string_code.to_lower();
-		warnings_panel->push_cell();
-		warnings_panel->push_meta(ignore_meta);
-		warnings_panel->add_text(TTR("(ignore)"));
-		warnings_panel->pop(); // Meta ignore.
 		warnings_panel->pop(); // Cell.
 	}
 	warnings_panel->pop(); // Table.
@@ -1747,6 +1750,8 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	warnings_panel = memnew(RichTextLabel);
 	editor_box->add_child(warnings_panel);
+	warnings_panel->add_theme_font_override(
+			"normal_font", EditorNode::get_singleton()->get_gui_base()->get_theme_font("main", "EditorFonts"));
 	warnings_panel->set_custom_minimum_size(Size2(0, 100 * EDSCALE));
 	warnings_panel->set_h_size_flags(SIZE_EXPAND_FILL);
 	warnings_panel->set_meta_underline(true);


### PR DESCRIPTION
- Make the Ignore button's position identical across all warnings by moving it to the left.
- Change the Ignore button's text and color to make it more obvious that it can be clicked.
- Use the editor font instead of the default project font to match the rest of the editor.

## Preview

### Before

![Script editor warning](https://user-images.githubusercontent.com/180032/82754166-6e240e00-9dcb-11ea-9855-e2ac1d11700a.png)

### After

*Disregard the underline thickness, it's a separate issue which stems from #31086.*

![Script editor warning](https://user-images.githubusercontent.com/180032/82754143-4e8ce580-9dcb-11ea-9d3e-b9d23983dbcc.png)