### PR TITLE
Fix weekday calculation in get_datetime_from_unix_time for negative times

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -454,7 +454,7 @@ Dictionary _OS::get_datetime_from_unix_time(int64_t unix_time_val) const {
 	} else {
 		dayno = (unix_time_val - SECS_DAY + 1) / SECS_DAY;
 		dayclock = unix_time_val - dayno * SECS_DAY;
-		date.weekday = static_cast<OS::Weekday>((dayno - 3) % 7 + 7);
+		date.weekday = static_cast<OS::Weekday>(((dayno % 7) + 11) % 7);
 		do {
 			year--;
 			dayno += YEARSIZE(year);


### PR DESCRIPTION
Fix calculation for negative times to ensure Sundays are wrapped around to '0'
instead of '7', making it consistent with the output for positive times.

Closes #39912 

Sample test script in the following project (which can be compared with results from [here](https://www.epochconverter.com/)):
[datetime.zip](https://github.com/godotengine/godot/files/4844216/datetime.zip)
