### PR TITLE
Fix Material.render_priority doc: claims opaque objects are sorted

### DIFF
--- a/doc/classes/Material.xml
+++ b/doc/classes/Material.xml
@@ -17,7 +17,7 @@
 		</member>
 		<member name="render_priority" type="int" setter="set_render_priority" getter="get_render_priority" default="0">
 			Sets the render priority for transparent objects in 3D scenes. Higher priority objects will be sorted in front of lower priority objects.
-			[b]Note:[/b] this only applies to sorting of transparent objects. This will not impact how transparent objects are sorted relative to opaque objects. This is because opaque objects are sorted based on depth, while transparent objects are sorted from back to front (subject to priority).
+			[b]Note:[/b] this only applies to sorting of transparent objects. This will not impact how transparent objects are sorted relative to opaque objects. This is because opaque objects are not sorted, while transparent objects are sorted from back to front (subject to priority).
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Opaque objects are rendered using the depth buffer, so the end result
appears sorted, but the opaque objects themselves are not sorted.

This doc could be longer to go into this more--not sure if the reader will know about the depth buffer--but figured I can at least submit this quick PR to fix the main problem without changing the overall message.

Fixes https://github.com/godotengine/godot-docs/issues/3591 (a little more context there.)