### PR TITLE
Make PosVertex to Vertex slicing explicit.

### DIFF
--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -287,7 +287,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 							pre_move_edit = vertices2;
 							edited_point = PosVertex(insert.polygon, insert.vertex + 1, xform.affine_inverse().xform(insert.pos));
 							vertices2.insert(edited_point.vertex, edited_point.pos);
-							selected_point = edited_point;
+							selected_point = Vertex(edited_point.polygon, edited_point.vertex);
 							edge_point = PosVertex();
 
 							undo_redo->create_action(TTR("Insert Point"));


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&severity=&id=cpp%2Fslicing&lang=cpp&tag=&ruleFocus=2160040902), when assigning a derived type to a base type, all members added to the derived class are sliced, which may not be desired.

In `AbstractPolygon2DEditor` `edited_point` is a `PosVertex` derived from `Vertex` and `selected_point` is a `Vertex`. When assigning `edited_point` to `selected_point` the additional `Vector2 pos` member of `edited_point` is sliced. Since this is intended, this PR makes the slicing explicit, by creating a new `Vertex` from `edited_point` and assigns that to `selected_point` instead.
