### PR TITLE
Added GDScript annotations for export variable tooltips and groupings.

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -146,6 +146,9 @@ struct PropertyInfo {
 	String hint_string;
 	uint32_t usage = PROPERTY_USAGE_DEFAULT;
 
+	String custom_tooltip;
+	String export_path;
+
 	_FORCE_INLINE_ PropertyInfo added_usage(int p_fl) const {
 		PropertyInfo pi = *this;
 		pi.usage |= p_fl;

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1634,7 +1634,8 @@ void EditorInspector::update_tree() {
 			continue;
 		}
 
-		String basename = p.name;
+		// Append the export path with the name so that properties are correctly grouped.
+		String basename = p.export_path + p.name;
 
 		if (subgroup != "") {
 			if (subgroup_base != "") {
@@ -1870,6 +1871,8 @@ void EditorInspector::update_tree() {
 					ep->connect("object_id_selected", callable_mp(this, &EditorInspector::_object_id_selected), varray(), CONNECT_DEFERRED);
 					if (doc_hint != String()) {
 						ep->set_tooltip(property_prefix + p.name + "::" + doc_hint);
+					} else if (p.custom_tooltip != String()) {
+						ep->set_tooltip(property_prefix + p.name + "::" + p.custom_tooltip);
 					} else {
 						ep->set_tooltip(property_prefix + p.name);
 					}

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2674,6 +2674,8 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 					prop_info.hint = export_info.hint;
 					prop_info.hint_string = export_info.hint_string;
 					prop_info.usage = export_info.usage;
+					prop_info.custom_tooltip = export_info.custom_tooltip;
+					prop_info.export_path = export_info.export_path;
 #ifdef TOOLS_ENABLED
 					if (variable->initializer != nullptr && variable->initializer->type == GDScriptParser::Node::LITERAL) {
 						p_script->member_default_values[name] = static_cast<const GDScriptParser::LiteralNode *>(variable->initializer)->value;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1087,6 +1087,7 @@ private:
 	ClassNode *current_class = nullptr;
 	FunctionNode *current_function = nullptr;
 	SuiteNode *current_suite = nullptr;
+	String current_group;
 
 	CompletionContext completion_context;
 	CompletionCall completion_call;
@@ -1215,6 +1216,8 @@ private:
 	bool warning_annotations(const AnnotationNode *p_annotation, Node *p_target);
 	template <MultiplayerAPI::RPCMode t_mode>
 	bool network_annotations(const AnnotationNode *p_annotation, Node *p_target);
+	bool tooltip_annotation(const AnnotationNode *p_annotation, Node *p_target);
+	bool group_annotation(const AnnotationNode *p_annotation, Node *p_target);
 	// Statements.
 	Node *parse_statement();
 	VariableNode *parse_variable();


### PR DESCRIPTION
Added some extra annotations for some features I have wanted for a long time!

`@group("my_group")`
`@group("my_group/my_sub_group")`

`@tooltip("An explanation of the variable.")`

Basically works the same as `HeaderAttribute` and `TooltipAttribute` in Unity, so as a result should be reasonably easy to implement in C# - haven't looked though.

![sKYrOsFZuE](https://user-images.githubusercontent.com/41730826/89365685-7fb55a80-d718-11ea-9433-940ad86ac757.gif)

![godot windows tools 64_uypvilWPiS](https://user-images.githubusercontent.com/41730826/89365705-88a62c00-d718-11ea-86ba-e5abe7813b2d.png)

This basically does the same thing as #40669 except it is with annotations (and as a result requires much less code). However since this relies on annotations, this is for 4.0 only and not 3.2.

Closes https://github.com/godotengine/godot-proposals/issues/1255#issue-665353468 and maybe others.
 