### PR TITLE
GDNative: merge API structs, bump version of merged structs.

### DIFF
--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -2,2276 +2,580 @@
   "core": {
     "type": "CORE",
     "version": {
-      "major": 1,
+      "major": 4,
       "minor": 0
     },
-    "next": {
-      "type": "CORE",
-      "version": {
-        "major": 1,
-        "minor": 1
-      },
-      "next": {
-        "type": "CORE",
-        "version": {
-          "major": 1,
-          "minor": 2
-        },
-        "next": {
-          "type": "CORE",
-          "version": {
-            "major": 1,
-            "minor": 3
-          },
-          "next": null,
-          "api": [
-            {
-              "name": "godot_object_get_instance_id",
-              "return_type": "uint64_t",
-              "arguments": [
-                ["const godot_object *", "p_object"]
-              ]
-            },
-            {
-              "name": "godot_array_new_packed_float64_array",
-              "return_type": "void",
-              "arguments": [
-                ["godot_array *", "r_dest"],
-                ["const godot_packed_float64_array *", "p_pra"]
-              ]
-            },
-            {
-              "name": "godot_array_new_packed_int64_array",
-              "return_type": "void",
-              "arguments": [
-                ["godot_array *", "r_dest"],
-                ["const godot_packed_int64_array *", "p_pia"]
-              ]
-            },
-            {
-              "name": "godot_callable_new_with_object",
-              "return_type": "void",
-              "arguments": [
-                ["godot_callable *", "r_dest"],
-                ["const godot_object *", "p_object"],
-                ["const godot_string_name *", "p_method"]
-              ]
-            },
-            {
-              "name": "godot_callable_new_with_object_id",
-              "return_type": "void",
-              "arguments": [
-                ["godot_callable *", "r_dest"],
-                ["uint64_t", "p_objectid"],
-                ["const godot_string_name *", "p_method"]
-              ]
-            },
-            {
-              "name": "godot_callable_new_copy",
-              "return_type": "void",
-              "arguments": [
-                ["godot_callable *", "r_dest"],
-                ["const godot_callable *", "p_src"]
-              ]
-            },
-            {
-              "name": "godot_callable_destroy",
-              "return_type": "void",
-              "arguments": [
-                ["godot_callable *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_callable_call",
-              "return_type": "godot_int",
-              "arguments": [
-                ["const godot_callable *", "p_self"],
-                ["const godot_variant **", "p_arguments"],
-                ["godot_int", "p_argcount"],
-                ["godot_variant *", "r_return_value"]
-              ]
-            },
-            {
-              "name": "godot_callable_call_deferred",
-              "return_type": "void",
-              "arguments": [
-                ["const godot_callable *", "p_self"],
-                ["const godot_variant **", "p_arguments"],
-                ["godot_int", "p_argcount"]
-              ]
-            },  
-            {
-              "name": "godot_callable_is_null",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_callable *", "p_self"]
-              ]
-            },  
-            {
-              "name": "godot_callable_is_custom",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_callable *", "p_self"]
-              ]
-            },  
-            {
-              "name": "godot_callable_is_standard",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_callable *", "p_self"]
-              ]
-            },    
-            {
-              "name": "godot_callable_get_object",
-              "return_type": "godot_object *",
-              "arguments": [
-                ["const godot_callable *", "p_self"]
-              ]
-            },    
-            {
-              "name": "godot_callable_get_object_id",
-              "return_type": "uint64_t",
-              "arguments": [
-                ["const godot_callable *", "p_self"]
-              ]
-            },    
-            {
-              "name": "godot_callable_get_method",
-              "return_type": "godot_string_name",
-              "arguments": [
-                ["const godot_callable *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_callable_hash",
-              "return_type": "uint32_t",
-              "arguments": [
-                ["const godot_callable *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_callable_as_string",
-              "return_type": "godot_string",
-              "arguments": [
-                ["const godot_callable *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_callable_operator_equal",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_callable *", "p_self"],
-                ["const godot_callable *", "p_other"]
-              ]
-            },
-            {
-              "name": "godot_callable_operator_less",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_callable *", "p_self"],
-                ["const godot_callable *", "p_other"]
-              ]
-            },
-            {
-              "name": "godot_signal_new_with_object",
-              "return_type": "void",
-              "arguments": [
-                ["godot_signal *", "r_dest"],
-                ["const godot_object *", "p_object"],
-                ["const godot_string_name *", "p_method"]
-              ]
-            },
-            {
-              "name": "godot_signal_new_with_object_id",
-              "return_type": "void",
-              "arguments": [
-                ["godot_signal *", "r_dest"],
-                ["uint64_t", "p_objectid"],
-                ["const godot_string_name *", "p_method"]
-              ]
-            },
-            {
-              "name": "godot_signal_new_copy",
-              "return_type": "void",
-              "arguments": [
-                ["godot_signal *", "r_dest"],
-                ["const godot_signal *", "p_src"]
-              ]
-            },
-            {
-              "name": "godot_signal_destroy",
-              "return_type": "void",
-              "arguments": [
-                ["godot_signal *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_signal_emit",
-              "return_type": "godot_int",
-              "arguments": [
-                ["const godot_signal *", "p_self"],
-                ["const godot_variant **", "p_arguments"],
-                ["godot_int", "p_argcount"]
-              ]
-            },
-            {
-              "name": "godot_signal_connect",
-              "return_type": "godot_int",
-              "arguments": [
-                ["godot_signal *", "p_self"],
-                ["const godot_callable *", "p_callable"],
-                ["const godot_array *", "p_binds"],
-                ["uint32_t", "p_flags"]
-              ]
-            },
-            {
-              "name": "godot_signal_disconnect",
-              "return_type": "void",
-              "arguments": [
-                ["godot_signal *", "p_self"],
-                ["const godot_callable *", "p_callable"]
-              ]
-            },
-            {
-              "name": "godot_signal_is_null",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_signal *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_signal_is_connected",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_signal *", "p_self"],
-                ["const godot_callable *", "p_callable"]
-              ]
-            },
-            {
-              "name": "godot_signal_get_connections",
-              "return_type": "godot_array",
-              "arguments": [
-                ["const godot_signal *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_signal_get_object",
-              "return_type": "godot_object *",
-              "arguments": [
-                ["const godot_signal *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_signal_get_object_id",
-              "return_type": "uint64_t",
-              "arguments": [
-                ["const godot_signal *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_signal_get_name",
-              "return_type": "godot_string_name",
-              "arguments": [
-                ["const godot_signal *", "p_self"]
-              ]
-            },  
-            {
-              "name": "godot_signal_as_string",
-              "return_type": "godot_string",
-              "arguments": [
-                ["const godot_signal *", "p_self"]
-              ]
-            },  
-            {
-              "name": "godot_signal_operator_equal",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_signal *", "p_self"],
-                ["const godot_signal *", "p_other"]
-              ]
-            },  
-            {
-              "name": "godot_signal_operator_less",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_signal *", "p_self"],
-                ["const godot_signal *", "p_other"]
-              ]
-            },  
-            {
-              "name": "godot_packed_int64_array_new",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_int64_array *", "r_dest"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_new_copy",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_int64_array *", "r_dest"],
-                ["const godot_packed_int64_array *", "p_src"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_new_with_array",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_int64_array *", "r_dest"],
-                ["const godot_array *", "p_a"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_append",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_int64_array *", "p_self"],
-                ["const int64_t", "p_data"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_append_array",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_int64_array *", "p_self"],
-                ["const godot_packed_int64_array *", "p_array"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_insert",
-              "return_type": "godot_error",
-              "arguments": [
-                ["godot_packed_int64_array *", "p_self"],
-                ["const godot_int", "p_idx"],
-                ["const int64_t", "p_data"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_invert",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_int64_array *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_push_back",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_int64_array *", "p_self"],
-                ["const int64_t", "p_data"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_remove",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_int64_array *", "p_self"],
-                ["const godot_int", "p_idx"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_resize",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_int64_array *", "p_self"],
-                ["const godot_int", "p_size"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_set",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_int64_array *", "p_self"],
-                ["const godot_int", "p_idx"],
-                ["const int64_t", "p_data"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_get",
-              "return_type": "int64_t",
-              "arguments": [
-                ["const godot_packed_int64_array *", "p_self"],
-                ["const godot_int", "p_idx"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_size",
-              "return_type": "godot_int",
-              "arguments": [
-                ["const godot_packed_int64_array *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_destroy",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_int64_array *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_new",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_float64_array *", "r_dest"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_new_copy",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_float64_array *", "r_dest"],
-                ["const godot_packed_float64_array *", "p_src"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_new_with_array",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_float64_array *", "r_dest"],
-                ["const godot_array *", "p_a"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_append",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_float64_array *", "p_self"],
-                ["const double", "p_data"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_append_array",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_float64_array *", "p_self"],
-                ["const godot_packed_float64_array *", "p_array"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_insert",
-              "return_type": "godot_error",
-              "arguments": [
-                ["godot_packed_float64_array *", "p_self"],
-                ["const godot_int", "p_idx"],
-                ["const double", "p_data"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_invert",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_float64_array *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_push_back",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_float64_array *", "p_self"],
-                ["const double", "p_data"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_remove",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_float64_array *", "p_self"],
-                ["const godot_int", "p_idx"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_resize",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_float64_array *", "p_self"],
-                ["const godot_int", "p_size"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_set",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_float64_array *", "p_self"],
-                ["const godot_int", "p_idx"],
-                ["const double", "p_data"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_get",
-              "return_type": "double",
-              "arguments": [
-                ["const godot_packed_float64_array *", "p_self"],
-                ["const godot_int", "p_idx"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_size",
-              "return_type": "godot_int",
-              "arguments": [
-                ["const godot_packed_float64_array *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_destroy",
-              "return_type": "void",
-              "arguments": [
-                ["godot_packed_float64_array *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_ptr",
-              "return_type": "const int64_t *",
-              "arguments": [
-                ["const godot_packed_int64_array *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_packed_int64_array_ptrw",
-              "return_type": "int64_t *",
-              "arguments": [
-                ["godot_packed_int64_array *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_ptr",
-              "return_type": "const double *",
-              "arguments": [
-                ["const godot_packed_float64_array *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_packed_float64_array_ptrw",
-              "return_type": "double *",
-              "arguments": [
-                ["godot_packed_float64_array *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_rect2_as_rect2i",
-              "return_type": "godot_rect2i",
-              "arguments": [
-                ["const godot_rect2 *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_new_with_position_and_size",
-              "return_type": "void",
-              "arguments": [
-                ["godot_rect2i *", "r_dest"],
-                ["const godot_vector2i *", "p_pos"],
-                ["const godot_vector2i *", "p_size"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_new",
-              "return_type": "void",
-              "arguments": [
-                ["godot_rect2i *", "r_dest"],
-                ["const godot_int", "p_x"],
-                ["const godot_int", "p_y"],
-                ["const godot_int", "p_width"],
-                ["const godot_int", "p_height"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_as_string",
-              "return_type": "godot_string",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_as_rect2",
-              "return_type": "godot_rect2",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_get_area",
-              "return_type": "godot_int",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_intersects",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"],
-                ["const godot_rect2i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_encloses",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"],
-                ["const godot_rect2i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_has_no_area",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_clip",
-              "return_type": "godot_rect2i",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"],
-                ["const godot_rect2i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_merge",
-              "return_type": "godot_rect2i",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"],
-                ["const godot_rect2i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_has_point",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"],
-                ["const godot_vector2i *", "p_point"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_grow",
-              "return_type": "godot_rect2i",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"],
-                ["const godot_int", "p_by"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_grow_individual",
-              "return_type": "godot_rect2i",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"],
-                ["const godot_int", "p_left"],
-                ["const godot_int", "p_top"],
-                ["const godot_int", "p_right"],
-                ["const godot_int", "p_bottom"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_grow_margin",
-              "return_type": "godot_rect2i",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"],
-                ["const godot_int", "p_margin"],
-                ["const godot_int", "p_by"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_abs",
-              "return_type": "godot_rect2i",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_expand",
-              "return_type": "godot_rect2i",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"],
-                ["const godot_vector2i *", "p_to"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_operator_equal",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"],
-                ["const godot_rect2i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_get_position",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_get_size",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_rect2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_set_position",
-              "return_type": "void",
-              "arguments": [
-                ["godot_rect2i *", "p_self"],
-                ["const godot_vector2i *", "p_pos"]
-              ]
-            },
-            {
-              "name": "godot_rect2i_set_size",
-              "return_type": "void",
-              "arguments": [
-                ["godot_rect2i *", "p_self"],
-                ["const godot_vector2i *", "p_size"]
-              ]
-            },
-            {
-              "name": "godot_variant_new_string_name",
-              "return_type": "void",
-              "arguments": [
-                ["godot_variant *", "r_dest"],
-                ["const godot_string_name *", "p_s"]
-              ]
-            },
-            {
-              "name": "godot_variant_new_vector2i",
-              "return_type": "void",
-              "arguments": [
-                ["godot_variant *", "r_dest"],
-                ["const godot_vector2i *", "p_v2"]
-              ]
-            },
-            {
-              "name": "godot_variant_new_rect2i",
-              "return_type": "void",
-              "arguments": [
-                ["godot_variant *", "r_dest"],
-                ["const godot_rect2i *", "p_rect2"]
-              ]
-            },
-            {
-              "name": "godot_variant_new_vector3i",
-              "return_type": "void",
-              "arguments": [
-                ["godot_variant *", "r_dest"],
-                ["const godot_vector3i *", "p_v3"]
-              ]
-            },
-            {
-              "name": "godot_variant_new_callable",
-              "return_type": "void",
-              "arguments": [
-                ["godot_variant *", "r_dest"],
-                ["const godot_callable *", "p_cb"]
-              ]
-            },
-            {
-              "name": "godot_variant_new_signal",
-              "return_type": "void",
-              "arguments": [
-                ["godot_variant *", "r_dest"],
-                ["const godot_signal *", "p_signal"]
-              ]
-            },
-            {
-              "name": "godot_variant_new_packed_int64_array",
-              "return_type": "void",
-              "arguments": [
-                ["godot_variant *", "r_dest"],
-                ["const godot_packed_int64_array *", "p_pia"]
-              ]
-            },
-            {
-              "name": "godot_variant_new_packed_float64_array",
-              "return_type": "void",
-              "arguments": [
-                ["godot_variant *", "r_dest"],
-                ["const godot_packed_float64_array *", "p_pra"]
-              ]
-            },
-            {
-              "name": "godot_variant_as_string_name",
-              "return_type": "godot_string_name",
-              "arguments": [
-                ["const godot_variant *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_variant_as_vector2i",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_variant *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_variant_as_rect2i",
-              "return_type": "godot_rect2i",
-              "arguments": [
-                ["const godot_variant *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_variant_as_vector3i",
-              "return_type": "godot_vector3i",
-              "arguments": [
-                ["const godot_variant *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_variant_as_callable",
-              "return_type": "godot_callable",
-              "arguments": [
-                ["const godot_variant *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_variant_as_signal",
-              "return_type": "godot_signal",
-              "arguments": [
-                ["const godot_variant *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_variant_as_packed_int64_array",
-              "return_type": "godot_packed_int64_array",
-              "arguments": [
-                ["const godot_variant *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_variant_as_packed_float64_array",
-              "return_type": "godot_packed_float64_array",
-              "arguments": [
-                ["const godot_variant *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_variant_hash",
-              "return_type": "uint32_t",
-              "arguments": [
-                ["const godot_variant *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector2_as_vector2i",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_vector2 *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector2_sign",
-              "return_type": "godot_vector2",
-              "arguments": [
-                ["const godot_vector2 *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_new",
-              "return_type": "void",
-              "arguments": [
-                ["godot_vector2i *", "r_dest"],
-                ["const godot_int", "p_x"],
-                ["const godot_int", "p_y"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_as_string",
-              "return_type": "godot_string",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_as_vector2",
-              "return_type": "godot_vector2",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_aspect",
-              "return_type": "godot_real",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_abs",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_sign",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_operator_add",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"],
-                ["const godot_vector2i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_operator_subtract",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"],
-                ["const godot_vector2i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_operator_multiply_vector",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"],
-                ["const godot_vector2i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_operator_multiply_scalar",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"],
-                ["const godot_int", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_operator_divide_vector",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"],
-                ["const godot_vector2i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_operator_divide_scalar",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"],
-                ["const godot_int", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_operator_equal",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"],
-                ["const godot_vector2i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_operator_less",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"],
-                ["const godot_vector2i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_operator_neg",
-              "return_type": "godot_vector2i",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_set_x",
-              "return_type": "void",
-              "arguments": [
-                ["godot_vector2i *", "p_self"],
-                ["const godot_int", "p_x"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_set_y",
-              "return_type": "void",
-              "arguments": [
-                ["godot_vector2i *", "p_self"],
-                ["const godot_int", "p_y"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_get_x",
-              "return_type": "godot_int",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector2i_get_y",
-              "return_type": "godot_int",
-              "arguments": [
-                ["const godot_vector2i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector3_as_vector3i",
-              "return_type": "godot_vector3i",
-              "arguments": [
-                ["const godot_vector3 *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector3_sign",
-              "return_type": "godot_vector3",
-              "arguments": [
-                ["const godot_vector3 *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_new",
-              "return_type": "void",
-              "arguments": [
-                ["godot_vector3i *", "r_dest"],
-                ["const godot_int", "p_x"],
-                ["const godot_int", "p_y"],
-                ["const godot_int", "p_z"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_as_string",
-              "return_type": "godot_string",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_as_vector3",
-              "return_type": "godot_vector3",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_min_axis",
-              "return_type": "godot_int",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_max_axis",
-              "return_type": "godot_int",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_abs",
-              "return_type": "godot_vector3i",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_sign",
-              "return_type": "godot_vector3i",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_operator_add",
-              "return_type": "godot_vector3i",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"],
-                ["const godot_vector3i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_operator_subtract",
-              "return_type": "godot_vector3i",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"],
-                ["const godot_vector3i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_operator_multiply_vector",
-              "return_type": "godot_vector3i",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"],
-                ["const godot_vector3i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_operator_multiply_scalar",
-              "return_type": "godot_vector3i",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"],
-                ["const godot_int", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_operator_divide_vector",
-              "return_type": "godot_vector3i",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"],
-                ["const godot_vector3i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_operator_divide_scalar",
-              "return_type": "godot_vector3i",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"],
-                ["const godot_int", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_operator_equal",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"],
-                ["const godot_vector3i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_operator_less",
-              "return_type": "godot_bool",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"],
-                ["const godot_vector3i *", "p_b"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_operator_neg",
-              "return_type": "godot_vector3i",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_set_axis",
-              "return_type": "void",
-              "arguments": [
-                ["godot_vector3i *", "p_self"],
-                ["const godot_vector3_axis", "p_axis"],
-                ["const godot_int", "p_val"]
-              ]
-            },
-            {
-              "name": "godot_vector3i_get_axis",
-              "return_type": "godot_int",
-              "arguments": [
-                ["const godot_vector3i *", "p_self"],
-                ["const godot_vector3_axis", "p_axis"]
-              ]
-            }          
-          ]
-        },
-        "api": [
-          {
-            "name": "godot_dictionary_duplicate",
-            "return_type": "godot_dictionary",
-            "arguments": [
-              ["const godot_dictionary *", "p_self"],
-              ["const godot_bool", "p_deep"]
-            ]
-          },
-          {
-            "name": "godot_vector3_move_toward",
-            "return_type": "godot_vector3",
-            "arguments": [
-              ["const godot_vector3 *", "p_self"],
-              ["const godot_vector3 *", "p_to"],
-              ["const godot_real", "p_delta"]
-            ]
-          },
-          {
-            "name": "godot_vector2_move_toward",
-            "return_type": "godot_vector2",
-            "arguments": [
-              ["const godot_vector2 *", "p_self"],
-              ["const godot_vector2 *", "p_to"],
-              ["const godot_real", "p_delta"]
-            ]
-          },
-          {
-            "name": "godot_string_count",
-            "return_type": "godot_int",
-            "arguments": [
-              ["const godot_string *", "p_self"],
-              ["godot_string", "p_what"],
-              ["godot_int", "p_from"],
-              ["godot_int", "p_to"]
-            ]
-          },
-          {
-            "name": "godot_string_countn",
-            "return_type": "godot_int",
-            "arguments": [
-              ["const godot_string *", "p_self"],
-              ["godot_string", "p_what"],
-              ["godot_int", "p_from"],
-              ["godot_int", "p_to"]
-            ]
-          },
-          {
-            "name": "godot_vector3_direction_to",
-            "return_type": "godot_vector3",
-            "arguments": [
-              ["const godot_vector3 *", "p_self"],
-              ["const godot_vector3 *", "p_to"]
-            ]
-          },
-          {
-            "name": "godot_vector2_direction_to",
-            "return_type": "godot_vector2",
-            "arguments": [
-              ["const godot_vector2 *", "p_self"],
-              ["const godot_vector2 *", "p_to"]
-            ]
-          },
-          {
-            "name": "godot_array_slice",
-            "return_type": "godot_array",
-            "arguments": [
-              ["const godot_array *", "p_self"],
-              ["const godot_int", "p_begin"],
-              ["const godot_int", "p_end"],
-              ["const godot_int", "p_step"],
-              ["const godot_bool", "p_deep"]
-            ]
-          },
-          {
-            "name": "godot_packed_byte_array_empty",
-            "return_type": "godot_bool",
-            "arguments": [
-              ["const godot_packed_byte_array *", "p_self"]
-            ]
-          },
-          {
-            "name": "godot_packed_int32_array_empty",
-            "return_type": "godot_bool",
-            "arguments": [
-              ["const godot_packed_int32_array *", "p_self"]
-            ]
-          },
-          {
-            "name": "godot_packed_float32_array_empty",
-            "return_type": "godot_bool",
-            "arguments": [
-              ["const godot_packed_float32_array *", "p_self"]
-            ]
-          },
-          {
-            "name": "godot_packed_string_array_empty",
-            "return_type": "godot_bool",
-            "arguments": [
-              ["const godot_packed_string_array *", "p_self"]
-            ]
-          },
-          {
-            "name": "godot_packed_vector2_array_empty",
-            "return_type": "godot_bool",
-            "arguments": [
-              ["const godot_packed_vector2_array *", "p_self"]
-            ]
-          },
-          {
-            "name": "godot_packed_vector3_array_empty",
-            "return_type": "godot_bool",
-            "arguments": [
-              ["const godot_packed_vector3_array *", "p_self"]
-            ]
-          },
-          {
-            "name": "godot_packed_color_array_empty",
-            "return_type": "godot_bool",
-            "arguments": [
-              ["const godot_packed_color_array *", "p_self"]
-            ]
-          },
-          {
-            "name": "godot_get_class_tag",
-            "return_type": "void *",
-            "arguments": [
-              ["const godot_string_name *", "p_class"]
-            ]
-          },
-          {
-            "name": "godot_object_cast_to",
-            "return_type": "godot_object *",
-            "arguments": [
-              ["const godot_object *", "p_object"],
-              ["void *", "p_class_tag"]
-            ]
-          },
-          {
-            "name": "godot_instance_from_id",
-            "return_type": "godot_object *",
-            "arguments": [
-              ["uint64_t", "p_instance_id"]
-            ]
-          }
-        ]
-      },
-      "api": [
-        {
-          "name": "godot_color_to_abgr32",
-          "return_type": "godot_int",
-          "arguments": [
-            ["const godot_color *", "p_self"]
-          ]
-        },
-        {
-          "name": "godot_color_to_abgr64",
-          "return_type": "godot_int",
-          "arguments": [
-            ["const godot_color *", "p_self"]
-          ]
-        },
-        {
-          "name": "godot_color_to_argb64",
-          "return_type": "godot_int",
-          "arguments": [
-            ["const godot_color *", "p_self"]
-          ]
-        },
-        {
-          "name": "godot_color_to_rgba64",
-          "return_type": "godot_int",
-          "arguments": [
-            ["const godot_color *", "p_self"]
-          ]
-        },
-        {
-          "name": "godot_color_darkened",
-          "return_type": "godot_color",
-          "arguments": [
-            ["const godot_color *", "p_self"],
-            ["const godot_real", "p_amount"]
-          ]
-        },
-        {
-          "name": "godot_color_from_hsv",
-          "return_type": "godot_color",
-          "arguments": [
-            ["const godot_color *", "p_self"],
-            ["const godot_real", "p_h"],
-            ["const godot_real", "p_s"],
-            ["const godot_real", "p_v"],
-            ["const godot_real", "p_a"]
-          ]
-        },
-        {
-          "name": "godot_color_lightened",
-          "return_type": "godot_color",
-          "arguments": [
-            ["const godot_color *", "p_self"],
-            ["const godot_real", "p_amount"]
-          ]
-        },
-        {
-          "name": "godot_array_duplicate",
-          "return_type": "godot_array",
-          "arguments": [
-            ["const godot_array *", "p_self"],
-            ["const godot_bool", "p_deep"]
-          ]
-        },
-        {
-          "name": "godot_array_max",
-          "return_type": "godot_variant",
-          "arguments": [
-            ["const godot_array *", "p_self"]
-          ]
-        },
-        {
-          "name": "godot_array_min",
-          "return_type": "godot_variant",
-          "arguments": [
-            ["const godot_array *", "p_self"]
-          ]
-        },
-        {
-          "name": "godot_array_shuffle",
-          "return_type": "void",
-          "arguments": [
-            ["godot_array *", "p_self"]
-          ]
-        },
-        {
-          "name": "godot_basis_slerp",
-          "return_type": "godot_basis",
-          "arguments": [
-            ["const godot_basis *", "p_self"],
-            ["const godot_basis *", "p_b"],
-            ["const godot_real", "p_t"]
-          ]
-        },
-        {
-          "name": "godot_dictionary_get_with_default",
-          "return_type": "godot_variant",
-          "arguments": [
-            ["const godot_dictionary *", "p_self"],
-            ["const godot_variant *", "p_key"],
-            ["const godot_variant *", "p_default"]
-          ]
-        },
-        {
-          "name": "godot_dictionary_erase_with_return",
-          "return_type": "bool",
-          "arguments": [
-            ["godot_dictionary *", "p_self"],
-            ["const godot_variant *", "p_key"]
-          ]
-        },
-        {
-          "name": "godot_node_path_get_as_property_path",
-          "return_type": "godot_node_path",
-          "arguments": [
-            ["const godot_node_path *", "p_self"]
-          ]
-        },
-        {
-          "name": "godot_quat_set_axis_angle",
-          "return_type": "void",
-          "arguments": [
-            ["godot_quat *", "p_self"],
-            ["const godot_vector3 *", "p_axis"],
-            ["const godot_real", "p_angle"]
-          ]
-        },
-        {
-          "name": "godot_rect2_grow_individual",
-          "return_type": "godot_rect2",
-          "arguments": [
-            ["const godot_rect2 *", "p_self"],
-            ["const godot_real", "p_left"],
-            ["const godot_real", "p_top"],
-            ["const godot_real", "p_right"],
-            ["const godot_real", "p_bottom"]
-          ]
-        },
-        {
-          "name": "godot_rect2_grow_margin",
-          "return_type": "godot_rect2",
-          "arguments": [
-            ["const godot_rect2 *", "p_self"],
-            ["const godot_int", "p_margin"],
-            ["const godot_real", "p_by"]
-          ]
-        },
-        {
-          "name": "godot_rect2_abs",
-          "return_type": "godot_rect2",
-          "arguments": [
-            ["const godot_rect2 *", "p_self"]
-          ]
-        },
-        {
-          "name": "godot_string_dedent",
-          "return_type": "godot_string",
-          "arguments": [
-            ["const godot_string *", "p_self"]
-          ]
-        },
-        {
-          "name": "godot_string_trim_prefix",
-          "return_type": "godot_string",
-          "arguments": [
-            ["const godot_string *", "p_self"],
-            ["const godot_string *", "p_prefix"]
-          ]
-        },
-        {
-          "name": "godot_string_trim_suffix",
-          "return_type": "godot_string",
-          "arguments": [
-            ["const godot_string *", "p_self"],
-            ["const godot_string *", "p_suffix"]
-          ]
-        },
-        {
-          "name": "godot_string_rstrip",
-          "return_type": "godot_string",
-          "arguments": [
-            ["const godot_string *", "p_self"],
-            ["const godot_string *", "p_chars"]
-          ]
-        },
-        {
-          "name": "godot_string_rsplit",
-          "return_type": "godot_packed_string_array",
-          "arguments": [
-            ["const godot_string *", "p_self"],
-            ["const godot_string *", "p_divisor"],
-            ["const godot_bool", "p_allow_empty"],
-            ["const godot_int", "p_maxsplit"]
-          ]
-        },
-        {
-          "name": "godot_basis_get_quat",
-          "return_type": "godot_quat",
-          "arguments": [
-            ["const godot_basis *", "p_self"]
-          ]
-        },
-        {
-          "name": "godot_basis_set_quat",
-          "return_type": "void",
-          "arguments": [
-            ["godot_basis *", "p_self"],
-            ["const godot_quat *", "p_quat"]
-          ]
-        },
-        {
-          "name": "godot_basis_set_axis_angle_scale",
-          "return_type": "void",
-          "arguments": [
-            ["godot_basis *", "p_self"],
-            ["const godot_vector3 *", "p_axis"],
-            ["godot_real", "p_phi"],
-            ["const godot_vector3 *", "p_scale"]
-          ]
-        },
-        {
-          "name": "godot_basis_set_euler_scale",
-          "return_type": "void",
-          "arguments": [
-            ["godot_basis *", "p_self"],
-            ["const godot_vector3 *", "p_euler"],
-            ["const godot_vector3 *", "p_scale"]
-          ]
-        },
-        {
-          "name": "godot_basis_set_quat_scale",
-          "return_type": "void",
-          "arguments": [
-            ["godot_basis *", "p_self"],
-            ["const godot_quat *", "p_quat"],
-            ["const godot_vector3 *", "p_scale"]
-          ]
-        },
-        {
-          "name": "godot_quat_new_with_basis",
-          "return_type": "void",
-          "arguments": [
-            ["godot_quat *", "r_dest"],
-            ["const godot_basis *", "p_basis"]
-          ]
-        },
-        {
-          "name": "godot_quat_new_with_euler",
-          "return_type": "void",
-          "arguments": [
-            ["godot_quat *", "r_dest"],
-            ["const godot_vector3 *", "p_euler"]
-          ]
-        },
-        {
-          "name": "godot_transform_new_with_quat",
-          "return_type": "void",
-          "arguments": [
-            ["godot_transform *", "r_dest"],
-            ["const godot_quat *", "p_quat"]
-          ]
-        },
-        {
-          "name": "godot_variant_get_operator_name",
-          "return_type": "godot_string",
-          "arguments": [
-            ["godot_variant_operator", "p_op"]
-          ]
-        },
-        {
-          "name": "godot_variant_evaluate",
-          "return_type": "void",
-          "arguments": [
-            ["godot_variant_operator", "p_op"],
-            ["const godot_variant *", "p_a"],
-            ["const godot_variant *", "p_b"],
-            ["godot_variant *", "r_ret"],
-            ["godot_bool *", "r_valid"]
-          ]
-        }
-      ]
-    },
+    "next": null,
     "api": [
       {
-        "name": "godot_color_new_rgba",
+        "name": "godot_aabb_new",
         "return_type": "void",
         "arguments": [
-          ["godot_color *", "r_dest"],
-          ["const godot_real", "p_r"],
-          ["const godot_real", "p_g"],
-          ["const godot_real", "p_b"],
-          ["const godot_real", "p_a"]
+          ["godot_aabb *", "r_dest"],
+          ["const godot_vector3 *", "p_pos"],
+          ["const godot_vector3 *", "p_size"]
         ]
       },
       {
-        "name": "godot_color_new_rgb",
-        "return_type": "void",
-        "arguments": [
-          ["godot_color *", "r_dest"],
-          ["const godot_real", "p_r"],
-          ["const godot_real", "p_g"],
-          ["const godot_real", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_color_get_r",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_color_set_r",
-        "return_type": "void",
-        "arguments": [
-          ["godot_color *", "p_self"],
-          ["const godot_real", "r"]
-        ]
-      },
-      {
-        "name": "godot_color_get_g",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_color_set_g",
-        "return_type": "void",
-        "arguments": [
-          ["godot_color *", "p_self"],
-          ["const godot_real", "g"]
-        ]
-      },
-      {
-        "name": "godot_color_get_b",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_color_set_b",
-        "return_type": "void",
-        "arguments": [
-          ["godot_color *", "p_self"],
-          ["const godot_real", "b"]
-        ]
-      },
-      {
-        "name": "godot_color_get_a",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_color_set_a",
-        "return_type": "void",
-        "arguments": [
-          ["godot_color *", "p_self"],
-          ["const godot_real", "a"]
-        ]
-      },
-      {
-        "name": "godot_color_get_h",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_color_get_s",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_color_get_v",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_color_as_string",
-        "return_type": "godot_string",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_color_to_rgba32",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_color_to_argb32",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_color_inverted",
-        "return_type": "godot_color",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_color_contrasted",
-        "return_type": "godot_color",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_color_lerp",
-        "return_type": "godot_color",
-        "arguments": [
-          ["const godot_color *", "p_self"],
-          ["const godot_color *", "p_b"],
-          ["const godot_real", "p_t"]
-        ]
-      },
-      {
-        "name": "godot_color_blend",
-        "return_type": "godot_color",
-        "arguments": [
-          ["const godot_color *", "p_self"],
-          ["const godot_color *", "p_over"]
-        ]
-      },
-      {
-        "name": "godot_color_to_html",
-        "return_type": "godot_string",
-        "arguments": [
-          ["const godot_color *", "p_self"],
-          ["const godot_bool", "p_with_alpha"]
-        ]
-      },
-      {
-        "name": "godot_color_operator_equal",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_color *", "p_self"],
-          ["const godot_color *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_color_operator_less",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_color *", "p_self"],
-          ["const godot_color *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector2_new",
-        "return_type": "void",
-        "arguments": [
-          ["godot_vector2 *", "r_dest"],
-          ["const godot_real", "p_x"],
-          ["const godot_real", "p_y"]
-        ]
-      },
-      {
-        "name": "godot_vector2_as_string",
-        "return_type": "godot_string",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector2_normalized",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector2_length",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector2_angle",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector2_length_squared",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector2_is_normalized",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector2_distance_to",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_to"]
-        ]
-      },
-      {
-        "name": "godot_vector2_distance_squared_to",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_to"]
-        ]
-      },
-      {
-        "name": "godot_vector2_angle_to",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_to"]
-        ]
-      },
-      {
-        "name": "godot_vector2_angle_to_point",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_to"]
-        ]
-      },
-      {
-        "name": "godot_vector2_lerp",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_b"],
-          ["const godot_real", "p_t"]
-        ]
-      },
-      {
-        "name": "godot_vector2_cubic_interpolate",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_b"],
-          ["const godot_vector2 *", "p_pre_a"],
-          ["const godot_vector2 *", "p_post_b"],
-          ["const godot_real", "p_t"]
-        ]
-      },
-      {
-        "name": "godot_vector2_rotated",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_real", "p_phi"]
-        ]
-      },
-      {
-        "name": "godot_vector2_tangent",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector2_floor",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector2_snapped",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_by"]
-        ]
-      },
-      {
-        "name": "godot_vector2_aspect",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector2_dot",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_with"]
-        ]
-      },
-      {
-        "name": "godot_vector2_slide",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_n"]
-        ]
-      },
-      {
-        "name": "godot_vector2_bounce",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_n"]
-        ]
-      },
-      {
-        "name": "godot_vector2_reflect",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_n"]
-        ]
-      },
-      {
-        "name": "godot_vector2_abs",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector2_clamped",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_real", "p_length"]
-        ]
-      },
-      {
-        "name": "godot_vector2_operator_add",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector2_operator_subtract",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector2_operator_multiply_vector",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector2_operator_multiply_scalar",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_real", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector2_operator_divide_vector",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector2_operator_divide_scalar",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_real", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector2_operator_equal",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector2_operator_less",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"],
-          ["const godot_vector2 *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector2_operator_neg",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector2_set_x",
-        "return_type": "void",
-        "arguments": [
-          ["godot_vector2 *", "p_self"],
-          ["const godot_real", "p_x"]
-        ]
-      },
-      {
-        "name": "godot_vector2_set_y",
-        "return_type": "void",
-        "arguments": [
-          ["godot_vector2 *", "p_self"],
-          ["const godot_real", "p_y"]
-        ]
-      },
-      {
-        "name": "godot_vector2_get_x",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector2_get_y",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector2 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_quat_new",
-        "return_type": "void",
-        "arguments": [
-          ["godot_quat *", "r_dest"],
-          ["const godot_real", "p_x"],
-          ["const godot_real", "p_y"],
-          ["const godot_real", "p_z"],
-          ["const godot_real", "p_w"]
-        ]
-      },
-      {
-        "name": "godot_quat_new_with_axis_angle",
-        "return_type": "void",
-        "arguments": [
-          ["godot_quat *", "r_dest"],
-          ["const godot_vector3 *", "p_axis"],
-          ["const godot_real", "p_angle"]
-        ]
-      },
-      {
-        "name": "godot_quat_get_x",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_quat *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_quat_set_x",
-        "return_type": "void",
-        "arguments": [
-          ["godot_quat *", "p_self"],
-          ["const godot_real", "val"]
-        ]
-      },
-      {
-        "name": "godot_quat_get_y",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_quat *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_quat_set_y",
-        "return_type": "void",
-        "arguments": [
-          ["godot_quat *", "p_self"],
-          ["const godot_real", "val"]
-        ]
-      },
-      {
-        "name": "godot_quat_get_z",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_quat *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_quat_set_z",
-        "return_type": "void",
-        "arguments": [
-          ["godot_quat *", "p_self"],
-          ["const godot_real", "val"]
-        ]
-      },
-      {
-        "name": "godot_quat_get_w",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_quat *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_quat_set_w",
-        "return_type": "void",
-        "arguments": [
-          ["godot_quat *", "p_self"],
-          ["const godot_real", "val"]
-        ]
-      },
-      {
-        "name": "godot_quat_as_string",
-        "return_type": "godot_string",
-        "arguments": [
-          ["const godot_quat *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_quat_length",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_quat *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_quat_length_squared",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_quat *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_quat_normalized",
-        "return_type": "godot_quat",
-        "arguments": [
-          ["const godot_quat *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_quat_is_normalized",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_quat *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_quat_inverse",
-        "return_type": "godot_quat",
-        "arguments": [
-          ["const godot_quat *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_quat_dot",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_quat *", "p_self"],
-          ["const godot_quat *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_quat_xform",
+        "name": "godot_aabb_get_position",
         "return_type": "godot_vector3",
         "arguments": [
-          ["const godot_quat *", "p_self"],
+          ["const godot_aabb *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_aabb_set_position",
+        "return_type": "void",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
           ["const godot_vector3 *", "p_v"]
         ]
       },
       {
-        "name": "godot_quat_slerp",
-        "return_type": "godot_quat",
+        "name": "godot_aabb_get_size",
+        "return_type": "godot_vector3",
         "arguments": [
-          ["const godot_quat *", "p_self"],
-          ["const godot_quat *", "p_b"],
-          ["const godot_real", "p_t"]
+          ["const godot_aabb *", "p_self"]
         ]
       },
       {
-        "name": "godot_quat_slerpni",
-        "return_type": "godot_quat",
+        "name": "godot_aabb_set_size",
+        "return_type": "void",
         "arguments": [
-          ["const godot_quat *", "p_self"],
-          ["const godot_quat *", "p_b"],
-          ["const godot_real", "p_t"]
+          ["const godot_aabb *", "p_self"],
+          ["const godot_vector3 *", "p_v"]
         ]
       },
       {
-        "name": "godot_quat_cubic_slerp",
-        "return_type": "godot_quat",
+        "name": "godot_aabb_as_string",
+        "return_type": "godot_string",
         "arguments": [
-          ["const godot_quat *", "p_self"],
-          ["const godot_quat *", "p_b"],
-          ["const godot_quat *", "p_pre_a"],
-          ["const godot_quat *", "p_post_b"],
-          ["const godot_real", "p_t"]
+          ["const godot_aabb *", "p_self"]
         ]
       },
       {
-        "name": "godot_quat_operator_multiply",
-        "return_type": "godot_quat",
+        "name": "godot_aabb_get_area",
+        "return_type": "godot_real",
         "arguments": [
-          ["const godot_quat *", "p_self"],
-          ["const godot_real", "p_b"]
+          ["const godot_aabb *", "p_self"]
         ]
       },
       {
-        "name": "godot_quat_operator_add",
-        "return_type": "godot_quat",
-        "arguments": [
-          ["const godot_quat *", "p_self"],
-          ["const godot_quat *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_quat_operator_subtract",
-        "return_type": "godot_quat",
-        "arguments": [
-          ["const godot_quat *", "p_self"],
-          ["const godot_quat *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_quat_operator_divide",
-        "return_type": "godot_quat",
-        "arguments": [
-          ["const godot_quat *", "p_self"],
-          ["const godot_real", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_quat_operator_equal",
+        "name": "godot_aabb_has_no_area",
         "return_type": "godot_bool",
         "arguments": [
-          ["const godot_quat *", "p_self"],
-          ["const godot_quat *", "p_b"]
+          ["const godot_aabb *", "p_self"]
         ]
       },
       {
-        "name": "godot_quat_operator_neg",
-        "return_type": "godot_quat",
+        "name": "godot_aabb_has_no_surface",
+        "return_type": "godot_bool",
         "arguments": [
-          ["const godot_quat *", "p_self"]
+          ["const godot_aabb *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_aabb_intersects",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
+          ["const godot_aabb *", "p_with"]
+        ]
+      },
+      {
+        "name": "godot_aabb_encloses",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
+          ["const godot_aabb *", "p_with"]
+        ]
+      },
+      {
+        "name": "godot_aabb_merge",
+        "return_type": "godot_aabb",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
+          ["const godot_aabb *", "p_with"]
+        ]
+      },
+      {
+        "name": "godot_aabb_intersection",
+        "return_type": "godot_aabb",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
+          ["const godot_aabb *", "p_with"]
+        ]
+      },
+      {
+        "name": "godot_aabb_intersects_plane",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
+          ["const godot_plane *", "p_plane"]
+        ]
+      },
+      {
+        "name": "godot_aabb_intersects_segment",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
+          ["const godot_vector3 *", "p_from"],
+          ["const godot_vector3 *", "p_to"]
+        ]
+      },
+      {
+        "name": "godot_aabb_has_point",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
+          ["const godot_vector3 *", "p_point"]
+        ]
+      },
+      {
+        "name": "godot_aabb_get_support",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
+          ["const godot_vector3 *", "p_dir"]
+        ]
+      },
+      {
+        "name": "godot_aabb_get_longest_axis",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_aabb *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_aabb_get_longest_axis_index",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_aabb *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_aabb_get_longest_axis_size",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_aabb *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_aabb_get_shortest_axis",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_aabb *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_aabb_get_shortest_axis_index",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_aabb *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_aabb_get_shortest_axis_size",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_aabb *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_aabb_expand",
+        "return_type": "godot_aabb",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
+          ["const godot_vector3 *", "p_to_point"]
+        ]
+      },
+      {
+        "name": "godot_aabb_grow",
+        "return_type": "godot_aabb",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
+          ["const godot_real", "p_by"]
+        ]
+      },
+      {
+        "name": "godot_aabb_get_endpoint",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_aabb_operator_equal",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_aabb *", "p_self"],
+          ["const godot_aabb *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_array_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_array_new_copy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "r_dest"],
+          ["const godot_array *", "p_src"]
+        ]
+      },
+      {
+        "name": "godot_array_new_packed_color_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "r_dest"],
+          ["const godot_packed_color_array *", "p_pca"]
+        ]
+      },
+      {
+        "name": "godot_array_new_packed_vector3_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "r_dest"],
+          ["const godot_packed_vector3_array *", "p_pv3a"]
+        ]
+      },
+      {
+        "name": "godot_array_new_packed_vector2_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "r_dest"],
+          ["const godot_packed_vector2_array *", "p_pv2a"]
+        ]
+      },
+      {
+        "name": "godot_array_new_packed_string_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "r_dest"],
+          ["const godot_packed_string_array *", "p_psa"]
+        ]
+      },
+      {
+        "name": "godot_array_new_packed_float32_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "r_dest"],
+          ["const godot_packed_float32_array *", "p_pra"]
+        ]
+      },
+      {
+        "name": "godot_array_new_packed_float64_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "r_dest"],
+          ["const godot_packed_float64_array *", "p_pra"]
+        ]
+      },
+      {
+        "name": "godot_array_new_packed_int32_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "r_dest"],
+          ["const godot_packed_int32_array *", "p_pia"]
+        ]
+      },
+      {
+        "name": "godot_array_new_packed_int64_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "r_dest"],
+          ["const godot_packed_int64_array *", "p_pia"]
+        ]
+      },
+      {
+        "name": "godot_array_new_packed_byte_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "r_dest"],
+          ["const godot_packed_byte_array *", "p_pba"]
+        ]
+      },
+      {
+        "name": "godot_array_set",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const godot_variant *", "p_value"]
+        ]
+      },
+      {
+        "name": "godot_array_get",
+        "return_type": "godot_variant",
+        "arguments": [
+          ["const godot_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_array_operator_index",
+        "return_type": "godot_variant *",
+        "arguments": [
+          ["godot_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_array_operator_index_const",
+        "return_type": "const godot_variant *",
+        "arguments": [
+          ["const godot_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_array_append",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"],
+          ["const godot_variant *", "p_value"]
+        ]
+      },
+      {
+        "name": "godot_array_clear",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_count",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_array *", "p_self"],
+          ["const godot_variant *", "p_value"]
+        ]
+      },
+      {
+        "name": "godot_array_duplicate",
+        "return_type": "godot_array",
+        "arguments": [
+          ["const godot_array *", "p_self"],
+          ["const godot_bool", "p_deep"]
+        ]
+      },
+      {
+        "name": "godot_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_erase",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"],
+          ["const godot_variant *", "p_value"]
+        ]
+      },
+      {
+        "name": "godot_array_front",
+        "return_type": "godot_variant",
+        "arguments": [
+          ["const godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_back",
+        "return_type": "godot_variant",
+        "arguments": [
+          ["const godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_find",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_array *", "p_self"],
+          ["const godot_variant *", "p_what"],
+          ["const godot_int", "p_from"]
+        ]
+      },
+      {
+        "name": "godot_array_find_last",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_array *", "p_self"],
+          ["const godot_variant *", "p_what"]
+        ]
+      },
+      {
+        "name": "godot_array_has",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_array *", "p_self"],
+          ["const godot_variant *", "p_value"]
+        ]
+      },
+      {
+        "name": "godot_array_hash",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_insert",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"],
+          ["const godot_int", "p_pos"],
+          ["const godot_variant *", "p_value"]
+        ]
+      },
+      {
+        "name": "godot_array_invert",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_max",
+        "return_type": "godot_variant",
+        "arguments": [
+          ["const godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_min",
+        "return_type": "godot_variant",
+        "arguments": [
+          ["const godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_pop_back",
+        "return_type": "godot_variant",
+        "arguments": [
+          ["godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_pop_front",
+        "return_type": "godot_variant",
+        "arguments": [
+          ["godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_push_back",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"],
+          ["const godot_variant *", "p_value"]
+        ]
+      },
+      {
+        "name": "godot_array_push_front",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"],
+          ["const godot_variant *", "p_value"]
+        ]
+      },
+      {
+        "name": "godot_array_remove",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_array_resize",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"],
+          ["const godot_int", "p_size"]
+        ]
+      },
+      {
+        "name": "godot_array_rfind",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_array *", "p_self"],
+          ["const godot_variant *", "p_what"],
+          ["const godot_int", "p_from"]
+        ]
+      },
+      {
+        "name": "godot_array_size",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_shuffle",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_slice",
+        "return_type": "godot_array",
+        "arguments": [
+          ["const godot_array *", "p_self"],
+          ["const godot_int", "p_begin"],
+          ["const godot_int", "p_end"],
+          ["const godot_int", "p_step"],
+          ["const godot_bool", "p_deep"]
+        ]
+      },
+      {
+        "name": "godot_array_sort",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_array_sort_custom",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"],
+          ["godot_object *", "p_obj"],
+          ["const godot_string *", "p_func"]
+        ]
+      },
+      {
+        "name": "godot_array_bsearch",
+        "return_type": "godot_int",
+        "arguments": [
+          ["godot_array *", "p_self"],
+          ["const godot_variant *", "p_value"],
+          ["const godot_bool", "p_before"]
+        ]
+      },
+      {
+        "name": "godot_array_bsearch_custom",
+        "return_type": "godot_int",
+        "arguments": [
+          ["godot_array *", "p_self"],
+          ["const godot_variant *", "p_value"],
+          ["godot_object *", "p_obj"],
+          ["const godot_string *", "p_func"],
+          ["const godot_bool", "p_before"]
+        ]
+      },
+      {
+        "name": "godot_array_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_array *", "p_self"]
         ]
       },
       {
@@ -2512,1471 +816,538 @@
         ]
       },
       {
-        "name": "godot_vector3_new",
+        "name": "godot_basis_slerp",
+        "return_type": "godot_basis",
+        "arguments": [
+          ["const godot_basis *", "p_self"],
+          ["const godot_basis *", "p_b"],
+          ["const godot_real", "p_t"]
+        ]
+      },
+      {
+        "name": "godot_basis_get_quat",
+        "return_type": "godot_quat",
+        "arguments": [
+          ["const godot_basis *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_basis_set_quat",
         "return_type": "void",
         "arguments": [
-          ["godot_vector3 *", "r_dest"],
-          ["const godot_real", "p_x"],
-          ["const godot_real", "p_y"],
-          ["const godot_real", "p_z"]
+          ["godot_basis *", "p_self"],
+          ["const godot_quat *", "p_quat"]
         ]
       },
       {
-        "name": "godot_vector3_as_string",
-        "return_type": "godot_string",
+        "name": "godot_basis_set_axis_angle_scale",
+        "return_type": "void",
         "arguments": [
-          ["const godot_vector3 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector3_min_axis",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector3_max_axis",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector3_length",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector3_length_squared",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector3_is_normalized",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector3_normalized",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector3_inverse",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector3_snapped",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_by"]
-        ]
-      },
-      {
-        "name": "godot_vector3_rotated",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
+          ["godot_basis *", "p_self"],
           ["const godot_vector3 *", "p_axis"],
-          ["const godot_real", "p_phi"]
+          ["godot_real", "p_phi"],
+          ["const godot_vector3 *", "p_scale"]
         ]
       },
       {
-        "name": "godot_vector3_lerp",
-        "return_type": "godot_vector3",
+        "name": "godot_basis_set_euler_scale",
+        "return_type": "void",
         "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"],
-          ["const godot_real", "p_t"]
+          ["godot_basis *", "p_self"],
+          ["const godot_vector3 *", "p_euler"],
+          ["const godot_vector3 *", "p_scale"]
         ]
       },
       {
-        "name": "godot_vector3_cubic_interpolate",
-        "return_type": "godot_vector3",
+        "name": "godot_basis_set_quat_scale",
+        "return_type": "void",
         "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"],
-          ["const godot_vector3 *", "p_pre_a"],
-          ["const godot_vector3 *", "p_post_b"],
-          ["const godot_real", "p_t"]
+          ["godot_basis *", "p_self"],
+          ["const godot_quat *", "p_quat"],
+          ["const godot_vector3 *", "p_scale"]
         ]
       },
       {
-        "name": "godot_vector3_dot",
-        "return_type": "godot_real",
+        "name": "godot_callable_new_with_object",
+        "return_type": "void",
         "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"]
+          ["godot_callable *", "r_dest"],
+          ["const godot_object *", "p_object"],
+          ["const godot_string_name *", "p_method"]
         ]
       },
       {
-        "name": "godot_vector3_cross",
-        "return_type": "godot_vector3",
+        "name": "godot_callable_new_with_object_id",
+        "return_type": "void",
         "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"]
+          ["godot_callable *", "r_dest"],
+          ["uint64_t", "p_objectid"],
+          ["const godot_string_name *", "p_method"]
         ]
       },
       {
-        "name": "godot_vector3_outer",
-        "return_type": "godot_basis",
+        "name": "godot_callable_new_copy",
+        "return_type": "void",
         "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"]
+          ["godot_callable *", "r_dest"],
+          ["const godot_callable *", "p_src"]
         ]
       },
       {
-        "name": "godot_vector3_to_diagonal_matrix",
-        "return_type": "godot_basis",
+        "name": "godot_callable_destroy",
+        "return_type": "void",
         "arguments": [
-          ["const godot_vector3 *", "p_self"]
+          ["godot_callable *", "p_self"]
         ]
       },
       {
-        "name": "godot_vector3_abs",
-        "return_type": "godot_vector3",
+        "name": "godot_callable_call",
+        "return_type": "godot_int",
         "arguments": [
-          ["const godot_vector3 *", "p_self"]
+          ["const godot_callable *", "p_self"],
+          ["const godot_variant **", "p_arguments"],
+          ["godot_int", "p_argcount"],
+          ["godot_variant *", "r_return_value"]
         ]
       },
       {
-        "name": "godot_vector3_floor",
-        "return_type": "godot_vector3",
+        "name": "godot_callable_call_deferred",
+        "return_type": "void",
         "arguments": [
-          ["const godot_vector3 *", "p_self"]
+          ["const godot_callable *", "p_self"],
+          ["const godot_variant **", "p_arguments"],
+          ["godot_int", "p_argcount"]
         ]
-      },
+      },  
       {
-        "name": "godot_vector3_ceil",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector3_distance_to",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector3_distance_squared_to",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector3_angle_to",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_to"]
-        ]
-      },
-      {
-        "name": "godot_vector3_slide",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_n"]
-        ]
-      },
-      {
-        "name": "godot_vector3_bounce",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_n"]
-        ]
-      },
-      {
-        "name": "godot_vector3_reflect",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_n"]
-        ]
-      },
-      {
-        "name": "godot_vector3_operator_add",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector3_operator_subtract",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector3_operator_multiply_vector",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector3_operator_multiply_scalar",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_real", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector3_operator_divide_vector",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector3_operator_divide_scalar",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_real", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_vector3_operator_equal",
+        "name": "godot_callable_is_null",
         "return_type": "godot_bool",
         "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"]
+          ["const godot_callable *", "p_self"]
         ]
-      },
+      },  
       {
-        "name": "godot_vector3_operator_less",
+        "name": "godot_callable_is_custom",
         "return_type": "godot_bool",
         "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3 *", "p_b"]
+          ["const godot_callable *", "p_self"]
         ]
-      },
+      },  
       {
-        "name": "godot_vector3_operator_neg",
-        "return_type": "godot_vector3",
+        "name": "godot_callable_is_standard",
+        "return_type": "godot_bool",
         "arguments": [
-          ["const godot_vector3 *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_vector3_set_axis",
-        "return_type": "void",
-        "arguments": [
-          ["godot_vector3 *", "p_self"],
-          ["const godot_vector3_axis", "p_axis"],
-          ["const godot_real", "p_val"]
-        ]
-      },
-      {
-        "name": "godot_vector3_get_axis",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_vector3 *", "p_self"],
-          ["const godot_vector3_axis", "p_axis"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_new",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_byte_array *", "r_dest"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_new_copy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_byte_array *", "r_dest"],
-          ["const godot_packed_byte_array *", "p_src"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_new_with_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_byte_array *", "r_dest"],
-          ["const godot_array *", "p_a"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_byte_array *", "p_self"],
-          ["const uint8_t", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_append_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_byte_array *", "p_self"],
-          ["const godot_packed_byte_array *", "p_array"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_insert",
-        "return_type": "godot_error",
-        "arguments": [
-          ["godot_packed_byte_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const uint8_t", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_invert",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_byte_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_push_back",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_byte_array *", "p_self"],
-          ["const uint8_t", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_remove",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_byte_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_resize",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_byte_array *", "p_self"],
-          ["const godot_int", "p_size"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_ptr",
-        "return_type": "const uint8_t *",
-        "arguments": [
-          ["const godot_packed_byte_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_ptrw",
-        "return_type": "uint8_t *",
-        "arguments": [
-          ["godot_packed_byte_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_set",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_byte_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const uint8_t", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_get",
-        "return_type": "uint8_t",
-        "arguments": [
-          ["const godot_packed_byte_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_size",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_packed_byte_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_byte_array_destroy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_byte_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_new",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int32_array *", "r_dest"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_new_copy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int32_array *", "r_dest"],
-          ["const godot_packed_int32_array *", "p_src"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_new_with_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int32_array *", "r_dest"],
-          ["const godot_array *", "p_a"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int32_array *", "p_self"],
-          ["const int32_t", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_append_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int32_array *", "p_self"],
-          ["const godot_packed_int32_array *", "p_array"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_insert",
-        "return_type": "godot_error",
-        "arguments": [
-          ["godot_packed_int32_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const int32_t", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_invert",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int32_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_push_back",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int32_array *", "p_self"],
-          ["const int32_t", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_remove",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int32_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_resize",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int32_array *", "p_self"],
-          ["const godot_int", "p_size"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_ptr",
-        "return_type": "const int32_t *",
-        "arguments": [
-          ["const godot_packed_int32_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_ptrw",
-        "return_type": "int32_t *",
-        "arguments": [
-          ["godot_packed_int32_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_set",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int32_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const int32_t", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_get",
-        "return_type": "int32_t",
-        "arguments": [
-          ["const godot_packed_int32_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_size",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_packed_int32_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_int32_array_destroy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_int32_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_new",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float32_array *", "r_dest"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_new_copy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float32_array *", "r_dest"],
-          ["const godot_packed_float32_array *", "p_src"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_new_with_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float32_array *", "r_dest"],
-          ["const godot_array *", "p_a"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float32_array *", "p_self"],
-          ["const float", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_append_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float32_array *", "p_self"],
-          ["const godot_packed_float32_array *", "p_array"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_insert",
-        "return_type": "godot_error",
-        "arguments": [
-          ["godot_packed_float32_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const float", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_invert",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float32_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_push_back",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float32_array *", "p_self"],
-          ["const float", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_remove",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float32_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_resize",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float32_array *", "p_self"],
-          ["const godot_int", "p_size"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_ptr",
-        "return_type": "const float *",
-        "arguments": [
-          ["const godot_packed_float32_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_ptrw",
-        "return_type": "float *",
-        "arguments": [
-          ["godot_packed_float32_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_set",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float32_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const float", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_get",
-        "return_type": "float",
-        "arguments": [
-          ["const godot_packed_float32_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_size",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_packed_float32_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_float32_array_destroy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_float32_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_new",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_string_array *", "r_dest"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_new_copy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_string_array *", "r_dest"],
-          ["const godot_packed_string_array *", "p_src"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_new_with_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_string_array *", "r_dest"],
-          ["const godot_array *", "p_a"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_string_array *", "p_self"],
-          ["const godot_string *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_append_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_string_array *", "p_self"],
-          ["const godot_packed_string_array *", "p_array"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_insert",
-        "return_type": "godot_error",
-        "arguments": [
-          ["godot_packed_string_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const godot_string *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_invert",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_string_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_push_back",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_string_array *", "p_self"],
-          ["const godot_string *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_remove",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_string_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_resize",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_string_array *", "p_self"],
-          ["const godot_int", "p_size"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_ptr",
-        "return_type": "const godot_string *",
-        "arguments": [
-          ["const godot_packed_string_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_ptrw",
-        "return_type": "godot_string *",
-        "arguments": [
-          ["godot_packed_string_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_set",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_string_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const godot_string *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_get",
-        "return_type": "godot_string",
-        "arguments": [
-          ["const godot_packed_string_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_size",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_packed_string_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_string_array_destroy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_string_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_new",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2_array *", "r_dest"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_new_copy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2_array *", "r_dest"],
-          ["const godot_packed_vector2_array *", "p_src"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_new_with_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2_array *", "r_dest"],
-          ["const godot_array *", "p_a"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2_array *", "p_self"],
-          ["const godot_vector2 *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_append_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2_array *", "p_self"],
-          ["const godot_packed_vector2_array *", "p_array"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_insert",
-        "return_type": "godot_error",
-        "arguments": [
-          ["godot_packed_vector2_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const godot_vector2 *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_invert",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_push_back",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2_array *", "p_self"],
-          ["const godot_vector2 *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_remove",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_resize",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2_array *", "p_self"],
-          ["const godot_int", "p_size"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_ptr",
-        "return_type": "const godot_vector2 *",
-        "arguments": [
-          ["const godot_packed_vector2_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_ptrw",
-        "return_type": "godot_vector2 *",
-        "arguments": [
-          ["godot_packed_vector2_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_set",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const godot_vector2 *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_get",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_packed_vector2_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_size",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_packed_vector2_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector2_array_destroy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector2_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_new",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector3_array *", "r_dest"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_new_copy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector3_array *", "r_dest"],
-          ["const godot_packed_vector3_array *", "p_src"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_new_with_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector3_array *", "r_dest"],
-          ["const godot_array *", "p_a"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector3_array *", "p_self"],
-          ["const godot_vector3 *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_append_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector3_array *", "p_self"],
-          ["const godot_packed_vector3_array *", "p_array"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_insert",
-        "return_type": "godot_error",
-        "arguments": [
-          ["godot_packed_vector3_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const godot_vector3 *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_invert",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector3_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_push_back",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector3_array *", "p_self"],
-          ["const godot_vector3 *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_remove",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector3_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_resize",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector3_array *", "p_self"],
-          ["const godot_int", "p_size"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_ptr",
-        "return_type": "const godot_vector3 *",
-        "arguments": [
-          ["const godot_packed_vector3_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_ptrw",
-        "return_type": "godot_vector3 *",
-        "arguments": [
-          ["godot_packed_vector3_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_set",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector3_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const godot_vector3 *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_get",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_packed_vector3_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_size",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_packed_vector3_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_vector3_array_destroy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_vector3_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_color_array_new",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_color_array *", "r_dest"]
-        ]
-      },
-      {
-        "name": "godot_packed_color_array_new_copy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_color_array *", "r_dest"],
-          ["const godot_packed_color_array *", "p_src"]
-        ]
-      },
-      {
-        "name": "godot_packed_color_array_new_with_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_color_array *", "r_dest"],
-          ["const godot_array *", "p_a"]
-        ]
-      },
-      {
-        "name": "godot_packed_color_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_color_array *", "p_self"],
-          ["const godot_color *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_color_array_append_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_color_array *", "p_self"],
-          ["const godot_packed_color_array *", "p_array"]
-        ]
-      },
-      {
-        "name": "godot_packed_color_array_insert",
-        "return_type": "godot_error",
-        "arguments": [
-          ["godot_packed_color_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const godot_color *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_color_array_invert",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_color_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_packed_color_array_push_back",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_color_array *", "p_self"],
-          ["const godot_color *", "p_data"]
-        ]
-      },
-      {
-        "name": "godot_packed_color_array_remove",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_color_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_packed_color_array_resize",
-        "return_type": "void",
-        "arguments": [
-          ["godot_packed_color_array *", "p_self"],
-          ["const godot_int", "p_size"]
+          ["const godot_callable *", "p_self"]
         ]
       },    
       {
-        "name": "godot_packed_color_array_ptr",
-        "return_type": "const godot_color *",
+        "name": "godot_callable_get_object",
+        "return_type": "godot_object *",
         "arguments": [
-          ["const godot_packed_color_array *", "p_self"]
+          ["const godot_callable *", "p_self"]
+        ]
+      },    
+      {
+        "name": "godot_callable_get_object_id",
+        "return_type": "uint64_t",
+        "arguments": [
+          ["const godot_callable *", "p_self"]
+        ]
+      },    
+      {
+        "name": "godot_callable_get_method",
+        "return_type": "godot_string_name",
+        "arguments": [
+          ["const godot_callable *", "p_self"]
         ]
       },
       {
-        "name": "godot_packed_color_array_ptrw",
-        "return_type": "godot_color *",
+        "name": "godot_callable_hash",
+        "return_type": "uint32_t",
         "arguments": [
-          ["godot_packed_color_array *", "p_self"]
+          ["const godot_callable *", "p_self"]
         ]
       },
       {
-        "name": "godot_packed_color_array_set",
+        "name": "godot_callable_as_string",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_callable *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_callable_operator_equal",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_callable *", "p_self"],
+          ["const godot_callable *", "p_other"]
+        ]
+      },
+      {
+        "name": "godot_callable_operator_less",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_callable *", "p_self"],
+          ["const godot_callable *", "p_other"]
+        ]
+      },
+      {
+        "name": "godot_signal_new_with_object",
         "return_type": "void",
         "arguments": [
-          ["godot_packed_color_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const godot_color *", "p_data"]
+          ["godot_signal *", "r_dest"],
+          ["const godot_object *", "p_object"],
+          ["const godot_string_name *", "p_method"]
         ]
       },
       {
-        "name": "godot_packed_color_array_get",
+        "name": "godot_signal_new_with_object_id",
+        "return_type": "void",
+        "arguments": [
+          ["godot_signal *", "r_dest"],
+          ["uint64_t", "p_objectid"],
+          ["const godot_string_name *", "p_method"]
+        ]
+      },
+      {
+        "name": "godot_signal_new_copy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_signal *", "r_dest"],
+          ["const godot_signal *", "p_src"]
+        ]
+      },
+      {
+        "name": "godot_signal_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_signal *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_signal_emit",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_signal *", "p_self"],
+          ["const godot_variant **", "p_arguments"],
+          ["godot_int", "p_argcount"]
+        ]
+      },
+      {
+        "name": "godot_signal_connect",
+        "return_type": "godot_int",
+        "arguments": [
+          ["godot_signal *", "p_self"],
+          ["const godot_callable *", "p_callable"],
+          ["const godot_array *", "p_binds"],
+          ["uint32_t", "p_flags"]
+        ]
+      },
+      {
+        "name": "godot_signal_disconnect",
+        "return_type": "void",
+        "arguments": [
+          ["godot_signal *", "p_self"],
+          ["const godot_callable *", "p_callable"]
+        ]
+      },
+      {
+        "name": "godot_signal_is_null",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_signal *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_signal_is_connected",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_signal *", "p_self"],
+          ["const godot_callable *", "p_callable"]
+        ]
+      },
+      {
+        "name": "godot_signal_get_connections",
+        "return_type": "godot_array",
+        "arguments": [
+          ["const godot_signal *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_signal_get_object",
+        "return_type": "godot_object *",
+        "arguments": [
+          ["const godot_signal *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_signal_get_object_id",
+        "return_type": "uint64_t",
+        "arguments": [
+          ["const godot_signal *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_signal_get_name",
+        "return_type": "godot_string_name",
+        "arguments": [
+          ["const godot_signal *", "p_self"]
+        ]
+      },  
+      {
+        "name": "godot_signal_as_string",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_signal *", "p_self"]
+        ]
+      },  
+      {
+        "name": "godot_signal_operator_equal",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_signal *", "p_self"],
+          ["const godot_signal *", "p_other"]
+        ]
+      },  
+      {
+        "name": "godot_signal_operator_less",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_signal *", "p_self"],
+          ["const godot_signal *", "p_other"]
+        ]
+      },
+      {
+        "name": "godot_color_new_rgba",
+        "return_type": "void",
+        "arguments": [
+          ["godot_color *", "r_dest"],
+          ["const godot_real", "p_r"],
+          ["const godot_real", "p_g"],
+          ["const godot_real", "p_b"],
+          ["const godot_real", "p_a"]
+        ]
+      },
+      {
+        "name": "godot_color_new_rgb",
+        "return_type": "void",
+        "arguments": [
+          ["godot_color *", "r_dest"],
+          ["const godot_real", "p_r"],
+          ["const godot_real", "p_g"],
+          ["const godot_real", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_color_get_r",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_color *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_color_set_r",
+        "return_type": "void",
+        "arguments": [
+          ["godot_color *", "p_self"],
+          ["const godot_real", "r"]
+        ]
+      },
+      {
+        "name": "godot_color_get_g",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_color *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_color_set_g",
+        "return_type": "void",
+        "arguments": [
+          ["godot_color *", "p_self"],
+          ["const godot_real", "g"]
+        ]
+      },
+      {
+        "name": "godot_color_get_b",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_color *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_color_set_b",
+        "return_type": "void",
+        "arguments": [
+          ["godot_color *", "p_self"],
+          ["const godot_real", "b"]
+        ]
+      },
+      {
+        "name": "godot_color_get_a",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_color *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_color_set_a",
+        "return_type": "void",
+        "arguments": [
+          ["godot_color *", "p_self"],
+          ["const godot_real", "a"]
+        ]
+      },
+      {
+        "name": "godot_color_get_h",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_color *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_color_get_s",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_color *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_color_get_v",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_color *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_color_as_string",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_color *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_color_to_rgba32",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_color *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_color_to_argb32",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_color *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_color_inverted",
         "return_type": "godot_color",
         "arguments": [
-          ["const godot_packed_color_array *", "p_self"],
-          ["const godot_int", "p_idx"]
+          ["const godot_color *", "p_self"]
         ]
       },
       {
-        "name": "godot_packed_color_array_size",
-        "return_type": "godot_int",
+        "name": "godot_color_contrasted",
+        "return_type": "godot_color",
         "arguments": [
-          ["const godot_packed_color_array *", "p_self"]
+          ["const godot_color *", "p_self"]
         ]
       },
       {
-        "name": "godot_packed_color_array_destroy",
-        "return_type": "void",
+        "name": "godot_color_lerp",
+        "return_type": "godot_color",
         "arguments": [
-          ["godot_packed_color_array *", "p_self"]
+          ["const godot_color *", "p_self"],
+          ["const godot_color *", "p_b"],
+          ["const godot_real", "p_t"]
         ]
       },
       {
-        "name": "godot_array_new",
-        "return_type": "void",
+        "name": "godot_color_blend",
+        "return_type": "godot_color",
         "arguments": [
-          ["godot_array *", "r_dest"]
+          ["const godot_color *", "p_self"],
+          ["const godot_color *", "p_over"]
         ]
       },
       {
-        "name": "godot_array_new_copy",
-        "return_type": "void",
+        "name": "godot_color_to_html",
+        "return_type": "godot_string",
         "arguments": [
-          ["godot_array *", "r_dest"],
-          ["const godot_array *", "p_src"]
+          ["const godot_color *", "p_self"],
+          ["const godot_bool", "p_with_alpha"]
         ]
       },
       {
-        "name": "godot_array_new_packed_color_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "r_dest"],
-          ["const godot_packed_color_array *", "p_pca"]
-        ]
-      },
-      {
-        "name": "godot_array_new_packed_vector3_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "r_dest"],
-          ["const godot_packed_vector3_array *", "p_pv3a"]
-        ]
-      },
-      {
-        "name": "godot_array_new_packed_vector2_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "r_dest"],
-          ["const godot_packed_vector2_array *", "p_pv2a"]
-        ]
-      },
-      {
-        "name": "godot_array_new_packed_string_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "r_dest"],
-          ["const godot_packed_string_array *", "p_psa"]
-        ]
-      },
-      {
-        "name": "godot_array_new_packed_float32_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "r_dest"],
-          ["const godot_packed_float32_array *", "p_pra"]
-        ]
-      },
-      {
-        "name": "godot_array_new_packed_int32_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "r_dest"],
-          ["const godot_packed_int32_array *", "p_pia"]
-        ]
-      },
-      {
-        "name": "godot_array_new_packed_byte_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "r_dest"],
-          ["const godot_packed_byte_array *", "p_pba"]
-        ]
-      },
-      {
-        "name": "godot_array_set",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"],
-          ["const godot_int", "p_idx"],
-          ["const godot_variant *", "p_value"]
-        ]
-      },
-      {
-        "name": "godot_array_get",
-        "return_type": "godot_variant",
-        "arguments": [
-          ["const godot_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_array_operator_index",
-        "return_type": "godot_variant *",
-        "arguments": [
-          ["godot_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_array_operator_index_const",
-        "return_type": "const godot_variant *",
-        "arguments": [
-          ["const godot_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_array_append",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"],
-          ["const godot_variant *", "p_value"]
-        ]
-      },
-      {
-        "name": "godot_array_clear",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_array_count",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_array *", "p_self"],
-          ["const godot_variant *", "p_value"]
-        ]
-      },
-      {
-        "name": "godot_array_empty",
+        "name": "godot_color_operator_equal",
         "return_type": "godot_bool",
         "arguments": [
-          ["const godot_array *", "p_self"]
+          ["const godot_color *", "p_self"],
+          ["const godot_color *", "p_b"]
         ]
       },
       {
-        "name": "godot_array_erase",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"],
-          ["const godot_variant *", "p_value"]
-        ]
-      },
-      {
-        "name": "godot_array_front",
-        "return_type": "godot_variant",
-        "arguments": [
-          ["const godot_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_array_back",
-        "return_type": "godot_variant",
-        "arguments": [
-          ["const godot_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_array_find",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_array *", "p_self"],
-          ["const godot_variant *", "p_what"],
-          ["const godot_int", "p_from"]
-        ]
-      },
-      {
-        "name": "godot_array_find_last",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_array *", "p_self"],
-          ["const godot_variant *", "p_what"]
-        ]
-      },
-      {
-        "name": "godot_array_has",
+        "name": "godot_color_operator_less",
         "return_type": "godot_bool",
         "arguments": [
-          ["const godot_array *", "p_self"],
-          ["const godot_variant *", "p_value"]
+          ["const godot_color *", "p_self"],
+          ["const godot_color *", "p_b"]
         ]
       },
       {
-        "name": "godot_array_hash",
+        "name": "godot_color_to_abgr32",
         "return_type": "godot_int",
         "arguments": [
-          ["const godot_array *", "p_self"]
+          ["const godot_color *", "p_self"]
         ]
       },
       {
-        "name": "godot_array_insert",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"],
-          ["const godot_int", "p_pos"],
-          ["const godot_variant *", "p_value"]
-        ]
-      },
-      {
-        "name": "godot_array_invert",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_array_pop_back",
-        "return_type": "godot_variant",
-        "arguments": [
-          ["godot_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_array_pop_front",
-        "return_type": "godot_variant",
-        "arguments": [
-          ["godot_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_array_push_back",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"],
-          ["const godot_variant *", "p_value"]
-        ]
-      },
-      {
-        "name": "godot_array_push_front",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"],
-          ["const godot_variant *", "p_value"]
-        ]
-      },
-      {
-        "name": "godot_array_remove",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_array_resize",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"],
-          ["const godot_int", "p_size"]
-        ]
-      },
-      {
-        "name": "godot_array_rfind",
+        "name": "godot_color_to_abgr64",
         "return_type": "godot_int",
         "arguments": [
-          ["const godot_array *", "p_self"],
-          ["const godot_variant *", "p_what"],
-          ["const godot_int", "p_from"]
+          ["const godot_color *", "p_self"]
         ]
       },
       {
-        "name": "godot_array_size",
+        "name": "godot_color_to_argb64",
         "return_type": "godot_int",
         "arguments": [
-          ["const godot_array *", "p_self"]
+          ["const godot_color *", "p_self"]
         ]
       },
       {
-        "name": "godot_array_sort",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_array_sort_custom",
-        "return_type": "void",
-        "arguments": [
-          ["godot_array *", "p_self"],
-          ["godot_object *", "p_obj"],
-          ["const godot_string *", "p_func"]
-        ]
-      },
-      {
-        "name": "godot_array_bsearch",
+        "name": "godot_color_to_rgba64",
         "return_type": "godot_int",
         "arguments": [
-          ["godot_array *", "p_self"],
-          ["const godot_variant *", "p_value"],
-          ["const godot_bool", "p_before"]
+          ["const godot_color *", "p_self"]
         ]
       },
       {
-        "name": "godot_array_bsearch_custom",
-        "return_type": "godot_int",
+        "name": "godot_color_darkened",
+        "return_type": "godot_color",
         "arguments": [
-          ["godot_array *", "p_self"],
-          ["const godot_variant *", "p_value"],
-          ["godot_object *", "p_obj"],
-          ["const godot_string *", "p_func"],
-          ["const godot_bool", "p_before"]
+          ["const godot_color *", "p_self"],
+          ["const godot_real", "p_amount"]
         ]
       },
       {
-        "name": "godot_array_destroy",
-        "return_type": "void",
+        "name": "godot_color_from_hsv",
+        "return_type": "godot_color",
         "arguments": [
-          ["godot_array *", "p_self"]
+          ["const godot_color *", "p_self"],
+          ["const godot_real", "p_h"],
+          ["const godot_real", "p_s"],
+          ["const godot_real", "p_v"],
+          ["const godot_real", "p_a"]
+        ]
+      },
+      {
+        "name": "godot_color_lightened",
+        "return_type": "godot_color",
+        "arguments": [
+          ["const godot_color *", "p_self"],
+          ["const godot_real", "p_amount"]
         ]
       },
       {
@@ -4124,6 +1495,31 @@
         ]
       },
       {
+        "name": "godot_dictionary_duplicate",
+        "return_type": "godot_dictionary",
+        "arguments": [
+          ["const godot_dictionary *", "p_self"],
+          ["const godot_bool", "p_deep"]
+        ]
+      },
+      {
+        "name": "godot_dictionary_get_with_default",
+        "return_type": "godot_variant",
+        "arguments": [
+          ["const godot_dictionary *", "p_self"],
+          ["const godot_variant *", "p_key"],
+          ["const godot_variant *", "p_default"]
+        ]
+      },
+      {
+        "name": "godot_dictionary_erase_with_return",
+        "return_type": "bool",
+        "arguments": [
+          ["godot_dictionary *", "p_self"],
+          ["const godot_variant *", "p_key"]
+        ]
+      },
+      {
         "name": "godot_node_path_new",
         "return_type": "void",
         "arguments": [
@@ -4210,6 +1606,1192 @@
         "arguments": [
           ["const godot_node_path *", "p_self"],
           ["const godot_node_path *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_node_path_get_as_property_path",
+        "return_type": "godot_node_path",
+        "arguments": [
+          ["const godot_node_path *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_byte_array *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_new_copy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_byte_array *", "r_dest"],
+          ["const godot_packed_byte_array *", "p_src"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_new_with_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_byte_array *", "r_dest"],
+          ["const godot_array *", "p_a"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_packed_byte_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_append",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_byte_array *", "p_self"],
+          ["const uint8_t", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_append_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_byte_array *", "p_self"],
+          ["const godot_packed_byte_array *", "p_array"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_insert",
+        "return_type": "godot_error",
+        "arguments": [
+          ["godot_packed_byte_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const uint8_t", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_invert",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_byte_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_push_back",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_byte_array *", "p_self"],
+          ["const uint8_t", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_remove",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_byte_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_resize",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_byte_array *", "p_self"],
+          ["const godot_int", "p_size"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_ptr",
+        "return_type": "const uint8_t *",
+        "arguments": [
+          ["const godot_packed_byte_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_ptrw",
+        "return_type": "uint8_t *",
+        "arguments": [
+          ["godot_packed_byte_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_set",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_byte_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const uint8_t", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_get",
+        "return_type": "uint8_t",
+        "arguments": [
+          ["const godot_packed_byte_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_size",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_packed_byte_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_byte_array_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_byte_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int32_array *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_new_copy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int32_array *", "r_dest"],
+          ["const godot_packed_int32_array *", "p_src"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_new_with_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int32_array *", "r_dest"],
+          ["const godot_array *", "p_a"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_packed_int32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_append",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int32_array *", "p_self"],
+          ["const int32_t", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_append_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int32_array *", "p_self"],
+          ["const godot_packed_int32_array *", "p_array"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_insert",
+        "return_type": "godot_error",
+        "arguments": [
+          ["godot_packed_int32_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const int32_t", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_invert",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_push_back",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int32_array *", "p_self"],
+          ["const int32_t", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_remove",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int32_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_resize",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int32_array *", "p_self"],
+          ["const godot_int", "p_size"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_ptr",
+        "return_type": "const int32_t *",
+        "arguments": [
+          ["const godot_packed_int32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_ptrw",
+        "return_type": "int32_t *",
+        "arguments": [
+          ["godot_packed_int32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_set",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int32_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const int32_t", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_get",
+        "return_type": "int32_t",
+        "arguments": [
+          ["const godot_packed_int32_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_size",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_packed_int32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int32_array_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int64_array *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_new_copy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int64_array *", "r_dest"],
+          ["const godot_packed_int64_array *", "p_src"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_new_with_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int64_array *", "r_dest"],
+          ["const godot_array *", "p_a"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_packed_int64_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_append",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int64_array *", "p_self"],
+          ["const int64_t", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_append_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int64_array *", "p_self"],
+          ["const godot_packed_int64_array *", "p_array"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_insert",
+        "return_type": "godot_error",
+        "arguments": [
+          ["godot_packed_int64_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const int64_t", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_invert",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int64_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_push_back",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int64_array *", "p_self"],
+          ["const int64_t", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_remove",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int64_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_resize",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int64_array *", "p_self"],
+          ["const godot_int", "p_size"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_ptr",
+        "return_type": "const int64_t *",
+        "arguments": [
+          ["const godot_packed_int64_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_ptrw",
+        "return_type": "int64_t *",
+        "arguments": [
+          ["godot_packed_int64_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_set",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int64_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const int64_t", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_get",
+        "return_type": "int64_t",
+        "arguments": [
+          ["const godot_packed_int64_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_size",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_packed_int64_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_int64_array_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_int64_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float32_array *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_new_copy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float32_array *", "r_dest"],
+          ["const godot_packed_float32_array *", "p_src"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_new_with_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float32_array *", "r_dest"],
+          ["const godot_array *", "p_a"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_packed_float32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_append",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float32_array *", "p_self"],
+          ["const float", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_append_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float32_array *", "p_self"],
+          ["const godot_packed_float32_array *", "p_array"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_insert",
+        "return_type": "godot_error",
+        "arguments": [
+          ["godot_packed_float32_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const float", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_invert",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_push_back",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float32_array *", "p_self"],
+          ["const float", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_remove",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float32_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_resize",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float32_array *", "p_self"],
+          ["const godot_int", "p_size"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_ptr",
+        "return_type": "const float *",
+        "arguments": [
+          ["const godot_packed_float32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_ptrw",
+        "return_type": "float *",
+        "arguments": [
+          ["godot_packed_float32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_set",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float32_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const float", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_get",
+        "return_type": "float",
+        "arguments": [
+          ["const godot_packed_float32_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_size",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_packed_float32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float32_array_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float32_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float64_array *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_new_copy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float64_array *", "r_dest"],
+          ["const godot_packed_float64_array *", "p_src"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_new_with_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float64_array *", "r_dest"],
+          ["const godot_array *", "p_a"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_packed_float64_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_append",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float64_array *", "p_self"],
+          ["const double", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_append_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float64_array *", "p_self"],
+          ["const godot_packed_float64_array *", "p_array"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_insert",
+        "return_type": "godot_error",
+        "arguments": [
+          ["godot_packed_float64_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const double", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_invert",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float64_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_push_back",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float64_array *", "p_self"],
+          ["const double", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_remove",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float64_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_resize",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float64_array *", "p_self"],
+          ["const godot_int", "p_size"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_ptr",
+        "return_type": "const double *",
+        "arguments": [
+          ["const godot_packed_float64_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_ptrw",
+        "return_type": "double *",
+        "arguments": [
+          ["godot_packed_float64_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_set",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float64_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const double", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_get",
+        "return_type": "double",
+        "arguments": [
+          ["const godot_packed_float64_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_size",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_packed_float64_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_float64_array_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_float64_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_string_array *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_new_copy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_string_array *", "r_dest"],
+          ["const godot_packed_string_array *", "p_src"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_new_with_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_string_array *", "r_dest"],
+          ["const godot_array *", "p_a"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_packed_string_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_append",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_string_array *", "p_self"],
+          ["const godot_string *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_append_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_string_array *", "p_self"],
+          ["const godot_packed_string_array *", "p_array"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_insert",
+        "return_type": "godot_error",
+        "arguments": [
+          ["godot_packed_string_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const godot_string *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_invert",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_string_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_push_back",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_string_array *", "p_self"],
+          ["const godot_string *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_remove",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_string_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_resize",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_string_array *", "p_self"],
+          ["const godot_int", "p_size"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_ptr",
+        "return_type": "const godot_string *",
+        "arguments": [
+          ["const godot_packed_string_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_ptrw",
+        "return_type": "godot_string *",
+        "arguments": [
+          ["godot_packed_string_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_set",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_string_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const godot_string *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_get",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_packed_string_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_size",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_packed_string_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_string_array_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_string_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector2_array *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_new_copy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector2_array *", "r_dest"],
+          ["const godot_packed_vector2_array *", "p_src"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_new_with_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector2_array *", "r_dest"],
+          ["const godot_array *", "p_a"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_packed_vector2_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_append",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector2_array *", "p_self"],
+          ["const godot_vector2 *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_append_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector2_array *", "p_self"],
+          ["const godot_packed_vector2_array *", "p_array"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_insert",
+        "return_type": "godot_error",
+        "arguments": [
+          ["godot_packed_vector2_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const godot_vector2 *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_invert",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector2_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_push_back",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector2_array *", "p_self"],
+          ["const godot_vector2 *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_remove",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector2_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_resize",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector2_array *", "p_self"],
+          ["const godot_int", "p_size"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_ptr",
+        "return_type": "const godot_vector2 *",
+        "arguments": [
+          ["const godot_packed_vector2_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_ptrw",
+        "return_type": "godot_vector2 *",
+        "arguments": [
+          ["godot_packed_vector2_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_set",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector2_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const godot_vector2 *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_get",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_packed_vector2_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_size",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_packed_vector2_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector2_array_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector2_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector3_array *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_new_copy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector3_array *", "r_dest"],
+          ["const godot_packed_vector3_array *", "p_src"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_new_with_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector3_array *", "r_dest"],
+          ["const godot_array *", "p_a"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_packed_vector3_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_append",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector3_array *", "p_self"],
+          ["const godot_vector3 *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_append_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector3_array *", "p_self"],
+          ["const godot_packed_vector3_array *", "p_array"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_insert",
+        "return_type": "godot_error",
+        "arguments": [
+          ["godot_packed_vector3_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const godot_vector3 *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_invert",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector3_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_push_back",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector3_array *", "p_self"],
+          ["const godot_vector3 *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_remove",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector3_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_resize",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector3_array *", "p_self"],
+          ["const godot_int", "p_size"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_ptr",
+        "return_type": "const godot_vector3 *",
+        "arguments": [
+          ["const godot_packed_vector3_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_ptrw",
+        "return_type": "godot_vector3 *",
+        "arguments": [
+          ["godot_packed_vector3_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_set",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector3_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const godot_vector3 *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_get",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_packed_vector3_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_size",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_packed_vector3_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_vector3_array_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_vector3_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_color_array *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_new_copy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_color_array *", "r_dest"],
+          ["const godot_packed_color_array *", "p_src"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_new_with_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_color_array *", "r_dest"],
+          ["const godot_array *", "p_a"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_empty",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_packed_color_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_append",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_color_array *", "p_self"],
+          ["const godot_color *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_append_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_color_array *", "p_self"],
+          ["const godot_packed_color_array *", "p_array"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_insert",
+        "return_type": "godot_error",
+        "arguments": [
+          ["godot_packed_color_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const godot_color *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_invert",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_color_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_push_back",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_color_array *", "p_self"],
+          ["const godot_color *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_remove",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_color_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_resize",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_color_array *", "p_self"],
+          ["const godot_int", "p_size"]
+        ]
+      },    
+      {
+        "name": "godot_packed_color_array_ptr",
+        "return_type": "const godot_color *",
+        "arguments": [
+          ["const godot_packed_color_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_ptrw",
+        "return_type": "godot_color *",
+        "arguments": [
+          ["godot_packed_color_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_set",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_color_array *", "p_self"],
+          ["const godot_int", "p_idx"],
+          ["const godot_color *", "p_data"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_get",
+        "return_type": "godot_color",
+        "arguments": [
+          ["const godot_packed_color_array *", "p_self"],
+          ["const godot_int", "p_idx"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_size",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_packed_color_array *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_packed_color_array_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_packed_color_array *", "p_self"]
         ]
       },
       {
@@ -4379,6 +2961,245 @@
         ]
       },
       {
+        "name": "godot_quat_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_quat *", "r_dest"],
+          ["const godot_real", "p_x"],
+          ["const godot_real", "p_y"],
+          ["const godot_real", "p_z"],
+          ["const godot_real", "p_w"]
+        ]
+      },
+      {
+        "name": "godot_quat_new_with_axis_angle",
+        "return_type": "void",
+        "arguments": [
+          ["godot_quat *", "r_dest"],
+          ["const godot_vector3 *", "p_axis"],
+          ["const godot_real", "p_angle"]
+        ]
+      },
+      {
+        "name": "godot_quat_new_with_basis",
+        "return_type": "void",
+        "arguments": [
+          ["godot_quat *", "r_dest"],
+          ["const godot_basis *", "p_basis"]
+        ]
+      },
+      {
+        "name": "godot_quat_new_with_euler",
+        "return_type": "void",
+        "arguments": [
+          ["godot_quat *", "r_dest"],
+          ["const godot_vector3 *", "p_euler"]
+        ]
+      },
+      {
+        "name": "godot_quat_get_x",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_quat *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_quat_set_x",
+        "return_type": "void",
+        "arguments": [
+          ["godot_quat *", "p_self"],
+          ["const godot_real", "val"]
+        ]
+      },
+      {
+        "name": "godot_quat_get_y",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_quat *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_quat_set_y",
+        "return_type": "void",
+        "arguments": [
+          ["godot_quat *", "p_self"],
+          ["const godot_real", "val"]
+        ]
+      },
+      {
+        "name": "godot_quat_get_z",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_quat *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_quat_set_z",
+        "return_type": "void",
+        "arguments": [
+          ["godot_quat *", "p_self"],
+          ["const godot_real", "val"]
+        ]
+      },
+      {
+        "name": "godot_quat_get_w",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_quat *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_quat_set_w",
+        "return_type": "void",
+        "arguments": [
+          ["godot_quat *", "p_self"],
+          ["const godot_real", "val"]
+        ]
+      },
+      {
+        "name": "godot_quat_set_axis_angle",
+        "return_type": "void",
+        "arguments": [
+          ["godot_quat *", "p_self"],
+          ["const godot_vector3 *", "p_axis"],
+          ["const godot_real", "p_angle"]
+        ]
+      },
+      {
+        "name": "godot_quat_as_string",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_quat *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_quat_length",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_quat *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_quat_length_squared",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_quat *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_quat_normalized",
+        "return_type": "godot_quat",
+        "arguments": [
+          ["const godot_quat *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_quat_is_normalized",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_quat *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_quat_inverse",
+        "return_type": "godot_quat",
+        "arguments": [
+          ["const godot_quat *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_quat_dot",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_quat *", "p_self"],
+          ["const godot_quat *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_quat_xform",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_quat *", "p_self"],
+          ["const godot_vector3 *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_quat_slerp",
+        "return_type": "godot_quat",
+        "arguments": [
+          ["const godot_quat *", "p_self"],
+          ["const godot_quat *", "p_b"],
+          ["const godot_real", "p_t"]
+        ]
+      },
+      {
+        "name": "godot_quat_slerpni",
+        "return_type": "godot_quat",
+        "arguments": [
+          ["const godot_quat *", "p_self"],
+          ["const godot_quat *", "p_b"],
+          ["const godot_real", "p_t"]
+        ]
+      },
+      {
+        "name": "godot_quat_cubic_slerp",
+        "return_type": "godot_quat",
+        "arguments": [
+          ["const godot_quat *", "p_self"],
+          ["const godot_quat *", "p_b"],
+          ["const godot_quat *", "p_pre_a"],
+          ["const godot_quat *", "p_post_b"],
+          ["const godot_real", "p_t"]
+        ]
+      },
+      {
+        "name": "godot_quat_operator_multiply",
+        "return_type": "godot_quat",
+        "arguments": [
+          ["const godot_quat *", "p_self"],
+          ["const godot_real", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_quat_operator_add",
+        "return_type": "godot_quat",
+        "arguments": [
+          ["const godot_quat *", "p_self"],
+          ["const godot_quat *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_quat_operator_subtract",
+        "return_type": "godot_quat",
+        "arguments": [
+          ["const godot_quat *", "p_self"],
+          ["const godot_quat *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_quat_operator_divide",
+        "return_type": "godot_quat",
+        "arguments": [
+          ["const godot_quat *", "p_self"],
+          ["const godot_real", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_quat_operator_equal",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_quat *", "p_self"],
+          ["const godot_quat *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_quat_operator_neg",
+        "return_type": "godot_quat",
+        "arguments": [
+          ["const godot_quat *", "p_self"]
+        ]
+      },
+      {
         "name": "godot_rect2_new_with_position_and_size",
         "return_type": "void",
         "arguments": [
@@ -4399,6 +3220,13 @@
         ]
       },
       {
+        "name": "godot_rect2_as_rect2i",
+        "return_type": "godot_rect2i",
+        "arguments": [
+          ["const godot_rect2 *", "p_self"]
+        ]
+      },
+      {
         "name": "godot_rect2_as_string",
         "return_type": "godot_string",
         "arguments": [
@@ -4408,6 +3236,33 @@
       {
         "name": "godot_rect2_get_area",
         "return_type": "godot_real",
+        "arguments": [
+          ["const godot_rect2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_rect2_grow_individual",
+        "return_type": "godot_rect2",
+        "arguments": [
+          ["const godot_rect2 *", "p_self"],
+          ["const godot_real", "p_left"],
+          ["const godot_real", "p_top"],
+          ["const godot_real", "p_right"],
+          ["const godot_real", "p_bottom"]
+        ]
+      },
+      {
+        "name": "godot_rect2_grow_margin",
+        "return_type": "godot_rect2",
+        "arguments": [
+          ["const godot_rect2 *", "p_self"],
+          ["const godot_int", "p_margin"],
+          ["const godot_real", "p_by"]
+        ]
+      },
+      {
+        "name": "godot_rect2_abs",
+        "return_type": "godot_rect2",
         "arguments": [
           ["const godot_rect2 *", "p_self"]
         ]
@@ -4514,209 +3369,172 @@
         ]
       },
       {
-        "name": "godot_aabb_new",
+        "name": "godot_rect2i_new_with_position_and_size",
         "return_type": "void",
         "arguments": [
-          ["godot_aabb *", "r_dest"],
-          ["const godot_vector3 *", "p_pos"],
-          ["const godot_vector3 *", "p_size"]
+          ["godot_rect2i *", "r_dest"],
+          ["const godot_vector2i *", "p_pos"],
+          ["const godot_vector2i *", "p_size"]
         ]
       },
       {
-        "name": "godot_aabb_get_position",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_aabb *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_aabb_set_position",
+        "name": "godot_rect2i_new",
         "return_type": "void",
         "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_vector3 *", "p_v"]
+          ["godot_rect2i *", "r_dest"],
+          ["const godot_int", "p_x"],
+          ["const godot_int", "p_y"],
+          ["const godot_int", "p_width"],
+          ["const godot_int", "p_height"]
         ]
       },
       {
-        "name": "godot_aabb_get_size",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_aabb *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_aabb_set_size",
-        "return_type": "void",
-        "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_vector3 *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_aabb_as_string",
+        "name": "godot_rect2i_as_string",
         "return_type": "godot_string",
         "arguments": [
-          ["const godot_aabb *", "p_self"]
+          ["const godot_rect2i *", "p_self"]
         ]
       },
       {
-        "name": "godot_aabb_get_area",
-        "return_type": "godot_real",
+        "name": "godot_rect2i_as_rect2",
+        "return_type": "godot_rect2",
         "arguments": [
-          ["const godot_aabb *", "p_self"]
+          ["const godot_rect2i *", "p_self"]
         ]
       },
       {
-        "name": "godot_aabb_has_no_area",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_aabb *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_aabb_has_no_surface",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_aabb *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_aabb_intersects",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_aabb *", "p_with"]
-        ]
-      },
-      {
-        "name": "godot_aabb_encloses",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_aabb *", "p_with"]
-        ]
-      },
-      {
-        "name": "godot_aabb_merge",
-        "return_type": "godot_aabb",
-        "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_aabb *", "p_with"]
-        ]
-      },
-      {
-        "name": "godot_aabb_intersection",
-        "return_type": "godot_aabb",
-        "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_aabb *", "p_with"]
-        ]
-      },
-      {
-        "name": "godot_aabb_intersects_plane",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_plane *", "p_plane"]
-        ]
-      },
-      {
-        "name": "godot_aabb_intersects_segment",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_vector3 *", "p_from"],
-          ["const godot_vector3 *", "p_to"]
-        ]
-      },
-      {
-        "name": "godot_aabb_has_point",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_vector3 *", "p_point"]
-        ]
-      },
-      {
-        "name": "godot_aabb_get_support",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_vector3 *", "p_dir"]
-        ]
-      },
-      {
-        "name": "godot_aabb_get_longest_axis",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_aabb *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_aabb_get_longest_axis_index",
+        "name": "godot_rect2i_get_area",
         "return_type": "godot_int",
         "arguments": [
-          ["const godot_aabb *", "p_self"]
+          ["const godot_rect2i *", "p_self"]
         ]
       },
       {
-        "name": "godot_aabb_get_longest_axis_size",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_aabb *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_aabb_get_shortest_axis",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_aabb *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_aabb_get_shortest_axis_index",
-        "return_type": "godot_int",
-        "arguments": [
-          ["const godot_aabb *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_aabb_get_shortest_axis_size",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_aabb *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_aabb_expand",
-        "return_type": "godot_aabb",
-        "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_vector3 *", "p_to_point"]
-        ]
-      },
-      {
-        "name": "godot_aabb_grow",
-        "return_type": "godot_aabb",
-        "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_real", "p_by"]
-        ]
-      },
-      {
-        "name": "godot_aabb_get_endpoint",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_int", "p_idx"]
-        ]
-      },
-      {
-        "name": "godot_aabb_operator_equal",
+        "name": "godot_rect2i_intersects",
         "return_type": "godot_bool",
         "arguments": [
-          ["const godot_aabb *", "p_self"],
-          ["const godot_aabb *", "p_b"]
+          ["const godot_rect2i *", "p_self"],
+          ["const godot_rect2i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_encloses",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"],
+          ["const godot_rect2i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_has_no_area",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_clip",
+        "return_type": "godot_rect2i",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"],
+          ["const godot_rect2i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_merge",
+        "return_type": "godot_rect2i",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"],
+          ["const godot_rect2i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_has_point",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"],
+          ["const godot_vector2i *", "p_point"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_grow",
+        "return_type": "godot_rect2i",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"],
+          ["const godot_int", "p_by"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_grow_individual",
+        "return_type": "godot_rect2i",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"],
+          ["const godot_int", "p_left"],
+          ["const godot_int", "p_top"],
+          ["const godot_int", "p_right"],
+          ["const godot_int", "p_bottom"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_grow_margin",
+        "return_type": "godot_rect2i",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"],
+          ["const godot_int", "p_margin"],
+          ["const godot_int", "p_by"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_abs",
+        "return_type": "godot_rect2i",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_expand",
+        "return_type": "godot_rect2i",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"],
+          ["const godot_vector2i *", "p_to"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_operator_equal",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"],
+          ["const godot_rect2i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_get_position",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_get_size",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_rect2i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_set_position",
+        "return_type": "void",
+        "arguments": [
+          ["godot_rect2i *", "p_self"],
+          ["const godot_vector2i *", "p_pos"]
+        ]
+      },
+      {
+        "name": "godot_rect2i_set_size",
+        "return_type": "void",
+        "arguments": [
+          ["godot_rect2i *", "p_self"],
+          ["const godot_vector2i *", "p_size"]
         ]
       },
       {
@@ -4755,845 +3573,6 @@
         "arguments": [
           ["const godot_rid *", "p_self"],
           ["const godot_rid *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_transform_new_with_axis_origin",
-        "return_type": "void",
-        "arguments": [
-          ["godot_transform *", "r_dest"],
-          ["const godot_vector3 *", "p_x_axis"],
-          ["const godot_vector3 *", "p_y_axis"],
-          ["const godot_vector3 *", "p_z_axis"],
-          ["const godot_vector3 *", "p_origin"]
-        ]
-      },
-      {
-        "name": "godot_transform_new",
-        "return_type": "void",
-        "arguments": [
-          ["godot_transform *", "r_dest"],
-          ["const godot_basis *", "p_basis"],
-          ["const godot_vector3 *", "p_origin"]
-        ]
-      },
-      {
-        "name": "godot_transform_get_basis",
-        "return_type": "godot_basis",
-        "arguments": [
-          ["const godot_transform *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform_set_basis",
-        "return_type": "void",
-        "arguments": [
-          ["godot_transform *", "p_self"],
-          ["const godot_basis *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform_get_origin",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_transform *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform_set_origin",
-        "return_type": "void",
-        "arguments": [
-          ["godot_transform *", "p_self"],
-          ["const godot_vector3 *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform_as_string",
-        "return_type": "godot_string",
-        "arguments": [
-          ["const godot_transform *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform_inverse",
-        "return_type": "godot_transform",
-        "arguments": [
-          ["const godot_transform *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform_affine_inverse",
-        "return_type": "godot_transform",
-        "arguments": [
-          ["const godot_transform *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform_orthonormalized",
-        "return_type": "godot_transform",
-        "arguments": [
-          ["const godot_transform *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform_rotated",
-        "return_type": "godot_transform",
-        "arguments": [
-          ["const godot_transform *", "p_self"],
-          ["const godot_vector3 *", "p_axis"],
-          ["const godot_real", "p_phi"]
-        ]
-      },
-      {
-        "name": "godot_transform_scaled",
-        "return_type": "godot_transform",
-        "arguments": [
-          ["const godot_transform *", "p_self"],
-          ["const godot_vector3 *", "p_scale"]
-        ]
-      },
-      {
-        "name": "godot_transform_translated",
-        "return_type": "godot_transform",
-        "arguments": [
-          ["const godot_transform *", "p_self"],
-          ["const godot_vector3 *", "p_ofs"]
-        ]
-      },
-      {
-        "name": "godot_transform_looking_at",
-        "return_type": "godot_transform",
-        "arguments": [
-          ["const godot_transform *", "p_self"],
-          ["const godot_vector3 *", "p_target"],
-          ["const godot_vector3 *", "p_up"]
-        ]
-      },
-      {
-        "name": "godot_transform_xform_plane",
-        "return_type": "godot_plane",
-        "arguments": [
-          ["const godot_transform *", "p_self"],
-          ["const godot_plane *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform_xform_inv_plane",
-        "return_type": "godot_plane",
-        "arguments": [
-          ["const godot_transform *", "p_self"],
-          ["const godot_plane *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform_new_identity",
-        "return_type": "void",
-        "arguments": [
-          ["godot_transform *", "r_dest"]
-        ]
-      },
-      {
-        "name": "godot_transform_operator_equal",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_transform *", "p_self"],
-          ["const godot_transform *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_transform_operator_multiply",
-        "return_type": "godot_transform",
-        "arguments": [
-          ["const godot_transform *", "p_self"],
-          ["const godot_transform *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_transform_xform_vector3",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_transform *", "p_self"],
-          ["const godot_vector3 *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform_xform_inv_vector3",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_transform *", "p_self"],
-          ["const godot_vector3 *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform_xform_aabb",
-        "return_type": "godot_aabb",
-        "arguments": [
-          ["const godot_transform *", "p_self"],
-          ["const godot_aabb *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform_xform_inv_aabb",
-        "return_type": "godot_aabb",
-        "arguments": [
-          ["const godot_transform *", "p_self"],
-          ["const godot_aabb *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_new",
-        "return_type": "void",
-        "arguments": [
-          ["godot_transform2d *", "r_dest"],
-          ["const godot_real", "p_rot"],
-          ["const godot_vector2 *", "p_pos"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_new_axis_origin",
-        "return_type": "void",
-        "arguments": [
-          ["godot_transform2d *", "r_dest"],
-          ["const godot_vector2 *", "p_x_axis"],
-          ["const godot_vector2 *", "p_y_axis"],
-          ["const godot_vector2 *", "p_origin"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_as_string",
-        "return_type": "godot_string",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_inverse",
-        "return_type": "godot_transform2d",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_affine_inverse",
-        "return_type": "godot_transform2d",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_get_rotation",
-        "return_type": "godot_real",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_get_origin",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_get_scale",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_orthonormalized",
-        "return_type": "godot_transform2d",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_rotated",
-        "return_type": "godot_transform2d",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"],
-          ["const godot_real", "p_phi"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_scaled",
-        "return_type": "godot_transform2d",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"],
-          ["const godot_vector2 *", "p_scale"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_translated",
-        "return_type": "godot_transform2d",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"],
-          ["const godot_vector2 *", "p_offset"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_xform_vector2",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"],
-          ["const godot_vector2 *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_xform_inv_vector2",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"],
-          ["const godot_vector2 *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_basis_xform_vector2",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"],
-          ["const godot_vector2 *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_basis_xform_inv_vector2",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"],
-          ["const godot_vector2 *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_interpolate_with",
-        "return_type": "godot_transform2d",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"],
-          ["const godot_transform2d *", "p_m"],
-          ["const godot_real", "p_c"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_operator_equal",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"],
-          ["const godot_transform2d *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_operator_multiply",
-        "return_type": "godot_transform2d",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"],
-          ["const godot_transform2d *", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_new_identity",
-        "return_type": "void",
-        "arguments": [
-          ["godot_transform2d *", "r_dest"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_xform_rect2",
-        "return_type": "godot_rect2",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"],
-          ["const godot_rect2 *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_xform_inv_rect2",
-        "return_type": "godot_rect2",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"],
-          ["const godot_rect2 *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_variant_get_type",
-        "return_type": "godot_variant_type",
-        "arguments": [
-          ["const godot_variant *", "p_v"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_copy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_variant *", "p_src"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_nil",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_bool",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_bool", "p_b"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_uint",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const uint64_t", "p_i"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_int",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const int64_t", "p_i"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_real",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const double", "p_r"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_string",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_string *", "p_s"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_vector2",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_vector2 *", "p_v2"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_rect2",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_rect2 *", "p_rect2"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_vector3",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_vector3 *", "p_v3"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_transform2d",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_transform2d *", "p_t2d"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_plane",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_plane *", "p_plane"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_quat",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_quat *", "p_quat"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_aabb",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_aabb *", "p_aabb"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_basis",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_basis *", "p_basis"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_transform",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_transform *", "p_trans"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_color",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_color *", "p_color"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_node_path",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_node_path *", "p_np"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_rid",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_rid *", "p_rid"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_object",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_object *", "p_obj"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_dictionary",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_dictionary *", "p_dict"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_array *", "p_arr"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_packed_byte_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_packed_byte_array *", "p_pba"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_packed_int32_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_packed_int32_array *", "p_pia"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_packed_float32_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_packed_float32_array *", "p_pra"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_packed_string_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_packed_string_array *", "p_psa"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_packed_vector2_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_packed_vector2_array *", "p_pv2a"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_packed_vector3_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_packed_vector3_array *", "p_pv3a"]
-        ]
-      },
-      {
-        "name": "godot_variant_new_packed_color_array",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_packed_color_array *", "p_pca"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_bool",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_uint",
-        "return_type": "uint64_t",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_int",
-        "return_type": "int64_t",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_real",
-        "return_type": "double",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_string",
-        "return_type": "godot_string",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_vector2",
-        "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_rect2",
-        "return_type": "godot_rect2",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_vector3",
-        "return_type": "godot_vector3",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_transform2d",
-        "return_type": "godot_transform2d",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_plane",
-        "return_type": "godot_plane",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_quat",
-        "return_type": "godot_quat",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_aabb",
-        "return_type": "godot_aabb",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_basis",
-        "return_type": "godot_basis",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_transform",
-        "return_type": "godot_transform",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_color",
-        "return_type": "godot_color",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_node_path",
-        "return_type": "godot_node_path",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_rid",
-        "return_type": "godot_rid",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_object",
-        "return_type": "godot_object *",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_dictionary",
-        "return_type": "godot_dictionary",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_array",
-        "return_type": "godot_array",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_packed_byte_array",
-        "return_type": "godot_packed_byte_array",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_packed_int32_array",
-        "return_type": "godot_packed_int32_array",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_packed_float32_array",
-        "return_type": "godot_packed_float32_array",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_packed_string_array",
-        "return_type": "godot_packed_string_array",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_packed_vector2_array",
-        "return_type": "godot_packed_vector2_array",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_packed_vector3_array",
-        "return_type": "godot_packed_vector3_array",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_as_packed_color_array",
-        "return_type": "godot_packed_color_array",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_call",
-        "return_type": "godot_variant",
-        "arguments": [
-          ["godot_variant *", "p_self"],
-          ["const godot_string *", "p_method"],
-          ["const godot_variant **", "p_args"],
-          ["const godot_int", "p_argcount"],
-          ["godot_variant_call_error *", "r_error"]
-        ]
-      },
-      {
-        "name": "godot_variant_has_method",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_variant *", "p_self"],
-          ["const godot_string *", "p_method"]
-        ]
-      },
-      {
-        "name": "godot_variant_operator_equal",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_variant *", "p_self"],
-          ["const godot_variant *", "p_other"]
-        ]
-      },
-      {
-        "name": "godot_variant_operator_less",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_variant *", "p_self"],
-          ["const godot_variant *", "p_other"]
-        ]
-      },
-      {
-        "name": "godot_variant_hash_compare",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_variant *", "p_self"],
-          ["const godot_variant *", "p_other"]
-        ]
-      },
-      {
-        "name": "godot_variant_booleanize",
-        "return_type": "godot_bool",
-        "arguments": [
-          ["const godot_variant *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_variant_destroy",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "p_self"]
         ]
       },
       {
@@ -5686,6 +3665,33 @@
         "arguments": [
           ["const godot_string *", "p_self"],
           ["const godot_string *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_string_count",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_string *", "p_self"],
+          ["godot_string", "p_what"],
+          ["godot_int", "p_from"],
+          ["godot_int", "p_to"]
+        ]
+      },
+      {
+        "name": "godot_string_countn",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_string *", "p_self"],
+          ["godot_string", "p_what"],
+          ["godot_int", "p_from"],
+          ["godot_int", "p_to"]
+        ]
+      },
+      {
+        "name": "godot_string_dedent",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_string *", "p_self"]
         ]
       },
       {
@@ -6325,6 +4331,40 @@
         ]
       },
       {
+        "name": "godot_string_rstrip",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_string *", "p_self"],
+          ["const godot_string *", "p_chars"]
+        ]
+      },
+      {
+        "name": "godot_string_rsplit",
+        "return_type": "godot_packed_string_array",
+        "arguments": [
+          ["const godot_string *", "p_self"],
+          ["const godot_string *", "p_divisor"],
+          ["const godot_bool", "p_allow_empty"],
+          ["const godot_int", "p_maxsplit"]
+        ]
+      },
+      {
+        "name": "godot_string_trim_prefix",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_string *", "p_self"],
+          ["const godot_string *", "p_prefix"]
+        ]
+      },
+      {
+        "name": "godot_string_trim_suffix",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_string *", "p_self"],
+          ["const godot_string *", "p_suffix"]
+        ]
+      },
+      {
         "name": "godot_string_char_lowercase",
         "return_type": "wchar_t",
         "arguments": [
@@ -6816,10 +4856,1921 @@
         ]
       },
       {
-        "name": "godot_object_destroy",
+        "name": "godot_transform_new_with_axis_origin",
         "return_type": "void",
         "arguments": [
-          ["godot_object *", "p_o"]
+          ["godot_transform *", "r_dest"],
+          ["const godot_vector3 *", "p_x_axis"],
+          ["const godot_vector3 *", "p_y_axis"],
+          ["const godot_vector3 *", "p_z_axis"],
+          ["const godot_vector3 *", "p_origin"]
+        ]
+      },
+      {
+        "name": "godot_transform_new_with_quat",
+        "return_type": "void",
+        "arguments": [
+          ["godot_transform *", "r_dest"],
+          ["const godot_quat *", "p_quat"]
+        ]
+      },
+      {
+        "name": "godot_transform_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_transform *", "r_dest"],
+          ["const godot_basis *", "p_basis"],
+          ["const godot_vector3 *", "p_origin"]
+        ]
+      },
+      {
+        "name": "godot_transform_get_basis",
+        "return_type": "godot_basis",
+        "arguments": [
+          ["const godot_transform *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform_set_basis",
+        "return_type": "void",
+        "arguments": [
+          ["godot_transform *", "p_self"],
+          ["const godot_basis *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform_get_origin",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_transform *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform_set_origin",
+        "return_type": "void",
+        "arguments": [
+          ["godot_transform *", "p_self"],
+          ["const godot_vector3 *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform_as_string",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_transform *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform_inverse",
+        "return_type": "godot_transform",
+        "arguments": [
+          ["const godot_transform *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform_affine_inverse",
+        "return_type": "godot_transform",
+        "arguments": [
+          ["const godot_transform *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform_orthonormalized",
+        "return_type": "godot_transform",
+        "arguments": [
+          ["const godot_transform *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform_rotated",
+        "return_type": "godot_transform",
+        "arguments": [
+          ["const godot_transform *", "p_self"],
+          ["const godot_vector3 *", "p_axis"],
+          ["const godot_real", "p_phi"]
+        ]
+      },
+      {
+        "name": "godot_transform_scaled",
+        "return_type": "godot_transform",
+        "arguments": [
+          ["const godot_transform *", "p_self"],
+          ["const godot_vector3 *", "p_scale"]
+        ]
+      },
+      {
+        "name": "godot_transform_translated",
+        "return_type": "godot_transform",
+        "arguments": [
+          ["const godot_transform *", "p_self"],
+          ["const godot_vector3 *", "p_ofs"]
+        ]
+      },
+      {
+        "name": "godot_transform_looking_at",
+        "return_type": "godot_transform",
+        "arguments": [
+          ["const godot_transform *", "p_self"],
+          ["const godot_vector3 *", "p_target"],
+          ["const godot_vector3 *", "p_up"]
+        ]
+      },
+      {
+        "name": "godot_transform_xform_plane",
+        "return_type": "godot_plane",
+        "arguments": [
+          ["const godot_transform *", "p_self"],
+          ["const godot_plane *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform_xform_inv_plane",
+        "return_type": "godot_plane",
+        "arguments": [
+          ["const godot_transform *", "p_self"],
+          ["const godot_plane *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform_new_identity",
+        "return_type": "void",
+        "arguments": [
+          ["godot_transform *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_transform_operator_equal",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_transform *", "p_self"],
+          ["const godot_transform *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_transform_operator_multiply",
+        "return_type": "godot_transform",
+        "arguments": [
+          ["const godot_transform *", "p_self"],
+          ["const godot_transform *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_transform_xform_vector3",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_transform *", "p_self"],
+          ["const godot_vector3 *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform_xform_inv_vector3",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_transform *", "p_self"],
+          ["const godot_vector3 *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform_xform_aabb",
+        "return_type": "godot_aabb",
+        "arguments": [
+          ["const godot_transform *", "p_self"],
+          ["const godot_aabb *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform_xform_inv_aabb",
+        "return_type": "godot_aabb",
+        "arguments": [
+          ["const godot_transform *", "p_self"],
+          ["const godot_aabb *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_transform2d *", "r_dest"],
+          ["const godot_real", "p_rot"],
+          ["const godot_vector2 *", "p_pos"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_new_axis_origin",
+        "return_type": "void",
+        "arguments": [
+          ["godot_transform2d *", "r_dest"],
+          ["const godot_vector2 *", "p_x_axis"],
+          ["const godot_vector2 *", "p_y_axis"],
+          ["const godot_vector2 *", "p_origin"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_as_string",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_inverse",
+        "return_type": "godot_transform2d",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_affine_inverse",
+        "return_type": "godot_transform2d",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_get_rotation",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_get_origin",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_get_scale",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_orthonormalized",
+        "return_type": "godot_transform2d",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_rotated",
+        "return_type": "godot_transform2d",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"],
+          ["const godot_real", "p_phi"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_scaled",
+        "return_type": "godot_transform2d",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"],
+          ["const godot_vector2 *", "p_scale"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_translated",
+        "return_type": "godot_transform2d",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"],
+          ["const godot_vector2 *", "p_offset"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_xform_vector2",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"],
+          ["const godot_vector2 *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_xform_inv_vector2",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"],
+          ["const godot_vector2 *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_basis_xform_vector2",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"],
+          ["const godot_vector2 *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_basis_xform_inv_vector2",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"],
+          ["const godot_vector2 *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_interpolate_with",
+        "return_type": "godot_transform2d",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"],
+          ["const godot_transform2d *", "p_m"],
+          ["const godot_real", "p_c"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_operator_equal",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"],
+          ["const godot_transform2d *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_operator_multiply",
+        "return_type": "godot_transform2d",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"],
+          ["const godot_transform2d *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_new_identity",
+        "return_type": "void",
+        "arguments": [
+          ["godot_transform2d *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_xform_rect2",
+        "return_type": "godot_rect2",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"],
+          ["const godot_rect2 *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_transform2d_xform_inv_rect2",
+        "return_type": "godot_rect2",
+        "arguments": [
+          ["const godot_transform2d *", "p_self"],
+          ["const godot_rect2 *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_variant_get_type",
+        "return_type": "godot_variant_type",
+        "arguments": [
+          ["const godot_variant *", "p_v"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_copy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_variant *", "p_src"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_nil",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_bool",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_bool", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_uint",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const uint64_t", "p_i"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_int",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const int64_t", "p_i"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_real",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const double", "p_r"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_string",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_string *", "p_s"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_string_name",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_string_name *", "p_s"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_vector2",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_vector2 *", "p_v2"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_vector2i",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_vector2i *", "p_v2"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_rect2",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_rect2 *", "p_rect2"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_rect2i",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_rect2i *", "p_rect2"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_vector3",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_vector3 *", "p_v3"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_vector3i",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_vector3i *", "p_v3"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_transform2d",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_transform2d *", "p_t2d"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_plane",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_plane *", "p_plane"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_quat",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_quat *", "p_quat"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_aabb",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_aabb *", "p_aabb"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_basis",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_basis *", "p_basis"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_transform",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_transform *", "p_trans"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_color",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_color *", "p_color"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_node_path",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_node_path *", "p_np"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_rid",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_rid *", "p_rid"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_object",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_object *", "p_obj"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_callable",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_callable *", "p_cb"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_signal",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_signal *", "p_signal"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_dictionary",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_dictionary *", "p_dict"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_array *", "p_arr"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_packed_byte_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_packed_byte_array *", "p_pba"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_packed_int32_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_packed_int32_array *", "p_pia"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_packed_int64_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_packed_int64_array *", "p_pia"]
+        ]
+      },    
+      {
+        "name": "godot_variant_new_packed_float32_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_packed_float32_array *", "p_pra"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_packed_float64_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_packed_float64_array *", "p_pra"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_packed_string_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_packed_string_array *", "p_psa"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_packed_vector2_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_packed_vector2_array *", "p_pv2a"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_packed_vector3_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_packed_vector3_array *", "p_pv3a"]
+        ]
+      },
+      {
+        "name": "godot_variant_new_packed_color_array",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "r_dest"],
+          ["const godot_packed_color_array *", "p_pca"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_bool",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_uint",
+        "return_type": "uint64_t",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_int",
+        "return_type": "int64_t",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_real",
+        "return_type": "double",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_string",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_string_name",
+        "return_type": "godot_string_name",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_vector2",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_vector2i",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_rect2",
+        "return_type": "godot_rect2",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_rect2i",
+        "return_type": "godot_rect2i",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_vector3",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_vector3i",
+        "return_type": "godot_vector3i",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_transform2d",
+        "return_type": "godot_transform2d",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_plane",
+        "return_type": "godot_plane",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_quat",
+        "return_type": "godot_quat",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_aabb",
+        "return_type": "godot_aabb",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_basis",
+        "return_type": "godot_basis",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_transform",
+        "return_type": "godot_transform",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_color",
+        "return_type": "godot_color",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_node_path",
+        "return_type": "godot_node_path",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_rid",
+        "return_type": "godot_rid",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_object",
+        "return_type": "godot_object *",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_callable",
+        "return_type": "godot_callable",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_signal",
+        "return_type": "godot_signal",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_dictionary",
+        "return_type": "godot_dictionary",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_array",
+        "return_type": "godot_array",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_packed_byte_array",
+        "return_type": "godot_packed_byte_array",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_packed_int32_array",
+        "return_type": "godot_packed_int32_array",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_packed_int64_array",
+        "return_type": "godot_packed_int64_array",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_packed_float32_array",
+        "return_type": "godot_packed_float32_array",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_packed_float64_array",
+        "return_type": "godot_packed_float64_array",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_packed_string_array",
+        "return_type": "godot_packed_string_array",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_packed_vector2_array",
+        "return_type": "godot_packed_vector2_array",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_packed_vector3_array",
+        "return_type": "godot_packed_vector3_array",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_as_packed_color_array",
+        "return_type": "godot_packed_color_array",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_call",
+        "return_type": "godot_variant",
+        "arguments": [
+          ["godot_variant *", "p_self"],
+          ["const godot_string *", "p_method"],
+          ["const godot_variant **", "p_args"],
+          ["const godot_int", "p_argcount"],
+          ["godot_variant_call_error *", "r_error"]
+        ]
+      },
+      {
+        "name": "godot_variant_has_method",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_variant *", "p_self"],
+          ["const godot_string *", "p_method"]
+        ]
+      },
+      {
+        "name": "godot_variant_hash",
+        "return_type": "uint32_t",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_operator_equal",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_variant *", "p_self"],
+          ["const godot_variant *", "p_other"]
+        ]
+      },
+      {
+        "name": "godot_variant_operator_less",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_variant *", "p_self"],
+          ["const godot_variant *", "p_other"]
+        ]
+      },
+      {
+        "name": "godot_variant_get_operator_name",
+        "return_type": "godot_string",
+        "arguments": [
+          ["godot_variant_operator", "p_op"]
+        ]
+      },
+      {
+        "name": "godot_variant_evaluate",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant_operator", "p_op"],
+          ["const godot_variant *", "p_a"],
+          ["const godot_variant *", "p_b"],
+          ["godot_variant *", "r_ret"],
+          ["godot_bool *", "r_valid"]
+        ]
+      },
+      {
+        "name": "godot_variant_hash_compare",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_variant *", "p_self"],
+          ["const godot_variant *", "p_other"]
+        ]
+      },
+      {
+        "name": "godot_variant_booleanize",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_variant_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_variant *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_as_vector2i",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_sign",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_move_toward",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_to"],
+          ["const godot_real", "p_delta"]
+        ]
+      },
+      {
+        "name": "godot_vector2_direction_to",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_to"]
+        ]
+      },
+      {
+        "name": "godot_vector2_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_vector2 *", "r_dest"],
+          ["const godot_real", "p_x"],
+          ["const godot_real", "p_y"]
+        ]
+      },
+      {
+        "name": "godot_vector2_as_string",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_normalized",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_length",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_angle",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_length_squared",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_is_normalized",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_distance_to",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_to"]
+        ]
+      },
+      {
+        "name": "godot_vector2_distance_squared_to",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_to"]
+        ]
+      },
+      {
+        "name": "godot_vector2_angle_to",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_to"]
+        ]
+      },
+      {
+        "name": "godot_vector2_angle_to_point",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_to"]
+        ]
+      },
+      {
+        "name": "godot_vector2_lerp",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_b"],
+          ["const godot_real", "p_t"]
+        ]
+      },
+      {
+        "name": "godot_vector2_cubic_interpolate",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_b"],
+          ["const godot_vector2 *", "p_pre_a"],
+          ["const godot_vector2 *", "p_post_b"],
+          ["const godot_real", "p_t"]
+        ]
+      },
+      {
+        "name": "godot_vector2_rotated",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_real", "p_phi"]
+        ]
+      },
+      {
+        "name": "godot_vector2_tangent",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_floor",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_snapped",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_by"]
+        ]
+      },
+      {
+        "name": "godot_vector2_aspect",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_dot",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_with"]
+        ]
+      },
+      {
+        "name": "godot_vector2_slide",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_n"]
+        ]
+      },
+      {
+        "name": "godot_vector2_bounce",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_n"]
+        ]
+      },
+      {
+        "name": "godot_vector2_reflect",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_n"]
+        ]
+      },
+      {
+        "name": "godot_vector2_abs",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_clamped",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_real", "p_length"]
+        ]
+      },
+      {
+        "name": "godot_vector2_operator_add",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2_operator_subtract",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2_operator_multiply_vector",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2_operator_multiply_scalar",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_real", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2_operator_divide_vector",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2_operator_divide_scalar",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_real", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2_operator_equal",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2_operator_less",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"],
+          ["const godot_vector2 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2_operator_neg",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_set_x",
+        "return_type": "void",
+        "arguments": [
+          ["godot_vector2 *", "p_self"],
+          ["const godot_real", "p_x"]
+        ]
+      },
+      {
+        "name": "godot_vector2_set_y",
+        "return_type": "void",
+        "arguments": [
+          ["godot_vector2 *", "p_self"],
+          ["const godot_real", "p_y"]
+        ]
+      },
+      {
+        "name": "godot_vector2_get_x",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2_get_y",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector2 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_vector2i *", "r_dest"],
+          ["const godot_int", "p_x"],
+          ["const godot_int", "p_y"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_as_string",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_as_vector2",
+        "return_type": "godot_vector2",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_aspect",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_abs",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_sign",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_operator_add",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"],
+          ["const godot_vector2i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_operator_subtract",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"],
+          ["const godot_vector2i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_operator_multiply_vector",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"],
+          ["const godot_vector2i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_operator_multiply_scalar",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"],
+          ["const godot_int", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_operator_divide_vector",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"],
+          ["const godot_vector2i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_operator_divide_scalar",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"],
+          ["const godot_int", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_operator_equal",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"],
+          ["const godot_vector2i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_operator_less",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"],
+          ["const godot_vector2i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_operator_neg",
+        "return_type": "godot_vector2i",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_set_x",
+        "return_type": "void",
+        "arguments": [
+          ["godot_vector2i *", "p_self"],
+          ["const godot_int", "p_x"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_set_y",
+        "return_type": "void",
+        "arguments": [
+          ["godot_vector2i *", "p_self"],
+          ["const godot_int", "p_y"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_get_x",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector2i_get_y",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_vector2i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_as_vector3i",
+        "return_type": "godot_vector3i",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_sign",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_move_toward",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_to"],
+          ["const godot_real", "p_delta"]
+        ]
+      },
+      {
+        "name": "godot_vector3_direction_to",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_to"]
+        ]
+      },
+      {
+        "name": "godot_vector3_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_vector3 *", "r_dest"],
+          ["const godot_real", "p_x"],
+          ["const godot_real", "p_y"],
+          ["const godot_real", "p_z"]
+        ]
+      },
+      {
+        "name": "godot_vector3_as_string",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_min_axis",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_max_axis",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_length",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_length_squared",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_is_normalized",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_normalized",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_inverse",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_snapped",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_by"]
+        ]
+      },
+      {
+        "name": "godot_vector3_rotated",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_axis"],
+          ["const godot_real", "p_phi"]
+        ]
+      },
+      {
+        "name": "godot_vector3_lerp",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"],
+          ["const godot_real", "p_t"]
+        ]
+      },
+      {
+        "name": "godot_vector3_cubic_interpolate",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"],
+          ["const godot_vector3 *", "p_pre_a"],
+          ["const godot_vector3 *", "p_post_b"],
+          ["const godot_real", "p_t"]
+        ]
+      },
+      {
+        "name": "godot_vector3_dot",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_cross",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_outer",
+        "return_type": "godot_basis",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_to_diagonal_matrix",
+        "return_type": "godot_basis",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_abs",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_floor",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_ceil",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_distance_to",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_distance_squared_to",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_angle_to",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_to"]
+        ]
+      },
+      {
+        "name": "godot_vector3_slide",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_n"]
+        ]
+      },
+      {
+        "name": "godot_vector3_bounce",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_n"]
+        ]
+      },
+      {
+        "name": "godot_vector3_reflect",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_n"]
+        ]
+      },
+      {
+        "name": "godot_vector3_operator_add",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_operator_subtract",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_operator_multiply_vector",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_operator_multiply_scalar",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_real", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_operator_divide_vector",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_operator_divide_scalar",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_real", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_operator_equal",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_operator_less",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3 *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3_operator_neg",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3_set_axis",
+        "return_type": "void",
+        "arguments": [
+          ["godot_vector3 *", "p_self"],
+          ["const godot_vector3_axis", "p_axis"],
+          ["const godot_real", "p_val"]
+        ]
+      },
+      {
+        "name": "godot_vector3_get_axis",
+        "return_type": "godot_real",
+        "arguments": [
+          ["const godot_vector3 *", "p_self"],
+          ["const godot_vector3_axis", "p_axis"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_new",
+        "return_type": "void",
+        "arguments": [
+          ["godot_vector3i *", "r_dest"],
+          ["const godot_int", "p_x"],
+          ["const godot_int", "p_y"],
+          ["const godot_int", "p_z"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_as_string",
+        "return_type": "godot_string",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_as_vector3",
+        "return_type": "godot_vector3",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_min_axis",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_max_axis",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_abs",
+        "return_type": "godot_vector3i",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_sign",
+        "return_type": "godot_vector3i",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_operator_add",
+        "return_type": "godot_vector3i",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"],
+          ["const godot_vector3i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_operator_subtract",
+        "return_type": "godot_vector3i",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"],
+          ["const godot_vector3i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_operator_multiply_vector",
+        "return_type": "godot_vector3i",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"],
+          ["const godot_vector3i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_operator_multiply_scalar",
+        "return_type": "godot_vector3i",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"],
+          ["const godot_int", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_operator_divide_vector",
+        "return_type": "godot_vector3i",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"],
+          ["const godot_vector3i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_operator_divide_scalar",
+        "return_type": "godot_vector3i",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"],
+          ["const godot_int", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_operator_equal",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"],
+          ["const godot_vector3i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_operator_less",
+        "return_type": "godot_bool",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"],
+          ["const godot_vector3i *", "p_b"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_operator_neg",
+        "return_type": "godot_vector3i",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_set_axis",
+        "return_type": "void",
+        "arguments": [
+          ["godot_vector3i *", "p_self"],
+          ["const godot_vector3_axis", "p_axis"],
+          ["const godot_int", "p_val"]
+        ]
+      },
+      {
+        "name": "godot_vector3i_get_axis",
+        "return_type": "godot_int",
+        "arguments": [
+          ["const godot_vector3i *", "p_self"],
+          ["const godot_vector3_axis", "p_axis"]
         ]
       },
       {
@@ -6827,6 +6778,42 @@
         "return_type": "godot_object *",
         "arguments": [
           ["char *", "p_name"]
+        ]
+      },
+      {
+        "name": "godot_get_class_tag",
+        "return_type": "void *",
+        "arguments": [
+          ["const godot_string_name *", "p_class"]
+        ]
+      },
+      {
+        "name": "godot_object_cast_to",
+        "return_type": "godot_object *",
+        "arguments": [
+          ["const godot_object *", "p_object"],
+          ["void *", "p_class_tag"]
+        ]
+      },
+      {
+        "name": "godot_object_get_instance_id",
+        "return_type": "uint64_t",
+        "arguments": [
+          ["const godot_object *", "p_object"]
+        ]
+      },
+      {
+        "name": "godot_instance_from_id",
+        "return_type": "godot_object *",
+        "arguments": [
+          ["uint64_t", "p_instance_id"]
+        ]
+      },
+      {
+        "name": "godot_object_destroy",
+        "return_type": "void",
+        "arguments": [
+          ["godot_object *", "p_o"]
         ]
       },
       {
@@ -6935,132 +6922,10 @@
       "name": "nativescript",
       "type": "NATIVESCRIPT",
       "version": {
-        "major": 1,
+        "major": 4,
         "minor": 0
       },
-      "next": {
-        "type": "NATIVESCRIPT",
-        "version": {
-          "major": 1,
-          "minor": 1
-        },
-        "next": null,
-        "api": [
-          {
-            "name": "godot_nativescript_set_method_argument_information",
-            "return_type": "void",
-            "arguments": [
-              ["void *", "p_gdnative_handle"],
-              ["const char *", "p_name"],
-              ["const char *", "p_function_name"],
-              ["int", "p_num_args"],
-              ["const godot_method_arg *", "p_args"]
-            ]
-          },
-          {
-            "name": "godot_nativescript_set_class_documentation",
-            "return_type": "void",
-            "arguments": [
-              ["void *", "p_gdnative_handle"],
-              ["const char *", "p_name"],
-              ["godot_string", "p_documentation"]
-            ]
-          },
-          {
-            "name": "godot_nativescript_set_method_documentation",
-            "return_type": "void",
-            "arguments": [
-              ["void *", "p_gdnative_handle"],
-              ["const char *", "p_name"],
-              ["const char *", "p_function_name"],
-              ["godot_string", "p_documentation"]
-            ]
-          },
-          {
-            "name": "godot_nativescript_set_property_documentation",
-            "return_type": "void",
-            "arguments": [
-              ["void *", "p_gdnative_handle"],
-              ["const char *", "p_name"],
-              ["const char *", "p_path"],
-              ["godot_string", "p_documentation"]
-            ]
-          },
-          {
-            "name": "godot_nativescript_set_signal_documentation",
-            "return_type": "void",
-            "arguments": [
-              ["void *", "p_gdnative_handle"],
-              ["const char *", "p_name"],
-              ["const char *", "p_signal_name"],
-              ["godot_string", "p_documentation"]
-            ]
-          },
-          {
-            "name": "godot_nativescript_set_global_type_tag",
-            "return_type": "void",
-            "arguments": [
-              ["int", "p_idx"],
-              ["const char *", "p_name"],
-              ["const void *", "p_type_tag"]
-            ]
-          },
-          {
-            "name": "godot_nativescript_get_global_type_tag",
-            "return_type": "const void *",
-            "arguments": [
-              ["int", "p_idx"],
-              ["const char *", "p_name"]
-            ]
-          },
-          {
-            "name": "godot_nativescript_set_type_tag",
-            "return_type": "void",
-            "arguments": [
-              ["void *", "p_gdnative_handle"],
-              ["const char *", "p_name"],
-              ["const void *", "p_type_tag"]
-            ]
-          },
-          {
-            "name": "godot_nativescript_get_type_tag",
-            "return_type": "const void *",
-            "arguments": [
-              ["const godot_object *", "p_object"]
-            ]
-          },
-          {
-            "name": "godot_nativescript_register_instance_binding_data_functions",
-            "return_type": "int",
-            "arguments": [
-              ["godot_instance_binding_functions", "p_binding_functions"]
-            ]
-          },
-          {
-            "name": "godot_nativescript_unregister_instance_binding_data_functions",
-            "return_type": "void",
-            "arguments": [
-              ["int", "p_idx"]
-            ]
-          },
-          {
-            "name": "godot_nativescript_get_instance_binding_data",
-            "return_type": "void *",
-            "arguments": [
-              ["int", "p_idx"],
-              ["godot_object *", "p_object"]
-            ]
-          },
-          {
-            "name": "godot_nativescript_profiling_add_data",
-            "return_type": "void",
-            "arguments": [
-              ["const char *", "p_signature"],
-              ["uint64_t", "p_line"]
-            ]
-          }
-        ]
-      },
+      "next": null,
       "api": [
         {
           "name": "godot_nativescript_register_class",
@@ -7069,8 +6934,8 @@
             ["void *", "p_gdnative_handle"],
             ["const char *", "p_name"],
             ["const char *", "p_base"],
-            ["godot_instance_create_func", "p_create_func"],
-            ["godot_instance_destroy_func", "p_destroy_func"]
+            ["godot_nativescript_instance_create_func", "p_create_func"],
+            ["godot_nativescript_instance_destroy_func", "p_destroy_func"]
           ]
         },
         {
@@ -7080,8 +6945,8 @@
             ["void *", "p_gdnative_handle"],
             ["const char *", "p_name"],
             ["const char *", "p_base"],
-            ["godot_instance_create_func", "p_create_func"],
-            ["godot_instance_destroy_func", "p_destroy_func"]
+            ["godot_nativescript_instance_create_func", "p_create_func"],
+            ["godot_nativescript_instance_destroy_func", "p_destroy_func"]
           ]
         },
         {
@@ -7091,8 +6956,19 @@
             ["void *", "p_gdnative_handle"],
             ["const char *", "p_name"],
             ["const char *", "p_function_name"],
-            ["godot_method_attributes", "p_attr"],
-            ["godot_instance_method", "p_method"]
+            ["godot_nativescript_method_attributes", "p_attr"],
+            ["godot_nativescript_instance_method", "p_method"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_set_method_argument_information",
+          "return_type": "void",
+          "arguments": [
+            ["void *", "p_gdnative_handle"],
+            ["const char *", "p_name"],
+            ["const char *", "p_function_name"],
+            ["int", "p_num_args"],
+            ["const godot_nativescript_method_argument *", "p_args"]
           ]
         },
         {
@@ -7102,9 +6978,9 @@
             ["void *", "p_gdnative_handle"],
             ["const char *", "p_name"],
             ["const char *", "p_path"],
-            ["godot_property_attributes *", "p_attr"],
-            ["godot_property_set_func", "p_set_func"],
-            ["godot_property_get_func", "p_get_func"]
+            ["godot_nativescript_property_attributes *", "p_attr"],
+            ["godot_nativescript_property_set_func", "p_set_func"],
+            ["godot_nativescript_property_get_func", "p_get_func"]
           ]
         },
         {
@@ -7121,6 +6997,108 @@
           "return_type": "void *",
           "arguments": [
             ["godot_object *", "p_instance"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_set_class_documentation",
+          "return_type": "void",
+          "arguments": [
+            ["void *", "p_gdnative_handle"],
+            ["const char *", "p_name"],
+            ["godot_string", "p_documentation"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_set_method_documentation",
+          "return_type": "void",
+          "arguments": [
+            ["void *", "p_gdnative_handle"],
+            ["const char *", "p_name"],
+            ["const char *", "p_function_name"],
+            ["godot_string", "p_documentation"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_set_property_documentation",
+          "return_type": "void",
+          "arguments": [
+            ["void *", "p_gdnative_handle"],
+            ["const char *", "p_name"],
+            ["const char *", "p_path"],
+            ["godot_string", "p_documentation"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_set_signal_documentation",
+          "return_type": "void",
+          "arguments": [
+            ["void *", "p_gdnative_handle"],
+            ["const char *", "p_name"],
+            ["const char *", "p_signal_name"],
+            ["godot_string", "p_documentation"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_set_global_type_tag",
+          "return_type": "void",
+          "arguments": [
+            ["int", "p_idx"],
+            ["const char *", "p_name"],
+            ["const void *", "p_type_tag"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_get_global_type_tag",
+          "return_type": "const void *",
+          "arguments": [
+            ["int", "p_idx"],
+            ["const char *", "p_name"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_set_type_tag",
+          "return_type": "void",
+          "arguments": [
+            ["void *", "p_gdnative_handle"],
+            ["const char *", "p_name"],
+            ["const void *", "p_type_tag"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_get_type_tag",
+          "return_type": "const void *",
+          "arguments": [
+            ["const godot_object *", "p_object"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_register_instance_binding_data_functions",
+          "return_type": "int",
+          "arguments": [
+            ["godot_nativescript_instance_binding_functions", "p_binding_functions"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_unregister_instance_binding_data_functions",
+          "return_type": "void",
+          "arguments": [
+            ["int", "p_idx"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_get_instance_binding_data",
+          "return_type": "void *",
+          "arguments": [
+            ["int", "p_idx"],
+            ["godot_object *", "p_object"]
+          ]
+        },
+        {
+          "name": "godot_nativescript_profiling_add_data",
+          "return_type": "void",
+          "arguments": [
+            ["const char *", "p_signature"],
+            ["uint64_t", "p_line"]
           ]
         }
       ]
@@ -7315,42 +7293,10 @@
       "name": "net",
       "type": "NET",
       "version": {
-        "major": 3,
-        "minor": 1
+        "major": 4,
+        "minor": 0
       },
-      "next": {
-        "type": "NET",
-        "version": {
-          "major": 3,
-          "minor": 2
-        },
-        "next": null,
-        "api": [
-          {
-            "name": "godot_net_set_webrtc_library",
-            "return_type": "godot_error",
-            "arguments": [
-              ["const godot_net_webrtc_library *", "p_library"]
-            ]
-          },
-          {
-            "name": "godot_net_bind_webrtc_peer_connection",
-            "return_type": "void",
-            "arguments": [
-              ["godot_object *", "p_obj"],
-              ["const godot_net_webrtc_peer_connection *", "p_interface"]
-            ]
-          },
-          {
-            "name": "godot_net_bind_webrtc_data_channel",
-            "return_type": "void",
-            "arguments": [
-              ["godot_object *", "p_obj"],
-              ["const godot_net_webrtc_data_channel *", "p_interface"]
-            ]
-          }
-        ]
-      },
+      "next": null,
       "api": [
         {
           "name": "godot_net_bind_stream_peer",
@@ -7374,6 +7320,29 @@
           "arguments": [
             ["godot_object *", "p_obj"],
             ["const godot_net_multiplayer_peer *", "p_interface"]
+          ]
+        },
+        {
+          "name": "godot_net_set_webrtc_library",
+          "return_type": "godot_error",
+          "arguments": [
+            ["const godot_net_webrtc_library *", "p_library"]
+          ]
+        },
+        {
+          "name": "godot_net_bind_webrtc_peer_connection",
+          "return_type": "void",
+          "arguments": [
+            ["godot_object *", "p_obj"],
+            ["const godot_net_webrtc_peer_connection *", "p_interface"]
+          ]
+        },
+        {
+          "name": "godot_net_bind_webrtc_data_channel",
+          "return_type": "void",
+          "arguments": [
+            ["godot_object *", "p_obj"],
+            ["const godot_net_webrtc_data_channel *", "p_interface"]
           ]
         }
       ]

--- a/modules/gdnative/gdnative_builders.py
+++ b/modules/gdnative/gdnative_builders.py
@@ -228,7 +228,16 @@ def _build_gdnative_api_struct_source(api):
         "extern const godot_gdnative_core_api_struct api_struct = {",
         "\tGDNATIVE_" + api["core"]["type"] + ",",
         "\t{" + str(api["core"]["version"]["major"]) + ", " + str(api["core"]["version"]["minor"]) + "},",
-        "\t(const godot_gdnative_api_struct *)&api_1_1,",
+        "\t"
+        + (
+            "nullptr, "
+            if not api["core"]["next"]
+            else (
+                "(const godot_gdnative_api_struct *)& api_{0}_{1},".format(
+                    api["core"]["next"]["version"]["major"], api["core"]["next"]["version"]["minor"]
+                )
+            )
+        ),
         "\t" + str(len(api["extensions"])) + ",",
         "\tgdnative_extensions_pointers,",
     ]

--- a/modules/gdnative/include/nativescript/godot_nativescript.h
+++ b/modules/gdnative/include/nativescript/godot_nativescript.h
@@ -45,7 +45,7 @@ typedef enum {
 	GODOT_METHOD_RPC_MODE_REMOTESYNC,
 	GODOT_METHOD_RPC_MODE_MASTERSYNC,
 	GODOT_METHOD_RPC_MODE_PUPPETSYNC,
-} godot_method_rpc_mode;
+} godot_nativescript_method_rpc_mode;
 
 typedef enum {
 	GODOT_PROPERTY_HINT_NONE, ///< no hint provided.
@@ -82,7 +82,7 @@ typedef enum {
 	GODOT_PROPERTY_HINT_PROPERTY_OF_INSTANCE, ///< a property of an instance
 	GODOT_PROPERTY_HINT_PROPERTY_OF_SCRIPT, ///< a property of a script & base
 	GODOT_PROPERTY_HINT_MAX,
-} godot_property_hint;
+} godot_nativescript_property_hint;
 
 typedef enum {
 
@@ -106,71 +106,80 @@ typedef enum {
 	GODOT_PROPERTY_USAGE_DEFAULT = GODOT_PROPERTY_USAGE_STORAGE | GODOT_PROPERTY_USAGE_EDITOR | GODOT_PROPERTY_USAGE_NETWORK,
 	GODOT_PROPERTY_USAGE_DEFAULT_INTL = GODOT_PROPERTY_USAGE_STORAGE | GODOT_PROPERTY_USAGE_EDITOR | GODOT_PROPERTY_USAGE_NETWORK | GODOT_PROPERTY_USAGE_INTERNATIONALIZED,
 	GODOT_PROPERTY_USAGE_NOEDITOR = GODOT_PROPERTY_USAGE_STORAGE | GODOT_PROPERTY_USAGE_NETWORK,
-} godot_property_usage_flags;
+} godot_nativescript_property_usage_flags;
 
 typedef struct {
-	godot_method_rpc_mode rset_type;
+	godot_nativescript_method_rpc_mode rset_type;
 
 	godot_int type;
-	godot_property_hint hint;
+	godot_nativescript_property_hint hint;
 	godot_string hint_string;
-	godot_property_usage_flags usage;
+	godot_nativescript_property_usage_flags usage;
 	godot_variant default_value;
-} godot_property_attributes;
+} godot_nativescript_property_attributes;
 
 typedef struct {
 	// instance pointer, method_data - return user data
 	GDCALLINGCONV void *(*create_func)(godot_object *, void *);
 	void *method_data;
 	GDCALLINGCONV void (*free_func)(void *);
-} godot_instance_create_func;
+} godot_nativescript_instance_create_func;
 
 typedef struct {
 	// instance pointer, method data, user data
 	GDCALLINGCONV void (*destroy_func)(godot_object *, void *, void *);
 	void *method_data;
 	GDCALLINGCONV void (*free_func)(void *);
-} godot_instance_destroy_func;
+} godot_nativescript_instance_destroy_func;
 
-void GDAPI godot_nativescript_register_class(void *p_gdnative_handle, const char *p_name, const char *p_base, godot_instance_create_func p_create_func, godot_instance_destroy_func p_destroy_func);
+void GDAPI godot_nativescript_register_class(void *p_gdnative_handle, const char *p_name, const char *p_base, godot_nativescript_instance_create_func p_create_func, godot_nativescript_instance_destroy_func p_destroy_func);
 
-void GDAPI godot_nativescript_register_tool_class(void *p_gdnative_handle, const char *p_name, const char *p_base, godot_instance_create_func p_create_func, godot_instance_destroy_func p_destroy_func);
+void GDAPI godot_nativescript_register_tool_class(void *p_gdnative_handle, const char *p_name, const char *p_base, godot_nativescript_instance_create_func p_create_func, godot_nativescript_instance_destroy_func p_destroy_func);
 
 typedef struct {
-	godot_method_rpc_mode rpc_type;
-} godot_method_attributes;
+	godot_nativescript_method_rpc_mode rpc_type;
+} godot_nativescript_method_attributes;
+
+typedef struct {
+	godot_string name;
+
+	godot_variant_type type;
+	godot_nativescript_property_hint hint;
+	godot_string hint_string;
+} godot_nativescript_method_argument;
 
 typedef struct {
 	// instance pointer, method data, user data, num args, args - return result as varaint
 	GDCALLINGCONV godot_variant (*method)(godot_object *, void *, void *, int, godot_variant **);
 	void *method_data;
 	GDCALLINGCONV void (*free_func)(void *);
-} godot_instance_method;
+} godot_nativescript_instance_method;
 
-void GDAPI godot_nativescript_register_method(void *p_gdnative_handle, const char *p_name, const char *p_function_name, godot_method_attributes p_attr, godot_instance_method p_method);
+void GDAPI godot_nativescript_register_method(void *p_gdnative_handle, const char *p_name, const char *p_function_name, godot_nativescript_method_attributes p_attr, godot_nativescript_instance_method p_method);
+void GDAPI godot_nativescript_set_method_argument_information(void *p_gdnative_handle, const char *p_name, const char *p_function_name, int p_num_args, const godot_nativescript_method_argument *p_args);
 
 typedef struct {
 	// instance pointer, method data, user data, value
 	GDCALLINGCONV void (*set_func)(godot_object *, void *, void *, godot_variant *);
 	void *method_data;
 	GDCALLINGCONV void (*free_func)(void *);
-} godot_property_set_func;
+} godot_nativescript_property_set_func;
 
 typedef struct {
 	// instance pointer, method data, user data, value
 	GDCALLINGCONV godot_variant (*get_func)(godot_object *, void *, void *);
 	void *method_data;
 	GDCALLINGCONV void (*free_func)(void *);
-} godot_property_get_func;
+} godot_nativescript_property_get_func;
 
-void GDAPI godot_nativescript_register_property(void *p_gdnative_handle, const char *p_name, const char *p_path, godot_property_attributes *p_attr, godot_property_set_func p_set_func, godot_property_get_func p_get_func);
+void GDAPI godot_nativescript_register_property(void *p_gdnative_handle, const char *p_name, const char *p_path, godot_nativescript_property_attributes *p_attr, godot_nativescript_property_set_func p_set_func, godot_nativescript_property_get_func p_get_func);
 
 typedef struct {
 	godot_string name;
 	godot_int type;
-	godot_property_hint hint;
+	godot_nativescript_property_hint hint;
 	godot_string hint_string;
-	godot_property_usage_flags usage;
+	godot_nativescript_property_usage_flags usage;
 	godot_variant default_value;
 } godot_nativescript_signal_argument;
 
@@ -185,26 +194,6 @@ typedef struct {
 void GDAPI godot_nativescript_register_signal(void *p_gdnative_handle, const char *p_name, const godot_nativescript_signal *p_signal);
 
 void GDAPI *godot_nativescript_get_userdata(godot_object *p_instance);
-
-/*
- *
- *
- * NativeScript 1.1
- *
- *
- */
-
-// method registering with argument names
-
-typedef struct {
-	godot_string name;
-
-	godot_variant_type type;
-	godot_property_hint hint;
-	godot_string hint_string;
-} godot_method_arg;
-
-void GDAPI godot_nativescript_set_method_argument_information(void *p_gdnative_handle, const char *p_name, const char *p_function_name, int p_num_args, const godot_method_arg *p_args);
 
 // documentation
 
@@ -230,9 +219,9 @@ typedef struct {
 	GDCALLINGCONV bool (*refcount_decremented_instance_binding)(void *, godot_object *);
 	void *data;
 	GDCALLINGCONV void (*free_func)(void *);
-} godot_instance_binding_functions;
+} godot_nativescript_instance_binding_functions;
 
-int GDAPI godot_nativescript_register_instance_binding_data_functions(godot_instance_binding_functions p_binding_functions);
+int GDAPI godot_nativescript_register_instance_binding_data_functions(godot_nativescript_instance_binding_functions p_binding_functions);
 void GDAPI godot_nativescript_unregister_instance_binding_data_functions(int p_idx);
 
 void GDAPI *godot_nativescript_get_instance_binding_data(int p_idx, godot_object *p_object);

--- a/modules/gdnative/nativescript/godot_nativescript.cpp
+++ b/modules/gdnative/nativescript/godot_nativescript.cpp
@@ -51,7 +51,7 @@ extern "C" void _native_script_hook() {
 
 // Script API
 
-void GDAPI godot_nativescript_register_class(void *p_gdnative_handle, const char *p_name, const char *p_base, godot_instance_create_func p_create_func, godot_instance_destroy_func p_destroy_func) {
+void GDAPI godot_nativescript_register_class(void *p_gdnative_handle, const char *p_name, const char *p_base, godot_nativescript_instance_create_func p_create_func, godot_nativescript_instance_destroy_func p_destroy_func) {
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc> *classes = &NSL->library_classes[*s];
@@ -83,7 +83,7 @@ void GDAPI godot_nativescript_register_class(void *p_gdnative_handle, const char
 	classes->insert(p_name, desc);
 }
 
-void GDAPI godot_nativescript_register_tool_class(void *p_gdnative_handle, const char *p_name, const char *p_base, godot_instance_create_func p_create_func, godot_instance_destroy_func p_destroy_func) {
+void GDAPI godot_nativescript_register_tool_class(void *p_gdnative_handle, const char *p_name, const char *p_base, godot_nativescript_instance_create_func p_create_func, godot_nativescript_instance_destroy_func p_destroy_func) {
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc> *classes = &NSL->library_classes[*s];
@@ -116,7 +116,7 @@ void GDAPI godot_nativescript_register_tool_class(void *p_gdnative_handle, const
 	classes->insert(p_name, desc);
 }
 
-void GDAPI godot_nativescript_register_method(void *p_gdnative_handle, const char *p_name, const char *p_function_name, godot_method_attributes p_attr, godot_instance_method p_method) {
+void GDAPI godot_nativescript_register_method(void *p_gdnative_handle, const char *p_name, const char *p_function_name, godot_nativescript_method_attributes p_attr, godot_nativescript_instance_method p_method) {
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
@@ -135,7 +135,7 @@ void GDAPI godot_nativescript_register_method(void *p_gdnative_handle, const cha
 	E->get().methods.insert(p_function_name, method);
 }
 
-void GDAPI godot_nativescript_register_property(void *p_gdnative_handle, const char *p_name, const char *p_path, godot_property_attributes *p_attr, godot_property_set_func p_set_func, godot_property_get_func p_get_func) {
+void GDAPI godot_nativescript_register_property(void *p_gdnative_handle, const char *p_name, const char *p_path, godot_nativescript_property_attributes *p_attr, godot_nativescript_property_set_func p_set_func, godot_nativescript_property_get_func p_get_func) {
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
@@ -221,7 +221,7 @@ void GDAPI *godot_nativescript_get_userdata(godot_object *p_instance) {
  *
  */
 
-void GDAPI godot_nativescript_set_method_argument_information(void *p_gdnative_handle, const char *p_name, const char *p_function_name, int p_num_args, const godot_method_arg *p_args) {
+void GDAPI godot_nativescript_set_method_argument_information(void *p_gdnative_handle, const char *p_name, const char *p_function_name, int p_num_args, const godot_nativescript_method_argument *p_args) {
 	String *s = (String *)p_gdnative_handle;
 
 	Map<StringName, NativeScriptDesc>::Element *E = NSL->library_classes[*s].find(p_name);
@@ -235,7 +235,7 @@ void GDAPI godot_nativescript_set_method_argument_information(void *p_gdnative_h
 	List<PropertyInfo> args;
 
 	for (int i = 0; i < p_num_args; i++) {
-		godot_method_arg arg = p_args[i];
+		godot_nativescript_method_argument arg = p_args[i];
 		String name = *(String *)&arg.name;
 		String hint_string = *(String *)&arg.hint_string;
 
@@ -329,7 +329,7 @@ const void GDAPI *godot_nativescript_get_type_tag(const godot_object *p_object) 
 	return nullptr;
 }
 
-int GDAPI godot_nativescript_register_instance_binding_data_functions(godot_instance_binding_functions p_binding_functions) {
+int GDAPI godot_nativescript_register_instance_binding_data_functions(godot_nativescript_instance_binding_functions p_binding_functions) {
 	return NativeScriptLanguage::get_singleton()->register_binding_functions(p_binding_functions);
 }
 

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1498,7 +1498,7 @@ void NativeScriptLanguage::profiling_add_data(StringName p_signature, uint64_t p
 #endif
 }
 
-int NativeScriptLanguage::register_binding_functions(godot_instance_binding_functions p_binding_functions) {
+int NativeScriptLanguage::register_binding_functions(godot_nativescript_instance_binding_functions p_binding_functions) {
 	// find index
 
 	int idx = -1;

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -48,7 +48,7 @@
 
 struct NativeScriptDesc {
 	struct Method {
-		godot_instance_method method;
+		godot_nativescript_instance_method method;
 		MethodInfo info;
 		int rpc_mode;
 		uint16_t rpc_method_id;
@@ -56,8 +56,8 @@ struct NativeScriptDesc {
 	};
 
 	struct Property {
-		godot_property_set_func setter;
-		godot_property_get_func getter;
+		godot_nativescript_property_set_func setter;
+		godot_nativescript_property_get_func getter;
 		PropertyInfo info;
 		Variant default_value;
 		int rset_mode;
@@ -78,8 +78,8 @@ struct NativeScriptDesc {
 	StringName base;
 	StringName base_native_type;
 	NativeScriptDesc *base_data;
-	godot_instance_create_func create_func;
-	godot_instance_destroy_func destroy_func;
+	godot_nativescript_instance_create_func create_func;
+	godot_nativescript_instance_destroy_func destroy_func;
 
 	String documentation;
 
@@ -88,8 +88,8 @@ struct NativeScriptDesc {
 	bool is_tool;
 
 	inline NativeScriptDesc() {
-		zeromem(&create_func, sizeof(godot_instance_create_func));
-		zeromem(&destroy_func, sizeof(godot_instance_destroy_func));
+		zeromem(&create_func, sizeof(godot_nativescript_instance_create_func));
+		zeromem(&destroy_func, sizeof(godot_nativescript_instance_destroy_func));
 	}
 };
 
@@ -267,7 +267,7 @@ private:
 
 	void call_libraries_cb(const StringName &name);
 
-	Vector<Pair<bool, godot_instance_binding_functions>> binding_functions;
+	Vector<Pair<bool, godot_nativescript_instance_binding_functions>> binding_functions;
 	Set<Vector<void *> *> binding_instances;
 
 	Map<int, HashMap<StringName, const void *>> global_type_tags;
@@ -360,7 +360,7 @@ public:
 	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max);
 	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max);
 
-	int register_binding_functions(godot_instance_binding_functions p_binding_functions);
+	int register_binding_functions(godot_nativescript_instance_binding_functions p_binding_functions);
 	void unregister_binding_functions(int p_idx);
 
 	void *get_instance_binding_data(int p_idx, Object *p_object);


### PR DESCRIPTION
Merge all core API functions from the old incompatible structs to the new single "Core API 2.0" and extension API functions with multiple sub-versions to the new single structs, bump version of the new structs, as was suggested in #39064.