### PR TITLE
[macOS] Fix transient windows.

### DIFF
--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -2465,7 +2465,7 @@ void DisplayServerOSX::window_set_transient(WindowID p_window, WindowID p_parent
 		wd_window.transient_parent = INVALID_WINDOW_ID;
 		wd_parent.transient_children.erase(p_window);
 
-		[wd_window.window_object setParentWindow:nil];
+		[wd_parent.window_object removeChildWindow:wd_window.window_object];
 	} else {
 		ERR_FAIL_COND(!windows.has(p_parent));
 		ERR_FAIL_COND_MSG(wd_window.transient_parent != INVALID_WINDOW_ID, "Window already has a transient parent");
@@ -2474,7 +2474,7 @@ void DisplayServerOSX::window_set_transient(WindowID p_window, WindowID p_parent
 		wd_window.transient_parent = p_parent;
 		wd_parent.transient_children.insert(p_window);
 
-		[wd_window.window_object setParentWindow:wd_parent.window_object];
+		[wd_parent.window_object addChildWindow:wd_window.window_object ordered:NSWindowAbove];
 	}
 }
 


### PR DESCRIPTION
While `setParentWindow` function exists and seems to work, according to documentation it's not correct to use it directly:
```
This property should be set from a subclass when it is overridden by a subclass’s implementation.
It should not be set otherwise.
```
Changed it to `addChildWindow`, `removeChildWindow`.
Fixes returning focus to the parent after child is closed.