### PR TITLE
Make intersect_ray() return true, if ray orginates inside of a shape.

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -110,12 +110,12 @@
 			<argument index="5" name="collide_with_areas" type="bool" default="false">
 			</argument>
 			<description>
-				Intersects a ray in a given space. The returned object is a dictionary with the following fields:
+				Intersects a ray in a given space. If the ray originates inside one or more objects, the first detected object will be selected. The returned object is a dictionary with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]metadata[/code]: The intersecting shape's metadata. This metadata is different from [method Object.get_meta], and is set with [method PhysicsServer2D.shape_set_data].
-				[code]normal[/code]: The object's surface normal at the intersection point.
-				[code]position[/code]: The intersection point.
+				[code]normal[/code]: The object's surface normal at the intersection point. If the ray originates inside the object, this will be a zero length [Vector2].
+				[code]position[/code]: The intersection point. If the ray originates inside the object, this will be the ray's origin.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty dictionary is returned instead.

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -65,11 +65,11 @@
 			<argument index="5" name="collide_with_areas" type="bool" default="false">
 			</argument>
 			<description>
-				Intersects a ray in a given space. The returned object is a dictionary with the following fields:
+				Intersects a ray in a given space. In Godot physics, if the ray originates inside one or more objects, the first detected object will be selected. In Bullet physics, these objects are ignored. The returned object is a dictionary with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
-				[code]normal[/code]: The object's surface normal at the intersection point.
-				[code]position[/code]: The intersection point.
+				[code]normal[/code]: The object's surface normal at the intersection point. In Godot physics, if the ray originates inside one or more objects, this will be a zero length [Vector3].
+				[code]position[/code]: The intersection point. In Godot physics, if the ray originates inside the object, this will be the ray's origin.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty dictionary is returned instead.

--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -4,7 +4,7 @@
 		Query the closest object intersecting a ray.
 	</brief_description>
 	<description>
-		A RayCast represents a line from its origin to its destination position, [member target_position]. It is used to query the 2D space in order to find the closest object along the path of the ray.
+		A RayCast represents a line from its origin to its destination position, [member target_position]. It is used to query the 2D space in order to find the closest object along the path of the ray. If the ray originates inside one or more objects, the first detected object will be selected.
 		RayCast2D can ignore some objects by adding them to the exception list via [method add_exception], by setting proper filtering with collision layers, or by filtering object types with type masks.
 		RayCast2D can be configured to report collisions with [Area2D]s ([member collide_with_areas]) and/or [PhysicsBody2D]s ([member collide_with_bodies]).
 		Only enabled raycasts will be able to query the space and report collisions.
@@ -74,7 +74,7 @@
 			<return type="Vector2">
 			</return>
 			<description>
-				Returns the normal of the intersecting object's shape at the collision point.
+				Returns the normal of the intersecting object's shape at the collision point. If the ray originates inside the object, a zero length [Vector2] will be returned.
 			</description>
 		</method>
 		<method name="get_collision_point" qualifiers="const">

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -4,7 +4,7 @@
 		Query the closest object intersecting a ray.
 	</brief_description>
 	<description>
-		A RayCast represents a line from its origin to its destination position, [member target_position]. It is used to query the 3D space in order to find the closest object along the path of the ray.
+		A RayCast represents a line from its origin to its destination position, [member target_position]. It is used to query the 3D space in order to find the closest object along the path of the ray. In Godot physics, if the ray originates inside one or more objects, the first detected object will be selected. In Bullet physics, these objects are ignored.
 		RayCast3D can ignore some objects by adding them to the exception list via [method add_exception] or by setting proper filtering with collision layers and masks.
 		RayCast3D can be configured to report collisions with [Area3D]s ([member collide_with_areas]) and/or [PhysicsBody3D]s ([member collide_with_bodies]).
 		Only enabled raycasts will be able to query the space and report collisions.
@@ -54,6 +54,7 @@
 			</return>
 			<description>
 				Returns the first object that the ray intersects, or [code]null[/code] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
