### PR TITLE
Ignore (clean) blend times for non-existent animations

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1055,6 +1055,8 @@ void AnimationPlayer::get_animation_list(List<StringName> *p_animations) const {
 }
 
 void AnimationPlayer::set_blend_time(const StringName &p_animation1, const StringName &p_animation2, float p_time) {
+	ERR_FAIL_COND(!animation_set.has(p_animation1));
+	ERR_FAIL_COND(!animation_set.has(p_animation2));
 	ERR_FAIL_COND_MSG(p_time < 0, "Blend time cannot be smaller than 0.");
 
 	BlendKey bk;


### PR DESCRIPTION
This adds a validation similar to the one in `animation_set_next()`.

This solves a problem: as the set of animations in your `AnimationPlayer`s evolve, obsolete blend time pairs can stay, referencing animations no longer existent and cluttering your scene files.

With this PR merged, if you re-save all your scenes where this happens, you'll have your `blend_times` arrays clean of those traces.