### PR TITLE
Export projects in release mode by default

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1304,14 +1304,18 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_project->connect("file_selected", callable_mp(this, &ProjectExportDialog::_export_project_to_path));
 	export_project->get_line_edit()->connect("text_changed", callable_mp(this, &ProjectExportDialog::_validate_export_path));
 
+	const String export_debug_tooltip =
+			TTR("By default, projects are exported in release mode.\nExporting in debug mode enables various runtime checks at the cost of larger and slower binaries.\nOnly enable this option if you actually need it.");
 	export_debug = memnew(CheckBox);
-	export_debug->set_text(TTR("Export With Debug"));
-	export_debug->set_pressed(true);
+	export_debug->set_text(TTR("Export In Debug Mode"));
+	export_debug->set_tooltip(export_debug_tooltip);
+	export_debug->set_pressed(false);
 	export_project->get_vbox()->add_child(export_debug);
 
 	export_pck_zip_debug = memnew(CheckBox);
-	export_pck_zip_debug->set_text(TTR("Export With Debug"));
-	export_pck_zip_debug->set_pressed(true);
+	export_pck_zip_debug->set_text(TTR("Export In Debug Mode"));
+	export_pck_zip_debug->set_tooltip(export_debug_tooltip);
+	export_pck_zip_debug->set_pressed(false);
 	export_pck_zip->get_vbox()->add_child(export_pck_zip_debug);
 
 	set_hide_on_ok(false);


### PR DESCRIPTION
This PR could be cherry-picked to the `3.2` branch as people tend to miss this checkbox when exporting a project.

___

This results in faster, smaller exported binaries out of the box. Most of the time, people won't need to export in debug mode, making the release mode a better default choice.

This behavior also matches the command-line interface, where the "default" option (`--export`) exports a project in release mode.

This also renames the option and adds a tooltip for clarity.