### PR TITLE
Clarify what a string being empty means

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -381,7 +381,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the string is empty.
+				Returns [code]true[/code] if the length of the string equals [code]0[/code].
 			</description>
 		</method>
 		<method name="ends_with">


### PR DESCRIPTION
Might close https://github.com/godotengine/godot-docs/issues/2432

The issue also has a question about the difference between `.empty()` and comparing the string with ` == ""` but I do not believe the class reference is the right place for this. 

I believe this commit is an enhancement, though -- saying that `empty` returns whether the string is empty is tautological, and says less than saying whether its length is `0`. 