### PR TITLE
Allow retrieval of FuncRef function string

### DIFF
--- a/core/func_ref.cpp
+++ b/core/func_ref.cpp
@@ -64,6 +64,10 @@ void FuncRef::set_function(const StringName &p_func) {
 	function = p_func;
 }
 
+StringName FuncRef::get_function() {
+	return function;
+}
+
 bool FuncRef::is_valid() const {
 	if (id.is_null()) {
 		return false;
@@ -89,5 +93,6 @@ void FuncRef::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_instance", "instance"), &FuncRef::set_instance);
 	ClassDB::bind_method(D_METHOD("set_function", "name"), &FuncRef::set_function);
+	ClassDB::bind_method(D_METHOD("get_function"), &FuncRef::get_function);
 	ClassDB::bind_method(D_METHOD("is_valid"), &FuncRef::is_valid);
 }

--- a/core/func_ref.h
+++ b/core/func_ref.h
@@ -46,6 +46,7 @@ public:
 	Variant call_funcv(const Array &p_args);
 	void set_instance(Object *p_obj);
 	void set_function(const StringName &p_func);
+	StringName get_function();
 	bool is_valid() const;
 
 	FuncRef() {}


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Recently I found myself generating a lot of function names dynamically and storing them up in `FuncRef` objects and as I was debugging the code I noticed we have no way of retrieving these function strings.

This PR fixes that.