### PR TITLE
Fix header guards in modules.

### DIFF
--- a/modules/arkit/register_types.h
+++ b/modules/arkit/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef ARKIT_REGISTER_TYPES_H
+#define ARKIT_REGISTER_TYPES_H
+
 void register_arkit_types();
 void unregister_arkit_types();
+
+#endif // ARKIT_REGISTER_TYPES_H

--- a/modules/basis_universal/texture_basisu.h
+++ b/modules/basis_universal/texture_basisu.h
@@ -28,6 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef BASIS_UNIVERSAL_TEXTURE_BASISU_H
+#define BASIS_UNIVERSAL_TEXTURE_BASISU_H
+
 #include "scene/resources/texture.h"
 
 #ifdef TOOLS_ENABLED
@@ -75,3 +78,5 @@ public:
 };
 
 #endif
+
+#endif // BASIS_UNIVERSAL_TEXTURE_BASISU_H

--- a/modules/camera/register_types.h
+++ b/modules/camera/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef CAMERA_REGISTER_TYPES_H
+#define CAMERA_REGISTER_TYPES_H
+
 void register_camera_types();
 void unregister_camera_types();
+
+#endif // CAMERA_REGISTER_TYPES_H

--- a/modules/denoise/register_types.h
+++ b/modules/denoise/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef DENOISE_REGISTER_TYPES_H
+#define DENOISE_REGISTER_TYPES_H
+
 void register_denoise_types();
 void unregister_denoise_types();
+
+#endif // DENOISE_REGISTER_TYPES_H

--- a/modules/mono/register_types.h
+++ b/modules/mono/register_types.h
@@ -28,5 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef MONO_REGISTER_TYPES_H
+#define MONO_REGISTER_TYPES_H
+
 void register_mono_types();
 void unregister_mono_types();
+
+#endif // MONO_REGISTER_TYPES_H

--- a/modules/webrtc/webrtc_data_channel_js.h
+++ b/modules/webrtc/webrtc_data_channel_js.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef JAVASCRIPT_ENABLED
-
 #ifndef WEBRTC_DATA_CHANNEL_JS_H
 #define WEBRTC_DATA_CHANNEL_JS_H
+
+#ifdef JAVASCRIPT_ENABLED
 
 #include "webrtc_data_channel.h"
 
@@ -88,6 +88,6 @@ public:
 	~WebRTCDataChannelJS();
 };
 
-#endif // WEBRTC_DATA_CHANNEL_JS_H
-
 #endif // JAVASCRIPT_ENABLED
+
+#endif // WEBRTC_DATA_CHANNEL_JS_H

--- a/modules/webrtc/webrtc_multiplayer.h
+++ b/modules/webrtc/webrtc_multiplayer.h
@@ -112,4 +112,4 @@ public:
 	ConnectionStatus get_connection_status() const override;
 };
 
-#endif
+#endif // WEBRTC_MULTIPLAYER_H


### PR DESCRIPTION
Adds missing header guards to various modules' `register_types.h`
Adds missing header guard to `basis_universal/texture_basisu.h`.
Ensures header guard encloses entire header in `webrtc/webrtc_data_channel_js.h`.
