### PR TITLE
Deprecate Redundant property enabled_focus_mode

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -52,7 +52,7 @@
 			If [code]true[/code], the button is in disabled state and can't be clicked or toggled.
 		</member>
 		<member name="enabled_focus_mode" type="int" setter="set_enabled_focus_mode" getter="get_enabled_focus_mode" enum="Control.FocusMode" default="2">
-			Focus access mode to use when switching between enabled/disabled (see [member Control.focus_mode] and [member disabled]).
+			[i]Deprecated.[/i] This property has been deprecated due to redundancy and no longer has any effect when set. Please use [member Control.focus_mode] instead.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
 		<member name="group" type="ButtonGroup" setter="set_button_group" getter="get_button_group">

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -326,6 +326,7 @@ void BaseButton::set_enabled_focus_mode(FocusMode p_mode) {
 	if (!status.disabled) {
 		set_focus_mode(p_mode);
 	}
+	WARN_DEPRECATED_MSG("BaseButton's Enabled Focus Mode property has been deprecated due to redundancy and will be removed in Godot 4.0. Please use Control.set_focus_mode instead.");
 }
 
 Control::FocusMode BaseButton::get_enabled_focus_mode() const {

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -140,6 +140,5 @@ void LinkButton::_bind_methods() {
 
 LinkButton::LinkButton() {
 	underline_mode = UNDERLINE_MODE_ALWAYS;
-	set_enabled_focus_mode(FOCUS_NONE);
 	set_default_cursor_shape(CURSOR_POINTING_HAND);
 }

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -129,7 +129,6 @@ MenuButton::MenuButton() {
 	set_flat(true);
 	set_toggle_mode(true);
 	set_disable_shortcuts(false);
-	set_enabled_focus_mode(FOCUS_NONE);
 	set_process_unhandled_key_input(true);
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 


### PR DESCRIPTION
of BaseButton
see #41529 for details
this closes #41529, related to #41576

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
