### PR TITLE
Fix exclusive child focus grab, when there are more than two child windows.

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -893,7 +893,12 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	}
 
 	if (exclusive_child != nullptr) {
-		exclusive_child->grab_focus();
+		Window *focus_target = exclusive_child;
+		while (focus_target->exclusive_child != nullptr) {
+			focus_target->grab_focus();
+			focus_target = focus_target->exclusive_child;
+		}
+		focus_target->grab_focus();
 
 		if (!is_embedding_subwindows()) { //not embedding, no need for event
 			return;


### PR DESCRIPTION
Follow exclusive child chain to the end and activate all widows, instead of only next one.

e.g. : 
- Before: Clicking on `Main window` activates `Create New Project` leaving `Open a directory` at the bottom and inactive.
- After: Clicking on `Main window` brings `Create New Project` on top of `Main window`, and `Open a directory` on top of all and active.
<img width="1210" alt="Screenshot 2020-07-09 at 11 20 12" src="https://user-images.githubusercontent.com/7645683/87015736-7a76f580-c1d6-11ea-983e-a58f8f03a914.png">
