### PR TITLE
Do not probe joypads if DirectInput cannot be initialized.

### DIFF
--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -67,13 +67,16 @@ JoypadWindows::JoypadWindows(HWND *hwnd) {
 	for (int i = 0; i < JOYPADS_MAX; i++)
 		attached_joypads[i] = false;
 
-	HRESULT result;
-	result = DirectInput8Create(GetModuleHandle(nullptr), DIRECTINPUT_VERSION, IID_IDirectInput8, (void **)&dinput, nullptr);
-	if (FAILED(result)) {
-		printf("Couldn't initialize DirectInput: %ld\n", result);
-		printf("Rebooting your PC may solve this issue.\n");
+	HRESULT result = DirectInput8Create(GetModuleHandle(nullptr), DIRECTINPUT_VERSION, IID_IDirectInput8, (void **)&dinput, nullptr);
+	if (result == DI_OK) {
+		probe_joypads();
+	} else {
+		ERR_PRINT("Couldn't initialize DirectInput. Error: " + itos(result));
+		if (result == DIERR_OUTOFMEMORY) {
+			ERR_PRINT("The Windows DirectInput subsystem could not allocate sufficient memory.");
+			ERR_PRINT("Rebooting your PC may solve this issue.");
+		}
 	}
-	probe_joypads();
 }
 
 JoypadWindows::~JoypadWindows() {


### PR DESCRIPTION
In response to this [comment](https://github.com/godotengine/godot/pull/39116#issuecomment-635216655). This will prevent Godot from crashing, informs the user that the problem lies with Windows (if it does), and suggests rebooting to solve the problem. The only impact on Godot should be that the joypads are not available.

Note: According to the [documentation](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ee416756(v=vs.85)) `DirectInput8Create` can return four possible errors:
- `DIERR_BETADIRECTINPUTVERSION`: The application was written for an unsupported prerelease version of DirectInput. (I wouldn't expect this to apply to Godot.)
- `DIERR_INVALIDPARAM`: An invalid parameter was passed to the returning function, or the object was not in a state that permitted the function to be called. (If this is the error, then Godot needs to be fixed.)
- `DIERR_OLDDIRECTINPUTVERSION`: The application requires a newer version of DirectInput. (This would suggest that the user's PC is more than 10 years old!)
- `DIERR_OUTOFMEMORY`: The DirectInput subsystem could not allocate sufficient memory to complete the call. (I suspect this is the error that is being returned, which would explain why rebooting helps.)

*Bugsquad edit:* Fully closes #36662.