### PR TITLE
Try to load project data from a ZIP data pack if no PCK is found

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -558,7 +558,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--path <directory>", "Path to a project (<directory> must contain a \"project.godot\" file).\n");
 	print_help_option("--scene <path>", "Path or UID of a scene in the project that should be started.\n");
 	print_help_option("-u, --upwards", "Scan folders upwards for project.godot file.\n");
-	print_help_option("--main-pack <file>", "Path to a pack (.pck) file to load.\n");
+	print_help_option("--main-pack <file>", "Path to a pack (.pck/.zip) file to load.\n");
 #ifdef DISABLE_DEPRECATED
 	print_help_option("--render-thread <mode>", "Render thread mode (\"safe\", \"separate\").\n");
 #else
@@ -1940,7 +1940,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 		editor = false;
 #else
-		const String error_msg = "Error: Couldn't load project data at path \"" + project_path + "\". Is the .pck file missing?\nIf you've renamed the executable, the associated .pck file should also be renamed to match the executable's name (without the extension).\n";
+		const String error_msg = "Error: Couldn't load project data at path \"" + project_path + "\". Is the .pck/.zip file missing?\nIf you've renamed the executable, the associated .pck/.zip file should also be renamed to match the executable's name (without the extension).\n";
 		OS::get_singleton()->print("%s", error_msg.utf8().get_data());
 		OS::get_singleton()->alert(error_msg);
 

--- a/misc/dist/linux/godot.6
+++ b/misc/dist/linux/godot.6
@@ -44,7 +44,7 @@ Path to a project (<directory> must contain a 'project.godot' file).
 Scan folders upwards for project.godot file.
 .TP
 \fB\-\-main\-pack\fR <file>
-Path to a pack (.pck) file to load.
+Path to a pack (.pck/.zip) file to load.
 .TP
 \fB\-\-render\-thread\fR <mode>
 Render thread mode ('unsafe', 'safe', 'separate').

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -38,7 +38,7 @@ _arguments \
   '(-l --language)'{-l,--language}'[use a specific locale (<locale> being a two-letter code)]:two-letter locale code' \
   "--path[path to a project (<directory> must contain a 'project.godot' file)]:path to directory with 'project.godot' file:_dirs" \
   '(-u --upwards)'{-u,--upwards}'[scan folders upwards for project.godot file]' \
-  '--main-pack[path to a pack (.pck) file to load]:path to .pck file:_files' \
+  '--main-pack[path to a pack (.pck/.zip) file to load]:path to .pck/.zip file:_files' \
   '--render-thread[set the render thread mode]:render thread mode:(unsafe safe separate)' \
   '--remote-fs[use a remote filesystem]:remote filesystem address' \
   '--remote-fs-password[password for remote filesystem]:remote filesystem password' \

--- a/misc/dist/shell/godot.fish
+++ b/misc/dist/shell/godot.fish
@@ -54,7 +54,7 @@ complete -c godot -l quit -d "Quit after the first iteration"
 complete -c godot -s l -l language -d "Use a specific locale (<locale> being a two-letter code)" -x
 complete -c godot -l path -d "Path to a project (<directory> must contain a 'project.godot' file)" -r
 complete -c godot -s u -l upwards -d "Scan folders upwards for project.godot file"
-complete -c godot -l main-pack -d "Path to a pack (.pck) file to load" -r
+complete -c godot -l main-pack -d "Path to a pack (.pck/.zip) file to load" -r
 complete -c godot -l render-thread -d "Set the render thread mode" -x -a "unsafe safe separate"
 complete -c godot -l remote-fs -d "Use a remote filesystem (<host/IP>[:<port>] address)" -x
 complete -c godot -l remote-fs-password -d "Password for remote filesystem" -x


### PR DESCRIPTION
Previously, a launch script with the `--main-pack` command-line argument had to be created by the user to run a project with a ZIP data pack.

This also updates the command-line help to mention ZIP data packs.

4.0-compatible PCK and ZIP data packs for testing: [dsds-datapacks.zip](https://github.com/godotengine/godot/files/5234184/dsds-datapacks.zip) (extract the ZIP, you'll find PCK and ZIP data packs inside)

- Note that the PCK and ZIP files have slightly different content. The engine will likely crash when loading the PCK data pack and close immediately after starting when loading the ZIP data pack, but this is unrelated to the issue I'm trying to solve here.