### PR TITLE
[3.2] Fix 'Parameter "assembly" is null' error

### DIFF
--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -458,7 +458,9 @@ GDMonoAssembly *GDMonoAssembly::load(const String &p_name, MonoAssemblyName *p_a
 
 	if (!assembly) {
 		assembly = _load_assembly_search(p_name, p_aname, p_refonly, p_search_dirs);
-		ERR_FAIL_NULL_V(assembly, nullptr);
+		if (!assembly) {
+			return nullptr;
+		}
 	}
 
 	GDMonoAssembly *loaded_asm = GDMono::get_singleton()->get_loaded_assembly(p_name);
@@ -481,7 +483,9 @@ GDMonoAssembly *GDMonoAssembly::load_from(const String &p_name, const String &p_
 
 	if (!assembly) {
 		assembly = _real_load_assembly_from(p_path, p_refonly);
-		ERR_FAIL_NULL_V(assembly, NULL);
+		if (!assembly) {
+			return nullptr;
+		}
 	}
 
 	GDMonoAssembly *loaded_asm = GDMono::get_singleton()->get_loaded_assembly(p_name);


### PR DESCRIPTION
Backport of #41748 to the 3.2 branch.
