### PR TITLE
Rename the `type` parameter to `node_type` in Theme and Control (3.2)

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -246,10 +246,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String" default="&quot;&quot;">
+			<argument index="1" name="node_type" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns a color from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]type[/code].
+				Returns a color from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
 				[codeblock]
 				func _ready():
 				    modulate = get_color("font_color", "Button") #get the color defined for button fonts
@@ -268,10 +268,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String" default="&quot;&quot;">
+			<argument index="1" name="node_type" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns a constant from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]type[/code].
+				Returns a constant from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_cursor_shape" qualifiers="const">
@@ -327,10 +327,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String" default="&quot;&quot;">
+			<argument index="1" name="node_type" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns a font from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]type[/code].
+				Returns a font from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_global_rect" qualifiers="const">
@@ -345,10 +345,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String" default="&quot;&quot;">
+			<argument index="1" name="node_type" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns an icon from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]type[/code].
+				Returns an icon from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_margin" qualifiers="const">
@@ -400,10 +400,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String" default="&quot;&quot;">
+			<argument index="1" name="node_type" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns a [StyleBox] from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]type[/code].
+				Returns a [StyleBox] from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_tooltip" qualifiers="const">
@@ -438,10 +438,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String" default="&quot;&quot;">
+			<argument index="1" name="node_type" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns [code]true[/code] if [Color] with given [code]name[/code] and associated with [Control] of given [code]type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if [Color] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
 			</description>
 		</method>
 		<method name="has_color_override" qualifiers="const">
@@ -458,10 +458,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String" default="&quot;&quot;">
+			<argument index="1" name="node_type" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns [code]true[/code] if constant with given [code]name[/code] and associated with [Control] of given [code]type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if constant with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
 			</description>
 		</method>
 		<method name="has_constant_override" qualifiers="const">
@@ -485,10 +485,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String" default="&quot;&quot;">
+			<argument index="1" name="node_type" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns [code]true[/code] if font with given [code]name[/code] and associated with [Control] of given [code]type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if font with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
 			</description>
 		</method>
 		<method name="has_font_override" qualifiers="const">
@@ -505,10 +505,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String" default="&quot;&quot;">
+			<argument index="1" name="node_type" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns [code]true[/code] if icon with given [code]name[/code] and associated with [Control] of given [code]type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if icon with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
 			</description>
 		</method>
 		<method name="has_icon_override" qualifiers="const">
@@ -545,10 +545,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String" default="&quot;&quot;">
+			<argument index="1" name="node_type" type="String" default="&quot;&quot;">
 			</argument>
 			<description>
-				Returns [code]true[/code] if [StyleBox] with given [code]name[/code] and associated with [Control] of given [code]type[/code] exists in assigned [Theme].
+				Returns [code]true[/code] if [StyleBox] with given [code]name[/code] and associated with [Control] of given [code]node_type[/code] exists in assigned [Theme].
 			</description>
 		</method>
 		<method name="has_stylebox_override" qualifiers="const">

--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -23,10 +23,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Clears the [Color] at [code]name[/code] if the theme has [code]type[/code].
+				Clears the [Color] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="clear_constant">
@@ -34,10 +34,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Clears the constant at [code]name[/code] if the theme has [code]type[/code].
+				Clears the constant at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="clear_font">
@@ -45,10 +45,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Clears the [Font] at [code]name[/code] if the theme has [code]type[/code].
+				Clears the [Font] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="clear_icon">
@@ -56,10 +56,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Clears the icon at [code]name[/code] if the theme has [code]type[/code].
+				Clears the icon at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="clear_stylebox">
@@ -67,10 +67,10 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Clears [StyleBox] at [code]name[/code] if the theme has [code]type[/code].
+				Clears [StyleBox] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="copy_default_theme">
@@ -94,19 +94,19 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns the [Color] at [code]name[/code] if the theme has [code]type[/code].
+				Returns the [Color] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_color_list" qualifiers="const">
 			<return type="PoolStringArray">
 			</return>
-			<argument index="0" name="type" type="String">
+			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the [Color]s as a [PoolStringArray] filled with each [Color]'s name, for use in [method get_color], if the theme has [code]type[/code].
+				Returns all the [Color]s as a [PoolStringArray] filled with each [Color]'s name, for use in [method get_color], if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_constant" qualifiers="const">
@@ -114,19 +114,19 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns the constant at [code]name[/code] if the theme has [code]type[/code].
+				Returns the constant at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_constant_list" qualifiers="const">
 			<return type="PoolStringArray">
 			</return>
-			<argument index="0" name="type" type="String">
+			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the constants as a [PoolStringArray] filled with each constant's name, for use in [method get_constant], if the theme has [code]type[/code].
+				Returns all the constants as a [PoolStringArray] filled with each constant's name, for use in [method get_constant], if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_font" qualifiers="const">
@@ -134,19 +134,19 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns the [Font] at [code]name[/code] if the theme has [code]type[/code].
+				Returns the [Font] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_font_list" qualifiers="const">
 			<return type="PoolStringArray">
 			</return>
-			<argument index="0" name="type" type="String">
+			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the [Font]s as a [PoolStringArray] filled with each [Font]'s name, for use in [method get_font], if the theme has [code]type[/code].
+				Returns all the [Font]s as a [PoolStringArray] filled with each [Font]'s name, for use in [method get_font], if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_icon" qualifiers="const">
@@ -154,19 +154,19 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns the icon [Texture] at [code]name[/code] if the theme has [code]type[/code].
+				Returns the icon [Texture] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_icon_list" qualifiers="const">
 			<return type="PoolStringArray">
 			</return>
-			<argument index="0" name="type" type="String">
+			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the icons as a [PoolStringArray] filled with each [Texture]'s name, for use in [method get_icon], if the theme has [code]type[/code].
+				Returns all the icons as a [PoolStringArray] filled with each [Texture]'s name, for use in [method get_icon], if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_stylebox" qualifiers="const">
@@ -174,35 +174,35 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns the icon [StyleBox] at [code]name[/code] if the theme has [code]type[/code].
+				Returns the icon [StyleBox] at [code]name[/code] if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_stylebox_list" qualifiers="const">
 			<return type="PoolStringArray">
 			</return>
-			<argument index="0" name="type" type="String">
+			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the [StyleBox]s as a [PoolStringArray] filled with each [StyleBox]'s name, for use in [method get_stylebox], if the theme has [code]type[/code].
+				Returns all the [StyleBox]s as a [PoolStringArray] filled with each [StyleBox]'s name, for use in [method get_stylebox], if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_stylebox_types" qualifiers="const">
 			<return type="PoolStringArray">
 			</return>
 			<description>
-				Returns all the [StyleBox] types as a [PoolStringArray] filled with each [StyleBox]'s type, for use in [method get_stylebox] and/or [method get_stylebox_list], if the theme has [code]type[/code].
+				Returns all the [StyleBox] types as a [PoolStringArray] filled with each [StyleBox]'s type, for use in [method get_stylebox] and/or [method get_stylebox_list], if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="get_type_list" qualifiers="const">
 			<return type="PoolStringArray">
 			</return>
