### PR TITLE
GitHub Actions: Prepend emoji to platform names for easy visual grepping

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -1,4 +1,4 @@
-name: Android Builds
+name: 🤖 Android Builds
 on: [push, pull_request]
 
 # Global Cache Settings

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -1,4 +1,4 @@
-name: iOS Builds
+name: 🍏 iOS Builds
 on: [push, pull_request]
 
 # Global Cache Settings

--- a/.github/workflows/javascript_builds.disabled
+++ b/.github/workflows/javascript_builds.disabled
@@ -1,4 +1,4 @@
-name: JavaScript Builds
+name: 🌐 JavaScript Builds
 on: [push, pull_request]
 
 # Global Cache Settings

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,4 +1,4 @@
-name: Linux Builds
+name: 🐧 Linux Builds
 on: [push, pull_request]
 
 # Global Cache Settings

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -1,4 +1,4 @@
-name: macOS Builds
+name: 🍎 macOS Builds
 on: [push, pull_request]
 
 # Global Cache Settings

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,4 +1,4 @@
-name: Static Checks
+name: 📊 Static Checks
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,4 +1,4 @@
-name: Windows Builds
+name: 🏁 Windows Builds
 on: [push, pull_request]
 
 # Global Cache Settings


### PR DESCRIPTION
I got the idea after opening a pull request on [Pixelorama](https://github.com/Orama-Interactive/Pixelorama):

![image](https://user-images.githubusercontent.com/180032/90965843-2301c000-e4cc-11ea-87fa-a2574ff1b1d6.png)

Since we have quite a lot of concurrent jobs, it might be worth trying to make them easier to visually distinguish.

You can see a preview of emoji in action in this very pull request :slightly_smiling_face: 
Note that emoji appearance will vary depending on your OS and system configuration. The Window emoji in particular is very recent (having been added in Unicode 13.0 in 2020) and may not appear everywhere.