### PR TITLE
Fix get_string_size not recognizing tab character + Added tab spacing equal to 4 spaces.

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -839,9 +839,13 @@ Size2 DynamicFont::get_char_size(CharType p_char, CharType p_next) const {
 		return Size2(1, 1);
 	}
 
+	const int tab_spacing = 4 * spacing_space;
+
 	Size2 ret = data_at_size->get_char_size(p_char, p_next, fallback_data_at_size);
 	if (p_char == ' ') {
 		ret.width += spacing_space + spacing_char;
+	} else if (p_char == '\t') {
+		ret.width += tab_spacing + spacing_char;
 	} else if (p_next) {
 		ret.width += spacing_char;
 	}


### PR DESCRIPTION
Fix #38315
As per issue, added special case for handling tab character, set equal to 4 spaces.