### PR TITLE
Mention `SceneTree.create_timer()` in the Timer class documentation

### DIFF
--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Counts down a specified interval and emits a signal on reaching 0. Can be set to repeat or "one-shot" mode.
+		[b]Note:[/b] To create an one-shot timer without instantiating a node, use [method SceneTree.create_timer].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-docs/issues/2349 (as the linked method already contains an example).