### PR TITLE
HTML5 event handlers refactor, request_quit, best effort virtual keyboard.

### DIFF
--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -147,6 +147,7 @@ $GODOT_HEAD_INCLUDE
 			const MAIN_PACK = '$GODOT_BASENAME.pck';
 			const EXTRA_ARGS = JSON.parse('$GODOT_ARGS');
 			const INDETERMINATE_STATUS_STEP_MS = 100;
+			const FULL_WINDOW = $GODOT_FULL_WINDOW;
 
 			var canvas = document.getElementById('canvas');
 			var statusProgress = document.getElementById('status-progress');
@@ -179,8 +180,12 @@ $GODOT_HEAD_INCLUDE
 					canvas.style.height = lastHeight + "px";
 				}
 			}
-			animationCallbacks.push(adjustCanvasDimensions);
-			adjustCanvasDimensions();
+			if (FULL_WINDOW) {
+				animationCallbacks.push(adjustCanvasDimensions);
+				adjustCanvasDimensions();
+			} else {
+				engine.setCanvasResizedOnStart(true);
+			}
 
 			setStatusMode = function setStatusMode(mode) {
 

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -156,6 +156,9 @@ $GODOT_HEAD_INCLUDE
 
 			var initializing = true;
 			var statusMode = 'hidden';
+			var lastWidth = 0;
+			var lastHeight = 0;
+			var lastScale = 0;
 
 			var animationCallbacks = [];
 			function animate(time) {
@@ -165,11 +168,16 @@ $GODOT_HEAD_INCLUDE
 			requestAnimationFrame(animate);
 
 			function adjustCanvasDimensions() {
-				var scale = window.devicePixelRatio || 1;
-				var width = window.innerWidth;
-				var height = window.innerHeight;
-				canvas.width = width * scale;
-				canvas.height = height * scale;
+				const scale = window.devicePixelRatio || 1;
+				if (lastWidth != window.innerWidth || lastHeight != window.innerHeight || lastScale != scale) {
+					lastScale = scale;
+					lastWidth = window.innerWidth;
+					lastHeight = window.innerHeight;
+					canvas.width = Math.floor(lastWidth * scale);
+					canvas.height = Math.floor(lastHeight * scale);
+					canvas.style.width = lastWidth + "px";
+					canvas.style.height = lastHeight + "px";
+				}
 			}
 			animationCallbacks.push(adjustCanvasDimensions);
 			adjustCanvasDimensions();

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -2,7 +2,7 @@
 <html xmlns='http://www.w3.org/1999/xhtml' lang='' xml:lang=''>
 <head>
 	<meta charset='utf-8' />
-	<meta name='viewport' content='width=device-width, user-scalable=no' />
+	<meta name='viewport' content='width=device-width, user-scalable=no, initial-scale=1' />
 	<link id='-gd-engine-icon' rel='icon' type='image/png' href='favicon.png' />
 	<title>$GODOT_PROJECT_NAME</title>
 	<style type='text/css'>

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -115,6 +115,8 @@
 $GODOT_HEAD_INCLUDE
 </head>
 <body>
+	<input id='vkInput' type="text" style='display: none; position: absolute; background: transparent; z-index: -1; left: 0;'>
+	<textarea id='vkTextArea' style='display: none; position: absolute; background: transparent; padding: 0px !important; margin: 0px !important; width: 0px !important; height: 0px !important; overflow: hidden; z-index: -1; left: 0;'></textarea>
 	<canvas id='canvas'>
 		HTML5 canvas appears to be unsupported in the current browser.<br />
 		Please try updating or use a different browser.
@@ -254,6 +256,9 @@ $GODOT_HEAD_INCLUDE
 					setStatusMode('indeterminate');
 				}
 			});
