### PR TITLE
Bug/lsp ignore $ notifications

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -89,6 +89,8 @@ protected:
 
 	Dictionary initialize(const Dictionary &p_params);
 	void initialized(const Variant &p_params);
+	void cancelRequest(const Dictionary &p_params);
+	void progress(const Dictionary &p_params);
 
 public:
 	_FORCE_INLINE_ static GDScriptLanguageProtocol *get_singleton() { return singleton; }

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -46,6 +46,7 @@ GDScriptLanguageServer::GDScriptLanguageServer() {
 	_EDITOR_DEF("network/language_server/enable_smart_resolve", true);
 	_EDITOR_DEF("network/language_server/show_native_symbols_in_editor", false);
 	_EDITOR_DEF("network/language_server/use_thread", use_thread);
+	_EDITOR_DEF("network/language_server/use_custom_methods", true);
 }
 
 void GDScriptLanguageServer::_notification(int p_what) {

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -38,6 +38,8 @@
 #include "gdscript_language_protocol.h"
 
 void GDScriptTextDocument::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("cancelRequest"), &GDScriptTextDocument::cancelRequest);
+	ClassDB::bind_method(D_METHOD("progress"), &GDScriptTextDocument::progress);
 	ClassDB::bind_method(D_METHOD("didOpen"), &GDScriptTextDocument::didOpen);
 	ClassDB::bind_method(D_METHOD("didChange"), &GDScriptTextDocument::didChange);
 	ClassDB::bind_method(D_METHOD("nativeSymbol"), &GDScriptTextDocument::nativeSymbol);
@@ -53,6 +55,16 @@ void GDScriptTextDocument::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("declaration"), &GDScriptTextDocument::declaration);
 	ClassDB::bind_method(D_METHOD("signatureHelp"), &GDScriptTextDocument::signatureHelp);
 	ClassDB::bind_method(D_METHOD("show_native_symbol_in_editor"), &GDScriptTextDocument::show_native_symbol_in_editor);
+}
+
+void GDScriptTextDocument::cancelRequest(const Dictionary &p_params) {
+	// IGNORE
+	return;
+}
+
+void GDScriptTextDocument::progress(const Dictionary &p_params) {
+	// IGNORE
+	return;
 }
 
 void GDScriptTextDocument::didOpen(const Variant &p_param) {

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -68,6 +68,8 @@ public:
 	Array definition(const Dictionary &p_params);
 	Variant declaration(const Dictionary &p_params);
 	Variant signatureHelp(const Dictionary &p_params);
+	void cancelRequest(const Dictionary &p_params);
+	void progress(const Dictionary &p_params);
 
 	void initialize();
 


### PR DESCRIPTION
Ignores $/ notification so that an error is not thrown to client.  This is per the [LSP specification](https://microsoft.github.io/language-server-protocol/specification.html#dollarRequests).  Also adds an option so users can choose whether non-standard messages are sent (in particular the gdscript/capabilities and gdscript_client/changeWorkspace messages).  