### PR TITLE
Create a .lgtm.yml file to enable lgtm to successfully build Godot.

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,7 @@
+extraction:
+  cpp:
+    after_prepare:
+      - pip3 install scons
+      - PATH="/opt/work/.local/bin:$PATH"
+    index:
+      build_command: scons -j2


### PR DESCRIPTION
Since we've added the LGTM badge in #35958, it's worth making sure that it at least builds successfully. Currently, the C/C++ build is [failing](https://lgtm.com/projects/g/godotengine/godot/logs/languages/lang:cpp), because it's using Ubuntu 19.10, which has an old version of SCons that has the old shebang and therefore tries to run it with Python 2.7.

This PR creates a basic LGTM yaml file (`.lgtm.yml`) that installs the current version of SCons, which has the `#! /usr/bin/python3` shebang, and then updates the path appropriately. This enables a C/C++ build using SCons to succeed; as tested [here](https://lgtm.com/logs/d0cf9e1ae3dcb949b177f904463f49d1bf99cbb8/lang:cpp).

Note: The test says the C/C++ analysis failed. However, the stated reason for the failure is that it timed out during the analysis phase, not that the build failed during the extraction phase. Furthermore, the log shows that the analysis completed (8 minutes after it timed out); so this may be a bug on their end. The important point is that it now builds succesfully.
