### PR TITLE
[macOS, Mono] Fix "Wdeprecated-declarations" build error.

### DIFF
--- a/modules/mono/utils/osx_utils.cpp
+++ b/modules/mono/utils/osx_utils.cpp
@@ -38,24 +38,21 @@
 #include <CoreServices/CoreServices.h>
 
 bool osx_is_app_bundle_installed(const String &p_bundle_id) {
-	CFURLRef app_url = nullptr;
 	CFStringRef bundle_id = CFStringCreateWithCString(nullptr, p_bundle_id.utf8(), kCFStringEncodingUTF8);
-	OSStatus result = LSFindApplicationForInfo(kLSUnknownCreator, bundle_id, nullptr, nullptr, &app_url);
+	CFArrayRef result = LSCopyApplicationURLsForBundleIdentifier(bundle_id, nullptr);
 	CFRelease(bundle_id);
 
-	if (app_url)
-		CFRelease(app_url);
-
-	switch (result) {
-		case noErr:
+	if (result) {
+		if (CFArrayGetCount(result) > 0) {
+			CFRelease(result);
 			return true;
-		case kLSApplicationNotFoundErr:
-			break;
-		default:
-			break;
+		} else {
+			CFRelease(result);
+			return false;
+		}
+	} else {
+		return false;
 	}
-
-	return false;
 }
 
 #endif


### PR DESCRIPTION
Fixes API deprecation error:

```
modules/mono/utils/osx_utils.cpp:43:20: error: 'LSFindApplicationForInfo' is deprecated: first deprecated in macOS 10.10 - Use
      LSCopyApplicationURLsForBundleIdentifier instead. [-Werror,-Wdeprecated-declarations]
        OSStatus result = LSFindApplicationForInfo(kLSUnknownCreator, bundle_id, nullptr, nullptr, &app_url);
                          ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Headers/LSInfoDeprecated.h:765:1: note:
      'LSFindApplicationForInfo' has been explicitly marked deprecated here
LSFindApplicationForInfo(
^
1 error generated.
```

Note: Tested to build with following command (see #40259):
```
scons p=osx target=release_debug tools=yes module_mono_enabled=yes mono_glue=yes -j4 CXXFLAGS="-Wno-inconsistent-missing-override"
``` 

Note: Should not be cherry-picked to 3.2, since it targets 10.9 as min version, old API is still available in current macOS.

Fixes #37567.