### PR TITLE
Tree: Calling update in _gui_input less frequently

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2364,7 +2364,6 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 					if (pos.x < len) {
 						cache.hover_type = Cache::CLICK_TITLE;
 						cache.hover_index = i;
-						update();
 						break;
 					}
 				}
@@ -2383,6 +2382,9 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 					mpos.y += v_scroll->get_value();
 				}
 
+				TreeItem *old_it = cache.hover_item;
+				int old_col = cache.hover_cell;
+
 				int col, h, section;
 				TreeItem *it = _find_item_at_pos(root, mpos, col, h, section);
 
@@ -2397,18 +2399,21 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 					}
 				}
 
-				if (it != cache.hover_item) {
-					cache.hover_item = it;
-					update();
-				}
+				cache.hover_item = it;
+				cache.hover_cell = col;
 
-				if (it && col != cache.hover_cell) {
-					cache.hover_cell = col;
-					update();
+				if (it != old_it || col != old_col) {
+					// Only need to update if mouse enters/exits a button
+					bool was_over_button = old_it && old_it->cells[old_col].custom_button;
+					bool is_over_button = it && it->cells[col].custom_button;
+					if (was_over_button || is_over_button) {
+						update();
+					}
 				}
 			}
 		}
 
+		// Update if mouse enters/exits columns
 		if (cache.hover_type != old_hover || cache.hover_index != old_index) {
 			update();
 		}


### PR DESCRIPTION
Optimizes _gui_input handling in tree control to only call `update()` when going from a control that actually needs to re-render which are the ones that use hover states (columns and cells which have `set_custom_as_button` set to true).

1) Columns already had a condition to only update when they changed but there was still an explicit call to `update()` which can safely be removed. 
2) Calling `update()` only when hovering in/out of cells that use `set_custom_as_button`. 

Can this fix be cherry picked for 3.2.2 since it's backwards compatible? 

Also, I'm not sure if anyone out there is using `set_custom_as_button` it looks like the editor used it a few years ago but no longer does. It's barely documented and I had to poke around the source code to figure out how to even get it to work so I'd be surprised if anyone is using it. Might be something good to remove for 4.0 if it's a good time to deprecate unused APIs.

Test project: [TreeSample.zip](https://github.com/godotengine/godot/files/4741025/TreeSample.zip)

Still seeing some updates that could be optimized but much less than before. The main benefit here is when I'm moving my mouse around the first 3 groups of cells which don't have any hover state, there are no draw call updates. Everything else is still working as expected.
![cap3](https://user-images.githubusercontent.com/92303/83955088-58780500-a81d-11ea-8a7b-008452d6777f.gif)

Fix: https://github.com/godotengine/godot/issues/39251