### PR TITLE
[WIP] Naive implementation of nullable type hints for the purpose of discussion

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -331,9 +331,7 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 		return result;
 	}
 
-	if (p_type->nullable) {
-		result.is_nullable = true;
-	}
+	result.is_nullable = p_type->nullable;
 
 	StringName first = p_type->type_chain[0]->name;
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -331,6 +331,10 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 		return result;
 	}
 
+	if (p_type->nullable) {
+		result.is_nullable = true;
+	}
+
 	StringName first = p_type->type_chain[0]->name;
 
 	if (first == "Variant") {
@@ -2927,6 +2931,11 @@ bool GDScriptAnalyzer::is_type_compatible(const GDScriptParser::DataType &p_targ
 
 	if (p_source.kind == GDScriptParser::DataType::VARIANT) {
 		// TODO: This is acceptable but unsafe. Make sure unsafe line is set.
+		return true;
+	}
+
+	if (p_source.is_nullable && p_target.kind == GDScriptParser::DataType::BUILTIN && p_target.builtin_type == Variant::NIL) {
+		// Allow null on a parameter that is marked nullable.
 		return true;
 	}
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -121,6 +121,7 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 
 	GDScriptDataType result;
 	result.has_type = true;
+	result.is_nullable = p_datatype.is_nullable;
 
 	switch (p_datatype.kind) {
 		case GDScriptParser::DataType::VARIANT: {

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -54,6 +54,7 @@ struct GDScriptDataType {
 	Kind kind = UNINITIALIZED;
 
 	bool has_type = false;
+	bool is_nullable = false;
 	Variant::Type builtin_type = Variant::NIL;
 	StringName native_type;
 	Ref<Script> script_type;
@@ -61,6 +62,11 @@ struct GDScriptDataType {
 	bool is_type(const Variant &p_variant, bool p_allow_implicit_conversion = false) const {
 		if (!has_type) {
 			return true; // Can't type check
+		}
+
+		if (is_nullable && p_variant.get_type() == Variant::NIL) {
+			// Nullable types will always accept null.
+			return true;
 		}
 
 		switch (kind) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2584,6 +2584,10 @@ GDScriptParser::TypeNode *GDScriptParser::parse_type(bool p_allow_void) {
 			type->type_chain.push_back(type_element);
 		}
 	}
+	
+	if (match(GDScriptTokenizer::Token::QUESTION_MARK)) {
+		type->nullable = true;
+	}
 
 	return type;
 }
@@ -3706,6 +3710,9 @@ void GDScriptParser::TreePrinter::print_type(TypeNode *p_type) {
 				push_text(".");
 			}
 			print_identifier(p_type->type_chain[i]);
+		}
+		if (p_type->nullable) {
+			push_text("?");
 		}
 	}
 }

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2584,7 +2584,7 @@ GDScriptParser::TypeNode *GDScriptParser::parse_type(bool p_allow_void) {
 			type->type_chain.push_back(type_element);
 		}
 	}
-	
+
 	if (match(GDScriptTokenizer::Token::QUESTION_MARK)) {
 		type->nullable = true;
 	}

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -120,6 +120,7 @@ public:
 		bool is_constant = false;
 		bool is_meta_type = false;
 		bool is_coroutine = false; // For function calls.
+		bool is_nullable = false;
 
 		Variant::Type builtin_type = Variant::NIL;
 		StringName native_type;
@@ -948,6 +949,7 @@ public:
 
 	struct TypeNode : public Node {
 		Vector<IdentifierNode *> type_chain;
+		bool nullable = false;
 
 		TypeNode() {
 			type = TYPE;


### PR DESCRIPTION
This is a quick, naive implementation of nullable type hints for the purpose of discussion on this proposal:

https://github.com/godotengine/godot-proposals/issues/162

It mainly exists for @reduz and @vnen to explain why this is a bad way to do it. :-)

I'm testing this with a simple GDScript attached to a Node2D:

```
extends Node2D
  
func _ready() -> void:
    print("hi")
    abc(Vector2(1, 2))
    abc(null)

func abc(a : Vector2?) -> void:
    print("here's my vector: " + str(a))
```

The output when run on Godot with this PR is:

```
hi
here's my vector: (1, 2)
here's my vector: Null
```

Without this PR (ie. just on master), you'll get a parse errror: `Expected closing ")" after function parameters.`