### PR TITLE
Rewrite/Improve LargeTexture

### DIFF
--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -299,6 +299,8 @@ class LargeTexture : public Texture2D {
 	GDCLASS(LargeTexture, Texture2D);
 	RES_BASE_EXTENSION("largetex");
 
+	bool _get_draw_region(const Point2 &p_offset, const Size2 &p_size, const Size2 &p_scale, const Rect2 &p_rect, const Rect2 &p_src_rect, Rect2 &r_rect, Rect2 &r_src_rect) const;
+
 protected:
 	struct Piece {
 		Point2 offset;


### PR DESCRIPTION
fix #41820 
I rewrote `draw_rect` and `draw_rect_region`, and now it looks well
![fixed](https://user-images.githubusercontent.com/12966814/92443771-8a19b700-f1e4-11ea-9879-bbdb744046c6.png)

This fix can solve most bugs for LargeTexture, but there are still things to improve later.