### PR TITLE
Revert "Check if global class file still exists before registering it"

### DIFF
--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -33,8 +33,6 @@
 #include "core/core_string_names.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
-#include "core/io/resource_loader.h"
-#include "core/os/file_access.h"
 #include "core/project_settings.h"
 
 #include <stdint.h>
@@ -164,7 +162,7 @@ void ScriptServer::init_languages() {
 
 			for (int i = 0; i < script_classes.size(); i++) {
 				Dictionary c = script_classes[i];
-				if (!c.has("class") || !c.has("language") || !c.has("path") || !FileAccess::exists(ResourceLoader::path_remap(c["path"])) || !c.has("base")) {
+				if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base")) {
 					continue;
 				}
 				add_global_class(c["class"], c["base"], c["language"], c["path"]);


### PR DESCRIPTION
And revert follow-up regression fix "Remap script path when registering class."

After the regression fix, the original issue is valid again so it's better
to go back to the previous state.
See https://github.com/godotengine/godot/issues/40584#issuecomment-679470085

This reverts commits e264ae20d2a828201a50868b3af334a3f8c8a37c and fceb64827ea50364f34f4ba9db3910602d1911bf.