### PR TITLE
Environment: Refactor code for readability + more

### DIFF
--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -67,6 +67,7 @@
 		<member name="dialog_text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
 			The text displayed by the dialog.
 		</member>
+		<member name="exclusive" type="bool" setter="set_exclusive" getter="is_exclusive" override="true" default="true" />
 		<member name="title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Alert!&quot;" />
 		<member name="transient" type="bool" setter="set_transient" getter="is_transient" override="true" default="true" />
 		<member name="visible" type="bool" setter="set_visible" getter="is_visible" override="true" default="false" />

--- a/doc/classes/CameraEffects.xml
+++ b/doc/classes/CameraEffects.xml
@@ -34,9 +34,9 @@
 			The length of the transition between the near blur and no-blur area.
 		</member>
 		<member name="override_exposure" type="float" setter="set_override_exposure" getter="get_override_exposure" default="1.0">
-			The exposure override value to use. Higher values will result in a brighter scene. Only effective if [member override_exposure_enable] is [code]true[/code].
+			The exposure override value to use. Higher values will result in a brighter scene. Only effective if [member override_exposure_enabled] is [code]true[/code].
 		</member>
-		<member name="override_exposure_enable" type="bool" setter="set_override_exposure_enabled" getter="is_override_exposure_enabled" default="false">
+		<member name="override_exposure_enabled" type="bool" setter="set_override_exposure_enabled" getter="is_override_exposure_enabled" default="false">
 			If [code]true[/code], overrides the manual or automatic exposure defined in the [Environment] with the value in [member override_exposure].
 		</member>
 	</members>

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -44,9 +44,9 @@
 			</return>
 			<argument index="0" name="mode" type="int" enum="DisplayServer.WindowMode">
 			</argument>
-			<argument index="1" name="rect" type="int">
+			<argument index="1" name="flags" type="int">
 			</argument>
-			<argument index="2" name="arg2" type="Rect2i" default="Rect2i( 0, 0, 0, 0 )">
+			<argument index="2" name="rect" type="Rect2i" default="Rect2i( 0, 0, 0, 0 )">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -24,7 +24,7 @@
 				Returns [code]true[/code] if the glow level [code]idx[/code] is specified, [code]false[/code] otherwise.
 			</description>
 		</method>
-		<method name="set_glow_level">
+		<method name="set_glow_level_enabled">
 			<return type="void">
 			</return>
 			<argument index="0" name="idx" type="int">
@@ -46,7 +46,7 @@
 		<member name="adjustment_contrast" type="float" setter="set_adjustment_contrast" getter="get_adjustment_contrast" default="1.0">
 			The global contrast value of the rendered scene (default value is 1). Effective only if [code]adjustment_enabled[/code] is [code]true[/code].
 		</member>
-		<member name="adjustment_enabled" type="bool" setter="set_adjustment_enable" getter="is_adjustment_enabled" default="false">
+		<member name="adjustment_enabled" type="bool" setter="set_adjustment_enabled" getter="is_adjustment_enabled" default="false">
 			If [code]true[/code], enables the [code]adjustment_*[/code] properties provided by this resource. If [code]false[/code], modifications to the [code]adjustment_*[/code] properties will have no effect on the rendered scene.
 		</member>
 		<member name="adjustment_saturation" type="float" setter="set_adjustment_saturation" getter="get_adjustment_saturation" default="1.0">
@@ -65,7 +65,7 @@
 		</member>
 		<member name="ambient_light_source" type="int" setter="set_ambient_source" getter="get_ambient_source" enum="Environment.AmbientSource" default="0">
 		</member>
-		<member name="auto_exposure_enabled" type="bool" setter="set_tonemap_auto_exposure" getter="get_tonemap_auto_exposure" default="false">
+		<member name="auto_exposure_enabled" type="bool" setter="set_tonemap_auto_exposure_enabled" getter="is_tonemap_auto_exposure_enabled" default="false">
 			If [code]true[/code], enables the tonemapping auto exposure mode of the scene renderer. If [code]true[/code], the renderer will automatically determine the exposure setting to adapt to the scene's illumination and the observed light.
 		</member>
 		<member name="auto_exposure_max_luma" type="float" setter="set_tonemap_auto_exposure_max" getter="get_tonemap_auto_exposure_max" default="8.0">
@@ -158,25 +158,25 @@
 		<member name="glow_intensity" type="float" setter="set_glow_intensity" getter="get_glow_intensity" default="0.8">
 			The glow intensity. When using the GLES2 renderer, this should be increased to 1.5 to compensate for the lack of HDR rendering.
 		</member>
-		<member name="glow_levels/1" type="bool" setter="set_glow_level" getter="is_glow_level_enabled" default="false">
+		<member name="glow_levels/1" type="bool" setter="set_glow_level_enabled" getter="is_glow_level_enabled" default="false">
 			If [code]true[/code], the 1st level of glow is enabled. This is the most "local" level (least blurry).
 		</member>
-		<member name="glow_levels/2" type="bool" setter="set_glow_level" getter="is_glow_level_enabled" default="false">
+		<member name="glow_levels/2" type="bool" setter="set_glow_level_enabled" getter="is_glow_level_enabled" default="false">
 			If [code]true[/code], the 2th level of glow is enabled.
 		</member>
-		<member name="glow_levels/3" type="bool" setter="set_glow_level" getter="is_glow_level_enabled" default="true">
+		<member name="glow_levels/3" type="bool" setter="set_glow_level_enabled" getter="is_glow_level_enabled" default="true">
 			If [code]true[/code], the 3th level of glow is enabled.
 		</member>
-		<member name="glow_levels/4" type="bool" setter="set_glow_level" getter="is_glow_level_enabled" default="false">
+		<member name="glow_levels/4" type="bool" setter="set_glow_level_enabled" getter="is_glow_level_enabled" default="false">
 			If [code]true[/code], the 4th level of glow is enabled.
 		</member>
-		<member name="glow_levels/5" type="bool" setter="set_glow_level" getter="is_glow_level_enabled" default="true">
+		<member name="glow_levels/5" type="bool" setter="set_glow_level_enabled" getter="is_glow_level_enabled" default="true">
 			If [code]true[/code], the 5th level of glow is enabled.
 		</member>
-		<member name="glow_levels/6" type="bool" setter="set_glow_level" getter="is_glow_level_enabled" default="false">
+		<member name="glow_levels/6" type="bool" setter="set_glow_level_enabled" getter="is_glow_level_enabled" default="false">
 			If [code]true[/code], the 6th level of glow is enabled.
 		</member>
-		<member name="glow_levels/7" type="bool" setter="set_glow_level" getter="is_glow_level_enabled" default="false">
+		<member name="glow_levels/7" type="bool" setter="set_glow_level_enabled" getter="is_glow_level_enabled" default="false">
 			If [code]true[/code], the 7th level of glow is enabled. This is the most "global" level (blurriest).
 		</member>
 		<member name="glow_mix" type="float" setter="set_glow_mix" getter="get_glow_mix" default="0.05">
@@ -185,6 +185,30 @@
 			The glow strength. When using the GLES2 renderer, this should be increased to 1.3 to compensate for the lack of HDR rendering.
 		</member>
 		<member name="reflected_light_source" type="int" setter="set_reflection_source" getter="get_reflection_source" enum="Environment.ReflectionSource" default="0">
+		</member>
+		<member name="sdfgi_cascade0_distance" type="float" setter="set_sdfgi_cascade0_distance" getter="get_sdfgi_cascade0_distance" default="12.8">
+		</member>
+		<member name="sdfgi_cascades" type="int" setter="set_sdfgi_cascades" getter="get_sdfgi_cascades" enum="Environment.SDFGICascades" default="1">
+		</member>
+		<member name="sdfgi_enabled" type="bool" setter="set_sdfgi_enabled" getter="is_sdfgi_enabled" default="false">
+		</member>
+		<member name="sdfgi_energy" type="float" setter="set_sdfgi_energy" getter="get_sdfgi_energy" default="1.0">
+		</member>
+		<member name="sdfgi_max_distance" type="float" setter="set_sdfgi_max_distance" getter="get_sdfgi_max_distance" default="819.2">
+		</member>
+		<member name="sdfgi_min_cell_size" type="float" setter="set_sdfgi_min_cell_size" getter="get_sdfgi_min_cell_size" default="0.2">
+		</member>
+		<member name="sdfgi_normal_bias" type="float" setter="set_sdfgi_normal_bias" getter="get_sdfgi_normal_bias" default="1.1">
+		</member>
+		<member name="sdfgi_probe_bias" type="float" setter="set_sdfgi_probe_bias" getter="get_sdfgi_probe_bias" default="1.1">
+		</member>
+		<member name="sdfgi_read_sky_light" type="bool" setter="set_sdfgi_read_sky_light" getter="is_sdfgi_reading_sky_light" default="false">
+		</member>
+		<member name="sdfgi_use_multi_bounce" type="bool" setter="set_sdfgi_use_multi_bounce" getter="is_sdfgi_using_multi_bounce" default="false">
+		</member>
+		<member name="sdfgi_use_occlusion" type="bool" setter="set_sdfgi_use_occlusion" getter="is_sdfgi_using_occlusion" default="false">
+		</member>
+		<member name="sdfgi_y_scale" type="int" setter="set_sdfgi_y_scale" getter="get_sdfgi_y_scale" enum="Environment.SDFGIYScale" default="0">
 		</member>
 		<member name="sky" type="Sky" setter="set_sky" getter="get_sky">
 			The [Sky] resource used for this [Environment].
@@ -285,6 +309,18 @@
 		<constant name="REFLECTION_SOURCE_SKY" value="2" enum="ReflectionSource">
 			Use the [Sky] for reflections regardless of what the background is.
 		</constant>
+		<constant name="TONE_MAPPER_LINEAR" value="0" enum="ToneMapper">
+			Linear tonemapper operator. Reads the linear data and passes it on unmodified.
+		</constant>
+		<constant name="TONE_MAPPER_REINHARDT" value="1" enum="ToneMapper">
+			Reinhardt tonemapper operator. Performs a variation on rendered pixels' colors by this formula: [code]color = color / (1 + color)[/code].
+		</constant>
+		<constant name="TONE_MAPPER_FILMIC" value="2" enum="ToneMapper">
+			Filmic tonemapper operator.
+		</constant>
+		<constant name="TONE_MAPPER_ACES" value="3" enum="ToneMapper">
+			Academy Color Encoding System tonemapper operator.
+		</constant>
 		<constant name="GLOW_BLEND_MODE_ADDITIVE" value="0" enum="GlowBlendMode">
 			Additive glow blending mode. Mostly used for particles, glows (bloom), lens flare, bright sources.
 		</constant>
@@ -300,18 +336,6 @@
 		<constant name="GLOW_BLEND_MODE_MIX" value="4" enum="GlowBlendMode">
 			Mixes the glow with the underlying color to avoid increasing brightness as much while still maintaining a glow effect.
 		</constant>
-		<constant name="TONE_MAPPER_LINEAR" value="0" enum="ToneMapper">
-			Linear tonemapper operator. Reads the linear data and passes it on unmodified.
-		</constant>
-		<constant name="TONE_MAPPER_REINHARDT" value="1" enum="ToneMapper">
-			Reinhardt tonemapper operator. Performs a variation on rendered pixels' colors by this formula: [code]color = color / (1 + color)[/code].
-		</constant>
-		<constant name="TONE_MAPPER_FILMIC" value="2" enum="ToneMapper">
-			Filmic tonemapper operator.
-		</constant>
-		<constant name="TONE_MAPPER_ACES" value="3" enum="ToneMapper">
-			Academy Color Encoding System tonemapper operator.
-		</constant>
 		<constant name="SSAO_BLUR_DISABLED" value="0" enum="SSAOBlur">
 			No blur for the screen-space ambient occlusion effect (fastest).
 		</constant>
@@ -323,6 +347,18 @@
 		</constant>
 		<constant name="SSAO_BLUR_3x3" value="3" enum="SSAOBlur">
 			3×3 blur for the screen-space ambient occlusion effect. Increases the radius of the blur for a smoother look, but can result in checkerboard-like artifacts.
+		</constant>
+		<constant name="SDFGI_CASCADES_4" value="0" enum="SDFGICascades">
+		</constant>
+		<constant name="SDFGI_CASCADES_6" value="1" enum="SDFGICascades">
+		</constant>
+		<constant name="SDFGI_CASCADES_8" value="2" enum="SDFGICascades">
+		</constant>
+		<constant name="SDFGI_Y_SCALE_DISABLED" value="0" enum="SDFGIYScale">
+		</constant>
+		<constant name="SDFGI_Y_SCALE_75_PERCENT" value="1" enum="SDFGIYScale">
+		</constant>
+		<constant name="SDFGI_Y_SCALE_50_PERCENT" value="2" enum="SDFGIYScale">
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/FileSystemDock.xml
+++ b/doc/classes/FileSystemDock.xml
@@ -10,11 +10,11 @@
 		<method name="can_drop_data_fw" qualifiers="const">
 			<return type="bool">
 			</return>
-			<argument index="0" name="arg0" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
-			<argument index="1" name="arg1" type="Variant">
+			<argument index="1" name="data" type="Variant">
 			</argument>
-			<argument index="2" name="arg2" type="Control">
+			<argument index="2" name="from" type="Control">
 			</argument>
 			<description>
 			</description>
@@ -22,11 +22,11 @@
 		<method name="drop_data_fw">
 			<return type="void">
 			</return>
-			<argument index="0" name="arg0" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
-			<argument index="1" name="arg1" type="Variant">
+			<argument index="1" name="data" type="Variant">
 			</argument>
-			<argument index="2" name="arg2" type="Control">
+			<argument index="2" name="from" type="Control">
 			</argument>
 			<description>
 			</description>
@@ -34,9 +34,9 @@
 		<method name="get_drag_data_fw">
 			<return type="Variant">
 			</return>
-			<argument index="0" name="arg0" type="Vector2">
+			<argument index="0" name="position" type="Vector2">
 			</argument>
-			<argument index="1" name="arg1" type="Control">
+			<argument index="1" name="from" type="Control">
 			</argument>
 			<description>
 			</description>
@@ -44,7 +44,7 @@
 		<method name="navigate_to_path">
 			<return type="void">
 			</return>
-			<argument index="0" name="arg0" type="String">
+			<argument index="0" name="path" type="String">
 			</argument>
 			<description>
 			</description>

--- a/doc/classes/GIProbe.xml
+++ b/doc/classes/GIProbe.xml
@@ -19,7 +19,7 @@
 			<argument index="1" name="create_visual_debug" type="bool" default="false">
 			</argument>
 			<description>
-				Bakes the effect from all [GeometryInstance3D]s marked with [constant GeometryInstance3D.GI_MODE_BAKED] and [Light3D]s marked with either [constant Light3D.BAKE_INDIRECT] or [constant Light3D.BAKE_ALL]. If [code]create_visual_debug[/code] is [code]true[/code], after baking the light, this will generate a [MultiMesh] that has a cube representing each solid cell with each cube colored to the cell's albedo color. This can be used to visualize the [GIProbe]'s data and debug any issues that may be occurring.
+				Bakes the effect from all [GeometryInstance3D]s marked with [constant GeometryInstance3D.GI_MODE_BAKED] and [Light3D]s marked with either [constant Light3D.BAKE_DYNAMIC] or [constant Light3D.BAKE_STATIC]. If [code]create_visual_debug[/code] is [code]true[/code], after baking the light, this will generate a [MultiMesh] that has a cube representing each solid cell with each cube colored to the cell's albedo color. This can be used to visualize the [GIProbe]'s data and debug any issues that may be occurring.
 			</description>
 		</method>
 		<method name="debug_bake">

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -364,6 +364,15 @@
 				Loads an image from the binary contents of a PNG file.
 			</description>
 		</method>
+		<method name="load_tga_from_buffer">
+			<return type="int" enum="Error">
+			</return>
+			<argument index="0" name="buffer" type="PackedByteArray">
+			</argument>
+			<description>
+				Loads an image from the binary contents of a TGA file.
+			</description>
+		</method>
 		<method name="load_webp_from_buffer">
 			<return type="int" enum="Error">
 			</return>

--- a/doc/classes/Light3D.xml
+++ b/doc/classes/Light3D.xml
@@ -148,12 +148,9 @@
 			Light is ignored when baking.
 			[b]Note:[/b] Hiding a light does [i]not[/i] affect baking.
 		</constant>
-		<constant name="BAKE_INDIRECT" value="1" enum="BakeMode">
-			Only indirect lighting will be baked (default).
+		<constant name="BAKE_DYNAMIC" value="1" enum="BakeMode">
 		</constant>
-		<constant name="BAKE_ALL" value="2" enum="BakeMode">
-			Both direct and indirect light will be baked.
-			[b]Note:[/b] You should hide the light if you don't want it to appear twice (dynamic and baked).
+		<constant name="BAKE_STATIC" value="2" enum="BakeMode">
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/MainLoop.xml
+++ b/doc/classes/MainLoop.xml
@@ -142,13 +142,21 @@
 			Notification received from the OS when an update of the Input Method Engine occurs (e.g. change of IME cursor position or composition string).
 			Specific to the macOS platform.
 		</constant>
-		<constant name="NOTIFICATION_APP_RESUMED" value="2014">
-			Notification received from the OS when the app is resumed.
+		<constant name="NOTIFICATION_APPLICATION_RESUMED" value="2014">
+			Notification received from the OS when the application is resumed.
 			Specific to the Android platform.
 		</constant>
-		<constant name="NOTIFICATION_APP_PAUSED" value="2015">
-			Notification received from the OS when the app is paused.
+		<constant name="NOTIFICATION_APPLICATION_PAUSED" value="2015">
+			Notification received from the OS when the application is paused.
 			Specific to the Android platform.
+		</constant>
+		<constant name="NOTIFICATION_APPLICATION_FOCUS_IN" value="2016">
+			Notification received from the OS when the application is focused, i.e. when changing the focus from the OS desktop or a thirdparty application to any open window of the Godot instance.
+			Implemented on desktop platforms.
+		</constant>
+		<constant name="NOTIFICATION_APPLICATION_FOCUS_OUT" value="2017">
+			Notification received from the OS when the application is defocused, i.e. when changing the focus from any open window of the Godot instance to the OS desktop or a thirdparty application.
+			Implemented on desktop platforms.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -926,13 +926,11 @@
 			Notification received from the OS when the mouse leaves the game window.
 			Implemented on desktop and web platforms.
 		</constant>
-		<constant name="NOTIFICATION_WM_FOCUS_IN" value="1004">
-			Notification received from the OS when the game window is focused.
-			Implemented on all platforms.
+		<constant name="NOTIFICATION_WM_WINDOW_FOCUS_IN" value="1004">
+			Notification received from the OS when the node's parent [Window] is focused. This may be a change of focus between two windows of the same engine instance, or from the OS desktop or a third-party application to a window of the game (in which case [constant NOTIFICATION_APPLICATION_FOCUS_IN] is also emitted).
 		</constant>
-		<constant name="NOTIFICATION_WM_FOCUS_OUT" value="1005">
-			Notification received from the OS when the game window is unfocused.
-			Implemented on all platforms.
+		<constant name="NOTIFICATION_WM_WINDOW_FOCUS_OUT" value="1005">
+			Notification received from the OS when the node's parent [Window] is defocused. This may be a change of focus between two windows of the same engine instance, or from a window of the game to the OS desktop or a third-party application (in which case [constant NOTIFICATION_APPLICATION_FOCUS_OUT] is also emitted).
 		</constant>
 		<constant name="NOTIFICATION_WM_CLOSE_REQUEST" value="1006">
 			Notification received from the OS when a close request is sent (e.g. closing the window with a "Close" button or [kbd]Alt + F4[/kbd]).
@@ -963,13 +961,21 @@
 			Notification received from the OS when an update of the Input Method Engine occurs (e.g. change of IME cursor position or composition string).
 			Specific to the macOS platform.
 		</constant>
-		<constant name="NOTIFICATION_APP_RESUMED" value="2014">
-			Notification received from the OS when the app is resumed.
+		<constant name="NOTIFICATION_APPLICATION_RESUMED" value="2014">
+			Notification received from the OS when the application is resumed.
 			Specific to the Android platform.
 		</constant>
-		<constant name="NOTIFICATION_APP_PAUSED" value="2015">
-			Notification received from the OS when the app is paused.
+		<constant name="NOTIFICATION_APPLICATION_PAUSED" value="2015">
+			Notification received from the OS when the application is paused.
 			Specific to the Android platform.
+		</constant>
+		<constant name="NOTIFICATION_APPLICATION_FOCUS_IN" value="2016">
+			Notification received from the OS when the application is focused, i.e. when changing the focus from the OS desktop or a thirdparty application to any open window of the Godot instance.
+			Implemented on desktop platforms.
+		</constant>
+		<constant name="NOTIFICATION_APPLICATION_FOCUS_OUT" value="2017">
+			Notification received from the OS when the application is defocused, i.e. when changing the focus from any open window of the Godot instance to the OS desktop or a thirdparty application.
+			Implemented on desktop platforms.
 		</constant>
 		<constant name="PAUSE_MODE_INHERIT" value="0" enum="PauseMode">
 			Inherits pause mode from the node's parent. For the root node, it is equivalent to [constant PAUSE_MODE_STOP]. Default.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1078,13 +1078,13 @@
 		</member>
 		<member name="rendering/quality/screen_filters/screen_space_aa" type="int" setter="" getter="" default="0">
 			Sets the screen-space antialiasing mode for the default screen [Viewport]. Screen-space antialiasing works by selectively blurring edges in a post-process shader. It differs from MSAA which takes multiple coverage samples while rendering objects. Screen-space AA methods are typically faster than MSAA and will smooth out specular aliasing, but tend to make scenes appear blurry.
-			Another way to combat specular aliasing is to enable [member rendering/quality/screen_filters/screen_space_roughness_limiter].
+			Another way to combat specular aliasing is to enable [member rendering/quality/screen_filters/screen_space_roughness_limiter_enabled].
 		</member>
-		<member name="rendering/quality/screen_filters/screen_space_roughness_limiter" type="int" setter="" getter="" default="0">
-			Enables the screen-space roughness limiter which increases material roughness in areas with a high normal frequency (i.e. when normals change a lot from pixel to pixel). This helps to reduce the amount of specular aliasing in a scene. Specular aliasing looks like random bright pixels that occur in reflections.
+		<member name="rendering/quality/screen_filters/screen_space_roughness_limiter_amount" type="float" setter="" getter="" default="0.25">
 		</member>
-		<member name="rendering/quality/screen_filters/screen_space_roughness_limiter_curve" type="float" setter="" getter="" default="1.0">
-			Curves the amount of the roughness limited effect. A higher value limits the effect to very sharply curved surfaces, while a lower threshold extends the effect to smoother surfaces.
+		<member name="rendering/quality/screen_filters/screen_space_roughness_limiter_enabled" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="rendering/quality/screen_filters/screen_space_roughness_limiter_limit" type="float" setter="" getter="" default="0.18">
 		</member>
 		<member name="rendering/quality/screen_space_reflection/roughness_quality" type="int" setter="" getter="" default="1">
 			Sets the quality for rough screen-space reflections. Turning off will make all screen space reflections sharp, while higher values make rough reflections look better.
@@ -1151,6 +1151,10 @@
 		</member>
 		<member name="rendering/quality/texture_filters/use_nearest_mipmap_filter" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], uses nearest-neighbor mipmap filtering when using mipmaps (also called "bilinear filtering"), which will result in visible seams appearing between mipmap stages. This may increase performance in mobile as less memory bandwidth is used. If [code]false[/code], linear mipmap filtering (also called "trilinear filtering") is used.
+		</member>
+		<member name="rendering/sdfgi/frames_to_converge" type="int" setter="" getter="" default="1">
+		</member>
+		<member name="rendering/sdfgi/probe_ray_count" type="int" setter="" getter="" default="2">
 		</member>
 		<member name="rendering/threads/thread_model" type="int" setter="" getter="" default="1">
 			Thread model for rendering. Rendering on a thread can vastly improve performance, but synchronizing to the main thread can cause a bit more jitter.

--- a/doc/classes/ReflectionProbe.xml
+++ b/doc/classes/ReflectionProbe.xml
@@ -13,6 +13,12 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="ambient_color" type="Color" setter="set_ambient_color" getter="get_ambient_color" default="Color( 0, 0, 0, 1 )">
+		</member>
+		<member name="ambient_color_energy" type="float" setter="set_ambient_color_energy" getter="get_ambient_color_energy" default="1.0">
+		</member>
+		<member name="ambient_mode" type="int" setter="set_ambient_mode" getter="get_ambient_mode" enum="ReflectionProbe.AmbientMode" default="1">
+		</member>
 		<member name="box_projection" type="bool" setter="set_enable_box_projection" getter="is_box_projection_enabled" default="false">
 			If [code]true[/code], enables box projection. This makes reflections look more correct in rectangle-shaped rooms by offsetting the reflection center depending on the camera's location.
 		</member>
@@ -28,17 +34,8 @@
 		<member name="intensity" type="float" setter="set_intensity" getter="get_intensity" default="1.0">
 			Defines the reflection intensity. Intensity modulates the strength of the reflection.
 		</member>
