### PR TITLE
EditorHelpBit: Fix not inheriting editor theme/fonts

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1588,9 +1588,8 @@ void EditorHelpBit::_bind_methods() {
 void EditorHelpBit::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			rich_text->clear();
-			_add_text_to_rt(text, rich_text);
-
+			set_theme(EditorNode::get_singleton()->get_theme_base()->get_theme());
+			set_text(text);
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			rich_text->add_theme_color_override("selection_color", get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
@@ -1603,7 +1602,10 @@ void EditorHelpBit::_notification(int p_what) {
 void EditorHelpBit::set_text(const String &p_text) {
 	text = p_text;
 	rich_text->clear();
+	Ref<Font> doc_font = get_theme_font("doc", "EditorFonts");
+	rich_text->push_font(doc_font);
 	_add_text_to_rt(text, rich_text);
+	rich_text->pop();
 }
 
 EditorHelpBit::EditorHelpBit() {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -815,7 +815,6 @@ void EditorProperty::set_object_and_property(Object *p_object, const StringName 
 Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
 	tooltip_text = p_text;
 	EditorHelpBit *help_bit = memnew(EditorHelpBit);
-	//help_bit->add_theme_style_override("panel", get_theme_stylebox("panel", "TooltipPanel"));
 	help_bit->get_rich_text()->set_fixed_size_to_width(360 * EDSCALE);
 
 	String text;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1525,8 +1525,6 @@ void Viewport::_gui_show_tooltip() {
 		return;
 	}
 
-	Control *rp = which;
-
 	Control *base_tooltip = which->make_custom_tooltip(tooltip);
 
 	if (!base_tooltip) {
@@ -1545,7 +1543,7 @@ void Viewport::_gui_show_tooltip() {
 
 	gui.tooltip_popup = panel;
 
-	rp->add_child(gui.tooltip_popup);
+	which->add_child(gui.tooltip_popup);
 
 	//if (gui.tooltip) // Avoids crash when rapidly switching controls.
 	//	gui.tooltip_popup->set_scale(gui.tooltip->get_global_transform().get_scale());


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/pull/37164#issuecomment-635090418.
_Bugsquad edit:_ Fixes #37676.

![Screenshot_20200528_162156](https://user-images.githubusercontent.com/4701338/83153546-616f2500-a0ff-11ea-8487-255980e5ad1b.png)

It seems to point at a bigger theme propagation issue though.
I'd expect that controls added as children to editor node should inherit the editor theme, but this doesn't seem to happen here. `EditorHelpBit` is a custom tooltip so I tried to make sure it reuses the theme of its parent control, but that didn't seem to work:
```diff
diff --git a/scene/main/viewport.cpp b/scene/main/viewport.cpp
index 23b559d3ec..ef66c11475 100644
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1539,6 +1539,8 @@ void Viewport::_gui_show_tooltip() {
        panel->set_transient(false);
        panel->set_flag(Window::FLAG_NO_FOCUS, true);
        panel->set_wrap_controls(true);
+       // Use same theme as parent control.
+       panel->set_theme(which->get_theme());
        panel->add_child(base_tooltip);
 
        gui.tooltip_popup = panel;
```