### PR TITLE
MessageQueue: Change default queue size to 4096 KB

### DIFF
--- a/core/message_queue.h
+++ b/core/message_queue.h
@@ -38,8 +38,7 @@ class MessageQueue {
 	_THREAD_SAFE_CLASS_
 
 	enum {
-
-		DEFAULT_QUEUE_SIZE_KB = 1024
+		DEFAULT_QUEUE_SIZE_KB = 4096
 	};
 
 	enum {


### PR DESCRIPTION
1024 KB was low enough that many users seem to hit it, which can lead to the
editor freezing.

The proper fixed as described in #35653 would be to implement a page allocator
to prevent this overflow, but as a stop-gap measure, we can increase the
default value to a more lenient 4096 KB which should be high enough for the
vast majority of use cases.

The default size can be brought down again if/when #35653 is properly fixed,
and if it's actually relevant from a memory point of view.

---

For the reference, this was already proposed and rejected in the past: #28294.
But IMO, even if page allocation is implemented in `master` for 4.0, it's unlikely to be backported to the `3.2` branch, so a stop-gap measure makes sense there IMO.

I haven't done any impact assessment of what changing this default value would mean in practice in terms of memory use or performance. But IMO a 4096 KiB buffer size for something as critical as MessageQueue is a good compromise.

There's also a pending PR to implement page allocation: #35658, but it has yet to be reviewed by @reduz / merged or redone.