### PR TITLE
Improvement for the Copy button in the Output Log

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -79,7 +79,15 @@ void EditorLog::_clear_request() {
 }
 
 void EditorLog::_copy_request() {
-	log->selection_copy();
+	String text = log->get_selected_text();
+
+	if (text == "") {
+		text = log->get_text();
+	}
+
+	if (text != "") {
+		DisplayServer::get_singleton()->clipboard_set(text);
+	}
 }
 
 void EditorLog::clear() {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2529,9 +2529,9 @@ bool RichTextLabel::search(const String &p_string, bool p_from_selection, bool p
 	return false;
 }
 
-void RichTextLabel::selection_copy() {
+String RichTextLabel::get_selected_text() {
 	if (!selection.active || !selection.enabled) {
-		return;
+		return "";
 	}
 
 	String text;
@@ -2560,6 +2560,12 @@ void RichTextLabel::selection_copy() {
 
 		item = _get_next_item(item, true);
 	}
+
+	return text;
+}
+
+void RichTextLabel::selection_copy() {
+	String text = get_selected_text();
 
 	if (text != "") {
 		DisplayServer::get_singleton()->clipboard_set(text);

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -475,6 +475,7 @@ public:
 
 	void set_selection_enabled(bool p_enabled);
 	bool is_selection_enabled() const;
+	String get_selected_text();
 	void selection_copy();
 
 	Error parse_bbcode(const String &p_bbcode);


### PR DESCRIPTION
Now if no text is selected, pressing the Copy button copies the entire text.