### PR TITLE
Viewport Usage enumeration documentation

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -415,10 +415,10 @@
 			Use 16x Multisample Antialiasing. Likely unsupported on medium and low-end hardware.
 		</constant>
 		<constant name="USAGE_2D" value="0" enum="Usage">
-			Allocates all buffers needed for drawing 2D scenes. This takes less VRAM than the 3D usage modes.
+			Allocates all buffers needed for drawing 2D scenes. This takes less VRAM than the 3D usage modes. Note that 3D rendering effects such as glow and HDR are not available when using this mode.
 		</constant>
 		<constant name="USAGE_2D_NO_SAMPLING" value="1" enum="Usage">
-			Allocates buffers needed for 2D scenes without allocating a buffer for screen copy. Accordingly, you cannot read from the screen. Of the [enum Usage] types, this requires the least VRAM.
+			Allocates buffers needed for 2D scenes without allocating a buffer for screen copy. Accordingly, you cannot read from the screen. Of the [enum Usage] types, this requires the least VRAM. Note that 3D rendering effects such as glow and HDR are not available when using this mode.
 		</constant>
 		<constant name="USAGE_3D" value="2" enum="Usage">
 			Allocates full buffers for drawing 3D scenes and all 3D effects including buffers needed for 2D scenes and effects.


### PR DESCRIPTION
Mention that 3D effects are not available when using USAGE_2D

Opening this after the discussion in https://github.com/godotengine/godot-docs/pull/3911

I just noticed that the godot-docs README specifically points out not to edit class references in that repository.
I probably skipped that when reading, my bad :sweat_smile: 

Fixes https://github.com/godotengine/godot/issues/41151

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