-		<member name="interior_ambient_color" type="Color" setter="set_interior_ambient" getter="get_interior_ambient" default="Color( 0, 0, 0, 1 )">
-			Sets the ambient light color to be used when this probe is set to [member interior_enable].
-		</member>
-		<member name="interior_ambient_contrib" type="float" setter="set_interior_ambient_probe_contribution" getter="get_interior_ambient_probe_contribution" default="0.0">
-			Sets the contribution value for how much the reflection affects the ambient light for this reflection probe when set to [member interior_enable]. Useful so that ambient light matches the color of the room.
-		</member>
-		<member name="interior_ambient_energy" type="float" setter="set_interior_ambient_energy" getter="get_interior_ambient_energy" default="1.0">
-			Sets the energy multiplier for this reflection probe's ambient light contribution when set to [member interior_enable].
-		</member>
-		<member name="interior_enable" type="bool" setter="set_as_interior" getter="is_set_as_interior" default="false">
-			If [code]true[/code], reflections will ignore sky contribution. Ambient lighting is then controlled by the [code]interior_ambient_*[/code] properties.
+		<member name="interior" type="bool" setter="set_as_interior" getter="is_set_as_interior" default="false">
+			If [code]true[/code], reflections will ignore sky contribution.
 		</member>
 		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="0.0">
 			Sets the max distance away from the probe an object can be before it is culled.
@@ -56,6 +53,12 @@
 		</constant>
 		<constant name="UPDATE_ALWAYS" value="1" enum="UpdateMode">
 			Update the probe every frame. This is needed when you want to capture dynamic objects. However, it results in an increased render time. Use [constant UPDATE_ONCE] whenever possible.
+		</constant>
+		<constant name="AMBIENT_DISABLED" value="0" enum="AmbientMode">
+		</constant>
+		<constant name="AMBIENT_ENVIRONMENT" value="1" enum="AmbientMode">
+		</constant>
+		<constant name="AMBIENT_COLOR" value="2" enum="AmbientMode">
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -152,6 +152,8 @@
 			</argument>
 			<argument index="8" name="region" type="Rect2" default="Rect2i( 0, 0, 0, 0 )">
 			</argument>
+			<argument index="9" name="storage_textures" type="Array" default="[  ]">
+			</argument>
 			<description>
 			</description>
 		</method>
@@ -187,6 +189,8 @@
 			<argument index="8" name="clear_stencil" type="int" default="0">
 			</argument>
 			<argument index="9" name="region" type="Rect2" default="Rect2i( 0, 0, 0, 0 )">
+			</argument>
+			<argument index="10" name="storage_textures" type="RID[]" default="[  ]">
 			</argument>
 			<description>
 			</description>
@@ -293,10 +297,28 @@
 			<description>
 			</description>
 		</method>
+		<method name="framebuffer_create_empty">
+			<return type="RID">
+			</return>
+			<argument index="0" name="size" type="Vector2i">
+			</argument>
+			<argument index="1" name="validate_with_format" type="int" default="-1">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="framebuffer_format_create">
 			<return type="int">
 			</return>
 			<argument index="0" name="attachments" type="RDAttachmentFormat[]">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="framebuffer_format_create_empty">
+			<return type="int">
+			</return>
+			<argument index="0" name="size" type="Vector2i">
 			</argument>
 			<description>
 			</description>
@@ -495,6 +517,8 @@
 			<argument index="0" name="size_bytes" type="int">
 			</argument>
 			<argument index="1" name="data" type="PackedByteArray" default="PackedByteArray(  )">
+			</argument>
+			<argument index="2" name="usage" type="int" default="0">
 			</argument>
 			<description>
 			</description>
@@ -1284,6 +1308,8 @@
 		<constant name="INDEX_BUFFER_FORMAT_UINT16" value="0" enum="IndexBufferFormat">
 		</constant>
 		<constant name="INDEX_BUFFER_FORMAT_UINT32" value="1" enum="IndexBufferFormat">
+		</constant>
+		<constant name="STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT" value="1" enum="StorageBufferUsage">
 		</constant>
 		<constant name="UNIFORM_TYPE_SAMPLER" value="0" enum="UniformType">
 		</constant>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1470,6 +1470,16 @@
 				Sets whether to use a dual paraboloid or a cubemap for the shadow map. Dual paraboloid is faster but may suffer from artifacts. Equivalent to [member OmniLight3D.omni_shadow_mode].
 			</description>
 		</method>
+		<method name="light_set_bake_mode">
+			<return type="void">
+			</return>
+			<argument index="0" name="light" type="RID">
+			</argument>
+			<argument index="1" name="bake_mode" type="int" enum="RenderingServer.LightBakeMode">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="light_set_color">
 			<return type="void">
 			</return>
@@ -1558,17 +1568,6 @@
 			</argument>
 			<description>
 				Sets the color of the shadow cast by the light. Equivalent to [member Light3D.shadow_color].
-			</description>
-		</method>
-		<method name="light_set_use_gi">
-			<return type="void">
-			</return>
-			<argument index="0" name="light" type="RID">
-			</argument>
-			<argument index="1" name="enabled" type="bool">
-			</argument>
-			<description>
-				Sets whether GI probes capture light information from this light.
 			</description>
 		</method>
 		<method name="make_sphere_mesh">
@@ -2292,6 +2291,36 @@
 				To place in a scene, attach this reflection probe to an instance using [method instance_set_base] using the returned RID.
 			</description>
 		</method>
+		<method name="reflection_probe_set_ambient_color">
+			<return type="void">
+			</return>
+			<argument index="0" name="probe" type="RID">
+			</argument>
+			<argument index="1" name="color" type="Color">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="reflection_probe_set_ambient_energy">
+			<return type="void">
+			</return>
+			<argument index="0" name="probe" type="RID">
+			</argument>
+			<argument index="1" name="energy" type="float">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="reflection_probe_set_ambient_mode">
+			<return type="void">
+			</return>
+			<argument index="0" name="probe" type="RID">
+			</argument>
+			<argument index="1" name="mode" type="int" enum="RenderingServer.ReflectionProbeAmbientMode">
+			</argument>
+			<description>
+			</description>
+		</method>
 		<method name="reflection_probe_set_as_interior">
 			<return type="void">
 			</return>
@@ -2300,7 +2329,7 @@
 			<argument index="1" name="enable" type="bool">
 			</argument>
 			<description>
-				If [code]true[/code], reflections will ignore sky contribution. Equivalent to [member ReflectionProbe.interior_enable].
+				If [code]true[/code], reflections will ignore sky contribution. Equivalent to [member ReflectionProbe.interior].
 			</description>
 		</method>
 		<method name="reflection_probe_set_cull_mask">
@@ -2356,39 +2385,6 @@
 			</argument>
 			<description>
 				Sets the intensity of the reflection probe. Intensity modulates the strength of the reflection. Equivalent to [member ReflectionProbe.intensity].
-			</description>
-		</method>
-		<method name="reflection_probe_set_interior_ambient">
-			<return type="void">
-			</return>
-			<argument index="0" name="probe" type="RID">
-			</argument>
-			<argument index="1" name="color" type="Color">
-			</argument>
-			<description>
-				Sets the ambient light color for this reflection probe when set to interior mode. Equivalent to [member ReflectionProbe.interior_ambient_color].
-			</description>
-		</method>
-		<method name="reflection_probe_set_interior_ambient_energy">
-			<return type="void">
-			</return>
-			<argument index="0" name="probe" type="RID">
-			</argument>
-			<argument index="1" name="energy" type="float">
-			</argument>
-			<description>
-				Sets the energy multiplier for this reflection probes ambient light contribution when set to interior mode. Equivalent to [member ReflectionProbe.interior_ambient_energy].
-			</description>
-		</method>
-		<method name="reflection_probe_set_interior_ambient_probe_contribution">
-			<return type="void">
-			</return>
-			<argument index="0" name="probe" type="RID">
-			</argument>
-			<argument index="1" name="contrib" type="float">
-			</argument>
-			<description>
-				Sets the contribution value for how much the reflection affects the ambient light for this reflection probe when set to interior mode. Useful so that ambient light matches the color of the room. Equivalent to [member ReflectionProbe.interior_ambient_contrib].
 			</description>
 		</method>
 		<method name="reflection_probe_set_max_distance">
@@ -3261,6 +3257,12 @@
 		<constant name="LIGHT_PARAM_MAX" value="18" enum="LightParam">
 			Represents the size of the [enum LightParam] enum.
 		</constant>
+		<constant name="LIGHT_BAKE_DISABLED" value="0" enum="LightBakeMode">
+		</constant>
+		<constant name="LIGHT_BAKE_DYNAMIC" value="1" enum="LightBakeMode">
+		</constant>
+		<constant name="LIGHT_BAKE_STATIC" value="2" enum="LightBakeMode">
+		</constant>
 		<constant name="LIGHT_OMNI_SHADOW_DUAL_PARABOLOID" value="0" enum="LightOmniShadowMode">
 			Use a dual paraboloid shadow map for omni lights.
 		</constant>
@@ -3287,6 +3289,12 @@
 		</constant>
 		<constant name="REFLECTION_PROBE_UPDATE_ALWAYS" value="1" enum="ReflectionProbeUpdateMode">
 			Reflection probe will update each frame. This mode is necessary to capture moving objects.
+		</constant>
+		<constant name="REFLECTION_PROBE_AMBIENT_DISABLED" value="0" enum="ReflectionProbeAmbientMode">
+		</constant>
+		<constant name="REFLECTION_PROBE_AMBIENT_ENVIRONMENT" value="1" enum="ReflectionProbeAmbientMode">
+		</constant>
+		<constant name="REFLECTION_PROBE_AMBIENT_COLOR" value="2" enum="ReflectionProbeAmbientMode">
 		</constant>
 		<constant name="DECAL_TEXTURE_ALBEDO" value="0" enum="DecalTexture">
 		</constant>
@@ -3412,13 +3420,16 @@
 		<constant name="VIEWPORT_DEBUG_DRAW_SSAO" value="12" enum="ViewportDebugDraw">
 			Draws the screen space ambient occlusion texture instead of the scene so that you can clearly see how it is affecting objects. In order for this display mode to work, you must have [member Environment.ssao_enabled] set in your [WorldEnvironment].
 		</constant>
-		<constant name="VIEWPORT_DEBUG_DRAW_ROUGHNESS_LIMITER" value="13" enum="ViewportDebugDraw">
-			Draws the roughness limiter post process over the Viewport so you can see where it has an effect. It must be enabled in [member ProjectSettings.rendering/quality/screen_filters/screen_space_roughness_limiter] to work.
-		</constant>
-		<constant name="VIEWPORT_DEBUG_DRAW_PSSM_SPLITS" value="14" enum="ViewportDebugDraw">
+		<constant name="VIEWPORT_DEBUG_DRAW_PSSM_SPLITS" value="13" enum="ViewportDebugDraw">
 			Colors each PSSM split for the [DirectionalLight3D]s in the scene a different color so you can see where the splits are. In order they will be colored red, green, blue, yellow.
 		</constant>
-		<constant name="VIEWPORT_DEBUG_DRAW_DECAL_ATLAS" value="15" enum="ViewportDebugDraw">
+		<constant name="VIEWPORT_DEBUG_DRAW_DECAL_ATLAS" value="14" enum="ViewportDebugDraw">
+		</constant>
+		<constant name="VIEWPORT_DEBUG_DRAW_SDFGI" value="15" enum="ViewportDebugDraw">
+		</constant>
+		<constant name="VIEWPORT_DEBUG_DRAW_SDFGI_PROBES" value="16" enum="ViewportDebugDraw">
+		</constant>
+		<constant name="VIEWPORT_DEBUG_DRAW_GI_BUFFER" value="17" enum="ViewportDebugDraw">
 		</constant>
 		<constant name="SKY_MODE_QUALITY" value="0" enum="SkyMode">
 			Uses high quality importance sampling to process the radiance map. In general, this results in much higher quality than [constant Sky.PROCESS_MODE_REALTIME] but takes much longer to generate. This should not be used if you plan on changing the sky at runtime. If you are finding that the reflection is not blurry enough and is showing sparkles or fireflies, try increasing [member ProjectSettings.rendering/quality/reflections/ggx_samples].

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -377,14 +377,17 @@
 		<constant name="DEBUG_DRAW_SSAO" value="12" enum="DebugDraw">
 			Draws the screen-space ambient occlusion texture instead of the scene so that you can clearly see how it is affecting objects. In order for this display mode to work, you must have [member Environment.ssao_enabled] set in your [WorldEnvironment].
 		</constant>
-		<constant name="DEBUG_DRAW_ROUGHNESS_LIMITER" value="13" enum="DebugDraw">
-			Draws the roughness limiter post process over the Viewport so you can see where it has an effect. It must be enabled in [member ProjectSettings.rendering/quality/screen_filters/screen_space_roughness_limiter] to work.
-		</constant>
-		<constant name="DEBUG_DRAW_PSSM_SPLITS" value="14" enum="DebugDraw">
+		<constant name="DEBUG_DRAW_PSSM_SPLITS" value="13" enum="DebugDraw">
 			Colors each PSSM split for the [DirectionalLight3D]s in the scene a different color so you can see where the splits are. In order, they will be colored red, green, blue, and yellow.
 		</constant>
-		<constant name="DEBUG_DRAW_DECAL_ATLAS" value="15" enum="DebugDraw">
+		<constant name="DEBUG_DRAW_DECAL_ATLAS" value="14" enum="DebugDraw">
 			Draws the decal atlas used by [Decal]s and light projector textures in the upper left quadrant of the [Viewport].
+		</constant>
+		<constant name="DEBUG_DRAW_SDFGI" value="15" enum="DebugDraw">
+		</constant>
+		<constant name="DEBUG_DRAW_SDFGI_PROBES" value="16" enum="DebugDraw">
+		</constant>
+		<constant name="DEBUG_DRAW_GI_BUFFER" value="17" enum="DebugDraw">
 		</constant>
 		<constant name="DEFAULT_CANVAS_ITEM_TEXTURE_FILTER_NEAREST" value="0" enum="DefaultCanvasItemTextureFilter">
 			The texture filter reads from the nearest pixel only. The simplest and fastest method of filtering, but the texture will look pixelized.

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -95,7 +95,7 @@ public:
 	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_bias, float p_light_affect, float p_ao_channel_affect, RS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) {}
 	virtual void environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size) {}
 
