### PR TITLE
Remove String::find_last (same as rfind)

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -2281,15 +2281,7 @@ String String::substr(int p_from, int p_chars) const {
 }
 
 int String::find_last(const String &p_str) const {
-	int pos = -1;
-	int findfrom = 0;
-	int findres = -1;
-	while ((findres = find(p_str, findfrom)) != -1) {
-		pos = findres;
-		findfrom = pos + 1;
-	}
-
-	return pos;
+	return rfind(p_str);
 }
 
 int String::find(const String &p_str, int p_from) const {


### PR DESCRIPTION
`find_last `and `rfind `do the same thing, only difference being that `find_last` starts at the beginning and finds all occurences, and throws away everything except the last. **This commit is incomplete.** For consistency I think `find_last` should be removed, because `rfind`, matches other functions like `rstrip`.