### PR TITLE
Make collision with TileMaps useful

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -55,6 +55,15 @@
 				Returns the tile index of the cell given by a Vector2. If no tile exists in the cell, returns [constant INVALID_CELL].
 			</description>
 		</method>
+		<method name="get_cell_from_shape">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="shape_id" type="int">
+			</argument>
+			<description>
+				Returns the coordinate of the cell referenced by the shape_id. Returns a zero vector if the [code]shape_id[/code] is non-existent and prints error. Useful in [code]*_shape_entered[/code] methods with the [code]body_shape[/code] parameter
+			</description>
+		</method>
 		<method name="get_collision_layer_bit" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -71,6 +80,13 @@
 			</argument>
 			<description>
 				Returns [code]true[/code] if the given collision mask bit is set.
+			</description>
+		</method>
+		<method name="get_rid">
+			<return type="RID">
+			</return>
+			<description>
+				Returns the [code]RID[/code] of the [code]TileMap[/code]. Use the [code]RID[/code] of the parent, when [code]use_parent[/code] is enabled.
 			</description>
 		</method>
 		<method name="get_used_cells" qualifiers="const">

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -75,6 +75,7 @@ protected:
 
 	void _update_pickable();
 	friend class Viewport;
+	friend class TileMap;
 	void _input_event(Node *p_viewport, const Ref<InputEvent> &p_input_event, int p_shape);
 	void _mouse_enter();
 	void _mouse_exit();

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -117,10 +117,7 @@ void TileMap::_notification(int p_what) {
 
 void TileMap::_update_quadrant_space(const RID &p_space) {
 	if (!use_parent) {
-		for (Map<PosKey, Quadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
-			Quadrant &q = E->get();
-			PhysicsServer2D::get_singleton()->body_set_space(q.body, p_space);
-		}
+		PhysicsServer2D::get_singleton()->body_set_space(rid, p_space);
 	}
 }
 
@@ -131,25 +128,14 @@ void TileMap::_update_quadrant_transform() {
 
 	Transform2D global_transform = get_global_transform();
 
-	Transform2D local_transform;
-	if (collision_parent) {
-		local_transform = get_transform();
-	}
-
 	Transform2D nav_rel;
 	if (navigation) {
 		nav_rel = get_relative_transform_to_parent(navigation);
 	}
 
+	PhysicsServer2D::get_singleton()->body_set_state(rid, PhysicsServer2D::BODY_STATE_TRANSFORM, global_transform);
 	for (Map<PosKey, Quadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
 		Quadrant &q = E->get();
-		Transform2D xform;
-		xform.set_origin(q.pos);
-
-		if (!use_parent) {
-			xform = global_transform * xform;
-			PhysicsServer2D::get_singleton()->body_set_state(q.body, PhysicsServer2D::BODY_STATE_TRANSFORM, xform);
-		}
 
 		if (navigation) {
 			for (Map<PosKey, Quadrant::NavPoly>::Element *F = q.navpoly_ids.front(); F; F = F->next()) {
@@ -278,13 +264,140 @@ void TileMap::_fix_cell_transform(Transform2D &xform, const Cell &p_cell, const 
 	xform.elements[2] += offset;
 }
 
+uint32_t TileMap::_create_shape_owner() {
+	if (!use_parent) {
+		CollisionObject2D::ShapeData sd;
+		uint32_t id;
+
+		if (shapes.size() == 0) {
+			id = 0;
+		} else {
+			id = shapes.back()->key() + 1;
+		}
+
+		sd.owner = this;
+
+		shapes[id] = sd;
+
+		return id;
+	}
+	if (collision_parent) {
+		return collision_parent->create_shape_owner(this);
+	}
+	return -1;
+}
+
+void TileMap::_shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape) {
+	if (!use_parent) {
+		ERR_FAIL_COND(!shapes.has(p_owner));
+		ERR_FAIL_COND(p_shape.is_null());
+
+		CollisionObject2D::ShapeData &sd = shapes[p_owner];
+		CollisionObject2D::ShapeData::Shape s;
+		s.index = total_subshapes;
+		s.shape = p_shape;
+		PhysicsServer2D::get_singleton()->body_add_shape(rid, p_shape->get_rid(), sd.xform, sd.disabled);
+
+		sd.shapes.push_back(s);
+
+		total_subshapes++;
+		return;
+	}
+	if (collision_parent) {
+		collision_parent->shape_owner_add_shape(p_owner, p_shape);
+	}
+}
+
+int TileMap::_shape_owner_get_shape_index(uint32_t p_owner, int p_shape) const {
+	if (!use_parent) {
+		ERR_FAIL_COND_V(!shapes.has(p_owner), -1);
+		ERR_FAIL_INDEX_V(p_shape, shapes[p_owner].shapes.size(), -1);
+
+		return shapes[p_owner].shapes[p_shape].index;
+	}
+	if (collision_parent) {
+		return collision_parent->shape_owner_get_shape_index(p_owner, p_shape);
+	}
+	ERR_FAIL_V_MSG(-1, "No collision parent set.");
+}
+
+void TileMap::_shape_owner_clear_shapes(uint32_t p_owner) {
+	if (!use_parent) {
+		ERR_FAIL_COND(!shapes.has(p_owner));
+
+		while (_shape_owner_get_shape_count(p_owner) > 0) {
+			_shape_owner_remove_shape(p_owner, 0);
+		}
+		return;
+	}
+	if (collision_parent) {
+		collision_parent->shape_owner_clear_shapes(p_owner);
+	}
+}
+
+int TileMap::_shape_owner_get_shape_count(uint32_t p_owner) const {
+	if (!use_parent) {
+		ERR_FAIL_COND_V(!shapes.has(p_owner), 0);
+
+		return shapes[p_owner].shapes.size();
+	}
+	if (collision_parent) {
+		return collision_parent->shape_owner_get_shape_count(p_owner);
+	}
+	return 0;
+}
+
+void TileMap::_shape_owner_remove_shape(uint32_t p_owner, int p_shape) {
+	if (!use_parent) {
+		ERR_FAIL_COND(!shapes.has(p_owner));
+		ERR_FAIL_INDEX(p_shape, shapes[p_owner].shapes.size());
+
+		int index_to_remove = shapes[p_owner].shapes[p_shape].index;
+		PhysicsServer2D::get_singleton()->body_remove_shape(rid, index_to_remove);
+
+		shapes[p_owner].shapes.remove(p_shape);
+
+		for (Map<uint32_t, CollisionObject2D::ShapeData>::Element *E = shapes.front(); E; E = E->next()) {
+			for (int i = 0; i < E->get().shapes.size(); i++) {
+				if (E->get().shapes[i].index > index_to_remove) {
+					E->get().shapes.write[i].index -= 1;
+				}
+			}
+		}
+
+		total_subshapes--;
+		return;
+	}
+	if (collision_parent) {
+		collision_parent->shape_owner_remove_shape(p_owner, p_shape);
+	}
+}
+
+void TileMap::_remove_shape_owner(uint32_t p_owner) {
+	if (!use_parent) {
+		ERR_FAIL_COND(!shapes.has(p_owner));
+
+		_shape_owner_clear_shapes(p_owner);
+
+		shapes.erase(p_owner);
+		return;
+	}
+	if (collision_parent) {
+		collision_parent->remove_shape_owner(p_owner);
+	}
+}
+
 void TileMap::_add_shape(int &shape_idx, const Quadrant &p_q, const Ref<Shape2D> &p_shape, const TileSet::ShapeData &p_shape_data, const Transform2D &p_xform, const Vector2 &p_metadata) {
 	PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
 
 	if (!use_parent) {
-		ps->body_add_shape(p_q.body, p_shape->get_rid(), p_xform);
-		ps->body_set_shape_metadata(p_q.body, shape_idx, p_metadata);
-		ps->body_set_shape_as_one_way_collision(p_q.body, shape_idx, p_shape_data.one_way_collision, p_shape_data.one_way_collision_margin);
+		Transform2D xform = p_xform;
+		xform.set_origin(xform.get_origin() + p_q.pos);
+		_shape_owner_add_shape(p_q.shape_owner_id, p_shape);
+		int real_index = _shape_owner_get_shape_index(p_q.shape_owner_id, shape_idx);
+		ps->body_set_shape_transform(rid, real_index, get_transform() * xform);
+		ps->body_set_shape_metadata(rid, real_index, p_metadata);
+		ps->body_set_shape_as_one_way_collision(rid, real_index, p_shape_data.one_way_collision, p_shape_data.one_way_collision_margin);
 
 	} else if (collision_parent) {
 		Transform2D xform = p_xform;
@@ -316,7 +429,6 @@ void TileMap::update_dirty_quadrants() {
 	}
 
 	RenderingServer *vs = RenderingServer::get_singleton();
-	PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
 	Vector2 tofs = get_cell_draw_offset();
 	Transform2D nav_rel;
 	if (navigation) {
@@ -348,11 +460,8 @@ void TileMap::update_dirty_quadrants() {
 
 		q.canvas_items.clear();
 
-		if (!use_parent) {
-			ps->body_clear_shapes(q.body);
-		} else if (collision_parent) {
-			collision_parent->shape_owner_clear_shapes(q.shape_owner_id);
-		}
+		_shape_owner_clear_shapes(q.shape_owner_id);
+		shape_cells.clear();
 		int shape_idx = 0;
 
 		if (navigation) {
@@ -730,8 +839,6 @@ void TileMap::_recompute_rect_cache() {
 }
 
 Map<TileMap::PosKey, TileMap::Quadrant>::Element *TileMap::_create_quadrant(const PosKey &p_qk) {
-	Transform2D xform;
-	//xform.set_origin(Point2(p_qk.x,p_qk.y)*cell_size*quadrant_size);
 	Quadrant q;
 	q.pos = _map_to_world(p_qk.x * _get_quadrant_size(), p_qk.y * _get_quadrant_size());
 	q.pos += get_cell_draw_offset();
@@ -741,31 +848,7 @@ Map<TileMap::PosKey, TileMap::Quadrant>::Element *TileMap::_create_quadrant(cons
 		q.pos.y += cell_size.y;
 	}
 
-	xform.set_origin(q.pos);
-	//q.canvas_item = RenderingServer::get_singleton()->canvas_item_create();
-	if (!use_parent) {
-		q.body = PhysicsServer2D::get_singleton()->body_create();
-		PhysicsServer2D::get_singleton()->body_set_mode(q.body, use_kinematic ? PhysicsServer2D::BODY_MODE_KINEMATIC : PhysicsServer2D::BODY_MODE_STATIC);
-
-		PhysicsServer2D::get_singleton()->body_attach_object_instance_id(q.body, get_instance_id());
-		PhysicsServer2D::get_singleton()->body_set_collision_layer(q.body, collision_layer);
-		PhysicsServer2D::get_singleton()->body_set_collision_mask(q.body, collision_mask);
-		PhysicsServer2D::get_singleton()->body_set_param(q.body, PhysicsServer2D::BODY_PARAM_FRICTION, friction);
-		PhysicsServer2D::get_singleton()->body_set_param(q.body, PhysicsServer2D::BODY_PARAM_BOUNCE, bounce);
-
-		if (is_inside_tree()) {
-			xform = get_global_transform() * xform;
-			RID space = get_world_2d()->get_space();
-			PhysicsServer2D::get_singleton()->body_set_space(q.body, space);
-		}
-
-		PhysicsServer2D::get_singleton()->body_set_state(q.body, PhysicsServer2D::BODY_STATE_TRANSFORM, xform);
-	} else if (collision_parent) {
-		xform = get_transform() * xform;
-		q.shape_owner_id = collision_parent->create_shape_owner(this);
-	} else {
-		q.shape_owner_id = -1;
-	}
+	q.shape_owner_id = _create_shape_owner();
 
 	rect_cache_dirty = true;
 	quadrant_order_dirty = true;
@@ -774,11 +857,7 @@ Map<TileMap::PosKey, TileMap::Quadrant>::Element *TileMap::_create_quadrant(cons
 
 void TileMap::_erase_quadrant(Map<PosKey, Quadrant>::Element *Q) {
 	Quadrant &q = Q->get();
-	if (!use_parent) {
-		PhysicsServer2D::get_singleton()->free(q.body);
-	} else if (collision_parent) {
-		collision_parent->remove_shape_owner(q.shape_owner_id);
-	}
+	_remove_shape_owner(q.shape_owner_id);
 
 	for (List<RID>::Element *E = q.canvas_items.front(); E; E = E->next()) {
 		RenderingServer::get_singleton()->free(E->get());
@@ -892,6 +971,10 @@ void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_
 
 int TileMap::get_cellv(const Vector2 &p_pos) const {
 	return get_cell(p_pos.x, p_pos.y);
+}
+
+Vector2 TileMap::get_cell_from_shape(int shape_id) const {
+	return PhysicsServer2D::get_singleton()->body_get_shape_metadata(rid, shape_id);
 }
 
 void TileMap::make_bitmask_area_dirty(const Vector2 &p_pos) {
@@ -1167,6 +1250,10 @@ void TileMap::clear() {
 	used_size_cache_dirty = true;
 }
 
+RID TileMap::get_rid() const {
+	return rid;
+}
+
 void TileMap::_set_tile_data(const Vector<int> &p_data) {
 	ERR_FAIL_COND(format > FORMAT_2);
 
@@ -1259,20 +1346,14 @@ Rect2 TileMap::_edit_get_rect() const {
 void TileMap::set_collision_layer(uint32_t p_layer) {
 	collision_layer = p_layer;
 	if (!use_parent) {
-		for (Map<PosKey, Quadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
-			Quadrant &q = E->get();
-			PhysicsServer2D::get_singleton()->body_set_collision_layer(q.body, collision_layer);
-		}
+		PhysicsServer2D::get_singleton()->body_set_collision_layer(rid, collision_layer);
 	}
 }
 
 void TileMap::set_collision_mask(uint32_t p_mask) {
 	collision_mask = p_mask;
 	if (!use_parent) {
-		for (Map<PosKey, Quadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
-			Quadrant &q = E->get();
-			PhysicsServer2D::get_singleton()->body_set_collision_mask(q.body, collision_mask);
-		}
+		PhysicsServer2D::get_singleton()->body_set_collision_mask(rid, collision_mask);
 	}
 }
 
@@ -1303,6 +1384,7 @@ bool TileMap::get_collision_use_kinematic() const {
 void TileMap::set_collision_use_kinematic(bool p_use_kinematic) {
 	_clear_quadrants();
 	use_kinematic = p_use_kinematic;
+	PhysicsServer2D::get_singleton()->body_set_mode(rid, use_kinematic ? PhysicsServer2D::BODY_MODE_KINEMATIC : PhysicsServer2D::BODY_MODE_STATIC);
 	_recreate_quadrants();
 }
 
@@ -1334,10 +1416,7 @@ void TileMap::set_collision_use_parent(bool p_use_parent) {
 void TileMap::set_collision_friction(float p_friction) {
 	friction = p_friction;
 	if (!use_parent) {
-		for (Map<PosKey, Quadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
-			Quadrant &q = E->get();
-			PhysicsServer2D::get_singleton()->body_set_param(q.body, PhysicsServer2D::BODY_PARAM_FRICTION, p_friction);
-		}
+		PhysicsServer2D::get_singleton()->body_set_param(rid, PhysicsServer2D::BODY_PARAM_FRICTION, p_friction);
 	}
 }
 
@@ -1348,10 +1427,7 @@ float TileMap::get_collision_friction() const {
 void TileMap::set_collision_bounce(float p_bounce) {
 	bounce = p_bounce;
 	if (!use_parent) {
-		for (Map<PosKey, Quadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
-			Quadrant &q = E->get();
-			PhysicsServer2D::get_singleton()->body_set_param(q.body, PhysicsServer2D::BODY_PARAM_BOUNCE, p_bounce);
-		}
+		PhysicsServer2D::get_singleton()->body_set_param(rid, PhysicsServer2D::BODY_PARAM_BOUNCE, p_bounce);
 	}
 }
 
@@ -1769,6 +1845,7 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_celld", "position", "data"), &TileMap::_set_celld);
 	ClassDB::bind_method(D_METHOD("get_cell", "x", "y"), &TileMap::get_cell);
 	ClassDB::bind_method(D_METHOD("get_cellv", "position"), &TileMap::get_cellv);
+	ClassDB::bind_method(D_METHOD("get_cell_from_shape", "shape_id"), &TileMap::get_cell_from_shape);
 	ClassDB::bind_method(D_METHOD("is_cell_x_flipped", "x", "y"), &TileMap::is_cell_x_flipped);
 	ClassDB::bind_method(D_METHOD("is_cell_y_flipped", "x", "y"), &TileMap::is_cell_y_flipped);
 	ClassDB::bind_method(D_METHOD("is_cell_transposed", "x", "y"), &TileMap::is_cell_transposed);
@@ -1793,6 +1870,7 @@ void TileMap::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_set_tile_data"), &TileMap::_set_tile_data);
 	ClassDB::bind_method(D_METHOD("_get_tile_data"), &TileMap::_get_tile_data);
+	ClassDB::bind_method(D_METHOD("get_rid"), &TileMap::get_rid);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Square,Isometric,Custom"), "set_mode", "get_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "tile_set", PROPERTY_HINT_RESOURCE_TYPE, "TileSet"), "set_tileset", "get_tileset");
@@ -1870,6 +1948,9 @@ TileMap::TileMap() {
 	occluder_light_mask = 1;
 	clip_uv = false;
 	format = FORMAT_1; // Assume lowest possible format if none is present
+	rid = PhysicsServer2D::get_singleton()->body_create();
+	PhysicsServer2D::get_singleton()->body_attach_object_instance_id(rid, get_instance_id());
+	PhysicsServer2D::get_singleton()->body_set_mode(rid, use_kinematic ? PhysicsServer2D::BODY_MODE_KINEMATIC : PhysicsServer2D::BODY_MODE_STATIC);
 
 	fp_adjust = 0.00001;
 	tile_origin = TILE_ORIGIN_TOP_LEFT;
@@ -1881,6 +1962,7 @@ TileMap::~TileMap() {
 	if (tile_set.is_valid()) {
 		tile_set->remove_change_receptor(this);
 	}
+	PhysicsServer2D::get_singleton()->free(rid);
 
 	clear();
 }

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -35,6 +35,7 @@
 #include "core/vset.h"
 #include "scene/2d/navigation_2d.h"
 #include "scene/2d/node_2d.h"
+#include "scene/2d/physics_body_2d.h"
 #include "scene/resources/tile_set.h"
 
 class CollisionObject2D;
@@ -76,6 +77,7 @@ private:
 	Transform2D custom_transform;
 	HalfOffset half_offset;
 	bool use_parent;
+	RID rid;
 	CollisionObject2D *collision_parent;
 	bool use_kinematic;
 	Navigation2D *navigation;
@@ -129,7 +131,6 @@ private:
 	struct Quadrant {
 		Vector2 pos;
 		List<RID> canvas_items;
-		RID body;
 		uint32_t shape_owner_id;
 
 		SelfList<Quadrant> dirty_list;
@@ -152,7 +153,6 @@ private:
 		void operator=(const Quadrant &q) {
 			pos = q.pos;
 			canvas_items = q.canvas_items;
-			body = q.body;
 			shape_owner_id = q.shape_owner_id;
 			cells = q.cells;
 			navpoly_ids = q.navpoly_ids;
@@ -162,7 +162,6 @@ private:
 				dirty_list(this) {
 			pos = q.pos;
 			canvas_items = q.canvas_items;
-			body = q.body;
 			shape_owner_id = q.shape_owner_id;
 			cells = q.cells;
 			occluder_instances = q.occluder_instances;
@@ -194,11 +193,24 @@ private:
 	uint32_t collision_mask;
 	mutable DataFormat format;
 
+	Map<int, Vector2> shape_cells;
+
+	Map<uint32_t, CollisionObject2D::ShapeData> shapes;
+	int total_subshapes = 0;
+
 	TileOrigin tile_origin;
 
 	int occluder_light_mask;
 
 	void _fix_cell_transform(Transform2D &xform, const Cell &p_cell, const Vector2 &p_offset, const Size2 &p_sc);
+
+	uint32_t _create_shape_owner();
+	void _shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape);
+	int _shape_owner_get_shape_index(uint32_t p_owner, int p_shape) const;
+	void _shape_owner_clear_shapes(uint32_t p_owner);
+	int _shape_owner_get_shape_count(uint32_t p_owner) const;
+	void _shape_owner_remove_shape(uint32_t p_owner, int p_shape);
+	void _remove_shape_owner(uint32_t owner);
 
 	void _add_shape(int &shape_idx, const Quadrant &p_q, const Ref<Shape2D> &p_shape, const TileSet::ShapeData &p_shape_data, const Transform2D &p_xform, const Vector2 &p_metadata);
 
@@ -264,6 +276,7 @@ public:
 	void _set_celld(const Vector2 &p_pos, const Dictionary &p_data);
 	void set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false);
 	int get_cellv(const Vector2 &p_pos) const;
+	Vector2 get_cell_from_shape(int shape_id) const;
 
 	void make_bitmask_area_dirty(const Vector2 &p_pos);
 	void update_bitmask_area(const Vector2 &p_pos);
@@ -344,6 +357,8 @@ public:
 
 	void fix_invalid_tiles();
 	void clear();
+
+	RID get_rid() const;
 
 	TileMap();
 	~TileMap();


### PR DESCRIPTION
Same as #39515 

I just ran into the problem of not beeing able to get the exact colliding tile. Since the described workaround in https://github.com/godotengine/godot/issues/24739#issuecomment-451529763 doesn't work ether and you don't have a chance to get the RID of the quadrant, to get the metadata with the cell position from the Physics2DServer, I gave the TileMap a RID and handle the owners comparable to the CollisionObject2D.

It changes the internal collision handling of the TileMap completly, but otherwise the collision handling of the TileMap is without the changes not usable. You can workaround that, by using use_parent and a StaticBody2D:
```gdscript
func _on_body_shape_entered(body_id, body, body_shape, area_shape):
	if not body is StaticBody2D:
		return
	var b := body as StaticBody2D
	var b_o = b.shape_owner_get_owner(b.shape_find_owner(body_shape))
	if not b_o is TileMap:
		return
	
	var tm : TileMap = b_o
	var cv: Vector2 = Physics2DServer.body_get_shape_metadata(body.get_rid(), body_shape)
```

With the fix you don't need a parent, to be able to use it:

```gdscript
func _on_body_shape_entered(body_id, body, body_shape, area_shape):
	if not body is TileMap:
		return
	var tm := body as TileMap
	var cv := tm.get_cell_from_shape(body_shape)
```
