### PR TITLE
Fix unsigned integer bug in LocalVector::erase

### DIFF
--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -75,7 +75,7 @@ public:
 	}
 
 	void erase(const T &p_val) {
-		U idx = find(p_val);
+		int64_t idx = find(p_val);
 		if (idx >= 0) {
 			remove(idx);
 		}


### PR DESCRIPTION
`erase()` calls `find()` to get the index of the element to remove, if
any.

https://github.com/godotengine/godot/blob/c2151e18135817c9f926a5a00341016ac77301d4/core/local_vector.h#L77-L81

`find()` returns a signed integer. In particular, it returns -1 if
no element is found. Since `erase()` converts this to an unsigned type, the
wrong element may be erroneously removed from the vector.

Other ways to fix this would involve changing function signatures, so
this seemed to be the least disruptive change.

Fixes #38884