### PR TITLE
Enable finer grained control when creating polygon with UV Editor

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -485,7 +485,8 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 					} else {
 						Vector2 tuv = mtx.affine_inverse().xform(snap_point(Vector2(mb->get_position().x, mb->get_position().y)));
 
-						if (points_prev.size() > 2 && tuv.distance_to(points_prev[0]) < 8) {
+						// Close the polygon if selected point is near start. Threshold for closing scaled by zoom level
+						if (points_prev.size() > 2 && tuv.distance_to(points_prev[0]) < (8 / uv_draw_zoom)) {
 							undo_redo->create_action(TTR("Create Polygon & UV"));
 							undo_redo->add_do_method(node, "set_uv", node->get_uv());
 							undo_redo->add_undo_method(node, "set_uv", uv_create_uv_prev);


### PR DESCRIPTION
Modifies 'auto-completion' of polygon to take into account the UV editor scale. Enables the 
user to select points closer to each other than the current threshold of 8 pixels if they wish to do so.

Fixes #38240

Before:
![uvEditorOrig](https://user-images.githubusercontent.com/22248849/85374074-d1d65e00-b566-11ea-8d4e-690b60c71b2f.gif)

After:
![uvEditorFixed](https://user-images.githubusercontent.com/22248849/85374099-d9960280-b566-11ea-966b-80a7fb51d45c.gif)
