### PR TITLE
Mono/C#: Use /restore instead of /t:restore when building

### DIFF
--- a/modules/mono/build_scripts/solution_builder.py
+++ b/modules/mono/build_scripts/solution_builder.py
@@ -142,9 +142,7 @@ def build_solution(env, solution_path, build_config, extra_msbuild_args=[]):
 
     # Build solution
 
-    targets = ["Restore", "Build"]
-
-    msbuild_args += [solution_path, "/t:%s" % ",".join(targets), "/p:Configuration=" + build_config]
+    msbuild_args += [solution_path, "/restore", "/t:Build", "/p:Configuration=" + build_config]
     msbuild_args += extra_msbuild_args
 
     run_command(msbuild_path, msbuild_args, env_override=msbuild_env, name="msbuild")

--- a/modules/mono/editor/GodotTools/GodotTools/BuildInfo.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/BuildInfo.cs
@@ -12,6 +12,7 @@ namespace GodotTools
         public string Solution { get; }
         public string[] Targets { get; }
         public string Configuration { get; }
+        public bool Restore { get; }
         public Array<string> CustomProperties { get; } = new Array<string>(); // TODO Use List once we have proper serialization
 
         public string LogsDirPath => Path.Combine(GodotSharpDirs.BuildLogsDirs, $"{Solution.MD5Text()}_{Configuration}");
@@ -39,11 +40,12 @@ namespace GodotTools
         {
         }
 
-        public BuildInfo(string solution, string[] targets, string configuration)
+        public BuildInfo(string solution, string[] targets, string configuration, bool restore)
         {
             Solution = solution;
             Targets = targets;
             Configuration = configuration;
+            Restore = restore;
         }
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/BuildManager.cs
@@ -175,7 +175,7 @@ namespace GodotTools
             {
                 pr.Step("Building project solution", 0);
 
-                var buildInfo = new BuildInfo(GodotSharpDirs.ProjectSlnPath, targets: new[] {"Restore", "Build"}, config);
+                var buildInfo = new BuildInfo(GodotSharpDirs.ProjectSlnPath, targets: new[] {"Build"}, config, restore: true);
 
                 bool escapeNeedsDoubleBackslash = buildTool == BuildTool.MsBuildMono || buildTool == BuildTool.DotnetCli;
 


### PR DESCRIPTION
Documentation recommends not to use /t:restore together with other targets (like /t:build), as it messes with the environment.
