### PR TITLE
Improve OS time api

### DIFF
--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -202,8 +202,8 @@ public:
 	Dictionary get_date(bool utc) const;
 	Dictionary get_time(bool utc) const;
 	Dictionary get_datetime(bool utc) const;
-	Dictionary get_datetime_from_unix_time(int64_t unix_time_val) const;
-	int64_t get_unix_time_from_datetime(Dictionary datetime) const;
+	Dictionary get_datetime_from_unix_time(double unix_time_val) const;
+	double get_unix_time_from_datetime(Dictionary datetime) const;
 	Dictionary get_time_zone_info() const;
 	double get_unix_time() const;
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -51,33 +51,63 @@ uint32_t OS::get_ticks_msec() const {
 	return get_ticks_usec() / 1000;
 }
 
-String OS::get_iso_date_time(bool local) const {
-	OS::Date date = get_date(local);
-	OS::Time time = get_time(local);
+String OS::get_iso_date_time(bool local, bool msec) const {
+	OS::DateTime dt = get_datetime(local);
 
 	String timezone;
 	if (!local) {
-		TimeZoneInfo zone = get_time_zone_info();
-		if (zone.bias >= 0) {
+		if (dt.timezone.bias >= 0) {
 			timezone = "+";
 		}
-		timezone = timezone + itos(zone.bias / 60).pad_zeros(2) + itos(zone.bias % 60).pad_zeros(2);
+		timezone = timezone + itos(dt.timezone.bias / 60).pad_zeros(2) + itos(dt.timezone.bias % 60).pad_zeros(2);
 	} else {
 		timezone = "Z";
 	}
 
-	return itos(date.year).pad_zeros(2) +
-		   "-" +
-		   itos(date.month).pad_zeros(2) +
-		   "-" +
-		   itos(date.day).pad_zeros(2) +
-		   "T" +
-		   itos(time.hour).pad_zeros(2) +
-		   ":" +
-		   itos(time.min).pad_zeros(2) +
-		   ":" +
-		   itos(time.sec).pad_zeros(2) +
-		   timezone;
+	String ret = itos(dt.year).pad_zeros(2) +
+				 "-" +
+				 itos(dt.month).pad_zeros(2) +
+				 "-" +
+				 itos(dt.day).pad_zeros(2) +
+				 "T" +
+				 itos(dt.hour).pad_zeros(2) +
+				 ":" +
+				 itos(dt.min).pad_zeros(2) +
+				 ":" +
+				 itos(dt.sec).pad_zeros(2);
+
+	if (msec) {
+		ret += "." + itos(dt.msec).pad_zeros(3);
+	}
+	ret += timezone;
+
+	return ret;
+}
+
+OS::Date OS::get_date(bool local) const {
+	OS::DateTime dt = get_datetime(local);
+	OS::Date ret;
+	ret.year = dt.year;
+	ret.month = dt.month;
+	ret.day = dt.day;
+	ret.weekday = dt.weekday;
+	ret.dst = dt.dst;
+	return ret;
+}
+
+OS::Time OS::get_time(bool local) const {
+	OS::DateTime dt = get_datetime(local);
+	OS::Time ret;
+	ret.hour = dt.hour;
+	ret.min = dt.min;
+	ret.sec = dt.sec;
+	ret.msec = dt.msec;
+	return ret;
+}
+
+OS::TimeZoneInfo OS::get_time_zone_info() const {
+	OS::DateTime dt = get_datetime(true);
+	return dt.timezone;
 }
 
 void OS::debug_break() {

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -80,10 +80,6 @@ String OS::get_iso_date_time(bool local) const {
 		   timezone;
 }
 
-double OS::get_unix_time() const {
-	return 0;
-}
-
 void OS::debug_break() {
 	// something
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -206,7 +206,7 @@ public:
 	virtual Time get_time(bool local = false) const = 0;
 	virtual TimeZoneInfo get_time_zone_info() const = 0;
 	virtual String get_iso_date_time(bool local = false) const;
-	virtual double get_unix_time() const;
+	virtual double get_unix_time() const = 0;
 
 	virtual void delay_usec(uint32_t p_usec) const = 0;
 	virtual void add_frame_delay(bool p_can_draw);

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -195,6 +195,7 @@ public:
 		int hour;
 		int min;
 		int sec;
+		int msec;
 	};
 
 	struct TimeZoneInfo {
@@ -202,10 +203,24 @@ public:
 		String name;
 	};
 
-	virtual Date get_date(bool local = false) const = 0;
-	virtual Time get_time(bool local = false) const = 0;
-	virtual TimeZoneInfo get_time_zone_info() const = 0;
-	virtual String get_iso_date_time(bool local = false) const;
+	struct DateTime {
+		int year;
+		Month month;
+		int day;
+		Weekday weekday;
+		bool dst;
+		int hour;
+		int min;
+		int sec;
+		int msec;
+		OS::TimeZoneInfo timezone;
+	};
+
+	virtual DateTime get_datetime(bool local = false) const = 0;
+	Date get_date(bool local = false) const;
+	Time get_time(bool local = false) const;
+	TimeZoneInfo get_time_zone_info() const;
+	String get_iso_date_time(bool local = false, bool msec = false) const;
 	virtual double get_unix_time() const = 0;
 
 	virtual void delay_usec(uint32_t p_usec) const = 0;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -191,17 +191,18 @@
 			<argument index="0" name="utc" type="bool" default="false">
 			</argument>
 			<description>
-				Returns current datetime as a dictionary of keys: [code]year[/code], [code]month[/code], [code]day[/code], [code]weekday[/code], [code]dst[/code] (Daylight Savings Time), [code]hour[/code], [code]minute[/code], [code]second[/code].
+				Returns current datetime as a dictionary of keys: [code]year[/code], [code]month[/code], [code]day[/code], [code]weekday[/code], [code]dst[/code] (Daylight Savings Time), [code]hour[/code], [code]minute[/code], [code]second[/code] and [code]millisecond[/code].
 			</description>
 		</method>
 		<method name="get_datetime_from_unix_time" qualifiers="const">
 			<return type="Dictionary">
 			</return>
-			<argument index="0" name="unix_time_val" type="int">
+			<argument index="0" name="unix_time_val" type="float">
 			</argument>
 			<description>
 				Gets a dictionary of time values corresponding to the given UNIX epoch time (in seconds).
-				The returned Dictionary's values will be the same as [method get_datetime], with the exception of Daylight Savings Time as it cannot be determined from the epoch.
+				Retuned dictionary will be equivalent to what is returned by [method get_datetime] with [code]utc=true[/code],
+				with the exception of Daylight Savings Time as it cannot be determined from epoch.
 			</description>
 		</method>
 		<method name="get_environment" qualifiers="const">
@@ -363,13 +364,13 @@
 			</description>
 		</method>
 		<method name="get_unix_time_from_datetime" qualifiers="const">
-			<return type="int">
+			<return type="float">
 			</return>
 			<argument index="0" name="datetime" type="Dictionary">
 			</argument>
 			<description>
 				Gets an epoch time value from a dictionary of time values.
-				[code]datetime[/code] must be populated with the following keys: [code]year[/code], [code]month[/code], [code]day[/code], [code]hour[/code], [code]minute[/code], [code]second[/code].
+				[code]datetime[/code] must be populated with the following keys: [code]year[/code], [code]month[/code], [code]day[/code], [code]hour[/code], [code]minute[/code], [code]second[/code] and [code]millisecond[/code].
 				If the dictionary is empty [code]0[/code] is returned.
 				You can pass the output from [method get_datetime_from_unix_time] directly into this function. Daylight Savings Time ([code]dst[/code]), if present, is ignored.
 			</description>

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -356,7 +356,10 @@
 			</return>
 			<description>
 				Returns the current UNIX epoch timestamp.
-				[b]Important:[/b] This is the system clock that the user can manully set. [b]Never use[/b] this method for precise time calculation since its results are also subject to automatic adjustments by the operating system. [b]Always use[/b] [method get_ticks_usec] or [method get_ticks_msec] for precise time calculation instead, since they are guaranteed to be monotonic (i.e. never decrease).
+				This correspond to the number of second elapsed since January 1, 1970, 00:00:00 (UTC), ignoring the leap seconds.
+				The time is returned as a floating number with sub-second precision depending of the platform.
+				[b]Note:[/b] This method doesn't guarantee monotonic time (i.e. a call may return a greater value than a subsequent one, for instance if the system clock is modified between the two calls).
+				For benchmarking usage you should consider [method get_ticks_usec] or [method get_ticks_msec] instead.
 			</description>
 		</method>
 		<method name="get_unix_time_from_datetime" qualifiers="const">

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -73,9 +73,7 @@ public:
 
 	virtual String get_name() const override;
 
-	virtual Date get_date(bool utc) const override;
-	virtual Time get_time(bool utc) const override;
-	virtual TimeZoneInfo get_time_zone_info() const override;
+	virtual DateTime get_datetime(bool utc) const override;
 
 	virtual double get_unix_time() const override;
 

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -472,6 +472,7 @@ OS::Time OS_UWP::get_time(bool utc) const {
 	time.hour = systemtime.wHour;
 	time.min = systemtime.wMinute;
 	time.sec = systemtime.wSecond;
+	time.msec = systemtime.wMilliseconds;
 	return time;
 }
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -117,10 +117,7 @@ public:
 	virtual String get_name() const override;
 
 	virtual void initialize_joypads() override {}
-
-	virtual Date get_date(bool utc) const override;
-	virtual Time get_time(bool utc) const override;
-	virtual TimeZoneInfo get_time_zone_info() const override;
+	virtual DateTime get_datetime(bool utc) const override;
 	virtual double get_unix_time() const override;
 
 	virtual Error set_cwd(const String &p_cwd) override;


### PR DESCRIPTION
Following #39189

This PR improve the OS.get_unix_time_from_datetime & OS.get_datetime familly of functions:

- `OS.get_datetime` is the main function that should be implemented by platforms
- datetime dictionary contains the a milliseconds field (it is considered trying to have a lower precision is not really useful)
- `OS.get_date/time/time_zone_info` are just wrappers over `OS.get_datetime`
- `OS.get_datetime` is GDscript returns a dict containing the timezone information. In my experience it's a really really bad idea to have timezone-naive variable (given you have no idea if this variable is UTC or local time, and this cause subtle bugs hard to catch on CI where local time is set to UTC...)
- The use of `OS.get_date` then `OS.get_time` in a row has been replaced by `OS.get_datetime`, this avoid potential invalid time when the date change between the two calls

Things I'm still wondering:
- `OS.get_datetime()` takes a `utc` parameter in GDScript while `OS.get_datetime()` takes a `local` parameter in C++... This is error-prone (as [is currently buggy !](https://github.com/godotengine/godot/blob/277d2f1f50fe060ad7ff4b2696bf67a742a0ea83/core/bind/core_bind.cpp#L335)). We should choose `utc` or `local` and stick to it everywhere
- I don't see the use for the `dst` field, especially since it is always set to false on Windows. So I think it would be just better to remove it ;-)
- It would be much more convenient to have Datetime as a builtin type instead of representing them with dictionaries (hence we could easily compare dates, represent them for debugging and encode them back and forth to a string format)
- `OS::get_iso_date_time` is only used [once in the whole codebase](https://github.com/godotengine/godot/blob/277d2f1f50fe060ad7ff4b2696bf67a742a0ea83/editor/editor_node.cpp#L2563), it would be better to expose it to GDNative (along with a iso string to datetime function)
- timezone naming on windows seems odd (I got `Romance Daylight Time` currently for UTC+2), it may be correct, but it forces `OS::get_iso_date_time` to [do extra work](https://github.com/godotengine/godot/blob/277d2f1f50fe060ad7ff4b2696bf67a742a0ea83/core/os/os.cpp#L63) to have a useful naming (which is something we may not want to push on GDscript users)