### PR TITLE
Add Control to preferred types in Create Dialog

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -350,17 +350,22 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			if (!profile_allow_editing) {
 				break;
 			}
-			String preferred = "";
-			Node *current_edited_scene_root = EditorNode::get_singleton()->get_edited_scene();
 
+			// Prefer nodes that inherit from the current scene root.
+			Node *current_edited_scene_root = EditorNode::get_singleton()->get_edited_scene();
 			if (current_edited_scene_root) {
-				if (ClassDB::is_parent_class(current_edited_scene_root->get_class_name(), "Node2D")) {
-					preferred = "Node2D";
-				} else if (ClassDB::is_parent_class(current_edited_scene_root->get_class_name(), "Node3D")) {
-					preferred = "Node3D";
+				static const String preferred_types[] = { "Node2D", "Node3D", "Control" };
+
+				StringName root_class = current_edited_scene_root->get_class_name();
+
+				for (int i = 0; i < preferred_types->size(); i++) {
+					if (ClassDB::is_parent_class(root_class, preferred_types[i])) {
+						create_dialog->set_preferred_search_result_type(preferred_types[i]);
+						break;
+					}
 				}
 			}
-			create_dialog->set_preferred_search_result_type(preferred);
+
 			create_dialog->popup_create(true);
 		} break;
 		case TOOL_INSTANCE: {


### PR DESCRIPTION
If the scene root inherited from Node2D/Node3D, search results would be biased towards those kind of types. This commit adds the same behaviour for Control nodes.
![pref2](https://user-images.githubusercontent.com/25907608/86114689-2f206100-bacb-11ea-8128-507c689db733.png)
