### PR TITLE
Cleanup obsolete tests from displaying in help

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -262,25 +262,20 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  -h, --help                       Display this help message.\n");
 	OS::get_singleton()->print("  --version                        Display the version string.\n");
 	OS::get_singleton()->print("  -v, --verbose                    Use verbose stdout mode.\n");
-	OS::get_singleton()->print(
-			"  --quiet                          Quiet mode, silences stdout messages. Errors are still displayed.\n");
+	OS::get_singleton()->print("  --quiet                          Quiet mode, silences stdout messages. Errors are still displayed.\n");
 	OS::get_singleton()->print("\n");
 
 	OS::get_singleton()->print("Run options:\n");
 #ifdef TOOLS_ENABLED
 	OS::get_singleton()->print("  -e, --editor                     Start the editor instead of running the scene.\n");
-	OS::get_singleton()->print(
-			"  -p, --project-manager            Start the project manager, even if a project is auto-detected.\n");
+	OS::get_singleton()->print("  -p, --project-manager            Start the project manager, even if a project is auto-detected.\n");
 #endif
 	OS::get_singleton()->print("  -q, --quit                       Quit after the first iteration.\n");
-	OS::get_singleton()->print(
-			"  -l, --language <locale>          Use a specific locale (<locale> being a two-letter code).\n");
-	OS::get_singleton()->print(
-			"  --path <directory>               Path to a project (<directory> must contain a 'project.godot' file).\n");
+	OS::get_singleton()->print("  -l, --language <locale>          Use a specific locale (<locale> being a two-letter code).\n");
+	OS::get_singleton()->print("  --path <directory>               Path to a project (<directory> must contain a 'project.godot' file).\n");
 	OS::get_singleton()->print("  -u, --upwards                    Scan folders upwards for project.godot file.\n");
 	OS::get_singleton()->print("  --main-pack <file>               Path to a pack (.pck) file to load.\n");
-	OS::get_singleton()->print(
-			"  --render-thread <mode>           Render thread mode ('unsafe', 'safe', 'separate').\n");
+	OS::get_singleton()->print("  --render-thread <mode>           Render thread mode ('unsafe', 'safe', 'separate').\n");
 	OS::get_singleton()->print("  --remote-fs <address>            Remote filesystem (<host/IP>[:<port>] address).\n");
 	OS::get_singleton()->print("  --remote-fs-password <password>  Password for remote filesystem.\n");
 
@@ -321,12 +316,9 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --resolution <W>x<H>             Request window resolution.\n");
 	OS::get_singleton()->print("  --position <X>,<Y>               Request window position.\n");
 	OS::get_singleton()->print("  --low-dpi                        Force low-DPI mode (macOS and Windows only).\n");
