### PR TITLE
Fix OpenGL error when generating radiance

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2177,7 +2177,7 @@ void RasterizerStorageGLES3::sky_set_texture(RID p_sky, RID p_panorama, int p_ra
 			}
 
 			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, tmp_fb);
-			glFramebufferTextureLayer(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, sky->radiance, 0, lod);
+			glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, sky->radiance, lod);
 			glBindFramebuffer(GL_READ_FRAMEBUFFER, tmp_fb2);
 			glReadBuffer(GL_COLOR_ATTACHMENT0);
 			glBlitFramebuffer(0, 0, size, size * 2, 0, 0, size, size * 2, GL_COLOR_BUFFER_BIT, GL_NEAREST);


### PR DESCRIPTION
Fixes: #40444 

Looks like my hardware just silently ignored the fact that the texture was the wrong type. 

Seems to work fine for me. But I was unable to reproduce the linked error. 