### PR TITLE
Reload Bullet space override modifier even when RigidBody is inactive.

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -897,8 +897,7 @@ void RigidBodyBullet::on_exit_area(AreaBullet *p_area) {
 }
 
 void RigidBodyBullet::reload_space_override_modificator() {
-	// Make sure that kinematic bodies have their total gravity calculated
-	if (!is_active() && PhysicsServer3D::BODY_MODE_KINEMATIC != mode) {
+	if (mode == PhysicsServer3D::BODY_MODE_STATIC) {
 		return;
 	}
 


### PR DESCRIPTION
Currently, changes made to a `RigidBody` that affect the gravity applied to the body are not applied if the `RigidBody` is inactive (sleeping) and are not applied when the body is activated either.

This PR ensures that the changes made to a `RigidBody` that affect the gravity applied to the body are applied even if the body is inactive.

Fixes: #40739
