### PR TITLE
Add CSV plural support

### DIFF
--- a/core/compressed_translation.cpp
+++ b/core/compressed_translation.cpp
@@ -31,6 +31,7 @@
 #include "compressed_translation.h"
 
 #include "core/pair.h"
+#include "core/translation_plural_rules.h"
 
 extern "C" {
 #include "thirdparty/misc/smaz.h"
@@ -272,8 +273,10 @@ StringName PHashTranslation::get_message(const StringName &p_src_text, const Str
 }
 
 StringName PHashTranslation::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
-	// The use of plurals translation is not yet supported in PHashTranslation.
-	return get_message(p_src_text, p_context);
+	// It is assumed for now that PHashTranslation is only used by CSV translation. So get_plural_message() method follows the CSV plural format to fetch the translation.
+	int index = TranslationPluralRules::get_plural_index(get_locale(), p_n);
+	String search_src = String(p_src_text) + "[" + String::num_int64(index) + "]";
+	return get_message(search_src, p_context);
 }
 
 void PHashTranslation::_get_property_list(List<PropertyInfo> *p_list) const {

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -139,12 +139,19 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 				}
 			} else if (config == "") {
 				config = msg_str;
-				// Record plural rule.
-				int p_start = config.find("Plural-Forms");
-				if (p_start != -1) {
-					int p_end = config.find("\n", p_start);
-					translation->set_plural_rule(config.substr(p_start, p_end - p_start));
-					plural_forms = translation->get_plural_forms();
+				// Set plural_forms and locale.
+				int nplural_start = config.find("nplurals=");
+				if (nplural_start != -1) {
+					nplural_start += String("nplurals=").length();
+					int nplural_end = config.find(";", nplural_start);
+					plural_forms = config.substr(nplural_start, nplural_end - nplural_start).to_int();
+
+					int lang_start = config.find("Language:") + String("Language:").length();
+					if (lang_start - String("Language:").length() == -1) {
+						lang_start = config.find("X-Language:") + String("X-Language:").length();
+					}
+					int lang_end = config.find("\n", lang_start);
+					translation->set_locale(config.substr(lang_start, lang_end - lang_start).strip_edges());
 				}
 			}
 

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1439,10 +1439,10 @@ String Object::tr(const StringName &p_message, const StringName &p_context) cons
 	return TranslationServer::get_singleton()->translate(p_message, p_context);
 }
 
