### PR TITLE
Only display a virtual keyboard if the text can be edited.

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -127,7 +127,7 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 			selection.creating = false;
 			selection.doubleclick = false;
 
-			if (OS::get_singleton()->has_virtual_keyboard()) {
+			if (is_editable() && OS::get_singleton()->has_virtual_keyboard()) {
 				if (selection.enabled) {
 					OS::get_singleton()->show_virtual_keyboard(text, get_global_rect(), max_length, selection.begin, selection.end);
 				} else {
@@ -930,7 +930,7 @@ void LineEdit::_notification(int p_what) {
 				OS::get_singleton()->set_ime_position(get_global_position() + cursor_pos2);
 			}
 
-			if (OS::get_singleton()->has_virtual_keyboard()) {
+			if (is_editable() && OS::get_singleton()->has_virtual_keyboard()) {
 				if (selection.enabled) {
 					OS::get_singleton()->show_virtual_keyboard(text, get_global_rect(), max_length, selection.begin, selection.end);
 				} else {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1740,7 +1740,7 @@ void TextEdit::_notification(int p_what) {
 			Point2 cursor_pos = Point2(cursor_get_column(), cursor_get_line()) * get_row_height();
 			OS::get_singleton()->set_ime_position(get_global_position() + cursor_pos);
 
-			if (OS::get_singleton()->has_virtual_keyboard())
+			if (!is_readonly() && OS::get_singleton()->has_virtual_keyboard())
 				OS::get_singleton()->show_virtual_keyboard(get_text(), get_global_rect());
 		} break;
 		case NOTIFICATION_FOCUS_EXIT: {


### PR DESCRIPTION
@pouleyKetchoupp I found this very useful, but I can only test & commit to the 3.2 branch.