### PR TITLE
Translate GDScript Code Examples to C# (Classes beginning with C)

### DIFF
--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -6,15 +6,32 @@
 	<description>
 		[Callable] is a first class object which can be held in variables and passed to functions. It represents a given method in an [Object], and is typically used for signal callbacks.
 		[b]Example:[/b]
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var callable = Callable(self, "print_args")
 		func print_args(arg1, arg2, arg3 = ""):
 		    prints(arg1, arg2, arg3)
+
 		func test():
 		    callable.call("hello", "world")  # Prints "hello world".
 		    callable.call(Vector2.UP, 42, callable)  # Prints "(0, -1) 42 Node(Node.gd)::print_args".
 		    callable.call("invalid")  # Invalid call, should have at least 2 arguments.
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		Callable callable = new Callable(this, "print_args");
+		public void PrintArgs(object arg1, object arg2, object arg3 = "")
+		{
+		    GD.PrintS(arg1, arg2, arg3);
+		}
+
+		public void Test()
+		{
+		    callable.Call("hello", "world"); // Prints "hello world".
+		    callable.Call(Vector2.Up, 42, callable); // Prints "(0, -1) 42 Node(Node.gd)::print_args".
+		    callable.Call("invalid"); // Invalid call, should have at least 2 arguments.
+		}
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -318,13 +318,22 @@
 			<description>
 				Draws [code]text[/code] using the specified [code]font[/code] at the [code]position[/code] (top-left corner). The text will have its color multiplied by [code]modulate[/code]. If [code]clip_w[/code] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
 				[b]Example using the default project font:[/b]
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				# If using this method in a script that redraws constantly, move the
 				# `default_font` declaration to a member variable assigned in `_ready()`
 				# so the Control is only created once.
 				var default_font = Control.new().get_font("font")
 				draw_string(default_font, Vector2(64, 64), "Hello world")
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				// If using this method in a script that redraws constantly, move the
+				// `default_font` declaration to a member variable assigned in `_ready()`
+				// so the Control is only created once.
+				Font defaultFont = new Control().GetFont("font");
+				DrawString(defaultFont, new Vector2(64, 64), "Hello world");
+				[/csharp]
+				[/codeblocks]
 				See also [method Font.draw].
 			</description>
 		</method>

--- a/doc/classes/CharFXTransform.xml
+++ b/doc/classes/CharFXTransform.xml
@@ -18,11 +18,18 @@
 		</member>
 		<member name="character" type="int" setter="set_character" getter="get_character" default="0">
 			The Unicode codepoint the character will use. This only affects non-whitespace characters. [method @GDScript.ord] can be useful here. For example, the following will replace all characters with asterisks:
-			[codeblock]
+			[codeblocks]
+			[gdscript]
 			# `char_fx` is the CharFXTransform parameter from `_process_custom_fx()`.
 			# See the RichTextEffect documentation for details.
 			char_fx.character = ord("*")
-			[/codeblock]
+			[/gdscript]
+			[csharp]
+			// `char_fx` is the CharFXTransform parameter from `_process_custom_fx()`.
+			// See the RichTextEffect documentation for details.
+			charFx.Character = char.GetNumericValue('*');
+			[/csharp]
+			[/codeblocks]
 		</member>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 0, 0, 0, 1 )">
 			The color the character will be drawn with.

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -20,21 +20,39 @@
 			</argument>
 			<description>
 				Constructs a color from an HTML hexadecimal color string in RGB or RGBA format. See also [method @GDScript.ColorN].
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				# Each of the following creates the same color RGBA(178, 217, 10, 255).
 				var c3 = Color("#b2d90a") # RGB format with "#".
 				var c4 = Color("b2d90a") # RGB format.
 				var c1 = Color("#b2d90aff") # RGBA format with "#".
 				var c2 = Color("b2d90aff") # RGBA format.
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				// Each of the following creates the same color RGBA(178, 217, 10, 255).
+				var c3 = new Color("#b2d90a");
+				var c4 = new Color("b2d90a"); // RGB format.
+				var c1 = new Color("#b2d90aff");
+				var c2 = new Color("b2d90aff"); // RGBA format.
+				[/csharp]
+				[/codeblocks]
 				You can also use the "web color" short-hand form by only using 3 or 4 digits.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				# Each of the following creates the same color RGBA(17, 34, 51, 255).
 				var c3 = Color("#123") # RGB format with "#".
 				var c4 = Color("123") # RGB format.
 				var c1 = Color("#123f") # RGBA format with "#".
 				var c2 = Color("123f") # RGBA format.
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				// Each of the following creates the same color RGBA(17, 34, 51, 255).
+				var c3 = new Color("#123");
+				var c4 = new Color("123"); // RGB format.
+				var c1 = new Color("#123f");
+				var c2 = new Color("123f"); // RGBA format.
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="Color">
@@ -44,9 +62,14 @@
 			</argument>
 			<description>
 				Constructs a color from a 32-bit integer (each byte represents a component of the RGBA profile).
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var c = Color(274) # Equivalent to RGBA(0, 0, 1, 18)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var c = new Color(274); // Equivalent to RGBA(0, 0, 1, 18)
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="Color">
@@ -58,9 +81,14 @@
 			</argument>
 			<description>
 				Constructs a color from an existing color, but with a custom alpha value.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var red = Color(Color.red, 0.5) # 50% transparent red.
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var red = new Color(Colors.Red, 0.5f); // 50% transparent red.
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="Color">
@@ -74,9 +102,14 @@
 			</argument>
 			<description>
 				Constructs a color from an RGB profile using values between 0 and 1. Alpha will always be 1.
