### PR TITLE
Add POT generation feature in Editor 

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -142,6 +142,15 @@
 				Adds a custom submenu under [b]Project &gt; Tools &gt;[/b] [code]name[/code]. [code]submenu[/code] should be an object of class [PopupMenu]. This submenu should be cleaned up using [code]remove_tool_menu_item(name)[/code].
 			</description>
 		</method>
+		<method name="add_translation_parser_plugin">
+			<return type="void">
+			</return>
+			<argument index="0" name="parser" type="EditorTranslationParserPlugin">
+			</argument>
+			<description>
+				Registers a custom translation parser plugin for extracting translatable strings from custom files.
+			</description>
+		</method>
 		<method name="apply_changes" qualifiers="virtual">
 			<return type="void">
 			</return>
@@ -462,6 +471,15 @@
 			</argument>
 			<description>
 				Removes a menu [code]name[/code] from [b]Project &gt; Tools[/b].
+			</description>
+		</method>
+		<method name="remove_translation_parser_plugin">
+			<return type="void">
+			</return>
+			<argument index="0" name="parser" type="EditorTranslationParserPlugin">
+			</argument>
+			<description>
+				Removes a registered custom translation parser plugin.
 			</description>
 		</method>
 		<method name="save_external_data" qualifiers="virtual">

--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorTranslationParserPlugin" inherits="Reference" version="4.0">
+	<brief_description>
+		Plugin for adding custom parsers to extract strings that are to be translated from custom files (.csv, .json etc.).
+	</brief_description>
+	<description>
+		Plugins are registered via [method EditorPlugin.add_translation_parser_plugin] method. To define the parsing and string extraction logic, override the [method parse_text] method in script.
+		The extracted strings will be written into a POT file selected by user under "POT Generation" in "Localization" tab in "Project Settings" menu.
+		Below shows an example of a custom parser that extracts strings in a CSV file to write into a POT.
+		[codeblock]
+		tool
+		extends EditorTranslationParserPlugin
+
+		func parse_text(text, extracted_strings):
+		    var split_strs = text.split(",", false, 0)
+		    for s in split_strs:
+		        extracted_strings.append(s)
+		        #print("Extracted string: " + s)
+
+		func get_recognized_extensions():
+		    return ["csv"]
+		[/codeblock]		
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_recognized_extensions" qualifiers="virtual">
+			<return type="Array">
+			</return>
+			<description>
+				Gets the list of file extensions to associate with this parser, e.g. [code]["csv"][/code].
+			</description>
+		</method>
+		<method name="parse_text" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="text" type="String">
+			</argument>
+			<argument index="1" name="extracted_strings" type="Array">
+			</argument>
+			<description>
+				Override this method to define a custom parsing logic to extract the translatable strings.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -85,6 +85,7 @@
 #include "editor/editor_settings.h"
 #include "editor/editor_spin_slider.h"
 #include "editor/editor_themes.h"
+#include "editor/editor_translation_parser.h"
 #include "editor/export_template_manager.h"
 #include "editor/filesystem_dock.h"
 #include "editor/import/editor_import_collada.h"
@@ -138,6 +139,7 @@
 #include "editor/plugins/multimesh_editor_plugin.h"
 #include "editor/plugins/navigation_polygon_editor_plugin.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
+#include "editor/plugins/packed_scene_translation_parser_plugin.h"
 #include "editor/plugins/path_2d_editor_plugin.h"
 #include "editor/plugins/path_3d_editor_plugin.h"
 #include "editor/plugins/physical_bone_3d_editor_plugin.h"
@@ -3589,6 +3591,7 @@ void EditorNode::register_editor_types() {
 	ResourceSaver::set_timestamp_on_save(true);
 
 	ClassDB::register_class<EditorPlugin>();
+	ClassDB::register_class<EditorTranslationParserPlugin>();
 	ClassDB::register_class<EditorImportPlugin>();
 	ClassDB::register_class<EditorScript>();
 	ClassDB::register_class<EditorSelection>();
@@ -6658,6 +6661,10 @@ EditorNode::EditorNode() {
 	export_text_to_binary_plugin.instance();
 
 	EditorExport::get_singleton()->add_export_plugin(export_text_to_binary_plugin);
+
+	Ref<PackedSceneEditorTranslationParserPlugin> packed_scene_translation_parser_plugin;
+	packed_scene_translation_parser_plugin.instance();
+	EditorTranslationParser::get_singleton()->add_parser(packed_scene_translation_parser_plugin, EditorTranslationParser::STANDARD);
 
 	_edit_current();
 	current = nullptr;

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -663,6 +663,14 @@ bool EditorPlugin::get_remove_list(List<Node *> *p_list) {
 void EditorPlugin::restore_global_state() {}
 void EditorPlugin::save_global_state() {}
 
+void EditorPlugin::add_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser) {
+	EditorTranslationParser::get_singleton()->add_parser(p_parser, EditorTranslationParser::CUSTOM);
+}
+
+void EditorPlugin::remove_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser) {
+	EditorTranslationParser::get_singleton()->remove_parser(p_parser, EditorTranslationParser::CUSTOM);
+}
+
 void EditorPlugin::add_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
 	ResourceFormatImporter::get_singleton()->add_importer(p_importer);
 	EditorFileSystem::get_singleton()->call_deferred("scan");
@@ -796,6 +804,8 @@ void EditorPlugin::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_undo_redo"), &EditorPlugin::_get_undo_redo);
 	ClassDB::bind_method(D_METHOD("queue_save_layout"), &EditorPlugin::queue_save_layout);
+	ClassDB::bind_method(D_METHOD("add_translation_parser_plugin", "parser"), &EditorPlugin::add_translation_parser_plugin);
+	ClassDB::bind_method(D_METHOD("remove_translation_parser_plugin", "parser"), &EditorPlugin::remove_translation_parser_plugin);
 	ClassDB::bind_method(D_METHOD("add_import_plugin", "importer"), &EditorPlugin::add_import_plugin);
 	ClassDB::bind_method(D_METHOD("remove_import_plugin", "importer"), &EditorPlugin::remove_import_plugin);
 	ClassDB::bind_method(D_METHOD("add_scene_import_plugin", "scene_importer"), &EditorPlugin::add_scene_import_plugin);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -34,6 +34,7 @@
 #include "core/io/config_file.h"
 #include "core/undo_redo.h"
 #include "editor/editor_inspector.h"
+#include "editor/editor_translation_parser.h"
 #include "editor/import/editor_import_plugin.h"
 #include "editor/import/resource_importer_scene.h"
 #include "editor/script_create_dialog.h"
@@ -219,6 +220,9 @@ public:
 
 	virtual void restore_global_state();
 	virtual void save_global_state();
+
+	void add_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser);
+	void remove_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser);
 
 	void add_import_plugin(const Ref<EditorImportPlugin> &p_importer);
 	void remove_import_plugin(const Ref<EditorImportPlugin> &p_importer);