+				In Godot physics, if the ray originates inside one or more objects, the first detected object will be returned. In Bullet physics, these objects are ignored.
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">
@@ -78,6 +79,7 @@
 			</return>
 			<description>
 				Returns the normal of the intersecting object's shape at the collision point.
+				In Godot physics, if the ray originates inside one or more objects, a zero length [Vector3] will be returned. In Bullet physics, these objects are ignored.
 			</description>
 		</method>
 		<method name="get_collision_point" qualifiers="const">
@@ -85,6 +87,7 @@
 			</return>
 			<description>
 				Returns the collision point at which the ray intersects the closest object.
+				In Godot physics, if the ray originates inside one or more objects, the ray origin will be returned. In Bullet physics, these objects are ignored.
 				[b]Note:[/b] This point is in the [b]global[/b] coordinate system.
 			</description>
 		</method>
@@ -93,6 +96,7 @@
 			</return>
 			<description>
 				Returns whether any object is intersecting with the ray's vector (considering the vector length).
+				[b]Note:[/b] In Godot physics, if the ray originates inside one or more objects, [method is_colliding] will return [code]true[/code]. In Bullet physics, these objects are ignored.
 			</description>
 		</method>
 		<method name="remove_exception">

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -164,7 +164,15 @@ bool PhysicsDirectSpaceState2DSW::intersect_ray(const Vector2 &p_from, const Vec
 
 		Vector2 shape_point, shape_normal;
 
-		if (shape->intersect_segment(local_from, local_to, shape_point, shape_normal)) {
+		if (shape->contains_point(local_from)) {
+			min_d = 0;
+			res_point = local_from;
+			res_normal = Vector2();
+			res_shape = shape_idx;
+			res_obj = col_obj;
+			collided = true;
+			break;
+		} else if (shape->intersect_segment(local_from, local_to, shape_point, shape_normal)) {
 			Transform2D xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
 			shape_point = xform.xform(shape_point);
 

--- a/servers/physics_3d/space_3d_sw.cpp
+++ b/servers/physics_3d/space_3d_sw.cpp
@@ -141,7 +141,15 @@ bool PhysicsDirectSpaceState3DSW::intersect_ray(const Vector3 &p_from, const Vec
 
 		Vector3 shape_point, shape_normal;
 
-		if (shape->intersect_segment(local_from, local_to, shape_point, shape_normal)) {
+		if (shape->get_closest_point_to(local_from) == local_from) {
+			min_d = 0;
+			res_point = local_from;
+			res_normal = Vector3();
+			res_shape = shape_idx;
+			res_obj = col_obj;
+			collided = true;
+			break;
+		} else if (shape->intersect_segment(local_from, local_to, shape_point, shape_normal)) {
 			Transform xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
 			shape_point = xform.xform(shape_point);
 


### PR DESCRIPTION
Fixes #35845
Fixes #38343
Fixes #38873
Fixes #39859
Fixes #44003
Supersedes #41277
Addresses [comment](https://github.com/godotengine/godot/issues/41167#issuecomment-674035596) in #41167.

The issues above suggest that, if the ray originates inside of a shape, `intersect_ray()` is expected to return true. This change performs this check and assigns the first shape that it detects that the ray is within as the colliding `Object`. It also sets the colliding point to the ray origin. Since the ray is not colliding with an edge or face, there is no normal; so the zero length vector is assigned. This makes all `CollisionShapes` consistent with the current results when a ray originates inside a `Rectangle2D` or `BoxShape3D` (in Godot physics).

This change has been applied to both Godot 2D and Godot 3D physics. It has not been applied to Bullet physics, which uses the opposite approach: returns no collision if the ray originates inside a shape (has an incalculable normal); as proposed in #41277. However, unlike in Godot physics, in Bullet physics, there does not appear to be an easy way to determine if a point (the ray origin) is contained inside a `CollisionShape` to make this consistent in Bullet physics too.