### PR TITLE
Remove Travis CI and AppVeyor build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,7 @@ There are also a number of other learning resources provided by the community,
 such as text and video tutorials, demos, etc. Consult the [community channels](https://godotengine.org/community)
 for more info.
 
-[![Travis Build Status](https://travis-ci.org/godotengine/godot.svg?branch=master)](https://travis-ci.org/godotengine/godot)
 [![Actions Build Status](https://github.com/godotengine/godot/workflows/Godot/badge.svg?branch=master)](https://github.com/godotengine/godot/actions)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/bfiihqq6byxsjxxh/branch/master?svg=true)](https://ci.appveyor.com/project/akien-mga/godot)
 [![Code Triagers Badge](https://www.codetriage.com/godotengine/godot/badges/users.svg)](https://www.codetriage.com/godotengine/godot)
 [![Translate on Weblate](https://hosted.weblate.org/widgets/godot-engine/-/godot/svg-badge.svg)](https://hosted.weblate.org/engage/godot-engine/?utm_source=widget)
 [![Total alerts on LGTM](https://img.shields.io/lgtm/alerts/g/godotengine/godot.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/godotengine/godot/alerts)


### PR DESCRIPTION
Travis CI and AppVeyor are phased out in [this](https://github.com/godotengine/godot/commit/431930bd09e082edce56f9cf6987368b868d07a1) commit, hence there is no point in keeping a badge of it in `README.md`.

Also in [actions](https://github.com/godotengine/godot/actions) there are 7 different workflows atm. Are we supposed to keep only `Godot CI` or others too? Keeping `Godot CI` should be enough imo but also wanted to know the thoughts of others.
