### PR TITLE
Respect 'mesh compression' editor import option in Assimp and glTF importers [master]

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -952,6 +952,9 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 		return OK;
 	}
 
+	bool compress_vert_data = state.import_flags & IMPORT_USE_COMPRESSION;
+	uint32_t mesh_flags = compress_vert_data ? Mesh::ARRAY_COMPRESS_DEFAULT : 0;
+
 	Array meshes = state.json["meshes"];
 	for (GLTFMeshIndex i = 0; i < meshes.size(); i++) {
 		print_verbose("glTF: Parsing mesh: " + itos(i));
@@ -1206,7 +1209,7 @@ Error EditorSceneImporterGLTF::_parse_meshes(GLTFState &state) {
 			}
 
 			//just add it
-			mesh.mesh->add_surface_from_arrays(primitive, array, morphs);
+			mesh.mesh->add_surface_from_arrays(primitive, array, morphs, Dictionary(), mesh_flags);
 
 			if (p.has("material")) {
 				const int material = p["material"];
@@ -2951,6 +2954,7 @@ Node *EditorSceneImporterGLTF::import_scene(const String &p_path, uint32_t p_fla
 
 	String version = asset["version"];
 
+	state.import_flags = p_flags;
 	state.major_version = version.get_slice(".", 0).to_int();
 	state.minor_version = version.get_slice(".", 1).to_int();
 	state.use_named_skin_binds = p_flags & IMPORT_USE_NAMED_SKIN_BINDS;

--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -279,6 +279,9 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 		Map<GLTFNodeIndex, Node *> scene_nodes;
 
+		// EditorSceneImporter::ImportFlags
+		uint32_t import_flags;
+
 		~GLTFState() {
 			for (int i = 0; i < nodes.size(); i++) {
 				memdelete(nodes[i]);

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -298,6 +298,7 @@ EditorSceneImporterAssimp::_generate_scene(const String &p_path, aiScene *scene,
 	state.assimp_scene = scene;
 	state.max_bone_weights = p_max_bone_weights;
 	state.animation_player = nullptr;
+	state.import_flags = p_flags;
 
 	// populate light map
 	for (unsigned int l = 0; l < scene->mNumLights; l++) {
@@ -829,6 +830,8 @@ EditorSceneImporterAssimp::_generate_mesh_from_surface_indices(ImportState &stat
 	Ref<ArrayMesh> mesh;
 	mesh.instance();
 	bool has_uvs = false;
+	bool compress_vert_data = state.import_flags & IMPORT_USE_COMPRESSION;
+	uint32_t mesh_flags = compress_vert_data ? Mesh::ARRAY_COMPRESS_DEFAULT : 0;
 
 	Map<String, uint32_t> morph_mesh_string_lookup;
 
@@ -1266,7 +1269,7 @@ EditorSceneImporterAssimp::_generate_mesh_from_surface_indices(ImportState &stat
 
 			morphs[j] = array_copy;
 		}
-		mesh->add_surface_from_arrays(primitive, array_mesh, morphs);
+		mesh->add_surface_from_arrays(primitive, array_mesh, morphs, Dictionary(), mesh_flags);
 		mesh->surface_set_material(i, mat);
 		mesh->surface_set_name(i, AssimpUtils::get_assimp_string(ai_mesh->mName));
 	}

--- a/modules/assimp/import_state.h
+++ b/modules/assimp/import_state.h
@@ -87,6 +87,9 @@ struct ImportState {
 	// this means we can detect
 	// what bones are for other armatures
 	List<aiBone *> bone_stack;
+
+	// EditorSceneImporter::ImportFlags
+	uint32_t import_flags;
 };
 
 struct AssimpImageData {


### PR DESCRIPTION
This is the master branch version of this 3.2 targeted PR https://github.com/godotengine/godot/pull/39134

While the 3.2 patch applied cleaning.  Due to the Ubuntu setup on my local dev machine causing build issues, I've not been able to verify the change.  I was able to verify against 3.1 and 3.2.

The mesh compression option is ignored by Assimp and glTF importers. This results in ARRAY_COMPRESS_DEFAULT used as default, which includes the ARRAY_COMPRESS_NORMAL flag. This quantization results in reflection artifacts (visible stair stepping) in models without normal maps. (Perhaps with normal maps too). This trade-off isn't bad for many cases, but in my case the rendered result was not acceptable. The option is respected with OBJ, but I'd prefer to use FBX or glTF.