### PR TITLE
Set 2D weight equal to mass x gravity.

### DIFF
--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -168,7 +168,7 @@
 		<member name="sleeping" type="bool" setter="set_sleeping" getter="is_sleeping" default="false">
 			If [code]true[/code], the body will not move and will not calculate forces until woken up by another body through, for example, a collision, or by using the [method apply_impulse] or [method add_force] methods.
 		</member>
-		<member name="weight" type="float" setter="set_weight" getter="get_weight" default="9.8">
+		<member name="weight" type="float" setter="set_weight" getter="get_weight" default="98">
 			The body's weight based on its mass and the [b]Default Gravity[/b] value in [b]Project &gt; Project Settings &gt; Physics &gt; 2d[/b].
 		</member>
 	</members>

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -493,11 +493,11 @@ real_t RigidBody2D::get_inertia() const {
 }
 
 void RigidBody2D::set_weight(real_t p_weight) {
-	set_mass(p_weight / (real_t(GLOBAL_DEF("physics/2d/default_gravity", 98)) / 10));
+	set_mass(p_weight / real_t(GLOBAL_GET("physics/2d/default_gravity")));
 }
 
 real_t RigidBody2D::get_weight() const {
-	return mass * (real_t(GLOBAL_DEF("physics/2d/default_gravity", 98)) / 10);
+	return mass * real_t(GLOBAL_GET("physics/2d/default_gravity"));
 }
 
 void RigidBody2D::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -501,11 +501,11 @@ real_t RigidBody3D::get_mass() const {
 }
 
 void RigidBody3D::set_weight(real_t p_weight) {
-	set_mass(p_weight / real_t(GLOBAL_DEF("physics/3d/default_gravity", 9.8)));
+	set_mass(p_weight / real_t(GLOBAL_GET("physics/3d/default_gravity")));
 }
 
 real_t RigidBody3D::get_weight() const {
-	return mass * real_t(GLOBAL_DEF("physics/3d/default_gravity", 9.8));
+	return mass * real_t(GLOBAL_GET("physics/3d/default_gravity"));
 }
 
 void RigidBody3D::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {


### PR DESCRIPTION
Removes the artificial scaling factor of 10.
Uses GLOBAL_GET instead of GLOBAL_DEF to retrieve the current gravity setting.

Closes #16039.