### PR TITLE
Respect 'mesh compression' editor import option in Assimp and glTF importers

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -951,6 +951,9 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 	if (!state.json.has("meshes"))
 		return OK;
 
+	bool compress_vert_data = state.import_flags & IMPORT_USE_COMPRESSION;
+	uint32_t mesh_flags = compress_vert_data ? Mesh::ARRAY_COMPRESS_DEFAULT : 0;
+
 	Array meshes = state.json["meshes"];
 	for (GLTFMeshIndex i = 0; i < meshes.size(); i++) {
 
@@ -1207,7 +1210,7 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 			}
 
 			//just add it
-			mesh.mesh->add_surface_from_arrays(primitive, array, morphs);
+			mesh.mesh->add_surface_from_arrays(primitive, array, morphs, mesh_flags);
 
 			if (p.has("material")) {
 				const int material = p["material"];
@@ -2987,6 +2990,7 @@ Node *EditorSceneImporterGLTF::import_scene(const String &p_path, uint32_t p_fla
 
 	String version = asset["version"];
 
+	state.import_flags = p_flags;
 	state.major_version = version.get_slice(".", 0).to_int();
 	state.minor_version = version.get_slice(".", 1).to_int();
 	state.use_named_skin_binds = p_flags & IMPORT_USE_NAMED_SKIN_BINDS;

--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -325,6 +325,9 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 		Map<GLTFNodeIndex, Node *> scene_nodes;
 
+		// EditorSceneImporter::ImportFlags
+		uint32_t import_flags;
+
 		~GLTFState() {
 			for (int i = 0; i < nodes.size(); i++) {
 				memdelete(nodes[i]);

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -37,7 +37,6 @@
 #include "scene/resources/shape.h"
 
 class Material;
-
 class EditorSceneImporter : public Reference {
 
 	GDCLASS(EditorSceneImporter, Reference);

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -308,6 +308,7 @@ EditorSceneImporterAssimp::_generate_scene(const String &p_path, aiScene *scene,
 	state.assimp_scene = scene;
 	state.max_bone_weights = p_max_bone_weights;
 	state.animation_player = NULL;
+	state.import_flags = p_flags;
 
 	// populate light map
 	for (unsigned int l = 0; l < scene->mNumLights; l++) {
@@ -848,6 +849,8 @@ EditorSceneImporterAssimp::_generate_mesh_from_surface_indices(ImportState &stat
 	Ref<ArrayMesh> mesh;
 	mesh.instance();
 	bool has_uvs = false;
+	bool compress_vert_data = state.import_flags & IMPORT_USE_COMPRESSION;
+	uint32_t mesh_flags = compress_vert_data ? Mesh::ARRAY_COMPRESS_DEFAULT : 0;
 
 	Map<String, uint32_t> morph_mesh_string_lookup;
 
@@ -1295,7 +1298,7 @@ EditorSceneImporterAssimp::_generate_mesh_from_surface_indices(ImportState &stat
 
 			morphs[j] = array_copy;
 		}
-		mesh->add_surface_from_arrays(primitive, array_mesh, morphs);
+		mesh->add_surface_from_arrays(primitive, array_mesh, morphs, mesh_flags);
 		mesh->surface_set_material(i, mat);
 		mesh->surface_set_name(i, AssimpUtils::get_assimp_string(ai_mesh->mName));
 	}

--- a/modules/assimp/import_state.h
+++ b/modules/assimp/import_state.h
@@ -88,6 +88,9 @@ struct ImportState {
 	// this means we can detect
 	// what bones are for other armatures
 	List<aiBone *> bone_stack;
+
+	// EditorSceneImporter::ImportFlags
+	uint32_t import_flags;
 };
 
 struct AssimpImageData {


### PR DESCRIPTION
The mesh compression option is ignored by Assimp and glTF importers.  This results in ARRAY_COMPRESS_DEFAULT used as default, which includes the ARRAY_COMPRESS_NORMAL flag.  This quantization results in reflection artifacts (visible stair stepping) in models without normal maps.  (Perhaps with normal maps too).  This trade-off isn't bad for many cases, but in my case the rendered result was not acceptable.  The option is respected with OBJ, but I'd prefer to use FBX or glTF.


