### PR TITLE
Ensure header guards enclose entire header.

### DIFF
--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef MINIZIP_ENABLED
-
 #ifndef FILE_ACCESS_ZIP_H
 #define FILE_ACCESS_ZIP_H
+
+#ifdef MINIZIP_ENABLED
 
 #include "core/io/file_access_pack.h"
 #include "core/map.h"
@@ -113,6 +113,6 @@ public:
 	~FileAccessZip();
 };
 
-#endif // FILE_ACCESS_ZIP_H
-
 #endif // MINIZIP_ENABLED
+
+#endif // FILE_ACCESS_ZIP_H

--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef ALSA_ENABLED
-
 #ifndef AUDIO_DRIVER_ALSA_H
 #define AUDIO_DRIVER_ALSA_H
+
+#ifdef ALSA_ENABLED
 
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
@@ -88,6 +88,6 @@ public:
 	~AudioDriverALSA() {}
 };
 
-#endif // AUDIO_DRIVER_ALSA_H
-
 #endif // ALSA_ENABLED
+
+#endif // AUDIO_DRIVER_ALSA_H

--- a/drivers/alsamidi/midi_driver_alsamidi.h
+++ b/drivers/alsamidi/midi_driver_alsamidi.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef ALSAMIDI_ENABLED
-
 #ifndef MIDI_DRIVER_ALSAMIDI_H
 #define MIDI_DRIVER_ALSAMIDI_H
+
+#ifdef ALSAMIDI_ENABLED
 
 #include "core/os/midi_driver.h"
 #include "core/os/mutex.h"
@@ -64,5 +64,6 @@ public:
 	virtual ~MIDIDriverALSAMidi();
 };
 
-#endif // MIDI_DRIVER_ALSAMIDI_H
 #endif // ALSAMIDI_ENABLED
+
+#endif // MIDI_DRIVER_ALSAMIDI_H

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef PULSEAUDIO_ENABLED
-
 #ifndef AUDIO_DRIVER_PULSEAUDIO_H
 #define AUDIO_DRIVER_PULSEAUDIO_H
+
+#ifdef PULSEAUDIO_ENABLED
 
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
@@ -124,6 +124,6 @@ public:
 	~AudioDriverPulseAudio() {}
 };
 
-#endif // AUDIO_DRIVER_PULSEAUDIO_H
-
 #endif // PULSEAUDIO_ENABLED
+
+#endif // AUDIO_DRIVER_PULSEAUDIO_H

--- a/modules/cvtt/register_types.h
+++ b/modules/cvtt/register_types.h
@@ -28,14 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef TOOLS_ENABLED
-
 #ifndef CVTT_REGISTER_TYPES_H
 #define CVTT_REGISTER_TYPES_H
+
+#ifdef TOOLS_ENABLED
 
 void register_cvtt_types();
 void unregister_cvtt_types();
 
-#endif // CVTT_REGISTER_TYPES_H
-
 #endif // TOOLS_ENABLED
+
+#endif // CVTT_REGISTER_TYPES_H

--- a/modules/webrtc/webrtc_data_channel_gdnative.h
+++ b/modules/webrtc/webrtc_data_channel_gdnative.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef WEBRTC_GDNATIVE_ENABLED
-
 #ifndef WEBRTC_DATA_CHANNEL_GDNATIVE_H
 #define WEBRTC_DATA_CHANNEL_GDNATIVE_H
+
+#ifdef WEBRTC_GDNATIVE_ENABLED
 
 #include "modules/gdnative/include/net/godot_net.h"
 #include "webrtc_data_channel.h"
@@ -75,6 +75,6 @@ public:
 	~WebRTCDataChannelGDNative();
 };
 
-#endif // WEBRTC_DATA_CHANNEL_GDNATIVE_H
-
 #endif // WEBRTC_GDNATIVE_ENABLED
+
+#endif // WEBRTC_DATA_CHANNEL_GDNATIVE_H

--- a/modules/webrtc/webrtc_peer_connection_gdnative.h
+++ b/modules/webrtc/webrtc_peer_connection_gdnative.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef WEBRTC_GDNATIVE_ENABLED
-
 #ifndef WEBRTC_PEER_CONNECTION_GDNATIVE_H
 #define WEBRTC_PEER_CONNECTION_GDNATIVE_H
+
+#ifdef WEBRTC_GDNATIVE_ENABLED
 
 #include "modules/gdnative/include/net/godot_net.h"
 #include "webrtc_peer_connection.h"
@@ -68,6 +68,6 @@ public:
 	~WebRTCPeerConnectionGDNative();
 };
 
-#endif // WEBRTC_PEER_CONNECTION_GDNATIVE_H
-
 #endif // WEBRTC_GDNATIVE_ENABLED
+
+#endif // WEBRTC_PEER_CONNECTION_GDNATIVE_H


### PR DESCRIPTION
Some header guards created with #37219, did not enclose the entire header, and therefore did not completely resolve #37143. This PR ensures all header guards enclose the entire header.
