### PR TITLE
Unify OS.get_system_time_* and OS.get_unix_time

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -498,16 +498,8 @@ Dictionary _OS::get_time_zone_info() const {
 	return infod;
 }
 
-uint64_t _OS::get_unix_time() const {
+double _OS::get_unix_time() const {
 	return OS::get_singleton()->get_unix_time();
-}
-
-uint64_t _OS::get_system_time_secs() const {
-	return OS::get_singleton()->get_system_time_secs();
-}
-
-uint64_t _OS::get_system_time_msecs() const {
-	return OS::get_singleton()->get_system_time_msecs();
 }
 
 void _OS::delay_usec(uint32_t p_usec) const {
@@ -729,8 +721,6 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_unix_time"), &_OS::get_unix_time);
 	ClassDB::bind_method(D_METHOD("get_datetime_from_unix_time", "unix_time_val"), &_OS::get_datetime_from_unix_time);
 	ClassDB::bind_method(D_METHOD("get_unix_time_from_datetime", "datetime"), &_OS::get_unix_time_from_datetime);
-	ClassDB::bind_method(D_METHOD("get_system_time_secs"), &_OS::get_system_time_secs);
-	ClassDB::bind_method(D_METHOD("get_system_time_msecs"), &_OS::get_system_time_msecs);
 
 	ClassDB::bind_method(D_METHOD("get_exit_code"), &_OS::get_exit_code);
 	ClassDB::bind_method(D_METHOD("set_exit_code", "code"), &_OS::set_exit_code);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -199,9 +199,7 @@ public:
 	Dictionary get_datetime_from_unix_time(int64_t unix_time_val) const;
 	int64_t get_unix_time_from_datetime(Dictionary datetime) const;
 	Dictionary get_time_zone_info() const;
-	uint64_t get_unix_time() const;
-	uint64_t get_system_time_secs() const;
-	uint64_t get_system_time_msecs() const;
+	double get_unix_time() const;
 
 	uint64_t get_static_memory_usage() const;
 	uint64_t get_static_memory_peak_usage() const;

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -83,15 +83,7 @@ uint64_t OS::get_splash_tick_msec() const {
 	return _msec_splash;
 }
 
-uint64_t OS::get_unix_time() const {
-	return 0;
-}
-
-uint64_t OS::get_system_time_secs() const {
-	return 0;
-}
-
-uint64_t OS::get_system_time_msecs() const {
+double OS::get_unix_time() const {
 	return 0;
 }
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -209,9 +209,7 @@ public:
 	virtual Time get_time(bool local = false) const = 0;
 	virtual TimeZoneInfo get_time_zone_info() const = 0;
 	virtual String get_iso_date_time(bool local = false) const;
-	virtual uint64_t get_unix_time() const;
-	virtual uint64_t get_system_time_secs() const;
-	virtual uint64_t get_system_time_msecs() const;
+	virtual double get_unix_time() const;
 
 	virtual void delay_usec(uint32_t p_usec) const = 0;
 	virtual uint64_t get_ticks_usec() const = 0;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -325,7 +325,7 @@
 			</description>
 		</method>
 		<method name="get_unix_time" qualifiers="const">
-			<return type="int">
+			<return type="float">
 			</return>
 			<description>
 				Returns the current UNIX epoch timestamp.

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -163,21 +163,11 @@ String OS_Unix::get_name() const {
 	return "Unix";
 }
 
-uint64_t OS_Unix::get_unix_time() const {
-	return time(nullptr);
+double OS_Unix::get_unix_time() const {
+	struct timeval tv_now;
+	gettimeofday(&tv_now, nullptr);
+	return (double)tv_now.tv_sec + double(tv_now.tv_usec) / 1000000;
 };
-
-uint64_t OS_Unix::get_system_time_secs() const {
-	struct timeval tv_now;
-	gettimeofday(&tv_now, nullptr);
-	return uint64_t(tv_now.tv_sec);
-}
-
-uint64_t OS_Unix::get_system_time_msecs() const {
-	struct timeval tv_now;
-	gettimeofday(&tv_now, nullptr);
-	return uint64_t(tv_now.tv_sec) * 1000 + uint64_t(tv_now.tv_usec) / 1000;
-}
 
 OS::Date OS_Unix::get_date(bool utc) const {
 	time_t t = time(nullptr);

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -77,9 +77,7 @@ public:
 	virtual Time get_time(bool utc) const;
 	virtual TimeZoneInfo get_time_zone_info() const;
 
-	virtual uint64_t get_unix_time() const;
-	virtual uint64_t get_system_time_secs() const;
-	virtual uint64_t get_system_time_msecs() const;
+	virtual double get_unix_time() const;
 
 	virtual void delay_usec(uint32_t p_usec) const;
 	virtual uint64_t get_ticks_usec() const;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -129,9 +129,7 @@ public:
 	virtual Date get_date(bool utc) const;
 	virtual Time get_time(bool utc) const;
 	virtual TimeZoneInfo get_time_zone_info() const;
-	virtual uint64_t get_unix_time() const;
-	virtual uint64_t get_system_time_secs() const;
-	virtual uint64_t get_system_time_msecs() const;
+	virtual double get_unix_time() const;
 
 	virtual Error set_cwd(const String &p_cwd);
 


### PR DESCRIPTION
fix  #38925

Rational behind this:
- `OS.get_system_time_secs`&`OS.get_system_time_msecs` are currently broken on Windows platforms (they return unix timestamp)
- Godot should provide platform-independent API as much as possible

So the idea is to drop `OS.get_system_time_secs`&`OS.get_system_time_msecs` and use `OS.get_unix_time` everywhere (making it return a double so milliseconds are also returned)

I wonder if `OS.get_datetime_from_unix_time`, `OS.get_unix_time_from_datetime`, `OS.get_datetime` and `OS.get_time` should also be updated so they handle milliseconds as well (currently the precision is only down to the second which seems pretty coarse...)