### PR TITLE
Add boot splash minimum display time setting

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -203,6 +203,9 @@
 			Path to an image used as the boot splash. If left empty, the default Godot Engine splash will be displayed instead.
 			[b]Note:[/b] Only effective if [member application/boot_splash/show_image] is [code]true[/code].
 		</member>
+		<member name="application/boot_splash/minimum_display_time" type="int" setter="" getter="" default="0">
+			Minimum boot splash display time (in milliseconds). It is not recommended to set too high values for this setting.
+		</member>
 		<member name="application/boot_splash/show_image" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], displays the image specified in [member application/boot_splash/image] when the engine starts. If [code]false[/code], only displays the plain color specified in [member application/boot_splash/bg_color].
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2175,6 +2175,13 @@ bool Main::start() {
 #endif
 	}
 
+	uint64_t minimum_time_msec = GLOBAL_DEF("application/boot_splash/minimum_display_time", 0);
+	ProjectSettings::get_singleton()->set_custom_property_info("application/boot_splash/minimum_display_time",
+			PropertyInfo(Variant::INT,
+					"application/boot_splash/minimum_display_time",
+					PROPERTY_HINT_RANGE,
+					"0,100,1,or_greater,suffix:ms")); // No negative numbers.
+
 #ifdef TOOLS_ENABLED
 	if (!doc_tool_path.is_empty()) {
 		// Needed to instance editor-only classes for their default values
@@ -2692,6 +2699,15 @@ bool Main::start() {
 	if (movie_writer) {
 		movie_writer->begin(DisplayServer::get_singleton()->window_get_size(), fixed_fps, write_movie_path);
 	}
+
+	if (minimum_time_msec) {
+		uint64_t minimum_time = 1000 * minimum_time_msec;
+		uint64_t elapsed_time = OS::get_singleton()->get_ticks_usec();
+		if (elapsed_time < minimum_time) {
+			OS::get_singleton()->delay_usec(minimum_time - elapsed_time);
+		}
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Implements #8867.

---

By default, display time is 0 (equivalent to current behavior).

I found this useful because simple games start so quickly that the splash screen blinks and you can't see anything. The recommended delay is 500 ms – 1 s.

https://github.com/godotengine/godot/blob/b592b74d66f8d728cc512bbde5448d9f4c4e1624/main/main.cpp#L1596

`delay_usec` is used instead of `delay_msec` because `delay_msec` is defined in `core_bind.cpp` and is not yet available in `main.cpp`.

This PR is cherry-pickable for 3.2.