### PR TITLE
Fix error message when exporting a write-only property without a setter

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2702,7 +2702,7 @@ bool CSharpScript::_get_member_export(IMonoClassMember *p_member, bool p_inspect
 		if (!property->has_getter()) {
 #ifdef TOOLS_ENABLED
 			if (exported) {
-				ERR_PRINT("Read-only property cannot be exported: '" + MEMBER_FULL_QUALIFIED_NAME(p_member) + "'.");
+				ERR_PRINT("Cannot export a property without a getter: '" + MEMBER_FULL_QUALIFIED_NAME(p_member) + "'.");
 			}
 #endif
 			return false;
@@ -2710,7 +2710,7 @@ bool CSharpScript::_get_member_export(IMonoClassMember *p_member, bool p_inspect
 		if (!property->has_setter()) {
 #ifdef TOOLS_ENABLED
 			if (exported) {
-				ERR_PRINT("Write-only property (without getter) cannot be exported: '" + MEMBER_FULL_QUALIFIED_NAME(p_member) + "'.");
+				ERR_PRINT("Cannot export a property without a setter: '" + MEMBER_FULL_QUALIFIED_NAME(p_member) + "'.");
 			}
 #endif
 			return false;


### PR DESCRIPTION
This is the fix regarding the [issue #42355](https://github.com/godotengine/godot/issues/42355).

```
When exporting a get-only property, the error message that gets printed mentions this wrongly:
"modules/mono/csharp_script.cpp:2618 - Write-only property (without getter) cannot be exported[..]"
```

It changes the message to `without setter`.

*Bugsquad edit:* fixes #42355.