### PR TITLE
Fix triple-quote completion bug #41361

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -483,6 +483,7 @@ protected:
 	void _gui_input(const Ref<InputEvent> &p_gui_input);
 	void _notification(int p_what);
 
+	String _get_running_quotes(int line_no, int col_no);
 	void _consume_pair_symbol(char32_t ch);
 	void _consume_backspace_for_pair_symbol(int prev_line, int prev_column);
 


### PR DESCRIPTION
**Previous state:**
Auto-complete did not recognise triple-quotes.

**After this commit:**
1. Auto-complete triple-quote pairs working.
2. Also, other auto-complete features, like single-quotes and braces, now recognise the presence of these multi-line strings. They act accordingly. Quotations inside multi-line comments are not closed automatically.

**Known Issues**
1. The new function _get_running_quotes() checks for open quotations and comments. It can be optimised (though it does not cause any lag. Tested with 500 lines). 
2. Quotations inside multi-line comments are consumed automatically (On `'``'`, backspace on the first `'` consumes the whole pair). This will be fixed in the next PR. This issue is not created in this PR. It exists in 3.2.2 also. 

*Bugsquad edit: This closes #41361.*