### PR TITLE
Make "Close and save changes?" actually save

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -538,7 +538,7 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save, bool p_history_back) {
 	ScriptEditorBase *current = Object::cast_to<ScriptEditorBase>(tab_container->get_child(selected));
 	if (current) {
 		if (p_save) {
-			apply_scripts();
+			_menu_option(FILE_SAVE);
 		}
 
 		Ref<Script> script = current->get_edited_resource();


### PR DESCRIPTION
This fixes #39844, where the confirmation dialog when a user attempts to close an unsaved script did not actually save it even after clicking "Save."

Also a newbie question: Should I be contributing to the master or 3.2 branch?