### PR TITLE
Update Issue Template column headers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
-name: Bug report
-about: Report a bug in Godot
-title: ''
-labels: ''
-assignees: ''
+Name: Bug report
+About: Report a bug in Godot
+Title: ''
+Labels: ''
+Assignees: ''
 
 ---
 <!-- Please search existing issues for potential duplicates before filing yours:	


### PR DESCRIPTION
Labels for column headers are usually capitalized.

Merely changed each of the words in the column headers to have a capital letter.