### PR TITLE
Add more test macros to follow Godot conventions

### DIFF
--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -30,13 +30,53 @@
 
 #ifndef TEST_MACROS_H
 #define TEST_MACROS_H
-
+//==============================================================================
 // See documentation for doctest at:
 // https://github.com/onqtam/doctest/blob/master/doc/markdown/readme.md#reference
 #include "thirdparty/doctest/doctest.h"
+//==============================================================================
 
-// The test is skipped with this, run pending tests with `--test --no-skip`.
-#define TEST_CASE_PENDING(name) TEST_CASE(name *doctest::skip())
+// Use `CHECK(condition)` to for simple assertions,
+// and `CHECK_MSG(condition, message)` for assertions with descriptions.
+#define CHECK_MSG DOCTEST_CHECK_MESSAGE
+#define TEST_CHECK DOCTEST_CHECK
+#define TEST_CHECK_MSG DOCTEST_CHECK_MESSAGE
+
+// Use `REQUIRE(condition)` to quit a test immediately if condition is not met,
+// and `REQUIRE_MSG(condition, message)` to quit a test by providing rationale.
+#define REQUIRE_MSG DOCTEST_REQUIRE_MESSAGE
+#define TEST_REQUIRE DOCTEST_REQUIRE
+#define TEST_REQUIRE_MSG DOCTEST_REQUIRE_MESSAGE
+
+// The following are like `ERR_FAIL_*` macros defined in `core/error_macros.h`.
+// Quit the test case if any assert fails and mark the test case as failed.
+// NOTE: these are the opposite of `REQUIRE`.
+#define TEST_FAIL() DOCTEST_FAIL();
+#define TEST_FAIL_MSG(m_msg) DOCTEST_FAIL(m_msg)
+#define TEST_FAIL_COND(m_cond) DOCTEST_REQUIRE_FALSE(m_cond);
+#define TEST_FAIL_COND_MSG(m_cond, m_msg) DOCTEST_REQUIRE_FALSE_MESSAGE(m_cond, m_msg);
+
+//==============================================================================
+
+// Use this if you need to test imprecise floating point values.
+// Always prefer using `Math::is_equal_approx` defined for most `Variant` types
+// unless you need more tolerant comparisons of floating point values.
+#define CHECK_EQUAL_APPROX(m_got, m_expected, m_eps) \
+	DOCTEST_CHECK(m_got == doctest::Approx(m_expected).epsilon(m_eps));
+
+//==============================================================================
+
+// The test case is skipped, run pending tests with `--test --no-skip`.
+#define TEST_CASE_PENDING(m_name) DOCTEST_TEST_CASE(m_name *doctest::skip())
+
+// The test case is allowed to fail without causing the entire test run to fail.
+#define TEST_CASE_MAY_FAIL(m_name) DOCTEST_TEST_CASE(m_name *doctest::may_fail())
+
+// The test is skipped and allowed to fail (a work-in-progress test).
+#define TEST_CASE_WIP(m_name) \
+	DOCTEST_TEST_CASE(m_name *doctest::skip() * doctest::may_fail())
+
+//==============================================================================
 
 // Temporarily disable error prints to test failure paths.
 // This allows to avoid polluting the test summary with error messages.

--- a/tests/test_validate_testing.h
+++ b/tests/test_validate_testing.h
@@ -38,20 +38,33 @@
 TEST_SUITE("Validate tests") {
 	TEST_CASE("Always pass") {
 		CHECK(true);
+		REQUIRE(true);
+	}
+	TEST_CASE("Checks with a message") {
+		CHECK_MSG(true, "Should print a message after successful check.");
+		REQUIRE_MSG(true, "Should print a message after successful require check.");
+	}
+	TEST_CASE("Test fail condition") {
+		bool something_bad_happened = false;
+		TEST_FAIL_COND(something_bad_happened); // If this is false, then OK.
+	}
+	TEST_CASE("Test fail condition with rationale") {
+		bool something_bad_happened = false;
+		TEST_FAIL_COND_MSG(something_bad_happened, "If this is false, then OK.");
 	}
 	TEST_CASE_PENDING("Pending tests are skipped") {
 		if (!doctest::getContextOptions()->no_skip) { // Normal run.
 			FAIL("This should be skipped if `--no-skip` is NOT set (missing `doctest::skip()` decorator?)");
 		} else {
-			CHECK_MESSAGE(true, "Pending test is run with `--no-skip`");
+			CHECK_MSG(true, "Pending test is run with `--no-skip`");
 		}
 	}
 	TEST_CASE("Muting Godot error messages") {
 		ERR_PRINT_OFF;
-		CHECK_MESSAGE(!_print_error_enabled, "Error printing should be disabled.");
+		CHECK_MSG(!_print_error_enabled, "Error printing should be disabled.");
 		ERR_PRINT("Still waiting for Godot!"); // This should never get printed!
 		ERR_PRINT_ON;
-		CHECK_MESSAGE(_print_error_enabled, "Error printing should be re-enabled.");
+		CHECK_MSG(_print_error_enabled, "Error printing should be re-enabled.");
 	}
 }
 


### PR DESCRIPTION
Some macros like `TEST_FAIL_COND` will be useful for porting existing `ClassDB` tests:

https://github.com/godotengine/godot/blob/db1259ac7086744f475b191b0644ac933c30289c/tests/test_class_db.cpp#L47-L77

Also add aliases for `*_MESSAGE` doctest macros: `*_MSG` (no, not `mesege`). 😛

Created this PR so it's not lost in my backlog of test related PRs, and of course up to discussion!
