### PR TITLE
Hide autoload category from general project settings

### DIFF
--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -234,7 +234,7 @@ void SectionedInspector::update_category_list() {
 			continue;
 		}
 
-		if (pi.name.find(":") != -1 || pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene" || pi.name.begins_with("_global_script")) {
+		if (pi.name.find(":") != -1 || pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene" || pi.name.begins_with("_global_script") || pi.name.begins_with("autoload")) {
 			continue;
 		}
 


### PR DESCRIPTION
Fixes #39639
Fixes godotengine/godot-proposals#1082
*Bugsquad edit:* Fixes #24453

While Autoload has its own tab in the Project Settings, it was also added as a category under the general settings. The issue is about incorrect autoload names, but the autoload is unnecessary here and can be removed. This commit removes Autoload from the General tab.
