### PR TITLE
Added string length checking to LineEdit.set_text()

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1281,7 +1281,12 @@ void LineEdit::delete_text(int p_from_column, int p_to_column) {
 
 void LineEdit::set_text(String p_text) {
 	clear_internal();
-	append_at_cursor(p_text);
+
+	if (p_text.length() > max_length) {
+		append_at_cursor(p_text.substr(0, max_length));
+	} else {
+		append_at_cursor(p_text);
+	}
 
 	if (expand_to_text_length) {
 		minimum_size_changed();


### PR DESCRIPTION
Updated set_max_length() function to actually pull a substring of the current text so it's not all thrown away when the new max length is shorter than the current length.

Whenever set_max_length() is called it also calls set_text() again to force a refresh. set_text() further called append_at_cursor() (Which is at 0 after clear_internal()).

append_at_cursor() would check the text length against the max length, and if it's too long, would emit text_change_rejected. So the text would get cleared out by set_text(), but because the text longer than max_length from set_max_length() was preserved in the call stack, it would never set the new text in and instead sent the signal.

Since one wouldn't expect text_change_rejected from set_max_length(), I could see why this is never caught. The behavior most people would expect would be to chop off the end of the text instead of making it empty.

*Bugsquad edit:* Fixes #41278. Fixes #33321.