### PR TITLE
Fix debugger not getting focused on break on Windows (3.2)

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -927,6 +927,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			memdelete(sdr);
 		} else {
 			script_debugger = sdr;
+			sdr->set_allow_focus_steal_pid(allow_focus_steal_pid);
 		}
 	} else if (debug_mode == "local") {
 
@@ -1304,10 +1305,6 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	}
 	if (init_always_on_top) {
 		OS::get_singleton()->set_window_always_on_top(true);
-	}
-
-	if (allow_focus_steal_pid) {
-		OS::get_singleton()->enable_for_stealing_focus(allow_focus_steal_pid);
 	}
 
 	register_server_types();

--- a/scene/debugger/script_debugger_remote.cpp
+++ b/scene/debugger/script_debugger_remote.cpp
@@ -142,6 +142,10 @@ void ScriptDebuggerRemote::debug(ScriptLanguage *p_script, bool p_can_continue, 
 
 	ERR_FAIL_COND_MSG(!tcp_client->is_connected_to_host(), "Script Debugger failed to connect, but being used anyway.");
 
+	if (allow_focus_steal_pid) {
+		OS::get_singleton()->enable_for_stealing_focus(allow_focus_steal_pid);
+	}
+
 	packet_peer_stream->put_var("debug_enter");
 	packet_peer_stream->put_var(2);
 	packet_peer_stream->put_var(p_can_continue);
@@ -1231,6 +1235,10 @@ void ScriptDebuggerRemote::set_skip_breakpoints(bool p_skip_breakpoints) {
 	skip_breakpoints = p_skip_breakpoints;
 }
 
+void ScriptDebuggerRemote::set_allow_focus_steal_pid(OS::ProcessID p_pid) {
+	allow_focus_steal_pid = p_pid;
+}
+
 ScriptDebuggerRemote::ResourceUsageFunc ScriptDebuggerRemote::resource_usage_func = NULL;
 
 ScriptDebuggerRemote::ScriptDebuggerRemote() :
@@ -1258,6 +1266,7 @@ ScriptDebuggerRemote::ScriptDebuggerRemote() :
 		warn_count(0),
 		last_msec(0),
 		msec_count(0),
+		allow_focus_steal_pid(0),
 		locking(false),
 		poll_every(0),
 		scene_tree(NULL) {

--- a/scene/debugger/script_debugger_remote.h
+++ b/scene/debugger/script_debugger_remote.h
@@ -114,6 +114,8 @@ class ScriptDebuggerRemote : public ScriptDebugger {
 	uint64_t last_msec;
 	uint64_t msec_count;
 
+	OS::ProcessID allow_focus_steal_pid;
+
 	bool locking; //hack to avoid a deadloop
 	static void _print_handler(void *p_this, const String &p_string, bool p_error);
 
@@ -198,6 +200,7 @@ public:
 	virtual void set_skip_breakpoints(bool p_skip_breakpoints);
 
 	void set_scene_tree(SceneTree *p_scene_tree) { scene_tree = p_scene_tree; };
+	void set_allow_focus_steal_pid(OS::ProcessID p_pid);
 
 	ScriptDebuggerRemote();
 	~ScriptDebuggerRemote();


### PR DESCRIPTION
This is a revert of 9d78274e068d4928044220c4d5c1a7baed423670, which was an attempt to fix #21431, but in the end it seems a different problem was the root of the issue.

Renewing focus steal allowance every time is needed on Windows.

A version for _master_ is not needed since there the approach is different and seemingly already correct.