### PR TITLE
Added the function `remove_unordered` to the LocalVector container.

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -82,6 +82,19 @@ public:
 		}
 	}
 
+	/// Removes the item copying the last value into the position of the one to
+	/// remove. It's generally faster than `remove`.
+	void remove_unordered(U p_index) {
+		ERR_FAIL_INDEX(p_index, count);
+		count--;
+		if (count > p_index) {
+			data[p_index] = data[count];
+		}
+		if (!__has_trivial_destructor(T) && !force_trivial) {
+			data[count].~T();
+		}
+	}
+
 	void erase(const T &p_val) {
 		int64_t idx = find(p_val);
 		if (idx >= 0) {
@@ -105,6 +118,7 @@ public:
 		}
 	}
 	_FORCE_INLINE_ bool is_empty() const { return count == 0; }
+	_FORCE_INLINE_ U get_capacity() const { return capacity; }
 	_FORCE_INLINE_ void reserve(U p_size) {
 		p_size = nearest_power_of_2_templated(p_size);
 		if (p_size > capacity) {

--- a/tests/test_local_vector.h
+++ b/tests/test_local_vector.h
@@ -1,0 +1,229 @@
+/*************************************************************************/
+/*  test_local_vector.h                                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_LOCAL_VECTOR_H
+#define TEST_LOCAL_VECTOR_H
+
+#include "core/templates/local_vector.h"
+
+#include "tests/test_macros.h"
+
+namespace TestLocalVector {
+
+TEST_CASE("[LocalVector] Push Back.") {
+	LocalVector<int> vector;
+	vector.push_back(0);
+	vector.push_back(1);
+	vector.push_back(2);
+	vector.push_back(3);
+	vector.push_back(4);
+
+	CHECK(vector[0] == 0);
+	CHECK(vector[1] == 1);
+	CHECK(vector[2] == 2);
+	CHECK(vector[3] == 3);
+	CHECK(vector[4] == 4);
+}
+
+TEST_CASE("[LocalVector] Find.") {
+	LocalVector<int> vector;
+	vector.push_back(3);
+	vector.push_back(1);
+	vector.push_back(4);
+	vector.push_back(0);
+	vector.push_back(2);
+
+	CHECK(vector[0] == 3);
+	CHECK(vector[1] == 1);
+	CHECK(vector[2] == 4);
+	CHECK(vector[3] == 0);
+	CHECK(vector[4] == 2);
+
+	CHECK(vector.find(0) == 3);
+	CHECK(vector.find(1) == 1);
+	CHECK(vector.find(2) == 4);
+	CHECK(vector.find(3) == 0);
+	CHECK(vector.find(4) == 2);
+
+	CHECK(vector.find(-1) == -1);
+	CHECK(vector.find(5) == -1);
+}
+
+TEST_CASE("[LocalVector] Remove.") {
+	LocalVector<int> vector;
+	vector.push_back(0);
+	vector.push_back(1);
+	vector.push_back(2);
+	vector.push_back(3);
+	vector.push_back(4);
+
+	vector.remove(0);
+
+	CHECK(vector[0] == 1);
+	CHECK(vector[1] == 2);
+	CHECK(vector[2] == 3);
+	CHECK(vector[3] == 4);
+
+	vector.remove(2);
+
+	CHECK(vector[0] == 1);
+	CHECK(vector[1] == 2);
+	CHECK(vector[2] == 4);
+
+	vector.remove(1);
+
+	CHECK(vector[0] == 1);
+	CHECK(vector[1] == 4);
+
+	vector.remove(0);
+
+	CHECK(vector[0] == 4);
+}
+
+TEST_CASE("[LocalVector] Remove Unordered.") {
+	LocalVector<int> vector;
+	vector.push_back(0);
+	vector.push_back(1);
+	vector.push_back(2);
+	vector.push_back(3);
+	vector.push_back(4);
+
+	CHECK(vector.size() == 5);
+
+	vector.remove_unordered(0);
+
+	CHECK(vector.size() == 4);
+
+	CHECK(vector.find(0) == -1);
+	CHECK(vector.find(1) != -1);
+	CHECK(vector.find(2) != -1);
+	CHECK(vector.find(3) != -1);
+	CHECK(vector.find(4) != -1);
+
+	// Now the vector is no more ordered.
+	vector.remove_unordered(vector.find(3));
+
+	CHECK(vector.size() == 3);
+
+	CHECK(vector.find(3) == -1);
+	CHECK(vector.find(1) != -1);
+	CHECK(vector.find(2) != -1);
+	CHECK(vector.find(4) != -1);
+
+	vector.remove_unordered(vector.find(2));
+
+	CHECK(vector.size() == 2);
+
+	CHECK(vector.find(2) == -1);
+	CHECK(vector.find(1) != -1);
+	CHECK(vector.find(4) != -1);
+
+	vector.remove_unordered(vector.find(4));
+
+	CHECK(vector.size() == 1);
+
+	CHECK(vector.find(4) == -1);
+	CHECK(vector.find(1) != -1);
+
+	// Remove the last one.
+	vector.remove_unordered(0);
+
+	CHECK(vector.is_empty());
+	CHECK(vector.size() == 0);
+}
+
+TEST_CASE("[LocalVector] Erase.") {
+	LocalVector<int> vector;
+	vector.push_back(1);
+	vector.push_back(3);
+	vector.push_back(0);
+	vector.push_back(2);
+	vector.push_back(4);
+
+	CHECK(vector.find(2) == 3);
+
+	vector.erase(2);
+
+	CHECK(vector.find(2) == -1);
+	CHECK(vector.size() == 4);
+}
+
+TEST_CASE("[LocalVector] Size / Resize / Reserve.") {
+	LocalVector<int> vector;
+
+	CHECK(vector.is_empty());
+	CHECK(vector.size() == 0);
+	CHECK(vector.get_capacity() == 0);
+
+	vector.resize(10);
+
+	CHECK(vector.size() == 10);
+	CHECK(vector.get_capacity() >= 10);
+
+	vector.resize(5);
+
+	CHECK(vector.size() == 5);
+	// Capacity is supposed to change only when the size increase.
+	CHECK(vector.get_capacity() >= 10);
+
+	vector.remove(0);
+	vector.remove(0);
+	vector.remove(0);
+
+	CHECK(vector.size() == 2);
+	// Capacity is supposed to change only when the size increase.
+	CHECK(vector.get_capacity() >= 10);
+
+	vector.reset();
+
+	CHECK(vector.size() == 0);
+	CHECK(vector.get_capacity() == 0);
+
+	vector.reserve(3);
+
+	CHECK(vector.is_empty());
+	CHECK(vector.size() == 0);
+	CHECK(vector.get_capacity() >= 3);
+
+	vector.push_back(0);
+	vector.push_back(0);
+	vector.push_back(0);
+
+	CHECK(vector.size() == 3);
+	CHECK(vector.get_capacity() >= 3);
+
+	vector.push_back(0);
+
+	CHECK(vector.size() == 4);
+	CHECK(vector.get_capacity() >= 4);
+}
+} // namespace TestLocalVector
+
+#endif // TEST_LOCAL_VECTOR_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -48,6 +48,7 @@
 #include "test_gui.h"
 #include "test_json.h"
 #include "test_list.h"
+#include "test_local_vector.h"
 #include "test_lru.h"
 #include "test_math.h"
 #include "test_method_bind.h"


### PR DESCRIPTION
Added function `remove_unordered` to `LocalVector`.

Sometimes you don't need to keep the vector's order, so you can just remove the item by swapping the item you need to remove with the last one. With `remove_unordered` it's possible to avoid the extra copies that the `remove` function does to maintain the original insertion order.