### PR TITLE
issue-40396 - Added missing error strings to JSON parsing when array …

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -371,6 +371,7 @@ Error JSON::_parse_array(Array &array, const CharType *p_str, int &index, int p_
 		need_comma = true;
 	}
 
+	r_err_str = "Expected ']'";
 	return ERR_PARSE_ERROR;
 }
 
@@ -433,6 +434,7 @@ Error JSON::_parse_object(Dictionary &object, const CharType *p_str, int &index,
 		}
 	}
 
+	r_err_str = "Expected '}'";
 	return ERR_PARSE_ERROR;
 }
 


### PR DESCRIPTION
…or object is never closed.

Fixes https://github.com/godotengine/godot/issues/40396