### PR TITLE
Disable decayment of freed Objects to null in debug builds

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -791,7 +791,7 @@ bool Variant::is_zero() const {
 		} break;
 		case OBJECT: {
 
-			return _OBJ_PTR(*this) == NULL;
+			return _UNSAFE_OBJ_PROXY_PTR(*this) == NULL;
 		} break;
 		case NODE_PATH: {
 
@@ -2865,7 +2865,7 @@ uint32_t Variant::hash() const {
 		} break;
 		case OBJECT: {
 
-			return hash_djb2_one_64(make_uint64_t(_OBJ_PTR(*this)));
+			return hash_djb2_one_64(make_uint64_t(_UNSAFE_OBJ_PROXY_PTR(*this)));
 		} break;
 		case NODE_PATH: {
 

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -400,7 +400,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_EQUAL, NIL) {
 				if (p_b.type == NIL) _RETURN(true);
 				if (p_b.type == OBJECT)
-					_RETURN(_OBJ_PTR(p_b) == NULL);
+					_RETURN(_UNSAFE_OBJ_PROXY_PTR(p_b) == NULL);
 
 				_RETURN(false);
 			}
@@ -417,9 +417,9 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 
 			CASE_TYPE(math, OP_EQUAL, OBJECT) {
 				if (p_b.type == OBJECT)
-					_RETURN(_OBJ_PTR(p_a) == _OBJ_PTR(p_b));
+					_RETURN(_UNSAFE_OBJ_PROXY_PTR(p_a) == _UNSAFE_OBJ_PROXY_PTR(p_b));
 				if (p_b.type == NIL)
-					_RETURN(_OBJ_PTR(p_a) == NULL);
+					_RETURN(_UNSAFE_OBJ_PROXY_PTR(p_a) == NULL);
 
 				_RETURN_FAIL;
 			}
@@ -487,7 +487,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_NOT_EQUAL, NIL) {
 				if (p_b.type == NIL) _RETURN(false);
 				if (p_b.type == OBJECT)
-					_RETURN(_OBJ_PTR(p_b) != NULL);
+					_RETURN(_UNSAFE_OBJ_PROXY_PTR(p_b) != NULL);
 
 				_RETURN(true);
 			}
@@ -505,9 +505,9 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 
 			CASE_TYPE(math, OP_NOT_EQUAL, OBJECT) {
 				if (p_b.type == OBJECT)
-					_RETURN((_OBJ_PTR(p_a) != _OBJ_PTR(p_b)));
+					_RETURN((_UNSAFE_OBJ_PROXY_PTR(p_a) != _UNSAFE_OBJ_PROXY_PTR(p_b)));
 				if (p_b.type == NIL)
-					_RETURN(_OBJ_PTR(p_a) != NULL);
+					_RETURN(_UNSAFE_OBJ_PROXY_PTR(p_a) != NULL);
 
 				_RETURN_FAIL;
 			}
@@ -590,7 +590,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_LESS, OBJECT) {
 				if (p_b.type != OBJECT)
 					_RETURN_FAIL;
-				_RETURN(_OBJ_PTR(p_a) < _OBJ_PTR(p_b));
+				_RETURN(_UNSAFE_OBJ_PROXY_PTR(p_a) < _UNSAFE_OBJ_PROXY_PTR(p_b));
 			}
 
 			CASE_TYPE(math, OP_LESS, ARRAY) {
@@ -644,7 +644,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_LESS_EQUAL, OBJECT) {
 				if (p_b.type != OBJECT)
 					_RETURN_FAIL;
-				_RETURN(_OBJ_PTR(p_a) <= _OBJ_PTR(p_b));
+				_RETURN(_UNSAFE_OBJ_PROXY_PTR(p_a) <= _UNSAFE_OBJ_PROXY_PTR(p_b));
 			}
 
 			DEFAULT_OP_NUM(math, OP_LESS_EQUAL, INT, <=, _int);
@@ -694,7 +694,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_GREATER, OBJECT) {
 				if (p_b.type != OBJECT)
 					_RETURN_FAIL;
-				_RETURN(_OBJ_PTR(p_a) > _OBJ_PTR(p_b));
+				_RETURN(_UNSAFE_OBJ_PROXY_PTR(p_a) > _UNSAFE_OBJ_PROXY_PTR(p_b));
 			}
 
 			CASE_TYPE(math, OP_GREATER, ARRAY) {
@@ -748,7 +748,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			CASE_TYPE(math, OP_GREATER_EQUAL, OBJECT) {
 				if (p_b.type != OBJECT)
 					_RETURN_FAIL;
-				_RETURN(_OBJ_PTR(p_a) >= _OBJ_PTR(p_b));
+				_RETURN(_UNSAFE_OBJ_PROXY_PTR(p_a) >= _UNSAFE_OBJ_PROXY_PTR(p_b));
 			}
 
 			DEFAULT_OP_NUM(math, OP_GREATER_EQUAL, INT, >=, _int);


### PR DESCRIPTION
Fixes #41179. (4.0 already features the right behavior.)