### PR TITLE
[iOS] Safe area reimplementation

### DIFF
--- a/platform/iphone/display_server_iphone.mm
+++ b/platform/iphone/display_server_iphone.mm
@@ -492,7 +492,22 @@ Size2i DisplayServerIPhone::screen_get_size(int p_screen) const {
 }
 
 Rect2i DisplayServerIPhone::screen_get_usable_rect(int p_screen) const {
-	return Rect2i(screen_get_position(p_screen), screen_get_size(p_screen));
+	if (@available(iOS 11, *)) {
+		UIEdgeInsets insets = UIEdgeInsetsZero;
+		UIView *view = AppDelegate.viewController.godotView;
+
+		if ([view respondsToSelector:@selector(safeAreaInsets)]) {
+			insets = [view safeAreaInsets];
+		}
+
+		float scale = screen_get_scale(p_screen);
+		Size2i insets_position = Size2i(insets.left, insets.top) * scale;
+		Size2i insets_size = Size2i(insets.left + insets.right, insets.top + insets.bottom) * scale;
+
+		return Rect2i(screen_get_position(p_screen) + insets_position, screen_get_size(p_screen) - insets_size);
+	} else {
+		return Rect2i(screen_get_position(p_screen), screen_get_size(p_screen));
+	}
 }
 
 int DisplayServerIPhone::screen_get_dpi(int p_screen) const {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Reimplements usage of `safeAreaInsets` for `master` branch and `Vulkan` support.
Tested with this GDScript on `Panel` with `Panel` child:
```
func _ready():
	var rect = DisplayServer.screen_get_usable_rect()
	var screen_size = DisplayServer.screen_get_size()
	var view_size = get_size()
	
	var aspect_y = view_size.y / screen_size.y
	var aspect_x = view_size.x / screen_size.x
	
	$Panel.set_position(Vector2(rect.position.x * aspect_x, rect.position.y * aspect_y))
	$Panel.set_size(Vector2(rect.size.x * aspect_x, rect.size.y * aspect_y))
```

<details>
<summary>
Result  
</summary>

**Storyboard**

<img src="https://user-images.githubusercontent.com/3750083/88556100-46eaf680-d031-11ea-8953-c743d6354382.jpg" height="250" /> <img src="https://user-images.githubusercontent.com/3750083/88556106-49e5e700-d031-11ea-910a-fae5a7c0e3f8.jpg" height="250" />

**Project**

<img src="https://user-images.githubusercontent.com/3750083/88556113-4c484100-d031-11ea-8693-2c388548ebaa.jpg" height="250" /> <img src="https://user-images.githubusercontent.com/3750083/88556123-4e120480-d031-11ea-8a6f-9dab92d0ea2b.jpg" height="250" />
</details>