### PR TITLE
Fix tilemap tile preview on horizontal/vertical flips. 

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -802,7 +802,6 @@ void TileMapEditor::_draw_cell(Control *p_viewport, int p_cell, const Point2i &p
 		r.size = node->get_tileset()->autotile_get_size(p_cell);
 		r.position += (r.size + Vector2(spacing, spacing)) * offset;
 	}
-	Size2 sc = p_xform.get_scale();
 	Size2 cell_size = node->get_cell_size();
 	bool centered_texture = node->is_centered_textures_enabled();
 	bool compatibility_mode_enabled = node->is_compatibility_mode_enabled();
@@ -838,12 +837,12 @@ void TileMapEditor::_draw_cell(Control *p_viewport, int p_cell, const Point2i &p
 	}
 
 	if (p_flip_h) {
-		sc.x *= -1.0;
+		rect.size.x *= -1.0;
 		tile_ofs.x *= -1.0;
 	}
 
 	if (p_flip_v) {
-		sc.y *= -1.0;
+		rect.size.y *= -1.0;
 		tile_ofs.y *= -1.0;
 	}
 


### PR DESCRIPTION
Fixes #41716. Tile Preview now shows correctly based on the horizontal and vertical buttons.

![image](https://user-images.githubusercontent.com/25291631/92314126-b8f41b00-efa1-11ea-8af1-fee0e8f78d9b.png)
![image](https://user-images.githubusercontent.com/25291631/92314148-eb057d00-efa1-11ea-8396-1ac47e5203c6.png)

This image shows: Zoom, Rotation, Flipping, and negative Scaling
![image](https://user-images.githubusercontent.com/25291631/92314197-b1814180-efa2-11ea-905f-ccc0943fc0a2.png)
