### PR TITLE
Move PopupWindow logic to GodotEditText on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -56,8 +56,6 @@ import android.content.SharedPreferences.Editor;
 import android.content.pm.ConfigurationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
-import android.graphics.Point;
-import android.graphics.Rect;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
@@ -70,7 +68,6 @@ import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.provider.Settings.Secure;
 import android.view.Display;
-import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -78,12 +75,10 @@ import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
-import android.view.ViewTreeObserver;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.FrameLayout;
-import android.widget.PopupWindow;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -165,7 +160,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	public GodotRenderView mRenderView;
 	private boolean godot_initialized = false;
 
-	private PopupWindow mKeyboardWindow;
+	private GodotEditText mEditText;
 
 	private SensorManager mSensorManager;
 	private Sensor mAccelerometer;
@@ -223,24 +218,6 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		containerLayout = new FrameLayout(activity);
 		containerLayout.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
 
-		// Create a popup window with an invisible layout for the virtual keyboard,
-		// so the view can be resized to get the vk height without resizing the main godot view.
-		final FrameLayout keyboardLayout = new FrameLayout(activity);
-		keyboardLayout.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
-		keyboardLayout.setVisibility(View.INVISIBLE);
-		mKeyboardWindow = new PopupWindow(keyboardLayout, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
-		mKeyboardWindow.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
-		mKeyboardWindow.setInputMethodMode(PopupWindow.INPUT_METHOD_NEEDED);
-		mKeyboardWindow.setFocusable(true); // for the text edit to work
-		mKeyboardWindow.setTouchable(false); // inputs need to go through
-
-		// GodotEditText layout
-		GodotEditText editText = new GodotEditText(activity);
-		editText.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
-		editText.setKeyboardView(keyboardLayout);
-		// ...add to keyboard layout
-		keyboardLayout.addView(editText);
-
 		GodotLib.setup(command_line);
 
 		final String videoDriver = GodotLib.getGlobal("rendering/quality/driver/driver_name");
@@ -253,21 +230,9 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 
 		View view = mRenderView.getView();
 		containerLayout.addView(view, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
-		editText.setView(mRenderView);
-		io.setEdit(editText);
 
-		keyboardLayout.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
-			@Override
-			public void onGlobalLayout() {
-				Point fullSize = new Point();
-				activity.getWindowManager().getDefaultDisplay().getSize(fullSize);
-				Rect gameSize = new Rect();
-				mKeyboardWindow.getContentView().getWindowVisibleDisplayFrame(gameSize);
-
-				final int keyboardHeight = fullSize.y - gameSize.bottom;
-				GodotLib.setVirtualKeyboardHeight(keyboardHeight);
-			}
-		});
+		mEditText = new GodotEditText(activity, mRenderView);
+		io.setEdit(mEditText);
 
 		mRenderView.queueOnRenderThread(new Runnable() {
 			@Override
@@ -626,14 +591,14 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		mRenderView.getView().post(new Runnable() {
 			@Override
 			public void run() {
-				mKeyboardWindow.showAtLocation(getActivity().getWindow().getDecorView(), Gravity.NO_GRAVITY, 0, 0);
+				mEditText.onInitView();
 			}
 		});
 	}
 
 	@Override
 	public void onDestroy() {
-		mKeyboardWindow.dismiss();
+		mEditText.onDestroyView();
 
 		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
 			plugin.onMainDestroy();


### PR DESCRIPTION
Same as #40791 for master.

Just some cleaning from #40672: moving the PopupWindow logic to GodotEditText and everything in GodotEditText in now setup in the constructor.