### PR TITLE
Lower MSVC cache limit

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 # SCONS_CACHE for windows must be set in the build environment
 env:
   SCONS_CACHE_MSVC_CONFIG: true
-  SCONS_CACHE_LIMIT: 8192
+  SCONS_CACHE_LIMIT: 4096
 
 jobs:
   windows-editor:


### PR DESCRIPTION
This will orphan older cache files - we need to do this to resolve the disk space issue on windows, this is windows specific issue