### PR TITLE
C#: Fix restore not called when building game projects

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -118,9 +118,14 @@ namespace GodotTools.Build
             string arguments = string.Empty;
 
             if (buildTool == BuildTool.DotnetCli)
-                arguments += "msbuild "; // `dotnet msbuild` command
+                arguments += "msbuild"; // `dotnet msbuild` command
 
-            arguments += $@"""{buildInfo.Solution}"" /t:{string.Join(",", buildInfo.Targets)} " +
+            arguments += $@" ""{buildInfo.Solution}""";
+
+            if (buildInfo.Restore)
+                arguments += " /restore";
+
+            arguments += $@" /t:{string.Join(",", buildInfo.Targets)} " +
                          $@"""/p:{"Configuration=" + buildInfo.Configuration}"" /v:normal " +
                          $@"""/l:{typeof(GodotBuildLogger).FullName},{GodotBuildLogger.AssemblyPath};{buildInfo.LogsDirPath}""";
 


### PR DESCRIPTION
Fixes #40546
