### PR TITLE
Allow exporting custom Resource variables from GDscript

### DIFF
--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -254,6 +254,18 @@ StringName ScriptServer::get_global_class_native_base(const String &p_class) {
 	}
 	return base;
 }
+
+StringName ScriptServer::get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path) {
+	for (int i = 0; i < get_language_count(); i++) {
+		ScriptLanguage *lang = get_language(i);
+		StringName class_name = lang->get_global_class_name(p_path, r_base_type, r_icon_path);
+		if (class_name != StringName()) {
+			return class_name;
+		}
+	}
+	return StringName();
+}
+
 void ScriptServer::get_global_class_list(List<StringName> *r_global_classes) {
 	const StringName *K = NULL;
 	List<StringName> classes;

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -84,6 +84,7 @@ public:
 	static String get_global_class_path(const String &p_class);
 	static StringName get_global_class_base(const String &p_class);
 	static StringName get_global_class_native_base(const String &p_class);
+	static StringName get_global_class_name(const String &p_path, String *r_base = NULL, String *r_icon_path = NULL);
 	static void get_global_class_list(List<StringName> *r_global_classes);
 	static void save_global_classes();
 

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -870,6 +870,14 @@ void EditorData::get_plugin_window_layout(Ref<ConfigFile> p_layout) {
 	}
 }
 
