### PR TITLE
Make search results font follow code editor font

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -640,6 +640,8 @@ void FindInFilesPanel::stop_search() {
 void FindInFilesPanel::_notification(int p_what) {
 	if (p_what == NOTIFICATION_PROCESS) {
 		_progress_bar->set_as_ratio(_finder->get_progress());
+	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
+		_update_font();
 	}
 }
 
@@ -836,6 +838,12 @@ public:
 private:
 	Vector<char> _line_buffer;
 };
+
+void FindInFilesPanel::_update_font() {
+
+	_search_text_label->add_font_override("font", get_font("source", "EditorFonts"));
+	_results_display->add_font_override("font", get_font("source", "EditorFonts"));
+}
 
 void FindInFilesPanel::apply_replaces_in_file(String fpath, const Vector<Result> &locations, String new_text) {
 

--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -177,6 +177,8 @@ private:
 		int begin_trimmed;
 	};
 
+	void _update_font();
+
 	void apply_replaces_in_file(String fpath, const Vector<Result> &locations, String new_text);
 	void update_replace_buttons();
 	String get_replace_text();


### PR DESCRIPTION
Resolves #35499

The font size of the Find in Files dialog used to get out of sync with the code editor font size.

The font of the Find in Files dialog is now updated each time there is a change to the theme. This way, the font size of the Find in Files results changes in response to the code font size being changed using Ctrl +/- or using the Editor Settings.

The changes are for the 3.2 branch, but they may also be relevant for master. I was unable to run master since my GPU is too old.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
