### PR TITLE
Expose `get_char_size()` from Font instead of BitmapFont

### DIFF
--- a/doc/classes/BitmapFont.xml
+++ b/doc/classes/BitmapFont.xml
@@ -65,17 +65,6 @@
 				Creates a BitmapFont from the [code]*.fnt[/code] file at [code]path[/code].
 			</description>
 		</method>
-		<method name="get_char_size" qualifiers="const">
-			<return type="Vector2">
-			</return>
-			<argument index="0" name="char" type="int">
-			</argument>
-			<argument index="1" name="next" type="int" default="0">
-			</argument>
-			<description>
-				Returns the size of a character, optionally taking kerning into account if the next character is provided.
-			</description>
-		</method>
 		<method name="get_kerning_pair" qualifiers="const">
 			<return type="int">
 			</return>

--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -54,6 +54,17 @@
 				Returns the font ascent (number of pixels above the baseline).
 			</description>
 		</method>
+		<method name="get_char_size" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="char" type="int">
+			</argument>
+			<argument index="1" name="next" type="int" default="0">
+			</argument>
+			<description>
+				Returns the size of a character, optionally taking kerning into account if the next character is provided.
+			</description>
+		</method>
 		<method name="get_descent" qualifiers="const">
 			<return type="float">
 			</return>

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -93,6 +93,7 @@ void Font::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_descent"), &Font::get_descent);
 	ClassDB::bind_method(D_METHOD("get_height"), &Font::get_height);
 	ClassDB::bind_method(D_METHOD("is_distance_field_hint"), &Font::is_distance_field_hint);
+	ClassDB::bind_method(D_METHOD("get_char_size", "char", "next"), &Font::get_char_size, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_string_size", "string"), &Font::get_string_size);
 	ClassDB::bind_method(D_METHOD("get_wordwrap_string_size", "string", "width"), &Font::get_wordwrap_string_size);
 	ClassDB::bind_method(D_METHOD("has_outline"), &Font::has_outline);
@@ -595,8 +596,6 @@ void BitmapFont::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_texture_count"), &BitmapFont::get_texture_count);
 	ClassDB::bind_method(D_METHOD("get_texture", "idx"), &BitmapFont::get_texture);
-
-	ClassDB::bind_method(D_METHOD("get_char_size", "char", "next"), &BitmapFont::get_char_size, DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("set_distance_field_hint", "enable"), &BitmapFont::set_distance_field_hint);
 


### PR DESCRIPTION
`get_char_size()` is a public virtual function defined in the `Font`
class. Implementations exist for both `BitmapFont` and `Dynamic Font`.
However, it was only exposed to the GDScript API through the Bitmap
Font, and not for Dynamic Font.

This commit exposes the function through `Font` instead.

Fixes #23967