### PR TITLE
Simplify some code in platform/uwp/export

### DIFF
--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -743,23 +743,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 
 		// TODO: Add resource creation or image rescaling to enable other scales:
 		// 1.25, 1.5, 2.0
-		real_t scales[] = { 1.0 };
-		bool valid_w = false;
-		bool valid_h = false;
-
-		for (int i = 0; i < 1; i++) {
-			int w = ceil(p_width * scales[i]);
-			int h = ceil(p_height * scales[i]);
-
-			if (w == p_image->get_width()) {
-				valid_w = true;
-			}
-			if (h == p_image->get_height()) {
-				valid_h = true;
-			}
-		}
-
-		return valid_w && valid_h;
+		return p_width == p_image->get_width() && p_height == p_image->get_height();
 	}
 
 	Vector<uint8_t> _fix_manifest(const Ref<EditorExportPreset> &p_preset, const Vector<uint8_t> &p_template, bool p_give_internet) const {


### PR DESCRIPTION
Supersedes and closes #37686.

This code is currently very overcomplicated considering the task it performs. There is a TODO about supporting other scales, but it doesn't seem like that is happening anytime soon since this code was written about 3 years ago.

Even if support for other scales is added, the code might need to be redone anyway, since if you took the current code and added `2.0` to the array, this would return true if the image is scaled by 1.0 on one axis and scaled by 2.0 on the other axis, which probably isn't desired. Therefore, I think it's best to simplify this code now, and other scales can be added later, with brand new code.

This could possibly be cherry-picked, but it only affects editor performance, and only when exporting, so this isn't particularly high priority code to cherry-pick.