### PR TITLE
Added Rigid Body Method "get_inverse_inertia_tensor"

### DIFF
--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -120,6 +120,13 @@
 				Sets an axis velocity. The velocity in the given vector axis will be set as the given vector length. This is useful for jumping behavior.
 			</description>
 		</method>
+		<method name="get_inverse_inertia_tensor">
+			<return type="Basis">
+			</return>
+			<description>
+				Returns the inverse inertia tensor basis. This is used to calculate the angular acceleration resulting from a torque applied to the RigidBody.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="angular_damp" type="float" setter="set_angular_damp" getter="get_angular_damp" default="-1.0">

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -453,6 +453,7 @@ void RigidBody::_direct_state_changed(Object *p_state) {
 	set_global_transform(state->get_transform());
 	linear_velocity = state->get_linear_velocity();
 	angular_velocity = state->get_angular_velocity();
+	inverse_inertia_tensor = state->get_inverse_inertia_tensor();
 	if (sleeping != state->is_sleeping()) {
 		sleeping = state->is_sleeping();
 		emit_signal(SceneStringNames::get_singleton()->sleeping_state_changed);
@@ -765,6 +766,10 @@ Vector3 RigidBody::get_angular_velocity() const {
 	return angular_velocity;
 }
 
+Basis RigidBody::get_inverse_inertia_tensor() {
+	return inverse_inertia_tensor;
+}
+
 void RigidBody::set_use_custom_integrator(bool p_enable) {
 
 	if (custom_integrator == p_enable)
@@ -955,6 +960,8 @@ void RigidBody::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_angular_velocity", "angular_velocity"), &RigidBody::set_angular_velocity);
 	ClassDB::bind_method(D_METHOD("get_angular_velocity"), &RigidBody::get_angular_velocity);
+
+	ClassDB::bind_method(D_METHOD("get_inverse_inertia_tensor"), &RigidBody::get_inverse_inertia_tensor);
 
 	ClassDB::bind_method(D_METHOD("set_gravity_scale", "gravity_scale"), &RigidBody::set_gravity_scale);
 	ClassDB::bind_method(D_METHOD("get_gravity_scale"), &RigidBody::get_gravity_scale);

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -135,6 +135,7 @@ protected:
 
 	Vector3 linear_velocity;
 	Vector3 angular_velocity;
+	Basis inverse_inertia_tensor;
 	real_t gravity_scale;
 	real_t linear_damp;
 	real_t angular_damp;
@@ -223,6 +224,8 @@ public:
 
 	void set_angular_velocity(const Vector3 &p_velocity);
 	Vector3 get_angular_velocity() const;
+
+	Basis get_inverse_inertia_tensor();
 
 	void set_gravity_scale(real_t p_gravity_scale);
 	real_t get_gravity_scale() const;


### PR DESCRIPTION
## Exposed inertia tensor to GDScript

### How
This was done by creating a variable on the rigidbody class. The variable receives the inverse inertia tensor value each time the RigidBody state gets changed, then the `get_inverse_inertia_tensor()` returns the the inverse_inertia_tensor. The method is exposed to GDScript with `bind_method`

### Consequences
As a consequence of this, rotations with rigid bodies can be controlled more accurately through the use of Physics Formulas of Torque

### Requests
This was proposed in: https://github.com/godotengine/godot-proposals/issues/1114 also in https://github.com/godotengine/godot/issues/2125 and kind of related to https://github.com/godotengine/godot-proposals/issues/945

