### PR TITLE
Check if the specified Android release keystore exists

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -1786,6 +1786,13 @@ public:
 			}
 		}
 
+		String rk = p_preset->get("keystore/release");
+
+		if (!rk.empty() && !FileAccess::exists(rk)) {
+			valid = false;
+			err += TTR("Release keystore incorrectly configured in the export preset.") + "\n";
+		}
+
 		if (bool(p_preset->get("custom_template/use_custom_build"))) {
 			String sdk_path = EditorSettings::get_singleton()->get("export/android/custom_build_sdk_path");
 			if (sdk_path == "") {


### PR DESCRIPTION
Fixes #34800.

I basically did the same thing as here: #36015 and added an error message.
@Anukriti12 if you want to update/reopen your original PR i can close this one again.