### PR TITLE
Fix building mono release templates

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2688,7 +2688,9 @@ bool CSharpScript::_get_member_export(IMonoClassMember *p_member, bool p_inspect
 		return true;
 	}
 
+#ifdef TOOLS_ENABLED
 	MonoObject *attr = p_member->get_attribute(CACHED_CLASS(ExportAttribute));
+#endif
 
 	PropertyHint hint = PROPERTY_HINT_NONE;
 	String hint_string;

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -422,10 +422,10 @@ void GDMono::initialize_load_assemblies() {
 #if defined(TOOLS_ENABLED)
 	bool tool_assemblies_loaded = _load_tools_assemblies();
 	CRASH_COND_MSG(!tool_assemblies_loaded, "Mono: Failed to load '" TOOLS_ASM_NAME "' assemblies.");
-#endif
 
 	if (Main::is_project_manager())
 		return;
+#endif
 
 	// Load the project's main assembly. This doesn't necessarily need to succeed.
 	// The game may not be using .NET at all, or if the project does use .NET and


### PR DESCRIPTION
Fixes undecleared variable `Main` and unused variable `*attr` when compiling mono release templates.
<details>

```
➜  godot-me git:(master) ✗ scons p=linuxbsd target=debug tools=no module_mono_enabled=yes -j17 CXX=clang++-9 CC=clang-9  CCFLAGS="-Wno-inconsistent-missing-override"
scons: Reading SConscript files ...
Enabling ALSA
Enabling PulseAudio
Mono root directory not found. Using pkg-config instead
Checking for C header file mntent.h... (cached) yes
scons: done reading SConscript files.
scons: Building targets ...
[ 38%] Compiling ==> modules/mono/csharp_script.cpp
[ 39%] Compiling ==> modules/mono/mono_gd/gd_mono.cpp
[ 39%] Compiling ==> modules/mono/mono_gd/gd_mono_method.cpp
[ 39%] Compiling ==> modules/mono/mono_gd/gd_mono_property.cpp
[ 39%] Compiling ==> modules/mono/mono_gd/gd_mono_utils.cpp
[ 39%] Compiling ==> modules/mono/mono_gd/managed_type.cpp
[ 39%] Compiling ==> modules/mono/utils/mono_reg_utils.cpp
[ 39%] Compiling ==> modules/mono/utils/osx_utils.cpp
[ 39%] Compiling ==> modules/mono/utils/path_utils.cpp
[ 39%] Compiling ==> modules/mono/utils/string_utils.cpp
[ 40%] Compiling ==> modules/mono/mono_gd/support/android_support.cpp
[ 40%] Compiling ==> modules/mobile_vr/mobile_vr_interface.cpp
[ 40%] Compiling ==> modules/mobile_vr/register_types.cpp
[ 40%] Compiling ==> thirdparty/mbedtls/library/aes.c
[ 40%] Compiling ==> thirdparty/mbedtls/library/aesni.c
[ 40%] Compiling ==> thirdparty/mbedtls/library/arc4.c
[ 40%] Compiling ==> thirdparty/mbedtls/library/aria.c
[ 40%] Compiling ==> thirdparty/mbedtls/library/asn1parse.c
[ 40%] Compiling ==> thirdparty/mbedtls/library/asn1write.c
[ 40%] Compiling ==> thirdparty/mbedtls/library/base64.c
[ 40%] Compiling ==> thirdparty/mbedtls/library/bignum.c
[ 40%] Compiling ==> thirdparty/mbedtls/library/blowfish.c
[ 40%] Compiling ==> thirdparty/mbedtls/library/camellia.c
[ 40%] Compiling ==> thirdparty/mbedtls/library/ccm.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/certs.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/chacha20.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/chachapoly.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/cipher.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/cipher_wrap.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/cmac.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/ctr_drbg.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/debug.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/des.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/dhm.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/ecdh.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/ecdsa.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/ecjpake.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/ecp.c
[ 41%] Compiling ==> thirdparty/mbedtls/library/ecp_curves.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/entropy.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/entropy_poll.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/error.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/gcm.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/havege.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/hkdf.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/hmac_drbg.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/md2.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/md4.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/md5.c
modules/mono/mono_gd/gd_mono.cpp:427:6: error: use of undeclared identifier 'Main'
        if (Main::is_project_manager())
            ^
[ 42%] Compiling ==> thirdparty/mbedtls/library/md.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/md_wrap.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/memory_buffer_alloc.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/net_sockets.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/nist_kw.c
[ 42%] modules/mono/csharp_script.cpp:2691:14: error: unused variable 'attr' [-Werror,-Wunused-variable]
        MonoObject *attr = p_member->get_attribute(CACHED_CLASS(ExportAttribute));
                    ^
Compiling ==> thirdparty/mbedtls/library/oid.c
[ 42%] Compiling ==> thirdparty/mbedtls/library/padlock.c
[ 43%] Compiling ==> thirdparty/mbedtls/library/pem.c
[ 43%] Compiling ==> thirdparty/mbedtls/library/pk.c
1 error generated.
[ 43%] Compiling ==> thirdparty/mbedtls/library/pkcs11.c
[ 43%] Compiling ==> thirdparty/mbedtls/library/pkcs12.c
[ 43%] Compiling ==> thirdparty/mbedtls/library/pkcs5.c
1 error generated.
[ 43%] Compiling ==> thirdparty/mbedtls/library/pkparse.c
scons: *** [modules/mono/mono_gd/gd_mono.linuxbsd.debug.64.llvm.o] Error 1
scons: *** [modules/mono/csharp_script.linuxbsd.debug.64.llvm.o] Error 1
scons: building terminated because of errors.

```
</details>

NOTE: i'm using `"-Wno-inconsistent-missing-override"` as clang would complain.