### PR TITLE
[iOS] [3.2] Simplify OS values retrieval

### DIFF
--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -4,7 +4,7 @@ Import("env")
 
 iphone_lib = [
     "godot_iphone.cpp",
-    "os_iphone.cpp",
+    "os_iphone.mm",
     "semaphore_iphone.cpp",
     "gl_view.mm",
     "main.m",

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -438,30 +438,6 @@ static int frame_count = 0;
 			};
 			++frame_count;
 
-			NSString *locale_code = [[NSLocale currentLocale] localeIdentifier];
-			OSIPhone::get_singleton()->set_locale(
-					String::utf8([locale_code UTF8String]));
-
-			NSString *uuid;
-			if ([[UIDevice currentDevice]
-						respondsToSelector:@selector(identifierForVendor)]) {
-				uuid = [UIDevice currentDevice].identifierForVendor.UUIDString;
-			} else {
-				// before iOS 6, so just generate an identifier and store it
-				uuid = [[NSUserDefaults standardUserDefaults]
-						objectForKey:@"identiferForVendor"];
-				if (!uuid) {
-					CFUUIDRef cfuuid = CFUUIDCreate(NULL);
-					uuid = (__bridge_transfer NSString *)CFUUIDCreateString(NULL, cfuuid);
-					CFRelease(cfuuid);
-					[[NSUserDefaults standardUserDefaults]
-							setObject:uuid
-							   forKey:@"identifierForVendor"];
-				}
-			}
-
-			OSIPhone::get_singleton()->set_unique_id(String::utf8([uuid UTF8String]));
-
 		}; break;
 
 		case 1: {

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -109,8 +109,6 @@ private:
 	void queue_event(const Ref<InputEvent> &p_event);
 
 	String data_dir;
-	String unique_id;
-	String locale_code;
 
 	InputDefault *input;
 
@@ -183,10 +181,8 @@ public:
 
 	String get_user_data_dir() const;
 
-	void set_locale(String p_locale);
 	String get_locale() const;
 
-	void set_unique_id(String p_id);
 	String get_unique_id() const;
 
 	virtual Error native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track);

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  os_iphone.cpp                                                        */
+/*  os_iphone.mm                                                         */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -47,6 +47,7 @@
 
 #include "semaphore_iphone.h"
 
+#import <UIKit/UIKit.h>
 #include <dlfcn.h>
 
 int OSIPhone::get_video_driver_count() const {
@@ -81,14 +82,9 @@ void OSIPhone::set_data_dir(String p_dir) {
 	memdelete(da);
 };
 
-void OSIPhone::set_unique_id(String p_id) {
-
-	unique_id = p_id;
-};
-
 String OSIPhone::get_unique_id() const {
-
-	return unique_id;
+	NSString *uuid = [UIDevice currentDevice].identifierForVendor.UUIDString;
+	return String::utf8([uuid UTF8String]);
 };
 
 void OSIPhone::initialize_core() {
@@ -542,12 +538,15 @@ bool OSIPhone::has_touchscreen_ui_hint() const {
 	return true;
 }
 
-void OSIPhone::set_locale(String p_locale) {
-	locale_code = p_locale;
-}
-
 String OSIPhone::get_locale() const {
-	return locale_code;
+	NSString *preferedLanguage = [NSLocale preferredLanguages].firstObject;
+
+	if (preferedLanguage) {
+		return String::utf8([preferedLanguage UTF8String]).replace("-", "_");
+	}
+
+	NSString *localeIdentifier = [[NSLocale currentLocale] localeIdentifier];
+	return String::utf8([localeIdentifier UTF8String]).replace("-", "_");
 }
 
 extern bool _play_video(String p_path, float p_volume, String p_audio_track, String p_subtitle_track);


### PR DESCRIPTION
Port of #41172 to `3.2`

> Simplifies the way `locale` and `unique_id` is retrieved.
> Also fixes `locale` returning incorrect parameters.
