### PR TITLE
Adding ability to evaluate the negation of an advance condition in an anim state machine transition

### DIFF
--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -17,7 +17,7 @@
 			[/codeblock]
 		</member>
 		<member name="inverted_advance_condition" type="bool" setter="set_inverted_advance_condition" getter="is_inverted_advance_condition" default="false">
-		Inverts the result of the advance condition parameter before evaluating if the transition should be set to auto advance.	
+			Inverts the result of the advance condition parameter before evaluating if the transition should be set to auto advance.	
 		</member>
 		<member name="auto_advance" type="bool" setter="set_auto_advance" getter="has_auto_advance" default="false">
 			Turn on the transition automatically when this state is reached. This works best with [constant SWITCH_MODE_AT_END].

--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -16,6 +16,9 @@
 			$animation_tree["parameters/conditions/idle"] = is_on_floor and (linear_velocity.x == 0)
 			[/codeblock]
 		</member>
+		<member name="inverted_advance_condition" type="bool" setter="set_inverted_advance_condition" getter="is_inverted_advance_condition" default="false">
+		Inverts the result of the advance condition parameter before evaluating if the transition should be set to auto advance.	
+		</member>
 		<member name="auto_advance" type="bool" setter="set_auto_advance" getter="has_auto_advance" default="false">
 			Turn on the transition automatically when this state is reached. This works best with [constant SWITCH_MODE_AT_END].
 		</member>

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -440,8 +440,9 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 			}
 
 			if (p_state_machine->transitions[i].from == current && auto_advance) {
-				if (considered_transition->get_priority() <= priority_best) {
-					priority_best = considered_transition->get_priority();
+				const int considered_transition_priority = considered_transition->get_priority();
+				if (considered_transition_priority <= priority_best) {
+					priority_best = considered_transition_priority;
 					auto_advance_to = i;
 				}
 			}

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -130,8 +130,8 @@ void AnimationNodeStateMachineTransition::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "switch_mode", PROPERTY_HINT_ENUM, "Immediate,Sync,AtEnd"), "set_switch_mode", "get_switch_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_advance"), "set_auto_advance", "has_auto_advance");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "advance_condition"), "set_advance_condition", "is_inverted_advance_condition");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "inverted_advance_condition"), "set_inverted_advance_condition", "has_auto_advance");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "advance_condition"), "set_advance_condition", "get_advance_condition");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "inverted_advance_condition"), "set_inverted_advance_condition", "is_inverted_advance_condition");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "xfade_time", PROPERTY_HINT_RANGE, "0,240,0.01"), "set_xfade_time", "get_xfade_time");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "priority", PROPERTY_HINT_RANGE, "0,32,1"), "set_priority", "get_priority");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -48,6 +48,7 @@ private:
 	bool auto_advance;
 	StringName advance_condition;
 	StringName advance_condition_name;
+	bool inverted_advance_condition;
 	float xfade;
 	bool disabled;
 	int priority;
@@ -66,6 +67,9 @@ public:
 	StringName get_advance_condition() const;
 
 	StringName get_advance_condition_name() const;
+
+	void set_inverted_advance_condition(bool p_inverted);
+	bool is_inverted_advance_condition() const;
 
 	void set_xfade_time(float p_xfade);
 	float get_xfade_time() const;


### PR DESCRIPTION
**What is the problem?**

When creating logic for a state machine, if you consider a simple setup such as the one below:

![image](https://user-images.githubusercontent.com/15147863/91641666-d5320e00-ea1d-11ea-8937-c156ca02cbee.png)

Let's say I want to enter the jumping animation state when a transition parameter "IsJump" evaluates to true. That's easy enough to setup...but what happens when I want to exit that jump state again? Adding another bool "HasFinishedJump" makes for a lot of extra headaches...especially if these simple states start to pile up!

**Proposed Solution**

By adding an extra inversion property to the transition, we allow for the negation of the bool to be considered and this measurably simplifies the ease in setting up these more simplistic animation states.

In the current implementation, it looks like this when highlighting the transition:

![image](https://user-images.githubusercontent.com/15147863/91641727-5b4e5480-ea1e-11ea-94b4-d510abcd345d.png)

![image](https://user-images.githubusercontent.com/15147863/91641736-7751f600-ea1e-11ea-9f3c-019bcd7c3435.png)

There are similar concepts available for animation transitions in other engines e.g using a NOT for boolean evaluation in unreal engine (which is still fast path accessible which shows they put a lot of stock in it) and although it's been a while since I've used Unity I recall the transition logic there allowing the negation to be considered in some fashion.

First go at adding a new feature...so if I've done something incredibly dumb happy to close/adjust as needed. 