### PR TITLE
set TextEdit's cursor column to 0 on first draw to prevent h_scroll

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4012,23 +4012,25 @@ void TextEdit::adjust_viewport_to_cursor() {
 	}
 	visible_width -= 20; // Give it a little more space.
 
-	if (!is_wrap_enabled()) {
-		// Adjust x offset.
-		int cursor_x = get_column_x_offset(cursor.column, text[cursor.line]);
+	if (first_draw) {
+		if (!is_wrap_enabled()) {
+			// Adjust x offset.
+			int cursor_x = get_column_x_offset(cursor.column, text[cursor.line]);
 
-		if (cursor_x > (cursor.x_ofs + visible_width)) {
-			cursor.x_ofs = cursor_x - visible_width + 1;
-		}
+			if (cursor_x > (cursor.x_ofs + visible_width)) {
+				cursor.x_ofs = cursor_x - visible_width + 1;
+			}
 
-		if (cursor_x < cursor.x_ofs) {
-			cursor.x_ofs = cursor_x;
+			if (cursor_x < cursor.x_ofs) {
+				cursor.x_ofs = cursor_x;
+			}
+		} else {
+			cursor.x_ofs = 0;
 		}
-	} else {
-		cursor.x_ofs = 0;
+		h_scroll->set_value(cursor.x_ofs);
+
+		update();
 	}
-	h_scroll->set_value(cursor.x_ofs);
-
-	update();
 }
 
 void TextEdit::center_viewport_to_cursor() {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Closes #33865.

Not sure if this should be done in TextEdit since that behaviour mentioned in the issue may be a feature as well.