### PR TITLE
Export: Rename 'Windows Universal' to 'UWP'

### DIFF
--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -283,7 +283,7 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 		platforms["Haiku"] = platform_haiku;
 
 		NativePlatformConfig platform_uwp;
-		platform_uwp.name = "Windows Universal";
+		platform_uwp.name = "UWP";
 		platform_uwp.entries.push_back("arm");
 		platform_uwp.entries.push_back("32");
 		platform_uwp.entries.push_back("64");

--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -970,7 +970,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 
 public:
 	virtual String get_name() const {
-		return "Windows Universal";
+		return "UWP";
 	}
 	virtual String get_os_name() const {
 		return "UWP";
@@ -1180,7 +1180,7 @@ public:
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) {
 		String src_appx;
 
-		EditorProgress ep("export", "Exporting for Windows Universal", 7, true);
+		EditorProgress ep("export", "Exporting for UWP", 7, true);
 
 		if (p_debug) {
 			src_appx = p_preset->get("custom_template/debug");


### PR DESCRIPTION
It's otherwise too easy to be confused between 'Windows Desktop' (Win32)
and 'Windows Universal' (UWP).