### PR TITLE
Do not rely on the existence of `config.py` while detecting modules

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -155,7 +155,7 @@ def detect_modules(at_path):
 
 
 def is_module(path):
-    return os.path.isdir(path) and os.path.exists(path + "/config.py")
+    return os.path.isdir(path) and os.path.exists(os.path.join(path, "SCsub"))
 
 
 def write_modules(module_list):


### PR DESCRIPTION
Throughout the existence of Godot, the build system relied on whether the module has `config.py` created as a way to detect modules.

The existence of `SCsub` is checked instead now. This file is required for all modules, and prevents the build system to leave modules without `config.py` undetected, leading to silently ignoring the module during compilation.

The build system still expects both `SCsub` and `config.py` for a module, but the odds of missing `SCsub` is far less than `config.py` (now, if `config.py` does not exist, scons would still be able to detect the module but also emit an error).

In fact the existence of `config.py` can be made optional, but this is outside of scope for this PR.

Worth cherry-picking to 3.2.
