### PR TITLE
Evenly distribute stretched Nodes in BoxContainer

### DIFF
--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -104,6 +104,7 @@ void BoxContainer::_resort() {
 
 		has_stretched = true;
 		bool refit_successful = true; //assume refit-test will go well
+		float error = 0; // Keep track of accumulated error in pixels
 
 		for (int i = 0; i < get_child_count(); i++) {
 			Control *c = Object::cast_to<Control>(get_child(i));
@@ -119,8 +120,9 @@ void BoxContainer::_resort() {
 
 			if (msc.will_stretch) { //wants to stretch
 				//let's see if it can really stretch
-
-				int final_pixel_size = stretch_avail * c->get_stretch_ratio() / stretch_ratio_total;
+				float final_pixel_size = stretch_avail * c->get_stretch_ratio() / stretch_ratio_total;
+				// Add leftover fractional pixels to error accumulator
+				error += final_pixel_size - (int)final_pixel_size;
 				if (final_pixel_size < msc.min_size) {
 					//if available stretching area is too small for widget,
 					//then remove it from stretching area
@@ -132,6 +134,11 @@ void BoxContainer::_resort() {
 					break;
 				} else {
 					msc.final_size = final_pixel_size;
+					// Dump accumulated error if one pixel or more
+					if (error >= 1) {
+						msc.final_size += 1;
+						error -= 1;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Add any leftover fractional pixels to an error accumulator. When the accumulator is greater or equal to one, add one pixel to the current Node's size and subtract one from the accumulator.

Closes #36522

Before:
![before](https://user-images.githubusercontent.com/43592069/87602834-4eb7ac00-c6bd-11ea-8b38-acd941f758eb.gif)

My proposed implementation:
![after](https://user-images.githubusercontent.com/43592069/87603482-a7874480-c6bd-11ea-9b5b-593ac304a9ae.gif)

(This is a bit different than my comment in #36522. I think this method is simpler but I am open to suggestions.)