### PR TITLE
OS: Remove unused get_splash_tick_msec

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -519,10 +519,6 @@ uint64_t _OS::get_ticks_usec() const {
 	return OS::get_singleton()->get_ticks_usec();
 }
 
-uint32_t _OS::get_splash_tick_msec() const {
-	return OS::get_singleton()->get_splash_tick_msec();
-}
-
 bool _OS::can_use_threads() const {
 	return OS::get_singleton()->can_use_threads();
 }
@@ -730,7 +726,6 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("delay_msec", "msec"), &_OS::delay_msec);
 	ClassDB::bind_method(D_METHOD("get_ticks_msec"), &_OS::get_ticks_msec);
 	ClassDB::bind_method(D_METHOD("get_ticks_usec"), &_OS::get_ticks_usec);
-	ClassDB::bind_method(D_METHOD("get_splash_tick_msec"), &_OS::get_splash_tick_msec);
 	ClassDB::bind_method(D_METHOD("get_locale"), &_OS::get_locale);
 	ClassDB::bind_method(D_METHOD("get_model_name"), &_OS::get_model_name);
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -208,7 +208,6 @@ public:
 	void delay_msec(uint32_t p_msec) const;
 	uint32_t get_ticks_msec() const;
 	uint64_t get_ticks_usec() const;
-	uint32_t get_splash_tick_msec() const;
 
 	bool can_use_threads() const;
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -80,10 +80,6 @@ String OS::get_iso_date_time(bool local) const {
 		   timezone;
 }
 
-uint64_t OS::get_splash_tick_msec() const {
-	return _msec_splash;
-}
-
 double OS::get_unix_time() const {
 	return 0;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -52,7 +52,6 @@ class OS {
 	bool _verbose_stdout = false;
 	bool _debug_stdout = false;
 	String _local_clipboard;
-	uint64_t _msec_splash;
 	bool _no_window = false;
 	int _exit_code = 0;
 	int _orientation;
@@ -220,7 +219,6 @@ public:
 
 	virtual uint64_t get_ticks_usec() const = 0;
 	uint32_t get_ticks_msec() const;
-	uint64_t get_splash_tick_msec() const;
 
 	virtual bool is_userfs_persistent() const { return true; }
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -234,13 +234,6 @@
 				Returns the number of threads available on the host machine.
 			</description>
 		</method>
-		<method name="get_splash_tick_msec" qualifiers="const">
-			<return type="int">
-			</return>
-			<description>
-				Returns the amount of time in milliseconds it took for the boot logo to appear.
-			</description>
-		</method>
 		<method name="get_static_memory_peak_usage" qualifiers="const">
 			<return type="int">
 			</return>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1569,7 +1569,6 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 		Color boot_bg_color = GLOBAL_DEF("application/boot_splash/bg_color", boot_splash_bg_color);
 		if (boot_logo.is_valid()) {
-			OS::get_singleton()->_msec_splash = OS::get_singleton()->get_ticks_msec();
 			RenderingServer::get_singleton()->set_boot_image(boot_logo, boot_bg_color, boot_logo_scale,
 					boot_logo_filter);
 


### PR DESCRIPTION
It was added in 3e20391bf607dc7c452b056854aed4a8c99ba0f6 but it doesn't seem
particularly useful, and it was only implemented for the custom splash branch
and not the default one, so it could return an uninitialized int.

---

Does anyone actually use this and wouldn't want it removed from the OS API?