### PR TITLE
Document the lack of kerning support in DynamicFont

### DIFF
--- a/doc/classes/DynamicFont.xml
+++ b/doc/classes/DynamicFont.xml
@@ -12,7 +12,7 @@
 		dynamic_font.size = 64
 		$"Label".set("custom_fonts/font", dynamic_font)
 		[/codeblock]
-		[b]Note:[/b] DynamicFont doesn't support features such as right-to-left typesetting, ligatures, text shaping, variable fonts and optional font features yet. If you wish to "bake" an optional font feature into a TTF font file, you can use [url=https://fontforge.org/]FontForge[/url] to do so. In FontForge, use [b]File &gt; Generate Fonts[/b], click [b]Options[/b], choose the desired features then generate the font.
+		[b]Note:[/b] DynamicFont doesn't support features such as kerning, right-to-left typesetting, ligatures, text shaping, variable fonts and optional font features yet. If you wish to "bake" an optional font feature into a TTF font file, you can use [url=https://fontforge.org/]FontForge[/url] to do so. In FontForge, use [b]File &gt; Generate Fonts[/b], click [b]Options[/b], choose the desired features then generate the font.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
This may change if https://github.com/godotengine/godot/issues/38731 is followed, but right now, DynamicFont doesn't support kerning.

[![](https://imgs.xkcd.com/comics/kerning.png)](https://xkcd.com/1015/)