### PR TITLE
Avoid warning about harmless unfulfilled yields (3.2)

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -975,8 +975,10 @@ GDScript::~GDScript() {
 		GDScriptLanguage::get_singleton()->lock->lock();
 	}
 	while (SelfList<GDScriptFunctionState> *E = pending_func_states.first()) {
-		E->self()->_clear_stack();
+		// Order matters since clearing the stack may already cause
+		// the GDSCriptFunctionState to be destroyed and thus removed from the list.
 		pending_func_states.remove(E);
+		E->self()->_clear_stack();
 	}
 	if (GDScriptLanguage::get_singleton()->lock) {
 		GDScriptLanguage::get_singleton()->lock->unlock();
@@ -1404,8 +1406,10 @@ GDScriptInstance::~GDScriptInstance() {
 #endif
 
 	while (SelfList<GDScriptFunctionState> *E = pending_func_states.first()) {
-		E->self()->_clear_stack();
+		// Order matters since clearing the stack may already cause
+		// the GDSCriptFunctionState to be destroyed and thus removed from the list.
 		pending_func_states.remove(E);
+		E->self()->_clear_stack();
 	}
 
 	if (script.is_valid() && owner) {


### PR DESCRIPTION
Version of #41829 for 3.2. Straight cherry-pick was not possible without conflicts.