### PR TITLE
Fix doctest runner ignoring all arguments starting with --test

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -86,8 +86,9 @@ int test_main(int argc, char *argv[]) {
 
 	// Clean arguments of "--test" from the args.
 	for (int x = 0; x < argc; x++) {
-		if (strncmp(argv[x], "--test", 6) != 0) {
-			test_args.push_back(String(argv[x]));
+		String arg = String(argv[x]);
+		if (arg != "--test") {
+			test_args.push_back(arg);
 		}
 	}
 	// Convert Godot command line arguments back to standard arguments.


### PR DESCRIPTION
Instead of just the one argument that is exactly --test.
The long-form arguments --test-case and --test-suite were ignored.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
