### PR TITLE
Handle 16 bit PNG files in sRGB color space

### DIFF
--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -50,7 +50,7 @@ Error ImageLoaderPNG::load_image(Ref<Image> p_image, FileAccess *f, bool p_force
 		f->close();
 	}
 	const uint8_t *reader = file_buffer.ptr();
-	return PNGDriverCommon::png_to_image(reader, buffer_size, p_image);
+	return PNGDriverCommon::png_to_image(reader, buffer_size, p_force_linear, p_image);
 }
 
 void ImageLoaderPNG::get_recognized_extensions(List<String> *p_extensions) const {
@@ -61,7 +61,8 @@ Ref<Image> ImageLoaderPNG::load_mem_png(const uint8_t *p_png, int p_size) {
 	Ref<Image> img;
 	img.instance();
 
-	Error err = PNGDriverCommon::png_to_image(p_png, p_size, img);
+	// the value of p_force_linear does not matter since it only applies to 16 bit
+	Error err = PNGDriverCommon::png_to_image(p_png, p_size, false, img);
 	ERR_FAIL_COND_V(err, Ref<Image>());
 
 	return img;

--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -58,7 +58,7 @@ static bool check_error(const png_image &image) {
 	return false;
 }
 
-Error png_to_image(const uint8_t *p_source, size_t p_size, Ref<Image> p_image) {
+Error png_to_image(const uint8_t *p_source, size_t p_size, bool p_force_linear, Ref<Image> p_image) {
 	png_image png_img;
 	zeromem(&png_img, sizeof(png_img));
 	png_img.version = PNG_IMAGE_VERSION;
@@ -97,6 +97,11 @@ Error png_to_image(const uint8_t *p_source, size_t p_size, Ref<Image> p_image) {
 			png_image_free(&png_img); // only required when we return before finish_read
 			ERR_PRINT("Unsupported png format.");
 			return ERR_UNAVAILABLE;
+	}
+
+	if (!p_force_linear) {
+		// assume 16 bit pngs without sRGB or gAMA chunks are in sRGB format
+		png_img.flags |= PNG_IMAGE_FLAG_16BIT_sRGB;
 	}
 
 	const png_uint_32 stride = PNG_IMAGE_ROW_STRIDE(png_img);

--- a/drivers/png/png_driver_common.h
+++ b/drivers/png/png_driver_common.h
@@ -36,7 +36,7 @@
 namespace PNGDriverCommon {
 
 // Attempt to load png from buffer (p_source, p_size) into p_image
-Error png_to_image(const uint8_t *p_source, size_t p_size, Ref<Image> p_image);
+Error png_to_image(const uint8_t *p_source, size_t p_size, bool p_force_linear, Ref<Image> p_image);
 
 // Append p_image, as a png, to p_buffer.
 // Contents of p_buffer is unspecified if error returned.


### PR DESCRIPTION
16-bit PNG files with sRGB color space turned out too bright (unless they had a gAMA chunk) when imported to Godot.

This change tells libpng to assume 16-bit files without gAMA or sRGB chunks are in sRGB color space rather than linear, unless the p_force_linear flag is set by load_image. Default to sRGB seems more consistent with other image viewers and file browsers (at least on Linux)

Fixes #37220
