### PR TITLE
Stringify `Variant` compatible types for doctest output

### DIFF
--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -47,4 +47,61 @@
 #define ERR_PRINT_OFF _print_error_enabled = false;
 #define ERR_PRINT_ON _print_error_enabled = true;
 
+// Stringify all `Variant` compatible types for doctest output by default.
+// https://github.com/onqtam/doctest/blob/master/doc/markdown/stringification.md
+
+#define DOCTEST_STRINGIFY_VARIANT(m_type)                        \
+	template <>                                                  \
+	struct doctest::StringMaker<m_type> {                        \
+		static doctest::String convert(const m_type &p_val) {    \
+			const Variant val = p_val;                           \
+			return val.get_construct_string().utf8().get_data(); \
+		}                                                        \
+	};
+
+#define DOCTEST_STRINGIFY_VARIANT_POINTER(m_type)                \
+	template <>                                                  \
+	struct doctest::StringMaker<m_type> {                        \
+		static doctest::String convert(const m_type *p_val) {    \
+			const Variant val = p_val;                           \
+			return val.get_construct_string().utf8().get_data(); \
+		}                                                        \
+	};
+
+DOCTEST_STRINGIFY_VARIANT(Variant);
+DOCTEST_STRINGIFY_VARIANT(::String); // Disambiguate from `doctest::String`.
+
+DOCTEST_STRINGIFY_VARIANT(Vector2);
+DOCTEST_STRINGIFY_VARIANT(Vector2i);
+DOCTEST_STRINGIFY_VARIANT(Rect2);
+DOCTEST_STRINGIFY_VARIANT(Rect2i);
+DOCTEST_STRINGIFY_VARIANT(Vector3);
+DOCTEST_STRINGIFY_VARIANT(Vector3i);
+DOCTEST_STRINGIFY_VARIANT(Transform2D);
+DOCTEST_STRINGIFY_VARIANT(Plane);
+DOCTEST_STRINGIFY_VARIANT(Quat);
+DOCTEST_STRINGIFY_VARIANT(AABB);
+DOCTEST_STRINGIFY_VARIANT(Basis);
+DOCTEST_STRINGIFY_VARIANT(Transform);
+
+DOCTEST_STRINGIFY_VARIANT(::Color); // Disambiguate from `doctest::Color`.
+DOCTEST_STRINGIFY_VARIANT(StringName);
+DOCTEST_STRINGIFY_VARIANT(NodePath);
+DOCTEST_STRINGIFY_VARIANT(RID);
+DOCTEST_STRINGIFY_VARIANT_POINTER(Object);
+DOCTEST_STRINGIFY_VARIANT(Callable);
+DOCTEST_STRINGIFY_VARIANT(Signal);
+DOCTEST_STRINGIFY_VARIANT(Dictionary);
+DOCTEST_STRINGIFY_VARIANT(Array);
+
+DOCTEST_STRINGIFY_VARIANT(PackedByteArray);
+DOCTEST_STRINGIFY_VARIANT(PackedInt32Array);
+DOCTEST_STRINGIFY_VARIANT(PackedInt64Array);
+DOCTEST_STRINGIFY_VARIANT(PackedFloat32Array);
+DOCTEST_STRINGIFY_VARIANT(PackedFloat64Array);
+DOCTEST_STRINGIFY_VARIANT(PackedStringArray);
+DOCTEST_STRINGIFY_VARIANT(PackedVector2Array);
+DOCTEST_STRINGIFY_VARIANT(PackedVector3Array);
+DOCTEST_STRINGIFY_VARIANT(PackedColorArray);
+
 #endif // TEST_MACROS_H

--- a/tests/test_validate_testing.h
+++ b/tests/test_validate_testing.h
@@ -53,6 +53,141 @@ TEST_SUITE("Validate tests") {
 		ERR_PRINT_ON;
 		CHECK_MESSAGE(_print_error_enabled, "Error printing should be re-enabled.");
 	}
