### PR TITLE
Properly handle empty CSGCombiners

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -646,7 +646,7 @@ CSGShape3D::~CSGShape3D() {
 //////////////////////////////////
 
 CSGBrush *CSGCombiner3D::_build_brush() {
-	return nullptr; //does not build anything
+	return memnew(CSGBrush); //does not build anything
 }
 
 CSGCombiner3D::CSGCombiner3D() {


### PR DESCRIPTION
Fixes "Cannot get CSGBrush" error spam.
Fixes #24696.
Fixes #40782.