### PR TITLE
[WIP, macOS] Move NSApplication(Delegate) to OS to fix file associations.

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -102,14 +102,14 @@ protected:
 	virtual void finalize() = 0;
 	virtual void finalize_core() = 0;
 
-	virtual void set_cmdline(const char *p_execpath, const List<String> &p_args);
-
 	virtual bool _check_internal_feature_support(const String &p_feature) = 0;
 
 public:
 	typedef int64_t ProcessID;
 
 	static OS *get_singleton();
+
+	virtual void set_cmdline(const char *p_execpath, const List<String> &p_args);
 
 	void print_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, Logger::ErrorType p_type = Logger::ERR_ERROR);
 	void print(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_2_3;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -423,7 +423,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	MAIN_PRINT("Main: Parse CMDLine");
 
 	/* argument parsing and main creation */
-	List<String> args;
+	List<String> args = OS::get_singleton()->get_cmdline_args(); // Add macOS openFiles to the args.
 	List<String> main_args;
 
 	for (int i = 0; i < argc; i++) {

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -68,6 +68,7 @@ public:
 	RenderingDeviceVulkan *rendering_device_vulkan;
 #endif
 
+	void _menu_callback(id p_sender) const;
 	const NSMenu *_get_menu_root(const String &p_menu_root) const;
 	NSMenu *_get_menu_root(const String &p_menu_root);
 
@@ -160,7 +161,6 @@ public:
 
 	String rendering_driver;
 
-	id delegate;
 	id autoreleasePool;
 	CGEventSourceRef eventSource;
 

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -103,46 +103,6 @@ static NSCursor *_cursorFromSelector(SEL selector, SEL fallback = nil) {
 }
 
 /*************************************************************************/
-/* GodotApplication                                                      */
-/*************************************************************************/
-
-@interface GodotApplication : NSApplication
-@end
-
-@implementation GodotApplication
-
-- (void)sendEvent:(NSEvent *)event {
-	// special case handling of command-period, which is traditionally a special
-	// shortcut in macOS and doesn't arrive at our regular keyDown handler.
-	if ([event type] == NSEventTypeKeyDown) {
-		if (([event modifierFlags] & NSEventModifierFlagCommand) && [event keyCode] == 0x2f) {
-			Ref<InputEventKey> k;
-			k.instance();
-
-			_get_key_modifier_state([event modifierFlags], k);
-			k->set_window_id(DisplayServerOSX::INVALID_WINDOW_ID);
-			k->set_pressed(true);
-			k->set_keycode(KEY_PERIOD);
-			k->set_physical_keycode(KEY_PERIOD);
-			k->set_echo([event isARepeat]);
-
-			Input::get_singleton()->accumulate_input_event(k);
-		}
-	}
-
-	// From http://cocoadev.com/index.pl?GameKeyboardHandlingAlmost
-	// This works around an AppKit bug, where key up events while holding
-	// down the command key don't get sent to the key window.
-	if ([event type] == NSEventTypeKeyUp && ([event modifierFlags] & NSEventModifierFlagCommand)) {
-		[[self keyWindow] sendEvent:event];
-	} else {
-		[super sendEvent:event];
-	}
-}
-
-@end
-
-/*************************************************************************/
 /* GlobalMenuItem                                                       */
 /*************************************************************************/
 
@@ -156,123 +116,6 @@ static NSCursor *_cursorFromSelector(SEL selector, SEL fallback = nil) {
 @end
 
 @implementation GlobalMenuItem
-@end
-
-/*************************************************************************/
-/* GodotApplicationDelegate                                              */
-/*************************************************************************/
-
-@interface GodotApplicationDelegate : NSObject
-- (void)forceUnbundledWindowActivationHackStep1;
-- (void)forceUnbundledWindowActivationHackStep2;
-- (void)forceUnbundledWindowActivationHackStep3;
-@end
-
-@implementation GodotApplicationDelegate
-
-- (void)forceUnbundledWindowActivationHackStep1 {
-	// Step1: Switch focus to macOS Dock.
-	// Required to perform step 2, TransformProcessType will fail if app is already the in focus.
-	for (NSRunningApplication *app in [NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.apple.dock"]) {
-		[app activateWithOptions:NSApplicationActivateIgnoringOtherApps];
-		break;
-	}
-	[self performSelector:@selector(forceUnbundledWindowActivationHackStep2) withObject:nil afterDelay:0.02];
-}
-
-- (void)forceUnbundledWindowActivationHackStep2 {
-	// Step 2: Register app as foreground process.
-	ProcessSerialNumber psn = { 0, kCurrentProcess };
-	(void)TransformProcessType(&psn, kProcessTransformToForegroundApplication);
-	[self performSelector:@selector(forceUnbundledWindowActivationHackStep3) withObject:nil afterDelay:0.02];
-}
-
-- (void)forceUnbundledWindowActivationHackStep3 {
-	// Step 3: Switch focus back to app window.
-	[[NSRunningApplication currentApplication] activateWithOptions:NSApplicationActivateIgnoringOtherApps];
-}
-
-- (void)applicationDidFinishLaunching:(NSNotification *)notice {
-	NSString *nsappname = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
-	if (nsappname == nil) {
-		// If executable is not a bundled, macOS WindowServer won't register and activate app window correctly (menu and title bar are grayed out and input ignored).
-		[self performSelector:@selector(forceUnbundledWindowActivationHackStep1) withObject:nil afterDelay:0.02];
-	}
-}
-
-- (void)applicationDidResignActive:(NSNotification *)notification {
-	if (OS_OSX::get_singleton()->get_main_loop()) {
-		OS_OSX::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
-	}
-}
-
-- (void)applicationDidBecomeActive:(NSNotification *)notification {
-	if (OS_OSX::get_singleton()->get_main_loop()) {
-		OS_OSX::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
-	}
-}
-
-- (void)globalMenuCallback:(id)sender {
-	if (![sender representedObject]) {
-		return;
-	}
-
-	GlobalMenuItem *value = [sender representedObject];
-
-	if (value) {
-		if (value->checkable) {
-			if ([sender state] == NSControlStateValueOff) {
-				[sender setState:NSControlStateValueOn];
-			} else {
-				[sender setState:NSControlStateValueOff];
-			}
-		}
-
-		if (value->callback != Callable()) {
-			Variant tag = value->meta;
-			Variant *tagp = &tag;
-			Variant ret;
-			Callable::CallError ce;
-			value->callback.call((const Variant **)&tagp, 1, ret, ce);
-		}
-	}
-}
-
-- (NSMenu *)applicationDockMenu:(NSApplication *)sender {
-	return DS_OSX->dock_menu;
-}
-
-- (BOOL)application:(NSApplication *)sender openFile:(NSString *)filename {
-	// Note: may be called called before main loop init!
-	char *utfs = strdup([filename UTF8String]);
-	((OS_OSX *)(OS_OSX::get_singleton()))->open_with_filename.parse_utf8(utfs);
-	free(utfs);
-
-#ifdef TOOLS_ENABLED
-	// Open new instance
-	if (OS_OSX::get_singleton()->get_main_loop()) {
-		List<String> args;
-		args.push_back(((OS_OSX *)(OS_OSX::get_singleton()))->open_with_filename);
-		String exec = OS::get_singleton()->get_executable_path();
-
-		OS::ProcessID pid = 0;
-		OS::get_singleton()->execute(exec, args, false, &pid);
-	}
-#endif
-	return YES;
-}
-
-- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender {
-	DS_OSX->_send_window_event(DS_OSX->windows[DisplayServerOSX::MAIN_WINDOW_ID], DisplayServerOSX::WINDOW_EVENT_CLOSE_REQUEST);
-	return NSTerminateCancel;
-}
-
-- (void)showAbout:(id)sender {
-	if (OS_OSX::get_singleton()->get_main_loop()) {
-		OS_OSX::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_WM_ABOUT);
-	}
-}
-
 @end
 
 /*************************************************************************/
@@ -1634,6 +1477,28 @@ NSMenu *DisplayServerOSX::_get_menu_root(const String &p_menu_root) {
 		return NULL;
 	}
 	return menu;
+}
+
+void DisplayServerOSX::_menu_callback(id p_sender) const {
+	GlobalMenuItem *value = [p_sender representedObject];
+
+	if (value) {
+		if (value->checkable) {
+			if ([p_sender state] == NSControlStateValueOff) {
+				[p_sender setState:NSControlStateValueOn];
+			} else {
+				[p_sender setState:NSControlStateValueOff];
+			}
+		}
+
+		if (value->callback != Callable()) {
+			Variant tag = value->meta;
+			Variant *tagp = &tag;
+			Variant ret;
+			Callable::CallError ce;
+			value->callback.call((const Variant **)&tagp, 1, ret, ce);
+		}
+	}
 }
 
 void DisplayServerOSX::global_menu_add_item(const String &p_menu_root, const String &p_label, const Callable &p_callback, const Variant &p_tag) {
@@ -3633,12 +3498,6 @@ DisplayServerOSX::DisplayServerOSX(const String &p_rendering_driver, WindowMode 
 
 	CGEventSourceSetLocalEventsSuppressionInterval(eventSource, 0.0);
 
-	// Implicitly create shared NSApplication instance
-	[GodotApplication sharedApplication];
-
-	// In case we are unbundled, make us a proper UI application
-	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-
 	keyboard_layout_dirty = true;
 	displays_arrangement_dirty = true;
 	displays_scale_dirty = true;
@@ -3695,31 +3554,9 @@ DisplayServerOSX::DisplayServerOSX(const String &p_rendering_driver, WindowMode 
 	[apple_menu addItemWithTitle:title action:@selector(terminate:) keyEquivalent:@"q"];
 
 	// Setup menu bar
-	NSMenu *main_menu = [[[NSMenu alloc] initWithTitle:@""] autorelease];
+	NSMenu *main_menu = [NSApp mainMenu];
 	menu_item = [main_menu addItemWithTitle:@"" action:nil keyEquivalent:@""];
 	[main_menu setSubmenu:apple_menu forItem:menu_item];
-	[NSApp setMainMenu:main_menu];
-
-	[NSApp finishLaunching];
-
-	delegate = [[GodotApplicationDelegate alloc] init];
-	ERR_FAIL_COND(!delegate);
-	[NSApp setDelegate:delegate];
-
-	//process application:openFile: event
-	while (true) {
-		NSEvent *event = [NSApp
-				nextEventMatchingMask:NSEventMaskAny
-							untilDate:[NSDate distantPast]
-							   inMode:NSDefaultRunLoopMode
-							  dequeue:YES];
-
-		if (event == nil) {
-			break;
-		}
-
-		[NSApp sendEvent:event];
-	}
 
 	//!!!!!!!!!!!!!!!!!!!!!!!!!!
 	//TODO - do Vulkan and GLES2 support checks, driver selection and fallback

--- a/platform/osx/godot_main_osx.mm
+++ b/platform/osx/godot_main_osx.mm
@@ -58,16 +58,7 @@ int main(int argc, char **argv) {
 #endif
 
 	OS_OSX os;
-	Error err;
-
-	if (os.open_with_filename != "") {
-		char *argv_c = (char *)malloc(os.open_with_filename.utf8().size());
-		memcpy(argv_c, os.open_with_filename.utf8().get_data(), os.open_with_filename.utf8().size());
-		err = Main::setup(argv[0], 1, &argv_c);
-		free(argv_c);
-	} else {
-		err = Main::setup(argv[0], argc - first_arg, &argv[first_arg]);
-	}
+	Error err = Main::setup(argv[0], argc - first_arg, &argv[first_arg]);
 
 	if (err != OK)
 		return 255;

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -57,9 +57,6 @@ class OS_OSX : public OS_Unix {
 
 	MainLoop *main_loop;
 
-public:
-	String open_with_filename;
-
 protected:
 	virtual void initialize_core();
 	virtual void initialize();


### PR DESCRIPTION
On macOS instead of using command line arguments file associations are handled using `NSApplicationDelegate openFiles` selector, which is called after `NSApplication` init is finished. `DispalyServer` is created too late to handle opening of project (`.godot`) file.

This PR moves `NSApplication` and `NSApplicationDelegate` init from `DisplayServer` to the `OS` to fix file associations.