### PR TITLE
Cleanup constructor code in visual shader nodes

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1590,8 +1590,6 @@ void VisualShader::_bind_methods() {
 }
 
 VisualShader::VisualShader() {
-	shader_mode = Shader::MODE_SPATIAL;
-
 	for (int i = 0; i < TYPE_MAX; i++) {
 		Ref<VisualShaderNodeOutput> output;
 		output.instance();
@@ -1600,8 +1598,6 @@ VisualShader::VisualShader() {
 		graph[i].nodes[NODE_ID_OUTPUT].node = output;
 		graph[i].nodes[NODE_ID_OUTPUT].position = Vector2(400, 150);
 	}
-
-	dirty = true;
 }
 
 ///////////////////////////////////////////////////////////
@@ -2039,10 +2035,6 @@ void VisualShaderNodeInput::_bind_methods() {
 }
 
 VisualShaderNodeInput::VisualShaderNodeInput() {
-	input_name = "[None]";
-	// changed when set
-	shader_type = VisualShader::TYPE_MAX;
-	shader_mode = Shader::MODE_MAX;
 }
 
 ////////////// UniformRef
@@ -2234,8 +2226,6 @@ Vector<StringName> VisualShaderNodeUniformRef::get_editable_properties() const {
 }
 
 VisualShaderNodeUniformRef::VisualShaderNodeUniformRef() {
-	uniform_name = "[None]";
-	uniform_type = UniformType::UNIFORM_TYPE_FLOAT;
 }
 
 ////////////////////////////////////////////
@@ -2488,7 +2478,6 @@ Vector<StringName> VisualShaderNodeUniform::get_editable_properties() const {
 }
 
 VisualShaderNodeUniform::VisualShaderNodeUniform() {
-	qualifier = QUAL_NONE;
 }
 
 ////////////// GroupBase
@@ -2962,11 +2951,6 @@ String VisualShaderNodeGroupBase::generate_code(Shader::Mode p_mode, VisualShade
 }
 
 VisualShaderNodeGroupBase::VisualShaderNodeGroupBase() {
-	size = Size2(0, 0);
-	inputs = "";
-	outputs = "";
-	editable = false;
-	simple_decl = false;
 }
 
 ////////////// Expression
@@ -3090,7 +3074,6 @@ void VisualShaderNodeExpression::_bind_methods() {
 }
 
 VisualShaderNodeExpression::VisualShaderNodeExpression() {
-	expression = "";
 	set_editable(true);
 }
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -78,7 +78,7 @@ private:
 		List<Connection> connections;
 	} graph[TYPE_MAX];
 
-	Shader::Mode shader_mode;
+	Shader::Mode shader_mode = Shader::MODE_SPATIAL;
 	mutable String previous_code;
 
 	Array _get_node_connections(Type p_type) const;
@@ -95,7 +95,7 @@ private:
 
 	static RenderModeEnums render_mode_enums[];
 
