### PR TITLE
Describe `ImageTexture`, `Image` creation and usage

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -4,10 +4,12 @@
 		Image datatype.
 	</brief_description>
 	<description>
-		Native image datatype. Contains image data, which can be converted to a [Texture2D], and several functions to interact with it. The maximum width and height for an [Image] are [constant MAX_WIDTH] and [constant MAX_HEIGHT].
-		[b]Note:[/b] The maximum image size is 16384×16384 pixels due to graphics hardware limitations. Larger images will fail to import.
+		Native image datatype. Contains image data which can be converted to an [ImageTexture] and provides commonly used [i]image processing[/i] methods. The maximum width and height for an [Image] are [constant MAX_WIDTH] and [constant MAX_HEIGHT].
+		An [Image] cannot be assigned to a [code]texture[/code] property of an object directly (such as [Sprite2D]), and has to be converted manually to an [ImageTexture] first.
+		[b]Note:[/b] The maximum image size is 16384×16384 pixels due to graphics hardware limitations. Larger images may fail to import.
 	</description>
 	<tutorials>
+		<link title="Importing images">https://docs.godotengine.org/en/latest/getting_started/workflow/assets/importing_images.html</link>
 	</tutorials>
 	<methods>
 		<method name="blend_rect">
@@ -344,6 +346,8 @@
 			</argument>
 			<description>
 				Loads an image from file [code]path[/code]. See [url=https://docs.godotengine.org/en/latest/getting_started/workflow/assets/importing_images.html#supported-image-formats]Supported image formats[/url] for a list of supported image formats and limitations.
+				[b]Warning:[/b] This method should only be used in the editor or in cases when you need to load external images at run-time, such as images located at the [code]user://[/code] directory, and may not work in exported projects.
+				See also [ImageTexture] description for usage examples.
 			</description>
 		</method>
 		<method name="load_bmp_from_buffer">

--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -4,10 +4,31 @@
 		A [Texture2D] based on an [Image].
 	</brief_description>
 	<description>
-		A [Texture2D] based on an [Image]. Can be created from an [Image] with [method create_from_image].
-		[b]Note:[/b] The maximum image size is 16384×16384 pixels due to graphics hardware limitations. Larger images will fail to import.
+		A [Texture2D] based on an [Image]. For an image to be displayed, an [ImageTexture] has to be created from it using the [method create_from_image] method:
+		[codeblock]
+		var texture = ImageTexture.new()
+		var image = Image.new()
+		image.load("res://icon.png")
+		texture.create_from_image(image)
+		$Sprite2D.texture = texture
+		[/codeblock]
+		This way, textures can be created at run-time by loading images both from within the editor and externally.
+		[b]Warning:[/b] Prefer to load imported textures with [method @GDScript.load] over loading them from within the filesystem dynamically with [method Image.load], as it may not work in exported projects:
+		[codeblock]
+		var texture = load("res://icon.png")
+		$Sprite2D.texture = texture
+		[/codeblock]
+		This is because images have to be imported as [StreamTexture2D] first to be loaded with [method @GDScript.load]. If you'd still like to load an image file just like any other [Resource], import it as an [Image] resource instead, and then load it normally using the [method @GDScript.load] method.
+		But do note that the image data can still be retrieved from an imported texture as well using the [method Texture2D.get_data] method, which returns a copy of the data:
+		[codeblock]
+		var texture = load("res://icon.png")
+		var image : Image = texture.get_data()
+		[/codeblock]
+		An [ImageTexture] is not meant to be operated from within the editor interface directly, and is mostly useful for rendering images on screen dynamically via code. If you need to generate images procedurally from within the editor, consider saving and importing images as custom texture resources implementing a new [EditorImportPlugin].
+		[b]Note:[/b] The maximum texture size is 16384×16384 pixels due to graphics hardware limitations.
 	</description>
 	<tutorials>
+		<link title="Importing images">https://docs.godotengine.org/en/latest/tutorials/assets_pipeline/importing_images.html</link>
 	</tutorials>
 	<methods>
 		<method name="create_from_image">
@@ -16,14 +37,14 @@
 			<argument index="0" name="image" type="Image">
 			</argument>
 			<description>
-				Create a new [ImageTexture] from an [Image].
+				Initializes the texture by allocating and setting the data from an [Image].
 			</description>
 		</method>
 		<method name="get_format" qualifiers="const">
 			<return type="int" enum="Image.Format">
 			</return>
 			<description>
-				Returns the format of the [ImageTexture], one of [enum Image.Format].
+				Returns the format of the texture, one of [enum Image.Format].
 			</description>
 		</method>
 		<method name="set_size_override">
@@ -32,7 +53,7 @@
 			<argument index="0" name="size" type="Vector2">
 			</argument>
 			<description>
-				Resizes the [ImageTexture] to the specified dimensions.
+				Resizes the texture to the specified dimensions.
 			</description>
 		</method>
 		<method name="update">
@@ -43,7 +64,9 @@
 			<argument index="1" name="immediate" type="bool" default="false">
 			</argument>
 			<description>
-				Replaces the texture's data with a new [code]image[/code]. If [code]immediate[/code] is [code]true[/code], it will take effect immediately after the call.
+				Replaces the texture's data with a new [Image]. If [code]immediate[/code] is [code]true[/code], it will take effect immediately after the call.
+				[b]Note:[/b] The texture has to be initialized first with the [method create_from_image] method before it can be updated. The new image dimensions, format, and mipmaps configuration should match the existing texture's image configuration, otherwise it has to be re-created with the [method create_from_image] method.
+				Use this method over [method create_from_image] if you need to update the texture frequently, which is faster than allocating additional memory for a new texture each time.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -7,6 +7,7 @@
 		A texture works by registering an image in the video hardware, which then can be used in 3D models or 2D [Sprite2D] or GUI [Control].
 		Textures are often created by loading them from a file. See [method @GDScript.load].
 		[Texture2D] is a base for other resources. It cannot be used directly.
+		[b]Note:[/b] The maximum texture size is 16384×16384 pixels due to graphics hardware limitations. Larger textures may fail to import.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -151,7 +151,7 @@ void ImageTexture::_reload_hook(const RID &p_hook) {
 }
 
 void ImageTexture::create_from_image(const Ref<Image> &p_image) {
-	ERR_FAIL_COND(p_image.is_null());
+	ERR_FAIL_COND_MSG(p_image.is_null(), "Invalid image");
 	w = p_image->get_width();
 	h = p_image->get_height();
 	format = p_image->get_format();
@@ -174,11 +174,14 @@ Image::Format ImageTexture::get_format() const {
 }
 
 void ImageTexture::update(const Ref<Image> &p_image, bool p_immediate) {
-	ERR_FAIL_COND(p_image.is_null());
-	ERR_FAIL_COND(texture.is_null());
-	ERR_FAIL_COND(p_image->get_width() != w || p_image->get_height() != h);
-	ERR_FAIL_COND(p_image->get_format() != format);
-	ERR_FAIL_COND(mipmaps != p_image->has_mipmaps());
+	ERR_FAIL_COND_MSG(p_image.is_null(), "Invalid image");
+	ERR_FAIL_COND_MSG(texture.is_null(), "Texture is not initialized.");
+	ERR_FAIL_COND_MSG(p_image->get_width() != w || p_image->get_height() != h,
+			"The new image dimensions must match the texture size.");
+	ERR_FAIL_COND_MSG(p_image->get_format() != format,
+			"The new image format must match the texture's image format.");
+	ERR_FAIL_COND_MSG(mipmaps != p_image->has_mipmaps(),
+			"The new image mipmaps configuration must match the texture's image mipmaps configuration");
 
 	if (p_immediate) {
 		RenderingServer::get_singleton()->texture_2d_update_immediate(texture, p_image);


### PR DESCRIPTION
Closes #20972.
Helps #41106, #42346, #38112, #23148, #16678, #17848.

Having this documented, I'd prefer #39396 or #42653 to get merged, as it's mostly documentation issue by now, see #24222 for instance.

Linking to the [Importing images](https://docs.godotengine.org/en/3.2/getting_started/workflow/assets/importing_images.html) docs as well.


