### PR TITLE
Added barycentric_coordinate function to Geometry

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1432,6 +1432,12 @@ Vector3 _Geometry::get_closest_point_to_segment_uncapped(const Vector3 &p_point,
 	Vector3 s[2] = { p_a, p_b };
 	return Geometry::get_closest_point_to_segment_uncapped(p_point, s);
 }
+Vector3 _Geometry::barycentric_coordinate(const Vector3 &point, const Vector3 &vertex_a, const Vector3 &vertex_b, const Vector3 &vertex_c) {
+	return Geometry::barycentric_coordinate(point, vertex_a, vertex_b, vertex_c);
+}
+float _Geometry::area_of_triangle(const Vector3 &vertex_a, const Vector3 &vertex_b, const Vector3 &vertex_c) {
+	return Geometry::area_of_triangle(vertex_a, vertex_b, vertex_c);
+}
 Variant _Geometry::ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2) {
 
 	Vector3 res;
@@ -1559,6 +1565,8 @@ void _Geometry::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_uv84_normal_bit", "normal"), &_Geometry::get_uv84_normal_bit);
 
+	ClassDB::bind_method(D_METHOD("barycentric_coordinate", "point", "vertex_a", "vertex_b", "vertex_c"), &_Geometry::barycentric_coordinate);
+	ClassDB::bind_method(D_METHOD("area_of_triangle", "vertex_a", "vertex_b", "vertex_c"), &_Geometry::area_of_triangle);
 	ClassDB::bind_method(D_METHOD("ray_intersects_triangle", "from", "dir", "a", "b", "c"), &_Geometry::ray_intersects_triangle);
 	ClassDB::bind_method(D_METHOD("segment_intersects_triangle", "from", "to", "a", "b", "c"), &_Geometry::segment_intersects_triangle);
 	ClassDB::bind_method(D_METHOD("segment_intersects_sphere", "from", "to", "sphere_position", "sphere_radius"), &_Geometry::segment_intersects_sphere);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -392,6 +392,8 @@ public:
 	Vector3 get_closest_point_to_segment(const Vector3 &p_point, const Vector3 &p_a, const Vector3 &p_b);
 	Vector2 get_closest_point_to_segment_uncapped_2d(const Vector2 &p_point, const Vector2 &p_a, const Vector2 &p_b);
 	Vector3 get_closest_point_to_segment_uncapped(const Vector3 &p_point, const Vector3 &p_a, const Vector3 &p_b);
+	Vector3 barycentric_coordinate(const Vector3 &point, const Vector3 &vertex_a, const Vector3 &vertex_b, const Vector3 &vertex_c);
+	float area_of_triangle(const Vector3 &vertex_a, const Vector3 &vertex_b, const Vector3 &vertex_c);
 	Variant ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2);
 	Variant segment_intersects_triangle(const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2);
 	bool point_is_inside_triangle(const Vector2 &s, const Vector2 &a, const Vector2 &b, const Vector2 &c) const;

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -190,6 +190,19 @@ public:
 		return dP.length(); // return the closest distance
 	}
 
+	static inline Vector3 barycentric_coordinate(const Vector3 &point, const Vector3 &vertex_a, const Vector3 &vertex_b, const Vector3 &vertex_c) {
+		float a0 = area_of_triangle(vertex_a, vertex_b, vertex_c);
+		float u = area_of_triangle(point, vertex_c, vertex_a) / a0;
+		float v = area_of_triangle(point, vertex_b, vertex_a) / a0;
+		float w = area_of_triangle(point, vertex_c, vertex_b) / a0;
+
+		return Vector3(w, u, v);
+	}
+
+	static inline float area_of_triangle(const Vector3 &vertex_a, const Vector3 &vertex_b, const Vector3 &vertex_c) {
+		return (vertex_b - vertex_a).cross(vertex_c - vertex_a).length() * 0.5f;
+	}
+
 	static inline bool ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2, Vector3 *r_res = 0) {
 		Vector3 e1 = p_v1 - p_v0;
 		Vector3 e2 = p_v2 - p_v0;

--- a/doc/classes/Geometry.xml
+++ b/doc/classes/Geometry.xml
@@ -7,6 +7,34 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="area_of_triangle">
+			<return type="float">
+			</return>
+			<argument index="0" name="vertex_a" type="Vector3">
+			</argument>
+			<argument index="1" name="vertex_b" type="Vector3">
+			</argument>
+			<argument index="2" name="vertex_c" type="Vector3">
+			</argument>
+			<description>
+				Returns the area of the triangle specified by the three verticies [code]vertex_a[/code], [code]vertex_b[/code] and [code]vertex_c[/code].
+			</description>
+		</method>
+		<method name="barycentric_coordinate">
+			<return type="Vector3">
+			</return>
+			<argument index="0" name="point" type="Vector3">
+			</argument>
+			<argument index="1" name="vertex_a" type="Vector3">
+			</argument>
+			<argument index="2" name="vertex_b" type="Vector3">
+			</argument>
+			<argument index="3" name="vertex_c" type="Vector3">
+			</argument>
+			<description>
+				Returns the barycentric coordinate for [code]point[/code] within the triangle specified by [code]vertex_a[/code], [code]vertex_b[/code] and [code]vertex_c[/code].
+			</description>
+		</method>
 		<method name="build_box_planes">
 			<return type="Array">
 			</return>


### PR DESCRIPTION
I added a new function to Geometry that returns the barycentric coordinate for a point within a triangle, and added documentation for the new function.

This algorithm uses the area of a triangle, so I exposed that inside Geometry as well (and documented it).

I used the pure mathematical definition of barycentric coordinates rather than a more optimized algorithm as this implementation has more defined behavior, specifically for points that do not intersect with the triangle, in that scenario, the barycentric coordinate returned will contain a negative number, or the sum will exceed 1. Most optimized versions of this algorithm only return sensical data for the case where the point is on the triangle.

It's a useful little function for lots of rendering stuff - namely getting the UV coordinate for any point on a triangle.

We could theoretically use this calculation to refactor ray_intersects_triangle and is_point_in_triangle, but there is no real need to do that - and we'd likely want to compare the performance between the two implementations.

REBASED from
https://github.com/godotengine/godot/pull/39553