### PR TITLE
Travis: Pin Emscripten version to 1.39.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
       misc/ci/android-tools-linux.sh;
     fi
   - if [ "$PLATFORM" = "javascript" ]; then
-      git clone --depth 1 "https://github.com/emscripten-core/emsdk.git";
+      git clone --depth 1 --branch 1.39.19 https://github.com/emscripten-core/emsdk;
       ./emsdk/emsdk install latest;
       ./emsdk/emsdk activate --no-embedded latest;
     fi


### PR DESCRIPTION
1.39.20 dropped support for the no-embedded mode we use since #39168,
as our detection logic hasn't been fixed yet to support the embedded
mode. (Support actually removed from emsdk in https://github.com/emscripten-core/emsdk/pull/510.)

This is just a temporary hack, we should implement support for the embedded mode.