### PR TITLE
Implement reverse playback for animtree

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -87,10 +87,10 @@ float AnimationNodeAnimation::process(float p_time, bool p_seek) {
 	float step;
 
 	if (p_seek) {
+		step = p_time - time;
 		time = p_time;
-		step = 0;
 	} else {
-		time = MAX(0, time + p_time);
+		time = time + p_time;
 		step = p_time;
 	}
 
@@ -103,6 +103,10 @@ float AnimationNodeAnimation::process(float p_time, bool p_seek) {
 
 	} else if (time > anim_size) {
 		time = anim_size;
+		step = 0;
+	} else if (time < 0) {
+		time = 0;
+		step = 0;
 	}
 
 	blend_animation(animation, time, step, p_seek, 1.0);
@@ -534,7 +538,7 @@ AnimationNodeBlend3::AnimationNodeBlend3() {
 /////////////////////////////////
 
 void AnimationNodeTimeScale::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::FLOAT, scale, PROPERTY_HINT_RANGE, "0,32,0.01,or_greater"));
+	r_list->push_back(PropertyInfo(Variant::FLOAT, scale, PROPERTY_HINT_RANGE, "-32,32,0.01,or_greater"));
 }
 
 Variant AnimationNodeTimeScale::get_parameter_default_value(const StringName &p_parameter) const {

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -181,7 +181,7 @@ private:
 	int _insert(float p_time, T &p_keys, const V &p_value);
 
 	template <class K>
-	inline int _find(const Vector<K> &p_keys, float p_time) const;
+	inline int _find(const Vector<K> &p_keys, float p_time, bool reverse = false) const;
 
 	_FORCE_INLINE_ Animation::TransformKey _interpolate(const Animation::TransformKey &p_a, const Animation::TransformKey &p_b, float p_c) const;
 
@@ -197,7 +197,7 @@ private:
 	_FORCE_INLINE_ float _cubic_interpolate(const float &p_pre_a, const float &p_a, const float &p_b, const float &p_post_b, float p_c) const;
 
 	template <class T>
-	_FORCE_INLINE_ T _interpolate(const Vector<TKey<T>> &p_keys, float p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok) const;
+	_FORCE_INLINE_ T _interpolate(const Vector<TKey<T>> &p_keys, float p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok, bool reverse = false) const;
 
 	template <class T>
 	_FORCE_INLINE_ void _track_get_key_indices_in_range(const Vector<T> &p_array, float from_time, float to_time, List<int> *p_indices) const;
@@ -211,11 +211,11 @@ private:
 
 	// bind helpers
 private:
-	Array _transform_track_interpolate(int p_track, float p_time) const {
+	Array _transform_track_interpolate(int p_track, float p_time, bool reverse = false) const {
 		Vector3 loc;
 		Quat rot;
 		Vector3 scale;
-		transform_track_interpolate(p_track, p_time, &loc, &rot, &scale);
+		transform_track_interpolate(p_track, p_time, &loc, &rot, &scale, reverse);
 		Array ret;
 		ret.push_back(loc);
 		ret.push_back(rot);
@@ -321,7 +321,7 @@ public:
 	void track_set_interpolation_loop_wrap(int p_track, bool p_enable);
 	bool track_get_interpolation_loop_wrap(int p_track) const;
 
-	Error transform_track_interpolate(int p_track, float p_time, Vector3 *r_loc, Quat *r_rot, Vector3 *r_scale) const;
+	Error transform_track_interpolate(int p_track, float p_time, Vector3 *r_loc, Quat *r_rot, Vector3 *r_scale, bool reverse = false) const;
 
 	Variant value_track_interpolate(int p_track, float p_time) const;
 	void value_track_get_key_indices(int p_track, float p_time, float p_delta, List<int> *p_indices) const;


### PR DESCRIPTION
For [#21665](https://github.com/godotengine/godot/issues/21665) and [#27215](https://github.com/godotengine/godot/issues/27215).

- Since it is assumed to be a non-reverse play, `find()` gets the key frame just before the current time.
- Also, the Animation Node was interfering with the loop and root motion.

This fix solves these issues and implements a negative Time Scale in the Animation Tree.

https://www.youtube.com/watch?v=iPIG41NEgyM

I've uploaded a sample project to be used for testing.

[animation_tracks_test.zip](https://github.com/godotengine/godot/files/5164690/animation_tracks_test.zip)
[reverse_root_motion.zip](https://github.com/godotengine/godot/files/5164807/reverse_root_motion.zip)
