### PR TITLE
Fix Vulkan layer creation when compiling with OSXCross

### DIFF
--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -3492,9 +3492,7 @@ DisplayServerOSX::WindowID DisplayServerOSX::_create_window(WindowMode p_mode, c
 		wd.window_view = [[GodotContentView alloc] init];
 		ERR_FAIL_COND_V_MSG(wd.window_view == nil, INVALID_WINDOW_ID, "Can't create a window view");
 		[wd.window_view setWindowID:window_id_counter];
-		if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_14) {
-			[wd.window_view setWantsLayer:TRUE];
-		}
+		[wd.window_view setWantsLayer:TRUE];
 
 		[wd.window_object setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
 		[wd.window_object setContentView:wd.window_view];


### PR DESCRIPTION
Vulkan initialization was failing on startup when compiling with OSXCross and darwin 16 (macOS 10.14).
```
[mvk-error] VK_ERROR_INITIALIZATION_FAILED: vkCreateMacOSSurfaceMVK(): On-screen rendering requires a layer of type CAMetalLayer.
ERROR: - Message Id Number: 0 | Message Id Name:
VK_ERROR_INITIALIZATION_FAILED: vkCreateMacOSSurfaceMVK(): On-screen rendering requires a layer of type CAMetalLayer.
Objects - 1
Object[0] - VK_OBJECT_TYPE_SURFACE_KHR, Handle 140430128525616

at: _debug_messenger_callback (drivers/vulkan/vulkan_context.cpp:136)
ERROR: Condition "err" is true. Returning: ERR_CANT_CREATE
at: window_create (platform/osx/vulkan_context_osx.mm:47)
ERROR: Can't create a Vulkan context
at: _create_window (platform/osx/display_server_osx.mm:3518)
ERROR: Condition "main_window == INVALID_WINDOW_ID" is true.
at: DisplayServerOSX (platform/osx/display_server_osx.mm:3754)
```

I'm not sure why the condition is failing in the case of OSXCross, but it should be safe to set `wantsLayer` in any case since it's available on version 10.5+:
https://developer.apple.com/documentation/appkit/nsview/1483695-wantslayer