### PR TITLE
Trigger RigidBodyBullet space override updates when Area properties change.

### DIFF
--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -82,8 +82,14 @@ void AreaBullet::dispatch_callbacks() {
 				otherObj.object->on_exit_area(this);
 				overlappingObjects.remove(i); // Remove after callback
 				break;
+			case OVERLAP_STATE_INSIDE: {
+				if (otherObj.object->getType() == TYPE_RIGID_BODY) {
+					RigidBodyBullet *body = static_cast<RigidBodyBullet *>(otherObj.object);
+					body->scratch_space_override_modificator();
+				}
+				break;
+			}
 			case OVERLAP_STATE_DIRTY:
-			case OVERLAP_STATE_INSIDE:
 				break;
 		}
 	}
@@ -240,6 +246,7 @@ void AreaBullet::set_param(PhysicsServer3D::AreaParameter p_param, const Variant
 		default:
 			WARN_PRINT("Area doesn't support this parameter in the Bullet backend: " + itos(p_param));
 	}
+	scratch();
 }
 
 Variant AreaBullet::get_param(PhysicsServer3D::AreaParameter p_param) const {


### PR DESCRIPTION
Currently, in Bullet physics, if an `Area's` properties change, any `RigidBody` that is already within the `Area` is not affected by the change.

This PR ensures that when the following `Area` properties are changed, the `RigidBodies` already enclosed in the `Area` are informed of the change and are updated accordingly:
- The `Gravity` magnitude.
- The `Gravity` direction `Vector`.
- Whether or not the `Area` is a `Gravity Point`.
- The `Gravity Point` location.
- The `Gravity Point` fall-off `Distance`.
- The `Linear Damp`
- The `Angular Damp`

Fixes #32776

Registering changes to whether or not the `Area` is `Monitoring` or `Monitorable` is fixed with #42306.

Note: Changes to the `Area`'s priority being ignored at runtime are not fixed with this PR or #42306.