### PR TITLE
Android: fix display server always alerting no Vulkan support

### DIFF
--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -448,6 +448,8 @@ DisplayServerAndroid::DisplayServerAndroid(const String &p_rendering_driver, Dis
 #endif
 
 	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
+
+	r_error = OK;
 }
 
 DisplayServerAndroid::~DisplayServerAndroid() {


### PR DESCRIPTION
Fixed android always alerting no support vulkan by copping `r_error = OK;` from windows display server 