### PR TITLE
Check for uncompressed uvs in Sprite3D

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -430,12 +430,12 @@ SpriteBase3D::SpriteBase3D() {
 	mesh_array[VS::ARRAY_TEX_UV] = mesh_uvs;
 
 	VS::get_singleton()->mesh_add_surface_from_arrays(mesh, VS::PRIMITIVE_TRIANGLE_FAN, mesh_array);
-	const uint32_t surface_format = VS::get_singleton()->mesh_surface_get_format(mesh, 0);
 	const int surface_vertex_len = VS::get_singleton()->mesh_surface_get_array_len(mesh, 0);
 	const int surface_index_len = VS::get_singleton()->mesh_surface_get_array_index_len(mesh, 0);
 
+	mesh_surface_format = VS::get_singleton()->mesh_surface_get_format(mesh, 0);
 	mesh_buffer = VS::get_singleton()->mesh_surface_get_array(mesh, 0);
-	mesh_stride = VS::get_singleton()->mesh_surface_make_offsets_from_format(surface_format, surface_vertex_len, surface_index_len, mesh_surface_offsets);
+	mesh_stride = VS::get_singleton()->mesh_surface_make_offsets_from_format(mesh_surface_format, surface_vertex_len, surface_index_len, mesh_surface_offsets);
 }
 
 SpriteBase3D::~SpriteBase3D() {
@@ -584,13 +584,18 @@ void Sprite3D::_draw() {
 		} else {
 			aabb.expand_to(vtx);
 		}
+		if (mesh_surface_format & VS::ARRAY_COMPRESS_TEX_UV) {
+			uint16_t v_uv[2] = { Math::make_half_float(uvs[i].x), Math::make_half_float(uvs[i].y) };
+			copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 4);
+		} else {
+			float v_uv[2] = { uvs[i].x, uvs[i].y };
+			copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 8);
+		}
 
-		uint16_t v_uv[2] = { Math::make_half_float(uvs[i].x), Math::make_half_float(uvs[i].y) };
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_VERTEX]], &vertices[i], sizeof(float) * 2);
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_NORMAL]], v_normal, 4);
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TANGENT]], v_tangent, 4);
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_COLOR]], v_color, 4);
-		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 2 * 2);
 	}
 
 	write_buffer.release();
@@ -945,12 +950,18 @@ void AnimatedSprite3D::_draw() {
 			aabb.expand_to(vtx);
 		}
 
-		uint16_t v_uv[2] = { Math::make_half_float(uvs[i].x), Math::make_half_float(uvs[i].y) };
+		if (mesh_surface_format & VS::ARRAY_COMPRESS_TEX_UV) {
+			uint16_t v_uv[2] = { Math::make_half_float(uvs[i].x), Math::make_half_float(uvs[i].y) };
+			copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 4);
+		} else {
+			float v_uv[2] = { uvs[i].x, uvs[i].y };
+			copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 8);
+		}
+
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_VERTEX]], &vertices[i], sizeof(float) * 2);
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_NORMAL]], v_normal, 4);
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TANGENT]], v_tangent, 4);
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_COLOR]], v_color, 4);
-		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 2 * 2);
 	}
 
 	write_buffer.release();

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -99,6 +99,7 @@ protected:
 	uint32_t mesh_surface_offsets[VS::ARRAY_MAX];
 	PoolByteArray mesh_buffer;
 	uint32_t mesh_stride;
+	uint32_t mesh_surface_format;
 
 	void _queue_update();
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/41270


Previously Sprite3D assumed default compression settings, but some platforms don't support half floats so the rasterizer uncompresses them:(https://github.com/godotengine/godot/blob/72d12289bb5e46ad2ec840a23a247f5690afb0d3/drivers/gles2/rasterizer_storage_gles2.cpp#L2063

 Specifically, UVs change size. This PR makes Sprite3D check for compressed UVs

