### PR TITLE
Fix errors when creating windows on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -476,6 +476,7 @@ DisplayServer::WindowID DisplayServerWindows::create_sub_window(WindowMode p_mod
 	_THREAD_SAFE_METHOD_
 
 	WindowID window_id = _create_window(p_mode, p_flags, p_rect);
+	ERR_FAIL_COND_V_MSG(window_id == INVALID_WINDOW_ID, INVALID_WINDOW_ID, "Failed to create sub window.");
 
 	WindowData &wd = windows[window_id];
 
@@ -1773,12 +1774,20 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 	};
 
 	WindowID window_id = INVALID_WINDOW_ID;
+	bool window_created = false;
 
 	for (Map<WindowID, WindowData>::Element *E = windows.front(); E; E = E->next()) {
 		if (E->get().hWnd == hWnd) {
 			window_id = E->key();
+			window_created = true;
 			break;
 		}
+	}
+
+	if (!window_created) {
+		// Window creation in progress.
+		window_id = window_id_counter;
+		ERR_FAIL_COND_V(!windows.has(window_id), 0);
 	}
 
 	switch (uMsg) // Check For Windows Messages
@@ -2493,7 +2502,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					windows[window_id].height = window_h;
 
 #if defined(VULKAN_ENABLED)
-					if (rendering_driver == "vulkan") {
+					if ((rendering_driver == "vulkan") && window_created) {
 						context_vulkan->window_resize(window_id, windows[window_id].width, windows[window_id].height);
 					}
 #endif
@@ -2849,7 +2858,7 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 
 	WindowID id = window_id_counter;
 	{
-		WindowData wd;
+		WindowData &wd = windows[id];
 
 		wd.hWnd = CreateWindowExW(
 				dwExStyle,
@@ -2864,6 +2873,7 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 				nullptr, nullptr, hInstance, nullptr);
 		if (!wd.hWnd) {
 			MessageBoxW(nullptr, L"Window Creation Error.", L"ERROR", MB_OK | MB_ICONEXCLAMATION);
+			windows.erase(id);
 			return INVALID_WINDOW_ID;
 		}
 #ifdef VULKAN_ENABLED
@@ -2872,7 +2882,8 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 			if (context_vulkan->window_create(id, wd.hWnd, hInstance, WindowRect.right - WindowRect.left, WindowRect.bottom - WindowRect.top) == -1) {
 				memdelete(context_vulkan);
 				context_vulkan = nullptr;
-				ERR_FAIL_V(INVALID_WINDOW_ID);
+				windows.erase(id);
+				ERR_FAIL_V_MSG(INVALID_WINDOW_ID, "Failed to create Vulkan Window.");
 			}
 		}
 #endif
@@ -2929,8 +2940,6 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 		wd.last_pos = p_rect.position;
 		wd.width = p_rect.size.width;
 		wd.height = p_rect.size.height;
-
-		windows[id] = wd;
 
 		window_id_counter++;
 	}
@@ -3062,7 +3071,10 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	Point2i window_position(
 			(screen_get_size(0).width - p_resolution.width) / 2,
 			(screen_get_size(0).height - p_resolution.height) / 2);
+
 	WindowID main_window = _create_window(p_mode, 0, Rect2i(window_position, p_resolution));
+	ERR_FAIL_COND_MSG(main_window == INVALID_WINDOW_ID, "Failed to create main window.");
+
 	for (int i = 0; i < WINDOW_FLAG_MAX; i++) {
 		if (p_flags & (1 << i)) {
 			window_set_flag(WindowFlags(i), true, main_window);


### PR DESCRIPTION
Detecting the case where `WM_SIZE` is received during the window creation (no need to call `window_resize` on the Vulkan context in this case because the window doesn't exist yet).

Also creating a `WindowData` entry early enough to avoid storing a separate `WindowData` wrongly associated to `INVALID_WINDOW_ID`.

Fixes #39199