### PR TITLE
Improve scene preview generation for empty scenes and disabled features

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1225,20 +1225,25 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 
 		_find_node_types(editor_data.get_edited_scene_root(), c2d, c3d);
 
-		bool is2d;
-		if (c3d < c2d) {
-			is2d = true;
-		} else {
-			is2d = false;
-		}
 		save.step(TTR("Creating Thumbnail"), 1);
 		//current view?
 
 		Ref<Image> img;
-		if (is2d) {
+		// If neither 3D or 2D nodes are present, make a 1x1 black texture.
+		// We cannot fallback on the 2D editor, because it may not have been used yet,
+		// which would result in an invalid texture.
+		if (c3d == 0 && c2d == 0) {
+			img.instance();
+			img->create(1, 1, 0, Image::FORMAT_RGB8);
+		} else if (c3d < c2d) {
 			img = scene_root->get_texture()->get_data();
 		} else {
-			img = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_data();
+			// The 3D editor may be disabled as a feature, but scenes can still be opened.
+			// This check prevents the preview from regenerating in case those scenes are then saved.
+			Ref<EditorFeatureProfile> profile = feature_profile_manager->get_current_profile();
+			if (!profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D)) {
+				img = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_data();
+			}
 		}
 
 		if (img.is_valid()) {


### PR DESCRIPTION
Closes #38332.

As mentioned in the issue, in `master` the problem is no longer present in the same way. Invalid images are just generated as purple plane instead of throwing. I'm not sure what change exactly was responsible for that, but it was clearly not ported to 3.2. So instead I propose the following changes that can be applied to both `master` and `3.2`:

1. If there are neither 2d nor 3d nodes, make a small black image as preview.
2. As before, if there are more 2d nodes than 3d nodes, make the preview using 2d viewport.
3. If there are more (or equal) 3d nodes, make the preview using 3d viewport, unless the 3d editor is disabled on feature level.
3.1. If 3d editor is disabled, don't update the preview so it cannot be accidentally overwritten.

This is what the resulting previews look like:
![image](https://user-images.githubusercontent.com/11782833/86614454-b5e9a800-bfbb-11ea-9e58-760c209799c2.png)

This is still an improvement in `master`, because currently empty scenes generate that purple preview, which is less than ideal.