### PR TITLE
[3.x] Improve responsiveness on underpowered Android devices

### DIFF
--- a/core/os/input.h
+++ b/core/os/input.h
@@ -136,7 +136,9 @@ public:
 	virtual int get_joy_axis_index_from_string(String p_axis) = 0;
 
 	virtual void parse_input_event(const Ref<InputEvent> &p_event) = 0;
-	virtual void flush_accumulated_events() = 0;
+	virtual void flush_buffered_events() = 0;
+	virtual bool is_using_input_buffering() = 0;
+	virtual void set_use_input_buffering(bool p_enable) = 0;
 	virtual void set_use_accumulated_input(bool p_enable) = 0;
 
 	Input();

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -136,7 +136,6 @@ public:
 	virtual int get_joy_axis_index_from_string(String p_axis) = 0;
 
 	virtual void parse_input_event(const Ref<InputEvent> &p_event) = 0;
-	virtual void accumulate_input_event(const Ref<InputEvent> &p_event) = 0;
 	virtual void flush_accumulated_events() = 0;
 	virtual void set_use_accumulated_input(bool p_enable) = 0;
 

--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -966,6 +966,22 @@ String InputEventScreenDrag::as_text() const {
 	return "InputEventScreenDrag : index=" + itos(index) + ", position=(" + String(get_position()) + "), relative=(" + String(get_relative()) + "), speed=(" + String(get_speed()) + ")";
 }
 
+bool InputEventScreenDrag::accumulate(const Ref<InputEvent> &p_event) {
+	Ref<InputEventScreenDrag> drag = p_event;
+	if (drag.is_null())
+		return false;
+
+	if (get_index() != drag->get_index()) {
+		return false;
+	}
+
+	set_position(drag->get_position());
+	set_speed(drag->get_speed());
+	relative += drag->get_relative();
+
+	return true;
+}
+
 void InputEventScreenDrag::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_index", "index"), &InputEventScreenDrag::set_index);
 	ClassDB::bind_method(D_METHOD("get_index"), &InputEventScreenDrag::get_index);

--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -502,6 +502,8 @@ public:
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const;
 	virtual String as_text() const;
 
+	virtual bool accumulate(const Ref<InputEvent> &p_event);
+
 	InputEventScreenDrag();
 };
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -583,6 +583,12 @@
 			Default [InputEventAction] to move up in the UI.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
+		<member name="input_devices/buffering/agile_event_flushing" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], key/touch/joystick events will be flushed just before every idle and physics frame.
+			If [code]false[/code], such events will be flushed only once per idle frame, between iterations of the engine.
+			Enabling this can greatly improve the responsiveness to input, specially in devices that need to run multiple physics frames per visible (idle) frame, because they can't run at the target frame rate.
+			[b]Note:[/b] Currently implemented only in Android.
+		</member>
 		<member name="input_devices/pointing/emulate_mouse_from_touch" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], sends mouse input events when tapping or swiping on the touchscreen.
 		</member>

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -205,7 +205,8 @@ private:
 
 	void _parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_emulated);
 
-	List<Ref<InputEvent>> accumulated_events;
+	List<Ref<InputEvent>> buffered_events;
+	bool use_input_buffering;
 	bool use_accumulated_input;
 
 protected:
@@ -302,7 +303,9 @@ public:
 	String get_joy_guid_remapped(int p_device) const;
 	void set_fallback_mapping(String p_guid);
 
-	virtual void flush_accumulated_events();
+	virtual void flush_buffered_events();
+	virtual bool is_using_input_buffering();
+	virtual void set_use_input_buffering(bool p_enable);
 	virtual void set_use_accumulated_input(bool p_enable);
 
 	virtual void release_pressed_events();

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -302,7 +302,6 @@ public:
 	String get_joy_guid_remapped(int p_device) const;
 	void set_fallback_mapping(String p_guid);
 
