### PR TITLE
Change the default editor camera rotation to position it in +X +Y +Z

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3419,11 +3419,7 @@ void Node3DEditorViewport::reset() {
 	last_message = "";
 	name = "";
 
-	cursor.x_rot = 0.5;
-	cursor.y_rot = 0.5;
-	cursor.distance = 4;
-	cursor.region_select = false;
-	cursor.pos = Vector3();
+	cursor = Cursor();
 	_update_name();
 }
 

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -391,7 +391,9 @@ private:
 		Point2 region_begin, region_end;
 
 		Cursor() {
-			x_rot = y_rot = 0.5;
+			// These rotations place the camera in +X +Y +Z, aka south east, facing north west.
+			x_rot = 0.5;
+			y_rot = -0.5;
 			distance = 4;
 			region_select = false;
 		}


### PR DESCRIPTION
This is nitpicking, but I think it's an improvement.

Since we now have a transform gizmo in the corner of the screen, I think it makes sense to have the default editor camera positioned in +X +Y +Z, such that the default orientation has all of the axes pointing towards the camera. This also may make it easier to use the transform gizmo when opening a new scene, since all gizmos are closer to the camera and facing towards it. Old behavior:

![old](https://user-images.githubusercontent.com/1646875/83976142-38505080-a8c6-11ea-9496-80bfbcf40391.png)

New behavior with this PR:

![new](https://user-images.githubusercontent.com/1646875/83976145-3b4b4100-a8c6-11ea-909b-053dde2d4e45.png)

With this PR, the camera starts in +X +Y +Z (south east) and faces towards the origin (north west). 

Also, I simplified the code in the `cpp` file to use the constructor instead of resetting all fields.