### PR TITLE
[macOS] Command-backspace in line edit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -274,6 +274,22 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 					set_cursor_position(text.length());
 					shift_selection_check_post(k->get_shift());
 				} break;
+				case (KEY_BACKSPACE): {
+					if (!editable)
+						break;
+
+					// If selected, delete the selection
+					if (selection.enabled) {
+						selection_delete();
+						break;
+					}
+
+					// Otherwise delete from cursor to beginning of text edit
+					int current_pos = get_cursor_position();
+					if (current_pos != 0) {
+						delete_text(0, current_pos);
+					}
+				} break;
 #endif
 				default: {
 					handled = false;


### PR DESCRIPTION
Make command-backspace in line edit work like other macOS applications.

If there is a selection, command-backspace deletes the selection.

If there isn't a selection, command-backspace deletes from the cursor to the beginning of the line edit.

The 3.2 PR for this  is #39658.

This addresses part of #23548