### PR TITLE
Remove the obsolete "2D Pixel" import preset

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -181,15 +181,14 @@ bool ResourceImporterTexture::get_option_visibility(const String &p_option, cons
 }
 
 int ResourceImporterTexture::get_preset_count() const {
-	return 4;
+	return 3;
 }
 
 String ResourceImporterTexture::get_preset_name(int p_idx) const {
 	static const char *preset_names[] = {
-		"2D, Detect 3D",
+		"2D/3D (Auto-Detect)",
 		"2D",
-		"2D Pixel",
-		"3D"
+		"3D",
 	};
 
 	return preset_names[p_idx];

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -93,7 +93,6 @@ public:
 	enum Preset {
 		PRESET_DETECT,
 		PRESET_2D,
-		PRESET_2D_PIXEL,
 		PRESET_3D,
 	};
 


### PR DESCRIPTION
**Note:** Not cherry-pickable to the `3.2` branch, as this is specific to the Vulkan renderer.

Texture filtering is now defined on a per-node basis, thanks to bindless textures provided by Vulkan.

This closes #37057.