### PR TITLE
Add fallback icons and make custom ones appear in the recent/favorites list in the "Create New" dialog

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -53,13 +53,15 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 	if (f) {
 		TreeItem *root = recent->create_item();
 
+		String icon_fallback = search_options->has_theme_icon(base_type, "EditorIcons") ? base_type : "Object";
+
 		while (!f->eof_reached()) {
 			String l = f->get_line().strip_edges();
 			String name = l.split(" ")[0];
 			if ((ClassDB::class_exists(name) || ScriptServer::is_global_class(name)) && !_is_class_disabled_by_feature_profile(name)) {
 				TreeItem *ti = recent->create_item(root);
 				ti->set_text(0, l);
-				ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(l, base_type));
+				ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(name, icon_fallback));
 			}
 		}
 
@@ -248,7 +250,8 @@ void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p
 	const String &description = DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description);
 	item->set_tooltip(0, description);
 
-	item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, base_type));
+	String icon_fallback = search_options->has_theme_icon(base_type, "EditorIcons") ? base_type : "Object";
+	item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, icon_fallback));
 
 	p_types[p_type] = item;
 }
@@ -305,9 +308,8 @@ void CreateDialog::_update_search() {
 	EditorData &ed = EditorNode::get_editor_data();
 
 	root->set_text(0, base_type);
-	if (search_options->has_theme_icon(base_type, "EditorIcons")) {
-		root->set_icon(0, search_options->get_theme_icon(base_type, "EditorIcons"));
-	}
+	String base_icon = search_options->has_theme_icon(base_type, "EditorIcons") ? base_type : "Object";
+	root->set_icon(0, search_options->get_theme_icon(base_icon, "EditorIcons"));
 
 	TreeItem *to_select = search_box->get_text() == base_type ? root : nullptr;
 
@@ -393,9 +395,7 @@ void CreateDialog::_update_search() {
 				TreeItem *item = search_options->create_item(ti);
 				item->set_metadata(0, type);
 				item->set_text(0, ct[i].name);
-				if (ct[i].icon.is_valid()) {
-					item->set_icon(0, ct[i].icon);
-				}
+				item->set_icon(0, ct[i].icon.is_valid() ? ct[i].icon : search_options->get_theme_icon(base_icon, "EditorIcons"));
 
 				if (!to_select || ct[i].name == search_box->get_text()) {
 					to_select = item;
@@ -598,16 +598,21 @@ void CreateDialog::_save_favorite_list() {
 
 void CreateDialog::_update_favorite_list() {
 	favorites->clear();
+
 	TreeItem *root = favorites->create_item();
+
+	String icon_fallback = search_options->has_theme_icon(base_type, "EditorIcons") ? base_type : "Object";
+
 	for (int i = 0; i < favorite_list.size(); i++) {
 		String l = favorite_list[i];
 		String name = l.split(" ")[0];
 		if (!((ClassDB::class_exists(name) || ScriptServer::is_global_class(name)) && !_is_class_disabled_by_feature_profile(name))) {
 			continue;
 		}
+
 		TreeItem *ti = favorites->create_item(root);
 		ti->set_text(0, l);
-		ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(l, base_type));
+		ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(name, icon_fallback));
 	}
 	emit_signal("favorites_updated");
 }


### PR DESCRIPTION
- If a item has no icon, fallback to the `Object` icon.
- Fix custom icons from custom classes (`class_name`) not being used in the recent and favorites lists.