### PR TITLE
Resize various dialogs

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4370,7 +4370,7 @@ void AnimationTrackEditor::_add_track(int p_type) {
 		return;
 	}
 	adding_track_type = p_type;
-	pick_track->popup_centered_ratio();
+	pick_track->popup_scenetree_dialog();
 }
 
 void AnimationTrackEditor::_new_track_property_selected(String p_name) {
@@ -5731,7 +5731,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	pick_track = memnew(SceneTreeDialog);
 	add_child(pick_track);
-	pick_track->set_title(TTR("Pick the node that will be animated:"));
+	pick_track->set_title(TTR("Pick a node to animate:"));
 	pick_track->connect("selected", callable_mp(this, &AnimationTrackEditor::_new_track_node_selected));
 	prop_selector = memnew(PropertySelector);
 	add_child(prop_selector);

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -238,7 +238,7 @@ void EditorDebuggerTree::_item_menu_id_pressed(int p_option) {
 				file_dialog->add_filter("*." + extensions[i] + " ; " + extensions[i].to_upper());
 			}
 
-			file_dialog->popup_centered_ratio();
+			file_dialog->popup_file_dialog();
 		} break;
 		case ITEM_MENU_COPY_NODE_PATH: {
 			String text = get_selected_path();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -282,7 +282,7 @@ void ScriptEditorDebugger::_video_mem_export() {
 	file_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	file_dialog->clear_filters();
 	file_dialog_purpose = SAVE_VRAM_CSV;
-	file_dialog->popup_centered_ratio();
+	file_dialog->popup_file_dialog();
 }
 
 Size2 ScriptEditorDebugger::get_minimum_size() const {
@@ -944,7 +944,7 @@ void ScriptEditorDebugger::_export_csv() {
 	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 	file_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	file_dialog_purpose = SAVE_MONITORS_CSV;
-	file_dialog->popup_centered_ratio();
+	file_dialog->popup_file_dialog();
 }
 
 String ScriptEditorDebugger::get_var_value(const String &p_var) const {

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -58,7 +58,7 @@ void DependencyEditor::_load_pressed(Object *p_item, int p_cell, int p_button) {
 	for (List<String>::Element *E = ext.front(); E; E = E->next()) {
 		search->add_filter("*" + E->get());
 	}
-	search->popup_centered_ratio(0.65); // So it doesn't completely cover the dialog below it.
+	search->popup_file_dialog();
 }
 
 void DependencyEditor::_fix_and_find(EditorFileSystemDirectory *efsd, Map<String, Map<String, String>> &candidates) {
@@ -205,7 +205,7 @@ void DependencyEditor::edit(const String &p_path) {
 	set_title(TTR("Dependencies For:") + " " + p_path.get_file());
 
 	_update_list();
-	popup_centered_ratio(0.7); // So it doesn't completely cover the dialog below it.
+	popup_centered_ratio(0.4);
 
 	if (EditorNode::get_singleton()->is_scene_open(p_path)) {
 		EditorNode::get_singleton()->show_warning(vformat(TTR("Scene '%s' is currently being edited.\nChanges will only take effect when reloaded."), p_path.get_file()));
@@ -323,7 +323,7 @@ void DependencyEditorOwners::show(const String &p_path) {
 	editing = p_path;
 	owners->clear();
 	_fill_owners(EditorFileSystem::get_singleton()->get_filesystem());
-	popup_centered_ratio();
+	popup_centered_ratio(0.3);
 
 	set_title(TTR("Owners Of:") + " " + p_path.get_file());
 }
@@ -714,7 +714,7 @@ void OrphanResourcesDialog::refresh() {
 
 void OrphanResourcesDialog::show() {
 	refresh();
-	popup_centered_ratio();
+	popup_centered_ratio(0.4);
 }
 
 void OrphanResourcesDialog::_find_to_delete(TreeItem *p_item, List<String> &paths) {

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1176,7 +1176,7 @@ void EditorAudioBuses::_save_as_layout() {
 	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 	file_dialog->set_title(TTR("Save Audio Bus Layout As..."));
 	file_dialog->set_current_path(edited_path);
-	file_dialog->popup_centered_ratio();
+	file_dialog->popup_file_dialog();
 	new_layout = false;
 }
 
@@ -1184,7 +1184,7 @@ void EditorAudioBuses::_new_layout() {
 	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 	file_dialog->set_title(TTR("Location for New Layout..."));
 	file_dialog->set_current_path(edited_path);
-	file_dialog->popup_centered_ratio();
+	file_dialog->popup_file_dialog();
 	new_layout = true;
 }
 
@@ -1192,7 +1192,7 @@ void EditorAudioBuses::_load_layout() {
 	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	file_dialog->set_title(TTR("Open Audio Bus Layout"));
 	file_dialog->set_current_path(edited_path);
-	file_dialog->popup_centered_ratio();
+	file_dialog->popup_file_dialog();
 	new_layout = false;
 }
 

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -919,5 +919,5 @@ void EditorAutoloadSettings::_set_autoload_add_path(const String &p_text) {
 }
 
 void EditorAutoloadSettings::_browse_autoload_add_path() {
-	file_dialog->popup_centered_ratio();
+	file_dialog->popup_file_dialog();
 }

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -403,10 +403,10 @@ void EditorFeatureProfileManager::_profile_action(int p_action) {
 			_emit_current_profile_changed();
 		} break;
 		case PROFILE_IMPORT: {
-			import_profiles->popup_centered_ratio();
+			import_profiles->popup_file_dialog();
 		} break;
 		case PROFILE_EXPORT: {
-			export_profile->popup_centered_ratio();
+			export_profile->popup_file_dialog();
 			export_profile->set_current_file(_get_selected_profile() + ".profile");
 		} break;
 		case PROFILE_NEW: {

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -50,6 +50,10 @@ EditorFileDialog::GetIconFunc EditorFileDialog::get_large_icon_func = nullptr;
 EditorFileDialog::RegisterFunc EditorFileDialog::register_func = nullptr;
 EditorFileDialog::RegisterFunc EditorFileDialog::unregister_func = nullptr;
 
+void EditorFileDialog::popup_file_dialog() {
+	popup_centered_clamped(Size2(1050, 700) * EDSCALE, 0.8);
+}
+
 VBoxContainer *EditorFileDialog::get_vbox() {
 	return vbox;
 }

--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -203,6 +203,7 @@ protected:
 	static void _bind_methods();
 	//bind helpers
 public:
+	void popup_file_dialog();
 	void clear_filters();
 	void add_filter(const String &p_filter);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -994,8 +994,8 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 		}
 		file->set_current_path(existing);
 	}
-	file->popup_centered_ratio();
 	file->set_title(TTR("Save Resource As..."));
+	file->popup_file_dialog();
 }
 
 void EditorNode::_menu_option(int p_option) {
@@ -2182,7 +2182,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				file->set_current_path(scene->get_filename());
 			};
 			file->set_title(p_option == FILE_OPEN_SCENE ? TTR("Open Scene") : TTR("Open Base Scene"));
-			file->popup_centered_ratio();
+			file->popup_file_dialog();
 
 		} break;
 		case FILE_QUICK_OPEN: {
@@ -2318,7 +2318,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				}
 				file->set_current_path(existing);
 			}
-			file->popup_centered_ratio();
+			file->popup_file_dialog();
 			file->set_title(TTR("Save Scene As..."));
 
 		} break;
@@ -2357,7 +2357,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				file_export_lib->add_filter("*." + E->get());
 			}
 
-			file_export_lib->popup_centered_ratio();
+			file_export_lib->popup_file_dialog();
 			file_export_lib->set_title(TTR("Export Mesh Library"));
 
 		} break;
@@ -2376,7 +2376,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				file_export_lib->add_filter("*." + E->get());
 			}
 
