### PR TITLE
Don't use arbitrary theme editor icons for scripts with the same name

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3637,16 +3637,13 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p_fallback) const {
 	ERR_FAIL_COND_V_MSG(p_class.empty(), nullptr, "Class name cannot be empty.");
 
-	if (gui_base->has_theme_icon(p_class, "EditorIcons")) {
-		return gui_base->get_theme_icon(p_class, "EditorIcons");
-	}
-
 	if (ScriptServer::is_global_class(p_class)) {
 		Ref<ImageTexture> icon;
 		Ref<Script> script = EditorNode::get_editor_data().script_class_load_script(p_class);
+		StringName name = p_class;
 
 		while (script.is_valid()) {
-			StringName name = EditorNode::get_editor_data().script_class_get_name(script->get_path());
+			name = EditorNode::get_editor_data().script_class_get_name(script->get_path());
 			String current_icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
 			icon = _load_custom_class_icon(current_icon_path);
 			if (icon.is_valid()) {
@@ -3656,7 +3653,7 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 		}
 
 		if (icon.is_null()) {
-			icon = gui_base->get_theme_icon(ScriptServer::get_global_class_base(p_class), "EditorIcons");
+			icon = gui_base->get_theme_icon(ScriptServer::get_global_class_base(name), "EditorIcons");
 		}
 
 		return icon;
@@ -3672,6 +3669,10 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 				}
 			}
 		}
+	}
+
+	if (gui_base->has_theme_icon(p_class, "EditorIcons")) {
+		return gui_base->get_theme_icon(p_class, "EditorIcons");
 	}
 
 	if (p_fallback.length() && gui_base->has_theme_icon(p_fallback, "EditorIcons")) {


### PR DESCRIPTION
Closes #23348.

The existing theme editor icon could be unintentionally set for any global class with matching name (`Group` icon, `Group` class_name etc), which would only show up in the "Create Dialog" context, but not the scene tree dock. So I think it's better to remove this "feature" out. 🙂

This change prevents this behavior, and ensures that the icon can be actually overridden by explicit icon path in `class_name`, if there's any custom icon to begin with.

The correct built-in type's icon is fetched for child classes if there are no custom icons detected up to the base script class as well, so it isn't left empty for those cases (because the theme does not actually contain `class_name` icons).

[weird-icons.zip](https://github.com/godotengine/godot/files/4830265/weird-icons.zip)
