### PR TITLE
Fix undo for moving multiple visual shader nodes

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -261,7 +261,16 @@ class VisualShaderEditor : public VBoxContainer {
 
 	static VisualShaderEditor *singleton;
 
+	struct DragOp {
+		VisualShader::Type type;
+		int node;
+		Vector2 from;
+		Vector2 to;
+	};
+	List<DragOp> drag_buffer;
+	bool drag_dirty = false;
 	void _node_dragged(const Vector2 &p_from, const Vector2 &p_to, int p_node);
+	void _nodes_dragged();
 	bool updating;
 
 	void _connection_request(const String &p_from, int p_from_index, const String &p_to, int p_to_index);


### PR DESCRIPTION
Currently moving multiple nodes at once takes one action but to undo this it requires multiple which is incorrect...
![vs_bug](https://user-images.githubusercontent.com/3036176/94363409-9f3e8300-00ca-11eb-8e5d-a9351e3e43e6.gif)
