### PR TITLE
Popup fixes for X11 display server

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -681,6 +681,14 @@ DisplayServer::WindowID DisplayServerX11::create_sub_window(WindowMode p_mode, u
 	return id;
 }
 
+void DisplayServerX11::show_window(WindowID p_id) {
+	_THREAD_SAFE_METHOD_
+
+	WindowData &wd = windows[p_id];
+
+	XMapWindow(x11_display, wd.x11_window);
+}
+
 void DisplayServerX11::delete_sub_window(WindowID p_id) {
 	_THREAD_SAFE_METHOD_
 
@@ -3145,8 +3153,6 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, u
 		WindowData wd;
 		wd.x11_window = XCreateWindow(x11_display, RootWindow(x11_display, visualInfo->screen), p_rect.position.x, p_rect.position.y, p_rect.size.width > 0 ? p_rect.size.width : 1, p_rect.size.height > 0 ? p_rect.size.height : 1, 0, visualInfo->depth, InputOutput, visualInfo->visual, valuemask, &windowAttributes);
 
-		XMapWindow(x11_display, wd.x11_window);
-
 		//associate PID
 		// make PID known to X11
 		{
@@ -3316,6 +3322,7 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, u
 	if (cursors[current_cursor] != None) {
 		XDefineCursor(x11_display, wd.x11_window, cursors[current_cursor]);
 	}
+
 	return id;
 }
 
@@ -3555,6 +3562,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 			window_set_flag(WindowFlags(i), true, main_window);
 		}
 	}
