### PR TITLE
[3.2] Correct Bullet's default Area angular damp value.

### DIFF
--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -53,7 +53,7 @@ AreaBullet::AreaBullet() :
 		spOv_gravityVec(0, -1, 0),
 		spOv_gravityMag(10),
 		spOv_linearDump(0.1),
-		spOv_angularDump(1),
+		spOv_angularDump(0.1),
 		spOv_priority(0),
 		isScratched(false) {
 


### PR DESCRIPTION
3.2 version of #39085.