-	volatile mutable bool dirty;
+	volatile mutable bool dirty = true;
 	void _queue_update();
 
 	union ConnectionKey {
@@ -188,7 +188,7 @@ class VisualShaderNode : public Resource {
 	int connected_output_count = 0;
 
 protected:
-	bool simple_decl;
+	bool simple_decl = false;
 	static void _bind_methods();
 
 public:
@@ -290,8 +290,8 @@ class VisualShaderNodeInput : public VisualShaderNode {
 	GDCLASS(VisualShaderNodeInput, VisualShaderNode);
 
 	friend class VisualShader;
-	VisualShader::Type shader_type;
-	Shader::Mode shader_mode;
+	VisualShader::Type shader_type = VisualShader::TYPE_MAX;
+	Shader::Mode shader_mode = Shader::MODE_MAX;
 
 	struct Port {
 		Shader::Mode mode;
@@ -304,7 +304,7 @@ class VisualShaderNodeInput : public VisualShaderNode {
 	static const Port ports[];
 	static const Port preview_ports[];
 
-	String input_name;
+	String input_name = "[None]";
 
 protected:
 	static void _bind_methods();
@@ -388,8 +388,8 @@ public:
 	};
 
 private:
-	String uniform_name;
-	Qualifier qualifier;
+	String uniform_name = "";
+	Qualifier qualifier = QUAL_NONE;
 	bool global_code_generated = false;
 
 protected:
@@ -436,8 +436,8 @@ public:
 	};
 
 private:
-	String uniform_name;
-	UniformType uniform_type;
+	String uniform_name = "[None]";
+	UniformType uniform_type = UniformType::UNIFORM_TYPE_FLOAT;
 
 protected:
 	static void _bind_methods();
@@ -479,10 +479,10 @@ private:
 	void _apply_port_changes();
 
 protected:
-	Vector2 size;
-	String inputs;
-	String outputs;
-	bool editable;
+	Vector2 size = Size2(0, 0);
+	String inputs = "";
+	String outputs = "";
+	bool editable = false;
 
 	struct Port {
 		PortType type;
@@ -550,7 +550,7 @@ class VisualShaderNodeExpression : public VisualShaderNodeGroupBase {
 	GDCLASS(VisualShaderNodeExpression, VisualShaderNodeGroupBase);
 
 protected:
-	String expression;
+	String expression = "";
 
 	static void _bind_methods();
 

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -87,7 +87,6 @@ void VisualShaderNodeFloatConstant::_bind_methods() {
 }
 
 VisualShaderNodeFloatConstant::VisualShaderNodeFloatConstant() {
-	constant = 0.0;
 }
 
 ////////////// Scalar(Int)
@@ -147,7 +146,6 @@ void VisualShaderNodeIntConstant::_bind_methods() {
 }
 
 VisualShaderNodeIntConstant::VisualShaderNodeIntConstant() {
-	constant = 0;
 }
 
 ////////////// Boolean
@@ -207,7 +205,6 @@ void VisualShaderNodeBooleanConstant::_bind_methods() {
 }
 
 VisualShaderNodeBooleanConstant::VisualShaderNodeBooleanConstant() {
-	constant = false;
 }
 
 ////////////// Color
@@ -271,7 +268,6 @@ void VisualShaderNodeColorConstant::_bind_methods() {
 }
 
 VisualShaderNodeColorConstant::VisualShaderNodeColorConstant() {
-	constant = Color(1, 1, 1, 1);
 }
 
 ////////////// Vector
@@ -777,8 +773,6 @@ void VisualShaderNodeTexture::_bind_methods() {
 }
 
 VisualShaderNodeTexture::VisualShaderNodeTexture() {
-	texture_type = TYPE_DATA;
-	source = SOURCE_TEXTURE;
 }
 
 ////////////// Sample3D
@@ -898,8 +892,6 @@ String VisualShaderNodeSample3D::get_warning(Shader::Mode p_mode, VisualShader::
 }
 
 VisualShaderNodeSample3D::VisualShaderNodeSample3D() {
-	source = SOURCE_TEXTURE;
-	simple_decl = false;
 }
 
 ////////////// Texture2DArray
@@ -1143,9 +1135,6 @@ void VisualShaderNodeCubemap::_bind_methods() {
 }
 
 VisualShaderNodeCubemap::VisualShaderNodeCubemap() {
-	texture_type = TYPE_DATA;
-	source = SOURCE_TEXTURE;
-	simple_decl = false;
 }
 
 ////////////// Float Op
@@ -1250,7 +1239,6 @@ void VisualShaderNodeFloatOp::_bind_methods() {
 }
 
 VisualShaderNodeFloatOp::VisualShaderNodeFloatOp() {
-	op = OP_ADD;
 	set_input_port_default_value(0, 0.0);
 	set_input_port_default_value(1, 0.0);
 }
@@ -1345,7 +1333,6 @@ void VisualShaderNodeIntOp::_bind_methods() {
 }
 
 VisualShaderNodeIntOp::VisualShaderNodeIntOp() {
-	op = OP_ADD;
 	set_input_port_default_value(0, 0);
 	set_input_port_default_value(1, 0);
 }
@@ -1460,7 +1447,6 @@ void VisualShaderNodeVectorOp::_bind_methods() {
 }
 
 VisualShaderNodeVectorOp::VisualShaderNodeVectorOp() {
-	op = OP_ADD;
 	set_input_port_default_value(0, Vector3());
 	set_input_port_default_value(1, Vector3());
 }
@@ -1628,7 +1614,6 @@ void VisualShaderNodeColorOp::_bind_methods() {
 }
 
 VisualShaderNodeColorOp::VisualShaderNodeColorOp() {
-	op = OP_SCREEN;
 	set_input_port_default_value(0, Vector3());
 	set_input_port_default_value(1, Vector3());
 }
@@ -1703,7 +1688,6 @@ void VisualShaderNodeTransformMult::_bind_methods() {
 }
 
 VisualShaderNodeTransformMult::VisualShaderNodeTransformMult() {
-	op = OP_AxB;
 	set_input_port_default_value(0, Transform());
 	set_input_port_default_value(1, Transform());
 }
@@ -1778,7 +1762,6 @@ void VisualShaderNodeTransformVecMult::_bind_methods() {
 }
 
 VisualShaderNodeTransformVecMult::VisualShaderNodeTransformVecMult() {
-	op = OP_AxB;
 	set_input_port_default_value(0, Transform());
 	set_input_port_default_value(1, Vector3());
 }
@@ -1908,7 +1891,6 @@ void VisualShaderNodeFloatFunc::_bind_methods() {
 }
 
 VisualShaderNodeFloatFunc::VisualShaderNodeFloatFunc() {
-	func = FUNC_SIGN;
 	set_input_port_default_value(0, 0.0);
 }
 
@@ -2003,7 +1985,6 @@ void VisualShaderNodeIntFunc::_bind_methods() {
 }
 
 VisualShaderNodeIntFunc::VisualShaderNodeIntFunc() {
-	func = FUNC_SIGN;
 	set_input_port_default_value(0, 0);
 }
 
@@ -2169,7 +2150,6 @@ void VisualShaderNodeVectorFunc::_bind_methods() {
 }
 
 VisualShaderNodeVectorFunc::VisualShaderNodeVectorFunc() {
-	func = FUNC_NORMALIZE;
 	set_input_port_default_value(0, Vector3());
 }
 
@@ -2256,9 +2236,7 @@ void VisualShaderNodeColorFunc::_bind_methods() {
 }
 
 VisualShaderNodeColorFunc::VisualShaderNodeColorFunc() {
-	func = FUNC_GRAYSCALE;
 	set_input_port_default_value(0, Vector3());
-	simple_decl = false;
 }
 
 ////////////// Transform Func
@@ -2328,7 +2306,6 @@ void VisualShaderNodeTransformFunc::_bind_methods() {
 }
 
 VisualShaderNodeTransformFunc::VisualShaderNodeTransformFunc() {
-	func = FUNC_INVERSE;
 	set_input_port_default_value(0, Transform());
 }
 
@@ -2516,7 +2493,6 @@ void VisualShaderNodeScalarDerivativeFunc::_bind_methods() {
 }
 
 VisualShaderNodeScalarDerivativeFunc::VisualShaderNodeScalarDerivativeFunc() {
-	func = FUNC_SUM;
 	set_input_port_default_value(0, 0.0);
 }
 
@@ -2589,7 +2565,6 @@ void VisualShaderNodeVectorDerivativeFunc::_bind_methods() {
 }
 
 VisualShaderNodeVectorDerivativeFunc::VisualShaderNodeVectorDerivativeFunc() {
-	func = FUNC_SUM;
 	set_input_port_default_value(0, Vector3());
 }
 
@@ -3561,12 +3536,6 @@ Vector<StringName> VisualShaderNodeFloatUniform::get_editable_properties() const
 }
 
 VisualShaderNodeFloatUniform::VisualShaderNodeFloatUniform() {
-	hint = HINT_NONE;
-	hint_range_min = 0.0;
-	hint_range_max = 1.0;
-	hint_range_step = 0.1;
-	default_value_enabled = false;
-	default_value = 0.0;
 }
 
 ////////////// Integer Uniform
@@ -3726,12 +3695,6 @@ Vector<StringName> VisualShaderNodeIntUniform::get_editable_properties() const {
 }
 
 VisualShaderNodeIntUniform::VisualShaderNodeIntUniform() {
-	hint = HINT_NONE;
-	hint_range_min = 0;
-	hint_range_max = 100;
-	hint_range_step = 1;
-	default_value_enabled = false;
-	default_value = 0;
 }
 
 ////////////// Boolean Uniform
@@ -3824,8 +3787,6 @@ Vector<StringName> VisualShaderNodeBooleanUniform::get_editable_properties() con
 }
 
 VisualShaderNodeBooleanUniform::VisualShaderNodeBooleanUniform() {
-	default_value_enabled = false;
-	default_value = false;
 }
 
 ////////////// Color Uniform
@@ -3916,8 +3877,6 @@ Vector<StringName> VisualShaderNodeColorUniform::get_editable_properties() const
 }
 
 VisualShaderNodeColorUniform::VisualShaderNodeColorUniform() {
-	default_value_enabled = false;
-	default_value = Color(1.0, 1.0, 1.0, 1.0);
 }
 
 ////////////// Vector Uniform
@@ -4006,8 +3965,6 @@ Vector<StringName> VisualShaderNodeVec3Uniform::get_editable_properties() const 
 }
 
 VisualShaderNodeVec3Uniform::VisualShaderNodeVec3Uniform() {
-	default_value_enabled = false;
-	default_value = Vector3(0.0, 0.0, 0.0);
 }
 
 ////////////// Transform Uniform
@@ -4100,8 +4057,6 @@ Vector<StringName> VisualShaderNodeTransformUniform::get_editable_properties() c
 }
 
 VisualShaderNodeTransformUniform::VisualShaderNodeTransformUniform() {
-	default_value_enabled = false;
-	default_value = Transform(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0);
 }
 
 ////////////// Texture Uniform
