### PR TITLE
Expose ENet statistics and throttle configuration

### DIFF
--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -818,6 +818,116 @@ bool NetworkedMultiplayerENet::is_server_relay_enabled() const {
 	return server_relay;
 }
 
+real_t NetworkedMultiplayerENet::get_packet_loss(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0.0);
+	// Packet loss of reliable packets.
+	return static_cast<real_t>(peer_map[p_peer]->packetLoss) / static_cast<real_t>(ENET_PEER_PACKET_LOSS_SCALE);
+}
+
+real_t NetworkedMultiplayerENet::get_packet_loss_variance(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0.0);
+	// Packet loss of reliable packets.
+	return static_cast<real_t>(peer_map[p_peer]->packetLossVariance) / static_cast<real_t>(ENET_PEER_PACKET_LOSS_SCALE);
+}
+
+uint32_t NetworkedMultiplayerENet::get_packet_loss_epoch(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0);
+	// Packet loss of reliable packets.
+	return peer_map[p_peer]->packetLossEpoch;
+}
+
+uint32_t NetworkedMultiplayerENet::get_round_trip_time(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0);
+	// Packet loss of reliable packets.
+	return peer_map[p_peer]->roundTripTime;
+}
+
+uint32_t NetworkedMultiplayerENet::get_round_trip_time_variance(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0);
+	// Packet loss of reliable packets.
+	return peer_map[p_peer]->roundTripTimeVariance;
+}
+
+uint32_t NetworkedMultiplayerENet::get_last_round_trip_time(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0);
+	// Packet loss of reliable packets.
+	return peer_map[p_peer]->lastRoundTripTime;
+}
+
+uint32_t NetworkedMultiplayerENet::get_packet_throttle(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0);
+	return peer_map[p_peer]->packetThrottle;
+}
+
+uint32_t NetworkedMultiplayerENet::get_packet_throttle_limit(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0);
+	return peer_map[p_peer]->packetThrottleLimit;
+}
+
+uint32_t NetworkedMultiplayerENet::get_packet_throttle_counter(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0);
+	return peer_map[p_peer]->packetThrottleCounter;
+}
+
+uint32_t NetworkedMultiplayerENet::get_packet_throttle_epoch(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0);
+	return peer_map[p_peer]->packetThrottleEpoch;
+}
+
+uint32_t NetworkedMultiplayerENet::get_packet_throttle_acceleration(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0);
+	return peer_map[p_peer]->packetThrottleAcceleration;
+}
+
+uint32_t NetworkedMultiplayerENet::get_packet_throttle_deceleration(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0);
+	return peer_map[p_peer]->packetThrottleDeceleration;
+}
+
+uint32_t NetworkedMultiplayerENet::get_packet_throttle_interval(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0);
+	return peer_map[p_peer]->packetThrottleInterval;
+}
+
+uint32_t NetworkedMultiplayerENet::get_last_round_trip_time_variance(int p_peer) const {
+	ERR_FAIL_COND_V(peer_map.has(p_peer) == false, 0);
+	// Packet loss of reliable packets.
+	return peer_map[p_peer]->lastRoundTripTimeVariance;
+}
+
+uint32_t NetworkedMultiplayerENet::pop_total_sent_data() {
+	ERR_FAIL_COND_V(host == nullptr, 0);
+	const uint32_t tsd = host->totalSentData;
+	host->totalSentData = 0;
+	return tsd;
+}
+
+uint32_t NetworkedMultiplayerENet::pop_total_sent_packets() {
+	ERR_FAIL_COND_V(host == nullptr, 0);
+	const uint32_t tsp = host->totalSentPackets;
+	host->totalSentPackets = 0;
+	return tsp;
+}
+
+uint32_t NetworkedMultiplayerENet::pop_total_received_data() {
+	ERR_FAIL_COND_V(host == nullptr, 0);
+	const uint32_t trd = host->totalReceivedData;
+	host->totalReceivedData = 0;
+	return trd;
+}
+
+uint32_t NetworkedMultiplayerENet::pop_total_received_packets() {
+	ERR_FAIL_COND_V(host == nullptr, 0);
+	const uint32_t trp = host->totalReceivedPackets;
+	host->totalReceivedPackets = 0;
+	return trp;
+}
+
+void NetworkedMultiplayerENet::configure_peer_throttle(int p_peer, uint32_t p_interval, uint32_t p_acceleration, uint32_t p_deceleration) {
+	ERR_FAIL_COND(peer_map.has(p_peer) == false);
+	enet_peer_throttle_configure(peer_map[p_peer], p_interval, p_acceleration, p_deceleration);
+}
+
 void NetworkedMultiplayerENet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_server", "port", "max_clients", "in_bandwidth", "out_bandwidth"), &NetworkedMultiplayerENet::create_server, DEFVAL(32), DEFVAL(0), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("create_client", "address", "port", "in_bandwidth", "out_bandwidth", "client_port"), &NetworkedMultiplayerENet::create_client, DEFVAL(0), DEFVAL(0), DEFVAL(0));
