### PR TITLE
Add a "not in" operator to GDScript.

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2025,6 +2025,17 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_unary_operator(ExpressionN
 	return operation;
 }
 
+GDScriptParser::ExpressionNode *GDScriptParser::parse_binary_not_in_operator(ExpressionNode *p_previous_operand, bool p_can_assign) {
+	// check that NOT is followed by IN by consuming it before calling parse_binary_operator which will only receive a plain IN
+	consume(GDScriptTokenizer::Token::IN, R"(Expected "in" after "not" in content-test operator.)");
+	ExpressionNode *in_operation = parse_binary_operator(p_previous_operand, p_can_assign);
+	UnaryOpNode *operation = alloc_node<UnaryOpNode>();
+	operation->operation = UnaryOpNode::OP_LOGIC_NOT;
+	operation->variant_op = Variant::OP_NOT;
+	operation->operand = in_operation;
+	return operation;
+}
+
 GDScriptParser::ExpressionNode *GDScriptParser::parse_binary_operator(ExpressionNode *p_previous_operand, bool p_can_assign) {
 	GDScriptTokenizer::Token op = previous;
 	BinaryOpNode *operation = alloc_node<BinaryOpNode>();
@@ -2637,7 +2648,7 @@ GDScriptParser::ParseRule *GDScriptParser::get_rule(GDScriptTokenizer::Token::Ty
 		// Logical
 		{ nullptr,                                          &GDScriptParser::parse_binary_operator,      	PREC_LOGIC_AND }, // AND,
 		{ nullptr,                                          &GDScriptParser::parse_binary_operator,      	PREC_LOGIC_OR }, // OR,
-		{ &GDScriptParser::parse_unary_operator,         	nullptr,                                        PREC_NONE }, // NOT,
+		{ &GDScriptParser::parse_unary_operator,         	&GDScriptParser::parse_binary_not_in_operator,	PREC_CONTENT_TEST }, // NOT,
 		{ nullptr,                                          &GDScriptParser::parse_binary_operator,			PREC_LOGIC_AND }, // AMPERSAND_AMPERSAND,
 		{ nullptr,                                          &GDScriptParser::parse_binary_operator,			PREC_LOGIC_OR }, // PIPE_PIPE,
 		{ &GDScriptParser::parse_unary_operator,			nullptr,                                        PREC_NONE }, // BANG,

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1256,6 +1256,7 @@ private:
 	ExpressionNode *parse_builtin_constant(ExpressionNode *p_previous_operand, bool p_can_assign);
 	ExpressionNode *parse_unary_operator(ExpressionNode *p_previous_operand, bool p_can_assign);
 	ExpressionNode *parse_binary_operator(ExpressionNode *p_previous_operand, bool p_can_assign);
+	ExpressionNode *parse_binary_not_in_operator(ExpressionNode *p_previous_operand, bool p_can_assign);
 	ExpressionNode *parse_ternary_operator(ExpressionNode *p_previous_operand, bool p_can_assign);
 	ExpressionNode *parse_assignment(ExpressionNode *p_previous_operand, bool p_can_assign);
 	ExpressionNode *parse_array(ExpressionNode *p_previous_operand, bool p_can_assign);


### PR DESCRIPTION
This provides the IMHO less controversial part of godotengine/godot-proposals#1319

(Outdated after patch revision: The implementation also requires a not-in operator in Variant which is actually
a small optimization of that conditional operator, as it avoids going through Variant again for the NOT-part.)

Here are also the diffs for my parser test-cases that show how parser behavior changed. I could add corresponding tests to the repo once godotengine/godot-proposals#1429 is in.

```
> cat tests/test_gdscript_doctest/not-is-not-an-operator.gd

var a = element not arr

--- a/tests/test_gdscript_doctest/not-is-not-an-operator.gd.parsed
+++ b/tests/test_gdscript_doctest/not-is-not-an-operator.gd.parsed
@@ -1,4 +1,4 @@
-02:17: Expected end of statement after variable declaration, found "not" instead.
+02:21: Expected "in" after "not" in content-test operator.
 Class <unnamed> :
 |   Variable a : Variant
-|   |   = element
+|   |   = (element NOT IN arr)
```

```
--- a/tests/test_gdscript_doctest/content-test.gd
+++ b/tests/test_gdscript_doctest/content-test.gd
@@ -1,4 +1,4 @@
 
 var a = element in arr
 var b = not element in arr
-#var c = element not in arr
+var c = element not in arr

--- a/tests/test_gdscript_doctest/content-test.gd.parsed
+++ b/tests/test_gdscript_doctest/content-test.gd.parsed
@@ -5,3 +5,5 @@ Class <unnamed> :
 |   Variable b : Variant
 |   |   = (NOT(element IN arr))
 
+|   Variable c : Variant
+|   |   = (NOT(element IN arr))
```

(Edit: updated the final test-case to reflect the revised patch. The `a not in b` is not a special operator anymore, so it gets parsed into exactly the same structure as `not (a in b)`.)