### PR TITLE
[HTML5] Synchronous main, better persistence, handlers fixes, optional full screen.

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -42,142 +42,137 @@ class RasterizerSceneDummy : public RasterizerScene {
 public:
 	/* SHADOW ATLAS API */
 
-	RID shadow_atlas_create() { return RID(); }
-	void shadow_atlas_set_size(RID p_atlas, int p_size) {}
-	void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) {}
-	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) { return false; }
+	RID shadow_atlas_create() override { return RID(); }
+	void shadow_atlas_set_size(RID p_atlas, int p_size) override {}
+	void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) override {}
+	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) override { return false; }
 
-	void directional_shadow_atlas_set_size(int p_size) {}
-	int get_directional_light_shadow_size(RID p_light_intance) { return 0; }
-	void set_directional_shadow_count(int p_count) {}
+	void directional_shadow_atlas_set_size(int p_size) override {}
+	int get_directional_light_shadow_size(RID p_light_intance) override { return 0; }
+	void set_directional_shadow_count(int p_count) override {}
 
 	/* SDFGI UPDATE */
 
-	virtual void sdfgi_update(RID p_render_buffers, RID p_environment, const Vector3 &p_world_position) {}
-	virtual int sdfgi_get_pending_region_count(RID p_render_buffers) const { return 0; }
-	virtual AABB sdfgi_get_pending_region_bounds(RID p_render_buffers, int p_region) const { return AABB(); }
-	virtual uint32_t sdfgi_get_pending_region_cascade(RID p_render_buffers, int p_region) const { return 0; }
-	virtual void sdfgi_update_probes(RID p_render_buffers, RID p_environment, const RID *p_directional_light_instances, uint32_t p_directional_light_count, const RID *p_positional_light_instances, uint32_t p_positional_light_count) {}
+	void sdfgi_update(RID p_render_buffers, RID p_environment, const Vector3 &p_world_position) override {}
+	int sdfgi_get_pending_region_count(RID p_render_buffers) const override { return 0; }
+	AABB sdfgi_get_pending_region_bounds(RID p_render_buffers, int p_region) const override { return AABB(); }
+	uint32_t sdfgi_get_pending_region_cascade(RID p_render_buffers, int p_region) const override { return 0; }
+	void sdfgi_update_probes(RID p_render_buffers, RID p_environment, const RID *p_directional_light_instances, uint32_t p_directional_light_count, const RID *p_positional_light_instances, uint32_t p_positional_light_count) override {}
 
 	/* SKY API */
 
-	RID sky_create() { return RID(); }
-	void sky_set_radiance_size(RID p_sky, int p_radiance_size) {}
-	void sky_set_mode(RID p_sky, RS::SkyMode p_samples) {}
-	void sky_set_texture(RID p_sky, RID p_panorama) {}
-	void sky_set_texture(RID p_sky, RID p_cube_map, int p_radiance_size) {}
-	void sky_set_material(RID p_sky, RID p_material) {}
-	virtual Ref<Image> sky_bake_panorama(RID p_sky, float p_energy, bool p_bake_irradiance, const Size2i &p_size) { return Ref<Image>(); }
+	RID sky_create() override { return RID(); }
+	void sky_set_radiance_size(RID p_sky, int p_radiance_size) override {}
+	void sky_set_mode(RID p_sky, RS::SkyMode p_samples) override {}
+	void sky_set_material(RID p_sky, RID p_material) override {}
+	Ref<Image> sky_bake_panorama(RID p_sky, float p_energy, bool p_bake_irradiance, const Size2i &p_size) override { return Ref<Image>(); }
 
 	/* ENVIRONMENT API */
 
-	RID environment_create() { return RID(); }
+	RID environment_create() override { return RID(); }
 
-	void environment_set_background(RID p_env, RS::EnvironmentBG p_bg) {}
-	void environment_set_sky(RID p_env, RID p_sky) {}
-	void environment_set_sky_custom_fov(RID p_env, float p_scale) {}
-	void environment_set_sky_orientation(RID p_env, const Basis &p_orientation) {}
-	void environment_set_bg_color(RID p_env, const Color &p_color) {}
-	void environment_set_bg_energy(RID p_env, float p_energy) {}
-	void environment_set_canvas_max_layer(RID p_env, int p_max_layer) {}
-	void environment_set_ambient_light(RID p_env, const Color &p_color, RS::EnvironmentAmbientSource p_ambient = RS::ENV_AMBIENT_SOURCE_BG, float p_energy = 1.0, float p_sky_contribution = 0.0, RS::EnvironmentReflectionSource p_reflection_source = RS::ENV_REFLECTION_SOURCE_BG, const Color &p_ao_color = Color()) {}
-// FIXME: Disabled during Vulkan refactoring, should be ported.
-#if 0
-	void environment_set_camera_feed_id(RID p_env, int p_camera_feed_id) {}
-#endif
+	void environment_set_background(RID p_env, RS::EnvironmentBG p_bg) override {}
+	void environment_set_sky(RID p_env, RID p_sky) override {}
+	void environment_set_sky_custom_fov(RID p_env, float p_scale) override {}
+	void environment_set_sky_orientation(RID p_env, const Basis &p_orientation) override {}
+	void environment_set_bg_color(RID p_env, const Color &p_color) override {}
+	void environment_set_bg_energy(RID p_env, float p_energy) override {}
+	void environment_set_canvas_max_layer(RID p_env, int p_max_layer) override {}
+	void environment_set_ambient_light(RID p_env, const Color &p_color, RS::EnvironmentAmbientSource p_ambient = RS::ENV_AMBIENT_SOURCE_BG, float p_energy = 1.0, float p_sky_contribution = 0.0, RS::EnvironmentReflectionSource p_reflection_source = RS::ENV_REFLECTION_SOURCE_BG, const Color &p_ao_color = Color()) override {}
 
-	void environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap) {}
-	virtual void environment_glow_set_use_bicubic_upscale(bool p_enable) {}
-	virtual void environment_glow_set_use_high_quality(bool p_enable) {}
-	void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture) {}
+	void environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap) override {}
+	void environment_glow_set_use_bicubic_upscale(bool p_enable) override {}
+	void environment_glow_set_use_high_quality(bool p_enable) override {}
 
-	void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance) {}
-	virtual void environment_set_ssr_roughness_quality(RS::EnvironmentSSRRoughnessQuality p_quality) {}
-	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_bias, float p_light_affect, float p_ao_channel_affect, RS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) {}
-	virtual void environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size) {}
+	void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance) override {}
+	void environment_set_ssr_roughness_quality(RS::EnvironmentSSRRoughnessQuality p_quality) override {}
+	void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_bias, float p_light_affect, float p_ao_channel_affect, RS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) override {}
+	void environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size) override {}
 
-	virtual void environment_set_sdfgi(RID p_env, bool p_enable, RS::EnvironmentSDFGICascades p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) {}
+	void environment_set_sdfgi(RID p_env, bool p_enable, RS::EnvironmentSDFGICascades p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, bool p_use_multibounce, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) override {}
 
-	virtual void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count) {}
-	virtual void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) {}
+	void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count) override {}
+	void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) override {}
 
-	void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) {}
+	void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) override {}
 
-	void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, RID p_ramp) {}
+	void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, RID p_ramp) override {}
 
-	void environment_set_fog(RID p_env, bool p_enable, const Color &p_color, const Color &p_sun_color, float p_sun_amount) {}
-	void environment_set_fog_depth(RID p_env, bool p_enable, float p_depth_begin, float p_depth_end, float p_depth_curve, bool p_transmit, float p_transmit_curve) {}
-	void environment_set_fog_height(RID p_env, bool p_enable, float p_min_height, float p_max_height, float p_height_curve) {}
+	void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density) override {}
+	void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_light, float p_light_energy, float p_length, float p_detail_spread, float p_gi_inject, RS::EnvVolumetricFogShadowFilter p_shadow_filter) override {}
+	void environment_set_volumetric_fog_volume_size(int p_size, int p_depth) override {}
+	void environment_set_volumetric_fog_filter_active(bool p_enable) override {}
+	void environment_set_volumetric_fog_directional_shadow_shrink_size(int p_shrink_size) override {}
+	void environment_set_volumetric_fog_positional_shadow_shrink_size(int p_shrink_size) override {}
 
-	virtual Ref<Image> environment_bake_panorama(RID p_env, bool p_bake_irradiance, const Size2i &p_size) { return Ref<Image>(); }
+	Ref<Image> environment_bake_panorama(RID p_env, bool p_bake_irradiance, const Size2i &p_size) override { return Ref<Image>(); }
 
-	bool is_environment(RID p_env) const { return false; }
-	RS::EnvironmentBG environment_get_background(RID p_env) const { return RS::ENV_BG_KEEP; }
-	int environment_get_canvas_max_layer(RID p_env) const { return 0; }
+	bool is_environment(RID p_env) const override { return false; }
+	RS::EnvironmentBG environment_get_background(RID p_env) const override { return RS::ENV_BG_KEEP; }
+	int environment_get_canvas_max_layer(RID p_env) const override { return 0; }
 
-	virtual RID camera_effects_create() { return RID(); }
+	RID camera_effects_create() override { return RID(); }
 
-	virtual void camera_effects_set_dof_blur_quality(RS::DOFBlurQuality p_quality, bool p_use_jitter) {}
-	virtual void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) {}
+	void camera_effects_set_dof_blur_quality(RS::DOFBlurQuality p_quality, bool p_use_jitter) override {}
+	void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) override {}
 
-	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) {}
-	virtual void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) {}
+	void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) override {}
+	void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) override {}
 
-	virtual void shadows_quality_set(RS::ShadowQuality p_quality) {}
-	virtual void directional_shadow_quality_set(RS::ShadowQuality p_quality) {}
+	void shadows_quality_set(RS::ShadowQuality p_quality) override {}
+	void directional_shadow_quality_set(RS::ShadowQuality p_quality) override {}
 
-	RID light_instance_create(RID p_light) { return RID(); }
-	void light_instance_set_transform(RID p_light_instance, const Transform &p_transform) {}
-	virtual void light_instance_set_aabb(RID p_light_instance, const AABB &p_aabb) {}
-	void light_instance_set_shadow_transform(RID p_light_instance, const CameraMatrix &p_projection, const Transform &p_transform, float p_far, float p_split, int p_pass, float p_shadow_texel_size, float p_bias_scale = 1.0, float p_range_begin = 0, const Vector2 &p_uv_scale = Vector2()) {}
-	void light_instance_mark_visible(RID p_light_instance) {}
+	RID light_instance_create(RID p_light) override { return RID(); }
+	void light_instance_set_transform(RID p_light_instance, const Transform &p_transform) override {}
+	void light_instance_set_aabb(RID p_light_instance, const AABB &p_aabb) override {}
+	void light_instance_set_shadow_transform(RID p_light_instance, const CameraMatrix &p_projection, const Transform &p_transform, float p_far, float p_split, int p_pass, float p_shadow_texel_size, float p_bias_scale = 1.0, float p_range_begin = 0, const Vector2 &p_uv_scale = Vector2()) override {}
+	void light_instance_mark_visible(RID p_light_instance) override {}
 
-	RID reflection_atlas_create() { return RID(); }
-	virtual void reflection_atlas_set_size(RID p_ref_atlas, int p_reflection_size, int p_reflection_count) {}
+	RID reflection_atlas_create() override { return RID(); }
+	void reflection_atlas_set_size(RID p_ref_atlas, int p_reflection_size, int p_reflection_count) override {}
 
-	RID reflection_probe_instance_create(RID p_probe) { return RID(); }
-	void reflection_probe_instance_set_transform(RID p_instance, const Transform &p_transform) {}
-	void reflection_probe_release_atlas_index(RID p_instance) {}
-	bool reflection_probe_instance_needs_redraw(RID p_instance) { return false; }
-	bool reflection_probe_instance_has_reflection(RID p_instance) { return false; }
-	bool reflection_probe_instance_begin_render(RID p_instance, RID p_reflection_atlas) { return false; }
-	bool reflection_probe_instance_postprocess_step(RID p_instance) { return true; }
+	RID reflection_probe_instance_create(RID p_probe) override { return RID(); }
+	void reflection_probe_instance_set_transform(RID p_instance, const Transform &p_transform) override {}
+	void reflection_probe_release_atlas_index(RID p_instance) override {}
+	bool reflection_probe_instance_needs_redraw(RID p_instance) override { return false; }
+	bool reflection_probe_instance_has_reflection(RID p_instance) override { return false; }
+	bool reflection_probe_instance_begin_render(RID p_instance, RID p_reflection_atlas) override { return false; }
+	bool reflection_probe_instance_postprocess_step(RID p_instance) override { return true; }
 
-	virtual RID decal_instance_create(RID p_decal) { return RID(); }
-	virtual void decal_instance_set_transform(RID p_decal, const Transform &p_transform) {}
+	RID decal_instance_create(RID p_decal) override { return RID(); }
+	void decal_instance_set_transform(RID p_decal, const Transform &p_transform) override {}
 
-	virtual RID gi_probe_instance_create(RID p_gi_probe) { return RID(); }
-	void gi_probe_instance_set_light_data(RID p_probe, RID p_base, RID p_data) {}
-	void gi_probe_instance_set_transform_to_data(RID p_probe, const Transform &p_xform) {}
-	virtual bool gi_probe_needs_update(RID p_probe) const { return false; }
-	virtual void gi_probe_update(RID p_probe, bool p_update_light_instances, const Vector<RID> &p_light_instances, int p_dynamic_object_count, InstanceBase **p_dynamic_objects) {}
+	RID gi_probe_instance_create(RID p_gi_probe) override { return RID(); }
+	void gi_probe_instance_set_transform_to_data(RID p_probe, const Transform &p_xform) override {}
+	bool gi_probe_needs_update(RID p_probe) const override { return false; }
+	void gi_probe_update(RID p_probe, bool p_update_light_instances, const Vector<RID> &p_light_instances, int p_dynamic_object_count, InstanceBase **p_dynamic_objects) override {}
 
-	virtual void gi_probe_set_quality(RS::GIProbeQuality) {}
+	void gi_probe_set_quality(RS::GIProbeQuality) override {}
 
