### PR TITLE
Delete Nodes message

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -736,16 +736,27 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				_delete_confirm();
 
 			} else {
-				if (remove_list.size() >= 2) {
-					delete_dialog->set_text(vformat(TTR("Delete %d nodes?"), remove_list.size()));
-				} else if (remove_list.size() == 1 && remove_list[0] == editor_data->get_edited_scene_root()) {
-					delete_dialog->set_text(vformat(TTR("Delete the root node \"%s\"?"), remove_list[0]->get_name()));
-				} else if (remove_list.size() == 1 && remove_list[0]->get_filename() == "" && remove_list[0]->get_child_count() >= 1) {
-					// Display this message only for non-instanced scenes
-					delete_dialog->set_text(vformat(TTR("Delete node \"%s\" and its children?"), remove_list[0]->get_name()));
+				String msg;
+				if (remove_list.size() > 1) {
+					bool any_children = false;
+					for (int i = 0; !any_children && i < remove_list.size(); i++) {
+						any_children = remove_list[i]->get_child_count() > 0;
+					}
+
+					msg = vformat(any_children ? TTR("Delete %d nodes and any children?") : TTR("Delete %d nodes?"), remove_list.size());
 				} else {
-					delete_dialog->set_text(vformat(TTR("Delete node \"%s\"?"), remove_list[0]->get_name()));
+					Node *node = remove_list[0];
+					if (node == editor_data->get_edited_scene_root()) {
+						msg = vformat(TTR("Delete the root node \"%s\"?"), node->get_name());
+					} else if (node->get_filename() == "" && node->get_child_count() > 0) {
+						// Display this message only for non-instanced scenes
+						msg = vformat(TTR("Delete node \"%s\" and its children?"), node->get_name());
+					} else {
+						msg = vformat(TTR("Delete node \"%s\"?"), node->get_name());
+					}
 				}
+
+				delete_dialog->set_text(msg);
 
 				// Resize the dialog to its minimum size.
 				// This prevents the dialog from being too wide after displaying


### PR DESCRIPTION
Selecting multiple items didn't include any child nodes in the node count.
![delete](https://user-images.githubusercontent.com/25907608/86023458-fc735b80-ba2b-11ea-9662-cf94af6fcb0d.png)

Now it will display:
![delete2](https://user-images.githubusercontent.com/25907608/86023456-fbdac500-ba2b-11ea-8933-c75d69beac79.png)

As for the code: removed `size()==1`, since we already handled `size == 0` and `size > 1`.