### PR TITLE
Fix some nullptr crashes in RenderingServerScene when scenario is unset

### DIFF
--- a/servers/rendering/rendering_server_scene.cpp
+++ b/servers/rendering/rendering_server_scene.cpp
@@ -370,8 +370,8 @@ void RenderingServerScene::instance_set_base(RID p_instance, RID p_base) {
 			case RS::INSTANCE_LIGHT: {
 				InstanceLightData *light = static_cast<InstanceLightData *>(instance->base_data);
 
-				if (RSG::storage->light_get_type(instance->base) != RS::LIGHT_DIRECTIONAL && light->bake_mode == RS::LIGHT_BAKE_DYNAMIC) {
-					instance->scenario->dynamic_lights.erase(light->instance);
+				if (scenario) {
+					scenario->dynamic_lights.erase(light->instance);
 				}
 
 #ifdef DEBUG_ENABLED
@@ -379,8 +379,8 @@ void RenderingServerScene::instance_set_base(RID p_instance, RID p_base) {
 					ERR_PRINT("BUG, indexing did not unpair geometries from light.");
 				}
 #endif
-				if (instance->scenario && light->D) {
-					instance->scenario->directional_lights.erase(light->D);
+				if (scenario && light->D) {
+					scenario->directional_lights.erase(light->D);
 					light->D = nullptr;
 				}
 				RSG::scene_render->free(light->instance);
@@ -529,6 +529,8 @@ void RenderingServerScene::instance_set_scenario(RID p_instance, RID p_scenario)
 					ERR_PRINT("BUG, indexing did not unpair geometries from light.");
 				}
 #endif
+				instance->scenario->dynamic_lights.erase(light->instance);
+
 				if (light->D) {
 					instance->scenario->directional_lights.erase(light->D);
 					light->D = nullptr;
@@ -854,7 +856,9 @@ void RenderingServerScene::instance_geometry_set_flag(RID p_instance, RS::Instan
 
 			if (instance->octree_id != 0) {
 				//remove from octree, it needs to be re-paired
-				instance->scenario->octree.erase(instance->octree_id);
+				if (instance->scenario) {
+					instance->scenario->octree.erase(instance->octree_id);
+				}
 				instance->octree_id = 0;
 				_instance_queue_update(instance, true, true);
 			}
@@ -986,13 +990,13 @@ void RenderingServerScene::_update_instance(Instance *p_instance) {
 
 		RS::LightBakeMode bake_mode = RSG::storage->light_get_bake_mode(p_instance->base);
 		if (RSG::storage->light_get_type(p_instance->base) != RS::LIGHT_DIRECTIONAL && bake_mode != light->bake_mode) {
-			if (light->bake_mode == RS::LIGHT_BAKE_DYNAMIC) {
+			if (light->bake_mode == RS::LIGHT_BAKE_DYNAMIC && p_instance->scenario) {
 				p_instance->scenario->dynamic_lights.erase(light->instance);
 			}
 
 			light->bake_mode = bake_mode;
 
-			if (light->bake_mode == RS::LIGHT_BAKE_DYNAMIC) {
+			if (light->bake_mode == RS::LIGHT_BAKE_DYNAMIC && p_instance->scenario) {
 				p_instance->scenario->dynamic_lights.push_back(light->instance);
 			}
 		}


### PR DESCRIPTION
line 373: I think the light should only exist in the LocalVector if this condition was true, but there is no condition under which an existing light should not be erased from it. I.e. the behaviour should be unchanged but I think this has less risk for error in any future refactoring. Change to check scenario isvalid to avoid segfault.

line 532: I tried to analyze the code and it think the light should be removed from the previous scenario here. This appears to fix a case where I closed a scene and reopened it, and it would spam "ERROR: Condition "!li" is true. Continuing.   at: sdfgi_update_probes (servers/rendering/rasterizer_rd/rasterizer_scene_rd.cpp:1217)" forever.

line 859, 993, 999: Avoid segfault if instance->scenario is nullptr.

Fixes #39951