### PR TITLE
Fix audio bus effects not deselecting after switching focus in the editor

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -172,6 +172,10 @@ void EditorAudioBus::_notification(int p_what) {
 					channel[i].prev_active = activity_found;
 				}
 			}
+
+			if (effects->is_anything_selected() && !effects->has_focus()) {
+				effects->deselect_all();
+			}
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {


### PR DESCRIPTION
Make the appropriate selection of the effect on the audio bus.

> - Select an effect on more than one Audio bus the other ones remains selected, so if you press the Delete key you can delete one effect selected at a time of each diferent Audio bus.

> - Create a new node in the scene and create and select a Audio bus effect, then select the new scene node and press the Delete key to delete the node, the effect will be deleted instead.

- Fixes godotengine/godot#11355