### PR TITLE
[WIP] GDScript documentation system

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -145,6 +145,9 @@ struct PropertyInfo {
 	PropertyHint hint = PROPERTY_HINT_NONE;
 	String hint_string;
 	uint32_t usage = PROPERTY_USAGE_DEFAULT;
+#ifdef TOOLS_ENABLED
+	String doc_string;
+#endif
 
 	_FORCE_INLINE_ PropertyInfo added_usage(int p_fl) const {
 		PropertyInfo pi = *this;
@@ -198,6 +201,9 @@ struct MethodInfo {
 	int id = 0;
 	List<PropertyInfo> arguments;
 	Vector<Variant> default_arguments;
+#ifdef TOOLS_ENABLED
+	String doc_string;
+#endif
 
 	inline bool operator==(const MethodInfo &p_method) const { return id == p_method.id; }
 	inline bool operator<(const MethodInfo &p_method) const { return id == p_method.id ? (name < p_method.name) : (id < p_method.id); }

--- a/editor/doc_data.cpp
+++ b/editor/doc_data.cpp
@@ -185,7 +185,24 @@ void DocData::remove_from(const DocData &p_data) {
 	}
 }
 
-static void return_doc_from_retinfo(DocData::MethodDoc &p_method, const PropertyInfo &p_retinfo) {
+void DocData::add_doc(const ClassDoc &p_class_doc) {
+	ERR_FAIL_COND(p_class_doc.name == "");
+	class_list[p_class_doc.name] = p_class_doc;
+}
+
+void DocData::remove_doc(const String &p_class_name) {
+	ERR_FAIL_COND(p_class_name == "" || !class_list.has(p_class_name));
+	class_list.erase(p_class_name);
+}
+
+bool DocData::has_doc(const String &p_class_name) {
+	if (p_class_name == "") {
+		return false;
+	}
+	return class_list.has(p_class_name);
+}
+
+void DocData::return_doc_from_retinfo(DocData::MethodDoc &p_method, const PropertyInfo &p_retinfo) {
 	if (p_retinfo.type == Variant::INT && p_retinfo.usage & PROPERTY_USAGE_CLASS_IS_ENUM) {
 		p_method.return_enum = p_retinfo.class_name;
 		if (p_method.return_enum.begins_with("_")) { //proxy class
@@ -207,7 +224,7 @@ static void return_doc_from_retinfo(DocData::MethodDoc &p_method, const Property
 	}
 }
 
-static void argument_doc_from_arginfo(DocData::ArgumentDoc &p_argument, const PropertyInfo &p_arginfo) {
+void DocData::argument_doc_from_arginfo(DocData::ArgumentDoc &p_argument, const PropertyInfo &p_arginfo) {
 	p_argument.name = p_arginfo.name;
 
 	if (p_arginfo.type == Variant::INT && p_arginfo.usage & PROPERTY_USAGE_CLASS_IS_ENUM) {
@@ -228,6 +245,56 @@ static void argument_doc_from_arginfo(DocData::ArgumentDoc &p_argument, const Pr
 	} else {
 		p_argument.type = Variant::get_type_name(p_arginfo.type);
 	}
+}
+
+void DocData::property_doc_from_scriptmemberinfo(DocData::PropertyDoc &p_property, const ScriptMemberInfo &p_memberinfo) {
+	p_property.name = p_memberinfo.propinfo.name;
+	p_property.description = p_memberinfo.propinfo.doc_string;
+
+	if (p_memberinfo.propinfo.type == Variant::OBJECT) {
+		p_property.type = p_memberinfo.propinfo.class_name;
+	} else if (p_memberinfo.propinfo.type == Variant::NIL && p_memberinfo.propinfo.usage & PROPERTY_USAGE_NIL_IS_VARIANT) {
+		p_property.type = "Variant";
+	} else {
+		p_property.type = Variant::get_type_name(p_memberinfo.propinfo.type);
+	}
+
+	p_property.setter = p_memberinfo.setter;
+	p_property.getter = p_memberinfo.getter;
+
+	if (p_memberinfo.has_default_value && p_memberinfo.default_value.get_type() != Variant::OBJECT) {
+		p_property.default_value = p_memberinfo.default_value.get_construct_string().replace("\n", "");
+	}
+
+	p_property.overridden = false;
+}
+
+void DocData::method_doc_from_methodinfo(DocData::MethodDoc &p_method, const MethodInfo &p_methodinfo) {
+	p_method.name = p_methodinfo.name;
+	p_method.description = p_methodinfo.doc_string;
+
+	return_doc_from_retinfo(p_method, p_methodinfo.return_val);
+
+	for (int i = 0; i < p_methodinfo.arguments.size(); i++) {
+		ArgumentDoc argument;
+		argument_doc_from_arginfo(argument, p_methodinfo.arguments[i]);
+		int default_arg_index = i - (p_methodinfo.arguments.size() - p_methodinfo.default_arguments.size());
+		if (default_arg_index >= 0) {
+			Variant default_arg = p_methodinfo.default_arguments[default_arg_index];
+			argument.default_value = default_arg.get_construct_string();
+		}
+		p_method.arguments.push_back(argument);
+	}
+}
+
+void DocData::constant_doc_from_variant(DocData::ConstantDoc &p_const, const StringName &p_name, const Variant &p_value, const String &p_desc) {
+	p_const.name = p_name;
+	p_const.value = p_value;
+	p_const.description = p_desc;
+}
+
+void DocData::signal_doc_from_methodinfo(DocData::MethodDoc &p_signal, const MethodInfo &p_methodinfo) {
+	return method_doc_from_methodinfo(p_signal, p_methodinfo);
 }
 
 static Variant get_documentation_default_value(const StringName &p_class_name, const StringName &p_property_name, bool &r_default_value_valid) {

--- a/editor/doc_data.h
+++ b/editor/doc_data.h
@@ -35,6 +35,15 @@
 #include "core/map.h"
 #include "core/variant.h"
 
+struct ScriptMemberInfo {
+	PropertyInfo propinfo;
+	StringName setter;
+	StringName getter;
+
+	bool has_default_value = false;
+	Variant default_value;
+};
+
 class DocData {
 public:
 	struct ArgumentDoc {
@@ -99,6 +108,7 @@ public:
 		Vector<ConstantDoc> constants;
 		Vector<PropertyDoc> properties;
 		Vector<PropertyDoc> theme_properties;
+		bool is_script_doc = false;
 		bool operator<(const ClassDoc &p_class) const {
 			return name < p_class.name;
 		}
@@ -110,8 +120,18 @@ public:
 	Error _load(Ref<XMLParser> parser);
 
 public:
+	static void return_doc_from_retinfo(DocData::MethodDoc &p_method, const PropertyInfo &p_retinfo);
+	static void argument_doc_from_arginfo(DocData::ArgumentDoc &p_argument, const PropertyInfo &p_arginfo);
+	static void property_doc_from_scriptmemberinfo(DocData::PropertyDoc &p_property, const ScriptMemberInfo &p_memberinfo);
+	static void method_doc_from_methodinfo(DocData::MethodDoc &p_method, const MethodInfo &p_methodinfo);
+	static void constant_doc_from_variant(DocData::ConstantDoc &p_const, const StringName &p_name, const Variant &p_value, const String &p_desc);
+	static void signal_doc_from_methodinfo(DocData::MethodDoc &p_signal, const MethodInfo &p_methodinfo);
+
 	void merge_from(const DocData &p_data);
 	void remove_from(const DocData &p_data);
+	void add_doc(const ClassDoc &p_class_doc);
+	void remove_doc(const String &p_class_name);
+	bool has_doc(const String &p_class_name);
 	void generate(bool p_basic_types = false);
 	Error load_classes(const String &p_dir);
 	static Error erase_classes(const String &p_dir);

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -794,6 +794,12 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, DirAccess
 			}
 		}
 
+		// TODO-DOC: not sure about calling here like this. (may need to refector)
+		//           ResourceLoader::load() will call compile and reload script and it'll update the doc.
+		if (fc && fc->type == "GDScript") {
+			RES scr = ResourceLoader::load(path);
+		}
+
 		p_dir->files.push_back(fi);
 		p_progress.update(idx, total);
 	}

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -400,7 +400,7 @@ void EditorHelp::_update_doc() {
 	}
 
 	// Descendents
-	if (ClassDB::class_exists(cd.name)) {
+	if (cd.is_script_doc || ClassDB::class_exists(cd.name)) {
 		bool found = false;
 		bool prev = false;
 
@@ -1468,7 +1468,6 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 
 			pos = brk_end + 1;
 			tag_stack.push_front("font");
-
 		} else {
 			p_rt->add_text("["); //ignore
 			pos = brk_pos + 1;
@@ -1510,6 +1509,12 @@ void EditorHelp::go_to_help(const String &p_help) {
 
 void EditorHelp::go_to_class(const String &p_class, int p_scroll) {
 	_goto_desc(p_class, p_scroll);
+}
+
+void EditorHelp::update_doc() {
+	ERR_FAIL_COND(!doc->class_list.has(edited_class));
+	ERR_FAIL_COND(!doc->class_list[edited_class].is_script_doc);
+	_update_doc();
 }
 
 Vector<Pair<String, int>> EditorHelp::get_sections() {

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -173,6 +173,7 @@ public:
 
 	void go_to_help(const String &p_help);
 	void go_to_class(const String &p_class, int p_scroll = 0);
+	void update_doc();
 
 	Vector<Pair<String, int>> get_sections();
 	void scroll_to_section(int p_section_index);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2833,6 +2833,18 @@ void ScriptEditor::_help_class_goto(const String &p_desc) {
 	_save_layout();
 }
 
+void ScriptEditor::update_doc(const String &p_name) {
+	ERR_FAIL_COND(!EditorHelp::get_doc_data()->has_doc(p_name));
+
+	for (int i = 0; i < tab_container->get_child_count(); i++) {
+		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_child(i));
+		if (eh && eh->get_class() == p_name) {
+			eh->update_doc();
+			return;
+		}
+	}
+}
+
 void ScriptEditor::_update_selected_editor_menu() {
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 		bool current = tab_container->get_current_tab() == i;

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -479,6 +479,7 @@ public:
 	void close_builtin_scripts_from_scene(const String &p_scene);
 
 	void goto_help(const String &p_desc) { _help_class_goto(p_desc); }
+	void update_doc(const String &p_name);
 
 	bool can_take_away_focus() const;
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -39,6 +39,8 @@
 #include "core/os/file_access.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
+#include "editor/editor_help.h"
+#include "editor/plugins/script_editor_plugin.h"
 #include "gdscript_compiler.h"
 
 ///////////////////////////
@@ -202,7 +204,7 @@ void GDScript::_placeholder_erased(PlaceHolderScriptInstance *p_placeholder) {
 }
 #endif
 
-void GDScript::get_script_method_list(List<MethodInfo> *p_list) const {
+void GDScript::_get_script_method_list(List<MethodInfo> *r_list, bool p_include_base) const {
 	const GDScript *current = this;
 	while (current) {
 		for (const Map<StringName, GDScriptFunction *>::Element *E = current->member_functions.front(); E; E = E->next()) {
@@ -210,18 +212,35 @@ void GDScript::get_script_method_list(List<MethodInfo> *p_list) const {
 			MethodInfo mi;
 			mi.name = E->key();
 			for (int i = 0; i < func->get_argument_count(); i++) {
-				mi.arguments.push_back(func->get_argument_type(i));
+				PropertyInfo arginfo = func->get_argument_type(i);
+#if TOOLS_ENABLED
+				arginfo.name = func->get_argument_name(i);
+#endif
+				mi.arguments.push_back(arginfo);
 			}
 
 			mi.return_val = func->get_return_type();
-			p_list->push_back(mi);
+#if TOOLS_ENABLED
+			if (doc_functions.has(E->key())) {
+				mi.doc_string = doc_functions[E->key()];
+			}
+			mi.default_arguments = func->get_default_arg_values();
+#endif
+			r_list->push_back(mi);
+		}
+		if (!p_include_base) {
+			return;
 		}
 
 		current = current->_base;
 	}
 }
 
-void GDScript::get_script_property_list(List<PropertyInfo> *p_list) const {
+void GDScript::get_script_method_list(List<MethodInfo> *r_list) const {
+	_get_script_method_list(r_list, true);
+}
+
+void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_include_base) const {
 	const GDScript *sptr = this;
 	List<PropertyInfo> props;
 
@@ -240,13 +259,20 @@ void GDScript::get_script_property_list(List<PropertyInfo> *p_list) const {
 		for (int i = 0; i < msort.size(); i++) {
 			props.push_front(sptr->member_info[msort[i].name]);
 		}
+		if (!p_include_base) {
+			break;
+		}
 
 		sptr = sptr->_base;
 	}
 
 	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-		p_list->push_back(E->get());
+		r_list->push_back(E->get());
 	}
+}
+
+void GDScript::get_script_property_list(List<PropertyInfo> *r_list) const {
+	_get_script_property_list(r_list, true);
 }
 
 bool GDScript::has_method(const StringName &p_method) const {
@@ -352,6 +378,147 @@ void GDScript::_update_exports_values(Map<StringName, Variant> &values, List<Pro
 
 	for (List<PropertyInfo>::Element *E = members_cache.front(); E; E = E->next()) {
 		propnames.push_back(E->get());
+	}
+}
+
+void GDScript::_clear_doc() {
+	if (EditorHelp::get_doc_data() && EditorHelp::get_doc_data()->has_doc(doc.name)) {
+		EditorHelp::get_doc_data()->remove_doc(doc.name);
+		doc = DocData::ClassDoc();
+	}
+}
+
+void GDScript::_update_doc() {
+	_clear_doc();
+
+	if (name.length() != 0) {
+		doc.name = name;
+	} else {
+		doc.name = "\"" + get_path().get_slice("://", 1) + "\"";
+	}
+	if (_owner) {
+		doc.name = _owner->doc.name + "." + doc.name;
+	}
+
+	doc.is_script_doc = true;
+
+	if (base.is_valid() && base->is_valid()) {
+		if (base->doc.name != String()) {
+			doc.inherits = base->doc.name;
+		} else {
+			doc.inherits = base->get_instance_base_type();
+		}
+	} else if (native.is_valid()) {
+		doc.inherits = native->get_name();
+	}
+
+	doc.brief_description = doc_brief_description;
+	doc.description = doc_description;
+	doc.tutorials = doc_tutorials;
+
+	List<MethodInfo> methods;
+	_get_script_method_list(&methods, false);
+	for (int i = 0; i < methods.size(); i++) {
+		// Ignore private.
+		if (methods[i].name.begins_with("_") && methods[i].doc_string == String()) {
+			continue;
+		}
+
+		DocData::MethodDoc method_doc;
+		const String &class_name = methods[i].name;
+		if (member_functions.has(class_name)) {
+			GDScriptFunction *fn = member_functions[class_name];
+
+			// Change class name if return type is script reference.
+			GDScriptDataType return_type = fn->get_return_type();
+			if (return_type.kind == GDScriptDataType::GDSCRIPT) {
+				methods[i].return_val.class_name = _get_gdscript_reference_class_name(Object::cast_to<GDScript>(return_type.script_type.ptr()));
+			}
+
+			// Change class name if argumetn is script reference.
+			for (int j = 0; j < fn->get_argument_count(); j++) {
+				GDScriptDataType arg_type = fn->get_argument_type(j);
+				if (arg_type.kind == GDScriptDataType::GDSCRIPT) {
+					methods[i].arguments[j].class_name = _get_gdscript_reference_class_name(Object::cast_to<GDScript>(arg_type.script_type.ptr()));
+				}
+			}
+		}
+
+		DocData::method_doc_from_methodinfo(method_doc, methods[i]);
+		doc.methods.push_back(method_doc);
+	}
+
+	List<PropertyInfo> props;
+	_get_script_property_list(&props, false);
+	for (int i = 0; i < props.size(); i++) {
+		// Ignore private.
+		if (props[i].name.begins_with("_") && props[i].doc_string == String()) {
+			continue;
+		}
+
+		ScriptMemberInfo scr_member_info;
+		scr_member_info.propinfo = props[i];
+		scr_member_info.propinfo.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
+		if (member_indices.has(props[i].name)) {
+			const MemberInfo &mi = member_indices[props[i].name];
+			scr_member_info.setter = mi.setter;
+			scr_member_info.getter = mi.getter;
+			if (mi.data_type.kind == GDScriptDataType::GDSCRIPT) {
+				scr_member_info.propinfo.class_name = _get_gdscript_reference_class_name(
+						Object::cast_to<GDScript>(mi.data_type.script_type.ptr()));
+			}
+		}
+		if (member_default_values.has(props[i].name)) {
+			scr_member_info.has_default_value = true;
+			scr_member_info.default_value = member_default_values[props[i].name];
+		}
+
+		DocData::PropertyDoc prop_doc;
+		DocData::property_doc_from_scriptmemberinfo(prop_doc, scr_member_info);
+		doc.properties.push_back(prop_doc);
+	}
+
+	List<MethodInfo> signals;
+	_get_script_signal_list(&signals, false);
+	for (int i = 0; i < signals.size(); i++) {
+		DocData::MethodDoc signal_doc;
+		DocData::signal_doc_from_methodinfo(signal_doc, signals[i]);
+		doc.signals.push_back(signal_doc);
+	}
+
+	for (Map<StringName, Variant>::Element *E = constants.front(); E; E = E->next()) {
+		// Ignore private.
+		if (E->key().operator String().begins_with("_") && !doc_constants.has(E->key())) {
+			continue;
+		}
+
+		if (subclasses.has(E->key())) {
+			continue;
+		}
+
+		// TODO-DOC: enums are const Dictionary ??
+		DocData::ConstantDoc constant_doc;
+		String doc_description;
+		if (doc_constants.has(E->key())) {
+			doc_description = doc_constants[E->key()];
+		}
+		DocData::constant_doc_from_variant(constant_doc, E->key(), E->value(), doc_description);
+		doc.constants.push_back(constant_doc);
+	}
+
+	for (Map<StringName, Ref<GDScript>>::Element *E = subclasses.front(); E; E = E->next()) {
+		// Ignore private.
+		if (E->key().operator String().begins_with("_") && E->get()->doc_brief_description == "" && E->get()->doc_description == "") {
+			continue;
+		}
+		E->get()->_update_doc();
+	}
+
+	if (EditorHelp::get_doc_data()) {
+		EditorHelp::get_doc_data()->add_doc(doc);
+	}
+	if (ScriptEditor::get_singleton()) {
+		ScriptEditor::get_singleton()->update_doc(doc.name);
 	}
 }
 #endif
@@ -568,6 +735,10 @@ Error GDScript::reload(bool p_keep_state) {
 
 	GDScriptCompiler compiler;
 	err = compiler.compile(&parser, this, p_keep_state);
+
+#if TOOLS_ENABLED
+	this->_update_doc();
+#endif
 
 	if (err) {
 		if (can_run) {
@@ -913,7 +1084,7 @@ bool GDScript::has_script_signal(const StringName &p_signal) const {
 	return false;
 }
 
-void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
+void GDScript::_get_script_signal_list(List<MethodInfo> *r_list, bool p_include_base) const {
 	for (const Map<StringName, Vector<StringName>>::Element *E = _signals.front(); E; E = E->next()) {
 		MethodInfo mi;
 		mi.name = E->key();
@@ -922,18 +1093,45 @@ void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
 			arg.name = E->get()[i];
 			mi.arguments.push_back(arg);
 		}
-		r_signals->push_back(mi);
+#if TOOLS_ENABLED
+		if (doc_signals.has(E->key())) {
+			mi.doc_string = doc_signals[E->key()];
+		}
+#endif
+		r_list->push_back(mi);
+	}
+
+	if (!p_include_base) {
+		return;
 	}
 
 	if (base.is_valid()) {
-		base->get_script_signal_list(r_signals);
+		base->get_script_signal_list(r_list);
 	}
 #ifdef TOOLS_ENABLED
 	else if (base_cache.is_valid()) {
-		base_cache->get_script_signal_list(r_signals);
+		base_cache->get_script_signal_list(r_list);
 	}
-
 #endif
+}
+
+void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
+	_get_script_signal_list(r_signals, true);
+}
+
+String GDScript::_get_gdscript_reference_class_name(const GDScript *p_gdscript) {
+	ERR_FAIL_NULL_V(p_gdscript, String());
+
+	String class_name;
+	while (p_gdscript) {
+		if (class_name == "") {
+			class_name = p_gdscript->get_script_class_name();
+		} else {
+			class_name = p_gdscript->get_script_class_name() + "." + class_name;
+		}
+		p_gdscript = p_gdscript->_owner;
+	}
+	return class_name;
 }
 
 GDScript::GDScript() :
@@ -1054,7 +1252,12 @@ GDScript::~GDScript() {
 	for (Map<StringName, GDScriptFunction *>::Element *E = member_functions.front(); E; E = E->next()) {
 		memdelete(E->get());
 	}
-
+#ifdef TOOLS_ENABLED
+	// Clearing inner class doc, script doc only cleared when the script source deleted.
+	if (_owner) {
+		_clear_doc();
+	}
+#endif
 	_save_orphaned_subclasses();
 
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -36,6 +36,7 @@
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/script_language.h"
+#include "editor/doc_data.h"
 #include "gdscript_function.h"
 
 class GDScriptNativeClass : public Reference {
@@ -101,6 +102,16 @@ class GDScript : public Script {
 	bool placeholder_fallback_enabled;
 	void _update_exports_values(Map<StringName, Variant> &values, List<PropertyInfo> &propnames);
 
+	DocData::ClassDoc doc;
+	String doc_brief_description;
+	String doc_description;
+	Vector<DocData::TutorialDoc> doc_tutorials;
+	Map<String, String> doc_functions;
+	Map<String, String> doc_constants;
+	Map<String, String> doc_signals;
+	void _clear_doc();
+	void _update_doc();
+
 #endif
 	Map<StringName, PropertyInfo> member_info;
 
@@ -137,6 +148,15 @@ class GDScript : public Script {
 
 	void _save_orphaned_subclasses();
 	void _init_rpc_methods_properties();
+
+	void _get_script_property_list(List<PropertyInfo> *r_list, bool p_include_base) const;
+	void _get_script_method_list(List<MethodInfo> *r_list, bool p_include_base) const;
+	void _get_script_signal_list(List<MethodInfo> *r_list, bool p_include_base) const;
+
+	// returns the class name of script reference
+	// if GDScript class is a script -> class_name is "Reference"
+	// which will set the name as MyClass.InnerClass
+	static String _get_gdscript_reference_class_name(const GDScript *p_gdscript);
 
 protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -262,6 +262,7 @@ private:
 
 #ifdef TOOLS_ENABLED
 	Vector<StringName> arg_names;
+	Vector<Variant> default_arg_values;
 #endif
 
 	List<StackDebug> stack_debug;
@@ -341,6 +342,11 @@ public:
 		ERR_FAIL_INDEX_V(p_idx, default_arguments.size(), Variant());
 		return default_arguments[p_idx];
 	}
+#ifdef TOOLS_ENABLED
+	const Vector<Variant> &get_default_arg_values() const {
+		return default_arg_values;
+	}
+#endif // TOOLS_ENABLED
 
 	Variant call(GDScriptInstance *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err, CallState *p_state = nullptr);
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -146,6 +146,11 @@ public:
 		Vector<StringName> extends_class;
 		DataType base_type;
 		String icon_path;
+#ifdef TOOLS_ENABLED
+		String doc_description;
+		String doc_brief_description;
+		Vector<Pair<String, String>> doc_tutorials;
+#endif // TOOLS_ENABLED
 
 		struct Member {
 			PropertyInfo _export;
@@ -156,6 +161,9 @@ public:
 			DataType data_type;
 			StringName setter;
 			StringName getter;
+#ifdef TOOLS_ENABLED
+			String doc_description;
+#endif // TOOLS_ENABLED
 			int line;
 			Node *expression;
 			OperatorNode *initial_assignment;
@@ -166,11 +174,17 @@ public:
 		struct Constant {
 			Node *expression;
 			DataType type;
+#ifdef TOOLS_ENABLED
+			String doc_description;
+#endif // TOOLS_ENABLED
 		};
 
 		struct Signal {
 			StringName name;
 			Vector<StringName> arguments;
+#ifdef TOOLS_ENABLED
+			String doc_description;
+#endif // TOOLS_ENABLED
 			int emissions;
 			int line;
 		};
@@ -207,6 +221,10 @@ public:
 		Vector<StringName> arguments;
 		Vector<DataType> argument_types;
 		Vector<Node *> default_values;
+#ifdef TOOLS_ENABLED
+		Vector<Variant> default_arg_values;
+		String doc_description;
+#endif // TOOLS_ENABLED
 		BlockNode *body;
 #ifdef DEBUG_ENABLED
 		Vector<int> arguments_usage;
@@ -547,6 +565,10 @@ private:
 	List<GDScriptWarning> warnings;
 #endif // DEBUG_ENABLED
 
+#ifdef TOOLS_ENABLED
+	Map<int, GDScriptTokenizer::CommentData> comments;
+#endif // TOOLS_ENABLED
+
 	int pending_newline;
 
 	struct IndentLevel {
@@ -655,6 +677,11 @@ private:
 		}
 #endif // DEBUG_ENABLED
 	}
+
+#ifdef TOOLS_ENABLED
+	String _pop_doc_comment(int p_line);
+	void _pop_class_doc_comment(int p_line, String &p_brief, String &p_desc, Vector<Pair<String, String>> &p_tutorials, bool p_subclass);
+#endif // TOOLS_ENABLED
 
 	Error _parse(const String &p_base_path);
 

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -503,13 +503,13 @@ void GDScriptTokenizerText::_advance() {
 				INCPOS(1);
 				continue;
 			case '#': { // line comment skip
-#ifdef DEBUG_ENABLED
+#if defined(TOOLS_ENABLED) || defined(DEBUG_ENABLED)
 				String comment;
-#endif // DEBUG_ENABLED
+#endif
 				while (GETCHAR(0) != '\n') {
-#ifdef DEBUG_ENABLED
+#if defined(TOOLS_ENABLED) || defined(DEBUG_ENABLED)
 					comment += GETCHAR(0);
-#endif // DEBUG_ENABLED
+#endif
 					code_pos++;
 					if (GETCHAR(0) == 0) { //end of file
 						//_make_error("Unterminated Comment");
@@ -517,6 +517,11 @@ void GDScriptTokenizerText::_advance() {
 						return;
 					}
 				}
+
+#ifdef TOOLS_ENABLED
+				comments[line] = CommentData(comment, tk_rb_pos == 0 || tk_rb[tk_rb_pos - 1].type == Token::TK_NEWLINE);
+#endif // TOOLS_ENABLED
+
 #ifdef DEBUG_ENABLED
 				String comment_content = comment.trim_prefix("#").trim_prefix(" ");
 				if (comment_content.begins_with("warning-ignore:")) {

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -31,6 +31,7 @@
 #ifndef GDSCRIPT_TOKENIZER_H
 #define GDSCRIPT_TOKENIZER_H
 
+#include "core/map.h"
 #include "core/pair.h"
 #include "core/set.h"
 #include "core/string_name.h"
@@ -176,6 +177,19 @@ public:
 	virtual bool is_ignoring_warnings() const = 0;
 #endif // DEBUG_ENABLED
 
+#ifdef TOOLS_ENABLED
+	struct CommentData {
+		String comment;
+		bool new_line = false;
+		CommentData() {}
+		CommentData(const String &p_comment, bool p_new_line) {
+			comment = p_comment;
+			new_line = p_new_line;
+		}
+	};
+	virtual const Map<int, CommentData> &get_comments() const = 0;
+#endif // TOOLS_ENABLED
+
 	virtual ~GDScriptTokenizer() {}
 };
 
@@ -228,6 +242,10 @@ class GDScriptTokenizerText : public GDScriptTokenizer {
 	bool ignore_warnings;
 #endif // DEBUG_ENABLED
 
+#ifdef TOOLS_ENABLED
+	Map<int, CommentData> comments;
+#endif // TOOLS_ENABLED
+
 	void _advance();
 
 public:
@@ -248,6 +266,10 @@ public:
 	virtual const Set<String> &get_warning_global_skips() const { return warning_global_skips; }
 	virtual bool is_ignoring_warnings() const { return ignore_warnings; }
 #endif // DEBUG_ENABLED
+
+#ifdef TOOLS_ENABLED
+	virtual const Map<int, CommentData> &get_comments() const { return comments; }
+#endif // TOOLS_ENABLED
 };
 
 class GDScriptTokenizerBuffer : public GDScriptTokenizer {
@@ -292,6 +314,14 @@ public:
 	}
 	virtual bool is_ignoring_warnings() const { return true; }
 #endif // DEBUG_ENABLED
+
+#ifdef TOOLS_ENABLED
+	virtual const Map<int, CommentData> &get_comments() const {
+		static Map<int, CommentData> m;
+		return m;
+	}
+#endif
+
 	GDScriptTokenizerBuffer();
 };
 


### PR DESCRIPTION
Documentation system for GDScript (a part of my GSoC 2020 project)

for more information / any suggestion I've opened a proposal on this at: https://github.com/godotengine/godot-proposals/issues/993

It will extract all the static type/reflection information from the parse tree and the description, brief description, tutorials, links etc, from "doc comments" (comments starting with `## ` and right before any property) and generate a ClassDoc every time the script reloads (saved) and display on the editor helper. also it currently support autocompletion at new line and indentation inside doc string. 

![doc](https://user-images.githubusercontent.com/41085900/83963729-bb24db80-a8c5-11ea-9e30-d0ad2340da72.gif)
