### PR TITLE
Move method bindings from ArrayMesh to Mesh:

### DIFF
--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -117,33 +117,6 @@
 				Returns the index of the first surface with this name held within this [ArrayMesh]. If none are found, -1 is returned.
 			</description>
 		</method>
-		<method name="surface_get_array_index_len" qualifiers="const">
-			<return type="int">
-			</return>
-			<argument index="0" name="surf_idx" type="int">
-			</argument>
-			<description>
-				Returns the length in indices of the index array in the requested surface (see [method add_surface_from_arrays]).
-			</description>
-		</method>
-		<method name="surface_get_array_len" qualifiers="const">
-			<return type="int">
-			</return>
-			<argument index="0" name="surf_idx" type="int">
-			</argument>
-			<description>
-				Returns the length in vertices of the vertex array in the requested surface (see [method add_surface_from_arrays]).
-			</description>
-		</method>
-		<method name="surface_get_format" qualifiers="const">
-			<return type="int">
-			</return>
-			<argument index="0" name="surf_idx" type="int">
-			</argument>
-			<description>
-				Returns the format mask of the requested surface (see [method add_surface_from_arrays]).
-			</description>
-		</method>
 		<method name="surface_get_name" qualifiers="const">
 			<return type="String">
 			</return>
@@ -151,15 +124,6 @@
 			</argument>
 			<description>
 				Gets the name assigned to this surface.
-			</description>
-		</method>
-		<method name="surface_get_primitive_type" qualifiers="const">
-			<return type="int" enum="Mesh.PrimitiveType">
-			</return>
-			<argument index="0" name="surf_idx" type="int">
-			</argument>
-			<description>
-				Returns the primitive type of the requested surface (see [method add_surface_from_arrays]).
 			</description>
 		</method>
 		<method name="surface_set_name">

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -62,6 +62,24 @@
 				Returns the amount of surfaces that the [Mesh] holds.
 			</description>
 		</method>
+		<method name="surface_get_array_index_len" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="surf_idx" type="int">
+			</argument>
+			<description>
+				Returns the length in indices of the index array in the requested surface.
+			</description>
+		</method>
+		<method name="surface_get_array_len" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="surf_idx" type="int">
+			</argument>
+			<description>
+				Returns the length in vertices of the vertex array in the requested surface.
+			</description>
+		</method>
 		<method name="surface_get_arrays" qualifiers="const">
 			<return type="Array">
 			</return>
@@ -80,6 +98,15 @@
 				Returns the blend shape arrays for the requested surface.
 			</description>
 		</method>
+		<method name="surface_get_format" qualifiers="const">
+			<return type="int">
+			</return>
+			<argument index="0" name="surf_idx" type="int">
+			</argument>
+			<description>
+				Returns the format mask of the requested surface.
+			</description>
+		</method>
 		<method name="surface_get_material" qualifiers="const">
 			<return type="Material">
 			</return>
@@ -87,6 +114,15 @@
 			</argument>
 			<description>
 				Returns a [Material] in a given surface. Surface is rendered using this material.
+			</description>
+		</method>
+		<method name="surface_get_primitive_type" qualifiers="const">
+			<return type="int" enum="Mesh.PrimitiveType">
+			</return>
+			<argument index="0" name="surf_idx" type="int">
+			</argument>
+			<description>
+				Returns the primitive type of the requested surface.
 			</description>
 		</method>
 		<method name="surface_set_material">

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -467,6 +467,11 @@ Size2i Mesh::get_lightmap_size_hint() const {
 }
 
 void Mesh::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("surface_get_primitive_type", "surf_idx"), &Mesh::surface_get_primitive_type);
+	ClassDB::bind_method(D_METHOD("surface_get_format", "surf_idx"), &Mesh::surface_get_format);
+	ClassDB::bind_method(D_METHOD("surface_get_array_index_len", "surf_idx"), &Mesh::surface_get_array_index_len);
+	ClassDB::bind_method(D_METHOD("surface_get_array_len", "surf_idx"), &Mesh::surface_get_array_len);
+
 	ClassDB::bind_method(D_METHOD("set_lightmap_size_hint", "size"), &Mesh::set_lightmap_size_hint);
 	ClassDB::bind_method(D_METHOD("get_lightmap_size_hint"), &Mesh::get_lightmap_size_hint);
 	ClassDB::bind_method(D_METHOD("get_aabb"), &Mesh::get_aabb);
@@ -1516,10 +1521,6 @@ void ArrayMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_surface_from_arrays", "primitive", "arrays", "blend_shapes", "lods", "compress_flags"), &ArrayMesh::add_surface_from_arrays, DEFVAL(Array()), DEFVAL(Dictionary()), DEFVAL(ARRAY_COMPRESS_DEFAULT));
 	ClassDB::bind_method(D_METHOD("clear_surfaces"), &ArrayMesh::clear_surfaces);
 	ClassDB::bind_method(D_METHOD("surface_update_region", "surf_idx", "offset", "data"), &ArrayMesh::surface_update_region);
-	ClassDB::bind_method(D_METHOD("surface_get_array_len", "surf_idx"), &ArrayMesh::surface_get_array_len);
-	ClassDB::bind_method(D_METHOD("surface_get_array_index_len", "surf_idx"), &ArrayMesh::surface_get_array_index_len);
-	ClassDB::bind_method(D_METHOD("surface_get_format", "surf_idx"), &ArrayMesh::surface_get_format);
-	ClassDB::bind_method(D_METHOD("surface_get_primitive_type", "surf_idx"), &ArrayMesh::surface_get_primitive_type);
 	ClassDB::bind_method(D_METHOD("surface_find_by_name", "name"), &ArrayMesh::surface_find_by_name);
 	ClassDB::bind_method(D_METHOD("surface_set_name", "surf_idx", "name"), &ArrayMesh::surface_set_name);
 	ClassDB::bind_method(D_METHOD("surface_get_name", "surf_idx"), &ArrayMesh::surface_get_name);


### PR DESCRIPTION
1. surface_get_primitive_type
2. surface_get_format
3. surface_get_array_index_len
4. surface_get_array_len

I would extend cpp-bindings to get access from gdnative modules via api.json. I have already successfully tested this.
I would appreciate it if this would be included in the **3.2 branch**.