### PR TITLE
GDScript LSP: Fix wrong error checks added in #39385

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -190,9 +190,7 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 		params["path"] = workspace->root;
 		Dictionary request = make_notification("gdscript_client/changeWorkspace", params);
 
-		ERR_FAIL_COND_V_MSG(latest_client_id == -1, ret.to_json(),
-				"GDScriptLanguageProtocol: Can't initialize as no client is connected.");
-		ERR_FAIL_INDEX_V_MSG((uint64_t)latest_client_id, clients.size(), ret.to_json(),
+		ERR_FAIL_COND_V_MSG(!clients.has(latest_client_id), ret.to_json(),
 				vformat("GDScriptLanguageProtocol: Can't initialize invalid peer '%d'.", latest_client_id));
 		Ref<LSPeer> peer = clients.get(latest_client_id);
 		if (peer != nullptr) {
@@ -277,7 +275,7 @@ void GDScriptLanguageProtocol::notify_client(const String &p_method, const Varia
 				"GDScript LSP: Can't notify client as none was connected.");
 		p_client_id = latest_client_id;
 	}
-	ERR_FAIL_INDEX((uint64_t)p_client_id, clients.size());
+	ERR_FAIL_COND(!clients.has(p_client_id));
 	Ref<LSPeer> peer = clients.get(p_client_id);
 	ERR_FAIL_COND(peer == nullptr);
 

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -70,7 +70,7 @@ private:
 
 	HashMap<int, Ref<LSPeer>> clients;
 	Ref<TCP_Server> server;
-	int latest_client_id = -1;
+	int latest_client_id = 0;
 	int next_client_id = 0;
 
 	Ref<GDScriptTextDocument> text_document;


### PR DESCRIPTION
Reverts `latest_client_id` back to 0, as I misunderstood how the client
IDs are assigned and, without further testing and debugging, I can't
say if this was a bug or a valid default value.
Similarly, a `latest_client_id` of -1 is no longer raising an error.

Fixes #39548.

@Rubonnek Can you confirm that it fixes the issue and that `vim-lsp` works fine with this patch? It should apply fine on `3.2`.