### PR TITLE
Add GDScript code generation abstraction

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -505,6 +505,9 @@ void GDScriptAnalyzer::resolve_class_interface(GDScriptParser::ClassNode *p_clas
 					member.variable->set_datatype(datatype); // Allow recursive usage.
 					reduce_expression(member.variable->initializer);
 					datatype = member.variable->initializer->get_datatype();
+					if (datatype.type_source != GDScriptParser::DataType::UNDETECTED) {
+						datatype.type_source = GDScriptParser::DataType::INFERRED;
+					}
 				}
 
 				if (member.variable->datatype_specifier != nullptr) {
@@ -540,6 +543,7 @@ void GDScriptAnalyzer::resolve_class_interface(GDScriptParser::ClassNode *p_clas
 					} else if (datatype.builtin_type == Variant::NIL) {
 						push_error(vformat(R"(Cannot infer the type of "%s" variable because the initial value is "null".)", member.variable->identifier->name), member.variable->initializer);
 					}
+					datatype.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
 				}
 
 				datatype.is_constant = false;
@@ -914,6 +918,7 @@ void GDScriptAnalyzer::decide_suite_type(GDScriptParser::Node *p_suite, GDScript
 				p_suite->datatype.type_source = GDScriptParser::DataType::UNDETECTED;
 			} else {
 				p_suite->set_datatype(p_statement->get_datatype());
+				p_suite->datatype.type_source = GDScriptParser::DataType::INFERRED;
 			}
 			break;
 		default:

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1,0 +1,736 @@
+/*************************************************************************/
+/*  gdscript_byte_codegen.cpp                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gdscript_byte_codegen.h"
+
+#include "core/debugger/engine_debugger.h"
+#include "gdscript.h"
+
+uint32_t GDScriptByteCodeGenerator::add_parameter(const StringName &p_name, bool p_is_optional, const GDScriptDataType &p_type) {
+#ifdef TOOLS_ENABLED
+	function->arg_names.push_back(p_name);
+#endif
+	function->_argument_count++;
+	function->argument_types.push_back(p_type);
+	if (p_is_optional) {
+		if (function->_default_arg_count == 0) {
+			append(GDScriptFunction::OPCODE_JUMP_TO_DEF_ARGUMENT);
+		}
+		function->default_arguments.push_back(opcodes.size());
+		function->_default_arg_count++;
+	}
+
+	return add_local(p_name, p_type);
+}
+
+uint32_t GDScriptByteCodeGenerator::add_local(const StringName &p_name, const GDScriptDataType &p_type) {
+	int stack_pos = increase_stack();
+	add_stack_identifier(p_name, stack_pos);
+	return stack_pos;
+}
+
+uint32_t GDScriptByteCodeGenerator::add_local_constant(const StringName &p_name, const Variant &p_constant) {
+	int index = add_or_get_constant(p_constant);
+	local_constants[p_name] = index;
+	return index;
+}
+
+uint32_t GDScriptByteCodeGenerator::add_or_get_constant(const Variant &p_constant) {
+	if (constant_map.has(p_constant)) {
+		return constant_map[p_constant];
+	}
+	int index = constant_map.size();
+	constant_map[p_constant] = index;
+	return index;
+}
+
+uint32_t GDScriptByteCodeGenerator::add_or_get_name(const StringName &p_name) {
+	return get_name_map_pos(p_name);
+}
+
+uint32_t GDScriptByteCodeGenerator::add_temporary() {
+	current_temporaries++;
+	return increase_stack();
+}
+
+void GDScriptByteCodeGenerator::pop_temporary() {
+	current_stack_size--;
+	current_temporaries--;
+}
+
+void GDScriptByteCodeGenerator::start_parameters() {}
+
+void GDScriptByteCodeGenerator::end_parameters() {
+	function->default_arguments.invert();
+}
+
+void GDScriptByteCodeGenerator::write_start(GDScript *p_script, const StringName &p_function_name, bool p_static, MultiplayerAPI::RPCMode p_rpc_mode, const GDScriptDataType &p_return_type) {
+	function = memnew(GDScriptFunction);
+	debug_stack = EngineDebugger::is_active();
+
+	function->name = p_function_name;
+	function->_script = p_script;
+	function->source = p_script->get_path();
+
+#ifdef DEBUG_ENABLED
+	function->func_cname = (String(function->source) + " - " + String(p_function_name)).utf8();
+	function->_func_cname = function->func_cname.get_data();
+#endif
+
+	function->_static = p_static;
+	function->return_type = p_return_type;
+	function->rpc_mode = p_rpc_mode;
+	function->_argument_count = 0;
+}
+
+GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
+	append(GDScriptFunction::OPCODE_END);
+
+	if (constant_map.size()) {
+		function->_constant_count = constant_map.size();
+		function->constants.resize(constant_map.size());
+		function->_constants_ptr = function->constants.ptrw();
+		const Variant *K = nullptr;
+		while ((K = constant_map.next(K))) {
+			int idx = constant_map[*K];
+			function->constants.write[idx] = *K;
+		}
+	} else {
+		function->_constants_ptr = nullptr;
+		function->_constant_count = 0;
+	}
+
+	if (name_map.size()) {
+		function->global_names.resize(name_map.size());
+		function->_global_names_ptr = &function->global_names[0];
+		for (Map<StringName, int>::Element *E = name_map.front(); E; E = E->next()) {
+			function->global_names.write[E->get()] = E->key();
+		}
+		function->_global_names_count = function->global_names.size();
+
+	} else {
+		function->_global_names_ptr = nullptr;
+		function->_global_names_count = 0;
+	}
+
+	if (opcodes.size()) {
+		function->code = opcodes;
+		function->_code_ptr = &function->code[0];
+		function->_code_size = opcodes.size();
+
+	} else {
+		function->_code_ptr = nullptr;
+		function->_code_size = 0;
+	}
+
+	if (function->default_arguments.size()) {
+		function->_default_arg_count = function->default_arguments.size();
+		function->_default_arg_ptr = &function->default_arguments[0];
+	} else {
+		function->_default_arg_count = 0;
+		function->_default_arg_ptr = nullptr;
+	}
+
+	if (debug_stack) {
+		function->stack_debug = stack_debug;
+	}
+	function->_stack_size = stack_max;
+	function->_call_size = call_max;
+
+	ended = true;
+	return function;
+}
+
+#ifdef DEBUG_ENABLED
+void GDScriptByteCodeGenerator::set_signature(const String &p_signature) {
+	function->profile.signature = p_signature;
+}
+#endif
+
+void GDScriptByteCodeGenerator::set_initial_line(int p_line) {
+	function->_initial_line = p_line;
+}
+
+void GDScriptByteCodeGenerator::write_operator(const Address &p_target, Variant::Operator p_operator, const Address &p_left_operand, const Address &p_right_operand) {
+	append(GDScriptFunction::OPCODE_OPERATOR);
+	append(p_operator);
+	append(p_left_operand);
+	append(p_right_operand);
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_type_test(const Address &p_target, const Address &p_source, const Address &p_type) {
+	append(GDScriptFunction::OPCODE_EXTENDS_TEST);
+	append(p_source);
+	append(p_type);
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_type_test_builtin(const Address &p_target, const Address &p_source, Variant::Type p_type) {
+	append(GDScriptFunction::OPCODE_IS_BUILTIN);
+	append(p_source);
+	append(p_type);
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_and_left_operand(const Address &p_left_operand) {
+	append(GDScriptFunction::OPCODE_JUMP_IF_NOT);
+	append(p_left_operand);
+	logic_op_jump_pos1.push_back(opcodes.size());
+	append(0); // Jump target, will be patched.
+}
+
+void GDScriptByteCodeGenerator::write_and_right_operand(const Address &p_right_operand) {
+	append(GDScriptFunction::OPCODE_JUMP_IF_NOT);
+	append(p_right_operand);
+	logic_op_jump_pos2.push_back(opcodes.size());
+	append(0); // Jump target, will be patched.
+}
+
+void GDScriptByteCodeGenerator::write_end_and(const Address &p_target) {
+	// If here means both operands are true.
+	append(GDScriptFunction::OPCODE_ASSIGN_TRUE);
+	append(p_target);
+	// Jump away from the fail condition.
+	append(GDScriptFunction::OPCODE_JUMP);
+	append(opcodes.size() + 3);
+	// Here it means one of operands is false.
+	patch_jump(logic_op_jump_pos1.back()->get());
+	patch_jump(logic_op_jump_pos2.back()->get());
+	logic_op_jump_pos1.pop_back();
+	logic_op_jump_pos2.pop_back();
+	append(GDScriptFunction::OPCODE_ASSIGN_FALSE);
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_or_left_operand(const Address &p_left_operand) {
+	append(GDScriptFunction::OPCODE_JUMP_IF);
+	append(p_left_operand);
+	logic_op_jump_pos1.push_back(opcodes.size());
+	append(0); // Jump target, will be patched.
+}
+
+void GDScriptByteCodeGenerator::write_or_right_operand(const Address &p_right_operand) {
+	append(GDScriptFunction::OPCODE_JUMP_IF);
+	append(p_right_operand);
+	logic_op_jump_pos2.push_back(opcodes.size());
+	append(0); // Jump target, will be patched.
+}
+
+void GDScriptByteCodeGenerator::write_end_or(const Address &p_target) {
+	// If here means both operands are false.
+	append(GDScriptFunction::OPCODE_ASSIGN_FALSE);
+	append(p_target);
+	// Jump away from the success condition.
+	append(GDScriptFunction::OPCODE_JUMP);
+	append(opcodes.size() + 3);
+	// Here it means one of operands is false.
+	patch_jump(logic_op_jump_pos1.back()->get());
+	patch_jump(logic_op_jump_pos2.back()->get());
+	logic_op_jump_pos1.pop_back();
+	logic_op_jump_pos2.pop_back();
+	append(GDScriptFunction::OPCODE_ASSIGN_TRUE);
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_start_ternary(const Address &p_target) {
+	ternary_result.push_back(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_ternary_condition(const Address &p_condition) {
+	append(GDScriptFunction::OPCODE_JUMP_IF_NOT);
+	append(p_condition);
+	ternary_jump_fail_pos.push_back(opcodes.size());
+	append(0); // Jump target, will be patched.
+}
+
+void GDScriptByteCodeGenerator::write_ternary_true_expr(const Address &p_expr) {
+	append(GDScriptFunction::OPCODE_ASSIGN);
+	append(ternary_result.back()->get());
+	append(p_expr);
+	// Jump away from the false path.
+	append(GDScriptFunction::OPCODE_JUMP);
+	ternary_jump_skip_pos.push_back(opcodes.size());
+	append(0);
+	// Fail must jump here.
+	patch_jump(ternary_jump_fail_pos.back()->get());
+	ternary_jump_fail_pos.pop_back();
+}
+
+void GDScriptByteCodeGenerator::write_ternary_false_expr(const Address &p_expr) {
+	append(GDScriptFunction::OPCODE_ASSIGN);
+	append(ternary_result.back()->get());
+	append(p_expr);
+}
+
+void GDScriptByteCodeGenerator::write_end_ternary() {
+	patch_jump(ternary_jump_skip_pos.back()->get());
+	ternary_jump_skip_pos.pop_back();
+}
+
+void GDScriptByteCodeGenerator::write_set(const Address &p_target, const Address &p_index, const Address &p_source) {
+	append(GDScriptFunction::OPCODE_SET);
+	append(p_target);
+	append(p_index);
+	append(p_source);
+}
+
+void GDScriptByteCodeGenerator::write_get(const Address &p_target, const Address &p_index, const Address &p_source) {
+	append(GDScriptFunction::OPCODE_GET);
+	append(p_source);
+	append(p_index);
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_set_named(const Address &p_target, const StringName &p_name, const Address &p_source) {
+	append(GDScriptFunction::OPCODE_SET_NAMED);
+	append(p_target);
+	append(p_name);
+	append(p_source);
+}
+
+void GDScriptByteCodeGenerator::write_get_named(const Address &p_target, const StringName &p_name, const Address &p_source) {
+	append(GDScriptFunction::OPCODE_GET_NAMED);
+	append(p_source);
+	append(p_name);
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_set_member(const Address &p_value, const StringName &p_name) {
+	append(GDScriptFunction::OPCODE_SET_MEMBER);
+	append(p_name);
+	append(p_value);
+}
+
+void GDScriptByteCodeGenerator::write_get_member(const Address &p_target, const StringName &p_name) {
+	append(GDScriptFunction::OPCODE_GET_MEMBER);
+	append(p_name);
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_assign(const Address &p_target, const Address &p_source) {
+	if (p_target.type.has_type && !p_source.type.has_type) {
+		// Typed assignment.
+		switch (p_target.type.kind) {
+			case GDScriptDataType::BUILTIN: {
+				append(GDScriptFunction::OPCODE_ASSIGN_TYPED_BUILTIN);
+				append(p_target.type.builtin_type);
+				append(p_target);
+				append(p_source);
+			} break;
+			case GDScriptDataType::NATIVE: {
+				int class_idx = GDScriptLanguage::get_singleton()->get_global_map()[p_target.type.native_type];
+				class_idx |= (GDScriptFunction::ADDR_TYPE_GLOBAL << GDScriptFunction::ADDR_BITS);
+				append(GDScriptFunction::OPCODE_ASSIGN_TYPED_NATIVE);
+				append(class_idx);
+				append(p_target);
+				append(p_source);
+			} break;
+			case GDScriptDataType::SCRIPT:
+			case GDScriptDataType::GDSCRIPT: {
+				Variant script = p_target.type.script_type;
+				int idx = get_constant_pos(script);
+
+				append(GDScriptFunction::OPCODE_ASSIGN_TYPED_SCRIPT);
+				append(idx);
+				append(p_target);
+				append(p_source);
+			} break;
+			default: {
+				ERR_PRINT("Compiler bug: unresolved assign.");
+
+				// Shouldn't get here, but fail-safe to a regular assignment
+				append(GDScriptFunction::OPCODE_ASSIGN);
+				append(p_target);
+				append(p_source);
+			}
+		}
+	} else {
+		if (p_target.type.kind == GDScriptDataType::BUILTIN && p_source.type.kind == GDScriptDataType::BUILTIN && p_target.type.builtin_type != p_source.type.builtin_type) {
+			// Need conversion..
+			append(GDScriptFunction::OPCODE_ASSIGN_TYPED_BUILTIN);
+			append(p_target.type.builtin_type);
+			append(p_target);
+			append(p_source);
+		} else {
+			// Either untyped assignment or already type-checked by the parser
+			append(GDScriptFunction::OPCODE_ASSIGN);
+			append(p_target);
+			append(p_source);
+		}
+	}
+}
+
+void GDScriptByteCodeGenerator::write_assign_true(const Address &p_target) {
+	append(GDScriptFunction::OPCODE_ASSIGN_TRUE);
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_assign_false(const Address &p_target) {
+	append(GDScriptFunction::OPCODE_ASSIGN_FALSE);
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_cast(const Address &p_target, const Address &p_source, const GDScriptDataType &p_type) {
+	switch (p_type.kind) {
+		case GDScriptDataType::BUILTIN: {
+			append(GDScriptFunction::OPCODE_CAST_TO_BUILTIN);
+			append(p_type.builtin_type);
+		} break;
+		case GDScriptDataType::NATIVE: {
+			int class_idx = GDScriptLanguage::get_singleton()->get_global_map()[p_type.native_type];
+			class_idx |= (GDScriptFunction::ADDR_TYPE_GLOBAL << GDScriptFunction::ADDR_BITS);
+			append(GDScriptFunction::OPCODE_CAST_TO_NATIVE);
+			append(class_idx);
+		} break;
+		case GDScriptDataType::SCRIPT:
+		case GDScriptDataType::GDSCRIPT: {
+			Variant script = p_type.script_type;
+			int idx = get_constant_pos(script);
+
+			append(GDScriptFunction::OPCODE_CAST_TO_SCRIPT);
+			append(idx);
+		} break;
+		default: {
+			return;
+		}
+	}
+
+	append(p_source);
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_call(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) {
+	append(p_target.mode == Address::NIL ? GDScriptFunction::OPCODE_CALL : GDScriptFunction::OPCODE_CALL_RETURN);
+	append(p_arguments.size());
+	append(p_base);
+	append(p_function_name);
+	for (int i = 0; i < p_arguments.size(); i++) {
+		append(p_arguments[i]);
+	}
+	append(p_target);
+	alloc_call(p_arguments.size());
+}
+
+void GDScriptByteCodeGenerator::write_super_call(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) {
+	append(GDScriptFunction::OPCODE_CALL_SELF_BASE);
+	append(p_function_name);
+	append(p_arguments.size());
+	for (int i = 0; i < p_arguments.size(); i++) {
+		append(p_arguments[i]);
+	}
+	append(p_target);
+	alloc_call(p_arguments.size());
+}
+
+void GDScriptByteCodeGenerator::write_call_async(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) {
+	append(GDScriptFunction::OPCODE_CALL_ASYNC);
+	append(p_arguments.size());
+	append(p_base);
+	append(p_function_name);
+	for (int i = 0; i < p_arguments.size(); i++) {
+		append(p_arguments[i]);
+	}
+	append(p_target);
+	alloc_call(p_arguments.size());
+}
+
+void GDScriptByteCodeGenerator::write_call_builtin(const Address &p_target, GDScriptFunctions::Function p_function, const Vector<Address> &p_arguments) {
+	append(GDScriptFunction::OPCODE_CALL_BUILT_IN);
+	append(p_function);
+	append(p_arguments.size());
+	for (int i = 0; i < p_arguments.size(); i++) {
+		append(p_arguments[i]);
+	}
+	append(p_target);
+	alloc_call(p_arguments.size());
+}
+
+void GDScriptByteCodeGenerator::write_call_method_bind(const Address &p_target, const Address &p_base, const MethodBind *p_method, const Vector<Address> &p_arguments) {
+	append(p_target.mode == Address::NIL ? GDScriptFunction::OPCODE_CALL : GDScriptFunction::OPCODE_CALL_RETURN);
+	append(p_arguments.size());
+	append(p_base);
+	append(p_method->get_name());
+	for (int i = 0; i < p_arguments.size(); i++) {
+		append(p_arguments[i]);
+	}
+	append(p_target);
+	alloc_call(p_arguments.size());
+}
+
+void GDScriptByteCodeGenerator::write_call_ptrcall(const Address &p_target, const Address &p_base, const MethodBind *p_method, const Vector<Address> &p_arguments) {
+	append(p_target.mode == Address::NIL ? GDScriptFunction::OPCODE_CALL : GDScriptFunction::OPCODE_CALL_RETURN);
+	append(p_arguments.size());
+	append(p_base);
+	append(p_method->get_name());
+	for (int i = 0; i < p_arguments.size(); i++) {
+		append(p_arguments[i]);
+	}
+	append(p_target);
+	alloc_call(p_arguments.size());
+}
+
+void GDScriptByteCodeGenerator::write_call_self(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) {
+	append(p_target.mode == Address::NIL ? GDScriptFunction::OPCODE_CALL : GDScriptFunction::OPCODE_CALL_RETURN);
+	append(p_arguments.size());
+	append(GDScriptFunction::ADDR_TYPE_SELF << GDScriptFunction::ADDR_BITS);
+	append(p_function_name);
+	for (int i = 0; i < p_arguments.size(); i++) {
+		append(p_arguments[i]);
+	}
+	append(p_target);
+	alloc_call(p_arguments.size());
+}
+
+void GDScriptByteCodeGenerator::write_call_script_function(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) {
+	append(p_target.mode == Address::NIL ? GDScriptFunction::OPCODE_CALL : GDScriptFunction::OPCODE_CALL_RETURN);
+	append(p_arguments.size());
+	append(p_base);
+	append(p_function_name);
+	for (int i = 0; i < p_arguments.size(); i++) {
+		append(p_arguments[i]);
+	}
+	append(p_target);
+	alloc_call(p_arguments.size());
+}
+
+void GDScriptByteCodeGenerator::write_construct(const Address &p_target, Variant::Type p_type, const Vector<Address> &p_arguments) {
+	append(GDScriptFunction::OPCODE_CONSTRUCT);
+	append(p_type);
+	append(p_arguments.size());
+	for (int i = 0; i < p_arguments.size(); i++) {
+		append(p_arguments[i]);
+	}
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_construct_array(const Address &p_target, const Vector<Address> &p_arguments) {
+	append(GDScriptFunction::OPCODE_CONSTRUCT_ARRAY);
+	append(p_arguments.size());
+	for (int i = 0; i < p_arguments.size(); i++) {
+		append(p_arguments[i]);
+	}
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_construct_dictionary(const Address &p_target, const Vector<Address> &p_arguments) {
+	append(GDScriptFunction::OPCODE_CONSTRUCT_DICTIONARY);
+	append(p_arguments.size() / 2); // This is number of key-value pairs, so only half of actual arguments.
+	for (int i = 0; i < p_arguments.size(); i++) {
+		append(p_arguments[i]);
+	}
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_await(const Address &p_target, const Address &p_operand) {
+	append(GDScriptFunction::OPCODE_AWAIT);
+	append(p_operand);
+	append(GDScriptFunction::OPCODE_AWAIT_RESUME);
+	append(p_target);
+}
+
+void GDScriptByteCodeGenerator::write_if(const Address &p_condition) {
+	append(GDScriptFunction::OPCODE_JUMP_IF_NOT);
+	append(p_condition);
+	if_jmp_addrs.push_back(opcodes.size());
+	append(0); // Jump destination, will be patched.
+}
+
+void GDScriptByteCodeGenerator::write_else() {
+	append(GDScriptFunction::OPCODE_JUMP); // Jump from true if block;
+	int else_jmp_addr = opcodes.size();
+	append(0); // Jump destination, will be patched.
+
+	patch_jump(if_jmp_addrs.back()->get());
+	if_jmp_addrs.pop_back();
+	if_jmp_addrs.push_back(else_jmp_addr);
+}
+
+void GDScriptByteCodeGenerator::write_endif() {
+	patch_jump(if_jmp_addrs.back()->get());
+	if_jmp_addrs.pop_back();
+}
+
+void GDScriptByteCodeGenerator::write_for(const Address &p_variable, const Address &p_list) {
+	int counter_pos = increase_stack() | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
+	int container_pos = increase_stack() | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
+
+	current_breaks_to_patch.push_back(List<int>());
+
+	// Assign container.
+	append(GDScriptFunction::OPCODE_ASSIGN);
+	append(container_pos);
+	append(p_list);
+
+	// Begin loop.
+	append(GDScriptFunction::OPCODE_ITERATE_BEGIN);
+	append(counter_pos);
+	append(container_pos);
+	for_jmp_addrs.push_back(opcodes.size());
+	append(0); // End of loop address, will be patched.
+	append(p_variable);
+	append(GDScriptFunction::OPCODE_JUMP);
+	append(opcodes.size() + 6); // Skip over 'continue' code.
+
+	// Next iteration.
+	int continue_addr = opcodes.size();
+	continue_addrs.push_back(continue_addr);
+	append(GDScriptFunction::OPCODE_ITERATE);
+	append(counter_pos);
+	append(container_pos);
+	for_jmp_addrs.push_back(opcodes.size());
+	append(0); // Jump destination, will be patched.
+	append(p_variable);
+}
+
+void GDScriptByteCodeGenerator::write_endfor() {
+	// Jump back to loop check.
+	append(GDScriptFunction::OPCODE_JUMP);
+	append(continue_addrs.back()->get());
+	continue_addrs.pop_back();
+
+	// Patch end jumps (two of them).
+	for (int i = 0; i < 2; i++) {
+		patch_jump(for_jmp_addrs.back()->get());
+		for_jmp_addrs.pop_back();
+	}
+
+	// Patch break statements.
+	for (const List<int>::Element *E = current_breaks_to_patch.back()->get().front(); E; E = E->next()) {
+		patch_jump(E->get());
+	}
+	current_breaks_to_patch.pop_back();
+
+	current_stack_size -= 2; // Remove loop temporaries.
+}
+
+void GDScriptByteCodeGenerator::start_while_condition() {
+	current_breaks_to_patch.push_back(List<int>());
+	continue_addrs.push_back(opcodes.size());
+}
+
+void GDScriptByteCodeGenerator::write_while(const Address &p_condition) {
+	// Condition check.
+	append(GDScriptFunction::OPCODE_JUMP_IF_NOT);
+	append(p_condition);
+	while_jmp_addrs.push_back(opcodes.size());
+	append(0); // End of loop address, will be patched.
+}
+
+void GDScriptByteCodeGenerator::write_endwhile() {
+	// Jump back to loop check.
+	append(GDScriptFunction::OPCODE_JUMP);
+	append(continue_addrs.back()->get());
+	continue_addrs.pop_back();
+
+	// Patch end jump.
+	patch_jump(while_jmp_addrs.back()->get());
+	while_jmp_addrs.pop_back();
+
+	// Patch break statements.
+	for (const List<int>::Element *E = current_breaks_to_patch.back()->get().front(); E; E = E->next()) {
+		patch_jump(E->get());
+	}
+	current_breaks_to_patch.pop_back();
+}
+
+void GDScriptByteCodeGenerator::start_match() {
+	match_continues_to_patch.push_back(List<int>());
+}
+
+void GDScriptByteCodeGenerator::start_match_branch() {
+	// Patch continue statements.
+	for (const List<int>::Element *E = match_continues_to_patch.back()->get().front(); E; E = E->next()) {
+		patch_jump(E->get());
+	}
+	match_continues_to_patch.pop_back();
+	// Start a new list for next branch.
+	match_continues_to_patch.push_back(List<int>());
+}
+
+void GDScriptByteCodeGenerator::end_match() {
+	// Patch continue statements.
+	for (const List<int>::Element *E = match_continues_to_patch.back()->get().front(); E; E = E->next()) {
+		patch_jump(E->get());
+	}
+	match_continues_to_patch.pop_back();
+}
+
+void GDScriptByteCodeGenerator::write_break() {
+	append(GDScriptFunction::OPCODE_JUMP);
+	current_breaks_to_patch.back()->get().push_back(opcodes.size());
+	append(0);
+}
+
+void GDScriptByteCodeGenerator::write_continue() {
+	append(GDScriptFunction::OPCODE_JUMP);
+	append(continue_addrs.back()->get());
+}
+
+void GDScriptByteCodeGenerator::write_continue_match() {
+	append(GDScriptFunction::OPCODE_JUMP);
+	match_continues_to_patch.back()->get().push_back(opcodes.size());
+	append(0);
+}
+
+void GDScriptByteCodeGenerator::write_breakpoint() {
+	append(GDScriptFunction::OPCODE_BREAKPOINT);
+}
+
+void GDScriptByteCodeGenerator::write_newline(int p_line) {
+	append(GDScriptFunction::OPCODE_LINE);
+	append(p_line);
+	current_line = p_line;
+}
+
+void GDScriptByteCodeGenerator::write_return(const Address &p_return_value) {
+	append(GDScriptFunction::OPCODE_RETURN);
+	append(p_return_value);
+}
+
+void GDScriptByteCodeGenerator::write_assert(const Address &p_test, const Address &p_message) {
+	append(GDScriptFunction::OPCODE_ASSERT);
+	append(p_test);
+	append(p_message);
+}
+
+void GDScriptByteCodeGenerator::start_block() {
+	push_stack_identifiers();
+}
+
+void GDScriptByteCodeGenerator::end_block() {
+	pop_stack_identifiers();
+}
+
+GDScriptByteCodeGenerator::~GDScriptByteCodeGenerator() {
+	if (!ended && function != nullptr) {
+		memdelete(function);
+	}
+}

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -1,0 +1,277 @@
+/*************************************************************************/
+/*  gdscript_byte_codegen.h                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GDSCRIPT_BYTE_CODEGEN
+#define GDSCRIPT_BYTE_CODEGEN
+
+#include "gdscript_codegen.h"
+
+class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
+	bool ended = false;
+	GDScriptFunction *function = nullptr;
+	bool debug_stack = false;
+
+	Vector<int> opcodes;
+	List<Map<StringName, int>> stack_id_stack;
+	Map<StringName, int> stack_identifiers;
+	Map<StringName, int> local_constants;
+
+	List<GDScriptFunction::StackDebug> stack_debug;
+	List<Map<StringName, int>> block_identifier_stack;
+	Map<StringName, int> block_identifiers;
+
+	int current_stack_size = 0;
+	int current_temporaries = 0;
+
+	HashMap<Variant, int, VariantHasher, VariantComparator> constant_map;
+	Map<StringName, int> name_map;
+#ifdef TOOLS_ENABLED
+	Vector<StringName> named_globals;
+#endif
+	int current_line = 0;
+	int stack_max = 0;
+	int call_max = 0;
+
+	List<int> if_jmp_addrs; // List since this can be nested.
+	List<int> for_jmp_addrs;
+	List<int> while_jmp_addrs;
+	List<int> continue_addrs;
+
+	// Used to patch jumps with `and` and `or` operators with short-circuit.
+	List<int> logic_op_jump_pos1;
+	List<int> logic_op_jump_pos2;
+
+	List<Address> ternary_result;
+	List<int> ternary_jump_fail_pos;
+	List<int> ternary_jump_skip_pos;
+
+	List<List<int>> current_breaks_to_patch;
+	List<List<int>> match_continues_to_patch;
+
+	void add_stack_identifier(const StringName &p_id, int p_stackpos) {
+		stack_identifiers[p_id] = p_stackpos;
+		if (debug_stack) {
+			block_identifiers[p_id] = p_stackpos;
+			GDScriptFunction::StackDebug sd;
+			sd.added = true;
+			sd.line = current_line;
+			sd.identifier = p_id;
+			sd.pos = p_stackpos;
+			stack_debug.push_back(sd);
+		}
+	}
+
+	void push_stack_identifiers() {
+		stack_id_stack.push_back(stack_identifiers);
+		if (debug_stack) {
+			block_identifier_stack.push_back(block_identifiers);
+			block_identifiers.clear();
+		}
+	}
+
+	void pop_stack_identifiers() {
+		stack_identifiers = stack_id_stack.back()->get();
+		current_stack_size = stack_identifiers.size() + current_temporaries;
+		stack_id_stack.pop_back();
+
+		if (debug_stack) {
+			for (Map<StringName, int>::Element *E = block_identifiers.front(); E; E = E->next()) {
+				GDScriptFunction::StackDebug sd;
+				sd.added = false;
+				sd.identifier = E->key();
+				sd.line = current_line;
+				sd.pos = E->get();
+				stack_debug.push_back(sd);
+			}
+			block_identifiers = block_identifier_stack.back()->get();
+			block_identifier_stack.pop_back();
+		}
+	}
+
+	int get_name_map_pos(const StringName &p_identifier) {
+		int ret;
+		if (!name_map.has(p_identifier)) {
+			ret = name_map.size();
+			name_map[p_identifier] = ret;
+		} else {
+			ret = name_map[p_identifier];
+		}
+		return ret;
+	}
+
+	int get_constant_pos(const Variant &p_constant) {
+		if (constant_map.has(p_constant))
+			return constant_map[p_constant];
+		int pos = constant_map.size();
+		constant_map[p_constant] = pos;
+		return pos;
+	}
+
+	void alloc_stack(int p_level) {
+		if (p_level >= stack_max)
+			stack_max = p_level + 1;
+	}
+
+	void alloc_call(int p_params) {
+		if (p_params >= call_max)
+			call_max = p_params;
+	}
+
+	int increase_stack() {
+		int top = current_stack_size++;
+		alloc_stack(current_stack_size);
+		return top;
+	}
+
+	int address_of(const Address &p_address) {
+		switch (p_address.mode) {
+			case Address::SELF:
+				return GDScriptFunction::ADDR_TYPE_SELF << GDScriptFunction::ADDR_BITS;
+			case Address::CLASS:
+				return GDScriptFunction::ADDR_TYPE_CLASS << GDScriptFunction::ADDR_BITS;
+			case Address::MEMBER:
+				return p_address.address | (GDScriptFunction::ADDR_TYPE_MEMBER << GDScriptFunction::ADDR_BITS);
+			case Address::CLASS_CONSTANT:
+				return p_address.address | (GDScriptFunction::ADDR_TYPE_CLASS_CONSTANT << GDScriptFunction::ADDR_BITS);
+			case Address::LOCAL_CONSTANT:
+			case Address::CONSTANT:
+				return p_address.address | (GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS);
+			case Address::LOCAL_VARIABLE:
+			case Address::TEMPORARY:
+			case Address::FUNCTION_PARAMETER:
+				return p_address.address | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
+			case Address::GLOBAL:
+				return p_address.address | (GDScriptFunction::ADDR_TYPE_GLOBAL << GDScriptFunction::ADDR_BITS);
+			case Address::NAMED_GLOBAL:
+				return p_address.address | (GDScriptFunction::ADDR_TYPE_NAMED_GLOBAL << GDScriptFunction::ADDR_BITS);
+			case Address::NIL:
+				return GDScriptFunction::ADDR_TYPE_NIL << GDScriptFunction::ADDR_BITS;
+		}
+		return -1; // Unreachable.
+	}
+
+	void append(int code) {
+		opcodes.push_back(code);
+	}
+
+	void append(const Address &p_address) {
+		opcodes.push_back(address_of(p_address));
+	}
+
+	void append(const StringName &p_name) {
+		opcodes.push_back(get_name_map_pos(p_name));
+	}
+
+	void patch_jump(int p_address) {
+		opcodes.write[p_address] = opcodes.size();
+	}
+
+public:
+	virtual uint32_t add_parameter(const StringName &p_name, bool p_is_optional, const GDScriptDataType &p_type) override;
+	virtual uint32_t add_local(const StringName &p_name, const GDScriptDataType &p_type) override;
+	virtual uint32_t add_local_constant(const StringName &p_name, const Variant &p_constant) override;
+	virtual uint32_t add_or_get_constant(const Variant &p_constant) override;
+	virtual uint32_t add_or_get_name(const StringName &p_name) override;
+	virtual uint32_t add_temporary() override;
+	virtual void pop_temporary() override;
+
+	virtual void start_parameters() override;
+	virtual void end_parameters() override;
+
+	virtual void start_block() override;
+	virtual void end_block() override;
+
+	virtual void write_start(GDScript *p_script, const StringName &p_function_name, bool p_static, MultiplayerAPI::RPCMode p_rpc_mode, const GDScriptDataType &p_return_type) override;
+	virtual GDScriptFunction *write_end() override;
+
+#ifdef DEBUG_ENABLED
+	virtual void set_signature(const String &p_signature) override;
+#endif
+	virtual void set_initial_line(int p_line) override;
+
+	virtual void write_operator(const Address &p_target, Variant::Operator p_operator, const Address &p_left_operand, const Address &p_right_operand) override;
+	virtual void write_type_test(const Address &p_target, const Address &p_source, const Address &p_type) override;
+	virtual void write_type_test_builtin(const Address &p_target, const Address &p_source, Variant::Type p_type) override;
+	virtual void write_and_left_operand(const Address &p_left_operand) override;
+	virtual void write_and_right_operand(const Address &p_right_operand) override;
+	virtual void write_end_and(const Address &p_target) override;
+	virtual void write_or_left_operand(const Address &p_left_operand) override;
+	virtual void write_or_right_operand(const Address &p_right_operand) override;
+	virtual void write_end_or(const Address &p_target) override;
+	virtual void write_start_ternary(const Address &p_target) override;
+	virtual void write_ternary_condition(const Address &p_condition) override;
+	virtual void write_ternary_true_expr(const Address &p_expr) override;
+	virtual void write_ternary_false_expr(const Address &p_expr) override;
+	virtual void write_end_ternary() override;
+	virtual void write_set(const Address &p_target, const Address &p_index, const Address &p_source) override;
+	virtual void write_get(const Address &p_target, const Address &p_index, const Address &p_source) override;
+	virtual void write_set_named(const Address &p_target, const StringName &p_name, const Address &p_source) override;
+	virtual void write_get_named(const Address &p_target, const StringName &p_name, const Address &p_source) override;
+	virtual void write_set_member(const Address &p_value, const StringName &p_name) override;
+	virtual void write_get_member(const Address &p_target, const StringName &p_name) override;
+	virtual void write_assign(const Address &p_target, const Address &p_source) override;
+	virtual void write_assign_true(const Address &p_target) override;
+	virtual void write_assign_false(const Address &p_target) override;
+	virtual void write_cast(const Address &p_target, const Address &p_source, const GDScriptDataType &p_type) override;
+	virtual void write_call(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
+	virtual void write_super_call(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
+	virtual void write_call_async(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
+	virtual void write_call_builtin(const Address &p_target, GDScriptFunctions::Function p_function, const Vector<Address> &p_arguments) override;
+	virtual void write_call_method_bind(const Address &p_target, const Address &p_base, const MethodBind *p_method, const Vector<Address> &p_arguments) override;
+	virtual void write_call_ptrcall(const Address &p_target, const Address &p_base, const MethodBind *p_method, const Vector<Address> &p_arguments) override;
+	virtual void write_call_self(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
+	virtual void write_call_script_function(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
+	virtual void write_construct(const Address &p_target, Variant::Type p_type, const Vector<Address> &p_arguments) override;
+	virtual void write_construct_array(const Address &p_target, const Vector<Address> &p_arguments) override;
+	virtual void write_construct_dictionary(const Address &p_target, const Vector<Address> &p_arguments) override;
+	virtual void write_await(const Address &p_target, const Address &p_operand) override;
+	virtual void write_if(const Address &p_condition) override;
+	virtual void write_else() override;
+	virtual void write_endif() override;
+	virtual void write_for(const Address &p_variable, const Address &p_list) override;
+	virtual void write_endfor() override;
+	virtual void start_while_condition() override;
+	virtual void write_while(const Address &p_condition) override;
+	virtual void write_endwhile() override;
+	virtual void start_match() override;
+	virtual void start_match_branch() override;
+	virtual void end_match() override;
+	virtual void write_break() override;
+	virtual void write_continue() override;
+	virtual void write_continue_match() override;
+	virtual void write_breakpoint() override;
+	virtual void write_newline(int p_line) override;
+	virtual void write_return(const Address &p_return_value) override;
+	virtual void write_assert(const Address &p_test, const Address &p_message) override;
+
+	virtual ~GDScriptByteCodeGenerator();
+};
+
+#endif // GDSCRIPT_BYTE_CODEGEN

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -1,0 +1,160 @@
+/*************************************************************************/
+/*  gdscript_codegen.h                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GDSCRIPT_CODEGEN
+#define GDSCRIPT_CODEGEN
+
+#include "core/io/multiplayer_api.h"
+#include "core/string_name.h"
+#include "core/variant.h"
+#include "gdscript_function.h"
+#include "gdscript_functions.h"
+
+class GDScriptCodeGenerator {
+public:
+	struct Address {
+		enum AddressMode {
+			SELF,
+			CLASS,
+			MEMBER,
+			CONSTANT,
+			CLASS_CONSTANT,
+			LOCAL_CONSTANT,
+			LOCAL_VARIABLE,
+			FUNCTION_PARAMETER,
+			TEMPORARY,
+			GLOBAL,
+			NAMED_GLOBAL,
+			NIL,
+		};
+		AddressMode mode = NIL;
+		uint32_t address = 0;
+		GDScriptDataType type;
+
+		Address() {}
+		Address(AddressMode p_mode, const GDScriptDataType &p_type = GDScriptDataType()) {
+			mode = p_mode;
+			type = p_type;
+		}
+		Address(AddressMode p_mode, uint32_t p_address, const GDScriptDataType &p_type = GDScriptDataType()) {
+			mode = p_mode,
+			address = p_address;
+			type = p_type;
+		}
+	};
+
+	virtual uint32_t add_parameter(const StringName &p_name, bool p_is_optional, const GDScriptDataType &p_type) = 0;
+	virtual uint32_t add_local(const StringName &p_name, const GDScriptDataType &p_type) = 0;
+	virtual uint32_t add_local_constant(const StringName &p_name, const Variant &p_constant) = 0;
+	virtual uint32_t add_or_get_constant(const Variant &p_constant) = 0;
+	virtual uint32_t add_or_get_name(const StringName &p_name) = 0;
+	virtual uint32_t add_temporary() = 0;
+	virtual void pop_temporary() = 0;
+
+	virtual void start_parameters() = 0;
+	virtual void end_parameters() = 0;
+
+	virtual void start_block() = 0;
+	virtual void end_block() = 0;
+
+	// virtual int get_max_stack_level() = 0;
+	// virtual int get_max_function_arguments() = 0;
+
+	virtual void write_start(GDScript *p_script, const StringName &p_function_name, bool p_static, MultiplayerAPI::RPCMode p_rpc_mode, const GDScriptDataType &p_return_type) = 0;
+	virtual GDScriptFunction *write_end() = 0;
+
+#ifdef DEBUG_ENABLED
+	virtual void set_signature(const String &p_signature) = 0;
+#endif
+	virtual void set_initial_line(int p_line) = 0;
+
+	// virtual void alloc_stack(int p_level) = 0; // Is this needed?
+	// virtual void alloc_call(int p_arg_count) = 0; // This might be automatic from other functions.
+
+	virtual void write_operator(const Address &p_target, Variant::Operator p_operator, const Address &p_left_operand, const Address &p_right_operand) = 0;
+	virtual void write_type_test(const Address &p_target, const Address &p_source, const Address &p_type) = 0;
+	virtual void write_type_test_builtin(const Address &p_target, const Address &p_source, Variant::Type p_type) = 0;
+	virtual void write_and_left_operand(const Address &p_left_operand) = 0;
+	virtual void write_and_right_operand(const Address &p_right_operand) = 0;
+	virtual void write_end_and(const Address &p_target) = 0;
+	virtual void write_or_left_operand(const Address &p_left_operand) = 0;
+	virtual void write_or_right_operand(const Address &p_right_operand) = 0;
+	virtual void write_end_or(const Address &p_target) = 0;
+	virtual void write_start_ternary(const Address &p_target) = 0;
+	virtual void write_ternary_condition(const Address &p_condition) = 0;
+	virtual void write_ternary_true_expr(const Address &p_expr) = 0;
+	virtual void write_ternary_false_expr(const Address &p_expr) = 0;
+	virtual void write_end_ternary() = 0;
+	virtual void write_set(const Address &p_target, const Address &p_index, const Address &p_source) = 0;
+	virtual void write_get(const Address &p_target, const Address &p_index, const Address &p_source) = 0;
+	virtual void write_set_named(const Address &p_target, const StringName &p_name, const Address &p_source) = 0;
+	virtual void write_get_named(const Address &p_target, const StringName &p_name, const Address &p_source) = 0;
+	virtual void write_set_member(const Address &p_value, const StringName &p_name) = 0;
+	virtual void write_get_member(const Address &p_target, const StringName &p_name) = 0;
+	virtual void write_assign(const Address &p_target, const Address &p_source) = 0;
+	virtual void write_assign_true(const Address &p_target) = 0;
+	virtual void write_assign_false(const Address &p_target) = 0;
+	virtual void write_cast(const Address &p_target, const Address &p_source, const GDScriptDataType &p_type) = 0;
+	virtual void write_call(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
+	virtual void write_super_call(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
+	virtual void write_call_async(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
+	virtual void write_call_builtin(const Address &p_target, GDScriptFunctions::Function p_function, const Vector<Address> &p_arguments) = 0;
+	virtual void write_call_method_bind(const Address &p_target, const Address &p_base, const MethodBind *p_method, const Vector<Address> &p_arguments) = 0;
+	virtual void write_call_ptrcall(const Address &p_target, const Address &p_base, const MethodBind *p_method, const Vector<Address> &p_arguments) = 0;
+	virtual void write_call_self(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
+	virtual void write_call_script_function(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
+	virtual void write_construct(const Address &p_target, Variant::Type p_type, const Vector<Address> &p_arguments) = 0;
+	virtual void write_construct_array(const Address &p_target, const Vector<Address> &p_arguments) = 0;
+	virtual void write_construct_dictionary(const Address &p_target, const Vector<Address> &p_arguments) = 0;
+	virtual void write_await(const Address &p_target, const Address &p_operand) = 0;
+	virtual void write_if(const Address &p_condition) = 0;
+	// virtual void write_elseif(const Address &p_condition) = 0; This kind of makes things more difficult for no real benefit.
+	virtual void write_else() = 0;
+	virtual void write_endif() = 0;
+	virtual void write_for(const Address &p_variable, const Address &p_list) = 0;
+	virtual void write_endfor() = 0;
+	virtual void start_while_condition() = 0; // Used to allow a jump to the expression evaluation.
+	virtual void write_while(const Address &p_condition) = 0;
+	virtual void write_endwhile() = 0;
+	virtual void start_match() = 0;
+	virtual void start_match_branch() = 0;
+	virtual void end_match() = 0;
+	virtual void write_break() = 0;
+	virtual void write_continue() = 0;
+	virtual void write_continue_match() = 0;
+	virtual void write_breakpoint() = 0;
+	virtual void write_newline(int p_line) = 0;
+	virtual void write_return(const Address &p_return_value) = 0;
+	virtual void write_assert(const Address &p_test, const Address &p_message) = 0;
+
+	virtual ~GDScriptCodeGenerator() {}
+};
+
+#endif // GDSCRIPT_CODEGEN

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -31,6 +31,7 @@
 #include "gdscript_compiler.h"
 
 #include "gdscript.h"
+#include "gdscript_byte_codegen.h"
 #include "gdscript_cache.h"
 
 bool GDScriptCompiler::_is_class_member_property(CodeGen &codegen, const StringName &p_name) {
@@ -38,7 +39,7 @@ bool GDScriptCompiler::_is_class_member_property(CodeGen &codegen, const StringN
 		return false;
 	}
 
-	if (codegen.stack_identifiers.has(p_name)) {
+	if (codegen.locals.has(p_name)) {
 		return false; //shadowed
 	}
 
@@ -73,45 +74,6 @@ void GDScriptCompiler::_set_error(const String &p_error, const GDScriptParser::N
 		err_line = 0;
 		err_column = 0;
 	}
-}
-
-bool GDScriptCompiler::_create_unary_operator(CodeGen &codegen, const GDScriptParser::UnaryOpNode *on, Variant::Operator op, int p_stack_level) {
-	int src_address_a = _parse_expression(codegen, on->operand, p_stack_level);
-	if (src_address_a < 0) {
-		return false;
-	}
-
-	codegen.opcodes.push_back(GDScriptFunction::OPCODE_OPERATOR); // perform operator
-	codegen.opcodes.push_back(op); //which operator
-	codegen.opcodes.push_back(src_address_a); // argument 1
-	codegen.opcodes.push_back(src_address_a); // argument 2 (repeated)
-	//codegen.opcodes.push_back(GDScriptFunction::ADDR_TYPE_NIL); // argument 2 (unary only takes one parameter)
-	return true;
-}
-
-bool GDScriptCompiler::_create_binary_operator(CodeGen &codegen, const GDScriptParser::ExpressionNode *p_left_operand, const GDScriptParser::ExpressionNode *p_right_operand, Variant::Operator op, int p_stack_level, bool p_initializer, int p_index_addr) {
-	int src_address_a = _parse_expression(codegen, p_left_operand, p_stack_level, false, p_initializer, p_index_addr);
-	if (src_address_a < 0) {
-		return false;
-	}
-	if (src_address_a & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-		p_stack_level++; //uses stack for return, increase stack
-	}
-
-	int src_address_b = _parse_expression(codegen, p_right_operand, p_stack_level, false, p_initializer);
-	if (src_address_b < 0) {
-		return false;
-	}
-
-	codegen.opcodes.push_back(GDScriptFunction::OPCODE_OPERATOR); // perform operator
-	codegen.opcodes.push_back(op); //which operator
-	codegen.opcodes.push_back(src_address_a); // argument 1
-	codegen.opcodes.push_back(src_address_b); // argument 2 (unary only takes one parameter)
-	return true;
-}
-
-bool GDScriptCompiler::_create_binary_operator(CodeGen &codegen, const GDScriptParser::BinaryOpNode *on, Variant::Operator op, int p_stack_level, bool p_initializer, int p_index_addr) {
-	return _create_binary_operator(codegen, on->left_operand, on->right_operand, op, p_stack_level, p_initializer, p_index_addr);
 }
 
 GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::DataType &p_datatype) const {
@@ -190,199 +152,64 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 	return result;
 }
 
-int GDScriptCompiler::_parse_assign_right_expression(CodeGen &codegen, const GDScriptParser::AssignmentNode *p_assignment, int p_stack_level, int p_index_addr) {
-	Variant::Operator var_op = Variant::OP_MAX;
-
-	switch (p_assignment->operation) {
-		case GDScriptParser::AssignmentNode::OP_ADDITION:
-			var_op = Variant::OP_ADD;
-			break;
-		case GDScriptParser::AssignmentNode::OP_SUBTRACTION:
-			var_op = Variant::OP_SUBTRACT;
-			break;
-		case GDScriptParser::AssignmentNode::OP_MULTIPLICATION:
-			var_op = Variant::OP_MULTIPLY;
-			break;
-		case GDScriptParser::AssignmentNode::OP_DIVISION:
-			var_op = Variant::OP_DIVIDE;
-			break;
-		case GDScriptParser::AssignmentNode::OP_MODULO:
-			var_op = Variant::OP_MODULE;
-			break;
-		case GDScriptParser::AssignmentNode::OP_BIT_SHIFT_LEFT:
-			var_op = Variant::OP_SHIFT_LEFT;
-			break;
-		case GDScriptParser::AssignmentNode::OP_BIT_SHIFT_RIGHT:
-			var_op = Variant::OP_SHIFT_RIGHT;
-			break;
-		case GDScriptParser::AssignmentNode::OP_BIT_AND:
-			var_op = Variant::OP_BIT_AND;
-			break;
-		case GDScriptParser::AssignmentNode::OP_BIT_OR:
-			var_op = Variant::OP_BIT_OR;
-			break;
-		case GDScriptParser::AssignmentNode::OP_BIT_XOR:
-			var_op = Variant::OP_BIT_XOR;
-			break;
-		case GDScriptParser::AssignmentNode::OP_NONE: {
-			//none
-		} break;
-		default: {
-			ERR_FAIL_V(-1);
-		}
-	}
-
-	// bool initializer = p_expression->op == GDScriptParser::OperatorNode::OP_INIT_ASSIGN;
-
-	if (var_op == Variant::OP_MAX) {
-		return _parse_expression(codegen, p_assignment->assigned_value, p_stack_level, false, false);
-	}
-
-	if (!_create_binary_operator(codegen, p_assignment->assignee, p_assignment->assigned_value, var_op, p_stack_level, false, p_index_addr)) {
-		return -1;
-	}
-
-	int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-	codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
-	codegen.alloc_stack(p_stack_level);
-	return dst_addr;
-}
-
-bool GDScriptCompiler::_generate_typed_assign(CodeGen &codegen, int p_src_address, int p_dst_address, const GDScriptDataType &p_datatype, const GDScriptParser::DataType &p_value_type) {
-	if (p_datatype.has_type && p_value_type.is_variant()) {
-		// Typed assignment
-		switch (p_datatype.kind) {
-			case GDScriptDataType::BUILTIN: {
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_TYPED_BUILTIN); // perform operator
-				codegen.opcodes.push_back(p_datatype.builtin_type); // variable type
-				codegen.opcodes.push_back(p_dst_address); // argument 1
-				codegen.opcodes.push_back(p_src_address); // argument 2
-			} break;
-			case GDScriptDataType::NATIVE: {
-				int class_idx;
-				if (GDScriptLanguage::get_singleton()->get_global_map().has(p_datatype.native_type)) {
-					class_idx = GDScriptLanguage::get_singleton()->get_global_map()[p_datatype.native_type];
-					class_idx |= (GDScriptFunction::ADDR_TYPE_GLOBAL << GDScriptFunction::ADDR_BITS); //argument (stack root)
-				} else {
-					// _set_error("Invalid native class type '" + String(p_datatype.native_type) + "'.", on->arguments[0]);
-					return false;
-				}
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_TYPED_NATIVE); // perform operator
-				codegen.opcodes.push_back(class_idx); // variable type
-				codegen.opcodes.push_back(p_dst_address); // argument 1
-				codegen.opcodes.push_back(p_src_address); // argument 2
-			} break;
-			case GDScriptDataType::SCRIPT:
-			case GDScriptDataType::GDSCRIPT: {
-				Variant script = p_datatype.script_type;
-				int idx = codegen.get_constant_pos(script); //make it a local constant (faster access)
-
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_TYPED_SCRIPT); // perform operator
-				codegen.opcodes.push_back(idx); // variable type
-				codegen.opcodes.push_back(p_dst_address); // argument 1
-				codegen.opcodes.push_back(p_src_address); // argument 2
-			} break;
-			default: {
-				ERR_PRINT("Compiler bug: unresolved assign.");
-
-				// Shouldn't get here, but fail-safe to a regular assignment
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN); // perform operator
-				codegen.opcodes.push_back(p_dst_address); // argument 1
-				codegen.opcodes.push_back(p_src_address); // argument 2 (unary only takes one parameter)
-			}
-		}
-	} else {
-		if (p_datatype.kind == GDScriptDataType::BUILTIN && p_value_type.kind == GDScriptParser::DataType::BUILTIN && p_datatype.builtin_type != p_value_type.builtin_type) {
-			// Need conversion.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_TYPED_BUILTIN); // perform operator
-			codegen.opcodes.push_back(p_datatype.builtin_type); // variable type
-			codegen.opcodes.push_back(p_dst_address); // argument 1
-			codegen.opcodes.push_back(p_src_address); // argument 2
-		} else {
-			// Either untyped assignment or already type-checked by the parser
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN); // perform operator
-			codegen.opcodes.push_back(p_dst_address); // argument 1
-			codegen.opcodes.push_back(p_src_address); // argument 2 (unary only takes one parameter)
-		}
-	}
-	return true;
-}
-
-int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::ExpressionNode *p_expression, int p_stack_level, bool p_root, bool p_initializer, int p_index_addr) {
+GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::ExpressionNode *p_expression, bool p_root, bool p_initializer, const GDScriptCodeGenerator::Address &p_index_addr) {
 	if (p_expression->is_constant) {
-		return codegen.get_constant_pos(p_expression->reduced_value);
+		return codegen.add_constant(p_expression->reduced_value);
 	}
+
+	GDScriptCodeGenerator *gen = codegen.generator;
 
 	switch (p_expression->type) {
-		//should parse variable declaration and adjust stack accordingly...
 		case GDScriptParser::Node::IDENTIFIER: {
-			//return identifier
-			//wait, identifier could be a local variable or something else... careful here, must reference properly
-			//as stack may be more interesting to work with
-
-			//This could be made much simpler by just indexing "self", but done this way (with custom self-addressing modes) increases performance a lot.
-
+			// Look for identifiers in current scope.
 			const GDScriptParser::IdentifierNode *in = static_cast<const GDScriptParser::IdentifierNode *>(p_expression);
 
 			StringName identifier = in->name;
 
-			// TRY STACK!
-			if (!p_initializer && codegen.stack_identifiers.has(identifier)) {
-				int pos = codegen.stack_identifiers[identifier];
-				return pos | (GDScriptFunction::ADDR_TYPE_STACK_VARIABLE << GDScriptFunction::ADDR_BITS);
+			// Try function parameters.
+			if (codegen.parameters.has(identifier)) {
+				return codegen.parameters[identifier];
 			}
 
-			// TRY LOCAL CONSTANTS!
-			if (codegen.local_named_constants.has(identifier)) {
-				return codegen.local_named_constants[identifier] | (GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS);
+			// Try local variables and constants.
+			if (!p_initializer && codegen.locals.has(identifier)) {
+				return codegen.locals[identifier];
 			}
 
-			// TRY CLASS MEMBER
+			// Try class members.
 			if (_is_class_member_property(codegen, identifier)) {
-				//get property
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_GET_MEMBER); // perform operator
-				codegen.opcodes.push_back(codegen.get_name_map_pos(identifier)); // argument 2 (unary only takes one parameter)
-				int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-				codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
-				codegen.alloc_stack(p_stack_level);
-				return dst_addr;
+				// Get property.
+				GDScriptCodeGenerator::Address temp = codegen.add_temporary(); // TODO: Could get the type of the class member here.
+				gen->write_get_member(temp, identifier);
+				return temp;
 			}
 
-			//TRY MEMBERS!
+			// Try members.
 			if (!codegen.function_node || !codegen.function_node->is_static) {
-				// TRY MEMBER VARIABLES!
-				//static function
+				// Try member variables.
 				if (codegen.script->member_indices.has(identifier)) {
 					if (codegen.script->member_indices[identifier].getter != StringName() && codegen.script->member_indices[identifier].getter != codegen.function_name) {
 						// Perform getter.
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL_RETURN);
-						codegen.opcodes.push_back(0); // Argument count.
-						codegen.opcodes.push_back(GDScriptFunction::ADDR_TYPE_SELF << GDScriptFunction::ADDR_BITS); // Base (self).
-						codegen.opcodes.push_back(codegen.get_name_map_pos(codegen.script->member_indices[identifier].getter)); // Method name.
-						// Destination.
-						int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-						codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
-						codegen.alloc_stack(p_stack_level);
-						return dst_addr;
+						GDScriptCodeGenerator::Address temp = codegen.add_temporary();
+						Vector<GDScriptCodeGenerator::Address> args; // No argument needed.
+						gen->write_call_self(temp, codegen.script->member_indices[identifier].getter, args);
+						return temp;
 					} else {
-						// No getter or inside getter: direct member access.
+						// No getter or inside getter: direct member access.,
 						int idx = codegen.script->member_indices[identifier].index;
-						return idx | (GDScriptFunction::ADDR_TYPE_MEMBER << GDScriptFunction::ADDR_BITS); //argument (stack root)
+						return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::MEMBER, idx, codegen.script->get_member_type(identifier));
 					}
 				}
 			}
 
-			//TRY CLASS CONSTANTS
-
+			// Try class constants.
 			GDScript *owner = codegen.script;
 			while (owner) {
 				GDScript *scr = owner;
 				GDScriptNativeClass *nc = nullptr;
 				while (scr) {
 					if (scr->constants.has(identifier)) {
-						//int idx=scr->constants[identifier];
-						int idx = codegen.get_name_map_pos(identifier);
-						return idx | (GDScriptFunction::ADDR_TYPE_CLASS_CONSTANT << GDScriptFunction::ADDR_BITS); //argument (stack root)
+						return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::CLASS_CONSTANT, gen->add_or_get_name(identifier)); // TODO: Get type here.
 					}
 					if (scr->native.is_valid()) {
 						nc = scr->native.ptr();
@@ -390,52 +217,37 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 					scr = scr->_base;
 				}
 
-				// CLASS C++ Integer Constant
-
+				// Class C++ integer constant.
 				if (nc) {
 					bool success = false;
 					int constant = ClassDB::get_integer_constant(nc->get_name(), identifier, &success);
 					if (success) {
-						Variant key = constant;
-						int idx;
-
-						if (!codegen.constant_map.has(key)) {
-							idx = codegen.constant_map.size();
-							codegen.constant_map[key] = idx;
-
-						} else {
-							idx = codegen.constant_map[key];
-						}
-
-						return idx | (GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS); //make it a local constant (faster access)
+						return codegen.add_constant(constant);
 					}
 				}
 
 				owner = owner->_owner;
 			}
 
-			// TRY SIGNALS AND METHODS (can be made callables)
+			// Try signals and methods (can be made callables);
 			if (codegen.class_node->members_indices.has(identifier)) {
 				const GDScriptParser::ClassNode::Member &member = codegen.class_node->members[codegen.class_node->members_indices[identifier]];
 				if (member.type == GDScriptParser::ClassNode::Member::FUNCTION || member.type == GDScriptParser::ClassNode::Member::SIGNAL) {
 					// Get like it was a property.
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_GET_NAMED); // perform operator
-					codegen.opcodes.push_back(GDScriptFunction::ADDR_TYPE_SELF << GDScriptFunction::ADDR_BITS); // Self.
-					codegen.opcodes.push_back(codegen.get_name_map_pos(identifier)); // argument 2 (unary only takes one parameter)
-					int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-					codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
-					codegen.alloc_stack(p_stack_level);
-					return dst_addr;
+					GDScriptCodeGenerator::Address temp = codegen.add_temporary(); // TODO: Get type here.
+					GDScriptCodeGenerator::Address self(GDScriptCodeGenerator::Address::SELF);
+
+					gen->write_get_named(temp, identifier, self);
+					return temp;
 				}
 			}
 
 			if (GDScriptLanguage::get_singleton()->get_global_map().has(identifier)) {
 				int idx = GDScriptLanguage::get_singleton()->get_global_map()[identifier];
-				return idx | (GDScriptFunction::ADDR_TYPE_GLOBAL << GDScriptFunction::ADDR_BITS); //argument (stack root)
+				return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::GLOBAL, idx); // TODO: Get type.
 			}
 
-			/* TRY GLOBAL CLASSES */
-
+			// Try global classes.
 			if (ScriptServer::is_global_class(identifier)) {
 				const GDScriptParser::ClassNode *class_node = codegen.class_node;
 				while (class_node->outer) {
@@ -450,356 +262,209 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 					res = ResourceLoader::load(ScriptServer::get_global_class_path(identifier));
 					if (res.is_null()) {
 						_set_error("Can't load global class " + String(identifier) + ", cyclic reference?", p_expression);
-						return -1;
+						r_error = ERR_COMPILATION_FAILED;
+						return GDScriptCodeGenerator::Address();
 					}
 				}
 
-				Variant key = res;
-				int idx;
-
-				if (!codegen.constant_map.has(key)) {
-					idx = codegen.constant_map.size();
-					codegen.constant_map[key] = idx;
-
-				} else {
-					idx = codegen.constant_map[key];
-				}
-
-				return idx | (GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS); //make it a local constant (faster access)
+				return codegen.add_constant(res);
 			}
 
 #ifdef TOOLS_ENABLED
 			if (GDScriptLanguage::get_singleton()->get_named_globals_map().has(identifier)) {
-				int idx = codegen.named_globals.find(identifier);
-				if (idx == -1) {
-					idx = codegen.named_globals.size();
-					codegen.named_globals.push_back(identifier);
-				}
-				return idx | (GDScriptFunction::ADDR_TYPE_NAMED_GLOBAL << GDScriptFunction::ADDR_BITS);
+				return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::NAMED_GLOBAL, gen->add_or_get_name(identifier)); // TODO: Get type.
 			}
 #endif
 
