### PR TITLE
NodePath export hint

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -418,7 +418,26 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	if (valid_types.size()) {
 		bool valid = false;
 		for (int i = 0; i < valid_types.size(); i++) {
-			if (p_node->is_class(valid_types[i])) {
+			String type = valid_types[i];
+			if (ScriptServer::is_global_class(type)) {
+				ScriptInstance *script_inst = p_node->get_script_instance();
+				if (script_inst != nullptr) {
+					Ref<Script> script = script_inst->get_script();
+					String path = ScriptServer::get_global_class_path(type);
+
+					while (script != nullptr) {
+						if (script->get_path() == path) {
+							valid = true;
+							break;
+						}
+						script = script->get_base_script();
+					}
+					if (valid) {
+						break;
+					}
+				}
+
+			} else if (p_node->is_class(type)) {
 				valid = true;
 				break;
 			}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4580,7 +4580,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 								case Variant::NODE_PATH: {
 									if (tokenizer->get_token() != GDScriptTokenizer::TK_IDENTIFIER) {
 										current_export = PropertyInfo();
-										_set_error("Hint expects a Node Type. (e.g. Control or Sprite2D)");
+										_set_error("Hint expects a Node Type. (e.g. Control or Sprite)");
 										return;
 									}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4577,6 +4577,38 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 									_ADVANCE_AND_CONSUME_NEWLINES;
 
 								} break;
+								case Variant::NODE_PATH: {
+									if (tokenizer->get_token() != GDScriptTokenizer::TK_IDENTIFIER) {
+										current_export = PropertyInfo();
+										_set_error("Hint expects a Node Type. (e.g. Control or Sprite2D)");
+										return;
+									}
+
+									String identifier = tokenizer->get_token_identifier();
+
+									if (!ClassDB::class_exists(identifier) && !ScriptServer::is_global_class(identifier)) {
+										current_export = PropertyInfo();
+										_set_error(vformat("Node Type \"%s\" doesn't exist", identifier));
+										return;
+									}
+
+									String class_type = identifier;
+									if (ScriptServer::is_global_class(identifier)) {
+										class_type = ScriptServer::get_global_class_native_base(identifier);
+									}
+
+									if (!ClassDB::is_parent_class(class_type, "Node")) {
+										current_export = PropertyInfo();
+										_set_error(vformat("\"%s\" does not inherit from Node", identifier));
+										return;
+									}
+
+									current_export.hint_string = identifier;
+									current_export.hint = PROPERTY_HINT_NODE_PATH_VALID_TYPES;
+
+									_ADVANCE_AND_CONSUME_NEWLINES;
+
+								} break;
 								default: {
 
 									current_export = PropertyInfo();


### PR DESCRIPTION
`export(NodePath, Button) var my_node_path`
Makes only Button (and its subclasses) selectable in the 'Select a Node' dialog window in the editor
![image](https://user-images.githubusercontent.com/58010307/83309412-7afc9380-a209-11ea-9a14-8d3e304f1d3b.png)


this also works for global classes
```
#Inventory.gd
extends Node
class_name Inventory

#...
```
```
#Player.gd
#...

export(NodePath, Inventory) var inventory_path

#...
```
![image](https://user-images.githubusercontent.com/58010307/83309372-615b4c00-a209-11ea-865d-8238434326d1.png)

