### PR TITLE
CI: Show `tests=yes` for builds which run tests

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   linux-editor:
     runs-on: "ubuntu-20.04"
-    name: Editor w/ Mono (target=release_debug, tools=yes)
+    name: Editor w/ Mono (target=release_debug, tools=yes, tests=yes)
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -10,7 +10,7 @@ jobs:
   macos-editor:
     runs-on: "macos-latest"
 
-    name: Editor (target=release_debug, tools=yes)
+    name: Editor (target=release_debug, tools=yes, tests=yes)
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "windows-latest"
 
     # Windows Editor - checkout with the plugin
-    name: Editor (target=release_debug, tools=yes)
+    name: Editor (target=release_debug, tools=yes, tests=yes)
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
An improvement for those who'd like to quickly identify builds with tests enabled for review.

One could look at `tools=yes` to figure this out currently, but this:
- doesn't give immediate information, requires deducing
- if we add more builds with `tools=yes` but with `tests=no` (default), this could lead to confusion.

Not to mention that we'd like to advertise the existence of tests for existing and new contributors. 🙂
