### PR TITLE
Store the shape reference in PhysicsShapeQueryParameters2D/3D

### DIFF
--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -9,15 +9,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="set_shape">
-			<return type="void">
-			</return>
-			<argument index="0" name="shape" type="Resource">
-			</argument>
-			<description>
-				Sets the [Shape2D] that will be used for collision/intersection queries.
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
@@ -38,8 +29,8 @@
 		<member name="motion" type="Vector2" setter="set_motion" getter="get_motion" default="Vector2( 0, 0 )">
 			The motion of the shape being queried for.
 		</member>
-		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid">
-			The queried shape's [RID]. See also [method set_shape].
+		<member name="shape" type="Resource" setter="set_shape" getter="get_shape">
+			The [Shape2D] that will be used for collision/intersection queries.
 		</member>
 		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D( 1, 0, 0, 1, 0, 0 )">
 			The queried shape's transform matrix.

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -9,15 +9,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="set_shape">
-			<return type="void">
-			</return>
-			<argument index="0" name="shape" type="Resource">
-			</argument>
-			<description>
-				Sets the [Shape3D] that will be used for collision/intersection queries.
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
@@ -35,8 +26,8 @@
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.0">
 			The collision margin for the shape.
 		</member>
-		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid">
-			The queried shape's [RID]. See also [method set_shape].
+		<member name="shape" type="Resource" setter="set_shape" getter="get_shape">
+			The [Shape3D] that will be used for collision/intersection queries.
 		</member>
 		<member name="transform" type="Transform" setter="set_transform" getter="get_transform" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
 			The queried shape's transform matrix.

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -98,7 +98,7 @@ class PhysicsShapeQueryResult2D;
 class PhysicsShapeQueryParameters2D : public Reference {
 	GDCLASS(PhysicsShapeQueryParameters2D, Reference);
 	friend class PhysicsDirectSpaceState2D;
-	RID shape;
+	RES shape;
 	Transform2D transform;
 	Vector2 motion;
 	float margin;
@@ -113,8 +113,7 @@ protected:
 
 public:
 	void set_shape(const RES &p_shape);
-	void set_shape_rid(const RID &p_shape);
-	RID get_shape_rid() const;
+	RES get_shape() const;
 
 	void set_transform(const Transform2D &p_transform);
 	Transform2D get_transform() const;

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -138,14 +138,10 @@ PhysicsDirectBodyState3D::PhysicsDirectBodyState3D() {}
 
 void PhysicsShapeQueryParameters3D::set_shape(const RES &p_shape) {
 	ERR_FAIL_COND(p_shape.is_null());
-	shape = p_shape->get_rid();
-}
-
-void PhysicsShapeQueryParameters3D::set_shape_rid(const RID &p_shape) {
 	shape = p_shape;
 }
 
-RID PhysicsShapeQueryParameters3D::get_shape_rid() const {
+RES PhysicsShapeQueryParameters3D::get_shape() const {
 	return shape;
 }
 
@@ -208,8 +204,7 @@ bool PhysicsShapeQueryParameters3D::is_collide_with_areas_enabled() const {
 
 void PhysicsShapeQueryParameters3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &PhysicsShapeQueryParameters3D::set_shape);
-	ClassDB::bind_method(D_METHOD("set_shape_rid", "shape"), &PhysicsShapeQueryParameters3D::set_shape_rid);
-	ClassDB::bind_method(D_METHOD("get_shape_rid"), &PhysicsShapeQueryParameters3D::get_shape_rid);
+	ClassDB::bind_method(D_METHOD("get_shape"), &PhysicsShapeQueryParameters3D::get_shape);
 
 	ClassDB::bind_method(D_METHOD("set_transform", "transform"), &PhysicsShapeQueryParameters3D::set_transform);
 	ClassDB::bind_method(D_METHOD("get_transform"), &PhysicsShapeQueryParameters3D::get_transform);
@@ -232,8 +227,7 @@ void PhysicsShapeQueryParameters3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude", PROPERTY_HINT_NONE, itos(Variant::_RID) + ":"), "set_exclude", "get_exclude");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_margin", "get_margin");
-	//ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", ""); // FIXME: Lacks a getter
-	ADD_PROPERTY(PropertyInfo(Variant::_RID, "shape_rid"), "set_shape_rid", "get_shape_rid");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape3D"), "set_shape", "get_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM, "transform"), "set_transform", "get_transform");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies"), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas"), "set_collide_with_areas", "is_collide_with_areas_enabled");
@@ -274,10 +268,11 @@ Dictionary PhysicsDirectSpaceState3D::_intersect_ray(const Vector3 &p_from, cons
 
 Array PhysicsDirectSpaceState3D::_intersect_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results) {
 	ERR_FAIL_COND_V(!p_shape_query.is_valid(), Array());
+	ERR_FAIL_COND_V_MSG(!p_shape_query->shape.is_valid(), Array(), "Shape not set in query parameters.");
 
 	Vector<ShapeResult> sr;
 	sr.resize(p_max_results);
-	int rc = intersect_shape(p_shape_query->shape, p_shape_query->transform, p_shape_query->margin, sr.ptrw(), sr.size(), p_shape_query->exclude, p_shape_query->collision_mask, p_shape_query->collide_with_bodies, p_shape_query->collide_with_areas);
+	int rc = intersect_shape(p_shape_query->shape->get_rid(), p_shape_query->transform, p_shape_query->margin, sr.ptrw(), sr.size(), p_shape_query->exclude, p_shape_query->collision_mask, p_shape_query->collide_with_bodies, p_shape_query->collide_with_areas);
 	Array ret;
 	ret.resize(rc);
 	for (int i = 0; i < rc; i++) {
@@ -294,9 +289,10 @@ Array PhysicsDirectSpaceState3D::_intersect_shape(const Ref<PhysicsShapeQueryPar
 
 Array PhysicsDirectSpaceState3D::_cast_motion(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, const Vector3 &p_motion) {
 	ERR_FAIL_COND_V(!p_shape_query.is_valid(), Array());
+	ERR_FAIL_COND_V_MSG(!p_shape_query->shape.is_valid(), Array(), "Shape not set in query parameters.");
 
 	float closest_safe = 1.0f, closest_unsafe = 1.0f;
-	bool res = cast_motion(p_shape_query->shape, p_shape_query->transform, p_motion, p_shape_query->margin, closest_safe, closest_unsafe, p_shape_query->exclude, p_shape_query->collision_mask, p_shape_query->collide_with_bodies, p_shape_query->collide_with_areas);
+	bool res = cast_motion(p_shape_query->shape->get_rid(), p_shape_query->transform, p_motion, p_shape_query->margin, closest_safe, closest_unsafe, p_shape_query->exclude, p_shape_query->collision_mask, p_shape_query->collide_with_bodies, p_shape_query->collide_with_areas);
 	if (!res) {
 		return Array();
 	}
@@ -309,11 +305,12 @@ Array PhysicsDirectSpaceState3D::_cast_motion(const Ref<PhysicsShapeQueryParamet
 
 Array PhysicsDirectSpaceState3D::_collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results) {
 	ERR_FAIL_COND_V(!p_shape_query.is_valid(), Array());
+	ERR_FAIL_COND_V_MSG(!p_shape_query->shape.is_valid(), Array(), "Shape not set in query parameters.");
 
 	Vector<Vector3> ret;
 	ret.resize(p_max_results * 2);
 	int rc = 0;
-	bool res = collide_shape(p_shape_query->shape, p_shape_query->transform, p_shape_query->margin, ret.ptrw(), p_max_results, rc, p_shape_query->exclude, p_shape_query->collision_mask, p_shape_query->collide_with_bodies, p_shape_query->collide_with_areas);
+	bool res = collide_shape(p_shape_query->shape->get_rid(), p_shape_query->transform, p_shape_query->margin, ret.ptrw(), p_max_results, rc, p_shape_query->exclude, p_shape_query->collision_mask, p_shape_query->collide_with_bodies, p_shape_query->collide_with_areas);
 	if (!res) {
 		return Array();
 	}
@@ -327,10 +324,11 @@ Array PhysicsDirectSpaceState3D::_collide_shape(const Ref<PhysicsShapeQueryParam
 
 Dictionary PhysicsDirectSpaceState3D::_get_rest_info(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query) {
 	ERR_FAIL_COND_V(!p_shape_query.is_valid(), Dictionary());
+	ERR_FAIL_COND_V_MSG(!p_shape_query->shape.is_valid(), Dictionary(), "Shape not set in query parameters.");
 
 	ShapeRestInfo sri;
 
-	bool res = rest_info(p_shape_query->shape, p_shape_query->transform, p_shape_query->margin, &sri, p_shape_query->exclude, p_shape_query->collision_mask, p_shape_query->collide_with_bodies, p_shape_query->collide_with_areas);
+	bool res = rest_info(p_shape_query->shape->get_rid(), p_shape_query->transform, p_shape_query->margin, &sri, p_shape_query->exclude, p_shape_query->collision_mask, p_shape_query->collide_with_bodies, p_shape_query->collide_with_areas);
 	Dictionary r;
 	if (!res) {
 		return r;

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -100,7 +100,7 @@ class PhysicsShapeQueryParameters3D : public Reference {
 	GDCLASS(PhysicsShapeQueryParameters3D, Reference);
 	friend class PhysicsDirectSpaceState3D;
 
-	RID shape;
+	RES shape;
 	Transform transform;
 	float margin;
 	Set<RID> exclude;
@@ -114,8 +114,7 @@ protected:
 
 public:
 	void set_shape(const RES &p_shape);
-	void set_shape_rid(const RID &p_shape);
-	RID get_shape_rid() const;
+	RES get_shape() const;
 
 	void set_transform(const Transform &p_transform);
 	Transform get_transform() const;


### PR DESCRIPTION
Fixes #39699 and changes Physics2D as well to make things consistent.

Stores the shape resource instead of RID to avoid the shape to be released while still used for queries.

Breaks compatibility by removing get/set_shape_rid from query parameters.