### PR TITLE
Ignore invalid tablet driver name, when non are available.

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -795,6 +795,9 @@ String OS_Windows::get_current_tablet_driver() const {
 }
 
 void OS_Windows::set_current_tablet_driver(const String &p_driver) {
+	if (get_tablet_driver_count() == 0) {
+		return;
+	}
 	bool found = false;
 	for (int i = 0; i < get_tablet_driver_count(); i++) {
 		if (p_driver == get_tablet_driver_name(i)) {


### PR DESCRIPTION
Ignore invalid tablet driver name, when non are available, e.g. on Windows 7 and 8 without WinTab drivers installed, Windows 8.1+ always have Windows Ink available.

Fixes #39067