### PR TITLE
Add an editor tooltip to document gizmo visibility options

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5397,6 +5397,9 @@ void Node3DEditor::_update_gizmos_menu() {
 		const int plugin_state = gizmo_plugins_by_name[i]->get_state();
 		gizmos_menu->add_multistate_item(TTR(plugin_name), 3, plugin_state, i);
 		const int idx = gizmos_menu->get_item_index(i);
+		gizmos_menu->set_item_tooltip(
+				idx,
+				TTR("Click to toggle between visibility states.\n\nOpen eye: Gizmo is visible.\nClosed eye: Gizmo is hidden.\nHalf-open eye: Gizmo is also visible through opaque surfaces (\"x-ray\")."));
 		switch (plugin_state) {
 			case EditorNode3DGizmoPlugin::VISIBLE:
 				gizmos_menu->set_item_icon(idx, gizmos_menu->get_theme_icon("visibility_visible"));


### PR DESCRIPTION
See discussion in https://github.com/godotengine/godot-proposals/issues/716.

## Preview

*Note: The screenshot below is from the `3.2` branch, as tooltips in PopupMenus are never shown due to a DisplayServer regression.*

![image](https://user-images.githubusercontent.com/180032/83971176-33959780-a8da-11ea-8880-0d568afc01ad.png)
