### PR TITLE
Added possbility to raise or lower the texture index in the TileMap Editor

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -49,6 +49,8 @@ class TileSetEditor : public HSplitContainer {
 	enum TextureButtons {
 		TOOL_TILESET_ADD_TEXTURE,
 		TOOL_TILESET_REMOVE_TEXTURE,
+		TOOL_TILESET_DEC_TEXTURE_INDEX,
+		TOOL_TILESET_INC_TEXTURE_INDEX,
 		TOOL_TILESET_CREATE_SCENE,
 		TOOL_TILESET_MERGE_SCENE,
 		TOOL_TILESET_MAX
@@ -166,6 +168,9 @@ class TileSetEditor : public HSplitContainer {
 
 	void add_texture(Ref<Texture2D> p_texture);
 	void remove_texture(Ref<Texture2D> p_texture);
+	void increment_texture_index(Ref<Texture> p_texture);
+	void decrement_texture_index(Ref<Texture> p_texture);
+	void change_texture_index(int p_from, int p_to);
 
 	Ref<Texture2D> get_current_texture();
 


### PR DESCRIPTION
This PR allows the changing index of the texture in the TileMap. The end-user should not suffer if he/she accidentally pushes textures to the TileMap in the wrong order.

![tilemap_index](https://user-images.githubusercontent.com/3036176/89043368-08b34700-d351-11ea-9d78-67bfda4aa93d.gif)

![tilemap2](https://user-images.githubusercontent.com/3036176/89047101-9a718300-d356-11ea-85fe-f2bc4cd9368c.gif)
