### PR TITLE
Convert some resource types in the inspector

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2980,7 +2980,16 @@ Variant EditorPropertyResource::get_drag_data_fw(const Point2 &p_point, Control 
 }
 
 bool EditorPropertyResource::_is_drop_valid(const Dictionary &p_drag_data) const {
-	String allowed_type = base_type;
+	Vector<String> allowed_types = base_type.split(",");
+	int size = allowed_types.size();
+	for (int i = 0; i < size; i++) {
+		String at = allowed_types[i].strip_edges();
+		if (at == "StandardMaterial3D") {
+			allowed_types.append("Texture2D");
+		} else if (at == "ShaderMaterial") {
+			allowed_types.append("Shader");
+		}
+	}
 
 	Dictionary drag_data = p_drag_data;
 
@@ -2993,9 +3002,9 @@ bool EditorPropertyResource::_is_drop_valid(const Dictionary &p_drag_data) const
 	}
 
 	if (res.is_valid()) {
-		for (int i = 0; i < allowed_type.get_slice_count(","); i++) {
-			String at = allowed_type.get_slice(",", i).strip_edges();
-			if (res.is_valid() && ClassDB::is_parent_class(res->get_class(), at)) {
+		for (int i = 0; i < allowed_types.size(); i++) {
+			String at = allowed_types[i].strip_edges();
+			if (ClassDB::is_parent_class(res->get_class(), at)) {
 				return true;
 			}
 		}
@@ -3009,8 +3018,8 @@ bool EditorPropertyResource::_is_drop_valid(const Dictionary &p_drag_data) const
 			String ftype = EditorFileSystem::get_singleton()->get_file_type(file);
 
 			if (ftype != "") {
-				for (int i = 0; i < allowed_type.get_slice_count(","); i++) {
-					String at = allowed_type.get_slice(",", i).strip_edges();
+				for (int i = 0; i < allowed_types.size(); i++) {
+					String at = allowed_types[i].strip_edges();
 					if (ClassDB::is_parent_class(ftype, at)) {
 						return true;
 					}
@@ -3039,24 +3048,49 @@ void EditorPropertyResource::drop_data_fw(const Point2 &p_point, const Variant &
 		res = drag_data["resource"];
 	}
 
-	if (res.is_valid()) {
-		emit_changed(get_edited_property(), res);
-		update_property();
-		return;
-	}
-
-	if (drag_data.has("type") && String(drag_data["type"]) == "files") {
+	if (!res.is_valid() && drag_data.has("type") && String(drag_data["type"]) == "files") {
 		Vector<String> files = drag_data["files"];
 
 		if (files.size() == 1) {
 			String file = files[0];
-			RES file_res = ResourceLoader::load(file);
-			if (file_res.is_valid()) {
-				emit_changed(get_edited_property(), file_res);
-				update_property();
-				return;
+			res = ResourceLoader::load(file);
+		}
+	}
+
+	if (res.is_valid()) {
+		bool need_convert = true;
+
+		Vector<String> allowed_types = base_type.split(",");
+		for (int i = 0; i < allowed_types.size(); i++) {
+			String at = allowed_types[i].strip_edges();
+			if (ClassDB::is_parent_class(res->get_class(), at)) {
+				need_convert = false;
+				break;
 			}
 		}
+
+		if (need_convert) {
+			for (int i = 0; i < allowed_types.size(); i++) {
+				String at = allowed_types[i].strip_edges();
+				if (at == "StandardMaterial3D" && ClassDB::is_parent_class(res->get_class(), "Texture2D")) {
+					Ref<StandardMaterial3D> mat = memnew(StandardMaterial3D);
+					mat->set_texture(StandardMaterial3D::TextureParam::TEXTURE_ALBEDO, res);
+					res = mat;
+					break;
+				}
+
+				if (at == "ShaderMaterial" && ClassDB::is_parent_class(res->get_class(), "Shader")) {
+					Ref<ShaderMaterial> mat = memnew(ShaderMaterial);
+					mat->set_shader(res);
+					res = mat;
+					break;
+				}
+			}
+		}
+
+		emit_changed(get_edited_property(), res);
+		update_property();
+		return;
 	}
 }
 


### PR DESCRIPTION
![A7nDt9jjJW](https://user-images.githubusercontent.com/2223172/87863538-30bba700-c95c-11ea-98c1-ad0bfd7d716c.gif)
![2iLoWjVg1S](https://user-images.githubusercontent.com/2223172/87863493-a115f880-c95b-11ea-8aef-06372594fae9.gif)
In case you don't know what happens in the GIFs above, I'm dropping a texture directly into a `material_override` field and it automatically creates a material with this texture as albedo. Then I drop a shader onto `material` slot and it automatically creates a ShaderMaterial with this shader assigned.

This is done in a pretty generic way so it's easy to add more auto-conversions like this.

Closes #27079
Addresses https://github.com/godotengine/godot-proposals/issues/96#issuecomment-535247671