### PR TITLE
Add a PR template with a message about PRs needing to be for master

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+<!--
+Pull requests should always be made for the `master` branch first, as that's
+where development happens and the source of all future stable release branches.
+
+Relevant fixes are cherry-picked for stable branches as needed.
+
+Do not create a pull request for stable branches unless the change is already
+available in the `master` branch and it cannot be easily cherry-picked.
+Alternatively, if the change is only relevant for that branch (e.g. rendering
+fixes for the 3.2 branch).
+-->


### PR DESCRIPTION
There are a lot of confused contributors making PRs for the 3.2 branch by mistake, so I think it would be helpful to document the proper procedure by adding some text in a PR template. Here's what I have so far:

```markdown
<!--
Pull requests must always be made for the "master" branch first.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change
is already available in the master branch and it cannot be
easily cherry-picked. Alternatively, if the change is only
relevant for that branch (ex: GLES3 fixes for the 3.2 branch)
-->
```