### PR TITLE
Option for software skinning in MeshInstance

### DIFF
--- a/doc/classes/MeshInstance.xml
+++ b/doc/classes/MeshInstance.xml
@@ -30,6 +30,15 @@
 				This helper creates a [StaticBody] child node with a [ConcavePolygonShape] collision shape calculated from the mesh geometry. It's mainly used for testing.
 			</description>
 		</method>
+		<method name="get_active_material" qualifiers="const">
+			<return type="Material">
+			</return>
+			<argument index="0" name="surface" type="int">
+			</argument>
+			<description>
+				Returns the [Material] that will be used by the [Mesh] when drawing. This can return the [member GeometryInstance.material_override], the surface override [Material] defined in this [MeshInstance], or the surface [Material] defined in the [Mesh]. For example, if [member GeometryInstance.material_override] is used, all surfaces will return the override material.
+			</description>
+		</method>
 		<method name="get_surface_material" qualifiers="const">
 			<return type="Material">
 			</return>
@@ -67,6 +76,10 @@
 		</member>
 		<member name="skin" type="Skin" setter="set_skin" getter="get_skin">
 			Sets the skin to be used by this instance.
+		</member>
+		<member name="software_skinning_transform_normals" type="bool" setter="set_software_skinning_transform_normals" getter="is_software_skinning_transform_normals_enabled" default="true">
+			If [code]true[/code], normals are transformed when software skinning is used. Set to [code]false[/code] when normals are not needed for better performance.
+			See [member ProjectSettings.rendering/quality/skinning/software_skinning_fallback] for details about how software skinning is enabled.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1177,6 +1177,16 @@
 		<member name="rendering/quality/shadows/filter_mode.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/quality/shadows/filter_mode] on mobile devices, due to performance concerns or driver support.
 		</member>
+		<member name="rendering/quality/skinning/software_skinning_fallback" type="bool" setter="" getter="" default="true">
+			Allows [MeshInstance] to perform skinning on the CPU when the hardware doesn't support the default GPU skinning process with GLES2.
+			If [code]false[/code], an alternative skinning process on the GPU is used in this case (slower in most cases).
+			See also [member rendering/quality/skinning/force_software_skinning].
+			[b]Note:[/b] When the software skinning fallback is triggered, custom vertex shaders will behave in a different way, because the bone transform will be already applied to the modelview matrix.
+		</member>
+		<member name="rendering/quality/skinning/force_software_skinning" type="bool" setter="" getter="" default="false">
+			Forces [MeshInstance] to always perform skinning on the CPU (applies to both GLES2 and GLES3).
+			See also [member rendering/quality/skinning/software_skinning_fallback].
+		</member>
 		<member name="rendering/quality/spatial_partitioning/render_tree_balance" type="float" setter="" getter="" default="0.17">
 			The rendering octree balance can be changed to favor smaller ([code]0[/code]), or larger ([code]1[/code]) branches.
 			Larger branches can increase performance significantly in some projects.

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -1679,7 +1679,8 @@
 			<argument index="0" name="feature" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] if the OS supports a certain feature. Features might be [code]s3tc[/code], [code]etc[/code], [code]etc2[/code] and [code]pvrtc[/code].
+				Returns [code]true[/code] if the OS supports a certain feature. Features might be [code]s3tc[/code], [code]etc[/code], [code]etc2[/code], [code]pvrtc[/code] and [code]skinning_fallback[/code].
+				When rendering with GLES2, returns [code]true[/code] with [code]skinning_fallback[/code] in case the hardware doesn't support the default GPU skinning process.
 			</description>
 		</method>
 		<method name="immediate_begin">

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1473,6 +1473,8 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 			p_shader->spatial.uses_screen_texture = false;
 			p_shader->spatial.uses_depth_texture = false;
 			p_shader->spatial.uses_vertex = false;
+			p_shader->spatial.uses_tangent = false;
+			p_shader->spatial.uses_ensure_correct_normals = false;
 			p_shader->spatial.writes_modelview_or_projection = false;
 			p_shader->spatial.uses_world_coordinates = false;
 
@@ -1497,6 +1499,8 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 
 			shaders.actions_scene.render_mode_flags["world_vertex_coords"] = &p_shader->spatial.uses_world_coordinates;
 
+			shaders.actions_scene.render_mode_flags["ensure_correct_normals"] = &p_shader->spatial.uses_ensure_correct_normals;
+
 			shaders.actions_scene.usage_flag_pointers["ALPHA"] = &p_shader->spatial.uses_alpha;
 			shaders.actions_scene.usage_flag_pointers["ALPHA_SCISSOR"] = &p_shader->spatial.uses_alpha_scissor;
 
