### PR TITLE
Implemented start and end offset for AnimationTrack (like AudioTrack has)

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -380,8 +380,8 @@ public:
 					setting = false;
 					return true;
 				}
-				if (name == "start_offset") {
 
+				if (name == "start_offset") {
 					float value = p_value;
 
 					setting = true;
@@ -396,8 +396,8 @@ public:
 					setting = false;
 					return true;
 				}
-				if (name == "end_offset") {
 
+				if (name == "end_offset") {
 					float value = p_value;
 
 					setting = true;
@@ -412,7 +412,6 @@ public:
 					setting = false;
 					return true;
 				}
-
 			} break;
 		}
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -380,6 +380,39 @@ public:
 					setting = false;
 					return true;
 				}
+				if (name == "start_offset") {
+
+					float value = p_value;
+
+					setting = true;
+					undo_redo->create_action(TTR("Anim Change Keyframe Value"), UndoRedo::MERGE_ENDS);
+					float prev = animation->animation_track_get_key_start_offset(track, key);
+					undo_redo->add_do_method(animation.ptr(), "animation_track_set_key_start_offset", track, key, value);
+					undo_redo->add_undo_method(animation.ptr(), "animation_track_set_key_start_offset", track, key, prev);
+					undo_redo->add_do_method(this, "_update_obj", animation);
+					undo_redo->add_undo_method(this, "_update_obj", animation);
+					undo_redo->commit_action();
+
+					setting = false;
+					return true;
+				}
+				if (name == "end_offset") {
+
+					float value = p_value;
+
+					setting = true;
+					undo_redo->create_action(TTR("Anim Change Keyframe Value"), UndoRedo::MERGE_ENDS);
+					float prev = animation->animation_track_get_key_end_offset(track, key);
+					undo_redo->add_do_method(animation.ptr(), "animation_track_set_key_end_offset", track, key, value);
+					undo_redo->add_undo_method(animation.ptr(), "animation_track_set_key_end_offset", track, key, prev);
+					undo_redo->add_do_method(this, "_update_obj", animation);
+					undo_redo->add_undo_method(this, "_update_obj", animation);
+					undo_redo->commit_action();
+
+					setting = false;
+					return true;
+				}
+
 			} break;
 		}
 
@@ -499,6 +532,14 @@ public:
 					r_ret = animation->animation_track_get_key_animation(track, key);
 					return true;
 				}
+				if (name == "start_offset") {
+					r_ret = animation->animation_track_get_key_start_offset(track, key);
+					return true;
+				}
+				if (name == "end_offset") {
+					r_ret = animation->animation_track_get_key_end_offset(track, key);
+					return true;
+				}
 
 			} break;
 		}
@@ -613,6 +654,8 @@ public:
 				animations += "[stop]";
 
 				p_list->push_back(PropertyInfo(Variant::STRING_NAME, "animation", PROPERTY_HINT_ENUM, animations));
+				p_list->push_back(PropertyInfo(Variant::FLOAT, "start_offset", PROPERTY_HINT_RANGE, "0,3600,0.01,or_greater"));
+				p_list->push_back(PropertyInfo(Variant::FLOAT, "end_offset", PROPERTY_HINT_RANGE, "0,3600,0.01,or_greater"));
 
 			} break;
 		}
@@ -2522,6 +2565,11 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 				case Animation::TYPE_ANIMATION: {
 					String name = animation->animation_track_get_key_animation(track, key_idx);
 					text += "Animation Clip: " + name + "\n";
+					text += "Animation: " + name + "\n";
+					float so = animation->animation_track_get_key_start_offset(track, key_idx);
+					text += "Start (s): " + rtos(so) + "\n";
+					float eo = animation->animation_track_get_key_end_offset(track, key_idx);
+					text += "End (s): " + rtos(eo) + "\n";
 				} break;
 			}
 			return text;
@@ -4553,10 +4601,13 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 			undo_redo->commit_action();
 		} break;
 		case Animation::TYPE_ANIMATION: {
-			StringName anim = "[stop]";
+			Dictionary ak;
+			ak["animation"] = "[stop]";
+			ak["start_offset"] = 0;
+			ak["end_offset"] = 0;
 
 			undo_redo->create_action(TTR("Add Track Key"));
-			undo_redo->add_do_method(animation.ptr(), "track_insert_key", p_track, p_ofs, anim);
+			undo_redo->add_do_method(animation.ptr(), "track_insert_key", p_track, p_ofs, ak);
 			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_position", p_track, p_ofs);
 			undo_redo->commit_action();
 		} break;

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -1222,8 +1222,8 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 		Ref<Font> font = get_theme_font("font", "Label");
 		int fh = font->get_height() * 1.5;
 
