### PR TITLE
Fix for the sprite display position jumps when placed at subpixel locations and moving the camera (3.2)

### DIFF
--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -99,6 +99,7 @@ void VisualServerCanvas::_render_canvas_item(Item *p_canvas_item, const Transfor
 	Rect2 rect = ci->get_rect();
 	Transform2D xform = p_transform * ci->xform;
 	Rect2 global_rect = xform.xform(rect);
+	xform.elements[2] =  xform.elements[2].floor() ; // Clean the undesirable fractional part distorting the final display position
 	global_rect.position += p_clip_rect.position;
 
 	if (ci->use_parent_material && p_material_owner)

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -96,10 +96,12 @@ void VisualServerCanvas::_render_canvas_item(Item *p_canvas_item, const Transfor
 		ci->children_order_dirty = false;
 	}
 
+	Transform2D p_transform2 = p_transform;
+	p_transform2.elements[2] = p_transform2.elements[2].floor(); // Clean the undesirable fractional part distorting the final display position
+
+	Transform2D xform = p_transform2 * ci->xform;
 	Rect2 rect = ci->get_rect();
-	Transform2D xform = p_transform * ci->xform;
 	Rect2 global_rect = xform.xform(rect);
-	xform.elements[2] = xform.elements[2].floor(); // Clean the undesirable fractional part distorting the final display position
 	global_rect.position += p_clip_rect.position;
 
 	if (ci->use_parent_material && p_material_owner)

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -99,7 +99,7 @@ void VisualServerCanvas::_render_canvas_item(Item *p_canvas_item, const Transfor
 	Rect2 rect = ci->get_rect();
 	Transform2D xform = p_transform * ci->xform;
 	Rect2 global_rect = xform.xform(rect);
-	xform.elements[2] =  xform.elements[2].floor(); // Clean the undesirable fractional part distorting the final display position
+	xform.elements[2] = xform.elements[2].floor(); // Clean the undesirable fractional part distorting the final display position
 	global_rect.position += p_clip_rect.position;
 
 	if (ci->use_parent_material && p_material_owner)

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -99,7 +99,7 @@ void VisualServerCanvas::_render_canvas_item(Item *p_canvas_item, const Transfor
 	Rect2 rect = ci->get_rect();
 	Transform2D xform = p_transform * ci->xform;
 	Rect2 global_rect = xform.xform(rect);
-	xform.elements[2] =  xform.elements[2].floor() ; // Clean the undesirable fractional part distorting the final display position
+	xform.elements[2] =  xform.elements[2].floor(); // Clean the undesirable fractional part distorting the final display position
 	global_rect.position += p_clip_rect.position;
 
 	if (ci->use_parent_material && p_material_owner)


### PR DESCRIPTION
Fixes the 2D canvas display positions jumping pseudo randomly when the are located at fractional coordinates and the camera changes location. Fixes #41491, fixes #35606 etc. Godot 3.2 branch.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
