### PR TITLE
VideoPlayer: fix possible race condition

### DIFF
--- a/scene/gui/video_player.cpp
+++ b/scene/gui/video_player.cpp
@@ -201,10 +201,9 @@ bool VideoPlayer::has_expand() const {
 
 void VideoPlayer::set_stream(const Ref<VideoStream> &p_stream) {
 	stop();
+
 	AudioServer::get_singleton()->lock();
 	mix_buffer.resize(AudioServer::get_singleton()->thread_get_mix_buffer_size());
-	AudioServer::get_singleton()->unlock();
-
 	stream = p_stream;
 	if (stream.is_valid()) {
 		stream->set_audio_track(audio_track);
@@ -212,6 +211,7 @@ void VideoPlayer::set_stream(const Ref<VideoStream> &p_stream) {
 	} else {
 		playback = Ref<VideoStreamPlayback>();
 	}
+	AudioServer::get_singleton()->unlock();
 
 	if (!playback.is_null()) {
 		playback->set_loop(loops);


### PR DESCRIPTION
In `set_stream()` we write to `playback` while accessing the same object in `_mix_audio()` in audio thread.
Protect the 'write' part in `set_stream()` to avoid possible crash in `_mix_audio()` function.

I've been stress testing the video playback in godot using short videos (~10 sec). I've seen a read access violation crash that happens in VideoPlayer::_mix_audio() when doing `playback->is_playing()`.