### PR TITLE
Use the editor theme accent color for 2D selections

### DIFF
--- a/editor/icons/EditorHandle.svg
+++ b/editor/icons/EditorHandle.svg
@@ -1,1 +1,1 @@
-<svg height="10" viewBox="0 0 10 10" width="10" xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" fill-opacity=".29412" r="5"/><circle cx="5" cy="5" fill="#fff" r="4"/><circle cx="5" cy="5" fill="#ff8484" r="3"/></svg>
+<svg height="10" viewBox="0 0 10 10" width="10" xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" fill-opacity=".29412" r="5"/><circle cx="5" cy="5" fill="#fff" r="4"/></svg>

--- a/editor/icons/EditorHandleColor.svg
+++ b/editor/icons/EditorHandleColor.svg
@@ -1,0 +1,1 @@
+<svg height="10" viewBox="0 0 10 10" width="10" xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" fill="#fefefe" r="3"/></svg>

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3300,8 +3300,7 @@ void CanvasItemEditor::_draw_selection() {
 				xform.xform(rect.position + Vector2(0, rect.size.y))
 			};
 
-			Color c = Color(1, 0.6, 0.4, 0.7);
-
+			Color c = get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.8);
 			if (item_locked) {
 				c = Color(0.7, 0.7, 0.7, 0.7);
 			}
@@ -3352,12 +3351,15 @@ void CanvasItemEditor::_draw_selection() {
 					Vector2 ofs = ((endpoints[i] - endpoints[prev]).normalized() + ((endpoints[i] - endpoints[next]).normalized())).normalized();
 					ofs *= Math_SQRT2 * (select_handle->get_size().width / 2);
 
+					const Color color = get_theme_color("accent_color", "Editor");
 					select_handle->draw(ci, (endpoints[i] + ofs - (select_handle->get_size() / 2)).floor());
+					select_handle_color->draw(ci, (endpoints[i] + ofs - (select_handle_color->get_size() / 2)).floor(), color);
 
 					ofs = (endpoints[i] + endpoints[next]) / 2;
 					ofs += (endpoints[next] - endpoints[i]).tangent().normalized() * (select_handle->get_size().width / 2);
 
 					select_handle->draw(ci, (ofs - (select_handle->get_size() / 2)).floor());
+					select_handle_color->draw(ci, (ofs - (select_handle_color->get_size() / 2)).floor(), color);
 				}
 			}
 
@@ -3988,7 +3990,10 @@ void CanvasItemEditor::_notification(int p_what) {
 		pan_button->set_icon(get_theme_icon("ToolPan", "EditorIcons"));
 		ruler_button->set_icon(get_theme_icon("Ruler", "EditorIcons"));
 		pivot_button->set_icon(get_theme_icon("EditPivot", "EditorIcons"));
+		// Contains the handle's background which is never modulated.
 		select_handle = get_theme_icon("EditorHandle", "EditorIcons");
+		// Contains only the part of the handle that should be modulated with the accent color.
+		select_handle_color = get_theme_icon("EditorHandleColor", "EditorIcons");
 		anchor_handle = get_theme_icon("EditorControlAnchor", "EditorIcons");
 		lock_button->set_icon(get_theme_icon("Lock", "EditorIcons"));
 		unlock_button->set_icon(get_theme_icon("Unlock", "EditorIcons"));

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -398,6 +398,7 @@ private:
 
 	Ref<StyleBoxTexture> select_sb;
 	Ref<Texture2D> select_handle;
+	Ref<Texture2D> select_handle_color;
 	Ref<Texture2D> anchor_handle;
 
 	Ref<ShortCut> drag_pivot_shortcut;

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -430,8 +430,11 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 
 	Transform2D gt = canvas_item_editor->get_canvas_transform() * node->get_global_transform();
 
-	Ref<Texture2D> h = get_theme_icon("EditorHandle", "EditorIcons");
-	Vector2 size = h->get_size() * 0.5;
+	const Ref<Texture2D> handle = get_theme_icon("EditorHandle", "EditorIcons");
+	const Ref<Texture2D> handle_color = get_theme_icon("EditorHandleColor", "EditorIcons");
+	const Vector2 handle_size = handle->get_size() * 0.5;
+	const Vector2 handle_color_size = handle_color->get_size() * 0.5;
+	const Color accent_color = get_theme_color("accent_color", "Editor");
 
 	handles.clear();
 
@@ -446,8 +449,10 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 			handles.write[0] = Point2(radius, height);
 			handles.write[1] = Point2(0, height + radius);
 
-			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
-			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);
+			p_overlay->draw_texture(handle, gt.xform(handles[0]) - handle_size);
+			p_overlay->draw_texture(handle_color, gt.xform(handles[0]) - handle_color_size, accent_color);
+			p_overlay->draw_texture(handle, gt.xform(handles[1]) - handle_size);
+			p_overlay->draw_texture(handle_color, gt.xform(handles[1]) - handle_color_size, accent_color);
 
 		} break;
 
@@ -457,7 +462,8 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 			handles.resize(1);
 			handles.write[0] = Point2(shape->get_radius(), 0);
 
-			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
+			p_overlay->draw_texture(handle, gt.xform(handles[0]) - handle_size);
+			p_overlay->draw_texture(handle_color, gt.xform(handles[0]) - handle_size, accent_color);
 
 		} break;
 
@@ -474,8 +480,10 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 			handles.write[0] = shape->get_normal() * shape->get_distance();
 			handles.write[1] = shape->get_normal() * (shape->get_distance() + 30.0);
 
