### PR TITLE
Decrease margins around the editor and project manager windows

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5933,8 +5933,12 @@ EditorNode::EditorNode() {
 
 	main_vbox = memnew(VBoxContainer);
 	gui_base->add_child(main_vbox);
-	main_vbox->set_anchors_and_offsets_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 8);
-	main_vbox->add_theme_constant_override("separation", 8 * EDSCALE);
+	// Add just one pixel of offset on all sides to prevent text or controls from touching the edges of the screen,
+	// and being partially occluded on some displays.
+	main_vbox->set_anchors_and_offsets_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, Math::round(EDSCALE));
+	// Add some offset at the top to avoid making text touch the window's top edge.
+	main_vbox->set_offset(SIDE_TOP, Math::round(4 * EDSCALE));
+	main_vbox->add_theme_constant_override("separation", Math::round(4 * EDSCALE));
 
 	menu_hb = memnew(HBoxContainer);
 	main_vbox->add_child(menu_hb);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2472,7 +2472,11 @@ ProjectManager::ProjectManager() {
 
 	VBoxContainer *vb = memnew(VBoxContainer);
 	panel->add_child(vb);
-	vb->set_anchors_and_offsets_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 8 * EDSCALE);
+	// Add just one pixel of offset on all sides to prevent text or controls from touching the edges of the screen,
+	// and being partially occluded on some displays.
+	vb->set_anchors_and_offsets_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, Math::round(EDSCALE));
+	// Add some offset at the top to avoid making text touch the window's top edge.
+	vb->set_offset(SIDE_TOP, Math::round(4 * EDSCALE));
 
 	Control *center_box = memnew(Control);
 	center_box->set_v_size_flags(Control::SIZE_EXPAND_FILL);


### PR DESCRIPTION
This increases the screen real estate available for Godot, especially at smaller window sizes.

## Preview

***Edit:** This preview is outdated; there's now 1 pixel of margin on all sides (instead of 0).*

### Editor - Before

![Before](https://user-images.githubusercontent.com/180032/87227127-17818c00-c399-11ea-8cc6-9ba6c7596264.png)

### Editor - After

![image](https://user-images.githubusercontent.com/180032/87431798-6de40a00-c5e7-11ea-8434-6ef24f7ffe09.png)

### Project manager - Before

![Before](https://user-images.githubusercontent.com/180032/87227134-1fd9c700-c399-11ea-803c-3e4022eeb0a8.png)

### Project manager - After

![After](https://user-images.githubusercontent.com/180032/87227135-20725d80-c399-11ea-82be-03ead1882128.png)