### PR TITLE
Make tilemap lines/rectangles their own tools

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -88,6 +88,8 @@ class TileMapEditor : public VBoxContainer {
 	MenuButton *options;
 
 	Button *paint_button;
+	Button *line_button;
+	Button *rectangle_button;
 	Button *bucket_fill_button;
 	Button *picker_button;
 	Button *select_button;
@@ -106,6 +108,7 @@ class TileMapEditor : public VBoxContainer {
 
 	bool selection_active;
 	bool mouse_over;
+	bool mouse_down;
 
 	bool flip_h;
 	bool flip_v;


### PR DESCRIPTION
Instead of having them as Shift and Shift+CTRL when using the paint tool their are now there own tool. This was discussed a little bit in https://github.com/godotengine/godot-proposals/issues/896. This has many benefits:
- Allows for snapping proporsions etc. I've only implemented snapping proporsions for rectangles but I'm sure shift and control will be used for something useful in the future like maybe snapping the lines to 45 degrees? These kinda stuff aren't currently possible as shift and ctrl are used for rectanges/lines
- Easier to find, I wouldn't exspect a line tool being part of the paint tool as that's not how it works in most other programs

Currently they use the same icon as the paint bucket, I'm defiantly not an artist so I think it's a better idea to let someone else create the icons. Other than that it works pretty well in my testing.

So overall I think this is a good adition which makes it easier to work will tilemaps. Also this allows for adding a eclipse/circle tool in the future if that's wanted. Let me know what you think!