### PR TITLE
Make GLTF Scene Importer populate node metadata with GLTF extras

### DIFF
--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -99,6 +99,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 		Transform xform;
 		String name;
+		Dictionary extras;
 
 		GLTFMeshIndex mesh;
 		GLTFCameraIndex camera;
@@ -300,6 +301,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 		Vector<uint8_t> glb_data;
 
 		bool use_named_skin_binds;
+		bool import_meta;
 
 		Vector<GLTFNode *> nodes;
 		Vector<Vector<uint8_t> > buffers;
@@ -394,6 +396,8 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 	Error _parse_cameras(GLTFState &state);
 
 	Error _parse_animations(GLTFState &state);
+
+	void _set_meta_from_gltf_extras(GLTFState &state, Node *node, const GLTFNode *gltf_node);
 
 	BoneAttachment *_generate_bone_attachment(GLTFState &state, Skeleton *skeleton, const GLTFNodeIndex node_index);
 	MeshInstance *_generate_mesh_instance(GLTFState &state, Node *scene_parent, const GLTFNodeIndex node_index);

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -114,6 +114,7 @@ void EditorSceneImporter::_bind_methods() {
 
 	BIND_CONSTANT(IMPORT_SCENE);
 	BIND_CONSTANT(IMPORT_ANIMATION);
+	BIND_CONSTANT(IMPORT_META);
 	BIND_CONSTANT(IMPORT_ANIMATION_DETECT_LOOP);
 	BIND_CONSTANT(IMPORT_ANIMATION_OPTIMIZE);
 	BIND_CONSTANT(IMPORT_ANIMATION_FORCE_ALL_TRACKS_IN_ALL_CLIPS);
@@ -1161,6 +1162,7 @@ void ResourceImporterScene::get_import_options(List<ImportOption> *r_options, in
 	bool animations_out = p_preset == PRESET_SEPARATE_ANIMATIONS || p_preset == PRESET_SEPARATE_MESHES_AND_ANIMATIONS || p_preset == PRESET_SEPARATE_MATERIALS_AND_ANIMATIONS || p_preset == PRESET_SEPARATE_MESHES_MATERIALS_AND_ANIMATIONS;
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::REAL, "nodes/root_scale", PROPERTY_HINT_RANGE, "0.001,1000,0.001"), 1.0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/meta"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "nodes/custom_script", PROPERTY_HINT_FILE, script_ext_hint), ""));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "nodes/storage", PROPERTY_HINT_ENUM, "Single Scene,Instanced Sub-Scenes"), scenes_out ? 1 : 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "materials/location", PROPERTY_HINT_ENUM, "Node,Mesh"), (meshes_out || materials_out) ? 1 : 0));
@@ -1299,6 +1301,9 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	float fps = p_options["animation/fps"];
 
 	int import_flags = EditorSceneImporter::IMPORT_ANIMATION_DETECT_LOOP;
+	if (bool(p_options["nodes/meta"]))
+		import_flags |= EditorSceneImporter::IMPORT_META;
+
 	if (!bool(p_options["animation/optimizer/remove_unused_tracks"]))
 		import_flags |= EditorSceneImporter::IMPORT_ANIMATION_FORCE_ALL_TRACKS_IN_ALL_CLIPS;
 

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -61,7 +61,7 @@ public:
 		IMPORT_MATERIALS_IN_INSTANCES = 1024,
 		IMPORT_USE_COMPRESSION = 2048,
 		IMPORT_USE_NAMED_SKIN_BINDS = 4096,
-
+		IMPORT_META = 8192,
 	};
 
 	virtual uint32_t get_import_flags() const;


### PR DESCRIPTION
# Introduction

This PR adds the boolean import option `nodes/meta` to the Scene Importer.

When enabled the imported nodes' [metadata](https://github.com/godotengine/godot/issues/18591) is populated from annotation data of the specific file format (currently limited to GLTF "extras").

This PR currently only generates metadata for Meshes, Cameras and
Spatials. Other nodes can be added in later PRs.

The change was discussed with @fire on the [engine](https://discordapp.com/channels/212250894228652034/279004126795268106/714188585888120845) room of the Godot discord.

# Motivation

I would like to be able to write [custom import scripts](https://docs.godotengine.org/en/stable/getting_started/workflow/assets/importing_scenes.html#custom-script) that modify the imported scene based on metadata on objects. e.g. generating physics objects for meshes that are somehow tagged in Blender.

The metadata can also be read at runtime, which makes it very easy to specify values in the 3d model (at modeling time i.e. in Blender) that are then used by the game e.g. physical properties of objects.

@fire [expressed the desire](https://discordapp.com/channels/212250894228652034/279004126795268106/714188585888120845) to include GDscripts in GLTF files.

# Example

![Screen Shot 2020-05-24 at 20 51 08](https://user-images.githubusercontent.com/4848178/82768209-d73c6d80-9e2d-11ea-8e56-69792610909b.png)

Notice the custom property `"is_floor"` on the box mesh specified in Blender.

![Screen Shot 2020-05-24 at 20 52 18](https://user-images.githubusercontent.com/4848178/82768212-dacff480-9e2d-11ea-81e1-f46c57f43319.png)

We export the model with the GLTF exporter while making sure to have the "Custom properties" option enabled.

![Screen Shot 2020-05-24 at 20 53 36](https://user-images.githubusercontent.com/4848178/82768213-db688b00-9e2d-11ea-84f6-fdccdbc3df61.png)

We can see that the `.gltf` file encodes the custom property in the `"extras"` field.

![Screen Shot 2020-05-24 at 21 00 04](https://user-images.githubusercontent.com/4848178/82768211-dacff480-9e2d-11ea-8f30-34c70bd365e1.png)

Importing the `.gltf` file into Godot results in a MeshInstance with the metadata set to the values specified in Blender.

(the metadata panel is displayed by [this plugin](https://github.com/ballerburg9005/godot-metadata-inspector))

# Breaking behavior

The option is disabled by default so it should not introduce unexpected behavior to anyone.

# Disclaimer

I have no prior experience with 3D model formats or game development.


