### PR TITLE
Fix laxist collision detection on one way shapes

### DIFF
--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -255,9 +255,8 @@ bool BodyPair2DSW::setup(real_t p_step) {
 	if (B->get_continuous_collision_detection_mode() == PhysicsServer2D::CCD_MODE_CAST_SHAPE) {
 		motion_B = B->get_motion();
 	}
-	//faster to set than to check..
 
-	//bool prev_collided=collided;
+	bool prev_collided = collided;
 
 	collided = CollisionSolver2DSW::solve(shape_A_ptr, xform_A, motion_A, shape_B_ptr, xform_B, motion_B, _add_contact, this, &sep_axis);
 	if (!collided) {
@@ -285,8 +284,7 @@ bool BodyPair2DSW::setup(real_t p_step) {
 		return false;
 	}
 
-	//if (!prev_collided) {
-	{
+	if (!prev_collided) {
 		if (A->is_shape_set_as_one_way_collision(shape_A)) {
 			Vector2 direction = xform_A.get_axis(1).normalized();
 			bool valid = false;


### PR DESCRIPTION
This PR fixes #23491 and possibly others.

The problem was actually more global than indicated in the mentionned issue as the moving body only had to collide and gain some rotation to pass through _any_ one way static body (not only adjacent with an other one and not only in a TileMap).
