### PR TITLE
Add Code::Blocks files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,11 @@ gmon.out
 *.cflags
 *.cxxflags
 
+# Code::Blocks files
+*.cbp
+*.layout
+*.depend
+
 # Eclipse CDT files
 .cproject
 .settings/


### PR DESCRIPTION
[Code::Blocks](https://codeblocks.org/) is a free, open source, cross platform IDE. However, unlike a number of other IDEs that can be used to develop Godot, the files Code::Blocks creates are not currently excluded in `.gitignore`.