### PR TITLE
Simplify and fix Transform2D get_rotation

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -78,12 +78,7 @@ void Transform2D::set_skew(float p_angle) {
 }
 
 real_t Transform2D::get_rotation() const {
-	real_t det = basis_determinant();
-	Transform2D m = orthonormalized();
-	if (det < 0) {
-		m.scale_basis(Size2(1, -1)); // convention to separate rotation and reflection for 2D is to absorb a flip along y into scaling.
-	}
-	return Math::atan2(m[0].y, m[0].x);
+	return Math::atan2(elements[0].y, elements[0].x);
 }
 
 void Transform2D::set_rotation(real_t p_rot) {


### PR DESCRIPTION
Supersedes #29668 and fixes item number 2 in #29625.

The convention about separating rotation/reflection is only relevant when getting and setting the scale. When getting the rotation, we only care about the X column's orientation. It doesn't need to be normalized either, since we only care about the ratio of its elements (`y/x`, but instead we use atan2). The old code was way overcomplicated, and broken, since it caused item 2 in #29625.