### PR TITLE
Added string length check to LineEdit.set_text()

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1210,7 +1210,12 @@ void LineEdit::delete_text(int p_from_column, int p_to_column) {
 
 void LineEdit::set_text(String p_text) {
 	clear_internal();
-	append_at_cursor(p_text);
+
+	if (max_length <= 0 || max_length > p_text.length()) {
+		append_at_cursor(p_text);
+	} else {
+		append_at_cursor(p_text.substr(0, max_length));
+	}
 
 	update();
 	cursor_pos = 0;


### PR DESCRIPTION
This corrects issue #41278 and #33321 without the bugs that I introduced in #41520 

The original issue was that set_max_length would shorten the max_length and then call set_text with the old text (which is longer than the new max length), which would fail and fire off a "text_change_rejected" signal, which is unexpected for changing the max length, and undesirable since all the information is nuked.

The new issue I accidentally introduced was a failure to check for a max_length of 0, which actually means that the string length is allowed to be as long as it wants. A max_length of zero or less would cause a 0 length string to be filled in, and a negative length would cause a crash.

Sorry for floundering about with this very, very simple fix. I definitely need to be both more awake and more vigilant before I try to program.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
