### PR TITLE
Provide warning when using polygon shapes in `CollisionShape2D` node

### DIFF
--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -242,9 +242,11 @@ void CollisionShape2DEditor::commit_handle(int idx, Variant &p_org) {
 		} break;
 
 		case CONCAVE_POLYGON_SHAPE: {
+			// Cannot be edited directly, use CollisionPolygon2D instead.
 		} break;
 
 		case CONVEX_POLYGON_SHAPE: {
+			// Cannot be edited directly, use CollisionPolygon2D instead.
 		} break;
 
 		case LINE_SHAPE: {

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -176,11 +176,14 @@ String CollisionShape2D::get_configuration_warning() const {
 	if (!Object::cast_to<CollisionObject2D>(get_parent())) {
 		return TTR("CollisionShape2D only serves to provide a collision shape to a CollisionObject2D derived node. Please only use it as a child of Area2D, StaticBody2D, RigidBody2D, KinematicBody2D, etc. to give them a shape.");
 	}
-
 	if (!shape.is_valid()) {
 		return TTR("A shape must be provided for CollisionShape2D to function. Please create a shape resource for it!");
 	}
-
+	Ref<ConvexPolygonShape2D> convex = shape;
+	Ref<ConcavePolygonShape2D> concave = shape;
+	if (convex.is_valid() || concave.is_valid()) {
+		return TTR("Polygon-based shapes are not meant be used nor edited directly through the CollisionShape2D node. Please use the CollisionPolygon2D node instead.");
+	}
 	return String();
 }
 


### PR DESCRIPTION
Closes #21394.

![godot-no-polygon-edit](https://user-images.githubusercontent.com/17108460/86471365-e6c0a780-bd45-11ea-9cfc-b34a94200a08.png)

`ConvexPolygonShape2D` and `ConcavePolygonShape2D` are only meant to be used directly in code and not in the editor for physics-based use cases specifically.

Developers are advised to use `CollisionPolygon2D` instead, which does generate those shapes under the hood, handling polygon convexivity, proper orientation etc.

This change is advised by @reduz with the discussion in https://github.com/godotengine/godot/issues/21394#issuecomment-653515250.

For enthusiasts, you can check out how I'd go for simple polygon editing in GoostGD/goost#2 implementing `VisualShape2D` node, with the use cases not necessarily related to physics. But given such a node likely won't be available in Godot due to https://github.com/godotengine/godot/pull/16483#issuecomment-385715858, it doesn't make much sense to provide an editor to edit polygon-based shapes, as there's no benefit doing so for physics-only use cases.
