### PR TITLE
CI: Fix cache key and include base branch

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -3,13 +3,14 @@ on: [push, pull_request]
 
 # Global Cache Settings
 env:
+  GODOT_BASE_BRANCH: master
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
   android-template:
     runs-on: "ubuntu-20.04"
 
-    name: Android Template (target=release, tools=no)
+    name: Template (target=release, tools=no)
 
     steps:
       - uses: actions/checkout@v2
@@ -20,13 +21,13 @@ jobs:
           sudo cp -f misc/ci/sources.list /etc/apt/sources.list
           sudo apt-get update
 
-      # install all packages (except scons)
+      # Install all packages (except scons)
       - name: Configure dependencies
         run: |
          sudo apt-get install openjdk-8-jdk
          echo "::set-env name=JAVA_HOME::usr/lib/jvm/java-8-openjdk-amd64"
 
-      - name: Install Android Sdk and Ndk
+      - name: Install Android SDK and NDK
         run: |
           echo "::set-env name=PATH::/usr/lib/jvm/java-8-openjdk-amd64/jre/bin:${PATH}"
           java -version
@@ -36,20 +37,18 @@ jobs:
           source ~/.bashrc
 
       # Upload cache on completion and check it out now
-      # Editing this is pretty dangerous for windows since it can break and needs properly tested with a fresh cache.
-      # Linux with this will work reliably, so not as bad to edit for Linux.
       - name: Load .scons_cache directory
         id: android-template-cache
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/.scons_cache/
-          key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
-            ${{github.job}}-${GITHUB_REF##*/}
-            ${{github.job}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
-        # Use python 3.x release (works cross platform)
+      # Use python 3.x release (works cross platform)
       - name: Set up Python 3.x
         uses: actions/setup-python@v2
         with:
@@ -65,6 +64,7 @@ jobs:
           python -m pip install scons
           python --version
           scons --version
+
       - name: Compilation
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/

--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 # Global Cache Settings
 env:
+  GODOT_BASE_BRANCH: master
   SCONS_CACHE_LIMIT: 4096
   EM_VERSION: latest
   EM_CACHE_FOLDER: 'emsdk-cache'
@@ -22,18 +23,16 @@ jobs:
           sudo apt-get update
 
       # Upload cache on completion and check it out now
-      # Editing this is pretty dangerous for windows since it can break and needs properly tested with a fresh cache.
-      # Linux with this will work reliably, so not as bad to edit for Linux.
       - name: Load .scons_cache directory
         id: javascript-template-cache
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/.scons_cache/
-          key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
-            ${{github.job}}-${GITHUB_REF##*/}
-            ${{github.job}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
       # Additional cache for Emscripten generated system libraries
       - name: Load Emscripten cache

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 # Global Cache Settings
 env:
+  GODOT_BASE_BRANCH: master
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -26,18 +27,16 @@ jobs:
             libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
 
       # Upload cache on completion and check it out now
-      # Editing this is pretty dangerous for windows since it can break and needs properly tested with a fresh cache.
-      # Linux with this will work reliably, so not as bad to edit for Linux.
       - name: Load .scons_cache directory
         id: linux-editor-cache
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/.scons_cache/
-          key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
-            ${{github.job}}-${GITHUB_REF##*/}
-            ${{github.job}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       - name: Set up Python 3.x
@@ -83,18 +82,16 @@ jobs:
             libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
 
       # Upload cache on completion and check it out now
-      # Editing this is pretty dangerous for windows since it can break and needs properly tested with a fresh cache.
-      # Linux with this will work reliably, so not as bad to edit for Linux.
       - name: Load .scons_cache directory
         id: linux-template-cache
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/.scons_cache/
-          key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
-            ${{github.job}}-${GITHUB_REF##*/}
-            ${{github.job}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
       # Use python 3.x release (works cross platform)
       - name: Set up Python 3.x
@@ -112,6 +109,7 @@ jobs:
           python -m pip install scons
           python --version
           scons --version
+
       - name: Compilation
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 # Global Cache Settings
 env:
+  GODOT_BASE_BRANCH: master
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -15,18 +16,16 @@ jobs:
       - uses: actions/checkout@v2
 
       # Upload cache on completion and check it out now
-      # Editing this is pretty dangerous for windows since it can break and needs properly tested with a fresh cache.
-      # Linux with this will work reliably, so not as bad to edit for Linux.
       - name: Load .scons_cache directory
         id: macos-editor-cache
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/.scons_cache/
-          key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
-            ${{github.job}}-${GITHUB_REF##*/}
-            ${{github.job}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       - name: Set up Python 3.x
@@ -60,18 +59,16 @@ jobs:
       - uses: actions/checkout@v2
 
       # Upload cache on completion and check it out now
-      # Editing this is pretty dangerous for windows since it can break and needs properly tested with a fresh cache.
-      # Linux with this will work reliably, so not as bad to edit for Linux.
       - name: Load .scons_cache directory
         id: macos-template-cache
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/.scons_cache/
-          key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
-            ${{github.job}}-${GITHUB_REF##*/}
-            ${{github.job}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
       # Use python 3.x release (works cross platform)
       - name: Set up Python 3.x
@@ -89,6 +86,7 @@ jobs:
           python -m pip install scons
           python --version
           scons --version
+
       - name: Compilation
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 # Global Cache Settings
 # SCONS_CACHE for windows must be set in the build environment
 env:
+  GODOT_BASE_BRANCH: master
   SCONS_CACHE_MSVC_CONFIG: true
   SCONS_CACHE_LIMIT: 4096
 
@@ -18,19 +19,18 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Upload cache on completion and check it out now
-    # Editing this is pretty dangerous for windows since it can break and needs properly tested with a fresh cache.
-    # Linux with this will work reliably, so not as bad to edit for Linux.
+      # Upload cache on completion and check it out now
+      # Editing this is pretty dangerous for Windows since it can break and needs to be properly tested with a fresh cache.
     - name: Load .scons_cache directory
       id: windows-editor-cache
       uses: RevoluPowered/cache@v2.1
       with:
         path: /.scons_cache/
-        key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+        key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
         restore-keys: |
-          ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
-          ${{github.job}}-${GITHUB_REF##*/}
-          ${{github.job}}
+          ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+          ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
     # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
     - name: Set up Python 3.x
@@ -73,18 +73,17 @@ jobs:
     - uses: actions/checkout@v2
 
     # Upload cache on completion and check it out now
-    # Editing this is pretty dangerous for windows since it can break and needs properly tested with a fresh cache.
-    # Linux with this will work reliably, so not as bad to edit for Linux.
+    # Editing this is pretty dangerous for Windows since it can break and needs to be properly tested with a fresh cache.
     - name: Load .scons_cache directory
       id: windows-template-cache
       uses: RevoluPowered/cache@v2.1
       with:
         path: /.scons_cache/
-        key: ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
+        key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
         restore-keys: |
-          ${{github.job}}-${GITHUB_REF##*/}-${{github.sha}}
-          ${{github.job}}-${GITHUB_REF##*/}
-          ${{github.job}}
+          ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+          ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
 
     # Use python 3.x release (works cross platform)
     - name: Set up Python 3.x
@@ -102,6 +101,7 @@ jobs:
         python -m pip install scons pywin32
         python --version
         scons --version
+
     - name: Compilation
       env:
         SCONS_CACHE: /.scons_cache/


### PR DESCRIPTION
The base branch is hardcoded as an env variable as I couldn't find a simple
way to just get either `3.2` or `master`. But it's easy to change when we
branch off from `master` to a new stable branch, which doesn't happen often.

(There's `{{github.base_ref}}` but it's probably more verbose like
`refs/heads/master`, and only valid for PRs.)

---

CC @RevoluPowered 

For the head branch (action on my fork), this gives this kind of cache keys:
```
Cache not found for input keys: linux-editor-master-refs/heads/ci-more-cache-key-2cf5ad9ea9b1c7edb77f5c3e42935d73d041f1f9, linux-editor-master-refs/heads/ci-more-cache-key-2cf5ad9ea9b1c7edb77f5c3e42935d73d041f1f9, linux-editor-master-refs/heads/ci-more-cache-key, linux-editor-master
```

For the PR branch, let's see once it's created. *Edit:*
```
Cache not found for input keys: linux-editor-master-refs/pull/40652/merge-28994c0a698afbaf38fe2bdda7fc1b3da4547986, linux-editor-master-refs/pull/40652/merge-28994c0a698afbaf38fe2bdda7fc1b3da4547986, linux-editor-master-refs/pull/40652/merge, linux-editor-master
```

So the lowest entry point would be `linux-editor-master` on the `master` branch and `linux-editor-3.2` on the `3.2` branch, so there's no risk of them overriding each other's cache.