### PR TITLE
Fix overriding compression related settings

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -488,6 +488,14 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bo
 			_load_settings_text(custom_settings);
 		}
 	}
+	// Using GLOBAL_GET on every block for compressing can be slow, so assigning here.
+	Compression::zstd_long_distance_matching = GLOBAL_GET("compression/formats/zstd/long_distance_matching");
+	Compression::zstd_level = GLOBAL_GET("compression/formats/zstd/compression_level");
+	Compression::zstd_window_log_size = GLOBAL_GET("compression/formats/zstd/window_log_size");
+
+	Compression::zlib_level = GLOBAL_GET("compression/formats/zlib/compression_level");
+
+	Compression::gzip_level = GLOBAL_GET("compression/formats/gzip/compression_level");
 
 	return err;
 }
@@ -1007,6 +1015,9 @@ void ProjectSettings::_bind_methods() {
 }
 
 ProjectSettings::ProjectSettings() {
+	// Initialization of engine variables should be done in the setup() method,
+	// so that the values can be overridden from project.godot or project.binary.
+
 	singleton = this;
 
 	Array events;
@@ -1206,18 +1217,17 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("debug/settings/profiler/max_functions", 16384);
 	custom_prop_info["debug/settings/profiler/max_functions"] = PropertyInfo(Variant::INT, "debug/settings/profiler/max_functions", PROPERTY_HINT_RANGE, "128,65535,1");
 
-	//assigning here, because using GLOBAL_GET on every block for compressing can be slow
-	Compression::zstd_long_distance_matching = GLOBAL_DEF("compression/formats/zstd/long_distance_matching", false);
+	GLOBAL_DEF("compression/formats/zstd/long_distance_matching", Compression::zstd_long_distance_matching);
 	custom_prop_info["compression/formats/zstd/long_distance_matching"] = PropertyInfo(Variant::BOOL, "compression/formats/zstd/long_distance_matching");
-	Compression::zstd_level = GLOBAL_DEF("compression/formats/zstd/compression_level", 3);
+	GLOBAL_DEF("compression/formats/zstd/compression_level", Compression::zstd_level);
 	custom_prop_info["compression/formats/zstd/compression_level"] = PropertyInfo(Variant::INT, "compression/formats/zstd/compression_level", PROPERTY_HINT_RANGE, "1,22,1");
-	Compression::zstd_window_log_size = GLOBAL_DEF("compression/formats/zstd/window_log_size", 27);
+	GLOBAL_DEF("compression/formats/zstd/window_log_size", Compression::zstd_window_log_size);
 	custom_prop_info["compression/formats/zstd/window_log_size"] = PropertyInfo(Variant::INT, "compression/formats/zstd/window_log_size", PROPERTY_HINT_RANGE, "10,30,1");
 
-	Compression::zlib_level = GLOBAL_DEF("compression/formats/zlib/compression_level", Z_DEFAULT_COMPRESSION);
+	GLOBAL_DEF("compression/formats/zlib/compression_level", Compression::zlib_level);
 	custom_prop_info["compression/formats/zlib/compression_level"] = PropertyInfo(Variant::INT, "compression/formats/zlib/compression_level", PROPERTY_HINT_RANGE, "-1,9,1");
 
-	Compression::gzip_level = GLOBAL_DEF("compression/formats/gzip/compression_level", Z_DEFAULT_COMPRESSION);
+	GLOBAL_DEF("compression/formats/gzip/compression_level", Compression::gzip_level);
 	custom_prop_info["compression/formats/gzip/compression_level"] = PropertyInfo(Variant::INT, "compression/formats/gzip/compression_level", PROPERTY_HINT_RANGE, "-1,9,1");
 }
 


### PR DESCRIPTION
Fixes #40233.

This is achieved by retrieving values from `project.godot` in `setup()` rather than `ProjectSettings()`, added some comments accordingly. I've also made it that the default values are taken from the `Compression` class (both had the same default values).

Note that this PR cannot be tested in `master` due to #36611 as of now, but works fine in `3.2`.
