### PR TITLE
Fixed Shader editor single-line comment highlight

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -172,7 +172,7 @@ void ShaderTextEditor::_load_theme_settings() {
 	const Color comment_color = EDITOR_GET("text_editor/highlighting/comment_color");
 	syntax_highlighter->clear_color_regions();
 	syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
-	syntax_highlighter->add_color_region("//", "", comment_color, false);
+	syntax_highlighter->add_color_region("//", "", comment_color, true);
 }
 
 void ShaderTextEditor::_check_shader_mode() {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -885,7 +885,7 @@ void VisualShaderEditor::_update_graph() {
 			expression_box->add_theme_color_override("font_color", text_color);
 			expression_syntax_highlighter->set_symbol_color(symbol_color);
 			expression_syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
-			expression_syntax_highlighter->add_color_region("//", "", comment_color, false);
+			expression_syntax_highlighter->add_color_region("//", "", comment_color, true);
 
 			expression_box->set_text(expression);
 			expression_box->set_context_menu_enabled(false);
@@ -1752,7 +1752,7 @@ void VisualShaderEditor::_notification(int p_what) {
 			syntax_highlighter->set_symbol_color(symbol_color);
 			syntax_highlighter->clear_color_regions();
 			syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
-			syntax_highlighter->add_color_region("//", "", comment_color, false);
+			syntax_highlighter->add_color_region("//", "", comment_color, true);
 
 			error_text->add_theme_font_override("font", get_theme_font("status_source", "EditorFonts"));
 			error_text->add_theme_color_override("font_color", get_theme_color("error_color", "Editor"));

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -488,7 +488,7 @@ void CodeHighlighter::add_color_region(const String &p_start_key, const String &
 	color_region.color = p_color;
 	color_region.start_key = p_start_key;
 	color_region.end_key = p_end_key;
-	color_region.line_only = p_line_only;
+	color_region.line_only = p_line_only || p_end_key == "";
 	color_regions.push_back(color_region);
 	clear_highlighting_cache();
 }


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes #40798 

This PR solves single-line comment highlighting by setting the `CodeHighlighter::add_color_region` `p_line_only` parameter to true for single-line comments, as well as reintroducing the implementation from 3.2 where `ColorRegion.line_only` is automatically set to true if there is no `end_key` symbol.

The second piece to the fix (checking if `p_end_key` is empty) is redundant, but I decided to include the check anyways.