### PR TITLE
Improve performance for Show/Hide port preview in visual shaders

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -50,8 +50,50 @@ public:
 	virtual Control *create_editor(const Ref<Resource> &p_parent_resource, const Ref<VisualShaderNode> &p_node);
 };
 
+class VisualShaderGraphPlugin : public Reference {
+	GDCLASS(VisualShaderGraphPlugin, Reference);
+
+private:
+	struct Port {
+		TextureButton *preview_button;
+	};
+
+	struct Link {
+		VisualShader::Type type;
+		VisualShaderNode *visual_node;
+		GraphNode *graph_node;
+		bool preview_visible;
+		int preview_pos;
+		Map<int, Port> output_ports;
+		VBoxContainer *preview_box;
+	};
+
+	Ref<VisualShader> visual_shader;
+	Map<int, Link> links;
+	bool dirty = false;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void register_shader(VisualShader *p_visual_shader);
+	void register_link(VisualShader::Type p_type, int p_id, VisualShaderNode *p_visual_node, GraphNode *p_graph_node);
+	void register_output_port(int p_id, int p_port, TextureButton *p_button);
+	void clear_links();
+	void set_shader_type(VisualShader::Type p_type);
+	bool is_preview_visible(int p_id) const;
+	bool is_dirty() const;
+	void make_dirty(bool p_enabled);
+
+	void show_port_preview(int p_node_id, int p_port_id);
+
+	VisualShaderGraphPlugin();
+	~VisualShaderGraphPlugin();
+};
+
 class VisualShaderEditor : public VBoxContainer {
 	GDCLASS(VisualShaderEditor, VBoxContainer);
+	friend class VisualShaderGraphPlugin;
 
 	CustomPropertyEditor *property_editor;
 	int editing_node;
@@ -242,6 +284,7 @@ class VisualShaderEditor : public VBoxContainer {
 	void _paste_nodes(bool p_use_custom_position = false, const Vector2 &p_custom_position = Vector2());
 
 	Vector<Ref<VisualShaderNodePlugin>> plugins;
+	Ref<VisualShaderGraphPlugin> graph_plugin;
 
 	void _mode_selected(int p_id);
 	void _rebuild();

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -40,6 +40,7 @@ bool VisualShaderNode::is_simple_decl() const {
 
 void VisualShaderNode::set_output_port_for_preview(int p_index) {
 	port_preview = p_index;
+	emit_signal("show_port_preview", p_index);
 }
 
 int VisualShaderNode::get_output_port_for_preview() const {
@@ -161,6 +162,7 @@ void VisualShaderNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "output_port_for_preview"), "set_output_port_for_preview", "get_output_port_for_preview");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "default_input_values", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL), "set_default_input_values", "get_default_input_values");
 	ADD_SIGNAL(MethodInfo("editor_refresh_request"));
+	ADD_SIGNAL(MethodInfo("show_port_preview", PropertyInfo(Variant::INT, "port_id")));
 
 	BIND_ENUM_CONSTANT(PORT_TYPE_SCALAR);
 	BIND_ENUM_CONSTANT(PORT_TYPE_SCALAR_INT);
@@ -326,6 +328,10 @@ void VisualShader::set_graph_node(Type p_type, int p_id, GraphNode *p_graph_node
 
 void VisualShader::set_shader_type(Type p_type) {
 	current_type = p_type;
+}
+
+VisualShader::Type VisualShader::get_shader_type() const {
+	return current_type;
 }
 
 void VisualShader::set_version(const String &p_version) {

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -131,6 +131,7 @@ protected:
 public: // internal methods
 	void set_graph_node(Type p_type, int p_id, GraphNode *p_graph_node);
 	void set_shader_type(Type p_type);
+	Type get_shader_type() const;
 
 public:
 	void set_version(const String &p_version);


### PR DESCRIPTION
Similar to #41898 this will improve performance on heavy shaders when you pressed port preview buttons (and this was much harder to make). I tested this extensively with a VisualStudio debugger and seems it doesn't have bugs.