### PR TITLE
Implement 3D textures as import and resource format.

### DIFF
--- a/core/image.h
+++ b/core/image.h
@@ -230,6 +230,19 @@ public:
 	void get_mipmap_offset_and_size(int p_mipmap, int &r_ofs, int &r_size) const; //get where the mipmap begins in data
 	void get_mipmap_offset_size_and_dimensions(int p_mipmap, int &r_ofs, int &r_size, int &w, int &h) const; //get where the mipmap begins in data
 
+	enum Image3DValidateError {
+		VALIDATE_3D_OK,
+		VALIDATE_3D_ERR_IMAGE_EMPTY,
+		VALIDATE_3D_ERR_MISSING_IMAGES,
+		VALIDATE_3D_ERR_EXTRA_IMAGES,
+		VALIDATE_3D_ERR_IMAGE_SIZE_MISMATCH,
+		VALIDATE_3D_ERR_IMAGE_FORMAT_MISMATCH,
+		VALIDATE_3D_ERR_IMAGE_HAS_MIPMAPS,
+	};
+
+	static Image3DValidateError validate_3d_image(Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_images);
+	static String get_3d_image_validation_error_text(Image3DValidateError p_error);
+
 	/**
 	 * Resize the image, using the preferred interpolation method.
 	 */

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -157,6 +157,7 @@
 #include "editor/plugins/sprite_frames_editor_plugin.h"
 #include "editor/plugins/style_box_editor_plugin.h"
 #include "editor/plugins/text_editor.h"
+#include "editor/plugins/texture_3d_editor_plugin.h"
 #include "editor/plugins/texture_editor_plugin.h"
 #include "editor/plugins/texture_layered_editor_plugin.h"
 #include "editor/plugins/texture_region_editor_plugin.h"
@@ -5620,10 +5621,10 @@ EditorNode::EditorNode() {
 		import_cubemap_array->set_mode(ResourceImporterLayeredTexture::MODE_CUBEMAP_ARRAY);
 		ResourceFormatImporter::get_singleton()->add_importer(import_cubemap_array);
 
-		/*Ref<ResourceImporterLayeredTexture> import_3d;
+		Ref<ResourceImporterLayeredTexture> import_3d;
 		import_3d.instance();
 		import_3d->set_mode(ResourceImporterLayeredTexture::MODE_3D);
-		ResourceFormatImporter::get_singleton()->add_importer(import_3d);*/
+		ResourceFormatImporter::get_singleton()->add_importer(import_3d);
 
 		Ref<ResourceImporterImage> import_image;
 		import_image.instance();
@@ -6622,6 +6623,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(CurveEditorPlugin(this)));
 	add_editor_plugin(memnew(TextureEditorPlugin(this)));
 	add_editor_plugin(memnew(TextureLayeredEditorPlugin(this)));
+	add_editor_plugin(memnew(Texture3DEditorPlugin(this)));
 	add_editor_plugin(memnew(AudioStreamEditorPlugin(this)));
 	add_editor_plugin(memnew(AudioBusesEditorPlugin(audio_bus_editor)));
 	add_editor_plugin(memnew(Skeleton3DEditorPlugin(this)));

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -93,10 +93,6 @@ private:
 	static const char *compression_formats[];
 
 protected:
