### PR TITLE
Fix Area monitorable in 2D and 3D Godot physics.

### DIFF
--- a/servers/physics_2d/godot_area_2d.cpp
+++ b/servers/physics_2d/godot_area_2d.cpp
@@ -213,6 +213,7 @@ void GodotArea2D::set_monitorable(bool p_monitorable) {
 
 	monitorable = p_monitorable;
 	_set_static(!monitorable);
+	_shapes_changed();
 }
 
 void GodotArea2D::call_queries() {

--- a/servers/physics_2d/godot_area_pair_2d.cpp
+++ b/servers/physics_2d/godot_area_pair_2d.cpp
@@ -128,7 +128,7 @@ bool GodotArea2Pair2D::setup(real_t p_step) {
 
 	process_collision_a = false;
 	if (result_a != colliding_a) {
-		if (area_a->has_area_monitor_callback() && area_b->is_monitorable()) {
+		if (area_a->has_area_monitor_callback() && area_b_monitorable) {
 			process_collision_a = true;
 			process_collision = true;
 		}
@@ -137,7 +137,7 @@ bool GodotArea2Pair2D::setup(real_t p_step) {
 
 	process_collision_b = false;
 	if (result_b != colliding_b) {
-		if (area_b->has_area_monitor_callback() && area_a->is_monitorable()) {
+		if (area_b->has_area_monitor_callback() && area_a_monitorable) {
 			process_collision_b = true;
 			process_collision = true;
 		}
@@ -176,19 +176,21 @@ GodotArea2Pair2D::GodotArea2Pair2D(GodotArea2D *p_area_a, int p_shape_a, GodotAr
 	area_b = p_area_b;
 	shape_a = p_shape_a;
 	shape_b = p_shape_b;
+	area_a_monitorable = area_a->is_monitorable();
+	area_b_monitorable = area_b->is_monitorable();
 	area_a->add_constraint(this);
 	area_b->add_constraint(this);
 }
 
 GodotArea2Pair2D::~GodotArea2Pair2D() {
 	if (colliding_a) {
-		if (area_a->has_area_monitor_callback()) {
+		if (area_a->has_area_monitor_callback() && area_b_monitorable) {
 			area_a->remove_area_from_query(area_b, shape_b, shape_a);
 		}
 	}
 
 	if (colliding_b) {
-		if (area_b->has_area_monitor_callback()) {
+		if (area_b->has_area_monitor_callback() && area_a_monitorable) {
 			area_b->remove_area_from_query(area_a, shape_a, shape_b);
 		}
 	}

--- a/servers/physics_2d/godot_area_pair_2d.h
+++ b/servers/physics_2d/godot_area_pair_2d.h
@@ -62,6 +62,8 @@ class GodotArea2Pair2D : public GodotConstraint2D {
 	bool colliding_b = false;
 	bool process_collision_a = false;
 	bool process_collision_b = false;
+	bool area_a_monitorable;
+	bool area_b_monitorable;
 
 public:
 	virtual bool setup(real_t p_step) override;

--- a/servers/physics_3d/godot_area_3d.cpp
+++ b/servers/physics_3d/godot_area_3d.cpp
@@ -242,6 +242,7 @@ void GodotArea3D::set_monitorable(bool p_monitorable) {
 
 	monitorable = p_monitorable;
 	_set_static(!monitorable);
+	_shapes_changed();
 }
 
 void GodotArea3D::call_queries() {

--- a/servers/physics_3d/godot_area_pair_3d.cpp
+++ b/servers/physics_3d/godot_area_pair_3d.cpp
@@ -129,7 +129,7 @@ bool GodotArea2Pair3D::setup(real_t p_step) {
 
 	process_collision_a = false;
 	if (result_a != colliding_a) {
-		if (area_a->has_area_monitor_callback() && area_b->is_monitorable()) {
+		if (area_a->has_area_monitor_callback() && area_b_monitorable) {
 			process_collision_a = true;
 			process_collision = true;
 		}
@@ -138,7 +138,7 @@ bool GodotArea2Pair3D::setup(real_t p_step) {
 
 	process_collision_b = false;
 	if (result_b != colliding_b) {
-		if (area_b->has_area_monitor_callback() && area_a->is_monitorable()) {
+		if (area_b->has_area_monitor_callback() && area_a_monitorable) {
 			process_collision_b = true;
 			process_collision = true;
 		}
@@ -177,19 +177,21 @@ GodotArea2Pair3D::GodotArea2Pair3D(GodotArea3D *p_area_a, int p_shape_a, GodotAr
 	area_b = p_area_b;
 	shape_a = p_shape_a;
 	shape_b = p_shape_b;
+	area_a_monitorable = area_a->is_monitorable();
+	area_b_monitorable = area_b->is_monitorable();
 	area_a->add_constraint(this);
 	area_b->add_constraint(this);
 }
 
 GodotArea2Pair3D::~GodotArea2Pair3D() {
 	if (colliding_a) {
-		if (area_a->has_area_monitor_callback()) {
+		if (area_a->has_area_monitor_callback() && area_b_monitorable) {
 			area_a->remove_area_from_query(area_b, shape_b, shape_a);
 		}
 	}
 
 	if (colliding_b) {
-		if (area_b->has_area_monitor_callback()) {
+		if (area_b->has_area_monitor_callback() && area_a_monitorable) {
 			area_b->remove_area_from_query(area_a, shape_a, shape_b);
 		}
 	}

--- a/servers/physics_3d/godot_area_pair_3d.h
+++ b/servers/physics_3d/godot_area_pair_3d.h
@@ -63,6 +63,8 @@ class GodotArea2Pair3D : public GodotConstraint3D {
 	bool colliding_b = false;
 	bool process_collision_a = false;
 	bool process_collision_b = false;
+	bool area_a_monitorable;
+	bool area_b_monitorable;
 
 public:
 	virtual bool setup(real_t p_step) override;


### PR DESCRIPTION
In Godot physics (2D and 3D), when an `Area`'s `Monitorable` property is changed, it updates the broadphase collision checker by changing the `static` field. This removes any active collision pairs and creates new ones. Currently, deleting an active collision pair will trigger `area_exited` signals. However, the `Area`'s status is not changed, so the new pair is ignored until something else forces an update e.g. moving the `Area`.

This patch does two things, both of which are required to fix the issues with changes to `Monitorable` not working. First, when changing the `Monitorable` property, it calls `_shapes_changed()`, which adds the `Area` to the `Space`'s moved areas' list, which will trigger a collision update for the new collision pair created. Second, it ensures that only areas that were `Monitorable` are added to the `Areas` removed list when the collision pair is deleted. This also ensures that the new pair's `area_entered` signals are not cancelled by the old pair's `area_exited` signals.

Fixes #23484
Fixes #27441

Note: This does not fix being unable to disable `Monitorable` in Bullet physics. This is fixed in #42306.
