### PR TITLE
Correct misspellings of damped spring.

### DIFF
--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -864,28 +864,28 @@
 				Creates a damped spring joint between two bodies. If not specified, the second body is assumed to be the joint itself.
 			</description>
 		</method>
-		<method name="damped_string_joint_get_param" qualifiers="const">
+		<method name="damped_spring_joint_get_param" qualifiers="const">
 			<return type="float">
 			</return>
 			<argument index="0" name="joint" type="RID">
 			</argument>
-			<argument index="1" name="param" type="int" enum="PhysicsServer2D.DampedStringParam">
+			<argument index="1" name="param" type="int" enum="PhysicsServer2D.DampedSpringParam">
 			</argument>
 			<description>
-				Returns the value of a damped spring joint parameter.
+				Returns the value of a damped spring joint parameter. See [enum DampedSpringParam] for a list of available parameters.
 			</description>
 		</method>
-		<method name="damped_string_joint_set_param">
+		<method name="damped_spring_joint_set_param">
 			<return type="void">
 			</return>
 			<argument index="0" name="joint" type="RID">
 			</argument>
-			<argument index="1" name="param" type="int" enum="PhysicsServer2D.DampedStringParam">
+			<argument index="1" name="param" type="int" enum="PhysicsServer2D.DampedSpringParam">
 			</argument>
 			<argument index="2" name="value" type="float">
 			</argument>
 			<description>
-				Sets a damped spring joint parameter. See [enum DampedStringParam] for a list of available parameters.
+				Sets a damped spring joint parameter. See [enum DampedSpringParam] for a list of available parameters.
 			</description>
 		</method>
 		<method name="free_rid">
@@ -1247,13 +1247,13 @@
 		</constant>
 		<constant name="JOINT_PARAM_MAX_FORCE" value="2" enum="JointParam">
 		</constant>
-		<constant name="DAMPED_STRING_REST_LENGTH" value="0" enum="DampedStringParam">
+		<constant name="DAMPED_SPRING_REST_LENGTH" value="0" enum="DampedSpringParam">
 			Sets the resting length of the spring joint. The joint will always try to go to back this length when pulled apart.
 		</constant>
-		<constant name="DAMPED_STRING_STIFFNESS" value="1" enum="DampedStringParam">
+		<constant name="DAMPED_SPRING_STIFFNESS" value="1" enum="DampedSpringParam">
 			Sets the stiffness of the spring joint. The joint applies a force equal to the stiffness times the distance from its resting length.
 		</constant>
-		<constant name="DAMPED_STRING_DAMPING" value="2" enum="DampedStringParam">
+		<constant name="DAMPED_SPRING_DAMPING" value="2" enum="DampedSpringParam">
 			Sets the damping ratio of the spring joint. A value of 0 indicates an undamped spring, while 1 causes the system to reach equilibrium as fast as possible (critical damping).
 		</constant>
 		<constant name="CCD_MODE_DISABLED" value="0" enum="CCDMode">

--- a/doc/translations/classes.pot
+++ b/doc/translations/classes.pot
@@ -35842,7 +35842,7 @@ msgstr ""
 
 #: doc/classes/PhysicsServer2D.xml:888
 msgid ""
-"Sets a damped spring joint parameter. See [enum DampedStringParam] for a "
+"Sets a damped spring joint parameter. See [enum DampedSpringParam] for a "
 "list of available parameters."
 msgstr ""
 

--- a/doc/translations/fr.po
+++ b/doc/translations/fr.po
@@ -35852,7 +35852,7 @@ msgstr ""
 
 #: doc/classes/PhysicsServer2D.xml:888
 msgid ""
-"Sets a damped spring joint parameter. See [enum DampedStringParam] for a "
+"Sets a damped spring joint parameter. See [enum DampedSpringParam] for a "
 "list of available parameters."
 msgstr ""
 

