### PR TITLE
Improve the quick hash function for all GPUs

### DIFF
--- a/servers/rendering/rasterizer_rd/shaders/scene_high_end.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/scene_high_end.glsl
@@ -681,9 +681,13 @@ LIGHT_SHADER_CODE
 
 #ifndef USE_NO_SHADOWS
 
-// Produces cheap but low-quality white noise, nothing special
+// Produces cheap white noise, optmized for window-space
+// Comes from: https://www.shadertoy.com/view/4djSRW
+// Copyright: Dave Hoskins, MIT License
 float quick_hash(vec2 pos) {
-	return fract(sin(dot(pos * 19.19, vec2(49.5791, 97.413))) * 49831.189237);
+	vec3 p3 = fract(vec3(pos.xyx) * .1031);
+	p3 += dot(p3, p3.yzx + 33.33);
+	return fract((p3.x + p3.y) * p3.z);
 }
 
 float sample_directional_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec4 coord) {


### PR DESCRIPTION
After upgrading my GPU I noticed that the soft shadow noise was looking horrible. I realized it was due to my noise choice in https://github.com/godotengine/godot/pull/37749. I had chosen a cheap sine-based noise that looked good on my hardware. However, sine-based noises look different on different hardware. Once I upgraded my GPU I could see how poor quality my noise choice was. 

This new noise should be equally as fast and is made to work in window-space integer coordinates. Consequently, it looks the same no matter what hardware is used. 

**Before this PR:**
![Screenshot (188)](https://user-images.githubusercontent.com/16521339/89112985-ca388d80-d41f-11ea-8431-7c068114513f.png)

**After this PR:**
![Screenshot (187)](https://user-images.githubusercontent.com/16521339/89112990-cefd4180-d41f-11ea-8107-8091b77398ce.png)

_For the record the "After" picture is what it looked like when I first added the old noise function_


