### PR TITLE
Add keyboard layout enumeration / set / get functions.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -127,12 +127,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_latin_keyboard_variant" qualifiers="const">
-			<return type="int" enum="DisplayServer.LatinKeyboardVariant">
-			</return>
-			<description>
-			</description>
-		</method>
 		<method name="get_name" qualifiers="const">
 			<return type="String">
 			</return>
@@ -387,6 +381,52 @@
 			<return type="bool">
 			</return>
 			<description>
+			</description>
+		</method>
+		<method name="keyboard_get_current_layout" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns active keyboard layout index.
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+			</description>
+		</method>
+		<method name="keyboard_get_layout_count" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the number of keyboard layouts.
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+			</description>
+		</method>
+		<method name="keyboard_get_layout_language" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="index" type="int">
+			</argument>
+			<description>
+				Returns the ISO-639/BCP-47 language code of the keyboard layout at position [code]index[/code].
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+			</description>
+		</method>
+		<method name="keyboard_get_layout_name" qualifiers="const">
+			<return type="String">
+			</return>
+			<argument index="0" name="index" type="int">
+			</argument>
+			<description>
+				Returns the localized name of the keyboard layout at position [code]index[/code].
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+			</description>
+		</method>
+		<method name="keyboard_set_current_layout">
+			<return type="void">
+			</return>
+			<argument index="0" name="index" type="int">
+			</argument>
+			<description>
+				Sets active keyboard layout.
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
 			</description>
 		</method>
 		<method name="mouse_get_absolute_position" qualifiers="const">
@@ -1020,20 +1060,6 @@
 		<constant name="WINDOW_FLAG_NO_FOCUS" value="4" enum="WindowFlags">
 		</constant>
 		<constant name="WINDOW_FLAG_MAX" value="5" enum="WindowFlags">
-		</constant>
-		<constant name="LATIN_KEYBOARD_QWERTY" value="0" enum="LatinKeyboardVariant">
-		</constant>
-		<constant name="LATIN_KEYBOARD_QWERTZ" value="1" enum="LatinKeyboardVariant">
-		</constant>
-		<constant name="LATIN_KEYBOARD_AZERTY" value="2" enum="LatinKeyboardVariant">
-		</constant>
-		<constant name="LATIN_KEYBOARD_QZERTY" value="3" enum="LatinKeyboardVariant">
-		</constant>
-		<constant name="LATIN_KEYBOARD_DVORAK" value="4" enum="LatinKeyboardVariant">
-		</constant>
-		<constant name="LATIN_KEYBOARD_NEO" value="5" enum="LatinKeyboardVariant">
-		</constant>
-		<constant name="LATIN_KEYBOARD_COLEMAK" value="6" enum="LatinKeyboardVariant">
 		</constant>
 		<constant name="WINDOW_EVENT_MOUSE_ENTER" value="0" enum="WindowEvent">
 		</constant>

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -327,7 +327,11 @@ public:
 	virtual CursorShape cursor_get_shape() const;
 	virtual void cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot);
 
-	virtual LatinKeyboardVariant get_latin_keyboard_variant() const;
+	virtual int keyboard_get_layout_count() const;
+	virtual int keyboard_get_current_layout() const;
+	virtual void keyboard_set_current_layout(int p_index);
+	virtual String keyboard_get_layout_language(int p_index) const;
+	virtual String keyboard_get_layout_name(int p_index) const;
 
 	virtual void process_events();
 

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -281,7 +281,11 @@ public:
 
 	virtual bool get_swap_ok_cancel();
 
-	virtual LatinKeyboardVariant get_latin_keyboard_variant() const;
+	virtual int keyboard_get_layout_count() const;
+	virtual int keyboard_get_current_layout() const;
+	virtual void keyboard_set_current_layout(int p_index);
+	virtual String keyboard_get_layout_language(int p_index) const;
+	virtual String keyboard_get_layout_name(int p_index) const;
 
 	virtual void process_events();
 	virtual void force_process_and_drop_events();

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1372,70 +1372,99 @@ void DisplayServerWindows::enable_for_stealing_focus(OS::ProcessID pid) {
 	AllowSetForegroundWindow(pid);
 }
 
