### PR TITLE
Remove bit fields and use fixed width integers instead.

### DIFF
--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -79,10 +79,10 @@ private:
 		struct Line {
 			Vector<Gutter> gutters;
 
-			int width_cache : 24;
-			bool marked : 1;
-			bool hidden : 1;
-			int wrap_amount_cache : 24;
+			int32_t width_cache;
+			bool marked;
+			bool hidden;
+			int32_t wrap_amount_cache;
 			String data;
 			Line() {
 				width_cache = 0;


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=list&lang=&id=cpp%2Fambiguously-signed-bit-field), the signedness of `int` bit fields is implementation specific. Therefore, they need to be explicitly signed or unsigned. Since -1 is used to identify an unconfigured `width_cache` or `wrap_amount_cache`, this PR makes them explicitly signed.
