### PR TITLE
Revert "Adds fuzzy search for help search dialog"

### DIFF
--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -332,17 +332,10 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 			if (search_flags & SEARCH_METHODS) {
 				for (int i = 0; i < class_doc.methods.size(); i++) {
 					String method_name = (search_flags & SEARCH_CASE_SENSITIVE) ? class_doc.methods[i].name : class_doc.methods[i].name.to_lower();
-					String aux_term = (search_flags & SEARCH_CASE_SENSITIVE) ? term : term.to_lower();
-
-					if (aux_term.begins_with(".")) {
-						aux_term = aux_term.right(1);
-					}
-
-					if (aux_term.ends_with("(")) {
-						aux_term = aux_term.left(aux_term.length() - 1).strip_edges();
-					}
-
-					if (aux_term.is_subsequence_of(method_name)) {
+					if (method_name.find(term) > -1 ||
+							(term.begins_with(".") && method_name.begins_with(term.right(1))) ||
+							(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
+							(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
 						match.methods.push_back(const_cast<DocData::MethodDoc *>(&class_doc.methods[i]));
 					}
 				}
@@ -448,9 +441,9 @@ bool EditorHelpSearch::Runner::_phase_select_match() {
 
 bool EditorHelpSearch::Runner::_match_string(const String &p_term, const String &p_string) const {
 	if (search_flags & SEARCH_CASE_SENSITIVE) {
-		return p_term.is_subsequence_of(p_string);
+		return p_string.find(p_term) > -1;
 	} else {
-		return p_term.is_subsequence_ofi(p_string);
+		return p_string.findn(p_term) > -1;
 	}
 }
 


### PR DESCRIPTION
This reverts commit 481dbceed0d0610a6c689e3be448b7953994763e.

Current fuzzy search implementation results in too many
non-useful results.

Could be re-added after result sort/filter/score functionality
is added. See #30072 for example existing implementation.

Fixes: #39128

Reverts: #32043

Fixed format style conflicts:
 * `editor/editor_help_search.cpp`