### PR TITLE
Improved Bullet Physics flush algorithm, Lazy collision filter reload, Shape reload regression fix.

### DIFF
--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -65,14 +65,11 @@ AreaBullet::~AreaBullet() {
 }
 
 void AreaBullet::dispatch_callbacks() {
-	if (!isScratched) {
-		return;
-	}
-	isScratched = false;
+	RigidCollisionObjectBullet::dispatch_callbacks();
 
 	// Reverse order because I've to remove EXIT objects
 	for (int i = overlappingObjects.size() - 1; 0 <= i; --i) {
-		OverlappingObjectData &otherObj = overlappingObjects.write[i];
+		OverlappingObjectData &otherObj = overlappingObjects[i];
 
 		switch (otherObj.state) {
 			case OVERLAP_STATE_ENTER:
@@ -112,10 +109,9 @@ void AreaBullet::call_event(CollisionObjectBullet *p_otherObject, PhysicsServer3
 }
 
 void AreaBullet::scratch() {
-	if (isScratched) {
-		return;
+	if (space != nullptr) {
+		space->add_to_pre_flush_queue(this);
 	}
-	isScratched = true;
 }
 
 void AreaBullet::clear_overlaps(bool p_notify) {
@@ -173,9 +169,9 @@ void AreaBullet::do_reload_body() {
 
 void AreaBullet::set_space(SpaceBullet *p_space) {
 	// Clear the old space if there is one
+
 	if (space) {
 		clear_overlaps(false);
-		isScratched = false;
 
 		// Remove this object form the physics world
 		space->unregister_collision_object(this);
@@ -187,10 +183,11 @@ void AreaBullet::set_space(SpaceBullet *p_space) {
 	if (space) {
 		space->register_collision_object(this);
 		reload_body();
+		scratch();
 	}
 }
 
-void AreaBullet::on_collision_filters_change() {
+void AreaBullet::do_reload_collision_filters() {
 	if (space) {
 		space->reload_collision_filters(this);
 	}
@@ -204,13 +201,13 @@ void AreaBullet::add_overlap(CollisionObjectBullet *p_otherObject) {
 
 void AreaBullet::put_overlap_as_exit(int p_index) {
 	scratch();
-	overlappingObjects.write[p_index].state = OVERLAP_STATE_EXIT;
+	overlappingObjects[p_index].state = OVERLAP_STATE_EXIT;
 }
 
 void AreaBullet::put_overlap_as_inside(int p_index) {
 	// This check is required to be sure this body was inside
 	if (OVERLAP_STATE_DIRTY == overlappingObjects[p_index].state) {
-		overlappingObjects.write[p_index].state = OVERLAP_STATE_INSIDE;
+		overlappingObjects[p_index].state = OVERLAP_STATE_INSIDE;
 	}
 }
 

--- a/modules/bullet/area_bullet.h
+++ b/modules/bullet/area_bullet.h
@@ -32,7 +32,7 @@
 #define AREABULLET_H
 
 #include "collision_object_bullet.h"
-#include "core/vector.h"
+#include "core/local_vector.h"
 #include "servers/physics_server_3d.h"
 #include "space_bullet.h"
 
@@ -83,7 +83,7 @@ private:
 	Variant *call_event_res_ptr[5];
 
 	btGhostObject *btGhost;
-	Vector<OverlappingObjectData> overlappingObjects;
+	LocalVector<OverlappingObjectData> overlappingObjects;
 	bool monitorable = true;
 
 	PhysicsServer3D::AreaSpaceOverrideMode spOv_mode = PhysicsServer3D::AREA_SPACE_OVERRIDE_DISABLED;
@@ -95,8 +95,6 @@ private:
 	real_t spOv_linearDump = 0.1;
 	real_t spOv_angularDump = 0.1;
 	int spOv_priority = 0;
-
-	bool isScratched = false;
 
 	InOutEventCallback eventsCallbacks[2];
 
@@ -139,11 +137,11 @@ public:
 	_FORCE_INLINE_ void set_spOv_priority(int p_priority) { spOv_priority = p_priority; }
 	_FORCE_INLINE_ int get_spOv_priority() { return spOv_priority; }
 
-	virtual void main_shape_changed();
-	virtual void do_reload_body();
-	virtual void set_space(SpaceBullet *p_space);
+	virtual void main_shape_changed() override;
+	virtual void do_reload_body() override;
+	virtual void set_space(SpaceBullet *p_space) override;
 
-	virtual void dispatch_callbacks();
+	virtual void dispatch_callbacks() override;
 	void call_event(CollisionObjectBullet *p_otherObject, PhysicsServer3D::AreaBodyStatus p_status);
 	void set_on_state_change(ObjectID p_id, const StringName &p_method, const Variant &p_udata = Variant());
 	void scratch();
@@ -152,9 +150,9 @@ public:
 	// Dispatch the callbacks and removes from overlapping list
 	void remove_overlap(CollisionObjectBullet *p_object, bool p_notify);
 
-	virtual void on_collision_filters_change();
-	virtual void on_collision_checker_start() {}
-	virtual void on_collision_checker_end() { isTransformChanged = false; }
+	virtual void do_reload_collision_filters() override;
+	virtual void on_collision_checker_start() override {}
+	virtual void on_collision_checker_end() override { isTransformChanged = false; }
 
 	void add_overlap(CollisionObjectBullet *p_otherObject);
 	void put_overlap_as_exit(int p_index);
@@ -166,8 +164,8 @@ public:
 	void set_event_callback(Type p_callbackObjectType, ObjectID p_id, const StringName &p_method);
 	bool has_event_callback(Type p_callbackObjectType);
 
-	virtual void on_enter_area(AreaBullet *p_area);
-	virtual void on_exit_area(AreaBullet *p_area);
+	virtual void on_enter_area(AreaBullet *p_area) override;
+	virtual void on_exit_area(AreaBullet *p_area) override;
 };
 
 #endif

--- a/modules/bullet/bullet_physics_server.h
+++ b/modules/bullet/bullet_physics_server.h
@@ -52,7 +52,7 @@ class BulletPhysicsServer3D : public PhysicsServer3D {
 
 	bool active = true;
 	char active_spaces_count = 0;
-	Vector<SpaceBullet *> active_spaces;
+	LocalVector<SpaceBullet *> active_spaces;
 
 	mutable RID_PtrOwner<SpaceBullet> space_owner;
 	mutable RID_PtrOwner<ShapeBullet> shape_owner;

--- a/modules/bullet/collision_object_bullet.h
+++ b/modules/bullet/collision_object_bullet.h
@@ -31,6 +31,7 @@
 #ifndef COLLISION_OBJECT_BULLET_H
 #define COLLISION_OBJECT_BULLET_H
 
+#include "core/local_vector.h"
 #include "core/math/transform.h"
 #include "core/math/vector3.h"
 #include "core/object.h"
@@ -126,16 +127,18 @@ protected:
 
 	VSet<RID> exceptions;
 
-	bool need_body_reload = true;
+	bool needs_body_reload = true;
+	bool needs_collision_filters_reload = true;
 
 	/// This array is used to know all areas where this Object is overlapped in
 	/// New area is added when overlap with new area (AreaBullet::addOverlap), then is removed when it exit (CollisionObjectBullet::onExitArea)
 	/// This array is used mainly to know which area hold the pointer of this object
-	Vector<AreaBullet *> areasOverlapped;
+	LocalVector<AreaBullet *> areasOverlapped;
 	bool isTransformChanged = false;
 
 public:
 	bool is_in_world = false;
+	bool is_in_flush_queue = false;
 
 public:
 	CollisionObjectBullet(Type p_type);
@@ -171,7 +174,7 @@ public:
 	_FORCE_INLINE_ void set_collision_layer(uint32_t p_layer) {
 		if (collisionLayer != p_layer) {
 			collisionLayer = p_layer;
-			on_collision_filters_change();
+			needs_collision_filters_reload = true;
 		}
 	}
 	_FORCE_INLINE_ uint32_t get_collision_layer() const { return collisionLayer; }
@@ -179,24 +182,23 @@ public:
 	_FORCE_INLINE_ void set_collision_mask(uint32_t p_mask) {
 		if (collisionMask != p_mask) {
 			collisionMask = p_mask;
-			on_collision_filters_change();
+			needs_collision_filters_reload = true;
 		}
 	}
 	_FORCE_INLINE_ uint32_t get_collision_mask() const { return collisionMask; }
 
-	virtual void on_collision_filters_change() = 0;
+	virtual void do_reload_collision_filters() = 0;
 
 	_FORCE_INLINE_ bool test_collision_mask(CollisionObjectBullet *p_other) const {
 		return collisionLayer & p_other->collisionMask || p_other->collisionLayer & collisionMask;
 	}
 
 	bool need_reload_body() const {
-		return need_body_reload;
+		return needs_body_reload;
 	}
 
-	void reload_body() {
-		need_body_reload = true;
-	}
+	void reload_body();
+
 	virtual void do_reload_body() = 0;
 	virtual void set_space(SpaceBullet *p_space) = 0;
 	_FORCE_INLINE_ SpaceBullet *get_space() const { return space; }
@@ -204,8 +206,8 @@ public:
 	virtual void on_collision_checker_start() = 0;
 	virtual void on_collision_checker_end() = 0;
 
-	virtual void prepare_object_for_dispatch();
-	virtual void dispatch_callbacks() = 0;
+	virtual void dispatch_callbacks();
+	virtual void pre_process();
 
 	void set_collision_enabled(bool p_enabled);
 	bool is_collisions_response_enabled();
@@ -229,7 +231,7 @@ public:
 class RigidCollisionObjectBullet : public CollisionObjectBullet, public ShapeOwnerBullet {
 protected:
 	btCollisionShape *mainShape = nullptr;
-	Vector<ShapeWrapper> shapes;
+	LocalVector<ShapeWrapper> shapes;
 	bool need_shape_reload = true;
 
 public:
@@ -237,7 +239,7 @@ public:
 			CollisionObjectBullet(p_type) {}
 	~RigidCollisionObjectBullet();
 
-	_FORCE_INLINE_ const Vector<ShapeWrapper> &get_shapes_wrappers() const { return shapes; }
+	_FORCE_INLINE_ const LocalVector<ShapeWrapper> &get_shapes_wrappers() const { return shapes; }
 
 	_FORCE_INLINE_ btCollisionShape *get_main_shape() const { return mainShape; }
 
@@ -248,9 +250,9 @@ public:
 	ShapeBullet *get_shape(int p_index) const;
 	btCollisionShape *get_bt_shape(int p_index) const;
 
-	int find_shape(ShapeBullet *p_shape) const;
+	virtual int find_shape(ShapeBullet *p_shape) const override;
 
-	virtual void remove_shape_full(ShapeBullet *p_shape);
+	virtual void remove_shape_full(ShapeBullet *p_shape) override;
 	void remove_shape_full(int p_index);
 	void remove_all_shapes(bool p_permanentlyFromThisBody = false, bool p_force_not_reload = false);
 
@@ -262,15 +264,15 @@ public:
 	void set_shape_disabled(int p_index, bool p_disabled);
 	bool is_shape_disabled(int p_index);
 
-	virtual void prepare_object_for_dispatch();
+	virtual void pre_process() override;
 
-	virtual void shape_changed(int p_shape_index);
-	void reload_shapes();
+	virtual void shape_changed(int p_shape_index) override;
+	virtual void reload_shapes() override;
 	bool need_reload_shapes() const { return need_shape_reload; }
 	virtual void do_reload_shapes();
 
 	virtual void main_shape_changed() = 0;
-	virtual void body_scale_changed();
+	virtual void body_scale_changed() override;
 
 private:
 	void internal_shape_destroy(int p_index, bool p_permanentlyFromThisBody = false);

--- a/modules/bullet/rigid_body_bullet.h
+++ b/modules/bullet/rigid_body_bullet.h
@@ -171,7 +171,7 @@ public:
 	struct KinematicUtilities {
 		RigidBodyBullet *owner;
 		btScalar safe_margin;
-		Vector<KinematicShape> shapes;
+		LocalVector<KinematicShape> shapes;
 
 		KinematicUtilities(RigidBodyBullet *p_owner);
 		~KinematicUtilities();
@@ -193,6 +193,7 @@ private:
 	PhysicsServer3D::BodyMode mode;
 	GodotMotionState *godotMotionState;
 	btRigidBody *btBody;
+	Vector3 total_gravity;
 	uint16_t locked_axis = 0;
 	real_t mass = 1;
 	real_t gravity_scale = 1;
@@ -202,18 +203,18 @@ private:
 	bool omit_forces_integration = false;
 	bool can_integrate_forces = false;
 
-	Vector<CollisionData> collisions;
-	Vector<RigidBodyBullet *> collision_traces_1;
-	Vector<RigidBodyBullet *> collision_traces_2;
-	Vector<RigidBodyBullet *> *prev_collision_traces;
-	Vector<RigidBodyBullet *> *curr_collision_traces;
+	LocalVector<CollisionData> collisions;
+	LocalVector<RigidBodyBullet *> collision_traces_1;
+	LocalVector<RigidBodyBullet *> collision_traces_2;
+	LocalVector<RigidBodyBullet *> *prev_collision_traces;
+	LocalVector<RigidBodyBullet *> *curr_collision_traces;
 
 	// these parameters are used to avoid vector resize
-	int maxCollisionsDetection = 0;
-	int collisionsCount = 0;
-	int prev_collision_count = 0;
+	uint32_t maxCollisionsDetection = 0;
+	uint32_t collisionsCount = 0;
+	uint32_t prev_collision_count = 0;
 
-	Vector<AreaBullet *> areasWhereIam;
+	LocalVector<AreaBullet *> areasWhereIam;
 	// these parameters are used to avoid vector resize
 	int maxAreasWhereIam = 10;
 	int areaWhereIamCount = 0;
@@ -235,21 +236,20 @@ public:
 
 	_FORCE_INLINE_ btRigidBody *get_bt_rigid_body() { return btBody; }
 
-	virtual void main_shape_changed();
-	virtual void do_reload_body();
-	virtual void set_space(SpaceBullet *p_space);
+	virtual void main_shape_changed() override;
+	virtual void do_reload_body() override;
+	virtual void set_space(SpaceBullet *p_space) override;
 
-	virtual void dispatch_callbacks();
+	virtual void dispatch_callbacks() override;
+	virtual void pre_process() override;
 	void set_force_integration_callback(ObjectID p_id, const StringName &p_method, const Variant &p_udata = Variant());
 	void scratch_space_override_modificator();
 
-	virtual void on_collision_filters_change();
-	virtual void on_collision_checker_start();
-	virtual void on_collision_checker_end();
+	virtual void do_reload_collision_filters() override;
+	virtual void on_collision_checker_start() override;
+	virtual void on_collision_checker_end() override;
 
-	void set_max_collisions_detection(int p_maxCollisionsDetection) {
-		ERR_FAIL_COND(0 > p_maxCollisionsDetection);
-
+	void set_max_collisions_detection(uint32_t p_maxCollisionsDetection) {
 		maxCollisionsDetection = p_maxCollisionsDetection;
 
 		collisions.resize(p_maxCollisionsDetection);
@@ -312,19 +312,19 @@ public:
 	void set_angular_velocity(const Vector3 &p_velocity);
 	Vector3 get_angular_velocity() const;
 
-	virtual void set_transform__bullet(const btTransform &p_global_transform);
-	virtual const btTransform &get_transform__bullet() const;
+	virtual void set_transform__bullet(const btTransform &p_global_transform) override;
+	virtual const btTransform &get_transform__bullet() const override;
 
-	virtual void do_reload_shapes();
+	virtual void do_reload_shapes() override;
 
-	virtual void on_enter_area(AreaBullet *p_area);
-	virtual void on_exit_area(AreaBullet *p_area);
+	virtual void on_enter_area(AreaBullet *p_area) override;
+	virtual void on_exit_area(AreaBullet *p_area) override;
 	void reload_space_override_modificator();
 
 	/// Kinematic
 	void reload_kinematic_shapes();
 
-	virtual void notify_transform_changed();
+	virtual void notify_transform_changed() override;
 
 private:
 	void _internal_set_mass(real_t p_mass);

--- a/modules/bullet/soft_body_bullet.cpp
+++ b/modules/bullet/soft_body_bullet.cpp
@@ -346,14 +346,14 @@ void SoftBodyBullet::set_trimesh_body_shape(Vector<int> p_indices, Vector<Vector
 					indices_table.push_back(Vector<int>());
 				}
 
-				indices_table.write[vertex_id].push_back(vs_vertex_index);
+				indices_table[vertex_id].push_back(vs_vertex_index);
 				vs_indices_to_physics_table.push_back(vertex_id);
 			}
 		}
 
 		const int indices_map_size(indices_table.size());
 
-		Vector<btScalar> bt_vertices;
+		LocalVector<btScalar> bt_vertices;
 
 		{ // Parse vertices to bullet
 
@@ -361,13 +361,13 @@ void SoftBodyBullet::set_trimesh_body_shape(Vector<int> p_indices, Vector<Vector
 			const Vector3 *p_vertices_read = p_vertices.ptr();
 
 			for (int i = 0; i < indices_map_size; ++i) {
-				bt_vertices.write[3 * i + 0] = p_vertices_read[indices_table[i][0]].x;
-				bt_vertices.write[3 * i + 1] = p_vertices_read[indices_table[i][0]].y;
-				bt_vertices.write[3 * i + 2] = p_vertices_read[indices_table[i][0]].z;
+				bt_vertices[3 * i + 0] = p_vertices_read[indices_table[i][0]].x;
+				bt_vertices[3 * i + 1] = p_vertices_read[indices_table[i][0]].y;
+				bt_vertices[3 * i + 2] = p_vertices_read[indices_table[i][0]].z;
 			}
 		}
 
-		Vector<int> bt_triangles;
+		LocalVector<int> bt_triangles;
 		const int triangles_size(p_indices.size() / 3);
 
 		{ // Parse indices
@@ -377,9 +377,9 @@ void SoftBodyBullet::set_trimesh_body_shape(Vector<int> p_indices, Vector<Vector
 			const int *p_indices_read = p_indices.ptr();
 
 			for (int i = 0; i < triangles_size; ++i) {
-				bt_triangles.write[3 * i + 0] = vs_indices_to_physics_table[p_indices_read[3 * i + 2]];
-				bt_triangles.write[3 * i + 1] = vs_indices_to_physics_table[p_indices_read[3 * i + 1]];
-				bt_triangles.write[3 * i + 2] = vs_indices_to_physics_table[p_indices_read[3 * i + 0]];
+				bt_triangles[3 * i + 0] = vs_indices_to_physics_table[p_indices_read[3 * i + 2]];
+				bt_triangles[3 * i + 1] = vs_indices_to_physics_table[p_indices_read[3 * i + 1]];
+				bt_triangles[3 * i + 2] = vs_indices_to_physics_table[p_indices_read[3 * i + 0]];
 			}
 		}
 

--- a/modules/bullet/soft_body_bullet.h
+++ b/modules/bullet/soft_body_bullet.h
@@ -32,7 +32,6 @@
 #define SOFT_BODY_BULLET_H
 
 #include "collision_object_bullet.h"
-#include "scene/resources/material.h" // TODO remove this please
 
 #ifdef None
 /// This is required to remove the macro None defined by x11 compiler because this word "None" is used internally by Bullet
@@ -58,7 +57,7 @@
 class SoftBodyBullet : public CollisionObjectBullet {
 private:
 	btSoftBody *bt_soft_body = nullptr;
-	Vector<Vector<int>> indices_table;
+	LocalVector<Vector<int>> indices_table;
 	btSoftBody::Material *mat0; // This is just a copy of pointer managed by btSoftBody
 	bool isScratched = false;
 
@@ -73,7 +72,7 @@ private:
 	real_t pose_matching_coefficient = 0.; // [0,1]
 	real_t damping_coefficient = 0.01; // [0,1]
 	real_t drag_coefficient = 0.; // [0,1]
-	Vector<int> pinned_nodes;
+	LocalVector<int> pinned_nodes;
 
 	// Other property to add
 	//btScalar				kVC;			// Volume conversation coefficient [0,+inf]
@@ -87,15 +86,14 @@ public:
 	SoftBodyBullet();
 	~SoftBodyBullet();
 
-	virtual void do_reload_body();
-	virtual void set_space(SpaceBullet *p_space);
+	virtual void do_reload_body() override;
+	virtual void set_space(SpaceBullet *p_space) override;
 
-	virtual void dispatch_callbacks() {}
-	virtual void on_collision_filters_change() {}
-	virtual void on_collision_checker_start() {}
-	virtual void on_collision_checker_end() {}
-	virtual void on_enter_area(AreaBullet *p_area);
-	virtual void on_exit_area(AreaBullet *p_area);
+	virtual void do_reload_collision_filters() override {}
+	virtual void on_collision_checker_start() override {}
+	virtual void on_collision_checker_end() override {}
+	virtual void on_enter_area(AreaBullet *p_area) override;
+	virtual void on_exit_area(AreaBullet *p_area) override;
 
 	_FORCE_INLINE_ btSoftBody *get_bt_soft_body() const { return bt_soft_body; }
 

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -31,8 +31,8 @@
 #ifndef SPACE_BULLET_H
 #define SPACE_BULLET_H
 
+#include "core/local_vector.h"
 #include "core/variant.h"
-#include "core/vector.h"
 #include "godot_result_callbacks.h"
 #include "rid_bullet.h"
 #include "servers/physics_server_3d.h"
@@ -110,16 +110,22 @@ class SpaceBullet : public RIDBullet {
 	real_t linear_damp = 0.0;
 	real_t angular_damp = 0.0;
 
-	Vector<CollisionObjectBullet *> collision_objects;
-	Vector<AreaBullet *> areas;
+	LocalVector<CollisionObjectBullet *> queue_pre_flush;
+	LocalVector<CollisionObjectBullet *> queue_flush;
+	LocalVector<CollisionObjectBullet *> collision_objects;
+	LocalVector<AreaBullet *> areas;
 
-	Vector<Vector3> contactDebug;
-	int contactDebugCount = 0;
+	LocalVector<Vector3> contactDebug;
+	uint32_t contactDebugCount = 0;
 	real_t delta_time = 0.;
 
 public:
 	SpaceBullet();
 	virtual ~SpaceBullet();
+
+	void add_to_flush_queue(CollisionObjectBullet *p_co);
+	void add_to_pre_flush_queue(CollisionObjectBullet *p_co);
+	void remove_from_any_queue(CollisionObjectBullet *p_co);
 
 	void flush_queries();
 	real_t get_delta_time() { return delta_time; }
@@ -177,7 +183,7 @@ public:
 	}
 	_FORCE_INLINE_ void add_debug_contact(const Vector3 &p_contact) {
 		if (contactDebugCount < contactDebug.size()) {
-			contactDebug.write[contactDebugCount++] = p_contact;
+			contactDebug[contactDebugCount++] = p_contact;
 		}
 	}
 	_FORCE_INLINE_ Vector<Vector3> get_debug_contacts() { return contactDebug; }


### PR DESCRIPTION
- Improved flush algorithm, so now when a RigidBody goes into sleeping mode, it's flush is not executed (as should have be).
- Added pre flush list, used by areas, so their notifications arrives to RigidBody before those get flushed.
- Make sure to correctly fetch gravity when the integrate_forces function is used
- Lazy reload body when layer and mask changes
- Shapes are reloaded just before the physics step starts.
- Improved some other parts of the code.
- Removed `std::vector` and `Vector` in favour of the recently added `LocalVector`.

Check this PR: https://github.com/godotengine/godot/pull/40186
Improves this: https://github.com/godotengine/godot/issues/40127

Fixes #40508
Fixes #40311
Fixes #40506