### PR TITLE
Remove oversized margins in the AnimationTree editor

### DIFF
--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -238,7 +238,7 @@ AnimationTreeEditor::AnimationTreeEditor() {
 	add_child(memnew(HSeparator));
 
 	singleton = this;
-	editor_base = memnew(PanelContainer);
+	editor_base = memnew(MarginContainer);
 	editor_base->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(editor_base);
 

--- a/editor/plugins/animation_tree_editor_plugin.h
+++ b/editor/plugins/animation_tree_editor_plugin.h
@@ -55,7 +55,7 @@ class AnimationTreeEditor : public VBoxContainer {
 	HBoxContainer *path_hb;
 
 	AnimationTree *tree;
-	PanelContainer *editor_base;
+	MarginContainer *editor_base;
 
 	Vector<String> button_path;
 	Vector<String> edited_path;


### PR DESCRIPTION
`PanelContainer` has a margin of its own, which makes the overall margin too large. By using a `MarginContainer`, which has none by default, makes the editor's margins be inline with others.