### PR TITLE
Fixed get_usable_parent_rect() errors when initialising popup menus.

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -101,9 +101,11 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 		minsize.width += check_w;
 	}
 
-	int height_limit = get_usable_parent_rect().size.height;
-	if (minsize.height > height_limit) {
-		minsize.height = height_limit;
+	if (is_inside_tree()) {
+		int height_limit = get_usable_parent_rect().size.height;
+		if (minsize.height > height_limit) {
+			minsize.height = height_limit;
+		}
 	}
 
 	return minsize;


### PR DESCRIPTION
Closes #41779

From what I can tell `_get_conents_minimum_size()` is called on the EditorNode constructor, which is before the editor scene tree exists, but then also is called immediately after when every node _is_ in the tree. So, this fixes the errors without affecting behaviour.