### PR TITLE
Add more sanitizer flags to shows more bugs by default

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -67,10 +67,10 @@ def get_opts():
         BoolVariable("use_static_cpp", "Link libgcc and libstdc++ statically for better portability", True),
         BoolVariable("use_coverage", "Test Godot coverage", False),
         BoolVariable("use_ubsan", "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)", False),
-        BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False),
-        BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN))", False),
-        BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False),
-        BoolVariable("use_msan", "Use LLVM/GCC compiler memory sanitizer (MSAN))", False),
+        BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN)", False),
+        BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN)", False),
+        BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN)", False),
+        BoolVariable("use_msan", "Use LLVM compiler memory sanitizer (MSAN)", False),
         BoolVariable("pulseaudio", "Detect and use PulseAudio", True),
         BoolVariable("udev", "Use udev for gamepad connection callbacks", True),
         BoolVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", True),
@@ -147,11 +147,23 @@ def configure(env):
         env.extra_suffix += "s"
 
         if env["use_ubsan"]:
-            env.Append(CCFLAGS=["-fsanitize=undefined"])
+            env.Append(
+                CCFLAGS=[
+                    "-fsanitize=undefined,shift,shift-exponent,integer-divide-by-zero,unreachable,vla-bound,null,return,signed-integer-overflow,bounds,float-divide-by-zero,float-cast-overflow,nonnull-attribute,returns-nonnull-attribute,bool,enum,vptr,pointer-overflow,builtin"
+                ]
+            )
             env.Append(LINKFLAGS=["-fsanitize=undefined"])
+            if env["use_llvm"]:
+                env.Append(
+                    CCFLAGS=[
+                        "-fsanitize=nullability-return,nullability-arg,function,nullability-assign,implicit-integer-sign-change,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation"
+                    ]
+                )
+            else:
+                env.Append(CCFLAGS=["-fsanitize=bounds-strict"])
 
         if env["use_asan"]:
-            env.Append(CCFLAGS=["-fsanitize=address"])
+            env.Append(CCFLAGS=["-fsanitize=address,pointer-subtract,pointer-compare"])
             env.Append(LINKFLAGS=["-fsanitize=address"])
 
         if env["use_lsan"]:
@@ -162,8 +174,10 @@ def configure(env):
             env.Append(CCFLAGS=["-fsanitize=thread"])
             env.Append(LINKFLAGS=["-fsanitize=thread"])
 
-        if env["use_msan"]:
+        if env["use_msan"] and env["use_llvm"]:
             env.Append(CCFLAGS=["-fsanitize=memory"])
+            env.Append(CCFLAGS=["-fsanitize-memory-track-origins"])
+            env.Append(CCFLAGS=["-fsanitize-recover=memory"])
             env.Append(LINKFLAGS=["-fsanitize=memory"])
 
     if env["use_lto"]:

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -34,9 +34,9 @@ def get_opts():
         BoolVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", True),
         BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         BoolVariable("use_ubsan", "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)", False),
-        BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False),
-        BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN))", False),
-        BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False),
+        BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN)", False),
+        BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN)", False),
+        BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN)", False),
     ]
 
 
@@ -136,11 +136,23 @@ def configure(env):
         env.extra_suffix += "s"
 
         if env["use_ubsan"]:
-            env.Append(CCFLAGS=["-fsanitize=undefined"])
+            env.Append(
+                CCFLAGS=[
+                    "-fsanitize=undefined,shift,shift-exponent,integer-divide-by-zero,unreachable,vla-bound,null,return,signed-integer-overflow,bounds,float-divide-by-zero,float-cast-overflow,nonnull-attribute,returns-nonnull-attribute,bool,enum,vptr,pointer-overflow,builtin"
+                ]
+            )
             env.Append(LINKFLAGS=["-fsanitize=undefined"])
+            if env["use_llvm"]:
+                env.Append(
+                    CCFLAGS=[
+                        "-fsanitize=nullability-return,nullability-arg,function,nullability-assign,implicit-integer-sign-change,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation"
+                    ]
+                )
+            else:
+                env.Append(CCFLAGS=["-fsanitize=bounds-strict"])
 
         if env["use_asan"]:
