### PR TITLE
Allow duplicating files when holding Control

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2085,7 +2085,32 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 				}
 			}
 			if (!to_move.empty()) {
-				_move_operation_confirm(to_dir);
+				if (Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
+					for (int i = 0; i < to_move.size(); i++) {
+						String new_path;
+						String new_path_base;
+
+						if (to_move[i].is_file) {
+							new_path = to_dir.plus_file(to_move[i].path.get_file());
+							new_path_base = new_path.get_basename() + " (%d)." + new_path.get_extension();
+						} else {
+							PackedStringArray path_split = to_move[i].path.split("/");
+							new_path = to_dir.plus_file(path_split[path_split.size() - 2]);
+							new_path_base = new_path + " (%d)";
+						}
+
+						int exist_counter = 1;
+						DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+						while (da->file_exists(new_path) || da->dir_exists(new_path)) {
+							exist_counter++;
+							new_path = vformat(new_path_base, exist_counter);
+						}
+						_try_duplicate_item(to_move[i], new_path);
+					}
+					_rescan();
+				} else {
+					_move_operation_confirm(to_dir);
+				}
 			}
 		} else if (favorite) {
 			// Add the files from favorites.


### PR DESCRIPTION
Closes #24072

![Lten2couJB](https://user-images.githubusercontent.com/2223172/83821816-af6fc400-a6cf-11ea-812a-75edbff657ad.gif)

Multiple files are bugged though, so draft for now.

~~When you duplicate multiple files this way, the editor seems to do rescan only after first file and the second file is invisible. It appears when you open the project twice (because it crashes after first reopen xd). Any clue why this happens would be appreciated.
(might be related to #39308)~~