-	virtual void environment_set_sdfgi(RID p_env, bool p_enable, RS::EnvironmentSDFGICascades p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, bool p_enhance_ssr, float p_energy, float p_normal_bias, float p_probe_bias) {}
+	virtual void environment_set_sdfgi(RID p_env, bool p_enable, RS::EnvironmentSDFGICascades p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) {}
 
 	virtual void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count) {}
 	virtual void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) {}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -360,7 +360,7 @@ void EditorNode::_notification(int p_what) {
 				bool dof_jitter = GLOBAL_GET("rendering/quality/depth_of_field/depth_of_field_use_jitter");
 				RS::get_singleton()->camera_effects_set_dof_blur_quality(dof_quality, dof_jitter);
 				RS::get_singleton()->environment_set_ssao_quality(RS::EnvironmentSSAOQuality(int(GLOBAL_GET("rendering/quality/ssao/quality"))), GLOBAL_GET("rendering/quality/ssao/half_size"));
-				RS::get_singleton()->screen_space_roughness_limiter_set_active(GLOBAL_GET("rendering/quality/screen_filters/screen_space_roughness_limiter_enable"), GLOBAL_GET("rendering/quality/screen_filters/screen_space_roughness_limiter_amount"), GLOBAL_GET("rendering/quality/screen_filters/screen_space_roughness_limiter_limit"));
+				RS::get_singleton()->screen_space_roughness_limiter_set_active(GLOBAL_GET("rendering/quality/screen_filters/screen_space_roughness_limiter_enabled"), GLOBAL_GET("rendering/quality/screen_filters/screen_space_roughness_limiter_amount"), GLOBAL_GET("rendering/quality/screen_filters/screen_space_roughness_limiter_limit"));
 				bool glow_bicubic = int(GLOBAL_GET("rendering/quality/glow/upscale_mode")) > 0;
 				RS::get_singleton()->environment_glow_set_use_bicubic_upscale(glow_bicubic);
 				RS::EnvironmentSSRRoughnessQuality ssr_roughness_quality = RS::EnvironmentSSRRoughnessQuality(int(GLOBAL_GET("rendering/quality/screen_space_reflection/roughness_quality")));

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2508,10 +2508,10 @@ void FileSystemDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_tree_thumbnail_done"), &FileSystemDock::_tree_thumbnail_done);
 	ClassDB::bind_method(D_METHOD("_select_file"), &FileSystemDock::_select_file);
 
-	ClassDB::bind_method(D_METHOD("get_drag_data_fw"), &FileSystemDock::get_drag_data_fw);
-	ClassDB::bind_method(D_METHOD("can_drop_data_fw"), &FileSystemDock::can_drop_data_fw);
-	ClassDB::bind_method(D_METHOD("drop_data_fw"), &FileSystemDock::drop_data_fw);
-	ClassDB::bind_method(D_METHOD("navigate_to_path"), &FileSystemDock::navigate_to_path);
+	ClassDB::bind_method(D_METHOD("get_drag_data_fw", "position", "from"), &FileSystemDock::get_drag_data_fw);
+	ClassDB::bind_method(D_METHOD("can_drop_data_fw", "position", "data", "from"), &FileSystemDock::can_drop_data_fw);
+	ClassDB::bind_method(D_METHOD("drop_data_fw", "position", "data", "from"), &FileSystemDock::drop_data_fw);
+	ClassDB::bind_method(D_METHOD("navigate_to_path", "path"), &FileSystemDock::navigate_to_path);
 
 	ClassDB::bind_method(D_METHOD("_update_import_dock"), &FileSystemDock::_update_import_dock);
 

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -220,7 +220,7 @@ public:
 
 	virtual Vector<int> get_window_list() const;
 
-	virtual WindowID create_sub_window(WindowMode p_mode, uint32_t p_flags, const Rect2i & = Rect2i());
+	virtual WindowID create_sub_window(WindowMode p_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i());
 	virtual void delete_sub_window(WindowID p_id);
 
 	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -35,6 +35,7 @@
 #include "core/math/camera_matrix.h"
 #include "scene/resources/material.h"
 #include "scene/resources/surface_tool.h"
+
 void Camera3D::_update_audio_listener_state() {
 }
 

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -34,6 +34,7 @@
 #include "scene/3d/node_3d.h"
 #include "scene/3d/velocity_tracker_3d.h"
 #include "scene/main/window.h"
+#include "scene/resources/camera_effects.h"
 #include "scene/resources/environment.h"
 
 class Camera3D : public Node3D {

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef LIGHT_H
-#define LIGHT_H
+#ifndef LIGHT_3D_H
+#define LIGHT_3D_H
 
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/texture.h"
@@ -145,7 +145,7 @@ public:
 	enum ShadowMode {
 		SHADOW_ORTHOGONAL,
 		SHADOW_PARALLEL_2_SPLITS,
-		SHADOW_PARALLEL_4_SPLITS
+		SHADOW_PARALLEL_4_SPLITS,
 	};
 
 	enum ShadowDepthRange {
@@ -217,4 +217,4 @@ public:
 			Light3D(RenderingServer::LIGHT_SPOT) {}
 };
 
-#endif
+#endif // LIGHT_3D_H

--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "world_environment.h"
+
 #include "scene/main/window.h"
 
 void WorldEnvironment::_notification(int p_what) {

--- a/scene/3d/world_environment.h
+++ b/scene/3d/world_environment.h
@@ -32,6 +32,8 @@
 #define SCENARIO_FX_H
 
 #include "scene/3d/node_3d.h"
+#include "scene/resources/camera_effects.h"
+#include "scene/resources/environment.h"
 
 class WorldEnvironment : public Node {
 	GDCLASS(WorldEnvironment, Node);

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -44,7 +44,6 @@ class LineEdit;
 class AcceptDialog : public Window {
 	GDCLASS(AcceptDialog, Window);
 
-public:
 	Window *parent_visible;
 	Panel *bg;
 	HBoxContainer *hbc;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -131,6 +131,7 @@
 #include "scene/resources/audio_stream_sample.h"
 #include "scene/resources/bit_map.h"
 #include "scene/resources/box_shape_3d.h"
+#include "scene/resources/camera_effects.h"
 #include "scene/resources/capsule_shape_2d.h"
 #include "scene/resources/capsule_shape_3d.h"
 #include "scene/resources/circle_shape_2d.h"

--- a/scene/resources/camera_effects.cpp
+++ b/scene/resources/camera_effects.cpp
@@ -1,0 +1,197 @@
+/*************************************************************************/
+/*  camera_effects.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "camera_effects.h"
+
+#include "servers/rendering_server.h"
+
+RID CameraEffects::get_rid() const {
+	return camera_effects;
+}
+
+// DOF blur
+
+void CameraEffects::set_dof_blur_far_enabled(bool p_enabled) {
+	dof_blur_far_enabled = p_enabled;
+	_update_dof_blur();
+	_change_notify();
+}
+
+bool CameraEffects::is_dof_blur_far_enabled() const {
+	return dof_blur_far_enabled;
+}
+
+void CameraEffects::set_dof_blur_far_distance(float p_distance) {
+	dof_blur_far_distance = p_distance;
+	_update_dof_blur();
+}
+
+float CameraEffects::get_dof_blur_far_distance() const {
+	return dof_blur_far_distance;
+}
+
+void CameraEffects::set_dof_blur_far_transition(float p_distance) {
+	dof_blur_far_transition = p_distance;
+	_update_dof_blur();
+}
+
+float CameraEffects::get_dof_blur_far_transition() const {
+	return dof_blur_far_transition;
+}
+
+void CameraEffects::set_dof_blur_near_enabled(bool p_enabled) {
+	dof_blur_near_enabled = p_enabled;
+	_update_dof_blur();
+	_change_notify();
+}
+
+bool CameraEffects::is_dof_blur_near_enabled() const {
+	return dof_blur_near_enabled;
+}
+
+void CameraEffects::set_dof_blur_near_distance(float p_distance) {
+	dof_blur_near_distance = p_distance;
+	_update_dof_blur();
+}
+
+float CameraEffects::get_dof_blur_near_distance() const {
+	return dof_blur_near_distance;
+}
+
+void CameraEffects::set_dof_blur_near_transition(float p_distance) {
+	dof_blur_near_transition = p_distance;
+	_update_dof_blur();
+}
+
+float CameraEffects::get_dof_blur_near_transition() const {
+	return dof_blur_near_transition;
+}
+
+void CameraEffects::set_dof_blur_amount(float p_amount) {
+	dof_blur_amount = p_amount;
+	_update_dof_blur();
+}
+
+float CameraEffects::get_dof_blur_amount() const {
+	return dof_blur_amount;
+}
+
+void CameraEffects::_update_dof_blur() {
+	RS::get_singleton()->camera_effects_set_dof_blur(
+			camera_effects,
+			dof_blur_far_enabled,
+			dof_blur_far_distance,
+			dof_blur_far_transition,
+			dof_blur_near_enabled,
+			dof_blur_near_distance,
+			dof_blur_near_transition,
+			dof_blur_amount);
+}
+
+// Custom exposure
+
+void CameraEffects::set_override_exposure_enabled(bool p_enabled) {
+	override_exposure_enabled = p_enabled;
+	_update_override_exposure();
+}
+
+bool CameraEffects::is_override_exposure_enabled() const {
+	return override_exposure_enabled;
+}
+
+void CameraEffects::set_override_exposure(float p_exposure) {
+	override_exposure = p_exposure;
+	_update_override_exposure();
+}
+
+float CameraEffects::get_override_exposure() const {
+	return override_exposure;
+}
+
+void CameraEffects::_update_override_exposure() {
+	RS::get_singleton()->camera_effects_set_custom_exposure(
+			camera_effects,
+			override_exposure_enabled,
+			override_exposure);
+}
+
+// Private methods, constructor and destructor
+
+void CameraEffects::_bind_methods() {
+	// DOF blur
+
+	ClassDB::bind_method(D_METHOD("set_dof_blur_far_enabled", "enabled"), &CameraEffects::set_dof_blur_far_enabled);
+	ClassDB::bind_method(D_METHOD("is_dof_blur_far_enabled"), &CameraEffects::is_dof_blur_far_enabled);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_far_distance", "distance"), &CameraEffects::set_dof_blur_far_distance);
+	ClassDB::bind_method(D_METHOD("get_dof_blur_far_distance"), &CameraEffects::get_dof_blur_far_distance);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_far_transition", "distance"), &CameraEffects::set_dof_blur_far_transition);
+	ClassDB::bind_method(D_METHOD("get_dof_blur_far_transition"), &CameraEffects::get_dof_blur_far_transition);
+
+	ClassDB::bind_method(D_METHOD("set_dof_blur_near_enabled", "enabled"), &CameraEffects::set_dof_blur_near_enabled);
+	ClassDB::bind_method(D_METHOD("is_dof_blur_near_enabled"), &CameraEffects::is_dof_blur_near_enabled);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_near_distance", "distance"), &CameraEffects::set_dof_blur_near_distance);
+	ClassDB::bind_method(D_METHOD("get_dof_blur_near_distance"), &CameraEffects::get_dof_blur_near_distance);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_near_transition", "distance"), &CameraEffects::set_dof_blur_near_transition);
+	ClassDB::bind_method(D_METHOD("get_dof_blur_near_transition"), &CameraEffects::get_dof_blur_near_transition);
+
+	ClassDB::bind_method(D_METHOD("set_dof_blur_amount", "amount"), &CameraEffects::set_dof_blur_amount);
+	ClassDB::bind_method(D_METHOD("get_dof_blur_amount"), &CameraEffects::get_dof_blur_amount);
+
+	ADD_GROUP("DOF Blur", "dof_blur_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dof_blur_far_enabled"), "set_dof_blur_far_enabled", "is_dof_blur_far_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_far_distance", PROPERTY_HINT_EXP_RANGE, "0.01,8192,0.01"), "set_dof_blur_far_distance", "get_dof_blur_far_distance");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_far_transition", PROPERTY_HINT_EXP_RANGE, "0.01,8192,0.01"), "set_dof_blur_far_transition", "get_dof_blur_far_transition");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dof_blur_near_enabled"), "set_dof_blur_near_enabled", "is_dof_blur_near_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_near_distance", PROPERTY_HINT_EXP_RANGE, "0.01,8192,0.01"), "set_dof_blur_near_distance", "get_dof_blur_near_distance");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_near_transition", PROPERTY_HINT_EXP_RANGE, "0.01,8192,0.01"), "set_dof_blur_near_transition", "get_dof_blur_near_transition");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_amount", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_dof_blur_amount", "get_dof_blur_amount");
+
+	// Override exposure
+
+	ClassDB::bind_method(D_METHOD("set_override_exposure_enabled", "enabled"), &CameraEffects::set_override_exposure_enabled);
+	ClassDB::bind_method(D_METHOD("is_override_exposure_enabled"), &CameraEffects::is_override_exposure_enabled);
+	ClassDB::bind_method(D_METHOD("set_override_exposure", "exposure"), &CameraEffects::set_override_exposure);
+	ClassDB::bind_method(D_METHOD("get_override_exposure"), &CameraEffects::get_override_exposure);
+
+	ADD_GROUP("Override Exposure", "override_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "override_exposure_enabled"), "set_override_exposure_enabled", "is_override_exposure_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "override_exposure", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_override_exposure", "get_override_exposure");
+}
+
+CameraEffects::CameraEffects() {
+	camera_effects = RS::get_singleton()->camera_effects_create();
+
+	_update_dof_blur();
+	_update_override_exposure();
+}
+
+CameraEffects::~CameraEffects() {
+	RS::get_singleton()->free(camera_effects);
+}

--- a/scene/resources/camera_effects.h
+++ b/scene/resources/camera_effects.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  world_3d.h                                                           */
+/*  camera_effects.h                                                     */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,65 +28,67 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef WORLD_3D_H
-#define WORLD_3D_H
+#ifndef CAMERA_EFFECTS_H
+#define CAMERA_EFFECTS_H
 
 #include "core/resource.h"
-#include "scene/resources/camera_effects.h"
-#include "scene/resources/environment.h"
-#include "servers/physics_server_3d.h"
-#include "servers/rendering_server.h"
+#include "core/rid.h"
 
-class Camera3D;
-class VisibilityNotifier3D;
-struct SpatialIndexer;
-
-class World3D : public Resource {
-	GDCLASS(World3D, Resource);
+class CameraEffects : public Resource {
+	GDCLASS(CameraEffects, Resource);
 
 private:
-	RID space;
-	RID scenario;
-	SpatialIndexer *indexer;
-	Ref<Environment> environment;
-	Ref<Environment> fallback_environment;
-	Ref<CameraEffects> camera_effects;
+	RID camera_effects;
+
+	// DOF blur
+	bool dof_blur_far_enabled = false;
+	float dof_blur_far_distance = 10;
+	float dof_blur_far_transition = 5;
+
+	bool dof_blur_near_enabled = false;
+	float dof_blur_near_distance = 2;
+	float dof_blur_near_transition = 1;
+
+	float dof_blur_amount = 0.1;
+	void _update_dof_blur();
+
+	// Override exposure
+	bool override_exposure_enabled = false;
+	float override_exposure = 1.0;
+	void _update_override_exposure();
 
 protected:
 	static void _bind_methods();
 
-	friend class Camera3D;
-	friend class VisibilityNotifier3D;
-
-	void _register_camera(Camera3D *p_camera);
-	void _update_camera(Camera3D *p_camera);
-	void _remove_camera(Camera3D *p_camera);
-
-	void _register_notifier(VisibilityNotifier3D *p_notifier, const AABB &p_rect);
-	void _update_notifier(VisibilityNotifier3D *p_notifier, const AABB &p_rect);
-	void _remove_notifier(VisibilityNotifier3D *p_notifier);
-	friend class Viewport;
-	void _update(uint64_t p_frame);
-
 public:
-	RID get_space() const;
-	RID get_scenario() const;
+	virtual RID get_rid() const;
 
-	void set_environment(const Ref<Environment> &p_environment);
-	Ref<Environment> get_environment() const;
+	// DOF blur
+	void set_dof_blur_far_enabled(bool p_enabled);
+	bool is_dof_blur_far_enabled() const;
+	void set_dof_blur_far_distance(float p_distance);
+	float get_dof_blur_far_distance() const;
+	void set_dof_blur_far_transition(float p_distance);
+	float get_dof_blur_far_transition() const;
 
-	void set_fallback_environment(const Ref<Environment> &p_environment);
-	Ref<Environment> get_fallback_environment() const;
+	void set_dof_blur_near_enabled(bool p_enabled);
+	bool is_dof_blur_near_enabled() const;
+	void set_dof_blur_near_distance(float p_distance);
+	float get_dof_blur_near_distance() const;
+	void set_dof_blur_near_transition(float p_distance);
+	float get_dof_blur_near_transition() const;
 
-	void set_camera_effects(const Ref<CameraEffects> &p_camera_effects);
-	Ref<CameraEffects> get_camera_effects() const;
+	void set_dof_blur_amount(float p_amount);
+	float get_dof_blur_amount() const;
 
-	void get_camera_list(List<Camera3D *> *r_cameras);
+	// Override exposure
+	void set_override_exposure_enabled(bool p_enabled);
+	bool is_override_exposure_enabled() const;
+	void set_override_exposure(float p_exposure);
+	float get_override_exposure() const;
 
-	PhysicsDirectSpaceState3D *get_direct_space_state();
-
-	World3D();
-	~World3D();
+	CameraEffects();
+	~CameraEffects();
 };
 
-#endif // WORLD_3D_H
+#endif // CAMERA_EFFECTS_H

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "environment.h"
+
 #include "core/project_settings.h"
 #include "servers/rendering_server.h"
 #include "texture.h"
@@ -37,21 +38,29 @@ RID Environment::get_rid() const {
 	return environment;
 }
 
+// Background
+
 void Environment::set_background(BGMode p_bg) {
 	bg_mode = p_bg;
 	RS::get_singleton()->environment_set_background(environment, RS::EnvironmentBG(p_bg));
 	_change_notify();
 }
 
+Environment::BGMode Environment::get_background() const {
+	return bg_mode;
+}
+
 void Environment::set_sky(const Ref<Sky> &p_sky) {
 	bg_sky = p_sky;
-
 	RID sb_rid;
 	if (bg_sky.is_valid()) {
 		sb_rid = bg_sky->get_rid();
 	}
-
 	RS::get_singleton()->environment_set_sky(environment, sb_rid);
+}
+
+Ref<Sky> Environment::get_sky() const {
+	return bg_sky;
 }
 
 void Environment::set_sky_custom_fov(float p_scale) {
@@ -59,9 +68,26 @@ void Environment::set_sky_custom_fov(float p_scale) {
 	RS::get_singleton()->environment_set_sky_custom_fov(environment, p_scale);
 }
 
+float Environment::get_sky_custom_fov() const {
+	return bg_sky_custom_fov;
+}
+
+void Environment::set_sky_rotation(const Vector3 &p_rotation) {
+	bg_sky_rotation = p_rotation;
+	RS::get_singleton()->environment_set_sky_orientation(environment, Basis(p_rotation));
+}
+
+Vector3 Environment::get_sky_rotation() const {
+	return bg_sky_rotation;
+}
+
 void Environment::set_bg_color(const Color &p_color) {
 	bg_color = p_color;
 	RS::get_singleton()->environment_set_bg_color(environment, p_color);
+}
+
+Color Environment::get_bg_color() const {
+	return bg_color;
 }
 
 void Environment::set_bg_energy(float p_energy) {
@@ -69,104 +95,102 @@ void Environment::set_bg_energy(float p_energy) {
 	RS::get_singleton()->environment_set_bg_energy(environment, p_energy);
 }
 
+float Environment::get_bg_energy() const {
+	return bg_energy;
+}
+
 void Environment::set_canvas_max_layer(int p_max_layer) {
 	bg_canvas_max_layer = p_max_layer;
 	RS::get_singleton()->environment_set_canvas_max_layer(environment, p_max_layer);
-}
-
-void Environment::set_ambient_light_color(const Color &p_color) {
-	ambient_color = p_color;
-	RS::get_singleton()->environment_set_ambient_light(environment, ambient_color, RS::EnvironmentAmbientSource(ambient_source), ambient_energy, ambient_sky_contribution, RS::EnvironmentReflectionSource(reflection_source), ao_color);
-}
-
-void Environment::set_ambient_light_energy(float p_energy) {
-	ambient_energy = p_energy;
-	RS::get_singleton()->environment_set_ambient_light(environment, ambient_color, RS::EnvironmentAmbientSource(ambient_source), ambient_energy, ambient_sky_contribution, RS::EnvironmentReflectionSource(reflection_source), ao_color);
-}
-
-void Environment::set_ambient_light_sky_contribution(float p_energy) {
-	ambient_sky_contribution = p_energy;
-	RS::get_singleton()->environment_set_ambient_light(environment, ambient_color, RS::EnvironmentAmbientSource(ambient_source), ambient_energy, ambient_sky_contribution, RS::EnvironmentReflectionSource(reflection_source), ao_color);
-}
-
-void Environment::set_camera_feed_id(int p_camera_feed_id) {
-	camera_feed_id = p_camera_feed_id;
-// FIXME: Disabled during Vulkan refactoring, should be ported.
-#if 0
-	RS::get_singleton()->environment_set_camera_feed_id(environment, camera_feed_id);
-#endif
-};
-
-void Environment::set_ambient_source(AmbientSource p_source) {
-	ambient_source = p_source;
-	RS::get_singleton()->environment_set_ambient_light(environment, ambient_color, RS::EnvironmentAmbientSource(ambient_source), ambient_energy, ambient_sky_contribution, RS::EnvironmentReflectionSource(reflection_source), ao_color);
-}
-
-Environment::AmbientSource Environment::get_ambient_source() const {
-	return ambient_source;
-}
-
-void Environment::set_reflection_source(ReflectionSource p_source) {
-	reflection_source = p_source;
-	RS::get_singleton()->environment_set_ambient_light(environment, ambient_color, RS::EnvironmentAmbientSource(ambient_source), ambient_energy, ambient_sky_contribution, RS::EnvironmentReflectionSource(reflection_source), ao_color);
-}
-
-Environment::ReflectionSource Environment::get_reflection_source() const {
-	return reflection_source;
-}
-
-Environment::BGMode Environment::get_background() const {
-	return bg_mode;
-}
-
-Ref<Sky> Environment::get_sky() const {
-	return bg_sky;
-}
-
-float Environment::get_sky_custom_fov() const {
-	return bg_sky_custom_fov;
-}
-
-void Environment::set_sky_rotation(const Vector3 &p_rotation) {
-	sky_rotation = p_rotation;
-	RS::get_singleton()->environment_set_sky_orientation(environment, Basis(p_rotation));
-}
-
-Vector3 Environment::get_sky_rotation() const {
-	return sky_rotation;
-}
-
-Color Environment::get_bg_color() const {
-	return bg_color;
-}
-
-float Environment::get_bg_energy() const {
-	return bg_energy;
 }
 
 int Environment::get_canvas_max_layer() const {
 	return bg_canvas_max_layer;
 }
 
+void Environment::set_camera_feed_id(int p_id) {
+	bg_camera_feed_id = p_id;
+// FIXME: Disabled during Vulkan refactoring, should be ported.
+#if 0
+	RS::get_singleton()->environment_set_camera_feed_id(environment, camera_feed_id);
+#endif
+}
+
+int Environment::get_camera_feed_id() const {
+	return bg_camera_feed_id;
+}
+
+// Ambient light
+
+void Environment::set_ambient_light_color(const Color &p_color) {
+	ambient_color = p_color;
+	_update_ambient_light();
+}
+
 Color Environment::get_ambient_light_color() const {
 	return ambient_color;
+}
+
+void Environment::set_ambient_source(AmbientSource p_source) {
+	ambient_source = p_source;
+	_update_ambient_light();
+}
+
+Environment::AmbientSource Environment::get_ambient_source() const {
+	return ambient_source;
+}
+
+void Environment::set_ambient_light_energy(float p_energy) {
+	ambient_energy = p_energy;
+	_update_ambient_light();
 }
 
 float Environment::get_ambient_light_energy() const {
 	return ambient_energy;
 }
 
+void Environment::set_ambient_light_sky_contribution(float p_ratio) {
+	ambient_sky_contribution = p_ratio;
+	_update_ambient_light();
+}
+
 float Environment::get_ambient_light_sky_contribution() const {
 	return ambient_sky_contribution;
 }
 
-int Environment::get_camera_feed_id() const {
-	return camera_feed_id;
+void Environment::set_reflection_source(ReflectionSource p_source) {
+	reflection_source = p_source;
+	_update_ambient_light();
 }
+
+Environment::ReflectionSource Environment::get_reflection_source() const {
+	return reflection_source;
+}
+
+void Environment::set_ao_color(const Color &p_color) {
+	ao_color = p_color;
+	_update_ambient_light();
+}
+
+Color Environment::get_ao_color() const {
+	return ao_color;
+}
+
+void Environment::_update_ambient_light() {
+	RS::get_singleton()->environment_set_ambient_light(
+			environment,
+			ambient_color,
+			RS::EnvironmentAmbientSource(ambient_source),
+			ambient_energy,
+			ambient_sky_contribution, RS::EnvironmentReflectionSource(reflection_source),
+			ao_color);
+}
+
+// Tonemap
 
 void Environment::set_tonemapper(ToneMapper p_tone_mapper) {
 	tone_mapper = p_tone_mapper;
-	RS::get_singleton()->environment_set_tonemap(environment, RS::EnvironmentToneMapper(tone_mapper), tonemap_exposure, tonemap_white, tonemap_auto_exposure, tonemap_auto_exposure_min, tonemap_auto_exposure_max, tonemap_auto_exposure_speed, tonemap_auto_exposure_grey);
+	_update_tonemap();
 }
 
 Environment::ToneMapper Environment::get_tonemapper() const {
@@ -175,7 +199,7 @@ Environment::ToneMapper Environment::get_tonemapper() const {
 
 void Environment::set_tonemap_exposure(float p_exposure) {
 	tonemap_exposure = p_exposure;
-	RS::get_singleton()->environment_set_tonemap(environment, RS::EnvironmentToneMapper(tone_mapper), tonemap_exposure, tonemap_white, tonemap_auto_exposure, tonemap_auto_exposure_min, tonemap_auto_exposure_max, tonemap_auto_exposure_speed, tonemap_auto_exposure_grey);
+	_update_tonemap();
 }
 
 float Environment::get_tonemap_exposure() const {
@@ -184,44 +208,44 @@ float Environment::get_tonemap_exposure() const {
 
 void Environment::set_tonemap_white(float p_white) {
 	tonemap_white = p_white;
-	RS::get_singleton()->environment_set_tonemap(environment, RS::EnvironmentToneMapper(tone_mapper), tonemap_exposure, tonemap_white, tonemap_auto_exposure, tonemap_auto_exposure_min, tonemap_auto_exposure_max, tonemap_auto_exposure_speed, tonemap_auto_exposure_grey);
+	_update_tonemap();
 }
 
 float Environment::get_tonemap_white() const {
 	return tonemap_white;
 }
 
-void Environment::set_tonemap_auto_exposure(bool p_enabled) {
-	tonemap_auto_exposure = p_enabled;
-	RS::get_singleton()->environment_set_tonemap(environment, RS::EnvironmentToneMapper(tone_mapper), tonemap_exposure, tonemap_white, tonemap_auto_exposure, tonemap_auto_exposure_min, tonemap_auto_exposure_max, tonemap_auto_exposure_speed, tonemap_auto_exposure_grey);
+void Environment::set_tonemap_auto_exposure_enabled(bool p_enabled) {
+	tonemap_auto_exposure_enabled = p_enabled;
+	_update_tonemap();
 	_change_notify();
 }
 
-bool Environment::get_tonemap_auto_exposure() const {
-	return tonemap_auto_exposure;
-}
-
-void Environment::set_tonemap_auto_exposure_max(float p_auto_exposure_max) {
-	tonemap_auto_exposure_max = p_auto_exposure_max;
-	RS::get_singleton()->environment_set_tonemap(environment, RS::EnvironmentToneMapper(tone_mapper), tonemap_exposure, tonemap_white, tonemap_auto_exposure, tonemap_auto_exposure_min, tonemap_auto_exposure_max, tonemap_auto_exposure_speed, tonemap_auto_exposure_grey);
-}
-
-float Environment::get_tonemap_auto_exposure_max() const {
-	return tonemap_auto_exposure_max;
+bool Environment::is_tonemap_auto_exposure_enabled() const {
+	return tonemap_auto_exposure_enabled;
 }
 
 void Environment::set_tonemap_auto_exposure_min(float p_auto_exposure_min) {
 	tonemap_auto_exposure_min = p_auto_exposure_min;
-	RS::get_singleton()->environment_set_tonemap(environment, RS::EnvironmentToneMapper(tone_mapper), tonemap_exposure, tonemap_white, tonemap_auto_exposure, tonemap_auto_exposure_min, tonemap_auto_exposure_max, tonemap_auto_exposure_speed, tonemap_auto_exposure_grey);
+	_update_tonemap();
 }
 
 float Environment::get_tonemap_auto_exposure_min() const {
 	return tonemap_auto_exposure_min;
 }
 
+void Environment::set_tonemap_auto_exposure_max(float p_auto_exposure_max) {
+	tonemap_auto_exposure_max = p_auto_exposure_max;
+	_update_tonemap();
+}
+
+float Environment::get_tonemap_auto_exposure_max() const {
+	return tonemap_auto_exposure_max;
+}
+
 void Environment::set_tonemap_auto_exposure_speed(float p_auto_exposure_speed) {
 	tonemap_auto_exposure_speed = p_auto_exposure_speed;
-	RS::get_singleton()->environment_set_tonemap(environment, RS::EnvironmentToneMapper(tone_mapper), tonemap_exposure, tonemap_white, tonemap_auto_exposure, tonemap_auto_exposure_min, tonemap_auto_exposure_max, tonemap_auto_exposure_speed, tonemap_auto_exposure_grey);
+	_update_tonemap();
 }
 
 float Environment::get_tonemap_auto_exposure_speed() const {
@@ -230,16 +254,597 @@ float Environment::get_tonemap_auto_exposure_speed() const {
 
 void Environment::set_tonemap_auto_exposure_grey(float p_auto_exposure_grey) {
 	tonemap_auto_exposure_grey = p_auto_exposure_grey;
-	RS::get_singleton()->environment_set_tonemap(environment, RS::EnvironmentToneMapper(tone_mapper), tonemap_exposure, tonemap_white, tonemap_auto_exposure, tonemap_auto_exposure_min, tonemap_auto_exposure_max, tonemap_auto_exposure_speed, tonemap_auto_exposure_grey);
+	_update_tonemap();
 }
 
 float Environment::get_tonemap_auto_exposure_grey() const {
 	return tonemap_auto_exposure_grey;
 }
 
-void Environment::set_adjustment_enable(bool p_enable) {
-	adjustment_enabled = p_enable;
-	RS::get_singleton()->environment_set_adjustment(environment, adjustment_enabled, adjustment_brightness, adjustment_contrast, adjustment_saturation, adjustment_color_correction.is_valid() ? adjustment_color_correction->get_rid() : RID());
+void Environment::_update_tonemap() {
+	RS::get_singleton()->environment_set_tonemap(
+			environment,
+			RS::EnvironmentToneMapper(tone_mapper),
+			tonemap_exposure,
+			tonemap_white,
+			tonemap_auto_exposure_enabled,
+			tonemap_auto_exposure_min,
+			tonemap_auto_exposure_max,
+			tonemap_auto_exposure_speed,
+			tonemap_auto_exposure_grey);
+}
+
+// SSR
+
+void Environment::set_ssr_enabled(bool p_enabled) {
+	ssr_enabled = p_enabled;
+	_update_ssr();
+	_change_notify();
+}
+
+bool Environment::is_ssr_enabled() const {
+	return ssr_enabled;
+}
+
+void Environment::set_ssr_max_steps(int p_steps) {
+	ssr_max_steps = p_steps;
+	_update_ssr();
+}
+
+int Environment::get_ssr_max_steps() const {
+	return ssr_max_steps;
+}
+
+void Environment::set_ssr_fade_in(float p_fade_in) {
+	ssr_fade_in = p_fade_in;
+	_update_ssr();
+}
+
+float Environment::get_ssr_fade_in() const {
+	return ssr_fade_in;
+}
+
+void Environment::set_ssr_fade_out(float p_fade_out) {
+	ssr_fade_out = p_fade_out;
+	_update_ssr();
+}
+
+float Environment::get_ssr_fade_out() const {
+	return ssr_fade_out;
+}
+
+void Environment::set_ssr_depth_tolerance(float p_depth_tolerance) {
+	ssr_depth_tolerance = p_depth_tolerance;
+	_update_ssr();
+}
+
+float Environment::get_ssr_depth_tolerance() const {
+	return ssr_depth_tolerance;
+}
+
+void Environment::_update_ssr() {
+	RS::get_singleton()->environment_set_ssr(
+			environment,
+			ssr_enabled,
+			ssr_max_steps,
+			ssr_fade_in,
+			ssr_fade_out,
+			ssr_depth_tolerance);
+}
+
+// SSAO
+
+void Environment::set_ssao_enabled(bool p_enabled) {
+	ssao_enabled = p_enabled;
+	_update_ssao();
+	_change_notify();
+}
+
+bool Environment::is_ssao_enabled() const {
+	return ssao_enabled;
+}
+
+void Environment::set_ssao_radius(float p_radius) {
+	ssao_radius = p_radius;
+	_update_ssao();
+}
+
+float Environment::get_ssao_radius() const {
+	return ssao_radius;
+}
+
+void Environment::set_ssao_intensity(float p_intensity) {
+	ssao_intensity = p_intensity;
+	_update_ssao();
+}
+
+float Environment::get_ssao_intensity() const {
+	return ssao_intensity;
+}
+
+void Environment::set_ssao_bias(float p_bias) {
+	ssao_bias = p_bias;
+	_update_ssao();
+}
+
+float Environment::get_ssao_bias() const {
+	return ssao_bias;
+}
+
+void Environment::set_ssao_direct_light_affect(float p_direct_light_affect) {
+	ssao_direct_light_affect = p_direct_light_affect;
+	_update_ssao();
+}
+
+float Environment::get_ssao_direct_light_affect() const {
+	return ssao_direct_light_affect;
+}
+
+void Environment::set_ssao_ao_channel_affect(float p_ao_channel_affect) {
+	ssao_ao_channel_affect = p_ao_channel_affect;
+	_update_ssao();
+}
+
+float Environment::get_ssao_ao_channel_affect() const {
+	return ssao_ao_channel_affect;
+}
+
+void Environment::set_ssao_blur(SSAOBlur p_blur) {
+	ssao_blur = p_blur;
+	_update_ssao();
+}
+
+Environment::SSAOBlur Environment::get_ssao_blur() const {
+	return ssao_blur;
+}
+
+void Environment::set_ssao_edge_sharpness(float p_edge_sharpness) {
+	ssao_edge_sharpness = p_edge_sharpness;
+	_update_ssao();
+}
+
+float Environment::get_ssao_edge_sharpness() const {
+	return ssao_edge_sharpness;
+}
+
+void Environment::_update_ssao() {
+	RS::get_singleton()->environment_set_ssao(
+			environment,
+			ssao_enabled,
+			ssao_radius,
+			ssao_intensity,
+			ssao_bias,
+			ssao_direct_light_affect,
+			ssao_ao_channel_affect,
+			RS::EnvironmentSSAOBlur(ssao_blur),
+			ssao_edge_sharpness);
+}
+
+// SDFGI
+
+void Environment::set_sdfgi_enabled(bool p_enabled) {
+	sdfgi_enabled = p_enabled;
+	_update_sdfgi();
+}
+
+bool Environment::is_sdfgi_enabled() const {
+	return sdfgi_enabled;
+}
+
+void Environment::set_sdfgi_cascades(SDFGICascades p_cascades) {
+	sdfgi_cascades = p_cascades;
+	_update_sdfgi();
+}
+
+Environment::SDFGICascades Environment::get_sdfgi_cascades() const {
+	return sdfgi_cascades;
+}
+
+void Environment::set_sdfgi_min_cell_size(float p_size) {
+	sdfgi_min_cell_size = p_size;
+	_change_notify("sdfgi_max_distance");
+	_change_notify("sdfgi_cascade0_distance");
+	_update_sdfgi();
+}
+
+float Environment::get_sdfgi_min_cell_size() const {
+	return sdfgi_min_cell_size;
+}
+
+void Environment::set_sdfgi_max_distance(float p_distance) {
+	p_distance /= 64.0;
+	int cc[3] = { 4, 6, 8 };
+	int cascades = cc[sdfgi_cascades];
+	for (int i = 0; i < cascades; i++) {
+		p_distance *= 0.5; //halve for each cascade
+	}
+	sdfgi_min_cell_size = p_distance;
+	_change_notify("sdfgi_min_cell_size");
+	_change_notify("sdfgi_cascade0_distance");
+	_update_sdfgi();
+}
+
+float Environment::get_sdfgi_max_distance() const {
+	float md = sdfgi_min_cell_size;
+	md *= 64.0;
+	int cc[3] = { 4, 6, 8 };
+	int cascades = cc[sdfgi_cascades];
+	for (int i = 0; i < cascades; i++) {
+		md *= 2.0;
+	}
+	return md;
+}
+
+void Environment::set_sdfgi_cascade0_distance(float p_distance) {
+	sdfgi_min_cell_size = p_distance / 64.0;
+	_change_notify("sdfgi_min_cell_size");
+	_change_notify("sdfgi_max_distance");
+	_update_sdfgi();
+}
+
+float Environment::get_sdfgi_cascade0_distance() const {
+	return sdfgi_min_cell_size * 64.0;
+}
+
+void Environment::set_sdfgi_y_scale(SDFGIYScale p_y_scale) {
+	sdfgi_y_scale = p_y_scale;
+	_update_sdfgi();
+}
+
+Environment::SDFGIYScale Environment::get_sdfgi_y_scale() const {
+	return sdfgi_y_scale;
+}
+
+void Environment::set_sdfgi_use_occlusion(bool p_enabled) {
+	sdfgi_use_occlusion = p_enabled;
+	_update_sdfgi();
+}
+
+bool Environment::is_sdfgi_using_occlusion() const {
+	return sdfgi_use_occlusion;
+}
+
+void Environment::set_sdfgi_use_multi_bounce(bool p_enabled) {
+	sdfgi_use_multibounce = p_enabled;
+	_update_sdfgi();
+}
+
+bool Environment::is_sdfgi_using_multi_bounce() const {
+	return sdfgi_use_multibounce;
+}
+
+void Environment::set_sdfgi_read_sky_light(bool p_enabled) {
+	sdfgi_read_sky_light = p_enabled;
+	_update_sdfgi();
+}
+
+bool Environment::is_sdfgi_reading_sky_light() const {
+	return sdfgi_read_sky_light;
+}
+
+void Environment::set_sdfgi_energy(float p_energy) {
+	sdfgi_energy = p_energy;
+	_update_sdfgi();
+}
+
+float Environment::get_sdfgi_energy() const {
+	return sdfgi_energy;
+}
+
+void Environment::set_sdfgi_normal_bias(float p_bias) {
+	sdfgi_normal_bias = p_bias;
+	_update_sdfgi();
+}
+
+float Environment::get_sdfgi_normal_bias() const {
+	return sdfgi_normal_bias;
+}
+
+void Environment::set_sdfgi_probe_bias(float p_bias) {
+	sdfgi_probe_bias = p_bias;
+	_update_sdfgi();
+}
+
+float Environment::get_sdfgi_probe_bias() const {
+	return sdfgi_probe_bias;
+}
+
+void Environment::_update_sdfgi() {
+	RS::get_singleton()->environment_set_sdfgi(
+			environment,
+			sdfgi_enabled,
+			RS::EnvironmentSDFGICascades(sdfgi_cascades),
+			sdfgi_min_cell_size,
+			RS::EnvironmentSDFGIYScale(sdfgi_y_scale),
+			sdfgi_use_occlusion,
+			sdfgi_use_multibounce,
+			sdfgi_read_sky_light,
+			sdfgi_energy,
+			sdfgi_normal_bias,
+			sdfgi_probe_bias);
+}
+
+// Glow
+
+void Environment::set_glow_enabled(bool p_enabled) {
+	glow_enabled = p_enabled;
+	_update_glow();
+	_change_notify();
+}
+
+bool Environment::is_glow_enabled() const {
+	return glow_enabled;
+}
+
+void Environment::set_glow_level_enabled(int p_level, bool p_enabled) {
+	ERR_FAIL_INDEX(p_level, RS::MAX_GLOW_LEVELS);
+
+	if (p_enabled) {
+		glow_levels |= (1 << p_level);
+	} else {
+		glow_levels &= ~(1 << p_level);
+	}
+
+	_update_glow();
+}
+
+bool Environment::is_glow_level_enabled(int p_level) const {
+	ERR_FAIL_INDEX_V(p_level, RS::MAX_GLOW_LEVELS, false);
+
+	return glow_levels & (1 << p_level);
+}
+
+void Environment::set_glow_intensity(float p_intensity) {
+	glow_intensity = p_intensity;
+	_update_glow();
+}
+
+float Environment::get_glow_intensity() const {
+	return glow_intensity;
+}
+
+void Environment::set_glow_strength(float p_strength) {
+	glow_strength = p_strength;
+	_update_glow();
+}
+
+float Environment::get_glow_strength() const {
+	return glow_strength;
+}
+
+void Environment::set_glow_mix(float p_mix) {
+	glow_mix = p_mix;
+	_update_glow();
+}
+
+float Environment::get_glow_mix() const {
+	return glow_mix;
+}
+
+void Environment::set_glow_bloom(float p_threshold) {
+	glow_bloom = p_threshold;
+	_update_glow();
+}
+
+float Environment::get_glow_bloom() const {
+	return glow_bloom;
+}
+
+void Environment::set_glow_blend_mode(GlowBlendMode p_mode) {
+	glow_blend_mode = p_mode;
+	_update_glow();
+	_change_notify();
+}
+
+Environment::GlowBlendMode Environment::get_glow_blend_mode() const {
+	return glow_blend_mode;
+}
+
+void Environment::set_glow_hdr_bleed_threshold(float p_threshold) {
+	glow_hdr_bleed_threshold = p_threshold;
+	_update_glow();
+}
+
+float Environment::get_glow_hdr_bleed_threshold() const {
+	return glow_hdr_bleed_threshold;
+}
+
+void Environment::set_glow_hdr_bleed_scale(float p_scale) {
+	glow_hdr_bleed_scale = p_scale;
+	_update_glow();
+}
+
+float Environment::get_glow_hdr_bleed_scale() const {
+	return glow_hdr_bleed_scale;
+}
+
+void Environment::set_glow_hdr_luminance_cap(float p_amount) {
+	glow_hdr_luminance_cap = p_amount;
+	_update_glow();
+}
+
+float Environment::get_glow_hdr_luminance_cap() const {
+	return glow_hdr_luminance_cap;
+}
+
+void Environment::_update_glow() {
+	RS::get_singleton()->environment_set_glow(
+			environment,
+			glow_enabled,
+			glow_levels,
+			glow_intensity,
+			glow_strength,
+			glow_mix,
+			glow_bloom,
+			RS::EnvironmentGlowBlendMode(glow_blend_mode),
+			glow_hdr_bleed_threshold,
+			glow_hdr_bleed_scale,
+			glow_hdr_luminance_cap);
+}
+
+// Fog
+
+void Environment::set_fog_enabled(bool p_enabled) {
+	fog_enabled = p_enabled;
+	_update_fog();
+	_change_notify();
+}
+
+bool Environment::is_fog_enabled() const {
+	return fog_enabled;
+}
+
+void Environment::set_fog_color(const Color &p_color) {
+	fog_color = p_color;
+	_update_fog();
+}
+
+Color Environment::get_fog_color() const {
+	return fog_color;
+}
+
+void Environment::set_fog_sun_color(const Color &p_color) {
+	fog_sun_color = p_color;
+	_update_fog();
+}
+
+Color Environment::get_fog_sun_color() const {
+	return fog_sun_color;
+}
+
+void Environment::set_fog_sun_amount(float p_amount) {
+	fog_sun_amount = p_amount;
+	_update_fog();
+}
+
+float Environment::get_fog_sun_amount() const {
+	return fog_sun_amount;
+}
+
+void Environment::_update_fog() {
+	RS::get_singleton()->environment_set_fog(
+			environment,
+			fog_enabled,
+			fog_color,
+			fog_sun_color,
+			fog_sun_amount);
+}
+
+void Environment::set_fog_depth_enabled(bool p_enabled) {
+	fog_depth_enabled = p_enabled;
+	_update_fog_depth();
+}
+
+bool Environment::is_fog_depth_enabled() const {
+	return fog_depth_enabled;
+}
+
+void Environment::set_fog_depth_begin(float p_distance) {
+	fog_depth_begin = p_distance;
+	_update_fog_depth();
+}
+
+float Environment::get_fog_depth_begin() const {
+	return fog_depth_begin;
+}
+
+void Environment::set_fog_depth_end(float p_distance) {
+	fog_depth_end = p_distance;
+	_update_fog_depth();
+}
+
+float Environment::get_fog_depth_end() const {
+	return fog_depth_end;
+}
+
+void Environment::set_fog_depth_curve(float p_curve) {
+	fog_depth_curve = p_curve;
+	_update_fog_depth();
+}
+
+float Environment::get_fog_depth_curve() const {
+	return fog_depth_curve;
+}
+
+void Environment::set_fog_transmit_enabled(bool p_enabled) {
+	fog_transmit_enabled = p_enabled;
+	_update_fog_depth();
+}
+
+bool Environment::is_fog_transmit_enabled() const {
+	return fog_transmit_enabled;
+}
+
+void Environment::set_fog_transmit_curve(float p_curve) {
+	fog_transmit_curve = p_curve;
+	_update_fog_depth();
+}
+
+float Environment::get_fog_transmit_curve() const {
+	return fog_transmit_curve;
+}
+
+void Environment::_update_fog_depth() {
+	RS::get_singleton()->environment_set_fog_depth(
+			environment,
+			fog_depth_enabled,
+			fog_depth_begin,
+			fog_depth_end,
+			fog_depth_curve,
+			fog_transmit_enabled,
+			fog_transmit_curve);
+}
+
+void Environment::set_fog_height_enabled(bool p_enabled) {
+	fog_height_enabled = p_enabled;
+	_update_fog_height();
+}
+
+bool Environment::is_fog_height_enabled() const {
+	return fog_height_enabled;
+}
+
+void Environment::set_fog_height_min(float p_distance) {
+	fog_height_min = p_distance;
+	_update_fog_height();
+}
+
+float Environment::get_fog_height_min() const {
+	return fog_height_min;
+}
+
+void Environment::set_fog_height_max(float p_distance) {
+	fog_height_max = p_distance;
+	_update_fog_height();
+}
+
+float Environment::get_fog_height_max() const {
+	return fog_height_max;
+}
+
+void Environment::set_fog_height_curve(float p_distance) {
+	fog_height_curve = p_distance;
+	_update_fog_height();
+}
+
+float Environment::get_fog_height_curve() const {
+	return fog_height_curve;
+}
+
+void Environment::_update_fog_height() {
+	RS::get_singleton()->environment_set_fog_height(
+			environment,
+			fog_height_enabled,
+			fog_height_min,
+			fog_height_max,
+			fog_height_curve);
+}
+
+// Adjustment
+
+void Environment::set_adjustment_enabled(bool p_enabled) {
+	adjustment_enabled = p_enabled;
+	_update_adjustment();
 	_change_notify();
 }
 
@@ -249,7 +854,7 @@ bool Environment::is_adjustment_enabled() const {
 
 void Environment::set_adjustment_brightness(float p_brightness) {
 	adjustment_brightness = p_brightness;
-	RS::get_singleton()->environment_set_adjustment(environment, adjustment_enabled, adjustment_brightness, adjustment_contrast, adjustment_saturation, adjustment_color_correction.is_valid() ? adjustment_color_correction->get_rid() : RID());
+	_update_adjustment();
 }
 
 float Environment::get_adjustment_brightness() const {
@@ -258,7 +863,7 @@ float Environment::get_adjustment_brightness() const {
 
 void Environment::set_adjustment_contrast(float p_contrast) {
 	adjustment_contrast = p_contrast;
-	RS::get_singleton()->environment_set_adjustment(environment, adjustment_enabled, adjustment_brightness, adjustment_contrast, adjustment_saturation, adjustment_color_correction.is_valid() ? adjustment_color_correction->get_rid() : RID());
+	_update_adjustment();
 }
 
 float Environment::get_adjustment_contrast() const {
@@ -267,7 +872,7 @@ float Environment::get_adjustment_contrast() const {
 
 void Environment::set_adjustment_saturation(float p_saturation) {
 	adjustment_saturation = p_saturation;
-	RS::get_singleton()->environment_set_adjustment(environment, adjustment_enabled, adjustment_brightness, adjustment_contrast, adjustment_saturation, adjustment_color_correction.is_valid() ? adjustment_color_correction->get_rid() : RID());
+	_update_adjustment();
 }
 
 float Environment::get_adjustment_saturation() const {
@@ -276,12 +881,24 @@ float Environment::get_adjustment_saturation() const {
 
 void Environment::set_adjustment_color_correction(const Ref<Texture2D> &p_ramp) {
 	adjustment_color_correction = p_ramp;
-	RS::get_singleton()->environment_set_adjustment(environment, adjustment_enabled, adjustment_brightness, adjustment_contrast, adjustment_saturation, adjustment_color_correction.is_valid() ? adjustment_color_correction->get_rid() : RID());
+	_update_adjustment();
 }
 
 Ref<Texture2D> Environment::get_adjustment_color_correction() const {
 	return adjustment_color_correction;
 }
+
+void Environment::_update_adjustment() {
+	RS::get_singleton()->environment_set_adjustment(
+			environment,
+			adjustment_enabled,
+			adjustment_brightness,
+			adjustment_contrast,
+			adjustment_saturation,
+			adjustment_color_correction.is_valid() ? adjustment_color_correction->get_rid() : RID());
+}
+
+// Private methods, constructor and destructor
 
 void Environment::_validate_property(PropertyInfo &property) const {
 	if (property.name == "sky" || property.name == "sky_custom_fov" || property.name == "sky_rotation" || property.name == "ambient_light/sky_contribution") {
@@ -364,368 +981,6 @@ void Environment::_validate_property(PropertyInfo &property) const {
 	}
 }
 
-void Environment::set_ssr_enabled(bool p_enable) {
-	ssr_enabled = p_enable;
-	RS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance);
-	_change_notify();
-}
-
-bool Environment::is_ssr_enabled() const {
-	return ssr_enabled;
-}
-
-void Environment::set_ssr_max_steps(int p_steps) {
-	ssr_max_steps = p_steps;
-	RS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance);
-}
-
-int Environment::get_ssr_max_steps() const {
-	return ssr_max_steps;
-}
-
-void Environment::set_ssr_fade_in(float p_fade_in) {
-	ssr_fade_in = p_fade_in;
-	RS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance);
-}
-
-float Environment::get_ssr_fade_in() const {
-	return ssr_fade_in;
-}
-
-void Environment::set_ssr_fade_out(float p_fade_out) {
-	ssr_fade_out = p_fade_out;
-	RS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance);
-}
-
-float Environment::get_ssr_fade_out() const {
-	return ssr_fade_out;
-}
-
-void Environment::set_ssr_depth_tolerance(float p_depth_tolerance) {
-	ssr_depth_tolerance = p_depth_tolerance;
-	RS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance);
-}
-
-float Environment::get_ssr_depth_tolerance() const {
-	return ssr_depth_tolerance;
-}
-
-void Environment::set_ssao_enabled(bool p_enable) {
-	ssao_enabled = p_enable;
-	RS::get_singleton()->environment_set_ssao(environment, ssao_enabled, ssao_radius, ssao_intensity, ssao_bias, ssao_direct_light_affect, ssao_ao_channel_affect, RS::EnvironmentSSAOBlur(ssao_blur), ssao_edge_sharpness);
-	_change_notify();
-}
-
-bool Environment::is_ssao_enabled() const {
-	return ssao_enabled;
-}
-
-void Environment::set_ssao_radius(float p_radius) {
-	ssao_radius = p_radius;
-	RS::get_singleton()->environment_set_ssao(environment, ssao_enabled, ssao_radius, ssao_intensity, ssao_bias, ssao_direct_light_affect, ssao_ao_channel_affect, RS::EnvironmentSSAOBlur(ssao_blur), ssao_edge_sharpness);
-}
-
-float Environment::get_ssao_radius() const {
-	return ssao_radius;
-}
-
-void Environment::set_ssao_intensity(float p_intensity) {
-	ssao_intensity = p_intensity;
-	RS::get_singleton()->environment_set_ssao(environment, ssao_enabled, ssao_radius, ssao_intensity, ssao_bias, ssao_direct_light_affect, ssao_ao_channel_affect, RS::EnvironmentSSAOBlur(ssao_blur), ssao_edge_sharpness);
-}
-
-float Environment::get_ssao_intensity() const {
-	return ssao_intensity;
-}
-
-void Environment::set_ssao_bias(float p_bias) {
-	ssao_bias = p_bias;
-	RS::get_singleton()->environment_set_ssao(environment, ssao_enabled, ssao_radius, ssao_intensity, ssao_bias, ssao_direct_light_affect, ssao_ao_channel_affect, RS::EnvironmentSSAOBlur(ssao_blur), ssao_edge_sharpness);
-}
-
-float Environment::get_ssao_bias() const {
-	return ssao_bias;
-}
-
-void Environment::set_ssao_direct_light_affect(float p_direct_light_affect) {
-	ssao_direct_light_affect = p_direct_light_affect;
-	RS::get_singleton()->environment_set_ssao(environment, ssao_enabled, ssao_radius, ssao_intensity, ssao_bias, ssao_direct_light_affect, ssao_ao_channel_affect, RS::EnvironmentSSAOBlur(ssao_blur), ssao_edge_sharpness);
-}
-
-float Environment::get_ssao_direct_light_affect() const {
-	return ssao_direct_light_affect;
-}
-
-void Environment::set_ssao_ao_channel_affect(float p_ao_channel_affect) {
-	ssao_ao_channel_affect = p_ao_channel_affect;
-	RS::get_singleton()->environment_set_ssao(environment, ssao_enabled, ssao_radius, ssao_intensity, ssao_bias, ssao_direct_light_affect, ssao_ao_channel_affect, RS::EnvironmentSSAOBlur(ssao_blur), ssao_edge_sharpness);
-}
-
-float Environment::get_ssao_ao_channel_affect() const {
-	return ssao_ao_channel_affect;
-}
-
-void Environment::set_ao_color(const Color &p_color) {
-	ao_color = p_color;
-	RS::get_singleton()->environment_set_ambient_light(environment, ambient_color, RS::EnvironmentAmbientSource(ambient_source), ambient_energy, ambient_sky_contribution, RS::EnvironmentReflectionSource(reflection_source), ao_color);
-}
-
-Color Environment::get_ao_color() const {
-	return ao_color;
-}
-
-void Environment::set_ssao_blur(SSAOBlur p_blur) {
-	ssao_blur = p_blur;
-	RS::get_singleton()->environment_set_ssao(environment, ssao_enabled, ssao_radius, ssao_intensity, ssao_bias, ssao_direct_light_affect, ssao_ao_channel_affect, RS::EnvironmentSSAOBlur(ssao_blur), ssao_edge_sharpness);
-}
-
-Environment::SSAOBlur Environment::get_ssao_blur() const {
-	return ssao_blur;
-}
-
-void Environment::set_ssao_edge_sharpness(float p_edge_sharpness) {
-	ssao_edge_sharpness = p_edge_sharpness;
-	RS::get_singleton()->environment_set_ssao(environment, ssao_enabled, ssao_radius, ssao_intensity, ssao_bias, ssao_direct_light_affect, ssao_ao_channel_affect, RS::EnvironmentSSAOBlur(ssao_blur), ssao_edge_sharpness);
-}
-
-float Environment::get_ssao_edge_sharpness() const {
-	return ssao_edge_sharpness;
-}
-
-void Environment::set_glow_enabled(bool p_enabled) {
-	glow_enabled = p_enabled;
-	RS::get_singleton()->environment_set_glow(environment, glow_enabled, glow_levels, glow_intensity, glow_strength, glow_mix, glow_bloom, RS::EnvironmentGlowBlendMode(glow_blend_mode), glow_hdr_bleed_threshold, glow_hdr_bleed_threshold, glow_hdr_luminance_cap);
-	_change_notify();
-}
-
-bool Environment::is_glow_enabled() const {
-	return glow_enabled;
-}
-
-void Environment::set_glow_level(int p_level, bool p_enabled) {
-	ERR_FAIL_INDEX(p_level, RS::MAX_GLOW_LEVELS);
-
-	if (p_enabled) {
-		glow_levels |= (1 << p_level);
-	} else {
-		glow_levels &= ~(1 << p_level);
-	}
-
-	RS::get_singleton()->environment_set_glow(environment, glow_enabled, glow_levels, glow_intensity, glow_strength, glow_mix, glow_bloom, RS::EnvironmentGlowBlendMode(glow_blend_mode), glow_hdr_bleed_threshold, glow_hdr_bleed_threshold, glow_hdr_luminance_cap);
-}
-
-bool Environment::is_glow_level_enabled(int p_level) const {
-	ERR_FAIL_INDEX_V(p_level, RS::MAX_GLOW_LEVELS, false);
-
-	return glow_levels & (1 << p_level);
-}
-
-void Environment::set_glow_intensity(float p_intensity) {
-	glow_intensity = p_intensity;
-
-	RS::get_singleton()->environment_set_glow(environment, glow_enabled, glow_levels, glow_intensity, glow_strength, glow_mix, glow_bloom, RS::EnvironmentGlowBlendMode(glow_blend_mode), glow_hdr_bleed_threshold, glow_hdr_bleed_threshold, glow_hdr_luminance_cap);
-}
-
-float Environment::get_glow_intensity() const {
-	return glow_intensity;
-}
-
-void Environment::set_glow_strength(float p_strength) {
-	glow_strength = p_strength;
-	RS::get_singleton()->environment_set_glow(environment, glow_enabled, glow_levels, glow_intensity, glow_strength, glow_mix, glow_bloom, RS::EnvironmentGlowBlendMode(glow_blend_mode), glow_hdr_bleed_threshold, glow_hdr_bleed_threshold, glow_hdr_luminance_cap);
-}
-
-float Environment::get_glow_strength() const {
-	return glow_strength;
-}
-
-void Environment::set_glow_mix(float p_mix) {
-	glow_mix = p_mix;
-	RS::get_singleton()->environment_set_glow(environment, glow_enabled, glow_levels, glow_intensity, glow_strength, glow_mix, glow_bloom, RS::EnvironmentGlowBlendMode(glow_blend_mode), glow_hdr_bleed_threshold, glow_hdr_bleed_threshold, glow_hdr_luminance_cap);
-}
-
-float Environment::get_glow_mix() const {
-	return glow_mix;
-}
-
-void Environment::set_glow_bloom(float p_threshold) {
-	glow_bloom = p_threshold;
-
-	RS::get_singleton()->environment_set_glow(environment, glow_enabled, glow_levels, glow_intensity, glow_strength, glow_mix, glow_bloom, RS::EnvironmentGlowBlendMode(glow_blend_mode), glow_hdr_bleed_threshold, glow_hdr_bleed_threshold, glow_hdr_luminance_cap);
-}
-
-float Environment::get_glow_bloom() const {
-	return glow_bloom;
-}
-
-void Environment::set_glow_blend_mode(GlowBlendMode p_mode) {
-	glow_blend_mode = p_mode;
-
-	RS::get_singleton()->environment_set_glow(environment, glow_enabled, glow_levels, glow_intensity, glow_strength, glow_mix, glow_bloom, RS::EnvironmentGlowBlendMode(glow_blend_mode), glow_hdr_bleed_threshold, glow_hdr_bleed_threshold, glow_hdr_luminance_cap);
-	_change_notify();
-}
-
-Environment::GlowBlendMode Environment::get_glow_blend_mode() const {
-	return glow_blend_mode;
-}
-
-void Environment::set_glow_hdr_bleed_threshold(float p_threshold) {
-	glow_hdr_bleed_threshold = p_threshold;
-
-	RS::get_singleton()->environment_set_glow(environment, glow_enabled, glow_levels, glow_intensity, glow_strength, glow_mix, glow_bloom, RS::EnvironmentGlowBlendMode(glow_blend_mode), glow_hdr_bleed_threshold, glow_hdr_bleed_threshold, glow_hdr_luminance_cap);
-}
-
-float Environment::get_glow_hdr_bleed_threshold() const {
-	return glow_hdr_bleed_threshold;
-}
-
-void Environment::set_glow_hdr_luminance_cap(float p_amount) {
-	glow_hdr_luminance_cap = p_amount;
-
-	RS::get_singleton()->environment_set_glow(environment, glow_enabled, glow_levels, glow_intensity, glow_strength, glow_mix, glow_bloom, RS::EnvironmentGlowBlendMode(glow_blend_mode), glow_hdr_bleed_threshold, glow_hdr_bleed_threshold, glow_hdr_luminance_cap);
-}
-
-float Environment::get_glow_hdr_luminance_cap() const {
-	return glow_hdr_luminance_cap;
-}
-
-void Environment::set_glow_hdr_bleed_scale(float p_scale) {
-	glow_hdr_bleed_scale = p_scale;
-
-	RS::get_singleton()->environment_set_glow(environment, glow_enabled, glow_levels, glow_intensity, glow_strength, glow_mix, glow_bloom, RS::EnvironmentGlowBlendMode(glow_blend_mode), glow_hdr_bleed_threshold, glow_hdr_bleed_threshold, glow_hdr_luminance_cap);
-}
-
-float Environment::get_glow_hdr_bleed_scale() const {
-	return glow_hdr_bleed_scale;
-}
-
-void Environment::set_fog_enabled(bool p_enabled) {
-	fog_enabled = p_enabled;
-	RS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount);
-	_change_notify();
-}
-
-bool Environment::is_fog_enabled() const {
-	return fog_enabled;
-}
-
-void Environment::set_fog_color(const Color &p_color) {
-	fog_color = p_color;
-	RS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount);
-}
-
-Color Environment::get_fog_color() const {
-	return fog_color;
-}
-
-void Environment::set_fog_sun_color(const Color &p_color) {
-	fog_sun_color = p_color;
-	RS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount);
-}
-
-Color Environment::get_fog_sun_color() const {
-	return fog_sun_color;
-}
-
-void Environment::set_fog_sun_amount(float p_amount) {
-	fog_sun_amount = p_amount;
-	RS::get_singleton()->environment_set_fog(environment, fog_enabled, fog_color, fog_sun_color, fog_sun_amount);
-}
-
-float Environment::get_fog_sun_amount() const {
-	return fog_sun_amount;
-}
-
-void Environment::set_fog_depth_enabled(bool p_enabled) {
-	fog_depth_enabled = p_enabled;
-	RS::get_singleton()->environment_set_fog_depth(environment, fog_depth_enabled, fog_depth_begin, fog_depth_end, fog_depth_curve, fog_transmit_enabled, fog_transmit_curve);
-}
-
-bool Environment::is_fog_depth_enabled() const {
-	return fog_depth_enabled;
-}
-
-void Environment::set_fog_depth_begin(float p_distance) {
-	fog_depth_begin = p_distance;
-	RS::get_singleton()->environment_set_fog_depth(environment, fog_depth_enabled, fog_depth_begin, fog_depth_end, fog_depth_curve, fog_transmit_enabled, fog_transmit_curve);
-}
-
-float Environment::get_fog_depth_begin() const {
-	return fog_depth_begin;
-}
-
-void Environment::set_fog_depth_end(float p_distance) {
-	fog_depth_end = p_distance;
-	RS::get_singleton()->environment_set_fog_depth(environment, fog_depth_enabled, fog_depth_begin, fog_depth_end, fog_depth_curve, fog_transmit_enabled, fog_transmit_curve);
-}
-
-float Environment::get_fog_depth_end() const {
-	return fog_depth_end;
-}
-
-void Environment::set_fog_depth_curve(float p_curve) {
-	fog_depth_curve = p_curve;
-	RS::get_singleton()->environment_set_fog_depth(environment, fog_depth_enabled, fog_depth_begin, fog_depth_end, fog_depth_curve, fog_transmit_enabled, fog_transmit_curve);
-}
-
-float Environment::get_fog_depth_curve() const {
-	return fog_depth_curve;
-}
-
-void Environment::set_fog_transmit_enabled(bool p_enabled) {
-	fog_transmit_enabled = p_enabled;
-	RS::get_singleton()->environment_set_fog_depth(environment, fog_depth_enabled, fog_depth_begin, fog_depth_end, fog_depth_curve, fog_transmit_enabled, fog_transmit_curve);
-}
-
-bool Environment::is_fog_transmit_enabled() const {
-	return fog_transmit_enabled;
-}
-
-void Environment::set_fog_transmit_curve(float p_curve) {
-	fog_transmit_curve = p_curve;
-	RS::get_singleton()->environment_set_fog_depth(environment, fog_depth_enabled, fog_depth_begin, fog_depth_end, fog_depth_curve, fog_transmit_enabled, fog_transmit_curve);
-}
-
-float Environment::get_fog_transmit_curve() const {
-	return fog_transmit_curve;
-}
-
-void Environment::set_fog_height_enabled(bool p_enabled) {
-	fog_height_enabled = p_enabled;
-	RS::get_singleton()->environment_set_fog_height(environment, fog_height_enabled, fog_height_min, fog_height_max, fog_height_curve);
-}
-
-bool Environment::is_fog_height_enabled() const {
-	return fog_height_enabled;
-}
-
-void Environment::set_fog_height_min(float p_distance) {
-	fog_height_min = p_distance;
-	RS::get_singleton()->environment_set_fog_height(environment, fog_height_enabled, fog_height_min, fog_height_max, fog_height_curve);
-}
-
-float Environment::get_fog_height_min() const {
-	return fog_height_min;
-}
-
-void Environment::set_fog_height_max(float p_distance) {
-	fog_height_max = p_distance;
-	RS::get_singleton()->environment_set_fog_height(environment, fog_height_enabled, fog_height_min, fog_height_max, fog_height_curve);
-}
-
-float Environment::get_fog_height_max() const {
-	return fog_height_max;
-}
-
-void Environment::set_fog_height_curve(float p_distance) {
-	fog_height_curve = p_distance;
-	RS::get_singleton()->environment_set_fog_height(environment, fog_height_enabled, fog_height_min, fog_height_max, fog_height_curve);
-}
-
-float Environment::get_fog_height_curve() const {
-	return fog_height_curve;
-}
-
 #ifndef DISABLE_DEPRECATED
 // Kept for compatibility from 3.x to 4.0.
 bool Environment::_set(const StringName &p_name, const Variant &p_value) {
@@ -745,264 +1000,79 @@ bool Environment::_set(const StringName &p_name, const Variant &p_value) {
 }
 #endif
 
-void Environment::set_sdfgi_enabled(bool p_enabled) {
-	sdfgi_enabled = p_enabled;
-	_update_sdfgi();
-}
-
-bool Environment::is_sdfgi_enabled() const {
-	return sdfgi_enabled;
-}
-
-void Environment::set_sdfgi_cascades(SDFGICascades p_cascades) {
-	sdfgi_cascades = p_cascades;
-	_update_sdfgi();
-}
-Environment::SDFGICascades Environment::get_sdfgi_cascades() const {
-	return sdfgi_cascades;
-}
-
-void Environment::set_sdfgi_min_cell_size(float p_size) {
-	sdfgi_min_cell_size = p_size;
-	_change_notify("sdfgi_max_distance");
-	_change_notify("sdfgi_cascade0_distance");
-	_update_sdfgi();
-}
-float Environment::get_sdfgi_min_cell_size() const {
-	return sdfgi_min_cell_size;
-}
-
-void Environment::set_sdfgi_max_distance(float p_size) {
-	p_size /= 64.0;
-	int cc[3] = { 4, 6, 8 };
-	int cascades = cc[sdfgi_cascades];
-	for (int i = 0; i < cascades; i++) {
-		p_size *= 0.5; //halve for each cascade
-	}
-	sdfgi_min_cell_size = p_size;
-	_change_notify("sdfgi_min_cell_size");
-	_change_notify("sdfgi_cascade0_distance");
-	_update_sdfgi();
-}
-float Environment::get_sdfgi_max_distance() const {
-	float md = sdfgi_min_cell_size;
-	md *= 64.0;
-	int cc[3] = { 4, 6, 8 };
-	int cascades = cc[sdfgi_cascades];
-	for (int i = 0; i < cascades; i++) {
-		md *= 2.0;
-	}
-	return md;
-}
-
-void Environment::set_sdfgi_cascade0_distance(float p_size) {
-	sdfgi_min_cell_size = p_size / 64.0;
-	_change_notify("sdfgi_min_cell_size");
-	_change_notify("sdfgi_max_distance");
-	_update_sdfgi();
-}
-float Environment::get_sdfgi_cascade0_distance() const {
-	return sdfgi_min_cell_size * 64.0;
-}
-
-void Environment::set_sdfgi_use_occlusion(bool p_enable) {
-	sdfgi_use_occlusion = p_enable;
-	_update_sdfgi();
-}
-
-bool Environment::is_sdfgi_using_occlusion() const {
-	return sdfgi_use_occlusion;
-}
-
-void Environment::set_sdfgi_use_multi_bounce(bool p_enable) {
-	sdfgi_use_multibounce = p_enable;
-	_update_sdfgi();
-}
-bool Environment::is_sdfgi_using_multi_bounce() const {
-	return sdfgi_use_multibounce;
-}
-
-void Environment::set_sdfgi_use_enhance_ssr(bool p_enable) {
-	sdfgi_enhance_ssr = p_enable;
-	_update_sdfgi();
-}
-bool Environment::is_sdfgi_using_enhance_ssr() const {
-	return sdfgi_enhance_ssr;
-}
-
-void Environment::set_sdfgi_read_sky_light(bool p_enable) {
-	sdfgi_read_sky_light = p_enable;
-	_update_sdfgi();
-}
-
-bool Environment::is_sdfgi_reading_sky_light() const {
-	return sdfgi_read_sky_light;
-}
-
-void Environment::set_sdfgi_energy(float p_energy) {
-	sdfgi_energy = p_energy;
-	_update_sdfgi();
-}
-float Environment::get_sdfgi_energy() const {
-	return sdfgi_energy;
-}
-
-void Environment::set_sdfgi_normal_bias(float p_bias) {
-	sdfgi_normal_bias = p_bias;
-	_update_sdfgi();
-}
-float Environment::get_sdfgi_normal_bias() const {
-	return sdfgi_normal_bias;
-}
-
-void Environment::set_sdfgi_probe_bias(float p_bias) {
-	sdfgi_probe_bias = p_bias;
-	_update_sdfgi();
-}
-float Environment::get_sdfgi_probe_bias() const {
-	return sdfgi_probe_bias;
-}
-
-void Environment::set_sdfgi_y_scale(SDFGIYScale p_y_scale) {
-	sdfgi_y_scale = p_y_scale;
-	_update_sdfgi();
-}
-Environment::SDFGIYScale Environment::get_sdfgi_y_scale() const {
-	return sdfgi_y_scale;
-}
-void Environment::_update_sdfgi() {
-	RS::get_singleton()->environment_set_sdfgi(environment, sdfgi_enabled, RS::EnvironmentSDFGICascades(sdfgi_cascades), sdfgi_min_cell_size, RS::EnvironmentSDFGIYScale(sdfgi_y_scale), sdfgi_use_occlusion, sdfgi_use_multibounce, sdfgi_read_sky_light, sdfgi_enhance_ssr, sdfgi_energy, sdfgi_normal_bias, sdfgi_probe_bias);
-}
-
 void Environment::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_background", "mode"), &Environment::set_background);
-	ClassDB::bind_method(D_METHOD("set_sky", "sky"), &Environment::set_sky);
-	ClassDB::bind_method(D_METHOD("set_sky_custom_fov", "scale"), &Environment::set_sky_custom_fov);
-	ClassDB::bind_method(D_METHOD("set_sky_rotation", "euler_radians"), &Environment::set_sky_rotation);
-	ClassDB::bind_method(D_METHOD("set_bg_color", "color"), &Environment::set_bg_color);
-	ClassDB::bind_method(D_METHOD("set_bg_energy", "energy"), &Environment::set_bg_energy);
-	ClassDB::bind_method(D_METHOD("set_canvas_max_layer", "layer"), &Environment::set_canvas_max_layer);
-	ClassDB::bind_method(D_METHOD("set_ambient_light_color", "color"), &Environment::set_ambient_light_color);
-	ClassDB::bind_method(D_METHOD("set_ambient_light_energy", "energy"), &Environment::set_ambient_light_energy);
-	ClassDB::bind_method(D_METHOD("set_ambient_light_sky_contribution", "energy"), &Environment::set_ambient_light_sky_contribution);
-	ClassDB::bind_method(D_METHOD("set_camera_feed_id", "camera_feed_id"), &Environment::set_camera_feed_id);
-	ClassDB::bind_method(D_METHOD("set_ambient_source", "source"), &Environment::set_ambient_source);
-	ClassDB::bind_method(D_METHOD("set_reflection_source", "source"), &Environment::set_reflection_source);
+	// Background
 
+	ClassDB::bind_method(D_METHOD("set_background", "mode"), &Environment::set_background);
 	ClassDB::bind_method(D_METHOD("get_background"), &Environment::get_background);
+	ClassDB::bind_method(D_METHOD("set_sky", "sky"), &Environment::set_sky);
 	ClassDB::bind_method(D_METHOD("get_sky"), &Environment::get_sky);
+	ClassDB::bind_method(D_METHOD("set_sky_custom_fov", "scale"), &Environment::set_sky_custom_fov);
 	ClassDB::bind_method(D_METHOD("get_sky_custom_fov"), &Environment::get_sky_custom_fov);
+	ClassDB::bind_method(D_METHOD("set_sky_rotation", "euler_radians"), &Environment::set_sky_rotation);
 	ClassDB::bind_method(D_METHOD("get_sky_rotation"), &Environment::get_sky_rotation);
+	ClassDB::bind_method(D_METHOD("set_bg_color", "color"), &Environment::set_bg_color);
 	ClassDB::bind_method(D_METHOD("get_bg_color"), &Environment::get_bg_color);
+	ClassDB::bind_method(D_METHOD("set_bg_energy", "energy"), &Environment::set_bg_energy);
 	ClassDB::bind_method(D_METHOD("get_bg_energy"), &Environment::get_bg_energy);
+	ClassDB::bind_method(D_METHOD("set_canvas_max_layer", "layer"), &Environment::set_canvas_max_layer);
 	ClassDB::bind_method(D_METHOD("get_canvas_max_layer"), &Environment::get_canvas_max_layer);
-	ClassDB::bind_method(D_METHOD("get_ambient_light_color"), &Environment::get_ambient_light_color);
-	ClassDB::bind_method(D_METHOD("get_ambient_light_energy"), &Environment::get_ambient_light_energy);
-	ClassDB::bind_method(D_METHOD("get_ambient_light_sky_contribution"), &Environment::get_ambient_light_sky_contribution);
+	ClassDB::bind_method(D_METHOD("set_camera_feed_id", "id"), &Environment::set_camera_feed_id);
 	ClassDB::bind_method(D_METHOD("get_camera_feed_id"), &Environment::get_camera_feed_id);
-	ClassDB::bind_method(D_METHOD("get_ambient_source"), &Environment::get_ambient_source);
-	ClassDB::bind_method(D_METHOD("get_reflection_source"), &Environment::get_reflection_source);
-	ClassDB::bind_method(D_METHOD("set_ao_color", "color"), &Environment::set_ao_color);
-	ClassDB::bind_method(D_METHOD("get_ao_color"), &Environment::get_ao_color);
 
 	ADD_GROUP("Background", "background_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "background_mode", PROPERTY_HINT_ENUM, "Clear Color,Custom Color,Sky,Canvas,Keep,Camera Feed"), "set_background", "get_background");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "background_canvas_max_layer", PROPERTY_HINT_RANGE, "-1000,1000,1"), "set_canvas_max_layer", "get_canvas_max_layer");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "background_camera_feed_id", PROPERTY_HINT_RANGE, "1,10,1"), "set_camera_feed_id", "get_camera_feed_id");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "background_color"), "set_bg_color", "get_bg_color");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "background_energy", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_bg_energy", "get_bg_energy");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "background_canvas_max_layer", PROPERTY_HINT_RANGE, "-1000,1000,1"), "set_canvas_max_layer", "get_canvas_max_layer");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "background_camera_feed_id", PROPERTY_HINT_RANGE, "1,10,1"), "set_camera_feed_id", "get_camera_feed_id");
+
 	ADD_GROUP("Sky", "sky_");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sky", PROPERTY_HINT_RESOURCE_TYPE, "Sky"), "set_sky", "get_sky");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sky_custom_fov", PROPERTY_HINT_RANGE, "0,180,0.1"), "set_sky_custom_fov", "get_sky_custom_fov");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "sky_rotation"), "set_sky_rotation", "get_sky_rotation");
+
+	// Ambient light
+
+	ClassDB::bind_method(D_METHOD("set_ambient_light_color", "color"), &Environment::set_ambient_light_color);
+	ClassDB::bind_method(D_METHOD("get_ambient_light_color"), &Environment::get_ambient_light_color);
+	ClassDB::bind_method(D_METHOD("set_ambient_source", "source"), &Environment::set_ambient_source);
+	ClassDB::bind_method(D_METHOD("get_ambient_source"), &Environment::get_ambient_source);
+	ClassDB::bind_method(D_METHOD("set_ambient_light_energy", "energy"), &Environment::set_ambient_light_energy);
+	ClassDB::bind_method(D_METHOD("get_ambient_light_energy"), &Environment::get_ambient_light_energy);
+	ClassDB::bind_method(D_METHOD("set_ambient_light_sky_contribution", "ratio"), &Environment::set_ambient_light_sky_contribution);
+	ClassDB::bind_method(D_METHOD("get_ambient_light_sky_contribution"), &Environment::get_ambient_light_sky_contribution);
+	ClassDB::bind_method(D_METHOD("set_reflection_source", "source"), &Environment::set_reflection_source);
+	ClassDB::bind_method(D_METHOD("get_reflection_source"), &Environment::get_reflection_source);
+	ClassDB::bind_method(D_METHOD("set_ao_color", "color"), &Environment::set_ao_color);
+	ClassDB::bind_method(D_METHOD("get_ao_color"), &Environment::get_ao_color);
+
 	ADD_GROUP("Ambient Light", "ambient_light_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ambient_light_source", PROPERTY_HINT_ENUM, "Background,Disabled,Color,Sky"), "set_ambient_source", "get_ambient_source");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "ambient_light_color"), "set_ambient_light_color", "get_ambient_light_color");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ambient_light_sky_contribution", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_ambient_light_sky_contribution", "get_ambient_light_sky_contribution");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ambient_light_energy", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_ambient_light_energy", "get_ambient_light_energy");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "ambient_light_occlusion_color", PROPERTY_HINT_COLOR_NO_ALPHA), "set_ao_color", "get_ao_color");
+
 	ADD_GROUP("Reflected Light", "reflected_light_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "reflected_light_source", PROPERTY_HINT_ENUM, "Background,Disabled,Sky"), "set_reflection_source", "get_reflection_source");
 
-	ClassDB::bind_method(D_METHOD("set_fog_enabled", "enabled"), &Environment::set_fog_enabled);
-	ClassDB::bind_method(D_METHOD("is_fog_enabled"), &Environment::is_fog_enabled);
-
-	ClassDB::bind_method(D_METHOD("set_fog_color", "color"), &Environment::set_fog_color);
-	ClassDB::bind_method(D_METHOD("get_fog_color"), &Environment::get_fog_color);
-
-	ClassDB::bind_method(D_METHOD("set_fog_sun_color", "color"), &Environment::set_fog_sun_color);
-	ClassDB::bind_method(D_METHOD("get_fog_sun_color"), &Environment::get_fog_sun_color);
-
-	ClassDB::bind_method(D_METHOD("set_fog_sun_amount", "amount"), &Environment::set_fog_sun_amount);
-	ClassDB::bind_method(D_METHOD("get_fog_sun_amount"), &Environment::get_fog_sun_amount);
-
-	ClassDB::bind_method(D_METHOD("set_fog_depth_enabled", "enabled"), &Environment::set_fog_depth_enabled);
-	ClassDB::bind_method(D_METHOD("is_fog_depth_enabled"), &Environment::is_fog_depth_enabled);
-
-	ClassDB::bind_method(D_METHOD("set_fog_depth_begin", "distance"), &Environment::set_fog_depth_begin);
-	ClassDB::bind_method(D_METHOD("get_fog_depth_begin"), &Environment::get_fog_depth_begin);
-
-	ClassDB::bind_method(D_METHOD("set_fog_depth_end", "distance"), &Environment::set_fog_depth_end);
-	ClassDB::bind_method(D_METHOD("get_fog_depth_end"), &Environment::get_fog_depth_end);
-
-	ClassDB::bind_method(D_METHOD("set_fog_depth_curve", "curve"), &Environment::set_fog_depth_curve);
-	ClassDB::bind_method(D_METHOD("get_fog_depth_curve"), &Environment::get_fog_depth_curve);
-
-	ClassDB::bind_method(D_METHOD("set_fog_transmit_enabled", "enabled"), &Environment::set_fog_transmit_enabled);
-	ClassDB::bind_method(D_METHOD("is_fog_transmit_enabled"), &Environment::is_fog_transmit_enabled);
-
-	ClassDB::bind_method(D_METHOD("set_fog_transmit_curve", "curve"), &Environment::set_fog_transmit_curve);
-	ClassDB::bind_method(D_METHOD("get_fog_transmit_curve"), &Environment::get_fog_transmit_curve);
-
-	ClassDB::bind_method(D_METHOD("set_fog_height_enabled", "enabled"), &Environment::set_fog_height_enabled);
-	ClassDB::bind_method(D_METHOD("is_fog_height_enabled"), &Environment::is_fog_height_enabled);
-
-	ClassDB::bind_method(D_METHOD("set_fog_height_min", "height"), &Environment::set_fog_height_min);
-	ClassDB::bind_method(D_METHOD("get_fog_height_min"), &Environment::get_fog_height_min);
-
-	ClassDB::bind_method(D_METHOD("set_fog_height_max", "height"), &Environment::set_fog_height_max);
-	ClassDB::bind_method(D_METHOD("get_fog_height_max"), &Environment::get_fog_height_max);
-
-	ClassDB::bind_method(D_METHOD("set_fog_height_curve", "curve"), &Environment::set_fog_height_curve);
-	ClassDB::bind_method(D_METHOD("get_fog_height_curve"), &Environment::get_fog_height_curve);
-
-	ADD_GROUP("Fog", "fog_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fog_enabled"), "set_fog_enabled", "is_fog_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "fog_color"), "set_fog_color", "get_fog_color");
-	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "fog_sun_color"), "set_fog_sun_color", "get_fog_sun_color");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_sun_amount", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_fog_sun_amount", "get_fog_sun_amount");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fog_depth_enabled"), "set_fog_depth_enabled", "is_fog_depth_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_depth_begin", PROPERTY_HINT_RANGE, "0,4000,0.1"), "set_fog_depth_begin", "get_fog_depth_begin");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_depth_end", PROPERTY_HINT_RANGE, "0,4000,0.1,or_greater"), "set_fog_depth_end", "get_fog_depth_end");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_depth_curve", PROPERTY_HINT_EXP_EASING), "set_fog_depth_curve", "get_fog_depth_curve");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fog_transmit_enabled"), "set_fog_transmit_enabled", "is_fog_transmit_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_transmit_curve", PROPERTY_HINT_EXP_EASING), "set_fog_transmit_curve", "get_fog_transmit_curve");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fog_height_enabled"), "set_fog_height_enabled", "is_fog_height_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_height_min", PROPERTY_HINT_RANGE, "-4000,4000,0.1,or_lesser,or_greater"), "set_fog_height_min", "get_fog_height_min");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_height_max", PROPERTY_HINT_RANGE, "-4000,4000,0.1,or_lesser,or_greater"), "set_fog_height_max", "get_fog_height_max");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_height_curve", PROPERTY_HINT_EXP_EASING), "set_fog_height_curve", "get_fog_height_curve");
+	// Tonemap
 
 	ClassDB::bind_method(D_METHOD("set_tonemapper", "mode"), &Environment::set_tonemapper);
 	ClassDB::bind_method(D_METHOD("get_tonemapper"), &Environment::get_tonemapper);
