### PR TITLE
Grabbing focus on ProjectList after clicking an item.

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -916,6 +916,8 @@ public:
 		icon = nullptr;
 		icon_needs_reload = true;
 		hover = false;
+
+		set_focus_mode(FocusMode::FOCUS_ALL);
 	}
 
 	void set_is_favorite(bool fav) {
@@ -1737,6 +1739,10 @@ void ProjectList::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
 		} else {
 			_last_clicked = clicked_project.project_key;
 			select_project(clicked_index);
+		}
+
+		if (_selected_project_keys.has(clicked_project.project_key)) {
+			clicked_project.control->grab_focus();
 		}
 
 		emit_signal(SIGNAL_SELECTION_CHANGED);


### PR DESCRIPTION
The fix is local, in ProjectManager itself (not modyfing line_edit as it was introduced in #37281).

It works like: clicking on an item and then pressing ENTER.

Unfortunatelly - pressing Tab key in ProjectManager is kinda messed up, focus is transmitted kinda random - but that's not introduced/fixed by this PR.

Fixes: #39012