### PR TITLE
Set proper file type attribute for OSX zip export

### DIFF
--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -829,7 +829,10 @@ void EditorExportPlatformOSX::_zip_folder_recursive(zipFile &p_zip, const String
 			zipfi.tmz_date.tm_sec = time.sec;
 			zipfi.tmz_date.tm_year = date.year;
 			zipfi.dosDate = 0;
-			zipfi.external_fa = (is_executable ? 0755 : 0644) << 16L;
+			// 0100000: regular file type
+			// 0000755: permissions rwxr-xr-x
+			// 0000644: permissions rw-r--r--
+			zipfi.external_fa = (is_executable ? 0100755 : 0100644) << 16L;
 			zipfi.internal_fa = 0;
 
 			zipOpenNewFileInZip4(p_zip,


### PR DESCRIPTION
The missing file type in file attributes was causing the file to lose executable permissions when unzipped with some software.

Fixes #37725 still occurring in some specific cases.
See https://github.com/godotengine/godot/issues/527#issuecomment-644250054

OSX version: 10.13.6 (High Sierra)
Zip export created on Windows 10
Zip extracted on Mac using default Archive Utility

Source for information about file attributes in zip:
https://unix.stackexchange.com/questions/14705/the-zip-formats-external-file-attribute