-
 	ClassDB::bind_method(D_METHOD("set_tonemap_exposure", "exposure"), &Environment::set_tonemap_exposure);
 	ClassDB::bind_method(D_METHOD("get_tonemap_exposure"), &Environment::get_tonemap_exposure);
-
 	ClassDB::bind_method(D_METHOD("set_tonemap_white", "white"), &Environment::set_tonemap_white);
 	ClassDB::bind_method(D_METHOD("get_tonemap_white"), &Environment::get_tonemap_white);
-
-	ClassDB::bind_method(D_METHOD("set_tonemap_auto_exposure", "auto_exposure"), &Environment::set_tonemap_auto_exposure);
-	ClassDB::bind_method(D_METHOD("get_tonemap_auto_exposure"), &Environment::get_tonemap_auto_exposure);
-
+	ClassDB::bind_method(D_METHOD("set_tonemap_auto_exposure_enabled", "enabled"), &Environment::set_tonemap_auto_exposure_enabled);
+	ClassDB::bind_method(D_METHOD("is_tonemap_auto_exposure_enabled"), &Environment::is_tonemap_auto_exposure_enabled);
 	ClassDB::bind_method(D_METHOD("set_tonemap_auto_exposure_max", "exposure_max"), &Environment::set_tonemap_auto_exposure_max);
 	ClassDB::bind_method(D_METHOD("get_tonemap_auto_exposure_max"), &Environment::get_tonemap_auto_exposure_max);
