### PR TITLE
Create default_env.tres with the same format used to save it

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -475,10 +475,12 @@ private:
 							set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
 						} else {
 							f->store_line("[gd_resource type=\"Environment\" load_steps=2 format=2]");
+							f->store_line("");
 							f->store_line("[sub_resource type=\"Sky\" id=1]");
+							f->store_line("");
 							f->store_line("[resource]");
 							f->store_line("background_mode = 2");
-							f->store_line("background_sky = SubResource( 1 )");
+							f->store_line("sky = SubResource( 1 )");
 							memdelete(f);
 						}
 					}


### PR DESCRIPTION
The project manager was generating a `default_env.tres` without newlines and the old `background_sky` property which is renamed to `sky` in 4.0. This PR makes the generation consistent with how it will be saved by the editor to prevent unnecessary diffs.