### PR TITLE
doc: Sync classref with current source

### DIFF
--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -70,15 +70,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="add_ios_framework">
-			<return type="void">
-			</return>
-			<argument index="0" name="path" type="String">
-			</argument>
-			<description>
-				Adds a static library (*.a) or dynamic library (*.dylib, *.framework) to Linking Phase in iOS's Xcode project.
-			</description>
-		</method>
 		<method name="add_ios_embedded_framework">
 			<return type="void">
 			</return>
@@ -88,6 +79,15 @@
 				Adds a dynamic library (*.dylib, *.framework) to Linking Phase in iOS's Xcode project and embeds it into resulting binary.
 				[b]Note:[/b] For static libraries (*.a) works in same way as [code]add_ios_framework[/code].
 				This method should not be used for System libraries as they are already present on the device.
+			</description>
+		</method>
+		<method name="add_ios_framework">
+			<return type="void">
+			</return>
+			<argument index="0" name="path" type="String">
+			</argument>
+			<description>
+				Adds a static library (*.a) or dynamic library (*.dylib, *.framework) to Linking Phase in iOS's Xcode project.
 			</description>
 		</method>
 		<method name="add_ios_linker_flags">

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -95,47 +95,20 @@
 		<member name="background_mode" type="int" setter="set_background" getter="get_background" enum="Environment.BGMode" default="0">
 			The background mode. See [enum BGMode] for possible values.
 		</member>
-		<member name="fog_color" type="Color" setter="set_fog_color" getter="get_fog_color" default="Color( 0.5, 0.6, 0.7, 1 )">
-			The fog's [Color].
-		</member>
-		<member name="fog_depth_begin" type="float" setter="set_fog_depth_begin" getter="get_fog_depth_begin" default="10.0">
-			The fog's depth starting distance from the camera.
-		</member>
-		<member name="fog_depth_curve" type="float" setter="set_fog_depth_curve" getter="get_fog_depth_curve" default="1.0">
-			The fog depth's intensity curve. A number of presets are available in the [b]Inspector[/b] by right-clicking the curve.
-		</member>
-		<member name="fog_depth_enabled" type="bool" setter="set_fog_depth_enabled" getter="is_fog_depth_enabled" default="true">
-			If [code]true[/code], the depth fog effect is enabled. When enabled, fog will appear in the distance (relative to the camera).
-		</member>
-		<member name="fog_depth_end" type="float" setter="set_fog_depth_end" getter="get_fog_depth_end" default="100.0">
-			The fog's depth end distance from the camera. If this value is set to 0, it will be equal to the current camera's [member Camera3D.far] value.
+		<member name="fog_density" type="float" setter="set_fog_density" getter="get_fog_density" default="0.001">
 		</member>
 		<member name="fog_enabled" type="bool" setter="set_fog_enabled" getter="is_fog_enabled" default="false">
-			If [code]true[/code], fog effects are enabled. [member fog_height_enabled] and/or [member fog_depth_enabled] must be set to [code]true[/code] to actually display fog.
+			If [code]true[/code], fog effects are enabled.
 		</member>
-		<member name="fog_height_curve" type="float" setter="set_fog_height_curve" getter="get_fog_height_curve" default="1.0">
-			The height fog's intensity. A number of presets are available in the [b]Inspector[/b] by right-clicking the curve.
+		<member name="fog_height" type="float" setter="set_fog_height" getter="get_fog_height" default="0.0">
 		</member>
-		<member name="fog_height_enabled" type="bool" setter="set_fog_height_enabled" getter="is_fog_height_enabled" default="false">
-			If [code]true[/code], the height fog effect is enabled. When enabled, fog will appear in a defined height range, regardless of the distance from the camera. This can be used to simulate "deep water" effects with a lower performance cost compared to a dedicated shader.
+		<member name="fog_height_density" type="float" setter="set_fog_height_density" getter="get_fog_height_density" default="0.0">
 		</member>
