### PR TITLE
Improve UI for creating and editing plugins.

### DIFF
--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -126,7 +126,51 @@ void PluginConfigDialog::_on_cancelled() {
 void PluginConfigDialog::_on_required_text_changed(const String &) {
 	int lang_idx = script_option_edit->get_selected();
 	String ext = ScriptServer::get_language(lang_idx)->get_extension();
-	get_ok_button()->set_disabled(script_edit->get_text().get_basename().is_empty() || script_edit->get_text().get_extension() != ext || name_edit->get_text().is_empty());
+
+	Ref<Texture2D> valid_icon = get_theme_icon("StatusSuccess", "EditorIcons");
+	Ref<Texture2D> invalid_icon = get_theme_icon("StatusWarning", "EditorIcons");
+
+	// Set variables to assume all is valid
+	bool is_valid = true;
+	name_validation->set_texture(valid_icon);
+	subfolder_validation->set_texture(valid_icon);
+	script_validation->set_texture(valid_icon);
+	name_validation->set_tooltip("");
+	subfolder_validation->set_tooltip("");
+	script_validation->set_tooltip("");
+
+	// Change valid status to invalid depending on conditions.
+	Vector<String> errors;
+	if (name_edit->get_text().is_empty()) {
+		is_valid = false;
+		name_validation->set_texture(invalid_icon);
+		name_validation->set_tooltip(TTR("Plugin name cannot not be blank."));
+	}
+	if (script_edit->get_text().get_extension() != ext) {
+		is_valid = false;
+		script_validation->set_texture(invalid_icon);
+		script_validation->set_tooltip(vformat(TTR("Script extension must match chosen langauge extension (.%s)."), ext));
+	}
+	if (script_edit->get_text().get_basename().is_empty()) {
+		is_valid = false;
+		script_validation->set_texture(invalid_icon);
+		script_validation->set_tooltip(TTR("Script name cannot not be blank."));
+	}
+	if (subfolder_edit->get_text().is_empty()) {
+		is_valid = false;
+		subfolder_validation->set_texture(invalid_icon);
+		subfolder_validation->set_tooltip(TTR("Subfolder cannot be blank."));
+	} else {
+		DirAccessRef dir = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		String path = "res://addons/" + subfolder_edit->get_text();
+		if (dir->dir_exists(path) && !_edit_mode) { // Only show this error if in "create" mode.
+			is_valid = false;
+			subfolder_validation->set_texture(invalid_icon);
+			subfolder_validation->set_tooltip(TTR("Subfolder cannot be one which already exists."));
+		}
+	}
+
+	get_ok_button()->set_disabled(!is_valid);
 }
 
 String PluginConfigDialog::_to_absolute_plugin_path(const String &p_plugin_name) {
@@ -162,19 +206,22 @@ void PluginConfigDialog::config(const String &p_config_path) {
 
 		_edit_mode = true;
 		active_edit->hide();
-		Object::cast_to<Label>(active_edit->get_parent()->get_child(active_edit->get_index() - 1))->hide();
+		Object::cast_to<Label>(active_edit->get_parent()->get_child(active_edit->get_index() - 2))->hide();
 		subfolder_edit->hide();
-		Object::cast_to<Label>(subfolder_edit->get_parent()->get_child(subfolder_edit->get_index() - 1))->hide();
+		Object::cast_to<Label>(subfolder_edit->get_parent()->get_child(subfolder_edit->get_index() - 2))->hide();
 		set_title(TTR("Edit a Plugin"));
 	} else {
 		_clear_fields();
 		_edit_mode = false;
 		active_edit->show();
-		Object::cast_to<Label>(active_edit->get_parent()->get_child(active_edit->get_index() - 1))->show();
+		Object::cast_to<Label>(active_edit->get_parent()->get_child(active_edit->get_index() - 2))->show();
 		subfolder_edit->show();
-		Object::cast_to<Label>(subfolder_edit->get_parent()->get_child(subfolder_edit->get_index() - 1))->show();
+		Object::cast_to<Label>(subfolder_edit->get_parent()->get_child(subfolder_edit->get_index() - 2))->show();
 		set_title(TTR("Create a Plugin"));
 	}
+	// Simulate text changing so the errors populate.
+	_on_required_text_changed("");
+
 	get_ok_button()->set_disabled(!_edit_mode);
 	get_ok_button()->set_text(_edit_mode ? TTR("Update") : TTR("Create"));
 }
@@ -187,55 +234,87 @@ PluginConfigDialog::PluginConfigDialog() {
 	get_ok_button()->set_disabled(true);
 	set_hide_on_ok(true);
 
-	GridContainer *grid = memnew(GridContainer);
-	grid->set_columns(2);
-	add_child(grid);
+	VBoxContainer *vbox = memnew(VBoxContainer);
+	vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	add_child(vbox);
 
+	GridContainer *grid = memnew(GridContainer);
+	grid->set_columns(3);
+	vbox->add_child(grid);
+
+	// Plugin Name
 	Label *name_lb = memnew(Label);
 	name_lb->set_text(TTR("Plugin Name:"));
 	grid->add_child(name_lb);
+
+	name_validation = memnew(TextureRect);
+	name_validation->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+	grid->add_child(name_validation);
 
 	name_edit = memnew(LineEdit);
 	name_edit->connect("text_changed", callable_mp(this, &PluginConfigDialog::_on_required_text_changed));
 	name_edit->set_placeholder("MyPlugin");
 	grid->add_child(name_edit);
 
+	// Subfolder
 	Label *subfolder_lb = memnew(Label);
 	subfolder_lb->set_text(TTR("Subfolder:"));
 	grid->add_child(subfolder_lb);
 
+	subfolder_validation = memnew(TextureRect);
+	subfolder_validation->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+	grid->add_child(subfolder_validation);
+
 	subfolder_edit = memnew(LineEdit);
 	subfolder_edit->set_placeholder("\"my_plugin\" -> res://addons/my_plugin");
+	subfolder_edit->connect("text_changed", callable_mp(this, &PluginConfigDialog::_on_required_text_changed));
 	grid->add_child(subfolder_edit);
 
+	// Description
 	Label *desc_lb = memnew(Label);
 	desc_lb->set_text(TTR("Description:"));
 	grid->add_child(desc_lb);
+
+	Control *desc_spacer = memnew(Control);
+	grid->add_child(desc_spacer);
 
 	desc_edit = memnew(TextEdit);
 	desc_edit->set_custom_minimum_size(Size2(400, 80) * EDSCALE);
 	desc_edit->set_wrap_enabled(true);
 	grid->add_child(desc_edit);
 
+	// Author
 	Label *author_lb = memnew(Label);
 	author_lb->set_text(TTR("Author:"));
 	grid->add_child(author_lb);
+
+	Control *author_spacer = memnew(Control);
+	grid->add_child(author_spacer);
 
 	author_edit = memnew(LineEdit);
 	author_edit->set_placeholder("Godette");
 	grid->add_child(author_edit);
 
+	// Version
 	Label *version_lb = memnew(Label);
 	version_lb->set_text(TTR("Version:"));
 	grid->add_child(version_lb);
+
+	Control *version_spacer = memnew(Control);
+	grid->add_child(version_spacer);
 
 	version_edit = memnew(LineEdit);
 	version_edit->set_placeholder("1.0");
 	grid->add_child(version_edit);
 
+	// Language dropdown
 	Label *script_option_lb = memnew(Label);
 	script_option_lb->set_text(TTR("Language:"));
 	grid->add_child(script_option_lb);
+
+	Control *script_opt_spacer = memnew(Control);
+	grid->add_child(script_opt_spacer);
 
 	script_option_edit = memnew(OptionButton);
 	int default_lang = 0;
@@ -251,19 +330,28 @@ PluginConfigDialog::PluginConfigDialog() {
 	script_option_edit->select(default_lang);
 	grid->add_child(script_option_edit);
 
+	// Plugin Script Name
 	Label *script_lb = memnew(Label);
 	script_lb->set_text(TTR("Script Name:"));
 	grid->add_child(script_lb);
+
+	script_validation = memnew(TextureRect);
+	script_validation->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
+	grid->add_child(script_validation);
 
 	script_edit = memnew(LineEdit);
 	script_edit->connect("text_changed", callable_mp(this, &PluginConfigDialog::_on_required_text_changed));
 	script_edit->set_placeholder("\"plugin.gd\" -> res://addons/my_plugin/plugin.gd");
 	grid->add_child(script_edit);
 
+	// Activate now checkbox
 	// TODO Make this option work better with languages like C#. Right now, it does not work because the C# project must be compiled first.
 	Label *active_lb = memnew(Label);
 	active_lb->set_text(TTR("Activate now?"));
 	grid->add_child(active_lb);
+
+	Control *active_spacer = memnew(Control);
+	grid->add_child(active_spacer);
 
 	active_edit = memnew(CheckBox);
 	active_edit->set_pressed(true);

--- a/editor/plugin_config_dialog.h
+++ b/editor/plugin_config_dialog.h
@@ -36,6 +36,7 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/text_edit.h"
+#include "scene/gui/texture_rect.h"
 
 class PluginConfigDialog : public ConfirmationDialog {
 	GDCLASS(PluginConfigDialog, ConfirmationDialog);
@@ -48,6 +49,10 @@ class PluginConfigDialog : public ConfirmationDialog {
 	OptionButton *script_option_edit;
 	LineEdit *script_edit;
 	CheckBox *active_edit;
+
+	TextureRect *name_validation;
+	TextureRect *subfolder_validation;
+	TextureRect *script_validation;
 
 	bool _edit_mode;
 


### PR DESCRIPTION
Commit 1: Moves `set_as_minsize()` from `Popup` to `Window`. This method only invokes methods in `Window`, and it is a nice helper to have on `Window` instead of just `Popup`, ~and I have used it in Commit 2.~

Commit 2: Improves plugin creation dialog by reporting validation errors in the form. Closes #41736

![plugin_creation_dialog_final](https://user-images.githubusercontent.com/41730826/92338271-9d4c5a00-f0f2-11ea-9d75-6e6fc4b75a09.gif)

