### PR TITLE
Revert "Fix editor inspector refresh not working"

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1969,7 +1969,7 @@ void EditorInspector::refresh() {
 	if (refresh_countdown > 0 || changing) {
 		return;
 	}
-	refresh_countdown = refresh_interval_cache;
+	refresh_countdown = EditorSettings::get_singleton()->get("docks/property_editor/auto_refresh_interval");
 }
 
 Object *EditorInspector::get_edited_object() {
@@ -2332,8 +2332,6 @@ void EditorInspector::_node_removed(Node *p_node) {
 void EditorInspector::_notification(int p_what) {
 	if (p_what == NOTIFICATION_READY) {
 		EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &EditorInspector::_feature_profile_changed));
-		refresh_interval_cache = EDITOR_GET("docks/property_editor/auto_refresh_interval");
-		refresh_countdown = refresh_interval_cache;
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
@@ -2369,9 +2367,6 @@ void EditorInspector::_notification(int p_what) {
 					}
 				}
 			}
-		} else {
-			// Restart countdown if <= 0
-			refresh_countdown = refresh_interval_cache;
 		}
 
 		changing++;
@@ -2403,9 +2398,6 @@ void EditorInspector::_notification(int p_what) {
 		} else if (is_inside_tree()) {
 			add_theme_style_override("bg", get_theme_stylebox("bg", "Tree"));
 		}
-
-		refresh_interval_cache = EDITOR_GET("docks/property_editor/auto_refresh_interval");
-		refresh_countdown = refresh_interval_cache;
 
 		update_tree();
 	}
@@ -2570,7 +2562,6 @@ EditorInspector::EditorInspector() {
 	update_all_pending = false;
 	update_tree_pending = false;
 	refresh_countdown = 0;
-	refresh_interval_cache = 0;
 	read_only = false;
 	search_box = nullptr;
 	keying = false;

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -294,7 +294,6 @@ class EditorInspector : public ScrollContainer {
 	bool deletable_properties;
 
 	float refresh_countdown;
-	float refresh_interval_cache;
 	bool update_tree_pending;
 	StringName _prop_edited;
 	StringName property_selected;


### PR DESCRIPTION
Reverts godotengine/godot#41697

See discussion in #41697 and the follow-up regression fix #42106. The fix was "correct" but the original code is wrong and should be removed/replaced by a cleaner update system.

Fixes #41809.