### PR TITLE
Implement Vector3.swizzle{2,3}.

### DIFF
--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -42,6 +42,21 @@ Vector3 Vector3::rotated(const Vector3 &p_axis, real_t p_phi) const {
 	return r;
 }
 
+Vector2 Vector3::swizzle2(int p_x, int p_y) const {
+	return Vector2(
+        p_x == Component::COMPONENT_ZERO ? 0 : get_axis(p_x),
+        p_y == Component::COMPONENT_ZERO ? 0 : get_axis(p_y)
+    );
+}
+
+Vector3 Vector3::swizzle3(int p_x, int p_y, int p_z) const {
+	return Vector3(
+        p_x == Component::COMPONENT_ZERO ? 0 : get_axis(p_x),
+        p_y == Component::COMPONENT_ZERO ? 0 : get_axis(p_y),
+        p_z == Component::COMPONENT_ZERO ? 0 : get_axis(p_z)
+    );
+}
+
 void Vector3::set_axis(int p_axis, real_t p_value) {
 	ERR_FAIL_INDEX(p_axis, 3);
 	coord[p_axis] = p_value;

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -33,6 +33,7 @@
 
 #include "core/math/math_funcs.h"
 #include "core/math/vector3i.h"
+#include "core/math/vector2.h"
 #include "core/ustring.h"
 
 class Basis;
@@ -42,6 +43,13 @@ struct Vector3 {
 		AXIS_X,
 		AXIS_Y,
 		AXIS_Z,
+	};
+
+	enum Component {
+		COMPONENT_X,
+		COMPONENT_Y,
+		COMPONENT_Z,
+		COMPONENT_ZERO,
 	};
 
 	union {
@@ -83,6 +91,9 @@ struct Vector3 {
 
 	void rotate(const Vector3 &p_axis, real_t p_phi);
 	Vector3 rotated(const Vector3 &p_axis, real_t p_phi) const;
+
+	Vector2 swizzle2(int p_x, int p_y) const;
+	Vector3 swizzle3(int p_x, int p_y, int p_z) const;
 
 	/* Static Methods between 2 vector3s */
 

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -428,6 +428,8 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(Vector3, inverse);
 	VCALL_LOCALMEM1R(Vector3, snapped);
 	VCALL_LOCALMEM2R(Vector3, rotated);
+	VCALL_LOCALMEM2R(Vector3, swizzle2);
+	VCALL_LOCALMEM3R(Vector3, swizzle3);
 	VCALL_LOCALMEM2R(Vector3, lerp);
 	VCALL_LOCALMEM2R(Vector3, slerp);
 	VCALL_LOCALMEM4R(Vector3, cubic_interpolate);
@@ -1938,6 +1940,8 @@ void register_variant_methods() {
 	ADDFUNC0R(VECTOR3, VECTOR3, Vector3, inverse, varray());
 	ADDFUNC1R(VECTOR3, VECTOR3, Vector3, snapped, VECTOR3, "by", varray());
 	ADDFUNC2R(VECTOR3, VECTOR3, Vector3, rotated, VECTOR3, "axis", FLOAT, "phi", varray());
+	ADDFUNC2R(VECTOR3, VECTOR2, Vector3, swizzle2, INT, "ax", INT, "ay", varray());
+	ADDFUNC3R(VECTOR3, VECTOR3, Vector3, swizzle3, INT, "ax", INT, "ay", INT, "az", varray());
 	ADDFUNC2R(VECTOR3, VECTOR3, Vector3, lerp, VECTOR3, "b", FLOAT, "t", varray());
 	ADDFUNC2R(VECTOR3, VECTOR3, Vector3, slerp, VECTOR3, "b", FLOAT, "t", varray());
 	ADDFUNC4R(VECTOR3, VECTOR3, Vector3, cubic_interpolate, VECTOR3, "b", VECTOR3, "pre_a", VECTOR3, "post_b", FLOAT, "t", varray());
@@ -2305,6 +2309,11 @@ void register_variant_methods() {
 	_VariantCall::add_constant(Variant::VECTOR3, "AXIS_X", Vector3::AXIS_X);
 	_VariantCall::add_constant(Variant::VECTOR3, "AXIS_Y", Vector3::AXIS_Y);
 	_VariantCall::add_constant(Variant::VECTOR3, "AXIS_Z", Vector3::AXIS_Z);
+
+	_VariantCall::add_constant(Variant::VECTOR3, "COMPONENT_X", Vector3::COMPONENT_X);
+	_VariantCall::add_constant(Variant::VECTOR3, "COMPONENT_Y", Vector3::COMPONENT_Y);
+	_VariantCall::add_constant(Variant::VECTOR3, "COMPONENT_Z", Vector3::COMPONENT_Z);
+	_VariantCall::add_constant(Variant::VECTOR3, "COMPONENT_ZERO", Vector3::COMPONENT_ZERO);
 
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ZERO", Vector3(0, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ONE", Vector3(1, 1, 1));

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -312,6 +312,40 @@
 				Returns the vector snapped to a grid with the given size.
 			</description>
 		</method>
+		<method name="swizzle2">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="ax" type="int">
+			</argument>
+			<argument index="1" name="ay" type="int">
+			</argument>
+			<description>
+				Construct a new vector by rearranging or zeroing components of this vector.
+				[b]Example:[/b]
+				[codeblock]
+				Vector3(1, 2, 3).swizzle2(Vector3.COMPONENT_Z, Vector3.COMPONENT_Y) # (3, 2)
+				Vector3(1, 2, 3).swizzle2(Vector3.COMPONENT_X, Vector3.COMPONENT_ZERO) # (1, 0)
+				[/codeblock]
+			</description>
+		</method>
+		<method name="swizzle3">
+			<return type="Vector3">
+			</return>
+			<argument index="0" name="ax" type="int">
+			</argument>
+			<argument index="1" name="ay" type="int">
+			</argument>
+			<argument index="2" name="az" type="int">
+			</argument>
+			<description>
+				Construct a new vector by rearranging or zeroing components of this vector.
+				[b]Example:[/b]
+				[codeblock]
+				Vector3(1, 2, 3).swizzle3(Vector3.COMPONENT_Z, Vector3.COMPONENT_Y, Vector3.COMPONENT_X) # (3, 2, 1)
+				Vector3(1, 2, 3).swizzle3(Vector3.COMPONENT_X, Vector3.COMPONENT_ZERO, Vector3.COMPONENT_Z) # (1, 0, 3)
+				[/codeblock]
+			</description>
+		</method>
 		<method name="to_diagonal_matrix">
 			<return type="Basis">
 			</return>
@@ -340,6 +374,18 @@
 		</constant>
 		<constant name="AXIS_Z" value="2">
 			Enumerated value for the Z axis. Returned by [method max_axis] and [method min_axis].
+		</constant>
+		<constant name="COMPONENT_X" value="0">
+			Used by [method swizzle2] and [method swizzle3] to select the X component.
+		</constant>
+		<constant name="COMPONENT_Y" value="1">
+			Used by [method swizzle2] and [method swizzle3] to select the Y component.
+		</constant>
+		<constant name="COMPONENT_Z" value="2">
+			Used by [method swizzle2] and [method swizzle3] to select the Z component.
+		</constant>
+		<constant name="COMPONENT_ZERO" value="3">
+			Used by [method swizzle2] and [method swizzle3] to set a resulting component to 0.
 		</constant>
 		<constant name="ZERO" value="Vector3( 0, 0, 0 )">
 			Zero vector.

--- a/modules/gdnative/gdnative/vector3.cpp
+++ b/modules/gdnative/gdnative/vector3.cpp
@@ -117,6 +117,20 @@ godot_vector3 GDAPI godot_vector3_rotated(const godot_vector3 *p_self, const god
 	return dest;
 }
 
+godot_vector2 GDAPI godot_vector3_swizzle2(const godot_vector3 *p_self, godot_vector3_component p_x, godot_vector3_component p_y) {
+	godot_vector2 dest;
+	const Vector3 *self = (const Vector3 *)p_self;
+	*((Vector2 *)&dest) = self->swizzle2(p_x, p_y);
+	return dest;
+}
+
+godot_vector3 GDAPI godot_vector3_swizzle3(const godot_vector3 *p_self, godot_vector3_component p_x, godot_vector3_component p_y, godot_vector3_component p_z) {
+	godot_vector3 dest;
+	const Vector3 *self = (const Vector3 *)p_self;
+	*((Vector3 *)&dest) = self->swizzle3(p_x, p_y, p_z);
+	return dest;
+}
+
 godot_vector3 GDAPI godot_vector3_lerp(const godot_vector3 *p_self, const godot_vector3 *p_b, const godot_real p_t) {
 	godot_vector3 dest;
 	const Vector3 *self = (const Vector3 *)p_self;

--- a/modules/gdnative/include/gdnative/vector3.h
+++ b/modules/gdnative/include/gdnative/vector3.h
@@ -62,6 +62,7 @@ typedef struct {
 
 #include <gdnative/basis.h>
 #include <gdnative/gdnative.h>
+#include "gdnative/vector2.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,6 +73,13 @@ typedef enum {
 	GODOT_VECTOR3_AXIS_Y,
 	GODOT_VECTOR3_AXIS_Z,
 } godot_vector3_axis;
+
+typedef enum {
+	GODOT_VECTOR3_COMPONENT_X,
+	GODOT_VECTOR3_COMPONENT_Y,
+	GODOT_VECTOR3_COMPONENT_Z,
+	GODOT_VECTOR3_COMPONENT_ZERO,
+} godot_vector3_component;
 
 // Vector3
 
@@ -98,6 +106,10 @@ godot_vector3 GDAPI godot_vector3_inverse(const godot_vector3 *p_self);
 godot_vector3 GDAPI godot_vector3_snapped(const godot_vector3 *p_self, const godot_vector3 *p_by);
 
 godot_vector3 GDAPI godot_vector3_rotated(const godot_vector3 *p_self, const godot_vector3 *p_axis, const godot_real p_phi);
+
+godot_vector2 GDAPI godot_vector3_swizzle2(const godot_vector3 *p_self, godot_vector3_component p_x, godot_vector3_component p_y);
+
+godot_vector3 GDAPI godot_vector3_swizzle3(const godot_vector3 *p_self, godot_vector3_component p_x, godot_vector3_component p_y, godot_vector3_component p_z);
 
 godot_vector3 GDAPI godot_vector3_lerp(const godot_vector3 *p_self, const godot_vector3 *p_b, const godot_real p_t);
 


### PR DESCRIPTION
Swizzling operators allow you to form a vector by rearranging or zeroing
certain components of another vector. This is often implemented with a
syntax like `v.zyx()`, but the number of permutations would take up a
massive API surface. Adding `swizzle{2,3}` allows us to handle
all the permutations with just 2 new methods. I'm assuming implementing
swizzling via dynamic dispatch (i.e. `_get` in godot) would be
infeasible for a low-level builtin type like Vector3.

It works like so:

```
var v := Vector3(1,2,3)
// (2, 3, 0)
v.swizzle3(Vector3.COMPONENT_Y, Vector3.COMPONENT_Z, Vector3.COMPONENT_ZERO))
// (1, 3)
v.swizzle2(Vector3.COMPONENT_X, Vector3.COMPONENT_Z))
```

Resolves godotengine/godot-proposals#727.