### PR TITLE
Fix Shader default_texture_param not being fed to render code.

### DIFF
--- a/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.cpp
@@ -1958,6 +1958,13 @@ void RasterizerCanvasRD::ShaderData::set_default_texture_param(const StringName 
 	}
 }
 
+RID RasterizerCanvasRD::ShaderData::get_default_texture_param(const StringName &p_name) const {
+	if (default_texture_params.has(p_name)) {
+		return default_texture_params[p_name];
+	}
+	return RID();
+}
+
 void RasterizerCanvasRD::ShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
 	Map<int, StringName> order;
 

--- a/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.h
@@ -182,6 +182,7 @@ class RasterizerCanvasRD : public RasterizerCanvas {
 
 		virtual void set_code(const String &p_Code);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture);
+		virtual RID get_default_texture_param(const StringName &p_name) const;
 		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
 		virtual void get_instance_param_list(List<RasterizerStorage::InstanceShaderParam> *p_param_list) const;
 

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -302,6 +302,13 @@ void RasterizerSceneHighEndRD::ShaderData::set_default_texture_param(const Strin
 	}
 }
 
+RID RasterizerSceneHighEndRD::ShaderData::get_default_texture_param(const StringName &p_name) const {
+	if (default_texture_params.has(p_name)) {
+		return default_texture_params[p_name];
+	}
+	return RID();
+}
+
 void RasterizerSceneHighEndRD::ShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
 	Map<int, StringName> order;
 

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.h
@@ -153,6 +153,7 @@ class RasterizerSceneHighEndRD : public RasterizerSceneRD {
 
 		virtual void set_code(const String &p_Code);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture);
+		virtual RID get_default_texture_param(const StringName &p_name) const;
 		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
 		void get_instance_param_list(List<RasterizerStorage::InstanceShaderParam> *p_param_list) const;
 

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_rd.cpp
@@ -2548,6 +2548,13 @@ void RasterizerSceneRD::SkyShaderData::set_default_texture_param(const StringNam
 	}
 }
 
+RID RasterizerSceneRD::SkyShaderData::get_default_texture_param(const StringName &p_name) const {
+	if (default_texture_params.has(p_name)) {
+		return default_texture_params[p_name];
+	}
+	return RID();
+}
+
 void RasterizerSceneRD::SkyShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
 	Map<int, StringName> order;
 

--- a/servers/rendering/rasterizer_rd/rasterizer_scene_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_rd.h
@@ -198,6 +198,7 @@ private:
 
 		virtual void set_code(const String &p_Code);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture);
+		virtual RID get_default_texture_param(const StringName &p_name) const;
 		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
 		virtual void get_instance_param_list(List<RasterizerStorage::InstanceShaderParam> *p_param_list) const;
 		virtual bool is_param_texture(const StringName &p_param) const;

--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
@@ -1083,9 +1083,9 @@ void RasterizerStorageRD::shader_set_default_texture_param(RID p_shader, const S
 	ERR_FAIL_COND(!shader);
 
 	if (p_texture.is_valid() && texture_owner.owns(p_texture)) {
-		shader->default_texture_parameter[p_name] = p_texture;
+		shader->data->set_default_texture_param(p_name, p_texture);
 	} else {
-		shader->default_texture_parameter.erase(p_name);
+		shader->data->set_default_texture_param(p_name, RID{});
 	}
 
 	for (Set<Material *>::Element *E = shader->owners.front(); E; E = E->next()) {
@@ -1097,10 +1097,9 @@ void RasterizerStorageRD::shader_set_default_texture_param(RID p_shader, const S
 RID RasterizerStorageRD::shader_get_default_texture_param(RID p_shader, const StringName &p_name) const {
 	Shader *shader = shader_owner.getornull(p_shader);
 	ERR_FAIL_COND_V(!shader, RID());
-	if (shader->default_texture_parameter.has(p_name)) {
-		return shader->default_texture_parameter[p_name];
+	if (shader->data) {
+		return shader->data->get_default_texture_param(p_name);
 	}
-
 	return RID();
 }
 

--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
@@ -114,6 +114,7 @@ public:
 	struct ShaderData {
 		virtual void set_code(const String &p_Code) = 0;
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture) = 0;
+		virtual RID get_default_texture_param(const StringName &p_name) const = 0;
 		virtual void get_param_list(List<PropertyInfo> *p_param_list) const = 0;
 
 		virtual void get_instance_param_list(List<InstanceShaderParam> *p_param_list) const = 0;
@@ -300,7 +301,6 @@ private:
 		ShaderData *data;
 		String code;
 		ShaderType type;
-		Map<StringName, RID> default_texture_parameter;
 		Set<Material *> owners;
 	};
 


### PR DESCRIPTION
Observed when assigning gradient to visual shader.

See rasterizer_storage_rd.h

default_texture_param map in both Shader and ShaderData. Rendering code reads from ShaderData map but not Shader map. Shader map however is not being fed to ShaderData map, causing rendering code to never retrieve the appropriate texture.
.
Fixed by removing Shader default_texture_param and only having the data owned by ShaderData. Following the premise of RasterizerStorageRD::shader_get_param_default.

Minimal Repro
[debug.zip](https://github.com/godotengine/godot/files/5079609/debug.zip)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
