### PR TITLE
CI: Pin Emscripten version for reproducible builds

### DIFF
--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   GODOT_BASE_BRANCH: master
   SCONS_CACHE_LIMIT: 4096
-  EM_VERSION: latest
+  EM_VERSION: 1.39.20
   EM_CACHE_FOLDER: 'emsdk-cache'
 
 jobs:


### PR DESCRIPTION
Emscripten is a fast-moving target which gets tons of improvements all the time,
but it's not rare that some regressions affect us and make our CI builds fail.
(See e.g. #33728, #35237, #39168, #40563, and #40914.)

Let's pin to a stable version to avoid having external factors impact our CI,
and update this version manually regularly in a PR to ensure that the new
version works well for us.