### PR TITLE
Ensure pair callback data is set to null when it's null.

### DIFF
--- a/servers/physics_2d/broad_phase_2d_hash_grid.cpp
+++ b/servers/physics_2d/broad_phase_2d_hash_grid.cpp
@@ -75,10 +75,7 @@ void BroadPhase2DHashGrid::_check_motion(Element *p_elem) {
 		if (pairing != E->get()->colliding) {
 			if (pairing) {
 				if (pair_callback) {
-					void *ud = pair_callback(p_elem->owner, p_elem->subindex, E->key()->owner, E->key()->subindex, pair_userdata);
-					if (ud) {
-						E->get()->ud = ud;
-					}
+					E->get()->ud = pair_callback(p_elem->owner, p_elem->subindex, E->key()->owner, E->key()->subindex, pair_userdata);
 				}
 			} else {
 				if (unpair_callback) {


### PR DESCRIPTION
Master branch version of #39504.

Fixes #39487
Fixes #39500