### PR TITLE
Fix editor texture preview for certain specific dimensions

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -127,7 +127,8 @@ Ref<Texture2D> EditorTexturePreviewPlugin::generate(const RES &p_from, const Siz
 	if (new_size.y > p_size.y) {
 		new_size = Vector2(new_size.x * p_size.y / new_size.y, p_size.y);
 	}
-	img->resize(new_size.x, new_size.y, Image::INTERPOLATE_CUBIC);
+	Vector2i new_size_i(MAX(1, (int)new_size.x), MAX(1, (int)new_size.y));
+	img->resize(new_size_i.x, new_size_i.y, Image::INTERPOLATE_CUBIC);
 
 	post_process_preview(img);
 


### PR DESCRIPTION
Currently, an error may be issued when showing a preview of a resource if
the associated image is resized to sub-1 pixel dimensions. This fix ensures no such error
is issued. 

For example, when previewing a 256 x 1 PNG image:
![Screenshot from 2020-06-18 16-50-53](https://user-images.githubusercontent.com/22248849/84999635-02dc1a80-b184-11ea-8fa0-8417b2eacdb7.png)

After:
![Screenshot from 2020-06-18 16-50-33](https://user-images.githubusercontent.com/22248849/84999640-040d4780-b184-11ea-88eb-6d711ea55193.png)

Figured that showing an image with 1-pixel width or height is better than not showing any 
preview at all, though there may be a small distortion. `p_size` must also already be size 1x1 or
bigger, else a different error would be issued in the `rendering_server`, so this should be safe.

Closes #36940

(The same issue may also occur with the `EditorImagePreviewPlugin`, `EditorBitmapPreviewPlugin` and `EditorMeshPreviewPlugin`, though none seem to have been raised so far)

Edit: Turns out it would also close #35662 