### PR TITLE
Fade screen-space reflection towards inner margin

### DIFF
--- a/drivers/gles3/shaders/screen_space_reflection.glsl
+++ b/drivers/gles3/shaders/screen_space_reflection.glsl
@@ -175,16 +175,17 @@ void main() {
 		float margin_blend = 1.0;
 
 		vec2 margin = vec2((viewport_size.x + viewport_size.y) * 0.5 * 0.05); // make a uniform margin
-		if (any(bvec4(lessThan(pos, -margin), greaterThan(pos, viewport_size + margin)))) {
-			// clip outside screen + margin
+		if (any(bvec4(lessThan(pos, vec2(0.0, 0.0)), greaterThan(pos, viewport_size * 0.5)))) {
+			// clip at the screen edges
 			frag_color = vec4(0.0);
 			return;
 		}
 
 		{
-			//blend fading out towards external margin
-			vec2 margin_grad = mix(pos - viewport_size, -pos, lessThan(pos, vec2(0.0)));
-			margin_blend = 1.0 - smoothstep(0.0, margin.x, max(margin_grad.x, margin_grad.y));
+			//blend fading out towards inner margin
+			// 0.25 = midpoint of half-resolution reflection
+			vec2 margin_grad = mix(viewport_size * 0.5 - pos, pos, lessThan(pos, viewport_size * 0.25));
+			margin_blend = smoothstep(0.0, margin.x * margin.y, margin_grad.x * margin_grad.y);
 			//margin_blend = 1.0;
 		}
 


### PR DESCRIPTION
- Fade reflection towards inner margin and clip it at screen edges instead of external margin.
- Fix top and right side not being cut off correctly (screen size was not multiplied by 0.5).
- Round edges of the fade margin if both are being cut off to prevent sharp corners.

Closes #38955

**Pictures**
*Original*
![original](https://user-images.githubusercontent.com/48544263/92534072-bcc5ae80-f1e8-11ea-803a-8aaa70f1e5b3.jpg)

*Fix edges only, no fading of corners*
![noblur](https://user-images.githubusercontent.com/48544263/92534086-c5b68000-f1e8-11ea-984c-461f21e27bef.jpg)

*Edge fix and corner fade (this PR)*
![rounded](https://user-images.githubusercontent.com/48544263/92534112-d2d36f00-f1e8-11ea-9e9b-688ca97da948.jpg)

