### PR TITLE
Remakes particles in visual shaders

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -63,7 +63,9 @@ class VisualShaderEditor : public VBoxContainer {
 	Button *add_node;
 	Button *preview_shader;
 
-	OptionButton *edit_type;
+	OptionButton *edit_type = nullptr;
+	OptionButton *edit_type_standart;
+	OptionButton *edit_type_particles;
 
 	PanelContainer *error_panel;
 	Label *error_label;
@@ -84,13 +86,18 @@ class VisualShaderEditor : public VBoxContainer {
 	MenuButton *tools;
 
 	bool preview_showed;
+	bool particles_mode;
 
 	enum TypeFlags {
 		TYPE_FLAGS_VERTEX = 1,
 		TYPE_FLAGS_FRAGMENT = 2,
 		TYPE_FLAGS_LIGHT = 4,
-		TYPE_FLAGS_COMPUTE = 8,
-		TYPE_FLAGS_VERTEX_FRAGMENT_LIGHT = TYPE_FLAGS_VERTEX | TYPE_FLAGS_FRAGMENT | TYPE_FLAGS_LIGHT,
+	};
+
+	enum ParticlesTypeFlags {
+		TYPE_FLAGS_EMIT = 1,
+		TYPE_FLAGS_PROCESS = 2,
+		TYPE_FLAGS_END = 4
 	};
 
 	enum ToolsMenuOptions {
@@ -241,6 +248,8 @@ class VisualShaderEditor : public VBoxContainer {
 
 	void _input_select_item(Ref<VisualShaderNodeInput> input, String name);
 	void _uniform_select_item(Ref<VisualShaderNodeUniformRef> p_uniform, String p_name);
+
+	VisualShader::Type get_current_shader_type() const;
 
 	void _add_input_port(int p_node, int p_port, int p_port_type, const String &p_name);
 	void _remove_input_port(int p_node, int p_port);

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -50,7 +50,9 @@ public:
 		TYPE_VERTEX,
 		TYPE_FRAGMENT,
 		TYPE_LIGHT,
-		TYPE_COMPUTE,
+		TYPE_EMIT,
+		TYPE_PROCESS,
+		TYPE_END,
 		TYPE_MAX
 	};
 
@@ -112,6 +114,7 @@ private:
 	Error _write_node(Type p_type, StringBuilder &global_code, StringBuilder &global_code_per_node, Map<Type, StringBuilder> &global_code_per_func, StringBuilder &code, Vector<DefaultTextureParam> &def_tex_params, const VMap<ConnectionKey, const List<Connection>::Element *> &input_connections, const VMap<ConnectionKey, const List<Connection>::Element *> &output_connections, int node, Set<int> &processed, bool for_preview, Set<StringName> &r_classes) const;
 
 	void _input_type_changed(Type p_type, int p_id);
+	bool has_func_name(RenderingServer::ShaderMode p_mode, const String &p_func_name) const;
 
 protected:
 	virtual void _update_shader() const override;


### PR DESCRIPTION
Alright, as @reduz requested, I began to rewrite the visual shader editor to handle particles more precisely. 

Changes:

- Added "Emit/Process/End" modes and makes a "Vertex/Fragment/Light" to be invisible in particle mode.
- Emit content will be pushed into compute function under if(RESTART) { ... }
- Process content will be pushed into compute function under if(RESTART) else { ... }

You can see the generated code in the following screenshots:

Emit mode screenshot:
![image](https://user-images.githubusercontent.com/3036176/92360418-6e83b300-f0f5-11ea-85e2-0ad75332f154.png)

Process mode screenshot:
![image](https://user-images.githubusercontent.com/3036176/92360968-582a2700-f0f6-11ea-8900-d17c7c7b8310.png)

I need to think about how to process End.