-            env.Append(CCFLAGS=["-fsanitize=address"])
+            env.Append(CCFLAGS=["-fsanitize=address,pointer-subtract,pointer-compare"])
             env.Append(LINKFLAGS=["-fsanitize=address"])
 
         if env["use_lsan"]:

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -35,11 +35,11 @@ def get_opts():
         BoolVariable("use_static_cpp", "Link libgcc and libstdc++ statically for better portability", True),
         BoolVariable("use_coverage", "Test Godot coverage", False),
         BoolVariable("use_ubsan", "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)", False),
-        BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN))", False),
-        BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN))", False),
-        BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN))", False),
+        BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN)", False),
+        BoolVariable("use_lsan", "Use LLVM/GCC compiler leak sanitizer (LSAN)", False),
+        BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN)", False),
+        BoolVariable("use_msan", "Use LLVM compiler memory sanitizer (MSAN)", False),
         BoolVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", True),
-        BoolVariable("use_msan", "Use LLVM/GCC compiler memory sanitizer (MSAN))", False),
         BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         BoolVariable("execinfo", "Use libexecinfo on systems where glibc is not available", False),
     ]
@@ -104,11 +104,23 @@ def configure(env):
         env.extra_suffix += "s"
 
         if env["use_ubsan"]:
-            env.Append(CCFLAGS=["-fsanitize=undefined"])
+            env.Append(
+                CCFLAGS=[
+                    "-fsanitize=undefined,shift,shift-exponent,integer-divide-by-zero,unreachable,vla-bound,null,return,signed-integer-overflow,bounds,float-divide-by-zero,float-cast-overflow,nonnull-attribute,returns-nonnull-attribute,bool,enum,vptr,pointer-overflow,builtin"
+                ]
+            )
             env.Append(LINKFLAGS=["-fsanitize=undefined"])
+            if env["use_llvm"]:
+                env.Append(
+                    CCFLAGS=[
+                        "-fsanitize=nullability-return,nullability-arg,function,nullability-assign,implicit-integer-sign-change,implicit-signed-integer-truncation,implicit-unsigned-integer-truncation"
+                    ]
+                )
+            else:
+                env.Append(CCFLAGS=["-fsanitize=bounds-strict"])
 
         if env["use_asan"]:
-            env.Append(CCFLAGS=["-fsanitize=address"])
+            env.Append(CCFLAGS=["-fsanitize=address,pointer-subtract,pointer-compare"])
             env.Append(LINKFLAGS=["-fsanitize=address"])
 
         if env["use_lsan"]:
@@ -119,8 +131,10 @@ def configure(env):
             env.Append(CCFLAGS=["-fsanitize=thread"])
             env.Append(LINKFLAGS=["-fsanitize=thread"])
 
-        if env["use_msan"]:
+        if env["use_msan"] and env["use_llvm"]:
             env.Append(CCFLAGS=["-fsanitize=memory"])
+            env.Append(CCFLAGS=["-fsanitize-memory-track-origins"])
+            env.Append(CCFLAGS=["-fsanitize-recover=memory"])
             env.Append(LINKFLAGS=["-fsanitize=memory"])
 
     if env["use_lto"]:


