### PR TITLE
Group the CanvasItem particle animation properties in the inspector

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -275,6 +275,7 @@ void CanvasItemMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_mode", PROPERTY_HINT_ENUM, "Normal,Unshaded,Light Only"), "set_light_mode", "get_light_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "particles_animation"), "set_particles_animation", "get_particles_animation");
 
+	ADD_GROUP("Particles Anim", "particles_anim_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "particles_anim_h_frames", PROPERTY_HINT_RANGE, "1,128,1"), "set_particles_anim_h_frames", "get_particles_anim_h_frames");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "particles_anim_v_frames", PROPERTY_HINT_RANGE, "1,128,1"), "set_particles_anim_v_frames", "get_particles_anim_v_frames");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "particles_anim_loop"), "set_particles_anim_loop", "get_particles_anim_loop");


### PR DESCRIPTION
This prevents the property names from overflowing with the default inspector width.

See https://github.com/godotengine/godot-docs/issues/2059#issuecomment-564042104.

## Preview

### Before

*Can't distinguish H frames from V frames without hovering them and waiting for the tooltip to appear.
Also, the Loop option (the last property in the list) appears identical to the overall animation toggle.*


![image](https://user-images.githubusercontent.com/180032/93530042-35d9aa00-f93d-11ea-8da0-80303f085c47.png)

### After

![image](https://user-images.githubusercontent.com/180032/93530018-2d816f00-f93d-11ea-9e69-99bb923c48d7.png)

The section will appear at the bottom instead of being "included" within the overall toggle. Unfortunately, we can't fix this without breaking backwards compatibility since we'd have to rename at least one property.