### PR TITLE
Change Shape3D::get_debug_mesh_lines into const methods

### DIFF
--- a/scene/resources/box_shape_3d.cpp
+++ b/scene/resources/box_shape_3d.cpp
@@ -31,7 +31,7 @@
 #include "box_shape_3d.h"
 #include "servers/physics_server_3d.h"
 
-Vector<Vector3> BoxShape3D::get_debug_mesh_lines() {
+Vector<Vector3> BoxShape3D::get_debug_mesh_lines() const {
 	Vector<Vector3> lines;
 	AABB aabb;
 	aabb.position = -get_extents();

--- a/scene/resources/box_shape_3d.h
+++ b/scene/resources/box_shape_3d.h
@@ -46,7 +46,7 @@ public:
 	void set_extents(const Vector3 &p_extents);
 	Vector3 get_extents() const;
 
-	virtual Vector<Vector3> get_debug_mesh_lines() override;
+	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override;
 
 	BoxShape3D();

--- a/scene/resources/capsule_shape_3d.cpp
+++ b/scene/resources/capsule_shape_3d.cpp
@@ -31,7 +31,7 @@
 #include "capsule_shape_3d.h"
 #include "servers/physics_server_3d.h"
 
-Vector<Vector3> CapsuleShape3D::get_debug_mesh_lines() {
+Vector<Vector3> CapsuleShape3D::get_debug_mesh_lines() const {
 	float radius = get_radius();
 	float height = get_height();
 

--- a/scene/resources/capsule_shape_3d.h
+++ b/scene/resources/capsule_shape_3d.h
@@ -49,7 +49,7 @@ public:
 	void set_height(float p_height);
 	float get_height() const;
 
-	virtual Vector<Vector3> get_debug_mesh_lines() override;
+	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override;
 
 	CapsuleShape3D();

--- a/scene/resources/concave_polygon_shape_3d.cpp
+++ b/scene/resources/concave_polygon_shape_3d.cpp
@@ -32,7 +32,7 @@
 
 #include "servers/physics_server_3d.h"
 
-Vector<Vector3> ConcavePolygonShape3D::get_debug_mesh_lines() {
+Vector<Vector3> ConcavePolygonShape3D::get_debug_mesh_lines() const {
 	Set<DrawEdge> edges;
 
 	Vector<Vector3> data = get_faces();

--- a/scene/resources/concave_polygon_shape_3d.h
+++ b/scene/resources/concave_polygon_shape_3d.h
@@ -65,7 +65,7 @@ public:
 	void set_faces(const Vector<Vector3> &p_faces);
 	Vector<Vector3> get_faces() const;
 
-	virtual Vector<Vector3> get_debug_mesh_lines() override;
+	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override;
 
 	ConcavePolygonShape3D();

--- a/scene/resources/convex_polygon_shape_3d.cpp
+++ b/scene/resources/convex_polygon_shape_3d.cpp
@@ -32,7 +32,7 @@
 #include "core/math/quick_hull.h"
 #include "servers/physics_server_3d.h"
 
-Vector<Vector3> ConvexPolygonShape3D::get_debug_mesh_lines() {
+Vector<Vector3> ConvexPolygonShape3D::get_debug_mesh_lines() const {
 	Vector<Vector3> points = get_points();
 
 	if (points.size() > 3) {

--- a/scene/resources/convex_polygon_shape_3d.h
+++ b/scene/resources/convex_polygon_shape_3d.h
@@ -46,7 +46,7 @@ public:
 	void set_points(const Vector<Vector3> &p_points);
 	Vector<Vector3> get_points() const;
 
-	virtual Vector<Vector3> get_debug_mesh_lines() override;
+	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override;
 
 	ConvexPolygonShape3D();

--- a/scene/resources/cylinder_shape_3d.cpp
+++ b/scene/resources/cylinder_shape_3d.cpp
@@ -31,7 +31,7 @@
 #include "cylinder_shape_3d.h"
 #include "servers/physics_server_3d.h"
 
-Vector<Vector3> CylinderShape3D::get_debug_mesh_lines() {
+Vector<Vector3> CylinderShape3D::get_debug_mesh_lines() const {
 	float radius = get_radius();
 	float height = get_height();
 

--- a/scene/resources/cylinder_shape_3d.h
+++ b/scene/resources/cylinder_shape_3d.h
@@ -48,7 +48,7 @@ public:
 	void set_height(float p_height);
 	float get_height() const;
 
-	virtual Vector<Vector3> get_debug_mesh_lines() override;
+	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override;
 
 	CylinderShape3D();

--- a/scene/resources/height_map_shape_3d.cpp
+++ b/scene/resources/height_map_shape_3d.cpp
@@ -31,7 +31,7 @@
 #include "height_map_shape_3d.h"
 #include "servers/physics_server_3d.h"
 
-Vector<Vector3> HeightMapShape3D::get_debug_mesh_lines() {
+Vector<Vector3> HeightMapShape3D::get_debug_mesh_lines() const {
 	Vector<Vector3> points;
 
 	if ((map_width != 0) && (map_depth != 0)) {

--- a/scene/resources/height_map_shape_3d.h
+++ b/scene/resources/height_map_shape_3d.h
@@ -54,7 +54,7 @@ public:
 	void set_map_data(PackedFloat32Array p_new);
 	PackedFloat32Array get_map_data() const;
 
-	virtual Vector<Vector3> get_debug_mesh_lines() override;
+	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override;
 
 	HeightMapShape3D();

--- a/scene/resources/ray_shape_3d.cpp
+++ b/scene/resources/ray_shape_3d.cpp
@@ -32,7 +32,7 @@
 
 #include "servers/physics_server_3d.h"
 
-Vector<Vector3> RayShape3D::get_debug_mesh_lines() {
+Vector<Vector3> RayShape3D::get_debug_mesh_lines() const {
 	Vector<Vector3> points;
 	points.push_back(Vector3());
 	points.push_back(Vector3(0, 0, get_length()));

--- a/scene/resources/ray_shape_3d.h
+++ b/scene/resources/ray_shape_3d.h
@@ -48,7 +48,7 @@ public:
 	void set_slips_on_slope(bool p_active);
 	bool get_slips_on_slope() const;
 
-	virtual Vector<Vector3> get_debug_mesh_lines() override;
+	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override;
 
 	RayShape3D();

--- a/scene/resources/shape_3d.h
+++ b/scene/resources/shape_3d.h
@@ -56,7 +56,7 @@ public:
 	virtual RID get_rid() const override { return shape; }
 
 	Ref<ArrayMesh> get_debug_mesh();
-	virtual Vector<Vector3> get_debug_mesh_lines() = 0; // { return Vector<Vector3>(); }
+	virtual Vector<Vector3> get_debug_mesh_lines() const = 0; // { return Vector<Vector3>(); }
 	/// Returns the radius of a sphere that fully enclose this shape
 	virtual real_t get_enclosing_radius() const = 0;
 

--- a/scene/resources/sphere_shape_3d.cpp
+++ b/scene/resources/sphere_shape_3d.cpp
@@ -31,7 +31,7 @@
 #include "sphere_shape_3d.h"
 #include "servers/physics_server_3d.h"
 
-Vector<Vector3> SphereShape3D::get_debug_mesh_lines() {
+Vector<Vector3> SphereShape3D::get_debug_mesh_lines() const {
 	float r = get_radius();
 
 	Vector<Vector3> points;

--- a/scene/resources/sphere_shape_3d.h
+++ b/scene/resources/sphere_shape_3d.h
@@ -46,7 +46,7 @@ public:
 	void set_radius(float p_radius);
 	float get_radius() const;
 
-	virtual Vector<Vector3> get_debug_mesh_lines() override;
+	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override;
 
 	SphereShape3D();

--- a/scene/resources/world_margin_shape_3d.cpp
+++ b/scene/resources/world_margin_shape_3d.cpp
@@ -32,7 +32,7 @@
 
 #include "servers/physics_server_3d.h"
 
-Vector<Vector3> WorldMarginShape3D::get_debug_mesh_lines() {
+Vector<Vector3> WorldMarginShape3D::get_debug_mesh_lines() const {
 	Plane p = get_plane();
 	Vector<Vector3> points;
 

--- a/scene/resources/world_margin_shape_3d.h
+++ b/scene/resources/world_margin_shape_3d.h
@@ -45,7 +45,7 @@ public:
 	void set_plane(Plane p_plane);
 	Plane get_plane() const;
 
-	virtual Vector<Vector3> get_debug_mesh_lines() override;
+	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual real_t get_enclosing_radius() const override {
 		// Should be infinite?
 		return 0;


### PR DESCRIPTION
Adds keyword const to the get_debug_mesh_lines() methods, so it is possible to use constant references (ie. const Ref<Shape3D>) to retrieve and draw debug shapes in custom gizmos (written in C++) - no need for objects to expose writeable Shape3D for gizmos.