### PR TITLE
Fix specular render_mode for visual shaders

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1367,10 +1367,19 @@ void VisualShader::_update_shader() const {
 	{
 		//fill render mode enums
 		int idx = 0;
+		bool specular = false;
 		while (render_mode_enums[idx].string) {
 			if (shader_mode == render_mode_enums[idx].mode) {
-				if (modes.has(render_mode_enums[idx].string)) {
-					int which = modes[render_mode_enums[idx].string];
+				if (shader_mode == Shader::MODE_SPATIAL) {
+					if (String(render_mode_enums[idx].string) == "specular") {
+						specular = true;
+					}
+				}
+				if (modes.has(render_mode_enums[idx].string) || specular) {
+					int which = 0;
+					if (modes.has(render_mode_enums[idx].string)) {
+						which = modes[render_mode_enums[idx].string];
+					}
 					int count = 0;
 					for (int i = 0; i < ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(shader_mode)).size(); i++) {
 						String mode = ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(shader_mode))[i];


### PR DESCRIPTION
Seems like "disabled" specular render mode should be first in order to correct processing, this may change the specular modes for existed visual shaders, but this will fix schlick_ggx specular mode...
Fix https://github.com/godotengine/godot/issues/41525

PS. I think documentation is wrong and the default specular mode is "specular_disabled"