### PR TITLE
File get_csv_line returns invalid PackedStringArray if the line is empty

### DIFF
--- a/core/os/file_access.cpp
+++ b/core/os/file_access.cpp
@@ -362,7 +362,9 @@ Vector<String> FileAccess::get_csv_line(const String &p_delim) const {
 		}
 	}
 
-	strings.push_back(current);
+	if (!l.is_empty()) {
+		strings.push_back(current);
+	}
 
 	return strings;
 }


### PR DESCRIPTION
```py
# Notice: Modify this for your OS
const path = "/tmp/temp.csv"

func _ready():
	_save()
	_load()

func _save():
	var file := File.new()
	file.open(path, File.WRITE)
	file.store_csv_line(["a", "b", "c"])
	file.close()

func _load():
	var file := File.new()
	file.open(path, File.READ)
	print(file.get_csv_line())
	var arr = file.get_csv_line()
	print(arr)
	print(arr.size())
	file.close()
```

Before:
```
[a, b, c]
[]
1
```

After:
```
[a, b, c]
[]
0
```

**Discuss**: Depending on how `get_csv_line` should behave, `[""]` could also be a valid return, but it makes it difficult to tell when EOF has been reached.