### PR TITLE
Utility methods for writing files to gradle project directory

### DIFF
--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -1,0 +1,101 @@
+/*************************************************************************/
+/*  gradle_export_util.h                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GODOT_GRADLE_EXPORT_UTIL_H
+#define GODOT_GRADLE_EXPORT_UTIL_H
+
+#include "core/io/zip_io.h"
+#include "core/os/dir_access.h"
+#include "core/os/file_access.h"
+#include "core/os/os.h"
+#include "editor/editor_export.h"
+
+// Utility method used to create a directory.
+Error create_directory(const String &p_dir) {
+	if (!DirAccess::exists(p_dir)) {
+		DirAccess *filesystem_da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		ERR_FAIL_COND_V_MSG(!filesystem_da, ERR_CANT_CREATE, "Cannot create directory '" + p_dir + "'.");
+		Error err = filesystem_da->make_dir_recursive(p_dir);
+		ERR_FAIL_COND_V_MSG(err, ERR_CANT_CREATE, "Cannot create directory '" + p_dir + "'.");
+		memdelete(filesystem_da);
+	}
+	return OK;
+}
+
+// Implementation of EditorExportSaveSharedObject.
+// This method will only be called as an input to export_project_files.
+// This method lets the .so files for all ABIs to be copied
+// into the gradle project from the .AAR file
+Error ignore_so_file(void *p_userdata, const SharedObject &p_so) {
+	return OK;
+}
+
+// Writes p_data into a file at p_path, creating directories if necessary.
+// Note: this will overwrite the file at p_path if it already exists.
+Error store_file_at_path(const String &p_path, const Vector<uint8_t> &p_data) {
+	String dir = p_path.get_base_dir();
+	Error err = create_directory(dir);
+	if (err != OK) {
+		return err;
+	}
+	FileAccess *fa = FileAccess::open(p_path, FileAccess::WRITE);
+	ERR_FAIL_COND_V_MSG(!fa, ERR_CANT_CREATE, "Cannot create file '" + p_path + "'.");
+	fa->store_buffer(p_data.ptr(), p_data.size());
+	memdelete(fa);
+	return OK;
+}
+
+// Writes string p_data into a file at p_path, creating directories if necessary.
+// Note: this will overwrite the file at p_path if it already exists.
+Error store_string_at_path(const String &p_path, const String &p_data) {
+	String dir = p_path.get_base_dir();
+	Error err = create_directory(dir);
+	if (err != OK) {
+		return err;
+	}
+	FileAccess *fa = FileAccess::open(p_path, FileAccess::WRITE);
+	ERR_FAIL_COND_V_MSG(!fa, ERR_CANT_CREATE, "Cannot create file '" + p_path + "'.");
+	fa->store_string(p_data);
+	memdelete(fa);
+	return OK;
+}
+
+// Implementation of EditorExportSaveFunction.
+// This method will only be called as an input to export_project_files.
+// It is used by the export_project_files method to save all the asset files into the gradle project.
+// It's functionality mirrors that of the method save_apk_file.
+// This method will be called ONLY when custom build is enabled.
+Error rename_and_store_file_in_gradle_project(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total) {
+	String dst_path = p_path.replace_first("res://", "res://android/build/assets/");
+	Error err = store_file_at_path(dst_path, p_data);
+	return err;
+}
+
+#endif //GODOT_GRADLE_EXPORT_UTIL_H


### PR DESCRIPTION
Being able to write files to the gradle project directory is a necessary step in moving towards a gradle-based build system that can export Android App Bundles. For more details on the final scope of this project, read [this comment](https://github.com/godotengine/godot-proposals/issues/342#issuecomment-648390053).

These methods aren't currently called anywhere in the code, but they will be useful in subsequent PR's.

We are working on this PR with @m4gr3d, as explained [here](https://github.com/godotengine/godot-proposals/issues/342#issuecomment-643655563)