### PR TITLE
Add C# Editor Documentation

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -177,6 +177,20 @@ void EditorHelp::_class_desc_resized() {
 	class_desc->add_theme_style_override("normal", class_desc_stylebox);
 }
 
+String EditorHelp::_convert_case(const String &p_name) {
+	switch ((int)EDITOR_GET("text_editor/help/class_reference_language")) {
+		case 0: // GDScript
+			return p_name;
+		case 1: {
+			// C#
+			bool first_is_underscore = p_name[0] == '_';
+			String result = p_name.capitalize();
+			return (first_is_underscore ? "_" : "") + result.replace(" ", "");
+		}
+	}
+	return p_name;
+}
+
 void EditorHelp::_add_type(const String &p_type, const String &p_enum) {
 	String t = p_type;
 	if (t.empty()) {
@@ -263,7 +277,7 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 	}
 
 	class_desc->push_color(headline_color);
-	_add_text(p_method.name);
+	_add_text(_convert_case(p_method.name));
 	class_desc->pop();
 
 	if (p_overview && p_method.description != "") {
@@ -558,7 +572,7 @@ void EditorHelp::_update_doc() {
 				class_desc->push_meta("@member " + cd.properties[i].name);
 			}
 
-			_add_text(cd.properties[i].name);
+			_add_text(_convert_case(cd.properties[i].name));
 
 			if (describe) {
 				class_desc->pop();
@@ -1013,7 +1027,7 @@ void EditorHelp::_update_doc() {
 			class_desc->push_cell();
 			class_desc->push_font(doc_code_font);
 			class_desc->push_color(headline_color);
-			_add_text(cd.properties[i].name);
+			_add_text(_convert_case(cd.properties[i].name));
 			class_desc->pop(); // color
 
 			if (cd.properties[i].default_value != "") {
@@ -1048,10 +1062,10 @@ void EditorHelp::_update_doc() {
 				if (method_map[cd.properties[i].setter].arguments.size() > 1) {
 					// Setters with additional arguments are exposed in the method list, so we link them here for quick access.
 					class_desc->push_meta("@method " + cd.properties[i].setter);
-					class_desc->add_text(cd.properties[i].setter + TTR("(value)"));
+					class_desc->add_text(_convert_case(cd.properties[i].setter) + TTR("(value)"));
 					class_desc->pop();
 				} else {
-					class_desc->add_text(cd.properties[i].setter + TTR("(value)"));
+					class_desc->add_text(_convert_case(cd.properties[i].setter) + TTR("(value)"));
 				}
 				class_desc->pop(); // color
 				class_desc->push_color(comment_color);
@@ -1072,10 +1086,10 @@ void EditorHelp::_update_doc() {
 				if (method_map[cd.properties[i].getter].arguments.size() > 0) {
 					// Getters with additional arguments are exposed in the method list, so we link them here for quick access.
 					class_desc->push_meta("@method " + cd.properties[i].getter);
-					class_desc->add_text(cd.properties[i].getter + "()");
+					class_desc->add_text(_convert_case(cd.properties[i].getter) + "()");
 					class_desc->pop();
 				} else {
-					class_desc->add_text(cd.properties[i].getter + "()");
+					class_desc->add_text(_convert_case(cd.properties[i].getter) + "()");
 				}
 				class_desc->pop(); //color
 				class_desc->push_color(comment_color);
@@ -1251,6 +1265,55 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 	Color kbd_color = accent_color.lerp(property_color, 0.6);
 
 	String bbcode = p_bbcode.dedent().replace("\t", "").replace("\r", "").strip_edges();
+
+	// Select the correct code examples
+	switch ((int)EDITOR_GET("text_editor/help/class_reference_examples")) {
+		case 0: // GDScript
+			bbcode = bbcode.replace("[gdscript]", "[codeblock]");
+			bbcode = bbcode.replace("[/gdscript]", "[/codeblock]");
+
+			for (int pos = bbcode.find("[csharp]"); pos != -1; pos = bbcode.find("[csharp]")) {
+				if (bbcode.find("[/csharp]") == -1) {
+					WARN_PRINT("Unclosed [csharp] block or parse fail in code (search for tag errors)");
+					break;
+				}
+
+				bbcode.erase(pos, bbcode.find("[/csharp]") + 9 - pos);
+				while (bbcode[pos] == '\n') {
+					bbcode.erase(pos, 1);
+				}
+			}
+			break;
+		case 1: // C#
+			bbcode = bbcode.replace("[csharp]", "[codeblock]");
+			bbcode = bbcode.replace("[/csharp]", "[/codeblock]");
+
+			for (int pos = bbcode.find("[gdscript]"); pos != -1; pos = bbcode.find("[gdscript]")) {
+				if (bbcode.find("[/gdscript]") == -1) {
+					WARN_PRINT("Unclosed [gdscript] block or parse fail in code (search for tag errors)");
+					break;
+				}
+
+				bbcode.erase(pos, bbcode.find("[/gdscript]") + 11 - pos);
+				while (bbcode[pos] == '\n') {
+					bbcode.erase(pos, 1);
+				}
+			}
+			break;
+		case 2: // GDScript and C#
+			bbcode = bbcode.replace("[csharp]", "[b]C#:[/b]\n[codeblock]");
+			bbcode = bbcode.replace("[gdscript]", "[b]GDScript:[/b]\n[codeblock]");
+
+			bbcode = bbcode.replace("[/csharp]", "[/codeblock]");
+			bbcode = bbcode.replace("[/gdscript]", "[/codeblock]");
+			break;
+	}
+
+	// Remove codeblocks (they would be printed otherwise)
+	bbcode = bbcode.replace("[codeblocks]\n", "");
+	bbcode = bbcode.replace("\n[/codeblocks]", "");
+	bbcode = bbcode.replace("[codeblocks]", "");
+	bbcode = bbcode.replace("[/codeblocks]", "");
 
 	// remove extra new lines around code blocks
 	bbcode = bbcode.replace("[codeblock]\n", "[codeblock]");

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -152,6 +152,8 @@ class EditorHelp : public VBoxContainer {
 	void _class_desc_input(const Ref<InputEvent> &p_input);
 	void _class_desc_resized();
 
+	String _convert_case(const String &p_name);
+
 	Error _goto_desc(const String &p_class, int p_vscr = -1);
 	//void _update_history_buttons();
 	void _update_doc();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -495,6 +495,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["text_editor/help/help_source_font_size"] = PropertyInfo(Variant::INT, "text_editor/help/help_source_font_size", PROPERTY_HINT_RANGE, "8,48,1");
 	_initial_set("text_editor/help/help_title_font_size", 23);
 	hints["text_editor/help/help_title_font_size"] = PropertyInfo(Variant::INT, "text_editor/help/help_title_font_size", PROPERTY_HINT_RANGE, "8,48,1");
+	_initial_set("text_editor/help/class_reference_language", 0);
+	hints["text_editor/help/class_reference_language"] = PropertyInfo(Variant::INT, "text_editor/help/class_reference_language", PROPERTY_HINT_ENUM, "GDScript,C#");
+	_initial_set("text_editor/help/class_reference_examples", 0);
+	hints["text_editor/help/class_reference_examples"] = PropertyInfo(Variant::INT, "text_editor/help/class_reference_examples", PROPERTY_HINT_ENUM, "GDScript,C#,GDScript and C#");
 
 	/* Editors */
 


### PR DESCRIPTION
The user can select, how the reference should be rendered in the editor settings.
**text_editor/help/class_reference_language: GDScript**
![grafik](https://user-images.githubusercontent.com/14185889/88271752-eb8ad280-ccd7-11ea-8f64-398f6838e187.png)

**text_editor/help/class_reference_language: C#**
![grafik](https://user-images.githubusercontent.com/14185889/88271874-20972500-ccd8-11ea-8bfd-302b733e4a1d.png)

The conversion to PascalCase is done automatically.

This is moved out of #40613 