### PR TITLE
Fix taking screenshot crashing the editor.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2693,10 +2693,8 @@ void EditorNode::_screenshot(bool p_use_utc) {
 }
 
 void EditorNode::_save_screenshot(NodePath p_path) {
-	SubViewport *viewport = Object::cast_to<SubViewport>(EditorInterface::get_singleton()->get_editor_viewport()->get_viewport());
-	viewport->set_clear_mode(SubViewport::CLEAR_MODE_ONLY_NEXT_FRAME);
+	Viewport *viewport = EditorInterface::get_singleton()->get_editor_viewport()->get_viewport();
 	Ref<Image> img = viewport->get_texture()->get_data();
-	viewport->set_clear_mode(SubViewport::CLEAR_MODE_ALWAYS);
 	Error error = img->save_png(p_path);
 	ERR_FAIL_COND_MSG(error != OK, "Cannot save screenshot to file '" + p_path + "'.");
 }


### PR DESCRIPTION
Closes #41541

`EditorInterface::get_singleton()->get_editor_viewport()->get_viewport()` was not returning a `SubViewport` so the cast to that was returning `null`. Removing the cast has resolved the issue on my end.