### PR TITLE
Allow to copy/paste properties in the inspector

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -49,6 +49,12 @@ public:
 class EditorProperty : public Container {
 	GDCLASS(EditorProperty, Container);
 
+public:
+	enum MenuItems {
+		MENU_COPY,
+		MENU_PASTE
+	};
+
 private:
 	String label;
 	int text_size;
@@ -95,6 +101,7 @@ private:
 	Vector<Control *> focusables;
 	Control *label_reference;
 	Control *bottom_editor;
+	PopupMenu *menu;
 
 	mutable String tooltip_text;
 
@@ -167,6 +174,8 @@ public:
 	void set_draw_top_bg(bool p_draw) { draw_top_bg = p_draw; }
 
 	bool can_revert_to_default() const { return can_revert; }
+
+	void menu_option(int p_option);
 
 	EditorProperty();
 };
@@ -305,6 +314,7 @@ class EditorInspector : public ScrollContainer {
 
 	String property_prefix; //used for sectioned inspector
 	String object_class;
+	Variant property_clipboard;
 
 	void _edit_set(const String &p_name, const Variant &p_value, bool p_refresh_all, const String &p_changed_field);
 
@@ -391,6 +401,9 @@ public:
 	void set_sub_inspector(bool p_enable);
 
 	void set_use_deletable_properties(bool p_enabled);
+
+	void set_property_clipboard(const Variant &p_value);
+	Variant get_property_clipboard() const;
 
 	EditorInspector();
 };


### PR DESCRIPTION
Addresses #23024
![ezgif-6-542be88dac7f](https://user-images.githubusercontent.com/2223172/84065453-b266ff00-a9c4-11ea-975a-db4019f08b5f.gif)

Unfortunately I couldn't make the shortcuts working, because key events are hijacked by other editor controls. Could be done in another PR probably (maybe after #39039 is merged).

*Bugsquad edit: This partially addresses https://github.com/godotengine/godot-proposals/issues/1504.*