-		int h = get_size().height;
-		Rect2 rect = Rect2(from_x, (h - fh) / 2, to_x - from_x, fh);
+		int sh = get_size().height;
+		Rect2 rect = Rect2(from_x, (sh - fh) / 2, to_x - from_x, fh);
 
 		Color color = get_theme_color("font_color", "Label");
 		Color bg = color;

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -1354,7 +1354,6 @@ void AnimationTrackEditTypeAnimation::_gui_input(const Ref<InputEvent> &p_event)
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT && get_default_cursor_shape() == CURSOR_HSIZE) {
-
 		len_resizing = true;
 		len_resizing_start = mb->get_shift();
 		len_resizing_from_px = mb->get_position().x;
@@ -1365,7 +1364,6 @@ void AnimationTrackEditTypeAnimation::_gui_input(const Ref<InputEvent> &p_event)
 	}
 
 	if (len_resizing && mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
-
 		float ofs_local = -len_resizing_rel / get_timeline()->get_zoom_scale();
 		if (len_resizing_start) {
 			float prev_ofs = get_animation()->animation_track_get_key_start_offset(get_track(), len_resizing_index);

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -1123,7 +1123,16 @@ Rect2 AnimationTrackEditTypeAnimation::get_key_rect(int p_index, float p_pixels_
 	String anim = get_animation()->animation_track_get_key_animation(get_track(), p_index);
 
 	if (anim != "[stop]" && ap->has_animation(anim)) {
+		float start_ofs = get_animation()->animation_track_get_key_start_offset(get_track(), p_index);
+		float end_ofs = get_animation()->animation_track_get_key_end_offset(get_track(), p_index);
+
 		float len = ap->get_animation(anim)->get_length();
+
+		len -= end_ofs;
+		len -= start_ofs;
+		if (len <= 0.001) {
+			len = 0.001;
+		}
 
 		if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
 			len = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
@@ -1161,8 +1170,27 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 	if (anim != "[stop]" && ap->has_animation(anim)) {
 		float len = ap->get_animation(anim)->get_length();
 
-		if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
-			len = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
+		float start_ofs = get_animation()->animation_track_get_key_start_offset(get_track(), p_index);
+		float end_ofs = get_animation()->animation_track_get_key_end_offset(get_track(), p_index);
+
+		if (len_resizing && p_index == len_resizing_index) {
+			float ofs_local = -len_resizing_rel / get_timeline()->get_zoom_scale();
+			if (len_resizing_start) {
+				start_ofs += ofs_local;
+				if (start_ofs < 0)
+					start_ofs = 0;
+			} else {
+				end_ofs += ofs_local;
+				if (end_ofs < 0)
+					end_ofs = 0;
+			}
+		}
+
+		len -= end_ofs;
+		len -= start_ofs;
+
+		if (len <= 0.001) {
+			len = 0.001;
 		}
 
 		int pixel_len = len * p_pixels_sec;
@@ -1181,14 +1209,21 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 		int from_x = MAX(pixel_begin, p_clip_left);
 		int to_x = MIN(pixel_end, p_clip_right);
 
+		if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
+			float limit = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
+			int limit_x = pixel_begin + limit * p_pixels_sec;
+			to_x = MIN(limit_x, to_x);
+		}
+
 		if (to_x <= from_x) {
-			return;
+			to_x = from_x + 1;
 		}
 
 		Ref<Font> font = get_theme_font("font", "Label");
 		int fh = font->get_height() * 1.5;
 
-		Rect2 rect(from_x, int(get_size().height - fh) / 2, to_x - from_x, fh);
+		int h = get_size().height;
+		Rect2 rect = Rect2(from_x, (h - fh) / 2, to_x - from_x, fh);
 
 		Color color = get_theme_color("font_color", "Label");
 		Color bg = color;
@@ -1232,6 +1267,15 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 			draw_string(font, Point2(from_x + 2, int(get_size().height - font->get_height()) / 2 + font->get_ascent()), anim, color);
 		}
 
+		Color cut_color = get_theme_color("accent_color", "Editor");
+		cut_color.a = 0.7;
+		if (start_ofs > 0 && pixel_begin > p_clip_left) {
+			draw_rect(Rect2(pixel_begin, rect.position.y, 1, rect.size.y), cut_color);
+		}
+		if (end_ofs > 0 && pixel_end < p_clip_right) {
+			draw_rect(Rect2(pixel_end, rect.position.y, 1, rect.size.y), cut_color);
+		}
+
 		if (p_selected) {
 			Color accent = get_theme_color("accent_color", "Editor");
 			draw_rect(rect, accent, false);
@@ -1249,6 +1293,103 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 			draw_rect(rect, accent, false);
 		}
 	}
+}
+
+void AnimationTrackEditTypeAnimation::_gui_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (!len_resizing && mm.is_valid()) {
+		bool use_hsize_cursor = false;
+		for (int i = 0; i < get_animation()->track_get_key_count(get_track()); i++) {
+			Object *object = ObjectDB::get_instance(id);
+
+			AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(object);
+
+			String anim = get_animation()->animation_track_get_key_animation(get_track(), i);
+
+			float start_ofs = get_animation()->animation_track_get_key_start_offset(get_track(), i);
+			float end_ofs = get_animation()->animation_track_get_key_end_offset(get_track(), i);
+			float len = 0;
+			if (anim != "[stop]" && ap->has_animation(anim)) {
+				len = ap->get_animation(anim)->get_length();
+			}
+
+			len -= end_ofs;
+			len -= start_ofs;
+			if (len <= 0.001) {
+				len = 0.001;
+			}
+
+			if (get_animation()->track_get_key_count(get_track()) > i + 1) {
+				len = MIN(len, get_animation()->track_get_key_time(get_track(), i + 1) - get_animation()->track_get_key_time(get_track(), i));
+			}
+
+			float ofs = get_animation()->track_get_key_time(get_track(), i);
+
+			ofs -= get_timeline()->get_value();
+			ofs *= get_timeline()->get_zoom_scale();
+			ofs += get_timeline()->get_name_limit();
+
+			int end = ofs + len * get_timeline()->get_zoom_scale();
+
+			if (end >= get_timeline()->get_name_limit() && end <= get_size().width - get_timeline()->get_buttons_width() && ABS(mm->get_position().x - end) < 5 * EDSCALE) {
+				use_hsize_cursor = true;
+				len_resizing_index = i;
+			}
+		}
+
+		if (use_hsize_cursor) {
+			set_default_cursor_shape(CURSOR_HSIZE);
+		} else {
+			set_default_cursor_shape(CURSOR_ARROW);
+		}
+	}
+
+	if (len_resizing && mm.is_valid()) {
+		len_resizing_rel += mm->get_relative().x;
+		len_resizing_start = mm->get_shift();
+		update();
+		accept_event();
+		return;
+	}
+
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT && get_default_cursor_shape() == CURSOR_HSIZE) {
+
+		len_resizing = true;
+		len_resizing_start = mb->get_shift();
+		len_resizing_from_px = mb->get_position().x;
+		len_resizing_rel = 0;
+		update();
+		accept_event();
+		return;
+	}
+
+	if (len_resizing && mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
+
+		float ofs_local = -len_resizing_rel / get_timeline()->get_zoom_scale();
+		if (len_resizing_start) {
+			float prev_ofs = get_animation()->animation_track_get_key_start_offset(get_track(), len_resizing_index);
+			get_undo_redo()->create_action(TTR("Change Animation Track Clip Start Offset"));
+			get_undo_redo()->add_do_method(get_animation().ptr(), "animation_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs + ofs_local);
+			get_undo_redo()->add_undo_method(get_animation().ptr(), "animation_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs);
+			get_undo_redo()->commit_action();
+
+		} else {
+			float prev_ofs = get_animation()->animation_track_get_key_end_offset(get_track(), len_resizing_index);
+			get_undo_redo()->create_action(TTR("Change Animation Track Clip End Offset"));
+			get_undo_redo()->add_do_method(get_animation().ptr(), "animation_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs + ofs_local);
+			get_undo_redo()->add_undo_method(get_animation().ptr(), "animation_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs);
+			get_undo_redo()->commit_action();
+		}
+
+		len_resizing = false;
+		len_resizing_index = -1;
+		update();
+		accept_event();
+		return;
+	}
+
+	AnimationTrackEdit::_gui_input(p_event);
 }
 
 void AnimationTrackEditTypeAnimation::set_node(Object *p_object) {

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -149,7 +149,7 @@ class AnimationTrackEditTypeAnimation : public AnimationTrackEdit {
 	float len_resizing_rel;
 
 public:
-	virtual void _gui_input(const Ref<InputEvent> &p_event);
+	virtual void _gui_input(const Ref<InputEvent> &p_event) override;
 
 	virtual int get_key_height() const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -142,7 +142,15 @@ class AnimationTrackEditTypeAnimation : public AnimationTrackEdit {
 
 	ObjectID id;
 
+	bool len_resizing;
+	bool len_resizing_start;
+	int len_resizing_index;
+	float len_resizing_from_px;
+	float len_resizing_rel;
+
 public:
+	virtual void _gui_input(const Ref<InputEvent> &p_event);
+
 	virtual int get_key_height() const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual bool is_key_selectable_by_distance() const override;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -683,69 +683,136 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 
 			} break;
 			case Animation::TYPE_ANIMATION: {
-				AnimationPlayer *player = Object::cast_to<AnimationPlayer>(nc->node);
-				if (!player) {
+				if (!nc->node)
 					continue;
+
+				AnimationPlayer *player = Object::cast_to<AnimationPlayer>(nc->node);
+				if (!player)
+					continue;
+
+				bool stop = false;
+
+				if (p_seeked)
+					nc->animation_idx = -1;
+
+				int idx = a->track_find_key(i, p_time);
+				if (idx != -1) {
+					StringName anim_name = a->animation_track_get_key_animation(i, idx);
+					if (String(anim_name) != "[stop]" && player->has_animation(anim_name)) {
+						BlockData &b = blockData;
+						get_animation_play_block(b, a, i, idx, p_time, player);
+						if (b.length > 0) { //on inside of clip
+							if (p_delta == 0 || p_seeked) { //on seeking
+								stop = true;
+
+								float local_pos = get_local_animation_pos(a, i, idx, p_time);
+
+								player->set_assigned_animation(anim_name);
+								player->seek(local_pos, true);
+
+							} else if (nc->animation_idx != idx) { //on playing
+								nc->animation_idx = idx;
+
+								float local_pos = get_local_animation_pos(a, i, idx, p_time);
+
+								int dir = sgn(p_delta);
+								bool fromEnd = (dir < 0);
+
+								player->play(anim_name, -1, speed_scale*dir, fromEnd);
+								player->seek(local_pos);
+
+								nc->animation_playing = true;
+								playing_caches.insert(nc);
+
+								nc->animation_start = b.pos;
+								nc->animation_len = b.length;
+							}
+
+						} else { //on outside of clip
+							if ((p_delta == 0 || p_seeked) || nc->animation_playing) {
+								stop = true;
+
+								float local_length = get_local_animation_end_pos(a, i, idx, player);
+
+								player->set_assigned_animation(anim_name);
+								player->seek(local_length, true);
+							}
+						}
+					} else {
+						stop = true;
+					}
 				}
 
-				if (p_delta == 0 || p_seeked) {
-					//seek
-					int idx = a->track_find_key(i, p_time);
-					if (idx < 0) {
-						continue;
-					}
+				if (!stop && nc->animation_playing) {
+					int dir = sgn(p_delta);
+					if ((dir > 0 && p_time < nc->animation_start) || (dir > 0 && p_time >= a->get_length()) || (dir < 0 && p_time > nc->animation_start) || (dir < 0 && p_time <= 0)) {
+						stop = true;
 
-					float pos = a->track_get_key_time(i, idx);
-
-					StringName anim_name = a->animation_track_get_key_animation(i, idx);
-					if (String(anim_name) == "[stop]" || !player->has_animation(anim_name)) {
-						continue;
-					}
-
-					Ref<Animation> anim = player->get_animation(anim_name);
-
-					float at_anim_pos;
-
-					if (anim->has_loop()) {
-						at_anim_pos = Math::fposmod(p_time - pos, anim->get_length()); //seek to loop
 					} else {
-						at_anim_pos = MAX(anim->get_length(), p_time - pos); //seek to end
-					}
-
-					if (player->is_playing() || p_seeked) {
-						player->play(anim_name);
-						player->seek(at_anim_pos);
-						nc->animation_playing = true;
-						playing_caches.insert(nc);
-					} else {
-						player->set_assigned_animation(anim_name);
-						player->seek(at_anim_pos, true);
-					}
-				} else {
-					//find stuff to play
-					List<int> to_play;
-					a->track_get_key_indices_in_range(i, p_time, p_delta, &to_play);
-					if (to_play.size()) {
-						int idx = to_play.back()->get();
-
-						StringName anim_name = a->animation_track_get_key_animation(i, idx);
-						if (String(anim_name) == "[stop]" || !player->has_animation(anim_name)) {
-							if (playing_caches.has(nc)) {
-								playing_caches.erase(nc);
-								player->stop();
-								nc->animation_playing = false;
-							}
-						} else {
-							player->play(anim_name);
-							nc->animation_playing = true;
-							playing_caches.insert(nc);
+						float animation_clamp_len = MAX(MIN((nc->animation_start + nc->animation_len), a->get_length()), 0);
+						float value = animation_clamp_len - p_time;
+						if (value <= 0) {
+							stop = true;
 						}
+					}
+				}
+
+				if (stop) {
+					if (playing_caches.has(nc)) {
+						playing_caches.erase(nc);
+						player->stop();
+						nc->animation_playing = false;
 					}
 				}
 
 			} break;
 		}
 	}
+}
+
+float AnimationPlayer::get_local_animation_pos(Animation *a, int p_track, int p_key, float p_time) {
+	return (p_time - a->track_get_key_time(p_track, p_key)) + a->animation_track_get_key_start_offset(p_track, p_key);
+}
+
+float AnimationPlayer::get_local_animation_end_pos(Animation *a, int p_track, int p_key, AnimationPlayer *player) {
+	StringName anim_name = a->animation_track_get_key_animation(p_track, p_key);
+	Ref<Animation> anim = player->get_animation(anim_name);
+	if (String(anim_name) != "[stop]" && player->has_animation(anim_name)) {
+		float end_ofs = a->animation_track_get_key_end_offset(p_track, p_key);
+		float length = anim->get_length();
+
+		return MIN(MAX(0, length - end_ofs), length);
+	}
+
+	return 0;
+}
+
+void AnimationPlayer::get_animation_play_block(BlockData &b, Animation *a, int p_track, int p_key, float p_time, AnimationPlayer *player) {
+	get_animation_block(b, a, p_track, p_key, player);
+	float local_pos = p_time - b.pos;
+	float newLen = b.length - local_pos;
+
+	b.pos = p_time;
+	b.length = newLen;
+}
+
+void AnimationPlayer::get_animation_block(BlockData &b, Animation *a, int p_track, int p_key, AnimationPlayer *player) {
+	StringName anim_name = a->animation_track_get_key_animation(p_track, p_key);
+	Ref<Animation> anim = player->get_animation(anim_name);
+	if (String(anim_name) != "[stop]" && player->has_animation(anim_name)) {
+		float start_ofs = a->animation_track_get_key_start_offset(p_track, p_key);
+		float end_ofs = a->animation_track_get_key_end_offset(p_track, p_key);
+		float length = anim->get_length();
+
+		length = MIN(MAX(0, length - start_ofs - end_ofs), length);
+
+		b.pos = a->track_get_key_time(p_track, p_key);
+		b.length = length;
+		return;
+	}
+
+	b.pos = a->track_get_key_time(p_track, p_key);
+	b.length = 0;
 }
 
 void AnimationPlayer::_animation_process_data(PlaybackData &cd, float p_delta, float p_blend, bool p_seeked, bool p_started) {
@@ -790,6 +857,11 @@ void AnimationPlayer::_animation_process_data(PlaybackData &cd, float p_delta, f
 		} else {
 			next_pos = looped_next_pos;
 		}
+	}
+
+	bool has_dir_changed = (sgn(delta) != sgn(next_pos - cd.pos));
+	if (has_dir_changed || cd.pos == 0 || cd.pos == len) {
+		p_seeked = true;
 	}
 
 	cd.pos = next_pos;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -718,7 +718,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, float 
 								int dir = sgn(p_delta);
 								bool fromEnd = (dir < 0);
 
-								player->play(anim_name, -1, speed_scale*dir, fromEnd);
+								player->play(anim_name, -1, speed_scale * dir, fromEnd);
 								player->seek(local_pos);
 
 								nc->animation_playing = true;

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -183,7 +183,6 @@ private:
 		float length;
 
 		BlockData() {
-
 			this->pos = -1;
 			this->length = -1;
 		}

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -71,6 +71,11 @@ public:
 	};
 
 private:
+	template <typename T>
+	int sgn(T val) {
+		return (T(0) < val) - (val < T(0));
+	}
+
 	enum {
 
 		NODE_CACHE_UPDATE_MAX = 1024,
@@ -105,6 +110,10 @@ private:
 		float audio_len = 0.0;
 
 		bool animation_playing = false;
+
+		int animation_idx;
+		float animation_start = 0.0;
+		float animation_len = 0.0;
 
 		struct PropertyAnim {
 			TrackNodeCache *owner = nullptr;
@@ -168,6 +177,17 @@ private:
 		Vector<TrackNodeCache *> node_cache;
 		Ref<Animation> animation;
 	};
+
+	struct BlockData {
+		float pos;
+		float length;
+
+		BlockData() {
+
+			this->pos = -1;
+			this->length = -1;
+		}
+	} blockData;
 
 	Map<StringName, AnimationData> animation_set;
 	struct BlendKey {
@@ -233,6 +253,12 @@ private:
 
 	void _node_removed(Node *p_node);
 	void _stop_playing_caches();
+
+	float get_local_animation_pos(Animation *a, int p_track, int p_key, float p_time);
+	float get_local_animation_end_pos(Animation *a, int p_track, int p_key, AnimationPlayer *player);
+
+	void get_animation_play_block(BlockData &b, Animation *a, int p_track, int p_key, float p_time, AnimationPlayer *player);
+	void get_animation_block(BlockData &b, Animation *a, int p_track, int p_key, AnimationPlayer *player);
 
 	// bind helpers
 	Vector<String> _get_animation_list() const {

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -283,7 +283,6 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 					an->values.clear();
 
 					for (int i = 0; i < valcount; i++) {
-
 						Dictionary d2 = clips[i];
 						if (!d2.has("start_offset"))
 							continue;
@@ -2529,7 +2528,6 @@ void Animation::animation_track_set_key_start_offset(int p_track, int p_key, flo
 }
 
 float Animation::animation_track_get_key_start_offset(int p_track, int p_key) const {
-
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
 	const Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_ANIMATION, 0);
@@ -2559,7 +2557,6 @@ void Animation::animation_track_set_key_end_offset(int p_track, int p_key, float
 }
 
 float Animation::animation_track_get_key_end_offset(int p_track, int p_key) const {
-
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
 	const Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_ANIMATION, 0);

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -271,7 +271,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				ERR_FAIL_COND_V(!d.has("clips"), false);
 
 				Vector<float> times = d["times"];
-				Vector<String> clips = d["clips"];
+				Array clips = d["clips"];
 
 				ERR_FAIL_COND_V(clips.size() != times.size(), false);
 
@@ -279,15 +279,26 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 					int valcount = times.size();
 
 					const float *rt = times.ptr();
-					const String *rc = clips.ptr();
 
-					an->values.resize(valcount);
+					an->values.clear();
 
 					for (int i = 0; i < valcount; i++) {
-						TKey<StringName> ak;
+
+						Dictionary d2 = clips[i];
+						if (!d2.has("start_offset"))
+							continue;
+						if (!d2.has("end_offset"))
+							continue;
+						if (!d2.has("animation"))
+							continue;
+
+						TKey<AnimationKey> ak;
 						ak.time = rt[i];
-						ak.value = rc[i];
-						an->values.write[i] = ak;
+						ak.value.start_offset = d2["start_offset"];
+						ak.value.end_offset = d2["end_offset"];
+						ak.value.animation = d2["animation"];
+
+						an->values.push_back(ak);
 					}
 				}
 
@@ -536,21 +547,27 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 				Dictionary d;
 
 				Vector<float> key_times;
-				Vector<String> clips;
+				Array clips;
 
 				int kk = an->values.size();
 
 				key_times.resize(kk);
-				clips.resize(kk);
+				//clips.resize(kk);
 
 				float *wti = key_times.ptrw();
-				String *wcl = clips.ptrw();
 
-				const TKey<StringName> *vls = an->values.ptr();
+				int idx = 0;
+
+				const TKey<AnimationKey> *vls = an->values.ptr();
 
 				for (int i = 0; i < kk; i++) {
-					wti[i] = vls[i].time;
-					wcl[i] = vls[i].value;
+					wti[idx] = vls[i].time;
+					Dictionary clip;
+					clip["start_offset"] = vls[i].value.start_offset;
+					clip["end_offset"] = vls[i].value.end_offset;
+					clip["animation"] = vls[i].value.animation;
+					clips.push_back(clip);
+					idx++;
 				}
 
 				d["times"] = key_times;
@@ -1037,10 +1054,16 @@ void Animation::track_insert_key(int p_track, float p_time, const Variant &p_key
 		case TYPE_ANIMATION: {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
 
-			TKey<StringName> ak;
-			ak.time = p_time;
-			ak.value = p_key;
+			Dictionary k = p_key;
+			ERR_FAIL_COND(!k.has("start_offset"));
+			ERR_FAIL_COND(!k.has("end_offset"));
+			ERR_FAIL_COND(!k.has("animation"));
 
+			TKey<AnimationKey> ak;
+			ak.time = p_time;
+			ak.value.start_offset = k["start_offset"];
+			ak.value.end_offset = k["end_offset"];
+			ak.value.animation = k["animation"];
 			_insert(p_time, at->values, ak);
 
 		} break;
@@ -1144,7 +1167,11 @@ Variant Animation::track_get_key_value(int p_track, int p_key_idx) const {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
 			ERR_FAIL_INDEX_V(p_key_idx, at->values.size(), Variant());
 
-			return at->values[p_key_idx].value;
+			Dictionary k;
+			k["start_offset"] = at->values[p_key_idx].value.start_offset;
+			k["end_offset"] = at->values[p_key_idx].value.end_offset;
+			k["animation"] = at->values[p_key_idx].value.animation;
+			return k;
 
 		} break;
 	}
@@ -1250,7 +1277,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, float p_time) {
 		case TYPE_ANIMATION: {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
 			ERR_FAIL_INDEX(p_key_idx, at->values.size());
-			TKey<StringName> key = at->values[p_key_idx];
+			TKey<AnimationKey> key = at->values[p_key_idx];
 			key.time = p_time;
 			at->values.remove(p_key_idx);
 			_insert(p_time, at->values, key);
@@ -1372,7 +1399,14 @@ void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
 			ERR_FAIL_INDEX(p_key_idx, at->values.size());
 
-			at->values.write[p_key_idx].value = p_value;
+			Dictionary k = p_value;
+			ERR_FAIL_COND(!k.has("start_offset"));
+			ERR_FAIL_COND(!k.has("end_offset"));
+			ERR_FAIL_COND(!k.has("animation"));
+
+			at->values.write[p_key_idx].value.start_offset = k["start_offset"];
+			at->values.write[p_key_idx].value.end_offset = k["end_offset"];
+			at->values.write[p_key_idx].value.animation = k["animation"];
 
 		} break;
 	}
@@ -2427,16 +2461,22 @@ float Animation::audio_track_get_key_end_offset(int p_track, int p_key) const {
 
 //
 
-int Animation::animation_track_insert_key(int p_track, float p_time, const StringName &p_animation) {
+int Animation::animation_track_insert_key(int p_track, float p_time, const StringName &p_animation, float p_start_offset, float p_end_offset) {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_ANIMATION, -1);
 
 	AnimationTrack *at = static_cast<AnimationTrack *>(t);
 
-	TKey<StringName> k;
+	TKey<AnimationKey> k;
 	k.time = p_time;
-	k.value = p_animation;
+	k.value.animation = p_animation;
+	k.value.start_offset = p_start_offset;
+	if (k.value.start_offset < 0)
+		k.value.start_offset = 0;
+	k.value.end_offset = p_end_offset;
+	if (k.value.end_offset < 0)
+		k.value.end_offset = 0;
 
 	int key = _insert(p_time, at->values, k);
 
@@ -2454,7 +2494,7 @@ void Animation::animation_track_set_key_animation(int p_track, int p_key, const 
 
 	ERR_FAIL_INDEX(p_key, at->values.size());
 
-	at->values.write[p_key].value = p_animation;
+	at->values.write[p_key].value.animation = p_animation;
 
 	emit_changed();
 }
@@ -2468,7 +2508,67 @@ StringName Animation::animation_track_get_key_animation(int p_track, int p_key) 
 
 	ERR_FAIL_INDEX_V(p_key, at->values.size(), StringName());
 
-	return at->values[p_key].value;
+	return at->values[p_key].value.animation;
+}
+
+void Animation::animation_track_set_key_start_offset(int p_track, int p_key, float p_offset) {
+	ERR_FAIL_INDEX(p_track, tracks.size());
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND(t->type != TYPE_ANIMATION);
+
+	AnimationTrack *at = static_cast<AnimationTrack *>(t);
+
+	ERR_FAIL_INDEX(p_key, at->values.size());
+
+	if (p_offset < 0)
+		p_offset = 0;
+
+	at->values.write[p_key].value.start_offset = p_offset;
+
+	emit_changed();
+}
+
+float Animation::animation_track_get_key_start_offset(int p_track, int p_key) const {
+
+	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
+	const Track *t = tracks[p_track];
+	ERR_FAIL_COND_V(t->type != TYPE_ANIMATION, 0);
+
+	const AnimationTrack *at = static_cast<const AnimationTrack *>(t);
+
+	ERR_FAIL_INDEX_V(p_key, at->values.size(), 0);
+
+	return at->values[p_key].value.start_offset;
+}
+
+void Animation::animation_track_set_key_end_offset(int p_track, int p_key, float p_offset) {
+	ERR_FAIL_INDEX(p_track, tracks.size());
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND(t->type != TYPE_ANIMATION);
+
+	AnimationTrack *at = static_cast<AnimationTrack *>(t);
+
+	ERR_FAIL_INDEX(p_key, at->values.size());
+
+	if (p_offset < 0)
+		p_offset = 0;
+
+	at->values.write[p_key].value.end_offset = p_offset;
+
+	emit_changed();
+}
+
+float Animation::animation_track_get_key_end_offset(int p_track, int p_key) const {
+
+	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
+	const Track *t = tracks[p_track];
+	ERR_FAIL_COND_V(t->type != TYPE_ANIMATION, 0);
+
+	const AnimationTrack *at = static_cast<const AnimationTrack *>(t);
+
+	ERR_FAIL_INDEX_V(p_key, at->values.size(), 0);
+
+	return at->values[p_key].value.end_offset;
 }
 
 void Animation::set_length(float p_length) {
@@ -2658,9 +2758,13 @@ void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("audio_track_get_key_start_offset", "track_idx", "key_idx"), &Animation::audio_track_get_key_start_offset);
 	ClassDB::bind_method(D_METHOD("audio_track_get_key_end_offset", "track_idx", "key_idx"), &Animation::audio_track_get_key_end_offset);
 
-	ClassDB::bind_method(D_METHOD("animation_track_insert_key", "track_idx", "time", "animation"), &Animation::animation_track_insert_key);
+	ClassDB::bind_method(D_METHOD("animation_track_insert_key", "track_idx", "time", "animation", "start_offset", "end_offset"), &Animation::animation_track_insert_key, DEFVAL(0), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("animation_track_set_key_animation", "track_idx", "key_idx", "animation"), &Animation::animation_track_set_key_animation);
 	ClassDB::bind_method(D_METHOD("animation_track_get_key_animation", "track_idx", "key_idx"), &Animation::animation_track_get_key_animation);
+	ClassDB::bind_method(D_METHOD("animation_track_set_key_start_offset", "track_idx", "key_idx", "offset"), &Animation::animation_track_set_key_start_offset);
+	ClassDB::bind_method(D_METHOD("animation_track_get_key_start_offset", "track_idx", "key_idx"), &Animation::animation_track_get_key_start_offset);
+	ClassDB::bind_method(D_METHOD("animation_track_set_key_end_offset", "track_idx", "key_idx", "offset"), &Animation::animation_track_set_key_end_offset);
+	ClassDB::bind_method(D_METHOD("animation_track_get_key_end_offset", "track_idx", "key_idx"), &Animation::animation_track_get_key_end_offset);
 
 	ClassDB::bind_method(D_METHOD("set_length", "time_sec"), &Animation::set_length);
 	ClassDB::bind_method(D_METHOD("get_length"), &Animation::get_length);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -170,8 +170,19 @@ private:
 
 	/* AUDIO TRACK */
 
+	struct AnimationKey {
+		StringName animation;
+		float start_offset; //offset from start
+		float end_offset; //offset from end, if 0 then full length or infinite
+		bool loop;
+		AnimationKey() {
+			start_offset = 0;
+			end_offset = 0;
+		}
+	};
+
 	struct AnimationTrack : public Track {
-		Vector<TKey<StringName>> values;
+		Vector<TKey<AnimationKey> > values;
 
 		AnimationTrack() {
 			type = TYPE_ANIMATION;
@@ -322,9 +333,13 @@ public:
 	float audio_track_get_key_start_offset(int p_track, int p_key) const;
 	float audio_track_get_key_end_offset(int p_track, int p_key) const;
 
-	int animation_track_insert_key(int p_track, float p_time, const StringName &p_animation);
+	int animation_track_insert_key(int p_track, float p_time, const StringName &p_animation, float p_start_offset = 0, float p_end_offset = 0);
 	void animation_track_set_key_animation(int p_track, int p_key, const StringName &p_animation);
 	StringName animation_track_get_key_animation(int p_track, int p_key) const;
+	void animation_track_set_key_start_offset(int p_track, int p_key, float p_offset);
+	float animation_track_get_key_start_offset(int p_track, int p_key) const;
+	void animation_track_set_key_end_offset(int p_track, int p_key, float p_offset);
+	float animation_track_get_key_end_offset(int p_track, int p_key) const;
 
 	void track_set_interpolation_loop_wrap(int p_track, bool p_enable);
 	bool track_get_interpolation_loop_wrap(int p_track) const;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -182,7 +182,7 @@ private:
 	};
 
 	struct AnimationTrack : public Track {
-		Vector<TKey<AnimationKey> > values;
+		Vector<TKey<AnimationKey>> values;
 
 		AnimationTrack() {
 			type = TYPE_ANIMATION;


### PR DESCRIPTION
Implemented start and end offset for AnimationTrack (like AudioTrack has). Several bugfixes on Animation playback included.

[![](https://img.youtube.com/vi/0t3_yYInLuY/0.jpg)](https://www.youtube.com/watch?v=0t3_yYInLuY)

- setting a start and end offset like AudioTrack has is now possible on AnimationTracks
- live-preview of animations are now possible in AnimationPlayer via Editor
- the correct last animation frame is now showing when going in AnimationPlayer on a empty area with the cursor
- backward playing of animations is now possible in AnimationPlayer
- overlapping areas ( < 0 and > length) of animations are now playing correctly in AnimationPlayer
- AnimationPlayer is now stopping on the correct time when AnimationTrack length is reached (loop off)
- serveral other fixes are made on AnimationTrack playback logic