### PR TITLE
[Windows, 3.2] Attach to parent console instead of creating new one.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2745,10 +2745,8 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		} break;
 		case SETTINGS_TOGGLE_CONSOLE: {
-
 			bool was_visible = OS::get_singleton()->is_console_visible();
 			OS::get_singleton()->set_console_visible(!was_visible);
-			EditorSettings::get_singleton()->set_setting("interface/editor/hide_console_window", was_visible);
 		} break;
 		case EDITOR_SCREENSHOT: {
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -340,7 +340,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	hints["interface/editor/unfocused_low_processor_mode_sleep_usec"] = PropertyInfo(Variant::REAL, "interface/editor/unfocused_low_processor_mode_sleep_usec", PROPERTY_HINT_RANGE, "1,100000,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 	_initial_set("interface/editor/separate_distraction_mode", false);
 	_initial_set("interface/editor/automatically_open_screenshots", true);
-	_initial_set("interface/editor/hide_console_window", false);
 	_initial_set("interface/editor/save_each_scene_on_quit", true); // Regression
 	_initial_set("interface/editor/quit_confirmation", true);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1985,10 +1985,6 @@ bool Main::start() {
 		}
 
 		if (project_manager || editor) {
-			// Hide console window if requested (Windows-only).
-			bool hide_console = EditorSettings::get_singleton()->get_setting("interface/editor/hide_console_window");
-			OS::get_singleton()->set_console_visible(!hide_console);
-
 			// Load SSL Certificates from Editor Settings (or builtin)
 			Crypto::load_default_certificates(EditorSettings::get_singleton()->get_setting("network/ssl/editor_ssl_certificates").operator String());
 		}

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -181,7 +181,6 @@ def configure_msvc(env, manual_msvc_config):
             env.Append(CCFLAGS=["/O2"])
         else:  # optimize for size
             env.Append(CCFLAGS=["/O1"])
-        env.Append(LINKFLAGS=["/SUBSYSTEM:WINDOWS"])
         env.Append(LINKFLAGS=["/ENTRY:mainCRTStartup"])
         env.Append(LINKFLAGS=["/OPT:REF"])
 
@@ -191,14 +190,14 @@ def configure_msvc(env, manual_msvc_config):
         else:  # optimize for size
             env.Append(CCFLAGS=["/O1"])
         env.AppendUnique(CPPDEFINES=["DEBUG_ENABLED"])
-        env.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
         env.Append(LINKFLAGS=["/OPT:REF"])
 
     elif env["target"] == "debug":
         env.AppendUnique(CCFLAGS=["/Z7", "/Od", "/EHsc"])
         env.AppendUnique(CPPDEFINES=["DEBUG_ENABLED"])
-        env.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
         env.Append(LINKFLAGS=["/DEBUG"])
+
+    env.Append(LINKFLAGS=["/SUBSYSTEM:WINDOWS"])
 
     if env["debug_symbols"] == "full" or env["debug_symbols"] == "yes":
         env.AppendUnique(CCFLAGS=["/Z7"])
@@ -304,8 +303,6 @@ def configure_mingw(env):
         else:  # optimize for size
             env.Prepend(CCFLAGS=["-Os"])
 
-        env.Append(LINKFLAGS=["-Wl,--subsystem,windows"])
-
         if env["debug_symbols"] == "yes":
             env.Prepend(CCFLAGS=["-g1"])
         if env["debug_symbols"] == "full":
@@ -326,6 +323,8 @@ def configure_mingw(env):
     elif env["target"] == "debug":
         env.Append(CCFLAGS=["-g3"])
         env.Append(CPPDEFINES=["DEBUG_ENABLED"])
+
+    env.Append(LINKFLAGS=["-Wl,--subsystem,windows"])
 
     ## Compiler configuration
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -406,6 +406,7 @@ protected:
 	bool borderless;
 	bool window_focused;
 	bool console_visible;
+	bool own_console;
 	bool was_maximized;
 
 public:


### PR DESCRIPTION
Same as #41164 for 3.2.