### PR TITLE
PO loader: Fix unclosed files and error messages

### DIFF
--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -35,7 +35,6 @@
 
 RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 	enum Status {
-
 		STATUS_NONE,
 		STATUS_READING_ID,
 		STATUS_READING_STRING,
@@ -56,6 +55,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 	bool skip_this = false;
 	bool skip_next = false;
 	bool is_eof = false;
+	const String path = f->get_path();
 
 	while (!is_eof) {
 		String l = f->get_line().strip_edges();
@@ -65,7 +65,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 		if (is_eof && l.empty()) {
 			if (status == STATUS_READING_ID) {
 				memdelete(f);
-				ERR_FAIL_V_MSG(RES(), f->get_path() + ":" + itos(line) + " Unexpected EOF while reading 'msgid' at file: ");
+				ERR_FAIL_V_MSG(RES(), "Unexpected EOF while reading 'msgid' at: " + path + ":" + itos(line));
 			} else {
 				break;
 			}
@@ -74,7 +74,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 		if (l.begins_with("msgid")) {
 			if (status == STATUS_READING_ID) {
 				memdelete(f);
-				ERR_FAIL_V_MSG(RES(), f->get_path() + ":" + itos(line) + " Unexpected 'msgid', was expecting 'msgstr' while parsing: ");
+				ERR_FAIL_V_MSG(RES(), "Unexpected 'msgid', was expecting 'msgstr' while parsing: " + path + ":" + itos(line));
 			}
 
 			if (msg_id != "") {
@@ -96,7 +96,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 		if (l.begins_with("msgstr")) {
 			if (status != STATUS_READING_ID) {
 				memdelete(f);
-				ERR_FAIL_V_MSG(RES(), f->get_path() + ":" + itos(line) + " Unexpected 'msgstr', was expecting 'msgid' while parsing: ");
+				ERR_FAIL_V_MSG(RES(), "Unexpected 'msgstr', was expecting 'msgid' while parsing: " + path + ":" + itos(line));
 			}
 
 			l = l.substr(6, l.length()).strip_edges();
@@ -111,7 +111,10 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 			continue; //nothing to read or comment
 		}
 
-		ERR_FAIL_COND_V_MSG(!l.begins_with("\"") || status == STATUS_NONE, RES(), f->get_path() + ":" + itos(line) + " Invalid line '" + l + "' while parsing: ");
+		if (!l.begins_with("\"") || status == STATUS_NONE) {
+			memdelete(f);
+			ERR_FAIL_V_MSG(RES(), "Invalid line '" + l + "' while parsing: " + path + ":" + itos(line));
+		}
 
 		l = l.substr(1, l.length());
 		// Find final quote, ignoring escaped ones (\").
@@ -133,7 +136,10 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 			escape_next = false;
 		}
 
-		ERR_FAIL_COND_V_MSG(end_pos == -1, RES(), f->get_path() + ":" + itos(line) + ": Expected '\"' at end of message while parsing file.");
+		if (end_pos == -1) {
+			memdelete(f);
+			ERR_FAIL_V_MSG(RES(), "Expected '\"' at end of message while parsing: " + path + ":" + itos(line));
+		}
 
 		l = l.substr(0, end_pos);
 		l = l.c_unescape();
@@ -147,7 +153,6 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 		line++;
 	}
 
-	f->close();
 	memdelete(f);
 
 	if (status == STATUS_READING_STRING) {
@@ -160,7 +165,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 		}
 	}
 
-	ERR_FAIL_COND_V_MSG(config == "", RES(), "No config found in file: " + f->get_path() + ".");
+	ERR_FAIL_COND_V_MSG(config == "", RES(), "No config found in file: " + path + ".");
 
 	Vector<String> configs = config.split("\n");
 	for (int i = 0; i < configs.size(); i++) {
@@ -197,7 +202,6 @@ RES TranslationLoaderPO::load(const String &p_path, const String &p_original_pat
 
 void TranslationLoaderPO::get_recognized_extensions(List<String> *p_extensions) const {
 	p_extensions->push_back("po");
-	//p_extensions->push_back("mo"); //mo in the future...
 }
 
 bool TranslationLoaderPO::handles_type(const String &p_type) const {


### PR DESCRIPTION
Trying to get `f->get_path()` after deleting `f` was not super clever :)

Fixes #40324.