### PR TITLE
Added predefined var check for `for` loop counter

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3179,6 +3179,15 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 				IdentifierNode *id = alloc_node<IdentifierNode>();
 				id->name = tokenizer->get_token_identifier();
 
+				BlockNode *check_block = p_block;
+				while (check_block) {
+					if (check_block->variables.has(id->name)) {
+						_set_error("Variable \"" + String(id->name) + "\" already defined in the scope (at line " + itos(check_block->variables[id->name]->line) + ").");
+						return;
+					}
+					check_block = check_block->parent_block;
+				}
+
 				tokenizer->advance();
 
 				if (tokenizer->get_token() != GDScriptTokenizer::TK_OP_IN) {


### PR DESCRIPTION
GDScript doesn't allow shadowing variables in nested scope, only allows to shadow class vars.

![for-conunter-predefined-check](https://user-images.githubusercontent.com/41085900/83717262-f1f1bc00-a64f-11ea-8c68-01b31d3d7b22.JPG)
