### PR TITLE
Fix default editor/project Button styles after ToolButton removal

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -570,17 +570,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("focus", "PopupMenu", style_menu);
 	theme->set_stylebox("disabled", "PopupMenu", style_menu);
 
-	theme->set_stylebox("normal", "Button", style_menu);
-	theme->set_stylebox("hover", "Button", style_menu);
-	theme->set_stylebox("pressed", "Button", style_menu);
-	theme->set_stylebox("focus", "Button", style_menu);
-	theme->set_stylebox("disabled", "Button", style_menu);
-
 	theme->set_color("font_color", "MenuButton", font_color);
 	theme->set_color("font_color_hover", "MenuButton", font_color_hl);
-	theme->set_color("font_color", "Button", font_color);
-	theme->set_color("font_color_hover", "Button", font_color_hl);
-	theme->set_color("font_color_pressed", "Button", accent_color);
 
 	theme->set_stylebox("MenuHover", "EditorStyles", style_menu_hover_border);
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -219,22 +219,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_constant("hseparation", "ColorPickerButton", 2 * scale);
 
-	// Button
-
-	theme->set_stylebox("normal", "Button", make_empty_stylebox(6, 4, 6, 4));
-	theme->set_stylebox("pressed", "Button", make_stylebox(button_pressed_png, 4, 4, 4, 4, 6, 4, 6, 4));
-	theme->set_stylebox("hover", "Button", make_stylebox(button_normal_png, 4, 4, 4, 4, 6, 4, 6, 4));
-	theme->set_stylebox("disabled", "Button", make_empty_stylebox(6, 4, 6, 4));
-	theme->set_stylebox("focus", "Button", focus);
-	theme->set_font("font", "Button", default_font);
-
-	theme->set_color("font_color", "Button", control_font_color);
-	theme->set_color("font_color_pressed", "Button", control_font_color_pressed);
-	theme->set_color("font_color_hover", "Button", control_font_color_hover);
-	theme->set_color("font_color_disabled", "Button", Color(0.9, 0.95, 1, 0.3));
-
-	theme->set_constant("hseparation", "Button", 3);
-
 	// OptionButton
 
 	Ref<StyleBox> sb_optbutton_normal = sb_expand(make_stylebox(option_button_normal_png, 4, 4, 21, 4, 6, 3, 9, 3), 2, 2, 2, 2);


### PR DESCRIPTION
**Note:** Not cherry-pickable to the `3.2` branch, as ToolButton was only removed in `master`.

___

Before this fix, all Buttons made with the default project theme looked flat until hovered.