@@ -1505,6 +1509,11 @@ void RasterizerStorageGLES2::_update_shader(Shader *p_shader) const {
 			shaders.actions_scene.usage_flag_pointers["SCREEN_TEXTURE"] = &p_shader->spatial.uses_screen_texture;
 			shaders.actions_scene.usage_flag_pointers["DEPTH_TEXTURE"] = &p_shader->spatial.uses_depth_texture;
 			shaders.actions_scene.usage_flag_pointers["TIME"] = &p_shader->spatial.uses_time;
+
+			// Use of any of these BUILTINS indicate the need for transformed tangents.
+			// This is needed to know when to transform tangents in software skinning.
+			shaders.actions_scene.usage_flag_pointers["TANGENT"] = &p_shader->spatial.uses_tangent;
+			shaders.actions_scene.usage_flag_pointers["NORMALMAP"] = &p_shader->spatial.uses_tangent;
 
 			shaders.actions_scene.write_flag_pointers["MODELVIEW_MATRIX"] = &p_shader->spatial.writes_modelview_or_projection;
 			shaders.actions_scene.write_flag_pointers["PROJECTION_MATRIX"] = &p_shader->spatial.writes_modelview_or_projection;
@@ -1895,6 +1904,36 @@ bool RasterizerStorageGLES2::material_casts_shadows(RID p_material) {
 	}
 
 	return casts_shadows;
+}
+
+bool RasterizerStorageGLES2::material_uses_tangents(RID p_material) {
+	Material *material = material_owner.get(p_material);
+	ERR_FAIL_COND_V(!material, false);
+
+	if (!material->shader) {
+		return false;
+	}
+
+	if (material->shader->dirty_list.in_list()) {
+		_update_shader(material->shader);
+	}
+
+	return material->shader->spatial.uses_tangent;
+}
+
+bool RasterizerStorageGLES2::material_uses_ensure_correct_normals(RID p_material) {
+	Material *material = material_owner.get(p_material);
+	ERR_FAIL_COND_V(!material, false);
+
+	if (!material->shader) {
+		return false;
+	}
+
+	if (material->shader->dirty_list.in_list()) {
+		_update_shader(material->shader);
+	}
+
+	return material->shader->spatial.uses_ensure_correct_normals;
 }
 
 void RasterizerStorageGLES2::material_add_instance_owner(RID p_material, RasterizerScene::InstanceBase *p_instance) {
@@ -5768,6 +5807,9 @@ bool RasterizerStorageGLES2::has_os_feature(const String &p_feature) const {
 
 	if (p_feature == "etc")
 		return config.etc1_supported;
+
+	if (p_feature == "skinning_fallback")
+		return config.use_skeleton_software;
 
 	return false;
 }

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -503,6 +503,8 @@ public:
 			bool uses_screen_texture;
 			bool uses_depth_texture;
 			bool uses_time;
+			bool uses_tangent;
+			bool uses_ensure_correct_normals;
 			bool writes_modelview_or_projection;
 			bool uses_vertex_lighting;
 			bool uses_world_coordinates;
@@ -607,6 +609,8 @@ public:
 
 	virtual bool material_is_animated(RID p_material);
 	virtual bool material_casts_shadows(RID p_material);
+	virtual bool material_uses_tangents(RID p_material);
+	virtual bool material_uses_ensure_correct_normals(RID p_material);
 
 	virtual void material_add_instance_owner(RID p_material, RasterizerScene::InstanceBase *p_instance);
 	virtual void material_remove_instance_owner(RID p_material, RasterizerScene::InstanceBase *p_instance);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -499,6 +499,8 @@ public:
 			bool uses_screen_texture;
 			bool uses_depth_texture;
 			bool uses_time;
+			bool uses_tangent;
+			bool uses_ensure_correct_normals;
 			bool writes_modelview_or_projection;
 			bool uses_vertex_lighting;
 			bool uses_world_coordinates;
@@ -606,6 +608,8 @@ public:
 
 	virtual bool material_is_animated(RID p_material);
 	virtual bool material_casts_shadows(RID p_material);
+	virtual bool material_uses_tangents(RID p_material);
+	virtual bool material_uses_ensure_correct_normals(RID p_material);
 
 	virtual void material_add_instance_owner(RID p_material, RasterizerScene::InstanceBase *p_instance);
 	virtual void material_remove_instance_owner(RID p_material, RasterizerScene::InstanceBase *p_instance);

--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -32,9 +32,11 @@
 
 #include "collision_shape.h"
 #include "core/core_string_names.h"
+#include "core/project_settings.h"
 #include "physics_body.h"
 #include "scene/resources/material.h"
 #include "scene/scene_string_names.h"
+#include "servers/visual/visual_server_globals.h"
 #include "skeleton.h"
 
 bool MeshInstance::_set(const StringName &p_name, const Variant &p_value) {
@@ -116,6 +118,16 @@ void MeshInstance::set_mesh(const Ref<Mesh> &p_mesh) {
 		materials.clear();
 	}
 
+	if (skin_ref.is_valid() && mesh.is_valid() && _is_software_skinning_enabled() && is_visible_in_tree()) {
+		ERR_FAIL_COND(!skin_ref->get_skeleton_node());
+		skin_ref->get_skeleton_node()->disconnect("skeleton_updated", this, "_update_skinning");
+	}
+
+	if (software_skinning) {
+		memdelete(software_skinning);
+		software_skinning = nullptr;
+	}
+
 	mesh = p_mesh;
 
 	blend_shape_tracks.clear();
@@ -132,7 +144,7 @@ void MeshInstance::set_mesh(const Ref<Mesh> &p_mesh) {
 		mesh->connect(CoreStringNames::get_singleton()->changed, this, SceneStringNames::get_singleton()->_mesh_changed);
 		materials.resize(mesh->get_surface_count());
 
-		set_base(mesh->get_rid());
+		_initialize_skinning();
 	} else {
 
 		set_base(RID());
@@ -163,13 +175,326 @@ void MeshInstance::_resolve_skeleton_path() {
 		}
 	}
 
+	if (skin_ref.is_valid() && mesh.is_valid() && _is_software_skinning_enabled() && is_visible_in_tree()) {
+		ERR_FAIL_COND(!skin_ref->get_skeleton_node());
+		skin_ref->get_skeleton_node()->disconnect("skeleton_updated", this, "_update_skinning");
+	}
+
 	skin_ref = new_skin_reference;
 
-	if (skin_ref.is_valid()) {
-		VisualServer::get_singleton()->instance_attach_skeleton(get_instance(), skin_ref->get_skeleton());
-	} else {
-		VisualServer::get_singleton()->instance_attach_skeleton(get_instance(), RID());
+	software_skinning_flags &= ~SoftwareSkinning::FLAG_BONES_READY;
+
+	_initialize_skinning();
+}
+
+bool MeshInstance::_is_global_software_skinning_enabled() {
+	// Check if forced in project settings.
+	if (GLOBAL_GET("rendering/quality/skinning/force_software_skinning")) {
+		return true;
 	}
+
+	// Check if enabled in project settings.
+	if (!GLOBAL_GET("rendering/quality/skinning/software_skinning_fallback")) {
+		return false;
+	}
+
+	// Check if requested by renderer settings.
+	return VSG::storage->has_os_feature("skinning_fallback");
+}
+
+bool MeshInstance::_is_software_skinning_enabled() const {
+	// Using static local variable which will be initialized only once,
+	// so _is_global_software_skinning_enabled can be only called once on first use.
+	static bool global_software_skinning = _is_global_software_skinning_enabled();
+	return global_software_skinning;
+}
+
+void MeshInstance::_initialize_skinning(bool p_force_reset) {
+	if (mesh.is_null()) {
+		return;
+	}
+
+	VisualServer *visual_server = VisualServer::get_singleton();
+
+	bool update_mesh = false;
+
+	if (skin_ref.is_valid()) {
+		if (_is_software_skinning_enabled()) {
+			if (is_visible_in_tree()) {
+				ERR_FAIL_COND(!skin_ref->get_skeleton_node());
+				if (!skin_ref->get_skeleton_node()->is_connected("skeleton_updated", this, "_update_skinning")) {
+					skin_ref->get_skeleton_node()->connect("skeleton_updated", this, "_update_skinning");
+				}
+			}
+
+			if (p_force_reset && software_skinning) {
+				memdelete(software_skinning);
+				software_skinning = nullptr;
+			}
+
+			if (!software_skinning) {
+				software_skinning = memnew(SoftwareSkinning);
+
+				if (mesh->get_blend_shape_count() > 0) {
+					ERR_PRINT("Blend shapes are not supported for software skinning.");
+				}
+
+				Ref<ArrayMesh> software_mesh;
+				software_mesh.instance();
+				RID mesh_rid = software_mesh->get_rid();
+
+				// Initialize mesh for dynamic update.
+				int surface_count = mesh->get_surface_count();
+				software_skinning->surface_data.resize(surface_count);
+				for (int surface_index = 0; surface_index < surface_count; ++surface_index) {
+					ERR_CONTINUE(Mesh::PRIMITIVE_TRIANGLES != mesh->surface_get_primitive_type(surface_index));
+
+					SoftwareSkinning::SurfaceData &surface_data = software_skinning->surface_data[surface_index];
+					surface_data.transform_tangents = false;
+					surface_data.ensure_correct_normals = false;
+
+					uint32_t format = mesh->surface_get_format(surface_index);
+					ERR_CONTINUE(0 == (format & Mesh::ARRAY_FORMAT_VERTEX));
+					ERR_CONTINUE(0 == (format & Mesh::ARRAY_FORMAT_BONES));
+					ERR_CONTINUE(0 == (format & Mesh::ARRAY_FORMAT_WEIGHTS));
+
+					format |= Mesh::ARRAY_FLAG_USE_DYNAMIC_UPDATE;
+					format &= ~Mesh::ARRAY_COMPRESS_VERTEX;
+					format &= ~Mesh::ARRAY_COMPRESS_WEIGHTS;
+					format &= ~Mesh::ARRAY_FLAG_USE_16_BIT_BONES;
+
+					Array write_arrays = mesh->surface_get_arrays(surface_index);
+					Array read_arrays;
+					read_arrays.resize(Mesh::ARRAY_MAX);
+
+					read_arrays[Mesh::ARRAY_VERTEX] = write_arrays[Mesh::ARRAY_VERTEX];
+					read_arrays[Mesh::ARRAY_BONES] = write_arrays[Mesh::ARRAY_BONES];
+					read_arrays[Mesh::ARRAY_WEIGHTS] = write_arrays[Mesh::ARRAY_WEIGHTS];
+
+					write_arrays[Mesh::ARRAY_BONES] = Variant();
+					write_arrays[Mesh::ARRAY_WEIGHTS] = Variant();
+
+					if (software_skinning_flags & SoftwareSkinning::FLAG_TRANSFORM_NORMALS) {
+						ERR_CONTINUE(0 == (format & Mesh::ARRAY_FORMAT_NORMAL));
+						format &= ~Mesh::ARRAY_COMPRESS_NORMAL;
+
+						read_arrays[Mesh::ARRAY_NORMAL] = write_arrays[Mesh::ARRAY_NORMAL];
+
+						Ref<Material> mat = get_active_material(surface_index);
+						if (mat.is_valid()) {
+							Ref<SpatialMaterial> spatial_mat = mat;
+							if (spatial_mat.is_valid()) {
+								// Spatial material, check from material settings.
+								surface_data.transform_tangents = spatial_mat->get_feature(SpatialMaterial::FEATURE_NORMAL_MAPPING);
+								surface_data.ensure_correct_normals = spatial_mat->get_flag(SpatialMaterial::FLAG_ENSURE_CORRECT_NORMALS);
+							} else {
+								// Custom shader, must check for compiled flags.
+								surface_data.transform_tangents = VSG::storage->material_uses_tangents(mat->get_rid());
+								surface_data.ensure_correct_normals = VSG::storage->material_uses_ensure_correct_normals(mat->get_rid());
+							}
+						}
+
+						if (surface_data.transform_tangents) {
+							ERR_CONTINUE(0 == (format & Mesh::ARRAY_FORMAT_TANGENT));
+							format &= ~Mesh::ARRAY_COMPRESS_TANGENT;
+
+							read_arrays[Mesh::ARRAY_TANGENT] = write_arrays[Mesh::ARRAY_TANGENT];
+						}
+					}
+
+					// 1. Temporarily add surface with bone data to create the read buffer.
+					software_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, read_arrays, Array(), format);
+
+					PoolByteArray buffer_read = visual_server->mesh_surface_get_array(mesh_rid, surface_index);
+					surface_data.source_buffer.append_array(buffer_read);
+					surface_data.source_format = software_mesh->surface_get_format(surface_index);
+
+					software_mesh->surface_remove(surface_index);
+
+					// 2. Create the surface again without the bone data for the write buffer.
+					software_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, write_arrays, Array(), format);
+
+					Ref<Material> material = mesh->surface_get_material(surface_index);
+					software_mesh->surface_set_material(surface_index, material);
+
+					surface_data.buffer = visual_server->mesh_surface_get_array(mesh_rid, surface_index);
+					surface_data.buffer_write = surface_data.buffer.write();
+				}
+
+				software_skinning->mesh_instance = software_mesh;
+				update_mesh = true;
+			}
+
+			visual_server->instance_attach_skeleton(get_instance(), RID());
+
+			if (is_visible_in_tree() && (software_skinning_flags & SoftwareSkinning::FLAG_BONES_READY)) {
+				// Intialize from current skeleton pose.
+				_update_skinning();
+			}
+		} else {
+			ERR_FAIL_COND(!skin_ref->get_skeleton_node());
+			if (skin_ref->get_skeleton_node()->is_connected("skeleton_updated", this, "_update_skinning")) {
+				skin_ref->get_skeleton_node()->disconnect("skeleton_updated", this, "_update_skinning");
+			}
+
+			visual_server->instance_attach_skeleton(get_instance(), skin_ref->get_skeleton());
+
+			if (software_skinning) {
+				memdelete(software_skinning);
+				software_skinning = nullptr;
+				update_mesh = true;
+			}
+		}
+	} else {
+		visual_server->instance_attach_skeleton(get_instance(), RID());
+		if (software_skinning) {
+			memdelete(software_skinning);
+			software_skinning = nullptr;
+			update_mesh = true;
+		}
+	}
+
+	RID render_mesh = software_skinning ? software_skinning->mesh_instance->get_rid() : mesh->get_rid();
+	set_base(render_mesh);
+
+	if (update_mesh) {
+		// Update instance materials after switching mesh.
+		int surface_count = mesh->get_surface_count();
+		for (int surface_index = 0; surface_index < surface_count; ++surface_index) {
+			if (materials[surface_index].is_valid()) {
+				visual_server->instance_set_surface_material(get_instance(), surface_index, materials[surface_index]->get_rid());
+			}
+		}
+	}
+}
+
+void MeshInstance::_update_skinning() {
+	ERR_FAIL_COND(!_is_software_skinning_enabled());
+	ERR_FAIL_COND(!is_visible_in_tree());
+
+	ERR_FAIL_COND(!software_skinning);
+	Ref<Mesh> software_skinning_mesh = software_skinning->mesh_instance;
+	ERR_FAIL_COND(!software_skinning_mesh.is_valid());
+	RID mesh_rid = software_skinning_mesh->get_rid();
+	ERR_FAIL_COND(!mesh_rid.is_valid());
+
+	ERR_FAIL_COND(!mesh.is_valid());
+	RID source_mesh_rid = mesh->get_rid();
+	ERR_FAIL_COND(!source_mesh_rid.is_valid());
+
+	ERR_FAIL_COND(skin_ref.is_null());
+	RID skeleton = skin_ref->get_skeleton();
+	ERR_FAIL_COND(!skeleton.is_valid());
+
+	VisualServer *visual_server = VisualServer::get_singleton();
+
+	// Prepare bone transforms.
+	const int num_bones = visual_server->skeleton_get_bone_count(skeleton);
+	ERR_FAIL_COND(num_bones <= 0);
+	Transform *bone_transforms = (Transform *)alloca(sizeof(Transform) * num_bones);
+	for (int bone_index = 0; bone_index < num_bones; ++bone_index) {
+		bone_transforms[bone_index] = visual_server->skeleton_bone_get_transform(skeleton, bone_index);
+	}
+
+	// Apply skinning.
+	int surface_count = software_skinning_mesh->get_surface_count();
+	for (int surface_index = 0; surface_index < surface_count; ++surface_index) {
+		ERR_CONTINUE((uint32_t)surface_index >= software_skinning->surface_data.size());
+		const SoftwareSkinning::SurfaceData &surface_data = software_skinning->surface_data[surface_index];
+		const bool transform_tangents = surface_data.transform_tangents;
+		const bool ensure_correct_normals = surface_data.ensure_correct_normals;
+
+		const uint32_t format_write = software_skinning_mesh->surface_get_format(surface_index);
+
+		const int vertex_count_write = software_skinning_mesh->surface_get_array_len(surface_index);
+		const int index_count_write = software_skinning_mesh->surface_get_array_index_len(surface_index);
+
+		uint32_t array_offsets_write[Mesh::ARRAY_MAX];
+		const uint32_t stride_write = visual_server->mesh_surface_make_offsets_from_format(format_write, vertex_count_write, index_count_write, array_offsets_write);
+		const uint32_t offset_vertices_write = array_offsets_write[Mesh::ARRAY_VERTEX];
+		const uint32_t offset_normals_write = array_offsets_write[Mesh::ARRAY_NORMAL];
+		const uint32_t offset_tangents_write = array_offsets_write[Mesh::ARRAY_TANGENT];
+
+		PoolByteArray buffer_source = surface_data.source_buffer;
+		PoolByteArray::Read buffer_read = buffer_source.read();
+
+		const uint32_t format_read = surface_data.source_format;
+
+		ERR_CONTINUE(0 == (format_read & Mesh::ARRAY_FORMAT_BONES));
+		ERR_CONTINUE(0 == (format_read & Mesh::ARRAY_FORMAT_WEIGHTS));
+
+		const int vertex_count = mesh->surface_get_array_len(surface_index);
+		const int index_count = mesh->surface_get_array_index_len(surface_index);
+
+		ERR_CONTINUE(vertex_count != vertex_count_write);
+
+		uint32_t array_offsets[Mesh::ARRAY_MAX];
+		const uint32_t stride = visual_server->mesh_surface_make_offsets_from_format(format_read, vertex_count, index_count, array_offsets);
+		const uint32_t offset_vertices = array_offsets[Mesh::ARRAY_VERTEX];
+		const uint32_t offset_normals = array_offsets[Mesh::ARRAY_NORMAL];
+		const uint32_t offset_tangents = array_offsets[Mesh::ARRAY_TANGENT];
+		const uint32_t offset_bones = array_offsets[Mesh::ARRAY_BONES];
+		const uint32_t offset_weights = array_offsets[Mesh::ARRAY_WEIGHTS];
+
+		PoolByteArray buffer = surface_data.buffer;
+		PoolByteArray::Write buffer_write = surface_data.buffer_write;
+
+		for (int vertex_index = 0; vertex_index < vertex_count; ++vertex_index) {
+			const uint32_t vertex_offset = vertex_index * stride;
+			const uint32_t vertex_offset_write = vertex_index * stride_write;
+
+			float bone_weights[4];
+			const float *weight_ptr = (const float *)(buffer_read.ptr() + offset_weights + vertex_offset);
+			bone_weights[0] = weight_ptr[0];
+			bone_weights[1] = weight_ptr[1];
+			bone_weights[2] = weight_ptr[2];
+			bone_weights[3] = weight_ptr[3];
+
+			const uint8_t *bones_ptr = buffer_read.ptr() + offset_bones + vertex_offset;
+			const int b0 = bones_ptr[0];
+			const int b1 = bones_ptr[1];
+			const int b2 = bones_ptr[2];
+			const int b3 = bones_ptr[3];
+
+			Transform transform;
+			transform.origin =
+					bone_weights[0] * bone_transforms[b0].origin +
+					bone_weights[1] * bone_transforms[b1].origin +
+					bone_weights[2] * bone_transforms[b2].origin +
+					bone_weights[3] * bone_transforms[b3].origin;
+
+			transform.basis =
+					bone_transforms[b0].basis * bone_weights[0] +
+					bone_transforms[b1].basis * bone_weights[1] +
+					bone_transforms[b2].basis * bone_weights[2] +
+					bone_transforms[b3].basis * bone_weights[3];
+
+			const Vector3 &vertex_read = (const Vector3 &)buffer_read[vertex_offset + offset_vertices];
+			Vector3 &vertex = (Vector3 &)buffer_write[vertex_offset_write + offset_vertices_write];
+			vertex = transform.xform(vertex_read);
+
+			if (software_skinning_flags & SoftwareSkinning::FLAG_TRANSFORM_NORMALS) {
+				if (ensure_correct_normals) {
+					transform.basis.invert();
+					transform.basis.transpose();
+				}
+
+				const Vector3 &normal_read = (const Vector3 &)buffer_read[vertex_offset + offset_normals];
+				Vector3 &normal = (Vector3 &)buffer_write[vertex_offset_write + offset_normals_write];
+				normal = transform.basis.xform(normal_read);
+
+				if (transform_tangents) {
+					const Vector3 &tangent_read = (const Vector3 &)buffer_read[vertex_offset + offset_tangents];
+					Vector3 &tangent = (Vector3 &)buffer_write[vertex_offset_write + offset_tangents_write];
+					tangent = transform.basis.xform(tangent_read);
+				}
+			}
+		}
+
+		visual_server->mesh_surface_update_region(mesh_rid, surface_index, 0, buffer);
+	}
+
+	software_skinning_flags |= SoftwareSkinning::FLAG_BONES_READY;
 }
 
 void MeshInstance::set_skin(const Ref<Skin> &p_skin) {
@@ -280,6 +605,17 @@ void MeshInstance::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 		_resolve_skeleton_path();
 	}
