### PR TITLE
Fix RichTextLabel alignment for clickable regions

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -256,7 +256,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 			lh = line < l.height_caches.size() ? l.height_caches[line] : 1;                                                                                     \
 			line_ascent = line < l.ascent_caches.size() ? l.ascent_caches[line] : 1;                                                                            \
 			line_descent = line < l.descent_caches.size() ? l.descent_caches[line] : 1;                                                                         \
-			if ((p_mode == PROCESS_DRAW) && (align != ALIGN_FILL)) {                                                                                            \
+			if (align != ALIGN_FILL) {                                                                                                                          \
 				if (line < l.offset_caches.size()) {                                                                                                            \
 					wofs = l.offset_caches[line];                                                                                                               \
 				}                                                                                                                                               \


### PR DESCRIPTION
Fixes #41006 (regression from #39164).

The original alignment fix was limited to `PROCESS_DRAW` mode, which caused some discrepancies with `PROCESS_POINTER` mode.
Now only `PROCESS_CACHE` is excluded with a condition a few lines above.
