### PR TITLE
Expose disable_render_loop property to GDScript

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -17,6 +17,11 @@
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/optimization/using_servers.html</link>
 	</tutorials>
+	<members>
+			<member name="render_loop_enabled" type="bool" setter="set_render_loop_enabled" getter="is_render_loop_enabled" default="true">
+				If [code]false[/code], disables rendering completely, but the engine logic is still being processed. You can call [method force_draw] to draw a frame even with rendering disabled.
+			</member>
+	</members>
 	<methods>
 		<method name="black_bars_set_images">
 			<return type="void">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1312,6 +1312,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	}
 
 	rendering_server->init();
+	rendering_server->set_render_loop_enabled(!disable_render_loop);
 
 	OS::get_singleton()->initialize_joypads();
 
@@ -2203,7 +2204,7 @@ bool Main::iteration() {
 
 	RenderingServer::get_singleton()->sync(); //sync if still drawing from previous frames.
 
-	if (DisplayServer::get_singleton()->can_any_window_draw() && !disable_render_loop) {
+	if (DisplayServer::get_singleton()->can_any_window_draw() && RenderingServer::get_singleton()->is_render_loop_enabled()) {
 		if ((!force_redraw_requested) && OS::get_singleton()->is_in_low_processor_usage_mode()) {
 			if (RenderingServer::get_singleton()->has_changed()) {
 				RenderingServer::get_singleton()->draw(true, scaled_step); // flush visual commands

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1895,6 +1895,10 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_os_feature", "feature"), &RenderingServer::has_os_feature);
 	ClassDB::bind_method(D_METHOD("set_debug_generate_wireframes", "generate"), &RenderingServer::set_debug_generate_wireframes);
 
+	ClassDB::bind_method(D_METHOD("is_render_loop_enabled"), &RenderingServer::is_render_loop_enabled);
+	ClassDB::bind_method(D_METHOD("set_render_loop_enabled", "enabled"), &RenderingServer::set_render_loop_enabled);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "render_loop_enabled"), "set_render_loop_enabled", "is_render_loop_enabled");
+
 	BIND_CONSTANT(NO_INDEX_ARRAY);
 	BIND_CONSTANT(ARRAY_WEIGHTS_SIZE);
 	BIND_CONSTANT(CANVAS_ITEM_Z_MIN);
@@ -2284,6 +2288,14 @@ RID RenderingServer::instance_create2(RID p_base, RID p_scenario) {
 	instance_set_base(instance, p_base);
 	instance_set_scenario(instance, p_scenario);
 	return instance;
+}
+
+bool RenderingServer::is_render_loop_enabled() const {
+	return render_loop_enabled;
+}
+
+void RenderingServer::set_render_loop_enabled(bool p_enabled) {
+	render_loop_enabled = p_enabled;
 }
 
 RenderingServer::RenderingServer() {

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -47,6 +47,7 @@ class RenderingServer : public Object {
 	static RenderingServer *singleton;
 
 	int mm_policy;
+	bool render_loop_enabled = true;
 
 	void _camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	void _canvas_item_add_style_box(RID p_item, const Rect2 &p_rect, const Rect2 &p_source, RID p_texture, const Vector<float> &p_margins, const Color &p_modulate = Color(1, 1, 1));
@@ -1228,6 +1229,9 @@ public:
 	virtual void call_set_use_vsync(bool p_enable) = 0;
 
 	virtual bool is_low_end() const = 0;
+
+	bool is_render_loop_enabled() const;
+	void set_render_loop_enabled(bool p_enabled);
 
 	RenderingServer();
 	virtual ~RenderingServer();


### PR DESCRIPTION
Exposes the `disable_render_loop` property from `main.cpp` to GDScript.

I've put the new code on `VisualServer` as it felt the most logic class to put to.