### PR TITLE
Fix overflow and underflow checks for string conversion to int

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1650,8 +1650,9 @@ int64_t String::hex_to_int(bool p_with_prefix) const {
 		} else {
 			return 0;
 		}
-
-		ERR_FAIL_COND_V_MSG(hex > INT64_MAX / 16, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as 64-bit integer, provided value is " + (sign == 1 ? "too big." : "too small."));
+		// Check for overflow/underflow, with special case to ensure INT64_MIN does not result in error
+		bool overflow = ((hex > INT64_MAX / 16) && (sign == 1 || (sign == -1 && hex != (INT64_MAX >> 4) + 1))) || (sign == -1 && hex == (INT64_MAX >> 4) + 1 && c > '0');
+		ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as 64-bit integer, provided value is " + (sign == 1 ? "too big." : "too small."));
 		hex *= 16;
 		hex += n;
 		s++;
@@ -1690,8 +1691,9 @@ int64_t String::bin_to_int(bool p_with_prefix) const {
 		} else {
 			return 0;
 		}
-
-		ERR_FAIL_COND_V_MSG(binary > INT64_MAX / 2, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as 64-bit integer, provided value is " + (sign == 1 ? "too big." : "too small."));
+		// Check for overflow/underflow, with special case to ensure INT64_MIN does not result in error
+		bool overflow = ((binary > INT64_MAX / 2) && (sign == 1 || (sign == -1 && binary != (INT64_MAX >> 1) + 1))) || (sign == -1 && binary == (INT64_MAX >> 1) + 1 && c > '0');
+		ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as 64-bit integer, provided value is " + (sign == 1 ? "too big." : "too small."));
 		binary *= 2;
 		binary += n;
 		s++;
@@ -1713,7 +1715,8 @@ int64_t String::to_int() const {
 	for (int i = 0; i < to; i++) {
 		CharType c = operator[](i);
 		if (c >= '0' && c <= '9') {
-			ERR_FAIL_COND_V_MSG(integer > INT64_MAX / 10, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as an integer, provided value is " + (sign == 1 ? "too big." : "too small."));
+			bool overflow = (integer > INT64_MAX / 10) || (integer == INT64_MAX / 10 && ((sign == 1 && c > '7') || (sign == -1 && c > '8')));
+			ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + *this + " as 64-bit integer, provided value is " + (sign == 1 ? "too big." : "too small."));
 			integer *= 10;
 			integer += c - '0';
 
@@ -1741,7 +1744,8 @@ int64_t String::to_int(const char *p_str, int p_len) {
 	for (int i = 0; i < to; i++) {
 		char c = p_str[i];
 		if (c >= '0' && c <= '9') {
-			ERR_FAIL_COND_V_MSG(integer > INT64_MAX / 10, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + String(p_str).substr(0, to) + " as an integer, provided value is " + (sign == 1 ? "too big." : "too small."));
+			bool overflow = (integer > INT64_MAX / 10) || (integer == INT64_MAX / 10 && ((sign == 1 && c > '7') || (sign == -1 && c > '8')));
+			ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + String(p_str).substr(0, to) + " as integer, provided value is " + (sign == 1 ? "too big." : "too small."));
 			integer *= 10;
 			integer += c - '0';
 


### PR DESCRIPTION
Current error checks for `String::to_int` and `String::to_int64` do not detect overflow for numbers like `INT(32/64)_MAX + 1`
and `INT(32/64)_MAX + 2` that are close to the integer limits, e.g.
```
var x_str = "-2147483649"
print(x_str.to_int())
```

Secondly,  error checks for `hex_to_int`, `hex_to_int64` and `bin_to_int64` issue false positive error messages
for `INT64_MIN` or `INT32_MIN` and clamp the values, e.g.
```
var x_str = "-0x80000000"
print(x_str.hex_to_int()) #issues error, clamps value to -0x7fffffff
```

This commit fixes these error checks. The new code is not the most elegant, but should take care of these edge cases.

Sample test script: [overflow.zip](https://github.com/godotengine/godot/files/4856803/overflow.zip)
