### PR TITLE
HTML5 fixes, refactor, audio fallback, fixed FPS.

### DIFF
--- a/platform/javascript/audio_driver_javascript.cpp
+++ b/platform/javascript/audio_driver_javascript.cpp
@@ -36,6 +36,15 @@
 
 AudioDriverJavaScript *AudioDriverJavaScript::singleton = nullptr;
 
+bool AudioDriverJavaScript::is_available() {
+	return EM_ASM_INT({
+		if (!(window.AudioContext || window.webkitAudioContext)) {
+			return 0;
+		}
+		return 1;
+	}) != 0;
+}
+
 const char *AudioDriverJavaScript::get_name() const {
 	return "JavaScript";
 }
@@ -207,12 +216,14 @@ void AudioDriverJavaScript::finish_async() {
 
 	/* clang-format off */
 	EM_ASM({
-		var ref = Module.IDHandler.get($0);
+		const id = $0;
+		var ref = Module.IDHandler.get(id);
 		Module.async_finish.push(new Promise(function(accept, reject) {
 			if (!ref) {
-				console.log("Ref not found!", $0, Module.IDHandler);
+				console.log("Ref not found!", id, Module.IDHandler);
 				setTimeout(accept, 0);
 			} else {
+				Module.IDHandler.remove(id);
 				const context = ref['context'];
 				// Disconnect script and input.
 				ref['script'].disconnect();
@@ -226,7 +237,6 @@ void AudioDriverJavaScript::finish_async() {
 				});
 			}
 		}));
-		Module.IDHandler.remove($0);
 	}, id);
 	/* clang-format on */
 }
@@ -293,9 +303,5 @@ Error AudioDriverJavaScript::capture_stop() {
 }
 
 AudioDriverJavaScript::AudioDriverJavaScript() {
-	_driver_id = 0;
-	internal_buffer = nullptr;
-	buffer_length = 0;
-
 	singleton = this;
 }

