### PR TITLE
Improve the `EditorInterface.get_editor_viewport()` description

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -51,8 +51,8 @@
 			<return type="Control">
 			</return>
 			<description>
-				Returns the editor's [Viewport] instance.
-				[b]Note:[/b] This returns the main editor viewport containing the whole editor, not the 2D or 3D viewports specifically.
+				Returns the main editor control. Use this as a parent for main screens.
+				[b]Note:[/b] This returns the main editor control containing the whole editor, not the 2D or 3D viewports specifically.
 			</description>
 		</method>
 		<method name="get_file_system_dock">


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-docs/issues/1109. Thanks to @vnen for clarifying this :slightly_smiling_face: