### PR TITLE
GitHub actions cache fixes

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -43,11 +43,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/.scons_cache/
-          key: ${{runner.os}}-template-${{github.sha}}
+          key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
           restore-keys: |
-            ${{runner.os}}-template-${{github.sha}}
-            ${{runner.os}}-template
-            ${{runner.os}}
+            ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+            ${{github.job}}-${GITHUB_REF##*/}
+            ${{github.job}}
 
         # Use python 3.x release (works cross platform)
       - name: Set up Python 3.x

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 # Global Cache Settings
 env:
-  SCONS_CACHE_LIMIT: 8192
+  SCONS_CACHE_LIMIT: 4096
 
 jobs:
   android-template:

--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 # Global Cache Settings
 env:
-  SCONS_CACHE_LIMIT: 8192
+  SCONS_CACHE_LIMIT: 4096
   EM_VERSION: latest
   EM_CACHE_FOLDER: 'emsdk-cache'
 

--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -29,9 +29,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/.scons_cache/
-          key: ${{github.job}}-${{github.sha}}
+          key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
           restore-keys: |
-            ${{github.job}}-${{github.sha}}
+            ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+            ${{github.job}}-${GITHUB_REF##*/}
             ${{github.job}}
 
       # Additional cache for Emscripten generated system libraries

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 # Global Cache Settings
 env:
-  SCONS_CACHE_LIMIT: 8192
+  SCONS_CACHE_LIMIT: 4096
 
 jobs:
   linux-editor:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -33,11 +33,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/.scons_cache/
-          key: ${{runner.os}}-editor-${{github.sha}}
+          key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
           restore-keys: |
-            ${{runner.os}}-editor-${{github.sha}}
-            ${{runner.os}}-editor
-            ${{runner.os}}
+            ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+            ${{github.job}}-${GITHUB_REF##*/}
+            ${{github.job}}
 
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       - name: Set up Python 3.x
@@ -90,11 +90,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/.scons_cache/
-          key: ${{runner.os}}-template-${{github.sha}}
+          key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
           restore-keys: |
-            ${{runner.os}}-template-${{github.sha}}
-            ${{runner.os}}-template
-            ${{runner.os}}
+            ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+            ${{github.job}}-${GITHUB_REF##*/}
+            ${{github.job}}
 
       # Use python 3.x release (works cross platform)
       - name: Set up Python 3.x

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -22,11 +22,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/.scons_cache/
-          key: ${{runner.os}}-editor-${{github.sha}}
+          key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
           restore-keys: |
-            ${{runner.os}}-editor-${{github.sha}}
-            ${{runner.os}}-editor
-            ${{runner.os}}
+            ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+            ${{github.job}}-${GITHUB_REF##*/}
+            ${{github.job}}
 
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       - name: Set up Python 3.x
@@ -67,11 +67,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/.scons_cache/
-          key: ${{runner.os}}-template-${{github.sha}}
+          key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
           restore-keys: |
-            ${{runner.os}}-template-${{github.sha}}
-            ${{runner.os}}-template
-            ${{runner.os}}
+            ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+            ${{github.job}}-${GITHUB_REF##*/}
+            ${{github.job}}
 
       # Use python 3.x release (works cross platform)
       - name: Set up Python 3.x

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 # Global Cache Settings
 env:
-  SCONS_CACHE_LIMIT: 8192
+  SCONS_CACHE_LIMIT: 4096
 
 jobs:
   macos-editor:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 # SCONS_CACHE for windows must be set in the build environment
 env:
   SCONS_CACHE_MSVC_CONFIG: true
-  SCONS_CACHE_LIMIT: 8192
+  SCONS_CACHE_LIMIT: 4096
 
 jobs:
   windows-editor:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -26,11 +26,11 @@ jobs:
       uses: RevoluPowered/cache@v2.1
       with:
         path: /.scons_cache/
-        key: ${{runner.os}}-editor-${{github.sha}}
+        key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
         restore-keys: |
-          ${{runner.os}}-editor-${{github.sha}}
-          ${{runner.os}}-editor
-          ${{runner.os}}
+          ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+          ${{github.job}}-${GITHUB_REF##*/}
+          ${{github.job}}
 
     # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
     - name: Set up Python 3.x
@@ -80,11 +80,11 @@ jobs:
       uses: RevoluPowered/cache@v2.1
       with:
         path: /.scons_cache/
-        key: ${{runner.os}}-template-${{github.sha}}
+        key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
         restore-keys: |
-          ${{runner.os}}-template-${{github.sha}}
-          ${{runner.os}}-template
-          ${{runner.os}}
+          ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+          ${{github.job}}-${GITHUB_REF##*/}
+          ${{github.job}}
 
     # Use python 3.x release (works cross platform)
     - name: Set up Python 3.x


### PR DESCRIPTION
Basically:
- we decided to lower cache size
- match cache based on the type of build and branch name

The cache will only match the relevant build explicitly e.g. windows-editor-mybranch-239dksk preventing pollution from other caches.

This should mean PRs build faster too when you make fixes, it should not have to rebuild entire codebase if there are larger changes.

It should also resolve the MSVC cache filling up the filesystem with a more sensible default on the cache size.