### PR TITLE
Remap script path when registering class.

### DIFF
--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -33,6 +33,7 @@
 #include "core/core_string_names.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
+#include "core/io/resource_loader.h"
 #include "core/os/file_access.h"
 #include "core/project_settings.h"
 
@@ -163,7 +164,7 @@ void ScriptServer::init_languages() {
 
 			for (int i = 0; i < script_classes.size(); i++) {
 				Dictionary c = script_classes[i];
-				if (!c.has("class") || !c.has("language") || !c.has("path") || !FileAccess::exists(c["path"]) || !c.has("base")) {
+				if (!c.has("class") || !c.has("language") || !c.has("path") || !FileAccess::exists(ResourceLoader::path_remap(c["path"])) || !c.has("base")) {
 					continue;
 				}
 				add_global_class(c["class"], c["base"], c["language"], c["path"]);


### PR DESCRIPTION
Was causing `class_name`-defined scripts to not being loaded in exported games due to the remap from `*.gd` to `*.gdc`/`*.gde`.

**Note**: I could have used `ResourceLoader::exists` directly, but it seems to come with a more complex logic (thus slower).
But I'd like an opinion on this from someone more knowledgable on the topic (since e.g. ResourceLoader would allow us to specify the exptected type).  @vnen @Xrayez ?

Fixes #40991