### PR TITLE
Fix functions name color in visual shader code preview and expressions

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -873,6 +873,7 @@ void VisualShaderEditor::_update_graph() {
 			Color keyword_color = EDITOR_GET("text_editor/highlighting/keyword_color");
 			Color comment_color = EDITOR_GET("text_editor/highlighting/comment_color");
 			Color symbol_color = EDITOR_GET("text_editor/highlighting/symbol_color");
+			Color function_color = EDITOR_GET("text_editor/highlighting/function_color");
 
 			expression_box->set_syntax_highlighter(expression_syntax_highlighter);
 			expression_box->add_theme_color_override("background_color", background_color);
@@ -884,6 +885,7 @@ void VisualShaderEditor::_update_graph() {
 			expression_box->add_theme_font_override("font", get_theme_font("expression", "EditorFonts"));
 			expression_box->add_theme_color_override("font_color", text_color);
 			expression_syntax_highlighter->set_symbol_color(symbol_color);
+			expression_syntax_highlighter->set_function_color(function_color);
 			expression_syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
 			expression_syntax_highlighter->add_color_region("//", "", comment_color, false);
 
@@ -1740,6 +1742,7 @@ void VisualShaderEditor::_notification(int p_what) {
 			Color keyword_color = EDITOR_GET("text_editor/highlighting/keyword_color");
 			Color comment_color = EDITOR_GET("text_editor/highlighting/comment_color");
 			Color symbol_color = EDITOR_GET("text_editor/highlighting/symbol_color");
+			Color function_color = EDITOR_GET("text_editor/highlighting/function_color");
 
 			preview_text->add_theme_color_override("background_color", background_color);
 
@@ -1750,6 +1753,7 @@ void VisualShaderEditor::_notification(int p_what) {
 			preview_text->add_theme_font_override("font", get_theme_font("expression", "EditorFonts"));
 			preview_text->add_theme_color_override("font_color", text_color);
 			syntax_highlighter->set_symbol_color(symbol_color);
+			syntax_highlighter->set_function_color(function_color);
 			syntax_highlighter->clear_color_regions();
 			syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
 			syntax_highlighter->add_color_region("//", "", comment_color, false);


### PR DESCRIPTION
Fix incorrect black functions names:

![image](https://user-images.githubusercontent.com/3036176/88702665-4ecf9700-d114-11ea-94b1-df94dcff8d8d.png)
