### PR TITLE
Remove community health files from this repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-patreon: godotengine
-custom: https://godotengine.org/donate

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,0 @@
-# Code of Conduct
-
-By participating in this repository, you agree to abide by the
-[Godot Engine Code of Conduct](https://godotengine.org/code-of-conduct).


### PR DESCRIPTION
They've been moved to the @godotengine organization's .github repository, which works as a fallback for all repositories in the organization. This way, the Sponsor button is automatically displayed on all repositories.

This closes #40972.