### PR TITLE
Keep the bottom panel visible when enabling the distraction-free mode

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -204,6 +204,7 @@
 	</methods>
 	<members>
 		<member name="distraction_free_mode" type="bool" setter="set_distraction_free_mode" getter="is_distraction_free_mode_enabled">
+			If [code]true[/code], enables distraction-free mode which hides side docks to increase the space available for the main view.
 		</member>
 	</members>
 	<constants>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4159,7 +4159,6 @@ void EditorNode::_update_dock_slots_visibility() {
 		}
 
 		right_hsplit->hide();
-		bottom_panel->hide();
 	} else {
 		for (int i = 0; i < DOCK_SLOT_MAX; i++) {
 			int tabs_visible = 0;
@@ -4189,7 +4188,6 @@ void EditorNode::_update_dock_slots_visibility() {
 				dock_slot[i]->set_current_tab(0);
 			}
 		}
-		bottom_panel->show();
 
 		if (right_l_vsplit->is_visible() || right_r_vsplit->is_visible()) {
 			right_hsplit->show();


### PR DESCRIPTION
- Document `EditorInterface.set_distraction_free_mode()` and rename its `enter` parameter to `enable` for clarity.

This closes https://github.com/godotengine/godot-proposals/issues/951.