### PR TITLE
[3.2] Do not update CSGShape if parent visibility or hierarchy changes

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -531,9 +531,10 @@ void CSGShape::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 
-		if (parent) {
+		if (parent && last_visible != is_visible()) {
 			parent->_make_dirty();
 		}
+		last_visible = is_visible();
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {
@@ -643,6 +644,7 @@ CSGShape::CSGShape() {
 	parent = NULL;
 	brush = NULL;
 	dirty = false;
+	last_visible = is_visible();
 	snap = 0.001;
 	use_collision = false;
 	collision_layer = 1;

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -519,7 +519,10 @@ void CSGShape::_notification(int p_what) {
 			set_collision_mask(collision_mask);
 		}
 
-		_make_dirty();
+		if (!_get_brush() || parentn && last_parent != Object::cast_to<CSGShape>(parentn)) {
+			_make_dirty();
+		}
+		last_parent = parent;
 	}
 
 	if (p_what == NOTIFICATION_LOCAL_TRANSFORM_CHANGED) {
@@ -642,6 +645,7 @@ void CSGShape::_bind_methods() {
 CSGShape::CSGShape() {
 	operation = OPERATION_UNION;
 	parent = NULL;
+	last_parent = NULL;
 	brush = NULL;
 	dirty = false;
 	last_visible = is_visible();

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -52,6 +52,7 @@ public:
 private:
 	Operation operation;
 	CSGShape *parent;
+	CSGShape *last_parent;
 
 	CSGBrush *brush;
 

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -58,6 +58,7 @@ private:
 	AABB node_aabb;
 
 	bool dirty;
+	bool last_visible;
 	float snap;
 
 	bool use_collision;


### PR DESCRIPTION
- Fixes `godotengine#40782`.
- Prevents unnecessary regeneration when reparenting nodes.