+	show_window(main_window);
 
 //create RenderingDevice if used
 #if defined(VULKAN_ENABLED)

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -132,6 +132,9 @@ class DisplayServerX11 : public DisplayServer {
 
 		ObjectID instance_id;
 
+		bool menu_type = false;
+		bool no_focus = false;
+
 		//better to guess on the fly, given WM can change it
 		//WindowMode mode;
 		bool fullscreen = false; //OS can't exit from this mode

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -277,6 +277,7 @@ public:
 	virtual Vector<DisplayServer::WindowID> get_window_list() const;
 
 	virtual WindowID create_sub_window(WindowMode p_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i());
+	virtual void show_window(WindowID p_id);
 	virtual void delete_sub_window(WindowID p_id);
 
 	virtual WindowID get_window_at_screen_position(const Point2i &p_position) const;

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -230,6 +230,7 @@ public:
 	virtual Vector<int> get_window_list() const override;
 
 	virtual WindowID create_sub_window(WindowMode p_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i()) override;
+	virtual void show_window(WindowID p_id) override;
 	virtual void delete_sub_window(WindowID p_id) override;
 
 	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -2314,18 +2314,23 @@ DisplayServer::WindowID DisplayServerOSX::create_sub_window(WindowMode p_mode, u
 	_THREAD_SAFE_METHOD_
 
 	WindowID id = _create_window(p_mode, p_rect);
-	WindowData &wd = windows[id];
 	for (int i = 0; i < WINDOW_FLAG_MAX; i++) {
 		if (p_flags & (1 << i)) {
 			window_set_flag(WindowFlags(i), true, id);
 		}
 	}
+
+	return id;
+}
+
+void DisplayServerOSX::show_window(WindowID p_id) {
+	WindowData &wd = windows[p_id];
+
 	if (wd.no_focus) {
 		[wd.window_object orderFront:nil];
 	} else {
 		[wd.window_object makeKeyAndOrderFront:nil];
 	}
-	return id;
 }
 
 void DisplayServerOSX::_send_window_event(const WindowData &wd, WindowEvent p_event) {
@@ -3774,7 +3779,7 @@ DisplayServerOSX::DisplayServerOSX(const String &p_rendering_driver, WindowMode 
 			window_set_flag(WindowFlags(i), true, main_window);
 		}
 	}
-	[windows[main_window].window_object makeKeyAndOrderFront:nil];
+	show_window(MAIN_WINDOW_ID);
 
 #if defined(OPENGL_ENABLED)
 	if (rendering_driver == "opengl_es") {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -493,13 +493,15 @@ DisplayServer::WindowID DisplayServerWindows::create_sub_window(WindowMode p_mod
 		wd.no_focus = true;
 	}
 
-	_update_window_style(window_id);
-
 	return window_id;
 }
 
 void DisplayServerWindows::show_window(WindowID p_id) {
 	WindowData &wd = windows[p_id];
+
+	if (p_id != MAIN_WINDOW_ID) {
+		_update_window_style(p_id);
+	}
 
 	ShowWindow(wd.hWnd, wd.no_focus ? SW_SHOWNOACTIVATE : SW_SHOW); // Show The Window
 	if (!wd.no_focus) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -495,13 +495,17 @@ DisplayServer::WindowID DisplayServerWindows::create_sub_window(WindowMode p_mod
 
 	_update_window_style(window_id);
 
-	ShowWindow(wd.hWnd, (p_flags & WINDOW_FLAG_NO_FOCUS_BIT) ? SW_SHOWNOACTIVATE : SW_SHOW); // Show The Window
-	if (!(p_flags & WINDOW_FLAG_NO_FOCUS_BIT)) {
+	return window_id;
+}
+
+void DisplayServerWindows::show_window(WindowID p_id) {
+	WindowData &wd = windows[p_id];
+
+	ShowWindow(wd.hWnd, wd.no_focus ? SW_SHOWNOACTIVATE : SW_SHOW); // Show The Window
+	if (!wd.no_focus) {
 		SetForegroundWindow(wd.hWnd); // Slightly Higher Priority
 		SetFocus(wd.hWnd); // Sets Keyboard Focus To
 	}
-
-	return window_id;
 }
 
 void DisplayServerWindows::delete_sub_window(WindowID p_window) {
@@ -3139,9 +3143,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 		}
 	}
 
-	ShowWindow(windows[MAIN_WINDOW_ID].hWnd, SW_SHOW); // Show The Window
-	SetForegroundWindow(windows[MAIN_WINDOW_ID].hWnd); // Slightly Higher Priority
-	SetFocus(windows[MAIN_WINDOW_ID].hWnd); // Sets Keyboard Focus To
+	show_window(MAIN_WINDOW_ID);
 
 #if defined(VULKAN_ENABLED)
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -461,6 +461,7 @@ public:
 	virtual Vector<DisplayServer::WindowID> get_window_list() const;
 
 	virtual WindowID create_sub_window(WindowMode p_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i());
+	virtual void show_window(WindowID p_window);
 	virtual void delete_sub_window(WindowID p_window);
 
 	virtual WindowID get_window_at_screen_position(const Point2i &p_position) const;

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -41,55 +41,71 @@ void Popup::_input_from_window(const Ref<InputEvent> &p_event) {
 	}
 }
 
-void Popup::_parent_focused() {
-	_close_pressed();
+void Popup::_initialize_visible_parents() {
+	visible_parents.clear();
+
+	Window *parent_window = this;
+	while (parent_window) {
+		parent_window = parent_window->get_parent_visible_window();
+		if (parent_window) {
+			visible_parents.push_back(parent_window);
+			parent_window->connect("focus_entered", callable_mp(this, &Popup::_parent_focused));
+			parent_window->connect("tree_exited", callable_mp(this, &Popup::_deinitialize_visible_parents));
+		}
+	}
+}
+
+void Popup::_deinitialize_visible_parents() {
+	for (uint32_t i = 0; i < visible_parents.size(); ++i) {
+		visible_parents[i]->disconnect("focus_entered", callable_mp(this, &Popup::_parent_focused));
+		visible_parents[i]->disconnect("tree_exited", callable_mp(this, &Popup::_deinitialize_visible_parents));
+	}
+
+	visible_parents.clear();
 }
 
 void Popup::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible()) {
-				parent_visible = get_parent_visible_window();
-				if (parent_visible) {
-					parent_visible->connect("focus_entered", callable_mp(this, &Popup::_parent_focused));
-				}
+				_initialize_visible_parents();
 			} else {
-				if (parent_visible) {
-					parent_visible->disconnect("focus_entered", callable_mp(this, &Popup::_parent_focused));
-					parent_visible = nullptr;
-				}
-
+				_deinitialize_visible_parents();
 				emit_signal("popup_hide");
 			}
 
 		} break;
-		case NOTIFICATION_EXIT_TREE: {
-			if (parent_visible) {
-				parent_visible->disconnect("focus_entered", callable_mp(this, &Popup::_parent_focused));
-				parent_visible = nullptr;
+		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
+			if (has_focus()) {
+				popped_up = true;
 			}
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			_deinitialize_visible_parents();
 		} break;
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
 			_close_pressed();
-
+		} break;
+		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+			_close_pressed();
 		} break;
 	}
 }
 
