### PR TITLE
Expose bookmark, breakpoint, and mark safe functions in TextEdit

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -262,6 +262,33 @@
 				Returns whether the line at the specified index is hidden or not.
 			</description>
 		</method>
+		<method name="is_line_set_as_bookmark" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<description>
+				Returns [code]true[/code] when the specified [code]line[/code] is bookmarked.
+			</description>
+		</method>
+		<method name="is_line_set_as_breakpoint" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<description>
+				Returns [code]true[/code] when the specified [code]line[/code] has a breakpoint.
+			</description>
+		</method>
+		<method name="is_line_set_as_safe" qualifiers="const">
+			<return type="bool">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<description>
+				Returns [code]true[/code] when the specified [code]line[/code] is marked as safe.
+			</description>
+		</method>
 		<method name="is_selection_active" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -357,6 +384,29 @@
 				Sets the text for a specific line.
 			</description>
 		</method>
+		<method name="set_line_as_bookmark">
+			<return type="void">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="bookmark" type="bool">
+			</argument>
+			<description>
+				Bookmarks the [code]line[/code] if [code]bookmark[/code] is true. Deletes the bookmark if [code]bookmark[/code] is false.
+				Bookmarks are shown in the [member breakpoint_gutter].
+			</description>
+		</method>
+		<method name="set_line_as_breakpoint">
+			<return type="void">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="breakpoint" type="bool">
+			</argument>
+			<description>
+				Adds or removes the breakpoint in [code]line[/code]. Breakpoints are shown in the [member breakpoint_gutter].
+			</description>
+		</method>
 		<method name="set_line_as_hidden">
 			<return type="void">
 			</return>
@@ -366,6 +416,18 @@
 			</argument>
 			<description>
 				If [code]true[/code], hides the line of the specified index.
+			</description>
+		</method>
+		<method name="set_line_as_safe">
+			<return type="void">
+			</return>
+			<argument index="0" name="line" type="int">
+			</argument>
+			<argument index="1" name="safe" type="bool">
+			</argument>
+			<description>
+				If [code]true[/code], marks the [code]line[/code] as safe.
+				This will show the line number with the color provided in the [code]safe_line_number_color[/code] theme property.
 			</description>
 		</method>
 		<method name="toggle_fold_line">

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7085,6 +7085,12 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_virtual_keyboard_enabled"), &TextEdit::is_virtual_keyboard_enabled);
 	ClassDB::bind_method(D_METHOD("set_selecting_enabled", "enable"), &TextEdit::set_selecting_enabled);
 	ClassDB::bind_method(D_METHOD("is_selecting_enabled"), &TextEdit::is_selecting_enabled);
+	ClassDB::bind_method(D_METHOD("is_line_set_as_safe", "line"), &TextEdit::is_line_set_as_safe);
+	ClassDB::bind_method(D_METHOD("set_line_as_safe", "line", "safe"), &TextEdit::set_line_as_safe);
+	ClassDB::bind_method(D_METHOD("is_line_set_as_bookmark", "line"), &TextEdit::is_line_set_as_bookmark);
+	ClassDB::bind_method(D_METHOD("set_line_as_bookmark", "line", "bookmark"), &TextEdit::set_line_as_bookmark);
+	ClassDB::bind_method(D_METHOD("set_line_as_breakpoint", "line", "breakpoint"), &TextEdit::set_line_as_breakpoint);
+	ClassDB::bind_method(D_METHOD("is_line_set_as_breakpoint", "line"), &TextEdit::is_line_set_as_breakpoint);
 
 	ClassDB::bind_method(D_METHOD("cut"), &TextEdit::cut);
 	ClassDB::bind_method(D_METHOD("copy"), &TextEdit::copy);


### PR DESCRIPTION
I am working on tool and need those functions exposed. I think they should be exposed, because they are public methods and you can even set the theme properties for them. There is a lot more to expose still...