### PR TITLE
Mark InterpolatedCamera as deprecated

### DIFF
--- a/doc/classes/InterpolatedCamera.xml
+++ b/doc/classes/InterpolatedCamera.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InterpolatedCamera" inherits="Camera" version="3.2">
 	<brief_description>
-		Camera which moves toward another node.
+		[i]Deprecated.[/i] Camera which moves toward another node.
 	</brief_description>
 	<description>
-		InterpolatedCamera is a [Camera] which smoothly moves to match a target node's position and rotation.
+		[i]Deprecated (will be removed in Godot 4.0).[/i] InterpolatedCamera is a [Camera] which smoothly moves to match a target node's position and rotation.
 		If it is not [member enabled] or does not have a valid target set, InterpolatedCamera acts like a normal Camera.
 	</description>
 	<tutorials>

--- a/scene/3d/interpolated_camera.cpp
+++ b/scene/3d/interpolated_camera.cpp
@@ -37,6 +37,8 @@ void InterpolatedCamera::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 
+			WARN_DEPRECATED_MSG("InterpolatedCamera has been deprecated and will be removed in Godot 4.0.");
+
 			if (Engine::get_singleton()->is_editor_hint() && enabled)
 				set_process_internal(false);
 
@@ -129,6 +131,11 @@ void InterpolatedCamera::set_speed(real_t p_speed) {
 real_t InterpolatedCamera::get_speed() const {
 
 	return speed;
+}
+
+String InterpolatedCamera::get_configuration_warning() const {
+
+	return TTR("InterpolatedCamera has been deprecated and will be removed in Godot 4.0.");
 }
 
 void InterpolatedCamera::_bind_methods() {

--- a/scene/3d/interpolated_camera.h
+++ b/scene/3d/interpolated_camera.h
@@ -57,6 +57,8 @@ public:
 	void set_interpolation_enabled(bool p_enable);
 	bool is_interpolation_enabled() const;
 
+	String get_configuration_warning() const;
+
 	InterpolatedCamera();
 };
 


### PR DESCRIPTION
InterpolatedCamera has already been removed from the `master` branch. This adds a deprecation notice to inform people about the upcoming removal in Godot 4.0.

Its functionality could be replicated in a GDScript add-on with relative ease.