### PR TITLE
 Fix some incorrect conversions which lead to crash in shaders

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -1137,13 +1137,13 @@ bool ShaderLanguage::_validate_operator(OperatorNode *p_op, DataType *r_ret_type
 			} else if (na == TYPE_FLOAT && nb == TYPE_VEC4) {
 				valid = true;
 				ret_type = TYPE_VEC4;
-			} else if (p_op->op == OP_MUL && na == TYPE_FLOAT && nb == TYPE_MAT2) {
+			} else if (na == TYPE_FLOAT && nb == TYPE_MAT2) {
 				valid = true;
 				ret_type = TYPE_MAT2;
-			} else if (p_op->op == OP_MUL && na == TYPE_FLOAT && nb == TYPE_MAT3) {
+			} else if (na == TYPE_FLOAT && nb == TYPE_MAT3) {
 				valid = true;
 				ret_type = TYPE_MAT3;
-			} else if (p_op->op == OP_MUL && na == TYPE_FLOAT && nb == TYPE_MAT4) {
+			} else if (na == TYPE_FLOAT && nb == TYPE_MAT4) {
 				valid = true;
 				ret_type = TYPE_MAT4;
 			} else if (p_op->op == OP_MUL && na == TYPE_VEC2 && nb == TYPE_MAT2) {
@@ -1313,13 +1313,13 @@ bool ShaderLanguage::_validate_operator(OperatorNode *p_op, DataType *r_ret_type
 			} else if (na == TYPE_VEC4 && nb == TYPE_FLOAT) {
 				valid = true;
 				ret_type = TYPE_VEC4;
-			} else if (p_op->op == OP_ASSIGN_MUL && na == TYPE_MAT2 && nb == TYPE_VEC2) {
+			} else if (na == TYPE_MAT2 && nb == TYPE_FLOAT) {
 				valid = true;
 				ret_type = TYPE_MAT2;
-			} else if (p_op->op == OP_ASSIGN_MUL && na == TYPE_MAT3 && nb == TYPE_VEC3) {
+			} else if (na == TYPE_MAT3 && nb == TYPE_FLOAT) {
 				valid = true;
 				ret_type = TYPE_MAT3;
-			} else if (p_op->op == OP_ASSIGN_MUL && na == TYPE_MAT4 && nb == TYPE_VEC4) {
+			} else if (na == TYPE_MAT4 && nb == TYPE_FLOAT) {
 				valid = true;
 				ret_type = TYPE_MAT4;
 			} else if (p_op->op == OP_ASSIGN_MUL && na == TYPE_VEC2 && nb == TYPE_MAT2) {


### PR DESCRIPTION
Allows expressions like: mat += 1.0 or mat = mat - 1.0 since there are valid expressions in GLSL and Fix #40344