### PR TITLE
Alpha Hash and Alpha2Coverage Implementation

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -193,6 +193,20 @@ static inline unsigned int nearest_shift(unsigned int p_number) {
 	return 0;
 }
 
+// constexpr function to find the floored log2 of a number
+template <typename T>
+constexpr T floor_log2(T x) {
+	return x < 2 ? x : 1 + floor_log2(x >> 1);
+}
+
+// Get the number of bits needed to represent the number.
+// IE, if you pass in 8, you will get 4.
+// If you want to know how many bits are needed to store 8 values however, pass in (8 - 1).
+template <typename T>
+constexpr T get_num_bits(T x) {
+	return floor_log2(x);
+}
+
 // Swap 16, 32 and 64 bits value for endianness.
 #if defined(__GNUC__)
 #define BSWAP16(x) __builtin_bswap16(x)

--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -81,6 +81,15 @@
 		<member name="albedo_texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			Texture to multiply by [member albedo_color]. Used for basic texturing of objects.
 		</member>
+		<member name="alpha_antialiasing_edge" type="float" setter="set_alpha_antialiasing_edge" getter="get_alpha_antialiasing_edge">
+			Threshold at which antialiasing will by applied on the alpha channel.
+		</member>
+		<member name="alpha_antialiasing_mode" type="int" setter="set_alpha_antialiasing" getter="get_alpha_antialiasing" enum="BaseMaterial3D.AlphaAntiAliasing">
+			The type of alpha antialiasing to apply. See [enum AlphaAntiAliasing].
+		</member>
+		<member name="alpha_hash_scale" type="float" setter="set_alpha_hash_scale" getter="get_alpha_hash_scale">
+			The hashing scale for Alpha Hash. Recommended values between [code]0[/code] and [code]2[/code].
+		</member>
 		<member name="alpha_scissor_threshold" type="float" setter="set_alpha_scissor_threshold" getter="get_alpha_scissor_threshold">
 			Threshold at which the alpha scissor will discard values.
 		</member>
@@ -486,10 +495,13 @@
 		<constant name="TRANSPARENCY_ALPHA_SCISSOR" value="2" enum="Transparency">
 			The material will cut off all values below a threshold, the rest will remain opaque.
 		</constant>
-		<constant name="TRANSPARENCY_ALPHA_DEPTH_PRE_PASS" value="3" enum="Transparency">
+		<constant name="TRANSPARENCY_ALPHA_HASH" value="3" enum="Transparency">
+			The material will cut off all values below a spatially-deterministic threshold, the rest will remain opaque.
+		</constant>
+		<constant name="TRANSPARENCY_ALPHA_DEPTH_PRE_PASS" value="4" enum="Transparency">
 			The material will use the texture's alpha value for transparency, but will still be rendered in the pre-pass.
 		</constant>
-		<constant name="TRANSPARENCY_MAX" value="4" enum="Transparency">
+		<constant name="TRANSPARENCY_MAX" value="5" enum="Transparency">
 			Represents the size of the [enum Transparency] enum.
 		</constant>
 		<constant name="SHADING_MODE_UNSHADED" value="0" enum="ShadingMode">
@@ -554,6 +566,15 @@
 		</constant>
 		<constant name="BLEND_MODE_MUL" value="3" enum="BlendMode">
 			The color of the object is multiplied by the background.
