### PR TITLE
Globally install Python libraries in GitHub Actions

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -12,7 +12,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq dos2unix recode clang-format
-          pip3 install --user black pygments
+          sudo pip3 install black pygments
 
       - name: File formatting checks (file_format.sh)
         run: |


### PR DESCRIPTION
Apparently GitHub doesn't already have `~/.local/bin` set up properly, so we need to do this manually ¯\\\_(ツ)\_/¯

This warning is produced with the current master (as of #40335), and calling `black` silently fails.

```
WARNING: The scripts black and blackd are installed in '/home/runner/.local/bin' which is not on PATH.
Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
```