### PR TITLE
Add configuration for GitHub issue templates

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Godot proposals
+    url: https://github.com/godotengine/godot-proposals
+    about: Please submit feature proposals on the Godot proposals repository, not here.
+
+  - name: Godot documentation repository
+    url: https://github.com/godotengine/godot-docs
+    about: Please report issues with documentation on the Godot documentation repository, not here.
+
+  - name: Godot community channels
+    url: https://godotengine.org/community
+    about: Please ask for technical support on one of the other community channels, not here.


### PR DESCRIPTION
This adds a few links on the issue creation page and disallows creating blank issues (since all issues must follow the bug report template).