### PR TITLE
Tooltip flickering and targeting fixes.

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -345,7 +345,7 @@ String BaseButton::get_tooltip(const Point2 &p_pos) const {
 	String tooltip = Control::get_tooltip(p_pos);
 	if (shortcut_in_tooltip && shortcut.is_valid() && shortcut->is_valid()) {
 		String text = shortcut->get_name() + " (" + shortcut->get_as_text() + ")";
-		if (shortcut->get_name().nocasecmp_to(tooltip) != 0) {
+		if (tooltip != String() && shortcut->get_name().nocasecmp_to(tooltip) != 0) {
 			text += "\n" + tooltip;
 		}
 		tooltip = text;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1509,7 +1509,7 @@ void Viewport::_gui_show_tooltip() {
 	}
 
 	Control *which = nullptr;
-	String tooltip = _gui_get_tooltip(gui.tooltip, gui.tooltip->get_global_transform().xform_inv(gui.tooltip_pos), &which);
+	String tooltip = _gui_get_tooltip(gui.tooltip, gui.tooltip->get_global_transform().xform_inv(gui.last_mouse_pos), &which);
 	tooltip = tooltip.strip_edges();
 	if (tooltip.length() == 0) {
 		return; // bye


### PR DESCRIPTION
Tooltip flickering was caused by...
* For Buttons with shortcuts, every call of `Viewport::_gui_get)tooltip()` in `Viewport` would return a different value, because the `BaseButton::get_tooltip()` method would always return a string with `\n` on the end, while `Label::get_text()` would have this `\n` removed, since `Viewport::_gui_show_tooltip` calls `String::string_edges()` which removes them. This mean't there was an inequality between the current tooltip and what it should be, which is what caused it to flicker. 

The equality test is shown on line 2061 below.
https://github.com/godotengine/godot/blob/c4865921ec8f2a4f5d3440b2b2abe5dbe289a4b9/scene/main/viewport.cpp#L2054-L2063

* For the Tree, the calculation of which item was hovered was incorrect because it seems that the wrong `Point` was being passed in. I don't know why the last tooltip position was being passed in rather than the last mouse position. Anyway, changing it to `gui.last_mouse_pos` solved the issue for me.

~Finally, I also made it so that tooltips disappear on hover, which is the current behaviour in Godot 3.2, but was missing in the current master.~

CC @pouleyKetchoupp 

Closes #41261