### PR TITLE
Added default value for uniforms in visual shaders

### DIFF
--- a/doc/classes/VisualShaderNodeBooleanUniform.xml
+++ b/doc/classes/VisualShaderNodeBooleanUniform.xml
@@ -10,6 +10,14 @@
 	</tutorials>
 	<methods>
 	</methods>
+	<members>
+		<member name="default_value" type="bool" setter="set_default_value" getter="get_default_value" default="false">
+			A default value to be assigned within the shader.
+		</member>
+		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">
+			Enables usage of the [member default_value].
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeColorUniform.xml
+++ b/doc/classes/VisualShaderNodeColorUniform.xml
@@ -10,6 +10,14 @@
 	</tutorials>
 	<methods>
 	</methods>
+	<members>
+		<member name="default_value" type="Color" setter="set_default_value" getter="get_default_value" default="Color( 1, 1, 1, 1 )">
+			A default value to be assigned within the shader.
+		</member>
+		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">
+			Enables usage of the [member default_value].
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeFloatUniform.xml
+++ b/doc/classes/VisualShaderNodeFloatUniform.xml
@@ -11,6 +11,12 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="default_value" type="float" setter="set_default_value" getter="get_default_value" default="0.0">
+			A default value to be assigned within the shader.
+		</member>
+		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">
+			Enables usage of the [member default_value].
+		</member>
 		<member name="hint" type="int" setter="set_hint" getter="get_hint" enum="VisualShaderNodeFloatUniform.Hint" default="0">
 			A hint applied to the uniform, which controls the values it can take when set through the inspector.
 		</member>

--- a/doc/classes/VisualShaderNodeIntUniform.xml
+++ b/doc/classes/VisualShaderNodeIntUniform.xml
@@ -11,6 +11,12 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="default_value" type="int" setter="set_default_value" getter="get_default_value" default="0">
+			A default value to be assigned within the shader.
+		</member>
+		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">
+			Enables usage of the [member default_value].
+		</member>
 		<member name="hint" type="int" setter="set_hint" getter="get_hint" enum="VisualShaderNodeIntUniform.Hint" default="0">
 			A hint applied to the uniform, which controls the values it can take when set through the inspector.
 		</member>

--- a/doc/classes/VisualShaderNodeTransformUniform.xml
+++ b/doc/classes/VisualShaderNodeTransformUniform.xml
@@ -10,6 +10,14 @@
 	</tutorials>
 	<methods>
 	</methods>
+	<members>
+		<member name="default_value" type="Transform" setter="set_default_value" getter="get_default_value" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+			A default value to be assigned within the shader.
+		</member>
+		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">
+			Enables usage of the [member default_value].
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVec3Uniform.xml
+++ b/doc/classes/VisualShaderNodeVec3Uniform.xml
@@ -10,6 +10,14 @@
 	</tutorials>
 	<methods>
 	</methods>
+	<members>
+		<member name="default_value" type="Vector3" setter="set_default_value" getter="get_default_value" default="Vector3( 0, 0, 0 )">
+			A default value to be assigned within the shader.
+		</member>
+		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">
+			Enables usage of the [member default_value].
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -3435,12 +3435,19 @@ String VisualShaderNodeFloatUniform::get_output_port_name(int p_port) const {
 }
 
 String VisualShaderNodeFloatUniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
+	String code = "";
 	if (hint == HINT_RANGE) {
-		return _get_qual_str() + "uniform float " + get_uniform_name() + " : hint_range(" + rtos(hint_range_min) + ", " + rtos(hint_range_max) + ");\n";
+		code += _get_qual_str() + "uniform float " + get_uniform_name() + " : hint_range(" + rtos(hint_range_min) + ", " + rtos(hint_range_max) + ")";
 	} else if (hint == HINT_RANGE_STEP) {
-		return _get_qual_str() + "uniform float " + get_uniform_name() + " : hint_range(" + rtos(hint_range_min) + ", " + rtos(hint_range_max) + ", " + rtos(hint_range_step) + ");\n";
+		code += _get_qual_str() + "uniform float " + get_uniform_name() + " : hint_range(" + rtos(hint_range_min) + ", " + rtos(hint_range_max) + ", " + rtos(hint_range_step) + ")";
+	} else {
+		code += _get_qual_str() + "uniform float " + get_uniform_name();
 	}
