### PR TITLE
Correctly flush dirty bodies - physics.

### DIFF
--- a/modules/bullet/collision_object_bullet.h
+++ b/modules/bullet/collision_object_bullet.h
@@ -139,6 +139,7 @@ protected:
 public:
 	bool is_in_world = false;
 	bool is_in_flush_queue = false;
+	bool is_in_dirty_queue = false;
 
 public:
 	CollisionObjectBullet(Type p_type);
@@ -171,20 +172,10 @@ public:
 	bool has_collision_exception(const CollisionObjectBullet *p_otherCollisionObject) const;
 	_FORCE_INLINE_ const VSet<RID> &get_exceptions() const { return exceptions; }
 
-	_FORCE_INLINE_ void set_collision_layer(uint32_t p_layer) {
-		if (collisionLayer != p_layer) {
-			collisionLayer = p_layer;
-			needs_collision_filters_reload = true;
-		}
-	}
+	void set_collision_layer(uint32_t p_layer);
 	_FORCE_INLINE_ uint32_t get_collision_layer() const { return collisionLayer; }
 
-	_FORCE_INLINE_ void set_collision_mask(uint32_t p_mask) {
-		if (collisionMask != p_mask) {
-			collisionMask = p_mask;
-			needs_collision_filters_reload = true;
-		}
-	}
+	void set_collision_mask(uint32_t p_mask);
 	_FORCE_INLINE_ uint32_t get_collision_mask() const { return collisionMask; }
 
 	virtual void do_reload_collision_filters() = 0;
@@ -207,6 +198,7 @@ public:
 	virtual void on_collision_checker_end() = 0;
 
 	virtual void dispatch_callbacks();
+	virtual void flush_dirty();
 	virtual void pre_process();
 
 	void set_collision_enabled(bool p_enabled);
@@ -264,7 +256,7 @@ public:
 	void set_shape_disabled(int p_index, bool p_disabled);
 	bool is_shape_disabled(int p_index);
 
-	virtual void pre_process() override;
+	virtual void flush_dirty() override;
 
 	virtual void shape_changed(int p_shape_index) override;
 	virtual void reload_shapes() override;

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -334,6 +334,7 @@ void RigidBodyBullet::set_space(SpaceBullet *p_space) {
 		space->register_collision_object(this);
 		reload_body();
 		space->add_to_flush_queue(this);
+		space->add_to_dirty_queue(this);
 	}
 }
 
@@ -362,14 +363,16 @@ void RigidBodyBullet::dispatch_callbacks() {
 	previousActiveState = btBody->isActive();
 }
 
-void RigidBodyBullet::pre_process() {
-	RigidCollisionObjectBullet::pre_process();
+void RigidBodyBullet::flush_dirty() {
+	RigidCollisionObjectBullet::flush_dirty();
 
 	if (isScratchedSpaceOverrideModificator || 0 < countGravityPointSpaces) {
 		isScratchedSpaceOverrideModificator = false;
 		reload_space_override_modificator();
 	}
+}
 
+void RigidBodyBullet::pre_process() {
 	if (is_active()) {
 		/// Lock axis
 		btBody->setLinearVelocity(btBody->getLinearVelocity() * btBody->getLinearFactor());
@@ -393,6 +396,9 @@ void RigidBodyBullet::set_force_integration_callback(ObjectID p_id, const String
 
 void RigidBodyBullet::scratch_space_override_modificator() {
 	isScratchedSpaceOverrideModificator = true;
+	if (likely(space)) {
+		space->add_to_dirty_queue(this);
+	}
 }
 
 void RigidBodyBullet::do_reload_collision_filters() {

--- a/modules/bullet/rigid_body_bullet.h
+++ b/modules/bullet/rigid_body_bullet.h
@@ -241,6 +241,7 @@ public:
 	virtual void set_space(SpaceBullet *p_space) override;
 
 	virtual void dispatch_callbacks() override;
+	virtual void flush_dirty() override;
 	virtual void pre_process() override;
 	void set_force_integration_callback(ObjectID p_id, const StringName &p_method, const Variant &p_udata = Variant());
 	void scratch_space_override_modificator();

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -112,6 +112,7 @@ class SpaceBullet : public RIDBullet {
 
 	LocalVector<CollisionObjectBullet *> queue_pre_flush;
 	LocalVector<CollisionObjectBullet *> queue_flush;
+	LocalVector<CollisionObjectBullet *> queue_dirty;
 	LocalVector<CollisionObjectBullet *> collision_objects;
 	LocalVector<AreaBullet *> areas;
 
@@ -125,9 +126,11 @@ public:
 
 	void add_to_flush_queue(CollisionObjectBullet *p_co);
 	void add_to_pre_flush_queue(CollisionObjectBullet *p_co);
+	void add_to_dirty_queue(CollisionObjectBullet *p_co);
 	void remove_from_any_queue(CollisionObjectBullet *p_co);
 
 	void flush_queries();
+	void flush_dirty();
 	real_t get_delta_time() { return delta_time; }
 	void step(real_t p_delta_time);
 


### PR DESCRIPTION
The lazy changes, implemented by this PR: #39726, was not flushing the dirty bodies when needed - causing different crashes.
This PR make sure to flush the dirty bodies, when is necessary do so, and not just during the physics step.

Note, the perf of this PR is not changed and is in line with the one measured here: https://github.com/godotengine/godot/pull/41082#issuecomment-670382832
```
Test start
Added: 0
Added: 50
Added: 100
Added: 150
Added: 200
Added: 250
Added: 300
Added: 350
Added: 400
Added: 450
Added: 500
Added: 550
Added: 600
Added: 650
Added: 700
Added: 750
Added: 800
Added: 850
Added: 900
Added: 950
Added: 1000
Added: 1050
Added: 1100
Added: 1150
Added: 1200
Added: 1250
Added: 1300
Added: 1350
Added: 1400
Added: 1450
Added: 1500
Added: 1550
Added: 1600
Added: 1650
Added: 1700
Added: 1750
Added: 1800
Added: 1850
Added: 1900
Added: 1950
Frame 1: 33ms
Frame 2: 9146ms
Frame 3: 14503ms
```

Fixes: #40311
Fixes: #40840
Superseed: #41067