### PR TITLE
Move generated translation files into `res://.godot/translations`

### DIFF
--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -111,6 +111,7 @@ class TranslationServer : public Object {
 
 public:
 	_FORCE_INLINE_ static TranslationServer *get_singleton() { return singleton; }
+	inline static const String TRANSLATION_FILES_PATH = "res://.godot/translations";
 
 	void set_enabled(bool p_enabled) { enabled = p_enabled; }
 	_FORCE_INLINE_ bool is_enabled() const { return enabled; }


### PR DESCRIPTION
Follow up to #38607. Implements and closes https://github.com/godotengine/godot-proposals/issues/1812.

This moves the generated `.translation` files into a subfolder of `res://.godot` called `res://.godot/translations` (defined as a constant: `TranslationServer::TRANSLATION_FILES_PATH`). These files are generated and don't need to be committed, which is the goal of the `res://.godot` folder.

Note that projects need to be manually updated, since `project.godot` explicitly references the translation files. For example, the translation demo contains `res://text.en.translation` in `project.godot`.

The simplest solution was to make the contents of this folder replicate the folder structure of the project, so a file `res://subfolder/text.csv` gets imported as `res://.godot/translations/subfolder/text.en.translation` etc. Because the generated translation files have to be referenced explicitly, I think this is actually really nice.

~~Another question is what to call this folder. I think "translation" is nice because it contains `.translation` files, but one could make the argument that this folder should be called "translation**s**" instead.~~