### PR TITLE
Improve undo log messages in the 2D editor for additional context

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1410,9 +1410,16 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 		}
 
 		// Confirm the pivot move
-		if ((b.is_valid() && !b->is_pressed() && b->get_button_index() == BUTTON_LEFT && tool == TOOL_EDIT_PIVOT) ||
-				(k.is_valid() && !k->is_pressed() && k->get_keycode() == KEY_V)) {
-			_commit_canvas_item_state(drag_selection, TTR("Move pivot"));
+		if (drag_selection.size() >= 1 &&
+				((b.is_valid() && !b->is_pressed() && b->get_button_index() == BUTTON_LEFT && tool == TOOL_EDIT_PIVOT) ||
+						(k.is_valid() && !k->is_pressed() && k->get_keycode() == KEY_V))) {
+			_commit_canvas_item_state(
+					drag_selection,
+					vformat(
+							TTR("Set CanvasItem \"%s\" Pivot Offset to (%d, %d)"),
+							drag_selection[0]->get_name(),
+							drag_selection[0]->_edit_get_pivot().x,
+							drag_selection[0]->_edit_get_pivot().y));
 			drag_type = DRAG_NONE;
 			return true;
 		}
@@ -1549,7 +1556,20 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 
 		// Confirms the node rotation
 		if (b.is_valid() && b->get_button_index() == BUTTON_LEFT && !b->is_pressed()) {
-			_commit_canvas_item_state(drag_selection, TTR("Rotate CanvasItem"));
+			if (drag_selection.size() != 1) {
+				_commit_canvas_item_state(
+						drag_selection,
+						vformat(TTR("Rotate %d CanvasItems"), drag_selection.size()),
+						true);
+			} else {
+				_commit_canvas_item_state(
+						drag_selection,
+						vformat(TTR("Rotate CanvasItem \"%s\" to %d degrees"),
+								drag_selection[0]->get_name(),
+								Math::rad2deg(drag_selection[0]->_edit_get_rotation())),
+						true);
+			}
+
 			if (key_auto_insert_button->is_pressed()) {
 				_insert_animation_keys(false, true, false, true);
 			}
@@ -1708,8 +1728,10 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 		}
 
 		// Confirms new anchor position
-		if (b.is_valid() && b->get_button_index() == BUTTON_LEFT && !b->is_pressed()) {
-			_commit_canvas_item_state(drag_selection, TTR("Move anchor"));
+		if (drag_selection.size() >= 1 && b.is_valid() && b->get_button_index() == BUTTON_LEFT && !b->is_pressed()) {
+			_commit_canvas_item_state(
+					drag_selection,
+					vformat(TTR("Move CanvasItem \"%s\" Anchor"), drag_selection[0]->get_name()));
 			drag_type = DRAG_NONE;
 			return true;
 		}
@@ -1885,8 +1907,31 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 		}
 
 		// Confirm resize
-		if (b.is_valid() && b->get_button_index() == BUTTON_LEFT && !b->is_pressed()) {
-			_commit_canvas_item_state(drag_selection, TTR("Resize CanvasItem"));
+		if (drag_selection.size() >= 1 && b.is_valid() && b->get_button_index() == BUTTON_LEFT && !b->is_pressed()) {
+			const Node2D *node2d = Object::cast_to<Node2D>(drag_selection[0]);
+			if (node2d) {
+				// Extends from Node2D.
+				// Node2D doesn't have an actual stored rect size, unlike Controls.
+				_commit_canvas_item_state(
+						drag_selection,
+						vformat(
+								TTR("Scale Node2D \"%s\" to (%s, %s)"),
+								drag_selection[0]->get_name(),
+								Math::stepify(drag_selection[0]->_edit_get_scale().x, 0.01),
+								Math::stepify(drag_selection[0]->_edit_get_scale().y, 0.01)),
+						true);
+			} else {
+				// Extends from Control.
+				_commit_canvas_item_state(
+						drag_selection,
+						vformat(
+								TTR("Resize Control \"%s\" to (%d, %d)"),
+								drag_selection[0]->get_name(),
+								drag_selection[0]->_edit_get_rect().size.x,
+								drag_selection[0]->_edit_get_rect().size.y),
+						true);
+			}
+
 			if (key_auto_insert_button->is_pressed()) {
 				_insert_animation_keys(false, false, true, true);
 			}
@@ -2014,7 +2059,20 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 
 		// Confirm resize
 		if (b.is_valid() && b->get_button_index() == BUTTON_LEFT && !b->is_pressed()) {
-			_commit_canvas_item_state(drag_selection, TTR("Scale CanvasItem"));
+			if (drag_selection.size() != 1) {
+				_commit_canvas_item_state(
+						drag_selection,
+						vformat(TTR("Scale %d CanvasItems"), drag_selection.size()),
+						true);
+			} else {
+				_commit_canvas_item_state(
+						drag_selection,
+						vformat(TTR("Scale CanvasItem \"%s\" to (%s, %s)"),
+								drag_selection[0]->get_name(),
+								Math::stepify(drag_selection[0]->_edit_get_scale().x, 0.01),
+								Math::stepify(drag_selection[0]->_edit_get_scale().y, 0.01)),
+						true);
+			}
 			if (key_auto_insert_button->is_pressed()) {
 				_insert_animation_keys(false, false, true, true);
 			}
@@ -2145,7 +2203,21 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 		// Confirm the move (only if it was moved)
 		if (b.is_valid() && !b->is_pressed() && b->get_button_index() == BUTTON_LEFT) {
 			if (transform.affine_inverse().xform(b->get_position()) != drag_from) {
-				_commit_canvas_item_state(drag_selection, TTR("Move CanvasItem"), true);
+				if (drag_selection.size() != 1) {
+					_commit_canvas_item_state(
+							drag_selection,
+							vformat(TTR("Move %d CanvasItems"), drag_selection.size()),
+							true);
+				} else {
+					_commit_canvas_item_state(
+							drag_selection,
+							vformat(
+									TTR("Move CanvasItem \"%s\" to (%d, %d)"),
+									drag_selection[0]->get_name(),
+									drag_selection[0]->_edit_get_position().x,
+									drag_selection[0]->_edit_get_position().y),
+							true);
+				}
 			}
 
 			if (key_auto_insert_button->is_pressed()) {
@@ -2270,7 +2342,20 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 				(!Input::get_singleton()->is_key_pressed(KEY_DOWN)) &&
 				(!Input::get_singleton()->is_key_pressed(KEY_LEFT)) &&
 				(!Input::get_singleton()->is_key_pressed(KEY_RIGHT))) {
-			_commit_canvas_item_state(drag_selection, TTR("Move CanvasItem"), true);
+			if (drag_selection.size() != 1) {
+				_commit_canvas_item_state(
+						drag_selection,
+						vformat(TTR("Move %d CanvasItems"), drag_selection.size()),
+						true);
+			} else {
+				_commit_canvas_item_state(
+						drag_selection,
+						vformat(TTR("Move CanvasItem \"%s\" to (%d, %d)"),
+								drag_selection[0]->get_name(),
+								drag_selection[0]->_edit_get_position().x,
+								drag_selection[0]->_edit_get_position().y),
+						true);
+			}
 			drag_type = DRAG_NONE;
 		}
 		viewport->update();


### PR DESCRIPTION
Undo/redo log messages will now specify the modified node's name (or number of modified nodes if several were modified). On top of that, the new position/rotation/scale/pivot offset will also be mentioned in the message.

If this feature is desired, I'll look into implementing it for the 3D editor in a future PR :slightly_smiling_face:

## Preview

### Before

```yaml
Move CanvasItem
Rotate CanvasItem
Resize CanvasItem
Move pivot
Move CanvasItem
# Select 4 CanvasItems…
Move CanvasItem
```

### After

```yaml
Move CanvasItem "Sprite2D" to (-3, 166)
Rotate CanvasItem "Sprite2D" to -13 degrees
Resize Control "Label" to (143, 32)
Set CanvasItem "Label" Pivot Offset to (13, 18)
Move CanvasItem "Control" to (273, -147)
# Select 4 CanvasItems…
Move 4 CanvasItems
```