### PR TITLE
Mute some of the warnings "Implicit conversion from type.."

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -134,7 +134,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 			} else {
 				ERR_FAIL_COND_V(len < 4, ERR_INVALID_DATA);
-				int32_t val = decode_uint32(buf);
+				int32_t val = int32_t(decode_uint32(buf));
 				r_variant = val;
 				if (r_len) {
 					(*r_len) += 4;
@@ -372,7 +372,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 		case Variant::NODE_PATH: {
 			ERR_FAIL_COND_V(len < 4, ERR_INVALID_DATA);
-			int32_t strlen = decode_uint32(buf);
+			uint32_t strlen = decode_uint32(buf);
 
 			if (strlen & 0x80000000) {
 				//new format
@@ -927,13 +927,13 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 			if (flags & ENCODE_FLAG_64) {
 				//64 bits
 				if (buf) {
-					encode_uint64(p_variant.operator int64_t(), buf);
+					encode_uint64(uint64_t(p_variant.operator int64_t()), buf);
 				}
 
 				r_len += 8;
 			} else {
 				if (buf) {
-					encode_uint32(p_variant.operator int32_t(), buf);
+					encode_uint32(uint32_t(p_variant.operator int32_t()), buf);
 				}
 
 				r_len += 4;

--- a/core/io/multiplayer_api.cpp
+++ b/core/io/multiplayer_api.cpp
@@ -711,7 +711,7 @@ Error MultiplayerAPI::_decode_and_decompress_variant(Variant &r_variant, const u
 			if (encode_mode == ENCODE_8) {
 				// 8 bits.
 				ERR_FAIL_COND_V(len < 1, ERR_INVALID_DATA);
-				int8_t val = buf[0];
+				int8_t val = int8_t(buf[0]);
 				r_variant = val;
 				if (r_len) {
 					(*r_len) += 1;
@@ -719,7 +719,7 @@ Error MultiplayerAPI::_decode_and_decompress_variant(Variant &r_variant, const u
 			} else if (encode_mode == ENCODE_16) {
 				// 16 bits.
 				ERR_FAIL_COND_V(len < 2, ERR_INVALID_DATA);
-				int16_t val = decode_uint16(buf);
+				int16_t val = int16_t(decode_uint16(buf));
 				r_variant = val;
 				if (r_len) {
 					(*r_len) += 2;
@@ -727,7 +727,7 @@ Error MultiplayerAPI::_decode_and_decompress_variant(Variant &r_variant, const u
 			} else if (encode_mode == ENCODE_32) {
 				// 32 bits.
 				ERR_FAIL_COND_V(len < 4, ERR_INVALID_DATA);
-				int32_t val = decode_uint32(buf);
+				int32_t val = int32_t(decode_uint32(buf));
 				r_variant = val;
 				if (r_len) {
 					(*r_len) += 4;
@@ -735,7 +735,7 @@ Error MultiplayerAPI::_decode_and_decompress_variant(Variant &r_variant, const u
 			} else {
 				// 64 bits.
 				ERR_FAIL_COND_V(len < 8, ERR_INVALID_DATA);
-				int64_t val = decode_uint64(buf);
+				int64_t val = int64_t(decode_uint64(buf));
 				r_variant = val;
 				if (r_len) {
 					(*r_len) += 8;

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -427,8 +427,8 @@ uint64_t ClassDB::get_api_hash(APIType p_api) {
 			snames.sort_custom<StringName::AlphCompare>();
 
 			for (List<StringName>::Element *F = snames.front(); F; F = F->next()) {
-				hash = hash_djb2_one_64(F->get().hash(), hash);
-				hash = hash_djb2_one_64(t->constant_map[F->get()], hash);
+				hash = hash_djb2_one_64(uint64_t(F->get().hash()), hash);
+				hash = hash_djb2_one_64(uint64_t(t->constant_map[F->get()]), hash);
 			}
 		}
 

--- a/core/object/object_id.h
+++ b/core/object/object_id.h
@@ -46,18 +46,18 @@ public:
 	_ALWAYS_INLINE_ bool is_valid() const { return id != 0; }
 	_ALWAYS_INLINE_ bool is_null() const { return id == 0; }
 	_ALWAYS_INLINE_ operator uint64_t() const { return id; }
-	_ALWAYS_INLINE_ operator int64_t() const { return id; }
+	_ALWAYS_INLINE_ operator int64_t() const { return int64_t(id); }
 
 	_ALWAYS_INLINE_ bool operator==(const ObjectID &p_id) const { return id == p_id.id; }
 	_ALWAYS_INLINE_ bool operator!=(const ObjectID &p_id) const { return id != p_id.id; }
 	_ALWAYS_INLINE_ bool operator<(const ObjectID &p_id) const { return id < p_id.id; }
 
-	_ALWAYS_INLINE_ void operator=(int64_t p_int64) { id = p_int64; }
+	_ALWAYS_INLINE_ void operator=(int64_t p_int64) { id = uint64_t(p_int64); }
 	_ALWAYS_INLINE_ void operator=(uint64_t p_uint64) { id = p_uint64; }
 
 	_ALWAYS_INLINE_ ObjectID() {}
 	_ALWAYS_INLINE_ explicit ObjectID(const uint64_t p_id) { id = p_id; }
-	_ALWAYS_INLINE_ explicit ObjectID(const int64_t p_id) { id = p_id; }
+	_ALWAYS_INLINE_ explicit ObjectID(const int64_t p_id) { id = uint64_t(p_id); }
 };
 
 #endif // OBJECT_ID_H

--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -306,7 +306,7 @@ String FileAccess::get_line() const {
 			line.push_back(0);
 			return String::utf8(line.get_data());
 		} else if (c != '\r') {
-			line.push_back(c);
+			line.push_back(char(c));
 		}
 
 		c = get_8();

--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -346,7 +346,7 @@ class CommandQueueMT {
 	template <class T>
 	T *allocate() {
 		// alloc size is size+T+safeguard
-		uint32_t alloc_size = ((sizeof(T) + 8 - 1) & ~(8 - 1)) + 8;
+		uint32_t alloc_size = ((sizeof(T) + 8 - 1) & ~(8u - 1)) + 8;
 
 		// Assert that the buffer is big enough to hold at least two messages.
 		ERR_FAIL_COND_V(alloc_size * 2 + sizeof(uint32_t) > command_mem_size, nullptr);
@@ -396,7 +396,7 @@ class CommandQueueMT {
 		// Allocate the size and the 'in use' bit.
 		// First bit used to mark if command is still in use (1)
 		// or if it has been destroyed and can be deallocated (0).
-		uint32_t size = (sizeof(T) + 8 - 1) & ~(8 - 1);
+		uint32_t size = (sizeof(T) + 8 - 1) & ~(8u - 1);
 		uint32_t *p = (uint32_t *)&command_mem[write_ptr];
 		*p = (size << 1) | 1;
 		write_ptr += 8;
@@ -465,7 +465,7 @@ class CommandQueueMT {
 
 		cmd->post();
 		cmd->~CommandBase();
-		*(uint32_t *)&command_mem[size_ptr] &= ~1;
+		*(uint32_t *)&command_mem[size_ptr] &= ~1u;
 
 		if (p_lock) {
 			unlock();

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -82,7 +82,7 @@ static inline uint32_t hash_one_uint64(const uint64_t p_int) {
 	v = v ^ (v >> 11);
 	v = v + (v << 6);
 	v = v ^ (v >> 22);
-	return (int)v;
+	return (uint32_t)v;
 }
 
 static inline uint32_t hash_djb2_one_float(double p_in, uint32_t p_prev = 5381) {

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2392,7 +2392,7 @@ Variant::Variant(int64_t p_int) {
 
 Variant::Variant(uint64_t p_int) {
 	type = INT;
-	_data._int = p_int;
+	_data._int = int64_t(p_int);
 }
 
 Variant::Variant(signed short p_short) {
@@ -2849,7 +2849,7 @@ uint32_t Variant::hash() const {
 			return _data._bool ? 1 : 0;
 		} break;
 		case INT: {
-			return _data._int;
+			return uint32_t(_data._int);
 		} break;
 		case FLOAT: {
 			return hash_djb2_one_float(_data._float);
@@ -2959,7 +2959,7 @@ uint32_t Variant::hash() const {
 			return hash_djb2_one_64(reinterpret_cast<const ::RID *>(_data._mem)->get_id());
 		} break;
 		case OBJECT: {
-			return hash_djb2_one_64(make_uint64_t(_get_obj().obj));
+			return uint32_t(hash_djb2_one_64(make_uint64_t(_get_obj().obj)));
 		} break;
 		case STRING_NAME: {
 			return reinterpret_cast<const StringName *>(_data._mem)->hash();

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -5407,7 +5407,7 @@ RID RenderingDeviceVulkan::render_pipeline_create(RID p_shader, FramebufferForma
 
 		//validate with inputs
 		for (uint32_t i = 0; i < 32; i++) {
-			if (!(shader->vertex_input_mask & (1 << i))) {
+			if (!(shader->vertex_input_mask & (1u << i))) {
 				continue;
 			}
 			bool found = false;

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -498,7 +498,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 			for (int i = 0; i < ds; i++) {
 				if (is16) {
 					int16_t v = CLAMP(data[i] * 32768, -32768, 32767);
-					encode_uint16(v, &w[i * 2]);
+					encode_uint16(uint16_t(v), &w[i * 2]);
 				} else {
 					int8_t v = CLAMP(data[i] * 128, -128, 127);
 					w[i] = v;

--- a/modules/csg/csg.h
+++ b/modules/csg/csg.h
@@ -130,9 +130,9 @@ struct CSGBrushOperation {
 
 		struct VertexKeyHash {
 			static _FORCE_INLINE_ uint32_t hash(const VertexKey &p_vk) {
-				uint32_t h = hash_djb2_one_32(p_vk.x);
-				h = hash_djb2_one_32(p_vk.y, h);
-				h = hash_djb2_one_32(p_vk.z, h);
+				uint32_t h = hash_djb2_one_32(uint32_t(p_vk.x));
+				h = hash_djb2_one_32(uint32_t(p_vk.y), h);
+				h = hash_djb2_one_32(uint32_t(p_vk.z), h);
 				return h;
 			}
 		};

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -2212,8 +2212,8 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 	// XLookupString returns keysyms usable as nice keycodes.
 	char str[256 + 1];
 	XKeyEvent xkeyevent_no_mod = *xkeyevent;
-	xkeyevent_no_mod.state &= ~ShiftMask;
-	xkeyevent_no_mod.state &= ~ControlMask;
+	xkeyevent_no_mod.state &= ~(uint32_t(ShiftMask));
+	xkeyevent_no_mod.state &= ~(uint32_t(ControlMask));
 	XLookupString(xkeyevent, str, 256, &keysym_unicode, nullptr);
 	XLookupString(&xkeyevent_no_mod, nullptr, 0, &keysym_keycode, nullptr);
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1202,10 +1202,10 @@ void TileMap::_set_tile_data(const Vector<int> &p_data) {
 		uint16_t x = decode_uint16(&local[0]);
 		uint16_t y = decode_uint16(&local[2]);
 		uint32_t v = decode_uint32(&local[4]);
-		bool flip_h = v & (1 << 29);
-		bool flip_v = v & (1 << 30);
-		bool transpose = v & (1 << 31);
-		v &= (1 << 29) - 1;
+		bool flip_h = v & (1u << 29);
+		bool flip_v = v & (1u << 30);
+		bool transpose = v & (1u << 31);
+		v &= (1u << 29) - 1;
 		int16_t coord_x = 0;
 		int16_t coord_y = 0;
 		if (format == FORMAT_2) {
@@ -1231,13 +1231,13 @@ Vector<int> TileMap::_get_tile_data() const {
 		encode_uint16(E->key().y, &ptr[2]);
 		uint32_t val = E->get().id;
 		if (E->get().flip_h) {
-			val |= (1 << 29);
+			val |= (1u << 29);
 		}
 		if (E->get().flip_v) {
-			val |= (1 << 30);
+			val |= (1u << 30);
 		}
 		if (E->get().transpose) {
-			val |= (1 << 31);
+			val |= (1u << 31);
 		}
 		encode_uint32(val, &ptr[4]);
 		encode_uint16(E->get().autotile_coord_x, &ptr[8]);

--- a/servers/physics_2d/broad_phase_2d_hash_grid.h
+++ b/servers/physics_2d/broad_phase_2d_hash_grid.h
@@ -137,7 +137,7 @@ class BroadPhase2DHashGrid : public BroadPhase2DSW {
 			k = k ^ (k >> 11);
 			k = k + (k << 6);
 			k = k ^ (k >> 22);
-			return k;
+			return uint32_t(k);
 		}
 
 		bool operator==(const PosKey &p_key) const { return key == p_key.key; }

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -66,7 +66,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		SHADER_VARIANT_MAX
 	};
 
-	enum {
+	enum : uint32_t {
 		FLAGS_INSTANCING_STRIDE_MASK = 0xF,
 		FLAGS_INSTANCING_ENABLED = (1 << 4),
 		FLAGS_INSTANCING_HAS_COLORS = (1 << 5),
@@ -90,7 +90,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 
 	};
 
-	enum {
+	enum : uint32_t {
 		LIGHT_FLAGS_TEXTURE_MASK = 0xFFFF,
 		LIGHT_FLAGS_BLEND_SHIFT = 16,
 		LIGHT_FLAGS_BLEND_MASK = (3 << 16),
@@ -103,7 +103,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 
 	};
 
-	enum {
+	enum : uint32_t {
 		MAX_RENDER_ITEMS = 256 * 1024,
 		MAX_LIGHT_TEXTURES = 1024,
 		MAX_LIGHTS_PER_ITEM = 16,

--- a/servers/rendering/renderer_rd/renderer_scene_render_forward.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_forward.cpp
@@ -245,7 +245,7 @@ void RendererSceneRenderForward::ShaderData::set_code(const String &p_code) {
 
 		RD::PolygonCullMode cull_mode_rd = cull_mode_rd_table[i][cull];
 
-		for (int j = 0; j < RS::PRIMITIVE_MAX; j++) {
+		for (unsigned int j = 0; j < RS::PRIMITIVE_MAX; j++) {
 			RD::RenderPrimitive primitive_rd_table[RS::PRIMITIVE_MAX] = {
 				RD::RENDER_PRIMITIVE_POINTS,
 				RD::RENDER_PRIMITIVE_LINES,

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -2426,7 +2426,7 @@ void RendererStorageRD::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_su
 		uint32_t attrib_stride = 0;
 		uint32_t skin_stride = 0;
 
-		for (int i = 0; i < RS::ARRAY_WEIGHTS; i++) {
+		for (unsigned int i = 0; i < RS::ARRAY_WEIGHTS; i++) {
 			if ((p_surface.format & (1 << i))) {
 				switch (i) {
 					case RS::ARRAY_VERTEX: {
@@ -3119,7 +3119,7 @@ void RendererStorageRD::_mesh_surface_generate_version_for_input_mask(Mesh::Surf
 	uint32_t attribute_stride = 0;
 	uint32_t skin_stride = 0;
 
-	for (int i = 0; i < RS::ARRAY_INDEX; i++) {
+	for (unsigned int i = 0; i < RS::ARRAY_INDEX; i++) {
 		RD::VertexAttribute vd;
 		RID buffer;
 		vd.location = i;
@@ -3280,7 +3280,7 @@ void RendererStorageRD::_mesh_surface_generate_version_for_input_mask(Mesh::Surf
 		if (attributes[i].stride == 0) {
 			continue; //default location
 		}
-		int loc = attributes[i].location;
+		unsigned int loc = attributes[i].location;
 
 		if (loc < RS::ARRAY_COLOR) {
 			attributes.write[i].stride = stride;
@@ -8573,8 +8573,8 @@ RendererStorageRD::RendererStorageRD() {
 	}
 
 	//default samplers
-	for (int i = 1; i < RS::CANVAS_ITEM_TEXTURE_FILTER_MAX; i++) {
-		for (int j = 1; j < RS::CANVAS_ITEM_TEXTURE_REPEAT_MAX; j++) {
+	for (unsigned int i = 1; i < RS::CANVAS_ITEM_TEXTURE_FILTER_MAX; i++) {
+		for (unsigned int j = 1; j < RS::CANVAS_ITEM_TEXTURE_REPEAT_MAX; j++) {
 			RD::SamplerState sampler_state;
 			switch (i) {
 				case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST: {
@@ -8961,8 +8961,8 @@ RendererStorageRD::~RendererStorageRD() {
 	}
 
 	//def samplers
-	for (int i = 1; i < RS::CANVAS_ITEM_TEXTURE_FILTER_MAX; i++) {
-		for (int j = 1; j < RS::CANVAS_ITEM_TEXTURE_REPEAT_MAX; j++) {
+	for (unsigned int i = 1; i < RS::CANVAS_ITEM_TEXTURE_FILTER_MAX; i++) {
+		for (unsigned int j = 1; j < RS::CANVAS_ITEM_TEXTURE_REPEAT_MAX; j++) {
 			RD::get_singleton()->free(default_rd_samplers[i][j]);
 		}
 	}

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -329,7 +329,7 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint
 
 	int max_bone = 0;
 
-	for (int ai = 0; ai < RS::ARRAY_MAX; ai++) {
+	for (unsigned int ai = 0; ai < RS::ARRAY_MAX; ai++) {
 		if (!(p_format & (1 << ai))) { // no array
 			continue;
 		}
@@ -717,7 +717,7 @@ void RenderingServer::mesh_surface_make_offsets_from_format(uint32_t p_format, i
 
 	uint32_t *size_accum;
 
-	for (int i = 0; i < RS::ARRAY_MAX; i++) {
+	for (unsigned int i = 0; i < RS::ARRAY_MAX; i++) {
 		r_offsets[i] = 0; //reset
 
 		if (i == RS::ARRAY_VERTEX) {
@@ -1041,7 +1041,7 @@ Array RenderingServer::_get_array_from_surface(uint32_t p_format, Vector<uint8_t
 	const uint8_t *ar = p_attrib_data.ptr();
 	const uint8_t *sr = p_skin_data.ptr();
 
-	for (int i = 0; i < RS::ARRAY_MAX; i++) {
+	for (unsigned int i = 0; i < RS::ARRAY_MAX; i++) {
 		if (!(p_format & (1 << i))) {
 			continue;
 		}

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -212,7 +212,7 @@ public:
 
 	/* MESH API */
 
-	enum ArrayType {
+	enum ArrayType : uint32_t {
 		ARRAY_VERTEX = 0, // RG32F or RGB32F (depending on 2D bit)
 		ARRAY_NORMAL = 1, // A2B10G10R10
 		ARRAY_TANGENT = 2, // A2B10G10R10, A flips sign of binormal
@@ -245,7 +245,7 @@ public:
 		ARRAY_CUSTOM_MAX
 	};
 
-	enum ArrayFormat {
+	enum ArrayFormat : uint32_t {
 		/* ARRAY FORMAT FLAGS */
 		ARRAY_FORMAT_VERTEX = 1 << ARRAY_VERTEX, // mandatory
 		ARRAY_FORMAT_NORMAL = 1 << ARRAY_NORMAL,
@@ -278,7 +278,7 @@ public:
 		ARRAY_FLAG_USE_8_BONE_WEIGHTS = 1 << (ARRAY_COMPRESS_FLAGS_BASE + 2),
 	};
 
-	enum PrimitiveType {
+	enum PrimitiveType : uint32_t {
 		PRIMITIVE_POINTS,
 		PRIMITIVE_LINES,
 		PRIMITIVE_LINE_STRIP,
@@ -1225,7 +1225,7 @@ public:
 
 	virtual void canvas_item_set_draw_behind_parent(RID p_item, bool p_enable) = 0;
 
-	enum NinePatchAxisMode {
+	enum NinePatchAxisMode : uint32_t {
 		NINE_PATCH_STRETCH,
 		NINE_PATCH_TILE,
 		NINE_PATCH_TILE_FIT,

--- a/thirdparty/misc/pcg.cpp
+++ b/thirdparty/misc/pcg.cpp
@@ -9,7 +9,7 @@ uint32_t pcg32_random_r(pcg32_random_t* rng)
     // Advance internal state
     rng->state = oldstate * 6364136223846793005ULL + (rng->inc|1);
     // Calculate output function (XSH RR), uses old state for max ILP
-    uint32_t xorshifted = ((oldstate >> 18u) ^ oldstate) >> 27u;
+    uint32_t xorshifted = uint32_t(((oldstate >> 18u) ^ oldstate) >> 27u);
     uint32_t rot = oldstate >> 59u;
     return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
 }


### PR DESCRIPTION
Fixes #33236
Fixes #41293

This should silence warnings similar to #41293, which are completely useless since are used in hashing or as enum flags(it's not the value that counts, it's the specific distribution of the bits).

This PR adds several explicit conversions for incompatible types that are not due to an error.