### PR TITLE
Fix popup closing when parent window is focused related issues.

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -51,7 +51,7 @@ void AcceptDialog::_input_from_window(const Ref<InputEvent> &p_event) {
 }
 
 void AcceptDialog::_parent_focused() {
-	_cancel_pressed();
+	//_cancel_pressed();
 }
 
 void AcceptDialog::_notification(int p_what) {


### PR DESCRIPTION
I know this is just avoiding a bug but it fixes #37732, #37731 and #37401(part 3).
Possibly more.

Initially, I thought this behaviour change would be bad. But quite a few applications don't close popups when the parent is focused.
Some like Windows Explorer(explorer.exe) just focus parent while hiding the popup(eg, shift+delete; permanent file deletion confirmation popup) behind it(but they also let popup windows be independent windows).
Some like Firefox doesn't let the user interact with the parent window till popup is closed(eg, file upload popup, close multiple tab popup, etc.).