### PR TITLE
[3.2] Fix `is` operation fail on get_script()

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -7003,7 +7003,11 @@ bool GDScriptParser::_get_function_signature(DataType &p_base_type, const String
 	}
 
 	r_default_arg_count = method->get_default_argument_count();
-	r_return_type = _type_from_property(method->get_return_info(), false);
+	if (method->get_name() == "get_script") {
+		r_return_type = DataType(); // Variant for now and let runtime decide.
+	} else {
+		r_return_type = _type_from_property(method->get_return_info(), false);
+	}
 	r_vararg = method->is_vararg();
 
 	for (int i = 0; i < method->get_argument_count(); i++) {


### PR DESCRIPTION
Fix: #39244

```gdscript
func _ready():
    var unresolved_type_var = $Control.get_script()
    print($Control is unresolved_type_var) ## this works fine
```

the above code is working fine on all including previous versions, since the type of `unresolved_type_var` is unresolved at compile time but a script at runtime. and also current master also working fine because get_script() return type is Variant. and this fix works the same. `get_script` return type will remain variant.

![get_script](https://user-images.githubusercontent.com/41085900/83657550-9c30fb80-a5de-11ea-8e96-53160811cbad.JPG)