+		</constant>
+		<constant name="ALPHA_ANTIALIASING_OFF" value="0" enum="AlphaAntiAliasing">
+			Disables Alpha AntiAliasing for the material.
+		</constant>
+		<constant name="ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE" value="1" enum="AlphaAntiAliasing">
+			Enables AlphaToCoverage. Alpha values in the material are passed to the AntiAliasing sample mask.
+		</constant>
+		<constant name="ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE_AND_TO_ONE" value="2" enum="AlphaAntiAliasing">
+			Enables AlphaToCoverage and forces all non-zero alpha values to [code]1[/code]. Alpha values in the material are passed to the AntiAliasing sample mask.
 		</constant>
 		<constant name="DEPTH_DRAW_OPAQUE_ONLY" value="0" enum="DepthDrawMode">
 			Default depth draw mode. Depth is drawn only for opaque objects.

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -145,15 +145,24 @@ public:
 
 	enum DetailUV {
 		DETAIL_UV_1,
-		DETAIL_UV_2
+		DETAIL_UV_2,
+		DETAIL_UV_MAX
 	};
 
 	enum Transparency {
 		TRANSPARENCY_DISABLED,
 		TRANSPARENCY_ALPHA,
 		TRANSPARENCY_ALPHA_SCISSOR,
+		TRANSPARENCY_ALPHA_HASH,
 		TRANSPARENCY_ALPHA_DEPTH_PRE_PASS,
 		TRANSPARENCY_MAX,
+	};
+
+	enum AlphaAntiAliasing {
+		ALPHA_ANTIALIASING_OFF,
+		ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE,
+		ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE_AND_TO_ONE,
+		ALPHA_ANTIALIASING_MAX
 	};
 
 	enum ShadingMode {
@@ -184,18 +193,21 @@ public:
 		BLEND_MODE_ADD,
 		BLEND_MODE_SUB,
 		BLEND_MODE_MUL,
+		BLEND_MODE_MAX
 	};
 
 	enum DepthDrawMode {
 		DEPTH_DRAW_OPAQUE_ONLY,
 		DEPTH_DRAW_ALWAYS,
 		DEPTH_DRAW_DISABLED,
+		DEPTH_DRAW_MAX
 	};
 
 	enum CullMode {
 		CULL_BACK,
 		CULL_FRONT,
-		CULL_DISABLED
+		CULL_DISABLED,
+		CULL_MAX
 	};
 
 	enum Flags {
@@ -227,6 +239,7 @@ public:
 		DIFFUSE_LAMBERT_WRAP,
 		DIFFUSE_OREN_NAYAR,
 		DIFFUSE_TOON,
+		DIFFUSE_MAX
 	};
 
 	enum SpecularMode {
@@ -235,6 +248,7 @@ public:
 		SPECULAR_PHONG,
 		SPECULAR_TOON,
 		SPECULAR_DISABLED,
+		SPECULAR_MAX
 	};
 
 	enum BillboardMode {
@@ -242,6 +256,7 @@ public:
 		BILLBOARD_ENABLED,
 		BILLBOARD_FIXED_Y,
 		BILLBOARD_PARTICLES,
+		BILLBOARD_MAX
 	};
 
 	enum TextureChannel {
@@ -249,12 +264,14 @@ public:
 		TEXTURE_CHANNEL_GREEN,
 		TEXTURE_CHANNEL_BLUE,
 		TEXTURE_CHANNEL_ALPHA,
-		TEXTURE_CHANNEL_GRAYSCALE
+		TEXTURE_CHANNEL_GRAYSCALE,
+		TEXTURE_CHANNEL_MAX
 	};
 
 	enum EmissionOperator {
 		EMISSION_OP_ADD,
-		EMISSION_OP_MULTIPLY
+		EMISSION_OP_MULTIPLY,
+		EMISSION_OP_MAX
 	};
 
 	enum DistanceFadeMode {
@@ -262,43 +279,47 @@ public:
 		DISTANCE_FADE_PIXEL_ALPHA,
 		DISTANCE_FADE_PIXEL_DITHER,
 		DISTANCE_FADE_OBJECT_DITHER,
+		DISTANCE_FADE_MAX
 	};
 
 private:
