### PR TITLE
Build the engine with custom modules in Visual Studio

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -536,6 +536,7 @@ def generate_vs_project(env, num_jobs):
                 '(if "$(PlatformTarget)"=="x64" (set "plat=x86_amd64"))',
                 'set "tools=yes"',
                 '(if "$(Configuration)"=="release" (set "tools=no"))',
+                'set "custom_modules=%s"' % env["custom_modules"],
                 'call "' + batch_file + '" !plat!',
             ]
 
@@ -555,15 +556,15 @@ def generate_vs_project(env, num_jobs):
         # last double quote off, confusing MSBuild
         env["MSVSBUILDCOM"] = build_commandline(
             "scons --directory=\"$(ProjectDir.TrimEnd('\\'))\" platform=windows progress=no target=$(Configuration)"
-            " tools=!tools! -j" + str(num_jobs)
+            " tools=!tools! custom_modules=!custom_modules! -j" + str(num_jobs)
         )
         env["MSVSREBUILDCOM"] = build_commandline(
             "scons --directory=\"$(ProjectDir.TrimEnd('\\'))\" platform=windows progress=no target=$(Configuration)"
-            " tools=!tools! vsproj=yes -j" + str(num_jobs)
+            " tools=!tools! custom_modules=!custom_modules! vsproj=yes -j" + str(num_jobs)
         )
         env["MSVSCLEANCOM"] = build_commandline(
             "scons --directory=\"$(ProjectDir.TrimEnd('\\'))\" --clean platform=windows progress=no"
-            " target=$(Configuration) tools=!tools! -j" + str(num_jobs)
+            " target=$(Configuration) tools=!tools! custom_modules=!custom_modules! -j" + str(num_jobs)
         )
 
         # This version information (Win32, x64, Debug, Release, Release_Debug seems to be


### PR DESCRIPTION
Follow-up to #36922.
Closes godotengine/godot-proposals#1232.

First, compile the engine with `custom_modules` and `vsproj=yes`:
```
scons custom_modules="path/to/your/modules" vsproj=yes
```
Run the Visual Studio project. You can now rebuild the engine if you need to make changes to custom modules directly within IDE.

![Annotation 2020-08-22 182422](https://user-images.githubusercontent.com/17108460/90959628-cccd5680-e4a4-11ea-92e4-031c83f3ba22.png)

---

**This feature is requested by IMVU members.**
