### PR TITLE
Add mouse event pass-through support for window.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -901,6 +901,30 @@
 			<description>
 			</description>
 		</method>
+		<method name="window_set_mouse_passthrough">
+			<return type="void">
+			</return>
+			<argument index="0" name="region" type="PackedVector2Array">
+			</argument>
+			<argument index="1" name="window_id" type="int" default="0">
+			</argument>
+			<description>
+				Sets a polygonal region of the window which accepts mouse events. Mouse events outside the region will be passed through.
+				Passing an empty array will disable passthrough support (all mouse events will be intercepted by the window, which is the default behavior).
+				[codeblock]
+				# Set region, using Path2D node.
+				DisplayServer.window_set_mouse_passthrough($Path2D.curve.get_baked_points())
+
+				# Set region, using Polygon2D node.
+				DisplayServer.window_set_mouse_passthrough($Polygon2D.polygon)
+
+				# Reset region to default.
+				DisplayServer.window_set_mouse_passthrough([])
+				[/codeblock]
+				[b]Note:[/b] On Windows, the portion of a window that lies outside the region is not drawn, while on Linux and macOS it is.
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+			</description>
+		</method>
 		<method name="window_set_position">
 			<return type="void">
 			</return>

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -35,6 +35,11 @@ def can_build():
         print("xinerama not found.. x11 disabled.")
         return False
 
+    x11_error = os.system("pkg-config xext --modversion > /dev/null ")
+    if x11_error:
+        print("xext not found.. x11 disabled.")
+        return False
+
     x11_error = os.system("pkg-config xrandr --modversion > /dev/null ")
     if x11_error:
         print("xrandr not found.. x11 disabled.")
@@ -194,6 +199,7 @@ def configure(env):
     env.ParseConfig("pkg-config x11 --cflags --libs")
     env.ParseConfig("pkg-config xcursor --cflags --libs")
     env.ParseConfig("pkg-config xinerama --cflags --libs")
+    env.ParseConfig("pkg-config xext --cflags --libs")
     env.ParseConfig("pkg-config xrandr --cflags --libs")
     env.ParseConfig("pkg-config xrender --cflags --libs")
     env.ParseConfig("pkg-config xi --cflags --libs")

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -291,6 +291,8 @@ public:
 	virtual ObjectID window_get_attached_instance_id(WindowID p_window = MAIN_WINDOW_ID) const;
 
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID);
+	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID);
+
 	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
 	virtual void window_set_window_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
 	virtual void window_set_input_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -102,6 +102,8 @@ public:
 		id window_object;
 		id window_view;
 
+		Vector<Vector2> mpath;
+
 #if defined(OPENGL_ENABLED)
 		ContextGL_OSX *context_gles2 = nullptr;
 #endif
@@ -240,6 +242,7 @@ public:
 	virtual void window_set_drop_files_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -323,6 +323,8 @@ private:
 		HWND hWnd;
 		//layered window
 
+		Vector<Vector2> mpath;
+
 		bool preserve_window_size = false;
 		bool pre_fs_valid = false;
 		RECT pre_fs_rect;
@@ -416,6 +418,7 @@ private:
 	void _touch_event(WindowID p_window, bool p_pressed, float p_x, float p_y, int idx);
 
 	void _update_window_style(WindowID p_window, bool p_repaint = true, bool p_maximized = false);
+	void _update_window_mouse_passthrough(WindowID p_window);
 
 	void _update_real_mouse_position(WindowID p_window);
 
@@ -477,6 +480,7 @@ public:
 	virtual void window_set_drop_files_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
 
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID);
+	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID);
 
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID);

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -194,6 +194,10 @@ void DisplayServer::delete_sub_window(WindowID p_id) {
 	ERR_FAIL_MSG("Sub-windows not supported by this display server.");
 }
 
+void DisplayServer::window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window) {
+	ERR_FAIL_MSG("Mouse passthrough not supported by this display server.");
+}
+
 void DisplayServer::window_set_ime_active(const bool p_active, WindowID p_window) {
 	WARN_PRINT("IME not supported by this display server.");
 }
@@ -412,6 +416,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("delete_sub_window", "window_id"), &DisplayServer::delete_sub_window);
 
 	ClassDB::bind_method(D_METHOD("window_set_title", "title", "window_id"), &DisplayServer::window_set_title, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_set_mouse_passthrough", "region", "window_id"), &DisplayServer::window_set_mouse_passthrough, DEFVAL(MAIN_WINDOW_ID));
 
 	ClassDB::bind_method(D_METHOD("window_get_current_screen", "window_id"), &DisplayServer::window_get_current_screen, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_set_current_screen", "screen", "window_id"), &DisplayServer::window_set_current_screen, DEFVAL(MAIN_WINDOW_ID));

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -247,6 +247,8 @@ public:
 
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) = 0;
 
+	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID);
+
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const = 0;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) = 0;
 


### PR DESCRIPTION
Adds `DisplayServer.window_set_mouse_passthrough` function to set polygonal region of the window which accepts mouse events, mouse events outside the region will be passed through to the window behind it.

Region can be drawn using Path2D (or similar) node and set by calling:
```gdscript
DisplayServer.window_set_mouse_passthru($Path2D.curve.get_baked_points())
```

The same changes for 3.2 are available in [click-through-3](https://github.com/bruvzg/godot/tree/click-through-3) branch.

- [x] macOS (implemented and tested on macOS 10.15.5)
- [x] Windows (implemented and tested on Windows 10)
- [x] Linux/X11 (implemented and tested on lubuntu 20.04)

Fixes #39914