### PR TITLE
Expose disable_render_loop property to GDScript

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -4231,6 +4231,11 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="render_loop_enabled" type="bool" setter="set_render_loop_enabled" getter="is_render_loop_enabled">
+			If [code]false[/code], disables rendering completely, but the engine logic is still being processed. You can call [method force_draw] to draw a frame even with rendering disabled.
+		</member>
+	</members>
 	<signals>
 		<signal name="frame_post_draw">
 			<description>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1271,6 +1271,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	// also init our arvr_server from here
 	arvr_server = memnew(ARVRServer);
 
+	// and finally setup this property under visual_server
+	VisualServer::get_singleton()->set_render_loop_enabled(!disable_render_loop);
+
 	register_core_singletons();
 
 	MAIN_PRINT("Main: Setup Logo");
@@ -2101,7 +2104,7 @@ bool Main::iteration() {
 
 	VisualServer::get_singleton()->sync(); //sync if still drawing from previous frames.
 
-	if (OS::get_singleton()->can_draw() && !disable_render_loop) {
+	if (OS::get_singleton()->can_draw() && VisualServer::get_singleton()->is_render_loop_enabled()) {
 
 		if ((!force_redraw_requested) && OS::get_singleton()->is_in_low_processor_usage_mode()) {
 			if (VisualServer::get_singleton()->has_changed()) {

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2050,6 +2050,10 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_os_feature", "feature"), &VisualServer::has_os_feature);
 	ClassDB::bind_method(D_METHOD("set_debug_generate_wireframes", "generate"), &VisualServer::set_debug_generate_wireframes);
 
+	ClassDB::bind_method(D_METHOD("is_render_loop_enabled"), &VisualServer::is_render_loop_enabled);
+	ClassDB::bind_method(D_METHOD("set_render_loop_enabled", "enabled"), &VisualServer::set_render_loop_enabled);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "render_loop_enabled"), "set_render_loop_enabled", "is_render_loop_enabled");
+
 	BIND_CONSTANT(NO_INDEX_ARRAY);
 	BIND_CONSTANT(ARRAY_WEIGHTS_SIZE);
 	BIND_CONSTANT(CANVAS_ITEM_Z_MIN);
@@ -2366,6 +2370,14 @@ RID VisualServer::instance_create2(RID p_base, RID p_scenario) {
 	instance_set_base(instance, p_base);
 	instance_set_scenario(instance, p_scenario);
 	return instance;
+}
+
+bool VisualServer::is_render_loop_enabled() const {
+	return render_loop_enabled;
+}
+
+void VisualServer::set_render_loop_enabled(bool p_enabled) {
+	render_loop_enabled = p_enabled;
 }
 
 VisualServer::VisualServer() {

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -46,6 +46,7 @@ class VisualServer : public Object {
 	static VisualServer *singleton;
 
 	int mm_policy;
+	bool render_loop_enabled = true;
 
 	void _camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	void _canvas_item_add_style_box(RID p_item, const Rect2 &p_rect, const Rect2 &p_source, RID p_texture, const Vector<float> &p_margins, const Color &p_modulate = Color(1, 1, 1));
@@ -1062,6 +1063,9 @@ public:
 	virtual void call_set_use_vsync(bool p_enable) = 0;
 
 	virtual bool is_low_end() const = 0;
+
+	bool is_render_loop_enabled() const;
+	void set_render_loop_enabled(bool p_enabled);
 
 	VisualServer();
 	virtual ~VisualServer();


### PR DESCRIPTION
Exposes the `disable_render_loop` property from `main.cpp` to GDScript.

Re-implementation of #39541 for the `3.2` branch

CC @akien-mga 