### PR TITLE
Fixes the right and center alignment bug of rich text label

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -256,6 +256,11 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 			lh = line < l.height_caches.size() ? l.height_caches[line] : 1;                                                                                     \
 			line_ascent = line < l.ascent_caches.size() ? l.ascent_caches[line] : 1;                                                                            \
 			line_descent = line < l.descent_caches.size() ? l.descent_caches[line] : 1;                                                                         \
+			if (p_mode == PROCESS_DRAW) {                                                                                                                       \
+				if (line < l.offset_caches.size()) {                                                                                                            \
+					wofs = l.offset_caches[line];                                                                                                               \
+				}                                                                                                                                               \
+			}                                                                                                                                                   \
 		}                                                                                                                                                       \
 		if (p_mode == PROCESS_POINTER && r_click_item && p_click_pos.y >= p_ofs.y + y && p_click_pos.y <= p_ofs.y + y + lh && p_click_pos.x < p_ofs.x + wofs) { \
 			if (r_outside)                                                                                                                                      \


### PR DESCRIPTION
Fixes #38846 
**Bug**:- `[right]` and `[center]` alignment tags of BBCode in RichTextLabel were not aligning properly like they were supposed to, and the text would overlap when the label was resized.
**Reason**:- Offset cache of the lines was not getting updated.

I've used center alignment for demonstration.
**Before the fix**:-
![Godot Engine - RichTextLabel Overlap Bug - Main Scene tscn (_) 2020-05-30 14-10-31](https://user-images.githubusercontent.com/41969735/83325290-d7eb5e80-a288-11ea-95c6-87181fbb7811.gif)

**After the fix**:-
![Godot Engine - RichTextLabel Overlap Bug - Main Scene tscn (_) 2020-05-30 14-06-08_Trim](https://user-images.githubusercontent.com/41969735/83324910-f0a64500-a285-11ea-90d6-da8aadc53fa3.gif)
