### PR TITLE
Updated output log with multiple enhancements and feature additions.

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -122,12 +122,7 @@ void EditorLog::_process_message(const String &p_msg, MessageType p_type) {
 		LogMessage &previous = messages.write[messages.size() - 1];
 		previous.count++;
 
-		if (collapse) {
-			// Remove last line if collapsing, as it will be replace by the next added line with an updated count.
-			log->remove_line(log->get_line_count() - 1);
-		}
-
-		_add_log_line(previous);
+		_add_log_line(previous, collapse);
 	} else {
 		// Different message to the previous one received.
 		LogMessage message(p_msg, p_type);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -63,6 +63,18 @@ void EditorLog::_notification(int p_what) {
 		log->add_theme_font_override("normal_font", get_theme_font("output_source", "EditorFonts"));
 		log->add_theme_font_size_override("normal_font_size", get_theme_font_size("output_source_size", "EditorFonts"));
 		log->add_theme_color_override("selection_color", get_theme_color("accent_color", "Editor") * Color(1, 1, 1, 0.4));
+		log->add_theme_font_override("bold_font", get_theme_font("bold", "EditorFonts"));
+
+		type_filter_map[MSG_TYPE_STD]->toggle_button->set_icon(get_theme_icon("Popup", "EditorIcons"));
+		type_filter_map[MSG_TYPE_ERROR]->toggle_button->set_icon(get_theme_icon("StatusError", "EditorIcons"));
+		type_filter_map[MSG_TYPE_WARNING]->toggle_button->set_icon(get_theme_icon("StatusWarning", "EditorIcons"));
+		type_filter_map[MSG_TYPE_EDITOR]->toggle_button->set_icon(get_theme_icon("Edit", "EditorIcons"));
+
+		clear_button->set_icon(get_theme_icon("Clear", "EditorIcons"));
+		copy_button->set_icon(get_theme_icon("ActionCopy", "EditorIcons"));
+		collapse_button->set_icon(get_theme_icon("CombineLines", "EditorIcons"));
+		show_search_button->set_icon(get_theme_icon("Search", "EditorIcons"));
+
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
 		Ref<Font> df_output_code = get_theme_font("output_source", "EditorFonts");
 		if (df_output_code.is_valid()) {
@@ -75,8 +87,15 @@ void EditorLog::_notification(int p_what) {
 	}
 }
 
+void EditorLog::_set_collapse(bool p_collapse) {
+	collapse = p_collapse;
+	_rebuild_log();
+}
+
 void EditorLog::_clear_request() {
 	log->clear();
+	messages.clear();
+	_reset_message_counts();
 	tool_button->set_icon(Ref<Texture2D>());
 }
 
@@ -96,13 +115,88 @@ void EditorLog::clear() {
 	_clear_request();
 }
 
-void EditorLog::copy() {
-	_copy_request();
+void EditorLog::_process_message(const String &p_msg, MessageType p_type) {
+	if (messages.size() > 0 && messages[messages.size() - 1].text == p_msg) {
+		// If previous message is the same as the new one, increase previous count rather than adding another
+		// instance to the messages list.
+		LogMessage &previous = messages.write[messages.size() - 1];
+		previous.count++;
+
+		if (collapse) {
+			// Remove last line if collapsing, as it will be replace by the next added line with an updated count.
+			log->remove_line(log->get_line_count() - 1);
+		}
+
+		_add_log_line(previous);
+	} else {
+		// Different message to the previous one received.
+		LogMessage message(p_msg, p_type);
+		_add_log_line(message);
+		messages.push_back(message);
+	}
+
+	type_filter_map[p_type]->set_message_count(type_filter_map[p_type]->get_message_count() + 1);
 }
 
 void EditorLog::add_message(const String &p_msg, MessageType p_type) {
-	bool restore = p_type != MSG_TYPE_STD;
-	switch (p_type) {
+	// Make text split by new lines their own message.
+	// See #41321 for reasoning. At time of writing, multiple print()'s in running projects
+	// get grouped together and sent to the editor log as one message. This can mess with the
+	// search functionality (see the comments on the PR above for more details). This behaviour
+	// also matches that of other IDE's.
+	Vector<String> lines = p_msg.split("\n", false);
+
+	for (int i = 0; i < lines.size(); i++) {
+		_process_message(lines[i], p_type);
+	}
+}
+
+void EditorLog::set_tool_button(Button *p_tool_button) {
+	tool_button = p_tool_button;
+}
+
+void EditorLog::_undo_redo_cbk(void *p_self, const String &p_name) {
+	EditorLog *self = (EditorLog *)p_self;
+	self->add_message(p_name, EditorLog::MSG_TYPE_EDITOR);
+}
+
+void EditorLog::_rebuild_log() {
+	log->clear();
+
+	for (int msg_idx = 0; msg_idx < messages.size(); msg_idx++) {
+		LogMessage msg = messages[msg_idx];
+
+		if (collapse) {
+			// If collapsing, only log one instance of the message.
+			_add_log_line(msg);
+		} else {
+			// If not collapsing, log each instance on a line.
+			for (int i = 0; i < msg.count; i++) {
+				_add_log_line(msg);
+			}
+		}
+	}
+}
+
+void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
+	// Only add the message to the log if it passes the filters.
+	bool filter_active = type_filter_map[p_message.type]->active;
+	String search_text = search_box->get_text();
+	bool search_match = search_text == String() || p_message.text.findn(search_text) > -1;
+
+	if (!filter_active || !search_match) {
+		return;
+	}
+
+	if (p_replace_previous) {
+		// Remove last line if replacing, as it will be replace by the next added line.
+		log->remove_line(log->get_line_count() - 1);
+		log->increment_line_count();
+	} else {
+		log->add_newline();
+	}
+
+	switch (p_message.type) {
 		case MSG_TYPE_STD: {
 		} break;
 		case MSG_TYPE_ERROR: {
@@ -125,21 +219,42 @@ void EditorLog::add_message(const String &p_msg, MessageType p_type) {
 		} break;
 	}
 
-	log->add_text(p_msg);
-	log->add_newline();
+	// If collapsing, add the count of this message in bold at the start of the line.
+	if (collapse && p_message.count > 1) {
+		log->push_bold();
+		log->add_text(vformat("(%s) ", itos(p_message.count)));
+		log->pop();
+	}
 
-	if (restore) {
+	log->add_text(p_message.text);
+
+	// Need to use pop() to exit out of the RichTextLabels current "push" stack.
+	// We only "push" in the above swicth when message type != STD, so only pop when that is the case.
+	if (p_message.type != MSG_TYPE_STD) {
 		log->pop();
 	}
 }
 
-void EditorLog::set_tool_button(Button *p_tool_button) {
-	tool_button = p_tool_button;
+void EditorLog::_set_filter_active(bool p_active, MessageType p_message_type) {
+	type_filter_map[p_message_type]->active = p_active;
+	_rebuild_log();
 }
 
-void EditorLog::_undo_redo_cbk(void *p_self, const String &p_name) {
-	EditorLog *self = (EditorLog *)p_self;
-	self->add_message(p_name, EditorLog::MSG_TYPE_EDITOR);
+void EditorLog::_set_search_visible(bool p_visible) {
+	search_box->set_visible(p_visible);
+	if (p_visible) {
+		search_box->grab_focus();
+	}
+}
+
+void EditorLog::_search_changed(const String &p_text) {
+	_rebuild_log();
+}
+
+void EditorLog::_reset_message_counts() {
+	for (Map<MessageType, LogFilter *>::Element *E = type_filter_map.front(); E; E = E->next()) {
+		E->value()->set_message_count(0);
+	}
 }
 
 void EditorLog::_bind_methods() {
@@ -148,37 +263,105 @@ void EditorLog::_bind_methods() {
 }
 
 EditorLog::EditorLog() {
-	VBoxContainer *vb = this;
+	HBoxContainer *hb = this;
 
-	HBoxContainer *hb = memnew(HBoxContainer);
-	vb->add_child(hb);
-	title = memnew(Label);
-	title->set_text(TTR("Output:"));
-	title->set_h_size_flags(SIZE_EXPAND_FILL);
-	hb->add_child(title);
+	VBoxContainer *vb_left = memnew(VBoxContainer);
+	vb_left->set_custom_minimum_size(Size2(0, 180) * EDSCALE);
+	vb_left->set_v_size_flags(SIZE_EXPAND_FILL);
+	vb_left->set_h_size_flags(SIZE_EXPAND_FILL);
+	hb->add_child(vb_left);
 
-	copybutton = memnew(Button);
-	hb->add_child(copybutton);
-	copybutton->set_text(TTR("Copy"));
-	copybutton->set_shortcut(ED_SHORTCUT("editor/copy_output", TTR("Copy Selection"), KEY_MASK_CMD | KEY_C));
-	copybutton->set_shortcut_context(this);
-	copybutton->connect("pressed", callable_mp(this, &EditorLog::_copy_request));
-
-	clearbutton = memnew(Button);
-	hb->add_child(clearbutton);
-	clearbutton->set_text(TTR("Clear"));
-	clearbutton->set_shortcut(ED_SHORTCUT("editor/clear_output", TTR("Clear Output"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_K));
-	clearbutton->set_shortcut_context(this);
-	clearbutton->connect("pressed", callable_mp(this, &EditorLog::_clear_request));
-
+	// Log - Rich Text Label.
 	log = memnew(RichTextLabel);
 	log->set_scroll_follow(true);
 	log->set_selection_enabled(true);
 	log->set_focus_mode(FOCUS_CLICK);
-	log->set_custom_minimum_size(Size2(0, 180) * EDSCALE);
 	log->set_v_size_flags(SIZE_EXPAND_FILL);
 	log->set_h_size_flags(SIZE_EXPAND_FILL);
-	vb->add_child(log);
+	vb_left->add_child(log);
+
+	// Search box
+	search_box = memnew(LineEdit);
+	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search_box->set_placeholder(TTR("Filter messages"));
+	search_box->set_right_icon(get_theme_icon("Search", "EditorIcons"));
+	search_box->set_clear_button_enabled(true);
+	search_box->set_visible(true);
+	search_box->connect("text_changed", callable_mp(this, &EditorLog::_search_changed));
+	vb_left->add_child(search_box);
+
+	VBoxContainer *vb_right = memnew(VBoxContainer);
+	hb->add_child(vb_right);
+
+	// Tools grid
+	HBoxContainer *hb_tools = memnew(HBoxContainer);
+	hb_tools->set_h_size_flags(SIZE_SHRINK_CENTER);
+	vb_right->add_child(hb_tools);
+
+	// Clear.
+	clear_button = memnew(Button);
+	clear_button->set_flat(true);
+	clear_button->set_focus_mode(FOCUS_NONE);
+	clear_button->set_shortcut(ED_SHORTCUT("editor/clear_output", TTR("Clear Output"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_K));
+	clear_button->connect("pressed", callable_mp(this, &EditorLog::_clear_request));
+	hb_tools->add_child(clear_button);
+
+	// Copy.
+	copy_button = memnew(Button);
+	copy_button->set_flat(true);
+	copy_button->set_focus_mode(FOCUS_NONE);
+	copy_button->set_shortcut(ED_SHORTCUT("editor/copy_output", TTR("Copy Selection"), KEY_MASK_CMD | KEY_C));
+	copy_button->connect("pressed", callable_mp(this, &EditorLog::_copy_request));
+	hb_tools->add_child(copy_button);
+
+	// A second hbox to make a 2x2 grid of buttons.
+	HBoxContainer *hb_tools2 = memnew(HBoxContainer);
+	hb_tools2->set_h_size_flags(SIZE_SHRINK_CENTER);
+	vb_right->add_child(hb_tools2);
+
+	// Collapse.
+	collapse_button = memnew(Button);
+	collapse_button->set_flat(true);
+	collapse_button->set_focus_mode(FOCUS_NONE);
+	collapse_button->set_tooltip(TTR("Collapse duplicate messages into one log entry. Shows number of occurences."));
+	collapse_button->set_toggle_mode(true);
+	collapse_button->set_pressed(false);
+	collapse_button->connect("toggled", callable_mp(this, &EditorLog::_set_collapse));
+	hb_tools2->add_child(collapse_button);
+
+	// Show Search.
+	show_search_button = memnew(Button);
+	show_search_button->set_flat(true);
+	show_search_button->set_focus_mode(FOCUS_NONE);
+	show_search_button->set_toggle_mode(true);
+	show_search_button->set_pressed(true);
+	show_search_button->set_shortcut(ED_SHORTCUT("editor/open_search", TTR("Open the search box."), KEY_MASK_CMD | KEY_F));
+	show_search_button->connect("toggled", callable_mp(this, &EditorLog::_set_search_visible));
+	hb_tools2->add_child(show_search_button);
+
+	// Message Type Filters.
+	vb_right->add_child(memnew(HSeparator));
+
+	LogFilter *std_filter = memnew(LogFilter(MSG_TYPE_STD));
+	std_filter->initialize_button("Toggle visibility of standard output messages.", callable_mp(this, &EditorLog::_set_filter_active));
+	vb_right->add_child(std_filter->toggle_button);
+	type_filter_map.insert(MSG_TYPE_STD, std_filter);
+
+	LogFilter *error_filter = memnew(LogFilter(MSG_TYPE_ERROR));
+	error_filter->initialize_button("Toggle visibility of errors.", callable_mp(this, &EditorLog::_set_filter_active));
+	vb_right->add_child(error_filter->toggle_button);
+	type_filter_map.insert(MSG_TYPE_ERROR, error_filter);
+
+	LogFilter *warning_filter = memnew(LogFilter(MSG_TYPE_WARNING));
+	warning_filter->initialize_button("Toggle visibility of warnings.", callable_mp(this, &EditorLog::_set_filter_active));
+	vb_right->add_child(warning_filter->toggle_button);
+	type_filter_map.insert(MSG_TYPE_WARNING, warning_filter);
+
+	LogFilter *editor_filter = memnew(LogFilter(MSG_TYPE_EDITOR));
+	editor_filter->initialize_button("Toggle visibility of editor messages.", callable_mp(this, &EditorLog::_set_filter_active));
+	vb_right->add_child(editor_filter->toggle_button);
+	type_filter_map.insert(MSG_TYPE_EDITOR, editor_filter);
+
 	add_message(VERSION_FULL_NAME " (c) 2007-2021 Juan Linietsky, Ariel Manzur & Godot Contributors.");
 
 	eh.errfunc = _error_handler;
@@ -186,8 +369,6 @@ EditorLog::EditorLog() {
 	add_error_handler(&eh);
 
 	current = Thread::get_caller_id();
-
-	add_theme_constant_override("separation", get_theme_constant("separation", "VBoxContainer"));
 
 	EditorNode::get_undo_redo()->set_commit_notify_callback(_undo_redo_cbk, this);
 }
@@ -197,4 +378,7 @@ void EditorLog::deinit() {
 }
 
 EditorLog::~EditorLog() {
+	for (Map<MessageType, LogFilter *>::Element *E = type_filter_map.front(); E; E = E->next()) {
+		memdelete(E->get());
+	}
 }

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -36,19 +36,92 @@
 #include "scene/gui/button.h"
 #include "scene/gui/control.h"
 #include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/texture_button.h"
 #include "scene/gui/texture_rect.h"
 
-class EditorLog : public VBoxContainer {
-	GDCLASS(EditorLog, VBoxContainer);
+class EditorLog : public HBoxContainer {
+	GDCLASS(EditorLog, HBoxContainer);
 
-	Button *clearbutton;
-	Button *copybutton;
-	Label *title;
+public:
+	enum MessageType {
+		MSG_TYPE_STD,
+		MSG_TYPE_ERROR,
+		MSG_TYPE_WARNING,
+		MSG_TYPE_EDITOR,
+	};
+
+private:
+	struct LogMessage {
+		String text;
+		MessageType type;
+		int count = 1;
+
+		LogMessage() {}
+
+		LogMessage(const String p_text, MessageType p_type) :
+				text(p_text),
+				type(p_type) {
+		}
+	};
+
+	// Encapsulates all data and functionality regarding filters.
+	struct LogFilter {
+	private:
+		// Force usage of set method since it has functionality built-in.
+		int message_count = 0;
+
+	public:
+		MessageType type;
+		Button *toggle_button = nullptr;
+		bool active = true;
+
+		void initialize_button(const String &p_tooltip, Callable p_toggled_callback) {
+			toggle_button = memnew(Button);
+			toggle_button->set_toggle_mode(true);
+			toggle_button->set_pressed(true);
+			toggle_button->set_text(itos(message_count));
+			toggle_button->set_tooltip(TTR(p_tooltip));
+			// Don't tint the icon even when in "pressed" state.
+			toggle_button->add_theme_color_override("icon_color_pressed", Color(1, 1, 1, 1));
+			toggle_button->set_focus_mode(FOCUS_NONE);
+			// When toggled call the callback and pass the MessageType this button is for.
+			toggle_button->connect("toggled", p_toggled_callback, varray(type));
+		}
+
+		int get_message_count() {
+			return message_count;
+		}
+
+		void set_message_count(int p_count) {
+			message_count = p_count;
+			toggle_button->set_text(itos(message_count));
+		}
+
+		LogFilter(MessageType p_type) :
+				type(p_type) {
+		}
+	};
+
+	Vector<LogMessage> messages;
+	// Maps MessageTypes to LogFilters for convenient access and storage (don't need 1 member per filter).
+	Map<MessageType, LogFilter *> type_filter_map;
+
 	RichTextLabel *log;
-	HBoxContainer *title_hb;
+
+	Button *clear_button;
+	Button *copy_button;
+
+	Button *collapse_button;
+	bool collapse = false;
+
+	Button *show_search_button;
+	LineEdit *search_box;
+
+	// Reference to the "Output" button on the toolbar so we can update it's icon when
+	// Warnings or Errors are encounetered.
 	Button *tool_button;
 
 	static void _error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, ErrorHandlerType p_type);
@@ -62,26 +135,33 @@ class EditorLog : public VBoxContainer {
 	void _copy_request();
 	static void _undo_redo_cbk(void *p_self, const String &p_name);
 
+	void _rebuild_log();
+	void _add_log_line(LogMessage &p_message, bool p_replace_previous = false);
+
+	void _set_filter_active(bool p_active, MessageType p_message_type);
+	void _set_search_visible(bool p_visible);
+	void _search_changed(const String &p_text);
+
+	void _process_message(const String &p_msg, MessageType p_type);
+	void _reset_message_counts();
+
+	void _set_collapse(bool p_collapse);
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 
 public:
-	enum MessageType {
-		MSG_TYPE_STD,
-		MSG_TYPE_ERROR,
-		MSG_TYPE_WARNING,
-		MSG_TYPE_EDITOR
-	};
-
 	void add_message(const String &p_msg, MessageType p_type = MSG_TYPE_STD);
 	void set_tool_button(Button *p_tool_button);
 	void deinit();
 
 	void clear();
-	void copy();
+
 	EditorLog();
 	~EditorLog();
 };
+
+VARIANT_ENUM_CAST(EditorLog::MessageType);
 
 #endif // EDITOR_LOG_H

--- a/editor/icons/CombineLines.svg
+++ b/editor/icons/CombineLines.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="M1 2v2h14V2zm7 5v2h7V7zm0 5v2h7v-2zM4.976 14V9h2l-1.5-2-1.5-2-1.5 2-1.5 2h2v5z" fill="#e0e0e0"/></svg>

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2612,6 +2612,13 @@ void RichTextLabel::pop() {
 	current = current->parent;
 }
 
+// Creates a new line without adding an ItemNewline to the previous line.
+// Useful when wanting to calling remove_line and add a new line immediately after.
+void RichTextLabel::increment_line_count() {
+	current_frame->lines.resize(current_frame->lines.size() + 1);
+	_invalidate_current_line(current_frame);
+}
+
 void RichTextLabel::clear() {
 	main->_clear_children();
 	current = main;

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -483,6 +483,8 @@ public:
 	void push_cell();
 	void pop();
 
+	void increment_line_count();
+
 	void clear();
 
 	void set_offset(int p_pixel);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/898#issue-624711321

From Output Log Tracker (#19122):
Closes part of #10870 (no. 2 on that list)
Closes #19098 (which was already closed but not addressed. A similar issue was not recreated in the Proposals repo)
Closes https://github.com/godotengine/godot-proposals/issues/971

Supercedes:
#39274
The above implementation only filters _incoming_ messages. It does not filter messages already in the log.

#38593
The idea of #38593 was to save vertical space. Putting them in a context menu obscures them a bit, so I think putting them vertically is a good compromise. Vertical space is more "valuable" in an output log so this achieves that goal without hiding options.

**Message Type Filters:**
![filters_showcase](https://user-images.githubusercontent.com/41730826/90373858-ed1ca000-e0b5-11ea-8cca-8ce0120087a4.gif)

**Collapse/Stack Duplicate Messages**
![collapse_showcase](https://user-images.githubusercontent.com/41730826/90373891-f9a0f880-e0b5-11ea-8d84-775df7aebf2d.gif)

**Searching**
![search_showcase](https://user-images.githubusercontent.com/41730826/90373904-fe65ac80-e0b5-11ea-923e-f1688b21663b.gif)

There are 2 commits in this PR on purpose. The first adds all log enhancements, the second adds a method to RichTextLabel to improve performance of this output log implementation. **Justification for addition:**

When performing this sequence of operations (which is the main thing the "collapse" functionality uses):

1. remove_line(last_line);
2. add_newline()
3. \<\<Push items as normal\>\>

Extra “newline” items are left behind after the removal. This is because remove_line() removes the content from a line but does not remove the “newline” item on the previous line. This means that if you do several remove_line(), add_newline() operations repeatedly, you get:

- Line1 Content, NewLine
- Line2 Content, NewLine, NewLine, NewLine, NewLine… etc
- Line3 Content

Because there is logic which iterates over all items in remove_item, this data duplication severely slows the speed of execution.
This sequence of operations is critical for the “collapse” functionality of the output log. 

With this change in effect, the log can output, at once (1 frame), 10,000 messages collapsed into one line in **250ms**. Without this change, it takes **12 minutes**.
