### PR TITLE
Refix GDScriptTranslationParser leak

### DIFF
--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -57,6 +57,8 @@ GDScriptCache *gdscript_cache = nullptr;
 #include "language_server/gdscript_language_server.h"
 #endif // !GDSCRIPT_NO_LSP
 
+Ref<GDScriptEditorTranslationParserPlugin> gdscript_translation_parser_plugin;
+
 class EditorExportGDScript : public EditorExportPlugin {
 	GDCLASS(EditorExportGDScript, EditorExportPlugin);
 
@@ -120,7 +122,6 @@ void register_gdscript_types() {
 #ifdef TOOLS_ENABLED
 	EditorNode::add_init_callback(_editor_init);
 
-	Ref<GDScriptEditorTranslationParserPlugin> gdscript_translation_parser_plugin;
 	gdscript_translation_parser_plugin.instance();
 	EditorTranslationParser::get_singleton()->add_parser(gdscript_translation_parser_plugin, EditorTranslationParser::STANDARD);
 #endif // TOOLS_ENABLED
@@ -142,4 +143,9 @@ void unregister_gdscript_types() {
 
 	ResourceSaver::remove_resource_format_saver(resource_saver_gd);
 	resource_saver_gd.unref();
+
+#ifdef TOOLS_ENABLED
+	EditorTranslationParser::get_singleton()->remove_parser(gdscript_translation_parser_plugin, EditorTranslationParser::STANDARD);
+	gdscript_translation_parser_plugin.unref();
+#endif // TOOLS_ENABLED
 }


### PR DESCRIPTION
`unref()` GDScriptTranslationParser instance in the file where it's created. 

Fixes #40846.