### PR TITLE
Move ItemListEditorPlugin to a sidedock

### DIFF
--- a/editor/plugins/item_list_editor_plugin.h
+++ b/editor/plugins/item_list_editor_plugin.h
@@ -49,7 +49,6 @@ protected:
 
 public:
 	enum Flags {
-
 		FLAG_ICON = 1,
 		FLAG_CHECKABLE = 2,
 		FLAG_ID = 4,
@@ -168,21 +167,21 @@ public:
 class ItemListItemListPlugin : public ItemListPlugin {
 	GDCLASS(ItemListItemListPlugin, ItemListPlugin);
 
-	ItemList *pp;
+	ItemList *il;
 
 public:
 	virtual void set_object(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual int get_flags() const override;
 
-	virtual void set_item_text(int p_idx, const String &p_text) override { pp->set_item_text(p_idx, p_text); }
-	virtual String get_item_text(int p_idx) const override { return pp->get_item_text(p_idx); }
+	virtual void set_item_text(int p_idx, const String &p_text) override { il->set_item_text(p_idx, p_text); }
+	virtual String get_item_text(int p_idx) const override { return il->get_item_text(p_idx); }
 
-	virtual void set_item_icon(int p_idx, const Ref<Texture2D> &p_tex) override { pp->set_item_icon(p_idx, p_tex); }
-	virtual Ref<Texture2D> get_item_icon(int p_idx) const override { return pp->get_item_icon(p_idx); }
+	virtual void set_item_icon(int p_idx, const Ref<Texture2D> &p_tex) override { il->set_item_icon(p_idx, p_tex); }
+	virtual Ref<Texture2D> get_item_icon(int p_idx) const override { return il->get_item_icon(p_idx); }
 
-	virtual void set_item_enabled(int p_idx, int p_enabled) override { pp->set_item_disabled(p_idx, !p_enabled); }
-	virtual bool is_item_enabled(int p_idx) const override { return !pp->is_item_disabled(p_idx); }
+	virtual void set_item_enabled(int p_idx, int p_enabled) override { il->set_item_disabled(p_idx, !p_enabled); }
+	virtual bool is_item_enabled(int p_idx) const override { return !il->is_item_disabled(p_idx); }
 
 	virtual void add_item() override;
 	virtual int get_item_count() const override;
@@ -193,28 +192,23 @@ public:
 
 ///////////////////////////////////////////////////////////////
 
-class ItemListEditor : public HBoxContainer {
-	GDCLASS(ItemListEditor, HBoxContainer);
+class ItemListEditor : public VBoxContainer {
+	GDCLASS(ItemListEditor, VBoxContainer);
 
 	Node *item_list;
 
-	Button *toolbar_button;
-
-	AcceptDialog *dialog;
 	EditorInspector *property_editor;
-	Tree *tree;
 	Button *add_button;
 	Button *del_button;
 
-	int selected_idx;
+	int plugin_idx;
 
 	Vector<ItemListPlugin *> item_plugins;
-
-	void _edit_items();
 
 	void _add_pressed();
 	void _delete_pressed();
 
+	void _update_del_button(const String &p_path);
 	void _node_removed(Node *p_node);
 
 protected:
@@ -233,7 +227,6 @@ class ItemListEditorPlugin : public EditorPlugin {
 	GDCLASS(ItemListEditorPlugin, EditorPlugin);
 
 	ItemListEditor *item_list_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "ItemList"; }


### PR DESCRIPTION
See godotengine/godot-proposals#368 for the problem. This commit moves the ItemListEditor from a popup window to a side dock. Additionally, the delete button is now disabled if no item is selected.

**Explanation:**
When working with nodes that use an ItemList, the ItemListEditor is often used. It is found in a toolbar button, which wouldn't be bad if it was an infrequently used feature or if this wasn't the only editor (like for Sprite2D). Additionally, the toolbar button is easily missed, leading some users to add nodes as children of an ItemList. Moving the editor from the popup window to the sidedock should make it more clear how to use it, and doesn't require opening and closing popup windows. The portion of the screen that is taken up when selecting such a node can be justified by how essential this functionality is to an ItemList, and a popup window disables the whole editor anyway. 

![il_plugin2](https://user-images.githubusercontent.com/25907608/86007028-23736280-ba17-11ea-8f85-2162bcd69af6.PNG)

Other options were 
- highlighting the toolbar: doesn't solve much, as the popup window is still awkward to use.
- putting the editor in the inspector as a dictionary: makes the inspector too messy. 