### PR TITLE
VisualScript: Fix -Wduplicate-branches warning

### DIFF
--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -36,8 +36,6 @@
 #include "scene/main/node.h"
 #include "visual_script_nodes.h"
 
-#include <stdint.h>
-
 //used by editor, this is not really saved
 void VisualScriptNode::set_breakpoint(bool p_breakpoint) {
 	breakpoint = p_breakpoint;
@@ -1764,11 +1762,7 @@ Variant VisualScriptInstance::_call_internal(const StringName &p_method, void *p
 			}
 
 			next = node->sequence_outputs[output];
-			if (next) {
-				VSDEBUG("GOT NEXT NODE - " + itos(next->get_id()));
-			} else {
-				VSDEBUG("GOT NEXT NODE - NULL");
-			}
+			VSDEBUG("GOT NEXT NODE - " + (next ? itos(next->get_id()) : "NULL"));
 		}
 
 		if (flow_stack) {


### PR DESCRIPTION
When VSDEBUG is a no-op (default), those branches did the same (nothing).