### PR TITLE
Expose local RenderingDevice creation to RenderingServer

### DIFF
--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1505,9 +1505,14 @@ ShaderLanguage::DataType RenderingServer::global_variable_type_get_shader_dataty
 	}
 }
 
+RenderingDevice *RenderingServer::create_local_rendering_device() const {
+	return RenderingDevice::get_singleton()->create_local_device();
+}
+
 void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("force_sync"), &RenderingServer::sync);
 	ClassDB::bind_method(D_METHOD("force_draw", "swap_buffers", "frame_step"), &RenderingServer::draw, DEFVAL(true), DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("create_local_rendering_device"), &RenderingServer::create_local_rendering_device);
 
 #ifndef _MSC_VER
 #warning TODO all texture methods need re-binding

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -39,6 +39,7 @@
 #include "core/typed_array.h"
 #include "core/variant.h"
 #include "servers/display_server.h"
+#include "servers/rendering/rendering_device.h"
 #include "servers/rendering/shader_language.h"
 
 class RenderingServer : public Object {
@@ -1310,6 +1311,8 @@ public:
 	virtual void call_set_use_vsync(bool p_enable) = 0;
 
 	virtual bool is_low_end() const = 0;
+
+	RenderingDevice *create_local_rendering_device() const;
 
 	bool is_render_loop_enabled() const;
 	void set_render_loop_enabled(bool p_enabled);


### PR DESCRIPTION
Marked as draft because I don't think that this is the way that @reduz wants to expose RenderingDevice. Also I am not sure why this works, I feel like it shouldnt. 

Anyway, I am opening this PR in case others want to play around with compute shaders from GDscript. 

Here is a minimal example of a compute shader.

*in a GDScript ``_ready()`` function*
```
var shader_file = load("res://compute.glsl")
var shader_bytecode = shader_file.get_bytecode()
var rd = RenderingServer.create_local_rendering_device()
var shader = rd.shader_create(shader_bytecode)
var pipeline = rd.compute_pipeline_create(shader)

var storage_buffer = rd.storage_buffer_create(64)
var u = RDUniform.new()
u.type = RenderingDevice.UNIFORM_TYPE_STORAGE_BUFFER
u.binding = 0 
u.add_id(storage_buffer)
var uniform_set = rd.uniform_set_create([u], shader, 0)
	
var compute_list = rd.compute_list_begin()
rd.compute_list_bind_compute_pipeline(compute_list, pipeline)
rd.compute_list_bind_uniform_set(compute_list, uniform_set, 0)
rd.compute_list_dispatch(compute_list, 8, 1, 1)
rd.compute_list_end()
```

*In a file named "compute.glsl"*
```
#[compute]

#version 450

layout(local_size_x = 8) in;

layout(set = 0, binding = 0, std430) restrict buffer ColorBuffer {
  float data[];
}
color_buffer;

void main() { 
    color_buffer.data[gl_GlobalInvocationID.x] = 1.0; 
}
```