### PR TITLE
Add color option for img bbcode tag in RichTextLabel to tint images

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -20,8 +20,10 @@
 			</argument>
 			<argument index="2" name="height" type="int" default="0">
 			</argument>
+			<argument index="3" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			</argument>
 			<description>
-				Adds an image's opening and closing tags to the tag stack, optionally providing a [code]width[/code] and [code]height[/code] to resize the image.
+				Adds an image's opening and closing tags to the tag stack, optionally providing a [code]width[/code] and [code]height[/code] to resize the image and a [code]color[/code] to tint the image.
 				If [code]width[/code] or [code]height[/code] is set to 0, the image size will be adjusted in order to keep the original aspect ratio.
 			</description>
 		</method>

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -149,6 +149,7 @@ private:
 	struct ItemImage : public Item {
 		Ref<Texture2D> image;
 		Size2 size;
+		Color color;
 		ItemImage() { type = ITEM_IMAGE; }
 	};
 
@@ -381,6 +382,8 @@ private:
 	bool _find_by_type(Item *p_item, ItemType p_type);
 	void _fetch_item_fx_stack(Item *p_item, Vector<ItemFX *> &r_stack);
 
+	static Color _get_color_from_string(const String &p_color_str, const Color &p_default_color);
+
 	void _update_scroll();
 	void _update_fx(ItemFrame *p_frame, float p_delta_time);
 	void _scroll_changed(double);
@@ -406,7 +409,7 @@ protected:
 public:
 	String get_text();
 	void add_text(const String &p_text);
-	void add_image(const Ref<Texture2D> &p_image, const int p_width = 0, const int p_height = 0);
+	void add_image(const Ref<Texture2D> &p_image, const int p_width = 0, const int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0));
 	void add_newline();
 	bool remove_line(const int p_line);
 	void push_font(const Ref<Font> &p_font);


### PR DESCRIPTION
*edit: changed to add a `color` option in `img` tag instead of a new tag `img-color`.*

Allows `RichTextLabel` to display an image with tint using a new option `color` in `img` tag.

~Allows `RichTextLabel` to display an image with tint using a new bbcode tag `img-color`.~

~It works the same way as the `color` tag, but only affects images. It was added as a separate tag to keep the expected behavior that `color` only affects the font color and images are not affected by color changes by default.~

bbcode = `Text with icon [img width=16]res://icon.png[/img]`
<img src="https://user-images.githubusercontent.com/1075032/83108081-8f347980-a0bf-11ea-9334-8fbad039c37b.png" width="200" />

bbcode = `Text with icon[img width=16 color=#00FF00]res://icon.png[/img]`
<img src="https://user-images.githubusercontent.com/1075032/83108171-b25f2900-a0bf-11ea-998f-051b4d8775fe.png" width="200" />
