### PR TITLE
Mention caveats for `popup_exclusive` in the WindowDialog documentation

### DIFF
--- a/doc/classes/Popup.xml
+++ b/doc/classes/Popup.xml
@@ -67,6 +67,7 @@
 	<members>
 		<member name="popup_exclusive" type="bool" setter="set_exclusive" getter="is_exclusive" default="false">
 			If [code]true[/code], the popup will not be hidden when a click event occurs outside of it, or when it receives the [code]ui_cancel[/code] action event.
+			[b]Note:[/b] Enabling this property doesn't affect the Close or Cancel buttons' behavior in dialogs that inherit from this class. As a workaround, you can use [method WindowDialog.get_close_button] or [method ConfirmationDialog.get_cancel] and hide the buttons in question by setting their [member CanvasItem.visible] property to [code]false[/code].
 		</member>
 		<member name="visible" type="bool" setter="set_visible" getter="is_visible" override="true" default="false" />
 	</members>


### PR DESCRIPTION
Thanks to @98teg for providing this documentation :slightly_smiling_face:

This closes #41045.

**Note:** Opened against the `3.2` branch as the exclusive property exists in a different form in the `master` branch (due to DisplayServer).