### PR TITLE
Optimize class icon loading

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3642,17 +3642,12 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 	}
 
 	if (ScriptServer::is_global_class(p_class)) {
-		String icon_path = EditorNode::get_editor_data().script_class_get_icon_path(p_class);
-		Ref<ImageTexture> icon = _load_custom_class_icon(icon_path);
-		if (icon.is_valid()) {
-			return icon;
-		}
-
-		Ref<Script> script = ResourceLoader::load(ScriptServer::get_global_class_path(p_class), "Script");
+		Ref<ImageTexture> icon;
+		Ref<Script> script = EditorNode::get_editor_data().script_class_load_script(p_class);
 
 		while (script.is_valid()) {
-			String current_icon_path;
-			script->get_language()->get_global_class_name(script->get_path(), nullptr, &current_icon_path);
+			StringName name = EditorNode::get_editor_data().script_class_get_name(script->get_path());
+			String current_icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
 			icon = _load_custom_class_icon(current_icon_path);
 			if (icon.is_valid()) {
 				return icon;


### PR DESCRIPTION
Helps #27333 and #34205.

`get_global_class_name` for `GDScriptLanguage` is slow because it forces to parse an entire script each time. This patch ensures that the icon is actually fetched from the `EditorData` where they are loaded beforehand.

This change also makes the behavior consistent with the existing `get_object_icon` method in `EditorNode` (see the method just above).

The inheritance issue is *not* reintroduced: #24657, and was originally fixed by #25676, and this PR fixes the performance issue introduced with it. The searching speed is improved from ~1s to ~0.1-0.2s for [1000 global scripts](https://github.com/godotengine/godot/issues/27333#issuecomment-574670963).

This change is compatible with 3.2.

## Test project

(this only tests the inheritance for class icons, not performance). Use [this script](https://github.com/godotengine/godot/issues/27333#issuecomment-574670963) to generate 1000 classes to test.

[class-icon-opt.zip](https://github.com/godotengine/godot/files/4824650/class-icon-opt.zip)
