### PR TITLE
Don't warp mouse when selecting tracks

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4959,11 +4959,6 @@ void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
 		box_selection->set_size(rect.size);
 
 		box_select_rect = rect;
-
-		if (get_local_mouse_position().y < 0) {
-			//avoid box selection from going up and lose focus to viewport
-			warp_mouse(Vector2(mm->get_position().x, 0));
-		}
 	}
 }
 


### PR DESCRIPTION
Closes #27780

Seems like the viewport isn't focused when you hold the mouse button, so this should be fine to remove. Not sure if on 3.2 branch it will work the same.