### PR TITLE
Removes some superfluous FORCE_INLINES

### DIFF
--- a/drivers/gles2/rasterizer_array_gles2.h
+++ b/drivers/gles2/rasterizer_array_gles2.h
@@ -81,8 +81,8 @@ public:
 	}
 	~RasterizerArrayGLES2() { free(); }
 
-	_FORCE_INLINE_ T &operator[](unsigned int ui) { return _list[ui]; }
-	_FORCE_INLINE_ const T &operator[](unsigned int ui) const { return _list[ui]; }
+	T &operator[](unsigned int ui) { return _list[ui]; }
+	const T &operator[](unsigned int ui) const { return _list[ui]; }
 
 	void free() {
 		if (_list) {
@@ -102,9 +102,9 @@ public:
 		_max_size = p_size;
 	}
 
-	_FORCE_INLINE_ void reset() { _size = 0; }
+	void reset() { _size = 0; }
 
-	_FORCE_INLINE_ T *request_with_grow() {
+	T *request_with_grow() {
 		T *p = request();
 		if (!p) {
 			grow();
@@ -114,7 +114,7 @@ public:
 	}
 
 	// none of that inefficient pass by value stuff here, thanks
-	_FORCE_INLINE_ T *request() {
+	T *request() {
 		if (_size < _max_size) {
 			return &_list[_size++];
 		}
@@ -122,7 +122,7 @@ public:
 	}
 
 	// several items at a time
-	_FORCE_INLINE_ T *request(int p_num_items) {
+	T *request(int p_num_items) {
 		int old_size = _size;
 		_size += p_num_items;
 
@@ -135,9 +135,9 @@ public:
 		return 0;
 	}
 
-	_FORCE_INLINE_ int size() const { return _size; }
-	_FORCE_INLINE_ int max_size() const { return _max_size; }
-	_FORCE_INLINE_ const T *get_data() const { return _list; }
+	int size() const { return _size; }
+	int max_size() const { return _max_size; }
+	const T *get_data() const { return _list; }
 
 	bool copy_from(const RasterizerArrayGLES2<T> &o) {
 		// no resizing done here, it should be done manually

--- a/drivers/gles2/rasterizer_canvas_gles2.h
+++ b/drivers/gles2/rasterizer_canvas_gles2.h
@@ -310,7 +310,7 @@ public:
 private:
 	// legacy codepath .. to remove after testing
 	void _canvas_render_item(Item *p_ci, RenderItemState &r_ris);
-	_FORCE_INLINE_ void _canvas_item_render_commands(Item *p_item, Item *p_current_clip, bool &r_reclip, RasterizerStorageGLES2::Material *p_material);
+	void _canvas_item_render_commands(Item *p_item, Item *p_current_clip, bool &r_reclip, RasterizerStorageGLES2::Material *p_material);
 
 	// high level batch funcs
 	void canvas_render_items_implementation(Item *p_item_list, int p_z, const Color &p_modulate, Light *p_light, const Transform2D &p_base_transform);
@@ -326,7 +326,7 @@ private:
 
 	// low level batch funcs
 	void _batch_translate_to_colored();
-	_FORCE_INLINE_ int _batch_find_or_create_tex(const RID &p_texture, const RID &p_normal, bool p_tile, int p_previous_match);
+	int _batch_find_or_create_tex(const RID &p_texture, const RID &p_normal, bool p_tile, int p_previous_match);
 	RasterizerStorageGLES2::Texture *_get_canvas_texture(const RID &p_texture) const;
 	void _batch_upload_buffers();
 	void _batch_render_rects(const Batch &p_batch, RasterizerStorageGLES2::Material *p_material);
@@ -337,7 +337,7 @@ private:
 	void _software_transform_vertex(BatchVector2 &r_v, const Transform2D &p_tr) const;
 	void _software_transform_vertex(Vector2 &r_v, const Transform2D &p_tr) const;
 	TransformMode _find_transform_mode(const Transform2D &p_tr) const;
-	_FORCE_INLINE_ void _prefill_default_batch(FillState &r_fill_state, int p_command_num, const Item &p_item);
+	void _prefill_default_batch(FillState &r_fill_state, int p_command_num, const Item &p_item);
 
 	// sorting
 	void sort_items();
@@ -365,7 +365,7 @@ public:
 // Default batches will not occur in software transform only items
 // EXCEPT IN THE CASE OF SINGLE RECTS (and this may well not occur, check the logic in prefill_join_item TYPE_RECT)
 // but can occur where transform commands have been sent during hardware batch
-_FORCE_INLINE_ void RasterizerCanvasGLES2::_prefill_default_batch(FillState &r_fill_state, int p_command_num, const Item &p_item) {
+inline void RasterizerCanvasGLES2::_prefill_default_batch(FillState &r_fill_state, int p_command_num, const Item &p_item) {
 	if (r_fill_state.curr_batch->type == Batch::BT_DEFAULT) {
 		// don't need to flush an extra transform command?
 		if (!r_fill_state.transform_extra_command_number_p1) {
@@ -434,17 +434,17 @@ _FORCE_INLINE_ void RasterizerCanvasGLES2::_prefill_default_batch(FillState &r_f
 	}
 }
 
-_FORCE_INLINE_ void RasterizerCanvasGLES2::_software_transform_vertex(BatchVector2 &r_v, const Transform2D &p_tr) const {
+inline void RasterizerCanvasGLES2::_software_transform_vertex(BatchVector2 &r_v, const Transform2D &p_tr) const {
 	Vector2 vc(r_v.x, r_v.y);
 	vc = p_tr.xform(vc);
 	r_v.set(vc);
 }
 
-_FORCE_INLINE_ void RasterizerCanvasGLES2::_software_transform_vertex(Vector2 &r_v, const Transform2D &p_tr) const {
+inline void RasterizerCanvasGLES2::_software_transform_vertex(Vector2 &r_v, const Transform2D &p_tr) const {
 	r_v = p_tr.xform(r_v);
 }
 
-_FORCE_INLINE_ RasterizerCanvasGLES2::TransformMode RasterizerCanvasGLES2::_find_transform_mode(const Transform2D &p_tr) const {
+inline RasterizerCanvasGLES2::TransformMode RasterizerCanvasGLES2::_find_transform_mode(const Transform2D &p_tr) const {
 	// decided whether to do translate only for software transform
 	if ((p_tr.elements[0].x == 1.0) &&
 			(p_tr.elements[0].y == 0.0) &&
@@ -456,7 +456,7 @@ _FORCE_INLINE_ RasterizerCanvasGLES2::TransformMode RasterizerCanvasGLES2::_find
 	return TM_ALL;
 }
 
-_FORCE_INLINE_ bool RasterizerCanvasGLES2::_sort_items_match(const BSortItem &p_a, const BSortItem &p_b) const {
+inline bool RasterizerCanvasGLES2::_sort_items_match(const BSortItem &p_a, const BSortItem &p_b) const {
 	const Item *a = p_a.item;
 	const Item *b = p_b.item;
 


### PR DESCRIPTION
Compiler is usually in the best position to decide whether to inline functions. Great care must be taken using FORCE_INLINE because it can have unforeseen consequences with recursion, loops and bloat to the executable.

Here some FORCE_INLINES are removed in order to allow the compiler to make best choice and remove a compilation warning where unable to inline during a recursive function.

Fixes #41226

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
