### PR TITLE
PopupMenu rework and enhancements.

### DIFF
--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -126,6 +126,28 @@ Rect2i Popup::_popup_adjust_rect() const {
 		current.position.y = parent.position.y;
 	}
 
+	if (current.size.y > parent.size.y) {
+		current.size.y = parent.size.y;
+	}
+
+	if (current.size.x > parent.size.x) {
+		current.size.x = parent.size.x;
+	}
+
+	// Early out if max size not set.
+	Size2i max_size = get_max_size();
+	if (max_size <= Size2()) {
+		return current;
+	}
+
+	if (current.size.x > max_size.x) {
+		current.size.x = max_size.x;
+	}
+
+	if (current.size.y > max_size.y) {
+		current.size.y = max_size.y;
+	}
+
 	return current;
 }
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -31,7 +31,9 @@
 #ifndef POPUP_MENU_H
 #define POPUP_MENU_H
 
+#include "scene/gui/margin_container.h"
 #include "scene/gui/popup.h"
+#include "scene/gui/scroll_container.h"
 #include "scene/gui/shortcut.h"
 
 class PopupMenu : public Popup {
@@ -57,10 +59,16 @@ class PopupMenu : public Popup {
 		String tooltip;
 		uint32_t accel;
 		int _ofs_cache;
+		int _height_cache;
 		int h_ofs;
 		Ref<ShortCut> shortcut;
 		bool shortcut_is_global;
 		bool shortcut_is_disabled;
+
+		// Returns (0,0) if icon is null.
+		Size2 get_icon_size() const {
+			return icon.is_null() ? Size2() : icon->get_size();
+		}
 
 		Item() {
 			checked = false;
@@ -71,6 +79,7 @@ class PopupMenu : public Popup {
 			accel = 0;
 			disabled = false;
 			_ofs_cache = 0;
+			_height_cache = 0;
 			h_ofs = 0;
 			shortcut_is_global = false;
 			shortcut_is_disabled = false;
@@ -88,7 +97,10 @@ class PopupMenu : public Popup {
 	String _get_accel_text(int p_item) const;
 	int _get_mouse_over(const Point2 &p_over) const;
 	virtual Size2 _get_contents_minimum_size() const override;
-	void _scroll(float p_factor, const Point2 &p_over);
+
+	int _get_items_total_height() const;
+	void _scroll_to_item(int p_item);
+
 	void _gui_input(const Ref<InputEvent> &p_event);
 	void _activate_submenu(int over);
 	void _submenu_timeout();
@@ -111,9 +123,12 @@ class PopupMenu : public Popup {
 	uint64_t search_time_msec;
 	String search_string;
 
+	MarginContainer *margin_container;
+	ScrollContainer *scroll_container;
 	Control *control;
 
-	void _draw();
+	void _draw_items();
+	void _draw_background();
 
 protected:
 	friend class MenuButton;


### PR DESCRIPTION
Initially inspired by [this](https://www.reddit.com/r/godot/comments/id93w6/resizing_the_optionbutton_popupmenu/) reddit post, which never got it's own issue submitted. This PR resolves a few existing issues with PopupMenu's which did have issue tickets, but also a few others which I found when making this PR.

* Popup menu size can now be limited, and content will scroll. Previously, if the popup menu had a lot of items, it would take up the entire window height and then scroll from there. Now, the size of popup menus can be limited by using `get_popup()->set_max_size()` (in C++) or `get_popup().max_size` (in GDScript). Of course, this works both in editor and in projects.
* This can be selectively used around the editor to help resolve ui issues such as #22404. Examples in-editor shown below.
![pum_in_game](https://user-images.githubusercontent.com/41730826/91675099-7e901580-eb7e-11ea-8167-9a6c4f2a5035.gif)
* Added margin container which improves consistency of look, as well as makes item positioning code simpler and easier to understand.
* Now uses a scroll container so users know it can be scrolled. This also allows the user to scroll without a scroll wheel by clicking and dragging the scrollbar. Previously users needed a scroll wheel to be able to scroll. (Closes #29111)
![pum_scrolling](https://user-images.githubusercontent.com/41730826/91675117-9071b880-eb7e-11ea-8126-5b806b5cbd61.gif)
* Changing item selection with arrow keys now scrolls to follow selected item, whereas previously it did not. (resolves this comment by @KoBeWi, which did not have a separate issue: https://github.com/godotengine/godot/issues/29111#issuecomment-495631414)
* Scrolling with arrow keys stops at first or last item when scrolling up and down, respectively. Previously it looped around and kept on going. 
![pum_arrow_scrolling](https://user-images.githubusercontent.com/41730826/91675132-9c5d7a80-eb7e-11ea-88cf-f0529043b4cf.gif)
* Fixed submenu autohide areas to match exactly the hover area. Previously they were slightly off. Also fixed selection of which item was hovered, as that was also slightly off. Previously the darker area which represented which item was hovered did not accurately represent the size of the actual item. As you can see, submenu's are correctly placed when scrolling is used. Note: I am not recommending that the project menu is made to scroll, this was only for submenu testing purposes.
![pum_submenus](https://user-images.githubusercontent.com/41730826/91675151-a7180f80-eb7e-11ea-9c32-2a2683e80b61.gif)
* When search is enabled, selected item from search query will be scrolled to and highlighted. In the below case I type "obj" and then "res".
![pum_scroll_to_search](https://user-images.githubusercontent.com/41730826/91675189-cadb5580-eb7e-11ea-8a38-ed20091da011.gif)
* Reduced code duplication by moving query of item icon size to a member function in the `Item` struct.
* General code clean up - comments where needed, and rewording variables to be more clear about what they are.

*Bugsquad edit:* Also fixes #41564.