### PR TITLE
SCons: Build tests/ and main/ in cloned environments

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -593,8 +593,6 @@ if selected_platform in platform_list:
         env.Append(CPPDEFINES=["PTRCALL_ENABLED"])
     if env["tools"]:
         env.Append(CPPDEFINES=["TOOLS_ENABLED"])
-    if env["tests"]:
-        env.Append(CPPDEFINES=["TESTS_ENABLED"])
     if env["disable_3d"]:
         if env["tools"]:
             print(
@@ -649,10 +647,6 @@ if selected_platform in platform_list:
                 )
             }
         )
-
-    # Enable test framework globally and inform it of configuration method.
-    if env["tests"]:
-        env.Append(CPPDEFINES=["DOCTEST_CONFIG_IMPLEMENT"])
 
     scons_cache_path = os.environ.get("SCONS_CACHE")
     if scons_cache_path != None:

--- a/main/SCsub
+++ b/main/SCsub
@@ -7,18 +7,23 @@ import main_builders
 
 env.main_sources = []
 
-env.add_source_files(env.main_sources, "*.cpp")
+env_main = env.Clone()
 
-env.Depends("#main/splash.gen.h", "#main/splash.png")
-env.CommandNoCache("#main/splash.gen.h", "#main/splash.png", run_in_subprocess(main_builders.make_splash))
+env_main.add_source_files(env.main_sources, "*.cpp")
 
-env.Depends("#main/splash_editor.gen.h", "#main/splash_editor.png")
-env.CommandNoCache(
+if env["tests"]:
+    env_main.Append(CPPDEFINES=["TESTS_ENABLED"])
+
+env_main.Depends("#main/splash.gen.h", "#main/splash.png")
+env_main.CommandNoCache("#main/splash.gen.h", "#main/splash.png", run_in_subprocess(main_builders.make_splash))
+
+env_main.Depends("#main/splash_editor.gen.h", "#main/splash_editor.png")
+env_main.CommandNoCache(
     "#main/splash_editor.gen.h", "#main/splash_editor.png", run_in_subprocess(main_builders.make_splash_editor)
 )
 
-env.Depends("#main/app_icon.gen.h", "#main/app_icon.png")
-env.CommandNoCache("#main/app_icon.gen.h", "#main/app_icon.png", run_in_subprocess(main_builders.make_app_icon))
+env_main.Depends("#main/app_icon.gen.h", "#main/app_icon.png")
+env_main.CommandNoCache("#main/app_icon.gen.h", "#main/app_icon.png", run_in_subprocess(main_builders.make_app_icon))
 
-lib = env.add_library("main", env.main_sources)
+lib = env_main.add_library("main", env.main_sources)
 env.Prepend(LIBS=[lib])

--- a/tests/SCsub
+++ b/tests/SCsub
@@ -3,7 +3,13 @@
 Import("env")
 
 env.tests_sources = []
-env.add_source_files(env.tests_sources, "*.cpp")
 
-lib = env.add_library("tests", env.tests_sources)
+env_tests = env.Clone()
+
+# Enable test framework and inform it of configuration method.
+env_tests.Append(CPPDEFINES=["DOCTEST_CONFIG_IMPLEMENT"])
+
+env_tests.add_source_files(env.tests_sources, "*.cpp")
+
+lib = env_tests.add_library("tests", env.tests_sources)
 env.Prepend(LIBS=[lib])


### PR DESCRIPTION
Allows switching `tests=yes`/`no` and rebuilding only tests and main,
instead of the whole engine.

Supersedes #40725.