### PR TITLE
Update CollisionShape2D doc

### DIFF
--- a/doc/classes/CollisionShape2D.xml
+++ b/doc/classes/CollisionShape2D.xml
@@ -13,7 +13,7 @@
 	</methods>
 	<members>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
-			A disabled collision shape has no effect in the world.
+			A disabled collision shape has no effect in the world. This property should be changed with [method Object.set_deferred].
 		</member>
 		<member name="one_way_collision" type="bool" setter="set_one_way_collision" getter="is_one_way_collision_enabled" default="false">
 			Sets whether this collision shape should only detect collision on one side (top or bottom).


### PR DESCRIPTION
Updates the CollisionShape2D doc to say that you should use `set_deferred()` when changing the disabled property. Closes https://github.com/godotengine/godot-docs/issues/3761
