### PR TITLE
Initialise Basis elements with a default Basis in the declaration.

### DIFF
--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -36,7 +36,11 @@
 
 class Basis {
 public:
-	Vector3 elements[3];
+	Vector3 elements[3] = {
+		Vector3(1, 0, 0),
+		Vector3(0, 1, 0),
+		Vector3(0, 0, 1)
+	};
 
 	_FORCE_INLINE_ const Vector3 &operator[](int axis) const {
 		return elements[axis];
@@ -254,17 +258,7 @@ public:
 		elements[2] = row2;
 	}
 
-	_FORCE_INLINE_ Basis() {
-		elements[0][0] = 1;
-		elements[0][1] = 0;
-		elements[0][2] = 0;
-		elements[1][0] = 0;
-		elements[1][1] = 1;
-		elements[1][2] = 0;
-		elements[2][0] = 0;
-		elements[2][1] = 0;
-		elements[2][2] = 1;
-	}
+	_FORCE_INLINE_ Basis() {}
 };
 
 _FORCE_INLINE_ void Basis::operator*=(const Basis &p_matrix) {


### PR DESCRIPTION
Ensures a valid `Basis` is created with all constructors.

For example, currently, when creating a `Basis` with ```Basis(const Vector3 &p_axis, real_t p_phi)```, if `p_axis` is not normalized, `set_axis_angle()` fails and a `Basis` with zero vectors is returned.

Note: The ```Basis(const Vector3 &p_axis, real_t p_phi)``` constructor is used by ```Node3D::rotate(const Vector3 &p_axis, float p_angle)```. The user is warned that `p_axis` needs to be normalized. However, the `Node3D`'s orientation is replaced with a `Basis` of zero vectors, because it's still multiplied by the `rotated()` `Basis` created. This PR ensures that a default `Basis` is returned, which ensures that the `Node3D`'s orientation is left unchanged as expected.

Fixes #40505.
