### PR TITLE
Highlight names of modified properties in the inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -262,6 +262,12 @@ void EditorProperty::_notification(int p_what) {
 			} else {
 				color = get_theme_color(is_read_only() ? SNAME("readonly_color") : SNAME("property_color"));
 			}
+
+			if (can_revert) {
+				// Property is modified from its default value; highlight it.
+				color = color.lerp(get_theme_color(SNAME("accent_color"), SNAME("Editor")), 0.6);
+			}
+
 			if (label.contains(".")) {
 				// FIXME: Move this to the project settings editor, as this is only used
 				// for project settings feature tag overrides.


### PR DESCRIPTION
This is more in line with how other software denotes modified properties in inspector-like controls.

## Preview

### Standard node

| Dark theme | Light theme |
|-|-|
| ![2022-06-19_07 02 12](https://user-images.githubusercontent.com/180032/174466837-2ad63f26-a96d-474e-8fad-ee86cd280b4c.png) | ![2022-06-19_07 01 41](https://user-images.githubusercontent.com/180032/174466836-a3cd1750-1b57-4ebd-83aa-eb9644969ea7.png) |

### Node edited via Editable Children

| Dark theme | Light theme |
|-|-|
| ![2022-06-19_07 05 06](https://user-images.githubusercontent.com/180032/174466838-0723e0fb-4758-494e-a452-f5adcd35ea2e.png) | ![2022-06-19_07 05 51](https://user-images.githubusercontent.com/180032/174466840-916597ba-2510-4232-bff2-eef9e1ebcf43.png) |