### PR TITLE
Allow to move timeline without moving animation

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1657,7 +1657,7 @@ void AnimationTimelineEdit::_gui_input(const Ref<InputEvent> &p_event) {
 			int x = mb->get_position().x - get_name_limit();
 
 			float ofs = x / get_zoom_scale() + get_value();
-			emit_signal("timeline_changed", ofs, false);
+			emit_signal("timeline_changed", ofs, false, Input::get_singleton()->is_key_pressed(KEY_ALT));
 			dragging_timeline = true;
 		}
 		if (!dragging_timeline && mb->get_button_index() == BUTTON_MIDDLE) {
@@ -1696,7 +1696,7 @@ void AnimationTimelineEdit::_gui_input(const Ref<InputEvent> &p_event) {
 		if (dragging_timeline) {
 			int x = mm->get_position().x - get_name_limit();
 			float ofs = x / get_zoom_scale() + get_value();
-			emit_signal("timeline_changed", ofs, false);
+			emit_signal("timeline_changed", ofs, false, Input::get_singleton()->is_key_pressed(KEY_ALT));
 		}
 		if (panning_timeline) {
 			int x = mm->get_position().x - get_name_limit();
@@ -3250,8 +3250,8 @@ void AnimationTrackEditor::_name_limit_changed() {
 	}
 }
 
-void AnimationTrackEditor::_timeline_changed(float p_new_pos, bool p_drag) {
-	emit_signal("timeline_changed", p_new_pos, p_drag);
+void AnimationTrackEditor::_timeline_changed(float p_new_pos, bool p_drag, bool p_timeline_only) {
+	emit_signal("timeline_changed", p_new_pos, p_drag, p_timeline_only);
 }
 
 void AnimationTrackEditor::_track_remove_request(int p_track) {

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -328,7 +328,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _update_tracks();
 
 	void _name_limit_changed();
-	void _timeline_changed(float p_new_pos, bool p_drag);
+	void _timeline_changed(float p_new_pos, bool p_drag, bool p_timeline_only = false);
 	void _track_remove_request(int p_track);
 	void _track_grab_focus(int p_track);
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -994,7 +994,7 @@ void AnimationPlayerEditor::_animation_duplicate() {
 	}
 }
 
-void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set) {
+void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set, bool p_timeline_only) {
 	if (updating || !player || player->is_playing()) {
 		return;
 	};
@@ -1015,18 +1015,18 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set) {
 		pos = Math::snapped(pos, _get_editor_step());
 	}
 
-	if (player->is_valid() && !p_set) {
-		float cpos = player->get_current_animation_position();
+	if (!p_timeline_only) {
+		if (player->is_valid() && !p_set) {
+			float cpos = player->get_current_animation_position();
 
-		player->seek_delta(pos, pos - cpos);
-	} else {
-		player->stop(true);
-		player->seek(pos, true);
+			player->seek_delta(pos, pos - cpos);
+		} else {
+			player->stop(true);
+			player->seek(pos, true);
+		}
 	}
 
 	track_editor->set_anim_pos(pos);
-
-	updating = true;
 };
 
 void AnimationPlayerEditor::_animation_player_changed(Object *p_pl) {
@@ -1048,7 +1048,7 @@ void AnimationPlayerEditor::_animation_key_editor_anim_len_changed(float p_len) 
 	frame->set_max(p_len);
 }
 
-void AnimationPlayerEditor::_animation_key_editor_seek(float p_pos, bool p_drag) {
+void AnimationPlayerEditor::_animation_key_editor_seek(float p_pos, bool p_drag, bool p_timeline_only) {
 	timeline_position = p_pos;
 
 	if (!is_visible_in_tree()) {
@@ -1070,7 +1070,7 @@ void AnimationPlayerEditor::_animation_key_editor_seek(float p_pos, bool p_drag)
 	updating = true;
 	frame->set_value(Math::snapped(p_pos, _get_editor_step()));
 	updating = false;
-	_seek_value_changed(p_pos, !p_drag);
+	_seek_value_changed(p_pos, !p_drag, p_timeline_only);
 }
 
 void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
@@ -1691,7 +1691,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	animation->connect("item_selected", callable_mp(this, &AnimationPlayerEditor::_animation_selected));
 
 	file->connect("file_selected", callable_mp(this, &AnimationPlayerEditor::_dialog_action));
-	frame->connect("value_changed", callable_mp(this, &AnimationPlayerEditor::_seek_value_changed), make_binds(true));
+	frame->connect("value_changed", callable_mp(this, &AnimationPlayerEditor::_seek_value_changed), make_binds(true, false));
 	scale->connect("text_entered", callable_mp(this, &AnimationPlayerEditor::_scale_changed));
 
 	renaming = false;

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -187,7 +187,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _scale_changed(const String &p_scale);
 	void _dialog_action(String p_file);
 	void _seek_frame_changed(const String &p_frame);
-	void _seek_value_changed(float p_value, bool p_set = false);
+	void _seek_value_changed(float p_value, bool p_set = false, bool p_timeline_only = false);
 	void _blend_editor_next_changed(const int p_idx);
 
 	void _list_changed();
@@ -197,7 +197,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 
 	void _animation_player_changed(Object *p_pl);
 
-	void _animation_key_editor_seek(float p_pos, bool p_drag);
+	void _animation_key_editor_seek(float p_pos, bool p_drag, bool p_timeline_only = false);
 	void _animation_key_editor_anim_len_changed(float p_len);
 
 	void _unhandled_key_input(const Ref<InputEvent> &p_ev);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/694

Hold Alt to move timeline cursor without seeking the animation. The use case is described in the proposal.

Playing animation will play it from the actual animation position, not timeline position. Changing this would require additional code, but I could do this if desired.

The removed `updating = true;` change is because it's done further up anyways.