### PR TITLE
Add multiple programming language support to class reference

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1252,6 +1252,55 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 
 	String bbcode = p_bbcode.dedent().replace("\t", "").replace("\r", "").strip_edges();
 
+	// Select the correct code examples
+	switch ((int)EDITOR_GET("text_editor/help/class_reference_examples")) {
+		case 0: // GDScript
+			bbcode = bbcode.replace("[gdscript]", "[codeblock]");
+			bbcode = bbcode.replace("[/gdscript]", "[/codeblock]");
+
+			for (int pos = bbcode.find("[csharp]"); pos != -1; pos = bbcode.find("[csharp]")) {
+				if (bbcode.find("[/csharp]") == -1) {
+					WARN_PRINT("Unclosed [csharp] block or parse fail in code (search for tag errors)");
+					break;
+				}
+
+				bbcode.erase(pos, bbcode.find("[/csharp]") + 9 - pos);
+				while (bbcode[pos] == '\n') {
+					bbcode.erase(pos, 1);
+				}
+			}
+			break;
+		case 1: // C#
+			bbcode = bbcode.replace("[csharp]", "[codeblock]");
+			bbcode = bbcode.replace("[/csharp]", "[/codeblock]");
+
+			for (int pos = bbcode.find("[gdscript]"); pos != -1; pos = bbcode.find("[gdscript]")) {
+				if (bbcode.find("[/gdscript]") == -1) {
+					WARN_PRINT("Unclosed [gdscript] block or parse fail in code (search for tag errors)");
+					break;
+				}
+
+				bbcode.erase(pos, bbcode.find("[/gdscript]") + 11 - pos);
+				while (bbcode[pos] == '\n') {
+					bbcode.erase(pos, 1);
+				}
+			}
+			break;
+		case 2: // GDScript and C#
+			bbcode = bbcode.replace("[csharp]", "[b]C#:[/b]\n[codeblock]");
+			bbcode = bbcode.replace("[gdscript]", "[b]GDScript:[/b]\n[codeblock]");
+
+			bbcode = bbcode.replace("[/csharp]", "[/codeblock]");
+			bbcode = bbcode.replace("[/gdscript]", "[/codeblock]");
+			break;
+	}
+
+	// Remove codeblocks (they would be printed otherwise)
+	bbcode = bbcode.replace("[codeblocks]\n", "");
+	bbcode = bbcode.replace("\n[/codeblocks]", "");
+	bbcode = bbcode.replace("[codeblocks]", "");
+	bbcode = bbcode.replace("[/codeblocks]", "");
+
 	// remove extra new lines around code blocks
 	bbcode = bbcode.replace("[codeblock]\n", "[codeblock]");
 	bbcode = bbcode.replace("\n[/codeblock]", "[/codeblock]");

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -495,6 +495,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["text_editor/help/help_source_font_size"] = PropertyInfo(Variant::INT, "text_editor/help/help_source_font_size", PROPERTY_HINT_RANGE, "8,48,1");
 	_initial_set("text_editor/help/help_title_font_size", 23);
 	hints["text_editor/help/help_title_font_size"] = PropertyInfo(Variant::INT, "text_editor/help/help_title_font_size", PROPERTY_HINT_RANGE, "8,48,1");
+	_initial_set("text_editor/help/class_reference_examples", 0);
+	hints["text_editor/help/class_reference_examples"] = PropertyInfo(Variant::INT, "text_editor/help/class_reference_examples", PROPERTY_HINT_ENUM, "GDScript,C#,GDScript and C#");
 
 	/* Editors */
 


### PR DESCRIPTION
This adds the possibility to write examples in the class reference in C# and GDScript. It is actually a sideeffect of the wanted effect of having a possiblity to collapse the examples in the documentation. (See https://github.com/godotengine/godot-docs/pull/3824)
The current behaviour is untouched. So using `[codeblock] ... [/codeblock]` behaves as it did before.
However, I made it possible to do the following:
```
[codeblocks]
[gdscript]
var can_shoot2 = true
[/gdscript]
[csharp]
bool can_shoot2 = true;
[/csharp]
[/codeblocks]
```

In the online class reference will that be rendered as:
![Online](https://user-images.githubusercontent.com/14185889/88227949-b1d1b180-cc6e-11ea-9633-3634eb5e575f.gif)

**text_editor/help/class_reference_examples: GDScript**
![grafik](https://user-images.githubusercontent.com/14185889/88272050-65bb5700-ccd8-11ea-98be-2b2125958c56.png)

**text_editor/help/class_reference_examples: C#**
![grafik](https://user-images.githubusercontent.com/14185889/88272111-7c61ae00-ccd8-11ea-90cf-0411b7f6daee.png)

**text_editor/help/class_reference_examples: GDScript and C#**
![grafik](https://user-images.githubusercontent.com/14185889/88272151-8e435100-ccd8-11ea-817b-791703c5427c.png)


It would be nice, if the `[gdscript]` and `[csharp]` tags could be used outside of codeblocks, but this will break the online reference. I will see if I find a way to set the programming language globally in the online class reference too. This would be useful to state binding specific differences which are currently [here](https://docs.godotengine.org/en/latest/getting_started/scripting/c_sharp/c_sharp_differences.html). Nonetheless that is probably a different PR.

I will start adding examples to the class reference once verified.
I remember having read about this feature somewhere and reduz stated that in IRC.