### PR TITLE
denoise: Restrict build to 64-bit desktop platforms

### DIFF
--- a/modules/denoise/config.py
+++ b/modules/denoise/config.py
@@ -1,5 +1,11 @@
 def can_build(env, platform):
-    return env["tools"]
+    # Thirdparty dependency OpenImage Denoise includes oneDNN library
+    # which only supports 64-bit architectures.
+    # It's also only relevant for tools build and desktop platforms,
+    # as doing lightmap generation and denoising on Android or HTML5
+    # would be a bit far-fetched.
+    desktop_platforms = ["linuxbsd", "osx", "windows"]
+    return env["tools"] and platform in desktop_platforms and env["bits"] == "64"
 
 
 def configure(env):


### PR DESCRIPTION
One of OIDN's dependencies only supports x86_64 and aarch64.
For now we also exclude potential future Android tools builds,
but this could be re-evaluated in the future.

Fixes #38759.