### PR TITLE
Make `AnimatedTexture.MAX_FRAMES` public

### DIFF
--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -632,11 +632,12 @@ class AnimatedTexture : public Texture2D {
 	//use readers writers lock for this, since its far more times read than written to
 	RWLock *rw_lock;
 
-private:
+public:
 	enum {
 		MAX_FRAMES = 256
 	};
 
+private:
 	RID proxy_ph;
 	RID proxy;
 


### PR DESCRIPTION
The constant is already exposed in GDScript, but not in C++. This information is useful for implementing animated texture resource importers via C++ modules.

For context, see godotengine/godot-proposals#1433.

These changes are equivalent to https://github.com/godotengine/godot/pull/31831/files#diff-35adffedcf62a406d734a90d307cb302R677-R682.