### PR TITLE
Make scrolling to a tree item optionally center on that item

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -240,6 +240,7 @@
 		<method name="scroll_to_item">
 			<return type="void" />
 			<argument index="0" name="item" type="TreeItem" />
+			<argument index="1" name="center_on_item" type="bool" default="false" />
 			<description>
 				Causes the [Tree] to jump to the specified [TreeItem].
 			</description>

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -446,14 +446,14 @@ void CreateDialog::_notification(int p_what) {
 	}
 }
 
-void CreateDialog::select_type(const String &p_type) {
+void CreateDialog::select_type(const String &p_type, bool p_center_on_item) {
 	if (!search_options_types.has(p_type)) {
 		return;
 	}
 
 	TreeItem *to_select = search_options_types[p_type];
 	to_select->select(0);
-	search_options->scroll_to_item(to_select);
+	search_options->scroll_to_item(to_select, p_center_on_item);
 
 	if (EditorHelp::get_doc_data()->class_list.has(p_type) && !DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description).is_empty()) {
 		// Display both class name and description, since the help bit may be displayed
@@ -520,7 +520,7 @@ Variant CreateDialog::instance_selected() {
 
 void CreateDialog::_item_selected() {
 	String name = get_selected_type();
-	select_type(name);
+	select_type(name, false);
 }
 
 void CreateDialog::_hide_requested() {

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -79,7 +79,7 @@ class CreateDialog : public ConfirmationDialog {
 
 	void _sbox_input(const Ref<InputEvent> &p_ie);
 	void _text_changed(const String &p_newtext);
-	void select_type(const String &p_type);
+	void select_type(const String &p_type, bool p_center_on_item = true);
 	void _item_selected();
 	void _hide_requested();
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -682,7 +682,7 @@ public:
 	TreeItem *get_item_with_text(const String &p_find) const;
 
 	Point2 get_scroll() const;
-	void scroll_to_item(TreeItem *p_item);
+	void scroll_to_item(TreeItem *p_item, bool p_center_on_item = false);
 	void set_h_scroll_enabled(bool p_enable);
 	bool is_h_scroll_enabled() const;
 	void set_v_scroll_enabled(bool p_enable);


### PR DESCRIPTION
In search dialogs, scrolling to a selected item will make that item visible, but it can be anywhere in the tree rect. If you are typing fast, the selected item can jump around a lot which can be confusing. This commit makes scrolling to an item always center on that item (unless there are no scrollbars of course). An added benefit is that you can always see search results below and above the item.
![scroll](https://user-images.githubusercontent.com/25907608/86540406-69439580-bf05-11ea-9f11-24adbe9aebc4.png)
