### PR TITLE
Move note about using ResourceLoader in the File documentation

### DIFF
--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -21,6 +21,7 @@
 		    return content
 		[/codeblock]
 		In the example above, the file will be saved in the user data folder as specified in the [url=https://docs.godotengine.org/en/latest/tutorials/io/data_paths.html]Data paths[/url] documentation.
+		[b]Note:[/b] To access project resources once exported, it is recommended to use [ResourceLoader] instead of the [File] API, as some files are converted to engine-specific formats and their original source files might not be present in the exported PCK package.
 	</description>
 	<tutorials>
 		<link title="File system">https://docs.godotengine.org/en/latest/getting_started/step_by_step/filesystem.html</link>
@@ -48,7 +49,7 @@
 			</argument>
 			<description>
 				Returns [code]true[/code] if the file exists in the given path.
-				[b]Note:[/b] Many resources types are imported (e.g. textures or sound files), and that their source asset will not be included in the exported game, as only the imported version is used (in the [code]res://.import[/code] folder). To check for the existence of such resources while taking into account the remapping to their imported location, use [method ResourceLoader.exists]. Typically, using [code]File.file_exists[/code] on an imported resource would work while you are developing in the editor (the source asset is present in [code]res://[/code], but fail when exported).
+				[b]Note:[/b] Many resources types are imported (e.g. textures or sound files), and their source asset will not be included in the exported game, as only the imported version is used. See [method ResourceLoader.exists] for an alternative approach that takes resource remapping into account.
 			</description>
 		</method>
 		<method name="get_16" qualifiers="const">


### PR DESCRIPTION
The note that you should not use `File` for internal resources, and instead use `ResourceLoader`, was moved to the `File` description, and shortened. I do not think it was very helpful only existing under the `file_exists` information.
