### PR TITLE
Timeline cursor now jumps to selected key #27278

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4617,6 +4617,7 @@ void AnimationTrackEditor::_key_selected(int p_key, bool p_single, int p_track) 
 	KeyInfo ki;
 	ki.pos = animation->track_get_key_time(p_track, p_key);
 	selection[sk] = ki;
+	emit_signal("timeline_changed", ki.pos, false);
 
 	for (int i = 0; i < track_edits.size(); i++) {
 		track_edits[i]->update();


### PR DESCRIPTION
Added a single line call to change the timeline position to the selected key to fix  #27278
Moves to the first key when box selecting. 