### PR DESCRIPTION
For now `scons p=linuxbsd use_ubsan=yes` shows this errors when running one of my projects:
```
thirdparty/glslang/glslang/MachineIndependent/localintermediate.h:100:8: runtime error: load of value 224, which is not a valid value for type 'bool'
thirdparty/glslang/glslang/MachineIndependent/localintermediate.h:100:8: runtime error: load of value 160, which is not a valid value for type 'bool'
thirdparty/glslang/glslang/MachineIndependent/localintermediate.h:100:8: runtime error: load of value 137, which is not a valid value for type 'bool'
thirdparty/misc/open-simplex-noise.c:195:14: runtime error: signed integer overflow: 1442695040888963407 * 6364136223846793005 cannot be represented in type 'long int'
thirdparty/misc/open-simplex-noise.c:196:14: runtime error: signed integer overflow: 1876011003808476466 * 6364136223846793005 cannot be represented in type 'long int'
thirdparty/misc/open-simplex-noise.c:198:15: runtime error: signed integer overflow: -7280499659394350823 * 6364136223846793005 cannot be represented in type 'long int'
thirdparty/misc/open-simplex-noise.c:198:8: runtime error: signed integer overflow: 8903339076496225463 + 1442695040888963407 cannot be represented in type 'long long int'
thirdparty/misc/open-simplex-noise.c:194:14: runtime error: signed integer overflow: 2 * 6364136223846793005 cannot be represented in type 'long int'
thirdparty/misc/open-simplex-noise.c:195:7: runtime error: signed integer overflow: 8665214161362419545 + 1442695040888963407 cannot be represented in type 'long long int'
thirdparty/misc/open-simplex-noise.c:194:7: runtime error: signed integer overflow: 8301130017339275202 + 1442695040888963407 cannot be represented in type 'long long int'
modules/bmp/image_loader_bmp.cpp:127:16: runtime error: load of misaligned address 0x6210003a7cb3 for type 'uint32_t', which requires 4 byte alignment
0x6210003a7cb3: note: pointer points here
 10  2c 80 10 2c 80 10 2c 80  10 2c 80 10 2c 80 10 2c  80 10 2c 80 10 2c 80 10  2c 80 10 2c 80 10 2c
              ^ 
thirdparty/misc/mikktspace.c:1659:21: runtime error: shift exponent 32 is too large for 32-bit type 'unsigned int'
editor/input_map_editor.cpp:641:6: runtime error: load of value 190, which is not a valid value for type 'bool'
```
with this PR will shows additionally:
```
servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp:1136:52: runtime error: division by zero
servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp:1137:52: runtime error: division by zero
core/image.cpp:3202:3: runtime error: null pointer passed as argument 1, which is declared to never be null
core/image.cpp:3202:3: runtime error: null pointer passed as argument 2, which is declared to never be null
modules/svg/image_loader_svg.cpp:59:43: runtime error: index 1 out of bounds for type 'NSVGgradientStop [1]'
thirdparty/nanosvg/nanosvgrast.h:1293:47: runtime error: index 2 out of bounds for type 'NSVGgradientStop [1]'
thirdparty/nanosvg/nanosvgrast.h:1302:43: runtime error: index 1 out of bounds for type 'NSVGgradientStop [1]'
thirdparty/nanosvg/nanosvgrast.h:1304:37: runtime error: index 1 out of bounds for type 'NSVGgradientStop [1]'
thirdparty/nanosvg/nanosvgrast.h:1301:41: runtime error: index 1 out of bounds for type 'NSVGgradientStop [1]'
thirdparty/nanosvg/nanosvgrast.h:1303:35: runtime error: index 1 out of bounds for type 'NSVGgradientStop [1]'
thirdparty/nanosvg/nanosvg.h:2161:49: runtime error: division by zero
```

