### PR TITLE
Extract remaining tabs from the ProjectSettingsEditor

### DIFF
--- a/editor/input_map_editor.cpp
+++ b/editor/input_map_editor.cpp
@@ -1,0 +1,1048 @@
+/*************************************************************************/
+/*  input_map_editor.cpp                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "input_map_editor.h"
+
+#include "core/input/input_map.h"
+#include "core/os/keyboard.h"
+#include "editor/editor_node.h"
+#include "editor/editor_scale.h"
+
+static const char *_button_descriptions[JOY_SDL_BUTTONS] = {
+	"Face Bottom, DualShock Cross, Xbox A, Nintendo B",
+	"Face Right, DualShock Circle, Xbox B, Nintendo A",
+	"Face Left, DualShock Square, Xbox X, Nintendo Y",
+	"Face Top, DualShock Triangle, Xbox Y, Nintendo X",
+	"DualShock Select, Xbox Back, Nintendo -",
+	"Home, DualShock PS, Guide",
+	"Start, Nintendo +",
+	"Left Stick, DualShock L3, Xbox L/LS",
+	"Right Stick, DualShock R3, Xbox R/RS",
+	"Left Shoulder, DualShock L1, Xbox LB",
+	"Right Shoulder, DualShock R1, Xbox RB",
+	"D-Pad Up",
+	"D-Pad Down",
+	"D-Pad Left",
+	"D-Pad Right"
+};
+
+static const char *_axis_descriptions[JOY_AXIS_MAX * 2] = {
+	"Left Stick Left",
+	"Left Stick Right",
+	"Left Stick Up",
+	"Left Stick Down",
+	"Right Stick Left",
+	"Right Stick Right",
+	"Right Stick Up",
+	"Right Stick Down",
+	"Joystick 2 Left",
+	"Joystick 2 Right, Left Trigger, L2, LT",
+	"Joystick 2 Up",
+	"Joystick 2 Down, Right Trigger, R2, RT",
+	"Joystick 3 Left",
+	"Joystick 3 Right",
+	"Joystick 3 Up",
+	"Joystick 3 Down",
+	"Joystick 4 Left",
+	"Joystick 4 Right",
+	"Joystick 4 Up",
+	"Joystick 4 Down",
+};
+
+void InputMapEditor::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			action_add_error->add_theme_color_override("font_color", input_editor->get_theme_color("error_color", "Editor"));
+			popup_add->add_icon_item(input_editor->get_theme_icon("Keyboard", "EditorIcons"), TTR("Key"), INPUT_KEY);
+			popup_add->add_icon_item(input_editor->get_theme_icon("KeyboardPhysical", "EditorIcons"), TTR("Physical Key"), INPUT_KEY_PHYSICAL);
+			popup_add->add_icon_item(input_editor->get_theme_icon("JoyButton", "EditorIcons"), TTR("Joy Button"), INPUT_JOY_BUTTON);
+			popup_add->add_icon_item(input_editor->get_theme_icon("JoyAxis", "EditorIcons"), TTR("Joy Axis"), INPUT_JOY_MOTION);
+			popup_add->add_icon_item(input_editor->get_theme_icon("Mouse", "EditorIcons"), TTR("Mouse Button"), INPUT_MOUSE_BUTTON);
+			_update_actions();
+		} break;
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			action_add_error->add_theme_color_override("font_color", input_editor->get_theme_color("error_color", "Editor"));
+			popup_add->set_item_icon(popup_add->get_item_index(INPUT_KEY), input_editor->get_theme_icon("Keyboard", "EditorIcons"));
+			popup_add->set_item_icon(popup_add->get_item_index(INPUT_KEY_PHYSICAL), input_editor->get_theme_icon("KeyboardPhysical", "EditorIcons"));
+			popup_add->set_item_icon(popup_add->get_item_index(INPUT_JOY_BUTTON), input_editor->get_theme_icon("JoyButton", "EditorIcons"));
+			popup_add->set_item_icon(popup_add->get_item_index(INPUT_JOY_MOTION), input_editor->get_theme_icon("JoyAxis", "EditorIcons"));
+			popup_add->set_item_icon(popup_add->get_item_index(INPUT_MOUSE_BUTTON), input_editor->get_theme_icon("Mouse", "EditorIcons"));
+			_update_actions();
+		} break;
+	}
+}
+
+static bool _validate_action_name(const String &p_name) {
+	const CharType *cstr = p_name.c_str();
+	for (int i = 0; cstr[i]; i++) {
+		if (cstr[i] == '/' || cstr[i] == ':' || cstr[i] == '"' ||
+				cstr[i] == '=' || cstr[i] == '\\' || cstr[i] < 32) {
+			return false;
+		}
+	}
+	return true;
+}
+
+void InputMapEditor::_action_selected() {
+	TreeItem *ti = input_editor->get_selected();
+	if (!ti || !ti->is_editable(0)) {
+		return;
+	}
+
+	add_at = "input/" + ti->get_text(0);
+	edit_idx = -1;
+}
+
+void InputMapEditor::_action_edited() {
+	TreeItem *ti = input_editor->get_selected();
+	if (!ti) {
+		return;
+	}
+
+	if (input_editor->get_selected_column() == 0) {
+		String new_name = ti->get_text(0);
+		String old_name = add_at.substr(add_at.find("/") + 1, add_at.length());
+
+		if (new_name == old_name) {
+			return;
+		}
+
+		if (new_name == "" || !_validate_action_name(new_name)) {
+			ti->set_text(0, old_name);
+			add_at = "input/" + old_name;
+
+			message->set_text(TTR("Invalid action name. it cannot be empty nor contain '/', ':', '=', '\\' or '\"'"));
+			message->popup_centered(Size2(300, 100) * EDSCALE);
+			return;
+		}
+
+		String action_prop = "input/" + new_name;
+
+		if (ProjectSettings::get_singleton()->has_setting(action_prop)) {
+			ti->set_text(0, old_name);
+			add_at = "input/" + old_name;
+
+			message->set_text(vformat(TTR("An action with the name '%s' already exists."), new_name));
+			message->popup_centered(Size2(300, 100) * EDSCALE);
+			return;
+		}
+
+		int order = ProjectSettings::get_singleton()->get_order(add_at);
+		Dictionary action = ProjectSettings::get_singleton()->get(add_at);
+
+		setting = true;
+		undo_redo->create_action(TTR("Rename Input Action Event"));
+		undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", add_at);
+		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", action_prop, action);
+		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", action_prop, order);
+		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", action_prop);
+		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", add_at, action);
+		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", add_at, order);
+		undo_redo->add_do_method(this, "_update_actions");
+		undo_redo->add_undo_method(this, "_update_actions");
+		undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
+		undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+		undo_redo->commit_action();
+		setting = false;
+
+		add_at = action_prop;
+	} else if (input_editor->get_selected_column() == 1) {
+		String name = "input/" + ti->get_text(0);
+		Dictionary old_action = ProjectSettings::get_singleton()->get(name);
+		Dictionary new_action = old_action.duplicate();
+		new_action["deadzone"] = ti->get_range(1);
+
+		undo_redo->create_action(TTR("Change Action deadzone"));
+		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, new_action);
+		undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
+		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_action);
+		undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+		undo_redo->commit_action();
+	}
+}
+
+void InputMapEditor::_device_input_add() {
+	Ref<InputEvent> ie;
+	String name = add_at;
+	int idx = edit_idx;
+	Dictionary old_val = ProjectSettings::get_singleton()->get(name);
+	Dictionary action = old_val.duplicate();
+	Array events = action["events"];
+
+	switch (add_type) {
+		case INPUT_MOUSE_BUTTON: {
+			Ref<InputEventMouseButton> mb;
+			mb.instance();
+			mb->set_button_index(device_index->get_selected() + 1);
+			mb->set_device(_get_current_device());
+
+			for (int i = 0; i < events.size(); i++) {
+				Ref<InputEventMouseButton> aie = events[i];
+				if (aie.is_null()) {
+					continue;
+				}
+				if (aie->get_device() == mb->get_device() && aie->get_button_index() == mb->get_button_index()) {
+					return;
+				}
+			}
+
+			ie = mb;
+
+		} break;
+		case INPUT_JOY_MOTION: {
+			Ref<InputEventJoypadMotion> jm;
+			jm.instance();
+			jm->set_axis(device_index->get_selected() >> 1);
+			jm->set_axis_value((device_index->get_selected() & 1) ? 1 : -1);
+			jm->set_device(_get_current_device());
+
+			for (int i = 0; i < events.size(); i++) {
+				Ref<InputEventJoypadMotion> aie = events[i];
+				if (aie.is_null()) {
+					continue;
+				}
+
+				if (aie->get_device() == jm->get_device() && aie->get_axis() == jm->get_axis() && aie->get_axis_value() == jm->get_axis_value()) {
+					return;
+				}
+			}
+
+			ie = jm;
+
+		} break;
+		case INPUT_JOY_BUTTON: {
+			Ref<InputEventJoypadButton> jb;
+			jb.instance();
+
+			jb->set_button_index(device_index->get_selected());
+			jb->set_device(_get_current_device());
+
+			for (int i = 0; i < events.size(); i++) {
+				Ref<InputEventJoypadButton> aie = events[i];
+				if (aie.is_null()) {
+					continue;
+				}
+				if (aie->get_device() == jb->get_device() && aie->get_button_index() == jb->get_button_index()) {
+					return;
+				}
+			}
+			ie = jb;
+
+		} break;
+		default: {
+		}
+	}
+
+	if (idx < 0 || idx >= events.size()) {
+		events.push_back(ie);
+	} else {
+		events[idx] = ie;
+	}
+	action["events"] = events;
+
+	undo_redo->create_action(TTR("Add Input Action Event"));
+	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
+	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
+	undo_redo->add_do_method(this, "_update_actions");
+	undo_redo->add_undo_method(this, "_update_actions");
+	undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
+	undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+	undo_redo->commit_action();
+
+	_show_last_added(ie, name);
+}
+
+void InputMapEditor::_set_current_device(int i_device) {
+	device_id->select(i_device + 1);
+}
+
+int InputMapEditor::_get_current_device() {
+	return device_id->get_selected() - 1;
+}
+
+String InputMapEditor::_get_device_string(int i_device) {
+	if (i_device == InputMap::ALL_DEVICES) {
+		return TTR("All Devices");
+	}
+	return TTR("Device") + " " + itos(i_device);
+}
+
+void InputMapEditor::_press_a_key_confirm() {
+	if (last_wait_for_key.is_null()) {
+		return;
+	}
+
+	Ref<InputEventKey> ie;
+	ie.instance();
+	if (press_a_key_physical) {
+		ie->set_physical_keycode(last_wait_for_key->get_physical_keycode());
+		ie->set_keycode(0);
+	} else {
+		ie->set_physical_keycode(0);
+		ie->set_keycode(last_wait_for_key->get_keycode());
+	}
+	ie->set_shift(last_wait_for_key->get_shift());
+	ie->set_alt(last_wait_for_key->get_alt());
+	ie->set_control(last_wait_for_key->get_control());
+	ie->set_metakey(last_wait_for_key->get_metakey());
+
+	String name = add_at;
+	int idx = edit_idx;
+
+	Dictionary old_val = ProjectSettings::get_singleton()->get(name);
+	Dictionary action = old_val.duplicate();
+	Array events = action["events"];
+
+	for (int i = 0; i < events.size(); i++) {
+		Ref<InputEventKey> aie = events[i];
+		if (aie.is_null()) {
+			continue;
+		}
+		if (!press_a_key_physical) {
+			if (aie->get_keycode_with_modifiers() == ie->get_keycode_with_modifiers()) {
+				return;
+			}
+		} else {
+			if (aie->get_physical_keycode_with_modifiers() == ie->get_physical_keycode_with_modifiers()) {
+				return;
+			}
+		}
+	}
+
+	if (idx < 0 || idx >= events.size()) {
+		events.push_back(ie);
+	} else {
+		events[idx] = ie;
+	}
+	action["events"] = events;
+
+	undo_redo->create_action(TTR("Add Input Action Event"));
+	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
+	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
+	undo_redo->add_do_method(this, "_update_actions");
+	undo_redo->add_undo_method(this, "_update_actions");
+	undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
+	undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+	undo_redo->commit_action();
+
+	_show_last_added(ie, name);
+}
+
+void InputMapEditor::_show_last_added(const Ref<InputEvent> &p_event, const String &p_name) {
+	TreeItem *r = input_editor->get_root();
+
+	String name = p_name;
+	name.erase(0, 6);
+	if (!r) {
+		return;
+	}
+	r = r->get_children();
+	if (!r) {
+		return;
+	}
+	bool found = false;
+	while (r) {
+		if (r->get_text(0) != name) {
+			r = r->get_next();
+			continue;
+		}
+		TreeItem *child = r->get_children();
+		while (child) {
+			Variant input = child->get_meta("__input");
+			if (p_event == input) {
+				r->set_collapsed(false);
+				child->select(0);
+				found = true;
+				break;
+			}
+			child = child->get_next();
+		}
+		if (found) {
+			break;
+		}
+		r = r->get_next();
+	}
+
+	if (found) {
+		input_editor->ensure_cursor_is_visible();
+	}
+}
+
+void InputMapEditor::_wait_for_key(const Ref<InputEvent> &p_event) {
+	Ref<InputEventKey> k = p_event;
+
+	if (k.is_valid() && k->is_pressed() && k->get_keycode() != 0) {
+		last_wait_for_key = p_event;
+		const String str = (press_a_key_physical) ? keycode_get_string(k->get_physical_keycode_with_modifiers()) + TTR(" (Physical)") : keycode_get_string(k->get_keycode_with_modifiers());
+
+		press_a_key_label->set_text(str);
+		press_a_key->get_ok()->set_disabled(false);
+		press_a_key->set_input_as_handled();
+	}
+}
+
+void InputMapEditor::_edit_item(Ref<InputEvent> p_exiting_event) {
+	InputType ie_type;
+
+	if ((Ref<InputEventKey>(p_exiting_event)).is_valid()) {
+		if ((Ref<InputEventKey>(p_exiting_event))->get_keycode() != 0) {
+			ie_type = INPUT_KEY;
+		} else {
+			ie_type = INPUT_KEY_PHYSICAL;
+		}
+	} else if ((Ref<InputEventJoypadButton>(p_exiting_event)).is_valid()) {
+		ie_type = INPUT_JOY_BUTTON;
+	} else if ((Ref<InputEventMouseButton>(p_exiting_event)).is_valid()) {
+		ie_type = INPUT_MOUSE_BUTTON;
+	} else if ((Ref<InputEventJoypadMotion>(p_exiting_event)).is_valid()) {
+		ie_type = INPUT_JOY_MOTION;
+	} else {
+		return;
+	}
+
+	_add_item(ie_type, p_exiting_event);
+}
+
+void InputMapEditor::_add_item(int p_item, Ref<InputEvent> p_exiting_event) {
+	add_type = InputType(p_item);
+
+	switch (add_type) {
+		case INPUT_KEY: {
+			press_a_key_physical = false;
+			press_a_key_label->set_text(TTR("Press a Key..."));
+			press_a_key->get_ok()->set_disabled(true);
+			last_wait_for_key = Ref<InputEvent>();
+			press_a_key->popup_centered(Size2(250, 80) * EDSCALE);
+			//press_a_key->grab_focus();
+
+		} break;
+		case INPUT_KEY_PHYSICAL: {
+			press_a_key_physical = true;
+			press_a_key_label->set_text(TTR("Press a Key..."));
+
+			last_wait_for_key = Ref<InputEvent>();
+			press_a_key->popup_centered(Size2(250, 80) * EDSCALE);
+			press_a_key->grab_focus();
+
+		} break;
+		case INPUT_MOUSE_BUTTON: {
+			device_index_label->set_text(TTR("Mouse Button Index:"));
+			device_index->clear();
+			device_index->add_item(TTR("Left Button"));
+			device_index->add_item(TTR("Right Button"));
+			device_index->add_item(TTR("Middle Button"));
+			device_index->add_item(TTR("Wheel Up Button"));
+			device_index->add_item(TTR("Wheel Down Button"));
+			device_index->add_item(TTR("Wheel Left Button"));
+			device_index->add_item(TTR("Wheel Right Button"));
+			device_index->add_item(TTR("X Button 1"));
+			device_index->add_item(TTR("X Button 2"));
+			device_input->popup_centered(Size2(350, 95) * EDSCALE);
+
+			Ref<InputEventMouseButton> mb = p_exiting_event;
+			if (mb.is_valid()) {
+				device_index->select(mb->get_button_index() - 1);
+				_set_current_device(mb->get_device());
+				device_input->get_ok()->set_text(TTR("Change"));
+			} else {
+				_set_current_device(0);
+				device_input->get_ok()->set_text(TTR("Add"));
+			}
+
+		} break;
+		case INPUT_JOY_MOTION: {
+			device_index_label->set_text(TTR("Joypad Axis Index:"));
+			device_index->clear();
+			for (int i = 0; i < JOY_AXIS_MAX * 2; i++) {
+				String desc = TTR("Axis") + " " + itos(i / 2) + " " + ((i & 1) ? "+" : "-") +
+							  " (" + TTR(_axis_descriptions[i]) + ")";
+				device_index->add_item(desc);
+			}
+			device_input->popup_centered(Size2(350, 95) * EDSCALE);
+
+			Ref<InputEventJoypadMotion> jm = p_exiting_event;
+			if (jm.is_valid()) {
+				device_index->select(jm->get_axis() * 2 + (jm->get_axis_value() > 0 ? 1 : 0));
+				_set_current_device(jm->get_device());
+				device_input->get_ok()->set_text(TTR("Change"));
+			} else {
+				_set_current_device(0);
+				device_input->get_ok()->set_text(TTR("Add"));
+			}
+
+		} break;
+		case INPUT_JOY_BUTTON: {
+			device_index_label->set_text(TTR("Joypad Button Index:"));
+			device_index->clear();
+			for (int i = 0; i < JOY_BUTTON_MAX; i++) {
+				String desc = TTR("Button") + " " + itos(i);
+				if (i < JOY_SDL_BUTTONS) {
+					desc += " (" + TTR(_button_descriptions[i]) + ")";
+				}
+				device_index->add_item(desc);
+			}
+			device_input->popup_centered(Size2(350, 95) * EDSCALE);
+
+			Ref<InputEventJoypadButton> jb = p_exiting_event;
+			if (jb.is_valid()) {
+				device_index->select(jb->get_button_index());
+				_set_current_device(jb->get_device());
+				device_input->get_ok()->set_text(TTR("Change"));
+			} else {
+				_set_current_device(0);
+				device_input->get_ok()->set_text(TTR("Add"));
+			}
+
+		} break;
+		default: {
+		}
+	}
+}
+
+void InputMapEditor::_action_activated() {
+	TreeItem *ti = input_editor->get_selected();
+
+	if (!ti || ti->get_parent() == input_editor->get_root()) {
+		return;
+	}
+
+	String name = "input/" + ti->get_parent()->get_text(0);
+	Dictionary action = ProjectSettings::get_singleton()->get(name);
+	Array events = action["events"];
+	int idx = ti->get_metadata(0);
+
+	ERR_FAIL_INDEX(idx, events.size());
+	Ref<InputEvent> event = events[idx];
+	if (event.is_null()) {
+		return;
+	}
+
+	add_at = name;
+	edit_idx = idx;
+	_edit_item(event);
+}
+
+void InputMapEditor::_action_button_pressed(Object *p_obj, int p_column, int p_id) {
+	TreeItem *ti = Object::cast_to<TreeItem>(p_obj);
+
+	ERR_FAIL_COND(!ti);
+
+	if (p_id == 1) {
+		// Add action event
+		Point2 ofs = input_editor->get_global_position();
+		Rect2 ir = input_editor->get_item_rect(ti);
+		ir.position.y -= input_editor->get_scroll().y;
+		ofs += ir.position + ir.size;
+		ofs.x -= 100;
+		popup_add->set_position(ofs);
+		popup_add->popup();
+		add_at = "input/" + ti->get_text(0);
+		edit_idx = -1;
+
+	} else if (p_id == 2) {
+		// Remove
+
+		if (ti->get_parent() == input_editor->get_root()) {
+			// Remove action
+			String name = "input/" + ti->get_text(0);
+			Dictionary old_val = ProjectSettings::get_singleton()->get(name);
+			int order = ProjectSettings::get_singleton()->get_order(name);
+
+			undo_redo->create_action(TTR("Erase Input Action"));
+			undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", name);
+			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
+			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", name, order);
+			undo_redo->add_do_method(this, "_update_actions");
+			undo_redo->add_undo_method(this, "_update_actions");
+			undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
+			undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+			undo_redo->commit_action();
+
+		} else {
+			// Remove action event
+			String name = "input/" + ti->get_parent()->get_text(0);
+			Dictionary old_val = ProjectSettings::get_singleton()->get(name);
+			Dictionary action = old_val.duplicate();
+			int idx = ti->get_metadata(0);
+
+			Array events = action["events"];
+			ERR_FAIL_INDEX(idx, events.size());
+			events.remove(idx);
+			action["events"] = events;
+
+			undo_redo->create_action(TTR("Erase Input Action Event"));
+			undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
+			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
+			undo_redo->add_do_method(this, "_update_actions");
+			undo_redo->add_undo_method(this, "_update_actions");
+			undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
+			undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+			undo_redo->commit_action();
+		}
+	} else if (p_id == 3) {
+		// Edit
+
+		if (ti->get_parent() == input_editor->get_root()) {
+			// Edit action name
+			ti->set_as_cursor(0);
+			input_editor->edit_selected();
+
+		} else {
+			// Edit action event
+			String name = "input/" + ti->get_parent()->get_text(0);
+			int idx = ti->get_metadata(0);
+			Dictionary action = ProjectSettings::get_singleton()->get(name);
+
+			Array events = action["events"];
+			ERR_FAIL_INDEX(idx, events.size());
+
+			Ref<InputEvent> event = events[idx];
+
+			if (event.is_null()) {
+				return;
+			}
+
+			ti->set_as_cursor(0);
+			add_at = name;
+			edit_idx = idx;
+			_edit_item(event);
+		}
+	}
+}
+
+void InputMapEditor::_update_actions() {
+	if (setting) {
+		return;
+	}
+
+	Map<String, bool> collapsed;
+
+	if (input_editor->get_root() && input_editor->get_root()->get_children()) {
+		for (TreeItem *item = input_editor->get_root()->get_children(); item; item = item->get_next()) {
+			collapsed[item->get_text(0)] = item->is_collapsed();
+		}
+	}
+
+	input_editor->clear();
+	TreeItem *root = input_editor->create_item();
+	input_editor->set_hide_root(true);
+
+	List<PropertyInfo> props;
+	ProjectSettings::get_singleton()->get_property_list(&props);
+	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
+		const String property_name = E->get().name;
+
+		if (!property_name.begins_with("input/")) {
+			continue;
+		}
+
+		const String name = property_name.get_slice("/", 1);
+
+		TreeItem *item = input_editor->create_item(root);
+		item->set_text(0, name);
+		item->set_custom_bg_color(0, input_editor->get_theme_color("prop_subsection", "Editor"));
+		if (collapsed.has(name)) {
+			item->set_collapsed(collapsed[name]);
+		}
+
+		item->set_editable(1, true);
+		item->set_cell_mode(1, TreeItem::CELL_MODE_RANGE);
+		item->set_range_config(1, 0.0, 1.0, 0.01);
+
+		item->set_custom_bg_color(1, input_editor->get_theme_color("prop_subsection", "Editor"));
+
+		const bool is_builtin_input = ProjectSettings::get_singleton()->get_input_presets().find(property_name) != nullptr;
+		const String tooltip_remove = is_builtin_input ? TTR("Built-in actions can't be removed as they're used for UI navigation.") : TTR("Remove");
+		item->add_button(2, input_editor->get_theme_icon("Add", "EditorIcons"), 1, false, TTR("Add Event"));
+		item->add_button(2, input_editor->get_theme_icon("Remove", "EditorIcons"), 2, false, tooltip_remove);
+
+		if (is_builtin_input) {
+			item->set_button_disabled(2, 1, true);
+		} else {
+			item->set_editable(0, true);
+		}
+
+		Dictionary action = ProjectSettings::get_singleton()->get(property_name);
+		Array events = action["events"];
+		item->set_range(1, action["deadzone"]);
+
+		for (int i = 0; i < events.size(); i++) {
+			Ref<InputEvent> event = events[i];
+			if (event.is_null()) {
+				continue;
+			}
+
+			TreeItem *action2 = input_editor->create_item(item);
+
+			Ref<InputEventKey> k = event;
+			if (k.is_valid()) {
+				if (k->get_keycode() != 0) {
+					action2->set_text(0, keycode_get_string(k->get_keycode_with_modifiers()));
+					action2->set_icon(0, input_editor->get_theme_icon("Keyboard", "EditorIcons"));
+				} else {
+					action2->set_text(0, keycode_get_string(k->get_physical_keycode_with_modifiers()) + TTR(" (Physical)"));
+					action2->set_icon(0, input_editor->get_theme_icon("KeyboardPhysical", "EditorIcons"));
+				}
+			}
+
+			Ref<InputEventJoypadButton> jb = event;
+			if (jb.is_valid()) {
+				const int idx = jb->get_button_index();
+				String str = _get_device_string(jb->get_device()) + ", " +
+							 TTR("Button") + " " + itos(idx);
+				if (idx >= 0 && idx < JOY_SDL_BUTTONS) {
+					str += String() + " (" + TTR(_button_descriptions[jb->get_button_index()]) + ")";
+				}
+
+				action2->set_text(0, str);
+				action2->set_icon(0, input_editor->get_theme_icon("JoyButton", "EditorIcons"));
+			}
+
+			Ref<InputEventMouseButton> mb = event;
+			if (mb.is_valid()) {
+				String str = _get_device_string(mb->get_device()) + ", ";
+				switch (mb->get_button_index()) {
+					case BUTTON_LEFT:
+						str += TTR("Left Button");
+						break;
+					case BUTTON_RIGHT:
+						str += TTR("Right Button");
+						break;
+					case BUTTON_MIDDLE:
+						str += TTR("Middle Button");
+						break;
+					case BUTTON_WHEEL_UP:
+						str += TTR("Wheel Up");
+						break;
+					case BUTTON_WHEEL_DOWN:
+						str += TTR("Wheel Down");
+						break;
+					default:
+						str += vformat(TTR("%d Button"), mb->get_button_index());
+				}
+
+				action2->set_text(0, str);
+				action2->set_icon(0, input_editor->get_theme_icon("Mouse", "EditorIcons"));
+			}
+
+			Ref<InputEventJoypadMotion> jm = event;
+			if (jm.is_valid()) {
+				int ax = jm->get_axis();
+				int n = 2 * ax + (jm->get_axis_value() < 0 ? 0 : 1);
+				String str = _get_device_string(jm->get_device()) + ", " +
+							 TTR("Axis") + " " + itos(ax) + " " + (jm->get_axis_value() < 0 ? "-" : "+") +
+							 " (" + _axis_descriptions[n] + ")";
+				action2->set_text(0, str);
+				action2->set_icon(0, input_editor->get_theme_icon("JoyAxis", "EditorIcons"));
+			}
+			action2->set_metadata(0, i);
+			action2->set_meta("__input", event);
+
+			action2->add_button(2, input_editor->get_theme_icon("Edit", "EditorIcons"), 3, false, TTR("Edit"));
+			action2->add_button(2, input_editor->get_theme_icon("Remove", "EditorIcons"), 2, false, TTR("Remove"));
+			// Fade out the individual event buttons slightly to make the
+			// Add/Remove buttons stand out more.
+			action2->set_button_color(2, 0, Color(1, 1, 1, 0.75));
+			action2->set_button_color(2, 1, Color(1, 1, 1, 0.75));
+		}
+	}
+
+	_action_check(action_name->get_text());
+}
+
+void InputMapEditor::_action_check(String p_action) {
+	if (p_action == "") {
+		action_add->set_disabled(true);
+	} else {
+		if (!_validate_action_name(p_action)) {
+			action_add_error->set_text(TTR("Invalid action name. It cannot be empty nor contain '/', ':', '=', '\\' or '\"'."));
+			action_add_error->show();
+			action_add->set_disabled(true);
+			return;
+		}
+		if (ProjectSettings::get_singleton()->has_setting("input/" + p_action)) {
+			action_add_error->set_text(vformat(TTR("An action with the name '%s' already exists."), p_action));
+			action_add_error->show();
+			action_add->set_disabled(true);
+			return;
+		}
+
+		action_add->set_disabled(false);
+	}
+
+	action_add_error->hide();
+}
+
+void InputMapEditor::_action_adds(String) {
+	if (!action_add->is_disabled()) {
+		_action_add();
+	}
+}
+
+void InputMapEditor::_action_add() {
+	Dictionary action;
+	action["events"] = Array();
+	action["deadzone"] = 0.5f;
+	String name = "input/" + action_name->get_text();
+	undo_redo->create_action(TTR("Add Input Action"));
+	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
+	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", name);
+	undo_redo->add_do_method(this, "_update_actions");
+	undo_redo->add_undo_method(this, "_update_actions");
+	undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
+	undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+	undo_redo->commit_action();
+
+	TreeItem *r = input_editor->get_root();
+
+	if (!r) {
+		return;
+	}
+	r = r->get_children();
+	if (!r) {
+		return;
+	}
+	while (r->get_next()) {
+		r = r->get_next();
+	}
+
+	r->select(0);
+	input_editor->ensure_cursor_is_visible();
+	action_add_error->hide();
+	action_name->clear();
+}
+
+Variant InputMapEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
+	TreeItem *selected = input_editor->get_selected();
+	if (!selected || selected->get_parent() != input_editor->get_root()) {
+		return Variant();
+	}
+
+	String name = selected->get_text(0);
+	VBoxContainer *vb = memnew(VBoxContainer);
+	HBoxContainer *hb = memnew(HBoxContainer);
+	Label *label = memnew(Label(name));
+	hb->set_modulate(Color(1, 1, 1, 1.0f));
+	hb->add_child(label);
+	vb->add_child(hb);
+	input_editor->set_drag_preview(vb);
+
+	Dictionary drag_data;
+	drag_data["type"] = "nodes";
+
+	input_editor->set_drop_mode_flags(Tree::DROP_MODE_INBETWEEN);
+
+	return drag_data;
+}
+
+bool InputMapEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
+	Dictionary d = p_data;
+	if (!d.has("type") || d["type"] != "nodes") {
+		return false;
+	}
+
+	TreeItem *selected = input_editor->get_selected();
+	TreeItem *item = input_editor->get_item_at_position(p_point);
+	if (!selected || !item || item == selected || item->get_parent() == selected) {
+		return false;
+	}
+
+	return true;
+}
+
+void InputMapEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
+	if (!can_drop_data_fw(p_point, p_data, p_from)) {
+		return;
+	}
+
+	TreeItem *selected = input_editor->get_selected();
+	TreeItem *item = input_editor->get_item_at_position(p_point);
+	if (!item) {
+		return;
+	}
+	TreeItem *target = item->get_parent() == input_editor->get_root() ? item : item->get_parent();
+
+	String selected_name = "input/" + selected->get_text(0);
+	int old_order = ProjectSettings::get_singleton()->get_order(selected_name);
+	String target_name = "input/" + target->get_text(0);
+	int target_order = ProjectSettings::get_singleton()->get_order(target_name);
+
+	int order = old_order;
+	bool is_below = target_order > old_order;
+	TreeItem *iterator = is_below ? selected->get_next() : selected->get_prev();
+
+	undo_redo->create_action(TTR("Moved Input Action Event"));
+	while (iterator != target) {
+		String iterator_name = "input/" + iterator->get_text(0);
+		int iterator_order = ProjectSettings::get_singleton()->get_order(iterator_name);
+		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", iterator_name, order);
+		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", iterator_name, iterator_order);
+		order = iterator_order;
+		iterator = is_below ? iterator->get_next() : iterator->get_prev();
+	}
+
+	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", target_name, order);
+	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", selected_name, target_order);
+	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", target_name, target_order);
+	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", selected_name, old_order);
+
+	undo_redo->add_do_method(this, "_update_actions");
+	undo_redo->add_undo_method(this, "_update_actions");
+	undo_redo->add_do_method(this, "emit_signal", inputmap_changed);
+	undo_redo->add_undo_method(this, "emit_signal", inputmap_changed);
+	undo_redo->commit_action();
+}
+
+void InputMapEditor::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_update_actions"), &InputMapEditor::_update_actions);
+
+	ClassDB::bind_method(D_METHOD("get_drag_data_fw"), &InputMapEditor::get_drag_data_fw);
+	ClassDB::bind_method(D_METHOD("can_drop_data_fw"), &InputMapEditor::can_drop_data_fw);
+	ClassDB::bind_method(D_METHOD("drop_data_fw"), &InputMapEditor::drop_data_fw);
+
+	ADD_SIGNAL(MethodInfo("inputmap_changed"));
+}
+
+InputMapEditor::InputMapEditor() {
+	undo_redo = EditorNode::get_undo_redo();
+	press_a_key_physical = false;
+	inputmap_changed = "inputmap_changed";
+
+	VBoxContainer *vbc = memnew(VBoxContainer);
+	vbc->set_anchor_and_margin(MARGIN_TOP, Control::ANCHOR_BEGIN, 0);
+	vbc->set_anchor_and_margin(MARGIN_BOTTOM, Control::ANCHOR_END, 0);
+	vbc->set_anchor_and_margin(MARGIN_LEFT, Control::ANCHOR_BEGIN, 0);
+	vbc->set_anchor_and_margin(MARGIN_RIGHT, Control::ANCHOR_END, 0);
+	add_child(vbc);
+
+	HBoxContainer *hbc = memnew(HBoxContainer);
+	vbc->add_child(hbc);
+
+	Label *l = memnew(Label);
+	l->set_text(TTR("Action:"));
+	hbc->add_child(l);
+
+	action_name = memnew(LineEdit);
+	action_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	action_name->connect("text_entered", callable_mp(this, &InputMapEditor::_action_adds));
+	action_name->connect("text_changed", callable_mp(this, &InputMapEditor::_action_check));
+	hbc->add_child(action_name);
+
+	action_add_error = memnew(Label);
+	action_add_error->hide();
+	hbc->add_child(action_add_error);
+
+	Button *add = memnew(Button);
+	add->set_text(TTR("Add"));
+	add->set_disabled(true);
+	add->connect("pressed", callable_mp(this, &InputMapEditor::_action_add));
+	hbc->add_child(add);
+	action_add = add;
+
+	input_editor = memnew(Tree);
+	input_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	input_editor->set_columns(3);
+	input_editor->set_column_titles_visible(true);
+	input_editor->set_column_title(0, TTR("Action"));
+	input_editor->set_column_title(1, TTR("Deadzone"));
+	input_editor->set_column_expand(1, false);
+	input_editor->set_column_min_width(1, 80 * EDSCALE);
+	input_editor->set_column_expand(2, false);
+	input_editor->set_column_min_width(2, 50 * EDSCALE);
+	input_editor->connect("item_edited", callable_mp(this, &InputMapEditor::_action_edited));
+	input_editor->connect("item_activated", callable_mp(this, &InputMapEditor::_action_activated));
+	input_editor->connect("cell_selected", callable_mp(this, &InputMapEditor::_action_selected));
+	input_editor->connect("button_pressed", callable_mp(this, &InputMapEditor::_action_button_pressed));
+#ifndef _MSC_VER
+#warning need to make drag data forwarding to non controls happen
+#endif
+	//input_editor->set_drag_forwarding(this);
+	vbc->add_child(input_editor);
+
+	// Popups
+
+	popup_add = memnew(PopupMenu);
+	popup_add->connect("id_pressed", callable_mp(this, &InputMapEditor::_add_item), make_binds(Ref<InputEvent>()));
+	add_child(popup_add);
+
+	press_a_key = memnew(ConfirmationDialog);
+	press_a_key->get_ok()->set_disabled(true);
+	//press_a_key->set_focus_mode(Control::FOCUS_ALL);
+	press_a_key->connect("window_input", callable_mp(this, &InputMapEditor::_wait_for_key));
+	press_a_key->connect("confirmed", callable_mp(this, &InputMapEditor::_press_a_key_confirm));
+	add_child(press_a_key);
+
+	l = memnew(Label);
+	l->set_text(TTR("Press a Key..."));
+	l->set_anchors_and_margins_preset(Control::PRESET_WIDE);
+	l->set_align(Label::ALIGN_CENTER);
+	l->set_margin(MARGIN_TOP, 20);
+	l->set_anchor_and_margin(MARGIN_BOTTOM, Control::ANCHOR_BEGIN, 30);
+	press_a_key->add_child(l);
+	press_a_key_label = l;
+
+	device_input = memnew(ConfirmationDialog);
+	device_input->get_ok()->set_text(TTR("Add"));
+	device_input->connect("confirmed", callable_mp(this, &InputMapEditor::_device_input_add));
+	add_child(device_input);
+
+	hbc = memnew(HBoxContainer);
+	device_input->add_child(hbc);
+
+	VBoxContainer *vbc_left = memnew(VBoxContainer);
+	hbc->add_child(vbc_left);
+
+	l = memnew(Label);
+	l->set_text(TTR("Device:"));
+	vbc_left->add_child(l);
+
+	device_id = memnew(OptionButton);
+	for (int i = -1; i < 8; i++) {
+		device_id->add_item(_get_device_string(i));
+	}
+	_set_current_device(0);
+	vbc_left->add_child(device_id);
+
+	VBoxContainer *vbc_right = memnew(VBoxContainer);
+	vbc_right->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	hbc->add_child(vbc_right);
+
+	l = memnew(Label);
+	l->set_text(TTR("Index:"));
+	vbc_right->add_child(l);
+
+	device_index_label = l;
+	device_index = memnew(OptionButton);
+	device_index->set_clip_text(true);
+	vbc_right->add_child(device_index);
+
+	message = memnew(AcceptDialog);
+	add_child(message);
+}

--- a/editor/input_map_editor.h
+++ b/editor/input_map_editor.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  project_settings_editor.h                                            */
+/*  input_map_editor.h                                                   */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,22 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PROJECT_SETTINGS_EDITOR_H
-#define PROJECT_SETTINGS_EDITOR_H
+#ifndef INPUT_MAP_EDITOR_H
+#define INPUT_MAP_EDITOR_H
 
 #include "core/undo_redo.h"
 #include "editor/editor_data.h"
