### PR TITLE
Add myself to CODEOWNERS for GodotSharp

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,7 @@ doc_classes/*        @godotengine/documentation
 /modules/mbedtls/    @godotengine/network
 /modules/mobile_vr/  @BastiaanOlij
 /modules/mono/       @neikeq
+/modules/mono/glue/GodotSharp @aaronfranke
 /modules/opensimplex/ @JFonS
 /modules/regex/      @LeeZH
 /modules/upnp/       @godotengine/network


### PR DESCRIPTION
I would like to be pinged for changes in this folder, and I can handle reviewing changes to files in this folder, so I've added myself to CODEOWNERS for `modules/mono/glue/GodotSharp`.

Note: There isn't much else inside of the `modules/mono/glue/GodotSharp` folder other than `GodotSharp/Core`, so this is basically the same as adding me as a codeowner for `/modules/mono/glue/GodotSharp/GodotSharp/Core`, but I figured there's not much use in including the trailing `/GodotSharp/Core` since it wouldn't really change anything.