### PR TITLE
Expose culling_rect to CanvasItems

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -543,6 +543,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="culling_rect" type="Rect2" setter="set_culling_rect" getter="get_culling_rect" default="Rect2( 0, 0, 0, 0 )">
+			Custom [Rect2] for culling the [CanvasItem] as it enters or exits the [Viewport]. Set the culling rect to a large size to keep the renderer from culling the [CanvasItem] or its draw commands. This can be especially useful if you have a [Node2D] with a [Skeleton2D] attached that moves the [Node2D] a lot. If the culling rect is smaller than the [CanvasItem], it will have no effect. 
+		</member>
 		<member name="light_mask" type="int" setter="set_light_mask" getter="get_light_mask" default="1">
 			The rendering layers in which this [CanvasItem] responds to [Light2D] nodes.
 		</member>

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -489,7 +489,7 @@
 			<argument index="2" name="rect" type="Rect2" default="Rect2( 0, 0, 0, 0 )">
 			</argument>
 			<description>
-				Defines a custom drawing rectangle for the [CanvasItem].
+				Sets a custom rectangle for culling. If [code]use_custom_rect[/code] is [code]true[/code], overrides generated culling rect. If [code]use_custom_rect[/code] is [code]false[/code], sets a minimum size for the culling rect.
 			</description>
 		</method>
 		<method name="canvas_item_set_distance_field_mode">

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -1118,6 +1118,17 @@ void CanvasItem::force_update_transform() {
 	notification(NOTIFICATION_TRANSFORM_CHANGED);
 }
 
+void CanvasItem::set_culling_rect(const Rect2 &p_rect) {
+
+	culling_rect = p_rect;
+
+	VS::get_singleton()->canvas_item_set_custom_rect(get_canvas_item(), false, p_rect);
+}
+
+Rect2 CanvasItem::get_culling_rect() const {
+	return culling_rect;
+}
+
 void CanvasItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_toplevel_raise_self"), &CanvasItem::_toplevel_raise_self);
@@ -1221,6 +1232,9 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("make_canvas_position_local", "screen_point"), &CanvasItem::make_canvas_position_local);
 	ClassDB::bind_method(D_METHOD("make_input_local", "event"), &CanvasItem::make_input_local);
 
+	ClassDB::bind_method(D_METHOD("set_culling_rect", "rect"), &CanvasItem::set_culling_rect);
+	ClassDB::bind_method(D_METHOD("get_culling_rect"), &CanvasItem::get_culling_rect);
+
 	BIND_VMETHOD(MethodInfo("_draw"));
 
 	ADD_GROUP("Visibility", "");
@@ -1230,6 +1244,7 @@ void CanvasItem::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_behind_parent"), "set_draw_behind_parent", "is_draw_behind_parent_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_on_top", PROPERTY_HINT_NONE, "", 0), "_set_on_top", "_is_on_top"); //compatibility
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_mask", PROPERTY_HINT_LAYERS_2D_RENDER), "set_light_mask", "get_light_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "culling_rect"), "set_culling_rect", "get_culling_rect");
 
 	ADD_GROUP("Material", "");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,CanvasItemMaterial"), "set_material", "get_material");
@@ -1338,6 +1353,8 @@ CanvasItem::CanvasItem() :
 	notify_local_transform = false;
 	notify_transform = false;
 	light_mask = 1;
+
+	culling_rect = Rect2();
 
 	C = NULL;
 }

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -203,6 +203,8 @@ private:
 	bool notify_local_transform;
 	bool notify_transform;
 
+	Rect2 culling_rect;
+
 	Ref<Material> material;
 
 	mutable Transform2D global_transform;
@@ -382,6 +384,9 @@ public:
 	bool is_transform_notification_enabled() const;
 
 	void force_update_transform();
+
+	void set_culling_rect(const Rect2 &p_rect);
+	Rect2 get_culling_rect() const;
 
 	// Used by control nodes to retrieve the parent's anchorable area
 	virtual Rect2 get_anchorable_rect() const { return Rect2(0, 0, 0, 0); };

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -620,7 +620,12 @@ void Control::_notification(int p_notification) {
 		case NOTIFICATION_DRAW: {
 
 			_update_canvas_item_transform();
-			VisualServer::get_singleton()->canvas_item_set_custom_rect(get_canvas_item(), !data.disable_visibility_clip, Rect2(Point2(), get_size()));
+
+			Rect2 cull_rect = get_culling_rect();
+			cull_rect = cull_rect.merge(Rect2(Point2(), get_size()));
+
+			VisualServer::get_singleton()->canvas_item_set_custom_rect(get_canvas_item(), !data.disable_visibility_clip, cull_rect);
+
 			VisualServer::get_singleton()->canvas_item_set_clip(get_canvas_item(), data.clip_contents);
 			//emit_signal(SceneStringNames::get_singleton()->draw);
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/35726

This exposes the custom culling rect to the editor so users can artificially increase the size of the culling rect. This is similar to AABBs in 3D rendering. Right now this is very useful for Node2Ds that use Skeleton2Ds and for Control-derived nodes that use the custom drawing API.

I think this is the best fix we can do for 3.2. Anything more complex is going to require a lot of changes to the VisualServer