### PR TITLE
Clarify the node parameters in `Node.add_child_below_node()` docs

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -147,7 +147,7 @@
 			<argument index="2" name="legible_unique_name" type="bool" default="false">
 			</argument>
 			<description>
-				Adds a child node. The child is placed below the given node in the list of children.
+				Adds [code]child_node[/code] as a child. The child is placed below the given [code]node[/code] in the list of children.
 				If [code]legible_unique_name[/code] is [code]true[/code], the child node will have an human-readable name based on the name of the node being instanced instead of its type.
 			</description>
 		</method>


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-docs/issues/3769.

**Note:** This method was removed in favor of `Node.add_sibling()` in `master`, which is why I opened this PR against the `3.2` branch.