### PR TITLE
Gdnative windows interface to obtain GL context info

### DIFF
--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -9,6 +9,7 @@ env_gdnative.add_source_files(env.modules_sources, "register_types.cpp")
 env_gdnative.add_source_files(env.modules_sources, "android/*.cpp")
 env_gdnative.add_source_files(env.modules_sources, "gdnative/*.cpp")
 env_gdnative.add_source_files(env.modules_sources, "nativescript/*.cpp")
+env_gdnative.add_source_files(env.modules_sources, "windows/*.cpp")
 env_gdnative.add_source_files(env.modules_sources, "gdnative_library_singleton_editor.cpp")
 env_gdnative.add_source_files(env.modules_sources, "gdnative_library_editor_plugin.cpp")
 

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -6651,6 +6651,29 @@
           ]
         }
       ]
+    },
+    {
+      "name": "windows",
+      "type": "WINDOWS",
+      "version": {
+        "major": 1,
+        "minor": 1
+      },
+      "next": null,
+      "api": [
+        {
+          "name": "godot_windows_get_hdc",
+          "return_type": "void *",
+          "arguments": [
+          ]
+        },
+        {
+          "name": "godot_windows_get_hglrc",
+          "return_type": "void *",
+          "arguments": [
+          ]
+        }
+      ]
     }
   ]
 }

--- a/modules/gdnative/gdnative_builders.py
+++ b/modules/gdnative/gdnative_builders.py
@@ -47,6 +47,7 @@ def _build_gdnative_api_struct_header(api):
         "#include <arvr/godot_arvr.h>",
         "#include <nativescript/godot_nativescript.h>",
         "#include <net/godot_net.h>",
+        "#include <windows/godot_windows.h>",
         "#include <pluginscript/godot_pluginscript.h>",
         "#include <videodecoder/godot_videodecoder.h>",
         "",

--- a/modules/gdnative/include/windows/godot_windows.h
+++ b/modules/gdnative/include/windows/godot_windows.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  context_gl_windows.h                                                 */
+/*  godot_windows.h                                                      */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,56 +28,29 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#if defined(OPENGL_ENABLED) || defined(GLES_ENABLED)
+#ifndef GODOT_WINDOWS_GDN_H
+#define GODOT_WINDOWS_GDN_H
 
-// Author: Juan Linietsky <reduzio@gmail.com>, (C) 2008
+#include <gdnative/gdnative.h>
 
