### PR TITLE
Update Bullet Area overlaps when Area properties or shapes change.

### DIFF
--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -153,6 +153,7 @@ int AreaBullet::find_overlapping_object(CollisionObjectBullet *p_colObj) {
 
 void AreaBullet::set_monitorable(bool p_monitorable) {
 	monitorable = p_monitorable;
+	updated = true;
 }
 
 bool AreaBullet::is_monitoring() const {
@@ -162,6 +163,7 @@ bool AreaBullet::is_monitoring() const {
 void AreaBullet::main_shape_changed() {
 	CRASH_COND(!get_main_shape());
 	btGhost->setCollisionShape(get_main_shape());
+	updated = true;
 }
 
 void AreaBullet::reload_body() {
@@ -192,6 +194,7 @@ void AreaBullet::on_collision_filters_change() {
 	if (space) {
 		space->reload_collision_filters(this);
 	}
+	updated = true;
 }
 
 void AreaBullet::add_overlap(CollisionObjectBullet *p_otherObject) {
@@ -277,6 +280,7 @@ void AreaBullet::set_event_callback(Type p_callbackObjectType, ObjectID p_id, co
 		set_godot_object_flags(get_godot_object_flags() | GOF_IS_MONITORING_AREA);
 	} else {
 		set_godot_object_flags(get_godot_object_flags() & (~GOF_IS_MONITORING_AREA));
+		clear_overlaps(true);
 	}
 }
 

--- a/modules/bullet/area_bullet.h
+++ b/modules/bullet/area_bullet.h
@@ -154,7 +154,7 @@ public:
 
 	virtual void on_collision_filters_change();
 	virtual void on_collision_checker_start() {}
-	virtual void on_collision_checker_end() { isTransformChanged = false; }
+	virtual void on_collision_checker_end() { updated = false; }
 
 	void add_overlap(CollisionObjectBullet *p_otherObject);
 	void put_overlap_as_exit(int p_index);

--- a/modules/bullet/collision_object_bullet.cpp
+++ b/modules/bullet/collision_object_bullet.cpp
@@ -181,6 +181,7 @@ void CollisionObjectBullet::on_exit_area(AreaBullet *p_area) {
 
 void CollisionObjectBullet::set_godot_object_flags(int flags) {
 	bt_collision_object->setUserIndex2(flags);
+	updated = true;
 }
 
 int CollisionObjectBullet::get_godot_object_flags() const {
@@ -214,7 +215,7 @@ const btTransform &CollisionObjectBullet::get_transform__bullet() const {
 }
 
 void CollisionObjectBullet::notify_transform_changed() {
-	isTransformChanged = true;
+	updated = true;
 }
 
 RigidCollisionObjectBullet::~RigidCollisionObjectBullet() {

--- a/modules/bullet/collision_object_bullet.h
+++ b/modules/bullet/collision_object_bullet.h
@@ -128,7 +128,7 @@ protected:
 	/// New area is added when overlap with new area (AreaBullet::addOverlap), then is removed when it exit (CollisionObjectBullet::onExitArea)
 	/// This array is used mainly to know which area hold the pointer of this object
 	Vector<AreaBullet *> areasOverlapped;
-	bool isTransformChanged = false;
+	bool updated = false;
 
 public:
 	CollisionObjectBullet(Type p_type);
@@ -206,9 +206,9 @@ public:
 	Transform get_transform() const;
 	virtual void set_transform__bullet(const btTransform &p_global_transform);
 	virtual const btTransform &get_transform__bullet() const;
-
-	bool is_transform_changed() const { return isTransformChanged; }
 	virtual void notify_transform_changed();
+
+	bool is_updated() const { return updated; }
 };
 
 class RigidCollisionObjectBullet : public CollisionObjectBullet, public ShapeOwnerBullet {

--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -410,7 +410,7 @@ void RigidBodyBullet::on_collision_checker_start() {
 
 void RigidBodyBullet::on_collision_checker_end() {
 	// Always true if active and not a static or kinematic body
-	isTransformChanged = btBody->isActive() && !btBody->isStaticOrKinematicObject();
+	updated = btBody->isActive() && !btBody->isStaticOrKinematicObject();
 }
 
 bool RigidBodyBullet::add_collision_object(RigidBodyBullet *p_otherObject, const Vector3 &p_hitWorldLocation, const Vector3 &p_hitLocalLocation, const Vector3 &p_hitNormal, const float &p_appliedImpulse, int p_other_shape_index, int p_local_shape_index) {

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -684,7 +684,7 @@ void SpaceBullet::check_ghost_overlaps() {
 			RigidCollisionObjectBullet *otherObject = static_cast<RigidCollisionObjectBullet *>(overlapped_bt_co->getUserPointer());
 			btVector3 other_body_scale(otherObject->get_bt_body_scale());
 
-			if (!area->is_transform_changed() && !otherObject->is_transform_changed()) {
+			if (!area->is_updated() && !otherObject->is_updated()) {
 				hasOverlap = -1 != area->find_overlapping_object(otherObject);
 				goto collision_found;
 			}


### PR DESCRIPTION
Currently, `Area`s in Bullet physics only update the `CollisionObject`s they overlap with when they or the other objects are moved (or created). This PR ensures that `Area`s are updated and trigger any necessary signals when their properties or shapes change too including:
- Collision shape enabled or disabled
- Collision shape added or removed
- Collision shape properties changed
- Collision layers changed
- Collision mask changed
- Monitoring enabled or disabled
- Monitorable enabled or disabled (ensures other `Area`s are updated)

Fixes #22889
Fixes #39947