+
+	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+		if (skin_ref.is_valid() && mesh.is_valid() && _is_software_skinning_enabled()) {
+			ERR_FAIL_COND(!skin_ref->get_skeleton_node());
+			if (is_visible_in_tree()) {
+				skin_ref->get_skeleton_node()->connect("skeleton_updated", this, "_update_skinning");
+			} else {
+				skin_ref->get_skeleton_node()->disconnect("skeleton_updated", this, "_update_skinning");
+			}
+		}
+	}
 }
 
 int MeshInstance::get_surface_material_count() const {
@@ -297,6 +633,10 @@ void MeshInstance::set_surface_material(int p_surface, const Ref<Material> &p_ma
 		VS::get_singleton()->instance_set_surface_material(get_instance(), p_surface, materials[p_surface]->get_rid());
 	else
 		VS::get_singleton()->instance_set_surface_material(get_instance(), p_surface, RID());
+
+	if (software_skinning) {
+		_initialize_skinning(true);
+	}
 }
 
 Ref<Material> MeshInstance::get_surface_material(int p_surface) const {
@@ -306,9 +646,63 @@ Ref<Material> MeshInstance::get_surface_material(int p_surface) const {
 	return materials[p_surface];
 }
 
-void MeshInstance::_mesh_changed() {
+Ref<Material> MeshInstance::get_active_material(int p_surface) const {
+	Ref<Material> material_override = get_material_override();
+	if (material_override.is_valid()) {
+		return material_override;
+	}
 
+	Ref<Material> surface_material = get_surface_material(p_surface);
+	if (surface_material.is_valid()) {
+		return surface_material;
+	}
+
+	Ref<Mesh> mesh = get_mesh();
+	if (mesh.is_valid()) {
+		return mesh->surface_get_material(p_surface);
+	}
+
+	return Ref<Material>();
+}
+
+void MeshInstance::set_material_override(const Ref<Material> &p_material) {
+	if (p_material == get_material_override()) {
+		return;
+	}
+
+	GeometryInstance::set_material_override(p_material);
+
+	if (software_skinning) {
+		_initialize_skinning(true);
+	}
+}
+
+void MeshInstance::set_software_skinning_transform_normals(bool p_enabled) {
+	if (p_enabled == is_software_skinning_transform_normals_enabled()) {
+		return;
+	}
+
+	if (p_enabled) {
+		software_skinning_flags |= SoftwareSkinning::FLAG_TRANSFORM_NORMALS;
+	} else {
+		software_skinning_flags &= ~SoftwareSkinning::FLAG_TRANSFORM_NORMALS;
+	}
+
+	if (software_skinning) {
+		_initialize_skinning(true);
+	}
+}
+
+bool MeshInstance::is_software_skinning_transform_normals_enabled() const {
+	return 0 != (software_skinning_flags & SoftwareSkinning::FLAG_TRANSFORM_NORMALS);
+}
+
+void MeshInstance::_mesh_changed() {
 	materials.resize(mesh->get_surface_count());
+
+	if (software_skinning) {
+		_initialize_skinning(true);
+	}
 }
 
 void MeshInstance::create_debug_tangents() {
@@ -398,12 +792,17 @@ void MeshInstance::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_surface_material_count"), &MeshInstance::get_surface_material_count);
 	ClassDB::bind_method(D_METHOD("set_surface_material", "surface", "material"), &MeshInstance::set_surface_material);
 	ClassDB::bind_method(D_METHOD("get_surface_material", "surface"), &MeshInstance::get_surface_material);
+	ClassDB::bind_method(D_METHOD("get_active_material", "surface"), &MeshInstance::get_active_material);
+
+	ClassDB::bind_method(D_METHOD("set_software_skinning_transform_normals", "enabled"), &MeshInstance::set_software_skinning_transform_normals);
+	ClassDB::bind_method(D_METHOD("is_software_skinning_transform_normals_enabled"), &MeshInstance::is_software_skinning_transform_normals_enabled);
 
 	ClassDB::bind_method(D_METHOD("create_trimesh_collision"), &MeshInstance::create_trimesh_collision);
 	ClassDB::set_method_flags("MeshInstance", "create_trimesh_collision", METHOD_FLAGS_DEFAULT);
 	ClassDB::bind_method(D_METHOD("create_convex_collision"), &MeshInstance::create_convex_collision);
 	ClassDB::set_method_flags("MeshInstance", "create_convex_collision", METHOD_FLAGS_DEFAULT);
 	ClassDB::bind_method(D_METHOD("_mesh_changed"), &MeshInstance::_mesh_changed);
+	ClassDB::bind_method(D_METHOD("_update_skinning"), &MeshInstance::_update_skinning);
 
 	ClassDB::bind_method(D_METHOD("create_debug_tangents"), &MeshInstance::create_debug_tangents);
 	ClassDB::set_method_flags("MeshInstance", "create_debug_tangents", METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
@@ -411,11 +810,20 @@ void MeshInstance::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh"), "set_mesh", "get_mesh");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "skin", PROPERTY_HINT_RESOURCE_TYPE, "Skin"), "set_skin", "get_skin");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "skeleton", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Skeleton"), "set_skeleton_path", "get_skeleton_path");
+
+	ADD_GROUP("Software Skinning", "software_skinning");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "software_skinning_transform_normals"), "set_software_skinning_transform_normals", "is_software_skinning_transform_normals_enabled");
 }
 
 MeshInstance::MeshInstance() {
 	skeleton_path = NodePath("..");
+	software_skinning = nullptr;
+	software_skinning_flags = SoftwareSkinning::FLAG_TRANSFORM_NORMALS;
 }
 
 MeshInstance::~MeshInstance() {
+	if (software_skinning) {
+		memdelete(software_skinning);
+		software_skinning = nullptr;
+	}
 }