-void Popup::_close_pressed() {
-	Window *parent_window = parent_visible;
-	if (parent_visible) {
-		parent_visible->disconnect("focus_entered", callable_mp(this, &Popup::_parent_focused));
-		parent_visible = nullptr;
+void Popup::_parent_focused() {
+	if (popped_up) {
+		_close_pressed();
 	}
+}
+
+void Popup::_close_pressed() {
+	popped_up = false;
+
+	_deinitialize_visible_parents();
 
 	call_deferred("hide");
 
 	emit_signal("cancelled");
-
-	if (parent_window) {
-		//parent_window->grab_focus();
-	}
 }
 
 void Popup::set_as_minsize() {
@@ -130,8 +146,6 @@ Rect2i Popup::_popup_adjust_rect() const {
 }
 
 Popup::Popup() {
-	parent_visible = nullptr;
-
 	set_wrap_controls(true);
 	set_visible(false);
 	set_transient(true);

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -33,12 +33,19 @@
 
 #include "scene/main/window.h"
 
+#include "core/local_vector.h"
+
 class Popup : public Window {
 	GDCLASS(Popup, Window);
 
-	Window *parent_visible;
+	LocalVector<Window *> visible_parents;
+	bool popped_up = false;
 
 	void _input_from_window(const Ref<InputEvent> &p_event);
+
+	void _initialize_visible_parents();
+	void _deinitialize_visible_parents();
+
 	void _parent_focused();
 
 protected:

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -247,6 +247,7 @@ void Window::_make_window() {
 	}
 
 	RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RS::VIEWPORT_UPDATE_WHEN_VISIBLE);
+	DisplayServer::get_singleton()->show_window(window_id);
 }
 
 void Window::_update_from_window() {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -246,6 +246,8 @@ void Window::_make_window() {
 		}
 	}
 
+	_update_window_callbacks();
+
 	RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RS::VIEWPORT_UPDATE_WHEN_VISIBLE);
 	DisplayServer::get_singleton()->show_window(window_id);
 }
@@ -379,7 +381,6 @@ void Window::set_visible(bool p_visible) {
 		}
 		if (p_visible && window_id == DisplayServer::INVALID_WINDOW_ID) {
 			_make_window();
-			_update_window_callbacks();
 		}
 	} else {
 		if (visible) {
@@ -738,7 +739,6 @@ void Window::_notification(int p_what) {
 				//create
 				if (visible) {
 					_make_window();
-					_update_window_callbacks();
 				}
 			}
 		}

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -186,6 +186,10 @@ DisplayServer::WindowID DisplayServer::create_sub_window(WindowMode p_mode, uint
 	ERR_FAIL_V_MSG(INVALID_WINDOW_ID, "Sub-windows not supported by this display server.");
 }
 
+void DisplayServer::show_window(WindowID p_id) {
+	ERR_FAIL_MSG("Sub-windows not supported by this display server.");
+}
+
 void DisplayServer::delete_sub_window(WindowID p_id) {
 	ERR_FAIL_MSG("Sub-windows not supported by this display server.");
 }

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -220,6 +220,7 @@ public:
 	};
 
 	virtual WindowID create_sub_window(WindowMode p_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i());
+	virtual void show_window(WindowID p_id);
 	virtual void delete_sub_window(WindowID p_id);
 
 	virtual WindowID get_window_at_screen_position(const Point2i &p_position) const = 0;


### PR DESCRIPTION
This PR fixes some issues with popups showing with a delay on linux, and also does a few general changes in how Popup nodes are handling focus changes.

Also fixes #37674, fixes #41578

**Re-apply "Fixes for windows in X11 tiling WMs"**
From PR #38727 by @Riteo which was reverted in #41373 because of regressions in Ubuntu with Gnome.
Regressions are now fixed with the other popup changes in this PR.

**Fix popup closed when an ancestor window is focused**
This is a general change for `Popup` which fixes issues that affect all platforms.

Previously, only the direct parent were taken into account.

Popups like contextual menus could stay open if an ancestor which is not a direct parent was focused.

Reproduction steps (any platform):
- Select a node in the scene tree
- Left click the node to start renaming
- Right click to open the copy/paste contextual menu
- Left click in the scene tree to deselect the node

Also closing popup when focusing out of the application, without waiting for the parent to get focus to do so.

**Fix menu popups delay and focus in X11 display server**
This is a fix for a linux specific issue with popups. Contextual menus, top bar menus and editable properties were showing with a delay due to some extra time to be initialized in the windows manager.

Now using `override_redirect` for all utility popups to prevent the WM from interfering with them, so we have more control over focus management and avoid a delay before they show up.

**Fix WINDOW_EVENT_FOCUS_IN for popups on Windows**
This is a fix for Windows, needed because of the changes in `Popup` in this PR.
On Windows, `WINDOW_EVENT_FOCUS_IN` was never sent by the display server for popups, because `WM_ACTIVATE` events are received during the call to `_update_window_style`, which happened before the callbacks were set.

This was causing some issues with the way `Popup` is now handling closing on parent focus.

Now `_update_window_style` is only called during show_window, after Window initialized callbacks.