### PR TITLE
Fixing destroying a sub_window which activates the wrong window

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -525,6 +525,24 @@ void DisplayServerWindows::delete_sub_window(WindowID p_window) {
 		wintab_WTClose(windows[p_window].wtctx);
 		windows[p_window].wtctx = 0;
 	}
+
+	// we only want this to happen if we close an active/focused window
+	if (GetActiveWindow() == windows[p_window].hWnd) {
+		Map<WindowID, WindowData>::Element *E = windows.back();
+		if (E->key() == p_window) {
+			E = E->prev();
+		}
+
+		WindowID next_active = E->key();
+
+		if (next_active != INVALID_WINDOW_ID) {
+			// we do this before DestroyWindow to prevent the OS to automatically activate another Window
+			SetActiveWindow(windows[next_active].hWnd);
+		} else {
+			WARN_PRINT("No top window found.");
+		}
+	}
+
 	DestroyWindow(windows[p_window].hWnd);
 	windows.erase(p_window);
 }


### PR DESCRIPTION
**Branch**: master
**Platform**: win7 (also tested on win10)
**Fixes**: #37731

**Problem:**
When closing the FileDialog, the wrong window(in this case "Godot Engine - Project Manager") is activated which in turn closes the "Create New Project" window.

This happens because Godot's Dialog and Popup close themselves when their parent gets focused. But this is actually not what's causing the problem.

I think the **underlying problem** and real culprit is:
`SetWindowLongPtr(wd_window.hWnd, GWLP_HWNDPARENT, (LONG_PTR) nullptr);`
and
`SetWindowLongPtr(wd_window.hWnd, GWLP_HWNDPARENT, (LONG_PTR)wd_parent.hWnd);`
located in 
_display_server_windows.cpp_

`SetWindowLongPtr` is used to set the owner of sub_window and is needed to make the windows behave transient. But this seems to mess with the list of recently active windows the OS is keeping. When closing an active window, Windows somehow finds another window to activate. And this fails when `SetWindowLongPtr` was used to set and unset the owner.

This can easily be tested by commenting out both occurrences of `SetWindowLongPtr`.


**How to Fix:**
Go through the list of windows, created by display_server_windows.cpp, and look for the last window we created(the window with the highest WindowID), excluding the window we want to close. Activating this window before closing another window was the simplest fix I could think of.

Before Fix:
![before](https://user-images.githubusercontent.com/39414297/83067114-63d17080-a066-11ea-94b0-6338b4123da2.gif)

After Fix:
![after](https://user-images.githubusercontent.com/39414297/83067154-7055c900-a066-11ea-85c1-81e603c5aeef.gif)


I'm quite sure this is also related to a few other issues with popup menues or closing windows. I will edit or comment later on it.

<i>Bugsquad edit</i>: Fix #37731
