### PR TITLE
Mention listener node in AudioStreamPlayer3D description

### DIFF
--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Plays a sound effect with directed sound effects, dampens with distance if needed, generates effect of hearable position in space.
+		By default, audio is heard from the camera position. This can be changed by adding a [Listener3D] node to the scene and enabling it by calling [method Listener3D.make_current] on it.
 	</description>
 	<tutorials>
 		<link>https://docs.godotengine.org/en/latest/tutorials/audio/audio_streams.html</link>


### PR DESCRIPTION
Mentions that by default audio is heard from the camera position, and that this can be changed with a Listener node. Closes https://github.com/godotengine/godot-docs/issues/3851