### PR TITLE
Replace all flags with one value when holding Ctrl/Cmd in the layers editor

### DIFF
--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -264,7 +264,7 @@ private:
 	bool expand_hovered = false;
 	bool expanded = false;
 	int expansion_rows = 0;
-	int hovered_index = -1;
+	uint32_t hovered_index = INT32_MAX; // Nothing is hovered.
 	bool read_only = false;
 	int renamed_layer_index = -1;
 	PopupMenu *layer_rename = nullptr;
@@ -275,7 +275,7 @@ private:
 	void _rename_operation_confirm();
 	void _update_hovered(const Vector2 &p_position);
 	void _on_hover_exit();
-	void _update_flag();
+	void _update_flag(bool p_replace);
 	Size2 get_grid_size() const;
 
 protected:
@@ -285,7 +285,7 @@ protected:
 public:
 	uint32_t value = 0;
 	int layer_group_size = 0;
-	int layer_count = 0;
+	uint32_t layer_count = 0;
 	Vector<String> names;
 	Vector<String> tooltips;
 


### PR DESCRIPTION
This behavior is inspired by Blender (except it's the other way around to preserve the current default behavior).

Trying to enable a single enabled value with <kbd>Cmd</kbd> held will invert the current flags, which makes enabling all flags but one faster.

## Preview

*On the GIF below, at first, I'm checking boxes as usual, then I hold down <kbd>Ctrl</kbd> (<kbd>Cmd</kbd> on macOS) to replace existing values.*

![file](https://user-images.githubusercontent.com/180032/83969850-908d4f80-a8d2-11ea-9e09-d5079357f205.gif)

<details>
<summary>June 2021 patch</summary>

```patch
From 5155ff04b1615d809051565cbd9b2a04cdccf8b1 Mon Sep 17 00:00:00 2001
From: Hugo Locurcio <hugo.locurcio@hugo.pro>
Date: Sun, 7 Jun 2020 15:14:18 +0200
Subject: [PATCH] Replace all flags with one value when holding Cmd in the
 layers editor

This behavior is inspired by Blender (except it's the other way
around to preserve the current default behavior).

Trying to enable a single enabled value with Cmd held will invert the
current flags, which makes enabling all flags but one faster.
---
 editor/editor_properties.cpp | 27 ++++++++++++++++++++-------
 1 file changed, 20 insertions(+), 7 deletions(-)

diff --git a/editor/editor_properties.cpp b/editor/editor_properties.cpp
index 84105f0cb733..f7b123219e09 100644
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -590,7 +590,8 @@ class EditorPropertyLayersGrid : public Control {
 	Vector<Rect2> flag_rects;
 	Vector<String> names;
 	Vector<String> tooltips;
-	int hovered_index;
+	// Set to `INT32_MAX` when nothing is hovered.
+	uint32_t hovered_index;
 
 	virtual Size2 get_minimum_size() const override {
 		Ref<Font> font = get_theme_font("font", "Label");
@@ -625,10 +626,22 @@ class EditorPropertyLayersGrid : public Control {
 		if (mb.is_valid() && mb->get_button_index() == MOUSE_BUTTON_LEFT && mb->is_pressed() && hovered_index >= 0) {
 			// Toggle the flag.
 			// We base our choice on the hovered flag, so that it always matches the hovered flag.
-			if (value & (1 << hovered_index)) {
-				value &= ~(1 << hovered_index);
+			if (mb->is_command_pressed()) {
+				// Holding Command will replace all flags with the hovered flag ("solo mode"),
+				// instead of toggling the hovered flags while preserving other flags's state.
+				if (value == 1 << hovered_index) {
+					// If the flag is already enbled, enable all other items and disable the current flag.
+					// This allows for quicker toggling.
+					value = INT32_MAX - (1 << hovered_index);
+				} else {
+					value = 1 << hovered_index;
+				}
 			} else {
-				value |= (1 << hovered_index);
+				if (value & (1 << hovered_index)) {
+					value &= ~(1 << hovered_index);
+				} else {
+					value |= (1 << hovered_index);
+				}
 			}
 
 			emit_signal("flag_changed", value);
@@ -661,7 +674,7 @@ class EditorPropertyLayersGrid : public Control {
 							o.x += 1;
 						}
 
-						const int idx = i * 10 + j;
+						const uint32_t idx = i * 10 + j;
 						const bool on = value & (1 << idx);
 						Rect2 rect2 = Rect2(o, Size2(bsize, bsize));
 
@@ -677,7 +690,7 @@ class EditorPropertyLayersGrid : public Control {
 				}
 			} break;
 			case NOTIFICATION_MOUSE_EXIT: {
-				hovered_index = -1;
+				hovered_index = INT32_MAX; // Nothing is hovered.
 				update();
 			} break;
 			default:
@@ -697,7 +710,7 @@ class EditorPropertyLayersGrid : public Control {
 
 	EditorPropertyLayersGrid() {
 		value = 0;
-		hovered_index = -1; // Nothing is hovered.
+		hovered_index = INT32_MAX; // Nothing is hovered.
 	}
 };
 void EditorPropertyLayers::_grid_changed(uint32_t p_grid) {

```
</details>