### PR TITLE
Remove unnecessary empty line from Dictionaries

### DIFF
--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -1608,10 +1608,12 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				write(dict[E->get()], p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud);
 				if (E->next()) {
 					p_store_string_func(p_store_string_ud, ",\n");
+				} else {
+					p_store_string_func(p_store_string_ud, "\n");
 				}
 			}
 
-			p_store_string_func(p_store_string_ud, "\n}");
+			p_store_string_func(p_store_string_ud, "}");
 
 		} break;
 		case Variant::ARRAY: {


### PR DESCRIPTION
This removes an empty line when saving an empty Dictionary to a `.tres` file.

Test code:
```
func _ready() -> void:
	ResourceSaver.save("test.tres", Test.new())

class Test extends Resource:
	@export var a: Dictionary = {}
	@export var b: Dictionary = {test = 123, other_test = Vector2()}
```

Before:
```
[resource]
script = SubResource( 1 )
a = {

}
b = {
"other_test": Vector2( 0, 0 ),
"test": 123
}
```

After:
```
[gd_resource type="Resource" load_steps=2 format=2]

[sub_resource type="GDScript" id=1]

[resource]
script = SubResource( 1 )
a = {
}
b = {
"other_test": Vector2( 0, 0 ),
"test": 123
}
```