### PR TITLE
Allow for loop with underscore (_) as variable, not creating an identifier

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1923,7 +1923,9 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 				codegen.alloc_stack(slevel);
 
 				codegen.push_stack_identifiers();
-				codegen.add_stack_identifier(for_n->variable->name, iter_stack_pos);
+				if (for_n->variable) {
+					codegen.add_stack_identifier(for_n->variable->name, iter_stack_pos);
+				}
 
 				int ret2 = _parse_expression(codegen, for_n->list, slevel, false);
 				if (ret2 < 0) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1465,8 +1465,12 @@ GDScriptParser::ContinueNode *GDScriptParser::parse_continue() {
 GDScriptParser::ForNode *GDScriptParser::parse_for() {
 	ForNode *n_for = alloc_node<ForNode>();
 
-	if (consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected loop variable name after "for".)")) {
+	if (match(GDScriptTokenizer::Token::IDENTIFIER)) {
 		n_for->variable = parse_identifier();
+	} else if (match(GDScriptTokenizer::Token::UNDERSCORE)) {
+		n_for->variable = nullptr;
+	} else {
+		push_error(R"(Expected loop variable name after "for".)");
 	}
 
 	consume(GDScriptTokenizer::Token::IN, R"(Expected "in" after "for" variable name.)");


### PR DESCRIPTION
Please see https://github.com/godotengine/godot-proposals/issues/1282 and especially https://github.com/godotengine/godot-proposals/issues/1282#issuecomment-669485182.

This does not include the second part of the proposal (the one were you can have anonymous variables like `var _ = xxx`).

This change allows one to do the following:

```
extends Node2D

func _ready() -> void:
	# Gives a warning (not in v4 yet?)
	for i in range(5):
		print("Hello")
		
	# NEW: without variable
	for _ in range(5):
		print("Hello")
		# Gives error
		# print(_)
```

cc @Calinou 
cc @peterhoglund