### PR TITLE
Remove duplicate or unnecessary Python definitions.

### DIFF
--- a/editor/translations/extract.py
+++ b/editor/translations/extract.py
@@ -70,7 +70,6 @@ def _write_message(msgctx, msg, msg_plural, location):
 def _add_additional_location(msgctx, msg, location):
     global main_po
     # Add additional location to previous occurrence.
-    msg_pos = -1
     if msgctx != "":
         msg_pos = main_po.find('\nmsgctxt "' + msgctx + '"\nmsgid "' + msg + '"')
     else:
@@ -86,7 +85,6 @@ def _write_translator_comment(msgctx, msg, translator_comment):
         return
 
     global main_po
-    msg_pos = -1
     if msgctx != "":
         msg_pos = main_po.find('\nmsgctxt "' + msgctx + '"\nmsgid "' + msg + '"')
     else:

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -211,11 +211,6 @@ def build_raw_header(filename):
     fd.close()
 
 
-def build_rd_headers(target, source, env):
-    for x in source:
-        build_rd_header(str(x))
-
-
 def build_raw_headers(target, source, env):
     for x in source:
         build_raw_header(str(x))


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=&severity=&id=py%2Fmultiple-definition&ruleFocus=1800095), this PR removes:
- The duplicate definition of `build_rd_headers()` in `glsl_builders.py`
- The unnecessary definitions of `msg_pos` in `editor/translations/extract.py`
