### PR TITLE
Include gdscript warning name in the warning message.

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2001,114 +2001,116 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 String GDScriptWarning::get_message() const {
 #define CHECK_SYMBOLS(m_amount) ERR_FAIL_COND_V(symbols.size() < m_amount, String());
 
+	String msg;
+
 	switch (code) {
 		case UNASSIGNED_VARIABLE_OP_ASSIGN: {
 			CHECK_SYMBOLS(1);
-			return "Using assignment with operation but the variable '" + symbols[0] + "' was not previously assigned a value.";
+			msg = "Using assignment with operation but the variable '" + symbols[0] + "' was not previously assigned a value.";
 		} break;
 		case UNASSIGNED_VARIABLE: {
 			CHECK_SYMBOLS(1);
-			return "The variable '" + symbols[0] + "' was used but never assigned a value.";
+			msg = "The variable '" + symbols[0] + "' was used but never assigned a value.";
 		} break;
 		case UNUSED_VARIABLE: {
 			CHECK_SYMBOLS(1);
-			return "The local variable '" + symbols[0] + "' is declared but never used in the block. If this is intended, prefix it with an underscore: '_" + symbols[0] + "'";
+			msg = "The local variable '" + symbols[0] + "' is declared but never used in the block. If this is intended, prefix it with an underscore: '_" + symbols[0] + "'";
 		} break;
 		case SHADOWED_VARIABLE: {
 			CHECK_SYMBOLS(2);
-			return "The local variable '" + symbols[0] + "' is shadowing an already-defined variable at line " + symbols[1] + ".";
+			msg = "The local variable '" + symbols[0] + "' is shadowing an already-defined variable at line " + symbols[1] + ".";
 		} break;
 		case UNUSED_CLASS_VARIABLE: {
 			CHECK_SYMBOLS(1);
-			return "The class variable '" + symbols[0] + "' is declared but never used in the script.";
+			msg = "The class variable '" + symbols[0] + "' is declared but never used in the script.";
 		} break;
 		case UNUSED_ARGUMENT: {
 			CHECK_SYMBOLS(2);
-			return "The argument '" + symbols[1] + "' is never used in the function '" + symbols[0] + "'. If this is intended, prefix it with an underscore: '_" + symbols[1] + "'";
+			msg = "The argument '" + symbols[1] + "' is never used in the function '" + symbols[0] + "'. If this is intended, prefix it with an underscore: '_" + symbols[1] + "'";
 		} break;
 		case UNREACHABLE_CODE: {
 			CHECK_SYMBOLS(1);
-			return "Unreachable code (statement after return) in function '" + symbols[0] + "()'.";
+			msg = "Unreachable code (statement after return) in function '" + symbols[0] + "()'.";
 		} break;
 		case STANDALONE_EXPRESSION: {
-			return "Standalone expression (the line has no effect).";
+			msg = "Standalone expression (the line has no effect).";
 		} break;
 		case VOID_ASSIGNMENT: {
 			CHECK_SYMBOLS(1);
-			return "Assignment operation, but the function '" + symbols[0] + "()' returns void.";
+			msg = "Assignment operation, but the function '" + symbols[0] + "()' returns void.";
 		} break;
 		case NARROWING_CONVERSION: {
-			return "Narrowing conversion (float is converted to int and loses precision).";
+			msg = "Narrowing conversion (float is converted to int and loses precision).";
 		} break;
 		case FUNCTION_MAY_YIELD: {
 			CHECK_SYMBOLS(1);
-			return "Assigned variable is typed but the function '" + symbols[0] + "()' may yield and return a GDScriptFunctionState instead.";
+			msg = "Assigned variable is typed but the function '" + symbols[0] + "()' may yield and return a GDScriptFunctionState instead.";
 		} break;
 		case VARIABLE_CONFLICTS_FUNCTION: {
 			CHECK_SYMBOLS(1);
-			return "Variable declaration of '" + symbols[0] + "' conflicts with a function of the same name.";
+			msg = "Variable declaration of '" + symbols[0] + "' conflicts with a function of the same name.";
 		} break;
 		case FUNCTION_CONFLICTS_VARIABLE: {
 			CHECK_SYMBOLS(1);
-			return "Function declaration of '" + symbols[0] + "()' conflicts with a variable of the same name.";
+			msg = "Function declaration of '" + symbols[0] + "()' conflicts with a variable of the same name.";
 		} break;
 		case FUNCTION_CONFLICTS_CONSTANT: {
 			CHECK_SYMBOLS(1);
-			return "Function declaration of '" + symbols[0] + "()' conflicts with a constant of the same name.";
+			msg = "Function declaration of '" + symbols[0] + "()' conflicts with a constant of the same name.";
 		} break;
 		case INCOMPATIBLE_TERNARY: {
-			return "Values of the ternary conditional are not mutually compatible.";
+			msg = "Values of the ternary conditional are not mutually compatible.";
 		} break;
 		case UNUSED_SIGNAL: {
 			CHECK_SYMBOLS(1);
-			return "The signal '" + symbols[0] + "' is declared but never emitted.";
+			msg = "The signal '" + symbols[0] + "' is declared but never emitted.";
 		} break;
 		case RETURN_VALUE_DISCARDED: {
 			CHECK_SYMBOLS(1);
-			return "The function '" + symbols[0] + "()' returns a value, but this value is never used.";
+			msg = "The function '" + symbols[0] + "()' returns a value, but this value is never used.";
 		} break;
 		case PROPERTY_USED_AS_FUNCTION: {
 			CHECK_SYMBOLS(2);
-			return "The method '" + symbols[0] + "()' was not found in base '" + symbols[1] + "' but there's a property with the same name. Did you mean to access it?";
+			msg = "The method '" + symbols[0] + "()' was not found in base '" + symbols[1] + "' but there's a property with the same name. Did you mean to access it?";
 		} break;
 		case CONSTANT_USED_AS_FUNCTION: {
 			CHECK_SYMBOLS(2);
-			return "The method '" + symbols[0] + "()' was not found in base '" + symbols[1] + "' but there's a constant with the same name. Did you mean to access it?";
+			msg = "The method '" + symbols[0] + "()' was not found in base '" + symbols[1] + "' but there's a constant with the same name. Did you mean to access it?";
 		} break;
 		case FUNCTION_USED_AS_PROPERTY: {
 			CHECK_SYMBOLS(2);
-			return "The property '" + symbols[0] + "' was not found in base '" + symbols[1] + "' but there's a method with the same name. Did you mean to call it?";
+			msg = "The property '" + symbols[0] + "' was not found in base '" + symbols[1] + "' but there's a method with the same name. Did you mean to call it?";
 		} break;
 		case INTEGER_DIVISION: {
-			return "Integer division, decimal part will be discarded.";
+			msg = "Integer division, decimal part will be discarded.";
 		} break;
 		case UNSAFE_PROPERTY_ACCESS: {
 			CHECK_SYMBOLS(2);
-			return "The property '" + symbols[0] + "' is not present on the inferred type '" + symbols[1] + "' (but may be present on a subtype).";
+			msg = "The property '" + symbols[0] + "' is not present on the inferred type '" + symbols[1] + "' (but may be present on a subtype).";
 		} break;
 		case UNSAFE_METHOD_ACCESS: {
 			CHECK_SYMBOLS(2);
-			return "The method '" + symbols[0] + "' is not present on the inferred type '" + symbols[1] + "' (but may be present on a subtype).";
+			msg = "The method '" + symbols[0] + "' is not present on the inferred type '" + symbols[1] + "' (but may be present on a subtype).";
 		} break;
 		case UNSAFE_CAST: {
 			CHECK_SYMBOLS(1);
-			return "The value is cast to '" + symbols[0] + "' but has an unknown type.";
+			msg = "The value is cast to '" + symbols[0] + "' but has an unknown type.";
 		} break;
 		case UNSAFE_CALL_ARGUMENT: {
 			CHECK_SYMBOLS(4);
-			return "The argument '" + symbols[0] + "' of the function '" + symbols[1] + "' requires a the subtype '" + symbols[2] + "' but the supertype '" + symbols[3] + "' was provided";
+			msg = "The argument '" + symbols[0] + "' of the function '" + symbols[1] + "' requires a the subtype '" + symbols[2] + "' but the supertype '" + symbols[3] + "' was provided";
 		} break;
 		case DEPRECATED_KEYWORD: {
 			CHECK_SYMBOLS(2);
-			return "The '" + symbols[0] + "' keyword is deprecated and will be removed in a future release, please replace its uses by '" + symbols[1] + "'.";
+			msg = "The '" + symbols[0] + "' keyword is deprecated and will be removed in a future release, please replace its uses by '" + symbols[1] + "'.";
 		} break;
 		case STANDALONE_TERNARY: {
-			return "Standalone ternary conditional operator: the return value is being discarded.";
-		}
+			msg = "Standalone ternary conditional operator: the return value is being discarded.";
+		} break;
 		case WARNING_MAX:
-			break; // Can't happen, but silences warning
+			ERR_FAIL_V_MSG(String(), "Invalid GDScript warning code: " + get_name_from_code(code) + ".");
 	}
-	ERR_FAIL_V_MSG(String(), "Invalid GDScript warning code: " + get_name_from_code(code) + ".");
+	return msg + " [" + get_name() + "]";
 
 #undef CHECK_SYMBOLS
 }


### PR DESCRIPTION
I can open a proposal if desired, but this is just a pretty small 
quality-of-life thing.

Occasionally you want to ignore a warning with a `warning-ignore`
comment, and you have to go into the settings to look up what the
actual name of the warning is. This patch appends the warning name to
the end of the warning so you know what string to use to ignore it,
similar to other linters like pylint.

For example

```
"The signal 'blah' is declared but never emitted.";
```

is now

```
"The signal 'blah' is declared but never emitted. (UNUSED_SIGNAL)";
```