### PR TITLE
Add static_assert checks where code assumes VARIANT_ARG_MAX == 5

### DIFF
--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -435,6 +435,7 @@ Variant UndoRedo::_add_do_method(const Variant **p_args, int p_argcount, Callabl
 		v[i] = *p_args[i + 2];
 	}
 
+	static_assert(VARIANT_ARG_MAX == 5, "This code needs to be updated if VARIANT_ARG_MAX != 5");
 	add_do_method(object, method, v[0], v[1], v[2], v[3], v[4]);
 	return Variant();
 }
@@ -471,6 +472,7 @@ Variant UndoRedo::_add_undo_method(const Variant **p_args, int p_argcount, Calla
 		v[i] = *p_args[i + 2];
 	}
 
+	static_assert(VARIANT_ARG_MAX == 5, "This code needs to be updated if VARIANT_ARG_MAX != 5");
 	add_undo_method(object, method, v[0], v[1], v[2], v[3], v[4]);
 	return Variant();
 }

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -435,6 +435,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_calldeferred(JNIEnv *
 		env->DeleteLocalRef(obj);
 	};
 
+	static_assert(VARIANT_ARG_MAX == 5, "This code needs to be updated if VARIANT_ARG_MAX != 5");
 	obj->call_deferred(str_method, args[0], args[1], args[2], args[3], args[4]);
 	// something
 	env->PopLocalFrame(nullptr);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -170,6 +170,7 @@ void SceneTree::_flush_ugc() {
 			v[i] = E->get()[i];
 		}
 
+		static_assert(VARIANT_ARG_MAX == 5, "This code needs to be updated if VARIANT_ARG_MAX != 5");
 		call_group_flags(GROUP_CALL_REALTIME, E->key().group, E->key().call, v[0], v[1], v[2], v[3], v[4]);
 
 		unique_group_calls.erase(E);
@@ -907,6 +908,7 @@ Variant SceneTree::_call_group_flags(const Variant **p_args, int p_argcount, Cal
 		v[i] = *p_args[i + 3];
 	}
 
+	static_assert(VARIANT_ARG_MAX == 5, "This code needs to be updated if VARIANT_ARG_MAX != 5");
 	call_group_flags(flags, group, method, v[0], v[1], v[2], v[3], v[4]);
 	return Variant();
 }
@@ -926,6 +928,7 @@ Variant SceneTree::_call_group(const Variant **p_args, int p_argcount, Callable:
 		v[i] = *p_args[i + 2];
 	}
 
+	static_assert(VARIANT_ARG_MAX == 5, "This code needs to be updated if VARIANT_ARG_MAX != 5");
 	call_group_flags(0, group, method, v[0], v[1], v[2], v[3], v[4]);
 	return Variant();
 }


### PR DESCRIPTION
This PR adds `static_assert` checks to all places I could find where the code assumes `VARIANT_ARG_MAX` to be 5 to prevent regressions should `VARIANT_ARG_MAX` change in the future.

Thanks to @pouleyKetchoupp for the initial hint! :)