### PR TITLE
Array/Dictionary Nodes no more reduced to array/dictionary variant

### DIFF
--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -89,6 +89,9 @@ class GDScriptAnalyzer {
 	void reduce_ternary_op(GDScriptParser::TernaryOpNode *p_ternary_op);
 	void reduce_unary_op(GDScriptParser::UnaryOpNode *p_unary_op);
 
+	void const_fold_array(GDScriptParser::ArrayNode *p_array);
+	void const_fold_dictionary(GDScriptParser::DictionaryNode *p_dictionary);
+
 	// Helpers.
 	GDScriptParser::DataType type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source);
 	GDScriptParser::DataType type_from_metatype(const GDScriptParser::DataType &p_meta_type) const;


### PR DESCRIPTION
Fix: #41377
Fix: #41953
Fix: #42335

```gdscript
var   arr = [1, 2, 3] ## <-- constructed at runtime
const ARR = [1, 2, 3] ## <-- constructed at compile time
```