### PR TITLE
Search result highlight follows font size

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -670,22 +670,20 @@ void FindInFilesPanel::_on_result_found(String fpath, int line_number, int begin
 	// Do this first because it resets properties of the cell...
 	item->set_cell_mode(text_index, TreeItem::CELL_MODE_CUSTOM);
 
-	String item_text = vformat("%3s:    %s", line_number, text.replace("\t", "    "));
+	// Trim result item line
+	int old_text_size = text.size();
+	text = text.strip_edges(true, false);
+	int chars_removed = old_text_size - text.size();
+	String start = vformat("%3s: ", line_number);
 
-	item->set_text(text_index, item_text);
+	item->set_text(text_index, start + text);
 	item->set_custom_draw(text_index, this, "_draw_result_text");
-
-	Ref<Font> font = _results_display->get_font("font");
-
-	float raw_text_width = font->get_string_size(text).x;
-	float item_text_width = font->get_string_size(item_text).x;
 
 	Result r;
 	r.line_number = line_number;
 	r.begin = begin;
 	r.end = end;
-	r.draw_begin = (item_text_width - raw_text_width) + font->get_string_size(text.left(r.begin)).x;
-	r.draw_width = font->get_string_size(text.substr(r.begin, r.end - r.begin)).x;
+	r.begin_trimmed = begin - chars_removed + start.size() - 1;
 	_result_items[item] = r;
 
 	if (_with_replace) {
@@ -706,9 +704,12 @@ void FindInFilesPanel::draw_result_text(Object *item_obj, Rect2 rect) {
 		return;
 	Result r = E->value();
 
+	String item_text = item->get_text(_with_replace ? 1 : 0);
+	Ref<Font> font = _results_display->get_font("font");
+
 	Rect2 match_rect = rect;
-	match_rect.position.x += r.draw_begin;
-	match_rect.size.x = r.draw_width;
+	match_rect.position.x += font->get_string_size(item_text.left(r.begin_trimmed)).x;
+	match_rect.size.x = font->get_string_size(_search_text_label->get_text()).x;
 	match_rect.position.y += 1 * EDSCALE;
 	match_rect.size.y -= 2 * EDSCALE;
 

--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -174,8 +174,7 @@ private:
 		int line_number;
 		int begin;
 		int end;
-		float draw_begin;
-		float draw_width;
+		float begin_trimmed;
 	};
 
 	void apply_replaces_in_file(String fpath, const Vector<Result> &locations, String new_text);


### PR DESCRIPTION
Resolves #38858 

Search results from 'Find in Files' have a box to highlight the search string. Now, these boxes correctly scale with the editor font. 

![image](https://user-images.githubusercontent.com/25907608/84772507-52331700-afdb-11ea-8559-27256b616b9a.png)

The dimensions are calcuated every time we draw. It could be improved by also caching the font size, but it would be messier.  

I worked off of 3.2 because I could not run master, but the code should be in master.

I looked into issue #35499 as well, but could not solve it. The cached font in the Tree that stores the search results is not updated when resizing the code editor, but only after losing clicking the code window. 