### PR TITLE
Fix Bullet prioritised list of Areas a RigidBody is a member of element shift.

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -849,8 +849,8 @@ void RigidBodyBullet::on_enter_area(AreaBullet *p_area) {
 		} else {
 			if (areasWhereIam[i]->get_spOv_priority() > p_area->get_spOv_priority()) {
 				// The position was found, just shift all elements
-				for (int j = i; j < areaWhereIamCount; ++j) {
-					areasWhereIam[j + 1] = areasWhereIam[j];
+				for (int j = areaWhereIamCount; j > i; j--) {
+					areasWhereIam[j] = areasWhereIam[j - 1];
 				}
 				areasWhereIam[i] = p_area;
 				break;


### PR DESCRIPTION
Currently, when shifting the elements in the prioritised list of `Area`s a `RigidBody` is intersecting with, the shifting is done in the wrong order. Therefore, all elements past the insertion point are replaced with the element at the insertion point. This effectively removes `Area`s from the list of `Area`s a body is intersecting with. In addition, it doesn't trigger updates to the `Area` `Space Override` modifiers when the `RigidBody` leaves the missing `Area`.

This PR reverses the order the elements are shifted to correctly shift the elements.

Fixes #41743.
