### PR TITLE
Allow control of client port on StreamPeerTCP connections

### DIFF
--- a/core/io/net_socket.h
+++ b/core/io/net_socket.h
@@ -67,6 +67,7 @@ public:
 
 	virtual bool is_open() const = 0;
 	virtual int get_available_bytes() const = 0;
+	virtual Error get_client_port(uint16_t &client_port) const = 0;
 
 	virtual Error set_broadcasting_enabled(bool p_enabled) = 0; // Returns OK if the socket option has been set successfully.
 	virtual void set_blocking_enabled(bool p_enabled) = 0;

--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -65,12 +65,17 @@ void StreamPeerTCP::accept_socket(Ref<NetSocket> p_sock, IP_Address p_host, uint
 
 	peer_host = p_host;
 	peer_port = p_port;
+	if (_sock->get_client_port(client_port) != OK) {
+		ERR_PRINT("Failed to get client port.");
+	}
 }
 
-Error StreamPeerTCP::connect_to_host(const IP_Address &p_host, uint16_t p_port) {
+Error StreamPeerTCP::connect_to_host(const IP_Address &p_host, int p_port, int c_port) {
 	ERR_FAIL_COND_V(!_sock.is_valid(), ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(_sock->is_open(), ERR_ALREADY_IN_USE);
 	ERR_FAIL_COND_V(!p_host.is_valid(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V_MSG(p_port < 0 || p_port > 65535, ERR_INVALID_PARAMETER, "The server port number must be set between 0 and 65535 (inclusive).");
+	ERR_FAIL_COND_V_MSG(c_port < 0 || c_port > 65535, ERR_INVALID_PARAMETER, "The client port number must be set between 0 and 65535 (inclusive).");
 
 	Error err;
 	IP::Type ip_type = p_host.is_ipv4() ? IP::TYPE_IPV4 : IP::TYPE_IPV6;
@@ -79,6 +84,12 @@ Error StreamPeerTCP::connect_to_host(const IP_Address &p_host, uint16_t p_port) 
 	ERR_FAIL_COND_V(err != OK, FAILED);
 
 	_sock->set_blocking_enabled(false);
+
+	if (_sock->bind(IP_Address("*"), c_port) != OK) {
+		ERR_PRINT("Failed to bind socket!");
+		_sock->close();
+		return FAILED;
+	}
 
 	timeout = OS::get_singleton()->get_ticks_msec() + (((uint64_t)GLOBAL_GET("network/limits/tcp/connect_timeout_seconds")) * 1000);
 	err = _sock->connect_to_host(p_host, p_port);
@@ -95,6 +106,11 @@ Error StreamPeerTCP::connect_to_host(const IP_Address &p_host, uint16_t p_port) 
 
 	peer_host = p_host;
 	peer_port = p_port;
+	if (_sock->get_client_port(client_port) != OK) {
+		ERR_PRINT("Failed to get client port.");
+		disconnect_from_host();
+		return FAILED;
+	}
 
 	return OK;
 }
@@ -266,6 +282,7 @@ void StreamPeerTCP::disconnect_from_host() {
 	status = STATUS_NONE;
 	peer_host = IP_Address();
 	peer_port = 0;
+	client_port = 0;
 }
 
 Error StreamPeerTCP::poll(NetSocket::PollType p_type, int timeout) {
@@ -300,11 +317,15 @@ IP_Address StreamPeerTCP::get_connected_host() const {
 	return peer_host;
 }
 
-uint16_t StreamPeerTCP::get_connected_port() const {
+int StreamPeerTCP::get_connected_port() const {
 	return peer_port;
 }
 
-Error StreamPeerTCP::_connect(const String &p_address, int p_port) {
+int StreamPeerTCP::get_client_port() const {
+	return client_port;
+}
+
+Error StreamPeerTCP::_connect(const String &p_address, int p_port, int c_port) {
 	IP_Address ip;
 	if (p_address.is_valid_ip_address()) {
 		ip = p_address;
@@ -315,15 +336,16 @@ Error StreamPeerTCP::_connect(const String &p_address, int p_port) {
 		}
 	}
 
-	return connect_to_host(ip, p_port);
+	return connect_to_host(ip, p_port, c_port);
 }
 
 void StreamPeerTCP::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("connect_to_host", "host", "port"), &StreamPeerTCP::_connect);
+	ClassDB::bind_method(D_METHOD("connect_to_host", "host", "port", "client_port"), &StreamPeerTCP::_connect, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("is_connected_to_host"), &StreamPeerTCP::is_connected_to_host);
 	ClassDB::bind_method(D_METHOD("get_status"), &StreamPeerTCP::get_status);
 	ClassDB::bind_method(D_METHOD("get_connected_host"), &StreamPeerTCP::get_connected_host);
 	ClassDB::bind_method(D_METHOD("get_connected_port"), &StreamPeerTCP::get_connected_port);
+	ClassDB::bind_method(D_METHOD("get_client_port"), &StreamPeerTCP::get_client_port);
 	ClassDB::bind_method(D_METHOD("disconnect_from_host"), &StreamPeerTCP::disconnect_from_host);
 	ClassDB::bind_method(D_METHOD("set_no_delay", "enabled"), &StreamPeerTCP::set_no_delay);
 

--- a/core/io/stream_peer_tcp.h
+++ b/core/io/stream_peer_tcp.h
@@ -55,8 +55,9 @@ protected:
 	Status status = STATUS_NONE;
 	IP_Address peer_host;
 	uint16_t peer_port = 0;
+	uint16_t client_port = 0;
 
-	Error _connect(const String &p_address, int p_port);
+	Error _connect(const String &p_address, int p_port, int c_port = 0);
 	Error _poll_connection();
 	Error write(const uint8_t *p_data, int p_bytes, int &r_sent, bool p_block);
 	Error read(uint8_t *p_buffer, int p_bytes, int &r_received, bool p_block);
@@ -64,12 +65,13 @@ protected:
 	static void _bind_methods();
 
 public:
-	void accept_socket(Ref<NetSocket> p_sock, IP_Address p_host, uint16_t p_port);
+	void accept_socket(Ref<NetSocket> p_sock, IP_Address p_host, uint16_t p_port); // Kept 'uint16_t p_port' since it is only being used internally.
 
-	Error connect_to_host(const IP_Address &p_host, uint16_t p_port);
+	Error connect_to_host(const IP_Address &p_host, int p_port, int c_port = 0);
 	bool is_connected_to_host() const;
 	IP_Address get_connected_host() const;
-	uint16_t get_connected_port() const;
+	int get_connected_port() const;
+	int get_client_port() const;
 	void disconnect_from_host();
 
 	int get_available_bytes() const override;

--- a/doc/classes/StreamPeerTCP.xml
+++ b/doc/classes/StreamPeerTCP.xml
@@ -16,8 +16,10 @@
 			</argument>
 			<argument index="1" name="port" type="int">
 			</argument>
+			<argument index="2" name="client_port" type="int" default="0">
+			</argument>
 			<description>
-				Connects to the specified [code]host:port[/code] pair. A hostname will be resolved if valid. Returns [constant OK] on success or [constant FAILED] on failure.
+				Connects to the specified [code]host:port[/code] pair. A hostname will be resolved if valid. Returns [constant OK] on success or [constant FAILED] on failure. If [code]client_port[/code] is specified, the provided port will be used as source of the connection, otherwise a port number from the ephemeral port range will be provided; this is useful for some NAT traversal techniques.
 			</description>
 		</method>
 		<method name="disconnect_from_host">
@@ -63,6 +65,13 @@
 			<description>
 				Disables Nagle's algorithm to improve latency for small packets.
 				[b]Note:[/b] For applications that send large packets or need to transfer a lot of data, this can decrease the total available bandwidth.
+			</description>
+		</method>
+		<method name="get_client_port" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the source port of this peer.
 			</description>
 		</method>
 	</methods>

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -187,15 +187,26 @@ NetSocketPosix::NetError NetSocketPosix::_get_socket_error() const {
 #if defined(WINDOWS_ENABLED)
 	int err = WSAGetLastError();
 
-	if (err == WSAEISCONN)
+	// More into here https://docs.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2
+	if (err == WSAEISCONN) {
 		return ERR_NET_IS_CONNECTED;
-	if (err == WSAEINPROGRESS || err == WSAEALREADY)
+	}
+	if (err == WSAEINPROGRESS || err == WSAEALREADY) {
 		return ERR_NET_IN_PROGRESS;
-	if (err == WSAEWOULDBLOCK)
+	}
+	if (err == WSAEWOULDBLOCK) {
 		return ERR_NET_WOULD_BLOCK;
+	}
+	if (err == WSAEADDRINUSE || err == WSAEADDRNOTAVAIL) {
+		return ERR_NET_ADDRESS_INVALID_OR_UNAVAILABLE;
+	}
+	if (err == WSAEACCES) {
+		return ERR_NET_UNAUTHORIZED;
+	}
 	print_verbose("Socket error: " + itos(err));
 	return ERR_NET_OTHER;
 #else
+	// More info here https://man7.org/linux/man-pages/man2/bind.2.html
 	if (errno == EISCONN) {
 		return ERR_NET_IS_CONNECTED;
 	}
@@ -204,6 +215,12 @@ NetSocketPosix::NetError NetSocketPosix::_get_socket_error() const {
 	}
 	if (errno == EAGAIN || errno == EWOULDBLOCK) {
 		return ERR_NET_WOULD_BLOCK;
+	}
+	if (errno == EADDRINUSE || errno == EINVAL || errno == EADDRNOTAVAIL) {
+		return ERR_NET_ADDRESS_INVALID_OR_UNAVAILABLE;
+	}
+	if (errno == EACCES) {
+		return ERR_NET_UNAUTHORIZED;
 	}
 	print_verbose("Socket error: " + itos(errno));
 	return ERR_NET_OTHER;
@@ -384,8 +401,8 @@ Error NetSocketPosix::bind(IP_Address p_addr, uint16_t p_port) {
 	size_t addr_size = _set_addr_storage(&addr, p_addr, p_port, _ip_type);
 
 	if (::bind(_sock, (struct sockaddr *)&addr, addr_size) != 0) {
-		_get_socket_error();
-		print_verbose("Failed to bind socket.");
+		NetError err = _get_socket_error();
+		print_verbose("Failed to bind socket with error '" + String::num_int64(err) + "'.");
 		close();
 		return ERR_UNAVAILABLE;
 	}
@@ -714,6 +731,20 @@ int NetSocketPosix::get_available_bytes() const {
 		return -1;
 	}
 	return len;
+}
+
+Error NetSocketPosix::get_client_port(uint16_t &client_port) const {
+	ERR_FAIL_COND_V(!is_open(), FAILED);
+
+	struct sockaddr_in saddr;
+	socklen_t len = sizeof(saddr);
+	if (getsockname(_sock, (struct sockaddr *)&saddr, &len) == -1) {
+		print_verbose("Error when checking socket source port.");
+		return FAILED;
+	}
+
+	client_port = ntohs(saddr.sin_port);
+	return OK;
 }
 
 Ref<NetSocket> NetSocketPosix::accept(IP_Address &r_ip, uint16_t &r_port) {

--- a/drivers/unix/net_socket_posix.h
+++ b/drivers/unix/net_socket_posix.h
@@ -54,7 +54,9 @@ private:
 		ERR_NET_WOULD_BLOCK,
 		ERR_NET_IS_CONNECTED,
 		ERR_NET_IN_PROGRESS,
-		ERR_NET_OTHER
+		ERR_NET_ADDRESS_INVALID_OR_UNAVAILABLE,
+		ERR_NET_UNAUTHORIZED,
+		ERR_NET_OTHER,
 	};
 
 	NetError _get_socket_error() const;
@@ -87,6 +89,7 @@ public:
 
 	virtual bool is_open() const;
 	virtual int get_available_bytes() const;
+	virtual Error get_client_port(uint16_t &client_port) const;
 
 	virtual Error set_broadcasting_enabled(bool p_enabled);
 	virtual void set_blocking_enabled(bool p_enabled);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Allow control of client port on StreamPeerTCP.
Project used to validate developments: [validation-test.zip](https://github.com/godotengine/godot/files/5242680/validation-test.zip)
