### PR TITLE
State how 'MOUSE_MODE_CAPTURED' actually works in the 'Input' docs

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -417,7 +417,8 @@
 			Makes the mouse cursor hidden if it is visible.
 		</constant>
 		<constant name="MOUSE_MODE_CAPTURED" value="2" enum="MouseMode">
-			Captures the mouse. The mouse will be hidden and unable to leave the game window, but it will still register movement and mouse button presses. On Windows and Linux, the mouse will use raw input mode, which means the reported movement will be unaffected by the OS' mouse acceleration settings.
+			Captures the mouse. The mouse will be hidden and its position locked at the center of the screen.
+			[b]Note:[/b] If you want to process the mouse's movement in this mode, you need to use [member InputEventMouseMotion.relative].
 		</constant>
 		<constant name="MOUSE_MODE_CONFINED" value="3" enum="MouseMode">
 			Makes the mouse cursor visible but confines it to the game window.


### PR DESCRIPTION
The docs previously erroneously stated that while on `MOUSE_MODE_CAPTURED`, the mouse was just kept inside the window, when in reality, it's locked at the center of the window. This PR gives the correct information, and also, gives a tip about getting the relative speed taken from the [online docs](https://docs.godotengine.org/en/latest/tutorials/inputs/mouse_and_input_coordinates.html).