### PR TITLE
Make LSP ignore $/cancelRequest msgs

### DIFF
--- a/modules/jsonrpc/jsonrpc.cpp
+++ b/modules/jsonrpc/jsonrpc.cpp
@@ -98,6 +98,10 @@ Variant JSONRPC::process_action(const Variant &p_action, bool p_process_arr_elem
 	if (p_action.get_type() == Variant::DICTIONARY) {
 		Dictionary dict = p_action;
 		String method = dict.get("method", "");
+		if (method.begins_with("$/")) {
+			return ret;
+		}
+
 		Array args;
 		if (dict.has("params")) {
 			Variant params = dict.get("params", Variant());


### PR DESCRIPTION
Currently, the LSP reports errors whenever the client sends $/cancelRequest messages. This PR will make the LSP ignore $ messages, as allowed by the [LSP specifications](https://microsoft.github.io/language-server-protocol/specification#dollarRequests)

> If a server or client receives notifications starting with ‘$/’ it is free to ignore the notification.

Fixes #38814
