### PR TITLE
Fix third or deeper child dialogue crash in single window mode

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -895,7 +895,6 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	if (exclusive_child != nullptr) {
 		Window *focus_target = exclusive_child;
 		while (focus_target->exclusive_child != nullptr) {
-			focus_target->grab_focus();
 			focus_target = focus_target->exclusive_child;
 		}
 		focus_target->grab_focus();


### PR DESCRIPTION
Removed a call to grab_focus() causing a third or deeper child window dialogue
to be immovable and to crash when exited through "accept" button in single
window mode.

![Ixhx4md7pT](https://user-images.githubusercontent.com/52422077/87844487-9e4bd280-c88b-11ea-8221-19400507688a.gif)


Bug was probably introduced accidentally by #40226