### PR TITLE
Fix crash accessing godot physics space from AudioStreamPlayer3D (3.2)

### DIFF
--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -387,11 +387,16 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 
 			//check if any area is diverting sound into a bus
 
+			// when paused, godot physics can return NULL for space_state
 			PhysicsDirectSpaceState *space_state = PhysicsServer::get_singleton()->space_get_direct_state(world->get_space());
 
 			PhysicsDirectSpaceState::ShapeResult sr[MAX_INTERSECT_AREAS];
 
-			int areas = space_state->intersect_point(global_pos, sr, MAX_INTERSECT_AREAS, Set<RID>(), area_mask, false, true);
+			int areas = 0;
+			if (space_state) {
+				areas = space_state->intersect_point(global_pos, sr, MAX_INTERSECT_AREAS, Set<RID>(), area_mask, false, true);
+			}
+
 			Area *area = NULL;
 
 			for (int i = 0; i < areas; i++) {


### PR DESCRIPTION
AudioStreamPlayer3D attempts to access the space_get_direct_state from the physics during update. This causes a crash with Godot physics when the scene tree is paused, because the space_state is NULL.

This PR deals with the NULL space_state gracefully without crashing.

However:
Error messages are still created from the space_get_direct_state call.
Areas are not processed in this situation in the audio.

Related to #42108

## Notes
* There may be a better / more preferable way of doing this, so feel free to suggest changes. I'm not that familiar with Godot physics.
* The primary PR is for 3.2 because I can't run 4.x on my machine. I'm trying to keep a matching 4.x PR (but that will require someone else to test).

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
