### PR TITLE
[macOS] Fix build for ARM64.

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -50,9 +50,11 @@ def configure(env):
 
     if env["target"] == "release":
         if env["optimize"] == "speed":  # optimize for speed (default)
-            env.Prepend(CCFLAGS=["-O3", "-fomit-frame-pointer", "-ftree-vectorize", "-msse2"])
+            env.Prepend(CCFLAGS=["-O3", "-fomit-frame-pointer", "-ftree-vectorize"])
         else:  # optimize for size
-            env.Prepend(CCFLAGS=["-Os", "-ftree-vectorize", "-msse2"])
+            env.Prepend(CCFLAGS=["-Os", "-ftree-vectorize"])
+        if env["arch"] != "arm64":
+            env.Prepend(CCFLAGS=["-msse2"])
 
         if env["debug_symbols"] == "yes":
             env.Prepend(CCFLAGS=["-g1"])

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -81,6 +81,9 @@ Files extracted from upstream source:
 
 Extracted from .zip provided. Extracted license and header only.
 
+Important: Some files have Godot-made changes.
+They are marked with `// -- GODOT start --` and `// -- GODOT end --`
+comments.
 
 ## enet
 

--- a/thirdparty/doctest/doctest.h
+++ b/thirdparty/doctest/doctest.h
@@ -356,7 +356,13 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26812) // Prefer 'enum class' over 'enum'
 #ifndef DOCTEST_BREAK_INTO_DEBUGGER
 // should probably take a look at https://github.com/scottt/debugbreak
 #ifdef DOCTEST_PLATFORM_MAC
+// -- GODOT start --
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__)
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :)
+#else
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0");
+#endif
+// -- GODOT end --
 #elif DOCTEST_MSVC
 #define DOCTEST_BREAK_INTO_DEBUGGER() __debugbreak()
 #elif defined(__MINGW32__)

--- a/thirdparty/doctest/patches/fix-arm64-mac.patch
+++ b/thirdparty/doctest/patches/fix-arm64-mac.patch
@@ -1,0 +1,18 @@
+diff --git a/thirdparty/doctest/doctest.h b/thirdparty/doctest/doctest.h
+index 9444698286..e4fed12767 100644
+--- a/thirdparty/doctest/doctest.h
++++ b/thirdparty/doctest/doctest.h
+@@ -356,7 +356,13 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26812) // Prefer 'enum class' over 'enum'
+ #ifndef DOCTEST_BREAK_INTO_DEBUGGER
+ // should probably take a look at https://github.com/scottt/debugbreak
+ #ifdef DOCTEST_PLATFORM_MAC
++// -- GODOT start --
++#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__)
+ #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :)
++#else
++#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0");
++#endif
++// -- GODOT end --
+ #elif DOCTEST_MSVC
+ #define DOCTEST_BREAK_INTO_DEBUGGER() __debugbreak()
+ #elif defined(__MINGW32__)


### PR DESCRIPTION
- Remove unsupported `-msse2` flag from ARM64 release export template build.
- Add ARM64 breakpoint inline assembly to `doctest.h` header (introduced in #40148).