### PR TITLE
Add 'include_borders' argument to 'Rect2i.intersects()'

### DIFF
--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -264,18 +264,33 @@ struct Rect2i {
 
 	int get_area() const { return size.width * size.height; }
 
-	inline bool intersects(const Rect2i &p_rect) const {
-		if (position.x > (p_rect.position.x + p_rect.size.width)) {
-			return false;
-		}
-		if ((position.x + size.width) < p_rect.position.x) {
-			return false;
-		}
-		if (position.y > (p_rect.position.y + p_rect.size.height)) {
-			return false;
-		}
-		if ((position.y + size.height) < p_rect.position.y) {
-			return false;
+	inline bool intersects(const Rect2i &p_rect, const bool p_include_borders = false) const {
+		if (p_include_borders) {
+			if (position.x > (p_rect.position.x + p_rect.size.width)) {
+				return false;
+			}
+			if ((position.x + size.width) < p_rect.position.x) {
+				return false;
+			}
+			if (position.y > (p_rect.position.y + p_rect.size.height)) {
+				return false;
+			}
+			if ((position.y + size.height) < p_rect.position.y) {
+				return false;
+			}
+		} else {
+			if (position.x >= (p_rect.position.x + p_rect.size.width)) {
+				return false;
+			}
+			if ((position.x + size.width) <= p_rect.position.x) {
+				return false;
+			}
+			if (position.y >= (p_rect.position.y + p_rect.size.height)) {
+				return false;
+			}
+			if ((position.y + size.height) <= p_rect.position.y) {
+				return false;
+			}
 		}
 
 		return true;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -405,7 +405,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0R(Rect2i, get_area);
 	VCALL_LOCALMEM0R(Rect2i, has_no_area);
 	VCALL_LOCALMEM1R(Rect2i, has_point);
-	VCALL_LOCALMEM1R(Rect2i, intersects);
+	VCALL_LOCALMEM2R(Rect2i, intersects);
 	VCALL_LOCALMEM1R(Rect2i, encloses);
 	VCALL_LOCALMEM1R(Rect2i, clip);
 	VCALL_LOCALMEM1R(Rect2i, merge);
@@ -1930,7 +1930,7 @@ void register_variant_methods() {
 	ADDFUNC0R(RECT2I, INT, Rect2i, get_area, varray());
 	ADDFUNC0R(RECT2I, BOOL, Rect2i, has_no_area, varray());
 	ADDFUNC1R(RECT2I, BOOL, Rect2i, has_point, VECTOR2I, "point", varray());
-	ADDFUNC1R(RECT2I, BOOL, Rect2i, intersects, RECT2I, "b", varray());
+	ADDFUNC2R(RECT2I, BOOL, Rect2i, intersects, RECT2I, "b", BOOL, "include_borders", varray(false));
 	ADDFUNC1R(RECT2I, BOOL, Rect2i, encloses, RECT2I, "b", varray());
 	ADDFUNC1R(RECT2I, RECT2I, Rect2i, clip, RECT2I, "b", varray());
 	ADDFUNC1R(RECT2I, RECT2I, Rect2i, merge, RECT2I, "b", varray());

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -143,6 +143,8 @@
 			</return>
 			<argument index="0" name="b" type="Rect2i">
 			</argument>
+			<argument index="1" name="include_borders" type="bool" default="false">
+			</argument>
 			<description>
 				Returns [code]true[/code] if the [Rect2i] overlaps with [code]b[/code] (i.e. they have at least one point in common).
 				If [code]include_borders[/code] is [code]true[/code], they will also be considered overlapping if their borders touch, even without intersection.


### PR DESCRIPTION
This makes it match the `Rect2` version of the method altered in #36021.