### PR TITLE
Properly pass safe margin on initialization.

### DIFF
--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1241,12 +1241,12 @@ void KinematicBody3D::_direct_state_changed(Object *p_state) {
 
 KinematicBody3D::KinematicBody3D() :
 		PhysicsBody3D(PhysicsServer3D::BODY_MODE_KINEMATIC) {
-	margin = 0.001;
 	locked_axis = 0;
 	on_floor = false;
 	on_ceiling = false;
 	on_wall = false;
 
+	set_safe_margin(0.001);
 	PhysicsServer3D::get_singleton()->body_set_force_integration_callback(get_rid(), this, "_direct_state_changed");
 }
 

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -750,7 +750,7 @@ Body3DSW::Body3DSW() :
 	active = true;
 
 	mass = 1;
-	kinematic_safe_margin = 0.01;
+	kinematic_safe_margin = 0.001;
 	//_inv_inertia=Transform();
 	_inv_mass = 1;
 	bounce = 0;


### PR DESCRIPTION
Fixes jitter.

This bug was introduced by #12713 but it was masked for a long time until f2e5405 exposed it.