### PR TITLE
Store Control constants as floats instead of integers

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -105,10 +105,10 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="constant" type="int">
+			<argument index="1" name="constant" type="float">
 			</argument>
 			<description>
-				Overrides an integer constant with given [code]name[/code] in the [member theme] resource the control uses. If the [code]constant[/code] is empty or invalid, the override is cleared and the constant from assigned [Theme] is used.
+				Overrides a floating-point constant with given [code]name[/code] in the [member theme] resource the control uses. If the [code]constant[/code] is empty or invalid, the override is cleared and the constant from assigned [Theme] is used.
 			</description>
 		</method>
 		<method name="add_theme_font_override">
@@ -341,7 +341,7 @@
 			</description>
 		</method>
 		<method name="get_theme_constant" qualifiers="const">
-			<return type="int">
+			<return type="float">
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>

--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -110,7 +110,7 @@
 			</description>
 		</method>
 		<method name="get_constant" qualifiers="const">
-			<return type="int">
+			<return type="float">
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
@@ -286,7 +286,7 @@
 			</argument>
 			<argument index="1" name="type" type="StringName">
 			</argument>
-			<argument index="2" name="constant" type="int">
+			<argument index="2" name="constant" type="float">
 			</argument>
 			<description>
 				Sets the theme's constant to [code]constant[/code] at [code]name[/code] in [code]type[/code].

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -955,9 +955,9 @@ Color Control::get_colors(Control *p_theme_owner, Window *p_theme_owner_window, 
 	return Theme::get_default()->get_color(p_name, p_type);
 }
 
