### PR TITLE
Improve AudioEffectDistortion and AudioEffectFilter documentation

### DIFF
--- a/doc/classes/AudioEffectDistortion.xml
+++ b/doc/classes/AudioEffectDistortion.xml
@@ -2,13 +2,14 @@
 <class name="AudioEffectDistortion" inherits="AudioEffect" version="4.0">
 	<brief_description>
 		Adds a distortion audio effect to an Audio bus.
-		Modify the sound to make it dirty.
+		Modify the sound to make it distorted.
 	</brief_description>
 	<description>
-		Modify the sound and make it dirty. Different types are available: clip, tan, lo-fi (bit crushing), overdrive, or waveshape.
+		Different types are available: clip, tan, lo-fi (bit crushing), overdrive, or waveshape.
 		By distorting the waveform the frequency content change, which will often make the sound "crunchy" or "abrasive". For games, it can simulate sound coming from some saturated device or speaker very efficiently.
 	</description>
 	<tutorials>
+		<link title="Audio buses">https://docs.godotengine.org/en/latest/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/AudioEffectFilter.xml
+++ b/doc/classes/AudioEffectFilter.xml
@@ -7,6 +7,7 @@
 		Allows frequencies other than the [member cutoff_hz] to pass.
 	</description>
 	<tutorials>
+		<link title="Audio buses">https://docs.godotengine.org/en/latest/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<methods>
 	</methods>
@@ -20,7 +21,7 @@
 			Gain amount of the frequencies after the filter.
 		</member>
 		<member name="resonance" type="float" setter="set_resonance" getter="get_resonance" default="0.5">
-			Amount of boost in the overtones near the cutoff frequency.
+			Amount of boost in the frequency range near the cutoff frequency.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Improves the description of distortion by removing the word dirty, since it isn't a good description. Fixes the description of resonance in AudioEffectFilter, resonance boosts all frequencies, not just overtones. Closes https://github.com/godotengine/godot-docs/issues/3993, closes https://github.com/godotengine/godot-docs/issues/3995.