### PR TITLE
Fix crash on project files import in EditorFileSystem

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1107,7 +1107,7 @@ void EditorFileSystem::_notification(int p_what) {
 						_queue_update_script_classes();
 						first_scan = false;
 					}
-				} else if (!scanning) {
+				} else if (!scanning && thread) {
 					set_process(false);
 
 					if (filesystem) {


### PR DESCRIPTION
Fixes #40017

This PR just adds a check during `NOTIFICATION_PROCESS` in `EditorFileSystem` in order to account for re-entrant calls that can occur during project initialization.

This change is in line with `NOTIFICATION_EXIT_TREE` which has a similar check on the thread's validity.

See #40017 for more details. It seems the problem is somewhat related to changes made in #36070 but I started to experience the crashes only recently, so I'm not sure what changes are causing them.
CC @RandomShaper