### PR TITLE
fix underlying type of enum crashing cast in RiderPathManager

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildTool.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildTool.cs
@@ -1,6 +1,6 @@
 namespace GodotTools.Build
 {
-    public enum BuildTool
+    public enum BuildTool : long
     {
         MsBuildMono,
         MsBuildVs,

--- a/modules/mono/editor/GodotTools/GodotTools/ExternalEditorId.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/ExternalEditorId.cs
@@ -1,6 +1,6 @@
 namespace GodotTools
 {
-    public enum ExternalEditorId
+    public enum ExternalEditorId : long
     {
         None,
         VisualStudio, // TODO (Windows-only)

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/ScriptClassParser.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/ScriptClassParser.cs
@@ -13,9 +13,9 @@ namespace GodotTools.Internals
             public string Name { get; }
             public string Namespace { get; }
             public bool Nested { get; }
-            public int BaseCount { get; }
+            public long BaseCount { get; }
 
-            public ClassDecl(string name, string @namespace, bool nested, int baseCount)
+            public ClassDecl(string name, string @namespace, bool nested, long baseCount)
             {
                 Name = name;
                 Namespace = @namespace;
@@ -45,7 +45,7 @@ namespace GodotTools.Internals
                     (string)classDeclDict["name"],
                     (string)classDeclDict["namespace"],
                     (bool)classDeclDict["nested"],
-                    (int)classDeclDict["base_count"]
+                    (long)classDeclDict["base_count"]
                 ));
             }
 


### PR DESCRIPTION
- I think someone else should evaluate whether maintaining all enum to be underlyingly typed as longs when they need to be shared with godot's runtime is a good idea
- fixes @NutmegStudio 's issue with #39629 