### PR TITLE
Fix overlappingObjects vector crash

### DIFF
--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -174,7 +174,7 @@ void AreaBullet::do_reload_body() {
 void AreaBullet::set_space(SpaceBullet *p_space) {
 	// Clear the old space if there is one
 	if (space) {
-		overlappingObjects.clear();
+		clear_overlaps(false);
 		isScratched = false;
 
 		// Remove this object form the physics world


### PR DESCRIPTION
use clear_overlaps() instead of clearing overlappingObjects directly

Fix #40325