### PR TITLE
Fix TextEdit line width cache not being updated

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4889,6 +4889,7 @@ void TextEdit::_update_caches() {
 	cache.folded_eol_icon = get_theme_icon("GuiEllipsis", "EditorIcons");
 	cache.executing_icon = get_theme_icon("MainPlay", "EditorIcons");
 	text.set_font(cache.font);
+	text.clear_width_cache();
 
 	if (syntax_highlighter.is_valid()) {
 		syntax_highlighter->set_text_edit(this);


### PR DESCRIPTION
`TextEdit` was no longer updating the line width cache causing code folding eol icon to become misplaced. 

Missed as part of #38440 which apparently had it updating when a `keyword` or `color_region` was added.