### PR TITLE
[2.1] Android: Target API level 29 as required by Google Play

### DIFF
--- a/platform/android/AndroidManifest.xml.template
+++ b/platform/android/AndroidManifest.xml.template
@@ -36,6 +36,6 @@ $$ADD_APPLICATION_CHUNKS$$
 
 $$ADD_PERMISSION_CHUNKS$$
 
-<uses-sdk android:minSdkVersion="18" android:targetSdkVersion="28"/>
+<uses-sdk android:minSdkVersion="18" android:targetSdkVersion="29"/>
          
 </manifest> 

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -105,7 +105,7 @@ gradle_asset_dirs_text = ""
 gradle_default_config_text = ""
 
 minSdk = 18
-targetSdk = 28
+targetSdk = 29
 
 for x in env.android_default_config:
     if x.startswith("minSdkVersion") and int(x.split(" ")[-1]) < minSdk: 

--- a/platform/android/build.gradle.template
+++ b/platform/android/build.gradle.template
@@ -31,8 +31,8 @@ android {
 		disable 'MissingTranslation'
 	}
 
-	compileSdkVersion 28
-	buildToolsVersion "28.0.3"
+	compileSdkVersion 29
+	buildToolsVersion "29.0.3"
 	useLibrary 'org.apache.http.legacy'
 
 	packagingOptions {


### PR DESCRIPTION
This is required for new apps since August 3, 2020:
https://support.google.com/googleplay/android-developer/answer/113469#targetsdk