### PR TITLE
SCons: Allow to read `custom_modules` option via a file

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -180,12 +180,16 @@ for k in platform_opts.keys():
     for o in opt_list:
         opts.Add(o)
 
+# Update the environment now as the "custom_modules" option may be
+# defined in a file rather than specified via the command line.
+opts.Update(env_base)
+
 # Detect modules.
 modules_detected = {}
 module_search_paths = ["modules"]  # Built-in path.
 
-if ARGUMENTS.get("custom_modules"):
-    paths = ARGUMENTS.get("custom_modules").split(",")
+if env_base["custom_modules"]:
+    paths = env_base["custom_modules"].split(",")
     for p in paths:
         try:
             module_search_paths.append(methods.convert_custom_modules_path(p))
@@ -216,8 +220,9 @@ for name, path in modules_detected.items():
 
 methods.write_modules(modules_detected)
 
-opts.Update(env_base)  # update environment
-Help(opts.GenerateHelpText(env_base))  # generate help
+# Update the environment again after all the module options are added.
+opts.Update(env_base)
+Help(opts.GenerateHelpText(env_base))
 
 # add default include paths
 


### PR DESCRIPTION
This is mainly a continuation of the feature introduced in #36922, specifically https://github.com/godotengine/godot/pull/36922#discussion_r429917998, and makes use of #38821.

The `custom_modules` option was only read via the command line by fetching `ARGUMENTS` dictionary directly.

Instead, the option's value can now be read via any existing configuration files (`custom.py`) as well as command line, while also updating the environment.

## Use case

Conditionally compile modules if on 3.2 (since most of the existing modules in existence are still exclusively 3.x compatible), while preventing the incompatibilities and build errors whenever you need to switch to and compile the `master` branch for development purposes. The `custom.py` may look like so in this case:

```python
# custom.py

import version

if version.major == 3:
    custom_modules = "/path/to/modules/which/are/3.2/compatible"
elif version.major == 4:
    pass # There are no modules for 4.0 yet, silly!
```

---

The reason why I haven't provided this feature before because I wasn't really sure whether the solution was hacky, because you have to update the environment twice in the main `SConstruct`: once after `custom_modules` option itself is added, and once after adding all module options detected from paths provided by `custom_modules`!..

Anyways, I've actually figured there's no interface to fetch the option values directly without updating everything, but this actually has astronomically negligible performance impact (according to my `time` measurements), if at all.

The change can be safely cherry-picked to 3.2 (and doing so would actually makes sense for the use case above).
