### PR TITLE
Fixed inconsistent base class detection

### DIFF
--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -33,6 +33,7 @@
 #include "core/core_string_names.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
+#include "core/os/file_access.h"
 #include "core/project_settings.h"
 
 #include <stdint.h>
@@ -162,7 +163,7 @@ void ScriptServer::init_languages() {
 
 			for (int i = 0; i < script_classes.size(); i++) {
 				Dictionary c = script_classes[i];
-				if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base")) {
+				if (!c.has("class") || !c.has("language") || !c.has("path") || !FileAccess::exists(c["path"]) || !c.has("base")) {
 					continue;
 				}
 				add_global_class(c["class"], c["base"], c["language"], c["path"]);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes #40584 and, also #35442.

I could not reproduce #40584 on the `master` branch on a previous commit (but I can't remember what commit it was), but the branch could also benefit from this patch.

The gist of the problem here is that users may have moved global script classes after these classes have been registered and saved to the project settings file whilst the engine wasn't running.

Upon initialization, the paths of these global classes were never checked to see if they still existed before registering them, which as it turns out caused issues in determining the base class of the global class later down the road somehow.

~~This patch also delays loading the global class icons until the newly found global classes have been registered and their icon paths been found.~~