### PR TITLE
Fix overwrite of manual changes in export_presets.cfg when export dialog is opened

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -100,7 +100,6 @@ void EditorExportPreset::update_files_to_export() {
 	for (int i = 0; i < to_remove.size(); ++i) {
 		selected_files.erase(to_remove[i]);
 	}
-	EditorExport::singleton->save_presets();
 }
 
 Vector<String> EditorExportPreset::get_files_to_export() const {


### PR DESCRIPTION
Ensures that when the export_presets.cfg file is edited manually while the editor is open, the behavior is identical to before #39434 - i.e. opening the export dialog box does not overwrite changes to the file.

Closes #39681, but the background issue of manual changes in export_presets.cfg not always being in sync with the editor's project export remains. Selecting/Deselecting a file in the project export dialog box would also overwrite any manual changes that are made to export_presets.cfg while the editor is open.