### PR TITLE
Mono: Always define options in main.cpp to keep them in docs

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -821,6 +821,8 @@
 		</member>
 		<member name="mono/profiler/enabled" type="bool" setter="" getter="" default="false">
 		</member>
+		<member name="mono/project/auto_update_project" type="bool" setter="" getter="" default="true">
+		</member>
 		<member name="mono/unhandled_exception_policy" type="int" setter="" getter="" default="0">
 		</member>
 		<member name="network/limits/debugger/max_chars_per_second" type="int" setter="" getter="" default="32768">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1633,6 +1633,8 @@ bool Main::start() {
 		GLOBAL_DEF("mono/profiler/args", "log:calls,alloc,sample,output=output.mlpd");
 		GLOBAL_DEF("mono/profiler/enabled", false);
 		GLOBAL_DEF("mono/unhandled_exception_policy", 0);
+		// From editor/csharp_project.cpp.
+		GLOBAL_DEF("mono/project/auto_update_project", true);
 #endif
 
 		DocData doc;


### PR DESCRIPTION
Otherwise generating docs with non-Mono builds removes them,
which is not so convenient for the documentation work.

Follow-up to #38047.

(FYI @neikeq, so that you remember to duplicate future new options in `main.cpp` - it's a hack but it doesn't cost too much for consistent docs.)