### PR TITLE
Prevents incorrect connection attempt on port clicking in GraphEdit

### DIFF
--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -93,6 +93,8 @@ private:
 	String connecting_target_to;
 	int connecting_target_index;
 	bool just_disconnected;
+	bool connecting_valid;
+	Vector2 click_pos;
 
 	bool dragging;
 	bool just_selected;


### PR DESCRIPTION
This will prevent the new node dialog from the show if the user simply clicks on port:
![vs_bug](https://user-images.githubusercontent.com/3036176/86508722-0362eb00-bdeb-11ea-86a2-6bc6b87cc2b1.gif)
Now, this dialog will show only if the user drags connection to a small distance (same for actual connection with other port):
![vs_fix](https://user-images.githubusercontent.com/3036176/86508784-6ce2f980-bdeb-11ea-9777-1e1c23c4cc59.gif)
