### PR TITLE
Avoid adding margin twice along capsule Y axis

### DIFF
--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -308,7 +308,7 @@ void CapsuleShapeBullet::setup(real_t p_height, real_t p_radius) {
 }
 
 btCollisionShape *CapsuleShapeBullet::internal_create_bt_shape(const btVector3 &p_implicit_scale, real_t p_extra_edge) {
-	return prepare(ShapeBullet::create_shape_capsule(radius * p_implicit_scale[0] + p_extra_edge, height * p_implicit_scale[1] + p_extra_edge));
+	return prepare(ShapeBullet::create_shape_capsule(radius * p_implicit_scale[0] + p_extra_edge, height * p_implicit_scale[1]));
 }
 
 /* Cylinder */


### PR DESCRIPTION
Avoid adding margin twice along capsule Y axis

The capsule radius is a quantity that is added all around the height of the capsule, so it's not needed add the margin to also the height:
![Untitled](https://user-images.githubusercontent.com/8342599/92323021-8e53a200-f035-11ea-929f-59477ef2a9df.png)
