### PR TITLE
[3.2] Fix navigation bar showing when virtual keyboard is hidden

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -132,6 +132,10 @@ public abstract class Godot extends FragmentActivity implements SensorEventListe
 	private boolean activityResumed;
 	private int mState;
 
+	public boolean isImmersiveUsed() {
+		return use_immersive;
+	}
+
 	// Used to dispatch events to the main thread.
 	private final Handler mainThreadHandler = new Handler(Looper.getMainLooper());
 
@@ -243,9 +247,8 @@ public abstract class Godot extends FragmentActivity implements SensorEventListe
 	private boolean use_apk_expansion;
 
 	public GodotView mView;
-	private boolean godot_initialized = false;
-
 	private GodotEditText mEditText;
+	private boolean godot_initialized = false;
 
 	private SensorManager mSensorManager;
 	private Sensor mAccelerometer;
@@ -302,6 +305,14 @@ public abstract class Godot extends FragmentActivity implements SensorEventListe
 		for (GodotPlugin plugin : pluginRegistry.getAllPlugins()) {
 			plugin.onGodotMainLoopStarted();
 		}
+	}
+
+	/**
+	 * Invoked on the render thread on each step of the Godot main loop.
+	 */
+	@CallSuper
+	protected void onGodotMainLoopStep() {
+		mEditText.onGodotMainLoopStep();
 	}
 
 	/**
@@ -694,19 +705,10 @@ public abstract class Godot extends FragmentActivity implements SensorEventListe
 	@Override
 	protected void onStart() {
 		super.onStart();
-
-		mView.post(new Runnable() {
-			@Override
-			public void run() {
-				mEditText.onInitView();
-			}
-		});
 	}
 
 	@Override
 	protected void onDestroy() {
-		mEditText.onDestroyView();
-
 		for (int i = 0; i < singleton_count; i++) {
 			singletons[i].onMainDestroy();
 		}

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -261,6 +261,8 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jcl
 		++step;
 	}
 
+	godot_java->on_godot_main_loop_step(env);
+
 	os_android->process_accelerometer(accelerometer);
 	os_android->process_gravity(gravity);
 	os_android->process_magnetometer(magnetometer);

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -67,6 +67,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_instance) {
 	_vibrate = p_env->GetMethodID(cls, "vibrate", "(I)V");
 	_get_input_fallback_mapping = p_env->GetMethodID(cls, "getInputFallbackMapping", "()Ljava/lang/String;");
 	_on_godot_main_loop_started = p_env->GetMethodID(cls, "onGodotMainLoopStarted", "()V");
+	_on_godot_main_loop_step = p_env->GetMethodID(cls, "onGodotMainLoopStep", "()V");
 }
 
 GodotJavaWrapper::~GodotJavaWrapper() {
@@ -122,6 +123,15 @@ void GodotJavaWrapper::on_godot_main_loop_started(JNIEnv *p_env) {
 		}
 	}
 	p_env->CallVoidMethod(godot_instance, _on_godot_main_loop_started);
+}
+
+void GodotJavaWrapper::on_godot_main_loop_step(JNIEnv *p_env) {
+	if (_on_godot_main_loop_step) {
+		if (p_env == NULL) {
+			p_env = ThreadAndroid::get_env();
+		}
+	}
+	p_env->CallVoidMethod(godot_instance, _on_godot_main_loop_step);
 }
 
 void GodotJavaWrapper::restart(JNIEnv *p_env) {

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -62,6 +62,7 @@ private:
 	jmethodID _vibrate = 0;
 	jmethodID _get_input_fallback_mapping = 0;
 	jmethodID _on_godot_main_loop_started = 0;
+	jmethodID _on_godot_main_loop_step = 0;
 
 public:
 	GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_instance);
@@ -75,6 +76,7 @@ public:
 	void gfx_init(bool gl2);
 	void on_video_init(JNIEnv *p_env = NULL);
 	void on_godot_main_loop_started(JNIEnv *p_env = NULL);
+	void on_godot_main_loop_step(JNIEnv *p_env = NULL);
 	void restart(JNIEnv *p_env = NULL);
 	void force_quit(JNIEnv *p_env = NULL);
 	void set_keep_screen_on(bool p_enabled);


### PR DESCRIPTION
Fixes regression from #40672 described in https://github.com/godotengine/godot/issues/37793#issuecomment-667089249
Fixes #41013

This PR is for 3.2 branch, I'm going to make a separate one for master.

The previous changes to add a popup for showing the virtual keyboard in order to keep track of the keyboard height caused a regression due to having the popup always showing: the navigation bar was always showing for devices that use a virtual navigation bar.

Now the popup is created and shown only when the virtual keyboard is needed, and dismissed when the keyboard is hidden.

In order to keep track of the state of the keyboard in cases where the keyboard is opened and closed several times in a row, ResultReceiver is used to detect exactly when the keyboard is fully initialized after a request, and then can be detected as hidden if the user presses the button to close the keyboard.