### PR TITLE
Fix JS audioContext parameters.

### DIFF
--- a/platform/javascript/audio_driver_javascript.cpp
+++ b/platform/javascript/audio_driver_javascript.cpp
@@ -70,14 +70,14 @@ Error AudioDriverJavaScript::init() {
 	/* clang-format off */
 	_driver_id = EM_ASM_INT({
 		const MIX_RATE = $0;
-		const LATENCY = $1;
+		const LATENCY = $1 / 1000;
 		return Module.IDHandler.add({
 			'context': new (window.AudioContext || window.webkitAudioContext)({ sampleRate: MIX_RATE, latencyHint: LATENCY}),
 			'input': null,
 			'stream': null,
 			'script': null
 		});
-	});
+	}, mix_rate, latency);
 	/* clang-format on */
 
 	int channel_count = get_total_channels_by_speaker_mode(get_speaker_mode());


### PR DESCRIPTION
Were not passed along correctly.
`latencyHint` is supposed to be in seconds, not milliseconds. See https://github.com/godotengine/godot/pull/38816#issuecomment-633382461 . Needs cherry pick for `3.2` (see https://github.com/Faless/godot/commit/f46c8746fb4e751c162ee4c6328acff6cc064110)