### PR TITLE
Show errors on Object.call_deferred

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -675,7 +675,7 @@ Variant Object::_call_deferred_bind(const Variant **p_args, int p_argcount, Call
 
 	StringName method = *p_args[0];
 
-	MessageQueue::get_singleton()->push_call(get_instance_id(), method, &p_args[1], p_argcount - 1);
+	MessageQueue::get_singleton()->push_call(get_instance_id(), method, &p_args[1], p_argcount - 1, true);
 
 	return Variant();
 }


### PR DESCRIPTION
Fixes  #40401

~~Update: this issue is specific to 3.2. I can't reproduce #40401 on the master branch.~~