### PR TITLE
Implement thread names with SetThreadDescription on Win32.

### DIFF
--- a/drivers/windows/thread_windows.h
+++ b/drivers/windows/thread_windows.h
@@ -51,6 +51,7 @@ class ThreadWindows : public Thread {
 	static Thread *create_func_windows(ThreadCreateCallback p_callback, void *, const Settings &);
 	static ID get_thread_id_func_windows();
 	static void wait_to_finish_func_windows(Thread *p_thread);
+	static Error set_name_func_windows(const String &p_name);
 
 	ThreadWindows() {}
 


### PR DESCRIPTION
Allows thread names to work on Win32! This could have implications for crash reporting as well as making engine debugging more accessible.

Here is an example of how things could look when debugging, if combined with another change to provide thread names.
![image](https://user-images.githubusercontent.com/39946030/87846653-4ced1480-c886-11ea-8ed8-59bbcf3bd410.png)

Note: The SetThreadDescription API requires Windows 10 version 1607 and Visual Studio 2017 version 15.6 or newer. This change uses GetProcAddress, so it should be harmless on OS versions which do not support SetThreadDescription. However, it would be good to test it on more OS combinations to be sure.