### PR TITLE
[3.2] Validate that `Use Custom Build` is enabled when `Plugins` are selected

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1900,6 +1900,15 @@ public:
 			}
 		}
 
+		// Ensure that `Use Custom Build` is enabled if a plugin is selected.
+		String enabled_plugins_names = get_plugins_names(get_enabled_plugins(p_preset));
+		bool custom_build_enabled = p_preset->get("custom_template/use_custom_build");
+		if (!enabled_plugins_names.empty() && !custom_build_enabled) {
+			valid = false;
+			err += TTR("\"Use Custom Build\" must be enabled to use the plugins.");
+			err += "\n";
+		}
+
 		r_error = err;
 		return valid;
 	}

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -72,17 +72,12 @@ ext.getGodotPluginsRemoteBinaries = { ->
 /**
  * Parse the project properties for the 'plugins_local_binaries' property and return
  * their binaries for inclusion in the build dependencies.
- *
- * Returns the prebuilt plugins if the 'plugins_local_binaries' property is unavailable.
  */
 ext.getGodotPluginsLocalBinaries = { ->
-    // Set the prebuilt plugins as default. If custom build is enabled,
-    // the 'plugins_local_binaries' will be defined so we can use it instead.
-    Set<String> binDeps = ["libs/plugins/GodotPayment.release.aar"]
+    Set<String> binDeps = []
 
     // Retrieve the list of local plugins binaries.
     if (project.hasProperty("plugins_local_binaries")) {
-        binDeps.clear()
         String pluginsList = project.property("plugins_local_binaries")
         if (pluginsList != null && !pluginsList.trim().isEmpty()) {
             for (String plugin : pluginsList.split(PLUGIN_VALUE_SEPARATOR_REGEX)) {

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -193,4 +193,6 @@ task cleanGodotTemplates(type: Delete) {
     delete("$binDir/android_source.zip")
     delete("$binDir/godot-lib.debug.aar")
     delete("$binDir/godot-lib.release.aar")
+
+    finalizedBy getTasksByName("clean", true)
 }


### PR DESCRIPTION
In addition, remove `GodotPayment` from the default build template.

This follows up from https://github.com/godotengine/godot/pull/39034#issuecomment-634853649.

Backport for #39097
