### PR TITLE
Use `.ini` extension for all ConfigFiles saved/loaded by the editor

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -369,7 +369,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 		Error err = _load_settings_text_or_binary("res://project.godot", "res://project.binary");
 		if (err == OK) {
 			// Optional, we don't mind if it fails
-			_load_settings_text("res://override.cfg");
+			_load_settings_text("res://override.ini");
 		}
 		return err;
 	}
@@ -384,7 +384,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 		if (err == OK) {
 			// Load override from location of the main pack
 			// Optional, we don't mind if it fails
-			_load_settings_text(p_main_pack.get_base_dir().plus_file("override.cfg"));
+			_load_settings_text(p_main_pack.get_base_dir().plus_file("override.ini"));
 		}
 		return err;
 	}
@@ -434,7 +434,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 			if (err == OK) {
 				// Load override from location of the executable.
 				// Optional, we don't mind if it fails.
-				_load_settings_text(exec_path.get_base_dir().plus_file("override.cfg"));
+				_load_settings_text(exec_path.get_base_dir().plus_file("override.ini"));
 			}
 			return err;
 		}
@@ -454,7 +454,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 		Error err = _load_settings_text_or_binary("res://project.godot", "res://project.binary");
 		if (err == OK) {
 			// Optional, we don't mind if it fails.
-			_load_settings_text("res://override.cfg");
+			_load_settings_text("res://override.ini");
 		}
 		return err;
 	}
@@ -477,7 +477,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 		err = _load_settings_text_or_binary(current_dir.plus_file("project.godot"), current_dir.plus_file("project.binary"));
 		if (err == OK) {
 			// Optional, we don't mind if it fails.
-			_load_settings_text(current_dir.plus_file("override.cfg"));
+			_load_settings_text(current_dir.plus_file("override.ini"));
 			found = true;
 			break;
 		}
@@ -906,7 +906,7 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 		custom_features += f;
 	}
 
