### PR TITLE
Fix crash when opening a ZIP data pack

### DIFF
--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -79,7 +79,7 @@ public:
 };
 
 class FileAccessZip : public FileAccess {
-	unzFile zfile;
+	unzFile zfile = nullptr;
 	unz_file_info64 file_info;
 
 	mutable bool at_eof;


### PR DESCRIPTION
Thanks to @bruvzg for providing a fix :slightly_smiling_face:

See also https://github.com/godotengine/godot/pull/42123.