### PR TITLE
Add information to get thread id

### DIFF
--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -15,7 +15,7 @@
 			<return type="String">
 			</return>
 			<description>
-				Returns the current [Thread]'s ID, uniquely identifying it among all threads.
+				Returns the current [Thread]'s ID, uniquely identifying it among all threads. If the [Thread] is not running this returns an empty string.
 			</description>
 		</method>
 		<method name="is_active" qualifiers="const">


### PR DESCRIPTION
Adds that if the thread is not running `get_id()` returns an empty string. Closes https://github.com/godotengine/godot-docs/issues/3808
