### PR TITLE
Fix a random crash in the TileSet editor

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -492,12 +492,14 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tools[SHAPE_NEW_RECTANGLE]->set_toggle_mode(true);
 	tools[SHAPE_NEW_RECTANGLE]->set_button_group(tg);
 	tools[SHAPE_NEW_RECTANGLE]->set_tooltip(TTR("Create a new rectangle."));
+	tools[SHAPE_NEW_RECTANGLE]->connect("pressed", callable_mp(this, &TileSetEditor::_on_tool_clicked), varray(SHAPE_NEW_RECTANGLE));
 
 	tools[SHAPE_NEW_POLYGON] = memnew(ToolButton);
 	toolbar->add_child(tools[SHAPE_NEW_POLYGON]);
 	tools[SHAPE_NEW_POLYGON]->set_toggle_mode(true);
 	tools[SHAPE_NEW_POLYGON]->set_button_group(tg);
 	tools[SHAPE_NEW_POLYGON]->set_tooltip(TTR("Create a new polygon."));
+	tools[SHAPE_NEW_POLYGON]->connect("pressed", callable_mp(this, &TileSetEditor::_on_tool_clicked), varray(SHAPE_NEW_POLYGON));
 
 	separator_shape_toggle = memnew(VSeparator);
 	toolbar->add_child(separator_shape_toggle);
@@ -1908,7 +1910,7 @@ void TileSetEditor::_on_tool_clicked(int p_tool) {
 				}
 			}
 		}
-	} else if (p_tool == TOOL_SELECT) {
+	} else if (p_tool == TOOL_SELECT || p_tool == SHAPE_NEW_POLYGON || p_tool == SHAPE_NEW_RECTANGLE) {
 		if (creating_shape) {
 			// Cancel Creation
 			creating_shape = false;


### PR DESCRIPTION
Occurs when selecting polygon collision mode, drawing a single point, selecting rectangle mode, and finally trying to select a rectangle.

Crash was reported by a friend, 3.2.x backtrace:
```
#0  0x0000000001c35307 in PoolVector<Vector2>::operator[] (this=0x9e37a58, p_index=2) at ./core/pool_vector.h:509
#1  0x00000000027d7d7e in TileSetEditor::_on_workspace_input (this=0x9e37510, p_ie=...) at editor/plugins/tile_set_editor_plugin.cpp:1748
#2  0x000000000178f385 in MethodBind1<Ref<InputEvent> const&>::call (this=0x9eed6a0, p_object=0x9e37510, p_args=0x7fffffffcd00, p_arg_count=1, r_error=...)
    at ./core/method_bind.gen.inc:775
#3  0x00000000039675da in Object::call (this=0x9e37510, p_method=..., p_args=0x7fffffffcd00, p_argcount=1, r_error=...) at core/object.cpp:921
#4  0x00000000039693f9 in Object::emit_signal (this=0x9e79a00, p_name=..., p_args=0x7fffffffcd00, p_argcount=1) at core/object.cpp:1217
#5  0x0000000003969ae4 in Object::emit_signal (this=0x9e79a00, p_name=..., p_arg1=..., p_arg2=..., p_arg3=..., p_arg4=..., p_arg5=...) at core/object.cpp:1274
#6  0x0000000002b723de in Viewport::_gui_call_input (this=0x6777740, p_control=0x9e79a00, p_input=...) at scene/main/viewport.cpp:1661
#7  0x0000000002b74d2d in Viewport::_gui_input_event (this=0x6777740, p_event=...) at scene/main/viewport.cpp:2265
#8  0x0000000002b7857a in Viewport::input (this=0x6777740, p_event=...) at scene/main/viewport.cpp:2825
#9  0x0000000002b71159 in Viewport::_vp_input (this=0x6777740, p_ev=...) at scene/main/viewport.cpp:1446
#10 0x000000000178f385 in MethodBind1<Ref<InputEvent> const&>::call (this=0x6104b10, p_object=0x6777740, p_args=0x7fffffffd2e0, p_arg_count=1, r_error=...)
    at ./core/method_bind.gen.inc:775
#11 0x00000000039675da in Object::call (this=0x6777740, p_method=..., p_args=0x7fffffffd2e0, p_argcount=1, r_error=...) at core/object.cpp:921
#12 0x0000000003967185 in Object::call (this=0x6777740, p_name=..., p_arg1=..., p_arg2=..., p_arg3=..., p_arg4=..., p_arg5=...) at core/object.cpp:847
#13 0x0000000002b43fef in SceneTree::call_group_flags (this=0x5bab430, p_call_flags=2, p_group=..., p_function=..., p_arg1=..., p_arg2=..., p_arg3=..., p_arg4=..., p_arg5=...)
    at scene/main/scene_tree.cpp:275
#14 0x0000000002b44d08 in SceneTree::input_event (this=0x5bab430, p_event=...) at scene/main/scene_tree.cpp:431
#15 0x000000000142244b in InputDefault::_parse_input_event_impl (this=0x5a63460, p_event=..., p_is_emulated=false) at main/input_default.cpp:442
#16 0x0000000001421436 in InputDefault::parse_input_event (this=0x5a63460, p_event=...) at main/input_default.cpp:259
#17 0x000000000142373e in InputDefault::flush_accumulated_events (this=0x5a63460) at main/input_default.cpp:678
#18 0x000000000140ca6f in OS_X11::process_xevents (this=0x7fffffffda70) at platform/x11/os_x11.cpp:2693
#19 0x000000000140ff54 in OS_X11::run (this=0x7fffffffda70) at platform/x11/os_x11.cpp:3257
#20 0x00000000013ff6a7 in main (argc=4, argv=0x7fffffffe258) at platform/x11/godot_x11.cpp:56
```

Code in question was added in #28178, CC @dankan1890.