-		<member name="fog_height_max" type="float" setter="set_fog_height_max" getter="get_fog_height_max" default="0.0">
-			The Y coordinate where the height fog will be the most intense. If this value is greater than [member fog_height_min], fog will be displayed from bottom to top. Otherwise, it will be displayed from top to bottom.
+		<member name="fog_light_color" type="Color" setter="set_fog_light_color" getter="get_fog_light_color" default="Color( 0.5, 0.6, 0.7, 1 )">
 		</member>
-		<member name="fog_height_min" type="float" setter="set_fog_height_min" getter="get_fog_height_min" default="10.0">
-			The Y coordinate where the height fog will be the least intense. If this value is greater than [member fog_height_max], fog will be displayed from top to bottom. Otherwise, it will be displayed from bottom to top.
+		<member name="fog_light_energy" type="float" setter="set_fog_light_energy" getter="get_fog_light_energy" default="1.0">
 		</member>
-		<member name="fog_sun_amount" type="float" setter="set_fog_sun_amount" getter="get_fog_sun_amount" default="0.0">
-			The intensity of the depth fog color transition when looking towards the sun. The sun's direction is determined automatically using the DirectionalLight3D node in the scene.
-		</member>
-		<member name="fog_sun_color" type="Color" setter="set_fog_sun_color" getter="get_fog_sun_color" default="Color( 1, 0.9, 0.7, 1 )">
-			The depth fog's [Color] when looking towards the sun.
-		</member>
-		<member name="fog_transmit_curve" type="float" setter="set_fog_transmit_curve" getter="get_fog_transmit_curve" default="1.0">
-			The intensity of the fog light transmittance effect. Amount of light that the fog transmits.
-		</member>
-		<member name="fog_transmit_enabled" type="bool" setter="set_fog_transmit_enabled" getter="is_fog_transmit_enabled" default="false">
-			Enables fog's light transmission effect. If [code]true[/code], light will be more visible in the fog to simulate light scattering as in real life.
+		<member name="fog_sun_scatter" type="float" setter="set_fog_sun_scatter" getter="get_fog_sun_scatter" default="0.0">
 		</member>
 		<member name="glow_blend_mode" type="int" setter="set_glow_blend_mode" getter="get_glow_blend_mode" enum="Environment.GlowBlendMode" default="2">
 			The glow blending mode.
@@ -265,6 +238,22 @@
 		<member name="tonemap_white" type="float" setter="set_tonemap_white" getter="get_tonemap_white" default="1.0">
 			The white reference value for tonemapping. Only effective if the [member tonemap_mode] isn't set to [constant TONE_MAPPER_LINEAR].
 		</member>
+		<member name="volumetric_fog_density" type="float" setter="set_volumetric_fog_density" getter="get_volumetric_fog_density" default="0.01">
+		</member>
+		<member name="volumetric_fog_detail_spread" type="float" setter="set_volumetric_fog_detail_spread" getter="get_volumetric_fog_detail_spread" default="2.0">
+		</member>
+		<member name="volumetric_fog_enabled" type="bool" setter="set_volumetric_fog_enabled" getter="is_volumetric_fog_enabled" default="false">
+		</member>
+		<member name="volumetric_fog_gi_inject" type="float" setter="set_volumetric_fog_gi_inject" getter="get_volumetric_fog_gi_inject" default="0.0">
+		</member>
+		<member name="volumetric_fog_length" type="float" setter="set_volumetric_fog_length" getter="get_volumetric_fog_length" default="64.0">
+		</member>
+		<member name="volumetric_fog_light" type="Color" setter="set_volumetric_fog_light" getter="get_volumetric_fog_light" default="Color( 0, 0, 0, 1 )">
+		</member>
+		<member name="volumetric_fog_light_energy" type="float" setter="set_volumetric_fog_light_energy" getter="get_volumetric_fog_light_energy" default="1.0">
+		</member>
+		<member name="volumetric_fog_shadow_filter" type="int" setter="set_volumetric_fog_shadow_filter" getter="get_volumetric_fog_shadow_filter" enum="Environment.VolumetricFogShadowFilter" default="1">
+		</member>
 	</members>
 	<constants>
 		<constant name="BG_CLEAR_COLOR" value="0" enum="BGMode">
