### PR TITLE
Implement log message filters

### DIFF
--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -63,6 +63,7 @@ class EditorLog : public VBoxContainer {
 	//void _dragged(const Point2& p_ofs);
 	void _clear_request();
 	void _copy_request();
+	void _set_filter_icons();
 	static void _undo_redo_cbk(void *p_self, const String &p_name);
 
 protected:
@@ -85,6 +86,41 @@ public:
 	void copy();
 	EditorLog();
 	~EditorLog();
+
+private:
+	// A filter for log messages. If active, then
+	// the filter disallows a certain MessageType
+	// from being displayed.
+	struct LogFilter : public Object {
+		GDCLASS(LogFilter, Object);
+
+	public:
+		bool active;
+		// The button that controls this filter.
+		// If the button is flat, it means the filter
+		// is on, and so no messages of a given type
+		// will get through.
+		Button *button;
+
+		void on_click() {
+			active = !active;
+			button->set_flat(active);
+		}
+
+		LogFilter() :
+				active(false),
+				button(memnew(Button)) {}
+		~LogFilter() {
+		}
+	};
+
+	// The filters for the four message types in the log.
+	// Each filter either blocks or allows messages of their
+	// respective types.
+	LogFilter error_filter;
+	LogFilter warning_filter;
+	LogFilter std_filter;
+	LogFilter editor_filter;
 };
 
 #endif // EDITOR_LOG_H


### PR DESCRIPTION
I implemented log message filtering as described in godotengine/godot-proposals#971. This allows the user to select from the editor whether or not to show error, warning, std, and editor log messages. An example of the new interface can be seen here.

![filter1](https://user-images.githubusercontent.com/35509264/83712776-59b9ef80-a5db-11ea-86c5-fcd6c6fbe32a.png)

[Here](https://github.com/godotengine/godot/files/4727381/filterex.zip) is an example project that you can play around with to see how log message filtering works. Here is a GIF as an example:

![filter](https://user-images.githubusercontent.com/35509264/83712890-a0a7e500-a5db-11ea-8d75-6d8b1e10321a.gif)

I added buttons to control message filtering just to the left of the `clear` and `copy` buttons, as can be seen in the pictures. The names and icons for the buttons can be changed to fit whatever consensus is reached. I have tested and confirmed the functionality of all the log filters except for the `warning` filter. If anyone has a suggestion on how to consistently produce warnings, I could then double-check that warnings are also suppressed. 

I am open to any suggestions for revisions/improvements of the current system. Please let me know what you think.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/971.*