### PR TITLE
Correctly showed `smooth_trimesh_collision` into the Project Settings.

### DIFF
--- a/modules/bullet/register_types.cpp
+++ b/modules/bullet/register_types.cpp
@@ -50,6 +50,7 @@ void register_bullet_types() {
 	PhysicsServer3DManager::set_default_server("Bullet", 1);
 
 	GLOBAL_DEF("physics/3d/active_soft_world", true);
+	GLOBAL_DEF("physics/3d/smooth_trimesh_collision", false);
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/active_soft_world", PropertyInfo(Variant::BOOL, "physics/3d/active_soft_world"));
 #endif
 }

--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -453,7 +453,7 @@ void ConcavePolygonShapeBullet::setup(Vector<Vector3> p_faces) {
 
 		meshShape = bulletnew(btBvhTriangleMeshShape(shapeInterface, useQuantizedAabbCompression));
 
-		if (GLOBAL_DEF("physics/3d/smooth_trimesh_collision", false)) {
+		if (GLOBAL_GET("physics/3d/smooth_trimesh_collision")) {
 			btTriangleInfoMap *triangleInfoMap = new btTriangleInfoMap();
 			btGenerateInternalEdgeInfo(meshShape, triangleInfoMap);
 		}


### PR DESCRIPTION
Correctly showed `smooth_trimesh_collision` into the Project Settings.
You can take more info about `smooth_trimesh_collision`, here: https://github.com/godotengine/godot-docs/pull/4040 and here: https://github.com/godotengine/godot/issues/21341#issuecomment-427364636