-			//not found, error
-
+			// Not found, error.
 			_set_error("Identifier not found: " + String(identifier), p_expression);
-
-			return -1;
-
+			r_error = ERR_COMPILATION_FAILED;
+			return GDScriptCodeGenerator::Address();
 		} break;
 		case GDScriptParser::Node::LITERAL: {
-			//return constant
+			// Return constant.
 			const GDScriptParser::LiteralNode *cn = static_cast<const GDScriptParser::LiteralNode *>(p_expression);
 
-			int idx;
-
-			if (!codegen.constant_map.has(cn->value)) {
-				idx = codegen.constant_map.size();
-				codegen.constant_map[cn->value] = idx;
-
-			} else {
-				idx = codegen.constant_map[cn->value];
-			}
-
-			return idx | (GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS); //argument (stack root)
-
+			return codegen.add_constant(cn->value);
 		} break;
 		case GDScriptParser::Node::SELF: {
 			//return constant
 			if (codegen.function_node && codegen.function_node->is_static) {
 				_set_error("'self' not present in static function!", p_expression);
-				return -1;
+				r_error = ERR_COMPILATION_FAILED;
+				return GDScriptCodeGenerator::Address();
 			}
-			return (GDScriptFunction::ADDR_TYPE_SELF << GDScriptFunction::ADDR_BITS);
+			return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::SELF);
 		} break;
 		case GDScriptParser::Node::ARRAY: {
 			const GDScriptParser::ArrayNode *an = static_cast<const GDScriptParser::ArrayNode *>(p_expression);
-			Vector<int> values;
+			Vector<GDScriptCodeGenerator::Address> values;
 
-			int slevel = p_stack_level;
+			// Create the result temporary first since it's the last to be killed.
+			GDScriptDataType array_type;
+			array_type.has_type = true;
+			array_type.kind = GDScriptDataType::BUILTIN;
+			array_type.builtin_type = Variant::ARRAY;
+			GDScriptCodeGenerator::Address result = codegen.add_temporary(array_type);
 
 			for (int i = 0; i < an->elements.size(); i++) {
-				int ret = _parse_expression(codegen, an->elements[i], slevel);
-				if (ret < 0) {
-					return ret;
+				GDScriptCodeGenerator::Address val = _parse_expression(codegen, r_error, an->elements[i]);
+				if (r_error) {
+					return GDScriptCodeGenerator::Address();
 				}
-				if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-					slevel++;
-					codegen.alloc_stack(slevel);
-				}
-
-				values.push_back(ret);
+				values.push_back(val);
 			}
 
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_CONSTRUCT_ARRAY);
-			codegen.opcodes.push_back(values.size());
+			gen->write_construct_array(result, values);
+
 			for (int i = 0; i < values.size(); i++) {
-				codegen.opcodes.push_back(values[i]);
+				if (values[i].mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					gen->pop_temporary();
+				}
 			}
 
