### PR TITLE
Make precision of time_step consistently float.

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -180,7 +180,7 @@ public:
 	void render_particle_collider_heightfield(RID p_collider, const Transform &p_transform, const PagedArray<GeometryInstance *> &p_instances) override {}
 
 	void set_scene_pass(uint64_t p_pass) override {}
-	void set_time(double p_time, double p_step) override {}
+	void set_time(float p_time, float p_step) override {}
 	void set_debug_draw_mode(RS::ViewportDebugDraw p_debug_draw) override {}
 
 	RID render_buffers_create() override { return RID(); }
@@ -712,7 +712,7 @@ public:
 	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) override {}
 
 	void initialize() override {}
-	void begin_frame(double frame_step) override {
+	void begin_frame(float frame_step) override {
 		frame++;
 		delta = frame_step;
 	}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2419,8 +2419,8 @@ bool Main::iteration() {
 	float time_scale = Engine::get_singleton()->get_time_scale();
 
 	MainFrameTime advance = main_timer_sync.advance(physics_step, physics_fps);
-	double process_step = advance.process_step;
-	double scaled_step = process_step * time_scale;
+	float process_step = advance.process_step;
+	float scaled_step = process_step * time_scale;
 
 	Engine::get_singleton()->_process_step = process_step;
 	Engine::get_singleton()->_physics_interpolation_fraction = advance.interpolation_fraction;

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -54,7 +54,7 @@ public:
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) = 0;
 
 	virtual void initialize() = 0;
-	virtual void begin_frame(double frame_step) = 0;
+	virtual void begin_frame(float frame_step) = 0;
 
 	struct BlitToScreen {
 		RID render_target;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2362,7 +2362,7 @@ RendererStorageRD::MaterialData *RendererCanvasRenderRD::_create_material_func(S
 	return material_data;
 }
 
-void RendererCanvasRenderRD::set_time(double p_time) {
+void RendererCanvasRenderRD::set_time(float p_time) {
 	state.time = p_time;
 }
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -380,7 +380,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		uint32_t max_lights_per_render;
 		uint32_t max_lights_per_item;
 
-		double time;
+		float time;
 
 	} state;
 
@@ -462,7 +462,7 @@ public:
 
 	virtual void set_shadow_texture_size(int p_size);
 
-	void set_time(double p_time);
+	void set_time(float p_time);
 	void update();
 	bool free(RID p_rid);
 	RendererCanvasRenderRD(RendererStorageRD *p_storage);

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -76,12 +76,12 @@ void RendererCompositorRD::blit_render_targets_to_screen(DisplayServer::WindowID
 	RD::get_singleton()->draw_list_end();
 }
 
-void RendererCompositorRD::begin_frame(double frame_step) {
+void RendererCompositorRD::begin_frame(float frame_step) {
 	frame++;
 	delta = frame_step;
 	time += frame_step;
 
-	double time_roll_over = GLOBAL_GET("rendering/limits/time/time_rollover_secs");
+	float time_roll_over = GLOBAL_GET("rendering/limits/time/time_rollover_secs");
 	time = Math::fmod(time, time_roll_over);
 
 	canvas->set_time(time);

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -52,7 +52,7 @@ protected:
 
 	Map<RID, RID> render_target_descriptors;
 
-	double time;
+	float time;
 	float delta;
 
 	static uint64_t frame;
@@ -65,7 +65,7 @@ public:
 	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {}
 
 	void initialize();
-	void begin_frame(double frame_step);
+	void begin_frame(float frame_step);
 	void prepare_for_blitting_render_targets();
 	void blit_render_targets_to_screen(DisplayServer::WindowID p_screen, const BlitToScreen *p_render_targets, int p_amount);
 
@@ -74,7 +74,7 @@ public:
 
 	_ALWAYS_INLINE_ uint64_t get_frame_number() const { return frame; }
 	_ALWAYS_INLINE_ float get_frame_delta_time() const { return delta; }
-	_ALWAYS_INLINE_ double get_total_time() const { return time; }
+	_ALWAYS_INLINE_ float get_total_time() const { return time; }
 
 	static Error is_viable() {
 		return OK;

--- a/servers/rendering/renderer_rd/renderer_scene_render_forward.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_forward.cpp
@@ -2804,7 +2804,7 @@ RID RendererSceneRenderForward::_render_buffers_get_normal_texture(RID p_render_
 
 RendererSceneRenderForward *RendererSceneRenderForward::singleton = nullptr;
 
-void RendererSceneRenderForward::set_time(double p_time, double p_step) {
+void RendererSceneRenderForward::set_time(float p_time, float p_step) {
 	time = p_time;
 	RendererSceneRenderRD::set_time(p_time, p_step);
 }

--- a/servers/rendering/renderer_rd/renderer_scene_render_forward.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_forward.h
@@ -492,7 +492,7 @@ class RendererSceneRenderForward : public RendererSceneRenderRD {
 
 	static RendererSceneRenderForward *singleton;
 
-	double time;
+	float time;
 	RID default_shader;
 	RID default_material;
 	RID overdraw_material_shader;
@@ -761,7 +761,7 @@ public:
 	virtual void geometry_instance_pair_decal_instances(GeometryInstance *p_geometry_instance, const RID *p_decal_instances, uint32_t p_decal_instance_count);
 	virtual void geometry_instance_pair_gi_probe_instances(GeometryInstance *p_geometry_instance, const RID *p_gi_probe_instances, uint32_t p_gi_probe_instance_count);
 
-	virtual void set_time(double p_time, double p_step);
+	virtual void set_time(float p_time, float p_step);
 
 	virtual bool free(RID p_rid);
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -8281,7 +8281,7 @@ void RendererSceneRenderRD::update() {
 	_update_dirty_skys();
 }
 
-void RendererSceneRenderRD::set_time(double p_time, double p_step) {
+void RendererSceneRenderRD::set_time(float p_time, float p_step) {
 	time = p_time;
 	time_step = p_step;
 }

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -51,7 +51,7 @@
 
 class RendererSceneRenderRD : public RendererSceneRender {
 protected:
-	double time;
+	float time;
 
 	// Skys need less info from Directional Lights than the normal shaders
 	struct SkyDirectionalLightData {
@@ -2108,7 +2108,7 @@ public:
 		return debug_draw;
 	}
 
-	virtual void set_time(double p_time, double p_step);
+	virtual void set_time(float p_time, float p_step);
 
 	RID get_reflection_probe_buffer();
 	RID get_omni_light_buffer();

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -222,7 +222,7 @@ public:
 	virtual void render_particle_collider_heightfield(RID p_collider, const Transform &p_transform, const PagedArray<GeometryInstance *> &p_instances) = 0;
 
 	virtual void set_scene_pass(uint64_t p_pass) = 0;
-	virtual void set_time(double p_time, double p_step) = 0;
+	virtual void set_time(float p_time, float p_step) = 0;
 	virtual void set_debug_draw_mode(RS::ViewportDebugDraw p_debug_draw) = 0;
 
 	virtual RID render_buffers_create() = 0;

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -91,7 +91,7 @@ void RenderingServerDefault::request_frame_drawn_callback(Object *p_where, const
 	frame_drawn_callbacks.push_back(fdc);
 }
 
-void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
+void RenderingServerDefault::_draw(bool p_swap_buffers, float frame_step) {
 	//needs to be done before changes is reset to 0, to not force the editor to redraw
 	RS::get_singleton()->emit_signal("frame_pre_draw");
 
@@ -332,7 +332,7 @@ void RenderingServerDefault::_thread_exit() {
 	exit = true;
 }
 
-void RenderingServerDefault::_thread_draw(bool p_swap_buffers, double frame_step) {
+void RenderingServerDefault::_thread_draw(bool p_swap_buffers, float frame_step) {
 	if (!atomic_decrement(&draw_pending)) {
 		_draw(p_swap_buffers, frame_step);
 	}
@@ -378,7 +378,7 @@ void RenderingServerDefault::sync() {
 	}
 }
 
-void RenderingServerDefault::draw(bool p_swap_buffers, double frame_step) {
+void RenderingServerDefault::draw(bool p_swap_buffers, float frame_step) {
 	if (create_thread) {
 		atomic_increment(&draw_pending);
 		command_queue.push(this, &RenderingServerDefault::_thread_draw, p_swap_buffers, frame_step);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -95,14 +95,14 @@ class RenderingServerDefault : public RenderingServer {
 	bool create_thread;
 
 	uint64_t draw_pending;
-	void _thread_draw(bool p_swap_buffers, double frame_step);
+	void _thread_draw(bool p_swap_buffers, float frame_step);
 	void _thread_flush();
 
 	void _thread_exit();
 
 	Mutex alloc_mutex;
 
-	void _draw(bool p_swap_buffers, double frame_step);
+	void _draw(bool p_swap_buffers, float frame_step);
 	void _init();
 	void _finish();
 
@@ -893,7 +893,7 @@ public:
 
 	virtual void request_frame_drawn_callback(Object *p_where, const StringName &p_method, const Variant &p_userdata) override;
 
-	virtual void draw(bool p_swap_buffers, double frame_step) override;
+	virtual void draw(bool p_swap_buffers, float frame_step) override;
 	virtual void sync() override;
 	virtual bool has_changed() const override;
 	virtual void init() override;

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1398,7 +1398,7 @@ public:
 
 	/* EVENT QUEUING */
 
-	virtual void draw(bool p_swap_buffers = true, double frame_step = 0.0) = 0;
+	virtual void draw(bool p_swap_buffers = true, float frame_step = 0.0f) = 0;
 	virtual void sync() = 0;
 	virtual bool has_changed() const = 0;
 	virtual void init() = 0;


### PR DESCRIPTION
The precision of `time_step` is `float`. However, there are a number of locations where `time_step` is converted to a `double`. This PR makes the uses of `time_step` consistently a `float`.

Note: The driver for this change is to avoid [lgtm](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=&id=cpp%2Finteger-multiplication-cast-to-long&tag=&ruleFocus=2157860313) warning about potential `float` overflows: If the reason for a conversion to a `double` were the need to increase the maximum size of the `float`, and the conversion to a `double` was done after a calculation, there is a risk of a `float` overflow that would go unnoticed. In other words, if there is actually a need for a `double` when using `time_step` in a calculation to prevent a `float` overflow (or a loss of precision, for example, when the numbers are larger) then the conversion to a `double` should be done earlier and made explicit.

The only place I have found where the conversion to a `double` may be required is when storing `RasterizerCanvasRD::State.time`:
https://github.com/godotengine/godot/blob/5bf28c735dc6d70fdf8dd5a27da86d6beb36933d/servers/rendering/rasterizer_rd/rasterizer_rd.cpp#L84-L87
However, I think it's unlikely this needs to be a `double`, because, at most the size is limited to the size of `rendering/limits/time/time_rollover_secs`, which, by default, is 3,600, and even within `RasterizerCanvasRD::State` the `RasterizerCanvasRD::State.Buffer.time` uses a `float` too:
https://github.com/godotengine/godot/blob/5bf28c735dc6d70fdf8dd5a27da86d6beb36933d/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.h#L397-L422



