### PR TITLE
[3.2] Export sections

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -144,6 +144,7 @@ struct PropertyInfo {
 
 	Variant::Type type;
 	String name;
+	String export_path;
 	StringName class_name; //for classes
 	PropertyHint hint;
 	String hint_string;

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1577,7 +1577,7 @@ void EditorInspector::update_tree() {
 			continue;
 		}
 
-		String basename = p.name;
+		String basename = p.export_path + p.name;
 		if (group != "") {
 			if (group_base != "") {
 				if (basename.begins_with(group_base)) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1876,6 +1876,7 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 		"const",
 		"enum",
 		"export",
+		"cosmetic",
 		"onready",
 		"static",
 		"var",

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4744,7 +4744,8 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 							return;
 						}
 						_ADVANCE_AND_CONSUME_NEWLINES;
-						if (tokenizer->get_token() != GDScriptTokenizer::TK_CONSTANT || tokenizer->get_token_constant().get_type() != Variant::STRING) {							_set_error("Expected a String for section name.");
+						if (tokenizer->get_token() != GDScriptTokenizer::TK_CONSTANT || tokenizer->get_token_constant().get_type() != Variant::STRING) {
+							_set_error("Expected a String for section name.");
 							return;
 						}
 						String to_add = String(tokenizer->get_token_constant()) + String("/");
@@ -4763,6 +4764,10 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 						export_section_path += to_add;
 						_parse_section(p_class);
 						export_section_path = past_export;
+					} break;
+					default: {
+						_set_error("Expected \"section\"");
+						return;
 					} break;
 				}
 			} break;
@@ -6338,16 +6343,17 @@ void GDScriptParser::_parse_section(ClassNode *p_class) {
 						_parse_section(p_class);
 						export_section_path = past_export;
 					} break;
+					default: {
+						_set_error("Expected \"section\"");
+						return;
+					} break;
 				}
 			} break;
 
 			default: {
-
 				_set_error(String() + "Unexpected token: " + tokenizer->get_token_name(tokenizer->get_token()) + ":" + tokenizer->get_token_identifier());
 				return;
-
 			} break;
-
 		}
 	}
 }

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -597,6 +597,7 @@ private:
 	bool completion_found;
 	bool completion_ident_is_call;
 
+	String export_section_path = "";
 	PropertyInfo current_export;
 
 	MultiplayerAPI::RPCMode rpc_mode;
@@ -624,6 +625,7 @@ private:
 	void _parse_block(BlockNode *p_block, bool p_static);
 	void _parse_extends(ClassNode *p_class);
 	void _parse_class(ClassNode *p_class);
+	void _parse_section(ClassNode *p_class);
 	bool _end_statement();
 	void _set_end_statement_error(String p_name);
 

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1578,7 +1578,7 @@ GDScriptTokenizerBuffer::GDScriptTokenizerBuffer() {
 	token = 0;
 }
 
