### PR TITLE
Fix for a crash on printing freed object

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1598,6 +1598,10 @@ String Variant::stringify(List<const void *> &stack) const {
 
 			Object *obj = _OBJ_PTR(*this);
 			if (obj) {
+				if (_get_obj().ref.is_null() && !ObjectDB::get_instance(obj->get_instance_id())) {
+					return "[Deleted Object]";
+				}
+
 				return obj->to_string();
 			} else {
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
Fixes #38597

Port of Object's check condition for freed object printing from `master` branch: https://github.com/godotengine/godot/blob/85220fec010a4946cb364974eac69418b4e06411/core/variant.cpp#L1833-L1838

I've checked this fix on MacOS, Windows and iOS and printing deleted object is no longer crashes compiled application.

[Test project](https://github.com/naithar/gd_richedit_test/tree/delete_check)