-				[codeblock]
-				var c = Color(0.2, 1.0, 0.7) # Equivalent to RGBA(51, 255, 178, 255)
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				var color = Color(0.2, 1.0, 0.7) # Equivalent to RGBA(51, 255, 178, 255)
+				[/gdscript]
+				[csharp]
+				var color = new Color(0.2f, 1.0f, 0.7f); // Equivalent to RGBA(51, 255, 178, 255)
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="Color">
@@ -92,9 +125,14 @@
 			</argument>
 			<description>
 				Constructs a color from an RGBA profile using values between 0 and 1.
-				[codeblock]
-				var c = Color(0.2, 1.0, 0.7, 0.8) # Equivalent to RGBA(51, 255, 178, 204)
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				var color = Color(0.2, 1.0, 0.7, 0.8) # Equivalent to RGBA(51, 255, 178, 204)
+				[/gdscript]
+				[csharp]
+				var color = new Color(0.2f, 1.0f, 0.7f, 0.8f); // Equivalent to RGBA(51, 255, 178, 255, 204)
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="blend">
@@ -104,11 +142,18 @@
 			</argument>
 			<description>
 				Returns a new color resulting from blending this color over another. If the color is opaque, the result is also opaque. The second color may have a range of alpha values.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var bg = Color(0.0, 1.0, 0.0, 0.5) # Green with alpha of 50%
 				var fg = Color(1.0, 0.0, 0.0, 0.5) # Red with alpha of 50%
 				var blended_color = bg.blend(fg) # Brown with alpha of 75%
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var bg = new Color(0.0f, 1.0f, 0.0f, 0.5f); // Green with alpha of 50%
+				var fg = new Color(1.0f, 0.0f, 0.0f, 0.5f); // Red with alpha of 50%
+				Color blendedColor = bg.Blend(fg); // Brown with alpha of 75%
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="contrasted">
@@ -116,10 +161,16 @@
 			</return>
 			<description>
 				Returns the most contrasting color.
-				[codeblock]
-				var c = Color(0.3, 0.4, 0.9)
-				var contrasted_color = c.contrasted() # Equivalent to RGBA(204, 229, 102, 255)
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				var color = Color(0.3, 0.4, 0.9)
+				var contrasted_color = color.contrasted() # Equivalent to RGBA(204, 229, 102, 255)
+				[/gdscript]
+				[csharp]
+				var color = new Color(0.3f, 0.4f, 0.9f);
+				Color contrastedColor = color.Contrasted(); // Equivalent to RGBA(204, 229, 102, 255)
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="darkened">
@@ -129,10 +180,16 @@
 			</argument>
 			<description>
 				Returns a new color resulting from making this color darker by the specified percentage (ratio from 0 to 1).
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var green = Color(0.0, 1.0, 0.0)
 				var darkgreen = green.darkened(0.2) # 20% darker than regular green
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var green = new Color(0.0f, 1.0f, 0.0f);
+				Color darkgreen = green.Darkened(0.2f); // 20% darker than regular green
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="from_hsv">
@@ -148,9 +205,14 @@
 			</argument>
 			<description>
 				Constructs a color from an HSV profile. [code]h[/code], [code]s[/code], and [code]v[/code] are values between 0 and 1.
