### PR TITLE
Add support for fr/us X11 kbd layout symbol 

### DIFF
--- a/main/tests/test_main.cpp
+++ b/main/tests/test_main.cpp
@@ -41,6 +41,7 @@
 #include "test_math.h"
 #include "test_oa_hash_map.h"
 #include "test_ordered_hash_map.h"
+#include "test_os.h"
 #include "test_physics_2d.h"
 #include "test_physics_3d.h"
 #include "test_render.h"
@@ -64,6 +65,7 @@ const char **tests_get_names() {
 		"gd_bytecode",
 		"ordered_hash_map",
 		"astar",
+		"os",
 		nullptr
 	};
 
@@ -131,6 +133,10 @@ MainLoop *test_main(String p_test, const List<String> &p_args) {
 
 	if (p_test == "astar") {
 		return TestAStar::test();
+	}
+
+	if (p_test == "os") {
+		return TestOS::test();
 	}
 
 	print_line("Unknown test: " + p_test);

--- a/main/tests/test_os.cpp
+++ b/main/tests/test_os.cpp
@@ -1,0 +1,75 @@
+/*************************************************************************/
+/*  test_os.cpp                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "test_os.h"
+
+#include "core/os/main_loop.h"
+#include "servers/display_server.h"
+#include "servers/rendering_server.h"
+
+namespace TestOS {
+
+bool test_get_latin_keyboard_variant() {
+	print_line("test_get_latin_keyboard_variant");
+	const DisplayServer::LatinKeyboardVariant r = DisplayServer::get_singleton()->get_latin_keyboard_variant();
+	OS::get_singleton()->print("latin_keyboard_variant: %d\n", r);
+	// As today get_latin_keyboard_variant cannot really fails as it returns by default QWERTY in case of any failure. That test at least checks for any crash.
+	return true;
+};
+
+typedef bool (*TestFunc)();
+
+TestFunc test_funcs[] = {
+	test_get_latin_keyboard_variant,
+	nullptr
+};
+
+MainLoop *test() {
+	int count = 0;
+	int passed = 0;
+
+	while (true) {
+		if (!test_funcs[count]) {
+			break;
+		}
+		bool pass = test_funcs[count]();
+		if (pass) {
+			passed++;
+		}
+		OS::get_singleton()->print("\t%s\n", pass ? "PASS" : "FAILED");
+
+		count++;
+	}
+	OS::get_singleton()->print("\n");
+	OS::get_singleton()->print("Passed %i of %i tests\n", passed, count);
+	return nullptr;
+}
+
+} // namespace TestOS

--- a/main/tests/test_os.h
+++ b/main/tests/test_os.h
@@ -1,0 +1,46 @@
+/*************************************************************************/
+/*  test_os.h                                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_OS_H
+#define TEST_OS_H
+
+#include "core/list.h"
+#include "core/os/main_loop.h"
+#include "core/ustring.h"
+
+namespace TestOS {
+
+MainLoop *test();
+}
+
+const char **tests_get_names();
+MainLoop *test_os(String p_test, const List<String> &p_args);
+
+#endif // TEST_OS_H


### PR DESCRIPTION
Add support for 'fr' X kbd layout in
DisplayServerX11::get_latin_keyboard_variant().
Add a new OS unittest suite.