### PR TITLE
PackedScene: Prevent crash when root node has `parent` attribute

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -903,19 +903,19 @@ void EditorNode::_dialog_display_load_error(String p_file, Error p_error) {
 	if (p_error) {
 		switch (p_error) {
 			case ERR_CANT_OPEN: {
-				show_accept(vformat(TTR("Can't open '%s'. The file could have been moved or deleted."), p_file.get_file()), TTR("OK"));
+				show_accept(vformat(TTR("Can't open file '%s'. The file could have been moved or deleted."), p_file.get_file()), TTR("OK"));
 			} break;
 			case ERR_PARSE_ERROR: {
-				show_accept(vformat(TTR("Error while parsing '%s'."), p_file.get_file()), TTR("OK"));
+				show_accept(vformat(TTR("Error while parsing file '%s'."), p_file.get_file()), TTR("OK"));
 			} break;
 			case ERR_FILE_CORRUPT: {
-				show_accept(vformat(TTR("Unexpected end of file '%s'."), p_file.get_file()), TTR("OK"));
+				show_accept(vformat(TTR("Scene file '%s' appears to be invalid/corrupt."), p_file.get_file()), TTR("OK"));
 			} break;
 			case ERR_FILE_NOT_FOUND: {
-				show_accept(vformat(TTR("Missing '%s' or its dependencies."), p_file.get_file()), TTR("OK"));
+				show_accept(vformat(TTR("Missing file '%s' or one its dependencies."), p_file.get_file()), TTR("OK"));
 			} break;
 			default: {
-				show_accept(vformat(TTR("Error while loading '%s'."), p_file.get_file()), TTR("OK"));
+				show_accept(vformat(TTR("Error while loading file '%s'."), p_file.get_file()), TTR("OK"));
 			} break;
 		}
 	}
@@ -3254,13 +3254,13 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 
 	if (!new_scene) {
 		sdata.unref();
-		_dialog_display_load_error(lpath, ERR_FILE_NOT_FOUND);
+		_dialog_display_load_error(lpath, ERR_FILE_CORRUPT);
 		opening_prev = false;
 		if (prev != -1) {
 			set_current_scene(prev);
 			editor_data.remove_scene(idx);
 		}
-		return ERR_FILE_NOT_FOUND;
+		return ERR_FILE_CORRUPT;
 	}
 
 	if (p_set_inherited) {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -98,6 +98,9 @@ Node *SceneState::instance(GenEditState p_edit_state) const {
 			}
 #endif
 			parent = nparent;
+		} else {
+			// i == 0 is root node. Confirm that it doesn't have a parent defined.
+			ERR_FAIL_COND_V_MSG(n.parent != -1, nullptr, vformat("Invalid scene: root node %s cannot specify a parent node.", snames[n.name]));
 		}
 
 		Node *node = nullptr;


### PR DESCRIPTION
The crash happens further down when setting an invalid owner in
`Node::_set_owner_nocheck` but I couldn't figure out how to fix it.

But here the proper fix is to catch the invalid scene file early on
and fail loading it.

Part of #17372.

---

PoC:
```ini
[gd_scene format=2]

[node name="Node2D" type="Node2D" parent="Node3D"]
position = Vector2( 20, 5 )

[node name="Node3D" type="Node3D" parent="."]
script = null
```

Backtrace without this PR:
```
Thread 1 "godot-git" received signal SIGSEGV, Segmentation fault.
0x0000000001a1d09b in List<Node*, DefaultAllocator>::push_back (this=0xffffa2b0, value=@0x7fffffffa0c8: 0x1385d8c0) at ./core/list.h:206
206                     if (!_data) {
(gdb) bt
#0  0x0000000001a1d09b in List<Node*, DefaultAllocator>::push_back (this=0xffffa2b0, value=@0x7fffffffa0c8: 0x1385d8c0) at ./core/list.h:206
#1  0x00000000035ffa6b in Node::_set_owner_nocheck (this=0x1385d8c0, p_owner=0xffffa110) at scene/main/node.cpp:1555
#2  0x0000000003dc4418 in SceneState::instance (this=0x14181b20, p_edit_state=SceneState::GEN_EDIT_STATE_MAIN) at scene/resources/packed_scene.cpp:282
#3  0x0000000003dceaec in PackedScene::instance (this=0x14a96160, p_edit_state=PackedScene::GEN_EDIT_STATE_MAIN) at scene/resources/packed_scene.cpp:1630
#4  0x0000000002b7d66b in EditorNode::load_scene (this=0x7e541f0, p_scene=..., p_ignore_broken_deps=false, p_set_inherited=false, p_clear_errors=true, p_force_open_imported=false) at editor/editor_node.cpp:3253
#5  0x0000000002b7de87 in EditorNode::open_request (this=0x7e541f0, p_path=...) at editor/editor_node.cpp:3313
#6  0x0000000002cc90e1 in FileSystemDock::_select_file (this=0xcbba840, p_path=..., p_select_in_favorites=false) at editor/filesystem_dock.cpp:845
#7  0x0000000002cc93a8 in FileSystemDock::_tree_activate_file (this=0xcbba840) at editor/filesystem_dock.cpp:864
#8  0x0000000002cec024 in call_with_variant_args_helper<FileSystemDock>(FileSystemDock*, void (FileSystemDock::*)(), Variant const**, Callable::CallError&, IndexSequence<>) (p_instance=0xcbba840, 
    p_method=(void (FileSystemDock::*)(FileSystemDock * const)) 0x2cc917a <FileSystemDock::_tree_activate_file()>, p_args=0x7fffffffae60, r_error=...) at ./core/callable_method_pointer.h:132
#9  0x0000000002ceb751 in call_with_variant_args<FileSystemDock> (p_instance=0xcbba840, p_method=(void (FileSystemDock::*)(FileSystemDock * const)) 0x2cc917a <FileSystemDock::_tree_activate_file()>, 
    p_args=0x7fffffffae60, p_argcount=0, r_error=...) at ./core/callable_method_pointer.h:157
#10 0x0000000002ceb052 in CallableCustomMethodPointer<FileSystemDock>::call (this=0xcc73ae0, p_arguments=0x7fffffffae60, p_argcount=0, r_return_value=..., r_call_error=...)
    at ./core/callable_method_pointer.h:184
#11 0x00000000044e03b1 in Callable::call (this=0x14939dc8, p_arguments=0x7fffffffae60, p_argcount=0, r_return_value=..., r_call_error=...) at core/callable.cpp:49
#12 0x000000000456d588 in Object::emit_signal (this=0xcc277d0, p_name=..., p_args=0x7fffffffae60, p_argcount=0) at core/object.cpp:1169
#13 0x000000000456dc39 in Object::emit_signal (this=0xcc277d0, p_name=..., p_arg1=..., p_arg2=..., p_arg3=..., p_arg4=..., p_arg5=...) at core/object.cpp:1224
#14 0x00000000038970d7 in Tree::_gui_input (this=0xcc277d0, p_event=...) at scene/gui/tree.cpp:2603
#15 0x0000000002e246bc in MethodBind1<Ref<InputEvent> >::call (this=0x76b6810, p_object=0xcc277d0, p_args=0x7fffffffb9f0, p_arg_count=1, r_error=...) at ./core/method_bind.gen.inc:775
#16 0x000000000456aeb8 in Object::call_multilevel (this=0xcc277d0, p_method=..., p_args=0x7fffffffb9f0, p_argcount=1) at core/object.cpp:737
#17 0x000000000456b615 in Object::call_multilevel (this=0xcc277d0, p_name=..., p_arg1=..., p_arg2=..., p_arg3=..., p_arg4=..., p_arg5=...) at core/object.cpp:835
#18 0x000000000364f32d in Viewport::_gui_call_input (this=0x7ceeee0, p_control=0xcc277d0, p_input=...) at scene/main/viewport.cpp:1610
#19 0x00000000036502d8 in Viewport::_gui_input_event (this=0x7ceeee0, p_event=...) at scene/main/viewport.cpp:1867
#20 0x00000000036569c3 in Viewport::input (this=0x7ceeee0, p_event=..., p_local_coords=false) at scene/main/viewport.cpp:2921
#21 0x0000000003682280 in Window::_window_input (this=0x7ceeee0, p_ev=...) at scene/main/window.cpp:885
#22 0x000000000369958f in call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul> (p_instance=0x7ceeee0, p_method=
    (void (Window::*)(Window * const, const Ref<InputEvent> &)) 0x3681fb4 <Window::_window_input(Ref<InputEvent> const&)>, p_args=0x7fffffffcaf8, r_error=...) at ./core/callable_method_pointer.h:132
#23 0x0000000003698f61 in call_with_variant_args<Window, Ref<InputEvent> const&> (p_instance=0x7ceeee0, p_method=
    (void (Window::*)(Window * const, const Ref<InputEvent> &)) 0x3681fb4 <Window::_window_input(Ref<InputEvent> const&)>, p_args=0x7fffffffcaf8, p_argcount=1, r_error=...)
    at ./core/callable_method_pointer.h:157
#24 0x0000000003697bf8 in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call (this=0x13ca5760, p_arguments=0x7fffffffcaf8, p_argcount=1, r_return_value=..., r_call_error=...)
    at ./core/callable_method_pointer.h:184
#25 0x00000000044e03b1 in Callable::call (this=0x7fffffffcab0, p_arguments=0x7fffffffcaf8, p_argcount=1, r_return_value=..., r_call_error=...) at core/callable.cpp:49
#26 0x00000000019f4828 in DisplayServerX11::_dispatch_input_event (this=0x6cb7a00, p_event=...) at platform/linuxbsd/display_server_x11.cpp:2302
#27 0x00000000019f4695 in DisplayServerX11::_dispatch_input_events (p_event=...) at platform/linuxbsd/display_server_x11.cpp:2285
#28 0x00000000047b6345 in Input::_parse_input_event_impl (this=0x6c3c730, p_event=..., p_is_emulated=false) at core/input/input.cpp:614
#29 0x00000000047b526e in Input::parse_input_event (this=0x6c3c730, p_event=...) at core/input/input.cpp:439
#30 0x00000000047b754a in Input::flush_accumulated_events (this=0x6c3c730) at core/input/input.cpp:829
#31 0x00000000019f7b70 in DisplayServerX11::process_events (this=0x6cb7a00) at platform/linuxbsd/display_server_x11.cpp:2966
#32 0x00000000019e5c74 in OS_LinuxBSD::run (this=0x7fffffffd3a0) at platform/linuxbsd/os_linuxbsd.cpp:237
#33 0x00000000019e39ac in main (argc=2, argv=0x7fffffffd8a8) at platform/linuxbsd/godot_linuxbsd.cpp:55
```

I'm not sure how `List::push_back` can segfault here on `if (!_data)`, if `_data` is a `nullptr` this should return `true` and alkocate `_data`.