### PR TITLE
Fix GdScript Analyzier not detecting Resource subclass correctly

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -533,6 +533,7 @@ void GDScriptAnalyzer::resolve_class_interface(GDScriptParser::ClassNode *p_clas
 								break;
 							case GDScriptParser::DataType::NATIVE:
 								if (ClassDB::is_parent_class(get_real_class_name(datatype.native_type), "Resource")) {
+									member.variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
 									member.variable->export_info.hint_string = get_real_class_name(datatype.native_type);
 								} else {
 									push_error(R"(Export type can only be built-in or a resource.)", member.variable);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
When using the `@export` annotation and optional typing, Godot detects builtin types correctly, but any Resource subclass was allowing any kind of resource to be assigned to the property:
![image](https://user-images.githubusercontent.com/1776044/90194713-3e6b1d80-dd9e-11ea-821f-0269e137201d.png)

With this patch, the inspector will realize the Resource subclass properly:
![image](https://user-images.githubusercontent.com/1776044/90194832-80945f00-dd9e-11ea-9732-9882d6b3b65e.png)
