### PR TITLE
 [3.2] Handle csproj "Remove" globs

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
@@ -23,6 +23,9 @@ namespace GodotTools.Core
 
         public static string NormalizePath(this string path)
         {
+            if (string.IsNullOrEmpty(path))
+                return path;
+
             bool rooted = path.IsAbsolutePath();
 
             path = path.Replace('\\', '/');

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectUtils.cs
@@ -188,9 +188,10 @@ namespace GodotTools.ProjectEditor
                     if (item.ItemType != itemType)
                         continue;
 
-                    string normalizedExclude = item.Exclude.NormalizePath();
 
-                    var glob = MSBuildGlob.Parse(normalizedExclude);
+                    string normalizedRemove= item.Remove.NormalizePath();
+
+                    var glob = MSBuildGlob.Parse(normalizedRemove);
 
                     excluded.AddRange(result.Where(includedFile => glob.IsMatch(includedFile)));
                 }


### PR DESCRIPTION
Backport of #41790

Fixes #41778 to enable support for multiple csprojs with the auto-include project format.

Note MSBuild Item returns empty strings if an attribute isn't set (which caused an IndexOutOfRangeException in NormalizePath).

We were using Exclude incorrectly, this change replaces Exclude with Remove which provides the intended behaviour in auto-include project format.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
