### PR TITLE
Fix few places in shaders where const passing still incorrect

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -3560,7 +3560,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 											error = true;
 										} else if (n->type == Node::TYPE_ARRAY) {
 											ArrayNode *an = static_cast<ArrayNode *>(n);
-											if (an->call_expression != nullptr) {
+											if (an->call_expression != nullptr || an->is_const) {
 												error = true;
 											}
 										} else if (n->type == Node::TYPE_VARIABLE) {
@@ -3569,7 +3569,9 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 												error = true;
 											} else {
 												StringName varname = vn->name;
-												if (shader->uniforms.has(varname)) {
+												if (shader->constants.has(varname)) {
+													error = true;
+												} else if (shader->uniforms.has(varname)) {
 													error = true;
 												} else {
 													if (p_builtin_types.has(varname)) {


### PR DESCRIPTION
I've fixed few places in code where you still allowed to incorrectly pass constant:

1. Global constants

```
const float t = 1.0;

void func(inout float k) {
//...
}

void fragment() {
func(t); // CRASH
}
```

2. Constant array indexing

```
void fragment() {
 const float t[] = {1.0};
func(t[0]); // MAY LEAD TO CRASH, SHADERTOY DOES NOT SUPPORT IT
}
```


Note: I've added them to https://github.com/godotengine/godot/pull/39820 for 3.2