### PR TITLE
Wrap angles to (-pi, pi) in momentum calculation.

### DIFF
--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -468,7 +468,7 @@ void Body2DSW::integrate_forces(real_t p_step) {
 		linear_velocity = motion / p_step;
 
 		real_t rot = new_transform.get_rotation() - get_transform().get_rotation();
-		angular_velocity = rot / p_step;
+		angular_velocity = remainder(rot, 2.0 * Math_PI) / p_step;
 
 		do_motion = true;
 


### PR DESCRIPTION
Fixes bug #41527 (Excess angular momentum when 2D kinematic body rotates beyond 180 degrees) by limiting the difference in angle between frames to the range (-pi, pi). 

This was the most minimal solution I could think of; it uses the standard library remainder function to produce the difference between the angle and the nearest integer multiple of 2pi. Another solution might be to add a method to the Transform2D class that gets an orientation vector, then use an angle-between-vectors method - this would avoid computing two angles then taking a modulus.

This change was actually tested on 3.2.2-stable; I assume the same change will work in 4.0, however I cannot get it to compile on my machine.

_Bugsquad edit:_ Fixes #31940, fixes #41527.