### PR TITLE
Expand env vars for `custom_modules` build option

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -217,14 +217,15 @@ void unregister_module_types() {
 def convert_custom_modules_path(path):
     if not path:
         return path
+    path = os.path.realpath(os.path.expanduser(os.path.expandvars(path)))
     err_msg = "Build option 'custom_modules' must %s"
     if not os.path.isdir(path):
         raise ValueError(err_msg % "point to an existing directory.")
-    if os.path.realpath(path) == os.path.realpath("modules"):
+    if path == os.path.realpath("modules"):
         raise ValueError(err_msg % "be a directory other than built-in `modules` directory.")
     if is_module(path):
         raise ValueError(err_msg % "point to a directory with modules, not a single module.")
-    return os.path.realpath(os.path.expanduser(path))
+    return path
 
 
 def disable_module(self):


### PR DESCRIPTION
Closes godotengine/godot-proposals#1178.

The order of conversion is also changed to ensure that the resulting path can be properly validated later on.

I tried hard to prevent the auto-expand in the shell to test this (Windows `cmd`):

1. Set `SCONSFLAGS` to `custom_modules=%MY_PROJECT_PATH%/modules` outside the shell.
2. `set MY_PROJECT_PATH=C:/path/to/project`
3. `scons` (should compile the engine with custom modules by expanding the variables in `SCONSFLAGS`, namely: `custom_modules=C:/path/to/project/modules`).

Before this PR, it would just throw `ValueError` denoting that the path must point to an existing directory (because of not expanded vars).