### PR TITLE
Fix theme changing for already opened editor docs

### DIFF
--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -182,7 +182,10 @@ public:
 
 	String get_class();
 
-	void set_focused() { class_desc->grab_focus(); }
+	void set_focused() {
+		notification(Control::NOTIFICATION_THEME_CHANGED);
+		class_desc->grab_focus();
+	}
 
 	int get_scroll() const;
 	void set_scroll(int p_scroll);


### PR DESCRIPTION
Fixed the following bug: ![bug](https://user-images.githubusercontent.com/3036176/83730278-8577bc80-a651-11ea-8060-4ad5c917f377.gif)
