### PR TITLE
Add dinput nullptr checks.

### DIFF
--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -76,12 +76,16 @@ JoypadWindows::JoypadWindows(HWND *hwnd) {
 			ERR_PRINT("The Windows DirectInput subsystem could not allocate sufficient memory.");
 			ERR_PRINT("Rebooting your PC may solve this issue.");
 		}
+		// Ensure dinput is still a nullptr.
+		dinput = nullptr;
 	}
 }
 
 JoypadWindows::~JoypadWindows() {
 	close_joypad();
-	dinput->Release();
+	if (dinput) {
+		dinput->Release();
+	}
 	unload_xinput();
 }
 
@@ -139,6 +143,7 @@ bool JoypadWindows::is_xinput_device(const GUID *p_guid) {
 }
 
 bool JoypadWindows::setup_dinput_joypad(const DIDEVICEINSTANCE *instance) {
+	ERR_FAIL_NULL_V_MSG(dinput, false, "DirectInput not initialized. Rebooting your PC may solve this issue.");
 	HRESULT hr;
 	int num = input->get_unused_joy_id();
 
@@ -270,6 +275,7 @@ void JoypadWindows::close_joypad(int id) {
 }
 
 void JoypadWindows::probe_joypads() {
+	ERR_FAIL_NULL_MSG(dinput, "DirectInput not initialized. Rebooting your PC may solve this issue.");
 	DWORD dwResult;
 	for (DWORD i = 0; i < XUSER_MAX_COUNT; i++) {
 		ZeroMemory(&x_joypads[i].state, sizeof(XINPUT_STATE));


### PR DESCRIPTION
#39143 prevents Godot from crashing when starting, but any subsequent attempts to use the joypads will currently also cause a crash; including when closing Godot. This PR prevents that and tells the user to try rebooting their PC when attempting to attach a joypad.