@@ -845,6 +955,30 @@ void NetworkedMultiplayerENet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_always_ordered"), &NetworkedMultiplayerENet::is_always_ordered);
 	ClassDB::bind_method(D_METHOD("set_server_relay_enabled", "enabled"), &NetworkedMultiplayerENet::set_server_relay_enabled);
 	ClassDB::bind_method(D_METHOD("is_server_relay_enabled"), &NetworkedMultiplayerENet::is_server_relay_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_packet_loss", "peer"), &NetworkedMultiplayerENet::get_packet_loss);
+	ClassDB::bind_method(D_METHOD("get_packet_loss_variance", "peer"), &NetworkedMultiplayerENet::get_packet_loss_variance);
+	ClassDB::bind_method(D_METHOD("get_packet_loss_epoch", "peer"), &NetworkedMultiplayerENet::get_packet_loss_epoch);
+
+	ClassDB::bind_method(D_METHOD("get_round_trip_time", "peer"), &NetworkedMultiplayerENet::get_round_trip_time);
+	ClassDB::bind_method(D_METHOD("get_round_trip_time_variance", "peer"), &NetworkedMultiplayerENet::get_round_trip_time_variance);
+	ClassDB::bind_method(D_METHOD("get_last_round_trip_time", "peer"), &NetworkedMultiplayerENet::get_last_round_trip_time);
+	ClassDB::bind_method(D_METHOD("get_last_round_trip_time_variance", "peer"), &NetworkedMultiplayerENet::get_last_round_trip_time);
+
+	ClassDB::bind_method(D_METHOD("get_packet_throttle", "peer"), &NetworkedMultiplayerENet::get_packet_throttle);
+	ClassDB::bind_method(D_METHOD("get_packet_throttle_limit", "peer"), &NetworkedMultiplayerENet::get_packet_throttle_limit);
+	ClassDB::bind_method(D_METHOD("get_packet_throttle_counter", "peer"), &NetworkedMultiplayerENet::get_packet_throttle_counter);
+	ClassDB::bind_method(D_METHOD("get_packet_throttle_epoch", "peer"), &NetworkedMultiplayerENet::get_packet_throttle_epoch);
+	ClassDB::bind_method(D_METHOD("get_packet_throttle_acceleration", "peer"), &NetworkedMultiplayerENet::get_packet_throttle_acceleration);
+	ClassDB::bind_method(D_METHOD("get_packet_throttle_deceleration", "peer"), &NetworkedMultiplayerENet::get_packet_throttle_deceleration);
+	ClassDB::bind_method(D_METHOD("get_packet_throttle_interval", "peer"), &NetworkedMultiplayerENet::get_packet_throttle_interval);
+
+	ClassDB::bind_method(D_METHOD("pop_total_sent_data"), &NetworkedMultiplayerENet::pop_total_sent_data);
+	ClassDB::bind_method(D_METHOD("pop_total_sent_packets"), &NetworkedMultiplayerENet::pop_total_sent_packets);
+	ClassDB::bind_method(D_METHOD("pop_total_received_data"), &NetworkedMultiplayerENet::pop_total_received_data);
+	ClassDB::bind_method(D_METHOD("pop_total_received_packets"), &NetworkedMultiplayerENet::pop_total_received_packets);
+
+	ClassDB::bind_method(D_METHOD("configure_peer_throttle", "peer", "interval", "acceleration", "deceleration"), &NetworkedMultiplayerENet::configure_peer_throttle);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "compression_mode", PROPERTY_HINT_ENUM, "None,Range Coder,FastLZ,ZLib,ZStd"), "set_compression_mode", "get_compression_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "transfer_channel"), "set_transfer_channel", "get_transfer_channel");

--- a/modules/enet/networked_multiplayer_enet.h
+++ b/modules/enet/networked_multiplayer_enet.h
@@ -166,6 +166,66 @@ public:
 	void set_server_relay_enabled(bool p_enabled);
 	bool is_server_relay_enabled() const;
 
