### PR TITLE
[2.1] Cannot export to OSX

### DIFF
--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -387,7 +387,7 @@ Error EditorExportPlatformOSX::export_project(const String &p_path, bool p_debug
 		}
 	}
 
-	String binary_to_use = "godot_osx_" + String(p_debug ? "debug" : "release") + ".";
+	String binary_to_use = "godot_osx_" + String(p_debug ? "debug" : "release") + ".64";
 
 	String pkg_name;
 	if (app_name != "")


### PR DESCRIPTION
OSX template name misses the 64

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
