### PR TITLE
Set skeleton path on outline mesh.

### DIFF
--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -410,6 +410,14 @@ void MeshInstance3DEditor::_create_outline_mesh() {
 	if (get_tree()->get_edited_scene_root() == node) {
 		owner = node;
 	}
+	NodePath skeleton_path = node->get_skeleton_path();
+	if (!skeleton_path.is_absolute()) {
+		Vector<StringName> parts;
+		parts.push_back("..");
+		parts.append_array(skeleton_path.get_names());
+		skeleton_path = NodePath(parts, false);
+		ERR_PRINT("path is " + skeleton_path);
+	}
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 
@@ -417,6 +425,7 @@ void MeshInstance3DEditor::_create_outline_mesh() {
 
 	ur->add_do_method(node, "add_child", mi);
 	ur->add_do_method(mi, "set_owner", owner);
+	ur->add_do_method(mi, "set_skeleton_path", skeleton_path);
 
 	ur->add_do_reference(mi);
 	ur->add_undo_method(node, "remove_child", mi);


### PR DESCRIPTION
When creating an outline mesh, we copy the bone data from the original
but don't set the skeleton_path. Since the outline is added as a child
of the original MeshInstance, the skeleton_path defaults to ".." and the
outline is not bound to the skeleton in the same way the parent is.

With this patch, the skeleton path is set appropriately, so you can use
an outline mesh on a rigged model.

Another option would be to create the outline mesh as a sibling of the
original rather than a child.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

**Before**
![Before](https://user-images.githubusercontent.com/2496231/93205787-63003f80-f726-11ea-9c4b-b8c1b98d6e0b.png)

**After**
![After](https://user-images.githubusercontent.com/2496231/93205784-6267a900-f726-11ea-894b-48ddcddad94e.png)