+	/// Reliable channel packet loss.
+	real_t get_packet_loss(int p_peer) const;
+	real_t get_packet_loss_variance(int p_peer) const;
+	/// The epoch of the current packet loss.
+	uint32_t get_packet_loss_epoch(int p_peer) const;
+
+	/// Mean - Time taken for a reliable packet to do a round trip in ms.
+	uint32_t get_round_trip_time(int p_peer) const;
+	uint32_t get_round_trip_time_variance(int p_peer) const;
+	/// Last packet - Time taken for a reliable packet to do a round trip in ms.
+	uint32_t get_last_round_trip_time(int p_peer) const;
+	uint32_t get_last_round_trip_time_variance(int p_peer) const;
+
+	uint32_t get_packet_throttle(int p_peer) const;
+	uint32_t get_packet_throttle_limit(int p_peer) const;
+	uint32_t get_packet_throttle_counter(int p_peer) const;
+	uint32_t get_packet_throttle_epoch(int p_peer) const;
+	uint32_t get_packet_throttle_acceleration(int p_peer) const;
+	uint32_t get_packet_throttle_deceleration(int p_peer) const;
+	uint32_t get_packet_throttle_interval(int p_peer) const;
+
+	/// Returns the total data sent from last time this function was called.
+	uint32_t pop_total_sent_data();
+	/// Returns the total packets sent from last time this function was called.
+	uint32_t pop_total_sent_packets();
+	/// Returns the total data received from last time this function was called.
+	uint32_t pop_total_received_data();
+	/// Returns the total packets received from last time this function was called.
+	uint32_t pop_total_received_packets();
+
+	/// Configures throttle parameter for a peer.
+	///
+	/// Unreliable packets are dropped by ENet in response to the varying conditions
+	/// of the Internet connection to the peer.  The throttle represents a probability
+	/// that an unreliable packet should not be dropped and thus sent by ENet to the peer.
+	/// The lowest mean round trip time from the sending of a reliable packet to the
+	/// receipt of its acknowledgement is measured over an amount of time specified by
+	/// the interval parameter in milliseconds.  If a measured round trip time happens to
+	/// be significantly less than the mean round trip time measured over the interval,
+	/// then the throttle probability is increased to allow more traffic by an amount
+	/// specified in the acceleration parameter, which is a ratio to the ENET_PEER_PACKET_THROTTLE_SCALE
+	/// constant.  If a measured round trip time happens to be significantly greater than
+	/// the mean round trip time measured over the interval, then the throttle probability
+	/// is decreased to limit traffic by an amount specified in the deceleration parameter, which
+	/// is a ratio to the ENET_PEER_PACKET_THROTTLE_SCALE constant.  When the throttle has
+	/// a value of ENET_PEER_PACKET_THROTTLE_SCALE, no unreliable packets are dropped by
+	/// ENet, and so 100% of all unreliable packets will be sent.  When the throttle has a
+	/// value of 0, all unreliable packets are dropped by ENet, and so 0% of all unreliable
+	/// packets will be sent.  Intermediate values for the throttle represent intermediate
+	/// probabilities between 0% and 100% of unreliable packets being sent.  The bandwidth
+	/// limits of the local and foreign hosts are taken into account to determine a
+	/// sensible limit for the throttle probability above which it should not raise even in
+	/// the best of conditions.
+	///
+	/// @param peer peer to configure.
+	/// @param interval interval, in milliseconds, over which to measure lowest mean RTT; the default value is ENET_PEER_PACKET_THROTTLE_INTERVAL.
+	/// @param acceleration rate at which to increase the throttle probability as mean RTT declines
+	/// @param deceleration rate at which to decrease the throttle probability as mean RTT increases
+	void configure_peer_throttle(int p_peer, uint32_t p_interval, uint32_t p_acceleration, uint32_t p_deceleration);
+
 	NetworkedMultiplayerENet();
 	~NetworkedMultiplayerENet();
 


### PR DESCRIPTION
- Exposed ENet stats
- Exposed ENet throttle config

Useful to obtain stats like:
```
- Loss: 0.112915%  
- Loss variance: 0.192261%  
- Ping: 15ms  
- Ping variance: 15ms  
- Throttle: 32
- Total sent data: 682202bytes 
- Total received data: 682202bytes
```

This work has been kindly sponsored by IMVU.
