### PR TITLE
[macOS] Implement seamless display scaling.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -523,6 +523,15 @@
 			<description>
 			</description>
 		</method>
+		<method name="screen_get_max_scale" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				Return the greatest scale factor of all screens.
+				[b]Note:[/b] On macOS returned value is [code]2.0[/code] if there is at least one hiDPI (Retina) screen in the system, and [code]1.0[/code] in all other cases.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
 		<method name="screen_get_orientation" qualifiers="const">
 			<return type="int" enum="DisplayServer.ScreenOrientation">
 			</return>
@@ -545,6 +554,9 @@
 			<argument index="0" name="screen" type="int" default="-1">
 			</argument>
 			<description>
+				Return the scale factor of the specified screen by index.
+				[b]Note:[/b] On macOS returned value is [code]2.0[/code] for hiDPI (Retina) screen, and [code]1.0[/code] for all other cases.
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="screen_get_size" qualifiers="const">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5520,10 +5520,10 @@ EditorNode::EditorNode() {
 		switch (display_scale) {
 			case 0: {
 				// Try applying a suitable display scale automatically
-				const int screen = DisplayServer::get_singleton()->window_get_current_screen();
 #ifdef OSX_ENABLED
-				editor_set_scale(DisplayServer::get_singleton()->screen_get_scale(screen));
+				editor_set_scale(DisplayServer::get_singleton()->screen_get_max_scale());
 #else
+				const int screen = DisplayServer::get_singleton()->window_get_current_screen();
 				editor_set_scale(DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && DisplayServer::get_singleton()->screen_get_size(screen).x > 2000 ? 2.0 : 1.0);
 #endif
 			} break;

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2336,10 +2336,10 @@ ProjectManager::ProjectManager() {
 		switch (display_scale) {
 			case 0: {
 				// Try applying a suitable display scale automatically
-				const int screen = DisplayServer::get_singleton()->window_get_current_screen();
 #ifdef OSX_ENABLED
-				editor_set_scale(DisplayServer::get_singleton()->screen_get_scale(screen));
+				editor_set_scale(DisplayServer::get_singleton()->screen_get_max_scale());
 #else
+				const int screen = DisplayServer::get_singleton()->window_get_current_screen();
 				editor_set_scale(DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && DisplayServer::get_singleton()->screen_get_size(screen).x > 2000 ? 2.0 : 1.0);
 #endif
 			} break;
@@ -2371,11 +2371,8 @@ ProjectManager::ProjectManager() {
 		// Define a minimum window size to prevent UI elements from overlapping or being cut off
 		DisplayServer::get_singleton()->window_set_min_size(Size2(750, 420) * EDSCALE);
 
-#ifndef OSX_ENABLED
-		// The macOS platform implementation uses its own hiDPI window resizing code
 		// TODO: Resize windows on hiDPI displays on Windows and Linux and remove the line below
 		DisplayServer::get_singleton()->window_set_size(DisplayServer::get_singleton()->window_get_size() * MAX(1, EDSCALE));
-#endif
 	}
 
 	FileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -132,6 +132,7 @@ public:
 		bool on_top = false;
 		bool borderless = false;
 		bool resize_disabled = false;
+		bool no_focus = false;
 	};
 
 	Point2i im_selection;
@@ -150,7 +151,6 @@ public:
 
 	void _set_window_per_pixel_transparency_enabled(bool p_enabled, WindowID p_window);
 
-	float _display_scale(id screen) const;
 	Point2i _get_screens_origin() const;
 	Point2i _get_native_screen_position(int p_screen) const;
 
@@ -224,6 +224,7 @@ public:
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
+	virtual float screen_get_max_scale() const;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 
 	virtual Vector<int> get_window_list() const;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -338,6 +338,7 @@ void Window::_event_callback(DisplayServer::WindowEvent p_event) {
 			emit_signal("go_back_requested");
 		} break;
 		case DisplayServer::WINDOW_EVENT_DPI_CHANGE: {
+			_update_viewport_size();
 			_propagate_window_notification(this, NOTIFICATION_WM_DPI_CHANGE);
 			emit_signal("dpi_changed");
 		} break;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -392,6 +392,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("screen_get_dpi", "screen"), &DisplayServer::screen_get_dpi, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_scale", "screen"), &DisplayServer::screen_get_scale, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_is_touchscreen", "screen"), &DisplayServer::screen_is_touchscreen, DEFVAL(SCREEN_OF_MAIN_WINDOW));
+	ClassDB::bind_method(D_METHOD("screen_get_max_scale"), &DisplayServer::screen_get_max_scale);
 
 	ClassDB::bind_method(D_METHOD("screen_set_orientation", "orientation", "screen"), &DisplayServer::screen_set_orientation, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_orientation", "screen"), &DisplayServer::screen_get_orientation, DEFVAL(SCREEN_OF_MAIN_WINDOW));

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -167,6 +167,14 @@ public:
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const = 0;
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
+	virtual float screen_get_max_scale() const {
+		float scale = 1.f;
+		int screen_count = get_screen_count();
+		for (int i = 0; i < screen_count; i++) {
+			scale = fmax(scale, screen_get_scale(i));
+		}
+		return scale;
+	}
 	virtual bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
 	enum ScreenOrientation {
 


### PR DESCRIPTION
Use the highest display scale to calculate window/screen coordinates and for rendering, ~downscale~ (we do not need to do it ourselves, just let OS to do the job) on lower scale displays. Also, should fix popup positions.

Before (moving from hiDPI to lowDPI display):
![mmove2](https://user-images.githubusercontent.com/7645683/86463513-5333aa80-bd36-11ea-9de0-53db1586de75.gif)

After:
![mmove1](https://user-images.githubusercontent.com/7645683/86463543-5e86d600-bd36-11ea-8608-1083a796a441.gif)

Fixes #5688 (no scale changes when moving from screen to screen)
Fixes #13017 (incorrect project window position when started from editor and project have different DPI settings).

*Update:*
- Added missing `No Focus` flag implementation.
- And tested all `window_...` and `screen_...` functions in the DS, except `window_set_input_text_callback` (callback is not used on any desktop platform) and `window_set_transient` (I have no idea what it is really supposed to do), everything seems to work.