-	virtual void render_scene(RID p_render_buffers, const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, InstanceBase **p_cull_result, int p_cull_count, RID *p_light_cull_result, int p_light_cull_count, RID *p_reflection_probe_cull_result, int p_reflection_probe_cull_count, RID *p_gi_probe_cull_result, int p_gi_probe_cull_count, RID *p_decal_cull_result, int p_decal_cull_count, InstanceBase **p_lightmap_cull_result, int p_lightmap_cull_count, RID p_environment, RID p_camera_effects, RID p_shadow_atlas, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass) {}
-	void render_shadow(RID p_light, RID p_shadow_atlas, int p_pass, InstanceBase **p_cull_result, int p_cull_count) {}
-	virtual void render_material(const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, InstanceBase **p_cull_result, int p_cull_count, RID p_framebuffer, const Rect2i &p_region) {}
-	virtual void render_sdfgi(RID p_render_buffers, int p_region, InstanceBase **p_cull_result, int p_cull_count) {}
-	virtual void render_sdfgi_static_lights(RID p_render_buffers, uint32_t p_cascade_count, const uint32_t *p_cascade_indices, const RID **p_positional_light_cull_result, const uint32_t *p_positional_light_cull_count) {}
+	void render_scene(RID p_render_buffers, const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, InstanceBase **p_cull_result, int p_cull_count, RID *p_light_cull_result, int p_light_cull_count, RID *p_reflection_probe_cull_result, int p_reflection_probe_cull_count, RID *p_gi_probe_cull_result, int p_gi_probe_cull_count, RID *p_decal_cull_result, int p_decal_cull_count, InstanceBase **p_lightmap_cull_result, int p_lightmap_cull_count, RID p_environment, RID p_camera_effects, RID p_shadow_atlas, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass) override {}
+	void render_shadow(RID p_light, RID p_shadow_atlas, int p_pass, InstanceBase **p_cull_result, int p_cull_count) override {}
+	void render_material(const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, InstanceBase **p_cull_result, int p_cull_count, RID p_framebuffer, const Rect2i &p_region) override {}
+	void render_sdfgi(RID p_render_buffers, int p_region, InstanceBase **p_cull_result, int p_cull_count) override {}
+	void render_sdfgi_static_lights(RID p_render_buffers, uint32_t p_cascade_count, const uint32_t *p_cascade_indices, const RID **p_positional_light_cull_result, const uint32_t *p_positional_light_cull_count) override {}
 
-	void set_scene_pass(uint64_t p_pass) {}
-	virtual void set_time(double p_time, double p_step) {}
-	void set_debug_draw_mode(RS::ViewportDebugDraw p_debug_draw) {}
+	void set_scene_pass(uint64_t p_pass) override {}
+	void set_time(double p_time, double p_step) override {}
+	void set_debug_draw_mode(RS::ViewportDebugDraw p_debug_draw) override {}
 
-	virtual RID render_buffers_create() { return RID(); }
-	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_width, int p_height, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa) {}
+	RID render_buffers_create() override { return RID(); }
+	void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_width, int p_height, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa) override {}
 
-	virtual void screen_space_roughness_limiter_set_active(bool p_enable, float p_amount, float p_curve) {}
-	virtual bool screen_space_roughness_limiter_is_active() const { return false; }
+	void screen_space_roughness_limiter_set_active(bool p_enable, float p_amount, float p_curve) override {}
+	bool screen_space_roughness_limiter_is_active() const override { return false; }
 
-	virtual void sub_surface_scattering_set_quality(RS::SubSurfaceScatteringQuality p_quality) {}
-	virtual void sub_surface_scattering_set_scale(float p_scale, float p_depth_scale) {}
+	void sub_surface_scattering_set_quality(RS::SubSurfaceScatteringQuality p_quality) override {}
+	void sub_surface_scattering_set_scale(float p_scale, float p_depth_scale) override {}
 
-	virtual TypedArray<Image> bake_render_uv2(RID p_base, const Vector<RID> &p_material_overrides, const Size2i &p_image_size) { return TypedArray<Image>(); }
+	TypedArray<Image> bake_render_uv2(RID p_base, const Vector<RID> &p_material_overrides, const Size2i &p_image_size) override { return TypedArray<Image>(); }
 
-	bool free(RID p_rid) { return true; }
-	virtual void update() {}
-	virtual void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) {}
+	bool free(RID p_rid) override { return true; }
+	void update() override {}
+	void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) override {}
 
 	RasterizerSceneDummy() {}
 	~RasterizerSceneDummy() {}
@@ -216,54 +211,54 @@ public:
 	mutable RID_PtrOwner<DummyTexture> texture_owner;
 	mutable RID_PtrOwner<DummyMesh> mesh_owner;
 
-	virtual RID texture_2d_create(const Ref<Image> &p_image) { return RID(); }
-	virtual RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) { return RID(); }
-	virtual RID texture_3d_create(const Vector<Ref<Image>> &p_slices) { return RID(); }
-	virtual RID texture_proxy_create(RID p_base) { return RID(); }
+	RID texture_2d_create(const Ref<Image> &p_image) override { return RID(); }
+	RID texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) override { return RID(); }
+	RID texture_3d_create(Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) override { return RID(); }
+	RID texture_proxy_create(RID p_base) override { return RID(); }
 
-	virtual void texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) {}
-	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) {}
-	virtual void texture_3d_update(RID p_texture, const Ref<Image> &p_image, int p_depth, int p_mipmap) {}
-	virtual void texture_proxy_update(RID p_proxy, RID p_base) {}
+	void texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override {}
+	void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override {}
+	void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override {}
+	void texture_proxy_update(RID p_proxy, RID p_base) override {}
 
-	virtual RID texture_2d_placeholder_create() { return RID(); }
-	virtual RID texture_2d_layered_placeholder_create(RenderingServer::TextureLayeredType p_layered_type) { return RID(); }
-	virtual RID texture_3d_placeholder_create() { return RID(); }
+	RID texture_2d_placeholder_create() override { return RID(); }
+	RID texture_2d_layered_placeholder_create(RenderingServer::TextureLayeredType p_layered_type) override { return RID(); }
+	RID texture_3d_placeholder_create() override { return RID(); }
 
-	virtual Ref<Image> texture_2d_get(RID p_texture) const { return Ref<Image>(); }
-	virtual Ref<Image> texture_2d_layer_get(RID p_texture, int p_layer) const { return Ref<Image>(); }
-	virtual Ref<Image> texture_3d_slice_get(RID p_texture, int p_depth, int p_mipmap) const { return Ref<Image>(); }
+	Ref<Image> texture_2d_get(RID p_texture) const override { return Ref<Image>(); }
+	Ref<Image> texture_2d_layer_get(RID p_texture, int p_layer) const override { return Ref<Image>(); }
+	Vector<Ref<Image>> texture_3d_get(RID p_texture) const override { return Vector<Ref<Image>>(); }
 
-	virtual void texture_replace(RID p_texture, RID p_by_texture) {}
-	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) {}
+	void texture_replace(RID p_texture, RID p_by_texture) override {}
+	void texture_set_size_override(RID p_texture, int p_width, int p_height) override {}
 // FIXME: Disabled during Vulkan refactoring, should be ported.
 #if 0
-	virtual void texture_bind(RID p_texture, uint32_t p_texture_no) = 0;
+	void texture_bind(RID p_texture, uint32_t p_texture_no) = 0;
 #endif
 
-	virtual void texture_set_path(RID p_texture, const String &p_path) {}
-	virtual String texture_get_path(RID p_texture) const { return String(); }
+	void texture_set_path(RID p_texture, const String &p_path) override {}
+	String texture_get_path(RID p_texture) const override { return String(); }
 
-	virtual void texture_set_detect_3d_callback(RID p_texture, RS::TextureDetectCallback p_callback, void *p_userdata) {}
-	virtual void texture_set_detect_normal_callback(RID p_texture, RS::TextureDetectCallback p_callback, void *p_userdata) {}
-	virtual void texture_set_detect_roughness_callback(RID p_texture, RS::TextureDetectRoughnessCallback p_callback, void *p_userdata) {}
+	void texture_set_detect_3d_callback(RID p_texture, RS::TextureDetectCallback p_callback, void *p_userdata) override {}
+	void texture_set_detect_normal_callback(RID p_texture, RS::TextureDetectCallback p_callback, void *p_userdata) override {}
+	void texture_set_detect_roughness_callback(RID p_texture, RS::TextureDetectRoughnessCallback p_callback, void *p_userdata) override {}
 
-	virtual void texture_debug_usage(List<RS::TextureInfo> *r_info) {}
-	virtual void texture_set_force_redraw_if_visible(RID p_texture, bool p_enable) {}
-	virtual Size2 texture_size_with_proxy(RID p_proxy) { return Size2(); }
+	void texture_debug_usage(List<RS::TextureInfo> *r_info) override {}
+	void texture_set_force_redraw_if_visible(RID p_texture, bool p_enable) override {}
+	Size2 texture_size_with_proxy(RID p_proxy) override { return Size2(); }
 
-	virtual void texture_add_to_decal_atlas(RID p_texture, bool p_panorama_to_dp = false) {}
-	virtual void texture_remove_from_decal_atlas(RID p_texture, bool p_panorama_to_dp = false) {}
+	void texture_add_to_decal_atlas(RID p_texture, bool p_panorama_to_dp = false) override {}
+	void texture_remove_from_decal_atlas(RID p_texture, bool p_panorama_to_dp = false) override {}
 
 #if 0
