### PR TITLE
Add missing reference to const T Vector::get().

### DIFF
--- a/core/vector.h
+++ b/core/vector.h
@@ -82,7 +82,7 @@ public:
 	_FORCE_INLINE_ bool empty() const { return _cowdata.empty(); }
 
 	_FORCE_INLINE_ T get(int p_index) { return _cowdata.get(p_index); }
-	_FORCE_INLINE_ const T get(int p_index) const { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ const T &get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 	Error resize(int p_size) { return _cowdata.resize(p_size); }


### PR DESCRIPTION
`Vector` has two `get()` functions, one returns a copy of the value that can be used as desired, the second should be for obtaining a reference to the underlying value without making a copy that is read-only (`const`). However, the second `get()` is missing the dereference. This PR adds the dereference symbol.

Note: The malformed function definition was identified by [lgtm](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=&ruleFocus=2156200647&id=cpp%2Fmember-const-no-effect).