-			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
-			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);
+			p_overlay->draw_texture(handle, gt.xform(handles[0]) - handle_size);
+			p_overlay->draw_texture(handle_color, gt.xform(handles[0]) - handle_color_size, accent_color);
+			p_overlay->draw_texture(handle, gt.xform(handles[1]) - handle_size);
+			p_overlay->draw_texture(handle_color, gt.xform(handles[1]) - handle_color_size, accent_color);
 
 		} break;
 
@@ -485,7 +493,8 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 			handles.resize(1);
 			handles.write[0] = Point2(0, shape->get_length());
 
-			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
+			p_overlay->draw_texture(handle, gt.xform(handles[0]) - handle_size);
+			p_overlay->draw_texture(handle_color, gt.xform(handles[0]) - handle_color_size, accent_color);
 
 		} break;
 
@@ -498,9 +507,12 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 			handles.write[1] = Point2(0, ext.y);
 			handles.write[2] = Point2(ext.x, ext.y);
 
-			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
-			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);
-			p_overlay->draw_texture(h, gt.xform(handles[2]) - size);
+			p_overlay->draw_texture(handle, gt.xform(handles[0]) - handle_size);
+			p_overlay->draw_texture(handle_color, gt.xform(handles[0]) - handle_color_size, accent_color);
+			p_overlay->draw_texture(handle, gt.xform(handles[1]) - handle_size);
+			p_overlay->draw_texture(handle_color, gt.xform(handles[1]) - handle_color_size, accent_color);
+			p_overlay->draw_texture(handle, gt.xform(handles[2]) - handle_size);
+			p_overlay->draw_texture(handle_color, gt.xform(handles[2]) - handle_color_size, accent_color);
 
 		} break;
 
@@ -511,8 +523,10 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 			handles.write[0] = shape->get_a();
 			handles.write[1] = shape->get_b();
 
-			p_overlay->draw_texture(h, gt.xform(handles[0]) - size);
-			p_overlay->draw_texture(h, gt.xform(handles[1]) - size);
+			p_overlay->draw_texture(handle, gt.xform(handles[0]) - handle_size);
+			p_overlay->draw_texture(handle_color, gt.xform(handles[0]) - handle_color_size, accent_color);
+			p_overlay->draw_texture(handle, gt.xform(handles[1]) - handle_size);
+			p_overlay->draw_texture(handle_color, gt.xform(handles[1]) - handle_color_size, accent_color);
 
 		} break;
 	}

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -146,7 +146,8 @@ void TextureRegionEditor::_region_draw() {
 		}
 	}
 
-	Ref<Texture2D> select_handle = get_theme_icon("EditorHandle", "EditorIcons");
+	const Ref<Texture2D> select_handle = get_theme_icon("EditorHandle", "EditorIcons");
+	const Ref<Texture2D> select_handle_color = get_theme_icon("EditorHandleColor", "EditorIcons");
 
 	Rect2 scroll_rect(Point2(), base_tex->get_size());
 
@@ -162,7 +163,8 @@ void TextureRegionEditor::_region_draw() {
 		mtx.basis_xform(raw_endpoints[2]),
 		mtx.basis_xform(raw_endpoints[3])
 	};
-	Color color = get_theme_color("mono_color", "Editor");
+	const Color color = get_theme_color("mono_color", "Editor");
+	const Color accent_color = get_theme_color("accent_color", "Editor");
 	for (int i = 0; i < 4; i++) {
 		int prev = (i + 3) % 4;
 		int next = (i + 1) % 4;
@@ -174,6 +176,10 @@ void TextureRegionEditor::_region_draw() {
 
 		if (snap_mode != SNAP_AUTOSLICE) {
 			edit_draw->draw_texture(select_handle, (endpoints[i] + ofs - (select_handle->get_size() / 2)).floor() - draw_ofs * draw_zoom);
+			edit_draw->draw_texture(
+					select_handle_color,
+					(endpoints[i] + ofs - (select_handle_color->get_size() / 2)).floor() - draw_ofs * draw_zoom,
+					accent_color);
 		}
 
 		ofs = (endpoints[next] - endpoints[i]) / 2;
@@ -181,6 +187,10 @@ void TextureRegionEditor::_region_draw() {
 
 		if (snap_mode != SNAP_AUTOSLICE) {
 			edit_draw->draw_texture(select_handle, (endpoints[i] + ofs - (select_handle->get_size() / 2)).floor() - draw_ofs * draw_zoom);
+			edit_draw->draw_texture(
+					select_handle_color,
+					(endpoints[i] + ofs - (select_handle_color->get_size() / 2)).floor() - draw_ofs * draw_zoom,
+					accent_color);
 		}
 
 		scroll_rect.expand_to(raw_endpoints[i]);

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -1168,10 +1168,15 @@ void TileSetEditor::_on_workspace_overlay_draw() {
 		return;
 	}
 
-	Ref<Texture2D> handle = get_theme_icon("EditorHandle", "EditorIcons");
+	const Ref<Texture2D> handle = get_theme_icon("EditorHandle", "EditorIcons");
+	const Ref<Texture2D> handle_color = get_theme_icon("EditorHandleColor", "EditorIcons");
 	if (draw_handles) {
 		for (int i = 0; i < current_shape.size(); i++) {
 			workspace_overlay->draw_texture(handle, current_shape[i] * workspace->get_scale().x - handle->get_size() * 0.5);
+			workspace_overlay->draw_texture(
+					handle_color,
+					current_shape[i] * workspace->get_scale().x - handle_color->get_size() * 0.5,
+					get_theme_color("accent_color", "Editor"));
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #40106.

This improves the visual consistency of selections in the editor.

## Preview (with default editor theme)

![image](https://user-images.githubusercontent.com/180032/86513425-64e68200-be0a-11ea-929c-c303f079be88.png)