### PR TITLE
Fix bug where leading and trailing spaces werent taken into account with center and right allignment

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -188,7 +188,7 @@ void Label::_notification(int p_what) {
 			int spaces = 0;
 			while (to && to->char_pos >= 0) {
 				taken += to->pixel_width;
-				if (to != from && to->space_count) {
+				if (to->space_count) {
 					spaces += to->space_count;
 				}
 				to = to->next;
@@ -417,6 +417,22 @@ void Label::regenerate_word_cache() {
 				wc->pixel_width = current_word_size;
 				wc->char_pos = word_pos;
 				wc->word_len = i - word_pos;
+				wc->space_count = space_count;
+				current_word_size = 0;
+				space_count = 0;
+			} else if ((i == xl_text.length() || current == '\n') && last != nullptr && space_count != 0) {
+				//in case there are trailing white spaces we add a placeholder word cache with just the spaces
+				WordCache *wc = memnew(WordCache);
+				if (word_cache) {
+					last->next = wc;
+				} else {
+					word_cache = wc;
+				}
+				last = wc;
+
+				wc->pixel_width = 0;
+				wc->char_pos = 0;
+				wc->word_len = 0;
 				wc->space_count = space_count;
 				current_word_size = 0;
 				space_count = 0;


### PR DESCRIPTION
This fixes a bug where leading ant trailing white spaces weren't taken into account when changing the label alignment to right or center. The leading spaces was fixed by removing a line that ignored the first word considering spaces and the trailing by making a fake word cache with only the spaces.

Fix #39630