### PR TITLE
The UndoRedo class has been extended to make it more useful for its own use in addition to internal use by the engine itself.

### DIFF
--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -256,6 +256,13 @@ void UndoRedo::commit_action() {
 	committing++;
 	redo(); // perform action
 	committing--;
+
+	if (max_actions > 0 && actions.size() > max_actions) {
+		//clear early steps
+		while (actions.size() > max_actions)
+			_pop_history_tail();
+	}
+
 	if (callback && actions.size() > 0) {
 		callback(callback_ud, actions[actions.size() - 1].name);
 	}
@@ -370,6 +377,22 @@ String UndoRedo::get_current_action_name() const {
 		return "";
 	}
 	return actions[current_action].name;
+}
+
+int UndoRedo::get_action_count() const {
+	return actions.size();
+}
+
+int UndoRedo::get_current_action() const {
+	return current_action;
+}
+
+void UndoRedo::set_max_actions(int p_max_actions) {
+	max_actions = p_max_actions;
+}
+
+int UndoRedo::get_max_actions() const {
+	return max_actions;
 }
 
 bool UndoRedo::has_undo() {
@@ -506,6 +529,10 @@ void UndoRedo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_undo_reference", "object"), &UndoRedo::add_undo_reference);
 	ClassDB::bind_method(D_METHOD("clear_history", "increase_version"), &UndoRedo::clear_history, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_current_action_name"), &UndoRedo::get_current_action_name);
+	ClassDB::bind_method(D_METHOD("set_max_actions", "max_actions"), &UndoRedo::set_max_actions);
+	ClassDB::bind_method(D_METHOD("get_max_actions"), &UndoRedo::get_max_actions);
+	ClassDB::bind_method(D_METHOD("get_action_count"), &UndoRedo::get_action_count);
+	ClassDB::bind_method(D_METHOD("get_current_action"), &UndoRedo::get_current_action);
 	ClassDB::bind_method(D_METHOD("has_undo"), &UndoRedo::has_undo);
 	ClassDB::bind_method(D_METHOD("has_redo"), &UndoRedo::has_redo);
 	ClassDB::bind_method(D_METHOD("get_version"), &UndoRedo::get_version);

--- a/core/undo_redo.h
+++ b/core/undo_redo.h
@@ -77,6 +77,7 @@ private:
 	Vector<Action> actions;
 	int current_action = -1;
 	int action_level = 0;
+	int max_actions = -1;
 	MergeMode merge_mode = MERGE_DISABLE;
 	bool merging = false;
 	uint64_t version = 1;
@@ -114,6 +115,10 @@ public:
 	bool redo();
 	bool undo();
 	String get_current_action_name() const;
+	int get_action_count() const;
+	int get_current_action() const;
+	void set_max_actions(int p_max_actions);
+	int get_max_actions() const;
 	void clear_history(bool p_increase_version = true);
 
 	bool has_undo();

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -133,6 +133,36 @@
 				Gets the name of the current action.
 			</description>
 		</method>
+		<method name="get_action_count" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Gets the ammount of actions.
+			</description>
+		</method>
+		<method name="get_current_action" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Gets the index of the current action.
+			</description>
+		</method>
+		<method name="set_max_actions">
+			<return type="void">
+			</return>
+			<argument index="0" name="max_actions" type="int">
+			</argument>
+			<description>
+				Sets the max ammount of actions. If [code]max_actions[/code] is [code]-1[/code], there is no limit of actions.
+			</description>
+		</method>
+		<method name="get_max_actions" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the max ammount of actions. Returns [code]-1[/code], when there is no limit of actions.
+			</description>
+		</method>
 		<method name="get_version" qualifiers="const">
 			<return type="int">
 			</return>


### PR DESCRIPTION
`int get_action_count() const;`
> Gets the amount of actions.

`int get_current_action() const;`
> Gets the index of the current action.

`void set_max_actions(int p_max_actions);`
> Sets the max amount of actions. If max_actions is -1, there is no limit of actions.

`int get_max_actions() const;`
> Returns the max amount of actions. Returns -1, when there is no limit of actions.