### PR TITLE
Added missing information about File.open_encrypted function to docs

### DIFF
--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -257,6 +257,7 @@
 			</argument>
 			<description>
 				Opens an encrypted file in write or read mode. You need to pass a binary key to encrypt/decrypt it.
+				[b]Note:[/b] The provided key must be 32 bytes long.
 			</description>
 		</method>
 		<method name="open_encrypted_with_pass">


### PR DESCRIPTION
When I tried this function it was giving ERR_INVALID_PARAMETER
Checked source and found a check about key length and thought it would be good to add this information to docs. 

https://github.com/godotengine/godot/blob/227494be59eca4f50604a9c90c3c36ed15e7ecc5/core/io/file_access_encrypted.cpp#L44
