### PR TITLE
Documentation: clarify the indent parameter of JSON.print

### DIFF
--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -30,6 +30,28 @@
 			<description>
 				Converts a [Variant] var to JSON text and returns the result. Useful for serializing data to store or send over the network.
 				[b]Note:[/b] The JSON specification does not define integer or float types, but only a [i]number[/i] type. Therefore, converting a Variant to JSON text will convert all numerical values to [float] types.
+				Use [code]indent[/code] parameter to pretty print the output.
+				[b]Example output:[/b]
+				[codeblock]
+				## JSON.print(my_dictionary)
+				{"name":"my_dictionary","version":"1.0.0","entities":[{"name":"entity_0","value":"value_0"},{"name":"entity_1","value":"value_1"}]}
+
+				## JSON.print(my_dictionary, "\t")
+				{
+				        "name": "my_dictionary",
+				        "version": "1.0.0",
+				        "entities": [
+				                {
+				                        "name": "entity_0",
+				                        "value": "value_0"
+				                },
+				                {
+				                        "name": "entity_1",
+				                        "value": "value_1"
+				                }
+				        ]
+				}
+				[/codeblock]
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
It's not clear how to pretty print the json string. (cause me to write my own version)