@@ -4271,9 +4226,6 @@ bool VisualShaderNodeTextureUniform::is_qualifier_supported(Qualifier p_qual) co
 }
 
 VisualShaderNodeTextureUniform::VisualShaderNodeTextureUniform() {
-	texture_type = TYPE_DATA;
-	color_default = COLOR_DEFAULT_WHITE;
-	simple_decl = false;
 }
 
 ////////////// Texture Uniform (Triplanar)
@@ -4583,7 +4535,6 @@ VisualShaderNodeIf::VisualShaderNodeIf() {
 	set_input_port_default_value(3, Vector3(0.0, 0.0, 0.0));
 	set_input_port_default_value(4, Vector3(0.0, 0.0, 0.0));
 	set_input_port_default_value(5, Vector3(0.0, 0.0, 0.0));
-	simple_decl = false;
 }
 
 ////////////// Switch
@@ -4645,7 +4596,6 @@ VisualShaderNodeSwitch::VisualShaderNodeSwitch() {
 	set_input_port_default_value(0, false);
 	set_input_port_default_value(1, Vector3(1.0, 1.0, 1.0));
 	set_input_port_default_value(2, Vector3(0.0, 0.0, 0.0));
-	simple_decl = false;
 }
 
 ////////////// Switch(scalar)