@@ -359,6 +348,14 @@
 		<constant name="SDFGI_Y_SCALE_75_PERCENT" value="1" enum="SDFGIYScale">
 		</constant>
 		<constant name="SDFGI_Y_SCALE_50_PERCENT" value="2" enum="SDFGIYScale">
+		</constant>
+		<constant name="VOLUMETRIC_FOG_SHADOW_FILTER_DISABLED" value="0" enum="VolumetricFogShadowFilter">
+		</constant>
+		<constant name="VOLUMETRIC_FOG_SHADOW_FILTER_LOW" value="1" enum="VolumetricFogShadowFilter">
+		</constant>
+		<constant name="VOLUMETRIC_FOG_SHADOW_FILTER_MEDIUM" value="2" enum="VolumetricFogShadowFilter">
+		</constant>
+		<constant name="VOLUMETRIC_FOG_SHADOW_FILTER_HIGH" value="3" enum="VolumetricFogShadowFilter">
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Light3D.xml
+++ b/doc/classes/Light3D.xml
@@ -77,6 +77,8 @@
 		<member name="shadow_enabled" type="bool" setter="set_shadow" getter="has_shadow" default="false">
 			If [code]true[/code], the light will cast shadows.
 		</member>
+		<member name="shadow_fog_fade" type="float" setter="set_param" getter="get_param" default="1.0">
+		</member>
 		<member name="shadow_normal_bias" type="float" setter="set_param" getter="get_param" default="2.0">
 			Offsets the lookup into the shadow map by the object's normal. This can be used to reduce self-shadowing artifacts without using [member shadow_bias]. In practice, this value should be tweaked along with [member shadow_bias] to reduce artifacts as much as possible.
 		</member>
@@ -138,10 +140,12 @@
 		<constant name="PARAM_SHADOW_BLUR" value="16" enum="Param">
 			Constant for accessing [member shadow_blur].
 		</constant>
-		<constant name="PARAM_TRANSMITTANCE_BIAS" value="17" enum="Param">
+		<constant name="PARAM_SHADOW_VOLUMETRIC_FOG_FADE" value="17" enum="Param">
+		</constant>
+		<constant name="PARAM_TRANSMITTANCE_BIAS" value="18" enum="Param">
 			Constant for accessing [member shadow_transmittance_bias].
 		</constant>
-		<constant name="PARAM_MAX" value="18" enum="Param">
+		<constant name="PARAM_MAX" value="19" enum="Param">
 			Represents the size of the [enum Param] enum.
 		</constant>
 		<constant name="BAKE_DISABLED" value="0" enum="BakeMode">

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -495,7 +495,7 @@
 			<description>
 				Translates a message using translation catalogs configured in the Project Settings. An additional context could be used to specify the translation context.
 				Only works if message translation is enabled (which it is by default), otherwise it returns the [code]message[/code] unchanged. See [method set_message_translation].
