### PR TITLE
Rename the `type` parameter to `node_type` in Theme and Control

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -444,7 +444,7 @@
 			<argument index="1" name="type" type="StringName" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns a color from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]type[/code].
+				Returns a color from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
 				[codeblocks]
 				[gdscript]
 				func _ready():
@@ -467,7 +467,7 @@
 			<argument index="1" name="type" type="StringName" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns a constant from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]type[/code].
+				Returns a constant from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_theme_font" qualifiers="const">
@@ -478,7 +478,7 @@
 			<argument index="1" name="type" type="StringName" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns a font from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]type[/code].
+				Returns a font from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_theme_icon" qualifiers="const">
@@ -489,7 +489,7 @@
 			<argument index="1" name="type" type="StringName" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns an icon from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]type[/code].
+				Returns an icon from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_theme_stylebox" qualifiers="const">
@@ -500,7 +500,7 @@
 			<argument index="1" name="type" type="StringName" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns a [StyleBox] from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]type[/code].
+				Returns a [StyleBox] from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_tooltip" qualifiers="const">
@@ -564,7 +564,7 @@
 			<argument index="1" name="type" type="StringName" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns [code]true[/code] if [Color] with given [code]name[/code] and associated with [Control] of given [code]type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if [Color] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
 			</description>
 		</method>
 		<method name="has_theme_color_override" qualifiers="const">
@@ -584,7 +584,7 @@
 			<argument index="1" name="type" type="StringName" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns [code]true[/code] if constant with given [code]name[/code] and associated with [Control] of given [code]type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if constant with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
 			</description>
 		</method>
 		<method name="has_theme_constant_override" qualifiers="const">
@@ -604,7 +604,7 @@
 			<argument index="1" name="type" type="StringName" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns [code]true[/code] if font with given [code]name[/code] and associated with [Control] of given [code]type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if font with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
 			</description>
 		</method>
 		<method name="has_theme_font_override" qualifiers="const">
@@ -624,7 +624,7 @@
 			<argument index="1" name="type" type="StringName" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns [code]true[/code] if icon with given [code]name[/code] and associated with [Control] of given [code]type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if icon with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
 			</description>
 		</method>
 		<method name="has_theme_icon_override" qualifiers="const">
@@ -653,7 +653,7 @@
 			<argument index="1" name="type" type="StringName" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns [code]true[/code] if [StyleBox] with given [code]name[/code] and associated with [Control] of given [code]type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if [StyleBox] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
 			</description>
 		</method>
 		<method name="has_theme_stylebox_override" qualifiers="const">

--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -23,10 +23,10 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Clears the [Color] at [code]name[/code] if the theme has [code]type[/code].
+				Clears the [Color] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="clear_constant">
@@ -34,10 +34,10 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Clears the constant at [code]name[/code] if the theme has [code]type[/code].
+				Clears the constant at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="clear_font">
@@ -45,10 +45,10 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Clears the [Font] at [code]name[/code] if the theme has [code]type[/code].
+				Clears the [Font] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="clear_icon">
@@ -56,10 +56,10 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Clears the icon at [code]name[/code] if the theme has [code]type[/code].
+				Clears the icon at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="clear_stylebox">
@@ -67,10 +67,10 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Clears [StyleBox] at [code]name[/code] if the theme has [code]type[/code].
+				Clears [StyleBox] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="copy_default_theme">
@@ -94,19 +94,19 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Returns the [Color] at [code]name[/code] if the theme has [code]type[/code].
+				Returns the [Color] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_color_list" qualifiers="const">
 			<return type="PackedStringArray">
 			</return>
-			<argument index="0" name="type" type="String">
+			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the [Color]s as a [PackedStringArray] filled with each [Color]'s name, for use in [method get_color], if the theme has [code]type[/code].
+				Returns all the [Color]s as a [PackedStringArray] filled with each [Color]'s name, for use in [method get_color], if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_constant" qualifiers="const">
@@ -114,19 +114,19 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Returns the constant at [code]name[/code] if the theme has [code]type[/code].
+				Returns the constant at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_constant_list" qualifiers="const">
 			<return type="PackedStringArray">
 			</return>
-			<argument index="0" name="type" type="String">
+			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the constants as a [PackedStringArray] filled with each constant's name, for use in [method get_constant], if the theme has [code]type[/code].
+				Returns all the constants as a [PackedStringArray] filled with each constant's name, for use in [method get_constant], if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_font" qualifiers="const">
@@ -134,19 +134,19 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Returns the [Font] at [code]name[/code] if the theme has [code]type[/code].
+				Returns the [Font] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_font_list" qualifiers="const">
 			<return type="PackedStringArray">
 			</return>
-			<argument index="0" name="type" type="String">
+			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the [Font]s as a [PackedStringArray] filled with each [Font]'s name, for use in [method get_font], if the theme has [code]type[/code].
+				Returns all the [Font]s as a [PackedStringArray] filled with each [Font]'s name, for use in [method get_font], if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_icon" qualifiers="const">
@@ -154,19 +154,19 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Returns the icon [Texture2D] at [code]name[/code] if the theme has [code]type[/code].
+				Returns the icon [Texture2D] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_icon_list" qualifiers="const">
 			<return type="PackedStringArray">
 			</return>
-			<argument index="0" name="type" type="String">
+			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the icons as a [PackedStringArray] filled with each [Texture2D]'s name, for use in [method get_icon], if the theme has [code]type[/code].
+				Returns all the icons as a [PackedStringArray] filled with each [Texture2D]'s name, for use in [method get_icon], if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_stylebox" qualifiers="const">
@@ -174,35 +174,35 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Returns the icon [StyleBox] at [code]name[/code] if the theme has [code]type[/code].
+				Returns the icon [StyleBox] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_stylebox_list" qualifiers="const">
 			<return type="PackedStringArray">
 			</return>
-			<argument index="0" name="type" type="String">
+			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the [StyleBox]s as a [PackedStringArray] filled with each [StyleBox]'s name, for use in [method get_stylebox], if the theme has [code]type[/code].
+				Returns all the [StyleBox]s as a [PackedStringArray] filled with each [StyleBox]'s name, for use in [method get_stylebox], if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_stylebox_types" qualifiers="const">
 			<return type="PackedStringArray">
 			</return>
 			<description>
-				Returns all the [StyleBox] types as a [PackedStringArray] filled with each [StyleBox]'s type, for use in [method get_stylebox] and/or [method get_stylebox_list], if the theme has [code]type[/code].
+				Returns all the [StyleBox] types as a [PackedStringArray] filled with each [StyleBox]'s type, for use in [method get_stylebox] and/or [method get_stylebox_list], if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_type_list" qualifiers="const">
 			<return type="PackedStringArray">
 			</return>
-			<argument index="0" name="type" type="String">
+			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the types in [code]type[/code] as a [PackedStringArray] for use in any of the [code]get_*[/code] functions, if the theme has [code]type[/code].
+				Returns all the types in [code]node_type[/code] as a [PackedStringArray] for use in any of the [code]get_*[/code] functions, if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="has_color" qualifiers="const">
@@ -210,11 +210,11 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Returns [code]true[/code] if [Color] with [code]name[/code] is in [code]type[/code].
-				Returns [code]false[/code] if the theme does not have [code]type[/code].
+				Returns [code]true[/code] if [Color] with [code]name[/code] is in [code]node_type[/code].
+				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="has_constant" qualifiers="const">
@@ -222,11 +222,11 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Returns [code]true[/code] if constant with [code]name[/code] is in [code]type[/code].
-				Returns [code]false[/code] if the theme does not have [code]type[/code].
+				Returns [code]true[/code] if constant with [code]name[/code] is in [code]node_type[/code].
+				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="has_font" qualifiers="const">
@@ -234,11 +234,11 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Returns [code]true[/code] if [Font] with [code]name[/code] is in [code]type[/code].
-				Returns [code]false[/code] if the theme does not have [code]type[/code].
+				Returns [code]true[/code] if [Font] with [code]name[/code] is in [code]node_type[/code].
+				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="has_icon" qualifiers="const">
@@ -246,11 +246,11 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Returns [code]true[/code] if icon [Texture2D] with [code]name[/code] is in [code]type[/code].
-				Returns [code]false[/code] if the theme does not have [code]type[/code].
+				Returns [code]true[/code] if icon [Texture2D] with [code]name[/code] is in [code]node_type[/code].
+				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="has_stylebox" qualifiers="const">
@@ -258,11 +258,11 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<description>
-				Returns [code]true[/code] if [StyleBox] with [code]name[/code] is in [code]type[/code].
-				Returns [code]false[/code] if the theme does not have [code]type[/code].
+				Returns [code]true[/code] if [StyleBox] with [code]name[/code] is in [code]node_type[/code].
+				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="set_color">
@@ -270,13 +270,13 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<argument index="2" name="color" type="Color">
 			</argument>
 			<description>
