### PR TITLE
Cross-reference AABB getter methods in the documentation

### DIFF
--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -44,7 +44,7 @@
 			<return type="AABB">
 			</return>
 			<description>
-				Returns the smallest [AABB] enclosing this mesh. Not affected by [code]custom_aabb[/code].
+				Returns the smallest [AABB] enclosing this mesh in local space. Not affected by [code]custom_aabb[/code]. See also [method VisualInstance3D.get_transformed_aabb].
 				[b]Note:[/b] This is only implemented for [ArrayMesh] and [PrimitiveMesh].
 			</description>
 		</method>

--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -18,7 +18,7 @@
 			<return type="AABB">
 			</return>
 			<description>
-				Returns the visibility axis-aligned bounding box.
+				Returns the visibility axis-aligned bounding box in local space. See also [method VisualInstance3D.get_transformed_aabb].
 			</description>
 		</method>
 		<method name="get_instance_color" qualifiers="const">

--- a/doc/classes/VisualInstance3D.xml
+++ b/doc/classes/VisualInstance3D.xml
@@ -13,7 +13,7 @@
 			<return type="AABB">
 			</return>
 			<description>
-				Returns the [AABB] (also known as the bounding box) for this [VisualInstance3D].
+				Returns the [AABB] (also known as the bounding box) for this [VisualInstance3D]. See also [method get_transformed_aabb].
 			</description>
 		</method>
 		<method name="get_base" qualifiers="const">
@@ -44,7 +44,7 @@
 			</return>
 			<description>
 				Returns the transformed [AABB] (also known as the bounding box) for this [VisualInstance3D].
-				Transformed in this case means the [AABB] plus the position, rotation, and scale of the [Node3D]'s [Transform].
+				Transformed in this case means the [AABB] plus the position, rotation, and scale of the [Node3D]'s [Transform]. See also [method get_aabb].
 			</description>
 		</method>
 		<method name="set_base">


### PR DESCRIPTION
This also clarifies that `get_aabb()` returns the AABB in local space.

See https://github.com/godotengine/godot/issues/42095.