### PR TITLE
Fix crash when creating new text file with no name

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -837,7 +837,6 @@ void ScriptEditor::_file_dialog_action(String p_file) {
 			Error err;
 			FileAccess *file = FileAccess::open(p_file, FileAccess::WRITE, &err);
 			if (err) {
-				memdelete(file);
 				editor->show_warning(TTR("Error writing TextFile:") + "\n" + p_file, TTR("Error!"));
 				break;
 			}


### PR DESCRIPTION
The editor crashes when the user creates a new text file with no name. This happens because the program attempts to call the destructor on a nullptr. FileAccess::open() returns a nullptr if a file can't be opened, which happens of course when an empty file name is specified. In addition to returning nullptr, FileAccess::open() actually frees the appropriate memory if there's any error, so it's not necessary to free the FileAccess object's memory when handling an error. I fixed the crash by removing the line that attempts to free the FileAccess object's memory.