### PR TITLE
Rename the "Delete" option in the FileSystem dock to "Move to Trash"

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -450,13 +450,13 @@ void DependencyRemoveDialog::show(const Vector<String> &p_folders, const Vector<
 	removed_deps.sort();
 	if (removed_deps.empty()) {
 		owners->hide();
-		text->set_text(TTR("Remove selected files from the project? (Can't be restored)"));
+		text->set_text(TTR("Remove selected files from the project? (no undo)\nYou can find the removed files in the system trash to restore them."));
 		set_size(Size2());
 		popup_centered();
 	} else {
 		_build_removed_dependency_tree(removed_deps);
 		owners->show();
-		text->set_text(TTR("The files being removed are required by other resources in order for them to work.\nRemove them anyway? (no undo)"));
+		text->set_text(TTR("The files being removed are required by other resources in order for them to work.\nRemove them anyway? (no undo)\nYou can find the removed files in the system trash to restore them."));
 		popup_centered(Size2(500, 350));
 	}
 	EditorFileSystem::get_singleton()->scan_changes();

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2277,7 +2277,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 
 	if (p_paths.size() > 1 || p_paths[0] != "res://") {
 		p_popup->add_icon_item(get_theme_icon("MoveUp", "EditorIcons"), TTR("Move To..."), FILE_MOVE);
-		p_popup->add_icon_item(get_theme_icon("Remove", "EditorIcons"), TTR("Delete"), FILE_REMOVE);
+		p_popup->add_icon_item(get_theme_icon("Remove", "EditorIcons"), TTR("Move to Trash"), FILE_REMOVE);
 	}
 
 	if (p_paths.size() == 1) {


### PR DESCRIPTION
It actually moves files to the system trash instead of removing them completely.