### PR TITLE
Manually prepend "Ranlib Library" message on build to keep aligment

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -384,9 +384,14 @@ def no_verbose(sys, env):
     link_library_message = "{}Linking Static Library {}==> {}$TARGET{}".format(
         colors["red"], colors["purple"], colors["yellow"], colors["end"]
     )
+
     ranlib_library_message = "{}Ranlib Library         {}==> {}$TARGET{}".format(
         colors["red"], colors["purple"], colors["yellow"], colors["end"]
     )
+    # The progress percentage isn't shown before this message, so it needs to be prepended manually to keep alignment.
+    if show_progress:
+        ranlib_library_message = "       " + ranlib_library_message
+
     link_shared_library_message = "{}Linking Shared Library {}==> {}$TARGET{}".format(
         colors["red"], colors["purple"], colors["yellow"], colors["end"]
     )


### PR DESCRIPTION
AFAIK, this is the only message that needs prepending, if there are any others, just tell.

**Before:**
![Screenshot_20200821_115631](https://user-images.githubusercontent.com/30739239/91311947-339f8800-e7a3-11ea-8b8f-1ff4c8cce0c3.png)
**After:**
![Screenshot_20200826_103804](https://user-images.githubusercontent.com/30739239/91311953-34d0b500-e7a3-11ea-8008-e6975fdbd5e7.png)