+bool EditorData::class_equals_or_inherits(const String &p_class, const String &p_inherits) {
+	if (p_class == p_inherits)
+		return true;
+	if (ScriptServer::is_global_class(p_class))
+		return script_class_is_parent(p_class, p_inherits);
+	return ClassDB::is_parent_class(p_class, p_inherits);
+}
+
 bool EditorData::script_class_is_parent(const String &p_class, const String &p_inherits) {
 	if (!ScriptServer::is_global_class(p_class))
 		return false;

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -215,6 +215,7 @@ public:
 	void notify_edited_scene_changed();
 	void notify_resource_saved(const Ref<Resource> &p_resource);
 
+	bool class_equals_or_inherits(const String &p_class, const String &p_inherits);
 	bool script_class_is_parent(const String &p_class, const String &p_inherits);
 	StringName script_class_get_base(const String &p_class) const;
 	Object *script_class_instance(const String &p_class);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2125,15 +2125,16 @@ void EditorPropertyResource::_file_selected(const String &p_path) {
 	if (!property_types.empty()) {
 		bool any_type_matches = false;
 		const Vector<String> split_property_types = property_types.split(",");
+		String res_class = _get_file_script_name_or_default(res);
 		for (int i = 0; i < split_property_types.size(); ++i) {
-			if (res->is_class(split_property_types[i])) {
+			if (EditorNode::get_editor_data().class_equals_or_inherits(res_class, split_property_types[i])) {
 				any_type_matches = true;
 				break;
 			}
 		}
 
 		if (!any_type_matches)
-			EditorNode::get_singleton()->show_warning(vformat(TTR("The selected resource (%s) does not match any type expected for this property (%s)."), res->get_class(), property_types));
+			EditorNode::get_singleton()->show_warning(vformat(TTR("The selected resource (%s) does not match any type expected for this property (%s)."), res_class, property_types));
 	}
 
 	emit_changed(get_edited_property(), res);
@@ -2153,6 +2154,9 @@ void EditorPropertyResource::_menu_option(int p_which) {
 			}
 			file->set_mode(EditorFileDialog::MODE_OPEN_FILE);
 			String type = base_type;
+			if (ScriptServer::is_global_class(type)) {
+				type = ScriptServer::get_global_class_native_base(type);
+			}
 
 			List<String> extensions;
 			for (int i = 0; i < type.get_slice_count(","); i++) {
@@ -2417,7 +2421,9 @@ void EditorPropertyResource::_update_menu_items() {
 			ClassDB::get_inheriters_from_class(base.strip_edges(), &inheritors);
 
 			for (int j = 0; j < custom_resources.size(); j++) {
-				inheritors.push_back(custom_resources[j].name);
+				if (EditorNode::get_editor_data().class_equals_or_inherits(custom_resources[j].name, base)) {
+					inheritors.push_back(custom_resources[j].name);
+				}
 			}
 
 			List<StringName>::Element *E = inheritors.front();
@@ -2701,7 +2707,7 @@ void EditorPropertyResource::update_property() {
 			assign->set_text(res->get_path().get_file());
 			assign->set_tooltip(res->get_path());
 		} else {
-			assign->set_text(res->get_class());
+			assign->set_text(_get_file_script_name_or_default(res));
 		}
 
 		if (res->get_path().is_resource_file()) {
@@ -2843,10 +2849,12 @@ bool EditorPropertyResource::_is_drop_valid(const Dictionary &p_drag_data) const
 			String ftype = EditorFileSystem::get_singleton()->get_file_type(file);
 
 			if (ftype != "") {
+				RES resource = ResourceLoader::load(file);
+				ftype = _get_file_script_name_or_default(resource);
 
 				for (int i = 0; i < allowed_type.get_slice_count(","); i++) {
 					String at = allowed_type.get_slice(",", i).strip_edges();
-					if (ClassDB::is_parent_class(ftype, at)) {
+					if (EditorNode::get_editor_data().class_equals_or_inherits(ftype, at)) {
 						return true;
 					}
 				}
@@ -2899,6 +2907,20 @@ void EditorPropertyResource::drop_data_fw(const Point2 &p_point, const Variant &
 
 void EditorPropertyResource::set_use_sub_inspector(bool p_enable) {
 	use_sub_inspector = p_enable;
+}
+
+String EditorPropertyResource::_get_file_script_name_or_default(const RES &p_resource) const {
+	Ref<Script> rscript = p_resource->get_script();
+	if (rscript.is_valid()) {
+		String rscript_path = rscript->get_path();
+		int script_index;
+		EditorFileSystemDirectory *fsdir = EditorFileSystem::get_singleton()->find_file(rscript_path, &script_index);
+		ERR_FAIL_COND_V(!fsdir, p_resource->get_class());
+		String file_script_name = fsdir->get_file_script_class_name(script_index);
+		if (!file_script_name.empty())
+			return file_script_name;
+	}
+	return p_resource->get_class();
 }
 
 void EditorPropertyResource::_bind_methods() {
@@ -3375,8 +3397,8 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Typ
 					String type = open_in_new.get_slicec(',', i).strip_edges();
 					for (int j = 0; j < p_hint_text.get_slice_count(","); j++) {
 						String inherits = p_hint_text.get_slicec(',', j);
-						if (ClassDB::is_parent_class(inherits, type)) {
 
+						if (!ScriptServer::is_global_class(inherits) && ClassDB::is_parent_class(inherits, type)) {
 							editor->set_use_sub_inspector(false);
 						}
 					}

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -596,6 +596,8 @@ class EditorPropertyResource : public EditorProperty {
 	void _open_editor_pressed();
 	void _fold_other_editors(Object *p_self);
 
+	String _get_file_script_name_or_default(const RES &p_resource) const;
+
 	bool opened_editor;
 
 protected:


### PR DESCRIPTION
This PR is based on the work by Will Nations (@willnationsdev) in
https://github.com/willnationsdev/godot/commits/gdres-3.2

It includes some extra changes to make it more robust to cyclic script
references and a minor bugfix. These changes were sponsored by IMVU.

In order to export a custom Resource:

1. Create a script that extends Resource (or any other Resource type) and give it a `class_name`
![res](https://user-images.githubusercontent.com/4402304/90281139-6759e400-de6c-11ea-8dc7-adcc1db6d0ce.png)

2. You are done! You can now export variables using the class name as a hint.
![Screenshot from 2020-08-14 21-00-10](https://user-images.githubusercontent.com/4402304/90283840-33cd8880-de71-11ea-8e3e-366a845cb6fc.png)
![myres2](https://user-images.githubusercontent.com/4402304/90281434-d8999700-de6c-11ea-8801-b131f4c49cb4.png)

3. Inheritance works too :)
![Screenshot from 2020-08-14 20-29-54](https://user-images.githubusercontent.com/4402304/90281482-f109b180-de6c-11ea-8e71-caaa467928f2.png)
![new](https://user-images.githubusercontent.com/4402304/90281444-dd5e4b00-de6c-11ea-850b-903b087508cd.png)


Thanks again to @willnationsdev for the awesome work!
