### PR TITLE
Fix typo in SDF jumpflood shader

### DIFF
--- a/servers/rendering/rasterizer_rd/shaders/sdfgi_preprocess.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/sdfgi_preprocess.glsl
@@ -338,7 +338,7 @@ void main() {
 			continue; //was not initialized yet, ignore
 		}
 
-		float q_dist = distance(posf, vec3(p.xyz));
+		float q_dist = distance(posf, vec3(q.xyz));
 		if (p.w == 0 || q_dist < p_dist) {
 			p = q; //just replace because current is unused
 			p_dist = q_dist;


### PR DESCRIPTION
Fixes small typo in the jumpflood shader that generates SDF cascades for SDFGI. 

It was mostly unnoticeable because the optimized version, used when the jumpflood steps are smaller, doesn't have this issue.
