### PR TITLE
Make blank project name create an error, not a warning

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -412,7 +412,7 @@ private:
 		_test_path();
 
 		if (p_text == "") {
-			set_message(TTR("It would be a good idea to name your project."), MESSAGE_WARNING);
+			set_message(TTR("It would be a good idea to name your project."), MESSAGE_ERROR);
 		}
 	}
 


### PR DESCRIPTION
A warning usually indicates the existence of a non-blocking problem.
A project cannot be created without a name, thus a blank project name is a blocking problem.
Therefor, I think it makes sense to turn the blank name warning into an error.