### PR TITLE
Clarify how to convert PrimitiveMesh to ArrayMesh.

### DIFF
--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -13,7 +13,12 @@
 			<return type="Array">
 			</return>
 			<description>
-				Returns mesh arrays used to constitute surface of [Mesh]. Mesh arrays can be used with [ArrayMesh] to create new surfaces.
+				Returns mesh arrays used to constitute surface of [Mesh]. The result can be passed to [method ArrayMesh.add_surface_from_arrays] to create a new surface. For example:
+				[codeblock]
+				var c := CylinderMesh.new()
+				var arr_mesh := ArrayMesh.new()
+				arr_mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, c.get_mesh_arrays())
+				[/codeblock]
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
It took me a bit to figure this out, as I was initially doing something
more complicated like this before I realized I just had to pass
`get_mesh_arrays` directly to `add_surface_from_arrays`.

```
var arr_mesh = ArrayMesh.new()
var arrays = []
arrays.resize(ArrayMesh.ARRAY_MAX)
arrays[ArrayMesh.ARRAY_VERTEX] = c.get_mesh_arrays()
arr_mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
```