### PR TITLE
Fix LineEdit not consuming enter events

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -313,7 +313,6 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 						DisplayServer::get_singleton()->virtual_keyboard_hide();
 					}
 
-					return;
 				} break;
 
 				case KEY_BACKSPACE: {


### PR DESCRIPTION
`LineEdit` should not return early when processing `KEY_ENTER`, so it can consume the event properly.

Regression introduced by mistake while fixing enter events for Android.
(PR #40487 - c0b394572f35498801571ad7176eb357d5de1bf3)

Fixes #41775 
I've tested again #37793 & #40262 on Android, they are still fixed after reverting this change.