### PR TITLE
Fix `RendererCanvasCull::canvas_item_add_line`

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -524,11 +524,11 @@ void RendererCanvasCull::canvas_item_add_line(RID p_item, const Point2 &p_from, 
 	Item::CommandPrimitive *line = canvas_item->alloc_command<Item::CommandPrimitive>();
 	ERR_FAIL_COND(!line);
 	if (p_width > 1.001) {
-		Vector2 t = (p_from - p_to).orthogonal().normalized();
-		line->points[0] = p_from + t * p_width;
-		line->points[1] = p_from - t * p_width;
-		line->points[2] = p_to - t * p_width;
-		line->points[3] = p_to + t * p_width;
+		Vector2 offset = 0.5 * p_width * (p_from - p_to).orthogonal().normalized();
+		line->points[0] = p_from + offset;
+		line->points[1] = p_from - offset;
+		line->points[2] = p_to - offset;
+		line->points[3] = p_to + offset;
 		line->point_count = 4;
 	} else {
 		line->point_count = 2;


### PR DESCRIPTION
Closes #44312.

Added missing coefficient `0.5`.

---

See https://github.com/godotengine/godot/issues/41023#issuecomment-674003794.

Similar code in 3.2:

https://github.com/godotengine/godot/blob/c8859f0463835266e6e9736d71891f81137673d1/drivers/gles3/rasterizer_canvas_gles3.cpp#L719-L723
https://github.com/godotengine/godot/blob/c8859f0463835266e6e9736d71891f81137673d1/drivers/gles3/rasterizer_canvas_gles3.cpp#L736-L746

But I couldn't solve [another problem](https://github.com/godotengine/godot/issues/41023#issuecomment-674064582).