### PR TITLE
Single window mode is not lost after starting a project from the project manager

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -146,6 +146,10 @@ bool OS::is_stdout_verbose() const {
 	return _verbose_stdout;
 }
 
+bool OS::is_single_window() const {
+	return _single_window;
+}
+
 bool OS::is_stdout_debug_enabled() const {
 	return _debug_stdout;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -52,6 +52,7 @@ class OS {
 	int low_processor_usage_mode_sleep_usec = 10000;
 	bool _verbose_stdout = false;
 	bool _debug_stdout = false;
+	bool _single_window = false;
 	String _local_clipboard;
 	int _exit_code = EXIT_FAILURE; // unexpected exit is marked as failure
 	int _orientation;
@@ -223,6 +224,8 @@ public:
 	bool is_stderr_enabled() const;
 	void set_stdout_enabled(bool p_enabled);
 	void set_stderr_enabled(bool p_enabled);
+
+	bool is_single_window() const;
 
 	virtual void disable_crash_handler() {}
 	virtual bool is_disable_crash_handler() const { return false; }

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2051,6 +2051,10 @@ void ProjectManager::_open_selected_projects() {
 			args.push_back("--disable-crash-handler");
 		}
 
+		if (OS::get_singleton()->is_single_window()) {
+			args.push_back("--single-window");
+		}
+
 		String exec = OS::get_singleton()->get_executable_path();
 		Error err = OS::get_singleton()->create_process(exec, args);
 		ERR_FAIL_COND(err);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -135,7 +135,6 @@ static int audio_driver_idx = -1;
 
 // Engine config/tools
 
-static bool single_window = false;
 static bool editor = false;
 static bool project_manager = false;
 static bool cmdline_tool = false;
@@ -755,7 +754,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			}
 		} else if (I->get() == "--single-window") { // force single window
 
-			single_window = true;
+			OS::get_singleton()->_single_window = true;
 		} else if (I->get() == "-t" || I->get() == "--always-on-top") { // force always-on-top window
 
 			init_always_on_top = true;
@@ -2131,7 +2130,7 @@ bool Main::start() {
 
 		bool embed_subwindows = GLOBAL_DEF("display/window/subwindows/embed_subwindows", false);
 
-		if (single_window || (!project_manager && !editor && embed_subwindows)) {
+		if (OS::get_singleton()->is_single_window() || (!project_manager && !editor && embed_subwindows)) {
 			sml->get_root()->set_embed_subwindows_hint(true);
 		}
 		ResourceLoader::add_custom_loaders();


### PR DESCRIPTION
Ran into so weird git stuff with rebasing got some help and they said to try a new pull request.  Previous pull request: https://github.com/godotengine/godot/pull/42071
This means you can start Godot with --single-window and it passes it through the project manager.

*Bugsquad edit:* Fixes #42034.