### PR TITLE
Remove the GIProbe `compress` property due to bugs

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -582,12 +582,8 @@ public:
 	void gi_probe_set_interior(RID p_probe, bool p_enable) {}
 	bool gi_probe_is_interior(RID p_probe) const { return false; }
 
-	void gi_probe_set_compress(RID p_probe, bool p_enable) {}
-	bool gi_probe_is_compressed(RID p_probe) const { return false; }
-
 	uint32_t gi_probe_get_version(RID p_probe) { return 0; }
 
-	GIProbeCompression gi_probe_get_dynamic_data_get_preferred_compression() const { return GI_PROBE_UNCOMPRESSED; }
 	RID gi_probe_dynamic_data_create(int p_width, int p_height, int p_depth, GIProbeCompression p_compression) { return RID(); }
 	void gi_probe_dynamic_data_update(RID p_gi_probe_data, int p_depth_slice, int p_slice_count, int p_mipmap, const void *p_data) {}
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4278,12 +4278,6 @@ bool RasterizerStorageGLES2::gi_probe_is_interior(RID p_probe) const {
 	return false;
 }
 
-void RasterizerStorageGLES2::gi_probe_set_compress(RID p_probe, bool p_enable) {
-}
-
-bool RasterizerStorageGLES2::gi_probe_is_compressed(RID p_probe) const {
-	return false;
-}
 float RasterizerStorageGLES2::gi_probe_get_energy(RID p_probe) const {
 	return 0;
 }
