### PR TITLE
CSGPolygon Add interpolation (Scaling/Moving) in mode Path

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2578,29 +2578,29 @@ void CSGPolygon3D::set_path_polygon2(const Vector<Vector2> &p_path_polygon2) {
 	update_gizmo();
 }
 
-Vector<Vector2> CSGPolygon::get_path_polygon2() const {
+Vector<Vector2> CSGPolygon3D::get_path_polygon2() const {
 	return path_polygon2;
 }
 
 void CSGPolygon3D::set_path_curve(const Ref<Curve> &p_path_curve) {
 	// Cleanup previous connection if any
 	if (path_curve.is_valid()) {
-		path_curve->disconnect(CoreStringNames::get_singleton()->changed, this, "_path_curve_changed");
+		path_curve->disconnect("path_curve_changed", callable_mp(this, &CSGPolygon3D::_path_curve_changed));
 	}
 	path_curve = p_path_curve;
 		// Connect to the curve so the line will update when it is changed
 	if (path_curve.is_valid()) {
-		path_curve->connect(CoreStringNames::get_singleton()->changed, this, "_path_curve_changed");
+		path_curve->connect("path_curve_changed", callable_mp(this, &CSGPolygon3D::_path_curve_changed));
 	}
 	_make_dirty();
 	update_gizmo();
 }
 
-Ref<Curve> CSGPolygon::get_path_curve() const {
+Ref<Curve> CSGPolygon3D::get_path_curve() const {
 	return path_curve;
 }
 
-void CSGPolygon::_path_curve_changed() {
+void CSGPolygon3D::_path_curve_changed() {
 	if (path_interpolate) {
 		_make_dirty();
 		update_gizmo();

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2415,7 +2415,7 @@ void CSGPolygon3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "smooth_faces"), "set_smooth_faces", "get_smooth_faces");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "StandardMaterial3D,ShaderMaterial"), "set_material", "get_material");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "path_interpolate"), "set_path_interpolate", "get_path_interpolate");
-	ADD_PROPERTY(PropertyInfo(Variant::POOL_VECTOR2_ARRAY, "path_polygon2"), "set_path_polygon2", "get_path_polygon2");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "path_polygon2"), "set_path_polygon2", "get_path_polygon2");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "path_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_path_curve", "get_path_curve");
 
 	BIND_ENUM_CONSTANT(MODE_DEPTH);

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2057,35 +2057,34 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 					if (!path_curve.is_null() && path_polygon2.size() == final_polygon.size()) {
 
 						final_polygon2 = path_polygon2;
-						if (Triangulate::get_area(final_polygon2) > 0) { 
+						if (Triangulate::get_area(final_polygon2) > 0) {
 							final_polygon2.invert(); 
 						}
 
-						float a = 2.0;
-						for (int i = 0; i < final_polygon.size(); i++) { // Check if both polygons arrays are egal
+						float p = 2.0;
+						for (int i = 0; i < final_polygon.size(); i++) {
 							if (median_polygon[i] != final_polygon2[i]) {
-								a = 1.0;
+								p = 1.0;
 								break;
 							}
 						}
-						for (int i = 0; i < final_polygon.size(); i++) { // active scaling if both array are egal and precalculate part of interpolation
-							modified_polygon.push_back(Vector2(final_polygon2[i].x * a - median_polygon[i].x, final_polygon2[i].y * a - median_polygon[i].y));
+						for (int i = 0; i < final_polygon.size(); i++) {
+							modified_polygon.push_back(Vector2(final_polygon2[i].x * p - median_polygon[i].x, final_polygon2[i].y * p - median_polygon[i].y));
 						}
 
-						curve_pos2 = path_curve->interpolate(0); 
+						curve_pos2 = path_curve->interpolate(0);
 
 						if (path_joined && curve_pos2 != path_curve->interpolate(1.0)) {
 
-							interpolate_curve = path_curve->duplicate(); // duplication because I need modify the curve for path_joined
-							int a = path_curve->get_point_count() - 1;
+							interpolate_curve = path_curve->duplicate();
 
-							if (a > 0 && path_curve->get_point_position(a).x == 1.0) {
+							if (path_curve->get_point_count() > 1 && path_curve->get_point_position(path_curve->get_point_count() - 1).x == 1.0) {
 								interpolate_curve->add_point(Vector2(1.0 - CMP_EPSILON, interpolate_curve->interpolate(1.0)));
 							}
 							interpolate_curve->add_point(Vector2(1.0, curve_pos2));
 
 						} else {
-							interpolate_curve = path_curve; // if no path_joined, the curve is not duplicated
+							interpolate_curve = path_curve;
 						}
 
 					} else {
@@ -2093,7 +2092,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 
 						if (path_curve.is_null()) {
 							WARN_PRINT("path_curve is null, interpolation not effective");
-						} 
+						}
 						if (path_polygon2.size() != final_polygon.size())
 						 {
 							WARN_PRINT("path_polygon2 size is different of polygon size, interpolation not effective");
@@ -2142,8 +2141,8 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 							curve_pos = curve_pos2;
 							curve_pos2 = interpolate_curve->interpolate((float) i / (float) splits);
 
-							for (int j = 0; j < final_polygon.size(); j++) { // interpolation : A + (B - A) * t
-
+							for (int j = 0; j < final_polygon.size(); j++) { 
+								// A + (B - A) * t
 								final_polygon.set(j, Vector2(
 									median_polygon[j].x + modified_polygon[j].x * curve_pos, 
 									median_polygon[j].y + modified_polygon[j].y * curve_pos
@@ -2206,8 +2205,8 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 						}
 					}
 
-					else if (!path_joined) { // i == 0
-					
+					else if (!path_joined) {
+						// i == 0
 						if (do_interpolation) {						
 							Vector2 p;
 							for (int j = 0; j < final_polygon.size(); j++) {
@@ -2218,7 +2217,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 								));
 								   p = final_polygon[j];
 
-								if (j == 0) { // need to duplicate code to set up var with the interpolation
+								if (j == 0) {
 									final_polygon_min = p;
 									final_polygon_max = final_polygon_min;
 								} else {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -29,9 +29,9 @@
 /*************************************************************************/
 
 #include "csg_shape.h"
+#include "core/core_string_names.h"
 #include "core/math/geometry_2d.h"
 #include "scene/3d/path_3d.h"
-#include "core/core_string_names.h"
 
 void CSGShape3D::set_use_collision(bool p_enable) {
 	if (use_collision == p_enable) {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2230,7 +2230,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 								}
 							}
 							final_polygon_size = final_polygon_max - final_polygon_min;
-							triangles = Geometry::triangulate_polygon(final_polygon);
+							triangles = Geometry2D::triangulate_polygon(final_polygon);
 						}
 
 						for (int j = 0; j < triangles.size(); j += 3) {
@@ -2268,7 +2268,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 								}
 							}
 							final_polygon_size = final_polygon_max - final_polygon_min;
-							triangles = Geometry::triangulate_polygon(final_polygon2);
+							triangles = Geometry2D::triangulate_polygon(final_polygon2);
 						}
 
 						for (int j = 0; j < triangles.size(); j += 3) {
@@ -2387,16 +2387,16 @@ void CSGPolygon3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_smooth_faces", "smooth_faces"), &CSGPolygon3D::set_smooth_faces);
 	ClassDB::bind_method(D_METHOD("get_smooth_faces"), &CSGPolygon3D::get_smooth_faces);
 
-	ClassDB::bind_method(D_METHOD("set_path_interpolate", "path_interpolate"), &CSGPolygon::set_path_interpolate);
-	ClassDB::bind_method(D_METHOD("get_path_interpolate"), &CSGPolygon::get_path_interpolate);
+	ClassDB::bind_method(D_METHOD("set_path_interpolate", "path_interpolate"), &CSGPolygon3D::set_path_interpolate);
+	ClassDB::bind_method(D_METHOD("get_path_interpolate"), &CSGPolygon3D::get_path_interpolate);
 
-	ClassDB::bind_method(D_METHOD("set_path_polygon2", "path_polygon2"), &CSGPolygon::set_path_polygon2);
-	ClassDB::bind_method(D_METHOD("get_path_polygon2"), &CSGPolygon::get_path_polygon2);
+	ClassDB::bind_method(D_METHOD("set_path_polygon2", "path_polygon2"), &CSGPolygon3D::set_path_polygon2);
+	ClassDB::bind_method(D_METHOD("get_path_polygon2"), &CSGPolygon3D::get_path_polygon2);
 
-	ClassDB::bind_method(D_METHOD("set_path_curve", "path_curve"), &CSGPolygon::set_path_curve);
-	ClassDB::bind_method(D_METHOD("get_path_curve"), &CSGPolygon::get_path_curve);
+	ClassDB::bind_method(D_METHOD("set_path_curve", "path_curve"), &CSGPolygon3D::set_path_curve);
+	ClassDB::bind_method(D_METHOD("get_path_curve"), &CSGPolygon3D::get_path_curve);
 
-	ClassDB::bind_method(D_METHOD("_path_curve_changed"), &CSGPolygon::_path_curve_changed);
+	ClassDB::bind_method(D_METHOD("_path_curve_changed"), &CSGPolygon3D::_path_curve_changed);
 
 	ClassDB::bind_method(D_METHOD("_is_editable_3d_polygon"), &CSGPolygon3D::_is_editable_3d_polygon);
 	ClassDB::bind_method(D_METHOD("_has_editable_3d_polygon_no_depth"), &CSGPolygon3D::_has_editable_3d_polygon_no_depth);
@@ -2559,7 +2559,7 @@ Ref<Material> CSGPolygon3D::get_material() const {
 	return material;
 }
 
-void CSGPolygon::set_path_interpolate(const bool p_path_interpolate) {
+void CSGPolygon3D::set_path_interpolate(const bool p_path_interpolate) {
 	path_interpolate = p_path_interpolate;
 	if (path_polygon2.empty()) {
 		path_polygon2 = polygon;
@@ -2568,11 +2568,11 @@ void CSGPolygon::set_path_interpolate(const bool p_path_interpolate) {
 	update_gizmo();
 }
 
-bool CSGPolygon::get_path_interpolate() const {
+bool CSGPolygon3D::get_path_interpolate() const {
 	return path_interpolate;
 }
 
-void CSGPolygon::set_path_polygon2(const Vector<Vector2> &p_path_polygon2) {
+void CSGPolygon3D::set_path_polygon2(const Vector<Vector2> &p_path_polygon2) {
 	path_polygon2 = p_path_polygon2;
 	_make_dirty();
 	update_gizmo();
@@ -2582,7 +2582,7 @@ Vector<Vector2> CSGPolygon::get_path_polygon2() const {
 	return path_polygon2;
 }
 
-void CSGPolygon::set_path_curve(const Ref<Curve> &p_path_curve) {
+void CSGPolygon3D::set_path_curve(const Ref<Curve> &p_path_curve) {
 	// Cleanup previous connection if any
 	if (path_curve.is_valid()) {
 		path_curve->disconnect(CoreStringNames::get_singleton()->changed, this, "_path_curve_changed");

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2055,7 +2055,6 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 
 				if (do_interpolation) {
 					if (!path_curve.is_null() && path_polygon2.size() == final_polygon.size()) {
-
 						final_polygon2 = path_polygon2;
 						if (Triangulate::get_area(final_polygon2) > 0) {
 							final_polygon2.invert();
@@ -2075,7 +2074,6 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 						curve_pos2 = path_curve->interpolate(0);
 
 						if (path_joined && curve_pos2 != path_curve->interpolate(1.0)) {
-
 							interpolate_curve = path_curve->duplicate();
 
 							if (path_curve->get_point_count() > 1 && path_curve->get_point_position(path_curve->get_point_count() - 1).x == 1.0) {
@@ -2093,8 +2091,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 						if (path_curve.is_null()) {
 							WARN_PRINT("path_curve is null, interpolation not effective");
 						}
-						if (path_polygon2.size() != final_polygon.size())
-						 {
+						if (path_polygon2.size() != final_polygon.size()) {
 							WARN_PRINT("path_polygon2 size is different of polygon size, interpolation not effective");
 						}
 					}
@@ -2139,18 +2136,12 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 
 						if (do_interpolation) {
 							curve_pos = curve_pos2;
-							curve_pos2 = interpolate_curve->interpolate((float) i / (float) splits);
+							curve_pos2 = interpolate_curve->interpolate((float)i / (float) splits);
 
 							for (int j = 0; j < final_polygon.size(); j++) {
 								// A + (B - A) * t
-								final_polygon.set(j, Vector2(
-									median_polygon[j].x + modified_polygon[j].x * curve_pos,
-									median_polygon[j].y + modified_polygon[j].y * curve_pos
-								));
-								final_polygon2.set(j, Vector2(
-									median_polygon[j].x + modified_polygon[j].x * curve_pos2,
-									median_polygon[j].y + modified_polygon[j].y * curve_pos2
-								));
+								final_polygon.set(j, Vector2(median_polygon[j].x + modified_polygon[j].x * curve_pos, median_polygon[j].y + modified_polygon[j].y * curve_pos));
+								final_polygon2.set(j, Vector2(median_polygon[j].x + modified_polygon[j].x * curve_pos2, median_polygon[j].y + modified_polygon[j].y * curve_pos2));
 							}
 						}
 
@@ -2203,18 +2194,13 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 
 							face++;
 						}
-					}
-					else if (!path_joined) {
+					} else if (!path_joined) {
 						// i == 0
 						if (do_interpolation) {
 							Vector2 p;
 							for (int j = 0; j < final_polygon.size(); j++) {
-
-								final_polygon.set(j, Vector2(
-									median_polygon[j].x + modified_polygon[j].x * curve_pos2,
-									median_polygon[j].y + modified_polygon[j].y * curve_pos2
-								));
-								   p = final_polygon[j];
+								final_polygon.set(j, Vector2(median_polygon[j].x + modified_polygon[j].x * curve_pos2, median_polygon[j].y + modified_polygon[j].y * curve_pos2));
+								p = final_polygon[j];
 
 								if (j == 0) {
 									final_polygon_min = p;
@@ -2224,7 +2210,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 										final_polygon_min.x = p.x;
 									}
 									if (p.y < final_polygon_min.y) {
-										 final_polygon_min.y = p.y;
+										final_polygon_min.y = p.y;
 									}
 									if (p.x > final_polygon_max.x) {
 										final_polygon_max.x = p.x;
@@ -2255,7 +2241,6 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 					}
 
 					if (i == splits && !path_joined) {
-
 						if (do_interpolation) {
 							Vector2 p;
 							for (int j = 0; j < final_polygon2.size(); j++) {
@@ -2269,7 +2254,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 										final_polygon_min.x = p.x;
 									}
 									if (p.y < final_polygon_min.y) {
-										 final_polygon_min.y = p.y;
+										final_polygon_min.y = p.y;
 									}
 									if (p.x > final_polygon_max.x) {
 										final_polygon_max.x = p.x;
@@ -2600,7 +2585,7 @@ void CSGPolygon3D::set_path_curve(const Ref<Curve> &p_path_curve) {
 		path_curve->disconnect("path_curve_changed", callable_mp(this, &CSGPolygon3D::_path_curve_changed));
 	}
 	path_curve = p_path_curve;
-		// Connect to the curve so the line will update when it is changed
+	// Connect to the curve so the line will update when it is changed
 	if (path_curve.is_valid()) {
 		path_curve->connect("path_curve_changed", callable_mp(this, &CSGPolygon3D::_path_curve_changed));
 	}

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2136,7 +2136,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 
 						if (do_interpolation) {
 							curve_pos = curve_pos2;
-							curve_pos2 = interpolate_curve->interpolate((float)i / (float) splits);
+							curve_pos2 = interpolate_curve->interpolate((float)i / (float)splits);
 
 							for (int j = 0; j < final_polygon.size(); j++) {
 								// A + (B - A) * t
@@ -2244,7 +2244,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 						if (do_interpolation) {
 							Vector2 p;
 							for (int j = 0; j < final_polygon2.size(); j++) {
-   								p = final_polygon2[j];
+								p = final_polygon2[j];
 
 								if (j == 0) {
 									final_polygon_min = p;

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2239,7 +2239,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 							face++;
 						}
 					}
-					
+
 					if (i == splits && !path_joined) {
 						if (do_interpolation) {
 							Vector2 p;

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2226,7 +2226,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 									if (p.y < final_polygon_min.y) {
 										 final_polygon_min.y = p.y;
 									}
-									if (p.x > final_polygon_max.x) { 
+									if (p.x > final_polygon_max.x) {
 										final_polygon_max.x = p.x;
 									}
 									if (p.y > final_polygon_max.y) {
@@ -2256,7 +2256,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 
 					if (i == splits && !path_joined) {
 
-						if (do_interpolation) { 
+						if (do_interpolation) {
 							Vector2 p;
 							for (int j = 0; j < final_polygon2.size(); j++) {
    								p = final_polygon2[j];
@@ -2271,7 +2271,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 									if (p.y < final_polygon_min.y) {
 										 final_polygon_min.y = p.y;
 									}
-									if (p.x > final_polygon_max.x) { 
+									if (p.x > final_polygon_max.x) {
 										final_polygon_max.x = p.x;
 									}
 									if (p.y > final_polygon_max.y) {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2239,7 +2239,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 							face++;
 						}
 					}
-
+					
 					if (i == splits && !path_joined) {
 						if (do_interpolation) {
 							Vector2 p;

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2058,7 +2058,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 
 						final_polygon2 = path_polygon2;
 						if (Triangulate::get_area(final_polygon2) > 0) {
-							final_polygon2.invert(); 
+							final_polygon2.invert();
 						}
 
 						float p = 2.0;
@@ -2141,14 +2141,14 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 							curve_pos = curve_pos2;
 							curve_pos2 = interpolate_curve->interpolate((float) i / (float) splits);
 
-							for (int j = 0; j < final_polygon.size(); j++) { 
+							for (int j = 0; j < final_polygon.size(); j++) {
 								// A + (B - A) * t
 								final_polygon.set(j, Vector2(
-									median_polygon[j].x + modified_polygon[j].x * curve_pos, 
+									median_polygon[j].x + modified_polygon[j].x * curve_pos,
 									median_polygon[j].y + modified_polygon[j].y * curve_pos
 								));
-								final_polygon2.set(j, Vector2( 
-									median_polygon[j].x + modified_polygon[j].x * curve_pos2, 
+								final_polygon2.set(j, Vector2(
+									median_polygon[j].x + modified_polygon[j].x * curve_pos2,
 									median_polygon[j].y + modified_polygon[j].y * curve_pos2
 								));
 							}
@@ -2204,15 +2204,14 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 							face++;
 						}
 					}
-
 					else if (!path_joined) {
 						// i == 0
-						if (do_interpolation) {						
+						if (do_interpolation) {
 							Vector2 p;
 							for (int j = 0; j < final_polygon.size(); j++) {
 
-								final_polygon.set(j, Vector2( 
-									median_polygon[j].x + modified_polygon[j].x * curve_pos2, 
+								final_polygon.set(j, Vector2(
+									median_polygon[j].x + modified_polygon[j].x * curve_pos2,
 									median_polygon[j].y + modified_polygon[j].y * curve_pos2
 								));
 								   p = final_polygon[j];
@@ -2221,11 +2220,18 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 									final_polygon_min = p;
 									final_polygon_max = final_polygon_min;
 								} else {
-									if (p.x < final_polygon_min.x) final_polygon_min.x = p.x;
-									if (p.y < final_polygon_min.y) final_polygon_min.y = p.y;
-
-									if (p.x > final_polygon_max.x) final_polygon_max.x = p.x;
-									if (p.y > final_polygon_max.y) final_polygon_max.y = p.y;
+									if (p.x < final_polygon_min.x) {
+										final_polygon_min.x = p.x;
+									}
+									if (p.y < final_polygon_min.y) {
+										 final_polygon_min.y = p.y;
+									}
+									if (p.x > final_polygon_max.x) { 
+										final_polygon_max.x = p.x;
+									}
+									if (p.y > final_polygon_max.y) {
+										final_polygon_max.y = p.y;
+									}
 								}
 							}
 							final_polygon_size = final_polygon_max - final_polygon_min;
@@ -2259,11 +2265,18 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 									final_polygon_min = p;
 									final_polygon_max = final_polygon_min;
 								} else {
-									if (p.x < final_polygon_min.x) final_polygon_min.x = p.x;
-									if (p.y < final_polygon_min.y) final_polygon_min.y = p.y;
-
-									if (p.x > final_polygon_max.x) final_polygon_max.x = p.x;
-									if (p.y > final_polygon_max.y) final_polygon_max.y = p.y;
+									if (p.x < final_polygon_min.x) {
+										final_polygon_min.x = p.x;
+									}
+									if (p.y < final_polygon_min.y) {
+										 final_polygon_min.y = p.y;
+									}
+									if (p.x > final_polygon_max.x) { 
+										final_polygon_max.x = p.x;
+									}
+									if (p.y > final_polygon_max.y) {
+										final_polygon_max.y = p.y;
+									}
 								}
 							}
 							final_polygon_size = final_polygon_max - final_polygon_min;

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -375,11 +375,16 @@ private:
 	bool path_continuous_u;
 	bool path_joined;
 
+	bool path_interpolate;
+	Vector<Vector2> path_polygon2;
+	Ref<Curve> path_curve;
+
 	bool _is_editable_3d_polygon() const;
 	bool _has_editable_3d_polygon_no_depth() const;
 
 	void _path_changed();
 	void _path_exited();
+	void _path_curve_changed();
 
 protected:
 	static void _bind_methods();
@@ -425,6 +430,15 @@ public:
 
 	void set_material(const Ref<Material> &p_material);
 	Ref<Material> get_material() const;
+
+	void set_path_interpolate(bool p_path_interpolate);
+	bool get_path_interpolate() const;
+
+	void set_path_polygon2(const Vector<Vector2> &p_path_polygon2);
+	Vector<Vector2> get_path_polygon2() const;
+
+	void set_path_curve(const Ref<Curve> &p_path_curve);
+	Ref<Curve> get_path_curve() const;
 
 	CSGPolygon3D();
 };


### PR DESCRIPTION
This new feature from my proposal:
Add Scaling/Modify a CSG Polygon in PathFollow when PathNode is drawing the mesh
[https://github.com/godotengine/godot-proposals/issues/1062](https://github.com/godotengine/godot-proposals/issues/1062)
- No conflict with anything else.
- No performance drop and no difference when is not active.
- path_joined is working with a manipulation of the path_curve.

I did't compile from the master. I had issues to compile Godot 4. But on 3.2.3.rc1 is running perfectly.

The interpolation work using a Curve who interpolate between two polygon array. If both polygons are equal, a single scaling mode is active.

If the path_polygon2 is empty, when you active the interpolation bool, you make a copy of the first polygon to the second. Is a way to reset or help you for editing the polygons.

Enjoy ! 

