### PR TITLE
Fix Editable Children issues with node renaming, moving, duplicating and instancing.

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2146,7 +2146,6 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 	if (n == edited_scene) {
 		edited_scene = newnode;
 		editor->set_edited_scene(newnode);
-		newnode->set_editable_instances(n->get_editable_instances());
 	}
 
 	//small hack to make collisionshapes and other kind of nodes to work

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1901,37 +1901,23 @@ String Node::get_editor_description() const {
 }
 
 void Node::set_editable_instance(Node *p_node, bool p_editable) {
-
 	ERR_FAIL_NULL(p_node);
 	ERR_FAIL_COND(!is_a_parent_of(p_node));
-	NodePath p = get_path_to(p_node);
 	if (!p_editable) {
-		data.editable_instances.erase(p);
+		p_node->data.editable_instance = false;
 		// Avoid this flag being needlessly saved;
 		// also give more visual feedback if editable children is re-enabled
 		set_display_folded(false);
 	} else {
-		data.editable_instances[p] = true;
+		p_node->data.editable_instance = true;
 	}
 }
 
 bool Node::is_editable_instance(const Node *p_node) const {
-
 	if (!p_node)
 		return false; //easier, null is never editable :)
 	ERR_FAIL_COND_V(!is_a_parent_of(p_node), false);
-	NodePath p = get_path_to(p_node);
-	return data.editable_instances.has(p);
-}
-
-void Node::set_editable_instances(const HashMap<NodePath, int> &p_editable_instances) {
-
-	data.editable_instances = p_editable_instances;
-}
-
-HashMap<NodePath, int> Node::get_editable_instances() const {
-
-	return data.editable_instances;
+	return p_node->data.editable_instance;
 }
 
 void Node::set_scene_instance_state(const Ref<SceneState> &p_state) {
@@ -2970,6 +2956,7 @@ Node::Node() {
 	data.use_placeholder = false;
 	data.display_folded = false;
 	data.ready_first = true;
+	data.editable_instance = false;
 
 	orphan_node_count++;
 }

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -91,8 +91,6 @@ private:
 		Ref<SceneState> instance_state;
 		Ref<SceneState> inherited_state;
 
-		HashMap<NodePath, int> editable_instances;
-
 		Node *parent;
 		Node *owner;
 		Vector<Node *> children; // list of children
@@ -139,6 +137,7 @@ private:
 		bool use_placeholder;
 
 		bool display_folded;
+		bool editable_instance;
 
 		mutable NodePath *path_cache;
 
@@ -325,8 +324,6 @@ public:
 
 	void set_editable_instance(Node *p_node, bool p_editable);
 	bool is_editable_instance(const Node *p_node) const;
-	void set_editable_instances(const HashMap<NodePath, int> &p_editable_instances);
-	HashMap<NodePath, int> get_editable_instances() const;
 
 	/* NOTIFICATIONS */
 


### PR DESCRIPTION
Hopefully fixes all the issues on KoBeWi`s tracker:
https://github.com/godotengine/godot/issues/33790

I'm aware it won't get merged to 3.2 but 4.0 is too unstable ATM to work with. Also i didn't managed to compile it yet.

I'm putting it here so people can test it properly. I did some testing myself but there's only so much one person can test (:

*Bugsquad edit:*
Fixes #28861
Fixes #27064
Fixes #23979
Fixes #20409
Fixes #27023