### PR TITLE
Fixed tile_set_editor_plugin.cpp selection issue where it wouldn't cycle through all subtiles of an autotile.

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -2133,7 +2133,6 @@ void TileSetEditor::_select_previous_tile() {
 				int spacing = tileset->autotile_get_spacing(get_current_tile());
 				Vector2 size = tileset->tile_get_region(get_current_tile()).size;
 				Vector2 cell_count = (size / (tileset->autotile_get_size(get_current_tile()) + Vector2(spacing, spacing))).floor();
-				cell_count -= Vector2(1, 1);
 				edited_shape_coord = cell_count;
 				_select_edited_shape_coord();
 			} break;
@@ -2190,11 +2189,11 @@ void TileSetEditor::_select_next_subtile() {
 		int spacing = tileset->autotile_get_spacing(get_current_tile());
 		Vector2 size = tileset->tile_get_region(get_current_tile()).size;
 		Vector2 cell_count = (size / (tileset->autotile_get_size(get_current_tile()) + Vector2(spacing, spacing))).floor();
-		if (edited_shape_coord.x >= cell_count.x - 1 && edited_shape_coord.y >= cell_count.y - 1) {
+		if (edited_shape_coord.x > cell_count.x - 1 && edited_shape_coord.y > cell_count.y - 1) {
 			_select_next_tile();
 		} else {
 			edited_shape_coord.x++;
-			if (edited_shape_coord.x >= cell_count.x) {
+			if (edited_shape_coord.x > cell_count.x) {
 				edited_shape_coord.x = 0;
 				edited_shape_coord.y++;
 			}
@@ -2221,7 +2220,7 @@ void TileSetEditor::_select_previous_subtile() {
 		} else {
 			edited_shape_coord.x--;
 			if (edited_shape_coord.x == -1) {
-				edited_shape_coord.x = cell_count.x - 1;
+				edited_shape_coord.x = cell_count.x;
 				edited_shape_coord.y--;
 			}
 			_select_edited_shape_coord();


### PR DESCRIPTION
Fixed issue where using arrows to change the selected tile would not iterate through all subtiles in an autotile, only going up to the second to last row and column.

**I am doing this PR in 3.2 in the basis that I tried using master but would crash upon execution of my compiled executabe.**

Closes  #42290

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
