### PR TITLE
Refactor GraphEdit connections

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -10,6 +10,17 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_get_connection_line" qualifiers="virtual">
+			<return type="PackedVector2Array">
+			</return>
+			<argument index="0" name="from" type="Vector2">
+			</argument>
+			<argument index="1" name="to" type="Vector2">
+			</argument>
+			<description>
+				Virtual method which can be overridden to customize how connections are drawn.
+			</description>
+		</method>
 		<method name="add_valid_connection_type">
 			<return type="void">
 			</return>
@@ -89,6 +100,17 @@
 			<description>
 				Gets the [HBoxContainer] that contains the zooming and grid snap controls in the top left of the graph.
 				Warning: The intended usage of this function is to allow you to reposition or add your own custom controls to the container. This is an internal control and as such should not be freed. If you wish to hide this or any of it's children use their [member CanvasItem.visible] property instead.
+			</description>
+		</method>
+		<method name="get_connection_line">
+			<return type="PackedVector2Array">
+			</return>
+			<argument index="0" name="from" type="Vector2">
+			</argument>
+			<argument index="1" name="to" type="Vector2">
+			</argument>
+			<description>
+				Returns the points which would make up a connection between [code]from[/code] and [code]to[/code].
 			</description>
 		</method>
 		<method name="is_node_connected">

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -115,9 +115,9 @@ private:
 	bool awaiting_scroll_offset_update;
 	List<Connection> connections;
 
-	void _bake_segment2d(Vector<Vector2> &points, Vector<Color> &colors, float p_begin, float p_end, const Vector2 &p_a, const Vector2 &p_out, const Vector2 &p_b, const Vector2 &p_in, int p_depth, int p_min_depth, int p_max_depth, float p_tol, const Color &p_color, const Color &p_to_color, int &lines) const;
+	PackedVector2Array get_connection_line(const Vector2 &p_from, const Vector2 &p_to);
 
-	void _draw_cos_line(CanvasItem *p_where, const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, const Color &p_to_color);
+	void _draw_connection_line(CanvasItem *p_where, const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, const Color &p_to_color);
 
 	void _graph_node_raised(Node *p_gn);
 	void _graph_node_moved(Node *p_gn);


### PR DESCRIPTION
There was code to draw bezier curves in graph_edit.cpp, which I removed to use Curve2D instead.
This PR makes it possible to retrieve the points of a connection line between two given points, and to customize how connections are drawn:

<details>
  <summary>Examples of custom connections</summary>

```gdscript
func _get_connection_line(from: Vector2, to: Vector2):
	var distance = to - from
	return [from, from + Vector2(distance.x / 2, 0), to - Vector2(distance.x / 2, 0), to]
```

![straight connection](https://user-images.githubusercontent.com/28286961/87880987-762cb280-c9f6-11ea-95f9-1fe7a6000267.png)

```gdscript
func _get_connection_line(from: Vector2, to: Vector2):
	var distance = to - from
	return [from, to]
```

![direct connection](https://user-images.githubusercontent.com/28286961/87880993-804eb100-c9f6-11ea-8dd0-ccc8992af29f.png)

When `_get_connection_line` isn't overriden:

![curve](https://user-images.githubusercontent.com/28286961/87880997-90ff2700-c9f6-11ea-9078-c15c77efe06e.png)

</details>  

By adding a way to access the connection line, it makes it possible to implement interaction, like putting nodes in between or adding reroute nodes:

![demo](https://user-images.githubusercontent.com/28286961/87881087-4a5dfc80-c9f7-11ea-8bcc-2b1f0aefaec1.gif)

Gist:
https://gist.github.com/Jummit/545d193b9f5119a428862abfefe4be53

<details open>
  <summary>Issues to fix:</summary>

- [ ] not tested on the latest build, as my computer can't run Vulkan
- [x] Colors don't work <details><summary>Example</summary>
![2020-07-20-122233_2646x1024_scrot](https://user-images.githubusercontent.com/28286961/87927611-c1d96d80-ca83-11ea-9e54-499d76445ee0.png)
</details>

- [ ] I'm not sure about the get_connection_line name, as it's very close to get_connection_list.
- [ ] inconsistent with the old line when the connection goes backwards (or is this ok?)<details><summary>Example</summary>
![image](https://user-images.githubusercontent.com/28286961/87881136-7da08b80-c9f7-11ea-853e-2ece1fd9819b.png)
Slide Comparison: https://imgsli.com/MTkyOTc
</details>
</details>