### PR TITLE
[Windows] Move console redirection to the OS constructor to allow test output.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3027,17 +3027,8 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	control_mem = false;
 	meta_mem = false;
 
-	if (AttachConsole(ATTACH_PARENT_PROCESS)) {
-		FILE *_file = nullptr;
-		freopen_s(&_file, "CONOUT$", "w", stdout);
-		freopen_s(&_file, "CONOUT$", "w", stderr);
-		freopen_s(&_file, "CONIN$", "r", stdin);
+	console_visible = (GetConsoleWindow() != nullptr);
 
-		printf("\n");
-		console_visible = true;
-	} else {
-		console_visible = false;
-	}
 	hInstance = ((OS_Windows *)OS::get_singleton())->get_hinstance();
 
 	pressrc = 0;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -180,6 +180,14 @@ void OS_Windows::initialize() {
 	crash_handler.initialize();
 
 	//RedirectIOToConsole();
+	if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+		FILE *_file = nullptr;
+		freopen_s(&_file, "CONOUT$", "w", stdout);
+		freopen_s(&_file, "CONOUT$", "w", stderr);
+		freopen_s(&_file, "CONIN$", "r", stdin);
+
+		printf("\n");
+	}
 
 	ThreadWindows::make_default();
 	RWLockWindows::make_default();


### PR DESCRIPTION
Move console redirection from `DisplaySever` to the `OS` constructor.

Fixes #41307

<img width="860" alt="Capture" src="https://user-images.githubusercontent.com/7645683/90391278-87202080-e095-11ea-8875-7076669cce55.PNG">
