### PR TITLE
Check for null in InputMap::_find_event

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -95,6 +95,8 @@ List<StringName> InputMap::get_actions() const {
 }
 
 List<Ref<InputEvent>>::Element *InputMap::_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength) const {
+	ERR_FAIL_COND_V(!p_event.is_valid(), nullptr);
+
 	for (List<Ref<InputEvent>>::Element *E = p_action.inputs.front(); E; E = E->next()) {
 		const Ref<InputEvent> e = E->get();
 


### PR DESCRIPTION
Prevents the engine from crashing when doing e.g. `InputMap.action_erase_event("ui_up", null)`.