### PR TITLE
[3.x] Follow URI links in the script text editor

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -977,7 +977,8 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 			EditorNode::get_singleton()->load_scene(path);
 		}
 	} else if (p_symbol.is_rel_path()) {
-		// Every symbol other than absolute path is relative path so keep this condition at last.
+		// Every symbol other than absolute path is relative path,
+		// so keep this condition at last for engine-related symbols and files.
 		String path = _get_absolute_path(p_symbol);
 		if (FileAccess::exists(path)) {
 			List<String> scene_extensions;
@@ -989,6 +990,10 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 				EditorNode::get_singleton()->load_resource(path);
 			}
 		}
+	} else {
+		// Assume we have an URI which can be opened by the OS externally.
+		// If the URI is invalid, nothing should happen.
+		OS::get_singleton()->shell_open(p_symbol);
 	}
 }
 


### PR DESCRIPTION
Implements godotengine/godot-proposals#1172 in `3.2`, this is just to demonstrate how trivial it is to make it work in `3.2`. The only caveat is that the link should be enclosed in quotes so the `TextEdit` can recognize it as a word (this is already the case for any "res://" paths which can be followed within the engine itself), any other changes require major rewrite of how `TextEdit` groups those words...

If the symbol is not recognized by the OS, nothing happens (which is cool, because you don't have to validate the URI manually). I'm not sure if this behavior is specific to Windows.

This needs an additional work for 4.0 (`master`), as it now requires validating script symbols #36518, so have to implement something akin to `String.is_valid_uri()` first in `master` which is not so trivial (requires either regex parsing or other in-house technique), so this cannot be merged until properly implemented in 4.0. Until then, feel free to use this in your forks.

Another alternative is partially reverting #36518 so this feature could be integrated in `master` as easily as in `3.2`.