### PR TITLE
Fix Directory make_dir and make_dir_recursive

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1690,7 +1690,7 @@ String _Directory::get_current_dir() {
 }
 
 Error _Directory::make_dir(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory is not configured properly.");
 	if (!p_dir.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		Error err = d->make_dir(p_dir);
@@ -1701,7 +1701,7 @@ Error _Directory::make_dir(String p_dir) {
 }
 
 Error _Directory::make_dir_recursive(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory is not configured properly.");
 	if (!p_dir.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		Error err = d->make_dir_recursive(p_dir);


### PR DESCRIPTION
Fix #40509 

Thanks @Relintai for the report

<details>
  <summary>To make sure there aren't any more issues with this, here is a list of all the Directory functions which require the Directory to be open</summary><p>

`list_dir_begin`
`get_next`
`current_is_dir`
`list_dir_end`
`get_drive_count`
`get_drive`
`get_current_drive`
`get_current_dir`
`get_space_left`
\* `copy`
`rename`
\* `remove`

\* - Maybe Remove This Requirement?
</p></details>