-	return _get_qual_str() + "uniform float " + get_uniform_name() + ";\n";
+	if (default_value_enabled) {
+		code += " = " + rtos(default_value);
+	}
+	code += ";\n";
+	return code;
 }
 
 String VisualShaderNodeFloatUniform::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
@@ -3483,6 +3490,24 @@ float VisualShaderNodeFloatUniform::get_step() const {
 	return hint_range_step;
 }
 
+void VisualShaderNodeFloatUniform::set_default_value_enabled(bool p_enabled) {
+	default_value_enabled = p_enabled;
+	emit_changed();
+}
+
+bool VisualShaderNodeFloatUniform::is_default_value_enabled() const {
+	return default_value_enabled;
+}
+
+void VisualShaderNodeFloatUniform::set_default_value(float p_value) {
+	default_value = p_value;
+	emit_changed();
+}
+
+float VisualShaderNodeFloatUniform::get_default_value() const {
+	return default_value;
+}
+
 void VisualShaderNodeFloatUniform::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_hint", "hint"), &VisualShaderNodeFloatUniform::set_hint);
 	ClassDB::bind_method(D_METHOD("get_hint"), &VisualShaderNodeFloatUniform::get_hint);
@@ -3496,10 +3521,18 @@ void VisualShaderNodeFloatUniform::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_step", "value"), &VisualShaderNodeFloatUniform::set_step);
 	ClassDB::bind_method(D_METHOD("get_step"), &VisualShaderNodeFloatUniform::get_step);
 
+	ClassDB::bind_method(D_METHOD("set_default_value_enabled", "enabled"), &VisualShaderNodeFloatUniform::set_default_value_enabled);
+	ClassDB::bind_method(D_METHOD("is_default_value_enabled"), &VisualShaderNodeFloatUniform::is_default_value_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_default_value", "value"), &VisualShaderNodeFloatUniform::set_default_value);
+	ClassDB::bind_method(D_METHOD("get_default_value"), &VisualShaderNodeFloatUniform::get_default_value);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hint", PROPERTY_HINT_ENUM, "None,Range,Range+Step"), "set_hint", "get_hint");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "min"), "set_min", "get_min");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max"), "set_max", "get_max");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "step"), "set_step", "get_step");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "default_value_enabled"), "set_default_value_enabled", "is_default_value_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "default_value"), "set_default_value", "get_default_value");
 
 	BIND_ENUM_CONSTANT(HINT_NONE);
 	BIND_ENUM_CONSTANT(HINT_RANGE);
@@ -3520,6 +3553,10 @@ Vector<StringName> VisualShaderNodeFloatUniform::get_editable_properties() const
 	if (hint == HINT_RANGE_STEP) {
 		props.push_back("step");
 	}
+	props.push_back("default_value_enabled");
+	if (default_value_enabled) {
+		props.push_back("default_value");
+	}
 	return props;
 }
 
@@ -3528,6 +3565,8 @@ VisualShaderNodeFloatUniform::VisualShaderNodeFloatUniform() {
 	hint_range_min = 0.0;
 	hint_range_max = 1.0;
 	hint_range_step = 0.1;
+	default_value_enabled = false;
+	default_value = 0.0;
 }
 
 ////////////// Integer Uniform
@@ -3561,12 +3600,19 @@ String VisualShaderNodeIntUniform::get_output_port_name(int p_port) const {
 }
 
 String VisualShaderNodeIntUniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
