### PR TITLE
Fixed mesh data access errors in GLES2

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -2566,9 +2566,7 @@ Vector<uint8_t> RasterizerStorageGLES2::mesh_surface_get_array(RID p_mesh, int p
 	ERR_FAIL_INDEX_V(p_surface, mesh->surfaces.size(), Vector<uint8_t>());
 
 	Surface *surface = mesh->surfaces[p_surface];
-#ifndef TOOLS_ENABLED
-	ERR_PRINT("OpenGL ES 2.0 does not allow retrieving mesh array data");
-#endif
+
 	return surface->data;
 }
 
@@ -2612,7 +2610,7 @@ Vector<Vector<uint8_t>> RasterizerStorageGLES2::mesh_surface_get_blend_shapes(RI
 	ERR_FAIL_COND_V(!mesh, Vector<Vector<uint8_t>>());
 	ERR_FAIL_INDEX_V(p_surface, mesh->surfaces.size(), Vector<Vector<uint8_t>>());
 #ifndef TOOLS_ENABLED
-	ERR_PRINT("OpenGL ES 2.0 does not allow retrieving mesh array data");
+	ERR_PRINT("OpenGL ES 2.0 does not allow retrieving blend shape data");
 #endif
 
 	return mesh->surfaces[p_surface]->blend_shape_data;


### PR DESCRIPTION
1. Removed error in `mesh_surface_get_array` as it's supported now
(see https://github.com/godotengine/godot/pull/34794#issuecomment-578497458)

2. More accurate error message in `mesh_surface_get_blend_shapes`