### PR TITLE
Enable Blend Splits in DirectionalLight3D by default

### DIFF
--- a/doc/classes/DirectionalLight3D.xml
+++ b/doc/classes/DirectionalLight3D.xml
@@ -12,8 +12,8 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="directional_shadow_blend_splits" type="bool" setter="set_blend_splits" getter="is_blend_splits_enabled" default="false">
-			If [code]true[/code], shadow detail is sacrificed in exchange for smoother transitions between splits.
+		<member name="directional_shadow_blend_splits" type="bool" setter="set_blend_splits" getter="is_blend_splits_enabled" default="true">
+			If [code]true[/code], shadow detail is sacrificed in exchange for smoother transitions between splits. This property has a moderate impact on performance. Consider disabling it when targeting low-end GPUs.
 		</member>
 		<member name="directional_shadow_depth_range" type="int" setter="set_shadow_depth_range" getter="get_shadow_depth_range" enum="DirectionalLight3D.ShadowDepthRange" default="0">
 			Optimizes shadow rendering for detail versus movement. See [enum ShadowDepthRange].

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -429,7 +429,7 @@ DirectionalLight3D::DirectionalLight3D() :
 	set_param(PARAM_SHADOW_BIAS, 0.05);
 	set_shadow_mode(SHADOW_PARALLEL_4_SPLITS);
 	set_shadow_depth_range(SHADOW_DEPTH_RANGE_STABLE);
-	blend_splits = false;
+	set_blend_splits(true);
 }
 
 void OmniLight3D::set_shadow_mode(ShadowMode p_mode) {


### PR DESCRIPTION
People occasionally wonder why sharp transitions between splits can be seen in DirectionalLight3D.

It's generally expected that modern renderers hide those sharp transitions by default, so let's do it.