+	String code = "";
 	if (hint == HINT_RANGE) {
-		return _get_qual_str() + "uniform int " + get_uniform_name() + " : hint_range(" + rtos(hint_range_min) + ", " + rtos(hint_range_max) + ");\n";
+		code += _get_qual_str() + "uniform int " + get_uniform_name() + " : hint_range(" + itos(hint_range_min) + ", " + itos(hint_range_max) + ")";
 	} else if (hint == HINT_RANGE_STEP) {
-		return _get_qual_str() + "uniform int " + get_uniform_name() + " : hint_range(" + rtos(hint_range_min) + ", " + rtos(hint_range_max) + ", " + rtos(hint_range_step) + ");\n";
+		code += _get_qual_str() + "uniform int " + get_uniform_name() + " : hint_range(" + itos(hint_range_min) + ", " + itos(hint_range_max) + ", " + itos(hint_range_step) + ")";
+	} else {
+		code += _get_qual_str() + "uniform int " + get_uniform_name();
 	}
-	return _get_qual_str() + "uniform int " + get_uniform_name() + ";\n";
+	if (default_value_enabled) {
+		code += " = " + itos(default_value);
+	}
+	code += ";\n";
+	return code;
 }
 
 String VisualShaderNodeIntUniform::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
@@ -3609,6 +3655,24 @@ int VisualShaderNodeIntUniform::get_step() const {
 	return hint_range_step;
 }
 
+void VisualShaderNodeIntUniform::set_default_value_enabled(bool p_enabled) {
+	default_value_enabled = p_enabled;
+	emit_changed();
+}
+
+bool VisualShaderNodeIntUniform::is_default_value_enabled() const {
+	return default_value_enabled;
+}
+
+void VisualShaderNodeIntUniform::set_default_value(int p_value) {
+	default_value = p_value;
+	emit_changed();
+}
+
+int VisualShaderNodeIntUniform::get_default_value() const {
+	return default_value;
+}
+
 void VisualShaderNodeIntUniform::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_hint", "hint"), &VisualShaderNodeIntUniform::set_hint);
 	ClassDB::bind_method(D_METHOD("get_hint"), &VisualShaderNodeIntUniform::get_hint);
@@ -3622,10 +3686,18 @@ void VisualShaderNodeIntUniform::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_step", "value"), &VisualShaderNodeIntUniform::set_step);
 	ClassDB::bind_method(D_METHOD("get_step"), &VisualShaderNodeIntUniform::get_step);
 
+	ClassDB::bind_method(D_METHOD("set_default_value_enabled", "enabled"), &VisualShaderNodeIntUniform::set_default_value_enabled);
+	ClassDB::bind_method(D_METHOD("is_default_value_enabled"), &VisualShaderNodeIntUniform::is_default_value_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_default_value", "value"), &VisualShaderNodeIntUniform::set_default_value);
+	ClassDB::bind_method(D_METHOD("get_default_value"), &VisualShaderNodeIntUniform::get_default_value);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hint", PROPERTY_HINT_ENUM, "None,Range,Range+Step"), "set_hint", "get_hint");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "min"), "set_min", "get_min");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max"), "set_max", "get_max");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "step"), "set_step", "get_step");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "default_value_enabled"), "set_default_value_enabled", "is_default_value_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "default_value"), "set_default_value", "get_default_value");
 
 	BIND_ENUM_CONSTANT(HINT_NONE);
 	BIND_ENUM_CONSTANT(HINT_RANGE);
@@ -3646,6 +3718,10 @@ Vector<StringName> VisualShaderNodeIntUniform::get_editable_properties() const {
 	if (hint == HINT_RANGE_STEP) {
 		props.push_back("step");
 	}
+	props.push_back("default_value_enabled");
+	if (default_value_enabled) {
+		props.push_back("default_value");
+	}
 	return props;
 }
 
@@ -3654,6 +3730,8 @@ VisualShaderNodeIntUniform::VisualShaderNodeIntUniform() {
 	hint_range_min = 0;
 	hint_range_max = 100;
 	hint_range_step = 1;
+	default_value_enabled = false;
+	default_value = 0;
 }
 
 ////////////// Boolean Uniform
@@ -3686,19 +3764,68 @@ String VisualShaderNodeBooleanUniform::get_output_port_name(int p_port) const {
 	return ""; //no output port means the editor will be used as port
 }
 