-			file_export_lib->popup_centered_ratio();
+			file_export_lib->popup_file_dialog();
 			file_export_lib->set_title(TTR("Export Tile Set"));
 
 		} break;
@@ -2642,7 +2642,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				file->set_current_path(scene->get_filename());
 			};
 			file->set_title(TTR("Pick a Main Scene"));
-			file->popup_centered_ratio();
+			file->popup_file_dialog();
 
 		} break;
 		case HELP_SEARCH: {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -253,7 +253,7 @@ void EditorPropertyPath::_path_pressed() {
 		dialog->set_current_path(full_path);
 	}
 
-	dialog->popup_centered_ratio();
+	dialog->popup_file_dialog();
 }
 
 void EditorPropertyPath::update_property() {
@@ -2207,7 +2207,7 @@ void EditorPropertyNodePath::_node_assign() {
 		add_child(scene_tree);
 		scene_tree->connect("selected", callable_mp(this, &EditorPropertyNodePath::_node_selected));
 	}
-	scene_tree->popup_centered_ratio();
+	scene_tree->popup_scenetree_dialog();
 }
 
 void EditorPropertyNodePath::_node_clear() {
@@ -2343,7 +2343,7 @@ void EditorPropertyResource::_file_selected(const String &p_path) {
 }
 
 void EditorPropertyResource::_menu_option(int p_which) {
-	//	scene_tree->popup_centered_ratio();
+	//scene_tree->popup_scenetree_dialog();
 	switch (p_which) {
 		case OBJ_MENU_LOAD: {
 			if (!file) {
@@ -2369,7 +2369,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 				file->add_filter("*." + E->get() + " ; " + E->get().to_upper());
 			}
 
-			file->popup_centered_ratio();
+			file->popup_file_dialog();
 		} break;
 
 		case OBJ_MENU_EDIT: {
@@ -2507,7 +2507,7 @@ void EditorPropertyResource::_menu_option(int p_which) {
 					scene_tree->connect("selected", callable_mp(this, &EditorPropertyResource::_viewport_selected));
 					scene_tree->set_title(TTR("Pick a Viewport"));
 				}
-				scene_tree->popup_centered_ratio();
+				scene_tree->popup_scenetree_dialog();
 
 				return;
 			}

--- a/editor/editor_sub_scene.cpp
+++ b/editor/editor_sub_scene.cpp
@@ -66,7 +66,7 @@ void EditorSubScene::_path_changed(const String &p_path) {
 }
 
 void EditorSubScene::_path_browse() {
-	file_dialog->popup_centered_ratio();
+	file_dialog->popup_file_dialog();
 }
 
 void EditorSubScene::_notification(int p_what) {

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -334,7 +334,7 @@ void ExportTemplateManager::popup_manager() {
 }
 
 void ExportTemplateManager::ok_pressed() {
-	template_open->popup_centered_ratio();
+	template_open->popup_file_dialog();
 }
 
 void ExportTemplateManager::_http_download_mirror_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data) {

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -483,7 +483,7 @@ void FindInFilesDialog::_notification(int p_what) {
 }
 
 void FindInFilesDialog::_on_folder_button_pressed() {
-	_folder_dialog->popup_centered_ratio();
+	_folder_dialog->popup_file_dialog();
 }
 
 void FindInFilesDialog::custom_action(const String &p_action) {

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -150,7 +150,7 @@ void InspectorDock::_load_resource(const String &p_type) {
 		load_resource_dialog->add_filter("*." + extensions[i] + " ; " + extensions[i].to_upper());
 	}
 
-	load_resource_dialog->popup_centered_ratio();
+	load_resource_dialog->popup_file_dialog();
 }
 
 void InspectorDock::_resource_file_selected(String p_file) {

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -82,7 +82,7 @@ void LocalizationEditor::_translation_add(const String &p_path) {
 }
 
 void LocalizationEditor::_translation_file_open() {
-	translation_file_open->popup_centered_ratio();
+	translation_file_open->popup_file_dialog();
 }
 
 void LocalizationEditor::_translation_delete(Object *p_item, int p_column, int p_button) {
@@ -108,7 +108,7 @@ void LocalizationEditor::_translation_delete(Object *p_item, int p_column, int p
 }
 
 void LocalizationEditor::_translation_res_file_open() {
-	translation_res_file_open_dialog->popup_centered_ratio();
+	translation_res_file_open_dialog->popup_file_dialog();
 }
 
 void LocalizationEditor::_translation_res_add(const String &p_path) {
@@ -137,7 +137,7 @@ void LocalizationEditor::_translation_res_add(const String &p_path) {
 }
 
 void LocalizationEditor::_translation_res_option_file_open() {
-	translation_res_option_file_open_dialog->popup_centered_ratio();
+	translation_res_option_file_open_dialog->popup_file_dialog();
 }
 
 void LocalizationEditor::_translation_res_option_add(const String &p_path) {
@@ -406,11 +406,11 @@ void LocalizationEditor::_pot_delete(Object *p_item, int p_column, int p_button)
 }
 
 void LocalizationEditor::_pot_file_open() {
-	pot_file_open_dialog->popup_centered_ratio();
+	pot_file_open_dialog->popup_file_dialog();
 }
 
 void LocalizationEditor::_pot_generate_open() {
-	pot_generate_dialog->popup_centered_ratio();
+	pot_generate_dialog->popup_file_dialog();
 }
 
 void LocalizationEditor::_pot_generate(const String &p_file) {

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -375,7 +375,7 @@ void AnimationNodeBlendSpace1DEditor::_add_menu_type(int p_index) {
 		for (List<String>::Element *E = filters.front(); E; E = E->next()) {
 			open_file->add_filter("*." + E->get());
 		}
-		open_file->popup_centered_ratio();
+		open_file->popup_file_dialog();
 		return;
 	} else if (p_index == MENU_LOAD_FILE_CONFIRM) {
 		node = file_loaded;

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -298,7 +298,7 @@ void AnimationNodeBlendSpace2DEditor::_add_menu_type(int p_index) {
 		for (List<String>::Element *E = filters.front(); E; E = E->next()) {
 			open_file->add_filter("*." + E->get());
 		}
-		open_file->popup_centered_ratio();
+		open_file->popup_file_dialog();
 		return;
 	} else if (p_index == MENU_LOAD_FILE_CONFIRM) {
 		node = file_loaded;

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -276,7 +276,7 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 		for (List<String>::Element *E = filters.front(); E; E = E->next()) {
 			open_file->add_filter("*." + E->get());
 		}
-		open_file->popup_centered_ratio();
+		open_file->popup_file_dialog();
 		return;
 	} else if (p_idx == MENU_LOAD_FILE_CONFIRM) {
 		anode = file_loaded;

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -340,7 +340,7 @@ void AnimationPlayerEditor::_animation_load() {
 		file->add_filter("*." + E->get() + " ; " + E->get().to_upper());
 	}
 
-	file->popup_centered_ratio();
+	file->popup_file_dialog();
 	current_option = RESOURCE_LOAD;
 }
 
@@ -399,8 +399,8 @@ void AnimationPlayerEditor::_animation_save_as(const Ref<Resource> &p_resource) 
 		}
 	}
 	file->set_current_path(path);
-	file->popup_centered_ratio();
 	file->set_title(TTR("Save Resource As..."));
+	file->popup_file_dialog();
 	current_option = RESOURCE_SAVE;
 }
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -406,7 +406,7 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 		for (List<String>::Element *E = filters.front(); E; E = E->next()) {
 			open_file->add_filter("*." + E->get());
 		}
-		open_file->popup_centered_ratio();
+		open_file->popup_file_dialog();
 		return;
 	} else if (p_index == MENU_LOAD_FILE_CONFIRM) {
 		node = file_loaded;

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1260,7 +1260,7 @@ void EditorAssetLibrary::_asset_file_selected(const String &p_file) {
 }
 
 void EditorAssetLibrary::_asset_open() {
-	asset_open->popup_centered_ratio();
+	asset_open->popup_file_dialog();
 }
 
 void EditorAssetLibrary::_manage_plugins() {

--- a/editor/plugins/baked_lightmap_editor_plugin.cpp
+++ b/editor/plugins/baked_lightmap_editor_plugin.cpp
@@ -54,7 +54,7 @@ void BakedLightmapEditorPlugin::_bake_select_file(const String &p_file) {
 				scene_path = scene_path.get_basename() + ".lmbake";
 
 				file_dialog->set_current_path(scene_path);
-				file_dialog->popup_centered_ratio();
+				file_dialog->popup_file_dialog();
 
 			} break;
 			case BakedLightmap::BAKE_ERROR_NO_MESHES:

--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -60,7 +60,7 @@ void CPUParticles2DEditorPlugin::_file_selected(const String &p_file) {
 void CPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 	switch (p_idx) {
 		case MENU_LOAD_EMISSION_MASK: {
-			file->popup_centered_ratio();
+			file->popup_file_dialog();
 
 		} break;
 		case MENU_CLEAR_EMISSION_MASK: {

--- a/editor/plugins/cpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_3d_editor_plugin.cpp
@@ -48,7 +48,7 @@ void CPUParticles3DEditor::_notification(int p_notification) {
 void CPUParticles3DEditor::_menu_option(int p_option) {
 	switch (p_option) {
 		case MENU_OPTION_CREATE_EMISSION_VOLUME_FROM_NODE: {
-			emission_tree_dialog->popup_centered_ratio();
+			emission_tree_dialog->popup_scenetree_dialog();
 
 		} break;
 

--- a/editor/plugins/gi_probe_editor_plugin.cpp
+++ b/editor/plugins/gi_probe_editor_plugin.cpp
@@ -41,7 +41,7 @@ void GIProbeEditorPlugin::_bake() {
 				path = path.get_basename() + "." + gi_probe->get_name() + "_data.res";
 			}
 			probe_file->set_current_path(path);
-			probe_file->popup_centered_ratio();
+			probe_file->popup_file_dialog();
 			return;
 		}
 		gi_probe->bake();

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -69,7 +69,7 @@ void GPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 			generate_visibility_rect->popup_centered();
 		} break;
 		case MENU_LOAD_EMISSION_MASK: {
-			file->popup_centered_ratio();
+			file->popup_file_dialog();
 
 		} break;
 		case MENU_CLEAR_EMISSION_MASK: {

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -254,7 +254,7 @@ void GPUParticles3DEditor::_menu_option(int p_option) {
 				return;
 			}
 
-			emission_tree_dialog->popup_centered_ratio();
+			emission_tree_dialog->popup_scenetree_dialog();
 
 		} break;
 		case MENU_OPTION_CONVERT_TO_CPU_PARTICLES: {

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -224,7 +224,7 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 			}
 		} break;
 		case MENU_OPTION_IMPORT_FROM_SCENE: {
-			file->popup_centered_ratio();
+			file->popup_file_dialog();
 		} break;
 		case MENU_OPTION_UPDATE_FROM_SCENE: {
 			cd->set_text(vformat(TTR("Update from existing scene?:\n%s"), String(mesh_library->get_meta("_editor_source_scene"))));

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -251,7 +251,7 @@ void MultiMeshEditor::edit(MultiMeshInstance3D *p_multimesh) {
 void MultiMeshEditor::_browse(bool p_source) {
 	browsing_source = p_source;
 	std->get_scene_tree()->set_marked(node, false);
-	std->popup_centered_ratio();
+	std->popup_scenetree_dialog();
 	if (p_source) {
 		std->set_title(TTR("Select a Source Mesh:"));
 	} else {

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -95,8 +95,7 @@ void ResourcePreloaderEditor::_load_pressed() {
 	}
 
 	file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILES);
-
-	file->popup_centered_ratio();
+	file->popup_file_dialog();
 }
 
 void ResourcePreloaderEditor::_item_edited() {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1107,7 +1107,7 @@ void ScriptEditor::_menu_option(int p_option) {
 			file_dialog_option = FILE_NEW_TEXTFILE;
 
 			file_dialog->clear_filters();
-			file_dialog->popup_centered_ratio();
+			file_dialog->popup_file_dialog();
 			file_dialog->set_title(TTR("New Text File..."));
 		} break;
 		case FILE_OPEN: {
@@ -1122,7 +1122,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				file_dialog->add_filter("*." + extensions[i] + " ; " + extensions[i].to_upper());
 			}
 
-			file_dialog->popup_centered_ratio();
+			file_dialog->popup_file_dialog();
 			file_dialog->set_title(TTR("Open File"));
 			return;
 		} break;
@@ -1275,7 +1275,7 @@ void ScriptEditor::_menu_option(int p_option) {
 					file_dialog->clear_filters();
 					file_dialog->set_current_dir(text_file->get_path().get_base_dir());
 					file_dialog->set_current_file(text_file->get_path().get_file());
-					file_dialog->popup_centered_ratio();
+					file_dialog->popup_file_dialog();
 					file_dialog->set_title(TTR("Save File As..."));
 					break;
 				}
@@ -1425,7 +1425,7 @@ void ScriptEditor::_theme_option(int p_option) {
 			file_dialog_option = THEME_IMPORT;
 			file_dialog->clear_filters();
 			file_dialog->add_filter("*.tet");
-			file_dialog->popup_centered_ratio();
+			file_dialog->popup_file_dialog();
 			file_dialog->set_title(TTR("Import Theme"));
 		} break;
 		case THEME_RELOAD: {
@@ -1451,7 +1451,7 @@ void ScriptEditor::_show_save_theme_as_dialog() {
 	file_dialog->clear_filters();
 	file_dialog->add_filter("*.tet");
 	file_dialog->set_current_path(EditorSettings::get_singleton()->get_text_editor_themes_dir().plus_file(EditorSettings::get_singleton()->get("text_editor/theme/color_theme")));
-	file_dialog->popup_centered_ratio();
+	file_dialog->popup_file_dialog();
 	file_dialog->set_title(TTR("Save Theme As..."));
 }
 

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -48,7 +48,7 @@ void SpriteFramesEditor::_open_sprite_sheet() {
 		file_split_sheet->add_filter("*." + extensions[i]);
 	}
 
-	file_split_sheet->popup_centered_ratio();
+	file_split_sheet->popup_file_dialog();
 }
 
 void SpriteFramesEditor::_sheet_preview_draw() {
@@ -298,8 +298,7 @@ void SpriteFramesEditor::_load_pressed() {
 	}
 
 	file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILES);
-
-	file->popup_centered_ratio();
+	file->popup_file_dialog();
 }
 
 void SpriteFramesEditor::_paste_pressed() {

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -646,7 +646,7 @@ void TileSetEditor::_on_tileset_toolbar_button_pressed(int p_index) {
 	option = p_index;
 	switch (option) {
 		case TOOL_TILESET_ADD_TEXTURE: {
-			texture_dialog->popup_centered_ratio();
+			texture_dialog->popup_file_dialog();
 		} break;
 		case TOOL_TILESET_REMOVE_TEXTURE: {
 			if (get_current_texture().is_valid()) {

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -397,7 +397,7 @@ void ProjectExportDialog::_patch_button_pressed(Object *p_item, int p_column, in
 		patch_erase->set_text(vformat(TTR("Delete patch '%s' from list?"), patches[patch_index].get_file()));
 		patch_erase->popup_centered();
 	} else {
-		patch_dialog->popup_centered_ratio();
+		patch_dialog->popup_file_dialog();
 	}
 }
 
@@ -876,7 +876,7 @@ void ProjectExportDialog::_tree_changed() {
 }
 
 void ProjectExportDialog::_export_pck_zip() {
-	export_pck_zip->popup_centered_ratio();
+	export_pck_zip->popup_file_dialog();
 }
 
 void ProjectExportDialog::_export_pck_zip_selected(const String &p_path) {
@@ -952,7 +952,7 @@ void ProjectExportDialog::_export_project() {
 	}
 
 	export_project->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
-	export_project->popup_centered_ratio();
+	export_project->popup_file_dialog();
 }
 
 void ProjectExportDialog::_export_project_to_path(const String &p_path) {

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -365,13 +365,13 @@ private:
 		} else {
 			fdialog->set_file_mode(FileDialog::FILE_MODE_OPEN_DIR);
 		}
-		fdialog->popup_centered_ratio();
+		fdialog->popup_file_dialog();
 	}
 
 	void _browse_install_path() {
 		fdialog_install->set_current_dir(install_path->get_text());
 		fdialog_install->set_file_mode(FileDialog::FILE_MODE_OPEN_DIR);
-		fdialog_install->popup_centered_ratio();
+		fdialog_install->popup_file_dialog();
 	}
 
 	void _create_folder() {
@@ -2159,7 +2159,7 @@ void ProjectManager::_scan_begin(const String &p_base) {
 }
 
 void ProjectManager::_scan_projects() {
-	scan_dir->popup_centered_ratio();
+	scan_dir->popup_file_dialog();
 }
 
 void ProjectManager::_new_project() {

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -152,7 +152,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 						file->add_filter("*." + E->get() + " ; " + E->get().to_upper());
 					}
 
-					file->popup_centered_ratio();
+					file->popup_file_dialog();
 				} break;
 
 				case OBJ_MENU_EDIT: {
@@ -257,7 +257,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 
 					if (intype == "ViewportTexture") {
 						scene_tree->set_title(TTR("Pick a Viewport"));
-						scene_tree->popup_centered_ratio();
+						scene_tree->popup_scenetree_dialog();
 						picking_viewport = true;
 						return;
 					}
@@ -1198,7 +1198,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 							file->add_filter(filter + " ; " + extensions[i].to_upper());
 						}
 					}
-					file->popup_centered_ratio();
+					file->popup_file_dialog();
 				} else {
 					v = "";
 					emit_signal("variant_changed");
@@ -1214,7 +1214,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 					}
 					file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
 					file->clear_filters();
-					file->popup_centered_ratio();
+					file->popup_file_dialog();
 				} else {
 					v = "";
 					emit_signal("variant_changed");
@@ -1227,7 +1227,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 			if (p_which == 0) {
 				picking_viewport = false;
 				scene_tree->set_title(TTR("Pick a Node"));
-				scene_tree->popup_centered_ratio();
+				scene_tree->popup_scenetree_dialog();
 
 			} else if (p_which == 1) {
 				v = NodePath();
@@ -1281,7 +1281,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 					file->add_filter("*." + E->get() + " ; " + E->get().to_upper());
 				}
 
-				file->popup_centered_ratio();
+				file->popup_file_dialog();
 
 			} else if (p_which == 2) {
 				RES r = v;

--- a/editor/reparent_dialog.cpp
+++ b/editor/reparent_dialog.cpp
@@ -75,14 +75,8 @@ ReparentDialog::ReparentDialog() {
 
 	tree = memnew(SceneTreeEditor(false));
 	tree->set_show_enabled_subscene(true);
-
-	vbc->add_margin_child(TTR("Reparent Location (Select new Parent):"), tree, true);
-
 	tree->get_scene_tree()->connect("item_activated", callable_mp(this, &ReparentDialog::_reparent));
-
-	//Label *label = memnew( Label );
-	//label->set_position( Point2( 15,8) );
-	//label->set_text("Reparent Location (Select new Parent):");
+	vbc->add_margin_child(TTR("Select new parent:"), tree, true);
 
 	keep_transform = memnew(CheckBox);
 	keep_transform->set_text(TTR("Keep Global Transform"));

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -645,9 +645,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			for (List<Node *>::Element *E = nodes.front(); E; E = E->next()) {
 				nodeset.insert(E->get());
 			}
-			reparent_dialog->popup_centered_ratio();
 			reparent_dialog->set_current(nodeset);
-
+			reparent_dialog->popup_centered_clamped(Size2(350, 700) * EDSCALE);
 		} break;
 		case TOOL_MAKE_ROOT: {
 			if (!profile_allow_editing) {
@@ -834,8 +833,8 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 			new_scene_from_dialog->set_current_path(existing);
 
-			new_scene_from_dialog->popup_centered_ratio();
 			new_scene_from_dialog->set_title(TTR("Save New Scene As..."));
+			new_scene_from_dialog->popup_file_dialog();
 		} break;
 		case TOOL_COPY_NODE_PATH: {
 			List<Node *> selection = editor_selection->get_selected_node_list();

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -33,6 +33,7 @@
 #include "core/message_queue.h"
 #include "core/print_string.h"
 #include "editor/editor_node.h"
+#include "editor/editor_scale.h"
 #include "editor/node_dock.h"
 #include "editor/plugins/animation_player_editor_plugin.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
@@ -1193,6 +1194,10 @@ SceneTreeEditor::~SceneTreeEditor() {
 }
 
 /******** DIALOG *********/
+
+void SceneTreeDialog::popup_scenetree_dialog() {
+	popup_centered_clamped(Size2(350, 700) * EDSCALE);
+}
 
 void SceneTreeDialog::_notification(int p_what) {
 	switch (p_what) {

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -179,6 +179,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	void popup_scenetree_dialog();
 	SceneTreeEditor *get_scene_tree() { return tree; }
 	SceneTreeDialog();
 	~SceneTreeDialog();

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -540,7 +540,7 @@ void ScriptCreateDialog::_browse_path(bool browse_parent, bool p_save) {
 	}
 
 	file_browse->set_current_path(file_path->get_text());
-	file_browse->popup_centered_ratio();
+	file_browse->popup_file_dialog();
 }
 
 void ScriptCreateDialog::_file_selected(const String &p_file) {

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -146,7 +146,7 @@ void GDNativeLibraryEditor::_on_item_button(Object *item, int column, int id) {
 		}
 
 		file_dialog->set_file_mode(mode);
-		file_dialog->popup_centered_ratio();
+		file_dialog->popup_file_dialog();
 
 	} else if (id == BUTTON_CLEAR_LIBRARY) {
 		_set_target_value(section, target, "");

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -40,6 +40,10 @@ FileDialog::GetIconFunc FileDialog::get_large_icon_func = nullptr;
 FileDialog::RegisterFunc FileDialog::register_func = nullptr;
 FileDialog::RegisterFunc FileDialog::unregister_func = nullptr;
 
+void FileDialog::popup_file_dialog() {
+	popup_centered_clamped(Size2i(700, 500), 0.8f);
+}
+
 VBoxContainer *FileDialog::get_vbox() {
 	return vbox;
 }

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -135,6 +135,7 @@ protected:
 	static void _bind_methods();
 	//bind helpers
 public:
+	void popup_file_dialog();
 	void clear_filters();
 	void add_filter(const String &p_filter);
 	void set_filters(const Vector<String> &p_filters);


### PR DESCRIPTION
Resized some dialogs that would take a default size of 80% of the window size. Specifically

- FileDialog --> `(700, 500)` or `0.8`
- EditorFileDialog --> `(1050, 700) * EDSCALE` or `0.8`
- DependencyEditor --> `0.4`
- DependencyOwnersEditor --> `0.3`
- OrphanResourcesDialog --> `0.4`
- ReparentDialog --> `(350, 700) * EDSCALE`
- SceneTreeDialog --> `(350, 700) * EDSCALE`

Size of `(Editor)FileDialog` can now also be easily updated in `popup_file_dialog`, and the `SceneTreeDialog` in `popup_scenetree_dialog`.