### PR TITLE
Use != 0 instead of > 0 when checking bit mask.

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -60,7 +60,7 @@ void BaseButton::_gui_input(Ref<InputEvent> p_event) {
 	Ref<InputEventMouseButton> mouse_button = p_event;
 	bool ui_accept = p_event->is_action("ui_accept") && !p_event->is_echo();
 
-	bool button_masked = mouse_button.is_valid() && ((1 << (mouse_button->get_button_index() - 1)) & button_mask) > 0;
+	bool button_masked = mouse_button.is_valid() && ((1 << (mouse_button->get_button_index() - 1)) & button_mask) != 0;
 	if (button_masked || ui_accept) {
 		on_action_event(p_event);
 		return;


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=list&lang=&id=cpp%2Fbitwise-sign-check), sign checks should not be used when checking bit masks. If the 32<sup>nd</sup> bit of an integer is set, the value will be negative and `> 0` will return `false` when it's expected to return `true`. This PR changes the bit mask check to `!= 0`.