### PR TITLE
Fix the update logic for user-added custom defines.

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -264,7 +264,7 @@ public:
 
 	void shader_add_custom_define(RID p_shader, const String &p_define) {}
 	void shader_get_custom_defines(RID p_shader, Vector<String> *p_defines) const {}
-	void shader_clear_custom_defines(RID p_shader) {}
+	void shader_remove_custom_define(RID p_shader, const String &p_define) {}
 
 	/* COMMON MATERIAL API */
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1753,12 +1753,12 @@ void RasterizerStorageGLES2::shader_get_custom_defines(RID p_shader, Vector<Stri
 	shader->shader->get_custom_defines(p_defines);
 }
 
-void RasterizerStorageGLES2::shader_clear_custom_defines(RID p_shader) {
+void RasterizerStorageGLES2::shader_remove_custom_define(RID p_shader, const String &p_define) {
 
 	Shader *shader = shader_owner.get(p_shader);
 	ERR_FAIL_COND(!shader);
 
-	shader->shader->clear_custom_defines();
+	shader->shader->remove_custom_define(p_define);
 
 	_shader_make_dirty(shader);
 }

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -543,7 +543,7 @@ public:
 
 	virtual void shader_add_custom_define(RID p_shader, const String &p_define);
 	virtual void shader_get_custom_defines(RID p_shader, Vector<String> *p_defines) const;
-	virtual void shader_clear_custom_defines(RID p_shader);
+	virtual void shader_remove_custom_define(RID p_shader, const String &p_define);
 
 	void _update_shader(Shader *p_shader) const;
 	void update_dirty_shaders();

--- a/drivers/gles2/shader_gles2.h
+++ b/drivers/gles2/shader_gles2.h
@@ -252,8 +252,8 @@ public:
 		}
 	}
 
-	void clear_custom_defines() {
-		custom_defines.clear();
+	void remove_custom_define(const String &p_define) {
+		custom_defines.erase(p_define.utf8());
 	}
 
 	virtual ~ShaderGLES2();

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2584,12 +2584,12 @@ void RasterizerStorageGLES3::shader_get_custom_defines(RID p_shader, Vector<Stri
 	shader->shader->get_custom_defines(p_defines);
 }
 
-void RasterizerStorageGLES3::shader_clear_custom_defines(RID p_shader) {
+void RasterizerStorageGLES3::shader_remove_custom_define(RID p_shader, const String &p_define) {
 
 	Shader *shader = shader_owner.get(p_shader);
 	ERR_FAIL_COND(!shader);
 
-	shader->shader->clear_custom_defines();
+	shader->shader->remove_custom_define(p_define);
 
 	_shader_make_dirty(shader);
 }

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -539,7 +539,7 @@ public:
 
 	virtual void shader_add_custom_define(RID p_shader, const String &p_define);
 	virtual void shader_get_custom_defines(RID p_shader, Vector<String> *p_defines) const;
-	virtual void shader_clear_custom_defines(RID p_shader);
+	virtual void shader_remove_custom_define(RID p_shader, const String &p_define);
 
 	void _update_shader(Shader *p_shader) const;
 

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -374,8 +374,8 @@ public:
 		}
 	}
 
-	void clear_custom_defines() {
-		custom_defines.clear();
+	void remove_custom_define(const String &p_define) {
+		custom_defines.erase(p_define.utf8());
 	}
 
 	virtual ~ShaderGLES3();

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -128,24 +128,20 @@ void Shader::get_default_texture_param_list(List<StringName> *r_textures) const 
 }
 
 void Shader::set_custom_defines(const String &p_defines) {
-
-	VS::get_singleton()->shader_clear_custom_defines(shader);
-	VS::get_singleton()->shader_add_custom_define(shader, p_defines);
-}
-
-String Shader::get_custom_defines() {
-	Vector<String> custom_defines;
-	VS::get_singleton()->shader_get_custom_defines(shader, &custom_defines);
-
-	String concatenated_defines;
-	for (int i = 0; i < custom_defines.size(); i++) {
-		if (i != 0) {
-			concatenated_defines += "\n";
-		}
-		concatenated_defines += custom_defines[i];
+	if (shader_custom_defines == p_defines) {
+		return;
 	}
 
-	return concatenated_defines;
+	if (!shader_custom_defines.empty()) {
+		VS::get_singleton()->shader_remove_custom_define(shader, shader_custom_defines);
+	}
+
+	shader_custom_defines = p_defines;
+	VS::get_singleton()->shader_add_custom_define(shader, shader_custom_defines);
+}
+
+String Shader::get_custom_defines() const {
+	return shader_custom_defines;
 }
 
 bool Shader::is_text_shader() const {

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -53,6 +53,7 @@ public:
 private:
 	RID shader;
 	Mode mode;
+	String shader_custom_defines;
 
 	// hack the name of performance
 	// shaders keep a list of ShaderMaterial -> VisualServer name translations, to make
@@ -80,7 +81,7 @@ public:
 	void get_default_texture_param_list(List<StringName> *r_textures) const;
 
 	void set_custom_defines(const String &p_defines);
-	String get_custom_defines();
+	String get_custom_defines() const;
 
 	virtual bool is_text_shader() const;
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -244,7 +244,7 @@ public:
 
 	virtual void shader_add_custom_define(RID p_shader, const String &p_define) = 0;
 	virtual void shader_get_custom_defines(RID p_shader, Vector<String> *p_defines) const = 0;
-	virtual void shader_clear_custom_defines(RID p_shader) = 0;
+	virtual void shader_remove_custom_define(RID p_shader, const String &p_define) = 0;
 
 	/* COMMON MATERIAL API */
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -192,7 +192,7 @@ public:
 
 	BIND2(shader_add_custom_define, RID, const String &)
 	BIND2C(shader_get_custom_defines, RID, Vector<String> *)
-	BIND1(shader_clear_custom_defines, RID)
+	BIND2(shader_remove_custom_define, RID, const String &)
 
 	/* COMMON MATERIAL API */
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -128,7 +128,7 @@ public:
 
 	FUNC2(shader_add_custom_define, RID, const String &)
 	FUNC2SC(shader_get_custom_defines, RID, Vector<String> *)
-	FUNC1(shader_clear_custom_defines, RID)
+	FUNC2(shader_remove_custom_define, RID, const String &)
 
 	/* COMMON MATERIAL API */
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -197,7 +197,7 @@ public:
 
 	virtual void shader_add_custom_define(RID p_shader, const String &p_define) = 0;
 	virtual void shader_get_custom_defines(RID p_shader, Vector<String> *p_defines) const = 0;
-	virtual void shader_clear_custom_defines(RID p_shader) = 0;
+	virtual void shader_remove_custom_define(RID p_shader, const String &p_define) = 0;
 
 	/* COMMON MATERIAL API */
 


### PR DESCRIPTION
The previous logic was causing the (unintentional) removal of custom defines automatically added by the engine.