### PR TITLE
Tileset editor set tile's origin

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -79,6 +79,7 @@ class TileSetEditor : public HSplitContainer {
 		SELECT_PREVIOUS,
 		SELECT_NEXT,
 		TOOL_SELECT,
+		TOOL_ORIGIN,
 		BITMASK_COPY,
 		BITMASK_PASTE,
 		BITMASK_CLEAR,
@@ -242,6 +243,7 @@ private:
 	void close_shape(const Vector2 &shape_anchor);
 	void select_coord(const Vector2 &coord);
 	Vector2 snap_point(const Vector2 &point);
+	Vector2 snap_vector2(const Vector2 &point);
 	void update_workspace_tile_mode();
 	void update_workspace_minsize();
 	void update_edited_region(const Vector2 &end_point);


### PR DESCRIPTION
### **The Proposal ([here](https://github.com/godotengine/godot-proposals/issues/1007))**
<!--
Please fill in *all* the questions below and don't remove any of them.
Proposals not following the template below will be closed immediately.
-->

**Describe the project you are working on:**
Tileset Editor

**Describe the problem or limitation you are having in your project:**
Can't set the tile origin (center point), it's doable using `texture_offset` at the inspector, but there's no feedback at the tileset editor.
Tile's origin is important, as it'll be used to calculate render order in YSort.

**Describe the feature / enhancement and how it helps to overcome the problem or limitation:**
Add a button to set origin in the tileset editor (this will change `texture_offset` value)

**Describe how your proposal will work, with code, pseudocode, mockups, and/or diagrams:**
![image](https://user-images.githubusercontent.com/2030889/83714838-19e41e00-a656-11ea-8b02-60e101a234b7.png)
(The crosshair is the tile origin)

**If this enhancement will not be used often, can it be worked around with a few lines of script?:**
You can manually modify `texture_offset` at the inspector as a workaround.

**Is there a reason why this should be core and not an add-on in the asset library?:**
It's a simple change to update the existing value (`texture_offset`) with GUI on the existing tileset editor.


### **Implementation**

This patch add a button to set origin (center point) in the Tileset Editor.

Implementation:
- Add a button in the editor to modify the `texture_offset`, `shape_offset`,
  `occluder_offset`, and `navigation_offset` from GUI selection.
- Draw a mark (crosshair) in the editor to show the tile's origin.

Limitation:
- Inspector values not updated on undo/redo. (The values is updated, but
  need to be refreshed)