### PR TITLE
Remove link to step-by-step/animations tutorial

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -9,7 +9,6 @@
 		Updating the target properties of animations occurs at process time.
 	</description>
 	<tutorials>
-		<link title="Animations">https://docs.godotengine.org/en/latest/getting_started/step_by_step/animations.html</link>
 		<link title="2D Sprite animation">https://docs.godotengine.org/en/latest/tutorials/2d/2d_sprite_animation.html</link>
 		<link title="Animation tutorial index">https://docs.godotengine.org/en/latest/tutorials/animation/index.html</link>
 	</tutorials>


### PR DESCRIPTION
Required for godotengine/godot-docs#4074 to pass, we're removing that
page from the docs as part of the audit and getting started section rewrite.