### PR TITLE
Auto-choose a mode for created visual shader

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1619,6 +1619,14 @@ void VisualShader::_input_type_changed(Type p_type, int p_id) {
 	}
 }
 
+bool VisualShader::is_initialized() const {
+	return initialized;
+}
+
+void VisualShader::set_initialized(bool p_enabled) {
+	initialized = p_enabled;
+}
+
 void VisualShader::rebuild() {
 	dirty.set();
 	_update_shader();
@@ -1654,10 +1662,14 @@ void VisualShader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_graph_offset", "offset"), &VisualShader::set_graph_offset);
 	ClassDB::bind_method(D_METHOD("get_graph_offset"), &VisualShader::get_graph_offset);
 
+	ClassDB::bind_method(D_METHOD("set_initialized", "enabled"), &VisualShader::set_initialized);
+	ClassDB::bind_method(D_METHOD("is_initialized"), &VisualShader::is_initialized);
+
 	ClassDB::bind_method(D_METHOD("_update_shader"), &VisualShader::_update_shader);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "graph_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_graph_offset", "get_graph_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "version", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_version", "get_version");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "initialized", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_initialized", "is_initialized");
 
 	ADD_PROPERTY_DEFAULT("code", ""); // Inherited from Shader, prevents showing default code as override in docs.
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -45,6 +45,7 @@ class VisualShader : public Shader {
 	friend class VisualShaderNodeVersionChecker;
 
 	String version = "";
+	bool initialized = false;
 
 public:
 	enum Type {
@@ -176,6 +177,9 @@ public:
 
 	void set_graph_offset(const Vector2 &p_offset);
 	Vector2 get_graph_offset() const;
+
+	bool is_initialized() const;
+	void set_initialized(bool p_enabled);
 
 	String generate_preview_shader(Type p_type, int p_node, int p_port, Vector<DefaultTextureParam> &r_default_tex_params) const;
 


### PR DESCRIPTION
QoL change(which especially be useful for the new users) - shader mode will automatically be selected depending on the base object (previously, it always be set to Spatial/Node3d which was a source of confusion). 

The intercepted cases are `CanvasItem`(and their derivatives Sprites, Node2D, etc) which will set the mode to `CanvasItem`, `process_material` property in `GPUParticles3D` and `GPUParticles2D` - `Particles` and `Environment` which currently does not have any other material nests other than `Sky`, all other cases remained to be `Node3D`
![test](https://user-images.githubusercontent.com/3036176/92113342-d84f4480-edf7-11ea-9cd8-56d82b159495.gif)
Also, in this PR I've added auto-selection of Compute graph for `Particles` mode.