### PR TITLE
Add DynamicFont::get_available_chars() (3.2)

### DIFF
--- a/doc/classes/DynamicFont.xml
+++ b/doc/classes/DynamicFont.xml
@@ -26,6 +26,14 @@
 				Adds a fallback font.
 			</description>
 		</method>
+		<method name="get_available_chars" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns a string containing all the characters available in the main and all the fallback fonts.
+				If a given character is included in more than one font, it appears only once in the returned string.
+			</description>
+		</method>
 		<method name="get_fallback" qualifiers="const">
 			<return type="DynamicFontData">
 			</return>

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -296,6 +296,21 @@ Size2 DynamicFontAtSize::get_char_size(CharType p_char, CharType p_next, const V
 	return ret;
 }
 
+String DynamicFontAtSize::get_available_chars() const {
+	String chars;
+
+	FT_UInt gindex;
+	FT_ULong charcode = FT_Get_First_Char(face, &gindex);
+	while (gindex != 0) {
+		if (charcode != 0) {
+			chars += CharType(charcode);
+		}
+		charcode = FT_Get_Next_Char(face, charcode, &gindex);
+	}
+
+	return chars;
+}
+
 void DynamicFontAtSize::set_texture_flags(uint32_t p_flags) {
 
 	texture_flags = p_flags;
@@ -876,6 +891,25 @@ Size2 DynamicFont::get_char_size(CharType p_char, CharType p_next) const {
 	return ret;
 }
 
+String DynamicFont::get_available_chars() const {
+
+	if (!data_at_size.is_valid())
+		return "";
+
+	String chars = data_at_size->get_available_chars();
+
+	for (int i = 0; i < fallback_data_at_size.size(); i++) {
+		String fallback_chars = fallback_data_at_size[i]->get_available_chars();
+		for (int j = 0; j < fallback_chars.length(); j++) {
+			if (chars.find_char(fallback_chars[j]) == -1) {
+				chars += fallback_chars[j];
+			}
+		}
+	}
+
+	return chars;
+}
+
 bool DynamicFont::is_distance_field_hint() const {
 
 	return false;
@@ -994,6 +1028,8 @@ void DynamicFont::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_font_data", "data"), &DynamicFont::set_font_data);
 	ClassDB::bind_method(D_METHOD("get_font_data"), &DynamicFont::get_font_data);
+
+	ClassDB::bind_method(D_METHOD("get_available_chars"), &DynamicFont::get_available_chars);
 
 	ClassDB::bind_method(D_METHOD("set_size", "data"), &DynamicFont::set_size);
 	ClassDB::bind_method(D_METHOD("get_size"), &DynamicFont::get_size);

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -191,6 +191,7 @@ public:
 	float get_descent() const;
 
 	Size2 get_char_size(CharType p_char, CharType p_next, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks) const;
+	String get_available_chars() const;
 
 	float draw_char(RID p_canvas_item, const Point2 &p_pos, CharType p_char, CharType p_next, const Color &p_modulate, const Vector<Ref<DynamicFontAtSize> > &p_fallbacks, bool p_advance_only = false, bool p_outline = false) const;
 
@@ -278,6 +279,7 @@ public:
 	virtual float get_descent() const;
 
 	virtual Size2 get_char_size(CharType p_char, CharType p_next = 0) const;
+	String get_available_chars() const;
 
 	virtual bool is_distance_field_hint() const;
 


### PR DESCRIPTION
Version of #40491 for 3.2. (They are almost the same, but according to Git the patch for the version for _master_ doesn't apply to 3.2.)