### PR TITLE
[3.2] SCons: use `OrderedDict` to ensure insertion order of modules

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -7,6 +7,7 @@ import glob
 import os
 import pickle
 import sys
+from collections import OrderedDict
 
 # Local
 import methods
@@ -177,7 +178,7 @@ for k in platform_opts.keys():
         opts.Add(o)
 
 # Detect modules.
-modules_detected = {}
+modules_detected = OrderedDict()
 module_search_paths = ["modules"]  # Built-in path.
 
 if ARGUMENTS.get("custom_modules"):
@@ -450,11 +451,11 @@ if selected_platform in platform_list:
     sys.path.remove(tmppath)
     sys.modules.pop('detect')
 
-    modules_enabled = {}
+    modules_enabled = OrderedDict()
     env.module_icons_paths = []
     env.doc_class_path = {}
 
-    for name, path in sorted(modules_detected.items()):
+    for name, path in modules_detected.items():
         if not env["module_" + name + "_enabled"]:
             continue
         sys.path.insert(0, path)

--- a/methods.py
+++ b/methods.py
@@ -2,6 +2,7 @@ import os
 import re
 import glob
 import subprocess
+from collections import OrderedDict
 from compat import iteritems, isbasestring, decode_utf8
 
 
@@ -131,7 +132,7 @@ def parse_cg_file(fname, uniforms, sizes, conditionals):
 
 
 def detect_modules(at_path):
-    module_list = {}  # name : path
+    module_list = OrderedDict()  # name : path
 
     modules_glob = os.path.join(at_path, "*")
     files = glob.glob(modules_glob)


### PR DESCRIPTION
Closes #39117 (CC @lawnjelly ~~to test this~~ thanks for testing!)

The insertion order for dictionaries is only a language feature for Python 3.6/3.7+ implementations, and not prior to that.

This ensures that the engine won't be rebuilt if the order of detected modules changes in any way, as the `OrderedDict` should guarantee insertion order.

This is basically taken from this [SO answer](https://stackoverflow.com/a/39980744/2564620).