### PR TITLE
Tweak the invalid preset error message to mention `export_presets.cfg`

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -619,7 +619,9 @@ void EditorNode::_fs_changed() {
 			preset.unref();
 		}
 		if (preset.is_null()) {
-			export_error = vformat("Invalid export preset name: %s.", preset_name);
+			export_error = vformat(
+					"Invalid export preset name: %s. Make sure `export_presets.cfg` is present in the current directory.",
+					preset_name);
 		} else {
 			Ref<EditorExportPlatform> platform = preset->get_platform();
 			if (platform.is_null()) {


### PR DESCRIPTION
See #39406.

This is a stop-gap solution; we might want to do a dedicated check for this file instead. We could even list the available presets if the file exists but the given name doesn't match any preset defined in `export_presets.cfg`.