### PR TITLE
Add information on bb code enabled

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -286,6 +286,7 @@
 	<members>
 		<member name="bbcode_enabled" type="bool" setter="set_use_bbcode" getter="is_using_bbcode" default="false">
 			If [code]true[/code], the label uses BBCode formatting.
+			[b]Note:[/b] Trying to alter the [RichTextLabel]'s text with [method set_text] will reset this to [code]false[/code]. Instead use [method set_bbcode] or another method.
 		</member>
 		<member name="bbcode_text" type="String" setter="set_bbcode" getter="get_bbcode" default="&quot;&quot;">
 			The label's text in BBCode format. Is not representative of manual modifications to the internal tag stack. Erases changes made by other methods when edited.


### PR DESCRIPTION
Add that if anything other than `set_bbcode` is used to alter a RichTextLabels text bb code will be disabled. Closes https://github.com/godotengine/godot-docs/issues/1466
