### PR TITLE
CanvasItemEditor: Fix losing position for drag'n'dropped scenes

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -6137,6 +6137,11 @@ bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, cons
 		Vector2 target_pos = canvas_item_editor->get_canvas_transform().affine_inverse().xform(p_point);
 		target_pos = canvas_item_editor->snap_point(target_pos);
 		target_pos = parent_ci->get_global_transform_with_canvas().affine_inverse().xform(target_pos);
+		// Preserve instance position of the original scene.
+		CanvasItem *instance_ci = Object::cast_to<CanvasItem>(instanced_scene);
+		if (instance_ci) {
+			target_pos += instance_ci->_edit_get_position();
+		}
 		editor_data->get_undo_redo().add_do_method(instanced_scene, "set_position", target_pos);
 	}
 


### PR DESCRIPTION
Fixes #26549.
Supersedes #36309.

Note: Tested on `3.2` as drag and drop is broken on Linux/X11 in `master`.

---

Some issues I noticed (not created by this fix):
- Drag and drop of scenes in an empty scene doesn't work well. It properly creates an inherited scene, but it doesn't get it marked as unsaved with `(*)`, and it also opens a new, empty scene which takes focus, so it looks like it didn't even work.
- The drag preview doesn't take the target node's transform into account, so if you drag a Sprite or scene e.g. on a rotated parent node, or a scaled one, the preview will be unaffected but once dropping, the new node will properly be subject to the transform. This could be good to fix so that WYSIWYG when dragging and dropping.