### PR TITLE
fix slipping move_and_slide() on moving platform when stop_on_slope is true

### DIFF
--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -318,8 +318,8 @@ public:
 	void set_safe_margin(float p_margin);
 	float get_safe_margin() const;
 
-	Vector2 move_and_slide(const Vector2 &p_linear_velocity, const Vector2 &p_up_direction = Vector2(0, 0), bool p_stop_on_slope = false, int p_max_slides = 4, float p_floor_max_angle = Math::deg2rad((float)45), bool p_infinite_inertia = true);
-	Vector2 move_and_slide_with_snap(const Vector2 &p_linear_velocity, const Vector2 &p_snap, const Vector2 &p_up_direction = Vector2(0, 0), bool p_stop_on_slope = false, int p_max_slides = 4, float p_floor_max_angle = Math::deg2rad((float)45), bool p_infinite_inertia = true);
+	Vector2 move_and_slide(const Vector2 &p_linear_velocity, const Vector2 &p_up_direction = Vector2(0, 0), bool p_stop_on_slope = false, int p_max_slides = 4, float p_floor_max_angle = Math::deg2rad((float)45), bool p_infinite_inertia = true, float p_floor_velocity_amount = float(1));
+	Vector2 move_and_slide_with_snap(const Vector2 &p_linear_velocity, const Vector2 &p_snap, const Vector2 &p_up_direction = Vector2(0, 0), bool p_stop_on_slope = false, int p_max_slides = 4, float p_floor_max_angle = Math::deg2rad((float)45), bool p_infinite_inertia = true, float p_floor_velocity_amount = float(1));
 	bool is_on_floor() const;
 	bool is_on_wall() const;
 	bool is_on_ceiling() const;

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -318,8 +318,8 @@ public:
 	void set_safe_margin(float p_margin);
 	float get_safe_margin() const;
 
-	Vector3 move_and_slide(const Vector3 &p_linear_velocity, const Vector3 &p_up_direction = Vector3(0, 0, 0), bool p_stop_on_slope = false, int p_max_slides = 4, float p_floor_max_angle = Math::deg2rad((float)45), bool p_infinite_inertia = true);
-	Vector3 move_and_slide_with_snap(const Vector3 &p_linear_velocity, const Vector3 &p_snap, const Vector3 &p_up_direction = Vector3(0, 0, 0), bool p_stop_on_slope = false, int p_max_slides = 4, float p_floor_max_angle = Math::deg2rad((float)45), bool p_infinite_inertia = true);
+	Vector3 move_and_slide(const Vector3 &p_linear_velocity, const Vector3 &p_up_direction = Vector3(0, 0, 0), bool p_stop_on_slope = false, int p_max_slides = 4, float p_floor_max_angle = Math::deg2rad((float)45), bool p_infinite_inertia = true, float p_floor_velocity_amount = float(1));
+	Vector3 move_and_slide_with_snap(const Vector3 &p_linear_velocity, const Vector3 &p_snap, const Vector3 &p_up_direction = Vector3(0, 0, 0), bool p_stop_on_slope = false, int p_max_slides = 4, float p_floor_max_angle = Math::deg2rad((float)45), bool p_infinite_inertia = true, float p_floor_velocity_amount = float(1));
 	bool is_on_floor() const;
 	bool is_on_wall() const;
 	bool is_on_ceiling() const;


### PR DESCRIPTION
Stopped KinematicBody has slipping on moving floor in spite of `stop_on_slope` in `move_and_slide_with_snap()` is `true`. This is because the stopping KinematicBody can't pass slide check as follows. It is related to [#30311](https://github.com/godotengine/godot/issues/30311).

![kbfix_01](https://user-images.githubusercontent.com/61938263/94366749-3fb99500-0115-11eb-93d9-bbe9fb45a745.gif)

`Vector3 KinematicBody::move_and_slide()` in `physics_body.cpp`
```cpp
if (p_stop_on_slope) {
	if ((body_velocity_normal + up_direction).length() < 0.01 && collision.travel.length() < 1) {
```

so you can fix it as follows

`Vector3 KinematicBody::move_and_slide()` in `physics_body.cpp`
```cpp
Vector3 body_velocity = p_linear_velocity;
Vector3 body_velocity_normal = body_velocity.normalized();
```
to
```cpp
Vector3 body_velocity = p_linear_velocity;
Vector3 body_velocity_normal = (body_velocity + floor_velocity).normalized();
```

![kbfix_02](https://user-images.githubusercontent.com/61938263/94366760-56f88280-0115-11eb-9525-6eef0108463d.gif)

*But this stuff doesn't matter, so there is a more fundamental problem. Prease pretend you didn't see the fix above.*

---

KinematicBody has slipping on **moving slope floor** in spite of `stop_on_slope` in `move_and_slide_with_snap()` is `true`. This is because `floor_velocity` will pass to `move_and_collide()`  in `move_and_slide()`. So I can guess there is that problem in `PhysicsServer`.

![kbfix_03](https://user-images.githubusercontent.com/61938263/94366777-68da2580-0115-11eb-970d-904dd479f529.gif)

You can solve this problem with adding floor_velocity directly to global_transform as follows.

`Vector3 KinematicBody::move_and_slide()` in `physics_body.cpp`
```cpp
// Hack in order to work with calling from _process as well as from _physics_process; calling from thread is risky
Vector3 motion = (floor_velocity + body_velocity) * (Engine::get_singleton()->is_in_physics_frame() ? get_physics_process_delta_time() : get_process_delta_time());
```
to
```cpp
// Hack in order to work with calling from _process as well as from _physics_process; calling from thread is risky
float delta_time = Engine::get_singleton()->is_in_physics_frame() ? get_physics_process_delta_time() : get_process_delta_time();
Vector3 motion = body_velocity * delta_time;
if (floor_velocity != Vector3()) {
	Vector3 floor_motion = floor_velocity * delta_time;
	Transform gt = get_global_transform();
	gt.origin += floor_motion;
	set_global_transform(gt);
}
```

![kbfix_04](https://user-images.githubusercontent.com/61938263/94366804-7a233200-0115-11eb-98f8-5852cc7df34d.gif)

Immediately after, the KinematicBody will check colliding with using `body_velocity` and `move_and_collide()`, so there is no extreme stuck. However, if `move_and_collide()` needs velocity: `body_velocity + floor_velocity` in the future, we need to rethink the `PhysicsServer` behavior while retaining the original logic.

I sent PR, but if you don't like this behavior, we could simply add an option to not calculate `floor_velocity` in `move_and_slide()` and leave it to the user how to apply `floor_velocity`.

Anyway, I think it's debatable.

[kinematic_test.zip](https://github.com/godotengine/godot/files/5288397/kinematic_test.zip)
