### PR TITLE
Document how to resize a SubViewportContainer to avoid stretching

### DIFF
--- a/doc/classes/SubViewportContainer.xml
+++ b/doc/classes/SubViewportContainer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A [Container] node that holds a [SubViewport], automatically setting its size.
+		[b]Note:[/b] Changing a SubViewportContainer's [member Control.rect_scale] will cause its contents to appear distorted. To change its visual size without causing distortion, adjust the node's margins instead (if it's not already in a container).
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
This is cherry-pickable to the `3.2` branch, but references to SubViewportContainer will have to be replaced with ViewportContainer (including in the file name).

This closes #27534.