### PR TITLE
Shaded wireframes.

### DIFF
--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -1802,8 +1802,19 @@ void RasterizerSceneHighEndRD::_render_scene(RID p_render_buffer, const Transfor
 		}
 
 		RID framebuffer = using_separate_specular ? opaque_specular_framebuffer : opaque_framebuffer;
+
 		RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(framebuffer, keep_color ? RD::INITIAL_ACTION_KEEP : RD::INITIAL_ACTION_CLEAR, will_continue_color ? RD::FINAL_ACTION_CONTINUE : RD::FINAL_ACTION_READ, depth_pre_pass ? (continue_depth ? RD::INITIAL_ACTION_KEEP : RD::INITIAL_ACTION_CONTINUE) : RD::INITIAL_ACTION_CLEAR, will_continue_depth ? RD::FINAL_ACTION_CONTINUE : RD::FINAL_ACTION_READ, c, 1.0, 0);
 		_render_list(draw_list, RD::get_singleton()->framebuffer_get_format(framebuffer), render_list.elements, render_list.element_count, false, using_separate_specular ? PASS_MODE_COLOR_SPECULAR : PASS_MODE_COLOR, render_buffer == nullptr, radiance_uniform_set, render_buffers_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME);
+		RD::get_singleton()->draw_list_end();
+
+		if (p_render_buffer.is_valid()) {
+			//update the render buffers uniform set in case it changed
+			_update_render_buffers_uniform_set(p_render_buffer);
+			render_buffers_uniform_set = render_buffer->uniform_set;
+		}
+
+		RD::DrawListID draw_list_render = RD::get_singleton()->draw_list_begin(framebuffer, keep_color ? RD::INITIAL_ACTION_KEEP : RD::INITIAL_ACTION_CLEAR, will_continue_color ? RD::FINAL_ACTION_CONTINUE : RD::FINAL_ACTION_READ, depth_pre_pass ? (continue_depth ? RD::INITIAL_ACTION_KEEP : RD::INITIAL_ACTION_CONTINUE) : RD::INITIAL_ACTION_CLEAR, will_continue_depth ? RD::FINAL_ACTION_CONTINUE : RD::FINAL_ACTION_READ, c, 1.0, 0);
+		_render_list(draw_list_render, RD::get_singleton()->framebuffer_get_format(framebuffer), render_list.elements, render_list.element_count, false, using_separate_specular ? PASS_MODE_COLOR_SPECULAR : PASS_MODE_COLOR, render_buffer == nullptr, radiance_uniform_set, render_buffers_uniform_set, true);
 		RD::get_singleton()->draw_list_end();
 
 		if (will_continue_color && using_separate_specular) {


### PR DESCRIPTION
Fixes  https://github.com/godotengine/godot-proposals/issues/1000

- [ ] Make a view menu option.
- [ ] Fix rendering flickering problem
- [ ] Grow the wireframe

This renders twice.

HELP! Need to understand why it's flickering.

Alternative implementation is using geometry? compute? shaders and https://github.com/XRTK/XRTK-Core/blob/8bd7559136374f6d6ae804d9e311a4d60ae0ae6c/XRTK-Core/Packages/com.xrtk.core/Runtime/StandardAssets/Shaders/XRTK_Wireframe.shader