### PR TITLE
Add description to TileSet.is_tile_bound() method

### DIFF
--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -44,6 +44,7 @@
 			<argument index="1" name="neighbor_id" type="int">
 			</argument>
 			<description>
+				Determines when the auto-tiler should consider two different auto-tile IDs to be bound together.
 			</description>
 		</method>
 		<method name="autotile_clear_bitmask_map">

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -45,7 +45,7 @@
 			</argument>
 			<description>
 				Determines when the auto-tiler should consider two different auto-tile IDs to be bound together.
-				Also, neighbor_id can (and will) be -1 when checking a tile against air.
+				Also, [code]neighbor_id[/code] can (and will) be [code]-1[/code] when checking a tile against air.
 			</description>
 		</method>
 		<method name="autotile_clear_bitmask_map">

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -45,6 +45,7 @@
 			</argument>
 			<description>
 				Determines when the auto-tiler should consider two different auto-tile IDs to be bound together.
+				Also, neighbor_id can (and will) be -1 when checking a tile against air.
 			</description>
 		</method>
 		<method name="autotile_clear_bitmask_map">

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -45,7 +45,7 @@
 			</argument>
 			<description>
 				Determines when the auto-tiler should consider two different auto-tile IDs to be bound together.
-				Also, [code]neighbor_id[/code] can (and will) be [code]-1[/code] when checking a tile against air.
+				[b]Note:[/b] [code]neighbor_id[/code] will be [code]-1[/code] ([constant TileMap.INVALID_CELL]) when checking a tile against an empty neighbor tile.
 			</description>
 		</method>
 		<method name="autotile_clear_bitmask_map">


### PR DESCRIPTION
This was missing from the documentation.

I have added a short description to the method:

_Determines when the auto-tiler should consider two different auto-tile id's to be bound together._

There is an [issue](https://github.com/godotengine/godot/issues/39381) created for this.

I hope this helps!