### PR TITLE
Reference the BaseButton class explicitly in button class documentations

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -17,6 +17,7 @@
 		    print("Hello world!")
 		[/codeblock]
 		Buttons (like all Control nodes) can also be created in the editor, but some situations may require creating them from code.
+		See also [BaseButton] which contains common properties and methods associated with this node.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A checkbox allows the user to make a binary choice (choosing only one of two possible options). It's similar to [CheckButton] in functionality, but it has a different appearance. To follow established UX patterns, it's recommended to use CheckBox when toggling it has [b]no[/b] immediate effect on something. For instance, it should be used when toggling it will only do something once a confirmation button is pressed.
+		See also [BaseButton] which contains common properties and methods associated with this node.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		CheckButton is a toggle button displayed as a check field. It's similar to [CheckBox] in functionality, but it has a different appearance. To follow established UX patterns, it's recommended to use CheckButton when toggling it has an [b]immediate[/b] effect on something. For instance, it should be used if toggling it enables/disables a setting without requiring the user to press a confirmation button.
+		See also [BaseButton] which contains common properties and methods associated with this node.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Encapsulates a [ColorPicker] making it accessible by pressing a button. Pressing the button will toggle the [ColorPicker] visibility.
+		See also [BaseButton] which contains common properties and methods associated with this node.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This kind of button is primarily used when the interaction with the button causes a context change (like linking to a web page).
+		See also [BaseButton] which contains common properties and methods associated with this node.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -6,6 +6,7 @@
 	<description>
 		Special button that brings up a [PopupMenu] when clicked.
 		New items can be created inside this [PopupMenu] using [code]get_popup().add_item("My Item Name")[/code]. You can also create them directly from the editor. To do so, select the [MenuButton] node, then in the toolbar at the top of the 2D editor, click [b]Items[/b] then click [b]Add[/b] in the popup. You will be able to give each items new properties.
+		See also [BaseButton] which contains common properties and methods associated with this node.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		OptionButton is a type button that provides a selectable list of items when pressed. The item selected becomes the "current" item and is displayed as the button text.
+		See also [BaseButton] which contains common properties and methods associated with this node.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/TextureButton.xml
+++ b/doc/classes/TextureButton.xml
@@ -6,6 +6,7 @@
 	<description>
 		[TextureButton] has the same functionality as [Button], except it uses sprites instead of Godot's [Theme] resource. It is faster to create, but it doesn't support localization like more complex [Control]s.
 		The "normal" state must contain a texture ([member texture_normal]); other textures are optional.
+		See also [BaseButton] which contains common properties and methods associated with this node.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Users are sometimes confused as to the `pressed` property not being visible in the Button class documentation. This is because `pressed` is defined in BaseButton.