### PR TITLE
Linux/BSD: Fix support for NetBSD

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -46,7 +46,8 @@ class Math {
 public:
 	Math() {} // useless to instance
 
-	static const uint64_t RANDOM_MAX = 0xFFFFFFFF;
+	// Not using 'RANDOM_MAX' to avoid conflict with system headers on some OSes (at least NetBSD).
+	static const uint64_t RANDOM_32BIT_MAX = 0xFFFFFFFF;
 
 	static _ALWAYS_INLINE_ double sin(double p_x) { return ::sin(p_x); }
 	static _ALWAYS_INLINE_ float sin(float p_x) { return ::sinf(p_x); }
@@ -283,8 +284,8 @@ public:
 	static void randomize();
 	static uint32_t rand_from_seed(uint64_t *seed);
 	static uint32_t rand();
-	static _ALWAYS_INLINE_ double randd() { return (double)rand() / (double)Math::RANDOM_MAX; }
-	static _ALWAYS_INLINE_ float randf() { return (float)rand() / (float)Math::RANDOM_MAX; }
+	static _ALWAYS_INLINE_ double randd() { return (double)rand() / (double)Math::RANDOM_32BIT_MAX; }
+	static _ALWAYS_INLINE_ float randf() { return (float)rand() / (float)Math::RANDOM_32BIT_MAX; }
 
 	static double random(double from, double to);
 	static float random(float from, float to);

--- a/core/math/random_pcg.h
+++ b/core/math/random_pcg.h
@@ -31,11 +31,11 @@
 #ifndef RANDOM_PCG_H
 #define RANDOM_PCG_H
 
-#include <math.h>
-
 #include "core/math/math_defs.h"
 
 #include "thirdparty/misc/pcg.h"
+
+#include <math.h>
 
 #if defined(__GNUC__)
 #define CLZ32(x) __builtin_clz(x)
@@ -67,7 +67,6 @@ class RandomPCG {
 public:
 	static const uint64_t DEFAULT_SEED = 12047754176567800795U;
 	static const uint64_t DEFAULT_INC = PCG_DEFAULT_INC_64;
-	static const uint64_t RANDOM_MAX = 0xFFFFFFFF;
 
 	RandomPCG(uint64_t p_seed = DEFAULT_SEED, uint64_t p_inc = DEFAULT_INC);
 

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -48,7 +48,7 @@
 #include <mach/mach_time.h>
 #endif
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #endif
@@ -477,7 +477,7 @@ String OS_Unix::get_executable_path() const {
 		return OS::get_executable_path();
 	}
 	return b;
-#elif defined(__OpenBSD__)
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
 	char resolved_path[MAXPATHLEN];
 
 	realpath(OS::get_executable_path().utf8().get_data(), resolved_path);

--- a/drivers/unix/thread_posix.cpp
+++ b/drivers/unix/thread_posix.cpp
@@ -29,16 +29,16 @@
 /*************************************************************************/
 
 #include "thread_posix.h"
-#include "core/script_language.h"
 
 #if (defined(UNIX_ENABLED) || defined(PTHREAD_ENABLED)) && !defined(NO_THREADS)
+
+#include "core/os/memory.h"
+#include "core/safe_refcount.h"
+#include "core/script_language.h"
 
 #ifdef PTHREAD_BSD_SET_NAME
 #include <pthread_np.h>
 #endif
-
-#include "core/os/memory.h"
-#include "core/safe_refcount.h"
 
 static void _thread_id_key_destr_callback(void *p_value) {
 	memdelete(static_cast<Thread::ID *>(p_value));
@@ -126,6 +126,8 @@ Error ThreadPosix::set_name_func_posix(const String &p_name) {
 #ifdef PTHREAD_BSD_SET_NAME
 	pthread_set_name_np(running_thread, p_name.utf8().get_data());
 	int err = 0; // Open/FreeBSD ignore errors in this function
+#elif defined(PTHREAD_NETBSD_SET_NAME)
+	int err = pthread_setname_np(running_thread, "%s", const_cast<char *>(p_name.utf8().get_data()));
 #else
 	int err = pthread_setname_np(running_thread, p_name.utf8().get_data());
 #endif // PTHREAD_BSD_SET_NAME

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -3575,7 +3575,12 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	xrandr_handle = dlopen("libXrandr.so.2", RTLD_LAZY);
 	if (!xrandr_handle) {
 		err = dlerror();
-		fprintf(stderr, "could not load libXrandr.so.2, Error: %s\n", err);
+		// For some arcane reason, NetBSD now ships libXrandr.so.3 while the rest of the world has libXrandr.so.2...
+		// In case this happens for other X11 platforms in the future, let's give it a try too before failing.
+		xrandr_handle = dlopen("libXrandr.so.3", RTLD_LAZY);
+		if (!xrandr_handle) {
+			fprintf(stderr, "could not load libXrandr.so.2, Error: %s\n", err);
+		}
 	} else {
 		XRRQueryVersion(x11_display, &xrandr_major, &xrandr_minor);
 		if (((xrandr_major << 8) | xrandr_minor) >= 0x0105) {

--- a/platform/linuxbsd/platform_config.h
+++ b/platform/linuxbsd/platform_config.h
@@ -31,7 +31,15 @@
 #ifdef __linux__
 #include <alloca.h>
 #endif
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
-#include <stdlib.h>
+
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#include <stdlib.h> // alloca
+// FreeBSD and OpenBSD use pthread_set_name_np, while other platforms,
+// include NetBSD, use pthread_setname_np. NetBSD's version however requires
+// a different format, we handle this directly in thread_posix.
+#ifdef __NetBSD__
+#define PTHREAD_NETBSD_SET_NAME
+#else
 #define PTHREAD_BSD_SET_NAME
+#endif
 #endif

--- a/platform/server/platform_config.h
+++ b/platform/server/platform_config.h
@@ -31,10 +31,19 @@
 #if defined(__linux__) || defined(__APPLE__)
 #include <alloca.h>
 #endif
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
-#include <stdlib.h>
+
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#include <stdlib.h> // alloca
+// FreeBSD and OpenBSD use pthread_set_name_np, while other platforms,
+// include NetBSD, use pthread_setname_np. NetBSD's version however requires
+// a different format, we handle this directly in thread_posix.
+#ifdef __NetBSD__
+#define PTHREAD_NETBSD_SET_NAME
+#else
 #define PTHREAD_BSD_SET_NAME
 #endif
+#endif
+
 #ifdef __APPLE__
 #define PTHREAD_RENAME_SELF
 #endif


### PR DESCRIPTION
Add __NetBSD__ to `platform_config.h` so that it can find `alloca`
and use the proper `pthread_setname_np` format.

Rename RANDOM_MAX to avoid conflict with NetBSD stdlib.

Fixes #42145.

@notepade Can you check if this works for you, and if there are other issues?

---

NetBSD: Implement OS_Unix::get_executable_path()

Same implementation as OpenBSD seems to work fine.

---

X11: Try to load libXrandr.so.3 if libXrandr.so.2 isn't found

All Linux distros, and FreeBSD and OpenBSD seem to have libXrandr.so.2,
but for some reason recent NetBSD versions seem to have libXrandr.so.3 now.