-				[codeblock]
-				var c = Color.from_hsv(0.58, 0.5, 0.79, 0.8) # Equivalent to HSV(210, 50, 79, 0.8) or Color8(100, 151, 201, 0.8)
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				var color = Color.from_hsv(0.58, 0.5, 0.79, 0.8) # Equivalent to HSV(210, 50, 79, 0.8) or Color8(100, 151, 201, 0.8)
+				[/gdscript]
+				[csharp]
+				Color color = Color.FromHsv(0.58f, 0.5f, 0.79f, 0.8f); // Equivalent to HSV(210, 50, 79, 0.8) or Color8(100, 151, 201, 0.8)
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="inverted">
@@ -158,10 +220,16 @@
 			</return>
 			<description>
 				Returns the inverted color [code](1 - r, 1 - g, 1 - b, a)[/code].
-				[codeblock]
-				var c = Color(0.3, 0.4, 0.9)
-				var inverted_color = c.inverted() # A color of an RGBA(178, 153, 26, 255)
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				var color = Color(0.3, 0.4, 0.9)
+				var inverted_color = color.inverted() # A color of an RGBA(178, 153, 26, 255)
+				[/gdscript]
+				[csharp]
+				var color = new Color(0.3f, 0.4f, 0.9f);
+				Color invertedColor = color.Inverted(); // A color of an RGBA(178, 153, 26, 255)
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="is_equal_approx">
@@ -182,11 +250,18 @@
 			</argument>
 			<description>
 				Returns the linear interpolation with another color. The interpolation factor [code]t[/code] is between 0 and 1.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var c1 = Color(1.0, 0.0, 0.0)
 				var c2 = Color(0.0, 1.0, 0.0)
-				var li_c = c1.lerp(c2, 0.5) # A color of an RGBA(128, 128, 0, 255)
-				[/codeblock]
+				var lerp_color = c1.lerp(c2, 0.5) # A color of an RGBA(128, 128, 0, 255)
+				[/gdscript]
+				[csharp]
+				var c1 = new Color(1.0f, 0.0f, 0.0f);
+				var c2 = new Color(0.0f, 1.0f, 0.0f);
+				Color lerpColor = c1.Lerp(c2, 0.5f); // A color of an RGBA(128, 128, 0, 255)
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="lightened">
@@ -196,10 +271,16 @@
 			</argument>
 			<description>
 				Returns a new color resulting from making this color lighter by the specified percentage (ratio from 0 to 1).
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var green = Color(0.0, 1.0, 0.0)
 				var lightgreen = green.lightened(0.2) # 20% lighter than regular green
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var green = new Color(0.0f, 1.0f, 0.0f);
+				Color lightgreen = green.Lightened(0.2f); // 20% lighter than regular green
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="to_abgr32">
@@ -207,10 +288,16 @@
 			</return>
 			<description>
 				Returns the color's 32-bit integer in ABGR format (each byte represents a component of the ABGR profile). ABGR is the reversed version of the default format.
-				[codeblock]
-				var c = Color(1, 0.5, 0.2)
-				print(c.to_abgr32()) # Prints 4281565439
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				var color = Color(1, 0.5, 0.2)
+				print(color.to_abgr32()) # Prints 4281565439
+				[/gdscript]
+				[csharp]
+				var color = new Color(1.0f, 0.5f, 0.2f);
+				GD.Print(color.ToAbgr32()); // Prints 4281565439
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="to_abgr64">
@@ -218,10 +305,16 @@
 			</return>
 			<description>
 				Returns the color's 64-bit integer in ABGR format (each word represents a component of the ABGR profile). ABGR is the reversed version of the default format.
-				[codeblock]
-				var c = Color(1, 0.5, 0.2)
-				print(c.to_abgr64()) # Prints -225178692812801
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				var color = Color(1, 0.5, 0.2)
+				print(color.to_abgr64()) # Prints -225178692812801
+				[/gdscript]
+				[csharp]
+				var color = new Color(1.0f, 0.5f, 0.2f);
+				GD.Print(color.ToAbgr64()); // Prints -225178692812801
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="to_argb32">
@@ -229,10 +322,16 @@
 			</return>
 			<description>
 				Returns the color's 32-bit integer in ARGB format (each byte represents a component of the ARGB profile). ARGB is more compatible with DirectX.
