### PR TITLE
Enable iOS modules and fix missing symbols errors (3.2)

### DIFF
--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -8,58 +8,22 @@
 
 /* Begin PBXBuildFile section */
 		1F1575721F582BE20003B888 /* dylibs in Resources */ = {isa = PBXBuildFile; fileRef = 1F1575711F582BE20003B888 /* dylibs */; };
-		1FE926991FBBF85400F53A6F /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE926961FBBF7D400F53A6F /* SystemConfiguration.framework */; };
-		1FE9269A1FBBF85F00F53A6F /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE926951FBBF7C400F53A6F /* Security.framework */; };
-		1FE9269B1FBBF86200F53A6F /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE926941FBBF7BD00F53A6F /* QuartzCore.framework */; };
-		1FE9269C1FBBF86500F53A6F /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE926931FBBF7AD00F53A6F /* MediaPlayer.framework */; };
-		1FE9269D1FBBF86600F53A6F /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE926921FBBF7A000F53A6F /* GameController.framework */; };
-		1FE9269E1FBBF86900F53A6F /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE926911FBBF79500F53A6F /* CoreMotion.framework */; };
-		1FE9269F1FBBF86B00F53A6F /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE926901FBBF78E00F53A6F /* CoreMedia.framework */; };
-		1FE926A01FBBF86D00F53A6F /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE9268E1FBBF77300F53A6F /* AudioToolbox.framework */; };
-		1FE926A11FBBF86D00F53A6F /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FE9268F1FBBF77F00F53A6F /* CoreAudio.framework */; };
-		E360193721F32F38009258C1 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E360193621F32F37009258C1 /* CoreVideo.framework */; };
 		DEADBEEF2F582BE20003B888 /* $binary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DEADBEEF1F582BE20003B888 /* $binary.a */; };
 		$modules_buildfile
 		1FF8DBB11FBA9DE1009DE660 /* dummy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */; };
-		1FF4C1851F584E3F00A41E41 /* GameKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FF4C1841F584E3F00A41E41 /* GameKit.framework */; };
-		1FF4C1871F584E5600A41E41 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FF4C1861F584E5600A41E41 /* StoreKit.framework */; };
-		1FF4C1871F584E7600A41E41 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1FF4C1881F584E7600A41E41 /* StoreKit.framework */; };
 		D07CD44E1C5D589C00B7FB28 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D07CD44D1C5D589C00B7FB28 /* Images.xcassets */; };
