### PR TITLE
Fixes the get_visible_line_count() of rich text label

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1020,7 +1020,8 @@ void RichTextLabel::_notification(int p_what) {
 
 			visible_line_count = 0;
 			while (y < size.height && from_line < main->lines.size()) {
-				visible_line_count += _process_line(main, text_rect.get_position(), y, text_rect.get_size().width - scroll_w, from_line, PROCESS_DRAW, base_font, base_color, font_color_shadow, use_outline, shadow_ofs, Point2i(), nullptr, nullptr, nullptr, total_chars);
+				visible_line_count++;
+				_process_line(main, text_rect.get_position(), y, text_rect.get_size().width - scroll_w, from_line, PROCESS_DRAW, base_font, base_color, font_color_shadow, use_outline, shadow_ofs, Point2i(), nullptr, nullptr, nullptr, total_chars);
 				total_chars += main->lines[from_line].char_count;
 
 				from_line++;


### PR DESCRIPTION
Fixes #18722

**Bug:** `get_visible_line_count()` would return wrong values.

**Reason:** While being drawn, `visible_line_count` was getting wrong values from `_process_line()`. Actually, `_process_line()` return wrong number of `nonblank_line_count`. This was messing up the `visible_line_count`.

**Fix:** Every time a line is drawn, `visible_line_count` is simply incremented, instead of getting wrong values from  `_process_line()`

### Before Fix
![Screenshot (96)](https://user-images.githubusercontent.com/41969735/86965085-a49fc780-c184-11ea-99a0-d95ffdd8d94b.png)
![Screenshot (98)](https://user-images.githubusercontent.com/41969735/86965166-be410f00-c184-11ea-85e0-399c181688dd.png)


### After Fix
![Screenshot (92)](https://user-images.githubusercontent.com/41969735/86965216-d022b200-c184-11ea-8a37-b55be27220e6.png)
![Screenshot (93)](https://user-images.githubusercontent.com/41969735/86965237-d749c000-c184-11ea-9909-303c646ba826.png)
![Screenshot (95)](https://user-images.githubusercontent.com/41969735/86965262-dfa1fb00-c184-11ea-9576-7ec11ea7b643.png)

