### PR TITLE
GDScript: for loop override stack variable bug fix

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -579,8 +579,8 @@ void GDScriptByteCodeGenerator::write_endif() {
 }
 
 void GDScriptByteCodeGenerator::write_for(const Address &p_variable, const Address &p_list) {
-	int counter_pos = increase_stack() | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-	int container_pos = increase_stack() | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
+	int counter_pos = add_temporary() | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
+	int container_pos = add_temporary() | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
 
 	current_breaks_to_patch.push_back(List<int>());
 
@@ -628,7 +628,9 @@ void GDScriptByteCodeGenerator::write_endfor() {
 	}
 	current_breaks_to_patch.pop_back();
 
-	current_stack_size -= 2; // Remove loop temporaries.
+	// Remove loop temporaries.
+	pop_temporary();
+	pop_temporary();
 }
 
 void GDScriptByteCodeGenerator::start_while_condition() {


### PR DESCRIPTION
Fix: #42050
Fix: #41725

for loop counter and container are not added to the current stack temporaries and because of that loop counter and container are overridden by other stack variable.
![Capture - Copy](https://user-images.githubusercontent.com/41085900/93139522-8dd69d80-f6fe-11ea-9856-35b51aefd890.jpg)
