### PR TITLE
Expose Node3DEditorViewport to GDScript

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -99,6 +99,15 @@
 				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
+		<method name="get_node_3d_editor_viewport" qualifiers="const">
+			<return type="Node3DEditorViewport">
+			</return>
+			<param index="0" name="index" type="int">
+			</param>
+			<description>
+				Returns the specified Node3DEditorViewport.
+			</description>
+		</method>
 		<method name="get_open_scenes" qualifiers="const">
 			<return type="PackedStringArray" />
 			<description>
@@ -260,4 +269,9 @@
 			If [code]true[/code], enables distraction-free mode which hides side docks to increase the space available for the main view.
 		</member>
 	</members>
+	<constants>
+		<constant name="VIEWPORTS_COUNT" value="4">
+			The maximum number of viewports that can be displayed at the same time in the 3D editor.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/Node3DEditorViewport.xml
+++ b/doc/classes/Node3DEditorViewport.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Node3DEditorViewport" inherits="Control" version="4.0">
+	<brief_description>
+		Control used by the 3D editor to display 3D scenes.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="can_drop_data_fw" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="point" type="Vector2">
+			</argument>
+			<argument index="1" name="data" type="Variant">
+			</argument>
+			<argument index="2" name="from" type="Control">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="drop_data_fw">
+			<return type="void">
+			</return>
+			<argument index="0" name="point" type="Vector2">
+			</argument>
+			<argument index="1" name="data" type="Variant">
+			</argument>
+			<argument index="2" name="from" type="Control">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="get_camera_3d">
+			<return type="Camera3D">
+			</return>
+			<description>
+				Gets the camera used by the viewport.
+			</description>
+		</method>
+		<method name="set_message">
+			<return type="void">
+			</return>
+			<argument index="0" name="message" type="String">
+			</argument>
+			<argument index="1" name="time" type="float" default="5.0">
+			</argument>
+			<description>
+				Displays a message in the bottom corner of the viewport for a limited duration.
+			</description>
+		</method>
+		<method name="update_transform_gizmo_view">
+			<return type="void">
+			</return>
+			<description>
+				Updates the transform gizmo belonging to the viewport.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="clicked">
+			<argument index="0" name="viewport" type="Object">
+			</argument>
+			<description>
+				Emitted when any mouse button is clicked inside the viewport.
+			</description>
+		</signal>
+		<signal name="toggle_maximize_view">
+			<argument index="0" name="viewport" type="Object">
+			</argument>
+			<description>
+				Emitted when the viewport is maximized.
+			</description>
+		</signal>
+	</signals>
+	<constants>
+	</constants>
+</class>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4145,6 +4145,7 @@ void EditorNode::register_editor_types() {
 	GDREGISTER_ABSTRACT_CLASS(ScriptEditorBase);
 	GDREGISTER_CLASS(EditorSyntaxHighlighter);
 	GDREGISTER_ABSTRACT_CLASS(EditorInterface);
+	GDREGISTER_ABSTRACT_CLASS(Node3DEditorViewport);
 	GDREGISTER_CLASS(EditorExportPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatform);
 	GDREGISTER_CLASS(EditorResourceConversionPlugin);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -160,6 +160,11 @@ VBoxContainer *EditorInterface::get_editor_main_screen() {
 	return EditorNode::get_singleton()->get_main_screen_control();
 }
 
+Node3DEditorViewport *EditorInterface::get_node_3d_editor_viewport(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, (int)Node3DEditor::VIEWPORTS_COUNT, Node3DEditor::get_singleton()->get_editor_viewport(Node3DEditor::VIEWPORTS_COUNT - 1));
+	return Node3DEditor::get_singleton()->get_editor_viewport(p_idx);
+}
+
 void EditorInterface::edit_resource(const Ref<Resource> &p_resource) {
 	EditorNode::get_singleton()->edit_resource(p_resource);
 }
@@ -353,6 +358,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer);
 	ClassDB::bind_method(D_METHOD("get_resource_filesystem"), &EditorInterface::get_resource_file_system);
 	ClassDB::bind_method(D_METHOD("get_editor_main_screen"), &EditorInterface::get_editor_main_screen);
+	ClassDB::bind_method(D_METHOD("get_node_3d_editor_viewport", "index"), &EditorInterface::get_node_3d_editor_viewport);
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
 	ClassDB::bind_method(D_METHOD("select_file", "file"), &EditorInterface::select_file);
 	ClassDB::bind_method(D_METHOD("get_selected_path"), &EditorInterface::get_selected_path);
@@ -375,6 +381,8 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_distraction_free_mode_enabled"), &EditorInterface::is_distraction_free_mode_enabled);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distraction_free_mode"), "set_distraction_free_mode", "is_distraction_free_mode_enabled");
+
+	ClassDB::bind_integer_constant(get_class_static(), StringName(), "VIEWPORTS_COUNT", (int)Node3DEditor::VIEWPORTS_COUNT);
 }
 
 EditorInterface::EditorInterface() {

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -59,6 +59,7 @@ class EditorToolAddons;
 class EditorPaths;
 class FileSystemDock;
 class ScriptEditor;
+class Node3DEditorViewport;
 
 class EditorInterface : public Node {
 	GDCLASS(EditorInterface, Node);
@@ -73,6 +74,7 @@ public:
 	static EditorInterface *get_singleton() { return singleton; }
 
 	VBoxContainer *get_editor_main_screen();
+	Node3DEditorViewport *get_node_3d_editor_viewport(int p_idx) const;
 	void edit_resource(const Ref<Resource> &p_resource);
 	void edit_node(Node *p_node);
 	void edit_script(const Ref<Script> &p_script, int p_line = -1, int p_col = 0, bool p_grab_focus = true);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3668,6 +3668,8 @@ void Node3DEditorViewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("update_transform_gizmo_view"), &Node3DEditorViewport::update_transform_gizmo_view); // Used by call_deferred.
 	ClassDB::bind_method(D_METHOD("_can_drop_data_fw"), &Node3DEditorViewport::can_drop_data_fw);
 	ClassDB::bind_method(D_METHOD("_drop_data_fw"), &Node3DEditorViewport::drop_data_fw);
+	ClassDB::bind_method(D_METHOD("set_message", "message", "time"), &Node3DEditorViewport::set_message, DEFVAL(5.0));
+	ClassDB::bind_method(D_METHOD("get_camera_3d"), &Node3DEditorViewport::get_camera_3d);
 
 	ADD_SIGNAL(MethodInfo("toggle_maximize_view", PropertyInfo(Variant::OBJECT, "viewport")));
 	ADD_SIGNAL(MethodInfo("clicked", PropertyInfo(Variant::OBJECT, "viewport")));


### PR DESCRIPTION
One user and I want access to the cameras from the 3D editor viewports for tools and plugins.
[Post on the QA forums](https://godotengine.org/qa/6369/how-to-get-the-editors-camera)

I went ahead and exposed the Node3DEditorViewport class, which has a method for getting the camera.

I've added a method to EditorInterface, get_node3D_editor_viewport(int p_idx), to access these viewports.

If it is preferable that I don't expose Node3DEditorViewport, I could expose this functionality through EditorInterface instead e.g.
get_node3d_editor_camera(int p_idx)
set_node3d_editor_message(string message, int p_idx, double p_time)

*Bugsquad edit: This closes #26534. This closes https://github.com/godotengine/godot-proposals/issues/1302.*