--- a/platform/javascript/audio_driver_javascript.h
+++ b/platform/javascript/audio_driver_javascript.h
@@ -34,12 +34,13 @@
 #include "servers/audio_server.h"
 
 class AudioDriverJavaScript : public AudioDriver {
-	float *internal_buffer;
+	float *internal_buffer = nullptr;
 
-	int _driver_id;
-	int buffer_length;
+	int _driver_id = 0;
+	int buffer_length = 0;
 
 public:
+	static bool is_available();
 	void mix_to_js();
 	void process_capture(float sample);
 

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -68,6 +68,20 @@ bool DisplayServerJavaScript::is_canvas_focused() {
 	/* clang-format on */
 }
 
+bool DisplayServerJavaScript::check_size_force_redraw() {
+	int canvas_width;
+	int canvas_height;
+	emscripten_get_canvas_element_size(DisplayServerJavaScript::canvas_id, &canvas_width, &canvas_height);
+	if (last_width != canvas_width || last_height != canvas_height) {
+		last_width = canvas_width;
+		last_height = canvas_height;
+		// Update the framebuffer size and for redraw.
+		emscripten_set_canvas_element_size(DisplayServerJavaScript::canvas_id, canvas_width, canvas_height);
+		return true;
+	}
+	return false;
+}
+
 Point2 DisplayServerJavaScript::compute_position_in_canvas(int p_x, int p_y) {
 	int canvas_x = EM_ASM_INT({
 		return Module['canvas'].getBoundingClientRect().x;
@@ -1080,6 +1094,8 @@ Size2i DisplayServerJavaScript::window_get_min_size(WindowID p_window) const {
 }
 
 void DisplayServerJavaScript::window_set_size(const Size2i p_size, WindowID p_window) {
+	last_width = p_size.x;
+	last_height = p_size.y;
 	emscripten_set_canvas_element_size(canvas_id, p_size.x, p_size.y);
 }
 

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -45,13 +45,14 @@
 #define DOM_BUTTON_XBUTTON2 4
 
 char DisplayServerJavaScript::canvas_id[256] = { 0 };
+static bool cursor_inside_canvas = true;
 
 DisplayServerJavaScript *DisplayServerJavaScript::get_singleton() {
 	return static_cast<DisplayServerJavaScript *>(DisplayServer::get_singleton());
 }
 
 // Window (canvas)
-static void focus_canvas() {
+void DisplayServerJavaScript::focus_canvas() {
 	/* clang-format off */
 	EM_ASM(
 		Module['canvas'].focus();
@@ -59,7 +60,7 @@ static void focus_canvas() {
 	/* clang-format on */
 }
 
-static bool is_canvas_focused() {
+bool DisplayServerJavaScript::is_canvas_focused() {
 	/* clang-format off */
 	return EM_ASM_INT_V(
 		return document.activeElement == Module['canvas'];
@@ -85,8 +86,6 @@ Point2 DisplayServerJavaScript::compute_position_in_canvas(int p_x, int p_y) {
 	return Point2((int)(canvas_width / element_width * (p_x - canvas_x)),
 			(int)(canvas_height / element_height * (p_y - canvas_y)));
 }
-
-static bool cursor_inside_canvas = true;
 
 EM_BOOL DisplayServerJavaScript::fullscreen_change_callback(int p_event_type, const EmscriptenFullscreenChangeEvent *p_event, void *p_user_data) {
 	DisplayServerJavaScript *display = get_singleton();
@@ -127,14 +126,14 @@ extern "C" EMSCRIPTEN_KEEPALIVE void _drop_files_callback(char *p_filev[], int p
 // Keys
 
 template <typename T>
-static void dom2godot_mod(T *emscripten_event_ptr, Ref<InputEventWithModifiers> godot_event) {
+void DisplayServerJavaScript::dom2godot_mod(T *emscripten_event_ptr, Ref<InputEventWithModifiers> godot_event) {
 	godot_event->set_shift(emscripten_event_ptr->shiftKey);
 	godot_event->set_alt(emscripten_event_ptr->altKey);
 	godot_event->set_control(emscripten_event_ptr->ctrlKey);
 	godot_event->set_metakey(emscripten_event_ptr->metaKey);
 }
 
-static Ref<InputEventKey> setup_key_event(const EmscriptenKeyboardEvent *emscripten_event) {
+Ref<InputEventKey> DisplayServerJavaScript::setup_key_event(const EmscriptenKeyboardEvent *emscripten_event) {
 	Ref<InputEventKey> ev;
 	ev.instance();
 	ev->set_echo(emscripten_event->repeat);
@@ -285,7 +284,7 @@ EM_BOOL DisplayServerJavaScript::mousemove_callback(int p_event_type, const Emsc
 }
 
 // Cursor
-static const char *godot2dom_cursor(DisplayServer::CursorShape p_shape) {
+const char *DisplayServerJavaScript::godot2dom_cursor(DisplayServer::CursorShape p_shape) {
 	switch (p_shape) {
 		case DisplayServer::CURSOR_ARROW:
 			return "auto";
@@ -326,7 +325,7 @@ static const char *godot2dom_cursor(DisplayServer::CursorShape p_shape) {
 	}
 }
 
-static void set_css_cursor(const char *p_cursor) {
+void DisplayServerJavaScript::set_css_cursor(const char *p_cursor) {
 	/* clang-format off */
 	EM_ASM_({
 		Module['canvas'].style.cursor = UTF8ToString($0);
@@ -334,7 +333,7 @@ static void set_css_cursor(const char *p_cursor) {
 	/* clang-format on */
 }
 
-static bool is_css_cursor_hidden() {
+bool DisplayServerJavaScript::is_css_cursor_hidden() const {
 	/* clang-format off */
 	return EM_ASM_INT({
 		return Module['canvas'].style.cursor === 'none';

--- a/platform/javascript/display_server_javascript.h
+++ b/platform/javascript/display_server_javascript.h
@@ -53,7 +53,18 @@ class DisplayServerJavaScript : public DisplayServer {
 	double last_click_ms = 0;
 	int last_click_button_index = -1;
 
+	// utilities
 	static Point2 compute_position_in_canvas(int p_x, int p_y);
+	static void focus_canvas();
+	static bool is_canvas_focused();
+	template <typename T>
+	static void dom2godot_mod(T *emscripten_event_ptr, Ref<InputEventWithModifiers> godot_event);
+	static Ref<InputEventKey> setup_key_event(const EmscriptenKeyboardEvent *emscripten_event);
+	static const char *godot2dom_cursor(DisplayServer::CursorShape p_shape);
+	static void set_css_cursor(const char *p_cursor);
+	bool is_css_cursor_hidden() const;
+
+	// events
 	static EM_BOOL fullscreen_change_callback(int p_event_type, const EmscriptenFullscreenChangeEvent *p_event, void *p_user_data);
 
 	static EM_BOOL keydown_callback(int p_event_type, const EmscriptenKeyboardEvent *p_event, void *p_user_data);

--- a/platform/javascript/display_server_javascript.h
+++ b/platform/javascript/display_server_javascript.h
@@ -53,6 +53,7 @@ class DisplayServerJavaScript : public DisplayServer {
 	double last_click_ms = 0;
 	int last_click_button_index = -1;
 
+	static Point2 compute_position_in_canvas(int p_x, int p_y);
 	static EM_BOOL fullscreen_change_callback(int p_event_type, const EmscriptenFullscreenChangeEvent *p_event, void *p_user_data);
 
 	static EM_BOOL keydown_callback(int p_event_type, const EmscriptenKeyboardEvent *p_event, void *p_user_data);
@@ -81,11 +82,11 @@ protected:
 public:
 	// Override return type to make writing static callbacks less tedious.
 	static DisplayServerJavaScript *get_singleton();
+	static char canvas_id[256];
 
 	WindowMode window_mode = WINDOW_MODE_WINDOWED;
 
 	String clipboard;
-	String canvas_id;
 
 	Callable window_event_callback;
 	Callable input_event_callback;

--- a/platform/javascript/display_server_javascript.h
+++ b/platform/javascript/display_server_javascript.h
@@ -53,6 +53,9 @@ class DisplayServerJavaScript : public DisplayServer {
 	double last_click_ms = 0;
 	int last_click_button_index = -1;
 
+	int last_width = 0;
+	int last_height = 0;
+
 	// utilities
 	static Point2 compute_position_in_canvas(int p_x, int p_y);
 	static void focus_canvas();
@@ -103,6 +106,9 @@ public:
 	Callable input_event_callback;
 	Callable input_text_callback;
 	Callable drop_files_callback;
+
+	// utilities
+	bool check_size_force_redraw();
 
 	// from DisplayServer
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");

--- a/platform/javascript/javascript_main.cpp
+++ b/platform/javascript/javascript_main.cpp
@@ -47,6 +47,10 @@ void exit_callback() {
 }
 
 void main_loop_callback() {
+	bool force_draw = DisplayServerJavaScript::get_singleton()->check_size_force_redraw();
+	if (force_draw) {
+		Main::force_redraw();
+	}
 	if (os->main_loop_iterate()) {
 		emscripten_cancel_main_loop(); // Cancel current loop and wait for finalize_async.
 		EM_ASM({

--- a/platform/javascript/javascript_main.cpp
+++ b/platform/javascript/javascript_main.cpp
@@ -63,10 +63,17 @@ void main_loop_callback() {
 	}
 	if (os->main_loop_iterate()) {
 		emscripten_cancel_main_loop(); // Cancel current loop and wait for finalize_async.
+		/* clang-format off */
 		EM_ASM({
 			// This will contain the list of operations that need to complete before cleanup.
-			Module.async_finish = [];
+			Module.async_finish = [
+				// Always contains at least one async promise, to avoid firing immediately if nothing is added.
+				new Promise(function(accept, reject) {
+					setTimeout(accept, 0);
+				})
+			];
 		});
+		/* clang-format on */
 		os->get_main_loop()->finish();
 		os->finalize_async(); // Will add all the async finish functions.
 		EM_ASM({

--- a/platform/javascript/javascript_main.cpp
+++ b/platform/javascript/javascript_main.cpp
@@ -86,6 +86,11 @@ extern "C" EMSCRIPTEN_KEEPALIVE void main_after_fs_sync(char *p_idbfs_err) {
 }
 
 int main(int argc, char *argv[]) {
+	// Create and mount userfs immediately.
+	EM_ASM({
+		FS.mkdir('/userfs');
+		FS.mount(IDBFS, {}, '/userfs');
+	});
 	os = new OS_JavaScript();
 	Main::setup(argv[0], argc - 1, &argv[1], false);
 	emscripten_set_main_loop(main_loop_callback, -1, false);
@@ -95,8 +100,6 @@ int main(int argc, char *argv[]) {
 	// run the 'main_after_fs_sync' function.
 	/* clang-format off */
 	EM_ASM({
-		FS.mkdir('/userfs');
-		FS.mount(IDBFS, {}, '/userfs');
 		FS.syncfs(true, function(err) {
 			requestAnimationFrame(function() {
 				ccall('main_after_fs_sync', null, ['string'], [err ? err.message : ""]);

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -77,7 +77,9 @@ void OS_JavaScript::initialize() {
 }
 
 void OS_JavaScript::resume_audio() {
-	audio_driver_javascript.resume();
+	if (audio_driver_javascript) {
+		audio_driver_javascript->resume();
+	}
 }
 
 void OS_JavaScript::set_main_loop(MainLoop *p_main_loop) {
@@ -125,11 +127,17 @@ void OS_JavaScript::delete_main_loop() {
 
 void OS_JavaScript::finalize_async() {
 	finalizing = true;
-	audio_driver_javascript.finish_async();
+	if (audio_driver_javascript) {
+		audio_driver_javascript->finish_async();
+	}
 }
 
 void OS_JavaScript::finalize() {
 	delete_main_loop();
+	if (audio_driver_javascript) {
+		memdelete(audio_driver_javascript);
+		audio_driver_javascript = nullptr;
+	}
 }
 
 // Miscellaneous
@@ -238,7 +246,10 @@ void OS_JavaScript::initialize_joypads() {
 }
 
 OS_JavaScript::OS_JavaScript() {
-	AudioDriverManager::add_driver(&audio_driver_javascript);
+	if (AudioDriverJavaScript::is_available()) {
+		audio_driver_javascript = memnew(AudioDriverJavaScript);
+		AudioDriverManager::add_driver(audio_driver_javascript);
+	}
 
 	Vector<Logger *> loggers;
 	loggers.push_back(memnew(StdLogger));

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -74,14 +74,6 @@ void OS_JavaScript::initialize() {
 	EngineDebugger::register_uri_handler("ws://", RemoteDebuggerPeerWebSocket::create);
 	EngineDebugger::register_uri_handler("wss://", RemoteDebuggerPeerWebSocket::create);
 #endif
-
-	char locale_ptr[16];
-	/* clang-format off */
-	EM_ASM({
-		stringToUTF8(Module['locale'], $0, 16);
-	}, locale_ptr);
-	/* clang-format on */
-	setenv("LANG", locale_ptr, true);
 }
 
 void OS_JavaScript::resume_audio() {

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -40,7 +40,7 @@
 
 class OS_JavaScript : public OS_Unix {
 	MainLoop *main_loop = nullptr;
-	AudioDriverJavaScript audio_driver_javascript;
+	AudioDriverJavaScript *audio_driver_javascript = nullptr;
 
 	bool finalizing = false;
 	bool idb_available = false;

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -83,6 +83,9 @@ public:
 	String get_executable_path() const;
 	virtual Error shell_open(String p_uri);
 	virtual String get_name() const;
+	// Override default OS implementation which would block the main thread with delay_usec.
+	// Implemented in javascript_main.cpp loop callback instead.
+	virtual void add_frame_delay(bool p_can_draw) {}
 	virtual bool can_draw() const;
 
 	virtual String get_cache_path() const;

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -184,6 +184,7 @@ void AudioDriverManager::initialize(int p_driver) {
 	GLOBAL_DEF_RST("audio/enable_audio_input", false);
 	GLOBAL_DEF_RST("audio/mix_rate", DEFAULT_MIX_RATE);
 	GLOBAL_DEF_RST("audio/output_latency", DEFAULT_OUTPUT_LATENCY);
+	GLOBAL_DEF_RST("audio/output_latency.web", 50); // Safer default output_latency for web.
 
 	int failed_driver = -1;
 


### PR DESCRIPTION
In this PR:

- Fix for HTML5 startup FS error (after #39563, referenced for cherry-pick).
- Refactor `DisplayServerJavaScript` to better handle canvas ID and avoid polluting global namespace.
- Canvas size check on each loop to force redrawing when the size changed (tested in a 3.2 backport).
- Working `Engine.target_fps` in HTML5 without blocking the main thread (fixes #38623).
- Fallback to `AudioDriverDummy` when `window.AudioContext` is not supported by the browser.
- Higher (50 ms) default `audio/output_latency` override for web export (fixes #39930).

I'll make another PR for the `3.2` since cherry-picking is not that easy.