### PR TITLE
Fix whole word search slowdown in editor

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -308,7 +308,7 @@ void FindReplaceBar::_update_results_count() {
 		}
 
 		if (is_whole_words()) {
-			from_pos++; // Making sure we won't hit the same match next time, if we get out via a continue.
+			from_pos = pos + 1; // Making sure we won't hit the same match next time, if we get out via a continue.
 			if (pos > 0 && !is_symbol(full_text[pos - 1])) {
 				continue;
 			}


### PR DESCRIPTION
Fix to ensure that the "Whole Words" option is usable when searching large files in the editor. Reduces search time when counting occurrences from O(n^2 * k) to O(nk), where n is the length of the entire text and k is the phrase to search for.

Closes #33473

Some sample large text files in a project if you wish to test: [wholeWordSearch.zip](https://github.com/godotengine/godot/files/4770075/wholeWordSearch.zip)
