### PR TITLE
Make GLTF Scene Importer populate node metadata with GLTF extras

### DIFF
--- a/editor/import/editor_scene_importer_gltf.h
+++ b/editor/import/editor_scene_importer_gltf.h
@@ -99,6 +99,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 
 		Transform xform;
 		String name;
+		Dictionary extras;
 
 		GLTFMeshIndex mesh = -1;
 		GLTFCameraIndex camera = -1;
@@ -269,6 +270,7 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 		Vector<uint8_t> glb_data;
 
 		bool use_named_skin_binds;
+		bool import_meta;
 
 		Vector<GLTFNode *> nodes;
 		Vector<Vector<uint8_t>> buffers;
@@ -368,11 +370,13 @@ class EditorSceneImporterGLTF : public EditorSceneImporter {
 	Error _parse_lights(GLTFState &state);
 	Error _parse_animations(GLTFState &state);
 
+	void _set_meta_from_gltf_extras(GLTFState &state, Node *node, const GLTFNode *gltf_node);
+
 	BoneAttachment3D *_generate_bone_attachment(GLTFState &state, Skeleton3D *skeleton, const GLTFNodeIndex node_index);
 	MeshInstance3D *_generate_mesh_instance(GLTFState &state, Node *scene_parent, const GLTFNodeIndex node_index);
 	Camera3D *_generate_camera(GLTFState &state, Node *scene_parent, const GLTFNodeIndex node_index);
+	Node3D *_generate_node_3d(GLTFState &state, Node *scene_parent, const GLTFNodeIndex node_index);
 	Light3D *_generate_light(GLTFState &state, Node *scene_parent, const GLTFNodeIndex node_index);
-	Node3D *_generate_spatial(GLTFState &state, Node *scene_parent, const GLTFNodeIndex node_index);
 
 	void _generate_scene_node(GLTFState &state, Node *scene_parent, Node3D *scene_root, const GLTFNodeIndex node_index);
 	Node3D *_generate_scene(GLTFState &state, const int p_bake_fps);

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -109,6 +109,7 @@ void EditorSceneImporter::_bind_methods() {
 
 	BIND_CONSTANT(IMPORT_SCENE);
 	BIND_CONSTANT(IMPORT_ANIMATION);
+	BIND_CONSTANT(IMPORT_META);
 	BIND_CONSTANT(IMPORT_ANIMATION_DETECT_LOOP);
 	BIND_CONSTANT(IMPORT_ANIMATION_OPTIMIZE);
 	BIND_CONSTANT(IMPORT_ANIMATION_FORCE_ALL_TRACKS_IN_ALL_CLIPS);
@@ -1115,6 +1116,7 @@ void ResourceImporterScene::get_import_options(List<ImportOption> *r_options, in
 	bool animations_out = p_preset == PRESET_SEPARATE_ANIMATIONS || p_preset == PRESET_SEPARATE_MESHES_AND_ANIMATIONS || p_preset == PRESET_SEPARATE_MATERIALS_AND_ANIMATIONS || p_preset == PRESET_SEPARATE_MESHES_MATERIALS_AND_ANIMATIONS;
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "nodes/root_scale", PROPERTY_HINT_RANGE, "0.001,1000,0.001"), 1.0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/meta"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "nodes/custom_script", PROPERTY_HINT_FILE, script_ext_hint), ""));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "nodes/storage", PROPERTY_HINT_ENUM, "Single Scene,Instanced Sub-Scenes"), scenes_out ? 1 : 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "materials/location", PROPERTY_HINT_ENUM, "Node,Mesh"), (meshes_out || materials_out) ? 1 : 0));
@@ -1245,6 +1247,11 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	float fps = p_options["animation/fps"];
 
 	int import_flags = EditorSceneImporter::IMPORT_ANIMATION_DETECT_LOOP;
+
+	if (bool(p_options["nodes/meta"])) {
+		import_flags |= EditorSceneImporter::IMPORT_META;
+	}
+
 	if (!bool(p_options["animation/optimizer/remove_unused_tracks"])) {
 		import_flags |= EditorSceneImporter::IMPORT_ANIMATION_FORCE_ALL_TRACKS_IN_ALL_CLIPS;
 	}

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -60,7 +60,7 @@ public:
 		IMPORT_MATERIALS_IN_INSTANCES = 1024,
 		IMPORT_USE_COMPRESSION = 2048,
 		IMPORT_USE_NAMED_SKIN_BINDS = 4096,
-
+		IMPORT_META = 8192,
 	};
 
 	virtual uint32_t get_import_flags() const;


### PR DESCRIPTION
*Bugsquad edit:* Depends on #30765 which depends on #35816

This PR currently only generates metadata for Meshes, Cameras and
Spatials. Other nodes can be added later.

This feature can be enabled by a Scene Importer import option called "Meta".

This is enabled by default unlike the original 3.2 commit.

https://github.com/godotengine/godot/pull/39024