### PR TITLE
Allow Godot to kill its own PID

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -212,6 +212,13 @@ void OS_Windows::initialize() {
 
 	process_map = memnew((Map<ProcessID, ProcessInfo>));
 
+	// Add current Godot PID to the list of known PIDs
+	ProcessInfo current_pi = {};
+	PROCESS_INFORMATION current_pi_pi = {};
+	current_pi.pi = current_pi_pi;
+	current_pi.pi.hProcess = GetCurrentProcess();
+	process_map->insert(GetCurrentProcessId(), current_pi);
+
 	IP_Unix::make_default();
 	main_loop = nullptr;
 }


### PR DESCRIPTION
Fixes #38577

Adds the current instance's PID information to the list of known PIDs on Windows platforms, so it's possible to kill it on runtime.

I have zero experience with Windows API, so this code might be too barebones.

Tested successfully on Windows 10.

*(Redone from #38666, it was causing me problems with git)*