### PR TITLE
Fix virtual keyboard height regression

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotEditText.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotEditText.java
@@ -38,6 +38,7 @@ import android.os.Message;
 import android.text.InputFilter;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
+import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
@@ -55,6 +56,7 @@ public class GodotEditText extends EditText {
 	// Fields
 	// ===========================================================
 	private GodotRenderView mRenderView;
+	private View mKeyboardView;
 	private GodotTextInputWrapper mInputWrapper;
 	private EditHandler sHandler = new EditHandler(this);
 	private String mOriginText;
@@ -117,7 +119,7 @@ public class GodotEditText extends EditText {
 
 					edit.mInputWrapper.setOriginText(text);
 					edit.addTextChangedListener(edit.mInputWrapper);
-					final InputMethodManager imm = (InputMethodManager)mRenderView.getView().getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+					final InputMethodManager imm = (InputMethodManager)mKeyboardView.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
 					imm.showSoftInput(edit, 0);
 				}
 			} break;
@@ -126,7 +128,7 @@ public class GodotEditText extends EditText {
 				GodotEditText edit = (GodotEditText)msg.obj;
 
 				edit.removeTextChangedListener(mInputWrapper);
-				final InputMethodManager imm = (InputMethodManager)mRenderView.getView().getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+				final InputMethodManager imm = (InputMethodManager)mKeyboardView.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
 				imm.hideSoftInputFromWindow(edit.getWindowToken(), 0);
 				edit.mRenderView.getView().requestFocus();
 			} break;
@@ -148,6 +150,10 @@ public class GodotEditText extends EditText {
 			mInputWrapper = new GodotTextInputWrapper(mRenderView, this);
 		setOnEditorActionListener(mInputWrapper);
 		view.getView().requestFocus();
+	}
+
+	public void setKeyboardView(final View keyboardView) {
+		mKeyboardView = keyboardView;
 	}
 
 	// ===========================================================


### PR DESCRIPTION
Fixes regression from https://github.com/godotengine/godot/pull/40484#issuecomment-661747147

Disabling virtual keyboard focus adjustement caused `get_keyboard_height` to always return 0 because it was calculated when the view is resized.

In order to fix it, a `PopupWindow` is now created on top of the main view and is set for focus adjustments so the keyboard size can be calculated based on this popup without affecting the main view.