### PR TITLE
Enable `doctest` within `tests/SCsub`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -650,10 +650,6 @@ if selected_platform in platform_list:
             }
         )
 
-    # Enable test framework globally and inform it of configuration method.
-    if env["tests"]:
-        env.Append(CPPDEFINES=["DOCTEST_CONFIG_IMPLEMENT"])
-
     scons_cache_path = os.environ.get("SCONS_CACHE")
     if scons_cache_path != None:
         CacheDir(scons_cache_path)

--- a/tests/SCsub
+++ b/tests/SCsub
@@ -2,8 +2,14 @@
 
 Import("env")
 
+env_tests = env.Clone()
+
 env.tests_sources = []
-env.add_source_files(env.tests_sources, "*.cpp")
+
+# Enable test framework and inform it of configuration method.
+env_tests.Append(CPPDEFINES=["DOCTEST_CONFIG_IMPLEMENT"])
+
+env_tests.add_source_files(env.tests_sources, "*.cpp")
 
 lib = env.add_library("tests", env.tests_sources)
 env.Prepend(LIBS=[lib])


### PR DESCRIPTION
`DOCTEST_CONFIG_IMPLEMENT` is not added to the entire build anymore. The engine is still rebuilt on switching the `tests=yes/no` option , but at least it's more self-contained now.

> Akien: Yeah if tests=yes changes the base env, everything builds, that's normal.