### PR TITLE
Clarify comparison when enabling or disabling canvas_item copy_back_buffer buffer.

### DIFF
--- a/servers/rendering/rendering_server_canvas.cpp
+++ b/servers/rendering/rendering_server_canvas.cpp
@@ -900,13 +900,12 @@ void RenderingServerCanvas::canvas_item_attach_skeleton(RID p_item, RID p_skelet
 void RenderingServerCanvas::canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable, const Rect2 &p_rect) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
-	if (bool(canvas_item->copy_back_buffer != nullptr) != p_enable) {
-		if (p_enable) {
-			canvas_item->copy_back_buffer = memnew(RasterizerCanvas::Item::CopyBackBuffer);
-		} else {
-			memdelete(canvas_item->copy_back_buffer);
-			canvas_item->copy_back_buffer = nullptr;
-		}
+	if (p_enable && (canvas_item->copy_back_buffer == nullptr)) {
+		canvas_item->copy_back_buffer = memnew(RasterizerCanvas::Item::CopyBackBuffer);
+	}
+	if (!p_enable && (canvas_item->copy_back_buffer != nullptr)) {
+		memdelete(canvas_item->copy_back_buffer);
+		canvas_item->copy_back_buffer = nullptr;
 	}
 
 	if (p_enable) {


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=&id=cpp%2Fcomparison-precedence&ruleFocus=2158910263), the condition for creating or deleting the `canvas_item->copy_back_buffer` is unclear. This PR makes it clear that when `p_enable` is `true` and a `canvas_item->copy_back_buffer` doesn't already exist, to create one. Similarly, when `p_enable` is `false` and a `canvas_item->copy_back_buffer` exists, to delete it.
