### PR TITLE
Fix: infer type fail on Vect2i Vect3i Rect2i

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1296,10 +1296,16 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 			// math types
 			case VECTOR2:
 				return Vector2();
+			case VECTOR2I:
+				return Vector2i();
 			case RECT2:
 				return Rect2();
+			case RECT2I:
+				return Rect2i();
 			case VECTOR3:
 				return Vector3();
+			case VECTOR3I:
+				return Vector3i();
 			case TRANSFORM2D:
 				return Transform2D();
 			case PLANE:


### PR DESCRIPTION
![vect2i-typefail](https://user-images.githubusercontent.com/41085900/83037457-6da0a700-a059-11ea-8d47-23dffd47b57d.JPG)

reproduce methods
```gdscript
func f()->Vector2i:
    return Vector2i()

var v1 :Vector2i = Vector2i()

var v2 := Vector2i()
```