### PR TITLE
Allow to cast custom objects for `Variant`

### DIFF
--- a/core/method_bind.h
+++ b/core/method_bind.h
@@ -117,6 +117,15 @@ struct VariantCaster<const T &> {
 // Object enum casts must go here
 VARIANT_ENUM_CAST(Object::ConnectFlags);
 
+// Custom object casting.
+#define VARIANT_OBJECT_CAST(m_obj)                                    \
+	template <>                                                       \
+	struct VariantCaster<m_obj *> {                                   \
+		static _FORCE_INLINE_ m_obj *cast(const Variant &p_variant) { \
+			return (m_obj *)p_variant.operator Object *();            \
+		}                                                             \
+	};
+
 template <typename T>
 struct VariantObjectClassChecker {
 	static _FORCE_INLINE_ bool check(const Variant &p_variant) {


### PR DESCRIPTION
Allows to cast custom object types to be compatible with `Variant` for binding methods.

This PR is created for discussion purposes, feel free to close if you think that the implementation is too complex or wrong, or when a better solution comes in, but if useful, I could continue working on this. 🙂

## Usage

Basically the same as for casting enums:

```c++
VARIANT_OBJECT_CAST(ListNode);
```

This is useful for implementing custom object types in C++ modules without having to manually cast `Object`s in code, and allows for such a custom class to appear in the documentation methods API! For concrete use case, see goostengine/goost#12, where this is implemented locally for a single class.

Note that casting builtin `Node` works because there's already a support for that in `Variant` natively.

There are other stuff which can/should be implemented to make this work with C# I think (PtrToArg?), and additionally allow to cast `const *` objects, but this is just to showcase the implementation to @reduz currently.

#godotengine-devel IRC discussion:
```
Xrayez> reduz: do you think it makes sense to add VARIANT_OBJECT_CAST macro to allow binding methods which accept custom Object datatypes? (useful for implementing other structures via C++ modules such as linked list, where there could be ListNode implemented as an Object, for instance). Similar to VARIANT_ENUM_CAST. Currently, only Node is able to be exposed like that, because it's natively supported by Variant.
reduz> Xrayez: with C++03 i never found a way to properly do this, I wonder if its possible with C++11 that of course does not require crating an extra macro for each class you bind
Xrayez> reduz: well I'm asking because it seems like I've managed to implement such a macro already, it would work similarly to VARIANT_ENUM_CAST. :)
reduz Xrayez: it may be possible to do with a template in newer C++ but I am not sure, did not investigate
Xrayez> I can submit a PR for this for testing purposes, if you don't mind.
reduz> sure but i prefer not to have to add a macro on every node you define if we can do automagically it would be great
Xrayez> reduz: what do you mean by defining a macro for each class? You'd just VARIANT_OBJECT_CAST(ListNode), for instance. It would be good enough in my eyes. xD
reduz> well, I want to make it work without actually doing that, I think it should be possible
Xrayez> I've dedicated 3 hours to figure how to do this, I wish it could be there in Godot since I already know about VARIANT_ENUM_CAST, for instance.
Ah ok then.
```