### PR TITLE
tonemap.glsl: Ensure color parameter of tonemap_reinhard() is positive

### DIFF
--- a/drivers/gles3/shaders/tonemap.glsl
+++ b/drivers/gles3/shaders/tonemap.glsl
@@ -156,6 +156,10 @@ vec3 tonemap_aces(vec3 color, float white) {
 }
 
 vec3 tonemap_reinhard(vec3 color, float white) {
+	// Ensure color values are positive.
+	// They can be negative in the case of negative lights, which leads to undesired behavior.
+	color = max(vec3(0.0), color);
+
 	return clamp((white * color + color) / (color * white + white), vec3(0.0f), vec3(1.0f));
 }
 


### PR DESCRIPTION
PR opened in response to https://github.com/godotengine/godot/issues/41901

The problem here is that there are indeed negative values in the `color` parameter of `tonemap_reinhard()`
The division in the forumla causes the negative signs to cancel out so the `clamp()` in the return statement doesn't fix this. 
The changes here add checks that ensure the color values are positive before applying the formula. 

The test scene now looks like this:
![correct](https://user-images.githubusercontent.com/43905913/93104745-ea15cf00-f6b6-11ea-9994-3bd9074d62ba.png)

This issue also happens in `master`. I'll make a separate PR there after this one reaches approval and is merged. 

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
