### PR TITLE
Script editor: Fix open dominant logic for language-specific external editors

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2092,7 +2092,9 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 	Ref<Script> script = p_resource;
 
 	// Don't open dominant script if using an external editor.
-	const bool use_external_editor = EditorSettings::get_singleton()->get("text_editor/external/use_external_editor");
+	const bool use_external_editor =
+			EditorSettings::get_singleton()->get("text_editor/external/use_external_editor") ||
+			script->get_language()->overrides_external_editor();
 	const bool open_dominant = EditorSettings::get_singleton()->get("text_editor/files/open_dominant_script_on_scene_change");
 
 	const bool should_open = (open_dominant && !use_external_editor) || !EditorNode::get_singleton()->is_changing_scene();
@@ -3001,7 +3003,9 @@ Array ScriptEditor::_get_open_script_editors() const {
 
 void ScriptEditor::set_scene_root_script(Ref<Script> p_script) {
 	// Don't open dominant script if using an external editor.
-	const bool use_external_editor = EditorSettings::get_singleton()->get("text_editor/external/use_external_editor");
+	const bool use_external_editor =
+			EditorSettings::get_singleton()->get("text_editor/external/use_external_editor") ||
+			p_script->get_language()->overrides_external_editor();
 	const bool open_dominant = EditorSettings::get_singleton()->get("text_editor/files/open_dominant_script_on_scene_change");
 
 	if (open_dominant && !use_external_editor && p_script.is_valid()) {


### PR DESCRIPTION
Follow-up to #40735.