### PR TITLE
Mono/C#: Fix editor using wrong project assembly path in rare cases

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
@@ -43,7 +43,7 @@ namespace GodotTools.Core
                    path.StartsWith(DriveRoot, StringComparison.Ordinal);
         }
 
-        public static string ToSafeDirName(this string dirName, bool allowDirSeparator)
+        public static string ToSafeDirName(this string dirName, bool allowDirSeparator = false)
         {
             var invalidChars = new List<string> { ":", "*", "?", "\"", "<", ">", "|" };
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -430,7 +430,7 @@ namespace GodotTools.Export
         private static string DetermineDataDirNameForProject()
         {
             var appName = (string)ProjectSettings.GetSetting("application/config/name");
-            string appNameSafe = appName.ToSafeDirName(allowDirSeparator: false);
+            string appNameSafe = appName.ToSafeDirName();
             return $"data_{appNameSafe}";
         }
 

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -45,6 +45,7 @@ namespace GodotTools
             get
             {
                 var projectAssemblyName = (string)ProjectSettings.GetSetting("application/config/name");
+                projectAssemblyName = projectAssemblyName.ToSafeDirName();
                 if (string.IsNullOrEmpty(projectAssemblyName))
                     projectAssemblyName = "UnnamedProject";
                 return projectAssemblyName;


### PR DESCRIPTION
We were removing invalid path characters from the
name in C++ code, but the C# editor code wasn't.
