### PR TITLE
Make sure built-in script warning fits in dialog

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -510,6 +510,7 @@ void ScriptCreateDialog::_built_in_pressed() {
 		_path_changed(file_path->get_text());
 	}
 	_update_dialog();
+	minimum_size_changed();
 }
 
 void ScriptCreateDialog::_browse_path(bool browse_parent, bool p_save) {


### PR DESCRIPTION
I didn't test it, but according to https://github.com/godotengine/godot/issues/39017#issuecomment-639145780 it fixes #39017
This is only relevant for 3.2 branch.