### PR TITLE
 The "Anim imported" warning gets displayed properly when working on imported anims.

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -2877,6 +2877,7 @@ void EditorSceneImporterGLTF::_import_animation(GLTFState &state, AnimationPlaye
 			int track_idx = animation->get_track_count();
 			animation->add_track(Animation::TYPE_TRANSFORM);
 			animation->track_set_path(track_idx, node_path);
+			animation->track_set_imported(track_idx, true);
 			//first determine animation length
 
 			const float increment = 1.0 / float(bake_fps);

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -943,9 +943,9 @@ void ResourceImporterScene::_make_external_resources(Node *p_node, const String 
 				ERR_CONTINUE(anim.is_null());
 
 				if (!p_animations.has(anim)) {
-					//mark what comes from the file first, this helps eventually keep user data
+					// We are making external files so they are modifiable
 					for (int i = 0; i < anim->get_track_count(); i++) {
-						anim->track_set_imported(i, true);
+						anim->track_set_imported(i, false);
 					}
 
 					String ext_name;


### PR DESCRIPTION
Fix #20467.