### PR TITLE
Cancel/OK swap on HTML5 platform, small fixes.

### DIFF
--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -829,6 +829,8 @@ DisplayServer *DisplayServerJavaScript::create_func(const String &p_rendering_dr
 }
 
 DisplayServerJavaScript::DisplayServerJavaScript(const String &p_rendering_driver, WindowMode p_mode, uint32_t p_flags, const Vector2i &p_resolution, Error &r_error) {
+	r_error = OK; // Always succeeds for now.
+
 	RasterizerDummy::make_current(); // TODO GLES2 in Godot 4.0... or webgpu?
 #if 0
 	EmscriptenWebGLContextAttributes attributes;

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -831,6 +831,17 @@ DisplayServer *DisplayServerJavaScript::create_func(const String &p_rendering_dr
 DisplayServerJavaScript::DisplayServerJavaScript(const String &p_rendering_driver, WindowMode p_mode, uint32_t p_flags, const Vector2i &p_resolution, Error &r_error) {
 	r_error = OK; // Always succeeds for now.
 
+	/* clang-format off */
+	swap_cancel_ok = EM_ASM_INT({
+		const win = (['Windows', 'Win64', 'Win32', 'WinCE']);
+		const plat = navigator.platform || "";
+		if (win.indexOf(plat) !== -1) {
+			return 1;
+		}
+		return 0;
+	}) == 1;
+	/* clang-format on */
+
 	RasterizerDummy::make_current(); // TODO GLES2 in Godot 4.0... or webgpu?
 #if 0
 	EmscriptenWebGLContextAttributes attributes;
@@ -1181,6 +1192,10 @@ void DisplayServerJavaScript::process_events() {
 
 int DisplayServerJavaScript::get_current_video_driver() const {
 	return 1;
+}
+
+bool DisplayServerJavaScript::get_swap_cancel_ok() {
+	return swap_cancel_ok;
 }
 
 void DisplayServerJavaScript::swap_buffers() {

--- a/platform/javascript/display_server_javascript.h
+++ b/platform/javascript/display_server_javascript.h
@@ -56,6 +56,8 @@ class DisplayServerJavaScript : public DisplayServer {
 	int last_width = 0;
 	int last_height = 0;
 
+	bool swap_cancel_ok = false;
+
 	// utilities
 	static Point2 compute_position_in_canvas(int p_x, int p_y);
 	static void focus_canvas();
@@ -195,6 +197,7 @@ public:
 	virtual void set_icon(const Ref<Image> &p_icon);
 
 	// others
+	virtual bool get_swap_cancel_ok();
 	virtual void swap_buffers();
 
 	static void register_javascript_driver();

--- a/platform/javascript/javascript_main.cpp
+++ b/platform/javascript/javascript_main.cpp
@@ -34,6 +34,7 @@
 #include "platform/javascript/os_javascript.h"
 
 #include <emscripten/emscripten.h>
+#include <stdlib.h>
 
 static OS_JavaScript *os = nullptr;
 static uint64_t target_ticks = 0;


### PR DESCRIPTION
In this PR:

- Two small fixes to address DisplayServer init, and `javascript_main.cpp` compilation and syncing with `3.2` (see #40432).
- Implement Cancel/OK UI button swap for HTML5 platform when Windows is detected. Fixes #30653 .

You can test it by checking the result of `DisplayServer.get_cancel_ok_swap()` (given there is no rendering yet).
For testing, you can override the platform value in firefox via `about:config` by setting a new property `general.platform.override` with the desired `string` value.

For a `3.2` version (where you can see the actual swap happening, and for easy cherry-pick) [see this branch](https://github.com/godotengine/godot/compare/3.2...Faless:js/swap_ok_cancel_3.2)