### PR TITLE
Restore default alpha_scissor_threshold to Sprite3D

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -394,6 +394,7 @@ SpriteBase3D::SpriteBase3D() {
 	VS::get_singleton()->material_set_param(material, "uv1_scale", Vector3(1, 1, 1));
 	VS::get_singleton()->material_set_param(material, "uv2_offset", Vector3(0, 0, 0));
 	VS::get_singleton()->material_set_param(material, "uv2_scale", Vector3(1, 1, 1));
+	VS::get_singleton()->material_set_param(material, "alpha_scissor_threshold", 0.98);
 
 	mesh = VisualServer::get_singleton()->mesh_create();
 


### PR DESCRIPTION
Fixes: #42326

This is another regression from the Sprite3D change. My apologies.

It was just missing a default value for ``alpha_scissor_threshold``. Without a default value, the threshold was defaulting to ``0.0`` instead of ``0.98``.
