### PR TITLE
Increment index when populating PhysicsShapeQueryParameters exclude array.

### DIFF
--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -197,7 +197,7 @@ Vector<RID> PhysicsShapeQueryParameters2D::get_exclude() const {
 	ret.resize(exclude.size());
 	int idx = 0;
 	for (Set<RID>::Element *E = exclude.front(); E; E = E->next()) {
-		ret.write[idx] = E->get();
+		ret.write[idx++] = E->get();
 	}
 	return ret;
 }

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -193,7 +193,7 @@ Vector<RID> PhysicsShapeQueryParameters3D::get_exclude() const {
 	ret.resize(exclude.size());
 	int idx = 0;
 	for (Set<RID>::Element *E = exclude.front(); E; E = E->next()) {
-		ret.write[idx] = E->get();
+		ret.write[idx++] = E->get();
 	}
 	return ret;
 }


### PR DESCRIPTION
While investigating #39887, I noticed that when getting the `PhysicsShapeQueryParameters` exclude array, the index used to populate the returned `Vector` isn't being incremented; so only the first element gets populated with the last entry. This PR increments the index so the returned `Vector` is properly populated.
