### PR TITLE
[3.2] Fix specular render_mode for visual shaders

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1246,13 +1246,20 @@ void VisualShader::_update_shader() const {
 	{
 		//fill render mode enums
 		int idx = 0;
+		bool specular = false;
 		while (render_mode_enums[idx].string) {
-
 			if (shader_mode == render_mode_enums[idx].mode) {
+				if (shader_mode == Shader::MODE_SPATIAL) {
+					if (String(render_mode_enums[idx].string) == "specular") {
+						specular = true;
+					}
+				}
+				if (modes.has(render_mode_enums[idx].string) || specular) {
 
-				if (modes.has(render_mode_enums[idx].string)) {
-
-					int which = modes[render_mode_enums[idx].string];
+					int which = 0;
+					if (modes.has(render_mode_enums[idx].string)) {
+						which = modes[render_mode_enums[idx].string];
+					}
 					int count = 0;
 					for (int i = 0; i < ShaderTypes::get_singleton()->get_modes(VisualServer::ShaderMode(shader_mode)).size(); i++) {
 						String mode = ShaderTypes::get_singleton()->get_modes(VisualServer::ShaderMode(shader_mode))[i];


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/41525 for 3.2