### PR TITLE
[2.1] OSX: Remove support for 32-bit and fat binaries 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,11 @@ matrix:
       compiler: gcc
     - env: GODOT_TARGET=osx TOOLS=yes CACHE_NAME=${GODOT_TARGET}-clang-tools
       os: osx
-      osx_image: xcode9.3
+      osx_image: xcode11.6
       compiler: clang
     - env: GODOT_TARGET=iphone TOOLS=no CACHE_NAME=${GODOT_TARGET}-clang
       os: osx
-      osx_image: xcode9.3
+      osx_image: xcode11.6
       compiler: clang
     - env: GODOT_TARGET=server TOOLS=no CACHE_NAME=${GODOT_TARGET}-clang
       os: linux

--- a/SConstruct
+++ b/SConstruct
@@ -139,7 +139,7 @@ opts = Variables(customs, ARGUMENTS)
 
 # Target build options
 opts.Add('arch', "Platform-dependent architecture (arm/arm64/x86/x64/mips/etc)", '')
-opts.Add('bits', "Target platform bits (default/32/64/fat)", 'default')
+opts.Add('bits', "Target platform bits (default/32/64)", 'default')
 opts.Add('p', "Platform (alias for 'platform')", '')
 opts.Add('platform', "Target platform: any in " + str(platform_list), '')
 opts.Add('target', "Compilation target (debug/release_debug/release)", 'debug')
@@ -347,8 +347,6 @@ if selected_platform in platform_list:
         suffix += ".32"
     elif (env["bits"] == "64"):
         suffix += ".64"
-    elif (env["bits"] == "fat"):
-        suffix += ".fat"
 
     suffix += env.extra_suffix
 

--- a/platform/osx/crash_handler_osx.mm
+++ b/platform/osx/crash_handler_osx.mm
@@ -34,7 +34,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#if defined(DEBUG_ENABLED) && defined(__x86_64__)
+#if defined(DEBUG_ENABLED)
 #define CRASH_HANDLER_ENABLED 1
 #endif
 
@@ -48,13 +48,8 @@
 #include <mach-o/dyld.h>
 #include <mach-o/getsect.h>
 
