### PR TITLE
[3.x] Make threaded loading safe

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -629,7 +629,8 @@ Ref<Resource> ResourceInteractiveLoaderBinary::get_resource() {
 
 	return resource;
 }
-Error ResourceInteractiveLoaderBinary::poll() {
+
+Error ResourceInteractiveLoaderBinary::_poll() {
 
 	if (error != OK)
 		return error;

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -82,10 +82,11 @@ class ResourceInteractiveLoaderBinary : public ResourceInteractiveLoader {
 
 	Error parse_variant(Variant &r_v);
 
+	virtual Error _poll();
+
 public:
 	virtual void set_local_path(const String &p_local_path);
 	virtual Ref<Resource> get_resource();
-	virtual Error poll();
 	virtual int get_stage() const;
 	virtual int get_stage_count() const;
 	virtual void set_translation_remapped(bool p_remapped);

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -31,6 +31,7 @@
 #include "resource_loader.h"
 
 #include "core/io/resource_importer.h"
+#include "core/message_queue.h"
 #include "core/os/file_access.h"
 #include "core/os/os.h"
 #include "core/path_remap.h"
@@ -42,6 +43,14 @@
 Ref<ResourceFormatLoader> ResourceLoader::loader[ResourceLoader::MAX_LOADERS];
 
 int ResourceLoader::loader_count = 0;
+
+Error ResourceInteractiveLoader::poll() {
+
+	MessageQueue::get_singleton()->set_current_thread_accumulation_enabled(true);
+	Error result = _poll();
+	MessageQueue::get_singleton()->set_current_thread_accumulation_enabled(false);
+	return result;
+}
 
 Error ResourceInteractiveLoader::wait() {
 
@@ -124,13 +133,14 @@ class ResourceInteractiveLoaderDefault : public ResourceInteractiveLoader {
 
 	GDCLASS(ResourceInteractiveLoaderDefault, ResourceInteractiveLoader);
 
+	virtual Error _poll() { return ERR_FILE_EOF; }
+
 public:
 	Ref<Resource> resource;
 
 	virtual void set_local_path(const String &p_local_path) { /*scene->set_filename(p_local_path);*/
 	}
 	virtual Ref<Resource> get_resource() { return resource; }
-	virtual Error poll() { return ERR_FILE_EOF; }
 	virtual int get_stage() const { return 1; }
 	virtual int get_stage_count() const { return 1; }
 	virtual void set_translation_remapped(bool p_remapped) { resource->set_as_translation_remapped(p_remapped); }

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -43,11 +43,12 @@ class ResourceInteractiveLoader : public Reference {
 
 protected:
 	static void _bind_methods();
+	virtual Error _poll() = 0;
 
 public:
 	virtual void set_local_path(const String &p_local_path) = 0;
 	virtual Ref<Resource> get_resource() = 0;
-	virtual Error poll() = 0;
+	Error poll();
 	virtual int get_stage() const = 0;
 	virtual int get_stage_count() const = 0;
 	virtual void set_translation_remapped(bool p_remapped) = 0;

--- a/core/message_queue.h
+++ b/core/message_queue.h
@@ -31,8 +31,11 @@
 #ifndef MESSAGE_QUEUE_H
 #define MESSAGE_QUEUE_H
 
+#include "core/map.h"
 #include "core/object.h"
+#include "core/os/thread.h"
 #include "core/os/thread_safe.h"
+#include "core/vector.h"
 
 class MessageQueue {
 
@@ -74,6 +77,12 @@ class MessageQueue {
 
 	bool flushing;
 
+	struct ThreadBuffer {
+		Vector<uint8_t> data;
+		int users;
+	};
+	Map<Thread::ID, ThreadBuffer> thread_buffers;
+
 public:
 	static MessageQueue *get_singleton();
 
@@ -92,6 +101,8 @@ public:
 	bool is_flushing() const;
 
 	int get_max_buffer_usage() const;
+
+	void set_current_thread_accumulation_enabled(bool p_enabled);
 
 	MessageQueue();
 	~MessageQueue();

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -389,7 +389,7 @@ Ref<PackedScene> ResourceInteractiveLoaderText::_parse_node_tag(VariantParser::R
 	return packed_scene;
 }
 
-Error ResourceInteractiveLoaderText::poll() {
+Error ResourceInteractiveLoaderText::_poll() {
 
 	if (error != OK)
 		return error;

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -109,10 +109,11 @@ class ResourceInteractiveLoaderText : public ResourceInteractiveLoader {
 
 	Ref<PackedScene> _parse_node_tag(VariantParser::ResourceParser &parser);
 
+	virtual Error _poll();
+
 public:
 	virtual void set_local_path(const String &p_local_path);
 	virtual Ref<Resource> get_resource();
-	virtual Error poll();
 	virtual int get_stage() const;
 	virtual int get_stage_count() const;
 	virtual void set_translation_remapped(bool p_remapped);


### PR DESCRIPTION
Loading resources from a thread other than the main was not safe because a number of resource types schedule a "flush" to get updated according to the loaded values for their properties.

That "flush" generally consists in a deferred call to their `_update()` member function. In other words, calls to that function are added to the `MessageQueue`.

The problem is that if the resource is loaded from another thread, **race conditions happen since the main thread will keep running, flushing the `MessageQueue` and therefore running those calls to `_update()`, while the loading thread may still be dealing with the resource**.

This PR addresses that problem by doing this:
- Adding to `MessageQueue` the ability for the current thread to opt-in to accumulation of deferred calls. When a thread that opted-in decides to opt-out, the accumulated message buffer for it is appended to the regular message queue so they are run when it's safe to do so.
- Making primitive resource loaders (text/binary) use that feature. This way no changes are required on every resource type. To further improve the robustness of this approach, `ResourceInteractiveLoader::poll()` has been refactored so that it's not meant to be overridden (it takes care of the opt-in/opt-out). Derived classes now implement the virtual protected `_poll()` instead, so this new approach is not an added concern to them.

---
**This code is generously donated by IMVU.**