### PR TITLE
Document how to display the vertex color in `SurfaceTool.add_color()`

### DIFF
--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -38,6 +38,7 @@
 			</argument>
 			<description>
 				Specifies a [Color] for the next vertex to use.
+				[b]Note:[/b] The material must have [member BaseMaterial3D.vertex_color_use_as_albedo] enabled for the vertex color to be visible.
 			</description>
 		</method>
 		<method name="add_index">


### PR DESCRIPTION
Thanks to @theoway for providing the description (which I modified) :slightly_smiling_face:

This closes https://github.com/godotengine/godot-docs/issues/4083.

**Note:** When cherry-picking to the `3.2` branch, replace the BaseMaterial3D references with SpatialMaterial.