### PR TITLE
[GDScript] Add static HashMap cleanup.

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -71,6 +71,10 @@ static StringName get_real_class_name(const StringName &p_source) {
 	return p_source;
 }
 
+void GDScriptAnalyzer::cleanup() {
+	underscore_map.clear();
+}
+
 static GDScriptParser::DataType make_callable_type(const MethodInfo &p_info) {
 	GDScriptParser::DataType type;
 	type.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -113,6 +113,8 @@ public:
 	Error analyze();
 
 	GDScriptAnalyzer(GDScriptParser *p_parser);
+
+	static void cleanup();
 };
 
 #endif // GDSCRIPT_ANALYZER_H

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -94,6 +94,10 @@ Variant::Type GDScriptParser::get_builtin_type(const StringName &p_type) {
 	return Variant::VARIANT_MAX;
 }
 
+void GDScriptParser::cleanup() {
+	builtin_types.clear();
+}
+
 GDScriptFunctions::Function GDScriptParser::get_builtin_function(const StringName &p_name) {
 	for (int i = 0; i < GDScriptFunctions::FUNC_MAX; i++) {
 		if (p_name == GDScriptFunctions::get_func_name(GDScriptFunctions::Function(i))) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1335,6 +1335,7 @@ public:
 		void print_tree(const GDScriptParser &p_parser);
 	};
 #endif // DEBUG_ENABLED
+	static void cleanup();
 };
 
 #endif // GDSCRIPT_PARSER_H

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -35,6 +35,7 @@
 #include "core/os/dir_access.h"
 #include "core/os/file_access.h"
 #include "gdscript.h"
+#include "gdscript_analyzer.h"
 #include "gdscript_cache.h"
 #include "gdscript_tokenizer.h"
 
@@ -148,4 +149,7 @@ void unregister_gdscript_types() {
 	EditorTranslationParser::get_singleton()->remove_parser(gdscript_translation_parser_plugin, EditorTranslationParser::STANDARD);
 	gdscript_translation_parser_plugin.unref();
 #endif // TOOLS_ENABLED
+
+	GDScriptParser::cleanup();
+	GDScriptAnalyzer::cleanup();
 }


### PR DESCRIPTION
Add GDScript static `HashMap` cleanup to prevent `recursive_mutex lock failed` in `StringName` destructor crash on editor exit:

```
libsystem_kernel.dylib!__pthread_kill (Unknown Source:0)
libsystem_pthread.dylib!pthread_kill (Unknown Source:0)
libsystem_c.dylib!abort (Unknown Source:0)
libc++abi.dylib!abort_message (Unknown Source:0)
libc++abi.dylib!demangling_terminate_handler() (Unknown Source:0)
libobjc.A.dylib!_objc_terminate() (Unknown Source:0)
libc++abi.dylib!std::__terminate(void (*)()) (Unknown Source:0)
libc++abi.dylib!std::terminate() (Unknown Source:0)
Godot!__clang_call_terminate (Unknown Source:0)
Godot!~StringName (godot/core/string_name.cpp:378)
Godot!::~StringName() (godot/core/string_name.cpp:377)
Godot!~Pair (godot/core/hash_map.h:61)
Godot!~Pair (godot/core/hash_map.h:61)
Godot!~Element (godot/core/hash_map.h:72)
Godot!~Element (godot/core/hash_map.h:72)
Godot!memdelete<HashMap<StringName, Variant::Type, HashMapHasherDefault, HashMapComparatorDefault<StringName>, 'x03', 'x08'>::Element> (godot/core/os/memory.h:115)
Godot!clear (godot/core/hash_map.h:511)
Godot!~HashMap (godot/core/hash_map.h:547)
Godot!::~HashMap() (godot/core/hash_map.h:546)
libsystem_c.dylib!__cxa_finalize_ranges (Unknown Source:0)

libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: recursive_mutex lock failed: Invalid argument
2582 Abort trap: 6
```

For the reference `ClassDB` is using the same approach to clean static `HashMap`s, see [core/class_db.cpp#L1543-L1561](https://github.com/godotengine/godot/blob/master/core/class_db.cpp#L1543-L1561).

Fixes #40667
Fixes #40654
