### PR TITLE
Fix one-way collision for moving objects

### DIFF
--- a/servers/physics_2d/body_pair_2d_sw.cpp
+++ b/servers/physics_2d/body_pair_2d_sw.cpp
@@ -295,17 +295,15 @@ bool BodyPair2DSW::setup(real_t p_step) {
 		if (A->is_shape_set_as_one_way_collision(shape_A)) {
 			Vector2 direction = xform_A.get_axis(1).normalized();
 			bool valid = false;
-			if (B->get_linear_velocity().dot(direction) >= 0) {
-				for (int i = 0; i < contact_count; i++) {
-					Contact &c = contacts[i];
-					if (!c.reused)
-						continue;
-					if (c.normal.dot(direction) > 0) //greater (normal inverted)
-						continue;
+			for (int i = 0; i < contact_count; i++) {
+				Contact &c = contacts[i];
+				if (!c.reused)
+					continue;
+				if (c.normal.dot(direction) > 0) //greater (normal inverted)
+					continue;
 
-					valid = true;
-					break;
-				}
+				valid = true;
+				break;
 			}
 
 			if (!valid) {
@@ -318,17 +316,15 @@ bool BodyPair2DSW::setup(real_t p_step) {
 		if (B->is_shape_set_as_one_way_collision(shape_B)) {
 			Vector2 direction = xform_B.get_axis(1).normalized();
 			bool valid = false;
-			if (A->get_linear_velocity().dot(direction) >= 0) {
-				for (int i = 0; i < contact_count; i++) {
-					Contact &c = contacts[i];
-					if (!c.reused)
-						continue;
-					if (c.normal.dot(direction) < 0) //less (normal ok)
-						continue;
+			for (int i = 0; i < contact_count; i++) {
+				Contact &c = contacts[i];
+				if (!c.reused)
+					continue;
+				if (c.normal.dot(direction) < 0) //less (normal ok)
+					continue;
 
-					valid = true;
-					break;
-				}
+				valid = true;
+				break;
 			}
 			if (!valid) {
 				collided = false;

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -174,16 +174,8 @@ void Physics2DServerSW::_shape_col_cbk(const Vector2 &p_point_A, const Vector2 &
 		}
 		Vector2 rel_dir = (p_point_A - p_point_B).normalized();
 
-		if (cbk->valid_dir.dot(rel_dir) < Math_SQRT12) { //sqrt(2)/2.0 - 45 degrees
+		if (rel_dir != Vector2() && cbk->valid_dir.dot(rel_dir) <= 0) {
 			cbk->invalid_by_dir++;
-
-			/*
-			print_line("A: "+p_point_A);
-			print_line("B: "+p_point_B);
-			print_line("discard too angled "+rtos(cbk->valid_dir.dot((p_point_A-p_point_B))));
-			print_line("resnorm: "+(p_point_A-p_point_B).normalized());
-			print_line("distance: "+rtos(p_point_A.distance_to(p_point_B)));
-			*/
 			return;
 		}
 	}

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -167,14 +167,14 @@ void Physics2DServerSW::_shape_col_cbk(const Vector2 &p_point_A, const Vector2 &
 	if (cbk->max == 0)
 		return;
 
-	if (cbk->valid_dir != Vector2()) {
+	Vector2 rel_dir = (p_point_A - p_point_B).normalized();
+	if (cbk->valid_dir != Vector2() && rel_dir != Vector2() && cbk->valid_depth < 10e20) {
 		if (p_point_A.distance_squared_to(p_point_B) > cbk->valid_depth * cbk->valid_depth) {
 			cbk->invalid_by_dir++;
 			return;
 		}
-		Vector2 rel_dir = (p_point_A - p_point_B).normalized();
 
-		if (rel_dir != Vector2() && cbk->valid_dir.dot(rel_dir) <= 0) {
+		if (cbk->valid_dir.dot(rel_dir) <= 0) {
 			cbk->invalid_by_dir++;
 			return;
 		}

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -794,6 +794,11 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 						float owc_margin = col_obj->get_shape_one_way_collision_margin(shape_idx);
 						cbk.valid_depth = MAX(owc_margin, p_margin); //user specified, but never less than actual margin or it won't work
 
+						//we need take out own movement into account
+						Vector2 a_motion = p_motion;
+						float a_depth = a_motion.dot(cbk.valid_dir);
+						cbk.valid_depth += a_depth;
+
 						if (col_obj->get_type() == CollisionObject2DSW::TYPE_BODY) {
 							const Body2DSW *b = static_cast<const Body2DSW *>(col_obj);
 							if (b->get_mode() == Physics2DServer::BODY_MODE_KINEMATIC || b->get_mode() == Physics2DServer::BODY_MODE_RIGID) {
@@ -802,12 +807,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 								//compute displacement from linear velocity
 								Vector2 b_motion = lv * Physics2DDirectBodyStateSW::singleton->step;
 								float b_depth = b_motion.dot(-cbk.valid_dir);
-								cbk.valid_depth += MAX(b_depth, 0.0);
-
-								//we need take out own movement into account
-								Vector2 a_motion = p_motion;
-								float a_depth = MAX(a_motion.dot(-cbk.valid_dir), 0.0);
-								cbk.valid_depth += a_depth;
+								cbk.valid_depth += b_depth;
 							}
 						}
 					} else {


### PR DESCRIPTION
This is 3.2 twin of https://github.com/godotengine/godot/pull/36280

Physics seems somewhat broken in `master` branch (see my comment [here](https://github.com/godotengine/godot/pull/36280#issuecomment-663190860)), so I created this one to avoid constant rebasing back and forth in order to get a working build.

Freshly build binaries can be found [here](https://pepya.tk/nextcloud/index.php/s/3Bqbfe7EMsrE9px)