### PR TITLE
Update Sprite3D docs to reflect recent changes

### DIFF
--- a/doc/classes/Sprite3D.xml
+++ b/doc/classes/Sprite3D.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		A node that displays a 2D texture in a 3D environment. The texture displayed can be a region from a larger atlas texture, or a frame from a sprite sheet animation.
-		[b]Note:[/b] There are [url=https://github.com/godotengine/godot/issues/20855]known performance issues[/url] when using [Sprite3D]. Consider using a [MeshInstance] with a [QuadMesh] as the mesh instead. You can still have billboarding by enabling billboard properties in the QuadMesh's [SpatialMaterial].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -28,7 +27,7 @@
 			The region of the atlas texture to display. [member region_enabled] must be [code]true[/code].
 		</member>
 		<member name="texture" type="Texture" setter="set_texture" getter="get_texture">
-			[Texture] object to draw.
+			[Texture] object to draw. If [member GeometryInstance.material_override] is used, this will be overridden.
 		</member>
 		<member name="vframes" type="int" setter="set_vframes" getter="get_vframes" default="1">
 			The number of rows in the sprite sheet.


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/33234

Update docs to reflect changes from #39867

Importantly, the behaviour of ``material_override`` has changed slightly. ImmediateGeometry overrides the override. Since we are using the mesh API, this is no longer possible and ``material_override`` now overrides the texture that is set. So if a user uses the ``material_override`` they need to set the texture in the ``albedo_texture`` slot.