### PR TITLE
Make `Object::to_string` virtual

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -658,7 +658,7 @@ public:
 	Variant call(const StringName &p_name, VARIANT_ARG_LIST); // C++ helper
 
 	void notification(int p_notification, bool p_reversed = false);
-	String to_string();
+	virtual String to_string();
 
 	//used mainly by script, get and set all INCLUDING string
 	virtual Variant getvar(const Variant &p_key, bool *r_valid = nullptr) const;


### PR DESCRIPTION
Allows to override printing via C++, not only via script. Useful for implementing pretty-printing for core data structures in C++ modules. See concrete use case at goostengine/goost#12.

Recommended usage for overriding:
```cpp
virtual String to_string() override;
```

But if you want to make the changes compatible in previous versions of Godot, just omit `override` keyword:
```cpp
virtual String to_string();
```