### PR TITLE
Fix tile placement preview for rotated, skewed or scaled TileMaps

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -886,17 +886,17 @@ void TileMapEditor::_draw_cell(Control *p_viewport, int p_cell, const Point2i &p
 		rect.position += tile_ofs;
 	}
 
-	rect.position = p_xform.xform(rect.position);
-	rect.size *= sc;
-
 	Color modulate = node->get_tileset()->tile_get_modulate(p_cell);
 	modulate.a = 0.5;
 
+	Transform2D old_transform = p_viewport->get_viewport_transform();
+	p_viewport->draw_set_transform_matrix(p_xform); // Take into account TileMap transformation when displaying cell
 	if (r.has_no_area()) {
 		p_viewport->draw_texture_rect(t, rect, false, modulate, p_transpose);
 	} else {
 		p_viewport->draw_texture_rect_region(t, rect, r, modulate, p_transpose);
 	}
+	p_viewport->draw_set_transform_matrix(old_transform);
 }
 
 void TileMapEditor::_draw_fill_preview(Control *p_viewport, int p_cell, const Point2i &p_point, bool p_flip_h, bool p_flip_v, bool p_transpose, const Point2i &p_autotile_coord, const Transform2D &p_xform) {


### PR DESCRIPTION
Ensures that the editor preview when placing a tile on a `TileMap` takes into account the transformation of the `TileMap`. 
Previously, only the origin of the Tile was transformed, but not its orientation or scaling.

Before:
![tilemappreview](https://user-images.githubusercontent.com/22248849/89364629-78d11c80-d705-11ea-8c28-68b12c7d1796.png)
After:
![tilemapprevew_new](https://user-images.githubusercontent.com/22248849/89364640-7a024980-d705-11ea-8f1d-2d8c84639a33.png)

Closes #40984

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
