### PR TITLE
[iOS] [4.0] Simplify OS value retrieval

### DIFF
--- a/platform/iphone/godot_view_renderer.mm
+++ b/platform/iphone/godot_view_renderer.mm
@@ -44,7 +44,6 @@
 
 @interface GodotViewRenderer ()
 
-@property(assign, nonatomic) BOOL hasFinishedLocaleSetup;
 @property(assign, nonatomic) BOOL hasFinishedProjectDataSetup;
 @property(assign, nonatomic) BOOL hasStartedMain;
 @property(assign, nonatomic) BOOL hasFinishedSetup;
@@ -58,9 +57,8 @@
 		return NO;
 	}
 
-	if (!self.hasFinishedLocaleSetup) {
-		[self setupLocaleAndUUID];
-		return YES;
+	if (!OS::get_singleton()) {
+		exit(0);
 	}
 
 	if (!self.hasFinishedProjectDataSetup) {
@@ -77,33 +75,6 @@
 	self.hasFinishedSetup = YES;
 
 	return NO;
-}
-
-- (void)setupLocaleAndUUID {
-	self.hasFinishedLocaleSetup = YES;
-
-	if (!OS::get_singleton()) {
-		exit(0);
-	}
-
-	NSString *locale_code = [[NSLocale currentLocale] localeIdentifier];
-	OSIPhone::get_singleton()->set_locale(String::utf8([locale_code UTF8String]));
-
-	NSString *uuid;
-	if ([[UIDevice currentDevice] respondsToSelector:@selector(identifierForVendor)]) {
-		uuid = [UIDevice currentDevice].identifierForVendor.UUIDString;
-	} else {
-		// before iOS 6, so just generate an identifier and store it
-		uuid = [[NSUserDefaults standardUserDefaults] objectForKey:@"identiferForVendor"];
-		if (!uuid) {
-			CFUUIDRef cfuuid = CFUUIDCreate(NULL);
-			uuid = [(NSString *)CFUUIDCreateString(NULL, cfuuid) autorelease];
-			CFRelease(cfuuid);
-			[[NSUserDefaults standardUserDefaults] setObject:uuid forKey:@"identifierForVendor"];
-		}
-	}
-
-	OSIPhone::get_singleton()->set_unique_id(String::utf8([uuid UTF8String]));
 }
 
 - (void)setupProjectData {

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -84,8 +84,6 @@ private:
 	virtual void finalize() override;
 
 	String user_data_dir;
-	String unique_id;
-	String locale_code;
 
 	bool is_focused = false;
 
@@ -118,10 +116,8 @@ public:
 	void set_user_data_dir(String p_dir);
 	virtual String get_user_data_dir() const override;
 
-	void set_locale(String p_locale);
 	virtual String get_locale() const override;
 
-	void set_unique_id(String p_id);
 	virtual String get_unique_id() const override;
 
 	virtual void vibrate_handheld(int p_duration_ms = 500) override;

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -305,20 +305,20 @@ String OSIPhone::get_user_data_dir() const {
 	return user_data_dir;
 }
 
-void OSIPhone::set_locale(String p_locale) {
-	locale_code = p_locale;
-}
-
 String OSIPhone::get_locale() const {
-	return locale_code;
-}
+	NSString *preferedLanguage = [NSLocale preferredLanguages].firstObject;
 
-void OSIPhone::set_unique_id(String p_id) {
-	unique_id = p_id;
+	if (preferedLanguage) {
+		return String::utf8([preferedLanguage UTF8String]).replace("-", "_");
+	}
+
+	NSString *localeIdentifier = [[NSLocale currentLocale] localeIdentifier];
+	return String::utf8([localeIdentifier UTF8String]).replace("-", "_");
 }
 
 String OSIPhone::get_unique_id() const {
-	return unique_id;
+	NSString *uuid = [UIDevice currentDevice].identifierForVendor.UUIDString;
+	return String::utf8([uuid UTF8String]);
 }
 
 void OSIPhone::vibrate_handheld(int p_duration_ms) {


### PR DESCRIPTION
Simplifies the way `locale` and `unique_id` is retrieved.
Also fixes `locale` returning incorrect parameters.

Issue related to `locale`, fixed #41058

`locale` also uses @bruvzg fix from #40708