### PR TITLE
Visible CollisionShape3D faces and random Color

### DIFF
--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -3255,6 +3255,17 @@ CollisionShape3DGizmoPlugin::CollisionShape3DGizmoPlugin() {
 	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);
 	create_material("shape_material_disabled", gizmo_color_disabled);
 	create_handle_material("handles");
+
+	const Color shape_face_color = EDITOR_DEF_RST("editors/3d_gizmos/collision_shape/face", Color(0, 0, 1.0));
+	Ref<StandardMaterial3D> shape_face_color_mat = memnew(StandardMaterial3D);
+	shape_face_color_mat->set_albedo(Color(shape_face_color, 0.66));
+	shape_face_color_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+	shape_face_color_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	add_material("face_material", shape_face_color_mat);
+
+	Ref<StandardMaterial3D> shape_face_color_mat_disabled = shape_face_color_mat->duplicate();
+	shape_face_color_mat_disabled->set_albedo(Color(shape_face_color, 0.20));
+	add_material("face_material_disabled", shape_face_color_mat_disabled);
 }
 
 bool CollisionShape3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
@@ -3613,6 +3624,21 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Vector<Vector3> handles;
 		handles.push_back(Vector3(r, 0, 0));
 		p_gizmo->add_handles(handles, handles_material);
