### PR TITLE
Mention Viewport.render_target_clear_mode property is intended for 2D usage

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -267,6 +267,7 @@
 		</member>
 		<member name="render_target_clear_mode" type="int" setter="set_clear_mode" getter="get_clear_mode" enum="Viewport.ClearMode" default="0">
 			The clear mode when viewport used as a render target.
+			[b]Note:[/b] This property is intended for 2D usage.
 		</member>
 		<member name="render_target_update_mode" type="int" setter="set_update_mode" getter="get_update_mode" enum="Viewport.UpdateMode" default="2">
 			The update mode when viewport used as a render target.


### PR DESCRIPTION
Targeting 3.2 since it seems this property has moved to the `SubViewport` class in master.
Making a separate PR for master now.

In response to https://github.com/godotengine/godot/issues/33831

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
