### PR TITLE
Fix crash when quickly closing editor

### DIFF
--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -163,6 +163,9 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 		}
 		r_texture = generated;
 
+		if (!EditorNode::get_singleton()->get_theme_base())
+			return;
+
 		int small_thumbnail_size = EditorNode::get_singleton()->get_theme_base()->get_theme_icon("Object", "EditorIcons")->get_width(); // Kind of a workaround to retrieve the default icon size
 		small_thumbnail_size *= EDSCALE;
 


### PR DESCRIPTION
Fixes  #37665

Not the best solution, because I think that still is very very small chance that one line after checking, another thread during cleanup when exiting editor, can remove parent of `gui_base` and `EditorNode::get_singleton()->get_theme_base()` can return null, but this never happened to me.

Added cherrypick because it would allow to use #40994 (crashed tests https://github.com/qarmin/godot/runs/940305766)