### PR TITLE
Improve Vector2.angle() description

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -43,7 +43,8 @@
 			<return type="float">
 			</return>
 			<description>
-				Returns this vector's angle with respect to the X axis, or [code](1, 0)[/code] vector, in radians.
+				Returns this vector's angle with respect to the positive X axis, or [code](1, 0)[/code] vector, in radians.
+				For example, [code]Vector2.RIGHT.angle()[/code] will return zero, [code]Vector2.DOWN.angle()[/code] will return [code]PI / 2[/code] (a quarter turn, or 90 degrees), and [code]Vector2(1, -1).angle()[/code] will return [code]-PI / 4[/code] (a negative eighth turn, or -45 degrees).
 				Equivalent to the result of [method @GDScript.atan2] when called with the vector's [member y] and [member x] as parameters: [code]atan2(y, x)[/code].
 			</description>
 		</method>


### PR DESCRIPTION
Closes #40956

Sooo, I thought that mentioning X-axis isn't completely correct, because the angle of `Vector2.LEFT` is `PI` (and it would be 0 if it was the angle from the horizontal axis, no?). Maybe I'm wrong though.

Also `Vector2.UP` and `Vector2.DOWN` both have the same angle, that's why the mention of positive result.