### PR TITLE
Fix window_get_current_screen for X11 display server

### DIFF
--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -197,6 +197,8 @@ class DisplayServerX11 : public DisplayServer {
 
 	bool _refresh_device_info();
 
+	Rect2i _screen_get_rect(int p_screen) const;
+
 	MouseButton _get_mouse_button_state(MouseButton p_x11_button, int p_x11_type);
 	void _get_key_modifier_state(unsigned int p_x11_state, Ref<InputEventWithModifiers> state);
 	void _flush_mouse_motion();


### PR DESCRIPTION
This method used to check which screen contains the top-left corner of the window (and default to the first screen in case none is found), which is not accurate in some cases.

Now the area of overlap with each screen is calculated, so we can get the best candidate based on the window's position.

This makes window_get_current_screen consistent with Windows platform, and fixes an issue where popups appear on the main screen when the main window is slightly moved outside of the desktop on the top or left.