### PR TITLE
SCons: Do not enable werror=yes by default

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -72,7 +72,6 @@ env_base.disabled_modules = []
 env_base.use_ptrcall = False
 env_base.module_version_string = ""
 env_base.msvc = False
-env_base.stable_release = version.status == "stable"
 
 env_base.__class__.disable_module = methods.disable_module
 
@@ -129,7 +128,7 @@ opts.Add("custom_modules", "A list of comma-separated directory paths containing
 opts.Add(BoolVariable("verbose", "Enable verbose output for the compilation", False))
 opts.Add(BoolVariable("progress", "Show a progress indicator during compilation", True))
 opts.Add(EnumVariable("warnings", "Level of compilation warnings", "all", ("extra", "all", "moderate", "no")))
-opts.Add(BoolVariable("werror", "Treat compiler warnings as errors", not env_base.stable_release))
+opts.Add(BoolVariable("werror", "Treat compiler warnings as errors", False))
 opts.Add(BoolVariable("dev", "If yes, alias for verbose=yes warnings=extra werror=yes", False))
 opts.Add("extra_suffix", "Custom extra suffix added to the base filename of all generated binary files", "")
 opts.Add(BoolVariable("vsproj", "Generate a Visual Studio solution", False))


### PR DESCRIPTION
There are too many users who compile Godot from source and are not familiar
with the buildsystem or C/C++ compilation warnings, and thus report any kind
of yet-unfixed warning as a (often duplicate) bug.

Compiler warnings change at every compiler version and are different for each
compiler, so it's difficult to ensure that the codebase would always be 100%
warning-free, especially in the future.

I already disabled it for stable releases in #37958, but having it on non
stable commits could also become an annoyance in the future when trying to
bisect issues with a new compiler version which emits warnings unknown at
the time of commit.

TL;DR: Contributors, use `dev=yes` or `werror=yes`. CI does and won't let you
create new warnings ;)