### PR TITLE
[3.2] C#: Fix Godot failing to find class namespace

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectUtils.cs
@@ -178,7 +178,7 @@ namespace GodotTools.ProjectEditor
             if (root.AreDefaultCompileItemsEnabled())
             {
                 var excluded = new List<string>();
-                result = GetAllFilesRecursive(Path.GetDirectoryName(projectPath), "*.cs").ToList();
+                result.AddRange(existingFiles);
 
                 foreach (var item in root.Items)
                 {

--- a/modules/mono/editor/GodotTools/GodotTools/CsProjOperations.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/CsProjOperations.cs
@@ -48,7 +48,7 @@ namespace GodotTools
 
             var firstMatch = classes.FirstOrDefault(classDecl =>
                     classDecl.BaseCount != 0 && // If it doesn't inherit anything, it can't be a Godot.Object.
-                    classDecl.SearchName != searchName // Filter by the name we're looking for
+                    classDecl.SearchName == searchName // Filter by the name we're looking for
             );
 
             if (firstMatch == null)


### PR DESCRIPTION
Backport of #41750 to the 3.2 branch.

It also includes a 3.2 specific change to avoid unnecessarily recursively  searching for C# files twice.