-				[codeblock]
-				var c = Color(1, 0.5, 0.2)
-				print(c.to_argb32()) # Prints 4294934323
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				var color = Color(1, 0.5, 0.2)
+				print(color.to_argb32()) # Prints 4294934323
+				[/gdscript]
+				[csharp]
+				var color = new Color(1.0f, 0.5f, 0.2f);
+				GD.Print(color.ToArgb32()); // Prints 4294934323
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="to_argb64">
@@ -240,10 +339,16 @@
 			</return>
 			<description>
 				Returns the color's 64-bit integer in ARGB format (each word represents a component of the ARGB profile). ARGB is more compatible with DirectX.
-				[codeblock]
-				var c = Color(1, 0.5, 0.2)
-				print(c.to_argb64()) # Prints -2147470541
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				var color = Color(1, 0.5, 0.2)
+				print(color.to_argb64()) # Prints -2147470541
+				[/gdscript]
+				[csharp]
+				var color = new Color(1.0f, 0.5f, 0.2f);
+				GD.Print(color.ToArgb64()); // Prints -2147470541
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="to_html">
@@ -254,11 +359,18 @@
 			<description>
 				Returns the color's HTML hexadecimal color string in RGBA format (ex: [code]ff34f822[/code]).
 				Setting [code]with_alpha[/code] to [code]false[/code] excludes alpha from the hexadecimal string (and uses RGB instead of RGBA format).
-				[codeblock]
-				var c = Color(1, 1, 1, 0.5)
-				var s1 = c.to_html() # Returns "ffffff7f"
-				var s2 = c.to_html(false) # Returns "ffffff"
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				var color = Color(1, 1, 1, 0.5)
+				var with_alpha = color.to_html() # Returns "ffffff7f"
+				var without_alpha = color.to_html(false) # Returns "ffffff"
+				[/gdscript]
+				[csharp]
+				var color = new Color(1, 1, 1, 0.5f);
+				String withAlpha = color.ToHtml(); // Returns "ffffff7f"
+				String withoutAlpha = color.ToHtml(false); // Returns "ffffff"
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="to_rgba32">
@@ -266,10 +378,16 @@
 			</return>
 			<description>
 				Returns the color's 32-bit integer in RGBA format (each byte represents a component of the RGBA profile). RGBA is Godot's default format.
-				[codeblock]
-				var c = Color(1, 0.5, 0.2)
-				print(c.to_rgba32()) # Prints 4286526463
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				var color = Color(1, 0.5, 0.2)
+				print(color.to_rgba32()) # Prints 4286526463
+				[/gdscript]
+				[csharp]
+				var color = new Color(1, 0.5f, 0.2f);
+				GD.Print(color.ToRgba32()); // Prints 4286526463
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="to_rgba64">
@@ -277,10 +395,16 @@
 			</return>
 			<description>
 				Returns the color's 64-bit integer in RGBA format (each word represents a component of the RGBA profile). RGBA is Godot's default format.
-				[codeblock]
-				var c = Color(1, 0.5, 0.2)
-				print(c.to_rgba64()) # Prints -140736629309441
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				var color = Color(1, 0.5, 0.2)
+				print(color.to_rgba64()) # Prints -140736629309441
+				[/gdscript]
+				[csharp]
+				var color = new Color(1, 0.5f, 0.2f);
+				GD.Print(color.ToRgba64()); // Prints -140736629309441
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ColorRect.xml
+++ b/doc/classes/ColorRect.xml
@@ -13,9 +13,14 @@
 	<members>
 		<member name="color" type="Color" setter="set_frame_color" getter="get_frame_color" default="Color( 1, 1, 1, 1 )">
 			The fill color.
-			[codeblock]
+			[codeblocks]
+			[gdscript]
 			$ColorRect.color = Color(1, 0, 0, 1) # Set ColorRect's color to red.
-			[/codeblock]
+			[/gdscript]
+			[csharp]
+			GetNode&lt;ColorRect&gt;("ColorRect").Color = new Color(1, 0, 0, 1); // Set ColorRect's color to red.
+			[/csharp]
+			[/codeblocks]
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -13,7 +13,8 @@
 		[/codeblock]
 		The stored data can be saved to or parsed from a file, though ConfigFile objects can also be used directly without accessing the filesystem.
 		The following example shows how to parse an INI-style file from the system, read its contents and store new values in it:
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var config = ConfigFile.new()
 		var err = config.load("user://settings.cfg")
 		if err == OK: # If not, something went wrong with the file loading
