### PR TITLE
C#: Fix editor unable to play game after IDE PlayRequest

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/BuildManager.cs
@@ -205,23 +205,8 @@ namespace GodotTools
             if (File.Exists(editorScriptsMetadataPath))
                 File.Copy(editorScriptsMetadataPath, playerScriptsMetadataPath);
 
-            var currentPlayRequest = GodotSharpEditor.Instance.CurrentPlaySettings;
-
-            if (currentPlayRequest != null)
-            {
-                if (currentPlayRequest.Value.HasDebugger)
-                {
-                    // Set the environment variable that will tell the player to connect to the IDE debugger
-                    // TODO: We should probably add a better way to do this
-                    Environment.SetEnvironmentVariable("GODOT_MONO_DEBUGGER_AGENT",
-                        "--debugger-agent=transport=dt_socket" +
-                        $",address={currentPlayRequest.Value.DebuggerHost}:{currentPlayRequest.Value.DebuggerPort}" +
-                        ",server=n");
-                }
-
-                if (!currentPlayRequest.Value.BuildBeforePlaying)
-                    return true; // Requested play from an external editor/IDE which already built the project
-            }
+            if (GodotSharpEditor.Instance.SkipBuildBeforePlaying)
+                return true; // Requested play from an external editor/IDE which already built the project
 
             return BuildProjectBlocking("Debug");
         }

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -38,7 +38,7 @@ namespace GodotTools
 
         public BottomPanel BottomPanel { get; private set; }
 
-        public PlaySettings? CurrentPlaySettings { get; set; }
+        public bool SkipBuildBeforePlaying { get; set; } = false;
 
         public static string ProjectAssemblyName
         {


### PR DESCRIPTION
The editor wasn't clearing the debugger agent settings properly after a processing a play request from an IDE. This caused consequent play attempts to fail if not launched from the IDE, as the game would still attempt and fail to connect to the debugger.

The concrete cause: Forgetting to clear the `GODOT_MONO_DEBUGGER_AGENT` environment variable.

Fixes godotengine/godot-csharp-visualstudio#7 (This issue was reproducible with VSCode and VSMac/MonoDevelop as well)
