### PR TITLE
Move project-specific editor data into res://.godot/editor

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -959,27 +959,16 @@ void EditorSettings::create() {
 
 		_create_script_templates(dir->get_current_dir().plus_file("script_templates"));
 
-		if (dir->change_dir("projects") != OK) {
-			dir->make_dir("projects");
-		} else {
-			dir->change_dir("..");
+		{
+			// Validate/create project-specific editor settings dir.
+			DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+			if (da->change_dir(EditorSettings::PROJECT_EDITOR_SETTINGS_PATH) != OK) {
+				Error err = da->make_dir_recursive(EditorSettings::PROJECT_EDITOR_SETTINGS_PATH);
+				if (err || da->change_dir(EditorSettings::PROJECT_EDITOR_SETTINGS_PATH) != OK) {
+					ERR_FAIL_MSG("Failed to create '" + EditorSettings::PROJECT_EDITOR_SETTINGS_PATH + "' folder.");
+				}
+			}
 		}
-
-		// Validate/create project-specific config dir
-
-		dir->change_dir("projects");
-		String project_config_dir = ProjectSettings::get_singleton()->get_resource_path();
-		if (project_config_dir.ends_with("/")) {
-			project_config_dir = config_path.substr(0, project_config_dir.size() - 1);
-		}
-		project_config_dir = project_config_dir.get_file() + "-" + project_config_dir.md5_text();
-
-		if (dir->change_dir(project_config_dir) != OK) {
-			dir->make_dir(project_config_dir);
-		} else {
-			dir->change_dir("..");
-		}
-		dir->change_dir("..");
 
 		// Validate editor config file
 
@@ -1001,7 +990,6 @@ void EditorSettings::create() {
 
 		singleton->save_changed_setting = true;
 		singleton->config_file_path = config_file_path;
-		singleton->project_config_dir = project_config_dir;
 		singleton->settings_dir = config_dir;
 		singleton->data_dir = data_dir;
 		singleton->cache_dir = cache_dir;
@@ -1277,7 +1265,7 @@ String EditorSettings::get_settings_dir() const {
 }
 
 String EditorSettings::get_project_settings_dir() const {
-	return get_settings_dir().plus_file("projects").plus_file(project_config_dir);
+	return EditorSettings::PROJECT_EDITOR_SETTINGS_PATH;
 }
 
 String EditorSettings::get_text_editor_themes_dir() const {

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -46,6 +46,7 @@ class EditorSettings : public Resource {
 	_THREAD_SAFE_CLASS_
 
 public:
+	inline static const String PROJECT_EDITOR_SETTINGS_PATH = "res://.godot/editor";
 	struct Plugin {
 		EditorPlugin *instance = nullptr;
 		String path;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/282, follow up to #38607, fixes #42578. This PR moves the project-specific editor data files into a subfolder of `res://.godot` called `res://.godot/editor` (defined as a constant: `EditorSettings::EDITOR_FILES_PATH`). 

One advantage of this change is that it's easy to delete a project without leaving any files behind. Another advantage is that if you screw up the editor settings for your project, it's very easy to reset them by deleting `res://.godot` (or just `res://.godot/editor`). A third advantage is that if you move a project to a different location, your editor settings are still there (previously the editor settings were stored in a location with the MD5 sum of the project path, so if the path changes then you lose the settings).

A change that people may or may not see as an advantage is that if you ZIP up a project without deleting the `res://.godot/editor` folder, you will share the project-specific editor settings with the recipient of that ZIP file, so they should see exactly what you see (in terms of editor layout, but not non-project-specific settings like the theme or font size).

A question remains about whether or not this should be configurable. It makes the code a lot simpler to just make it always inside the project, but maybe some people wouldn't like this behavior.