### PR TITLE
Emit signals for GraphEdit multi-node selection and unselection

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -812,9 +812,20 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 			bool in_box = r.intersects(box_selecting_rect);
 
 			if (in_box) {
+				if (!gn->is_selected() && box_selection_mode_additive) {
+					emit_signal("node_selected", gn);
+				} else if (gn->is_selected() && !box_selection_mode_additive) {
+					emit_signal("node_unselected", gn);
+				}
 				gn->set_selected(box_selection_mode_additive);
 			} else {
-				gn->set_selected(previus_selected.find(gn) != nullptr);
+				bool select = (previus_selected.find(gn) != nullptr);
+				if (gn->is_selected() && !select) {
+					emit_signal("node_unselected", gn);
+				} else if (!gn->is_selected() && select) {
+					emit_signal("node_selected", gn);
+				}
+				gn->set_selected(select);
 			}
 		}
 
@@ -832,7 +843,13 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 						continue;
 					}
 
-					gn->set_selected(previus_selected.find(gn) != nullptr);
+					bool select = (previus_selected.find(gn) != nullptr);
+					if (gn->is_selected() && !select) {
+						emit_signal("node_unselected", gn);
+					} else if (!gn->is_selected() && select) {
+						emit_signal("node_selected", gn);
+					}
+					gn->set_selected(select);
 				}
 				top_layer->update();
 			} else {
@@ -855,6 +872,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 						Rect2 r = gn->get_rect();
 						r.size *= zoom;
 						if (r.has_point(b->get_position())) {
+							emit_signal("node_unselected", gn);
 							gn->set_selected(false);
 						}
 					}


### PR DESCRIPTION
Emit `node_selected` and `node_unselected` signals where appropriate when clicking-and-dragging in a  `GraphEdit` node to
select/unselect multiple nodes at once.

Closes #40196 
(4.0 version of the minimal reproducible project here: [multiNode.zip](https://github.com/godotengine/godot/files/4895927/multiNode.zip))

