### PR TITLE
Merge python EnvironmentError, IOError and WindowsError into OSError.

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -185,7 +185,7 @@ def write_modules(module_list):
                 unregister_cpp += "#ifdef MODULE_" + name.upper() + "_ENABLED\n"
                 unregister_cpp += "\tunregister_" + name + "_types();\n"
                 unregister_cpp += "#endif\n"
-        except IOError:
+        except OSError:
             pass
 
     modules_cpp = """// register_module_types.gen.cpp
@@ -522,7 +522,7 @@ def generate_cpp_hint_file(filename):
         try:
             with open(filename, "w") as fd:
                 fd.write("#define GDCLASS(m_class, m_inherits)\n")
-        except IOError:
+        except OSError:
             print("Could not write cpp.hint file.")
 
 

--- a/modules/mono/build_scripts/mono_reg_utils.py
+++ b/modules/mono/build_scripts/mono_reg_utils.py
@@ -9,7 +9,7 @@ if os.name == "nt":
 def _reg_open_key(key, subkey):
     try:
         return winreg.OpenKey(key, subkey)
-    except (WindowsError, OSError):
+    except OSError:
         if platform.architecture()[0] == "32bit":
             bitness_sam = winreg.KEY_WOW64_64KEY
         else:
@@ -37,7 +37,7 @@ def _find_mono_in_reg(subkey, bits):
         with _reg_open_key_bits(winreg.HKEY_LOCAL_MACHINE, subkey, bits) as hKey:
             value = winreg.QueryValueEx(hKey, "SdkInstallRoot")[0]
             return value
-    except (WindowsError, OSError):
+    except OSError:
         return None
 
 
@@ -48,7 +48,7 @@ def _find_mono_in_reg_old(subkey, bits):
             if default_clr:
                 return _find_mono_in_reg(subkey + "\\" + default_clr, bits)
             return None
-    except (WindowsError, EnvironmentError):
+    except OSError:
         return None
 
 
@@ -97,7 +97,7 @@ def find_msbuild_tools_path_reg():
         raise ValueError("Cannot find `installationPath` entry")
     except ValueError as e:
         print("Error reading output from vswhere: " + e.message)
-    except WindowsError:
+    except OSError:
         pass  # Fine, vswhere not found
     except (subprocess.CalledProcessError, OSError):
         pass
@@ -109,5 +109,5 @@ def find_msbuild_tools_path_reg():
         with _reg_open_key(winreg.HKEY_LOCAL_MACHINE, subkey) as hKey:
             value = winreg.QueryValueEx(hKey, "MSBuildToolsPath")[0]
             return value
-    except (WindowsError, OSError):
+    except OSError:
         return ""

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -55,7 +55,7 @@ def run_in_subprocess(builder_function):
         finally:
             try:
                 os.remove(json_path)
-            except (OSError, IOError) as e:
+            except OSError as e:
                 # Do not fail the entire build if it cannot delete a temporary file
                 print(
                     "WARNING: Could not delete temporary file: path=%r; [%s] %s" % (json_path, e.__class__.__name__, e)


### PR DESCRIPTION
Since Python 3.3 ([PEP3151](https://www.python.org/dev/peps/pep-3151/)), `EnvironmentError`, `IOError` and `WindowsError` have been merged into `OSError`. This patch converts all instances of `EnvironmentError`, `IOError` and `WindowsError` into `OSError`.

~Should fix the (unrelated) "Syntax Error" found by LGTM.~
*Edit:* It didn't :-( 