### PR TITLE
Fix XMLParser crash when comment contains '<' without closing '>'

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -205,17 +205,20 @@ void XMLParser::_parse_comment() {
 
 	char *pCommentBegin = P;
 
-	int count = 1;
+	ERR_FAIL_COND_MSG(*P != '-', "Bad XML comment");
+	++P;
+	ERR_FAIL_COND_MSG(*P != '-', "Bad XML comment");
+	++P;
 
 	// move until end of comment reached
-	while (count) {
-		if (*P == '>') {
-			--count;
-		} else if (*P == '<') {
-			++count;
-		}
-
+	for (;;) {
+		while (*P != '-')
+			++P;
+		if (*P != '-')
+			continue;
 		++P;
+		if (*P == '>')
+			break;
 	}
 
 	P -= 3;

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -201,24 +201,58 @@ bool XMLParser::_parse_cdata() {
 
 void XMLParser::_parse_comment() {
 	node_type = NODE_COMMENT;
-	P += 1;
+	ERR_FAIL_COND_MSG(*P != '!', "Bad XML comment");
+	++P;
+	if (*P == '\0') // End of string - exist
+		return;
 
 	char *pCommentBegin = P;
+	int count = 0;
+	int hyphen = 0;
 
 	ERR_FAIL_COND_MSG(*P != '-', "Bad XML comment");
 	++P;
+	if (*P == '\0') // End of string - exist
+		return;
 	ERR_FAIL_COND_MSG(*P != '-', "Bad XML comment");
-	++P;
+	if (*P == '\0') // End of string - exist
+		return;
 
 	// move until end of comment reached
 	for (;;) {
-		while (*P != '-')
-			++P;
-		if (*P != '-')
-			continue;
 		++P;
-		if (*P == '>')
+		if (*P == '\0') // End of string - exist
+			return;
+		if (*P == '<') { // detect open comment (not XML standard, but use in godot)
+			hyphen = 0;
+			++P;
+			if (*P == '\0') // End of string - exist
+				return;
+			if (*P != '!') // continue if not comment like : '<!--'
+				continue;
+			++P;
+			if (*P == '\0') // End of string - exist
+				return;
+			if (*P != '-') // continue if not comment like : '<!--'
+				continue;
+			++P;
+			if (*P == '\0') // End of string - exist
+				return;
+			if (*P != '-') // continue if not comment like : '<!--'
+				continue;
+			++count;
+			hyphen = 0;
+		} else if (*P == '>' && hyphen == 2) { // Check if end comment is '-->'
+			if (count > 0) {
+				--count;
+				continue;
+			}
 			break;
+		} else if (*P == '-') {
+			if (hyphen < 3) // in XML, doesn't exist comment like '--->', so not necessary to check number hyphen > 3
+				++hyphen;
+		} else
+			hyphen = 0;
 	}
 
 	P -= 3;


### PR DESCRIPTION
Fix #38904 - Read XML file - comment step
* detect correctly end of XMLcomment 
* adding check end of string (or exist)
* manage nested comments