### PR TITLE
Fix for Expression class: string inside an expression can't be single quoted

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -896,6 +896,7 @@ Error Expression::_get_token(Token &r_token) {
 
 				return OK;
 			}
+			case '\'':
 			case '"': {
 				String str;
 				while (true) {
@@ -905,7 +906,8 @@ Error Expression::_get_token(Token &r_token) {
 						_set_error("Unterminated String");
 						r_token.type = TK_ERROR;
 						return ERR_PARSE_ERROR;
-					} else if (ch == '"') {
+					} else if (ch == cchar) {
+						// cchar contain a corresponding quote symbol
 						break;
 					} else if (ch == '\\') {
 						//escaped characters...


### PR DESCRIPTION
Hello
I noticed that `Expression` class doesn't accept string in single quotes inside expression.
Line like this `e.parse ("get_tree().current_scene.get_node('Button')")` cause runtime error with mesage: "Unexpected character."
This patch was inspired by ./modules/gdscript/gdscript_tokenizer.cpp

Also I noticed that `$` doesn't work as `get_node` synonym but it doesn't covered by this PR

Reproducer:
[expression.zip](https://github.com/godotengine/godot/files/4713827/expression.zip)