-			<argument index="0" name="type" type="String">
+			<argument index="0" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns all the types in [code]type[/code] as a [PoolStringArray] for use in any of the [code]get_*[/code] functions, if the theme has [code]type[/code].
+				Returns all the types in [code]node_type[/code] as a [PoolStringArray] for use in any of the [code]get_*[/code] functions, if the theme has [code]node_type[/code].
 			</description>
 		</method>
 		<method name="has_color" qualifiers="const">
@@ -210,11 +210,11 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] if [Color] with [code]name[/code] is in [code]type[/code].
-				Returns [code]false[/code] if the theme does not have [code]type[/code].
+				Returns [code]true[/code] if [Color] with [code]name[/code] is in [code]node_type[/code].
+				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="has_constant" qualifiers="const">
@@ -222,11 +222,11 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] if constant with [code]name[/code] is in [code]type[/code].
-				Returns [code]false[/code] if the theme does not have [code]type[/code].
+				Returns [code]true[/code] if constant with [code]name[/code] is in [code]node_type[/code].
+				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="has_font" qualifiers="const">
@@ -234,11 +234,11 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] if [Font] with [code]name[/code] is in [code]type[/code].
-				Returns [code]false[/code] if the theme does not have [code]type[/code].
+				Returns [code]true[/code] if [Font] with [code]name[/code] is in [code]node_type[/code].
+				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="has_icon" qualifiers="const">
@@ -246,11 +246,11 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] if icon [Texture] with [code]name[/code] is in [code]type[/code].
-				Returns [code]false[/code] if the theme does not have [code]type[/code].
+				Returns [code]true[/code] if icon [Texture] with [code]name[/code] is in [code]node_type[/code].
+				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="has_stylebox" qualifiers="const">
@@ -258,11 +258,11 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<description>
-				Returns [code]true[/code] if [StyleBox] with [code]name[/code] is in [code]type[/code].
-				Returns [code]false[/code] if the theme does not have [code]type[/code].
+				Returns [code]true[/code] if [StyleBox] with [code]name[/code] is in [code]node_type[/code].
+				Returns [code]false[/code] if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="set_color">
@@ -270,13 +270,13 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<argument index="2" name="color" type="Color">
 			</argument>
 			<description>
-				Sets the theme's [Color] to [code]color[/code] at [code]name[/code] in [code]type[/code].
-				Does nothing if the theme does not have [code]type[/code].
+				Sets the theme's [Color] to [code]color[/code] at [code]name[/code] in [code]node_type[/code].
+				Does nothing if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="set_constant">
@@ -284,13 +284,13 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<argument index="2" name="constant" type="int">
 			</argument>
 			<description>
-				Sets the theme's constant to [code]constant[/code] at [code]name[/code] in [code]type[/code].
-				Does nothing if the theme does not have [code]type[/code].
+				Sets the theme's constant to [code]constant[/code] at [code]name[/code] in [code]node_type[/code].
+				Does nothing if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="set_font">
@@ -298,13 +298,13 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<argument index="2" name="font" type="Font">
 			</argument>
 			<description>
-				Sets the theme's [Font] to [code]font[/code] at [code]name[/code] in [code]type[/code].
-				Does nothing if the theme does not have [code]type[/code].
+				Sets the theme's [Font] to [code]font[/code] at [code]name[/code] in [code]node_type[/code].
+				Does nothing if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="set_icon">
@@ -312,13 +312,13 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<argument index="2" name="texture" type="Texture">
 			</argument>
 			<description>
-				Sets the theme's icon [Texture] to [code]texture[/code] at [code]name[/code] in [code]type[/code].
-				Does nothing if the theme does not have [code]type[/code].
+				Sets the theme's icon [Texture] to [code]texture[/code] at [code]name[/code] in [code]node_type[/code].
+				Does nothing if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 		<method name="set_stylebox">
@@ -326,13 +326,13 @@
 			</return>
 			<argument index="0" name="name" type="String">
 			</argument>
-			<argument index="1" name="type" type="String">
+			<argument index="1" name="node_type" type="String">
 			</argument>
 			<argument index="2" name="texture" type="StyleBox">
 			</argument>
 			<description>
-				Sets theme's [StyleBox] to [code]stylebox[/code] at [code]name[/code] in [code]type[/code].
-				Does nothing if the theme does not have [code]type[/code].
+				Sets theme's [StyleBox] to [code]stylebox[/code] at [code]name[/code] in [code]node_type[/code].
+				Does nothing if the theme does not have [code]node_type[/code].
 			</description>
 		</method>
 	</methods>

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -818,16 +818,16 @@ Size2 Control::get_minimum_size() const {
 	return Size2();
 }
 
