### PR TITLE
Remove GitHub actions badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ provided by the community, such as text and video tutorials, demos, etc.
 Consult the [community channels](https://godotengine.org/community)
 for more information.
 
-[![Actions Build Status](https://github.com/godotengine/godot/workflows/Godot/badge.svg?branch=master)](https://github.com/godotengine/godot/actions)
 [![Code Triagers Badge](https://www.codetriage.com/godotengine/godot/badges/users.svg)](https://www.codetriage.com/godotengine/godot)
 [![Translate on Weblate](https://hosted.weblate.org/widgets/godot-engine/-/godot/svg-badge.svg)](https://hosted.weblate.org/engage/godot-engine/?utm_source=widget)
 [![Total alerts on LGTM](https://img.shields.io/lgtm/alerts/g/godotengine/godot.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/godotengine/godot/alerts)


### PR DESCRIPTION
`Godot` workflow is long removed in `master`, and is only found in the `3.2-android-app-bundle` branch currently. As of now Github actions has no way to show `passing` if all checks are passed but only to show the badge of each workflow individually. We can make a feature request later on but for now, we should remove the `Godot CI` badge as it reflects completely something else.