### PR TITLE
[3.2] Add support for focus awareness

### DIFF
--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -52,6 +52,9 @@
             android:resizeableActivity="false"
             tools:ignore="UnusedAttribute" >
 
+            <!-- Focus awareness metadata populated at export time if the user enables it in the 'Xr Features' section. -->
+            <meta-data android:name="com.oculus.vr.focusaware" android:value="oculus_focus_aware_value" />
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Add an export option to enable [focus awareness](https://developer.oculus.com/documentation/native/android/mobile-overlays/?locale=en_US) (Oculus Quest system overlays) in the Godot editor.

Backport for #39304
Fixes https://github.com/GodotVR/godot_oculus_mobile/issues/92