### PR TITLE
Fix C# string.IsAbsPath()

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -440,7 +440,12 @@ namespace Godot
         // </summary>
         public static bool IsAbsPath(this string instance)
         {
-            return System.IO.Path.IsPathRooted(instance);
+            if (string.IsNullOrEmpty(instance))
+                return false;
+            else if (instance.Length > 1)
+                return instance[0] == '/' || instance[0] == '\\' || instance.Contains(":/") || instance.Contains(":\\");
+            else
+                return instance[0] == '/' || instance[0] == '\\';
         }
 
         // <summary>
@@ -448,7 +453,7 @@ namespace Godot
         // </summary>
         public static bool IsRelPath(this string instance)
         {
-            return !System.IO.Path.IsPathRooted(instance);
+            return !IsAbsPath(instance);
         }
 
         // <summary>


### PR DESCRIPTION
fix #42250 