@@ -4836,7 +4786,6 @@ void VisualShaderNodeIs::_bind_methods() {
 }
 
 VisualShaderNodeIs::VisualShaderNodeIs() {
-	func = FUNC_IS_INF;
 	set_input_port_default_value(0, 0.0);
 }
 
@@ -5072,9 +5021,6 @@ void VisualShaderNodeCompare::_bind_methods() {
 }
 
 VisualShaderNodeCompare::VisualShaderNodeCompare() {
-	ctype = CTYPE_SCALAR;
-	func = FUNC_EQUAL;
-	condition = COND_ALL;
 	set_input_port_default_value(0, 0.0);
 	set_input_port_default_value(1, 0.0);
 	set_input_port_default_value(2, CMP_EPSILON);
@@ -5167,7 +5113,6 @@ void VisualShaderNodeMultiplyAdd::_bind_methods() {
 }
 
 VisualShaderNodeMultiplyAdd::VisualShaderNodeMultiplyAdd() {
-	type = TYPE_SCALAR;
 	set_input_port_default_value(0, 0.0);
 	set_input_port_default_value(1, 0.0);
 	set_input_port_default_value(2, 0.0);

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -39,7 +39,7 @@
 
 class VisualShaderNodeFloatConstant : public VisualShaderNode {
 	GDCLASS(VisualShaderNodeFloatConstant, VisualShaderNode);
-	float constant;
+	float constant = 0.0f;
 
 protected:
 	static void _bind_methods();
@@ -69,7 +69,7 @@ public:
 
 class VisualShaderNodeIntConstant : public VisualShaderNode {
 	GDCLASS(VisualShaderNodeIntConstant, VisualShaderNode);
-	int constant;
+	int constant = 0;
 
 protected:
 	static void _bind_methods();
@@ -99,7 +99,7 @@ public:
 
 class VisualShaderNodeBooleanConstant : public VisualShaderNode {
 	GDCLASS(VisualShaderNodeBooleanConstant, VisualShaderNode);
-	bool constant;
+	bool constant = false;
 
 protected:
 	static void _bind_methods();
@@ -129,7 +129,7 @@ public:
 
 class VisualShaderNodeColorConstant : public VisualShaderNode {
 	GDCLASS(VisualShaderNodeColorConstant, VisualShaderNode);
-	Color constant;
+	Color constant = Color(1, 1, 1, 1);
 
 protected:
 	static void _bind_methods();
@@ -240,8 +240,8 @@ public:
 	};
 
 private:
-	Source source;
-	TextureType texture_type;
+	Source source = SOURCE_TEXTURE;
+	TextureType texture_type = TYPE_DATA;
 
 protected:
 	static void _bind_methods();
@@ -294,7 +294,7 @@ public:
 	};
 
 protected:
-	Source source;
+	Source source = SOURCE_TEXTURE;
 
 	static void _bind_methods();
 
@@ -360,8 +360,8 @@ public:
 	};
 
 private:
-	Source source;
-	TextureType texture_type;
+	Source source = SOURCE_TEXTURE;
+	TextureType texture_type = TYPE_DATA;
 
 protected:
 	static void _bind_methods();
@@ -421,7 +421,7 @@ public:
 	};
 
 protected:
-	Operator op;
+	Operator op = OP_ADD;
 
 	static void _bind_methods();
 
@@ -463,7 +463,7 @@ public:
 	};
 
 protected:
-	Operator op;
+	Operator op = OP_ADD;
 
 	static void _bind_methods();
 
@@ -510,7 +510,7 @@ public:
 	};
 
 protected:
