### PR TITLE
Ensure CSG parent's _make_dirty() is called when entering a tree.

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -132,18 +132,13 @@ void CSGShape3D::_make_dirty() {
 		return;
 	}
 
-	if (dirty) {
-		return;
+	if (parent) {
+		parent->_make_dirty();
+	} else if (!dirty) {
+		call_deferred("_update_shape");
 	}
 
 	dirty = true;
-
-	if (parent) {
-		parent->_make_dirty();
-	} else {
-		//only parent will do
-		call_deferred("_update_shape");
-	}
 }
 
 CSGBrush *CSGShape3D::_get_brush() {


### PR DESCRIPTION
When a `CSGShape` is removed from the tree it is made `dirty`. However, currently, when the `CSGShape` is later added to the tree the new `parent` is not marked `dirty`, and hence the shape is not updated. This PR resolves this issue by ensuring that the `parent` is marked `dirty` (and updated) when a `dirty` `CSGShape` is made `dirty`.