### PR TITLE
[WIP] Fix crash accessing godot physics space from AudioStreamPlayer3D whil…

### DIFF
--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -191,6 +191,11 @@ bool BulletPhysicsServer3D::space_is_active(RID p_space) const {
 	return -1 != active_spaces.find(space);
 }
 
+bool BulletPhysicsServer3D::space_is_accessible(RID p_space) const {
+	SpaceBullet *space = space_owner.getornull(p_space);
+	return (space != nullptr);
+}
+
 void BulletPhysicsServer3D::space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) {
 	SpaceBullet *space = space_owner.getornull(p_space);
 	ERR_FAIL_COND(!space);

--- a/modules/bullet/bullet_physics_server.h
+++ b/modules/bullet/bullet_physics_server.h
@@ -106,6 +106,7 @@ public:
 	virtual RID space_create() override;
 	virtual void space_set_active(RID p_space, bool p_active) override;
 	virtual bool space_is_active(RID p_space) const override;
+	virtual bool space_is_accessible(RID p_space) const override;
 
 	/// Not supported
 	virtual void space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) override;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -381,12 +381,17 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 			int bus_index = AudioServer::get_singleton()->thread_find_bus_index(bus);
 
 			//check if any area is diverting sound into a bus
-
-			PhysicsDirectSpaceState3D *space_state = PhysicsServer3D::get_singleton()->space_get_direct_state(world_3d->get_space());
+			PhysicsDirectSpaceState3D *space_state = nullptr;
+			if (PhysicsServer3D::get_singleton()->space_is_accessible(world_3d->get_space())) {
+				space_state = PhysicsServer3D::get_singleton()->space_get_direct_state(world_3d->get_space());
+			}
 
 			PhysicsDirectSpaceState3D::ShapeResult sr[MAX_INTERSECT_AREAS];
 
-			int areas = space_state->intersect_point(global_pos, sr, MAX_INTERSECT_AREAS, Set<RID>(), area_mask, false, true);
+			int areas = 0;
+			if (space_state) {
+				areas = space_state->intersect_point(global_pos, sr, MAX_INTERSECT_AREAS, Set<RID>(), area_mask, false, true);
+			}
 			Area3D *area = nullptr;
 
 			for (int i = 0; i < areas; i++) {

--- a/servers/physics_3d/physics_server_3d_sw.cpp
+++ b/servers/physics_3d/physics_server_3d_sw.cpp
@@ -158,6 +158,17 @@ bool PhysicsServer3DSW::space_is_active(RID p_space) const {
 	return active_spaces.has(space);
 }
 
+bool PhysicsServer3DSW::space_is_accessible(RID p_space) const {
+	Space3DSW *space = space_owner.getornull(p_space);
+	if (!space) {
+		return false;
+	}
+	if (!doing_sync || space->is_locked()) {
+		return false;
+	}
+	return true;
+}
+
 void PhysicsServer3DSW::space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) {
 	Space3DSW *space = space_owner.getornull(p_space);
 	ERR_FAIL_COND(!space);

--- a/servers/physics_3d/physics_server_3d_sw.h
+++ b/servers/physics_3d/physics_server_3d_sw.h
@@ -97,6 +97,7 @@ public:
 	virtual RID space_create() override;
 	virtual void space_set_active(RID p_space, bool p_active) override;
 	virtual bool space_is_active(RID p_space) const override;
+	virtual bool space_is_accessible(RID p_space) const override;
 
 	virtual void space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) override;
 	virtual real_t space_get_param(RID p_space, SpaceParameter p_param) const override;

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -257,6 +257,7 @@ public:
 	virtual RID space_create() = 0;
 	virtual void space_set_active(RID p_space, bool p_active) = 0;
 	virtual bool space_is_active(RID p_space) const = 0;
+	virtual bool space_is_accessible(RID p_space) const = 0;
 
 	enum SpaceParameter {
 


### PR DESCRIPTION
…e paused

AudioStreamPlayer3D attempts to access the space_get_direct_state from the physics during update. This causes a crash with Godot physics when the scene tree is paused.

This fix does mean that areas will be ignored while paused (with Godot physics), although that is preferable to a crash.

It may be possible as a more in depth fix to allow access to areas, this would require a Godot physics contributor, and this PR will do as a stopgap solution.

Fixes #42108

Finally managed to compile on 4.x branch. But I can't currently test on 4.x as I'm getting a vulkan crash on startup (unrelated). I'll make the equivalent PR on 3.2 and leave someone else to test this I guess until I can get 4.x working.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
