### PR TITLE
Implement add_directly to animation tree node add2 and add3

### DIFF
--- a/doc/classes/AnimationNodeAdd2.xml
+++ b/doc/classes/AnimationNodeAdd2.xml
@@ -15,6 +15,9 @@
 		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
 			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
 		</member>
+		<member name="add_directly" type="bool" setter="set_add_directly" getter="get_add_directly" default="false">
+			If [code]false[/code], adds the blended transformation after the subtraction of the difference. If [code]true[/code], adds the second transformation to first it directly.
+		</member>
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/AnimationNodeAdd3.xml
+++ b/doc/classes/AnimationNodeAdd3.xml
@@ -19,6 +19,9 @@
 		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
 			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
 		</member>
+		<member name="add_directly" type="bool" setter="set_add_directly" getter="get_add_directly" default="false">
+			If [code]false[/code], adds the blended transformation after the subtraction of the difference. If [code]true[/code], adds the first or third transformation to second it directly.
+		</member>
 	</members>
 	<constants>
 	</constants>

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -385,6 +385,14 @@ bool AnimationNodeAdd2::is_using_sync() const {
 	return sync;
 }
 
+void AnimationNodeAdd2::set_add_directly(bool p_add_directly) {
+	add_directly = p_add_directly;
+}
+
+bool AnimationNodeAdd2::get_add_directly() const {
+	return add_directly;
+}
+
 bool AnimationNodeAdd2::has_filter() const {
 	return true;
 }
