### PR TITLE
Checkbox on Delete-Node dialog regarding deleting animations

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -806,7 +806,11 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 					// TODO: resize this properly, or rather add it with a vbox?
 
 					// TODO: connect signal to actually set the editor setting:
+
 				}
+				// set checkbox state based on editor setting:
+				bool auto_rename = bool(EDITOR_DEF("editors/animation/autorename_animation_tracks", true));
+				checkbox->set_pressed(auto_rename);
 				// Resize the dialog to its minimum size.
 				// This prevents the dialog from being too wide after displaying
 				// a deletion confirmation for a node with a long name.

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -44,6 +44,7 @@
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"
+#include "scene/gui/check_box.h"
 #include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
 #include "servers/display_server.h"
@@ -777,6 +778,15 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				}
 
 				delete_dialog->set_text(msg);
+				// add a checkbox to set/unset
+				// "editors/animation/autorename_animation_tracks"
+				// as this currenctly decides if animation tracks will be deleted
+				CheckBox* checkbox = memnew(CheckBox);
+				delete_dialog->add_child(checkbox);
+				checkbox->set_text("Also delete animation tracks?");
+				// TODO: connect signal to actually set the editor setting:
+
+				// TODO: will this leak memory or does add_child take ownership?
 
 				// Resize the dialog to its minimum size.
 				// This prevents the dialog from being too wide after displaying

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -324,6 +324,10 @@ bool SceneTreeDock::_track_inherit(const String &p_target_scene_path, Node *p_de
 	return result;
 }
 
+void SceneTreeDock::set_editor_setting(const Variant &p_value, const String &p_setting) {
+	EditorSettings::get_singleton()->set_setting(p_setting, p_value);
+}
+
 void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 	current_option = p_tool;
 
@@ -805,8 +809,13 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 					delete_dialog->set_min_size(Size2(200, 120) * EDSCALE);
 					// TODO: resize this properly, or rather add it with a vbox?
 
-					// TODO: connect signal to actually set the editor setting:
-
+					// connect signal to actually set the editor setting:
+					// This here doesn't work, as the binds can only be set for trailing arguments in the target callable:
+					//checkbox->connect("toggled", callable_mp(EditorSettings::get_singleton(), &EditorSettings::set_setting), make_binds("editors/animation/autorename_animation_tracks"));
+					// This here, using a lambda to make a partial function, does not work as the callable_mp helper insists that the function passed in is actually a method of the instance, even though that seems to not be required for it to work AFAICT
+					//checkbox->connect("toggled", callable_mp(EditorSettings::get_singleton(), [](bool button_pressed) {EditorSettings::get_singleton()->set_setting("editors/animation/autorename_animation_tracks", button_pressed); } );
+					// So let's resort for now to making a local method in this class:
+					checkbox->connect("toggled", callable_mp(this, &SceneTreeDock::set_editor_setting), make_binds("editors/animation/autorename_animation_tracks"));
 				}
 				// set checkbox state based on editor setting:
 				bool auto_rename = bool(EDITOR_DEF("editors/animation/autorename_animation_tracks", true));

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -780,14 +780,33 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				delete_dialog->set_text(msg);
 				// add a checkbox to set/unset
 				// "editors/animation/autorename_animation_tracks"
-				// as this currenctly decides if animation tracks will be deleted
-				CheckBox* checkbox = memnew(CheckBox);
-				delete_dialog->add_child(checkbox);
-				checkbox->set_text("Also delete animation tracks?");
-				// TODO: connect signal to actually set the editor setting:
+				// as this currently decides if animation tracks will be deleted
+				// but check if we did it previously:
+				// TODO: if we keep it like this, move this to the constructor...
+				Node *child_node = nullptr;
+				int cc = delete_dialog->get_child_count();
+				for (int i = 0; i < cc; i++) {
+					Node *cd = delete_dialog->get_child(i);
+					if (cd->get_name() == "DeleteAnimationsCheckBox") {
+						child_node = cd;
+						break;
+					}
+				}
+				CheckBox* checkbox = nullptr;
+				if (child_node) {
+					checkbox = (CheckBox*) child_node;
+				} else {
+					// This shouldn't leak memory because add_child takes ownership (?)
+					checkbox = memnew(CheckBox);
+					checkbox->set_name("DeleteAnimationsCheckBox");
+					checkbox->set_text(TTR("Also delete animation tracks?"));
+					checkbox->set_tooltip(TTR("Explain that this directly sets the editor setting"));
+					delete_dialog->add_child(checkbox);
+					delete_dialog->set_min_size(Size2(200, 120) * EDSCALE);
+					// TODO: resize this properly, or rather add it with a vbox?
 
-				// TODO: will this leak memory or does add_child take ownership?
-
+					// TODO: connect signal to actually set the editor setting:
+				}
 				// Resize the dialog to its minimum size.
 				// This prevents the dialog from being too wide after displaying
 				// a deletion confirmation for a node with a long name.

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -796,9 +796,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 						break;
 					}
 				}
-				CheckBox* checkbox = nullptr;
+				CheckBox *checkbox = nullptr;
 				if (child_node) {
-					checkbox = (CheckBox*) child_node;
+					checkbox = (CheckBox *)child_node;
 				} else {
 					// This shouldn't leak memory because add_child takes ownership (?)
 					checkbox = memnew(CheckBox);

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -265,6 +265,8 @@ public:
 
 	ScriptCreateDialog *get_script_create_dialog() { return script_create_dialog; }
 
+	void set_editor_setting(const Variant &p_value, const String &p_setting);
+
 	SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data);
 };
 


### PR DESCRIPTION
Initial version to fix #3562.

This is a minimal fix. Mainly to get feedback for a proper one.
It is therefore also not cleaned up or squashed, with lots of comments in the code regarding issues that showed up. I welcome any feedback on all those comments.

This fix simply adds a checkbox to the "Delete Node" confirmation dialog. The checkbox directly reflects, and changes, the editor setting "editors/animation/autorename_animation_tracks", as this controls if animation tracks that refer to a node are deleted.

This is suboptimal, I would say - for one autorename is not autoremove. But see below for more.