### PR TITLE
Make default main screen plugin work even if 2D and 3D are disabled in editor features

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -524,6 +524,26 @@ void EditorNode::_update_from_settings() {
 	RS::get_singleton()->light_projectors_set_filter(RS::LightProjectorFilter(int(GLOBAL_GET("rendering/textures/light_projectors/filter"))));
 }
 
+void EditorNode::_select_default_main_screen_plugin() {
+	if (EDITOR_3D < main_editor_buttons.size() && main_editor_buttons[EDITOR_3D]->is_visible()) {
+		// If the 3D editor is enabled, use this as the default.
+		_editor_select(EDITOR_3D);
+		return;
+	}
+
+	// Switch to the first main screen plugin that is enabled. Usually this is
+	// 2D, but may be subsequent ones if 2D is disabled in the feature profile.
+	for (int i = 0; i < main_editor_buttons.size(); i++) {
+		Button *editor_button = main_editor_buttons[i];
+		if (editor_button->is_visible()) {
+			_editor_select(i);
+			return;
+		}
+	}
+
+	_editor_select(-1);
+}
+
 void EditorNode::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_PROCESS: {
@@ -613,11 +633,7 @@ void EditorNode::_notification(int p_what) {
 
 			feature_profile_manager->notify_changed();
 
-			if (!main_editor_buttons[EDITOR_3D]->is_visible()) { //may be hidden due to feature profile
-				_editor_select(EDITOR_2D);
-			} else {
-				_editor_select(EDITOR_3D);
-			}
+			_select_default_main_screen_plugin();
 
 			// Save the project after opening to mark it as last modified, except in headless mode.
 			if (DisplayServer::get_singleton()->window_can_draw()) {
@@ -3106,9 +3122,10 @@ void EditorNode::add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed
 		tb->set_flat(true);
 		tb->set_toggle_mode(true);
 		tb->connect("pressed", callable_mp(singleton, &EditorNode::_editor_select), varray(singleton->main_editor_buttons.size()));
+		tb->set_name(p_editor->get_name());
 		tb->set_text(p_editor->get_name());
-		Ref<Texture2D> icon = p_editor->get_icon();
 
+		Ref<Texture2D> icon = p_editor->get_icon();
 		if (icon.is_valid()) {
 			tb->set_icon(icon);
 		} else if (singleton->gui_base->has_theme_icon(p_editor->get_name(), "EditorIcons")) {
@@ -3118,7 +3135,6 @@ void EditorNode::add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed
 		tb->add_theme_font_override("font", singleton->gui_base->get_theme_font(SNAME("main_button_font"), SNAME("EditorFonts")));
 		tb->add_theme_font_size_override("font_size", singleton->gui_base->get_theme_font_size(SNAME("main_button_font_size"), SNAME("EditorFonts")));
 
-		tb->set_name(p_editor->get_name());
 		singleton->main_editor_buttons.push_back(tb);
 		singleton->main_editor_button_vb->add_child(tb);
 		singleton->editor_table.push_back(p_editor);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -681,6 +681,8 @@ private:
 	bool immediate_dialog_confirmed = false;
 	void _immediate_dialog_confirmed();
 
+	void _select_default_main_screen_plugin();
+
 protected:
 	void _notification(int p_what);
 


### PR DESCRIPTION
Note that 2D can not yet be disabled in editor features. This is a precursor to #41038

<details>

~~This was based on a request [here](https://github.com/godotengine/godot/issues/2207#issuecomment-117028091) by @itsraineing:~~

~~> I would recommend that either the default (eg when creating a new scene) be changed to 2D, or the 3D tab moved to be the first; it's always stricken me as a bit odd that the editor defaults to the second tab.~~

~~This PR changes the default main screen plugin to the first one that is enabled. Typically, 2D~~

~~Before:~~
![image](https://user-images.githubusercontent.com/14253836/89368362-f878d000-d6a0-11ea-9a2b-65decdf14caa.png)
~~After:~~
![image](https://user-images.githubusercontent.com/14253836/89368366-fb73c080-d6a0-11ea-9743-25e80f7b1c50.png)

~~*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/1352~~