### PR TITLE
Fix possible accidental duplication of Polygon2D start point

### DIFF
--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -369,7 +369,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 				} else {
 					const real_t grab_threshold = EDITOR_GET("editors/poly_editor/point_grab_radius");
 
-					if (!_is_line() && wip.size() > 1 && xform.xform(wip[0]).distance_to(gpoint) < grab_threshold) {
+					if (!_is_line() && wip.size() > 1 && xform.xform(wip[0]).distance_to(xform.xform(cpoint)) < grab_threshold) {
 						//wip closed
 						_wip_close();
 


### PR DESCRIPTION
Ensures that closure of Polygon2D in the editor takes into account Grid Snap if enabled. Does this by 
comparing the polygon start to the mouse click location with grid snap applied. The transformation back is applied 
in order to deal with different editor zoom levels or resolutions.

Closes #36024