-			int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-			codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
-			codegen.alloc_stack(p_stack_level);
-			return dst_addr;
-
+			return result;
 		} break;
 		case GDScriptParser::Node::DICTIONARY: {
 			const GDScriptParser::DictionaryNode *dn = static_cast<const GDScriptParser::DictionaryNode *>(p_expression);
-			Vector<int> elements;
+			Vector<GDScriptCodeGenerator::Address> elements;
 
-			int slevel = p_stack_level;
+			// Create the result temporary first since it's the last to be killed.
+			GDScriptDataType dict_type;
+			dict_type.has_type = true;
+			dict_type.kind = GDScriptDataType::BUILTIN;
+			dict_type.builtin_type = Variant::DICTIONARY;
+			GDScriptCodeGenerator::Address result = codegen.add_temporary(dict_type);
 
 			for (int i = 0; i < dn->elements.size(); i++) {
 				// Key.
-				int ret = -1;
+				GDScriptCodeGenerator::Address element;
 				switch (dn->style) {
 					case GDScriptParser::DictionaryNode::PYTHON_DICT:
 						// Python-style: key is any expression.
-						ret = _parse_expression(codegen, dn->elements[i].key, slevel);
-						if (ret < 0) {
-							return ret;
-						}
-						if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-							slevel++;
-							codegen.alloc_stack(slevel);
+						element = _parse_expression(codegen, r_error, dn->elements[i].key);
+						if (r_error) {
+							return GDScriptCodeGenerator::Address();
 						}
 						break;
 					case GDScriptParser::DictionaryNode::LUA_TABLE:
 						// Lua-style: key is an identifier interpreted as string.
 						String key = static_cast<const GDScriptParser::IdentifierNode *>(dn->elements[i].key)->name;
-						ret = codegen.get_constant_pos(key);
+						element = codegen.add_constant(key);
 						break;
 				}
 
-				elements.push_back(ret);
+				elements.push_back(element);
 
-				ret = _parse_expression(codegen, dn->elements[i].value, slevel);
-				if (ret < 0) {
-					return ret;
-				}
-				if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-					slevel++;
-					codegen.alloc_stack(slevel);
+				element = _parse_expression(codegen, r_error, dn->elements[i].value);
+				if (r_error) {
+					return GDScriptCodeGenerator::Address();
 				}
 
-				elements.push_back(ret);
+				elements.push_back(element);
 			}
 
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_CONSTRUCT_DICTIONARY);
-			codegen.opcodes.push_back(dn->elements.size());
+			gen->write_construct_dictionary(result, elements);
+
 			for (int i = 0; i < elements.size(); i++) {
-				codegen.opcodes.push_back(elements[i]);
+				if (elements[i].mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					gen->pop_temporary();
+				}
 			}
 
-			int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-			codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
-			codegen.alloc_stack(p_stack_level);
-			return dst_addr;
-
+			return result;
 		} break;
 		case GDScriptParser::Node::CAST: {
 			const GDScriptParser::CastNode *cn = static_cast<const GDScriptParser::CastNode *>(p_expression);
-
-			int slevel = p_stack_level;
-			int src_addr = _parse_expression(codegen, cn->operand, slevel);
-			if (src_addr < 0) {
-				return src_addr;
-			}
-			if (src_addr & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-				slevel++;
-				codegen.alloc_stack(slevel);
-			}
-
 			GDScriptDataType cast_type = _gdtype_from_datatype(cn->cast_type->get_datatype());
 
-			switch (cast_type.kind) {
-				case GDScriptDataType::BUILTIN: {
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_CAST_TO_BUILTIN);
-					codegen.opcodes.push_back(cast_type.builtin_type);
-				} break;
-				case GDScriptDataType::NATIVE: {
-					int class_idx;
-					if (GDScriptLanguage::get_singleton()->get_global_map().has(cast_type.native_type)) {
-						class_idx = GDScriptLanguage::get_singleton()->get_global_map()[cast_type.native_type];
-						class_idx |= (GDScriptFunction::ADDR_TYPE_GLOBAL << GDScriptFunction::ADDR_BITS); //argument (stack root)
-					} else {
-						_set_error("Invalid native class type '" + String(cast_type.native_type) + "'.", cn);
-						return -1;
-					}
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_CAST_TO_NATIVE); // perform operator
-					codegen.opcodes.push_back(class_idx); // variable type
-				} break;
-				case GDScriptDataType::SCRIPT:
-				case GDScriptDataType::GDSCRIPT: {
-					Variant script = cast_type.script_type;
-					int idx = codegen.get_constant_pos(script); //make it a local constant (faster access)
+			// Create temporary for result first since it will be deleted last.
+			GDScriptCodeGenerator::Address result = codegen.add_temporary(cast_type);
 
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_CAST_TO_SCRIPT); // perform operator
-					codegen.opcodes.push_back(idx); // variable type
-				} break;
-				default: {
-					_set_error("Parser bug: unresolved data type.", cn);
-					return -1;
-				}
+			GDScriptCodeGenerator::Address source = _parse_expression(codegen, r_error, cn->operand);
+
+			gen->write_cast(result, source, cast_type);
+
+			if (source.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				gen->pop_temporary();
 			}
 
-			codegen.opcodes.push_back(src_addr); // source address
-			int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-			codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
-			codegen.alloc_stack(p_stack_level);
-			return dst_addr;
-
+			return source;
 		} break;
