### PR TITLE
[macOS] Add "Khronos Validation Layer" config file to the tools .app bundle template.

### DIFF
--- a/misc/dist/osx_tools.app/Contents/Resources/vulkan/explicit_layer.d/VkLayer_khronos_validation.json
+++ b/misc/dist/osx_tools.app/Contents/Resources/vulkan/explicit_layer.d/VkLayer_khronos_validation.json
@@ -1,0 +1,55 @@
+{
+    "file_format_version": "1.1.0",
+    "layer": {
+        "instance_extensions": [
+            {
+                "spec_version": "9",
+                "name": "VK_EXT_debug_report"
+            },
+            {
+                "spec_version": "1",
+                "name": "VK_EXT_debug_utils"
+            },
+            {
+                "spec_version": "2",
+                "name": "VK_EXT_validation_features"
+            }
+        ],
+        "description": "Khronos Validation Layer",
+        "device_extensions": [
+            {
+                "entrypoints": [
+                    "vkDebugMarkerSetObjectTagEXT",
+                    "vkDebugMarkerSetObjectNameEXT",
+                    "vkCmdDebugMarkerBeginEXT",
+                    "vkCmdDebugMarkerEndEXT",
+                    "vkCmdDebugMarkerInsertEXT"
+                ],
+                "spec_version": "4",
+                "name": "VK_EXT_debug_marker"
+            },
+            {
+                "entrypoints": [
+                    "vkCreateValidationCacheEXT",
+                    "vkDestroyValidationCacheEXT",
+                    "vkGetValidationCacheDataEXT",
+                    "vkMergeValidationCachesEXT"
+                ],
+                "spec_version": "1",
+                "name": "VK_EXT_validation_cache"
+            },
+            {
+                "entrypoints": [
+                    "vkGetPhysicalDeviceToolPropertiesEXT"
+                ],
+                "spec_version": "1",
+                "name": "VK_EXT_tooling_info"
+            }
+        ],
+        "library_path": "../../../Frameworks/libVkLayer_khronos_validation.dylib",
+        "implementation_version": "1",
+        "type": "GLOBAL",
+        "api_version": "1.2.141",
+        "name": "VK_LAYER_KHRONOS_validation"
+    }
+}


### PR DESCRIPTION
Adds "Khronos Validation Layer" config file required to load validation layer if its library is place inside the editor `.app` bundle, to distribute it without need for the LunarG SDK installation.