-
 	ClassDB::bind_method(D_METHOD("set_tonemap_auto_exposure_min", "exposure_min"), &Environment::set_tonemap_auto_exposure_min);
 	ClassDB::bind_method(D_METHOD("get_tonemap_auto_exposure_min"), &Environment::get_tonemap_auto_exposure_min);
-
 	ClassDB::bind_method(D_METHOD("set_tonemap_auto_exposure_speed", "exposure_speed"), &Environment::set_tonemap_auto_exposure_speed);
 	ClassDB::bind_method(D_METHOD("get_tonemap_auto_exposure_speed"), &Environment::get_tonemap_auto_exposure_speed);
-
 	ClassDB::bind_method(D_METHOD("set_tonemap_auto_exposure_grey", "exposure_grey"), &Environment::set_tonemap_auto_exposure_grey);
 	ClassDB::bind_method(D_METHOD("get_tonemap_auto_exposure_grey"), &Environment::get_tonemap_auto_exposure_grey);
 
@@ -1011,24 +1081,22 @@ void Environment::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_exposure", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_tonemap_exposure", "get_tonemap_exposure");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_white", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_tonemap_white", "get_tonemap_white");
 	ADD_GROUP("Auto Exposure", "auto_exposure_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_exposure_enabled"), "set_tonemap_auto_exposure", "get_tonemap_auto_exposure");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_exposure_enabled"), "set_tonemap_auto_exposure_enabled", "is_tonemap_auto_exposure_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auto_exposure_scale", PROPERTY_HINT_RANGE, "0.01,64,0.01"), "set_tonemap_auto_exposure_grey", "get_tonemap_auto_exposure_grey");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auto_exposure_min_luma", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_tonemap_auto_exposure_min", "get_tonemap_auto_exposure_min");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auto_exposure_max_luma", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_tonemap_auto_exposure_max", "get_tonemap_auto_exposure_max");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auto_exposure_speed", PROPERTY_HINT_RANGE, "0.01,64,0.01"), "set_tonemap_auto_exposure_speed", "get_tonemap_auto_exposure_speed");
 
