### PR TITLE
Stop reset of MultiMesh properties on populate

### DIFF
--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -172,7 +172,8 @@ void MultiMeshEditor::_populate() {
 	int instance_count = populate_amount->get_value();
 
 	multimesh->set_transform_format(MultiMesh::TRANSFORM_3D);
-	multimesh->set_color_format(MultiMesh::COLOR_NONE);
+	multimesh->set_color_format(node->get_multimesh()->get_color_format());
+	multimesh->set_custom_data_format(node->get_multimesh()->get_custom_data_format());
 	multimesh->set_instance_count(instance_count);
 
 	float _tilt_random = populate_tilt_random->get_value();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/42223

ColorFormat and CustomFormat is not changed when populate is called.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
