### PR TITLE
Remove "erasing" print from Directory.remove (Windows)

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -286,10 +286,6 @@ Error DirAccessWindows::remove(String p_path) {
 
 	p_path = fix_path(p_path);
 
-	printf("erasing %s\n", p_path.utf8().get_data());
-	//WIN32_FILE_ATTRIBUTE_DATA    fileInfo;
-	//DWORD fileAttr = GetFileAttributesExW(p_path.c_str(), GetFileExInfoStandard, &fileInfo);
-
 	DWORD fileAttr;
 
 	fileAttr = GetFileAttributesW(p_path.c_str());


### PR DESCRIPTION
Fixes #39106

Haven't contributed in a while, nice simple bug to fix :)