### PR TITLE
Fix DynamicFont breaking mouse grab in inspector spinners

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -677,7 +677,7 @@ DynamicFontAtSize::~DynamicFontAtSize() {
 
 /////////////////////////
 
-void DynamicFont::_reload_cache() {
+void DynamicFont::_reload_cache(const char *p_triggering_property) {
 	ERR_FAIL_COND(cache_id.size < 1);
 	if (!data.is_valid()) {
 		data_at_size.unref();
@@ -705,15 +705,12 @@ void DynamicFont::_reload_cache() {
 	}
 
 	emit_changed();
-	_change_notify();
+	_change_notify(p_triggering_property);
 }
 
 void DynamicFont::set_font_data(const Ref<DynamicFontData> &p_data) {
 	data = p_data;
-	_reload_cache();
-
-	emit_changed();
-	_change_notify();
+	_reload_cache(); // not passing the prop name as clearing the font data also clears fallbacks
 }
 
 Ref<DynamicFontData> DynamicFont::get_font_data() const {
@@ -726,7 +723,7 @@ void DynamicFont::set_size(int p_size) {
 	}
 	cache_id.size = p_size;
 	outline_cache_id.size = p_size;
-	_reload_cache();
+	_reload_cache("size");
 }
 
 int DynamicFont::get_size() const {
@@ -739,7 +736,7 @@ void DynamicFont::set_outline_size(int p_size) {
 	}
 	ERR_FAIL_COND(p_size < 0 || p_size > UINT8_MAX);
 	outline_cache_id.outline_size = p_size;
-	_reload_cache();
+	_reload_cache("outline_size");
 }
 
 int DynamicFont::get_outline_size() const {
@@ -750,7 +747,7 @@ void DynamicFont::set_outline_color(Color p_color) {
 	if (p_color != outline_color) {
 		outline_color = p_color;
 		emit_changed();
-		_change_notify();
+		_change_notify("outline_color");
 	}
 }
 
@@ -797,16 +794,19 @@ int DynamicFont::get_spacing(int p_type) const {
 void DynamicFont::set_spacing(int p_type, int p_value) {
 	if (p_type == SPACING_TOP) {
 		spacing_top = p_value;
+		_change_notify("extra_spacing_top");
 	} else if (p_type == SPACING_BOTTOM) {
 		spacing_bottom = p_value;
+		_change_notify("extra_spacing_bottom");
 	} else if (p_type == SPACING_CHAR) {
 		spacing_char = p_value;
+		_change_notify("extra_spacing_char");
 	} else if (p_type == SPACING_SPACE) {
 		spacing_space = p_value;
+		_change_notify("extra_spacing_space");
 	}
 
 	emit_changed();
-	_change_notify();
 }
 
 float DynamicFont::get_height() const {
@@ -921,7 +921,6 @@ void DynamicFont::add_fallback(const Ref<DynamicFontData> &p_data) {
 		fallback_outline_data_at_size.push_back(fallbacks.write[fallbacks.size() - 1]->_get_dynamic_font_at_size(outline_cache_id));
 	}
 
-	_change_notify();
 	emit_changed();
 	_change_notify();
 }

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -234,7 +234,7 @@ private:
 	Color outline_color;
 
 protected:
-	void _reload_cache();
+	void _reload_cache(const char *p_triggering_property = "");
 
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;


### PR DESCRIPTION
This was caused by DynamicFont not specifying which property was edited, resulting in the whole inspector being recreated

Fixes #25046

Edit: Valuable lessons about code formatting and the tools associated have been learned.