### PR TITLE
Got rid of +1 to gravity_distance_scale

### DIFF
--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -384,13 +384,17 @@ void Body2DSW::set_space(Space2DSW *p_space) {
 
 void Body2DSW::_compute_area_gravity_and_dampenings(const Area2DSW *p_area) {
 	if (p_area->is_gravity_point()) {
+		const real_t EVENT_HORIZON = 1.0; // TODO: Make user modifiable
+		const real_t gravity_distance_scale = p_area->get_gravity_distance_scale();
 		Vector2 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
-		const real_t v_length = v.length();
-		if (v_length <= 0) {
-			// Prevent Divide by Zero Error
-			// gravity += 0.0;
-		} else if (p_area->get_gravity_distance_scale() > 0) {
-			gravity += v.normalized() * (p_area->get_gravity() / Math::pow(v_length * p_area->get_gravity_distance_scale(), 2));
+		real_t v_length = v.length();
+		if (gravity_distance_scale > 0 && v_length > EVENT_HORIZON) {
+			real_t new_gravity = (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2));
+			if (isinf(new_gravity)) {
+				WARN_PRINT_ONCE("Gravity is Infinite");
+			} else {
+				gravity += v.normalized() * new_gravity;
+			}
 		} else {
 			gravity += v.normalized() * p_area->get_gravity();
 		}

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -384,12 +384,12 @@ void Body2DSW::set_space(Space2DSW *p_space) {
 
 void Body2DSW::_compute_area_gravity_and_dampenings(const Area2DSW *p_area) {
 	if (p_area->is_gravity_point()) {
-		const float v_length = v.length();
+		Vector2 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
+		const t_real v_length = v.length();
 		if (p_area->get_gravity_distance_scale() > 0 && v_length > 0) {
-			Vector2 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
 			gravity += v.normalized() * (p_area->get_gravity() / Math::pow(v_length * p_area->get_gravity_distance_scale(), 2));
 		} else {
-			gravity += (p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin()).normalized() * p_area->get_gravity();
+			gravity += v.normalized() * p_area->get_gravity();
 		}
 	} else {
 		gravity += p_area->get_gravity_vector() * p_area->get_gravity();

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -387,13 +387,17 @@ void Body2DSW::_compute_area_gravity_and_dampenings(const Area2DSW *p_area) {
 		const real_t gravity_distance_scale = p_area->get_gravity_distance_scale();
 		Vector2 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
 		real_t v_length = v.length();
-		if (gravity_distance_scale > 0 && v_length > 0) {
-			Vector2 new_gravity = gravity + (v.normalized() * (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2)));
-			if (isinf(new_gravity.x) || isinf(new_gravity.y)) {
-				WARN_PRINT_ONCE("Gravity is Infinite");
-			} else {
-				gravity = new_gravity;
+		if (gravity_distance_scale > 0) {
+			if (v_length > 0) {
+				Vector2 new_gravity = gravity + (v.normalized() * (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2)));
+				if (isinf(new_gravity.x) || isinf(new_gravity.y)) {
+					WARN_PRINT_ONCE("Gravity is Infinite");
+				} else {
+					gravity = new_gravity;
+				}
 			}
+		} else {
+			gravity += v.normalized() * p_area->get_gravity();
 		}
 	} else {
 		gravity += p_area->get_gravity_vector() * p_area->get_gravity();

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -386,7 +386,10 @@ void Body2DSW::_compute_area_gravity_and_dampenings(const Area2DSW *p_area) {
 	if (p_area->is_gravity_point()) {
 		Vector2 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
 		const real_t v_length = v.length();
-		if (p_area->get_gravity_distance_scale() > 0 && v_length > 0) {
+		if (v_length <= 0) {
+			// Prevent Divide by Zero Error
+			// gravity += 0.0;
+		} else if (p_area->get_gravity_distance_scale() > 0) {
 			gravity += v.normalized() * (p_area->get_gravity() / Math::pow(v_length * p_area->get_gravity_distance_scale(), 2));
 		} else {
 			gravity += v.normalized() * p_area->get_gravity();

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -384,9 +384,10 @@ void Body2DSW::set_space(Space2DSW *p_space) {
 
 void Body2DSW::_compute_area_gravity_and_dampenings(const Area2DSW *p_area) {
 	if (p_area->is_gravity_point()) {
-		if (p_area->get_gravity_distance_scale() > 0) {
+		const float v_length = v.length();
+		if (p_area->get_gravity_distance_scale() > 0 && v_length > 0) {
 			Vector2 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
-			gravity += v.normalized() * (p_area->get_gravity() / Math::pow(v.length() * p_area->get_gravity_distance_scale() + 1, 2));
+			gravity += v.normalized() * (p_area->get_gravity() / Math::pow(v_length * p_area->get_gravity_distance_scale(), 2));
 		} else {
 			gravity += (p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin()).normalized() * p_area->get_gravity();
 		}

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -386,8 +386,8 @@ void Body2DSW::_compute_area_gravity_and_dampenings(const Area2DSW *p_area) {
 	if (p_area->is_gravity_point()) {
 		const real_t gravity_distance_scale = p_area->get_gravity_distance_scale();
 		Vector2 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
-		real_t v_length = v.length();
 		if (gravity_distance_scale > 0) {
+			real_t v_length = v.length();
 			if (v_length > 0) {
 				Vector2 new_gravity = gravity + (v.normalized() * (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2)));
 				if (isinf(new_gravity.x) || isinf(new_gravity.y)) {

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -389,11 +389,11 @@ void Body2DSW::_compute_area_gravity_and_dampenings(const Area2DSW *p_area) {
 		Vector2 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
 		real_t v_length = v.length();
 		if (gravity_distance_scale > 0 && v_length > EVENT_HORIZON) {
-			real_t new_gravity = (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2));
-			if (isinf(new_gravity)) {
+			Vector2 new_gravity = gravity + (v.normalized() * (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2)));
+			if (isinf(new_gravity.x) || isinf(new_gravity.y)) {
 				WARN_PRINT_ONCE("Gravity is Infinite");
 			} else {
-				gravity += v.normalized() * new_gravity;
+				gravity = new_gravity;
 			}
 		} else {
 			gravity += v.normalized() * p_area->get_gravity();

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -385,7 +385,7 @@ void Body2DSW::set_space(Space2DSW *p_space) {
 void Body2DSW::_compute_area_gravity_and_dampenings(const Area2DSW *p_area) {
 	if (p_area->is_gravity_point()) {
 		Vector2 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
-		const t_real v_length = v.length();
+		const real_t v_length = v.length();
 		if (p_area->get_gravity_distance_scale() > 0 && v_length > 0) {
 			gravity += v.normalized() * (p_area->get_gravity() / Math::pow(v_length * p_area->get_gravity_distance_scale(), 2));
 		} else {

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -384,11 +384,10 @@ void Body2DSW::set_space(Space2DSW *p_space) {
 
 void Body2DSW::_compute_area_gravity_and_dampenings(const Area2DSW *p_area) {
 	if (p_area->is_gravity_point()) {
-		const real_t EVENT_HORIZON = 1.0; // TODO: Make user modifiable
 		const real_t gravity_distance_scale = p_area->get_gravity_distance_scale();
 		Vector2 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
 		real_t v_length = v.length();
-		if (gravity_distance_scale > 0 && v_length > EVENT_HORIZON) {
+		if (gravity_distance_scale > 0 && v_length > 0) {
 			Vector2 new_gravity = gravity + (v.normalized() * (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2)));
 			if (isinf(new_gravity.x) || isinf(new_gravity.y)) {
 				WARN_PRINT_ONCE("Gravity is Infinite");

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -394,8 +394,6 @@ void Body2DSW::_compute_area_gravity_and_dampenings(const Area2DSW *p_area) {
 			} else {
 				gravity = new_gravity;
 			}
-		} else {
-			gravity += v.normalized() * p_area->get_gravity();
 		}
 	} else {
 		gravity += p_area->get_gravity_vector() * p_area->get_gravity();

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -401,13 +401,17 @@ void Body3DSW::_compute_area_gravity_and_dampenings(const Area3DSW *p_area) {
 		const real_t gravity_distance_scale = p_area->get_gravity_distance_scale();
 		Vector3 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
 		real_t v_length = v.length();
-		if (gravity_distance_scale > 0 && v_length > 0) {
-			Vector3 new_gravity = gravity + (v.normalized() * (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2)));
-			if (isinf(new_gravity.x) || isinf(new_gravity.y)) {
-				WARN_PRINT_ONCE("Gravity is Infinite");
-			} else {
-				gravity = new_gravity;
+		if (gravity_distance_scale > 0) {
+			if (v_length > 0) {
+				Vector3 new_gravity = gravity + (v.normalized() * (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2)));
+				if (isinf(new_gravity.x) || isinf(new_gravity.y)) {
+					WARN_PRINT_ONCE("Gravity is Infinite");
+				} else {
+					gravity = new_gravity;
+				}
 			}
+		} else {
+			gravity += v.normalized() * p_area->get_gravity();
 		}
 	} else {
 		gravity += p_area->get_gravity_vector() * p_area->get_gravity();

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -398,12 +398,12 @@ void Body3DSW::set_space(Space3DSW *p_space) {
 
 void Body3DSW::_compute_area_gravity_and_dampenings(const Area3DSW *p_area) {
 	if (p_area->is_gravity_point()) {
-		const float v_length = v.length();
+		Vector3 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
+		const t_real v_length = v.length();
 		if (p_area->get_gravity_distance_scale() > 0 && v_length > 0) {
-			Vector3 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
 			gravity += v.normalized() * (p_area->get_gravity() / Math::pow(v_length * p_area->get_gravity_distance_scale(), 2));
 		} else {
-			gravity += (p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin()).normalized() * p_area->get_gravity();
+			gravity += v.normalized() * p_area->get_gravity();
 		}
 	} else {
 		gravity += p_area->get_gravity_vector() * p_area->get_gravity();

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -398,11 +398,10 @@ void Body3DSW::set_space(Space3DSW *p_space) {
 
 void Body3DSW::_compute_area_gravity_and_dampenings(const Area3DSW *p_area) {
 	if (p_area->is_gravity_point()) {
-		const real_t EVENT_HORIZON = 1.0; // TODO: Make user modifiable
 		const real_t gravity_distance_scale = p_area->get_gravity_distance_scale();
 		Vector3 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
 		real_t v_length = v.length();
-		if (gravity_distance_scale > 0 && v_length > EVENT_HORIZON) {
+		if (gravity_distance_scale > 0 && v_length > 0) {
 			Vector3 new_gravity = gravity + (v.normalized() * (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2)));
 			if (isinf(new_gravity.x) || isinf(new_gravity.y)) {
 				WARN_PRINT_ONCE("Gravity is Infinite");

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -403,11 +403,11 @@ void Body3DSW::_compute_area_gravity_and_dampenings(const Area3DSW *p_area) {
 		Vector3 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
 		real_t v_length = v.length();
 		if (gravity_distance_scale > 0 && v_length > EVENT_HORIZON) {
-			real_t new_gravity = (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2));
-			if (isinf(new_gravity)) {
+			Vector2 new_gravity = gravity + (v.normalized() * (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2)));
+			if (isinf(new_gravity.x) || isinf(new_gravity.y)) {
 				WARN_PRINT_ONCE("Gravity is Infinite");
 			} else {
-				gravity += v.normalized() * new_gravity;
+				gravity = new_gravity;
 			}
 		} else {
 			gravity += v.normalized() * p_area->get_gravity();

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -403,7 +403,7 @@ void Body3DSW::_compute_area_gravity_and_dampenings(const Area3DSW *p_area) {
 		Vector3 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
 		real_t v_length = v.length();
 		if (gravity_distance_scale > 0 && v_length > EVENT_HORIZON) {
-			Vector2 new_gravity = gravity + (v.normalized() * (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2)));
+			Vector3 new_gravity = gravity + (v.normalized() * (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2)));
 			if (isinf(new_gravity.x) || isinf(new_gravity.y)) {
 				WARN_PRINT_ONCE("Gravity is Infinite");
 			} else {

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -399,7 +399,7 @@ void Body3DSW::set_space(Space3DSW *p_space) {
 void Body3DSW::_compute_area_gravity_and_dampenings(const Area3DSW *p_area) {
 	if (p_area->is_gravity_point()) {
 		Vector3 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
-		const t_real v_length = v.length();
+		const real_t v_length = v.length();
 		if (p_area->get_gravity_distance_scale() > 0 && v_length > 0) {
 			gravity += v.normalized() * (p_area->get_gravity() / Math::pow(v_length * p_area->get_gravity_distance_scale(), 2));
 		} else {

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -398,9 +398,10 @@ void Body3DSW::set_space(Space3DSW *p_space) {
 
 void Body3DSW::_compute_area_gravity_and_dampenings(const Area3DSW *p_area) {
 	if (p_area->is_gravity_point()) {
-		if (p_area->get_gravity_distance_scale() > 0) {
+		const float v_length = v.length();
+		if (p_area->get_gravity_distance_scale() > 0 && v_length > 0) {
 			Vector3 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
-			gravity += v.normalized() * (p_area->get_gravity() / Math::pow(v.length() * p_area->get_gravity_distance_scale() + 1, 2));
+			gravity += v.normalized() * (p_area->get_gravity() / Math::pow(v_length * p_area->get_gravity_distance_scale(), 2));
 		} else {
 			gravity += (p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin()).normalized() * p_area->get_gravity();
 		}

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -400,7 +400,10 @@ void Body3DSW::_compute_area_gravity_and_dampenings(const Area3DSW *p_area) {
 	if (p_area->is_gravity_point()) {
 		Vector3 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
 		const real_t v_length = v.length();
-		if (p_area->get_gravity_distance_scale() > 0 && v_length > 0) {
+		if (v_length <= 0) {
+			// Prevent Divide by Zero Error
+			// gravity += 0.0;
+		} else if (p_area->get_gravity_distance_scale() > 0) {
 			gravity += v.normalized() * (p_area->get_gravity() / Math::pow(v_length * p_area->get_gravity_distance_scale(), 2));
 		} else {
 			gravity += v.normalized() * p_area->get_gravity();

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -408,8 +408,6 @@ void Body3DSW::_compute_area_gravity_and_dampenings(const Area3DSW *p_area) {
 			} else {
 				gravity = new_gravity;
 			}
-		} else {
-			gravity += v.normalized() * p_area->get_gravity();
 		}
 	} else {
 		gravity += p_area->get_gravity_vector() * p_area->get_gravity();

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -400,8 +400,8 @@ void Body3DSW::_compute_area_gravity_and_dampenings(const Area3DSW *p_area) {
 	if (p_area->is_gravity_point()) {
 		const real_t gravity_distance_scale = p_area->get_gravity_distance_scale();
 		Vector3 v = p_area->get_transform().xform(p_area->get_gravity_vector()) - get_transform().get_origin();
-		real_t v_length = v.length();
 		if (gravity_distance_scale > 0) {
+			real_t v_length = v.length();
 			if (v_length > 0) {
 				Vector3 new_gravity = gravity + (v.normalized() * (p_area->get_gravity() / Math::pow(v_length * gravity_distance_scale, 2)));
 				if (isinf(new_gravity.x) || isinf(new_gravity.y)) {


### PR DESCRIPTION
Reference: #1932

The +1 in the gravity_distance scale formula breaks any ability to convert the point gravity into standard gravitational form.
This also causes precession in orbits.

The gravitation parameter `mu=G*M`
	
Newtons Equation using the gravitational parameter is:
`F = mu*mass/distance^2` [1]
	
The equation in the godot code is:
	`F = gravity * mass / (distance * gravity_distance_scale + 1)^2` [2]

The resultant equation is:
	`mu = distance^2*gravity/(1+distance*gravity_distance_scale)^2` [3]

But this still contains distance, which is weird.
	
So now we can get this if we remove that +1:
	`mu = gravity/gravity_distance_scale^2` [4]

## References

1. https://en.wikipedia.org/wiki/Standard_gravitational_parameter
2. https://github.com/Faless/godot/blob/590afbcac461f87b05391996ca85d32627c81a75/servers/physics_2d/body_2d_sw.cpp
3. https://www.wolframalpha.com/input/?i=u+*+m+%2F+r%5E2+%3D+g+*+m+%2F+%28r+*+s+%2B+1%29%5E2+solve+for+u
4. https://www.wolframalpha.com/input/?i=u+*+m+%2F+r%5E2+%3D+g+*+m+%2F+%28r+*+s%29%5E2+solve+for+u