### PR TITLE
Make all String float conversion methods be 64-bit

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -265,7 +265,7 @@ Error JSON::_get_token(const CharType *p_str, int &index, int p_len, Token &r_to
 				if (p_str[index] == '-' || (p_str[index] >= '0' && p_str[index] <= '9')) {
 					//a number
 					const CharType *rptr;
-					double number = String::to_double(&p_str[index], &rptr);
+					double number = String::to_float(&p_str[index], &rptr);
 					index += (rptr - &p_str[index]);
 					r_token.type = TK_NUMBER;
 					r_token.value = number;

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -1062,7 +1062,7 @@ Error Expression::_get_token(Token &r_token) {
 					r_token.type = TK_CONSTANT;
 
 					if (is_float) {
-						r_token.value = num.to_double();
+						r_token.value = num.to_float();
 					} else {
 						r_token.value = num.to_int();
 					}

--- a/core/string_buffer.h
+++ b/core/string_buffer.h
@@ -150,7 +150,7 @@ String StringBuffer<SHORT_BUFFER_SIZE>::as_string() {
 template <int SHORT_BUFFER_SIZE>
 double StringBuffer<SHORT_BUFFER_SIZE>::as_double() {
 	current_buffer_ptr()[string_length] = '\0';
-	return String::to_double(current_buffer_ptr());
+	return String::to_float(current_buffer_ptr());
 }
 
 template <int SHORT_BUFFER_SIZE>

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -851,7 +851,7 @@ Vector<float> String::split_floats(const String &p_splitter, bool p_allow_empty)
 			end = len;
 		}
 		if (p_allow_empty || (end > from)) {
-			ret.push_back(String::to_double(&c_str()[from]));
+			ret.push_back(String::to_float(&c_str()[from]));
 		}
 
 		if (end == len) {
@@ -880,7 +880,7 @@ Vector<float> String::split_floats_mk(const Vector<String> &p_splitters, bool p_
 		}
 
 		if (p_allow_empty || (end > from)) {
-			ret.push_back(String::to_double(&c_str()[from]));
+			ret.push_back(String::to_float(&c_str()[from]));
 		}
 
 		if (end == len) {
@@ -2006,7 +2006,7 @@ done:
 #define READING_EXP 3
 #define READING_DONE 4
 
-double String::to_double(const char *p_str) {
+double String::to_float(const char *p_str) {
 #ifndef NO_USE_STDLIB
 	return built_in_strtod<char>(p_str);
 //return atof(p_str); DOES NOT WORK ON ANDROID(??)
@@ -2015,11 +2015,7 @@ double String::to_double(const char *p_str) {
 #endif
 }
 
-float String::to_float() const {
-	return to_double();
-}
-
-double String::to_double(const CharType *p_str, const CharType **r_end) {
+double String::to_float(const CharType *p_str, const CharType **r_end) {
 	return built_in_strtod<CharType>(p_str, (CharType **)r_end);
 }
 
@@ -2087,7 +2083,7 @@ int64_t String::to_int(const CharType *p_str, int p_len, bool p_clamp) {
 	return sign * integer;
 }
 
-double String::to_double() const {
+double String::to_float() const {
 	if (empty()) {
 		return 0;
 	}

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -242,15 +242,14 @@ public:
 	static String md5(const uint8_t *p_md5);
 	static String hex_encode_buffer(const uint8_t *p_buffer, int p_len);
 	bool is_numeric() const;
-	double to_double() const;
-	float to_float() const;
+	double to_float() const;
 
 	int64_t hex_to_int(bool p_with_prefix = true) const;
 	int64_t bin_to_int(bool p_with_prefix = true) const;
 	int64_t to_int() const;
 	static int64_t to_int(const char *p_str, int p_len = -1);
-	static double to_double(const char *p_str);
-	static double to_double(const CharType *p_str, const CharType **r_end = nullptr);
+	static double to_float(const char *p_str);
+	static double to_float(const CharType *p_str, const CharType **r_end = nullptr);
 	static int64_t to_int(const CharType *p_str, int p_len = -1, bool p_clamp = false);
 	String capitalize() const;
 	String camelcase_to_underscore(bool lowercase = true) const;

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -1573,7 +1573,7 @@ Variant::operator float() const {
 		case FLOAT:
 			return _data._float;
 		case STRING:
-			return operator String().to_double();
+			return operator String().to_float();
 		default: {
 			return 0;
 		}
@@ -1591,7 +1591,7 @@ Variant::operator double() const {
 		case FLOAT:
 			return _data._float;
 		case STRING:
-			return operator String().to_double();
+			return operator String().to_float();
 		default: {
 			return 0;
 		}

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1405,7 +1405,7 @@ Variant Variant::construct(const Variant::Type p_type, const Variant **p_args, i
 				return (int64_t(*p_args[0]));
 			}
 			case FLOAT: {
-				return real_t(*p_args[0]);
+				return double(*p_args[0]);
 			}
 			case STRING: {
 				return String(*p_args[0]);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3275,10 +3275,10 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 				if ((p_hint == PROPERTY_HINT_RANGE || p_hint == PROPERTY_HINT_EXP_RANGE) && p_hint_text.get_slice_count(",") >= 2) {
 					greater = false; //if using ranged, assume false by default
 					lesser = false;
-					min = p_hint_text.get_slice(",", 0).to_double();
-					max = p_hint_text.get_slice(",", 1).to_double();
+					min = p_hint_text.get_slice(",", 0).to_float();
+					max = p_hint_text.get_slice(",", 1).to_float();
 					if (p_hint_text.get_slice_count(",") >= 3) {
-						step = p_hint_text.get_slice(",", 2).to_double();
+						step = p_hint_text.get_slice(",", 2).to_float();
 					}
 					hide_slider = false;
 					exp_range = p_hint == PROPERTY_HINT_EXP_RANGE;
@@ -3378,10 +3378,10 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			bool hide_slider = true;
 
 			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
-				min = p_hint_text.get_slice(",", 0).to_double();
-				max = p_hint_text.get_slice(",", 1).to_double();
+				min = p_hint_text.get_slice(",", 0).to_float();
+				max = p_hint_text.get_slice(",", 1).to_float();
 				if (p_hint_text.get_slice_count(",") >= 3) {
-					step = p_hint_text.get_slice(",", 2).to_double();
+					step = p_hint_text.get_slice(",", 2).to_float();
 				}
 				hide_slider = false;
 			}
@@ -3396,8 +3396,8 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			bool hide_slider = true;
 
 			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
-				min = p_hint_text.get_slice(",", 0).to_double();
-				max = p_hint_text.get_slice(",", 1).to_double();
+				min = p_hint_text.get_slice(",", 0).to_float();
+				max = p_hint_text.get_slice(",", 1).to_float();
 				hide_slider = false;
 			}
 
@@ -3411,10 +3411,10 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			bool hide_slider = true;
 
 			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
-				min = p_hint_text.get_slice(",", 0).to_double();
-				max = p_hint_text.get_slice(",", 1).to_double();
+				min = p_hint_text.get_slice(",", 0).to_float();
+				max = p_hint_text.get_slice(",", 1).to_float();
 				if (p_hint_text.get_slice_count(",") >= 3) {
-					step = p_hint_text.get_slice(",", 2).to_double();
+					step = p_hint_text.get_slice(",", 2).to_float();
 				}
 				hide_slider = false;
 			}
@@ -3428,8 +3428,8 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			bool hide_slider = true;
 
 			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
-				min = p_hint_text.get_slice(",", 0).to_double();
-				max = p_hint_text.get_slice(",", 1).to_double();
+				min = p_hint_text.get_slice(",", 0).to_float();
+				max = p_hint_text.get_slice(",", 1).to_float();
 				hide_slider = false;
 			}
 
@@ -3442,10 +3442,10 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			bool hide_slider = true;
 
 			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
-				min = p_hint_text.get_slice(",", 0).to_double();
-				max = p_hint_text.get_slice(",", 1).to_double();
+				min = p_hint_text.get_slice(",", 0).to_float();
+				max = p_hint_text.get_slice(",", 1).to_float();
 				if (p_hint_text.get_slice_count(",") >= 3) {
-					step = p_hint_text.get_slice(",", 2).to_double();
+					step = p_hint_text.get_slice(",", 2).to_float();
 				}
 				hide_slider = false;
 			}
@@ -3460,8 +3460,8 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			bool hide_slider = true;
 
 			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
-				min = p_hint_text.get_slice(",", 0).to_double();
-				max = p_hint_text.get_slice(",", 1).to_double();
+				min = p_hint_text.get_slice(",", 0).to_float();
+				max = p_hint_text.get_slice(",", 1).to_float();
 
 				hide_slider = false;
 			}
@@ -3476,10 +3476,10 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			bool hide_slider = true;
 
 			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
-				min = p_hint_text.get_slice(",", 0).to_double();
-				max = p_hint_text.get_slice(",", 1).to_double();
+				min = p_hint_text.get_slice(",", 0).to_float();
+				max = p_hint_text.get_slice(",", 1).to_float();
 				if (p_hint_text.get_slice_count(",") >= 3) {
-					step = p_hint_text.get_slice(",", 2).to_double();
+					step = p_hint_text.get_slice(",", 2).to_float();
 				}
 				hide_slider = false;
 			}
@@ -3494,10 +3494,10 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			bool hide_slider = true;
 
 			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
-				min = p_hint_text.get_slice(",", 0).to_double();
-				max = p_hint_text.get_slice(",", 1).to_double();
+				min = p_hint_text.get_slice(",", 0).to_float();
+				max = p_hint_text.get_slice(",", 1).to_float();
 				if (p_hint_text.get_slice_count(",") >= 3) {
-					step = p_hint_text.get_slice(",", 2).to_double();
+					step = p_hint_text.get_slice(",", 2).to_float();
 				}
 				hide_slider = false;
 			}
@@ -3511,10 +3511,10 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			bool hide_slider = true;
 
 			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
-				min = p_hint_text.get_slice(",", 0).to_double();
-				max = p_hint_text.get_slice(",", 1).to_double();
+				min = p_hint_text.get_slice(",", 0).to_float();
+				max = p_hint_text.get_slice(",", 1).to_float();
 				if (p_hint_text.get_slice_count(",") >= 3) {
-					step = p_hint_text.get_slice(",", 2).to_double();
+					step = p_hint_text.get_slice(",", 2).to_float();
 				}
 				hide_slider = false;
 			}
@@ -3528,10 +3528,10 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			bool hide_slider = true;
 
 			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
-				min = p_hint_text.get_slice(",", 0).to_double();
-				max = p_hint_text.get_slice(",", 1).to_double();
+				min = p_hint_text.get_slice(",", 0).to_float();
+				max = p_hint_text.get_slice(",", 1).to_float();
 				if (p_hint_text.get_slice_count(",") >= 3) {
-					step = p_hint_text.get_slice(",", 2).to_double();
+					step = p_hint_text.get_slice(",", 2).to_float();
 				}
 				hide_slider = false;
 			}
@@ -3545,10 +3545,10 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			bool hide_slider = true;
 
 			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
-				min = p_hint_text.get_slice(",", 0).to_double();
-				max = p_hint_text.get_slice(",", 1).to_double();
+				min = p_hint_text.get_slice(",", 0).to_float();
+				max = p_hint_text.get_slice(",", 1).to_float();
 				if (p_hint_text.get_slice_count(",") >= 3) {
-					step = p_hint_text.get_slice(",", 2).to_double();
+					step = p_hint_text.get_slice(",", 2).to_float();
 				}
 				hide_slider = false;
 			}
@@ -3562,10 +3562,10 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 			bool hide_slider = true;
 
 			if (p_hint == PROPERTY_HINT_RANGE && p_hint_text.get_slice_count(",") >= 2) {
-				min = p_hint_text.get_slice(",", 0).to_double();
-				max = p_hint_text.get_slice(",", 1).to_double();
+				min = p_hint_text.get_slice(",", 0).to_float();
+				max = p_hint_text.get_slice(",", 1).to_float();
 				if (p_hint_text.get_slice_count(",") >= 3) {
-					step = p_hint_text.get_slice(",", 2).to_double();
+					step = p_hint_text.get_slice(",", 2).to_float();
 				}
 				hide_slider = false;
 			}

--- a/editor/import/collada.cpp
+++ b/editor/import/collada.cpp
@@ -262,7 +262,7 @@ void Collada::_parse_asset(XMLParser &parser) {
 
 				COLLADA_PRINT("up axis: " + parser.get_node_data());
 			} else if (name == "unit") {
-				state.unit_scale = parser.get_attribute_value("meter").to_double();
+				state.unit_scale = parser.get_attribute_value("meter").to_float();
 				COLLADA_PRINT("unit scale: " + rtos(state.unit_scale));
 			}
 
@@ -433,7 +433,7 @@ Transform Collada::_read_transform(XMLParser &parser) {
 	Vector<float> farr;
 	farr.resize(16);
 	for (int i = 0; i < 16; i++) {
-		farr.write[i] = array[i].to_double();
+		farr.write[i] = array[i].to_float();
 	}
 
 	return _read_transform_from_array(farr);
@@ -469,7 +469,7 @@ Variant Collada::_parse_param(XMLParser &parser) {
 			if (parser.get_node_name() == "float") {
 				parser.read();
 				if (parser.get_node_type() == XMLParser::NODE_TEXT) {
-					data = parser.get_node_data().to_double();
+					data = parser.get_node_data().to_float();
 				}
 			} else if (parser.get_node_name() == "float2") {
 				Vector<float> v2 = _read_float_array(parser);
@@ -735,29 +735,29 @@ void Collada::_parse_camera(XMLParser &parser) {
 				camera.mode = CameraData::MODE_ORTHOGONAL;
 			} else if (name == "xfov") {
 				parser.read();
-				camera.perspective.x_fov = parser.get_node_data().to_double();
+				camera.perspective.x_fov = parser.get_node_data().to_float();
 
 			} else if (name == "yfov") {
 				parser.read();
-				camera.perspective.y_fov = parser.get_node_data().to_double();
+				camera.perspective.y_fov = parser.get_node_data().to_float();
 			} else if (name == "xmag") {
 				parser.read();
-				camera.orthogonal.x_mag = parser.get_node_data().to_double();
+				camera.orthogonal.x_mag = parser.get_node_data().to_float();
 
 			} else if (name == "ymag") {
 				parser.read();
-				camera.orthogonal.y_mag = parser.get_node_data().to_double();
+				camera.orthogonal.y_mag = parser.get_node_data().to_float();
 			} else if (name == "aspect_ratio") {
 				parser.read();
-				camera.aspect = parser.get_node_data().to_double();
+				camera.aspect = parser.get_node_data().to_float();
 
 			} else if (name == "znear") {
 				parser.read();
-				camera.z_near = parser.get_node_data().to_double();
+				camera.z_near = parser.get_node_data().to_float();
 
 			} else if (name == "zfar") {
 				parser.read();
-				camera.z_far = parser.get_node_data().to_double();
+				camera.z_far = parser.get_node_data().to_float();
 			}
 
 		} else if (parser.get_node_type() == XMLParser::NODE_ELEMENT_END && parser.get_node_name() == "camera") {
@@ -806,20 +806,20 @@ void Collada::_parse_light(XMLParser &parser) {
 
 			} else if (name == "constant_attenuation") {
 				parser.read();
-				light.constant_att = parser.get_node_data().to_double();
+				light.constant_att = parser.get_node_data().to_float();
 			} else if (name == "linear_attenuation") {
 				parser.read();
-				light.linear_att = parser.get_node_data().to_double();
+				light.linear_att = parser.get_node_data().to_float();
 			} else if (name == "quadratic_attenuation") {
 				parser.read();
-				light.quad_att = parser.get_node_data().to_double();
+				light.quad_att = parser.get_node_data().to_float();
 			} else if (name == "falloff_angle") {
 				parser.read();
-				light.spot_angle = parser.get_node_data().to_double();
+				light.spot_angle = parser.get_node_data().to_float();
 
 			} else if (name == "falloff_exponent") {
 				parser.read();
-				light.spot_exp = parser.get_node_data().to_double();
+				light.spot_exp = parser.get_node_data().to_float();
 			}
 
 		} else if (parser.get_node_type() == XMLParser::NODE_ELEMENT_END && parser.get_node_name() == "light") {
@@ -1877,10 +1877,10 @@ void Collada::_parse_animation_clip(XMLParser &parser) {
 		clip.name = parser.get_attribute_value("id");
 	}
 	if (parser.has_attribute("start")) {
-		clip.begin = parser.get_attribute_value("start").to_double();
+		clip.begin = parser.get_attribute_value("start").to_float();
 	}
 	if (parser.has_attribute("end")) {
-		clip.end = parser.get_attribute_value("end").to_double();
+		clip.end = parser.get_attribute_value("end").to_float();
 	}
 
 	while (parser.read() == OK) {

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -744,7 +744,7 @@ void AnimationPlayerEditor::_dialog_action(String p_path) {
 }
 
 void AnimationPlayerEditor::_scale_changed(const String &p_scale) {
-	player->set_speed_scale(p_scale.to_double());
+	player->set_speed_scale(p_scale.to_float());
 }
 
 void AnimationPlayerEditor::_update_animation() {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4689,9 +4689,9 @@ void Node3DEditor::edit(Node3D *p_spatial) {
 }
 
 void Node3DEditor::_snap_changed() {
-	snap_translate_value = snap_translate->get_text().to_double();
-	snap_rotate_value = snap_rotate->get_text().to_double();
-	snap_scale_value = snap_scale->get_text().to_double();
+	snap_translate_value = snap_translate->get_text().to_float();
+	snap_rotate_value = snap_rotate->get_text().to_float();
+	snap_scale_value = snap_scale->get_text().to_float();
 }
 
 void Node3DEditor::_snap_update() {
@@ -4708,9 +4708,9 @@ void Node3DEditor::_xform_dialog_action() {
 	Vector3 translate;
 
 	for (int i = 0; i < 3; i++) {
-		translate[i] = xform_translate[i]->get_text().to_double();
-		rotate[i] = Math::deg2rad(xform_rotate[i]->get_text().to_double());
-		scale[i] = xform_scale[i]->get_text().to_double();
+		translate[i] = xform_translate[i]->get_text().to_float();
+		rotate[i] = Math::deg2rad(xform_rotate[i]->get_text().to_float());
+		scale[i] = xform_scale[i]->get_text().to_float();
 	}
 
 	t.basis.scale(scale);
@@ -6432,9 +6432,9 @@ Vector3 Node3DEditor::snap_point(Vector3 p_target, Vector3 p_start) const {
 float Node3DEditor::get_translate_snap() const {
 	float snap_value;
 	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
-		snap_value = snap_translate->get_text().to_double() / 10.0;
+		snap_value = snap_translate->get_text().to_float() / 10.0;
 	} else {
-		snap_value = snap_translate->get_text().to_double();
+		snap_value = snap_translate->get_text().to_float();
 	}
 
 	return snap_value;
@@ -6443,9 +6443,9 @@ float Node3DEditor::get_translate_snap() const {
 float Node3DEditor::get_rotate_snap() const {
 	float snap_value;
 	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
-		snap_value = snap_rotate->get_text().to_double() / 3.0;
+		snap_value = snap_rotate->get_text().to_float() / 3.0;
 	} else {
-		snap_value = snap_rotate->get_text().to_double();
+		snap_value = snap_rotate->get_text().to_float();
 	}
 
 	return snap_value;
@@ -6454,9 +6454,9 @@ float Node3DEditor::get_rotate_snap() const {
 float Node3DEditor::get_scale_snap() const {
 	float snap_value;
 	if (Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
-		snap_value = snap_scale->get_text().to_double() / 2.0;
+		snap_value = snap_scale->get_text().to_float() / 2.0;
 	} else {
-		snap_value = snap_scale->get_text().to_double();
+		snap_value = snap_scale->get_text().to_float();
 	}
 
 	return snap_value;

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -458,7 +458,7 @@ void SpriteFramesEditor::_animation_select() {
 	}
 
 	if (frames->has_animation(edited_anim)) {
-		double value = anim_speed->get_line_edit()->get_text().to_double();
+		double value = anim_speed->get_line_edit()->get_text().to_float();
 		if (!Math::is_equal_approx(value, frames->get_animation_speed(edited_anim))) {
 			_animation_fps_changed(value);
 		}

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -368,18 +368,18 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				float min = 0, max = 100, step = type == Variant::FLOAT ? .01 : 1;
 				if (c >= 1) {
 					if (!hint_text.get_slice(",", 0).empty()) {
-						min = hint_text.get_slice(",", 0).to_double();
+						min = hint_text.get_slice(",", 0).to_float();
 					}
 				}
 				if (c >= 2) {
 					if (!hint_text.get_slice(",", 1).empty()) {
-						max = hint_text.get_slice(",", 1).to_double();
+						max = hint_text.get_slice(",", 1).to_float();
 					}
 				}
 
 				if (c >= 3) {
 					if (!hint_text.get_slice(",", 2).empty()) {
-						step = hint_text.get_slice(",", 2).to_double();
+						step = hint_text.get_slice(",", 2).to_float();
 					}
 				}
 
@@ -1590,7 +1590,7 @@ real_t CustomPropertyEditor::_parse_real_expression(String text) {
 	Error err = expr->parse(text);
 	real_t out;
 	if (err != OK) {
-		out = value_editor[0]->get_text().to_double();
+		out = value_editor[0]->get_text().to_float();
 	} else {
 		out = expr->execute(Array(), nullptr, false);
 	}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -879,7 +879,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "--time-scale") { // force time scale
 
 			if (I->next()) {
-				Engine::get_singleton()->set_time_scale(I->next()->get().to_double());
+				Engine::get_singleton()->set_time_scale(I->next()->get().to_float());
 				N = I->next()->next();
 			} else {
 				OS::get_singleton()->print("Missing time scale argument, aborting.\n");
@@ -2017,7 +2017,7 @@ bool Main::start() {
 
 			String stretch_mode = GLOBAL_DEF("display/window/stretch/mode", "disabled");
 			String stretch_aspect = GLOBAL_DEF("display/window/stretch/aspect", "ignore");
-			Size2i stretch_size = Size2(GLOBAL_DEF("display/window/size/width", 0),
+			Size2i stretch_size = Size2i(GLOBAL_DEF("display/window/size/width", 0),
 					GLOBAL_DEF("display/window/size/height", 0));
 
 			Window::ContentScaleMode cs_sm = Window::CONTENT_SCALE_MODE_DISABLED;

--- a/modules/gdnative/gdnative/string.cpp
+++ b/modules/gdnative/gdnative/string.cpp
@@ -541,13 +541,7 @@ godot_string GDAPI godot_string_substr(const godot_string *p_self, godot_int p_f
 	return result;
 }
 
-double GDAPI godot_string_to_double(const godot_string *p_self) {
-	const String *self = (const String *)p_self;
-
-	return self->to_double();
-}
-
-godot_real GDAPI godot_string_to_float(const godot_string *p_self) {
+double GDAPI godot_string_to_float(const godot_string *p_self) {
 	const String *self = (const String *)p_self;
 
 	return self->to_float();
@@ -583,8 +577,8 @@ godot_string GDAPI godot_string_camelcase_to_underscore_lowercased(const godot_s
 	return result;
 }
 
-double GDAPI godot_string_char_to_double(const char *p_what) {
-	return String::to_double(p_what);
+double GDAPI godot_string_char_to_float(const char *p_what) {
+	return String::to_float(p_what);
 }
 
 godot_int GDAPI godot_string_char_to_int(const char *p_what) {
@@ -621,8 +615,8 @@ int64_t GDAPI godot_string_to_int64(const godot_string *p_self) {
 	return self->to_int();
 }
 
-double GDAPI godot_string_unicode_char_to_double(const wchar_t *p_str, const wchar_t **r_end) {
-	return String::to_double(p_str, r_end);
+double GDAPI godot_string_unicode_char_to_float(const wchar_t *p_str, const wchar_t **r_end) {
+	return String::to_float(p_str, r_end);
 }
 
 godot_string GDAPI godot_string_get_slice(const godot_string *p_self, godot_string p_splitter, godot_int p_slice) {

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -4237,15 +4237,8 @@
         ]
       },
       {
-        "name": "godot_string_to_double",
-        "return_type": "double",
-        "arguments": [
-          ["const godot_string *", "p_self"]
-        ]
-      },
-      {
         "name": "godot_string_to_float",
-        "return_type": "godot_real",
+        "return_type": "double",
         "arguments": [
           ["const godot_string *", "p_self"]
         ]
@@ -4279,7 +4272,7 @@
         ]
       },
       {
-        "name": "godot_string_char_to_double",
+        "name": "godot_string_char_to_float",
         "return_type": "double",
         "arguments": [
           ["const char *", "p_what"]
@@ -4337,7 +4330,7 @@
         ]
       },
       {
-        "name": "godot_string_unicode_char_to_double",
+        "name": "godot_string_unicode_char_to_float",
         "return_type": "double",
         "arguments": [
           ["const wchar_t *", "p_str"],

--- a/modules/gdnative/include/gdnative/string.h
+++ b/modules/gdnative/include/gdnative/string.h
@@ -145,14 +145,13 @@ godot_string GDAPI godot_string_rpad_with_custom_character(const godot_string *p
 godot_real GDAPI godot_string_similarity(const godot_string *p_self, const godot_string *p_string);
 godot_string GDAPI godot_string_sprintf(const godot_string *p_self, const godot_array *p_values, godot_bool *p_error);
 godot_string GDAPI godot_string_substr(const godot_string *p_self, godot_int p_from, godot_int p_chars);
-double GDAPI godot_string_to_double(const godot_string *p_self);
-godot_real GDAPI godot_string_to_float(const godot_string *p_self);
+double GDAPI godot_string_to_float(const godot_string *p_self);
 godot_int GDAPI godot_string_to_int(const godot_string *p_self);
 
 godot_string GDAPI godot_string_camelcase_to_underscore(const godot_string *p_self);
 godot_string GDAPI godot_string_camelcase_to_underscore_lowercased(const godot_string *p_self);
 godot_string GDAPI godot_string_capitalize(const godot_string *p_self);
-double GDAPI godot_string_char_to_double(const char *p_what);
+double GDAPI godot_string_char_to_float(const char *p_what);
 godot_int GDAPI godot_string_char_to_int(const char *p_what);
 int64_t GDAPI godot_string_wchar_to_int(const wchar_t *p_str);
 godot_int GDAPI godot_string_char_to_int_with_len(const char *p_what, godot_int p_len);
@@ -160,7 +159,7 @@ int64_t GDAPI godot_string_char_to_int64_with_len(const wchar_t *p_str, int p_le
 int64_t GDAPI godot_string_hex_to_int64(const godot_string *p_self);
 int64_t GDAPI godot_string_hex_to_int64_with_prefix(const godot_string *p_self);
 int64_t GDAPI godot_string_to_int64(const godot_string *p_self);
-double GDAPI godot_string_unicode_char_to_double(const wchar_t *p_str, const wchar_t **r_end);
+double GDAPI godot_string_unicode_char_to_float(const wchar_t *p_str, const wchar_t **r_end);
 
 godot_int GDAPI godot_string_get_slice_count(const godot_string *p_self, godot_string p_splitter);
 godot_string GDAPI godot_string_get_slice(const godot_string *p_self, godot_string p_splitter, godot_int p_slice);

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -646,7 +646,7 @@ GDScriptTokenizer::Token GDScriptTokenizer::number() {
 		int64_t value = number.bin_to_int();
 		return make_literal(value);
 	} else if (has_decimal || has_exponent) {
-		double value = number.to_double();
+		double value = number.to_float();
 		return make_literal(value);
 	} else {
 		int64_t value = number.to_int();

--- a/modules/mono/editor/script_class_parser.cpp
+++ b/modules/mono/editor/script_class_parser.cpp
@@ -235,7 +235,7 @@ ScriptClassParser::Token ScriptClassParser::get_token() {
 				if (code[idx] == '-' || (code[idx] >= '0' && code[idx] <= '9')) {
 					//a number
 					const CharType *rptr;
-					double number = String::to_double(&code[idx], &rptr);
+					double number = String::to_float(&code[idx], &rptr);
 					idx += (rptr - &code[idx]);
 					value = number;
 					return TK_NUMBER;

--- a/modules/visual_script/visual_script_expression.cpp
+++ b/modules/visual_script/visual_script_expression.cpp
@@ -489,7 +489,7 @@ Error VisualScriptExpression::_get_token(Token &r_token) {
 					r_token.type = TK_CONSTANT;
 
 					if (is_float) {
-						r_token.value = num.to_double();
+						r_token.value = num.to_float();
 					} else {
 						r_token.value = num.to_int();
 					}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2898,7 +2898,7 @@ Dictionary RichTextLabel::parse_expressions_for_values(Vector<String> p_expressi
 					a.append(false);
 				}
 			} else if (!decimal.search(values[j]).is_null()) {
-				a.append(values[j].to_double());
+				a.append(values[j].to_float());
 			} else if (!numerical.search(values[j]).is_null()) {
 				a.append(values[j].to_int());
 			} else {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1971,7 +1971,7 @@ void Tree::_text_editor_enter(String p_text) {
 			//popup_edited_item->edited_signal.call( popup_edited_item_col );
 		} break;
 		case TreeItem::CELL_MODE_RANGE: {
-			c.val = p_text.to_double();
+			c.val = p_text.to_float();
 			if (c.step > 0) {
 				c.val = Math::stepify(c.val, c.step);
 			}

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -645,7 +645,7 @@ ShaderLanguage::Token ShaderLanguage::_get_token() {
 					if (hexa_found) {
 						tk.constant = (double)str.hex_to_int(true);
 					} else {
-						tk.constant = str.to_double();
+						tk.constant = str.to_float();
 					}
 					tk.line = tk_line;
 

--- a/tests/test_math.cpp
+++ b/tests/test_math.cpp
@@ -242,7 +242,7 @@ class GetClassAndNamespace {
 					if (code[idx] == '-' || (code[idx] >= '0' && code[idx] <= '9')) {
 						//a number
 						const CharType *rptr;
-						double number = String::to_double(&code[idx], &rptr);
+						double number = String::to_float(&code[idx], &rptr);
 						idx += (rptr - &code[idx]);
 						value = number;
 						return TK_NUMBER;

--- a/tests/test_string.h
+++ b/tests/test_string.h
@@ -209,7 +209,7 @@ TEST_CASE("[String] String to float") {
 	static const double num[4] = { -12348298412.2, 0.05, 2.0002, -0.0001 };
 
 	for (int i = 0; i < 4; i++) {
-		CHECK(!(ABS(String(nums[i]).to_double() - num[i]) > 0.00001));
+		CHECK(!(ABS(String(nums[i]).to_float() - num[i]) > 0.00001));
 	}
 }
 


### PR DESCRIPTION
This is in a similar vain to #38713, and fixes #40624.

The current 32-bit and 64-bit methods are identical to each other. Literally, the 32-bit `float` version was just a wrapper:

```cpp
float String::to_float() const {
	return to_double();
}
```

This PR removes the 32-bit versions, and renames the 64-bit versions from "to_double" to "to_float".

Test code:

```gdscript
func _ready():
	print(float("122.54"))
	print(float("99264.899"))
	print(float("12.5"))
	print(float("6998.904"))
	print(float("9.69"))
	print(float("9799.1111"))
```

![Output](https://user-images.githubusercontent.com/1646875/88428797-8f9d7800-cdc3-11ea-8758-258a3540f0ec.png)
