### PR TITLE
Added is_playing_backwards() method to AnimatedSprite2D

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -36,6 +36,13 @@
 				Stops the current animation (does not reset the frame counter).
 			</description>
 		</method>
+		<method name="is_playing_backwards">
+			<return type="bool">
+			</return>
+			<description>
+				Returns [code]true[/code] if the animation is played backwards, otherwise returns [code]false[/code]. This is set when [method play] is called.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="animation" type="StringName" setter="set_animation" getter="get_animation" default="@&quot;default&quot;">

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -580,6 +580,10 @@ bool AnimatedSprite2D::is_flipped_v() const {
 	return vflip;
 }
 
+bool AnimatedSprite2D::is_playing_backwards() const {
+	return backwards;
+}
+
 void AnimatedSprite2D::_res_changed() {
 	set_frame(frame);
 	_change_notify("frame");
@@ -710,6 +714,8 @@ void AnimatedSprite2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_flip_v", "flip_v"), &AnimatedSprite2D::set_flip_v);
 	ClassDB::bind_method(D_METHOD("is_flipped_v"), &AnimatedSprite2D::is_flipped_v);
+
+	ClassDB::bind_method(D_METHOD("is_playing_backwards"), &AnimatedSprite2D::is_playing_backwards);
 
 	ClassDB::bind_method(D_METHOD("set_frame", "frame"), &AnimatedSprite2D::set_frame);
 	ClassDB::bind_method(D_METHOD("get_frame"), &AnimatedSprite2D::get_frame);

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -216,6 +216,8 @@ public:
 	void set_flip_v(bool p_flip);
 	bool is_flipped_v() const;
 
+	bool is_playing_backwards() const;
+
 	void set_specular_color(const Color &p_color);
 	Color get_specular_color() const;
 


### PR DESCRIPTION
It was talked about that backwards should not be a property, so this keeps it private while still exposing it to script for reading.

This is an updated version of #30785