### PR TITLE
Don't remove the owner immediately

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -154,14 +154,14 @@ void Node::_notification(int p_notification) {
 			data.in_constructor = false;
 		} break;
 		case NOTIFICATION_PREDELETE: {
-			set_owner(nullptr);
-
-			while (data.owned.size()) {
-				data.owned.front()->get()->set_owner(nullptr);
-			}
-
 			if (data.parent) {
-				data.parent->remove_child(this);
+				data.parent->remove_child(this); // This also removes the owner.
+			} else {
+				set_owner(nullptr);
+
+				while (data.owned.size()) {
+					data.owned.front()->get()->set_owner(nullptr);
+				}
 			}
 
 			// kill children as cleanly as possible


### PR DESCRIPTION
Closes #22840

The question is whether setting owner to `null` immediately in NOTIFICATION_PREDELETE was done for a reason or the order doesn't matter (but some code might still rely on the old order). I did a quick test and didn't notice any unusual behavior.

Also here's a test code:
```
func _ready():
	var se1f = self
	$Node2D.connect("tree_exiting", Callable(se1f, "exiting"), [$Node2D])
	$Node2D.connect("tree_exited", Callable(se1f, "exited"), [$Node2D])
	$Node2D.free()

func exiting(node):
	print(node.owner) #prints node; before it was null

func exited(node):
	print(node.owner) #prints null
```