### PR TITLE
Clarify port/slot distinction and add method to get slot idx from port idx in GraphNode

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -6,6 +6,7 @@
 	<description>
 		GraphEdit manages the showing of GraphNodes it contains, as well as connections and disconnections between them. Signals are sent for each of these two events. Disconnection between GraphNode slots is disabled by default.
 		It is greatly advised to enable low-processor usage mode (see [member OS.low_processor_usage_mode]) when using GraphEdits.
+		On this page, a port refers to a left or right slot on a GraphNode that is enabled. The index of a port corresponds to its slot index minus the number of disabled slots before it. The slot index corresponding to a port can be obtained using [method GraphNode.get_connection_slot_index].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -58,7 +59,7 @@
 			<argument index="3" name="to_port" type="int">
 			</argument>
 			<description>
-				Create a connection between the [code]from_port[/code] slot of the [code]from[/code] GraphNode and the [code]to_port[/code] slot of the [code]to[/code] GraphNode. If the connection already exists, no connection is created.
+				Create a connection between the [code]from_port[/code] port of the [code]from[/code] GraphNode and the [code]to_port[/code] port of the [code]to[/code] GraphNode. If the connection already exists, no connection is created.
 			</description>
 		</method>
 		<method name="disconnect_node">
@@ -73,7 +74,7 @@
 			<argument index="3" name="to_port" type="int">
 			</argument>
 			<description>
-				Removes the connection between the [code]from_port[/code] slot of the [code]from[/code] GraphNode and the [code]to_port[/code] slot of the [code]to[/code] GraphNode. If the connection does not exist, no connection is removed.
+				Removes the connection between the [code]from_port[/code] port of the [code]from[/code] GraphNode and the [code]to_port[/code] port of the [code]to[/code] GraphNode. If the connection does not exist, no connection is removed.
 			</description>
 		</method>
 		<method name="get_connection_list" qualifiers="const">
@@ -103,7 +104,7 @@
 			<argument index="3" name="to_port" type="int">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the [code]from_port[/code] slot of the [code]from[/code] GraphNode is connected to the [code]to_port[/code] slot of the [code]to[/code] GraphNode.
+				Returns [code]true[/code] if the [code]from_port[/code] port of the [code]from[/code] GraphNode is connected to the [code]to_port[/code] port of the [code]to[/code] GraphNode.
 			</description>
 		</method>
 		<method name="is_valid_connection_type" qualifiers="const">
@@ -206,31 +207,31 @@
 		<signal name="connection_from_empty">
 			<argument index="0" name="to" type="StringName">
 			</argument>
-			<argument index="1" name="to_slot" type="int">
+			<argument index="1" name="to_port" type="int">
 			</argument>
 			<argument index="2" name="release_position" type="Vector2">
 			</argument>
 			<description>
-				Emitted when user dragging connection from input port into empty space of the graph.
+				Emitted when user drags connection from input port into empty space of the graph.
 			</description>
 		</signal>
 		<signal name="connection_request">
 			<argument index="0" name="from" type="StringName">
 			</argument>
-			<argument index="1" name="from_slot" type="int">
+			<argument index="1" name="from_port" type="int">
 			</argument>
 			<argument index="2" name="to" type="StringName">
 			</argument>
-			<argument index="3" name="to_slot" type="int">
+			<argument index="3" name="to_port" type="int">
 			</argument>
 			<description>
-				Emitted to the GraphEdit when the connection between the [code]from_slot[/code] slot of the [code]from[/code] GraphNode and the [code]to_slot[/code] slot of the [code]to[/code] GraphNode is attempted to be created.
+				Emitted to the GraphEdit when the connection between [code]from_port[/code] of the [code]from[/code] GraphNode and [code]to_port[/code] of the [code]to[/code] GraphNode is attempted to be created.
 			</description>
 		</signal>
 		<signal name="connection_to_empty">
 			<argument index="0" name="from" type="StringName">
 			</argument>
