### PR TITLE
Accept DynamicFontData for Fonts

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -36,6 +36,7 @@
 #include "editor_properties_array_dict.h"
 #include "editor_scale.h"
 #include "scene/main/window.h"
+#include "scene/resources/dynamic_font.h"
 
 ///////////////////// NULL /////////////////////////
 
@@ -3014,6 +3015,8 @@ bool EditorPropertyResource::_is_drop_valid(const Dictionary &p_drag_data) const
 			allowed_types.append("Texture2D");
 		} else if (at == "ShaderMaterial") {
 			allowed_types.append("Shader");
+		} else if (at == "Font") {
+			allowed_types.append("DynamicFontData");
 		}
 	}
 
@@ -3109,6 +3112,13 @@ void EditorPropertyResource::drop_data_fw(const Point2 &p_point, const Variant &
 					Ref<ShaderMaterial> mat = memnew(ShaderMaterial);
 					mat->set_shader(res);
 					res = mat;
+					break;
+				}
+
+				if (at == "Font" && ClassDB::is_parent_class(res->get_class(), "DynamicFontData")) {
+					Ref<DynamicFont> font = memnew(DynamicFont);
+					font->set_font_data(res);
+					res = font;
 					break;
 				}
 			}


### PR DESCRIPTION
Somewhat follow-up to #40500

With this you can drop DynamicFontData files (e.g. `.ttf`) directly into font properties e.g. in Label. This is mostly useful when you need a unique font that doesn't need to be shared.