### PR TITLE
Removes redundant code generation in VisualShaderNodeTextureUniform

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -63,6 +63,21 @@ bool VisualShaderNode::is_port_separator(int p_index) const {
 	return false;
 }
 
+bool VisualShaderNode::is_output_port_connected(int p_port) const {
+	if (connected_output_ports.has(p_port)) {
+		return connected_output_ports[p_port];
+	}
+	return false;
+}
+
+void VisualShaderNode::set_output_port_connected(int p_port, bool p_connected) {
+	connected_output_ports[p_port] = p_connected;
+}
+
+bool VisualShaderNode::is_code_generated() const {
+	return true;
+}
+
 Vector<VisualShader::DefaultTextureParam> VisualShaderNode::get_default_texture_parameters(VisualShader::Type p_type, int p_id) const {
 	return Vector<VisualShader::DefaultTextureParam>();
 }
@@ -526,6 +541,7 @@ void VisualShader::connect_nodes_forced(Type p_type, int p_from_node, int p_from
 	c.to_port = p_to_port;
 	g->connections.push_back(c);
 	g->nodes[p_to_node].prev_connected_nodes.push_back(p_from_node);
+	g->nodes[p_from_node].node->set_output_port_connected(p_from_port, true);
 
 	_queue_update();
 }
@@ -557,6 +573,7 @@ Error VisualShader::connect_nodes(Type p_type, int p_from_node, int p_from_port,
 	c.to_port = p_to_port;
 	g->connections.push_back(c);
 	g->nodes[p_to_node].prev_connected_nodes.push_back(p_from_node);
+	g->nodes[p_from_node].node->set_output_port_connected(p_from_port, true);
 
 	_queue_update();
 	return OK;
@@ -570,6 +587,7 @@ void VisualShader::disconnect_nodes(Type p_type, int p_from_node, int p_from_por
 		if (E->get().from_node == p_from_node && E->get().from_port == p_from_port && E->get().to_node == p_to_node && E->get().to_port == p_to_port) {
 			g->connections.erase(E);
 			g->nodes[p_to_node].prev_connected_nodes.erase(p_from_node);
+			g->nodes[p_from_node].node->set_output_port_connected(p_from_port, false);
 			_queue_update();
 			return;
 		}
@@ -1105,6 +1123,35 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 
 	// then this node
 
+	Vector<VisualShader::DefaultTextureParam> params = vsnode->get_default_texture_parameters(type, node);
+	for (int i = 0; i < params.size(); i++) {
+		def_tex_params.push_back(params[i]);
+	}
+
+	Ref<VisualShaderNodeInput> input = vsnode;
+	bool skip_global = input.is_valid() && for_preview;
+
+	if (!skip_global) {
+		global_code += vsnode->generate_global(get_mode(), type, node);
+
+		String class_name = vsnode->get_class_name();
+		if (class_name == "VisualShaderNodeCustom") {
+			class_name = vsnode->get_script_instance()->get_script()->get_path();
+		}
+		if (!r_classes.has(class_name)) {
+			global_code_per_node += vsnode->generate_global_per_node(get_mode(), type, node);
+			for (int i = 0; i < TYPE_MAX; i++) {
+				global_code_per_func[Type(i)] += vsnode->generate_global_per_func(get_mode(), Type(i), node);
+			}
+			r_classes.insert(class_name);
+		}
+	}
+
+	if (!vsnode->is_code_generated()) { // just generate globals and ignore locals
+		processed.insert(node);
+		return OK;
+	}
+
 	code += "// " + vsnode->get_caption() + ":" + itos(node) + "\n";
 	Vector<String> input_vars;
 
@@ -1252,30 +1299,6 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 				default: {
 				}
 			}
-		}
-	}
-
-	Vector<VisualShader::DefaultTextureParam> params = vsnode->get_default_texture_parameters(type, node);
-	for (int i = 0; i < params.size(); i++) {
-		def_tex_params.push_back(params[i]);
-	}
-
-	Ref<VisualShaderNodeInput> input = vsnode;
-	bool skip_global = input.is_valid() && for_preview;
-
-	if (!skip_global) {
-		global_code += vsnode->generate_global(get_mode(), type, node);
-
-		String class_name = vsnode->get_class_name();
-		if (class_name == "VisualShaderNodeCustom") {
-			class_name = vsnode->get_script_instance()->get_script()->get_path();
-		}
-		if (!r_classes.has(class_name)) {
-			global_code_per_node += vsnode->generate_global_per_node(get_mode(), type, node);
-			for (int i = 0; i < TYPE_MAX; i++) {
-				global_code_per_func[Type(i)] += vsnode->generate_global_per_func(get_mode(), Type(i), node);
-			}
-			r_classes.insert(class_name);
 		}
 	}
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -182,6 +182,7 @@ class VisualShaderNode : public Resource {
 	int port_preview;
 
 	Map<int, Variant> default_input_values;
+	Map<int, bool> connected_output_ports;
 
 protected:
 	bool simple_decl;
@@ -221,6 +222,11 @@ public:
 	int get_output_port_for_preview() const;
 
 	virtual bool is_port_separator(int p_index) const;
+
+	bool is_output_port_connected(int p_port) const;
+	void set_output_port_connected(int p_port, bool p_connected);
+
+	virtual bool is_code_generated() const;
 
 	virtual Vector<StringName> get_editable_properties() const;
 

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -3915,6 +3915,10 @@ String VisualShaderNodeTextureUniform::generate_global(Shader::Mode p_mode, Visu
 	return code;
 }
 
+bool VisualShaderNodeTextureUniform::is_code_generated() const {
+	return is_output_port_connected(0) || is_output_port_connected(1); // rgb or alpha
+}
+
 String VisualShaderNodeTextureUniform::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String id = get_uniform_name();
 	String code = "\t{\n";

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -1715,6 +1715,8 @@ public:
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
 
+	virtual bool is_code_generated() const override;
+
 	Vector<StringName> get_editable_properties() const override;
 
 	void set_texture_type(TextureType p_type);


### PR DESCRIPTION
This PR removes redundant shader code generation if this node is only be connected through samplerPort.

Before (Godot 3.2):
![image](https://user-images.githubusercontent.com/3036176/88472558-ca66f380-cf1c-11ea-85cc-098b5acf8896.png)

After (Godot 4.0):
![image](https://user-images.githubusercontent.com/3036176/88472592-26317c80-cf1d-11ea-87ae-348f22c09aa4.png)

