### PR TITLE
JSON parser fix

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -301,7 +301,6 @@ Error JSON::_parse_value(Variant &value, Token &token, const char32_t *p_str, in
 			return err;
 		}
 		value = d;
-		return OK;
 	} else if (token.type == TK_BRACKET_OPEN) {
 		Array a;
 		Error err = _parse_array(a, p_str, index, p_len, line, r_err_str);
@@ -309,8 +308,6 @@ Error JSON::_parse_value(Variant &value, Token &token, const char32_t *p_str, in
 			return err;
 		}
 		value = a;
-		return OK;
-
 	} else if (token.type == TK_IDENTIFIER) {
 		String id = token.value;
 		if (id == "true") {
@@ -323,18 +320,16 @@ Error JSON::_parse_value(Variant &value, Token &token, const char32_t *p_str, in
 			r_err_str = "Expected 'true','false' or 'null', got '" + id + "'.";
 			return ERR_PARSE_ERROR;
 		}
-		return OK;
-
 	} else if (token.type == TK_NUMBER) {
 		value = token.value;
-		return OK;
 	} else if (token.type == TK_STRING) {
 		value = token.value;
-		return OK;
 	} else {
 		r_err_str = "Expected value, got " + String(tk_name[token.type]) + ".";
 		return ERR_PARSE_ERROR;
 	}
+
+	return OK;
 }
 
 Error JSON::_parse_array(Array &array, const char32_t *p_str, int &index, int p_len, int &line, String &r_err_str) {
@@ -452,6 +447,19 @@ Error JSON::parse(const String &p_json, Variant &r_ret, String &r_err_str, int &
 	}
 
 	err = _parse_value(r_ret, token, str, idx, len, r_err_line, r_err_str);
+
+	// Check if EOF is reached
+	// or it's a type of the next token.
+	if (err == OK && idx < len) {
+		err = _get_token(str, idx, len, token, r_err_line, r_err_str);
+
+		if (err || token.type != TK_EOF) {
+			r_err_str = "Expected 'EOF'";
+			// Reset return value to empty `Variant`
+			r_ret = Variant();
+			return ERR_PARSE_ERROR;
+		}
+	}
 
 	return err;
 }


### PR DESCRIPTION
Related issue: https://github.com/godotengine/godot/issues/40794

Tested with:
```
func _ready():
	_check('"text"')
	_check('   "text"   ')
	_check('"10"')
	_check('10')
	_check('{}')
	_check('["a", 0]')
	_check('["a", 0, null]')
	_check(' { "a": "b" }')
	_check(' { "a": null }')
	_check(' { "a": 0 }')
	_check(' { "a": ["b"] }')
	_check(' { "a": {} }')
	print("should fail")
	_check('"a": 0 }')
	_check('{ "a": 0 ')
	_check('"a')
	_check('"a"0')
	_check('{}{}')
	_check('["a", 0')
	_check('["a", 0}')
	_check('{ ["a", 0] }')
	_check('true, false, [1,2,3]')


func _check(jsonString):
	var a = validate_json(jsonString)
	print('validation error: "{error}", result: "{json}"'.format({'error' : a, 'json' : parse_json(jsonString)}))
```
Some test cases could probably be added to the test added in https://github.com/godotengine/godot/pull/40795

Result:
```
2020-07-28 22:16:20.077650+0300 godot_4_test[14675:6335126] validation error: "", result: "text"
2020-07-28 22:16:20.077687+0300 godot_4_test[14675:6335126] validation error: "", result: "text"
2020-07-28 22:16:20.077716+0300 godot_4_test[14675:6335126] validation error: "", result: "10"
2020-07-28 22:16:20.077745+0300 godot_4_test[14675:6335126] validation error: "", result: "10"
2020-07-28 22:16:20.077775+0300 godot_4_test[14675:6335126] validation error: "", result: "{}"
2020-07-28 22:16:20.077811+0300 godot_4_test[14675:6335126] validation error: "", result: "[a, 0]"
2020-07-28 22:16:20.077855+0300 godot_4_test[14675:6335126] validation error: "", result: "[a, 0, Null]"
2020-07-28 22:16:20.077895+0300 godot_4_test[14675:6335126] validation error: "", result: "{a:b}"
2020-07-28 22:16:20.077939+0300 godot_4_test[14675:6335126] validation error: "", result: "{a:Null}"
2020-07-28 22:16:20.077978+0300 godot_4_test[14675:6335126] validation error: "", result: "{a:0}"
2020-07-28 22:16:20.078020+0300 godot_4_test[14675:6335126] validation error: "", result: "{a:[b]}"
2020-07-28 22:16:20.078063+0300 godot_4_test[14675:6335126] validation error: "", result: "{a:{}}"
2020-07-28 22:16:20.078077+0300 godot_4_test[14675:6335126] should fail
2020-07-28 22:16:20.078155+0300 godot_4_test[14675:6335126] validation error: "0:Expected 'EOF'", result: "Null"
2020-07-28 22:16:20.078232+0300 godot_4_test[14675:6335126] validation error: "0:Expected '}' or ','", result: "Null"
2020-07-28 22:16:20.078304+0300 godot_4_test[14675:6335126] validation error: "0:Unterminated String", result: "Null"
2020-07-28 22:16:20.078379+0300 godot_4_test[14675:6335126] validation error: "0:Expected 'EOF'", result: "Null"
2020-07-28 22:16:20.078450+0300 godot_4_test[14675:6335126] validation error: "0:Expected 'EOF'", result: "Null"
2020-07-28 22:16:20.078525+0300 godot_4_test[14675:6335126] validation error: "0:Expected ']'", result: "Null"
2020-07-28 22:16:20.078598+0300 godot_4_test[14675:6335126] validation error: "0:Expected ','", result: "Null"
2020-07-28 22:16:20.078667+0300 godot_4_test[14675:6335126] validation error: "0:Expected key", result: "Null"
2020-07-28 22:16:20.078748+0300 godot_4_test[14675:6335126] validation error: "0:Expected 'EOF'", result: "Null"
```

Testing same test cases with macOS's `JSONSerializer` produces same success/failure results.

*Bugsquad edit:* Fixes #40794.