### PR TITLE
add force caret display to line edit

### DIFF
--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -134,6 +134,7 @@ private:
 	void update_placeholder_width();
 
 	bool caret_blink_enabled;
+	bool caret_force_displayed;
 	bool draw_caret;
 	bool window_has_focus;
 
@@ -200,6 +201,9 @@ public:
 
 	float cursor_get_blink_speed() const;
 	void cursor_set_blink_speed(const float p_speed);
+
+	bool cursor_get_force_displayed() const;
+	void cursor_set_force_displayed(const bool p_enabled);
 
 	void copy_text();
 	void cut_text();


### PR DESCRIPTION
This pull request adds the possibility to force the rendering of the cursor inside LineEdit Node even if it doesn't have focus. This is useful when the LineEdit can be filled by a custom virtual keyboard. Key buttons of the virtual keyboard can be focused without losing the visual feedback of the cursor position. Check the following use case example (virtual keyboard is controlled by a gamepad): 

![gamepad_keyboard](https://user-images.githubusercontent.com/5015561/85231454-5ace8780-b3f7-11ea-8cfa-e6402abbb82a.gif). 