### PR TITLE
Sort points in a Gradient for color and offset updates.

### DIFF
--- a/scene/resources/gradient.cpp
+++ b/scene/resources/gradient.cpp
@@ -141,32 +141,29 @@ void Gradient::set_points(Vector<Gradient::Point> &p_points) {
 }
 
 void Gradient::set_offset(int pos, const float offset) {
-	ERR_FAIL_COND(pos < 0);
-	if (points.size() <= pos) {
-		points.resize(pos + 1);
-	}
+	ERR_FAIL_INDEX(pos, points.size());
+	_update_sorting();
 	points.write[pos].offset = offset;
 	is_sorted = false;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
 
-float Gradient::get_offset(int pos) const {
+float Gradient::get_offset(int pos) {
 	ERR_FAIL_INDEX_V(pos, points.size(), 0.0);
+	_update_sorting();
 	return points[pos].offset;
 }
 
 void Gradient::set_color(int pos, const Color &color) {
-	ERR_FAIL_COND(pos < 0);
-	if (points.size() <= pos) {
-		points.resize(pos + 1);
-		is_sorted = false;
-	}
+	ERR_FAIL_INDEX(pos, points.size());
+	_update_sorting();
 	points.write[pos].color = color;
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }
 
-Color Gradient::get_color(int pos) const {
+Color Gradient::get_color(int pos) {
 	ERR_FAIL_INDEX_V(pos, points.size(), Color());
+	_update_sorting();
 	return points[pos].color;
 }
 

--- a/scene/resources/gradient.h
+++ b/scene/resources/gradient.h
@@ -49,6 +49,12 @@ public:
 private:
 	Vector<Point> points;
 	bool is_sorted;
+	_FORCE_INLINE_ void _update_sorting() {
+		if (!is_sorted) {
+			points.sort();
+			is_sorted = true;
+		}
+	}
 
 protected:
 	static void _bind_methods();
@@ -64,10 +70,10 @@ public:
 	Vector<Point> &get_points();
 
 	void set_offset(int pos, const float offset);
-	float get_offset(int pos) const;
+	float get_offset(int pos);
 
 	void set_color(int pos, const Color &color);
-	Color get_color(int pos) const;
+	Color get_color(int pos);
 
 	void set_offsets(const Vector<float> &p_offsets);
 	Vector<float> get_offsets() const;
@@ -80,10 +86,7 @@ public:
 			return Color(0, 0, 0, 1);
 		}
 
-		if (!is_sorted) {
-			points.sort();
-			is_sorted = true;
-		}
+		_update_sorting();
 
 		//binary search
 		int low = 0;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes #41136

Points in a Gradient are now sorted by offset if required for each `get_offset`, `set_offset`, `get_color` and `set_color` call, instead of only during `interpolate` calls.