### PR TITLE
Clarify get_data texture method

### DIFF
--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -96,7 +96,7 @@
 			<return type="Image">
 			</return>
 			<description>
-				Returns an [Image] with the data from this [Texture2D]. [Image]s can be accessed and manipulated directly.
+				Returns an [Image] that is a copy of data from this [Texture2D]. [Image]s can be accessed and manipulated directly.
 			</description>
 		</method>
 		<method name="get_height" qualifiers="const">


### PR DESCRIPTION
Clarifies that the `get_data()` method returns a copy of the texture and not the texture itself. Closes https://github.com/godotengine/godot-docs/issues/2609