### PR TITLE
Fixed issues with input propagation triggering unwanted shortcuts

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -114,7 +114,12 @@ void SceneTreeDock::_unhandled_key_input(Ref<InputEvent> p_event) {
 		_tool_selected(TOOL_COPY_NODE_PATH);
 	} else if (ED_IS_SHORTCUT("scene_tree/delete", p_event)) {
 		_tool_selected(TOOL_ERASE);
+	} else {
+		return;
 	}
+
+	// Accept event if one of the shortcuts matched
+	accept_event();
 }
 
 void SceneTreeDock::instance(const String &p_file) {

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -338,6 +338,7 @@ Ref<ShortCut> BaseButton::get_shortcut() const {
 void BaseButton::_unhandled_input(Ref<InputEvent> p_event) {
 	if (!is_disabled() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->is_shortcut(p_event)) {
 		on_action_event(p_event);
+		accept_event();
 	}
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3000,7 +3000,17 @@ void Viewport::unhandled_input(const Ref<InputEvent> &p_event, bool p_local_coor
 
 	get_tree()->_call_input_pause(unhandled_input_group, "_unhandled_input", ev, this);
 	if (!is_input_handled() && Object::cast_to<InputEventKey>(*ev) != nullptr) {
-		get_tree()->_call_input_pause(unhandled_key_input_group, "_unhandled_key_input", ev, this);
+		Array arg;
+		arg.push_back(ev);
+		// Start with the control which is focused
+		Node *node = _gui_get_focus_owner();
+
+		// Iterate through focused node parents until input is handled. Stop when this viewport is reached.
+		while (node && !is_input_handled() && node != this) {
+			node->propagate_call("_unhandled_key_input", arg, true);
+
+			node = node->get_parent();
+		}
 	}
 
 	if (physics_object_picking && !is_input_handled()) {


### PR DESCRIPTION
Fixes #36205, fixes #38922, fixes #37807, fixes #37054, fixes #17591 and potentially others.

This fix adds a check in viewport.cpp which ~checks that the focused node and none of its parents can handle the input, before propagating the input to all editor nodes which implement _unhandled_key_input.~ iterates through the node and it's parents, propagating calls to it's children. This ensures that `_unhandled_input` is called not only on the node itself, but things like MenuButtons and Buttons which have assigned shortcuts.

Also, a few accept_events() were added where needed to stop multiple
shortcuts from running at once. See #38922 for more comments.

Replaces/builds upon #37839 and #37068.

Requesting review/feedback from @reduz @akien-mga and others to see what they think. I think this is more a 'band-aid' fix over some bigger shortcut/input issues but hey, it works.

**Before (3.2.1, latest master):**
![oKU32YC3hh](https://user-images.githubusercontent.com/41730826/82819365-999a1c00-9ee3-11ea-97b9-1c9ae61ff34c.gif)

**After:**
![iwNrawfhK4](https://user-images.githubusercontent.com/41730826/82819369-9bfc7600-9ee3-11ea-83ac-686b6b5e7b54.gif)
