### PR TITLE
Fix crash caused by GDScript self unreferencing during reload

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -603,10 +603,8 @@ Error GDScript::reload(bool p_keep_state) {
 		}
 		if (!source_path.empty()) {
 			MutexLock lock(GDScriptCache::singleton->lock);
-			Ref<GDScript> self(this);
 			if (!GDScriptCache::singleton->shallow_gdscript_cache.has(source_path)) {
-				GDScriptCache::singleton->shallow_gdscript_cache[source_path] = self;
-				self->unreference();
+				GDScriptCache::singleton->shallow_gdscript_cache[source_path] = Ref<GDScript>(this);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #41393, caused by 8088e9e6acb3d8cec00610e9345596bbabed6923.

Saving stuff in the editor runs through threads as well, which likely explains crashes to happen sporadically.

I'm not sure if manual unreferencing is needed for something else, but I couldn't reproduce the crash with this change anymore.
