### PR TITLE
Add up/down keys to inc/dec val in editor spin slider

### DIFF
--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -71,6 +71,7 @@ class EditorSpinSlider : public Range {
 	void _value_input_closed();
 	void _value_input_submitted(const String &);
 	void _value_focus_exited();
+	void _value_input_gui_input(const Ref<InputEvent> &p_event);
 	bool hide_slider;
 	bool flat;
 


### PR DESCRIPTION
Adds the ability to increment and decrement an integer while focused in the editor spin slider's line edit, via a gui_input event. Also works with shift to increment and decrement by x10, alt for x0.1, and control/command for x100.

*Bugsquad edit: This closes godotengine/godot-proposals#29.*