### PR TITLE
Make threaded loading safe

### DIFF
--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -94,7 +94,7 @@ void Crypto::_bind_methods() {
 
 /// Resource loader/saver
 
-RES ResourceFormatLoaderCrypto::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderCrypto::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	String el = p_path.get_extension().to_lower();
 	if (el == "crt") {
 		X509Certificate *cert = X509Certificate::create();

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -92,8 +92,10 @@ public:
 };
 
 class ResourceFormatLoaderCrypto : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -122,7 +122,7 @@ void ImageLoader::cleanup() {
 
 /////////////////
 
-RES ResourceFormatLoaderImage::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderImage::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	if (!f) {
 		if (r_error) {

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -71,8 +71,10 @@ public:
 };
 
 class ResourceFormatLoaderImage : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -962,7 +962,7 @@ ResourceLoaderBinary::~ResourceLoaderBinary() {
 	}
 }
 
-RES ResourceFormatLoaderBinary::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderBinary::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (r_error) {
 		*r_error = ERR_FILE_CANT_OPEN;
 	}

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -102,8 +102,10 @@ public:
 };
 
 class ResourceFormatLoaderBinary : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -115,7 +115,7 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 	return OK;
 }
 
-RES ResourceFormatImporter::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatImporter::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	PathAndType pat;
 	Error err = _get_path_and_type(p_path, pat);
 

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -55,9 +55,11 @@ class ResourceFormatImporter : public ResourceFormatLoader {
 
 	Vector<Ref<ResourceImporter>> importers;
 
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
 	static ResourceFormatImporter *get_singleton() { return singleton; }
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
 	virtual bool recognize_path(const String &p_path, const String &p_for_type = String()) const;

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -31,6 +31,7 @@
 #include "resource_loader.h"
 
 #include "core/io/resource_importer.h"
+#include "core/message_queue.h"
 #include "core/os/file_access.h"
 #include "core/os/os.h"
 #include "core/print_string.h"
@@ -114,6 +115,13 @@ void ResourceFormatLoader::get_recognized_extensions(List<String> *p_extensions)
 }
 
 RES ResourceFormatLoader::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+	MessageQueue::get_singleton()->set_current_thread_accumulation_enabled(true);
+	RES result = _load(p_path, p_original_path, r_error, p_use_sub_threads, r_progress, p_no_cache);
+	MessageQueue::get_singleton()->set_current_thread_accumulation_enabled(false);
+	return result;
+}
+
+RES ResourceFormatLoader::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (get_script_instance() && get_script_instance()->has_method("load")) {
 		Variant res = get_script_instance()->call("load", p_path, p_original_path, p_use_sub_threads);
 

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -41,8 +41,10 @@ class ResourceFormatLoader : public Reference {
 protected:
 	static void _bind_methods();
 
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache);
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
+	RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual bool exists(const String &p_path) const;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -189,7 +189,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 	return translation;
 }
 
-RES TranslationLoaderPO::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES TranslationLoaderPO::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (r_error) {
 		*r_error = ERR_CANT_OPEN;
 	}

