### PR TITLE
Updated cursor positioning description for File open()

### DIFF
--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -451,16 +451,16 @@
 	</members>
 	<constants>
 		<constant name="READ" value="1" enum="ModeFlags">
-			Opens the file for read operations.
+			Opens the file for read operations. The cursor is positioned at the beginning of the file.
 		</constant>
 		<constant name="WRITE" value="2" enum="ModeFlags">
-			Opens the file for write operations. Create it if the file does not exist and truncate if it exists.
+			Opens the file for write operations. The file is created if it does not exist, and truncated if it does.
 		</constant>
 		<constant name="READ_WRITE" value="3" enum="ModeFlags">
-			Opens the file for read and write operations. Does not truncate the file.
+			Opens the file for read and write operations. Does not truncate the file. The cursor is positioned at the beginning of the file.
 		</constant>
 		<constant name="WRITE_READ" value="7" enum="ModeFlags">
-			Opens the file for read and write operations. Create it if the file does not exist and truncate if it exists.
+			Opens the file for read and write operations. The file is created if it does not exist, and truncated if it does. The cursor is positioned at the beginning of the file.
 		</constant>
 		<constant name="COMPRESSION_FASTLZ" value="0" enum="CompressionMode">
 			Uses the [url=http://fastlz.org/]FastLZ[/url] compression method.


### PR DESCRIPTION
Added more details about the cursor offsets for the different ModeFlags when opening files with the `File` class.

There is also currently no 'append' mode when opening files. I'm not sure if that is a valuable thing to have, but 
if so, I can make a separate PR for it. Would probably need to edit the driver files for Windows and unix:
https://github.com/godotengine/godot/blob/9adf6d3441d4927bdbab7bcb03cfafe42249ba90/drivers/unix/file_access_unix.cpp#L86-L96
As well as a couple of other files.

Closes #40878
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
