### PR TITLE
Fix UniformRef invalid updating when LineEdit focus out

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -288,8 +288,8 @@ class VisualShaderEditor : public VBoxContainer {
 	void _connection_to_empty(const String &p_from, int p_from_slot, const Vector2 &p_release_position);
 	void _connection_from_empty(const String &p_to, int p_to_slot, const Vector2 &p_release_position);
 
-	void _line_edit_changed(const String &p_text, Object *line_edit, int p_node_id);
-	void _line_edit_focus_out(Object *line_edit, int p_node_id);
+	void _uniform_line_edit_changed(const String &p_text, int p_node_id);
+	void _uniform_line_edit_focus_out(Object *line_edit, int p_node_id);
 
 	void _port_name_focus_out(Object *line_edit, int p_node_id, int p_port_id, bool p_output);
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
