### PR TITLE
Fix crash on editor without a feature profile

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1241,7 +1241,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			// The 3D editor may be disabled as a feature, but scenes can still be opened.
 			// This check prevents the preview from regenerating in case those scenes are then saved.
 			Ref<EditorFeatureProfile> profile = feature_profile_manager->get_current_profile();
-			if (!profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D)) {
+			if (profile.is_valid() && !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D)) {
 				img = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_data();
 			}
 		}


### PR DESCRIPTION
When you don't have a feature profile, "current" is null. 
It fix crash introduced with https://github.com/godotengine/godot/commit/b00e8ffb22256c7815a577c30f5294ca4dbdaf42
![image](https://user-images.githubusercontent.com/471393/86800665-901fda00-c073-11ea-9db5-79f8cc45864f.png)
