### PR TITLE
Stop ignoring hidden files and directories in the `assets` directory

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -75,6 +75,11 @@ android {
     }
 
     defaultConfig {
+        // The default ignore pattern for the 'assets' directory includes hidden files and directories which are used by Godot projects.
+        aaptOptions {
+            ignoreAssetsPattern "!.svn:!.git:!.ds_store:!*.scc:<dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"
+        }
+
         // Feel free to modify the application id to your own.
         applicationId getExportPackageName()
         minSdkVersion versions.minSdk


### PR DESCRIPTION
As commented in the change:
`The default ignore pattern for the 'assets' directory includes hidden files and directories which are used by Godot projects`

It hasn't affected `apk`s generated by the editor because the editor directly inserts the needed files and directories (including hidden ones) in the `assets` directory **after** the `apk` has been generated.
But it's safer to remain consistent.