### PR TITLE
Stopped canvas/spatial editor from becoming active when clicking a node in the scene tree if script editor is currently active. Can use alt + click to switch editor.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1991,10 +1991,9 @@ void EditorNode::_edit_current() {
 				if (!changing_scene) {
 					main_plugin->edit(current_obj);
 				}
-			}
-
-			else if (main_plugin != editor_plugin_screen && (!ScriptEditor::get_singleton() || !ScriptEditor::get_singleton()->is_visible_in_tree() || ScriptEditor::get_singleton()->can_take_away_focus())) {
-				// update screen main_plugin
+			} else if (main_plugin != editor_plugin_screen && (!ScriptEditor::get_singleton() || !ScriptEditor::get_singleton()->is_visible_in_tree() || (ScriptEditor::get_singleton()->can_take_away_focus() || Input::get_singleton()->is_key_pressed(KEY_ALT)))) {
+				// Update screen main_plugin if plugin is different and script editor either doesnt exist, isn't visible or can lose focus.
+				// Even if script editor can't lose focus, user can override behaviour by pressing alt.
 
 				if (!changing_scene) {
 					if (editor_plugin_screen) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1534,15 +1534,6 @@ void ScriptEditor::_notification(int p_what) {
 	}
 }
 
-bool ScriptEditor::can_take_away_focus() const {
-	ScriptEditorBase *current = _get_current_editor();
-	if (current) {
-		return current->can_lose_focus_on_node_selection();
-	} else {
-		return true;
-	}
-}
-
 void ScriptEditor::close_builtin_scripts_from_scene(const String &p_scene) {
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -155,7 +155,6 @@ public:
 	virtual void add_callback(const String &p_function, PackedStringArray p_args) = 0;
 	virtual void update_settings() = 0;
 	virtual void set_debugger_active(bool p_active) = 0;
-	virtual bool can_lose_focus_on_node_selection() { return true; }
 
 	virtual bool show_members_overview() = 0;
 
@@ -483,7 +482,7 @@ public:
 
 	void goto_help(const String &p_desc) { _help_class_goto(p_desc); }
 
-	bool can_take_away_focus() const;
+	bool can_take_away_focus() const { return false; };
 
 	VSplitContainer *get_left_list_split() { return list_split; }
 

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -132,7 +132,6 @@ public:
 	virtual void tag_saved_version() override;
 	virtual void update_settings() override;
 	virtual bool show_members_overview() override;
-	virtual bool can_lose_focus_on_node_selection() override { return true; }
 	virtual void set_debugger_active(bool p_active) override;
 	virtual void set_tooltip_request_func(String p_method, Object *p_obj) override;
 	virtual void add_callback(const String &p_function, PackedStringArray p_args) override;

--- a/modules/visual_script/visual_script_editor.h
+++ b/modules/visual_script/visual_script_editor.h
@@ -320,7 +320,6 @@ public:
 	virtual void set_tooltip_request_func(String p_method, Object *p_obj) override;
 	virtual Control *get_edit_menu() override;
 	virtual void clear_edit_menu() override;
-	virtual bool can_lose_focus_on_node_selection() override { return false; }
 	virtual void validate() override;
 
 	static void register_editor();


### PR DESCRIPTION
Closes #39539, Closes #14862, Closes #33704

If the script editor is open, clicking on a node in the scene tree no longer switches you to the canvas item or spatial editors. The inspector is updated so you can change properties, or drag and drop the node path onto the script easily. 

If you want to switch to the other editor, simply hold down the Alt key.

![QBocbLiUOt](https://user-images.githubusercontent.com/41730826/87616574-b1aa5100-c758-11ea-8892-675b5b583c5a.gif)
