### PR TITLE
Clear a Bullet Area's overlappingObjects vector when removing an area from a space.

### DIFF
--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -174,6 +174,7 @@ void AreaBullet::reload_body() {
 void AreaBullet::set_space(SpaceBullet *p_space) {
 	// Clear the old space if there is one
 	if (space) {
+		overlappingObjects.clear();
 		isScratched = false;
 
 		// Remove this object form the physics world


### PR DESCRIPTION
Fixes #39765.