### PR TITLE
Added confirmation dialog for making sub-resources unique.

### DIFF
--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -40,8 +40,6 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/control.h"
-#include "scene/gui/label.h"
-#include "scene/gui/popup_menu.h"
 
 class EditorNode;
 
@@ -92,7 +90,13 @@ class InspectorDock : public VBoxContainer {
 	Button *warning;
 	AcceptDialog *warning_dialog;
 
+	int current_option = -1;
+	ConfirmationDialog *unique_resources_confirmation;
+	Tree *unique_resources_list_tree;
+
 	void _menu_option(int p_option);
+	void _menu_confirm_current();
+	void _menu_option_confirm(int p_option, bool p_confirmed);
 
 	void _new_resource();
 	void _load_resource(const String &p_type = "");


### PR DESCRIPTION
Making sub-resources unique is a destructive operation without the ability to undo. Having no feedback to the user about this operation seems bad UX.

This PR adds:
![image](https://user-images.githubusercontent.com/41730826/92730700-7f634b80-f3b7-11ea-9369-9a43635a5896.png)

Maybe in the future this could even be a list with checkboxes for each resource, allowing the user to easily select some/all of the resources to be made unique. For example, I would say it's quite common to not want the script to be made unique.

P.S. it's not really +86/-24, more like +50/-0, the diff just gets confused by code being moved around.