### PR TITLE
Fix emoji branch compilation error

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -92,7 +92,7 @@ def update_version(module_version_string=""):
             gitfolder = module_folder[8:]
 
     if os.path.isfile(os.path.join(gitfolder, "HEAD")):
-        head = open(os.path.join(gitfolder, "HEAD"), "r").readline().strip()
+        head = open(os.path.join(gitfolder, "HEAD"), "r", encoding="utf8").readline().strip()
         if head.startswith("ref: "):
             head = os.path.join(gitfolder, head[5:])
             if os.path.isfile(head):


### PR DESCRIPTION
When trying to build a branch with emoji in name, an error appears:
```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x83 in position 19: character maps to <undefined>:
  File "X:\Inne\Godot\Source\godot\SConstruct", line 568:
    methods.update_version(env.module_version_string)
  File "X:\Inne\Godot\Source\godot\methods.py", line 95:
    head = open(os.path.join(gitfolder, "HEAD"), "r").readline().strip()
  File "C:\Python\lib\encodings\cp1250.py", line 23:
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
```
(could be Windows-specific)


This PR fixes it.