--- a/core/io/translation_loader_po.h
+++ b/core/io/translation_loader_po.h
@@ -36,9 +36,11 @@
 #include "core/translation.h"
 
 class TranslationLoaderPO : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
 	static RES load_translation(FileAccess *f, Error *r_error = nullptr);
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/core/message_queue.cpp
+++ b/core/message_queue.cpp
@@ -64,25 +64,34 @@ Error MessageQueue::push_set(ObjectID p_id, const StringName &p_prop, const Vari
 
 	uint8_t room_needed = sizeof(Message) + sizeof(Variant);
 
-	if ((buffer_end + room_needed) >= buffer_size) {
-		String type;
-		if (ObjectDB::get_instance(p_id)) {
-			type = ObjectDB::get_instance(p_id)->get_class();
+	Map<Thread::ID, ThreadBuffer>::Element *thread_buffer = thread_buffers.find(Thread::get_caller_id());
+	uint8_t *write_ptr;
+	if (likely(!thread_buffer)) {
+		if ((buffer_end + room_needed) >= buffer_size) {
+			String type;
+			if (ObjectDB::get_instance(p_id)) {
+				type = ObjectDB::get_instance(p_id)->get_class();
+			}
+			print_line("Failed set: " + type + ":" + p_prop + " target ID: " + itos(p_id));
+			statistics();
+			ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_kb' in project settings.");
 		}
-		print_line("Failed set: " + type + ":" + p_prop + " target ID: " + itos(p_id));
-		statistics();
-		ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_kb' in project settings.");
+		write_ptr = &buffer[buffer_end];
+		buffer_end += room_needed;
+	} else {
+		int curr_size = thread_buffer->get().data.size();
+		thread_buffer->get().data.resize(curr_size + room_needed);
+		write_ptr = thread_buffer->get().data.ptr() + curr_size;
 	}
 
-	Message *msg = memnew_placement(&buffer[buffer_end], Message);
+	Message *msg = memnew_placement(write_ptr, Message);
 	msg->args = 1;
 	msg->callable = Callable(p_id, p_prop);
 	msg->type = TYPE_SET;
 
-	buffer_end += sizeof(Message);
+	write_ptr += sizeof(Message);
 
-	Variant *v = memnew_placement(&buffer[buffer_end], Variant);
-	buffer_end += sizeof(Variant);
+	Variant *v = memnew_placement(write_ptr, Variant);
 	*v = p_value;
 
 	return OK;
@@ -95,20 +104,32 @@ Error MessageQueue::push_notification(ObjectID p_id, int p_notification) {
 
 	uint8_t room_needed = sizeof(Message);
 
-	if ((buffer_end + room_needed) >= buffer_size) {
-		print_line("Failed notification: " + itos(p_notification) + " target ID: " + itos(p_id));
-		statistics();
-		ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_kb' in project settings.");
+	Map<Thread::ID, ThreadBuffer>::Element *thread_buffer = thread_buffers.find(Thread::get_caller_id());
+	uint8_t *write_ptr;
+	if (likely(!thread_buffer)) {
+		if ((buffer_end + room_needed) >= buffer_size) {
+			String type;
+			if (ObjectDB::get_instance(p_id)) {
+				type = ObjectDB::get_instance(p_id)->get_class();
+			}
+			print_line("Failed notification: " + itos(p_notification) + " target ID: " + itos(p_id));
+			statistics();
+			ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_kb' in project settings.");
+		}
+		write_ptr = &buffer[buffer_end];
+		buffer_end += room_needed;
+	} else {
+		int curr_size = thread_buffer->get().data.size();
+		thread_buffer->get().data.resize(curr_size + room_needed);
+		write_ptr = thread_buffer->get().data.ptr() + curr_size;
 	}
 
-	Message *msg = memnew_placement(&buffer[buffer_end], Message);
+	Message *msg = memnew_placement(write_ptr, Message);
 
 	msg->type = TYPE_NOTIFICATION;
 	msg->callable = Callable(p_id, CoreStringNames::get_singleton()->notification); //name is meaningless but callable needs it
 	//msg->target;
 	msg->notification = p_notification;
-
-	buffer_end += sizeof(Message);
 
 	return OK;
 }
@@ -130,13 +151,23 @@ Error MessageQueue::push_callable(const Callable &p_callable, const Variant **p_
 
 	int room_needed = sizeof(Message) + sizeof(Variant) * p_argcount;
 
-	if ((buffer_end + room_needed) >= buffer_size) {
-		print_line("Failed method: " + p_callable);
-		statistics();
-		ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_kb' in project settings.");
+	Map<Thread::ID, ThreadBuffer>::Element *thread_buffer = thread_buffers.find(Thread::get_caller_id());
+	uint8_t *write_ptr;
+	if (likely(!thread_buffer)) {
+		if ((buffer_end + room_needed) >= buffer_size) {
+			print_line("Failed method: " + p_callable);
+			statistics();
+			ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_kb' in project settings.");
+		}
+		write_ptr = &buffer[buffer_end];
+		buffer_end += room_needed;
+	} else {
+		int curr_size = thread_buffer->get().data.size();
+		thread_buffer->get().data.resize(curr_size + room_needed);
+		write_ptr = thread_buffer->get().data.ptr() + curr_size;
 	}
 
-	Message *msg = memnew_placement(&buffer[buffer_end], Message);
+	Message *msg = memnew_placement(write_ptr, Message);
 	msg->args = p_argcount;
 	msg->callable = p_callable;
 	msg->type = TYPE_CALL;
@@ -144,11 +175,11 @@ Error MessageQueue::push_callable(const Callable &p_callable, const Variant **p_
 		msg->type |= FLAG_SHOW_ERROR;
 	}
 
-	buffer_end += sizeof(Message);
+	write_ptr += sizeof(Message);
 
 	for (int i = 0; i < p_argcount; i++) {
-		Variant *v = memnew_placement(&buffer[buffer_end], Variant);
-		buffer_end += sizeof(Variant);
+		Variant *v = memnew_placement(write_ptr, Variant);
+		write_ptr += sizeof(Variant);
 		*v = *p_args[i];
 	}
 
@@ -170,7 +201,50 @@ Error MessageQueue::push_callable(const Callable &p_callable, VARIANT_ARG_DECLAR
 	return push_callable(p_callable, argptr, argc);
 }
 
+void MessageQueue::set_current_thread_accumulation_enabled(bool p_enabled) {
+	_THREAD_SAFE_METHOD_
+
+	Thread::ID caller_tid = Thread::get_caller_id();
+
+	if (caller_tid == Thread::get_main_id()) {
+		return;
+	}
+
+	Map<Thread::ID, ThreadBuffer>::Element *thread_buffer = thread_buffers.find(caller_tid);
+
+	if (p_enabled) {
+		if (!thread_buffer) {
+			thread_buffer = thread_buffers.insert(caller_tid, ThreadBuffer());
+			thread_buffer->get().users = 1;
+		} else {
+			thread_buffer->get().users++;
+		}
+	} else {
+		ERR_FAIL_COND(!thread_buffer);
+
+		bool must_flush = --thread_buffer->get().users == 0;
+		if (must_flush) {
+			int thread_buffer_size = thread_buffer->get().data.size();
+			if (thread_buffer_size) {
+				// Append this thread's buffer to the main one so it's processed on the next flush
+				if (buffer_end + thread_buffer_size >= buffer_size) {
+					print_line("Failed flushing of queue for thread ID: " + itos(caller_tid));
+					statistics();
+					ERR_FAIL_MSG("Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_kb' in project settings.");
+				} else {
+					memcpy(buffer + buffer_end, thread_buffer->get().data.ptr(), thread_buffer_size);
+					buffer_end += thread_buffer_size;
+				}
+			}
+
+			thread_buffers.erase(thread_buffer);
+		}
+	}
+}
+
 void MessageQueue::statistics() {
+	// TODO: Report about thread-specific buffers (they end up contributing to the main buffer, but some numbers won't harm)
+
 	Map<StringName, int> set_count;
 	Map<int, int> notify_count;
 	Map<Callable, int> call_count;

--- a/core/message_queue.h
+++ b/core/message_queue.h
@@ -31,7 +31,10 @@
 #ifndef MESSAGE_QUEUE_H
 #define MESSAGE_QUEUE_H
 
+#include "core/local_vector.h"
+#include "core/map.h"
 #include "core/object.h"
+#include "core/os/thread.h"
 #include "core/os/thread_safe.h"
 
 class MessageQueue {
@@ -71,6 +74,12 @@ class MessageQueue {
 
 	bool flushing = false;
 
+	struct ThreadBuffer {
+		LocalVector<uint8_t> data;
+		int users;
+	};
+	Map<Thread::ID, ThreadBuffer> thread_buffers;
+
 public:
 	static MessageQueue *get_singleton();
 
@@ -91,6 +100,8 @@ public:
 	bool is_flushing() const;
 
 	int get_max_buffer_usage() const;
+
+	void set_current_thread_accumulation_enabled(bool p_enabled);
 
 	MessageQueue();
 	~MessageQueue();

--- a/drivers/dummy/texture_loader_dummy.cpp
+++ b/drivers/dummy/texture_loader_dummy.cpp
@@ -35,7 +35,7 @@
 
 #include <string.h>
 
-RES ResourceFormatDummyTexture::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatDummyTexture::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	unsigned int width = 8;
 	unsigned int height = 8;
 

--- a/drivers/dummy/texture_loader_dummy.h
+++ b/drivers/dummy/texture_loader_dummy.h
@@ -35,8 +35,10 @@
 #include "scene/resources/texture.h"
 
 class ResourceFormatDummyTexture : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -94,7 +94,7 @@ static const DDSFormatInfo dds_format_info[DDS_MAX] = {
 	{ "GRAYSCALE_ALPHA", false, false, 1, 2, Image::FORMAT_LA8 }
 };
 
-RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatDDS::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (r_error) {
 		*r_error = ERR_CANT_OPEN;
 	}

--- a/modules/dds/texture_loader_dds.h
+++ b/modules/dds/texture_loader_dds.h
@@ -35,8 +35,10 @@
 #include "scene/resources/texture.h"
 
 class ResourceFormatDDS : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/modules/etc/texture_loader_pkm.cpp
+++ b/modules/etc/texture_loader_pkm.cpp
@@ -42,7 +42,7 @@ struct ETC1Header {
 	uint16_t origHeight;
 };
 
-RES ResourceFormatPKM::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatPKM::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (r_error) {
 		*r_error = ERR_CANT_OPEN;
 	}

--- a/modules/etc/texture_loader_pkm.h
+++ b/modules/etc/texture_loader_pkm.h
@@ -35,8 +35,10 @@
 #include "scene/resources/texture.h"
 
 class ResourceFormatPKM : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/modules/gdnative/gdnative.cpp
+++ b/modules/gdnative/gdnative.cpp
@@ -508,7 +508,7 @@ Error GDNative::get_symbol(StringName p_procedure_name, void *&r_handle, bool p_
 	return result;
 }
 
-RES GDNativeLibraryResourceLoader::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES GDNativeLibraryResourceLoader::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	Ref<GDNativeLibrary> lib;
 	lib.instance();
 

--- a/modules/gdnative/gdnative.h
+++ b/modules/gdnative/gdnative.h
@@ -165,8 +165,10 @@ public:
 };
 
 class GDNativeLibraryResourceLoader : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1932,7 +1932,7 @@ void NativeReloadNode::_notification(int p_what) {
 #endif
 }
 
-RES ResourceFormatLoaderNativeScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderNativeScript::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	return ResourceFormatLoaderText::singleton->load(p_path, p_original_path, r_error);
 }
 

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -393,8 +393,10 @@ public:
 };
 
 class ResourceFormatLoaderNativeScript : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/modules/gdnative/pluginscript/pluginscript_loader.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_loader.cpp
@@ -39,7 +39,7 @@ ResourceFormatLoaderPluginScript::ResourceFormatLoaderPluginScript(PluginScriptL
 	_language = language;
 }
 
-RES ResourceFormatLoaderPluginScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderPluginScript::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (r_error) {
 		*r_error = ERR_FILE_CANT_OPEN;
 	}

--- a/modules/gdnative/pluginscript/pluginscript_loader.h
+++ b/modules/gdnative/pluginscript/pluginscript_loader.h
@@ -41,9 +41,11 @@ class PluginScriptLanguage;
 class ResourceFormatLoaderPluginScript : public ResourceFormatLoader {
 	PluginScriptLanguage *_language;
 
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
 	ResourceFormatLoaderPluginScript(PluginScriptLanguage *language);
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/modules/gdnative/videodecoder/video_stream_gdnative.cpp
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.cpp
@@ -360,7 +360,7 @@ void VideoStreamGDNative::set_audio_track(int p_track) {
 
 /* --- NOTE ResourceFormatLoaderVideoStreamGDNative starts here. ----- */
 
-RES ResourceFormatLoaderVideoStreamGDNative::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderVideoStreamGDNative::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	if (!f) {
 		if (r_error) {

--- a/modules/gdnative/videodecoder/video_stream_gdnative.h
+++ b/modules/gdnative/videodecoder/video_stream_gdnative.h
@@ -195,8 +195,10 @@ public:
 };
 
 class ResourceFormatLoaderVideoStreamGDNative : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2045,7 +2045,7 @@ Ref<GDScript> GDScriptLanguage::get_orphan_subclass(const String &p_qualified_na
 
 /*************** RESOURCE ***************/
 
-RES ResourceFormatLoaderGDScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderGDScript::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (r_error) {
 		*r_error = ERR_FILE_CANT_OPEN;
 	}

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -500,8 +500,10 @@ public:
 };
 
 class ResourceFormatLoaderGDScript : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -3676,7 +3676,7 @@ void CSharpScript::get_members(Set<StringName> *p_members) {
 
 /*************** RESOURCE ***************/
 
-RES ResourceFormatLoaderCSharpScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderCSharpScript::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (r_error) {
 		*r_error = ERR_FILE_CANT_OPEN;
 	}

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -531,8 +531,10 @@ public:
 };
 
 class ResourceFormatLoaderCSharpScript : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false) override;
 	void get_recognized_extensions(List<String> *p_extensions) const override;
 	bool handles_type(const String &p_type) const override;
 	String get_resource_type(const String &p_path) const override;

--- a/modules/pvr/texture_loader_pvr.cpp
+++ b/modules/pvr/texture_loader_pvr.cpp
@@ -51,7 +51,7 @@ enum PVRFLags {
 
 };
 
-RES ResourceFormatPVR::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatPVR::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (r_error) {
 		*r_error = ERR_CANT_OPEN;
 	}

--- a/modules/pvr/texture_loader_pvr.h
+++ b/modules/pvr/texture_loader_pvr.h
@@ -35,8 +35,10 @@
 #include "scene/resources/texture.h"
 
 class ResourceFormatPVR : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path, Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -697,7 +697,7 @@ void VideoStreamTheora::_bind_methods() {
 
 ////////////
 
-RES ResourceFormatLoaderTheora::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderTheora::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	if (!f) {
 		if (r_error) {

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -184,8 +184,10 @@ public:
 };
 
 class ResourceFormatLoaderTheora : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -429,7 +429,7 @@ void VideoStreamWebm::set_audio_track(int p_track) {
 
 ////////////
 
-RES ResourceFormatLoaderWebm::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderWebm::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	if (!f) {
 		if (r_error) {

--- a/modules/webm/video_stream_webm.h
+++ b/modules/webm/video_stream_webm.h
@@ -125,8 +125,10 @@ public:
 };
 
 class ResourceFormatLoaderWebm : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -1107,7 +1107,7 @@ void DynamicFont::update_oversampling() {
 
 /////////////////////////
 
-RES ResourceFormatLoaderDynamicFont::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderDynamicFont::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (r_error) {
 		*r_error = ERR_FILE_CANT_OPEN;
 	}

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -304,8 +304,10 @@ VARIANT_ENUM_CAST(DynamicFont::SpacingType);
 /////////////
 
 class ResourceFormatLoaderDynamicFont : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -633,7 +633,7 @@ BitmapFont::~BitmapFont() {
 
 ////////////
 
-RES ResourceFormatLoaderBMFont::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderBMFont::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (r_error) {
 		*r_error = ERR_FILE_CANT_OPEN;
 	}

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -199,8 +199,10 @@ public:
 };
 
 class ResourceFormatLoaderBMFont : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1248,7 +1248,7 @@ String ResourceLoaderText::recognize(FileAccess *p_f) {
 
 /////////////////////
 
-RES ResourceFormatLoaderText::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderText::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (r_error) {
 		*r_error = ERR_CANT_OPEN;
 	}

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -132,9 +132,11 @@ public:
 };
 
 class ResourceFormatLoaderText : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
 	static ResourceFormatLoaderText *singleton;
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -164,7 +164,7 @@ Shader::~Shader() {
 
 ////////////
 
-RES ResourceFormatLoaderShader::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderShader::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	if (r_error) {
 		*r_error = ERR_FILE_CANT_OPEN;
 	}

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -102,8 +102,10 @@ public:
 VARIANT_ENUM_CAST(Shader::Mode);
 
 class ResourceFormatLoaderShader : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -762,7 +762,7 @@ StreamTexture2D::~StreamTexture2D() {
 	}
 }
 
-RES ResourceFormatLoaderStreamTexture2D::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderStreamTexture2D::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	Ref<StreamTexture2D> st;
 	st.instance();
 	Error err = st->load(p_path);
@@ -2215,7 +2215,7 @@ StreamTextureLayered::~StreamTextureLayered() {
 
 /////////////////////////////////////////////////
 
-RES ResourceFormatLoaderStreamTextureLayered::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
+RES ResourceFormatLoaderStreamTextureLayered::_load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) {
 	Ref<StreamTextureLayered> st;
 	if (p_path.get_extension().to_lower() == "stexarray") {
 		Ref<StreamTexture2DArray> s;

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -208,8 +208,10 @@ public:
 };
 
 class ResourceFormatLoaderStreamTexture2D : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;
@@ -508,8 +510,10 @@ public:
 };
 
 class ResourceFormatLoaderStreamTextureLayered : public ResourceFormatLoader {
+protected:
+	virtual RES _load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, bool p_no_cache) override;
+
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;


### PR DESCRIPTION
Loading resources from a thread other than the main was not safe because a number of resource types schedule a "flush" to get updated according to the loaded values for their properties.

That "flush" generally consists in a deferred call to their `_update()` member function. In other words, calls to that function are added to the `MessageQueue`.

Resource loading in Godot 4.0 is threaded by design, so **race conditions happen since the main thread will keep running, flushing the `MessageQueue` and therefore running those calls to the relevant update/flush, while a loading thread may still be dealing with the resource**.

This PR addresses that problem by doing this:
- Adding to `MessageQueue` the ability for the current thread to opt-in to accumulation of deferred calls. When a thread that opted-in decides to opt-out, the accumulated message buffer for it is appended to the regular message queue so they are run when it's safe to do so.
- Ensuring every resource load opts-in to that feature for loading and opts-out when done. `ResourceFormatLoader::load()` has been refactored so that it's not overridabl; it now just opts-in, calls through the virtual protected `_load()` -which is were specific resource loaders do the bulk of the work now- and opts-out. This way, no changes are required in how each resource type is written and doesn't require special care when writing new types.

---
**This code is generously donated by IMVU.**