### PR TITLE
Adding pause() and resume() to AnimationPlayer

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1241,6 +1241,26 @@ void AnimationPlayer::stop(bool p_reset) {
 	playing = false;
 }
 
+void AnimationPlayer::pause(bool p_pause) {
+	_stop_playing_caches();
+	Playback &c = playback;
+	c.blend.clear();
+
+	_set_process(!p_pause);
+	queued.clear();
+	playing = !p_pause;
+}
+
+void AnimationPlayer::resume() {
+	_stop_playing_caches();
+	Playback &c = playback;
+	c.blend.clear();
+
+	_set_process(true);
+	queued.clear();
+	playing = true;
+}
+
 void AnimationPlayer::set_speed_scale(float p_speed) {
 	speed_scale = p_speed;
 }
@@ -1559,6 +1579,8 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("play", "name", "custom_blend", "custom_speed", "from_end"), &AnimationPlayer::play, DEFVAL(""), DEFVAL(-1), DEFVAL(1.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("play_backwards", "name", "custom_blend"), &AnimationPlayer::play_backwards, DEFVAL(""), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("stop", "reset"), &AnimationPlayer::stop, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("pause", "pause"), &AnimationPlayer::pause, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("resume"), &AnimationPlayer::resume);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimationPlayer::is_playing);
 
 	ClassDB::bind_method(D_METHOD("set_current_animation", "anim"), &AnimationPlayer::set_current_animation);

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1241,14 +1241,14 @@ void AnimationPlayer::stop(bool p_reset) {
 	playing = false;
 }
 
-void AnimationPlayer::pause(bool p_pause) {
+void AnimationPlayer::pause() {
 	_stop_playing_caches();
 	Playback &c = playback;
 	c.blend.clear();
 
-	_set_process(!p_pause);
+	_set_process(false);
 	queued.clear();
-	playing = !p_pause;
+	playing = false;
 }
 
 void AnimationPlayer::resume() {
@@ -1579,7 +1579,7 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("play", "name", "custom_blend", "custom_speed", "from_end"), &AnimationPlayer::play, DEFVAL(""), DEFVAL(-1), DEFVAL(1.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("play_backwards", "name", "custom_blend"), &AnimationPlayer::play_backwards, DEFVAL(""), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("stop", "reset"), &AnimationPlayer::stop, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("pause", "pause"), &AnimationPlayer::pause, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("pause"), &AnimationPlayer::pause);
 	ClassDB::bind_method(D_METHOD("resume"), &AnimationPlayer::resume);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimationPlayer::is_playing);
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1241,26 +1241,6 @@ void AnimationPlayer::stop(bool p_reset) {
 	playing = false;
 }
 
-void AnimationPlayer::pause(bool p_pause) {
-	_stop_playing_caches();
-	Playback &c = playback;
-	c.blend.clear();
-
-	_set_process(!p_pause);
-	queued.clear();
-	playing = !p_pause;
-}
-
-void AnimationPlayer::resume() {
-	_stop_playing_caches();
-	Playback &c = playback;
-	c.blend.clear();
-
-	_set_process(true);
-	queued.clear();
-	playing = true;
-}
-
 void AnimationPlayer::set_speed_scale(float p_speed) {
 	speed_scale = p_speed;
 }
@@ -1579,8 +1559,6 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("play", "name", "custom_blend", "custom_speed", "from_end"), &AnimationPlayer::play, DEFVAL(""), DEFVAL(-1), DEFVAL(1.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("play_backwards", "name", "custom_blend"), &AnimationPlayer::play_backwards, DEFVAL(""), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("stop", "reset"), &AnimationPlayer::stop, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("pause", "pause"), &AnimationPlayer::pause, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("resume"), &AnimationPlayer::resume);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimationPlayer::is_playing);
 
 	ClassDB::bind_method(D_METHOD("set_current_animation", "anim"), &AnimationPlayer::set_current_animation);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -288,6 +288,8 @@ public:
 	Vector<String> get_queue();
 	void clear_queue();
 	void stop(bool p_reset = true);
+	void pause(bool p_pause = true);
+	void resume();
 	bool is_playing() const;
 	String get_current_animation() const;
 	void set_current_animation(const String &p_anim);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -288,8 +288,6 @@ public:
 	Vector<String> get_queue();
 	void clear_queue();
 	void stop(bool p_reset = true);
-	void pause(bool p_pause = true);
-	void resume();
 	bool is_playing() const;
 	String get_current_animation() const;
 	void set_current_animation(const String &p_anim);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -288,7 +288,7 @@ public:
 	Vector<String> get_queue();
 	void clear_queue();
 	void stop(bool p_reset = true);
-	void pause(bool p_pause = true);
+	void pause();
 	void resume();
 	bool is_playing() const;
 	String get_current_animation() const;

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -764,23 +764,8 @@ void GraphEdit::set_selected(Node *p_child) {
 		if (!gn) {
 			continue;
 		}
-		
-		if (gn != p_child && gn->is_selected()) {
-			emit_signal("node_unselected", gn);
-		}
-	}
-
-	for (int i = get_child_count() - 1; i >= 0; i--) {
-		GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
-		if (!gn) {
-			continue;
-		}
 
 		gn->set_selected(gn == p_child);
-
-		if (gn == p_child) {
-			emit_signal("node_selected", gn);
-		}
 	}
 }
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -764,8 +764,23 @@ void GraphEdit::set_selected(Node *p_child) {
 		if (!gn) {
 			continue;
 		}
+		
+		if (gn != p_child && gn->is_selected()) {
+			emit_signal("node_unselected", gn);
+		}
+	}
+
+	for (int i = get_child_count() - 1; i >= 0; i--) {
+		GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
+		if (!gn) {
+			continue;
+		}
 
 		gn->set_selected(gn == p_child);
+
+		if (gn == p_child) {
+			emit_signal("node_selected", gn);
+		}
 	}
 }
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -227,7 +227,10 @@ void GraphEdit::_graph_node_raised(Node *p_gn) {
 
 	move_child(connections_layer, first_not_comment);
 	top_layer->raise();
-	emit_signal("node_selected", p_gn);
+	
+	if (!gn->is_selected()) {
+		emit_signal("node_selected", p_gn);
+	}
 }
 
 void GraphEdit::_graph_node_moved(Node *p_gn) {

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -227,10 +227,7 @@ void GraphEdit::_graph_node_raised(Node *p_gn) {
 
 	move_child(connections_layer, first_not_comment);
 	top_layer->raise();
-	
-	if (!gn->is_selected()) {
-		emit_signal("node_selected", p_gn);
-	}
+	emit_signal("node_selected", p_gn);
 }
 
 void GraphEdit::_graph_node_moved(Node *p_gn) {


### PR DESCRIPTION
This pull request is the implementation of [#41838](https://github.com/godotengine/godot/issues/41838) and adds two methods to the AnimationPlayer: pause() and resume(). They do exactly what you think ($AnimationPlayer.pause() pauses the animation and $AnimationPlayer.resume() resumes the animation). This is way more intuitive than using stop() both pause and resume. (stop still working in the same way)