### PR TITLE
SCons: Print info message on build failures with `werror=yes`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -700,3 +700,16 @@ if "env" in locals():
     # TODO: replace this with `env.Dump(format="json")`
     # once we start requiring SCons 4.0 as min version.
     methods.dump(env)
+
+    import atexit
+
+    def check_build_failures():
+        failed = len(GetBuildFailures()) > 0
+        if failed and env["werror"] and not env.stable_release:
+            print(
+                "Build failed while treating warnings as errors. "
+                "Use `werror=no` build option to compile the engine normally "
+                "in the development versions."
+            )
+
+    atexit.register(check_build_failures)


### PR DESCRIPTION
This provides an informational message allowing people to compile the engine by bypassing `werror` build option (this does not change the defaults).

Using [`GetBuildFailures`](https://scons.org/doc/3.1.1/HTML/scons-user.html#idm2091) method provided by SCons to know whether a build has failed internally.

The condition is quite specific and should only affect development versions.

See some reports which justify this change:

#38829
#39648
#39901
~~#40286~~ https://github.com/godotengine/godot/pull/40355#issuecomment-658032776
#40342