### PR TITLE
Fix regression in FBX import caused by Skeleton3D

### DIFF
--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -441,7 +441,6 @@ EditorSceneImporterAssimp::_generate_scene(const String &p_path, aiScene *scene,
 				Transform pform = AssimpUtils::assimp_matrix_transform(bone->mNode->mTransformation);
 				skeleton->add_bone(bone_name);
 				skeleton->set_bone_rest(boneIdx, pform);
-				skeleton->set_bone_pose(boneIdx, pform);
 
 				if (parent_node != nullptr) {
 					int parent_bone_id = skeleton->find_bone(AssimpUtils::get_anim_string_from_assimp(parent_node->mName));
@@ -612,7 +611,7 @@ void EditorSceneImporterAssimp::_insert_animation_track(ImportState &scene, cons
 				xform.basis.set_quat_scale(rot, scale);
 				xform.origin = pos;
 
-				xform = skeleton->get_bone_pose(skeleton_bone).inverse() * xform;
+				xform = skeleton->get_bone_rest(skeleton_bone).inverse() * xform;
 
 				rot = xform.basis.get_rotation_quat();
 				rot.normalize();


### PR DESCRIPTION
A change in commit f7fdc87 changed the Skeleton3D "`pose`" property from `PROPERTY_USAGE_EDITOR` to `PROPERTY_USAGE_NOEDITOR`.
This should have had no effect, however it turns out assimp was assigning to the pose property.

This change adjusts the FBX import to only `get_bone_rest`/`set_bone_rest`, not `set_bone_pose`

This PR supersedes #41490 - In other words, rather than *undoing* the cause of the regression, this attempts to fix the *root cause* in the old assimp FBX importer.

I have tested this on a poorly hand animated FBX, and can confirm that the second part of this patch appears to fix animation issues.