### PR TITLE
Dont slice 64-bit integers marshaled to mono in dynamic contexts

### DIFF
--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -624,8 +624,8 @@ MonoObject *variant_to_mono_object(const Variant *p_var, const ManagedType &p_ty
 					return BOX_BOOLEAN(val);
 				}
 				case Variant::INT: {
-					int32_t val = p_var->operator signed int();
-					return BOX_INT32(val);
+					int64_t val = p_var->operator int64_t();
+					return BOX_INT64(val);
 				}
 				case Variant::FLOAT: {
 #ifdef REAL_T_IS_DOUBLE


### PR DESCRIPTION
- dont slice 64-bit integers marshaled to mono in dynamic contexts
- previous was converting to a 32 bit integer, instead return a boxed 64-bit integer

@neikeq let me know how you want me to retarget the branch, if you'd like to take over, whether this PR isn't aligned with scope or any other way I can help.

*Bugsquad edit:* Fixes #39609.