### PR TITLE
Fix CanvasModulate not updating modulate color when changing scenes

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -583,6 +583,19 @@
 				Modulates all colors in the given canvas.
 			</description>
 		</method>
+		<method name="canvas_set_modulate_if_equal">
+			<return type="void">
+			</return>
+			<argument index="0" name="canvas" type="RID">
+			</argument>
+			<argument index="1" name="old_color" type="Color">
+			</argument>
+			<argument index="2" name="color" type="Color">
+			</argument>
+			<description>
+				Sets canvas's modulating color to [code]color[/code], if the existing modulating color equals [code]old_color[/code].
+			</description>
+		</method>
 		<method name="directional_light_create">
 			<return type="RID">
 			</return>

--- a/scene/2d/canvas_modulate.cpp
+++ b/scene/2d/canvas_modulate.cpp
@@ -39,7 +39,8 @@ void CanvasModulate::_notification(int p_what) {
 
 	} else if (p_what == NOTIFICATION_EXIT_CANVAS) {
 		if (is_visible_in_tree()) {
-			RS::get_singleton()->canvas_set_modulate(get_canvas(), Color(1, 1, 1, 1));
+			// Reset color to default only if no other node has changed canvas's modulation color
+			RS::get_singleton()->canvas_set_modulate_if_equal(get_canvas(), color, Color(1, 1, 1, 1));
 			remove_from_group("_canvas_modulate_" + itos(get_canvas().get_id()));
 		}
 	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {

--- a/servers/rendering/rendering_server_canvas.cpp
+++ b/servers/rendering/rendering_server_canvas.cpp
@@ -314,6 +314,14 @@ void RenderingServerCanvas::canvas_set_modulate(RID p_canvas, const Color &p_col
 	canvas->modulate = p_color;
 }
 
+void RenderingServerCanvas::canvas_set_modulate_if_equal(RID p_canvas, const Color &old_color, const Color &p_color) {
+	Canvas *canvas = canvas_owner.getornull(p_canvas);
+	ERR_FAIL_COND(!canvas);
+	if (canvas->modulate == old_color) {
+		canvas->modulate = p_color;
+	}
+}
+
 void RenderingServerCanvas::canvas_set_disable_scale(bool p_disable) {
 	disable_scale = p_disable;
 }

--- a/servers/rendering/rendering_server_canvas.h
+++ b/servers/rendering/rendering_server_canvas.h
@@ -169,6 +169,7 @@ public:
 	RID canvas_create();
 	void canvas_set_item_mirroring(RID p_canvas, RID p_item, const Point2 &p_mirroring);
 	void canvas_set_modulate(RID p_canvas, const Color &p_color);
+	void canvas_set_modulate_if_equal(RID p_canvas, const Color &old_color, const Color &p_color);
 	void canvas_set_parent(RID p_canvas, RID p_parent, float p_scale);
 	void canvas_set_disable_scale(bool p_disable);
 

--- a/servers/rendering/rendering_server_raster.h
+++ b/servers/rendering/rendering_server_raster.h
@@ -643,6 +643,7 @@ public:
 	BIND0R(RID, canvas_create)
 	BIND3(canvas_set_item_mirroring, RID, RID, const Point2 &)
 	BIND2(canvas_set_modulate, RID, const Color &)
+	BIND3(canvas_set_modulate_if_equal, RID, const Color &, const Color &)
 	BIND3(canvas_set_parent, RID, RID, float)
 	BIND1(canvas_set_disable_scale, bool)
 

--- a/servers/rendering/rendering_server_wrap_mt.h
+++ b/servers/rendering/rendering_server_wrap_mt.h
@@ -546,6 +546,7 @@ public:
 	FUNCRID(canvas)
 	FUNC3(canvas_set_item_mirroring, RID, RID, const Point2 &)
 	FUNC2(canvas_set_modulate, RID, const Color &)
+	FUNC3(canvas_set_modulate_if_equal, RID, const Color &, const Color &)
 	FUNC3(canvas_set_parent, RID, RID, float)
 	FUNC1(canvas_set_disable_scale, bool)
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1788,6 +1788,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_create"), &RenderingServer::canvas_create);
 	ClassDB::bind_method(D_METHOD("canvas_set_item_mirroring", "canvas", "item", "mirroring"), &RenderingServer::canvas_set_item_mirroring);
 	ClassDB::bind_method(D_METHOD("canvas_set_modulate", "canvas", "color"), &RenderingServer::canvas_set_modulate);
+	ClassDB::bind_method(D_METHOD("canvas_set_modulate_if_equal", "canvas", "old_color", "color"), &RenderingServer::canvas_set_modulate_if_equal);
 #ifndef _MSC_VER
 #warning TODO method bindings need to be fixed
 #endif

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -966,6 +966,7 @@ public:
 	virtual RID canvas_create() = 0;
 	virtual void canvas_set_item_mirroring(RID p_canvas, RID p_item, const Point2 &p_mirroring) = 0;
 	virtual void canvas_set_modulate(RID p_canvas, const Color &p_color) = 0;
+	virtual void canvas_set_modulate_if_equal(RID p_canvas, const Color &old_color, const Color &p_color) = 0;
 	virtual void canvas_set_parent(RID p_canvas, RID p_parent, float p_scale) = 0;
 
 	virtual void canvas_set_disable_scale(bool p_disable) = 0;


### PR DESCRIPTION
When a `CanvasModulate` node is freed using `queue_free()` and a new `CanvasModulate` 
node is added, the new color is not visible. This occurs because the old node receives its
`NOTIFICATION_EXIT_CANVAS` after the new `CanvasModulate` node sets its own color. 
The old node overrides this new color and sets it to the default instead.

To fix, `CanvasModulate` now resets the canvas's modulate color to the default when it receives
`NOTIFICATION_EXIT_CANVAS` only if the canvas's modulate color is the same as node's color field, i.e. the color that was set by the node.

Before and after:
![canvasModulateOrig](https://user-images.githubusercontent.com/22248849/83756994-66554b00-a6a2-11ea-9f0c-aa7575a85de0.gif)

![ezgif com-gif-maker](https://user-images.githubusercontent.com/22248849/83753055-29865580-a69c-11ea-98e4-cc04182485d8.gif)

[bug_test.zip](https://github.com/godotengine/godot/files/4729918/bug_test.zip)

(Note: The PR involves adding a new function to the Rendering Server API to use for this specific case. Perhaps there is a better way to fix this issue.)

Closes #39182

Edit: Force pushed to correct formatting checks. Can also make a separate PR for 3.2, if it seems to be okay.