-				See <link>https://docs.godotengine.org/en/latest/tutorials/i18n/internationalizing_games.html</link> for examples of the usage of this method.
+				See [url=https://docs.godotengine.org/en/latest/tutorials/i18n/internationalizing_games.html]Internationalizing games[/url] for examples of the usage of this method.
 			</description>
 		</method>
 		<method name="tr_n" qualifiers="const">
@@ -514,7 +514,7 @@
 				Only works if message translation is enabled (which it is by default), otherwise it returns the [code]message[/code] or [code]plural_message[/code] unchanged. See [method set_message_translation].
 				The number [code]n[/code] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form for the selected language.
 				[b]Note:[/b] Negative and floating-point values usually represent physical entities for which singular and plural don't clearly apply. In such cases, use [method tr].
-				See <link>https://docs.godotengine.org/en/latest/tutorials/i18n/localization_using_gettext.html</link> for examples of the usage of this method.
+				See [url=https://docs.godotengine.org/en/latest/tutorials/i18n/localization_using_gettext.html]Localization using gettext[/url] for examples of the usage of this method.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1158,6 +1158,16 @@
 		<member name="rendering/threads/thread_model" type="int" setter="" getter="" default="1">
 			Thread model for rendering. Rendering on a thread can vastly improve performance, but synchronizing to the main thread can cause a bit more jitter.
 		</member>
+		<member name="rendering/volumetric_fog/directional_shadow_shrink" type="int" setter="" getter="" default="512">
+		</member>
+		<member name="rendering/volumetric_fog/positional_shadow_shrink" type="int" setter="" getter="" default="512">
+		</member>
+		<member name="rendering/volumetric_fog/use_filter" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="rendering/volumetric_fog/volume_depth" type="int" setter="" getter="" default="128">
+		</member>
+		<member name="rendering/volumetric_fog/volume_size" type="int" setter="" getter="" default="64">
+		</member>
 		<member name="rendering/vram_compression/import_bptc" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the texture importer will import VRAM-compressed textures using the BPTC algorithm. This texture compression algorithm is only supported on desktop platforms, and only when using the Vulkan renderer.
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -690,52 +690,19 @@
 			</argument>
 			<argument index="1" name="enable" type="bool">
 			</argument>
-			<argument index="2" name="color" type="Color">
+			<argument index="2" name="light_color" type="Color">
 			</argument>
-			<argument index="3" name="sun_color" type="Color">
+			<argument index="3" name="light_energy" type="float">
 			</argument>
-			<argument index="4" name="sun_amount" type="float">
+			<argument index="4" name="sun_scatter" type="float">
 			</argument>
-			<description>
-				Sets the variables to be used with the scene fog. See [Environment] for more details.
-			</description>
-		</method>
-		<method name="environment_set_fog_depth">
-			<return type="void">
-			</return>
-			<argument index="0" name="env" type="RID">
+			<argument index="5" name="density" type="float">
 			</argument>
-			<argument index="1" name="enable" type="bool">
+			<argument index="6" name="height" type="float">
 			</argument>
-			<argument index="2" name="depth_begin" type="float">
-			</argument>
-			<argument index="3" name="depth_end" type="float">
-			</argument>
-			<argument index="4" name="depth_curve" type="float">
-			</argument>
-			<argument index="5" name="transmit" type="bool">
-			</argument>
-			<argument index="6" name="transmit_curve" type="float">
+			<argument index="7" name="height_density" type="float">
 			</argument>
 			<description>
-				Sets the variables to be used with the fog depth effect. See [Environment] for more details.
-			</description>
-		</method>
-		<method name="environment_set_fog_height">
-			<return type="void">
-			</return>
-			<argument index="0" name="env" type="RID">
-			</argument>
-			<argument index="1" name="enable" type="bool">
-			</argument>
-			<argument index="2" name="min_height" type="float">
-			</argument>
-			<argument index="3" name="max_height" type="float">
-			</argument>
-			<argument index="4" name="height_curve" type="float">
-			</argument>
-			<description>
-				Sets the variables to be used with the fog height effect. See [Environment] for more details.
 			</description>
 		</method>
 		<method name="environment_set_glow">
@@ -3252,9 +3219,9 @@
 		<constant name="LIGHT_PARAM_SHADOW_BLUR" value="16" enum="LightParam">
 			Blurs the edges of the shadow. Can be used to hide pixel artifacts in low resolution shadow maps. A high value can make shadows appear grainy and can cause other unwanted artifacts. Try to keep as near default as possible.
 		</constant>
-		<constant name="LIGHT_PARAM_TRANSMITTANCE_BIAS" value="17" enum="LightParam">
+		<constant name="LIGHT_PARAM_TRANSMITTANCE_BIAS" value="18" enum="LightParam">
 		</constant>
-		<constant name="LIGHT_PARAM_MAX" value="18" enum="LightParam">
+		<constant name="LIGHT_PARAM_MAX" value="19" enum="LightParam">
 			Represents the size of the [enum LightParam] enum.
 		</constant>
 		<constant name="LIGHT_BAKE_DISABLED" value="0" enum="LightBakeMode">


### PR DESCRIPTION
CC @clayjohn @Calinou if you want to salvage removed docstrings from 3.2 fog for the new properties.