-		//hell breaks loose
-
-#define OPERATOR_RETURN                                                                                  \
-	int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS); \
-	codegen.opcodes.push_back(dst_addr);                                                                 \
-	codegen.alloc_stack(p_stack_level);                                                                  \
-	return dst_addr
-
 		case GDScriptParser::Node::CALL: {
 			const GDScriptParser::CallNode *call = static_cast<const GDScriptParser::CallNode *>(p_expression);
-			if (!call->is_super && call->callee->type == GDScriptParser::Node::IDENTIFIER && GDScriptParser::get_builtin_type(static_cast<GDScriptParser::IdentifierNode *>(call->callee)->name) != Variant::VARIANT_MAX) {
-				//construct a basic type
+			GDScriptDataType type = _gdtype_from_datatype(call->get_datatype());
+			GDScriptCodeGenerator::Address result = codegen.add_temporary(type);
 
+			Vector<GDScriptCodeGenerator::Address> arguments;
+			for (int i = 0; i < call->arguments.size(); i++) {
+				GDScriptCodeGenerator::Address arg = _parse_expression(codegen, r_error, call->arguments[i]);
+				if (r_error) {
+					return GDScriptCodeGenerator::Address();
+				}
+				arguments.push_back(arg);
+			}
+
+			if (!call->is_super && call->callee->type == GDScriptParser::Node::IDENTIFIER && GDScriptParser::get_builtin_type(static_cast<GDScriptParser::IdentifierNode *>(call->callee)->name) != Variant::VARIANT_MAX) {
+				// Construct a built-in type.
 				Variant::Type vtype = GDScriptParser::get_builtin_type(static_cast<GDScriptParser::IdentifierNode *>(call->callee)->name);
 
-				Vector<int> arguments;
-				int slevel = p_stack_level;
-				for (int i = 0; i < call->arguments.size(); i++) {
-					int ret = _parse_expression(codegen, call->arguments[i], slevel);
-					if (ret < 0) {
-						return ret;
-					}
-					if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-						slevel++;
-						codegen.alloc_stack(slevel);
-					}
-					arguments.push_back(ret);
-				}
-
-				//push call bytecode
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_CONSTRUCT); // basic type constructor
-				codegen.opcodes.push_back(vtype); //instance
-				codegen.opcodes.push_back(arguments.size()); //argument count
-				codegen.alloc_call(arguments.size());
-				for (int i = 0; i < arguments.size(); i++) {
-					codegen.opcodes.push_back(arguments[i]); //arguments
-				}
-
+				gen->write_construct(result, vtype, arguments);
 			} else if (!call->is_super && call->callee->type == GDScriptParser::Node::IDENTIFIER && GDScriptParser::get_builtin_function(static_cast<GDScriptParser::IdentifierNode *>(call->callee)->name) != GDScriptFunctions::FUNC_MAX) {
-				//built in function
-
-				Vector<int> arguments;
-				int slevel = p_stack_level;
-				for (int i = 0; i < call->arguments.size(); i++) {
-					int ret = _parse_expression(codegen, call->arguments[i], slevel);
-					if (ret < 0) {
-						return ret;
-					}
-
-					if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-						slevel++;
-						codegen.alloc_stack(slevel);
-					}
-
-					arguments.push_back(ret);
-				}
-
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL_BUILT_IN);
-				codegen.opcodes.push_back(GDScriptParser::get_builtin_function(static_cast<GDScriptParser::IdentifierNode *>(call->callee)->name));
-				codegen.opcodes.push_back(arguments.size());
-				codegen.alloc_call(arguments.size());
-				for (int i = 0; i < arguments.size(); i++) {
-					codegen.opcodes.push_back(arguments[i]);
-				}
-
+				// Built-in function.
+				GDScriptFunctions::Function func = GDScriptParser::get_builtin_function(static_cast<GDScriptParser::IdentifierNode *>(call->callee)->name);
+				gen->write_call_builtin(result, func, arguments);
 			} else {
-				//regular function
-
+				// Regular function.
 				const GDScriptParser::ExpressionNode *callee = call->callee;
 
-				Vector<int> arguments;
-				int slevel = p_stack_level;
-
-				// TODO: Use callables when possible if needed.
-				int ret = -1;
-				int super_address = -1;
 				if (call->is_super) {
 					// Super call.
-					if (call->callee == nullptr) {
-						// Implicit super function call.
-						super_address = codegen.get_name_map_pos(codegen.function_node->identifier->name);
-					} else {
-						super_address = codegen.get_name_map_pos(static_cast<GDScriptParser::IdentifierNode *>(call->callee)->name);
-					}
+					gen->write_super_call(result, call->function_name, arguments);
 				} else {
 					if (callee->type == GDScriptParser::Node::IDENTIFIER) {
 						// Self function call.
 						if ((codegen.function_node && codegen.function_node->is_static) || call->function_name == "new") {
-							ret = (GDScriptFunction::ADDR_TYPE_CLASS << GDScriptFunction::ADDR_BITS);
+							GDScriptCodeGenerator::Address self;
+							self.mode = GDScriptCodeGenerator::Address::CLASS;
+							gen->write_call(result, self, call->function_name, arguments);
 						} else {
-							ret = (GDScriptFunction::ADDR_TYPE_SELF << GDScriptFunction::ADDR_BITS);
+							gen->write_call_self(result, call->function_name, arguments);
 						}
-						arguments.push_back(ret);
-						ret = codegen.get_name_map_pos(static_cast<GDScriptParser::IdentifierNode *>(call->callee)->name);
-						arguments.push_back(ret);
 					} else if (callee->type == GDScriptParser::Node::SUBSCRIPT) {
 						const GDScriptParser::SubscriptNode *subscript = static_cast<const GDScriptParser::SubscriptNode *>(call->callee);
 
 						if (subscript->is_attribute) {
-							ret = _parse_expression(codegen, subscript->base, slevel);
-							if (ret < 0) {
-								return ret;
+							GDScriptCodeGenerator::Address base = _parse_expression(codegen, r_error, subscript->base);
+							if (r_error) {
+								return GDScriptCodeGenerator::Address();
 							}
-							if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-								slevel++;
-								codegen.alloc_stack(slevel);
+							if (within_await) {
+								gen->write_call_async(result, base, call->function_name, arguments);
+							} else {
+								gen->write_call(result, base, call->function_name, arguments);
 							}
-							arguments.push_back(ret);
-							arguments.push_back(codegen.get_name_map_pos(subscript->attribute->name));
+							if (base.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+								gen->pop_temporary();
+							}
 						} else {
 							_set_error("Cannot call something that isn't a function.", call->callee);
-							return -1;
+							r_error = ERR_COMPILATION_FAILED;
+							return GDScriptCodeGenerator::Address();
 						}
 					} else {
-						_set_error("Cannot call something that isn't a function.", call->callee);
-						return -1;
+						r_error = ERR_COMPILATION_FAILED;
+						return GDScriptCodeGenerator::Address();
 					}
-				}
-
-				for (int i = 0; i < call->arguments.size(); i++) {
-					ret = _parse_expression(codegen, call->arguments[i], slevel);
-					if (ret < 0) {
-						return ret;
-					}
-					if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-						slevel++;
-						codegen.alloc_stack(slevel);
-					}
-					arguments.push_back(ret);
-				}
-
-				int opcode = GDScriptFunction::OPCODE_CALL_RETURN;
-				if (call->is_super) {
-					opcode = GDScriptFunction::OPCODE_CALL_SELF_BASE;
-				} else if (within_await) {
-					opcode = GDScriptFunction::OPCODE_CALL_ASYNC;
-				} else if (p_root) {
-					opcode = GDScriptFunction::OPCODE_CALL;
-				}
-
-				codegen.opcodes.push_back(opcode); // perform operator
-				if (call->is_super) {
-					codegen.opcodes.push_back(super_address);
-				}
-				codegen.opcodes.push_back(call->arguments.size());
-				codegen.alloc_call(call->arguments.size());
-				for (int i = 0; i < arguments.size(); i++) {
-					codegen.opcodes.push_back(arguments[i]);
 				}
 			}
-			OPERATOR_RETURN;
+
+			for (int i = 0; i < arguments.size(); i++) {
+				if (arguments[i].mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					gen->pop_temporary();
+				}
+			}
+			return result;
 		} break;
 		case GDScriptParser::Node::GET_NODE: {
 			const GDScriptParser::GetNodeNode *get_node = static_cast<const GDScriptParser::GetNodeNode *>(p_expression);
@@ -816,59 +481,55 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 				}
 			}
 
-			int arg_address = codegen.get_constant_pos(NodePath(node_name));
+			Vector<GDScriptCodeGenerator::Address> args;
+			args.push_back(codegen.add_constant(NodePath(node_name)));
 
-			codegen.opcodes.push_back(p_root ? GDScriptFunction::OPCODE_CALL : GDScriptFunction::OPCODE_CALL_RETURN);
-			codegen.opcodes.push_back(1); // number of arguments.
-			codegen.alloc_call(1);
-			codegen.opcodes.push_back(GDScriptFunction::ADDR_TYPE_SELF << GDScriptFunction::ADDR_BITS); // self.
-			codegen.opcodes.push_back(codegen.get_name_map_pos("get_node")); // function.
-			codegen.opcodes.push_back(arg_address); // argument (NodePath).
-			OPERATOR_RETURN;
+			GDScriptCodeGenerator::Address result = codegen.add_temporary(_gdtype_from_datatype(get_node->get_datatype()));
+
+			MethodBind *get_node_method = ClassDB::get_method("Node", "get_node");
+			gen->write_call_method_bind(result, GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::SELF), get_node_method, args);
+
+			return result;
 		} break;
 		case GDScriptParser::Node::PRELOAD: {
 			const GDScriptParser::PreloadNode *preload = static_cast<const GDScriptParser::PreloadNode *>(p_expression);
 
 			// Add resource as constant.
-			return codegen.get_constant_pos(preload->resource);
+			return codegen.add_constant(preload->resource);
 		} break;
 		case GDScriptParser::Node::AWAIT: {
 			const GDScriptParser::AwaitNode *await = static_cast<const GDScriptParser::AwaitNode *>(p_expression);
 
-			int slevel = p_stack_level;
+			GDScriptCodeGenerator::Address result = codegen.add_temporary(_gdtype_from_datatype(p_expression->get_datatype()));
 			within_await = true;
-			int argument = _parse_expression(codegen, await->to_await, slevel);
+			GDScriptCodeGenerator::Address argument = _parse_expression(codegen, r_error, await->to_await);
 			within_await = false;
-			if (argument < 0) {
-				return argument;
+			if (r_error) {
+				return GDScriptCodeGenerator::Address();
 			}
-			if ((argument >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-				slevel++;
-				codegen.alloc_stack(slevel);
-			}
-			//push call bytecode
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_AWAIT);
-			codegen.opcodes.push_back(argument);
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_AWAIT_RESUME);
-			//next will be where to place the result :)
 
-			OPERATOR_RETURN;
+			gen->write_await(result, argument);
+
+			if (argument.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				gen->pop_temporary();
+			}
+
+			return result;
 		} break;
