### PR TITLE
Add concatenation support and a new constructor to Godot.Collections.Array

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -44,6 +44,15 @@ namespace Godot.Collections
                 Add(element);
         }
 
+        public Array(params object[] array) : this()
+        {
+            if (array == null)
+            {
+                throw new NullReferenceException($"Parameter '{nameof(array)} cannot be null.'");
+            }
+            safeHandle = new ArraySafeHandle(godot_icall_Array_Ctor_MonoArray(array));
+        }
+
         internal Array(ArraySafeHandle handle)
         {
             safeHandle = handle;
@@ -70,6 +79,11 @@ namespace Godot.Collections
         public Error Resize(int newSize)
         {
             return godot_icall_Array_Resize(GetPtr(), newSize);
+        }
+
+        public static Array operator +(Array left, Array right)
+        {
+            return new Array(godot_icall_Array_Concatenate(left.GetPtr(), right.GetPtr()));
         }
 
         // IDisposable
@@ -155,6 +169,9 @@ namespace Godot.Collections
         internal extern static IntPtr godot_icall_Array_Ctor();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern static IntPtr godot_icall_Array_Ctor_MonoArray(System.Array array);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static void godot_icall_Array_Dtor(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -174,6 +191,9 @@ namespace Godot.Collections
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static void godot_icall_Array_Clear(IntPtr ptr);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern static IntPtr godot_icall_Array_Concatenate(IntPtr left, IntPtr right);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern static bool godot_icall_Array_Contains(IntPtr ptr, object item);
@@ -231,6 +251,15 @@ namespace Godot.Collections
             objectArray = new Array(collection);
         }
 
+        public Array(params T[] array) : this()
+        {
+            if (array == null)
+            {
+                throw new NullReferenceException($"Parameter '{nameof(array)} cannot be null.'");
+            }
+            objectArray = new Array(array);
+        }
+
         public Array(Array array)
         {
             objectArray = array;
@@ -264,6 +293,11 @@ namespace Godot.Collections
         public Error Resize(int newSize)
         {
             return objectArray.Resize(newSize);
+        }
+
+        public static Array<T> operator +(Array<T> left, Array<T> right)
+        {
+            return new Array<T>(left.objectArray + right.objectArray);
         }
 
         // IList<T>

--- a/modules/mono/glue/collections_glue.cpp
+++ b/modules/mono/glue/collections_glue.cpp
@@ -104,8 +104,29 @@ void godot_icall_Array_CopyTo(Array *ptr, MonoArray *array, int array_index) {
 	}
 }
 
+Array *godot_icall_Array_Ctor_MonoArray(MonoArray *mono_array) {
+	Array *godot_array = memnew(Array);
+	unsigned int count = mono_array_length(mono_array);
+	godot_array->resize(count);
+	for (unsigned int i = 0; i < count; i++) {
+		MonoObject *item = mono_array_get(mono_array, MonoObject *, i);
+		godot_icall_Array_SetAt(godot_array, i, item);
+	}
+	return godot_array;
+}
+
 Array *godot_icall_Array_Duplicate(Array *ptr, MonoBoolean deep) {
 	return memnew(Array(ptr->duplicate(deep)));
+}
+
+Array *godot_icall_Array_Concatenate(Array *left, Array *right) {
+	int count = left->size() + right->size();
+	Array *new_array = memnew(Array(left->duplicate(false)));
+	new_array->resize(count);
+	for (unsigned int i = 0; i < (unsigned int)right->size(); i++) {
+		new_array->operator[](i + left->size()) = right->operator[](i);
+	}
+	return new_array;
 }
 
 int godot_icall_Array_IndexOf(Array *ptr, MonoObject *item) {
@@ -284,6 +305,7 @@ MonoString *godot_icall_Dictionary_ToString(Dictionary *ptr) {
 
 void godot_register_collections_icalls() {
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Ctor", (void *)godot_icall_Array_Ctor);
+	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Ctor_MonoArray", (void *)godot_icall_Array_Ctor_MonoArray);
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Dtor", (void *)godot_icall_Array_Dtor);
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_At", (void *)godot_icall_Array_At);
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_At_Generic", (void *)godot_icall_Array_At_Generic);
@@ -291,6 +313,7 @@ void godot_register_collections_icalls() {
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Count", (void *)godot_icall_Array_Count);
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Add", (void *)godot_icall_Array_Add);
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Clear", (void *)godot_icall_Array_Clear);
+	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Concatenate", (void *)godot_icall_Array_Concatenate);
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Contains", (void *)godot_icall_Array_Contains);
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_CopyTo", (void *)godot_icall_Array_CopyTo);
 	mono_add_internal_call("Godot.Collections.Array::godot_icall_Array_Duplicate", (void *)godot_icall_Array_Duplicate);


### PR DESCRIPTION
The primary reason for adding this is having a more consistent feature set with GDScript arrays. Test code:

```cs
var array1 = new Godot.Collections.Array("One", 2);
var array2 = new Godot.Collections.Array(3, "Four");
GD.Print(array1 + array2); // Prints [One, 2, 3, Four]
```

Compared to this GDScript code (there is a difference with the strings including quotation marks or not):

```gdscript
var array1 = ["One", 2]
var array2 = [3, "Four"]
print(array1 + array2) # Prints ["One", 2, 3, "Four"]
```

Test code for typed array:

```cs
var array3 = new Godot.Collections.Array<Vector2>(new Vector2(1, 2), new Vector2(3, 4));
var array4 = new Godot.Collections.Array<Vector2>(new Vector2(5, 6), new Vector2(7, 8));
GD.Print(array3 + array4); // Prints [(1, 2), (3, 4), (5, 6), (7, 8)]
```