### PR TITLE
Cross-reference AABB and Rect2 in the class reference

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -4,7 +4,9 @@
 		Axis-Aligned Bounding Box.
 	</brief_description>
 	<description>
-		AABB consists of a position, a size, and several utility functions. It is typically used for fast overlap tests.
+		[AABB] consists of a position, a size, and several utility functions. It is typically used for fast overlap tests.
+		It uses floating-point coordinates. The 2D counterpart to [AABB] is [Rect2].
+		[b]Note:[/b] Unlike [Rect2], [AABB] does not have a variant that uses integer coordinates.
 	</description>
 	<tutorials>
 		<link title="Math tutorial index">https://docs.godotengine.org/en/latest/tutorials/math/index.html</link>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -5,7 +5,8 @@
 	</brief_description>
 	<description>
 		[Rect2] consists of a position, a size, and several utility functions. It is typically used for fast overlap tests.
-		It uses floating point coordinates.
+		It uses floating-point coordinates. If you need integer coordinates, use [Rect2i] instead.
+		The 3D counterpart to [Rect2] is [AABB].
 	</description>
 	<tutorials>
 		<link title="Math tutorial index">https://docs.godotengine.org/en/latest/tutorials/math/index.html</link>

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[Rect2i] consists of a position, a size, and several utility functions. It is typically used for fast overlap tests.
-		It uses integer coordinates.
+		It uses integer coordinates. If you need floating-point coordinates, use [Rect2] instead.
 	</description>
 	<tutorials>
 		<link title="Math tutorial index">https://docs.godotengine.org/en/latest/tutorials/math/index.html</link>


### PR DESCRIPTION
See https://github.com/godotengine/godot-proposals/issues/1528#issuecomment-695988891.

**Note:** When cherry-picking to the `3.2` branch, drop the references to Rect2i as it doesn't exist there.