### PR TITLE
Print errors when calling MIDI input methods on unsupported platforms

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -457,18 +457,22 @@ PackedStringArray OS::get_connected_midi_inputs() {
 	}
 
 	PackedStringArray list;
-	return list;
+	ERR_FAIL_V_MSG(list, vformat("MIDI input isn't supported on %s.", OS::get_singleton()->get_name()));
 }
 
 void OS::open_midi_inputs() {
 	if (MIDIDriver::get_singleton()) {
 		MIDIDriver::get_singleton()->open();
+	} else {
+		ERR_PRINT(vformat("MIDI input isn't supported on %s.", OS::get_singleton()->get_name()));
 	}
 }
 
 void OS::close_midi_inputs() {
 	if (MIDIDriver::get_singleton()) {
 		MIDIDriver::get_singleton()->close();
+	} else {
+		ERR_PRINT(vformat("MIDI input isn't supported on %s.", OS::get_singleton()->get_name()));
 	}
 }
 


### PR DESCRIPTION
I'm not sure if this is the correct way to do it (please advise).

This partially addresses #32065.