### PR TITLE
Fix wrong assumption of callee thread

### DIFF
--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -30,7 +30,7 @@
 
 #define FUNC0R(m_r, m_type)                                                     \
 	virtual m_r m_type() {                                                      \
-		if (Thread::get_caller_id() != server_thread) {                         \
+		if (Thread::get_caller_id() != server_thread && create_thread) {        \
 			m_r ret;                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret); \
 			SYNC_DEBUG                                                          \
@@ -55,7 +55,7 @@
 		}                                                                                  \
 	}                                                                                      \
 	virtual RID m_type##_create() {                                                        \
-		if (Thread::get_caller_id() != server_thread) {                                    \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                   \
 			RID rid;                                                                       \
 			MutexLock lock(alloc_mutex);                                                   \
 			if (m_type##_id_pool.size() == 0) {                                            \
@@ -85,7 +85,7 @@
 		}                                                                                      \
 	}                                                                                          \
 	virtual RID m_type##_create(m_arg1 p1) {                                                   \
-		if (Thread::get_caller_id() != server_thread) {                                        \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                       \
 			RID rid;                                                                           \
 			MutexLock lock(alloc_mutex);                                                       \
 			if (m_type##_id_pool.size() == 0) {                                                \
@@ -115,7 +115,7 @@
 		}                                                                                          \
 	}                                                                                              \
 	virtual RID m_type##_create(m_arg1 p1, m_arg2 p2) {                                            \
-		if (Thread::get_caller_id() != server_thread) {                                            \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                           \
 			RID rid;                                                                               \
 			MutexLock lock(alloc_mutex);                                                           \
 			if (m_type##_id_pool.size() == 0) {                                                    \
@@ -145,7 +145,7 @@
 		}                                                                                              \
 	}                                                                                                  \
 	virtual RID m_type##_create(m_arg1 p1, m_arg2 p2, m_arg3 p3) {                                     \
-		if (Thread::get_caller_id() != server_thread) {                                                \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                               \
 			RID rid;                                                                                   \
 			MutexLock lock(alloc_mutex);                                                               \
 			if (m_type##_id_pool.size() == 0) {                                                        \
@@ -175,7 +175,7 @@
 		}                                                                                                  \
 	}                                                                                                      \
 	virtual RID m_type##_create(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) {                              \
-		if (Thread::get_caller_id() != server_thread) {                                                    \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                   \
 			RID rid;                                                                                       \
 			MutexLock lock(alloc_mutex);                                                                   \
 			if (m_type##_id_pool.size() == 0) {                                                            \
@@ -206,7 +206,7 @@
 		}                                                                                                      \
 	}                                                                                                          \
 	virtual RID m_type##_create(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) {                       \
