### PR TITLE
Add all headers to Visual Studio Project

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -320,31 +320,6 @@ if selected_platform in platform_list:
         if env["tools"]:
             env["tests"] = True
 
-    if env["vsproj"]:
-        env.vs_incs = []
-        env.vs_srcs = []
-
-        def AddToVSProject(sources):
-            for x in sources:
-                if type(x) == type(""):
-                    fname = env.File(x).path
-                else:
-                    fname = env.File(x)[0].path
-                pieces = fname.split(".")
-                if len(pieces) > 0:
-                    basename = pieces[0]
-                    basename = basename.replace("\\\\", "/")
-                    if os.path.isfile(basename + ".h"):
-                        env.vs_incs = env.vs_incs + [basename + ".h"]
-                    elif os.path.isfile(basename + ".hpp"):
-                        env.vs_incs = env.vs_incs + [basename + ".hpp"]
-                    if os.path.isfile(basename + ".c"):
-                        env.vs_srcs = env.vs_srcs + [basename + ".c"]
-                    elif os.path.isfile(basename + ".cpp"):
-                        env.vs_srcs = env.vs_srcs + [basename + ".cpp"]
-
-        env.AddToVSProject = AddToVSProject
-
     env.extra_suffix = ""
 
     if env["extra_suffix"] != "":
@@ -645,6 +620,10 @@ if selected_platform in platform_list:
     if scons_cache_path != None:
         CacheDir(scons_cache_path)
         print("Scons cache enabled... (path: '" + scons_cache_path + "')")
+
+    if env["vsproj"]:
+        env.vs_incs = []
+        env.vs_srcs = []
 
     Export("env")
 

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -32,15 +32,6 @@ else:
 SConscript("png/SCsub")
 SConscript("spirv-reflect/SCsub")
 
-if env["vsproj"]:
-    import os
-
-    path = os.getcwd()
-    # Change directory so the path resolves correctly in the function call.
-    os.chdir("..")
-    env.AddToVSProject(env.drivers_sources)
-    os.chdir(path)
-
 env.add_source_files(env.drivers_sources, "*.cpp")
 
 lib = env.add_library("drivers", env.drivers_sources)

--- a/methods.py
+++ b/methods.py
@@ -7,6 +7,8 @@ from collections import OrderedDict
 # We need to define our own `Action` method to control the verbosity of output
 # and whenever we need to run those commands in a subprocess on some platforms.
 from SCons.Script import Action
+from SCons import Node
+from SCons.Script import Glob
 from platform_methods import run_in_subprocess
 
 
@@ -526,6 +528,35 @@ def generate_cpp_hint_file(filename):
             print("Could not write cpp.hint file.")
 
 
+def glob_recursive(pattern, node="."):
+    results = []
+    for f in Glob(str(node) + "/*", source=True):
+        if type(f) is Node.FS.Dir:
+            results += glob_recursive(pattern, f)
+    results += Glob(str(node) + "/" + pattern, source=True)
+    return results
+
+
+def add_to_vs_project(env, sources):
+    for x in sources:
+        if type(x) == type(""):
+            fname = env.File(x).path
+        else:
+            fname = env.File(x)[0].path
+        pieces = fname.split(".")
+        if len(pieces) > 0:
+            basename = pieces[0]
+            basename = basename.replace("\\\\", "/")
+            if os.path.isfile(basename + ".h"):
+                env.vs_incs += [basename + ".h"]
+            elif os.path.isfile(basename + ".hpp"):
+                env.vs_incs += [basename + ".hpp"]
+            if os.path.isfile(basename + ".c"):
+                env.vs_srcs += [basename + ".c"]
+            elif os.path.isfile(basename + ".cpp"):
+                env.vs_srcs += [basename + ".cpp"]
+
+
 def generate_vs_project(env, num_jobs):
     batch_file = find_visual_c_batch_file(env)
     if batch_file:
@@ -558,12 +589,16 @@ def generate_vs_project(env, num_jobs):
             result = " ^& ".join(common_build_prefix + [" ".join([commands] + common_build_postfix)])
             return result
 
-        env.AddToVSProject(env.core_sources)
-        env.AddToVSProject(env.main_sources)
-        env.AddToVSProject(env.modules_sources)
-        env.AddToVSProject(env.scene_sources)
-        env.AddToVSProject(env.servers_sources)
-        env.AddToVSProject(env.editor_sources)
+        add_to_vs_project(env, env.core_sources)
+        add_to_vs_project(env, env.drivers_sources)
+        add_to_vs_project(env, env.main_sources)
+        add_to_vs_project(env, env.modules_sources)
+        add_to_vs_project(env, env.scene_sources)
+        add_to_vs_project(env, env.servers_sources)
+        add_to_vs_project(env, env.editor_sources)
+
+        for header in glob_recursive("**/*.h"):
+            env.vs_incs.append(str(header))
 
         env["MSVSBUILDCOM"] = build_commandline("scons")
         env["MSVSREBUILDCOM"] = build_commandline("scons vsproj=yes")

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -26,10 +26,10 @@ prog = env.add_program("#bin/godot", common_win + res_obj, PROGSUFFIX=env["PROGS
 
 # Microsoft Visual Studio Project Generation
 if env["vsproj"]:
-    env.vs_srcs = env.vs_srcs + ["platform/windows/" + res_file]
-    env.vs_srcs = env.vs_srcs + ["platform/windows/godot.natvis"]
+    env.vs_srcs += ["platform/windows/" + res_file]
+    env.vs_srcs += ["platform/windows/godot.natvis"]
     for x in common_win:
-        env.vs_srcs = env.vs_srcs + ["platform/windows/" + str(x)]
+        env.vs_srcs += ["platform/windows/" + str(x)]
 
 if not os.getenv("VCINSTALLDIR"):
     if (env["debug_symbols"] == "full" or env["debug_symbols"] == "yes") and env["separate_debug_symbols"]:


### PR DESCRIPTION
Visual Studio project will display all Godot headers (including single header classes, like `cowdata.h`) in corresponding subfolders/filters instead of mixing some of them in External Dependencies. It doesn't matter for the build pipeline itself as it affects only VS project generation part and not which headers are passed to the compiler.

![cowdata](https://user-images.githubusercontent.com/1554127/94340711-19f09b00-0004-11eb-94cf-ed07f5f611fe.jpg)

Fixes #34371
