### PR TITLE
Import hints refactoring

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -68,6 +68,10 @@ bool is_symbol(char32_t c) {
 	return c != '_' && ((c >= '!' && c <= '/') || (c >= ':' && c <= '@') || (c >= '[' && c <= '`') || (c >= '{' && c <= '~') || c == '\t' || c == ' ');
 }
 
+bool is_alpha(char32_t c) {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
 bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end) {
 	const String &s = p_s;
 	int beg = CLAMP(p_col, 0, s.length());

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -534,6 +534,7 @@ String RTR(const String &p_text, const String &p_context = "");
 String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
 
 bool is_symbol(char32_t c);
+bool is_alpha(char32_t c);
 bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end);
 
 _FORCE_INLINE_ void sarray_add_str(Vector<String> &arr) {

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -38,7 +38,10 @@
 #include "scene/resources/shape_3d.h"
 #include "scene/resources/skin.h"
 
+class AnimationPlayer;
 class Material;
+class MeshInstance3D;
+class CollisionShape3D;
 
 class EditorSceneImporter : public Reference {
 	GDCLASS(EditorSceneImporter, Reference);
@@ -120,8 +123,52 @@ class ResourceImporterScene : public ResourceImporter {
 		LIGHT_BAKE_LIGHTMAPS
 	};
 
-	void _replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner);
-	void _generate_meshes(Node *p_node, bool p_generate_lods);
+	enum NodeHint {
+		NODE_HINT_NONE,
+		NODE_HINT_NO_IMPORT,
+		NODE_HINT_COLLISION,
+		NODE_HINT_CONVEX_COLLISION,
+		NODE_HINT_COLLISION_ONLY,
+		NODE_HINT_CONVEX_COLLISION_ONLY,
+		NODE_HINT_RIGID,
+		NODE_HINT_NAVMESH,
+		NODE_HINT_VEHICLE,
+		NODE_HINT_WHEEL,
+		NODE_HINT_LAST,
+	};
+
+	enum MaterialHint {
+		MATERIAL_HINT_NONE,
+		MATERIAL_HINT_ALPHA,
+		MATERIAL_HINT_VERTEX_COLOR,
+		MATERIAL_HINT_LAST,
+	};
+
+	struct ParsedNode {
+		String name;
+		NodeHint hint;
+	};
+
+	struct ParsedMaterial {
+		String name;
+		Vector<MaterialHint> hints;
+	};
+
+	static void _replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner);
+	static void _generate_meshes(Node *p_node, bool p_generate_lods);
+
+	static String _import_hint_string(NodeHint p_hint);
+	static String _import_hint_string(MaterialHint p_hint);
+
+	static ParsedNode _get_node_import_hint(String p_name);
+	static ParsedMaterial _get_material_import_hints(const String &p_name);
+
+	static void _gen_shape_list(const Ref<Mesh> &p_mesh, List<Ref<Shape3D>> &r_shape_list, bool p_convex);
+	static void _add_shapes(Node *p_node, List<Ref<Shape3D>> p_shapes, const Transform &p_transform = Transform(), const String &p_basename = String());
+	static CollisionShape3D *_shape_from_empty_meta(Node *p_node);
+
+	static void _fix_materials(MeshInstance3D *p_mesh, LightBakeMode p_light_bake_mode);
+	static void _fix_animations(AnimationPlayer *p_player);
 
 public:
 	static ResourceImporterScene *get_singleton() { return singleton; }


### PR DESCRIPTION
~An implementation of https://github.com/godotengine/godot-proposals/issues/542.~

~This PR improves 3D models import workflow. As described in proposal,  I've added 4 additional import hints:~

~1. `shape`~
~2. `shapeonly`~
~3. `convshape`~
~4. `convshapeonly`~

~Such import hints works like `col`, `colonly`, `convcolonly` and `convcol`, but don't create a StaticBody. See proposal for details.~

~Documentation was also updated: https://github.com/godotengine/godot-docs/pull/3622~

Now contains only refactoring.

Since the `_fix_node` function that is responsible for this is very huge and with a lot of duplicated code - I split it into several helper functions to simplify adding the new hints.

Also node name were parsed for hints in each `if`. I fixed it, now the name parsed only once.

Each object added from the import hints had a hardcoded name in the code (`static_body` for `col` hint, for example). Now the name is determined automatically based on the type of object and respects editor's case settings, closes #35690.

Also I fixed coding style (for example, sometimes variables were not in `snake_case`)

Fixes: https://github.com/godotengine/godot-proposals/issues/542
