### PR TITLE
fixed linker being slow on OSX

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -76,6 +76,7 @@ def configure(env):
     elif env["target"] == "debug":
         env.Prepend(CCFLAGS=["-g3"])
         env.Prepend(CPPDEFINES=["DEBUG_ENABLED"])
+        env.Prepend(LINKFLAGS=["-Xlinker", "-no_deduplicate"])
 
     ## Architecture
 


### PR DESCRIPTION
linker is slow on OSX when using debug builds, these options improve it drastically (80s to 20s)