### PR TITLE
Remove unused Python imports.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -13,8 +13,6 @@ from collections import OrderedDict
 # Local
 import methods
 import glsl_builders
-import version
-from platform_methods import run_in_subprocess
 
 # Scan possible build platforms
 

--- a/core/SCsub
+++ b/core/SCsub
@@ -4,7 +4,6 @@ Import("env")
 
 import core_builders
 import make_binders
-from platform_methods import run_in_subprocess
 
 env.core_sources = []
 

--- a/core/input/SCsub
+++ b/core/input/SCsub
@@ -2,7 +2,6 @@
 
 Import("env")
 
-from platform_methods import run_in_subprocess
 import input_builders
 
 

--- a/main/main_builders.py
+++ b/main/main_builders.py
@@ -4,7 +4,6 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 
 """
 from platform_methods import subprocess_main
-from collections import OrderedDict
 
 
 def make_splash(target, source, env):

--- a/modules/denoise/resource_to_cpp.py
+++ b/modules/denoise/resource_to_cpp.py
@@ -17,8 +17,6 @@
 ## ======================================================================== ##
 
 import os
-import sys
-import argparse
 from array import array
 
 # Generates a C++ file from the specified binary resource file

--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -1,6 +1,5 @@
 import os
 import os.path
-import sys
 import subprocess
 
 from SCons.Script import Dir, Environment

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import subprocess
 from methods import detect_darwin_sdk_path
 
 


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=&severity=&id=py%2Funused-import&ruleFocus=6770079), this PR removes the unused Python imports in various SCons files.