+	// SSR
+
 	ClassDB::bind_method(D_METHOD("set_ssr_enabled", "enabled"), &Environment::set_ssr_enabled);
 	ClassDB::bind_method(D_METHOD("is_ssr_enabled"), &Environment::is_ssr_enabled);
-
 	ClassDB::bind_method(D_METHOD("set_ssr_max_steps", "max_steps"), &Environment::set_ssr_max_steps);
 	ClassDB::bind_method(D_METHOD("get_ssr_max_steps"), &Environment::get_ssr_max_steps);
-
 	ClassDB::bind_method(D_METHOD("set_ssr_fade_in", "fade_in"), &Environment::set_ssr_fade_in);
 	ClassDB::bind_method(D_METHOD("get_ssr_fade_in"), &Environment::get_ssr_fade_in);
-
 	ClassDB::bind_method(D_METHOD("set_ssr_fade_out", "fade_out"), &Environment::set_ssr_fade_out);
 	ClassDB::bind_method(D_METHOD("get_ssr_fade_out"), &Environment::get_ssr_fade_out);
-
 	ClassDB::bind_method(D_METHOD("set_ssr_depth_tolerance", "depth_tolerance"), &Environment::set_ssr_depth_tolerance);
 	ClassDB::bind_method(D_METHOD("get_ssr_depth_tolerance"), &Environment::get_ssr_depth_tolerance);
 
@@ -1039,27 +1107,22 @@ void Environment::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ss_reflections_fade_out", PROPERTY_HINT_EXP_EASING), "set_ssr_fade_out", "get_ssr_fade_out");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ss_reflections_depth_tolerance", PROPERTY_HINT_RANGE, "0.01,128,0.1"), "set_ssr_depth_tolerance", "get_ssr_depth_tolerance");
 
+	// SSAO
+
 	ClassDB::bind_method(D_METHOD("set_ssao_enabled", "enabled"), &Environment::set_ssao_enabled);
 	ClassDB::bind_method(D_METHOD("is_ssao_enabled"), &Environment::is_ssao_enabled);
-
 	ClassDB::bind_method(D_METHOD("set_ssao_radius", "radius"), &Environment::set_ssao_radius);
 	ClassDB::bind_method(D_METHOD("get_ssao_radius"), &Environment::get_ssao_radius);
-
 	ClassDB::bind_method(D_METHOD("set_ssao_intensity", "intensity"), &Environment::set_ssao_intensity);
 	ClassDB::bind_method(D_METHOD("get_ssao_intensity"), &Environment::get_ssao_intensity);
-
 	ClassDB::bind_method(D_METHOD("set_ssao_bias", "bias"), &Environment::set_ssao_bias);
 	ClassDB::bind_method(D_METHOD("get_ssao_bias"), &Environment::get_ssao_bias);
-
 	ClassDB::bind_method(D_METHOD("set_ssao_direct_light_affect", "amount"), &Environment::set_ssao_direct_light_affect);
 	ClassDB::bind_method(D_METHOD("get_ssao_direct_light_affect"), &Environment::get_ssao_direct_light_affect);
-
 	ClassDB::bind_method(D_METHOD("set_ssao_ao_channel_affect", "amount"), &Environment::set_ssao_ao_channel_affect);
 	ClassDB::bind_method(D_METHOD("get_ssao_ao_channel_affect"), &Environment::get_ssao_ao_channel_affect);
-
 	ClassDB::bind_method(D_METHOD("set_ssao_blur", "mode"), &Environment::set_ssao_blur);
 	ClassDB::bind_method(D_METHOD("get_ssao_blur"), &Environment::get_ssao_blur);
-
 	ClassDB::bind_method(D_METHOD("set_ssao_edge_sharpness", "edge_sharpness"), &Environment::set_ssao_edge_sharpness);
 	ClassDB::bind_method(D_METHOD("get_ssao_edge_sharpness"), &Environment::get_ssao_edge_sharpness);
 
@@ -1073,41 +1136,32 @@ void Environment::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ssao_blur", PROPERTY_HINT_ENUM, "Disabled,1x1,2x2,3x3"), "set_ssao_blur", "get_ssao_blur");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ssao_edge_sharpness", PROPERTY_HINT_RANGE, "0,32,0.01"), "set_ssao_edge_sharpness", "get_ssao_edge_sharpness");
 
+	// SDFGI
+
 	ClassDB::bind_method(D_METHOD("set_sdfgi_enabled", "enabled"), &Environment::set_sdfgi_enabled);
 	ClassDB::bind_method(D_METHOD("is_sdfgi_enabled"), &Environment::is_sdfgi_enabled);
-
 	ClassDB::bind_method(D_METHOD("set_sdfgi_cascades", "amount"), &Environment::set_sdfgi_cascades);
 	ClassDB::bind_method(D_METHOD("get_sdfgi_cascades"), &Environment::get_sdfgi_cascades);
-
-	ClassDB::bind_method(D_METHOD("set_sdfgi_min_cell_size", "strength"), &Environment::set_sdfgi_min_cell_size);
+	ClassDB::bind_method(D_METHOD("set_sdfgi_min_cell_size", "size"), &Environment::set_sdfgi_min_cell_size);
 	ClassDB::bind_method(D_METHOD("get_sdfgi_min_cell_size"), &Environment::get_sdfgi_min_cell_size);
-
-	ClassDB::bind_method(D_METHOD("set_sdfgi_max_distance", "strength"), &Environment::set_sdfgi_max_distance);
+	ClassDB::bind_method(D_METHOD("set_sdfgi_max_distance", "distance"), &Environment::set_sdfgi_max_distance);
 	ClassDB::bind_method(D_METHOD("get_sdfgi_max_distance"), &Environment::get_sdfgi_max_distance);
-
-	ClassDB::bind_method(D_METHOD("set_sdfgi_cascade0_distance", "strength"), &Environment::set_sdfgi_cascade0_distance);
+	ClassDB::bind_method(D_METHOD("set_sdfgi_cascade0_distance", "distance"), &Environment::set_sdfgi_cascade0_distance);
 	ClassDB::bind_method(D_METHOD("get_sdfgi_cascade0_distance"), &Environment::get_sdfgi_cascade0_distance);
-
-	ClassDB::bind_method(D_METHOD("set_sdfgi_use_occlusion", "enable"), &Environment::set_sdfgi_use_occlusion);
-	ClassDB::bind_method(D_METHOD("is_sdfgi_using_occlusion"), &Environment::is_sdfgi_using_occlusion);
-
-	ClassDB::bind_method(D_METHOD("set_sdfgi_use_multi_bounce", "enable"), &Environment::set_sdfgi_use_multi_bounce);
-	ClassDB::bind_method(D_METHOD("is_sdfgi_using_multi_bounce"), &Environment::is_sdfgi_using_multi_bounce);
-
-	ClassDB::bind_method(D_METHOD("set_sdfgi_read_sky_light", "enable"), &Environment::set_sdfgi_read_sky_light);
-	ClassDB::bind_method(D_METHOD("is_sdfgi_reading_sky_light"), &Environment::is_sdfgi_reading_sky_light);
-
-	ClassDB::bind_method(D_METHOD("set_sdfgi_energy", "amount"), &Environment::set_sdfgi_energy);
-	ClassDB::bind_method(D_METHOD("get_sdfgi_energy"), &Environment::get_sdfgi_energy);
-
-	ClassDB::bind_method(D_METHOD("set_sdfgi_normal_bias", "bias"), &Environment::set_sdfgi_normal_bias);
-	ClassDB::bind_method(D_METHOD("get_sdfgi_normal_bias"), &Environment::get_sdfgi_normal_bias);
-
-	ClassDB::bind_method(D_METHOD("set_sdfgi_probe_bias", "bias"), &Environment::set_sdfgi_probe_bias);
-	ClassDB::bind_method(D_METHOD("get_sdfgi_probe_bias"), &Environment::get_sdfgi_probe_bias);
-
 	ClassDB::bind_method(D_METHOD("set_sdfgi_y_scale", "scale"), &Environment::set_sdfgi_y_scale);
 	ClassDB::bind_method(D_METHOD("get_sdfgi_y_scale"), &Environment::get_sdfgi_y_scale);
+	ClassDB::bind_method(D_METHOD("set_sdfgi_use_occlusion", "enable"), &Environment::set_sdfgi_use_occlusion);
+	ClassDB::bind_method(D_METHOD("is_sdfgi_using_occlusion"), &Environment::is_sdfgi_using_occlusion);
+	ClassDB::bind_method(D_METHOD("set_sdfgi_use_multi_bounce", "enable"), &Environment::set_sdfgi_use_multi_bounce);
+	ClassDB::bind_method(D_METHOD("is_sdfgi_using_multi_bounce"), &Environment::is_sdfgi_using_multi_bounce);
+	ClassDB::bind_method(D_METHOD("set_sdfgi_read_sky_light", "enable"), &Environment::set_sdfgi_read_sky_light);
+	ClassDB::bind_method(D_METHOD("is_sdfgi_reading_sky_light"), &Environment::is_sdfgi_reading_sky_light);
+	ClassDB::bind_method(D_METHOD("set_sdfgi_energy", "amount"), &Environment::set_sdfgi_energy);
+	ClassDB::bind_method(D_METHOD("get_sdfgi_energy"), &Environment::get_sdfgi_energy);
+	ClassDB::bind_method(D_METHOD("set_sdfgi_normal_bias", "bias"), &Environment::set_sdfgi_normal_bias);
+	ClassDB::bind_method(D_METHOD("get_sdfgi_normal_bias"), &Environment::get_sdfgi_normal_bias);
+	ClassDB::bind_method(D_METHOD("set_sdfgi_probe_bias", "bias"), &Environment::set_sdfgi_probe_bias);
+	ClassDB::bind_method(D_METHOD("get_sdfgi_probe_bias"), &Environment::get_sdfgi_probe_bias);
 
 	ADD_GROUP("SDFGI", "sdfgi_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sdfgi_enabled"), "set_sdfgi_enabled", "is_sdfgi_enabled");
@@ -1123,76 +1177,119 @@ void Environment::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sdfgi_normal_bias"), "set_sdfgi_normal_bias", "get_sdfgi_normal_bias");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sdfgi_probe_bias"), "set_sdfgi_probe_bias", "get_sdfgi_probe_bias");
 
+	// Glow
+
 	ClassDB::bind_method(D_METHOD("set_glow_enabled", "enabled"), &Environment::set_glow_enabled);
 	ClassDB::bind_method(D_METHOD("is_glow_enabled"), &Environment::is_glow_enabled);
-
-	ClassDB::bind_method(D_METHOD("set_glow_level", "idx", "enabled"), &Environment::set_glow_level);
+	ClassDB::bind_method(D_METHOD("set_glow_level_enabled", "idx", "enabled"), &Environment::set_glow_level_enabled);
 	ClassDB::bind_method(D_METHOD("is_glow_level_enabled", "idx"), &Environment::is_glow_level_enabled);
-
 	ClassDB::bind_method(D_METHOD("set_glow_intensity", "intensity"), &Environment::set_glow_intensity);
 	ClassDB::bind_method(D_METHOD("get_glow_intensity"), &Environment::get_glow_intensity);
-
 	ClassDB::bind_method(D_METHOD("set_glow_strength", "strength"), &Environment::set_glow_strength);
 	ClassDB::bind_method(D_METHOD("get_glow_strength"), &Environment::get_glow_strength);
-
 	ClassDB::bind_method(D_METHOD("set_glow_mix", "mix"), &Environment::set_glow_mix);
 	ClassDB::bind_method(D_METHOD("get_glow_mix"), &Environment::get_glow_mix);
-
 	ClassDB::bind_method(D_METHOD("set_glow_bloom", "amount"), &Environment::set_glow_bloom);
 	ClassDB::bind_method(D_METHOD("get_glow_bloom"), &Environment::get_glow_bloom);
-
 	ClassDB::bind_method(D_METHOD("set_glow_blend_mode", "mode"), &Environment::set_glow_blend_mode);
 	ClassDB::bind_method(D_METHOD("get_glow_blend_mode"), &Environment::get_glow_blend_mode);
-
 	ClassDB::bind_method(D_METHOD("set_glow_hdr_bleed_threshold", "threshold"), &Environment::set_glow_hdr_bleed_threshold);
 	ClassDB::bind_method(D_METHOD("get_glow_hdr_bleed_threshold"), &Environment::get_glow_hdr_bleed_threshold);
-
+	ClassDB::bind_method(D_METHOD("set_glow_hdr_bleed_scale", "scale"), &Environment::set_glow_hdr_bleed_scale);
+	ClassDB::bind_method(D_METHOD("get_glow_hdr_bleed_scale"), &Environment::get_glow_hdr_bleed_scale);
 	ClassDB::bind_method(D_METHOD("set_glow_hdr_luminance_cap", "amount"), &Environment::set_glow_hdr_luminance_cap);
 	ClassDB::bind_method(D_METHOD("get_glow_hdr_luminance_cap"), &Environment::get_glow_hdr_luminance_cap);
 
-	ClassDB::bind_method(D_METHOD("set_glow_hdr_bleed_scale", "scale"), &Environment::set_glow_hdr_bleed_scale);
-	ClassDB::bind_method(D_METHOD("get_glow_hdr_bleed_scale"), &Environment::get_glow_hdr_bleed_scale);
-
 	ADD_GROUP("Glow", "glow_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "glow_enabled"), "set_glow_enabled", "is_glow_enabled");
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/1"), "set_glow_level", "is_glow_level_enabled", 0);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/2"), "set_glow_level", "is_glow_level_enabled", 1);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/3"), "set_glow_level", "is_glow_level_enabled", 2);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/4"), "set_glow_level", "is_glow_level_enabled", 3);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/5"), "set_glow_level", "is_glow_level_enabled", 4);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/6"), "set_glow_level", "is_glow_level_enabled", 5);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/7"), "set_glow_level", "is_glow_level_enabled", 6);
-
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/1"), "set_glow_level_enabled", "is_glow_level_enabled", 0);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/2"), "set_glow_level_enabled", "is_glow_level_enabled", 1);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/3"), "set_glow_level_enabled", "is_glow_level_enabled", 2);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/4"), "set_glow_level_enabled", "is_glow_level_enabled", 3);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/5"), "set_glow_level_enabled", "is_glow_level_enabled", 4);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/6"), "set_glow_level_enabled", "is_glow_level_enabled", 5);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "glow_levels/7"), "set_glow_level_enabled", "is_glow_level_enabled", 6);
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_intensity", PROPERTY_HINT_RANGE, "0.0,8.0,0.01"), "set_glow_intensity", "get_glow_intensity");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_mix", PROPERTY_HINT_RANGE, "0.0,1.0,0.001"), "set_glow_mix", "get_glow_mix");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_strength", PROPERTY_HINT_RANGE, "0.0,2.0,0.01"), "set_glow_strength", "get_glow_strength");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_mix", PROPERTY_HINT_RANGE, "0.0,1.0,0.001"), "set_glow_mix", "get_glow_mix");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_bloom", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_glow_bloom", "get_glow_bloom");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "glow_blend_mode", PROPERTY_HINT_ENUM, "Additive,Screen,Softlight,Replace,Mix"), "set_glow_blend_mode", "get_glow_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_hdr_threshold", PROPERTY_HINT_RANGE, "0.0,4.0,0.01"), "set_glow_hdr_bleed_threshold", "get_glow_hdr_bleed_threshold");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_hdr_luminance_cap", PROPERTY_HINT_RANGE, "0.0,256.0,0.01"), "set_glow_hdr_luminance_cap", "get_glow_hdr_luminance_cap");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_hdr_scale", PROPERTY_HINT_RANGE, "0.0,4.0,0.01"), "set_glow_hdr_bleed_scale", "get_glow_hdr_bleed_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_hdr_luminance_cap", PROPERTY_HINT_RANGE, "0.0,256.0,0.01"), "set_glow_hdr_luminance_cap", "get_glow_hdr_luminance_cap");
 
-	ClassDB::bind_method(D_METHOD("set_adjustment_enable", "enabled"), &Environment::set_adjustment_enable);
+	// Fog
+
+	ClassDB::bind_method(D_METHOD("set_fog_enabled", "enabled"), &Environment::set_fog_enabled);
+	ClassDB::bind_method(D_METHOD("is_fog_enabled"), &Environment::is_fog_enabled);
+	ClassDB::bind_method(D_METHOD("set_fog_color", "color"), &Environment::set_fog_color);
+	ClassDB::bind_method(D_METHOD("get_fog_color"), &Environment::get_fog_color);
+	ClassDB::bind_method(D_METHOD("set_fog_sun_color", "color"), &Environment::set_fog_sun_color);
+	ClassDB::bind_method(D_METHOD("get_fog_sun_color"), &Environment::get_fog_sun_color);
+	ClassDB::bind_method(D_METHOD("set_fog_sun_amount", "amount"), &Environment::set_fog_sun_amount);
+	ClassDB::bind_method(D_METHOD("get_fog_sun_amount"), &Environment::get_fog_sun_amount);
+
+	ClassDB::bind_method(D_METHOD("set_fog_depth_enabled", "enabled"), &Environment::set_fog_depth_enabled);
+	ClassDB::bind_method(D_METHOD("is_fog_depth_enabled"), &Environment::is_fog_depth_enabled);
+	ClassDB::bind_method(D_METHOD("set_fog_depth_begin", "distance"), &Environment::set_fog_depth_begin);
+	ClassDB::bind_method(D_METHOD("get_fog_depth_begin"), &Environment::get_fog_depth_begin);
+	ClassDB::bind_method(D_METHOD("set_fog_depth_end", "distance"), &Environment::set_fog_depth_end);
+	ClassDB::bind_method(D_METHOD("get_fog_depth_end"), &Environment::get_fog_depth_end);
+	ClassDB::bind_method(D_METHOD("set_fog_depth_curve", "curve"), &Environment::set_fog_depth_curve);
+	ClassDB::bind_method(D_METHOD("get_fog_depth_curve"), &Environment::get_fog_depth_curve);
+	ClassDB::bind_method(D_METHOD("set_fog_transmit_enabled", "enabled"), &Environment::set_fog_transmit_enabled);
+	ClassDB::bind_method(D_METHOD("is_fog_transmit_enabled"), &Environment::is_fog_transmit_enabled);
+	ClassDB::bind_method(D_METHOD("set_fog_transmit_curve", "curve"), &Environment::set_fog_transmit_curve);
+	ClassDB::bind_method(D_METHOD("get_fog_transmit_curve"), &Environment::get_fog_transmit_curve);
+
+	ClassDB::bind_method(D_METHOD("set_fog_height_enabled", "enabled"), &Environment::set_fog_height_enabled);
+	ClassDB::bind_method(D_METHOD("is_fog_height_enabled"), &Environment::is_fog_height_enabled);
+	ClassDB::bind_method(D_METHOD("set_fog_height_min", "height"), &Environment::set_fog_height_min);
+	ClassDB::bind_method(D_METHOD("get_fog_height_min"), &Environment::get_fog_height_min);
+	ClassDB::bind_method(D_METHOD("set_fog_height_max", "height"), &Environment::set_fog_height_max);
+	ClassDB::bind_method(D_METHOD("get_fog_height_max"), &Environment::get_fog_height_max);
+	ClassDB::bind_method(D_METHOD("set_fog_height_curve", "curve"), &Environment::set_fog_height_curve);
+	ClassDB::bind_method(D_METHOD("get_fog_height_curve"), &Environment::get_fog_height_curve);
+
+	ADD_GROUP("Fog", "fog_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fog_enabled"), "set_fog_enabled", "is_fog_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "fog_color"), "set_fog_color", "get_fog_color");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "fog_sun_color"), "set_fog_sun_color", "get_fog_sun_color");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_sun_amount", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_fog_sun_amount", "get_fog_sun_amount");
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fog_depth_enabled"), "set_fog_depth_enabled", "is_fog_depth_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_depth_begin", PROPERTY_HINT_RANGE, "0,4000,0.1"), "set_fog_depth_begin", "get_fog_depth_begin");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_depth_end", PROPERTY_HINT_RANGE, "0,4000,0.1,or_greater"), "set_fog_depth_end", "get_fog_depth_end");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_depth_curve", PROPERTY_HINT_EXP_EASING), "set_fog_depth_curve", "get_fog_depth_curve");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fog_transmit_enabled"), "set_fog_transmit_enabled", "is_fog_transmit_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_transmit_curve", PROPERTY_HINT_EXP_EASING), "set_fog_transmit_curve", "get_fog_transmit_curve");
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fog_height_enabled"), "set_fog_height_enabled", "is_fog_height_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_height_min", PROPERTY_HINT_RANGE, "-4000,4000,0.1,or_lesser,or_greater"), "set_fog_height_min", "get_fog_height_min");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_height_max", PROPERTY_HINT_RANGE, "-4000,4000,0.1,or_lesser,or_greater"), "set_fog_height_max", "get_fog_height_max");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_height_curve", PROPERTY_HINT_EXP_EASING), "set_fog_height_curve", "get_fog_height_curve");
+
+	// Adjustment
+
+	ClassDB::bind_method(D_METHOD("set_adjustment_enabled", "enabled"), &Environment::set_adjustment_enabled);
 	ClassDB::bind_method(D_METHOD("is_adjustment_enabled"), &Environment::is_adjustment_enabled);
-
 	ClassDB::bind_method(D_METHOD("set_adjustment_brightness", "brightness"), &Environment::set_adjustment_brightness);
 	ClassDB::bind_method(D_METHOD("get_adjustment_brightness"), &Environment::get_adjustment_brightness);
-
 	ClassDB::bind_method(D_METHOD("set_adjustment_contrast", "contrast"), &Environment::set_adjustment_contrast);
 	ClassDB::bind_method(D_METHOD("get_adjustment_contrast"), &Environment::get_adjustment_contrast);
-
 	ClassDB::bind_method(D_METHOD("set_adjustment_saturation", "saturation"), &Environment::set_adjustment_saturation);
 	ClassDB::bind_method(D_METHOD("get_adjustment_saturation"), &Environment::get_adjustment_saturation);
-
 	ClassDB::bind_method(D_METHOD("set_adjustment_color_correction", "color_correction"), &Environment::set_adjustment_color_correction);
 	ClassDB::bind_method(D_METHOD("get_adjustment_color_correction"), &Environment::get_adjustment_color_correction);
 
 	ADD_GROUP("Adjustments", "adjustment_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "adjustment_enabled"), "set_adjustment_enable", "is_adjustment_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "adjustment_enabled"), "set_adjustment_enabled", "is_adjustment_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_brightness", PROPERTY_HINT_RANGE, "0.01,8,0.01"), "set_adjustment_brightness", "get_adjustment_brightness");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_contrast", PROPERTY_HINT_RANGE, "0.01,8,0.01"), "set_adjustment_contrast", "get_adjustment_contrast");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "adjustment_saturation", PROPERTY_HINT_RANGE, "0.01,8,0.01"), "set_adjustment_saturation", "get_adjustment_saturation");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "adjustment_color_correction", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_adjustment_color_correction", "get_adjustment_color_correction");
+
+	// Constants
 
 	BIND_ENUM_CONSTANT(BG_CLEAR_COLOR);
 	BIND_ENUM_CONSTANT(BG_COLOR);
