### PR TITLE
Replace GD_MONO_SCOPE_THREAD_ATTACH with GD_MONO_ENSURE_THREAD_ATTACH

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -583,7 +583,7 @@ Vector<ScriptLanguage::StackInfo> CSharpLanguage::debug_get_current_stack_info()
 	_recursion_flag_ = true;
 	SCOPE_EXIT { _recursion_flag_ = false; };
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	if (!gdmono->is_runtime_initialized() || !GDMono::get_singleton()->get_core_api_assembly() || !GDMonoCache::cached_data.corlib_cache_updated) {
 		return Vector<StackInfo>();
@@ -615,7 +615,7 @@ Vector<ScriptLanguage::StackInfo> CSharpLanguage::stack_trace_get_info(MonoObjec
 	_recursion_flag_ = true;
 	SCOPE_EXIT { _recursion_flag_ = false; };
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	MonoException *exc = nullptr;
 
@@ -724,7 +724,7 @@ struct CSharpScriptDepSort {
 void CSharpLanguage::reload_all_scripts() {
 #ifdef GD_MONO_HOT_RELOAD
 	if (is_assembly_reloading_needed()) {
-		GD_MONO_SCOPE_THREAD_ATTACH;
+		GD_MONO_ENSURE_THREAD_ATTACH;
 		reload_assemblies(false);
 	}
 #endif
@@ -741,7 +741,7 @@ void CSharpLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_soft
 
 #ifdef GD_MONO_HOT_RELOAD
 	if (is_assembly_reloading_needed()) {
-		GD_MONO_SCOPE_THREAD_ATTACH;
+		GD_MONO_ENSURE_THREAD_ATTACH;
 		reload_assemblies(p_soft_reload);
 	}
 #endif
@@ -1496,7 +1496,7 @@ void CSharpLanguage::refcount_incremented_instance_binding(Object *p_object) {
 	}
 
 	if (ref_owner->reference_get_count() > 1 && gchandle.is_weak()) { // The managed side also holds a reference, hence 1 instead of 0
-		GD_MONO_SCOPE_THREAD_ATTACH;
+		GD_MONO_ENSURE_THREAD_ATTACH;
 
 		// The reference count was increased after the managed side was the only one referencing our owner.
 		// This means the owner is being referenced again by the unmanaged side,
@@ -1535,7 +1535,7 @@ bool CSharpLanguage::refcount_decremented_instance_binding(Object *p_object) {
 	}
 
 	if (refcount == 1 && !gchandle.is_released() && !gchandle.is_weak()) { // The managed side also holds a reference, hence 1 instead of 0
-		GD_MONO_SCOPE_THREAD_ATTACH;
+		GD_MONO_ENSURE_THREAD_ATTACH;
 
 		// If owner owner is no longer referenced by the unmanaged side,
 		// the managed instance takes responsibility of deleting the owner when GCed.
@@ -1586,7 +1586,7 @@ Object *CSharpInstance::get_owner() {
 bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 	ERR_FAIL_COND_V(!script.is_valid(), false);
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	MonoObject *mono_object = get_mono_object();
 	ERR_FAIL_NULL_V(mono_object, false);
@@ -1640,7 +1640,7 @@ bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
 bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 	ERR_FAIL_COND_V(!script.is_valid(), false);
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	MonoObject *mono_object = get_mono_object();
 	ERR_FAIL_NULL_V(mono_object, false);
@@ -1765,7 +1765,7 @@ void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 
 	ERR_FAIL_COND(!script.is_valid());
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	MonoObject *mono_object = get_mono_object();
 	ERR_FAIL_NULL(mono_object);
@@ -1813,7 +1813,7 @@ bool CSharpInstance::has_method(const StringName &p_method) const {
 		return false;
 	}
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	GDMonoClass *top = script->script_class;
 
@@ -1831,7 +1831,7 @@ bool CSharpInstance::has_method(const StringName &p_method) const {
 Variant CSharpInstance::call(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	ERR_FAIL_COND_V(!script.is_valid(), Variant());
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	MonoObject *mono_object = get_mono_object();
 
@@ -2028,7 +2028,7 @@ void CSharpInstance::refcount_incremented() {
 	Reference *ref_owner = Object::cast_to<Reference>(owner);
 
 	if (ref_owner->reference_get_count() > 1 && gchandle.is_weak()) { // The managed side also holds a reference, hence 1 instead of 0
-		GD_MONO_SCOPE_THREAD_ATTACH;
+		GD_MONO_ENSURE_THREAD_ATTACH;
 
 		// The reference count was increased after the managed side was the only one referencing our owner.
 		// This means the owner is being referenced again by the unmanaged side,
@@ -2052,7 +2052,7 @@ bool CSharpInstance::refcount_decremented() {
 	int refcount = ref_owner->reference_get_count();
 
 	if (refcount == 1 && !gchandle.is_weak()) { // The managed side also holds a reference, hence 1 instead of 0
-		GD_MONO_SCOPE_THREAD_ATTACH;
+		GD_MONO_ENSURE_THREAD_ATTACH;
 
 		// If owner owner is no longer referenced by the unmanaged side,
 		// the managed instance takes responsibility of deleting the owner when GCed.
@@ -2111,7 +2111,7 @@ MultiplayerAPI::RPCMode CSharpInstance::get_rset_mode(const StringName &p_variab
 }
 
 void CSharpInstance::notification(int p_notification) {
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	if (p_notification == Object::NOTIFICATION_PREDELETE) {
 		// When NOTIFICATION_PREDELETE is sent, we also take the chance to call Dispose().
@@ -2175,7 +2175,7 @@ void CSharpInstance::_call_notification(int p_notification) {
 }
 
 String CSharpInstance::to_string(bool *r_valid) {
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	MonoObject *mono_object = get_mono_object();
 
@@ -2220,7 +2220,7 @@ CSharpInstance::CSharpInstance(const Ref<CSharpScript> &p_script) :
 }
 
 CSharpInstance::~CSharpInstance() {
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	destructing_script_instance = true;
 
@@ -2385,7 +2385,7 @@ bool CSharpScript::_update_exports() {
 	if (exports_invalidated)
 #endif
 	{
-		GD_MONO_SCOPE_THREAD_ATTACH;
+		GD_MONO_ENSURE_THREAD_ATTACH;
 
 		changed = true;
 
@@ -2566,7 +2566,7 @@ void CSharpScript::load_script_signals(GDMonoClass *p_class, GDMonoClass *p_nati
 	_signals.clear();
 	event_signals.clear();
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	GDMonoClass *top = p_class;
 	while (top && top != p_native_class) {
@@ -2876,7 +2876,7 @@ Variant CSharpScript::call(const StringName &p_method, const Variant **p_args, i
 		return Variant();
 	}
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	GDMonoClass *top = script_class;
 
@@ -3140,7 +3140,7 @@ Variant CSharpScript::_new(const Variant **p_args, int p_argcount, Callable::Cal
 
 	ERR_FAIL_NULL_V(native, Variant());
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	Object *owner = ClassDB::instance(NATIVE_GDMONOCLASS_NAME(native));
 
@@ -3183,7 +3183,7 @@ ScriptInstance *CSharpScript::instance_create(Object *p_this) {
 		}
 	}
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	Callable::CallError unchecked_error;
 	return _create_instance(nullptr, 0, p_this, Object::cast_to<Reference>(p_this) != nullptr, unchecked_error);
@@ -3228,7 +3228,7 @@ void CSharpScript::get_script_method_list(List<MethodInfo> *p_list) const {
 		return;
 	}
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	// TODO: Filter out things unsuitable for explicit calls, like constructors.
 	const Vector<GDMonoMethod *> &methods = script_class->get_all_methods();
@@ -3242,7 +3242,7 @@ bool CSharpScript::has_method(const StringName &p_method) const {
 		return false;
 	}
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	return script_class->has_fetched_method_unknown_params(p_method);
 }
@@ -3252,7 +3252,7 @@ MethodInfo CSharpScript::get_method_info(const StringName &p_method) const {
 		return MethodInfo();
 	}
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	GDMonoClass *top = script_class;
 
@@ -3277,7 +3277,7 @@ Error CSharpScript::reload(bool p_keep_state) {
 
 	ERR_FAIL_COND_V(!p_keep_state && has_instances, ERR_ALREADY_IN_USE);
 
-	GD_MONO_SCOPE_THREAD_ATTACH;
+	GD_MONO_ENSURE_THREAD_ATTACH;
 
 	GDMonoAssembly *project_assembly = GDMono::get_singleton()->get_project_assembly();
 

--- a/modules/mono/mono_gd/gd_mono_utils.h
+++ b/modules/mono/mono_gd/gd_mono_utils.h
@@ -81,9 +81,9 @@ MonoObject *unmanaged_get_managed(Object *unmanaged);
 void set_main_thread(MonoThread *p_thread);
 MonoThread *attach_current_thread();
 void detach_current_thread();
-void detach_current_thread(MonoThread *p_mono_thread);
 MonoThread *get_current_thread();
 bool is_thread_attached();
+void ensure_thread_attach();
 
 uint32_t new_strong_gchandle(MonoObject *p_object);
 uint32_t new_strong_gchandle_pinned(MonoObject *p_object);
@@ -147,14 +147,6 @@ uint64_t unbox_enum_value(MonoObject *p_boxed, MonoType *p_enum_basetype, bool &
 
 void dispose(MonoObject *p_mono_object, MonoException **r_exc);
 
-struct ScopeThreadAttach {
-	ScopeThreadAttach();
-	~ScopeThreadAttach();
-
-private:
-	MonoThread *mono_thread = nullptr;
-};
-
 StringName get_native_godot_class_name(GDMonoClass *p_class);
 
 } // namespace GDMonoUtils
@@ -170,10 +162,8 @@ StringName get_native_godot_class_name(GDMonoClass *p_class);
 	_runtime_invoke_count_ref -= 1; \
 	((void)0)
 
-#define GD_MONO_SCOPE_THREAD_ATTACH                                   \
-	GDMonoUtils::ScopeThreadAttach __gdmono__scope__thread__attach__; \
-	(void)__gdmono__scope__thread__attach__;                          \
-	((void)0)
+#define GD_MONO_ENSURE_THREAD_ATTACH \
+	GDMonoUtils::ensure_thread_attach();
 
 #ifdef DEBUG_ENABLED
 #define GD_MONO_ASSERT_THREAD_ATTACHED              \


### PR DESCRIPTION
It appears that mono can't currently handle a thread calling mono_thread_attach, mono_thread_detach and then mono_thread_attach again.
Doing so results in mono issuing a fatal error with the following log entry:
* Assertion at debugger-agent.c:4144, condition `!tls' not met

I'm currently looking in to what it would take to fix that in mono -- tentative fix is posted here: https://github.com/tdaffin/mono/commit/fd8399a08b250461e9eb1d30959cb96547dced25

In order to handle the current state of mono I'm recommending switching to a strategy where godot does a single attach per thread and never attempts to detach.

To give this PR some context, I've been working on getting voxel_tools to work with the mono build (https://github.com/Zylann/godot_voxel/pull/193), and I ran into this problem while fixing the virtual bindings for VoxelGenerator and VoxelStream (https://github.com/tdaffin/godot_voxel/commit/2ce4b53ebdc7959a724d8cd0581c911f12deaeaf).

This PR was initially developed on the 3.2 stable branch with voxel_tools, but voxel_tools will not build on 4.0 so I can't test that the specific case is fixed on 4.0
In order to reproduce this problem on 3.2, use this project (https://github.com/tdaffin/voxel_tools_mono) with the fixed bindings for voxel_tools.
