### PR TITLE
Autosize inspector property editors rather than always being half-half with label

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -90,7 +90,9 @@ private:
 	bool selected;
 	int selected_focusable;
 
-	float split_ratio;
+	// Sets the "target" width for the label. Width is limited to 50% of inspector width in NOTIFICATION_SORT_CHILDREN.
+	float label_target_width;
+	bool force_target_width = false;
 
 	Vector<Control *> focusables;
 	Control *label_reference;
@@ -156,8 +158,11 @@ public:
 	void set_selectable(bool p_selectable);
 	bool is_selectable() const;
 
-	void set_name_split_ratio(float p_ratio);
-	float get_name_split_ratio() const;
+	void set_label_target_width(float p_width);
+	float get_label_target_width() const;
+
+	void set_force_label_target_width(bool p_force);
+	bool is_force_label_target_width() const;
 
 	void set_object_and_property(Object *p_object, const StringName &p_property);
 	virtual Control *make_custom_tooltip(const String &p_text) const override;

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -164,7 +164,8 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 			if (prop) {
 				prop->set_object_and_property(AnimationTreeEditor::get_singleton()->get_tree(), base_path);
 				prop->update_property();
-				prop->set_name_split_ratio(0);
+				prop->set_label_target_width(0);
+				prop->set_force_label_target_width(true);
 				prop->connect("property_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_property_changed));
 				node->add_child(prop);
 				visible_properties.push_back(prop);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -3534,7 +3534,8 @@ public:
 			properties[i]->connect("property_changed", callable_mp(this, &VisualShaderNodePluginDefaultEditor::_property_changed));
 			properties[i]->set_object_and_property(node.ptr(), p_names[i]);
 			properties[i]->update_property();
-			properties[i]->set_name_split_ratio(0);
+			properties[i]->set_label_target_width(0);
+			properties[i]->set_force_label_target_width(true);
 		}
 		node->connect("changed", callable_mp(this, &VisualShaderNodePluginDefaultEditor::_node_changed));
 	}


### PR DESCRIPTION
Closes #7133
Closes #35564

This resolves a (seemingly longstanding) issue where the editor inspector always splits Property Editors and their Labels 50/50 no matter what. Most of the time it would be beneficial to have a better view of the Property Editor, especially for long strings or paths.

Demo:
Note that the width of the label is capped at 50%, so the property editor does not become tiny.
![inspector_autosize](https://user-images.githubusercontent.com/41730826/90631810-bb970680-e266-11ea-9a9e-3cccdbb4ad04.gif)

Works everywhere inspector is used, as expected.
![inspector_autosize_projsettings](https://user-images.githubusercontent.com/41730826/90631839-c5206e80-e266-11ea-8ce5-130d607c6f46.gif)

This also maintains a form of "backwards compatibility" with the Animation Blend Tree Editor and the Visual Shader Editor, which both used the previous setting, which was `set_name_split_ratio()` . The method (and associated property) is now `label_target_width`, so setting it to 0 has the same effect in both cases, requiring no other changes.