### PR TITLE
Document missing character behavior when drawing text with fonts

### DIFF
--- a/doc/classes/DynamicFont.xml
+++ b/doc/classes/DynamicFont.xml
@@ -4,7 +4,7 @@
 		DynamicFont renders vector font files at runtime.
 	</brief_description>
 	<description>
-		DynamicFont renders vector font files (such as TTF or OTF) dynamically at runtime instead of using a prerendered texture atlas like [BitmapFont]. This trades the faster loading time of [BitmapFont]s for the ability to change font parameters like size and spacing during runtime. [DynamicFontData] is used for referencing the font file paths. DynamicFont also supports defining one or more fallbacks fonts, which will be used when displaying a character not supported by the main font.
+		DynamicFont renders vector font files (such as TTF or OTF) dynamically at runtime instead of using a prerendered texture atlas like [BitmapFont]. This trades the faster loading time of [BitmapFont]s for the ability to change font parameters like size and spacing during runtime. [DynamicFontData] is used for referencing the font file paths. DynamicFont also supports defining one or more fallback fonts, which will be used when displaying a character not supported by the main font.
 		DynamicFont uses the [url=https://www.freetype.org/]FreeType[/url] library for rasterization.
 		[codeblock]
 		var dynamic_font = DynamicFont.new()

--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -5,6 +5,8 @@
 	</brief_description>
 	<description>
 		Font contains a Unicode-compatible character set, as well as the ability to draw it with variable width, ascent, descent and kerning. For creating fonts from TTF files (or other font formats), see the editor support for fonts.
+		[b]Note:[/b] If a DynamicFont doesn't contain a character used in a string, the character in question will be replaced with codepoint [code]0xfffd[/code] if it's available in the DynamicFont. If this replacement character isn't available in the DynamicFont, the character will be hidden without displaying any replacement character in the string.
+		[b]Note:[/b] If a BitmapFont doesn't contain a character used in a string, the character in question will be hidden without displaying any replacement character in the string.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Note that there's a [proposal](https://github.com/godotengine/godot-proposals/issues/591) about changing this behavior (which I think is better), but I don't know how difficult it is to implement.

See #40405.