### PR TITLE
Allow using a comma as decimal separator in EditorSpinSlider

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -356,7 +356,12 @@ String EditorSpinSlider::get_label() const {
 }
 
 void EditorSpinSlider::_evaluate_input_text() {
-	String text = value_input->get_text();
+	// Replace comma with dot to support it as decimal separator (GH-6028).
+	// This prevents using functions like `pow()`, but using functions
+	// in EditorSpinSlider is a barely known (and barely used) feature.
+	// Instead, we'd rather support German/French keyboard layouts out of the box.
+	const String text = value_input->get_text().replace(",", ".");
+
 	Ref<Expression> expr;
 	expr.instance();
 	Error err = expr->parse(text);


### PR DESCRIPTION
Replacing the comma with a dot prevents using functions like `pow()`, but using functions in EditorSpinSlider is a barely known (and barely used) feature. Instead, we'd rather support German/French keyboard layouts out of the box.

This closes https://github.com/godotengine/godot-proposals/issues/1576.