### PR TITLE
Make sure that Image is not locked before creation

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1586,6 +1586,7 @@ void Image::create(int p_width, int p_height, bool p_use_mipmaps, Format p_forma
 	ERR_FAIL_COND_MSG(p_height <= 0, "Image height must be greater than 0.");
 	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH, "Image width cannot be greater than " + itos(MAX_WIDTH) + ".");
 	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT, "Image height cannot be greater than " + itos(MAX_HEIGHT) + ".");
+	ERR_FAIL_COND_MSG(write_lock.ptr(), "Cannot create image when it is locked.");
 
 	int mm = 0;
 	int size = _get_dst_image_size(p_width, p_height, p_format, mm, p_use_mipmaps ? -1 : 0);


### PR DESCRIPTION
This fixes #40888.

I added a simple check to prevent overwriting image memory when either the image is already locked or the resizing of the underlying buffer fails. 

Other functions in this class have already done this (e.g. resize()).

I think this is not relevant for the master branch, since lock() seems to have been removed entirely.