@@ -24,7 +25,24 @@
 		        config.set_value("audio", "mute", false)
 		    # Save the changes by overwriting the previous file
 		    config.save("user://settings.cfg")
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		var config = new ConfigFile();
+		Error err = config.Load("user://settings.cfg");
+		if (err == Error.Ok) // If not, something went wrong with the file loading
+		{
+		    // Look for the display/width pair, and default to 1024 if missing
+		    int screenWidth = (int)config.GetValue("display", "width", 1024);
+		    // Store a variable if and only if it hasn't been defined yet
+		    if (!config.HasSectionKey("audio", "mute"))
+		    {
+		        config.SetValue("audio", "mute", false);
+		    }
+		    // Save the changes by overwriting the previous file
+		    config.Save("user://settings.cfg");
+		}
+		[/csharp]
+		[/codeblocks]
 		Keep in mind that section and property names can't contain spaces. Anything after a space will be ignored on save and on load.
 		ConfigFiles can also contain manually written comment lines starting with a semicolon ([code];[/code]). Those lines will be ignored when parsing the file. Note that comments will be lost when saving the ConfigFile. This can still be useful for dedicated server configuration files, which are typically never overwritten without explicit user action.
 	</description>

--- a/doc/classes/ConfirmationDialog.xml
+++ b/doc/classes/ConfirmationDialog.xml
@@ -6,9 +6,14 @@
 	<description>
 		Dialog for confirmation of actions. This dialog inherits from [AcceptDialog], but has by default an OK and Cancel button (in host OS order).
 		To get cancel action, you can use:
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		get_cancel().connect("pressed", self, "cancelled")
-		[/codeblock].
+		[/gdscript]
+		[csharp]
+		GetCancel().Connect("pressed", this, nameof(Cancelled));
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -44,12 +44,27 @@
 			<description>
 				Virtual method to be implemented by the user. Use this method to process and accept inputs on UI elements. See [method accept_event].
 				Example: clicking a control.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				func _gui_input(event):
 				    if event is InputEventMouseButton:
 				        if event.button_index == BUTTON_LEFT and event.pressed:
 				            print("I've been clicked D:")
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				public override void _GuiInput(InputEvent @event)
+				{
+				    if (@event is InputEventMouseButton)
+				    {
+				        var mb = @event as InputEventMouseButton;
+				        if (mb.ButtonIndex == (int)ButtonList.Left &amp;&amp; mb.Pressed)
+				        {
+				            GD.Print("I've been clicked D:");
+				        }
+				    }
+				}
+				[/csharp]
+				[/codeblocks]
 				The event won't trigger if:
 				* clicking outside the control (see [method has_point]);
 				* control has [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE];
