### PR TITLE
Ensure node's area tree signals are disconnected when clearing monitoring, even if nodes are no longer in the tree.

### DIFF
--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -222,6 +222,9 @@ void Area3D::_clear_monitoring() {
 			}
 			//ERR_CONTINUE(!node);
 
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area3D::_body_enter_tree));
+			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area3D::_body_exit_tree));
+
 			if (!E->get().in_tree) {
 				continue;
 			}
@@ -231,9 +234,6 @@ void Area3D::_clear_monitoring() {
 			}
 
 			emit_signal(SceneStringNames::get_singleton()->body_exited, node);
-
-			node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area3D::_body_enter_tree));
-			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area3D::_body_exit_tree));
 		}
 	}
 
@@ -251,6 +251,9 @@ void Area3D::_clear_monitoring() {
 			}
 			//ERR_CONTINUE(!node);
 
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area3D::_area_enter_tree));
+			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area3D::_area_exit_tree));
+
 			if (!E->get().in_tree) {
 				continue;
 			}
@@ -260,9 +263,6 @@ void Area3D::_clear_monitoring() {
 			}
 
 			emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
-
-			node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area3D::_area_enter_tree));
-			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area3D::_area_exit_tree));
 		}
 	}
 }


### PR DESCRIPTION
When removing an `Area3D` from a `Space`, the signals that were added to `Nodes` that are in the `Area3D` should be removed. However, currently, if the `Nodes` are removed before the `Area3D`, the signals are not removed.

This patch ensures that the signals are removed whether or not the `Nodes` are in the `Tree`. This patch was applied to 2D in #7508.

Fixes #41397.
