### PR TITLE
Fix timers running inside scene preview on drag

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6041,10 +6041,11 @@ void CanvasItemEditorViewport::_create_preview(const Vector<String> &files) cons
 #warning TODO find a better method for pausing preview
 #endif
 					if (instance) {
+						
 						for (int j = 0; j < instance->get_child_count(); j++) {
-							Node *curr_child = instance->get_child(j);
-							if (curr_child->get_class() == "Timer") {
-								curr_child->call("stop");
+							Timer *timer = Object::cast_to<Timer>(instance->get_child(j));
+							if (timer) {
+								timer->stop();
 							}
 						}
 						preview_node->add_child(instance);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6038,6 +6038,17 @@ void CanvasItemEditorViewport::_create_preview(const Vector<String> &files) cons
 				if (scene.is_valid()) {
 					Node *instance = scene->instance();
 					if (instance) {
+						// TODO: Find a better method
+						// This fix works if the timer on the scene is an immediate child 
+						// (it breaks on nested timers).
+						// I tried to use something like "instance->get_tree()->set_pause(true)"
+						// to pause updates on the whole scene tree, but Godot crashes, so I need to investigate.
+						for (int j = 0; j < instance->get_child_count(); j++) {
+							Node *curr_child = instance->get_child(j);
+							if (curr_child->get_class() == "Timer") {
+								curr_child->call("stop");
+							}
+						}
 						preview_node->add_child(instance);
 					}
 				}

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6037,12 +6037,10 @@ void CanvasItemEditorViewport::_create_preview(const Vector<String> &files) cons
 			} else {
 				if (scene.is_valid()) {
 					Node *instance = scene->instance();
+#ifndef _MSC_VER
+#warning TODO find a better method for pausing preview
+#endif
 					if (instance) {
-						// TODO: Find a better method
-						// This fix works if the timer on the scene is an immediate child 
-						// (it breaks on nested timers).
-						// I tried to use something like "instance->get_tree()->set_pause(true)"
-						// to pause updates on the whole scene tree, but Godot crashes, so I need to investigate.
 						for (int j = 0; j < instance->get_child_count(); j++) {
 							Node *curr_child = instance->get_child(j);
 							if (curr_child->get_class() == "Timer") {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6037,18 +6037,11 @@ void CanvasItemEditorViewport::_create_preview(const Vector<String> &files) cons
 			} else {
 				if (scene.is_valid()) {
 					Node *instance = scene->instance();
-#ifndef _MSC_VER
-#warning TODO find a better method for pausing preview
-#endif
 					if (instance) {
-						
-						for (int j = 0; j < instance->get_child_count(); j++) {
-							Timer *timer = Object::cast_to<Timer>(instance->get_child(j));
-							if (timer) {
-								timer->stop();
-							}
-						}
 						preview_node->add_child(instance);
+						preview_node->set_pause_mode(PAUSE_MODE_STOP);
+						// make sure only the preview node stops
+						editor->set_pause_mode(PAUSE_MODE_PROCESS);
 					}
 				}
 			}
@@ -6058,6 +6051,7 @@ void CanvasItemEditorViewport::_create_preview(const Vector<String> &files) cons
 
 	if (add_preview) {
 		editor->get_scene_root()->add_child(preview_node);
+		preview_node->get_tree()->set_pause(true);
 	}
 }
 


### PR DESCRIPTION
This PR closes #39221.

~~As a hacky work-around, we iterate through all first-level children of the scene's root and call `stop()` on the ones that are Timers.~~

~~This approach is bad, and I'm currently thinking of using the pause function of the scene tree, but for some reason Godot crashes when toggling pause, which I'll need to investigate.~~

New approach is to pause the subtree which starts with the node containing the preview, instead of iterating through all of its children. This ensures that the preview stays frozen regardless of the existence of second-level timers (unless the child nodes are set to `Process` pause mode) and is cleaner than the old one, IMO.

(This is not a duplicate PR, the old one was not based on the `master` branch due to an oversight of mine)

EDIT: Waiting for the `OS/DisplayServer` split to be completed ~~(or at least previews working again on master)~~
Previews are working again, so this is ready for review.