### PR TITLE
Enable the 2D editor's "scroll to pan" option by default

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -598,7 +598,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/2d/constrain_editor_view", true);
 	_initial_set("editors/2d/warped_mouse_panning", true);
 	_initial_set("editors/2d/simple_panning", false);
-	_initial_set("editors/2d/scroll_to_pan", false);
+	_initial_set("editors/2d/scroll_to_pan", true);
 	_initial_set("editors/2d/pan_speed", 20);
 
 	// Polygon editor


### PR DESCRIPTION
This makes the mouse wheel pan up and down instead of zooming. To zoom, hold down <kbd>Ctrl</kbd> while scrolling.

I'm opening this to gauge community interest. I think it's better to follow the behavior found in most applications. If we implement <kbd>Shift</kbd> to pan horizontally, it makes more sense that scrolling without a modifier will pan vertically rather than zoom.

See https://github.com/godotengine/godot-proposals/issues/1077.