### PR TITLE
Fix hard-coded OP_MAX in variant_op.cpp

### DIFF
--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -118,32 +118,32 @@
 
 /* clang-format on */
 
-#define CASES(PREFIX) static const void *switch_table_##PREFIX[25][Variant::VARIANT_MAX] = { \
-	TYPES(PREFIX, OP_EQUAL),                                                                 \
-	TYPES(PREFIX, OP_NOT_EQUAL),                                                             \
-	TYPES(PREFIX, OP_LESS),                                                                  \
-	TYPES(PREFIX, OP_LESS_EQUAL),                                                            \
-	TYPES(PREFIX, OP_GREATER),                                                               \
-	TYPES(PREFIX, OP_GREATER_EQUAL),                                                         \
-	TYPES(PREFIX, OP_ADD),                                                                   \
-	TYPES(PREFIX, OP_SUBTRACT),                                                              \
-	TYPES(PREFIX, OP_MULTIPLY),                                                              \
-	TYPES(PREFIX, OP_DIVIDE),                                                                \
-	TYPES(PREFIX, OP_NEGATE),                                                                \
-	TYPES(PREFIX, OP_POSITIVE),                                                              \
-	TYPES(PREFIX, OP_MODULE),                                                                \
-	TYPES(PREFIX, OP_STRING_CONCAT),                                                         \
-	TYPES(PREFIX, OP_SHIFT_LEFT),                                                            \
-	TYPES(PREFIX, OP_SHIFT_RIGHT),                                                           \
-	TYPES(PREFIX, OP_BIT_AND),                                                               \
-	TYPES(PREFIX, OP_BIT_OR),                                                                \
-	TYPES(PREFIX, OP_BIT_XOR),                                                               \
-	TYPES(PREFIX, OP_BIT_NEGATE),                                                            \
-	TYPES(PREFIX, OP_AND),                                                                   \
-	TYPES(PREFIX, OP_OR),                                                                    \
-	TYPES(PREFIX, OP_XOR),                                                                   \
-	TYPES(PREFIX, OP_NOT),                                                                   \
-	TYPES(PREFIX, OP_IN),                                                                    \
+#define CASES(PREFIX) static const void *switch_table_##PREFIX[Variant::OP_MAX][Variant::VARIANT_MAX] = { \
+	TYPES(PREFIX, OP_EQUAL),                                                                              \
+	TYPES(PREFIX, OP_NOT_EQUAL),                                                                          \
+	TYPES(PREFIX, OP_LESS),                                                                               \
+	TYPES(PREFIX, OP_LESS_EQUAL),                                                                         \
+	TYPES(PREFIX, OP_GREATER),                                                                            \
+	TYPES(PREFIX, OP_GREATER_EQUAL),                                                                      \
+	TYPES(PREFIX, OP_ADD),                                                                                \
+	TYPES(PREFIX, OP_SUBTRACT),                                                                           \
+	TYPES(PREFIX, OP_MULTIPLY),                                                                           \
+	TYPES(PREFIX, OP_DIVIDE),                                                                             \
+	TYPES(PREFIX, OP_NEGATE),                                                                             \
+	TYPES(PREFIX, OP_POSITIVE),                                                                           \
+	TYPES(PREFIX, OP_MODULE),                                                                             \
+	TYPES(PREFIX, OP_STRING_CONCAT),                                                                      \
+	TYPES(PREFIX, OP_SHIFT_LEFT),                                                                         \
+	TYPES(PREFIX, OP_SHIFT_RIGHT),                                                                        \
+	TYPES(PREFIX, OP_BIT_AND),                                                                            \
+	TYPES(PREFIX, OP_BIT_OR),                                                                             \
+	TYPES(PREFIX, OP_BIT_XOR),                                                                            \
+	TYPES(PREFIX, OP_BIT_NEGATE),                                                                         \
+	TYPES(PREFIX, OP_AND),                                                                                \
+	TYPES(PREFIX, OP_OR),                                                                                 \
+	TYPES(PREFIX, OP_XOR),                                                                                \
+	TYPES(PREFIX, OP_NOT),                                                                                \
+	TYPES(PREFIX, OP_IN),                                                                                 \
 }
 
 #define SWITCH(PREFIX, op, val) goto *switch_table_##PREFIX[op][val];


### PR DESCRIPTION
Found a hard-coded 25 in variant_op that should be Variant::OP_MAX if I am not mistaken.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
