### PR TITLE
Fix debugger error when Dictionary key is a freed Object

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1169,15 +1169,14 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				while (r_len%4)
 					r_len++; //pad
 				*/
+				Variant *v = d.getptr(E->get());
 				int len;
-				encode_variant(E->get(), buf, len, p_full_objects);
+				encode_variant(v ? E->get() : Variant("[Deleted Object]"), buf, len, p_full_objects);
 				ERR_FAIL_COND_V(len % 4, ERR_BUG);
 				r_len += len;
 				if (buf)
 					buf += len;
-				Variant *v = d.getptr(E->get());
-				ERR_FAIL_COND_V(!v, ERR_BUG);
-				encode_variant(*v, buf, len, p_full_objects);
+				encode_variant(v ? *v : Variant(), buf, len, p_full_objects);
 				ERR_FAIL_COND_V(len % 4, ERR_BUG);
 				r_len += len;
 				if (buf)


### PR DESCRIPTION
If a remotely inspected `Dictionary` had one or more keys that are freed `Object`s, in the inspector you'll see a single entry corresponding to all of them: `[Deleted Object] -> null`.

It's not perfectly accurate, but it's the best I can come up with now. At least, it hints about the source of the problem and avoids the debugger from failing.

On 4.0 it's not needed. The debugger keeps running just fine showing a `null` key where the freed `Object` was.

Fixes #39868.