-#ifdef __x86_64__
 static uint64_t load_address() {
 	const struct segment_command_64 *cmd = getsegbyname("__TEXT");
-#else
-static uint32_t load_address() {
-	const struct segment_command *cmd = getsegbyname("__TEXT");
-#endif
 	char full_path[1024];
 	uint32_t size = sizeof(full_path);
 
@@ -120,11 +115,7 @@ static void handle_crash(int sig) {
 				args.push_back("-o");
 				args.push_back(_execpath);
 				args.push_back("-arch");
-#ifdef __x86_64__
 				args.push_back("x86_64");
-#else
-				args.push_back("i386");
-#endif
 				args.push_back("-l");
 				snprintf(str, 1024, "%p", load_addr);
 				args.push_back(str);

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -22,7 +22,6 @@ def can_build():
 def get_opts():
 
     return [
-        ('force_64_bits', 'Force 64 bits binary', 'no'),
         ('osxcross_sdk', 'OSXCross SDK version', 'darwin14'),
 
     ]
@@ -38,8 +37,9 @@ def configure(env):
 
     env.Append(CPPPATH=['#platform/osx'])
 
-    if (env["bits"] == "default"):
-        env["bits"] = "32"
+    # Mac OS X no longer runs on 32-bit since 10.7 which is unsupported since 2014
+    # As such, we only support 64-bit
+    env["bits"] = "64"
 
     if (env["target"] == "release"):
 
@@ -55,26 +55,12 @@ def configure(env):
 
     if ("OSXCROSS_ROOT" not in os.environ):
         # regular native build
-        if (env["bits"] == "64"):
-            env.Append(CCFLAGS=['-arch', 'x86_64'])
-            env.Append(LINKFLAGS=['-arch', 'x86_64'])
-        elif (env["bits"] == "32"):
-            env.Append(CCFLAGS=['-arch', 'i386'])
-            env.Append(LINKFLAGS=['-arch', 'i386'])
-        else:
-            env.Append(CCFLAGS=['-arch', 'i386', '-arch', 'x86_64'])
-            env.Append(LINKFLAGS=['-arch', 'i386', '-arch', 'x86_64'])
+        env.Append(CCFLAGS=['-arch', 'x86_64'])
+        env.Append(LINKFLAGS=['-arch', 'x86_64'])
     else:
         # osxcross build
         root = os.environ.get("OSXCROSS_ROOT", 0)
-        if env["bits"] == "fat":
-            basecmd = root + "/target/bin/x86_64-apple-" + env["osxcross_sdk"] + "-"
-            env.Append(CCFLAGS=['-arch', 'i386', '-arch', 'x86_64'])
-            env.Append(LINKFLAGS=['-arch', 'i386', '-arch', 'x86_64'])
-        elif env["bits"] == "32":
-            basecmd = root + "/target/bin/i386-apple-" + env["osxcross_sdk"] + "-"
-        else: # 64-bit, default
-            basecmd = root + "/target/bin/x86_64-apple-" + env["osxcross_sdk"] + "-"
+        basecmd = root + "/target/bin/x86_64-apple-" + env["osxcross_sdk"] + "-"
 
         ccache_path = os.environ.get("CCACHE")
         if ccache_path == None:

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -49,12 +49,6 @@ class EditorExportPlatformOSX : public EditorExportPlatform {
 	String custom_release_package;
 	String custom_debug_package;
 
-	enum BitsMode {
-		BITS_FAT,
-		BITS_64,
-		BITS_32
-	};
-
 	int version_code;
 
 	String app_name;
@@ -67,7 +61,6 @@ class EditorExportPlatformOSX : public EditorExportPlatform {
 	String copyright;
 	String identity;
 	String entitlements;
-	BitsMode bits_mode;
 	bool high_resolution;
 
 	Ref<ImageTexture> logo;
@@ -136,8 +129,6 @@ bool EditorExportPlatformOSX::_set(const StringName &p_name, const Variant &p_va
 		version = p_value;
 	else if (n == "application/copyright")
 		copyright = p_value;
-	else if (n == "application/bits_mode")
-		bits_mode = BitsMode(int(p_value));
 	else if (n == "display/high_res")
 		high_resolution = p_value;
 	else if (n == "codesign/identity")
@@ -174,8 +165,6 @@ bool EditorExportPlatformOSX::_get(const StringName &p_name, Variant &r_ret) con
 		r_ret = version;
 	else if (n == "application/copyright")
 		r_ret = copyright;
-	else if (n == "application/bits_mode")
-		r_ret = bits_mode;
 	else if (n == "display/high_res")
 		r_ret = high_resolution;
 	else if (n == "codesign/identity")
@@ -200,7 +189,6 @@ void EditorExportPlatformOSX::_get_property_list(List<PropertyInfo> *p_list) con
 	p_list->push_back(PropertyInfo(Variant::STRING, "application/short_version"));
 	p_list->push_back(PropertyInfo(Variant::STRING, "application/version"));
 	p_list->push_back(PropertyInfo(Variant::STRING, "application/copyright"));
-	p_list->push_back(PropertyInfo(Variant::INT, "application/bits_mode", PROPERTY_HINT_ENUM, "Fat (32 & 64 bits),64 bits,32 bits"));
 	p_list->push_back(PropertyInfo(Variant::BOOL, "display/high_res"));
 
 	p_list->push_back(PropertyInfo(Variant::STRING, "codesign/identity"));
@@ -400,9 +388,7 @@ Error EditorExportPlatformOSX::export_project(const String &p_path, bool p_debug
 	}
 
 	String binary_to_use = "godot_osx_" + String(p_debug ? "debug" : "release") + ".";
-	binary_to_use += String(bits_mode == BITS_FAT ? "fat" : bits_mode == BITS_64 ? "64" : "32");
 
-	print_line("binary: " + binary_to_use);
 	String pkg_name;
 	if (app_name != "")
 		pkg_name = app_name;
@@ -661,7 +647,6 @@ EditorExportPlatformOSX::EditorExportPlatformOSX() {
 	signature = "godotmacgame";
 	short_version = "1.0";
 	version = "1.0";
-	bits_mode = BITS_FAT;
 	high_resolution = false;
 	identity = "";
 	entitlements = "";


### PR DESCRIPTION
Mac OS X is 64-bit only since 10.7 (Lion), which has reached End-Of-Life in October 2014.
Therefore it no longer makes sense to support exporting 32-bit binaries for Mac OS X,
and we can now default to 64-bit instead of bigger "fat" binaries.

(cherry picked from commits f04958c, 42c5af5, 3e6f2b7, and 1602e0c)

This is a cherry-pick of #16816 + fixups.

---

Travis: Use Xcode 11.6 instead of 9.3