### PR TITLE
fix tree-item's behavior on Asset Installer.

### DIFF
--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -54,6 +54,27 @@ void EditorAssetInstaller::_update_subitems(TreeItem *p_item, bool p_check, bool
 	}
 }
 
+void EditorAssetInstaller::_uncheck_parent(TreeItem *p_item) {
+	if (!p_item) {
+		return;
+	}
+
+	bool any_checked = false;
+	TreeItem *item = p_item->get_children();
+	while (item) {
+		if (item->is_checked(0)) {
+			any_checked = true;
+			break;
+		}
+		item = item->get_next();
+	}
+
+	if (!any_checked) {
+		p_item->set_checked(0, false);
+		_uncheck_parent(p_item->get_parent());
+	}
+}
+
 void EditorAssetInstaller::_item_edited() {
 	if (updating) {
 		return;
@@ -67,7 +88,7 @@ void EditorAssetInstaller::_item_edited() {
 	String path = item->get_metadata(0);
 
 	updating = true;
-	if (path == String()) { //a dir
+	if (path == String() || item == tree->get_root()) { //a dir or root
 		_update_subitems(item, item->is_checked(0), true);
 	}
 
@@ -76,6 +97,8 @@ void EditorAssetInstaller::_item_edited() {
 			item->set_checked(0, true);
 			item = item->get_parent();
 		}
+	} else {
+		_uncheck_parent(item->get_parent());
 	}
 	updating = false;
 }

--- a/editor/editor_asset_installer.h
+++ b/editor/editor_asset_installer.h
@@ -42,6 +42,7 @@ class EditorAssetInstaller : public ConfirmationDialog {
 	Map<String, TreeItem *> status_map;
 	bool updating;
 	void _update_subitems(TreeItem *p_item, bool p_check, bool p_first = false);
+	void _uncheck_parent(TreeItem *p_item);
 	void _item_edited();
 	virtual void ok_pressed();
 


### PR DESCRIPTION
1. When check Tree's root item(res://), children won't turn checked.
2. If all children are unchecked, the parent should be unchecked as well.
This PR fixed bugs above.
![fix](https://user-images.githubusercontent.com/12966814/86941221-479d1500-c176-11ea-9603-7a60f648d76c.gif)
