### PR TITLE
FileSystem dock now filters the import options based on search filter.

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -526,6 +526,12 @@ void DependencyRemoveDialog::ok_pressed() {
 		EditorFileSystem::get_singleton()->scan_changes();
 	}
 
+	Vector<String> files_removed;
+	for (Map<String, String>::Element *F = all_remove_files.front(); F; F = F->next()) {
+		files_removed.push_back(F->key());
+	}
+	emit_signal("files_removed", files_removed);
+
 	// If some files/dirs would be deleted, favorite dirs need to be updated
 	Vector<String> previous_favorites = EditorSettings::get_singleton()->get_favorites();
 	Vector<String> new_favorites;
@@ -550,6 +556,7 @@ void DependencyRemoveDialog::ok_pressed() {
 void DependencyRemoveDialog::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("file_removed", PropertyInfo(Variant::STRING, "file")));
 	ADD_SIGNAL(MethodInfo("folder_removed", PropertyInfo(Variant::STRING, "folder")));
+	ADD_SIGNAL(MethodInfo("files_removed", PropertyInfo(Variant::PACKED_STRING_ARRAY, "files")));
 }
 
 DependencyRemoveDialog::DependencyRemoveDialog() {

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -181,6 +181,7 @@ private:
 	int history_max_size;
 
 	String path;
+	Vector<String> paths_selected;
 
 	bool initialized;
 
@@ -194,6 +195,8 @@ private:
 	bool _create_tree(TreeItem *p_parent, EditorFileSystemDirectory *p_dir, Vector<String> &uncollapsed_paths, bool p_select_in_favorites, bool p_unfold_path = false);
 	Vector<String> _compute_uncollapsed_paths();
 	void _update_tree(const Vector<String> &p_uncollapsed_paths = Vector<String>(), bool p_uncollapse_root = false, bool p_select_in_favorites = false, bool p_unfold_path = false);
+	bool _restore_selection(TreeItem *p_parent, int p_restored_count, bool &p_parent_should_expand);
+	bool _is_valid_path(TreeItem *p_parent, const String &p_path) const;
 	void _navigate_to_path(const String &p_path, bool p_select_in_favorites = false);
 
 	void _file_list_gui_input(Ref<InputEvent> p_event);
@@ -227,6 +230,7 @@ private:
 
 	void _file_removed(String p_file);
 	void _folder_removed(String p_folder);
+	void _files_removed(const Vector<String> &p_files);
 	void _files_moved(String p_old_file, String p_new_file);
 	void _folder_moved(String p_old_folder, String p_new_folder);
 

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -89,11 +89,34 @@ public:
 	}
 };
 