+	TEST_CASE("Stringify Variant types") {
+		ClassDB::init(); // For objects.
+
+		Variant var;
+		INFO(var);
+
+		String string("Godot is finally here!");
+		INFO(string);
+
+		Vector2 vec2(0.5, 1.0);
+		INFO(vec2);
+
+		Vector2i vec2i(1, 2);
+		INFO(vec2i);
+
+		Rect2 rect2(0.5, 0.5, 100.5, 100.5);
+		INFO(rect2);
+
+		Rect2i rect2i(0, 0, 100, 100);
+		INFO(rect2i);
+
+		Vector3 vec3(0.5, 1.0, 2.0);
+		INFO(vec3);
+
+		Vector3i vec3i(1, 2, 3);
+		INFO(vec3i);
+
+		Transform2D trans2d(0.5, Vector2(100, 100));
+		INFO(trans2d);
+
+		Plane plane(Vector3(1, 1, 1), 1.0);
+		INFO(plane);
+
+		Quat quat(Vector3(0.5, 1.0, 2.0));
+		INFO(quat);
+
+		AABB aabb(Vector3(), Vector3(100, 100, 100));
+		INFO(aabb);
+
+		Basis basis(quat);
+		INFO(basis);
+
+		Transform trans(basis);
+		INFO(trans);
+
+		Color color(1, 0.5, 0.2, 0.3);
+		INFO(color);
+
+		StringName string_name("has_method");
+		INFO(string_name);
+
+		NodePath node_path("godot/sprite");
+		INFO(node_path);
+
+		INFO(RID());
+
+		Object *obj = memnew(Object);
+		INFO(obj);
+
+		Callable callable(obj, "has_method");
+		INFO(callable);
+
+		Signal signal(obj, "script_changed");
+		INFO(signal);
+
+		memdelete(obj);
+
+		Dictionary dict;
+		dict["string"] = string;
+		dict["color"] = color;
+		INFO(dict);
+
+		Array arr;
+		arr.push_back(string);
+		arr.push_back(color);
+		INFO(arr);
+
+		PackedByteArray byte_arr;
+		byte_arr.push_back(0);
+		byte_arr.push_back(1);
+		byte_arr.push_back(2);
+		INFO(byte_arr);
+
+		PackedInt32Array int32_arr;
+		int32_arr.push_back(0);
+		int32_arr.push_back(1);
+		int32_arr.push_back(2);
+		INFO(int32_arr);
+
+		PackedInt64Array int64_arr;
+		int64_arr.push_back(0);
+		int64_arr.push_back(1);
+		int64_arr.push_back(2);
+		INFO(int64_arr);
+
+		PackedFloat32Array float32_arr;
+		float32_arr.push_back(0.5);
+		float32_arr.push_back(1.5);
+		float32_arr.push_back(2.5);
+		INFO(float32_arr);
+
+		PackedFloat64Array float64_arr;
+		float64_arr.push_back(0.5);
+		float64_arr.push_back(1.5);
+		float64_arr.push_back(2.5);
+		INFO(float64_arr);
+
+		PackedStringArray str_arr = string.split(" ");
+		INFO(str_arr);
+
+		PackedVector2Array vec2_arr;
+		vec2_arr.push_back(Vector2(0, 0));
+		vec2_arr.push_back(Vector2(1, 1));
+		vec2_arr.push_back(Vector2(2, 2));
+		INFO(vec2_arr);
+
+		PackedVector3Array vec3_arr;
+		vec3_arr.push_back(Vector3(0, 0, 0));
+		vec3_arr.push_back(Vector3(1, 1, 1));
+		vec3_arr.push_back(Vector3(2, 2, 2));
+		INFO(vec3_arr);
+
+		PackedColorArray color_arr;
+		color_arr.push_back(Color(0, 0, 0));
+		color_arr.push_back(Color(1, 1, 1));
+		color_arr.push_back(Color(2, 2, 2));
+		INFO(color_arr);
+
+		INFO("doctest insertion operator << "
+				<< var << " " << vec2 << " " << rect2 << " " << color);
+
+		CHECK(true); // So all above prints.
+
+		ClassDB::cleanup();
+	}
 }
 
 #endif // TEST_VALIDATE_TESTING_H


### PR DESCRIPTION
See #40890 and #40940 for context.

Assertion messages should now be able to properly convert `Variant` to doctest strings (using `VariantWriter` aka `var2str` in GDScript), example output for `Color`:
```
D:\src\godot\tests\test_color.h(73): SUCCESS: CHECK( Color() != blue_html ) is correct!
  values: CHECK( Color( 0, 0, 0, 1 ) != Color( 0.25098, 0.376471, 1, 0.501961 ) )
  logged: Should not equal
```

Using `VariantWriter` is necessary if you want to copy and paste the output from doctest directly in code or even GDScript from them to be parsed back properly.