### PR TITLE
[WIP] WinTab: handle pen coordinates in the WT_PACKET event.

### DIFF
--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -74,15 +74,24 @@
 
 #define WTI_DEFSYSCTX 4
 #define WTI_DEVICES 100
+#define WTI_INTERFACE 1
+#define IFC_WINTABID 1
+#define IFC_SPECVERSION 2
+#define IFC_IMPLVERSION 3
+#define IFC_CTXOPTIONS 7
 #define DVC_NPRESSURE 15
 #define DVC_TPRESSURE 16
 #define DVC_ORIENTATION 17
 #define DVC_ROTATION 18
 
 #define CXO_MESSAGES 0x0004
+#define CXO_CSRMESSAGES 0x0008
 #define PK_NORMAL_PRESSURE 0x0400
 #define PK_TANGENT_PRESSURE 0x0800
 #define PK_ORIENTATION 0x1000
+#define PK_X 0x0080
+#define PK_Y 0x0100
+#define PK_Z 0x0200
 
 typedef struct tagLOGCONTEXTW {
 	WCHAR lcName[40];
@@ -135,6 +144,9 @@ typedef struct tagORIENTATION {
 } ORIENTATION;
 
 typedef struct tagPACKET {
+	LONG pkX;
+	LONG pkY;
+	LONG pkZ;
 	int pkNormalPressure;
 	int pkTangentPressure;
 	ORIENTATION pkOrientation;
@@ -145,6 +157,10 @@ typedef BOOL(WINAPI *WTClosePtr)(HANDLE p_ctx);
 typedef UINT(WINAPI *WTInfoPtr)(UINT p_category, UINT p_index, LPVOID p_output);
 typedef BOOL(WINAPI *WTPacketPtr)(HANDLE p_ctx, UINT p_param, LPVOID p_packets);
 typedef BOOL(WINAPI *WTEnablePtr)(HANDLE p_ctx, BOOL p_enable);
+typedef int(WINAPI *WTPacketsGetPtr)(HANDLE p_ctx, int p_count, LPVOID p_buffer);
+typedef int(WINAPI *WTQueueSizeGetPtr)(HANDLE p_ctx);
+typedef BOOL(WINAPI *WTQueueSizeSetPtr)(HANDLE p_ctx, int p_size);
+typedef BOOL(WINAPI *WTOverlapPtr)(HANDLE p_ctx, BOOL p_enable);
 
 // Windows Ink API
 #ifndef POINTER_STRUCTURES
@@ -237,8 +253,14 @@ typedef struct tagPOINTER_PEN_INFO {
 #define WM_POINTERLEAVE 0x024A
 #endif
 
+#ifndef WM_POINTERCAPTURECHANGED
+#define WM_POINTERCAPTURECHANGED 0x024C
+#endif
+
 typedef BOOL(WINAPI *GetPointerTypePtr)(uint32_t p_id, POINTER_INPUT_TYPE *p_type);
 typedef BOOL(WINAPI *GetPointerPenInfoPtr)(uint32_t p_id, POINTER_PEN_INFO *p_pen_info);
+typedef BOOL(WINAPI *PhysicalToLogicalPointForPerMonitorDPIPtr)(HWND hWnd, LPPOINT lpPoint);
+typedef UINT(WINAPI *GetDpiForWindowPtr)(HWND hwnd);
 
 typedef struct {
 	BYTE bWidth; // Width, in pixels, of the image
@@ -272,11 +294,16 @@ public:
 	static WTInfoPtr wintab_WTInfo;
 	static WTPacketPtr wintab_WTPacket;
 	static WTEnablePtr wintab_WTEnable;
+	static WTPacketsGetPtr wintab_WTPacketsGet;
+	static WTQueueSizeGetPtr wintab_WTQueueSizeGet;
+	static WTQueueSizeSetPtr wintab_WTQueueSizeSet;
+	static WTOverlapPtr wintab_WTOverlap;
 
 	// Windows Ink API
 	static bool winink_available;
 	static GetPointerTypePtr win8p_GetPointerType;
 	static GetPointerPenInfoPtr win8p_GetPointerPenInfo;
+	static PhysicalToLogicalPointForPerMonitorDPIPtr win8p_PhysicalToLogicalPointForPerMonitorDPI;
 
 	void _update_tablet_ctx(const String &p_old_driver, const String &p_new_driver);
 
@@ -284,7 +311,13 @@ private:
 	void GetMaskBitmaps(HBITMAP hSourceBitmap, COLORREF clrTransparent, OUT HBITMAP &hAndMaskBitmap, OUT HBITMAP &hXorMaskBitmap);
 
 	enum {
-		KEY_EVENT_BUFFER_SIZE = 512
+		KEY_EVENT_BUFFER_SIZE = 512,
+		PACKET_QUERY_SIZE = 128
+	};
+
+	enum {
+		MOVE_TIMER_ID = 1,
+		UNLOCK_TIMER_ID = 2
 	};
 
 	struct KeyEvent {
@@ -343,10 +376,6 @@ private:
 		bool tilt_supported;
 		bool block_mm = false;
 
-		int last_pressure_update;
-		float last_pressure;
-		Vector2 last_tilt;
-
 		HBITMAP hBitmap; //DIB section for layered window
 		uint8_t *dib_data = nullptr;
 		Size2 dib_size;
@@ -385,6 +414,7 @@ private:
 	WindowID last_focused_window = INVALID_WINDOW_ID;
 
 	uint32_t move_timer_id;
+	uint32_t unlock_timer_id;
 
 	HCURSOR hCursor;
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -820,8 +820,12 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 		DisplayServerWindows::wintab_WTInfo = (WTInfoPtr)GetProcAddress(wintab_lib, "WTInfoW");
 		DisplayServerWindows::wintab_WTPacket = (WTPacketPtr)GetProcAddress(wintab_lib, "WTPacket");
 		DisplayServerWindows::wintab_WTEnable = (WTEnablePtr)GetProcAddress(wintab_lib, "WTEnable");
+		DisplayServerWindows::wintab_WTPacketsGet = (WTPacketsGetPtr)GetProcAddress(wintab_lib, "WTPacketsGet");
+		DisplayServerWindows::wintab_WTQueueSizeGet = (WTQueueSizeGetPtr)GetProcAddress(wintab_lib, "WTQueueSizeGet");
+		DisplayServerWindows::wintab_WTQueueSizeSet = (WTQueueSizeSetPtr)GetProcAddress(wintab_lib, "WTQueueSizeSet");
+		DisplayServerWindows::wintab_WTOverlap = (WTOverlapPtr)GetProcAddress(wintab_lib, "WTOverlap");
 
-		DisplayServerWindows::wintab_available = DisplayServerWindows::wintab_WTOpen && DisplayServerWindows::wintab_WTClose && DisplayServerWindows::wintab_WTInfo && DisplayServerWindows::wintab_WTPacket && DisplayServerWindows::wintab_WTEnable;
+		DisplayServerWindows::wintab_available = DisplayServerWindows::wintab_WTOpen && DisplayServerWindows::wintab_WTClose && DisplayServerWindows::wintab_WTInfo && DisplayServerWindows::wintab_WTPacket && DisplayServerWindows::wintab_WTEnable && DisplayServerWindows::wintab_WTPacketsGet && DisplayServerWindows::wintab_WTQueueSizeGet && DisplayServerWindows::wintab_WTQueueSizeSet && DisplayServerWindows::wintab_WTOverlap;
 	}
 
 	if (DisplayServerWindows::wintab_available) {
@@ -833,6 +837,7 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	if (user32_lib) {
 		DisplayServerWindows::win8p_GetPointerType = (GetPointerTypePtr)GetProcAddress(user32_lib, "GetPointerType");
 		DisplayServerWindows::win8p_GetPointerPenInfo = (GetPointerPenInfoPtr)GetProcAddress(user32_lib, "GetPointerPenInfo");
+		DisplayServerWindows::win8p_PhysicalToLogicalPointForPerMonitorDPI = (PhysicalToLogicalPointForPerMonitorDPIPtr)GetProcAddress(user32_lib, "PhysicalToLogicalPointForPerMonitorDPI");
 
 		DisplayServerWindows::winink_available = DisplayServerWindows::win8p_GetPointerType && DisplayServerWindows::win8p_GetPointerPenInfo;
 	}


### PR DESCRIPTION
- Changes WT_PACKET event handler to process coordinates directly, instead of relaying on the subsequent WM_MOUSEMOVE, and block WM_MOUSEMOVE while pen is in use (Similar to the Windows Ink handling).

- Adds WM_POINTERCAPTURECHANGED handler for Windows Ink processing, to make sure WM_MOUSEMOVE is unblocked if tablet access is captured by another app in the middle of movement.

- Adds WM_MOUSEMOVE unlock timeout in case pen leave event is not registered for some reason.


