### PR TITLE
iOS Game Center improvements

### DIFF
--- a/platform/iphone/game_center.h
+++ b/platform/iphone/game_center.h
@@ -49,7 +49,7 @@ class GameCenter : public Object {
 	void return_connect_error(const char *p_error_description);
 
 public:
-	void connect();
+	Error authenticate();
 	bool is_authenticated();
 
 	Error post_score(Variant p_score);

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -163,7 +163,6 @@ Error OSIPhone::initialize(const VideoMode &p_desired, int p_video_driver, int p
 #ifdef GAME_CENTER_ENABLED
 	game_center = memnew(GameCenter);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GameCenter", game_center));
-	game_center->connect();
 #endif
 
 #ifdef STOREKIT_ENABLED


### PR DESCRIPTION
Godot authenticates user automatically. It's problem for unsupported games.

Changing:

1. Disabled calling ``connect`` from ``OS``.
2. Renamed ``connect`` method to ``authenticate``.
3. Add GDScript binding for ``authenticate``