### PR TITLE
Reset clear and update mode when set to only next frame

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1323,6 +1323,9 @@ void Viewport::set_update_mode(UpdateMode p_mode) {
 
 	update_mode = p_mode;
 	VS::get_singleton()->viewport_set_update_mode(viewport, VS::ViewportUpdateMode(p_mode));
+	if (update_mode == UPDATE_ONCE) {
+		VS::get_singleton()->request_frame_drawn_callback(const_cast<Viewport *>(this), "set_update_mode", Variant(UPDATE_DISABLED));
+	}
 }
 Viewport::UpdateMode Viewport::get_update_mode() const {
 
@@ -1349,6 +1352,9 @@ void Viewport::set_clear_mode(ClearMode p_mode) {
 
 	clear_mode = p_mode;
 	VS::get_singleton()->viewport_set_clear_mode(viewport, VS::ViewportClearMode(p_mode));
+	if (clear_mode == CLEAR_MODE_ONLY_NEXT_FRAME) {
+		VS::get_singleton()->request_frame_drawn_callback(const_cast<Viewport *>(this), "set_clear_mode", Variant(CLEAR_MODE_NEVER));
+	}
 }
 
 Viewport::ClearMode Viewport::get_clear_mode() const {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/33351

I am not certain this is the best approach. It is certainly one of the simplest approaches. 

We could also track the frame manually within the Viewport class.

If we decide that this is an acceptable approach, I will make an equivalent PR for ``SubViewport`` in master