### PR TITLE
Make YSort stable

### DIFF
--- a/servers/rendering/rendering_server_canvas.cpp
+++ b/servers/rendering/rendering_server_canvas.cpp
@@ -81,6 +81,7 @@ void _collect_ysort_children(RenderingServerCanvas::Item *p_canvas_item, Transfo
 				child_items[i]->ysort_xform = p_transform;
 				child_items[i]->ysort_pos = p_transform.xform(child_items[i]->xform.elements[2]);
 				child_items[i]->material_owner = child_items[i]->use_parent_material ? p_material_owner : nullptr;
+				child_items[i]->ysort_index = r_index;
 			}
 
 			r_index++;

--- a/servers/rendering/rendering_server_canvas.h
+++ b/servers/rendering/rendering_server_canvas.h
@@ -51,6 +51,7 @@ public:
 		Color ysort_modulate;
 		Transform2D ysort_xform;
 		Vector2 ysort_pos;
+		int ysort_index;
 		RS::CanvasItemTextureFilter texture_filter;
 		RS::CanvasItemTextureRepeat texture_repeat;
 
@@ -69,6 +70,7 @@ public:
 			ysort_children_count = -1;
 			ysort_xform = Transform2D();
 			ysort_pos = Vector2();
+			ysort_index = 0;
 			texture_filter = RS::CANVAS_ITEM_TEXTURE_FILTER_DEFAULT;
 			texture_repeat = RS::CANVAS_ITEM_TEXTURE_REPEAT_DEFAULT;
 		}
@@ -83,7 +85,7 @@ public:
 	struct ItemPtrSort {
 		_FORCE_INLINE_ bool operator()(const Item *p_left, const Item *p_right) const {
 			if (Math::is_equal_approx(p_left->ysort_pos.y, p_right->ysort_pos.y)) {
-				return p_left->ysort_pos.x < p_right->ysort_pos.x;
+				return p_left->ysort_index < p_right->ysort_index;
 			}
 
 			return p_left->ysort_pos.y < p_right->ysort_pos.y;


### PR DESCRIPTION
Keeps track of the order in which items are collected by
`_collect_ysort_children`, and uses that order to break
ties between items with similar Y positions.

Closes https://github.com/godotengine/godot/issues/33230.