-	Operator op;
+	Operator op = OP_ADD;
 
 	static void _bind_methods();
 
@@ -556,7 +556,7 @@ public:
 	};
 
 protected:
-	Operator op;
+	Operator op = OP_SCREEN;
 
 	static void _bind_methods();
 
@@ -599,7 +599,7 @@ public:
 	};
 
 protected:
-	Operator op;
+	Operator op = OP_AxB;
 
 	static void _bind_methods();
 
@@ -642,7 +642,7 @@ public:
 	};
 
 protected:
-	Operator op;
+	Operator op = OP_AxB;
 
 	static void _bind_methods();
 
@@ -713,7 +713,7 @@ public:
 	};
 
 protected:
-	Function func;
+	Function func = FUNC_SIGN;
 
 	static void _bind_methods();
 
@@ -756,7 +756,7 @@ public:
 	};
 
 protected:
-	Function func;
+	Function func = FUNC_SIGN;
 
 	static void _bind_methods();
 
@@ -830,7 +830,7 @@ public:
 	};
 
 protected:
-	Function func;
+	Function func = FUNC_NORMALIZE;
 
 	static void _bind_methods();
 
@@ -871,7 +871,7 @@ public:
 	};
 
 protected:
-	Function func;
+	Function func = FUNC_GRAYSCALE;
 
 	static void _bind_methods();
 
