### PR TITLE
Quick Open search ranking: favor filenames over extensions.

### DIFF
--- a/editor/quick_open.h
+++ b/editor/quick_open.h
@@ -41,6 +41,7 @@ class EditorQuickOpen : public ConfirmationDialog {
 
 	LineEdit *search_box;
 	Tree *search_options;
+
 	StringName base_type;
 	StringName ei;
 	StringName ot;
@@ -50,7 +51,7 @@ class EditorQuickOpen : public ConfirmationDialog {
 	void _sbox_input(const Ref<InputEvent> &p_ie);
 	void _parse_fs(EditorFileSystemDirectory *efsd, Vector<Pair<String, Ref<Texture2D>>> &list);
 	Vector<Pair<String, Ref<Texture2D>>> _sort_fs(Vector<Pair<String, Ref<Texture2D>>> &list);
-	float _path_cmp(String search, String path) const;
+	float _score_path(String search, String path) const;
 
 	void _confirmed();
 	void _text_changed(const String &p_newtext);


### PR DESCRIPTION
In Quick Open, if a search pattern would be a substring of a file extension, a file with that extension would be ranked higher even if it's filename didn't contain that pattern. For example, "sc" is part of "tscn",  so this happens right now:
![old_qo](https://user-images.githubusercontent.com/25907608/85959135-d18cf700-b99a-11ea-99d4-c9d866e8c9c3.png)

This commit changes `_score_path` to first look _forwards_ in the filename+extension, ranking an earlier match higher to prefer the filename over the extension. If nothing is found, the algorithm continues as before. **Other changes is just refactoring.**


