### PR TITLE
CI: Pin Emscripten version to 1.39.20 to fix regression

### DIFF
--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   GODOT_BASE_BRANCH: 3.2
   SCONS_CACHE_LIMIT: 4096
-  EM_VERSION: latest
+  EM_VERSION: 1.39.20
   EM_CACHE_FOLDER: 'emsdk-cache'
 
 jobs:


### PR DESCRIPTION
1.40.0 introduced a regression for us:
https://github.com/emscripten-core/emscripten/issues/11771

This is not necessary in the master branch, presumably because
it doesn't build any WebGL code (yet).