### PR TITLE
Add call to Bullet pre_process() at start of dispatch_callbacks()

### DIFF
--- a/modules/bullet/collision_object_bullet.cpp
+++ b/modules/bullet/collision_object_bullet.cpp
@@ -361,6 +361,9 @@ void RigidCollisionObjectBullet::shape_changed(int p_shape_index) {
 
 void RigidCollisionObjectBullet::reload_shapes() {
 	need_shape_reload = true;
+	if (space) {
+		space->add_to_flush_queue(this);
+	}
 }
 
 void RigidCollisionObjectBullet::do_reload_shapes() {

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -338,6 +338,7 @@ void RigidBodyBullet::set_space(SpaceBullet *p_space) {
 }
 
 void RigidBodyBullet::dispatch_callbacks() {
+	pre_process();
 	RigidCollisionObjectBullet::dispatch_callbacks();
 
 	/// The check isFirstTransformChanged is necessary in order to call integrated forces only when the first transform is sent


### PR DESCRIPTION
Also adds `RigidBodyCollisionObjectBullet` to flush queue when a shape reload is needed.

Fixes #40840.