### PR TITLE
iOS: Fix multiple issues with PVRTC import, disable ETC1

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1406,6 +1406,20 @@ String EditorExportPlatform::test_etc2() const {
 	return String();
 }
 
+String EditorExportPlatform::test_etc2_or_pvrtc() const {
+	String driver = ProjectSettings::get_singleton()->get("rendering/quality/driver/driver_name");
+	bool etc2_supported = ProjectSettings::get_singleton()->get("rendering/vram_compression/import_etc2");
+	bool pvrtc_supported = ProjectSettings::get_singleton()->get("rendering/vram_compression/import_pvrtc");
+
+	if (driver == "GLES2" && !pvrtc_supported) {
+		return TTR("Target platform requires 'PVRTC' texture compression for GLES2. Enable 'Import Pvrtc' in Project Settings.");
+	} else if (driver == "Vulkan" && !etc2_supported && !pvrtc_supported) {
+		// FIXME: Review if this is true for Vulkan.
+		return TTR("Target platform requires 'ETC2' or 'PVRTC' texture compression for Vulkan. Enable 'Import Etc 2' or 'Import Pvrtc' in Project Settings.");
+	}
+	return String();
+}
+
 int EditorExport::get_export_preset_count() const {
 	return export_presets.size();
 }

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -277,6 +277,7 @@ public:
 	virtual Ref<Texture2D> get_run_icon() const { return get_logo(); }
 
 	String test_etc2() const; //generic test for etc2 since most platforms use it
+	String test_etc2_or_pvrtc() const; // test for etc2 or pvrtc support for iOS
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const = 0;
 
 	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const = 0;

--- a/modules/pvr/texture_loader_pvr.cpp
+++ b/modules/pvr/texture_loader_pvr.cpp
@@ -213,10 +213,12 @@ static void _compress_pvrtc4(Image *p_img) {
 			int ofs, size, w, h;
 			img->get_mipmap_offset_size_and_dimensions(i, ofs, size, w, h);
 			Javelin::RgbaBitmap bm(w, h);
+			void *dst = (void *)bm.GetData();
+			copymem(dst, &r[ofs], size);
+			Javelin::ColorRgba<unsigned char> *dp = bm.GetData();
 			for (int j = 0; j < size / 4; j++) {
-				Javelin::ColorRgba<unsigned char> *dp = bm.GetData();
-				/* red and Green colors are swapped.  */
-				new (dp) Javelin::ColorRgba<unsigned char>(r[ofs + 4 * j + 2], r[ofs + 4 * j + 1], r[ofs + 4 * j], r[ofs + 4 * j + 3]);
+				/* red and blue colors are swapped.  */
+				SWAP(dp[j].r, dp[j].b);
 			}
 			new_img->get_mipmap_offset_size_and_dimensions(i, ofs, size, w, h);
 			Javelin::PvrTcEncoder::EncodeRgba4Bpp(&wr[ofs], bm);

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -160,9 +160,8 @@ public:
 
 void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
 	String driver = ProjectSettings::get_singleton()->get("rendering/quality/driver/driver_name");
-	if (driver == "GLES2") {
-		r_features->push_back("etc");
-	} else if (driver == "Vulkan") {
+	r_features->push_back("pvrtc");
+	if (driver == "Vulkan") {
 		// FIXME: Review if this is correct.
 		r_features->push_back("etc2");
 	}
@@ -1649,7 +1648,7 @@ bool EditorExportPlatformIOS::can_export(const Ref<EditorExportPreset> &p_preset
 		}
 	}
 
-	String etc_error = test_etc2();
+	String etc_error = test_etc2_or_pvrtc();
 	if (etc_error != String()) {
 		valid = false;
 		err += etc_error;


### PR DESCRIPTION
Closes #28683, closes #28621, closes #28596 and maybe others

For iOS we enable pvrtc feature by default for all backends
Etc1 for iOS doesn't have any sense, so it disabled.
Fixed checks in export editor.
Fixed pvrtc encoding procedure.

Edit by Akien: Forward-ported from #38076, this may not make sense as is for
Godot 4.0, but it's important that we have the latest code in sync with 3.2
for when more rendering backends and proper iOS support are added back.