### PR TITLE
Mark the first shape as inside, not the second shape, when CSG shapes are co-planer.

### DIFF
--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -583,8 +583,8 @@ bool CSGBrushOperation::MeshMerge::_bvh_inside(FaceBVH *facebvhptr, int p_max_de
 							// Check if faces are co-planar.
 							if ((current_normal - face_normal).length_squared() < CMP_EPSILON2 &&
 									is_point_in_triangle(face_center, current_points)) {
-								// Only add an intersection if checking a B face.
-								if (face.from_b) {
+								// Only add an intersection if not a B face.
+								if (!face.from_b) {
 									_add_distance(intersectionsA, intersectionsB, current_face.from_b, 0);
 								}
 							} else if (ray_intersects_triangle(face_center, face_normal, current_points, CMP_EPSILON, intersection_point)) {


### PR DESCRIPTION
Fixes #38001. 
