### PR TITLE
Fix TURN server example in WebRTC documentation

### DIFF
--- a/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
@@ -97,7 +97,7 @@
 				        {
 				            "urls": [ "turn:turn.example.com:3478" ], # One or more TURN servers.
 				            "username": "a_username", # Optional username for the TURN server.
-				            "credentials": "a_password", # Optional password for the TURN server.
+				            "credential": "a_password", # Optional password for the TURN server.
 				        }
 				    ]
 				}


### PR DESCRIPTION
WebRTC GDNative plugin uses `credential` and not `credentials`.
https://github.com/godotengine/webrtc-native/blob/74f2c78db5cdffa5b2b6ba9cd041061d7694400c/src/WebRTCLibPeerConnection.cpp#L35-L37