### PR TITLE
Make the editor's 'CheckButton' icon be smaller

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -477,11 +477,6 @@ ConnectDialog::ConnectDialog() {
 	advanced->set_text(TTR("Advanced"));
 	advanced->connect("pressed", callable_mp(this, &ConnectDialog::_advanced_pressed));
 
-	// Add spacing so the tree and inspector are the same size.
-	Control *spacing = memnew(Control);
-	spacing->set_custom_minimum_size(Size2(0, 4) * EDSCALE);
-	vbc_right->add_child(spacing);
-
 	deferred = memnew(CheckBox);
 	deferred->set_h_size_flags(0);
 	deferred->set_text(TTR("Deferred"));

--- a/editor/icons/GuiToggleOff.svg
+++ b/editor/icons/GuiToggleOff.svg
@@ -1,1 +1,1 @@
-<svg height="26" viewBox="0 0 42 25.999998" width="42" xmlns="http://www.w3.org/2000/svg"><g fill="#e0e0e0"><rect fill-opacity=".188235" height="16" rx="9" stroke-width="55.8958" width="38" x="2" y="5"/><circle cx="10" cy="13" r="5" stroke-width="97.3613"/></g></svg>
+<svg height="16" viewBox="0 0 38 15.999999" width="38" xmlns="http://www.w3.org/2000/svg"><g fill="#e0e0e0"><rect fill-opacity=".188235" height="14" rx="7" stroke-width="55.8958" width="36" x="1" y="1"/><circle cx="8" cy="8" r="5" stroke-width="97.3613"/></g></svg>

--- a/editor/icons/GuiToggleOn.svg
+++ b/editor/icons/GuiToggleOn.svg
@@ -1,1 +1,1 @@
-<svg height="26" viewBox="0 0 42 25.999998" width="42" xmlns="http://www.w3.org/2000/svg"><path d="m11 5c-4.986 0-9 3.568-9 8s4.014 8 9 8h20c4.986 0 9-3.568 9-8s-4.014-8-9-8zm21 3a5 5 0 0 1 5 5 5 5 0 0 1 -5 5 5 5 0 0 1 -5-5 5 5 0 0 1 5-5z" fill="#e0e0e0" stroke-width="55.8958"/></svg>
+<svg height="16" viewBox="0 0 38 15.999999" width="38" xmlns="http://www.w3.org/2000/svg"><path d="m8 1c-3.878 0-7 3.122-7 7s3.122 7 7 7h22c3.878 0 7-3.122 7-7s-3.122-7-7-7zm22 2a5 5 0 0 1 5 5 5 5 0 0 1 -5 5 5 5 0 0 1 -5-5 5 5 0 0 1 5-5z" fill="#e0e0e0" stroke-width="55.8958"/></svg>


### PR DESCRIPTION
`CheckButtons` are very tall UI components due to their icon's size, this makes so that they stretch any other `Control` that happens to be together with them. This PR shrinks the icon for the editor a little, so they now appear less out-of-place.

**Before:**
![Screenshot_20200814_105433](https://user-images.githubusercontent.com/30739239/90256753-b2a4d000-de35-11ea-95d5-6c8674135c8a.png)

**After:**
![Screenshot_20200814_101848](https://user-images.githubusercontent.com/30739239/90253475-bb46d780-de30-11ea-8db2-4d8a54494868.png)