### PR TITLE
Fix window size change when restoring from minimized state

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -812,10 +812,6 @@ Size2i DisplayServerWindows::window_get_size(WindowID p_window) const {
 	ERR_FAIL_COND_V(!windows.has(p_window), Size2i());
 	const WindowData &wd = windows[p_window];
 
-	if (wd.minimized) {
-		return Size2(wd.width, wd.height);
-	}
-
 	RECT r;
 	if (GetClientRect(wd.hWnd, &r)) { // Only area inside of window border
 		return Size2(r.right - r.left, r.bottom - r.top);


### PR DESCRIPTION
Fixes #37328

When restoring the window (editor or project manager) from a minized state, the window becomes larger. When the window is minimized, `window_get_size` would return the size as if the window was not minimized. This results in a miscalculation during a WM_MINMAXINFO message here:
`L1827: Size2 decor = window_get_size(window_id) - window_get_real_size(window_id);`

A simple solution that seems to work fine is to just remove the if statement. If this code is needed, another solution would be to skip the calculation in WM_MINMAXINFO if the window is currently minimized, but it seems like this is the only place the if branch is actually true.