### PR TITLE
Fix memory leaks in RasterizerStorageDummy::free

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -725,20 +725,25 @@ public:
 	}
 
 	bool free(RID p_rid) {
-
 		if (texture_owner.owns(p_rid)) {
 			// delete the texture
 			DummyTexture *texture = texture_owner.get(p_rid);
 			texture_owner.free(p_rid);
 			memdelete(texture);
-		}
-
-		if (mesh_owner.owns(p_rid)) {
+		} else if (mesh_owner.owns(p_rid)) {
 			// delete the mesh
 			DummyMesh *mesh = mesh_owner.getornull(p_rid);
 			mesh_owner.free(p_rid);
 			memdelete(mesh);
+		} else if (lightmap_capture_data_owner.owns(p_rid)) {
+			// delete the lightmap
+			LightmapCapture *lightmap_capture = lightmap_capture_data_owner.getornull(p_rid);
+			lightmap_capture_data_owner.free(p_rid);
+			memdelete(lightmap_capture);
+		} else {
+			return false;
 		}
+
 		return true;
 	}
 


### PR DESCRIPTION
This fixes 2 potentially very large memory leaks in the Linux headless server build which I've been tracking my progress in #39696 

`rasterizer_dummy.h` has a `free(rid)` function which was only handling dummy texture data. But Mesh and Lightmap data was also being allocated and stored in its Dummy Storage class.

Adding handling for these two data types freed a large amount of memory that was being leaked previously.

There appears to still be some memory leaks, though I'm not 100% sure they are purely related to the server build. They are related to Canvas items. They are also much less memory than these two.