### PR TITLE
Fix string test code for MinGW

### DIFF
--- a/main/tests/test_string.cpp
+++ b/main/tests/test_string.cpp
@@ -370,8 +370,11 @@ bool test_22() {
 	static const int num[4] = { 1237461283, -22, 0, -1123412 };
 
 	for (int i = 0; i < 4; i++) {
+#ifdef __MINGW32__ // MinGW can't handle normal format specifiers for some reason. So we need special code just for MinGW.
+		OS::get_singleton()->print("\tString: \"%s\" as Int is %I64i\n", nums[i], (long long)(String(nums[i]).to_int()));
+#else
 		OS::get_singleton()->print("\tString: \"%s\" as Int is %lli\n", nums[i], (long long)(String(nums[i]).to_int()));
-
+#endif
 		if (String(nums[i]).to_int() != num[i]) {
 			return false;
 		}


### PR DESCRIPTION
I haven't actually tested this on MinGW. This implementation was based on https://books.google.com/books?id=4VOKcEAPPO0C&pg=PA126&lpg=PA126&dq=mingw+format+specifier+lli&ved=2ahUKEwiatK6u1LXqAhXDWc0KHSnmBwoQ6AEwAnoECAoQAQ#v=onepage&q=mingw%20format%20specifier%20lli&f=false