-	RID texture_create() {
+	RID texture_create() override {
 
 		DummyTexture *texture = memnew(DummyTexture);
 		ERR_FAIL_COND_V(!texture, RID());
 		return texture_owner.make_rid(texture);
 	}
 
-	void texture_allocate(RID p_texture, int p_width, int p_height, int p_depth_3d, Image::Format p_format, RenderingServer::TextureType p_type = RS::TEXTURE_TYPE_2D, uint32_t p_flags = RS::TEXTURE_FLAGS_DEFAULT) {
+	void texture_allocate(RID p_texture, int p_width, int p_height, int p_depth_3d, Image::Format p_format, RenderingServer::TextureType p_type = RS::TEXTURE_TYPE_2D, uint32_t p_flags = RS::TEXTURE_FLAGS_DEFAULT) override {
 		DummyTexture *t = texture_owner.getornull(p_texture);
 		ERR_FAIL_COND(!t);
 		t->width = p_width;
@@ -273,7 +268,7 @@ public:
 		t->image = Ref<Image>(memnew(Image));
 		t->image->create(p_width, p_height, false, p_format);
 	}
-	void texture_set_data(RID p_texture, const Ref<Image> &p_image, int p_level) {
+	void texture_set_data(RID p_texture, const Ref<Image> &p_image, int p_level) override {
 		DummyTexture *t = texture_owner.getornull(p_texture);
 		ERR_FAIL_COND(!t);
 		t->width = p_image->get_width();
@@ -282,7 +277,7 @@ public:
 		t->image->create(t->width, t->height, false, t->format, p_image->get_data());
 	}
 
-	void texture_set_data_partial(RID p_texture, const Ref<Image> &p_image, int src_x, int src_y, int src_w, int src_h, int dst_x, int dst_y, int p_dst_mip, int p_level) {
+	void texture_set_data_partial(RID p_texture, const Ref<Image> &p_image, int src_x, int src_y, int src_w, int src_h, int dst_x, int dst_y, int p_dst_mip, int p_level) override {
 		DummyTexture *t = texture_owner.getornull(p_texture);
 
 		ERR_FAIL_COND(!t);
@@ -295,100 +290,95 @@ public:
 		t->image->blit_rect(p_image, Rect2(src_x, src_y, src_w, src_h), Vector2(dst_x, dst_y));
 	}
 
-	Ref<Image> texture_get_data(RID p_texture, int p_level) const {
+	Ref<Image> texture_get_data(RID p_texture, int p_level) const override {
 		DummyTexture *t = texture_owner.getornull(p_texture);
 		ERR_FAIL_COND_V(!t, Ref<Image>());
 		return t->image;
 	}
-	void texture_set_flags(RID p_texture, uint32_t p_flags) {
+	void texture_set_flags(RID p_texture, uint32_t p_flags) override {
 		DummyTexture *t = texture_owner.getornull(p_texture);
 		ERR_FAIL_COND(!t);
 		t->flags = p_flags;
 	}
-	uint32_t texture_get_flags(RID p_texture) const {
+	uint32_t texture_get_flags(RID p_texture) const override {
 		DummyTexture *t = texture_owner.getornull(p_texture);
 		ERR_FAIL_COND_V(!t, 0);
 		return t->flags;
 	}
-	Image::Format texture_get_format(RID p_texture) const {
+	Image::Format texture_get_format(RID p_texture) const override {
 		DummyTexture *t = texture_owner.getornull(p_texture);
 		ERR_FAIL_COND_V(!t, Image::FORMAT_RGB8);
 		return t->format;
 	}
 
-	RenderingServer::TextureType texture_get_type(RID p_texture) const { return RS::TEXTURE_TYPE_2D; }
-	uint32_t texture_get_texid(RID p_texture) const { return 0; }
-	uint32_t texture_get_width(RID p_texture) const { return 0; }
-	uint32_t texture_get_height(RID p_texture) const { return 0; }
-	uint32_t texture_get_depth(RID p_texture) const { return 0; }
-	void texture_set_size_override(RID p_texture, int p_width, int p_height, int p_depth_3d) {}
-	void texture_bind(RID p_texture, uint32_t p_texture_no) {}
+	RenderingServer::TextureType texture_get_type(RID p_texture) const override { return RS::TEXTURE_TYPE_2D; }
+	uint32_t texture_get_texid(RID p_texture) const override { return 0; }
+	uint32_t texture_get_width(RID p_texture) const override { return 0; }
+	uint32_t texture_get_height(RID p_texture) const override { return 0; }
+	uint32_t texture_get_depth(RID p_texture) const override { return 0; }
+	void texture_set_size_override(RID p_texture, int p_width, int p_height, int p_depth_3d) override {}
+	void texture_bind(RID p_texture, uint32_t p_texture_no) override {}
 
-	void texture_set_path(RID p_texture, const String &p_path) {
+	void texture_set_path(RID p_texture, const String &p_path) override {
 		DummyTexture *t = texture_owner.getornull(p_texture);
 		ERR_FAIL_COND(!t);
 		t->path = p_path;
 	}
-	String texture_get_path(RID p_texture) const {
+	String texture_get_path(RID p_texture) const override {
 		DummyTexture *t = texture_owner.getornull(p_texture);
 		ERR_FAIL_COND_V(!t, String());
 		return t->path;
 	}
 
-	void texture_set_shrink_all_x2_on_set_data(bool p_enable) {}
+	void texture_set_shrink_all_x2_on_set_data(bool p_enable) override {}
 
-	void texture_debug_usage(List<RS::TextureInfo> *r_info) {}
+	void texture_debug_usage(List<RS::TextureInfo> *r_info) override {}
 
-	RID texture_create_radiance_cubemap(RID p_source, int p_resolution = -1) const { return RID(); }
+	RID texture_create_radiance_cubemap(RID p_source, int p_resolution = -1) const override { return RID(); }
 
-	void texture_set_detect_3d_callback(RID p_texture, RenderingServer::TextureDetectCallback p_callback, void *p_userdata) {}
-	void texture_set_detect_srgb_callback(RID p_texture, RenderingServer::TextureDetectCallback p_callback, void *p_userdata) {}
-	void texture_set_detect_normal_callback(RID p_texture, RenderingServer::TextureDetectCallback p_callback, void *p_userdata) {}
+	void texture_set_detect_3d_callback(RID p_texture, RenderingServer::TextureDetectCallback p_callback, void *p_userdata) override {}
+	void texture_set_detect_srgb_callback(RID p_texture, RenderingServer::TextureDetectCallback p_callback, void *p_userdata) override {}
+	void texture_set_detect_normal_callback(RID p_texture, RenderingServer::TextureDetectCallback p_callback, void *p_userdata) override {}
 
-	void textures_keep_original(bool p_enable) {}
+	void textures_keep_original(bool p_enable) override {}
 
-	void texture_set_proxy(RID p_proxy, RID p_base) {}
-	virtual Size2 texture_size_with_proxy(RID p_texture) const { return Size2(); }
-	void texture_set_force_redraw_if_visible(RID p_texture, bool p_enable) {}
+	void texture_set_proxy(RID p_proxy, RID p_base) override {}
+	Size2 texture_size_with_proxy(RID p_texture) const override { return Size2(); }
+	void texture_set_force_redraw_if_visible(RID p_texture, bool p_enable) override {}
 #endif
-
-	/* SKY API */
-
-	RID sky_create() { return RID(); }
-	void sky_set_texture(RID p_sky, RID p_cube_map, int p_radiance_size) {}
 
 	/* SHADER API */
 
-	RID shader_create() { return RID(); }
+	RID shader_create() override { return RID(); }
 
-	void shader_set_code(RID p_shader, const String &p_code) {}
-	String shader_get_code(RID p_shader) const { return ""; }
-	void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const {}
+	void shader_set_code(RID p_shader, const String &p_code) override {}
+	String shader_get_code(RID p_shader) const override { return ""; }
+	void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const override {}
 
-	void shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture) {}
-	RID shader_get_default_texture_param(RID p_shader, const StringName &p_name) const { return RID(); }
-	virtual Variant shader_get_param_default(RID p_material, const StringName &p_param) const { return Variant(); }
+	void shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture) override {}
+	RID shader_get_default_texture_param(RID p_shader, const StringName &p_name) const override { return RID(); }
+	Variant shader_get_param_default(RID p_material, const StringName &p_param) const override { return Variant(); }
 
 	/* COMMON MATERIAL API */
 
-	RID material_create() { return RID(); }
+	RID material_create() override { return RID(); }
 
-	void material_set_render_priority(RID p_material, int priority) {}
-	void material_set_shader(RID p_shader_material, RID p_shader) {}
+	void material_set_render_priority(RID p_material, int priority) override {}
+	void material_set_shader(RID p_shader_material, RID p_shader) override {}
 
-	void material_set_param(RID p_material, const StringName &p_param, const Variant &p_value) {}
-	Variant material_get_param(RID p_material, const StringName &p_param) const { return Variant(); }
+	void material_set_param(RID p_material, const StringName &p_param, const Variant &p_value) override {}
+	Variant material_get_param(RID p_material, const StringName &p_param) const override { return Variant(); }
 
-	void material_set_next_pass(RID p_material, RID p_next_material) {}
+	void material_set_next_pass(RID p_material, RID p_next_material) override {}
 
-	bool material_is_animated(RID p_material) { return false; }
-	bool material_casts_shadows(RID p_material) { return false; }
-	virtual void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) {}
-	void material_update_dependency(RID p_material, RasterizerScene::InstanceBase *p_instance) {}
+	bool material_is_animated(RID p_material) override { return false; }
+	bool material_casts_shadows(RID p_material) override { return false; }
+	void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) override {}
+	void material_update_dependency(RID p_material, RasterizerScene::InstanceBase *p_instance) override {}
 
 	/* MESH API */
 
-	RID mesh_create() {
+	RID mesh_create() override {
 		DummyMesh *mesh = memnew(DummyMesh);
 		ERR_FAIL_COND_V(!mesh, RID());
 		mesh->blend_shape_count = 0;
@@ -396,10 +386,10 @@ public:
 		return mesh_owner.make_rid(mesh);
 	}
 
-	void mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface) {}
+	void mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface) override {}
 
 #if 0
-	void mesh_add_surface(RID p_mesh, uint32_t p_format, RS::PrimitiveType p_primitive, const Vector<uint8_t> &p_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<Vector<uint8_t> > &p_blend_shapes = Vector<Vector<uint8_t> >(), const Vector<AABB> &p_bone_aabbs = Vector<AABB>()) {
+	void mesh_add_surface(RID p_mesh, uint32_t p_format, RS::PrimitiveType p_primitive, const Vector<uint8_t> &p_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<Vector<uint8_t> > &p_blend_shapes = Vector<Vector<uint8_t> >(), const Vector<AABB> &p_bone_aabbs = Vector<AABB>()) override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND(!m);
 
@@ -416,95 +406,95 @@ public:
 		s->bone_aabbs = p_bone_aabbs;
 	}
 
-	void mesh_set_blend_shape_count(RID p_mesh, int p_amount) {
+	void mesh_set_blend_shape_count(RID p_mesh, int p_amount) override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND(!m);
 		m->blend_shape_count = p_amount;
 	}
 #endif
 
-	int mesh_get_blend_shape_count(RID p_mesh) const {
+	int mesh_get_blend_shape_count(RID p_mesh) const override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND_V(!m, 0);
 		return m->blend_shape_count;
 	}
 
-	void mesh_set_blend_shape_mode(RID p_mesh, RS::BlendShapeMode p_mode) {
+	void mesh_set_blend_shape_mode(RID p_mesh, RS::BlendShapeMode p_mode) override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND(!m);
 		m->blend_shape_mode = p_mode;
 	}
-	RS::BlendShapeMode mesh_get_blend_shape_mode(RID p_mesh) const {
+	RS::BlendShapeMode mesh_get_blend_shape_mode(RID p_mesh) const override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND_V(!m, RS::BLEND_SHAPE_MODE_NORMALIZED);
 		return m->blend_shape_mode;
 	}
 
-	void mesh_surface_update_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {}
+	void mesh_surface_update_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) override {}
 
-	void mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) {}
-	RID mesh_surface_get_material(RID p_mesh, int p_surface) const { return RID(); }
+	void mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) override {}
+	RID mesh_surface_get_material(RID p_mesh, int p_surface) const override { return RID(); }
 
 #if 0
-	int mesh_surface_get_array_len(RID p_mesh, int p_surface) const {
+	int mesh_surface_get_array_len(RID p_mesh, int p_surface) const override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND_V(!m, 0);
 
 		return m->surfaces[p_surface].vertex_count;
 	}
-	int mesh_surface_get_array_index_len(RID p_mesh, int p_surface) const {
+	int mesh_surface_get_array_index_len(RID p_mesh, int p_surface) const override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND_V(!m, 0);
 
 		return m->surfaces[p_surface].index_count;
 	}
 
-	Vector<uint8_t> mesh_surface_get_array(RID p_mesh, int p_surface) const {
+	Vector<uint8_t> mesh_surface_get_array(RID p_mesh, int p_surface) const override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND_V(!m, Vector<uint8_t>());
 
 		return m->surfaces[p_surface].array;
 	}
-	Vector<uint8_t> mesh_surface_get_index_array(RID p_mesh, int p_surface) const {
+	Vector<uint8_t> mesh_surface_get_index_array(RID p_mesh, int p_surface) const override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND_V(!m, Vector<uint8_t>());
 
 		return m->surfaces[p_surface].index_array;
 	}
 
-	uint32_t mesh_surface_get_format(RID p_mesh, int p_surface) const {
+	uint32_t mesh_surface_get_format(RID p_mesh, int p_surface) const override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND_V(!m, 0);
 
 		return m->surfaces[p_surface].format;
 	}
-	RS::PrimitiveType mesh_surface_get_primitive_type(RID p_mesh, int p_surface) const {
+	RS::PrimitiveType mesh_surface_get_primitive_type(RID p_mesh, int p_surface) const override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND_V(!m, RS::PRIMITIVE_POINTS);
 
 		return m->surfaces[p_surface].primitive;
 	}
 
-	AABB mesh_surface_get_aabb(RID p_mesh, int p_surface) const {
+	AABB mesh_surface_get_aabb(RID p_mesh, int p_surface) const override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND_V(!m, AABB());
 
 		return m->surfaces[p_surface].aabb;
 	}
-	Vector<Vector<uint8_t> > mesh_surface_get_blend_shapes(RID p_mesh, int p_surface) const {
+	Vector<Vector<uint8_t> > mesh_surface_get_blend_shapes(RID p_mesh, int p_surface) const override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND_V(!m, Vector<Vector<uint8_t> >());
 
 		return m->surfaces[p_surface].blend_shapes;
 	}
-	Vector<AABB> mesh_surface_get_skeleton_aabb(RID p_mesh, int p_surface) const {
+	Vector<AABB> mesh_surface_get_skeleton_aabb(RID p_mesh, int p_surface) const override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND_V(!m, Vector<AABB>());
 
 		return m->surfaces[p_surface].bone_aabbs;
 	}
 
-	void mesh_remove_surface(RID p_mesh, int p_index) {
+	void mesh_remove_surface(RID p_mesh, int p_index) override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND(!m);
 		ERR_FAIL_COND(p_index >= m->surfaces.size());
@@ -513,203 +503,198 @@ public:
 	}
 #endif
 
-	RS::SurfaceData mesh_get_surface(RID p_mesh, int p_surface) const { return RS::SurfaceData(); }
-	int mesh_get_surface_count(RID p_mesh) const {
+	RS::SurfaceData mesh_get_surface(RID p_mesh, int p_surface) const override { return RS::SurfaceData(); }
+	int mesh_get_surface_count(RID p_mesh) const override {
 		DummyMesh *m = mesh_owner.getornull(p_mesh);
 		ERR_FAIL_COND_V(!m, 0);
 		return m->surfaces.size();
 	}
 
-	void mesh_set_custom_aabb(RID p_mesh, const AABB &p_aabb) {}
-	AABB mesh_get_custom_aabb(RID p_mesh) const { return AABB(); }
+	void mesh_set_custom_aabb(RID p_mesh, const AABB &p_aabb) override {}
+	AABB mesh_get_custom_aabb(RID p_mesh) const override { return AABB(); }
 
-	AABB mesh_get_aabb(RID p_mesh, RID p_skeleton = RID()) { return AABB(); }
-	void mesh_clear(RID p_mesh) {}
+	AABB mesh_get_aabb(RID p_mesh, RID p_skeleton = RID()) override { return AABB(); }
+	void mesh_clear(RID p_mesh) override {}
 
 	/* MULTIMESH API */
 
-	virtual RID multimesh_create() { return RID(); }
+	RID multimesh_create() override { return RID(); }
 
-	virtual void multimesh_allocate(RID p_multimesh, int p_instances, RS::MultimeshTransformFormat p_transform_format, bool p_use_colors = false, bool p_use_custom_data = false) {}
-	int multimesh_get_instance_count(RID p_multimesh) const { return 0; }
+	void multimesh_allocate(RID p_multimesh, int p_instances, RS::MultimeshTransformFormat p_transform_format, bool p_use_colors = false, bool p_use_custom_data = false) override {}
+	int multimesh_get_instance_count(RID p_multimesh) const override { return 0; }
 
-	void multimesh_set_mesh(RID p_multimesh, RID p_mesh) {}
-	void multimesh_instance_set_transform(RID p_multimesh, int p_index, const Transform &p_transform) {}
-	void multimesh_instance_set_transform_2d(RID p_multimesh, int p_index, const Transform2D &p_transform) {}
-	void multimesh_instance_set_color(RID p_multimesh, int p_index, const Color &p_color) {}
-	void multimesh_instance_set_custom_data(RID p_multimesh, int p_index, const Color &p_color) {}
+	void multimesh_set_mesh(RID p_multimesh, RID p_mesh) override {}
+	void multimesh_instance_set_transform(RID p_multimesh, int p_index, const Transform &p_transform) override {}
+	void multimesh_instance_set_transform_2d(RID p_multimesh, int p_index, const Transform2D &p_transform) override {}
+	void multimesh_instance_set_color(RID p_multimesh, int p_index, const Color &p_color) override {}
+	void multimesh_instance_set_custom_data(RID p_multimesh, int p_index, const Color &p_color) override {}
 
-	RID multimesh_get_mesh(RID p_multimesh) const { return RID(); }
-	AABB multimesh_get_aabb(RID p_multimesh) const { return AABB(); }
+	RID multimesh_get_mesh(RID p_multimesh) const override { return RID(); }
+	AABB multimesh_get_aabb(RID p_multimesh) const override { return AABB(); }
 
-	Transform multimesh_instance_get_transform(RID p_multimesh, int p_index) const { return Transform(); }
-	Transform2D multimesh_instance_get_transform_2d(RID p_multimesh, int p_index) const { return Transform2D(); }
-	Color multimesh_instance_get_color(RID p_multimesh, int p_index) const { return Color(); }
-	Color multimesh_instance_get_custom_data(RID p_multimesh, int p_index) const { return Color(); }
-	virtual void multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_buffer) {}
-	virtual Vector<float> multimesh_get_buffer(RID p_multimesh) const { return Vector<float>(); }
+	Transform multimesh_instance_get_transform(RID p_multimesh, int p_index) const override { return Transform(); }
+	Transform2D multimesh_instance_get_transform_2d(RID p_multimesh, int p_index) const override { return Transform2D(); }
+	Color multimesh_instance_get_color(RID p_multimesh, int p_index) const override { return Color(); }
+	Color multimesh_instance_get_custom_data(RID p_multimesh, int p_index) const override { return Color(); }
+	void multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_buffer) override {}
+	Vector<float> multimesh_get_buffer(RID p_multimesh) const override { return Vector<float>(); }
 
-	void multimesh_set_visible_instances(RID p_multimesh, int p_visible) {}
-	int multimesh_get_visible_instances(RID p_multimesh) const { return 0; }
+	void multimesh_set_visible_instances(RID p_multimesh, int p_visible) override {}
+	int multimesh_get_visible_instances(RID p_multimesh) const override { return 0; }
 
 	/* IMMEDIATE API */
 
-	RID immediate_create() { return RID(); }
-	void immediate_begin(RID p_immediate, RS::PrimitiveType p_rimitive, RID p_texture = RID()) {}
-	void immediate_vertex(RID p_immediate, const Vector3 &p_vertex) {}
-	void immediate_normal(RID p_immediate, const Vector3 &p_normal) {}
-	void immediate_tangent(RID p_immediate, const Plane &p_tangent) {}
-	void immediate_color(RID p_immediate, const Color &p_color) {}
-	void immediate_uv(RID p_immediate, const Vector2 &tex_uv) {}
-	void immediate_uv2(RID p_immediate, const Vector2 &tex_uv) {}
-	void immediate_end(RID p_immediate) {}
-	void immediate_clear(RID p_immediate) {}
-	void immediate_set_material(RID p_immediate, RID p_material) {}
-	RID immediate_get_material(RID p_immediate) const { return RID(); }
-	AABB immediate_get_aabb(RID p_immediate) const { return AABB(); }
+	RID immediate_create() override { return RID(); }
+	void immediate_begin(RID p_immediate, RS::PrimitiveType p_rimitive, RID p_texture = RID()) override {}
+	void immediate_vertex(RID p_immediate, const Vector3 &p_vertex) override {}
+	void immediate_normal(RID p_immediate, const Vector3 &p_normal) override {}
+	void immediate_tangent(RID p_immediate, const Plane &p_tangent) override {}
+	void immediate_color(RID p_immediate, const Color &p_color) override {}
+	void immediate_uv(RID p_immediate, const Vector2 &tex_uv) override {}
+	void immediate_uv2(RID p_immediate, const Vector2 &tex_uv) override {}
+	void immediate_end(RID p_immediate) override {}
+	void immediate_clear(RID p_immediate) override {}
+	void immediate_set_material(RID p_immediate, RID p_material) override {}
+	RID immediate_get_material(RID p_immediate) const override { return RID(); }
+	AABB immediate_get_aabb(RID p_immediate) const override { return AABB(); }
 
 	/* SKELETON API */
 
-	RID skeleton_create() { return RID(); }
-	void skeleton_allocate(RID p_skeleton, int p_bones, bool p_2d_skeleton = false) {}
-	void skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform) {}
-	void skeleton_set_world_transform(RID p_skeleton, bool p_enable, const Transform &p_world_transform) {}
-	int skeleton_get_bone_count(RID p_skeleton) const { return 0; }
-	void skeleton_bone_set_transform(RID p_skeleton, int p_bone, const Transform &p_transform) {}
-	Transform skeleton_bone_get_transform(RID p_skeleton, int p_bone) const { return Transform(); }
-	void skeleton_bone_set_transform_2d(RID p_skeleton, int p_bone, const Transform2D &p_transform) {}
-	Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const { return Transform2D(); }
+	RID skeleton_create() override { return RID(); }
+	void skeleton_allocate(RID p_skeleton, int p_bones, bool p_2d_skeleton = false) override {}
+	void skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform) override {}
+	int skeleton_get_bone_count(RID p_skeleton) const override { return 0; }
+	void skeleton_bone_set_transform(RID p_skeleton, int p_bone, const Transform &p_transform) override {}
+	Transform skeleton_bone_get_transform(RID p_skeleton, int p_bone) const override { return Transform(); }
+	void skeleton_bone_set_transform_2d(RID p_skeleton, int p_bone, const Transform2D &p_transform) override {}
+	Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const override { return Transform2D(); }
 
 	/* Light API */
 
