### PR TITLE
Implement `Node` custom iterator for traversing children

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -989,6 +989,20 @@ void Node::_set_name_nocheck(const StringName &p_name) {
 	data.name = p_name;
 }
 
+Variant Node::_iter_init(const Array &p_iter) {
+	_iter_idx = 0;
+	return _iter_idx < data.children.size();
+}
+
+Variant Node::_iter_next(const Array &p_iter) {
+	_iter_idx++;
+	return _iter_idx < data.children.size();
+}
+
+Variant Node::_iter_get(const Variant &p_iter) {
+	return data.children[_iter_idx];
+}
+
 String Node::invalid_character = ". : @ / \"";
 
 bool Node::_validate_node_name(String &p_name) {
@@ -2908,6 +2922,10 @@ void Node::_bind_methods() {
 	BIND_VMETHOD(MethodInfo("_unhandled_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
 	BIND_VMETHOD(MethodInfo("_unhandled_key_input", PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEventKey")));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "_get_configuration_warning"));
+
+	ClassDB::bind_method(D_METHOD("_iter_init"), &Node::_iter_init);
+	ClassDB::bind_method(D_METHOD("_iter_get"), &Node::_iter_get);
+	ClassDB::bind_method(D_METHOD("_iter_next"), &Node::_iter_next);
 }
 
 String Node::_get_name_num_separator() {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -217,6 +217,12 @@ protected:
 	void _set_owner_nocheck(Node *p_owner);
 	void _set_name_nocheck(const StringName &p_name);
 
+	// Custom iterator for traversing children via script.
+	int _iter_idx;
+	Variant _iter_init(const Array &p_iter);
+	Variant _iter_next(const Array &p_iter);
+	Variant _iter_get(const Variant &p_iter);
+
 public:
 	enum {
 


### PR DESCRIPTION
This PR is created as a minimal example implementation to demonstrate performance issues with using custom iterators in C++ as described in #42053.

Allows to iterate children with a plain `for` loop without using `Node.get_children()`:

```gdscript
extends Node2D

func _ready():
	for child in $node:
		print(child)
```

Unfortunately, performs 10 times worse than allocating an array from `get_children()` and iterating it (even with 100000 nodes).

On a side note, I think this could be improved to the point that using a built-in custom iterator in C++ (#7225) could prove to be faster than current way of traversing children with `get_children()`, and this could be potentially in alignment to how it's currently possible to `for i in number` without allocating array for similar reasons, and obviously this would apply to any other custom data structure, such as linked list.
