### PR TITLE
Added inspector_only option to inspect_object in EditorInterface.

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -125,8 +125,10 @@
 			</argument>
 			<argument index="1" name="for_property" type="String" default="&quot;&quot;">
 			</argument>
+			<argument index="2" name="inspector_only" type="bool" default="false">
+			</argument>
 			<description>
-				Shows the given property on the given [code]object[/code] in the editor's Inspector dock.
+				Shows the given property on the given [code]object[/code] in the editor's Inspector dock. If [code]inspector_only[/code] is [code]true[/code], plugins will not attempt to edit [code]object[/code].
 			</description>
 		</method>
 		<method name="is_playing_scene" qualifiers="const">

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -234,8 +234,8 @@ String EditorInterface::get_current_path() const {
 	return EditorNode::get_singleton()->get_filesystem_dock()->get_current_path();
 }
 
-void EditorInterface::inspect_object(Object *p_obj, const String &p_for_property) {
-	EditorNode::get_singleton()->push_item(p_obj, p_for_property);
+void EditorInterface::inspect_object(Object *p_obj, const String &p_for_property, bool p_inspector_only) {
+	EditorNode::get_singleton()->push_item(p_obj, p_for_property, p_inspector_only);
 }
 
 EditorFileSystem *EditorInterface::get_resource_file_system() {
@@ -301,7 +301,7 @@ bool EditorInterface::is_distraction_free_mode_enabled() const {
 EditorInterface *EditorInterface::singleton = nullptr;
 
 void EditorInterface::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("inspect_object", "object", "for_property"), &EditorInterface::inspect_object, DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("inspect_object", "object", "for_property", "inspector_only"), &EditorInterface::inspect_object, DEFVAL(String()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_selection"), &EditorInterface::get_selection);
 	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
 	ClassDB::bind_method(D_METHOD("get_script_editor"), &EditorInterface::get_script_editor);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -89,7 +89,7 @@ public:
 	String get_selected_path() const;
 	String get_current_path() const;
 
-	void inspect_object(Object *p_obj, const String &p_for_property = String());
+	void inspect_object(Object *p_obj, const String &p_for_property = String(), bool p_inspector_only = false);
 
 	EditorSelection *get_selection();
 	//EditorImportExport *get_import_export();


### PR DESCRIPTION
This adds an inspector_only parameter as the last parameter in EditorInterface.inspect_object. This is to mimic the underlying function EditorNode.push_item, which also has an inspector_only parameter that is for some reason not exposed to GDScript.

The need for this is to allow editor plugins to edit subresources without resetting the state of the edit. EditorNode.push_item with inspector_only set to true is used (and required) within AnimationBlendTreeEditor, which means without this making an editor similar to AnimationBlendTreeEditor would be impossible.

Since this parameter is last, and is defaulted to its regular 'false' value, all existing code will work with this change. New code can however now take advantage of this and make better editors, specifically for resources with several subresources.