### PR TITLE
[3.2] Fixed SkeletonIK not working with scaled skeletons

### DIFF
--- a/scene/animation/skeleton_ik.cpp
+++ b/scene/animation/skeleton_ik.cpp
@@ -274,7 +274,7 @@ void FabrikInverseKinematic::make_goal(Task *p_task, const Transform &p_inverse_
 	} else {
 
 		// End effector in local transform
-		const Transform end_effector_pose(p_task->skeleton->get_bone_global_pose(p_task->end_effectors.write[0].tip_bone));
+		const Transform end_effector_pose(p_task->skeleton->get_bone_global_pose(p_task->end_effectors[0].tip_bone));
 
 		// Update the end_effector (local transform) by blending with current pose
 		p_task->end_effectors.write[0].goal_transform = end_effector_pose.interpolate_with(p_inverse_transf * p_task->goal_global_transform, blending_delta);
@@ -330,6 +330,10 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 			else
 				new_bone_pose.basis = new_bone_pose.basis * p_task->chain.tips[0].end_effector->goal_transform.basis;
 		}
+
+		// IK should not affect scale, so undo any scaling
+		new_bone_pose.basis.orthonormalize();
+		new_bone_pose.basis.scale(p_task->skeleton->get_bone_global_pose(ci->bone).basis.get_scale());
 
 		p_task->skeleton->set_bone_global_pose_override(ci->bone, new_bone_pose, 1.0, true);
 


### PR DESCRIPTION
Closes #25544

The issue turns out to be that the target in the minimum replication project given, in the linked issue, is a child node of the scaled bone. This means it is also being scaled when the Skeleton is scaled. Scaling *only* the Skeleton/Armature node or increasing the scale of the IK target relative to the parent's scale also fixes the issue.
However, IK probably shouldn't be affecting the scale of bones, since IK is really only for rotation. To prevent this, the scale calculated in the IK chain is discarded before being applied to the Skeleton. This should fix any issues where the bone's are scaled when being operated on by IK.

This PR is targeted towards Godot 3.2, as the reworked IK in Godot 4.0/master does not exhibit this issue.