-			<argument index="1" name="from_slot" type="int">
+			<argument index="1" name="from_port" type="int">
 			</argument>
 			<argument index="2" name="release_position" type="Vector2">
 			</argument>
@@ -251,14 +252,14 @@
 		<signal name="disconnection_request">
 			<argument index="0" name="from" type="StringName">
 			</argument>
-			<argument index="1" name="from_slot" type="int">
+			<argument index="1" name="from_port" type="int">
 			</argument>
 			<argument index="2" name="to" type="StringName">
 			</argument>
-			<argument index="3" name="to_slot" type="int">
+			<argument index="3" name="to_port" type="int">
 			</argument>
 			<description>
-				Emitted to the GraphEdit when the connection between [code]from_slot[/code] slot of [code]from[/code] GraphNode and [code]to_slot[/code] slot of [code]to[/code] GraphNode is attempted to be removed.
+				Emitted to the GraphEdit when the connection between [code]from_port[/code] of the [code]from[/code] GraphNode and [code]to_port[/code] of the [code]to[/code] GraphNode is attempted to be removed.
 			</description>
 		</signal>
 		<signal name="duplicate_nodes_request">

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -95,6 +95,17 @@
 				Returns the type of the output connection [code]idx[/code].
 			</description>
 		</method>
+		<method name="get_connection_slot_index">
+			<return type="int">
+			</return>
+			<argument index="0" name="idx" type="int">
+			</argument>
+			<argument index="1" name="is_input" type="bool">
+			</argument>
+			<description>
+				Returns the index of the slot corresponding to the connection [code]idx[/code]. If [code]is_input[/code] is [code]true[/code], [code]idx[/code] is treated as an input connection, else as an output connection.
+			</description>
+		</method>
 		<method name="get_slot_color_left" qualifiers="const">
 			<return type="Color">
 			</return>

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1245,16 +1245,16 @@ void GraphEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_snap"), "set_use_snap", "is_using_snap");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "zoom"), "set_zoom", "get_zoom");
 
