### PR TITLE
Fixes msvc debugging tests crashing

### DIFF
--- a/tests/SCsub
+++ b/tests/SCsub
@@ -9,6 +9,13 @@ env_tests = env.Clone()
 # Enable test framework and inform it of configuration method.
 env_tests.Append(CPPDEFINES=["DOCTEST_CONFIG_IMPLEMENT"])
 
+# We must disable the THREAD_LOCAL entirely in doctest to prevent crashes on debugging
+# Since we link with /MT thread_local is always expired when the header is used
+# So the debugger crashes the engine and it causes weird errors
+# Explained in https://github.com/onqtam/doctest/issues/401
+if env_tests["platform"] == "windows":
+    env_tests.Append(CPPDEFINES=[("DOCTEST_THREAD_LOCAL", "")])
+
 env_tests.add_source_files(env.tests_sources, "*.cpp")
 
 lib = env_tests.add_library("tests", env.tests_sources)


### PR DESCRIPTION
If you are to debug MSVC tests and don't want it to crash with tests=yes when you attach the MSVC or VSCode debugger (only on windows) this commit fixes the behaviour by removing thread_local entirely from the equation.

In a /MT context the linkage / compiler unit will falsely expire the doctest thread_local calls in all contexts in which it is used therefore we define this context as nothing.

Expiring is pointless as it will always crash unless we use /MD linking which is not going to be supported by Godot.

Resolves #40666 properly