### PR TITLE
Fix code format scripts compat with non-GNU Unices

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,8 +6,8 @@ labels: ''
 assignees: ''
 
 ---
-<!-- Please search existing issues for potential duplicates before filing yours:	
-https://github.com/godotengine/godot/issues?q=is%3Aissue	
+<!-- Please search existing issues for potential duplicates before filing yours:
+https://github.com/godotengine/godot/issues?q=is%3Aissue
 -->
 
 **Godot version:**

--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -35,7 +35,7 @@
 
 
 		func get_recognized_extensions():
-		    return ["gd"]			
+		    return ["gd"]
 		[/codeblock]
 	</description>
 	<tutorials>

--- a/misc/scripts/black_format.sh
+++ b/misc/scripts/black_format.sh
@@ -16,11 +16,9 @@ PY_FILES=$(find \( -path "./.git" \
 black -l 120 $PY_FILES
 
 git diff > patch.patch
-FILESIZE="$(stat -c%s patch.patch)"
-MAXSIZE=5
 
 # If no patch has been generated all is OK, clean up, and exit.
-if (( FILESIZE < MAXSIZE )); then
+if [ ! -s patch.patch ] ; then
     printf "Files in this commit comply with the black style rules.\n"
     rm -f patch.patch
     exit 0

--- a/misc/scripts/clang_format.sh
+++ b/misc/scripts/clang_format.sh
@@ -39,11 +39,9 @@ while IFS= read -rd '' f; do
 done
 
 git diff > patch.patch
-FILESIZE="$(stat -c%s patch.patch)"
-MAXSIZE=5
 
 # If no patch has been generated all is OK, clean up, and exit.
-if (( FILESIZE < MAXSIZE )); then
+if [ ! -s patch.patch ] ; then
     printf "Files in this commit comply with the clang-format style rules.\n"
     rm -f patch.patch
     exit 0

--- a/misc/scripts/file_format.sh
+++ b/misc/scripts/file_format.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
 # This script ensures proper POSIX text file formatting and a few other things.
-# This is supplementary to clang-black-format.sh, but should be run before it.
+# This is supplementary to clang_format.sh and black_format.sh, but should be
+# run before them.
+
+# We need dos2unix and recode.
+if [ ! -x "$(command -v dos2unix)" -o ! -x "$(command -v recode)" ]; then
+    printf "Install 'dos2unix' and 'recode' to use this script.\n"
+fi
 
 set -uo pipefail
 IFS=$'\n\t'
@@ -29,22 +35,17 @@ while IFS= read -rd '' f; do
     recode UTF-8 "$f" 2> /dev/null
     # Ensures that files have LF line endings.
     dos2unix "$f" 2> /dev/null
-    # Ensures that files do not contain a BOM.
-    sed -i '1s/^\xEF\xBB\xBF//' "$f"
-    # Ensures that files end with newline characters.
-    tail -c1 < "$f" | read -r _ || echo >> "$f";
     # Remove trailing space characters.
-    sed -z -i 's/\x20\x0A/\x0A/g' "$f"
+    # -l option handles newlines conveniently and seems to also get rid of BOMs.
+    perl -i -ple 's/\s*$//g' "$f"
     # Remove the character sequence "== true" if it has a leading space.
-    sed -z -i 's/\x20== true//g' "$f"
+    perl -i -pe 's/\x20== true//g' "$f"
 done
 
 git diff > patch.patch
-FILESIZE="$(stat -c%s patch.patch)"
-MAXSIZE=5
 
 # If no patch has been generated all is OK, clean up, and exit.
-if (( FILESIZE < MAXSIZE )); then
+if [ ! -s patch.patch ] ; then
     printf "Files in this commit comply with the formatting rules.\n"
     rm -f patch.patch
     exit 0

--- a/modules/etc/image_etc.cpp
+++ b/modules/etc/image_etc.cpp
@@ -106,7 +106,7 @@ static void _compress_etc(Image *p_img, float p_lossy_quality, bool force_etc1_f
 		// If VRAM compression is using ETC, but image has alpha, convert to RGBA4444 or LA8
 		// This saves space while maintaining the alpha channel
 		if (detected_channels == Image::USED_CHANNELS_RGBA) {
-			
+
 			if (p_img->has_mipmaps()) {
 				// Image doesn't support mipmaps with RGBA4444 textures
 				p_img->clear_mipmaps();

--- a/platform/android/java/lib/src/org/godotengine/godot/vulkan/VkRenderer.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/vulkan/VkRenderer.kt
@@ -71,7 +71,7 @@ internal class VkRenderer {
 	 */
 	fun onVkSurfaceChanged(surface: Surface, width: Int, height: Int) {
 		GodotLib.resize(surface, width, height)
-		
+
 		for (plugin in pluginRegistry.getAllPlugins()) {
 			plugin.onVkSurfaceChanged(surface, width, height)
 		}

--- a/platform/windows/godot.natvis
+++ b/platform/windows/godot.natvis
@@ -19,7 +19,7 @@
 			</ArrayItems>
 		</Expand>
 	</Type>
-	
+
 	<Type Name="List&lt;*&gt;">
 		<Expand>
 			<Item Name="[size]">_data ? (_data->size_cache) : 0</Item>
@@ -62,7 +62,7 @@
 		<DisplayString Condition="type == Variant::POOL_COLOR_ARRAY">{*(PoolColorArray *)_data._mem}</DisplayString>
 
 		<StringView Condition="type == Variant::STRING &amp;&amp; ((String *)(_data._mem))->_cowdata._ptr">((String *)(_data._mem))->_cowdata._ptr,su</StringView>
-		
+
 		<Expand>
 			<Item Name="[value]" Condition="type == Variant::BOOL">_data._bool</Item>
 			<Item Name="[value]" Condition="type == Variant::INT">_data._int</Item>
@@ -143,7 +143,7 @@
 			<Item Name="alpha">a</Item>
 		</Expand>
 	</Type>
-	
+
 	<Type Name="Node" Inheritable="false">
 		<Expand>
 			<Item Name="Object">(Object*)this</Item>


### PR DESCRIPTION
And improve it to also remove trailing tabs, not just spaces.

Not tested on macOS myself but at least this is documented as working on https://stackoverflow.com/a/15416836
CC @RevoluPowered or @bruvzg to confirm.

@aaronfranke The script takes a while to format the codebase, it would be nice if we can find some optimizations:
```
$ time misc/scripts/file_format.sh
real    1m8,844s
user    0m56,079s
sys     0m12,323s
```