### PR TITLE
Fix typos in GodotSharp code docs

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -554,7 +554,7 @@ namespace Godot
         /// Returns a vector transformed (multiplied) by the basis matrix.
         /// </summary>
         /// <param name="v">A vector to transform.</param>
-        /// <returns>The transfomed vector.</returns>
+        /// <returns>The transformed vector.</returns>
         public Vector3 Xform(Vector3 v)
         {
             return new Vector3
@@ -572,7 +572,7 @@ namespace Godot
         /// basis matrix only if it represents a rotation-reflection.
         /// </summary>
         /// <param name="v">A vector to inversely transform.</param>
-        /// <returns>The inversely transfomed vector.</returns>
+        /// <returns>The inversely transformed vector.</returns>
         public Vector3 XformInv(Vector3 v)
         {
             return new Vector3

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -109,7 +109,7 @@ namespace Godot
         /// <summary>
         /// Returns the shortest distance from this plane to the position `point`.
         /// </summary>
-        /// <param name="point">The position to use for the calcualtion.</param>
+        /// <param name="point">The position to use for the calculation.</param>
         /// <returns>The shortest distance.</returns>
         public real_t DistanceTo(Vector3 point)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quat.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quat.cs
@@ -299,7 +299,7 @@ namespace Godot
         /// Returns a vector transformed (multiplied) by this quaternion.
         /// </summary>
         /// <param name="v">A vector to transform.</param>
-        /// <returns>The transfomed vector.</returns>
+        /// <returns>The transformed vector.</returns>
         public Vector3 Xform(Vector3 v)
         {
 #if DEBUG

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform.cs
@@ -248,7 +248,7 @@ namespace Godot
         /// Returns a vector transformed (multiplied) by this transformation matrix.
         /// </summary>
         /// <param name="v">A vector to transform.</param>
-        /// <returns>The transfomed vector.</returns>
+        /// <returns>The transformed vector.</returns>
         public Vector3 Xform(Vector3 v)
         {
             return new Vector3
@@ -266,7 +266,7 @@ namespace Godot
         /// transformation matrix only if it represents a rotation-reflection.
         /// </summary>
         /// <param name="v">A vector to inversely transform.</param>
-        /// <returns>The inversely transfomed vector.</returns>
+        /// <returns>The inversely transformed vector.</returns>
         public Vector3 XformInv(Vector3 v)
         {
             Vector3 vInv = v - origin;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -181,7 +181,7 @@ namespace Godot
         /// This method does not account for translation (the origin vector).
         /// </summary>
         /// <param name="v">A vector to transform.</param>
-        /// <returns>The transfomed vector.</returns>
+        /// <returns>The transformed vector.</returns>
         public Vector2 BasisXform(Vector2 v)
         {
             return new Vector2(Tdotx(v), Tdoty(v));
@@ -195,7 +195,7 @@ namespace Godot
         /// basis matrix only if it represents a rotation-reflection.
         /// </summary>
         /// <param name="v">A vector to inversely transform.</param>
-        /// <returns>The inversely transfomed vector.</returns>
+        /// <returns>The inversely transformed vector.</returns>
         public Vector2 BasisXformInv(Vector2 v)
         {
             return new Vector2(x.Dot(v), y.Dot(v));
@@ -355,7 +355,7 @@ namespace Godot
         /// Returns a vector transformed (multiplied) by this transformation matrix.
         /// </summary>
         /// <param name="v">A vector to transform.</param>
-        /// <returns>The transfomed vector.</returns>
+        /// <returns>The transformed vector.</returns>
         public Vector2 Xform(Vector2 v)
         {
             return new Vector2(Tdotx(v), Tdoty(v)) + origin;
@@ -365,7 +365,7 @@ namespace Godot
         /// Returns a vector transformed (multiplied) by the inverse transformation matrix.
         /// </summary>
         /// <param name="v">A vector to inversely transform.</param>
-        /// <returns>The inversely transfomed vector.</returns>
+        /// <returns>The inversely transformed vector.</returns>
         public Vector2 XformInv(Vector2 v)
         {
             Vector2 vInv = v - origin;


### PR DESCRIPTION
Changes 'tranfomed' to 'transformed' in several places.
Also 'calcualtion' to 'calculation'.