### PR TITLE
[macOS] Fix "on top" not set on init, and resetting on window update.

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -127,6 +127,7 @@ public:
 	bool zoomed;
 	bool resizable;
 	bool window_focused;
+	bool on_top;
 
 	Size2 window_size;
 	Rect2 restore_rect;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1682,6 +1682,11 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	[window_object makeKeyAndOrderFront:nil];
 
+	on_top = p_desired.always_on_top;
+	if (p_desired.always_on_top) {
+		[window_object setLevel:NSFloatingWindowLevel];
+	}
+
 	if (p_desired.fullscreen)
 		zoomed = true;
 
@@ -2501,7 +2506,11 @@ void OS_OSX::_update_window() {
 		[window_object setHidesOnDeactivate:YES];
 	} else {
 		// Reset these when our window is not a borderless window that covers up the screen
-		[window_object setLevel:NSNormalWindowLevel];
+		if (on_top) {
+			[window_object setLevel:NSFloatingWindowLevel];
+		} else {
+			[window_object setLevel:NSNormalWindowLevel];
+		}
 		[window_object setHidesOnDeactivate:NO];
 	}
 }
@@ -2736,6 +2745,8 @@ void OS_OSX::move_window_to_foreground() {
 }
 
 void OS_OSX::set_window_always_on_top(bool p_enabled) {
+	on_top = p_enabled;
+
 	if (is_window_always_on_top() == p_enabled)
 		return;
 
@@ -3320,6 +3331,7 @@ OS_OSX::OS_OSX() {
 	zoomed = false;
 	resizable = false;
 	window_focused = true;
+	on_top = false;
 
 	Vector<Logger *> loggers;
 	loggers.push_back(memnew(OSXTerminalLogger));


### PR DESCRIPTION
Similar to #41285 for 3.2 branch.