--- a/scene/3d/mesh_instance.h
+++ b/scene/3d/mesh_instance.h
@@ -36,6 +36,8 @@
 #include "scene/resources/mesh.h"
 #include "scene/resources/skin.h"
 
+#include "core/local_vector.h"
+
 class MeshInstance : public GeometryInstance {
 
 	GDCLASS(MeshInstance, GeometryInstance);
@@ -46,6 +48,31 @@ protected:
 	Ref<Skin> skin_internal;
 	Ref<SkinReference> skin_ref;
 	NodePath skeleton_path;
+
+	struct SoftwareSkinning {
+		enum Flags {
+			// Data flags.
+			FLAG_TRANSFORM_NORMALS = 1 << 0,
+
+			// Runtime flags.
+			FLAG_BONES_READY = 1 << 1,
+		};
+
+		struct SurfaceData {
+			PoolByteArray source_buffer;
+			uint32_t source_format;
+			PoolByteArray buffer;
+			PoolByteArray::Write buffer_write;
+			bool transform_tangents;
+			bool ensure_correct_normals;
+		};
+
+		Ref<Mesh> mesh_instance;
+		LocalVector<SurfaceData> surface_data;
+	};
+
+	SoftwareSkinning *software_skinning;
+	uint32_t software_skinning_flags;
 
 	struct BlendShapeTrack {
 
@@ -62,6 +89,12 @@ protected:
 
 	void _mesh_changed();
 	void _resolve_skeleton_path();
+
+	bool _is_software_skinning_enabled() const;
+	static bool _is_global_software_skinning_enabled();
+
+	void _initialize_skinning(bool p_force_reset = false);
+	void _update_skinning();
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -84,6 +117,12 @@ public:
 	int get_surface_material_count() const;
 	void set_surface_material(int p_surface, const Ref<Material> &p_material);
 	Ref<Material> get_surface_material(int p_surface) const;
+	Ref<Material> get_active_material(int p_surface) const;
+
+	virtual void set_material_override(const Ref<Material> &p_material);
+
+	void set_software_skinning_transform_normals(bool p_enabled);
+	bool is_software_skinning_transform_normals_enabled() const;
 
 	Node *create_trimesh_collision_node();
 	void create_trimesh_collision();

--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -53,6 +53,10 @@ RID SkinReference::get_skeleton() const {
 	return skeleton;
 }
 
+Skeleton *SkinReference::get_skeleton_node() const {
+	return skeleton_node;
+}
+
 Ref<Skin> SkinReference::get_skin() const {
 	return skin;
 }
@@ -371,6 +375,7 @@ void Skeleton::_notification(int p_what) {
 			}
 
 			dirty = false;
+			emit_signal("skeleton_updated");
 		} break;
 	}
 }
