### PR TITLE
Fix RichTextLabel fill alignment regression

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -256,7 +256,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 			lh = line < l.height_caches.size() ? l.height_caches[line] : 1;                                                                                     \
 			line_ascent = line < l.ascent_caches.size() ? l.ascent_caches[line] : 1;                                                                            \
 			line_descent = line < l.descent_caches.size() ? l.descent_caches[line] : 1;                                                                         \
-			if (p_mode == PROCESS_DRAW) {                                                                                                                       \
+			if ((p_mode == PROCESS_DRAW) && (align != ALIGN_FILL)) {                                                                                            \
 				if (line < l.offset_caches.size()) {                                                                                                            \
 					wofs = l.offset_caches[line];                                                                                                               \
 				}                                                                                                                                               \


### PR DESCRIPTION
Fixes #40068 (regression from #39164) by not applying the line offset change in the case of fill alignment mode.

CC @theoway 