### PR TITLE
Fix GraphEdit reconnecting to disconnected port

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -471,7 +471,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 		connecting_to = mm->get_position();
 		connecting_target = false;
 		top_layer->update();
-		connecting_valid = click_pos.distance_to(connecting_to) > 20.0 * zoom;
+		connecting_valid = just_disconnected || click_pos.distance_to(connecting_to) > 20.0 * zoom;
 
 		if (connecting_valid) {
 			Ref<Texture2D> port = get_theme_icon("port", "GraphNode");


### PR DESCRIPTION
Seems like I did a small regression in https://github.com/godotengine/godot/pull/40112 which applies the same behavior for disconnection which is not good for usability.

![vs_fix2](https://user-images.githubusercontent.com/3036176/86527176-16d28c80-bea5-11ea-99fa-dc3d2a0b7f1d.gif)