-	union MaterialKey {
-		struct {
-			uint64_t feature_mask : FEATURE_MAX;
-			uint64_t detail_uv : 1;
-			uint64_t blend_mode : 2;
-			uint64_t depth_draw_mode : 2;
-			uint64_t cull_mode : 2;
-			uint64_t flags : FLAG_MAX;
-			uint64_t detail_blend_mode : 2;
-			uint64_t diffuse_mode : 3;
-			uint64_t specular_mode : 3;
-			uint64_t invalid_key : 1;
-			uint64_t deep_parallax : 1;
-			uint64_t billboard_mode : 2;
-			uint64_t grow : 1;
-			uint64_t proximity_fade : 1;
-			uint64_t distance_fade : 2;
-			uint64_t emission_op : 1;
-			uint64_t texture_filter : 3;
-			uint64_t transparency : 2;
-			uint64_t shading_mode : 2;
-			uint64_t roughness_channel : 3;
-		};
+	struct MaterialKey {
+		// enum values
+		uint64_t texture_filter : get_num_bits(TEXTURE_FILTER_MAX - 1);
+		uint64_t detail_uv : get_num_bits(DETAIL_UV_MAX - 1);
+		uint64_t transparency : get_num_bits(TRANSPARENCY_MAX - 1);
+		uint64_t alpha_antialiasing_mode : get_num_bits(ALPHA_ANTIALIASING_MAX - 1);
+		uint64_t shading_mode : get_num_bits(SHADING_MODE_MAX - 1);
+		uint64_t blend_mode : get_num_bits(BLEND_MODE_MAX - 1);
+		uint64_t depth_draw_mode : get_num_bits(DEPTH_DRAW_MAX - 1);
+		uint64_t cull_mode : get_num_bits(CULL_MAX - 1);
+		uint64_t diffuse_mode : get_num_bits(DIFFUSE_MAX - 1);
+		uint64_t specular_mode : get_num_bits(SPECULAR_MAX - 1);
+		uint64_t billboard_mode : get_num_bits(BILLBOARD_MAX - 1);
+		uint64_t detail_blend_mode : get_num_bits(BLEND_MODE_MAX - 1);
+		uint64_t roughness_channel : get_num_bits(TEXTURE_CHANNEL_MAX - 1);
+		uint64_t emission_op : get_num_bits(EMISSION_OP_MAX - 1);
+		uint64_t distance_fade : get_num_bits(DISTANCE_FADE_MAX - 1);
 
-		struct {
-			uint64_t key0;
-			uint64_t key1;
-		};
+		// flag bitfield
+		uint64_t feature_mask : FEATURE_MAX - 1;
+		uint64_t flags : FLAG_MAX - 1;
+
+		// booleans
+		uint64_t deep_parallax : 1;
+		uint64_t grow : 1;
+		uint64_t proximity_fade : 1;
+
+		MaterialKey() {
+			memset(this, 0, sizeof(MaterialKey));
+		}
 
 		bool operator==(const MaterialKey &p_key) const {
-			return (key0 == p_key.key0) && (key1 == p_key.key1);
+			return memcmp(this, &p_key, sizeof(MaterialKey)) == 0;
 		}
+
 		bool operator<(const MaterialKey &p_key) const {
-			return (key0 == p_key.key0) ? (key1 < p_key.key1) : (key0 < p_key.key0);
+			return memcmp(this, &p_key, sizeof(MaterialKey)) < 0;
 		}
 	};
 
@@ -313,13 +334,7 @@ private:
 
 	_FORCE_INLINE_ MaterialKey _compute_key() const {
 		MaterialKey mk;
-		mk.key0 = 0;
-		mk.key1 = 0;
-		for (int i = 0; i < FEATURE_MAX; i++) {
-			if (features[i]) {
-				mk.feature_mask |= ((uint64_t)1 << i);
-			}
-		}
+
 		mk.detail_uv = detail_uv;
 		mk.blend_mode = blend_mode;
 		mk.depth_draw_mode = depth_draw_mode;
@@ -328,20 +343,28 @@ private:
 		mk.transparency = transparency;
 		mk.shading_mode = shading_mode;
 		mk.roughness_channel = roughness_texture_channel;
+		mk.detail_blend_mode = detail_blend_mode;
+		mk.diffuse_mode = diffuse_mode;
+		mk.specular_mode = specular_mode;
+		mk.billboard_mode = billboard_mode;
+		mk.deep_parallax = deep_parallax;
+		mk.grow = grow_enabled;
+		mk.proximity_fade = proximity_fade_enabled;
+		mk.distance_fade = distance_fade;
+		mk.emission_op = emission_op;
+		mk.alpha_antialiasing_mode = alpha_antialiasing_mode;
+
+		for (int i = 0; i < FEATURE_MAX; i++) {
+			if (features[i]) {
+				mk.feature_mask |= ((uint64_t)1 << i);
+			}
+		}
+
 		for (int i = 0; i < FLAG_MAX; i++) {
 			if (flags[i]) {
 				mk.flags |= ((uint64_t)1 << i);
 			}
 		}
-		mk.detail_blend_mode = detail_blend_mode;
-		mk.diffuse_mode = diffuse_mode;
-		mk.specular_mode = specular_mode;
-		mk.billboard_mode = billboard_mode;
-		mk.deep_parallax = deep_parallax ? 1 : 0;
-		mk.grow = grow_enabled;
-		mk.proximity_fade = proximity_fade_enabled;
-		mk.distance_fade = distance_fade;
-		mk.emission_op = emission_op;
 
 		return mk;
 	}
@@ -392,9 +415,14 @@ private:
 		StringName rim_texture_channel;
 		StringName heightmap_texture_channel;
 		StringName refraction_texture_channel;
-		StringName alpha_scissor_threshold;
 
 		StringName texture_names[TEXTURE_MAX];
+
+		StringName alpha_scissor_threshold;
+		StringName alpha_hash_scale;
+
+		StringName alpha_antialiasing_edge;
+		StringName albedo_texture_size;
 	};
 
 	static Mutex material_mutex;