@@ -1211,267 +1308,49 @@ void Environment::_bind_methods() {
 	BIND_ENUM_CONSTANT(REFLECTION_SOURCE_DISABLED);
 	BIND_ENUM_CONSTANT(REFLECTION_SOURCE_SKY);
 
+	BIND_ENUM_CONSTANT(TONE_MAPPER_LINEAR);
+	BIND_ENUM_CONSTANT(TONE_MAPPER_REINHARDT);
+	BIND_ENUM_CONSTANT(TONE_MAPPER_FILMIC);
+	BIND_ENUM_CONSTANT(TONE_MAPPER_ACES);
+
 	BIND_ENUM_CONSTANT(GLOW_BLEND_MODE_ADDITIVE);
 	BIND_ENUM_CONSTANT(GLOW_BLEND_MODE_SCREEN);
 	BIND_ENUM_CONSTANT(GLOW_BLEND_MODE_SOFTLIGHT);
 	BIND_ENUM_CONSTANT(GLOW_BLEND_MODE_REPLACE);
 	BIND_ENUM_CONSTANT(GLOW_BLEND_MODE_MIX);
 
-	BIND_ENUM_CONSTANT(TONE_MAPPER_LINEAR);
-	BIND_ENUM_CONSTANT(TONE_MAPPER_REINHARDT);
-	BIND_ENUM_CONSTANT(TONE_MAPPER_FILMIC);
-	BIND_ENUM_CONSTANT(TONE_MAPPER_ACES);
-
 	BIND_ENUM_CONSTANT(SSAO_BLUR_DISABLED);
 	BIND_ENUM_CONSTANT(SSAO_BLUR_1x1);
 	BIND_ENUM_CONSTANT(SSAO_BLUR_2x2);
 	BIND_ENUM_CONSTANT(SSAO_BLUR_3x3);
+
+	BIND_ENUM_CONSTANT(SDFGI_CASCADES_4);
+	BIND_ENUM_CONSTANT(SDFGI_CASCADES_6);
+	BIND_ENUM_CONSTANT(SDFGI_CASCADES_8);
+
+	BIND_ENUM_CONSTANT(SDFGI_Y_SCALE_DISABLED);
+	BIND_ENUM_CONSTANT(SDFGI_Y_SCALE_75_PERCENT);
+	BIND_ENUM_CONSTANT(SDFGI_Y_SCALE_50_PERCENT);
 }
 
 Environment::Environment() {
 	environment = RS::get_singleton()->environment_create();
 
-	bg_mode = BG_CLEAR_COLOR;
-	bg_sky_custom_fov = 0;
-	bg_energy = 1.0;
-	bg_canvas_max_layer = 0;
-	ambient_energy = 1.0;
-	//ambient_sky_contribution = 1.0;
-	ambient_source = AMBIENT_SOURCE_BG;
-	reflection_source = REFLECTION_SOURCE_BG;
-	set_ambient_light_sky_contribution(1.0);
-	set_camera_feed_id(1);
-
-	tone_mapper = TONE_MAPPER_LINEAR;
-	tonemap_exposure = 1.0;
-	tonemap_white = 1.0;
-	tonemap_auto_exposure = false;
-	tonemap_auto_exposure_max = 8;
-	tonemap_auto_exposure_min = 0.05;
-	tonemap_auto_exposure_speed = 0.5;
-	tonemap_auto_exposure_grey = 0.4;
-
-	set_tonemapper(tone_mapper); //update
-
-	adjustment_enabled = false;
-	adjustment_contrast = 1.0;
-	adjustment_saturation = 1.0;
-	adjustment_brightness = 1.0;
-
-	set_adjustment_enable(adjustment_enabled); //update
-
-	ssr_enabled = false;
-	ssr_max_steps = 64;
-	ssr_fade_in = 0.15;
-	ssr_fade_out = 2.0;
-	ssr_depth_tolerance = 0.2;
-
-	ssao_enabled = false;
-	ssao_radius = 1;
-	ssao_intensity = 1;
-	ssao_bias = 0.01;
-	ssao_direct_light_affect = 0.0;
-	ssao_ao_channel_affect = 0.0;
-	ssao_blur = SSAO_BLUR_3x3;
-	set_ssao_edge_sharpness(4);
-
-	glow_enabled = false;
-	glow_levels = (1 << 2) | (1 << 4);
-	glow_intensity = 0.8;
-	glow_strength = 1.0;
-	glow_mix = 0.05;
-	glow_bloom = 0.0;
-	glow_blend_mode = GLOW_BLEND_MODE_SOFTLIGHT;
-	glow_hdr_bleed_threshold = 1.0;
-	glow_hdr_luminance_cap = 12.0;
-	glow_hdr_bleed_scale = 2.0;
-
-	fog_enabled = false;
-	fog_color = Color(0.5, 0.5, 0.5);
-	fog_sun_color = Color(0.8, 0.8, 0.0);
-	fog_sun_amount = 0;
-
-	fog_depth_enabled = true;
-
-	fog_depth_begin = 10;
-	fog_depth_end = 100;
-	fog_depth_curve = 1;
-
-	fog_transmit_enabled = false;
-	fog_transmit_curve = 1;
-
-	fog_height_enabled = false;
-	fog_height_min = 10;
-	fog_height_max = 0;
-	fog_height_curve = 1;
-
-	set_fog_color(Color(0.5, 0.6, 0.7));
-	set_fog_sun_color(Color(1.0, 0.9, 0.7));
-
-	sdfgi_enabled = false;
-	sdfgi_cascades = SDFGI_CASCADES_6;
-	sdfgi_min_cell_size = 0.2;
-	sdfgi_use_occlusion = false;
-	sdfgi_use_multibounce = false;
-	sdfgi_read_sky_light = false;
-	sdfgi_enhance_ssr = false;
-	sdfgi_energy = 1.0;
-	sdfgi_normal_bias = 1.1;
-	sdfgi_probe_bias = 1.1;
-	sdfgi_y_scale = SDFGI_Y_SCALE_DISABLED;
+	set_camera_feed_id(bg_camera_feed_id);
+	_update_ambient_light();
+	_update_tonemap();
+	_update_ssr();
+	_update_ssao();
 	_update_sdfgi();
+	_update_glow();
+	_update_fog();
+	_update_fog_depth();
+	_update_fog_height();
+	_update_adjustment();
+
+	_change_notify();
 }
 
 Environment::~Environment() {
 	RS::get_singleton()->free(environment);
-}
-
-//////////////////////
-
-void CameraEffects::set_dof_blur_far_enabled(bool p_enable) {
-	dof_blur_far_enabled = p_enable;
-	RS::get_singleton()->camera_effects_set_dof_blur(camera_effects, dof_blur_far_enabled, dof_blur_far_distance, dof_blur_far_transition, dof_blur_near_enabled, dof_blur_near_distance, dof_blur_near_transition, dof_blur_amount);
-}
-
-bool CameraEffects::is_dof_blur_far_enabled() const {
-	return dof_blur_far_enabled;
-}
-
-void CameraEffects::set_dof_blur_far_distance(float p_distance) {
-	dof_blur_far_distance = p_distance;
-	RS::get_singleton()->camera_effects_set_dof_blur(camera_effects, dof_blur_far_enabled, dof_blur_far_distance, dof_blur_far_transition, dof_blur_near_enabled, dof_blur_near_distance, dof_blur_near_transition, dof_blur_amount);
-}
-
-float CameraEffects::get_dof_blur_far_distance() const {
-	return dof_blur_far_distance;
-}
-
-void CameraEffects::set_dof_blur_far_transition(float p_distance) {
-	dof_blur_far_transition = p_distance;
-	RS::get_singleton()->camera_effects_set_dof_blur(camera_effects, dof_blur_far_enabled, dof_blur_far_distance, dof_blur_far_transition, dof_blur_near_enabled, dof_blur_near_distance, dof_blur_near_transition, dof_blur_amount);
-}
-
-float CameraEffects::get_dof_blur_far_transition() const {
-	return dof_blur_far_transition;
-}
-
-void CameraEffects::set_dof_blur_near_enabled(bool p_enable) {
-	dof_blur_near_enabled = p_enable;
-	RS::get_singleton()->camera_effects_set_dof_blur(camera_effects, dof_blur_far_enabled, dof_blur_far_distance, dof_blur_far_transition, dof_blur_near_enabled, dof_blur_near_distance, dof_blur_near_transition, dof_blur_amount);
-	_change_notify();
-}
-
-bool CameraEffects::is_dof_blur_near_enabled() const {
-	return dof_blur_near_enabled;
-}
-
-void CameraEffects::set_dof_blur_near_distance(float p_distance) {
-	dof_blur_near_distance = p_distance;
-	RS::get_singleton()->camera_effects_set_dof_blur(camera_effects, dof_blur_far_enabled, dof_blur_far_distance, dof_blur_far_transition, dof_blur_near_enabled, dof_blur_near_distance, dof_blur_near_transition, dof_blur_amount);
-}
-
-float CameraEffects::get_dof_blur_near_distance() const {
-	return dof_blur_near_distance;
-}
-
-void CameraEffects::set_dof_blur_near_transition(float p_distance) {
-	dof_blur_near_transition = p_distance;
-	RS::get_singleton()->camera_effects_set_dof_blur(camera_effects, dof_blur_far_enabled, dof_blur_far_distance, dof_blur_far_transition, dof_blur_near_enabled, dof_blur_near_distance, dof_blur_near_transition, dof_blur_amount);
-}
-
-float CameraEffects::get_dof_blur_near_transition() const {
-	return dof_blur_near_transition;
-}
-
-void CameraEffects::set_dof_blur_amount(float p_amount) {
-	dof_blur_amount = p_amount;
-	RS::get_singleton()->camera_effects_set_dof_blur(camera_effects, dof_blur_far_enabled, dof_blur_far_distance, dof_blur_far_transition, dof_blur_near_enabled, dof_blur_near_distance, dof_blur_near_transition, dof_blur_amount);
-}
-
-float CameraEffects::get_dof_blur_amount() const {
-	return dof_blur_amount;
-}
-
-void CameraEffects::set_override_exposure_enabled(bool p_enabled) {
-	override_exposure_enabled = p_enabled;
-	RS::get_singleton()->camera_effects_set_custom_exposure(camera_effects, override_exposure_enabled, override_exposure);
-}
-
-bool CameraEffects::is_override_exposure_enabled() const {
-	return override_exposure_enabled;
-}
-
-void CameraEffects::set_override_exposure(float p_exposure) {
-	override_exposure = p_exposure;
-	RS::get_singleton()->camera_effects_set_custom_exposure(camera_effects, override_exposure_enabled, override_exposure);
-}
-
-float CameraEffects::get_override_exposure() const {
-	return override_exposure;
-}
-
-RID CameraEffects::get_rid() const {
-	return camera_effects;
-}
-
-void CameraEffects::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_dof_blur_far_enabled", "enabled"), &CameraEffects::set_dof_blur_far_enabled);
-	ClassDB::bind_method(D_METHOD("is_dof_blur_far_enabled"), &CameraEffects::is_dof_blur_far_enabled);
-
-	ClassDB::bind_method(D_METHOD("set_dof_blur_far_distance", "intensity"), &CameraEffects::set_dof_blur_far_distance);
-	ClassDB::bind_method(D_METHOD("get_dof_blur_far_distance"), &CameraEffects::get_dof_blur_far_distance);
-
-	ClassDB::bind_method(D_METHOD("set_dof_blur_far_transition", "intensity"), &CameraEffects::set_dof_blur_far_transition);
-	ClassDB::bind_method(D_METHOD("get_dof_blur_far_transition"), &CameraEffects::get_dof_blur_far_transition);
-
-	ClassDB::bind_method(D_METHOD("set_dof_blur_near_enabled", "enabled"), &CameraEffects::set_dof_blur_near_enabled);
-	ClassDB::bind_method(D_METHOD("is_dof_blur_near_enabled"), &CameraEffects::is_dof_blur_near_enabled);
-
-	ClassDB::bind_method(D_METHOD("set_dof_blur_near_distance", "intensity"), &CameraEffects::set_dof_blur_near_distance);
-	ClassDB::bind_method(D_METHOD("get_dof_blur_near_distance"), &CameraEffects::get_dof_blur_near_distance);
-
-	ClassDB::bind_method(D_METHOD("set_dof_blur_near_transition", "intensity"), &CameraEffects::set_dof_blur_near_transition);
-	ClassDB::bind_method(D_METHOD("get_dof_blur_near_transition"), &CameraEffects::get_dof_blur_near_transition);
-
-	ClassDB::bind_method(D_METHOD("set_dof_blur_amount", "intensity"), &CameraEffects::set_dof_blur_amount);
-	ClassDB::bind_method(D_METHOD("get_dof_blur_amount"), &CameraEffects::get_dof_blur_amount);
-
-	ClassDB::bind_method(D_METHOD("set_override_exposure_enabled", "enable"), &CameraEffects::set_override_exposure_enabled);
-	ClassDB::bind_method(D_METHOD("is_override_exposure_enabled"), &CameraEffects::is_override_exposure_enabled);
-
-	ClassDB::bind_method(D_METHOD("set_override_exposure", "exposure"), &CameraEffects::set_override_exposure);
-	ClassDB::bind_method(D_METHOD("get_override_exposure"), &CameraEffects::get_override_exposure);
-
-	ADD_GROUP("DOF Blur", "dof_blur_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dof_blur_far_enabled"), "set_dof_blur_far_enabled", "is_dof_blur_far_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_far_distance", PROPERTY_HINT_EXP_RANGE, "0.01,8192,0.01"), "set_dof_blur_far_distance", "get_dof_blur_far_distance");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_far_transition", PROPERTY_HINT_EXP_RANGE, "0.01,8192,0.01"), "set_dof_blur_far_transition", "get_dof_blur_far_transition");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dof_blur_near_enabled"), "set_dof_blur_near_enabled", "is_dof_blur_near_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_near_distance", PROPERTY_HINT_EXP_RANGE, "0.01,8192,0.01"), "set_dof_blur_near_distance", "get_dof_blur_near_distance");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_near_transition", PROPERTY_HINT_EXP_RANGE, "0.01,8192,0.01"), "set_dof_blur_near_transition", "get_dof_blur_near_transition");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_amount", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_dof_blur_amount", "get_dof_blur_amount");
-	ADD_GROUP("Override Exposure", "override_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "override_exposure_enable"), "set_override_exposure_enabled", "is_override_exposure_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "override_exposure", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_override_exposure", "get_override_exposure");
-}
-
-CameraEffects::CameraEffects() {
-	camera_effects = RS::get_singleton()->camera_effects_create();
-
-	dof_blur_far_enabled = false;
-	dof_blur_far_distance = 10;
-	dof_blur_far_transition = 5;
-
-	dof_blur_near_enabled = false;
-	dof_blur_near_distance = 2;
-	dof_blur_near_transition = 1;
-
-	set_dof_blur_amount(0.1);
-
-	override_exposure_enabled = false;
-	set_override_exposure(1.0);
-}
-
-CameraEffects::~CameraEffects() {
-	RS::get_singleton()->free(camera_effects);
 }

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -41,7 +41,6 @@ class Environment : public Resource {
 
 public:
 	enum BGMode {
-
 		BG_CLEAR_COLOR,
 		BG_COLOR,
 		BG_SKY,
@@ -68,22 +67,14 @@ public:
 		TONE_MAPPER_LINEAR,
 		TONE_MAPPER_REINHARDT,
 		TONE_MAPPER_FILMIC,
-		TONE_MAPPER_ACES
-	};
-
-	enum GlowBlendMode {
-		GLOW_BLEND_MODE_ADDITIVE,
-		GLOW_BLEND_MODE_SCREEN,
-		GLOW_BLEND_MODE_SOFTLIGHT,
-		GLOW_BLEND_MODE_REPLACE,
-		GLOW_BLEND_MODE_MIX,
+		TONE_MAPPER_ACES,
 	};
 
 	enum SSAOBlur {
 		SSAO_BLUR_DISABLED,
 		SSAO_BLUR_1x1,
 		SSAO_BLUR_2x2,
-		SSAO_BLUR_3x3
+		SSAO_BLUR_3x3,
 	};
 
 	enum SDFGICascades {
@@ -98,96 +89,120 @@ public:
 		SDFGI_Y_SCALE_50_PERCENT,
 	};
 
+	enum GlowBlendMode {
+		GLOW_BLEND_MODE_ADDITIVE,
+		GLOW_BLEND_MODE_SCREEN,
+		GLOW_BLEND_MODE_SOFTLIGHT,
+		GLOW_BLEND_MODE_REPLACE,
+		GLOW_BLEND_MODE_MIX,
+	};
+
 private:
 	RID environment;
 
+	// Background
 	BGMode bg_mode = BG_CLEAR_COLOR;
 	Ref<Sky> bg_sky;
-	float bg_sky_custom_fov;
-	Vector3 sky_rotation;
+	float bg_sky_custom_fov = 0;
+	Vector3 bg_sky_rotation;
 	Color bg_color;
-	float bg_energy;
-	int bg_canvas_max_layer;
+	float bg_energy = 1.0;
+	int bg_canvas_max_layer = 0;
+	int bg_camera_feed_id = 1;
+
+	// Ambient light
 	Color ambient_color;
-	float ambient_energy;
+	AmbientSource ambient_source = AMBIENT_SOURCE_BG;
+	float ambient_energy = 1.0;
+	float ambient_sky_contribution = 1.0;
+	ReflectionSource reflection_source = REFLECTION_SOURCE_BG;
 	Color ao_color;
-	float ambient_sky_contribution;
-	int camera_feed_id;
-	AmbientSource ambient_source;
-	ReflectionSource reflection_source;
+	void _update_ambient_light();
 
+	// Tonemap
 	ToneMapper tone_mapper = TONE_MAPPER_LINEAR;
-	float tonemap_exposure;
-	float tonemap_white;
-	bool tonemap_auto_exposure;
-	float tonemap_auto_exposure_max;
-	float tonemap_auto_exposure_min;
-	float tonemap_auto_exposure_speed;
-	float tonemap_auto_exposure_grey;
+	float tonemap_exposure = 1.0;
+	float tonemap_white = 1.0;
+	bool tonemap_auto_exposure_enabled = false;
+	float tonemap_auto_exposure_min = 0.05;
+	float tonemap_auto_exposure_max = 8;
+	float tonemap_auto_exposure_speed = 0.5;
+	float tonemap_auto_exposure_grey = 0.4;
+	void _update_tonemap();
 
-	bool adjustment_enabled;
-	float adjustment_contrast;
-	float adjustment_saturation;
-	float adjustment_brightness;
-	Ref<Texture2D> adjustment_color_correction;
+	// SSR
+	bool ssr_enabled = false;
+	int ssr_max_steps = 64;
+	float ssr_fade_in = 0.15;
+	float ssr_fade_out = 2.0;
+	float ssr_depth_tolerance = 0.2;
+	void _update_ssr();
 
-	bool ssr_enabled;
-	int ssr_max_steps;
-	float ssr_fade_in;
-	float ssr_fade_out;
-	float ssr_depth_tolerance;
-
-	bool ssao_enabled;
-	float ssao_radius;
-	float ssao_intensity;
-	float ssao_bias;
-	float ssao_direct_light_affect;
-	float ssao_ao_channel_affect;
+	// SSAO
+	bool ssao_enabled = false;
+	float ssao_radius = 1.0;
+	float ssao_intensity = 1.0;
+	float ssao_bias = 0.01;
+	float ssao_direct_light_affect = 0.0;
+	float ssao_ao_channel_affect = 0.0;
 	SSAOBlur ssao_blur = SSAO_BLUR_3x3;
-	float ssao_edge_sharpness;
+	float ssao_edge_sharpness = 4.0;
+	void _update_ssao();
 
-	bool glow_enabled;
-	int glow_levels;
-	float glow_intensity;
-	float glow_strength;
-	float glow_mix;
-	float glow_bloom;
-	GlowBlendMode glow_blend_mode = GLOW_BLEND_MODE_ADDITIVE;
-	float glow_hdr_bleed_threshold;
-	float glow_hdr_bleed_scale;
-	float glow_hdr_luminance_cap;
-
-	bool fog_enabled;
-	Color fog_color;
-	Color fog_sun_color;
-	float fog_sun_amount;
-
-	bool fog_depth_enabled;
-	float fog_depth_begin;
-	float fog_depth_end;
-	float fog_depth_curve;
-
-	bool fog_transmit_enabled;
-	float fog_transmit_curve;
-
-	bool fog_height_enabled;
-	float fog_height_min;
-	float fog_height_max;
-	float fog_height_curve;
-
-	bool sdfgi_enabled;
-	SDFGICascades sdfgi_cascades;
-	float sdfgi_min_cell_size;
-	bool sdfgi_use_occlusion;
-	bool sdfgi_use_multibounce;
-	bool sdfgi_read_sky_light;
-	bool sdfgi_enhance_ssr;
-	float sdfgi_energy;
-	float sdfgi_normal_bias;
-	float sdfgi_probe_bias;
-	SDFGIYScale sdfgi_y_scale;
-
+	// SDFGI
+	bool sdfgi_enabled = false;
+	SDFGICascades sdfgi_cascades = SDFGI_CASCADES_6;
+	float sdfgi_min_cell_size = 0.2;
+	SDFGIYScale sdfgi_y_scale = SDFGI_Y_SCALE_DISABLED;
+	bool sdfgi_use_occlusion = false;
+	bool sdfgi_use_multibounce = false;
+	bool sdfgi_read_sky_light = false;
+	float sdfgi_energy = 1.0;
+	float sdfgi_normal_bias = 1.1;
+	float sdfgi_probe_bias = 1.1;
 	void _update_sdfgi();
+
+	// Glow
+	bool glow_enabled = false;
+	int glow_levels = (1 << 2) | (1 << 4);
+	float glow_intensity = 0.8;
+	float glow_strength = 1.0;
+	float glow_mix = 0.05;
+	float glow_bloom = 0.0;
+	GlowBlendMode glow_blend_mode = GLOW_BLEND_MODE_SOFTLIGHT;
+	float glow_hdr_bleed_threshold = 1.0;
+	float glow_hdr_bleed_scale = 2.0;
+	float glow_hdr_luminance_cap = 12.0;
+	void _update_glow();
+
+	// Fog
+	bool fog_enabled = false;
+	Color fog_color = Color(0.5, 0.6, 0.7);
+	Color fog_sun_color = Color(1.0, 0.9, 0.7);
+	float fog_sun_amount = 0.0;
+	void _update_fog();
+
+	bool fog_depth_enabled = true;
+	float fog_depth_begin = 10.0;
+	float fog_depth_end = 100.0;
+	float fog_depth_curve = 1.0;
+	bool fog_transmit_enabled = false;
+	float fog_transmit_curve = 1.0;
+	void _update_fog_depth();
+
+	bool fog_height_enabled = false;
+	float fog_height_min = 10.0;
+	float fog_height_max = 0.0;
+	float fog_height_curve = 1.0;
+	void _update_fog_height();
+
+	// Adjustment
+	bool adjustment_enabled = false;
+	float adjustment_brightness = 1.0;
+	float adjustment_contrast = 1.0;
+	float adjustment_saturation = 1.0;
+	Ref<Texture2D> adjustment_color_correction;
+	void _update_adjustment();
 
 protected:
 	static void _bind_methods();
@@ -198,228 +213,179 @@ protected:
 #endif
 
 public:
+	virtual RID get_rid() const;
+
+	// Background
 	void set_background(BGMode p_bg);
-
-	void set_sky(const Ref<Sky> &p_sky);
-	void set_sky_custom_fov(float p_scale);
-	void set_sky_rotation(const Vector3 &p_rotation);
-	void set_bg_color(const Color &p_color);
-	void set_bg_energy(float p_energy);
-	void set_canvas_max_layer(int p_max_layer);
-	void set_ambient_light_color(const Color &p_color);
-	void set_ambient_light_energy(float p_energy);
-	void set_ambient_light_sky_contribution(float p_energy);
-	void set_camera_feed_id(int p_camera_feed_id);
-	void set_ambient_source(AmbientSource p_source);
-	AmbientSource get_ambient_source() const;
-	void set_reflection_source(ReflectionSource p_source);
-	ReflectionSource get_reflection_source() const;
-
 	BGMode get_background() const;
+	void set_sky(const Ref<Sky> &p_sky);
 	Ref<Sky> get_sky() const;
+	void set_sky_custom_fov(float p_scale);
 	float get_sky_custom_fov() const;
+	void set_sky_rotation(const Vector3 &p_rotation);
 	Vector3 get_sky_rotation() const;
+	void set_bg_color(const Color &p_color);
 	Color get_bg_color() const;
+	void set_bg_energy(float p_energy);
 	float get_bg_energy() const;
+	void set_canvas_max_layer(int p_max_layer);
 	int get_canvas_max_layer() const;
-	Color get_ambient_light_color() const;
-	float get_ambient_light_energy() const;
-	float get_ambient_light_sky_contribution() const;
+	void set_camera_feed_id(int p_id);
 	int get_camera_feed_id() const;
 
-	void set_tonemapper(ToneMapper p_tone_mapper);
-	ToneMapper get_tonemapper() const;
-
-	void set_tonemap_exposure(float p_exposure);
-	float get_tonemap_exposure() const;
-
-	void set_tonemap_white(float p_white);
-	float get_tonemap_white() const;
-
-	void set_tonemap_auto_exposure(bool p_enabled);
-	bool get_tonemap_auto_exposure() const;
-
-	void set_tonemap_auto_exposure_max(float p_auto_exposure_max);
-	float get_tonemap_auto_exposure_max() const;
-
-	void set_tonemap_auto_exposure_min(float p_auto_exposure_min);
-	float get_tonemap_auto_exposure_min() const;
-
-	void set_tonemap_auto_exposure_speed(float p_auto_exposure_speed);
-	float get_tonemap_auto_exposure_speed() const;
-
-	void set_tonemap_auto_exposure_grey(float p_auto_exposure_grey);
-	float get_tonemap_auto_exposure_grey() const;
-
-	void set_adjustment_enable(bool p_enable);
-	bool is_adjustment_enabled() const;
-
-	void set_adjustment_brightness(float p_brightness);
-	float get_adjustment_brightness() const;
-
-	void set_adjustment_contrast(float p_contrast);
-	float get_adjustment_contrast() const;
-
-	void set_adjustment_saturation(float p_saturation);
-	float get_adjustment_saturation() const;
-
-	void set_adjustment_color_correction(const Ref<Texture2D> &p_ramp);
-	Ref<Texture2D> get_adjustment_color_correction() const;
-
-	void set_ssr_enabled(bool p_enable);
-	bool is_ssr_enabled() const;
-
-	void set_ssr_max_steps(int p_steps);
-	int get_ssr_max_steps() const;
-
-	void set_ssr_fade_in(float p_fade_in);
-	float get_ssr_fade_in() const;
-
-	void set_ssr_fade_out(float p_fade_out);
-	float get_ssr_fade_out() const;
-
-	void set_ssr_depth_tolerance(float p_depth_tolerance);
-	float get_ssr_depth_tolerance() const;
-
-	void set_ssao_enabled(bool p_enable);
-	bool is_ssao_enabled() const;
-
-	void set_ssao_radius(float p_radius);
-	float get_ssao_radius() const;
-
-	void set_ssao_intensity(float p_intensity);
-	float get_ssao_intensity() const;
-
-	void set_ssao_bias(float p_bias);
-	float get_ssao_bias() const;
-
-	void set_ssao_direct_light_affect(float p_direct_light_affect);
-	float get_ssao_direct_light_affect() const;
-
-	void set_ssao_ao_channel_affect(float p_ao_channel_affect);
-	float get_ssao_ao_channel_affect() const;
-
+	// Ambient light
+	void set_ambient_light_color(const Color &p_color);
+	Color get_ambient_light_color() const;
+	void set_ambient_source(AmbientSource p_source);
+	AmbientSource get_ambient_source() const;
+	void set_ambient_light_energy(float p_energy);
+	float get_ambient_light_energy() const;
+	void set_ambient_light_sky_contribution(float p_ratio);
+	float get_ambient_light_sky_contribution() const;
+	void set_reflection_source(ReflectionSource p_source);
+	ReflectionSource get_reflection_source() const;
 	void set_ao_color(const Color &p_color);
 	Color get_ao_color() const;
 
+	// Tonemap
+	void set_tonemapper(ToneMapper p_tone_mapper);
+	ToneMapper get_tonemapper() const;
+	void set_tonemap_exposure(float p_exposure);
+	float get_tonemap_exposure() const;
+	void set_tonemap_white(float p_white);
+	float get_tonemap_white() const;
+	void set_tonemap_auto_exposure_enabled(bool p_enabled);
+	bool is_tonemap_auto_exposure_enabled() const;
+	void set_tonemap_auto_exposure_min(float p_auto_exposure_min);
+	float get_tonemap_auto_exposure_min() const;
+	void set_tonemap_auto_exposure_max(float p_auto_exposure_max);
+	float get_tonemap_auto_exposure_max() const;
+	void set_tonemap_auto_exposure_speed(float p_auto_exposure_speed);
+	float get_tonemap_auto_exposure_speed() const;
+	void set_tonemap_auto_exposure_grey(float p_auto_exposure_grey);
+	float get_tonemap_auto_exposure_grey() const;
+
+	// SSR
+	void set_ssr_enabled(bool p_enabled);
+	bool is_ssr_enabled() const;
+	void set_ssr_max_steps(int p_steps);
+	int get_ssr_max_steps() const;
+	void set_ssr_fade_in(float p_fade_in);
+	float get_ssr_fade_in() const;
+	void set_ssr_fade_out(float p_fade_out);
+	float get_ssr_fade_out() const;
+	void set_ssr_depth_tolerance(float p_depth_tolerance);
+	float get_ssr_depth_tolerance() const;
+
+	// SSAO
+	void set_ssao_enabled(bool p_enabled);
+	bool is_ssao_enabled() const;
+	void set_ssao_radius(float p_radius);
+	float get_ssao_radius() const;
+	void set_ssao_intensity(float p_intensity);
+	float get_ssao_intensity() const;
+	void set_ssao_bias(float p_bias);
+	float get_ssao_bias() const;
+	void set_ssao_direct_light_affect(float p_direct_light_affect);
+	float get_ssao_direct_light_affect() const;
+	void set_ssao_ao_channel_affect(float p_ao_channel_affect);
+	float get_ssao_ao_channel_affect() const;
 	void set_ssao_blur(SSAOBlur p_blur);
 	SSAOBlur get_ssao_blur() const;
-
 	void set_ssao_edge_sharpness(float p_edge_sharpness);
 	float get_ssao_edge_sharpness() const;
 
+	// SDFGI
+	void set_sdfgi_enabled(bool p_enabled);
+	bool is_sdfgi_enabled() const;
+	void set_sdfgi_cascades(SDFGICascades p_cascades);
+	SDFGICascades get_sdfgi_cascades() const;
+	void set_sdfgi_min_cell_size(float p_size);
+	float get_sdfgi_min_cell_size() const;
+	void set_sdfgi_max_distance(float p_distance);
+	float get_sdfgi_max_distance() const;
+	void set_sdfgi_cascade0_distance(float p_distance);
+	float get_sdfgi_cascade0_distance() const;
+	void set_sdfgi_y_scale(SDFGIYScale p_y_scale);
+	SDFGIYScale get_sdfgi_y_scale() const;
+	void set_sdfgi_use_occlusion(bool p_enabled);
+	bool is_sdfgi_using_occlusion() const;
+	void set_sdfgi_use_multi_bounce(bool p_enabled);
+	bool is_sdfgi_using_multi_bounce() const;
+	void set_sdfgi_read_sky_light(bool p_enabled);
+	bool is_sdfgi_reading_sky_light() const;
+	void set_sdfgi_energy(float p_energy);
+	float get_sdfgi_energy() const;
+	void set_sdfgi_normal_bias(float p_bias);
+	float get_sdfgi_normal_bias() const;
+	void set_sdfgi_probe_bias(float p_bias);
+	float get_sdfgi_probe_bias() const;
+
+	// Glow
 	void set_glow_enabled(bool p_enabled);
 	bool is_glow_enabled() const;
-
-	void set_glow_level(int p_level, bool p_enabled);
+	void set_glow_level_enabled(int p_level, bool p_enabled);
 	bool is_glow_level_enabled(int p_level) const;
-
 	void set_glow_intensity(float p_intensity);
 	float get_glow_intensity() const;
-
 	void set_glow_strength(float p_strength);
 	float get_glow_strength() const;
-
 	void set_glow_mix(float p_mix);
 	float get_glow_mix() const;
-
 	void set_glow_bloom(float p_threshold);
 	float get_glow_bloom() const;
-
 	void set_glow_blend_mode(GlowBlendMode p_mode);
 	GlowBlendMode get_glow_blend_mode() const;
-
 	void set_glow_hdr_bleed_threshold(float p_threshold);
 	float get_glow_hdr_bleed_threshold() const;
-
+	void set_glow_hdr_bleed_scale(float p_scale);
+	float get_glow_hdr_bleed_scale() const;
 	void set_glow_hdr_luminance_cap(float p_amount);
 	float get_glow_hdr_luminance_cap() const;
 
-	void set_glow_hdr_bleed_scale(float p_scale);
-	float get_glow_hdr_bleed_scale() const;
-
+	// Fog
 	void set_fog_enabled(bool p_enabled);
 	bool is_fog_enabled() const;
-
 	void set_fog_color(const Color &p_color);
 	Color get_fog_color() const;
-
 	void set_fog_sun_color(const Color &p_color);
 	Color get_fog_sun_color() const;
-
 	void set_fog_sun_amount(float p_amount);
 	float get_fog_sun_amount() const;
 
 	void set_fog_depth_enabled(bool p_enabled);
 	bool is_fog_depth_enabled() const;
-
 	void set_fog_depth_begin(float p_distance);
 	float get_fog_depth_begin() const;
-
 	void set_fog_depth_end(float p_distance);
 	float get_fog_depth_end() const;
-
 	void set_fog_depth_curve(float p_curve);
 	float get_fog_depth_curve() const;
-
 	void set_fog_transmit_enabled(bool p_enabled);
 	bool is_fog_transmit_enabled() const;
-
 	void set_fog_transmit_curve(float p_curve);
 	float get_fog_transmit_curve() const;
 
 	void set_fog_height_enabled(bool p_enabled);
 	bool is_fog_height_enabled() const;
-
 	void set_fog_height_min(float p_distance);
 	float get_fog_height_min() const;
-
 	void set_fog_height_max(float p_distance);
 	float get_fog_height_max() const;
-
 	void set_fog_height_curve(float p_distance);
 	float get_fog_height_curve() const;
 
-	void set_sdfgi_enabled(bool p_enabled);
-	bool is_sdfgi_enabled() const;
-
-	void set_sdfgi_cascades(SDFGICascades p_cascades);
-	SDFGICascades get_sdfgi_cascades() const;
-
-	void set_sdfgi_min_cell_size(float p_size);
-	float get_sdfgi_min_cell_size() const;
-
-	void set_sdfgi_cascade0_distance(float p_size);
-	float get_sdfgi_cascade0_distance() const;
-
-	void set_sdfgi_max_distance(float p_size);
-	float get_sdfgi_max_distance() const;
-
-	void set_sdfgi_use_occlusion(bool p_enable);
-	bool is_sdfgi_using_occlusion() const;
-
-	void set_sdfgi_use_multi_bounce(bool p_enable);
-	bool is_sdfgi_using_multi_bounce() const;
-
-	void set_sdfgi_use_enhance_ssr(bool p_enable);
-	bool is_sdfgi_using_enhance_ssr() const;
-
-	void set_sdfgi_read_sky_light(bool p_enable);
-	bool is_sdfgi_reading_sky_light() const;
-
-	void set_sdfgi_energy(float p_energy);
-	float get_sdfgi_energy() const;
-
-	void set_sdfgi_normal_bias(float p_bias);
-	float get_sdfgi_normal_bias() const;
-
-	void set_sdfgi_probe_bias(float p_bias);
-	float get_sdfgi_probe_bias() const;
-
-	void set_sdfgi_y_scale(SDFGIYScale p_y_scale);
-	SDFGIYScale get_sdfgi_y_scale() const;
-
-	virtual RID get_rid() const;
+	// Adjustment
+	void set_adjustment_enabled(bool p_enabled);
+	bool is_adjustment_enabled() const;
+	void set_adjustment_brightness(float p_brightness);
+	float get_adjustment_brightness() const;
+	void set_adjustment_contrast(float p_contrast);
+	float get_adjustment_contrast() const;
+	void set_adjustment_saturation(float p_saturation);
+	float get_adjustment_saturation() const;
+	void set_adjustment_color_correction(const Ref<Texture2D> &p_ramp);
+	Ref<Texture2D> get_adjustment_color_correction() const;
 
 	Environment();
 	~Environment();
@@ -429,65 +395,9 @@ VARIANT_ENUM_CAST(Environment::BGMode)
 VARIANT_ENUM_CAST(Environment::AmbientSource)
 VARIANT_ENUM_CAST(Environment::ReflectionSource)
 VARIANT_ENUM_CAST(Environment::ToneMapper)
-VARIANT_ENUM_CAST(Environment::GlowBlendMode)
 VARIANT_ENUM_CAST(Environment::SSAOBlur)
 VARIANT_ENUM_CAST(Environment::SDFGICascades)
 VARIANT_ENUM_CAST(Environment::SDFGIYScale)
-
-class CameraEffects : public Resource {
-	GDCLASS(CameraEffects, Resource);
-
-private:
-	RID camera_effects;
-
-	bool dof_blur_far_enabled;
-	float dof_blur_far_distance;
-	float dof_blur_far_transition;
-
-	bool dof_blur_near_enabled;
-	float dof_blur_near_distance;
-	float dof_blur_near_transition;
-
-	float dof_blur_amount;
-
-	bool override_exposure_enabled;
-	float override_exposure;
-
-protected:
-	static void _bind_methods();
-
-public:
-	void set_dof_blur_far_enabled(bool p_enable);
-	bool is_dof_blur_far_enabled() const;
-
-	void set_dof_blur_far_distance(float p_distance);
-	float get_dof_blur_far_distance() const;
-
-	void set_dof_blur_far_transition(float p_distance);
-	float get_dof_blur_far_transition() const;
-
-	void set_dof_blur_near_enabled(bool p_enable);
-	bool is_dof_blur_near_enabled() const;
-
-	void set_dof_blur_near_distance(float p_distance);
-	float get_dof_blur_near_distance() const;
-
-	void set_dof_blur_near_transition(float p_distance);
-	float get_dof_blur_near_transition() const;
-
-	void set_dof_blur_amount(float p_amount);
-	float get_dof_blur_amount() const;
-
-	void set_override_exposure_enabled(bool p_enabled);
-	bool is_override_exposure_enabled() const;
-
-	void set_override_exposure(float p_exposure);
-	float get_override_exposure() const;
-
-	virtual RID get_rid() const;
-
-	CameraEffects();
-	~CameraEffects();
-};
+VARIANT_ENUM_CAST(Environment::GlowBlendMode)
 
 #endif // ENVIRONMENT_H

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -181,7 +181,7 @@ bool DisplayServer::screen_is_kept_on() const {
 	return false;
 }
 
-DisplayServer::WindowID DisplayServer::create_sub_window(WindowMode p_mode, uint32_t p_flags, const Rect2i &) {
+DisplayServer::WindowID DisplayServer::create_sub_window(WindowMode p_mode, uint32_t p_flags, const Rect2i &p_rect) {
 	ERR_FAIL_V_MSG(INVALID_WINDOW_ID, "Sub-windows not supported by this display server.");
 }
 
@@ -402,7 +402,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_window_list"), &DisplayServer::get_window_list);
 	ClassDB::bind_method(D_METHOD("get_window_at_screen_position", "position"), &DisplayServer::get_window_at_screen_position);
 
-	ClassDB::bind_method(D_METHOD("create_sub_window", "mode", "rect"), &DisplayServer::create_sub_window, DEFVAL(Rect2i()));
+	ClassDB::bind_method(D_METHOD("create_sub_window", "mode", "flags", "rect"), &DisplayServer::create_sub_window, DEFVAL(Rect2i()));
 	ClassDB::bind_method(D_METHOD("delete_sub_window", "window_id"), &DisplayServer::delete_sub_window);
 
 	ClassDB::bind_method(D_METHOD("window_set_title", "title", "window_id"), &DisplayServer::window_set_title, DEFVAL(MAIN_WINDOW_ID));

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -211,7 +211,7 @@ public:
 		WINDOW_FLAG_NO_FOCUS_BIT = (1 << WINDOW_FLAG_NO_FOCUS)
 	};
 
-	virtual WindowID create_sub_window(WindowMode p_mode, uint32_t p_flags, const Rect2i & = Rect2i());
+	virtual WindowID create_sub_window(WindowMode p_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i());
 	virtual void delete_sub_window(WindowID p_id);
 
 	virtual WindowID get_window_at_screen_position(const Point2i &p_position) const = 0;

--- a/servers/rendering/rasterizer.h
+++ b/servers/rendering/rasterizer.h
@@ -32,10 +32,9 @@
 #define RASTERIZER_H
 
 #include "core/math/camera_matrix.h"
-#include "servers/rendering_server.h"
-
 #include "core/pair.h"
 #include "core/self_list.h"
+#include "servers/rendering_server.h"
 
 class RasterizerScene {
 public:
@@ -96,7 +95,7 @@ public:
 
 	virtual void environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size) = 0;
 
-	virtual void environment_set_sdfgi(RID p_env, bool p_enable, RS::EnvironmentSDFGICascades p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, bool p_enhance_ssr, float p_energy, float p_normal_bias, float p_probe_bias) = 0;
+	virtual void environment_set_sdfgi(RID p_env, bool p_enable, RS::EnvironmentSDFGICascades p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) = 0;
 
 	virtual void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count) = 0;
 	virtual void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) = 0;

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_rd.cpp
@@ -34,6 +34,7 @@
 #include "core/project_settings.h"
 #include "rasterizer_rd.h"
 #include "servers/rendering/rendering_server_raster.h"
