### PR TITLE
Deprecate the GIProbe Compress property due to known bugs

### DIFF
--- a/doc/classes/GIProbe.xml
+++ b/doc/classes/GIProbe.xml
@@ -36,7 +36,7 @@
 			[b]Note:[/b] [code]bias[/code] should usually be above 1.0 as that is the size of the voxels.
 		</member>
 		<member name="compress" type="bool" setter="set_compress" getter="is_compressed" default="false">
-			If [code]true[/code], the data for this [GIProbe] will be compressed. Compression saves space, but results in far worse visual quality.
+			[i]Deprecated.[/i] This property has been deprecated due to known bugs and no longer has any effect when enabled.
 		</member>
 		<member name="data" type="GIProbeData" setter="set_probe_data" getter="get_probe_data">
 			The [GIProbeData] resource that holds the data for this [GIProbe].

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -587,7 +587,6 @@ public:
 
 	uint32_t gi_probe_get_version(RID p_probe) { return 0; }
 
-	GIProbeCompression gi_probe_get_dynamic_data_get_preferred_compression() const { return GI_PROBE_UNCOMPRESSED; }
 	RID gi_probe_dynamic_data_create(int p_width, int p_height, int p_depth, GIProbeCompression p_compression) { return RID(); }
 	void gi_probe_dynamic_data_update(RID p_gi_probe_data, int p_depth_slice, int p_slice_count, int p_mipmap, const void *p_data) {}
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -4373,10 +4373,6 @@ uint32_t RasterizerStorageGLES2::gi_probe_get_version(RID p_probe) {
 	return 0;
 }
 
-RasterizerStorage::GIProbeCompression RasterizerStorageGLES2::gi_probe_get_dynamic_data_get_preferred_compression() const {
-	return GI_PROBE_UNCOMPRESSED;
-}
-
 RID RasterizerStorageGLES2::gi_probe_dynamic_data_create(int p_width, int p_height, int p_depth, GIProbeCompression p_compression) {
 	return RID();
 }

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1074,7 +1074,6 @@ public:
 
 	virtual uint32_t gi_probe_get_version(RID p_probe);
 
