### PR TITLE
Tidy up assignment operator check

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1369,48 +1369,11 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 		push_error("Cannot assign a new value to a constant.", p_assignment->assignee);
 	}
 
-	Variant::Operator vop = Variant::Operator::OP_EQUAL;
-	switch (p_assignment->operation) {
-		case GDScriptParser::AssignmentNode::OP_NONE:
-			vop = Variant::Operator::OP_EQUAL;
-			break;
-		case GDScriptParser::AssignmentNode::OP_ADDITION:
-			vop = Variant::Operator::OP_ADD;
-			break;
-		case GDScriptParser::AssignmentNode::OP_SUBTRACTION:
-			vop = Variant::Operator::OP_SUBTRACT;
-			break;
-		case GDScriptParser::AssignmentNode::OP_MULTIPLICATION:
-			vop = Variant::Operator::OP_MULTIPLY;
-			break;
-		case GDScriptParser::AssignmentNode::OP_DIVISION:
-			vop = Variant::Operator::OP_DIVIDE;
-			break;
-		case GDScriptParser::AssignmentNode::OP_MODULO:
-			vop = Variant::Operator::OP_MODULE;
-			break;
-		case GDScriptParser::AssignmentNode::OP_BIT_SHIFT_LEFT:
-			vop = Variant::Operator::OP_SHIFT_LEFT;
-			break;
-		case GDScriptParser::AssignmentNode::OP_BIT_SHIFT_RIGHT:
-			vop = Variant::Operator::OP_SHIFT_RIGHT;
-			break;
-		case GDScriptParser::AssignmentNode::OP_BIT_AND:
-			vop = Variant::Operator::OP_BIT_AND;
-			break;
-		case GDScriptParser::AssignmentNode::OP_BIT_OR:
-			vop = Variant::Operator::OP_BIT_OR;
-			break;
-		case GDScriptParser::AssignmentNode::OP_BIT_XOR:
-			vop = Variant::Operator::OP_BIT_XOR;
-			break;
-	}
-
 	if (!p_assignment->assignee->get_datatype().is_variant() && !p_assignment->assigned_value->get_datatype().is_variant()) {
 		bool compatible = true;
 		GDScriptParser::DataType op_type = p_assignment->assigned_value->get_datatype();
-		if (vop != Variant::OP_EQUAL) {
-			op_type = get_operation_type(vop, p_assignment->assignee->get_datatype(), p_assignment->assigned_value->get_datatype(), compatible);
+		if (p_assignment->operation != GDScriptParser::AssignmentNode::OP_NONE) {
+			op_type = get_operation_type(p_assignment->variant_op, p_assignment->assignee->get_datatype(), p_assignment->assigned_value->get_datatype(), compatible);
 		}
 
 		if (compatible) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2005,7 +2005,6 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_binary_operator(Expression
 		push_error(vformat(R"(Expected expression after "%s" operator.")", op.get_name()));
 	}
 
-	// TODO: Store the Variant operator here too (in the node).
 	// TODO: Also for unary, ternary, and assignment.
 	switch (op.type) {
 		case GDScriptTokenizer::Token::PLUS:
@@ -2167,39 +2166,50 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_assignment(ExpressionNode 
 	switch (previous.type) {
 		case GDScriptTokenizer::Token::EQUAL:
 			assignment->operation = AssignmentNode::OP_NONE;
+			assignment->variant_op = Variant::OP_MAX;
 #ifdef DEBUG_ENABLED
 			has_operator = false;
 #endif
 			break;
 		case GDScriptTokenizer::Token::PLUS_EQUAL:
 			assignment->operation = AssignmentNode::OP_ADDITION;
+			assignment->variant_op = Variant::OP_ADD;
 			break;
 		case GDScriptTokenizer::Token::MINUS_EQUAL:
 			assignment->operation = AssignmentNode::OP_SUBTRACTION;
+			assignment->variant_op = Variant::OP_SUBTRACT;
 			break;
 		case GDScriptTokenizer::Token::STAR_EQUAL:
 			assignment->operation = AssignmentNode::OP_MULTIPLICATION;
+			assignment->variant_op = Variant::OP_MULTIPLY;
 			break;
 		case GDScriptTokenizer::Token::SLASH_EQUAL:
 			assignment->operation = AssignmentNode::OP_DIVISION;
+			assignment->variant_op = Variant::OP_DIVIDE;
 			break;
 		case GDScriptTokenizer::Token::PERCENT_EQUAL:
 			assignment->operation = AssignmentNode::OP_MODULO;
+			assignment->variant_op = Variant::OP_MODULE;
 			break;
 		case GDScriptTokenizer::Token::LESS_LESS_EQUAL:
 			assignment->operation = AssignmentNode::OP_BIT_SHIFT_LEFT;
+			assignment->variant_op = Variant::OP_SHIFT_LEFT;
 			break;
 		case GDScriptTokenizer::Token::GREATER_GREATER_EQUAL:
 			assignment->operation = AssignmentNode::OP_BIT_SHIFT_RIGHT;
+			assignment->variant_op = Variant::OP_SHIFT_RIGHT;
 			break;
 		case GDScriptTokenizer::Token::AMPERSAND_EQUAL:
 			assignment->operation = AssignmentNode::OP_BIT_AND;
+			assignment->variant_op = Variant::OP_BIT_AND;
 			break;
 		case GDScriptTokenizer::Token::PIPE_EQUAL:
 			assignment->operation = AssignmentNode::OP_BIT_OR;
+			assignment->variant_op = Variant::OP_BIT_OR;
 			break;
 		case GDScriptTokenizer::Token::CARET_EQUAL:
 			assignment->operation = AssignmentNode::OP_BIT_XOR;
+			assignment->variant_op = Variant::OP_BIT_XOR;
 			break;
 		default:
 			break; // Unreachable.


### PR DESCRIPTION
The operator is already gathered by the parser, no need to do it again in the analyzer.

This was added in #40690 and without checking I though I had forgotten to do this in the parser, but it's actually already there (cc @ThakeeNathees).