### PR TITLE
Explicitly add implicitly added JavaScript semicolons.

### DIFF
--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -201,7 +201,7 @@ $GODOT_HEAD_INCLUDE
 						throw new Error('Invalid status mode');
 				}
 				statusMode = mode;
-			}
+			};
 
 			function animateStatusIndeterminate(ms) {
 

--- a/platform/javascript/engine/engine.js
+++ b/platform/javascript/engine/engine.js
@@ -121,7 +121,7 @@ Function('return this')()['Engine'] = (function() {
 				if (me.onExit)
 					me.onExit(code);
 				me.rtenv = null;
-			}
+			};
 			return new Promise(function(resolve, reject) {
 				preloader.preloadedFiles.forEach(function(file) {
 					me.rtenv['copyToFS'](file.path, file.buffer);
@@ -207,18 +207,18 @@ Function('return this')()['Engine'] = (function() {
 		if (this.rtenv)
 			this.rtenv.onExecute = onExecute;
 		this.onExecute = onExecute;
-	}
+	};
 
 	Engine.prototype.setOnExit = function(onExit) {
 		this.onExit = onExit;
-	}
+	};
 
 	Engine.prototype.copyToFS = function(path, buffer) {
 		if (this.rtenv == null) {
 			throw new Error("Engine must be inited before copying files");
 		}
 		this.rtenv['copyToFS'](path, buffer);
-	}
+	};
 
 	// Closure compiler exported engine methods.
 	/** @export */


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=&severity=&id=js%2Fautomatic-semicolon-insertion&ruleFocus=4860080), this PR explicitly adds the implicitly added JavaScript semicolons.