### PR TITLE
Set minimum osx version to 10.12 for OSXCross compilation

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -24,7 +24,7 @@ def get_opts():
     from SCons.Variables import BoolVariable, EnumVariable
 
     return [
-        ("osxcross_sdk", "OSXCross SDK version", "darwin14"),
+        ("osxcross_sdk", "OSXCross SDK version", "darwin16"),
         ("MACOS_SDK_PATH", "Path to the macOS SDK", ""),
         BoolVariable(
             "use_static_mvk",
@@ -86,16 +86,16 @@ def configure(env):
     if "OSXCROSS_ROOT" in os.environ:
         env["osxcross"] = True
 
-    if not "osxcross" in env:  # regular native build
-        if env["arch"] == "arm64":
-            print("Building for macOS 10.15+, platform arm64.")
-            env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15", "-target", "arm64-apple-macos10.15"])
-            env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15", "-target", "arm64-apple-macos10.15"])
-        else:
-            print("Building for macOS 10.12+, platform x86-64.")
-            env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
-            env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
+    if env["arch"] == "arm64":
+        print("Building for macOS 10.15+, platform arm64.")
+        env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15", "-target", "arm64-apple-macos10.15"])
+        env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15", "-target", "arm64-apple-macos10.15"])
+    else:
+        print("Building for macOS 10.12+, platform x86-64.")
+        env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
+        env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
 
+    if not "osxcross" in env:  # regular native build
         if env["macports_clang"] != "no":
             mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
             mpclangver = env["macports_clang"]
@@ -116,7 +116,10 @@ def configure(env):
 
     else:  # osxcross build
         root = os.environ.get("OSXCROSS_ROOT", 0)
-        basecmd = root + "/target/bin/x86_64-apple-" + env["osxcross_sdk"] + "-"
+        if env["arch"] == "arm64":
+            basecmd = root + "/target/bin/arm64-apple-" + env["osxcross_sdk"] + "-"
+        else:
+            basecmd = root + "/target/bin/x86_64-apple-" + env["osxcross_sdk"] + "-"
 
         ccache_path = os.environ.get("CCACHE")
         if ccache_path is None:


### PR DESCRIPTION
Fixes this compilation error:

```
In file included from thirdparty/vulkan/vk_mem_alloc.cpp:7:
thirdparty/vulkan/vk_mem_alloc.h:3691:18: error: 'shared_mutex' is unavailable: introduced in macOS 10.12
            std::shared_mutex m_Mutex;
                 ^
/home/[user]/sources/osxcross/target/bin/../SDK/MacOSX10.14.sdk/usr/include/c++/v1/shared_mutex:178:58: note: 'shared_mutex' has been explicitly marked unavailable here
class _LIBCPP_TYPE_VIS _LIBCPP_AVAILABILITY_SHARED_MUTEX shared_mutex
```

Command line:
```
scons platform=osx osxcross_sdk=darwin18 target=release_debug
```