### PR TITLE
Implement CollisionShape3D.make_convex_from_siblings()

### DIFF
--- a/doc/classes/CollisionShape3D.xml
+++ b/doc/classes/CollisionShape3D.xml
@@ -10,7 +10,7 @@
 		<link>https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<methods>
-		<method name="make_convex_from_brothers">
+		<method name="make_convex_from_siblings">
 			<return type="void">
 			</return>
 			<description>

--- a/scene/3d/collision_shape_3d.h
+++ b/scene/3d/collision_shape_3d.h
@@ -60,7 +60,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void make_convex_from_brothers();
+	void make_convex_from_siblings();
 
 	void set_shape(const Ref<Shape3D> &p_shape);
 	Ref<Shape3D> get_shape() const;


### PR DESCRIPTION
Renames `make_convex_from_brothers` to `make_convex_from_siblings` as per https://github.com/godotengine/godot/issues/16863#issuecomment-493794313.
Fixes godotengine#3383.