### PR TITLE
C#: Use BOM when creating a solution

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/DotNetSolution.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/DotNetSolution.cs
@@ -2,6 +2,7 @@ using GodotTools.Core;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace GodotTools.ProjectEditor
@@ -88,7 +89,7 @@ namespace GodotTools.ProjectEditor
             string solutionPath = Path.Combine(DirectoryPath, Name + ".sln");
             string content = string.Format(SolutionTemplate, projectsDecl, slnPlatformsCfg, projPlatformsCfg);
 
-            File.WriteAllText(solutionPath, content);
+            File.WriteAllText(solutionPath, content, Encoding.UTF8); // UTF-8 with BOM
         }
 
         public DotNetSolution(string name)


### PR DESCRIPTION
At least on Windows there seems to be issues if the solution has no BOM and contains a project with cyrillic chars.
