### PR TITLE
Fix 2D Particle velocity with directed emission mask

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -749,7 +749,11 @@ void CPUParticles2D::_particles_process(float p_delta) {
 					p.transform[2] = emission_points.get(random_idx);
 
 					if (emission_shape == EMISSION_SHAPE_DIRECTED_POINTS && emission_normals.size() == pc) {
-						p.velocity = emission_normals.get(random_idx);
+						Vector2 normal = emission_normals.get(random_idx);
+						Transform2D m2;
+						m2.set_axis(0, normal);
+						m2.set_axis(1, normal.tangent());
+						p.velocity = m2.basis_xform(p.velocity);
 					}
 
 					if (emission_colors.size() == pc) {

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -726,13 +726,15 @@ void CPUParticles3D::_particles_process(float p_delta) {
 
 					if (emission_shape == EMISSION_SHAPE_DIRECTED_POINTS && emission_normals.size() == pc) {
 						if (flags[FLAG_DISABLE_Z]) {
-							/*
-							mat2 rotm;
-							";
-									rotm[0] = texelFetch(emission_texture_normal, emission_tex_ofs, 0).xy;
-							rotm[1] = rotm[0].yx * vec2(1.0, -1.0);
-							VELOCITY.xy = rotm * VELOCITY.xy;
-							*/
+							Vector3 normal = emission_normals.get(random_idx);
+							Vector2 normal_2d(normal.x, normal.y);
+							Transform2D m2;
+							m2.set_axis(0, normal_2d);
+							m2.set_axis(1, normal_2d.tangent());
+							Vector2 velocity_2d(p.velocity.x, p.velocity.y);
+							velocity_2d = m2.basis_xform(velocity_2d);
+							p.velocity.x = velocity_2d.x;
+							p.velocity.y = velocity_2d.y;
 						} else {
 							Vector3 normal = emission_normals.get(random_idx);
 							Vector3 v0 = Math::abs(normal.z) < 0.999 ? Vector3(0.0, 0.0, 1.0) : Vector3(0, 1.0, 0.0);


### PR DESCRIPTION
Changed CPU velocity calculation for `EMISSION_SHAPE_DIRECTED_POINTS` to follow the same logic as in the GPU version:
```
mat2 rotm;
rotm[0] = texelFetch(emission_texture_normal, emission_tex_ofs, 0).xy;
rotm[1] = rotm[0].yx * vec2(1.0, -1.0);
VELOCITY.xy = rotm * VELOCITY.xy;
```

Now both `CPUParticles2D` & `CPUParticles3D` (z disabled) show the same results as their GPU counterparts and take the initial velocity settings into account.

Tested on 3.2 branch only because CPU particles are currently not supported on master.
Fixes #40807