### PR TITLE
Fix C# Match stackoverflow

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -624,41 +624,46 @@ namespace Godot
             return instance.Length;
         }
 
-        // <summary>
-        // Do a simple expression match, where '*' matches zero or more arbitrary characters and '?' matches any single character except '.'.
-        // </summary>
-        public static bool ExprMatch(this string instance, string expr, bool caseSensitive)
+        /// <summary>
+        /// Do a simple expression match, where '*' matches zero or more arbitrary characters and '?' matches any single character except '.'.
+        /// </summary>
+        private static bool ExprMatch(this string instance, string expr, bool caseSensitive)
         {
-            if (expr.Length == 0 || instance.Length == 0)
-                return false;
+            // case '\0':
+            if (expr.Length == 0)
+                return instance.Length == 0;
 
             switch (expr[0])
             {
-                case '\0':
-                    return instance[0] == 0;
                 case '*':
-                    return ExprMatch(expr + 1, instance, caseSensitive) || instance[0] != 0 && ExprMatch(expr, instance + 1, caseSensitive);
+                    return ExprMatch(instance, expr.Substring(1), caseSensitive) || (instance.Length > 0 && ExprMatch(instance.Substring(1), expr, caseSensitive));
                 case '?':
-                    return instance[0] != 0 && instance[0] != '.' && ExprMatch(expr + 1, instance + 1, caseSensitive);
+                    return instance.Length > 0 && instance[0] != '.' && ExprMatch(instance.Substring(1), expr.Substring(1), caseSensitive);
                 default:
-                    return (caseSensitive ? instance[0] == expr[0] : char.ToUpper(instance[0]) == char.ToUpper(expr[0])) &&
-                                ExprMatch(expr + 1, instance + 1, caseSensitive);
+                    if (instance.Length == 0) return false;
+                    return (caseSensitive ? instance[0] == expr[0] : char.ToUpper(instance[0]) == char.ToUpper(expr[0])) && ExprMatch(instance.Substring(1), expr.Substring(1), caseSensitive);
             }
         }
 
-        // <summary>
-        // Do a simple case sensitive expression match, using ? and * wildcards (see [method expr_match]).
-        // </summary>
+        /// <summary>
+        /// Do a simple case sensitive expression match, using ? and * wildcards (see [method expr_match]).
+        /// </summary>
         public static bool Match(this string instance, string expr, bool caseSensitive = true)
         {
+            if (instance.Length == 0 || expr.Length == 0)
+                return false;
+
             return instance.ExprMatch(expr, caseSensitive);
         }
 
-        // <summary>
-        // Do a simple case insensitive expression match, using ? and * wildcards (see [method expr_match]).
-        // </summary>
+        /// <summary>
+        /// Do a simple case insensitive expression match, using ? and * wildcards (see [method expr_match]).
+        /// </summary>
         public static bool MatchN(this string instance, string expr)
         {
+            if (instance.Length == 0 || expr.Length == 0)
+                return false;
+
             return instance.ExprMatch(expr, caseSensitive: false);
         }
 


### PR DESCRIPTION
This PR fixes #41966.

The current `ExprMatch` implementation seems to be a copy of the C++ version because there were the following issues:
- C# strings are not null terminated but the code was checking for the char `\0`
- The recursive calls were passing `instance + 1` which is fine in C++ because as a pointer that moves the current position in the string to the next character but in C# that just appends 1 at the end of the string, I replaced it with `Substring(1)`.
- The recursive calls had the arguments in the wrong order, the C++  version has arguments in a different order but because the C# version is an Extension the first argument must be `this` (the instance), I fixed the order.

In order to get the same results as the C++ version I added a check in the `Match` and `MatchN` methods to return `false` if either `expr` or `instance` is an empty string.

Also, since the equivalent C++ method `_wildcard_match` is private I also made `ExprMatch` private but this would be a breaking change I guess and I'm not sure if that's desired.