### PR TITLE
Handle `Ctrl` and `Alt` to fold nodes recursively with mouse input

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1050,8 +1050,11 @@ void SceneTreeDock::_node_collapsed(Object *p_obj) {
 	if (!ti) {
 		return;
 	}
-
-	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
+	const bool should_collapse =
+			Input::get_singleton()->is_key_pressed(KEY_CONTROL) ||
+			Input::get_singleton()->is_key_pressed(KEY_SHIFT) ||
+			Input::get_singleton()->is_key_pressed(KEY_ALT);
+	if (should_collapse) {
 		_set_collapsed_recursive(ti, ti->is_collapsed());
 	}
 }


### PR DESCRIPTION
Closes #28626.

Either <kbd>Ctrl</kbd>, <kbd>Shift</kbd>, or <kbd>Alt</kbd> need to be pressed to recursively collapse/expand nodes in the scene tree dock combined with the mouse input now. This should hopefully cover all cases, and it's safe to handle those for the `TreeItem` folding arrow input.