### PR TITLE
Add translators comments extraction for Editor

### DIFF
--- a/editor/translations/extract.py
+++ b/editor/translations/extract.py
@@ -49,27 +49,27 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/godotengine/godot\\n"
 "MIME-Version: 1.0\\n"
 "Content-Type: text/plain; charset=UTF-8\\n"
-"Content-Transfer-Encoding: 8-bit\\n"
+"Content-Transfer-Encoding: 8-bit\\n"\n
 """
 
 
 def _write_message(msgctx, msg, msg_plural, location):
     global main_po
-    main_po += "\n#: " + location + "\n"
+    main_po += "#: " + location + "\n"
     if msgctx != "":
         main_po += 'msgctxt "' + msgctx + '"\n'
     main_po += 'msgid "' + msg + '"\n'
     if msg_plural != "":
         main_po += 'msgid_plural "' + msg_plural + '"\n'
         main_po += 'msgstr[0] ""\n'
-        main_po += 'msgstr[1] ""\n'
+        main_po += 'msgstr[1] ""\n\n'
     else:
-        main_po += 'msgstr ""\n'
+        main_po += 'msgstr ""\n\n'
 
 
 def _add_additional_location(msgctx, msg, location):
     global main_po
-    # Add additional location to previous occurrence
+    # Add additional location to previous occurrence.
     msg_pos = -1
     if msgctx != "":
         msg_pos = main_po.find('\nmsgctxt "' + msgctx + '"\nmsgid "' + msg + '"')
@@ -81,18 +81,138 @@ def _add_additional_location(msgctx, msg, location):
     main_po = main_po[:msg_pos] + " " + location + main_po[msg_pos:]
 
 
+def _write_translator_comment(msgctx, msg, translator_comment):
+    if translator_comment == "":
+        return
+
+    global main_po
+    msg_pos = -1
+    if msgctx != "":
+        msg_pos = main_po.find('\nmsgctxt "' + msgctx + '"\nmsgid "' + msg + '"')
+    else:
+        msg_pos = main_po.find('\nmsgid "' + msg + '"')
+
+    # If it's a new message, just append comment to the end of PO file.
+    if msg_pos == -1:
+        main_po += _format_translator_comment(translator_comment, True)
+        return
+
+    # Find position just before location. Translator comment will be added there.
+    translator_comment_pos = main_po.rfind("\n\n#", 0, msg_pos) + 2
+    if translator_comment_pos - 2 == -1:
+        print("translator_comment_pos not found")
+        return
+
+    # Check if a previous translator comment already exists. If so, merge them together.
+    if main_po.find("TRANSLATORS:", translator_comment_pos, msg_pos) != -1:
+        translator_comment_pos = main_po.find("\n#:", translator_comment_pos, msg_pos) + 1
+        if translator_comment_pos == 0:
+            print('translator_comment_pos after "TRANSLATORS:" not found')
+            return
+        main_po = (
+            main_po[:translator_comment_pos]
+            + _format_translator_comment(translator_comment, False)
+            + main_po[translator_comment_pos:]
+        )
+        return
+
+    main_po = (
+        main_po[:translator_comment_pos]
+        + _format_translator_comment(translator_comment, True)
+        + main_po[translator_comment_pos:]
+    )
+
+
+def _format_translator_comment(comment, new):
+    if not comment:
+        return ""
+
+    comment_lines = comment.split("\n")
+
+    formatted_comment = ""
+    if not new:
+        for comment in comment_lines:
+            formatted_comment += "#. " + comment.strip() + "\n"
+        return formatted_comment
+
+    formatted_comment = "#. TRANSLATORS: "
+    for i in range(len(comment_lines)):
+        if i == 0:
+            formatted_comment += comment_lines[i].strip() + "\n"
+        else:
+            formatted_comment += "#. " + comment_lines[i].strip() + "\n"
+    return formatted_comment
+
+
+def _is_block_translator_comment(translator_line):
+    line = translator_line.strip()
+    if line.find("//") == 0:
+        return False
+    else:
+        return True
+
+
+def _extract_translator_comment(line, is_block_translator_comment):
+    line = line.strip()
+    reached_end = False
+    extracted_comment = ""
+
+    start = line.find("TRANSLATORS:")
+    if start == -1:
+        start = 0
+    else:
+        start += len("TRANSLATORS:")
+
+    if is_block_translator_comment:
+        # If '*/' is found, then it's the end.
+        if line.rfind("*/") != -1:
+            extracted_comment = line[start : line.rfind("*/")]
+            reached_end = True
+        else:
+            extracted_comment = line[start:]
+    else:
+        # If beginning is not '//', then it's the end.
+        if line.find("//") != 0:
+            reached_end = True
+        else:
+            start = 2 if start == 0 else start
+            extracted_comment = line[start:]
+
+    return (not reached_end, extracted_comment)
+
+
 def process_file(f, fname):
 
     global main_po, unique_str, unique_loc
 
+    patterns = ['RTR("', 'TTR("', 'TTRC("', 'TTRN("', 'RTRN("']
+
     l = f.readline()
     lc = 1
+    reading_translator_comment = False
+    is_block_translator_comment = False
+    translator_comment = ""
+
     while l:
 
-        patterns = ['RTR("', 'TTR("', 'TTRC("', 'TTRN("', 'RTRN("']
+        # Detect translator comments.
+        if not reading_translator_comment and l.find("TRANSLATORS:") != -1:
+            reading_translator_comment = True
+            is_block_translator_comment = _is_block_translator_comment(l)
+            translator_comment = ""
+
+        # Gather translator comments. It will be gathered for the next translation function.
+        if reading_translator_comment:
+            reading_translator_comment, extracted_comment = _extract_translator_comment(l, is_block_translator_comment)
+            if extracted_comment != "":
+                translator_comment += extracted_comment + "\n"
+            if not reading_translator_comment:
+                translator_comment = translator_comment[:-1]  # Remove extra \n at the end.
+
         idx = 0
         pos = 0
-        while pos >= 0:
+
+        while not reading_translator_comment and pos >= 0:
             # Loop until a pattern is found. If not, next line.
             pos = l.find(patterns[idx], pos)
             if pos == -1:
@@ -140,6 +260,10 @@ def process_file(f, fname):
             if line_nb:
                 location += ":" + str(lc)
 
+            # Write translator comment.
+            _write_translator_comment(msgctx, msg, translator_comment)
+            translator_comment = ""
+
             if msgctx != "":
                 # If it's a new context or a new message within an existing context, then write new msgid.
                 # Else add location to existing msgid.
@@ -160,6 +284,7 @@ def process_file(f, fname):
                 elif not location in unique_loc[msg]:
                     _add_additional_location(msgctx, msg, location)
                     unique_loc[msg].append(location)
+
         l = f.readline()
         lc += 1
 


### PR DESCRIPTION
Added ability to extract translator comments in the C++ code.

When `TRANSLATORS:` tag is used in a comment, text following the tag will be extracted into the `POT` file as translator comment. The translator comment will be applied to the next translation function (`TTR()`, `RTR()` etc.) following it.

### Example usage:

- Single line

![2](https://user-images.githubusercontent.com/23119524/91195740-93415900-e6f9-11ea-8163-ce8427c0a916.png)


- Multiline

<img src="https://user-images.githubusercontent.com/23119524/91195730-90466880-e6f9-11ea-8115-56b13d21036f.png" width="90%">


- Using block-comment style

<img src="https://user-images.githubusercontent.com/23119524/91195748-950b1c80-e6f9-11ea-9018-285941cc6901.png" width="50%">

### Resulting POT file
The resulting POT file from the 3 comments above:
[editor.pot.txt](https://github.com/godotengine/godot/files/5124746/editor.pot.txt)
(I have to add the extension `.txt` at the end to be able to attach it)


