### PR TITLE
Travis CI: Use the Xcode 11.5 image for macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
       stage: build
       env: PLATFORM=osx TOOLS=yes TARGET=debug CACHE_NAME=${PLATFORM}-tools-clang EXTRA_ARGS="warnings=extra werror=yes"
       os: osx
-      osx_image: xcode11.3
+      osx_image: xcode11.5
       compiler: clang
       addons:
         homebrew:
@@ -83,7 +83,7 @@ matrix:
 #      stage: build
 #      env: PLATFORM=iphone TOOLS=no TARGET=debug CACHE_NAME=${PLATFORM}-clang
 #      os: osx
-#      osx_image: xcode11.3
+#      osx_image: xcode11.5
 #      compiler: clang
 #      addons:
 #        homebrew:


### PR DESCRIPTION
https://changelog.travis-ci.com/xcode-11-5-gm-released-152058