### PR TITLE
Update Rigidbody 2D and 3D sleep documentation.

### DIFF
--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -127,7 +127,7 @@
 			The body's total applied torque.
 		</member>
 		<member name="can_sleep" type="bool" setter="set_can_sleep" getter="is_able_to_sleep" default="true">
-			If [code]true[/code], the body will not calculate forces and will act as a static body if there is no movement. The body will wake up when other forces are applied via collisions or by using [method apply_impulse] or [method add_force].
+			If [code]true[/code], the body can enter sleep mode when there is no movement. See [member sleeping].
 		</member>
 		<member name="contact_monitor" type="bool" setter="set_contact_monitor" getter="is_contact_monitor_enabled" default="false">
 			If [code]true[/code], the body will emit signals when it collides with another RigidBody2D. See also [member contacts_reported].
@@ -165,7 +165,7 @@
 			If a material is assigned to this property, it will be used instead of any other physics material, such as an inherited one.
 		</member>
 		<member name="sleeping" type="bool" setter="set_sleeping" getter="is_sleeping" default="false">
-			If [code]true[/code], the body is sleeping and will not calculate forces until woken up by a collision or by using [method apply_impulse] or [method add_force].
+			If [code]true[/code], the body will not move and will not calculate forces until woken up by another body through, for example, a collision, or by using the [method apply_impulse] or [method add_force] methods.
 		</member>
 		<member name="weight" type="float" setter="set_weight" getter="get_weight" default="9.8">
 			The body's weight based on its mass and the [b]Default Gravity[/b] value in [b]Project &gt; Project Settings &gt; Physics &gt; 2d[/b].
@@ -214,7 +214,8 @@
 		</signal>
 		<signal name="sleeping_state_changed">
 			<description>
-				Emitted when [member sleeping] changes.
+				Emitted when the physics engine changes the body's sleeping state.
+				[b]Note:[/b] Changing the value [member sleeping] will not trigger this signal. It is only emitted if the sleeping state is changed by the physics engine or [code]emit_signal("sleeping_state_changed")[/code] is used.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -147,7 +147,7 @@
 			Lock the body's movement in the Z axis.
 		</member>
 		<member name="can_sleep" type="bool" setter="set_can_sleep" getter="is_able_to_sleep" default="true">
-			If [code]true[/code], the body is deactivated when there is no movement, so it will not take part in the simulation until it is awaken by an external force.
+			If [code]true[/code], the body can enter sleep mode when there is no movement. See [member sleeping].
 		</member>
 		<member name="contact_monitor" type="bool" setter="set_contact_monitor" getter="is_contact_monitor_enabled" default="false">
 			If [code]true[/code], the RigidBody3D will emit signals when it collides with another RigidBody3D.
@@ -182,7 +182,7 @@
 			If a material is assigned to this property, it will be used instead of any other physics material, such as an inherited one.
 		</member>
 		<member name="sleeping" type="bool" setter="set_sleeping" getter="is_sleeping" default="false">
-			If [code]true[/code], the body is sleeping and will not calculate forces until woken up by a collision or the [code]apply_impulse[/code] method.
+			If [code]true[/code], the body will not move and will not calculate forces until woken up by another body through, for example, a collision, or by using the [method apply_impulse] or [method add_force] methods.
 		</member>
 		<member name="weight" type="float" setter="set_weight" getter="get_weight" default="9.8">
 			The body's weight based on its mass and the global 3D gravity. Global values are set in [b]Project &gt; Project Settings &gt; Physics &gt; 3d[/b].
@@ -233,7 +233,8 @@
 		</signal>
 		<signal name="sleeping_state_changed">
 			<description>
-				Emitted when the body changes its sleeping state. Either by sleeping or waking up.
+				Emitted when the physics engine changes the body's sleeping state.
+				[b]Note:[/b] Changing the value [member sleeping] will not trigger this signal. It is only emitted if the sleeping state is changed by the physics engine or [code]emit_signal("sleeping_state_changed")[/code] is used.
 			</description>
 		</signal>
 	</signals>


### PR DESCRIPTION
Correct and clarify the `Rigidbody` documentation around `sleeping`, `can_sleep` and `sleeping_state_changed()`.

Closes #39366
Closes #39367