### PR TITLE
Fixes ParallaxLayer offset when camera zoom is ignored

### DIFF
--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -101,7 +101,7 @@ void ParallaxBackground::_update_scroll() {
 		}
 
 		if (ignore_camera_zoom) {
-			l->set_base_offset_and_scale(ofs, 1.0, screen_offset);
+			l->set_base_offset_and_scale((ofs + screen_offset * (scale - 1)) / scale, 1.0, screen_offset);
 		} else {
 			l->set_base_offset_and_scale(ofs, scale, screen_offset);
 		}


### PR DESCRIPTION
This fixes #25176.

Currently, Ignore Camera Zoom only makes it as if scroll scale is 1.0, but leaves scroll offset untouched. I removed the additional scroll offset introduced by camera zoom so that the parallax layer stays still when zooming.

Tested on the current master (ab7e7b8116) and 3.2 branch (49b3750).