### PR TITLE
Fix incorrect documentation for Vector2.angle()

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -44,7 +44,7 @@
 			</return>
 			<description>
 				Returns the vector's angle in radians with respect to the X axis, or [code](1, 0)[/code] vector.
-				Equivalent to the result of [method @GDScript.atan2] when called with the vector's [member x] and [member y] as parameters: [code]atan2(x, y)[/code].
+				Equivalent to the result of [method @GDScript.atan2] when called with the vector's [member y] and [member x] as parameters: [code]atan2(y, x)[/code].
 			</description>
 		</method>
 		<method name="angle_to">


### PR DESCRIPTION
`atan2`'s arguments are in `y, x` order. This was documented incorrectly in Vector2.angle(), so I fixed it.

I did a search with `grep -RIn atan2 | grep -v "\.po"` and there are no other instances of `atan2` documented incorrectly.