### PR TITLE
Fix inconsistent indentation in the FreeDesktop MIME type XML

### DIFF
--- a/misc/dist/linux/x-godot-project.xml
+++ b/misc/dist/linux/x-godot-project.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
- <mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
-   <mime-type type="application/x-godot-project">
-   <comment>Godot Engine project</comment>
-   <icon name="godot" />
-   <glob pattern="*.godot" weight="100" />
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/x-godot-project">
+    <comment>Godot Engine project</comment>
+    <icon name="godot" />
+    <glob pattern="*.godot" weight="100" />
   </mime-type>
 </mime-info>


### PR DESCRIPTION
The MIME type still works with inconsistent indentation, but we may want to fix it anyway.