### PR TITLE
Clarify usage of AnimationPlayer with AnimationTree and fill empty doc descriptions

### DIFF
--- a/doc/classes/AnimationTree.xml
+++ b/doc/classes/AnimationTree.xml
@@ -4,6 +4,7 @@
 		A node to be used for advanced animation transitions in an [AnimationPlayer].
 	</brief_description>
 	<description>
+		Note: When linked with an [AnimationPlayer], several properties and methods of the corresponding [AnimationPlayer] will not function as expected. Playback and transitions should be handled using only the [AnimationTree] and its constituent [AnimationNode](s). The [AnimationPlayer] node should be used solely for adding, deleting, and editing animations.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html</link>
@@ -23,6 +24,7 @@
 			<return type="Transform">
 			</return>
 			<description>
+				Retrieve the motion of the [member root_motion_track] as a [Transform] that can be used elsewhere. If [member root_motion_track] is not a path to a track of type [constant Animation.TYPE_TRANSFORM], returns an identity transformation.
 			</description>
 		</method>
 		<method name="rename_parameter">
@@ -47,6 +49,8 @@
 			The process mode of this [AnimationTree]. See [enum AnimationProcessMode] for available modes.
 		</member>
 		<member name="root_motion_track" type="NodePath" setter="set_root_motion_track" getter="get_root_motion_track" default="NodePath(&quot;&quot;)">
+			The path to the Animation track used for root motion. Paths must be valid scene-tree paths to a node, and must be specified starting from the parent node of the node that will reproduce the animation. To specify a track that controls properties or bones, append its name after the path, separated by [code]":"[/code]. For example, [code]"character/skeleton:ankle"[/code] or [code]"character/mesh:transform/local"[/code].
+			If the track has type [constant Animation.TYPE_TRANSFORM], the transformation will be cancelled visually, and the animation will appear to stay in place.
 		</member>
 		<member name="tree_root" type="AnimationNode" setter="set_tree_root" getter="get_tree_root">
 			The root animation node of this [AnimationTree]. See [AnimationNode].


### PR DESCRIPTION
Updated class documentation for `AnimationTree`:

1. Added missing descriptions for `root_motion_track` and `get_root_motion_transform()`

2. Clarified usage of `AnimationPlayer` when paired with an `AnimationTree`. The behavior is described in more detail in godotengine/godot-docs#3610. Essentially, when an `AnimationPlayer` object is paired with an `AnimationTree`, several properties and methods exposed by the `AnimationPlayer` class will not work as expected. Some of these include:

```
current_animation
assigned_animation
current_animation_position
current_animation_length
playback_default_blend_time
playback_active
playback_speed
```

as well as their associated setters and getters, and a couple of other methods. This occurs because an `AnimationTree` uses its `AnimationPlayer* player` primarily for its `Map<StringName, AnimationData> animation_set`. 

`AnimationTree::_process_graph()` calls `AnimationTree::_update_caches()` to get the `animation_set` from the `player` and  populate its `track_cache`, instead of calling `AnimationPlayer::play()` directly. Hence, most of the properties of the `AnimationPlayer` will not be updated.

https://github.com/godotengine/godot/blob/d2be503ebb79b168782c1fb97136ac86016cec6d/scene/animation/animation_tree.cpp#L526-L537

As suggested by @Calinou in #34947, it would be good to mention this behavior in the `AnimationTree`'s class documentation.

This closes #38956, closes #34947 and closes godotengine/godot-docs#3610