### PR TITLE
Always disable low-processor usage mode on mobile platforms

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -227,7 +227,8 @@
 			Forces a delay between frames in the main loop (in milliseconds). This may be useful if you plan to disable vertical synchronization.
 		</member>
 		<member name="application/run/low_processor_mode" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], enables low-processor usage mode. This setting only works on desktop platforms. The screen is not redrawn if nothing changes visually. This is meant for writing applications and editors, but is pretty useless (and can hurt performance) in most games.
+			If [code]true[/code], enables low-processor usage mode. The screen is not redrawn if nothing changes visually. This is meant for writing applications and editors, but is pretty useless (and can hurt performance) in most games.
+			[b]Note:[/b] This option won't have any effect on Android and iOS as it's not implemented yet on those platforms.
 		</member>
 		<member name="application/run/low_processor_mode_sleep_usec" type="int" setter="" getter="" default="6900">
 			Amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU usage.

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -282,6 +282,16 @@ void OS_Android::vibrate_handheld(int p_duration_ms) {
 	godot_java->vibrate(p_duration_ms);
 }
 
+void OS_Android::set_low_processor_usage_mode(bool p_enabled) {
+	if (p_enabled) {
+		WARN_PRINT("Low-processor usage mode is not supported on Android and iOS.");
+	}
+}
+
+bool OS_Android::is_in_low_processor_usage_mode() const {
+	return false;
+}
+
 bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 	if (p_feature == "mobile") {
 		return true;

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -120,6 +120,8 @@ public:
 	virtual String get_system_dir(SystemDir p_dir) const;
 
 	void vibrate_handheld(int p_duration_ms);
+	virtual void set_low_processor_usage_mode(bool p_enabled);
+	virtual bool is_in_low_processor_usage_mode() const;
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
 	OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_godot_io_java, bool p_use_apk_expansion);

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -125,6 +125,8 @@ public:
 	virtual String get_unique_id() const override;
 
 	virtual void vibrate_handheld(int p_duration_ms = 500) override;
+	virtual void set_low_processor_usage_mode(bool p_enabled);
+	virtual bool is_in_low_processor_usage_mode() const;
 
 	virtual bool _check_internal_feature_support(const String &p_feature) override;
 

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -326,6 +326,16 @@ void OSIPhone::vibrate_handheld(int p_duration_ms) {
 	AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
 }
 
+void OSIPhone::set_low_processor_usage_mode(bool p_enabled) {
+	if (p_enabled) {
+		WARN_PRINT("Low-processor usage mode is not supported on Android and iOS.");
+	}
+}
+
+bool OSIPhone::is_in_low_processor_usage_mode() const {
+	return false;
+}
+
 bool OSIPhone::_check_internal_feature_support(const String &p_feature) {
 	return p_feature == "mobile";
 }


### PR DESCRIPTION
This partially addresses https://github.com/godotengine/godot/issues/19304.

**Note:** It may be easier to cherry-pick this PR by copy-pasting the relevant parts rather than using `git cherry-pick`.