### PR TITLE
Fix Directory Open Check

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1619,12 +1619,17 @@ Error _Directory::open(const String &p_path) {
 		memdelete(d);
 	}
 	d = alt;
+	dir_open = true;
 
 	return OK;
 }
 
+bool _Directory::is_open() const {
+	return d && dir_open;
+}
+
 Error _Directory::list_dir_begin(bool p_skip_navigational, bool p_skip_hidden) {
-	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 
 	_list_skip_navigational = p_skip_navigational;
 	_list_skip_hidden = p_skip_hidden;
@@ -1633,7 +1638,7 @@ Error _Directory::list_dir_begin(bool p_skip_navigational, bool p_skip_hidden) {
 }
 
 String _Directory::get_next() {
-	ERR_FAIL_COND_V_MSG(!d, "", "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), "", "Directory must be opened before use.");
 
 	String next = d->get_next();
 	while (next != "" && ((_list_skip_navigational && (next == "." || next == "..")) || (_list_skip_hidden && d->current_is_hidden()))) {
@@ -1643,42 +1648,42 @@ String _Directory::get_next() {
 }
 
 bool _Directory::current_is_dir() const {
-	ERR_FAIL_COND_V_MSG(!d, false, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), false, "Directory must be opened before use.");
 	return d->current_is_dir();
 }
 
 void _Directory::list_dir_end() {
-	ERR_FAIL_COND_MSG(!d, "Directory must be opened before use.");
+	ERR_FAIL_COND_MSG(!is_open(), "Directory must be opened before use.");
 	d->list_dir_end();
 }
 
 int _Directory::get_drive_count() {
-	ERR_FAIL_COND_V_MSG(!d, 0, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), 0, "Directory must be opened before use.");
 	return d->get_drive_count();
 }
 
 String _Directory::get_drive(int p_drive) {
-	ERR_FAIL_COND_V_MSG(!d, "", "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), "", "Directory must be opened before use.");
 	return d->get_drive(p_drive);
 }
 
 int _Directory::get_current_drive() {
-	ERR_FAIL_COND_V_MSG(!d, 0, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), 0, "Directory must be opened before use.");
 	return d->get_current_drive();
 }
 
 Error _Directory::change_dir(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	return d->change_dir(p_dir);
 }
 
 String _Directory::get_current_dir() {
-	ERR_FAIL_COND_V_MSG(!d, "", "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), "", "Directory must be opened before use.");
 	return d->get_current_dir();
 }
 
 Error _Directory::make_dir(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_dir.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		Error err = d->make_dir(p_dir);
@@ -1689,7 +1694,7 @@ Error _Directory::make_dir(String p_dir) {
 }
 
 Error _Directory::make_dir_recursive(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_dir.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		Error err = d->make_dir_recursive(p_dir);
@@ -1700,7 +1705,7 @@ Error _Directory::make_dir_recursive(String p_dir) {
 }
 
 bool _Directory::file_exists(String p_file) {
-	ERR_FAIL_COND_V_MSG(!d, false, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), false, "Directory must be opened before use.");
 
 	if (!p_file.is_rel_path()) {
 		return FileAccess::exists(p_file);
@@ -1710,7 +1715,7 @@ bool _Directory::file_exists(String p_file) {
 }
 
 bool _Directory::dir_exists(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!d, false, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), false, "Directory must be opened before use.");
 	if (!p_dir.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		bool exists = d->dir_exists(p_dir);
@@ -1723,17 +1728,17 @@ bool _Directory::dir_exists(String p_dir) {
 }
 
 int _Directory::get_space_left() {
-	ERR_FAIL_COND_V_MSG(!d, 0, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), 0, "Directory must be opened before use.");
 	return d->get_space_left() / 1024 * 1024; //return value in megabytes, given binding is int
 }
 
 Error _Directory::copy(String p_from, String p_to) {
-	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	return d->copy(p_from, p_to);
 }
 
 Error _Directory::rename(String p_from, String p_to) {
-	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_from.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_from);
 		Error err = d->rename(p_from, p_to);
@@ -1745,7 +1750,7 @@ Error _Directory::rename(String p_from, String p_to) {
 }
 
 Error _Directory::remove(String p_name) {
-	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_name.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_name);
 		Error err = d->remove(p_name);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -457,12 +457,15 @@ VARIANT_ENUM_CAST(_File::CompressionMode);
 class _Directory : public Reference {
 	GDCLASS(_Directory, Reference);
 	DirAccess *d;
+	bool dir_open = false;
 
 protected:
 	static void _bind_methods();
 
 public:
 	Error open(const String &p_path);
+
+	bool is_open() const;
 
 	Error list_dir_begin(bool p_skip_navigational = false, bool p_skip_hidden = false); // This starts dir listing.
 	String get_next();

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -67,7 +67,11 @@ Error DirAccessWindows::list_dir_begin() {
 	list_dir_end();
 	p->h = FindFirstFileExW((current_dir + "\\*").c_str(), FindExInfoStandard, &p->fu, FindExSearchNameMatch, nullptr, 0);
 
-	return (p->h == INVALID_HANDLE_VALUE) ? ERR_CANT_OPEN : OK;
+	if (p->h == INVALID_HANDLE_VALUE) {
+		return ERR_CANT_OPEN;
+	}
+
+	return OK;
 }
 
 String DirAccessWindows::get_next() {


### PR DESCRIPTION
Fixes #40146 

All the error checks were simply checking if the `DirAccess* d` was defined, when in reality it is always defined, even if a file is not open.
