### PR TITLE
Add DynamicFont::get_available_chars()

### DIFF
--- a/doc/classes/DynamicFont.xml
+++ b/doc/classes/DynamicFont.xml
@@ -26,6 +26,14 @@
 				Adds a fallback font.
 			</description>
 		</method>
+		<method name="get_available_chars" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns a string containing all the characters available in the main and all the fallback fonts.
+				If a given character is included in more than one font, it appears only once in the returned string.
+			</description>
+		</method>
 		<method name="get_fallback" qualifiers="const">
 			<return type="DynamicFontData">
 			</return>

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -290,6 +290,21 @@ Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const V
 	return ret;
 }
 
+String DynamicFontAtSize::get_available_chars() const {
+	String chars;
+
+	FT_UInt gindex;
+	FT_ULong charcode = FT_Get_First_Char(face, &gindex);
+	while (gindex != 0) {
+		if (charcode != 0) {
+			chars += CharType(charcode);
+		}
+		charcode = FT_Get_Next_Char(face, charcode, &gindex);
+	}
+
+	return chars;
+}
+
 float DynamicFontAtSize::draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next, const Color &p_modulate, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks, bool p_advance_only, bool p_outline) const {
 	if (!valid) {
 		return 0;
@@ -849,6 +864,25 @@ Size2 DynamicFont::get_char_size(CharType p_char, CharType p_next) const {
 	return ret;
 }
 
+String DynamicFont::get_available_chars() const {
+	if (!data_at_size.is_valid()) {
+		return "";
+	}
+
+	String chars = data_at_size->get_available_chars();
+
+	for (int i = 0; i < fallback_data_at_size.size(); i++) {
+		String fallback_chars = fallback_data_at_size[i]->get_available_chars();
+		for (int j = 0; j < fallback_chars.length(); j++) {
+			if (chars.find_char(fallback_chars[j]) == -1) {
+				chars += fallback_chars[j];
+			}
+		}
+	}
+
+	return chars;
+}
+
 bool DynamicFont::is_distance_field_hint() const {
 	return false;
 }
@@ -963,6 +997,8 @@ void DynamicFont::_get_property_list(List<PropertyInfo> *p_list) const {
 void DynamicFont::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_font_data", "data"), &DynamicFont::set_font_data);
 	ClassDB::bind_method(D_METHOD("get_font_data"), &DynamicFont::get_font_data);
+
+	ClassDB::bind_method(D_METHOD("get_available_chars"), &DynamicFont::get_available_chars);
 
 	ClassDB::bind_method(D_METHOD("set_size", "data"), &DynamicFont::set_size);
 	ClassDB::bind_method(D_METHOD("get_size"), &DynamicFont::get_size);

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -189,6 +189,7 @@ public:
 	float get_underline_thickness() const;
 
 	Size2 get_char_size(CharType p_char, CharType p_next, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks) const;
+	String get_available_chars() const;
 
 	float draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next, const Color &p_modulate, const Vector<Ref<DynamicFontAtSize>> &p_fallbacks, bool p_advance_only = false, bool p_outline = false) const;
 
@@ -277,6 +278,7 @@ public:
 	virtual float get_underline_thickness() const override;
 
 	virtual Size2 get_char_size(CharType p_char, CharType p_next = 0) const override;
+	String get_available_chars() const;
 
 	virtual bool is_distance_field_hint() const override;
 


### PR DESCRIPTION
Quoting the description of the new method for the docs:
> Returns a string containing all the characters available in the main and all the fallback fonts.
> If a given character is included in more than one font, it appears only once in the returned string.

This is useful in the cases where you want to use a `DynamicFont`, but at the same time you want to prerasterize all its characters, much as if you were using a `BitmapFont`, but at runtime. You create a scene with a label, set its text to the string of available characters and ensure it's rendered at least once, while you keep the reference to your font.

This is much like the usual tricks to precompile shaders and lets you benefit from the font being dynamic while avoiding stalls when new text appears during the game needing to rasterize many characters. This is what I'm doing in my game.

**NOTE:** Separate version for 3.2 is submitted.

Other use cases may apply.