### PR TITLE
Fix and tweak the new header in "Project Settings"

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -171,7 +171,7 @@ void ProjectSettingsEditor::_update_advanced_bar() {
 				}
 			}
 
-			disable_add = !bad_category;
+			disable_add = bad_category;
 
 			if (!property_text.is_valid_identifier()) {
 				disable_add = true;
@@ -327,10 +327,8 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		header->add_child(search_bar);
 
 		search_box = memnew(LineEdit);
-		search_box->set_custom_minimum_size(Size2(300, 0));
+		search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		search_bar->add_child(search_box);
-
-		search_bar->add_spacer();
 
 		advanced = memnew(CheckButton);
 		advanced->set_text(TTR("Advanced"));
@@ -345,12 +343,14 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		advanced_bar->hide();
 		header->add_child(advanced_bar);
 
+		advanced_bar->add_child(memnew(HSeparator));
+
 		HBoxContainer *hbc = memnew(HBoxContainer);
 		hbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		advanced_bar->add_margin_child(TTR("Add or remove custom project settings."), hbc, true);
+		advanced_bar->add_margin_child(TTR("Add or Remove Custom Project Settings:"), hbc, true);
 
 		category_box = memnew(LineEdit);
-		category_box->set_custom_minimum_size(Size2(140, 0) * EDSCALE);
+		category_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		category_box->connect("text_changed", callable_mp(this, &ProjectSettingsEditor::_text_field_changed));
 		category_box->set_placeholder(TTR("Category"));
 		hbc->add_child(category_box);
@@ -370,7 +370,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		hbc->add_child(l);
 
 		type = memnew(OptionButton);
-		type->set_custom_minimum_size(Size2(70, 0) * EDSCALE);
+		type->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 		hbc->add_child(type);
 
 		// Start at 1 to avoid adding "Nil" as an option
@@ -383,25 +383,23 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		hbc->add_child(l);
 
 		feature_override = memnew(OptionButton);
-		feature_override->set_custom_minimum_size(Size2(70, 0) * EDSCALE);
+		feature_override->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 		feature_override->connect("item_selected", callable_mp(this, &ProjectSettingsEditor::_feature_selected));
 		hbc->add_child(feature_override);
 
-		hbc->add_spacer();
-
 		add_button = memnew(Button);
+		add_button->set_flat(true);
 		add_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_add_setting));
 		hbc->add_child(add_button);
 
 		del_button = memnew(Button);
+		del_button->set_flat(true);
 		del_button->connect("pressed", callable_mp(this, &ProjectSettingsEditor::_delete_setting));
 		hbc->add_child(del_button);
 
 		error_label = memnew(Label);
 		advanced_bar->add_child(error_label);
 	}
-
-	header->add_child(memnew(HSeparator));
 
 	inspector = memnew(SectionedInspector);
 	inspector->get_inspector()->set_undo_redo(EditorNode::get_singleton()->get_undo_redo());


### PR DESCRIPTION
Changes for the new header added in #40445:

- Fix logic on adding properties being reversed (it was allowing to add when the categories where invalid). Fixes #41244, supersedes part of #41247.
- Place the separator between the search box and the advanced bar instead of below everything. Also hide it together with the advanced bar.
- Make both search box and the advanced bar stretch fully. Making it consistent with other parts of the editor.