### PR TITLE
Fix missing slider joystick handling on Windows

### DIFF
--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -172,6 +172,7 @@ bool JoypadWindows::setup_dinput_joypad(const DIDEVICEINSTANCE *instance) {
 	sprintf_s(uid, "%04x%04x%04x%04x%04x%04x%04x%04x", type, 0, vendor, 0, product, 0, version, 0);
 
 	id_to_change = joypad_count;
+	slider_count = 0;
 
 	joy->di_joy->SetDataFormat(&c_dfDIJoystick2);
 	joy->di_joy->SetCooperativeLevel(*hWnd, DISCL_FOREGROUND);
@@ -206,9 +207,12 @@ void JoypadWindows::setup_joypad_object(const DIDEVICEOBJECTINSTANCE *ob, int p_
 			ofs = DIJOFS_RY;
 		else if (ob->guidType == GUID_RzAxis)
 			ofs = DIJOFS_RZ;
-		else if (ob->guidType == GUID_Slider)
-			ofs = DIJOFS_SLIDER(0);
-		else
+		else if (ob->guidType == GUID_Slider) {
+			if (slider_count < 2) {
+				ofs = DIJOFS_SLIDER(slider_count);
+				slider_count++;
+			}
+		} else
 			return;
 		prop_range.diph.dwSize = sizeof(DIPROPRANGE);
 		prop_range.diph.dwHeaderSize = sizeof(DIPROPHEADER);
@@ -388,9 +392,9 @@ void JoypadWindows::process_joypads() {
 		}
 
 		// on mingw, these constants are not constants
-		int count = 6;
-		unsigned int axes[] = { DIJOFS_X, DIJOFS_Y, DIJOFS_Z, DIJOFS_RX, DIJOFS_RY, DIJOFS_RZ };
-		int values[] = { js.lX, js.lY, js.lZ, js.lRx, js.lRy, js.lRz };
+		int count = 8;
+		unsigned int axes[] = { DIJOFS_X, DIJOFS_Y, DIJOFS_Z, DIJOFS_RX, DIJOFS_RY, DIJOFS_RZ, DIJOFS_SLIDER(0), DIJOFS_SLIDER(1) };
+		int values[] = { js.lX, js.lY, js.lZ, js.lRx, js.lRy, js.lRz, js.rglSlider[0], js.rglSlider[1] };
 
 		for (int j = 0; j < joy->joy_axis.size(); j++) {
 			for (int k = 0; k < count; k++) {

--- a/platform/windows/joypad_windows.h
+++ b/platform/windows/joypad_windows.h
@@ -118,6 +118,7 @@ private:
 	Input *input;
 
 	int id_to_change;
+	int slider_count;
 	int joypad_count;
 	bool attached_joypads[JOYPADS_MAX];
 	dinput_gamepad d_joypads[JOYPADS_MAX];


### PR DESCRIPTION
Playing around with my new flight stick I noticed that the throttle input wasn't being fed into Godot. 

Turns out on Windows the code that handles so called "sliders" was only half implemented. The first (of the possible two) was being recognized but the value wasn't being retrieved.

Added the code that completes this.

I have only tested this in Godot 3.2 and my Joystick only supports one slider, I'm guessing if you have something like a pedal setup with steering wheel both may be used. 