### PR TITLE
Make dialogs exclusive by default, fixes #37732

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -51,7 +51,9 @@ void AcceptDialog::_input_from_window(const Ref<InputEvent> &p_event) {
 }
 
 void AcceptDialog::_parent_focused() {
-	_cancel_pressed();
+	if (!is_exclusive()) {
+		_cancel_pressed();
+	}
 }
 
 void AcceptDialog::_notification(int p_what) {
@@ -295,6 +297,7 @@ AcceptDialog::AcceptDialog() {
 	set_wrap_controls(true);
 	set_visible(false);
 	set_transient(true);
+	set_exclusive(true);
 
 	bg = memnew(Panel);
 	add_child(bg);

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -44,6 +44,7 @@ class LineEdit;
 class AcceptDialog : public Window {
 	GDCLASS(AcceptDialog, Window);
 
+public:
 	Window *parent_visible;
 	Panel *bg;
 	HBoxContainer *hbc;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -398,6 +398,18 @@ void Window::set_visible(bool p_visible) {
 	emit_signal(SceneStringNames::get_singleton()->visibility_changed);
 
 	RS::get_singleton()->viewport_set_active(get_viewport_rid(), visible);
+
+	//update transient exclusive
+	if (transient_parent) {
+		if (exclusive && visible) {
+			ERR_FAIL_COND_MSG(transient_parent->exclusive_child && transient_parent->exclusive_child != this, "Transient parent has another exclusive child.");
+			transient_parent->exclusive_child = this;
+		} else {
+			if (transient_parent->exclusive_child == this) {
+				transient_parent->exclusive_child = nullptr;
+			}
+		}
+	}
 }
 
 void Window::_clear_transient() {


### PR DESCRIPTION
Also fix on set_visible, not creating exclusive children as it should.

The idea is that if you open a transient dialog (a dialog that is spawned from a parent window) by default you are not allowed to do changes in the parent window until this dialog is closed. Likewise, the dialog will not close if you focus in/out as it is now an exclusive dialog.

*Bugsquad edit:* Fixes #37732. Also fixes #37731 and fixes #37710