### PR TITLE
Save the current script when adding a new method via signal connection

### DIFF
--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -312,6 +312,7 @@ class ScriptEditor : public PanelContainer {
 
 	String _get_debug_tooltip(const String &p_text, Node *_se);
 
+	void _save_current_script();
 	void _resave_scripts(const String &p_str);
 	void _reload_scripts();
 


### PR DESCRIPTION
This makes it possible for external editors to pick up the changes. Most modern editors should reload the file automatically, but some older/lightweight editors may ask the user instead (or only warn after trying to save in the external editor).

This closes #41283.