### PR TITLE
Make timeline cursor in the Bezier editor just as thick as the Animation editor

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -31,6 +31,7 @@
 #include "animation_bezier_editor.h"
 
 #include "editor/editor_node.h"
+#include "editor_scale.h"
 
 float AnimationBezierTrackEdit::_bezier_h_to_pixel(float p_h) {
 	float h = p_h;
@@ -539,7 +540,7 @@ void AnimationBezierTrackEdit::_play_position_draw() {
 
 	if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
 		Color color = get_theme_color("accent_color", "Editor");
-		play_position->draw_line(Point2(px, 0), Point2(px, h), color);
+		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 	}
 }
 


### PR DESCRIPTION
PR #31424 made the timeline cursor in the Animation editor thicker for easier visibility. However, the Bezier editor got neglected and its cursor stayed thin. This PR fixes that.