### PR TITLE
Set resource path on load.

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -1893,6 +1893,10 @@ Error Image::load(const String &p_path) {
 		WARN_PRINTS("Loaded resource as image file, this will not work on export: '" + p_path + "'. Instead, import the image file as an Image resource and load it normally as a resource.");
 	}
 #endif
+	if (get_path() == String()) {
+		//temporarily set path if no path set for resource, helps find errors
+		set_path(p_path, true);
+	}
 	return ImageLoader::load_image(p_path, this);
 }
 

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -243,6 +243,10 @@ Error ImageTexture::load(const String &p_path) {
 	if (err == OK) {
 		create_from_image(img);
 	}
+	if (get_path() == String()) {
+		//temporarily set path if no path set for resource, helps find errors
+		set_path(p_path, true);
+	}
 	return err;
 }
 #endif
@@ -725,7 +729,7 @@ Error StreamTexture::load(const String &p_path) {
 
 	if (get_path() == String()) {
 		//temporarily set path if no path set for resource, helps find errors
-		VisualServer::get_singleton()->texture_set_path(texture, p_path);
+		set_path(p_path, true);
 	}
 	VS::get_singleton()->texture_allocate(texture, image->get_width(), image->get_height(), 0, image->get_format(), VS::TEXTURE_TYPE_2D, lflags);
 	VS::get_singleton()->texture_set_data(texture, image);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes #39881

Calling `get_path()` returns null for certain resources after their `load()` function is used. For `StreamTexture` a block of code intended to set the resource path in the load function does not actually do so. This fix rectifies that block, and adds a similar changes to `ImageTexture` and `Image` . More information [here](https://github.com/godotengine/godot/issues/39881#issuecomment-670953617)