### PR TITLE
Improve and Simplify SpinBox Focus Behaviour

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -122,8 +122,6 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 
 		switch (mb->get_button_index()) {
 			case MouseButton::LEFT: {
-				line_edit->grab_focus();
-
 				set_value(get_value() + (up ? get_step() : -get_step()));
 
 				range_click_timer->set_wait_time(0.6);
@@ -134,20 +132,15 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 				drag.capture_pos = mb->get_position();
 			} break;
 			case MouseButton::RIGHT: {
-				line_edit->grab_focus();
 				set_value((up ? get_max() : get_min()));
 			} break;
 			case MouseButton::WHEEL_UP: {
-				if (line_edit->has_focus()) {
-					set_value(get_value() + get_step() * mb->get_factor());
-					accept_event();
-				}
+				set_value(get_value() + get_step() * mb->get_factor());
+				accept_event();
 			} break;
 			case MouseButton::WHEEL_DOWN: {
-				if (line_edit->has_focus()) {
-					set_value(get_value() - get_step() * mb->get_factor());
-					accept_event();
-				}
+				set_value(get_value() - get_step() * mb->get_factor());
+				accept_event();
 			} break;
 			default:
 				break;
@@ -215,10 +208,8 @@ void SpinBox::_notification(int p_what) {
 	} else if (p_what == NOTIFICATION_ENTER_TREE) {
 		_adjust_width_for_icon(get_theme_icon(SNAME("updown")));
 		_value_changed(0);
-	} else if (p_what == NOTIFICATION_EXIT_TREE) {
-		_release_mouse();
-	} else if (p_what == NOTIFICATION_TRANSLATION_CHANGED) {
-		_value_changed(0);
+
+		line_edit->set_focus_mode(get_focus_mode());
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
 		call_deferred(SNAME("minimum_size_changed"));
 		get_line_edit()->call_deferred(SNAME("minimum_size_changed"));


### PR DESCRIPTION
SpinBox should now respect `focus_mode` correctly.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