--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -309,10 +309,10 @@ RID DampedSpringJoint2D::_configure_joint(PhysicsBody2D *body_a, PhysicsBody2D *
 
 	RID dsj = PhysicsServer2D::get_singleton()->damped_spring_joint_create(anchor_A, anchor_B, body_a->get_rid(), body_b->get_rid());
 	if (rest_length) {
-		PhysicsServer2D::get_singleton()->damped_string_joint_set_param(dsj, PhysicsServer2D::DAMPED_STRING_REST_LENGTH, rest_length);
+		PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(dsj, PhysicsServer2D::DAMPED_SPRING_REST_LENGTH, rest_length);
 	}
-	PhysicsServer2D::get_singleton()->damped_string_joint_set_param(dsj, PhysicsServer2D::DAMPED_STRING_STIFFNESS, stiffness);
-	PhysicsServer2D::get_singleton()->damped_string_joint_set_param(dsj, PhysicsServer2D::DAMPED_STRING_DAMPING, damping);
+	PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(dsj, PhysicsServer2D::DAMPED_SPRING_STIFFNESS, stiffness);
+	PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(dsj, PhysicsServer2D::DAMPED_SPRING_DAMPING, damping);
 
 	return dsj;
 }
@@ -330,7 +330,7 @@ void DampedSpringJoint2D::set_rest_length(real_t p_rest_length) {
 	rest_length = p_rest_length;
 	update();
 	if (get_joint().is_valid()) {
-		PhysicsServer2D::get_singleton()->damped_string_joint_set_param(get_joint(), PhysicsServer2D::DAMPED_STRING_REST_LENGTH, p_rest_length ? p_rest_length : length);
+		PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(get_joint(), PhysicsServer2D::DAMPED_SPRING_REST_LENGTH, p_rest_length ? p_rest_length : length);
 	}
 }
 
@@ -342,7 +342,7 @@ void DampedSpringJoint2D::set_stiffness(real_t p_stiffness) {
 	stiffness = p_stiffness;
 	update();
 	if (get_joint().is_valid()) {
-		PhysicsServer2D::get_singleton()->damped_string_joint_set_param(get_joint(), PhysicsServer2D::DAMPED_STRING_STIFFNESS, p_stiffness);
+		PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(get_joint(), PhysicsServer2D::DAMPED_SPRING_STIFFNESS, p_stiffness);
 	}
 }
 
@@ -354,7 +354,7 @@ void DampedSpringJoint2D::set_damping(real_t p_damping) {
 	damping = p_damping;
 	update();
 	if (get_joint().is_valid()) {
-		PhysicsServer2D::get_singleton()->damped_string_joint_set_param(get_joint(), PhysicsServer2D::DAMPED_STRING_DAMPING, p_damping);
+		PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(get_joint(), PhysicsServer2D::DAMPED_SPRING_DAMPING, p_damping);
 	}
 }
 

--- a/servers/physics_2d/joints_2d_sw.cpp
+++ b/servers/physics_2d/joints_2d_sw.cpp
@@ -390,29 +390,29 @@ void DampedSpringJoint2DSW::solve(real_t p_step) {
 	B->apply_impulse(rB, j);
 }
 
