### PR TITLE
Makes "Create shader node" dialog non-exclusive (visual shaders)

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2450,6 +2450,7 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	members_dialog = memnew(ConfirmationDialog);
 	members_dialog->set_title(TTR("Create Shader Node"));
+	members_dialog->set_exclusive(false);
 	members_dialog->add_child(members_vb);
 	members_dialog->get_ok()->set_text(TTR("Create"));
 	members_dialog->get_ok()->connect("pressed", callable_mp(this, &VisualShaderEditor::_member_create));


### PR DESCRIPTION
This was changed for all dialogs by @reduz in https://github.com/godotengine/godot/pull/39993, but I think the old behavior from 3.2 is better for this particular dialog. This just allows it to close up when the user clicks outside the dialog which makes it more comfortable to use.