-	virtual GIProbeCompression gi_probe_get_dynamic_data_get_preferred_compression() const;
 	virtual RID gi_probe_dynamic_data_create(int p_width, int p_height, int p_depth, GIProbeCompression p_compression);
 	virtual void gi_probe_dynamic_data_update(RID p_gi_probe_data, int p_depth_slice, int p_slice_count, int p_mipmap, const void *p_data);
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -6106,6 +6106,10 @@ bool RasterizerStorageGLES3::gi_probe_is_interior(RID p_probe) const {
 
 void RasterizerStorageGLES3::gi_probe_set_compress(RID p_probe, bool p_enable) {
 
+	if (p_enable) {
+		WARN_DEPRECATED_MSG("GIProbe's Compress property has been deprecated due to known bugs and will be removed in Godot 4.0.");
+	}
+
 	GIProbe *gip = gi_probe_owner.getornull(p_probe);
 	ERR_FAIL_COND(!gip);
 
@@ -6159,14 +6163,6 @@ uint32_t RasterizerStorageGLES3::gi_probe_get_version(RID p_probe) {
 	return gip->version;
 }
 
-RasterizerStorage::GIProbeCompression RasterizerStorageGLES3::gi_probe_get_dynamic_data_get_preferred_compression() const {
-	if (config.s3tc_supported) {
-		return GI_PROBE_S3TC;
-	} else {
-		return GI_PROBE_UNCOMPRESSED;
-	}
-}
-
 RID RasterizerStorageGLES3::gi_probe_dynamic_data_create(int p_width, int p_height, int p_depth, GIProbeCompression p_compression) {
 
 	GIProbeData *gipd = memnew(GIProbeData);
@@ -6174,7 +6170,7 @@ RID RasterizerStorageGLES3::gi_probe_dynamic_data_create(int p_width, int p_heig
 	gipd->width = p_width;
 	gipd->height = p_height;
 	gipd->depth = p_depth;
-	gipd->compression = p_compression;
+	gipd->compression = GI_PROBE_UNCOMPRESSED;
 
 	glActiveTexture(GL_TEXTURE0);
 	glGenTextures(1, &gipd->tex_id);
@@ -6188,13 +6184,7 @@ RID RasterizerStorageGLES3::gi_probe_dynamic_data_create(int p_width, int p_heig
 	}
 
 	while (true) {
-
-		if (gipd->compression == GI_PROBE_S3TC) {
-			int size = p_width * p_height * p_depth;
-			glCompressedTexImage3D(GL_TEXTURE_3D, level, _EXT_COMPRESSED_RGBA_S3TC_DXT5_EXT, p_width, p_height, p_depth, 0, size, NULL);
-		} else {
-			glTexImage3D(GL_TEXTURE_3D, level, GL_RGBA8, p_width, p_height, p_depth, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-		}
+		glTexImage3D(GL_TEXTURE_3D, level, GL_RGBA8, p_width, p_height, p_depth, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
 		if (p_width <= min_size || p_height <= min_size || p_depth <= min_size)
 			break;
@@ -6241,12 +6231,7 @@ void RasterizerStorageGLES3::gi_probe_dynamic_data_update(RID p_gi_probe_data, i
 */
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_3D, gipd->tex_id);
-	if (gipd->compression == GI_PROBE_S3TC) {
-		int size = (gipd->width >> p_mipmap) * (gipd->height >> p_mipmap) * p_slice_count;
-		glCompressedTexSubImage3D(GL_TEXTURE_3D, p_mipmap, 0, 0, p_depth_slice, gipd->width >> p_mipmap, gipd->height >> p_mipmap, p_slice_count, _EXT_COMPRESSED_RGBA_S3TC_DXT5_EXT, size, p_data);
-	} else {
-		glTexSubImage3D(GL_TEXTURE_3D, p_mipmap, 0, 0, p_depth_slice, gipd->width >> p_mipmap, gipd->height >> p_mipmap, p_slice_count, GL_RGBA, GL_UNSIGNED_BYTE, p_data);
-	}
+	glTexSubImage3D(GL_TEXTURE_3D, p_mipmap, 0, 0, p_depth_slice, gipd->width >> p_mipmap, gipd->height >> p_mipmap, p_slice_count, GL_RGBA, GL_UNSIGNED_BYTE, p_data);
 	//glTexImage3D(GL_TEXTURE_3D,p_mipmap,GL_RGBA8,gipd->width>>p_mipmap,gipd->height>>p_mipmap,gipd->depth>>p_mipmap,0,GL_RGBA,GL_UNSIGNED_BYTE,p_data);
 	//glTexImage3D(GL_TEXTURE_3D,p_mipmap,GL_RGBA8,gipd->width>>p_mipmap,gipd->height>>p_mipmap,gipd->depth>>p_mipmap,0,GL_RGBA,GL_UNSIGNED_BYTE,data.ptr());
 }

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1110,7 +1110,6 @@ public:
 
 	mutable RID_Owner<GIProbeData> gi_probe_data_owner;
 
-	virtual GIProbeCompression gi_probe_get_dynamic_data_get_preferred_compression() const;
 	virtual RID gi_probe_dynamic_data_create(int p_width, int p_height, int p_depth, GIProbeCompression p_compression);
 	virtual void gi_probe_dynamic_data_update(RID p_gi_probe_data, int p_depth_slice, int p_slice_count, int p_mipmap, const void *p_data);
 

--- a/scene/3d/gi_probe.cpp
+++ b/scene/3d/gi_probe.cpp
@@ -327,6 +327,8 @@ void GIProbe::set_compress(bool p_enable) {
 	if (probe_data.is_valid()) {
 		probe_data->set_compress(p_enable);
 	}
+
+	update_configuration_warning();
 }
 
 bool GIProbe::is_compressed() const {
@@ -497,6 +499,14 @@ String GIProbe::get_configuration_warning() const {
 		}
 		warning += TTR("GIProbes are not supported by the GLES2 video driver.\nUse a BakedLightmap instead.");
 	}
+
+	if (is_compressed()) {
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("The GIProbe Compress property has been deprecated due to known bugs and no longer has any effect.\nTo remove this warning, disable the GIProbe's Compress property.");
+	}
+
 	return warning;
 }
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -480,7 +480,6 @@ public:
 		GI_PROBE_ETC2
 	};
 
-	virtual GIProbeCompression gi_probe_get_dynamic_data_get_preferred_compression() const = 0;
 	virtual RID gi_probe_dynamic_data_create(int p_width, int p_height, int p_depth, GIProbeCompression p_compression) = 0;
 	virtual void gi_probe_dynamic_data_update(RID p_gi_probe_data, int p_depth_slice, int p_slice_count, int p_mipmap, const void *p_data) = 0;
 

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -2377,9 +2377,7 @@ void VisualServerScene::_setup_gi_probe(Instance *p_instance) {
 
 	_gi_probe_fill_local_data(0, 0, 0, 0, 0, cells, header, ldw.ptr(), probe->dynamic.level_cell_lists.ptrw());
 
-	bool compress = VSG::storage->gi_probe_is_compressed(p_instance->base);
-
-	probe->dynamic.compression = compress ? VSG::storage->gi_probe_get_dynamic_data_get_preferred_compression() : RasterizerStorage::GI_PROBE_UNCOMPRESSED;
+	probe->dynamic.compression = RasterizerStorage::GI_PROBE_UNCOMPRESSED;
 
 	probe->dynamic.probe_data = VSG::storage->gi_probe_dynamic_data_create(header->width, header->height, header->depth, probe->dynamic.compression);
 


### PR DESCRIPTION
Follow-up to #39343, but without breaking compatibility.

This property introduced green artifacts in GI and didn't improve performance.

The new GIProbe in `master` no longer has a Compress property.

*Bugsquad edit: This closes #32427, closes #8705 and closes #18449.*