+
 uint64_t RasterizerSceneRD::auto_exposure_counter = 2;
 
 void get_vogel_disk(float *r_kernel, int p_sample_count) {
@@ -2826,7 +2827,7 @@ void RasterizerSceneRD::environment_glow_set_use_bicubic_upscale(bool p_enable) 
 	glow_bicubic_upscale = p_enable;
 }
 
-void RasterizerSceneRD::environment_set_sdfgi(RID p_env, bool p_enable, RS::EnvironmentSDFGICascades p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, bool p_enhance_ssr, float p_energy, float p_normal_bias, float p_probe_bias) {
+void RasterizerSceneRD::environment_set_sdfgi(RID p_env, bool p_enable, RS::EnvironmentSDFGICascades p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) {
 	Environent *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
 
@@ -2836,7 +2837,6 @@ void RasterizerSceneRD::environment_set_sdfgi(RID p_env, bool p_enable, RS::Envi
 	env->sdfgi_use_occlusion = p_use_occlusion;
 	env->sdfgi_use_multibounce = p_use_multibounce;
 	env->sdfgi_read_sky_light = p_read_sky;
-	env->sdfgi_enhance_ssr = p_enhance_ssr;
 	env->sdfgi_energy = p_energy;
 	env->sdfgi_normal_bias = p_normal_bias;
 	env->sdfgi_probe_bias = p_probe_bias;

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_rd.h
@@ -689,7 +689,6 @@ private:
 		bool sdfgi_use_occlusion = false;
 		bool sdfgi_use_multibounce = false;
 		bool sdfgi_read_sky_light = false;
-		bool sdfgi_enhance_ssr = false;
 		float sdfgi_energy = 1.0;
 		float sdfgi_normal_bias = 1.1;
 		float sdfgi_probe_bias = 1.1;
@@ -1290,7 +1289,7 @@ public:
 	bool environment_is_ssr_enabled(RID p_env) const;
 	bool environment_is_sdfgi_enabled(RID p_env) const;
 
-	virtual void environment_set_sdfgi(RID p_env, bool p_enable, RS::EnvironmentSDFGICascades p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, bool p_enhance_ssr, float p_energy, float p_normal_bias, float p_probe_bias);
+	virtual void environment_set_sdfgi(RID p_env, bool p_enable, RS::EnvironmentSDFGICascades p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias);
 	virtual void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count);
 	virtual void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames);
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -281,7 +281,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shader_get_vertex_input_attribute_mask", "shader"), &RenderingDevice::shader_get_vertex_input_attribute_mask);
 
 	ClassDB::bind_method(D_METHOD("uniform_buffer_create", "size_bytes", "data"), &RenderingDevice::uniform_buffer_create, DEFVAL(Vector<uint8_t>()));
-	ClassDB::bind_method(D_METHOD("storage_buffer_create", "size_bytes", "data"), &RenderingDevice::storage_buffer_create, DEFVAL(Vector<uint8_t>()), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("storage_buffer_create", "size_bytes", "data", "usage"), &RenderingDevice::storage_buffer_create, DEFVAL(Vector<uint8_t>()), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("texture_buffer_create", "size_bytes", "format", "data"), &RenderingDevice::texture_buffer_create, DEFVAL(Vector<uint8_t>()));
 
 	ClassDB::bind_method(D_METHOD("uniform_set_create", "uniforms", "shader", "shader_set"), &RenderingDevice::_uniform_set_create);

--- a/servers/rendering/rendering_server_raster.h
+++ b/servers/rendering/rendering_server_raster.h
@@ -566,7 +566,7 @@ public:
 	BIND7(environment_set_fog_depth, RID, bool, float, float, float, bool, float)
 	BIND5(environment_set_fog_height, RID, bool, float, float, float)
 
-	BIND12(environment_set_sdfgi, RID, bool, EnvironmentSDFGICascades, float, EnvironmentSDFGIYScale, bool, bool, bool, bool, float, float, float)
+	BIND11(environment_set_sdfgi, RID, bool, EnvironmentSDFGICascades, float, EnvironmentSDFGIYScale, bool, bool, bool, float, float, float)
 	BIND1(environment_set_sdfgi_ray_count, EnvironmentSDFGIRayCount)
 	BIND1(environment_set_sdfgi_frames_to_converge, EnvironmentSDFGIFramesToConverge)
 

--- a/servers/rendering/rendering_server_wrap_mt.h
+++ b/servers/rendering/rendering_server_wrap_mt.h
@@ -468,7 +468,7 @@ public:
 
 	FUNC2(environment_set_ssao_quality, EnvironmentSSAOQuality, bool)
 
-	FUNC12(environment_set_sdfgi, RID, bool, EnvironmentSDFGICascades, float, EnvironmentSDFGIYScale, bool, bool, bool, bool, float, float, float)
+	FUNC11(environment_set_sdfgi, RID, bool, EnvironmentSDFGICascades, float, EnvironmentSDFGIYScale, bool, bool, bool, float, float, float)
 	FUNC1(environment_set_sdfgi_ray_count, EnvironmentSDFGIRayCount)
 	FUNC1(environment_set_sdfgi_frames_to_converge, EnvironmentSDFGIFramesToConverge)
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1995,6 +1995,10 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(LIGHT_PARAM_TRANSMITTANCE_BIAS);
 	BIND_ENUM_CONSTANT(LIGHT_PARAM_MAX);
 
+	BIND_ENUM_CONSTANT(LIGHT_BAKE_DISABLED);
+	BIND_ENUM_CONSTANT(LIGHT_BAKE_DYNAMIC);
+	BIND_ENUM_CONSTANT(LIGHT_BAKE_STATIC);
+
 	BIND_ENUM_CONSTANT(LIGHT_OMNI_SHADOW_DUAL_PARABOLOID);
 	BIND_ENUM_CONSTANT(LIGHT_OMNI_SHADOW_CUBE);
 
@@ -2007,6 +2011,10 @@ void RenderingServer::_bind_methods() {
 
 	BIND_ENUM_CONSTANT(REFLECTION_PROBE_UPDATE_ONCE);
 	BIND_ENUM_CONSTANT(REFLECTION_PROBE_UPDATE_ALWAYS);
+
+	BIND_ENUM_CONSTANT(REFLECTION_PROBE_AMBIENT_DISABLED);
+	BIND_ENUM_CONSTANT(REFLECTION_PROBE_AMBIENT_ENVIRONMENT);
+	BIND_ENUM_CONSTANT(REFLECTION_PROBE_AMBIENT_COLOR);
 
 	BIND_ENUM_CONSTANT(DECAL_TEXTURE_ALBEDO);
 	BIND_ENUM_CONSTANT(DECAL_TEXTURE_NORMAL);
@@ -2374,7 +2382,7 @@ RenderingServer::RenderingServer() {
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/ssao/quality", PropertyInfo(Variant::INT, "rendering/quality/ssao/quality", PROPERTY_HINT_ENUM, "Low (Fast),Medium (Average),High (Slow),Ultra (Slower)"));
 	GLOBAL_DEF("rendering/quality/ssao/half_size", false);
 
-	GLOBAL_DEF("rendering/quality/screen_filters/screen_space_roughness_limiter_enable", true);
+	GLOBAL_DEF("rendering/quality/screen_filters/screen_space_roughness_limiter_enabled", true);
 	GLOBAL_DEF("rendering/quality/screen_filters/screen_space_roughness_limiter_amount", 0.25);
 	GLOBAL_DEF("rendering/quality/screen_filters/screen_space_roughness_limiter_limit", 0.18);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/screen_filters/screen_space_roughness_limiter_amount", PropertyInfo(Variant::FLOAT, "rendering/quality/screen_filters/screen_space_roughness_limiter_amount", PROPERTY_HINT_RANGE, "0.01,4.0,0.01"));

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -428,7 +428,7 @@ public:
 	enum LightDirectionalShadowMode {
 		LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL,
 		LIGHT_DIRECTIONAL_SHADOW_PARALLEL_2_SPLITS,
-		LIGHT_DIRECTIONAL_SHADOW_PARALLEL_4_SPLITS
+		LIGHT_DIRECTIONAL_SHADOW_PARALLEL_4_SPLITS,
 	};
 
 	virtual void light_directional_set_shadow_mode(RID p_light, LightDirectionalShadowMode p_mode) = 0;
@@ -437,7 +437,6 @@ public:
 	enum LightDirectionalShadowDepthRangeMode {
 		LIGHT_DIRECTIONAL_SHADOW_DEPTH_RANGE_STABLE,
 		LIGHT_DIRECTIONAL_SHADOW_DEPTH_RANGE_OPTIMIZED,
-
 	};
 
 	virtual void light_directional_set_shadow_depth_range_mode(RID p_light, LightDirectionalShadowDepthRangeMode p_range_mode) = 0;
@@ -457,7 +456,7 @@ public:
 	enum ReflectionProbeAmbientMode {
 		REFLECTION_PROBE_AMBIENT_DISABLED,
 		REFLECTION_PROBE_AMBIENT_ENVIRONMENT,
-		REFLECTION_PROBE_AMBIENT_COLOR
+		REFLECTION_PROBE_AMBIENT_COLOR,
 	};
 
 	virtual void reflection_probe_set_ambient_mode(RID p_probe, ReflectionProbeAmbientMode p_mode) = 0;
@@ -607,16 +606,6 @@ public:
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;
 	virtual void camera_set_camera_effects(RID p_camera, RID p_camera_effects) = 0;
 	virtual void camera_set_use_vertical_aspect(RID p_camera, bool p_enable) = 0;
-
-	/*
-	enum ParticlesCollisionMode {
-		PARTICLES_COLLISION_NONE,
-		PARTICLES_COLLISION_TEXTURE,
-		PARTICLES_COLLISION_CUBEMAP,
-	};
-
-	virtual void particles_set_collision(RID p_particles,ParticlesCollisionMode p_mode,const Transform&, p_xform,const RID p_depth_tex,const RID p_normal_tex)=0;
-	*/
 
 	/* VIEWPORT TARGET API */
 
@@ -844,7 +833,7 @@ public:
 		ENV_SDFGI_Y_SCALE_50_PERCENT
 	};
 
-	virtual void environment_set_sdfgi(RID p_env, bool p_enable, EnvironmentSDFGICascades p_cascades, float p_min_cell_size, EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, bool p_enhance_ssr, float p_energy, float p_normal_bias, float p_probe_bias) = 0;
+	virtual void environment_set_sdfgi(RID p_env, bool p_enable, EnvironmentSDFGICascades p_cascades, float p_min_cell_size, EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) = 0;
 
 	enum EnvironmentSDFGIRayCount {
 		ENV_SDFGI_RAY_COUNT_8,


### PR DESCRIPTION
- Makes all boolean setters/getters consistent.
- Moved member initialization from constructor to declaration,
  fixing a couple cases where default values were overridden in the
  constructor (I kept the last override to keep compatibility).
- Fixes bug where `glow_hdr_bleed_scale` was not used.
- Split CameraEffects to their own source file.
- Reorder all Environment method and properties declarations,
  definitions and bindings to be consistent with each other
  and with the order of property bindings.
- Bind missing enum values added with SDFGI.
- Remove unused SDFGI enhance_ssr boolean.
- Sync doc changes after SDFGI merge and other misc changes.