-	if (p_path.ends_with(".godot") || p_path.ends_with("override.cfg")) {
+	if (p_path.ends_with(".godot") || p_path.ends_with("override.ini")) {
 		return _save_settings_text(p_path, props, p_custom, custom_features);
 	} else if (p_path.ends_with(".binary")) {
 		return _save_settings_binary(p_path, props, p_custom, custom_features);

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -16,7 +16,7 @@
 		[codeblocks]
 		[gdscript]
 		var config = ConfigFile.new()
-		var err = config.load("user://settings.cfg")
+		var err = config.load("user://settings.ini")
 		if err == OK: # If not, something went wrong with the file loading
 		    # Look for the display/width pair, and default to 1024 if missing
 		    var screen_width = config.get_value("display", "width", 1024)
@@ -24,11 +24,11 @@
 		    if not config.has_section_key("audio", "mute"):
 		        config.set_value("audio", "mute", false)
 		    # Save the changes by overwriting the previous file
-		    config.save("user://settings.cfg")
+		    config.save("user://settings.ini")
 		[/gdscript]
 		[csharp]
 		var config = new ConfigFile();
-		Error err = config.Load("user://settings.cfg");
+		Error err = config.Load("user://settings.ini");
 		if (err == Error.Ok) // If not, something went wrong with the file loading
 		{
 		    // Look for the display/width pair, and default to 1024 if missing
@@ -39,7 +39,7 @@
 		        config.SetValue("audio", "mute", false);
 		    }
 		    // Save the changes by overwriting the previous file
-		    config.Save("user://settings.cfg");
+		    config.Save("user://settings.ini");
 		}
 		[/csharp]
 		[/codeblocks]

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -7,7 +7,7 @@
 		Contains global variables accessible from everywhere. Use [method get_setting], [method set_setting] or [method has_setting] to access them. Variables stored in [code]project.godot[/code] are also loaded into ProjectSettings, making this object very useful for reading custom game configuration options.
 		When naming a Project Settings property, use the full path to the setting including the category. For example, [code]"application/config/name"[/code] for the project name. Category and property names can be viewed in the Project Settings dialog.
 		[b]Feature tags:[/b] Project settings can be overriden for specific platforms and configurations (debug, release, ...) using [url=https://docs.godotengine.org/en/latest/tutorials/export/feature_tags.html]feature tags[/url].
-		[b]Overriding:[/b] Any project setting can be overridden by creating a file named [code]override.cfg[/code] in the project's root directory. This can also be used in exported projects by placing this file in the same directory as the project binary. Overriding will still take the base project settings' [url=https://docs.godotengine.org/en/latest/tutorials/export/feature_tags.html]feature tags[/url] in account. Therefore, make sure to [i]also[/i] override the setting with the desired feature tags if you want them to override base project settings on all platforms and configurations.
+		[b]Overriding:[/b] Any project setting can be overridden by creating a file named [code]override.ini[/code] in the project's root directory. This can also be used in exported projects by placing this file in the same directory as the project binary. Overriding will still take the base project settings' [url=https://docs.godotengine.org/en/latest/tutorials/export/feature_tags.html]feature tags[/url] in account. Therefore, make sure to [i]also[/i] override the setting with the desired feature tags if you want them to override base project settings on all platforms and configurations.
 	</description>
 	<tutorials>
 		<link title="3D Physics Tests Demo">https://godotengine.org/asset-library/asset/675</link>
@@ -170,7 +170,7 @@
 			</return>
 			<description>
 				Saves the configuration to the [code]project.godot[/code] file.
-				[b]Note:[/b] This method is intended to be used by editor plugins, as modified [ProjectSettings] can't be loaded back in the running app. If you want to change project settings in exported projects, use [method save_custom] to save [code]override.cfg[/code] file.
+				[b]Note:[/b] This method is intended to be used by editor plugins, as modified [ProjectSettings] can't be loaded back in the running app. If you want to change project settings in exported projects, use [method save_custom] to save [code]override.ini[/code] file.
 			</description>
 		</method>
 		<method name="save_custom">
@@ -179,7 +179,7 @@
 			<argument index="0" name="file" type="String">
 			</argument>
 			<description>
-				Saves the configuration to a custom file. The file extension must be [code].godot[/code] (to save in text-based [ConfigFile] format) or [code].binary[/code] (to save in binary format). You can also save [code]override.cfg[/code] file, which is also text, but can be used in exported projects unlike other formats.
+				Saves the configuration to a custom file. The file extension must be [code].godot[/code] (to save in text-based [ConfigFile] format) or [code].binary[/code] (to save in binary format). You can also save [code]override.ini[/code] file, which is also text, but can be used in exported projects unlike other formats.
 			</description>
 		</method>
 		<method name="set_initial_value">
@@ -256,8 +256,8 @@
 			[b]Note:[/b] Changing this value will also change the user data folder's path if [member application/config/use_custom_user_dir] is [code]false[/code]. After renaming the project, you will no longer be able to access existing data in [code]user://[/code] unless you rename the old folder to match the new project name. See [url=https://docs.godotengine.org/en/latest/tutorials/io/data_paths.html]Data paths[/url] in the documentation for more information.
 		</member>
 		<member name="application/config/project_settings_override" type="String" setter="" getter="" default="&quot;&quot;">
-			Specifies a file to override project settings. For example: [code]user://custom_settings.cfg[/code]. See "Overriding" in the [ProjectSettings] class description at the top for more information.
-			[b]Note:[/b] Regardless of this setting's value, [code]res://override.cfg[/code] will still be read to override the project settings.
+			Specifies a file to override project settings. For example: [code]user://custom_settings.ini[/code]. See "Overriding" in the [ProjectSettings] class description at the top for more information.
+			[b]Note:[/b] Regardless of this setting's value, [code]res://override.ini[/code] will still be read to override the project settings.
 		</member>
 		<member name="application/config/use_custom_user_dir" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the project will save user data to its own user directory (see [member application/config/custom_user_dir_name]). This setting is only effective on desktop platforms. A name must be set in the [member application/config/custom_user_dir_name] setting for this to take effect. If [code]false[/code], the project will save user data to [code](OS user data directory)/Godot/app_userdata/(project name)[/code].

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1441,7 +1441,7 @@ void EditorExport::_save() {
 		}
 	}
 
-	config->save("res://export_presets.cfg");
+	config->save("res://export_presets.ini");
 }
 
 void EditorExport::save_presets() {
@@ -1547,7 +1547,7 @@ void EditorExport::_notification(int p_what) {
 void EditorExport::load_config() {
 	Ref<ConfigFile> config;
 	config.instance();
-	Error err = config->load("res://export_presets.cfg");
+	Error err = config->load("res://export_presets.ini");
 	if (err != OK) {
 		return;
 	}

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -54,7 +54,7 @@ void EditorFolding::save_resource_folding(const RES &p_resource, const String &p
 	Vector<String> unfolds = _get_unfolds(p_resource.ptr());
 	config->set_value("folding", "sections_unfolded", unfolds);
 
-	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
+	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".ini";
 	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
 	config->save(file);
 }
@@ -72,7 +72,7 @@ void EditorFolding::load_resource_folding(RES p_resource, const String &p_path) 
 	Ref<ConfigFile> config;
 	config.instance();
 
-	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
+	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".ini";
 	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
 
 	if (config->load(file) != OK) {
@@ -148,7 +148,7 @@ void EditorFolding::save_scene_folding(const Node *p_scene, const String &p_path
 	config->set_value("folding", "resource_unfolds", res_unfolds);
 	config->set_value("folding", "nodes_folded", nodes_folded);
 
-	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
+	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".ini";
 	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
 	config->save(file);
 }
@@ -158,7 +158,7 @@ void EditorFolding::load_scene_folding(Node *p_scene, const String &p_path) {
 	config.instance();
 
 	String path = EditorSettings::get_singleton()->get_project_settings_dir();
-	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
+	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".ini";
 	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
 
 	if (config->load(file) != OK) {
@@ -215,7 +215,7 @@ void EditorFolding::load_scene_folding(Node *p_scene, const String &p_path) {
 }
 
 bool EditorFolding::has_folding_data(const String &p_path) {
-	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
+	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".ini";
 	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
 	return FileAccess::exists(file);
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -803,16 +803,16 @@ void EditorNode::_fs_changed() {
 
 		if (preset.is_null()) {
 			DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-			if (da->file_exists("res://export_presets.cfg")) {
+			if (da->file_exists("res://export_presets.ini")) {
 				export_error = vformat(
-						"Invalid export preset name: %s.\nThe following presets were detected in this project's `export_presets.cfg`:\n\n",
+						"Invalid export preset name: %s.\nThe following presets were detected in this project's `export_presets.ini`:\n\n",
 						preset_name);
 				for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); ++i) {
 					// Write the preset name between double quotes since it needs to be written between quotes on the command line if it contains spaces.
 					export_error += vformat("        \"%s\"\n", EditorExport::get_singleton()->get_export_preset(i)->get_name());
 				}
 			} else {
-				export_error = "This project doesn't have an `export_presets.cfg` file at its root.\nCreate an export preset from the \"Project > Export\" dialog and try again.";
+				export_error = "This project doesn't have an `export_presets.ini` file at its root.\nCreate an export preset from the \"Project > Export\" dialog and try again.";
 			}
 		} else {
 			Ref<EditorExportPlatform> platform = preset->get_platform();
@@ -1216,7 +1216,7 @@ void EditorNode::_get_scene_metadata(const String &p_file) {
 		return;
 	}
 
-	String path = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".cfg");
+	String path = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".ini");
 
 	Ref<ConfigFile> cf;
 	cf.instance();
@@ -1250,7 +1250,7 @@ void EditorNode::_set_scene_metadata(const String &p_file, int p_idx) {
 	scene->set_meta("__editor_run_settings__", Variant()); //clear it (no point in keeping it)
 	scene->set_meta("__editor_plugin_states__", Variant());
 
-	String path = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".cfg");
+	String path = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".ini");
 
 	Ref<ConfigFile> cf;
 	cf.instance();
@@ -4367,7 +4367,7 @@ void EditorNode::_save_docks() {
 	_save_open_scenes_to_config(config, "EditorNode");
 	editor_data.get_plugin_window_layout(config);
 
-	config->save(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
+	config->save(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.ini"));
 }
 
 void EditorNode::_save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) {
@@ -4425,7 +4425,7 @@ void EditorNode::_dock_split_dragged(int ofs) {
 void EditorNode::_load_docks() {
 	Ref<ConfigFile> config;
 	config.instance();
-	Error err = config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
+	Error err = config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.ini"));
 	if (err != OK) {
 		//no config
 		if (overridden_default_layout >= 0) {
@@ -4658,7 +4658,7 @@ bool EditorNode::has_scenes_in_session() {
 	}
 	Ref<ConfigFile> config;
 	config.instance();
-	Error err = config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
+	Error err = config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.ini"));
 	if (err != OK) {
 		return false;
 	}

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -171,7 +171,7 @@ Vector<String> EditorPluginSettings::_get_plugins(const String &p_dir) {
 		}
 
 		const String full_path = p_dir.plus_file(path);
-		const String plugin_config = full_path.plus_file("plugin.cfg");
+		const String plugin_config = full_path.plus_file("plugin.ini");
 		if (FileAccess::exists(plugin_config)) {
 			plugins.push_back(plugin_config);
 		} else {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1351,7 +1351,7 @@ String EditorSettings::get_feature_profiles_dir() const {
 
 void EditorSettings::set_project_metadata(const String &p_section, const String &p_key, Variant p_data) {
 	Ref<ConfigFile> cf = memnew(ConfigFile);
-	String path = get_project_settings_dir().plus_file("project_metadata.cfg");
+	String path = get_project_settings_dir().plus_file("project_metadata.ini");
 	Error err;
 	err = cf->load(path);
 	ERR_FAIL_COND_MSG(err != OK && err != ERR_FILE_NOT_FOUND, "Cannot load editor settings from file '" + path + "'.");
@@ -1362,7 +1362,7 @@ void EditorSettings::set_project_metadata(const String &p_section, const String 
 
 Variant EditorSettings::get_project_metadata(const String &p_section, const String &p_key, Variant p_default) const {
 	Ref<ConfigFile> cf = memnew(ConfigFile);
-	String path = get_project_settings_dir().plus_file("project_metadata.cfg");
+	String path = get_project_settings_dir().plus_file("project_metadata.ini");
 	Error err = cf->load(path);
 	if (err != OK) {
 		return p_default;
@@ -1571,7 +1571,7 @@ Vector<String> EditorSettings::get_script_templates(const String &p_extension, c
 }
 
 String EditorSettings::get_editor_layouts_config() const {
-	return get_settings_dir().plus_file("editor_layouts.cfg");
+	return get_settings_dir().plus_file("editor_layouts.ini");
 }
 
 // Shortcuts

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -68,7 +68,7 @@ void PluginConfigDialog::_on_confirmed() {
 	cf->set_value("plugin", "version", version_edit->get_text());
 	cf->set_value("plugin", "script", script_edit->get_text());
 
-	cf->save(path.plus_file("plugin.cfg"));
+	cf->save(path.plus_file("plugin.ini"));
 
 	if (!_edit_mode) {
 		int lang_idx = script_option_edit->get_selected();
@@ -130,7 +130,7 @@ void PluginConfigDialog::_on_required_text_changed(const String &) {
 }
 
 String PluginConfigDialog::_to_absolute_plugin_path(const String &p_plugin_name) {
-	return "res://addons/" + p_plugin_name + "/plugin.cfg";
+	return "res://addons/" + p_plugin_name + "/plugin.ini";
 }
 
 void PluginConfigDialog::_notification(int p_what) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -361,7 +361,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  -s, --script <script>                        Run a script.\n");
 	OS::get_singleton()->print("  --check-only                                 Only parse for errors and quit (use with --script).\n");
 #ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("  --export <preset> <path>                     Export the project using the given preset and matching release template. The preset name should match one defined in export_presets.cfg.\n");
+	OS::get_singleton()->print("  --export <preset> <path>                     Export the project using the given preset and matching release template. The preset name should match one defined in export_presets.ini.\n");
 	OS::get_singleton()->print("                                               <path> should be absolute or relative to the project directory, and include the filename for the binary (e.g. 'builds/game.exe'). The target directory should exist.\n");
 	OS::get_singleton()->print("  --export-debug <preset> <path>               Same as --export, but using the debug template.\n");
 	OS::get_singleton()->print("  --export-pack <preset> <path>                Same as --export, but only export the game pack for the given preset. The <path> extension determines whether it will be in PCK or ZIP format.\n");

--- a/misc/dist/linux/godot.6
+++ b/misc/dist/linux/godot.6
@@ -137,7 +137,7 @@ Run a script.
 Only parse for errors and quit (use with --script).
 .TP
 \fB\-\-export\fR <preset> <path>
-Export the project using the given preset and matching release template. The preset name should match one defined in export_presets.cfg.
+Export the project using the given preset and matching release template. The preset name should match one defined in export_presets.ini.
 .br
 <path> should be absolute or relative to the project directory, and include the filename for the binary (e.g. 'builds/game.exe'). The target directory should exist.
 .TP

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -684,7 +684,7 @@ static bool try_get_cached_api_hash_for(const String &p_api_assemblies_dir, bool
 		return false;
 	}
 
-	String cached_api_hash_path = p_api_assemblies_dir.plus_file("api_hash_cache.cfg");
+	String cached_api_hash_path = p_api_assemblies_dir.plus_file("api_hash_cache.ini");
 
 	if (!FileAccess::exists(cached_api_hash_path)) {
 		return false;
@@ -714,7 +714,7 @@ static bool try_get_cached_api_hash_for(const String &p_api_assemblies_dir, bool
 static void create_cached_api_hash_for(const String &p_api_assemblies_dir) {
 	String core_api_assembly_path = p_api_assemblies_dir.plus_file(CORE_API_ASSEMBLY_NAME ".dll");
 	String editor_api_assembly_path = p_api_assemblies_dir.plus_file(EDITOR_API_ASSEMBLY_NAME ".dll");
-	String cached_api_hash_path = p_api_assemblies_dir.plus_file("api_hash_cache.cfg");
+	String cached_api_hash_path = p_api_assemblies_dir.plus_file("api_hash_cache.ini");
 
 	Ref<ConfigFile> cfg;
 	cfg.instance();


### PR DESCRIPTION
This lets text editors use better syntax highlighting compared to `.cfg` (which is typically treated as plain text, or sometimes poorly autodetected).

On Windows, `.ini` files are also associated to Notepad out of the box, which makes it possible to open them by double-clicking them even if no external editor is available.

Since this changes the expected name for plugin files and export presets, this is a breaking change.

## Preview (in KWrite)

### Before

*The file is detected as being a [Nagios](https://www.nagios.org/) configuration file.*

![image](https://user-images.githubusercontent.com/180032/83365516-d5802600-a3a8-11ea-97e9-0752e14abe6c.png)

### After

*The file is detected as being an INI file.*

![image](https://user-images.githubusercontent.com/180032/83365511-c4cfb000-a3a8-11ea-8035-9b5d8b378857.png)