### PR TITLE
makerst: Add descriptions to method qualifiers

### DIFF
--- a/doc/tools/makerst.py
+++ b/doc/tools/makerst.py
@@ -565,6 +565,8 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
 
                 index += 1
 
+    f.write(make_footer())
+
 
 def escape_rst(text, until_pos=-1):  # type: (str) -> str
     # Escape \ character, otherwise it ends up as an escape character in rst
@@ -995,13 +997,28 @@ def make_method_signature(
     out += " **)**"
 
     if isinstance(method_def, MethodDef) and method_def.qualifiers is not None:
-        out += " " + method_def.qualifiers
+        # Use substitutions for abbreviations. This is used to display tooltips on hover.
+        # See `make_footer()` for descriptions.
+        for qualifier in method_def.qualifiers.split():
+            out += " |" + qualifier + "|"
 
     return ret_type, out
 
 
 def make_heading(title, underline):  # type: (str, str) -> str
     return title + "\n" + (underline * len(title)) + "\n\n"
+
+
+def make_footer():  # type: () -> str
+    # Generate reusable abbreviation substitutions.
+    # This way, we avoid bloating the generated rST with duplicate abbreviations.
+    # fmt: off
+    return (
+        ".. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`\n"
+        ".. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`\n"
+        ".. |vararg| replace:: :abbr:`vararg (This method accepts any number of arguments after the ones described here.)`"
+    )
+    # fmt: on
 
 
 def make_url(link):  # type: (str) -> str


### PR DESCRIPTION
This works successfully when building documentation locally:

![image](https://user-images.githubusercontent.com/180032/88910519-e17b4d80-d25c-11ea-88b8-9b4c93101e48.png)

Hovering `virtual` will display a tooltip.

~~That said, we may want to refactor it to make use of reusable blocks placed at the bottom of the generated class. This would avoid bloating the generated rST files.~~

**Edit:** I'm not sure if the above is possible, as the following substitution declarations are considered "empty or invalid" by Sphinx:

```rst
.. |virtual| :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`

.. |const| :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

.. |vararg| :abbr:`vararg (This method accepts any number of arguments after the ones described here.)`
```

**Edit 2:** It might be possible using an alternative syntax: https://github.com/sphinx-doc/sphinx/issues/203#issuecomment-68532109

**Edit 3:** The alternative syntax works :slightly_smiling_face: 

This closes https://github.com/godotengine/godot-docs/issues/1753.