-void ImportDock::set_edit_path(const String &p_path) {
+Ref<ConfigFile> ImportDock::_get_config(const String &p_path) {
+	const String config_path = p_path + ".import";
 	Ref<ConfigFile> config;
-	config.instance();
-	Error err = config->load(p_path + ".import");
-	if (err != OK) {
+	if (config_cache.has(config_path)) {
+		config = config_cache[config_path];
+	} else {
+		config.instance();
+		Error err = config->load(config_path);
+		if (err == OK) {
+			config_cache[config_path] = config;
+		} else {
+			config.unref();
+		}
+	}
+	return config;
+}
+
+void ImportDock::set_edit_path(const String &p_path) {
+	clear();
+
+	files_to_import.clear();
+	files_to_import.push_back(p_path);
+	if (!is_visible()) {
+		return;
+	}
+
+	Ref<ConfigFile> config = _get_config(p_path);
+	if (config.is_null()) {
 		clear();
 		return;
 	}
@@ -177,14 +200,37 @@ void ImportDock::_update_options(const Ref<ConfigFile> &p_config) {
 void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 	clear();
 
-	// Use the value that is repeated the most.
-	Map<String, Dictionary> value_frequency;
+	files_to_import.clear();
+	files_to_import.append_array(p_paths);
+	if (!is_visible()) {
+		return;
+	}
 
-	for (int i = 0; i < p_paths.size(); i++) {
-		Ref<ConfigFile> config;
-		config.instance();
-		Error err = config->load(p_paths[i] + ".import");
-		ERR_CONTINUE(err != OK);
+	importing_canceled = false;
+	threadvar_importing_complete = false;
+	thread.start(_thread_func, this);
+}
+
+void ImportDock::_thread_func(void *user_data) {
+	ImportDock *id = (ImportDock *)user_data;
+	id->_parse_config_files();
+}
+
+void ImportDock::_parse_config_files() {
+	value_frequency.clear();
+
+	for (int i = 0; i < files_to_import.size(); i++) {
+		importing_mutex.lock();
+		threadvar_importing_text = vformat(TTR("Processing %d / %d"), i, files_to_import.size());
+		bool should_stop = importing_canceled;
+		importing_mutex.unlock();
+
+		if (should_stop) {
+			return;
+		}
+
+		Ref<ConfigFile> config = _get_config(files_to_import[i]);
+		ERR_CONTINUE(config.is_null());
 
 		if (i == 0) {
 			params->importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(config->get_value("remap", "importer"));
@@ -214,6 +260,29 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 				value_frequency[E->get()][value] = 1;
 			}
 		}
+
+		call_deferred("_finish_set_edit_multiple_paths");
+	}
+
+	importing_mutex.lock();
+	threadvar_importing_complete = true;
+	importing_mutex.unlock();
+
+	call_deferred("_finish_set_edit_multiple_paths");
+}
+
+void ImportDock::_finish_set_edit_multiple_paths() {
+	importing_mutex.lock();
+	String label_text = threadvar_importing_text;
+	bool complete = threadvar_importing_complete;
+	importing_mutex.unlock();
+
+	if (!importing_canceled) {
+		imported->set_text(label_text);
+	}
+
+	if (!complete) {
+		return;
 	}
 
 	ERR_FAIL_COND(params->importer.is_null());
@@ -251,7 +320,7 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 	params->update();
 
 	List<Ref<ResourceImporter>> importers;
-	ResourceFormatImporter::get_singleton()->get_importers_for_extension(p_paths[0].get_extension(), &importers);
+	ResourceFormatImporter::get_singleton()->get_importers_for_extension(files_to_import[0].get_extension(), &importers);
 	List<Pair<String, String>> importer_names;
 
 	for (List<Ref<ResourceImporter>>::Element *E = importers.front(); E; E = E->next()) {
@@ -272,12 +341,12 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 
 	_update_preset_menu();
 
-	params->paths = p_paths;
+	params->paths = files_to_import;
 	import->set_disabled(false);
 	import_as->set_disabled(false);
 	preset->set_disabled(false);
 
-	imported->set_text(vformat(TTR("%d Files"), p_paths.size()));
+	imported->set_text(vformat(TTR("%d Files"), files_to_import.size()));
 
 	if (params->paths.size() == 1 && params->importer->has_advanced_options()) {
 		advanced->show();
@@ -328,11 +397,7 @@ void ImportDock::_importer_selected(int i_idx) {
 
 		Ref<ConfigFile> config;
 		if (params->paths.size()) {
-			config.instance();
-			Error err = config->load(params->paths[0] + ".import");
-			if (err != OK) {
-				config.unref();
-			}
+			config = _get_config(params->paths[0]);
 		}
 		_update_options(config);
 	}
@@ -395,7 +460,20 @@ void ImportDock::_preset_selected(int p_idx) {
 	}
 }
 
+void ImportDock::files_removed(const Vector<String> &p_paths) {
+	for (int i = 0; i < p_paths.size(); i++) {
+		config_cache.erase(p_paths[i] + ".import");
+	}
+}
+
 void ImportDock::clear() {
+	if (thread.is_started()) {
+		importing_mutex.lock();
+		importing_canceled = true;
+		importing_mutex.unlock();
+		thread.wait_to_finish();
+	}
+
 	imported->set_text("");
 	import->set_disabled(true);
 	import_as->clear();
@@ -439,10 +517,8 @@ void ImportDock::_reimport_attempt() {
 		importer_name = "keep";
 	}
 	for (int i = 0; i < params->paths.size(); i++) {
-		Ref<ConfigFile> config;
-		config.instance();
-		Error err = config->load(params->paths[i] + ".import");
-		ERR_CONTINUE(err != OK);
+		Ref<ConfigFile> config = _get_config(params->paths[i]);
+		ERR_CONTINUE(config.is_null());
 
 		String imported_with = config->get_value("remap", "importer");
 		if (imported_with != importer_name) {
@@ -515,7 +591,6 @@ void ImportDock::_reimport() {
 			} else {
 				config->set_value("remap", "group_file", Variant()); //clear group file if unused
 			}
-
 		} else {
 			//set to no import
 			config->clear();
@@ -539,6 +614,30 @@ void ImportDock::_notification(int p_what) {
 			import_opts->edit(params);
 			label_warning->add_theme_color_override("font_color", get_theme_color("warning_color", "Editor"));
 		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (is_visible()) {
+				if (files_to_import.size() == 1) {
+					// ??? A crash can occur in set_edit_path when accessing p_path,
+					// if files_to_import[0] is passed directly.
+					String file = files_to_import[0];
+					set_edit_path(file);
+				} else if (files_to_import.size() > 1) {
+					// Copy the vector because set_edit_multiple_paths resets files_to_import.
+					Vector<String> files = files_to_import;
+					set_edit_multiple_paths(files);
+				}
+			} else {
+				clear();
+				config_cache.clear();
+			}
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			// If the ImportDock or the windows closes while processing
+			// stop the thread so the editor doesn't crash.
+			clear();
+		} break;
 	}
 }
 
@@ -552,6 +651,7 @@ void ImportDock::_property_toggled(const StringName &p_prop, bool p_checked) {
 
 void ImportDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_reimport"), &ImportDock::_reimport);
+	ClassDB::bind_method(D_METHOD("_finish_set_edit_multiple_paths"), &ImportDock::_finish_set_edit_multiple_paths);
 }
 
 void ImportDock::initialize_import_options() const {

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -50,8 +50,17 @@ class ImportDock : public VBoxContainer {
 	MenuButton *preset;
 	EditorInspector *import_opts;
 
+	Vector<String> files_to_import;
+	Thread thread;
+	Mutex importing_mutex;
+	String threadvar_importing_text;
+	bool threadvar_importing_complete;
+	bool importing_canceled;
+	Map<String, Dictionary> value_frequency;
+
 	List<PropertyInfo> properties;
 	Map<StringName, Variant> property_values;
+	Map<String, Ref<ConfigFile>> config_cache;
 
 	ConfirmationDialog *reimport_confirm;
 	Label *label_warning;
@@ -61,6 +70,8 @@ class ImportDock : public VBoxContainer {
 	Button *advanced;
 
 	ImportDockParameters *params;
+
+	Ref<ConfigFile> _get_config(const String &p_path);
 
 	void _preset_selected(int p_idx);
 	void _importer_selected(int i_idx);
@@ -73,6 +84,11 @@ class ImportDock : public VBoxContainer {
 	void _reimport();
 
 	void _advanced_options();
+
+	static void _thread_func(void *user_data);
+	void _parse_config_files();
+	void _finish_set_edit_multiple_paths();
+
 	enum {
 		ITEM_SET_AS_DEFAULT = 100,
 		ITEM_LOAD_DEFAULT,
@@ -87,6 +103,7 @@ public:
 	void set_edit_path(const String &p_path);
 	void set_edit_multiple_paths(const Vector<String> &p_paths);
 	void initialize_import_options() const;
+	void files_removed(const Vector<String> &p_paths);
 	void clear();
 
 	ImportDock();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -390,7 +390,6 @@ void TreeItem::set_collapsed(bool p_collapsed) {
 			ci = ci->parent;
 		}
 		if (ci) { // collapsing cursor/selected, move it!
-
 			if (tree->select_mode == Tree::SELECT_MULTI) {
 				tree->selected_item = this;
 				emit_signal("cell_selected");
@@ -493,7 +492,6 @@ TreeItem *TreeItem::get_next_visible(bool p_wrap) {
 
 	if (!current->collapsed && current->children) {
 		current = current->children;
-
 	} else if (current->next) {
 		current = current->next;
 	} else {
@@ -1094,7 +1092,6 @@ int Tree::compute_item_height(TreeItem *p_item) const {
 				if (p_item->cells[i].mode == TreeItem::CELL_MODE_CUSTOM && p_item->cells[i].custom_button) {
 					height += cache.custom_button->get_minimum_size().height;
 				}
-
 			} break;
 			default: {
 			}
@@ -1236,7 +1233,6 @@ void Tree::update_item_cell(TreeItem *p_item, int p_col) {
 					break;
 				}
 			}
-
 		} else {
 			valtext = String::num(p_item->cells[p_col].val, Math::range_step_decimals(p_item->cells[p_col].step));
 		}
@@ -1490,7 +1486,6 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					item_rect.position.x += check_w;
 
 					draw_item_rect(p_item->cells.write[i], item_rect, col, icon_col, outline_size, font_outline_color);
-
 				} break;
 				case TreeItem::CELL_MODE_RANGE: {
 					if (p_item->cells[i].text != "") {
@@ -1546,7 +1541,6 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 						updown->draw(ci, updown_pos);
 					}
-
 				} break;
 				case TreeItem::CELL_MODE_ICON: {
 					if (p_item->cells[i].icon.is_null()) {
@@ -1562,7 +1556,6 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					icon_ofs += item_rect.position;
 
 					draw_texture_rect(p_item->cells[i].icon, Rect2(icon_ofs, icon_size), false, icon_col);
-
 				} break;
 				case TreeItem::CELL_MODE_CUSTOM: {
 					if (p_item->cells[i].custom_draw_obj.is_valid()) {
@@ -1604,7 +1597,6 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					draw_item_rect(p_item->cells.write[i], ir, col, icon_col, outline_size, font_outline_color);
 
 					downarrow->draw(ci, arrow_pos);
-
 				} break;
 			}
 
@@ -1627,7 +1619,6 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 		}
 
 		if (!p_item->disable_folding && !hide_folding && p_item->children) { //has children, draw the guide box
-
 			Ref<Texture2D> arrow;
 
 			if (p_item->collapsed) {
@@ -1765,7 +1756,6 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 					if (p_col==i)
 						p_current->selected_signal.call(p_col);
 					*/
-
 			} else if (c.selected) {
 				c.selected = false;
 				//p_current->deselected_signal.call(p_col);
@@ -1784,7 +1774,6 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 					} else if (select_mode == SELECT_SINGLE) {
 						emit_signal("item_selected");
 					}
-
 				} else if (select_mode == SELECT_MULTI && (selected_item != p_selected || selected_col != i)) {
 					selected_item = p_selected;
 					selected_col = i;
@@ -1796,7 +1785,6 @@ void Tree::select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_c
 						c.selected = true;
 						emit_signal("multi_selected", p_current, i, true);
 					}
-
 				} else if (!r_in_range || p_force_deselect) {
 					if (select_mode == SELECT_MULTI && c.selected) {
 						emit_signal("multi_selected", p_current, i, false);
@@ -1860,7 +1848,6 @@ void Tree::_range_click_timeout() {
 			emit_signal("item_activated");
 			propagate_mouse_activated = false;
 		}
-
 	} else {
 		range_click_timer->stop();
 	}
@@ -1964,7 +1951,6 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 			/* process selection */
 
 			if (p_doubleclick && (!c.editable || c.mode == TreeItem::CELL_MODE_CUSTOM || c.mode == TreeItem::CELL_MODE_ICON /*|| c.mode==TreeItem::CELL_MODE_CHECK*/)) { //it's confusing for check
-
 				propagate_mouse_activated = true;
 
 				incr_search.clear();
@@ -1985,7 +1971,6 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 					emit_signal("multi_selected", p_item, col, false);
 					//p_item->deselected_signal.call(col);
 				}
-
 			} else {
 				if (c.selectable) {
 					if (select_mode == SELECT_MULTI && p_mod->get_shift() && selected_item && selected_item != p_item) {
@@ -2038,7 +2023,6 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 				if (select_mode == SELECT_MULTI && (get_viewport()->get_processed_events_count() == focus_in_id || !already_cursor)) {
 					bring_up_editor = false;
 				}
-
 			} break;
 			case TreeItem::CELL_MODE_CHECK: {
 				bring_up_editor = false; //checkboxes are not edited with editor
@@ -2053,7 +2037,6 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 				}
 				click_handled = true;
 				//p_item->edited_signal.call(col);
-
 			} break;
 			case TreeItem::CELL_MODE_RANGE: {
 				if (c.text != "") {
@@ -2084,7 +2067,6 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 								range_click_timer->set_wait_time(0.6);
 								range_click_timer->set_one_shot(true);
 								range_click_timer->start();
-
 							} else if (up != range_up_last) {
 								return -1; // break. avoid changing direction on mouse held
 							}
@@ -2092,7 +2074,6 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 							p_item->set_range(col, c.val + (up ? 1.0 : -1.0) * c.step);
 
 							item_edited(col, p_item);
-
 						} else if (p_button == MOUSE_BUTTON_RIGHT) {
 							p_item->set_range(col, (up ? c.max : c.min));
 							item_edited(col, p_item);
@@ -2106,7 +2087,6 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 
 						//p_item->edited_signal.call(col);
 						bring_up_editor = false;
-
 					} else {
 						editor_text = String::num(p_item->cells[col].val, Math::range_step_decimals(p_item->cells[col].step));
 						if (select_mode == SELECT_MULTI && get_viewport()->get_processed_events_count() == focus_in_id) {
@@ -2115,7 +2095,6 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 					}
 				}
 				click_handled = true;
-
 			} break;
 			case TreeItem::CELL_MODE_ICON: {
 				bring_up_editor = false;
@@ -2442,21 +2421,18 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 		} else {
 			_go_left();
 		}
-
 	} else if (p_event->is_action("ui_up") && p_event->is_pressed() && !is_command) {
 		if (!cursor_can_exit_tree) {
 			accept_event();
 		}
 
 		_go_up();
-
 	} else if (p_event->is_action("ui_down") && p_event->is_pressed() && !is_command) {
 		if (!cursor_can_exit_tree) {
 			accept_event();
 		}
 
 		_go_down();
-
 	} else if (p_event->is_action("ui_page_down") && p_event->is_pressed()) {
 		if (!cursor_can_exit_tree) {
 			accept_event();
@@ -2558,7 +2534,6 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 	}
 
 	if (k.is_valid()) { // Incremental search
-
 		if (!k->is_pressed()) {
 			return;
 		}
@@ -2888,7 +2863,6 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 					emit_signal("item_activated");
 					propagate_mouse_activated = false;
 				}
-
 			} break;
 			case MOUSE_BUTTON_WHEEL_UP: {
 				double prev_value = v_scroll->get_value();
@@ -2896,7 +2870,6 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 				if (v_scroll->get_value() != prev_value) {
 					accept_event();
 				}
-
 			} break;
 			case MOUSE_BUTTON_WHEEL_DOWN: {
 				double prev_value = v_scroll->get_value();
@@ -2904,7 +2877,6 @@ void Tree::_gui_input(Ref<InputEvent> p_event) {
 				if (v_scroll->get_value() != prev_value) {
 					accept_event();
 				}
-
 			} break;
 		}
 	}
@@ -2969,7 +2941,6 @@ bool Tree::edit_selected() {
 		popup_edited_item = s;
 		popup_edited_item_col = col;
 		return true;
-
 	} else if (c.mode == TreeItem::CELL_MODE_STRING || c.mode == TreeItem::CELL_MODE_RANGE) {
 		Rect2 popup_rect;
 
@@ -3284,7 +3255,6 @@ TreeItem *Tree::create_item(TreeItem *p_parent, int p_idx) {
 			p_parent->children = ti;
 		}
 		ti->parent = p_parent;
-
 	} else {
 		if (!root) {
 			// No root exists, make the given item the new root.
@@ -3386,8 +3356,12 @@ Tree::SelectMode Tree::get_select_mode() const {
 
 void Tree::deselect_all() {
 	TreeItem *item = get_next_selected(get_root());
+
+	// Calling item->deselect resets selected_col.
+	int col = selected_col;
+
 	while (item) {
-		item->deselect(selected_col);
+		item->deselect(col);
 		TreeItem *prev_item = item;
 		item = get_next_selected(get_root());
 		ERR_FAIL_COND(item == prev_item);
@@ -3484,7 +3458,6 @@ TreeItem *Tree::get_next_selected(TreeItem *p_item) {
 		} else {
 			if (p_item->children) {
 				p_item = p_item->children;
-
 			} else if (p_item->next) {
 				p_item = p_item->next;
 			} else {
@@ -3604,7 +3577,6 @@ int Tree::get_item_offset(TreeItem *p_item) const {
 
 		if (it->children && !it->collapsed) {
 			it = it->children;
-
 		} else if (it->next) {
 			it = it->next;
 		} else {


### PR DESCRIPTION
In conjunction with PR #41242, you can have directories
of mixed import types, filter by part of a file name
and select a directory to reimport all the matching files.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