-void DampedSpringJoint2DSW::set_param(PhysicsServer2D::DampedStringParam p_param, real_t p_value) {
+void DampedSpringJoint2DSW::set_param(PhysicsServer2D::DampedSpringParam p_param, real_t p_value) {
 	switch (p_param) {
-		case PhysicsServer2D::DAMPED_STRING_REST_LENGTH: {
+		case PhysicsServer2D::DAMPED_SPRING_REST_LENGTH: {
 			rest_length = p_value;
 		} break;
-		case PhysicsServer2D::DAMPED_STRING_DAMPING: {
+		case PhysicsServer2D::DAMPED_SPRING_DAMPING: {
 			damping = p_value;
 		} break;
-		case PhysicsServer2D::DAMPED_STRING_STIFFNESS: {
+		case PhysicsServer2D::DAMPED_SPRING_STIFFNESS: {
 			stiffness = p_value;
 		} break;
 	}
 }
 
-real_t DampedSpringJoint2DSW::get_param(PhysicsServer2D::DampedStringParam p_param) const {
+real_t DampedSpringJoint2DSW::get_param(PhysicsServer2D::DampedSpringParam p_param) const {
 	switch (p_param) {
-		case PhysicsServer2D::DAMPED_STRING_REST_LENGTH: {
+		case PhysicsServer2D::DAMPED_SPRING_REST_LENGTH: {
 			return rest_length;
 		} break;
-		case PhysicsServer2D::DAMPED_STRING_DAMPING: {
+		case PhysicsServer2D::DAMPED_SPRING_DAMPING: {
 			return damping;
 		} break;
-		case PhysicsServer2D::DAMPED_STRING_STIFFNESS: {
+		case PhysicsServer2D::DAMPED_SPRING_STIFFNESS: {
 			return stiffness;
 		} break;
 	}

--- a/servers/physics_2d/joints_2d_sw.h
+++ b/servers/physics_2d/joints_2d_sw.h
@@ -151,8 +151,8 @@ public:
 	virtual bool setup(real_t p_step);
 	virtual void solve(real_t p_step);
 
-	void set_param(PhysicsServer2D::DampedStringParam p_param, real_t p_value);
-	real_t get_param(PhysicsServer2D::DampedStringParam p_param) const;
+	void set_param(PhysicsServer2D::DampedSpringParam p_param, real_t p_value);
+	real_t get_param(PhysicsServer2D::DampedSpringParam p_param) const;
 
 	DampedSpringJoint2DSW(const Vector2 &p_anchor_a, const Vector2 &p_anchor_b, Body2DSW *p_body_a, Body2DSW *p_body_b);
 	~DampedSpringJoint2DSW();

--- a/servers/physics_2d/physics_server_2d_sw.cpp
+++ b/servers/physics_2d/physics_server_2d_sw.cpp
@@ -1113,7 +1113,7 @@ real_t PhysicsServer2DSW::pin_joint_get_param(RID p_joint, PinJointParam p_param
 	return pin_joint->get_param(p_param);
 }
 
-void PhysicsServer2DSW::damped_string_joint_set_param(RID p_joint, DampedStringParam p_param, real_t p_value) {
+void PhysicsServer2DSW::damped_spring_joint_set_param(RID p_joint, DampedSpringParam p_param, real_t p_value) {
 	Joint2DSW *j = joint_owner.getornull(p_joint);
 	ERR_FAIL_COND(!j);
 	ERR_FAIL_COND(j->get_type() != JOINT_DAMPED_SPRING);
@@ -1122,7 +1122,7 @@ void PhysicsServer2DSW::damped_string_joint_set_param(RID p_joint, DampedStringP
 	dsj->set_param(p_param, p_value);
 }
 
-real_t PhysicsServer2DSW::damped_string_joint_get_param(RID p_joint, DampedStringParam p_param) const {
+real_t PhysicsServer2DSW::damped_spring_joint_get_param(RID p_joint, DampedSpringParam p_param) const {
 	Joint2DSW *j = joint_owner.getornull(p_joint);
 	ERR_FAIL_COND_V(!j, 0);
 	ERR_FAIL_COND_V(j->get_type() != JOINT_DAMPED_SPRING, 0);

--- a/servers/physics_2d/physics_server_2d_sw.h
+++ b/servers/physics_2d/physics_server_2d_sw.h
@@ -266,8 +266,8 @@ public:
 	virtual RID damped_spring_joint_create(const Vector2 &p_anchor_a, const Vector2 &p_anchor_b, RID p_body_a, RID p_body_b = RID());
 	virtual void pin_joint_set_param(RID p_joint, PinJointParam p_param, real_t p_value);
 	virtual real_t pin_joint_get_param(RID p_joint, PinJointParam p_param) const;
-	virtual void damped_string_joint_set_param(RID p_joint, DampedStringParam p_param, real_t p_value);
-	virtual real_t damped_string_joint_get_param(RID p_joint, DampedStringParam p_param) const;
+	virtual void damped_spring_joint_set_param(RID p_joint, DampedSpringParam p_param, real_t p_value);
+	virtual real_t damped_spring_joint_get_param(RID p_joint, DampedSpringParam p_param) const;
 
 	virtual JointType joint_get_type(RID p_joint) const;
 

--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -287,8 +287,8 @@ public:
 	FUNC3(pin_joint_set_param, RID, PinJointParam, real_t);
 	FUNC2RC(real_t, pin_joint_get_param, RID, PinJointParam);
 
-	FUNC3(damped_string_joint_set_param, RID, DampedStringParam, real_t);
-	FUNC2RC(real_t, damped_string_joint_get_param, RID, DampedStringParam);
+	FUNC3(damped_spring_joint_set_param, RID, DampedSpringParam, real_t);
+	FUNC2RC(real_t, damped_spring_joint_get_param, RID, DampedSpringParam);
 
 	FUNC1RC(JointType, joint_get_type, RID);
 

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -654,8 +654,8 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("groove_joint_create", "groove1_a", "groove2_a", "anchor_b", "body_a", "body_b"), &PhysicsServer2D::groove_joint_create, DEFVAL(RID()), DEFVAL(RID()));
 	ClassDB::bind_method(D_METHOD("damped_spring_joint_create", "anchor_a", "anchor_b", "body_a", "body_b"), &PhysicsServer2D::damped_spring_joint_create, DEFVAL(RID()));
 
-	ClassDB::bind_method(D_METHOD("damped_string_joint_set_param", "joint", "param", "value"), &PhysicsServer2D::damped_string_joint_set_param);
-	ClassDB::bind_method(D_METHOD("damped_string_joint_get_param", "joint", "param"), &PhysicsServer2D::damped_string_joint_get_param);
+	ClassDB::bind_method(D_METHOD("damped_spring_joint_set_param", "joint", "param", "value"), &PhysicsServer2D::damped_spring_joint_set_param);
+	ClassDB::bind_method(D_METHOD("damped_spring_joint_get_param", "joint", "param"), &PhysicsServer2D::damped_spring_joint_get_param);
 
 	ClassDB::bind_method(D_METHOD("joint_get_type", "joint"), &PhysicsServer2D::joint_get_type);
 
@@ -727,9 +727,9 @@ void PhysicsServer2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(JOINT_PARAM_MAX_BIAS);
 	BIND_ENUM_CONSTANT(JOINT_PARAM_MAX_FORCE);
 
-	BIND_ENUM_CONSTANT(DAMPED_STRING_REST_LENGTH);
-	BIND_ENUM_CONSTANT(DAMPED_STRING_STIFFNESS);
-	BIND_ENUM_CONSTANT(DAMPED_STRING_DAMPING);
+	BIND_ENUM_CONSTANT(DAMPED_SPRING_REST_LENGTH);
+	BIND_ENUM_CONSTANT(DAMPED_SPRING_STIFFNESS);
+	BIND_ENUM_CONSTANT(DAMPED_SPRING_DAMPING);
 
 	BIND_ENUM_CONSTANT(CCD_MODE_DISABLED);
 	BIND_ENUM_CONSTANT(CCD_MODE_CAST_RAY);

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -552,13 +552,13 @@ public:
 	virtual void pin_joint_set_param(RID p_joint, PinJointParam p_param, real_t p_value) = 0;
 	virtual real_t pin_joint_get_param(RID p_joint, PinJointParam p_param) const = 0;
 
-	enum DampedStringParam {
-		DAMPED_STRING_REST_LENGTH,
-		DAMPED_STRING_STIFFNESS,
-		DAMPED_STRING_DAMPING
+	enum DampedSpringParam {
+		DAMPED_SPRING_REST_LENGTH,
+		DAMPED_SPRING_STIFFNESS,
+		DAMPED_SPRING_DAMPING
 	};
-	virtual void damped_string_joint_set_param(RID p_joint, DampedStringParam p_param, real_t p_value) = 0;
-	virtual real_t damped_string_joint_get_param(RID p_joint, DampedStringParam p_param) const = 0;
+	virtual void damped_spring_joint_set_param(RID p_joint, DampedSpringParam p_param, real_t p_value) = 0;
+	virtual real_t damped_spring_joint_get_param(RID p_joint, DampedSpringParam p_param) const = 0;
 
 	virtual JointType joint_get_type(RID p_joint) const = 0;
 
@@ -678,7 +678,7 @@ VARIANT_ENUM_CAST(PhysicsServer2D::BodyState);
 VARIANT_ENUM_CAST(PhysicsServer2D::CCDMode);
 VARIANT_ENUM_CAST(PhysicsServer2D::JointParam);
 VARIANT_ENUM_CAST(PhysicsServer2D::JointType);
-VARIANT_ENUM_CAST(PhysicsServer2D::DampedStringParam);
+VARIANT_ENUM_CAST(PhysicsServer2D::DampedSpringParam);
 //VARIANT_ENUM_CAST( PhysicsServer2D::ObjectType );
 VARIANT_ENUM_CAST(PhysicsServer2D::AreaBodyStatus);
 VARIANT_ENUM_CAST(PhysicsServer2D::ProcessInfo);


### PR DESCRIPTION
Fixes #27921.