### PR TITLE
Add PROPERTY_USAGE_ALWAYS_SHARE_ON_DUPLICATE flag

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -617,7 +617,7 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 #ifdef TOOLS_ENABLED
 		p_list->push_back(PropertyInfo(Variant::NIL, "Script", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
 #endif
-		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT));
+		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ALWAYS_SHARE_ON_DUPLICATE));
 	}
 	if (!metadata.empty()) {
 		p_list->push_back(PropertyInfo(Variant::DICTIONARY, "__meta__", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));

--- a/core/object.h
+++ b/core/object.h
@@ -125,6 +125,7 @@ enum PropertyUsageFlags {
 	PROPERTY_USAGE_KEYING_INCREMENTS = 1 << 25, // Used in inspector to increment property when keyed in animation player
 	PROPERTY_USAGE_DEFERRED_SET_RESOURCE = 1 << 26, // when loading, the resource for this property can be set at the end of loading
 	PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT = 1 << 27, // For Object properties, instantiate them when creating in editor.
+	PROPERTY_USAGE_ALWAYS_SHARE_ON_DUPLICATE = 1 << 28, // If the object is duplicated this property will never be duplicated
 
 	PROPERTY_USAGE_DEFAULT = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_NETWORK,
 	PROPERTY_USAGE_DEFAULT_INTL = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_NETWORK | PROPERTY_USAGE_INTERNATIONALIZED,

--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -220,7 +220,7 @@ Ref<Resource> Resource::duplicate(bool p_subresources) const {
 
 		if ((p.get_type() == Variant::DICTIONARY || p.get_type() == Variant::ARRAY)) {
 			r->set(E->get().name, p.duplicate(p_subresources));
-		} else if (p.get_type() == Variant::OBJECT && (p_subresources || (E->get().usage & PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE))) {
+		} else if (p.get_type() == Variant::OBJECT && !(E->get().usage & PROPERTY_USAGE_ALWAYS_SHARE_ON_DUPLICATE) && (p_subresources || (E->get().usage & PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE))) {
 			RES sr = p;
 			if (sr.is_valid()) {
 				r->set(E->get().name, sr->duplicate(p_subresources));


### PR DESCRIPTION
This adds `PROPERTY_USAGE_ALWAYS_SHARE_ON_DUPLICATE` flag. With this PR, `Resource.duplicate` will not duplicate `Object.script` property. Fixes #33079.
