### PR TITLE
GDScript: Fix crash caused by inconsistent get_member

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2019,7 +2019,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 		GDScriptParser::ClassNode *outer = base_class->outer;
 		while (outer != nullptr) {
 			if (outer->has_member(name)) {
-				const GDScriptParser::ClassNode::Member &member = base_class->get_member(name);
+				const GDScriptParser::ClassNode::Member &member = outer->get_member(name);
 				if (member.type == GDScriptParser::ClassNode::Member::CONSTANT) {
 					// TODO: Make sure loops won't cause problem. And make special error message for those.
 					// For out-of-order resolution:


### PR DESCRIPTION
There's clearly something off in the original code: it checks has_member on one object, but uses get_member on a different one. This leads to a CRASH_BAD_INDEX when the key is inevitably not in the dictionary.

The thing I am unsure of is if the *intent* of the code was to use `base_class`; or to use `outer` - My guess is `outer` as that is the subject of the loop.

Fixes #40825