### PR TITLE
Fixed issue where custom project settings could not be deleted as they were said to be 'internal'

### DIFF
--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -76,8 +76,8 @@ protected:
 	};
 
 	bool registering_order = true;
-	int last_order = 0;
-	int last_builtin_order = NO_BUILTIN_ORDER_BASE;
+	int last_order = NO_BUILTIN_ORDER_BASE;
+	int last_builtin_order = 0;
 	Map<StringName, VariantContainer> props;
 	String resource_path;
 	Map<StringName, PropertyInfo> custom_prop_info;


### PR DESCRIPTION
This is a bug which I traced back to 1f6f364a, where member initialisation was moved from constructor to declaration. The values of `last_order` and `last_builtin_order` were mistakenly swapped around, leading to the below error every time.

![godot windows tools 32_EJ2DhQuWL1](https://user-images.githubusercontent.com/41730826/90222567-aded1580-de4f-11ea-9549-41a7c1c0935b.png)
