### PR TITLE
Fix crashing of VisualScript due to function change

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -3216,6 +3216,7 @@ void VisualScriptEditor::_move_nodes_with_rescan(const StringName &p_func_from, 
 	{
 		List<VisualScript::DataConnection> data_connections;
 		script->get_data_connection_list(p_func_from, &data_connections);
+		int func_from_node_id = script->get_function_node_id(p_func_from);
 
 		HashMap<int, Map<int, Pair<int, int>>> connections;
 
@@ -3224,6 +3225,11 @@ void VisualScriptEditor::_move_nodes_with_rescan(const StringName &p_func_from, 
 			int to = E->get().to_node;
 			int out_p = E->get().from_port;
 			int in_p = E->get().to_port;
+
+			// skip if the from_node is a function node
+			if (from == func_from_node_id) {
+				continue;
+			}
 
 			if (!connections.has(to)) {
 				connections.set(to, Map<int, Pair<int, int>>());


### PR DESCRIPTION
Attempting to move the function node to another function whose data connection is a dependency of the node the specific node being moved to a different function during changes to sequence connections.
By skipping, if the from_node is a function_node during the data connection dependencies scan.

Should fix #37991

Tested on 3.2.1 stable release branch.