-	static void _texture_reimport_srgb(const Ref<StreamTexture2D> &p_tex);
-	static void _texture_reimport_3d(const Ref<StreamTexture2D> &p_tex);
-	static void _texture_reimport_normal(const Ref<StreamTexture2D> &p_tex);
-
 	static ResourceImporterLayeredTexture *singleton;
 
 public:

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -1,0 +1,213 @@
+/*************************************************************************/
+/*  texture_3d_editor_plugin.cpp                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "texture_3d_editor_plugin.h"
+
+#include "core/io/resource_loader.h"
+#include "core/project_settings.h"
+#include "editor/editor_settings.h"
+
+void Texture3DEditor::_gui_input(Ref<InputEvent> p_event) {
+}
+
+void Texture3DEditor::_texture_rect_draw() {
+	texture_rect->draw_rect(Rect2(Point2(), texture_rect->get_size()), Color(1, 1, 1, 1));
+}
+
+void Texture3DEditor::_notification(int p_what) {
+	if (p_what == NOTIFICATION_READY) {
+		//get_scene()->connect("node_removed",this,"_node_removed");
+	}
+	if (p_what == NOTIFICATION_RESIZED) {
+		_texture_rect_update_area();
+	}
+
+	if (p_what == NOTIFICATION_DRAW) {
+		Ref<Texture2D> checkerboard = get_theme_icon("Checkerboard", "EditorIcons");
+		Size2 size = get_size();
+
+		draw_texture_rect(checkerboard, Rect2(Point2(), size), true);
+	}
+}
+
+void Texture3DEditor::_changed_callback(Object *p_changed, const char *p_prop) {
+	if (!is_visible()) {
+		return;
+	}
+	update();
+}
+
+void Texture3DEditor::_update_material() {
+	material->set_shader_param("layer", (layer->get_value() + 0.5) / texture->get_depth());
+	material->set_shader_param("tex", texture->get_rid());
+
+	String format = Image::get_format_name(texture->get_format());
+
+	String text;
+	text = itos(texture->get_width()) + "x" + itos(texture->get_height()) + "x" + itos(texture->get_depth()) + " " + format;
+
+	info->set_text(text);
+}
+
+void Texture3DEditor::_make_shaders() {
+	String shader_3d = ""
+					   "shader_type canvas_item;\n"
+					   "uniform sampler3D tex;\n"
+					   "uniform float layer;\n"
+					   "void fragment() {\n"
+					   "  COLOR = textureLod(tex,vec3(UV,layer),0.0);\n"
+					   "}";
+
+	shader.instance();
+	shader->set_code(shader_3d);
+	material.instance();
+	material->set_shader(shader);
+}
+
+void Texture3DEditor::_texture_rect_update_area() {
+	Size2 size = get_size();
+	int tex_width = texture->get_width() * size.height / texture->get_height();
+	int tex_height = size.height;
+
+	if (tex_width > size.width) {
+		tex_width = size.width;
+		tex_height = texture->get_height() * tex_width / texture->get_width();
+	}
+
+	// Prevent the texture from being unpreviewable after the rescale, so that we can still see something
+	if (tex_height <= 0) {
+		tex_height = 1;
+	}
+	if (tex_width <= 0) {
+		tex_width = 1;
+	}
+
+	int ofs_x = (size.width - tex_width) / 2;
+	int ofs_y = (size.height - tex_height) / 2;
+
+	texture_rect->set_position(Vector2(ofs_x, ofs_y));
+	texture_rect->set_size(Vector2(tex_width, tex_height));
+}
+
+void Texture3DEditor::edit(Ref<Texture3D> p_texture) {
+	if (!texture.is_null()) {
+		texture->remove_change_receptor(this);
+	}
+
+	texture = p_texture;
+
+	if (!texture.is_null()) {
+		if (shader.is_null()) {
+			_make_shaders();
+		}
+
+		texture->add_change_receptor(this);
+		update();
+		texture_rect->set_material(material);
+		setting = true;
+		layer->set_max(texture->get_depth() - 1);
+		layer->set_value(0);
+		layer->show();
+		_update_material();
+		setting = false;
+		_texture_rect_update_area();
+	} else {
+		hide();
+	}
+}
+
+void Texture3DEditor::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_gui_input"), &Texture3DEditor::_gui_input);
+	ClassDB::bind_method(D_METHOD("_layer_changed"), &Texture3DEditor::_layer_changed);
+}
+
+Texture3DEditor::Texture3DEditor() {
+	set_texture_repeat(TextureRepeat::TEXTURE_REPEAT_ENABLED);
+	set_custom_minimum_size(Size2(1, 150));
+	texture_rect = memnew(Control);
+	texture_rect->connect("draw", callable_mp(this, &Texture3DEditor::_texture_rect_draw));
+	texture_rect->set_mouse_filter(MOUSE_FILTER_IGNORE);
+	add_child(texture_rect);
+
+	layer = memnew(SpinBox);
+	layer->set_step(1);
+	layer->set_max(100);
+	add_child(layer);
+	layer->set_anchor(MARGIN_RIGHT, 1);
+	layer->set_anchor(MARGIN_LEFT, 1);
+	layer->set_h_grow_direction(GROW_DIRECTION_BEGIN);
+	layer->set_modulate(Color(1, 1, 1, 0.8));
+	info = memnew(Label);
+	add_child(info);
+	info->set_anchor(MARGIN_RIGHT, 1);
+	info->set_anchor(MARGIN_LEFT, 1);
+	info->set_anchor(MARGIN_BOTTOM, 1);
+	info->set_anchor(MARGIN_TOP, 1);
+	info->set_h_grow_direction(GROW_DIRECTION_BEGIN);
+	info->set_v_grow_direction(GROW_DIRECTION_BEGIN);
+	info->add_theme_color_override("font_color", Color(1, 1, 1, 1));
+	info->add_theme_color_override("font_color_shadow", Color(0, 0, 0, 0.5));
+	info->add_theme_color_override("font_color_shadow", Color(0, 0, 0, 0.5));
+	info->add_theme_constant_override("shadow_as_outline", 1);
+	info->add_theme_constant_override("shadow_offset_x", 2);
+	info->add_theme_constant_override("shadow_offset_y", 2);
+
+	setting = false;
+	layer->connect("value_changed", Callable(this, "_layer_changed"));
+}
+
+Texture3DEditor::~Texture3DEditor() {
+	if (!texture.is_null()) {
+		texture->remove_change_receptor(this);
+	}
+}
+
+//
+bool EditorInspectorPlugin3DTexture::can_handle(Object *p_object) {
+	return Object::cast_to<Texture3D>(p_object) != nullptr;
+}
+
+void EditorInspectorPlugin3DTexture::parse_begin(Object *p_object) {
+	Texture3D *texture = Object::cast_to<Texture3D>(p_object);
+	if (!texture) {
+		return;
+	}
+	Ref<Texture3D> m(texture);
+
+	Texture3DEditor *editor = memnew(Texture3DEditor);
+	editor->edit(m);
+	add_custom_control(editor);
+}
+
+Texture3DEditorPlugin::Texture3DEditorPlugin(EditorNode *p_node) {
+	Ref<EditorInspectorPlugin3DTexture> plugin;
+	plugin.instance();
+	add_inspector_plugin(plugin);
+}

--- a/editor/plugins/texture_3d_editor_plugin.h
+++ b/editor/plugins/texture_3d_editor_plugin.h
@@ -1,0 +1,93 @@
+/*************************************************************************/
+/*  texture_3d_editor_plugin.h                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEXTURE_3D_EDITOR_PLUGIN_H
+#define TEXTURE_3D_EDITOR_PLUGIN_H
+
+#include "editor/editor_node.h"
+#include "editor/editor_plugin.h"
+#include "scene/resources/shader.h"
+#include "scene/resources/texture.h"
+
+class Texture3DEditor : public Control {
+	GDCLASS(Texture3DEditor, Control);
+
+	SpinBox *layer;
+	Label *info;
+	Ref<Texture3D> texture;
+
+	Ref<Shader> shader;
+	Ref<ShaderMaterial> material;
+
+	Control *texture_rect;
+
+	void _make_shaders();
+
+	void _update_material();
+	bool setting;
+	void _layer_changed(double) {
+		if (!setting) {
+			_update_material();
+		}
+	}
+
+	void _texture_rect_update_area();
+	void _texture_rect_draw();
+
+protected:
+	void _notification(int p_what);
+	void _gui_input(Ref<InputEvent> p_event);
+	void _changed_callback(Object *p_changed, const char *p_prop) override;
+	static void _bind_methods();
+
+public:
+	void edit(Ref<Texture3D> p_texture);
+	Texture3DEditor();
+	~Texture3DEditor();
+};
+
+class EditorInspectorPlugin3DTexture : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPlugin3DTexture, EditorInspectorPlugin);
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual void parse_begin(Object *p_object) override;
+};
+
+class Texture3DEditorPlugin : public EditorPlugin {
+	GDCLASS(Texture3DEditorPlugin, EditorPlugin);
+
+public:
+	virtual String get_name() const override { return "Texture3D"; }
+
+	Texture3DEditorPlugin(EditorNode *p_node);
+};
+
+#endif // TEXTURE_EDITOR_PLUGIN_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -230,6 +230,7 @@ static Ref<ResourceFormatLoaderDynamicFont> resource_loader_dynamic_font;
 
 static Ref<ResourceFormatLoaderStreamTexture2D> resource_loader_stream_texture;
 static Ref<ResourceFormatLoaderStreamTextureLayered> resource_loader_texture_layered;
+static Ref<ResourceFormatLoaderStreamTexture3D> resource_loader_texture_3d;
 
 static Ref<ResourceFormatLoaderBMFont> resource_loader_bmfont;
 
@@ -251,6 +252,9 @@ void register_scene_types() {
 
 	resource_loader_texture_layered.instance();
 	ResourceLoader::add_resource_format_loader(resource_loader_texture_layered);
+
+	resource_loader_texture_3d.instance();
+	ResourceLoader::add_resource_format_loader(resource_loader_texture_3d);
 
 	resource_saver_text.instance();
 	ResourceSaver::add_resource_format_saver(resource_saver_text, true);
@@ -701,6 +705,9 @@ void register_scene_types() {
 	ClassDB::register_class<CameraTexture>();
 	ClassDB::register_virtual_class<TextureLayered>();
 	ClassDB::register_virtual_class<ImageTextureLayered>();
+	ClassDB::register_virtual_class<Texture3D>();
+	ClassDB::register_class<ImageTexture3D>();
+	ClassDB::register_class<StreamTexture3D>();
 	ClassDB::register_class<Cubemap>();
 	ClassDB::register_class<CubemapArray>();
 	ClassDB::register_class<Texture2DArray>();
@@ -945,6 +952,9 @@ void unregister_scene_types() {
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_texture_layered);
 	resource_loader_texture_layered.unref();
+
+	ResourceLoader::remove_resource_format_loader(resource_loader_texture_3d);
+	resource_loader_texture_3d.unref();
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_stream_texture);
 	resource_loader_stream_texture.unref();

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -515,6 +515,122 @@ public:
 	virtual String get_resource_type(const String &p_path) const;
 };
 
+class Texture3D : public Texture {
+	GDCLASS(Texture3D, Texture);
+
+protected:
+	static void _bind_methods();
+
+	TypedArray<Image> _get_data() const;
+
+public:
+	virtual Image::Format get_format() const = 0;
+	virtual int get_width() const = 0;
+	virtual int get_height() const = 0;
+	virtual int get_depth() const = 0;
+	virtual bool has_mipmaps() const = 0;
+	virtual Vector<Ref<Image>> get_data() const = 0;
+};
+
+class ImageTexture3D : public Texture3D {
+	GDCLASS(ImageTexture3D, Texture3D);
+
+	mutable RID texture;
+
+	Image::Format format = Image::FORMAT_MAX;
+	int width = 1;
+	int height = 1;
+	int depth = 1;
+	bool mipmaps = false;
+
+protected:
+	static void _bind_methods();
+
+	Error _create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const TypedArray<Image> &p_data);
+	void _update(const TypedArray<Image> &p_data);
+
+public:
+	virtual Image::Format get_format() const override;
+	virtual int get_width() const override;
+	virtual int get_height() const override;
+	virtual int get_depth() const override;
+	virtual bool has_mipmaps() const override;
+
+	Error create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data);
+	void update(const Vector<Ref<Image>> &p_data);
+	virtual Vector<Ref<Image>> get_data() const override;
+
+	virtual RID get_rid() const override;
+	virtual void set_path(const String &p_path, bool p_take_over = false) override;
+
+	ImageTexture3D();
+	~ImageTexture3D();
+};
+
+class StreamTexture3D : public Texture3D {
+	GDCLASS(StreamTexture3D, Texture3D);
+
+public:
+	enum DataFormat {
+		DATA_FORMAT_IMAGE,
+		DATA_FORMAT_LOSSLESS,
+		DATA_FORMAT_LOSSY,
+		DATA_FORMAT_BASIS_UNIVERSAL,
+	};
+
+	enum {
+		FORMAT_VERSION = 1
+	};
+
+	enum FormatBits {
+		FORMAT_MASK_IMAGE_FORMAT = (1 << 20) - 1,
+		FORMAT_BIT_LOSSLESS = 1 << 20,
+		FORMAT_BIT_LOSSY = 1 << 21,
+		FORMAT_BIT_STREAM = 1 << 22,
+		FORMAT_BIT_HAS_MIPMAPS = 1 << 23,
+	};
+
+private:
+	Error _load_data(const String &p_path, Vector<Ref<Image>> &r_data, Image::Format &r_format, int &r_width, int &r_height, int &r_depth, bool &r_mipmaps);
+	String path_to_file;
+	mutable RID texture;
+	Image::Format format;
+	int w, h, d;
+	bool mipmaps;
+
+	virtual void reload_from_file() override;
+
+protected:
+	static void _bind_methods();
+	void _validate_property(PropertyInfo &property) const override;
+
+public:
+	Image::Format get_format() const override;
+	Error load(const String &p_path);
+	String get_load_path() const;
+
+	int get_width() const override;
+	int get_height() const override;
+	int get_depth() const override;
+	virtual bool has_mipmaps() const override;
+	virtual RID get_rid() const override;
+
+	virtual void set_path(const String &p_path, bool p_take_over) override;
+
+	virtual Vector<Ref<Image>> get_data() const override;
+
+	StreamTexture3D();
+	~StreamTexture3D();
+};
+
+class ResourceFormatLoaderStreamTexture3D : public ResourceFormatLoader {
+public:
+	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, bool p_no_cache = false);
+	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual bool handles_type(const String &p_type) const;
+	virtual String get_resource_type(const String &p_path) const;
+};
+
 class CurveTexture : public Texture2D {
 	GDCLASS(CurveTexture, Texture2D);
 	RES_BASE_EXTENSION("curvetex")

--- a/servers/rendering/rasterizer.h
+++ b/servers/rendering/rasterizer.h
@@ -331,12 +331,12 @@ public:
 
 	virtual RID texture_2d_create(const Ref<Image> &p_image) = 0;
 	virtual RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) = 0;
-	virtual RID texture_3d_create(const Vector<Ref<Image>> &p_slices) = 0; //all slices, then all the mipmaps, must be coherent
+	virtual RID texture_3d_create(Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) = 0;
 	virtual RID texture_proxy_create(RID p_base) = 0; //all slices, then all the mipmaps, must be coherent
 
 	virtual void texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0; //mostly used for video and streaming
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0;
-	virtual void texture_3d_update(RID p_texture, const Ref<Image> &p_image, int p_depth, int p_mipmap) = 0;
+	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) = 0;
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) = 0;
 
 	//these two APIs can be used together or in combination with the others.
@@ -346,7 +346,7 @@ public:
 
 	virtual Ref<Image> texture_2d_get(RID p_texture) const = 0;
 	virtual Ref<Image> texture_2d_layer_get(RID p_texture, int p_layer) const = 0;
-	virtual Ref<Image> texture_3d_slice_get(RID p_texture, int p_depth, int p_mipmap) const = 0;
+	virtual Vector<Ref<Image>> texture_3d_get(RID p_texture) const = 0;
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture) = 0;
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) = 0;

--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
@@ -205,6 +205,14 @@ private:
 		int height_2d;
 		int width_2d;
 
+		struct BufferSlice3D {
+			Size2i size;
+			uint32_t offset = 0;
+			uint32_t buffer_size = 0;
+		};
+		Vector<BufferSlice3D> buffer_slices_3d;
+		uint32_t buffer_size_3d = 0;
+
 		bool is_render_target;
 		bool is_proxy;
 
@@ -980,14 +988,14 @@ public:
 
 	virtual RID texture_2d_create(const Ref<Image> &p_image);
 	virtual RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type);
-	virtual RID texture_3d_create(const Vector<Ref<Image>> &p_slices); //all slices, then all the mipmaps, must be coherent
+	virtual RID texture_3d_create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data); //all slices, then all the mipmaps, must be coherent
 	virtual RID texture_proxy_create(RID p_base);
 
 	virtual void _texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer, bool p_immediate);
 
 	virtual void texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer = 0); //mostly used for video and streaming
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0);
-	virtual void texture_3d_update(RID p_texture, const Ref<Image> &p_image, int p_depth, int p_mipmap);
+	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data);
 	virtual void texture_proxy_update(RID p_texture, RID p_proxy_to);
 
 	//these two APIs can be used together or in combination with the others.
@@ -997,7 +1005,7 @@ public:
 
 	virtual Ref<Image> texture_2d_get(RID p_texture) const;
 	virtual Ref<Image> texture_2d_layer_get(RID p_texture, int p_layer) const;
-	virtual Ref<Image> texture_3d_slice_get(RID p_texture, int p_depth, int p_mipmap) const;
+	virtual Vector<Ref<Image>> texture_3d_get(RID p_texture) const;
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture);
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height);

--- a/servers/rendering/rendering_server_raster.h
+++ b/servers/rendering/rendering_server_raster.h
@@ -114,6 +114,14 @@ public:
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) { return BINDBASE->m_name(arg1, arg2, arg3, arg4); }
 #define BIND4RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4) \
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) const { return BINDBASE->m_name(arg1, arg2, arg3, arg4); }
+#define BIND5R(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5) \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5) { return BINDBASE->m_name(arg1, arg2, arg3, arg4, arg5); }
+#define BIND5RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5) \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5) const { return BINDBASE->m_name(arg1, arg2, arg3, arg4, arg5); }
+#define BIND6R(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6) \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6) { return BINDBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6); }
+#define BIND6RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6) \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6) const { return BINDBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6); }
 
 #define BIND0(m_name) \
 	void m_name() { DISPLAY_CHANGED BINDBASE->m_name(); }
@@ -160,14 +168,14 @@ public:
 	//these go pass-through, as they can be called from any thread
 	BIND1R(RID, texture_2d_create, const Ref<Image> &)
 	BIND2R(RID, texture_2d_layered_create, const Vector<Ref<Image>> &, TextureLayeredType)
-	BIND1R(RID, texture_3d_create, const Vector<Ref<Image>> &)
+	BIND6R(RID, texture_3d_create, Image::Format, int, int, int, bool, const Vector<Ref<Image>> &)
 	BIND1R(RID, texture_proxy_create, RID)
 
 	//goes pass-through
 	BIND3(texture_2d_update_immediate, RID, const Ref<Image> &, int)
 	//these go through command queue if they are in another thread
 	BIND3(texture_2d_update, RID, const Ref<Image> &, int)
-	BIND4(texture_3d_update, RID, const Ref<Image> &, int, int)
+	BIND2(texture_3d_update, RID, const Vector<Ref<Image>> &)
 	BIND2(texture_proxy_update, RID, RID)
 
 	//these also go pass-through
@@ -177,7 +185,7 @@ public:
 
 	BIND1RC(Ref<Image>, texture_2d_get, RID)
 	BIND2RC(Ref<Image>, texture_2d_layer_get, RID, int)
-	BIND3RC(Ref<Image>, texture_3d_slice_get, RID, int, int)
+	BIND1RC(Vector<Ref<Image>>, texture_3d_get, RID)
 
 	BIND2(texture_replace, RID, RID)
 

--- a/servers/rendering/rendering_server_wrap_mt.h
+++ b/servers/rendering/rendering_server_wrap_mt.h
@@ -79,14 +79,14 @@ public:
 	//these go pass-through, as they can be called from any thread
 	virtual RID texture_2d_create(const Ref<Image> &p_image) { return rendering_server->texture_2d_create(p_image); }
 	virtual RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, TextureLayeredType p_layered_type) { return rendering_server->texture_2d_layered_create(p_layers, p_layered_type); }
-	virtual RID texture_3d_create(const Vector<Ref<Image>> &p_slices) { return rendering_server->texture_3d_create(p_slices); }
+	virtual RID texture_3d_create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) { return rendering_server->texture_3d_create(p_format, p_width, p_height, p_depth, p_mipmaps, p_data); }
 	virtual RID texture_proxy_create(RID p_base) { return rendering_server->texture_proxy_create(p_base); }
 
 	//goes pass-through
 	virtual void texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) { rendering_server->texture_2d_update_immediate(p_texture, p_image, p_layer); }
 	//these go through command queue if they are in another thread
 	FUNC3(texture_2d_update, RID, const Ref<Image> &, int)
-	FUNC4(texture_3d_update, RID, const Ref<Image> &, int, int)
+	FUNC2(texture_3d_update, RID, const Vector<Ref<Image>> &)
 	FUNC2(texture_proxy_update, RID, RID)
 
 	//these also go pass-through
@@ -96,7 +96,7 @@ public:
 
 	FUNC1RC(Ref<Image>, texture_2d_get, RID)
 	FUNC2RC(Ref<Image>, texture_2d_layer_get, RID, int)
-	FUNC3RC(Ref<Image>, texture_3d_slice_get, RID, int, int)
+	FUNC1RC(Vector<Ref<Image>>, texture_3d_get, RID)
 
 	FUNC2(texture_replace, RID, RID)
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -97,12 +97,12 @@ public:
 
 	virtual RID texture_2d_create(const Ref<Image> &p_image) = 0;
 	virtual RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, TextureLayeredType p_layered_type) = 0;
-	virtual RID texture_3d_create(const Vector<Ref<Image>> &p_slices) = 0; //all slices, then all the mipmaps, must be coherent
+	virtual RID texture_3d_create(Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) = 0; //all slices, then all the mipmaps, must be coherent
 	virtual RID texture_proxy_create(RID p_base) = 0;
 
 	virtual void texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0; //mostly used for video and streaming
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0;
-	virtual void texture_3d_update(RID p_texture, const Ref<Image> &p_image, int p_depth, int p_mipmap) = 0;
+	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) = 0;
 	virtual void texture_proxy_update(RID p_texture, RID p_proxy_to) = 0;
 
 	//these two APIs can be used together or in combination with the others.
@@ -112,7 +112,7 @@ public:
 
 	virtual Ref<Image> texture_2d_get(RID p_texture) const = 0;
 	virtual Ref<Image> texture_2d_layer_get(RID p_texture, int p_layer) const = 0;
-	virtual Ref<Image> texture_3d_slice_get(RID p_texture, int p_depth, int p_mipmap) const = 0;
+	virtual Vector<Ref<Image>> texture_3d_get(RID p_texture) const = 0;
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture) = 0;
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) = 0;


### PR DESCRIPTION
To import a 3D texture, select import type Texture3D and the slicing:
![image](https://user-images.githubusercontent.com/6265307/92621333-120dc880-f29a-11ea-84e9-b1c140d30ae6.png)
New resource types have been added, Texture3D( base), ImageTexture3D, and StreamTexture3D.
![image](https://user-images.githubusercontent.com/6265307/92621456-35d10e80-f29a-11ea-967a-deb96978dc46.png)
And a previewer:
![image](https://user-images.githubusercontent.com/6265307/92621527-4b463880-f29a-11ea-9ea1-fb16edadb31b.png)
