### PR TITLE
[Doc] Fix RegEx expression result

### DIFF
--- a/modules/regex/doc_classes/RegEx.xml
+++ b/modules/regex/doc_classes/RegEx.xml
@@ -32,8 +32,7 @@
 		[codeblock]
 		for result in regex.search_all("d01, d03, d0c, x3f and x42"):
 		    print(result.get_string("digit"))
-		# Would print 01 03 3f 42
-		# Note that d0c would not match
+		# Would print 01 03 0 3f 42
 		[/codeblock]
 		[b]Note:[/b] Godot's regex implementation is based on the [url=https://www.pcre.org/]PCRE2[/url] library. You can view the full pattern reference [url=https://www.pcre.org/current/doc/html/pcre2pattern.html]here[/url].
 		[b]Tip:[/b] You can use [url=https://regexr.com/]Regexr[/url] to test regular expressions online.

--- a/modules/regex/doc_classes/RegExMatch.xml
+++ b/modules/regex/doc_classes/RegExMatch.xml
@@ -49,7 +49,7 @@
 	</methods>
 	<members>
 		<member name="names" type="Dictionary" setter="" getter="get_names" default="{}">
-			A dictionary of named groups and its corresponding group number. Only groups with that were matched are included. If multiple groups have the same name, that name would refer to the first matching one.
+			A dictionary of named groups and its corresponding group number. Only groups that were matched are included. If multiple groups have the same name, that name would refer to the first matching one.
 		</member>
 		<member name="strings" type="Array" setter="" getter="get_strings" default="[  ]">
 			An [Array] of the match and its capturing groups.


### PR DESCRIPTION
Fix error in `search_all` example in RegEx class doc and correct minor typo in RegExMatch class doc.

Result of the RegEx expression (in both Godot and other PCRE RegEx tools):
[regexr.com/56n0e](https://regexr.com/56n0e)