### PR TITLE
Fix ultra long node names

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1060,7 +1060,7 @@ void Node::_validate_child_name(Node *p_child, bool p_force_human_readable) {
 
 		bool unique = true;
 
-		if (p_child->data.name == StringName() || p_child->data.name.operator String()[0] == '@') {
+		if (p_child->data.name == StringName()) {
 			//new unique name must be assigned
 			unique = false;
 		} else {


### PR DESCRIPTION
Fixes #15608

Looking at the code, the condition was probably meant to skip checking for name validity. It probably increased performance a bit, but at the cost of the names getting ultra long on multiple additions. The change affects only the scenario when node is removed and re-added, not sure if it happens often enough in the editor to be noticeable.