### PR TITLE
Update bool documentation to be more clear

### DIFF
--- a/doc/classes/bool.xml
+++ b/doc/classes/bool.xml
@@ -4,14 +4,14 @@
 		Boolean built-in type.
 	</brief_description>
 	<description>
-		Boolean is a built-in type. It can represent any data type that is either a true or false value. You can think of it as an switch with on or off (1 or 0) setting. It's often used as part of programming logic in condition statements like [code]if[/code] statements.
-		[b]Note:[/b] In a code below [code]if can_shoot[/code] is equivalent of [code]if can_shoot == true[/code]. It is good practice to follow the natural spoken language structure when possible. Use [code]if can_shoot[/code] rather than [code]if can_shoot == true[/code] and use [code]if not can_shoot[/code] rather than [code]if can_shoot == false[/code].
+		Boolean is a built-in type. There are two boolean values: [code]true[/code] and [code]false[/code]. You can think of it as an switch with on or off (1 or 0) setting. Booleans are used in programming for logic in condition statements, like [code]if[/code] statements.
+		Booleans can be directly used in [code]if[/code] statements. The code below demonstrates this on the [code]if can_shoot:[/code] line. You don't need to use [code]== true[/code], you only need [code]if can_shoot:[/code]. Similarly, use [code]if not can_shoot:[/code] rather than [code]== false[/code].
 		[codeblock]
 		var can_shoot = true
 
 		func shoot():
 		    if can_shoot:
-		        # Perform shooting actions here.
+		        pass # Perform shooting actions here.
 		[/codeblock]
 		The following code will only create a bullet if both conditions are met: action "shoot" is pressed and if [code]can_shoot[/code] is [code]true[/code].
 		[b]Note:[/b] [code]Input.is_action_pressed("shoot")[/code] is also a boolean that is [code]true[/code] when "shoot" is pressed and [code]false[/code] when "shoot" isn't pressed.
@@ -46,7 +46,7 @@
 			<argument index="0" name="from" type="int">
 			</argument>
 			<description>
-				Cast an [int] value to a boolean value, this method will return [code]true[/code] if called with an integer value different to 0 and [code]false[/code] in other case.
+				Cast an [int] value to a boolean value, this method will return [code]false[/code] if [code]0[/code] is passed in, and [code]true[/code] for all other ints.
 			</description>
 		</method>
 		<method name="bool">
@@ -55,7 +55,7 @@
 			<argument index="0" name="from" type="float">
 			</argument>
 			<description>
-				Cast a [float] value to a boolean value, this method will return [code]true[/code] if called with a floating-point value different to 0 and [code]false[/code] in other case.
+				Cast a [float] value to a boolean value, this method will return [code]false[/code] if [code]0.0[/code] is passed in, and [code]true[/code] for all other floats.
 			</description>
 		</method>
 		<method name="bool">
@@ -64,7 +64,8 @@
 			<argument index="0" name="from" type="String">
 			</argument>
 			<description>
-				Cast a [String] value to a boolean value, this method will return [code]true[/code] if called with a non-empty string and [code]false[/code] in other case. Examples: [code]bool("False")[/code] returns [code]true[/code], [code]bool("")[/code] returns [code]false[/code].
+				Cast a [String] value to a boolean value, this method will return [code]false[/code] if [code]""[/code] is passed in, and [code]true[/code] for all non-empty strings.
+				Examples: [code]bool("False")[/code] returns [code]true[/code], [code]bool("")[/code] returns [code]false[/code].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
"Boolean is a built-in type. It can represent any data type that is either a true or false value". These sentences are basically saying that boolean both is and isn't a type, since it is a built-in type, but it can represent any data type. What? I replaced the second sentence with "There are two boolean values: [code]true[/code] and [code]false[/code]".

For the casting methods, previously the documentation looked like "this method will return [code]true[/code] if called with an integer value different to 0 and [code]false[/code] in other case". I find it confusing to define the return for something that isn't the case (true if different from zero), and then say the other return value is "the other case" (what was previously being stated as not the case for true, so... not different from zero, aka zero). I changed this to first define the case for false, and then state that true is anything else.

There are a few other tweaks that aren't in the above paragraphs, check the diff.