+void VisualShaderNodeBooleanUniform::set_default_value_enabled(bool p_enabled) {
+	default_value_enabled = p_enabled;
+	emit_changed();
+}
+
+bool VisualShaderNodeBooleanUniform::is_default_value_enabled() const {
+	return default_value_enabled;
+}
+
+void VisualShaderNodeBooleanUniform::set_default_value(bool p_value) {
+	default_value = p_value;
+	emit_changed();
+}
+
+bool VisualShaderNodeBooleanUniform::get_default_value() const {
+	return default_value;
+}
+
 String VisualShaderNodeBooleanUniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
-	return _get_qual_str() + "uniform bool " + get_uniform_name() + ";\n";
+	String code = _get_qual_str() + "uniform bool " + get_uniform_name();
+	if (default_value_enabled) {
+		if (default_value) {
+			code += " = true";
+		} else {
+			code += " = false";
+		}
+	}
+	code += ";\n";
+	return code;
 }
 
 String VisualShaderNodeBooleanUniform::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	return "\t" + p_output_vars[0] + " = " + get_uniform_name() + ";\n";
 }
 
+void VisualShaderNodeBooleanUniform::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_default_value_enabled", "enabled"), &VisualShaderNodeBooleanUniform::set_default_value_enabled);
+	ClassDB::bind_method(D_METHOD("is_default_value_enabled"), &VisualShaderNodeBooleanUniform::is_default_value_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_default_value", "value"), &VisualShaderNodeBooleanUniform::set_default_value);
+	ClassDB::bind_method(D_METHOD("get_default_value"), &VisualShaderNodeBooleanUniform::get_default_value);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "default_value_enabled"), "set_default_value_enabled", "is_default_value_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "default_value"), "set_default_value", "get_default_value");
+}
+
 bool VisualShaderNodeBooleanUniform::is_qualifier_supported(Qualifier p_qual) const {
 	return true; // all qualifiers are supported
 }
 
+Vector<StringName> VisualShaderNodeBooleanUniform::get_editable_properties() const {
+	Vector<StringName> props = VisualShaderNodeUniform::get_editable_properties();
+	props.push_back("default_value_enabled");
+	if (default_value_enabled) {
+		props.push_back("default_value");
+	}
+	return props;
+}
+
 VisualShaderNodeBooleanUniform::VisualShaderNodeBooleanUniform() {
+	default_value_enabled = false;
+	default_value = false;
 }
 
 ////////////// Color Uniform
@@ -3731,8 +3858,31 @@ String VisualShaderNodeColorUniform::get_output_port_name(int p_port) const {
 	return p_port == 0 ? "color" : "alpha"; //no output port means the editor will be used as port
 }
 
+void VisualShaderNodeColorUniform::set_default_value_enabled(bool p_enabled) {
+	default_value_enabled = p_enabled;
+	emit_changed();
+}
+
+bool VisualShaderNodeColorUniform::is_default_value_enabled() const {
+	return default_value_enabled;
+}
+
+void VisualShaderNodeColorUniform::set_default_value(const Color &p_value) {
+	default_value = p_value;
+	emit_changed();
+}
+
+Color VisualShaderNodeColorUniform::get_default_value() const {
+	return default_value;
+}
+
 String VisualShaderNodeColorUniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
-	return _get_qual_str() + "uniform vec4 " + get_uniform_name() + " : hint_color;\n";
+	String code = _get_qual_str() + "uniform vec4 " + get_uniform_name() + " : hint_color";
+	if (default_value_enabled) {
+		code += vformat(" = vec4(%.6f, %.6f, %.6f, %.6f)", default_value.r, default_value.g, default_value.b, default_value.a);
+	}
+	code += ";\n";
+	return code;
 }
 
 String VisualShaderNodeColorUniform::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
@@ -3741,11 +3891,33 @@ String VisualShaderNodeColorUniform::generate_code(Shader::Mode p_mode, VisualSh
 	return code;
 }
 