-	RID light_create(RS::LightType p_type) { return RID(); }
+	RID light_create(RS::LightType p_type) override { return RID(); }
 
-	RID directional_light_create() { return light_create(RS::LIGHT_DIRECTIONAL); }
-	RID omni_light_create() { return light_create(RS::LIGHT_OMNI); }
-	RID spot_light_create() { return light_create(RS::LIGHT_SPOT); }
+	void light_set_color(RID p_light, const Color &p_color) override {}
+	void light_set_param(RID p_light, RS::LightParam p_param, float p_value) override {}
+	void light_set_shadow(RID p_light, bool p_enabled) override {}
+	void light_set_shadow_color(RID p_light, const Color &p_color) override {}
+	void light_set_projector(RID p_light, RID p_texture) override {}
+	void light_set_negative(RID p_light, bool p_enable) override {}
+	void light_set_cull_mask(RID p_light, uint32_t p_mask) override {}
+	void light_set_reverse_cull_face_mode(RID p_light, bool p_enabled) override {}
+	void light_set_bake_mode(RID p_light, RS::LightBakeMode p_bake_mode) override {}
+	void light_set_max_sdfgi_cascade(RID p_light, uint32_t p_cascade) override {}
 
-	void light_set_color(RID p_light, const Color &p_color) {}
-	void light_set_param(RID p_light, RS::LightParam p_param, float p_value) {}
-	void light_set_shadow(RID p_light, bool p_enabled) {}
-	void light_set_shadow_color(RID p_light, const Color &p_color) {}
-	void light_set_projector(RID p_light, RID p_texture) {}
-	void light_set_negative(RID p_light, bool p_enable) {}
-	void light_set_cull_mask(RID p_light, uint32_t p_mask) {}
-	void light_set_reverse_cull_face_mode(RID p_light, bool p_enabled) {}
-	void light_set_bake_mode(RID p_light, RS::LightBakeMode p_bake_mode) {}
-	void light_set_max_sdfgi_cascade(RID p_light, uint32_t p_cascade) {}
+	void light_omni_set_shadow_mode(RID p_light, RS::LightOmniShadowMode p_mode) override {}
 
-	void light_omni_set_shadow_mode(RID p_light, RS::LightOmniShadowMode p_mode) {}
+	void light_directional_set_shadow_mode(RID p_light, RS::LightDirectionalShadowMode p_mode) override {}
+	void light_directional_set_blend_splits(RID p_light, bool p_enable) override {}
+	bool light_directional_get_blend_splits(RID p_light) const override { return false; }
+	void light_directional_set_shadow_depth_range_mode(RID p_light, RS::LightDirectionalShadowDepthRangeMode p_range_mode) override {}
+	RS::LightDirectionalShadowDepthRangeMode light_directional_get_shadow_depth_range_mode(RID p_light) const override { return RS::LIGHT_DIRECTIONAL_SHADOW_DEPTH_RANGE_STABLE; }
 
-	void light_directional_set_shadow_mode(RID p_light, RS::LightDirectionalShadowMode p_mode) {}
-	void light_directional_set_blend_splits(RID p_light, bool p_enable) {}
-	bool light_directional_get_blend_splits(RID p_light) const { return false; }
-	void light_directional_set_shadow_depth_range_mode(RID p_light, RS::LightDirectionalShadowDepthRangeMode p_range_mode) {}
-	RS::LightDirectionalShadowDepthRangeMode light_directional_get_shadow_depth_range_mode(RID p_light) const { return RS::LIGHT_DIRECTIONAL_SHADOW_DEPTH_RANGE_STABLE; }
+	RS::LightDirectionalShadowMode light_directional_get_shadow_mode(RID p_light) override { return RS::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL; }
+	RS::LightOmniShadowMode light_omni_get_shadow_mode(RID p_light) override { return RS::LIGHT_OMNI_SHADOW_DUAL_PARABOLOID; }
 
-	RS::LightDirectionalShadowMode light_directional_get_shadow_mode(RID p_light) { return RS::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL; }
-	RS::LightOmniShadowMode light_omni_get_shadow_mode(RID p_light) { return RS::LIGHT_OMNI_SHADOW_DUAL_PARABOLOID; }
+	bool light_has_shadow(RID p_light) const override { return false; }
 
-	bool light_has_shadow(RID p_light) const { return false; }
-
-	RS::LightType light_get_type(RID p_light) const { return RS::LIGHT_OMNI; }
-	AABB light_get_aabb(RID p_light) const { return AABB(); }
-	float light_get_param(RID p_light, RS::LightParam p_param) { return 0.0; }
-	Color light_get_color(RID p_light) { return Color(); }
-	virtual RS::LightBakeMode light_get_bake_mode(RID p_light) { return RS::LIGHT_BAKE_DISABLED; }
-	virtual uint32_t light_get_max_sdfgi_cascade(RID p_light) { return 0; }
-	uint64_t light_get_version(RID p_light) const { return 0; }
+	RS::LightType light_get_type(RID p_light) const override { return RS::LIGHT_OMNI; }
+	AABB light_get_aabb(RID p_light) const override { return AABB(); }
+	float light_get_param(RID p_light, RS::LightParam p_param) override { return 0.0; }
+	Color light_get_color(RID p_light) override { return Color(); }
+	RS::LightBakeMode light_get_bake_mode(RID p_light) override { return RS::LIGHT_BAKE_DISABLED; }
+	uint32_t light_get_max_sdfgi_cascade(RID p_light) override { return 0; }
+	uint64_t light_get_version(RID p_light) const override { return 0; }
 
 	/* PROBE API */
 
-	RID reflection_probe_create() { return RID(); }
+	RID reflection_probe_create() override { return RID(); }
 
-	void reflection_probe_set_update_mode(RID p_probe, RS::ReflectionProbeUpdateMode p_mode) {}
-	void reflection_probe_set_intensity(RID p_probe, float p_intensity) {}
-	void reflection_probe_set_ambient_mode(RID p_probe, RS::ReflectionProbeAmbientMode p_mode) {}
-	void reflection_probe_set_ambient_color(RID p_probe, const Color &p_color) {}
-	void reflection_probe_set_ambient_energy(RID p_probe, float p_energy) {}
-	void reflection_probe_set_max_distance(RID p_probe, float p_distance) {}
-	void reflection_probe_set_extents(RID p_probe, const Vector3 &p_extents) {}
-	void reflection_probe_set_origin_offset(RID p_probe, const Vector3 &p_offset) {}
-	void reflection_probe_set_as_interior(RID p_probe, bool p_enable) {}
-	void reflection_probe_set_enable_box_projection(RID p_probe, bool p_enable) {}
-	void reflection_probe_set_enable_shadows(RID p_probe, bool p_enable) {}
-	void reflection_probe_set_cull_mask(RID p_probe, uint32_t p_layers) {}
-	void reflection_probe_set_resolution(RID p_probe, int p_resolution) {}
+	void reflection_probe_set_update_mode(RID p_probe, RS::ReflectionProbeUpdateMode p_mode) override {}
+	void reflection_probe_set_intensity(RID p_probe, float p_intensity) override {}
+	void reflection_probe_set_ambient_mode(RID p_probe, RS::ReflectionProbeAmbientMode p_mode) override {}
+	void reflection_probe_set_ambient_color(RID p_probe, const Color &p_color) override {}
+	void reflection_probe_set_ambient_energy(RID p_probe, float p_energy) override {}
+	void reflection_probe_set_max_distance(RID p_probe, float p_distance) override {}
+	void reflection_probe_set_extents(RID p_probe, const Vector3 &p_extents) override {}
+	void reflection_probe_set_origin_offset(RID p_probe, const Vector3 &p_offset) override {}
+	void reflection_probe_set_as_interior(RID p_probe, bool p_enable) override {}
+	void reflection_probe_set_enable_box_projection(RID p_probe, bool p_enable) override {}
+	void reflection_probe_set_enable_shadows(RID p_probe, bool p_enable) override {}
+	void reflection_probe_set_cull_mask(RID p_probe, uint32_t p_layers) override {}
+	void reflection_probe_set_resolution(RID p_probe, int p_resolution) override {}
 
-	AABB reflection_probe_get_aabb(RID p_probe) const { return AABB(); }
-	RS::ReflectionProbeUpdateMode reflection_probe_get_update_mode(RID p_probe) const { return RenderingServer::REFLECTION_PROBE_UPDATE_ONCE; }
-	uint32_t reflection_probe_get_cull_mask(RID p_probe) const { return 0; }
-	Vector3 reflection_probe_get_extents(RID p_probe) const { return Vector3(); }
-	Vector3 reflection_probe_get_origin_offset(RID p_probe) const { return Vector3(); }
-	float reflection_probe_get_origin_max_distance(RID p_probe) const { return 0.0; }
-	bool reflection_probe_renders_shadows(RID p_probe) const { return false; }
+	AABB reflection_probe_get_aabb(RID p_probe) const override { return AABB(); }
+	RS::ReflectionProbeUpdateMode reflection_probe_get_update_mode(RID p_probe) const override { return RenderingServer::REFLECTION_PROBE_UPDATE_ONCE; }
+	uint32_t reflection_probe_get_cull_mask(RID p_probe) const override { return 0; }
+	Vector3 reflection_probe_get_extents(RID p_probe) const override { return Vector3(); }
+	Vector3 reflection_probe_get_origin_offset(RID p_probe) const override { return Vector3(); }
+	float reflection_probe_get_origin_max_distance(RID p_probe) const override { return 0.0; }
+	bool reflection_probe_renders_shadows(RID p_probe) const override { return false; }
 
-	virtual void base_update_dependency(RID p_base, RasterizerScene::InstanceBase *p_instance) {}
-	virtual void skeleton_update_dependency(RID p_base, RasterizerScene::InstanceBase *p_instance) {}
+	void base_update_dependency(RID p_base, RasterizerScene::InstanceBase *p_instance) override {}
+	void skeleton_update_dependency(RID p_base, RasterizerScene::InstanceBase *p_instance) override {}
 
 	/* DECAL API */
 