--- a/editor/editor_translation_parser.cpp
+++ b/editor/editor_translation_parser.cpp
@@ -1,0 +1,180 @@
+/*************************************************************************/
+/*  editor_translation_parser.cpp                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor_translation_parser.h"
+
+#include "core/error_macros.h"
+#include "core/os/file_access.h"
+#include "core/script_language.h"
+#include "core/set.h"
+
+EditorTranslationParser *EditorTranslationParser::singleton = nullptr;
+
+Error EditorTranslationParserPlugin::parse_file(const String &p_path, Vector<String> *r_extracted_strings) {
+	if (!get_script_instance())
+		return ERR_UNAVAILABLE;
+
+	if (get_script_instance()->has_method("parse_text")) {
+		Error err;
+		FileAccess *file = FileAccess::open(p_path, FileAccess::READ, &err);
+		if (err != OK) {
+			ERR_PRINT("Failed to open " + p_path);
+			return err;
+		}
+		parse_text(file->get_as_utf8_string(), r_extracted_strings);
+		return OK;
+	} else {
+		ERR_PRINT("Custom translation parser plugin's \"func parse_text(text, extracted_strings)\" is undefined.");
+		return ERR_UNAVAILABLE;
+	}
+}
+
+void EditorTranslationParserPlugin::parse_text(const String &p_text, Vector<String> *r_extracted_strings) {
+	if (!get_script_instance())
+		return;
+
+	if (get_script_instance()->has_method("parse_text")) {
+		Array extracted_strings;
+		get_script_instance()->call("parse_text", p_text, extracted_strings);
+		for (int i = 0; i < extracted_strings.size(); i++) {
+			r_extracted_strings->append(extracted_strings[i]);
+		}
+	} else {
+		ERR_PRINT("Custom translation parser plugin's \"func parse_text(text, extracted_strings)\" is undefined.");
+	}
+}
+
+void EditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_extensions) const {
+	if (!get_script_instance())
+		return;
+
+	if (get_script_instance()->has_method("get_recognized_extensions")) {
+		Array extensions = get_script_instance()->call("get_recognized_extensions");
+		for (int i = 0; i < extensions.size(); i++) {
+			r_extensions->push_back(extensions[i]);
+		}
+	} else {
+		ERR_PRINT("Custom translation parser plugin's \"func get_recognized_extensions()\" is undefined.");
+	}
+}
+
+void EditorTranslationParserPlugin::_bind_methods() {
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::NIL, "parse_text", PropertyInfo(Variant::STRING, "text"), PropertyInfo(Variant::ARRAY, "extracted_strings")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::ARRAY, "get_recognized_extensions"));
+}
+
+/////////////////////////
+
+void EditorTranslationParser::get_recognized_extensions(List<String> *r_extensions) const {
+	Set<String> extensions;
+	List<String> temp;
+	for (int i = 0; i < standard_parsers.size(); i++) {
+		standard_parsers[i]->get_recognized_extensions(&temp);
+	}
+	for (int i = 0; i < custom_parsers.size(); i++) {
+		custom_parsers[i]->get_recognized_extensions(&temp);
+	}
+	// Remove duplicates.
+	for (int i = 0; i < temp.size(); i++) {
+		extensions.insert(temp[i]);
+	}
+	for (auto E = extensions.front(); E; E = E->next()) {
+		r_extensions->push_back(E->get());
+	}
+}
+
+bool EditorTranslationParser::can_parse(const String &p_extension) const {
+	List<String> extensions;
+	get_recognized_extensions(&extensions);
+	for (int i = 0; i < extensions.size(); i++) {
+		if (p_extension == extensions[i]) {
+			return true;
+		}
+	}
+	return false;
+}
+
+Ref<EditorTranslationParserPlugin> EditorTranslationParser::get_parser(const String &p_extension) const {
+	// Consider user-defined parsers first.
+	for (int i = 0; i < custom_parsers.size(); i++) {
+		List<String> temp;
+		custom_parsers[i]->get_recognized_extensions(&temp);
+		for (int j = 0; j < temp.size(); j++) {
+			if (temp[j] == p_extension) {
+				return custom_parsers[i];
+			}
+		}
+	}
+
+	for (int i = 0; i < standard_parsers.size(); i++) {
+		List<String> temp;
+		standard_parsers[i]->get_recognized_extensions(&temp);
+		for (int j = 0; j < temp.size(); j++) {
+			if (temp[j] == p_extension) {
+				return standard_parsers[i];
+			}
+		}
+	}
+
+	WARN_PRINT("No translation parser available for \"" + p_extension + "\" extension.");
+
+	return nullptr;
+}
+
+void EditorTranslationParser::add_parser(const Ref<EditorTranslationParserPlugin> &p_parser, ParserType p_type) {
+	if (p_type == ParserType::STANDARD) {
+		standard_parsers.push_back(p_parser);
+	} else if (p_type == ParserType::CUSTOM) {
+		custom_parsers.push_back(p_parser);
+	}
+}
+
+void EditorTranslationParser::remove_parser(const Ref<EditorTranslationParserPlugin> &p_parser, ParserType p_type) {
+	if (p_type == ParserType::STANDARD) {
+		standard_parsers.erase(p_parser);
+	} else if (p_type == ParserType::CUSTOM) {
+		custom_parsers.erase(p_parser);
+	}
+}
+
+EditorTranslationParser *EditorTranslationParser::get_singleton() {
+	if (!singleton) {
+		singleton = memnew(EditorTranslationParser);
+	}
+	return singleton;
+}
+
+EditorTranslationParser::EditorTranslationParser() {
+}
+
+EditorTranslationParser::~EditorTranslationParser() {
+	memdelete(singleton);
+	singleton = nullptr;
+}

--- a/editor/editor_translation_parser.h
+++ b/editor/editor_translation_parser.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  pot_generator.h                                                      */
+/*  editor_translation_parser.h                                          */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,25 +28,46 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef POT_GENERATOR_H
-#define POT_GENERATOR_H
+#ifndef EDITOR_TRANSLATION_PARSER_H
+#define EDITOR_TRANSLATION_PARSER_H
 
-#include "core/ordered_hash_map.h"
-#include "core/set.h"
+#include "core/error_list.h"
+#include "core/reference.h"
 