-		D0BCFE3818AEBDA2004A7AAE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0BCFE3718AEBDA2004A7AAE /* Foundation.framework */; };
-		D0BCFE3A18AEBDA2004A7AAE /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0BCFE3918AEBDA2004A7AAE /* CoreGraphics.framework */; };
-		D0BCFE3C18AEBDA2004A7AAE /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0BCFE3B18AEBDA2004A7AAE /* UIKit.framework */; };
-		D0BCFE3E18AEBDA2004A7AAE /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0BCFE3D18AEBDA2004A7AAE /* GLKit.framework */; };
-		D0BCFE4018AEBDA2004A7AAE /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0BCFE3F18AEBDA2004A7AAE /* OpenGLES.framework */; };
 		D0BCFE4618AEBDA2004A7AAE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D0BCFE4418AEBDA2004A7AAE /* InfoPlist.strings */; };
 		D0BCFE7818AEBFEB004A7AAE /* $binary.pck in Resources */ = {isa = PBXBuildFile; fileRef = D0BCFE7718AEBFEB004A7AAE /* $binary.pck */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		1F1575711F582BE20003B888 /* dylibs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = dylibs; path = "$binary/dylibs"; sourceTree = "<group>"; };
-		1FE9268E1FBBF77300F53A6F /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
-		1FE9268F1FBBF77F00F53A6F /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
-		1FE926901FBBF78E00F53A6F /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
-		1FE926911FBBF79500F53A6F /* CoreMotion.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMotion.framework; path = System/Library/Frameworks/CoreMotion.framework; sourceTree = SDKROOT; };
-		1FE926921FBBF7A000F53A6F /* GameController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameController.framework; path = System/Library/Frameworks/GameController.framework; sourceTree = SDKROOT; };
-		1FE926931FBBF7AD00F53A6F /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
-		1FE926941FBBF7BD00F53A6F /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
-		1FE926951FBBF7C400F53A6F /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
-		1FE926961FBBF7D400F53A6F /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		DEADBEEF1F582BE20003B888 /* $binary.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = godot; path = "$binary.a"; sourceTree = "<group>"; };
 		$modules_fileref
-		1FF4C1841F584E3F00A41E41 /* GameKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameKit.framework; path = System/Library/Frameworks/GameKit.framework; sourceTree = SDKROOT; };
-		1FF4C1861F584E5600A41E41 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
-		1FF4C1881F584E7600A41E41 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		1FF4C1881F584E6300A41E41 /* $binary.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "$binary.entitlements"; sourceTree = "<group>"; };
 		1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = dummy.cpp; sourceTree = "<group>"; };
 		D07CD44D1C5D589C00B7FB28 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		D0BCFE3418AEBDA2004A7AAE /* $binary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "$binary.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D0BCFE3718AEBDA2004A7AAE /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		D0BCFE3918AEBDA2004A7AAE /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
-		E360193621F32F37009258C1 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
-		D0BCFE3B18AEBDA2004A7AAE /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
-		D0BCFE3D18AEBDA2004A7AAE /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
-		D0BCFE3F18AEBDA2004A7AAE /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		D0BCFE4318AEBDA2004A7AAE /* $binary-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "$binary-Info.plist"; sourceTree = "<group>"; };
 		D0BCFE4518AEBDA2004A7AAE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		D0BCFE7718AEBFEB004A7AAE /* $binary.pck */ = {isa = PBXFileReference; lastKnownFileType = file; path = "$binary.pck"; sourceTree = "<group>"; };
@@ -72,24 +36,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D0BCFE3A18AEBDA2004A7AAE /* CoreGraphics.framework in Frameworks */,
-				E360193721F32F38009258C1 /* CoreVideo.framework in Frameworks */,
-				1FE926991FBBF85400F53A6F /* SystemConfiguration.framework in Frameworks */,
-				1FE9269A1FBBF85F00F53A6F /* Security.framework in Frameworks */,
-				1FE9269B1FBBF86200F53A6F /* QuartzCore.framework in Frameworks */,
-				1FE9269C1FBBF86500F53A6F /* MediaPlayer.framework in Frameworks */,
-				1FE9269D1FBBF86600F53A6F /* GameController.framework in Frameworks */,
-				1FE9269E1FBBF86900F53A6F /* CoreMotion.framework in Frameworks */,
-				1FE9269F1FBBF86B00F53A6F /* CoreMedia.framework in Frameworks */,
-				1FE926A11FBBF86D00F53A6F /* CoreAudio.framework in Frameworks */,
-				1FE926A01FBBF86D00F53A6F /* AudioToolbox.framework in Frameworks */,
-				D0BCFE4018AEBDA2004A7AAE /* OpenGLES.framework in Frameworks */,
-				1FF4C1871F584E5600A41E41 /* StoreKit.framework in Frameworks */,
-				1FF4C1871F584E7600A41E41 /* AVFoundation.framework in Frameworks */,
-				D0BCFE3C18AEBDA2004A7AAE /* UIKit.framework in Frameworks */,
-				1FF4C1851F584E3F00A41E41 /* GameKit.framework in Frameworks */,
-				D0BCFE3E18AEBDA2004A7AAE /* GLKit.framework in Frameworks */,
-				D0BCFE3818AEBDA2004A7AAE /* Foundation.framework in Frameworks */,
 				DEADBEEF2F582BE20003B888 /* $binary.a */,
 				$modules_buildphase
 				$additional_pbx_frameworks_build
@@ -122,24 +68,6 @@
 		D0BCFE3618AEBDA2004A7AAE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				1FE926961FBBF7D400F53A6F /* SystemConfiguration.framework */,
-				1FE926951FBBF7C400F53A6F /* Security.framework */,
-				1FE926941FBBF7BD00F53A6F /* QuartzCore.framework */,
-				1FE926931FBBF7AD00F53A6F /* MediaPlayer.framework */,
-				1FE926921FBBF7A000F53A6F /* GameController.framework */,
-				1FE926911FBBF79500F53A6F /* CoreMotion.framework */,
-				1FE926901FBBF78E00F53A6F /* CoreMedia.framework */,
-				1FE9268F1FBBF77F00F53A6F /* CoreAudio.framework */,
-				E360193621F32F37009258C1 /* CoreVideo.framework */,
-				1FE9268E1FBBF77300F53A6F /* AudioToolbox.framework */,
-				1FF4C1861F584E5600A41E41 /* StoreKit.framework */,
-				1FF4C1841F584E3F00A41E41 /* GameKit.framework */,
-				1FF4C1881F584E7600A41E41 /* AVFoundation.framework */,
-				D0BCFE3718AEBDA2004A7AAE /* Foundation.framework */,
-				D0BCFE3918AEBDA2004A7AAE /* CoreGraphics.framework */,
-				D0BCFE3B18AEBDA2004A7AAE /* UIKit.framework */,
-				D0BCFE3D18AEBDA2004A7AAE /* GLKit.framework */,
-				D0BCFE3F18AEBDA2004A7AAE /* OpenGLES.framework */,
 				DEADBEEF1F582BE20003B888 /* $binary.a */,
 				$modules_buildgrp
 				$additional_pbx_frameworks_refs

--- a/misc/dist/ios_xcode/godot_ios/godot_ios.entitlements
+++ b/misc/dist/ios_xcode/godot_ios/godot_ios.entitlements
@@ -2,7 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>development</string>
+$entitlements_push_notifications
 </dict>
 </plist>

--- a/modules/arkit/SCsub
+++ b/modules/arkit/SCsub
@@ -5,6 +5,9 @@ Import("env_modules")
 
 env_arkit = env_modules.Clone()
 
+# (iOS) Enable module support
+env_arkit.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
+
 # (iOS) Build as separate static library
 modules_sources = []
 env_arkit.add_source_files(modules_sources, "*.cpp")

--- a/modules/camera/SCsub
+++ b/modules/camera/SCsub
@@ -6,6 +6,9 @@ Import("env_modules")
 env_camera = env_modules.Clone()
 
 if env["platform"] == "iphone":
+    # (iOS) Enable module support
+    env_camera.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
+
     # (iOS) Build as separate static library
     modules_sources = []
     env_camera.add_source_files(modules_sources, "register_types.cpp")

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -19,6 +19,9 @@ iphone_lib = [
 env_ios = env.Clone()
 ios_lib = env_ios.add_library("iphone", iphone_lib)
 
+# (iOS) Enable module support
+env_ios.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
+
 
 def combine_libs(target=None, source=None, env=None):
     lib_path = target[0].srcnode().abspath

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -343,6 +343,9 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 		} else if (lines[i].find("$push_notifications") != -1) {
 			bool is_on = p_preset->get("capabilities/push_notifications");
 			strnew += lines[i].replace("$push_notifications", is_on ? "1" : "0") + "\n";
+		} else if (lines[i].find("$entitlements_push_notifications") != -1) {
+			bool is_on = p_preset->get("capabilities/push_notifications");
+			strnew += lines[i].replace("$entitlements_push_notifications", is_on ? "<key>aps-environment</key><string>development</string>" : "") + "\n";
 		} else if (lines[i].find("$required_device_capabilities") != -1) {
 			String capabilities;
 
@@ -932,6 +935,7 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 	files_to_parse.insert("godot_ios/dummy.cpp");
 	files_to_parse.insert("godot_ios.xcodeproj/project.xcworkspace/contents.xcworkspacedata");
 	files_to_parse.insert("godot_ios.xcodeproj/xcshareddata/xcschemes/godot_ios.xcscheme");
+	files_to_parse.insert("godot_ios/godot_ios.entitlements");
 
 	IOSConfigData config_data = {
 		pkg_name,


### PR DESCRIPTION
Fixes #18359 and should be fixing all other issues connected to missing symbols from iOS frameworks. 
Would probably fix issues connected to XCode Capabilities that gets enabled automatically by linking specific framework and not allowing to build a game in XCode without enabling them at developer portal for game's AppID.

Enabling `-fmodules` and `-fcxx-modules` for iOS platform code allows application to automatically link frameworks used in the code. Which also removes the need to specify required frameworks in XCode project and this in turn will remove auto-enabling of unwanted XCode Capabilities that could potentially block the build.
This way adding or removing Capability for exported game would not cause any issues for building a project.

Push Notifications Capability are additionally handled in entitlements file, so it's here too.

I've tested this fix by using newly built `.a` files in existing XCode project. This allowed too remove `In-App Purchase` without breaking the ability to build and run on device or simulator
I've also tested it by creating new XCode project from export template I've managed to create with this fixes. No capabilities were enabled, so it should be building without any issue for non-paid developer account.