### PR TITLE
Fixed issues with adding custom project settings and added confirmation dialog when deleting settings.

### DIFF
--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -76,8 +76,8 @@ protected:
 	};
 
 	bool registering_order = true;
-	int last_order = 0;
-	int last_builtin_order = NO_BUILTIN_ORDER_BASE;
+	int last_order = NO_BUILTIN_ORDER_BASE;
+	int last_builtin_order = 0;
 	Map<StringName, VariantContainer> props;
 	String resource_path;
 	Map<StringName, PropertyInfo> custom_prop_info;

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -113,10 +113,16 @@ void ProjectSettingsEditor::_add_setting() {
 	inspector->set_current_section(setting.get_slice("/", 1));
 }
 
-void ProjectSettingsEditor::_delete_setting() {
+void ProjectSettingsEditor::_delete_setting(bool p_confirmed) {
 	String setting = _get_setting_name();
 	Variant value = ps->get(setting);
 	int order = ps->get_order(setting);
+
+	if (!p_confirmed) {
+		del_confirmation->set_text(vformat(TTR("Are you sure you want to delete '%s'?"), setting));
+		del_confirmation->popup_centered();
+		return;
+	}
 
 	undo_redo->create_action(TTR("Delete Item"));
 
@@ -394,7 +400,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 		del_button = memnew(Button);
 		del_button->set_flat(true);
-		del_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_delete_setting));
+		del_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_delete_setting), varray(false));
 		hbc->add_child(del_button);
 
 		error_label = memnew(Label);
@@ -465,6 +471,10 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	timer->connect("timeout", callable_mp(ps, &ProjectSettings::save));
 	timer->set_one_shot(true);
 	add_child(timer);
+
+	del_confirmation = memnew(ConfirmationDialog);
+	del_confirmation->connect("confirmed", callable_mp(this, &ProjectSettingsEditor::_delete_setting), varray(true));
+	add_child(del_confirmation);
 
 	get_ok()->set_text(TTR("Close"));
 	set_hide_on_ok(true);

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -77,6 +77,8 @@ class ProjectSettingsEditor : public AcceptDialog {
 	OptionButton *feature_override;
 	Label *error_label;
 
+	ConfirmationDialog *del_confirmation;
+
 	Label *restart_label;
 	TextureRect *restart_icon;
 	PanelContainer *restart_container;
@@ -94,7 +96,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _setting_edited(const String &p_name);
 	void _setting_selected(const String &p_path);
 	void _add_setting();
-	void _delete_setting();
+	void _delete_setting(bool p_confirmed);
 
 	void _editor_restart_request();
 	void _editor_restart();


### PR DESCRIPTION
Closes #9488, closes #41244. Incorporates fix from my PR #41243 (already closed/superseded).

In #9488, logging the deletion property and value to the console is not really that realistic since the value can be anything... Like an array of dictionarys with strings as the key and color arrays as the value. Not really a nice thing to log. So, instead I have put in the alternative of the deletion confirmation. Happy to add logging if it's wanted. 

![godot windows tools 32_q9WHpV8gsx](https://user-images.githubusercontent.com/41730826/90230051-4e493700-de5c-11ea-9e09-f31b520d525b.png)

https://github.com/godotengine/godot/pull/41247/files#diff-4ff2c2c3d2b51423bf963d3ab9e3daf2L174
Fixes not being able to add new custom properties.

https://github.com/godotengine/godot/pull/41247/files#diff-3c7bc6175f35b87bf27ba48a16640472L79-R80
Fixes custom properties being mistaken as built-in.