### PR TITLE
Skip internal scripts for breakpoints without printing an error

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1577,7 +1577,9 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 		List<int> bpoints;
 		se->get_breakpoints(&bpoints);
 		String base = script->get_path();
-		ERR_CONTINUE(base.begins_with("local://") || base == "");
+		if (base.begins_with("local://") || base == "") {
+			continue;
+		}
 
 		for (List<int>::Element *E = bpoints.front(); E; E = E->next()) {
 			p_breakpoints->push_back(base + ":" + itos(E->get() + 1));


### PR DESCRIPTION
Closes #35211.

This removes:
```
ERROR: get_breakpoints: Condition ' base.begins_with("local://")
```
while running a project with blank scripts caused by deleting (#33313) or moving (#27635), or built-in scripts which are not yet saved within a scene on running a project.

This simply prevents the error to be printed. The check for internal scripts is handled without printing any errors in other places within the plugin already, I don't see why this should print an error here (I've always found it annoying from "Day 1" I started using Godot).

This part of code predates the time Godot was made open-source.
