### PR TITLE
GLES2 batching - Add UV precision adjustment for tilemaps

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1003,6 +1003,14 @@
 		<member name="rendering/batching/parameters/max_join_item_commands" type="int" setter="" getter="" default="16">
 			Sets the number of commands to lookahead to determine whether to batch render items. A value of 1 can join items consisting of single commands, 0 turns off joining. Higher values are in theory more likely to join, however this has diminishing returns and has a runtime cost so a small value is recommended.
 		</member>
+		<member name="rendering/batching/precision/uv_contract" type="bool" setter="" getter="" default="false">
+			On some platforms (especially mobile), precision issues in shaders can lead to reading 1 texel outside of bounds, particularly where rects are scaled. This can particularly lead to border artifacts around tiles in tilemaps.
+			This adjustment corrects for this by making a small contraction to the UV coordinates used. Note that this can result in a slight squashing of border texels.
+		</member>
+		<member name="rendering/batching/precision/uv_contract_amount" type="int" setter="" getter="" default="100">
+			The amount of UV contraction. This figure is divided by 1000000, and is a proportion of the total texture dimensions, where the width and height are both ranged from 0.0 to 1.0.
+			Use the default unless correcting for a problem on particular hardware.
+		</member>
 		<member name="rendering/environment/default_clear_color" type="Color" setter="" getter="" default="Color( 0.3, 0.3, 0.3, 1 )">
 			Default background clear color. Overridable per [Viewport] using its [Environment]. See [member Environment.background_mode] and [member Environment.background_color] in particular. To change this default color programmatically, use [method VisualServer.set_default_clear_color].
 		</member>
@@ -1042,6 +1050,7 @@
 		</member>
 		<member name="rendering/quality/2d/use_pixel_snap" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], forces snapping of polygons to pixels in 2D rendering. May help in some pixel art styles.
+			Consider using the project setting [member rendering/batching/precision/uv_contract] to prevent artifacts.
 		</member>
 		<member name="rendering/quality/depth/hdr" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], allocates the main framebuffer with high dynamic range. High dynamic range allows the use of [Color] values greater than 1.

--- a/drivers/gles2/rasterizer_canvas_gles2.h
+++ b/drivers/gles2/rasterizer_canvas_gles2.h
@@ -113,6 +113,7 @@ class RasterizerCanvasGLES2 : public RasterizerCanvasBaseGLES2 {
 		RID RID_normal;
 		TileMode tile_mode;
 		BatchVector2 tex_pixel_size;
+		uint32_t flags;
 	};
 
 	// items in a list to be sorted prior to joining
@@ -237,6 +238,10 @@ class RasterizerCanvasGLES2 : public RasterizerCanvasBaseGLES2 {
 		bool settings_use_single_rect_fallback;
 		int settings_light_max_join_items;
 
+		// uv contraction
+		bool settings_uv_contract;
+		float settings_uv_contract_amount;
+
 		// only done on diagnose frame
 		void reset_stats() {
 			stats_items_sorted = 0;
@@ -278,10 +283,12 @@ class RasterizerCanvasGLES2 : public RasterizerCanvasBaseGLES2 {
 			curr_batch = 0;
 			batch_tex_id = -1;
 			texpixel_size = Vector2(1, 1);
+			contract_uvs = false;
 		}
 		Batch *curr_batch;
 		int batch_tex_id;
 		bool use_hardware_transform;
+		bool contract_uvs;
 		Vector2 texpixel_size;
 		Color final_modulate;
 		TransformMode transform_mode;

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2432,6 +2432,8 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/batching/debug/flash_batching", false);
 	GLOBAL_DEF("rendering/batching/debug/diagnose_frame", false);
 	GLOBAL_DEF("rendering/gles2/compatibility/disable_half_float", false);
+	GLOBAL_DEF("rendering/batching/precision/uv_contract", false);
+	GLOBAL_DEF("rendering/batching/precision/uv_contract_amount", 100);
 
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/batching/parameters/max_join_item_commands", PropertyInfo(Variant::INT, "rendering/batching/parameters/max_join_item_commands", PROPERTY_HINT_RANGE, "0,65535"));
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/batching/parameters/colored_vertex_format_threshold", PropertyInfo(Variant::REAL, "rendering/batching/parameters/colored_vertex_format_threshold", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"));
@@ -2439,6 +2441,7 @@ VisualServer::VisualServer() {
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/batching/lights/scissor_area_threshold", PropertyInfo(Variant::REAL, "rendering/batching/lights/scissor_area_threshold", PROPERTY_HINT_RANGE, "0.0,1.0"));
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/batching/lights/max_join_items", PropertyInfo(Variant::INT, "rendering/batching/lights/max_join_items", PROPERTY_HINT_RANGE, "0,512"));
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/batching/parameters/item_reordering_lookahead", PropertyInfo(Variant::INT, "rendering/batching/parameters/item_reordering_lookahead", PROPERTY_HINT_RANGE, "0,256"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/batching/precision/uv_contract_amount", PropertyInfo(Variant::INT, "rendering/batching/precision/uv_contract_amount", PROPERTY_HINT_RANGE, "0,10000"));
 }
 
 VisualServer::~VisualServer() {


### PR DESCRIPTION
Scaling tilemaps can cause border artifacts around the edges of tiles. This has been traced to precision issues in the GPU. This PR adds an adjustment to allow a minor contraction of the UVs of rects in order to compensate for the incorrect classification of texels across the UV border.

Fixes #39096.

### Notes
* See the issue for a detailed description of the problem and approaches to solving it
* This problem seems less likely to occur using the old uniform draw method. However it still exists - border artifacts occur when pixel_snap is off even with uniform draw. Also there are reports of this occurring pre-batching.
* This problem is very clear with either the nvidia_workaround, or the batching draw methods, which are standard drawing methods passing regular vertices.
* Other engines may deal with this problem by adding a single pixel border around tiles on tilemaps. While it may be worth adding this capability, we can't rely on this for backward compatibility reasons.
* The contraction may lead to a corresponding decrease in the size of the edge texels at high magnifications. This is undesirable, but may be a cost of dealing with this problem.
* There is a setting to enable / disable the feature. I did consider only having it on with pixel_snap, however the problem occurs with pixel_snap off as well so it could benefit from independent control.
* The offset is applied only when using unfiltered textures (i.e. GL_NEAREST)
* I have used the new 'batching' common project setting, in accordance with #39068 (moving common batching settings into a batching folder, rather than gles2) - these adjustments will also be needed in GLES3.

### Defaults
After further thought I decided to add a separate on / off setting and amount setting, and the default is off. There could be an argument for having it on as default - I'll leave this to the reviewers.

### Padded tilemaps
I am also investigating adding the ability to Godot to automatically create and use padded tilemaps from unpadded source tilemaps. Although this may add one more (possibly automatic) step to the tilemap creation process, it may be the only way to solve the texel precision problem in an efficient manner with no squashing of edge pixels. However it will not be backward compatible, and would have to be applied to all atlased artwork (including animated sprites), so the technique in this PR would probably still be needed.