### PR TITLE
Prevent setting a bad Node3D scale or transform

### DIFF
--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -51,6 +51,8 @@ public:
 	Basis inverse() const;
 	Basis transposed() const;
 
+	_FORCE_INLINE_ bool is_invertible() const;
+
 	_FORCE_INLINE_ real_t determinant() const;
 
 	void from_z(const Vector3 &p_z);
@@ -329,6 +331,10 @@ Vector3 Basis::xform_inv(const Vector3 &p_vector) const {
 			(elements[0][0] * p_vector.x) + (elements[1][0] * p_vector.y) + (elements[2][0] * p_vector.z),
 			(elements[0][1] * p_vector.x) + (elements[1][1] * p_vector.y) + (elements[2][1] * p_vector.z),
 			(elements[0][2] * p_vector.x) + (elements[1][2] * p_vector.y) + (elements[2][2] * p_vector.z));
+}
+
+bool Basis::is_invertible() const {
+	return determinant() != 0;
 }
 
 real_t Basis::determinant() const {

--- a/core/math/transform.h
+++ b/core/math/transform.h
@@ -46,6 +46,8 @@ public:
 	void affine_invert();
 	Transform affine_inverse() const;
 
+	_FORCE_INLINE_ bool is_invertible() const;
+
 	Transform rotated(const Vector3 &p_axis, real_t p_phi) const;
 
 	void rotate(const Vector3 &p_axis, real_t p_phi);
@@ -110,6 +112,10 @@ public:
 	Transform(const Basis &p_basis, const Vector3 &p_origin = Vector3());
 	Transform() {}
 };
+
+bool Transform::is_invertible() const {
+	return basis.is_invertible();
+}
 
 _FORCE_INLINE_ Vector3 Transform::xform(const Vector3 &p_vector) const {
 	return Vector3(

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -63,6 +63,10 @@ Transform2D Transform2D::affine_inverse() const {
 	return inv;
 }
 
+bool Transform2D::is_invertible() const {
+	return basis_determinant() != 0;
+}
+
 void Transform2D::rotate(real_t p_phi) {
 	*this = Transform2D(p_phi, Vector2()) * (*this);
 }

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -68,6 +68,8 @@ struct Transform2D {
 	void affine_invert();
 	Transform2D affine_inverse() const;
 
+	bool is_invertible() const;
+
 	void set_rotation(real_t p_rot);
 	real_t get_rotation() const;
 	real_t get_skew() const;

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -224,6 +224,10 @@ void Node3D::_notification(int p_what) {
 }
 
 void Node3D::set_transform(const Transform &p_transform) {
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND(!p_transform.is_invertible());
+#endif
+
 	data.local_transform = p_transform;
 	data.dirty |= DIRTY_VECTORS;
 	_change_notify("translation");
@@ -334,6 +338,10 @@ void Node3D::set_rotation_degrees(const Vector3 &p_euler_deg) {
 }
 
 void Node3D::set_scale(const Vector3 &p_scale) {
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_MSG(p_scale.x == 0 || p_scale.y == 0 || p_scale.z == 0, "Scale must not be 0");
+#endif
+
 	if (data.dirty & DIRTY_VECTORS) {
 		data.rotation = data.local_transform.basis.get_rotation();
 		data.dirty &= ~DIRTY_VECTORS;


### PR DESCRIPTION
Setting a scale to 0 or a transform with 0-determinant in Node3D will later lead to a division by 0 when the basis is inverted, or in best case error message spam if MATH_CHECKS is defined.

Fixes #32405