### PR TITLE
Properly handle `CSGShape` parent and visibility updates, plus some refactoring

### DIFF
--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -52,13 +52,14 @@ public:
 
 private:
 	Operation operation = OPERATION_UNION;
-	CSGShape3D *parent = nullptr;
+	CSGShape3D *parent_shape = nullptr;
 
 	CSGBrush *brush = nullptr;
 
 	AABB node_aabb;
 
 	bool dirty = false;
+	bool last_visible = false;
 	float snap = 0.001;
 
 	bool use_collision = false;
@@ -104,11 +105,12 @@ private:
 			const tbool bIsOrientationPreserving, const int iFace, const int iVert);
 
 	void _update_shape();
+	void _update_collision_faces();
 
 protected:
 	void _notification(int p_what);
 	virtual CSGBrush *_build_brush() = 0;
-	void _make_dirty();
+	void _make_dirty(bool p_parent_removing = false);
 
 	static void _bind_methods();
 


### PR DESCRIPTION
- `CSGShapes` no longer lose collision when the root shape is made invisible. Fixes #43251.
- Prevents unnecessary `CSGShape` updates when changing the parent's visibility or hierarchy. Fixes godotengine#40931.
- Allows `_update_shape` to be used on invisible shapes. Fixes godotengine#41093.
- Closes #43381.
- Refactor: Renames `parent` to `parent_shape`.
- Refactor: Cleaned up `CSGShape3D::_notification`.

##
Test projects:
[40814 Test Suite - Visibility.zip](https://github.com/godotengine/godot/files/5044638/40814.Test.Suite.-.Visibility.zip)
[40814 Test Suite - Scene Tree.zip](https://github.com/godotengine/godot/files/5044637/40814.Test.Suite.-.Scene.Tree.zip)
[40814 Test Suite - Collision.zip](https://github.com/godotengine/godot/files/5044952/40814.Test.Suite.-.Collision.zip)