### PR TITLE
Fix label percent visible doc description

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -57,7 +57,7 @@
 		</member>
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" override="true" enum="Control.MouseFilter" default="2" />
 		<member name="percent_visible" type="float" setter="set_percent_visible" getter="get_percent_visible" default="1.0">
-			Limits the count of visible characters. If you set [code]percent_visible[/code] to 50, only up to half of the text's characters will display on screen. Useful to animate the text in a dialog box.
+			Limits the amount of visible characters. If you set [code]percent_visible[/code] to 0.5, only up to half of the text's characters will display on screen. Useful to animate the text in a dialog box.
 		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" override="true" default="4" />
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">


### PR DESCRIPTION
The percent visible setting of the label node uses a float value from 0 to 1. The doc incorrectly stated that it uses a value between 1 and 100. I also changed "count" to "amount" to be more clear. Closes https://github.com/godotengine/godot-docs/issues/3677