### PR TITLE
Fix PlaneShape in Godot physics

### DIFF
--- a/servers/physics_3d/collision_solver_3d_sw.cpp
+++ b/servers/physics_3d/collision_solver_3d_sw.cpp
@@ -461,7 +461,7 @@ bool CollisionSolver3DSW::solve_distance_plane(const Shape3DSW *p_shape_A, const
 		if (i == 0 || d < closest_d) {
 			closest = supports[i];
 			closest_d = d;
-			if (d <= 0) {
+			if (d < 0) {
 				collided = true;
 			}
 		}

--- a/servers/physics_3d/collision_solver_3d_sw.cpp
+++ b/servers/physics_3d/collision_solver_3d_sw.cpp
@@ -76,6 +76,12 @@ bool CollisionSolver3DSW::solve_static_plane(const Shape3DSW *p_shape_A, const T
 		found = true;
 
 		Vector3 support_A = p.project(supports[i]);
+		if (p_shape_B->get_type() == PhysicsServer3D::SHAPE_RAY) {
+			const RayShape3DSW *ray = static_cast<const RayShape3DSW *>(p_shape_B);
+			if (!ray->get_slips_on_slope()) {
+				plane->get_plane().intersects_ray(p_transform_B.origin, p_transform_B.basis.get_axis(2), &support_A);
+			}
+		}
 
 		if (p_result_callback) {
 			if (p_swap_result) {
@@ -345,9 +351,6 @@ bool CollisionSolver3DSW::solve_static(const Shape3DSW *p_shape_A, const Transfo
 
 	if (type_A == PhysicsServer3D::SHAPE_PLANE) {
 		if (type_B == PhysicsServer3D::SHAPE_PLANE) {
-			return false;
-		}
-		if (type_B == PhysicsServer3D::SHAPE_RAY) {
 			return false;
 		}
 		if (type_B == PhysicsServer3D::SHAPE_SOFT_BODY) {

--- a/servers/physics_3d/shape_3d_sw.cpp
+++ b/servers/physics_3d/shape_3d_sw.cpp
@@ -1720,3 +1720,13 @@ HeightMapShape3DSW::HeightMapShape3DSW() {
 	depth = 0;
 	cell_size = 0;
 }
+
+void MotionShape3DSW::get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const {
+	shape->get_supports(p_normal, p_max, r_supports, r_amount, r_type);
+
+	for (int i = 0; i < r_amount; i++) {
+		r_supports[i + r_amount] = r_supports[i] + motion;
+	}
+
+	r_amount *= 2;
+}

--- a/servers/physics_3d/shape_3d_sw.h
+++ b/servers/physics_3d/shape_3d_sw.h
@@ -473,7 +473,7 @@ struct MotionShape3DSW : public Shape3DSW {
 		}
 		return support;
 	}
-	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const { r_amount = 0; }
+	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const;
 	bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal) const { return false; }
 	virtual bool intersect_point(const Vector3 &p_point) const { return false; }
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const { return p_point; }


### PR DESCRIPTION
Fixes Godot physics part of #5910.

The Bullet physics part is fixed in #35945.

*BugSquad edit*: fixes #5910