### PR TITLE
Properly calculate polygon2D AABB with skeleton

### DIFF
--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -969,6 +969,53 @@ public:
 						for (int j = 1; j < l; j++) {
 							r.expand_to(pp[j]);
 						}
+
+						if (skeleton != RID()) {
+							// calculate bone AABBs
+							int bone_count = RasterizerStorage::base_singleton->skeleton_get_bone_count(skeleton);
+
+							Vector<Rect2> bone_aabbs;
+							bone_aabbs.resize(bone_count);
+							Rect2 *bptr = bone_aabbs.ptrw();
+
+							for (int j = 0; j < bone_count; j++) {
+								bptr[j].size = Vector2(-1, -1); //negative means unused
+							}
+
+							for (int j = 0; j < l; j++) {
+								Point2 p = pp[j];
+								for (int k = 0; k < 4; k++) {
+									int idx = polygon->bones[j * 4 + k];
+									float w = polygon->weights[j * 4 + k];
+									if (w == 0)
+										continue;
+
+									if (bptr[idx].size.x < 0) {
+										//first
+										bptr[idx] = Rect2(p, Vector2(0.00001, 0.00001));
+									} else {
+										bptr[idx].expand_to(p);
+									}
+								}
+							}
+
+							Rect2 aabb;
+							bool first_bone = true;
+							for (int j = 0; j < bone_count; j++) {
+								Transform2D mtx = RasterizerStorage::base_singleton->skeleton_bone_get_transform_2d(skeleton, j);
+								Rect2 baabb = mtx.xform(bone_aabbs[j]);
+
+								if (first_bone) {
+									aabb = baabb;
+									first_bone = false;
+								} else {
+									aabb = aabb.merge(baabb);
+								}
+							}
+
+							r = r.merge(aabb);
+						}
+
 					} break;
 					case Item::Command::TYPE_MESH: {
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/35726

I copied the logic from mesh here:

https://github.com/godotengine/godot/blob/19802f7dc0c6e28c96c58c499a3dcfbee008b0b5/servers/visual_server.cpp#L765-L787

and here:

https://github.com/godotengine/godot/blob/19802f7dc0c6e28c96c58c499a3dcfbee008b0b5/drivers/gles3/rasterizer_storage_gles3.cpp#L4240-L4265

A similar change is needed for 4.0. But things have moved around, so a new PR will be needed. 