@@ -433,6 +461,8 @@ private:
 	float refraction;
 	float point_size;
 	float alpha_scissor_threshold;
+	float alpha_hash_scale;
+	float alpha_antialiasing_edge;
 	bool grow_enabled;
 	float ao_light_affect;
 	float grow;
@@ -481,6 +511,8 @@ private:
 	TextureChannel roughness_texture_channel;
 	TextureChannel ao_texture_channel;
 	TextureChannel refraction_texture_channel;
+
+	AlphaAntiAliasing alpha_antialiasing_mode;
 
 	bool features[FEATURE_MAX];
 
@@ -584,6 +616,12 @@ public:
 	void set_transparency(Transparency p_transparency);
 	Transparency get_transparency() const;
 
+	void set_alpha_antialiasing(AlphaAntiAliasing p_alpha_aa);
+	AlphaAntiAliasing get_alpha_antialiasing() const;
+
+	void set_alpha_antialiasing_edge(float p_edge);
+	float get_alpha_antialiasing_edge() const;
+
 	void set_shading_mode(ShadingMode p_shading_mode);
 	ShadingMode get_shading_mode() const;
 
@@ -660,6 +698,9 @@ public:
 	void set_alpha_scissor_threshold(float p_threshold);
 	float get_alpha_scissor_threshold() const;
 
+	void set_alpha_hash_scale(float p_scale);
+	float get_alpha_hash_scale() const;
+
 	void set_on_top_of_alpha();
 
 	void set_proximity_fade(bool p_enable);
@@ -707,6 +748,7 @@ VARIANT_ENUM_CAST(BaseMaterial3D::TextureParam)
 VARIANT_ENUM_CAST(BaseMaterial3D::TextureFilter)
 VARIANT_ENUM_CAST(BaseMaterial3D::ShadingMode)
 VARIANT_ENUM_CAST(BaseMaterial3D::Transparency)