-DisplayServer::LatinKeyboardVariant DisplayServerWindows::get_latin_keyboard_variant() const {
-	_THREAD_SAFE_METHOD_
+int DisplayServerWindows::keyboard_get_layout_count() const {
+	return GetKeyboardLayoutList(0, NULL);
+}
 
-	unsigned long azerty[] = {
-		0x00020401, // Arabic (102) AZERTY
-		0x0001080c, // Belgian (Comma)
-		0x0000080c, // Belgian French
-		0x0000040c, // French
-		0 // <--- STOP MARK
-	};
-	unsigned long qwertz[] = {
-		0x0000041a, // Croation
-		0x00000405, // Czech
-		0x00000407, // German
-		0x00010407, // German (IBM)
-		0x0000040e, // Hungarian
-		0x0000046e, // Luxembourgish
-		0x00010415, // Polish (214)
-		0x00000418, // Romanian (Legacy)
-		0x0000081a, // Serbian (Latin)
-		0x0000041b, // Slovak
-		0x00000424, // Slovenian
-		0x0001042e, // Sorbian Extended
-		0x0002042e, // Sorbian Standard
-		0x0000042e, // Sorbian Standard (Legacy)
-		0x0000100c, // Swiss French
-		0x00000807, // Swiss German
-		0 // <--- STOP MARK
-	};
-	unsigned long dvorak[] = {
-		0x00010409, // US-Dvorak
-		0x00030409, // US-Dvorak for left hand
-		0x00040409, // US-Dvorak for right hand
-		0 // <--- STOP MARK
-	};
+int DisplayServerWindows::keyboard_get_current_layout() const {
+	HKL cur_layout = GetKeyboardLayout(0);
 
-	char name[KL_NAMELENGTH + 1];
-	name[0] = 0;
-	GetKeyboardLayoutNameA(name);
+	int layout_count = GetKeyboardLayoutList(0, NULL);
+	HKL *layouts = (HKL *)memalloc(layout_count * sizeof(HKL));
+	GetKeyboardLayoutList(layout_count, layouts);
 
-	unsigned long hex = strtoul(name, nullptr, 16);
+	for (int i = 0; i < layout_count; i++) {
+		if (cur_layout == layouts[i]) {
+			memfree(layouts);
+			return i;
+		}
+	}
+	memfree(layouts);
+	return -1;
+}
 
-	int i = 0;
-	while (azerty[i] != 0) {
-		if (azerty[i] == hex)
-			return LATIN_KEYBOARD_AZERTY;
-		i++;
+void DisplayServerWindows::keyboard_set_current_layout(int p_index) {
+	int layout_count = GetKeyboardLayoutList(0, NULL);
+
+	ERR_FAIL_INDEX(p_index, layout_count);
+
+	HKL *layouts = (HKL *)memalloc(layout_count * sizeof(HKL));
+	GetKeyboardLayoutList(layout_count, layouts);
+	ActivateKeyboardLayout(layouts[p_index], KLF_SETFORPROCESS);
+	memfree(layouts);
+}
+
+String DisplayServerWindows::keyboard_get_layout_language(int p_index) const {
+	int layout_count = GetKeyboardLayoutList(0, NULL);
+
+	ERR_FAIL_INDEX_V(p_index, layout_count, "");
+
+	HKL *layouts = (HKL *)memalloc(layout_count * sizeof(HKL));
+	GetKeyboardLayoutList(layout_count, layouts);
+
+	wchar_t buf[LOCALE_NAME_MAX_LENGTH];
+	memset(buf, 0, LOCALE_NAME_MAX_LENGTH * sizeof(wchar_t));
+	LCIDToLocaleName(MAKELCID(LOWORD(layouts[p_index]), SORT_DEFAULT), buf, LOCALE_NAME_MAX_LENGTH, 0);
+
+	memfree(layouts);
+
+	return String(buf).substr(0, 2);
+}
+
+String _get_full_layout_name_from_registry(HKL p_layout) {
+	String id = "SYSTEM\\CurrentControlSet\\Control\\Keyboard Layouts\\" + String::num_int64((int64_t)p_layout, 16, false).lpad(8, "0");
+	String ret;
+
+	HKEY hkey;
+	wchar_t layout_text[1024];
+	memset(layout_text, 0, 1024 * sizeof(wchar_t));
+
+	if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, (LPCWSTR)id.c_str(), 0, KEY_QUERY_VALUE, &hkey) != ERROR_SUCCESS) {
+		return ret;
 	}
 
-	i = 0;
-	while (qwertz[i] != 0) {
-		if (qwertz[i] == hex)
-			return LATIN_KEYBOARD_QWERTZ;
-		i++;
+	DWORD buffer = 1024;
+	DWORD vtype = REG_SZ;
+	if (RegQueryValueExW(hkey, L"Layout Text", NULL, &vtype, (LPBYTE)layout_text, &buffer) == ERROR_SUCCESS) {
+		ret = String(layout_text);
 	}
+	RegCloseKey(hkey);
+	return ret;
+}
 
-	i = 0;
-	while (dvorak[i] != 0) {
-		if (dvorak[i] == hex)
-			return LATIN_KEYBOARD_DVORAK;
-		i++;
+String DisplayServerWindows::keyboard_get_layout_name(int p_index) const {
+	int layout_count = GetKeyboardLayoutList(0, NULL);
+
+	ERR_FAIL_INDEX_V(p_index, layout_count, "");
+
+	HKL *layouts = (HKL *)memalloc(layout_count * sizeof(HKL));
+	GetKeyboardLayoutList(layout_count, layouts);
+
+	String ret = _get_full_layout_name_from_registry(layouts[p_index]); // Try reading full name from Windows registry, fallback to locale name if failed (e.g. on Wine).
+	if (ret == String()) {
+		wchar_t buf[LOCALE_NAME_MAX_LENGTH];
+		memset(buf, 0, LOCALE_NAME_MAX_LENGTH * sizeof(wchar_t));
+		LCIDToLocaleName(MAKELCID(LOWORD(layouts[p_index]), SORT_DEFAULT), buf, LOCALE_NAME_MAX_LENGTH, 0);
+
+		wchar_t name[1024];
+		memset(name, 0, 1024 * sizeof(wchar_t));
+		GetLocaleInfoEx(buf, LOCALE_SLOCALIZEDDISPLAYNAME, (LPWSTR)&name, 1024);
+
+		ret = String(name);
 	}
+	memfree(layouts);
 
-	return LATIN_KEYBOARD_QWERTY;
+	return ret;
 }
 
 void DisplayServerWindows::process_events() {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -523,7 +523,11 @@ public:
 
 	virtual void enable_for_stealing_focus(OS::ProcessID pid);
 
-	virtual LatinKeyboardVariant get_latin_keyboard_variant() const;
+	virtual int keyboard_get_layout_count() const;
+	virtual int keyboard_get_current_layout() const;
+	virtual void keyboard_set_current_layout(int p_index);
+	virtual String keyboard_get_layout_language(int p_index) const;
+	virtual String keyboard_get_layout_name(int p_index) const;
 
 	virtual void process_events();
 

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -276,8 +276,23 @@ Error DisplayServer::dialog_input_text(String p_title, String p_description, Str
 	return OK;
 }
 
-DisplayServer::LatinKeyboardVariant DisplayServer::get_latin_keyboard_variant() const {
-	return LATIN_KEYBOARD_QWERTY;
+int DisplayServer::keyboard_get_layout_count() const {
+	return 0;
+}
+
+int DisplayServer::keyboard_get_current_layout() const {
+	return -1;
+}
+
+void DisplayServer::keyboard_set_current_layout(int p_index) {
+}
+
+String DisplayServer::keyboard_get_layout_language(int p_index) const {
+	return "";
+}
+
+String DisplayServer::keyboard_get_layout_name(int p_index) const {
+	return "Not supported";
 }
 
 void DisplayServer::force_process_and_drop_events() {
@@ -461,7 +476,11 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("dialog_show", "title", "description", "buttons", "callback"), &DisplayServer::dialog_show);
 	ClassDB::bind_method(D_METHOD("dialog_input_text", "title", "description", "existing_text", "callback"), &DisplayServer::dialog_input_text);
 
-	ClassDB::bind_method(D_METHOD("get_latin_keyboard_variant"), &DisplayServer::get_latin_keyboard_variant);
+	ClassDB::bind_method(D_METHOD("keyboard_get_layout_count"), &DisplayServer::keyboard_get_layout_count);
+	ClassDB::bind_method(D_METHOD("keyboard_get_current_layout"), &DisplayServer::keyboard_get_current_layout);
+	ClassDB::bind_method(D_METHOD("keyboard_set_current_layout", "index"), &DisplayServer::keyboard_set_current_layout);
+	ClassDB::bind_method(D_METHOD("keyboard_get_layout_language", "index"), &DisplayServer::keyboard_get_layout_language);
+	ClassDB::bind_method(D_METHOD("keyboard_get_layout_name", "index"), &DisplayServer::keyboard_get_layout_name);
 
 	ClassDB::bind_method(D_METHOD("process_events"), &DisplayServer::process_events);
 	ClassDB::bind_method(D_METHOD("force_process_and_drop_events"), &DisplayServer::force_process_and_drop_events);
@@ -542,14 +561,6 @@ void DisplayServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(WINDOW_FLAG_TRANSPARENT);
 	BIND_ENUM_CONSTANT(WINDOW_FLAG_NO_FOCUS);
 	BIND_ENUM_CONSTANT(WINDOW_FLAG_MAX);
-
-	BIND_ENUM_CONSTANT(LATIN_KEYBOARD_QWERTY);
-	BIND_ENUM_CONSTANT(LATIN_KEYBOARD_QWERTZ);
-	BIND_ENUM_CONSTANT(LATIN_KEYBOARD_AZERTY);
-	BIND_ENUM_CONSTANT(LATIN_KEYBOARD_QZERTY);
-	BIND_ENUM_CONSTANT(LATIN_KEYBOARD_DVORAK);
-	BIND_ENUM_CONSTANT(LATIN_KEYBOARD_NEO);
-	BIND_ENUM_CONSTANT(LATIN_KEYBOARD_COLEMAK);
 
 	BIND_ENUM_CONSTANT(WINDOW_EVENT_MOUSE_ENTER);
 	BIND_ENUM_CONSTANT(WINDOW_EVENT_MOUSE_EXIT);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -324,17 +324,11 @@ public:
 	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback);
 	virtual Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback);
 
-	enum LatinKeyboardVariant {
-		LATIN_KEYBOARD_QWERTY,
-		LATIN_KEYBOARD_QWERTZ,
-		LATIN_KEYBOARD_AZERTY,
-		LATIN_KEYBOARD_QZERTY,
-		LATIN_KEYBOARD_DVORAK,
-		LATIN_KEYBOARD_NEO,
-		LATIN_KEYBOARD_COLEMAK,
-	};
-
-	virtual LatinKeyboardVariant get_latin_keyboard_variant() const;
+	virtual int keyboard_get_layout_count() const;
+	virtual int keyboard_get_current_layout() const;
+	virtual void keyboard_set_current_layout(int p_index);
+	virtual String keyboard_get_layout_language(int p_index) const;
+	virtual String keyboard_get_layout_name(int p_index) const;
 
 	virtual void process_events() = 0;
 
@@ -384,6 +378,5 @@ VARIANT_ENUM_CAST(DisplayServer::ScreenOrientation)
 VARIANT_ENUM_CAST(DisplayServer::WindowMode)
 VARIANT_ENUM_CAST(DisplayServer::WindowFlags)
 VARIANT_ENUM_CAST(DisplayServer::CursorShape)
-VARIANT_ENUM_CAST(DisplayServer::LatinKeyboardVariant)
 
 #endif // DISPLAY_SERVER_H


### PR DESCRIPTION
Replaces limited and mostly useless `get_latin_keyboard_variant` function with keyboard layout enumeration (names and language codes) and getting/setting current layout.

### New functions:

```c++
int DisplayServer::keyboard_get_layout_count() const;
int DisplayServer::keyboard_get_current_layout() const;
void DisplayServer::keyboard_set_current_layout(int p_index);
String DisplayServer::keyboard_get_layout_language(int p_index) const;
String DisplayServer::keyboard_get_layout_name(int p_index) const;
```

- [x] macOS
- [x] Windows
- [x] Linux/X11
- [ ] ~Android/iOS~ (controlled by virtual keyboard, probably not needed)
- [ ] ~Web~ (not sure it's accessible for web app)

![kdb_layout_test](https://user-images.githubusercontent.com/7645683/84507532-a4b5c000-acc9-11ea-977f-bb076c09619f.gif)

### Test project:
[kbd_ind.zip](https://github.com/godotengine/godot/files/4774676/kbd_ind.zip)

Related: #5503, #39330