-#include "editor/editor_plugin_settings.h"
-#include "editor/editor_sectioned_inspector.h"
-#include "editor_autoload_settings.h"
-#include "input_map_editor.h"
-#include "localization_editor.h"
-#include "scene/gui/dialogs.h"
-#include "scene/gui/tab_container.h"
-#include "shader_globals_editor.h"
 
-class ProjectSettingsEditor : public AcceptDialog {
-	GDCLASS(ProjectSettingsEditor, AcceptDialog);
+class InputMapEditor : public Control {
+	GDCLASS(InputMapEditor, Control);
 
 	enum InputType {
 		INPUT_KEY,
@@ -53,76 +45,63 @@ class ProjectSettingsEditor : public AcceptDialog {
 		INPUT_MOUSE_BUTTON
 	};
 
-	TabContainer *tab_container;
-	AcceptDialog *message;
-	Timer *timer;
+	Tree *input_editor;
+	LineEdit *action_name;
+	Button *action_add;
+	Label *action_add_error;
 
-	HBoxContainer *search_bar;
-	Button *search_button;
-	LineEdit *search_box;
-	HBoxContainer *add_prop_bar;
-	LineEdit *category;
-	LineEdit *property;
-	OptionButton *type;
+	InputType add_type;
+	String add_at;
+	int edit_idx;
 
-	SectionedInspector *globals_editor;
-
+	PopupMenu *popup_add;
+	ConfirmationDialog *press_a_key;
+	bool press_a_key_physical;
+	Label *press_a_key_label;
+	ConfirmationDialog *device_input;
+	OptionButton *device_id;
+	OptionButton *device_index;
+	Label *device_index_label;
 	MenuButton *popup_copy_to_feature;
 
-	InputMapEditor *inputmap_editor;
-	LocalizationEditor *localization_editor;
-	EditorAutoloadSettings *autoload_settings;
-	ShaderGlobalsEditor *shaders_global_variables_editor;
-	EditorPluginSettings *plugin_settings;
+	Ref<InputEventKey> last_wait_for_key;
 
-	Label *restart_label;
-	TextureRect *restart_icon;
-	PanelContainer *restart_container;
-	Button *restart_close_button;
-
-	EditorData *data;
+	AcceptDialog *message;
 	UndoRedo *undo_redo;
+	String inputmap_changed;
+	bool setting;
 
-	void _item_selected(const String &);
-	void _item_adds(String);
-	void _item_add();
-	void _item_del();
-	void _save();
+	void _update_actions();
+	void _add_item(int p_item, Ref<InputEvent> p_exiting_event = Ref<InputEvent>());
+	void _edit_item(Ref<InputEvent> p_exiting_event);
 
-	void _settings_prop_edited(const String &p_name);
-	void _settings_changed();
+	void _action_check(String p_action);
+	void _action_adds(String);
+	void _action_add();
+	void _device_input_add();
 
-	void _copy_to_platform(int p_which);
-	void _copy_to_platform_about_to_show();
+	void _action_selected();
+	void _action_edited();
+	void _action_activated();
+	void _action_button_pressed(Object *p_obj, int p_column, int p_id);
+	void _wait_for_key(const Ref<InputEvent> &p_event);
+	void _press_a_key_confirm();
+	void _show_last_added(const Ref<InputEvent> &p_event, const String &p_name);
 
-	void _toggle_search_bar(bool p_pressed);
-
-	ProjectSettingsEditor();
-
-	static ProjectSettingsEditor *singleton;
-
-	void _editor_restart_request();
-	void _editor_restart();
-	void _editor_restart_close();
+	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
+	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
+	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
 protected:
-	void _unhandled_input(const Ref<InputEvent> &p_event);
+	int _get_current_device();
+	void _set_current_device(int i_device);
+	String _get_device_string(int i_device);
+
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
-	static ProjectSettingsEditor *get_singleton() { return singleton; }
-	void popup_project_settings();
-	void set_plugins_page();
-	void update_plugins();
-
-	EditorAutoloadSettings *get_autoload_settings() { return autoload_settings; }
-
-	TabContainer *get_tabs();
-
-	void queue_save();
-
-	ProjectSettingsEditor(EditorData *p_data);
+	InputMapEditor();
 };
 
-#endif // PROJECT_SETTINGS_EDITOR_H
+#endif // INPUT_MAP_EDITOR_H

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -1,0 +1,794 @@
+/*************************************************************************/
+/*  localization_editor.cpp                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "localization_editor.h"
+
+#include "core/translation.h"
+#include "editor_node.h"
+#include "editor_translation_parser.h"
+#include "pot_generator.h"
+#include "scene/gui/control.h"
+
+void LocalizationEditor::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		translation_list->connect("button_pressed", callable_mp(this, &LocalizationEditor::_translation_delete));
+		translation_pot_list->connect("button_pressed", callable_mp(this, &LocalizationEditor::_pot_delete));
+
+		List<String> tfn;
+		ResourceLoader::get_recognized_extensions_for_type("Translation", &tfn);
+		for (List<String>::Element *E = tfn.front(); E; E = E->next()) {
+			translation_file_open->add_filter("*." + E->get());
+		}
+
+		List<String> rfn;
+		ResourceLoader::get_recognized_extensions_for_type("Resource", &rfn);
+		for (List<String>::Element *E = rfn.front(); E; E = E->next()) {
+			translation_res_file_open_dialog->add_filter("*." + E->get());
+			translation_res_option_file_open_dialog->add_filter("*." + E->get());
+		}
+
+		_update_pot_file_extensions();
+		pot_generate_dialog->add_filter("*.pot");
+	}
+}
+
+void LocalizationEditor::add_translation(const String &p_translation) {
+	_translation_add(p_translation);
+}
+
+void LocalizationEditor::_translation_add(const String &p_path) {
+	PackedStringArray translations = ProjectSettings::get_singleton()->get("locale/translations");
+	if (translations.has(p_path)) {
+		return;
+	}
+
+	translations.push_back(p_path);
+
+	undo_redo->create_action(TTR("Add Translation"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translations", translations);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translations", ProjectSettings::get_singleton()->get("locale/translations"));
+	undo_redo->add_do_method(this, "update_translations");
+	undo_redo->add_undo_method(this, "update_translations");
+	undo_redo->add_do_method(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->commit_action();
+}
+
+void LocalizationEditor::_translation_file_open() {
+	translation_file_open->popup_centered_ratio();
+}
+
+void LocalizationEditor::_translation_delete(Object *p_item, int p_column, int p_button) {
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
+	ERR_FAIL_COND(!ti);
+
+	int idx = ti->get_metadata(0);
+
+	PackedStringArray translations = ProjectSettings::get_singleton()->get("locale/translations");
+
+	ERR_FAIL_INDEX(idx, translations.size());
+
+	translations.remove(idx);
+
+	undo_redo->create_action(TTR("Remove Translation"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translations", translations);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translations", ProjectSettings::get_singleton()->get("locale/translations"));
+	undo_redo->add_do_method(this, "update_translations");
+	undo_redo->add_undo_method(this, "update_translations");
+	undo_redo->add_do_method(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->commit_action();
+}
+
+void LocalizationEditor::_translation_res_file_open() {
+	translation_res_file_open_dialog->popup_centered_ratio();
+}
+
+void LocalizationEditor::_translation_res_add(const String &p_path) {
+	Variant prev;
+	Dictionary remaps;
+
+	if (ProjectSettings::get_singleton()->has_setting("locale/translation_remaps")) {
+		remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
+		prev = remaps;
+	}
+
+	if (remaps.has(p_path)) {
+		return; //pointless already has it
+	}
+
+	remaps[p_path] = PackedStringArray();
+
+	undo_redo->create_action(TTR("Add Remapped Path"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", prev);
+	undo_redo->add_do_method(this, "update_translations");
+	undo_redo->add_undo_method(this, "update_translations");
+	undo_redo->add_do_method(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->commit_action();
+}
+
+void LocalizationEditor::_translation_res_option_file_open() {
+	translation_res_option_file_open_dialog->popup_centered_ratio();
+}
+
+void LocalizationEditor::_translation_res_option_add(const String &p_path) {
+	ERR_FAIL_COND(!ProjectSettings::get_singleton()->has_setting("locale/translation_remaps"));
+
+	Dictionary remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
+
+	TreeItem *k = translation_remap->get_selected();
+	ERR_FAIL_COND(!k);
+
+	String key = k->get_metadata(0);
+
+	ERR_FAIL_COND(!remaps.has(key));
+	PackedStringArray r = remaps[key];
+	r.push_back(p_path + ":" + "en");
+	remaps[key] = r;
+
+	undo_redo->create_action(TTR("Resource Remap Add Remap"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", ProjectSettings::get_singleton()->get("locale/translation_remaps"));
+	undo_redo->add_do_method(this, "update_translations");
+	undo_redo->add_undo_method(this, "update_translations");
+	undo_redo->add_do_method(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->commit_action();
+}
+
+void LocalizationEditor::_translation_res_select() {
+	if (updating_translations) {
+		return;
+	}
+
+	call_deferred("update_translations");
+}
+
+void LocalizationEditor::_translation_res_option_changed() {
+	if (updating_translations) {
+		return;
+	}
+
+	if (!ProjectSettings::get_singleton()->has_setting("locale/translation_remaps")) {
+		return;
+	}
+
+	Dictionary remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
+
+	TreeItem *k = translation_remap->get_selected();
+	ERR_FAIL_COND(!k);
+	TreeItem *ed = translation_remap_options->get_edited();
+	ERR_FAIL_COND(!ed);
+
+	String key = k->get_metadata(0);
+	int idx = ed->get_metadata(0);
+	String path = ed->get_metadata(1);
+	int which = ed->get_range(1);
+
+	Vector<String> langs = TranslationServer::get_all_locales();
+
+	ERR_FAIL_INDEX(which, langs.size());
+
+	ERR_FAIL_COND(!remaps.has(key));
+	PackedStringArray r = remaps[key];
+	ERR_FAIL_INDEX(idx, r.size());
+	if (translation_locales_idxs_remap.size() > which) {
+		r.set(idx, path + ":" + langs[translation_locales_idxs_remap[which]]);
+	} else {
+		r.set(idx, path + ":" + langs[which]);
+	}
+	remaps[key] = r;
+
+	updating_translations = true;
+	undo_redo->create_action(TTR("Change Resource Remap Language"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", ProjectSettings::get_singleton()->get("locale/translation_remaps"));
+	undo_redo->add_do_method(this, "update_translations");
+	undo_redo->add_undo_method(this, "update_translations");
+	undo_redo->add_do_method(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->commit_action();
+	updating_translations = false;
+}
+
+void LocalizationEditor::_translation_res_delete(Object *p_item, int p_column, int p_button) {
+	if (updating_translations) {
+		return;
+	}
+
+	if (!ProjectSettings::get_singleton()->has_setting("locale/translation_remaps")) {
+		return;
+	}
+
+	Dictionary remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
+
+	TreeItem *k = Object::cast_to<TreeItem>(p_item);
+
+	String key = k->get_metadata(0);
+	ERR_FAIL_COND(!remaps.has(key));
+
+	remaps.erase(key);
+
+	undo_redo->create_action(TTR("Remove Resource Remap"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", ProjectSettings::get_singleton()->get("locale/translation_remaps"));
+	undo_redo->add_do_method(this, "update_translations");
+	undo_redo->add_undo_method(this, "update_translations");
+	undo_redo->add_do_method(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->commit_action();
+}
+
+void LocalizationEditor::_translation_res_option_delete(Object *p_item, int p_column, int p_button) {
+	if (updating_translations) {
+		return;
+	}
+
+	if (!ProjectSettings::get_singleton()->has_setting("locale/translation_remaps")) {
+		return;
+	}
+
+	Dictionary remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
+
+	TreeItem *k = translation_remap->get_selected();
+	ERR_FAIL_COND(!k);
+	TreeItem *ed = Object::cast_to<TreeItem>(p_item);
+	ERR_FAIL_COND(!ed);
+
+	String key = k->get_metadata(0);
+	int idx = ed->get_metadata(0);
+
+	ERR_FAIL_COND(!remaps.has(key));
+	PackedStringArray r = remaps[key];
+	ERR_FAIL_INDEX(idx, r.size());
+	r.remove(idx);
+	remaps[key] = r;
+
+	undo_redo->create_action(TTR("Remove Resource Remap Option"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", ProjectSettings::get_singleton()->get("locale/translation_remaps"));
+	undo_redo->add_do_method(this, "update_translations");
+	undo_redo->add_undo_method(this, "update_translations");
+	undo_redo->add_do_method(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->commit_action();
+}
+
+void LocalizationEditor::_translation_filter_option_changed() {
+	int sel_id = translation_locale_filter_mode->get_selected_id();
+	TreeItem *t = translation_filter->get_edited();
+	String locale = t->get_tooltip(0);
+	bool checked = t->is_checked(0);
+
+	Variant prev;
+	Array f_locales_all;
+
+	if (ProjectSettings::get_singleton()->has_setting("locale/locale_filter")) {
+		f_locales_all = ProjectSettings::get_singleton()->get("locale/locale_filter");
+		prev = f_locales_all;
+
+		if (f_locales_all.size() != 2) {
+			f_locales_all.clear();
+			f_locales_all.append(sel_id);
+			f_locales_all.append(Array());
+		}
+	} else {
+		f_locales_all.append(sel_id);
+		f_locales_all.append(Array());
+	}
+
+	Array f_locales = f_locales_all[1];
+	int l_idx = f_locales.find(locale);
+
+	if (checked) {
+		if (l_idx == -1) {
+			f_locales.append(locale);
+		}
+	} else {
+		if (l_idx != -1) {
+			f_locales.remove(l_idx);
+		}
+	}
+
+	f_locales = f_locales.sort();
+
+	undo_redo->create_action(TTR("Changed Locale Filter"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/locale_filter", f_locales_all);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/locale_filter", prev);
+	undo_redo->add_do_method(this, "update_translations");
+	undo_redo->add_undo_method(this, "update_translations");
+	undo_redo->add_do_method(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->commit_action();
+}
+
+void LocalizationEditor::_translation_filter_mode_changed(int p_mode) {
+	int sel_id = translation_locale_filter_mode->get_selected_id();
+
+	Variant prev;
+	Array f_locales_all;
+
+	if (ProjectSettings::get_singleton()->has_setting("locale/locale_filter")) {
+		f_locales_all = ProjectSettings::get_singleton()->get("locale/locale_filter");
+		prev = f_locales_all;
+
+		if (f_locales_all.size() != 2) {
+			f_locales_all.clear();
+			f_locales_all.append(sel_id);
+			f_locales_all.append(Array());
+		} else {
+			f_locales_all[0] = sel_id;
+		}
+	} else {
+		f_locales_all.append(sel_id);
+		f_locales_all.append(Array());
+	}
+
+	undo_redo->create_action(TTR("Changed Locale Filter Mode"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/locale_filter", f_locales_all);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/locale_filter", prev);
+	undo_redo->add_do_method(this, "update_translations");
+	undo_redo->add_undo_method(this, "update_translations");
+	undo_redo->add_do_method(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->commit_action();
+}
+
+void LocalizationEditor::_pot_add(const String &p_path) {
+	PackedStringArray pot_translations = ProjectSettings::get_singleton()->get("locale/translations_pot_files");
+
+	for (int i = 0; i < pot_translations.size(); i++) {
+		if (pot_translations[i] == p_path) {
+			return; //exists
+		}
+	}
+
+	pot_translations.push_back(p_path);
+	undo_redo->create_action(TTR("Add files for POT generation"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translations_pot_files", pot_translations);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translations_pot_files", ProjectSettings::get_singleton()->get("locale/translations_pot_files"));
+	undo_redo->add_do_method(this, "update_translations");
+	undo_redo->add_undo_method(this, "update_translations");
+	undo_redo->add_do_method(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->commit_action();
+}
+
+void LocalizationEditor::_pot_delete(Object *p_item, int p_column, int p_button) {
+	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
+	ERR_FAIL_COND(!ti);
+
+	int idx = ti->get_metadata(0);
+
+	PackedStringArray pot_translations = ProjectSettings::get_singleton()->get("locale/translations_pot_files");
+
+	ERR_FAIL_INDEX(idx, pot_translations.size());
+
+	pot_translations.remove(idx);
+
+	undo_redo->create_action(TTR("Remove file from POT generation"));
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translations_pot_files", pot_translations);
+	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translations_pot_files", ProjectSettings::get_singleton()->get("locale/translations_pot_files"));
+	undo_redo->add_do_method(this, "update_translations");
+	undo_redo->add_undo_method(this, "update_translations");
+	undo_redo->add_do_method(this, "emit_signal", localization_changed);
+	undo_redo->add_undo_method(this, "emit_signal", localization_changed);
+	undo_redo->commit_action();
+}
+
+void LocalizationEditor::_pot_file_open() {
+	pot_file_open_dialog->popup_centered_ratio();
+}
+
+void LocalizationEditor::_pot_generate_open() {
+	pot_generate_dialog->popup_centered_ratio();
+}
+
+void LocalizationEditor::_pot_generate(const String &p_file) {
+	POTGenerator::get_singleton()->generate_pot(p_file);
+}
+
+void LocalizationEditor::_update_pot_file_extensions() {
+	pot_file_open_dialog->clear_filters();
+	List<String> translation_parse_file_extensions;
+	EditorTranslationParser::get_singleton()->get_recognized_extensions(&translation_parse_file_extensions);
+	for (List<String>::Element *E = translation_parse_file_extensions.front(); E; E = E->next()) {
+		pot_file_open_dialog->add_filter("*." + E->get());
+	}
+}
+
+void LocalizationEditor::update_translations() {
+	if (updating_translations) {
+		return;
+	}
+
+	updating_translations = true;
+
+	translation_list->clear();
+	TreeItem *root = translation_list->create_item(nullptr);
+	translation_list->set_hide_root(true);
+	if (ProjectSettings::get_singleton()->has_setting("locale/translations")) {
+		PackedStringArray translations = ProjectSettings::get_singleton()->get("locale/translations");
+		for (int i = 0; i < translations.size(); i++) {
+			TreeItem *t = translation_list->create_item(root);
+			t->set_editable(0, false);
+			t->set_text(0, translations[i].replace_first("res://", ""));
+			t->set_tooltip(0, translations[i]);
+			t->set_metadata(0, i);
+			t->add_button(0, get_theme_icon("Remove", "EditorIcons"), 0, false, TTR("Remove"));
+		}
+	}
+
+	Vector<String> langs = TranslationServer::get_all_locales();
+	Vector<String> names = TranslationServer::get_all_locale_names();
+
+	// Update filter tab
+	Array l_filter_all;
+
+	bool is_arr_empty = true;
+	if (ProjectSettings::get_singleton()->has_setting("locale/locale_filter")) {
+		l_filter_all = ProjectSettings::get_singleton()->get("locale/locale_filter");
+
+		if (l_filter_all.size() == 2) {
+			translation_locale_filter_mode->select(l_filter_all[0]);
+			is_arr_empty = false;
+		}
+	}
+	if (is_arr_empty) {
+		l_filter_all.append(0);
+		l_filter_all.append(Array());
+		translation_locale_filter_mode->select(0);
+	}
+
+	int filter_mode = l_filter_all[0];
+	Array l_filter = l_filter_all[1];
+
+	int s = names.size();
+	bool is_short_list_when_show_all_selected = filter_mode == SHOW_ALL_LOCALES && translation_filter_treeitems.size() < s;
+	bool is_full_list_when_show_only_selected = filter_mode == SHOW_ONLY_SELECTED_LOCALES && translation_filter_treeitems.size() == s;
+	bool should_recreate_locales_list = is_short_list_when_show_all_selected || is_full_list_when_show_only_selected;
+
+	if (!translation_locales_list_created || should_recreate_locales_list) {
+		translation_locales_list_created = true;
+		translation_filter->clear();
+		root = translation_filter->create_item(nullptr);
+		translation_filter->set_hide_root(true);
+		translation_filter_treeitems.clear();
+		for (int i = 0; i < s; i++) {
+			String n = names[i];
+			String l = langs[i];
+			bool is_checked = l_filter.has(l);
+			if (filter_mode == SHOW_ONLY_SELECTED_LOCALES && !is_checked) {
+				continue;
+			}
+
+			TreeItem *t = translation_filter->create_item(root);
+			t->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
+			t->set_text(0, n);
+			t->set_editable(0, true);
+			t->set_tooltip(0, l);
+			t->set_checked(0, is_checked);
+			translation_filter_treeitems.push_back(t);
+		}
+	} else {
+		for (int i = 0; i < translation_filter_treeitems.size(); i++) {
+			TreeItem *t = translation_filter_treeitems[i];
+			t->set_checked(0, l_filter.has(t->get_tooltip(0)));
+		}
+	}
+
+	// Update translation remaps.
+	String remap_selected;
+	if (translation_remap->get_selected()) {
+		remap_selected = translation_remap->get_selected()->get_metadata(0);
+	}
+
+	translation_remap->clear();
+	translation_remap_options->clear();
+	root = translation_remap->create_item(nullptr);
+	TreeItem *root2 = translation_remap_options->create_item(nullptr);
+	translation_remap->set_hide_root(true);
+	translation_remap_options->set_hide_root(true);
+	translation_res_option_add_button->set_disabled(true);
+
+	translation_locales_idxs_remap.clear();
+	translation_locales_idxs_remap.resize(l_filter.size());
+	int fl_idx_count = translation_locales_idxs_remap.size();
+
+	String langnames = "";
+	int l_idx = 0;
+	for (int i = 0; i < names.size(); i++) {
+		if (filter_mode == SHOW_ONLY_SELECTED_LOCALES && fl_idx_count != 0) {
+			if (l_filter.size() > 0) {
+				if (l_filter.find(langs[i]) != -1) {
+					if (langnames.length() > 0) {
+						langnames += ",";
+					}
+					langnames += names[i];
+					translation_locales_idxs_remap.write[l_idx] = i;
+					l_idx++;
+				}
+			}
+		} else {
+			if (i > 0) {
+				langnames += ",";
+			}
+			langnames += names[i];
+		}
+	}
+
+	if (ProjectSettings::get_singleton()->has_setting("locale/translation_remaps")) {
+		Dictionary remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
+		List<Variant> rk;
+		remaps.get_key_list(&rk);
+		Vector<String> keys;
+		for (List<Variant>::Element *E = rk.front(); E; E = E->next()) {
+			keys.push_back(E->get());
+		}
+		keys.sort();
+
+		for (int i = 0; i < keys.size(); i++) {
+			TreeItem *t = translation_remap->create_item(root);
+			t->set_editable(0, false);
+			t->set_text(0, keys[i].replace_first("res://", ""));
+			t->set_tooltip(0, keys[i]);
+			t->set_metadata(0, keys[i]);
+			t->add_button(0, get_theme_icon("Remove", "EditorIcons"), 0, false, TTR("Remove"));
+			if (keys[i] == remap_selected) {
+				t->select(0);
+				translation_res_option_add_button->set_disabled(false);
+
+				PackedStringArray selected = remaps[keys[i]];
+				for (int j = 0; j < selected.size(); j++) {
+					String s2 = selected[j];
+					int qp = s2.rfind(":");
+					String path = s2.substr(0, qp);
+					String locale = s2.substr(qp + 1, s2.length());
+
+					TreeItem *t2 = translation_remap_options->create_item(root2);
+					t2->set_editable(0, false);
+					t2->set_text(0, path.replace_first("res://", ""));
+					t2->set_tooltip(0, path);
+					t2->set_metadata(0, j);
+					t2->add_button(0, get_theme_icon("Remove", "EditorIcons"), 0, false, TTR("Remove"));
+					t2->set_cell_mode(1, TreeItem::CELL_MODE_RANGE);
+					t2->set_text(1, langnames);
+					t2->set_editable(1, true);
+					t2->set_metadata(1, path);
+					int idx = langs.find(locale);
+					if (idx < 0) {
+						idx = 0;
+					}
+
+					int f_idx = translation_locales_idxs_remap.find(idx);
+					if (f_idx != -1 && fl_idx_count > 0 && filter_mode == SHOW_ONLY_SELECTED_LOCALES) {
+						t2->set_range(1, f_idx);
+					} else {
+						t2->set_range(1, idx);
+					}
+				}
+			}
+		}
+	}
+
+	// Update translation POT files.
+	translation_pot_list->clear();
+	root = translation_pot_list->create_item(nullptr);
+	translation_pot_list->set_hide_root(true);
+	if (ProjectSettings::get_singleton()->has_setting("locale/translations_pot_files")) {
+		PackedStringArray pot_translations = ProjectSettings::get_singleton()->get("locale/translations_pot_files");
+		for (int i = 0; i < pot_translations.size(); i++) {
+			TreeItem *t = translation_pot_list->create_item(root);
+			t->set_editable(0, false);
+			t->set_text(0, pot_translations[i].replace_first("res://", ""));
+			t->set_tooltip(0, pot_translations[i]);
+			t->set_metadata(0, i);
+			t->add_button(0, get_theme_icon("Remove", "EditorIcons"), 0, false, TTR("Remove"));
+		}
+	}
+
+	// New translation parser plugin might extend possible file extensions in POT generation.
+	_update_pot_file_extensions();
+
+	updating_translations = false;
+}
+
+void LocalizationEditor::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("update_translations"), &LocalizationEditor::update_translations);
+
+	ADD_SIGNAL(MethodInfo("localization_changed"));
+}
+
+LocalizationEditor::LocalizationEditor() {
+	undo_redo = EditorNode::get_undo_redo();
+	updating_translations = false;
+	localization_changed = "localization_changed";
+
+	translation_locales_idxs_remap = Vector<int>();
+	translation_locales_list_created = false;
+
+	TabContainer *translations = memnew(TabContainer);
+	translations->set_tab_align(TabContainer::ALIGN_LEFT);
+	translations->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	add_child(translations);
+
+	{
+		VBoxContainer *tvb = memnew(VBoxContainer);
+		tvb->set_name(TTR("Translations"));
+		translations->add_child(tvb);
+
+		HBoxContainer *thb = memnew(HBoxContainer);
+		thb->add_spacer();
+		thb->add_child(memnew(Label(TTR("Translations:"))));
+		tvb->add_child(thb);
+
+		Button *addtr = memnew(Button(TTR("Add...")));
+		addtr->connect("pressed", callable_mp(this, &LocalizationEditor::_translation_file_open));
+		thb->add_child(addtr);
+
+		VBoxContainer *tmc = memnew(VBoxContainer);
+		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tvb->add_child(tmc);
+
+		translation_list = memnew(Tree);
+		translation_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tmc->add_child(translation_list);
+
+		translation_file_open = memnew(EditorFileDialog);
+		translation_file_open->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
+		translation_file_open->connect("file_selected", callable_mp(this, &LocalizationEditor::_translation_add));
+		add_child(translation_file_open);
+	}
+
+	{
+		VBoxContainer *tvb = memnew(VBoxContainer);
+		tvb->set_name(TTR("Remaps"));
+		translations->add_child(tvb);
+
+		HBoxContainer *thb = memnew(HBoxContainer);
+		thb->add_child(memnew(Label(TTR("Resources:"))));
+		thb->add_spacer();
+		tvb->add_child(thb);
+
+		Button *addtr = memnew(Button(TTR("Add...")));
+		addtr->connect("pressed", callable_mp(this, &LocalizationEditor::_translation_res_file_open));
+		thb->add_child(addtr);
+
+		VBoxContainer *tmc = memnew(VBoxContainer);
+		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tvb->add_child(tmc);
+
+		translation_remap = memnew(Tree);
+		translation_remap->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		translation_remap->connect("cell_selected", callable_mp(this, &LocalizationEditor::_translation_res_select));
+		translation_remap->connect("button_pressed", callable_mp(this, &LocalizationEditor::_translation_res_delete));
+		tmc->add_child(translation_remap);
+
+		translation_res_file_open_dialog = memnew(EditorFileDialog);
+		translation_res_file_open_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
+		translation_res_file_open_dialog->connect("file_selected", callable_mp(this, &LocalizationEditor::_translation_res_add));
+		add_child(translation_res_file_open_dialog);
+
+		thb = memnew(HBoxContainer);
+		thb->add_child(memnew(Label(TTR("Remaps by Locale:"))));
+		thb->add_spacer();
+		tvb->add_child(thb);
+
+		addtr = memnew(Button(TTR("Add...")));
+		addtr->connect("pressed", callable_mp(this, &LocalizationEditor::_translation_res_option_file_open));
+		translation_res_option_add_button = addtr;
+		thb->add_child(addtr);
+
+		tmc = memnew(VBoxContainer);
+		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tvb->add_child(tmc);
+
+		translation_remap_options = memnew(Tree);
+		translation_remap_options->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		translation_remap_options->set_columns(2);
+		translation_remap_options->set_column_title(0, TTR("Path"));
+		translation_remap_options->set_column_title(1, TTR("Locale"));
+		translation_remap_options->set_column_titles_visible(true);
+		translation_remap_options->set_column_expand(0, true);
+		translation_remap_options->set_column_expand(1, false);
+		translation_remap_options->set_column_min_width(1, 200);
+		translation_remap_options->connect("item_edited", callable_mp(this, &LocalizationEditor::_translation_res_option_changed));
+		translation_remap_options->connect("button_pressed", callable_mp(this, &LocalizationEditor::_translation_res_option_delete));
+		tmc->add_child(translation_remap_options);
+
+		translation_res_option_file_open_dialog = memnew(EditorFileDialog);
+		translation_res_option_file_open_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
+		translation_res_option_file_open_dialog->connect("file_selected", callable_mp(this, &LocalizationEditor::_translation_res_option_add));
+		add_child(translation_res_option_file_open_dialog);
+	}
+
+	{
+		VBoxContainer *tvb = memnew(VBoxContainer);
+		tvb->set_name(TTR("Locales Filter"));
+		translations->add_child(tvb);
+
+		VBoxContainer *tmc = memnew(VBoxContainer);
+		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tvb->add_child(tmc);
+
+		translation_locale_filter_mode = memnew(OptionButton);
+		translation_locale_filter_mode->add_item(TTR("Show All Locales"), SHOW_ALL_LOCALES);
+		translation_locale_filter_mode->add_item(TTR("Show Selected Locales Only"), SHOW_ONLY_SELECTED_LOCALES);
+		translation_locale_filter_mode->select(0);
+		translation_locale_filter_mode->connect("item_selected", callable_mp(this, &LocalizationEditor::_translation_filter_mode_changed));
+		tmc->add_margin_child(TTR("Filter mode:"), translation_locale_filter_mode);
+
+		tmc->add_child(memnew(Label(TTR("Locales:"))));
+		translation_filter = memnew(Tree);
+		translation_filter->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		translation_filter->set_columns(1);
+		translation_filter->connect("item_edited", callable_mp(this, &LocalizationEditor::_translation_filter_option_changed));
+		tmc->add_child(translation_filter);
+	}
+
+	{
+		VBoxContainer *tvb = memnew(VBoxContainer);
+		tvb->set_name(TTR("POT Generation"));
+		translations->add_child(tvb);
+
+		HBoxContainer *thb = memnew(HBoxContainer);
+		thb->add_child(memnew(Label(TTR("Files with translation strings:"))));
+		thb->add_spacer();
+		tvb->add_child(thb);
+
+		Button *addtr = memnew(Button(TTR("Add...")));
+		addtr->connect("pressed", callable_mp(this, &LocalizationEditor::_pot_file_open));
+		thb->add_child(addtr);
+
+		Button *generate = memnew(Button(TTR("Generate POT")));
+		generate->connect("pressed", callable_mp(this, &LocalizationEditor::_pot_generate_open));
+		thb->add_child(generate);
+
+		VBoxContainer *tmc = memnew(VBoxContainer);
+		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tvb->add_child(tmc);
+
+		translation_pot_list = memnew(Tree);
+		translation_pot_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		tmc->add_child(translation_pot_list);
+
+		pot_generate_dialog = memnew(EditorFileDialog);
+		pot_generate_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
+		pot_generate_dialog->connect("file_selected", callable_mp(this, &LocalizationEditor::_pot_generate));
+		add_child(pot_generate_dialog);
+
+		pot_file_open_dialog = memnew(EditorFileDialog);
+		pot_file_open_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
+		pot_file_open_dialog->connect("file_selected", callable_mp(this, &LocalizationEditor::_pot_add));
+		add_child(pot_file_open_dialog);
+	}
+}

--- a/editor/localization_editor.h
+++ b/editor/localization_editor.h
@@ -1,0 +1,103 @@
+/*************************************************************************/
+/*  localization_editor.h                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef LOCALIZATION_EDITOR_H
+#define LOCALIZATION_EDITOR_H
+
+#include "core/undo_redo.h"
+#include "editor_file_dialog.h"
+#include "scene/gui/tree.h"
+
+class LocalizationEditor : public VBoxContainer {
+	GDCLASS(LocalizationEditor, VBoxContainer);
+
+	enum LocaleFilter {
+		SHOW_ALL_LOCALES,
+		SHOW_ONLY_SELECTED_LOCALES,
+	};
+
+	Tree *translation_list;
+
+	EditorFileDialog *translation_file_open;
+
+	Button *translation_res_option_add_button;
+	EditorFileDialog *translation_res_file_open_dialog;
+	EditorFileDialog *translation_res_option_file_open_dialog;
+	Tree *translation_remap;
+	Tree *translation_remap_options;
+	Tree *translation_filter;
+	bool translation_locales_list_created;
+	OptionButton *translation_locale_filter_mode;
+	Vector<TreeItem *> translation_filter_treeitems;
+	Vector<int> translation_locales_idxs_remap;
+
+	Tree *translation_pot_list;
+	EditorFileDialog *pot_file_open_dialog;
+	EditorFileDialog *pot_generate_dialog;
+
+	UndoRedo *undo_redo;
+	bool updating_translations;
+	String localization_changed;
+
+	void _translation_file_open();
+	void _translation_add(const String &p_path);
+	void _translation_delete(Object *p_item, int p_column, int p_button);
+
+	void _translation_res_file_open();
+	void _translation_res_add(const String &p_path);
+	void _translation_res_delete(Object *p_item, int p_column, int p_button);
+	void _translation_res_select();
+	void _translation_res_option_file_open();
+	void _translation_res_option_add(const String &p_path);
+	void _translation_res_option_changed();
+	void _translation_res_option_delete(Object *p_item, int p_column, int p_button);
+
+	void _translation_filter_option_changed();
+	void _translation_filter_mode_changed(int p_mode);
+
+	void _pot_add(const String &p_path);
+	void _pot_delete(Object *p_item, int p_column, int p_button);
+	void _pot_file_open();
+	void _pot_generate_open();
+	void _pot_generate(const String &p_file);
+	void _update_pot_file_extensions();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void add_translation(const String &p_translation);
+	void update_translations();
+
+	LocalizationEditor();
+};
+
+#endif // LOCALIZATION_EDITOR_H

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -31,60 +31,29 @@
 #include "project_settings_editor.h"
 
 #include "core/global_constants.h"
-#include "core/input/input_map.h"
 #include "core/os/keyboard.h"
 #include "core/project_settings.h"
-#include "core/translation.h"
 #include "editor/editor_export.h"
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
-#include "editor/editor_translation_parser.h"
-#include "editor/pot_generator.h"
-#include "scene/gui/margin_container.h"
-#include "scene/gui/tab_container.h"
 
 ProjectSettingsEditor *ProjectSettingsEditor::singleton = nullptr;
 
-static const char *_button_descriptions[JOY_SDL_BUTTONS] = {
-	"Face Bottom, DualShock Cross, Xbox A, Nintendo B",
-	"Face Right, DualShock Circle, Xbox B, Nintendo A",
-	"Face Left, DualShock Square, Xbox X, Nintendo Y",
-	"Face Top, DualShock Triangle, Xbox Y, Nintendo X",
-	"DualShock Select, Xbox Back, Nintendo -",
-	"Home, DualShock PS, Guide",
-	"Start, Nintendo +",
-	"Left Stick, DualShock L3, Xbox L/LS",
-	"Right Stick, DualShock R3, Xbox R/RS",
-	"Left Shoulder, DualShock L1, Xbox LB",
-	"Right Shoulder, DualShock R1, Xbox RB",
-	"D-Pad Up",
-	"D-Pad Down",
-	"D-Pad Left",
-	"D-Pad Right"
-};
+void ProjectSettingsEditor::popup_project_settings() {
+	// Restore valid window bounds or pop up at default size.
+	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "project_settings", Rect2());
+	if (saved_size != Rect2()) {
+		popup(saved_size);
+	} else {
+		popup_centered_clamped(Size2(900, 700) * EDSCALE, 0.8);
+	}
 
-static const char *_axis_descriptions[JOY_AXIS_MAX * 2] = {
-	"Left Stick Left",
-	"Left Stick Right",
-	"Left Stick Up",
-	"Left Stick Down",
-	"Right Stick Left",
-	"Right Stick Right",
-	"Right Stick Up",
-	"Right Stick Down",
-	"Joystick 2 Left",
-	"Joystick 2 Right, Left Trigger, L2, LT",
-	"Joystick 2 Up",
-	"Joystick 2 Down, Right Trigger, R2, RT",
-	"Joystick 3 Left",
-	"Joystick 3 Right",
-	"Joystick 3 Up",
-	"Joystick 3 Down",
-	"Joystick 4 Left",
-	"Joystick 4 Right",
-	"Joystick 4 Up",
-	"Joystick 4 Down",
-};
+	globals_editor->update_category_list();
+	localization_editor->update_translations();
+	autoload_settings->update_autoload();
+	plugin_settings->update_plugins();
+	set_process_unhandled_input(true);
+}
 
 void ProjectSettingsEditor::_unhandled_input(const Ref<InputEvent> &p_event) {
 	const Ref<InputEventKey> k = p_event;
@@ -115,765 +84,22 @@ void ProjectSettingsEditor::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			globals_editor->edit(ProjectSettings::get_singleton());
 
-			search_button->set_icon(input_editor->get_theme_icon("Search", "EditorIcons"));
-			search_box->set_right_icon(input_editor->get_theme_icon("Search", "EditorIcons"));
+			search_button->set_icon(get_theme_icon("Search", "EditorIcons"));
+			search_box->set_right_icon(get_theme_icon("Search", "EditorIcons"));
 			search_box->set_clear_button_enabled(true);
 
-			action_add_error->add_theme_color_override("font_color", input_editor->get_theme_color("error_color", "Editor"));
-
-			translation_list->connect("button_pressed", callable_mp(this, &ProjectSettingsEditor::_translation_delete));
-			translation_pot_list->connect("button_pressed", callable_mp(this, &ProjectSettingsEditor::_translation_pot_delete));
-			_update_actions();
-			popup_add->add_icon_item(input_editor->get_theme_icon("Keyboard", "EditorIcons"), TTR("Key"), INPUT_KEY);
-			popup_add->add_icon_item(input_editor->get_theme_icon("KeyboardPhysical", "EditorIcons"), TTR("Physical Key"), INPUT_KEY_PHYSICAL);
-			popup_add->add_icon_item(input_editor->get_theme_icon("JoyButton", "EditorIcons"), TTR("Joy Button"), INPUT_JOY_BUTTON);
-			popup_add->add_icon_item(input_editor->get_theme_icon("JoyAxis", "EditorIcons"), TTR("Joy Axis"), INPUT_JOY_MOTION);
-			popup_add->add_icon_item(input_editor->get_theme_icon("Mouse", "EditorIcons"), TTR("Mouse Button"), INPUT_MOUSE_BUTTON);
-
-			List<String> tfn;
-			ResourceLoader::get_recognized_extensions_for_type("Translation", &tfn);
-			for (List<String>::Element *E = tfn.front(); E; E = E->next()) {
-				translation_file_open->add_filter("*." + E->get());
-			}
-
-			List<String> rfn;
-			ResourceLoader::get_recognized_extensions_for_type("Resource", &rfn);
-			for (List<String>::Element *E = rfn.front(); E; E = E->next()) {
-				translation_res_file_open->add_filter("*." + E->get());
-				translation_res_option_file_open->add_filter("*." + E->get());
-			}
-
-			_update_translation_pot_file_extensions();
-			translation_pot_generate->add_filter("*.pot");
-
-			restart_close_button->set_icon(input_editor->get_theme_icon("Close", "EditorIcons"));
-			restart_container->add_theme_style_override("panel", input_editor->get_theme_stylebox("bg", "Tree"));
-			restart_icon->set_texture(input_editor->get_theme_icon("StatusWarning", "EditorIcons"));
-			restart_label->add_theme_color_override("font_color", input_editor->get_theme_color("warning_color", "Editor"));
+			restart_close_button->set_icon(get_theme_icon("Close", "EditorIcons"));
+			restart_container->add_theme_style_override("panel", get_theme_stylebox("bg", "Tree"));
+			restart_icon->set_texture(get_theme_icon("StatusWarning", "EditorIcons"));
+			restart_label->add_theme_color_override("font_color", get_theme_color("warning_color", "Editor"));
 
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			search_button->set_icon(input_editor->get_theme_icon("Search", "EditorIcons"));
-			search_box->set_right_icon(input_editor->get_theme_icon("Search", "EditorIcons"));
+			search_button->set_icon(get_theme_icon("Search", "EditorIcons"));
+			search_box->set_right_icon(get_theme_icon("Search", "EditorIcons"));
 			search_box->set_clear_button_enabled(true);
-			action_add_error->add_theme_color_override("font_color", input_editor->get_theme_color("error_color", "Editor"));
-			popup_add->set_item_icon(popup_add->get_item_index(INPUT_KEY), input_editor->get_theme_icon("Keyboard", "EditorIcons"));
-			popup_add->set_item_icon(popup_add->get_item_index(INPUT_KEY_PHYSICAL), input_editor->get_theme_icon("KeyboardPhysical", "EditorIcons"));
-			popup_add->set_item_icon(popup_add->get_item_index(INPUT_JOY_BUTTON), input_editor->get_theme_icon("JoyButton", "EditorIcons"));
-			popup_add->set_item_icon(popup_add->get_item_index(INPUT_JOY_MOTION), input_editor->get_theme_icon("JoyAxis", "EditorIcons"));
-			popup_add->set_item_icon(popup_add->get_item_index(INPUT_MOUSE_BUTTON), input_editor->get_theme_icon("Mouse", "EditorIcons"));
-			_update_actions();
 		} break;
 	}
-}
-
-static bool _validate_action_name(const String &p_name) {
-	const CharType *cstr = p_name.c_str();
-	for (int i = 0; cstr[i]; i++) {
-		if (cstr[i] == '/' || cstr[i] == ':' || cstr[i] == '"' ||
-				cstr[i] == '=' || cstr[i] == '\\' || cstr[i] < 32) {
-			return false;
-		}
-	}
-	return true;
-}
-
-void ProjectSettingsEditor::_action_selected() {
-	TreeItem *ti = input_editor->get_selected();
-	if (!ti || !ti->is_editable(0)) {
-		return;
-	}
-
-	add_at = "input/" + ti->get_text(0);
-	edit_idx = -1;
-}
-
-void ProjectSettingsEditor::_action_edited() {
-	TreeItem *ti = input_editor->get_selected();
-	if (!ti) {
-		return;
-	}
-
-	if (input_editor->get_selected_column() == 0) {
-		String new_name = ti->get_text(0);
-		String old_name = add_at.substr(add_at.find("/") + 1, add_at.length());
-
-		if (new_name == old_name) {
-			return;
-		}
-
-		if (new_name == "" || !_validate_action_name(new_name)) {
-			ti->set_text(0, old_name);
-			add_at = "input/" + old_name;
-
-			message->set_text(TTR("Invalid action name. it cannot be empty nor contain '/', ':', '=', '\\' or '\"'"));
-			message->popup_centered(Size2(300, 100) * EDSCALE);
-			return;
-		}
-
-		String action_prop = "input/" + new_name;
-
-		if (ProjectSettings::get_singleton()->has_setting(action_prop)) {
-			ti->set_text(0, old_name);
-			add_at = "input/" + old_name;
-
-			message->set_text(vformat(TTR("An action with the name '%s' already exists."), new_name));
-			message->popup_centered(Size2(300, 100) * EDSCALE);
-			return;
-		}
-
-		int order = ProjectSettings::get_singleton()->get_order(add_at);
-		Dictionary action = ProjectSettings::get_singleton()->get(add_at);
-
-		setting = true;
-		undo_redo->create_action(TTR("Rename Input Action Event"));
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", add_at);
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", action_prop, action);
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", action_prop, order);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", action_prop);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", add_at, action);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", add_at, order);
-		undo_redo->add_do_method(this, "_update_actions");
-		undo_redo->add_undo_method(this, "_update_actions");
-		undo_redo->add_do_method(this, "_settings_changed");
-		undo_redo->add_undo_method(this, "_settings_changed");
-		undo_redo->commit_action();
-		setting = false;
-
-		add_at = action_prop;
-	} else if (input_editor->get_selected_column() == 1) {
-		String name = "input/" + ti->get_text(0);
-		Dictionary old_action = ProjectSettings::get_singleton()->get(name);
-		Dictionary new_action = old_action.duplicate();
-		new_action["deadzone"] = ti->get_range(1);
-
-		undo_redo->create_action(TTR("Change Action deadzone"));
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, new_action);
-		undo_redo->add_do_method(this, "_settings_changed");
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_action);
-		undo_redo->add_undo_method(this, "_settings_changed");
-		undo_redo->commit_action();
-	}
-}
-
-void ProjectSettingsEditor::_device_input_add() {
-	Ref<InputEvent> ie;
-	String name = add_at;
-	int idx = edit_idx;
-	Dictionary old_val = ProjectSettings::get_singleton()->get(name);
-	Dictionary action = old_val.duplicate();
-	Array events = action["events"];
-
-	switch (add_type) {
-		case INPUT_MOUSE_BUTTON: {
-			Ref<InputEventMouseButton> mb;
-			mb.instance();
-			mb->set_button_index(device_index->get_selected() + 1);
-			mb->set_device(_get_current_device());
-
-			for (int i = 0; i < events.size(); i++) {
-				Ref<InputEventMouseButton> aie = events[i];
-				if (aie.is_null()) {
-					continue;
-				}
-				if (aie->get_device() == mb->get_device() && aie->get_button_index() == mb->get_button_index()) {
-					return;
-				}
-			}
-
-			ie = mb;
-
-		} break;
-		case INPUT_JOY_MOTION: {
-			Ref<InputEventJoypadMotion> jm;
-			jm.instance();
-			jm->set_axis(device_index->get_selected() >> 1);
-			jm->set_axis_value((device_index->get_selected() & 1) ? 1 : -1);
-			jm->set_device(_get_current_device());
-
-			for (int i = 0; i < events.size(); i++) {
-				Ref<InputEventJoypadMotion> aie = events[i];
-				if (aie.is_null()) {
-					continue;
-				}
-
-				if (aie->get_device() == jm->get_device() && aie->get_axis() == jm->get_axis() && aie->get_axis_value() == jm->get_axis_value()) {
-					return;
-				}
-			}
-
-			ie = jm;
-
-		} break;
-		case INPUT_JOY_BUTTON: {
-			Ref<InputEventJoypadButton> jb;
-			jb.instance();
-
-			jb->set_button_index(device_index->get_selected());
-			jb->set_device(_get_current_device());
-
-			for (int i = 0; i < events.size(); i++) {
-				Ref<InputEventJoypadButton> aie = events[i];
-				if (aie.is_null()) {
-					continue;
-				}
-				if (aie->get_device() == jb->get_device() && aie->get_button_index() == jb->get_button_index()) {
-					return;
-				}
-			}
-			ie = jb;
-
-		} break;
-		default: {
-		}
-	}
-
-	if (idx < 0 || idx >= events.size()) {
-		events.push_back(ie);
-	} else {
-		events[idx] = ie;
-	}
-	action["events"] = events;
-
-	undo_redo->create_action(TTR("Add Input Action Event"));
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
-	undo_redo->add_do_method(this, "_update_actions");
-	undo_redo->add_undo_method(this, "_update_actions");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-
-	_show_last_added(ie, name);
-}
-
-void ProjectSettingsEditor::_set_current_device(int i_device) {
-	device_id->select(i_device + 1);
-}
-
-int ProjectSettingsEditor::_get_current_device() {
-	return device_id->get_selected() - 1;
-}
-
-String ProjectSettingsEditor::_get_device_string(int i_device) {
-	if (i_device == InputMap::ALL_DEVICES) {
-		return TTR("All Devices");
-	}
-	return TTR("Device") + " " + itos(i_device);
-}
-
-void ProjectSettingsEditor::_press_a_key_confirm() {
-	if (last_wait_for_key.is_null()) {
-		return;
-	}
-
-	Ref<InputEventKey> ie;
-	ie.instance();
-	if (press_a_key_physical) {
-		ie->set_physical_keycode(last_wait_for_key->get_physical_keycode());
-		ie->set_keycode(0);
-	} else {
-		ie->set_physical_keycode(0);
-		ie->set_keycode(last_wait_for_key->get_keycode());
-	}
-	ie->set_shift(last_wait_for_key->get_shift());
-	ie->set_alt(last_wait_for_key->get_alt());
-	ie->set_control(last_wait_for_key->get_control());
-	ie->set_metakey(last_wait_for_key->get_metakey());
-
-	String name = add_at;
-	int idx = edit_idx;
-
-	Dictionary old_val = ProjectSettings::get_singleton()->get(name);
-	Dictionary action = old_val.duplicate();
-	Array events = action["events"];
-
-	for (int i = 0; i < events.size(); i++) {
-		Ref<InputEventKey> aie = events[i];
-		if (aie.is_null()) {
-			continue;
-		}
-		if (!press_a_key_physical) {
-			if (aie->get_keycode_with_modifiers() == ie->get_keycode_with_modifiers()) {
-				return;
-			}
-		} else {
-			if (aie->get_physical_keycode_with_modifiers() == ie->get_physical_keycode_with_modifiers()) {
-				return;
-			}
-		}
-	}
-
-	if (idx < 0 || idx >= events.size()) {
-		events.push_back(ie);
-	} else {
-		events[idx] = ie;
-	}
-	action["events"] = events;
-
-	undo_redo->create_action(TTR("Add Input Action Event"));
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
-	undo_redo->add_do_method(this, "_update_actions");
-	undo_redo->add_undo_method(this, "_update_actions");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-
-	_show_last_added(ie, name);
-}
-
-void ProjectSettingsEditor::_show_last_added(const Ref<InputEvent> &p_event, const String &p_name) {
-	TreeItem *r = input_editor->get_root();
-
-	String name = p_name;
-	name.erase(0, 6);
-	if (!r) {
-		return;
-	}
-	r = r->get_children();
-	if (!r) {
-		return;
-	}
-	bool found = false;
-	while (r) {
-		if (r->get_text(0) != name) {
-			r = r->get_next();
-			continue;
-		}
-		TreeItem *child = r->get_children();
-		while (child) {
-			Variant input = child->get_meta("__input");
-			if (p_event == input) {
-				r->set_collapsed(false);
-				child->select(0);
-				found = true;
-				break;
-			}
-			child = child->get_next();
-		}
-		if (found) {
-			break;
-		}
-		r = r->get_next();
-	}
-
-	if (found) {
-		input_editor->ensure_cursor_is_visible();
-	}
-}
-
-void ProjectSettingsEditor::_wait_for_key(const Ref<InputEvent> &p_event) {
-	Ref<InputEventKey> k = p_event;
-
-	if (k.is_valid() && k->is_pressed() && k->get_keycode() != 0) {
-		last_wait_for_key = p_event;
-		const String str = (press_a_key_physical) ? keycode_get_string(k->get_physical_keycode_with_modifiers()) + TTR(" (Physical)") : keycode_get_string(k->get_keycode_with_modifiers());
-
-		press_a_key_label->set_text(str);
-		press_a_key->get_ok()->set_disabled(false);
-		press_a_key->set_input_as_handled();
-	}
-}
-
-void ProjectSettingsEditor::_add_item(int p_item, Ref<InputEvent> p_exiting_event) {
-	add_type = InputType(p_item);
-
-	switch (add_type) {
-		case INPUT_KEY: {
-			press_a_key_physical = false;
-			press_a_key_label->set_text(TTR("Press a Key..."));
-			press_a_key->get_ok()->set_disabled(true);
-			last_wait_for_key = Ref<InputEvent>();
-			press_a_key->popup_centered(Size2(250, 80) * EDSCALE);
-			//press_a_key->grab_focus();
-
-		} break;
-		case INPUT_KEY_PHYSICAL: {
-			press_a_key_physical = true;
-			press_a_key_label->set_text(TTR("Press a Key..."));
-
-			last_wait_for_key = Ref<InputEvent>();
-			press_a_key->popup_centered(Size2(250, 80) * EDSCALE);
-			press_a_key->grab_focus();
-
-		} break;
-		case INPUT_MOUSE_BUTTON: {
-			device_index_label->set_text(TTR("Mouse Button Index:"));
-			device_index->clear();
-			device_index->add_item(TTR("Left Button"));
-			device_index->add_item(TTR("Right Button"));
-			device_index->add_item(TTR("Middle Button"));
-			device_index->add_item(TTR("Wheel Up Button"));
-			device_index->add_item(TTR("Wheel Down Button"));
-			device_index->add_item(TTR("Wheel Left Button"));
-			device_index->add_item(TTR("Wheel Right Button"));
-			device_index->add_item(TTR("X Button 1"));
-			device_index->add_item(TTR("X Button 2"));
-			device_input->popup_centered(Size2(350, 95) * EDSCALE);
-
-			Ref<InputEventMouseButton> mb = p_exiting_event;
-			if (mb.is_valid()) {
-				device_index->select(mb->get_button_index() - 1);
-				_set_current_device(mb->get_device());
-				device_input->get_ok()->set_text(TTR("Change"));
-			} else {
-				_set_current_device(0);
-				device_input->get_ok()->set_text(TTR("Add"));
-			}
-
-		} break;
-		case INPUT_JOY_MOTION: {
-			device_index_label->set_text(TTR("Joypad Axis Index:"));
-			device_index->clear();
-			for (int i = 0; i < JOY_AXIS_MAX * 2; i++) {
-				String desc = TTR("Axis") + " " + itos(i / 2) + " " + ((i & 1) ? "+" : "-") +
-							  " (" + TTR(_axis_descriptions[i]) + ")";
-				device_index->add_item(desc);
-			}
-			device_input->popup_centered(Size2(350, 95) * EDSCALE);
-
-			Ref<InputEventJoypadMotion> jm = p_exiting_event;
-			if (jm.is_valid()) {
-				device_index->select(jm->get_axis() * 2 + (jm->get_axis_value() > 0 ? 1 : 0));
-				_set_current_device(jm->get_device());
-				device_input->get_ok()->set_text(TTR("Change"));
-			} else {
-				_set_current_device(0);
-				device_input->get_ok()->set_text(TTR("Add"));
-			}
-
-		} break;
-		case INPUT_JOY_BUTTON: {
-			device_index_label->set_text(TTR("Joypad Button Index:"));
-			device_index->clear();
-			for (int i = 0; i < JOY_BUTTON_MAX; i++) {
-				String desc = TTR("Button") + " " + itos(i);
-				if (i < JOY_SDL_BUTTONS) {
-					desc += " (" + TTR(_button_descriptions[i]) + ")";
-				}
-				device_index->add_item(desc);
-			}
-			device_input->popup_centered(Size2(350, 95) * EDSCALE);
-
-			Ref<InputEventJoypadButton> jb = p_exiting_event;
-			if (jb.is_valid()) {
-				device_index->select(jb->get_button_index());
-				_set_current_device(jb->get_device());
-				device_input->get_ok()->set_text(TTR("Change"));
-			} else {
-				_set_current_device(0);
-				device_input->get_ok()->set_text(TTR("Add"));
-			}
-
-		} break;
-		default: {
-		}
-	}
-}
-
-void ProjectSettingsEditor::_edit_item(Ref<InputEvent> p_exiting_event) {
-	InputType ie_type;
-
-	if ((Ref<InputEventKey>(p_exiting_event)).is_valid()) {
-		if ((Ref<InputEventKey>(p_exiting_event))->get_keycode() != 0) {
-			ie_type = INPUT_KEY;
-		} else {
-			ie_type = INPUT_KEY_PHYSICAL;
-		}
-
-	} else if ((Ref<InputEventJoypadButton>(p_exiting_event)).is_valid()) {
-		ie_type = INPUT_JOY_BUTTON;
-
-	} else if ((Ref<InputEventMouseButton>(p_exiting_event)).is_valid()) {
-		ie_type = INPUT_MOUSE_BUTTON;
-
-	} else if ((Ref<InputEventJoypadMotion>(p_exiting_event)).is_valid()) {
-		ie_type = INPUT_JOY_MOTION;
-
-	} else {
-		return;
-	}
-
-	_add_item(ie_type, p_exiting_event);
-}
-
-void ProjectSettingsEditor::_action_activated() {
-	TreeItem *ti = input_editor->get_selected();
-
-	if (!ti || ti->get_parent() == input_editor->get_root()) {
-		return;
-	}
-
-	String name = "input/" + ti->get_parent()->get_text(0);
-	int idx = ti->get_metadata(0);
-	Dictionary action = ProjectSettings::get_singleton()->get(name);
-	Array events = action["events"];
-
-	ERR_FAIL_INDEX(idx, events.size());
-	Ref<InputEvent> event = events[idx];
-	if (event.is_null()) {
-		return;
-	}
-
-	add_at = name;
-	edit_idx = idx;
-	_edit_item(event);
-}
-
-void ProjectSettingsEditor::_action_button_pressed(Object *p_obj, int p_column, int p_id) {
-	TreeItem *ti = Object::cast_to<TreeItem>(p_obj);
-
-	ERR_FAIL_COND(!ti);
-
-	if (p_id == 1) {
-		// Add action event
-		Point2 ofs = input_editor->get_global_position();
-		Rect2 ir = input_editor->get_item_rect(ti);
-		ir.position.y -= input_editor->get_scroll().y;
-		ofs += ir.position + ir.size;
-		ofs.x -= 100;
-		popup_add->set_position(ofs);
-		popup_add->popup();
-		add_at = "input/" + ti->get_text(0);
-		edit_idx = -1;
-
-	} else if (p_id == 2) {
-		// Remove
-
-		if (ti->get_parent() == input_editor->get_root()) {
-			// Remove action
-			String name = "input/" + ti->get_text(0);
-			Dictionary old_val = ProjectSettings::get_singleton()->get(name);
-			int order = ProjectSettings::get_singleton()->get_order(name);
-
-			undo_redo->create_action(TTR("Erase Input Action"));
-			undo_redo->add_do_method(ProjectSettings::get_singleton(), "clear", name);
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", name, order);
-			undo_redo->add_do_method(this, "_update_actions");
-			undo_redo->add_undo_method(this, "_update_actions");
-			undo_redo->add_do_method(this, "_settings_changed");
-			undo_redo->add_undo_method(this, "_settings_changed");
-			undo_redo->commit_action();
-
-		} else {
-			// Remove action event
-			String name = "input/" + ti->get_parent()->get_text(0);
-			Dictionary old_val = ProjectSettings::get_singleton()->get(name);
-			Dictionary action = old_val.duplicate();
-			int idx = ti->get_metadata(0);
-
-			Array events = action["events"];
-			ERR_FAIL_INDEX(idx, events.size());
-			events.remove(idx);
-			action["events"] = events;
-
-			undo_redo->create_action(TTR("Erase Input Action Event"));
-			undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
-			undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set", name, old_val);
-			undo_redo->add_do_method(this, "_update_actions");
-			undo_redo->add_undo_method(this, "_update_actions");
-			undo_redo->add_do_method(this, "_settings_changed");
-			undo_redo->add_undo_method(this, "_settings_changed");
-			undo_redo->commit_action();
-		}
-	} else if (p_id == 3) {
-		// Edit
-
-		if (ti->get_parent() == input_editor->get_root()) {
-			// Edit action name
-			ti->set_as_cursor(0);
-			input_editor->edit_selected();
-
-		} else {
-			// Edit action event
-			String name = "input/" + ti->get_parent()->get_text(0);
-			int idx = ti->get_metadata(0);
-			Dictionary action = ProjectSettings::get_singleton()->get(name);
-
-			Array events = action["events"];
-			ERR_FAIL_INDEX(idx, events.size());
-
-			Ref<InputEvent> event = events[idx];
-
-			if (event.is_null()) {
-				return;
-			}
-
-			ti->set_as_cursor(0);
-			add_at = name;
-			edit_idx = idx;
-			_edit_item(event);
-		}
-	}
-}
-
-void ProjectSettingsEditor::_update_actions() {
-	if (setting) {
-		return;
-	}
-
-	Map<String, bool> collapsed;
-
-	if (input_editor->get_root() && input_editor->get_root()->get_children()) {
-		for (TreeItem *item = input_editor->get_root()->get_children(); item; item = item->get_next()) {
-			collapsed[item->get_text(0)] = item->is_collapsed();
-		}
-	}
-
-	input_editor->clear();
-	TreeItem *root = input_editor->create_item();
-	input_editor->set_hide_root(true);
-
-	List<PropertyInfo> props;
-	ProjectSettings::get_singleton()->get_property_list(&props);
-
-	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
-		const PropertyInfo &pi = E->get();
-		if (!pi.name.begins_with("input/")) {
-			continue;
-		}
-
-		String name = pi.name.get_slice("/", 1);
-		if (name == "") {
-			continue;
-		}
-
-		Dictionary action = ProjectSettings::get_singleton()->get(pi.name);
-		Array events = action["events"];
-
-		TreeItem *item = input_editor->create_item(root);
-		item->set_text(0, name);
-		item->set_custom_bg_color(0, input_editor->get_theme_color("prop_subsection", "Editor"));
-		if (collapsed.has(name)) {
-			item->set_collapsed(collapsed[name]);
-		}
-
-		item->set_editable(1, true);
-		item->set_cell_mode(1, TreeItem::CELL_MODE_RANGE);
-		item->set_range_config(1, 0.0, 1.0, 0.01);
-		item->set_range(1, action["deadzone"]);
-		item->set_custom_bg_color(1, input_editor->get_theme_color("prop_subsection", "Editor"));
-
-		const bool is_builtin_input = ProjectSettings::get_singleton()->get_input_presets().find(pi.name) != nullptr;
-		const String tooltip = is_builtin_input ? TTR("Built-in actions can't be removed as they're used for UI navigation.") : TTR("Remove");
-		item->add_button(2, input_editor->get_theme_icon("Add", "EditorIcons"), 1, false, TTR("Add Event"));
-		item->add_button(2, input_editor->get_theme_icon("Remove", "EditorIcons"), 2, false, tooltip);
-
-		if (is_builtin_input) {
-			// Built-in action (like `ui_up`). Make the action not removable,
-			// but still display the button so the "Add" button is at the same
-			// horizontal position as for custom actions.
-			item->set_button_disabled(2, 1, true);
-		} else {
-			// Not a built-in action. Make the action name editable.
-			item->set_editable(0, true);
-		}
-
-		for (int i = 0; i < events.size(); i++) {
-			Ref<InputEvent> event = events[i];
-			if (event.is_null()) {
-				continue;
-			}
-
-			TreeItem *action2 = input_editor->create_item(item);
-
-			Ref<InputEventKey> k = event;
-			if (k.is_valid()) {
-				const String str = (k->get_keycode() == 0) ? keycode_get_string(k->get_physical_keycode_with_modifiers()) + TTR(" (Physical)") : keycode_get_string(k->get_keycode_with_modifiers());
-
-				action2->set_text(0, str);
-				if ((k->get_keycode() != 0)) {
-					action2->set_icon(0, input_editor->get_theme_icon("Keyboard", "EditorIcons"));
-				} else {
-					action2->set_icon(0, input_editor->get_theme_icon("KeyboardPhysical", "EditorIcons"));
-				}
-			}
-
-			Ref<InputEventJoypadButton> jb = event;
-
-			if (jb.is_valid()) {
-				String str = _get_device_string(jb->get_device()) + ", " +
-							 TTR("Button") + " " + itos(jb->get_button_index());
-				if (jb->get_button_index() >= 0 && jb->get_button_index() < JOY_SDL_BUTTONS) {
-					str += String() + " (" + TTR(_button_descriptions[jb->get_button_index()]) + ")";
-				}
-
-				action2->set_text(0, str);
-				action2->set_icon(0, input_editor->get_theme_icon("JoyButton", "EditorIcons"));
-			}
-
-			Ref<InputEventMouseButton> mb = event;
-
-			if (mb.is_valid()) {
-				String str = _get_device_string(mb->get_device()) + ", ";
-				switch (mb->get_button_index()) {
-					case BUTTON_LEFT:
-						str += TTR("Left Button");
-						break;
-					case BUTTON_RIGHT:
-						str += TTR("Right Button");
-						break;
-					case BUTTON_MIDDLE:
-						str += TTR("Middle Button");
-						break;
-					case BUTTON_WHEEL_UP:
-						str += TTR("Wheel Up");
-						break;
-					case BUTTON_WHEEL_DOWN:
-						str += TTR("Wheel Down");
-						break;
-					default:
-						str += vformat(TTR("%d Button"), mb->get_button_index());
-				}
-
-				action2->set_text(0, str);
-				action2->set_icon(0, input_editor->get_theme_icon("Mouse", "EditorIcons"));
-			}
-
-			Ref<InputEventJoypadMotion> jm = event;
-
-			if (jm.is_valid()) {
-				int ax = jm->get_axis();
-				int n = 2 * ax + (jm->get_axis_value() < 0 ? 0 : 1);
-				String str = _get_device_string(jm->get_device()) + ", " +
-							 TTR("Axis") + " " + itos(ax) + " " + (jm->get_axis_value() < 0 ? "-" : "+") +
-							 " (" + _axis_descriptions[n] + ")";
-				action2->set_text(0, str);
-				action2->set_icon(0, input_editor->get_theme_icon("JoyAxis", "EditorIcons"));
-			}
-			action2->set_metadata(0, i);
-			action2->set_meta("__input", event);
-
-			action2->add_button(2, input_editor->get_theme_icon("Edit", "EditorIcons"), 3, false, TTR("Edit"));
-			action2->add_button(2, input_editor->get_theme_icon("Remove", "EditorIcons"), 2, false, TTR("Remove"));
-			// Fade out the individual event buttons slightly to make the
-			// Add/Remove buttons stand out more.
-			action2->set_button_color(2, 0, Color(1, 1, 1, 0.75));
-			action2->set_button_color(2, 1, Color(1, 1, 1, 0.75));
-		}
-	}
-
-	_action_check(action_name->get_text());
-}
-
-void ProjectSettingsEditor::popup_project_settings() {
-	// Restore valid window bounds or pop up at default size.
-	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "project_settings", Rect2());
-	if (saved_size != Rect2()) {
-		popup(saved_size);
-	} else {
-		popup_centered_clamped(Size2(900, 700) * EDSCALE, 0.8);
-	}
-
-	globals_editor->update_category_list();
-	_update_translations();
-	autoload_settings->update_autoload();
-	plugin_settings->update_plugins();
-	// New translation parser plugin might extend possible file extensions in POT generation.
-	_update_translation_pot_file_extensions();
-	set_process_unhandled_input(true);
 }
 
 void ProjectSettingsEditor::update_plugins() {
@@ -925,10 +151,8 @@ void ProjectSettingsEditor::_item_add() {
 
 	undo_redo->add_do_method(globals_editor, "update_category_list");
 	undo_redo->add_undo_method(globals_editor, "update_category_list");
-
 	undo_redo->add_do_method(this, "_settings_changed");
 	undo_redo->add_undo_method(this, "_settings_changed");
-
 	undo_redo->commit_action();
 
 	globals_editor->set_current_section(catname);
@@ -971,71 +195,6 @@ void ProjectSettingsEditor::_item_del() {
 	undo_redo->add_undo_method(this, "_settings_changed");
 
 	undo_redo->commit_action();
-}
-
-void ProjectSettingsEditor::_action_check(String p_action) {
-	if (p_action == "") {
-		action_add->set_disabled(true);
-	} else {
-		if (!_validate_action_name(p_action)) {
-			action_add_error->set_text(TTR("Invalid action name. It cannot be empty nor contain '/', ':', '=', '\\' or '\"'."));
-			action_add_error->show();
-			action_add->set_disabled(true);
-			return;
-		}
-		if (ProjectSettings::get_singleton()->has_setting("input/" + p_action)) {
-			action_add_error->set_text(vformat(TTR("An action with the name '%s' already exists."), p_action));
-			action_add_error->show();
-			action_add->set_disabled(true);
-			return;
-		}
-
-		action_add->set_disabled(false);
-	}
-
-	action_add_error->hide();
-}
-
-void ProjectSettingsEditor::_action_adds(String) {
-	if (!action_add->is_disabled()) {
-		_action_add();
-	}
-}
-
-void ProjectSettingsEditor::_action_add() {
-	Dictionary action;
-	action["events"] = Array();
-	action["deadzone"] = 0.5f;
-	String name = "input/" + action_name->get_text();
-	undo_redo->create_action(TTR("Add Input Action"));
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set", name, action);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "clear", name);
-	undo_redo->add_do_method(this, "_update_actions");
-	undo_redo->add_undo_method(this, "_update_actions");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-
-	TreeItem *r = input_editor->get_root();
-
-	if (!r) {
-		return;
-	}
-	r = r->get_children();
-	if (!r) {
-		return;
-	}
-	while (r->get_next()) {
-		r = r->get_next();
-	}
-
-	r->select(0);
-	input_editor->ensure_cursor_is_visible();
-	action_add_error->hide();
-	action_name->clear();
-}
-
-void ProjectSettingsEditor::_item_checked(const String &p_item, bool p_check) {
 }
 
 void ProjectSettingsEditor::_save() {
@@ -1106,87 +265,6 @@ void ProjectSettingsEditor::_copy_to_platform_about_to_show() {
 	}
 }
 
-Variant ProjectSettingsEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-	TreeItem *selected = input_editor->get_selected();
-	if (!selected || selected->get_parent() != input_editor->get_root()) {
-		return Variant();
-	}
-
-	String name = selected->get_text(0);
-	VBoxContainer *vb = memnew(VBoxContainer);
-	HBoxContainer *hb = memnew(HBoxContainer);
-	Label *label = memnew(Label(name));
-	hb->set_modulate(Color(1, 1, 1, 1.0f));
-	hb->add_child(label);
-	vb->add_child(hb);
-	input_editor->set_drag_preview(vb);
-
-	Dictionary drag_data;
-	drag_data["type"] = "nodes";
-
-	input_editor->set_drop_mode_flags(Tree::DROP_MODE_INBETWEEN);
-
-	return drag_data;
-}
-
-bool ProjectSettingsEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
-	Dictionary d = p_data;
-	if (!d.has("type") || d["type"] != "nodes") {
-		return false;
-	}
-
-	TreeItem *selected = input_editor->get_selected();
-	TreeItem *item = input_editor->get_item_at_position(p_point);
-	if (!selected || !item || item == selected || item->get_parent() == selected) {
-		return false;
-	}
-
-	return true;
-}
-
-void ProjectSettingsEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-	if (!can_drop_data_fw(p_point, p_data, p_from)) {
-		return;
-	}
-
-	TreeItem *selected = input_editor->get_selected();
-	TreeItem *item = input_editor->get_item_at_position(p_point);
-	if (!item) {
-		return;
-	}
-	TreeItem *target = item->get_parent() == input_editor->get_root() ? item : item->get_parent();
-
-	String selected_name = "input/" + selected->get_text(0);
-	int old_order = ProjectSettings::get_singleton()->get_order(selected_name);
-	String target_name = "input/" + target->get_text(0);
-	int target_order = ProjectSettings::get_singleton()->get_order(target_name);
-
-	int order = old_order;
-	bool is_below = target_order > old_order;
-	TreeItem *iterator = is_below ? selected->get_next() : selected->get_prev();
-
-	undo_redo->create_action(TTR("Moved Input Action Event"));
-	while (iterator != target) {
-		String iterator_name = "input/" + iterator->get_text(0);
-		int iterator_order = ProjectSettings::get_singleton()->get_order(iterator_name);
-		undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", iterator_name, order);
-		undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", iterator_name, iterator_order);
-		order = iterator_order;
-		iterator = is_below ? iterator->get_next() : iterator->get_prev();
-	}
-
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", target_name, order);
-	undo_redo->add_do_method(ProjectSettings::get_singleton(), "set_order", selected_name, target_order);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", target_name, target_order);
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", selected_name, old_order);
-
-	undo_redo->add_do_method(this, "_update_actions");
-	undo_redo->add_undo_method(this, "_update_actions");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-}
-
 void ProjectSettingsEditor::_copy_to_platform(int p_which) {
 	String path = globals_editor->get_inspector()->get_selected_path();
 	if (path == String()) {
@@ -1219,572 +297,6 @@ void ProjectSettingsEditor::_copy_to_platform(int p_which) {
 	undo_redo->add_undo_method(this, "_settings_changed");
 
 	undo_redo->commit_action();
-}
-
-void ProjectSettingsEditor::add_translation(const String &p_translation) {
-	_translation_add(p_translation);
-}
-
-void ProjectSettingsEditor::_translation_add(const String &p_path) {
-	PackedStringArray translations = ProjectSettings::get_singleton()->get("locale/translations");
-
-	for (int i = 0; i < translations.size(); i++) {
-		if (translations[i] == p_path) {
-			return; //exists
-		}
-	}
-
-	translations.push_back(p_path);
-	undo_redo->create_action(TTR("Add Translation"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translations", translations);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translations", ProjectSettings::get_singleton()->get("locale/translations"));
-	undo_redo->add_do_method(this, "_update_translations");
-	undo_redo->add_undo_method(this, "_update_translations");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-}
-
-void ProjectSettingsEditor::_translation_file_open() {
-	translation_file_open->popup_centered_ratio();
-}
-
-void ProjectSettingsEditor::_translation_delete(Object *p_item, int p_column, int p_button) {
-	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
-	ERR_FAIL_COND(!ti);
-
-	int idx = ti->get_metadata(0);
-
-	PackedStringArray translations = ProjectSettings::get_singleton()->get("locale/translations");
-
-	ERR_FAIL_INDEX(idx, translations.size());
-
-	translations.remove(idx);
-
-	undo_redo->create_action(TTR("Remove Translation"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translations", translations);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translations", ProjectSettings::get_singleton()->get("locale/translations"));
-	undo_redo->add_do_method(this, "_update_translations");
-	undo_redo->add_undo_method(this, "_update_translations");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-}
-
-void ProjectSettingsEditor::_translation_res_file_open() {
-	translation_res_file_open->popup_centered_ratio();
-}
-
-void ProjectSettingsEditor::_translation_res_add(const String &p_path) {
-	Variant prev;
-	Dictionary remaps;
-
-	if (ProjectSettings::get_singleton()->has_setting("locale/translation_remaps")) {
-		remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
-		prev = remaps;
-	}
-
-	if (remaps.has(p_path)) {
-		return; //pointless already has it
-	}
-
-	remaps[p_path] = PackedStringArray();
-
-	undo_redo->create_action(TTR("Add Remapped Path"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", prev);
-	undo_redo->add_do_method(this, "_update_translations");
-	undo_redo->add_undo_method(this, "_update_translations");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-}
-
-void ProjectSettingsEditor::_translation_res_option_file_open() {
-	translation_res_option_file_open->popup_centered_ratio();
-}
-
-void ProjectSettingsEditor::_translation_res_option_add(const String &p_path) {
-	ERR_FAIL_COND(!ProjectSettings::get_singleton()->has_setting("locale/translation_remaps"));
-
-	Dictionary remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
-
-	TreeItem *k = translation_remap->get_selected();
-	ERR_FAIL_COND(!k);
-
-	String key = k->get_metadata(0);
-
-	ERR_FAIL_COND(!remaps.has(key));
-	PackedStringArray r = remaps[key];
-	r.push_back(p_path + ":" + "en");
-	remaps[key] = r;
-
-	undo_redo->create_action(TTR("Resource Remap Add Remap"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", ProjectSettings::get_singleton()->get("locale/translation_remaps"));
-	undo_redo->add_do_method(this, "_update_translations");
-	undo_redo->add_undo_method(this, "_update_translations");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-}
-
-void ProjectSettingsEditor::_translation_res_select() {
-	if (updating_translations) {
-		return;
-	}
-
-	call_deferred("_update_translations");
-}
-
-void ProjectSettingsEditor::_translation_res_option_changed() {
-	if (updating_translations) {
-		return;
-	}
-
-	if (!ProjectSettings::get_singleton()->has_setting("locale/translation_remaps")) {
-		return;
-	}
-
-	Dictionary remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
-
-	TreeItem *k = translation_remap->get_selected();
-	ERR_FAIL_COND(!k);
-	TreeItem *ed = translation_remap_options->get_edited();
-	ERR_FAIL_COND(!ed);
-
-	String key = k->get_metadata(0);
-	int idx = ed->get_metadata(0);
-	String path = ed->get_metadata(1);
-	int which = ed->get_range(1);
-
-	Vector<String> langs = TranslationServer::get_all_locales();
-
-	ERR_FAIL_INDEX(which, langs.size());
-
-	ERR_FAIL_COND(!remaps.has(key));
-	PackedStringArray r = remaps[key];
-	ERR_FAIL_INDEX(idx, r.size());
-	if (translation_locales_idxs_remap.size() > which) {
-		r.set(idx, path + ":" + langs[translation_locales_idxs_remap[which]]);
-	} else {
-		r.set(idx, path + ":" + langs[which]);
-	}
-	remaps[key] = r;
-
-	updating_translations = true;
-	undo_redo->create_action(TTR("Change Resource Remap Language"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", ProjectSettings::get_singleton()->get("locale/translation_remaps"));
-	undo_redo->add_do_method(this, "_update_translations");
-	undo_redo->add_undo_method(this, "_update_translations");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-	updating_translations = false;
-}
-
-void ProjectSettingsEditor::_translation_res_delete(Object *p_item, int p_column, int p_button) {
-	if (updating_translations) {
-		return;
-	}
-
-	if (!ProjectSettings::get_singleton()->has_setting("locale/translation_remaps")) {
-		return;
-	}
-
-	Dictionary remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
-
-	TreeItem *k = Object::cast_to<TreeItem>(p_item);
-
-	String key = k->get_metadata(0);
-	ERR_FAIL_COND(!remaps.has(key));
-
-	remaps.erase(key);
-
-	undo_redo->create_action(TTR("Remove Resource Remap"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", ProjectSettings::get_singleton()->get("locale/translation_remaps"));
-	undo_redo->add_do_method(this, "_update_translations");
-	undo_redo->add_undo_method(this, "_update_translations");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-}
-
-void ProjectSettingsEditor::_translation_res_option_delete(Object *p_item, int p_column, int p_button) {
-	if (updating_translations) {
-		return;
-	}
-
-	if (!ProjectSettings::get_singleton()->has_setting("locale/translation_remaps")) {
-		return;
-	}
-
-	Dictionary remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
-
-	TreeItem *k = translation_remap->get_selected();
-	ERR_FAIL_COND(!k);
-	TreeItem *ed = Object::cast_to<TreeItem>(p_item);
-	ERR_FAIL_COND(!ed);
-
-	String key = k->get_metadata(0);
-	int idx = ed->get_metadata(0);
-
-	ERR_FAIL_COND(!remaps.has(key));
-	PackedStringArray r = remaps[key];
-	ERR_FAIL_INDEX(idx, r.size());
-	r.remove(idx);
-	remaps[key] = r;
-
-	undo_redo->create_action(TTR("Remove Resource Remap Option"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translation_remaps", remaps);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translation_remaps", ProjectSettings::get_singleton()->get("locale/translation_remaps"));
-	undo_redo->add_do_method(this, "_update_translations");
-	undo_redo->add_undo_method(this, "_update_translations");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-}
-
-void ProjectSettingsEditor::_translation_filter_option_changed() {
-	int sel_id = translation_locale_filter_mode->get_selected_id();
-	TreeItem *t = translation_filter->get_edited();
-	String locale = t->get_tooltip(0);
-	bool checked = t->is_checked(0);
-
-	Variant prev;
-	Array f_locales_all;
-
-	if (ProjectSettings::get_singleton()->has_setting("locale/locale_filter")) {
-		f_locales_all = ProjectSettings::get_singleton()->get("locale/locale_filter");
-		prev = f_locales_all;
-
-		if (f_locales_all.size() != 2) {
-			f_locales_all.clear();
-			f_locales_all.append(sel_id);
-			f_locales_all.append(Array());
-		}
-	} else {
-		f_locales_all.append(sel_id);
-		f_locales_all.append(Array());
-	}
-
-	Array f_locales = f_locales_all[1];
-	int l_idx = f_locales.find(locale);
-
-	if (checked) {
-		if (l_idx == -1) {
-			f_locales.append(locale);
-		}
-	} else {
-		if (l_idx != -1) {
-			f_locales.remove(l_idx);
-		}
-	}
-
-	f_locales = f_locales.sort();
-
-	undo_redo->create_action(TTR("Changed Locale Filter"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/locale_filter", f_locales_all);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/locale_filter", prev);
-	undo_redo->add_do_method(this, "_update_translations");
-	undo_redo->add_undo_method(this, "_update_translations");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-}
-
-void ProjectSettingsEditor::_translation_filter_mode_changed(int p_mode) {
-	int sel_id = translation_locale_filter_mode->get_selected_id();
-
-	Variant prev;
-	Array f_locales_all;
-
-	if (ProjectSettings::get_singleton()->has_setting("locale/locale_filter")) {
-		f_locales_all = ProjectSettings::get_singleton()->get("locale/locale_filter");
-		prev = f_locales_all;
-
-		if (f_locales_all.size() != 2) {
-			f_locales_all.clear();
-			f_locales_all.append(sel_id);
-			f_locales_all.append(Array());
-		} else {
-			f_locales_all[0] = sel_id;
-		}
-	} else {
-		f_locales_all.append(sel_id);
-		f_locales_all.append(Array());
-	}
-
-	undo_redo->create_action(TTR("Changed Locale Filter Mode"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/locale_filter", f_locales_all);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/locale_filter", prev);
-	undo_redo->add_do_method(this, "_update_translations");
-	undo_redo->add_undo_method(this, "_update_translations");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-}
-
-void ProjectSettingsEditor::_translation_pot_add(const String &p_path) {
-	PackedStringArray pot_translations = ProjectSettings::get_singleton()->get("locale/translations_pot_files");
-
-	for (int i = 0; i < pot_translations.size(); i++) {
-		if (pot_translations[i] == p_path) {
-			return; //exists
-		}
-	}
-
-	pot_translations.push_back(p_path);
-	undo_redo->create_action(TTR("Add files for POT generation"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translations_pot_files", pot_translations);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translations_pot_files", ProjectSettings::get_singleton()->get("locale/translations_pot_files"));
-	undo_redo->add_do_method(this, "_update_translations");
-	undo_redo->add_undo_method(this, "_update_translations");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-}
-
-void ProjectSettingsEditor::_translation_pot_delete(Object *p_item, int p_column, int p_button) {
-	TreeItem *ti = Object::cast_to<TreeItem>(p_item);
-	ERR_FAIL_COND(!ti);
-
-	int idx = ti->get_metadata(0);
-
-	PackedStringArray pot_translations = ProjectSettings::get_singleton()->get("locale/translations_pot_files");
-
-	ERR_FAIL_INDEX(idx, pot_translations.size());
-
-	pot_translations.remove(idx);
-
-	undo_redo->create_action(TTR("Remove file from POT generation"));
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/translations_pot_files", pot_translations);
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "locale/translations_pot_files", ProjectSettings::get_singleton()->get("locale/translations_pot_files"));
-	undo_redo->add_do_method(this, "_update_translations");
-	undo_redo->add_undo_method(this, "_update_translations");
-	undo_redo->add_do_method(this, "_settings_changed");
-	undo_redo->add_undo_method(this, "_settings_changed");
-	undo_redo->commit_action();
-}
-
-void ProjectSettingsEditor::_translation_pot_file_open() {
-	translation_pot_file_open->popup_centered_ratio();
-}
-
-void ProjectSettingsEditor::_translation_pot_generate_open() {
-	translation_pot_generate->popup_centered_ratio();
-}
-
-void ProjectSettingsEditor::_translation_pot_generate(const String &p_file) {
-	POTGenerator::get_singleton()->generate_pot(p_file);
-}
-
-void ProjectSettingsEditor::_update_translation_pot_file_extensions() {
-	translation_pot_file_open->clear_filters();
-	List<String> translation_parse_file_extensions;
-	EditorTranslationParser::get_singleton()->get_recognized_extensions(&translation_parse_file_extensions);
-	for (List<String>::Element *E = translation_parse_file_extensions.front(); E; E = E->next()) {
-		translation_pot_file_open->add_filter("*." + E->get());
-	}
-}
-
-void ProjectSettingsEditor::_update_translations() {
-	// Update translations.
-
-	if (updating_translations) {
-		return;
-	}
-
-	updating_translations = true;
-
-	translation_list->clear();
-	TreeItem *root = translation_list->create_item(nullptr);
-	translation_list->set_hide_root(true);
-	if (ProjectSettings::get_singleton()->has_setting("locale/translations")) {
-		PackedStringArray translations = ProjectSettings::get_singleton()->get("locale/translations");
-		for (int i = 0; i < translations.size(); i++) {
-			TreeItem *t = translation_list->create_item(root);
-			t->set_editable(0, false);
-			t->set_text(0, translations[i].replace_first("res://", ""));
-			t->set_tooltip(0, translations[i]);
-			t->set_metadata(0, i);
-			t->add_button(0, input_editor->get_theme_icon("Remove", "EditorIcons"), 0, false, TTR("Remove"));
-		}
-	}
-
-	Vector<String> langs = TranslationServer::get_all_locales();
-	Vector<String> names = TranslationServer::get_all_locale_names();
-
-	//update filter tab
-	Array l_filter_all;
-
-	bool is_arr_empty = true;
-	if (ProjectSettings::get_singleton()->has_setting("locale/locale_filter")) {
-		l_filter_all = ProjectSettings::get_singleton()->get("locale/locale_filter");
-
-		if (l_filter_all.size() == 2) {
-			translation_locale_filter_mode->select(l_filter_all[0]);
-			is_arr_empty = false;
-		}
-	}
-	if (is_arr_empty) {
-		l_filter_all.append(0);
-		l_filter_all.append(Array());
-		translation_locale_filter_mode->select(0);
-	}
-
-	int filter_mode = l_filter_all[0];
-	Array l_filter = l_filter_all[1];
-
-	int s = names.size();
-	bool is_short_list_when_show_all_selected = filter_mode == SHOW_ALL_LOCALES && translation_filter_treeitems.size() < s;
-	bool is_full_list_when_show_only_selected = filter_mode == SHOW_ONLY_SELECTED_LOCALES && translation_filter_treeitems.size() == s;
-	bool should_recreate_locales_list = is_short_list_when_show_all_selected || is_full_list_when_show_only_selected;
-
-	if (!translation_locales_list_created || should_recreate_locales_list) {
-		translation_locales_list_created = true;
-		translation_filter->clear();
-		root = translation_filter->create_item(nullptr);
-		translation_filter->set_hide_root(true);
-		translation_filter_treeitems.clear();
-		for (int i = 0; i < s; i++) {
-			String n = names[i];
-			String l = langs[i];
-			bool is_checked = l_filter.has(l);
-			if (filter_mode == SHOW_ONLY_SELECTED_LOCALES && !is_checked) {
-				continue;
-			}
-
-			TreeItem *t = translation_filter->create_item(root);
-			t->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-			t->set_text(0, n);
-			t->set_editable(0, true);
-			t->set_tooltip(0, l);
-			t->set_checked(0, is_checked);
-			translation_filter_treeitems.push_back(t);
-		}
-	} else {
-		for (int i = 0; i < translation_filter_treeitems.size(); i++) {
-			TreeItem *t = translation_filter_treeitems[i];
-			t->set_checked(0, l_filter.has(t->get_tooltip(0)));
-		}
-	}
-
-	// Update translation remaps.
-
-	String remap_selected;
-	if (translation_remap->get_selected()) {
-		remap_selected = translation_remap->get_selected()->get_metadata(0);
-	}
-
-	translation_remap->clear();
-	translation_remap_options->clear();
-	root = translation_remap->create_item(nullptr);
-	TreeItem *root2 = translation_remap_options->create_item(nullptr);
-	translation_remap->set_hide_root(true);
-	translation_remap_options->set_hide_root(true);
-	translation_res_option_add_button->set_disabled(true);
-
-	translation_locales_idxs_remap.clear();
-	translation_locales_idxs_remap.resize(l_filter.size());
-	int fl_idx_count = translation_locales_idxs_remap.size();
-
-	String langnames = "";
-	int l_idx = 0;
-	for (int i = 0; i < names.size(); i++) {
-		if (filter_mode == SHOW_ONLY_SELECTED_LOCALES && fl_idx_count != 0) {
-			if (l_filter.size() > 0) {
-				if (l_filter.find(langs[i]) != -1) {
-					if (langnames.length() > 0) {
-						langnames += ",";
-					}
-					langnames += names[i];
-					translation_locales_idxs_remap.write[l_idx] = i;
-					l_idx++;
-				}
-			}
-		} else {
-			if (i > 0) {
-				langnames += ",";
-			}
-			langnames += names[i];
-		}
-	}
-
-	if (ProjectSettings::get_singleton()->has_setting("locale/translation_remaps")) {
-		Dictionary remaps = ProjectSettings::get_singleton()->get("locale/translation_remaps");
-		List<Variant> rk;
-		remaps.get_key_list(&rk);
-		Vector<String> keys;
-		for (List<Variant>::Element *E = rk.front(); E; E = E->next()) {
-			keys.push_back(E->get());
-		}
-		keys.sort();
-
-		for (int i = 0; i < keys.size(); i++) {
-			TreeItem *t = translation_remap->create_item(root);
-			t->set_editable(0, false);
-			t->set_text(0, keys[i].replace_first("res://", ""));
-			t->set_tooltip(0, keys[i]);
-			t->set_metadata(0, keys[i]);
-			t->add_button(0, input_editor->get_theme_icon("Remove", "EditorIcons"), 0, false, TTR("Remove"));
-			if (keys[i] == remap_selected) {
-				t->select(0);
-				translation_res_option_add_button->set_disabled(false);
-
-				PackedStringArray selected = remaps[keys[i]];
-				for (int j = 0; j < selected.size(); j++) {
-					String s2 = selected[j];
-					int qp = s2.rfind(":");
-					String path = s2.substr(0, qp);
-					String locale = s2.substr(qp + 1, s2.length());
-
-					TreeItem *t2 = translation_remap_options->create_item(root2);
-					t2->set_editable(0, false);
-					t2->set_text(0, path.replace_first("res://", ""));
-					t2->set_tooltip(0, path);
-					t2->set_metadata(0, j);
-					t2->add_button(0, input_editor->get_theme_icon("Remove", "EditorIcons"), 0, false, TTR("Remove"));
-					t2->set_cell_mode(1, TreeItem::CELL_MODE_RANGE);
-					t2->set_text(1, langnames);
-					t2->set_editable(1, true);
-					t2->set_metadata(1, path);
-					int idx = langs.find(locale);
-					if (idx < 0) {
-						idx = 0;
-					}
-
-					int f_idx = translation_locales_idxs_remap.find(idx);
-					if (f_idx != -1 && fl_idx_count > 0 && filter_mode == SHOW_ONLY_SELECTED_LOCALES) {
-						t2->set_range(1, f_idx);
-					} else {
-						t2->set_range(1, idx);
-					}
-				}
-			}
-		}
-	}
-
-	// Update translation POT files.
-
-	translation_pot_list->clear();
-	root = translation_pot_list->create_item(nullptr);
-	translation_pot_list->set_hide_root(true);
-	if (ProjectSettings::get_singleton()->has_setting("locale/translations_pot_files")) {
-		PackedStringArray pot_translations = ProjectSettings::get_singleton()->get("locale/translations_pot_files");
-		for (int i = 0; i < pot_translations.size(); i++) {
-			TreeItem *t = translation_pot_list->create_item(root);
-			t->set_editable(0, false);
-			t->set_text(0, pot_translations[i].replace_first("res://", ""));
-			t->set_tooltip(0, pot_translations[i]);
-			t->set_metadata(0, i);
-			t->add_button(0, input_editor->get_theme_icon("Remove", "EditorIcons"), 0, false, TTR("Remove"));
-		}
-	}
-
-	updating_translations = false;
 }
 
 void ProjectSettingsEditor::_toggle_search_bar(bool p_pressed) {
@@ -1825,17 +337,9 @@ void ProjectSettingsEditor::_editor_restart_close() {
 
 void ProjectSettingsEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_unhandled_input"), &ProjectSettingsEditor::_unhandled_input);
-	ClassDB::bind_method(D_METHOD("_item_checked"), &ProjectSettingsEditor::_item_checked);
 	ClassDB::bind_method(D_METHOD("_save"), &ProjectSettingsEditor::_save);
-	ClassDB::bind_method(D_METHOD("_update_actions"), &ProjectSettingsEditor::_update_actions);
-
-	ClassDB::bind_method(D_METHOD("_update_translations"), &ProjectSettingsEditor::_update_translations);
 
 	ClassDB::bind_method(D_METHOD("get_tabs"), &ProjectSettingsEditor::get_tabs);
-
-	ClassDB::bind_method(D_METHOD("get_drag_data_fw"), &ProjectSettingsEditor::get_drag_data_fw);
-	ClassDB::bind_method(D_METHOD("can_drop_data_fw"), &ProjectSettingsEditor::can_drop_data_fw);
-	ClassDB::bind_method(D_METHOD("drop_data_fw"), &ProjectSettingsEditor::drop_data_fw);
 }
 
 ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
@@ -1851,21 +355,21 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	add_child(tab_container);
 
 	VBoxContainer *props_base = memnew(VBoxContainer);
+	props_base->set_name(TTR("General"));
 	props_base->set_alignment(BoxContainer::ALIGN_BEGIN);
 	props_base->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tab_container->add_child(props_base);
-	props_base->set_name(TTR("General"));
 
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	hbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	props_base->add_child(hbc);
 
 	search_button = memnew(Button);
+	search_button->set_text(TTR("Search"));
 	search_button->set_toggle_mode(true);
 	search_button->set_pressed(false);
-	search_button->set_text(TTR("Search"));
-	hbc->add_child(search_button);
 	search_button->connect("toggled", callable_mp(this, &ProjectSettingsEditor::_toggle_search_bar));
+	hbc->add_child(search_button);
 
 	hbc->add_child(memnew(VSeparator));
 
@@ -1874,26 +378,26 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	hbc->add_child(add_prop_bar);
 
 	Label *l = memnew(Label);
-	add_prop_bar->add_child(l);
 	l->set_text(TTR("Category:"));
+	add_prop_bar->add_child(l);
 
 	category = memnew(LineEdit);
 	category->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	add_prop_bar->add_child(category);
 	category->connect("text_entered", callable_mp(this, &ProjectSettingsEditor::_item_adds));
+	add_prop_bar->add_child(category);
 
 	l = memnew(Label);
-	add_prop_bar->add_child(l);
 	l->set_text(TTR("Property:"));
+	add_prop_bar->add_child(l);
 
 	property = memnew(LineEdit);
 	property->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	add_prop_bar->add_child(property);
 	property->connect("text_entered", callable_mp(this, &ProjectSettingsEditor::_item_adds));
+	add_prop_bar->add_child(property);
 
 	l = memnew(Label);
-	add_prop_bar->add_child(l);
 	l->set_text(TTR("Type:"));
+	add_prop_bar->add_child(l);
 
 	type = memnew(OptionButton);
 	type->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -1905,32 +409,32 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	}
 
 	Button *add = memnew(Button);
-	add_prop_bar->add_child(add);
 	add->set_text(TTR("Add"));
 	add->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_item_add));
+	add_prop_bar->add_child(add);
 
 	search_bar = memnew(HBoxContainer);
 	search_bar->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	hbc->add_child(search_bar);
 	search_bar->hide();
+	hbc->add_child(search_bar);
 
 	search_box = memnew(LineEdit);
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	search_bar->add_child(search_box);
 
 	globals_editor = memnew(SectionedInspector);
-	props_base->add_child(globals_editor);
 	globals_editor->get_inspector()->set_undo_redo(EditorNode::get_singleton()->get_undo_redo());
 	globals_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	globals_editor->register_search_box(search_box);
 	globals_editor->get_inspector()->connect("property_selected", callable_mp(this, &ProjectSettingsEditor::_item_selected));
 	globals_editor->get_inspector()->connect("property_edited", callable_mp(this, &ProjectSettingsEditor::_settings_prop_edited));
 	globals_editor->get_inspector()->connect("restart_requested", callable_mp(this, &ProjectSettingsEditor::_editor_restart_request));
+	props_base->add_child(globals_editor);
 
 	Button *del = memnew(Button);
-	hbc->add_child(del);
 	del->set_text(TTR("Delete"));
 	del->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_item_del));
+	hbc->add_child(del);
 
 	add_prop_bar->add_child(memnew(VSeparator));
 
@@ -1947,296 +451,52 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	restart_container = memnew(PanelContainer);
 	props_base->add_child(restart_container);
+
 	HBoxContainer *restart_hb = memnew(HBoxContainer);
+	restart_container->hide();
 	restart_container->add_child(restart_hb);
+
 	restart_icon = memnew(TextureRect);
 	restart_icon->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 	restart_hb->add_child(restart_icon);
+
 	restart_label = memnew(Label);
 	restart_label->set_text(TTR("Changed settings will be applied to the editor after restarting."));
 	restart_hb->add_child(restart_label);
 	restart_hb->add_spacer();
+
 	Button *restart_button = memnew(Button);
 	restart_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_editor_restart));
 	restart_hb->add_child(restart_button);
 	restart_button->set_text(TTR("Save & Restart"));
+
 	restart_close_button = memnew(Button);
 	restart_close_button->set_flat(true);
 	restart_close_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_editor_restart_close));
 	restart_hb->add_child(restart_close_button);
-	restart_container->hide();
 
 	message = memnew(AcceptDialog);
 	add_child(message);
 
-	Control *input_base = memnew(Control);
-	input_base->set_name(TTR("Input Map"));
-	tab_container->add_child(input_base);
+	inputmap_editor = memnew(InputMapEditor);
+	inputmap_editor->set_name(TTR("Input Map"));
+	inputmap_editor->connect("inputmap_changed", callable_mp(this, &ProjectSettingsEditor::_settings_changed));
+	tab_container->add_child(inputmap_editor);
 
-	VBoxContainer *vbc = memnew(VBoxContainer);
-	input_base->add_child(vbc);
-	vbc->set_anchor_and_margin(MARGIN_TOP, Control::ANCHOR_BEGIN, 0);
-	vbc->set_anchor_and_margin(MARGIN_BOTTOM, Control::ANCHOR_END, 0);
-	vbc->set_anchor_and_margin(MARGIN_LEFT, Control::ANCHOR_BEGIN, 0);
-	vbc->set_anchor_and_margin(MARGIN_RIGHT, Control::ANCHOR_END, 0);
-
-	hbc = memnew(HBoxContainer);
-	vbc->add_child(hbc);
-
-	l = memnew(Label);
-	hbc->add_child(l);
-	l->set_text(TTR("Action:"));
-
-	action_name = memnew(LineEdit);
-	action_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	hbc->add_child(action_name);
-	action_name->connect("text_entered", callable_mp(this, &ProjectSettingsEditor::_action_adds));
-	action_name->connect("text_changed", callable_mp(this, &ProjectSettingsEditor::_action_check));
-
-	action_add_error = memnew(Label);
-	hbc->add_child(action_add_error);
-	action_add_error->hide();
-
-	add = memnew(Button);
-	hbc->add_child(add);
-	add->set_text(TTR("Add"));
-	add->set_disabled(true);
-	add->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_action_add));
-	action_add = add;
-
-	input_editor = memnew(Tree);
-	vbc->add_child(input_editor);
-	input_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	input_editor->set_columns(3);
-	input_editor->set_column_titles_visible(true);
-	input_editor->set_column_title(0, TTR("Action"));
-	input_editor->set_column_title(1, TTR("Deadzone"));
-	input_editor->set_column_expand(1, false);
-	input_editor->set_column_min_width(1, 80 * EDSCALE);
-	input_editor->set_column_expand(2, false);
-	input_editor->set_column_min_width(2, 50 * EDSCALE);
-	input_editor->connect("item_edited", callable_mp(this, &ProjectSettingsEditor::_action_edited));
-	input_editor->connect("item_activated", callable_mp(this, &ProjectSettingsEditor::_action_activated));
-	input_editor->connect("cell_selected", callable_mp(this, &ProjectSettingsEditor::_action_selected));
-	input_editor->connect("button_pressed", callable_mp(this, &ProjectSettingsEditor::_action_button_pressed));
-#ifndef _MSC_VER
-#warning need to make drag data forwarding to non controls happen
-#endif
-	//input_editor->set_drag_forwarding(this);
-
-	popup_add = memnew(PopupMenu);
-	add_child(popup_add);
-	popup_add->connect("id_pressed", callable_mp(this, &ProjectSettingsEditor::_add_item), make_binds(Ref<InputEvent>()));
-
-	press_a_key_physical = false;
-
-	press_a_key = memnew(ConfirmationDialog);
-	//press_a_key->set_focus_mode(Control::FOCUS_ALL);
-	add_child(press_a_key);
-
-	l = memnew(Label);
-	l->set_text(TTR("Press a Key..."));
-	l->set_anchors_and_margins_preset(Control::PRESET_WIDE);
-	l->set_align(Label::ALIGN_CENTER);
-	l->set_margin(MARGIN_TOP, 20);
-	l->set_anchor_and_margin(MARGIN_BOTTOM, Control::ANCHOR_BEGIN, 30);
-	press_a_key->get_ok()->set_disabled(true);
-	press_a_key_label = l;
-	press_a_key->add_child(l);
-	press_a_key->connect("window_input", callable_mp(this, &ProjectSettingsEditor::_wait_for_key));
-	press_a_key->connect("confirmed", callable_mp(this, &ProjectSettingsEditor::_press_a_key_confirm));
-
-	device_input = memnew(ConfirmationDialog);
-	add_child(device_input);
-	device_input->get_ok()->set_text(TTR("Add"));
-	device_input->connect("confirmed", callable_mp(this, &ProjectSettingsEditor::_device_input_add));
-
-	hbc = memnew(HBoxContainer);
-	device_input->add_child(hbc);
-
-	VBoxContainer *vbc_left = memnew(VBoxContainer);
-	hbc->add_child(vbc_left);
-
-	l = memnew(Label);
-	l->set_text(TTR("Device:"));
-	vbc_left->add_child(l);
-
-	device_id = memnew(OptionButton);
-	for (int i = -1; i < 8; i++) {
-		device_id->add_item(_get_device_string(i));
-	}
-	_set_current_device(0);
-	vbc_left->add_child(device_id);
-
-	VBoxContainer *vbc_right = memnew(VBoxContainer);
-	hbc->add_child(vbc_right);
-	vbc_right->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-
-	l = memnew(Label);
-	l->set_text(TTR("Index:"));
-	vbc_right->add_child(l);
-	device_index_label = l;
-
-	device_index = memnew(OptionButton);
-	device_index->set_clip_text(true);
-
-	vbc_right->add_child(device_index);
-
-	setting = false;
-
-	//translations
-	TabContainer *translations = memnew(TabContainer);
-	translations->set_tab_align(TabContainer::ALIGN_LEFT);
-	translations->set_name(TTR("Localization"));
-	tab_container->add_child(translations);
-	//remap for properly select language in popup
-	translation_locales_idxs_remap = Vector<int>();
-	translation_locales_list_created = false;
-
-	{
-		VBoxContainer *tvb = memnew(VBoxContainer);
-		translations->add_child(tvb);
-		tvb->set_name(TTR("Translations"));
-		HBoxContainer *thb = memnew(HBoxContainer);
-		tvb->add_child(thb);
-		thb->add_child(memnew(Label(TTR("Translations:"))));
-		thb->add_spacer();
-		Button *addtr = memnew(Button(TTR("Add...")));
-		addtr->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_translation_file_open));
-		thb->add_child(addtr);
-		VBoxContainer *tmc = memnew(VBoxContainer);
-		tvb->add_child(tmc);
-		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		translation_list = memnew(Tree);
-		translation_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		tmc->add_child(translation_list);
-
-		translation_file_open = memnew(EditorFileDialog);
-		add_child(translation_file_open);
-		translation_file_open->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-		translation_file_open->connect("file_selected", callable_mp(this, &ProjectSettingsEditor::_translation_add));
-	}
-
-	{
-		VBoxContainer *tvb = memnew(VBoxContainer);
-		translations->add_child(tvb);
-		tvb->set_name(TTR("Remaps"));
-		HBoxContainer *thb = memnew(HBoxContainer);
-		tvb->add_child(thb);
-		thb->add_child(memnew(Label(TTR("Resources:"))));
-		thb->add_spacer();
-		Button *addtr = memnew(Button(TTR("Add...")));
-		addtr->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_translation_res_file_open));
-		thb->add_child(addtr);
-		VBoxContainer *tmc = memnew(VBoxContainer);
-		tvb->add_child(tmc);
-		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		translation_remap = memnew(Tree);
-		translation_remap->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		translation_remap->connect("cell_selected", callable_mp(this, &ProjectSettingsEditor::_translation_res_select));
-		tmc->add_child(translation_remap);
-		translation_remap->connect("button_pressed", callable_mp(this, &ProjectSettingsEditor::_translation_res_delete));
-
-		translation_res_file_open = memnew(EditorFileDialog);
-		add_child(translation_res_file_open);
-		translation_res_file_open->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-		translation_res_file_open->connect("file_selected", callable_mp(this, &ProjectSettingsEditor::_translation_res_add));
-
-		thb = memnew(HBoxContainer);
-		tvb->add_child(thb);
-		thb->add_child(memnew(Label(TTR("Remaps by Locale:"))));
-		thb->add_spacer();
-		addtr = memnew(Button(TTR("Add...")));
-		addtr->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_translation_res_option_file_open));
-		translation_res_option_add_button = addtr;
-		thb->add_child(addtr);
-		tmc = memnew(VBoxContainer);
-		tvb->add_child(tmc);
-		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		translation_remap_options = memnew(Tree);
-		translation_remap_options->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		tmc->add_child(translation_remap_options);
-
-		translation_remap_options->set_columns(2);
-		translation_remap_options->set_column_title(0, TTR("Path"));
-		translation_remap_options->set_column_title(1, TTR("Locale"));
-		translation_remap_options->set_column_titles_visible(true);
-		translation_remap_options->set_column_expand(0, true);
-		translation_remap_options->set_column_expand(1, false);
-		translation_remap_options->set_column_min_width(1, 200);
-		translation_remap_options->connect("item_edited", callable_mp(this, &ProjectSettingsEditor::_translation_res_option_changed));
-		translation_remap_options->connect("button_pressed", callable_mp(this, &ProjectSettingsEditor::_translation_res_option_delete));
-
-		translation_res_option_file_open = memnew(EditorFileDialog);
-		add_child(translation_res_option_file_open);
-		translation_res_option_file_open->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-		translation_res_option_file_open->connect("file_selected", callable_mp(this, &ProjectSettingsEditor::_translation_res_option_add));
-	}
-
-	{
-		VBoxContainer *tvb = memnew(VBoxContainer);
-		translations->add_child(tvb);
-		tvb->set_name(TTR("Locales Filter"));
-		VBoxContainer *tmc = memnew(VBoxContainer);
-		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		tvb->add_child(tmc);
-
-		translation_locale_filter_mode = memnew(OptionButton);
-		translation_locale_filter_mode->add_item(TTR("Show All Locales"), SHOW_ALL_LOCALES);
-		translation_locale_filter_mode->add_item(TTR("Show Selected Locales Only"), SHOW_ONLY_SELECTED_LOCALES);
-		translation_locale_filter_mode->select(0);
-		tmc->add_margin_child(TTR("Filter mode:"), translation_locale_filter_mode);
-		translation_locale_filter_mode->connect("item_selected", callable_mp(this, &ProjectSettingsEditor::_translation_filter_mode_changed));
-
-		translation_filter = memnew(Tree);
-		translation_filter->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		translation_filter->set_columns(1);
-		tmc->add_child(memnew(Label(TTR("Locales:"))));
-		tmc->add_child(translation_filter);
-		translation_filter->connect("item_edited", callable_mp(this, &ProjectSettingsEditor::_translation_filter_option_changed));
-	}
-
-	{
-		VBoxContainer *tvb = memnew(VBoxContainer);
-		translations->add_child(tvb);
-		tvb->set_name(TTR("POT Generation"));
-		HBoxContainer *thb = memnew(HBoxContainer);
-		tvb->add_child(thb);
-		thb->add_child(memnew(Label(TTR("Files with translation strings:"))));
-		thb->add_spacer();
-		Button *addtr = memnew(Button(TTR("Add...")));
-		addtr->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_translation_pot_file_open));
-		thb->add_child(addtr);
-		Button *generate = memnew(Button(TTR("Generate POT")));
-		generate->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_translation_pot_generate_open));
-		thb->add_child(generate);
-		VBoxContainer *tmc = memnew(VBoxContainer);
-		tvb->add_child(tmc);
-		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		translation_pot_list = memnew(Tree);
-		translation_pot_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-		tmc->add_child(translation_pot_list);
-
-		translation_pot_generate = memnew(EditorFileDialog);
-		add_child(translation_pot_generate);
-		translation_pot_generate->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
-		translation_pot_generate->connect("file_selected", callable_mp(this, &ProjectSettingsEditor::_translation_pot_generate));
-
-		translation_pot_file_open = memnew(EditorFileDialog);
-		add_child(translation_pot_file_open);
-		translation_pot_file_open->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-		translation_pot_file_open->connect("file_selected", callable_mp(this, &ProjectSettingsEditor::_translation_pot_add));
-	}
+	localization_editor = memnew(LocalizationEditor);
+	localization_editor->set_name(TTR("Localization"));
+	localization_editor->connect("localization_changed", callable_mp(this, &ProjectSettingsEditor::_settings_changed));
+	tab_container->add_child(localization_editor);
 
 	autoload_settings = memnew(EditorAutoloadSettings);
 	autoload_settings->set_name(TTR("AutoLoad"));
-	tab_container->add_child(autoload_settings);
 	autoload_settings->connect("autoload_changed", callable_mp(this, &ProjectSettingsEditor::_settings_changed));
+	tab_container->add_child(autoload_settings);
 
 	shaders_global_variables_editor = memnew(ShaderGlobalsEditor);
 	shaders_global_variables_editor->set_name(TTR("Shader Globals"));
-	tab_container->add_child(shaders_global_variables_editor);
 	shaders_global_variables_editor->connect("globals_changed", callable_mp(this, &ProjectSettingsEditor::_settings_changed));
+	tab_container->add_child(shaders_global_variables_editor);
 
 	plugin_settings = memnew(EditorPluginSettings);
 	plugin_settings->set_name(TTR("Plugins"));
@@ -2247,6 +507,4 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	timer->connect("timeout", callable_mp(ProjectSettings::get_singleton(), &ProjectSettings::save));
 	timer->set_one_shot(true);
 	add_child(timer);
-
-	updating_translations = false;
 }


### PR DESCRIPTION
The ProjectSettingsEditor has multiple tabs, some of which have their own file. Two tabs are still part of the main file. With this commit, the editors for InputMap and for Localization are moved to new files. Codewise not much has changed, but this should make it easier to modify these editors in the future.

It seemed like a good choice, because:
 - Other editors (such as for autoload, or shaderglobals) already had their own file.
 - Just like those, these editors are quite large in LoC, and also easily decoupled from the ProjectSettingsEditor.

Similar to how these other editors were decoupled, instead of saving the PS directly, the two tabs emit a signal when some setting has changed. This signal is received by the ProjectSettingsEditor, which then calls `_settings_changed`, saving the PS.  

Other changes 
- Removed empty method _item_checked from ProjectSettingsEditor.
- Reordered some code for better readability.