### PR TITLE
Expose GraphEdit Zoom Settings

### DIFF
--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -100,6 +100,9 @@ private:
 	bool just_selected;
 	Vector2 drag_accum;
 
+	float zoom_scale;
+	float max_zoom;
+	float min_zoom;
 	float zoom;
 
 	bool box_selecting;
@@ -191,6 +194,12 @@ public:
 	void remove_valid_connection_type(int p_type, int p_with_type);
 	bool is_valid_connection_type(int p_type, int p_with_type) const;
 
+	void set_max_zoom(float p_max_zoom);
+	float get_max_zoom() const;
+	void set_min_zoom(float p_min_zoom);
+	float get_min_zoom() const;
+	void set_zoom_scale(float p_zoom_scale);
+	float get_zoom_scale() const;
 	void set_zoom(float p_zoom);
 	void set_zoom_custom(float p_zoom, const Vector2 &p_center);
 	float get_zoom() const;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

I was playing around with [LittleMouseGames/whiskers](https://github.com/LittleMouseGames/whiskers) dialogue editor by @finchMFG when I noticed that the `GraphEdit` zoom settings are locked in as macros and not configurable.

This PR fixes that by allowing users to set the maximum and minimum zoom options as well as the zoom scale that configures the intensity the plus/minus zoom buttons act upon.

What I feel is missing is the ability to zoom in and out by holding Ctrl + Button Wheel Up and Down. It looks like the code intended to provide this but it was never finished -- I'll submit a separate PR for that later.