### PR TITLE
Modify the scene only when color changed

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2108,6 +2108,11 @@ EditorPropertyTransform::EditorPropertyTransform() {
 ////////////// COLOR PICKER //////////////////////
 
 void EditorPropertyColor::_color_changed(const Color &p_color) {
+	// Cancel the color change if the current color is identical to the new one.
+	if (get_edited_object()->get(get_edited_property()) == p_color) {
+		return;
+	}
+
 	emit_changed(get_edited_property(), p_color, "", true);
 }
 


### PR DESCRIPTION
Editor now changes a color in the inspector only when it is different
from the current one.

Solves fake unsaved changes in editor after using the ColorPicker.

Resolves: #40879