### PR TITLE
Add a getter and property for the editor distraction-free mode

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4782,7 +4782,7 @@ void EditorNode::set_distraction_free_mode(bool p_enter) {
 	}
 }
 
-bool EditorNode::get_distraction_free_mode() const {
+bool EditorNode::is_distraction_free_mode_enabled() const {
 	return distraction_free->is_pressed();
 }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -693,7 +693,7 @@ public:
 	bool get_docks_visible() const;
 
 	void set_distraction_free_mode(bool p_enter);
-	bool get_distraction_free_mode() const;
+	bool is_distraction_free_mode_enabled() const;
 
 	void add_control_to_dock(DockSlot p_slot, Control *p_control);
 	void remove_control_from_dock(Control *p_control);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -270,6 +270,10 @@ void EditorInterface::set_distraction_free_mode(bool p_enter) {
 	EditorNode::get_singleton()->set_distraction_free_mode(p_enter);
 }
 
+bool EditorInterface::is_distraction_free_mode_enabled() const {
+	return EditorNode::get_singleton()->is_distraction_free_mode_enabled();
+}
+
 EditorInterface *EditorInterface::singleton = nullptr;
 
 void EditorInterface::_bind_methods() {
@@ -302,6 +306,9 @@ void EditorInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_main_screen_editor", "name"), &EditorInterface::set_main_screen_editor);
 	ClassDB::bind_method(D_METHOD("set_distraction_free_mode", "enter"), &EditorInterface::set_distraction_free_mode);
+	ClassDB::bind_method(D_METHOD("is_distraction_free_mode_enabled"), &EditorInterface::is_distraction_free_mode_enabled);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distraction_free_mode"), "set_distraction_free_mode", "is_distraction_free_mode_enabled");
 }
 
 EditorInterface::EditorInterface() {

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -105,6 +105,7 @@ public:
 
 	void set_main_screen_editor(const String &p_name);
 	void set_distraction_free_mode(bool p_enter);
+	bool is_distraction_free_mode_enabled() const;
 
 	EditorInterface();
 };


### PR DESCRIPTION
The distraction-free setter method was renamed for consistency.

## Test this change

Create a new editor plugin, add the following script to it:

```gdscript
tool
extends EditorPlugin


func _enter_tree():
	print(get_editor_interface().distraction_free_mode)
	get_editor_interface().distraction_free_mode = false
```

Enable the distraction-free mode by clicking the button in the top-right corner of the editor. Then disable and enable the plugin repeatedly and look at the console output.