### PR TITLE
Core: Add hints to run with --verbose when leaking nodes/resources at exit

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -2038,7 +2038,7 @@ void ObjectDB::cleanup() {
 	if (slot_count > 0) {
 		spin_lock.lock();
 
-		WARN_PRINT("ObjectDB Instances still exist!");
+		WARN_PRINT("ObjectDB instances leaked at exit (run with --verbose for details).");
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			for (uint32_t i = 0; i < slot_count; i++) {
 				uint32_t slot = object_slots[i].next_free;
@@ -2049,12 +2049,13 @@ void ObjectDB::cleanup() {
 					node_name = " - Node name: " + String(obj->call("get_name"));
 				}
 				if (obj->is_class("Resource")) {
-					node_name = " - Resource name: " + String(obj->call("get_name")) + " Path: " + String(obj->call("get_path"));
+					node_name = " - Resource path: " + String(obj->call("get_path"));
 				}
 
 				uint64_t id = uint64_t(slot) | (uint64_t(object_slots[slot].validator) << OBJECTDB_VALIDATOR_BITS) | (object_slots[slot].is_reference ? OBJECTDB_REFERENCE_BIT : 0);
 				print_line("Leaked instance: " + String(obj->get_class()) + ":" + itos(id) + node_name);
 			}
+			print_line("Hint: Leaked instances typically happen when nodes are removed from the scene tree (with `remove_child()`) but not freed (with `free()` or `queue_free()`).");
 		}
 		spin_lock.unlock();
 	}

--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -33,6 +33,7 @@
 #include "core/core_string_names.h"
 #include "core/io/resource_loader.h"
 #include "core/os/file_access.h"
+#include "core/os/os.h"
 #include "core/script_language.h"
 #include "scene/main/node.h" //only so casting works
 
@@ -431,7 +432,14 @@ void ResourceCache::setup() {
 
 void ResourceCache::clear() {
 	if (resources.size()) {
-		ERR_PRINT("Resources Still in use at Exit!");
+		ERR_PRINT("Resources still in use at exit (run with --verbose for details).");
+		if (OS::get_singleton()->is_stdout_verbose()) {
+			const String *K = nullptr;
+			while ((K = resources.next(K))) {
+				Resource *r = resources[*K];
+				print_line(vformat("Resource still in use: %s (%s)", *K, r->get_class()));
+			}
+		}
 	}
 
 	resources.clear();
@@ -442,12 +450,6 @@ void ResourceCache::clear() {
 }
 
 void ResourceCache::reload_externals() {
-	/*
-	const String *K=nullptr;
-	while ((K=resources.next(K))) {
-		resources[*K]->reload_external_data();
-	}
-	*/
 }
 
 bool ResourceCache::has(const String &p_path) {
@@ -530,6 +532,5 @@ void ResourceCache::dump(const char *p_file, bool p_short) {
 	}
 
 	lock->read_unlock();
-
 #endif
 }


### PR DESCRIPTION
Note that on the `master` branch, `ObjectDB::cleanup()` currently crashes in verbose mode (at least in my MRP), as the new code added by @reduz is not guaranteed to give a valid `obj` pointer: 867d073b983

But that's independent from these changes, which I plan to cherry-pick for `3.2` where they work fine.