### PR TITLE
doc/FileDialog: warn about access limitations in sandboxed apps

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -57,6 +57,7 @@
 	<members>
 		<member name="access" type="int" setter="set_access" getter="get_access" enum="FileDialog.Access" default="0">
 			The file system access scope. See enum [code]Access[/code] constants.
+			[b]Warning:[/b] Currently, in sandboxed environments such as HTML5 builds or sandboxed macOS apps, FileDialog cannot access the host file system. See [url=https://github.com/godotengine/godot-proposals/issues/1123]godot-proposals#1123[/url].
 		</member>
 		<member name="current_dir" type="String" setter="set_current_dir" getter="get_current_dir" default="&quot;res://&quot;">
 			The current working directory of the file dialog.


### PR DESCRIPTION
As commented in godotengine/godot-proposals#1443, in this PR a warning is added to FileDialog docs about limitations for accessing the host file system in sandboxed environments (HTML5 or macOS).

Ref godotengine/godot-proposals#1123