Also added memory sanitizer support which track uninitialized variables(it is only available on Linux LLVM) and for it is hard to find useful info in error flood(almost 4GB log when running project manager, mostly by thirdparty(Vulkan and SpirV)).
example report:
```
SUMMARY: MemorySanitizer: use-of-uninitialized-value /mnt/Miecz/mojgodot/thirdparty/vulkan/loader/loader.c:2020:29 in loader_get_icd_loader_instance_extensions
Uninitialized bytes in __interceptor_strcmp at offset 0 inside [0x725000000104, 8)
==55437==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0xcd74cf6 in loader_get_icd_loader_instance_extensions /mnt/Miecz/mojgodot/thirdparty/vulkan/loader/loader.c:2020:29
    #1 0xcddd3ab in terminator_EnumerateInstanceExtensionProperties /mnt/Miecz/mojgodot/thirdparty/vulkan/loader/loader.c:7248:15
    #2 0xc926c43 in vkEnumerateInstanceExtensionProperties /mnt/Miecz/mojgodot/thirdparty/vulkan/loader/trampoline.c:171:15
    #3 0xc8cc649 in VulkanContext::_initialize_extensions() /mnt/Miecz/mojgodot/drivers/vulkan/vulkan_context.cpp:229:8
    #4 0xc8ce6f1 in VulkanContext::_create_physical_device() /mnt/Miecz/mojgodot/drivers/vulkan/vulkan_context.cpp:281:15
    #5 0xc8e8c0d in VulkanContext::initialize() /mnt/Miecz/mojgodot/drivers/vulkan/vulkan_context.cpp:1133:14
    #6 0x1d8fc7a in DisplayServerX11::DisplayServerX11(String const&, DisplayServer::WindowMode, unsigned int, Vector2i const&, Error&) /mnt/Miecz/mojgodot/platform/linuxbsd/display_server_x11.cpp:3583:23
    #7 0x1d89e41 in DisplayServerX11::create_func(String const&, DisplayServer::WindowMode, unsigned int, Vector2i const&, Error&) /mnt/Miecz/mojgodot/platform/linuxbsd/display_server_x11.cpp:3196:22
    #8 0x1a379316 in DisplayServer::create(int, String const&, DisplayServer::WindowMode, unsigned int, Vector2i const&, Error&) /mnt/Miecz/mojgodot/servers/display_server.cpp:604:9
    #9 0x1e7f3da in Main::setup2(unsigned long) /mnt/Miecz/mojgodot/main/main.cpp:1377:20
    #10 0x1e7c408 in Main::setup(char const*, int, char**, bool) /mnt/Miecz/mojgodot/main/main.cpp:1299:10
    #11 0x1ca59cf in main /mnt/Miecz/mojgodot/platform/linuxbsd/godot_linuxbsd.cpp:51:14
    #12 0x7fd63a2ae0b2 in __libc_start_main /build/glibc-YYA7BZ/glibc-2.31/csu/../csu/libc-start.c:308:16
    #13 0x1c29cbd in _start (/mnt/Miecz/mojgodot/bin/godot.linuxbsd.tools.64.llvms+0x1c29cbd)

  Uninitialized value was stored to memory at
    #0 0x1c2f826 in __msan_memcpy (/mnt/Miecz/mojgodot/bin/godot.linuxbsd.tools.64.llvms+0x1c2f826)
    #1 0xcd664d7 in loader_add_to_ext_list /mnt/Miecz/mojgodot/thirdparty/vulkan/loader/loader.c:1563:9
    #2 0xcd76cd8 in loader_add_instance_extensions /mnt/Miecz/mojgodot/thirdparty/vulkan/loader/loader.c:1418:19
    #3 0xcd746d7 in loader_get_icd_loader_instance_extensions /mnt/Miecz/mojgodot/thirdparty/vulkan/loader/loader.c:2011:15
    #4 0xcddd3ab in terminator_EnumerateInstanceExtensionProperties /mnt/Miecz/mojgodot/thirdparty/vulkan/loader/loader.c:7248:15
    #5 0xc926c43 in vkEnumerateInstanceExtensionProperties /mnt/Miecz/mojgodot/thirdparty/vulkan/loader/trampoline.c:171:15
    #6 0xc8cc649 in VulkanContext::_initialize_extensions() /mnt/Miecz/mojgodot/drivers/vulkan/vulkan_context.cpp:229:8
    #7 0xc8ce6f1 in VulkanContext::_create_physical_device() /mnt/Miecz/mojgodot/drivers/vulkan/vulkan_context.cpp:281:15
    #8 0xc8e8c0d in VulkanContext::initialize() /mnt/Miecz/mojgodot/drivers/vulkan/vulkan_context.cpp:1133:14
    #9 0x1d8fc7a in DisplayServerX11::DisplayServerX11(String const&, DisplayServer::WindowMode, unsigned int, Vector2i const&, Error&) /mnt/Miecz/mojgodot/platform/linuxbsd/display_server_x11.cpp:3583:23
    #10 0x1d89e41 in DisplayServerX11::create_func(String const&, DisplayServer::WindowMode, unsigned int, Vector2i const&, Error&) /mnt/Miecz/mojgodot/platform/linuxbsd/display_server_x11.cpp:3196:22
    #11 0x1a379316 in DisplayServer::create(int, String const&, DisplayServer::WindowMode, unsigned int, Vector2i const&, Error&) /mnt/Miecz/mojgodot/servers/display_server.cpp:604:9
    #12 0x1e7f3da in Main::setup2(unsigned long) /mnt/Miecz/mojgodot/main/main.cpp:1377:20
    #13 0x1e7c408 in Main::setup(char const*, int, char**, bool) /mnt/Miecz/mojgodot/main/main.cpp:1299:10
    #14 0x1ca59cf in main /mnt/Miecz/mojgodot/platform/linuxbsd/godot_linuxbsd.cpp:51:14
    #15 0x7fd63a2ae0b2 in __libc_start_main /build/glibc-YYA7BZ/glibc-2.31/csu/../csu/libc-start.c:308:16

  Uninitialized value was created by an allocation of '' in the stack frame of function 'loader_add_instance_extensions'
    #0 0xcd75700 in loader_add_instance_extensions /mnt/Miecz/mojgodot/thirdparty/vulkan/loader/loader.c:1369
```

The only missing flag is `-fsanitize=implicit-unsigned-integer-truncation` available only in LLVM because it cause to big error spam.
