### PR TITLE
[macOS, 3.2] Add support for the Apple Silicon (ARM64) build target.

### DIFF
--- a/misc/dist/osx_template.app/Contents/Info.plist
+++ b/misc/dist/osx_template.app/Contents/Info.plist
@@ -30,12 +30,18 @@
 	<string>$camera_usage_description</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>$copyright</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.9.0</string>
+	<string>10.9</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>x86_64</key>
-		<string>10.9.0</string>
+		<string>10.9</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	$highres

--- a/misc/dist/osx_tools.app/Contents/Info.plist
+++ b/misc/dist/osx_tools.app/Contents/Info.plist
@@ -29,15 +29,21 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Camera access is required to capture video.</string>
 	<key>NSRequiresAquaSystemAppearance</key>
-    	<false />
+	<false />
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2007-2020 Juan Linietsky, Ariel Manzur &amp; Godot Engine contributors</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.9.0</string>
+	<string>10.9</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>x86_64</key>
-		<string>10.9.0</string>
+		<string>10.9</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>

--- a/modules/camera/camera_osx.mm
+++ b/modules/camera/camera_osx.mm
@@ -313,7 +313,12 @@ MyDeviceNotifications *device_notifications = nil;
 // CameraOSX - Subclass for our camera server on OSX
 
 void CameraOSX::update_feeds() {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
+	AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+	NSArray *devices = session.devices;
+#else
 	NSArray *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+#endif
 
 	// remove devices that are gone..
 	for (int i = feeds.size() - 1; i >= 0; i--) {

--- a/modules/opus/SCsub
+++ b/modules/opus/SCsub
@@ -227,6 +227,9 @@ if env["builtin_opus"]:
             env_opus.Append(CPPDEFINES=["OPUS_ARM_OPT"])
         elif "arch" in env and env["arch"] == "arm64":
             env_opus.Append(CPPDEFINES=["OPUS_ARM64_OPT"])
+    elif env["platform"] == "osx":
+        if "arch" in env and env["arch"] == "arm64":
+            env_opus.Append(CPPDEFINES=["OPUS_ARM64_OPT"])
 
     env_thirdparty = env_opus.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/webm/libvpx/SCsub
+++ b/modules/webm/libvpx/SCsub
@@ -230,6 +230,7 @@ else:
     is_x11_or_server_arm = (env["platform"] == "x11" or env["platform"] == "server") and (
         platform.machine().startswith("arm") or platform.machine().startswith("aarch")
     )
+    is_macos_x86 = env["platform"] == "osx" and ("arch" in env and (env["arch"] != "arm64"))
     is_ios_x86 = env["platform"] == "iphone" and ("arch" in env and env["arch"].startswith("x86"))
     is_android_x86 = env["platform"] == "android" and env["android_arch"].startswith("x86")
     if is_android_x86:
@@ -240,14 +241,15 @@ else:
         and (
             env["platform"] == "windows"
             or env["platform"] == "x11"
-            or env["platform"] == "osx"
             or env["platform"] == "haiku"
+            or is_macos_x86
             or is_android_x86
             or is_ios_x86
         )
     )
     webm_cpu_arm = (
         is_x11_or_server_arm
+        or (not is_macos_x86 and env["platform"] == "osx")
         or (not is_ios_x86 and env["platform"] == "iphone")
         or (not is_android_x86 and env["platform"] == "android")
     )

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -81,8 +81,15 @@ def configure(env):
         env["osxcross"] = True
 
     if not "osxcross" in env:  # regular native build
-        env.Append(CCFLAGS=["-arch", "x86_64"])
-        env.Append(LINKFLAGS=["-arch", "x86_64"])
+        if env["arch"] == "arm64":
+            print("Building for macOS 10.15+, platform arm64.")
+            env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15", "-target", "arm64-apple-macos10.15"])
+            env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15", "-target", "arm64-apple-macos10.15"])
+        else:
+            print("Building for macOS 10.9+, platform x86-64.")
+            env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.9"])
+            env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.9"])
+
         if env["macports_clang"] != "no":
             mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
             mpclangver = env["macports_clang"]
@@ -142,7 +149,8 @@ def configure(env):
     ## Dependencies
 
     if env["builtin_libtheora"]:
-        env["x86_libtheora_opt_gcc"] = True
+        if env["arch"] != "arm64":
+            env["x86_libtheora_opt_gcc"] = True
 
     ## Flags
 
@@ -155,6 +163,7 @@ def configure(env):
             "APPLE_STYLE_KEYS",
             "COREAUDIO_ENABLED",
             "COREMIDI_ENABLED",
+            "GL_SILENCE_DEPRECATION",
         ]
     )
     env.Append(
@@ -187,6 +196,3 @@ def configure(env):
         ]
     )
     env.Append(LIBS=["pthread"])
-
-    env.Append(CCFLAGS=["-mmacosx-version-min=10.9"])
-    env.Append(LINKFLAGS=["-mmacosx-version-min=10.9"])


### PR DESCRIPTION
Adds support for ARM64 target on macOS (with `-arch arm64` option, targets x86-64 when arch is not specified).

Same as #39788 for 3.2 branch.

Universal binary can be created in the similar manner to iOS (currently this step is not automated):
```
lipo -create ./bin/godot.osx.opt.tools.64 ./bin/godot.osx.opt.tools.arm64 -output ./bin/godot.osx.opt.tools.universal
```