### PR TITLE
Make the SpriteFrames animation speed SpinBox take less vertical space

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -892,11 +892,16 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	animations->connect("item_edited", callable_mp(this, &SpriteFramesEditor::_animation_name_edited));
 	animations->set_allow_reselect(true);
 
+	HBoxContainer *hbc_anim_speed = memnew(HBoxContainer);
+	hbc_anim_speed->add_child(memnew(Label(TTR("Speed:"))));
+	vbc_animlist->add_child(hbc_anim_speed);
 	anim_speed = memnew(SpinBox);
-	vbc_animlist->add_margin_child(TTR("Speed (FPS):"), anim_speed);
+	anim_speed->set_suffix(TTR("FPS"));
 	anim_speed->set_min(0);
 	anim_speed->set_max(100);
 	anim_speed->set_step(0.01);
+	anim_speed->set_h_size_flags(SIZE_EXPAND_FILL);
+	hbc_anim_speed->add_child(anim_speed);
 	anim_speed->connect("value_changed", callable_mp(this, &SpriteFramesEditor::_animation_fps_changed));
 
 	anim_loop = memnew(CheckButton);


### PR DESCRIPTION
This makes it possible to display one more animation with the same vertical space.

## Preview

### Before

![SpriteFrames editor](https://user-images.githubusercontent.com/180032/89431995-e51d4180-d740-11ea-9c6d-46c87671f832.png)

### After

![SpriteFrames editor](https://user-images.githubusercontent.com/180032/89432000-e64e6e80-d740-11ea-8c2a-83b901602988.png)