+VARIANT_ENUM_CAST(BaseMaterial3D::AlphaAntiAliasing)
 VARIANT_ENUM_CAST(BaseMaterial3D::DetailUV)
 VARIANT_ENUM_CAST(BaseMaterial3D::Feature)
 VARIANT_ENUM_CAST(BaseMaterial3D::BlendMode)

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.h
@@ -83,6 +83,7 @@ class RasterizerSceneHighEndRD : public RasterizerSceneRD {
 			BLEND_MODE_ADD,
 			BLEND_MODE_SUB,
 			BLEND_MODE_MUL,
+			BLEND_MODE_ALPHA_TO_COVERAGE
 		};
 
 		enum DepthDraw {
@@ -110,6 +111,12 @@ class RasterizerSceneHighEndRD : public RasterizerSceneRD {
 
 		};
 
+		enum AlphaAntiAliasing {
+			ALPHA_ANTIALIASING_OFF,
+			ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE,
+			ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE_AND_TO_ONE
+		};
+
 		bool valid;
 		RID version;
 		uint32_t vertex_input_mask;
@@ -132,6 +139,7 @@ class RasterizerSceneHighEndRD : public RasterizerSceneRD {
 		bool uses_point_size;
 		bool uses_alpha;
 		bool uses_blend_alpha;
+		bool uses_alpha_clip;
 		bool uses_depth_pre_pass;
 		bool uses_discard;
 		bool uses_roughness;

--- a/servers/rendering/rasterizer_rd/shaders/scene_high_end.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/scene_high_end.glsl
@@ -361,6 +361,65 @@ layout(location = 0) out vec4 frag_color;
 
 #endif // RENDER DEPTH
 
+#ifdef ALPHA_HASH_USED
+
+float hash_2d(vec2 p) {
+	return fract(1.0e4 * sin(17.0 * p.x + 0.1 * p.y) *
+				 (0.1 + abs(sin(13.0 * p.y + p.x))));
+}
+
+float hash_3d(vec3 p) {
+	return hash_2d(vec2(hash_2d(p.xy), p.z));
+}
+
+float compute_alpha_hash_threshold(vec3 pos, float hash_scale) {
+	vec3 dx = dFdx(pos);
+	vec3 dy = dFdx(pos);
+	float delta_max_sqr = max(length(dx), length(dy));
+	float pix_scale = 1.0 / (hash_scale * delta_max_sqr);
+
+	vec2 pix_scales =
+			vec2(exp2(floor(log2(pix_scale))), exp2(ceil(log2(pix_scale))));
+
+	vec2 a_thresh = vec2(hash_3d(floor(pix_scales.x * pos.xyz)),
+			hash_3d(floor(pix_scales.y * pos.xyz)));
+
+	float lerp_factor = fract(log2(pix_scale));
+
+	float a_interp = (1.0 - lerp_factor) * a_thresh.x + lerp_factor * a_thresh.y;
+
+	float min_lerp = min(lerp_factor, 1.0 - lerp_factor);
+
+	vec3 cases = vec3(a_interp * a_interp / (2.0 * min_lerp * (1.0 - min_lerp)),
+			(a_interp - 0.5 * min_lerp) / (1.0 - min_lerp),
+			1.0 - ((1.0 - a_interp) * (1.0 - a_interp) /
+						  (2.0 * min_lerp * (1.0 - min_lerp))));
+
+	float alpha_hash_threshold =
+			(lerp_factor < (1.0 - min_lerp)) ? ((lerp_factor < min_lerp) ? cases.x : cases.y) : cases.z;
+
+	return clamp(alpha_hash_threshold, 0.0, 1.0);
+}
+
+#endif // ALPHA_HASH_USED
+
+#ifdef ALPHA_ANTIALIASING_EDGE_USED
+
+float calc_mip_level(vec2 texture_coord) {
+	vec2 dx = dFdx(texture_coord);
+	vec2 dy = dFdy(texture_coord);
+	float delta_max_sqr = max(dot(dx, dx), dot(dy, dy));
+	return max(0.0, 0.5 * log2(delta_max_sqr));
+}
+
+float compute_alpha_antialiasing_edge(float input_alpha, vec2 texture_coord, float alpha_edge) {
+	input_alpha *= 1.0 + max(0, calc_mip_level(texture_coord)) * 0.25; // 0.25 mip scale, magic number
+	input_alpha = (input_alpha - alpha_edge) / max(fwidth(input_alpha), 0.0001) + 0.5;
+	return clamp(input_alpha, 0.0, 1.0);
+}
+
+#endif // ALPHA_ANTIALIASING_USED
+
 // This returns the G_GGX function divided by 2 cos_theta_m, where in practice cos_theta_m is either N.L or N.V.
 // We're dividing this factor off because the overall term we'll end up looks like
 // (see, for example, the first unnumbered equation in B. Burley, "Physically Based Shading at Disney", SIGGRAPH 2012):
@@ -1709,10 +1768,6 @@ void main() {
 
 	float alpha = 1.0;
 
-#if defined(ALPHA_SCISSOR_USED)
-	float alpha_scissor = 0.5;
-#endif
-
 #if defined(TANGENT_USED) || defined(NORMALMAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 	vec3 binormal = normalize(binormal_interp);
 	vec3 tangent = normalize(tangent_interp);
@@ -1749,6 +1804,19 @@ void main() {
 
 	float sss_strength = 0.0;
 
+#ifdef ALPHA_SCISSOR_USED
+	float alpha_scissor_threshold = 1.0;
+#endif // ALPHA_SCISSOR_USED
+
+#ifdef ALPHA_HASH_USED
+	float alpha_hash_scale = 1.0;
+#endif // ALPHA_HASH_USED
+
+#ifdef ALPHA_ANTIALIASING_EDGE_USED
+	float alpha_antialiasing_edge = 0.0;
+	vec2 alpha_texture_coordinate = vec2(0.0, 0.0);
+#endif // ALPHA_ANTIALIASING_EDGE_USED
+
 	{
 		/* clang-format off */
 
@@ -1757,7 +1825,7 @@ FRAGMENT_SHADER_CODE
 		/* clang-format on */
 	}
 
-#if defined(LIGHT_TRANSMITTANCE_USED)
+#ifdef LIGHT_TRANSMITTANCE_USED
 #ifdef SSS_MODE_SKIN
 	transmittance_color.a = sss_strength;
 #else
@@ -1765,25 +1833,43 @@ FRAGMENT_SHADER_CODE
 #endif
 #endif
 
-#if !defined(USE_SHADOW_TO_OPACITY)
+#ifndef USE_SHADOW_TO_OPACITY
 
-#if defined(ALPHA_SCISSOR_USED)
-	if (alpha < alpha_scissor) {
+#ifdef ALPHA_SCISSOR_USED
+	if (alpha < alpha_scissor_threshold) {
 		discard;
 	}
 #endif // ALPHA_SCISSOR_USED
 
-#ifdef USE_OPAQUE_PREPASS
+// alpha hash can be used in unison with alpha antialiasing
+#ifdef ALPHA_HASH_USED
+	if (alpha < compute_alpha_hash_threshold(vertex, alpha_hash_scale)) {
+		discard;
+	}
+#endif // ALPHA_HASH_USED
 
+// If we are not edge antialiasing, we need to remove the output alpha channel from scissor and hash
+#if (defined(ALPHA_SCISSOR_USED) || defined(ALPHA_HASH_USED)) && !defined(ALPHA_ANTIALIASING_EDGE_USED)
+	alpha = 1.0;
+#endif
+
+#ifdef ALPHA_ANTIALIASING_EDGE_USED
+// If alpha scissor is used, we must further the edge threshold, otherwise we wont get any edge feather
+#ifdef ALPHA_SCISSOR_USED
+	alpha_antialiasing_edge = clamp(alpha_scissor_threshold + alpha_antialiasing_edge, 0.0, 1.0);
+#endif
+	alpha = compute_alpha_antialiasing_edge(alpha, alpha_texture_coordinate, alpha_antialiasing_edge);
+#endif // ALPHA_ANTIALIASING_EDGE_USED
+
+#ifdef USE_OPAQUE_PREPASS
 	if (alpha < opaque_prepass_threshold) {
 		discard;
 	}
-
 #endif // USE_OPAQUE_PREPASS
 
 #endif // !USE_SHADOW_TO_OPACITY
 
-#if defined(NORMALMAP_USED)
+#ifdef NORMALMAP_USED
 
 	normalmap.xy = normalmap.xy * 2.0 - 1.0;
 	normalmap.z = sqrt(max(0.0, 1.0 - dot(normalmap.xy, normalmap.xy))); //always ignore Z, as it can be RG packed, Z may be pos/neg, etc.
@@ -1792,7 +1878,7 @@ FRAGMENT_SHADER_CODE
 
 #endif
 
-#if defined(LIGHT_ANISOTROPY_USED)
+#ifdef LIGHT_ANISOTROPY_USED
 
 	if (anisotropy > 0.01) {
 		//rotation matrix

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -134,6 +134,11 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["IRRADIANCE"] = ShaderLanguage::TYPE_VEC4;
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].can_discard = true;
 
+	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["ALPHA_SCISSOR_THRESHOLD"] = ShaderLanguage::TYPE_FLOAT;
+	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["ALPHA_HASH_SCALE"] = ShaderLanguage::TYPE_FLOAT;
+	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["ALPHA_ANTIALIASING_EDGE"] = ShaderLanguage::TYPE_FLOAT;
+	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["ALPHA_TEXTURE_COORDINATE"] = ShaderLanguage::TYPE_VEC2;
+
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["WORLD_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["INV_CAMERA_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["CAMERA_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
@@ -205,6 +210,9 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].modes.push_back("shadow_to_opacity");
 
 	shader_modes[RS::SHADER_SPATIAL].modes.push_back("vertex_lighting");
+
+	shader_modes[RS::SHADER_SPATIAL].modes.push_back("alpha_to_coverage");
+	shader_modes[RS::SHADER_SPATIAL].modes.push_back("alpha_to_coverage_and_one");
 
 	/************ CANVAS ITEM **************************/
 


### PR DESCRIPTION
This commit adds the following features to the Vulkan rendering pipeline:
Alpha Hash, AlphaToCoverage + AlphaToOne, and "mipped" antialiased edges.

These techniques are very helpful for creating nice looking Hair and Foliage, where alpha channels are used the most.

## Preview Video:
https://youtu.be/zQKkUNvAAJ4

## Alpha Hashing
Alpha Hashing is a dithered alpha testing method from NVIDIA that you can find more documentation for [here](https://developer.download.nvidia.com/assets/gameworks/downloads/regular/GDC17/RealTimeRenderingAdvances_HashedAlphaTesting_GDC2017_FINAL.pdf?pXO7jOEIrzP_kUqTc2Hwz88svU8woWuXonDBKl_PaMl48YZvczzsPGfgu3kvxE1gAri9d-f9IoR5mjgr8thwG7V1kTAPs49DdnmiGdxaEz5OrSyawbhCp5EdC0aq7uckAuGpSXM6eWnKAHrd7nmFnPMv8tZQqhU-dwEUUeRpoe_86TFQI1Re6jngDwW2NnMprcJMinDzn0NFI4Z5erF3MrnrH65AeQ)

## AlphaToCoverage and AlphaToOne
AlphaToCoverage is a technique that takes the fragment shaders alpha channel and AND's it with the MSAA SampleMask to produce additional areas for Anti-aliasing.

AlphaToOne is an additional flag in which after the alpha channel is used for the MSAA SampleMask, the alpha value is *set* to the maximum alpha value.

It is the combination of these two techniques that allow for good-looking anti-aliased alpha testing.

### But why both? Why is AlphaToCoverage by itself not enough?
In the preview video above, you may notice that when switching from "Alpha Edge Blend" to "Alpha Edge Clip" *(the respective names in the UI for AlphaToCoverage and AlphaToCoverage + AlphaToOne)* that using AlphaToCoverage by itself still results is some bleed/halo effects around the textures. This is because AlphaToCoverage alone does not clamp the alpha value; that is - the resulting alpha of the fragment shader still has to be *blended* somehow. And in general this is an issue we have with alpha blending. All AlphaToCoverage does by itself is export the Alpha channel as an area for MSAA to act upon.

This is where AlphaToOne comes in - after adding the apha to the MSAA SampleMask, the alpha value is set to the maximum - so no *blending* occurs anymore.

The final result is fragment color output with no alpha channel, yet MSAA smooths the areas where the alpha channel *was*.

## Alpha Edge Sharpening
This [blog post](https://medium.com/@bgolus/anti-aliased-alpha-test-the-esoteric-alpha-to-coverage-8b177335ae4f) by Ben Golus goes through some techniques for sharpening the Anti-aliasing edge with some mipmapping techniques.

This technique has been implemented as a function called `compute_alpha_antialiasing_edge` in `scene_hight_end.glsl` and usage will be explained below.

The Material3D system uses this by default when AlphaAntialiasing is enabled.

## Render Flags and Usage
### AlphaToCoverage, AlphaToCoverage + AlphaToOne
In the spatial shader, the render flags `alpha_to_coverage` OR `alpha_to_coverage_and_one` can be added to process the result of the shaders `ALPHA` with either AlphaToCoverage, or AlphaToCoverage + AlphaToOne.

When either of these are set, the blend_mode is overridden to BLEND_MODE_ALPHA_TO_COVERAGE, which is better suited for blending.

### Alpha Scissor
* If `ALPHA_SCISSOR_THRESHOLD` *float, [0,1]* is set in the shader, then alpha values less than the threshold will be discarded.

### Alpha Hash
* If `ALPHA_HASH_SCALE` *float, recommended (0,2]* is set in the shader, alpha hashing will be used and alpha values less than the hash are discarded. Alpha Hash Scale simply affects the dithering affect of the alpha hash

### Alpha Edge (Needs Texture)
Alpha Edge requires two variables:
* `ALPHA_ANTIALIASING_EDGE` *float [0,1]* - Affects the edge point of the Edge sharpening. If `ALPHA_SCISSOR_THRESHOLD` is set, it is *added* to `ALPHA_ANTIALIASING_EDGE` and clamped from [0,1].
* `ALPHA_TEXTURE_COORDINATE` *vec2* - The texture coordinate to use. Think `uv_coordinate * alpha_texture_size`.

Please feel free to ask question and test it out!
I am looking forward to your feedback.

Thanks,
Marios S.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/1273.*