### PR TITLE
Update Tree display on add/remove TreeItem

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -433,6 +433,8 @@ void TreeItem::remove_child(TreeItem *p_item) {
 			*c = (*c)->next;
 
 			aux->parent = nullptr;
+
+			tree->update();
 			return;
 		}
 
@@ -2987,6 +2989,8 @@ TreeItem *Tree::create_item(TreeItem *p_parent, int p_idx) {
 			ti = create_item(root, p_idx);
 		}
 	}
+
+	update();
 
 	return ti;
 }


### PR DESCRIPTION
Updates the Tree display in a scene immediately after a TreeItem is added or removed through certain GDScript commands. 

This should fix #38787.

Before, calling `TreeItem.remove_child(TreeItem)` or `TreeItem.free()` did not update the tree display until either the user interacts with the tree or calls another command that updates the tree, such as `TreeItem.set_text`. Calling `Tree.create_item(TreeItem)` behaved similarly.

It's not clear to me though if this was the intended behavior? It's currently possible to work around this issue by having the user call `$Tree.update()` in the GDScript. Should the user be responsible for calling update after adding/removing items, or should the tree update immediately after adding/removing an item? I ask because it's possible that the user would want to add/remove a large number of items from the tree all at once but only update the display once when finished (for performance), rather than have the display update after every change. Still, I haven't noticed a performance difference between the two perspectives when testing with >100,000 items.