### PR TITLE
AnimationStateMachinePlayback: Added Missing Method Bindings

### DIFF
--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -35,6 +35,13 @@
 				Returns the current travel path as computed internally by the A* algorithm.
 			</description>
 		</method>
+		<method name="get_current_play_position" qualifiers="const">
+			<return type="float">
+			</return>
+			<description>
+				Returns the playback position within the current animation state.
+			</description>
+		</method>
 		<method name="is_playing" qualifiers="const">
 			<return type="bool">
 			</return>

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -495,6 +495,8 @@ void AnimationNodeStateMachinePlayback::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("stop"), &AnimationNodeStateMachinePlayback::stop);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimationNodeStateMachinePlayback::is_playing);
 	ClassDB::bind_method(D_METHOD("get_current_node"), &AnimationNodeStateMachinePlayback::get_current_node);
+	ClassDB::bind_method(D_METHOD("get_current_play_position"), &AnimationNodeStateMachinePlayback::get_current_play_pos);
+	ClassDB::bind_method(D_METHOD("get_current_length"), &AnimationNodeStateMachinePlayback::get_current_length);
 	ClassDB::bind_method(D_METHOD("get_travel_path"), &AnimationNodeStateMachinePlayback::get_travel_path);
 }
 


### PR DESCRIPTION
Added missing bindings to `get_current_play_pos` and `get_current_length`.

This allows the user to query the AnimationNodeStateMachinePlayback's current play position and total length of current state. These methods are currently used in the C++ editor plugin, but can also be useful for querying general playback state information for gameplay purposes. It can also be useful for driving state machine playback via script.