### PR TITLE
Show correct name of signal when editing an existing one

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -754,8 +754,9 @@ void ConnectionsDock::_open_connection_dialog(ConnectDialog::ConnectionData cToE
 	Node *dst = static_cast<Node *>(cToEdit.target);
 
 	if (src && dst) {
+		const String &signalname = cToEdit.signal;
 		connect_dialog->set_title(TTR("Edit Connection:") + cToEdit.signal);
-		connect_dialog->popup_centered();
+		connect_dialog->popup_dialog(signalname);
 		connect_dialog->init(cToEdit, true);
 	}
 }


### PR DESCRIPTION
Use popup_dialog() instead of popup_centered() to show edit dialog/

With popup_centered it is not possible to change the displayed
signal name. When this is not set the previous shown name is show
for the current dialog.

This is no problem when creating a new conenction as popop_dialog
is used there and this would update the title.

Fixes #42074