@@ -392,7 +400,7 @@ bool AnimationNodeAdd2::has_filter() const {
 float AnimationNodeAdd2::process(float p_time, bool p_seek) {
 	float amount = get_parameter(add_amount);
 	float rem0 = blend_input(0, p_time, p_seek, 1.0, FILTER_IGNORE, !sync);
-	blend_input(1, p_time, p_seek, amount, FILTER_PASS, !sync);
+	blend_input(1, p_time, p_seek, amount, FILTER_PASS, !sync, add_directly);
 
 	return rem0;
 }
@@ -401,7 +409,11 @@ void AnimationNodeAdd2::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_sync", "enable"), &AnimationNodeAdd2::set_use_sync);
 	ClassDB::bind_method(D_METHOD("is_using_sync"), &AnimationNodeAdd2::is_using_sync);
 
+	ClassDB::bind_method(D_METHOD("set_add_directly", "enable"), &AnimationNodeAdd2::set_add_directly);
+	ClassDB::bind_method(D_METHOD("get_add_directly"), &AnimationNodeAdd2::get_add_directly);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync"), "set_use_sync", "is_using_sync");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "add_directly"), "set_add_directly", "get_add_directly");
 }
 
 AnimationNodeAdd2::AnimationNodeAdd2() {
@@ -409,6 +421,7 @@ AnimationNodeAdd2::AnimationNodeAdd2() {
 	add_input("in");
 	add_input("add");
 	sync = false;
+	add_directly = false;
 }
 
 ////////////////////////////////////////////////
@@ -433,15 +446,28 @@ bool AnimationNodeAdd3::is_using_sync() const {
 	return sync;
 }
 
+void AnimationNodeAdd3::set_add_directly(bool p_add_directly) {
+	add_directly = p_add_directly;
+}
+
+bool AnimationNodeAdd3::get_add_directly() const {
+	return add_directly;
+}
+
 bool AnimationNodeAdd3::has_filter() const {
 	return true;
 }
 
 float AnimationNodeAdd3::process(float p_time, bool p_seek) {
 	float amount = get_parameter(add_amount);
-	blend_input(0, p_time, p_seek, MAX(0, -amount), FILTER_PASS, !sync);
 	float rem0 = blend_input(1, p_time, p_seek, 1.0, FILTER_IGNORE, !sync);
-	blend_input(2, p_time, p_seek, MAX(0, amount), FILTER_PASS, !sync);
+	if (amount < 0) {
+		blend_input(0, p_time, p_seek, -amount, FILTER_PASS, !sync, add_directly);
+		blend_input(2, p_time, p_seek, 0, FILTER_PASS, !sync);
+	} else {
+		blend_input(2, p_time, p_seek, amount, FILTER_PASS, !sync, add_directly);
+		blend_input(0, p_time, p_seek, 0, FILTER_PASS, !sync);
+	}
 
 	return rem0;
 }
@@ -450,7 +476,11 @@ void AnimationNodeAdd3::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_sync", "enable"), &AnimationNodeAdd3::set_use_sync);
 	ClassDB::bind_method(D_METHOD("is_using_sync"), &AnimationNodeAdd3::is_using_sync);
 
+	ClassDB::bind_method(D_METHOD("set_add_directly", "enable"), &AnimationNodeAdd3::set_add_directly);
+	ClassDB::bind_method(D_METHOD("get_add_directly"), &AnimationNodeAdd3::get_add_directly);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync"), "set_use_sync", "is_using_sync");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "add_directly"), "set_add_directly", "get_add_directly");
 }
 
 AnimationNodeAdd3::AnimationNodeAdd3() {
@@ -459,6 +489,7 @@ AnimationNodeAdd3::AnimationNodeAdd3() {
 	add_input("in");
 	add_input("+add");
 	sync = false;
+	add_directly = false;
 }
 
 /////////////////////////////////////////////

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -134,6 +134,7 @@ class AnimationNodeAdd2 : public AnimationNode {
 
 	StringName add_amount;
 	bool sync;
+	bool add_directly;
 
 protected:
 	static void _bind_methods();
@@ -146,6 +147,9 @@ public:
 
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
+
+	void set_add_directly(bool p_add_directly);
+	bool get_add_directly() const;
 
 	virtual bool has_filter() const override;
 	virtual float process(float p_time, bool p_seek) override;
@@ -158,6 +162,7 @@ class AnimationNodeAdd3 : public AnimationNode {
 
 	StringName add_amount;
 	bool sync;
+	bool add_directly;
 
 protected:
 	static void _bind_methods();
@@ -170,6 +175,9 @@ public:
 
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
+
+	void set_add_directly(bool p_add_directly);
+	bool get_add_directly() const;
 
 	virtual bool has_filter() const override;
 	virtual float process(float p_time, bool p_seek) override;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -112,6 +112,7 @@ void AnimationNode::blend_animation(const StringName &p_animation, float p_time,
 	anim_state.time = p_time;
 	anim_state.animation = animation;
 	anim_state.seeked = p_seeked;
+	anim_state.add_directly = add_directly;
 
 	state->animation_states.push_back(anim_state);
 }
@@ -141,7 +142,7 @@ void AnimationNode::make_invalid(const String &p_reason) {
 	state->invalid_reasons += "- " + p_reason;
 }
 
-float AnimationNode::blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter, bool p_optimize) {
+float AnimationNode::blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter, bool p_optimize, bool p_add_directly) {
 	ERR_FAIL_INDEX_V(p_input, inputs.size(), 0);
 	ERR_FAIL_COND_V(!state, 0);
 
@@ -154,6 +155,9 @@ float AnimationNode::blend_input(int p_input, float p_time, bool p_seek, float p
 		String name = blend_tree->get_node_name(Ref<AnimationNode>(this));
 		make_invalid(vformat(RTR("Nothing connected to input '%s' of node '%s'."), get_input_name(p_input), name));
 		return 0;
+	} else {
+		Ref<AnimationNode> node = blend_tree->get_node(node_name);
+		node->add_directly = p_add_directly;
 	}
 
 	Ref<AnimationNode> node = blend_tree->get_node(node_name);
@@ -411,7 +415,7 @@ void AnimationNode::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("blend_animation", "animation", "time", "delta", "seeked", "blend"), &AnimationNode::blend_animation);
 	ClassDB::bind_method(D_METHOD("blend_node", "name", "node", "time", "seek", "blend", "filter", "optimize"), &AnimationNode::blend_node, DEFVAL(FILTER_IGNORE), DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("blend_input", "input_index", "time", "seek", "blend", "filter", "optimize"), &AnimationNode::blend_input, DEFVAL(FILTER_IGNORE), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("blend_input", "input_index", "time", "seek", "blend", "filter", "optimize", "add_directly"), &AnimationNode::blend_input, DEFVAL(FILTER_IGNORE), DEFVAL(true), DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("set_parameter", "name", "value"), &AnimationNode::set_parameter);
 	ClassDB::bind_method(D_METHOD("get_parameter", "name"), &AnimationNode::get_parameter);
@@ -922,16 +926,23 @@ void AnimationTree::_process_graph(float p_delta) {
 								continue;
 							}
 
-							t->loc = t->loc.lerp(loc, blend);
-							if (t->rot_blend_accum == 0) {
-								t->rot = rot;
-								t->rot_blend_accum = blend;
+							if (!as.add_directly) {
+								t->loc = t->loc.lerp(loc, blend);
+								if (t->rot_blend_accum == 0) {
+									t->rot = rot;
+									t->rot_blend_accum = blend;
+								} else {
+									float rot_total = t->rot_blend_accum + blend;
+									t->rot = rot.slerp(t->rot, t->rot_blend_accum / rot_total).normalized();
+									t->rot_blend_accum = rot_total;
+								}
+								t->scale = t->scale.lerp(scale, blend);
 							} else {
-								float rot_total = t->rot_blend_accum + blend;
-								t->rot = rot.slerp(t->rot, t->rot_blend_accum / rot_total).normalized();
-								t->rot_blend_accum = rot_total;
+								t->loc += loc * blend;
+								t->scale = t->scale.lerp(scale, blend);
+								Quat q = Quat().slerp(rot.normalized(), blend).normalized();
+								t->rot = (t->rot * q).normalized();
 							}
-							t->scale = t->scale.lerp(scale, blend);
 						}
 
 					} break;

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -68,6 +68,7 @@ public:
 		const Vector<float> *track_blends;
 		float blend;
 		bool seeked;
+		bool add_directly;
 	};
 
 	struct State {
@@ -94,6 +95,7 @@ public:
 
 	HashMap<NodePath, bool> filter;
 	bool filter_enabled;
+	bool add_directly;
 
 	Array _get_filters() const;
 	void _set_filters(const Array &p_filters);
@@ -103,7 +105,7 @@ public:
 protected:
 	void blend_animation(const StringName &p_animation, float p_time, float p_delta, bool p_seeked, float p_blend);
 	float blend_node(const StringName &p_sub_path, Ref<AnimationNode> p_node, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true);
-	float blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true);
+	float blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true, bool p_add_directly = false);
 	void make_invalid(const String &p_reason);
 
 	static void _bind_methods();


### PR DESCRIPTION
For [#37661](https://github.com/godotengine/godot/issues/37661)

The current algorithm adds the transformations after the subtraction of the difference.
So, for compatibility, I implemented a checkbox to add the transforms directly.
