### PR TITLE
Made get_child support negative indexes

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -213,6 +213,7 @@
 			</argument>
 			<description>
 				Returns a child node by its index (see [method get_child_count]). This method is often used for iterating all children of a node.
+				Negative indices access the children from the last one.
 				To access a child node via its name, use [method get_node].
 			</description>
 		</method>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1327,6 +1327,9 @@ int Node::get_child_count() const {
 }
 
 Node *Node::get_child(int p_index) const {
+	if (p_index < 0) {
+		p_index += data.children.size();
+	}
 	ERR_FAIL_INDEX_V(p_index, data.children.size(), nullptr);
 
 	return data.children[p_index];


### PR DESCRIPTION
PR for https://github.com/godotengine/godot-proposals/issues/1392. get_child was adapted to support negative indexes. Negative indices go between -1 to -(number of children). Not much to say.

*Bugsquad edit:* Closes godotengine/godot-proposals#1392.