### PR TITLE
Add a Tightness parameter to AudioStreamPlayer3D

### DIFF
--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -103,6 +103,9 @@
 		<member name="stream_paused" type="bool" setter="set_stream_paused" getter="get_stream_paused" default="false">
 			If [code]true[/code], the playback is paused. You can resume it by setting [code]stream_paused[/code] to [code]false[/code].
 		</member>
+		<member name="tightness" type="float" setter="set_tightness" getter="get_tightness" default="4.0">
+			How much the sound will "enclose" the listener (more undirected / playing from speakers not facing the source). Lower values enclose more.
+		</member>
 		<member name="unit_db" type="float" setter="set_unit_db" getter="get_unit_db" default="0.0">
 			Base sound level unaffected by dampening, in dB.
 		</member>

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -675,11 +675,9 @@ float AudioStreamPlayer3D::get_max_db() const {
 }
 
 void AudioStreamPlayer3D::set_tightness(float p_tightness) {
-
 	tightness = p_tightness;
 }
 float AudioStreamPlayer3D::get_tightness() const {
-
 	return tightness;
 }
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -1023,7 +1023,7 @@ AudioStreamPlayer3D::AudioStreamPlayer3D() {
 	attenuation_model = ATTENUATION_INVERSE_DISTANCE;
 	max_db = 3;
 	pitch_scale = 1.0;
-    tightness = 4.0;
+	tightness = 4.0;
 	autoplay = false;
 	setseek = -1;
 	active = false;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -474,7 +474,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 
 				//TODO: The lower the second parameter (tightness) the more the sound will "enclose" the listener (more undirected / playing from
 				//      speakers not facing the source) - this could be made distance dependent.
-				_calc_output_vol(local_pos.normalized(), 4.0, output);
+				_calc_output_vol(local_pos.normalized(), tightness, output);
 
 				unsigned int cc = AudioServer::get_singleton()->get_channel_count();
 				for (unsigned int k = 0; k < cc; k++) {
@@ -672,6 +672,15 @@ void AudioStreamPlayer3D::set_max_db(float p_boost) {
 
 float AudioStreamPlayer3D::get_max_db() const {
 	return max_db;
+}
+
+void AudioStreamPlayer3D::set_tightness(float p_tightness) {
+
+	tightness = p_tightness;
+}
+float AudioStreamPlayer3D::get_tightness() const {
+
+	return tightness;
 }
 
 void AudioStreamPlayer3D::set_pitch_scale(float p_pitch_scale) {
@@ -912,6 +921,9 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_max_db", "max_db"), &AudioStreamPlayer3D::set_max_db);
 	ClassDB::bind_method(D_METHOD("get_max_db"), &AudioStreamPlayer3D::get_max_db);
 
+	ClassDB::bind_method(D_METHOD("set_tightness", "tightness"), &AudioStreamPlayer3D::set_tightness);
+	ClassDB::bind_method(D_METHOD("get_tightness"), &AudioStreamPlayer3D::get_tightness);
+
 	ClassDB::bind_method(D_METHOD("set_pitch_scale", "pitch_scale"), &AudioStreamPlayer3D::set_pitch_scale);
 	ClassDB::bind_method(D_METHOD("get_pitch_scale"), &AudioStreamPlayer3D::get_pitch_scale);
 
@@ -971,6 +983,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "unit_db", PROPERTY_HINT_RANGE, "-80,80"), "set_unit_db", "get_unit_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "unit_size", PROPERTY_HINT_RANGE, "0.1,100,0.1"), "set_unit_size", "get_unit_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_db", PROPERTY_HINT_RANGE, "-24,6"), "set_max_db", "get_max_db");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tightness", PROPERTY_HINT_RANGE, "0,8"), "set_tightness", "get_tightness");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "_set_playing", "is_playing");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay_enabled");
@@ -1010,6 +1023,7 @@ AudioStreamPlayer3D::AudioStreamPlayer3D() {
 	attenuation_model = ATTENUATION_INVERSE_DISTANCE;
 	max_db = 3;
 	pitch_scale = 1.0;
+    tightness = 4.0;
 	autoplay = false;
 	setseek = -1;
 	active = false;

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -161,7 +161,7 @@ public:
 
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;
-    
+
 	void set_tightness(float p_tightness);
 	float get_tightness() const;
 

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -107,7 +107,7 @@ private:
 	float unit_size;
 	float max_db;
 	float pitch_scale;
-    float tightness;
+	float tightness;
 	bool autoplay;
 	bool stream_paused;
 	bool stream_paused_fade_in;

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -107,6 +107,7 @@ private:
 	float unit_size;
 	float max_db;
 	float pitch_scale;
+    float tightness;
 	bool autoplay;
 	bool stream_paused;
 	bool stream_paused_fade_in;
@@ -160,6 +161,9 @@ public:
 
 	void set_pitch_scale(float p_pitch_scale);
 	float get_pitch_scale() const;
+    
+	void set_tightness(float p_tightness);
+	float get_tightness() const;
 
 	void play(float p_from_pos = 0.0);
 	void seek(float p_seconds);


### PR DESCRIPTION
Allows this parameter for the sound algorithm in AudioStreamPlayer3D to be modified.

I didn't like the fact that an object directly on my left would only play through the left channel with 0 in the right, seemed too artificial for me. Now I can customize it as I like! :)

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/3384.*