### PR TITLE
Fix some broken visual shader nodes

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -172,8 +172,6 @@ void VisualShaderNode::_bind_methods() {
 }
 
 VisualShaderNode::VisualShaderNode() {
-	port_preview = -1;
-	simple_decl = true;
 }
 
 /////////////////////////////////////////////////////////
@@ -2951,6 +2949,7 @@ String VisualShaderNodeGroupBase::generate_code(Shader::Mode p_mode, VisualShade
 }
 
 VisualShaderNodeGroupBase::VisualShaderNodeGroupBase() {
+	simple_decl = false;
 }
 
 ////////////// Expression

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -180,7 +180,7 @@ VARIANT_ENUM_CAST(VisualShader::Type)
 class VisualShaderNode : public Resource {
 	GDCLASS(VisualShaderNode, Resource);
 
-	int port_preview;
+	int port_preview = -1;
 
 	Map<int, Variant> default_input_values;
 	Map<int, bool> connected_input_ports;
@@ -188,7 +188,7 @@ class VisualShaderNode : public Resource {
 	int connected_output_count = 0;
 
 protected:
-	bool simple_decl = false;
+	bool simple_decl = true;
 	static void _bind_methods();
 
 public:

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -892,6 +892,7 @@ String VisualShaderNodeSample3D::get_warning(Shader::Mode p_mode, VisualShader::
 }
 
 VisualShaderNodeSample3D::VisualShaderNodeSample3D() {
+	simple_decl = false;
 }
 
 ////////////// Texture2DArray
@@ -1135,6 +1136,7 @@ void VisualShaderNodeCubemap::_bind_methods() {
 }
 
 VisualShaderNodeCubemap::VisualShaderNodeCubemap() {
+	simple_decl = false;
 }
 
 ////////////// Float Op
@@ -2236,6 +2238,7 @@ void VisualShaderNodeColorFunc::_bind_methods() {
 }
 
 VisualShaderNodeColorFunc::VisualShaderNodeColorFunc() {
+	simple_decl = false;
 	set_input_port_default_value(0, Vector3());
 }
 
@@ -4226,6 +4229,7 @@ bool VisualShaderNodeTextureUniform::is_qualifier_supported(Qualifier p_qual) co
 }
 
 VisualShaderNodeTextureUniform::VisualShaderNodeTextureUniform() {
+	simple_decl = false;
 }
 
 ////////////// Texture Uniform (Triplanar)
@@ -4529,6 +4533,7 @@ String VisualShaderNodeIf::generate_code(Shader::Mode p_mode, VisualShader::Type
 }
 
 VisualShaderNodeIf::VisualShaderNodeIf() {
+	simple_decl = false;
 	set_input_port_default_value(0, 0.0);
 	set_input_port_default_value(1, 0.0);
 	set_input_port_default_value(2, CMP_EPSILON);
@@ -4593,6 +4598,7 @@ String VisualShaderNodeSwitch::generate_code(Shader::Mode p_mode, VisualShader::
 }
 
 VisualShaderNodeSwitch::VisualShaderNodeSwitch() {
+	simple_decl = false;
 	set_input_port_default_value(0, false);
 	set_input_port_default_value(1, Vector3(1.0, 1.0, 1.0));
 	set_input_port_default_value(2, Vector3(0.0, 0.0, 0.0));


### PR DESCRIPTION
After https://github.com/godotengine/godot/pull/41789 I found some nodes generate incorrect code cuz `simple_decl` variable set to an incorrect value.
