### PR TITLE
Skip extra newline in .tscn when renaming dependency

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -838,6 +838,11 @@ Error ResourceLoaderText::rename_dependencies(FileAccess *p_f, const String &p_p
 	f->seek(tag_end);
 
 	uint8_t c = f->get_8();
+	if (c == '\n' && !f->eof_reached()) {
+		// Skip first newline character since we added one
+		c = f->get_8();
+	}
+
 	while (!f->eof_reached()) {
 		fw->store_8(c);
 		c = f->get_8();


### PR DESCRIPTION
Fixes #39020 

In `scene/resources/resource_format_text.cpp` in `ResourceLoaderText::rename_dependencies`, an extra newline character is introduced when a dependency is renamed. Line `832` calls `fw->store_line` to add the new `ext_resource` tag, and then, later, when the rest of the original .tscn is appended to the new .tscn, the newline character that originally came after the tag is added to the file. I added a check before appending to skip the first newline character, so that `fw->store_line` will still separate consecutive tags. 