### PR TITLE
Ensure assignment operators return by reference to avoid unnecessary copies.

### DIFF
--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -121,7 +121,7 @@ struct AudioFrame {
 		r = p_frame.r;
 	}
 
-	_ALWAYS_INLINE_ AudioFrame operator=(const AudioFrame &p_frame) {
+	_ALWAYS_INLINE_ AudioFrame &operator=(const AudioFrame &p_frame) {
 		l = p_frame.l;
 		r = p_frame.r;
 		return *this;

--- a/core/math/quat.h
+++ b/core/math/quat.h
@@ -130,7 +130,7 @@ public:
 			w(q.w) {
 	}
 
-	Quat operator=(const Quat &q) {
+	Quat &operator=(const Quat &q) {
 		x = q.x;
 		y = q.y;
 		z = q.z;

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -103,7 +103,7 @@ public:
 
 	_FORCE_INLINE_ Char16String() {}
 	_FORCE_INLINE_ Char16String(const Char16String &p_str) { _cowdata._ref(p_str._cowdata); }
-	_FORCE_INLINE_ Char16String operator=(const Char16String &p_str) {
+	_FORCE_INLINE_ Char16String &operator=(const Char16String &p_str) {
 		_cowdata._ref(p_str._cowdata);
 		return *this;
 	}
@@ -147,7 +147,7 @@ public:
 
 	_FORCE_INLINE_ CharString() {}
 	_FORCE_INLINE_ CharString(const CharString &p_str) { _cowdata._ref(p_str._cowdata); }
-	_FORCE_INLINE_ CharString operator=(const CharString &p_str) {
+	_FORCE_INLINE_ CharString &operator=(const CharString &p_str) {
 		_cowdata._ref(p_str._cowdata);
 		return *this;
 	}
@@ -435,7 +435,7 @@ public:
 
 	_FORCE_INLINE_ String() {}
 	_FORCE_INLINE_ String(const String &p_str) { _cowdata._ref(p_str._cowdata); }
-	String operator=(const String &p_str) {
+	String &operator=(const String &p_str) {
 		_cowdata._ref(p_str._cowdata);
 		return *this;
 	}

--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -230,7 +230,7 @@ private:
 			render_db_value = n.render_db_value;
 		}
 
-		_FORCE_INLINE_ AudioNotch operator=(const EditorAudioMeterNotches::AudioNotch &n) {
+		_FORCE_INLINE_ AudioNotch &operator=(const EditorAudioMeterNotches::AudioNotch &n) {
 			relative_position = n.relative_position;
 			db_value = n.db_value;
 			render_db_value = n.render_db_value;

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -106,7 +106,7 @@ SoftBody3D::PinnedPoint::PinnedPoint(const PinnedPoint &obj_tocopy) {
 	offset = obj_tocopy.offset;
 }
 
-SoftBody3D::PinnedPoint SoftBody3D::PinnedPoint::operator=(const PinnedPoint &obj) {
+SoftBody3D::PinnedPoint &SoftBody3D::PinnedPoint::operator=(const PinnedPoint &obj) {
 	point_index = obj.point_index;
 	spatial_attachment_path = obj.spatial_attachment_path;
 	spatial_attachment = obj.spatial_attachment;

--- a/scene/3d/soft_body_3d.h
+++ b/scene/3d/soft_body_3d.h
@@ -74,7 +74,7 @@ public:
 
 		PinnedPoint();
 		PinnedPoint(const PinnedPoint &obj_tocopy);
-		PinnedPoint operator=(const PinnedPoint &obj);
+		PinnedPoint &operator=(const PinnedPoint &obj);
 	};
 
 private:

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -644,7 +644,7 @@ class PhysicsServer2DManager {
 				name(p_ci.name),
 				create_callback(p_ci.create_callback) {}
 
-		ClassInfo operator=(const ClassInfo &p_ci) {
+		ClassInfo &operator=(const ClassInfo &p_ci) {
 			name = p_ci.name;
 			create_callback = p_ci.create_callback;
 			return *this;

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -785,7 +785,7 @@ class PhysicsServer3DManager {
 				name(p_ci.name),
 				create_callback(p_ci.create_callback) {}
 
-		ClassInfo operator=(const ClassInfo &p_ci) {
+		ClassInfo &operator=(const ClassInfo &p_ci) {
 			name = p_ci.name;
 			create_callback = p_ci.create_callback;
 			return *this;


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&severity=&id=cpp%2Fassignment-does-not-return-this&lang=cpp&tag=&ruleFocus=2164010517), a number of assignment operators are returning by value instead of by reference, which causes an unnecessary copy when called. This PR changes those assignment operators to return by reference.