-	virtual RID decal_create() { return RID(); }
-	virtual void decal_set_extents(RID p_decal, const Vector3 &p_extents) {}
-	virtual void decal_set_texture(RID p_decal, RS::DecalTexture p_type, RID p_texture) {}
-	virtual void decal_set_emission_energy(RID p_decal, float p_energy) {}
-	virtual void decal_set_albedo_mix(RID p_decal, float p_mix) {}
-	virtual void decal_set_modulate(RID p_decal, const Color &p_modulate) {}
-	virtual void decal_set_cull_mask(RID p_decal, uint32_t p_layers) {}
-	virtual void decal_set_distance_fade(RID p_decal, bool p_enabled, float p_begin, float p_length) {}
-	virtual void decal_set_fade(RID p_decal, float p_above, float p_below) {}
-	virtual void decal_set_normal_fade(RID p_decal, float p_fade) {}
+	RID decal_create() override { return RID(); }
+	void decal_set_extents(RID p_decal, const Vector3 &p_extents) override {}
+	void decal_set_texture(RID p_decal, RS::DecalTexture p_type, RID p_texture) override {}
+	void decal_set_emission_energy(RID p_decal, float p_energy) override {}
+	void decal_set_albedo_mix(RID p_decal, float p_mix) override {}
+	void decal_set_modulate(RID p_decal, const Color &p_modulate) override {}
+	void decal_set_cull_mask(RID p_decal, uint32_t p_layers) override {}
+	void decal_set_distance_fade(RID p_decal, bool p_enabled, float p_begin, float p_length) override {}
+	void decal_set_fade(RID p_decal, float p_above, float p_below) override {}
+	void decal_set_normal_fade(RID p_decal, float p_fade) override {}
 
-	virtual AABB decal_get_aabb(RID p_decal) const { return AABB(); }
+	AABB decal_get_aabb(RID p_decal) const override { return AABB(); }
 
 	/* GI PROBE API */
 
-	RID gi_probe_create() { return RID(); }
+	RID gi_probe_create() override { return RID(); }
 
-	virtual void gi_probe_allocate(RID p_gi_probe, const Transform &p_to_cell_xform, const AABB &p_aabb, const Vector3i &p_octree_size, const Vector<uint8_t> &p_octree_cells, const Vector<uint8_t> &p_data_cells, const Vector<uint8_t> &p_distance_field, const Vector<int> &p_level_counts) {}
+	void gi_probe_allocate(RID p_gi_probe, const Transform &p_to_cell_xform, const AABB &p_aabb, const Vector3i &p_octree_size, const Vector<uint8_t> &p_octree_cells, const Vector<uint8_t> &p_data_cells, const Vector<uint8_t> &p_distance_field, const Vector<int> &p_level_counts) override {}
 
-	virtual AABB gi_probe_get_bounds(RID p_gi_probe) const { return AABB(); }
-	virtual Vector3i gi_probe_get_octree_size(RID p_gi_probe) const { return Vector3i(); }
-	virtual Vector<uint8_t> gi_probe_get_octree_cells(RID p_gi_probe) const { return Vector<uint8_t>(); }
-	virtual Vector<uint8_t> gi_probe_get_data_cells(RID p_gi_probe) const { return Vector<uint8_t>(); }
-	virtual Vector<uint8_t> gi_probe_get_distance_field(RID p_gi_probe) const { return Vector<uint8_t>(); }
+	AABB gi_probe_get_bounds(RID p_gi_probe) const override { return AABB(); }
+	Vector3i gi_probe_get_octree_size(RID p_gi_probe) const override { return Vector3i(); }
+	Vector<uint8_t> gi_probe_get_octree_cells(RID p_gi_probe) const override { return Vector<uint8_t>(); }
+	Vector<uint8_t> gi_probe_get_data_cells(RID p_gi_probe) const override { return Vector<uint8_t>(); }
+	Vector<uint8_t> gi_probe_get_distance_field(RID p_gi_probe) const override { return Vector<uint8_t>(); }
 
-	virtual Vector<int> gi_probe_get_level_counts(RID p_gi_probe) const { return Vector<int>(); }
-	virtual Transform gi_probe_get_to_cell_xform(RID p_gi_probe) const { return Transform(); }
+	Vector<int> gi_probe_get_level_counts(RID p_gi_probe) const override { return Vector<int>(); }
+	Transform gi_probe_get_to_cell_xform(RID p_gi_probe) const override { return Transform(); }
 
-	virtual void gi_probe_set_dynamic_range(RID p_gi_probe, float p_range) {}
-	virtual float gi_probe_get_dynamic_range(RID p_gi_probe) const { return 0; }
+	void gi_probe_set_dynamic_range(RID p_gi_probe, float p_range) override {}
+	float gi_probe_get_dynamic_range(RID p_gi_probe) const override { return 0; }
 
-	virtual void gi_probe_set_propagation(RID p_gi_probe, float p_range) {}
-	virtual float gi_probe_get_propagation(RID p_gi_probe) const { return 0; }
+	void gi_probe_set_propagation(RID p_gi_probe, float p_range) override {}
+	float gi_probe_get_propagation(RID p_gi_probe) const override { return 0; }
 
-	void gi_probe_set_energy(RID p_gi_probe, float p_range) {}
-	float gi_probe_get_energy(RID p_gi_probe) const { return 0.0; }
+	void gi_probe_set_energy(RID p_gi_probe, float p_range) override {}
+	float gi_probe_get_energy(RID p_gi_probe) const override { return 0.0; }
 
-	virtual void gi_probe_set_ao(RID p_gi_probe, float p_ao) {}
-	virtual float gi_probe_get_ao(RID p_gi_probe) const { return 0; }
+	void gi_probe_set_ao(RID p_gi_probe, float p_ao) override {}
+	float gi_probe_get_ao(RID p_gi_probe) const override { return 0; }
 
-	virtual void gi_probe_set_ao_size(RID p_gi_probe, float p_strength) {}
-	virtual float gi_probe_get_ao_size(RID p_gi_probe) const { return 0; }
+	void gi_probe_set_ao_size(RID p_gi_probe, float p_strength) override {}
+	float gi_probe_get_ao_size(RID p_gi_probe) const override { return 0; }
 
-	void gi_probe_set_bias(RID p_gi_probe, float p_range) {}
-	float gi_probe_get_bias(RID p_gi_probe) const { return 0.0; }
+	void gi_probe_set_bias(RID p_gi_probe, float p_range) override {}
+	float gi_probe_get_bias(RID p_gi_probe) const override { return 0.0; }
 
-	void gi_probe_set_normal_bias(RID p_gi_probe, float p_range) {}
-	float gi_probe_get_normal_bias(RID p_gi_probe) const { return 0.0; }
+	void gi_probe_set_normal_bias(RID p_gi_probe, float p_range) override {}
+	float gi_probe_get_normal_bias(RID p_gi_probe) const override { return 0.0; }
 
-	void gi_probe_set_interior(RID p_gi_probe, bool p_enable) {}
-	bool gi_probe_is_interior(RID p_gi_probe) const { return false; }
+	void gi_probe_set_interior(RID p_gi_probe, bool p_enable) override {}
+	bool gi_probe_is_interior(RID p_gi_probe) const override { return false; }
 
-	virtual void gi_probe_set_use_two_bounces(RID p_gi_probe, bool p_enable) {}
-	virtual bool gi_probe_is_using_two_bounces(RID p_gi_probe) const { return false; }
+	void gi_probe_set_use_two_bounces(RID p_gi_probe, bool p_enable) override {}
+	bool gi_probe_is_using_two_bounces(RID p_gi_probe) const override { return false; }
 
-	virtual void gi_probe_set_anisotropy_strength(RID p_gi_probe, float p_strength) {}
-	virtual float gi_probe_get_anisotropy_strength(RID p_gi_probe) const { return 0; }
+	void gi_probe_set_anisotropy_strength(RID p_gi_probe, float p_strength) override {}
+	float gi_probe_get_anisotropy_strength(RID p_gi_probe) const override { return 0; }
 
-	uint32_t gi_probe_get_version(RID p_gi_probe) { return 0; }
+	uint32_t gi_probe_get_version(RID p_gi_probe) override { return 0; }
 
 	/* LIGHTMAP CAPTURE */
 #if 0
@@ -717,19 +702,19 @@ public:
 
 		SelfList<RasterizerScene::InstanceBase>::List instance_list;
 
