### PR TITLE
Document support for normal and specular maps in AnimatedSprite2D

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Animations are created using a [SpriteFrames] resource, which can be configured in the editor via the SpriteFrames panel.
+		[b]Note:[/b] You can associate a set of normal or specular maps by creating additional [SpriteFrames] resources with a [code]_normal[/code] or [code]_specular[/code] suffix. For example, having 3 [SpriteFrames] resources [code]run[/code], [code]run_normal[/code], and [code]run_specular[/code] will make it so the [code]run[/code] animation uses normal and specular maps.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Sprite frame library for [AnimatedSprite2D]. Contains frames and animation data for playback.
+		[b]Note:[/b] You can associate a set of normal or specular maps by creating additional [SpriteFrames] resources with a [code]_normal[/code] or [code]_specular[/code] suffix. For example, having 3 [SpriteFrames] resources [code]run[/code], [code]run_normal[/code], and [code]run_specular[/code] will make it so the [code]run[/code] animation uses normal and specular maps.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
This closes #38509.

I duplicated the note in both AnimatedSprite2D and SpriteFrames, but I'm not sure if we actually need to do this. It might be worth keeping this only in AnimatedSprite2D.

**Note:** When cherry-picking this PR to the `3.2` branch, make sure to remove the reference to specular maps as only the `master` branch supports those.