-
-		//indexing operator
+		// Indexing operator.
 		case GDScriptParser::Node::SUBSCRIPT: {
-			int slevel = p_stack_level;
-
 			const GDScriptParser::SubscriptNode *subscript = static_cast<const GDScriptParser::SubscriptNode *>(p_expression);
+			GDScriptCodeGenerator::Address result = codegen.add_temporary(_gdtype_from_datatype(subscript->get_datatype()));
 
-			int from = _parse_expression(codegen, subscript->base, slevel);
-			if (from < 0) {
-				return from;
+			GDScriptCodeGenerator::Address base = _parse_expression(codegen, r_error, subscript->base);
+			if (r_error) {
+				return GDScriptCodeGenerator::Address();
 			}
 
 			bool named = subscript->is_attribute;
-			int index;
-			if (p_index_addr != 0) {
+			StringName name;
+			GDScriptCodeGenerator::Address index;
+			if (p_index_addr.mode != GDScriptCodeGenerator::Address::NIL) {
 				index = p_index_addr;
 			} else if (subscript->is_attribute) {
 				if (subscript->base->type == GDScriptParser::Node::SELF && codegen.script) {
@@ -879,306 +540,179 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 					if (MI && MI->get().getter == codegen.function_name) {
 						String n = identifier->name;
 						_set_error("Must use '" + n + "' instead of 'self." + n + "' in getter.", identifier);
-						return -1;
+						r_error = ERR_COMPILATION_FAILED;
+						return GDScriptCodeGenerator::Address();
 					}
 #endif
 
 					if (MI && MI->get().getter == "") {
-						// Faster than indexing self (as if no self. had been used)
-						return (MI->get().index) | (GDScriptFunction::ADDR_TYPE_MEMBER << GDScriptFunction::ADDR_BITS);
+						// Remove result temp as we don't need it.
+						gen->pop_temporary();
+						// Faster than indexing self (as if no self. had been used).
+						return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::MEMBER, MI->get().index, _gdtype_from_datatype(subscript->get_datatype()));
 					}
 				}
 
-				index = codegen.get_name_map_pos(subscript->attribute->name);
-
+				name = subscript->attribute->name;
+				named = true;
 			} else {
 				if (subscript->index->type == GDScriptParser::Node::LITERAL && static_cast<const GDScriptParser::LiteralNode *>(subscript->index)->value.get_type() == Variant::STRING) {
-					//also, somehow, named (speed up anyway)
-					StringName name = static_cast<const GDScriptParser::LiteralNode *>(subscript->index)->value;
-					index = codegen.get_name_map_pos(name);
+					// Also, somehow, named (speed up anyway).
+					name = static_cast<const GDScriptParser::LiteralNode *>(subscript->index)->value;
 					named = true;
-
 				} else {
-					//regular indexing
-					if (from & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-						slevel++;
-						codegen.alloc_stack(slevel);
-					}
-
-					index = _parse_expression(codegen, subscript->index, slevel);
-					if (index < 0) {
-						return index;
+					// Regular indexing.
+					index = _parse_expression(codegen, r_error, subscript->index);
+					if (r_error) {
+						return GDScriptCodeGenerator::Address();
 					}
 				}
 			}
 
-			codegen.opcodes.push_back(named ? GDScriptFunction::OPCODE_GET_NAMED : GDScriptFunction::OPCODE_GET); // perform operator
-			codegen.opcodes.push_back(from); // argument 1
-			codegen.opcodes.push_back(index); // argument 2 (unary only takes one parameter)
-			OPERATOR_RETURN;
+			if (named) {
+				gen->write_get_named(result, name, base);
+			} else {
+				gen->write_get(result, index, base);
+			}
+
+			if (index.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				gen->pop_temporary();
+			}
+			if (base.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				gen->pop_temporary();
+			}
+
+			return result;
 		} break;
 		case GDScriptParser::Node::UNARY_OPERATOR: {
-			//unary operators
 			const GDScriptParser::UnaryOpNode *unary = static_cast<const GDScriptParser::UnaryOpNode *>(p_expression);
-			switch (unary->operation) {
-				case GDScriptParser::UnaryOpNode::OP_NEGATIVE: {
-					if (!_create_unary_operator(codegen, unary, Variant::OP_NEGATE, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::UnaryOpNode::OP_POSITIVE: {
-					if (!_create_unary_operator(codegen, unary, Variant::OP_POSITIVE, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::UnaryOpNode::OP_LOGIC_NOT: {
-					if (!_create_unary_operator(codegen, unary, Variant::OP_NOT, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::UnaryOpNode::OP_COMPLEMENT: {
-					if (!_create_unary_operator(codegen, unary, Variant::OP_BIT_NEGATE, p_stack_level)) {
-						return -1;
-					}
-				} break;
+
+			GDScriptCodeGenerator::Address result = codegen.add_temporary();
+
+			GDScriptCodeGenerator::Address operand = _parse_expression(codegen, r_error, unary->operand);
+			if (r_error) {
+				return GDScriptCodeGenerator::Address();
 			}
-			OPERATOR_RETURN;
+
+			gen->write_operator(result, unary->variant_op, operand, GDScriptCodeGenerator::Address());
+
+			if (operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				gen->pop_temporary();
+			}
+
+			return result;
 		}
 		case GDScriptParser::Node::BINARY_OPERATOR: {
-			//binary operators (in precedence order)
 			const GDScriptParser::BinaryOpNode *binary = static_cast<const GDScriptParser::BinaryOpNode *>(p_expression);
+
+			GDScriptCodeGenerator::Address result = codegen.add_temporary();
 
 			switch (binary->operation) {
 				case GDScriptParser::BinaryOpNode::OP_LOGIC_AND: {
-					// AND operator with early out on failure
+					// AND operator with early out on failure.
+					GDScriptCodeGenerator::Address left_operand = _parse_expression(codegen, r_error, binary->left_operand);
+					gen->write_and_left_operand(left_operand);
+					GDScriptCodeGenerator::Address right_operand = _parse_expression(codegen, r_error, binary->right_operand);
+					gen->write_and_right_operand(right_operand);
 
-					int res = _parse_expression(codegen, binary->left_operand, p_stack_level);
-					if (res < 0) {
-						return res;
+					gen->write_end_and(result);
+
+					if (right_operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+						gen->pop_temporary();
 					}
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-					codegen.opcodes.push_back(res);
-					int jump_fail_pos = codegen.opcodes.size();
-					codegen.opcodes.push_back(0);
-
-					res = _parse_expression(codegen, binary->right_operand, p_stack_level);
-					if (res < 0) {
-						return res;
+					if (left_operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+						gen->pop_temporary();
 					}
-
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-					codegen.opcodes.push_back(res);
-					int jump_fail_pos2 = codegen.opcodes.size();
-					codegen.opcodes.push_back(0);
-
-					codegen.alloc_stack(p_stack_level); //it will be used..
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_TRUE);
-					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-					codegen.opcodes.push_back(codegen.opcodes.size() + 3);
-					codegen.opcodes.write[jump_fail_pos] = codegen.opcodes.size();
-					codegen.opcodes.write[jump_fail_pos2] = codegen.opcodes.size();
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_FALSE);
-					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-					return p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
-
 				} break;
 				case GDScriptParser::BinaryOpNode::OP_LOGIC_OR: {
-					// OR operator with early out on success
+					// OR operator with early out on success.
+					GDScriptCodeGenerator::Address left_operand = _parse_expression(codegen, r_error, binary->left_operand);
+					gen->write_or_left_operand(left_operand);
+					GDScriptCodeGenerator::Address right_operand = _parse_expression(codegen, r_error, binary->right_operand);
+					gen->write_or_right_operand(right_operand);
 
-					int res = _parse_expression(codegen, binary->left_operand, p_stack_level);
-					if (res < 0) {
-						return res;
+					gen->write_end_or(result);
+
+					if (right_operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+						gen->pop_temporary();
 					}
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF);
-					codegen.opcodes.push_back(res);
-					int jump_success_pos = codegen.opcodes.size();
-					codegen.opcodes.push_back(0);
-
-					res = _parse_expression(codegen, binary->right_operand, p_stack_level);
-					if (res < 0) {
-						return res;
+					if (left_operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+						gen->pop_temporary();
 					}
-
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF);
-					codegen.opcodes.push_back(res);
-					int jump_success_pos2 = codegen.opcodes.size();
-					codegen.opcodes.push_back(0);
-
-					codegen.alloc_stack(p_stack_level); //it will be used..
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_FALSE);
-					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-					codegen.opcodes.push_back(codegen.opcodes.size() + 3);
-					codegen.opcodes.write[jump_success_pos] = codegen.opcodes.size();
-					codegen.opcodes.write[jump_success_pos2] = codegen.opcodes.size();
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_TRUE);
-					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-					return p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
-
 				} break;
 				case GDScriptParser::BinaryOpNode::OP_TYPE_TEST: {
-					int slevel = p_stack_level;
+					GDScriptCodeGenerator::Address operand = _parse_expression(codegen, r_error, binary->left_operand);
 
-					int src_address_a = _parse_expression(codegen, binary->left_operand, slevel);
-					if (src_address_a < 0) {
-						return -1;
-					}
-
-					if (src_address_a & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-						slevel++; //uses stack for return, increase stack
-					}
-
-					int src_address_b = -1;
-					bool builtin = false;
 					if (binary->right_operand->type == GDScriptParser::Node::IDENTIFIER && GDScriptParser::get_builtin_type(static_cast<const GDScriptParser::IdentifierNode *>(binary->right_operand)->name) != Variant::VARIANT_MAX) {
-						// `is` with builtin type
-						builtin = true;
-						src_address_b = (int)GDScriptParser::get_builtin_type(static_cast<const GDScriptParser::IdentifierNode *>(binary->right_operand)->name);
+						// `is` with builtin type)
+						Variant::Type type = GDScriptParser::get_builtin_type(static_cast<const GDScriptParser::IdentifierNode *>(binary->right_operand)->name);
+						gen->write_type_test_builtin(result, operand, type);
 					} else {
-						src_address_b = _parse_expression(codegen, binary->right_operand, slevel);
-						if (src_address_b < 0) {
-							return -1;
+						GDScriptCodeGenerator::Address type = _parse_expression(codegen, r_error, binary->right_operand);
+						if (r_error) {
+							return GDScriptCodeGenerator::Address();
+						}
+						gen->write_type_test(result, operand, type);
+						if (type.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+							gen->pop_temporary();
 						}
 					}
+				} break;
+				default: {
+					GDScriptCodeGenerator::Address left_operand = _parse_expression(codegen, r_error, binary->left_operand);
+					GDScriptCodeGenerator::Address right_operand = _parse_expression(codegen, r_error, binary->right_operand);
 
-					codegen.opcodes.push_back(builtin ? GDScriptFunction::OPCODE_IS_BUILTIN : GDScriptFunction::OPCODE_EXTENDS_TEST); // perform operator
-					codegen.opcodes.push_back(src_address_a); // argument 1
-					codegen.opcodes.push_back(src_address_b); // argument 2 (unary only takes one parameter)
+					gen->write_operator(result, binary->variant_op, left_operand, right_operand);
 
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_CONTENT_TEST: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_IN, p_stack_level)) {
-						return -1;
+					if (right_operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+						gen->pop_temporary();
 					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_COMP_EQUAL: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_EQUAL, p_stack_level)) {
-						return -1;
+					if (left_operand.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+						gen->pop_temporary();
 					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_COMP_NOT_EQUAL: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_NOT_EQUAL, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_COMP_LESS: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_LESS, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_COMP_LESS_EQUAL: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_LESS_EQUAL, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_COMP_GREATER: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_GREATER, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_COMP_GREATER_EQUAL: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_GREATER_EQUAL, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_ADDITION: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_ADD, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_SUBTRACTION: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_SUBTRACT, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_MULTIPLICATION: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_MULTIPLY, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_DIVISION: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_DIVIDE, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_MODULO: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_MODULE, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_BIT_AND: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_BIT_AND, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_BIT_OR: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_BIT_OR, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_BIT_XOR: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_BIT_XOR, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				//shift
-				case GDScriptParser::BinaryOpNode::OP_BIT_LEFT_SHIFT: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_SHIFT_LEFT, p_stack_level)) {
-						return -1;
-					}
-				} break;
-				case GDScriptParser::BinaryOpNode::OP_BIT_RIGHT_SHIFT: {
-					if (!_create_binary_operator(codegen, binary, Variant::OP_SHIFT_RIGHT, p_stack_level)) {
-						return -1;
-					}
-				} break;
+				}
 			}
-			OPERATOR_RETURN;
+			return result;
 		} break;
-		// ternary operators
 		case GDScriptParser::Node::TERNARY_OPERATOR: {
-			// x IF a ELSE y operator with early out on failure
-
+			// x IF a ELSE y operator with early out on failure.
 			const GDScriptParser::TernaryOpNode *ternary = static_cast<const GDScriptParser::TernaryOpNode *>(p_expression);
-			int res = _parse_expression(codegen, ternary->condition, p_stack_level);
-			if (res < 0) {
-				return res;
+			GDScriptCodeGenerator::Address result = codegen.add_temporary(_gdtype_from_datatype(ternary->get_datatype()));
+
+			gen->write_start_ternary(result);
+
+			GDScriptCodeGenerator::Address condition = _parse_expression(codegen, r_error, ternary->condition);
+			if (r_error) {
+				return GDScriptCodeGenerator::Address();
 			}
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-			codegen.opcodes.push_back(res);
-			int jump_fail_pos = codegen.opcodes.size();
-			codegen.opcodes.push_back(0);
+			gen->write_ternary_condition(condition);
 
-			res = _parse_expression(codegen, ternary->true_expr, p_stack_level);
-			if (res < 0) {
-				return res;
-			}
-
-			codegen.alloc_stack(p_stack_level); //it will be used..
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN);
-			codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-			codegen.opcodes.push_back(res);
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-			int jump_past_pos = codegen.opcodes.size();
-			codegen.opcodes.push_back(0);
-
-			codegen.opcodes.write[jump_fail_pos] = codegen.opcodes.size();
-			res = _parse_expression(codegen, ternary->false_expr, p_stack_level);
-			if (res < 0) {
-				return res;
+			if (condition.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				gen->pop_temporary();
 			}
 
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN);
-			codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-			codegen.opcodes.push_back(res);
+			GDScriptCodeGenerator::Address true_expr = _parse_expression(codegen, r_error, ternary->true_expr);
+			if (r_error) {
+				return GDScriptCodeGenerator::Address();
+			}
+			gen->write_ternary_true_expr(true_expr);
+			if (true_expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				gen->pop_temporary();
+			}
 
-			codegen.opcodes.write[jump_past_pos] = codegen.opcodes.size();
+			GDScriptCodeGenerator::Address false_expr = _parse_expression(codegen, r_error, ternary->false_expr);
+			if (r_error) {
+				return GDScriptCodeGenerator::Address();
+			}
+			gen->write_ternary_false_expr(false_expr);
+			if (false_expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				gen->pop_temporary();
+			}
 
-			return p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
+			gen->write_end_ternary();
 
+			return result;
 		} break;
-		//assignment operators
 		case GDScriptParser::Node::ASSIGNMENT: {
 			const GDScriptParser::AssignmentNode *assignment = static_cast<const GDScriptParser::AssignmentNode *>(p_expression);
 
@@ -1186,20 +720,16 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 				// SET (chained) MODE!
 				const GDScriptParser::SubscriptNode *subscript = static_cast<GDScriptParser::SubscriptNode *>(assignment->assignee);
 #ifdef DEBUG_ENABLED
-				if (subscript->is_attribute) {
-					if (subscript->base->type == GDScriptParser::Node::SELF && codegen.script) {
-						const Map<StringName, GDScript::MemberInfo>::Element *MI = codegen.script->member_indices.find(subscript->attribute->name);
-						if (MI && MI->get().setter == codegen.function_name) {
-							String n = subscript->attribute->name;
-							_set_error("Must use '" + n + "' instead of 'self." + n + "' in setter.", subscript);
-							return -1;
-						}
+				if (subscript->is_attribute && subscript->base->type == GDScriptParser::Node::SELF && codegen.script) {
+					const Map<StringName, GDScript::MemberInfo>::Element *MI = codegen.script->member_indices.find(subscript->attribute->name);
+					if (MI && MI->get().setter == codegen.function_name) {
+						String n = subscript->attribute->name;
+						_set_error("Must use '" + n + "' instead of 'self." + n + "' in setter.", subscript);
+						r_error = ERR_COMPILATION_FAILED;
+						return GDScriptCodeGenerator::Address();
 					}
 				}
 #endif
-
-				int slevel = p_stack_level;
-
 				/* Find chain of sets */
 
 				StringName assign_property;
@@ -1207,13 +737,12 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 				List<const GDScriptParser::SubscriptNode *> chain;
 
 				{
-					//create get/set chain
+					// Create get/set chain.
 					const GDScriptParser::SubscriptNode *n = subscript;
 					while (true) {
 						chain.push_back(n);
-
 						if (n->base->type != GDScriptParser::Node::SUBSCRIPT) {
-							//check for a built-in property
+							// Check for a built-in property.
 							if (n->base->type == GDScriptParser::Node::IDENTIFIER) {
 								GDScriptParser::IdentifierNode *identifier = static_cast<GDScriptParser::IdentifierNode *>(n->base);
 								if (_is_class_member_property(codegen, identifier->name)) {
@@ -1228,366 +757,396 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 
 				/* Chain of gets */
 
-				//get at (potential) root stack pos, so it can be returned
-				int prev_pos = _parse_expression(codegen, chain.back()->get()->base, slevel);
-				if (prev_pos < 0) {
-					return prev_pos;
-				}
-				int retval = prev_pos;
-
-				if (retval & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-					slevel++;
-					codegen.alloc_stack(slevel);
+				// Get at (potential) root stack pos, so it can be returned.
+				GDScriptCodeGenerator::Address base = _parse_expression(codegen, r_error, chain.back()->get()->base);
+				if (r_error) {
+					return GDScriptCodeGenerator::Address();
 				}
 
-				Vector<int> setchain;
+				GDScriptCodeGenerator::Address prev_base = base;
 
-				if (assign_property != StringName()) {
-					// recover and assign at the end, this allows stuff like
-					// position.x+=2.0
-					// in Node2D
-					setchain.push_back(prev_pos);
-					setchain.push_back(codegen.get_name_map_pos(assign_property));
-					setchain.push_back(GDScriptFunction::OPCODE_SET_MEMBER);
-				}
+				struct ChainInfo {
+					bool is_named = false;
+					GDScriptCodeGenerator::Address base;
+					GDScriptCodeGenerator::Address key;
+					StringName name;
+				};
+
+				List<ChainInfo> set_chain;
 
 				for (List<const GDScriptParser::SubscriptNode *>::Element *E = chain.back(); E; E = E->prev()) {
-					if (E == chain.front()) { //ignore first
+					if (E == chain.front()) {
+						// Skip the main subscript, since we'll assign to that.
 						break;
 					}
-
 					const GDScriptParser::SubscriptNode *subscript_elem = E->get();
-					int key_idx;
+					GDScriptCodeGenerator::Address value = codegen.add_temporary(_gdtype_from_datatype(subscript_elem->get_datatype()));
+					GDScriptCodeGenerator::Address key;
+					StringName name;
 
 					if (subscript_elem->is_attribute) {
-						key_idx = codegen.get_name_map_pos(subscript_elem->attribute->name);
-						//printf("named key %x\n",key_idx);
-
+						name = subscript_elem->attribute->name;
+						gen->write_get_named(value, name, prev_base);
 					} else {
-						if (prev_pos & (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS)) {
-							slevel++;
-							codegen.alloc_stack(slevel);
+						key = _parse_expression(codegen, r_error, subscript_elem->index);
+						if (r_error) {
+							return GDScriptCodeGenerator::Address();
 						}
-
-						GDScriptParser::ExpressionNode *key = subscript_elem->index;
-						key_idx = _parse_expression(codegen, key, slevel);
-						//printf("expr key %x\n",key_idx);
-
-						//stack was raised here if retval was stack but..
+						gen->write_get(value, key, prev_base);
 					}
 
-					if (key_idx < 0) { //error
-						return key_idx;
-					}
-
-					codegen.opcodes.push_back(subscript_elem->is_attribute ? GDScriptFunction::OPCODE_GET_NAMED : GDScriptFunction::OPCODE_GET);
-					codegen.opcodes.push_back(prev_pos);
-					codegen.opcodes.push_back(key_idx);
-					slevel++;
-					codegen.alloc_stack(slevel);
-					int dst_pos = (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) | slevel;
-
-					codegen.opcodes.push_back(dst_pos);
-
-					//add in reverse order, since it will be reverted
-
-					setchain.push_back(dst_pos);
-					setchain.push_back(key_idx);
-					setchain.push_back(prev_pos);
-					setchain.push_back(subscript_elem->is_attribute ? GDScriptFunction::OPCODE_SET_NAMED : GDScriptFunction::OPCODE_SET);
-
-					prev_pos = dst_pos;
+					// Store base and key for setting it back later.
+					set_chain.push_front({ subscript_elem->is_attribute, prev_base, key, name }); // Push to front to invert the list.
+					prev_base = value;
 				}
 
-				setchain.invert();
-
-				int set_index;
-
+				// Get value to assign.
+				GDScriptCodeGenerator::Address assigned = _parse_expression(codegen, r_error, assignment->assigned_value);
+				if (r_error) {
+					return GDScriptCodeGenerator::Address();
+				}
+				// Get the key if needed.
+				GDScriptCodeGenerator::Address key;
+				StringName name;
 				if (subscript->is_attribute) {
-					set_index = codegen.get_name_map_pos(subscript->attribute->name);
+					name = subscript->attribute->name;
 				} else {
-					set_index = _parse_expression(codegen, subscript->index, slevel + 1);
+					key = _parse_expression(codegen, r_error, subscript->index);
+					if (r_error) {
+						return GDScriptCodeGenerator::Address();
+					}
 				}
 
-				if (set_index < 0) { //error
-					return set_index;
+				// Perform operator if any.
+				if (assignment->operation != GDScriptParser::AssignmentNode::OP_NONE) {
+					GDScriptCodeGenerator::Address value = codegen.add_temporary();
+					if (subscript->is_attribute) {
+						gen->write_get_named(value, name, prev_base);
+					} else {
+						gen->write_get(value, key, prev_base);
+					}
+					gen->write_operator(value, assignment->variant_op, value, assigned);
+					if (assigned.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+						gen->pop_temporary();
+					}
+					assigned = value;
 				}
 
-				if (set_index & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-					slevel++;
-					codegen.alloc_stack(slevel);
+				// Perform assignment.
+				if (subscript->is_attribute) {
+					gen->write_set_named(prev_base, name, assigned);
+				} else {
+					gen->write_set(prev_base, key, assigned);
+				}
+				if (assigned.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					gen->pop_temporary();
 				}
 
-				int set_value = _parse_assign_right_expression(codegen, assignment, slevel + 1, subscript->is_attribute ? 0 : set_index);
-				if (set_value < 0) { //error
-					return set_value;
+				assigned = prev_base;
+
+				// Set back the values into their bases.
+				for (List<ChainInfo>::Element *E = set_chain.front(); E; E = E->next()) {
+					const ChainInfo &info = E->get();
+					if (!info.is_named) {
+						gen->write_set(info.base, info.key, assigned);
+						if (info.key.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+							gen->pop_temporary();
+						}
+					} else {
+						gen->write_set_named(info.base, info.name, assigned);
+					}
+					if (assigned.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+						gen->pop_temporary();
+					}
+					assigned = info.base;
 				}
 
-				codegen.opcodes.push_back(subscript->is_attribute ? GDScriptFunction::OPCODE_SET_NAMED : GDScriptFunction::OPCODE_SET);
-				codegen.opcodes.push_back(prev_pos);
-				codegen.opcodes.push_back(set_index);
-				codegen.opcodes.push_back(set_value);
-
-				for (int i = 0; i < setchain.size(); i++) {
-					codegen.opcodes.push_back(setchain[i]);
+				// If this is a local member, also assign to it.
+				// This allow things like: position.x += 2.0
+				if (assign_property != StringName()) {
+					gen->write_set_member(assigned, assign_property);
 				}
 
-				return retval;
-
+				if (assigned.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					gen->pop_temporary();
+				}
 			} else if (assignment->assignee->type == GDScriptParser::Node::IDENTIFIER && _is_class_member_property(codegen, static_cast<GDScriptParser::IdentifierNode *>(assignment->assignee)->name)) {
-				//assignment to member property
-
-				int slevel = p_stack_level;
-
-				int src_address = _parse_assign_right_expression(codegen, assignment, slevel);
-				if (src_address < 0) {
-					return -1;
+				// Assignment to member property.
+				GDScriptCodeGenerator::Address assigned = _parse_expression(codegen, r_error, assignment->assigned_value);
+				if (r_error) {
+					return GDScriptCodeGenerator::Address();
 				}
+				GDScriptCodeGenerator::Address assign_temp = assigned;
 
 				StringName name = static_cast<GDScriptParser::IdentifierNode *>(assignment->assignee)->name;
 
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_SET_MEMBER);
-				codegen.opcodes.push_back(codegen.get_name_map_pos(name));
-				codegen.opcodes.push_back(src_address);
+				if (assignment->operation != GDScriptParser::AssignmentNode::OP_NONE) {
+					GDScriptCodeGenerator::Address member = codegen.add_temporary();
+					gen->write_get_member(member, name);
+					gen->write_operator(assigned, assignment->variant_op, member, assigned);
+					gen->pop_temporary();
+				}
 
-				return GDScriptFunction::ADDR_TYPE_NIL << GDScriptFunction::ADDR_BITS;
+				gen->write_set_member(assigned, name);
+
+				if (assign_temp.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					gen->pop_temporary();
+				}
 			} else {
-				//REGULAR ASSIGNMENT MODE!!
-
-				int slevel = p_stack_level;
-				int dst_address_a = -1;
+				// Regular assignment.
+				GDScriptCodeGenerator::Address target;
 
 				bool has_setter = false;
 				bool is_in_setter = false;
 				StringName setter_function;
 				if (assignment->assignee->type == GDScriptParser::Node::IDENTIFIER) {
 					StringName var_name = static_cast<const GDScriptParser::IdentifierNode *>(assignment->assignee)->name;
-					if (!codegen.stack_identifiers.has(var_name) && codegen.script->member_indices.has(var_name)) {
+					if (!codegen.locals.has(var_name) && codegen.script->member_indices.has(var_name)) {
 						setter_function = codegen.script->member_indices[var_name].setter;
 						if (setter_function != StringName()) {
 							has_setter = true;
 							is_in_setter = setter_function == codegen.function_name;
-							dst_address_a = codegen.script->member_indices[var_name].index;
+							target.mode = GDScriptCodeGenerator::Address::MEMBER;
+							target.address = codegen.script->member_indices[var_name].index;
 						}
 					}
 				}
 
 				if (has_setter) {
-					if (is_in_setter) {
-						// Use direct member access.
-						dst_address_a |= GDScriptFunction::ADDR_TYPE_MEMBER << GDScriptFunction::ADDR_BITS;
-					} else {
+					if (!is_in_setter) {
 						// Store stack slot for the temp value.
-						dst_address_a = slevel++;
-						codegen.alloc_stack(slevel);
-						dst_address_a |= GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
+						target = codegen.add_temporary(_gdtype_from_datatype(assignment->assignee->get_datatype()));
 					}
 				} else {
-					dst_address_a = _parse_expression(codegen, assignment->assignee, slevel);
-					if (dst_address_a < 0) {
-						return -1;
-					}
-
-					if (dst_address_a & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-						slevel++;
-						codegen.alloc_stack(slevel);
+					target = _parse_expression(codegen, r_error, assignment->assignee);
+					if (r_error) {
+						return GDScriptCodeGenerator::Address();
 					}
 				}
 
-				int src_address_b = _parse_assign_right_expression(codegen, assignment, slevel);
-				if (src_address_b < 0) {
-					return -1;
+				GDScriptCodeGenerator::Address assigned = _parse_expression(codegen, r_error, assignment->assigned_value);
+				GDScriptCodeGenerator::Address op_result;
+				if (r_error) {
+					return GDScriptCodeGenerator::Address();
+				}
+
+				if (assignment->operation != GDScriptParser::AssignmentNode::OP_NONE) {
+					// Perform operation.
+					op_result = codegen.add_temporary();
+					gen->write_operator(op_result, assignment->variant_op, target, assigned);
+				} else {
+					op_result = assigned;
+					assigned = GDScriptCodeGenerator::Address();
 				}
 
 				GDScriptDataType assign_type = _gdtype_from_datatype(assignment->assignee->get_datatype());
 
 				if (has_setter && !is_in_setter) {
 					// Call setter.
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL);
-					codegen.opcodes.push_back(1); // Argument count.
-					codegen.opcodes.push_back(GDScriptFunction::ADDR_TYPE_SELF << GDScriptFunction::ADDR_BITS); // Base (self).
-					codegen.opcodes.push_back(codegen.get_name_map_pos(setter_function)); // Method name.
-					codegen.opcodes.push_back(dst_address_a); // Argument.
-					codegen.opcodes.push_back(dst_address_a); // Result address (won't be used here).
-					codegen.alloc_call(1);
-				} else if (!_generate_typed_assign(codegen, src_address_b, dst_address_a, assign_type, assignment->assigned_value->get_datatype())) {
-					return -1;
+					Vector<GDScriptCodeGenerator::Address> args;
+					args.push_back(op_result);
+					gen->write_call(GDScriptCodeGenerator::Address(), GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::SELF), setter_function, args);
+				} else {
+					// Just assign.
+					gen->write_assign(target, op_result);
 				}
 
-				return dst_address_a; //if anything, returns wathever was assigned or correct stack position
+				if (op_result.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					gen->pop_temporary();
+				}
+				if (assigned.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					gen->pop_temporary();
+				}
+				if (target.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					gen->pop_temporary();
+				}
 			}
+			return GDScriptCodeGenerator::Address(); // Assignment does not return a value.
 		} break;
-#undef OPERATOR_RETURN
-		//TYPE_TYPE,
 		default: {
-			ERR_FAIL_V_MSG(-1, "Bug in bytecode compiler, unexpected node in parse tree while parsing expression."); //unreachable code
+			ERR_FAIL_V_MSG(GDScriptCodeGenerator::Address(), "Bug in bytecode compiler, unexpected node in parse tree while parsing expression."); // Unreachable code.
 		} break;
 	}
 }
 
-Error GDScriptCompiler::_parse_match_pattern(CodeGen &codegen, const GDScriptParser::PatternNode *p_pattern, int p_stack_level, int p_value_addr, int p_type_addr, int &r_bound_variables, Vector<int> &r_patch_addresses, Vector<int> &r_block_patch_address) {
-	// TODO: Many "repeated" code here that could be abstracted. This compiler is going away when new VM arrives though, so...
+GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &codegen, Error &r_error, const GDScriptParser::PatternNode *p_pattern, const GDScriptCodeGenerator::Address &p_value_addr, const GDScriptCodeGenerator::Address &p_type_addr, const GDScriptCodeGenerator::Address &p_previous_test, bool p_is_first, bool p_is_nested) {
 	switch (p_pattern->pattern_type) {
 		case GDScriptParser::PatternNode::PT_LITERAL: {
-			// Get literal type into constant map.
-			int literal_type_addr = -1;
-			if (!codegen.constant_map.has((int)p_pattern->literal->value.get_type())) {
-				literal_type_addr = codegen.constant_map.size();
-				codegen.constant_map[(int)p_pattern->literal->value.get_type()] = literal_type_addr;
-
-			} else {
-				literal_type_addr = codegen.constant_map[(int)p_pattern->literal->value.get_type()];
+			if (p_is_nested) {
+				codegen.generator->write_and_left_operand(p_previous_test);
+			} else if (!p_is_first) {
+				codegen.generator->write_or_left_operand(p_previous_test);
 			}
-			literal_type_addr |= GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS;
+
+			// Get literal type into constant map.
+			GDScriptCodeGenerator::Address literal_type_addr = codegen.add_constant((int)p_pattern->literal->value.get_type());
+
+			// Equality is always a boolean.
+			GDScriptDataType equality_type;
+			equality_type.has_type = true;
+			equality_type.kind = GDScriptDataType::BUILTIN;
+			equality_type.builtin_type = Variant::BOOL;
 
 			// Check type equality.
-			int equality_addr = p_stack_level++;
-			equality_addr |= GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
-			codegen.alloc_stack(p_stack_level);
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_OPERATOR);
-			codegen.opcodes.push_back(Variant::OP_EQUAL);
-			codegen.opcodes.push_back(p_type_addr);
-			codegen.opcodes.push_back(literal_type_addr);
-			codegen.opcodes.push_back(equality_addr); // Address to result.
-
-			// Jump away if not the same type.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-			codegen.opcodes.push_back(equality_addr);
-			r_patch_addresses.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
+			GDScriptCodeGenerator::Address type_equality_addr = codegen.add_temporary(equality_type);
+			codegen.generator->write_operator(type_equality_addr, Variant::OP_EQUAL, p_type_addr, literal_type_addr);
+			codegen.generator->write_and_left_operand(type_equality_addr);
 
 			// Get literal.
-			int literal_addr = _parse_expression(codegen, p_pattern->literal, p_stack_level);
+			GDScriptCodeGenerator::Address literal_addr = _parse_expression(codegen, r_error, p_pattern->literal);
+			if (r_error) {
+				return GDScriptCodeGenerator::Address();
+			}
 
 			// Check value equality.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_OPERATOR);
-			codegen.opcodes.push_back(Variant::OP_EQUAL);
-			codegen.opcodes.push_back(p_value_addr);
-			codegen.opcodes.push_back(literal_addr);
-			codegen.opcodes.push_back(equality_addr); // Address to result.
+			GDScriptCodeGenerator::Address equality_addr = codegen.add_temporary(equality_type);
+			codegen.generator->write_operator(equality_addr, Variant::OP_EQUAL, p_value_addr, literal_addr);
+			codegen.generator->write_and_right_operand(equality_addr);
 
-			// Jump away if doesn't match.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-			codegen.opcodes.push_back(equality_addr);
-			r_patch_addresses.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
+			// AND both together (reuse temporary location).
+			codegen.generator->write_end_and(type_equality_addr);
 
-			// Jump to the actual block since it matches. This is needed to take multi-pattern into account.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-			r_block_patch_address.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
+			codegen.generator->pop_temporary(); // Remove equality_addr from stack.
+
+			if (literal_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				codegen.generator->pop_temporary();
+			}
+
+			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
+			if (p_is_nested) {
+				// Use the previous value as target, since we only need one temporary variable.
+				codegen.generator->write_and_right_operand(type_equality_addr);
+				codegen.generator->write_end_and(p_previous_test);
+			} else if (!p_is_first) {
+				// Use the previous value as target, since we only need one temporary variable.
+				codegen.generator->write_or_right_operand(type_equality_addr);
+				codegen.generator->write_end_or(p_previous_test);
+			} else {
+				// Just assign this value to the accumulator temporary.
+				codegen.generator->write_assign(p_previous_test, type_equality_addr);
+			}
+			codegen.generator->pop_temporary(); // Remove type_equality_addr.
+
+			return p_previous_test;
 		} break;
 		case GDScriptParser::PatternNode::PT_EXPRESSION: {
+			if (p_is_nested) {
+				codegen.generator->write_and_left_operand(p_previous_test);
+			} else if (!p_is_first) {
+				codegen.generator->write_or_left_operand(p_previous_test);
+			}
+			// Create the result temps first since it's the last to go away.
+			GDScriptCodeGenerator::Address result_addr = codegen.add_temporary();
+			GDScriptCodeGenerator::Address equality_test_addr = codegen.add_temporary();
+
 			// Evaluate expression.
-			int expr_addr = _parse_expression(codegen, p_pattern->expression, p_stack_level);
-			if ((expr_addr >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-				p_stack_level++;
-				codegen.alloc_stack(p_stack_level);
+			GDScriptCodeGenerator::Address expr_addr;
+			expr_addr = _parse_expression(codegen, r_error, p_pattern->expression);
+			if (r_error) {
+				return GDScriptCodeGenerator::Address();
 			}
 
 			// Evaluate expression type.
-			int expr_type_addr = p_stack_level++;
-			expr_type_addr |= GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
-			codegen.alloc_stack(p_stack_level);
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL_BUILT_IN);
-			codegen.opcodes.push_back(GDScriptFunctions::TYPE_OF);
-			codegen.opcodes.push_back(1); // One argument.
-			codegen.opcodes.push_back(expr_addr); // Argument is the value we want to test.
-			codegen.opcodes.push_back(expr_type_addr); // Address to result.
+			Vector<GDScriptCodeGenerator::Address> typeof_args;
+			typeof_args.push_back(expr_addr);
+			codegen.generator->write_call_builtin(result_addr, GDScriptFunctions::TYPE_OF, typeof_args);
 
 			// Check type equality.
-			int equality_addr = p_stack_level++;
-			equality_addr |= GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
-			codegen.alloc_stack(p_stack_level);
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_OPERATOR);
-			codegen.opcodes.push_back(Variant::OP_EQUAL);
-			codegen.opcodes.push_back(p_type_addr);
-			codegen.opcodes.push_back(expr_type_addr);
-			codegen.opcodes.push_back(equality_addr); // Address to result.
-
-			// Jump away if not the same type.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-			codegen.opcodes.push_back(equality_addr);
-			r_patch_addresses.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
+			codegen.generator->write_operator(result_addr, Variant::OP_EQUAL, p_type_addr, result_addr);
+			codegen.generator->write_and_left_operand(result_addr);
 
 			// Check value equality.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_OPERATOR);
-			codegen.opcodes.push_back(Variant::OP_EQUAL);
-			codegen.opcodes.push_back(p_value_addr);
-			codegen.opcodes.push_back(expr_addr);
-			codegen.opcodes.push_back(equality_addr); // Address to result.
+			codegen.generator->write_operator(result_addr, Variant::OP_EQUAL, p_value_addr, expr_addr);
+			codegen.generator->write_and_right_operand(equality_test_addr);
 
-			// Jump away if doesn't match.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-			codegen.opcodes.push_back(equality_addr);
-			r_patch_addresses.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
+			// AND both type and value equality.
+			codegen.generator->write_end_and(result_addr);
 
-			// Jump to the actual block since it matches. This is needed to take multi-pattern into account.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-			r_block_patch_address.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
-		} break;
-		case GDScriptParser::PatternNode::PT_BIND: {
-			// Create new stack variable.
-			int bind_addr = p_stack_level | (GDScriptFunction::ADDR_TYPE_STACK_VARIABLE << GDScriptFunction::ADDR_BITS);
-			codegen.add_stack_identifier(p_pattern->bind->name, p_stack_level++);
-			codegen.alloc_stack(p_stack_level);
-			r_bound_variables++;
+			// We don't need the expression temporary anymore.
+			if (expr_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				codegen.generator->pop_temporary();
+			}
+			codegen.generator->pop_temporary(); // Remove type equality temporary.
 
-			// Assign value to bound variable.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN);
-			codegen.opcodes.push_back(bind_addr); // Destination.
-			codegen.opcodes.push_back(p_value_addr); // Source.
-			// Not need to block jump because bind happens only once.
+			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
+			if (p_is_nested) {
+				// Use the previous value as target, since we only need one temporary variable.
+				codegen.generator->write_and_right_operand(result_addr);
+				codegen.generator->write_end_and(p_previous_test);
+			} else if (!p_is_first) {
+				// Use the previous value as target, since we only need one temporary variable.
+				codegen.generator->write_or_right_operand(result_addr);
+				codegen.generator->write_end_or(p_previous_test);
+			} else {
+				// Just assign this value to the accumulator temporary.
+				codegen.generator->write_assign(p_previous_test, result_addr);
+			}
+			codegen.generator->pop_temporary(); // Remove temp result addr.
+
+			return p_previous_test;
 		} break;
 		case GDScriptParser::PatternNode::PT_ARRAY: {
-			int slevel = p_stack_level;
-
+			if (p_is_nested) {
+				codegen.generator->write_and_left_operand(p_previous_test);
+			} else if (!p_is_first) {
+				codegen.generator->write_or_left_operand(p_previous_test);
+			}
 			// Get array type into constant map.
-			int array_type_addr = codegen.get_constant_pos(Variant::ARRAY);
+			GDScriptCodeGenerator::Address array_type_addr = codegen.add_constant((int)Variant::ARRAY);
+
+			// Equality is always a boolean.
+			GDScriptDataType temp_type;
+			temp_type.has_type = true;
+			temp_type.kind = GDScriptDataType::BUILTIN;
+			temp_type.builtin_type = Variant::BOOL;
 
 			// Check type equality.
-			int equality_addr = slevel++;
-			equality_addr |= GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
-			codegen.alloc_stack(slevel);
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_OPERATOR);
-			codegen.opcodes.push_back(Variant::OP_EQUAL);
-			codegen.opcodes.push_back(p_type_addr);
-			codegen.opcodes.push_back(array_type_addr);
-			codegen.opcodes.push_back(equality_addr); // Address to result.
-
-			// Jump away if not the same type.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-			codegen.opcodes.push_back(equality_addr);
-			r_patch_addresses.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
+			GDScriptCodeGenerator::Address result_addr = codegen.add_temporary(temp_type);
+			codegen.generator->write_operator(result_addr, Variant::OP_EQUAL, p_type_addr, array_type_addr);
+			codegen.generator->write_and_left_operand(result_addr);
 
 			// Store pattern length in constant map.
-			int array_length_addr = codegen.get_constant_pos(p_pattern->rest_used ? p_pattern->array.size() - 1 : p_pattern->array.size());
+			GDScriptCodeGenerator::Address array_length_addr = codegen.add_constant(p_pattern->rest_used ? p_pattern->array.size() - 1 : p_pattern->array.size());
 
 			// Get value length.
-			int value_length_addr = slevel++;
-			codegen.alloc_stack(slevel);
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL_BUILT_IN);
-			codegen.opcodes.push_back(GDScriptFunctions::LEN);
-			codegen.opcodes.push_back(1); // One argument.
-			codegen.opcodes.push_back(p_value_addr); // Argument is the value we want to test.
-			codegen.opcodes.push_back(value_length_addr); // Address to result.
+			temp_type.builtin_type = Variant::INT;
+			GDScriptCodeGenerator::Address value_length_addr = codegen.add_temporary(temp_type);
+			Vector<GDScriptCodeGenerator::Address> len_args;
+			len_args.push_back(p_value_addr);
+			codegen.generator->write_call_builtin(value_length_addr, GDScriptFunctions::LEN, len_args);
 
 			// Test length compatibility.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_OPERATOR);
-			codegen.opcodes.push_back(p_pattern->rest_used ? Variant::OP_GREATER_EQUAL : Variant::OP_EQUAL);
-			codegen.opcodes.push_back(value_length_addr);
-			codegen.opcodes.push_back(array_length_addr);
-			codegen.opcodes.push_back(equality_addr); // Address to result.
+			temp_type.builtin_type = Variant::BOOL;
+			GDScriptCodeGenerator::Address length_compat_addr = codegen.add_temporary(temp_type);
+			codegen.generator->write_operator(length_compat_addr, p_pattern->rest_used ? Variant::OP_GREATER_EQUAL : Variant::OP_EQUAL, value_length_addr, array_length_addr);
+			codegen.generator->write_and_right_operand(length_compat_addr);
 
-			// Jump away if length is not compatible.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-			codegen.opcodes.push_back(equality_addr);
-			r_patch_addresses.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
+			// AND type and length check.
+			codegen.generator->write_end_and(result_addr);
+
+			// Remove length temporaries.
+			codegen.generator->pop_temporary();
+			codegen.generator->pop_temporary();
+
+			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
+			if (p_is_nested) {
+				// Use the previous value as target, since we only need one temporary variable.
+				codegen.generator->write_and_right_operand(result_addr);
+				codegen.generator->write_end_and(p_previous_test);
+			} else if (!p_is_first) {
+				// Use the previous value as target, since we only need one temporary variable.
+				codegen.generator->write_or_right_operand(result_addr);
+				codegen.generator->write_end_or(p_previous_test);
+			} else {
+				// Just assign this value to the accumulator temporary.
+				codegen.generator->write_assign(p_previous_test, result_addr);
+			}
+			codegen.generator->pop_temporary(); // Remove temp result addr.
+
+			// Create temporaries outside the loop so they can be reused.
+			GDScriptCodeGenerator::Address element_addr = codegen.add_temporary();
+			GDScriptCodeGenerator::Address element_type_addr = codegen.add_temporary();
+			GDScriptCodeGenerator::Address test_addr = p_previous_test;
 
 			// Evaluate element by element.
 			for (int i = 0; i < p_pattern->array.size(); i++) {
@@ -1596,494 +1155,461 @@ Error GDScriptCompiler::_parse_match_pattern(CodeGen &codegen, const GDScriptPar
 					break;
 				}
 
-				int stlevel = p_stack_level;
-				Vector<int> element_block_patches; // I want to internal patterns try the next element instead of going to the block.
+				// Use AND here too, as we don't want to be checking elements if previous test failed (which means this might be an invalid get).
+				codegen.generator->write_and_left_operand(test_addr);
+
 				// Add index to constant map.
-				int index_addr = codegen.get_constant_pos(i);
+				GDScriptCodeGenerator::Address index_addr = codegen.add_constant(i);
 
 				// Get the actual element from the user-sent array.
-				int element_addr = stlevel++;
-				codegen.alloc_stack(stlevel);
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_GET);
-				codegen.opcodes.push_back(p_value_addr); // Source.
-				codegen.opcodes.push_back(index_addr); // Index.
-				codegen.opcodes.push_back(element_addr); // Destination.
+				codegen.generator->write_get(element_addr, index_addr, p_value_addr);
 
 				// Also get type of element.
-				int element_type_addr = stlevel++;
-				element_type_addr |= GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
-				codegen.alloc_stack(stlevel);
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL_BUILT_IN);
-				codegen.opcodes.push_back(GDScriptFunctions::TYPE_OF);
-				codegen.opcodes.push_back(1); // One argument.
-				codegen.opcodes.push_back(element_addr); // Argument is the value we want to test.
-				codegen.opcodes.push_back(element_type_addr); // Address to result.
+				Vector<GDScriptCodeGenerator::Address> typeof_args;
+				typeof_args.push_back(element_addr);
+				codegen.generator->write_call_builtin(element_type_addr, GDScriptFunctions::TYPE_OF, typeof_args);
 
 				// Try the pattern inside the element.
-				Error err = _parse_match_pattern(codegen, p_pattern->array[i], stlevel, element_addr, element_type_addr, r_bound_variables, r_patch_addresses, element_block_patches);
-				if (err != OK) {
-					return err;
+				test_addr = _parse_match_pattern(codegen, r_error, p_pattern->array[i], element_addr, element_type_addr, p_previous_test, false, true);
+				if (r_error != OK) {
+					return GDScriptCodeGenerator::Address();
 				}
 
-				// Patch jumps to block to try the next element.
-				for (int j = 0; j < element_block_patches.size(); j++) {
-					codegen.opcodes.write[element_block_patches[j]] = codegen.opcodes.size();
-				}
+				codegen.generator->write_and_right_operand(test_addr);
+				codegen.generator->write_end_and(test_addr);
 			}
+			// Remove element temporaries.
+			codegen.generator->pop_temporary();
+			codegen.generator->pop_temporary();
 
-			// Jump to the actual block since it matches. This is needed to take multi-pattern into account.
-			// Also here for the case of empty arrays.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-			r_block_patch_address.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
+			return test_addr;
 		} break;
 		case GDScriptParser::PatternNode::PT_DICTIONARY: {
-			int slevel = p_stack_level;
-
+			if (p_is_nested) {
+				codegen.generator->write_and_left_operand(p_previous_test);
+			} else if (!p_is_first) {
+				codegen.generator->write_or_left_operand(p_previous_test);
+			}
 			// Get dictionary type into constant map.
-			int dict_type_addr = codegen.get_constant_pos(Variant::DICTIONARY);
+			GDScriptCodeGenerator::Address dict_type_addr = codegen.add_constant((int)Variant::DICTIONARY);
+
+			// Equality is always a boolean.
+			GDScriptDataType temp_type;
+			temp_type.has_type = true;
+			temp_type.kind = GDScriptDataType::BUILTIN;
+			temp_type.builtin_type = Variant::BOOL;
 
 			// Check type equality.
-			int equality_addr = slevel++;
-			equality_addr |= GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
-			codegen.alloc_stack(slevel);
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_OPERATOR);
-			codegen.opcodes.push_back(Variant::OP_EQUAL);
-			codegen.opcodes.push_back(p_type_addr);
-			codegen.opcodes.push_back(dict_type_addr);
-			codegen.opcodes.push_back(equality_addr); // Address to result.
-
-			// Jump away if not the same type.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-			codegen.opcodes.push_back(equality_addr);
-			r_patch_addresses.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
+			GDScriptCodeGenerator::Address result_addr = codegen.add_temporary(temp_type);
+			codegen.generator->write_operator(result_addr, Variant::OP_EQUAL, p_type_addr, dict_type_addr);
+			codegen.generator->write_and_left_operand(result_addr);
 
 			// Store pattern length in constant map.
-			int dict_length_addr = codegen.get_constant_pos(p_pattern->rest_used ? p_pattern->dictionary.size() - 1 : p_pattern->dictionary.size());
+			GDScriptCodeGenerator::Address dict_length_addr = codegen.add_constant(p_pattern->rest_used ? p_pattern->dictionary.size() - 1 : p_pattern->dictionary.size());
 
 			// Get user's dictionary length.
-			int value_length_addr = slevel++;
-			codegen.alloc_stack(slevel);
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL_BUILT_IN);
-			codegen.opcodes.push_back(GDScriptFunctions::LEN);
-			codegen.opcodes.push_back(1); // One argument.
-			codegen.opcodes.push_back(p_value_addr); // Argument is the value we want to test.
-			codegen.opcodes.push_back(value_length_addr); // Address to result.
+			temp_type.builtin_type = Variant::INT;
+			GDScriptCodeGenerator::Address value_length_addr = codegen.add_temporary(temp_type);
+			Vector<GDScriptCodeGenerator::Address> func_args;
+			func_args.push_back(p_value_addr);
+			codegen.generator->write_call_builtin(value_length_addr, GDScriptFunctions::LEN, func_args);
 
 			// Test length compatibility.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_OPERATOR);
-			codegen.opcodes.push_back(p_pattern->rest_used ? Variant::OP_GREATER_EQUAL : Variant::OP_EQUAL);
-			codegen.opcodes.push_back(value_length_addr);
-			codegen.opcodes.push_back(dict_length_addr);
-			codegen.opcodes.push_back(equality_addr); // Address to result.
+			temp_type.builtin_type = Variant::BOOL;
+			GDScriptCodeGenerator::Address length_compat_addr = codegen.add_temporary(temp_type);
+			codegen.generator->write_operator(length_compat_addr, p_pattern->rest_used ? Variant::OP_GREATER_EQUAL : Variant::OP_EQUAL, value_length_addr, dict_length_addr);
+			codegen.generator->write_and_right_operand(length_compat_addr);
 
-			// Jump away if length is not compatible.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-			codegen.opcodes.push_back(equality_addr);
-			r_patch_addresses.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
+			// AND type and length check.
+			codegen.generator->write_end_and(result_addr);
+
+			// Remove length temporaries.
+			codegen.generator->pop_temporary();
+			codegen.generator->pop_temporary();
+
+			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
+			if (p_is_nested) {
+				// Use the previous value as target, since we only need one temporary variable.
+				codegen.generator->write_and_right_operand(result_addr);
+				codegen.generator->write_end_and(p_previous_test);
+			} else if (!p_is_first) {
+				// Use the previous value as target, since we only need one temporary variable.
+				codegen.generator->write_or_right_operand(result_addr);
+				codegen.generator->write_end_or(p_previous_test);
+			} else {
+				// Just assign this value to the accumulator temporary.
+				codegen.generator->write_assign(p_previous_test, result_addr);
+			}
+			codegen.generator->pop_temporary(); // Remove temp result addr.
+
+			// Create temporaries outside the loop so they can be reused.
+			temp_type.builtin_type = Variant::BOOL;
+			GDScriptCodeGenerator::Address test_result = codegen.add_temporary(temp_type);
+			GDScriptCodeGenerator::Address element_addr = codegen.add_temporary();
+			GDScriptCodeGenerator::Address element_type_addr = codegen.add_temporary();
+			GDScriptCodeGenerator::Address test_addr = p_previous_test;
 
 			// Evaluate element by element.
 			for (int i = 0; i < p_pattern->dictionary.size(); i++) {
 				const GDScriptParser::PatternNode::Pair &element = p_pattern->dictionary[i];
 				if (element.value_pattern && element.value_pattern->pattern_type == GDScriptParser::PatternNode::PT_REST) {
 					// Ignore rest pattern.
-					continue;
+					break;
 				}
-				int stlevel = p_stack_level;
-				Vector<int> element_block_patches; // I want to internal patterns try the next element instead of going to the block.
+
+				// Use AND here too, as we don't want to be checking elements if previous test failed (which means this might be an invalid get).
+				codegen.generator->write_and_left_operand(test_addr);
 
 				// Get the pattern key.
-				int pattern_key_addr = _parse_expression(codegen, element.key, stlevel);
-				if (pattern_key_addr < 0) {
-					return ERR_PARSE_ERROR;
-				}
-				if ((pattern_key_addr >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-					stlevel++;
-					codegen.alloc_stack(stlevel);
+				GDScriptCodeGenerator::Address pattern_key_addr = _parse_expression(codegen, r_error, element.key);
+				if (r_error) {
+					return GDScriptCodeGenerator::Address();
 				}
 
-				// Create stack slot for test result.
-				int test_result = stlevel++;
-				test_result |= GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
-				codegen.alloc_stack(stlevel);
-
-				// Check if pattern key exists in user's dictionary.
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL_RETURN);
-				codegen.opcodes.push_back(1); // Argument count.
-				codegen.opcodes.push_back(p_value_addr); // Base (user dictionary).
-				codegen.opcodes.push_back(codegen.get_name_map_pos("has")); // Function name.
-				codegen.opcodes.push_back(pattern_key_addr); // Argument (pattern key).
-				codegen.opcodes.push_back(test_result); // Return address.
-
-				// Jump away if key doesn't exist.
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-				codegen.opcodes.push_back(test_result);
-				r_patch_addresses.push_back(codegen.opcodes.size());
-				codegen.opcodes.push_back(0); // Will be replaced.
+				// Check if pattern key exists in user's dictionary. This will be AND-ed with next result.
+				func_args.clear();
+				func_args.push_back(pattern_key_addr);
+				codegen.generator->write_call(test_result, p_value_addr, "has", func_args);
 
 				if (element.value_pattern != nullptr) {
+					// Use AND here too, as we don't want to be checking elements if previous test failed (which means this might be an invalid get).
+					codegen.generator->write_and_left_operand(test_result);
+
 					// Get actual value from user dictionary.
-					int value_addr = stlevel++;
-					codegen.alloc_stack(stlevel);
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_GET);
-					codegen.opcodes.push_back(p_value_addr); // Source.
-					codegen.opcodes.push_back(pattern_key_addr); // Index.
-					codegen.opcodes.push_back(value_addr); // Destination.
+					codegen.generator->write_get(element_addr, pattern_key_addr, p_value_addr);
 
 					// Also get type of value.
-					int value_type_addr = stlevel++;
-					value_type_addr |= GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
-					codegen.alloc_stack(stlevel);
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL_BUILT_IN);
-					codegen.opcodes.push_back(GDScriptFunctions::TYPE_OF);
-					codegen.opcodes.push_back(1); // One argument.
-					codegen.opcodes.push_back(value_addr); // Argument is the value we want to test.
-					codegen.opcodes.push_back(value_type_addr); // Address to result.
+					func_args.clear();
+					func_args.push_back(element_addr);
+					codegen.generator->write_call_builtin(element_type_addr, GDScriptFunctions::TYPE_OF, func_args);
 
 					// Try the pattern inside the value.
-					Error err = _parse_match_pattern(codegen, element.value_pattern, stlevel, value_addr, value_type_addr, r_bound_variables, r_patch_addresses, element_block_patches);
-					if (err != OK) {
-						return err;
+					test_addr = _parse_match_pattern(codegen, r_error, element.value_pattern, element_addr, element_type_addr, test_addr, false, true);
+					if (r_error != OK) {
+						return GDScriptCodeGenerator::Address();
 					}
+					codegen.generator->write_and_right_operand(test_addr);
+					codegen.generator->write_end_and(test_addr);
 				}
 
-				// Patch jumps to block to try the next element.
-				for (int j = 0; j < element_block_patches.size(); j++) {
-					codegen.opcodes.write[element_block_patches[j]] = codegen.opcodes.size();
+				codegen.generator->write_and_right_operand(test_addr);
+				codegen.generator->write_end_and(test_addr);
+
+				// Remove pattern key temporary.
+				if (pattern_key_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					codegen.generator->pop_temporary();
 				}
 			}
 
-			// Jump to the actual block since it matches. This is needed to take multi-pattern into account.
-			// Also here for the case of empty dictionaries.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-			r_block_patch_address.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
+			// Remove element temporaries.
+			codegen.generator->pop_temporary();
+			codegen.generator->pop_temporary();
+			codegen.generator->pop_temporary();
 
+			return test_addr;
 		} break;
 		case GDScriptParser::PatternNode::PT_REST:
 			// Do nothing.
+			return p_previous_test;
 			break;
+		case GDScriptParser::PatternNode::PT_BIND: {
+			if (p_is_nested) {
+				codegen.generator->write_and_left_operand(p_previous_test);
+			} else if (!p_is_first) {
+				codegen.generator->write_or_left_operand(p_previous_test);
+			}
+			// Get the bind address.
+			GDScriptCodeGenerator::Address bind = codegen.locals[p_pattern->bind->name];
+
+			// Assign value to bound variable.
+			codegen.generator->write_assign(bind, p_value_addr);
+		}
+			[[fallthrough]]; // Act like matching anything too.
 		case GDScriptParser::PatternNode::PT_WILDCARD:
-			// This matches anything so just do the jump.
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-			r_block_patch_address.push_back(codegen.opcodes.size());
-			codegen.opcodes.push_back(0); // Will be replaced.
+			// If this is a fall through we don't want to do this again.
+			if (p_pattern->pattern_type != GDScriptParser::PatternNode::PT_BIND) {
+				if (p_is_nested) {
+					codegen.generator->write_and_left_operand(p_previous_test);
+				} else if (!p_is_first) {
+					codegen.generator->write_or_left_operand(p_previous_test);
+				}
+			}
+			// This matches anything so just do the same as `if(true)`.
+			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
+			if (p_is_nested) {
+				// Use the operator with the `true` constant so it works as always matching.
+				GDScriptCodeGenerator::Address constant = codegen.add_constant(true);
+				codegen.generator->write_and_right_operand(constant);
+				codegen.generator->write_end_and(p_previous_test);
+			} else if (!p_is_first) {
+				// Use the operator with the `true` constant so it works as always matching.
+				GDScriptCodeGenerator::Address constant = codegen.add_constant(true);
+				codegen.generator->write_or_right_operand(constant);
+				codegen.generator->write_end_or(p_previous_test);
+			} else {
+				// Just assign this value to the accumulator temporary.
+				codegen.generator->write_assign_true(p_previous_test);
+			}
+			return p_previous_test;
 	}
-	return OK;
+	ERR_FAIL_V_MSG(p_previous_test, "Reaching the end of pattern compilation without matching a pattern.");
 }
 
-Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block, int p_stack_level, int p_break_addr, int p_continue_addr) {
-	codegen.push_stack_identifiers();
-	int new_identifiers = 0;
-	codegen.current_line = p_block->start_line;
+void GDScriptCompiler::_add_locals_in_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block) {
+	for (int i = 0; i < p_block->locals.size(); i++) {
+		if (p_block->locals[i].type == GDScriptParser::SuiteNode::Local::PARAMETER || p_block->locals[i].type == GDScriptParser::SuiteNode::Local::FOR_VARIABLE) {
+			// Parameters are added directly from function and loop variables are declared explicitly.
+			continue;
+		}
+		codegen.add_local(p_block->locals[i].name, _gdtype_from_datatype(p_block->locals[i].get_datatype()));
+	}
+}
+
+Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block, bool p_add_locals) {
+	Error error = OK;
+	GDScriptCodeGenerator *gen = codegen.generator;
+
+	codegen.start_block();
+
+	if (p_add_locals) {
+		_add_locals_in_block(codegen, p_block);
+	}
 
 	for (int i = 0; i < p_block->statements.size(); i++) {
 		const GDScriptParser::Node *s = p_block->statements[i];
 
 #ifdef DEBUG_ENABLED
 		// Add a newline before each statement, since the debugger needs those.
-		codegen.opcodes.push_back(GDScriptFunction::OPCODE_LINE);
-		codegen.opcodes.push_back(s->start_line);
-		codegen.current_line = s->start_line;
+		gen->write_newline(s->start_line);
 #endif
 
 		switch (s->type) {
 			case GDScriptParser::Node::MATCH: {
 				const GDScriptParser::MatchNode *match = static_cast<const GDScriptParser::MatchNode *>(s);
 
-				int slevel = p_stack_level;
+				gen->start_match();
+				codegen.start_block();
 
-				// First, let's save the addres of the value match.
-				int temp_addr = _parse_expression(codegen, match->test, slevel);
-				if (temp_addr < 0) {
-					return ERR_PARSE_ERROR;
-				}
-				if ((temp_addr >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-					slevel++;
-					codegen.alloc_stack(slevel);
+				// Evaluate the match expression.
+				GDScriptCodeGenerator::Address value = _parse_expression(codegen, error, match->test);
+				if (error) {
+					return error;
 				}
 
 				// Then, let's save the type of the value in the stack too, so we can reuse for later comparisons.
-				int type_addr = slevel++;
-				type_addr |= GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
-				codegen.alloc_stack(slevel);
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL_BUILT_IN);
-				codegen.opcodes.push_back(GDScriptFunctions::TYPE_OF);
-				codegen.opcodes.push_back(1); // One argument.
-				codegen.opcodes.push_back(temp_addr); // Argument is the value we want to test.
-				codegen.opcodes.push_back(type_addr); // Address to result.
-
-				Vector<int> patch_match_end; // Will patch the jump to the end of match.
+				GDScriptCodeGenerator::Address type = codegen.add_temporary();
+				Vector<GDScriptCodeGenerator::Address> typeof_args;
+				typeof_args.push_back(value);
+				gen->write_call_builtin(type, GDScriptFunctions::TYPE_OF, typeof_args);
 
 				// Now we can actually start testing.
 				// For each branch.
 				for (int j = 0; j < match->branches.size(); j++) {
+					if (j > 0) {
+						// Use `else` to not check the next branch after matching.
+						gen->write_else();
+					}
+
 					const GDScriptParser::MatchBranchNode *branch = match->branches[j];
 
-					int bound_variables = 0;
-					codegen.push_stack_identifiers(); // Create an extra block around for binds.
+					gen->start_match_branch(); // Need so lower level code can patch 'continue' jumps.
+					codegen.start_block(); // Create an extra block around for binds.
+
+					// Add locals in block before patterns, so temporaries don't use the stack address for binds.
+					_add_locals_in_block(codegen, branch->block);
 
 #ifdef DEBUG_ENABLED
 					// Add a newline before each branch, since the debugger needs those.
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_LINE);
-					codegen.opcodes.push_back(s->start_line);
-					codegen.current_line = s->start_line;
+					gen->write_newline(branch->start_line);
 #endif
-					Vector<int> patch_addrs; // Will patch with end of pattern to jump.
-					Vector<int> block_patch_addrs; // Will patch with start of block to jump.
-
 					// For each pattern in branch.
+					GDScriptCodeGenerator::Address pattern_result = codegen.add_temporary();
 					for (int k = 0; k < branch->patterns.size(); k++) {
-						if (k > 0) {
-							// Patch jumps per pattern to allow for multipattern. If a pattern fails it just tries the next.
-							for (int l = 0; l < patch_addrs.size(); l++) {
-								codegen.opcodes.write[patch_addrs[l]] = codegen.opcodes.size();
-							}
-							patch_addrs.clear();
+						pattern_result = _parse_match_pattern(codegen, error, branch->patterns[k], value, type, pattern_result, k == 0, false);
+						if (error != OK) {
+							return error;
 						}
-						Error err = _parse_match_pattern(codegen, branch->patterns[k], slevel, temp_addr, type_addr, bound_variables, patch_addrs, block_patch_addrs);
-						if (err != OK) {
-							return err;
-						}
-					}
-					// Patch jumps to the block.
-					for (int k = 0; k < block_patch_addrs.size(); k++) {
-						codegen.opcodes.write[block_patch_addrs[k]] = codegen.opcodes.size();
 					}
 
-					// Leave space for bound variables.
-					slevel += bound_variables;
-					codegen.alloc_stack(slevel);
+					// Check if pattern did match.
+					gen->write_if(pattern_result);
+
+					// Remove the result from stack.
+					gen->pop_temporary();
 
 					// Parse the branch block.
-					_parse_block(codegen, branch->block, slevel, p_break_addr, p_continue_addr);
-
-					// Jump to end of match.
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-					patch_match_end.push_back(codegen.opcodes.size());
-					codegen.opcodes.push_back(0); // Will be patched.
-
-					// Patch the addresses of last pattern to jump to the end of the branch, into the next one.
-					for (int k = 0; k < patch_addrs.size(); k++) {
-						codegen.opcodes.write[patch_addrs[k]] = codegen.opcodes.size();
+					error = _parse_block(codegen, branch->block, false); // Don't add locals again.
+					if (error) {
+						return error;
 					}
 
-					codegen.pop_stack_identifiers(); // Get out of extra block.
+					codegen.end_block(); // Get out of extra block.
 				}
-				// Patch the addresses to jump to the end of the match statement.
-				for (int j = 0; j < patch_match_end.size(); j++) {
-					codegen.opcodes.write[patch_match_end[j]] = codegen.opcodes.size();
-				}
-			} break;
 
+				// End all nested `if`s.
+				for (int j = 0; j < match->branches.size(); j++) {
+					gen->write_endif();
+				}
+
+				gen->pop_temporary();
+
+				if (value.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					codegen.generator->pop_temporary();
+				}
+
+				gen->end_match();
+			} break;
 			case GDScriptParser::Node::IF: {
 				const GDScriptParser::IfNode *if_n = static_cast<const GDScriptParser::IfNode *>(s);
-				int ret2 = _parse_expression(codegen, if_n->condition, p_stack_level, false);
-				if (ret2 < 0) {
-					return ERR_PARSE_ERROR;
+				GDScriptCodeGenerator::Address condition = _parse_expression(codegen, error, if_n->condition);
+				if (error) {
+					return error;
 				}
 
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-				codegen.opcodes.push_back(ret2);
-				int else_addr = codegen.opcodes.size();
-				codegen.opcodes.push_back(0); //temporary
+				gen->write_if(condition);
 
-				Error err = _parse_block(codegen, if_n->true_block, p_stack_level, p_break_addr, p_continue_addr);
-				if (err) {
-					return err;
+				if (condition.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					codegen.generator->pop_temporary();
+				}
+
+				error = _parse_block(codegen, if_n->true_block);
+				if (error) {
+					return error;
 				}
 
 				if (if_n->false_block) {
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-					int end_addr = codegen.opcodes.size();
-					codegen.opcodes.push_back(0);
-					codegen.opcodes.write[else_addr] = codegen.opcodes.size();
+					gen->write_else();
 
-					Error err2 = _parse_block(codegen, if_n->false_block, p_stack_level, p_break_addr, p_continue_addr);
-					if (err2) {
-						return err2;
+					error = _parse_block(codegen, if_n->false_block);
+					if (error) {
+						return error;
 					}
-
-					codegen.opcodes.write[end_addr] = codegen.opcodes.size();
-				} else {
-					//end without else
-					codegen.opcodes.write[else_addr] = codegen.opcodes.size();
 				}
 
+				gen->write_endif();
 			} break;
 			case GDScriptParser::Node::FOR: {
 				const GDScriptParser::ForNode *for_n = static_cast<const GDScriptParser::ForNode *>(s);
-				int slevel = p_stack_level;
-				int iter_stack_pos = slevel;
-				int iterator_pos = (slevel++) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-				int counter_pos = (slevel++) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-				int container_pos = (slevel++) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-				codegen.alloc_stack(slevel);
 
-				codegen.push_stack_identifiers();
-				codegen.add_stack_identifier(for_n->variable->name, iter_stack_pos);
+				codegen.start_block();
+				GDScriptCodeGenerator::Address iterator = codegen.add_local(for_n->variable->name, _gdtype_from_datatype(for_n->variable->get_datatype()));
 
-				int ret2 = _parse_expression(codegen, for_n->list, slevel, false);
-				if (ret2 < 0) {
-					return ERR_COMPILATION_FAILED;
+				GDScriptCodeGenerator::Address list = _parse_expression(codegen, error, for_n->list);
+				if (error) {
+					return error;
 				}
 
-				//assign container
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN);
-				codegen.opcodes.push_back(container_pos);
-				codegen.opcodes.push_back(ret2);
+				gen->write_for(iterator, list);
 
-				//begin loop
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_ITERATE_BEGIN);
-				codegen.opcodes.push_back(counter_pos);
-				codegen.opcodes.push_back(container_pos);
-				codegen.opcodes.push_back(codegen.opcodes.size() + 4);
-				codegen.opcodes.push_back(iterator_pos);
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP); //skip code for next
-				codegen.opcodes.push_back(codegen.opcodes.size() + 8);
-				//break loop
-				int break_pos = codegen.opcodes.size();
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP); //skip code for next
-				codegen.opcodes.push_back(0); //skip code for next
-				//next loop
-				int continue_pos = codegen.opcodes.size();
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_ITERATE);
-				codegen.opcodes.push_back(counter_pos);
-				codegen.opcodes.push_back(container_pos);
-				codegen.opcodes.push_back(break_pos);
-				codegen.opcodes.push_back(iterator_pos);
-
-				Error err = _parse_block(codegen, for_n->loop, slevel, break_pos, continue_pos);
-				if (err) {
-					return err;
+				error = _parse_block(codegen, for_n->loop);
+				if (error) {
+					return error;
 				}
 
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-				codegen.opcodes.push_back(continue_pos);
-				codegen.opcodes.write[break_pos + 1] = codegen.opcodes.size();
+				gen->write_endfor();
 
-				codegen.pop_stack_identifiers();
+				if (list.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					codegen.generator->pop_temporary();
+				}
 
+				codegen.end_block();
 			} break;
 			case GDScriptParser::Node::WHILE: {
 				const GDScriptParser::WhileNode *while_n = static_cast<const GDScriptParser::WhileNode *>(s);
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-				codegen.opcodes.push_back(codegen.opcodes.size() + 3);
-				int break_addr = codegen.opcodes.size();
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-				codegen.opcodes.push_back(0);
-				int continue_addr = codegen.opcodes.size();
 
-				int ret2 = _parse_expression(codegen, while_n->condition, p_stack_level, false);
-				if (ret2 < 0) {
-					return ERR_PARSE_ERROR;
+				gen->start_while_condition();
+
+				GDScriptCodeGenerator::Address condition = _parse_expression(codegen, error, while_n->condition);
+				if (error) {
+					return error;
 				}
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-				codegen.opcodes.push_back(ret2);
-				codegen.opcodes.push_back(break_addr);
-				Error err = _parse_block(codegen, while_n->loop, p_stack_level, break_addr, continue_addr);
-				if (err) {
-					return err;
+
+				gen->write_while(condition);
+
+				if (condition.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					codegen.generator->pop_temporary();
 				}
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-				codegen.opcodes.push_back(continue_addr);
 
-				codegen.opcodes.write[break_addr + 1] = codegen.opcodes.size();
+				error = _parse_block(codegen, while_n->loop);
+				if (error) {
+					return error;
+				}
 
+				gen->write_endwhile();
 			} break;
 			case GDScriptParser::Node::BREAK: {
-				if (p_break_addr < 0) {
-					_set_error("'break'' not within loop", s);
-					return ERR_COMPILATION_FAILED;
-				}
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-				codegen.opcodes.push_back(p_break_addr);
-
+				gen->write_break();
 			} break;
 			case GDScriptParser::Node::CONTINUE: {
-				if (p_continue_addr < 0) {
-					_set_error("'continue' not within loop", s);
-					return ERR_COMPILATION_FAILED;
+				const GDScriptParser::ContinueNode *cont = static_cast<const GDScriptParser::ContinueNode *>(s);
+				if (cont->is_for_match) {
+					gen->write_continue_match();
+				} else {
+					gen->write_continue();
 				}
-
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-				codegen.opcodes.push_back(p_continue_addr);
-
 			} break;
 			case GDScriptParser::Node::RETURN: {
 				const GDScriptParser::ReturnNode *return_n = static_cast<const GDScriptParser::ReturnNode *>(s);
-				int ret2;
+
+				GDScriptCodeGenerator::Address return_value;
 
 				if (return_n->return_value != nullptr) {
-					ret2 = _parse_expression(codegen, return_n->return_value, p_stack_level, false);
-					if (ret2 < 0) {
-						return ERR_PARSE_ERROR;
+					return_value = _parse_expression(codegen, error, return_n->return_value);
+					if (error) {
+						return error;
 					}
-
-				} else {
-					ret2 = GDScriptFunction::ADDR_TYPE_NIL << GDScriptFunction::ADDR_BITS;
 				}
 
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_RETURN);
-				codegen.opcodes.push_back(ret2);
-
+				gen->write_return(return_value);
+				if (return_value.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					codegen.generator->pop_temporary();
+				}
 			} break;
 			case GDScriptParser::Node::ASSERT: {
 #ifdef DEBUG_ENABLED
-				// try subblocks
-
 				const GDScriptParser::AssertNode *as = static_cast<const GDScriptParser::AssertNode *>(s);
 
-				int ret2 = _parse_expression(codegen, as->condition, p_stack_level, false);
-				if (ret2 < 0) {
-					return ERR_PARSE_ERROR;
+				GDScriptCodeGenerator::Address condition = _parse_expression(codegen, error, as->condition);
+				if (error) {
+					return error;
 				}
 
-				int message_ret = 0;
+				GDScriptCodeGenerator::Address message;
+
 				if (as->message) {
-					message_ret = _parse_expression(codegen, as->message, p_stack_level + 1, false);
-					if (message_ret < 0) {
-						return ERR_PARSE_ERROR;
+					message = _parse_expression(codegen, error, as->message);
+					if (error) {
+						return error;
 					}
 				}
+				gen->write_assert(condition, message);
 
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSERT);
-				codegen.opcodes.push_back(ret2);
-				codegen.opcodes.push_back(message_ret);
+				if (condition.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					codegen.generator->pop_temporary();
+				}
+				if (message.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					codegen.generator->pop_temporary();
+				}
 #endif
 			} break;
 			case GDScriptParser::Node::BREAKPOINT: {
 #ifdef DEBUG_ENABLED
-				// try subblocks
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_BREAKPOINT);
+				gen->write_breakpoint();
 #endif
 			} break;
 			case GDScriptParser::Node::VARIABLE: {
 				const GDScriptParser::VariableNode *lv = static_cast<const GDScriptParser::VariableNode *>(s);
-
-				// since we are using properties now for most class access, allow shadowing of class members to make user's life easier.
-				//
-				//if (_is_class_member_property(codegen, lv->name)) {
-				//	_set_error("Name for local variable '" + String(lv->name) + "' can't shadow class property of the same name.", lv);
-				//	return ERR_ALREADY_EXISTS;
-				//}
-
-				codegen.add_stack_identifier(lv->identifier->name, p_stack_level++);
-				codegen.alloc_stack(p_stack_level);
-				new_identifiers++;
+				// Should be already in stack when the block began.
+				GDScriptCodeGenerator::Address local = codegen.locals[lv->identifier->name];
 
 				if (lv->initializer != nullptr) {
-					int dst_address = codegen.stack_identifiers[lv->identifier->name];
-					dst_address |= GDScriptFunction::ADDR_TYPE_STACK_VARIABLE << GDScriptFunction::ADDR_BITS;
-
-					int src_address = _parse_expression(codegen, lv->initializer, p_stack_level);
-					if (src_address < 0) {
-						return ERR_PARSE_ERROR;
+					GDScriptCodeGenerator::Address src_address = _parse_expression(codegen, error, lv->initializer);
+					if (error) {
+						return error;
 					}
-					if (!_generate_typed_assign(codegen, src_address, dst_address, _gdtype_from_datatype(lv->get_datatype()), lv->initializer->get_datatype())) {
-						return ERR_PARSE_ERROR;
+					gen->write_assign(local, src_address);
+					if (src_address.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+						codegen.generator->pop_temporary();
 					}
 				}
 			} break;
@@ -2094,163 +1620,55 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 					_set_error("Local constant must have a constant value as initializer.", lc->initializer);
 					return ERR_PARSE_ERROR;
 				}
-				codegen.local_named_constants[lc->identifier->name] = codegen.get_constant_pos(lc->initializer->reduced_value);
+
+				codegen.add_local_constant(lc->identifier->name, lc->initializer->reduced_value);
 			} break;
 			case GDScriptParser::Node::PASS:
 				// Nothing to do.
 				break;
 			default: {
-				//expression
+				// Expression.
 				if (s->is_expression()) {
-					int ret2 = _parse_expression(codegen, static_cast<const GDScriptParser::ExpressionNode *>(s), p_stack_level, true);
-					if (ret2 < 0) {
-						return ERR_PARSE_ERROR;
+					GDScriptCodeGenerator::Address expr = _parse_expression(codegen, error, static_cast<const GDScriptParser::ExpressionNode *>(s), true);
+					if (error) {
+						return error;
+					}
+					if (expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+						codegen.generator->pop_temporary();
 					}
 				} else {
-					ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Bug in bytecode compiler, unexpected node in parse tree while parsing statement."); //unreachable code
+					ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Bug in bytecode compiler, unexpected node in parse tree while parsing statement."); // Unreachable code.
 				}
 			} break;
 		}
 	}
 
-	codegen.pop_stack_identifiers();
+	codegen.end_block();
 	return OK;
 }
 
 Error GDScriptCompiler::_parse_function(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready) {
-	Vector<int> bytecode;
+	Error error = OK;
 	CodeGen codegen;
+	codegen.generator = memnew(GDScriptByteCodeGenerator);
 
 	codegen.class_node = p_class;
 	codegen.script = p_script;
 	codegen.function_node = p_func;
-	codegen.stack_max = 0;
-	codegen.current_line = 0;
-	codegen.call_max = 0;
-	codegen.debug_stack = EngineDebugger::is_active();
-	Vector<StringName> argnames;
 
-	int stack_level = 0;
-	int optional_parameters = 0;
-
-	if (p_func) {
-		for (int i = 0; i < p_func->parameters.size(); i++) {
-			// since we are using properties now for most class access, allow shadowing of class members to make user's life easier.
-			//
-			//if (_is_class_member_property(p_script, p_func->arguments[i])) {
-			//	_set_error("Name for argument '" + String(p_func->arguments[i]) + "' can't shadow class property of the same name.", p_func);
-			//	return ERR_ALREADY_EXISTS;
-			//}
-
-			codegen.add_stack_identifier(p_func->parameters[i]->identifier->name, i);
-#ifdef TOOLS_ENABLED
-			argnames.push_back(p_func->parameters[i]->identifier->name);
-#endif
-			if (p_func->parameters[i]->default_value != nullptr) {
-				optional_parameters++;
-			}
-		}
-		stack_level = p_func->parameters.size();
-	}
-
-	codegen.alloc_stack(stack_level);
-
-	/* Parse initializer -if applies- */
-
-	bool is_implicit_initializer = !p_for_ready && !p_func;
-	bool is_initializer = p_func && String(p_func->identifier->name) == GDScriptLanguage::get_singleton()->strings._init;
-
-	if (is_implicit_initializer) {
-		// Initialize class fields.
-		for (int i = 0; i < p_class->members.size(); i++) {
-			if (p_class->members[i].type != GDScriptParser::ClassNode::Member::VARIABLE) {
-				continue;
-			}
-			const GDScriptParser::VariableNode *field = p_class->members[i].variable;
-			if (field->onready) {
-				// Only initialize in _ready.
-				continue;
-			}
-
-			if (field->initializer) {
-				// Emit proper line change.
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_LINE);
-				codegen.opcodes.push_back(field->initializer->start_line);
-
-				int src_address = _parse_expression(codegen, field->initializer, stack_level, false, true);
-				if (src_address < 0) {
-					return ERR_PARSE_ERROR;
-				}
-				int dst_address = codegen.script->member_indices[field->identifier->name].index;
-				dst_address |= GDScriptFunction::ADDR_TYPE_MEMBER << GDScriptFunction::ADDR_BITS;
-
-				if (!_generate_typed_assign(codegen, src_address, dst_address, _gdtype_from_datatype(field->get_datatype()), field->initializer->get_datatype())) {
-					return ERR_PARSE_ERROR;
-				}
-			}
-		}
-	}
-
-	if (p_for_ready || (p_func && String(p_func->identifier->name) == "_ready")) {
-		// Initialize class fields on ready.
-		for (int i = 0; i < p_class->members.size(); i++) {
-			if (p_class->members[i].type != GDScriptParser::ClassNode::Member::VARIABLE) {
-				continue;
-			}
-			const GDScriptParser::VariableNode *field = p_class->members[i].variable;
-			if (!field->onready) {
-				continue;
-			}
-
-			if (field->initializer) {
-				// Emit proper line change.
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_LINE);
-				codegen.opcodes.push_back(field->initializer->start_line);
-
-				int src_address = _parse_expression(codegen, field->initializer, stack_level, false, true);
-				if (src_address < 0) {
-					return ERR_PARSE_ERROR;
-				}
-				int dst_address = codegen.script->member_indices[field->identifier->name].index;
-				dst_address |= GDScriptFunction::ADDR_TYPE_MEMBER << GDScriptFunction::ADDR_BITS;
-
-				if (!_generate_typed_assign(codegen, src_address, dst_address, _gdtype_from_datatype(field->get_datatype()), field->initializer->get_datatype())) {
-					return ERR_PARSE_ERROR;
-				}
-			}
-		}
-	}
-
-	/* Parse default argument code -if applies- */
-
-	Vector<int> defarg_addr;
 	StringName func_name;
+	bool is_static = false;
+	MultiplayerAPI::RPCMode rpc_mode = MultiplayerAPI::RPC_MODE_DISABLED;
+	GDScriptDataType return_type;
+	return_type.has_type = true;
+	return_type.kind = GDScriptDataType::BUILTIN;
+	return_type.builtin_type = Variant::NIL;
 
 	if (p_func) {
-		if (optional_parameters > 0) {
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_TO_DEF_ARGUMENT);
-			defarg_addr.push_back(codegen.opcodes.size());
-			for (int i = p_func->parameters.size() - optional_parameters; i < p_func->parameters.size(); i++) {
-				int src_addr = _parse_expression(codegen, p_func->parameters[i]->default_value, stack_level, true);
-				if (src_addr < 0) {
-					return ERR_PARSE_ERROR;
-				}
-				int dst_addr = codegen.stack_identifiers[p_func->parameters[i]->identifier->name] | (GDScriptFunction::ADDR_TYPE_STACK_VARIABLE << GDScriptFunction::ADDR_BITS);
-				if (!_generate_typed_assign(codegen, src_addr, dst_addr, _gdtype_from_datatype(p_func->parameters[i]->get_datatype()), p_func->parameters[i]->default_value->get_datatype())) {
-					return ERR_PARSE_ERROR;
-				}
-				defarg_addr.push_back(codegen.opcodes.size());
-			}
-			defarg_addr.invert();
-		}
 		func_name = p_func->identifier->name;
-		codegen.function_name = func_name;
-
-		Error err = _parse_block(codegen, p_func->body, stack_level);
-		if (err) {
-			return err;
-		}
-
+		is_static = p_func->is_static;
+		rpc_mode = p_func->rpc_mode;
+		return_type = _gdtype_from_datatype(p_func->get_datatype());
 	} else {
 		if (p_for_ready) {
 			func_name = "_ready";
@@ -2260,115 +1678,98 @@ Error GDScriptCompiler::_parse_function(GDScript *p_script, const GDScriptParser
 	}
 
 	codegen.function_name = func_name;
-	codegen.opcodes.push_back(GDScriptFunction::OPCODE_END);
+	codegen.generator->write_start(p_script, func_name, is_static, rpc_mode, return_type);
 
-	/*
-	if (String(p_func->name)=="") { //initializer func
-		gdfunc = &p_script->initializer;
-	*/
-	//} else { //regular func
-	p_script->member_functions[func_name] = memnew(GDScriptFunction);
-	GDScriptFunction *gdfunc = p_script->member_functions[func_name];
-	//}
+	int optional_parameters = 0;
 
 	if (p_func) {
-		gdfunc->_static = p_func->is_static;
-		gdfunc->rpc_mode = p_func->rpc_mode;
-		gdfunc->argument_types.resize(p_func->parameters.size());
 		for (int i = 0; i < p_func->parameters.size(); i++) {
-			gdfunc->argument_types.write[i] = _gdtype_from_datatype(p_func->parameters[i]->get_datatype());
+			const GDScriptParser::ParameterNode *parameter = p_func->parameters[i];
+			GDScriptDataType par_type = _gdtype_from_datatype(parameter->get_datatype());
+			uint32_t par_addr = codegen.generator->add_parameter(parameter->identifier->name, parameter->default_value != nullptr, par_type);
+			codegen.parameters[parameter->identifier->name] = GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::FUNCTION_PARAMETER, par_addr, par_type);
+
+			if (p_func->parameters[i]->default_value != nullptr) {
+				optional_parameters++;
+			}
 		}
-		gdfunc->return_type = _gdtype_from_datatype(p_func->get_datatype());
-	} else {
-		gdfunc->_static = false;
-		gdfunc->rpc_mode = MultiplayerAPI::RPC_MODE_DISABLED;
-		gdfunc->return_type = GDScriptDataType();
-		gdfunc->return_type.has_type = true;
-		gdfunc->return_type.kind = GDScriptDataType::BUILTIN;
-		gdfunc->return_type.builtin_type = Variant::NIL;
 	}
 
-#ifdef TOOLS_ENABLED
-	gdfunc->arg_names = argnames;
-#endif
-	//constants
-	if (codegen.constant_map.size()) {
-		gdfunc->_constant_count = codegen.constant_map.size();
-		gdfunc->constants.resize(codegen.constant_map.size());
-		gdfunc->_constants_ptr = gdfunc->constants.ptrw();
-		const Variant *K = nullptr;
-		while ((K = codegen.constant_map.next(K))) {
-			int idx = codegen.constant_map[*K];
-			gdfunc->constants.write[idx] = *K;
+	// Parse initializer if applies.
+	bool is_implicit_initializer = !p_for_ready && !p_func;
+	bool is_initializer = p_func && String(p_func->identifier->name) == GDScriptLanguage::get_singleton()->strings._init;
+	bool is_for_ready = p_for_ready || (p_func && String(p_func->identifier->name) == "_ready");
+
+	if (is_implicit_initializer || is_for_ready) {
+		// Initialize class fields.
+		for (int i = 0; i < p_class->members.size(); i++) {
+			if (p_class->members[i].type != GDScriptParser::ClassNode::Member::VARIABLE) {
+				continue;
+			}
+			const GDScriptParser::VariableNode *field = p_class->members[i].variable;
+			if (field->onready != is_for_ready) {
+				// Only initialize in _ready.
+				continue;
+			}
+
+			if (field->initializer) {
+				// Emit proper line change.
+				codegen.generator->write_newline(field->initializer->start_line);
+
+				GDScriptCodeGenerator::Address src_address = _parse_expression(codegen, error, field->initializer, false, true);
+				if (error) {
+					return error;
+				}
+				GDScriptCodeGenerator::Address dst_address(GDScriptCodeGenerator::Address::MEMBER, codegen.script->member_indices[field->identifier->name].index, _gdtype_from_datatype(field->get_datatype()));
+
+				codegen.generator->write_assign(dst_address, src_address);
+				if (src_address.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					codegen.generator->pop_temporary();
+				}
+			}
 		}
-	} else {
-		gdfunc->_constants_ptr = nullptr;
-		gdfunc->_constant_count = 0;
 	}
-	//global names
-	if (codegen.name_map.size()) {
-		gdfunc->global_names.resize(codegen.name_map.size());
-		gdfunc->_global_names_ptr = &gdfunc->global_names[0];
-		for (Map<StringName, int>::Element *E = codegen.name_map.front(); E; E = E->next()) {
-			gdfunc->global_names.write[E->get()] = E->key();
+
+	// Parse default argument code if applies.
+	if (p_func) {
+		if (optional_parameters > 0) {
+			codegen.generator->start_parameters();
+			for (int i = p_func->parameters.size() - optional_parameters; i < p_func->parameters.size(); i++) {
+				const GDScriptParser::ParameterNode *parameter = p_func->parameters[i];
+				GDScriptCodeGenerator::Address src_addr = _parse_expression(codegen, error, parameter->default_value, true);
+				if (error) {
+					return error;
+				}
+				GDScriptCodeGenerator::Address dst_addr = codegen.parameters[parameter->identifier->name];
+				codegen.generator->write_assign(dst_addr, src_addr);
+				if (src_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					codegen.generator->pop_temporary();
+				}
+			}
+			codegen.generator->end_parameters();
 		}
-		gdfunc->_global_names_count = gdfunc->global_names.size();
 
-	} else {
-		gdfunc->_global_names_ptr = nullptr;
-		gdfunc->_global_names_count = 0;
-	}
-
-#ifdef TOOLS_ENABLED
-	// Named globals
-	if (codegen.named_globals.size()) {
-		gdfunc->named_globals.resize(codegen.named_globals.size());
-		gdfunc->_named_globals_ptr = gdfunc->named_globals.ptr();
-		for (int i = 0; i < codegen.named_globals.size(); i++) {
-			gdfunc->named_globals.write[i] = codegen.named_globals[i];
+		Error err = _parse_block(codegen, p_func->body);
+		if (err) {
+			return err;
 		}
-		gdfunc->_named_globals_count = gdfunc->named_globals.size();
-	}
-#endif
-
-	if (codegen.opcodes.size()) {
-		gdfunc->code = codegen.opcodes;
-		gdfunc->_code_ptr = &gdfunc->code[0];
-		gdfunc->_code_size = codegen.opcodes.size();
-
-	} else {
-		gdfunc->_code_ptr = nullptr;
-		gdfunc->_code_size = 0;
 	}
 
-	if (defarg_addr.size()) {
-		gdfunc->default_arguments = defarg_addr;
-		gdfunc->_default_arg_count = defarg_addr.size() - 1;
-		gdfunc->_default_arg_ptr = &gdfunc->default_arguments[0];
-	} else {
-		gdfunc->_default_arg_count = 0;
-		gdfunc->_default_arg_ptr = nullptr;
-	}
-
-	gdfunc->_argument_count = p_func ? p_func->parameters.size() : 0;
-	gdfunc->_stack_size = codegen.stack_max;
-	gdfunc->_call_size = codegen.call_max;
-	gdfunc->name = func_name;
 #ifdef DEBUG_ENABLED
 	if (EngineDebugger::is_active()) {
 		String signature;
-		//path
+		// Path.
 		if (p_script->get_path() != String()) {
 			signature += p_script->get_path();
 		}
-		//loc
+		// Location.
 		if (p_func) {
 			signature += "::" + itos(p_func->body->start_line);
 		} else {
 			signature += "::0";
 		}
 
-		//function and class
+		// Function and class.
 
 		if (p_class->identifier) {
 			signature += "::" + String(p_class->identifier->name) + "." + String(func_name);
@@ -2376,65 +1777,39 @@ Error GDScriptCompiler::_parse_function(GDScript *p_script, const GDScriptParser
 			signature += "::" + String(func_name);
 		}
 
-		gdfunc->profile.signature = signature;
+		codegen.generator->set_signature(signature);
 	}
 #endif
-	gdfunc->_script = p_script;
-	gdfunc->source = source;
 
-#ifdef DEBUG_ENABLED
-
-	{
-		gdfunc->func_cname = (String(source) + " - " + String(func_name)).utf8();
-		gdfunc->_func_cname = gdfunc->func_cname.get_data();
-	}
-
-#endif
 	if (p_func) {
-		gdfunc->_initial_line = p_func->start_line;
+		codegen.generator->set_initial_line(p_func->start_line);
 #ifdef TOOLS_ENABLED
-
 		p_script->member_lines[func_name] = p_func->start_line;
 #endif
 	} else {
-		gdfunc->_initial_line = 0;
+		codegen.generator->set_initial_line(0);
 	}
 
-	if (codegen.debug_stack) {
-		gdfunc->stack_debug = codegen.stack_debug;
-	}
+	GDScriptFunction *gd_function = codegen.generator->write_end();
 
 	if (is_initializer) {
-		p_script->initializer = gdfunc;
+		p_script->initializer = gd_function;
+	} else if (is_implicit_initializer) {
+		p_script->implicit_initializer = gd_function;
 	}
-	if (is_implicit_initializer) {
-		p_script->implicit_initializer = gdfunc;
-	}
+
+	p_script->member_functions[func_name] = gd_function;
 
 	return OK;
 }
 
 Error GDScriptCompiler::_parse_setter_getter(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::VariableNode *p_variable, bool p_is_setter) {
-	Vector<int> bytecode;
+	Error error = OK;
 	CodeGen codegen;
+	codegen.generator = memnew(GDScriptByteCodeGenerator);
 
 	codegen.class_node = p_class;
 	codegen.script = p_script;
-	codegen.function_node = nullptr;
-	codegen.stack_max = 0;
-	codegen.current_line = 0;
-	codegen.call_max = 0;
-	codegen.debug_stack = EngineDebugger::is_active();
-	Vector<StringName> argnames;
-
-	int stack_level = 0;
-
-	if (p_is_setter) {
-		codegen.add_stack_identifier(p_variable->setter_parameter->name, stack_level++);
-		argnames.push_back(p_variable->setter_parameter->name);
-	}
-
-	codegen.alloc_stack(stack_level);
 
 	StringName func_name;
 
@@ -2443,76 +1818,32 @@ Error GDScriptCompiler::_parse_setter_getter(GDScript *p_script, const GDScriptP
 	} else {
 		func_name = "@" + p_variable->identifier->name + "_getter";
 	}
-	codegen.function_name = func_name;
 
-	Error err = _parse_block(codegen, p_is_setter ? p_variable->setter : p_variable->getter, stack_level);
-	if (err != OK) {
-		return err;
-	}
-
-	codegen.opcodes.push_back(GDScriptFunction::OPCODE_END);
-
-	p_script->member_functions[func_name] = memnew(GDScriptFunction);
-	GDScriptFunction *gdfunc = p_script->member_functions[func_name];
-
-	gdfunc->_static = false;
-	gdfunc->rpc_mode = p_variable->rpc_mode;
-	gdfunc->argument_types.resize(p_is_setter ? 1 : 0);
-	gdfunc->return_type = _gdtype_from_datatype(p_variable->get_datatype());
-#ifdef TOOLS_ENABLED
-	gdfunc->arg_names = argnames;
-#endif
-
-	// TODO: Unify this with function compiler.
-	//constants
-	if (codegen.constant_map.size()) {
-		gdfunc->_constant_count = codegen.constant_map.size();
-		gdfunc->constants.resize(codegen.constant_map.size());
-		gdfunc->_constants_ptr = gdfunc->constants.ptrw();
-		const Variant *K = nullptr;
-		while ((K = codegen.constant_map.next(K))) {
-			int idx = codegen.constant_map[*K];
-			gdfunc->constants.write[idx] = *K;
-		}
+	GDScriptDataType return_type;
+	if (p_is_setter) {
+		return_type.has_type = true;
+		return_type.kind = GDScriptDataType::BUILTIN;
+		return_type.builtin_type = Variant::NIL;
 	} else {
-		gdfunc->_constants_ptr = nullptr;
-		gdfunc->_constant_count = 0;
-	}
-	//global names
-	if (codegen.name_map.size()) {
-		gdfunc->global_names.resize(codegen.name_map.size());
-		gdfunc->_global_names_ptr = &gdfunc->global_names[0];
-		for (Map<StringName, int>::Element *E = codegen.name_map.front(); E; E = E->next()) {
-			gdfunc->global_names.write[E->get()] = E->key();
-		}
-		gdfunc->_global_names_count = gdfunc->global_names.size();
-
-	} else {
-		gdfunc->_global_names_ptr = nullptr;
-		gdfunc->_global_names_count = 0;
+		return_type = _gdtype_from_datatype(p_variable->get_datatype());
 	}
 
-#ifdef TOOLS_ENABLED
-	// Named globals
-	if (codegen.named_globals.size()) {
-		gdfunc->named_globals.resize(codegen.named_globals.size());
-		gdfunc->_named_globals_ptr = gdfunc->named_globals.ptr();
-		for (int i = 0; i < codegen.named_globals.size(); i++) {
-			gdfunc->named_globals.write[i] = codegen.named_globals[i];
-		}
-		gdfunc->_named_globals_count = gdfunc->named_globals.size();
-	}
-#endif
+	codegen.generator->write_start(p_script, func_name, false, p_variable->rpc_mode, return_type);
 
-	gdfunc->code = codegen.opcodes;
-	gdfunc->_code_ptr = &gdfunc->code[0];
-	gdfunc->_code_size = codegen.opcodes.size();
-	gdfunc->_default_arg_count = 0;
-	gdfunc->_default_arg_ptr = nullptr;
-	gdfunc->_argument_count = argnames.size();
-	gdfunc->_stack_size = codegen.stack_max;
-	gdfunc->_call_size = codegen.call_max;
-	gdfunc->name = func_name;
+	if (p_is_setter) {
+		uint32_t par_addr = codegen.generator->add_parameter(p_variable->setter_parameter->name, false, _gdtype_from_datatype(p_variable->get_datatype()));
+		codegen.parameters[p_variable->setter_parameter->name] = GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::FUNCTION_PARAMETER, par_addr, _gdtype_from_datatype(p_variable->get_datatype()));
+	}
+
+	error = _parse_block(codegen, p_is_setter ? p_variable->setter : p_variable->getter);
+	if (error) {
+		return error;
+	}
+
+	GDScriptFunction *gd_function = codegen.generator->write_end();
+
+	p_script->member_functions[func_name] = gd_function;
+
 #ifdef DEBUG_ENABLED
 	if (EngineDebugger::is_active()) {
 		String signature;
@@ -2531,29 +1862,14 @@ Error GDScriptCompiler::_parse_setter_getter(GDScript *p_script, const GDScriptP
 			signature += "::" + String(func_name);
 		}
 
-		gdfunc->profile.signature = signature;
+		codegen.generator->set_signature(signature);
 	}
 #endif
-	gdfunc->_script = p_script;
-	gdfunc->source = source;
+	codegen.generator->set_initial_line(p_is_setter ? p_variable->setter->start_line : p_variable->getter->start_line);
 
-#ifdef DEBUG_ENABLED
-
-	{
-		gdfunc->func_cname = (String(source) + " - " + String(func_name)).utf8();
-		gdfunc->_func_cname = gdfunc->func_cname.get_data();
-	}
-
-#endif
-	gdfunc->_initial_line = p_is_setter ? p_variable->setter->start_line : p_variable->getter->start_line;
 #ifdef TOOLS_ENABLED
-
-	p_script->member_lines[func_name] = gdfunc->_initial_line;
+	p_script->member_lines[func_name] = p_is_setter ? p_variable->setter->start_line : p_variable->getter->start_line;
 #endif
-
-	if (codegen.debug_stack) {
-		gdfunc->stack_debug = codegen.stack_debug;
-	}
 
 	return OK;
 }

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -33,109 +33,88 @@
 
 #include "core/set.h"
 #include "gdscript.h"
+#include "gdscript_codegen.h"
 #include "gdscript_function.h"
 #include "gdscript_parser.h"
 
 class GDScriptCompiler {
-	const GDScriptParser *parser;
+	const GDScriptParser *parser = nullptr;
 	Set<GDScript *> parsed_classes;
 	Set<GDScript *> parsing_classes;
-	GDScript *main_script;
+	GDScript *main_script = nullptr;
+
 	struct CodeGen {
-		GDScript *script;
-		const GDScriptParser::ClassNode *class_node;
-		const GDScriptParser::FunctionNode *function_node;
+		GDScript *script = nullptr;
+		const GDScriptParser::ClassNode *class_node = nullptr;
+		const GDScriptParser::FunctionNode *function_node = nullptr;
 		StringName function_name;
-		bool debug_stack;
+		GDScriptCodeGenerator *generator = nullptr;
+		Map<StringName, GDScriptCodeGenerator::Address> parameters;
+		Map<StringName, GDScriptCodeGenerator::Address> locals;
+		List<Set<StringName>> locals_in_scope;
 
-		List<Map<StringName, int>> stack_id_stack;
-		Map<StringName, int> stack_identifiers;
-
-		List<GDScriptFunction::StackDebug> stack_debug;
-		List<Map<StringName, int>> block_identifier_stack;
-		Map<StringName, int> block_identifiers;
-		Map<StringName, int> local_named_constants;
-
-		void add_stack_identifier(const StringName &p_id, int p_stackpos) {
-			stack_identifiers[p_id] = p_stackpos;
-			if (debug_stack) {
-				block_identifiers[p_id] = p_stackpos;
-				GDScriptFunction::StackDebug sd;
-				sd.added = true;
-				sd.line = current_line;
-				sd.identifier = p_id;
-				sd.pos = p_stackpos;
-				stack_debug.push_back(sd);
-			}
+		GDScriptCodeGenerator::Address add_local(const StringName &p_name, const GDScriptDataType &p_type) {
+			uint32_t addr = generator->add_local(p_name, p_type);
+			locals[p_name] = GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::LOCAL_VARIABLE, addr, p_type);
+			locals_in_scope.back()->get().insert(p_name);
+			return locals[p_name];
 		}
 
-		void push_stack_identifiers() {
-			stack_id_stack.push_back(stack_identifiers);
-			if (debug_stack) {
-				block_identifier_stack.push_back(block_identifiers);
-				block_identifiers.clear();
-			}
+		GDScriptCodeGenerator::Address add_local_constant(const StringName &p_name, const Variant &p_value) {
+			uint32_t addr = generator->add_local_constant(p_name, p_value);
+			locals[p_name] = GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::LOCAL_CONSTANT, addr);
+			return locals[p_name];
 		}
 
-		void pop_stack_identifiers() {
-			stack_identifiers = stack_id_stack.back()->get();
-			stack_id_stack.pop_back();
+		GDScriptCodeGenerator::Address add_temporary(const GDScriptDataType &p_type = GDScriptDataType()) {
+			uint32_t addr = generator->add_temporary();
+			return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::TEMPORARY, addr, p_type);
+		}
 
-			if (debug_stack) {
-				for (Map<StringName, int>::Element *E = block_identifiers.front(); E; E = E->next()) {
-					GDScriptFunction::StackDebug sd;
-					sd.added = false;
-					sd.identifier = E->key();
-					sd.line = current_line;
-					sd.pos = E->get();
-					stack_debug.push_back(sd);
+		GDScriptCodeGenerator::Address add_constant(const Variant &p_constant) {
+			GDScriptDataType type;
+			type.has_type = true;
+			type.kind = GDScriptDataType::BUILTIN;
+			type.builtin_type = p_constant.get_type();
+			if (type.builtin_type == Variant::OBJECT) {
+				Object *obj = p_constant;
+				if (obj) {
+					type.kind = GDScriptDataType::NATIVE;
+					type.native_type = obj->get_class_name();
+
+					Ref<Script> script = obj->get_script();
+					if (script.is_valid()) {
+						type.script_type = script;
+						Ref<GDScript> gdscript = script;
+						if (gdscript.is_valid()) {
+							type.kind = GDScriptDataType::GDSCRIPT;
+						} else {
+							type.kind = GDScriptDataType::SCRIPT;
+						}
+					}
+				} else {
+					type.builtin_type = Variant::NIL;
 				}
-				block_identifiers = block_identifier_stack.back()->get();
-				block_identifier_stack.pop_back();
 			}
+
+			uint32_t addr = generator->add_or_get_constant(p_constant);
+			return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::CONSTANT, addr, type);
 		}
 
-		HashMap<Variant, int, VariantHasher, VariantComparator> constant_map;
-		Map<StringName, int> name_map;
-#ifdef TOOLS_ENABLED
-		Vector<StringName> named_globals;
-#endif
-
-		int get_name_map_pos(const StringName &p_identifier) {
-			int ret;
-			if (!name_map.has(p_identifier)) {
-				ret = name_map.size();
-				name_map[p_identifier] = ret;
-			} else {
-				ret = name_map[p_identifier];
-			}
-			return ret;
+		void start_block() {
+			Set<StringName> scope;
+			locals_in_scope.push_back(scope);
+			generator->start_block();
 		}
 
-		int get_constant_pos(const Variant &p_constant) {
-			if (constant_map.has(p_constant)) {
-				return constant_map[p_constant] | (GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS);
+		void end_block() {
+			Set<StringName> &scope = locals_in_scope.back()->get();
+			for (Set<StringName>::Element *E = scope.front(); E; E = E->next()) {
+				locals.erase(E->get());
 			}
-			int pos = constant_map.size();
-			constant_map[p_constant] = pos;
-			return pos | (GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS);
+			locals_in_scope.pop_back();
+			generator->end_block();
 		}
-
-		Vector<int> opcodes;
-		void alloc_stack(int p_level) {
-			if (p_level >= stack_max) {
-				stack_max = p_level + 1;
-			}
-		}
-		void alloc_call(int p_params) {
-			if (p_params >= call_max) {
-				call_max = p_params;
-			}
-		}
-
-		int current_line;
-		int stack_max;
-		int call_max;
 	};
 
 	bool _is_class_member_property(CodeGen &codegen, const StringName &p_name);
@@ -143,17 +122,16 @@ class GDScriptCompiler {
 
 	void _set_error(const String &p_error, const GDScriptParser::Node *p_node);
 
-	bool _create_unary_operator(CodeGen &codegen, const GDScriptParser::UnaryOpNode *on, Variant::Operator op, int p_stack_level);
-	bool _create_binary_operator(CodeGen &codegen, const GDScriptParser::BinaryOpNode *on, Variant::Operator op, int p_stack_level, bool p_initializer = false, int p_index_addr = 0);
-	bool _create_binary_operator(CodeGen &codegen, const GDScriptParser::ExpressionNode *p_left_operand, const GDScriptParser::ExpressionNode *p_right_operand, Variant::Operator op, int p_stack_level, bool p_initializer = false, int p_index_addr = 0);
-	bool _generate_typed_assign(CodeGen &codegen, int p_src_address, int p_dst_address, const GDScriptDataType &p_datatype, const GDScriptParser::DataType &p_value_type);
+	Error _create_binary_operator(CodeGen &codegen, const GDScriptParser::BinaryOpNode *on, Variant::Operator op, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
+	Error _create_binary_operator(CodeGen &codegen, const GDScriptParser::ExpressionNode *p_left_operand, const GDScriptParser::ExpressionNode *p_right_operand, Variant::Operator op, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
 
 	GDScriptDataType _gdtype_from_datatype(const GDScriptParser::DataType &p_datatype) const;
 
-	int _parse_assign_right_expression(CodeGen &codegen, const GDScriptParser::AssignmentNode *p_assignment, int p_stack_level, int p_index_addr = 0);
-	int _parse_expression(CodeGen &codegen, const GDScriptParser::ExpressionNode *p_expression, int p_stack_level, bool p_root = false, bool p_initializer = false, int p_index_addr = 0);
-	Error _parse_match_pattern(CodeGen &codegen, const GDScriptParser::PatternNode *p_pattern, int p_stack_level, int p_value_addr, int p_type_addr, int &r_bound_variables, Vector<int> &r_patch_addresses, Vector<int> &r_block_patch_address);
-	Error _parse_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block, int p_stack_level = 0, int p_break_addr = -1, int p_continue_addr = -1);
+	GDScriptCodeGenerator::Address _parse_assign_right_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::AssignmentNode *p_assignmentint, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
+	GDScriptCodeGenerator::Address _parse_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::ExpressionNode *p_expression, bool p_root = false, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
+	GDScriptCodeGenerator::Address _parse_match_pattern(CodeGen &codegen, Error &r_error, const GDScriptParser::PatternNode *p_pattern, const GDScriptCodeGenerator::Address &p_value_addr, const GDScriptCodeGenerator::Address &p_type_addr, const GDScriptCodeGenerator::Address &p_previous_test, bool p_is_first, bool p_is_nested);
+	void _add_locals_in_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block);
+	Error _parse_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block, bool p_add_locals = true);
 	Error _parse_function(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready = false);
 	Error _parse_setter_getter(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::VariableNode *p_variable, bool p_is_setter);
 	Error _parse_class_level(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -224,6 +224,7 @@ public:
 
 private:
 	friend class GDScriptCompiler;
+	friend class GDScriptByteCodeGenerator;
 
 	StringName source;
 

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -182,7 +182,6 @@ public:
 		OPCODE_CALL_RETURN,
 		OPCODE_CALL_ASYNC,
 		OPCODE_CALL_BUILT_IN,
-		OPCODE_CALL_SELF,
 		OPCODE_CALL_SELF_BASE,
 		OPCODE_AWAIT,
 		OPCODE_AWAIT_RESUME,
@@ -233,10 +232,6 @@ private:
 	int _constant_count;
 	const StringName *_global_names_ptr;
 	int _global_names_count;
-#ifdef TOOLS_ENABLED
-	const StringName *_named_globals_ptr;
-	int _named_globals_count;
-#endif
 	const int *_default_arg_ptr;
 	int _default_arg_count;
 	const int *_code_ptr;
@@ -253,9 +248,6 @@ private:
 	StringName name;
 	Vector<Variant> constants;
 	Vector<StringName> global_names;
-#ifdef TOOLS_ENABLED
-	Vector<StringName> named_globals;
-#endif
 	Vector<int> default_arguments;
 	Vector<int> code;
 	Vector<GDScriptDataType> argument_types;
@@ -344,6 +336,10 @@ public:
 	}
 
 	Variant call(GDScriptInstance *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err, CallState *p_state = nullptr);
+
+#ifdef DEBUG_ENABLED
+	void disassemble(const Vector<String> &p_code_lines) const;
+#endif
 
 	_FORCE_INLINE_ MultiplayerAPI::RPCMode get_rpc_mode() const { return rpc_mode; }
 	GDScriptFunction();

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -609,6 +609,7 @@ public:
 	};
 
 	struct ContinueNode : public Node {
+		bool is_for_match = false;
 		ContinueNode() {
 			type = CONTINUE;
 		}
@@ -1079,6 +1080,7 @@ private:
 	bool panic_mode = false;
 	bool can_break = false;
 	bool can_continue = false;
+	bool is_continue_match = false; // Whether a `continue` will act on a `match`.
 	bool is_ignoring_warnings = false;
 	List<bool> multiline_stack;
 

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1039,7 +1039,7 @@ void GDScriptTokenizer::check_indent() {
 			// First time indenting, choose character now.
 			indent_char = current_indent_char;
 		} else if (current_indent_char != indent_char) {
-			Token error = make_error(vformat("Used \"%c\" for indentation instead \"%c\" as used before in the file.", String(&current_indent_char, 1).c_escape(), String(&indent_char, 1).c_escape()));
+			Token error = make_error(vformat("Used \"%s\" for indentation instead \"%s\" as used before in the file.", String(&current_indent_char, 1).c_escape(), String(&indent_char, 1).c_escape()));
 			error.start_line = line;
 			error.start_column = 1;
 			error.leftmost_column = 1;


### PR DESCRIPTION
This adds an interface for code generation to GDScript. In itself it does not make much of a difference, but it does make it easier to add a new backend without having to worry about the parse tree, instead just implementing a lower-level interface.

This will be useful for the new typed VM, since it can be made without creating a new compiler code. Could also be useful in the future if we want to compile GDScript to other targets.

Also includes a disassembler for the current VM which I used to debug the code generation. It can't be accessed currently since the command for the old tests isn't available anymore, but this is useful to have for when we have a new way to trigger those.