-Ref<Texture> Control::get_icon(const StringName &p_name, const StringName &p_type) const {
+Ref<Texture> Control::get_icon(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (p_type == StringName() || p_type == get_class_name()) {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 
 		const Ref<Texture> *tex = data.icon_override.getptr(p_name);
 		if (tex)
 			return *tex;
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -861,15 +861,15 @@ Ref<Texture> Control::get_icon(const StringName &p_name, const StringName &p_typ
 	return Theme::get_default()->get_icon(p_name, type);
 }
 
-Ref<Shader> Control::get_shader(const StringName &p_name, const StringName &p_type) const {
-	if (p_type == StringName() || p_type == get_class_name()) {
+Ref<Shader> Control::get_shader(const StringName &p_name, const StringName &p_node_type) const {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 
 		const Ref<Shader> *sdr = data.shader_override.getptr(p_name);
 		if (sdr)
 			return *sdr;
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -903,15 +903,15 @@ Ref<Shader> Control::get_shader(const StringName &p_name, const StringName &p_ty
 	return Theme::get_default()->get_shader(p_name, type);
 }
 
-Ref<StyleBox> Control::get_stylebox(const StringName &p_name, const StringName &p_type) const {
+Ref<StyleBox> Control::get_stylebox(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (p_type == StringName() || p_type == get_class_name()) {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		const Ref<StyleBox> *style = data.style_override.getptr(p_name);
 		if (style)
 			return *style;
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -949,15 +949,15 @@ Ref<StyleBox> Control::get_stylebox(const StringName &p_name, const StringName &
 	}
 	return Theme::get_default()->get_stylebox(p_name, type);
 }
-Ref<Font> Control::get_font(const StringName &p_name, const StringName &p_type) const {
+Ref<Font> Control::get_font(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (p_type == StringName() || p_type == get_class_name()) {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		const Ref<Font> *font = data.font_override.getptr(p_name);
 		if (font)
 			return *font;
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -986,15 +986,15 @@ Ref<Font> Control::get_font(const StringName &p_name, const StringName &p_type) 
 
 	return Theme::get_default()->get_font(p_name, type);
 }
-Color Control::get_color(const StringName &p_name, const StringName &p_type) const {
+Color Control::get_color(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (p_type == StringName() || p_type == get_class_name()) {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		const Color *color = data.color_override.getptr(p_name);
 		if (color)
 			return *color;
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
 
@@ -1026,15 +1026,15 @@ Color Control::get_color(const StringName &p_name, const StringName &p_type) con
 	return Theme::get_default()->get_color(p_name, type);
 }
 
-int Control::get_constant(const StringName &p_name, const StringName &p_type) const {
+int Control::get_constant(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (p_type == StringName() || p_type == get_class_name()) {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		const int *constant = data.constant_override.getptr(p_name);
 		if (constant)
 			return *constant;
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
 
@@ -1102,14 +1102,14 @@ bool Control::has_constant_override(const StringName &p_name) const {
 	return constant != NULL;
 }
 
-bool Control::has_icon(const StringName &p_name, const StringName &p_type) const {
+bool Control::has_icon(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (p_type == StringName() || p_type == get_class_name()) {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		if (has_icon_override(p_name))
 			return true;
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -1141,14 +1141,14 @@ bool Control::has_icon(const StringName &p_name, const StringName &p_type) const
 	return Theme::get_default()->has_icon(p_name, type);
 }
 
-bool Control::has_shader(const StringName &p_name, const StringName &p_type) const {
+bool Control::has_shader(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (p_type == StringName() || p_type == get_class_name()) {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		if (has_shader_override(p_name))
 			return true;
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -1179,14 +1179,14 @@ bool Control::has_shader(const StringName &p_name, const StringName &p_type) con
 	}
 	return Theme::get_default()->has_shader(p_name, type);
 }
-bool Control::has_stylebox(const StringName &p_name, const StringName &p_type) const {
+bool Control::has_stylebox(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (p_type == StringName() || p_type == get_class_name()) {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		if (has_stylebox_override(p_name))
 			return true;
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -1217,14 +1217,14 @@ bool Control::has_stylebox(const StringName &p_name, const StringName &p_type) c
 	}
 	return Theme::get_default()->has_stylebox(p_name, type);
 }
-bool Control::has_font(const StringName &p_name, const StringName &p_type) const {
+bool Control::has_font(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (p_type == StringName() || p_type == get_class_name()) {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		if (has_font_override(p_name))
 			return true;
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -1256,14 +1256,14 @@ bool Control::has_font(const StringName &p_name, const StringName &p_type) const
 	return Theme::get_default()->has_font(p_name, type);
 }
 
-bool Control::has_color(const StringName &p_name, const StringName &p_type) const {
+bool Control::has_color(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (p_type == StringName() || p_type == get_class_name()) {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		if (has_color_override(p_name))
 			return true;
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -1295,14 +1295,14 @@ bool Control::has_color(const StringName &p_name, const StringName &p_type) cons
 	return Theme::get_default()->has_color(p_name, type);
 }
 
-bool Control::has_constant(const StringName &p_name, const StringName &p_type) const {
+bool Control::has_constant(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (p_type == StringName() || p_type == get_class_name()) {
+	if (p_node_type == StringName() || p_node_type == get_class_name()) {
 		if (has_constant_override(p_name))
 			return true;
 	}
 
-	StringName type = p_type ? p_type : get_class_name();
+	StringName type = p_node_type ? p_node_type : get_class_name();
 
 	// try with custom themes
 	Control *theme_owner = data.theme_owner;
@@ -2886,11 +2886,11 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_color_override", "name", "color"), &Control::add_color_override);
 	ClassDB::bind_method(D_METHOD("add_constant_override", "name", "constant"), &Control::add_constant_override);
 
-	ClassDB::bind_method(D_METHOD("get_icon", "name", "type"), &Control::get_icon, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "type"), &Control::get_stylebox, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("get_font", "name", "type"), &Control::get_font, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("get_color", "name", "type"), &Control::get_color, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("get_constant", "name", "type"), &Control::get_constant, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("get_icon", "name", "node_type"), &Control::get_icon, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "node_type"), &Control::get_stylebox, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("get_font", "name", "node_type"), &Control::get_font, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("get_color", "name", "node_type"), &Control::get_color, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("get_constant", "name", "node_type"), &Control::get_constant, DEFVAL(""));
 
 	ClassDB::bind_method(D_METHOD("has_icon_override", "name"), &Control::has_icon_override);
 	ClassDB::bind_method(D_METHOD("has_shader_override", "name"), &Control::has_shader_override);
@@ -2899,11 +2899,11 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_color_override", "name"), &Control::has_color_override);
 	ClassDB::bind_method(D_METHOD("has_constant_override", "name"), &Control::has_constant_override);
 
-	ClassDB::bind_method(D_METHOD("has_icon", "name", "type"), &Control::has_icon, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("has_stylebox", "name", "type"), &Control::has_stylebox, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("has_font", "name", "type"), &Control::has_font, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("has_color", "name", "type"), &Control::has_color, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("has_constant", "name", "type"), &Control::has_constant, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("has_icon", "name", "node_type"), &Control::has_icon, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("has_stylebox", "name", "node_type"), &Control::has_stylebox, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("has_font", "name", "node_type"), &Control::has_font, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("has_color", "name", "node_type"), &Control::has_color, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("has_constant", "name", "node_type"), &Control::has_constant, DEFVAL(""));
 
 	ClassDB::bind_method(D_METHOD("get_parent_control"), &Control::get_parent_control);
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -427,12 +427,12 @@ public:
 	void add_color_override(const StringName &p_name, const Color &p_color);
 	void add_constant_override(const StringName &p_name, int p_constant);
 
-	Ref<Texture> get_icon(const StringName &p_name, const StringName &p_type = StringName()) const;
-	Ref<Shader> get_shader(const StringName &p_name, const StringName &p_type = StringName()) const;
-	Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_type = StringName()) const;
-	Ref<Font> get_font(const StringName &p_name, const StringName &p_type = StringName()) const;
-	Color get_color(const StringName &p_name, const StringName &p_type = StringName()) const;
-	int get_constant(const StringName &p_name, const StringName &p_type = StringName()) const;
+	Ref<Texture> get_icon(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	Ref<Shader> get_shader(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	Ref<Font> get_font(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	Color get_color(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	int get_constant(const StringName &p_name, const StringName &p_node_type = StringName()) const;
 
 	bool has_icon_override(const StringName &p_name) const;
 	bool has_shader_override(const StringName &p_name) const;
@@ -441,12 +441,12 @@ public:
 	bool has_color_override(const StringName &p_name) const;
 	bool has_constant_override(const StringName &p_name) const;
 
-	bool has_icon(const StringName &p_name, const StringName &p_type = StringName()) const;
-	bool has_shader(const StringName &p_name, const StringName &p_type = StringName()) const;
-	bool has_stylebox(const StringName &p_name, const StringName &p_type = StringName()) const;
-	bool has_font(const StringName &p_name, const StringName &p_type = StringName()) const;
-	bool has_color(const StringName &p_name, const StringName &p_type = StringName()) const;
-	bool has_constant(const StringName &p_name, const StringName &p_type = StringName()) const;
+	bool has_icon(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	bool has_shader(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	bool has_stylebox(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	bool has_font(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	bool has_color(const StringName &p_name, const StringName &p_node_type = StringName()) const;
+	bool has_constant(const StringName &p_name, const StringName &p_node_type = StringName()) const;
 
 	/* TOOLTIP */
 

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -37,12 +37,12 @@ void Theme::_emit_theme_changed() {
 	emit_changed();
 }
 
-PoolVector<String> Theme::_get_icon_list(const String &p_type) const {
+PoolVector<String> Theme::_get_icon_list(const String &p_node_type) const {
 
 	PoolVector<String> ilret;
 	List<StringName> il;
 
-	get_icon_list(p_type, &il);
+	get_icon_list(p_node_type, &il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -53,12 +53,12 @@ PoolVector<String> Theme::_get_icon_list(const String &p_type) const {
 	return ilret;
 }
 
-PoolVector<String> Theme::_get_stylebox_list(const String &p_type) const {
+PoolVector<String> Theme::_get_stylebox_list(const String &p_node_type) const {
 
 	PoolVector<String> ilret;
 	List<StringName> il;
 
-	get_stylebox_list(p_type, &il);
+	get_stylebox_list(p_node_type, &il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -85,12 +85,12 @@ PoolVector<String> Theme::_get_stylebox_types(void) const {
 	return ilret;
 }
 
-PoolVector<String> Theme::_get_font_list(const String &p_type) const {
+PoolVector<String> Theme::_get_font_list(const String &p_node_type) const {
 
 	PoolVector<String> ilret;
 	List<StringName> il;
 
-	get_font_list(p_type, &il);
+	get_font_list(p_node_type, &il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -101,12 +101,12 @@ PoolVector<String> Theme::_get_font_list(const String &p_type) const {
 	return ilret;
 }
 
-PoolVector<String> Theme::_get_color_list(const String &p_type) const {
+PoolVector<String> Theme::_get_color_list(const String &p_node_type) const {
 
 	PoolVector<String> ilret;
 	List<StringName> il;
 
-	get_color_list(p_type, &il);
+	get_color_list(p_node_type, &il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -117,12 +117,12 @@ PoolVector<String> Theme::_get_color_list(const String &p_type) const {
 	return ilret;
 }
 
-PoolVector<String> Theme::_get_constant_list(const String &p_type) const {
+PoolVector<String> Theme::_get_constant_list(const String &p_node_type) const {
 
 	PoolVector<String> ilret;
 	List<StringName> il;
 
-	get_constant_list(p_type, &il);
+	get_constant_list(p_node_type, &il);
 	ilret.resize(il.size());
 
 	int i = 0;
@@ -133,7 +133,7 @@ PoolVector<String> Theme::_get_constant_list(const String &p_type) const {
 	return ilret;
 }
 
-PoolVector<String> Theme::_get_type_list(const String &p_type) const {
+PoolVector<String> Theme::_get_type_list(const String &p_node_type) const {
 
 	PoolVector<String> ilret;
 	List<StringName> il;
@@ -359,20 +359,20 @@ void Theme::set_default_font(const Ref<Font> &p_font) {
 	default_font = p_font;
 }
 
-void Theme::set_icon(const StringName &p_name, const StringName &p_type, const Ref<Texture> &p_icon) {
+void Theme::set_icon(const StringName &p_name, const StringName &p_node_type, const Ref<Texture> &p_icon) {
 
 	//ERR_FAIL_COND(p_icon.is_null());
 
-	bool new_value = !icon_map.has(p_type) || !icon_map[p_type].has(p_name);
+	bool new_value = !icon_map.has(p_node_type) || !icon_map[p_node_type].has(p_name);
 
-	if (icon_map[p_type].has(p_name) && icon_map[p_type][p_name].is_valid()) {
-		icon_map[p_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
+	if (icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid()) {
+		icon_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
 	}
 
-	icon_map[p_type][p_name] = p_icon;
+	icon_map[p_node_type][p_name] = p_icon;
 
 	if (p_icon.is_valid()) {
-		icon_map[p_type][p_name]->connect("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
+		icon_map[p_node_type][p_name]->connect("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	if (new_value) {
@@ -380,55 +380,55 @@ void Theme::set_icon(const StringName &p_name, const StringName &p_type, const R
 		emit_changed();
 	}
 }
-Ref<Texture> Theme::get_icon(const StringName &p_name, const StringName &p_type) const {
+Ref<Texture> Theme::get_icon(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (icon_map.has(p_type) && icon_map[p_type].has(p_name) && icon_map[p_type][p_name].is_valid()) {
+	if (icon_map.has(p_node_type) && icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid()) {
 
-		return icon_map[p_type][p_name];
+		return icon_map[p_node_type][p_name];
 	} else {
 		return default_icon;
 	}
 }
 
-bool Theme::has_icon(const StringName &p_name, const StringName &p_type) const {
+bool Theme::has_icon(const StringName &p_name, const StringName &p_node_type) const {
 
-	return (icon_map.has(p_type) && icon_map[p_type].has(p_name) && icon_map[p_type][p_name].is_valid());
+	return (icon_map.has(p_node_type) && icon_map[p_node_type].has(p_name) && icon_map[p_node_type][p_name].is_valid());
 }
 
-void Theme::clear_icon(const StringName &p_name, const StringName &p_type) {
+void Theme::clear_icon(const StringName &p_name, const StringName &p_node_type) {
 
-	ERR_FAIL_COND(!icon_map.has(p_type));
-	ERR_FAIL_COND(!icon_map[p_type].has(p_name));
+	ERR_FAIL_COND(!icon_map.has(p_node_type));
+	ERR_FAIL_COND(!icon_map[p_node_type].has(p_name));
 
-	if (icon_map[p_type][p_name].is_valid()) {
-		icon_map[p_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
+	if (icon_map[p_node_type][p_name].is_valid()) {
+		icon_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
 	}
 
-	icon_map[p_type].erase(p_name);
+	icon_map[p_node_type].erase(p_name);
 
 	_change_notify();
 	emit_changed();
 }
 
-void Theme::get_icon_list(StringName p_type, List<StringName> *p_list) const {
+void Theme::get_icon_list(StringName p_node_type, List<StringName> *p_list) const {
 
 	ERR_FAIL_NULL(p_list);
 
-	if (!icon_map.has(p_type))
+	if (!icon_map.has(p_node_type))
 		return;
 
 	const StringName *key = NULL;
 
-	while ((key = icon_map[p_type].next(key))) {
+	while ((key = icon_map[p_node_type].next(key))) {
 
 		p_list->push_back(*key);
 	}
 }
 
-void Theme::set_shader(const StringName &p_name, const StringName &p_type, const Ref<Shader> &p_shader) {
-	bool new_value = !shader_map.has(p_type) || !shader_map[p_type].has(p_name);
+void Theme::set_shader(const StringName &p_name, const StringName &p_node_type, const Ref<Shader> &p_shader) {
+	bool new_value = !shader_map.has(p_node_type) || !shader_map[p_node_type].has(p_name);
 
-	shader_map[p_type][p_name] = p_shader;
+	shader_map[p_node_type][p_name] = p_shader;
 
 	if (new_value) {
 		_change_notify();
@@ -436,56 +436,56 @@ void Theme::set_shader(const StringName &p_name, const StringName &p_type, const
 	}
 }
 
-Ref<Shader> Theme::get_shader(const StringName &p_name, const StringName &p_type) const {
-	if (shader_map.has(p_type) && shader_map[p_type].has(p_name) && shader_map[p_type][p_name].is_valid()) {
-		return shader_map[p_type][p_name];
+Ref<Shader> Theme::get_shader(const StringName &p_name, const StringName &p_node_type) const {
+	if (shader_map.has(p_node_type) && shader_map[p_node_type].has(p_name) && shader_map[p_node_type][p_name].is_valid()) {
+		return shader_map[p_node_type][p_name];
 	} else {
 		return NULL;
 	}
 }
 
-bool Theme::has_shader(const StringName &p_name, const StringName &p_type) const {
-	return (shader_map.has(p_type) && shader_map[p_type].has(p_name) && shader_map[p_type][p_name].is_valid());
+bool Theme::has_shader(const StringName &p_name, const StringName &p_node_type) const {
+	return (shader_map.has(p_node_type) && shader_map[p_node_type].has(p_name) && shader_map[p_node_type][p_name].is_valid());
 }
 
-void Theme::clear_shader(const StringName &p_name, const StringName &p_type) {
-	ERR_FAIL_COND(!shader_map.has(p_type));
-	ERR_FAIL_COND(!shader_map[p_type].has(p_name));
+void Theme::clear_shader(const StringName &p_name, const StringName &p_node_type) {
+	ERR_FAIL_COND(!shader_map.has(p_node_type));
+	ERR_FAIL_COND(!shader_map[p_node_type].has(p_name));
 
-	shader_map[p_type].erase(p_name);
+	shader_map[p_node_type].erase(p_name);
 	_change_notify();
 	emit_changed();
 }
 
-void Theme::get_shader_list(const StringName &p_type, List<StringName> *p_list) const {
+void Theme::get_shader_list(const StringName &p_node_type, List<StringName> *p_list) const {
 
 	ERR_FAIL_NULL(p_list);
 
-	if (!shader_map.has(p_type))
+	if (!shader_map.has(p_node_type))
 		return;
 
 	const StringName *key = NULL;
 
-	while ((key = shader_map[p_type].next(key))) {
+	while ((key = shader_map[p_node_type].next(key))) {
 
 		p_list->push_back(*key);
 	}
 }
 
-void Theme::set_stylebox(const StringName &p_name, const StringName &p_type, const Ref<StyleBox> &p_style) {
+void Theme::set_stylebox(const StringName &p_name, const StringName &p_node_type, const Ref<StyleBox> &p_style) {
 
 	//ERR_FAIL_COND(p_style.is_null());
 
-	bool new_value = !style_map.has(p_type) || !style_map[p_type].has(p_name);
+	bool new_value = !style_map.has(p_node_type) || !style_map[p_node_type].has(p_name);
 
-	if (style_map[p_type].has(p_name) && style_map[p_type][p_name].is_valid()) {
-		style_map[p_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
+	if (style_map[p_node_type].has(p_name) && style_map[p_node_type][p_name].is_valid()) {
+		style_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
 	}
 
-	style_map[p_type][p_name] = p_style;
+	style_map[p_node_type][p_name] = p_style;
 
 	if (p_style.is_valid()) {
-		style_map[p_type][p_name]->connect("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
+		style_map[p_node_type][p_name]->connect("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	if (new_value)
@@ -493,46 +493,46 @@ void Theme::set_stylebox(const StringName &p_name, const StringName &p_type, con
 	emit_changed();
 }
 
-Ref<StyleBox> Theme::get_stylebox(const StringName &p_name, const StringName &p_type) const {
+Ref<StyleBox> Theme::get_stylebox(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (style_map.has(p_type) && style_map[p_type].has(p_name) && style_map[p_type][p_name].is_valid()) {
+	if (style_map.has(p_node_type) && style_map[p_node_type].has(p_name) && style_map[p_node_type][p_name].is_valid()) {
 
-		return style_map[p_type][p_name];
+		return style_map[p_node_type][p_name];
 	} else {
 		return default_style;
 	}
 }
 
-bool Theme::has_stylebox(const StringName &p_name, const StringName &p_type) const {
+bool Theme::has_stylebox(const StringName &p_name, const StringName &p_node_type) const {
 
-	return (style_map.has(p_type) && style_map[p_type].has(p_name) && style_map[p_type][p_name].is_valid());
+	return (style_map.has(p_node_type) && style_map[p_node_type].has(p_name) && style_map[p_node_type][p_name].is_valid());
 }
 
-void Theme::clear_stylebox(const StringName &p_name, const StringName &p_type) {
+void Theme::clear_stylebox(const StringName &p_name, const StringName &p_node_type) {
 
-	ERR_FAIL_COND(!style_map.has(p_type));
-	ERR_FAIL_COND(!style_map[p_type].has(p_name));
+	ERR_FAIL_COND(!style_map.has(p_node_type));
+	ERR_FAIL_COND(!style_map[p_node_type].has(p_name));
 
-	if (style_map[p_type][p_name].is_valid()) {
-		style_map[p_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
+	if (style_map[p_node_type][p_name].is_valid()) {
+		style_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
 	}
 
-	style_map[p_type].erase(p_name);
+	style_map[p_node_type].erase(p_name);
 
 	_change_notify();
 	emit_changed();
 }
 
-void Theme::get_stylebox_list(StringName p_type, List<StringName> *p_list) const {
+void Theme::get_stylebox_list(StringName p_node_type, List<StringName> *p_list) const {
 
 	ERR_FAIL_NULL(p_list);
 
-	if (!style_map.has(p_type))
+	if (!style_map.has(p_node_type))
 		return;
 
 	const StringName *key = NULL;
 
-	while ((key = style_map[p_type].next(key))) {
+	while ((key = style_map[p_node_type].next(key))) {
 
 		p_list->push_back(*key);
 	}
@@ -547,20 +547,20 @@ void Theme::get_stylebox_types(List<StringName> *p_list) const {
 	}
 }
 
-void Theme::set_font(const StringName &p_name, const StringName &p_type, const Ref<Font> &p_font) {
+void Theme::set_font(const StringName &p_name, const StringName &p_node_type, const Ref<Font> &p_font) {
 
 	//ERR_FAIL_COND(p_font.is_null());
 
-	bool new_value = !font_map.has(p_type) || !font_map[p_type].has(p_name);
+	bool new_value = !font_map.has(p_node_type) || !font_map[p_node_type].has(p_name);
 
-	if (font_map[p_type][p_name].is_valid()) {
-		font_map[p_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
+	if (font_map[p_node_type][p_name].is_valid()) {
+		font_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
 	}
 
-	font_map[p_type][p_name] = p_font;
+	font_map[p_node_type][p_name] = p_font;
 
 	if (p_font.is_valid()) {
-		font_map[p_type][p_name]->connect("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
+		font_map[p_node_type][p_name]->connect("changed", this, "_emit_theme_changed", varray(), CONNECT_REFERENCE_COUNTED);
 	}
 
 	if (new_value) {
@@ -568,55 +568,55 @@ void Theme::set_font(const StringName &p_name, const StringName &p_type, const R
 		emit_changed();
 	}
 }
-Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_type) const {
+Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (font_map.has(p_type) && font_map[p_type].has(p_name) && font_map[p_type][p_name].is_valid())
-		return font_map[p_type][p_name];
+	if (font_map.has(p_node_type) && font_map[p_node_type].has(p_name) && font_map[p_node_type][p_name].is_valid())
+		return font_map[p_node_type][p_name];
 	else if (default_theme_font.is_valid())
 		return default_theme_font;
 	else
 		return default_font;
 }
 
-bool Theme::has_font(const StringName &p_name, const StringName &p_type) const {
+bool Theme::has_font(const StringName &p_name, const StringName &p_node_type) const {
 
-	return (font_map.has(p_type) && font_map[p_type].has(p_name) && font_map[p_type][p_name].is_valid());
+	return (font_map.has(p_node_type) && font_map[p_node_type].has(p_name) && font_map[p_node_type][p_name].is_valid());
 }
 
-void Theme::clear_font(const StringName &p_name, const StringName &p_type) {
+void Theme::clear_font(const StringName &p_name, const StringName &p_node_type) {
 
-	ERR_FAIL_COND(!font_map.has(p_type));
-	ERR_FAIL_COND(!font_map[p_type].has(p_name));
+	ERR_FAIL_COND(!font_map.has(p_node_type));
+	ERR_FAIL_COND(!font_map[p_node_type].has(p_name));
 
-	if (font_map[p_type][p_name].is_valid()) {
-		font_map[p_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
+	if (font_map[p_node_type][p_name].is_valid()) {
+		font_map[p_node_type][p_name]->disconnect("changed", this, "_emit_theme_changed");
 	}
 
-	font_map[p_type].erase(p_name);
+	font_map[p_node_type].erase(p_name);
 	_change_notify();
 	emit_changed();
 }
 
-void Theme::get_font_list(StringName p_type, List<StringName> *p_list) const {
+void Theme::get_font_list(StringName p_node_type, List<StringName> *p_list) const {
 
 	ERR_FAIL_NULL(p_list);
 
-	if (!font_map.has(p_type))
+	if (!font_map.has(p_node_type))
 		return;
 
 	const StringName *key = NULL;
 
-	while ((key = font_map[p_type].next(key))) {
+	while ((key = font_map[p_node_type].next(key))) {
 
 		p_list->push_back(*key);
 	}
 }
 
-void Theme::set_color(const StringName &p_name, const StringName &p_type, const Color &p_color) {
+void Theme::set_color(const StringName &p_name, const StringName &p_node_type, const Color &p_color) {
 
-	bool new_value = !color_map.has(p_type) || !color_map[p_type].has(p_name);
+	bool new_value = !color_map.has(p_node_type) || !color_map[p_node_type].has(p_name);
 
-	color_map[p_type][p_name] = p_color;
+	color_map[p_node_type][p_name] = p_color;
 
 	if (new_value) {
 		_change_notify();
@@ -624,48 +624,48 @@ void Theme::set_color(const StringName &p_name, const StringName &p_type, const 
 	}
 }
 
-Color Theme::get_color(const StringName &p_name, const StringName &p_type) const {
+Color Theme::get_color(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (color_map.has(p_type) && color_map[p_type].has(p_name))
-		return color_map[p_type][p_name];
+	if (color_map.has(p_node_type) && color_map[p_node_type].has(p_name))
+		return color_map[p_node_type][p_name];
 	else
 		return Color();
 }
 
-bool Theme::has_color(const StringName &p_name, const StringName &p_type) const {
+bool Theme::has_color(const StringName &p_name, const StringName &p_node_type) const {
 
-	return (color_map.has(p_type) && color_map[p_type].has(p_name));
+	return (color_map.has(p_node_type) && color_map[p_node_type].has(p_name));
 }
 
-void Theme::clear_color(const StringName &p_name, const StringName &p_type) {
+void Theme::clear_color(const StringName &p_name, const StringName &p_node_type) {
 
-	ERR_FAIL_COND(!color_map.has(p_type));
-	ERR_FAIL_COND(!color_map[p_type].has(p_name));
+	ERR_FAIL_COND(!color_map.has(p_node_type));
+	ERR_FAIL_COND(!color_map[p_node_type].has(p_name));
 
-	color_map[p_type].erase(p_name);
+	color_map[p_node_type].erase(p_name);
 	_change_notify();
 	emit_changed();
 }
 
-void Theme::get_color_list(StringName p_type, List<StringName> *p_list) const {
+void Theme::get_color_list(StringName p_node_type, List<StringName> *p_list) const {
 
 	ERR_FAIL_NULL(p_list);
 
-	if (!color_map.has(p_type))
+	if (!color_map.has(p_node_type))
 		return;
 
 	const StringName *key = NULL;
 
-	while ((key = color_map[p_type].next(key))) {
+	while ((key = color_map[p_node_type].next(key))) {
 
 		p_list->push_back(*key);
 	}
 }
 
-void Theme::set_constant(const StringName &p_name, const StringName &p_type, int p_constant) {
+void Theme::set_constant(const StringName &p_name, const StringName &p_node_type, int p_constant) {
 
-	bool new_value = !constant_map.has(p_type) || !constant_map[p_type].has(p_name);
-	constant_map[p_type][p_name] = p_constant;
+	bool new_value = !constant_map.has(p_node_type) || !constant_map[p_node_type].has(p_name);
+	constant_map[p_node_type][p_name] = p_constant;
 
 	if (new_value) {
 		_change_notify();
@@ -673,40 +673,40 @@ void Theme::set_constant(const StringName &p_name, const StringName &p_type, int
 	}
 }
 
-int Theme::get_constant(const StringName &p_name, const StringName &p_type) const {
+int Theme::get_constant(const StringName &p_name, const StringName &p_node_type) const {
 
-	if (constant_map.has(p_type) && constant_map[p_type].has(p_name))
-		return constant_map[p_type][p_name];
+	if (constant_map.has(p_node_type) && constant_map[p_node_type].has(p_name))
+		return constant_map[p_node_type][p_name];
 	else {
 		return 0;
 	}
 }
 
-bool Theme::has_constant(const StringName &p_name, const StringName &p_type) const {
+bool Theme::has_constant(const StringName &p_name, const StringName &p_node_type) const {
 
-	return (constant_map.has(p_type) && constant_map[p_type].has(p_name));
+	return (constant_map.has(p_node_type) && constant_map[p_node_type].has(p_name));
 }
 
-void Theme::clear_constant(const StringName &p_name, const StringName &p_type) {
+void Theme::clear_constant(const StringName &p_name, const StringName &p_node_type) {
 
-	ERR_FAIL_COND(!constant_map.has(p_type));
-	ERR_FAIL_COND(!constant_map[p_type].has(p_name));
+	ERR_FAIL_COND(!constant_map.has(p_node_type));
+	ERR_FAIL_COND(!constant_map[p_node_type].has(p_name));
 
-	constant_map[p_type].erase(p_name);
+	constant_map[p_node_type].erase(p_name);
 	_change_notify();
 	emit_changed();
 }
 
-void Theme::get_constant_list(StringName p_type, List<StringName> *p_list) const {
+void Theme::get_constant_list(StringName p_node_type, List<StringName> *p_list) const {
 
 	ERR_FAIL_NULL(p_list);
 
-	if (!constant_map.has(p_type))
+	if (!constant_map.has(p_node_type))
 		return;
 
 	const StringName *key = NULL;
 
-	while ((key = constant_map[p_type].next(key))) {
+	while ((key = constant_map[p_node_type].next(key))) {
 
 		p_list->push_back(*key);
 	}
@@ -868,43 +868,43 @@ void Theme::get_type_list(List<StringName> *p_list) const {
 
 void Theme::_bind_methods() {
 
-	ClassDB::bind_method(D_METHOD("set_icon", "name", "type", "texture"), &Theme::set_icon);
-	ClassDB::bind_method(D_METHOD("get_icon", "name", "type"), &Theme::get_icon);
-	ClassDB::bind_method(D_METHOD("has_icon", "name", "type"), &Theme::has_icon);
-	ClassDB::bind_method(D_METHOD("clear_icon", "name", "type"), &Theme::clear_icon);
-	ClassDB::bind_method(D_METHOD("get_icon_list", "type"), &Theme::_get_icon_list);
+	ClassDB::bind_method(D_METHOD("set_icon", "name", "node_type", "texture"), &Theme::set_icon);
+	ClassDB::bind_method(D_METHOD("get_icon", "name", "node_type"), &Theme::get_icon);
+	ClassDB::bind_method(D_METHOD("has_icon", "name", "node_type"), &Theme::has_icon);
+	ClassDB::bind_method(D_METHOD("clear_icon", "name", "node_type"), &Theme::clear_icon);
+	ClassDB::bind_method(D_METHOD("get_icon_list", "node_type"), &Theme::_get_icon_list);
 
-	ClassDB::bind_method(D_METHOD("set_stylebox", "name", "type", "texture"), &Theme::set_stylebox);
-	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "type"), &Theme::get_stylebox);
-	ClassDB::bind_method(D_METHOD("has_stylebox", "name", "type"), &Theme::has_stylebox);
-	ClassDB::bind_method(D_METHOD("clear_stylebox", "name", "type"), &Theme::clear_stylebox);
-	ClassDB::bind_method(D_METHOD("get_stylebox_list", "type"), &Theme::_get_stylebox_list);
+	ClassDB::bind_method(D_METHOD("set_stylebox", "name", "node_type", "texture"), &Theme::set_stylebox);
+	ClassDB::bind_method(D_METHOD("get_stylebox", "name", "node_type"), &Theme::get_stylebox);
+	ClassDB::bind_method(D_METHOD("has_stylebox", "name", "node_type"), &Theme::has_stylebox);
+	ClassDB::bind_method(D_METHOD("clear_stylebox", "name", "node_type"), &Theme::clear_stylebox);
+	ClassDB::bind_method(D_METHOD("get_stylebox_list", "node_type"), &Theme::_get_stylebox_list);
 	ClassDB::bind_method(D_METHOD("get_stylebox_types"), &Theme::_get_stylebox_types);
 
-	ClassDB::bind_method(D_METHOD("set_font", "name", "type", "font"), &Theme::set_font);
-	ClassDB::bind_method(D_METHOD("get_font", "name", "type"), &Theme::get_font);
-	ClassDB::bind_method(D_METHOD("has_font", "name", "type"), &Theme::has_font);
-	ClassDB::bind_method(D_METHOD("clear_font", "name", "type"), &Theme::clear_font);
-	ClassDB::bind_method(D_METHOD("get_font_list", "type"), &Theme::_get_font_list);
+	ClassDB::bind_method(D_METHOD("set_font", "name", "node_type", "font"), &Theme::set_font);
+	ClassDB::bind_method(D_METHOD("get_font", "name", "node_type"), &Theme::get_font);
+	ClassDB::bind_method(D_METHOD("has_font", "name", "node_type"), &Theme::has_font);
+	ClassDB::bind_method(D_METHOD("clear_font", "name", "node_type"), &Theme::clear_font);
+	ClassDB::bind_method(D_METHOD("get_font_list", "node_type"), &Theme::_get_font_list);
 
-	ClassDB::bind_method(D_METHOD("set_color", "name", "type", "color"), &Theme::set_color);
-	ClassDB::bind_method(D_METHOD("get_color", "name", "type"), &Theme::get_color);
-	ClassDB::bind_method(D_METHOD("has_color", "name", "type"), &Theme::has_color);
-	ClassDB::bind_method(D_METHOD("clear_color", "name", "type"), &Theme::clear_color);
-	ClassDB::bind_method(D_METHOD("get_color_list", "type"), &Theme::_get_color_list);
+	ClassDB::bind_method(D_METHOD("set_color", "name", "node_type", "color"), &Theme::set_color);
+	ClassDB::bind_method(D_METHOD("get_color", "name", "node_type"), &Theme::get_color);
+	ClassDB::bind_method(D_METHOD("has_color", "name", "node_type"), &Theme::has_color);
+	ClassDB::bind_method(D_METHOD("clear_color", "name", "node_type"), &Theme::clear_color);
+	ClassDB::bind_method(D_METHOD("get_color_list", "node_type"), &Theme::_get_color_list);
 
-	ClassDB::bind_method(D_METHOD("set_constant", "name", "type", "constant"), &Theme::set_constant);
-	ClassDB::bind_method(D_METHOD("get_constant", "name", "type"), &Theme::get_constant);
-	ClassDB::bind_method(D_METHOD("has_constant", "name", "type"), &Theme::has_constant);
-	ClassDB::bind_method(D_METHOD("clear_constant", "name", "type"), &Theme::clear_constant);
-	ClassDB::bind_method(D_METHOD("get_constant_list", "type"), &Theme::_get_constant_list);
+	ClassDB::bind_method(D_METHOD("set_constant", "name", "node_type", "constant"), &Theme::set_constant);
+	ClassDB::bind_method(D_METHOD("get_constant", "name", "node_type"), &Theme::get_constant);
+	ClassDB::bind_method(D_METHOD("has_constant", "name", "node_type"), &Theme::has_constant);
+	ClassDB::bind_method(D_METHOD("clear_constant", "name", "node_type"), &Theme::clear_constant);
+	ClassDB::bind_method(D_METHOD("get_constant_list", "node_type"), &Theme::_get_constant_list);
 
 	ClassDB::bind_method(D_METHOD("clear"), &Theme::clear);
 
 	ClassDB::bind_method(D_METHOD("set_default_font", "font"), &Theme::set_default_theme_font);
 	ClassDB::bind_method(D_METHOD("get_default_font"), &Theme::get_default_theme_font);
 
-	ClassDB::bind_method(D_METHOD("get_type_list", "type"), &Theme::_get_type_list);
+	ClassDB::bind_method(D_METHOD("get_type_list", "node_type"), &Theme::_get_type_list);
 
 	ClassDB::bind_method(D_METHOD("_emit_theme_changed"), &Theme::_emit_theme_changed);
 

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -52,13 +52,13 @@ class Theme : public Resource {
 	HashMap<StringName, HashMap<StringName, Color> > color_map;
 	HashMap<StringName, HashMap<StringName, int> > constant_map;
 
-	PoolVector<String> _get_icon_list(const String &p_type) const;
-	PoolVector<String> _get_stylebox_list(const String &p_type) const;
+	PoolVector<String> _get_icon_list(const String &p_node_type) const;
+	PoolVector<String> _get_stylebox_list(const String &p_node_type) const;
 	PoolVector<String> _get_stylebox_types(void) const;
-	PoolVector<String> _get_font_list(const String &p_type) const;
-	PoolVector<String> _get_color_list(const String &p_type) const;
-	PoolVector<String> _get_constant_list(const String &p_type) const;
-	PoolVector<String> _get_type_list(const String &p_type) const;
+	PoolVector<String> _get_font_list(const String &p_node_type) const;
+	PoolVector<String> _get_color_list(const String &p_node_type) const;
+	PoolVector<String> _get_constant_list(const String &p_node_type) const;
+	PoolVector<String> _get_type_list(const String &p_node_type) const;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -89,42 +89,42 @@ public:
 	void set_default_theme_font(const Ref<Font> &p_default_font);
 	Ref<Font> get_default_theme_font() const;
 
-	void set_icon(const StringName &p_name, const StringName &p_type, const Ref<Texture> &p_icon);
-	Ref<Texture> get_icon(const StringName &p_name, const StringName &p_type) const;
-	bool has_icon(const StringName &p_name, const StringName &p_type) const;
-	void clear_icon(const StringName &p_name, const StringName &p_type);
-	void get_icon_list(StringName p_type, List<StringName> *p_list) const;
+	void set_icon(const StringName &p_name, const StringName &p_node_type, const Ref<Texture> &p_icon);
+	Ref<Texture> get_icon(const StringName &p_name, const StringName &p_node_type) const;
+	bool has_icon(const StringName &p_name, const StringName &p_node_type) const;
+	void clear_icon(const StringName &p_name, const StringName &p_node_type);
+	void get_icon_list(StringName p_node_type, List<StringName> *p_list) const;
 
-	void set_shader(const StringName &p_name, const StringName &p_type, const Ref<Shader> &p_shader);
-	Ref<Shader> get_shader(const StringName &p_name, const StringName &p_type) const;
-	bool has_shader(const StringName &p_name, const StringName &p_type) const;
-	void clear_shader(const StringName &p_name, const StringName &p_type);
-	void get_shader_list(const StringName &p_type, List<StringName> *p_list) const;
+	void set_shader(const StringName &p_name, const StringName &p_node_type, const Ref<Shader> &p_shader);
+	Ref<Shader> get_shader(const StringName &p_name, const StringName &p_node_type) const;
+	bool has_shader(const StringName &p_name, const StringName &p_node_type) const;
+	void clear_shader(const StringName &p_name, const StringName &p_node_type);
+	void get_shader_list(const StringName &p_node_type, List<StringName> *p_list) const;
 
-	void set_stylebox(const StringName &p_name, const StringName &p_type, const Ref<StyleBox> &p_style);
-	Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_type) const;
-	bool has_stylebox(const StringName &p_name, const StringName &p_type) const;
-	void clear_stylebox(const StringName &p_name, const StringName &p_type);
-	void get_stylebox_list(StringName p_type, List<StringName> *p_list) const;
+	void set_stylebox(const StringName &p_name, const StringName &p_node_type, const Ref<StyleBox> &p_style);
+	Ref<StyleBox> get_stylebox(const StringName &p_name, const StringName &p_node_type) const;
+	bool has_stylebox(const StringName &p_name, const StringName &p_node_type) const;
+	void clear_stylebox(const StringName &p_name, const StringName &p_node_type);
+	void get_stylebox_list(StringName p_node_type, List<StringName> *p_list) const;
 	void get_stylebox_types(List<StringName> *p_list) const;
 
-	void set_font(const StringName &p_name, const StringName &p_type, const Ref<Font> &p_font);
-	Ref<Font> get_font(const StringName &p_name, const StringName &p_type) const;
-	bool has_font(const StringName &p_name, const StringName &p_type) const;
-	void clear_font(const StringName &p_name, const StringName &p_type);
-	void get_font_list(StringName p_type, List<StringName> *p_list) const;
+	void set_font(const StringName &p_name, const StringName &p_node_type, const Ref<Font> &p_font);
+	Ref<Font> get_font(const StringName &p_name, const StringName &p_node_type) const;
+	bool has_font(const StringName &p_name, const StringName &p_node_type) const;
+	void clear_font(const StringName &p_name, const StringName &p_node_type);
+	void get_font_list(StringName p_node_type, List<StringName> *p_list) const;
 
-	void set_color(const StringName &p_name, const StringName &p_type, const Color &p_color);
-	Color get_color(const StringName &p_name, const StringName &p_type) const;
-	bool has_color(const StringName &p_name, const StringName &p_type) const;
-	void clear_color(const StringName &p_name, const StringName &p_type);
-	void get_color_list(StringName p_type, List<StringName> *p_list) const;
+	void set_color(const StringName &p_name, const StringName &p_node_type, const Color &p_color);
+	Color get_color(const StringName &p_name, const StringName &p_node_type) const;
+	bool has_color(const StringName &p_name, const StringName &p_node_type) const;
+	void clear_color(const StringName &p_name, const StringName &p_node_type);
+	void get_color_list(StringName p_node_type, List<StringName> *p_list) const;
 
-	void set_constant(const StringName &p_name, const StringName &p_type, int p_constant);
-	int get_constant(const StringName &p_name, const StringName &p_type) const;
-	bool has_constant(const StringName &p_name, const StringName &p_type) const;
-	void clear_constant(const StringName &p_name, const StringName &p_type);
-	void get_constant_list(StringName p_type, List<StringName> *p_list) const;
+	void set_constant(const StringName &p_name, const StringName &p_node_type, int p_constant);
+	int get_constant(const StringName &p_name, const StringName &p_node_type) const;
+	bool has_constant(const StringName &p_name, const StringName &p_node_type) const;
+	void clear_constant(const StringName &p_name, const StringName &p_node_type);
+	void get_constant_list(StringName p_node_type, List<StringName> *p_list) const;
 
 	void get_type_list(List<StringName> *p_list) const;
 


### PR DESCRIPTION
This makes it clearer that it expects a node type as a string (such as "Label") instead of a type like "TYPE_ARRAY". This is backwards-compatible since only the name of the parameter is changed, not its order.

See https://github.com/godotengine/godot-proposals/issues/1495#issuecomment-691507839.