+void VisualShaderNodeColorUniform::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_default_value_enabled", "enabled"), &VisualShaderNodeColorUniform::set_default_value_enabled);
+	ClassDB::bind_method(D_METHOD("is_default_value_enabled"), &VisualShaderNodeColorUniform::is_default_value_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_default_value", "value"), &VisualShaderNodeColorUniform::set_default_value);
+	ClassDB::bind_method(D_METHOD("get_default_value"), &VisualShaderNodeColorUniform::get_default_value);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "default_value_enabled"), "set_default_value_enabled", "is_default_value_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "default_value"), "set_default_value", "get_default_value");
+}
+
 bool VisualShaderNodeColorUniform::is_qualifier_supported(Qualifier p_qual) const {
 	return true; // all qualifiers are supported
 }
 
+Vector<StringName> VisualShaderNodeColorUniform::get_editable_properties() const {
+	Vector<StringName> props = VisualShaderNodeUniform::get_editable_properties();
+	props.push_back("default_value_enabled");
+	if (default_value_enabled) {
+		props.push_back("default_value");
+	}
+	return props;
+}
+
 VisualShaderNodeColorUniform::VisualShaderNodeColorUniform() {
+	default_value_enabled = false;
+	default_value = Color(1.0, 1.0, 1.0, 1.0);
 }
 
 ////////////// Vector Uniform
@@ -3778,19 +3950,64 @@ String VisualShaderNodeVec3Uniform::get_output_port_name(int p_port) const {
 	return ""; //no output port means the editor will be used as port
 }
 
+void VisualShaderNodeVec3Uniform::set_default_value_enabled(bool p_enabled) {
+	default_value_enabled = p_enabled;
+	emit_changed();
+}
+
+bool VisualShaderNodeVec3Uniform::is_default_value_enabled() const {
+	return default_value_enabled;
+}
+
+void VisualShaderNodeVec3Uniform::set_default_value(const Vector3 &p_value) {
+	default_value = p_value;
+	emit_changed();
+}
+
+Vector3 VisualShaderNodeVec3Uniform::get_default_value() const {
+	return default_value;
+}
+
 String VisualShaderNodeVec3Uniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
-	return _get_qual_str() + "uniform vec3 " + get_uniform_name() + ";\n";
+	String code = _get_qual_str() + "uniform vec3 " + get_uniform_name();
+	if (default_value_enabled) {
+		code += vformat(" = vec3(%.6f, %.6f, %.6f)", default_value.x, default_value.y, default_value.z);
+	}
+	code += ";\n";
+	return code;
 }
 
 String VisualShaderNodeVec3Uniform::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	return "\t" + p_output_vars[0] + " = " + get_uniform_name() + ";\n";
 }
 
+void VisualShaderNodeVec3Uniform::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_default_value_enabled", "enabled"), &VisualShaderNodeVec3Uniform::set_default_value_enabled);
+	ClassDB::bind_method(D_METHOD("is_default_value_enabled"), &VisualShaderNodeVec3Uniform::is_default_value_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_default_value", "value"), &VisualShaderNodeVec3Uniform::set_default_value);
+	ClassDB::bind_method(D_METHOD("get_default_value"), &VisualShaderNodeVec3Uniform::get_default_value);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "default_value_enabled"), "set_default_value_enabled", "is_default_value_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "default_value"), "set_default_value", "get_default_value");
+}
+
 bool VisualShaderNodeVec3Uniform::is_qualifier_supported(Qualifier p_qual) const {
 	return true; // all qualifiers are supported
 }
 
+Vector<StringName> VisualShaderNodeVec3Uniform::get_editable_properties() const {
+	Vector<StringName> props = VisualShaderNodeUniform::get_editable_properties();
+	props.push_back("default_value_enabled");
+	if (default_value_enabled) {
+		props.push_back("default_value");
+	}
+	return props;
+}
+
 VisualShaderNodeVec3Uniform::VisualShaderNodeVec3Uniform() {
+	default_value_enabled = false;
+	default_value = Vector3(0.0, 0.0, 0.0);
 }
 
 ////////////// Transform Uniform
