### PR TITLE
Prevent crash attaching a script with no languages registered

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2557,6 +2557,11 @@ void SceneTreeDock::_focus_node() {
 }
 
 void SceneTreeDock::attach_script_to_selected(bool p_extend) {
+	if (ScriptServer::get_language_count() == 0) {
+		EditorNode::get_singleton()->show_warning(TTR("Cannot attach a script: there are no languages registered.\nThis is probably because this editor was built with all language modules disabled."));
+		return;
+	}
+
 	if (!profile_allow_script_editing) {
 		return;
 	}

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -783,7 +783,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	gc->add_child(memnew(Label(TTR("Language:"))));
 	gc->add_child(language_menu);
 
-	default_language = 0;
+	default_language = -1;
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 		String lang = ScriptServer::get_language(i)->get_name();
 		language_menu->add_item(lang);
@@ -791,8 +791,9 @@ ScriptCreateDialog::ScriptCreateDialog() {
 			default_language = i;
 		}
 	}
-
-	language_menu->select(default_language);
+	if (default_language >= 0) {
+		language_menu->select(default_language);
+	}
 	current_language = default_language;
 
 	language_menu->connect("item_selected", callable_mp(this, &ScriptCreateDialog::_lang_changed));


### PR DESCRIPTION
Show a warning instead:

![Annotation 2020-05-31 202526](https://user-images.githubusercontent.com/17108460/83358687-ea938f80-a37d-11ea-947f-ff2b88965482.png)

The crash can be reproduced with a build with no language support (EDIT: missing VisualScript module, added).
```
scons tools=yes module_gdscript_enabled=no module_gdnative_enabled=no module_mono_enabled=no module_visual_script_enabled=no
```
