### PR TITLE
Add GitHub Actions badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ such as text and video tutorials, demos, etc. Consult the [community channels](h
 for more info.
 
 [![Travis Build Status](https://travis-ci.org/godotengine/godot.svg?branch=master)](https://travis-ci.org/godotengine/godot)
+[![Actions Build Status](https://github.com/godotengine/godot/workflows/Godot/badge.svg?branch=master)](https://github.com/godotengine/godot/actions)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/bfiihqq6byxsjxxh/branch/master?svg=true)](https://ci.appveyor.com/project/akien-mga/godot)
 [![Code Triagers Badge](https://www.codetriage.com/godotengine/godot/badges/users.svg)](https://www.codetriage.com/godotengine/godot)
 [![Translate on Weblate](https://hosted.weblate.org/widgets/godot-engine/-/godot/svg-badge.svg)](https://hosted.weblate.org/engage/godot-engine/?utm_source=widget)


### PR DESCRIPTION
P.S: Do we use AppVeyor anymore? There hasn't been a run since two days neither do I see it in any build statuses. If not, we might remove it from `README.md`. Ignore this post-script if we still do.