### PR TITLE
Allow script editor scripts to be drag-dropped onto resource properties

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2983,8 +2983,16 @@ bool EditorPropertyResource::_is_drop_valid(const Dictionary &p_drag_data) const
 	String allowed_type = base_type;
 
 	Dictionary drag_data = p_drag_data;
-	if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
-		Ref<Resource> res = drag_data["resource"];
+
+	Ref<Resource> res;
+	if (drag_data.has("type") && String(drag_data["type"]) == "script_list_element") {
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(drag_data["script_list_element"]);
+		res = se->get_edited_resource();
+	} else if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
+		res = drag_data["resource"];
+	}
+
+	if (res.is_valid()) {
 		for (int i = 0; i < allowed_type.get_slice_count(","); i++) {
 			String at = allowed_type.get_slice(",", i).strip_edges();
 			if (res.is_valid() && ClassDB::is_parent_class(res->get_class(), at)) {
@@ -3022,13 +3030,19 @@ void EditorPropertyResource::drop_data_fw(const Point2 &p_point, const Variant &
 	ERR_FAIL_COND(!_is_drop_valid(p_data));
 
 	Dictionary drag_data = p_data;
-	if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
-		Ref<Resource> res = drag_data["resource"];
-		if (res.is_valid()) {
-			emit_changed(get_edited_property(), res);
-			update_property();
-			return;
-		}
+
+	Ref<Resource> res;
+	if (drag_data.has("type") && String(drag_data["type"]) == "script_list_element") {
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(drag_data["script_list_element"]);
+		res = se->get_edited_resource();
+	} else if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
+		res = drag_data["resource"];
+	}
+
+	if (res.is_valid()) {
+		emit_changed(get_edited_property(), res);
+		update_property();
+		return;
 	}
 
 	if (drag_data.has("type") && String(drag_data["type"]) == "files") {
@@ -3036,9 +3050,9 @@ void EditorPropertyResource::drop_data_fw(const Point2 &p_point, const Variant &
 
 		if (files.size() == 1) {
 			String file = files[0];
-			RES res = ResourceLoader::load(file);
-			if (res.is_valid()) {
-				emit_changed(get_edited_property(), res);
+			RES file_res = ResourceLoader::load(file);
+			if (file_res.is_valid()) {
+				emit_changed(get_edited_property(), file_res);
 				update_property();
 				return;
 			}


### PR DESCRIPTION
Fixes #38456.

Resource properties in the inspector currently only allow `drag_data` of type `"files"` and `"resource"` to be drag-dropped. This adds the ability to drag-drop `drag_data` of type `"script_list_element"` onto inspector resource properties. This way, a user can choose to drag-drop a script into the inspector either from the file explorer or the script editor list, whereas before they had to drag from the file explorer. 

[Here](https://github.com/godotengine/godot/files/4865963/ScriptDragDropExample.-.2.zip) is a reproduction courtesy of @Error7Studios where you can test that this works as intended. 
