### PR TITLE
CollisionShape2D 'Disabled' Visualization Correction

### DIFF
--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -110,6 +110,7 @@ void CollisionShape2D::_notification(int p_what) {
 				draw_col.r = g;
 				draw_col.g = g;
 				draw_col.b = g;
+				draw_col.a *= 0.5;
 			}
 			shape->draw(get_canvas_item(), draw_col);
 


### PR DESCRIPTION
Having a white or closely desaturated `debug collision shape color` setting would make it harder to visualize enabled / disabled state CollisionShape2D. This change makes it easier to visualize enabled / disabled state by reducing the alpha color by half when disabled.

For the record, white debug collision color makes it useful for developers who want to use the modulation color settings to colorize multiple collision types to their own desired color preferences.