### PR TITLE
Disable "misleading indentation" warning on GCC

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -455,6 +455,7 @@ if selected_platform in platform_list:
         all_plus_warnings = ["-Wwrite-strings"]
 
         if methods.using_gcc(env):
+            env.Append(CCFLAGS=["-Wno-misleading-indentation"])
             if cc_version_major >= 7:
                 shadow_local_warning = ["-Wshadow-local"]
 


### PR DESCRIPTION
This warning has been bugged in GCC for the past several versions: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89549

Aside from that, this warning isn't relevant to Godot anymore, since we enforce braces now in the master branch.

*Bugsquad edit:* Fixes #26443.