### PR TITLE
Document scroll horizontal and scroll vertical in text edit

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -404,10 +404,10 @@
 			If [code]true[/code], read-only mode is enabled. Existing text cannot be modified and new text cannot be added.
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
-			The current horizontal scroll value.
+			If there is a horizontal scrollbar this determines the current horizontal scroll value in pixels.
 		</member>
 		<member name="scroll_vertical" type="float" setter="set_v_scroll" getter="get_v_scroll" default="0.0">
-			The current vertical scroll value.
+			If there is a vertical scrollbar this determines the current vertical scroll value in line numbers, starting at 0 for the top line.
 		</member>
 		<member name="selecting_enabled" type="bool" setter="set_selecting_enabled" getter="is_selecting_enabled" default="true">
 			If [code]true[/code], text can be selected.


### PR DESCRIPTION
Documents the scroll horizontal and scroll vertical properties of the text edit node. Closes https://github.com/godotengine/godot-docs/issues/3899

I'd like to open an issue to have how scroll horizontal works changed to be character based instead of pixel based. Should I open an issue here or in the proposals repo?