### PR TITLE
Fix RichTextLabel center alignment bug

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -188,7 +188,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 		wofs += line_ofs;
 	}
 
-	int begin = wofs;
+	int begin = margin;
 
 	Ref<Font> cfont = _find_font(it);
 	if (cfont.is_null()) {


### PR DESCRIPTION

Fixes #40207 
**Bug:** Center alignment of rich text label showed incorrect behavior
**Reason:** The value of `begin` , with which the cache data of the lines was being calculated, would be set incorrectly while drawing the lines.
**Fix:** This PR fixes that by correctly initializing `begin`