### PR TITLE
Fixes `is_action_released` firing with no modifiers

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -392,15 +392,23 @@ bool InputEventKey::action_match(const Ref<InputEvent> &p_event, bool *p_pressed
 
 	bool match = false;
 	if (get_keycode() == 0) {
-		uint32_t code = get_physical_keycode_with_modifiers();
-		uint32_t event_code = key->get_physical_keycode_with_modifiers();
+		uint32_t code = get_physical_keycode();
+		uint32_t event_code = key->get_physical_keycode();
 
-		match = get_physical_keycode() == key->get_physical_keycode() && (!key->is_pressed() || (code & event_code) == code);
+		// Get modifiers without keycode
+		uint32_t mods = get_physical_keycode_with_modifiers() & ~code;
+		uint32_t event_mods = key->get_physical_keycode_with_modifiers() & ~event_code;
+
+		match = code == event_code && (mods & event_mods) == mods;
 	} else {
-		uint32_t code = get_keycode_with_modifiers();
-		uint32_t event_code = key->get_keycode_with_modifiers();
+		uint32_t code = get_keycode();
+		uint32_t event_code = key->get_keycode();
 
-		match = get_keycode() == key->get_keycode() && (!key->is_pressed() || (code & event_code) == code);
+		// Get modifiers without keycode
+		uint32_t mods = get_keycode_with_modifiers() & ~code;
+		uint32_t event_mods = key->get_keycode_with_modifiers() & ~event_code;
+
+		match = code == event_code && (mods & event_mods) == mods;
 	}
 	if (match) {
 		if (p_pressed != nullptr) {


### PR DESCRIPTION
Should fix #34502
If you have an action like "CTRL + A", it will now fire on both press and release, however if you release "CTRL" while still holding "A" it will not fire the release event.

Also tested with just modifier keys like only "CTRL" or "CTRL+SHIFT" and that still works.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
