### PR TITLE
Enable support for C++ modules tests

### DIFF
--- a/modules/SCsub
+++ b/modules/SCsub
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-Import("env")
-
 import modules_builders
 import os
+
+Import("env")
 
 env_modules = env.Clone()
 
@@ -11,6 +11,15 @@ Export("env_modules")
 
 # Header with MODULE_*_ENABLED defines.
 env.CommandNoCache("modules_enabled.gen.h", Value(env.module_list), modules_builders.generate_modules_enabled)
+
+# Header to be included in `tests/test_main.cpp` to run module-specific tests.
+if env["tests"]:
+    env.CommandNoCache(
+        "modules_tests.gen.h",
+        Value(env.module_list),
+        Action(modules_builders.generate_modules_tests, "Generating modules tests header."),
+    )
+    env.AlwaysBuild("modules_tests.gen.h")
 
 vs_sources = []
 # libmodule_<name>.a for each active module.

--- a/modules/modules_builders.py
+++ b/modules/modules_builders.py
@@ -12,5 +12,16 @@ def generate_modules_enabled(target, source, env):
             f.write("#define %s\n" % ("MODULE_" + module.upper() + "_ENABLED"))
 
 
+def generate_modules_tests(target, source, env):
+    import os
+    import glob
+
+    with open(target[0].path, "w") as f:
+        for name, path in env.module_list.items():
+            headers = glob.glob(os.path.join(path, "tests", "*.h"))
+            for h in headers:
+                f.write('#include "%s"\n' % (os.path.normpath(h)))
+
+
 if __name__ == "__main__":
     subprocess_main(globals())

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -49,6 +49,8 @@
 #include "test_string.h"
 #include "test_validate_testing.h"
 
+#include "modules/modules_tests.gen.h"
+
 #include "thirdparty/doctest/doctest.h"
 
 const char **tests_get_names() {


### PR DESCRIPTION
Modules-specific tests can be written under respective module folders now.

Each module can have "tests" folder created with the tests implemented as headers including `doctest`, so they can be collected by the buildsystem and included directly in `tests/test_main.cpp` to be compiled.

This works both for built-in and `custom_modules`, so you can write your C++ tests outside of Godot core as well (removes the need to use thirdparty GDScript-only testing frameworks).

I've created `modules/gdscript/test_gdscript_dummy.h` file just for the sake of testing, I'll remove this file once this PR is accepted. I've also added `--test --success` switch to the CI configs to include successful assertions in output (again for testing purposes, but we could leave this option on for CI builds).

In theory this could be extended to collect *all* tests within Godot (perhaps have `test_` prefix as a convention), but I think this could negatively impact performance anyway. Yet the benefit of doing so is that no headers would have to be included manually for each test suite created, even for core, but again likely too much.
