### PR TITLE
Add documentation for shelf filters

### DIFF
--- a/doc/classes/AudioEffectHighShelfFilter.xml
+++ b/doc/classes/AudioEffectHighShelfFilter.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectHighShelfFilter" inherits="AudioEffectFilter" version="4.0">
 	<brief_description>
+		Reduces all frequencies above the [member AudioEffectFilter.cutoff_hz].
 	</brief_description>
 	<description>
 	</description>
 	<tutorials>
+		<link title="Audio buses">https://docs.godotengine.org/en/latest/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<methods>
 	</methods>

--- a/doc/classes/AudioEffectLowShelfFilter.xml
+++ b/doc/classes/AudioEffectLowShelfFilter.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectLowShelfFilter" inherits="AudioEffectFilter" version="4.0">
 	<brief_description>
+		Reduces all frequencies below the [member AudioEffectFilter.cutoff_hz].
 	</brief_description>
 	<description>
 	</description>
 	<tutorials>
+		<link title="Audio buses">https://docs.godotengine.org/en/latest/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<methods>
 	</methods>


### PR DESCRIPTION
Adds documentation for the high and low shelf filters. Closes https://github.com/godotengine/godot-docs/issues/3994. @robbertzzz any issues with how this is worded? From what I read reduces would be the better word to use instead of cuts, since from what I read pass filters cut the audio after the given frequency. And it doesn't look like Godot has a boost mode for these.