### PR TITLE
GLES2 Batching - prevent baking on VERTEX use in a shader

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1426,7 +1426,7 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 			p_shader->canvas_item.uses_time = false;
 			p_shader->canvas_item.uses_modulate = false;
 			p_shader->canvas_item.uses_color = false;
-			p_shader->canvas_item.reads_vertex = false;
+			p_shader->canvas_item.uses_vertex = false;
 			p_shader->canvas_item.batch_flags = 0;
 
 			shaders.actions_canvas.render_mode_values["blend_add"] = Pair<int *, int>(&p_shader->canvas_item.blend_mode, Shader::CanvasItem::BLEND_MODE_ADD);
@@ -1444,8 +1444,7 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 			shaders.actions_canvas.usage_flag_pointers["TIME"] = &p_shader->canvas_item.uses_time;
 			shaders.actions_canvas.usage_flag_pointers["MODULATE"] = &p_shader->canvas_item.uses_modulate;
 			shaders.actions_canvas.usage_flag_pointers["COLOR"] = &p_shader->canvas_item.uses_color;
-
-			shaders.actions_canvas.read_flag_pointers["VERTEX"] = &p_shader->canvas_item.reads_vertex;
+			shaders.actions_canvas.usage_flag_pointers["VERTEX"] = &p_shader->canvas_item.uses_vertex;
 
 			actions = &shaders.actions_canvas;
 			actions->uniforms = &p_shader->uniforms;
@@ -1538,7 +1537,7 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 		if (p_shader->canvas_item.uses_modulate | p_shader->canvas_item.uses_color) {
 			p_shader->canvas_item.batch_flags |= Shader::CanvasItem::PREVENT_COLOR_BAKING;
 		}
-		if (p_shader->canvas_item.reads_vertex) {
+		if (p_shader->canvas_item.uses_vertex) {
 			p_shader->canvas_item.batch_flags |= Shader::CanvasItem::PREVENT_VERTEX_BAKING;
 		}
 	}

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -461,7 +461,7 @@ public:
 			bool uses_time;
 			bool uses_modulate;
 			bool uses_color;
-			bool reads_vertex;
+			bool uses_vertex;
 
 		} canvas_item;
 

--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -486,10 +486,6 @@ String ShaderCompilerGLES2::_dump_node_code(SL::Node *p_node, int p_level, Gener
 				*p_actions.write_flag_pointers[var_node->name] = true;
 			}
 
-			if (!p_assigning && p_actions.read_flag_pointers.has(var_node->name)) {
-				*p_actions.read_flag_pointers[var_node->name] = true;
-			}
-
 			if (p_default_actions.usage_defines.has(var_node->name) && !used_name_defines.has(var_node->name)) {
 				String define = p_default_actions.usage_defines[var_node->name];
 				String node_name = define.substr(1, define.length());

--- a/drivers/gles2/shader_compiler_gles2.h
+++ b/drivers/gles2/shader_compiler_gles2.h
@@ -44,7 +44,6 @@ public:
 		Map<StringName, Pair<int *, int> > render_mode_values;
 		Map<StringName, bool *> render_mode_flags;
 		Map<StringName, bool *> usage_flag_pointers;
-		Map<StringName, bool *> read_flag_pointers;
 		Map<StringName, bool *> write_flag_pointers;
 
 		Map<StringName, ShaderLanguage::ShaderNode::Uniform> *uniforms;


### PR DESCRIPTION
Using the operator += in a shader is classified as an 'assign', and so is classified as a write rather than a read. This means that we need to prevent vertex baking on either a write or read (i.e. on usage), rather than just on reads.

Fixes #39651.

### Notes
* This was probably always needed realistically, and it means that most custom shaders will have some baking prevented.