### PR TITLE
Enable Unicode support for RegEx class

### DIFF
--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -7,7 +7,7 @@ env_regex = env_modules.Clone()
 
 if env["builtin_pcre2"]:
     thirdparty_dir = "#thirdparty/pcre2/src/"
-    thirdparty_flags = ["PCRE2_STATIC", "HAVE_CONFIG_H"]
+    thirdparty_flags = ["PCRE2_STATIC", "HAVE_CONFIG_H", "SUPPORT_UNICODE"]
 
     if env["builtin_pcre2_with_jit"]:
         thirdparty_flags.append("SUPPORT_JIT")


### PR DESCRIPTION
The PCRE2 library is normally built with Unicode support by default when built separately,
but this was not enabled in the module's SCsub file. 

Modified the flags to build with unicode support. Enables RegEx objects in Godot to be used to recognize unicode strings, making it closer to the full PCRE specification.

Closes #38487

Some sample tests: [regex.zip](https://github.com/godotengine/godot/files/4763146/regexMaster.zip)

