### PR TITLE
Document enlarging Particles visibility AABB when they cast shadows

### DIFF
--- a/doc/classes/Particles.xml
+++ b/doc/classes/Particles.xml
@@ -103,6 +103,7 @@
 		</member>
 		<member name="visibility_aabb" type="AABB" setter="set_visibility_aabb" getter="get_visibility_aabb" default="AABB( -4, -4, -4, 8, 8, 8 )">
 			The [AABB] that determines the area of the world part of which needs to be visible on screen for the particle system to be active.
+			[b]Note:[/b] If the [ParticlesMaterial] in use is configured to cast shadows, you may want to enlarge this AABB to ensure the shadow is updated when particles are off-screen.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
**Note:** I opened this directly against the `3.2` branch as GPU particles are temporarily absent from the `master` branch.

___

This closes https://github.com/godotengine/godot/issues/17267. Adjusting the visibility AABB to take shadows into account is probably too difficult (and maybe inefficient), so documenting this behavior should work well enough.