### PR TITLE
gitignore: Ignore binutils linker temp stXXXXXX objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ platform/android/java/lib/.cxx/*
 *.os
 *.Plo
 *.lo
+# Binutils tmp linker output of the form "stXXXXXX" where "X" is alphanumeric
+st[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]
 
 # Libs generated files
 .deps/*


### PR DESCRIPTION
Fixes #40607.