### PR TITLE
Account for file deletion and renaming in Export Presets

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -90,6 +90,19 @@ Ref<EditorExportPlatform> EditorExportPreset::get_platform() const {
 	return platform;
 }
 
+void EditorExportPreset::update_files_to_export() {
+	Vector<String> to_remove;
+	for (Set<String>::Element *E = selected_files.front(); E; E = E->next()) {
+		if (!FileAccess::exists(E->get())) {
+			to_remove.push_back(E->get());
+		}
+	}
+	for (int i = 0; i < to_remove.size(); ++i) {
+		selected_files.erase(to_remove[i]);
+	}
+	EditorExport::singleton->save_presets();
+}
+
 Vector<String> EditorExportPreset::get_files_to_export() const {
 	Vector<String> files;
 	for (Set<String>::Element *E = selected_files.front(); E; E = E->next()) {
@@ -1298,7 +1311,11 @@ void EditorExport::load_config() {
 			Vector<String> files = config->get_value(section, "export_files");
 
 			for (int i = 0; i < files.size(); i++) {
-				preset->add_export_file(files[i]);
+				if (!FileAccess::exists(files[i])) {
+					preset->remove_export_file(files[i]);
+				} else {
+					preset->add_export_file(files[i]);
+				}
 			}
 		}
 

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -94,6 +94,8 @@ public:
 
 	bool has(const StringName &p_property) const { return values.has(p_property); }
 
+	void update_files_to_export();
+
 	Vector<String> get_files_to_export() const;
 
 	void add_export_file(const String &p_path);

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -163,6 +163,7 @@ void ProjectExportDialog::_update_presets() {
 		if (preset->is_runnable()) {
 			name += " (" + TTR("Runnable") + ")";
 		}
+		preset->update_files_to_export();
 		presets->add_item(name, preset->get_platform()->get_logo());
 	}
 


### PR DESCRIPTION
Previously, when a file was deleted after an export preset was created, Godot
 would still attempt to export the deleted file, and issue a spurious error in the
process. There was also no way to change this from the Project Export window.

This PR ensures that presets stay updated, by removing any deleted or renamed 
files from the presets. It does this either when the editor starts up, or when the Project
Export window is opened, ensuring that the user always sees the latest versions.

Closes #39269

Can be cherry picked for 3.2