### PR TITLE
Fix upscaling image with bilinear interpolation option specified

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -678,34 +678,35 @@ static void _scale_bilinear(const uint8_t *__restrict p_src, uint8_t *__restrict
 	enum {
 		FRAC_BITS = 8,
 		FRAC_LEN = (1 << FRAC_BITS),
+		FRAC_HALF = (FRAC_LEN >> 1),
 		FRAC_MASK = FRAC_LEN - 1
-
 	};
 
 	for (uint32_t i = 0; i < p_dst_height; i++) {
-		uint32_t src_yofs_up_fp = (i * p_src_height * FRAC_LEN / p_dst_height);
-		uint32_t src_yofs_frac = src_yofs_up_fp & FRAC_MASK;
-		uint32_t src_yofs_up = src_yofs_up_fp >> FRAC_BITS;
-
-		uint32_t src_yofs_down = (i + 1) * p_src_height / p_dst_height;
+		// Add 0.5 in order to interpolate based on pixel center
+		uint32_t src_yofs_up_fp = (i + 0.5) * p_src_height * FRAC_LEN / p_dst_height;
+		// Calculate nearest src pixel center above current, and truncate to get y index
+		uint32_t src_yofs_up = src_yofs_up_fp >= FRAC_HALF ? (src_yofs_up_fp - FRAC_HALF) >> FRAC_BITS : 0;
+		uint32_t src_yofs_down = (src_yofs_up_fp + FRAC_HALF) >> FRAC_BITS;
 		if (src_yofs_down >= p_src_height) {
 			src_yofs_down = p_src_height - 1;
 		}
-
-		//src_yofs_up*=CC;
-		//src_yofs_down*=CC;
+		// Calculate distance to pixel center of src_yofs_up
+		uint32_t src_yofs_frac = src_yofs_up_fp & FRAC_MASK;
+		src_yofs_frac = src_yofs_frac >= FRAC_HALF ? src_yofs_frac - FRAC_HALF : src_yofs_frac + FRAC_HALF;
 
 		uint32_t y_ofs_up = src_yofs_up * p_src_width * CC;
 		uint32_t y_ofs_down = src_yofs_down * p_src_width * CC;
 
 		for (uint32_t j = 0; j < p_dst_width; j++) {
-			uint32_t src_xofs_left_fp = (j * p_src_width * FRAC_LEN / p_dst_width);
-			uint32_t src_xofs_frac = src_xofs_left_fp & FRAC_MASK;
-			uint32_t src_xofs_left = src_xofs_left_fp >> FRAC_BITS;
-			uint32_t src_xofs_right = (j + 1) * p_src_width / p_dst_width;
+			uint32_t src_xofs_left_fp = (j + 0.5) * p_src_width * FRAC_LEN / p_dst_width;
+			uint32_t src_xofs_left = src_xofs_left_fp >= FRAC_HALF ? (src_xofs_left_fp - FRAC_HALF) >> FRAC_BITS : 0;
+			uint32_t src_xofs_right = (src_xofs_left_fp + FRAC_HALF) >> FRAC_BITS;
 			if (src_xofs_right >= p_src_width) {
 				src_xofs_right = p_src_width - 1;
 			}
+			uint32_t src_xofs_frac = src_xofs_left_fp & FRAC_MASK;
+			src_xofs_frac = src_xofs_frac >= FRAC_HALF ? src_xofs_frac - FRAC_HALF : src_xofs_frac + FRAC_HALF;
 
 			src_xofs_left *= CC;
 			src_xofs_right *= CC;


### PR DESCRIPTION
Fixes bug in calculation of the 4 nearest points in the source image for a destination image pixel,
when resizing an image with `INTERPOLATE_BILINEAR`.

Based upon the following [notes](https://ia802707.us.archive.org/23/items/Lectures_on_Image_Processing/EECE_4353_15_Resampling.pdf) (see slide 55).

Before:
![upload2](https://user-images.githubusercontent.com/22248849/84875893-28e8b880-b0b9-11ea-89e3-4fefcddfc40d.png)

After:
![upload1](https://user-images.githubusercontent.com/22248849/84875885-26865e80-b0b9-11ea-940a-cdb2eafdb5f4.png)

Closes #39371 
