### PR TITLE
Fix docs generation for Vector2i/Vector3i/Rect2i

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1296,10 +1296,16 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 			// math types
 			case VECTOR2:
 				return Vector2();
+			case VECTOR2I:
+				return Vector2i();
 			case RECT2:
 				return Rect2();
+			case RECT2I:
+				return Rect2i();
 			case VECTOR3:
 				return Vector3();
+			case VECTOR3I:
+				return Vector3i();
 			case TRANSFORM2D:
 				return Transform2D();
 			case PLANE:

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -46,7 +46,129 @@
 				Constructs a new [Rect2i] from [Rect2]. The floating point coordinates will be truncated.
 			</description>
 		</method>
+		<method name="abs">
+			<return type="Rect2i">
+			</return>
+			<description>
+				Returns a [Rect2i] with equivalent position and area, modified so that the top-left corner is the origin and [code]width[/code] and [code]height[/code] are positive.
+			</description>
+		</method>
+		<method name="clip">
+			<return type="Rect2i">
+			</return>
+			<argument index="0" name="b" type="Rect2i">
+			</argument>
+			<description>
+				Returns the intersection of this [Rect2i] and b.
+			</description>
+		</method>
+		<method name="encloses">
+			<return type="bool">
+			</return>
+			<argument index="0" name="b" type="Rect2i">
+			</argument>
+			<description>
+				Returns [code]true[/code] if this [Rect2i] completely encloses another one.
+			</description>
+		</method>
+		<method name="expand">
+			<return type="Rect2i">
+			</return>
+			<argument index="0" name="to" type="Vector2i">
+			</argument>
+			<description>
+				Returns this [Rect2i] expanded to include a given point.
+			</description>
+		</method>
+		<method name="get_area">
+			<return type="int">
+			</return>
+			<description>
+				Returns the area of the [Rect2i].
+			</description>
+		</method>
+		<method name="grow">
+			<return type="Rect2i">
+			</return>
+			<argument index="0" name="by" type="int">
+			</argument>
+			<description>
+				Returns a copy of the [Rect2i] grown a given amount of units towards all the sides.
+			</description>
+		</method>
+		<method name="grow_individual">
+			<return type="Rect2i">
+			</return>
+			<argument index="0" name="left" type="int">
+			</argument>
+			<argument index="1" name="top" type="int">
+			</argument>
+			<argument index="2" name="right" type="int">
+			</argument>
+			<argument index="3" name=" bottom" type="int">
+			</argument>
+			<description>
+				Returns a copy of the [Rect2i] grown a given amount of units towards each direction individually.
+			</description>
+		</method>
+		<method name="grow_margin">
+			<return type="Rect2i">
+			</return>
+			<argument index="0" name="margin" type="int">
+			</argument>
+			<argument index="1" name="by" type="int">
+			</argument>
+			<description>
+				Returns a copy of the [Rect2i] grown a given amount of units towards the [enum Margin] direction.
+			</description>
+		</method>
+		<method name="has_no_area">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if the [Rect2i] is flat or empty.
+			</description>
+		</method>
+		<method name="has_point">
+			<return type="bool">
+			</return>
+			<argument index="0" name="point" type="Vector2i">
+			</argument>
+			<description>
+				Returns [code]true[/code] if the [Rect2i] contains a point.
+			</description>
+		</method>
+		<method name="intersects">
+			<return type="bool">
+			</return>
+			<argument index="0" name="b" type="Rect2i">
+			</argument>
+			<description>
+				Returns [code]true[/code] if the [Rect2i] overlaps with [code]b[/code] (i.e. they have at least one point in common).
+				If [code]include_borders[/code] is [code]true[/code], they will also be considered overlapping if their borders touch, even without intersection.
+			</description>
+		</method>
+		<method name="merge">
+			<return type="Rect2i">
+			</return>
+			<argument index="0" name="b" type="Rect2i">
+			</argument>
+			<description>
+				Returns a larger [Rect2i] that contains this [Rect2i] and [code]b[/code].
+			</description>
+		</method>
 	</methods>
+	<members>
+		<member name="end" type="Vector2i" setter="" getter="" default="Vector2i( 0, 0 )">
+			Ending corner.
+		</member>
+		<member name="position" type="Vector2i" setter="" getter="" default="Vector2i( 0, 0 )">
+			Position (starting corner).
+		</member>
+		<member name="size" type="Vector2i" setter="" getter="" default="Vector2i( 0, 0 )">
+			Size from position to end.
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -31,7 +31,36 @@
 				Constructs a new [Vector2i] from [Vector2]. The floating point coordinates will be truncated.
 			</description>
 		</method>
+		<method name="abs">
+			<return type="Vector2i">
+			</return>
+			<description>
+				Returns a new vector with all components in absolute values (i.e. positive).
+			</description>
+		</method>
+		<method name="aspect">
+			<return type="float">
+			</return>
+			<description>
+				Returns the ratio of [member x] to [member y].
+			</description>
+		</method>
+		<method name="sign">
+			<return type="Vector2i">
+			</return>
+			<description>
+				Returns the vector with each component set to one or negative one, depending on the signs of the components.
+			</description>
+		</method>
 	</methods>
+	<members>
+		<member name="x" type="int" setter="" getter="" default="0">
+			The vector's X component. Also accessible by using the index position [code][0][/code].
+		</member>
+		<member name="y" type="int" setter="" getter="" default="0">
+			The vector's Y component. Also accessible by using the index position [code][1][/code].
+		</member>
+	</members>
 	<constants>
 		<constant name="AXIS_X" value="0">
 			Enumerated value for the X axis.

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -33,7 +33,39 @@
 				Constructs a new [Vector3i] from [Vector3]. The floating point coordinates will be truncated.
 			</description>
 		</method>
+		<method name="max_axis">
+			<return type="int">
+			</return>
+			<description>
+				Returns the axis of the vector's largest value. See [code]AXIS_*[/code] constants.
+			</description>
+		</method>
+		<method name="min_axis">
+			<return type="int">
+			</return>
+			<description>
+				Returns the axis of the vector's smallest value. See [code]AXIS_*[/code] constants.
+			</description>
+		</method>
+		<method name="sign">
+			<return type="Vector3i">
+			</return>
+			<description>
+				Returns the vector with each component set to one or negative one, depending on the signs of the components.
+			</description>
+		</method>
 	</methods>
+	<members>
+		<member name="x" type="int" setter="" getter="" default="0">
+			The vector's X component. Also accessible by using the index position [code][0][/code].
+		</member>
+		<member name="y" type="int" setter="" getter="" default="0">
+			The vector's Y component. Also accessible by using the index position [code][1][/code].
+		</member>
+		<member name="z" type="int" setter="" getter="" default="0">
+			The vector's Z component. Also accessible by using the index position [code][2][/code].
+		</member>
+	</members>
 	<constants>
 		<constant name="AXIS_X" value="0">
 			Enumerated value for the X axis.


### PR DESCRIPTION
Added rest of the docs for these classes and enabled the generation of them in code + its also fixed usage of empty constructions like:

> 	var v = Vector2i()
> 	print(v[0])
