### PR TITLE
Print warning when set/get non-existing Audio bus for AudioStreamPlayer

### DIFF
--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -55,7 +55,7 @@
 			If [code]true[/code], audio plays when added to scene tree.
 		</member>
 		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="@&quot;Master&quot;">
-			Bus on which this audio is playing.
+			Bus on which this audio is playing. If [code]bus[/code] is not defined in [AudioServer], [code]get_bus[/code] will default to "Master".
 		</member>
 		<member name="mix_target" type="int" setter="set_mix_target" getter="get_mix_target" enum="AudioStreamPlayer.MixTarget" default="0">
 			If the audio configuration has more than two speakers, this sets the target channels. See [enum MixTarget] constants.

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -278,6 +278,20 @@ void AudioStreamPlayer::set_bus(const StringName &p_bus) {
 	AudioServer::get_singleton()->lock();
 	bus = p_bus;
 	AudioServer::get_singleton()->unlock();
+
+#ifdef DEBUG_ENABLED
+	bool found = false;
+	for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
+		if (AudioServer::get_singleton()->get_bus_name(i) == bus) {
+			found = true;
+			break;
+		}
+	}
+
+	if (!found) {
+		WARN_PRINT("There is no bus \"" + p_bus + "\" defined.");
+	}
+#endif
 }
 
 StringName AudioStreamPlayer::get_bus() const {
@@ -286,6 +300,9 @@ StringName AudioStreamPlayer::get_bus() const {
 			return bus;
 		}
 	}
+
+	WARN_PRINT("There is no bus \"" + bus + "\" defined. Defaulting to 'Master'");
+
 	return "Master";
 }
 


### PR DESCRIPTION
Fixes: #39585