### PR TITLE
Add `GodotConsoleReporter` for doctest

### DIFF
--- a/tests/SCsub
+++ b/tests/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+import methods
+
 Import("env")
 
 env.tests_sources = []
@@ -14,8 +16,13 @@ if env["module_gdnative_enabled"]:
 # Since we link with /MT thread_local is always expired when the header is used
 # So the debugger crashes the engine and it causes weird errors
 # Explained in https://github.com/onqtam/doctest/issues/401
-if env_tests["platform"] == "windows":
+if env["platform"] == "windows":
     env_tests.Append(CPPDEFINES=[("DOCTEST_THREAD_LOCAL", "")])
+
+if methods.using_gcc(env):
+    # Supressing "-Wsubobject-linkage" is needed for extending
+    # `doctest::ConsoleReporter` which resides in an anonymous namespace.
+    env_tests.Append(CCFLAGS=["-Wno-subobject-linkage"])
 
 env_tests.add_source_files(env.tests_sources, "*.cpp")
 

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -48,6 +48,9 @@
 // which are used by error macros which call into `OS::print_error`, effectively
 // disabling any error messages to be printed from the engine side (not tests).
 #define ERR_PRINT_OFF _print_error_enabled = false;
+
+// NOTE: This is always re-enabled before each test case or subcase is run if
+// using "godot_console" test reporter (default).
 #define ERR_PRINT_ON _print_error_enabled = true;
 
 // Stringify all `Variant` compatible types for doctest output by default.

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -53,7 +53,7 @@
 
 #include "modules/modules_tests.gen.h"
 
-#include "tests/test_macros.h"
+#include "test_reporters.h"
 
 int test_main(int argc, char *argv[]) {
 	bool run_tests = true;
@@ -103,12 +103,14 @@ int test_main(int argc, char *argv[]) {
 		// Copy this into memory.
 		memcpy(doctest_args[x], str, strlen(str) + 1);
 	}
-
-	test_context.applyCommandLine(test_args.size(), doctest_args);
-
 	test_context.setOption("order-by", "name");
 	test_context.setOption("abort-after", 5);
 	test_context.setOption("no-breaks", true);
+	// Use Godot version of console reporter (registered in `test_reporters.h`).
+	test_context.setOption("reporters", "godot_console"); // Default: "console".
+
+	// Command-line options can override defaults.
+	test_context.applyCommandLine(valid_arguments.size(), args);
 
 	for (int x = 0; x < test_args.size(); x++) {
 		delete[] doctest_args[x];

--- a/tests/test_reporters.h
+++ b/tests/test_reporters.h
@@ -1,0 +1,67 @@
+/*************************************************************************/
+/*  test_reporters.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_REPORTERS_H
+#define TEST_REPORTERS_H
+
+#include "test_macros.h"
+
+// NOTE: we need make sure to re-enable Godot error prints with `ERR_PRINT_ON`
+// automatically in case of a human error or other unexpected failures.
+
+struct GodotConsoleReporter : public doctest::ConsoleReporter {
+	GodotConsoleReporter(const doctest::ContextOptions &co) :
+			doctest::ConsoleReporter(co) {}
+
+	void test_run_start() override {
+		ERR_PRINT_ON;
+		ConsoleReporter::test_run_start();
+	}
+	void test_case_start(const doctest::TestCaseData &p_in) override {
+		ERR_PRINT_ON;
+		ConsoleReporter::test_case_start(p_in);
+	}
+	void test_case_reenter(const doctest::TestCaseData &p_in) override {
+		ERR_PRINT_ON;
+		ConsoleReporter::test_case_reenter(p_in);
+	}
+	void test_case_exception(const doctest::TestCaseException &p_in) override {
+		ERR_PRINT_ON;
+		ConsoleReporter::test_case_exception(p_in);
+	}
+	void subcase_start(const doctest::SubcaseSignature &p_in) override {
+		ERR_PRINT_ON;
+		ConsoleReporter::subcase_start(p_in);
+	}
+};
+
+REGISTER_REPORTER("godot_console", 1, GodotConsoleReporter);
+
+#endif // TEST_REPORTERS_H


### PR DESCRIPTION
This introduces a doctest reporter which inherits from the builtin `ConsoleReporter`. Some methods are overridden to make sure that Godot error prints get always re-enabled between test case runs, and the reporter is set as default now (named as "godot_console", built-in is just "console").

We currently have a problem that some values are not converted in the test runner output (should be fixed by #40945):
```
D:\src\godot\tests\test_string.h(191): SUCCESS: CHECK( s == "Who is Frederic Chopin?" ) is correct!
  values: CHECK( {?} == Who is Frederic Chopin? )
```

`GodotConsoleReporter` can be extended to potentially customize the output of running tests to work better with Godot datatypes in the future... This only provides stub implementation with the doctest defaults.

Linking some test cases which allow to test these changes in `tests\test_validate_testing.h`:
```c++
	// The following only makes sense for when "godot_console" reporter is used.
	// But there's no way to fetch currently active reporter in doctest...
	SUBCASE("Forgetting to ERR_PRINT_ON after ERR_PRINT_OFF") {
		ERR_PRINT_OFF;
		ERR_PRINT("Still waiting for Godot!"); // This should never get printed!
		SUBCASE("") {
			CHECK_MESSAGE(_print_error_enabled, "Error printing should be re-enabled automatically.");
		}
	}
```