### PR TITLE
Rename RayCast's `cast_to` property to `target_position`

### DIFF
--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -4,8 +4,8 @@
 		Query the closest object intersecting a ray.
 	</brief_description>
 	<description>
-		A RayCast represents a line from its origin to its destination position, [code]cast_to[/code]. It is used to query the 2D space in order to find the closest object along the path of the ray.
-		RayCast2D can ignore some objects by adding them to the exception list via [code]add_exception[/code], by setting proper filtering with collision layers, or by filtering object types with type masks.
+		A RayCast represents a line from its origin to its destination position, [member target_position]. It is used to query the 2D space in order to find the closest object along the path of the ray.
+		RayCast2D can ignore some objects by adding them to the exception list via [method add_exception], by setting proper filtering with collision layers, or by filtering object types with type masks.
 		RayCast2D can be configured to report collisions with [Area2D]s ([member collide_with_areas]) and/or [PhysicsBody2D]s ([member collide_with_bodies]).
 		Only enabled raycasts will be able to query the space and report collisions.
 		RayCast2D calculates intersection every physics frame (see [Node]), and the result is cached so it can be used later until the next frame. If multiple queries are required between physics frames (or during the same frame) use [method force_raycast_update] after adjusting the raycast.
@@ -123,7 +123,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="cast_to" type="Vector2" setter="set_cast_to" getter="get_cast_to" default="Vector2( 0, 50 )">
+		<member name="target_position" type="Vector2" setter="set_target_position" getter="get_target_position" default="Vector2( 0, 50 )">
 			The ray's destination point, relative to the RayCast's [code]position[/code].
 		</member>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -4,8 +4,8 @@
 		Query the closest object intersecting a ray.
 	</brief_description>
 	<description>
-		A RayCast represents a line from its origin to its destination position, [code]cast_to[/code]. It is used to query the 3D space in order to find the closest object along the path of the ray.
-		RayCast3D can ignore some objects by adding them to the exception list via [code]add_exception[/code] or by setting proper filtering with collision layers and masks.
+		A RayCast represents a line from its origin to its destination position, [member target_position]. It is used to query the 3D space in order to find the closest object along the path of the ray.
+		RayCast3D can ignore some objects by adding them to the exception list via [method add_exception] or by setting proper filtering with collision layers and masks.
 		RayCast3D can be configured to report collisions with [Area3D]s ([member collide_with_areas]) and/or [PhysicsBody3D]s ([member collide_with_bodies]).
 		Only enabled raycasts will be able to query the space and report collisions.
 		RayCast3D calculates intersection every physics frame (see [Node]), and the result is cached so it can be used later until the next frame. If multiple queries are required between physics frames (or during the same frame), use [method force_raycast_update] after adjusting the raycast.
@@ -126,7 +126,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="cast_to" type="Vector3" setter="set_cast_to" getter="get_cast_to" default="Vector3( 0, -1, 0 )">
+		<member name="target_position" type="Vector3" setter="set_target_position" getter="get_target_position" default="Vector3( 0, -1, 0 )">
 			The ray's destination point, relative to the RayCast's [code]position[/code].
 		</member>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">

--- a/editor/node_3d_editor_gizmos.cpp
+++ b/editor/node_3d_editor_gizmos.cpp
@@ -1912,7 +1912,7 @@ void RayCast3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	Vector<Vector3> lines;
 
 	lines.push_back(Vector3());
-	lines.push_back(raycast->get_cast_to());
+	lines.push_back(raycast->get_target_position());
 
 	const Ref<StandardMaterial3D> material =
 			get_material(raycast->is_enabled() ? "shape_material" : "shape_material_disabled", p_gizmo);

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -35,15 +35,15 @@
 #include "physics_body_2d.h"
 #include "servers/physics_server_2d.h"
 
