### PR TITLE
Fix warning using ERR_FAIL_INDEX on unsigned int

### DIFF
--- a/core/rid_owner.h
+++ b/core/rid_owner.h
@@ -236,7 +236,7 @@ public:
 	}
 
 	_FORCE_INLINE_ T *get_ptr_by_index(uint32_t p_index) {
-		ERR_FAIL_INDEX_V(p_index, alloc_count, nullptr);
+		ERR_FAIL_UNSIGNED_INDEX_V(p_index, alloc_count, nullptr);
 		if (THREAD_SAFE) {
 			spin_lock.lock();
 		}


### PR DESCRIPTION
This method starting being used in 079ca220e14669ef7c31c399985cd2c733af15bd,
which now triggers this warning from GCC 10:
```
./core/error_macros.h:151:25: error: comparison of unsigned expression in '< 0' is always false [-Werror=type-limits]
```