### PR TITLE
Fix memory leak in test args

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -84,6 +84,9 @@ int test_main(int argc, char *argv[]) {
 	test_context.setOption("abort-after", 5);
 	test_context.setOption("no-breaks", true);
 
+	for (int x = 0; x < valid_arguments.size(); x++) {
+		delete[] args[x];
+	}
 	delete[] args;
 
 	return test_context.run();


### PR DESCRIPTION
With the #40928, this allows #40920 to pass the tests with sanitizer.
```
==24982==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 47 byte(s) in 2 object(s) allocated from:
    #0 0x7fa785b20618 in operator new[](unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0618)
    #1 0x1bac644 in test_main(int, char**) tests/test_main.cpp:76
    #2 0x1a55116 in Main::test_entrypoint(int, char**, bool&) main/main.cpp:380
    #3 0x1973940 in main platform/linuxbsd/godot_linuxbsd.cpp:45
    #4 0x7fa782ad1b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 47 byte(s) leaked in 2 allocation(s).
```
P.S. My first bug fix with sanitizer's help. 😛
