### PR TITLE
Refactors and corrects the AudioStreamPlayer3D's SPCAP volume calculation.

### DIFF
--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -37,7 +37,6 @@
 #include "servers/audio/audio_stream.h"
 #include "servers/audio_server.h"
 
-class Camera3D;
 class AudioStreamPlayer3D : public Node3D {
 	GDCLASS(AudioStreamPlayer3D, Node3D);
 
@@ -79,6 +78,13 @@ private:
 		Viewport *viewport = nullptr; //pointer only used for reference to previous mix
 	};
 
+	static unsigned int speaker_count;
+	static Vector3 speaker_directions[7];
+	static real_t spcap_speaker_effects[7];
+	static void _calculate_spcap_speaker_effects();
+	static void _calculate_spcap_volumes(const Vector3 &source_direction, real_t tightness, real_t *volumes);
+	static void _calculate_output_volumes(const Vector3 &source_dir, real_t tightness, Output &output);
+
 	Output outputs[MAX_OUTPUTS];
 	volatile int output_count = 0;
 	volatile bool output_ready = false;
@@ -106,7 +112,6 @@ private:
 	bool stream_paused_fade_out = false;
 	StringName bus;
 
-	static void _calc_output_vol(const Vector3 &source_dir, real_t tightness, Output &output);
 	void _mix_audio();
 	static void _mix_audios(void *self) { reinterpret_cast<AudioStreamPlayer3D *>(self)->_mix_audio(); }
 


### PR DESCRIPTION
Removes the Spcap class and replaces it with just two functions which:
- Calculate the SPCAP speaker effects: `_calculate_spcap_speaker_effects()`
- Calculate the SPCAP volumes: `_calculate_spcap_volumes()`

In addition:
- The speaker effects are now only calculated when the speaker mode changes.
- The speaker effect calculation now includes all speaker directions, not just the previous directions.
- There is no longer a hidden variable (`speaker_directions`).
- The `speaker_directions` are now also a non `const` `static` member of `AudioStreamPlayer3D` allowing them to be configurable.