### PR TITLE
Check intersect_ray normal is not a zero vector, to ensure the ray is  colliding with and not just enclosed in the shape.

### DIFF
--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -213,7 +213,8 @@ void RayCast2D::_update_raycast_state() {
 
 	PhysicsDirectSpaceState2D::RayResult rr;
 
-	if (dss->intersect_ray(gt.get_origin(), gt.xform(to), rr, exclude, collision_mask, collide_with_bodies, collide_with_areas)) {
+	if (dss->intersect_ray(gt.get_origin(), gt.xform(to), rr, exclude, collision_mask, collide_with_bodies, collide_with_areas) &&
+			rr.normal != Vector2()) {
 		collided = true;
 		against = rr.collider_id;
 		collision_point = rr.position;

--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -209,7 +209,8 @@ void RayCast3D::_update_raycast_state() {
 
 	PhysicsDirectSpaceState3D::RayResult rr;
 
-	if (dss->intersect_ray(gt.get_origin(), gt.xform(to), rr, exclude, collision_mask, collide_with_bodies, collide_with_areas)) {
+	if (dss->intersect_ray(gt.get_origin(), gt.xform(to), rr, exclude, collision_mask, collide_with_bodies, collide_with_areas) &&
+			rr.normal != Vector3()) {
 		collided = true;
 		against = rr.collider_id;
 		collision_point = rr.position;


### PR DESCRIPTION
While investigating #41167, I noticed that `RectangleShape2D` returns the `Object` when calling `get_collider()` for a `RayCast2D` that is completely enclosed by the shape. However, `CapsuleShape2D`, `CircleShape2D` and `ConvexPolygonShape2D` all return null. The other shapes don't create enclosures.

In 3D Bullet physics, all of the Shapes (`BoxShape3D`, `CapsuleShape3D`, `CylinderShape3D`, `SphereShape3D` and `ConvexPolygonShape3D`) return null when calling `get_collider()` if the `RayShape3D` is completely enclosed. However, in Godot 3D physics, `BoxShape3D` and `CapsuleShape3D` also return the `Object` when calling `get_collider()` and a zero length normal `Vector3` when calling `get_collision_normal()`. The `SphereShape3D` and the `ConvexPolygonShape3D` don't. Godot 3D physics doesn't support the `CylinderShape3D`.

~This patch makes `Rect2D::intersects_segment()` and `AABB::intersects_segment()` return `false` when the segment doesn't intersect an edge or a face respectively, and hence doesn't set the normal to a zero length vector either.~
This patch checks that `intersects_segment()` sets the `normal` to a normal vector, to ensure the ray is colliding with and not just enclosed in the shape, before deciding there is a collision.

This makes all shapes consistently return `null` when calling `get_collider()` if the `Raycast` is completely enclosed in the shape.