-		_FORCE_INLINE_ void instance_change_notify(bool p_aabb = true, bool p_materials = true) {
+		_FORCE_INLINE_ void instance_change_notify(bool p_aabb = true, bool p_materials = true) override {
 
 			SelfList<RasterizerScene::InstanceBase> *instances = instance_list.first();
-			while (instances) {
+			while (instances) override {
 
 				//instances->self()->base_changed(p_aabb, p_materials);
 				instances = instances->next();
 			}
 		}
 
-		_FORCE_INLINE_ void instance_remove_deps() {
+		_FORCE_INLINE_ void instance_remove_deps() override {
 			SelfList<RasterizerScene::InstanceBase> *instances = instance_list.first();
-			while (instances) {
+			while (instances) override {
 
 				SelfList<RasterizerScene::InstanceBase> *next = instances->next();
 				//instances->self()->base_removed();
@@ -737,8 +722,8 @@ public:
 			}
 		}
 
-		Instantiable() {}
-		virtual ~Instantiable() {
+		Instantiable() override {}
+		~Instantiable() override {
 		}
 	};
 
@@ -749,126 +734,129 @@ public:
 		Transform cell_xform;
 		int cell_subdiv;
 		float energy;
-		LightmapCapture() {
+		LightmapCapture() override {
 			energy = 1.0;
 			cell_subdiv = 1;
 		}
 	};
 
 	mutable RID_PtrOwner<LightmapCapture> lightmap_capture_data_owner;
-	void lightmap_capture_set_bounds(RID p_capture, const AABB &p_bounds) {}
-	AABB lightmap_capture_get_bounds(RID p_capture) const { return AABB(); }
-	void lightmap_capture_set_octree(RID p_capture, const Vector<uint8_t> &p_octree) {}
-	RID lightmap_capture_create() {
+	void lightmap_capture_set_bounds(RID p_capture, const AABB &p_bounds) override {}
+	AABB lightmap_capture_get_bounds(RID p_capture) const override { return AABB(); }
+	void lightmap_capture_set_octree(RID p_capture, const Vector<uint8_t> &p_octree) override {}
+	RID lightmap_capture_create() override {
 		LightmapCapture *capture = memnew(LightmapCapture);
 		return lightmap_capture_data_owner.make_rid(capture);
 	}
-	Vector<uint8_t> lightmap_capture_get_octree(RID p_capture) const {
+	Vector<uint8_t> lightmap_capture_get_octree(RID p_capture) const override {
 		const LightmapCapture *capture = lightmap_capture_data_owner.getornull(p_capture);
 		ERR_FAIL_COND_V(!capture, Vector<uint8_t>());
 		return Vector<uint8_t>();
 	}
-	void lightmap_capture_set_octree_cell_transform(RID p_capture, const Transform &p_xform) {}
-	Transform lightmap_capture_get_octree_cell_transform(RID p_capture) const { return Transform(); }
-	void lightmap_capture_set_octree_cell_subdiv(RID p_capture, int p_subdiv) {}
-	int lightmap_capture_get_octree_cell_subdiv(RID p_capture) const { return 0; }
-	void lightmap_capture_set_energy(RID p_capture, float p_energy) {}
-	float lightmap_capture_get_energy(RID p_capture) const { return 0.0; }
-	const Vector<LightmapCaptureOctree> *lightmap_capture_get_octree_ptr(RID p_capture) const {
+	void lightmap_capture_set_octree_cell_transform(RID p_capture, const Transform &p_xform) override {}
+	Transform lightmap_capture_get_octree_cell_transform(RID p_capture) const override { return Transform(); }
+	void lightmap_capture_set_octree_cell_subdiv(RID p_capture, int p_subdiv) override {}
+	int lightmap_capture_get_octree_cell_subdiv(RID p_capture) const override { return 0; }
+	void lightmap_capture_set_energy(RID p_capture, float p_energy) override {}
+	float lightmap_capture_get_energy(RID p_capture) const override { return 0.0; }
+	const Vector<LightmapCaptureOctree> *lightmap_capture_get_octree_ptr(RID p_capture) const override {
 		const LightmapCapture *capture = lightmap_capture_data_owner.getornull(p_capture);
 		ERR_FAIL_COND_V(!capture, nullptr);
 		return &capture->octree;
 	}
 #endif
 
-	virtual RID lightmap_create() { return RID(); }
+	RID lightmap_create() override { return RID(); }
 
-	virtual void lightmap_set_textures(RID p_lightmap, RID p_light, bool p_uses_spherical_haromics) {}
-	virtual void lightmap_set_probe_bounds(RID p_lightmap, const AABB &p_bounds) {}
-	virtual void lightmap_set_probe_interior(RID p_lightmap, bool p_interior) {}
-	virtual void lightmap_set_probe_capture_data(RID p_lightmap, const PackedVector3Array &p_points, const PackedColorArray &p_point_sh, const PackedInt32Array &p_tetrahedra, const PackedInt32Array &p_bsp_tree) {}
-	virtual PackedVector3Array lightmap_get_probe_capture_points(RID p_lightmap) const { return PackedVector3Array(); }
-	virtual PackedColorArray lightmap_get_probe_capture_sh(RID p_lightmap) const { return PackedColorArray(); }
-	virtual PackedInt32Array lightmap_get_probe_capture_tetrahedra(RID p_lightmap) const { return PackedInt32Array(); }
-	virtual PackedInt32Array lightmap_get_probe_capture_bsp_tree(RID p_lightmap) const { return PackedInt32Array(); }
-	virtual AABB lightmap_get_aabb(RID p_lightmap) const { return AABB(); }
-	virtual void lightmap_tap_sh_light(RID p_lightmap, const Vector3 &p_point, Color *r_sh) {}
-	virtual bool lightmap_is_interior(RID p_lightmap) const { return false; }
-	virtual void lightmap_set_probe_capture_update_speed(float p_speed) {}
-	virtual float lightmap_get_probe_capture_update_speed() const { return 0; }
+	void lightmap_set_textures(RID p_lightmap, RID p_light, bool p_uses_spherical_haromics) override {}
+	void lightmap_set_probe_bounds(RID p_lightmap, const AABB &p_bounds) override {}
+	void lightmap_set_probe_interior(RID p_lightmap, bool p_interior) override {}
+	void lightmap_set_probe_capture_data(RID p_lightmap, const PackedVector3Array &p_points, const PackedColorArray &p_point_sh, const PackedInt32Array &p_tetrahedra, const PackedInt32Array &p_bsp_tree) override {}
+	PackedVector3Array lightmap_get_probe_capture_points(RID p_lightmap) const override { return PackedVector3Array(); }
+	PackedColorArray lightmap_get_probe_capture_sh(RID p_lightmap) const override { return PackedColorArray(); }
+	PackedInt32Array lightmap_get_probe_capture_tetrahedra(RID p_lightmap) const override { return PackedInt32Array(); }
+	PackedInt32Array lightmap_get_probe_capture_bsp_tree(RID p_lightmap) const override { return PackedInt32Array(); }
+	AABB lightmap_get_aabb(RID p_lightmap) const override { return AABB(); }
+	void lightmap_tap_sh_light(RID p_lightmap, const Vector3 &p_point, Color *r_sh) override {}
+	bool lightmap_is_interior(RID p_lightmap) const override { return false; }
+	void lightmap_set_probe_capture_update_speed(float p_speed) override {}
+	float lightmap_get_probe_capture_update_speed() const override { return 0; }
 
 	/* PARTICLES */
 
-	RID particles_create() { return RID(); }
+	RID particles_create() override { return RID(); }
 
-	void particles_set_emitting(RID p_particles, bool p_emitting) {}
-	void particles_set_amount(RID p_particles, int p_amount) {}
-	void particles_set_lifetime(RID p_particles, float p_lifetime) {}
-	void particles_set_one_shot(RID p_particles, bool p_one_shot) {}
-	void particles_set_pre_process_time(RID p_particles, float p_time) {}
-	void particles_set_explosiveness_ratio(RID p_particles, float p_ratio) {}
-	void particles_set_randomness_ratio(RID p_particles, float p_ratio) {}
-	void particles_set_custom_aabb(RID p_particles, const AABB &p_aabb) {}
-	void particles_set_speed_scale(RID p_particles, float p_scale) {}
-	void particles_set_use_local_coordinates(RID p_particles, bool p_enable) {}
-	void particles_set_process_material(RID p_particles, RID p_material) {}
-	void particles_set_fixed_fps(RID p_particles, int p_fps) {}
-	void particles_set_fractional_delta(RID p_particles, bool p_enable) {}
-	void particles_restart(RID p_particles) {}
+	void particles_emit(RID p_particles, const Transform &p_transform, const Vector3 &p_velocity, const Color &p_color, const Color &p_custom, uint32_t p_emit_flags) override {}
+	void particles_set_emitting(RID p_particles, bool p_emitting) override {}
+	void particles_set_amount(RID p_particles, int p_amount) override {}
+	void particles_set_lifetime(RID p_particles, float p_lifetime) override {}
+	void particles_set_one_shot(RID p_particles, bool p_one_shot) override {}
+	void particles_set_pre_process_time(RID p_particles, float p_time) override {}
+	void particles_set_explosiveness_ratio(RID p_particles, float p_ratio) override {}
+	void particles_set_randomness_ratio(RID p_particles, float p_ratio) override {}
+	void particles_set_custom_aabb(RID p_particles, const AABB &p_aabb) override {}
+	void particles_set_speed_scale(RID p_particles, float p_scale) override {}
+	void particles_set_use_local_coordinates(RID p_particles, bool p_enable) override {}
+	void particles_set_process_material(RID p_particles, RID p_material) override {}
+	void particles_set_fixed_fps(RID p_particles, int p_fps) override {}
+	void particles_set_fractional_delta(RID p_particles, bool p_enable) override {}
+	void particles_set_subemitter(RID p_particles, RID p_subemitter_particles) override {}
+	void particles_set_view_axis(RID p_particles, const Vector3 &p_axis) override {}
+	void particles_restart(RID p_particles) override {}
 
-	void particles_set_draw_order(RID p_particles, RS::ParticlesDrawOrder p_order) {}
+	void particles_set_draw_order(RID p_particles, RS::ParticlesDrawOrder p_order) override {}
 
-	void particles_set_draw_passes(RID p_particles, int p_count) {}
-	void particles_set_draw_pass_mesh(RID p_particles, int p_pass, RID p_mesh) {}
+	void particles_set_draw_passes(RID p_particles, int p_count) override {}
+	void particles_set_draw_pass_mesh(RID p_particles, int p_pass, RID p_mesh) override {}
 
-	void particles_request_process(RID p_particles) {}
-	AABB particles_get_current_aabb(RID p_particles) { return AABB(); }
-	AABB particles_get_aabb(RID p_particles) const { return AABB(); }
+	void particles_request_process(RID p_particles) override {}
+	AABB particles_get_current_aabb(RID p_particles) override { return AABB(); }
+	AABB particles_get_aabb(RID p_particles) const override { return AABB(); }
 
-	void particles_set_emission_transform(RID p_particles, const Transform &p_transform) {}
+	void particles_set_emission_transform(RID p_particles, const Transform &p_transform) override {}
 
-	bool particles_get_emitting(RID p_particles) { return false; }
-	int particles_get_draw_passes(RID p_particles) const { return 0; }
-	RID particles_get_draw_pass_mesh(RID p_particles, int p_pass) const { return RID(); }
+	bool particles_get_emitting(RID p_particles) override { return false; }
+	int particles_get_draw_passes(RID p_particles) const override { return 0; }
+	RID particles_get_draw_pass_mesh(RID p_particles, int p_pass) const override { return RID(); }
 
 	/* GLOBAL VARIABLES */
 
-	virtual void global_variable_add(const StringName &p_name, RS::GlobalVariableType p_type, const Variant &p_value) {}
-	virtual void global_variable_remove(const StringName &p_name) {}
-	virtual Vector<StringName> global_variable_get_list() const { return Vector<StringName>(); }
+	void global_variable_add(const StringName &p_name, RS::GlobalVariableType p_type, const Variant &p_value) override {}
+	void global_variable_remove(const StringName &p_name) override {}
+	Vector<StringName> global_variable_get_list() const override { return Vector<StringName>(); }
 
-	virtual void global_variable_set(const StringName &p_name, const Variant &p_value) {}
-	virtual void global_variable_set_override(const StringName &p_name, const Variant &p_value) {}
-	virtual Variant global_variable_get(const StringName &p_name) const { return Variant(); }
-	virtual RS::GlobalVariableType global_variable_get_type(const StringName &p_name) const { return RS::GLOBAL_VAR_TYPE_MAX; }
+	void global_variable_set(const StringName &p_name, const Variant &p_value) override {}
+	void global_variable_set_override(const StringName &p_name, const Variant &p_value) override {}
+	Variant global_variable_get(const StringName &p_name) const override { return Variant(); }
+	RS::GlobalVariableType global_variable_get_type(const StringName &p_name) const override { return RS::GLOBAL_VAR_TYPE_MAX; }
 
-	virtual void global_variables_load_settings(bool p_load_textures = true) {}
-	virtual void global_variables_clear() {}
+	void global_variables_load_settings(bool p_load_textures = true) override {}
+	void global_variables_clear() override {}
 
-	virtual int32_t global_variables_instance_allocate(RID p_instance) { return 0; }
-	virtual void global_variables_instance_free(RID p_instance) {}
-	virtual void global_variables_instance_update(RID p_instance, int p_index, const Variant &p_value) {}
+	int32_t global_variables_instance_allocate(RID p_instance) override { return 0; }
+	void global_variables_instance_free(RID p_instance) override {}
+	void global_variables_instance_update(RID p_instance, int p_index, const Variant &p_value) override {}
 
-	virtual bool particles_is_inactive(RID p_particles) const { return false; }
+	bool particles_is_inactive(RID p_particles) const override { return false; }
 
 	/* RENDER TARGET */
 
-	RID render_target_create() { return RID(); }
-	void render_target_set_position(RID p_render_target, int p_x, int p_y) {}
-	void render_target_set_size(RID p_render_target, int p_width, int p_height) {}
-	RID render_target_get_texture(RID p_render_target) { return RID(); }
-	void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) {}
-	void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) {}
-	bool render_target_was_used(RID p_render_target) { return false; }
-	void render_target_set_as_unused(RID p_render_target) {}
+	RID render_target_create() override { return RID(); }
+	void render_target_set_position(RID p_render_target, int p_x, int p_y) override {}
+	void render_target_set_size(RID p_render_target, int p_width, int p_height) override {}
+	RID render_target_get_texture(RID p_render_target) override { return RID(); }
+	void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) override {}
+	void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) override {}
+	bool render_target_was_used(RID p_render_target) override { return false; }
+	void render_target_set_as_unused(RID p_render_target) override {}
 
-	virtual void render_target_request_clear(RID p_render_target, const Color &p_clear_color) {}
-	virtual bool render_target_is_clear_requested(RID p_render_target) { return false; }
-	virtual Color render_target_get_clear_request_color(RID p_render_target) { return Color(); }
-	virtual void render_target_disable_clear_request(RID p_render_target) {}
-	virtual void render_target_do_clear_request(RID p_render_target) {}
+	void render_target_request_clear(RID p_render_target, const Color &p_clear_color) override {}
+	bool render_target_is_clear_requested(RID p_render_target) override { return false; }
+	Color render_target_get_clear_request_color(RID p_render_target) override { return Color(); }
+	void render_target_disable_clear_request(RID p_render_target) override {}
+	void render_target_do_clear_request(RID p_render_target) override {}
 
-	RS::InstanceType get_base_type(RID p_rid) const {
+	RS::InstanceType get_base_type(RID p_rid) const override {
 		if (mesh_owner.owns(p_rid)) {
 			return RS::INSTANCE_MESH;
 		}
@@ -876,7 +864,7 @@ public:
 		return RS::INSTANCE_NONE;
 	}
 
-	bool free(RID p_rid) {
+	bool free(RID p_rid) override {
 		if (texture_owner.owns(p_rid)) {
 			// delete the texture
 			DummyTexture *texture = texture_owner.getornull(p_rid);
@@ -893,29 +881,29 @@ public:
 		return true;
 	}
 
-	bool has_os_feature(const String &p_feature) const { return false; }
+	bool has_os_feature(const String &p_feature) const override { return false; }
 
-	void update_dirty_resources() {}
+	void update_dirty_resources() override {}
 
-	void set_debug_generate_wireframes(bool p_generate) {}
+	void set_debug_generate_wireframes(bool p_generate) override {}
 
-	void render_info_begin_capture() {}
-	void render_info_end_capture() {}
-	int get_captured_render_info(RS::RenderInfo p_info) { return 0; }
+	void render_info_begin_capture() override {}
+	void render_info_end_capture() override {}
+	int get_captured_render_info(RS::RenderInfo p_info) override { return 0; }
 
-	int get_render_info(RS::RenderInfo p_info) { return 0; }
-	String get_video_adapter_name() const { return String(); }
-	String get_video_adapter_vendor() const { return String(); }
+	int get_render_info(RS::RenderInfo p_info) override { return 0; }
+	String get_video_adapter_name() const override { return String(); }
+	String get_video_adapter_vendor() const override { return String(); }
 
 	static RasterizerStorage *base_singleton;
 
-	virtual void capture_timestamps_begin() {}
-	virtual void capture_timestamp(const String &p_name) {}
-	virtual uint32_t get_captured_timestamps_count() const { return 0; }
-	virtual uint64_t get_captured_timestamps_frame() const { return 0; }
-	virtual uint64_t get_captured_timestamp_gpu_time(uint32_t p_index) const { return 0; }
-	virtual uint64_t get_captured_timestamp_cpu_time(uint32_t p_index) const { return 0; }
-	virtual String get_captured_timestamp_name(uint32_t p_index) const { return String(); }
+	void capture_timestamps_begin() override {}
+	void capture_timestamp(const String &p_name) override {}
+	uint32_t get_captured_timestamps_count() const override { return 0; }
+	uint64_t get_captured_timestamps_frame() const override { return 0; }
+	uint64_t get_captured_timestamp_gpu_time(uint32_t p_index) const override { return 0; }
+	uint64_t get_captured_timestamp_cpu_time(uint32_t p_index) const override { return 0; }
+	String get_captured_timestamp_name(uint32_t p_index) const override { return String(); }
 
 	RasterizerStorageDummy() {}
 	~RasterizerStorageDummy() {}
@@ -923,28 +911,28 @@ public:
 
 class RasterizerCanvasDummy : public RasterizerCanvas {
 public:
-	virtual TextureBindingID request_texture_binding(RID p_texture, RID p_normalmap, RID p_specular, RS::CanvasItemTextureFilter p_filter, RS::CanvasItemTextureRepeat p_repeat, RID p_multimesh) { return 0; }
-	virtual void free_texture_binding(TextureBindingID p_binding) {}
+	TextureBindingID request_texture_binding(RID p_texture, RID p_normalmap, RID p_specular, RS::CanvasItemTextureFilter p_filter, RS::CanvasItemTextureRepeat p_repeat, RID p_multimesh) override { return 0; }
+	void free_texture_binding(TextureBindingID p_binding) override {}
 
-	virtual PolygonID request_polygon(const Vector<int> &p_indices, const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs = Vector<Point2>(), const Vector<int> &p_bones = Vector<int>(), const Vector<float> &p_weights = Vector<float>()) { return 0; }
-	virtual void free_polygon(PolygonID p_polygon) {}
+	PolygonID request_polygon(const Vector<int> &p_indices, const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs = Vector<Point2>(), const Vector<int> &p_bones = Vector<int>(), const Vector<float> &p_weights = Vector<float>()) override { return 0; }
+	void free_polygon(PolygonID p_polygon) override {}
 
-	virtual void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, const Transform2D &p_canvas_transform) {}
-	virtual void canvas_debug_viewport_shadows(Light *p_lights_with_shadow) {}
+	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, const Transform2D &p_canvas_transform) override {}
+	void canvas_debug_viewport_shadows(Light *p_lights_with_shadow) override {}
 
-	virtual RID light_create() { return RID(); }
-	virtual void light_set_texture(RID p_rid, RID p_texture) {}
-	virtual void light_set_use_shadow(RID p_rid, bool p_enable, int p_resolution) {}
-	virtual void light_update_shadow(RID p_rid, const Transform2D &p_light_xform, int p_light_mask, float p_near, float p_far, LightOccluderInstance *p_occluders) {}
+	RID light_create() override { return RID(); }
+	void light_set_texture(RID p_rid, RID p_texture) override {}
+	void light_set_use_shadow(RID p_rid, bool p_enable, int p_resolution) override {}
+	void light_update_shadow(RID p_rid, const Transform2D &p_light_xform, int p_light_mask, float p_near, float p_far, LightOccluderInstance *p_occluders) override {}
 
-	virtual RID occluder_polygon_create() { return RID(); }
-	virtual void occluder_polygon_set_shape_as_lines(RID p_occluder, const Vector<Vector2> &p_lines) {}
-	virtual void occluder_polygon_set_cull_mode(RID p_occluder, RS::CanvasOccluderPolygonCullMode p_mode) {}
+	RID occluder_polygon_create() override { return RID(); }
+	void occluder_polygon_set_shape_as_lines(RID p_occluder, const Vector<Vector2> &p_lines) override {}
+	void occluder_polygon_set_cull_mode(RID p_occluder, RS::CanvasOccluderPolygonCullMode p_mode) override {}
 
-	void draw_window_margins(int *p_margins, RID *p_margin_textures) {}
+	void draw_window_margins(int *p_margins, RID *p_margin_textures) override {}
 
-	virtual bool free(RID p_rid) { return true; }
-	virtual void update() {}
+	bool free(RID p_rid) override { return true; }
+	void update() override {}
 
 	RasterizerCanvasDummy() {}
 	~RasterizerCanvasDummy() {}
@@ -961,32 +949,28 @@ protected:
 	RasterizerSceneDummy scene;
 
 public:
-	RasterizerStorage *get_storage() { return &storage; }
-	RasterizerCanvas *get_canvas() { return &canvas; }
-	RasterizerScene *get_scene() { return &scene; }
+	RasterizerStorage *get_storage() override { return &storage; }
+	RasterizerCanvas *get_canvas() override { return &canvas; }
+	RasterizerScene *get_scene() override { return &scene; }
 
-	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) {}
+	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) override {}
 
-	void initialize() {}
-	void begin_frame(double frame_step) {
+	void initialize() override {}
+	void begin_frame(double frame_step) override {
 		frame++;
 		delta = frame_step;
 	}
 
-	virtual void prepare_for_blitting_render_targets() {}
-	virtual void blit_render_targets_to_screen(int p_screen, const BlitToScreen *p_render_targets, int p_amount) {}
+	void prepare_for_blitting_render_targets() override {}
+	void blit_render_targets_to_screen(int p_screen, const BlitToScreen *p_render_targets, int p_amount) override {}
 
-	void end_frame(bool p_swap_buffers) {
+	void end_frame(bool p_swap_buffers) override {
 		if (p_swap_buffers) {
 			DisplayServer::get_singleton()->swap_buffers();
 		}
 	}
 
-	void finalize() {}
-
-	static Error is_viable() {
-		return OK;
-	}
+	void finalize() override {}
 
 	static Rasterizer *_create_current() {
 		return memnew(RasterizerDummy);
@@ -996,9 +980,9 @@ public:
 		_create_func = _create_current;
 	}
 
-	virtual bool is_low_end() const { return true; }
-	virtual uint64_t get_frame_number() const { return frame; }
-	virtual float get_frame_delta_time() const { return delta; }
+	bool is_low_end() const override { return true; }
+	uint64_t get_frame_number() const override { return frame; }
+	float get_frame_delta_time() const override { return delta; }
 
 	RasterizerDummy() {}
 	~RasterizerDummy() {}

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -147,6 +147,7 @@ $GODOT_HEAD_INCLUDE
 			const MAIN_PACK = '$GODOT_BASENAME.pck';
 			const EXTRA_ARGS = JSON.parse('$GODOT_ARGS');
 			const INDETERMINATE_STATUS_STEP_MS = 100;
+			const FULL_WINDOW = $GODOT_FULL_WINDOW;
 
 			var canvas = document.getElementById('canvas');
 			var statusProgress = document.getElementById('status-progress');
@@ -179,8 +180,12 @@ $GODOT_HEAD_INCLUDE
 					canvas.style.height = lastHeight + "px";
 				}
 			}
-			animationCallbacks.push(adjustCanvasDimensions);
-			adjustCanvasDimensions();
+			if (FULL_WINDOW) {
+				animationCallbacks.push(adjustCanvasDimensions);
+				adjustCanvasDimensions();
+			} else {
+				engine.setCanvasResizedOnStart(true);
+			}
 
 			setStatusMode = function setStatusMode(mode) {
 

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -156,6 +156,9 @@ $GODOT_HEAD_INCLUDE
 
 			var initializing = true;
 			var statusMode = 'hidden';
+			var lastWidth = 0;
+			var lastHeight = 0;
+			var lastScale = 0;
 
 			var animationCallbacks = [];
 			function animate(time) {
@@ -165,11 +168,16 @@ $GODOT_HEAD_INCLUDE
 			requestAnimationFrame(animate);
 
 			function adjustCanvasDimensions() {
-				var scale = window.devicePixelRatio || 1;
-				var width = window.innerWidth;
-				var height = window.innerHeight;
-				canvas.width = width * scale;
-				canvas.height = height * scale;
+				const scale = window.devicePixelRatio || 1;
+				if (lastWidth != window.innerWidth || lastHeight != window.innerHeight || lastScale != scale) {
+					lastScale = scale;
+					lastWidth = window.innerWidth;
+					lastHeight = window.innerHeight;
+					canvas.width = Math.floor(lastWidth * scale);
+					canvas.height = Math.floor(lastHeight * scale);
+					canvas.style.width = lastWidth + "px";
+					canvas.style.height = lastHeight + "px";
+				}
 			}
 			animationCallbacks.push(adjustCanvasDimensions);
 			adjustCanvasDimensions();

--- a/platform/javascript/audio_driver_javascript.h
+++ b/platform/javascript/audio_driver_javascript.h
@@ -46,21 +46,21 @@ public:
 
 	static AudioDriverJavaScript *singleton;
 
-	virtual const char *get_name() const;
+	const char *get_name() const override;
 
-	virtual Error init();
-	virtual void start();
+	Error init() override;
+	void start() override;
 	void resume();
-	virtual float get_latency();
-	virtual int get_mix_rate() const;
-	virtual SpeakerMode get_speaker_mode() const;
-	virtual void lock();
-	virtual void unlock();
-	virtual void finish();
+	float get_latency() override;
+	int get_mix_rate() const override;
+	SpeakerMode get_speaker_mode() const override;
+	void lock() override;
+	void unlock() override;
+	void finish() override;
 	void finish_async();
 
-	virtual Error capture_start();
-	virtual Error capture_stop();
+	Error capture_start() override;
+	Error capture_stop() override;
 
 	AudioDriverJavaScript();
 };

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -892,15 +892,18 @@ DisplayServerJavaScript::DisplayServerJavaScript(const String &p_rendering_drive
 #define SET_EM_CALLBACK(target, ev, cb)                                  \
 	result = emscripten_set_##ev##_callback(target, nullptr, true, &cb); \
 	EM_CHECK(ev)
+#define SET_EM_WINDOW_CALLBACK(ev, cb)                                                         \
+	result = emscripten_set_##ev##_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, false, &cb); \
+	EM_CHECK(ev)
 #define SET_EM_CALLBACK_NOTARGET(ev, cb)                         \
 	result = emscripten_set_##ev##_callback(nullptr, true, &cb); \
 	EM_CHECK(ev)
 	// These callbacks from Emscripten's html5.h suffice to access most
 	// JavaScript APIs. For APIs that are not (sufficiently) exposed, EM_ASM
 	// is used below.
-	SET_EM_CALLBACK(EMSCRIPTEN_EVENT_TARGET_WINDOW, mousemove, mousemove_callback)
 	SET_EM_CALLBACK(canvas_id, mousedown, mouse_button_callback)
-	SET_EM_CALLBACK(EMSCRIPTEN_EVENT_TARGET_WINDOW, mouseup, mouse_button_callback)
+	SET_EM_WINDOW_CALLBACK(mousemove, mousemove_callback)
+	SET_EM_WINDOW_CALLBACK(mouseup, mouse_button_callback)
 	SET_EM_CALLBACK(canvas_id, wheel, wheel_callback)
 	SET_EM_CALLBACK(canvas_id, touchstart, touch_press_callback)
 	SET_EM_CALLBACK(canvas_id, touchmove, touchmove_callback)

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -75,7 +75,7 @@ bool DisplayServerJavaScript::check_size_force_redraw() {
 	if (last_width != canvas_width || last_height != canvas_height) {
 		last_width = canvas_width;
 		last_height = canvas_height;
-		// Update the framebuffer size and for redraw.
+		// Update the framebuffer size for redraw.
 		emscripten_set_canvas_element_size(DisplayServerJavaScript::canvas_id, canvas_width, canvas_height);
 		return true;
 	}
@@ -1103,7 +1103,11 @@ Size2i DisplayServerJavaScript::window_get_min_size(WindowID p_window) const {
 void DisplayServerJavaScript::window_set_size(const Size2i p_size, WindowID p_window) {
 	last_width = p_size.x;
 	last_height = p_size.y;
-	emscripten_set_canvas_element_size(canvas_id, p_size.x, p_size.y);
+	double scale = EM_ASM_DOUBLE({
+		return window.devicePixelRatio || 1;
+	});
+	emscripten_set_canvas_element_size(canvas_id, p_size.x * scale, p_size.y * scale);
+	emscripten_set_element_css_size(canvas_id, p_size.x, p_size.y);
 }
 
 Size2i DisplayServerJavaScript::window_get_size(WindowID p_window) const {

--- a/platform/javascript/display_server_javascript.h
+++ b/platform/javascript/display_server_javascript.h
@@ -93,7 +93,7 @@ class DisplayServerJavaScript : public DisplayServer {
 	static void _dispatch_input_event(const Ref<InputEvent> &p_event);
 
 protected:
-	virtual int get_current_video_driver() const;
+	int get_current_video_driver() const;
 
 public:
 	// Override return type to make writing static callbacks less tedious.
@@ -113,92 +113,92 @@ public:
 	bool check_size_force_redraw();
 
 	// from DisplayServer
-	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
-	virtual bool has_feature(Feature p_feature) const;
-	virtual String get_name() const;
+	void alert(const String &p_alert, const String &p_title = "ALERT!") override;
+	bool has_feature(Feature p_feature) const override;
+	String get_name() const override;
 
 	// cursor
-	virtual void cursor_set_shape(CursorShape p_shape);
-	virtual CursorShape cursor_get_shape() const;
-	virtual void cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
+	void cursor_set_shape(CursorShape p_shape) override;
+	CursorShape cursor_get_shape() const override;
+	void cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) override;
 
 	// mouse
-	virtual void mouse_set_mode(MouseMode p_mode);
-	virtual MouseMode mouse_get_mode() const;
+	void mouse_set_mode(MouseMode p_mode) override;
+	MouseMode mouse_get_mode() const override;
 
 	// touch
-	virtual bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
+	bool screen_is_touchscreen(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 
 	// clipboard
-	virtual void clipboard_set(const String &p_text);
-	virtual String clipboard_get() const;
+	void clipboard_set(const String &p_text) override;
+	String clipboard_get() const override;
 
 	// screen
-	virtual int get_screen_count() const;
-	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
-	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
-	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
-	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const;
+	int get_screen_count() const override;
+	Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 
 	// windows
-	virtual Vector<DisplayServer::WindowID> get_window_list() const;
-	virtual WindowID get_window_at_screen_position(const Point2i &p_position) const;
+	Vector<DisplayServer::WindowID> get_window_list() const override;
+	WindowID get_window_at_screen_position(const Point2i &p_position) const override;
 
-	virtual void window_attach_instance_id(ObjectID p_instance, WindowID p_window = MAIN_WINDOW_ID);
-	virtual ObjectID window_get_attached_instance_id(WindowID p_window = MAIN_WINDOW_ID) const;
+	void window_attach_instance_id(ObjectID p_instance, WindowID p_window = MAIN_WINDOW_ID) override;
+	ObjectID window_get_attached_instance_id(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
+	void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual void window_set_window_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
-	virtual void window_set_input_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
-	virtual void window_set_input_text_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
+	void window_set_window_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	void window_set_input_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	void window_set_input_text_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual void window_set_drop_files_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID);
+	void window_set_drop_files_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID);
+	void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const;
-	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID);
+	int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
+	void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual Point2i window_get_position(WindowID p_window = MAIN_WINDOW_ID) const;
-	virtual void window_set_position(const Point2i &p_position, WindowID p_window = MAIN_WINDOW_ID);
+	Point2i window_get_position(WindowID p_window = MAIN_WINDOW_ID) const override;
+	void window_set_position(const Point2i &p_position, WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual void window_set_transient(WindowID p_window, WindowID p_parent);
+	void window_set_transient(WindowID p_window, WindowID p_parent) override;
 
-	virtual void window_set_max_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID);
-	virtual Size2i window_get_max_size(WindowID p_window = MAIN_WINDOW_ID) const;
+	void window_set_max_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
+	Size2i window_get_max_size(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual void window_set_min_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID);
-	virtual Size2i window_get_min_size(WindowID p_window = MAIN_WINDOW_ID) const;
+	void window_set_min_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
+	Size2i window_get_min_size(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual void window_set_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID);
-	virtual Size2i window_get_size(WindowID p_window = MAIN_WINDOW_ID) const;
-	virtual Size2i window_get_real_size(WindowID p_window = MAIN_WINDOW_ID) const; // FIXME: Find clearer name for this.
+	void window_set_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
+	Size2i window_get_size(WindowID p_window = MAIN_WINDOW_ID) const override;
+	Size2i window_get_real_size(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual void window_set_mode(WindowMode p_mode, WindowID p_window = MAIN_WINDOW_ID);
-	virtual WindowMode window_get_mode(WindowID p_window = MAIN_WINDOW_ID) const;
+	void window_set_mode(WindowMode p_mode, WindowID p_window = MAIN_WINDOW_ID) override;
+	WindowMode window_get_mode(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual bool window_is_maximize_allowed(WindowID p_window = MAIN_WINDOW_ID) const;
+	bool window_is_maximize_allowed(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual void window_set_flag(WindowFlags p_flag, bool p_enabled, WindowID p_window = MAIN_WINDOW_ID);
-	virtual bool window_get_flag(WindowFlags p_flag, WindowID p_window = MAIN_WINDOW_ID) const;
+	void window_set_flag(WindowFlags p_flag, bool p_enabled, WindowID p_window = MAIN_WINDOW_ID) override;
+	bool window_get_flag(WindowFlags p_flag, WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual void window_request_attention(WindowID p_window = MAIN_WINDOW_ID);
-	virtual void window_move_to_foreground(WindowID p_window = MAIN_WINDOW_ID);
+	void window_request_attention(WindowID p_window = MAIN_WINDOW_ID) override;
+	void window_move_to_foreground(WindowID p_window = MAIN_WINDOW_ID) override;
 
-	virtual bool window_can_draw(WindowID p_window = MAIN_WINDOW_ID) const;
+	bool window_can_draw(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual bool can_any_window_draw() const;
+	bool can_any_window_draw() const override;
 
 	// events
-	virtual void process_events();
+	void process_events() override;
 
 	// icon
-	virtual void set_icon(const Ref<Image> &p_icon);
+	void set_icon(const Ref<Image> &p_icon) override;
 
 	// others
-	virtual bool get_swap_cancel_ok();
-	virtual void swap_buffers();
+	bool get_swap_cancel_ok() override;
+	void swap_buffers() override;
 
 	static void register_javascript_driver();
 	DisplayServerJavaScript(const String &p_rendering_driver, WindowMode p_mode, uint32_t p_flags, const Vector2i &p_resolution, Error &r_error);

--- a/platform/javascript/engine/engine.js
+++ b/platform/javascript/engine/engine.js
@@ -33,6 +33,7 @@ Function('return this')()['Engine'] = (function() {
 		this.resizeCanvasOnStart = false;
 		this.onExecute = null;
 		this.onExit = null;
+		this.persistentPaths = [];
 	};
 
 	Engine.prototype.init = /** @param {string=} basePath */ function(basePath) {
@@ -56,12 +57,14 @@ Function('return this')()['Engine'] = (function() {
 			config['locateFile'] = Utils.createLocateRewrite(loadPath);
 			config['instantiateWasm'] = Utils.createInstantiatePromise(loadPromise);
 			Godot(config).then(function(module) {
-				me.rtenv = module;
-				if (unloadAfterInit) {
-					unload();
-				}
-				resolve();
-				config = null;
+				module['initFS'](me.persistentPaths).then(function(fs_err) {
+					me.rtenv = module;
+					if (unloadAfterInit) {
+						unload();
+					}
+					resolve();
+					config = null;
+				});
 			});
 		});
 		return initPromise;
@@ -220,6 +223,10 @@ Function('return this')()['Engine'] = (function() {
 		this.rtenv['copyToFS'](path, buffer);
 	};
 
+	Engine.prototype.setPersistentPaths = function(persistentPaths) {
+		this.persistentPaths = persistentPaths;
+	};
+
 	// Closure compiler exported engine methods.
 	/** @export */
 	Engine['isWebGLAvailable'] = Utils.isWebGLAvailable;
@@ -241,5 +248,6 @@ Function('return this')()['Engine'] = (function() {
 	Engine.prototype['setOnExecute'] = Engine.prototype.setOnExecute;
 	Engine.prototype['setOnExit'] = Engine.prototype.setOnExit;
 	Engine.prototype['copyToFS'] = Engine.prototype.copyToFS;
+	Engine.prototype['setPersistentPaths'] = Engine.prototype.setPersistentPaths;
 	return Engine;
 })();

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -258,6 +258,7 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t> &p_html, const Re
 		current_line = current_line.replace("$GODOT_BASENAME", p_name);
 		current_line = current_line.replace("$GODOT_PROJECT_NAME", ProjectSettings::get_singleton()->get_setting("application/config/name"));
 		current_line = current_line.replace("$GODOT_HEAD_INCLUDE", p_preset->get("html/head_include"));
+		current_line = current_line.replace("$GODOT_FULL_WINDOW", p_preset->get("html/full_window_size") ? "true" : "false");
 		current_line = current_line.replace("$GODOT_DEBUG_ENABLED", p_debug ? "true" : "false");
 		current_line = current_line.replace("$GODOT_ARGS", flags_json);
 		str_export += current_line + "\n";
@@ -291,6 +292,7 @@ void EditorExportPlatformJavaScript::get_export_options(List<ExportOption> *r_op
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "vram_texture_compression/for_mobile"), false)); // ETC or ETC2, depending on renderer
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "html/custom_html_shell", PROPERTY_HINT_FILE, "*.html"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "html/head_include", PROPERTY_HINT_MULTILINE_TEXT), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "html/full_window_size"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/release", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/debug", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 }

--- a/platform/javascript/native/utils.js
+++ b/platform/javascript/native/utils.js
@@ -202,3 +202,44 @@ Module.drop_handler = (function() {
 		});
 	}
 })();
+
+function EventHandlers() {
+	function Handler(target, event, method, capture) {
+		this.target = target;
+		this.event = event;
+		this.method = method;
+		this.capture = capture;
+	}
+
+	var listeners = [];
+
+	function has(target, event, method, capture) {
+		return listeners.findIndex(function(e) {
+			return e.target === target && e.event === event && e.method === method && e.capture == capture;
+		}) !== -1;
+	}
+
+	this.add = function(target, event, method, capture) {
+		if (has(target, event, method, capture)) {
+			return;
+		}
+		listeners.push(new Handler(target, event, method, capture));
+		target.addEventListener(event, method, capture);
+	};
+
+	this.remove = function(target, event, method, capture) {
+		if (!has(target, event, method, capture)) {
+			return;
+		}
+		target.removeEventListener(event, method, capture);
+	};
+
+	this.clear = function() {
+		listeners.forEach(function(h) {
+			h.target.removeEventListener(h.event, h.method, h.capture);
+		});
+		listeners.length = 0;
+	};
+}
+
+Module.listeners = new EventHandlers();

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -72,27 +72,24 @@ MainLoop *OS_JavaScript::get_main_loop() const {
 	return main_loop;
 }
 
-void OS_JavaScript::main_loop_callback() {
-	get_singleton()->main_loop_iterate();
+extern "C" EMSCRIPTEN_KEEPALIVE void _idb_synced() {
+	OS_JavaScript::get_singleton()->idb_is_syncing = false;
 }
 
 bool OS_JavaScript::main_loop_iterate() {
-	if (is_userfs_persistent() && sync_wait_time >= 0) {
-		int64_t current_time = get_ticks_msec();
-		int64_t elapsed_time = current_time - last_sync_check_time;
-		last_sync_check_time = current_time;
-
-		sync_wait_time -= elapsed_time;
-
-		if (sync_wait_time < 0) {
-			/* clang-format off */
-			EM_ASM(
-				FS.syncfs(function(error) {
-					if (error) { err('Failed to save IDB file system: ' + error.message); }
-				});
-			);
-			/* clang-format on */
-		}
+	if (is_userfs_persistent() && idb_needs_sync && !idb_is_syncing) {
+		idb_is_syncing = true;
+		idb_needs_sync = false;
+		/* clang-format off */
+		EM_ASM({
+			FS.syncfs(function(error) {
+				if (error) {
+					err('Failed to save IDB file system: ' + error.message);
+				}
+				ccall("_idb_synced", 'void', [], []);
+			});
+		});
+		/* clang-format on */
 	}
 
 	DisplayServer::get_singleton()->process_events();
@@ -200,11 +197,17 @@ String OS_JavaScript::get_data_path() const {
 }
 
 void OS_JavaScript::file_access_close_callback(const String &p_file, int p_flags) {
-	OS_JavaScript *os = get_singleton();
-	if (os->is_userfs_persistent() && p_file.begins_with("/userfs") && p_flags & FileAccess::WRITE) {
-		os->last_sync_check_time = OS::get_singleton()->get_ticks_msec();
-		// Wait five seconds in case more files are about to be closed.
-		os->sync_wait_time = 5000;
+	OS_JavaScript *os = OS_JavaScript::get_singleton();
+	if (!(os->is_userfs_persistent() && (p_flags & FileAccess::WRITE))) {
+		return; // FS persistence is not working or we are not writing.
+	}
+	bool is_file_persistent = p_file.begins_with("/userfs");
+#ifdef TOOLS_ENABLED
+	// Hack for editor persistence (can we track).
+	is_file_persistent = is_file_persistent || p_file.begins_with("/home/web_user/");
+#endif
+	if (is_file_persistent) {
+		os->idb_needs_sync = true;
 	}
 }
 

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -46,24 +46,6 @@
 #include <emscripten.h>
 #include <stdlib.h>
 
-bool OS_JavaScript::has_touchscreen_ui_hint() const {
-	/* clang-format off */
-	return EM_ASM_INT_V(
-		return 'ontouchstart' in window;
-	);
-	/* clang-format on */
-}
-
-// Audio
-
-int OS_JavaScript::get_audio_driver_count() const {
-	return 1;
-}
-
-const char *OS_JavaScript::get_audio_driver_name(int p_driver) const {
-	return "JavaScript";
-}
-
 // Lifecycle
 void OS_JavaScript::initialize() {
 	OS_Unix::initialize_core();
@@ -199,10 +181,6 @@ Error OS_JavaScript::shell_open(String p_uri) {
 
 String OS_JavaScript::get_name() const {
 	return "HTML5";
-}
-
-bool OS_JavaScript::can_draw() const {
-	return true; // Always?
 }
 
 String OS_JavaScript::get_user_data_dir() const {

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -44,8 +44,7 @@ class OS_JavaScript : public OS_Unix {
 
 	bool finalizing = false;
 	bool idb_available = false;
-	int64_t sync_wait_time = -1;
-	int64_t last_sync_check_time = -1;
+	bool idb_needs_sync = false;
 
 	static void main_loop_callback();
 
@@ -62,6 +61,8 @@ protected:
 	bool _check_internal_feature_support(const String &p_feature) override;
 
 public:
+	bool idb_is_syncing = false;
+
 	// Override return type to make writing static callbacks less tedious.
 	static OS_JavaScript *get_singleton();
 

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -52,49 +52,43 @@ class OS_JavaScript : public OS_Unix {
 	static void file_access_close_callback(const String &p_file, int p_flags);
 
 protected:
-	virtual void initialize();
+	void initialize() override;
 
-	virtual void set_main_loop(MainLoop *p_main_loop);
-	virtual void delete_main_loop();
+	void set_main_loop(MainLoop *p_main_loop) override;
+	void delete_main_loop() override;
 
-	virtual void finalize();
+	void finalize() override;
 
-	virtual bool _check_internal_feature_support(const String &p_feature);
+	bool _check_internal_feature_support(const String &p_feature) override;
 
 public:
 	// Override return type to make writing static callbacks less tedious.
 	static OS_JavaScript *get_singleton();
 
-	virtual void initialize_joypads();
+	void initialize_joypads() override;
 
-	virtual bool has_touchscreen_ui_hint() const;
-
-	virtual int get_audio_driver_count() const;
-	virtual const char *get_audio_driver_name(int p_driver) const;
-
-	virtual MainLoop *get_main_loop() const;
+	MainLoop *get_main_loop() const override;
 	void finalize_async();
 	bool main_loop_iterate();
 
-	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking = true, ProcessID *r_child_id = nullptr, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr);
-	virtual Error kill(const ProcessID &p_pid);
-	virtual int get_process_id() const;
+	Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking = true, ProcessID *r_child_id = nullptr, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr) override;
+	Error kill(const ProcessID &p_pid) override;
+	int get_process_id() const override;
 
-	String get_executable_path() const;
-	virtual Error shell_open(String p_uri);
-	virtual String get_name() const;
+	String get_executable_path() const override;
+	Error shell_open(String p_uri) override;
+	String get_name() const override;
 	// Override default OS implementation which would block the main thread with delay_usec.
 	// Implemented in javascript_main.cpp loop callback instead.
-	virtual void add_frame_delay(bool p_can_draw) {}
-	virtual bool can_draw() const;
+	void add_frame_delay(bool p_can_draw) override {}
 
-	virtual String get_cache_path() const;
-	virtual String get_config_path() const;
-	virtual String get_data_path() const;
-	virtual String get_user_data_dir() const;
+	String get_cache_path() const override;
+	String get_config_path() const override;
+	String get_data_path() const override;
+	String get_user_data_dir() const override;
 
 	void set_idb_available(bool p_idb_available);
-	virtual bool is_userfs_persistent() const;
+	bool is_userfs_persistent() const override;
 
 	void resume_audio();
 	bool is_finalizing() { return finalizing; }


### PR DESCRIPTION
This PR has most of the things in #41097 (excluding the virtual keyboard support):

- Expose request_quit method to JS (sync with 3.2)
- Refactor event handlers, moving add/remove logic to native/utils.js
- window event handlers no longer useCapture (fixes #33020)
- Canvas resize option now available on export (fixes #37205).
- Add the override keyword to javascript platform

Plus, a rework of the initialization process to better handle file system synchronization (last commit, fixes #39643):

The engine now expects to emscripten FS to be setup and sync-ed before
main is called. This is exposed via `Module["initFS"]` which also allows
to setup multiple persistence paths (internal use only for now).

Additionally, FS syncing is done **once** for every loop if at least one
file in a persistent path was open for writing and closed, and if the FS
is not syncing already.

This should potentially fix issues reported by users where "autosave"
would not work on the web (never calling `syncfs` because of too many
writes).

There is a `3.2` branch of all these changes for testing and easy cherry picking: https://github.com/Faless/godot/tree/js/3.0_sync_fs_size_handlers

EDIT: ~Converted to draft, there is a bug when de-registering events. Will update soonish~ Fixed