### PR TITLE
Fix JNI emitSignal with one or more parameters

### DIFF
--- a/platform/android/plugin/godot_plugin_jni.cpp
+++ b/platform/android/plugin/godot_plugin_jni.cpp
@@ -114,16 +114,19 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeEmitS
 	String signal_name = jstring_to_string(j_signal_name, env);
 
 	int count = env->GetArrayLength(j_signal_params);
-	const Variant *args[count];
+	Variant args[VARIANT_ARG_MAX];
 
-	for (int i = 0; i < count; i++) {
+	ERR_FAIL_COND_MSG(count > VARIANT_ARG_MAX, "Maximum argument count exceeded!");
+
+	for (int i = 0; i < MIN(count, VARIANT_ARG_MAX); i++) {
 		jobject j_param = env->GetObjectArrayElement(j_signal_params, i);
-		Variant variant = _jobject_to_variant(env, j_param);
-		args[i] = &variant;
+		if (j_param) {
+			args[i] = _jobject_to_variant(env, j_param);
+		}
 		env->DeleteLocalRef(j_param);
 	};
 
-	singleton->emit_signal(signal_name, args, count);
+	singleton->emit_signal(signal_name, args[0], args[1], args[2], args[3], args[4]);
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeRegisterGDNativeLibraries(JNIEnv *env, jobject obj, jobjectArray gdnlib_paths) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/39018

Code borrowed from JNI `GodotLib.calldeferred` [here](https://github.com/godotengine/godot/blob/f69760b4befd7348c443960b84dd5f4e1d372e17/platform/android/plugin/godot_plugin_jni.cpp#L112-L133).

~**Disclaimer:** I have not quite figured out _why_ this fixes the issue, so I'd be glad if anyone knows and is able to explain. :)~