### PR TITLE
[3.x] Move Bullet physics query flush from Bullet space pre-tick callback to Bullet physics flush_queries() again.

### DIFF
--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -1572,6 +1572,12 @@ void BulletPhysicsServer::sync() {
 }
 
 void BulletPhysicsServer::flush_queries() {
+	if (!active)
+		return;
+
+	for (int i = 0; i < active_spaces_count; ++i) {
+		active_spaces[i]->flush_queries();
+	}
 }
 
 void BulletPhysicsServer::finish() {

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -1003,10 +1003,15 @@ void RigidBodyBullet::reload_space_override_modificator() {
 		newAngularDamp += space->get_angular_damp();
 	}
 
-	btVector3 newBtGravity;
-	G_TO_B(newGravity * gravity_scale, newBtGravity);
+	if (omit_forces_integration) {
+		// Custom behaviour.
+		btBody->setGravity(btVector3(0, 0, 0));
+	} else {
+		btVector3 newBtGravity;
+		G_TO_B(newGravity * gravity_scale, newBtGravity);
+		btBody->setGravity(newBtGravity);
+	}
 
-	btBody->setGravity(newBtGravity);
 	btBody->setDamping(newLinearDamp, newAngularDamp);
 }
 

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -561,10 +561,6 @@ void SpaceBullet::remove_all_collision_objects() {
 	}
 }
 
-void onBulletPreTickCallback(btDynamicsWorld *p_dynamicsWorld, btScalar timeStep) {
-	static_cast<SpaceBullet *>(p_dynamicsWorld->getWorldUserInfo())->flush_queries();
-}
-
 void onBulletTickCallback(btDynamicsWorld *p_dynamicsWorld, btScalar timeStep) {
 
 	const btCollisionObjectArray &colObjArray = p_dynamicsWorld->getCollisionObjectArray();
@@ -636,7 +632,6 @@ void SpaceBullet::create_empty_world(bool p_create_soft_world) {
 
 	dynamicsWorld->setWorldUserInfo(this);
 
-	dynamicsWorld->setInternalTickCallback(onBulletPreTickCallback, this, true);
 	dynamicsWorld->setInternalTickCallback(onBulletTickCallback, this, false);
 	dynamicsWorld->getBroadphase()->getOverlappingPairCache()->setInternalGhostPairCallback(ghostPairCallback); // Setup ghost check
 	dynamicsWorld->getPairCache()->setOverlapFilterCallback(godotFilterCallback);


### PR DESCRIPTION
This reverts commit 10544f1cf777324efc676565ecc698f8ba9f06e3.

As per discussion [here](https://github.com/godotengine/godot/pull/40185#issuecomment-664977928), #40185 was reverted for 3.2.3, because of a regression issues. Once all the regression issues have been resolved this change can be reapplied.

Regression issues that need to be resolved before applying this PR:
- [ ] #40486
- [x] #40508 - Fixed with c31acd0058cb or a 3.2 cherry-pick of #42650.
- [x] #40739 - Fixed with #40990

**Edit:** I've added the fix for #40508 as a separate commit to this PR.

Closes #37702