### PR TITLE
Improve null check in FindReplaceBar

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -108,22 +108,25 @@ void FindReplaceBar::_notification(int p_what) {
 
 void FindReplaceBar::_unhandled_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventKey> k = p_event;
-	if (k.is_valid()) {
-		if (k->is_pressed() && (text_edit->has_focus() || vbc_lineedit->is_a_parent_of(get_focus_owner()))) {
-			bool accepted = true;
+	if (!k.is_valid() || !k->is_pressed()) {
+		return;
+	}
 
-			switch (k->get_keycode()) {
-				case KEY_ESCAPE: {
-					_hide_bar();
-				} break;
-				default: {
-					accepted = false;
-				} break;
-			}
+	Control *focus_owner = get_focus_owner();
+	if (text_edit->has_focus() || (focus_owner && vbc_lineedit->is_a_parent_of(focus_owner))) {
+		bool accepted = true;
 
-			if (accepted) {
-				accept_event();
-			}
+		switch (k->get_keycode()) {
+			case KEY_ESCAPE: {
+				_hide_bar();
+			} break;
+			default: {
+				accepted = false;
+			} break;
+		}
+
+		if (accepted) {
+			accept_event();
 		}
 	}
 }


### PR DESCRIPTION
Fixes #24174. This is important for 3.2 branch. In `master` this issue is not currently reproducible in the same way.

`FindReplaceBar` doesn't properly check for null reference in the Viewport's focus owner while trying to use it. #24174 describes one way to achieve this error with ease, but that same way is no longer possible in `master` due to unrelated changes in #36244, which removed the code that was screwing the focus owner (it was `ScriptEditor::_editor_play()`). But the problem is still present, `focus_owner` can still be `NULL` and `FindReplaceBar` would still fail in that case, it's just harder to reproduce. This PR hopefully improves checks to remove problematic cases.

To reproduce the issue in `master` one can use this plugin, for example: [addons.zip](https://github.com/godotengine/godot/files/4879461/addons.zip)

![image](https://user-images.githubusercontent.com/11782833/86604127-a4999f00-bfad-11ea-8008-a1a559fb507f.png)

It adds a big button to the main editor view which clears focus owner when clicked. The rest of steps to reproduce the issue is the same as described in https://github.com/godotengine/godot/issues/24174#issuecomment-595088216:

1. Bring up and focus on the search `LineEdit` in the script editor.
2. Click the button created by the helpful plugin.
3. Press <kbd>Ctrl</kbd>.
4. There should be errors in the Output panel.

After this PR is applied, there are no longer any errors with the same steps.

