### PR TITLE
Fix Image.create_from_data "use_mipmaps" class doc

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -154,7 +154,7 @@
 			<argument index="4" name="data" type="PackedByteArray">
 			</argument>
 			<description>
-				Creates a new image of given size and format. See [enum Format] constants. Fills the image with the given raw data. If [code]use_mipmaps[/code] is [code]true[/code] then generate mipmaps for this image. See the [method generate_mipmaps].
+				Creates a new image of given size and format. See [enum Format] constants. Fills the image with the given raw data. If [code]use_mipmaps[/code] is [code]true[/code] then loads mipmaps for this image from [code]data[/code]. See [method generate_mipmaps].
 			</description>
 		</method>
 		<method name="crop">


### PR DESCRIPTION
The `Image.create_from_data` doc describes the `use_mipmaps` argument as a
way to generate mipmaps, but this method only allocates and loads data.
This can cause confusion, where this function reads more or less data
than expected. Update the doc to be more specific that create_from_data
is loading the mipmaps from the raw data.

The confusion happens when you have some data that does have mipmaps, then you try to read this doc. You don't want to generate the mipmaps (you already have them in the data), so you set it to `false`, but then Godot gives you an error that the data has more bytes than expected because it isn't expecting mipmaps.

Thanks @paulloz for looking into the engine side of this to confirm the behavior.

---

The `create` doc also says "generate mipmaps", which I thought about changing too, but I couldn't figure out how to word it well. (And technically I suppose it does "generate" blank mipmaps.) I can include a change there too if there are any suggestions:

https://github.com/godotengine/godot/blob/58034f39829b8b95a3e5d4c6e8d1ab0427371548/doc/classes/Image.xml#L140