### PR TITLE
Forbids varying declaration in particles and sky shaders

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -6099,6 +6099,14 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 			case TK_UNIFORM:
 			case TK_VARYING: {
 				bool uniform = tk.type == TK_UNIFORM;
+
+				if (!uniform) {
+					if (shader_type_identifier == "particles" || shader_type_identifier == "sky") {
+						_set_error(vformat("Varyings cannot be used in '%s' shaders!", shader_type_identifier));
+						return ERR_PARSE_ERROR;
+					}
+				}
+
 				DataPrecision precision = PRECISION_DEFAULT;
 				DataInterpolation interpolation = INTERPOLATION_SMOOTH;
 				DataType type;


### PR DESCRIPTION
Because it's not possible to set up them properly in these shader types.