@@ -3823,19 +4040,68 @@ String VisualShaderNodeTransformUniform::get_output_port_name(int p_port) const 
 	return ""; //no output port means the editor will be used as port
 }
 
+void VisualShaderNodeTransformUniform::set_default_value_enabled(bool p_enabled) {
+	default_value_enabled = p_enabled;
+	emit_changed();
+}
+
+bool VisualShaderNodeTransformUniform::is_default_value_enabled() const {
+	return default_value_enabled;
+}
+
+void VisualShaderNodeTransformUniform::set_default_value(const Transform &p_value) {
+	default_value = p_value;
+	emit_changed();
+}
+
+Transform VisualShaderNodeTransformUniform::get_default_value() const {
+	return default_value;
+}
+
 String VisualShaderNodeTransformUniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
-	return _get_qual_str() + "uniform mat4 " + get_uniform_name() + ";\n";
+	String code = _get_qual_str() + "uniform mat4 " + get_uniform_name();
+	if (default_value_enabled) {
+		Vector3 row0 = default_value.basis.get_row(0);
+		Vector3 row1 = default_value.basis.get_row(1);
+		Vector3 row2 = default_value.basis.get_row(2);
+		Vector3 origin = default_value.origin;
+		code += " = mat4(" + vformat("vec4(%.6f, %.6f, %.6f, 0.0)", row0.x, row0.y, row0.z) + vformat(", vec4(%.6f, %.6f, %.6f, 0.0)", row1.x, row1.y, row1.z) + vformat(", vec4(%.6f, %.6f, %.6f, 0.0)", row2.x, row2.y, row2.z) + vformat(", vec4(%.6f, %.6f, %.6f, 1.0)", origin.x, origin.y, origin.z) + ")";
+	}
+	code += ";\n";
+	return code;
 }
 
 String VisualShaderNodeTransformUniform::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	return "\t" + p_output_vars[0] + " = " + get_uniform_name() + ";\n";
 }
 
+void VisualShaderNodeTransformUniform::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_default_value_enabled", "enabled"), &VisualShaderNodeTransformUniform::set_default_value_enabled);
+	ClassDB::bind_method(D_METHOD("is_default_value_enabled"), &VisualShaderNodeTransformUniform::is_default_value_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_default_value", "value"), &VisualShaderNodeTransformUniform::set_default_value);
+	ClassDB::bind_method(D_METHOD("get_default_value"), &VisualShaderNodeTransformUniform::get_default_value);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "default_value_enabled"), "set_default_value_enabled", "is_default_value_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM, "default_value"), "set_default_value", "get_default_value");
+}
+
 bool VisualShaderNodeTransformUniform::is_qualifier_supported(Qualifier p_qual) const {
 	return true; // all qualifiers are supported
 }
 
+Vector<StringName> VisualShaderNodeTransformUniform::get_editable_properties() const {
+	Vector<StringName> props = VisualShaderNodeUniform::get_editable_properties();
+	props.push_back("default_value_enabled");
+	if (default_value_enabled) {
+		props.push_back("default_value");
+	}
+	return props;
+}
+
 VisualShaderNodeTransformUniform::VisualShaderNodeTransformUniform() {
+	default_value_enabled = false;
+	default_value = Transform(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0);
 }
 
 ////////////// Texture Uniform

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -1486,6 +1486,8 @@ private:
 	float hint_range_min;
 	float hint_range_max;
 	float hint_range_step;
+	bool default_value_enabled;
+	float default_value;
 
 protected:
 	static void _bind_methods();
@@ -1516,6 +1518,12 @@ public:
 	void set_step(float p_value);
 	float get_step() const;
 
+	void set_default_value_enabled(bool p_enabled);
+	bool is_default_value_enabled() const;
+
+	void set_default_value(float p_value);
+	float get_default_value() const;
+
 	bool is_qualifier_supported(Qualifier p_qual) const override;
 
 	virtual Vector<StringName> get_editable_properties() const override;
@@ -1540,6 +1548,8 @@ private:
 	int hint_range_min;
 	int hint_range_max;
 	int hint_range_step;