-				Sets the theme's [Color] to [code]color[/code] at [code]name[/code] in [code]type[/code].
-				Does nothing if the theme does not have [code]type[/code].
+				Sets the theme's [Color] to [code]color[/code] at [code]name[/code] in [code]node_type[/code].
+				Does nothing if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="set_constant">
@@ -284,13 +284,13 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<argument index="2" name="constant" type="int">
 			</argument>
 			<description>
-				Sets the theme's constant to [code]constant[/code] at [code]name[/code] in [code]type[/code].
-				Does nothing if the theme does not have [code]type[/code].
+				Sets the theme's constant to [code]constant[/code] at [code]name[/code] in [code]node_type[/code].
+				Does nothing if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="set_font">
@@ -298,13 +298,13 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<argument index="2" name="font" type="Font">
 			</argument>
 			<description>
-				Sets the theme's [Font] to [code]font[/code] at [code]name[/code] in [code]type[/code].
-				Does nothing if the theme does not have [code]type[/code].
+				Sets the theme's [Font] to [code]font[/code] at [code]name[/code] in [code]node_type[/code].
+				Does nothing if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="set_icon">
@@ -312,13 +312,13 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<argument index="2" name="texture" type="Texture2D">
 			</argument>
 			<description>
-				Sets the theme's icon [Texture2D] to [code]texture[/code] at [code]name[/code] in [code]type[/code].
-				Does nothing if the theme does not have [code]type[/code].
+				Sets the theme's icon [Texture2D] to [code]texture[/code] at [code]name[/code] in [code]node_type[/code].
+				Does nothing if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="set_stylebox">
@@ -326,13 +326,13 @@
 			</return>
 			<argument index="0" name="name" type="StringName">
 			</argument>
-			<argument index="1" name="type" type="StringName">
+			<argument index="1" name="node_type" type="StringName">
 			</argument>
 			<argument index="2" name="texture" type="StyleBox">
 			</argument>
 			<description>
-				Sets theme's [StyleBox] to [code]stylebox[/code] at [code]name[/code] in [code]type[/code].
-				Does nothing if the theme does not have [code]type[/code].
+				Sets theme's [StyleBox] to [code]stylebox[/code] at [code]name[/code] in [code]node_type[/code].
+				Does nothing if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 	</methods>

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -728,13 +728,13 @@ Size2 Control::get_minimum_size() const {
 }
 
 template <class T>
