### PR TITLE
i18n: Rename pt_PT to pt

### DIFF
--- a/editor/translations/pt.po
+++ b/editor/translations/pt.po
@@ -1,4 +1,4 @@
-# Portuguese (Portugal) translation of the Godot Engine editor
+# Portuguese translation of the Godot Engine editor
 # Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.
 # Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).
 # This file is distributed under the same license as the Godot source code.
@@ -22,9 +22,9 @@ msgstr ""
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2020-09-24 12:43+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
-"Language-Team: Portuguese (Portugal) <https://hosted.weblate.org/projects/"
-"godot-engine/godot/pt_PT/>\n"
-"Language: pt_PT\n"
+"Language-Team: Portuguese <https://hosted.weblate.org/projects/"
+"godot-engine/godot/pt/>\n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"


### PR DESCRIPTION
We originally used `pt_PT` (i.e. Portuguese (Portugal)) to distinguish with
the Brazilian Portuguese variant `pt_BR`, as both are significantly different
and need separate translation files.

But Portugal's Portuguese (or "European Portuguese") is close to the variant
spoken and written in other Portuguese-speaking countries such as Angola and
Mozambique, so it makes sense for users of these countries to also have access
to the European Portuguese translation (at least until translators decide that
adding e.g. `pt_AO` and `pt_MZ` variants would make sense, taking into account
the translation effort that this duplication implies).

Godot's locale matching checks first for the full locale (e.g. `pt_AO`), and
if no translation is found, it checks for the non-regional language code
(`pt`), so this change enables translations for Portuguese speakers outside
Portugal and Brazil.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
