### PR TITLE
Enable text selection in the execute output of EditorNode

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6568,6 +6568,7 @@ EditorNode::EditorNode() {
 	gui_base->add_child(load_error_dialog);
 
 	execute_outputs = memnew(RichTextLabel);
+	execute_outputs->set_selection_enabled(true);
 	execute_output_dialog = memnew(AcceptDialog);
 	execute_output_dialog->add_child(execute_outputs);
 	execute_output_dialog->set_title("");


### PR DESCRIPTION
While reporting an error in the Android build process (#38986) i had to take a screenshot of the error because i couldn't copy the error message. 

This PR enables text selection in the output label, which also makes it easier to google for specific error messages or search Github issues in case you encounter one.