### PR TITLE
Remove the unnecessary sync() and the restrictions it imposes on 3D Physics.

### DIFF
--- a/doc/classes/World2D.xml
+++ b/doc/classes/World2D.xml
@@ -16,7 +16,7 @@
 			The [RID] of this world's canvas resource. Used by the [RenderingServer] for 2D drawing.
 		</member>
 		<member name="direct_space_state" type="PhysicsDirectSpaceState2D" setter="" getter="get_direct_space_state">
-			Direct access to the world's physics 2D space state. Used for querying current and potential collisions. Must only be accessed from the main thread within [code]_physics_process(delta)[/code].
+			Direct access to the world's physics 2D space state. Used for querying current and potential collisions. When using multi-threaded physics, access is limited to [code]_physics_process(delta)[/code] in the main thread.
 		</member>
 		<member name="space" type="RID" setter="" getter="get_space">
 			The [RID] of this world's physics space resource. Used by the [PhysicsServer2D] for 2D physics, treating it as both a space and an area.

--- a/doc/classes/World3D.xml
+++ b/doc/classes/World3D.xml
@@ -15,7 +15,7 @@
 		<member name="camera_effects" type="CameraEffects" setter="set_camera_effects" getter="get_camera_effects">
 		</member>
 		<member name="direct_space_state" type="PhysicsDirectSpaceState3D" setter="" getter="get_direct_space_state">
-			Direct access to the world's physics 3D space state. Used for querying current and potential collisions. Must only be accessed from within [code]_physics_process(delta)[/code].
+			Direct access to the world's physics 3D space state. Used for querying current and potential collisions.
 		</member>
 		<member name="environment" type="Environment" setter="set_environment" getter="get_environment">
 			The World3D's [Environment].

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2387,7 +2387,6 @@ bool Main::iteration() {
 	for (int iters = 0; iters < advance.physics_steps; ++iters) {
 		uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
 
-		PhysicsServer3D::get_singleton()->sync();
 		PhysicsServer3D::get_singleton()->flush_queries();
 
 		PhysicsServer2D::get_singleton()->sync();

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -1553,9 +1553,6 @@ void BulletPhysicsServer3D::step(float p_deltaTime) {
 	}
 }
 
-void BulletPhysicsServer3D::sync() {
-}
-
 void BulletPhysicsServer3D::flush_queries() {
 	if (!active) {
 		return;

--- a/modules/bullet/bullet_physics_server.h
+++ b/modules/bullet/bullet_physics_server.h
@@ -397,7 +397,6 @@ public:
 
 	virtual void init() override;
 	virtual void step(float p_deltaTime) override;
-	virtual void sync() override;
 	virtual void flush_queries() override;
 	virtual void finish() override;
 

--- a/servers/physics_2d/physics_server_2d_sw.cpp
+++ b/servers/physics_2d/physics_server_2d_sw.cpp
@@ -1230,8 +1230,6 @@ void PhysicsServer2DSW::step(real_t p_step) {
 
 	_update_shapes();
 
-	doing_sync = false;
-
 	last_step = p_step;
 	PhysicsDirectBodyState2DSW::singleton->step = p_step;
 	island_count = 0;

--- a/servers/physics_3d/physics_server_3d_sw.cpp
+++ b/servers/physics_3d/physics_server_3d_sw.cpp
@@ -174,7 +174,7 @@ real_t PhysicsServer3DSW::space_get_param(RID p_space, SpaceParameter p_param) c
 PhysicsDirectSpaceState3D *PhysicsServer3DSW::space_get_direct_state(RID p_space) {
 	Space3DSW *space = space_owner.getornull(p_space);
 	ERR_FAIL_COND_V(!space, nullptr);
-	ERR_FAIL_COND_V_MSG(!doing_sync || space->is_locked(), nullptr, "Space state is inaccessible right now, wait for iteration or physics process notification.");
+	ERR_FAIL_COND_V_MSG(space->is_locked(), nullptr, "Space state is inaccessible right now, wait for iteration or physics process notification.");
 
 	return space->get_direct_state();
 }
@@ -888,7 +888,7 @@ int PhysicsServer3DSW::body_test_ray_separation(RID p_body, const Transform &p_t
 PhysicsDirectBodyState3D *PhysicsServer3DSW::body_get_direct_state(RID p_body) {
 	Body3DSW *body = body_owner.getornull(p_body);
 	ERR_FAIL_COND_V(!body, nullptr);
-	ERR_FAIL_COND_V_MSG(!doing_sync || body->get_space()->is_locked(), nullptr, "Body state is inaccessible right now, wait for iteration or physics process notification.");
+	ERR_FAIL_COND_V_MSG(body->get_space()->is_locked(), nullptr, "Body state is inaccessible right now, wait for iteration or physics process notification.");
 
 	direct_state->body = body;
 	return direct_state;
@@ -1287,7 +1287,6 @@ void PhysicsServer3DSW::set_active(bool p_active) {
 };
 
 void PhysicsServer3DSW::init() {
-	doing_sync = true;
 	last_step = 0.001;
 	iterations = 8; // 8?
 	stepper = memnew(Step3DSW);
@@ -1302,8 +1301,6 @@ void PhysicsServer3DSW::step(real_t p_step) {
 	}
 
 	_update_shapes();
-
-	doing_sync = false;
 
 	last_step = p_step;
 	PhysicsDirectBodyState3DSW::singleton->step = p_step;
@@ -1326,8 +1323,6 @@ void PhysicsServer3DSW::flush_queries() {
 	if (!active) {
 		return;
 	}
-
-	doing_sync = true;
 
 	flushing_queries = true;
 

--- a/servers/physics_3d/physics_server_3d_sw.h
+++ b/servers/physics_3d/physics_server_3d_sw.h
@@ -44,7 +44,6 @@ class PhysicsServer3DSW : public PhysicsServer3D {
 	friend class PhysicsDirectSpaceState3DSW;
 	bool active;
 	int iterations;
-	bool doing_sync;
 	real_t last_step;
 
 	int island_count;
@@ -365,7 +364,6 @@ public:
 	virtual void set_active(bool p_active) override;
 	virtual void init() override;
 	virtual void step(real_t p_step) override;
-	virtual void sync() override {}
 	virtual void flush_queries() override;
 	virtual void finish() override;
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -749,7 +749,6 @@ public:
 	virtual void set_active(bool p_active) = 0;
 	virtual void init() = 0;
 	virtual void step(float p_step) = 0;
-	virtual void sync() = 0;
 	virtual void flush_queries() = 0;
 	virtual void finish() = 0;
 


### PR DESCRIPTION
Limiting access to the `PhysicsDirectSpaceState` and `PhysicsDirectBodyState` during the `_physics_process()` and `_integrate_forces()` is only required when using multi-threaded 2D physics, because the physics step is running in a separate thread when processing `_process()` and `_input()`.

This PR removes the unneeded `doing_sync` flag from 3D physics, which limited access to `PhysicsDirectSpaceState` and `PhysicsDirectBodyState` in Godot physics 3D to when this flag was set. It also removes the problem of this flag not being set when the tree is paused, which caused the issues this PR fixes. Note: Access is still denied if the space is locked, which happens during the physics step.

Fixes #38909.
Fixes #42108.
