### PR TITLE
[3.2] Fix macOS global menu removal and preserve order.

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -170,6 +170,7 @@ public:
 	};
 
 	Map<String, Vector<GlobalMenuItem> > global_menus;
+	List<String> global_menus_order;
 
 	void _update_global_menu();
 


### PR DESCRIPTION
Fixes removing old menus and menu order.

Fixes #39241, irrelevant for the master since global menu implementation was changed during OS/DS split.