### PR TITLE
Keep debug & verbose options after loading project from project manager

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -163,6 +163,10 @@ bool OS::is_stdout_verbose() const {
 	return _verbose_stdout;
 }
 
+bool OS::is_stdout_debug_enabled() const {
+	return _debug_stdout;
+}
+
 void OS::dump_memory_to_file(const char *p_file) {
 	//Memory::dump_static_mem_to_file(p_file);
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -50,6 +50,7 @@ class OS {
 	bool low_processor_usage_mode = false;
 	int low_processor_usage_mode_sleep_usec = 10000;
 	bool _verbose_stdout = false;
+	bool _debug_stdout = false;
 	String _local_clipboard;
 	uint64_t _msec_splash;
 	bool _no_window = false;
@@ -222,6 +223,7 @@ public:
 	virtual bool is_userfs_persistent() const { return true; }
 
 	bool is_stdout_verbose() const;
+	bool is_stdout_debug_enabled() const;
 
 	virtual void disable_crash_handler() {}
 	virtual bool is_disable_crash_handler() const { return false; }

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2004,6 +2004,14 @@ void ProjectManager::_open_selected_projects() {
 
 		args.push_back("--editor");
 
+		if (OS::get_singleton()->is_stdout_debug_enabled()) {
+			args.push_back("--debug");
+		}
+
+		if (OS::get_singleton()->is_stdout_verbose()) {
+			args.push_back("--verbose");
+		}
+
 		if (OS::get_singleton()->is_disable_crash_handler()) {
 			args.push_back("--disable-crash-handler");
 		}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -836,6 +836,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 		} else if (I->get() == "-d" || I->get() == "--debug") {
 			debug_uri = "local://";
+			OS::get_singleton()->_debug_stdout = true;
 #if defined(DEBUG_ENABLED) && !defined(SERVER_ENABLED)
 		} else if (I->get() == "--debug-collisions") {
 			debug_collisions = true;


### PR DESCRIPTION
When starting the editor with `--debug` or `--verbose` command line options without loading a project directly, this change propagates them to the opened project from the project manager.