### PR TITLE
Fix: ctrl + click not working on script member

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2762,6 +2762,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					if (base_type.class_type->has_member(p_symbol)) {
 						r_result.type = ScriptLanguage::LookupResult::RESULT_SCRIPT_LOCATION;
 						r_result.location = base_type.class_type->get_member(p_symbol).get_line();
+						return OK;
 					}
 					base_type = base_type.class_type->base_type;
 				}


### PR DESCRIPTION
ctrl + click not working on script member fixed