### PR TITLE
Fix parameters passing when emitting signal

### DIFF
--- a/platform/android/plugin/godot_plugin_jni.cpp
+++ b/platform/android/plugin/godot_plugin_jni.cpp
@@ -114,12 +114,13 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeEmitS
 	String signal_name = jstring_to_string(j_signal_name, env);
 
 	int count = env->GetArrayLength(j_signal_params);
+	Variant variant_params[count];
 	const Variant *args[count];
 
 	for (int i = 0; i < count; i++) {
 		jobject j_param = env->GetObjectArrayElement(j_signal_params, i);
-		Variant variant = _jobject_to_variant(env, j_param);
-		args[i] = &variant;
+		variant_params[i] = _jobject_to_variant(env, j_param);
+		args[i] = &variant_params[i];
 		env->DeleteLocalRef(j_param);
 	};
 


### PR DESCRIPTION
The issue was caused because we were using variables local to the `for` loop block.

Fixes #39018