@@ -912,7 +912,7 @@ public:
 	};
 
 protected:
-	Function func;
+	Function func = FUNC_INVERSE;
 
 	static void _bind_methods();
 
@@ -1067,7 +1067,7 @@ public:
 	};
 
 protected:
-	Function func;
+	Function func = FUNC_SUM;
 
 	static void _bind_methods();
 
@@ -1107,7 +1107,7 @@ public:
 	};
 
 protected:
-	Function func;
+	Function func = FUNC_SUM;
 
 	static void _bind_methods();
 
@@ -1482,12 +1482,12 @@ public:
 	};
 
 private:
-	Hint hint;
-	float hint_range_min;
-	float hint_range_max;
-	float hint_range_step;
-	bool default_value_enabled;
-	float default_value;
+	Hint hint = HINT_NONE;
+	float hint_range_min = 0.0f;
+	float hint_range_max = 1.0f;
+	float hint_range_step = 0.1f;
+	bool default_value_enabled = false;
+	float default_value = 0.0f;
 
 protected:
 	static void _bind_methods();
@@ -1544,12 +1544,12 @@ public:
 	};
 
 private:
-	Hint hint;
-	int hint_range_min;
-	int hint_range_max;
-	int hint_range_step;
-	bool default_value_enabled;
-	int default_value;
+	Hint hint = HINT_NONE;
+	int hint_range_min = 0;
+	int hint_range_max = 100;
+	int hint_range_step = 1;
+	bool default_value_enabled = false;
+	int default_value = 0;
 
 protected:
 	static void _bind_methods();
@@ -1601,8 +1601,8 @@ class VisualShaderNodeBooleanUniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeBooleanUniform, VisualShaderNodeUniform);
 
 private:
-	bool default_value_enabled;
-	bool default_value;
+	bool default_value_enabled = false;
+	bool default_value = false;
 
 protected:
 	static void _bind_methods();
@@ -1640,8 +1640,8 @@ class VisualShaderNodeColorUniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeColorUniform, VisualShaderNodeUniform);
 
 private:
-	bool default_value_enabled;
-	Color default_value;
+	bool default_value_enabled = false;
+	Color default_value = Color(1.0, 1.0, 1.0, 1.0);
 
 protected:
 	static void _bind_methods();
@@ -1679,7 +1679,7 @@ class VisualShaderNodeVec3Uniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeVec3Uniform, VisualShaderNodeUniform);
 
 private:
-	bool default_value_enabled;
+	bool default_value_enabled = false;
 	Vector3 default_value;
 
 protected:
@@ -1718,8 +1718,8 @@ class VisualShaderNodeTransformUniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeTransformUniform, VisualShaderNodeUniform);
 
 private:
-	bool default_value_enabled;
-	Transform default_value;
+	bool default_value_enabled = false;
+	Transform default_value = Transform(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0);
 
 protected:
 	static void _bind_methods();
@@ -1770,8 +1770,8 @@ public:
 	};
 
 protected:
-	TextureType texture_type;
-	ColorDefault color_default;
+	TextureType texture_type = TYPE_DATA;
+	ColorDefault color_default = COLOR_DEFAULT_WHITE;
 
 protected:
 	static void _bind_methods();
@@ -1973,7 +1973,7 @@ public:
 	};
 
 protected:
-	Function func;
+	Function func = FUNC_IS_INF;
 
 protected:
 	static void _bind_methods();
@@ -2032,9 +2032,9 @@ public:
 	};
 
 protected:
-	ComparisonType ctype;
-	Function func;
-	Condition condition;
+	ComparisonType ctype = CTYPE_SCALAR;
+	Function func = FUNC_EQUAL;
+	Condition condition = COND_ALL;
 
 protected:
 	static void _bind_methods();
@@ -2082,7 +2082,7 @@ public:
 	};
 
 protected:
-	Type type;
+	Type type = TYPE_SCALAR;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Pushes variable initialization code from various constructors to the class definitions (as we are transferred to C++17).
