### PR TITLE
Only display the Windows toggle console option if it can actually be used

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6198,7 +6198,9 @@ EditorNode::EditorNode() {
 #else
 	p->add_shortcut(ED_SHORTCUT("editor/fullscreen_mode", TTR("Toggle Fullscreen"), KEY_MASK_SHIFT | KEY_F11), SETTINGS_TOGGLE_FULLSCREEN);
 #endif
-#ifdef WINDOWS_ENABLED
+#if defined(WINDOWS_ENABLED) && defined(WINDOWS_SUBSYSTEM_CONSOLE)
+	// The console can only be toggled if the application was built for the console subsystem,
+	// not the GUI subsystem.
 	p->add_item(TTR("Toggle System Console"), SETTINGS_TOGGLE_CONSOLE);
 #endif
 	p->add_separator();

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -65,12 +65,14 @@ def configure(env):
         env.Append(CCFLAGS=["/MD"])
         env.Append(CPPDEFINES=["DEBUG_ENABLED"])
         env.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
+        env.AppendUnique(CPPDEFINES=["WINDOWS_SUBSYSTEM_CONSOLE"])
 
     elif env["target"] == "debug":
         env.Append(CCFLAGS=["/Zi"])
         env.Append(CCFLAGS=["/MDd"])
         env.Append(CPPDEFINES=["DEBUG_ENABLED"])
         env.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
+        env.AppendUnique(CPPDEFINES=["WINDOWS_SUBSYSTEM_CONSOLE"])
         env.Append(LINKFLAGS=["/DEBUG"])
 
     ## Compiler configuration

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -210,6 +210,7 @@ def configure_msvc(env, manual_msvc_config):
         env.Append(LINKFLAGS=["/SUBSYSTEM:WINDOWS"])
     else:
         env.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
+        env.AppendUnique(CPPDEFINES=["WINDOWS_SUBSYSTEM_CONSOLE"])
 
     ## Compile/link flags
 
@@ -347,6 +348,7 @@ def configure_mingw(env):
         env.Append(LINKFLAGS=["-Wl,--subsystem,windows"])
     else:
         env.Append(LINKFLAGS=["-Wl,--subsystem,console"])
+        env.AppendUnique(CPPDEFINES=["WINDOWS_SUBSYSTEM_CONSOLE"])
 
     ## Compiler configuration
 


### PR DESCRIPTION
I'm not sure if we should hide the option entirely or just disable it with a tooltip instead. Feedback welcome :slightly_smiling_face:

**Note:** Not cherry-pickable to the `3.2` branch since this PR depends on https://github.com/godotengine/godot/pull/41332.