### PR TITLE
Change translation parser plugin API to parse_file()

### DIFF
--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -4,21 +4,38 @@
 		Plugin for adding custom parsers to extract strings that are to be translated from custom files (.csv, .json etc.).
 	</brief_description>
 	<description>
-		Plugins are registered via [method EditorPlugin.add_translation_parser_plugin] method. To define the parsing and string extraction logic, override the [method parse_text] method in script.
+		Plugins are registered via [method EditorPlugin.add_translation_parser_plugin] method. To define the parsing and string extraction logic, override the [method parse_file] method in script.
 		The extracted strings will be written into a POT file selected by user under "POT Generation" in "Localization" tab in "Project Settings" menu.
 		Below shows an example of a custom parser that extracts strings in a CSV file to write into a POT.
 		[codeblock]
 		tool
 		extends EditorTranslationParserPlugin
 
-		func parse_text(text, extracted_strings):
+
+		func parse_file(path, extracted_strings):
+		    var file = File.new()
+		    file.open(path, File.READ)
+		    var text = file.get_as_text()
 		    var split_strs = text.split(",", false, 0)
 		    for s in split_strs:
 		        extracted_strings.append(s)
 		        #print("Extracted string: " + s)
 
+
 		func get_recognized_extensions():
 		    return ["csv"]
+		[/codeblock]
+		[b]Note:[/b] If you override parsing logic for standard script types (GDScript, C#, etc.), it would be better to load the [code]path[/code] argument using [method ResourceLoader.load]. This is because built-in scripts are loaded as [Resource] type, not [File] type.
+		For example:
+		[codeblock]
+		func parse_file(path, extracted_strings):
+		    var res = ResourceLoader.load(path, "Script")
+		    var text = res.get_source_code()
+		    # Parsing logic.
+
+
+		func get_recognized_extensions():
+		    return ["gd"]			
 		[/codeblock]
 	</description>
 	<tutorials>
@@ -31,10 +48,10 @@
 				Gets the list of file extensions to associate with this parser, e.g. [code]["csv"][/code].
 			</description>
 		</method>
-		<method name="parse_text" qualifiers="virtual">
+		<method name="parse_file" qualifiers="virtual">
 			<return type="void">
 			</return>
-			<argument index="0" name="text" type="String">
+			<argument index="0" name="path" type="String">
 			</argument>
 			<argument index="1" name="extracted_strings" type="Array">
 			</argument>

--- a/editor/editor_translation_parser.cpp
+++ b/editor/editor_translation_parser.cpp
@@ -41,33 +41,16 @@ Error EditorTranslationParserPlugin::parse_file(const String &p_path, Vector<Str
 	if (!get_script_instance())
 		return ERR_UNAVAILABLE;
 
-	if (get_script_instance()->has_method("parse_text")) {
-		Error err;
-		FileAccess *file = FileAccess::open(p_path, FileAccess::READ, &err);
-		if (err != OK) {
-			ERR_PRINT("Failed to open " + p_path);
-			return err;
-		}
-		parse_text(file->get_as_utf8_string(), r_extracted_strings);
-		return OK;
-	} else {
-		ERR_PRINT("Custom translation parser plugin's \"func parse_text(text, extracted_strings)\" is undefined.");
-		return ERR_UNAVAILABLE;
-	}
-}
-
-void EditorTranslationParserPlugin::parse_text(const String &p_text, Vector<String> *r_extracted_strings) {
-	if (!get_script_instance())
-		return;
-
-	if (get_script_instance()->has_method("parse_text")) {
+	if (get_script_instance()->has_method("parse_file")) {
 		Array extracted_strings;
-		get_script_instance()->call("parse_text", p_text, extracted_strings);
+		get_script_instance()->call("parse_file", p_path, extracted_strings);
 		for (int i = 0; i < extracted_strings.size(); i++) {
 			r_extracted_strings->append(extracted_strings[i]);
 		}
+		return OK;
 	} else {
-		ERR_PRINT("Custom translation parser plugin's \"func parse_text(text, extracted_strings)\" is undefined.");
+		ERR_PRINT("Custom translation parser plugin's \"func parse_file(path, extracted_strings)\" is undefined.");
+		return ERR_UNAVAILABLE;
 	}
 }
 
@@ -86,7 +69,7 @@ void EditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_ex
 }
 
 void EditorTranslationParserPlugin::_bind_methods() {
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::NIL, "parse_text", PropertyInfo(Variant::STRING, "text"), PropertyInfo(Variant::ARRAY, "extracted_strings")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::NIL, "parse_file", PropertyInfo(Variant::STRING, "path"), PropertyInfo(Variant::ARRAY, "extracted_strings")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::ARRAY, "get_recognized_extensions"));
 }
 

--- a/editor/editor_translation_parser.h
+++ b/editor/editor_translation_parser.h
@@ -42,7 +42,6 @@ protected:
 
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_extracted_strings);
-	virtual void parse_text(const String &p_text, Vector<String> *r_extracted_strings);
 	virtual void get_recognized_extensions(List<String> *r_extensions) const;
 };
 

--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -71,7 +71,7 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 				String extension = s->get_language()->get_extension();
 				if (EditorTranslationParser::get_singleton()->can_parse(extension)) {
 					Vector<String> temp;
-					EditorTranslationParser::get_singleton()->get_parser(extension)->parse_text(s->get_source_code(), &temp);
+					EditorTranslationParser::get_singleton()->get_parser(extension)->parse_file(s->get_path(), &temp);
 					parsed_strings.append_array(temp);
 				}
 			} else if (property_name == "filters") {

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.h
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.h
@@ -48,7 +48,6 @@ class GDScriptEditorTranslationParserPlugin : public EditorTranslationParserPlug
 
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_extracted_strings);
-	virtual void parse_text(const String &p_text, Vector<String> *r_extracted_strings);
 	virtual void get_recognized_extensions(List<String> *r_extensions) const;
 
 	GDScriptEditorTranslationParserPlugin();


### PR DESCRIPTION
Changed translation parser plugin API from parse_text() to parse_file(), as it's more flexible.

Test project:
[test_project_plugins.zip](https://github.com/godotengine/godot/files/4871000/test_project_plugins.zip)
