### PR TITLE
Fix popup menu item selected when opening the menu

### DIFF
--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -105,7 +105,7 @@ class PopupMenu : public Popup {
 	void _activate_submenu(int over);
 	void _submenu_timeout();
 
-	bool invalidated_click;
+	uint64_t popup_time_msec = 0;
 	bool hide_on_item_selection;
 	bool hide_on_checkable_item_selection;
 	bool hide_on_multistate_item_selection;


### PR DESCRIPTION
In order to allow selecting items by either holding left click, or click to open and click again to select, mouse button release was invalidated based on the amount of mouse motion.

This was causing issues in some scenarios where an item could be selected while opening the menu if the mouse moved enough between button press and release.

This case could happen in the language selection of the project manager, especially on linux, because of the order and timing of the mouse events on x11.

This change invalidates mouse release based on a timing condition rather than moved distance to handle any case from the display server properly.

Fixes #42172