### PR TITLE
Added type checks for Tween's interpolate_property values

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -1371,6 +1371,10 @@ void Tween::interpolate_property(Object *p_object, NodePath p_property, Variant 
 		p_final_val = p_final_val.operator real_t();
 	}
 
+	Variant::Type property_type = p_object->get_indexed(p_property.get_subnames()).get_type();
+	ERR_FAIL_COND_MSG(p_initial_val.get_type() != property_type, "Tween property expected type " + Variant::get_type_name(property_type) + " for initial value, but got " + Variant::get_type_name(p_initial_val.get_type()) + " instead.");
+	ERR_FAIL_COND_MSG(p_final_val.get_type() != property_type, "Tween property expected type " + Variant::get_type_name(property_type) + " for final value, but got " + Variant::get_type_name(p_final_val.get_type()) + " instead.");
+
 	// Build the interpolation data
 	_build_interpolation(INTER_PROPERTY, p_object, &p_property, nullptr, p_initial_val, p_final_val, p_duration, p_trans_type, p_ease_type, p_delay);
 }


### PR DESCRIPTION
The current implementation of interpolate_property does not check that the type of the values provided by the user matches the type of the property they're trying to interpolate. In case they don't, the Tween simply fails to execute and no error is shown to the user. This happened to me when trying to interpolate the scale of a Sprite2D with a float, instead of the proper Vector2.

This PR adds checks that alert the user if the initial/final value parameters do not match the property they're trying to interpolate.
The error message is of the form "Tween property expected type [Vector2] for [initial/final] value, but got [float] instead."

Note: This is my first PR, so please bear with me.