### PR TITLE
Handle gone TabContainer popup nicely

### DIFF
--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -57,7 +57,7 @@ private:
 	TabAlign align;
 	Control *_get_tab(int p_idx) const;
 	int _get_top_margin() const;
-	Popup *popup;
+	mutable ObjectID popup_obj_id;
 	bool drag_to_rearrange_enabled;
 	bool use_hidden_tabs_for_min_size;
 	int tabs_rearrange_group;


### PR DESCRIPTION
Fixes #39787.

The crash in the original bug report is caused by the fact that `TabContainer` keeps a raw pointer to its assigned popup. If such popup node is deleted while it's assigned, you end up getting UB; usually, a crash.

This PR adds nice handling of that situation. I'm tagging it as _Enhancement_ rather than _Bug_ because the bug is actually in the project committing such naughty acts, yet now Godot will warn you and won't crash.

**In my opinion, this would be a good pattern to follow in similar cases where raw pointers are used, where you expect safety and where the performance hit of doing the check is negligible, like, of course, GUI programming.**

(There's a separate version of this PR for 3.2.)

---
**This code is generously donated by IMVU.**