### PR TITLE
Use mesh instead of immediate for drawing Sprite3D

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -4431,7 +4431,7 @@
 			Flag used to mark that the array uses 16-bit bones instead of 8-bit.
 		</constant>
 		<constant name="ARRAY_COMPRESS_DEFAULT" value="97280" enum="ArrayFormat">
-			Used to set flags [constant ARRAY_COMPRESS_VERTEX], [constant ARRAY_COMPRESS_NORMAL], [constant ARRAY_COMPRESS_TANGENT], [constant ARRAY_COMPRESS_COLOR], [constant ARRAY_COMPRESS_TEX_UV], [constant ARRAY_COMPRESS_TEX_UV2] and [constant ARRAY_COMPRESS_WEIGHTS] quickly.
+			Used to set flags [constant ARRAY_COMPRESS_NORMAL], [constant ARRAY_COMPRESS_TANGENT], [constant ARRAY_COMPRESS_COLOR], [constant ARRAY_COMPRESS_TEX_UV], [constant ARRAY_COMPRESS_TEX_UV2] and [constant ARRAY_COMPRESS_WEIGHTS] quickly.
 		</constant>
 		<constant name="PRIMITIVE_POINTS" value="0" enum="PrimitiveType">
 			Primitive to draw consists of points.

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -76,7 +76,8 @@ private:
 	float pixel_size;
 	AABB aabb;
 
-	RID immediate;
+	RID mesh;
+	RID material;
 
 	bool flags[FLAG_MAX];
 	AlphaCutMode alpha_cut;
@@ -92,7 +93,13 @@ protected:
 	static void _bind_methods();
 	virtual void _draw() = 0;
 	_FORCE_INLINE_ void set_aabb(const AABB &p_aabb) { aabb = p_aabb; }
-	_FORCE_INLINE_ RID &get_immediate() { return immediate; }
+	_FORCE_INLINE_ RID &get_mesh() { return mesh; }
+	_FORCE_INLINE_ RID &get_material() { return material; }
+
+	uint32_t mesh_surface_offsets[VS::ARRAY_MAX];
+	PoolByteArray mesh_buffer;
+	uint32_t mesh_stride;
+
 	void _queue_update();
 
 public:

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1838,6 +1838,8 @@ RID SpatialMaterial::get_material_rid_for_2d(bool p_shaded, bool p_transparent, 
 	}
 
 	materials_for_2d[version] = material;
+	// flush before using so we can access the shader right away
+	flush_changes();
 
 	return materials_for_2d[version]->get_rid();
 }


### PR DESCRIPTION
Closes: #20855

Using ``ImmediateGeometry`` to draw the ``Sprite3D`` made it very slow. On my phone 128 ``Sprite3D``s ran at 1 FPS.

This PR replaces ``ImmediateGeometry`` with a regular old mesh. As a result it needs to store a unique material per ``Sprite3D`` so each Sprite can have different textures. ``ImmediateGeometry`` got around this because each instance had its own override texture.

With these changes my phone can now have over 1000 ``Sprite3D``s before FPS drops below 60 FPS. On my desktop, the performance improvement is around 3x.

Note re 4.0: reduz says he wants to improve ``ImmediateGeometry`` for Vulkan, so this change may not be worth porting to 4.0. But I will discuss it with him as it should be useful for the low-end backend (GLES2, GLES3 or both?)