### PR TITLE
Fix custom tracks causing issues on reimport

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -943,9 +943,9 @@ void ResourceImporterScene::_make_external_resources(Node *p_node, const String 
 				ERR_CONTINUE(anim.is_null());
 
 				if (!p_animations.has(anim)) {
-					// We are making external files so they are modifiable
+					// Tracks from source file should be set as imported, anything else is a custom track.
 					for (int i = 0; i < anim->get_track_count(); i++) {
-						anim->track_set_imported(i, false);
+						anim->track_set_imported(i, true);
 					}
 
 					String ext_name;
@@ -957,10 +957,9 @@ void ResourceImporterScene::_make_external_resources(Node *p_node, const String 
 					}
 
 					if (FileAccess::exists(ext_name) && p_keep_animations) {
-						//try to keep custom animation tracks
+						// Copy custom animation tracks from previously imported files.
 						Ref<Animation> old_anim = ResourceLoader::load(ext_name, "Animation", true);
 						if (old_anim.is_valid()) {
-							//meergeee
 							for (int i = 0; i < old_anim->get_track_count(); i++) {
 								if (!old_anim->track_is_imported(i)) {
 									old_anim->copy_track(i, anim);
@@ -970,7 +969,7 @@ void ResourceImporterScene::_make_external_resources(Node *p_node, const String 
 						}
 					}
 
-					anim->set_path(ext_name, true); //if not set, then its never saved externally
+					anim->set_path(ext_name, true); // Set path to save externally.
 					ResourceSaver::save(ext_name, anim, ResourceSaver::FLAG_CHANGE_PATH);
 					p_animations[anim] = anim;
 				}

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2577,7 +2577,10 @@ void Animation::copy_track(int p_track, Ref<Animation> p_to_animation) {
 	p_to_animation->track_set_enabled(dst_track, track_is_enabled(p_track));
 	p_to_animation->track_set_interpolation_type(dst_track, track_get_interpolation_type(p_track));
 	p_to_animation->track_set_interpolation_loop_wrap(dst_track, track_get_interpolation_loop_wrap(p_track));
-	p_to_animation->value_track_set_update_mode(dst_track, value_track_get_update_mode(p_track));
+	if (track_get_type(p_track) == TYPE_VALUE) {
+		p_to_animation->value_track_set_update_mode(dst_track, value_track_get_update_mode(p_track));
+	}
+
 	for (int i = 0; i < track_get_key_count(p_track); i++) {
 		p_to_animation->track_insert_key(dst_track, track_get_key_time(p_track, i), track_get_key_value(p_track, i), track_get_key_transition(p_track, i));
 	}


### PR DESCRIPTION
Upon importing a scene with custom tracks enabled, the importer was treating _all_ of the tracks as custom tracks, meaning that when reimported it would overwrite the tracks with the previously imported ones. I just deleted the bit of code that did that.

Also fixed an issue with copy_track in which it would try to copy a value track's update mode even if it wasn't a value track, which led to it printing a ton of error messages each time you reimported a scene.

(This is my first time contributing here by the way, let me know if I'm doing anything wrong)

*Bugsquad edit:* Fixes #39959.