### PR TITLE
SkeletonIK changes and bug fixes

### DIFF
--- a/scene/3d/skeleton_ik_3d.h
+++ b/scene/3d/skeleton_ik_3d.h
@@ -52,7 +52,6 @@ class FabrikInverseKinematic {
 
 		// Bone info
 		BoneId bone = -1;
-		PhysicalBone3D *pb = nullptr;
 
 		real_t length = 0;
 		/// Positions relative to root bone
@@ -112,8 +111,6 @@ public:
 private:
 	/// Init a chain that starts from the root to tip
 	static bool build_chain(Task *p_task, bool p_force_simple_chain = true);
-
-	static void update_chain(const Skeleton3D *p_sk, ChainItem *p_chain_item);
 
 	static void solve_simple(Task *p_task, bool p_solve_magnet);
 	/// Special solvers that solve only chains with one end effector


### PR DESCRIPTION
Changes to SkeletonIK:
* Removed the pointers to PhysicalBone in the code, as they were unused.
* Forward ported the SkeletonIK bone scaling fix I made from Godot 3.2 to Godot 4.0. I realized that even with my current GSoC work, the SkeletonIK node will probably need to be updated to give everyone time to transition to the new SkeletonModification system.
* Fixed issue where the root bone in the IK chain would not rotate correctly. ~~It is not the most ideal fix, but it works while all of the other changes and fixes I tried did not~~. Closes #39893.
  * Turns out the issue was the `update_chain` function being called in `solve`. Removing the function fixes the issue and has no adverse effects in any of the projects I tested. The SkeletonIK node still works with AnimationPlayer nodes (Skeleton3D or otherwise) and when moved around in the scene.
* Fixed issue where the scale of the Skeleton node would change the position of the target for SkeletonIK. ~~Now the target's world transform is converted to a global pose, which fixes the issue.~~ Fixed by converting the target's world transform a global pose on each solve. Closes #40466.

________

These changes can probably be cherry picked to Godot 3, since many of the bugs are present in both versions. If it is needed or wanted, I can make a Godot 3 PR with the same changes.