-int Control::get_theme_constant(const StringName &p_name, const StringName &p_type) const {
+float Control::get_theme_constant(const StringName &p_name, const StringName &p_type) const {
 	if (p_type == StringName() || p_type == get_class_name()) {
-		const int *constant = data.constant_override.getptr(p_name);
+		const float *constant = data.constant_override.getptr(p_name);
 		if (constant) {
 			return *constant;
 		}
@@ -968,8 +968,8 @@ int Control::get_theme_constant(const StringName &p_name, const StringName &p_ty
 	return get_constants(data.theme_owner, data.theme_owner_window, p_name, type);
 }
 
-int Control::get_constants(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
-	int constant;
+float Control::get_constants(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
+	float constant;
 
 	if (_find_theme_item(p_theme_owner, p_theme_owner_window, constant, &Theme::get_constant, &Theme::has_constant, p_name, p_type)) {
 		return constant;
@@ -1009,7 +1009,7 @@ bool Control::has_theme_color_override(const StringName &p_name) const {
 }
 
 bool Control::has_theme_constant_override(const StringName &p_name) const {
-	const int *constant = data.constant_override.getptr(p_name);
+	const float *constant = data.constant_override.getptr(p_name);
 	return constant != nullptr;
 }
 
@@ -1789,7 +1789,7 @@ void Control::add_theme_color_override(const StringName &p_name, const Color &p_
 	notification(NOTIFICATION_THEME_CHANGED);
 }
 
-void Control::add_theme_constant_override(const StringName &p_name, int p_constant) {
+void Control::add_theme_constant_override(const StringName &p_name, float p_constant) {
 	data.constant_override[p_name] = p_constant;
 	notification(NOTIFICATION_THEME_CHANGED);
 }

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -194,7 +194,7 @@ private:
 		HashMap<StringName, Ref<StyleBox>> style_override;
 		HashMap<StringName, Ref<Font>> font_override;
 		HashMap<StringName, Color> color_override;
-		HashMap<StringName, int> constant_override;
+		HashMap<StringName, float> constant_override;
 
 	} data;
 
@@ -245,7 +245,7 @@ private:
 	static Ref<StyleBox> get_styleboxs(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
 	static Ref<Font> get_fonts(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
 	static Color get_colors(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
-	static int get_constants(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
+	static float get_constants(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
 
 	static bool has_icons(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
 	static bool has_shaders(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
@@ -427,14 +427,14 @@ public:
 	void add_theme_style_override(const StringName &p_name, const Ref<StyleBox> &p_style);
 	void add_theme_font_override(const StringName &p_name, const Ref<Font> &p_font);
 	void add_theme_color_override(const StringName &p_name, const Color &p_color);
-	void add_theme_constant_override(const StringName &p_name, int p_constant);
+	void add_theme_constant_override(const StringName &p_name, float p_constant);
 
 	Ref<Texture2D> get_theme_icon(const StringName &p_name, const StringName &p_type = StringName()) const;
 	Ref<Shader> get_theme_shader(const StringName &p_name, const StringName &p_type = StringName()) const;
 	Ref<StyleBox> get_theme_stylebox(const StringName &p_name, const StringName &p_type = StringName()) const;
 	Ref<Font> get_theme_font(const StringName &p_name, const StringName &p_type = StringName()) const;
 	Color get_theme_color(const StringName &p_name, const StringName &p_type = StringName()) const;
-	int get_theme_constant(const StringName &p_name, const StringName &p_type = StringName()) const;
+	float get_theme_constant(const StringName &p_name, const StringName &p_type = StringName()) const;
 
 	bool has_theme_icon_override(const StringName &p_name) const;
 	bool has_theme_shader_override(const StringName &p_name) const;

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -610,8 +610,8 @@ void Theme::get_color_list(StringName p_type, List<StringName> *p_list) const {
 	}
 }
 
-void Theme::set_constant(const StringName &p_name, const StringName &p_type, int p_constant) {
-	bool new_value = !constant_map.has(p_type) || !constant_map[p_type].has(p_name);
+void Theme::set_constant(const StringName &p_name, const StringName &p_type, float p_constant) {
+	const bool new_value = !constant_map.has(p_type) || !constant_map[p_type].has(p_name);
 	constant_map[p_type][p_name] = p_constant;
 
 	if (new_value) {
@@ -620,7 +620,7 @@ void Theme::set_constant(const StringName &p_name, const StringName &p_type, int
 	}
 }
 
-int Theme::get_constant(const StringName &p_name, const StringName &p_type) const {
+float Theme::get_constant(const StringName &p_name, const StringName &p_type) const {
 	if (constant_map.has(p_type) && constant_map[p_type].has(p_name)) {
 		return constant_map[p_type][p_name];
 	} else {

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -49,7 +49,7 @@ class Theme : public Resource {
 	HashMap<StringName, HashMap<StringName, Ref<Font>>> font_map;
 	HashMap<StringName, HashMap<StringName, Ref<Shader>>> shader_map;
 	HashMap<StringName, HashMap<StringName, Color>> color_map;
-	HashMap<StringName, HashMap<StringName, int>> constant_map;
+	HashMap<StringName, HashMap<StringName, float>> constant_map;
 
 	Vector<String> _get_icon_list(const String &p_type) const;
 	Vector<String> _get_stylebox_list(const String &p_type) const;
@@ -119,8 +119,8 @@ public:
 	void clear_color(const StringName &p_name, const StringName &p_type);
 	void get_color_list(StringName p_type, List<StringName> *p_list) const;
 
-	void set_constant(const StringName &p_name, const StringName &p_type, int p_constant);
-	int get_constant(const StringName &p_name, const StringName &p_type) const;
+	void set_constant(const StringName &p_name, const StringName &p_type, float p_constant);
+	float get_constant(const StringName &p_name, const StringName &p_type) const;
 	bool has_constant(const StringName &p_name, const StringName &p_type) const;
 	void clear_constant(const StringName &p_name, const StringName &p_type);
 	void get_constant_list(StringName p_type, List<StringName> *p_list) const;


### PR DESCRIPTION
This allows to store values like the editor scale in a constant. This way, we can eventually [remove the need to include editor-only headers in source files in the `scene/` folder](https://github.com/godotengine/godot/issues/29730).

The editor still appears to look correct, but please test for regressions anyway. I'd be surprised if *everything* worked as expected right now :slightly_smiling_face: 