### PR TITLE
Removes redundant code & fix documentation for VisualShaderNodeCustom

### DIFF
--- a/doc/classes/VisualShaderNodeCustom.xml
+++ b/doc/classes/VisualShaderNodeCustom.xml
@@ -5,9 +5,9 @@
 	</brief_description>
 	<description>
 		By inheriting this class you can create a custom [VisualShader] script addon which will be automatically added to the Visual Shader Editor. The [VisualShaderNode]'s behavior is defined by overriding the provided virtual methods.
-		In order for the node to be registered as an editor addon, you must use the [code]tool[/code] keyword and provide a [code]class_name[/code] for your custom script. For example:
+		In order for the node to be registered as an editor addon, you must use the [code]@tool[/code] annotation and provide a [code]class_name[/code] for your custom script. For example:
 		[codeblock]
-		tool
+		@tool
 		extends VisualShaderNodeCustom
 		class_name VisualShaderNodeNoise
 		[/codeblock]

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -183,26 +183,6 @@ bool VisualShaderEditor::_is_available(int p_mode) {
 			default:
 				break;
 		}
-
-		int temp_mode = 0;
-
-		if (p_mode & TYPE_FLAGS_VERTEX) {
-			temp_mode |= 1;
-		}
-
-		if (p_mode & TYPE_FLAGS_FRAGMENT) {
-			temp_mode |= 2;
-		}
-
-		if (p_mode & TYPE_FLAGS_LIGHT) {
-			temp_mode |= 4;
-		}
-
-		if (p_mode & TYPE_FLAGS_COMPUTE) {
-			temp_mode |= 8;
-		}
-
-		p_mode = temp_mode;
 	}
 
 	return (p_mode == -1 || (p_mode & current_mode) != 0);


### PR DESCRIPTION
Removes a bit of redundant code + rename tool keyword to annotation in VisualShaderNodeCustom docs 
