### PR TITLE
Hide special folders in FileDialog for macOS

### DIFF
--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -152,7 +152,7 @@ String DirAccessUnix::get_next() {
 		_cisdir = (entry->d_type == DT_DIR);
 	}
 
-	_cishidden = (fname != "." && fname != ".." && fname.begins_with("."));
+	_cishidden = is_hidden(fname);
 
 	return fname;
 }
@@ -398,6 +398,10 @@ size_t DirAccessUnix::get_space_left() {
 
 String DirAccessUnix::get_filesystem_type() const {
 	return ""; //TODO this should be implemented
+}
+
+bool DirAccessUnix::is_hidden(const String &p_name) {
+	return p_name != "." && p_name != ".." && p_name.begins_with(".");
 }
 
 DirAccessUnix::DirAccessUnix() {

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -51,6 +51,7 @@ class DirAccessUnix : public DirAccess {
 
 protected:
 	virtual String fix_unicode_name(const char *p_name) const { return String::utf8(p_name); }
+	virtual bool is_hidden(const String &p_name);
 
 public:
 	virtual Error list_dir_begin(); ///< This starts dir listing

--- a/platform/osx/dir_access_osx.h
+++ b/platform/osx/dir_access_osx.h
@@ -47,6 +47,8 @@ protected:
 
 	virtual int get_drive_count();
 	virtual String get_drive(int p_drive);
+
+	virtual bool is_hidden(const String &p_name);
 };
 
 #endif //UNIX ENABLED

--- a/platform/osx/dir_access_osx.mm
+++ b/platform/osx/dir_access_osx.mm
@@ -68,4 +68,14 @@ String DirAccessOSX::get_drive(int p_drive) {
 	return volname;
 }
 
+bool DirAccessOSX::is_hidden(const String &p_name) {
+	String f = get_current_dir().plus_file(p_name);
+	NSURL *url = [NSURL fileURLWithPath:@(f.utf8().get_data())];
+	NSNumber *hidden = nil;
+	if (![url getResourceValue:&hidden forKey:NSURLIsHiddenKey error:nil]) {
+		return DirAccessUnix::is_hidden(p_name);
+	}
+	return [hidden boolValue];
+}
+
 #endif //posix_enabled


### PR DESCRIPTION
This PR makes folders that are normally not displayed to users on macOS as hidden files in a FileDialog. They are still accessible via the "Toggle the visibility of hidden files" button.

Example of such folders:

* `/usr`
* `~/Library`

These folders are hidden by default in the macOS Finder and Blender's file view.

This falls back to the original "starts with dot" approach in case of API failure.

The `is_hidden` function is not marked as `const` because it has to call the non-`const` function `get_current_dir`.

Tested on the current master and 3.2 branch.