### PR TITLE
expose copy_selection() and select_all() for RichTextLabel

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -281,6 +281,20 @@
 				If [code]expand[/code] is [code]false[/code], the column will not contribute to the total ratio.
 			</description>
 		</method>
+		<method name="copy_selection">
+			<return type="void">
+			</return>
+			<description>
+				Copies the current selection to the clipboard. This will only copy the raw text without any BBCode formatting.
+			</description>
+		</method>
+		<method name="select_all">
+			<return type="void">
+			</return>
+			<description>
+				Select all the text if selection is enabled.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="bbcode_enabled" type="bool" setter="set_use_bbcode" getter="is_using_bbcode" default="false">

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2565,6 +2565,21 @@ void RichTextLabel::selection_copy() {
 	}
 }
 
+void RichTextLabel::select_all() {
+	if (!selection.enabled) {
+		return;
+	}
+
+	if (main->lines.size() > 0) {
+		selection.from = main->subitems[0];
+		selection.to = main->subitems[main->subitems.size() - 1];
+		selection.from_char = 0;
+		selection.to_char = static_cast<ItemText *>(main->subitems[main->subitems.size() - 1])->text.length() - 1;
+		selection.active = true;
+		update();
+	}
+}
+
 bool RichTextLabel::is_selection_enabled() const {
 	return selection.enabled;
 }
@@ -2749,6 +2764,9 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_effects", "effects"), &RichTextLabel::set_effects);
 	ClassDB::bind_method(D_METHOD("get_effects"), &RichTextLabel::get_effects);
 	ClassDB::bind_method(D_METHOD("install_effect", "effect"), &RichTextLabel::install_effect);
+
+	ClassDB::bind_method(D_METHOD("copy_selection"), &RichTextLabel::selection_copy);
+	ClassDB::bind_method(D_METHOD("select_all"), &RichTextLabel::select_all);
 
 	ADD_GROUP("BBCode", "bbcode_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bbcode_enabled"), "set_use_bbcode", "is_using_bbcode");

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -476,6 +476,7 @@ public:
 	void set_selection_enabled(bool p_enabled);
 	bool is_selection_enabled() const;
 	void selection_copy();
+	void select_all();
 
 	Error parse_bbcode(const String &p_bbcode);
 	Error append_bbcode(const String &p_bbcode);


### PR DESCRIPTION
This PR exposes two functions for RichTextLabel: **copy_selection()** and **select_all()**

My usecase:
I'm working on a render manager and I use RichTextLabel to show a colorized log output of some external processes. It was already possible to copy the selection by pressing ctrl+c as this is hard coded, but I also wanted to add a "copy" option in a right click context menu. So I need to have access to this function. Selecting everything would also be handy in my case in order to select the whole log, which can be quit long.

By the way, TextEdit also has those two functions exposed ( copy() and select_all() ), so I see no reason why they shouldn't be exposed in RichTextLabel, too.

For select_all() I'm not sure if the way how I access the items is correct or problematic in any way. I've tested it and it seems to work nicely. I couldn't find any problems with it.