### PR TITLE
Add Method get_inverse_inertia_tensor

### DIFF
--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -100,6 +100,13 @@
 				[b]Note:[/b] The result of this test is not immediate after moving objects. For performance, list of collisions is updated once per frame and before the physics step. Consider using signals instead.
 			</description>
 		</method>
+		<method name="get_inverse_inertia_tensor">
+			<return type="Basis">
+			</return>
+			<description>
+				Returns the inverse inertia tensor basis. This is used to calculate the angular acceleration resulting from a torque applied to the [RigidBody3D].
+			</description>
+		</method>
 		<method name="set_axis_lock">
 			<return type="void">
 			</return>

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -358,6 +358,7 @@ void RigidBody3D::_direct_state_changed(Object *p_state) {
 	set_global_transform(state->get_transform());
 	linear_velocity = state->get_linear_velocity();
 	angular_velocity = state->get_angular_velocity();
+	inverse_inertia_tensor = state->get_inverse_inertia_tensor();
 	if (sleeping != state->is_sleeping()) {
 		sleeping = state->is_sleeping();
 		emit_signal(SceneStringNames::get_singleton()->sleeping_state_changed);
@@ -594,6 +595,10 @@ Vector3 RigidBody3D::get_angular_velocity() const {
 	return angular_velocity;
 }
 
+Basis RigidBody3D::get_inverse_inertia_tensor() {
+	return inverse_inertia_tensor;
+}
+
 void RigidBody3D::set_use_custom_integrator(bool p_enable) {
 	if (custom_integrator == p_enable) {
 		return;
@@ -759,6 +764,8 @@ void RigidBody3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_angular_velocity", "angular_velocity"), &RigidBody3D::set_angular_velocity);
 	ClassDB::bind_method(D_METHOD("get_angular_velocity"), &RigidBody3D::get_angular_velocity);
+
+	ClassDB::bind_method(D_METHOD("get_inverse_inertia_tensor"), &RigidBody3D::get_inverse_inertia_tensor);
 
 	ClassDB::bind_method(D_METHOD("set_gravity_scale", "gravity_scale"), &RigidBody3D::set_gravity_scale);
 	ClassDB::bind_method(D_METHOD("get_gravity_scale"), &RigidBody3D::get_gravity_scale);

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -123,6 +123,7 @@ protected:
 
 	Vector3 linear_velocity;
 	Vector3 angular_velocity;
+	Basis inverse_inertia_tensor;
 	real_t gravity_scale;
 	real_t linear_damp;
 	real_t angular_damp;
@@ -200,6 +201,8 @@ public:
 
 	void set_angular_velocity(const Vector3 &p_velocity);
 	Vector3 get_angular_velocity() const override;
+
+	Basis get_inverse_inertia_tensor();
 
 	void set_gravity_scale(real_t p_gravity_scale);
 	real_t get_gravity_scale() const;


### PR DESCRIPTION
## Exposed inertia tensor to GDScript

### How
This was done by creating a variable on the rigidbody class. The variable receives the inverse inertia tensor value each time the RigidBody state gets changed, then the `get_inverse_inertia_tensor()` returns the the inverse_inertia_tensor. The method is exposed to GDScript with `bind_method`

### Consequences
As a consequence of this, rotations with rigid bodies can be controlled more accurately through the use of Physics Formulas of Torque

### Requests
This was proposed in: https://github.com/godotengine/godot-proposals/issues/1114 also in https://github.com/godotengine/godot/issues/2125 and kind of related to https://github.com/godotengine/godot-proposals/issues/945

This Pull Request has been made in the Godot 3.2 branch at https://github.com/godotengine/godot/pull/39817 and now I've made it in the Master Branch (due to class name changes, for instance RigidBody class became RigidBody3D)