### PR TITLE
Fix TextEdit::get_line_count() when lines are wrapped

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6002,7 +6002,13 @@ void TextEdit::toggle_fold_line(int p_line) {
 }
 
 int TextEdit::get_line_count() const {
-	return text.size();
+	int line_count = text.size();
+
+	for (int i = 0; i < text.size(); ++i) {
+		line_count += times_line_wraps(i);
+	}
+
+	return line_count;
 }
 
 void TextEdit::_do_text_op(const TextOperation &p_op, bool p_reverse) {


### PR DESCRIPTION
After this PR TextEdit::get_line_count() will return the number of entries in text vector, as well as a number of times those lines wrap around so that the result is the same as what users can see on screen, as opposed to a number of '\n' characters.

*Bugsquad edit:* Fixes #38180.