### PR TITLE
Enable addition of points directly in Polygon2D UV Editor

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -50,6 +50,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 		UV_MODE_CREATE_INTERNAL,
 		UV_MODE_REMOVE_INTERNAL,
 		UV_MODE_EDIT_POINT,
+		UV_MODE_REMOVE_POINT,
 		UV_MODE_MOVE,
 		UV_MODE_ROTATE,
 		UV_MODE_SCALE,
@@ -108,6 +109,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	int point_drag_index;
 	bool uv_drag;
 	bool uv_create;
+	bool uv_add;
 	Vector<int> polygon_create;
 	UVMode uv_move_current;
 	Vector2 uv_drag_from;


### PR DESCRIPTION
Avoids the need to switch between canvas editor and UV editor whenever a polygon and its associated UV coordinates need to be modified by adding points. Also avoids the need to delete all internal vertices every time a new point needs to be added. The behavior of this new function aims to be identical to the add points option found in the canvas editor.

![addPoints](https://user-images.githubusercontent.com/22248849/86568345-4bc30a00-bf9f-11ea-8ca7-ca024e42e356.gif)

I understand that there is discussion about possibly refactoring the Polygon2D UV editor sometime in the future, so if this change may conflict or be superseded by those other changes, please feel free to close this PR. On the other hand, if this seems like a worthwhile addition, I could also make another PR for deleting points.

Closes #24021