### PR TITLE
Make popups appear on same monitor as parent window

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -969,7 +969,7 @@ void Window::popup_centered_clamped(const Size2i &p_size, float p_fallback_ratio
 
 	Rect2i popup_rect;
 	popup_rect.size = Vector2i(MIN(size_ratio.x, p_size.x), MIN(size_ratio.y, p_size.y));
-	popup_rect.position = (parent_rect.size - popup_rect.size) / 2;
+	popup_rect.position = (parent_rect.size - popup_rect.size) / 2 + parent_rect.position;
 
 	popup(popup_rect);
 }
@@ -995,7 +995,7 @@ void Window::popup_centered(const Size2i &p_minsize) {
 	} else {
 		popup_rect.size = p_minsize;
 	}
-	popup_rect.position = (parent_rect.size - popup_rect.size) / 2;
+	popup_rect.position = (parent_rect.size - popup_rect.size) / 2 + parent_rect.position;
 
 	popup(popup_rect);
 }
@@ -1017,7 +1017,7 @@ void Window::popup_centered_ratio(float p_ratio) {
 
 	Rect2i popup_rect;
 	popup_rect.size = parent_rect.size * p_ratio;
-	popup_rect.position = (parent_rect.size - popup_rect.size) / 2;
+	popup_rect.position = (parent_rect.size - popup_rect.size) / 2 + parent_rect.position;
 
 	popup(popup_rect);
 }


### PR DESCRIPTION
Popups appear on the left-most monitor in multi-monitor setups.

This PR offsets the popup's position by the position of the screen of the parent window.

EDIT: I've only tested this on X11, the handling of monitors may differ on other platforms.