### PR TITLE
Fixed EditorProperties resetting when being edited.

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2364,6 +2364,11 @@ void EditorInspector::_notification(int p_what) {
 			if (refresh_countdown <= 0) {
 				for (Map<StringName, List<EditorProperty *>>::Element *F = editor_property_map.front(); F; F = F->next()) {
 					for (List<EditorProperty *>::Element *E = F->get().front(); E; E = E->next()) {
+						// Don't update the property if one of it's children is currently focused.
+						// This prevents the property being editor from being overriden by the current value in update_property().
+						if (get_focus_owner() && E->get()->is_a_parent_of(get_focus_owner())) {
+							continue;
+						}
 						E->get()->update_property();
 						E->get()->update_reload_status();
 					}


### PR DESCRIPTION
Fixes #41809. Thank @Paulb23 for the prompt on what the issue was.

After fixing the Editor Inspector autorefresh (#41697), every EditorProperty which used a LineEdit or TextEdit to display and alter it's value was calling `set_text()` every refresh. `set_text()` includes `cursor_pos = 0;` which is what caused this issue. To circumvent this, `EditorProperty`'s will only update if they are _not_ selected in the inspector. This means they will not refresh while being edited.