@@ -4302,10 +4296,6 @@ float RasterizerStorageGLES2::gi_probe_get_propagation(RID p_probe) const {
 
 uint32_t RasterizerStorageGLES2::gi_probe_get_version(RID p_probe) {
 	return 0;
-}
-
-RasterizerStorage::GIProbeCompression RasterizerStorageGLES2::gi_probe_get_dynamic_data_get_preferred_compression() const {
-	return GI_PROBE_UNCOMPRESSED;
 }
 
 RID RasterizerStorageGLES2::gi_probe_dynamic_data_create(int p_width, int p_height, int p_depth, GIProbeCompression p_compression) {

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1049,12 +1049,8 @@ public:
 	virtual void gi_probe_set_interior(RID p_probe, bool p_enable);
 	virtual bool gi_probe_is_interior(RID p_probe) const;
 
-	virtual void gi_probe_set_compress(RID p_probe, bool p_enable);
-	virtual bool gi_probe_is_compressed(RID p_probe) const;
-
 	virtual uint32_t gi_probe_get_version(RID p_probe);
 
-	virtual GIProbeCompression gi_probe_get_dynamic_data_get_preferred_compression() const;
 	virtual RID gi_probe_dynamic_data_create(int p_width, int p_height, int p_depth, GIProbeCompression p_compression);
 	virtual void gi_probe_dynamic_data_update(RID p_gi_probe_data, int p_depth_slice, int p_slice_count, int p_mipmap, const void *p_data);
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -6050,21 +6050,6 @@ bool RasterizerStorageGLES3::gi_probe_is_interior(RID p_probe) const {
 	return gip->interior;
 }
 
-void RasterizerStorageGLES3::gi_probe_set_compress(RID p_probe, bool p_enable) {
-
-	GIProbe *gip = gi_probe_owner.getornull(p_probe);
-	ERR_FAIL_COND(!gip);
-
-	gip->compress = p_enable;
-}
-
-bool RasterizerStorageGLES3::gi_probe_is_compressed(RID p_probe) const {
-
-	const GIProbe *gip = gi_probe_owner.getornull(p_probe);
-	ERR_FAIL_COND_V(!gip, false);
-
-	return gip->compress;
-}
 float RasterizerStorageGLES3::gi_probe_get_energy(RID p_probe) const {
 
 	const GIProbe *gip = gi_probe_owner.getornull(p_probe);
@@ -6103,14 +6088,6 @@ uint32_t RasterizerStorageGLES3::gi_probe_get_version(RID p_probe) {
 	ERR_FAIL_COND_V(!gip, 0);
 
 	return gip->version;
-}
-
-RasterizerStorage::GIProbeCompression RasterizerStorageGLES3::gi_probe_get_dynamic_data_get_preferred_compression() const {
-	if (config.s3tc_supported) {
-		return GI_PROBE_S3TC;
-	} else {
-		return GI_PROBE_UNCOMPRESSED;
-	}
 }
 
 RID RasterizerStorageGLES3::gi_probe_dynamic_data_create(int p_width, int p_height, int p_depth, GIProbeCompression p_compression) {

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1082,9 +1082,6 @@ public:
 	virtual void gi_probe_set_interior(RID p_probe, bool p_enable);
 	virtual bool gi_probe_is_interior(RID p_probe) const;
 
-	virtual void gi_probe_set_compress(RID p_probe, bool p_enable);
-	virtual bool gi_probe_is_compressed(RID p_probe) const;
-
 	virtual uint32_t gi_probe_get_version(RID p_probe);
 
 	struct GIProbeData : public RID_Data {
@@ -1102,7 +1099,6 @@ public:
 
 	mutable RID_Owner<GIProbeData> gi_probe_data_owner;
 
-	virtual GIProbeCompression gi_probe_get_dynamic_data_get_preferred_compression() const;
 	virtual RID gi_probe_dynamic_data_create(int p_width, int p_height, int p_depth, GIProbeCompression p_compression);
 	virtual void gi_probe_dynamic_data_update(RID p_gi_probe_data, int p_depth_slice, int p_slice_count, int p_mipmap, const void *p_data);
 

--- a/scene/3d/gi_probe.cpp
+++ b/scene/3d/gi_probe.cpp
@@ -129,16 +129,6 @@ bool GIProbeData::is_interior() const {
 	return VS::get_singleton()->gi_probe_is_interior(probe);
 }
 
-bool GIProbeData::is_compressed() const {
-
-	return VS::get_singleton()->gi_probe_is_compressed(probe);
-}
-
-void GIProbeData::set_compress(bool p_enable) {
-
-	VS::get_singleton()->gi_probe_set_compress(probe, p_enable);
-}
-
 int GIProbeData::get_dynamic_range() const {
 
 	return VS::get_singleton()->gi_probe_get_dynamic_range(probe);
@@ -181,9 +171,6 @@ void GIProbeData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_interior", "interior"), &GIProbeData::set_interior);
 	ClassDB::bind_method(D_METHOD("is_interior"), &GIProbeData::is_interior);
 
-	ClassDB::bind_method(D_METHOD("set_compress", "compress"), &GIProbeData::set_compress);
-	ClassDB::bind_method(D_METHOD("is_compressed"), &GIProbeData::is_compressed);
-
 	ADD_PROPERTY(PropertyInfo(Variant::AABB, "bounds", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_bounds", "get_bounds");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "cell_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_cell_size", "get_cell_size");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM, "to_cell_xform", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_to_cell_xform", "get_to_cell_xform");
@@ -195,7 +182,6 @@ void GIProbeData::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "normal_bias", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_normal_bias", "get_normal_bias");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "propagation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_propagation", "get_propagation");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "interior", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_interior", "is_interior");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "compress", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_compress", "is_compressed");
 }
 
 GIProbeData::GIProbeData() {
@@ -319,19 +305,6 @@ void GIProbe::set_interior(bool p_enable) {
 bool GIProbe::is_interior() const {
 
 	return interior;
-}
-
-void GIProbe::set_compress(bool p_enable) {
-
-	compress = p_enable;
-	if (probe_data.is_valid()) {
-		probe_data->set_compress(p_enable);
-	}
-}
-
-bool GIProbe::is_compressed() const {
-
-	return compress;
 }
 
 void GIProbe::_find_meshes(Node *p_at_node, List<PlotMesh> &plot_meshes) {
@@ -463,7 +436,6 @@ void GIProbe::bake(Node *p_from_node, bool p_create_visual_debug) {
 		probe_data->set_normal_bias(normal_bias);
 		probe_data->set_propagation(propagation);
 		probe_data->set_interior(interior);
-		probe_data->set_compress(compress);
 		probe_data->set_to_cell_xform(baker.get_to_cell_space_xform());
 
 		set_probe_data(probe_data);
@@ -526,9 +498,6 @@ void GIProbe::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_interior", "enable"), &GIProbe::set_interior);
 	ClassDB::bind_method(D_METHOD("is_interior"), &GIProbe::is_interior);
 
-	ClassDB::bind_method(D_METHOD("set_compress", "enable"), &GIProbe::set_compress);
-	ClassDB::bind_method(D_METHOD("is_compressed"), &GIProbe::is_compressed);
-
 	ClassDB::bind_method(D_METHOD("bake", "from_node", "create_visual_debug"), &GIProbe::bake, DEFVAL(Variant()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("debug_bake"), &GIProbe::_debug_bake);
 	ClassDB::set_method_flags(get_class_static(), _scs_create("debug_bake"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
@@ -541,7 +510,6 @@ void GIProbe::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "bias", PROPERTY_HINT_RANGE, "0,4,0.001"), "set_bias", "get_bias");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "normal_bias", PROPERTY_HINT_RANGE, "0,4,0.001"), "set_normal_bias", "get_normal_bias");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "interior"), "set_interior", "is_interior");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "compress"), "set_compress", "is_compressed");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "data", PROPERTY_HINT_RESOURCE_TYPE, "GIProbeData", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE), "set_probe_data", "get_probe_data");
 
 	BIND_ENUM_CONSTANT(SUBDIV_64);
@@ -561,7 +529,6 @@ GIProbe::GIProbe() {
 	propagation = 0.7;
 	extents = Vector3(10, 10, 10);
 	interior = false;
-	compress = false;
 
 	gi_probe = VS::get_singleton()->gi_probe_create();
 	set_disable_scale(true);

--- a/scene/3d/gi_probe.h
+++ b/scene/3d/gi_probe.h
@@ -74,9 +74,6 @@ public:
 	void set_interior(bool p_enable);
 	bool is_interior() const;
 
-	void set_compress(bool p_enable);
-	bool is_compressed() const;
-
 	virtual RID get_rid() const;
 
 	GIProbeData();
@@ -113,7 +110,6 @@ private:
 	float normal_bias;
 	float propagation;
 	bool interior;
-	bool compress;
 
 	struct PlotMesh {
 		Ref<Material> override_material;
@@ -159,9 +155,6 @@ public:
 
 	void set_interior(bool p_enable);
 	bool is_interior() const;
-
-	void set_compress(bool p_enable);
-	bool is_compressed() const;
 
 	void bake(Node *p_from_node = NULL, bool p_create_visual_debug = false);
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -467,9 +467,6 @@ public:
 	virtual void gi_probe_set_interior(RID p_probe, bool p_enable) = 0;
 	virtual bool gi_probe_is_interior(RID p_probe) const = 0;
 
-	virtual void gi_probe_set_compress(RID p_probe, bool p_enable) = 0;
-	virtual bool gi_probe_is_compressed(RID p_probe) const = 0;
-
 	virtual uint32_t gi_probe_get_version(RID p_probe) = 0;
 
 	enum GIProbeCompression {
@@ -478,7 +475,6 @@ public:
 		GI_PROBE_ETC2
 	};
 
-	virtual GIProbeCompression gi_probe_get_dynamic_data_get_preferred_compression() const = 0;
 	virtual RID gi_probe_dynamic_data_create(int p_width, int p_height, int p_depth, GIProbeCompression p_compression) = 0;
 	virtual void gi_probe_dynamic_data_update(RID p_gi_probe_data, int p_depth_slice, int p_slice_count, int p_mipmap, const void *p_data) = 0;
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -371,9 +371,6 @@ public:
 	BIND2(gi_probe_set_interior, RID, bool)
 	BIND1RC(bool, gi_probe_is_interior, RID)
 
-	BIND2(gi_probe_set_compress, RID, bool)
-	BIND1RC(bool, gi_probe_is_compressed, RID)
-
 	BIND2(gi_probe_set_dynamic_data, RID, const PoolVector<int> &)
 	BIND1RC(PoolVector<int>, gi_probe_get_dynamic_data, RID)
 

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -2363,9 +2363,8 @@ void VisualServerScene::_setup_gi_probe(Instance *p_instance) {
 
 	_gi_probe_fill_local_data(0, 0, 0, 0, 0, cells, header, ldw.ptr(), probe->dynamic.level_cell_lists.ptrw());
 
-	bool compress = VSG::storage->gi_probe_is_compressed(p_instance->base);
-
-	probe->dynamic.compression = compress ? VSG::storage->gi_probe_get_dynamic_data_get_preferred_compression() : RasterizerStorage::GI_PROBE_UNCOMPRESSED;
+	// Support for compressed textures was removed due to bugs.
+	probe->dynamic.compression = RasterizerStorage::GI_PROBE_UNCOMPRESSED;
 
 	probe->dynamic.probe_data = VSG::storage->gi_probe_dynamic_data_create(header->width, header->height, header->depth, probe->dynamic.compression);
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -307,9 +307,6 @@ public:
 	FUNC2(gi_probe_set_interior, RID, bool)
 	FUNC1RC(bool, gi_probe_is_interior, RID)
 
-	FUNC2(gi_probe_set_compress, RID, bool)
-	FUNC1RC(bool, gi_probe_is_compressed, RID)
-
 	FUNC2(gi_probe_set_dynamic_data, RID, const PoolVector<int> &)
 	FUNC1RC(PoolVector<int>, gi_probe_get_dynamic_data, RID)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1815,8 +1815,6 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("gi_probe_get_propagation", "probe"), &VisualServer::gi_probe_get_propagation);
 	ClassDB::bind_method(D_METHOD("gi_probe_set_interior", "probe", "enable"), &VisualServer::gi_probe_set_interior);
 	ClassDB::bind_method(D_METHOD("gi_probe_is_interior", "probe"), &VisualServer::gi_probe_is_interior);
-	ClassDB::bind_method(D_METHOD("gi_probe_set_compress", "probe", "enable"), &VisualServer::gi_probe_set_compress);
-	ClassDB::bind_method(D_METHOD("gi_probe_is_compressed", "probe"), &VisualServer::gi_probe_is_compressed);
 
 	ClassDB::bind_method(D_METHOD("lightmap_capture_create"), &VisualServer::lightmap_capture_create);
 	ClassDB::bind_method(D_METHOD("lightmap_capture_set_bounds", "capture", "bounds"), &VisualServer::lightmap_capture_set_bounds);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -532,9 +532,6 @@ public:
 	virtual void gi_probe_set_interior(RID p_probe, bool p_enable) = 0;
 	virtual bool gi_probe_is_interior(RID p_probe) const = 0;
 
-	virtual void gi_probe_set_compress(RID p_probe, bool p_enable) = 0;
-	virtual bool gi_probe_is_compressed(RID p_probe) const = 0;
-
 	/* LIGHTMAP CAPTURE */
 
 	virtual RID lightmap_capture_create() = 0;


### PR DESCRIPTION
**Note:** GIProbe in 4.0 doesn't have a compression option, so this bug doesn't apply there.

This closes #32427.