### PR TITLE
Update Windows GUID to SDL uid conversion.

### DIFF
--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -33,10 +33,6 @@
 #include <oleauto.h>
 #include <wbemidl.h>
 
-#ifndef __GNUC__
-#define __builtin_bswap32 _byteswap_ulong
-#endif
-
 #if defined(__GNUC__)
 // Workaround GCC warning from -Wcast-function-type.
 #define GetProcAddress (void *)GetProcAddress
@@ -158,10 +154,13 @@ bool JoypadWindows::setup_dinput_joypad(const DIDEVICEINSTANCE *instance) {
 
 	const GUID &guid = instance->guidProduct;
 	char uid[128];
-	sprintf_s(uid, "%08lx%04hx%04hx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx",
-			__builtin_bswap32(guid.Data1), guid.Data2, guid.Data3,
-			guid.Data4[0], guid.Data4[1], guid.Data4[2], guid.Data4[3],
-			guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]);
+
+	ERR_FAIL_COND_V_MSG(memcmp(&guid.Data4[2], "PIDVID", 6), false, "DirectInput device not recognised.");
+	WORD type = BSWAP16(0x03);
+	WORD vendor = BSWAP16(LOWORD(guid.Data1));
+	WORD product = BSWAP16(HIWORD(guid.Data1));
+	WORD version = 0;
+	sprintf_s(uid, "%04x%04x%04x%04x%04x%04x%04x%04x", type, 0, vendor, 0, product, 0, version, 0);
 
 	id_to_change = joypad_count;
 


### PR DESCRIPTION
Should fix #38869. However, since I don't have controllers to test this with, I need help with testing.
cc @hoontee @RonanZe

Note: This is specific to Windows. I've checked the Linux version and this does not appear to need to be updated. The other OSes don't appear to use the SDL mapping database. 