### PR TITLE
Impulse report

### DIFF
--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -109,6 +109,7 @@ class Body2DSW : public CollisionObject2DSW {
 		ObjectID collider_instance_id;
 		RID collider;
 		Vector2 collider_velocity_at_pos;
+		const Vector2 *impulse; // pointer to the impulse vector in BodyPair2DSW::Contact
 	};
 
 	Vector<Contact> contacts; //no contacts by default
@@ -163,7 +164,7 @@ public:
 	_FORCE_INLINE_ int get_max_contacts_reported() const { return contacts.size(); }
 
 	_FORCE_INLINE_ bool can_report_contacts() const { return !contacts.empty(); }
-	_FORCE_INLINE_ void add_contact(const Vector2 &p_local_pos, const Vector2 &p_local_normal, real_t p_depth, int p_local_shape, const Vector2 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector2 &p_collider_velocity_at_pos);
+	_FORCE_INLINE_ void add_contact(const Vector2 &p_local_pos, const Vector2 &p_local_normal, real_t p_depth, int p_local_shape, const Vector2 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector2 &p_collider_velocity_at_pos, const Vector2 *p_impulse);
 
 	_FORCE_INLINE_ void add_exception(const RID &p_exception) { exceptions.insert(p_exception); }
 	_FORCE_INLINE_ void remove_exception(const RID &p_exception) { exceptions.erase(p_exception); }
@@ -293,7 +294,7 @@ public:
 
 //add contact inline
 
-void Body2DSW::add_contact(const Vector2 &p_local_pos, const Vector2 &p_local_normal, real_t p_depth, int p_local_shape, const Vector2 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector2 &p_collider_velocity_at_pos) {
+void Body2DSW::add_contact(const Vector2 &p_local_pos, const Vector2 &p_local_normal, real_t p_depth, int p_local_shape, const Vector2 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector2 &p_collider_velocity_at_pos, const Vector2 *p_impulse) {
 	int c_max = contacts.size();
 
 	if (c_max == 0) {
@@ -333,6 +334,7 @@ void Body2DSW::add_contact(const Vector2 &p_local_pos, const Vector2 &p_local_no
 	c[idx].collider_instance_id = p_collider_instance_id;
 	c[idx].collider = p_collider;
 	c[idx].collider_velocity_at_pos = p_collider_velocity_at_pos;
+	c[idx].impulse = p_impulse;
 }
 
 class PhysicsDirectBodyState2DSW : public PhysicsDirectBodyState2D {
@@ -405,6 +407,10 @@ public:
 	virtual Vector2 get_contact_collider_velocity_at_position(int p_contact_idx) const {
 		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, Vector2());
 		return body->contacts[p_contact_idx].collider_velocity_at_pos;
+	}
+	virtual Vector2 get_contact_impulse(int p_contact_idx) const {
+		ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, Vector2());
+		return *(body->contacts[p_contact_idx].impulse);
 	}
 
 	virtual PhysicsDirectSpaceState2D *get_space_state();

--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -53,6 +53,8 @@ void BodyPair2DSW::_contact_added_callback(const Vector2 &p_point_A, const Vecto
 
 	Contact contact;
 
+	contact.acc_impulse_A = Vector2(0.0f, 0.0f);
+	contact.acc_impulse_B = Vector2(0.0f, 0.0f);
 	contact.acc_normal_impulse = 0;
 	contact.acc_bias_impulse = 0;
 	contact.acc_tangent_impulse = 0;
@@ -390,11 +392,11 @@ bool BodyPair2DSW::setup(real_t p_step) {
 
 			if (gather_A) {
 				Vector2 crB(-B->get_angular_velocity() * c.rB.y, B->get_angular_velocity() * c.rB.x);
-				A->add_contact(global_A, -c.normal, depth, shape_A, global_B, shape_B, B->get_instance_id(), B->get_self(), crB + B->get_linear_velocity());
+				A->add_contact(global_A, -c.normal, depth, shape_A, global_B, shape_B, B->get_instance_id(), B->get_self(), crB + B->get_linear_velocity(), &c.acc_impulse_A);
 			}
 			if (gather_B) {
 				Vector2 crA(-A->get_angular_velocity() * c.rA.y, A->get_angular_velocity() * c.rA.x);
-				B->add_contact(global_B, c.normal, depth, shape_B, global_A, shape_A, A->get_instance_id(), A->get_self(), crA + A->get_linear_velocity());
+				B->add_contact(global_B, c.normal, depth, shape_B, global_A, shape_A, A->get_instance_id(), A->get_self(), crA + A->get_linear_velocity(), &c.acc_impulse_B);
 			}
 		}
 
@@ -429,6 +431,8 @@ bool BodyPair2DSW::setup(real_t p_step) {
 
 			A->apply_impulse(c.rA, -P);
 			B->apply_impulse(c.rB, P);
+			c.acc_impulse_A = -P;
+			c.acc_impulse_B = P;
 		}
 
 #endif
@@ -499,6 +503,8 @@ void BodyPair2DSW::solve(real_t p_step) {
 
 		A->apply_impulse(c.rA, -j);
 		B->apply_impulse(c.rB, j);
+		c.acc_impulse_A -= j;
+		c.acc_impulse_B += j;
 	}
 }
 

--- a/servers/physics_2d/body_pair_2d_sw.h
+++ b/servers/physics_2d/body_pair_2d_sw.h
@@ -56,6 +56,8 @@ class BodyPair2DSW : public Constraint2DSW {
 		Vector2 position;
 		Vector2 normal;
 		Vector2 local_A, local_B;
+		Vector2 acc_impulse_A; // accumulated impulse vector applied to body A
+		Vector2 acc_impulse_B; // accumulated impulse vector applieb to body B
 		real_t acc_normal_impulse; // accumulated normal impulse (Pn)
 		real_t acc_tangent_impulse; // accumulated tangent impulse (Pt)
 		real_t acc_bias_impulse; // accumulated normal impulse for position bias (Pnb)

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -104,6 +104,7 @@ void PhysicsDirectBodyState2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_contact_local_position", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_local_position);
 	ClassDB::bind_method(D_METHOD("get_contact_local_normal", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_local_normal);
+	ClassDB::bind_method(D_METHOD("get_contact_impulse", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_impulse);
 	ClassDB::bind_method(D_METHOD("get_contact_local_shape", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_local_shape);
 	ClassDB::bind_method(D_METHOD("get_contact_collider", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_collider);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_position", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_collider_position);

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -74,6 +74,7 @@ public:
 
 	virtual Vector2 get_contact_local_position(int p_contact_idx) const = 0;
 	virtual Vector2 get_contact_local_normal(int p_contact_idx) const = 0;
+	virtual Vector2 get_contact_impulse(int p_contact_idx) const = 0;
 	virtual int get_contact_local_shape(int p_contact_idx) const = 0;
 
 	virtual RID get_contact_collider(int p_contact_idx) const = 0;


### PR DESCRIPTION
Implements [feature request #409](https://github.com/godotengine/godot-proposals/issues/409). The total final impulse applied to the contact is saved in the BodyPair2DSW::contacts structure. By total final impulse, I mean the impulses applied to the contact throughout each solver iteration is summed, so when get_contact_impulse is called, the resulting impulse vector should be the exact impulse that was applied to the contact. Also I added the documentation entry as well