### PR TITLE
LocalVector: Correctly destroy the removed item.

### DIFF
--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -73,12 +73,12 @@ public:
 
 	void remove(U p_index) {
 		ERR_FAIL_UNSIGNED_INDEX(p_index, count);
+		if (!__has_trivial_destructor(T) && !force_trivial) {
+			data[p_index].~T();
+		}
 		count--;
 		for (U i = p_index; i < count; i++) {
 			data[i] = data[i + 1];
-		}
-		if (!__has_trivial_destructor(T) && !force_trivial) {
-			data[count].~T();
 		}
 	}
 


### PR DESCRIPTION
Previously the destroyed item was always the last one, while the desired item to be remove was kept alive.