### PR TITLE
Implement no-window mode for X11 and MacOS (3.2)

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -156,7 +156,7 @@ void OS_Unix::finalize_core() {
 
 void OS_Unix::alert(const String &p_alert, const String &p_title) {
 
-	fprintf(stderr, "ERROR: %s\n", p_alert.utf8().get_data());
+	fprintf(stderr, "ALERT: %s: %s\n", p_title.utf8().get_data(), p_alert.utf8().get_data());
 }
 
 String OS_Unix::get_stdin_string(bool p_block) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -259,7 +259,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --resolution <W>x<H>             Request window resolution.\n");
 	OS::get_singleton()->print("  --position <X>,<Y>               Request window position.\n");
 	OS::get_singleton()->print("  --low-dpi                        Force low-DPI mode (macOS and Windows only).\n");
-	OS::get_singleton()->print("  --no-window                      Disable window creation (Windows only). Useful together with --script.\n");
+	OS::get_singleton()->print("  --no-window                      Run with invisible window. Useful together with --script.\n");
 	OS::get_singleton()->print("  --enable-vsync-via-compositor    When vsync is enabled, vsync via the OS' window compositor (Windows only).\n");
 	OS::get_singleton()->print("  --disable-vsync-via-compositor   Disable vsync via the OS' window compositor (Windows only).\n");
 	OS::get_singleton()->print("  --tablet-driver                  Tablet input driver (");
@@ -609,7 +609,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "--low-dpi") { // force low DPI (macOS only)
 
 			force_lowdpi = true;
-		} else if (I->get() == "--no-window") { // disable window creation (Windows only)
+		} else if (I->get() == "--no-window") { // run with an invisible window
 
 			OS::get_singleton()->set_no_window_mode(true);
 		} else if (I->get() == "--tablet-driver") {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1855,10 +1855,12 @@ void OS_Windows::finalize_core() {
 
 void OS_Windows::alert(const String &p_alert, const String &p_title) {
 
-	if (!is_no_window_mode_enabled())
-		MessageBoxW(NULL, p_alert.c_str(), p_title.c_str(), MB_OK | MB_ICONEXCLAMATION | MB_TASKMODAL);
-	else
-		print_line("ALERT: " + p_alert);
+	if (is_no_window_mode_enabled()) {
+		print_line("ALERT: " + p_title + ": " + p_alert);
+		return;
+	}
+
+	MessageBoxW(NULL, p_alert.c_str(), p_title.c_str(), MB_OK | MB_ICONEXCLAMATION | MB_TASKMODAL);
 }
 
 void OS_Windows::set_mouse_mode(MouseMode p_mode) {

--- a/platform/x11/context_gl_x11.cpp
+++ b/platform/x11/context_gl_x11.cpp
@@ -197,7 +197,10 @@ Error ContextGL_X11::initialize() {
 
 	ERR_FAIL_COND_V(!x11_window, ERR_UNCONFIGURED);
 	set_class_hint(x11_display, x11_window);
-	XMapWindow(x11_display, x11_window);
+
+	if (!OS::get_singleton()->is_no_window_mode_enabled()) {
+		XMapWindow(x11_display, x11_window);
+	}
 
 	XSync(x11_display, False);
 	XSetErrorHandler(oldHandler);

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -847,7 +847,9 @@ void OS_X11::finalize() {
 	if (xrandr_handle)
 		dlclose(xrandr_handle);
 
-	XUnmapWindow(x11_display, x11_window);
+	if (!OS::get_singleton()->is_no_window_mode_enabled()) {
+		XUnmapWindow(x11_display, x11_window);
+	}
 	XDestroyWindow(x11_display, x11_window);
 
 #if defined(OPENGL_ENABLED)
@@ -3226,6 +3228,12 @@ void OS_X11::swap_buffers() {
 }
 
 void OS_X11::alert(const String &p_alert, const String &p_title) {
+
+	if (is_no_window_mode_enabled()) {
+		print_line("ALERT: " + p_title + ": " + p_alert);
+		return;
+	}
+
 	const char *message_programs[] = { "zenity", "kdialog", "Xdialog", "xmessage" };
 
 	String path = get_environment("PATH");


### PR DESCRIPTION
This adds support for `--no-window` to MacOS and X11.

It also makes the non-windowed and non-overridden versions of `OS::alert()` include the title as well.

The credit for the MacOS support goes to a developer called Anton Breusov, on top of which I applied minimal changes. It seems that on Mac we can't get perfect hidden window behavior (it's still shown in the dock, though unpickable) and we need stronger measures to have it working as closer to expected as possible, as the code changes show.

**NOTE:** There's no version of this for 4.0, since, as far as I've checked, 4.0 still doesn't implement `--no-window` at all. Therefore, I believe that a good plan is that when it's implemented there the 3.2 version is more platform-complete so it gets everything at once.

*Bugsquad edit:* Fixes #43325.

---
**This code is generously donated by IMVU.**