### PR TITLE
Mention ordering caveats for `Dictionary.hash()`

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -148,6 +148,7 @@
 				# The line below prints `true`, whereas it would have printed `false` if both variables were compared directly.
 				print(dict1.hash() == dict2.hash())
 				[/codeblock]
+				[b]Note:[/b] Dictionaries with the same keys/values but in a different order will have a different hash.
 			</description>
 		</method>
 		<method name="keys">


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/27615.