@@ -68,19 +83,39 @@
 				The returned node must be of type [Control] or Control-derieved. It can have child nodes of any type. It is freed when the tooltip disappears, so make sure you always provide a new instance, not e.g. a node from scene. When [code]null[/code] or non-Control node is returned, the default tooltip will be used instead.
 				[b]Note:[/b] The tooltip is shrunk to minimal size. If you want to ensure it's fully visible, you might want to set its [member rect_min_size] to some non-zero value.
 				Example of usage with custom-constructed node:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				func _make_custom_tooltip(for_text):
 				    var label = Label.new()
 				    label.text = for_text
 				    return label
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				public override Godot.Object _MakeCustomTooltip(String forText)
+				{
+				    var label = new Label();
+				    label.Text = forText;
+				    return label;
+				}
+				[/csharp]
+				[/codeblocks]
 				Example of usage with custom scene instance:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				func _make_custom_tooltip(for_text):
 				    var tooltip = preload("SomeTooltipScene.tscn").instance()
 				    tooltip.get_node("Label").text = for_text
 				    return tooltip
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				public override Godot.Object _MakeCustomTooltip(String forText)
+				{
+				    Node tooltip = ResourceLoader.Load&lt;PackedScene&gt;("SomeTooltipScene.tscn").Instance();
+				    tooltip.GetNode&lt;Label&gt;("Label").Text = forText;
+				    return tooltip;
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="accept_event">
@@ -101,14 +136,22 @@
 				Overrides the [Color] with given [code]name[/code] in the [member theme] resource the control uses.
 				[b]Note:[/b] Unlike other theme overrides, there is no way to undo a color override without manually assigning the previous color.
 				[b]Example of overriding a label's color and resetting it later:[/b]
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				# Override the child node "MyLabel"'s font color to orange.
 				$MyLabel.add_theme_color_override("font_color", Color(1, 0.5, 0))
-
 				# Reset the color by creating a new node to get the default value:
 				var default_label_color = Label.new().get_theme_color("font_color")
 				$MyLabel.add_theme_color_override("font_color", default_label_color)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				// Override the child node "MyLabel"'s font color to orange.
+				GetNode&lt;Label&gt;("MyLabel").AddThemeColorOverride("font_color", new Color(1, 0.5f, 0));
+				// Reset the color by creating a new node to get the default value:
+				var defaultLabelColor = new Label().GetThemeColor("font_color");
+				GetNode&lt;Label&gt;("MyLabel").AddThemeColorOverride("font_color", defaultLabelColor);
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="add_theme_constant_override">
@@ -165,7 +208,8 @@
 			<description>
 				Overrides the [StyleBox] with given [code]name[/code] in the [member theme] resource the control uses. If [code]stylebox[/code] is empty or invalid, the override is cleared and the [StyleBox] from assigned [Theme] is used.
 				[b]Example of modifying a property in a StyleBox by duplicating it:[/b]
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				# The snippet below assumes the child node MyButton has a StyleBoxFlat assigned.
 				# Resources are shared across instances, so we need to duplicate it
 				# to avoid modifying the appearance of all other buttons.
@@ -173,10 +217,21 @@
 				new_stylebox_normal.border_width_top = 3
 				new_stylebox_normal.border_color = Color(0, 1, 0.5)
 				$MyButton.add_theme_stylebox_override("normal", new_stylebox_normal)
-
 				# Remove the stylebox override:
 				$MyButton.add_theme_stylebox_override("normal", null)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				// The snippet below assumes the child node MyButton has a StyleBoxFlat assigned.
+				// Resources are shared across instances, so we need to duplicate it
+				// to avoid modifying the appearance of all other buttons.
+				StyleBoxFlat newStyleboxNormal = GetNode&lt;Button&gt;("MyButton").GetThemeStylebox("normal").Duplicate() as StyleBoxFlat;
+				newStyleboxNormal.BorderWidthTop = 3;
+				newStyleboxNormal.BorderColor = new Color(0, 1, 0.5f);
+				GetNode&lt;Button&gt;("MyButton").AddThemeStyleboxOverride("normal", newStyleboxNormal);
+				// Remove the stylebox override:
+				GetNode&lt;Button&gt;("MyButton").AddThemeStyleboxOverride("normal", null);
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="can_drop_data" qualifiers="virtual">
@@ -189,12 +244,22 @@
 			<description>
 				Godot calls this method to test if [code]data[/code] from a control's [method get_drag_data] can be dropped at [code]position[/code]. [code]position[/code] is local to this control.
 				This method should only be used to test the data. Process the data in [method drop_data].
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				func can_drop_data(position, data):
 				    # Check position if it is relevant to you
 				    # Otherwise, just check data
 				    return typeof(data) == TYPE_DICTIONARY and data.has("expected")
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				public override bool CanDropData(Vector2 position, object data)
+				{
+				    // Check position if it is relevant to you
+				    // Otherwise, just check data
+				    return data is Godot.Collections.Dictionary &amp;&amp; (data as Godot.Collections.Dictionary).Contains("expected");
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="drop_data" qualifiers="virtual">
@@ -206,13 +271,24 @@
 			</argument>
 			<description>
 				Godot calls this method to pass you the [code]data[/code] from a control's [method get_drag_data] result. Godot first calls [method can_drop_data] to test if [code]data[/code] is allowed to drop at [code]position[/code] where [code]position[/code] is local to this control.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				func can_drop_data(position, data):
 				    return typeof(data) == TYPE_DICTIONARY and data.has("color")
-
 				func drop_data(position, data):
-				    color = data["color"]
-				[/codeblock]
+				    var color = data["color"]
+				[/gdscript]
+				[csharp]
+				public override bool CanDropData(Vector2 position, object data)
+				{
+				    return data is Godot.Collections.Dictionary &amp;&amp; (data as Godot.Collections.Dictionary).Contains("color");
+				}
+				public override void DropData(Vector2 position, object data)
+				{
+				    Color color = (Color)(data as Godot.Collections.Dictionary)["color"];
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="force_drag">
@@ -267,12 +343,22 @@
 			<description>
 				Godot calls this method to get data that can be dragged and dropped onto controls that expect drop data. Returns [code]null[/code] if there is no data to drag. Controls that want to receive drop data should implement [method can_drop_data] and [method drop_data]. [code]position[/code] is local to this control. Drag may be forced with [method force_drag].
 				A preview that will follow the mouse that should represent the data can be set with [method set_drag_preview]. A good time to set the preview is in this method.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				func get_drag_data(position):
-				    var mydata = make_data()
-				    set_drag_preview(make_preview(mydata))
+				    var mydata = make_data() # This is your custom method generating the drag data.
+				    set_drag_preview(make_preview(mydata)) # This is your custom method generating the preview of the drag data.
 				    return mydata
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				public override object GetDragData(Vector2 position)
+				{
+				    object mydata = MakeData(); // This is your custom method generating the drag data.
+				    SetDragPreview(MakePreview(mydata)); // This is your custom method generating the preview of the drag data.
+				    return mydata;
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_end" qualifiers="const">
@@ -358,10 +444,18 @@
 			</argument>
 			<description>
 				Returns a color from assigned [Theme] with given [code]name[/code] and associated with [Control] of given [code]type[/code].
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				func _ready():
 				    modulate = get_theme_color("font_color", "Button") #get the color defined for button fonts
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				public override void _Ready()
+				{
+				    Modulate = GetThemeColor("font_color", "Button"); //get the color defined for button fonts
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_theme_constant" qualifiers="const">
@@ -422,10 +516,18 @@
 			</return>
 			<description>
 				Creates an [InputEventMouseButton] that attempts to click the control. If the event is received, the control acquires focus.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				func _process(delta):
 				    grab_click_focus() #when clicking another Control node, this node will be clicked instead
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				public override void _Process(float delta)
+				{
+				    GrabClickFocus(); //when clicking another Control node, this node will be clicked instead
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="grab_focus">
@@ -652,24 +754,61 @@
 				Forwarding can be implemented in the target control similar to the methods [method get_drag_data], [method can_drop_data], and [method drop_data] but with two differences:
 				1. The function name must be suffixed with [b]_fw[/b]
 				2. The function must take an extra argument that is the control doing the forwarding
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				# ThisControl.gd
 				extends Control
+				export(Control) var target_control
+
 				func _ready():
 				    set_drag_forwarding(target_control)
 
 				# TargetControl.gd
 				extends Control
+
 				func can_drop_data_fw(position, data, from_control):
 				    return true
 
 				func drop_data_fw(position, data, from_control):
-				    my_handle_data(data)
+				    my_handle_data(data) # Your handler method.
 
 				func get_drag_data_fw(position, from_control):
 				    set_drag_preview(my_preview)
 				    return my_data()
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				// ThisControl.cs
+				public class ThisControl : Control
+				{
+				    [Export]
+				    public Control TargetControl { get; set; }
+				    public override void _Ready()
+				    {
+				        SetDragForwarding(TargetControl);
+				    }
+				}
+
+				// TargetControl.cs
+				public class TargetControl : Control
+				{
+				    public void CanDropDataFw(Vector2 position, object data, Control fromControl)
+				    {
+				        return true;
+				    }
+
+				    public void DropDataFw(Vector2 position, object data, Control fromControl)
+				    {
+				        MyHandleData(data); // Your handler method.
+				    }
+
+				    public void GetDragDataFw(Vector2 position, Control fromControl)
+				    {
+				        SetDragPreview(MyPreview);
+				        return MyData();
+				    }
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="set_drag_preview">
@@ -679,7 +818,8 @@
 			</argument>
 			<description>
 				Shows the given control at the mouse pointer. A good time to call this method is in [method get_drag_data]. The control must not be in the scene tree.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				export (Color, RGBA) var color = Color(1, 0, 0, 1)
 
 				func get_drag_data(position):
@@ -689,7 +829,22 @@
 				    cpb.rect_size = Vector2(50, 50)
 				    set_drag_preview(cpb)
 				    return color
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				[Export]
+				public Color Color = new Color(1, 0, 0, 1);
+
+				public override object GetDragData(Vector2 position)
+				{
+				    // Use a control that is not in the tree
+				    var cpb = new ColorPickerButton();
+				    cpb.Color = Color;
+				    cpb.RectSize = new Vector2(50, 50);
+				    SetDragPreview(cpb);
+				    return Color;
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="set_end">

--- a/doc/classes/Crypto.xml
+++ b/doc/classes/Crypto.xml
@@ -6,13 +6,12 @@
 	<description>
 		The Crypto class allows you to access some more advanced cryptographic functionalities in Godot.
 		For now, this includes generating cryptographically secure random bytes, RSA keys and self-signed X509 certificates generation, asymmetric key encryption/decryption, and signing/verification.
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		extends Node
-
 		var crypto = Crypto.new()
 		var key = CryptoKey.new()
 		var cert = X509Certificate.new()
-
 		func _ready():
 		    # Generate new RSA key.
 		    key = crypto.generate_rsa(4096)
@@ -33,7 +32,42 @@
 		    # Checks
 		    assert(verified)
 		    assert(data.to_utf8() == decrypted)
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		using Godot;
+		using System;
+		using System.Diagnostics;
+
+		public class CryptoNode : Node
+		{
+		    public Crypto Crypto = new Crypto();
+		    public CryptoKey Key = new CryptoKey();
+		    public X509Certificate Cert = new X509Certificate();
+		    public override void _Ready()
+		    {
+		        // Generate new RSA key.
+		        Key = Crypto.GenerateRsa(4096);
+		        // Generate new self-signed certificate with the given key.
+		        Cert = Crypto.GenerateSelfSignedCertificate(Key, "CN=mydomain.com,O=My Game Company,C=IT");
+		        // Save key and certificate in the user folder.
+		        Key.Save("user://generated.key");
+		        Cert.Save("user://generated.crt");
+		        // Encryption
+		        string data = "Some data";
+		        byte[] encrypted = Crypto.Encrypt(Key, data.ToUTF8());
+		        // Decryption
+		        byte[] decrypted = Crypto.Decrypt(Key, encrypted);
+		        // Signing
+		        byte[] signature = Crypto.Sign(HashingContext.HashType.Sha256, Data.SHA256Buffer(), Key);
+		        // Verifying
+		        bool verified = Crypto.Verify(HashingContext.HashType.Sha256, Data.SHA256Buffer(), signature, Key);
+		        // Checks
+		        Debug.Assert(verified);
+		        Debug.Assert(data.ToUTF8() == decrypted);
+		    }
+		}
+		[/csharp]
+		[/codeblocks]
 		[b]Note:[/b] Not available in HTML5 exports.
 	</description>
 	<tutorials>
@@ -95,13 +129,22 @@
 			<description>
 				Generates a self-signed [X509Certificate] from the given [CryptoKey] and [code]issuer_name[/code]. The certificate validity will be defined by [code]not_before[/code] and [code]not_after[/code] (first valid date and last valid date). The [code]issuer_name[/code] must contain at least "CN=" (common name, i.e. the domain name), "O=" (organization, i.e. your company name), "C=" (country, i.e. 2 lettered ISO-3166 code of the country the organization is based in).
 				A small example to generate an RSA key and a X509 self-signed certificate.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var crypto = Crypto.new()
 				# Generate 4096 bits RSA key.
 				var key = crypto.generate_rsa(4096)
 				# Generate self-signed certificate using the given key.
 				var cert = crypto.generate_self_signed_certificate(key, "CN=example.com,O=A Game Company,C=IT")
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var crypto = new Crypto();
+				// Generate 4096 bits RSA key.
+				CryptoKey key = crypto.GenerateRsa(4096);
+				// Generate self-signed certificate using the given key.
+				X509Certificate cert = crypto.GenerateSelfSignedCertificate(key, "CN=mydomain.com,O=My Game Company,C=IT");
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="sign">


### PR DESCRIPTION
Translates Code Examples in classes beginning with `C`.

Includes:
 * Callable
 * CanvasItem
 * CharFXTransform
 * Color
 * ColorRect
 * ConfigFile
 * ConfirmationDialog
 * Control
 * Crypto

Work was done while using and improving my [codetranslator](https://github.com/HaSa1002/codetranslator). I hope the ongoing effort pays out in less mistakes, altough I am not sure how much is catched.

Base PR multi-language code examples: #40613
Following: #40978 