### PR TITLE
Disable antialiasing on the DynamicFont outline as well when requested

### DIFF
--- a/doc/classes/DynamicFontData.xml
+++ b/doc/classes/DynamicFontData.xml
@@ -12,7 +12,7 @@
 	</methods>
 	<members>
 		<member name="antialiased" type="bool" setter="set_antialiased" getter="is_antialiased" default="true">
-			If [code]true[/code], the font is rendered with anti-aliasing.
+			If [code]true[/code], the font is rendered with anti-aliasing. This property applies both to the main font and its outline (if it has one).
 		</member>
 		<member name="font_path" type="String" setter="set_font_path" getter="get_font_path" default="&quot;&quot;">
 			The path to the vector font file.

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -567,7 +567,7 @@ DynamicFontAtSize::Character DynamicFontAtSize::_make_outline_char(CharType p_ch
 	if (FT_Glyph_Stroke(&glyph, stroker, 1) != 0) {
 		goto cleanup_glyph;
 	}
-	if (FT_Glyph_To_Bitmap(&glyph, FT_RENDER_MODE_NORMAL, nullptr, 1) != 0) {
+	if (FT_Glyph_To_Bitmap(&glyph, font->antialiased ? FT_RENDER_MODE_NORMAL : FT_RENDER_MODE_MONO, nullptr, 1) != 0) {
 		goto cleanup_glyph;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/943.

## Preview

***Top:** not antialiased*
***Bottom:** antialiased*

*Pay attention to the font outline as well.*

![Not antialiased vs antialiased](https://user-images.githubusercontent.com/180032/83190325-8b8e0a80-a132-11ea-9b4c-6891ea5653e7.png)

[test_font_outline.zip](https://github.com/godotengine/godot/files/4698066/test_font_outline.zip)