+	bool default_value_enabled;
+	int default_value;
 
 protected:
 	static void _bind_methods();
@@ -1570,6 +1580,12 @@ public:
 	void set_step(int p_value);
 	int get_step() const;
 
+	void set_default_value_enabled(bool p_enabled);
+	bool is_default_value_enabled() const;
+
+	void set_default_value(int p_value);
+	int get_default_value() const;
+
 	bool is_qualifier_supported(Qualifier p_qual) const override;
 
 	virtual Vector<StringName> get_editable_properties() const override;
@@ -1584,6 +1600,13 @@ VARIANT_ENUM_CAST(VisualShaderNodeIntUniform::Hint)
 class VisualShaderNodeBooleanUniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeBooleanUniform, VisualShaderNodeUniform);
 
+private:
+	bool default_value_enabled;
+	bool default_value;
+
+protected:
+	static void _bind_methods();
+
 public:
 	virtual String get_caption() const override;
 
@@ -1598,7 +1621,15 @@ public:
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
 
+	void set_default_value_enabled(bool p_enabled);
+	bool is_default_value_enabled() const;
+
+	void set_default_value(bool p_value);
+	bool get_default_value() const;
+
 	bool is_qualifier_supported(Qualifier p_qual) const override;
+
+	virtual Vector<StringName> get_editable_properties() const override;
 
 	VisualShaderNodeBooleanUniform();
 };
@@ -1608,6 +1639,13 @@ public:
 class VisualShaderNodeColorUniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeColorUniform, VisualShaderNodeUniform);
 
+private:
+	bool default_value_enabled;
+	Color default_value;
+
+protected:
+	static void _bind_methods();
+
 public:
 	virtual String get_caption() const override;
 
@@ -1622,7 +1660,15 @@ public:
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
 
+	void set_default_value_enabled(bool p_enabled);
+	bool is_default_value_enabled() const;
+
+	void set_default_value(const Color &p_value);
+	Color get_default_value() const;
+
 	bool is_qualifier_supported(Qualifier p_qual) const override;
+
+	virtual Vector<StringName> get_editable_properties() const override;
 
 	VisualShaderNodeColorUniform();
 };
@@ -1632,6 +1678,13 @@ public:
 class VisualShaderNodeVec3Uniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeVec3Uniform, VisualShaderNodeUniform);
 
+private:
+	bool default_value_enabled;
+	Vector3 default_value;
+
+protected:
+	static void _bind_methods();
+
 public:
 	virtual String get_caption() const override;
 
@@ -1646,7 +1699,15 @@ public:
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
 
+	void set_default_value_enabled(bool p_enabled);
+	bool is_default_value_enabled() const;
+
+	void set_default_value(const Vector3 &p_value);
+	Vector3 get_default_value() const;
+
 	bool is_qualifier_supported(Qualifier p_qual) const override;
+
+	virtual Vector<StringName> get_editable_properties() const override;
 
 	VisualShaderNodeVec3Uniform();
 };
@@ -1656,6 +1717,13 @@ public:
 class VisualShaderNodeTransformUniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeTransformUniform, VisualShaderNodeUniform);
 
+private:
+	bool default_value_enabled;
+	Transform default_value;
+
+protected:
+	static void _bind_methods();
+
 public:
 	virtual String get_caption() const override;
 
@@ -1670,7 +1738,15 @@ public:
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
 
+	void set_default_value_enabled(bool p_enabled);
+	bool is_default_value_enabled() const;
+
+	void set_default_value(const Transform &p_value);
+	Transform get_default_value() const;
+
 	bool is_qualifier_supported(Qualifier p_qual) const override;
+
+	virtual Vector<StringName> get_editable_properties() const override;
 
 	VisualShaderNodeTransformUniform();
 };


### PR DESCRIPTION
Added possibility to the setup a default value for Float,Int,Boolean,Color,Vector and Transform uniforms.

![image](https://user-images.githubusercontent.com/3036176/88537565-7809fd80-d016-11ea-9b72-7e100bcf9368.png)

Closes https://github.com/godotengine/godot-proposals/issues/807

