### PR TITLE
Fix incorrect key name in the Animation documentation code sample

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -7,10 +7,10 @@
 		An Animation resource contains data used to animate everything in the engine. Animations are divided into tracks, and each track must be linked to a node. The state of that node can be changed through time, by adding timed keys (events) to the track.
 		[codeblock]
 		# This creates an animation that makes the node "Enemy" move to the right by
-		# 100 pixels in 1 second.
+		# 100 pixels in 0.5 seconds.
 		var animation = Animation.new()
 		var track_index = animation.add_track(Animation.TYPE_VALUE)
-		animation.track_set_path(track_index, "Enemy:position.x")
+		animation.track_set_path(track_index, "Enemy:position:x")
 		animation.track_insert_key(track_index, 0.0, 0)
 		animation.track_insert_key(track_index, 0.5, 100)
 		[/codeblock]


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-docs/issues/3841.