### PR TITLE
Fixes recently introduced shader leaks

### DIFF
--- a/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.cpp
@@ -2497,7 +2497,7 @@ RasterizerCanvasRD::~RasterizerCanvasRD() {
 		_dispose_bindings();
 		//anything remains?
 		if (bindings.texture_bindings.size()) {
-			ERR_PRINT("Some texture bindings were not properly freed (leaked canvasitems?");
+			ERR_PRINT("Some texture bindings were not properly freed (leaked CanvasItems?)");
 			const TextureBindingID *key = nullptr;
 			while ((key = bindings.texture_bindings.next(key))) {
 				TextureBinding *tb = bindings.texture_bindings[*key];

--- a/servers/rendering/rasterizer_rd/rasterizer_effects_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_effects_rd.cpp
@@ -1612,6 +1612,7 @@ RasterizerEffectsRD::~RasterizerEffectsRD() {
 	cubemap_downsampler.shader.version_free(cubemap_downsampler.shader_version);
 	filter.shader.version_free(filter.shader_version);
 	luminance_reduce.shader.version_free(luminance_reduce.shader_version);
+	resolve.shader.version_free(resolve.shader_version);
 	roughness.shader.version_free(roughness.shader_version);
 	roughness_limiter.shader.version_free(roughness_limiter.shader_version);
 	specular_merge.shader.version_free(specular_merge.shader_version);

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_rd.cpp
@@ -6802,10 +6802,18 @@ RasterizerSceneRD::~RasterizerSceneRD() {
 	}
 
 	RD::get_singleton()->free(default_giprobe_buffer);
-
 	RD::get_singleton()->free(gi_probe_lights_uniform);
+	RD::get_singleton()->free(gi.sdfgi_ubo);
+
 	giprobe_debug_shader.version_free(giprobe_debug_shader_version);
 	giprobe_shader.version_free(giprobe_lighting_shader_version);
+	gi.shader.version_free(gi.shader_version);
+	sdfgi_shader.debug_probes.version_free(sdfgi_shader.debug_probes_shader);
+	sdfgi_shader.debug.version_free(sdfgi_shader.debug_shader);
+	sdfgi_shader.direct_light.version_free(sdfgi_shader.direct_light_shader);
+	sdfgi_shader.integrate.version_free(sdfgi_shader.integrate_shader);
+	sdfgi_shader.preprocess.version_free(sdfgi_shader.preprocess_shader);
+
 	memdelete_arr(gi_probe_lights);
 	SkyMaterialData *md = (SkyMaterialData *)storage->material_get_data(sky_shader.default_material, RasterizerStorageRD::SHADER_TYPE_SKY);
 	sky_shader.shader.version_free(md->shader_data->version);


### PR DESCRIPTION
Fixes this leaks
```
ERROR: 1 shaders of type GiShaderRD were never freed
   at: ~ShaderRD (servers/rendering/rasterizer_rd/shader_rd.cpp:470)
ERROR: 1 shaders of type SdfgiIntegrateShaderRD were never freed
   at: ~ShaderRD (servers/rendering/rasterizer_rd/shader_rd.cpp:470)
ERROR: 1 shaders of type SdfgiDirectLightShaderRD were never freed
   at: ~ShaderRD (servers/rendering/rasterizer_rd/shader_rd.cpp:470)
ERROR: 1 shaders of type SdfgiDebugProbesShaderRD were never freed
   at: ~ShaderRD (servers/rendering/rasterizer_rd/shader_rd.cpp:470)
ERROR: 1 shaders of type SdfgiDebugShaderRD were never freed
   at: ~ShaderRD (servers/rendering/rasterizer_rd/shader_rd.cpp:470)
ERROR: 1 shaders of type SdfgiPreprocessShaderRD were never freed
   at: ~ShaderRD (servers/rendering/rasterizer_rd/shader_rd.cpp:470)
ERROR: 1 shaders of type ResolveShaderRD were never freed
   at: ~ShaderRD (servers/rendering/rasterizer_rd/shader_rd.cpp:470)
WARNING: 1 RIDs of type 'UniformBuffer' were leaked.
     at: _free_rids (drivers/vulkan/rendering_device_vulkan.cpp:7275)
```