-bool Control::_find_theme_item(Control *p_theme_owner, Window *p_theme_owner_window, T &r_ret, T (Theme::*get_func)(const StringName &, const StringName &) const, bool (Theme::*has_func)(const StringName &, const StringName &) const, const StringName &p_name, const StringName &p_type) {
+bool Control::_find_theme_item(Control *p_theme_owner, Window *p_theme_owner_window, T &r_ret, T (Theme::*get_func)(const StringName &, const StringName &) const, bool (Theme::*has_func)(const StringName &, const StringName &) const, const StringName &p_name, const StringName &p_node_type) {
 	// try with custom themes
 	Control *theme_owner = p_theme_owner;
 	Window *theme_owner_window = p_theme_owner_window;
 
 	while (theme_owner || theme_owner_window) {
-		StringName class_name = p_type;
+		StringName class_name = p_node_type;
 
 		while (class_name != StringName()) {
 			if (theme_owner && (theme_owner->data.theme.operator->()->*has_func)(p_name, class_name)) {
@@ -771,13 +771,13 @@ bool Control::_find_theme_item(Control *p_theme_owner, Window *p_theme_owner_win
 	return false;
 }
 
-bool Control::_has_theme_item(Control *p_theme_owner, Window *p_theme_owner_window, bool (Theme::*has_func)(const StringName &, const StringName &) const, const StringName &p_name, const StringName &p_type) {
+bool Control::_has_theme_item(Control *p_theme_owner, Window *p_theme_owner_window, bool (Theme::*has_func)(const StringName &, const StringName &) const, const StringName &p_name, const StringName &p_node_type) {
 	// try with custom themes
 	Control *theme_owner = p_theme_owner;
 	Window *theme_owner_window = p_theme_owner_window;
 
 	while (theme_owner || theme_owner_window) {
-		StringName class_name = p_type;
+		StringName class_name = p_node_type;
 
 		while (class_name != StringName()) {
 			if (theme_owner && (theme_owner->data.theme.operator->()->*has_func)(p_name, class_name)) {
@@ -812,176 +812,176 @@ bool Control::_has_theme_item(Control *p_theme_owner, Window *p_theme_owner_wind
 	return false;
 }
 
-Ref<Texture2D> Control::get_theme_icon(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+Ref<Texture2D> Control::get_theme_icon(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		const Ref<Texture2D> *tex = data.icon_override.getptr(p_name);
 		if (tex) {
 			return *tex;
 		}
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	return get_icons(data.theme_owner, data.theme_owner_window, p_name, type);
 }
 
-Ref<Texture2D> Control::get_icons(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
+Ref<Texture2D> Control::get_icons(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type) {
 	Ref<Texture2D> icon;
 
-	if (_find_theme_item(p_theme_owner, p_theme_owner_window, icon, &Theme::get_icon, &Theme::has_icon, p_name, p_type)) {
+	if (_find_theme_item(p_theme_owner, p_theme_owner_window, icon, &Theme::get_icon, &Theme::has_icon, p_name, p_node_type)) {
 		return icon;
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_icon(p_name, p_type)) {
-			return Theme::get_project_default()->get_icon(p_name, p_type);
+		if (Theme::get_project_default()->has_icon(p_name, p_node_type)) {
+			return Theme::get_project_default()->get_icon(p_name, p_node_type);
 		}
 	}
 
-	return Theme::get_default()->get_icon(p_name, p_type);
+	return Theme::get_default()->get_icon(p_name, p_node_type);
 }
 
-Ref<Shader> Control::get_theme_shader(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+Ref<Shader> Control::get_theme_shader(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		const Ref<Shader> *sdr = data.shader_override.getptr(p_name);
 		if (sdr) {
 			return *sdr;
 		}
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	return get_shaders(data.theme_owner, data.theme_owner_window, p_name, type);
 }
 
-Ref<Shader> Control::get_shaders(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
+Ref<Shader> Control::get_shaders(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type) {
 	Ref<Shader> shader;
 
-	if (_find_theme_item(p_theme_owner, p_theme_owner_window, shader, &Theme::get_shader, &Theme::has_shader, p_name, p_type)) {
+	if (_find_theme_item(p_theme_owner, p_theme_owner_window, shader, &Theme::get_shader, &Theme::has_shader, p_name, p_node_type)) {
 		return shader;
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_shader(p_name, p_type)) {
-			return Theme::get_project_default()->get_shader(p_name, p_type);
+		if (Theme::get_project_default()->has_shader(p_name, p_node_type)) {
+			return Theme::get_project_default()->get_shader(p_name, p_node_type);
 		}
 	}
 
-	return Theme::get_default()->get_shader(p_name, p_type);
+	return Theme::get_default()->get_shader(p_name, p_node_type);
 }
 
-Ref<StyleBox> Control::get_theme_stylebox(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+Ref<StyleBox> Control::get_theme_stylebox(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		const Ref<StyleBox> *style = data.style_override.getptr(p_name);
 		if (style) {
 			return *style;
 		}
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	return get_styleboxs(data.theme_owner, data.theme_owner_window, p_name, type);
 }
 
-Ref<StyleBox> Control::get_styleboxs(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
+Ref<StyleBox> Control::get_styleboxs(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type) {
 	Ref<StyleBox> stylebox;
 
-	if (_find_theme_item(p_theme_owner, p_theme_owner_window, stylebox, &Theme::get_stylebox, &Theme::has_stylebox, p_name, p_type)) {
+	if (_find_theme_item(p_theme_owner, p_theme_owner_window, stylebox, &Theme::get_stylebox, &Theme::has_stylebox, p_name, p_node_type)) {
 		return stylebox;
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_stylebox(p_name, p_type)) {
-			return Theme::get_project_default()->get_stylebox(p_name, p_type);
+		if (Theme::get_project_default()->has_stylebox(p_name, p_node_type)) {
+			return Theme::get_project_default()->get_stylebox(p_name, p_node_type);
 		}
 	}
 
-	return Theme::get_default()->get_stylebox(p_name, p_type);
+	return Theme::get_default()->get_stylebox(p_name, p_node_type);
 }
 
-Ref<Font> Control::get_theme_font(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+Ref<Font> Control::get_theme_font(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		const Ref<Font> *font = data.font_override.getptr(p_name);
 		if (font) {
 			return *font;
 		}
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	return get_fonts(data.theme_owner, data.theme_owner_window, p_name, type);
 }
 
-Ref<Font> Control::get_fonts(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
+Ref<Font> Control::get_fonts(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type) {
 	Ref<Font> font;
 
-	if (_find_theme_item(p_theme_owner, p_theme_owner_window, font, &Theme::get_font, &Theme::has_font, p_name, p_type)) {
+	if (_find_theme_item(p_theme_owner, p_theme_owner_window, font, &Theme::get_font, &Theme::has_font, p_name, p_node_type)) {
 		return font;
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_font(p_name, p_type)) {
-			return Theme::get_project_default()->get_font(p_name, p_type);
+		if (Theme::get_project_default()->has_font(p_name, p_node_type)) {
+			return Theme::get_project_default()->get_font(p_name, p_node_type);
 		}
 	}
 
-	return Theme::get_default()->get_font(p_name, p_type);
+	return Theme::get_default()->get_font(p_name, p_node_type);
 }
 
-Color Control::get_theme_color(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+Color Control::get_theme_color(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		const Color *color = data.color_override.getptr(p_name);
 		if (color) {
 			return *color;
 		}
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	return get_colors(data.theme_owner, data.theme_owner_window, p_name, type);
 }
 
-Color Control::get_colors(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
+Color Control::get_colors(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type) {
 	Color color;
 
-	if (_find_theme_item(p_theme_owner, p_theme_owner_window, color, &Theme::get_color, &Theme::has_color, p_name, p_type)) {
+	if (_find_theme_item(p_theme_owner, p_theme_owner_window, color, &Theme::get_color, &Theme::has_color, p_name, p_node_type)) {
 		return color;
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_color(p_name, p_type)) {
-			return Theme::get_project_default()->get_color(p_name, p_type);
+		if (Theme::get_project_default()->has_color(p_name, p_node_type)) {
+			return Theme::get_project_default()->get_color(p_name, p_node_type);
 		}
 	}
-	return Theme::get_default()->get_color(p_name, p_type);
+	return Theme::get_default()->get_color(p_name, p_node_type);
 }
 
-int Control::get_theme_constant(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+int Control::get_theme_constant(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		const int *constant = data.constant_override.getptr(p_name);
 		if (constant) {
 			return *constant;
 		}
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	return get_constants(data.theme_owner, data.theme_owner_window, p_name, type);
 }
 
-int Control::get_constants(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
+int Control::get_constants(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type) {
 	int constant;
 
-	if (_find_theme_item(p_theme_owner, p_theme_owner_window, constant, &Theme::get_constant, &Theme::has_constant, p_name, p_type)) {
+	if (_find_theme_item(p_theme_owner, p_theme_owner_window, constant, &Theme::get_constant, &Theme::has_constant, p_name, p_node_type)) {
 		return constant;
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_constant(p_name, p_type)) {
-			return Theme::get_project_default()->get_constant(p_name, p_type);
+		if (Theme::get_project_default()->has_constant(p_name, p_node_type)) {
+			return Theme::get_project_default()->get_constant(p_name, p_node_type);
 		}
 	}
-	return Theme::get_default()->get_constant(p_name, p_type);
+	return Theme::get_default()->get_constant(p_name, p_node_type);
 }
 
 bool Control::has_theme_icon_override(const StringName &p_name) const {
@@ -1014,154 +1014,154 @@ bool Control::has_theme_constant_override(const StringName &p_name) const {
 	return constant != nullptr;
 }
 
-bool Control::has_theme_icon(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+bool Control::has_theme_icon(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		if (has_theme_icon_override(p_name)) {
 			return true;
 		}
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	return has_icons(data.theme_owner, data.theme_owner_window, p_name, type);
 }
 
-bool Control::has_icons(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
-	if (_has_theme_item(p_theme_owner, p_theme_owner_window, &Theme::has_icon, p_name, p_type)) {
+bool Control::has_icons(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type) {
+	if (_has_theme_item(p_theme_owner, p_theme_owner_window, &Theme::has_icon, p_name, p_node_type)) {
 		return true;
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_color(p_name, p_type)) {
+		if (Theme::get_project_default()->has_color(p_name, p_node_type)) {
 			return true;
 		}
 	}
-	return Theme::get_default()->has_icon(p_name, p_type);
+	return Theme::get_default()->has_icon(p_name, p_node_type);
 }
 
-bool Control::has_theme_shader(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+bool Control::has_theme_shader(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		if (has_theme_shader_override(p_name)) {
 			return true;
 		}
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	return has_shaders(data.theme_owner, data.theme_owner_window, p_name, type);
 }
 
-bool Control::has_shaders(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
-	if (_has_theme_item(p_theme_owner, p_theme_owner_window, &Theme::has_shader, p_name, p_type)) {
+bool Control::has_shaders(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type) {
+	if (_has_theme_item(p_theme_owner, p_theme_owner_window, &Theme::has_shader, p_name, p_node_type)) {
 		return true;
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_shader(p_name, p_type)) {
+		if (Theme::get_project_default()->has_shader(p_name, p_node_type)) {
 			return true;
 		}
 	}
-	return Theme::get_default()->has_shader(p_name, p_type);
+	return Theme::get_default()->has_shader(p_name, p_node_type);
 }
 
-bool Control::has_theme_stylebox(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+bool Control::has_theme_stylebox(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		if (has_theme_stylebox_override(p_name)) {
 			return true;
 		}
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	return has_styleboxs(data.theme_owner, data.theme_owner_window, p_name, type);
 }
 
-bool Control::has_styleboxs(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
-	if (_has_theme_item(p_theme_owner, p_theme_owner_window, &Theme::has_stylebox, p_name, p_type)) {
+bool Control::has_styleboxs(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type) {
+	if (_has_theme_item(p_theme_owner, p_theme_owner_window, &Theme::has_stylebox, p_name, p_node_type)) {
 		return true;
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_stylebox(p_name, p_type)) {
+		if (Theme::get_project_default()->has_stylebox(p_name, p_node_type)) {
 			return true;
 		}
 	}
-	return Theme::get_default()->has_stylebox(p_name, p_type);
+	return Theme::get_default()->has_stylebox(p_name, p_node_type);
 }
 
-bool Control::has_theme_font(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+bool Control::has_theme_font(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		if (has_theme_font_override(p_name)) {
 			return true;
 		}
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	return has_fonts(data.theme_owner, data.theme_owner_window, p_name, type);
 }
 
-bool Control::has_fonts(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
-	if (_has_theme_item(p_theme_owner, p_theme_owner_window, &Theme::has_font, p_name, p_type)) {
+bool Control::has_fonts(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type) {
+	if (_has_theme_item(p_theme_owner, p_theme_owner_window, &Theme::has_font, p_name, p_node_type)) {
 		return true;
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_font(p_name, p_type)) {
+		if (Theme::get_project_default()->has_font(p_name, p_node_type)) {
 			return true;
 		}
 	}
-	return Theme::get_default()->has_font(p_name, p_type);
+	return Theme::get_default()->has_font(p_name, p_node_type);
 }
 
-bool Control::has_theme_color(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+bool Control::has_theme_color(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		if (has_theme_color_override(p_name)) {
 			return true;
 		}
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	return has_colors(data.theme_owner, data.theme_owner_window, p_name, type);
 }
 
-bool Control::has_colors(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
-	if (_has_theme_item(p_theme_owner, p_theme_owner_window, &Theme::has_color, p_name, p_type)) {
+bool Control::has_colors(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type) {
+	if (_has_theme_item(p_theme_owner, p_theme_owner_window, &Theme::has_color, p_name, p_node_type)) {
 		return true;
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_color(p_name, p_type)) {
+		if (Theme::get_project_default()->has_color(p_name, p_node_type)) {
 			return true;
 		}
 	}
-	return Theme::get_default()->has_color(p_name, p_type);
+	return Theme::get_default()->has_color(p_name, p_node_type);
 }
 
-bool Control::has_theme_constant(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+bool Control::has_theme_constant(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		if (has_theme_constant_override(p_name)) {
 			return true;
 		}
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
-	return has_constants(data.theme_owner, data.theme_owner_window, p_name, p_type);
+	return has_constants(data.theme_owner, data.theme_owner_window, p_name, p_node_type);
 }
 
-bool Control::has_constants(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type) {
-	if (_has_theme_item(p_theme_owner, p_theme_owner_window, &Theme::has_constant, p_name, p_type)) {
+bool Control::has_constants(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type) {
+	if (_has_theme_item(p_theme_owner, p_theme_owner_window, &Theme::has_constant, p_name, p_node_type)) {
 		return true;
 	}
 
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_constant(p_name, p_type)) {
+		if (Theme::get_project_default()->has_constant(p_name, p_node_type)) {
 			return true;
 		}
 	}
-	return Theme::get_default()->has_constant(p_name, p_type);
+	return Theme::get_default()->has_constant(p_name, p_node_type);
 }
 
 Rect2 Control::get_parent_anchorable_rect() const {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -236,23 +236,23 @@ private:
 	static void _propagate_theme_changed(Node *p_at, Control *p_owner, Window *p_owner_window, bool p_assign = true);
 
 	template <class T>
-	_FORCE_INLINE_ static bool _find_theme_item(Control *p_theme_owner, Window *p_theme_owner_window, T &, T (Theme::*get_func)(const StringName &, const StringName &) const, bool (Theme::*has_func)(const StringName &, const StringName &) const, const StringName &p_name, const StringName &p_type);
+	_FORCE_INLINE_ static bool _find_theme_item(Control *p_theme_owner, Window *p_theme_owner_window, T &, T (Theme::*get_func)(const StringName &, const StringName &) const, bool (Theme::*has_func)(const StringName &, const StringName &) const, const StringName &p_name, const StringName &p_node_type);
 
-	_FORCE_INLINE_ static bool _has_theme_item(Control *p_theme_owner, Window *p_theme_owner_window, bool (Theme::*has_func)(const StringName &, const StringName &) const, const StringName &p_name, const StringName &p_type);
+	_FORCE_INLINE_ static bool _has_theme_item(Control *p_theme_owner, Window *p_theme_owner_window, bool (Theme::*has_func)(const StringName &, const StringName &) const, const StringName &p_name, const StringName &p_node_type);
 
-	static Ref<Texture2D> get_icons(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
-	static Ref<Shader> get_shaders(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
-	static Ref<StyleBox> get_styleboxs(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
-	static Ref<Font> get_fonts(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
-	static Color get_colors(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
-	static int get_constants(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
+	static Ref<Texture2D> get_icons(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type = StringName());
+	static Ref<Shader> get_shaders(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type = StringName());
+	static Ref<StyleBox> get_styleboxs(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type = StringName());
+	static Ref<Font> get_fonts(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type = StringName());
+	static Color get_colors(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type = StringName());
+	static int get_constants(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type = StringName());
 
-	static bool has_icons(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
-	static bool has_shaders(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
-	static bool has_styleboxs(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
-	static bool has_fonts(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
-	static bool has_colors(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
-	static bool has_constants(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_type = StringName());
+	static bool has_icons(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type = StringName());
+	static bool has_shaders(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type = StringName());
+	static bool has_styleboxs(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type = StringName());
+	static bool has_fonts(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type = StringName());
+	static bool has_colors(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type = StringName());
+	static bool has_constants(Control *p_theme_owner, Window *p_theme_owner_window, const StringName &p_name, const StringName &p_node_type = StringName());
 
 protected:
 	virtual void add_child_notify(Node *p_child) override;
@@ -429,12 +429,12 @@ public:
 	void add_theme_color_override(const StringName &p_name, const Color &p_color);
 	void add_theme_constant_override(const StringName &p_name, int p_constant);
 
-	Ref<Texture2D> get_theme_icon(const StringName &p_name, const StringName &p_type = StringName()) const;
-	Ref<Shader> get_theme_shader(const StringName &p_name, const StringName &p_type = StringName()) const;
-	Ref<StyleBox> get_theme_stylebox(const StringName &p_name, const StringName &p_type = StringName()) const;
-	Ref<Font> get_theme_font(const StringName &p_name, const StringName &p_type = StringName()) const;
-	Color get_theme_color(const StringName &p_name, const StringName &p_type = StringName()) const;
-	int get_theme_constant(const StringName &p_name, const StringName &p_type = StringName()) const;
+	Ref<Texture2D> get_theme_icon(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	Ref<Shader> get_theme_shader(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	Ref<StyleBox> get_theme_stylebox(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	Ref<Font> get_theme_font(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	Color get_theme_color(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	int get_theme_constant(const StringName &p_name, const StringName &p_node_type = StringName()) const;
 
 	bool has_theme_icon_override(const StringName &p_name) const;
 	bool has_theme_shader_override(const StringName &p_name) const;
@@ -443,12 +443,12 @@ public:
 	bool has_theme_color_override(const StringName &p_name) const;
 	bool has_theme_constant_override(const StringName &p_name) const;
 
-	bool has_theme_icon(const StringName &p_name, const StringName &p_type = StringName()) const;
-	bool has_theme_shader(const StringName &p_name, const StringName &p_type = StringName()) const;
-	bool has_theme_stylebox(const StringName &p_name, const StringName &p_type = StringName()) const;
-	bool has_theme_font(const StringName &p_name, const StringName &p_type = StringName()) const;
-	bool has_theme_color(const StringName &p_name, const StringName &p_type = StringName()) const;
-	bool has_theme_constant(const StringName &p_name, const StringName &p_type = StringName()) const;
+	bool has_theme_icon(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	bool has_theme_shader(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	bool has_theme_stylebox(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	bool has_theme_font(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	bool has_theme_color(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	bool has_theme_constant(const StringName &p_name, const StringName &p_node_type = StringName()) const;
 
 	/* TOOLTIP */
 

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -36,11 +36,11 @@ void Theme::_emit_theme_changed() {
 	emit_changed();
 }
 
-Vector<String> Theme::_get_icon_list(const String &p_type) const {
+Vector<String> Theme::_get_icon_list(const String &p_node_type) const {
 	Vector<String> ilret;
 	List<StringName> il;
 
-	get_icon_list(p_type, &il);
+	get_icon_list(p_node_type, &il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -51,11 +51,11 @@ Vector<String> Theme::_get_icon_list(const String &p_type) const {
 	return ilret;
 }
 
-Vector<String> Theme::_get_stylebox_list(const String &p_type) const {
+Vector<String> Theme::_get_stylebox_list(const String &p_node_type) const {
 	Vector<String> ilret;
 	List<StringName> il;
 
-	get_stylebox_list(p_type, &il);
+	get_stylebox_list(p_node_type, &il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -81,11 +81,11 @@ Vector<String> Theme::_get_stylebox_types() const {
 	return ilret;
 }
 
-Vector<String> Theme::_get_font_list(const String &p_type) const {
+Vector<String> Theme::_get_font_list(const String &p_node_type) const {
 	Vector<String> ilret;
 	List<StringName> il;
 
-	get_font_list(p_type, &il);
+	get_font_list(p_node_type, &il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -96,11 +96,11 @@ Vector<String> Theme::_get_font_list(const String &p_type) const {
 	return ilret;
 }
 
-Vector<String> Theme::_get_color_list(const String &p_type) const {
+Vector<String> Theme::_get_color_list(const String &p_node_type) const {
 	Vector<String> ilret;
 	List<StringName> il;
 
-	get_color_list(p_type, &il);
+	get_color_list(p_node_type, &il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -111,11 +111,11 @@ Vector<String> Theme::_get_color_list(const String &p_type) const {
 	return ilret;
 }
 
-Vector<String> Theme::_get_constant_list(const String &p_type) const {
+Vector<String> Theme::_get_constant_list(const String &p_node_type) const {
 	Vector<String> ilret;
 	List<StringName> il;
 
-	get_constant_list(p_type, &il);
+	get_constant_list(p_node_type, &il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -126,7 +126,7 @@ Vector<String> Theme::_get_constant_list(const String &p_type) const {
 	return ilret;
 }
 
-Vector<String> Theme::_get_type_list(const String &p_type) const {
+Vector<String> Theme::_get_type_list(const String &p_node_type) const {
 	Vector<String> ilret;
 	List<StringName> il;
 
@@ -325,19 +325,19 @@ void Theme::set_default_font(const Ref<Font> &p_font) {
 	default_font = p_font;
 }
 
-void Theme::set_icon(const StringName &p_name, const StringName &p_type, const Ref<Texture2D> &p_icon) {
+void Theme::set_icon(const StringName &p_name, const StringName &p_node_type, const Ref<Texture2D> &p_icon) {
 	//ERR_FAIL_COND(p_icon.is_null());
 
-	bool new_value = !icon_map.has(p_type) || !icon_map[p_type].has(p_name);
+	bool new_value = !icon_map.has(p_node_type) || !icon_map[p_node_type].has(p_name);
 
-	if (icon_map[p_type].has(p_name) && icon_map[p_type][p_name].is_valid()) {
-		icon_map[p_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	if (icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid()) {
+		icon_map[p_node_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
-	icon_map[p_type][p_name] = p_icon;
+	icon_map[p_node_type][p_name] = p_icon;
 
 	if (p_icon.is_valid()) {
-		icon_map[p_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
+		icon_map[p_node_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	if (new_value) {
@@ -346,50 +346,50 @@ void Theme::set_icon(const StringName &p_name, const StringName &p_type, const R
 	}
 }
 
-Ref<Texture2D> Theme::get_icon(const StringName &p_name, const StringName &p_type) const {
-	if (icon_map.has(p_type) && icon_map[p_type].has(p_name) && icon_map[p_type][p_name].is_valid()) {
-		return icon_map[p_type][p_name];
+Ref<Texture2D> Theme::get_icon(const StringName &p_name, const StringName &p_node_type) const {
+	if (icon_map.has(p_node_type) && icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid()) {
+		return icon_map[p_node_type][p_name];
 	} else {
 		return default_icon;
 	}
 }
 
-bool Theme::has_icon(const StringName &p_name, const StringName &p_type) const {
-	return (icon_map.has(p_type) && icon_map[p_type].has(p_name) && icon_map[p_type][p_name].is_valid());
+bool Theme::has_icon(const StringName &p_name, const StringName &p_node_type) const {
+	return (icon_map.has(p_node_type) && icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid());
 }
 
-void Theme::clear_icon(const StringName &p_name, const StringName &p_type) {
-	ERR_FAIL_COND(!icon_map.has(p_type));
-	ERR_FAIL_COND(!icon_map[p_type].has(p_name));
+void Theme::clear_icon(const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND(!icon_map.has(p_node_type));
+	ERR_FAIL_COND(!icon_map[p_node_type].has(p_name));
 
-	if (icon_map[p_type][p_name].is_valid()) {
-		icon_map[p_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	if (icon_map[p_node_type][p_name].is_valid()) {
+		icon_map[p_node_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
-	icon_map[p_type].erase(p_name);
+	icon_map[p_node_type].erase(p_name);
 
 	_change_notify();
 	emit_changed();
 }
 
-void Theme::get_icon_list(StringName p_type, List<StringName> *p_list) const {
+void Theme::get_icon_list(StringName p_node_type, List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
-	if (!icon_map.has(p_type)) {
+	if (!icon_map.has(p_node_type)) {
 		return;
 	}
 
 	const StringName *key = nullptr;
 
-	while ((key = icon_map[p_type].next(key))) {
+	while ((key = icon_map[p_node_type].next(key))) {
 		p_list->push_back(*key);
 	}
 }
 
-void Theme::set_shader(const StringName &p_name, const StringName &p_type, const Ref<Shader> &p_shader) {
-	bool new_value = !shader_map.has(p_type) || !shader_map[p_type].has(p_name);
+void Theme::set_shader(const StringName &p_name, const StringName &p_node_type, const Ref<Shader> &p_shader) {
+	bool new_value = !shader_map.has(p_node_type) || !shader_map[p_node_type].has(p_name);
 
-	shader_map[p_type][p_name] = p_shader;
+	shader_map[p_node_type][p_name] = p_shader;
 
 	if (new_value) {
 		_change_notify();
@@ -397,54 +397,54 @@ void Theme::set_shader(const StringName &p_name, const StringName &p_type, const
 	}
 }
 
-Ref<Shader> Theme::get_shader(const StringName &p_name, const StringName &p_type) const {
-	if (shader_map.has(p_type) && shader_map[p_type].has(p_name) && shader_map[p_type][p_name].is_valid()) {
-		return shader_map[p_type][p_name];
+Ref<Shader> Theme::get_shader(const StringName &p_name, const StringName &p_node_type) const {
+	if (shader_map.has(p_node_type) && shader_map[p_node_type].has(p_name) && shader_map[p_node_type][p_name].is_valid()) {
+		return shader_map[p_node_type][p_name];
 	} else {
 		return nullptr;
 	}
 }
 
-bool Theme::has_shader(const StringName &p_name, const StringName &p_type) const {
-	return (shader_map.has(p_type) && shader_map[p_type].has(p_name) && shader_map[p_type][p_name].is_valid());
+bool Theme::has_shader(const StringName &p_name, const StringName &p_node_type) const {
+	return (shader_map.has(p_node_type) && shader_map[p_node_type].has(p_name) && shader_map[p_node_type][p_name].is_valid());
 }
 
-void Theme::clear_shader(const StringName &p_name, const StringName &p_type) {
-	ERR_FAIL_COND(!shader_map.has(p_type));
-	ERR_FAIL_COND(!shader_map[p_type].has(p_name));
+void Theme::clear_shader(const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND(!shader_map.has(p_node_type));
+	ERR_FAIL_COND(!shader_map[p_node_type].has(p_name));
 
-	shader_map[p_type].erase(p_name);
+	shader_map[p_node_type].erase(p_name);
 	_change_notify();
 	emit_changed();
 }
 
-void Theme::get_shader_list(const StringName &p_type, List<StringName> *p_list) const {
+void Theme::get_shader_list(const StringName &p_node_type, List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
-	if (!shader_map.has(p_type)) {
+	if (!shader_map.has(p_node_type)) {
 		return;
 	}
 
 	const StringName *key = nullptr;
 
-	while ((key = shader_map[p_type].next(key))) {
+	while ((key = shader_map[p_node_type].next(key))) {
 		p_list->push_back(*key);
 	}
 }
 
-void Theme::set_stylebox(const StringName &p_name, const StringName &p_type, const Ref<StyleBox> &p_style) {
+void Theme::set_stylebox(const StringName &p_name, const StringName &p_node_type, const Ref<StyleBox> &p_style) {
 	//ERR_FAIL_COND(p_style.is_null());
 
-	bool new_value = !style_map.has(p_type) || !style_map[p_type].has(p_name);
+	bool new_value = !style_map.has(p_node_type) || !style_map[p_node_type].has(p_name);
 
-	if (style_map[p_type].has(p_name) && style_map[p_type][p_name].is_valid()) {
-		style_map[p_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	if (style_map[p_node_type].has(p_name) && style_map[p_node_type][p_name].is_valid()) {
+		style_map[p_node_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
-	style_map[p_type][p_name] = p_style;
+	style_map[p_node_type][p_name] = p_style;
 
 	if (p_style.is_valid()) {
-		style_map[p_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
+		style_map[p_node_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	if (new_value) {
@@ -453,42 +453,42 @@ void Theme::set_stylebox(const StringName &p_name, const StringName &p_type, con
 	emit_changed();
 }
 
-Ref<StyleBox> Theme::get_stylebox(const StringName &p_name, const StringName &p_type) const {
-	if (style_map.has(p_type) && style_map[p_type].has(p_name) && style_map[p_type][p_name].is_valid()) {
-		return style_map[p_type][p_name];
+Ref<StyleBox> Theme::get_stylebox(const StringName &p_name, const StringName &p_node_type) const {
+	if (style_map.has(p_node_type) && style_map[p_node_type].has(p_name) && style_map[p_node_type][p_name].is_valid()) {
+		return style_map[p_node_type][p_name];
 	} else {
 		return default_style;
 	}
 }
 
-bool Theme::has_stylebox(const StringName &p_name, const StringName &p_type) const {
-	return (style_map.has(p_type) && style_map[p_type].has(p_name) && style_map[p_type][p_name].is_valid());
+bool Theme::has_stylebox(const StringName &p_name, const StringName &p_node_type) const {
+	return (style_map.has(p_node_type) && style_map[p_node_type].has(p_name) && style_map[p_node_type][p_name].is_valid());
 }
 
-void Theme::clear_stylebox(const StringName &p_name, const StringName &p_type) {
-	ERR_FAIL_COND(!style_map.has(p_type));
-	ERR_FAIL_COND(!style_map[p_type].has(p_name));
+void Theme::clear_stylebox(const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND(!style_map.has(p_node_type));
+	ERR_FAIL_COND(!style_map[p_node_type].has(p_name));
 
-	if (style_map[p_type][p_name].is_valid()) {
-		style_map[p_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	if (style_map[p_node_type][p_name].is_valid()) {
+		style_map[p_node_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
-	style_map[p_type].erase(p_name);
+	style_map[p_node_type].erase(p_name);
 
 	_change_notify();
 	emit_changed();
 }
 
-void Theme::get_stylebox_list(StringName p_type, List<StringName> *p_list) const {
+void Theme::get_stylebox_list(StringName p_node_type, List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
-	if (!style_map.has(p_type)) {
+	if (!style_map.has(p_node_type)) {
 		return;
 	}
 
 	const StringName *key = nullptr;
 
-	while ((key = style_map[p_type].next(key))) {
+	while ((key = style_map[p_node_type].next(key))) {
 		p_list->push_back(*key);
 	}
 }
@@ -502,19 +502,19 @@ void Theme::get_stylebox_types(List<StringName> *p_list) const {
 	}
 }
 
-void Theme::set_font(const StringName &p_name, const StringName &p_type, const Ref<Font> &p_font) {
+void Theme::set_font(const StringName &p_name, const StringName &p_node_type, const Ref<Font> &p_font) {
 	//ERR_FAIL_COND(p_font.is_null());
 
-	bool new_value = !font_map.has(p_type) || !font_map[p_type].has(p_name);
+	bool new_value = !font_map.has(p_node_type) || !font_map[p_node_type].has(p_name);
 
-	if (font_map[p_type][p_name].is_valid()) {
-		font_map[p_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	if (font_map[p_node_type][p_name].is_valid()) {
+		font_map[p_node_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
-	font_map[p_type][p_name] = p_font;
+	font_map[p_node_type][p_name] = p_font;
 
 	if (p_font.is_valid()) {
-		font_map[p_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
+		font_map[p_node_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	if (new_value) {
@@ -523,9 +523,9 @@ void Theme::set_font(const StringName &p_name, const StringName &p_type, const R
 	}
 }
 
-Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_type) const {
-	if (font_map.has(p_type) && font_map[p_type].has(p_name) && font_map[p_type][p_name].is_valid()) {
-		return font_map[p_type][p_name];
+Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_node_type) const {
+	if (font_map.has(p_node_type) && font_map[p_node_type].has(p_name) && font_map[p_node_type][p_name].is_valid()) {
+		return font_map[p_node_type][p_name];
 	} else if (default_theme_font.is_valid()) {
 		return default_theme_font;
 	} else {
@@ -533,41 +533,41 @@ Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_type) co
 	}
 }
 
-bool Theme::has_font(const StringName &p_name, const StringName &p_type) const {
-	return (font_map.has(p_type) && font_map[p_type].has(p_name) && font_map[p_type][p_name].is_valid());
+bool Theme::has_font(const StringName &p_name, const StringName &p_node_type) const {
+	return (font_map.has(p_node_type) && font_map[p_node_type].has(p_name) && font_map[p_node_type][p_name].is_valid());
 }
 
-void Theme::clear_font(const StringName &p_name, const StringName &p_type) {
-	ERR_FAIL_COND(!font_map.has(p_type));
-	ERR_FAIL_COND(!font_map[p_type].has(p_name));
+void Theme::clear_font(const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND(!font_map.has(p_node_type));
+	ERR_FAIL_COND(!font_map[p_node_type].has(p_name));
 
-	if (font_map[p_type][p_name].is_valid()) {
-		font_map[p_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	if (font_map[p_node_type][p_name].is_valid()) {
+		font_map[p_node_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
-	font_map[p_type].erase(p_name);
+	font_map[p_node_type].erase(p_name);
 	_change_notify();
 	emit_changed();
 }
 
-void Theme::get_font_list(StringName p_type, List<StringName> *p_list) const {
+void Theme::get_font_list(StringName p_node_type, List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
-	if (!font_map.has(p_type)) {
+	if (!font_map.has(p_node_type)) {
 		return;
 	}
 
 	const StringName *key = nullptr;
 
-	while ((key = font_map[p_type].next(key))) {
+	while ((key = font_map[p_node_type].next(key))) {
 		p_list->push_back(*key);
 	}
 }
 
-void Theme::set_color(const StringName &p_name, const StringName &p_type, const Color &p_color) {
-	bool new_value = !color_map.has(p_type) || !color_map[p_type].has(p_name);
+void Theme::set_color(const StringName &p_name, const StringName &p_node_type, const Color &p_color) {
+	bool new_value = !color_map.has(p_node_type) || !color_map[p_node_type].has(p_name);
 
-	color_map[p_type][p_name] = p_color;
+	color_map[p_node_type][p_name] = p_color;
 
 	if (new_value) {
 		_change_notify();
@@ -575,44 +575,44 @@ void Theme::set_color(const StringName &p_name, const StringName &p_type, const 
 	}
 }
 
-Color Theme::get_color(const StringName &p_name, const StringName &p_type) const {
-	if (color_map.has(p_type) && color_map[p_type].has(p_name)) {
-		return color_map[p_type][p_name];
+Color Theme::get_color(const StringName &p_name, const StringName &p_node_type) const {
+	if (color_map.has(p_node_type) && color_map[p_node_type].has(p_name)) {
+		return color_map[p_node_type][p_name];
 	} else {
 		return Color();
 	}
 }
 
-bool Theme::has_color(const StringName &p_name, const StringName &p_type) const {
-	return (color_map.has(p_type) && color_map[p_type].has(p_name));
+bool Theme::has_color(const StringName &p_name, const StringName &p_node_type) const {
+	return (color_map.has(p_node_type) && color_map[p_node_type].has(p_name));
 }
 
-void Theme::clear_color(const StringName &p_name, const StringName &p_type) {
-	ERR_FAIL_COND(!color_map.has(p_type));
-	ERR_FAIL_COND(!color_map[p_type].has(p_name));
+void Theme::clear_color(const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND(!color_map.has(p_node_type));
+	ERR_FAIL_COND(!color_map[p_node_type].has(p_name));
 
-	color_map[p_type].erase(p_name);
+	color_map[p_node_type].erase(p_name);
 	_change_notify();
 	emit_changed();
 }
 
-void Theme::get_color_list(StringName p_type, List<StringName> *p_list) const {
+void Theme::get_color_list(StringName p_node_type, List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
-	if (!color_map.has(p_type)) {
+	if (!color_map.has(p_node_type)) {
 		return;
 	}
 
 	const StringName *key = nullptr;
 
-	while ((key = color_map[p_type].next(key))) {
+	while ((key = color_map[p_node_type].next(key))) {
 		p_list->push_back(*key);
 	}
 }
 
-void Theme::set_constant(const StringName &p_name, const StringName &p_type, int p_constant) {
-	bool new_value = !constant_map.has(p_type) || !constant_map[p_type].has(p_name);
-	constant_map[p_type][p_name] = p_constant;
+void Theme::set_constant(const StringName &p_name, const StringName &p_node_type, int p_constant) {
+	bool new_value = !constant_map.has(p_node_type) || !constant_map[p_node_type].has(p_name);
+	constant_map[p_node_type][p_name] = p_constant;
 
 	if (new_value) {
 		_change_notify();
@@ -620,37 +620,37 @@ void Theme::set_constant(const StringName &p_name, const StringName &p_type, int
 	}
 }
 
-int Theme::get_constant(const StringName &p_name, const StringName &p_type) const {
-	if (constant_map.has(p_type) && constant_map[p_type].has(p_name)) {
-		return constant_map[p_type][p_name];
+int Theme::get_constant(const StringName &p_name, const StringName &p_node_type) const {
+	if (constant_map.has(p_node_type) && constant_map[p_node_type].has(p_name)) {
+		return constant_map[p_node_type][p_name];
 	} else {
 		return 0;
 	}
 }
 
-bool Theme::has_constant(const StringName &p_name, const StringName &p_type) const {
-	return (constant_map.has(p_type) && constant_map[p_type].has(p_name));
+bool Theme::has_constant(const StringName &p_name, const StringName &p_node_type) const {
+	return (constant_map.has(p_node_type) && constant_map[p_node_type].has(p_name));
 }
 
-void Theme::clear_constant(const StringName &p_name, const StringName &p_type) {
-	ERR_FAIL_COND(!constant_map.has(p_type));
-	ERR_FAIL_COND(!constant_map[p_type].has(p_name));
+void Theme::clear_constant(const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND(!constant_map.has(p_node_type));
+	ERR_FAIL_COND(!constant_map[p_node_type].has(p_name));
 
-	constant_map[p_type].erase(p_name);
+	constant_map[p_node_type].erase(p_name);
 	_change_notify();
 	emit_changed();
 }
 
-void Theme::get_constant_list(StringName p_type, List<StringName> *p_list) const {
+void Theme::get_constant_list(StringName p_node_type, List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
-	if (!constant_map.has(p_type)) {
+	if (!constant_map.has(p_node_type)) {
 		return;
 	}
 
 	const StringName *key = nullptr;
 
-	while ((key = constant_map[p_type].next(key))) {
+	while ((key = constant_map[p_node_type].next(key))) {
 		p_list->push_back(*key);
 	}
 }
@@ -800,43 +800,43 @@ void Theme::get_type_list(List<StringName> *p_list) const {
 }
 
 void Theme::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_icon", "name", "type", "texture"), &Theme::set_icon);
-	ClassDB::bind_method(D_METHOD("get_icon", "name", "type"), &Theme::get_icon);
-	ClassDB::bind_method(D_METHOD("has_icon", "name", "type"), &Theme::has_icon);
-	ClassDB::bind_method(D_METHOD("clear_icon", "name", "type"), &Theme::clear_icon);
-	ClassDB::bind_method(D_METHOD("get_icon_list", "type"), &Theme::_get_icon_list);
+	ClassDB::bind_method(D_METHOD("set_icon", "name", "node_type", "texture"), &Theme::set_icon);
+	ClassDB::bind_method(D_METHOD("get_icon", "name", "node_type"), &Theme::get_icon);
+	ClassDB::bind_method(D_METHOD("has_icon", "name", "node_type"), &Theme::has_icon);
+	ClassDB::bind_method(D_METHOD("clear_icon", "name", "node_type"), &Theme::clear_icon);
+	ClassDB::bind_method(D_METHOD("get_icon_list", "node_type"), &Theme::_get_icon_list);
 
-	ClassDB::bind_method(D_METHOD("set_stylebox", "name", "type", "texture"), &Theme::set_stylebox);
-	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "type"), &Theme::get_stylebox);
-	ClassDB::bind_method(D_METHOD("has_stylebox", "name", "type"), &Theme::has_stylebox);
-	ClassDB::bind_method(D_METHOD("clear_stylebox", "name", "type"), &Theme::clear_stylebox);
-	ClassDB::bind_method(D_METHOD("get_stylebox_list", "type"), &Theme::_get_stylebox_list);
+	ClassDB::bind_method(D_METHOD("set_stylebox", "name", "node_type", "texture"), &Theme::set_stylebox);
+	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "node_type"), &Theme::get_stylebox);
+	ClassDB::bind_method(D_METHOD("has_stylebox", "name", "node_type"), &Theme::has_stylebox);
+	ClassDB::bind_method(D_METHOD("clear_stylebox", "name", "node_type"), &Theme::clear_stylebox);
+	ClassDB::bind_method(D_METHOD("get_stylebox_list", "node_type"), &Theme::_get_stylebox_list);
 	ClassDB::bind_method(D_METHOD("get_stylebox_types"), &Theme::_get_stylebox_types);
 
-	ClassDB::bind_method(D_METHOD("set_font", "name", "type", "font"), &Theme::set_font);
-	ClassDB::bind_method(D_METHOD("get_font", "name", "type"), &Theme::get_font);
-	ClassDB::bind_method(D_METHOD("has_font", "name", "type"), &Theme::has_font);
-	ClassDB::bind_method(D_METHOD("clear_font", "name", "type"), &Theme::clear_font);
-	ClassDB::bind_method(D_METHOD("get_font_list", "type"), &Theme::_get_font_list);
+	ClassDB::bind_method(D_METHOD("set_font", "name", "node_type", "font"), &Theme::set_font);
+	ClassDB::bind_method(D_METHOD("get_font", "name", "node_type"), &Theme::get_font);
+	ClassDB::bind_method(D_METHOD("has_font", "name", "node_type"), &Theme::has_font);
+	ClassDB::bind_method(D_METHOD("clear_font", "name", "node_type"), &Theme::clear_font);
+	ClassDB::bind_method(D_METHOD("get_font_list", "node_type"), &Theme::_get_font_list);
 
-	ClassDB::bind_method(D_METHOD("set_color", "name", "type", "color"), &Theme::set_color);
-	ClassDB::bind_method(D_METHOD("get_color", "name", "type"), &Theme::get_color);
-	ClassDB::bind_method(D_METHOD("has_color", "name", "type"), &Theme::has_color);
-	ClassDB::bind_method(D_METHOD("clear_color", "name", "type"), &Theme::clear_color);
-	ClassDB::bind_method(D_METHOD("get_color_list", "type"), &Theme::_get_color_list);
+	ClassDB::bind_method(D_METHOD("set_color", "name", "node_type", "color"), &Theme::set_color);
+	ClassDB::bind_method(D_METHOD("get_color", "name", "node_type"), &Theme::get_color);
+	ClassDB::bind_method(D_METHOD("has_color", "name", "node_type"), &Theme::has_color);
+	ClassDB::bind_method(D_METHOD("clear_color", "name", "node_type"), &Theme::clear_color);
+	ClassDB::bind_method(D_METHOD("get_color_list", "node_type"), &Theme::_get_color_list);
 
-	ClassDB::bind_method(D_METHOD("set_constant", "name", "type", "constant"), &Theme::set_constant);
-	ClassDB::bind_method(D_METHOD("get_constant", "name", "type"), &Theme::get_constant);
-	ClassDB::bind_method(D_METHOD("has_constant", "name", "type"), &Theme::has_constant);
-	ClassDB::bind_method(D_METHOD("clear_constant", "name", "type"), &Theme::clear_constant);
-	ClassDB::bind_method(D_METHOD("get_constant_list", "type"), &Theme::_get_constant_list);
+	ClassDB::bind_method(D_METHOD("set_constant", "name", "node_type", "constant"), &Theme::set_constant);
+	ClassDB::bind_method(D_METHOD("get_constant", "name", "node_type"), &Theme::get_constant);
+	ClassDB::bind_method(D_METHOD("has_constant", "name", "node_type"), &Theme::has_constant);
+	ClassDB::bind_method(D_METHOD("clear_constant", "name", "node_type"), &Theme::clear_constant);
+	ClassDB::bind_method(D_METHOD("get_constant_list", "node_type"), &Theme::_get_constant_list);
 
 	ClassDB::bind_method(D_METHOD("clear"), &Theme::clear);
 
 	ClassDB::bind_method(D_METHOD("set_default_font", "font"), &Theme::set_default_theme_font);
 	ClassDB::bind_method(D_METHOD("get_default_font"), &Theme::get_default_theme_font);
 
-	ClassDB::bind_method(D_METHOD("get_type_list", "type"), &Theme::_get_type_list);
+	ClassDB::bind_method(D_METHOD("get_type_list", "node_type"), &Theme::_get_type_list);
 
 	ClassDB::bind_method("copy_default_theme", &Theme::copy_default_theme);
 	ClassDB::bind_method(D_METHOD("copy_theme", "other"), &Theme::copy_theme);

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -51,13 +51,13 @@ class Theme : public Resource {
 	HashMap<StringName, HashMap<StringName, Color>> color_map;
 	HashMap<StringName, HashMap<StringName, int>> constant_map;
 
-	Vector<String> _get_icon_list(const String &p_type) const;
-	Vector<String> _get_stylebox_list(const String &p_type) const;
+	Vector<String> _get_icon_list(const String &p_node_type) const;
+	Vector<String> _get_stylebox_list(const String &p_node_type) const;
 	Vector<String> _get_stylebox_types() const;
-	Vector<String> _get_font_list(const String &p_type) const;
-	Vector<String> _get_color_list(const String &p_type) const;
-	Vector<String> _get_constant_list(const String &p_type) const;
-	Vector<String> _get_type_list(const String &p_type) const;
+	Vector<String> _get_font_list(const String &p_node_type) const;
+	Vector<String> _get_color_list(const String &p_node_type) const;
+	Vector<String> _get_constant_list(const String &p_node_type) const;
+	Vector<String> _get_type_list(const String &p_node_type) const;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -88,42 +88,42 @@ public:
 	void set_default_theme_font(const Ref<Font> &p_default_font);
 	Ref<Font> get_default_theme_font() const;
 
-	void set_icon(const StringName &p_name, const StringName &p_type, const Ref<Texture2D> &p_icon);
-	Ref<Texture2D> get_icon(const StringName &p_name, const StringName &p_type) const;
-	bool has_icon(const StringName &p_name, const StringName &p_type) const;
-	void clear_icon(const StringName &p_name, const StringName &p_type);
-	void get_icon_list(StringName p_type, List<StringName> *p_list) const;
+	void set_icon(const StringName &p_name, const StringName &p_node_type, const Ref<Texture2D> &p_icon);
+	Ref<Texture2D> get_icon(const StringName &p_name, const StringName &p_node_type) const;
+	bool has_icon(const StringName &p_name, const StringName &p_node_type) const;
+	void clear_icon(const StringName &p_name, const StringName &p_node_type);
+	void get_icon_list(StringName p_node_type, List<StringName> *p_list) const;
 
-	void set_shader(const StringName &p_name, const StringName &p_type, const Ref<Shader> &p_shader);
-	Ref<Shader> get_shader(const StringName &p_name, const StringName &p_type) const;
-	bool has_shader(const StringName &p_name, const StringName &p_type) const;
-	void clear_shader(const StringName &p_name, const StringName &p_type);
-	void get_shader_list(const StringName &p_type, List<StringName> *p_list) const;
+	void set_shader(const StringName &p_name, const StringName &p_node_type, const Ref<Shader> &p_shader);
+	Ref<Shader> get_shader(const StringName &p_name, const StringName &p_node_type) const;
+	bool has_shader(const StringName &p_name, const StringName &p_node_type) const;
+	void clear_shader(const StringName &p_name, const StringName &p_node_type);
+	void get_shader_list(const StringName &p_node_type, List<StringName> *p_list) const;
 
-	void set_stylebox(const StringName &p_name, const StringName &p_type, const Ref<StyleBox> &p_style);
-	Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_type) const;
-	bool has_stylebox(const StringName &p_name, const StringName &p_type) const;
-	void clear_stylebox(const StringName &p_name, const StringName &p_type);
-	void get_stylebox_list(StringName p_type, List<StringName> *p_list) const;
+	void set_stylebox(const StringName &p_name, const StringName &p_node_type, const Ref<StyleBox> &p_style);
+	Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_node_type) const;
+	bool has_stylebox(const StringName &p_name, const StringName &p_node_type) const;
+	void clear_stylebox(const StringName &p_name, const StringName &p_node_type);
+	void get_stylebox_list(StringName p_node_type, List<StringName> *p_list) const;
 	void get_stylebox_types(List<StringName> *p_list) const;
 
-	void set_font(const StringName &p_name, const StringName &p_type, const Ref<Font> &p_font);
-	Ref<Font> get_font(const StringName &p_name, const StringName &p_type) const;
-	bool has_font(const StringName &p_name, const StringName &p_type) const;
-	void clear_font(const StringName &p_name, const StringName &p_type);
-	void get_font_list(StringName p_type, List<StringName> *p_list) const;
+	void set_font(const StringName &p_name, const StringName &p_node_type, const Ref<Font> &p_font);
+	Ref<Font> get_font(const StringName &p_name, const StringName &p_node_type) const;
+	bool has_font(const StringName &p_name, const StringName &p_node_type) const;
+	void clear_font(const StringName &p_name, const StringName &p_node_type);
+	void get_font_list(StringName p_node_type, List<StringName> *p_list) const;
 
-	void set_color(const StringName &p_name, const StringName &p_type, const Color &p_color);
-	Color get_color(const StringName &p_name, const StringName &p_type) const;
-	bool has_color(const StringName &p_name, const StringName &p_type) const;
-	void clear_color(const StringName &p_name, const StringName &p_type);
-	void get_color_list(StringName p_type, List<StringName> *p_list) const;
+	void set_color(const StringName &p_name, const StringName &p_node_type, const Color &p_color);
+	Color get_color(const StringName &p_name, const StringName &p_node_type) const;
+	bool has_color(const StringName &p_name, const StringName &p_node_type) const;
+	void clear_color(const StringName &p_name, const StringName &p_node_type);
+	void get_color_list(StringName p_node_type, List<StringName> *p_list) const;
 
-	void set_constant(const StringName &p_name, const StringName &p_type, int p_constant);
-	int get_constant(const StringName &p_name, const StringName &p_type) const;
-	bool has_constant(const StringName &p_name, const StringName &p_type) const;
-	void clear_constant(const StringName &p_name, const StringName &p_type);
-	void get_constant_list(StringName p_type, List<StringName> *p_list) const;
+	void set_constant(const StringName &p_name, const StringName &p_node_type, int p_constant);
+	int get_constant(const StringName &p_name, const StringName &p_node_type) const;
+	bool has_constant(const StringName &p_name, const StringName &p_node_type) const;
+	void clear_constant(const StringName &p_name, const StringName &p_node_type);
+	void get_constant_list(StringName p_node_type, List<StringName> *p_list) const;
 
 	void get_type_list(List<StringName> *p_list) const;
 


### PR DESCRIPTION
This makes it clearer that it expects a node type as a string (such as "Label") instead of a type like "TYPE_ARRAY". This is backwards-compatible since only the name of the parameter is changed, not its order.

3.2 version in #42009.

See https://github.com/godotengine/godot-proposals/issues/1495#issuecomment-691507839.