### PR TITLE
Added a "title" attribute for the link tag in the docs xml

### DIFF
--- a/doc/classes/KinematicBody2D.xml
+++ b/doc/classes/KinematicBody2D.xml
@@ -9,7 +9,7 @@
 		[b]Kinematic characters:[/b] KinematicBody2D also has an API for moving objects (the [method move_and_collide] and [method move_and_slide] methods) while performing collision tests. This makes them really useful to implement characters that collide against a world, but that don't require advanced physics.
 	</description>
 	<tutorials>
-		<link>https://docs.godotengine.org/en/latest/tutorials/physics/kinematic_character_2d.html</link>
+		<link title="Kinematic character (2D)">https://docs.godotengine.org/en/latest/tutorials/physics/kinematic_character_2d.html</link>
 		<link>https://docs.godotengine.org/en/latest/tutorials/physics/using_kinematic_body_2d.html</link>
 	</tutorials>
 	<methods>

--- a/editor/doc_data.cpp
+++ b/editor/doc_data.cpp
@@ -881,9 +881,14 @@ Error DocData::_load(Ref<XMLParser> parser) {
 							String name3 = parser->get_node_name();
 
 							if (name3 == "link") {
+								TutorialDoc tutorial;
+								if (parser->has_attribute("title")) {
+									tutorial.title = parser->get_attribute_value("title");
+								}
 								parser->read();
 								if (parser->get_node_type() == XMLParser::NODE_TEXT) {
-									c.tutorials.push_back(parser->get_node_data().strip_edges());
+									tutorial.link = parser->get_node_data().strip_edges();
+									c.tutorials.push_back(tutorial);
 								}
 							} else {
 								ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Invalid tag in doc file: " + name3 + ".");
@@ -1055,7 +1060,9 @@ Error DocData::save_classes(const String &p_default_path, const Map<String, Stri
 
 		_write_string(f, 1, "<tutorials>");
 		for (int i = 0; i < c.tutorials.size(); i++) {
-			_write_string(f, 2, "<link>" + c.tutorials.get(i).xml_escape() + "</link>");
+			TutorialDoc tutorial = c.tutorials.get(i);
+			String title_attribute = (!tutorial.title.empty()) ? " title=\"" + tutorial.title.xml_escape() + "\"" : "";
+			_write_string(f, 2, "<link" + title_attribute + ">" + tutorial.link.xml_escape() + "</link>");
 		}
 		_write_string(f, 1, "</tutorials>");
 

--- a/editor/doc_data.h
+++ b/editor/doc_data.h
@@ -82,13 +82,18 @@ public:
 		}
 	};
 
+	struct TutorialDoc {
+		String link;
+		String title;
+	};
+
 	struct ClassDoc {
 		String name;
 		String inherits;
 		String category;
 		String brief_description;
 		String description;
-		Vector<String> tutorials;
+		Vector<TutorialDoc> tutorials;
 		Vector<MethodDoc> methods;
 		Vector<MethodDoc> signals;
 		Vector<ConstantDoc> constants;

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -480,8 +480,8 @@ void EditorHelp::_update_doc() {
 		class_desc->add_newline();
 
 		for (int i = 0; i < cd.tutorials.size(); i++) {
-			const String link = DTR(cd.tutorials[i]);
-			String linktxt = link;
+			const String link = DTR(cd.tutorials[i].link);
+			String linktxt = (cd.tutorials[i].title.empty()) ? link : DTR(cd.tutorials[i].title);
 			const int seppos = linktxt.find("//");
 			if (seppos != -1) {
 				linktxt = link.right(seppos + 2);


### PR DESCRIPTION
To allow better titles for the tutorial links in the documentation I've added a `title` attribute for the link tag. The link itself will be used in the title if the attribute is absent.

I also changed the KinematicBody2D.xml file to show how it can be used:
```
<link title="Kinematic character (2D)">
      https://docs.godotengine.org/en/latest/tutorials/physics/kinematic_character_2d.html
</link>
```


