### PR TITLE
[4.0] [iOS] Native loading screen implementation

### DIFF
--- a/platform/iphone/godot_view.h
+++ b/platform/iphone/godot_view.h
@@ -32,12 +32,20 @@
 
 class String;
 
+@class GodotView;
 @protocol DisplayLayer;
 @protocol GodotViewRendererProtocol;
+
+@protocol GodotViewDelegate
+
+- (BOOL)godotViewFinishedSetup:(GodotView *)view;
+
+@end
 
 @interface GodotView : UIView
 
 @property(assign, nonatomic) id<GodotViewRendererProtocol> renderer;
+@property(assign, nonatomic) id<GodotViewDelegate> delegate;
 
 @property(assign, readonly, nonatomic) BOOL isActive;
 

--- a/platform/iphone/godot_view.mm
+++ b/platform/iphone/godot_view.mm
@@ -120,6 +120,7 @@ static const int max_touches = 8;
 	[self stopRendering];
 
 	self.renderer = nil;
+	self.delegate = nil;
 
 	if (self.renderingLayer) {
 		[self.renderingLayer removeFromSuperlayer];
@@ -239,6 +240,14 @@ static const int max_touches = 8;
 
 	if ([self.renderer setupView:self]) {
 		return;
+	}
+
+	if (self.delegate) {
+		BOOL delegateFinishedSetup = [self.delegate godotViewFinishedSetup:self];
+
+		if (!delegateFinishedSetup) {
+			return;
+		}
 	}
 
 	[self handleMotion];

--- a/platform/iphone/view_controller.mm
+++ b/platform/iphone/view_controller.mm
@@ -40,11 +40,13 @@
 #import <AVFoundation/AVFoundation.h>
 #import <GameController/GameController.h>
 
-@interface ViewController ()
+@interface ViewController () <GodotViewDelegate>
 
 @property(strong, nonatomic) GodotViewRenderer *renderer;
 @property(strong, nonatomic) GodotNativeVideoView *videoView;
 @property(strong, nonatomic) GodotKeyboardInputView *keyboardView;
+
+@property(strong, nonatomic) UIView *godotLoadingOverlay;
 
 @end
 
@@ -62,6 +64,7 @@
 	self.view = view;
 
 	view.renderer = self.renderer;
+	view.delegate = self;
 }
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
@@ -97,6 +100,7 @@
 	[super viewDidLoad];
 
 	[self observeKeyboard];
+	[self displayLoadingOverlay];
 
 	if (@available(iOS 11.0, *)) {
 		[self setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
@@ -121,6 +125,31 @@
 				 object:nil];
 }
 
+- (void)displayLoadingOverlay {
+	NSBundle *bundle = [NSBundle mainBundle];
+	NSString *storyboardName = @"Launch Screen";
+
+	if ([bundle pathForResource:storyboardName ofType:@"storyboardc"] == nil) {
+		return;
+	}
+
+	UIStoryboard *launchStoryboard = [UIStoryboard storyboardWithName:storyboardName bundle:bundle];
+
+	UIViewController *controller = [launchStoryboard instantiateInitialViewController];
+	self.godotLoadingOverlay = controller.view;
+	self.godotLoadingOverlay.frame = self.view.bounds;
+	self.godotLoadingOverlay.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+
+	[self.view addSubview:self.godotLoadingOverlay];
+}
+
+- (BOOL)godotViewFinishedSetup:(GodotView *)view {
+	[self.godotLoadingOverlay removeFromSuperview];
+	self.godotLoadingOverlay = nil;
+
+	return YES;
+}
+
 - (void)dealloc {
 	[self.videoView stopVideo];
 
@@ -129,6 +158,11 @@
 	self.keyboardView = nil;
 
 	self.renderer = nil;
+
+	if (self.godotLoadingOverlay) {
+		[self.godotLoadingOverlay removeFromSuperview];
+		self.godotLoadingOverlay = nil;
+	}
 
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 }


### PR DESCRIPTION
Implements native loading screen for iOS. 
If storyboard named `Launch Screen` is present it will be used as overlay while `Main` performs `setup` and `setup2`.

Could be ported to `3.2` to eliminate black screen appearing between iOS's loading image and loading screen displayed by Godot.

<details>
<summary>
Result
</summary>

<img src="https://user-images.githubusercontent.com/3750083/88563247-6fc3b980-d03a-11ea-9194-1f5dcdca96b5.gif" height="250" />

</details>

