### PR TITLE
dummy_rasterizer now returns correct instance type: VS::INSTANCE_LIGHTMAP_CAPTURE

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -719,6 +719,8 @@ public:
 	VS::InstanceType get_base_type(RID p_rid) const {
 		if (mesh_owner.owns(p_rid)) {
 			return VS::INSTANCE_MESH;
+		} else if (lightmap_capture_data_owner.owns(p_rid)) {
+			return VS::INSTANCE_LIGHTMAP_CAPTURE;
 		}
 
 		return VS::INSTANCE_NONE;


### PR DESCRIPTION
Previously `VS::INSTANCE_NONE` was returned for Lightmap data, this caused `visual_server_scene.cpp` to assert in `instance_set_use_lightmap()`

Now `dummy_rasterizer.h` returns `VS::INSTANCE_LIGHTMAP_CAPTURE` for lightmap capture data thus satisfying `visual_server_scene`

What this is fixing is an excessive amount of log spam from that `assert()` in `visual_server_scene.cpp` when ever a scene is loaded that contains light maps:
```
ERROR: instance_set_use_lightmap: Condition "lightmap_instance->base_type != VisualServer::INSTANCE_LIGHTMAP_CAPTURE" is true.
   At: servers/visual/visual_server_scene.cpp:713.
```
