### PR TITLE
Modified FileSystemDock so folders can be selected for reimport.

### DIFF
--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -195,6 +195,7 @@ private:
 	void _file_multi_selected(int p_index, bool p_selected);
 	void _tree_multi_selected(Object *p_item, int p_column, bool p_selected);
 
+	void _get_imported_files(const String &p_path, Vector<String> &files) const;
 	void _update_import_dock();
 
 	void _get_all_items_in_dir(EditorFileSystemDirectory *efsd, Vector<String> &files, Vector<String> &folders) const;


### PR DESCRIPTION
Now, you can select folders from the file system dock, and as long as the directory contains importable files all of the same type, the Import dock will allow them to be reimported.