-	virtual void accumulate_input_event(const Ref<InputEvent> &p_event);
 	virtual void flush_accumulated_events();
 	virtual void set_use_accumulated_input(bool p_enable);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1413,6 +1413,8 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	InputDefault *id = Object::cast_to<InputDefault>(Input::get_singleton());
 	if (id) {
+		agile_input_event_flushing = GLOBAL_DEF("input_devices/buffering/agile_event_flushing", false);
+
 		if (bool(GLOBAL_DEF("input_devices/pointing/emulate_touch_from_mouse", false)) && !(editor || project_manager)) {
 			if (!OS::get_singleton()->has_touchscreen_ui_hint()) {
 				//only if no touchscreen ui hint, set emulation
@@ -2045,6 +2047,8 @@ uint32_t Main::frames = 0;
 uint32_t Main::frame = 0;
 bool Main::force_redraw_requested = false;
 int Main::iterating = 0;
+bool Main::agile_input_event_flushing = false;
+
 bool Main::is_iterating() {
 	return iterating > 0;
 }
@@ -2114,9 +2118,13 @@ bool Main::iteration() {
 
 	bool exit = false;
 
-	Engine::get_singleton()->_in_physics = true;
-
 	for (int iters = 0; iters < advance.physics_steps; ++iters) {
+		if (InputDefault::get_singleton()->is_using_input_buffering() && agile_input_event_flushing) {
+			InputDefault::get_singleton()->flush_buffered_events();
+		}
+
+		Engine::get_singleton()->_in_physics = true;
+
 		uint64_t physics_begin = OS::get_singleton()->get_ticks_usec();
 
 		PhysicsServer::get_singleton()->flush_queries();
@@ -2141,9 +2149,13 @@ bool Main::iteration() {
 		physics_process_ticks = MAX(physics_process_ticks, OS::get_singleton()->get_ticks_usec() - physics_begin); // keep the largest one for reference
 		physics_process_max = MAX(OS::get_singleton()->get_ticks_usec() - physics_begin, physics_process_max);
 		Engine::get_singleton()->_physics_frames++;
+
+		Engine::get_singleton()->_in_physics = false;
 	}
 
-	Engine::get_singleton()->_in_physics = false;
+	if (InputDefault::get_singleton()->is_using_input_buffering() && agile_input_event_flushing) {
+		InputDefault::get_singleton()->flush_buffered_events();
+	}
 
 	uint64_t idle_begin = OS::get_singleton()->get_ticks_usec();
 
@@ -2218,7 +2230,7 @@ bool Main::iteration() {
 	iterating--;
 
 	// Needed for OSs using input buffering regardless accumulation (like Android)
-	if (InputDefault::get_singleton()->is_using_input_buffering()) {
+	if (InputDefault::get_singleton()->is_using_input_buffering() && !agile_input_event_flushing) {
 		InputDefault::get_singleton()->flush_buffered_events();
 	}
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2217,6 +2217,11 @@ bool Main::iteration() {
 
 	iterating--;
 
+	// Needed for OSs using input buffering regardless accumulation (like Android)
+	if (InputDefault::get_singleton()->is_using_input_buffering()) {
+		InputDefault::get_singleton()->flush_buffered_events();
+	}
+
 	if (fixed_fps != -1) {
 		return exit;
 	}

--- a/main/main.h
+++ b/main/main.h
@@ -42,6 +42,7 @@ class Main {
 	static uint32_t frame;
 	static bool force_redraw_requested;
 	static int iterating;
+	static bool agile_input_event_flushing;
 
 public:
 	static bool is_project_manager();

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -4,6 +4,7 @@ Import("env")
 
 android_files = [
     "os_android.cpp",
+    "android_input_handler.cpp",
     "file_access_android.cpp",
     "audio_driver_opensl.cpp",
     "dir_access_jandroid.cpp",

--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -1,0 +1,372 @@
+/*************************************************************************/
+/*  android_input_handler.cpp                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "android_input_handler.h"
+
+#include "android_keys_utils.h"
+
+#include "core/os/os.h"
+
+void AndroidInputHandler::process_joy_event(const JoypadEvent &p_event) {
+	switch (p_event.type) {
+		case JOY_EVENT_BUTTON:
+			input->joy_button(p_event.device, p_event.index, p_event.pressed);
+			break;
+		case JOY_EVENT_AXIS:
+			InputDefault::JoyAxis value;
+			value.min = -1;
+			value.value = p_event.value;
+			input->joy_axis(p_event.device, p_event.index, value);
+			break;
+		case JOY_EVENT_HAT:
+			input->joy_hat(p_event.device, p_event.hat);
+			break;
+		default:
+			return;
+	}
+}
+
+void AndroidInputHandler::_set_key_modifier_state(Ref<InputEventWithModifiers> ev) const {
+	ev->set_shift(shift_mem);
+	ev->set_alt(alt_mem);
+	ev->set_metakey(meta_mem);
+	ev->set_control(control_mem);
+}
+
+void AndroidInputHandler::process_event(Ref<InputEvent> &p_event) {
+	input->parse_input_event(p_event);
+}
+
+void AndroidInputHandler::process_key_event(int p_keycode, int p_scancode, int p_unicode_char, bool p_pressed) {
+	Ref<InputEventKey> ev;
+	ev.instance();
+	int val = p_unicode_char;
+	unsigned int scancode = android_get_keysym(p_keycode);
+	unsigned int phy_scancode = android_get_keysym(p_scancode);
+
+	switch (scancode) {
+		case KEY_SHIFT: {
+			shift_mem = p_pressed;
+		} break;
+		case KEY_ALT: {
+			alt_mem = p_pressed;
+		} break;
+		case KEY_CONTROL: {
+			control_mem = p_pressed;
+		} break;
+		case KEY_META: {
+			meta_mem = p_pressed;
+		} break;
+	}
+
+	ev->set_scancode(scancode);
+	ev->set_physical_scancode(phy_scancode);
+
+	ev->set_unicode(val);
+	ev->set_pressed(p_pressed);
+
+	_set_key_modifier_state(ev);
+
+	if (val == '\n') {
+		ev->set_scancode(KEY_ENTER);
+	} else if (val == 61448) {
+		ev->set_scancode(KEY_BACKSPACE);
+		ev->set_unicode(KEY_BACKSPACE);
+	} else if (val == 61453) {
+		ev->set_scancode(KEY_ENTER);
+		ev->set_unicode(KEY_ENTER);
+	} else if (p_scancode == 4) {
+		if (MainLoop *main_loop = OS::get_singleton()->get_main_loop()) {
+			main_loop->call_deferred("notification", MainLoop::NOTIFICATION_WM_GO_BACK_REQUEST);
+		}
+	}
+
+	input->parse_input_event(ev);
+}
+
+void AndroidInputHandler::process_touch(int p_event, int p_pointer, const Vector<TouchPos> &p_points) {
+	switch (p_event) {
+		case AMOTION_EVENT_ACTION_DOWN: { //gesture begin
+			if (touch.size()) {
+				//end all if exist
+				for (int i = 0; i < touch.size(); i++) {
+					Ref<InputEventScreenTouch> ev;
+					ev.instance();
+					ev->set_index(touch[i].id);
+					ev->set_pressed(false);
+					ev->set_position(touch[i].pos);
+					input->parse_input_event(ev);
+				}
+			}
+
+			touch.resize(p_points.size());
+			for (int i = 0; i < p_points.size(); i++) {
+				touch.write[i].id = p_points[i].id;
+				touch.write[i].pos = p_points[i].pos;
+			}
+
+			//send touch
+			for (int i = 0; i < touch.size(); i++) {
+				Ref<InputEventScreenTouch> ev;
+				ev.instance();
+				ev->set_index(touch[i].id);
+				ev->set_pressed(true);
+				ev->set_position(touch[i].pos);
+				input->parse_input_event(ev);
+			}
+
+		} break;
+		case AMOTION_EVENT_ACTION_MOVE: { //motion
+			ERR_FAIL_COND(touch.size() != p_points.size());
+
+			for (int i = 0; i < touch.size(); i++) {
+				int idx = -1;
+				for (int j = 0; j < p_points.size(); j++) {
+					if (touch[i].id == p_points[j].id) {
+						idx = j;
+						break;
+					}
+				}
+
+				ERR_CONTINUE(idx == -1);
+
+				if (touch[i].pos == p_points[idx].pos)
+					continue; //no move unncesearily
+
+				Ref<InputEventScreenDrag> ev;
+				ev.instance();
+				ev->set_index(touch[i].id);
+				ev->set_position(p_points[idx].pos);
+				ev->set_relative(p_points[idx].pos - touch[i].pos);
+				input->parse_input_event(ev);
+				touch.write[i].pos = p_points[idx].pos;
+			}
+
+		} break;
+		case AMOTION_EVENT_ACTION_CANCEL:
+		case AMOTION_EVENT_ACTION_UP: { //release
+			if (touch.size()) {
+				//end all if exist
+				for (int i = 0; i < touch.size(); i++) {
+					Ref<InputEventScreenTouch> ev;
+					ev.instance();
+					ev->set_index(touch[i].id);
+					ev->set_pressed(false);
+					ev->set_position(touch[i].pos);
+					input->parse_input_event(ev);
+				}
+				touch.clear();
+			}
+		} break;
+		case AMOTION_EVENT_ACTION_POINTER_DOWN: { // add touch
+			for (int i = 0; i < p_points.size(); i++) {
+				if (p_points[i].id == p_pointer) {
+					TouchPos tp = p_points[i];
+					touch.push_back(tp);
+
+					Ref<InputEventScreenTouch> ev;
+					ev.instance();
+
+					ev->set_index(tp.id);
+					ev->set_pressed(true);
+					ev->set_position(tp.pos);
+					input->parse_input_event(ev);
+
+					break;
+				}
+			}
+		} break;
+		case AMOTION_EVENT_ACTION_POINTER_UP: { // remove touch
+			for (int i = 0; i < touch.size(); i++) {
+				if (touch[i].id == p_pointer) {
+					Ref<InputEventScreenTouch> ev;
+					ev.instance();
+					ev->set_index(touch[i].id);
+					ev->set_pressed(false);
+					ev->set_position(touch[i].pos);
+					input->parse_input_event(ev);
+					touch.remove(i);
+
+					break;
+				}
+			}
+		} break;
+	}
+}
+
+void AndroidInputHandler::process_hover(int p_type, Point2 p_pos) {
+	// https://developer.android.com/reference/android/view/MotionEvent.html#ACTION_HOVER_ENTER
+	switch (p_type) {
+		case AMOTION_EVENT_ACTION_HOVER_MOVE: // hover move
+		case AMOTION_EVENT_ACTION_HOVER_ENTER: // hover enter
+		case AMOTION_EVENT_ACTION_HOVER_EXIT: { // hover exit
+			Ref<InputEventMouseMotion> ev;
+			ev.instance();
+			_set_key_modifier_state(ev);
+			ev->set_position(p_pos);
+			ev->set_global_position(p_pos);
+			ev->set_relative(p_pos - hover_prev_pos);
+			input->parse_input_event(ev);
+			hover_prev_pos = p_pos;
+		} break;
+	}
+}
+
+void AndroidInputHandler::process_mouse_event(int event_action, int event_android_buttons_mask, Point2 event_pos, float event_vertical_factor, float event_horizontal_factor) {
+	int event_buttons_mask = _android_button_mask_to_godot_button_mask(event_android_buttons_mask);
+	switch (event_action) {
+		case AMOTION_EVENT_ACTION_BUTTON_PRESS:
+		case AMOTION_EVENT_ACTION_BUTTON_RELEASE: {
+			Ref<InputEventMouseButton> ev;
+			ev.instance();
+			_set_key_modifier_state(ev);
+			ev->set_position(event_pos);
+			ev->set_global_position(event_pos);
+			ev->set_pressed(event_action == AMOTION_EVENT_ACTION_BUTTON_PRESS);
+			int changed_button_mask = buttons_state ^ event_buttons_mask;
+
+			buttons_state = event_buttons_mask;
+
+			ev->set_button_index(_button_index_from_mask(changed_button_mask));
+			ev->set_button_mask(event_buttons_mask);
+			input->parse_input_event(ev);
+		} break;
+
+		case AMOTION_EVENT_ACTION_MOVE: {
+			Ref<InputEventMouseMotion> ev;
+			ev.instance();
+			_set_key_modifier_state(ev);
+			ev->set_position(event_pos);
+			ev->set_global_position(event_pos);
+			ev->set_relative(event_pos - hover_prev_pos);
+			ev->set_button_mask(event_buttons_mask);
+			input->parse_input_event(ev);
+			hover_prev_pos = event_pos;
+		} break;
+		case AMOTION_EVENT_ACTION_SCROLL: {
+			Ref<InputEventMouseButton> ev;
+			ev.instance();
+			_set_key_modifier_state(ev);
+			ev->set_position(event_pos);
+			ev->set_global_position(event_pos);
+			ev->set_pressed(true);
+			buttons_state = event_buttons_mask;
+			if (event_vertical_factor > 0) {
+				_wheel_button_click(event_buttons_mask, ev, BUTTON_WHEEL_UP, event_vertical_factor);
+			} else if (event_vertical_factor < 0) {
+				_wheel_button_click(event_buttons_mask, ev, BUTTON_WHEEL_DOWN, -event_vertical_factor);
+			}
+
+			if (event_horizontal_factor > 0) {
+				_wheel_button_click(event_buttons_mask, ev, BUTTON_WHEEL_RIGHT, event_horizontal_factor);
+			} else if (event_horizontal_factor < 0) {
+				_wheel_button_click(event_buttons_mask, ev, BUTTON_WHEEL_LEFT, -event_horizontal_factor);
+			}
+		} break;
+	}
+}
+
+void AndroidInputHandler::_wheel_button_click(int event_buttons_mask, const Ref<InputEventMouseButton> &ev, int wheel_button, float factor) {
+	Ref<InputEventMouseButton> evd = ev->duplicate();
+	evd->set_button_index(wheel_button);
+	evd->set_button_mask(event_buttons_mask ^ (1 << (wheel_button - 1)));
+	evd->set_factor(factor);
+	input->parse_input_event(evd);
+	Ref<InputEventMouseButton> evdd = evd->duplicate();
+	evdd->set_pressed(false);
+	evdd->set_button_mask(event_buttons_mask);
+	input->parse_input_event(evdd);
+}
+
+void AndroidInputHandler::process_double_tap(int event_android_button_mask, Point2 p_pos) {
+	int event_button_mask = _android_button_mask_to_godot_button_mask(event_android_button_mask);
+	Ref<InputEventMouseButton> ev;
+	ev.instance();
+	_set_key_modifier_state(ev);
+	ev->set_position(p_pos);
+	ev->set_global_position(p_pos);
+	ev->set_pressed(event_button_mask != 0);
+	ev->set_button_index(_button_index_from_mask(event_button_mask));
+	ev->set_button_mask(event_button_mask);
+	ev->set_doubleclick(true);
+	input->parse_input_event(ev);
+}
+
+void AndroidInputHandler::process_scroll(Point2 p_pos) {
+	Ref<InputEventPanGesture> ev;
+	ev.instance();
+	_set_key_modifier_state(ev);
+	ev->set_position(p_pos);
+	ev->set_delta(p_pos - scroll_prev_pos);
+	input->parse_input_event(ev);
+	scroll_prev_pos = p_pos;
+}
+
+int AndroidInputHandler::_button_index_from_mask(int button_mask) {
+	switch (button_mask) {
+		case BUTTON_MASK_LEFT:
+			return BUTTON_LEFT;
+		case BUTTON_MASK_RIGHT:
+			return BUTTON_RIGHT;
+		case BUTTON_MASK_MIDDLE:
+			return BUTTON_MIDDLE;
+		case BUTTON_MASK_XBUTTON1:
+			return BUTTON_XBUTTON1;
+		case BUTTON_MASK_XBUTTON2:
+			return BUTTON_XBUTTON2;
+		default:
+			return 0;
+	}
+}
+
+int AndroidInputHandler::_android_button_mask_to_godot_button_mask(int android_button_mask) {
+	int godot_button_mask = 0;
+	if (android_button_mask & AMOTION_EVENT_BUTTON_PRIMARY) {
+		godot_button_mask |= BUTTON_MASK_LEFT;
+	}
+	if (android_button_mask & AMOTION_EVENT_BUTTON_SECONDARY) {
+		godot_button_mask |= BUTTON_MASK_RIGHT;
+	}
+	if (android_button_mask & AMOTION_EVENT_BUTTON_TERTIARY) {
+		godot_button_mask |= BUTTON_MASK_MIDDLE;
+	}
+	if (android_button_mask & AMOTION_EVENT_BUTTON_BACK) {
+		godot_button_mask |= BUTTON_MASK_XBUTTON1;
+	}
+	if (android_button_mask & AMOTION_EVENT_BUTTON_SECONDARY) {
+		godot_button_mask |= BUTTON_MASK_XBUTTON2;
+	}
+
+	return godot_button_mask;
+}
+
+void AndroidInputHandler::joy_connection_changed(int p_device, bool p_connected, String p_name) {
+	input->joy_connection_changed(p_device, p_connected, p_name, "");
+}

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -1,0 +1,96 @@
+/*************************************************************************/
+/*  android_input_handler.h                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef ANDROID_INPUT_HANDLER_H
+#define ANDROID_INPUT_HANDLER_H
+
+#include "main/input_default.h"
+
+// This class encapsulates all the handling of input events that come from the Android UI thread.
+// Remarks:
+// - It's not thread-safe by itself, so its functions must only be called on a single thread, which is the Android UI thread.
+// - Its functions must only call thread-safe methods.
+class AndroidInputHandler {
+public:
+	struct TouchPos {
+		int id;
+		Point2 pos;
+	};
+
+	enum {
+		JOY_EVENT_BUTTON = 0,
+		JOY_EVENT_AXIS = 1,
+		JOY_EVENT_HAT = 2
+	};
+
+	struct JoypadEvent {
+		int device;
+		int type;
+		int index;
+		bool pressed;
+		float value;
+		int hat;
+	};
+
+private:
+	Vector<TouchPos> touch;
+	Point2 hover_prev_pos; // needed to calculate the relative position on hover events
+	Point2 scroll_prev_pos; // needed to calculate the relative position on scroll events
+
+	bool alt_mem = false;
+	bool shift_mem = false;
+	bool control_mem = false;
+	bool meta_mem = false;
+
+	int buttons_state = 0;
+
+	InputDefault *input = static_cast<InputDefault *>(InputDefault::get_singleton());
+
+	void _set_key_modifier_state(Ref<InputEventWithModifiers> ev) const;
+
+	static int _button_index_from_mask(int button_mask);
+
+	static int _android_button_mask_to_godot_button_mask(int android_button_mask);
+
+	void _wheel_button_click(int event_buttons_mask, const Ref<InputEventMouseButton> &ev, int wheel_button, float factor);
+
+public:
+	void process_event(Ref<InputEvent> &p_event);
+	void process_joy_event(const JoypadEvent &p_event);
+	void process_key_event(int p_keycode, int p_scancode, int p_unicode_char, bool p_pressed);
+	void process_touch(int p_event, int p_pointer, const Vector<TouchPos> &p_points);
+	void process_hover(int p_type, Point2 p_pos);
+	void process_mouse_event(int event_action, int event_android_buttons_mask, Point2 event_pos, float event_vertical_factor, float event_horizontal_factor);
+	void process_double_tap(int event_android_button_mask, Point2 p_pos);
+	void process_scroll(Point2 p_pos);
+	void joy_connection_changed(int p_device, bool p_connected, String p_name);
+};
+
+#endif

--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.java
@@ -75,7 +75,7 @@ public class GodotGestureHandler extends GestureDetector.SimpleOnGestureListener
 		final int x = Math.round(event.getX());
 		final int y = Math.round(event.getY());
 		final int buttonMask = event.getButtonState();
-		queueEvent(() -> GodotLib.doubleTap(buttonMask, x, y));
+		GodotLib.doubleTap(buttonMask, x, y);
 		return true;
 	}
 
@@ -84,7 +84,7 @@ public class GodotGestureHandler extends GestureDetector.SimpleOnGestureListener
 		//Log.i("GodotGesture", "onScroll");
 		final int x = Math.round(distanceX);
 		final int y = Math.round(distanceY);
-		queueEvent(() -> GodotLib.scroll(x, y));
+		GodotLib.scroll(x, y);
 		return true;
 	}
 

--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
@@ -68,10 +68,6 @@ public class GodotInputHandler implements InputDeviceListener {
 		this.inputManager.registerInputDeviceListener(this, null);
 	}
 
-	private void queueEvent(Runnable task) {
-		godotView.queueEvent(task);
-	}
-
 	private boolean isKeyEvent_GameDevice(int source) {
 		// Note that keyboards are often (SOURCE_KEYBOARD | SOURCE_DPAD)
 		if (source == (InputDevice.SOURCE_KEYBOARD | InputDevice.SOURCE_DPAD))
@@ -96,13 +92,12 @@ public class GodotInputHandler implements InputDeviceListener {
 			if (mJoystickIds.indexOfKey(deviceId) >= 0) {
 				final int button = getGodotButton(keyCode);
 				final int godotJoyId = mJoystickIds.get(deviceId);
-
-				queueEvent(() -> GodotLib.joybutton(godotJoyId, button, false));
+				GodotLib.joybutton(godotJoyId, button, false);
 			}
 		} else {
 			final int scanCode = event.getScanCode();
 			final int chr = event.getUnicodeChar(0);
-			queueEvent(() -> GodotLib.key(keyCode, scanCode, chr, false));
+			GodotLib.key(keyCode, scanCode, chr, false);
 		};
 
 		return true;
@@ -132,13 +127,12 @@ public class GodotInputHandler implements InputDeviceListener {
 			if (mJoystickIds.indexOfKey(deviceId) >= 0) {
 				final int button = getGodotButton(keyCode);
 				final int godotJoyId = mJoystickIds.get(deviceId);
-
-				queueEvent(() -> GodotLib.joybutton(godotJoyId, button, true));
+				GodotLib.joybutton(godotJoyId, button, true);
 			}
 		} else {
 			final int scanCode = event.getScanCode();
 			final int chr = event.getUnicodeChar(0);
-			queueEvent(() -> GodotLib.key(keyCode, scanCode, chr, true));
+			GodotLib.key(keyCode, scanCode, chr, true);
 		}
 
 		return true;
@@ -170,18 +164,16 @@ public class GodotInputHandler implements InputDeviceListener {
 			final int action = event.getActionMasked();
 			final int pointer_idx = event.getPointerId(event.getActionIndex());
 
-			godotView.queueEvent(() -> {
-				switch (action) {
-					case MotionEvent.ACTION_DOWN:
-					case MotionEvent.ACTION_CANCEL:
-					case MotionEvent.ACTION_UP:
-					case MotionEvent.ACTION_MOVE:
-					case MotionEvent.ACTION_POINTER_UP:
-					case MotionEvent.ACTION_POINTER_DOWN: {
-						GodotLib.touch(event.getSource(), action, pointer_idx, evcount, arr);
-					} break;
-				}
-			});
+			switch (action) {
+				case MotionEvent.ACTION_DOWN:
+				case MotionEvent.ACTION_CANCEL:
+				case MotionEvent.ACTION_UP:
+				case MotionEvent.ACTION_MOVE:
+				case MotionEvent.ACTION_POINTER_UP:
+				case MotionEvent.ACTION_POINTER_DOWN: {
+					GodotLib.touch(event.getSource(), action, pointer_idx, evcount, arr);
+				} break;
+			}
 		}
 		return true;
 	}
@@ -205,7 +197,7 @@ public class GodotInputHandler implements InputDeviceListener {
 						// save value to prevent repeats
 						joystick.axesValues.put(axis, value);
 						final int godotAxisIdx = i;
-						queueEvent(() -> GodotLib.joyaxis(godotJoyId, godotAxisIdx, value));
+						GodotLib.joyaxis(godotJoyId, godotAxisIdx, value);
 					}
 				}
 
@@ -215,7 +207,7 @@ public class GodotInputHandler implements InputDeviceListener {
 					if (joystick.hatX != hatX || joystick.hatY != hatY) {
 						joystick.hatX = hatX;
 						joystick.hatY = hatY;
-						queueEvent(() -> GodotLib.joyhat(godotJoyId, hatX, hatY));
+						GodotLib.joyhat(godotJoyId, hatX, hatY);
 					}
 				}
 				return true;
@@ -224,7 +216,7 @@ public class GodotInputHandler implements InputDeviceListener {
 			final float x = event.getX();
 			final float y = event.getY();
 			final int type = event.getAction();
-			queueEvent(() -> GodotLib.hover(type, x, y));
+			GodotLib.hover(type, x, y);
 			return true;
 		} else if ((event.isFromSource(InputDevice.SOURCE_MOUSE))) {
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -315,7 +307,7 @@ public class GodotInputHandler implements InputDeviceListener {
 		}
 		mJoysticksDevices.put(deviceId, joystick);
 
-		queueEvent(() -> GodotLib.joyconnectionchanged(id, true, joystick.name));
+		GodotLib.joyconnectionchanged(id, true, joystick.name);
 	}
 
 	@Override
@@ -327,8 +319,7 @@ public class GodotInputHandler implements InputDeviceListener {
 		final int godotJoyId = mJoystickIds.get(deviceId);
 		mJoystickIds.delete(deviceId);
 		mJoysticksDevices.delete(deviceId);
-
-		queueEvent(() -> GodotLib.joyconnectionchanged(godotJoyId, false, ""));
+		GodotLib.joyconnectionchanged(godotJoyId, false, "");
 	}
 
 	@Override
@@ -417,7 +408,7 @@ public class GodotInputHandler implements InputDeviceListener {
 				final float x = event.getX();
 				final float y = event.getY();
 				final int type = event.getAction();
-				queueEvent(() -> GodotLib.hover(type, x, y));
+				GodotLib.hover(type, x, y);
 				return true;
 			}
 			case MotionEvent.ACTION_BUTTON_PRESS:
@@ -427,7 +418,7 @@ public class GodotInputHandler implements InputDeviceListener {
 				final float y = event.getY();
 				final int buttonsMask = event.getButtonState();
 				final int action = event.getAction();
-				queueEvent(() -> GodotLib.touch(event.getSource(), action, 0, 1, new float[] { 0, x, y }, buttonsMask));
+				GodotLib.touch(event.getSource(), action, 0, 1, new float[] { 0, x, y }, buttonsMask);
 				return true;
 			}
 			case MotionEvent.ACTION_SCROLL: {
@@ -437,7 +428,7 @@ public class GodotInputHandler implements InputDeviceListener {
 				final int action = event.getAction();
 				final float verticalFactor = event.getAxisValue(MotionEvent.AXIS_VSCROLL);
 				final float horizontalFactor = event.getAxisValue(MotionEvent.AXIS_HSCROLL);
-				queueEvent(() -> GodotLib.touch(event.getSource(), action, 0, 1, new float[] { 0, x, y }, buttonsMask, verticalFactor, horizontalFactor));
+				GodotLib.touch(event.getSource(), action, 0, 1, new float[] { 0, x, y }, buttonsMask, verticalFactor, horizontalFactor);
 			}
 		}
 		return false;

--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
@@ -94,17 +94,15 @@ public class GodotTextInputWrapper implements TextWatcher, OnEditorActionListene
 	public void beforeTextChanged(final CharSequence pCharSequence, final int start, final int count, final int after) {
 		//Log.d(TAG, "beforeTextChanged(" + pCharSequence + ")start: " + start + ",count: " + count + ",after: " + after);
 
-		mView.queueEvent(() -> {
-			for (int i = 0; i < count; ++i) {
-				GodotLib.key(KeyEvent.KEYCODE_DEL, KeyEvent.KEYCODE_DEL, 0, true);
-				GodotLib.key(KeyEvent.KEYCODE_DEL, KeyEvent.KEYCODE_DEL, 0, false);
+		for (int i = 0; i < count; ++i) {
+			GodotLib.key(KeyEvent.KEYCODE_DEL, KeyEvent.KEYCODE_DEL, 0, true);
+			GodotLib.key(KeyEvent.KEYCODE_DEL, KeyEvent.KEYCODE_DEL, 0, false);
 
-				if (mHasSelection) {
-					mHasSelection = false;
-					break;
-				}
+			if (mHasSelection) {
+				mHasSelection = false;
+				break;
 			}
-		});
+		}
 	}
 
 	@Override
@@ -115,17 +113,15 @@ public class GodotTextInputWrapper implements TextWatcher, OnEditorActionListene
 		for (int i = start; i < start + count; ++i) {
 			newChars[i - start] = pCharSequence.charAt(i);
 		}
-		mView.queueEvent(() -> {
-			for (int i = 0; i < count; ++i) {
-				int key = newChars[i];
-				if ((key == '\n') && !mEdit.isMultiline()) {
-					// Return keys are handled through action events
-					continue;
-				}
-				GodotLib.key(0, 0, key, true);
-				GodotLib.key(0, 0, key, false);
+		for (int i = 0; i < count; ++i) {
+			int key = newChars[i];
+			if ((key == '\n') && !mEdit.isMultiline()) {
+				// Return keys are handled through action events
+				continue;
 			}
-		});
+			GodotLib.key(0, 0, key, true);
+			GodotLib.key(0, 0, key, false);
+		}
 	}
 
 	@Override
@@ -133,13 +129,11 @@ public class GodotTextInputWrapper implements TextWatcher, OnEditorActionListene
 		if (this.mEdit == pTextView && this.isFullScreenEdit()) {
 			final String characters = pKeyEvent.getCharacters();
 
-			mView.queueEvent(() -> {
-				for (int i = 0; i < characters.length(); i++) {
-					final int ch = characters.codePointAt(i);
-					GodotLib.key(0, 0, ch, true);
-					GodotLib.key(0, 0, ch, false);
-				}
-			});
+			for (int i = 0; i < characters.length(); i++) {
+				final int ch = characters.codePointAt(i);
+				GodotLib.key(0, 0, ch, true);
+				GodotLib.key(0, 0, ch, false);
+			}
 		}
 
 		if (pActionID == EditorInfo.IME_ACTION_DONE) {

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -33,7 +33,7 @@
 #include "java_godot_wrapper.h"
 
 #include "android/asset_manager_jni.h"
-#include "android_keys_utils.h"
+#include "android_input_handler.h"
 #include "api/java_class_wrapper.h"
 #include "api/jni_singleton.h"
 #include "core/engine.h"
@@ -50,14 +50,16 @@
 
 #include <android/input.h>
 #include <unistd.h>
+#include <atomic>
 
 static JavaClassWrapper *java_class_wrapper = NULL;
 static OS_Android *os_android = NULL;
+static AndroidInputHandler *input_handler = NULL;
 static GodotJavaWrapper *godot_java = NULL;
 static GodotIOJavaWrapper *godot_io_java = NULL;
 
 static bool initialized = false;
-static int step = 0;
+static std::atomic<int> step; // Shared between UI and render threads
 
 static Size2 new_size;
 static Vector3 accelerometer;
@@ -153,6 +155,9 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ondestroy(JNIEnv *env
 	if (godot_java) {
 		delete godot_java;
 	}
+	if (input_handler) {
+		delete input_handler;
+	}
 	if (os_android) {
 		delete os_android;
 	}
@@ -215,9 +220,9 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_newcontext(JNIEnv *en
 			os_android->set_context_is_16_bits(!p_32_bits);
 		} else {
 			// GL context recreated because it was lost; restart app to let it reload everything
+			step = -1; // Ensure no further steps are attempted and no further events are sent
 			os_android->main_loop_end();
 			godot_java->restart(env);
-			step = -1; // Ensure no further steps are attempted
 		}
 	}
 }
@@ -226,7 +231,9 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_back(JNIEnv *env, jcl
 	if (step == 0)
 		return;
 
-	os_android->main_loop_request_go_back();
+	if (os_android->get_main_loop()) {
+		os_android->get_main_loop()->notification(MainLoop::NOTIFICATION_WM_GO_BACK_REQUEST);
+	}
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jclass clazz) {
@@ -237,6 +244,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jcl
 		// Since Godot is initialized on the UI thread, _main_thread_id was set to that thread's id,
 		// but for Godot purposes, the main thread is the one running the game loop
 		Main::setup2(Thread::get_caller_id());
+		input_handler = new AndroidInputHandler();
 		++step;
 		return;
 	}
@@ -263,92 +271,101 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jcl
 }
 
 void touch_preprocessing(JNIEnv *env, jclass clazz, jint input_device, jint ev, jint pointer, jint pointer_count, jfloatArray positions, jint buttons_mask, jfloat vertical_factor, jfloat horizontal_factor) {
-	if (step == 0)
+	if (step <= 0)
 		return;
 
-	Vector<OS_Android::TouchPos> points;
+	Vector<AndroidInputHandler::TouchPos> points;
 	for (int i = 0; i < pointer_count; i++) {
 		jfloat p[3];
 		env->GetFloatArrayRegion(positions, i * 3, 3, p);
-		OS_Android::TouchPos tp;
+		AndroidInputHandler::TouchPos tp;
 		tp.pos = Point2(p[1], p[2]);
 		tp.id = (int)p[0];
 		points.push_back(tp);
 	}
 
 	if ((input_device & AINPUT_SOURCE_MOUSE) == AINPUT_SOURCE_MOUSE) {
-		os_android->process_mouse_event(ev, buttons_mask, points[0].pos, vertical_factor, horizontal_factor);
+		input_handler->process_mouse_event(ev, buttons_mask, points[0].pos, vertical_factor, horizontal_factor);
 	} else {
-		os_android->process_touch(ev, pointer, points);
+		input_handler->process_touch(ev, pointer, points);
 	}
 }
 
+// Called on the UI thread
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_touch__IIII_3F(JNIEnv *env, jclass clazz, jint input_device, jint ev, jint pointer, jint pointer_count, jfloatArray position) {
 	touch_preprocessing(env, clazz, input_device, ev, pointer, pointer_count, position);
 }
 
+// Called on the UI thread
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_touch__IIII_3FI(JNIEnv *env, jclass clazz, jint input_device, jint ev, jint pointer, jint pointer_count, jfloatArray position, jint buttons_mask) {
 	touch_preprocessing(env, clazz, input_device, ev, pointer, pointer_count, position, buttons_mask);
 }
 
+// Called on the UI thread
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_touch__IIII_3FIFF(JNIEnv *env, jclass clazz, jint input_device, jint ev, jint pointer, jint pointer_count, jfloatArray position, jint buttons_mask, jfloat vertical_factor, jfloat horizontal_factor) {
 	touch_preprocessing(env, clazz, input_device, ev, pointer, pointer_count, position, buttons_mask, vertical_factor, horizontal_factor);
 }
 
+// Called on the UI thread
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_hover(JNIEnv *env, jclass clazz, jint p_type, jfloat p_x, jfloat p_y) {
-	if (step == 0)
+	if (step <= 0)
 		return;
 
-	os_android->process_hover(p_type, Point2(p_x, p_y));
+	input_handler->process_hover(p_type, Point2(p_x, p_y));
 }
 
+// Called on the UI thread
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_doubleTap(JNIEnv *env, jclass clazz, jint p_button_mask, jint p_x, jint p_y) {
-	if (step == 0)
+	if (step <= 0)
 		return;
 
-	os_android->process_double_tap(p_button_mask, Point2(p_x, p_y));
+	input_handler->process_double_tap(p_button_mask, Point2(p_x, p_y));
 }
 
+// Called on the UI thread
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_scroll(JNIEnv *env, jclass clazz, jint p_x, jint p_y) {
-	if (step == 0)
+	if (step <= 0)
 		return;
 
-	os_android->process_scroll(Point2(p_x, p_y));
+	input_handler->process_scroll(Point2(p_x, p_y));
 }
 
+// Called on the UI thread
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joybutton(JNIEnv *env, jclass clazz, jint p_device, jint p_button, jboolean p_pressed) {
-	if (step == 0)
+	if (step <= 0)
 		return;
 
-	OS_Android::JoypadEvent jevent;
+	AndroidInputHandler::JoypadEvent jevent;
 	jevent.device = p_device;
-	jevent.type = OS_Android::JOY_EVENT_BUTTON;
+	jevent.type = AndroidInputHandler::JOY_EVENT_BUTTON;
 	jevent.index = p_button;
 	jevent.pressed = p_pressed;
 
-	os_android->process_joy_event(jevent);
+	input_handler->process_joy_event(jevent);
 }
 
+// Called on the UI thread
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyaxis(JNIEnv *env, jclass clazz, jint p_device, jint p_axis, jfloat p_value) {
-	if (step == 0)
+	if (step <= 0)
 		return;
 
-	OS_Android::JoypadEvent jevent;
+	AndroidInputHandler::JoypadEvent jevent;
 	jevent.device = p_device;
-	jevent.type = OS_Android::JOY_EVENT_AXIS;
+	jevent.type = AndroidInputHandler::JOY_EVENT_AXIS;
 	jevent.index = p_axis;
 	jevent.value = p_value;
 
-	os_android->process_joy_event(jevent);
+	input_handler->process_joy_event(jevent);
 }
 
+// Called on the UI thread
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyhat(JNIEnv *env, jclass clazz, jint p_device, jint p_hat_x, jint p_hat_y) {
-	if (step == 0)
+	if (step <= 0)
 		return;
 
-	OS_Android::JoypadEvent jevent;
+	AndroidInputHandler::JoypadEvent jevent;
 	jevent.device = p_device;
-	jevent.type = OS_Android::JOY_EVENT_HAT;
+	jevent.type = AndroidInputHandler::JOY_EVENT_HAT;
 	int hat = 0;
 	if (p_hat_x != 0) {
 		if (p_hat_x < 0)
@@ -364,21 +381,24 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyhat(JNIEnv *env, j
 	}
 	jevent.hat = hat;
 
-	os_android->process_joy_event(jevent);
+	input_handler->process_joy_event(jevent);
 }
 
+// Called on the UI thread
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyconnectionchanged(JNIEnv *env, jclass clazz, jint p_device, jboolean p_connected, jstring p_name) {
-	if (os_android) {
-		String name = jstring_to_string(p_name, env);
-		os_android->joy_connection_changed(p_device, p_connected, name);
-	}
-}
-
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_key(JNIEnv *env, jclass clazz, jint p_keycode, jint p_scancode, jint p_unicode_char, jboolean p_pressed) {
-	if (step == 0)
+	if (step <= 0)
 		return;
 
-	os_android->process_key_event(p_keycode, p_scancode, p_unicode_char, p_pressed);
+	String name = jstring_to_string(p_name, env);
+	input_handler->joy_connection_changed(p_device, p_connected, name);
+}
+
+// Called on the UI thread
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_key(JNIEnv *env, jclass clazz, jint p_keycode, jint p_scancode, jint p_unicode_char, jboolean p_pressed) {
+	if (step <= 0)
+		return;
+
+	input_handler->process_key_event(p_keycode, p_scancode, p_unicode_char, p_pressed);
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_accelerometer(JNIEnv *env, jclass clazz, jfloat x, jfloat y, jfloat z) {
@@ -398,14 +418,14 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_gyroscope(JNIEnv *env
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_focusin(JNIEnv *env, jclass clazz) {
-	if (step == 0)
+	if (step <= 0)
 		return;
 
 	os_android->main_loop_focusin();
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_focusout(JNIEnv *env, jclass clazz) {
-	if (step == 0)
+	if (step <= 0)
 		return;
 
 	os_android->main_loop_focusout();
@@ -483,7 +503,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResu
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererResumed(JNIEnv *env, jclass clazz) {
-	if (step == 0)
+	if (step <= 0)
 		return;
 
 	if (os_android->get_main_loop()) {
@@ -492,7 +512,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererResumed(JNI
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererPaused(JNIEnv *env, jclass clazz) {
-	if (step == 0)
+	if (step <= 0)
 		return;
 
 	if (os_android->get_main_loop()) {

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -47,7 +47,6 @@
 #include <core/os/keyboard.h>
 #include <dlfcn.h>
 
-#include "android_keys_utils.h"
 #include "java_godot_io_wrapper.h"
 #include "java_godot_wrapper.h"
 
@@ -181,6 +180,7 @@ Error OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int
 	AudioDriverManager::initialize(p_audio_driver);
 
 	input = memnew(InputDefault);
+	input->set_use_input_buffering(true); // Needed because events will come directly from the UI thread
 	input->set_fallback_mapping(godot_java->get_input_fallback_mapping());
 
 	//power_manager = memnew(PowerAndroid);
@@ -246,11 +246,11 @@ bool OS_Android::is_mouse_grab_enabled() const {
 }
 
 Point2 OS_Android::get_mouse_position() const {
-	return hover_prev_pos;
+	return input->get_mouse_position();
 }
 
 int OS_Android::get_mouse_button_state() const {
-	return buttons_state;
+	return input->get_mouse_button_mask();
 }
 
 void OS_Android::set_window_title(const String &p_title) {
@@ -327,337 +327,6 @@ void OS_Android::main_loop_focusin() {
 	audio_driver_android.set_pause(false);
 }
 
-void OS_Android::process_joy_event(OS_Android::JoypadEvent p_event) {
-	switch (p_event.type) {
-		case JOY_EVENT_BUTTON:
-			input->joy_button(p_event.device, p_event.index, p_event.pressed);
-			break;
-		case JOY_EVENT_AXIS:
-			InputDefault::JoyAxis value;
-			value.min = -1;
-			value.value = p_event.value;
-			input->joy_axis(p_event.device, p_event.index, value);
-			break;
-		case JOY_EVENT_HAT:
-			input->joy_hat(p_event.device, p_event.hat);
-			break;
-		default:
-			return;
-	}
-}
-
-void OS_Android::_set_key_modifier_state(Ref<InputEventWithModifiers> ev) const {
-	ev->set_shift(shift_mem);
-	ev->set_alt(alt_mem);
-	ev->set_metakey(meta_mem);
-	ev->set_control(control_mem);
-}
-
-void OS_Android::process_event(Ref<InputEvent> p_event) {
-	input->parse_input_event(p_event);
-}
-
-void OS_Android::process_key_event(int p_keycode, int p_scancode, int p_unicode_char, bool p_pressed) {
-	Ref<InputEventKey> ev;
-	ev.instance();
-	int val = p_unicode_char;
-	unsigned int scancode = android_get_keysym(p_keycode);
-	unsigned int phy_scancode = android_get_keysym(p_scancode);
-
-	switch (scancode) {
-		case KEY_SHIFT: {
-			shift_mem = p_pressed;
-		} break;
-		case KEY_ALT: {
-			alt_mem = p_pressed;
-		} break;
-		case KEY_CONTROL: {
-			control_mem = p_pressed;
-		} break;
-		case KEY_META: {
-			meta_mem = p_pressed;
-		} break;
-	}
-
-	ev->set_scancode(scancode);
-	ev->set_physical_scancode(phy_scancode);
-
-	ev->set_unicode(val);
-	ev->set_pressed(p_pressed);
-
-	_set_key_modifier_state(ev);
-
-	if (val == '\n') {
-		ev->set_scancode(KEY_ENTER);
-	} else if (val == 61448) {
-		ev->set_scancode(KEY_BACKSPACE);
-		ev->set_unicode(KEY_BACKSPACE);
-	} else if (val == 61453) {
-		ev->set_scancode(KEY_ENTER);
-		ev->set_unicode(KEY_ENTER);
-	} else if (p_scancode == 4) {
-		main_loop_request_go_back();
-	}
-
-	input->parse_input_event(ev);
-}
-
-void OS_Android::process_touch(int p_event, int p_pointer, const Vector<TouchPos> &p_points) {
-	switch (p_event) {
-		case AMOTION_EVENT_ACTION_DOWN: { //gesture begin
-			if (touch.size()) {
-				//end all if exist
-				for (int i = 0; i < touch.size(); i++) {
-					Ref<InputEventScreenTouch> ev;
-					ev.instance();
-					ev->set_index(touch[i].id);
-					ev->set_pressed(false);
-					ev->set_position(touch[i].pos);
-					input->parse_input_event(ev);
-				}
-			}
-
-			touch.resize(p_points.size());
-			for (int i = 0; i < p_points.size(); i++) {
-				touch.write[i].id = p_points[i].id;
-				touch.write[i].pos = p_points[i].pos;
-			}
-
-			//send touch
-			for (int i = 0; i < touch.size(); i++) {
-				Ref<InputEventScreenTouch> ev;
-				ev.instance();
-				ev->set_index(touch[i].id);
-				ev->set_pressed(true);
-				ev->set_position(touch[i].pos);
-				input->parse_input_event(ev);
-			}
-
-		} break;
-		case AMOTION_EVENT_ACTION_MOVE: { //motion
-			ERR_FAIL_COND(touch.size() != p_points.size());
-
-			for (int i = 0; i < touch.size(); i++) {
-				int idx = -1;
-				for (int j = 0; j < p_points.size(); j++) {
-					if (touch[i].id == p_points[j].id) {
-						idx = j;
-						break;
-					}
-				}
-
-				ERR_CONTINUE(idx == -1);
-
-				if (touch[i].pos == p_points[idx].pos)
-					continue; //no move unncesearily
-
-				Ref<InputEventScreenDrag> ev;
-				ev.instance();
-				ev->set_index(touch[i].id);
-				ev->set_position(p_points[idx].pos);
-				ev->set_relative(p_points[idx].pos - touch[i].pos);
-				input->parse_input_event(ev);
-				touch.write[i].pos = p_points[idx].pos;
-			}
-
-		} break;
-		case AMOTION_EVENT_ACTION_CANCEL:
-		case AMOTION_EVENT_ACTION_UP: { //release
-			if (touch.size()) {
-				//end all if exist
-				for (int i = 0; i < touch.size(); i++) {
-					Ref<InputEventScreenTouch> ev;
-					ev.instance();
-					ev->set_index(touch[i].id);
-					ev->set_pressed(false);
-					ev->set_position(touch[i].pos);
-					input->parse_input_event(ev);
-				}
-				touch.clear();
-			}
-		} break;
-		case AMOTION_EVENT_ACTION_POINTER_DOWN: { // add touch
-			for (int i = 0; i < p_points.size(); i++) {
-				if (p_points[i].id == p_pointer) {
-					TouchPos tp = p_points[i];
-					touch.push_back(tp);
-
-					Ref<InputEventScreenTouch> ev;
-					ev.instance();
-
-					ev->set_index(tp.id);
-					ev->set_pressed(true);
-					ev->set_position(tp.pos);
-					input->parse_input_event(ev);
-
-					break;
-				}
-			}
-		} break;
-		case AMOTION_EVENT_ACTION_POINTER_UP: { // remove touch
-			for (int i = 0; i < touch.size(); i++) {
-				if (touch[i].id == p_pointer) {
-					Ref<InputEventScreenTouch> ev;
-					ev.instance();
-					ev->set_index(touch[i].id);
-					ev->set_pressed(false);
-					ev->set_position(touch[i].pos);
-					input->parse_input_event(ev);
-					touch.remove(i);
-
-					break;
-				}
-			}
-		} break;
-	}
-}
-
-void OS_Android::process_hover(int p_type, Point2 p_pos) {
-	// https://developer.android.com/reference/android/view/MotionEvent.html#ACTION_HOVER_ENTER
-	switch (p_type) {
-		case AMOTION_EVENT_ACTION_HOVER_MOVE: // hover move
-		case AMOTION_EVENT_ACTION_HOVER_ENTER: // hover enter
-		case AMOTION_EVENT_ACTION_HOVER_EXIT: { // hover exit
-			Ref<InputEventMouseMotion> ev;
-			ev.instance();
-			_set_key_modifier_state(ev);
-			ev->set_position(p_pos);
-			ev->set_global_position(p_pos);
-			ev->set_relative(p_pos - hover_prev_pos);
-			input->parse_input_event(ev);
-			hover_prev_pos = p_pos;
-		} break;
-	}
-}
-
-void OS_Android::process_mouse_event(int event_action, int event_android_buttons_mask, Point2 event_pos, float event_vertical_factor, float event_horizontal_factor) {
-	int event_buttons_mask = _android_button_mask_to_godot_button_mask(event_android_buttons_mask);
-	switch (event_action) {
-		case AMOTION_EVENT_ACTION_BUTTON_PRESS:
-		case AMOTION_EVENT_ACTION_BUTTON_RELEASE: {
-			Ref<InputEventMouseButton> ev;
-			ev.instance();
-			_set_key_modifier_state(ev);
-			ev->set_position(event_pos);
-			ev->set_global_position(event_pos);
-			ev->set_pressed(event_action == AMOTION_EVENT_ACTION_BUTTON_PRESS);
-			int changed_button_mask = buttons_state ^ event_buttons_mask;
-
-			buttons_state = event_buttons_mask;
-
-			ev->set_button_index(_button_index_from_mask(changed_button_mask));
-			ev->set_button_mask(event_buttons_mask);
-			input->parse_input_event(ev);
-		} break;
-
-		case AMOTION_EVENT_ACTION_MOVE: {
-			Ref<InputEventMouseMotion> ev;
-			ev.instance();
-			_set_key_modifier_state(ev);
-			ev->set_position(event_pos);
-			ev->set_global_position(event_pos);
-			ev->set_relative(event_pos - hover_prev_pos);
-			ev->set_button_mask(event_buttons_mask);
-			input->parse_input_event(ev);
-			hover_prev_pos = event_pos;
-		} break;
-		case AMOTION_EVENT_ACTION_SCROLL: {
-			Ref<InputEventMouseButton> ev;
-			ev.instance();
-			_set_key_modifier_state(ev);
-			ev->set_position(event_pos);
-			ev->set_global_position(event_pos);
-			ev->set_pressed(true);
-			buttons_state = event_buttons_mask;
-			if (event_vertical_factor > 0) {
-				_wheel_button_click(event_buttons_mask, ev, BUTTON_WHEEL_UP, event_vertical_factor);
-			} else if (event_vertical_factor < 0) {
-				_wheel_button_click(event_buttons_mask, ev, BUTTON_WHEEL_DOWN, -event_vertical_factor);
-			}
-
-			if (event_horizontal_factor > 0) {
-				_wheel_button_click(event_buttons_mask, ev, BUTTON_WHEEL_RIGHT, event_horizontal_factor);
-			} else if (event_horizontal_factor < 0) {
-				_wheel_button_click(event_buttons_mask, ev, BUTTON_WHEEL_LEFT, -event_horizontal_factor);
-			}
-		} break;
-	}
-}
-
-void OS_Android::_wheel_button_click(int event_buttons_mask, const Ref<InputEventMouseButton> &ev, int wheel_button, float factor) {
-	Ref<InputEventMouseButton> evd = ev->duplicate();
-	evd->set_button_index(wheel_button);
-	evd->set_button_mask(event_buttons_mask ^ (1 << (wheel_button - 1)));
-	evd->set_factor(factor);
-	input->parse_input_event(evd);
-	Ref<InputEventMouseButton> evdd = evd->duplicate();
-	evdd->set_pressed(false);
-	evdd->set_button_mask(event_buttons_mask);
-	input->parse_input_event(evdd);
-}
-
-void OS_Android::process_double_tap(int event_android_button_mask, Point2 p_pos) {
-	int event_button_mask = _android_button_mask_to_godot_button_mask(event_android_button_mask);
-	Ref<InputEventMouseButton> ev;
-	ev.instance();
-	_set_key_modifier_state(ev);
-	ev->set_position(p_pos);
-	ev->set_global_position(p_pos);
-	ev->set_pressed(event_button_mask != 0);
-	ev->set_button_index(_button_index_from_mask(event_button_mask));
-	ev->set_button_mask(event_button_mask);
-	ev->set_doubleclick(true);
-	input->parse_input_event(ev);
-}
-
-void OS_Android::process_scroll(Point2 p_pos) {
-	Ref<InputEventPanGesture> ev;
-	ev.instance();
-	_set_key_modifier_state(ev);
-	ev->set_position(p_pos);
-	ev->set_delta(p_pos - scroll_prev_pos);
-	input->parse_input_event(ev);
-	scroll_prev_pos = p_pos;
-}
-
-int OS_Android::_button_index_from_mask(int button_mask) {
-	switch (button_mask) {
-		case BUTTON_MASK_LEFT:
-			return BUTTON_LEFT;
-		case BUTTON_MASK_RIGHT:
-			return BUTTON_RIGHT;
-		case BUTTON_MASK_MIDDLE:
-			return BUTTON_MIDDLE;
-		case BUTTON_MASK_XBUTTON1:
-			return BUTTON_XBUTTON1;
-		case BUTTON_MASK_XBUTTON2:
-			return BUTTON_XBUTTON2;
-		default:
-			return 0;
-	}
-}
-
-int OS_Android::_android_button_mask_to_godot_button_mask(int android_button_mask) {
-	int godot_button_mask = 0;
-	if (android_button_mask & AMOTION_EVENT_BUTTON_PRIMARY) {
-		godot_button_mask |= BUTTON_MASK_LEFT;
-	}
-	if (android_button_mask & AMOTION_EVENT_BUTTON_SECONDARY) {
-		godot_button_mask |= BUTTON_MASK_RIGHT;
-	}
-	if (android_button_mask & AMOTION_EVENT_BUTTON_TERTIARY) {
-		godot_button_mask |= BUTTON_MASK_MIDDLE;
-	}
-	if (android_button_mask & AMOTION_EVENT_BUTTON_BACK) {
-		godot_button_mask |= BUTTON_MASK_XBUTTON1;
-	}
-	if (android_button_mask & AMOTION_EVENT_BUTTON_SECONDARY) {
-		godot_button_mask |= BUTTON_MASK_XBUTTON2;
-	}
-
-	return godot_button_mask;
-}
-
 void OS_Android::process_accelerometer(const Vector3 &p_accelerometer) {
 	input->set_accelerometer(p_accelerometer);
 }
@@ -710,11 +379,6 @@ void OS_Android::init_video_mode(int p_video_width, int p_video_height) {
 	default_videomode.height = p_video_height;
 	default_videomode.fullscreen = true;
 	default_videomode.resizable = false;
-}
-
-void OS_Android::main_loop_request_go_back() {
-	if (main_loop)
-		main_loop->notification(MainLoop::NOTIFICATION_WM_GO_BACK_REQUEST);
 }
 
 void OS_Android::set_display_size(Size2 p_size) {
@@ -817,10 +481,6 @@ void OS_Android::set_context_is_16_bits(bool p_is_16) {
 	//	rasterizer->set_force_16_bits_fbo(p_is_16);
 }
 
-void OS_Android::joy_connection_changed(int p_device, bool p_connected, String p_name) {
-	return input->joy_connection_changed(p_device, p_connected, p_name, "");
-}
-
 bool OS_Android::is_joy_known(int p_device) {
 	return input->is_joy_mapped(p_device);
 }
@@ -860,7 +520,6 @@ OS_Android::OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_god
 	default_videomode.height = 600;
 	default_videomode.fullscreen = true;
 	default_videomode.resizable = false;
-	buttons_state = 0;
 
 	main_loop = NULL;
 	gl_extensions = NULL;

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -32,7 +32,6 @@
 #define OS_ANDROID_H
 
 #include "audio_driver_opensl.h"
-#include "core/os/input.h"
 #include "core/os/main_loop.h"
 #include "drivers/unix/os_unix.h"
 #include "main/input_default.h"
@@ -43,32 +42,6 @@ class GodotJavaWrapper;
 class GodotIOJavaWrapper;
 
 class OS_Android : public OS_Unix {
-public:
-	struct TouchPos {
-		int id;
-		Point2 pos;
-	};
-
-	enum {
-		JOY_EVENT_BUTTON = 0,
-		JOY_EVENT_AXIS = 1,
-		JOY_EVENT_HAT = 2
-	};
-
-	struct JoypadEvent {
-		int device;
-		int type;
-		int index;
-		bool pressed;
-		float value;
-		int hat;
-	};
-
-private:
-	Vector<TouchPos> touch;
-	Point2 hover_prev_pos; // needed to calculate the relative position on hover events
-	Point2 scroll_prev_pos; // needed to calculate the relative position on scroll events
-
 	bool use_gl2;
 	bool use_apk_expansion;
 
@@ -92,21 +65,6 @@ private:
 	//PowerAndroid *power_manager_func;
 
 	int video_driver_index;
-
-	bool alt_mem = false;
-	bool shift_mem = false;
-	bool control_mem = false;
-	bool meta_mem = false;
-
-	int buttons_state;
-
-	void _set_key_modifier_state(Ref<InputEventWithModifiers> ev) const;
-
-	static int _button_index_from_mask(int button_mask);
-
-	static int _android_button_mask_to_godot_button_mask(int android_button_mask);
-
-	void _wheel_button_click(int event_buttons_mask, const Ref<InputEventMouseButton> &ev, int wheel_button, float factor);
 
 public:
 	// functions used by main to initialize/deinitialize the OS
@@ -162,7 +120,6 @@ public:
 
 	void main_loop_begin();
 	bool main_loop_iterate();
-	void main_loop_request_go_back();
 	void main_loop_end();
 	void main_loop_focusout();
 	void main_loop_focusin();
@@ -200,19 +157,10 @@ public:
 	void process_gravity(const Vector3 &p_gravity);
 	void process_magnetometer(const Vector3 &p_magnetometer);
 	void process_gyroscope(const Vector3 &p_gyroscope);
-	void process_touch(int p_event, int p_pointer, const Vector<TouchPos> &p_points);
-	void process_hover(int p_type, Point2 p_pos);
-	void process_mouse_event(int event_action, int event_android_buttons_mask, Point2 event_pos, float event_vertical_factor = 0, float event_horizontal_factor = 0);
-	void process_double_tap(int event_android_button_mask, Point2 p_pos);
-	void process_scroll(Point2 p_pos);
-	void process_joy_event(JoypadEvent p_event);
-	void process_key_event(int p_keycode, int p_scancode, int p_unicode_char, bool p_pressed);
-	void process_event(Ref<InputEvent> p_event);
 	void init_video_mode(int p_video_width, int p_video_height);
 
 	virtual bool is_joy_known(int p_device);
 	virtual String get_joy_guid(int p_device) const;
-	void joy_connection_changed(int p_device, bool p_connected, String p_name);
 	void vibrate_handheld(int p_duration_ms);
 
 	virtual bool _check_internal_feature_support(const String &p_feature);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -3159,7 +3159,7 @@ void OS_OSX::process_events() {
 	[autoreleasePool drain];
 	autoreleasePool = [[NSAutoreleasePool alloc] init];
 
-	input->flush_accumulated_events();
+	input->flush_buffered_events();
 }
 
 void OS_OSX::process_key_events() {

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -3216,7 +3216,7 @@ void OS_OSX::process_key_events() {
 
 void OS_OSX::push_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEvent> ev = p_event;
-	input->accumulate_input_event(ev);
+	input->parse_input_event(ev);
 }
 
 void OS_OSX::force_process_input() {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -283,7 +283,7 @@ void OS_Windows::_touch_event(bool p_pressed, float p_x, float p_y, int idx) {
 	event->set_position(Vector2(p_x, p_y));
 
 	if (main_loop) {
-		input->accumulate_input_event(event);
+		input->parse_input_event(event);
 	}
 };
 
@@ -303,7 +303,7 @@ void OS_Windows::_drag_event(float p_x, float p_y, int idx) {
 	event->set_relative(Vector2(p_x, p_y) - curr->get());
 
 	if (main_loop)
-		input->accumulate_input_event(event);
+		input->parse_input_event(event);
 
 	curr->get() = Vector2(p_x, p_y);
 };
@@ -487,7 +487,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 				}
 
 				if (window_has_focus && main_loop && mm->get_relative() != Vector2())
-					input->accumulate_input_event(mm);
+					input->parse_input_event(mm);
 			}
 			delete[] lpb;
 		} break;
@@ -575,7 +575,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 					old_x = mm->get_position().x;
 					old_y = mm->get_position().y;
 					if (window_has_focus && main_loop)
-						input->accumulate_input_event(mm);
+						input->parse_input_event(mm);
 				}
 				return 0;
 			}
@@ -719,7 +719,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			old_x = mm->get_position().x;
 			old_y = mm->get_position().y;
 			if (window_has_focus && main_loop)
-				input->accumulate_input_event(mm);
+				input->parse_input_event(mm);
 			return 0;
 		} break;
 		case WM_MOUSEMOVE: {
@@ -821,7 +821,7 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			old_x = mm->get_position().x;
 			old_y = mm->get_position().y;
 			if (window_has_focus && main_loop)
-				input->accumulate_input_event(mm);
+				input->parse_input_event(mm);
 
 		} break;
 		case WM_LBUTTONDOWN:
@@ -984,14 +984,14 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 			mb->set_global_position(mb->get_position());
 
 			if (main_loop) {
-				input->accumulate_input_event(mb);
+				input->parse_input_event(mb);
 				if (mb->is_pressed() && mb->get_button_index() > 3 && mb->get_button_index() < 8) {
 					//send release for mouse wheel
 					Ref<InputEventMouseButton> mbd = mb->duplicate();
 					last_button_state &= ~(1 << (mbd->get_button_index() - 1));
 					mbd->set_button_mask(last_button_state);
 					mbd->set_pressed(false);
-					input->accumulate_input_event(mbd);
+					input->parse_input_event(mbd);
 				}
 			}
 		} break;
@@ -1222,7 +1222,7 @@ void OS_Windows::process_key_events() {
 					if (k->get_unicode() < 32)
 						k->set_unicode(0);
 
-					input->accumulate_input_event(k);
+					input->parse_input_event(k);
 				}
 
 				//do nothing
@@ -1261,7 +1261,7 @@ void OS_Windows::process_key_events() {
 
 				k->set_echo((ke.uMsg == WM_KEYDOWN && (ke.lParam & (1 << 30))));
 
-				input->accumulate_input_event(k);
+				input->parse_input_event(k);
 
 			} break;
 		}

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2529,7 +2529,7 @@ void OS_Windows::process_events() {
 
 	if (!drop_events) {
 		process_key_events();
-		input->flush_accumulated_events();
+		input->flush_buffered_events();
 	}
 }
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2904,7 +2904,7 @@ void OS_X11::process_xevents() {
 		*/
 	}
 
-	input->flush_accumulated_events();
+	input->flush_buffered_events();
 }
 
 MainLoop *OS_X11::get_main_loop() const {

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1928,7 +1928,7 @@ void OS_X11::_handle_key_event(XKeyEvent *p_event, LocalVector<XEvent> &p_events
 					k->set_shift(true);
 				}
 
-				input->accumulate_input_event(k);
+				input->parse_input_event(k);
 			}
 			memfree(utf8string);
 			return;
@@ -2075,7 +2075,7 @@ void OS_X11::_handle_key_event(XKeyEvent *p_event, LocalVector<XEvent> &p_events
 	}
 
 	//printf("key: %x\n",k->get_scancode());
-	input->accumulate_input_event(k);
+	input->parse_input_event(k);
 }
 
 Atom OS_X11::_process_selection_request_target(Atom p_target, Window p_requestor, Atom p_property) const {
@@ -2491,13 +2491,13 @@ void OS_X11::process_xevents() {
 								// in a spurious mouse motion event being sent to Godot; remember it to be able to filter it out
 								xi.mouse_pos_to_filter = pos;
 							}
-							input->accumulate_input_event(st);
+							input->parse_input_event(st);
 						} else {
 							if (!xi.state.has(index)) { // Defensive
 								break;
 							}
 							xi.state.erase(index);
-							input->accumulate_input_event(st);
+							input->parse_input_event(st);
 						}
 					} break;
 
@@ -2513,7 +2513,7 @@ void OS_X11::process_xevents() {
 							sd->set_index(index);
 							sd->set_position(pos);
 							sd->set_relative(pos - curr_pos_elem->value());
-							input->accumulate_input_event(sd);
+							input->parse_input_event(sd);
 
 							curr_pos_elem->value() = pos;
 						}
@@ -2607,7 +2607,7 @@ void OS_X11::process_xevents() {
 					st.instance();
 					st->set_index(E->key());
 					st->set_position(E->get());
-					input->accumulate_input_event(st);
+					input->parse_input_event(st);
 				}
 				xi.state.clear();
 #endif
@@ -2668,7 +2668,7 @@ void OS_X11::process_xevents() {
 					}
 				}
 
-				input->accumulate_input_event(mb);
+				input->parse_input_event(mb);
 
 			} break;
 			case MotionNotify: {
@@ -2783,7 +2783,7 @@ void OS_X11::process_xevents() {
 				// this is so that the relative motion doesn't get messed up
 				// after we regain focus.
 				if (window_has_focus || !mouse_mode_grab) {
-					input->accumulate_input_event(mm);
+					input->parse_input_event(mm);
 				}
 
 			} break;


### PR DESCRIPTION
This PR adds a new project setting to switch to a different way of delivering input events which can greatly improve the responsiveness of games in devices that need to run multiple physics frames per idle frame (and, specially, where the input is handled in the physics frame so that the pace at which the input is taken isn't limited by the visual frame rate).

Before adding that and making it work, some preliminar steps have been taken, and are in separate commits.

Notes:
- This has helped a lot with my game. On a device that can keep 60 FPS it was fine, but when running it on an older, mid-range phone that achieves between 20-30 FPS, the input felt very laggy and the game looked more difficult and unresponsive that it actually is. **After this change (when the setting enabled), the performance is the same, but the game feels waaay more responsive.**
- If this is accepted, I'll port it to 4.0 (and probably also to iOS). I've needed to do 3.2 first since my game needed this and it wanted to have it ready as soon as possible.
- **UPDATE:** I haven't measured analytically, but I can perceive that my game is now free from some minor few millisecond hiccups that were happening once in a while. I was attributing them to other causes, but with buffering active they seem to be gone. I believe that consuming the input events from Android as they come is smoothing things out.

----------------------------
Summary of commits:

**UPDATE:** Commit structure modified.
**UPDATE:** Input handling extracted from Android OS.

### 1. Improve input event accumulation
- API has been simplified: all events now go through `parse_input_event()`. Whether they are accumulated or not depends on the `use_accumulated_input` flag.
- Event accumulation is now thread-safe (it was not needed so far, but it prepares the ground for the following changes).
- Touch drag events now support accumulation.

### 2. Add input buffering framework
Input buffering is implicitly used by event accumulation, but this commit makes it more generic so it can be enabled for other uses.

For desktop OSs it's currently not feasible given main and UI threads are the same).

### 3. Add project setting for agile input event flushing
If enabled, key/touch/joystick events will be flushed just before every idle and physics frame.

Enabling this can greatly improve the responsiveness to input, specially in devices that need to run multiple physics frames per each idle frame, because of not being powerful enough to run at the target frame rate.

This will only work for platforms using input buffering (regardless event accumulation). Currenly, only Android does so, but could be implemented for iOS in an upcoming PR.

### 4. Switch to input buffering on Android

Switch to input buffering on Android

Key, touch and joystick events will be passed directly from the UI thread to Godot, so they can benefit from agile input flushing.

As another consequence of this new way of passing events, less Java object are created at runtime (`Runnable`), which is good since the garbage collector needs to run less.

`AndroidInputHandler` is introduced to have a smaller cross-thread surface. `main_loop_request_go_back()` is removed in favor just inline calling `notification()` on the `MainLoop` at the most caller's convenience.

Lastly, `get_mouse_position()` and `get_mouse_button_state()` now just call through `InputDefault` to avoid the need of sync of mouse data tracked on the UI thread.