### PR TITLE
Fix leaked ObjectRCs on object Variant reassignment

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1996,7 +1996,7 @@ Object::~Object() {
 	ObjectRC *rc = _rc.load(std::memory_order_acquire);
 	if (rc) {
 		if (rc->invalidate()) {
-			memfree(rc);
+			memdelete(rc);
 		}
 	}
 #endif

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1121,9 +1121,9 @@ void Variant::clear() {
 		case OBJECT: {
 
 #ifdef DEBUG_ENABLED
-			if (_get_obj().rc) {
-				if (_get_obj().rc->decrement()) {
-					memfree(_get_obj().rc);
+			if (likely(_get_obj().rc)) {
+				if (unlikely(_get_obj().rc->decrement())) {
+					memdelete(_get_obj().rc);
 				}
 			} else {
 				_get_obj().ref.unref();
@@ -2655,9 +2655,16 @@ void Variant::operator=(const Variant &p_variant) {
 		} break;
 		case OBJECT: {
 
+#ifdef DEBUG_ENABLED
+			if (likely(_get_obj().rc)) {
+				if (unlikely(_get_obj().rc->decrement())) {
+					memdelete(_get_obj().rc);
+				}
+			}
+#endif
 			*reinterpret_cast<ObjData *>(_data._mem) = p_variant._get_obj();
 #ifdef DEBUG_ENABLED
-			if (_get_obj().rc) {
+			if (likely(_get_obj().rc)) {
 				_get_obj().rc->increment();
 			}
 #endif


### PR DESCRIPTION
Bonus:
- Add some (`un``)likely` magic
- Use `memdelete()` instead of `memfree()` for `ObjectRC`  (not strictly needed, but more correct; hinted by @ThakeeNathees's comment on the bug report)

Fixes #39821.