### PR TITLE
Fix regression from Skeleton3D Inspector redesign

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -164,7 +164,7 @@ void Skeleton3D::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::INT, prep + "parent", PROPERTY_HINT_RANGE, "-1," + itos(bones.size() - 1) + ",1", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "rest", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 		p_list->push_back(PropertyInfo(Variant::BOOL, prep + "enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
-		p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "pose", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+		p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "pose", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::ARRAY, prep + "bound_children", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
 	}
 }


### PR DESCRIPTION
It can be reproduced by reimporting many FBX files with a skeleton.

A change in commit f7fdc87 [Merged on May 27] mistakenly changed the Skeleton3D "`pose`" property from `PROPERTY_USAGE_EDITOR` to `PROPERTY_USAGE_NOEDITOR`.

Oddly, I cannot find a bug report documenting the breakage. Up to now, I had assumed that FBX support in Godot was incomplete, but upon finding out that the files were working in 3.2, I decided to bisect, landed upon this commit, and then bisected the individual lines until I stumbled upon this line causing the problem.

@fire The bugs about FBX support that I would expect to be relevant are filed against 3.2; and a patchset with FBX improvements (issue 39418) is also targeting the 3.2 branch, so I really have no data if anyone aside from me has encountered this problem on the master branch.

The relevant part of the original change is this:
```diff
diff --git a/scene/3d/skeleton_3d.cpp b/scene/3d/skeleton_3d.cpp
index 7516cf95b0..a09424fa17 100644
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -158,12 +158,12 @@ bool Skeleton3D::_get(const StringName &p_path, Variant &r_ret) const {
 void Skeleton3D::_get_property_list(List<PropertyInfo> *p_list) const {
        for (int i = 0; i < bones.size(); i++) {
                String prep = "bones/" + itos(i) + "/";
-               p_list->push_back(PropertyInfo(Variant::STRING, prep + "name"));
-               p_list->push_back(PropertyInfo(Variant::INT, prep + "parent", PROPERTY_HINT_RANGE, "-1," + itos(bones.size() - 1) + ",1"));
-               p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "rest"));
-               p_list->push_back(PropertyInfo(Variant::BOOL, prep + "enabled"));
-               p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "pose", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
-               p_list->push_back(PropertyInfo(Variant::ARRAY, prep + "bound_children"));
+               p_list->push_back(PropertyInfo(Variant::STRING, prep + "name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+               p_list->push_back(PropertyInfo(Variant::INT, prep + "parent", PROPERTY_HINT_RANGE, "-1," + itos(bones.size() - 1) + ",1", PROPERTY_USAGE_NOEDITOR));
+               p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "rest", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+               p_list->push_back(PropertyInfo(Variant::BOOL, prep + "enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+               p_list->push_back(PropertyInfo(Variant::TRANSFORM, prep + "pose", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
+               p_list->push_back(PropertyInfo(Variant::ARRAY, prep + "bound_children", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR));
        }
 }
```
Here I was able to ascertain the intent of the change was to change the unspecified `p_usage` (`PROPERTY_USAGE_DEFAULT`) to be `PROPERTY_USAGE_NOEDITOR`. However, the `pose` property was actually not default but was set to `PROPERTY_USAGE_EDITOR`, yet it was still changed to `PROPERTY_USAGE_NOEDITOR`.

Another thing I have not explained is why the issue only appears on clicking Reimport, and why it only affects FBX models and not glTF, despite the change being in core engine code.

Here are screenshots of the mesh I was testing with, though the model I happened to use is not redistributable, so here are screenshots:
Current master branch:
<img width="1003" alt="fbx_import_broken" src="https://user-images.githubusercontent.com/39946030/91047859-993b1b00-e5cf-11ea-8df2-7e521341eb07.png">
After this patch (looks the same as 3.2):
<img width="1003" alt="fbx_import_fixed" src="https://user-images.githubusercontent.com/39946030/91047868-9b9d7500-e5cf-11ea-9d35-6c902de6c4be.png">