### PR TITLE
Crypto virtual methods, fix editor crash when mbedtls is disabled

### DIFF
--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -70,7 +70,7 @@ Crypto *Crypto::create() {
 	if (_create) {
 		return _create();
 	}
-	return memnew(Crypto);
+	ERR_FAIL_V_MSG(nullptr, "Crypto is not available when the mbedtls module is disabled.");
 }
 
 void Crypto::load_default_certificates(String p_path) {
@@ -83,18 +83,6 @@ void Crypto::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("generate_random_bytes", "size"), &Crypto::generate_random_bytes);
 	ClassDB::bind_method(D_METHOD("generate_rsa", "size"), &Crypto::generate_rsa);
 	ClassDB::bind_method(D_METHOD("generate_self_signed_certificate", "key", "issuer_name", "not_before", "not_after"), &Crypto::generate_self_signed_certificate, DEFVAL("CN=myserver,O=myorganisation,C=IT"), DEFVAL("20140101000000"), DEFVAL("20340101000000"));
-}
-
-PackedByteArray Crypto::generate_random_bytes(int p_bytes) {
-	ERR_FAIL_V_MSG(PackedByteArray(), "generate_random_bytes is not available when mbedtls module is disabled.");
-}
-
-Ref<CryptoKey> Crypto::generate_rsa(int p_bytes) {
-	ERR_FAIL_V_MSG(nullptr, "generate_rsa is not available when mbedtls module is disabled.");
-}
-
-Ref<X509Certificate> Crypto::generate_self_signed_certificate(Ref<CryptoKey> p_key, String p_issuer_name, String p_not_before, String p_not_after) {
-	ERR_FAIL_V_MSG(nullptr, "generate_self_signed_certificate is not available when mbedtls module is disabled.");
 }
 
 /// Resource loader/saver

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -75,9 +75,9 @@ public:
 	static Crypto *create();
 	static void load_default_certificates(String p_path);
 
-	virtual PackedByteArray generate_random_bytes(int p_bytes);
-	virtual Ref<CryptoKey> generate_rsa(int p_bytes);
-	virtual Ref<X509Certificate> generate_self_signed_certificate(Ref<CryptoKey> p_key, String p_issuer_name, String p_not_before, String p_not_after);
+	virtual PackedByteArray generate_random_bytes(int p_bytes) = 0;
+	virtual Ref<CryptoKey> generate_rsa(int p_bytes) = 0;
+	virtual Ref<X509Certificate> generate_self_signed_certificate(Ref<CryptoKey> p_key, String p_issuer_name, String p_not_before, String p_not_after) = 0;
 
 	Crypto() {}
 };

--- a/core/io/dtls_server.cpp
+++ b/core/io/dtls_server.cpp
@@ -37,7 +37,10 @@ DTLSServer *(*DTLSServer::_create)() = nullptr;
 bool DTLSServer::available = false;
 
 DTLSServer *DTLSServer::create() {
-	return _create();
+	if (_create) {
+		return _create();
+	}
+	return nullptr;
 }
 
 bool DTLSServer::is_available() {

--- a/core/io/packet_peer_dtls.cpp
+++ b/core/io/packet_peer_dtls.cpp
@@ -36,7 +36,10 @@ PacketPeerDTLS *(*PacketPeerDTLS::_create)() = nullptr;
 bool PacketPeerDTLS::available = false;
 
 PacketPeerDTLS *PacketPeerDTLS::create() {
-	return _create();
+	if (_create) {
+		return _create();
+	}
+	return nullptr;
 }
 
 bool PacketPeerDTLS::is_available() {


### PR DESCRIPTION
In this PR:

- Crypto was registered as a custom instance class, but stub methods where provided so it could be instantiated even when mbedtls was disabled. Now, instantiating it will return `nullptr` like other custom instance class, along with the explanation that it is not available when mbedtls is disabled.
- DTLS classes (`DTLSServer` and `PacketPeerDTLS`) were causing the editor to crash when mbedtls was disabled, calling a null function ptr.

Cherry-picks for 3.2 are available here: https://github.com/Faless/godot/tree/crypto/instantiate_fix_32