### PR TITLE
Use translated docs in PropertySelector

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -4338,13 +4338,14 @@ String TTR(const String &p_text) {
 }
 
 String DTR(const String &p_text) {
+	// Comes straight from the XML, so remove indentation and any trailing whitespace.
+	const String text = p_text.dedent().strip_edges();
+
 	if (TranslationServer::get_singleton()) {
-		// Comes straight from the XML, so remove indentation and any trailing whitespace.
-		const String text = p_text.dedent().strip_edges();
 		return TranslationServer::get_singleton()->doc_translate(text);
 	}
 
-	return p_text;
+	return text;
 }
 #endif
 

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -984,7 +984,7 @@ void ConnectionsDock::update_tree() {
 					while (F && descr == String()) {
 						for (int i = 0; i < F->get().signals.size(); i++) {
 							if (F->get().signals[i].name == signal_name.operator String()) {
-								descr = DTR(F->get().signals[i].description.strip_edges());
+								descr = DTR(F->get().signals[i].description);
 								break;
 							}
 						}

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1583,9 +1583,9 @@ void EditorInspector::update_tree() {
 					DocData *dd = EditorHelp::get_doc_data();
 					Map<String, DocData::ClassDoc>::Element *E = dd->class_list.find(type2);
 					if (E) {
-						descr = E->get().brief_description;
+						descr = DTR(E->get().brief_description);
 					}
-					class_descr_cache[type2] = DTR(descr);
+					class_descr_cache[type2] = descr;
 				}
 
 				category->set_tooltip(p.name + "::" + (class_descr_cache[type2] == "" ? "" : class_descr_cache[type2]));
@@ -1755,7 +1755,7 @@ void EditorInspector::update_tree() {
 				while (F && descr == String()) {
 					for (int i = 0; i < F->get().properties.size(); i++) {
 						if (F->get().properties[i].name == propname.operator String()) {
-							descr = DTR(F->get().properties[i].description.strip_edges());
+							descr = DTR(F->get().properties[i].description);
 							break;
 						}
 					}
@@ -1765,7 +1765,7 @@ void EditorInspector::update_tree() {
 						// Likely a theme property.
 						for (int i = 0; i < F->get().theme_properties.size(); i++) {
 							if (F->get().theme_properties[i].name == slices[1]) {
-								descr = DTR(F->get().theme_properties[i].description.strip_edges());
+								descr = DTR(F->get().theme_properties[i].description);
 								break;
 							}
 						}

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -357,7 +357,7 @@ void PropertySelector::_item_selected() {
 			if (E) {
 				for (int i = 0; i < E->get().properties.size(); i++) {
 					if (E->get().properties[i].name == name) {
-						text = E->get().properties[i].description;
+						text = DTR(E->get().properties[i].description);
 					}
 				}
 			}
@@ -372,7 +372,7 @@ void PropertySelector::_item_selected() {
 			if (E) {
 				for (int i = 0; i < E->get().methods.size(); i++) {
 					if (E->get().methods[i].name == name) {
-						text = E->get().methods[i].description;
+						text = DTR(E->get().methods[i].description);
 					}
 				}
 			}

--- a/modules/visual_script/visual_script_property_selector.cpp
+++ b/modules/visual_script/visual_script_property_selector.cpp
@@ -447,7 +447,7 @@ void VisualScriptPropertySelector::_item_selected() {
 		if (E) {
 			for (int i = 0; i < E->get().properties.size(); i++) {
 				if (E->get().properties[i].name == name) {
-					text = E->get().properties[i].description;
+					text = DTR(E->get().properties[i].description);
 				}
 			}
 		}
@@ -461,7 +461,7 @@ void VisualScriptPropertySelector::_item_selected() {
 		if (C) {
 			for (int i = 0; i < C->get().methods.size(); i++) {
 				if (C->get().methods[i].name == name) {
-					text = C->get().methods[i].description;
+					text = DTR(C->get().methods[i].description);
 				}
 			}
 		}
@@ -473,7 +473,7 @@ void VisualScriptPropertySelector::_item_selected() {
 		for (int i = 0; i < T->get().methods.size(); i++) {
 			Vector<String> functions = name.rsplit("/", false, 1);
 			if (T->get().methods[i].name == functions[functions.size() - 1]) {
-				text = T->get().methods[i].description;
+				text = DTR(T->get().methods[i].description);
 			}
 		}
 	}
@@ -492,7 +492,7 @@ void VisualScriptPropertySelector::_item_selected() {
 		if (typecast_node.is_valid()) {
 			Map<String, DocData::ClassDoc>::Element *F = dd->class_list.find(typecast_node->get_class_name());
 			if (F) {
-				text = F->get().description;
+				text = DTR(F->get().description);
 			}
 		}
 
@@ -502,7 +502,7 @@ void VisualScriptPropertySelector::_item_selected() {
 			if (F) {
 				for (int i = 0; i < F->get().constants.size(); i++) {
 					if (F->get().constants[i].value.to_int() == int(builtin_node->get_func())) {
-						text = F->get().constants[i].description;
+						text = DTR(F->get().constants[i].description);
 					}
 				}
 			}


### PR DESCRIPTION
And do the dedent and stripping for both translated and
non-translated strings for consistency, and so that we
don't need to do it at the call site.

---

Worked on it while investigating https://github.com/godotengine/godot/pull/37164#issuecomment-635090418 but it does *not* fix that issue.

Follow-up to #37164.