### PR TITLE
C#: Hide Build button if there's no solution to build

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -31,6 +31,7 @@ namespace GodotTools
         private CheckBox aboutDialogCheckBox;
 
         private Button bottomPanelBtn;
+        private Button toolBarBuildButton;
 
         public GodotIdeManager GodotIdeManager { get; private set; }
 
@@ -127,6 +128,7 @@ namespace GodotTools
         {
             menuPopup.RemoveItem(menuPopup.GetItemIndex((int)MenuOptions.CreateSln));
             bottomPanelBtn.Show();
+            toolBarBuildButton.Show();
         }
 
         private void _ShowAboutDialog()
@@ -468,6 +470,15 @@ namespace GodotTools
                 aboutVBox.AddChild(aboutDialogCheckBox);
             }
 
+            toolBarBuildButton = new Button
+            {
+                Text = "Build",
+                HintTooltip = "Build solution",
+                FocusMode = Control.FocusModeEnum.None
+            };
+            toolBarBuildButton.PressedSignal += _BuildSolutionPressed;
+            AddControlToContainer(CustomControlContainer.Toolbar, toolBarBuildButton);
+
             if (File.Exists(GodotSharpDirs.ProjectSlnPath) && File.Exists(GodotSharpDirs.ProjectCsProjPath))
             {
                 ApplyNecessaryChangesToSolution();
@@ -475,19 +486,11 @@ namespace GodotTools
             else
             {
                 bottomPanelBtn.Hide();
+                toolBarBuildButton.Hide();
                 menuPopup.AddItem("Create C# solution".TTR(), (int)MenuOptions.CreateSln);
             }
 
             menuPopup.IdPressed += _MenuOptionPressed;
-
-            var buildButton = new Button
-            {
-                Text = "Build",
-                HintTooltip = "Build solution",
-                FocusMode = Control.FocusModeEnum.None
-            };
-            buildButton.PressedSignal += _BuildSolutionPressed;
-            AddControlToContainer(CustomControlContainer.Toolbar, buildButton);
 
             // External editor settings
             EditorDef("mono/editor/external_editor", ExternalEditorId.None);


### PR DESCRIPTION
Same as we do with the bottom panel. Mainly to avoid bothering if the project is not using C#.
