### PR TITLE
Fix drag and drop between windows in X11 display server

### DIFF
--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -144,6 +144,8 @@ class DisplayServerX11 : public DisplayServer {
 		Vector2i last_position_before_fs;
 		bool focused = false;
 		bool minimized = false;
+
+		unsigned int focus_order = 0;
 	};
 
 	Map<WindowID, WindowData> windows;


### PR DESCRIPTION
**Proper implementation for get_window_at_screen_position:**
Now getting the topmost last active window when overlapping.

**Mouse drag & release events:**
They are now propagated through the current focused window, in order to make it consistent with the engine expectations and the Windows display server implementation.

Helps with #38312 (fixes Linux) although it still needs to be fixed on Mac.