### PR TITLE
[3.2] Ensure pair callback data is set to null when it's null.

### DIFF
--- a/servers/physics_2d/broad_phase_2d_hash_grid.cpp
+++ b/servers/physics_2d/broad_phase_2d_hash_grid.cpp
@@ -83,10 +83,7 @@ void BroadPhase2DHashGrid::_check_motion(Element *p_elem) {
 			if (pairing) {
 
 				if (pair_callback) {
-					void *ud = pair_callback(p_elem->owner, p_elem->subindex, E->key()->owner, E->key()->subindex, pair_userdata);
-					if (ud) {
-						E->get()->ud = ud;
-					}
+					E->get()->ud = pair_callback(p_elem->owner, p_elem->subindex, E->key()->owner, E->key()->subindex, pair_userdata);
 				}
 			} else {
 


### PR DESCRIPTION
Fixes #39487
Fixes #39500 
