### PR TITLE
VideoStreamGDNative: close file in cleanup()

### DIFF
--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -214,6 +214,11 @@ void VideoStreamPlaybackGDNative::cleanup() {
 	if (pcm) {
 		memfree(pcm);
 	}
+	if (file) {
+		file->close();
+		memdelete(file);
+		file = nullptr;
+	}
 	pcm = nullptr;
 	time = 0;
 	num_channels = -1;


### PR DESCRIPTION
We should close the file handle (created by FileAccess::open()) and remove it when we are done playing the video. 

I've had a Windows app playing short videos (~10 sec) in loop, by repeatedly calling `set_stream()` and `play()` in a `VideoPlayer` node with a `VideoStreamGDNative` instance. A few hours later this has depleted allowed Windows file handle count in the godot process. All subsequent API call related to filesystem open will fail.