### PR TITLE
Renamed InputMap.get_action_list to InputMap.action_get_events

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -48,7 +48,7 @@ void InputMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("action_has_event", "action", "event"), &InputMap::action_has_event);
 	ClassDB::bind_method(D_METHOD("action_erase_event", "action", "event"), &InputMap::action_erase_event);
 	ClassDB::bind_method(D_METHOD("action_erase_events", "action"), &InputMap::action_erase_events);
-	ClassDB::bind_method(D_METHOD("get_action_list", "action"), &InputMap::_get_action_list);
+	ClassDB::bind_method(D_METHOD("action_get_events", "action"), &InputMap::_action_get_events);
 	ClassDB::bind_method(D_METHOD("event_is_action", "event", "action"), &InputMap::event_is_action);
 	ClassDB::bind_method(D_METHOD("load_from_globals"), &InputMap::load_from_globals);
 }
@@ -152,9 +152,9 @@ void InputMap::action_erase_events(const StringName &p_action) {
 	input_map[p_action].inputs.clear();
 }
 
-Array InputMap::_get_action_list(const StringName &p_action) {
+Array InputMap::_action_get_events(const StringName &p_action) {
 	Array ret;
-	const List<Ref<InputEvent>> *al = get_action_list(p_action);
+	const List<Ref<InputEvent>> *al = action_get_events(p_action);
 	if (al) {
 		for (const List<Ref<InputEvent>>::Element *E = al->front(); E; E = E->next()) {
 			ret.push_back(E->get());
@@ -164,7 +164,7 @@ Array InputMap::_get_action_list(const StringName &p_action) {
 	return ret;
 }
 
-const List<Ref<InputEvent>> *InputMap::get_action_list(const StringName &p_action) {
+const List<Ref<InputEvent>> *InputMap::action_get_events(const StringName &p_action) {
 	const Map<StringName, Action>::Element *E = input_map.find(p_action);
 	if (!E) {
 		return nullptr;

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -56,7 +56,7 @@ private:
 
 	List<Ref<InputEvent>>::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool *p_pressed = nullptr, float *p_strength = nullptr) const;
 
-	Array _get_action_list(const StringName &p_action);
+	Array _action_get_events(const StringName &p_action);
 	Array _get_actions();
 
 protected:
@@ -76,7 +76,7 @@ public:
 	void action_erase_event(const StringName &p_action, const Ref<InputEvent> &p_event);
 	void action_erase_events(const StringName &p_action);
 
-	const List<Ref<InputEvent>> *get_action_list(const StringName &p_action);
+	const List<Ref<InputEvent>> *action_get_events(const StringName &p_action);
 	bool event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action) const;
 	bool event_get_action_status(const Ref<InputEvent> &p_event, const StringName &p_action, bool *p_pressed = nullptr, float *p_strength = nullptr) const;
 

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -95,7 +95,7 @@
 				Returns [code]true[/code] if the given event is part of an existing action. This method ignores keyboard modifiers if the given [InputEvent] is not pressed (for proper release detection). See [method action_has_event] if you don't want this behavior.
 			</description>
 		</method>
-		<method name="get_action_list">
+		<method name="action_get_events">
 			<return type="Array">
 			</return>
 			<argument index="0" name="action" type="StringName">


### PR DESCRIPTION
`InputMap`'s `get_action_list` function implies getting a list of all actions but instead returns a list of all `InputEvent`s for a specific action.This is unintuitive.

This PR changes this functions name to `get_action_events` which is way more describing of what this function is supposed to do.