### PR TITLE
stb_vorbis: Increase max alloc buffer size for big Vorbis comments

### DIFF
--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -158,13 +158,15 @@ void AudioStreamOGGVorbis::clear_data() {
 
 void AudioStreamOGGVorbis::set_data(const Vector<uint8_t> &p_data) {
 	int src_data_len = p_data.size();
-#define MAX_TEST_MEM (1 << 20)
-
 	uint32_t alloc_try = 1024;
 	Vector<char> alloc_mem;
 	char *w;
 	stb_vorbis *ogg_stream = nullptr;
 	stb_vorbis_alloc ogg_alloc;
+
+	// Vorbis comments may be up to UINT32_MAX, but that's arguably pretty rare.
+	// Let's go with 2^30 so we don't risk going out of bounds.
+	const uint32_t MAX_TEST_MEM = 1 << 30;
 
 	while (alloc_try < MAX_TEST_MEM) {
 		alloc_mem.resize(alloc_try);
@@ -205,6 +207,8 @@ void AudioStreamOGGVorbis::set_data(const Vector<uint8_t> &p_data) {
 			break;
 		}
 	}
+
+	ERR_FAIL_COND_MSG(alloc_try == MAX_TEST_MEM, vformat("Couldn't set vorbis data even with an alloc buffer of %d bytes, report bug.", MAX_TEST_MEM));
 }
 
 Vector<uint8_t> AudioStreamOGGVorbis::get_data() const {


### PR DESCRIPTION
The previous max worked OK for audio data, but stb_vorbis recently gained support
for Vorbis comments, which can embed up to 2^32-1 bytes of data (e.g. cover art
encoded as base64).

We use 2^30 as max which should be sufficient for most files.

Fixes #41913.
