### PR TITLE
3.2 Light2D shadow mask construction fix

### DIFF
--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -665,7 +665,7 @@ public:
 			item_mask = 1;
 			scale = 1.0;
 			energy = 1.0;
-			item_shadow_mask = -1;
+			item_shadow_mask = 1;
 			mode = VS::CANVAS_LIGHT_MODE_ADD;
 			texture_cache = NULL;
 			next_ptr = NULL;


### PR DESCRIPTION
When using the default setting (layer 1 set only) nothing is stored in the tscn file for a Light2D, hence it relies on the value in the constructor.

The problem is the constructed value is 1 in Light2D, and -1 in RasterizerCanvas::Light. -1 results in all bits being set so all occluders are shown, rather than just those in layer 1.

This PR changes Rasterizer::Canvas constructor to set to 1. An alternative is to have -1 as the value for layer 1 throughout.

### Overview
I've now checked this with reduz and although we aren't sure why it was originally -1, it sounds as though changing this to 1 is correct.
The -1 I traced back to 09489e3a78de39bb4d8690f3c65f8a5e7a56a95e in 2015.

### Notes
* This is a breaking change. Current behaviour is nonsense, but fixing this may require slight tweaks to some projects (although it may be that hardly anyone is currently using this because it is broken).
* Same changes may be needed in 4.x.

Fixes #39133.