### PR TITLE
[macOS] Add support for the Apple Silicon (ARM64) build target.

### DIFF
--- a/misc/dist/osx_template.app/Contents/Info.plist
+++ b/misc/dist/osx_template.app/Contents/Info.plist
@@ -30,12 +30,18 @@
 	<string>$camera_usage_description</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>$copyright</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.12.0</string>
+	<string>10.12</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>x86_64</key>
-		<string>10.12.0</string>
+		<string>10.12</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	$highres

--- a/misc/dist/osx_tools.app/Contents/Info.plist
+++ b/misc/dist/osx_tools.app/Contents/Info.plist
@@ -29,15 +29,21 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Camera access is required to capture video.</string>
 	<key>NSRequiresAquaSystemAppearance</key>
-    	<false />
+	<false/>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2007-2020 Juan Linietsky, Ariel Manzur &amp; Godot Engine contributors</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.12.0</string>
+	<string>10.12</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>x86_64</key>
-		<string>10.12.0</string>
+		<string>10.12</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>

--- a/modules/camera/camera_osx.mm
+++ b/modules/camera/camera_osx.mm
@@ -313,7 +313,12 @@ MyDeviceNotifications *device_notifications = nil;
 // CameraOSX - Subclass for our camera server on OSX
 
 void CameraOSX::update_feeds() {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
+	AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+	NSArray *devices = session.devices;
+#else
 	NSArray *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+#endif
 
 	// remove devices that are gone..
 	for (int i = feeds.size() - 1; i >= 0; i--) {
@@ -325,7 +330,6 @@ void CameraOSX::update_feeds() {
 		};
 	};
 
-	// add new devices..
 	for (AVCaptureDevice *device in devices) {
 		bool found = false;
 		for (int i = 0; i < feeds.size() && !found; i++) {

--- a/modules/denoise/config.py
+++ b/modules/denoise/config.py
@@ -5,7 +5,7 @@ def can_build(env, platform):
     # as doing lightmap generation and denoising on Android or HTML5
     # would be a bit far-fetched.
     desktop_platforms = ["linuxbsd", "osx", "windows"]
-    return env["tools"] and platform in desktop_platforms and env["bits"] == "64"
+    return env["tools"] and platform in desktop_platforms and env["bits"] == "64" and env["arch"] != "arm64"
 
 
 def configure(env):

--- a/modules/opus/SCsub
+++ b/modules/opus/SCsub
@@ -227,6 +227,9 @@ if env["builtin_opus"]:
             env_opus.Append(CPPDEFINES=["OPUS_ARM_OPT"])
         elif "arch" in env and env["arch"] == "arm64":
             env_opus.Append(CPPDEFINES=["OPUS_ARM64_OPT"])
+    elif env["platform"] == "osx":
+        if "arch" in env and env["arch"] == "arm64":
+            env_opus.Append(CPPDEFINES=["OPUS_ARM64_OPT"])
 
     env_thirdparty = env_opus.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -238,6 +238,7 @@ else:
     is_x11_or_server_arm = (env["platform"] == "linuxbsd" or env["platform"] == "server") and (
         platform.machine().startswith("arm") or platform.machine().startswith("aarch")
     )
+    is_macos_x86 = env["platform"] == "osx" and ("arch" in env and (env["arch"] != "arm64"))
     is_ios_x86 = env["platform"] == "iphone" and ("arch" in env and env["arch"].startswith("x86"))
     is_android_x86 = env["platform"] == "android" and env["android_arch"].startswith("x86")
     if is_android_x86:
@@ -248,14 +249,15 @@ else:
         and (
             env["platform"] == "windows"
             or env["platform"] == "linuxbsd"
-            or env["platform"] == "osx"
             or env["platform"] == "haiku"
+            or is_macos_x86
             or is_android_x86
             or is_ios_x86
         )
     )
     webm_cpu_arm = (
         is_x11_or_server_arm
+        or (not is_macos_x86 and env["platform"] == "osx")
         or (not is_ios_x86 and env["platform"] == "iphone")
         or (not is_android_x86 and env["platform"] == "android")
     )

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -87,8 +87,15 @@ def configure(env):
         env["osxcross"] = True
 
     if not "osxcross" in env:  # regular native build
-        env.Append(CCFLAGS=["-arch", "x86_64"])
-        env.Append(LINKFLAGS=["-arch", "x86_64"])
+        if env["arch"] == "arm64":
+            print("Building for macOS 10.15+, platform arm64.")
+            env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15", "-target", "arm64-apple-macos10.15"])
+            env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15", "-target", "arm64-apple-macos10.15"])
+        else:
+            print("Building for macOS 10.12+, platform x86-64.")
+            env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
+            env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
+
         if env["macports_clang"] != "no":
             mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
             mpclangver = env["macports_clang"]
@@ -148,7 +155,8 @@ def configure(env):
     ## Dependencies
 
     if env["builtin_libtheora"]:
-        env["x86_libtheora_opt_gcc"] = True
+        if env["arch"] != "arm64":
+            env["x86_libtheora_opt_gcc"] = True
 
     ## Flags
 
@@ -189,6 +197,3 @@ def configure(env):
         env.Append(LIBS=["vulkan"])
 
     # env.Append(CPPDEFINES=['GLES_ENABLED', 'OPENGL_ENABLED'])
-
-    env.Append(CCFLAGS=["-mmacosx-version-min=10.12"])
-    env.Append(LINKFLAGS=["-mmacosx-version-min=10.12"])

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -566,7 +566,11 @@ static NSCursor *_cursorFromSelector(SEL selector, SEL fallback = nil) {
 	trackingArea = nil;
 	imeInputEventInProgress = false;
 	[self updateTrackingAreas];
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101400
+	[self registerForDraggedTypes:[NSArray arrayWithObject:NSPasteboardTypeFileURL]];
+#else
 	[self registerForDraggedTypes:[NSArray arrayWithObject:NSFilenamesPboardType]];
+#endif
 	markedText = [[NSMutableAttributedString alloc] init];
 	return self;
 }
@@ -723,11 +727,19 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
 	DisplayServerOSX::WindowData &wd = DS_OSX->windows[window_id];
 
 	NSPasteboard *pboard = [sender draggingPasteboard];
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101400
+	NSArray<NSURL *> *filenames = [pboard propertyListForType:NSPasteboardTypeFileURL];
+#else
 	NSArray *filenames = [pboard propertyListForType:NSFilenamesPboardType];
+#endif
 
 	Vector<String> files;
 	for (NSUInteger i = 0; i < filenames.count; i++) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101400
+		NSString *ns = [[filenames objectAtIndex:i] path];
+#else
 		NSString *ns = [filenames objectAtIndex:i];
+#endif
 		char *utfs = strdup([ns UTF8String]);
 		String ret;
 		ret.parse_utf8(utfs);


### PR DESCRIPTION
Adds support for ARM64 target on macOS (with `-arch arm64` option, targets x86-64 when arch is not specified).

- Tested to build with [Xcode 12.0 beta for macOS universal apps](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-for-macos-universal-apps-beta-release-notes/) (12A8158a).
- NOT tested on real hardware.
- OpenImage Denoise is disabled for ARM64 build (current version of oneDNN doesn't support ARM, but experimental support should be available in upstream).
- libvpx builds, but configuration might be not fully optimal.

Universal binary can be created in the similar manner to iOS (currently this step is not automated):
```
lipo -create ./bin/godot.osx.opt.tools.64 ./bin/godot.osx.opt.tools.arm64 -output ./bin/godot.osx.opt.tools.universal
```