### PR TITLE
WebSocketServer: Expose the resource name the client used

### DIFF
--- a/modules/websocket/doc_classes/WebSocketServer.xml
+++ b/modules/websocket/doc_classes/WebSocketServer.xml
@@ -116,8 +116,11 @@
 			</argument>
 			<argument index="1" name="protocol" type="String">
 			</argument>
+			<argument index="2" name="resource_name" type="String">
+			</argument>
 			<description>
-				Emitted when a new client connects. "protocol" will be the sub-protocol agreed with the client.
+				Emitted when a new client connects. "protocol" will be the sub-protocol agreed with the client, and "resource_name" will be the resource name of the URI the peer used.
+				"resource_name" is a path (at the very least a single forward slash) and potentially a query string.
 			</description>
 		</signal>
 		<signal name="client_disconnected">

--- a/modules/websocket/emws_peer.cpp
+++ b/modules/websocket/emws_peer.cpp
@@ -56,7 +56,7 @@ Error EMWSPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 	int is_bin = write_mode == WebSocketPeer::WRITE_MODE_BINARY ? 1 : 0;
 	godot_js_websocket_send(peer_sock, p_buffer, p_buffer_size, is_bin);
 	return OK;
-};
+}
 
 Error EMWSPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 	if (_in_buffer.packets_left() == 0)
@@ -70,19 +70,19 @@ Error EMWSPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 	r_buffer_size = read;
 
 	return OK;
-};
+}
 
 int EMWSPeer::get_available_packet_count() const {
 	return _in_buffer.packets_left();
-};
+}
 
 bool EMWSPeer::was_string_packet() const {
 	return _is_string;
-};
+}
 
 bool EMWSPeer::is_connected_to_host() const {
 	return peer_sock != -1;
-};
+}
 
 void EMWSPeer::close(int p_code, String p_reason) {
 	if (peer_sock != -1) {
@@ -91,7 +91,7 @@ void EMWSPeer::close(int p_code, String p_reason) {
 	_is_string = 0;
 	_in_buffer.clear();
 	peer_sock = -1;
-};
+}
 
 IPAddress EMWSPeer::get_connected_host() const {
 	ERR_FAIL_V_MSG(IPAddress(), "Not supported in HTML5 export.");
@@ -99,7 +99,7 @@ IPAddress EMWSPeer::get_connected_host() const {
 
 uint16_t EMWSPeer::get_connected_port() const {
 	ERR_FAIL_V_MSG(0, "Not supported in HTML5 export.");
-};
+}
 
 void EMWSPeer::set_no_delay(bool p_enabled) {
 	ERR_FAIL_MSG("'set_no_delay' is not supported in HTML5 export.");
@@ -107,10 +107,10 @@ void EMWSPeer::set_no_delay(bool p_enabled) {
 
 EMWSPeer::EMWSPeer() {
 	close();
-};
+}
 
 EMWSPeer::~EMWSPeer() {
 	close();
-};
+}
 
 #endif // JAVASCRIPT_ENABLED

--- a/modules/websocket/websocket_server.cpp
+++ b/modules/websocket/websocket_server.cpp
@@ -71,7 +71,7 @@ void WebSocketServer::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("client_close_request", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::INT, "code"), PropertyInfo(Variant::STRING, "reason")));
 	ADD_SIGNAL(MethodInfo("client_disconnected", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::BOOL, "was_clean_close")));
-	ADD_SIGNAL(MethodInfo("client_connected", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::STRING, "protocol")));
+	ADD_SIGNAL(MethodInfo("client_connected", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::STRING, "protocol"), PropertyInfo(Variant::STRING, "resource_name")));
 	ADD_SIGNAL(MethodInfo("data_received", PropertyInfo(Variant::INT, "id")));
 }
 
@@ -141,13 +141,13 @@ void WebSocketServer::_on_peer_packet(int32_t p_peer_id) {
 	}
 }
 
-void WebSocketServer::_on_connect(int32_t p_peer_id, String p_protocol) {
+void WebSocketServer::_on_connect(int32_t p_peer_id, String p_protocol, String p_resource_name) {
 	if (_is_multiplayer) {
 		// Send add to clients
 		_send_add(p_peer_id);
 		emit_signal("peer_connected", p_peer_id);
 	} else {
-		emit_signal("client_connected", p_peer_id, p_protocol);
+		emit_signal("client_connected", p_peer_id, p_protocol, p_resource_name);
 	}
 }
 

--- a/modules/websocket/websocket_server.h
+++ b/modules/websocket/websocket_server.h
@@ -63,7 +63,7 @@ public:
 	virtual void disconnect_peer(int p_peer_id, int p_code = 1000, String p_reason = "") = 0;
 
 	void _on_peer_packet(int32_t p_peer_id);
-	void _on_connect(int32_t p_peer_id, String p_protocol);
+	void _on_connect(int32_t p_peer_id, String p_protocol, String p_resource_name);
 	void _on_disconnect(int32_t p_peer_id, bool p_was_clean);
 	void _on_close_request(int32_t p_peer_id, int p_code, String p_reason);
 

--- a/modules/websocket/wsl_server.h
+++ b/modules/websocket/wsl_server.h
@@ -46,7 +46,7 @@ class WSLServer : public WebSocketServer {
 private:
 	class PendingPeer : public RefCounted {
 	private:
-		bool _parse_request(const Vector<String> p_protocols);
+		bool _parse_request(const Vector<String> p_protocols, String &r_resource_name);
 
 	public:
 		Ref<StreamPeerTCP> tcp;
@@ -62,7 +62,7 @@ private:
 		CharString response;
 		int response_sent = 0;
 
-		Error do_handshake(const Vector<String> p_protocols, uint64_t p_timeout);
+		Error do_handshake(const Vector<String> p_protocols, uint64_t p_timeout, String &r_resource_name);
 	};
 
 	int _in_buf_size = DEF_BUF_SHIFT;


### PR DESCRIPTION
This adds a method to WebSocketServer to retrieve the resource name (the part after the domain name, including any queries) that the client connected with.

I did not expose it to clients both due to reduced code-complexity and the fact that the clients (at least non-html5 ones) should already have access to it implicitly. 

My use-cases for this are 
* Process a client immediately upon connection rather than wait for them to send a followup.
* Related to the above, possibly authentication of a client so that connections can be dropped immediately rather than possibly hanging open waiting for a bad client to authenticate itself in a followup. 

Very open to comments/feedback.