### PR TITLE
Fix not saving new filter order in project manager

### DIFF
--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -41,9 +41,9 @@ class ProjectDialog;
 class ProjectList;
 
 enum FilterOption {
-	FILTER_NAME,
-	FILTER_PATH,
-	FILTER_EDIT_DATE,
+	NAME,
+	PATH,
+	EDIT_DATE,
 };
 
 class ProjectManager : public Control {
@@ -55,7 +55,6 @@ class ProjectManager : public Control {
 
 	LineEdit *search_box;
 	OptionButton *filter_option;
-	FilterOption _current_filter;
 
 	Button *run_btn;
 	Button *open_btn;


### PR DESCRIPTION
Fixes #41598.

Filter option was not saved, but this would only happen because of the because of the default enum value of _order_option, which caused a mismatch. Now, we always save and sort because OptionButton never emits a signal if the selected item isn't different anyway. This also made `ProjectManager::_current_filter` unnecessary. 

To synchronize the values at startup, we manually call `set_order_option()` because `OptionButton::select()` does not trigger a signal unless it's from an inputevent (not sure if that is intended).