### PR TITLE
Alias the "linuxbsd" platform to "x11" for forward compatibility

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -284,6 +284,14 @@ else:
         print("Automatically detected platform: " + selected_platform)
         env_base["platform"] = selected_platform
 
+if selected_platform in ["linux", "bsd", "linuxbsd"]:
+    if selected_platform == "linuxbsd":
+        # Alias for forward compatibility.
+        print('Platform "linuxbsd" is still called "x11" in Godot 3.2.x. Building for platform "x11".')
+    # Alias for convenience.
+    selected_platform = "x11"
+    env_base["platform"] = selected_platform
+
 if selected_platform in platform_list:
     tmppath = "./platform/" + selected_platform
     sys.path.insert(0, tmppath)


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/37369.

This makes it possible to follow documentation designed for the `master` branch while building the `3.2` branch.