### PR TITLE
GDNative: Add bindings for the Packed*Array ptr() and ptrw() functions.

### DIFF
--- a/modules/gdnative/gdnative/packed_arrays.cpp
+++ b/modules/gdnative/gdnative/packed_arrays.cpp
@@ -78,6 +78,16 @@ void GDAPI godot_packed_byte_array_new_with_array(godot_packed_byte_array *r_des
 	}
 }
 
+const uint8_t GDAPI *godot_packed_byte_array_ptr(const godot_packed_byte_array *p_self) {
+	const Vector<uint8_t> *self = (const Vector<uint8_t> *)p_self;
+	return self->ptr();
+}
+
+uint8_t GDAPI *godot_packed_byte_array_ptrw(godot_packed_byte_array *p_self) {
+	Vector<uint8_t> *self = (Vector<uint8_t> *)p_self;
+	return self->ptrw();
+}
+
 void GDAPI godot_packed_byte_array_append(godot_packed_byte_array *p_self, const uint8_t p_data) {
 	Vector<uint8_t> *self = (Vector<uint8_t> *)p_self;
 	self->push_back(p_data);
@@ -160,6 +170,16 @@ void GDAPI godot_packed_int32_array_new_with_array(godot_packed_int32_array *r_d
 	for (int i = 0; i < a->size(); i++) {
 		dest->set(i, (*a)[i]);
 	}
+}
+
+const int32_t GDAPI *godot_packed_int32_array_ptr(const godot_packed_int32_array *p_self) {
+	const Vector<int32_t> *self = (const Vector<int32_t> *)p_self;
+	return self->ptr();
+}
+
+int32_t GDAPI *godot_packed_int32_array_ptrw(godot_packed_int32_array *p_self) {
+	Vector<int32_t> *self = (Vector<int32_t> *)p_self;
+	return self->ptrw();
 }
 
 void GDAPI godot_packed_int32_array_append(godot_packed_int32_array *p_self, const int32_t p_data) {
@@ -246,6 +266,16 @@ void GDAPI godot_packed_int64_array_new_with_array(godot_packed_int64_array *r_d
 	}
 }
 
+const int64_t GDAPI *godot_packed_int64_array_ptr(const godot_packed_int64_array *p_self) {
+	const Vector<int64_t> *self = (const Vector<int64_t> *)p_self;
+	return self->ptr();
+}
+
+int64_t GDAPI *godot_packed_int64_array_ptrw(godot_packed_int64_array *p_self) {
+	Vector<int64_t> *self = (Vector<int64_t> *)p_self;
+	return self->ptrw();
+}
+
 void GDAPI godot_packed_int64_array_append(godot_packed_int64_array *p_self, const int64_t p_data) {
 	Vector<int64_t> *self = (Vector<int64_t> *)p_self;
 	self->push_back(p_data);
@@ -328,6 +358,16 @@ void GDAPI godot_packed_float32_array_new_with_array(godot_packed_float32_array 
 	for (int i = 0; i < a->size(); i++) {
 		dest->set(i, (*a)[i]);
 	}
+}
+
+const float GDAPI *godot_packed_float32_array_ptr(const godot_packed_float32_array *p_self) {
+	const Vector<float> *self = (const Vector<float> *)p_self;
+	return self->ptr();
+}
+
+float GDAPI *godot_packed_float32_array_ptrw(godot_packed_float32_array *p_self) {
+	Vector<float> *self = (Vector<float> *)p_self;
+	return self->ptrw();
 }
 
 void GDAPI godot_packed_float32_array_append(godot_packed_float32_array *p_self, const float p_data) {
@@ -414,6 +454,16 @@ void GDAPI godot_packed_float64_array_new_with_array(godot_packed_float64_array 
 	}
 }
 
+const double GDAPI *godot_packed_float64_array_ptr(const godot_packed_float64_array *p_self) {
+	const Vector<double> *self = (const Vector<double> *)p_self;
+	return self->ptr();
+}
+
+double GDAPI *godot_packed_float64_array_ptrw(godot_packed_float64_array *p_self) {
+	Vector<double> *self = (Vector<double> *)p_self;
+	return self->ptrw();
+}
+
 void GDAPI godot_packed_float64_array_append(godot_packed_float64_array *p_self, const double p_data) {
 	Vector<double> *self = (Vector<double> *)p_self;
 	self->push_back(p_data);
@@ -496,6 +546,16 @@ void GDAPI godot_packed_string_array_new_with_array(godot_packed_string_array *r
 	for (int i = 0; i < a->size(); i++) {
 		dest->set(i, (*a)[i]);
 	}
+}
+
+const godot_string GDAPI *godot_packed_string_array_ptr(const godot_packed_string_array *p_self) {
+	const Vector<String> *self = (const Vector<String> *)p_self;
+	return (const godot_string *)self->ptr();
+}
+
+godot_string GDAPI *godot_packed_string_array_ptrw(godot_packed_string_array *p_self) {
+	Vector<String> *self = (Vector<String> *)p_self;
+	return (godot_string *)self->ptrw();
 }
 
 void GDAPI godot_packed_string_array_append(godot_packed_string_array *p_self, const godot_string *p_data) {
@@ -590,6 +650,16 @@ void GDAPI godot_packed_vector2_array_new_with_array(godot_packed_vector2_array 
 	}
 }
 
+const godot_vector2 GDAPI *godot_packed_vector2_array_ptr(const godot_packed_vector2_array *p_self) {
+	const Vector<Vector2> *self = (const Vector<Vector2> *)p_self;
+	return (const godot_vector2 *)self->ptr();
+}
+
+godot_vector2 GDAPI *godot_packed_vector2_array_ptrw(godot_packed_vector2_array *p_self) {
+	Vector<Vector2> *self = (Vector<Vector2> *)p_self;
+	return (godot_vector2 *)self->ptrw();
+}
+
 void GDAPI godot_packed_vector2_array_append(godot_packed_vector2_array *p_self, const godot_vector2 *p_data) {
 	Vector<Vector2> *self = (Vector<Vector2> *)p_self;
 	Vector2 &s = *(Vector2 *)p_data;
@@ -681,6 +751,16 @@ void GDAPI godot_packed_vector3_array_new_with_array(godot_packed_vector3_array 
 	}
 }
 
+const godot_vector3 GDAPI *godot_packed_vector3_array_ptr(const godot_packed_vector3_array *p_self) {
+	const Vector<Vector3> *self = (const Vector<Vector3> *)p_self;
+	return (const godot_vector3 *)self->ptr();
+}
+
+godot_vector3 GDAPI *godot_packed_vector3_array_ptrw(godot_packed_vector3_array *p_self) {
+	Vector<Vector3> *self = (Vector<Vector3> *)p_self;
+	return (godot_vector3 *)self->ptrw();
+}
+
 void GDAPI godot_packed_vector3_array_append(godot_packed_vector3_array *p_self, const godot_vector3 *p_data) {
 	Vector<Vector3> *self = (Vector<Vector3> *)p_self;
 	Vector3 &s = *(Vector3 *)p_data;
@@ -770,6 +850,16 @@ void GDAPI godot_packed_color_array_new_with_array(godot_packed_color_array *r_d
 	for (int i = 0; i < a->size(); i++) {
 		dest->set(i, (*a)[i]);
 	}
+}
+
+const godot_color GDAPI *godot_packed_color_array_ptr(const godot_packed_color_array *p_self) {
+	const Vector<Color> *self = (const Vector<Color> *)p_self;
+	return (const godot_color *)self->ptr();
+}
+
+godot_color GDAPI *godot_packed_color_array_ptrw(godot_packed_color_array *p_self) {
+	Vector<Color> *self = (Vector<Color> *)p_self;
+	return (godot_color *)self->ptrw();
 }
 
 void GDAPI godot_packed_color_array_append(godot_packed_color_array *p_self, const godot_color *p_data) {

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -519,6 +519,34 @@
               ]
             },
             {
+              "name": "godot_packed_int64_array_ptr",
+              "return_type": "const int64_t *",
+              "arguments": [
+                ["const godot_packed_int64_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_packed_int64_array_ptrw",
+              "return_type": "int64_t *",
+              "arguments": [
+                ["godot_packed_int64_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_ptr",
+              "return_type": "const double *",
+              "arguments": [
+                ["const godot_packed_float64_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_packed_float64_array_ptrw",
+              "return_type": "double *",
+              "arguments": [
+                ["godot_packed_float64_array *", "p_self"]
+              ]
+            },
+            {
               "name": "godot_rect2_as_rect2i",
               "return_type": "godot_rect2i",
               "arguments": [
@@ -2854,6 +2882,20 @@
         ]
       },
       {
+        "name": "godot_packed_byte_array_ptr",
+        "return_type": "const uint8_t *",
+        "arguments": [
+          ["const godot_packed_byte_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_ptrw",
+        "return_type": "uint8_t *",
+        "arguments": [
+          ["godot_packed_byte_array *", "p_self"]
+        ]
+      },
+      {
         "name": "godot_packed_byte_array_set",
         "return_type": "void",
         "arguments": [
@@ -2961,6 +3003,20 @@
         "arguments": [
           ["godot_packed_int32_array *", "p_self"],
           ["const godot_int", "p_size"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_ptr",
+        "return_type": "const int32_t *",
+        "arguments": [
+          ["const godot_packed_int32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_ptrw",
+        "return_type": "int32_t *",
+        "arguments": [
+          ["godot_packed_int32_array *", "p_self"]
         ]
       },
       {
@@ -3074,6 +3130,20 @@
         ]
       },
       {
+        "name": "godot_packed_float32_array_ptr",
+        "return_type": "const float *",
+        "arguments": [
+          ["const godot_packed_float32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_ptrw",
+        "return_type": "float *",
+        "arguments": [
+          ["godot_packed_float32_array *", "p_self"]
+        ]
+      },
+      {
         "name": "godot_packed_float32_array_set",
         "return_type": "void",
         "arguments": [
@@ -3181,6 +3251,20 @@
         "arguments": [
           ["godot_packed_string_array *", "p_self"],
           ["const godot_int", "p_size"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_ptr",
+        "return_type": "const godot_string *",
+        "arguments": [
+          ["const godot_packed_string_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_ptrw",
+        "return_type": "godot_string *",
+        "arguments": [
+          ["godot_packed_string_array *", "p_self"]
         ]
       },
       {
@@ -3294,6 +3378,20 @@
         ]
       },
       {
+        "name": "godot_packed_vector2_array_ptr",
+        "return_type": "const godot_vector2 *",
+        "arguments": [
+          ["const godot_packed_vector2_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_ptrw",
+        "return_type": "godot_vector2 *",
+        "arguments": [
+          ["godot_packed_vector2_array *", "p_self"]
+        ]
+      },
+      {
         "name": "godot_packed_vector2_array_set",
         "return_type": "void",
         "arguments": [
@@ -3404,6 +3502,20 @@
         ]
       },
       {
+        "name": "godot_packed_vector3_array_ptr",
+        "return_type": "const godot_vector3 *",
+        "arguments": [
+          ["const godot_packed_vector3_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_ptrw",
+        "return_type": "godot_vector3 *",
+        "arguments": [
+          ["godot_packed_vector3_array *", "p_self"]
+        ]
+      },
+      {
         "name": "godot_packed_vector3_array_set",
         "return_type": "void",
         "arguments": [
@@ -3511,6 +3623,20 @@
         "arguments": [
           ["godot_packed_color_array *", "p_self"],
           ["const godot_int", "p_size"]
+        ]
+      },    
+      {
+        "name": "godot_packed_color_array_ptr",
+        "return_type": "const godot_color *",
+        "arguments": [
+          ["const godot_packed_color_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_ptrw",
+        "return_type": "godot_color *",
+        "arguments": [
+          ["godot_packed_color_array *", "p_self"]
         ]
       },
       {

--- a/modules/gdnative/include/gdnative/packed_arrays.h
+++ b/modules/gdnative/include/gdnative/packed_arrays.h
@@ -158,6 +158,9 @@ void GDAPI godot_packed_byte_array_new(godot_packed_byte_array *r_dest);
 void GDAPI godot_packed_byte_array_new_copy(godot_packed_byte_array *r_dest, const godot_packed_byte_array *p_src);
 void GDAPI godot_packed_byte_array_new_with_array(godot_packed_byte_array *r_dest, const godot_array *p_a);
 
+const uint8_t GDAPI *godot_packed_byte_array_ptr(const godot_packed_byte_array *p_self);
+uint8_t GDAPI *godot_packed_byte_array_ptrw(godot_packed_byte_array *p_self);
+
 void GDAPI godot_packed_byte_array_append(godot_packed_byte_array *p_self, const uint8_t p_data);
 
 void GDAPI godot_packed_byte_array_append_array(godot_packed_byte_array *p_self, const godot_packed_byte_array *p_array);
@@ -186,6 +189,9 @@ void GDAPI godot_packed_byte_array_destroy(godot_packed_byte_array *p_self);
 void GDAPI godot_packed_int32_array_new(godot_packed_int32_array *r_dest);
 void GDAPI godot_packed_int32_array_new_copy(godot_packed_int32_array *r_dest, const godot_packed_int32_array *p_src);
 void GDAPI godot_packed_int32_array_new_with_array(godot_packed_int32_array *r_dest, const godot_array *p_a);
+
+const int32_t GDAPI *godot_packed_int32_array_ptr(const godot_packed_int32_array *p_self);
+int32_t GDAPI *godot_packed_int32_array_ptrw(godot_packed_int32_array *p_self);
 
 void GDAPI godot_packed_int32_array_append(godot_packed_int32_array *p_self, const int32_t p_data);
 
@@ -216,6 +222,9 @@ void GDAPI godot_packed_int64_array_new(godot_packed_int64_array *r_dest);
 void GDAPI godot_packed_int64_array_new_copy(godot_packed_int64_array *r_dest, const godot_packed_int64_array *p_src);
 void GDAPI godot_packed_int64_array_new_with_array(godot_packed_int64_array *r_dest, const godot_array *p_a);
 
+const int64_t GDAPI *godot_packed_int64_array_ptr(const godot_packed_int64_array *p_self);
+int64_t GDAPI *godot_packed_int64_array_ptrw(godot_packed_int64_array *p_self);
+
 void GDAPI godot_packed_int64_array_append(godot_packed_int64_array *p_self, const int64_t p_data);
 
 void GDAPI godot_packed_int64_array_append_array(godot_packed_int64_array *p_self, const godot_packed_int64_array *p_array);
@@ -244,6 +253,9 @@ void GDAPI godot_packed_int64_array_destroy(godot_packed_int64_array *p_self);
 void GDAPI godot_packed_float32_array_new(godot_packed_float32_array *r_dest);
 void GDAPI godot_packed_float32_array_new_copy(godot_packed_float32_array *r_dest, const godot_packed_float32_array *p_src);
 void GDAPI godot_packed_float32_array_new_with_array(godot_packed_float32_array *r_dest, const godot_array *p_a);
+
+const float GDAPI *godot_packed_float32_array_ptr(const godot_packed_float32_array *p_self);
+float GDAPI *godot_packed_float32_array_ptrw(godot_packed_float32_array *p_self);
 
 void GDAPI godot_packed_float32_array_append(godot_packed_float32_array *p_self, const float p_data);
 
@@ -274,6 +286,9 @@ void GDAPI godot_packed_float64_array_new(godot_packed_float64_array *r_dest);
 void GDAPI godot_packed_float64_array_new_copy(godot_packed_float64_array *r_dest, const godot_packed_float64_array *p_src);
 void GDAPI godot_packed_float64_array_new_with_array(godot_packed_float64_array *r_dest, const godot_array *p_a);
 
+const double GDAPI *godot_packed_float64_array_ptr(const godot_packed_float64_array *p_self);
+double GDAPI *godot_packed_float64_array_ptrw(godot_packed_float64_array *p_self);
+
 void GDAPI godot_packed_float64_array_append(godot_packed_float64_array *p_self, const double p_data);
 
 void GDAPI godot_packed_float64_array_append_array(godot_packed_float64_array *p_self, const godot_packed_float64_array *p_array);
@@ -302,6 +317,9 @@ void GDAPI godot_packed_float64_array_destroy(godot_packed_float64_array *p_self
 void GDAPI godot_packed_string_array_new(godot_packed_string_array *r_dest);
 void GDAPI godot_packed_string_array_new_copy(godot_packed_string_array *r_dest, const godot_packed_string_array *p_src);
 void GDAPI godot_packed_string_array_new_with_array(godot_packed_string_array *r_dest, const godot_array *p_a);
+
+const godot_string GDAPI *godot_packed_string_array_ptr(const godot_packed_string_array *p_self);
+godot_string GDAPI *godot_packed_string_array_ptrw(godot_packed_string_array *p_self);
 
 void GDAPI godot_packed_string_array_append(godot_packed_string_array *p_self, const godot_string *p_data);
 
@@ -332,6 +350,9 @@ void GDAPI godot_packed_vector2_array_new(godot_packed_vector2_array *r_dest);
 void GDAPI godot_packed_vector2_array_new_copy(godot_packed_vector2_array *r_dest, const godot_packed_vector2_array *p_src);
 void GDAPI godot_packed_vector2_array_new_with_array(godot_packed_vector2_array *r_dest, const godot_array *p_a);
 
+const godot_vector2 GDAPI *godot_packed_vector2_array_ptr(const godot_packed_vector2_array *p_self);
+godot_vector2 GDAPI *godot_packed_vector2_array_ptrw(godot_packed_vector2_array *p_self);
+
 void GDAPI godot_packed_vector2_array_append(godot_packed_vector2_array *p_self, const godot_vector2 *p_data);
 
 void GDAPI godot_packed_vector2_array_append_array(godot_packed_vector2_array *p_self, const godot_packed_vector2_array *p_array);
@@ -361,6 +382,9 @@ void GDAPI godot_packed_vector3_array_new(godot_packed_vector3_array *r_dest);
 void GDAPI godot_packed_vector3_array_new_copy(godot_packed_vector3_array *r_dest, const godot_packed_vector3_array *p_src);
 void GDAPI godot_packed_vector3_array_new_with_array(godot_packed_vector3_array *r_dest, const godot_array *p_a);
 
+const godot_vector3 GDAPI *godot_packed_vector3_array_ptr(const godot_packed_vector3_array *p_self);
+godot_vector3 GDAPI *godot_packed_vector3_array_ptrw(godot_packed_vector3_array *p_self);
+
 void GDAPI godot_packed_vector3_array_append(godot_packed_vector3_array *p_self, const godot_vector3 *p_data);
 
 void GDAPI godot_packed_vector3_array_append_array(godot_packed_vector3_array *p_self, const godot_packed_vector3_array *p_array);
@@ -389,6 +413,9 @@ void GDAPI godot_packed_vector3_array_destroy(godot_packed_vector3_array *p_self
 void GDAPI godot_packed_color_array_new(godot_packed_color_array *r_dest);
 void GDAPI godot_packed_color_array_new_copy(godot_packed_color_array *r_dest, const godot_packed_color_array *p_src);
 void GDAPI godot_packed_color_array_new_with_array(godot_packed_color_array *r_dest, const godot_array *p_a);
+
+const godot_color GDAPI *godot_packed_color_array_ptr(const godot_packed_color_array *p_self);
+godot_color GDAPI *godot_packed_color_array_ptrw(godot_packed_color_array *p_self);
 
 void GDAPI godot_packed_color_array_append(godot_packed_color_array *p_self, const godot_color *p_data);
 


### PR DESCRIPTION
Adds bindings for the `Packed*Array` read/write direct pointers (in place of `PoolVector` read_access and write_access helpers that were removed in #36311).

Unrelated note: Since Core API binary compatibility was broken by #36311 and some subsequent changes, it might me worth to sort and consolidate all function to the new single "Core API 2.0", instead of maintaining multiple Core API extensions that are incompatible with 3.2 anyway.