+
+		// Visible Faces
+		if (EDITOR_DEF_RST("editors/3d_gizmos/collision_shape/show_faces", true)) {
+			Ref<ArrayMesh> m = sp->get_debug_arraymesh_faces();
+			if (EDITOR_DEF_RST("editors/3d_gizmos/collision_shape/random_color", true)) {
+				Ref<StandardMaterial3D> shape_face_color_mat = memnew(StandardMaterial3D);
+				const Color shape_face_color = Color().from_hsv(hash_one_uint64(sp->get_instance_id()) / (float)UINT32_MAX, 1.0, 1.0, 1.0);
+				shape_face_color_mat->set_albedo(Color(shape_face_color, cs->is_disabled() ? 0.25 : 0.66));
+				shape_face_color_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+				shape_face_color_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+				m->surface_set_material(0, shape_face_color_mat);
+			} else
+				m->surface_set_material(0, get_material(cs->is_disabled() ? "face_material_disabled" : "face_material"));
+			p_gizmo->add_mesh(m);
+		}
 	}
 
 	if (Object::cast_to<BoxShape3D>(*s)) {
@@ -3640,6 +3666,21 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		p_gizmo->add_lines(lines, material);
 		p_gizmo->add_collision_segments(lines);
 		p_gizmo->add_handles(handles, handles_material);
+
+		// Visible Faces
+		if (EDITOR_DEF_RST("editors/3d_gizmos/collision_shape/show_faces", true)) {
+			Ref<ArrayMesh> m = bs->get_debug_arraymesh_faces();
+			if (EDITOR_DEF_RST("editors/3d_gizmos/collision_shape/random_color", true)) {
+				Ref<StandardMaterial3D> shape_face_color_mat = memnew(StandardMaterial3D);
+				const Color shape_face_color = Color().from_hsv(hash_one_uint64(bs->get_instance_id()) / (float)UINT32_MAX, 1.0, 1.0, 1.0);
+				shape_face_color_mat->set_albedo(Color(shape_face_color, cs->is_disabled() ? 0.25 : 0.66));
+				shape_face_color_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+				shape_face_color_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+				m->surface_set_material(0, shape_face_color_mat);
+			} else
+				m->surface_set_material(0, get_material(cs->is_disabled() ? "face_material_disabled" : "face_material"));
+			p_gizmo->add_mesh(m);
+		}
 	}
 
 	if (Object::cast_to<CapsuleShape3D>(*s)) {
@@ -3710,6 +3751,22 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		handles.push_back(Vector3(cs2->get_radius(), 0, 0));
 		handles.push_back(Vector3(0, cs2->get_height() * 0.5 + cs2->get_radius(), 0));
 		p_gizmo->add_handles(handles, handles_material);
+
+		// Visible Faces
+		// Mesh
+		if (EDITOR_DEF_RST("editors/3d_gizmos/collision_shape/show_faces", true)) {
+			Ref<ArrayMesh> m = cs2->get_debug_arraymesh_faces();
+			if (EDITOR_DEF_RST("editors/3d_gizmos/collision_shape/random_color", true)) {
+				Ref<StandardMaterial3D> shape_face_color_mat = memnew(StandardMaterial3D);
+				const Color shape_face_color = Color().from_hsv(hash_one_uint64(cs2->get_instance_id()) / (float)UINT32_MAX, 1.0, 1.0, 1.0);
+				shape_face_color_mat->set_albedo(Color(shape_face_color, cs->is_disabled() ? 0.25 : 0.66));
+				shape_face_color_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+				shape_face_color_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+				m->surface_set_material(0, shape_face_color_mat);
+			} else
+				m->surface_set_material(0, get_material(cs->is_disabled() ? "face_material_disabled" : "face_material"));
+			p_gizmo->add_mesh(m);
+		}
 	}
 
 	if (Object::cast_to<CylinderShape3D>(*s)) {
@@ -3766,6 +3823,21 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		handles.push_back(Vector3(cs2->get_radius(), 0, 0));
 		handles.push_back(Vector3(0, cs2->get_height() * 0.5, 0));
 		p_gizmo->add_handles(handles, handles_material);
+
+		// Visible Faces
+		if (EDITOR_DEF_RST("editors/3d_gizmos/collision_shape/show_faces", true)) {
+			Ref<ArrayMesh> m = cs2->get_debug_arraymesh_faces();
+			if (EDITOR_DEF_RST("editors/3d_gizmos/collision_shape/random_color", true)) {
+				Ref<StandardMaterial3D> shape_face_color_mat = memnew(StandardMaterial3D);
+				const Color shape_face_color = Color().from_hsv(hash_one_uint64(cs2->get_instance_id()) / (float)UINT32_MAX, 1.0, 1.0, 1.0);
+				shape_face_color_mat->set_albedo(Color(shape_face_color, cs->is_disabled() ? 0.25 : 0.66));
+				shape_face_color_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+				shape_face_color_mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+				m->surface_set_material(0, shape_face_color_mat);
+			} else
+				m->surface_set_material(0, get_material(cs->is_disabled() ? "face_material_disabled" : "face_material"));
+			p_gizmo->add_mesh(m);
+		}
 	}
 
 	if (Object::cast_to<WorldMarginShape3D>(*s)) {

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -3256,7 +3256,7 @@ CollisionShape3DGizmoPlugin::CollisionShape3DGizmoPlugin() {
 	create_material("shape_material_disabled", gizmo_color_disabled);
 	create_handle_material("handles");
 
-	const Color shape_face_color = EDITOR_DEF_RST("editors/3d_gizmos/collision_shape/face", Color(0, 0, 1.0));
+	const Color shape_face_color = EDITOR_DEF_RST("editors/3d_gizmos/gizmo_colors/shape_face", Color(0, 0, 1.0));
 	Ref<StandardMaterial3D> shape_face_color_mat = memnew(StandardMaterial3D);
 	shape_face_color_mat->set_albedo(Color(shape_face_color, 0.66));
 	shape_face_color_mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);

--- a/scene/3d/collision_shape_3d.h
+++ b/scene/3d/collision_shape_3d.h
@@ -43,6 +43,7 @@ class CollisionShape3D : public Node3D {
 	uint32_t owner_id;
 	CollisionObject3D *parent;
 
+	Node *debug_shape_faces;
 	Node *debug_shape;
 	bool debug_shape_dirty;
 

--- a/scene/resources/box_shape_3d.cpp
+++ b/scene/resources/box_shape_3d.cpp
@@ -29,7 +29,17 @@
 /*************************************************************************/
 
 #include "box_shape_3d.h"
+#include "primitive_meshes.h"
 #include "servers/physics_server_3d.h"
+
+Ref<ArrayMesh> BoxShape3D::get_debug_arraymesh_faces() const {
+	CubeMesh mesh;
+	mesh.set_size(extents * 2);
+	const Array a = mesh.surface_get_arrays(0);
+	Ref<ArrayMesh> m = memnew(ArrayMesh);
+	m->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, a);
+	return m;
+}
 
 Vector<Vector3> BoxShape3D::get_debug_mesh_lines() {
 	Vector<Vector3> lines;

--- a/scene/resources/box_shape_3d.h
+++ b/scene/resources/box_shape_3d.h
@@ -46,6 +46,7 @@ public:
 	void set_extents(const Vector3 &p_extents);
 	Vector3 get_extents() const;
 
+	Ref<ArrayMesh> get_debug_arraymesh_faces() const;
 	virtual Vector<Vector3> get_debug_mesh_lines();
 	virtual real_t get_enclosing_radius() const;
 

--- a/scene/resources/capsule_shape_3d.cpp
+++ b/scene/resources/capsule_shape_3d.cpp
@@ -29,7 +29,18 @@
 /*************************************************************************/
 
 #include "capsule_shape_3d.h"
+#include "primitive_meshes.h"
 #include "servers/physics_server_3d.h"
+
+Ref<ArrayMesh> CapsuleShape3D::get_debug_arraymesh_faces() const {
+	CapsuleMesh sm;
+	sm.set_radius(radius);
+	sm.set_mid_height(height);
+	Array a = sm.surface_get_arrays(0);
+	Ref<ArrayMesh> m = memnew(ArrayMesh);
+	m->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, a);
+	return m;
+}
 
 Vector<Vector3> CapsuleShape3D::get_debug_mesh_lines() {
 	float radius = get_radius();

--- a/scene/resources/capsule_shape_3d.h
+++ b/scene/resources/capsule_shape_3d.h
@@ -49,6 +49,7 @@ public:
 	void set_height(float p_height);
 	float get_height() const;
 
+	Ref<ArrayMesh> get_debug_arraymesh_faces() const;
 	virtual Vector<Vector3> get_debug_mesh_lines();
 	virtual real_t get_enclosing_radius() const;
 

--- a/scene/resources/cylinder_shape_3d.cpp
+++ b/scene/resources/cylinder_shape_3d.cpp
@@ -29,7 +29,19 @@
 /*************************************************************************/
 
 #include "cylinder_shape_3d.h"
+#include "primitive_meshes.h"
 #include "servers/physics_server_3d.h"
+
+Ref<ArrayMesh> CylinderShape3D::get_debug_arraymesh_faces() const {
+	CylinderMesh sm;
+	sm.set_bottom_radius(radius);
+	sm.set_top_radius(radius);
+	sm.set_height(height);
+	Array a = sm.surface_get_arrays(0);
+	Ref<ArrayMesh> m = memnew(ArrayMesh);
+	m->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, a);
+	return m;
+}
 
 Vector<Vector3> CylinderShape3D::get_debug_mesh_lines() {
 	float radius = get_radius();

--- a/scene/resources/cylinder_shape_3d.h
+++ b/scene/resources/cylinder_shape_3d.h
@@ -48,6 +48,7 @@ public:
 	void set_height(float p_height);
 	float get_height() const;
 
+	Ref<ArrayMesh> get_debug_arraymesh_faces() const;
 	virtual Vector<Vector3> get_debug_mesh_lines();
 	virtual real_t get_enclosing_radius() const;
 

--- a/scene/resources/sphere_shape_3d.cpp
+++ b/scene/resources/sphere_shape_3d.cpp
@@ -29,7 +29,18 @@
 /*************************************************************************/
 
 #include "sphere_shape_3d.h"
+#include "primitive_meshes.h"
 #include "servers/physics_server_3d.h"
+
+Ref<ArrayMesh> SphereShape3D::get_debug_arraymesh_faces() const {
+	SphereMesh sm;
+	sm.set_radius(radius);
+	sm.set_height(radius * 2);
+	Array a = sm.surface_get_arrays(0);
+	Ref<ArrayMesh> m = memnew(ArrayMesh);
+	m->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, a);
+	return m;
+}
 
 Vector<Vector3> SphereShape3D::get_debug_mesh_lines() {
 	float r = get_radius();

--- a/scene/resources/sphere_shape_3d.h
+++ b/scene/resources/sphere_shape_3d.h
@@ -46,6 +46,7 @@ public:
 	void set_radius(float p_radius);
 	float get_radius() const;
 
+	Ref<ArrayMesh> get_debug_arraymesh_faces() const;
 	virtual Vector<Vector3> get_debug_mesh_lines();
 	virtual real_t get_enclosing_radius() const;
 


### PR DESCRIPTION
edit : After lots of change https://github.com/godotengine/godot/pull/40123#issuecomment-655251208 better show the state of the PR

https://github.com/godotengine/godot-proposals/issues/906
It add a default color face to `BoxShape3D`, `CapsuleShape3D`, `CylinderShape3D` and `SphereShape3D` when used with `CollisionShape3D`. 
Each instance can have custom color and texture to differentiate them to help gamedesigning bigger scene.

![rLMxdbfhPR](https://user-images.githubusercontent.com/471393/86520764-5919b080-be48-11ea-8d0d-4765a81c3c98.gif)

I still have thing TODO but not sure what fit the best for godot

- [x] Default Color in EditorSettings
- [x] Random Color
- ~~Miss other shapes~~
- ~~Random Color EditorSettings~~
