### PR TITLE
Avoid overflow when calculating visible_cells

### DIFF
--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -211,7 +211,7 @@ struct SpatialIndexer2D {
 			List<VisibilityNotifier2D *> added;
 			List<VisibilityNotifier2D *> removed;
 
-			int visible_cells = (end.x - begin.x) * (end.y - begin.y);
+			uint64_t visible_cells = (uint64_t)(end.x - begin.x) * (uint64_t)(end.y - begin.y);
 
 			if (visible_cells > 10000) {
 				//well you zoomed out a lot, it's your problem. To avoid freezing in the for loops below, we'll manually check cell by cell


### PR DESCRIPTION
Integer overflow occurs at a Camera2D zoom level of around (6000, 6000), resulting in the `else` branch being incorrectly executed, with predictably terrible performance. Fixed by using 64-bit integers for the multiplication.