### PR TITLE
Added const qualifier support for function arguments in shaders

### DIFF
--- a/drivers/gles2/shader_compiler_gles2.cpp
+++ b/drivers/gles2/shader_compiler_gles2.cpp
@@ -247,6 +247,9 @@ void ShaderCompilerGLES2::_dump_function_deps(SL::ShaderNode *p_node, const Stri
 		for (int i = 0; i < fnode->arguments.size(); i++) {
 			if (i > 0)
 				header += ", ";
+			if (fnode->arguments[i].is_const) {
+				header += "const ";
+			}
 			if (fnode->arguments[i].type == SL::TYPE_STRUCT) {
 				header += _qualstr(fnode->arguments[i].qualifier) + _mkid(fnode->arguments[i].type_str) + " " + _mkid(fnode->arguments[i].name);
 			} else {

--- a/servers/rendering/rasterizer_rd/shader_compiler_rd.cpp
+++ b/servers/rendering/rasterizer_rd/shader_compiler_rd.cpp
@@ -399,6 +399,9 @@ void ShaderCompilerRD::_dump_function_deps(const SL::ShaderNode *p_node, const S
 			if (i > 0) {
 				header += ", ";
 			}
+			if (fnode->arguments[i].is_const) {
+				header += "const ";
+			}
 			if (fnode->arguments[i].type == SL::TYPE_STRUCT) {
 				header += _qualstr(fnode->arguments[i].qualifier) + _mkid(fnode->arguments[i].type_str) + " " + _mkid(fnode->arguments[i].name);
 			} else {

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -554,6 +554,7 @@ public:
 			TextureRepeat tex_argument_repeat;
 			bool tex_builtin_check;
 			StringName tex_builtin;
+			bool is_const;
 
 			Map<StringName, Set<int>> tex_argument_connect;
 		};


### PR DESCRIPTION
Allow 'const' qualifier in shader function declaration like:

```
void test(const int t){
}
```