### PR TITLE
Clarify get_data Image method

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -233,7 +233,7 @@
 			<return type="PackedByteArray">
 			</return>
 			<description>
-				Returns the image's raw data.
+				Returns a copy of the image's raw data.
 			</description>
 		</method>
 		<method name="get_format" qualifiers="const">


### PR DESCRIPTION
Clarifies that the `get_data()` method of `Image` returns a copy of the data and not the data itself. 

Compare to [PR #41638](https://github.com/godotengine/godot/pull/41638) and the related [godot-docs issue #2609](https://github.com/godotengine/godot-docs/issues/2609), which were about `Texture` class. This is about `Image` class.