-	OS::get_singleton()->print(
-			"  --no-window                      Disable window creation (Windows only). Useful together with --script.\n");
-	OS::get_singleton()->print(
-			"  --enable-vsync-via-compositor    When vsync is enabled, vsync via the OS' window compositor (Windows only).\n");
-	OS::get_singleton()->print(
-			"  --disable-vsync-via-compositor   Disable vsync via the OS' window compositor (Windows only).\n");
+	OS::get_singleton()->print("  --no-window                      Disable window creation (Windows only). Useful together with --script.\n");
+	OS::get_singleton()->print("  --enable-vsync-via-compositor    When vsync is enabled, vsync via the OS' window compositor (Windows only).\n");
+	OS::get_singleton()->print("  --disable-vsync-via-compositor   Disable vsync via the OS' window compositor (Windows only).\n");
 	OS::get_singleton()->print("  --single-window                  Use a single window (no separate subwindows).\n");
 	OS::get_singleton()->print("  --tablet-driver                  Tablet input driver (");
 	for (int i = 0; i < OS::get_singleton()->get_tablet_driver_count(); i++) {
@@ -340,62 +332,38 @@ void Main::print_help(const char *p_binary) {
 
 	OS::get_singleton()->print("Debug options:\n");
 	OS::get_singleton()->print("  -d, --debug                      Debug (local stdout debugger).\n");
-	OS::get_singleton()->print(
-			"  -b, --breakpoints                Breakpoint list as source::line comma-separated pairs, no spaces (use %%20 instead).\n");
+	OS::get_singleton()->print("  -b, --breakpoints                Breakpoint list as source::line comma-separated pairs, no spaces (use %%20 instead).\n");
 	OS::get_singleton()->print("  --profiling                      Enable profiling in the script debugger.\n");
-	OS::get_singleton()->print(
-			"  --gpu-abort                      Abort on GPU errors (usually validation layer errors), may help see the problem if your system freezes.\n");
-	OS::get_singleton()->print(
-			"  --remote-debug <uri>             Remote debug (<protocol>://<host/IP>[:<port>], e.g. tcp://127.0.0.1:6007).\n");
+	OS::get_singleton()->print("  --gpu-abort                      Abort on GPU errors (usually validation layer errors), may help see the problem if your system freezes.\n");
+	OS::get_singleton()->print("  --remote-debug <uri>             Remote debug (<protocol>://<host/IP>[:<port>], e.g. tcp://127.0.0.1:6007).\n");
 #if defined(DEBUG_ENABLED) && !defined(SERVER_ENABLED)
 	OS::get_singleton()->print("  --debug-collisions               Show collision shapes when running the scene.\n");
 	OS::get_singleton()->print("  --debug-navigation               Show navigation polygons when running the scene.\n");
 #endif
-	OS::get_singleton()->print(
-			"  --frame-delay <ms>               Simulate high CPU load (delay each frame by <ms> milliseconds).\n");
-	OS::get_singleton()->print(
-			"  --time-scale <scale>             Force time scale (higher values are faster, 1.0 is normal speed).\n");
-	OS::get_singleton()->print(
-			"  --disable-render-loop            Disable render loop so rendering only occurs when called explicitly from script.\n");
-	OS::get_singleton()->print(
-			"  --disable-crash-handler          Disable crash handler when supported by the platform code.\n");
-	OS::get_singleton()->print(
-			"  --fixed-fps <fps>                Force a fixed number of frames per second. This setting disables real-time synchronization.\n");
+	OS::get_singleton()->print("  --frame-delay <ms>               Simulate high CPU load (delay each frame by <ms> milliseconds).\n");
+	OS::get_singleton()->print("  --time-scale <scale>             Force time scale (higher values are faster, 1.0 is normal speed).\n");
+	OS::get_singleton()->print("  --disable-render-loop            Disable render loop so rendering only occurs when called explicitly from script.\n");
+	OS::get_singleton()->print("  --disable-crash-handler          Disable crash handler when supported by the platform code.\n");
+	OS::get_singleton()->print("  --fixed-fps <fps>                Force a fixed number of frames per second. This setting disables real-time synchronization.\n");
 	OS::get_singleton()->print("  --print-fps                      Print the frames per second to the stdout.\n");
 	OS::get_singleton()->print("\n");
 
 	OS::get_singleton()->print("Standalone tools:\n");
 	OS::get_singleton()->print("  -s, --script <script>            Run a script.\n");
-	OS::get_singleton()->print(
-			"  --check-only                     Only parse for errors and quit (use with --script).\n");
+	OS::get_singleton()->print("  --check-only                     Only parse for errors and quit (use with --script).\n");
 #ifdef TOOLS_ENABLED
-	OS::get_singleton()->print(
-			"  --export <preset> <path>         Export the project using the given preset and matching release template. The preset name should match one defined in export_presets.cfg.\n");
-	OS::get_singleton()->print(
-			"                                   <path> should be absolute or relative to the project directory, and include the filename for the binary (e.g. 'builds/game.exe'). The target directory should exist.\n");
+	OS::get_singleton()->print("  --export <preset> <path>         Export the project using the given preset and matching release template. The preset name should match one defined in export_presets.cfg.\n");
+	OS::get_singleton()->print("                                   <path> should be absolute or relative to the project directory, and include the filename for the binary (e.g. 'builds/game.exe'). The target directory should exist.\n");
 	OS::get_singleton()->print("  --export-debug <preset> <path>   Same as --export, but using the debug template.\n");
-	OS::get_singleton()->print(
-			"  --export-pack <preset> <path>    Same as --export, but only export the game pack for the given preset. The <path> extension determines whether it will be in PCK or ZIP format.\n");
-	OS::get_singleton()->print(
-			"  --doctool <path>                 Dump the engine API reference to the given <path> in XML format, merging if existing files are found.\n");
-	OS::get_singleton()->print(
-			"  --no-docbase                     Disallow dumping the base types (used with --doctool).\n");
-	OS::get_singleton()->print(
-			"  --build-solutions                Build the scripting solutions (e.g. for C# projects). Implies --editor and requires a valid project to edit.\n");
+	OS::get_singleton()->print("  --export-pack <preset> <path>    Same as --export, but only export the game pack for the given preset. The <path> extension determines whether it will be in PCK or ZIP format.\n");
+	OS::get_singleton()->print("  --doctool <path>                 Dump the engine API reference to the given <path> in XML format, merging if existing files are found.\n");
+	OS::get_singleton()->print("  --no-docbase                     Disallow dumping the base types (used with --doctool).\n");
+	OS::get_singleton()->print("  --build-solutions                Build the scripting solutions (e.g. for C# projects). Implies --editor and requires a valid project to edit.\n");
 #ifdef DEBUG_METHODS_ENABLED
-	OS::get_singleton()->print(
-			"  --gdnative-generate-json-api     Generate JSON dump of the Godot API for GDNative bindings.\n");
+	OS::get_singleton()->print("  --gdnative-generate-json-api     Generate JSON dump of the Godot API for GDNative bindings.\n");
 #endif
 #ifdef TESTS_ENABLED
-	OS::get_singleton()->print("  --test <test>                    Run a unit test [");
-	const char **test_names = tests_get_names();
-	const char *comma = "";
-	while (*test_names) {
-		OS::get_singleton()->print("%s'%s'", comma, *test_names);
-		test_names++;
-		comma = ", ";
-	}
-	OS::get_singleton()->print("].\n");
+	OS::get_singleton()->print("  --test [--help]                  Run unit tests. Use --test --help for more information.\n");
 #endif
 	OS::get_singleton()->print("\n");
 #endif

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -32,8 +32,6 @@
 
 #include "core/list.h"
 
-#ifdef DEBUG_ENABLED
-
 #include "test_astar.h"
 #include "test_basis.h"
 #include "test_class_db.h"
@@ -54,37 +52,12 @@
 
 #include "thirdparty/doctest/doctest.h"
 
-const char **tests_get_names() {
-	static const char *test_names[] = {
-		"*",
-		"all",
-		"math",
-		"basis",
-		"physics_2d",
-		"physics_3d",
-		"render",
-		"oa_hash_map",
-		"class_db",
-		"gui",
-		"shaderlang",
-		"gd_tokenizer",
-		"gd_parser",
-		"gd_compiler",
-		"gd_bytecode",
-		"ordered_hash_map",
-		"astar",
-		nullptr
-	};
-
-	return test_names;
-}
-
 int test_main(int argc, char *argv[]) {
-	// doctest runner for when legacy unit tests are no  found
+	// Doctest runner.
 	doctest::Context test_context;
 	List<String> valid_arguments;
 
-	// clean arguments of --test from the args
+	// Clean arguments of "--test" from the args.
 	int argument_count = 0;
 	for (int x = 0; x < argc; x++) {
 		if (strncmp(argv[x], "--test", 6) != 0) {
@@ -92,15 +65,14 @@ int test_main(int argc, char *argv[]) {
 			argument_count++;
 		}
 	}
-
-	// convert godot command line arguments back to standard arguments.
+	// Convert Godot command line arguments back to standard arguments.
 	char **args = new char *[valid_arguments.size()];
 	for (int x = 0; x < valid_arguments.size(); x++) {
-		// operation to convert godot string to non wchar string
+		// Operation to convert Godot string to non wchar string.
 		const char *str = valid_arguments[x].utf8().ptr();
-		// allocate the string copy
+		// Allocate the string copy.
 		args[x] = new char[strlen(str) + 1];
-		// copy this into memory
+		// Copy this into memory.
 		std::memcpy(args[x], str, strlen(str) + 1);
 	}
 
@@ -109,22 +81,8 @@ int test_main(int argc, char *argv[]) {
 	test_context.setOption("order-by", "name");
 	test_context.setOption("abort-after", 5);
 	test_context.setOption("no-breaks", true);
+
 	delete[] args;
+
 	return test_context.run();
 }
-
-#else
-
-const char **tests_get_names() {
-	static const char *test_names[] = {
-		nullptr
-	};
-
-	return test_names;
-}
-
-int test_main(int argc, char *argv[]) {
-	return 0;
-}
-
-#endif

--- a/tests/test_main.h
+++ b/tests/test_main.h
@@ -31,11 +31,6 @@
 #ifndef TEST_MAIN_H
 #define TEST_MAIN_H
 
-#include "core/list.h"
-#include "core/os/main_loop.h"
-#include "core/ustring.h"
-
-const char **tests_get_names();
 int test_main(int argc, char *argv[]);
 
 #endif // TEST_MAIN_H


### PR DESCRIPTION
Previous tests cannot be run with the current doctest runner, so makes sense just to remove the list to prevent confusion.

Some tests still have to be ported as described in #40659.

Let it go. 🙂