### PR TITLE
Update Linux gamepad detection to match SDL.

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -311,16 +311,9 @@ void JoypadLinux::open_joypad(const char *p_path) {
 			return;
 		}
 
-		//check if the device supports basic gamepad events, prevents certain keyboards from
-		//being detected as joypads
+		// Check if the device supports basic gamepad events
 		if (!(test_bit(EV_KEY, evbit) && test_bit(EV_ABS, evbit) &&
-					(test_bit(ABS_X, absbit) || test_bit(ABS_Y, absbit) || test_bit(ABS_HAT0X, absbit) ||
-							test_bit(ABS_GAS, absbit) || test_bit(ABS_RUDDER, absbit)) &&
-					(test_bit(BTN_A, keybit) || test_bit(BTN_THUMBL, keybit) ||
-							test_bit(BTN_TRIGGER, keybit) || test_bit(BTN_1, keybit))) &&
-				!(test_bit(EV_ABS, evbit) &&
-						test_bit(ABS_X, absbit) && test_bit(ABS_Y, absbit) &&
-						test_bit(ABS_RX, absbit) && test_bit(ABS_RY, absbit))) {
+					test_bit(ABS_X, absbit) && test_bit(ABS_Y, absbit))) {
 			close(fd);
 			return;
 		}


### PR DESCRIPTION
Simplifies and eases the constraints on what is considered a gamepad: basically anything with an absolute x- and a y-axis (i.e. not a mouse, which uses relative coordinates) is considered a gamepad. So this will include trackpads and tablets too, but this is probably a desired side-effect.

Could fix #24526, but it will need to be tested, because the issue claims that ```test_bit(EV_KEY, evbit)``` returns `false` with a rudder. Also may cause a regression following effectively reverting #37261 too (which added a specific exception that excludes the `EV_KEY` test but adds two more axes tests `ABS_RX` and `ABS_RY`). If either is the case then the ```test_bit(EV_KEY, evbit)``` can be dropped too. However, I've kept it, because this is the logic currently used by SDL.