### PR TITLE
Remove unused variable in fixed-size.html.

### DIFF
--- a/misc/dist/html/fixed-size.html
+++ b/misc/dist/html/fixed-size.html
@@ -236,7 +236,6 @@ $GODOT_HEAD_INCLUDE
 			const DEBUG_ENABLED = $GODOT_DEBUG_ENABLED;
 			const INDETERMINATE_STATUS_STEP_MS = 100;
 
-			var container = document.getElementById('container');
 			var canvas = document.getElementById('canvas');
 			var statusProgress = document.getElementById('status-progress');
 			var statusProgressInner = document.getElementById('status-progress-inner');


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=&severity=&id=js%2Funused-local-variable&ruleFocus=1780092), this PR removes the unused variable `container` from `misc/dist/html/fixed-size.html`.
