### PR TITLE
Mono/C#: Fix unhandled exception not being printed

### DIFF
--- a/modules/mono/mono_gd/gd_mono_internals.cpp
+++ b/modules/mono/mono_gd/gd_mono_internals.cpp
@@ -114,7 +114,7 @@ void tie_managed_to_unmanaged(MonoObject *managed, Object *unmanaged) {
 }
 
 void unhandled_exception(MonoException *p_exc) {
-	mono_unhandled_exception((MonoObject *)p_exc); // prints the exception as well
+	mono_print_unhandled_exception((MonoObject *)p_exc);
 
 	if (GDMono::get_singleton()->get_unhandled_exception_policy() == GDMono::POLICY_TERMINATE_APP) {
 		// Too bad 'mono_invoke_unhandled_exception_hook' is not exposed to embedders


### PR DESCRIPTION
For some reason `mono_unhandled_exception` is not printing the exception as its comment claims. Use `mono_print_unhandled_exception` instead.
