### PR TITLE
Accept global classes  for `MainLoop` type in project settings

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1730,7 +1730,6 @@ bool Main::start() {
 		}
 	}
 
-	String main_loop_type;
 #ifdef TOOLS_ENABLED
 	if (doc_tool != "") {
 		Engine::get_singleton()->set_editor_hint(
@@ -1825,6 +1824,7 @@ bool Main::start() {
 	if (editor) {
 		main_loop = memnew(SceneTree);
 	};
+	String main_loop_type = GLOBAL_DEF("application/run/main_loop_type", "SceneTree");
 
 	if (script != "") {
 		Ref<Script> script_res = ResourceLoader::load(script);
@@ -1855,9 +1855,23 @@ bool Main::start() {
 		} else {
 			return false;
 		}
-
-	} else {
-		main_loop_type = GLOBAL_DEF("application/run/main_loop_type", "");
+	} else { // Not based on script path.
+		if (!editor && !ClassDB::class_exists(main_loop_type) && ScriptServer::is_global_class(main_loop_type)) {
+			String script_path = ScriptServer::get_global_class_path(main_loop_type);
+			Ref<Script> script_res = ResourceLoader::load(script_path);
+			StringName script_base = ScriptServer::get_global_class_native_base(main_loop_type);
+			Object *obj = ClassDB::instance(script_base);
+			MainLoop *script_loop = Object::cast_to<MainLoop>(obj);
+			if (!script_loop) {
+				if (obj) {
+					memdelete(obj);
+				}
+				DisplayServer::get_singleton()->alert("Error: Invalid MainLoop script base type: " + script_base);
+				ERR_FAIL_V_MSG(false, vformat("The global class %s does not inherit from SceneTree or MainLoop.", main_loop_type));
+			}
+			script_loop->set_init_script(script_res);
+			main_loop = script_loop;
+		}
 	}
 
 	if (!main_loop && main_loop_type == "") {


### PR DESCRIPTION
Fixes #35822.
Helps godotengine/godot-proposals#1349.

The `application/run/main_loop_type` setting can handle custom global classes now (classes exposed with `class_name` keyword).  For instance: `MySceneTree`.

The setting's default is changed from empty to `SceneTree` as to give some hint of what kind of input is accepted for the main loop type.

![Main Loop Type](https://user-images.githubusercontent.com/17108460/89928477-8eb47500-dc10-11ea-818d-deb817385020.png)

Tested on both editor and release builds.

Some custom scene tree class:
```gdscript
class_name MySceneTree extends SceneTree

func _initialize():
	print("MySceneTree startup!")

func _finalize():
	print("MySceneTree cleanup!")

func _iteration(_delta):
	return false

func _drop_files(files, from_screen):
	print(files, " ", from_screen)
```

Test project:

[global_class_main_loop.zip](https://github.com/godotengine/godot/files/5058401/global_class_main_loop.zip)
