### PR TITLE
[3.2] Provide the ability to override the command line arguments

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -454,7 +454,8 @@ public abstract class Godot extends FragmentActivity implements SensorEventListe
 		return deviceInfo.reqGlEsVersion;
 	}
 
-	private String[] getCommandLine() {
+	@CallSuper
+	protected String[] getCommandLine() {
 		InputStream is;
 		try {
 			is = getAssets().open("_cl_");


### PR DESCRIPTION
This is useful for clients of the Godot Android library as it allows them to add or override the command line arguments passed to the engine.

Backport of #39077 