### PR TITLE
Make unsaved scripts in the script editor more user-friendly

### DIFF
--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -371,6 +371,8 @@ class ScriptEditor : public PanelContainer {
 
 	void _save_layout();
 	void _editor_settings_changed();
+	void _filesystem_changed();
+	void _file_removed(const String &p_file);
 	void _autosave_scripts();
 	void _update_autosave_timer();
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -338,7 +338,10 @@ void ScriptTextEditor::update_settings() {
 }
 
 bool ScriptTextEditor::is_unsaved() {
-	return code_editor->get_text_edit()->get_version() != code_editor->get_text_edit()->get_saved_version();
+	const bool unsaved =
+			code_editor->get_text_edit()->get_version() != code_editor->get_text_edit()->get_saved_version() ||
+			script->get_path().empty(); // In memory.
+	return unsaved;
 }
 
 Variant ScriptTextEditor::get_edit_state() {
@@ -415,6 +418,9 @@ String ScriptTextEditor::get_name() {
 	if (script->get_path().find("local://") == -1 && script->get_path().find("::") == -1) {
 		name = script->get_path().get_file();
 		if (is_unsaved()) {
+			if (script->get_path().empty()) {
+				name = TTR("[unsaved]");
+			}
 			name += "(*)";
 		}
 	} else if (script->get_name() != "") {

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -119,6 +119,9 @@ String TextEditor::get_name() {
 	if (text_file->get_path().find("local://") == -1 && text_file->get_path().find("::") == -1) {
 		name = text_file->get_path().get_file();
 		if (is_unsaved()) {
+			if (text_file->get_path().empty()) {
+				name = TTR("[unsaved]");
+			}
 			name += "(*)";
 		}
 	} else if (text_file->get_name() != "") {
@@ -236,7 +239,10 @@ void TextEditor::apply_code() {
 }
 
 bool TextEditor::is_unsaved() {
-	return code_editor->get_text_edit()->get_version() != code_editor->get_text_edit()->get_saved_version();
+	const bool unsaved =
+			code_editor->get_text_edit()->get_version() != code_editor->get_text_edit()->get_saved_version() ||
+			text_file->get_path().empty(); // In memory.
+	return unsaved;
 }
 
 Variant TextEditor::get_edit_state() {

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2551,6 +2551,9 @@ String VisualScriptEditor::get_name() {
 	if (script->get_path().find("local://") == -1 && script->get_path().find("::") == -1) {
 		name = script->get_path().get_file();
 		if (is_unsaved()) {
+			if (script->get_path().empty()) {
+				name = TTR("[unsaved]");
+			}
 			name += "(*)";
 		}
 	} else if (script->get_name() != "") {
@@ -2567,7 +2570,11 @@ Ref<Texture2D> VisualScriptEditor::get_theme_icon() {
 }
 
 bool VisualScriptEditor::is_unsaved() {
-	return script->is_edited() || script->are_subnodes_edited();
+	bool unsaved =
+			script->is_edited() ||
+			script->are_subnodes_edited() ||
+			script->get_path().empty(); // In memory.
+	return unsaved;
 }
 
 Variant VisualScriptEditor::get_edit_state() {


### PR DESCRIPTION
Closes #33313.

![Annotation 2020-07-24 014226](https://user-images.githubusercontent.com/17108460/88345619-00ef1380-cd4f-11ea-8dae-fdb3c99038e9.png)

Unsaved scripts were previously displayed with blank tabs, which are mostly a result of deleted or improperly moved scripts, which is another issue in and of itself: #27635.

This patch makes sure that those kind of scripts are displayed as "[unsaved]" now, and ensures that scripts are removed from the list while deleting scripts from the filesystem dock preventing the unsaved tabs to appear in the first place (a user is already prompted with "no undo" warning while deleting any file).

A user is always prompted to save those "[unsaved]" scripts if they attempt to close them without saving in any case except as described above.

These changes don't seem to re-introduce #40175, as I've modified the "save" condition to allow saving in-memory scripts (have no resource path associated).

This also helps #35211.
