### PR TITLE
[3.2] Check intersect_ray normal is not a zero vector, to ensure the ray is colliding with and not just enclosed in the shape.

### DIFF
--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -216,8 +216,8 @@ void RayCast2D::_update_raycast_state() {
 
 	Physics2DDirectSpaceState::RayResult rr;
 
-	if (dss->intersect_ray(gt.get_origin(), gt.xform(to), rr, exclude, collision_mask, collide_with_bodies, collide_with_areas)) {
-
+	if (dss->intersect_ray(gt.get_origin(), gt.xform(to), rr, exclude, collision_mask, collide_with_bodies, collide_with_areas) &&
+			rr.normal != Vector2()) {
 		collided = true;
 		against = rr.collider_id;
 		collision_point = rr.position;

--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -210,8 +210,8 @@ void RayCast::_update_raycast_state() {
 
 	PhysicsDirectSpaceState::RayResult rr;
 
-	if (dss->intersect_ray(gt.get_origin(), gt.xform(to), rr, exclude, collision_mask, collide_with_bodies, collide_with_areas)) {
-
+	if (dss->intersect_ray(gt.get_origin(), gt.xform(to), rr, exclude, collision_mask, collide_with_bodies, collide_with_areas) &&
+			rr.normal != Vector3()) {
 		collided = true;
 		against = rr.collider_id;
 		collision_point = rr.position;


### PR DESCRIPTION
3.2 version of #41277.