### PR TITLE
Add description to TileSet.is_tile_bound() method

### DIFF
--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -44,6 +44,8 @@
 			<argument index="1" name="neighbor_id" type="int">
 			</argument>
 			<description>
+				Determines when the auto-tiler should consider two different auto-tile IDs to be bound together.
+				[b]Note:[/b] [code]neighbor_id[/code] will be [code]-1[/code] ([constant TileMap.INVALID_CELL]) when checking a tile against an empty neighbor tile.
 			</description>
 		</method>
 		<method name="autotile_clear_bitmask_map">


### PR DESCRIPTION
This was missing from the documentation.

I have added a short description to the method.
There is an issue created for this.

I hope this helps!

*Bugsquad edit:* Fixes #39381.