-const char* GDScriptCosmetics::get_cosmetic_name(GDScriptCosmetics::Cosmetic p_cosm) {
+const char *GDScriptCosmetics::get_cosmetic_name(GDScriptCosmetics::Cosmetic p_cosm) {
 	ERR_FAIL_INDEX_V(p_cosm, COSM_MAX, "");
 
 	static const char *_names[COSM_MAX] = {

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -38,6 +38,16 @@
 #include "core/vmap.h"
 #include "gdscript_functions.h"
 
+class GDScriptCosmetics {
+public:
+	enum Cosmetic {
+		SECTION,
+		COSM_MAX,
+	};
+
+	static const char *get_cosmetic_name(Cosmetic p_cosm);
+};
+
 class GDScriptTokenizer {
 public:
 	enum Token {
@@ -46,6 +56,7 @@ public:
 		TK_IDENTIFIER,
 		TK_CONSTANT,
 		TK_SELF,
+		TK_BUILT_IN_COSMETIC,
 		TK_BUILT_IN_TYPE,
 		TK_BUILT_IN_FUNC,
 		TK_OP_IN,
@@ -101,6 +112,7 @@ public:
 		TK_PR_TOOL,
 		TK_PR_STATIC,
 		TK_PR_EXPORT,
+		TK_PR_COSMETIC,
 		TK_PR_SETGET,
 		TK_PR_CONST,
 		TK_PR_VAR,
@@ -164,6 +176,7 @@ public:
 	virtual Token get_token(int p_offset = 0) const = 0;
 	virtual StringName get_token_identifier(int p_offset = 0) const = 0;
 	virtual GDScriptFunctions::Function get_token_built_in_func(int p_offset = 0) const = 0;
+	virtual GDScriptCosmetics::Cosmetic get_token_built_in_cosm(int p_offset = 0) const = 0;
 	virtual Variant::Type get_token_type(int p_offset = 0) const = 0;
 	virtual int get_token_line(int p_offset = 0) const = 0;
 	virtual int get_token_column(int p_offset = 0) const = 0;
@@ -195,6 +208,7 @@ class GDScriptTokenizerText : public GDScriptTokenizer {
 		union {
 			Variant::Type vtype; //for type types
 			GDScriptFunctions::Function func; //function for built in functions
+			GDScriptCosmetics::Cosmetic cosm; //cosmetic for built in cosmetics
 			int warning_code; //for warning skip
 		};
 		int line, col;
@@ -209,6 +223,7 @@ class GDScriptTokenizerText : public GDScriptTokenizer {
 	void _make_newline(int p_indentation = 0, int p_tabs = 0);
 	void _make_identifier(const StringName &p_identifier);
 	void _make_built_in_func(GDScriptFunctions::Function p_func);
+	void _make_built_in_cosm(GDScriptCosmetics::Cosmetic p_cosm);
 	void _make_constant(const Variant &p_constant);
 	void _make_type(const Variant::Type &p_type);
 	void _make_error(const String &p_error);
@@ -237,6 +252,7 @@ public:
 	virtual Token get_token(int p_offset = 0) const;
 	virtual StringName get_token_identifier(int p_offset = 0) const;
 	virtual GDScriptFunctions::Function get_token_built_in_func(int p_offset = 0) const;
+	virtual GDScriptCosmetics::Cosmetic get_token_built_in_cosm(int p_offset = 0) const;
 	virtual Variant::Type get_token_type(int p_offset = 0) const;
 	virtual int get_token_line(int p_offset = 0) const;
 	virtual int get_token_column(int p_offset = 0) const;
@@ -276,6 +292,7 @@ public:
 	virtual Token get_token(int p_offset = 0) const;
 	virtual StringName get_token_identifier(int p_offset = 0) const;
 	virtual GDScriptFunctions::Function get_token_built_in_func(int p_offset = 0) const;
+	virtual GDScriptCosmetics::Cosmetic get_token_built_in_cosm(int p_offset = 0) const;
 	virtual Variant::Type get_token_type(int p_offset = 0) const;
 	virtual int get_token_line(int p_offset = 0) const;
 	virtual int get_token_column(int p_offset = 0) const;


### PR DESCRIPTION
This PR introduces export sections, which are a way to organize exported variables in the inspector. There is technically a way to do sections already, however this method is controverted (https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_exports.html#adding-script-categories) and takes a lot of space. This PR introduces the `cosmetic` syntax.
The code permits easy additions for other cosmetics, such as a line break or a comment (not given in this PR).
It's also coded in a seamless way, that isn't out of place or hacky.

The syntax is the following: `cosmetic (section, "sectionname"):` followed by an indent and any variable declarations wanted.  This is purely cosmetic, and targeting of variables is the same as usual.

![Example of code](https://user-images.githubusercontent.com/51149447/88411572-76eb8d00-cdd8-11ea-8c6a-133c2a31320d.png) 
![Result of said code.](https://user-images.githubusercontent.com/51149447/88411617-8cf94d80-cdd8-11ea-97b4-372101b33303.png)

This feature has been appreciated by the community, as shown by the reddit post getting over 100 upvotes ( https://www.reddit.com/r/godot/comments/hwgh8l/edited_the_engine_a_bit_to_add_sections_wont_be/) with multiple comments asking for this to be added, and by discussing with people in the discord.

This feature makes making nodes with a lot of variables much easier, which happens often for modular nodes, such as customizable particle emitters or player characters (particularly in 3D).

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/4378.*