### PR TITLE
[macOS export] Set correct external file attributes, and creation time.

### DIFF
--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -825,14 +825,15 @@ void EditorExportPlatformOSX::_zip_folder_recursive(zipFile &p_zip, const String
 			zipfi.tmz_date.tm_hour = time.hour;
 			zipfi.tmz_date.tm_mday = date.day;
 			zipfi.tmz_date.tm_min = time.min;
-			zipfi.tmz_date.tm_mon = date.month;
+			zipfi.tmz_date.tm_mon = date.month - 1; // Note: "tm" month range - 0..11, Godot month range - 1..12, http://www.cplusplus.com/reference/ctime/tm/
 			zipfi.tmz_date.tm_sec = time.sec;
 			zipfi.tmz_date.tm_year = date.year;
 			zipfi.dosDate = 0;
 			// 0100000: regular file type
 			// 0000755: permissions rwxr-xr-x
 			// 0000644: permissions rw-r--r--
-			zipfi.external_fa = (is_executable ? 0100755 : 0100644) << 16L;
+			uint32_t _mode = (is_executable ? 0100755 : 0100644);
+			zipfi.external_fa = (_mode << 16L) | !(_mode & 0200);
 			zipfi.internal_fa = 0;
 
 			zipOpenNewFileInZip4(p_zip,


### PR DESCRIPTION
Fixes file creation date (TM month range is 0…11, `OS::get_date()` month range is 1…12).
Fixes file attributes (lost +x flag, and broken files when extracting with macOS `Archive Utility`), do it like info-zip do: 
[unix/unix.c#L382](https://github.com/cysin/info-zip/blob/b4b2ab3c5ae0dce0a7c3884f364ad1fd15854d90/unix/unix.c#L382)

Fixes: #39931