### PR TITLE
Surrounds boolean false with code tag in doc

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -182,7 +182,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the vector is normalized, and false otherwise.
+				Returns [code]true[/code] if the vector is normalized, [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="length">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -157,7 +157,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the vector is normalized, and false otherwise.
+				Returns [code]true[/code] if the vector is normalized, [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="length">


### PR DESCRIPTION
When translating the class reference, I find the description hard to translate without the `false` being `[code]false[/code]`:

https://github.com/godotengine/godot/blob/c4903a603b819c6389f3a3a8a542be03a3a46aec/doc/classes/Vector2.xml#L181-L187

A quick search with `ag 'Returns \[code\]true.+otherwise\.' --ignore-dir doc/translations` shows that it's all phrased as 

> Returns [code]true[/code] if X, [code]false[/code] otherwise.

in other places. So I made this PR.