### PR TITLE
[3.2] Reload Bullet space override modifier even when RigidBody is inactive.

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -906,8 +906,7 @@ void RigidBodyBullet::on_exit_area(AreaBullet *p_area) {
 }
 
 void RigidBodyBullet::reload_space_override_modificator() {
-	// Make sure that kinematic bodies have their total gravity calculated
-	if (!is_active() && PhysicsServer::BODY_MODE_KINEMATIC != mode)
+	if (mode == PhysicsServer::BODY_MODE_STATIC)
 		return;
 
 	Vector3 newGravity(0.0, 0.0, 0.0);


### PR DESCRIPTION
3.2 version of #40989.
