### PR TITLE
Added hysteresis for popup sub-menus

### DIFF
--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -93,7 +93,7 @@ void Popup::_notification(int p_what) {
 }
 
 void Popup::_parent_focused() {
-	if (popped_up) {
+	if (popped_up && close_on_parent_focus) {
 		_close_pressed();
 	}
 }
@@ -112,7 +112,19 @@ void Popup::set_as_minsize() {
 	set_size(get_contents_minimum_size());
 }
 
+void Popup::set_close_on_parent_focus(bool p_close) {
+	close_on_parent_focus = p_close;
+}
+
+bool Popup::get_close_on_parent_focus() {
+	return close_on_parent_focus;
+}
+
 void Popup::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_close_on_parent_focus", "close"), &Popup::set_close_on_parent_focus);
+	ClassDB::bind_method(D_METHOD("get_close_on_parent_focus"), &Popup::get_close_on_parent_focus);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "close_on_parent_focus"), "set_close_on_parent_focus", "get_close_on_parent_focus");
+
 	ADD_SIGNAL(MethodInfo("popup_hide"));
 }
 

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -40,6 +40,7 @@ class Popup : public Window {
 
 	LocalVector<Window *> visible_parents;
 	bool popped_up = false;
+	bool close_on_parent_focus = true;
 
 	void _input_from_window(const Ref<InputEvent> &p_event);
 
@@ -57,6 +58,10 @@ protected:
 
 public:
 	void set_as_minsize();
+
+	void set_close_on_parent_focus(bool p_close);
+	bool get_close_on_parent_focus();
+
 	Popup();
 	~Popup();
 };

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -86,6 +86,9 @@ class PopupMenu : public Popup {
 		}
 	};
 
+	bool close_allowed = false;
+
+	Timer *minimum_lifetime_timer = nullptr;
 	Timer *submenu_timer;
 	List<Rect2> autohide_areas;
 	Vector<Item> items;
@@ -102,7 +105,7 @@ class PopupMenu : public Popup {
 	void _scroll_to_item(int p_item);
 
 	void _gui_input(const Ref<InputEvent> &p_event);
-	void _activate_submenu(int over);
+	void _activate_submenu(int p_over);
 	void _submenu_timeout();
 
 	uint64_t popup_time_msec = 0;
@@ -129,6 +132,9 @@ class PopupMenu : public Popup {
 
 	void _draw_items();
 	void _draw_background();
+
+	void _minimum_lifetime_timeout();
+	void _close_pressed();
 
 protected:
 	friend class MenuButton;


### PR DESCRIPTION
This adds a small lag effect when opening submenus which allow the user to move directly to an item on the submenu without worrying about avoiding the autohide regions.

I tested with Windows 10 submenu's and seems like their timer is just under 0.5 seconds, so that is what I used. The timer only starts when the user enters an autohide area for the first time. Again, this simulates the behaviour I observed on Windows 10. Please note this is a delay-only based implementation. I am not doing any fancy mouse-movement tracking or prediction - that's overkill imo. 

Builds on #41640
Closes #11219
Supersedes/Closes #35487

CC @KoBeWi 

Note how in the below GIF I actually enter autohide areas on my way to the submenu, but it does not close.
![popup_hysteresis](https://user-images.githubusercontent.com/41730826/92392836-42eae200-f162-11ea-8ac7-6b1b6ee384aa.gif)