### PR TITLE
Lowered the number of map look up calls

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -55,10 +55,11 @@ void InputMap::_bind_methods() {
 
 void InputMap::add_action(const StringName &p_action, float p_deadzone) {
 	ERR_FAIL_COND_MSG(input_map.has(p_action), "InputMap already has action '" + String(p_action) + "'.");
-	input_map[p_action] = Action();
 	static int last_id = 1;
-	input_map[p_action].id = last_id;
-	input_map[p_action].deadzone = p_deadzone;
+	Action action;
+	action.id = last_id;
+	action.deadzone = p_deadzone;
+	input_map[p_action] = action;
 	last_id++;
 }
 


### PR DESCRIPTION
Does this not make more sense here? It saves 2 map look up calls at the expense of creating a variable on the stack

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