+
+			engine.setVirtualKeyboardInput(document.getElementById('vkInput'));
+			engine.setVirtualKeyboardTextArea(document.getElementById('vkTextArea'));
 
 			function displayFailureNotice(err) {
 				var msg = err.message || err;

--- a/platform/javascript/audio_driver_javascript.h
+++ b/platform/javascript/audio_driver_javascript.h
@@ -46,21 +46,21 @@ public:
 
 	static AudioDriverJavaScript *singleton;
 
-	virtual const char *get_name() const;
+	virtual const char *get_name() const override;
 
-	virtual Error init();
-	virtual void start();
+	virtual Error init() override;
+	virtual void start() override;
 	void resume();
-	virtual float get_latency();
-	virtual int get_mix_rate() const;
-	virtual SpeakerMode get_speaker_mode() const;
-	virtual void lock();
-	virtual void unlock();
-	virtual void finish();
+	virtual float get_latency() override;
+	virtual int get_mix_rate() const override;
+	virtual SpeakerMode get_speaker_mode() const override;
+	virtual void lock() override;
+	virtual void unlock() override;
+	virtual void finish() override;
 	void finish_async();
 
-	virtual Error capture_start();
-	virtual Error capture_stop();
+	virtual Error capture_start() override;
+	virtual Error capture_stop() override;
 
 	AudioDriverJavaScript();
 };

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -892,15 +892,18 @@ DisplayServerJavaScript::DisplayServerJavaScript(const String &p_rendering_drive
 #define SET_EM_CALLBACK(target, ev, cb)                                  \
 	result = emscripten_set_##ev##_callback(target, nullptr, true, &cb); \
 	EM_CHECK(ev)
+#define SET_EM_WINDOW_CALLBACK(ev, cb)                                                         \
+	result = emscripten_set_##ev##_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, false, &cb); \
+	EM_CHECK(ev)
 #define SET_EM_CALLBACK_NOTARGET(ev, cb)                         \
 	result = emscripten_set_##ev##_callback(nullptr, true, &cb); \
 	EM_CHECK(ev)
 	// These callbacks from Emscripten's html5.h suffice to access most
 	// JavaScript APIs. For APIs that are not (sufficiently) exposed, EM_ASM
 	// is used below.
-	SET_EM_CALLBACK(EMSCRIPTEN_EVENT_TARGET_WINDOW, mousemove, mousemove_callback)
 	SET_EM_CALLBACK(canvas_id, mousedown, mouse_button_callback)
-	SET_EM_CALLBACK(EMSCRIPTEN_EVENT_TARGET_WINDOW, mouseup, mouse_button_callback)
+	SET_EM_WINDOW_CALLBACK(mousemove, mousemove_callback)
+	SET_EM_WINDOW_CALLBACK(mouseup, mouse_button_callback)
 	SET_EM_CALLBACK(canvas_id, wheel, wheel_callback)
 	SET_EM_CALLBACK(canvas_id, touchstart, touch_press_callback)
 	SET_EM_CALLBACK(canvas_id, touchmove, touchmove_callback)

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -75,7 +75,7 @@ bool DisplayServerJavaScript::check_size_force_redraw() {
 	if (last_width != canvas_width || last_height != canvas_height) {
 		last_width = canvas_width;
 		last_height = canvas_height;
-		// Update the framebuffer size and for redraw.
+		// Update the framebuffer size for redraw.
 		emscripten_set_canvas_element_size(DisplayServerJavaScript::canvas_id, canvas_width, canvas_height);
 		return true;
 	}
@@ -1103,7 +1103,11 @@ Size2i DisplayServerJavaScript::window_get_min_size(WindowID p_window) const {
 void DisplayServerJavaScript::window_set_size(const Size2i p_size, WindowID p_window) {
 	last_width = p_size.x;
 	last_height = p_size.y;
-	emscripten_set_canvas_element_size(canvas_id, p_size.x, p_size.y);
+	double scale = EM_ASM_DOUBLE({
+		return window.devicePixelRatio || 1;
+	});
+	emscripten_set_canvas_element_size(canvas_id, p_size.x * scale, p_size.y * scale);
+	emscripten_set_element_css_size(canvas_id, p_size.x, p_size.y);
 }
 
 Size2i DisplayServerJavaScript::window_get_size(WindowID p_window) const {

--- a/platform/javascript/display_server_javascript.h
+++ b/platform/javascript/display_server_javascript.h
@@ -129,6 +129,10 @@ public:
 	// touch
 	virtual bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 
+	// virtual keyboard
+	virtual void virtual_keyboard_show(const String &p_existing_text, const Rect2 &p_screen_rect, bool p_multiline, int p_max_length, int p_cursor_start, int p_cursor_end) override;
+	virtual void virtual_keyboard_hide() override;
+
 	// clipboard
 	virtual void clipboard_set(const String &p_text) override;
 	virtual String clipboard_get() const override;

--- a/platform/javascript/display_server_javascript.h
+++ b/platform/javascript/display_server_javascript.h
@@ -113,92 +113,92 @@ public:
 	bool check_size_force_redraw();
 
 	// from DisplayServer
-	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
-	virtual bool has_feature(Feature p_feature) const;
-	virtual String get_name() const;
+	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") override;
+	virtual bool has_feature(Feature p_feature) const override;
+	virtual String get_name() const override;
 
 	// cursor
-	virtual void cursor_set_shape(CursorShape p_shape);
-	virtual CursorShape cursor_get_shape() const;
-	virtual void cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
+	virtual void cursor_set_shape(CursorShape p_shape) override;
+	virtual CursorShape cursor_get_shape() const override;
+	virtual void cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) override;
 
 	// mouse
-	virtual void mouse_set_mode(MouseMode p_mode);
-	virtual MouseMode mouse_get_mode() const;
+	virtual void mouse_set_mode(MouseMode p_mode) override;
+	virtual MouseMode mouse_get_mode() const override;
 
 	// touch
-	virtual bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
+	virtual bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 
 	// clipboard
-	virtual void clipboard_set(const String &p_text);
-	virtual String clipboard_get() const;
+	virtual void clipboard_set(const String &p_text) override;
+	virtual String clipboard_get() const override;
 
 	// screen
-	virtual int get_screen_count() const;
-	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
-	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
-	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
-	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
+	virtual int get_screen_count() const override;
+	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 
 	// windows
-	virtual Vector<DisplayServer::WindowID> get_window_list() const;
-	virtual WindowID get_window_at_screen_position(const Point2i &p_position) const;
+	virtual Vector<DisplayServer::WindowID> get_window_list() const override;
+	virtual WindowID get_window_at_screen_position(const Point2i &p_position) const override;
 
-	virtual void window_attach_instance_id(ObjectID p_instance, WindowID p_window = MAIN_WINDOW_ID);
-	virtual ObjectID window_get_attached_instance_id(WindowID p_window = MAIN_WINDOW_ID) const;
+	virtual void window_attach_instance_id(ObjectID p_instance, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual ObjectID window_get_attached_instance_id(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
+	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual void window_set_window_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
-	virtual void window_set_input_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
-	virtual void window_set_input_text_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
+	virtual void window_set_window_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_input_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_input_text_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual void window_set_drop_files_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
+	virtual void window_set_drop_files_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID);
+	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const;
-	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID);
+	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual Point2i window_get_position(WindowID p_window = MAIN_WINDOW_ID) const;
-	virtual void window_set_position(const Point2i &p_position, WindowID p_window = MAIN_WINDOW_ID);
+	virtual Point2i window_get_position(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual void window_set_position(const Point2i &p_position, WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual void window_set_transient(WindowID p_window, WindowID p_parent);
+	virtual void window_set_transient(WindowID p_window, WindowID p_parent) override;
 
-	virtual void window_set_max_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID);
-	virtual Size2i window_get_max_size(WindowID p_window = MAIN_WINDOW_ID) const;
+	virtual void window_set_max_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual Size2i window_get_max_size(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual void window_set_min_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID);
-	virtual Size2i window_get_min_size(WindowID p_window = MAIN_WINDOW_ID) const;
+	virtual void window_set_min_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual Size2i window_get_min_size(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual void window_set_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID);
-	virtual Size2i window_get_size(WindowID p_window = MAIN_WINDOW_ID) const;
-	virtual Size2i window_get_real_size(WindowID p_window = MAIN_WINDOW_ID) const; // FIXME: Find clearer name for this.
+	virtual void window_set_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual Size2i window_get_size(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual Size2i window_get_real_size(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual void window_set_mode(WindowMode p_mode, WindowID p_window = MAIN_WINDOW_ID);
-	virtual WindowMode window_get_mode(WindowID p_window = MAIN_WINDOW_ID) const;
+	virtual void window_set_mode(WindowMode p_mode, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual WindowMode window_get_mode(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual bool window_is_maximize_allowed(WindowID p_window = MAIN_WINDOW_ID) const;
+	virtual bool window_is_maximize_allowed(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual void window_set_flag(WindowFlags p_flag, bool p_enabled, WindowID p_window = MAIN_WINDOW_ID);
-	virtual bool window_get_flag(WindowFlags p_flag, WindowID p_window = MAIN_WINDOW_ID) const;
+	virtual void window_set_flag(WindowFlags p_flag, bool p_enabled, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual bool window_get_flag(WindowFlags p_flag, WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual void window_request_attention(WindowID p_window = MAIN_WINDOW_ID);
-	virtual void window_move_to_foreground(WindowID p_window = MAIN_WINDOW_ID);
+	virtual void window_request_attention(WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_move_to_foreground(WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual bool window_can_draw(WindowID p_window = MAIN_WINDOW_ID) const;
+	virtual bool window_can_draw(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual bool can_any_window_draw() const;
+	virtual bool can_any_window_draw() const override;
 
 	// events
-	virtual void process_events();
+	virtual void process_events() override;
 
 	// icon
-	virtual void set_icon(const Ref<Image> &p_icon);
+	virtual void set_icon(const Ref<Image> &p_icon) override;
 
 	// others
-	virtual bool get_swap_cancel_ok();
-	virtual void swap_buffers();
+	virtual bool get_swap_cancel_ok() override;
+	virtual void swap_buffers() override;
 
 	static void register_javascript_driver();
 	DisplayServerJavaScript(const String &p_rendering_driver, WindowMode p_mode, uint32_t p_flags, const Vector2i &p_resolution, Error &r_error);

--- a/platform/javascript/engine/engine.js
+++ b/platform/javascript/engine/engine.js
@@ -27,6 +27,8 @@ Function('return this')()['Engine'] = (function() {
 	/** @constructor */
 	function Engine() {
 		this.canvas = null;
+		this.vkInput = null;
+		this.vkTextArea = null;
 		this.executableName = '';
 		this.rtenv = null;
 		this.customLocale = null;
@@ -113,6 +115,8 @@ Function('return this')()['Engine'] = (function() {
 			}
 			me.rtenv['locale'] = locale;
 			me.rtenv['canvas'] = me.canvas;
+			me.rtenv['vkInput'] = me.vkInput;
+			me.rtenv['vkTextArea'] = me.vkTextArea;
 			me.rtenv['thisProgram'] = me.executableName;
 			me.rtenv['resizeCanvasOnStart'] = me.resizeCanvasOnStart;
 			me.rtenv['noExitRuntime'] = true;
@@ -168,6 +172,14 @@ Function('return this')()['Engine'] = (function() {
 		this.resizeCanvasOnStart = enabled;
 	};
 
+	Engine.prototype.setVirtualKeyboardInput = function(inputElem) {
+		this.vkInput = inputElem;
+	};
+
+	Engine.prototype.setVirtualKeyboardTextArea = function(textAreaElem) {
+		this.vkTextArea = textAreaElem;
+	};
+
 	Engine.prototype.setLocale = function(locale) {
 		this.customLocale = locale;
 	};
@@ -207,18 +219,18 @@ Function('return this')()['Engine'] = (function() {
 		if (this.rtenv)
 			this.rtenv.onExecute = onExecute;
 		this.onExecute = onExecute;
-	}
+	};
 
 	Engine.prototype.setOnExit = function(onExit) {
 		this.onExit = onExit;
-	}
+	};
 
 	Engine.prototype.copyToFS = function(path, buffer) {
 		if (this.rtenv == null) {
 			throw new Error("Engine must be inited before copying files");
 		}
 		this.rtenv['copyToFS'](path, buffer);
-	}
+	};
 
 	// Closure compiler exported engine methods.
 	/** @export */
@@ -233,6 +245,8 @@ Function('return this')()['Engine'] = (function() {
 	Engine.prototype['setUnloadAfterInit'] = Engine.prototype.setUnloadAfterInit;
 	Engine.prototype['setCanvas'] = Engine.prototype.setCanvas;
 	Engine.prototype['setCanvasResizedOnStart'] = Engine.prototype.setCanvasResizedOnStart;
+	Engine.prototype['setVirtualKeyboardInput'] = Engine.prototype.setVirtualKeyboardInput;
+	Engine.prototype['setVirtualKeyboardTextArea'] = Engine.prototype.setVirtualKeyboardTextArea;
 	Engine.prototype['setLocale'] = Engine.prototype.setLocale;
 	Engine.prototype['setExecutableName'] = Engine.prototype.setExecutableName;
 	Engine.prototype['setProgressFunc'] = Engine.prototype.setProgressFunc;

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -258,6 +258,7 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t> &p_html, const Re
 		current_line = current_line.replace("$GODOT_BASENAME", p_name);
 		current_line = current_line.replace("$GODOT_PROJECT_NAME", ProjectSettings::get_singleton()->get_setting("application/config/name"));
 		current_line = current_line.replace("$GODOT_HEAD_INCLUDE", p_preset->get("html/head_include"));
+		current_line = current_line.replace("$GODOT_FULL_WINDOW", p_preset->get("html/full_window_size") ? "true" : "false");
 		current_line = current_line.replace("$GODOT_DEBUG_ENABLED", p_debug ? "true" : "false");
 		current_line = current_line.replace("$GODOT_ARGS", flags_json);
 		str_export += current_line + "\n";
@@ -291,6 +292,7 @@ void EditorExportPlatformJavaScript::get_export_options(List<ExportOption> *r_op
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "vram_texture_compression/for_mobile"), false)); // ETC or ETC2, depending on renderer
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "html/custom_html_shell", PROPERTY_HINT_FILE, "*.html"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "html/head_include", PROPERTY_HINT_MULTILINE_TEXT), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "html/full_window_size"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/release", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/debug", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 }

--- a/platform/javascript/native/utils.js
+++ b/platform/javascript/native/utils.js
@@ -202,3 +202,47 @@ Module.drop_handler = (function() {
 		});
 	}
 })();
+
+function EventHandlers() {
+	function Handler(target, event, method, capture) {
+		this.target = target;
+		this.event = event;
+		this.method = method;
+		this.capture = capture;
+	}
+
+	var listeners = [];
+
+	function has(target, event, method, capture) {
+		return listeners.findIndex(function(e) {
+			return e.target === target && e.event === event && e.method === method && e.capture == capture;
+		}) !== -1;
+	}
+
+	this.add = function(target, event, method, capture) {
+		if (listeners[event] === undefined) {
+			listeners[event] = [];
+		}
+		if (has(target, event, method, capture)) {
+			return;
+		}
+		listeners[event].push(new Handler(target, event, method, capture));
+		target.addEventListener(event, method, capture);
+	};
+
+	this.remove = function(target, event, method, capture) {
+		if (!has(target, event, method, capture)) {
+			return;
+		}
+		target.removeEventListener(event, method, capture);
+	};
+
+	this.clear = function() {
+		listeners.forEach(function(h) {
+			h.target.removeEventListener(h.event, h.method, h.capture);
+		});
+		listeners.length = 0;
+	};
+}
+
+Module.listeners = new EventHandlers();

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -46,24 +46,6 @@
 #include <emscripten.h>
 #include <stdlib.h>
 
-bool OS_JavaScript::has_touchscreen_ui_hint() const {
-	/* clang-format off */
-	return EM_ASM_INT_V(
-		return 'ontouchstart' in window;
-	);
-	/* clang-format on */
-}
-
-// Audio
-
-int OS_JavaScript::get_audio_driver_count() const {
-	return 1;
-}
-
-const char *OS_JavaScript::get_audio_driver_name(int p_driver) const {
-	return "JavaScript";
-}
-
 // Lifecycle
 void OS_JavaScript::initialize() {
 	OS_Unix::initialize_core();
@@ -199,10 +181,6 @@ Error OS_JavaScript::shell_open(String p_uri) {
 
 String OS_JavaScript::get_name() const {
 	return "HTML5";
-}
-
-bool OS_JavaScript::can_draw() const {
-	return true; // Always?
 }
 
 String OS_JavaScript::get_user_data_dir() const {

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -52,49 +52,43 @@ class OS_JavaScript : public OS_Unix {
 	static void file_access_close_callback(const String &p_file, int p_flags);
 
 protected:
-	virtual void initialize();
+	virtual void initialize() override;
 
-	virtual void set_main_loop(MainLoop *p_main_loop);
-	virtual void delete_main_loop();
+	virtual void set_main_loop(MainLoop *p_main_loop) override;
+	virtual void delete_main_loop() override;
 
-	virtual void finalize();
+	virtual void finalize() override;
 
-	virtual bool _check_internal_feature_support(const String &p_feature);
+	virtual bool _check_internal_feature_support(const String &p_feature) override;
 
 public:
 	// Override return type to make writing static callbacks less tedious.
 	static OS_JavaScript *get_singleton();
 
-	virtual void initialize_joypads();
+	virtual void initialize_joypads() override;
 
-	virtual bool has_touchscreen_ui_hint() const;
-
-	virtual int get_audio_driver_count() const;
-	virtual const char *get_audio_driver_name(int p_driver) const;
-
-	virtual MainLoop *get_main_loop() const;
+	virtual MainLoop *get_main_loop() const override;
 	void finalize_async();
 	bool main_loop_iterate();
 
-	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking = true, ProcessID *r_child_id = nullptr, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr);
-	virtual Error kill(const ProcessID &p_pid);
-	virtual int get_process_id() const;
+	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking = true, ProcessID *r_child_id = nullptr, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr) override;
+	virtual Error kill(const ProcessID &p_pid) override;
+	virtual int get_process_id() const override;
 
-	String get_executable_path() const;
-	virtual Error shell_open(String p_uri);
-	virtual String get_name() const;
+	String get_executable_path() const override;
+	virtual Error shell_open(String p_uri) override;
+	virtual String get_name() const override;
 	// Override default OS implementation which would block the main thread with delay_usec.
 	// Implemented in javascript_main.cpp loop callback instead.
-	virtual void add_frame_delay(bool p_can_draw) {}
-	virtual bool can_draw() const;
+	virtual void add_frame_delay(bool p_can_draw) override {}
 
-	virtual String get_cache_path() const;
-	virtual String get_config_path() const;
-	virtual String get_data_path() const;
-	virtual String get_user_data_dir() const;
+	virtual String get_cache_path() const override;
+	virtual String get_config_path() const override;
+	virtual String get_data_path() const override;
+	virtual String get_user_data_dir() const override;
 
 	void set_idb_available(bool p_idb_available);
-	virtual bool is_userfs_persistent() const;
+	virtual bool is_userfs_persistent() const override;
 
 	void resume_audio();
 	bool is_finalizing() { return finalizing; }

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -919,7 +919,7 @@ void LineEdit::_notification(int p_what) {
 			}
 
 			if (has_focus()) {
-				if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID) {
+				if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 					DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
 					DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + Point2(using_placeholder ? 0 : x_ofs, y_ofs + caret_height), get_viewport()->get_window_id());
 				}
@@ -936,7 +936,7 @@ void LineEdit::_notification(int p_what) {
 				}
 			}
 
-			if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID) {
+			if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 				DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
 				Point2 cursor_pos = Point2(get_cursor_position(), 1) * get_minimum_size().height;
 				DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + cursor_pos, get_viewport()->get_window_id());
@@ -956,7 +956,7 @@ void LineEdit::_notification(int p_what) {
 				caret_blink_timer->stop();
 			}
 
-			if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID) {
+			if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 				DisplayServer::get_singleton()->window_set_ime_position(Point2(), get_viewport()->get_window_id());
 				DisplayServer::get_singleton()->window_set_ime_active(false, get_viewport()->get_window_id());
 			}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1612,7 +1612,7 @@ void TextEdit::_notification(int p_what) {
 			}
 
 			if (has_focus()) {
-				if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID) {
+				if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 					DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
 					DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + cursor_pos + Point2(0, get_row_height()), get_viewport()->get_window_id());
 				}
@@ -1625,7 +1625,7 @@ void TextEdit::_notification(int p_what) {
 				draw_caret = true;
 			}
 
-			if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID) {
+			if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 				DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
 				Point2 cursor_pos = Point2(cursor_get_column(), cursor_get_line()) * get_row_height();
 				DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + cursor_pos, get_viewport()->get_window_id());
@@ -1640,7 +1640,7 @@ void TextEdit::_notification(int p_what) {
 				caret_blink_timer->stop();
 			}
 
-			if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID) {
+			if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 				DisplayServer::get_singleton()->window_set_ime_position(Point2(), get_viewport()->get_window_id());
 				DisplayServer::get_singleton()->window_set_ime_active(false, get_viewport()->get_window_id());
 			}


### PR DESCRIPTION
In this PR (I can split it up, but I'd like some comments for now, see below):

- Expose `request_quit` method to JS (sync with 3.2)
- Refactor event handlers, moving add/remove logic to `native/utils.js`
- `window` event handlers no longer `useCapture` (fixes #33020)
- Canvas resize option now available on export.
- Add the override keyword to javascript platform
- Basic implementation for HTML5 virtual keyboard. Using `input` or `textarea` (fixes #32680 as best effort).
  This comes with a lot of limitations from browsers. Visual caret will keep resetting (tested in `3.2`), but text insertion will be correct.
  I tried using IME (for this 4.0 branch), but browsers support is quite awful, and I found no way to get the IME range (which is a must to work correctly), so things would get messy when you delete stuff (see https://github.com/w3c/uievents/issues/5#issuecomment-566775530).
- Also properly guard `LineEdit` and `TextEdit` `ime` access with `DisplayServer::has_feature(...)`

There is a `3.2` branch of this (where I did most of the tests): https://github.com/Faless/godot/tree/js/vk .
You can test try it out here:
~https://itch.io/embed-upload/2568463?color=333333~
~Updated link to use GLES2 (so safari can be tested): https://itch.io/embed-upload/2569386?color=333333~
Update link to also set initial scale in meta viewport: https://itch.io/embed-upload/2632673?color=333333

Export window:
![full-window-size](https://user-images.githubusercontent.com/1687918/89634742-2418d780-d8a6-11ea-853c-1b3dbe3d9765.png)
