### PR TITLE
Re-enable scroll follow on RichTextLabel clear

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1970,6 +1970,9 @@ void RichTextLabel::clear() {
 	selection.click = nullptr;
 	selection.active = false;
 	current_idx = 1;
+	if (scroll_follow) {
+		scroll_following = true;
+	}
 
 	if (fixed_width != -1) {
 		minimum_size_changed();


### PR DESCRIPTION
Fixes #37476
Closes https://github.com/godotengine/godot-proposals/issues/666

Turns out this was a bug in RichTextLabel. Normally the scroll following gets enabled when scrollbar is invisible, but clear method wasn't updating it.