### PR TITLE
Call reload_space_override_modificator() directly when processing a body entering or leaving an area.

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -852,7 +852,7 @@ void RigidBodyBullet::on_enter_area(AreaBullet *p_area) {
 		}
 	}
 	if (PhysicsServer3D::AREA_SPACE_OVERRIDE_DISABLED != p_area->get_spOv_mode()) {
-		scratch_space_override_modificator();
+		reload_space_override_modificator();
 	}
 
 	if (p_area->is_spOv_gravityPoint()) {
@@ -885,7 +885,7 @@ void RigidBodyBullet::on_exit_area(AreaBullet *p_area) {
 		--areaWhereIamCount;
 		areasWhereIam.write[areaWhereIamCount] = nullptr; // Even if this is not required, I clear the last element to be safe
 		if (PhysicsServer3D::AREA_SPACE_OVERRIDE_DISABLED != p_area->get_spOv_mode()) {
-			scratch_space_override_modificator();
+			reload_space_override_modificator();
 		}
 	}
 }


### PR DESCRIPTION
Currently, when processing a `RigidBody` entering or exiting an `Area`, the code to update the effect that an `Area` has on a `RigidBody` is not called directly, instead it is added to the queue to be processed in the next physics iteration.

This PR ensures the code to update the effect an Area has on the `RigidBody` entering or exiting an `Area` is called as the `RigidBody` enters or exits the `Area` ensuring its affect is felt immediately and not only in the next physics iteration.

Improves #40127 which is caused by the effect an `Area` has on a `RigidBody` only being applied two physics frames later. This PR reduces it to one. The other is due to a physics iteration still being required to detect the `RigidBody` colliding with the `Area`, but that is for another PR.
