### PR TITLE
Fix colour region end key seach and start key order

### DIFF
--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -229,18 +229,16 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting(int p_line) {
 
 				/* if we are in one find the end key */
 				if (in_region != -1) {
-					/* check there is enough room */
-					int chars_left = line_length - from;
-					int end_key_length = color_regions[in_region].end_key.length();
-					if (chars_left < end_key_length) {
-						continue;
-					}
-
 					/* search the line */
 					int region_end_index = -1;
-					const CharType *end_key = color_regions[in_region].start_key.c_str();
+					int end_key_length = color_regions[in_region].end_key.length();
+					const CharType *end_key = color_regions[in_region].end_key.c_str();
 					for (; from < line_length; from++) {
-						if (!is_a_symbol) {
+						if (line_length - from < end_key_length) {
+							break;
+						}
+
+						if (!is_symbol(str[from])) {
 							continue;
 						}
 
@@ -249,9 +247,10 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting(int p_line) {
 							continue;
 						}
 
+						region_end_index = from;
 						for (int k = 0; k < end_key_length; k++) {
-							if (end_key[k] == str[from + k]) {
-								region_end_index = from;
+							if (end_key[k] != str[from + k]) {
+								region_end_index = -1;
 								break;
 							}
 						}
@@ -265,7 +264,7 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting(int p_line) {
 					highlighter_info["color"] = color_regions[in_region].color;
 					color_map[j] = highlighter_info;
 
-					j = from;
+					j = from + (end_key_length - 1);
 					if (region_end_index == -1) {
 						color_region_cache[p_line] = in_region;
 					}
@@ -484,8 +483,12 @@ void CodeHighlighter::add_color_region(const String &p_start_key, const String &
 		}
 	}
 
+	int at = 0;
 	for (int i = 0; i < color_regions.size(); i++) {
 		ERR_FAIL_COND_MSG(color_regions[i].start_key == p_start_key, "color region with start key '" + p_start_key + "' already exists.");
+		if (p_start_key.length() < color_regions[i].start_key.length()) {
+			at++;
+		}
 	}
 
 	ColorRegion color_region;
@@ -493,7 +496,7 @@ void CodeHighlighter::add_color_region(const String &p_start_key, const String &
 	color_region.start_key = p_start_key;
 	color_region.end_key = p_end_key;
 	color_region.line_only = p_line_only || p_end_key == "";
-	color_regions.push_back(color_region);
+	color_regions.insert(at, color_region);
 	clear_highlighting_cache();
 }
 


### PR DESCRIPTION
Forces evaluation of longer start keys first i.e. will check `"""` before `"`.

Fixed end key search:
- using the start_key
- not checking the entire key
- not highlighting when the line is too short or highlighting too much if a non-symbol appear before the end key.
- not skipping the entire end key.

closes #41403