### PR TITLE
Prevent cleaned up GDScriptFunctionStates from emitting "completed" signals

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1908,7 +1908,7 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 	function = NULL; //cleaned up;
 	state.result = Variant();
 
-	if (completed) {
+	if (completed && reference_get_count() > 0) {
 		if (first_state.is_valid()) {
 			first_state->emit_signal("completed", ret);
 		} else {


### PR DESCRIPTION
This fixes the crashes I described in #39957, but I will admit I don't know enough about the engine details to say if this is the correct approach. If there are no remaining references to a `GDScriptFunctionState`, there's no point in it emitting a signal because nobody is listening, correct? That may not be a correct assumption, but is there another way to guard against the engine trying to call emit on junk memory? 