### PR TITLE
Restore previous mouse position when leaving the editor freelook mode

### DIFF
--- a/editor/icons/Crosshair.svg
+++ b/editor/icons/Crosshair.svg
@@ -1,1 +1,0 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m6 1v5h-5v1 3h5v5h4v-5h5v-4h-5v-5z" fill-opacity=".627451"/><path d="m2 7v2l5.0000803.0000197-.0000803 4.9999803h2l-.0000803-4.9999803 5.0000803-.0000197v-2l-5.0000803.0001803.0000803-5.0001803h-2l.0000803 5.0001803z" fill="#fefefe" fill-opacity=".862745"/></svg>

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -284,8 +284,8 @@ private:
 
 	bool freelook_active;
 	real_t freelook_speed;
+	Vector2 previous_mouse_position;
 
-	TextureRect *crosshair;
 	Label *info_label;
 	Label *cinema_label;
 	Label *locked_label;


### PR DESCRIPTION
- Remove the crosshair as it no longer serves a purpose (the cursor will now appear where the user "expects" it to).

This closes https://github.com/godotengine/godot-proposals/issues/1076.