### PR TITLE
Print warning once when loading an image from `res://` path

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -2199,7 +2199,7 @@ Image::AlphaMode Image::detect_alpha() const {
 Error Image::load(const String &p_path) {
 #ifdef DEBUG_ENABLED
 	if (p_path.begins_with("res://") && ResourceLoader::exists(p_path)) {
-		WARN_PRINT("Loaded resource as image file, this will not work on export: '" + p_path + "'. Instead, import the image file as an Image resource and load it normally as a resource.");
+		WARN_PRINT_ONCE("Loaded resource as image file, this will not work on export: '" + p_path + "'. Instead, import the image file as an Image resource and load it normally as a resource.");
 	}
 #endif
 	return ImageLoader::load_image(p_path, this);


### PR DESCRIPTION
Closes #24222.

I write unit tests for image processing methods and run them via command line. Unfortunately, the output is polluted with the warning messages for each and every `image.load()`, often "shadowing" any error messages:
```
* test_image_resize_hqx2_rgb
WARNING: load: Loaded resource as image file, this will not work on export: 'res://rect_rgb.png'. Instead, import the image file as an Image resource and load it normally as a resource.
   At: core/image.cpp:1889.
* test_image_resize_hqx3_rgba
WARNING: load: Loaded resource as image file, this will not work on export: 'res://rect_rgba.png'. Instead, import the image file as an Image resource and load it normally as a resource.
   At: core/image.cpp:1889.
* test_image_rotate
WARNING: load: Loaded resource as image file, this will not work on export: 'res://rect_rgb.png'. Instead, import the image file as an Image resource and load it normally as a resource.
   At: core/image.cpp:1889.
* test_image_rotate_90_cw
WARNING: load: Loaded resource as image file, this will not work on export: 'res://rect_rgba.png'. Instead, import the image file as an Image resource and load it normally as a resource.
   At: core/image.cpp:1889.
* test_image_rotate_90_ccw
WARNING: load: Loaded resource as image file, this will not work on export: 'res://rect_rgba.png'. Instead, import the image file as an Image resource and load it normally as a resource.
   At: core/image.cpp:1889.
* test_image_rotate_180_grayscale
WARNING: load: Loaded resource as image file, this will not work on export: 'res://rect_grayscale.png'. Instead, import the image file as an Image resource and load it normally as a resource.
   At: core/image.cpp:1889.
```

This PR makes it so that the warning is printed only once during the lifetime of Godot instance.
