### PR TITLE
Update resource paths before updating dependencies

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1352,9 +1352,9 @@ void FileSystemDock::_rename_operation_confirm() {
 	_try_move_item(to_rename, new_path, file_renames, folder_renames);
 
 	int current_tab = editor->get_current_tab();
-	_save_scenes_after_move(file_renames); // save scenes before updating
-	_update_dependencies_after_move(file_renames);
+	_save_scenes_after_move(file_renames); // Save scenes before updating.
 	_update_resource_paths_after_move(file_renames);
+	_update_dependencies_after_move(file_renames);
 	_update_project_settings_after_move(file_renames);
 	_update_favorites_list_after_move(file_renames, folder_renames);
 
@@ -1457,8 +1457,8 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_ove
 	if (is_moved) {
 		int current_tab = editor->get_current_tab();
 		_save_scenes_after_move(file_renames); // Save scenes before updating.
-		_update_dependencies_after_move(file_renames);
 		_update_resource_paths_after_move(file_renames);
+		_update_dependencies_after_move(file_renames);
 		_update_project_settings_after_move(file_renames);
 		_update_favorites_list_after_move(file_renames, folder_renames);
 


### PR DESCRIPTION
Fixes #27635.

Dependencies can only be resolved properly by having valid resource paths in the first place (?)

