### PR TITLE
Add "shader_param/" prefix in Shader::has_param()

### DIFF
--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -125,7 +125,7 @@ bool Shader::is_text_shader() const {
 }
 
 bool Shader::has_param(const StringName &p_param) const {
-	return params_cache.has(p_param);
+	return params_cache.has("shader_param/" + p_param);
 }
 
 void Shader::_update_shader() const {


### PR DESCRIPTION
Fixes #39288 

When the param list is created the "shader_param/" prefix is added to the uniform name and then used as key for the cache: https://github.com/godotengine/godot/blob/57d21ebeda8460036efac1f70cd9ecd0896de517/scene/resources/shader.cpp#L74-L89

So has_param() always returned false. This PR just adds the same prefix before checking if it's in the cache.

Edit: The prefix will also be added at the same location in 3.2 btw.