### PR TITLE
Fix leaks in GDScript

### DIFF
--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -84,7 +84,7 @@ class GDScriptCompiler {
 
 					Ref<Script> script = obj->get_script();
 					if (script.is_valid()) {
-						type.script_type = script;
+						type.script_type = script.ptr();
 						Ref<GDScript> gdscript = script;
 						if (gdscript.is_valid()) {
 							type.kind = GDScriptDataType::GDSCRIPT;
@@ -125,7 +125,7 @@ class GDScriptCompiler {
 	Error _create_binary_operator(CodeGen &codegen, const GDScriptParser::BinaryOpNode *on, Variant::Operator op, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
 	Error _create_binary_operator(CodeGen &codegen, const GDScriptParser::ExpressionNode *p_left_operand, const GDScriptParser::ExpressionNode *p_right_operand, Variant::Operator op, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
 
-	GDScriptDataType _gdtype_from_datatype(const GDScriptParser::DataType &p_datatype) const;
+	GDScriptDataType _gdtype_from_datatype(const GDScriptParser::DataType &p_datatype, GDScript *p_owner = nullptr) const;
 
 	GDScriptCodeGenerator::Address _parse_assign_right_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::AssignmentNode *p_assignmentint, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
 	GDScriptCodeGenerator::Address _parse_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::ExpressionNode *p_expression, bool p_root = false, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -56,7 +56,8 @@ struct GDScriptDataType {
 	bool has_type = false;
 	Variant::Type builtin_type = Variant::NIL;
 	StringName native_type;
-	Ref<Script> script_type;
+	Script *script_type = nullptr;
+	Ref<Script> script_type_ref;
 
 	bool is_type(const Variant &p_variant, bool p_allow_implicit_conversion = false) const {
 		if (!has_type) {


### PR DESCRIPTION
This PR does two things:
- Prevents generation of cyclic references in the simple case: scripts such that some of their items (function parameters, return types, etc.) have the same script as their type. In that case, instead of creating a hard (ref-counted) reference, a raw pointer is used, since the lifetime of those items is guaranteed to be the same of the script.
- Clears potential cyclic references in the complex cases: script A may use script B as a type and viceversa. That is very hard to  handle properly at runtime. However, we still want every object in the engine to have been freed at shutdown (or at least, if user code is causing leaks, we don't want leaks from the engine itself to appear there mixed with the other). Therefore, my approach is to clear all the references from those types of script items (function args, return types, etc.) to the script, in case the type is a script, so all the scripts involved in cycles can be finally freed.

**NOTE:** A separate version of this PR is submitted for 3.2.

Fixes #30668.
Fixes #40330.
Fixes #40403.
Fixes #41740.