@@ -891,6 +896,8 @@ void Skeleton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("physical_bones_remove_collision_exception", "exception"), &Skeleton::physical_bones_remove_collision_exception);
 
 #endif // _3D_DISABLED
+
+	ADD_SIGNAL(MethodInfo("skeleton_updated"));
 
 	BIND_CONSTANT(NOTIFICATION_UPDATE_SKELETON);
 }

--- a/scene/3d/skeleton.h
+++ b/scene/3d/skeleton.h
@@ -47,13 +47,13 @@ class SkinReference : public Reference {
 	GDCLASS(SkinReference, Reference)
 	friend class Skeleton;
 
-	Skeleton *skeleton_node;
+	Skeleton *skeleton_node = nullptr;
 	RID skeleton;
 	Ref<Skin> skin;
 	uint32_t bind_count = 0;
 	uint64_t skeleton_version = 0;
 	Vector<uint32_t> skin_bone_indices;
-	uint32_t *skin_bone_indices_ptrs;
+	uint32_t *skin_bone_indices_ptrs = nullptr;
 	void _skin_changed();
 
 protected:
@@ -61,6 +61,7 @@ protected:
 
 public:
 	RID get_skeleton() const;
+	Skeleton *get_skeleton_node() const;
 	Ref<Skin> get_skin() const;
 	~SkinReference();
 };

