### PR TITLE
Add algorithm and wrap parameters to Image::bump_map_to_normal_map

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3153,7 +3153,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("srgb_to_linear"), &Image::srgb_to_linear);
 	ClassDB::bind_method(D_METHOD("normal_map_to_xy"), &Image::normal_map_to_xy);
 	ClassDB::bind_method(D_METHOD("rgbe_to_srgb"), &Image::rgbe_to_srgb);
-	ClassDB::bind_method(D_METHOD("bump_map_to_normal_map", "bump_scale"), &Image::bump_map_to_normal_map, DEFVAL(1.0));
+	ClassDB::bind_method(D_METHOD("bump_map_to_normal_map", "bump_scale", "algorithm", "wrap_mode"), &Image::bump_map_to_normal_map, DEFVAL(1.0), DEFVAL(BUMP_TO_NORMAL_ALGORITHM_PARTIAL_DERIVATIVE), DEFVAL(BUMP_TO_NORMAL_WRAP_REPEAT));
 
 	ClassDB::bind_method(D_METHOD("blit_rect", "src", "src_rect", "dst"), &Image::blit_rect);
 	ClassDB::bind_method(D_METHOD("blit_rect_mask", "src", "mask", "src_rect", "dst"), &Image::blit_rect_mask);
@@ -3254,6 +3254,12 @@ void Image::_bind_methods() {
 	BIND_ENUM_CONSTANT(COMPRESS_SOURCE_GENERIC);
 	BIND_ENUM_CONSTANT(COMPRESS_SOURCE_SRGB);
 	BIND_ENUM_CONSTANT(COMPRESS_SOURCE_NORMAL);
+
+	BIND_ENUM_CONSTANT(BUMP_TO_NORMAL_ALGORITHM_PARTIAL_DERIVATIVE);
+	BIND_ENUM_CONSTANT(BUMP_TO_NORMAL_ALGORITHM_SOBEL);
+
+	BIND_ENUM_CONSTANT(BUMP_TO_NORMAL_WRAP_REPEAT);
+	BIND_ENUM_CONSTANT(BUMP_TO_NORMAL_WRAP_CLAMP);
 }
 
 void Image::set_compress_bc_func(void (*p_compress_func)(Image *, float, UsedChannels)) {
@@ -3329,7 +3335,7 @@ Ref<Image> Image::get_image_from_mipmap(int p_mipamp) const {
 	return image;
 }
 
-void Image::bump_map_to_normal_map(float bump_scale) {
+void Image::bump_map_to_normal_map(float bump_scale, BumpMapToNormalMapAlgorithm algorithm, BumpMapToNormalMapWrap wrap_mode) {
 	ERR_FAIL_COND(!_can_modify(format));
 	convert(Image::FORMAT_RF);
 
@@ -3345,30 +3351,97 @@ void Image::bump_map_to_normal_map(float bump_scale) {
 		unsigned char *write_ptr = wp;
 		float *read_ptr = (float *)rp;
 
-		for (int ty = 0; ty < height; ty++) {
-			int py = ty + 1;
-			if (py >= height) {
-				py -= height;
+		int x = 0, x_right = 0, x_left = 0;
+		int y = 0, y_up = 0, y_down = 0;
+
+		for (int it_y = 0; it_y < height; it_y++) {
+			y = it_y;
+
+			if (wrap_mode == BUMP_TO_NORMAL_WRAP_REPEAT) {
+				y_up = y + 1;
+				y_down = y - 1;
+
+				if (y_up >= height) {
+					y_up -= height;
+				}
+
+				if (y_down < 0) {
+					y_down += height;
+				}
+			} else if (wrap_mode == BUMP_TO_NORMAL_WRAP_CLAMP) {
+				if (algorithm == BUMP_TO_NORMAL_ALGORITHM_PARTIAL_DERIVATIVE) {
+					// For partial derivative, we only need to correct for up and right.
+					y = CLAMP(y, 0, height - 2);
+				} else if (algorithm == BUMP_TO_NORMAL_ALGORITHM_SOBEL) {
+					// Sobel filter also needs the pixels down and left, so we need to limit the area even further.
+					y = CLAMP(y, 1, height - 2);
+				}
+
+				y_up = y + 1;
+				y_down = y - 1;
 			}
 
-			for (int tx = 0; tx < width; tx++) {
-				int px = tx + 1;
-				if (px >= width) {
-					px -= width;
-				}
-				float here = read_ptr[ty * width + tx];
-				float to_right = read_ptr[ty * width + px];
-				float above = read_ptr[py * width + tx];
-				Vector3 up = Vector3(0, 1, (here - above) * bump_scale);
-				Vector3 across = Vector3(1, 0, (to_right - here) * bump_scale);
+			for (int it_x = 0; it_x < width; it_x++) {
+				x = it_x;
 
-				Vector3 normal = across.cross(up);
+				if (wrap_mode == BUMP_TO_NORMAL_WRAP_REPEAT) {
+					x_right = x + 1;
+					x_left = x - 1;
+
+					if (x_right >= width) {
+						x_right -= width;
+					}
+
+					if (x_left < 0) {
+						x_left -= width;
+					}
+				} else if (wrap_mode == BUMP_TO_NORMAL_WRAP_CLAMP) {
+					if (algorithm == BUMP_TO_NORMAL_ALGORITHM_PARTIAL_DERIVATIVE) {
+						// For partial derivative, we only need to correct for up and right.
+						x = CLAMP(x, 0, width - 2);
+					} else if (algorithm == BUMP_TO_NORMAL_ALGORITHM_SOBEL) {
+						// Sobel filter also needs the pixels down and left, so we need to limit the area even further.
+						x = CLAMP(x, 1, width - 2);
+					}
+
+					x_right = x + 1;
+					x_left = x - 1;
+				}
+
+				Vector3 normal;
+
+				if (algorithm == BUMP_TO_NORMAL_ALGORITHM_PARTIAL_DERIVATIVE) {
+					float here = read_ptr[y * width + x];
+					float to_right = read_ptr[y * width + x_right];
+					float above = read_ptr[y_up * width + x];
+
+					Vector3 up = Vector3(0, 1, (here - above) * bump_scale);
+					Vector3 across = Vector3(1, 0, (to_right - here) * bump_scale);
+
+					normal = across.cross(up);
+				} else if (algorithm == BUMP_TO_NORMAL_ALGORITHM_SOBEL) {
+					float bottom_left = read_ptr[y_up * width + x_right];
+					float bottom_center = read_ptr[y_up * width + x];
+					float bottom_right = read_ptr[y_up * width + x_left];
+
+					float center_left = read_ptr[y * width + x_right];
+					float center_right = read_ptr[y * width + x_left];
+
+					float top_left = read_ptr[y_down * width + x_right];
+					float top_center = read_ptr[y_down * width + x];
+					float top_right = read_ptr[y_down * width + x_left];
+
+					normal.x = ((top_right + 2.0 * center_right + bottom_right) - (top_left + 2.0 * center_left + bottom_left));
+					normal.y = ((bottom_left + 2.0 * bottom_center + bottom_right) - (top_left + 2.0 * top_center + top_right));
+					normal.z = 8.0 / bump_scale; // Multiply by 8.0 to compensate for the additional variables, matching the scale with BUMP_TO_NORMAL_ALGORITHM_PARTIAL_DERIVATIVE
+				}
+
 				normal.normalize();
 
-				write_ptr[((ty * width + tx) << 2) + 0] = (127.5 + normal.x * 127.5);
-				write_ptr[((ty * width + tx) << 2) + 1] = (127.5 + normal.y * 127.5);
-				write_ptr[((ty * width + tx) << 2) + 2] = (127.5 + normal.z * 127.5);
-				write_ptr[((ty * width + tx) << 2) + 3] = 255;
+				write_ptr[((it_y * width + it_x) << 2) + 0] = (127.5 + normal.x * 127.5);
+				write_ptr[((it_y * width + it_x) << 2) + 1] = (127.5 + normal.y * 127.5);
+				write_ptr[((it_y * width + it_x) << 2) + 2] = (127.5 + normal.z * 127.5);
+				write_ptr[((it_y * width + it_x) << 2) + 3] = 255;
 			}
 		}
 	}

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -356,7 +356,16 @@ public:
 	void normal_map_to_xy();
 	Ref<Image> rgbe_to_srgb();
 	Ref<Image> get_image_from_mipmap(int p_mipamp) const;
-	void bump_map_to_normal_map(float bump_scale = 1.0);
+
+	enum BumpMapToNormalMapAlgorithm {
+		BUMP_TO_NORMAL_ALGORITHM_PARTIAL_DERIVATIVE, // Cross product of the partial derivatives - fast, but potentially noisy
+		BUMP_TO_NORMAL_ALGORITHM_SOBEL // Sobel Filter - about 3x slower, but cleaner result
+	};
+	enum BumpMapToNormalMapWrap {
+		BUMP_TO_NORMAL_WRAP_REPEAT, // Assumes that the pixel row outside of the available bump map image, which is required for calculating normals, has the same height as the closest available row. Should only be used for tiling textures.
+		BUMP_TO_NORMAL_WRAP_CLAMP // Assumes that the incline stays constant in the pixel row outside of the available bump map image. This prevents flat (upright) normal vectors at the edge of the normal map.
+	};
+	void bump_map_to_normal_map(float bump_scale = 1.0, BumpMapToNormalMapAlgorithm algorithm = BUMP_TO_NORMAL_ALGORITHM_PARTIAL_DERIVATIVE, BumpMapToNormalMapWrap wrap_mode = BUMP_TO_NORMAL_WRAP_REPEAT);
 
 	void blit_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Point2 &p_dest);
 	void blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, const Rect2 &p_src_rect, const Point2 &p_dest);
@@ -411,6 +420,8 @@ VARIANT_ENUM_CAST(Image::Format)
 VARIANT_ENUM_CAST(Image::Interpolation)
 VARIANT_ENUM_CAST(Image::CompressMode)
 VARIANT_ENUM_CAST(Image::CompressSource)
+VARIANT_ENUM_CAST(Image::BumpMapToNormalMapAlgorithm)
+VARIANT_ENUM_CAST(Image::BumpMapToNormalMapWrap)
 VARIANT_ENUM_CAST(Image::UsedChannels)
 VARIANT_ENUM_CAST(Image::AlphaMode)
 VARIANT_ENUM_CAST(Image::RoughnessChannel)

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -61,6 +61,8 @@
 		<method name="bump_map_to_normal_map">
 			<return type="void" />
 			<argument index="0" name="bump_scale" type="float" default="1.0" />
+			<argument index="1" name="algorithm" type="int" enum="Image.BumpMapToNormalMapAlgorithm" default="0" />
+			<argument index="2" name="wrap_mode" type="int" enum="Image.BumpMapToNormalMapWrap" default="0" />
 			<description>
 				Converts a bump map to a normal map. A bump map provides a height offset per-pixel, while a normal map provides a normal direction per pixel.
 			</description>
@@ -646,6 +648,18 @@
 		</constant>
 		<constant name="COMPRESS_SOURCE_NORMAL" value="2" enum="CompressSource">
 			Source texture (before compression) is a normal texture (e.g. it can be compressed into two channels).
+		</constant>
+		<constant name="BUMP_TO_NORMAL_ALGORITHM_PARTIAL_DERIVATIVE" value="0" enum="BumpMapToNormalMapAlgorithm">
+			Calculate normals in [method bump_map_to_normal_map] using the [url=https://en.wikipedia.org/wiki/Partial_derivative]partial derivatives[/url] of the heights. Faster, but potentially noisy.
+		</constant>
+		<constant name="BUMP_TO_NORMAL_ALGORITHM_SOBEL" value="1" enum="BumpMapToNormalMapAlgorithm">
+			Calculate normals in [method bump_map_to_normal_map] using a [url=https://en.wikipedia.org/wiki/Sobel_operator]Sobel operator[/url]. Slower, but smoother since it looks at more adjacent pixels than [constant BUMP_TO_NORMAL_ALGORITHM_PARTIAL_DERIVATIVE].
+		</constant>
+		<constant name="BUMP_TO_NORMAL_WRAP_REPEAT" value="0" enum="BumpMapToNormalMapWrap">
+			Repeat wrapping in [method bump_map_to_normal_map]. Should be used with tileable textures to get seamlessly tiling normal maps.
+		</constant>
+		<constant name="BUMP_TO_NORMAL_WRAP_CLAMP" value="1" enum="BumpMapToNormalMapWrap">
+			Clamp wrapping in [method bump_map_to_normal_map]. Should always be used with non-tileable textures to prevent wrong normals at the border.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
As discussed and shown in https://github.com/godotengine/godot-proposals/issues/659, this improves the `Image::bump_map_to_normal_map` function in two ways:

1. In addition to the default "repeat" wrapping, "clamp" wrapping is now supported. This is required when the algorithm is applied to non-tileable images, e.g. when two different, adjacent heightmap tiles are next to each other. The wrapping type to use can be given as an additional parameter - either `BUMP_TO_NORMAL_WRAP_REPEAT` or `BUMP_TO_NORMAL_WRAP_CLAMP`.

![connected_previous](https://user-images.githubusercontent.com/18697097/87324308-35352980-c530-11ea-84e7-0b37d93e09c4.png) Result with `BUMP_TO_NORMAL_WRAP_REPEAT` (previously the only possible result)

![connected_new_wrapping](https://user-images.githubusercontent.com/18697097/87324357-43834580-c530-11ea-9175-830dbb2c3055.png) New result with `BUMP_TO_NORMAL_WRAP_CLAMP`


2. The option of using a higher quality (but slower) algorithm for calculating the normal for a given pixel is added, also via an enum parameter. This new algorithm uses a Sobel operator instead of the partial derivatives. Especially when using very detailed bump maps, this noticeably reduces noise and creates smoother heights.

![algo_comparison](https://user-images.githubusercontent.com/18697097/87324442-601f7d80-c530-11ea-9736-30ade20a731d.png)

Side-by-side comparison of the `BUMP_TO_NORMAL_ALGO_PARTIAL_DERIVATIVE` algorithm (previously the only option) (left) and the new `BUMP_TO_NORMAL_ALGO_SOBEL` algorithm (right).

Both of these options can be passed to `Image::bump_map_to_normal_map` as __optional__ parameters - the previous function call still works and yields exactly the same result as before. Calling the function with both new parameters looks like this: `img.bump_map_to_normal_map(10.0, Image.BUMP_TO_NORMAL_ALGO_SOBEL, Image.BUMP_TO_NORMAL_WRAP_CLAMP)`

(All screenshots were taken in the engine with a directional light and two meshes with normal maps.)