### PR TITLE
add warning for move_and_slide()

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1047,8 +1047,10 @@ Vector2 KinematicBody2D::move_and_slide(const Vector2 &p_linear_velocity, const 
 					//all is a wall
 					on_wall = true;
 				} else {
+					if (!p_up_direction.is_normalized()) {
+						WARN_PRINT("move_and_slide() up_direction should be normalized; wall, floor, and ceiling checks may not work properly.");
+					}
 					if (Math::acos(collision.normal.dot(p_up_direction)) <= p_floor_max_angle + FLOOR_ANGLE_THRESHOLD) { //floor
-
 						on_floor = true;
 						floor_normal = collision.normal;
 						on_floor_body = collision.collider_rid;

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -992,6 +992,9 @@ Vector3 KinematicBody3D::move_and_slide(const Vector3 &p_linear_velocity, const 
 					//all is a wall
 					on_wall = true;
 				} else {
+					if (!p_up_direction.is_normalized()) {
+						WARN_PRINT("move_and_slide() up_direction should be normalized; wall, floor, and ceiling checks may not work properly.");
+					}
 					if (Math::acos(collision.normal.dot(p_up_direction)) <= p_floor_max_angle + FLOOR_ANGLE_THRESHOLD) { //floor
 
 						on_floor = true;


### PR DESCRIPTION
This adds warning for both 3d and 2d move_and_slide when the up direction is not a normalized vector. This is (a fix?) for #39506.