### PR TITLE
fix unintentional object rotation by anim tree

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -601,9 +601,9 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 
 						if (path.get_subname_count() == 1 && Object::cast_to<Skeleton3D>(spatial)) {
 							Skeleton3D *sk = Object::cast_to<Skeleton3D>(spatial);
+							track_xform->skeleton = sk;
 							int bone_idx = sk->find_bone(path.get_subname(0));
 							if (bone_idx != -1) {
-								track_xform->skeleton = sk;
 								track_xform->bone_idx = bone_idx;
 							}
 						}
@@ -1208,7 +1208,7 @@ void AnimationTree::_process_graph(float p_delta) {
 					} else if (t->skeleton && t->bone_idx >= 0) {
 						t->skeleton->set_bone_pose(t->bone_idx, xform);
 
-					} else {
+					} else if (!t->skeleton) {
 						t->spatial->set_transform(xform);
 					}
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixed #41419

An object is rotated unintentional by animation tree when object's bone is not found.

It's weird that the parent object rotates when the skeleton of the bone's parent exists and the bone is not found. So I fixed.


