### PR TITLE
GDScript: Script.get_property_default_value() removed

### DIFF
--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -116,7 +116,6 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_script_method_list"), &Script::_get_script_method_list);
 	ClassDB::bind_method(D_METHOD("get_script_signal_list"), &Script::_get_script_signal_list);
 	ClassDB::bind_method(D_METHOD("get_script_constant_map"), &Script::_get_script_constant_map);
-	ClassDB::bind_method(D_METHOD("get_property_default_value", "property"), &Script::_get_property_default_value);
 
 	ClassDB::bind_method(D_METHOD("is_tool"), &Script::is_tool);
 

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -32,15 +32,6 @@
 				Returns the script's base type.
 			</description>
 		</method>
-		<method name="get_property_default_value">
-			<return type="Variant">
-			</return>
-			<argument index="0" name="property" type="StringName">
-			</argument>
-			<description>
-				Returns the default value of the specified property.
-			</description>
-		</method>
 		<method name="get_script_constant_map">
 			<return type="Dictionary">
 			</return>


### PR DESCRIPTION
Fix: #40122

The default values of exported variables (only) are cached and used by the editor, so the method `get_property_default_value` shouldn't exposed to GDScript