### PR TITLE
Ignore thread models when compiling with NO_THREAD

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1274,9 +1274,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (rtm >= 0 && rtm < 3) {
+#ifdef NO_THREADS
+		rtm = OS::RENDER_THREAD_UNSAFE; // No threads available on this platform.
+#else
 		if (editor) {
 			rtm = OS::RENDER_THREAD_SAFE;
 		}
+#endif
 		OS::get_singleton()->_render_thread_mode = OS::RenderThreadMode(rtm);
 	}
 

--- a/servers/physics_2d/physics_server_2d_sw.cpp
+++ b/servers/physics_2d/physics_server_2d_sw.cpp
@@ -1342,6 +1342,10 @@ PhysicsServer2DSW::PhysicsServer2DSW() {
 	island_count = 0;
 	active_objects = 0;
 	collision_pairs = 0;
+#ifdef NO_THREADS
+	using_threads = false;
+#else
 	using_threads = int(ProjectSettings::get_singleton()->get("physics/2d/thread_model")) == 2;
+#endif
 	flushing_queries = false;
 };

--- a/servers/physics_2d/physics_server_2d_wrap_mt.h
+++ b/servers/physics_2d/physics_server_2d_wrap_mt.h
@@ -317,6 +317,9 @@ public:
 
 	template <class T>
 	static PhysicsServer2D *init_server() {
+#ifdef NO_THREADS
+		return memnew(T); // Always single unsafe when no threads are available.
+#else
 		int tm = GLOBAL_DEF("physics/2d/thread_model", 1);
 		if (tm == 0) { // single unsafe
 			return memnew(T);
@@ -325,6 +328,7 @@ public:
 		} else { // multi threaded
 			return memnew(PhysicsServer2DWrapMT(memnew(T), true));
 		}
+#endif
 	}
 
 #undef ServerNameWrapMT


### PR DESCRIPTION
The thread model option for physics (2D) and rendering (single-unsafe, single-safe, multithread), was causing crashes/locks when set as multithreaded and exported for a platform that does not support threads (namely HTML5).

This commit ensures that when threads support is not available, that option is ignored, and the equivalent of "single-unsafe" is always used instead.

Fixes #29641