### PR TITLE
Add option `modules_enabled_by_default` for shorthand disabling modules

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -137,6 +137,7 @@ opts.Add("extra_suffix", "Custom extra suffix added to the base filename of all 
 opts.Add(BoolVariable("vsproj", "Generate a Visual Studio solution", False))
 opts.Add(BoolVariable("disable_3d", "Disable 3D nodes for a smaller executable", False))
 opts.Add(BoolVariable("disable_advanced_gui", "Disable advanced GUI nodes and behaviors", False))
+opts.Add(BoolVariable("modules_enabled_by_default", "If no, disable all modules except ones explicitly enabled", True))
 opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", False))
 opts.Add("system_certs_path", "Use this path as SSL certificates default for editor (for package maintainers)", "")
 opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise epsilon (debug option)", False))
@@ -259,16 +260,21 @@ for path in module_search_paths:
 
 # Add module options.
 for name, path in modules_detected.items():
-    enabled = True
-    sys.path.insert(0, path)
-    import config
+    if env_base["modules_enabled_by_default"]:
+        enabled = True
 
-    try:
-        enabled = config.is_enabled()
-    except AttributeError:
-        pass
-    sys.path.remove(path)
-    sys.modules.pop("config")
+        sys.path.insert(0, path)
+        import config
+
+        try:
+            enabled = config.is_enabled()
+        except AttributeError:
+            pass
+        sys.path.remove(path)
+        sys.modules.pop("config")
+    else:
+        enabled = False
+
     opts.Add(BoolVariable("module_" + name + "_enabled", "Enable module '%s'" % (name,), enabled))
 
 methods.write_modules(modules_detected)

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -375,8 +375,8 @@ void Main::print_help(const char *p_binary) {
 #ifdef TESTS_ENABLED
 	OS::get_singleton()->print("  --test [--help]                              Run unit tests. Use --test --help for more information.\n");
 #endif
-	OS::get_singleton()->print("\n");
 #endif
+	OS::get_singleton()->print("\n");
 }
 
 #ifdef TESTS_ENABLED


### PR DESCRIPTION
Godot has frankly a lot of modules, only complicated further when adding custom modules, so disabling each of them by hand can get rather cumbersome. This PR adds in a shorthand form for disabling all modules, including overriding their default settings (such as `mono`'s default disabled). It's intended to be an advanced, experimental debug option.

~~Side note: I had to add in some ifdefs in cpp files because those files did not compile correctly with the new option.~~

---

For example, if I wanted to test out `bullet` exclusively without compiling others because I (e.g.) modified something in `bullet`, I would have to do:

```
scons -j6 tools=no module_bullet_enabled=yes module_arkit_enabled=no module_assimp_enabled=no module_basis_universal_enabled=no module_bmp_enabled=no  module_camera_enabled=no module_csg_enabled=no module_cvtt_enabled=no module_dds_enabled=no module_denoise_enabled=no module_enet_enabled=no module_etc_enabled=no module_freetype_enabled=no module_gdnative_enabled=no module_gdnavigation_enabled=no module_gdscript_enabled=no module_glslang_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_jpg_enabled=no module_jsonrpc_enabled=no module_lightmapper_rd_enabled=no module_mbedtls_enabled=no module_mobile_vr_enabled=no module_ogg_enabled=no module_opensimplex_enabled=no module_opus_enabled=no module_pvr_enabled=no module_regex_enabled=no module_squish_enabled=no module_stb_vorbis_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_visual_script_enabled=no module_vorbis_enabled=no module_webm_enabled=no module_webp_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_xatlas_unwrap_enabled=no 
```

This obviously gets even more complicated if I wanted to (e.g.) add in my custom module, enable it with `bullet`, and test it against that. In any case, the previous line with my new options becomes:

```
scons -j6 tools=no modules_enabled_by_default=no module_bullet_enabled=yes
```

Note: updated with `module_bullet_enabled=yes` instead of `except_modules=bullet` and `modules_enabled_by_default=yes` instead of `disable_all_modules=yes` and `dev` option.

~~Note that I added in `dev` as well, because one of the primary ways to effectively see if Godot works as is is to actually run the tests. Of course, in order to have the full effect of this PR to be realized, #40659 should be completed as well.~~