### PR TITLE
Fix crash with null callee

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1259,8 +1259,10 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 					GDScriptParser::CompletionContext c = p_context;
 					c.current_line = call->start_line;
 
+					GDScriptParser::Node::Type callee_type = call->get_callee_type();
+
 					GDScriptCompletionIdentifier base;
-					if (call->callee->type == GDScriptParser::Node::IDENTIFIER || call->is_super) {
+					if (callee_type == GDScriptParser::Node::IDENTIFIER || call->is_super) {
 						// Simple call, so base is 'self'.
 						if (p_context.current_class) {
 							base.type.kind = GDScriptParser::DataType::CLASS;
@@ -1271,7 +1273,7 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 						} else {
 							break;
 						}
-					} else if (call->callee->type == GDScriptParser::Node::SUBSCRIPT && static_cast<const GDScriptParser::SubscriptNode *>(call->callee)->is_attribute) {
+					} else if (callee_type == GDScriptParser::Node::SUBSCRIPT && static_cast<const GDScriptParser::SubscriptNode *>(call->callee)->is_attribute) {
 						if (!_guess_expression_type(c, static_cast<const GDScriptParser::SubscriptNode *>(call->callee)->base, base)) {
 							found = false;
 							break;
@@ -2290,6 +2292,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	GDScriptParser::DataType base_type;
 	bool _static = false;
 	const GDScriptParser::CallNode *call = static_cast<const GDScriptParser::CallNode *>(p_call);
+	GDScriptParser::Node::Type callee_type = GDScriptParser::Node::NONE;
 
 	GDScriptCompletionIdentifier connect_base;
 
@@ -2319,14 +2322,14 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			i++;
 		}
 		return;
-	} else if (call->is_super || call->callee->type == GDScriptParser::Node::IDENTIFIER) {
+	} else if (call->is_super || callee_type == GDScriptParser::Node::IDENTIFIER) {
 		base = p_context.base;
 
 		if (p_context.current_class) {
 			base_type = p_context.current_class->get_datatype();
 			_static = !p_context.current_function || p_context.current_function->is_static;
 		}
-	} else if (call->callee->type == GDScriptParser::Node::SUBSCRIPT) {
+	} else if (callee_type == GDScriptParser::Node::SUBSCRIPT) {
 		const GDScriptParser::SubscriptNode *subscript = static_cast<const GDScriptParser::SubscriptNode *>(call->callee);
 
 		if (subscript->is_attribute) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2328,7 +2328,11 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 GDScriptParser::ExpressionNode *GDScriptParser::parse_grouping(ExpressionNode *p_previous_operand, bool p_can_assign) {
 	ExpressionNode *grouped = parse_expression(false);
 	pop_multiline();
-	consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected closing ")" after grouping expression.)*");
+	if (grouped == nullptr) {
+		push_error(R"(Expected grouping expression.)");
+	} else {
+		consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected closing ")" after grouping expression.)*");
+	}
 	return grouped;
 }
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2419,7 +2419,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_call(ExpressionNode *p_pre
 	} else {
 		call->callee = p_previous_operand;
 
-		if (call->callee->type == Node::IDENTIFIER) {
+		if (call->callee == nullptr) {
+			push_error(R"*(Cannot call on an expression. Use ".call()" if it's a Callable.)*");
+		} else if (call->callee->type == Node::IDENTIFIER) {
 			call->function_name = static_cast<IdentifierNode *>(call->callee)->name;
 			make_completion_context(COMPLETION_METHOD, call->callee);
 		} else if (call->callee->type == Node::SUBSCRIPT) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -383,6 +383,14 @@ public:
 		CallNode() {
 			type = CALL;
 		}
+
+		Type get_callee_type() const {
+			if (callee == nullptr) {
+				return Type::NONE;
+			} else {
+				return callee->type;
+			}
+		}
 	};
 
 	struct CastNode : public ExpressionNode {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
### Issue
This PR fixes https://github.com/godotengine/godot/issues/40942.  It's also related to https://github.com/godotengine/godot/pull/40943.

### Summary
Malformed call expressions that create `GDScript::CallNode` instances with `callee == nullptr` are possible.  An example of such a malformed expression is `var crash = ()(1)`.  When these cases happen during editing, the editor crashes.

The PR fixes the bug by:
1.  Adding an accessor `GDScript::CallNode::get_callee_type` which checks for `nullptr` and returns `Type::NONE` in that case.
1.  Refactoring the code, where sensible, to use the new accessor.

Additionally, this PR adds a more descriptive error message when empty grouping expressions are encountered.