### PR TITLE
Fixes the stopping of animation effects in bbcode text after appending

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2409,6 +2409,17 @@ Error RichTextLabel::append_bbcode(const String &p_bbcode) {
 		}
 	}
 
+	Vector<ItemFX *> fx_items;
+	for (List<Item *>::Element *E = main->subitems.front(); E; E = E->next()) {
+		Item *subitem = static_cast<Item *>(E->get());
+		_fetch_item_fx_stack(subitem, fx_items);
+
+		if (fx_items.size()) {
+			set_process_internal(true);
+			break;
+		}
+	}
+
 	return OK;
 }
 


### PR DESCRIPTION
Fixes #38169

**Reason:** `set_process_internal()` would be set to false before appending, but wouldn't be set to true after appending(in `append_bbcode()` function) as there was no condition to check if the text contained animation effects.
**Fix:** Introduced a check to call `set_process_internal(true)` if there are any animation effects in the bbcode text.
**Results:**
Now, rich effects text can be appended without stopping the animation.
![RTLEffectsDemo 2020-06-12 23-57-39_Trim](https://user-images.githubusercontent.com/41969735/84536986-8f15ba00-ad0c-11ea-8b64-6912ad1c1de7.gif)
