### PR TITLE
[macOS] Fix crash on failed `fork`.

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -323,7 +323,7 @@ Error OS_Unix::execute(const String &p_path, const List<String> &p_arguments, bo
 		execvp(p_path.utf8().get_data(), &args[0]);
 		// still alive? something failed..
 		fprintf(stderr, "**ERROR** OS_Unix::execute - Could not create child process while executing: %s\n", p_path.utf8().get_data());
-		abort();
+		raise(SIGKILL);
 	}
 
 	if (p_blocking) {


### PR DESCRIPTION
Use `SIGKILL` instead of `SIGABRT`. This should not have any negative effects, but probably we should make `NSTask` based implementation at some point (see #17629).

Fixes #17615