### PR TITLE
[3.2] Revert "Fix Directory" PRs

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2369,17 +2369,13 @@ Error _Directory::open(const String &p_path) {
 	if (d)
 		memdelete(d);
 	d = alt;
-	dir_open = true;
 
 	return OK;
 }
 
-bool _Directory::is_open() const {
-	return d && dir_open;
-}
-
 Error _Directory::list_dir_begin(bool p_skip_navigational, bool p_skip_hidden) {
-	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
 
 	_list_skip_navigational = p_skip_navigational;
 	_list_skip_hidden = p_skip_hidden;
@@ -2388,7 +2384,8 @@ Error _Directory::list_dir_begin(bool p_skip_navigational, bool p_skip_hidden) {
 }
 
 String _Directory::get_next() {
-	ERR_FAIL_COND_V_MSG(!is_open(), "", "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, "", "Directory must be opened before use.");
 
 	String next = d->get_next();
 	while (next != "" && ((_list_skip_navigational && (next == "." || next == "..")) || (_list_skip_hidden && d->current_is_hidden()))) {
@@ -2398,38 +2395,45 @@ String _Directory::get_next() {
 	return next;
 }
 bool _Directory::current_is_dir() const {
-	ERR_FAIL_COND_V_MSG(!is_open(), false, "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, false, "Directory must be opened before use.");
 	return d->current_is_dir();
 }
 
 void _Directory::list_dir_end() {
-	ERR_FAIL_COND_MSG(!is_open(), "Directory must be opened before use.");
+
+	ERR_FAIL_COND_MSG(!d, "Directory must be opened before use.");
 	d->list_dir_end();
 }
 
 int _Directory::get_drive_count() {
-	ERR_FAIL_COND_V_MSG(!is_open(), 0, "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, 0, "Directory must be opened before use.");
 	return d->get_drive_count();
 }
 String _Directory::get_drive(int p_drive) {
-	ERR_FAIL_COND_V_MSG(!is_open(), "", "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, "", "Directory must be opened before use.");
 	return d->get_drive(p_drive);
 }
 int _Directory::get_current_drive() {
-	ERR_FAIL_COND_V_MSG(!is_open(), 0, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!d, 0, "Directory must be opened before use.");
 	return d->get_current_drive();
 }
 
 Error _Directory::change_dir(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
 	return d->change_dir(p_dir);
 }
 String _Directory::get_current_dir() {
-	ERR_FAIL_COND_V_MSG(!is_open(), "", "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, "", "Directory must be opened before use.");
 	return d->get_current_dir();
 }
 Error _Directory::make_dir(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_dir.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		Error err = d->make_dir(p_dir);
@@ -2439,7 +2443,8 @@ Error _Directory::make_dir(String p_dir) {
 	return d->make_dir(p_dir);
 }
 Error _Directory::make_dir_recursive(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_dir.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		Error err = d->make_dir_recursive(p_dir);
@@ -2450,7 +2455,8 @@ Error _Directory::make_dir_recursive(String p_dir) {
 }
 
 bool _Directory::file_exists(String p_file) {
-	ERR_FAIL_COND_V_MSG(!is_open(), false, "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, false, "Directory must be opened before use.");
 
 	if (!p_file.is_rel_path()) {
 		return FileAccess::exists(p_file);
@@ -2460,7 +2466,7 @@ bool _Directory::file_exists(String p_file) {
 }
 
 bool _Directory::dir_exists(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!is_open(), false, "Directory must be opened before use.");
+	ERR_FAIL_COND_V_MSG(!d, false, "Directory must be opened before use.");
 	if (!p_dir.is_rel_path()) {
 
 		DirAccess *d = DirAccess::create_for_path(p_dir);
@@ -2474,16 +2480,19 @@ bool _Directory::dir_exists(String p_dir) {
 }
 
 int _Directory::get_space_left() {
-	ERR_FAIL_COND_V_MSG(!is_open(), 0, "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, 0, "Directory must be opened before use.");
 	return d->get_space_left() / 1024 * 1024; //return value in megabytes, given binding is int
 }
 
 Error _Directory::copy(String p_from, String p_to) {
-	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
 	return d->copy(p_from, p_to);
 }
 Error _Directory::rename(String p_from, String p_to) {
-	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_from.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_from);
 		Error err = d->rename(p_from, p_to);
@@ -2494,7 +2503,8 @@ Error _Directory::rename(String p_from, String p_to) {
 	return d->rename(p_from, p_to);
 }
 Error _Directory::remove(String p_name) {
-	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
+
+	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_name.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_name);
 		Error err = d->remove(p_name);

--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2421,15 +2421,8 @@ int _Directory::get_current_drive() {
 }
 
 Error _Directory::change_dir(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory is not configured properly.");
-	Error err = d->change_dir(p_dir);
-
-	if (err != OK) {
-		return err;
-	}
-	dir_open = true;
-
-	return OK;
+	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
+	return d->change_dir(p_dir);
 }
 String _Directory::get_current_dir() {
 	ERR_FAIL_COND_V_MSG(!is_open(), "", "Directory must be opened before use.");
@@ -2457,7 +2450,8 @@ Error _Directory::make_dir_recursive(String p_dir) {
 }
 
 bool _Directory::file_exists(String p_file) {
-	ERR_FAIL_COND_V_MSG(!d, false, "Directory is not configured properly.");
+	ERR_FAIL_COND_V_MSG(!is_open(), false, "Directory must be opened before use.");
+
 	if (!p_file.is_rel_path()) {
 		return FileAccess::exists(p_file);
 	}
@@ -2466,16 +2460,17 @@ bool _Directory::file_exists(String p_file) {
 }
 
 bool _Directory::dir_exists(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!d, false, "Directory is not configured properly.");
+	ERR_FAIL_COND_V_MSG(!is_open(), false, "Directory must be opened before use.");
 	if (!p_dir.is_rel_path()) {
 
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		bool exists = d->dir_exists(p_dir);
 		memdelete(d);
 		return exists;
-	}
 
-	return d->dir_exists(p_dir);
+	} else {
+		return d->dir_exists(p_dir);
+	}
 }
 
 int _Directory::get_space_left() {

--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2436,7 +2436,7 @@ String _Directory::get_current_dir() {
 	return d->get_current_dir();
 }
 Error _Directory::make_dir(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory is not configured properly.");
+	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_dir.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		Error err = d->make_dir(p_dir);
@@ -2446,7 +2446,7 @@ Error _Directory::make_dir(String p_dir) {
 	return d->make_dir(p_dir);
 }
 Error _Directory::make_dir_recursive(String p_dir) {
-	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory is not configured properly.");
+	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_dir.is_rel_path()) {
 		DirAccess *d = DirAccess::create_for_path(p_dir);
 		Error err = d->make_dir_recursive(p_dir);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -570,15 +570,12 @@ class _Directory : public Reference {
 
 	GDCLASS(_Directory, Reference);
 	DirAccess *d;
-	bool dir_open = false;
 
 protected:
 	static void _bind_methods();
 
 public:
 	Error open(const String &p_path);
-
-	bool is_open() const;
 
 	Error list_dir_begin(bool p_skip_navigational = false, bool p_skip_hidden = false); // This starts dir listing.
 	String get_next();

--- a/doc/classes/Directory.xml
+++ b/doc/classes/Directory.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Directory type. It is used to manage directories and their content (not restricted to the project folder).
-		When creating a new [Directory], it must be explicitly opened using [method open] before most methods can be used. However, [method file_exists] and [method dir_exists] can be used without opening a directory. If so, they use a path relative to [code]res://[/code].
+		When creating a new [Directory], its default opened directory will be [code]res://[/code]. This may change in the future, so it is advised to always use [method open] to initialize your [Directory] where you want to operate, with explicit error checking.
 		Here is an example on how to iterate through the files of a directory:
 		[codeblock]
 		func dir_contents(path):
@@ -63,7 +63,6 @@
 			</argument>
 			<description>
 				Returns whether the target directory exists. The argument can be relative to the current directory, or an absolute path.
-				If the [Directory] is not open, the path is relative to [code]res://[/code].
 			</description>
 		</method>
 		<method name="file_exists">
@@ -73,7 +72,6 @@
 			</argument>
 			<description>
 				Returns whether the target file exists. The argument can be relative to the current directory, or an absolute path.
-				If the [Directory] is not open, the path is relative to [code]res://[/code].
 			</description>
 		</method>
 		<method name="get_current_dir">

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -69,11 +69,7 @@ Error DirAccessWindows::list_dir_begin() {
 	list_dir_end();
 	p->h = FindFirstFileExW((current_dir + "\\*").c_str(), FindExInfoStandard, &p->fu, FindExSearchNameMatch, NULL, 0);
 
-	if (p->h == INVALID_HANDLE_VALUE) {
-		return ERR_CANT_OPEN;
-	}
-
-	return OK;
+	return (p->h == INVALID_HANDLE_VALUE) ? ERR_CANT_OPEN : OK;
 }
 
 String DirAccessWindows::get_next() {


### PR DESCRIPTION
Reverts #40528, #40243, and #40151 in the 3.2 branch, @nathanfranke asked me to do this.

@akien-mga IMO, don't bother re-adding these commits for 3.2.4. It seems that the plan is to redesign these APIs for Godot 4.0, so any work put towards the current API would be solely for 3.2. I don't really think it's worth the effort of putting additional layers of duct tape on the problem if there's a high chance of compatibility breakage and the work would only exist for 3.2. @nathanfranke disagrees with me on this, he wants these changes in 3.2.

Closes #40763.