### PR TITLE
[3.x] Ensure node's area tree signals are disconnected when clearing monitoring, even if nodes are no longer in the tree.

### DIFF
--- a/scene/3d/area.cpp
+++ b/scene/3d/area.cpp
@@ -207,7 +207,9 @@ void Area::_clear_monitoring() {
 			if (!node) { //node may have been deleted in previous frame or at other legiminate point
 				continue;
 			}
-			//ERR_CONTINUE(!node);
+
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
 
 			if (!E->get().in_tree) {
 				continue;
@@ -218,9 +220,6 @@ void Area::_clear_monitoring() {
 			}
 
 			emit_signal(SceneStringNames::get_singleton()->body_exited, node);
-
-			node->disconnect(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
-			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
 		}
 	}
 
@@ -236,7 +235,9 @@ void Area::_clear_monitoring() {
 			if (!node) { //node may have been deleted in previous frame or at other legiminate point
 				continue;
 			}
-			//ERR_CONTINUE(!node);
+
+			node->disconnect(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree);
+			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree);
 
 			if (!E->get().in_tree) {
 				continue;
@@ -247,9 +248,6 @@ void Area::_clear_monitoring() {
 			}
 
 			emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
-
-			node->disconnect(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree);
-			node->disconnect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree);
 		}
 	}
 }


### PR DESCRIPTION
3.2 version of #41469.