-class POTGenerator {
-	static POTGenerator *singleton;
-	// Stores all translatable strings and the source files containing them.
-	OrderedHashMap<String, Set<String>> all_translation_strings;
+class EditorTranslationParserPlugin : public Reference {
+	GDCLASS(EditorTranslationParserPlugin, Reference);
 
-	void _write_to_pot(const String &p_file);
+protected:
+	static void _bind_methods();
 
 public:
-	static POTGenerator *get_singleton();
-	void generate_pot(const String &p_file);
-
-	POTGenerator();
-	~POTGenerator();
+	virtual Error parse_file(const String &p_path, Vector<String> *r_extracted_strings);
+	virtual void parse_text(const String &p_text, Vector<String> *r_extracted_strings);
+	virtual void get_recognized_extensions(List<String> *r_extensions) const;
 };
 
-#endif // POT_GENERATOR_H
+class EditorTranslationParser {
+	static EditorTranslationParser *singleton;
+
+public:
+	enum ParserType {
+		STANDARD, // GDScript, CSharp, ...
+		CUSTOM // User-defined parser plugins. This will override standard parsers if the same extension type is defined.
+	};
+
+	static EditorTranslationParser *get_singleton();
+
+	Vector<Ref<EditorTranslationParserPlugin>> standard_parsers;
+	Vector<Ref<EditorTranslationParserPlugin>> custom_parsers;
+
+	void get_recognized_extensions(List<String> *r_extensions) const;
+	bool can_parse(const String &p_extension) const;
+	Ref<EditorTranslationParserPlugin> get_parser(const String &p_extension) const;
+	void add_parser(const Ref<EditorTranslationParserPlugin> &p_parser, ParserType p_type);
+	void remove_parser(const Ref<EditorTranslationParserPlugin> &p_parser, ParserType p_type);
+
+	EditorTranslationParser();
+	~EditorTranslationParser();
+};
+
+#endif // EDITOR_TRANSLATION_PARSER_H

--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -1,0 +1,114 @@
+/*************************************************************************/
+/*  packed_scene_translation_parser_plugin.cpp                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "packed_scene_translation_parser_plugin.h"
+
+#include "core/io/resource_loader.h"
+#include "scene/resources/packed_scene.h"
+
+void PackedSceneEditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_extensions) const {
+	ResourceLoader::get_recognized_extensions_for_type("PackedScene", r_extensions);
+}
+
+Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path, Vector<String> *r_extracted_strings) {
+	// Parse specific scene Node's properties (see in constructor) that are auto-translated by the engine when set. E.g Label's text property.
+	// These properties are translated with the tr() function in the C++ code when being set or updated.
+
+	Error err;
+	RES loaded_res = ResourceLoader::load(p_path, "PackedScene", false, &err);
+	if (err) {
+		ERR_PRINT("Failed to load " + p_path);
+		return err;
+	}
+	Ref<SceneState> state = Ref<PackedScene>(loaded_res)->get_state();
+
+	Vector<String> parsed_strings;
+	String property_name;
+	Variant property_value;
+	for (int i = 0; i < state->get_node_count(); i++) {
+		if (!ClassDB::is_parent_class(state->get_node_type(i), "Control") && !ClassDB::is_parent_class(state->get_node_type(i), "Viewport")) {
+			continue;
+		}
+
+		for (int j = 0; j < state->get_node_property_count(i); j++) {
+			property_name = state->get_node_property_name(i, j);
+			if (!lookup_properties.has(property_name)) {
+				continue;
+			}
+
+			property_value = state->get_node_property_value(i, j);
+
+			if (property_name == "script" && property_value.get_type() == Variant::OBJECT && !property_value.is_null()) {
+				// Parse built-in script.
+				Ref<Script> s = Object::cast_to<Script>(property_value);
+				String extension = s->get_language()->get_extension();
+				if (EditorTranslationParser::get_singleton()->can_parse(extension)) {
+					Vector<String> temp;
+					EditorTranslationParser::get_singleton()->get_parser(extension)->parse_text(s->get_source_code(), &temp);
+					parsed_strings.append_array(temp);
+				}
+			} else if (property_name == "filters") {
+				// Extract FileDialog's filters property with values in format "*.png ; PNG Images","*.gd ; GDScript Files".
+				Vector<String> str_values = property_value;
+				for (int k = 0; k < str_values.size(); k++) {
+					String desc = str_values[k].get_slice(";", 1).strip_edges();
+					if (!desc.empty()) {
+						parsed_strings.push_back(desc);
+					}
+				}
+			} else if (property_value.get_type() == Variant::STRING) {
+				String str_value = String(property_value);
+				// Prevent reading text containing only spaces.
+				if (!str_value.strip_edges().empty()) {
+					parsed_strings.push_back(str_value);
+				}
+			}
+		}
+	}
+
+	r_extracted_strings->append_array(parsed_strings);
+
+	return OK;
+}
+
+PackedSceneEditorTranslationParserPlugin::PackedSceneEditorTranslationParserPlugin() {
+	// Scene Node's properties containing strings that will be fetched for translation.
+	lookup_properties.insert("text");
+	lookup_properties.insert("hint_tooltip");
+	lookup_properties.insert("placeholder_text");
+	lookup_properties.insert("dialog_text");
+	lookup_properties.insert("filters");
+	lookup_properties.insert("script");
+
+	//Add exception list (to prevent false positives)
+	//line edit, text edit, richtextlabel
+	//Set<String> exception_list;
+	//exception_list.insert("RichTextLabel");
+}

--- a/editor/plugins/packed_scene_translation_parser_plugin.h
+++ b/editor/plugins/packed_scene_translation_parser_plugin.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  pot_generator.h                                                      */
+/*  packed_scene_translation_parser_plugin.h                             */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,25 +28,22 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef POT_GENERATOR_H
-#define POT_GENERATOR_H
+#ifndef PACKED_SCENE_TRANSLATION_PARSER_PLUGIN_H
+#define PACKED_SCENE_TRANSLATION_PARSER_PLUGIN_H
 
-#include "core/ordered_hash_map.h"
-#include "core/set.h"
+#include "editor/editor_translation_parser.h"
 
-class POTGenerator {
-	static POTGenerator *singleton;
-	// Stores all translatable strings and the source files containing them.
-	OrderedHashMap<String, Set<String>> all_translation_strings;
+class PackedSceneEditorTranslationParserPlugin : public EditorTranslationParserPlugin {
+	GDCLASS(PackedSceneEditorTranslationParserPlugin, EditorTranslationParserPlugin);
 
-	void _write_to_pot(const String &p_file);
+	// Scene Node's properties that contain translation strings.
+	Set<String> lookup_properties;
 
 public:
-	static POTGenerator *get_singleton();
-	void generate_pot(const String &p_file);
+	virtual Error parse_file(const String &p_path, Vector<String> *r_extracted_strings);
+	virtual void get_recognized_extensions(List<String> *r_extensions) const;
 
-	POTGenerator();
-	~POTGenerator();
+	PackedSceneEditorTranslationParserPlugin();
 };
 
-#endif // POT_GENERATOR_H
+#endif // PACKED_SCENE_TRANSLATION_PARSER_PLUGIN_H

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -30,14 +30,11 @@
 
 #include "pot_generator.h"
 
-#include "core/class_db.h"
 #include "core/error_macros.h"
-#include "core/io/resource_loader.h"
+#include "core/os/file_access.h"
 #include "core/project_settings.h"
-#include "core/script_language.h"
-#include "core/variant.h"
-#include "modules/gdscript/gdscript.h"
-#include "scene/resources/packed_scene.h"
+#include "editor_translation_parser.h"
+#include "plugins/packed_scene_translation_parser_plugin.h"
 
 POTGenerator *POTGenerator::singleton = nullptr;
 
@@ -65,40 +62,18 @@ void POTGenerator::generate_pot(const String &p_file) {
 	all_translation_strings.clear();
 
 	Vector<String> files = ProjectSettings::get_singleton()->get("locale/translations_pot_files");
-	Vector<String> translation_strings;
-	List<String> packed_scene_extensions;
-	ResourceLoader::get_recognized_extensions_for_type("PackedScene", &packed_scene_extensions);
 
 	// Collect all translatable strings according to files order in "POT Generation" setting.
 	for (int i = 0; i < files.size(); i++) {
+		Vector<String> translation_strings;
 		String file_path = files[i];
 		String file_extension = file_path.get_extension();
 
-		Error err;
-		RES loaded_res = ResourceLoader::load(file_path, "", false, &err);
-		if (err) {
-			ERR_PRINT("Failed to load " + file_path);
-			continue;
-		}
-
-		bool is_scene_file = false;
-		for (List<String>::Element *E = packed_scene_extensions.front(); E; E = E->next()) {
-			if (file_extension == E->get()) {
-				is_scene_file = true;
-				break;
-			}
-		}
-
-		if (is_scene_file) {
-			Ref<PackedScene> ps = loaded_res;
-			translation_strings = _parse_scene(ps->get_state());
-		} else if (file_extension == "gd") {
-			// Currently we only support GDScript.
-			Ref<GDScript> s = loaded_res;
-			translation_strings = _parse_script(s->get_source_code());
+		if (EditorTranslationParser::get_singleton()->can_parse(file_extension)) {
+			EditorTranslationParser::get_singleton()->get_parser(file_extension)->parse_file(file_path, &translation_strings);
 		} else {
-			ERR_PRINT("Unrecognized file extension in generate_pot()");
-			continue;
+			ERR_PRINT("Unrecognized file extension " + file_extension + " in generate_pot()");
+			return;
 		}
 
 		// Store translation strings parsed in this iteration along with their corresponding source file - to write into POT later on.
@@ -112,118 +87,6 @@ void POTGenerator::generate_pot(const String &p_file) {
 #endif
 
 	_write_to_pot(p_file);
-}
-
-Vector<String> POTGenerator::_parse_scene(const Ref<SceneState> &p_state) {
-	// Parse specific scene Node's properties (see in constructor) that are auto-translated by the engine when set. E.g Label's text property.
-	// These properties are translated with the tr() function in the C++ code when being set or updated.
-
-	Vector<String> parsed_strings;
-
-	String property_name;
-	Variant property_value;
-	for (int i = 0; i < p_state->get_node_count(); i++) {
-		if (!ClassDB::is_parent_class(p_state->get_node_type(i), "Control") && !ClassDB::is_parent_class(p_state->get_node_type(i), "Viewport")) {
-			continue;
-		}
-
-		for (int j = 0; j < p_state->get_node_property_count(i); j++) {
-			property_name = p_state->get_node_property_name(i, j);
-			if (!lookup_properties.has(property_name)) {
-				continue;
-			}
-
-			property_value = p_state->get_node_property_value(i, j);
-
-			if (property_name == "script" && property_value.get_type() == Variant::OBJECT && !property_value.is_null()) {
-				// Parse built-in script. Currently we only support GDScript.
-				Ref<GDScript> s = Object::cast_to<GDScript>(property_value);
-				parsed_strings.append_array(_parse_script(s->get_source_code()));
-			} else if (property_name == "filters") {
-				// Extract FileDialog's filters property with values in format "*.png ; PNG Images","*.gd ; GDScript Files".
-				Vector<String> str_values = property_value;
-				for (int k = 0; k < str_values.size(); k++) {
-					String desc = str_values[k].get_slice(";", 1).strip_edges();
-					if (!desc.empty()) {
-						parsed_strings.push_back(desc);
-					}
-				}
-			} else if (property_value.get_type() == Variant::STRING) {
-				String str_value = String(property_value);
-				// Prevent reading text containing only spaces.
-				if (!str_value.strip_edges().empty()) {
-					parsed_strings.push_back(str_value);
-				}
-			}
-		}
-	}
-
-	return parsed_strings;
-}
-
-Vector<String> POTGenerator::_parse_script(const String &p_source_code) {
-	// Parse and match all GDScript function API that involves translation string.
-	// E.g get_node("Label").text = "something", var test = tr("something")
-	// "something" will be matched and collected
-	// The extra complication in the regex pattern is to ensure that the matching works when users write over multiple lines, use tabs etc.
-
-	Vector<String> parsed_strings;
-
-	regex.clear();
-	regex.compile(String("|").join(patterns));
-	Array results = regex.search_all(p_source_code);
-	_get_captured_strings(results, &parsed_strings);
-
-	// Special handling for FileDialog
-	Vector<String> temp;
-	_parse_file_dialog(p_source_code, &temp);
-	parsed_strings.append_array(temp);
-
-	// Filter out / and +
-	String filter = "(?:\\\\\\n|\"[\\s\\\\]*\\+\\s*\")";
-	regex.clear();
-	regex.compile(filter);
-	for (int i = 0; i < parsed_strings.size(); i++) {
-		parsed_strings.set(i, regex.sub(parsed_strings[i], "", true));
-	}
-
-	return parsed_strings;
-}
-
-void POTGenerator::_parse_file_dialog(const String &p_source_code, Vector<String> *r_output) {
-	// FileDialog API has the form .filters = PackedStringArray(["*.png ; PNG Images","*.gd ; GDScript Files"]).
-	// First filter: Get "*.png ; PNG Images", "*.gd ; GDScript Files" from PackedStringArray.
-	regex.clear();
-	regex.compile(String("|").join(file_dialog_patterns));
-	Array results = regex.search_all(p_source_code);
-
-	Vector<String> temp;
-	_get_captured_strings(results, &temp);
-	String captured_strings = String(",").join(temp);
-
-	// Second filter: Get the texts after semicolon from "*.png ; PNG Images","*.gd ; GDScript Files".
-	String second_filter = "\"[^;]+;" + text + "\"";
-	regex.clear();
-	regex.compile(second_filter);
-	results = regex.search_all(captured_strings);
-	_get_captured_strings(results, r_output);
-	for (int i = 0; i < r_output->size(); i++) {
-		r_output->set(i, r_output->get(i).strip_edges());
-	}
-}
-
-void POTGenerator::_get_captured_strings(const Array &p_results, Vector<String> *r_output) {
-	Ref<RegExMatch> result;
-	for (int i = 0; i < p_results.size(); i++) {
-		result = p_results[i];
-		for (int j = 0; j < result->get_group_count(); j++) {
-			String s = result->get_string(j + 1);
-			// Prevent reading text with only spaces.
-			if (!s.strip_edges().empty()) {
-				r_output->push_back(s);
-			}
-		}
-	}
 }
 
 void POTGenerator::_write_to_pot(const String &p_file) {
@@ -264,14 +127,22 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 			file->store_line("#: " + E->get().trim_prefix("res://"));
 		}
 
-		// Write msgid.
-		Vector<String> msg_lines = msg.split("\\n");
-		file->store_string("msgid \"" + msg_lines[0]);
-		for (int i = 1; i < msg_lines.size(); i++) {
-			file->store_line("\\n\"");
-			file->store_string("\"" + msg_lines[i]);
+		// Split \\n and \n.
+		Vector<String> temp = msg.split("\\n");
+		Vector<String> msg_lines;
+		for (int i = 0; i < temp.size(); i++) {
+			msg_lines.append_array(temp[i].split("\n"));
+			if (i < temp.size() - 1) {
+				// Add \n.
+				msg_lines.set(msg_lines.size() - 1, msg_lines[msg_lines.size() - 1] + "\\n");
+			}
 		}
-		file->store_line("\"");
+
+		// Write msgid.
+		file->store_string("msgid ");
+		for (int i = 0; i < msg_lines.size(); i++) {
+			file->store_line("\"" + msg_lines[i] + "\"");
+		}
 
 		file->store_line("msgstr \"\"\n");
 	}
@@ -287,57 +158,6 @@ POTGenerator *POTGenerator::get_singleton() {
 }
 
 POTGenerator::POTGenerator() {
-	// Scene Node's properties containing strings that will be fetched for translation.
-	lookup_properties.insert("text");
-	lookup_properties.insert("hint_tooltip");
-	lookup_properties.insert("placeholder_text");
-	lookup_properties.insert("dialog_text");
-	lookup_properties.insert("filters");
-	lookup_properties.insert("script");
-
-	//Add exception list (to prevent false positives)
-	//line edit, text edit, richtextlabel
-	//Set<String> exception_list;
-	//exception_list.insert("RichTextLabel");
-
-	// Regex search pattern templates.
-	const String dot = "\\.[\\s\\\\]*";
-	const String str_assign_template = "[\\s\\\\]*=[\\s\\\\]*\"" + text + "\"";
-	const String first_arg_template = "[\\s\\\\]*\\([\\s\\\\]*\"" + text + "\"[\\s\\S]*?\\)";
-	const String second_arg_template = "[\\s\\\\]*\\([\\s\\S]+?,[\\s\\\\]*\"" + text + "\"[\\s\\S]*?\\)";
-
-	// Common patterns.
-	patterns.push_back("tr" + first_arg_template);
-	patterns.push_back(dot + "text" + str_assign_template);
-	patterns.push_back(dot + "placeholder_text" + str_assign_template);
-	patterns.push_back(dot + "hint_tooltip" + str_assign_template);
-	patterns.push_back(dot + "set_text" + first_arg_template);
-	patterns.push_back(dot + "set_tooltip" + first_arg_template);
-	patterns.push_back(dot + "set_placeholder" + first_arg_template);
-
-	// Tabs and TabContainer API.
-	patterns.push_back(dot + "set_tab_title" + second_arg_template);
-	patterns.push_back(dot + "add_tab" + first_arg_template);
-
-	// PopupMenu API.
-	patterns.push_back(dot + "add_check_item" + first_arg_template);
-	patterns.push_back(dot + "add_icon_check_item" + second_arg_template);
-	patterns.push_back(dot + "add_icon_item" + second_arg_template);
-	patterns.push_back(dot + "add_icon_radio_check_item" + second_arg_template);
-	patterns.push_back(dot + "add_item" + first_arg_template);
-	patterns.push_back(dot + "add_multistate_item" + first_arg_template);
-	patterns.push_back(dot + "add_radio_check_item" + first_arg_template);
-	patterns.push_back(dot + "add_separator" + first_arg_template);
-	patterns.push_back(dot + "add_submenu_item" + first_arg_template);
-	patterns.push_back(dot + "set_item_text" + second_arg_template);
-	//patterns.push_back(dot + "set_item_tooltip" + second_arg_template); //no tr() behind this function. might be bug.
-
-	// FileDialog API - special case.
-	const String fd_text = "((?:[\\s\\\\]*\"(?:[^\"\\\\]|\\\\[\\s\\S])*(?:\"[\\s\\\\]*\\+[\\s\\\\]*\"(?:[^\"\\\\]|\\\\[\\s\\S])*)*\"[\\s\\\\]*,?)*)";
-	const String packed_string_array = "[\\s\\\\]*PackedStringArray[\\s\\\\]*\\([\\s\\\\]*\\[" + fd_text + "\\][\\s\\\\]*\\)";
-	file_dialog_patterns.push_back(dot + "add_filter[\\s\\\\]*\\(" + fd_text + "[\\s\\\\]*\\)");
-	file_dialog_patterns.push_back(dot + "filters[\\s\\\\]*=" + packed_string_array);
-	file_dialog_patterns.push_back(dot + "set_filters[\\s\\\\]*\\(" + packed_string_array + "[\\s\\\\]*\\)");
 }
 
 POTGenerator::~POTGenerator() {

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -1,0 +1,346 @@
+/*************************************************************************/
+/*  pot_generator.cpp                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "pot_generator.h"
+
+#include "core/class_db.h"
+#include "core/error_macros.h"
+#include "core/io/resource_loader.h"
+#include "core/project_settings.h"
+#include "core/script_language.h"
+#include "core/variant.h"
+#include "modules/gdscript/gdscript.h"
+#include "scene/resources/packed_scene.h"
+
+POTGenerator *POTGenerator::singleton = nullptr;
+
+//#define DEBUG_POT
+
+#ifdef DEBUG_POT
+void _print_all_translation_strings(const OrderedHashMap<String, Set<String>> &p_all_translation_strings) {
+	for (auto E_pair = p_all_translation_strings.front(); E_pair; E_pair = E_pair.next()) {
+		String msg = static_cast<String>(E_pair.key()) + " : ";
+		for (Set<String>::Element *E = E_pair.value().front(); E; E = E->next()) {
+			msg += E->get() + " ";
+		}
+		print_line(msg);
+	}
+}
+#endif
+
+void POTGenerator::generate_pot(const String &p_file) {
+	if (!ProjectSettings::get_singleton()->has_setting("locale/translations_pot_files")) {
+		WARN_PRINT("No files selected for POT generation.");
+		return;
+	}
+
+	// Clear all_translation_strings of the previous round.
+	all_translation_strings.clear();
+
+	Vector<String> files = ProjectSettings::get_singleton()->get("locale/translations_pot_files");
+	Vector<String> translation_strings;
+	List<String> packed_scene_extensions;
+	ResourceLoader::get_recognized_extensions_for_type("PackedScene", &packed_scene_extensions);
+
+	// Collect all translatable strings according to files order in "POT Generation" setting.
+	for (int i = 0; i < files.size(); i++) {
+		String file_path = files[i];
+		String file_extension = file_path.get_extension();
+
+		Error err;
+		RES loaded_res = ResourceLoader::load(file_path, "", false, &err);
+		if (err) {
+			ERR_PRINT("Failed to load " + file_path);
+			continue;
+		}
+
+		bool is_scene_file = false;
+		for (List<String>::Element *E = packed_scene_extensions.front(); E; E = E->next()) {
+			if (file_extension == E->get()) {
+				is_scene_file = true;
+				break;
+			}
+		}
+
+		if (is_scene_file) {
+			Ref<PackedScene> ps = loaded_res;
+			translation_strings = _parse_scene(ps->get_state());
+		} else if (file_extension == "gd") {
+			// Currently we only support GDScript.
+			Ref<GDScript> s = loaded_res;
+			translation_strings = _parse_script(s->get_source_code());
+		} else {
+			ERR_PRINT("Unrecognized file extension in generate_pot()");
+			continue;
+		}
+
+		// Store translation strings parsed in this iteration along with their corresponding source file - to write into POT later on.
+		for (int j = 0; j < translation_strings.size(); j++) {
+			all_translation_strings[translation_strings[j]].insert(file_path);
+		}
+	}
+
+#ifdef DEBUG_POT
+	_print_all_translation_strings(all_translation_strings);
+#endif
+
+	_write_to_pot(p_file);
+}
+
+Vector<String> POTGenerator::_parse_scene(const Ref<SceneState> &p_state) {
+	// Parse specific scene Node's properties (see in constructor) that are auto-translated by the engine when set. E.g Label's text property.
+	// These properties are translated with the tr() function in the C++ code when being set or updated.
+
+	Vector<String> parsed_strings;
+
+	String property_name;
+	Variant property_value;
+	for (int i = 0; i < p_state->get_node_count(); i++) {
+		if (!ClassDB::is_parent_class(p_state->get_node_type(i), "Control") && !ClassDB::is_parent_class(p_state->get_node_type(i), "Viewport")) {
+			continue;
+		}
+
+		for (int j = 0; j < p_state->get_node_property_count(i); j++) {
+			property_name = p_state->get_node_property_name(i, j);
+			if (!lookup_properties.has(property_name)) {
+				continue;
+			}
+
+			property_value = p_state->get_node_property_value(i, j);
+
+			if (property_name == "script" && property_value.get_type() == Variant::OBJECT && !property_value.is_null()) {
+				// Parse built-in script. Currently we only support GDScript.
+				Ref<GDScript> s = Object::cast_to<GDScript>(property_value);
+				parsed_strings.append_array(_parse_script(s->get_source_code()));
+			} else if (property_name == "filters") {
+				// Extract FileDialog's filters property with values in format "*.png ; PNG Images","*.gd ; GDScript Files".
+				Vector<String> str_values = property_value;
+				for (int k = 0; k < str_values.size(); k++) {
+					String desc = str_values[k].get_slice(";", 1).strip_edges();
+					if (!desc.empty()) {
+						parsed_strings.push_back(desc);
+					}
+				}
+			} else if (property_value.get_type() == Variant::STRING) {
+				String str_value = String(property_value);
+				// Prevent reading text containing only spaces.
+				if (!str_value.strip_edges().empty()) {
+					parsed_strings.push_back(str_value);
+				}
+			}
+		}
+	}
+
+	return parsed_strings;
+}
+
+Vector<String> POTGenerator::_parse_script(const String &p_source_code) {
+	// Parse and match all GDScript function API that involves translation string.
+	// E.g get_node("Label").text = "something", var test = tr("something")
+	// "something" will be matched and collected
+	// The extra complication in the regex pattern is to ensure that the matching works when users write over multiple lines, use tabs etc.
+
+	Vector<String> parsed_strings;
+
+	regex.clear();
+	regex.compile(String("|").join(patterns));
+	Array results = regex.search_all(p_source_code);
+	_get_captured_strings(results, &parsed_strings);
+
+	// Special handling for FileDialog
+	Vector<String> temp;
+	_parse_file_dialog(p_source_code, &temp);
+	parsed_strings.append_array(temp);
+
+	// Filter out / and +
+	String filter = "(?:\\\\\\n|\"[\\s\\\\]*\\+\\s*\")";
+	regex.clear();
+	regex.compile(filter);
+	for (int i = 0; i < parsed_strings.size(); i++) {
+		parsed_strings.set(i, regex.sub(parsed_strings[i], "", true));
+	}
+
+	return parsed_strings;
+}
+
+void POTGenerator::_parse_file_dialog(const String &p_source_code, Vector<String> *r_output) {
+	// FileDialog API has the form .filters = PackedStringArray(["*.png ; PNG Images","*.gd ; GDScript Files"]).
+	// First filter: Get "*.png ; PNG Images", "*.gd ; GDScript Files" from PackedStringArray.
+	regex.clear();
+	regex.compile(String("|").join(file_dialog_patterns));
+	Array results = regex.search_all(p_source_code);
+
+	Vector<String> temp;
+	_get_captured_strings(results, &temp);
+	String captured_strings = String(",").join(temp);
+
+	// Second filter: Get the texts after semicolon from "*.png ; PNG Images","*.gd ; GDScript Files".
+	String second_filter = "\"[^;]+;" + text + "\"";
+	regex.clear();
+	regex.compile(second_filter);
+	results = regex.search_all(captured_strings);
+	_get_captured_strings(results, r_output);
+	for (int i = 0; i < r_output->size(); i++) {
+		r_output->set(i, r_output->get(i).strip_edges());
+	}
+}
+
+void POTGenerator::_get_captured_strings(const Array &p_results, Vector<String> *r_output) {
+	Ref<RegExMatch> result;
+	for (int i = 0; i < p_results.size(); i++) {
+		result = p_results[i];
+		for (int j = 0; j < result->get_group_count(); j++) {
+			String s = result->get_string(j + 1);
+			// Prevent reading text with only spaces.
+			if (!s.strip_edges().empty()) {
+				r_output->push_back(s);
+			}
+		}
+	}
+}
+
+void POTGenerator::_write_to_pot(const String &p_file) {
+	Error err;
+	FileAccess *file = FileAccess::open(p_file, FileAccess::WRITE, &err);
+	if (err != OK) {
+		ERR_PRINT("Failed to open " + p_file);
+		return;
+	}
+
+	String project_name = ProjectSettings::get_singleton()->get("application/config/name");
+	Vector<String> files = ProjectSettings::get_singleton()->get("locale/translations_pot_files");
+	String extracted_files = "";
+	for (int i = 0; i < files.size(); i++) {
+		extracted_files += "# " + files[i] + "\n";
+	}
+	const String header =
+			"# LANGUAGE translation for " + project_name + " for the following files:\n" + extracted_files +
+			"#\n"
+			"#\n"
+			"# FIRST AUTHOR < EMAIL @ADDRESS>, YEAR.\n"
+			"#\n"
+			"#, fuzzy\n"
+			"msgid \"\"\n"
+			"msgstr \"\"\n"
+			"\"Project-Id-Version: " +
+			project_name + "\\n\"\n"
+						   "\"Content-Type: text/plain; charset=UTF-8\\n\"\n"
+						   "\"Content-Transfer-Encoding: 8-bit\\n\"\n\n";
+
+	file->store_string(header);
+
+	for (OrderedHashMap<String, Set<String>>::Element E_pair = all_translation_strings.front(); E_pair; E_pair = E_pair.next()) {
+		String msg = E_pair.key();
+
+		// Write file locations.
+		for (Set<String>::Element *E = E_pair.value().front(); E; E = E->next()) {
+			file->store_line("#: " + E->get().trim_prefix("res://"));
+		}
+
+		// Write msgid.
+		Vector<String> msg_lines = msg.split("\\n");
+		file->store_string("msgid \"" + msg_lines[0]);
+		for (int i = 1; i < msg_lines.size(); i++) {
+			file->store_line("\\n\"");
+			file->store_string("\"" + msg_lines[i]);
+		}
+		file->store_line("\"");
+
+		file->store_line("msgstr \"\"\n");
+	}
+
+	file->close();
+}
+
+POTGenerator *POTGenerator::get_singleton() {
+	if (!singleton) {
+		singleton = memnew(POTGenerator);
+	}
+	return singleton;
+}
+
+POTGenerator::POTGenerator() {
+	// Scene Node's properties containing strings that will be fetched for translation.
+	lookup_properties.insert("text");
+	lookup_properties.insert("hint_tooltip");
+	lookup_properties.insert("placeholder_text");
+	lookup_properties.insert("dialog_text");
+	lookup_properties.insert("filters");
+	lookup_properties.insert("script");
+
+	//Add exception list (to prevent false positives)
+	//line edit, text edit, richtextlabel
+	//Set<String> exception_list;
+	//exception_list.insert("RichTextLabel");
+
+	// Regex search pattern templates.
+	const String dot = "\\.[\\s\\\\]*";
+	const String str_assign_template = "[\\s\\\\]*=[\\s\\\\]*\"" + text + "\"";
+	const String first_arg_template = "[\\s\\\\]*\\([\\s\\\\]*\"" + text + "\"[\\s\\S]*?\\)";
+	const String second_arg_template = "[\\s\\\\]*\\([\\s\\S]+?,[\\s\\\\]*\"" + text + "\"[\\s\\S]*?\\)";
+
+	// Common patterns.
+	patterns.push_back("tr" + first_arg_template);
+	patterns.push_back(dot + "text" + str_assign_template);
+	patterns.push_back(dot + "placeholder_text" + str_assign_template);
+	patterns.push_back(dot + "hint_tooltip" + str_assign_template);
+	patterns.push_back(dot + "set_text" + first_arg_template);
+	patterns.push_back(dot + "set_tooltip" + first_arg_template);
+	patterns.push_back(dot + "set_placeholder" + first_arg_template);
+
+	// Tabs and TabContainer API.
+	patterns.push_back(dot + "set_tab_title" + second_arg_template);
+	patterns.push_back(dot + "add_tab" + first_arg_template);
+
+	// PopupMenu API.
+	patterns.push_back(dot + "add_check_item" + first_arg_template);
+	patterns.push_back(dot + "add_icon_check_item" + second_arg_template);
+	patterns.push_back(dot + "add_icon_item" + second_arg_template);
+	patterns.push_back(dot + "add_icon_radio_check_item" + second_arg_template);
+	patterns.push_back(dot + "add_item" + first_arg_template);
+	patterns.push_back(dot + "add_multistate_item" + first_arg_template);
+	patterns.push_back(dot + "add_radio_check_item" + first_arg_template);
+	patterns.push_back(dot + "add_separator" + first_arg_template);
+	patterns.push_back(dot + "add_submenu_item" + first_arg_template);
+	patterns.push_back(dot + "set_item_text" + second_arg_template);
+	//patterns.push_back(dot + "set_item_tooltip" + second_arg_template); //no tr() behind this function. might be bug.
+
+	// FileDialog API - special case.
+	const String fd_text = "((?:[\\s\\\\]*\"(?:[^\"\\\\]|\\\\[\\s\\S])*(?:\"[\\s\\\\]*\\+[\\s\\\\]*\"(?:[^\"\\\\]|\\\\[\\s\\S])*)*\"[\\s\\\\]*,?)*)";
+	const String packed_string_array = "[\\s\\\\]*PackedStringArray[\\s\\\\]*\\([\\s\\\\]*\\[" + fd_text + "\\][\\s\\\\]*\\)";
+	file_dialog_patterns.push_back(dot + "add_filter[\\s\\\\]*\\(" + fd_text + "[\\s\\\\]*\\)");
+	file_dialog_patterns.push_back(dot + "filters[\\s\\\\]*=" + packed_string_array);
+	file_dialog_patterns.push_back(dot + "set_filters[\\s\\\\]*\\(" + packed_string_array + "[\\s\\\\]*\\)");
+}
+
+POTGenerator::~POTGenerator() {
+	memdelete(singleton);
+	singleton = nullptr;
+}

--- a/editor/pot_generator.h
+++ b/editor/pot_generator.h
@@ -1,0 +1,67 @@
+/*************************************************************************/
+/*  pot_generator.h                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef POT_GENERATOR_H
+#define POT_GENERATOR_H
+
+#include "core/ordered_hash_map.h"
+#include "core/set.h"
+#include "modules/regex/regex.h"
+#include "scene/resources/packed_scene.h"
+
+class POTGenerator {
+	static POTGenerator *singleton;
+	// Stores all translatable strings and the source files containing them.
+	OrderedHashMap<String, Set<String>> all_translation_strings;
+
+	// Scene Node's properties that contain translation strings.
+	Set<String> lookup_properties;
+
+	// Regex and search patterns that are used to match translation strings in scripts.
+	const String text = "((?:[^\"\\\\]|\\\\[\\s\\S])*(?:\"[\\s\\\\]*\\+[\\s\\\\]*\"(?:[^\"\\\\]|\\\\[\\s\\S])*)*)";
+	RegEx regex;
+	Vector<String> patterns;
+	Vector<String> file_dialog_patterns;
+
+	Vector<String> _parse_scene(const Ref<SceneState> &p_state);
+	Vector<String> _parse_script(const String &p_source_code);
+	void _parse_file_dialog(const String &p_source_code, Vector<String> *r_output);
+	void _get_captured_strings(const Array &p_results, Vector<String> *r_output);
+	void _write_to_pot(const String &p_file);
+
+public:
+	static POTGenerator *get_singleton();
+	void generate_pot(const String &p_file);
+
+	POTGenerator();
+	~POTGenerator();
+};
+
+#endif // POT_GENERATOR_H

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -168,6 +168,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _translation_pot_file_open();
 	void _translation_pot_generate_open();
 	void _translation_pot_generate(const String &p_file);
+	void _update_translation_pot_file_extensions();
 
 	void _toggle_search_bar(bool p_pressed);
 

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -110,6 +110,10 @@ class ProjectSettingsEditor : public AcceptDialog {
 	Vector<TreeItem *> translation_filter_treeitems;
 	Vector<int> translation_locales_idxs_remap;
 
+	Tree *translation_pot_list;
+	EditorFileDialog *translation_pot_file_open;
+	EditorFileDialog *translation_pot_generate;
+
 	EditorAutoloadSettings *autoload_settings;
 
 	EditorPluginSettings *plugin_settings;
@@ -158,6 +162,12 @@ class ProjectSettingsEditor : public AcceptDialog {
 
 	void _translation_filter_option_changed();
 	void _translation_filter_mode_changed(int p_mode);
+
+	void _translation_pot_add(const String &p_path);
+	void _translation_pot_delete(Object *p_item, int p_column, int p_button);
+	void _translation_pot_file_open();
+	void _translation_pot_generate_open();
+	void _translation_pot_generate(const String &p_file);
 
 	void _toggle_search_bar(bool p_pressed);
 

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -1,0 +1,178 @@
+/*************************************************************************/
+/*  gdscript_translation_parser_plugin.cpp                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gdscript_translation_parser_plugin.h"
+
+#include "core/io/resource_loader.h"
+#include "modules/gdscript/gdscript.h"
+
+void GDScriptEditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_extensions) const {
+	GDScriptLanguage::get_singleton()->get_recognized_extensions(r_extensions);
+}
+
+Error GDScriptEditorTranslationParserPlugin::parse_file(const String &p_path, Vector<String> *r_extracted_strings) {
+	List<String> extensions;
+	get_recognized_extensions(&extensions);
+	bool extension_valid = false;
+	for (auto E = extensions.front(); E; E = E->next()) {
+		if (p_path.get_extension() == E->get()) {
+			extension_valid = true;
+			break;
+		}
+	}
+
+	if (!extension_valid) {
+		Vector<String> temp;
+		for (auto E = extensions.front(); E; E = E->next()) {
+			temp.push_back(E->get());
+		}
+		String valid_extensions = String(", ").join(temp);
+		ERR_PRINT("Argument p_path \"" + p_path + "\" has wrong extension. List of valid extensions: " + valid_extensions);
+		return ERR_INVALID_PARAMETER;
+	}
+
+	Error err;
+	RES loaded_res = ResourceLoader::load(p_path, "", false, &err);
+	if (err) {
+		ERR_PRINT("Failed to load " + p_path);
+		return err;
+	}
+
+	Ref<GDScript> gdscript = loaded_res;
+	parse_text(gdscript->get_source_code(), r_extracted_strings);
+
+	return OK;
+}
+
+void GDScriptEditorTranslationParserPlugin::parse_text(const String &p_text, Vector<String> *r_extracted_strings) {
+	// Parse and match all GDScript function API that involves translation string.
+	// E.g get_node("Label").text = "something", var test = tr("something"), "something" will be matched and collected.
+
+	Vector<String> parsed_strings;
+
+	// Search translation strings with RegEx.
+	regex.clear();
+	regex.compile(String("|").join(patterns));
+	Array results = regex.search_all(p_text);
+	_get_captured_strings(results, &parsed_strings);
+
+	// Special handling for FileDialog.
+	Vector<String> temp;
+	_parse_file_dialog(p_text, &temp);
+	parsed_strings.append_array(temp);
+
+	// Filter out / and +
+	String filter = "(?:\\\\\\n|\"[\\s\\\\]*\\+\\s*\")";
+	regex.clear();
+	regex.compile(filter);
+	for (int i = 0; i < parsed_strings.size(); i++) {
+		parsed_strings.set(i, regex.sub(parsed_strings[i], "", true));
+	}
+
+	r_extracted_strings->append_array(parsed_strings);
+}
+
+void GDScriptEditorTranslationParserPlugin::_parse_file_dialog(const String &p_source_code, Vector<String> *r_output) {
+	// FileDialog API has the form .filters = PackedStringArray(["*.png ; PNG Images","*.gd ; GDScript Files"]).
+	// First filter: Get "*.png ; PNG Images", "*.gd ; GDScript Files" from PackedStringArray.
+	regex.clear();
+	regex.compile(String("|").join(file_dialog_patterns));
+	Array results = regex.search_all(p_source_code);
+
+	Vector<String> temp;
+	_get_captured_strings(results, &temp);
+	String captured_strings = String(",").join(temp);
+
+	// Second filter: Get the texts after semicolon from "*.png ; PNG Images","*.gd ; GDScript Files".
+	String second_filter = "\"[^;]+;" + text + "\"";
+	regex.clear();
+	regex.compile(second_filter);
+	results = regex.search_all(captured_strings);
+	_get_captured_strings(results, r_output);
+	for (int i = 0; i < r_output->size(); i++) {
+		r_output->set(i, r_output->get(i).strip_edges());
+	}
+}
+
+void GDScriptEditorTranslationParserPlugin::_get_captured_strings(const Array &p_results, Vector<String> *r_output) {
+	Ref<RegExMatch> result;
+	for (int i = 0; i < p_results.size(); i++) {
+		result = p_results[i];
+		for (int j = 0; j < result->get_group_count(); j++) {
+			String s = result->get_string(j + 1);
+			// Prevent reading text with only spaces.
+			if (!s.strip_edges().empty()) {
+				r_output->push_back(s);
+			}
+		}
+	}
+}
+
+GDScriptEditorTranslationParserPlugin::GDScriptEditorTranslationParserPlugin() {
+	// Regex search pattern templates.
+	// The extra complication in the regex pattern is to ensure that the matching works when users write over multiple lines, use tabs etc.
+	const String dot = "\\.[\\s\\\\]*";
+	const String str_assign_template = "[\\s\\\\]*=[\\s\\\\]*\"" + text + "\"";
+	const String first_arg_template = "[\\s\\\\]*\\([\\s\\\\]*\"" + text + "\"[\\s\\S]*?\\)";
+	const String second_arg_template = "[\\s\\\\]*\\([\\s\\S]+?,[\\s\\\\]*\"" + text + "\"[\\s\\S]*?\\)";
+
+	// Common patterns.
+	patterns.push_back("tr" + first_arg_template);
+	patterns.push_back(dot + "text" + str_assign_template);
+	patterns.push_back(dot + "placeholder_text" + str_assign_template);
+	patterns.push_back(dot + "hint_tooltip" + str_assign_template);
+	patterns.push_back(dot + "set_text" + first_arg_template);
+	patterns.push_back(dot + "set_tooltip" + first_arg_template);
+	patterns.push_back(dot + "set_placeholder" + first_arg_template);
+
+	// Tabs and TabContainer API.
+	patterns.push_back(dot + "set_tab_title" + second_arg_template);
+	patterns.push_back(dot + "add_tab" + first_arg_template);
+
+	// PopupMenu API.
+	patterns.push_back(dot + "add_check_item" + first_arg_template);
+	patterns.push_back(dot + "add_icon_check_item" + second_arg_template);
+	patterns.push_back(dot + "add_icon_item" + second_arg_template);
+	patterns.push_back(dot + "add_icon_radio_check_item" + second_arg_template);
+	patterns.push_back(dot + "add_item" + first_arg_template);
+	patterns.push_back(dot + "add_multistate_item" + first_arg_template);
+	patterns.push_back(dot + "add_radio_check_item" + first_arg_template);
+	patterns.push_back(dot + "add_separator" + first_arg_template);
+	patterns.push_back(dot + "add_submenu_item" + first_arg_template);
+	patterns.push_back(dot + "set_item_text" + second_arg_template);
+	//patterns.push_back(dot + "set_item_tooltip" + second_arg_template); //no tr() behind this function. might be bug.
+
+	// FileDialog API - special case.
+	const String fd_text = "((?:[\\s\\\\]*\"(?:[^\"\\\\]|\\\\[\\s\\S])*(?:\"[\\s\\\\]*\\+[\\s\\\\]*\"(?:[^\"\\\\]|\\\\[\\s\\S])*)*\"[\\s\\\\]*,?)*)";
+	const String packed_string_array = "[\\s\\\\]*PackedStringArray[\\s\\\\]*\\([\\s\\\\]*\\[" + fd_text + "\\][\\s\\\\]*\\)";
+	file_dialog_patterns.push_back(dot + "add_filter[\\s\\\\]*\\(" + fd_text + "[\\s\\\\]*\\)");
+	file_dialog_patterns.push_back(dot + "filters[\\s\\\\]*=" + packed_string_array);
+	file_dialog_patterns.push_back(dot + "set_filters[\\s\\\\]*\\(" + packed_string_array + "[\\s\\\\]*\\)");
+}

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.h
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  pot_generator.h                                                      */
+/*  gdscript_translation_parser_plugin.h                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,25 +28,30 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef POT_GENERATOR_H
-#define POT_GENERATOR_H
+#ifndef GDSCRIPT_TRANSLATION_PARSER_PLUGIN_H
+#define GDSCRIPT_TRANSLATION_PARSER_PLUGIN_H
 
-#include "core/ordered_hash_map.h"
-#include "core/set.h"
+#include "editor/editor_translation_parser.h"
+#include "modules/regex/regex.h"
 
-class POTGenerator {
-	static POTGenerator *singleton;
-	// Stores all translatable strings and the source files containing them.
-	OrderedHashMap<String, Set<String>> all_translation_strings;
+class GDScriptEditorTranslationParserPlugin : public EditorTranslationParserPlugin {
+	GDCLASS(GDScriptEditorTranslationParserPlugin, EditorTranslationParserPlugin);
 
-	void _write_to_pot(const String &p_file);
+	// Regex and search patterns that are used to match translation strings.
+	const String text = "((?:[^\"\\\\]|\\\\[\\s\\S])*(?:\"[\\s\\\\]*\\+[\\s\\\\]*\"(?:[^\"\\\\]|\\\\[\\s\\S])*)*)";
+	RegEx regex;
+	Vector<String> patterns;
+	Vector<String> file_dialog_patterns;
+
+	void _parse_file_dialog(const String &p_source_code, Vector<String> *r_output);
+	void _get_captured_strings(const Array &p_results, Vector<String> *r_output);
 
 public:
-	static POTGenerator *get_singleton();
-	void generate_pot(const String &p_file);
+	virtual Error parse_file(const String &p_path, Vector<String> *r_extracted_strings);
+	virtual void parse_text(const String &p_text, Vector<String> *r_extracted_strings);
+	virtual void get_recognized_extensions(List<String> *r_extensions) const;
 
-	POTGenerator();
-	~POTGenerator();
+	GDScriptEditorTranslationParserPlugin();
 };
 
-#endif // POT_GENERATOR_H
+#endif // GDSCRIPT_TRANSLATION_PARSER_PLUGIN_H

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -46,7 +46,9 @@ Ref<ResourceFormatSaverGDScript> resource_saver_gd;
 #include "editor/editor_export.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
+#include "editor/editor_translation_parser.h"
 #include "editor/gdscript_highlighter.h"
+#include "editor/gdscript_translation_parser_plugin.h"
 
 #ifndef GDSCRIPT_NO_LSP
 #include "core/engine.h"
@@ -164,6 +166,10 @@ void register_gdscript_types() {
 #ifdef TOOLS_ENABLED
 	ScriptEditor::register_create_syntax_highlighter_function(GDScriptSyntaxHighlighter::create);
 	EditorNode::add_init_callback(_editor_init);
+
+	Ref<GDScriptEditorTranslationParserPlugin> gdscript_translation_parser_plugin;
+	gdscript_translation_parser_plugin.instance();
+	EditorTranslationParser::get_singleton()->add_parser(gdscript_translation_parser_plugin, EditorTranslationParser::STANDARD);
 #endif // TOOLS_ENABLED
 }
 


### PR DESCRIPTION
_Context: i18n, localization_

Added "POT generation" tab under "Localization" to generate translation template files  (known as POT files) from selected files. 

Behind the scene, the system collects all translatable strings from the included files, and write the collected strings to a user-selected POT file.

==============
_Update 23/06/2020_
Added plugin support. Users can now define their custom parser to extract translation strings from custom files (.csv, .json etc.) into the POT file.



![TranslationParserPlugin](https://user-images.githubusercontent.com/23119524/85404126-cc751580-b55e-11ea-9236-04ef91edd23e.png)


Test project:
[test_project.zip](https://github.com/godotengine/godot/files/4819367/test_project.zip)
