### PR TITLE
C#: Fix Windows detection for copying MSBuild stub

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <None Include="MSBuild.exe" CopyToOutputDirectory="Always" />
   </ItemGroup>
-  <Target Name="CopyMSBuildStubWindows" AfterTargets="Build" Condition="$([MSBuild]::IsOsPlatform(Windows))">
+  <Target Name="CopyMSBuildStubWindows" AfterTargets="Build" Condition=" '$(GodotPlatform)' == 'windows' Or ( '$(GodotPlatform)' == '' And '$(OS)' == 'Windows_NT' ) ">
     <PropertyGroup>
       <GodotSourceRootPath>$(SolutionDir)/../../../../</GodotSourceRootPath>
       <GodotOutputDataDir>$(GodotSourceRootPath)/bin/GodotSharp</GodotOutputDataDir>


### PR DESCRIPTION
Previous condition checked only the host platform. This was a problem as our official builds are from Linux.

Fixes #41726
