### PR TITLE
Fix MinGW build (use uninitialized `ofs` variable introduced in 39701).

### DIFF
--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -211,6 +211,8 @@ void JoypadWindows::setup_joypad_object(const DIDEVICEOBJECTINSTANCE *ob, int p_
 			if (slider_count < 2) {
 				ofs = DIJOFS_SLIDER(slider_count);
 				slider_count++;
+			} else {
+				return;
 			}
 		} else
 			return;


### PR DESCRIPTION
Fixes following MinGW build error:
```
[ 19%] In file included from ./core/method_bind.h:38,
                 from ./core/class_db.h:34,
                 from ./core/resource.h:34,
                 from ./core/input/input_event.h:36,
                 from ./core/input/input.h:34,
                 from platform/windows/os_windows.h:34,
                 from platform/windows/joypad_windows.h:34,
                 from platform/windows/joypad_windows.cpp:31:
./core/list.h: In member function 'void JoypadWindows::setup_joypad_object(const DIDEVICEOBJECTINSTANCE*, int)':
./core/list.h:214:3: error: 'ofs' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  214 |   n->value = (T &)value;
      |   ^
[ 19%] 'ofs' was declared here
  197 |   DWORD ofs;
      |         ^~~
```

New execution path was added in #39701, that can lead to uninitialized `ofs` (`(ob->guidType == GUID_Slider) and (slider_count >= 2)`).