### PR TITLE
Document which escape sequences are supported by `String.c_unescape()`

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -325,7 +325,8 @@
 			<return type="String">
 			</return>
 			<description>
-				Returns a copy of the string with escaped characters replaced by their meanings according to the C language standard.
+				Returns a copy of the string with escaped characters replaced by their meanings. Supported escape sequences are [code]\'[/code], [code]\"[/code], [code]\?[/code], [code]\\[/code], [code]\a[/code], [code]\b[/code], [code]\f[/code], [code]\n[/code], [code]\r[/code], [code]\t[/code], [code]\v[/code].
+				[b]Note:[/b] Unlike the GDScript parser, this method doesn't support the [code]\uXXXX[/code] escape sequence.
 			</description>
 		</method>
 		<method name="capitalize">
@@ -413,7 +414,6 @@
 			</argument>
 			<description>
 				Returns the index of the [b]first[/b] case-sensitive occurrence of the specified string in this instance, or [code]-1[/code]. Optionally, the starting search index can be specified, continuing to the end of the string.
-				
 				[b]Note:[/b] If you just want to know whether a string contains a substring, use the [code]in[/code] operator as follows:
 				[codeblock]
 				# Will evaluate to `false`.


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/38716.

It's probably worth supporting `\uXXXX` in `String.c_unescape()` in the future, but documenting it is better than nothing.