-String Object::tr_n(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
+String Object::tr_n(int p_n, const StringName &p_message, const StringName &p_message_plural, const StringName &p_context) const {
 	if (!_can_translate || !TranslationServer::get_singleton()) {
-		// Return message based on English plural rule if translation is not possible.
-		if (p_n == 1) {
+		// If no plural message, just return the key (for CSV). Else, return message based on English plural rule.
+		if (p_message_plural == StringName() || p_n == 1) {
 			return p_message;
 		}
 		return p_message_plural;
@@ -1589,7 +1589,7 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_message_translation", "enable"), &Object::set_message_translation);
 	ClassDB::bind_method(D_METHOD("can_translate_messages"), &Object::can_translate_messages);
 	ClassDB::bind_method(D_METHOD("tr", "message", "context"), &Object::tr, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("tr_n", "message", "plural_message", "n", "context"), &Object::tr_n, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("tr_n", "n", "message", "plural_message", "context"), &Object::tr_n, DEFVAL(""), DEFVAL(""));
 
 	ClassDB::bind_method(D_METHOD("is_queued_for_deletion"), &Object::is_queued_for_deletion);
 

--- a/core/object.h
+++ b/core/object.h
@@ -720,7 +720,7 @@ public:
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;
 
 	String tr(const StringName &p_message, const StringName &p_context = "") const; // translate message (internationalization)
-	String tr_n(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
+	String tr_n(int p_n, const StringName &p_message, const StringName &p_message_plural = "", const StringName &p_context = "") const;
 
 	bool _is_queued_for_deletion = false; // set to true by SceneTree::queue_delete()
 	bool is_queued_for_deletion() const;

--- a/core/plural_rules_builder.py
+++ b/core/plural_rules_builder.py
@@ -1,0 +1,78 @@
+#### TO MENTORS:
+#### I'm not sure what is the right way to write a Python script in Godot? I saw other Python files all have def func_name(target, source, env).
+#### Also I'm not sure of the location.
+#### Right now I call this script using the "python" command.
+
+# This script is used to generate core/translation_plural_rules.h
+# The plural data used in this Python script is from POEdit Github repository - https://github.com/vslavik/poedit/raw/master/src/language_impl_plurals.h
+# POEdit in turn parsed and extracted the plural data from Unicode Consortium (see http://www.unicode.org/cldr/charts/supplemental/language_plural_rules.html).
+
+#!/bin/python
+
+import sys
+import urllib.request
+
+target_file = "translation_plural_rules.h"
+
+plural_data_url = "https://github.com/vslavik/poedit/raw/master/src/language_impl_plurals.h"
+generate_text = "// The rest of the file is generated via plural_rules_builder.py (DO NOT MODIFY THIS LINE).\n"
+
+# Get plural data from POEdit github repository. See above for the link.
+text = ""
+with urllib.request.urlopen(plural_data_url) as response:
+    text = response.read().decode("utf-8")
+
+# Build dictionary mapping plural rule to a list of locales from plural data. Also store the number of plural forms each local has.
+rules = text.split("\n")
+rule_to_locales = {}
+locale_nplural = {}
+for rule in rules:
+    if rule.find("plural=") == -1:
+        continue
+
+    first_quote = rule.find('"')
+    second_quote = rule.find('"', first_quote + 1)
+    locale = rule[first_quote + 1 : second_quote]
+
+    plural_start = rule.find("plural=") + len("plural=")
+    plural_end = rule.find(";", plural_start)
+    plural_rule = rule[plural_start:plural_end]
+
+    if plural_rule in rule_to_locales:
+        rule_to_locales[plural_rule].append(locale)
+    else:
+        rule_to_locales[plural_rule] = [locale]
+
+    nplural_start = rule.find("nplurals=") + len("nplurals=")
+    locale_nplural[locale] = rule[nplural_start : nplural_start + 1]
+
+# Find the position in translation_plural_rules.h for code generation.
+with open(target_file, "r") as f:
+    text = f.read()
+gen_start_pos = text.find(generate_text) + len(generate_text)
+pretext = text[:gen_start_pos]
+
+# Generate mapping in build_mapping().
+gen_content = "\n"
+rule_number = 1
+for rule in rule_to_locales:
+    for locale in rule_to_locales[rule]:
+        gen_content += (
+            '\t\ttemp.set("' + locale + '", { ' + locale_nplural[locale] + ", &rule" + str(rule_number) + " });\n"
+        )
+    rule_number += 1
+gen_content += "\t\treturn temp;\n\t}\n"
+
+# Generate rule functions.
+rule_number = 1
+for rule in rule_to_locales:
+    gen_content += "\n\tstatic int rule" + str(rule_number) + "(const int p_n) {\n\t\t// "
+    gen_content += ", ".join(rule_to_locales[rule]) + ".\n\t\t"
+    gen_content += "return " + rule.replace("n", "p_n") + ";\n\t}\n"
+    rule_number += 1
+
+gen_content += "};\n\n#endif // TRANSLATION_PLURAL_RULES_H\n"
+
+# Write to file.
+with open(target_file, "w") as f:
+    f.write(pretext + gen_content)

--- a/core/translation.h
+++ b/core/translation.h
@@ -92,6 +92,8 @@ public:
 
 	void set_locale(const String &p_locale);
 	String get_locale() const;
+	int get_plural_index(const String &p_locale, int p_n);
+	int get_plural_forms(const String &p_locale);
 	Ref<Translation> get_translation_object(const String &p_locale);
 
 	String get_locale_name(const String &p_locale) const;

--- a/core/translation_plural_rules.cpp
+++ b/core/translation_plural_rules.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  translation_po.h                                                     */
+/*  translation_plural_rules.cpp                                         */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,42 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef TRANSLATION_PO_H
-#define TRANSLATION_PO_H
+#include "core/translation_plural_rules.h"
 
-//#define DEBUG_TRANSLATION_PO
-
-#include "core/math/expression.h"
-#include "core/translation.h"
-
-class TranslationPO : public Translation {
-	GDCLASS(TranslationPO, Translation);
-
-	// TLDR: Maps context to a list of source strings and translated strings. In PO terms, maps msgctxt to a list of msgid and msgstr.
-	// The first key corresponds to context, and the second key (of the contained HashMap) corresponds to source string.
-	// The value Vector<StringName> in the second map stores the translated strings. Index 0, 1, 2 matches msgstr[0], msgstr[1], msgstr[2]... in the case of plurals.
-	// Otherwise index 0 mathes to msgstr in a singular translation.
-	// Strings without context have "" as first key.
-	HashMap<StringName, HashMap<StringName, Vector<StringName>>> translation_map;
-
-	Vector<String> _get_message_list() const override;
-	Dictionary _get_messages() const override;
-	void _set_messages(const Dictionary &p_messages) override;
-
-public:
-	void get_message_list(List<StringName> *r_messages) const override;
-	int get_message_count() const override;
-	void add_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context = "") override;
-	void add_plural_message(const StringName &p_src_text, const Vector<String> &p_plural_xlated_texts, const StringName &p_context = "") override;
-	StringName get_message(const StringName &p_src_text, const StringName &p_context = "") const override;
-	StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const override;
-	void erase_message(const StringName &p_src_text, const StringName &p_context = "") override;
-
-#ifdef DEBUG_TRANSLATION_PO
-	void print_translation_map();
-#endif
-
-	TranslationPO() {}
-};
-
-#endif // TRANSLATION_PO_H
+// Initialize static member plural_rule_mapping.
+HashMap<String, TranslationPluralRules::PluralData> TranslationPluralRules::plural_rule_mapping = TranslationPluralRules::build_mapping();

--- a/core/translation_plural_rules.h
+++ b/core/translation_plural_rules.h
@@ -1,0 +1,421 @@
+/*************************************************************************/
+/*  translation_plural_rules.h                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TRANSLATION_PLURAL_RULES_H
+#define TRANSLATION_PLURAL_RULES_H
+
+#include "core/hash_map.h"
+#include "core/translation.h"
+#include "core/ustring.h"
+
+class TranslationPluralRules {
+public:
+	static int get_plural_index(const String &p_locale, const int p_n) {
+		if (plural_rule_mapping.has(p_locale)) {
+			return (*plural_rule_mapping[p_locale].rule)(p_n);
+		}
+
+		String lang_code = TranslationServer::get_language_code(p_locale);
+		if (plural_rule_mapping.has(lang_code)) {
+			return (*plural_rule_mapping[lang_code].rule)(p_n);
+		}
+
+		ERR_FAIL_V_MSG(-1, "Cannot find locale \"" + p_locale + "\" in TranslationPluralRules. Please report this bug.");
+	}
+
+	static int get_plural_forms(const String &p_locale) {
+		if (plural_rule_mapping.has(p_locale)) {
+			return plural_rule_mapping[p_locale].forms;
+		}
+
+		String lang_code = TranslationServer::get_language_code(p_locale);
+		if (plural_rule_mapping.has(lang_code)) {
+			return plural_rule_mapping[lang_code].forms;
+		}
+
+		ERR_FAIL_V_MSG(-1, "Cannot find locale \"" + p_locale + "\" in TranslationPluralRules. Please report this bug.");
+	}
+
+private:
+	typedef int (*PluralRule)(const int);
+
+	struct PluralData {
+		int forms;
+		PluralRule rule;
+	};
+
+	static HashMap<String, PluralData> plural_rule_mapping;
+
+	static const HashMap<String, PluralData> build_mapping() {
+		HashMap<String, PluralData> temp;
+
+		////////////////////////////////////////////////////////////////////////////////////////////
+		// The rest of the file is generated via plural_rules_builder.py (DO NOT MODIFY THIS LINE).
+
+		temp.set("af", { 2, &rule1 });
+		temp.set("asa", { 2, &rule1 });
+		temp.set("ast", { 2, &rule1 });
+		temp.set("az", { 2, &rule1 });
+		temp.set("bem", { 2, &rule1 });
+		temp.set("bez", { 2, &rule1 });
+		temp.set("bg", { 2, &rule1 });
+		temp.set("brx", { 2, &rule1 });
+		temp.set("ca", { 2, &rule1 });
+		temp.set("ce", { 2, &rule1 });
+		temp.set("cgg", { 2, &rule1 });
+		temp.set("chr", { 2, &rule1 });
+		temp.set("ckb", { 2, &rule1 });
+		temp.set("da", { 2, &rule1 });
+		temp.set("de", { 2, &rule1 });
+		temp.set("dv", { 2, &rule1 });
+		temp.set("ee", { 2, &rule1 });
+		temp.set("el", { 2, &rule1 });
+		temp.set("en", { 2, &rule1 });
+		temp.set("eo", { 2, &rule1 });
+		temp.set("es", { 2, &rule1 });
+		temp.set("et", { 2, &rule1 });
+		temp.set("eu", { 2, &rule1 });
+		temp.set("fi", { 2, &rule1 });
+		temp.set("fo", { 2, &rule1 });
+		temp.set("fur", { 2, &rule1 });
+		temp.set("fy", { 2, &rule1 });
+		temp.set("gl", { 2, &rule1 });
+		temp.set("gsw", { 2, &rule1 });
+		temp.set("ha", { 2, &rule1 });
+		temp.set("haw", { 2, &rule1 });
+		temp.set("hu", { 2, &rule1 });
+		temp.set("io", { 2, &rule1 });
+		temp.set("it", { 2, &rule1 });
+		temp.set("jgo", { 2, &rule1 });
+		temp.set("ji", { 2, &rule1 });
+		temp.set("jmc", { 2, &rule1 });
+		temp.set("ka", { 2, &rule1 });
+		temp.set("kaj", { 2, &rule1 });
+		temp.set("kcg", { 2, &rule1 });
+		temp.set("kk", { 2, &rule1 });
+		temp.set("kkj", { 2, &rule1 });
+		temp.set("kl", { 2, &rule1 });
+		temp.set("ks", { 2, &rule1 });
+		temp.set("ksb", { 2, &rule1 });
+		temp.set("ku", { 2, &rule1 });
+		temp.set("ky", { 2, &rule1 });
+		temp.set("lb", { 2, &rule1 });
+		temp.set("lg", { 2, &rule1 });
+		temp.set("mas", { 2, &rule1 });
+		temp.set("mgo", { 2, &rule1 });
+		temp.set("ml", { 2, &rule1 });
+		temp.set("mn", { 2, &rule1 });
+		temp.set("nah", { 2, &rule1 });
+		temp.set("nb", { 2, &rule1 });
+		temp.set("nd", { 2, &rule1 });
+		temp.set("ne", { 2, &rule1 });
+		temp.set("nl", { 2, &rule1 });
+		temp.set("nn", { 2, &rule1 });
+		temp.set("nnh", { 2, &rule1 });
+		temp.set("no", { 2, &rule1 });
+		temp.set("nr", { 2, &rule1 });
+		temp.set("ny", { 2, &rule1 });
+		temp.set("nyn", { 2, &rule1 });
+		temp.set("om", { 2, &rule1 });
+		temp.set("or", { 2, &rule1 });
+		temp.set("os", { 2, &rule1 });
+		temp.set("pap", { 2, &rule1 });
+		temp.set("ps", { 2, &rule1 });
+		temp.set("pt_PT", { 2, &rule1 });
+		temp.set("rm", { 2, &rule1 });
+		temp.set("rof", { 2, &rule1 });
+		temp.set("rwk", { 2, &rule1 });
+		temp.set("saq", { 2, &rule1 });
+		temp.set("scn", { 2, &rule1 });
+		temp.set("sd", { 2, &rule1 });
+		temp.set("sdh", { 2, &rule1 });
+		temp.set("seh", { 2, &rule1 });
+		temp.set("sn", { 2, &rule1 });
+		temp.set("so", { 2, &rule1 });
+		temp.set("sq", { 2, &rule1 });
+		temp.set("ss", { 2, &rule1 });
+		temp.set("ssy", { 2, &rule1 });
+		temp.set("st", { 2, &rule1 });
+		temp.set("sv", { 2, &rule1 });
+		temp.set("sw", { 2, &rule1 });
+		temp.set("syr", { 2, &rule1 });
+		temp.set("ta", { 2, &rule1 });
+		temp.set("te", { 2, &rule1 });
+		temp.set("teo", { 2, &rule1 });
+		temp.set("tig", { 2, &rule1 });
+		temp.set("tk", { 2, &rule1 });
+		temp.set("tn", { 2, &rule1 });
+		temp.set("tr", { 2, &rule1 });
+		temp.set("ts", { 2, &rule1 });
+		temp.set("ug", { 2, &rule1 });
+		temp.set("ur", { 2, &rule1 });
+		temp.set("uz", { 2, &rule1 });
+		temp.set("ve", { 2, &rule1 });
+		temp.set("vo", { 2, &rule1 });
+		temp.set("vun", { 2, &rule1 });
+		temp.set("wae", { 2, &rule1 });
+		temp.set("xh", { 2, &rule1 });
+		temp.set("xog", { 2, &rule1 });
+		temp.set("yi", { 2, &rule1 });
+		temp.set("ak", { 2, &rule2 });
+		temp.set("bh", { 2, &rule2 });
+		temp.set("ff", { 2, &rule2 });
+		temp.set("fr", { 2, &rule2 });
+		temp.set("guw", { 2, &rule2 });
+		temp.set("hy", { 2, &rule2 });
+		temp.set("kab", { 2, &rule2 });
+		temp.set("ln", { 2, &rule2 });
+		temp.set("mg", { 2, &rule2 });
+		temp.set("nso", { 2, &rule2 });
+		temp.set("pa", { 2, &rule2 });
+		temp.set("pt", { 2, &rule2 });
+		temp.set("si", { 2, &rule2 });
+		temp.set("ti", { 2, &rule2 });
+		temp.set("wa", { 2, &rule2 });
+		temp.set("am", { 2, &rule3 });
+		temp.set("as", { 2, &rule3 });
+		temp.set("bn", { 2, &rule3 });
+		temp.set("fa", { 2, &rule3 });
+		temp.set("gu", { 2, &rule3 });
+		temp.set("hi", { 2, &rule3 });
+		temp.set("kn", { 2, &rule3 });
+		temp.set("mr", { 2, &rule3 });
+		temp.set("zu", { 2, &rule3 });
+		temp.set("ar", { 6, &rule4 });
+		temp.set("ars", { 6, &rule4 });
+		temp.set("be", { 3, &rule5 });
+		temp.set("bs", { 3, &rule5 });
+		temp.set("hr", { 3, &rule5 });
+		temp.set("ru", { 3, &rule5 });
+		temp.set("sh", { 3, &rule5 });
+		temp.set("sr", { 3, &rule5 });
+		temp.set("uk", { 3, &rule5 });
+		temp.set("bm", { 1, &rule6 });
+		temp.set("bo", { 1, &rule6 });
+		temp.set("dz", { 1, &rule6 });
+		temp.set("id", { 1, &rule6 });
+		temp.set("ig", { 1, &rule6 });
+		temp.set("ii", { 1, &rule6 });
+		temp.set("in", { 1, &rule6 });
+		temp.set("ja", { 1, &rule6 });
+		temp.set("jbo", { 1, &rule6 });
+		temp.set("jv", { 1, &rule6 });
+		temp.set("jw", { 1, &rule6 });
+		temp.set("kde", { 1, &rule6 });
+		temp.set("kea", { 1, &rule6 });
+		temp.set("km", { 1, &rule6 });
+		temp.set("ko", { 1, &rule6 });
+		temp.set("lkt", { 1, &rule6 });
+		temp.set("lo", { 1, &rule6 });
+		temp.set("ms", { 1, &rule6 });
+		temp.set("my", { 1, &rule6 });
+		temp.set("nqo", { 1, &rule6 });
+		temp.set("root", { 1, &rule6 });
+		temp.set("sah", { 1, &rule6 });
+		temp.set("ses", { 1, &rule6 });
+		temp.set("sg", { 1, &rule6 });
+		temp.set("th", { 1, &rule6 });
+		temp.set("to", { 1, &rule6 });
+		temp.set("vi", { 1, &rule6 });
+		temp.set("wo", { 1, &rule6 });
+		temp.set("yo", { 1, &rule6 });
+		temp.set("yue", { 1, &rule6 });
+		temp.set("zh", { 1, &rule6 });
+		temp.set("br", { 5, &rule7 });
+		temp.set("cs", { 3, &rule8 });
+		temp.set("sk", { 3, &rule8 });
+		temp.set("cy", { 6, &rule9 });
+		temp.set("dsb", { 4, &rule10 });
+		temp.set("hsb", { 4, &rule10 });
+		temp.set("sl", { 4, &rule10 });
+		temp.set("fil", { 2, &rule11 });
+		temp.set("tl", { 2, &rule11 });
+		temp.set("ga", { 5, &rule12 });
+		temp.set("gd", { 4, &rule13 });
+		temp.set("gv", { 4, &rule14 });
+		temp.set("he", { 4, &rule15 });
+		temp.set("iw", { 4, &rule15 });
+		temp.set("is", { 2, &rule16 });
+		temp.set("mk", { 2, &rule16 });
+		temp.set("iu", { 3, &rule17 });
+		temp.set("kw", { 3, &rule17 });
+		temp.set("naq", { 3, &rule17 });
+		temp.set("se", { 3, &rule17 });
+		temp.set("sma", { 3, &rule17 });
+		temp.set("smi", { 3, &rule17 });
+		temp.set("smj", { 3, &rule17 });
+		temp.set("smn", { 3, &rule17 });
+		temp.set("sms", { 3, &rule17 });
+		temp.set("ksh", { 3, &rule18 });
+		temp.set("lag", { 3, &rule19 });
+		temp.set("lt", { 3, &rule20 });
+		temp.set("lv", { 3, &rule21 });
+		temp.set("prg", { 3, &rule21 });
+		temp.set("mo", { 3, &rule22 });
+		temp.set("ro", { 3, &rule22 });
+		temp.set("mt", { 4, &rule23 });
+		temp.set("pl", { 3, &rule24 });
+		temp.set("shi", { 3, &rule25 });
+		temp.set("tzm", { 2, &rule26 });
+		return temp;
+	}
+
+	static int rule1(const int p_n) {
+		// af, asa, ast, az, bem, bez, bg, brx, ca, ce, cgg, chr, ckb, da, de, dv, ee, el, en, eo, es, et, eu, fi, fo, fur, fy, gl, gsw, ha, haw, hu, io, it, jgo, ji, jmc, ka, kaj, kcg, kk, kkj, kl, ks, ksb, ku, ky, lb, lg, mas, mgo, ml, mn, nah, nb, nd, ne, nl, nn, nnh, no, nr, ny, nyn, om, or, os, pap, ps, pt_PT, rm, rof, rwk, saq, scn, sd, sdh, seh, sn, so, sq, ss, ssy, st, sv, sw, syr, ta, te, teo, tig, tk, tn, tr, ts, ug, ur, uz, ve, vo, vun, wae, xh, xog, yi.
+		return (p_n != 1);
+	}
+
+	static int rule2(const int p_n) {
+		// ak, bh, ff, fr, guw, hy, kab, ln, mg, nso, pa, pt, si, ti, wa.
+		return (p_n > 1);
+	}
+
+	static int rule3(const int p_n) {
+		// am, as, bn, fa, gu, hi, kn, mr, zu.
+		return (p_n == 0 || p_n == 1);
+	}
+
+	static int rule4(const int p_n) {
+		// ar, ars.
+		return (p_n == 0 ? 0 : p_n == 1 ? 1 : p_n == 2 ? 2 : p_n % 100 >= 3 && p_n % 100 <= 10 ? 3 : p_n % 100 >= 11 && p_n % 100 <= 99 ? 4 : 5);
+	}
+
+	static int rule5(const int p_n) {
+		// be, bs, hr, ru, sh, sr, uk.
+		return (p_n % 10 == 1 && p_n % 100 != 11 ? 0 : p_n % 10 >= 2 && p_n % 10 <= 4 && (p_n % 100 < 12 || p_n % 100 > 14) ? 1 : 2);
+	}
+
+	static int rule6(const int p_n) {
+		// bm, bo, dz, id, ig, ii, in, ja, jbo, jv, jw, kde, kea, km, ko, lkt, lo, ms, my, nqo, root, sah, ses, sg, th, to, vi, wo, yo, yue, zh.
+		return 0;
+	}
+
+	static int rule7(const int p_n) {
+		// br.
+		return (p_n % 10 == 1 && p_n % 100 != 11 && p_n % 100 != 71 && p_n % 100 != 91 ? 0 : p_n % 10 == 2 && p_n % 100 != 12 && p_n % 100 != 72 && p_n % 100 != 92 ? 1 : ((p_n % 10 >= 3 && p_n % 10 <= 4) || p_n % 10 == 9) && (p_n % 100 < 10 || p_n % 100 > 19) && (p_n % 100 < 70 || p_n % 100 > 79) && (p_n % 100 < 90 || p_n % 100 > 99) ? 2 : p_n != 0 && p_n % 1000000 == 0 ? 3 : 4);
+	}
+
+	static int rule8(const int p_n) {
+		// cs, sk.
+		return (p_n == 1 ? 0 : p_n >= 2 && p_n <= 4 ? 1 : 2);
+	}
+
+	static int rule9(const int p_n) {
+		// cy.
+		return (p_n == 0 ? 0 : p_n == 1 ? 1 : p_n == 2 ? 2 : p_n == 3 ? 3 : p_n == 6 ? 4 : 5);
+	}
+
+	static int rule10(const int p_n) {
+		// dsb, hsb, sl.
+		return (p_n % 100 == 1 ? 0 : p_n % 100 == 2 ? 1 : p_n % 100 >= 3 && p_n % 100 <= 4 ? 2 : 3);
+	}
+
+	static int rule11(const int p_n) {
+		// fil, tl.
+		return (p_n == 1 || p_n == 2 || p_n == 3 || (p_n % 10 != 4 && p_n % 10 != 6 && p_n % 10 != 9));
+	}
+
+	static int rule12(const int p_n) {
+		// ga.
+		return (p_n == 1 ? 0 : p_n == 2 ? 1 : p_n >= 3 && p_n <= 6 ? 2 : p_n >= 7 && p_n <= 10 ? 3 : 4);
+	}
+
+	static int rule13(const int p_n) {
+		// gd.
+		return (p_n == 1 || p_n == 11 ? 0 : p_n == 2 || p_n == 12 ? 1 : (p_n >= 3 && p_n <= 10) || (p_n >= 13 && p_n <= 19) ? 2 : 3);
+	}
+
+	static int rule14(const int p_n) {
+		// gv.
+		return (p_n % 10 == 1 ? 0 : p_n % 10 == 2 ? 1 : p_n % 100 == 0 || p_n % 100 == 20 || p_n % 100 == 40 || p_n % 100 == 60 || p_n % 100 == 80 ? 2 : 3);
+	}
+
+	static int rule15(const int p_n) {
+		// he, iw.
+		return (p_n == 1 ? 0 : p_n == 2 ? 1 : p_n > 10 && p_n % 10 == 0 ? 2 : 3);
+	}
+
+	static int rule16(const int p_n) {
+		// is, mk.
+		return (p_n % 10 == 1 && p_n % 100 != 11);
+	}
+
+	static int rule17(const int p_n) {
+		// iu, kw, naq, se, sma, smi, smj, smn, sms.
+		return (p_n == 1 ? 0 : p_n == 2 ? 1 : 2);
+	}
+
+	static int rule18(const int p_n) {
+		// ksh.
+		return (p_n == 0 ? 0 : p_n == 1 ? 1 : 2);
+	}
+
+	static int rule19(const int p_n) {
+		// lag.
+		return (p_n == 0 ? 0 : (p_n == 0 || p_n == 1) && p_n != 0 ? 1 : 2);
+	}
+
+	static int rule20(const int p_n) {
+		// lt.
+		return (p_n % 10 == 1 && (p_n % 100 < 11 || p_n % 100 > 19) ? 0 : p_n % 10 >= 2 && p_n % 10 <= 9 && (p_n % 100 < 11 || p_n % 100 > 19) ? 1 : 2);
+	}
+
+	static int rule21(const int p_n) {
+		// lv, prg.
+		return (p_n % 10 == 0 || (p_n % 100 >= 11 && p_n % 100 <= 19) ? 0 : p_n % 10 == 1 && p_n % 100 != 11 ? 1 : 2);
+	}
+
+	static int rule22(const int p_n) {
+		// mo, ro.
+		return (p_n == 1 ? 0 : p_n == 0 || (p_n != 1 && p_n % 100 >= 1 && p_n % 100 <= 19) ? 1 : 2);
+	}
+
+	static int rule23(const int p_n) {
+		// mt.
+		return (p_n == 1 ? 0 : p_n == 0 || (p_n % 100 >= 2 && p_n % 100 <= 10) ? 1 : p_n % 100 >= 11 && p_n % 100 <= 19 ? 2 : 3);
+	}
+
+	static int rule24(const int p_n) {
+		// pl.
+		return (p_n == 1 ? 0 : p_n % 10 >= 2 && p_n % 10 <= 4 && (p_n % 100 < 12 || p_n % 100 > 14) ? 1 : 2);
+	}
+
+	static int rule25(const int p_n) {
+		// shi.
+		return (p_n == 0 || p_n == 1 ? 0 : p_n >= 2 && p_n <= 10 ? 1 : 2);
+	}
+
+	static int rule26(const int p_n) {
+		// tzm.
+		return (p_n <= 1 || (p_n >= 11 && p_n <= 99));
+	}
+};
+
+#endif // TRANSLATION_PLURAL_RULES_H

--- a/core/translation_po.cpp
+++ b/core/translation_po.cpp
@@ -31,6 +31,7 @@
 #include "translation_po.h"
 
 #include "core/os/file_access.h"
+#include "translation_plural_rules.h"
 
 #ifdef DEBUG_TRANSLATION_PO
 void TranslationPO::print_translation_map() {
@@ -40,10 +41,6 @@ void TranslationPO::print_translation_map() {
 		ERR_PRINT("Failed to open translation_map_print_test.txt");
 		return;
 	}
-
-	file->store_line("NPlural : " + String::num_int64(this->get_plural_forms()));
-	file->store_line("Plural rule : " + this->get_plural_rule());
-	file->store_line("");
 
 	List<StringName> context_l;
 	translation_map.get_key_list(&context_l);
@@ -128,70 +125,6 @@ Vector<String> TranslationPO::_get_message_list() const {
 	return v;
 }
 
-int TranslationPO::_get_plural_index(int p_n) const {
-	// Get a number between [0;number of plural forms).
-
-	input_val.clear();
-	input_val.push_back(p_n);
-
-	Variant result;
-	for (int i = 0; i < equi_tests.size(); i++) {
-		Error err = expr->parse(equi_tests[i], input_name);
-		ERR_FAIL_COND_V_MSG(err != OK, 0, "Cannot parse expression. Error: " + expr->get_error_text());
-
-		result = expr->execute(input_val);
-		ERR_FAIL_COND_V_MSG(expr->has_execute_failed(), 0, "Cannot evaluate expression.");
-
-		// Last expression. Variant result will either map to a bool or an integer, in both cases returning it will give the correct plural index.
-		if (i + 1 == equi_tests.size()) {
-			return result;
-		}
-
-		if (bool(result)) {
-			return i;
-		}
-	}
-
-	ERR_FAIL_V_MSG(0, "Unexpected. Function should have returned. Please report this bug.");
-}
-
-void TranslationPO::_cache_plural_tests(const String &p_plural_rule) {
-	// Some examples of p_plural_rule passed in can have the form:
-	// "n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5" (Arabic)
-	// "n >= 2" (French) // When evaluating the last, esp careful with this one.
-	// "n != 1" (English)
-	int first_ques_mark = p_plural_rule.find("?");
-	if (first_ques_mark == -1) {
-		equi_tests.push_back(p_plural_rule.strip_edges());
-		return;
-	}
-
-	String equi_test = p_plural_rule.substr(0, first_ques_mark).strip_edges();
-	equi_tests.push_back(equi_test);
-
-	String after_colon = p_plural_rule.substr(p_plural_rule.find(":") + 1, p_plural_rule.length());
-	_cache_plural_tests(after_colon);
-}
-
-void TranslationPO::set_plural_rule(const String &p_plural_rule) {
-	// Set plural_forms and plural_rule.
-	// p_plural_rule passed in has the form "Plural-Forms: nplurals=2; plural=(n >= 2);".
-
-	int first_semi_col = p_plural_rule.find(";");
-	plural_forms = p_plural_rule.substr(p_plural_rule.find("=") + 1, first_semi_col - (p_plural_rule.find("=") + 1)).to_int();
-
-	int expression_start = p_plural_rule.find("=", first_semi_col) + 1;
-	int second_semi_col = p_plural_rule.rfind(";");
-	plural_rule = p_plural_rule.substr(expression_start, second_semi_col - expression_start);
-
-	// Setup the cache to make evaluating plural rule faster later on.
-	plural_rule = plural_rule.replacen("(", "");
-	plural_rule = plural_rule.replacen(")", "");
-	_cache_plural_tests(plural_rule);
-	expr.instance();
-	input_name.push_back("n");
-}
-
 void TranslationPO::add_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context) {
 	HashMap<StringName, Vector<StringName>> &map_id_str = translation_map[p_context];
 
@@ -204,7 +137,7 @@ void TranslationPO::add_message(const StringName &p_src_text, const StringName &
 }
 
 void TranslationPO::add_plural_message(const StringName &p_src_text, const Vector<String> &p_plural_xlated_texts, const StringName &p_context) {
-	ERR_FAIL_COND_MSG(p_plural_xlated_texts.size() != plural_forms, "Trying to add plural texts that don't match the required number of plural forms for locale \"" + get_locale() + "\"");
+	ERR_FAIL_COND_MSG(p_plural_xlated_texts.size() != TranslationPluralRules::get_plural_forms(get_locale()), "Parameter passed in Vector \"p_plural_xlated_texts\" don't match the required number of plural forms for locale \"" + get_locale() + "\"");
 
 	HashMap<StringName, Vector<StringName>> &map_id_str = translation_map[p_context];
 
@@ -216,14 +149,6 @@ void TranslationPO::add_plural_message(const StringName &p_src_text, const Vecto
 	for (int i = 0; i < p_plural_xlated_texts.size(); i++) {
 		map_id_str[p_src_text].push_back(p_plural_xlated_texts[i]);
 	}
-}
-
-int TranslationPO::get_plural_forms() const {
-	return plural_forms;
-}
-
-String TranslationPO::get_plural_rule() const {
-	return plural_rule;
 }
 
 StringName TranslationPO::get_message(const StringName &p_src_text, const StringName &p_context) const {
@@ -238,30 +163,13 @@ StringName TranslationPO::get_message(const StringName &p_src_text, const String
 StringName TranslationPO::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
 	ERR_FAIL_COND_V_MSG(p_n < 0, StringName(), "N passed into translation to get a plural message should not be negative. For negative numbers, use singular translation please. Search \"gettext PO Plural Forms\" online for the documentation on translating negative numbers.");
 
-	// If the query is the same as last time, return the cached result.
-	if (p_n == last_plural_n && p_context == last_plural_context && p_src_text == last_plural_key) {
-		return translation_map[p_context][p_src_text][last_plural_mapped_index];
-	}
-
 	if (!translation_map.has(p_context) || !translation_map[p_context].has(p_src_text)) {
 		return StringName();
 	}
 	ERR_FAIL_COND_V_MSG(translation_map[p_context][p_src_text].empty(), StringName(), "Source text \"" + String(p_src_text) + "\" is registered but doesn't have a translation. Please report this bug.");
 
-	if (translation_map[p_context][p_src_text].size() == 1) {
-		WARN_PRINT("Source string \"" + String(p_src_text) + "\" doesn't have plural translations. Use singular translation API for such as tr(), TTR() to translate \"" + String(p_src_text) + "\"");
-		return translation_map[p_context][p_src_text][0];
-	}
-
-	int plural_index = _get_plural_index(p_n);
-	ERR_FAIL_COND_V_MSG(plural_index < 0 || translation_map[p_context][p_src_text].size() < plural_index + 1, StringName(), "Plural index returned or number of plural translations is not valid. Please report this bug.");
-
-	// Cache result so that if the next entry is the same, we can return directly.
-	// _get_plural_index(p_n) can get very costly, especially when evaluating long plural-rule (Arabic)
-	last_plural_key = p_src_text;
-	last_plural_context = p_context;
-	last_plural_n = p_n;
-	last_plural_mapped_index = plural_index;
+	int plural_index = TranslationPluralRules::get_plural_index(get_locale(), p_n);
+	ERR_FAIL_COND_V_MSG(plural_index < 0 || translation_map[p_context][p_src_text].size() <= plural_index, StringName(), "Plural index returned or number of plural translations is not valid. Please report this bug.");
 
 	return translation_map[p_context][p_src_text][plural_index];
 }
@@ -304,9 +212,4 @@ int TranslationPO::get_message_count() const {
 		count += translation_map[E->get()].size();
 	}
 	return count;
-}
-
-void TranslationPO::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_plural_forms"), &TranslationPO::get_plural_forms);
-	ClassDB::bind_method(D_METHOD("get_plural_rule"), &TranslationPO::get_plural_rule);
 }

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -493,28 +493,29 @@
 			<argument index="1" name="context" type="StringName" default="&quot;&quot;">
 			</argument>
 			<description>
-				Translates a message using translation catalogs configured in the Project Settings. An additional context could be used to specify the translation context.
-				Only works if message translation is enabled (which it is by default), otherwise it returns the [code]message[/code] unchanged. See [method set_message_translation].
-				See <link>https://docs.godotengine.org/en/latest/tutorials/i18n/internationalizing_games.html</link> for examples of the usage of this method.
+				Translates a message using translation catalogs configured in the Project Settings. Only works if message translation is enabled (which it is by default). See [method set_message_translation].
+				If you're translating using PO files, an additional context could be used to specify the translation context. If you're translating using CSV files, the [code]context[/code] parameter is ignored.
+				If the translation fails, [code]message[/code] will be returned.
 			</description>
 		</method>
 		<method name="tr_n" qualifiers="const">
 			<return type="String">
 			</return>
-			<argument index="0" name="message" type="StringName">
+			<argument index="0" name="n" type="int">
 			</argument>
-			<argument index="1" name="plural_message" type="StringName">
+			<argument index="1" name="message" type="StringName">
 			</argument>
-			<argument index="2" name="n" type="int">
+			<argument index="2" name="plural_message" type="StringName" default="&quot;&quot;">
 			</argument>
 			<argument index="3" name="context" type="StringName" default="&quot;&quot;">
 			</argument>
 			<description>
-				Translates a message involving plurals using translation catalogs configured in the Project Settings. An additional context could be used to specify the translation context.
-				Only works if message translation is enabled (which it is by default), otherwise it returns the [code]message[/code] or [code]plural_message[/code] unchanged. See [method set_message_translation].
-				The number [code]n[/code] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form for the selected language.
-				[b]Note:[/b] Negative and floating-point values usually represent physical entities for which singular and plural don't clearly apply. In such cases, use [method tr].
-				See <link>https://docs.godotengine.org/en/latest/tutorials/i18n/localization_using_gettext.html</link> for examples of the usage of this method.
+				Translates a message involving plurals using translation catalogs configured in the Project Settings. Only works if message translation is enabled (which it is by default). See [method set_message_translation].
+				The number [code]n[/code] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form based on the selected language.
+				If you're translating using CSV files, only the parameters [code]n[/code] and [code]message[/code] are relevant. The other two will be ignored.
+				If you're translating using PO files, you must provide a [code]plural_message[/code]. An additional context could be used to specify the translation context when using PO files.
+				If the translation fails, CSV translation will try to return the base form ([code]message[0][/code]) of the target language. If it fails again, it will return back the key, which is [code]message[/code]. For PO translation, when the translation fails, it will return [code]message[/code] or [code]plural_message[/code] based on English plural rule.
+				[b]Note:[/b] Negative and floating-point values usually represent physical entities for which singular and plural don't clearly apply. Normally one should use [method tr] in these cases. Search online for advise on how to deal with these situation.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -50,6 +50,29 @@
 				Returns a locale's language and its variant (e.g. [code]"en_US"[/code] would return [code]"English (United States)"[/code]).
 			</description>
 		</method>
+		<method name="get_plural_forms">
+			<return type="int">
+			</return>
+			<argument index="0" name="locale" type="String">
+			</argument>
+			<description>
+				Returns the number of plural forms the [code]locale[/code] has. For example, the Arabic language has six plural forms, English has two, Russian has three and so on.
+				Search "plural form localization" online for more information and the complete list.
+			</description>
+		</method>
+		<method name="get_plural_index">
+			<return type="int">
+			</return>
+			<argument index="0" name="locale" type="String">
+			</argument>
+			<argument index="1" name="n" type="int">
+			</argument>
+			<description>
+				Returns the plural form index based on the [code]locale[/code] and [code]n[/code] passed in.
+				For example, English has two forms, with singular having index 0 and plural having index 1. When [code]n[/code] is not one, which signifies plural in English, the returned index is 1 since it maps to the plural form.
+				Different languages have different range of plural forms, see [method get_plural_forms].
+			</description>
+		</method>
 		<method name="get_translation_object">
 			<return type="Translation">
 			</return>
@@ -57,7 +80,7 @@
 			</argument>
 			<description>
 				Returns the [Translation] instance based on the [code]locale[/code] passed in.
-				It will return a [code]nullptr[/code] if there is no [Translation] instance that matches the [code]locale[/code].
+				It will return [code]nullptr[/code] if there is no [Translation] instance that matches the [code]locale[/code].
 			</description>
 		</method>
 		<method name="remove_translation">

--- a/editor/editor_translation_parser.cpp
+++ b/editor/editor_translation_parser.cpp
@@ -46,12 +46,12 @@ Error EditorTranslationParserPlugin::parse_file(const String &p_path, Vector<Str
 		Array ids_ctx_plural;
 		get_script_instance()->call("parse_file", p_path, ids, ids_ctx_plural);
 
-		// Add user's extracted translatable messages.
+		// Add extracted translatable messages.
 		for (int i = 0; i < ids.size(); i++) {
 			r_ids->append(ids[i]);
 		}
 
-		// Add user's collected translatable messages with context or plurals.
+		// Add extracted translatable messages with context or plurals.
 		for (int i = 0; i < ids_ctx_plural.size(); i++) {
 			Array arr = ids_ctx_plural[i];
 			ERR_FAIL_COND_V_MSG(arr.size() != 3, ERR_INVALID_DATA, "Array entries written into `msgids_context_plural` in `parse_file()` method should have the form [\"message\", \"context\", \"plural message\"]");

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -364,7 +364,10 @@ void LocalizationEditor::_translation_filter_mode_changed(int p_mode) {
 }
 
 void LocalizationEditor::_pot_add(const String &p_path) {
-	PackedStringArray pot_translations = ProjectSettings::get_singleton()->get("locale/translations_pot_files");
+	PackedStringArray pot_translations;
+	if (ProjectSettings::get_singleton()->has_setting("locale/translations_pot_files")) {
+		pot_translations = ProjectSettings::get_singleton()->get("locale/translations_pot_files");
+	}
 
 	for (int i = 0; i < pot_translations.size(); i++) {
 		if (pot_translations[i] == p_path) {

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -267,11 +267,11 @@ void GDScriptEditorTranslationParserPlugin::_extract_from_call(GDScriptParser::C
 			ids_ctx_plural->push_back(id_ctx_plural);
 		}
 	} else if (function_name == trn_func) {
-		// Extract from tr_n(id, plural, n, ctx).
+		// Extract from tr_n(n, id, plural, ctx).
 		Vector<int> indices;
-		indices.push_back(0);
-		indices.push_back(3);
 		indices.push_back(1);
+		indices.push_back(3);
+		indices.push_back(2);
 		for (int i = 0; i < indices.size(); i++) {
 			if (indices[i] >= p_call->arguments.size()) {
 				continue;
@@ -283,7 +283,10 @@ void GDScriptEditorTranslationParserPlugin::_extract_from_call(GDScriptParser::C
 				extract_id_ctx_plural = false;
 			}
 		}
+
 		if (extract_id_ctx_plural) {
+			// If plural is not given in tr_n(), ask user to provide it.
+			ERR_FAIL_COND_MSG(id_ctx_plural[2].empty(), "A plural message must be given to tr_n() function to generate POT, as PO files require the plural message field.");
 			ids_ctx_plural->push_back(id_ctx_plural);
 		}
 	} else if (first_arg_patterns.has(function_name)) {


### PR DESCRIPTION
Added CSV plural support, as requested by this proposal godotengine/godot-proposals#1291.

### Usage:
It functions like how the proposal describes. Some key notes:

- tr_n() now accepts arguments in the form of tr_n(n, message, plural_message = "", context = "").

- Plural translation using CSV should leave out `plural_message` and `context` parameters as they aren't used during the translation (which explains the reordering of the parameters).

- How it works: tr_n(n, "KEY") will fetch the correct plural translation from the CSV using adjusted key, i.e. KEY[0], KEY[1] etc. depending on the current `locale` and n. The system will concatenate the `KEY` with appropriate subscript for us.

### Condition
Because of how the concatenation works, in the CSV users should append [0], [1] and so on for keys mapping plurals for it to work. This is the contract. Examples can be seen in the proposal.

#### Note for PO users: 
Users using PO files to translate will still have to fill in the `plural_message` field, as PO files expect to have the plural message data (I have documented this in the class reference too). The `context` parameter is optional.

#### Test project:
[test_project.zip](https://github.com/godotengine/godot/files/5126286/test_project.zip)
