### PR TITLE
Print build info used when using godot --build-info

### DIFF
--- a/main/SCsub
+++ b/main/SCsub
@@ -3,6 +3,8 @@
 Import("env")
 
 import main_builders
+import sys
+import os
 
 env.main_sources = []
 
@@ -36,3 +38,16 @@ env_main.CommandNoCache(
 
 lib = env_main.add_library("main", env.main_sources)
 env.Prepend(LIBS=[lib])
+
+build_args = " ".join(sys.argv[1:])
+
+SCONSFLAGS = os.environ.get("SCONSFLAGS")
+if SCONSFLAGS:
+    build_args = SCONSFLAGS + " " + build_args
+
+with open("build_arguments.gen.h", "w") as fd:
+    fd.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+    fd.write("#ifndef BUILD_ARGUMENTS_GEN_H\n")
+    fd.write("#define BUILD_ARGUMENTS_GEN_H\n")
+    fd.write('#define BUILD_ARGUMENTS "' + build_args + '"\n')
+    fd.write("#endif // BUILD_ARGUMENTS_GEN_H\n")

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -53,6 +53,7 @@
 #include "core/version_hash.gen.h"
 #include "drivers/register_driver_types.h"
 #include "main/app_icon.gen.h"
+#include "main/build_arguments.gen.h"
 #include "main/main_timer_sync.h"
 #include "main/performance.h"
 #include "main/splash.gen.h"
@@ -645,6 +646,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 		} else if (I->get() == "--version") {
 			print_line(get_full_version_string());
+			goto error;
+
+		} else if (I->get() == "--build-info") {
+			print_line(get_full_version_string());
+			print_line("Build arguments: " + String(BUILD_ARGUMENTS));
 			goto error;
 
 		} else if (I->get() == "-v" || I->get() == "--verbose") { // verbose output


### PR DESCRIPTION
Print build arguments used when using `godot --version`.
I couldn't find how official builds are generated without hashes so that part is still not done.

*Bugsquad edit: This partially addresses #28617.*