### PR TITLE
Fix window max_size acting as min_size

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -527,11 +527,11 @@ void Window::_update_window_size() {
 	size.x = MAX(size_limit.x, size.x);
 	size.y = MAX(size_limit.y, size.y);
 
-	if (max_size.x > 0 && max_size.x > min_size.x && max_size.x > size.x) {
+	if (max_size.x > 0 && max_size.x > min_size.x && size.x > max_size.x) {
 		size.x = max_size.x;
 	}
 
-	if (max_size.y > 0 && max_size.y > min_size.y && max_size.y > size.y) {
+	if (max_size.y > 0 && max_size.y > min_size.y && size.y > max_size.y) {
 		size.y = max_size.y;
 	}
 


### PR DESCRIPTION
The condition used appears to be backwards, causing the window to be resized to the maximum size that was set.