-		if (Thread::get_caller_id() != server_thread) {                                                        \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                       \
 			RID rid;                                                                                           \
 			MutexLock lock(alloc_mutex);                                                                       \
 			if (m_type##_id_pool.size() == 0) {                                                                \
@@ -224,7 +224,7 @@
 
 #define FUNC0RC(m_r, m_type)                                                    \
 	virtual m_r m_type() const {                                                \
-		if (Thread::get_caller_id() != server_thread) {                         \
+		if (Thread::get_caller_id() != server_thread && create_thread) {        \
 			m_r ret;                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret); \
 			SYNC_DEBUG                                                          \
@@ -234,27 +234,27 @@
 		}                                                                       \
 	}
 
-#define FUNC0(m_type)                                             \
-	virtual void m_type() {                                       \
-		if (Thread::get_caller_id() != server_thread) {           \
-			command_queue.push(server_name, &ServerName::m_type); \
-		} else {                                                  \
-			server_name->m_type();                                \
-		}                                                         \
+#define FUNC0(m_type)                                                    \
+	virtual void m_type() {                                              \
+		if (Thread::get_caller_id() != server_thread && create_thread) { \
+			command_queue.push(server_name, &ServerName::m_type);        \
+		} else {                                                         \
+			server_name->m_type();                                       \
+		}                                                                \
 	}
 
-#define FUNC0C(m_type)                                            \
-	virtual void m_type() const {                                 \
-		if (Thread::get_caller_id() != server_thread) {           \
-			command_queue.push(server_name, &ServerName::m_type); \
-		} else {                                                  \
-			server_name->m_type();                                \
-		}                                                         \
+#define FUNC0C(m_type)                                                   \
+	virtual void m_type() const {                                        \
+		if (Thread::get_caller_id() != server_thread && create_thread) { \
+			command_queue.push(server_name, &ServerName::m_type);        \
+		} else {                                                         \
+			server_name->m_type();                                       \
+		}                                                                \
 	}
 
 #define FUNC0S(m_type)                                                     \
 	virtual void m_type() {                                                \
-		if (Thread::get_caller_id() != server_thread) {                    \
+		if (Thread::get_caller_id() != server_thread && create_thread) {   \
 			command_queue.push_and_sync(server_name, &ServerName::m_type); \
 			SYNC_DEBUG                                                     \
 		} else {                                                           \
@@ -264,7 +264,7 @@
 
 #define FUNC0SC(m_type)                                                    \
 	virtual void m_type() const {                                          \
-		if (Thread::get_caller_id() != server_thread) {                    \
+		if (Thread::get_caller_id() != server_thread && create_thread) {   \
 			command_queue.push_and_sync(server_name, &ServerName::m_type); \
 			SYNC_DEBUG                                                     \
 		} else {                                                           \
@@ -276,7 +276,7 @@
 
 #define FUNC1R(m_r, m_type, m_arg1)                                                 \
 	virtual m_r m_type(m_arg1 p1) {                                                 \
-		if (Thread::get_caller_id() != server_thread) {                             \
+		if (Thread::get_caller_id() != server_thread && create_thread) {            \
 			m_r ret;                                                                \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, &ret); \
 			SYNC_DEBUG                                                              \
@@ -288,7 +288,7 @@
 
 #define FUNC1RC(m_r, m_type, m_arg1)                                                \
 	virtual m_r m_type(m_arg1 p1) const {                                           \
-		if (Thread::get_caller_id() != server_thread) {                             \
+		if (Thread::get_caller_id() != server_thread && create_thread) {            \
 			m_r ret;                                                                \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, &ret); \
 			SYNC_DEBUG                                                              \
@@ -300,7 +300,7 @@
 
 #define FUNC1S(m_type, m_arg1)                                                 \
 	virtual void m_type(m_arg1 p1) {                                           \
-		if (Thread::get_caller_id() != server_thread) {                        \
+		if (Thread::get_caller_id() != server_thread && create_thread) {       \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1); \
 			SYNC_DEBUG                                                         \
 		} else {                                                               \
@@ -310,7 +310,7 @@
 
 #define FUNC1SC(m_type, m_arg1)                                                \
 	virtual void m_type(m_arg1 p1) const {                                     \
-		if (Thread::get_caller_id() != server_thread) {                        \
+		if (Thread::get_caller_id() != server_thread && create_thread) {       \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1); \
 			SYNC_DEBUG                                                         \
 		} else {                                                               \
@@ -318,27 +318,27 @@
 		}                                                                      \
 	}
 
-#define FUNC1(m_type, m_arg1)                                         \
-	virtual void m_type(m_arg1 p1) {                                  \
-		if (Thread::get_caller_id() != server_thread) {               \
-			command_queue.push(server_name, &ServerName::m_type, p1); \
-		} else {                                                      \
-			server_name->m_type(p1);                                  \
-		}                                                             \
+#define FUNC1(m_type, m_arg1)                                            \
+	virtual void m_type(m_arg1 p1) {                                     \
+		if (Thread::get_caller_id() != server_thread && create_thread) { \
+			command_queue.push(server_name, &ServerName::m_type, p1);    \
+		} else {                                                         \
+			server_name->m_type(p1);                                     \
+		}                                                                \
 	}
 
-#define FUNC1C(m_type, m_arg1)                                        \
-	virtual void m_type(m_arg1 p1) const {                            \
-		if (Thread::get_caller_id() != server_thread) {               \
-			command_queue.push(server_name, &ServerName::m_type, p1); \
-		} else {                                                      \
-			server_name->m_type(p1);                                  \
-		}                                                             \
+#define FUNC1C(m_type, m_arg1)                                           \
+	virtual void m_type(m_arg1 p1) const {                               \
+		if (Thread::get_caller_id() != server_thread && create_thread) { \
+			command_queue.push(server_name, &ServerName::m_type, p1);    \
+		} else {                                                         \
+			server_name->m_type(p1);                                     \
+		}                                                                \
 	}
 
 #define FUNC2R(m_r, m_type, m_arg1, m_arg2)                                             \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2) {                                          \
-		if (Thread::get_caller_id() != server_thread) {                                 \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                \
 			m_r ret;                                                                    \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, &ret); \
 			SYNC_DEBUG                                                                  \
@@ -350,7 +350,7 @@
 
 #define FUNC2RC(m_r, m_type, m_arg1, m_arg2)                                            \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2) const {                                    \
-		if (Thread::get_caller_id() != server_thread) {                                 \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                \
 			m_r ret;                                                                    \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, &ret); \
 			SYNC_DEBUG                                                                  \
@@ -362,7 +362,7 @@
 
 #define FUNC2S(m_type, m_arg1, m_arg2)                                             \
 	virtual void m_type(m_arg1 p1, m_arg2 p2) {                                    \
-		if (Thread::get_caller_id() != server_thread) {                            \
+		if (Thread::get_caller_id() != server_thread && create_thread) {           \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2); \
 			SYNC_DEBUG                                                             \
 		} else {                                                                   \
@@ -372,7 +372,7 @@
 
 #define FUNC2SC(m_type, m_arg1, m_arg2)                                            \
 	virtual void m_type(m_arg1 p1, m_arg2 p2) const {                              \
-		if (Thread::get_caller_id() != server_thread) {                            \
+		if (Thread::get_caller_id() != server_thread && create_thread) {           \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2); \
 			SYNC_DEBUG                                                             \
 		} else {                                                                   \
@@ -382,7 +382,7 @@
 
 #define FUNC2(m_type, m_arg1, m_arg2)                                     \
 	virtual void m_type(m_arg1 p1, m_arg2 p2) {                           \
-		if (Thread::get_caller_id() != server_thread) {                   \
+		if (Thread::get_caller_id() != server_thread && create_thread) {  \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2); \
 		} else {                                                          \
 			server_name->m_type(p1, p2);                                  \
@@ -391,7 +391,7 @@
 
 #define FUNC2C(m_type, m_arg1, m_arg2)                                    \
 	virtual void m_type(m_arg1 p1, m_arg2 p2) const {                     \
-		if (Thread::get_caller_id() != server_thread) {                   \
+		if (Thread::get_caller_id() != server_thread && create_thread) {  \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2); \
 		} else {                                                          \
 			server_name->m_type(p1, p2);                                  \
@@ -400,7 +400,7 @@
 
 #define FUNC3R(m_r, m_type, m_arg1, m_arg2, m_arg3)                                         \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) {                                   \
-		if (Thread::get_caller_id() != server_thread) {                                     \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                    \
 			m_r ret;                                                                        \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, &ret); \
 			SYNC_DEBUG                                                                      \
@@ -412,7 +412,7 @@
 
 #define FUNC3RC(m_r, m_type, m_arg1, m_arg2, m_arg3)                                        \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) const {                             \
-		if (Thread::get_caller_id() != server_thread) {                                     \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                    \
 			m_r ret;                                                                        \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, &ret); \
 			SYNC_DEBUG                                                                      \
@@ -424,7 +424,7 @@
 
 #define FUNC3S(m_type, m_arg1, m_arg2, m_arg3)                                         \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) {                             \
-		if (Thread::get_caller_id() != server_thread) {                                \
+		if (Thread::get_caller_id() != server_thread && create_thread) {               \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3); \
 			SYNC_DEBUG                                                                 \
 		} else {                                                                       \
@@ -434,7 +434,7 @@
 
 #define FUNC3SC(m_type, m_arg1, m_arg2, m_arg3)                                        \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) const {                       \
-		if (Thread::get_caller_id() != server_thread) {                                \
+		if (Thread::get_caller_id() != server_thread && create_thread) {               \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3); \
 			SYNC_DEBUG                                                                 \
 		} else {                                                                       \
@@ -444,7 +444,7 @@
 
 #define FUNC3(m_type, m_arg1, m_arg2, m_arg3)                                 \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) {                    \
-		if (Thread::get_caller_id() != server_thread) {                       \
+		if (Thread::get_caller_id() != server_thread && create_thread) {      \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3); \
 		} else {                                                              \
 			server_name->m_type(p1, p2, p3);                                  \
@@ -453,7 +453,7 @@
 
 #define FUNC3C(m_type, m_arg1, m_arg2, m_arg3)                                \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) const {              \
-		if (Thread::get_caller_id() != server_thread) {                       \
+		if (Thread::get_caller_id() != server_thread && create_thread) {      \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3); \
 		} else {                                                              \
 			server_name->m_type(p1, p2, p3);                                  \
@@ -462,7 +462,7 @@
 
 #define FUNC4R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4)                                     \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) {                            \
-		if (Thread::get_caller_id() != server_thread) {                                         \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                        \
 			m_r ret;                                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, &ret); \
 			SYNC_DEBUG                                                                          \
@@ -474,7 +474,7 @@
 
 #define FUNC4RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4)                                    \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) const {                      \
-		if (Thread::get_caller_id() != server_thread) {                                         \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                        \
 			m_r ret;                                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, &ret); \
 			SYNC_DEBUG                                                                          \
@@ -486,7 +486,7 @@
 
 #define FUNC4S(m_type, m_arg1, m_arg2, m_arg3, m_arg4)                                     \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) {                      \
-		if (Thread::get_caller_id() != server_thread) {                                    \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                   \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4); \
 			SYNC_DEBUG                                                                     \
 		} else {                                                                           \
@@ -496,7 +496,7 @@
 
 #define FUNC4SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4)                                    \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) const {                \
-		if (Thread::get_caller_id() != server_thread) {                                    \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                   \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4); \
 			SYNC_DEBUG                                                                     \
 		} else {                                                                           \
@@ -506,7 +506,7 @@
 
 #define FUNC4(m_type, m_arg1, m_arg2, m_arg3, m_arg4)                             \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) {             \
-		if (Thread::get_caller_id() != server_thread) {                           \
+		if (Thread::get_caller_id() != server_thread && create_thread) {          \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4); \
 		} else {                                                                  \
 			server_name->m_type(p1, p2, p3, p4);                                  \
@@ -515,7 +515,7 @@
 
 #define FUNC4C(m_type, m_arg1, m_arg2, m_arg3, m_arg4)                            \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) const {       \
-		if (Thread::get_caller_id() != server_thread) {                           \
+		if (Thread::get_caller_id() != server_thread && create_thread) {          \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4); \
 		} else {                                                                  \
 			server_name->m_type(p1, p2, p3, p4);                                  \
@@ -524,7 +524,7 @@
 
 #define FUNC5R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                 \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) {                     \
-		if (Thread::get_caller_id() != server_thread) {                                             \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                            \
 			m_r ret;                                                                                \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, &ret); \
 			SYNC_DEBUG                                                                              \
@@ -536,7 +536,7 @@
 
 #define FUNC5RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) const {               \
-		if (Thread::get_caller_id() != server_thread) {                                             \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                            \
 			m_r ret;                                                                                \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, &ret); \
 			SYNC_DEBUG                                                                              \
@@ -548,7 +548,7 @@
 
 #define FUNC5S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                 \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) {               \
-		if (Thread::get_caller_id() != server_thread) {                                        \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                       \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5); \
 			SYNC_DEBUG                                                                         \
 		} else {                                                                               \
@@ -558,7 +558,7 @@
 
 #define FUNC5SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) const {         \
-		if (Thread::get_caller_id() != server_thread) {                                        \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                       \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5); \
 			SYNC_DEBUG                                                                         \
 		} else {                                                                               \
@@ -568,7 +568,7 @@
 
 #define FUNC5(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                         \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) {      \
-		if (Thread::get_caller_id() != server_thread) {                               \
+		if (Thread::get_caller_id() != server_thread && create_thread) {              \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5); \
 		} else {                                                                      \
 			server_name->m_type(p1, p2, p3, p4, p5);                                  \
@@ -577,7 +577,7 @@
 
 #define FUNC5C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                         \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) const { \
-		if (Thread::get_caller_id() != server_thread) {                                \
+		if (Thread::get_caller_id() != server_thread && create_thread) {               \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5);  \
 		} else {                                                                       \
 			server_name->m_type(p1, p2, p3, p4, p5);                                   \
@@ -586,7 +586,7 @@
 
 #define FUNC6R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                             \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) {              \
-		if (Thread::get_caller_id() != server_thread) {                                                 \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                \
 			m_r ret;                                                                                    \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, &ret); \
 			SYNC_DEBUG                                                                                  \
@@ -598,7 +598,7 @@
 
 #define FUNC6RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                            \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) const {        \
-		if (Thread::get_caller_id() != server_thread) {                                                 \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                \
 			m_r ret;                                                                                    \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, &ret); \
 			SYNC_DEBUG                                                                                  \
@@ -610,7 +610,7 @@
 
 #define FUNC6S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                             \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) {        \
-		if (Thread::get_caller_id() != server_thread) {                                            \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                           \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6); \
 			SYNC_DEBUG                                                                             \
 		} else {                                                                                   \
@@ -620,7 +620,7 @@
 
 #define FUNC6SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                            \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) const {  \
-		if (Thread::get_caller_id() != server_thread) {                                            \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                           \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6); \
 			SYNC_DEBUG                                                                             \
 		} else {                                                                                   \
@@ -630,7 +630,7 @@
 
 #define FUNC6(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                       \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) { \
-		if (Thread::get_caller_id() != server_thread) {                                     \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                    \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6);   \
 		} else {                                                                            \
 			server_name->m_type(p1, p2, p3, p4, p5, p6);                                    \
@@ -639,7 +639,7 @@
 
 #define FUNC6C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                            \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) const { \
-		if (Thread::get_caller_id() != server_thread) {                                           \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                          \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6);         \
 		} else {                                                                                  \
 			server_name->m_type(p1, p2, p3, p4, p5, p6);                                          \
@@ -648,7 +648,7 @@
 
 #define FUNC7R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                         \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) {       \
-		if (Thread::get_caller_id() != server_thread) {                                                     \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                    \
 			m_r ret;                                                                                        \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, &ret); \
 			SYNC_DEBUG                                                                                      \
@@ -660,7 +660,7 @@
 
 #define FUNC7RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                        \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) const { \
-		if (Thread::get_caller_id() != server_thread) {                                                     \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                    \
 			m_r ret;                                                                                        \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, &ret); \
 			SYNC_DEBUG                                                                                      \
@@ -672,7 +672,7 @@
 
 #define FUNC7S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                         \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) { \
-		if (Thread::get_caller_id() != server_thread) {                                                \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                               \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7); \
 			SYNC_DEBUG                                                                                 \
 		} else {                                                                                       \
@@ -682,7 +682,7 @@
 
 #define FUNC7SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                              \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) const { \
-		if (Thread::get_caller_id() != server_thread) {                                                      \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                     \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);       \
 			SYNC_DEBUG                                                                                       \
 		} else {                                                                                             \
@@ -692,7 +692,7 @@
 
 #define FUNC7(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                          \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) { \
-		if (Thread::get_caller_id() != server_thread) {                                                \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                               \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);          \
 		} else {                                                                                       \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7);                                           \
@@ -701,7 +701,7 @@
 
 #define FUNC7C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                               \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) const { \
-		if (Thread::get_caller_id() != server_thread) {                                                      \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                     \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);                \
 		} else {                                                                                             \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7);                                                 \
@@ -710,7 +710,7 @@
 
 #define FUNC8R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                      \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) { \
-		if (Thread::get_caller_id() != server_thread) {                                                          \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                         \
 			m_r ret;                                                                                             \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, &ret);  \
 			SYNC_DEBUG                                                                                           \
@@ -722,7 +722,7 @@
 
 #define FUNC8RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                           \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) const { \
-		if (Thread::get_caller_id() != server_thread) {                                                                \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                               \
 			m_r ret;                                                                                                   \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, &ret);        \
 			SYNC_DEBUG                                                                                                 \
@@ -734,7 +734,7 @@
 
 #define FUNC8S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                            \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) { \
-		if (Thread::get_caller_id() != server_thread) {                                                           \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                          \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);        \
 			SYNC_DEBUG                                                                                            \
 		} else {                                                                                                  \
@@ -744,7 +744,7 @@
 
 #define FUNC8SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                                 \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) const { \
-		if (Thread::get_caller_id() != server_thread) {                                                                 \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                                \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);              \
 			SYNC_DEBUG                                                                                                  \
 		} else {                                                                                                        \
@@ -754,7 +754,7 @@
 
 #define FUNC8(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                             \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) { \
-		if (Thread::get_caller_id() != server_thread) {                                                           \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                          \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);                 \
 		} else {                                                                                                  \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);                                                  \
@@ -763,7 +763,7 @@
 
 #define FUNC8C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                                  \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) const { \
-		if (Thread::get_caller_id() != server_thread) {                                                                 \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                                \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);                       \
 		} else {                                                                                                        \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8);                                                        \
@@ -772,7 +772,7 @@
 
 #define FUNC9(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9)                                \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9) { \
-		if (Thread::get_caller_id() != server_thread) {                                                                      \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                                     \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9);                        \
 		} else {                                                                                                             \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9);                                                         \
@@ -781,7 +781,7 @@
 
 #define FUNC10(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10)                                   \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10) { \
-		if (Thread::get_caller_id() != server_thread) {                                                                                   \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                                                  \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);                                \
 		} else {                                                                                                                          \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);                                                                 \
@@ -790,7 +790,7 @@
 
 #define FUNC11(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11)                                       \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11) { \
-		if (Thread::get_caller_id() != server_thread) {                                                                                                \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                                                               \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);                                        \
 		} else {                                                                                                                                       \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);                                                                         \
@@ -799,7 +799,7 @@
 
 #define FUNC12(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12)                                           \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11, m_arg12 p12) { \
-		if (Thread::get_caller_id() != server_thread) {                                                                                                             \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                                                                            \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12);                                                \
 		} else {                                                                                                                                                    \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12);                                                                                 \
@@ -808,7 +808,7 @@
 
 #define FUNC13(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12, m_arg13)                                               \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11, m_arg12 p12, m_arg13 p13) { \
-		if (Thread::get_caller_id() != server_thread) {                                                                                                                          \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                                                                                         \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13);                                                        \
 		} else {                                                                                                                                                                 \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13);                                                                                         \
@@ -817,7 +817,7 @@
 
 #define FUNC14(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12, m_arg13, m_arg14)                                                   \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11, m_arg12 p12, m_arg13 p13, m_arg14 p14) { \
-		if (Thread::get_caller_id() != server_thread) {                                                                                                                                       \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                                                                                                      \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14);                                                                \
 		} else {                                                                                                                                                                              \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14);                                                                                                 \
@@ -826,7 +826,7 @@
 
 #define FUNC15(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12, m_arg13, m_arg14, m_arg15)                                                       \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11, m_arg12 p12, m_arg13 p13, m_arg14 p14, m_arg15 p15) { \
-		if (Thread::get_caller_id() != server_thread) {                                                                                                                                                    \
+		if (Thread::get_caller_id() != server_thread && create_thread) {                                                                                                                                   \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15);                                                                        \
 		} else {                                                                                                                                                                                           \
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15);                                                                                                         \


### PR DESCRIPTION
Fixes #39392

I think Godot was making a wrong assumption here: if `Thread::get_caller_id() != server_thread` failed, it would assume the render thread was running in a separate thread, which might not be the case, as shown in the issue.

This added check fixes this.