-void RayCast2D::set_cast_to(const Vector2 &p_point) {
-	cast_to = p_point;
+void RayCast2D::set_target_position(const Vector2 &p_point) {
+	target_position = p_point;
 	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_collisions_hint())) {
 		update();
 	}
 }
 
-Vector2 RayCast2D::get_cast_to() const {
-	return cast_to;
+Vector2 RayCast2D::get_target_position() const {
+	return target_position;
 }
 
 void RayCast2D::set_collision_mask(uint32_t p_mask) {
@@ -160,8 +160,8 @@ void RayCast2D::_notification(int p_what) {
 				break;
 			}
 			Transform2D xf;
-			xf.rotate(cast_to.angle());
-			xf.translate(Vector2(cast_to.length(), 0));
+			xf.rotate(target_position.angle());
+			xf.translate(Vector2(target_position.length(), 0));
 
 			// Draw an arrow indicating where the RayCast is pointing to
 			Color draw_col = get_tree()->get_debug_collisions_color();
@@ -171,7 +171,7 @@ void RayCast2D::_notification(int p_what) {
 				draw_col.g = g;
 				draw_col.b = g;
 			}
-			draw_line(Vector2(), cast_to, draw_col, 2);
+			draw_line(Vector2(), target_position, draw_col, 2);
 			Vector<Vector2> pts;
 			float tsize = 8;
 			pts.push_back(xf.xform(Vector2(tsize, 0)));
@@ -206,7 +206,7 @@ void RayCast2D::_update_raycast_state() {
 
 	Transform2D gt = get_global_transform();
 
-	Vector2 to = cast_to;
+	Vector2 to = target_position;
 	if (to == Vector2()) {
 		to = Vector2(0, 0.01);
 	}
@@ -280,8 +280,8 @@ void RayCast2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &RayCast2D::set_enabled);
 	ClassDB::bind_method(D_METHOD("is_enabled"), &RayCast2D::is_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_cast_to", "local_point"), &RayCast2D::set_cast_to);
-	ClassDB::bind_method(D_METHOD("get_cast_to"), &RayCast2D::get_cast_to);
+	ClassDB::bind_method(D_METHOD("set_target_position", "local_point"), &RayCast2D::set_target_position);
+	ClassDB::bind_method(D_METHOD("get_target_position"), &RayCast2D::get_target_position);
 
 	ClassDB::bind_method(D_METHOD("is_colliding"), &RayCast2D::is_colliding);
 	ClassDB::bind_method(D_METHOD("force_raycast_update"), &RayCast2D::force_raycast_update);
@@ -316,7 +316,7 @@ void RayCast2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exclude_parent"), "set_exclude_parent_body", "get_exclude_parent_body");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "cast_to"), "set_cast_to", "get_cast_to");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "target_position"), "set_target_position", "get_target_position");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collision_mask", "get_collision_mask");
 
 	ADD_GROUP("Collide With", "collide_with");
@@ -329,7 +329,7 @@ RayCast2D::RayCast2D() {
 	collided = false;
 	against_shape = 0;
 	collision_mask = 1;
-	cast_to = Vector2(0, 50);
+	target_position = Vector2(0, 50);
 	exclude_parent_body = true;
 	collide_with_bodies = true;
 	collide_with_areas = false;

--- a/scene/2d/ray_cast_2d.h
+++ b/scene/2d/ray_cast_2d.h
@@ -46,7 +46,7 @@ class RayCast2D : public Node2D {
 	uint32_t collision_mask;
 	bool exclude_parent_body;
 
-	Vector2 cast_to;
+	Vector2 target_position;
 
 	bool collide_with_areas;
 	bool collide_with_bodies;
@@ -66,8 +66,8 @@ public:
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
 
-	void set_cast_to(const Vector2 &p_point);
-	Vector2 get_cast_to() const;
+	void set_target_position(const Vector2 &p_point);
+	Vector2 get_target_position() const;
 
 	void set_collision_mask(uint32_t p_mask);
 	uint32_t get_collision_mask() const;

--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -35,8 +35,8 @@
 #include "mesh_instance_3d.h"
 #include "servers/physics_server_3d.h"
 
-void RayCast3D::set_cast_to(const Vector3 &p_point) {
-	cast_to = p_point;
+void RayCast3D::set_target_position(const Vector3 &p_point) {
+	target_position = p_point;
 	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_collisions_hint())) {
 		update_gizmo();
 	}
@@ -45,8 +45,8 @@ void RayCast3D::set_cast_to(const Vector3 &p_point) {
 	}
 }
 
-Vector3 RayCast3D::get_cast_to() const {
-	return cast_to;
+Vector3 RayCast3D::get_target_position() const {
+	return target_position;
 }
 
 void RayCast3D::set_collision_mask(uint32_t p_mask) {
@@ -202,7 +202,7 @@ void RayCast3D::_update_raycast_state() {
 
 	Transform gt = get_global_transform();
 
-	Vector3 to = cast_to;
+	Vector3 to = target_position;
 	if (to == Vector3()) {
 		to = Vector3(0, 0.01, 0);
 	}
@@ -276,8 +276,8 @@ void RayCast3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &RayCast3D::set_enabled);
 	ClassDB::bind_method(D_METHOD("is_enabled"), &RayCast3D::is_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_cast_to", "local_point"), &RayCast3D::set_cast_to);
-	ClassDB::bind_method(D_METHOD("get_cast_to"), &RayCast3D::get_cast_to);
+	ClassDB::bind_method(D_METHOD("set_target_position", "local_point"), &RayCast3D::set_target_position);
+	ClassDB::bind_method(D_METHOD("get_target_position"), &RayCast3D::get_target_position);
 
 	ClassDB::bind_method(D_METHOD("is_colliding"), &RayCast3D::is_colliding);
 	ClassDB::bind_method(D_METHOD("force_raycast_update"), &RayCast3D::force_raycast_update);
@@ -312,7 +312,7 @@ void RayCast3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exclude_parent"), "set_exclude_parent_body", "get_exclude_parent_body");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "cast_to"), "set_cast_to", "get_cast_to");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "target_position"), "set_target_position", "get_target_position");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 
 	ADD_GROUP("Collide With", "collide_with");
@@ -360,7 +360,7 @@ void RayCast3D::_update_debug_shape() {
 
 	Vector<Vector3> verts;
 	verts.push_back(Vector3());
-	verts.push_back(cast_to);
+	verts.push_back(target_position);
 	a[Mesh::ARRAY_VERTEX] = verts;
 
 	mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, a);
@@ -387,7 +387,7 @@ RayCast3D::RayCast3D() {
 	collided = false;
 	against_shape = 0;
 	collision_mask = 1;
-	cast_to = Vector3(0, -1, 0);
+	target_position = Vector3(0, -1, 0);
 	debug_shape = nullptr;
 	exclude_parent_body = true;
 	collide_with_areas = false;

--- a/scene/3d/ray_cast_3d.h
+++ b/scene/3d/ray_cast_3d.h
@@ -43,7 +43,7 @@ class RayCast3D : public Node3D {
 	Vector3 collision_point;
 	Vector3 collision_normal;
 
-	Vector3 cast_to;
+	Vector3 target_position;
 	Set<RID> exclude;
 
 	uint32_t collision_mask;
@@ -74,8 +74,8 @@ public:
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
 
-	void set_cast_to(const Vector3 &p_point);
-	Vector3 get_cast_to() const;
+	void set_target_position(const Vector3 &p_point);
+	Vector3 get_target_position() const;
 
 	void set_collision_mask(uint32_t p_mask);
 	uint32_t get_collision_mask() const;


### PR DESCRIPTION
`cast_to` is sometimes mistaken as a method rather than a property. `target_position` makes it more obvious that it's a property.

See https://github.com/godotengine/godot/issues/16863#issuecomment-676512989.