### PR TITLE
Activate emscripten with no-embedded option.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ install:
   - if [ "$PLATFORM" = "javascript" ]; then
       git clone --depth 1 "https://github.com/emscripten-core/emsdk.git";
       ./emsdk/emsdk install latest;
-      ./emsdk/emsdk activate latest;
+      ./emsdk/emsdk activate --no-embedded latest;
     fi
   - if [ "$STATIC_CHECKS" = "yes" ]; then
       unset SCONS_CACHE;


### PR DESCRIPTION
Javascript's Travis CI is failing because javascript's `can_build()` is returning `false`:
https://github.com/godotengine/godot/blob/0f1da724924fc494bfd316c57757e0e1d7b90143/platform/javascript/detect.py#L14-L15

Emscripten is moving to an embedded config model:
https://github.com/emscripten-core/emscripten/issues/9543
The activate option was changed to --embedded by default:
https://github.com/emscripten-core/emsdk/pull/472
So this is a quick fix to mirror their own quick fix:
https://github.com/emscripten-core/emscripten/pull/11293

Basically, we need to use --no-embedded until we can update our own check for a properly installed Emscripten.