-	ADD_SIGNAL(MethodInfo("connection_request", PropertyInfo(Variant::STRING_NAME, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::STRING_NAME, "to"), PropertyInfo(Variant::INT, "to_slot")));
-	ADD_SIGNAL(MethodInfo("disconnection_request", PropertyInfo(Variant::STRING_NAME, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::STRING_NAME, "to"), PropertyInfo(Variant::INT, "to_slot")));
+	ADD_SIGNAL(MethodInfo("connection_request", PropertyInfo(Variant::STRING_NAME, "from"), PropertyInfo(Variant::INT, "from_port"), PropertyInfo(Variant::STRING_NAME, "to"), PropertyInfo(Variant::INT, "to_port")));
+	ADD_SIGNAL(MethodInfo("disconnection_request", PropertyInfo(Variant::STRING_NAME, "from"), PropertyInfo(Variant::INT, "from_port"), PropertyInfo(Variant::STRING_NAME, "to"), PropertyInfo(Variant::INT, "to_port")));
 	ADD_SIGNAL(MethodInfo("popup_request", PropertyInfo(Variant::VECTOR2, "position")));
 	ADD_SIGNAL(MethodInfo("duplicate_nodes_request"));
 	ADD_SIGNAL(MethodInfo("copy_nodes_request"));
 	ADD_SIGNAL(MethodInfo("paste_nodes_request"));
 	ADD_SIGNAL(MethodInfo("node_selected", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("node_unselected", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
-	ADD_SIGNAL(MethodInfo("connection_to_empty", PropertyInfo(Variant::STRING_NAME, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));
-	ADD_SIGNAL(MethodInfo("connection_from_empty", PropertyInfo(Variant::STRING_NAME, "to"), PropertyInfo(Variant::INT, "to_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));
+	ADD_SIGNAL(MethodInfo("connection_to_empty", PropertyInfo(Variant::STRING_NAME, "from"), PropertyInfo(Variant::INT, "from_port"), PropertyInfo(Variant::VECTOR2, "release_position")));
+	ADD_SIGNAL(MethodInfo("connection_from_empty", PropertyInfo(Variant::STRING_NAME, "to"), PropertyInfo(Variant::INT, "to_port"), PropertyInfo(Variant::VECTOR2, "release_position")));
 	ADD_SIGNAL(MethodInfo("delete_nodes_request"));
 	ADD_SIGNAL(MethodInfo("_begin_node_move"));
 	ADD_SIGNAL(MethodInfo("_end_node_move"));

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -491,6 +491,7 @@ void GraphNode::_connpos_update() {
 				ConnCache cc;
 				cc.pos = Point2i(edgeofs, y + h / 2);
 				cc.type = slot_info[idx].type_left;
+				cc.slot_idx = idx;
 				cc.color = slot_info[idx].color_left;
 				conn_input_cache.push_back(cc);
 			}
@@ -498,6 +499,7 @@ void GraphNode::_connpos_update() {
 				ConnCache cc;
 				cc.pos = Point2i(get_size().width - edgeofs, y + h / 2);
 				cc.type = slot_info[idx].type_right;
+				cc.slot_idx = idx;
 				cc.color = slot_info[idx].color_right;
 				conn_output_cache.push_back(cc);
 			}
@@ -587,6 +589,20 @@ Color GraphNode::get_connection_output_color(int p_idx) {
 
 	ERR_FAIL_INDEX_V(p_idx, conn_output_cache.size(), Color());
 	return conn_output_cache[p_idx].color;
+}
+
+int GraphNode::get_connection_slot_index(int p_connection_idx, bool p_is_input) {
+	if (connpos_dirty) {
+		_connpos_update();
+	}
+
+	if (p_is_input) {
+		ERR_FAIL_INDEX_V(p_connection_idx, conn_input_cache.size(), 0);
+		return conn_input_cache[p_connection_idx].slot_idx;
+	} else {
+		ERR_FAIL_INDEX_V(p_connection_idx, conn_output_cache.size(), 0);
+		return conn_output_cache[p_connection_idx].slot_idx;
+	}
 }
 
 void GraphNode::_gui_input(const Ref<InputEvent> &p_ev) {
@@ -695,6 +711,7 @@ void GraphNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_connection_input_position", "idx"), &GraphNode::get_connection_input_position);
 	ClassDB::bind_method(D_METHOD("get_connection_input_type", "idx"), &GraphNode::get_connection_input_type);
 	ClassDB::bind_method(D_METHOD("get_connection_input_color", "idx"), &GraphNode::get_connection_input_color);
+	ClassDB::bind_method(D_METHOD("get_connection_slot_index", "idx", "is_input"), &GraphNode::get_connection_slot_index);
 
 	ClassDB::bind_method(D_METHOD("set_show_close_button", "show"), &GraphNode::set_show_close_button);
 	ClassDB::bind_method(D_METHOD("is_close_button_visible"), &GraphNode::is_close_button_visible);

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -81,6 +81,7 @@ private:
 	struct ConnCache {
 		Vector2 pos;
 		int type;
+		int slot_idx;
 		Color color;
 	};
 
@@ -144,6 +145,7 @@ public:
 	Vector2 get_connection_output_position(int p_idx);
 	int get_connection_output_type(int p_idx);
 	Color get_connection_output_color(int p_idx);
+	int get_connection_slot_index(int p_connection_idx, bool p_is_input);
 
 	void set_overlay(Overlay p_overlay);
 	Overlay get_overlay() const;


### PR DESCRIPTION
The `GraphEdit` class documentation uses the terms `port` and `slot` interchangeably to refer only to slots that are enabled,
whereas the `GraphNode` class documentation uses `slot` to refer to any slot, regardless of whether it is enabled or not.
This PR clarifies the distinction between ports and slots in the `GraphEdit` class documentation, and updates the relevant 
signal descriptions accordingly.  

It also adds a method to convert a port/connection index to its corresponding slot index on the `GraphNode`.

Closes #37227