### PR TITLE
[3.2] Fix parameters passing when emitting signal

### DIFF
--- a/platform/android/plugin/godot_plugin_jni.cpp
+++ b/platform/android/plugin/godot_plugin_jni.cpp
@@ -119,13 +119,15 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeEmitS
 	String signal_name = jstring_to_string(j_signal_name, env);
 
 	int count = env->GetArrayLength(j_signal_params);
-	const Variant *args[count];
+	ERR_FAIL_COND_MSG(count > VARIANT_ARG_MAX, "Maximum argument count exceeded!");
+
+	Variant variant_params[VARIANT_ARG_MAX];
+	const Variant *args[VARIANT_ARG_MAX];
 
 	for (int i = 0; i < count; i++) {
-
 		jobject j_param = env->GetObjectArrayElement(j_signal_params, i);
-		Variant variant = _jobject_to_variant(env, j_param);
-		args[i] = &variant;
+		variant_params[i] = _jobject_to_variant(env, j_param);
+		args[i] = &variant_params[i];
 		env->DeleteLocalRef(j_param);
 	};
 


### PR DESCRIPTION
The issue was caused because we were using variables local to the `for` loop block.

Address [feedback](https://github.com/godotengine/godot/pull/39047#issuecomment-634545849) by @pouleyKetchoupp regarding the use of arrays on stack with dynamic size.

Backport of #39047 and #39080 