--- a/scene/3d/visual_instance.h
+++ b/scene/3d/visual_instance.h
@@ -132,7 +132,7 @@ public:
 	void set_lod_max_hysteresis(float p_dist);
 	float get_lod_max_hysteresis() const;
 
-	void set_material_override(const Ref<Material> &p_material);
+	virtual void set_material_override(const Ref<Material> &p_material);
 	Ref<Material> get_material_override() const;
 
 	void set_extra_cull_margin(float p_margin);

--- a/servers/visual/rasterizer.cpp
+++ b/servers/visual/rasterizer.cpp
@@ -46,3 +46,11 @@ RasterizerStorage::RasterizerStorage() {
 
 	base_singleton = this;
 }
+
+bool RasterizerStorage::material_uses_tangents(RID p_material) {
+	return false;
+}
+
+bool RasterizerStorage::material_uses_ensure_correct_normals(RID p_material) {
+	return false;
+}

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -264,6 +264,8 @@ public:
 
 	virtual bool material_is_animated(RID p_material) = 0;
 	virtual bool material_casts_shadows(RID p_material) = 0;
+	virtual bool material_uses_tangents(RID p_material);
+	virtual bool material_uses_ensure_correct_normals(RID p_material);
 
 	virtual void material_add_instance_owner(RID p_material, RasterizerScene::InstanceBase *p_instance) = 0;
 	virtual void material_remove_instance_owner(RID p_material, RasterizerScene::InstanceBase *p_instance) = 0;

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2432,6 +2432,9 @@ VisualServer::VisualServer() {
 
 	GLOBAL_DEF("rendering/quality/filters/use_nearest_mipmap_filter", false);
 
+	GLOBAL_DEF("rendering/quality/skinning/software_skinning_fallback", true);
+	GLOBAL_DEF("rendering/quality/skinning/force_software_skinning", false);
+
 	const char *sz_balance_render_tree = "rendering/quality/spatial_partitioning/render_tree_balance";
 	GLOBAL_DEF(sz_balance_render_tree, 0.17f);
 	ProjectSettings::get_singleton()->set_custom_property_info(sz_balance_render_tree, PropertyInfo(Variant::REAL, sz_balance_render_tree, PROPERTY_HINT_RANGE, "0.0,1.0,0.01"));


### PR DESCRIPTION
Option in `MeshInstance` to enable software skinning, in order to test against the current `USE_SKELETON_SOFTWARE` path which causes problems with bad performance.

Co-authored by @lawnjelly 

More details in #37696.

Remaining things to do around this feature:
- [x] Fix issues with changing `mesh` and `override_material` properties (https://github.com/godotengine/godot/pull/40313#issuecomment-657649437)
- [x] Support for transforming normals (https://github.com/godotengine/godot/issues/37696#issuecomment-657198549)
- [x] Option for correct normals for non-uniform scale (https://github.com/godotengine/godot/pull/40313#issuecomment-660546685)
- [x] Flags for enabling/disabling normals (https://github.com/godotengine/godot/pull/40313#issuecomment-657737563)
- [x] Check if tangent transformation is needed (https://github.com/godotengine/godot/pull/40313#issuecomment-657737563)
- [x] Project setting to switch fallback between USE_SKELETON_SOFTWARE & software skinning (https://github.com/godotengine/godot/pull/40313#issuecomment-657737563)
- [x] Handle variable bone count allocation on stack (https://github.com/godotengine/godot/pull/40313#discussion_r453296113)
- [x] GLES3 not working (https://github.com/godotengine/godot/pull/40313#issuecomment-666213287)
- [x] Profile and check for extra optimization