### PR TITLE
Clarify points in Line2D doc

### DIFF
--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -85,7 +85,7 @@
 			The style for the points between the start and the end.
 		</member>
 		<member name="points" type="PackedVector2Array" setter="set_points" getter="get_points" default="PackedVector2Array(  )">
-			The points that form the lines. The line is drawn between every point set in this array.
+			The points that form the lines. The line is drawn between every point set in this array. Points are interpreted as local vectors.
 		</member>
 		<member name="round_precision" type="int" setter="set_round_precision" getter="get_round_precision" default="8">
 			The smoothness of the rounded joints and caps. This is only used if a cap or joint is set as round.


### PR DESCRIPTION
Clarify that PoolVector2Array Points are interpreted as local vectors and not global. Closes https://github.com/godotengine/godot-docs/issues/3115
