### PR TITLE
Remove unused Python local variables.

### DIFF
--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -54,7 +54,6 @@ def make_fonts_header(target, source, env):
     g.write("#define _EDITOR_FONTS_H\n")
 
     # saving uncompressed, since freetype will reference from memory pointer
-    xl_names = []
     for i in range(len(source)):
         with open(source[i], "rb") as f:
             buf = f.read()

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -96,8 +96,6 @@ def build_rd_header(filename):
     out_file = filename + ".gen.h"
     fd = open(out_file, "w")
 
-    enum_constants = []
-
     fd.write("/* WARNING, THIS FILE WAS GENERATED, DO NOT EDIT */\n")
 
     out_file_base = out_file
@@ -165,7 +163,6 @@ class RAWHeaderStruct:
 def include_file_in_raw_header(filename, header_data, depth):
     fs = open(filename, "r")
     line = fs.readline()
-    text = ""
 
     while line:
 
@@ -191,8 +188,6 @@ def build_raw_header(filename):
 
     out_file = filename + ".gen.h"
     fd = open(out_file, "w")
-
-    enum_constants = []
 
     fd.write("/* WARNING, THIS FILE WAS GENERATED, DO NOT EDIT */\n")
 

--- a/modules/mono/build_scripts/solution_builder.py
+++ b/modules/mono/build_scripts/solution_builder.py
@@ -8,9 +8,6 @@ def find_dotnet_cli():
     import os.path
 
     if os.name == "nt":
-        windows_exts = os.environ["PATHEXT"]
-        windows_exts = windows_exts.split(os.pathsep) if windows_exts else []
-
         for hint_dir in os.environ["PATH"].split(os.pathsep):
             hint_dir = hint_dir.strip('"')
             hint_path = os.path.join(hint_dir, "dotnet")


### PR DESCRIPTION
As identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=&ruleFocus=6780086&id=py%2Funused-local-variable), there are a number of location where a value assigned to a local variable is not used. This PR deletes local variables that are not used.

Note: I have left the unused assigned value to `vc_chosen_compiler_index`, because the variable is used in the function, and it serves as documentation in the final `if` statement:
https://github.com/godotengine/godot/blob/a2a78a80663674a1cd348a860184be8507bb76e3/methods.py#L500-L506