### PR TITLE
Fixed "Favourite Project" button in Project Manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1741,10 +1741,6 @@ void ProjectList::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
 			select_project(clicked_index);
 		}
 
-		if (_selected_project_keys.has(clicked_project.project_key)) {
-			clicked_project.control->grab_focus();
-		}
-
 		emit_signal(SIGNAL_SELECTION_CHANGED);
 
 		if (!mb->get_control() && mb->is_doubleclick()) {


### PR DESCRIPTION
Fixes a regression caused by 1ec8f59397c157e9f826e1cd53e7790315c969d7 where clicking on a "star" button in Project Manager has stopped working.

I need to ask someone else to test it on master branch since i have troubles compiling it.

*Bugsquad edit:* PR for `3.2`: #39501.