-#ifndef CONTEXT_GL_WIN_H
-#define CONTEXT_GL_WIN_H
-
-#include "core/error_list.h"
-#include "core/os/os.h"
-
+/* for some reason including windows.h here makes things go boeboe so we always return as void *
+#ifdef WIN32
 #include <windows.h>
-
-typedef bool(APIENTRY *PFNWGLSWAPINTERVALEXTPROC)(int interval);
-typedef int(APIENTRY *PFNWGLGETSWAPINTERVALEXTPROC)(void);
-
-class ContextGL_Windows {
-
-	HDC hDC;
-	HGLRC hRC;
-	unsigned int pixel_format;
-	HWND hWnd;
-	bool opengl_3_context;
-	bool use_vsync;
-	bool vsync_via_compositor;
-
-	PFNWGLSWAPINTERVALEXTPROC wglSwapIntervalEXT;
-	PFNWGLGETSWAPINTERVALEXTPROC wglGetSwapIntervalEXT;
-
-	static bool should_vsync_via_compositor();
-
-public:
-	void release_current();
-
-	void make_current();
-
-	HDC get_hdc();
-	HGLRC get_hglrc();
-
-	int get_window_width();
-	int get_window_height();
-	void swap_buffers();
-
-	Error initialize();
-
-	void set_use_vsync(bool p_use);
-	bool is_using_vsync() const;
-
-	ContextGL_Windows(HWND hwnd, bool p_opengl_3_context);
-	~ContextGL_Windows();
-};
-
+#else
+#define HDC void *
+#define HGLRC void *
 #endif
+*/
+
+#ifdef __cplusplus
+extern "C" {
 #endif
+
+void *GDAPI godot_windows_get_hdc();
+void *GDAPI godot_windows_get_hglrc();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !GODOT_WINDOWS_GDN_H */

--- a/modules/gdnative/windows/windows_gdn.cpp
+++ b/modules/gdnative/windows/windows_gdn.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  context_gl_windows.h                                                 */
+/*  windows_gdn.cpp                                                      */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,56 +28,39 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#if defined(OPENGL_ENABLED) || defined(GLES_ENABLED)
+#include "modules/gdnative/gdnative.h"
 
-// Author: Juan Linietsky <reduzio@gmail.com>, (C) 2008
-
-#ifndef CONTEXT_GL_WIN_H
-#define CONTEXT_GL_WIN_H
-
-#include "core/error_list.h"
-#include "core/os/os.h"
-
-#include <windows.h>
-
-typedef bool(APIENTRY *PFNWGLSWAPINTERVALEXTPROC)(int interval);
-typedef int(APIENTRY *PFNWGLGETSWAPINTERVALEXTPROC)(void);
-
-class ContextGL_Windows {
-
-	HDC hDC;
-	HGLRC hRC;
-	unsigned int pixel_format;
-	HWND hWnd;
-	bool opengl_3_context;
-	bool use_vsync;
-	bool vsync_via_compositor;
-
-	PFNWGLSWAPINTERVALEXTPROC wglSwapIntervalEXT;
-	PFNWGLGETSWAPINTERVALEXTPROC wglGetSwapIntervalEXT;
-
-	static bool should_vsync_via_compositor();
-
-public:
-	void release_current();
-
-	void make_current();
-
-	HDC get_hdc();
-	HGLRC get_hglrc();
-
-	int get_window_width();
-	int get_window_height();
-	void swap_buffers();
-
-	Error initialize();
-
-	void set_use_vsync(bool p_use);
-	bool is_using_vsync() const;
-
-	ContextGL_Windows(HWND hwnd, bool p_opengl_3_context);
-	~ContextGL_Windows();
-};
-
+#ifdef WIN32
+#include "platform/windows/os_windows.h"
+/*
+#else
+#define HDC void *
+#define HGLRC void *
+*/
 #endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *GDAPI godot_windows_get_hdc() {
+#if defined(WIN32) && (defined(OPENGL_ENABLED) || defined(GLES_ENABLED))
+	OS_Windows *os_windows = (OS_Windows *)OS::get_singleton();
+	return os_windows->get_gl_context()->get_hdc();
+#else
+	return NULL;
+#endif
+}
+
+void *GDAPI godot_windows_get_hglrc() {
+#if defined(WIN32) && (defined(OPENGL_ENABLED) || defined(GLES_ENABLED))
+	OS_Windows *os_windows = (OS_Windows *)OS::get_singleton();
+	return os_windows->get_gl_context()->get_hglrc();
+#else
+	return NULL;
+#endif
+}
+
+#ifdef __cplusplus
+}
 #endif

--- a/platform/windows/context_gl_windows.cpp
+++ b/platform/windows/context_gl_windows.cpp
@@ -60,6 +60,14 @@ void ContextGL_Windows::make_current() {
 	wglMakeCurrent(hDC, hRC);
 }
 
+HDC ContextGL_Windows::get_hdc() {
+	return hDC;
+}
+
+HGLRC ContextGL_Windows::get_hglrc() {
+	return hRC;
+}
+
 int ContextGL_Windows::get_window_width() {
 
 	return OS::get_singleton()->get_video_mode().width;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1852,6 +1852,10 @@ void OS_Windows::finalize_core() {
 	NetSocketPosix::cleanup();
 }
 
+ContextGL_Windows *OS_Windows::get_gl_context() {
+	return gl_context;
+}
+
 void OS_Windows::alert(const String &p_alert, const String &p_title) {
 
 	if (!is_no_window_mode_enabled())

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -411,6 +411,8 @@ protected:
 public:
 	LRESULT WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
+	ContextGL_Windows *get_gl_context();
+
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 	String get_stdin_string(bool p_block);
 


### PR DESCRIPTION
This PR adds two access methods to GDNative that give GDNative modules access to the GL context created on Windows. We need access to these to make our new OpenXR module work on Windows. 