### PR TITLE
C#: Fix endless reload loop if project has unicode chars

### DIFF
--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -107,7 +107,7 @@ void GDMonoAssembly::assembly_load_hook(MonoAssembly *assembly, [[maybe_unused]]
 	GDMonoAssembly *gdassembly = memnew(GDMonoAssembly(name, image, assembly));
 
 #ifdef GD_MONO_HOT_RELOAD
-	const char *path = mono_image_get_filename(image);
+	String path = String::utf8(mono_image_get_filename(image));
 	if (FileAccess::exists(path)) {
 		gdassembly->modified_time = FileAccess::get_modified_time(path);
 	}


### PR DESCRIPTION
The assembly modified time wasn't picked properly
as the path was treated as latin-1, so the file
watcher was constantly firing the event.

Fixes #40001
