### PR TITLE
Expose OS::get_*_path functions

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -223,6 +223,18 @@ String _OS::get_executable_path() const {
 	return OS::get_singleton()->get_executable_path();
 }
 
+String _OS::get_data_path() const {
+	return OS::get_singleton()->get_data_path();
+}
+
+String _OS::get_config_path() const {
+	return OS::get_singleton()->get_config_path();
+}
+
+String _OS::get_cache_path() const {
+	return OS::get_singleton()->get_cache_path();
+}
+
 Error _OS::shell_open(String p_uri) {
 	if (p_uri.begins_with("res://")) {
 		WARN_PRINT("Attempting to open an URL with the \"res://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_open()`.");
@@ -700,6 +712,9 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_processor_count"), &_OS::get_processor_count);
 
 	ClassDB::bind_method(D_METHOD("get_executable_path"), &_OS::get_executable_path);
+	ClassDB::bind_method(D_METHOD("get_data_path"), &_OS::get_data_path);
+	ClassDB::bind_method(D_METHOD("get_config_path"), &_OS::get_config_path);
+	ClassDB::bind_method(D_METHOD("get_cache_path"), &_OS::get_cache_path);
 	ClassDB::bind_method(D_METHOD("execute", "path", "arguments", "output", "read_stderr"), &_OS::execute, DEFVAL(Array()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("create_process", "path", "arguments"), &_OS::create_process);
 	ClassDB::bind_method(D_METHOD("kill", "pid"), &_OS::kill);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -163,8 +163,12 @@ public:
 	int get_low_processor_usage_mode_sleep_usec() const;
 
 	String get_executable_path() const;
+	String get_data_path() const;
+	String get_config_path() const;
+	String get_cache_path() const;
 	int execute(const String &p_path, const Vector<String> &p_arguments, Array r_output = Array(), bool p_read_stderr = false);
 	int create_process(const String &p_path, const Vector<String> &p_arguments);
+
 	Error kill(int p_pid);
 	Error shell_open(String p_uri);
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -221,6 +221,27 @@
 				Returns the path to the current engine executable.
 			</description>
 		</method>
+		<method name="get_data_path" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns the path to where the Godot templates and the application user data is stored per project. See [url=https://docs.godotengine.org/en/latest/tutorials/io/data_paths.html]File paths in Godot projects[/url] for information on the default paths.
+			</description>
+		</method>
+		<method name="get_config_path" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns the path where the configuration for Godot is stored and possibly other applications. See [url=https://docs.godotengine.org/en/latest/tutorials/io/data_paths.html]File paths in Godot projects[/url] for information on the default paths.
+			</description>
+		</method>
+		<method name="get_cache_path" qualifiers="const">
+			<return type="String">
+			</return>
+			<description>
+				Returns the path to where the cache is stored per project. See [url=https://docs.godotengine.org/en/latest/tutorials/io/data_paths.html]File paths in Godot projects[/url] for information on the default paths.
+			</description>
+		</method>
 		<method name="get_granted_permissions" qualifiers="const">
 			<return type="PackedStringArray">
 			</return>


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

As I was working on issue #40584 I noticed these `OS::get_*_path` functions were not exposed to GDScript.

It took me a while to figure out that Godot was using a caching mechanism and I stumbled upon these functions after I did so. I think it would be great to have these functions exposed just to let users know where things are in case another issue like the one aforementioned pops up.

It will also be handy for users who want to use `add_tool_menu_item` to open their shells on these folders as they work on multiple projects.