### PR TITLE
Improve SpriteFrames get_animation_loop description

### DIFF
--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -54,7 +54,7 @@
 			<argument index="0" name="anim" type="StringName">
 			</argument>
 			<description>
-				If [code]true[/code], the given animation will loop.
+   				Returns [code]true[/code] if the given animation is configured to loop when it finishes playing. Otherwise, returns [code]false[/code].
 			</description>
 		</method>
 		<method name="get_animation_names" qualifiers="const">


### PR DESCRIPTION
makes the description for the get_animation_loop method less confusing. Uses the description suggested by clayjohn in https://github.com/godotengine/godot-docs/issues/3987. Closes https://github.com/godotengine/godot-docs/issues/3987
