### PR TITLE
Make the pressed autokey icon red to emphasize its "recording" status

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4023,6 +4023,12 @@ void CanvasItemEditor::_notification(int p_what) {
 		key_scale_button->set_icon(get_theme_icon("KeyScale", "EditorIcons"));
 		key_insert_button->set_icon(get_theme_icon("Key", "EditorIcons"));
 		key_auto_insert_button->set_icon(get_theme_icon("AutoKey", "EditorIcons"));
+		// Use a different color for the active autokey icon to make them easier
+		// to distinguish from the other key icons at the top. On a light theme,
+		// the icon will be dark, so we need to lighten it before blending it
+		// with the red color.
+		const Color key_auto_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25);
+		key_auto_insert_button->add_theme_color_override("icon_color_pressed", key_auto_color.lerp(Color(1, 0, 0), 0.55));
 		animation_menu->set_icon(get_theme_icon("GuiTabMenuHl", "EditorIcons"));
 
 		zoom_minus->set_icon(get_theme_icon("ZoomLess", "EditorIcons"));


### PR DESCRIPTION
Follow-up to #42333.

## Preview

### Before

![Blue pressed icon](https://user-images.githubusercontent.com/180032/94618347-49750100-02ab-11eb-98c9-b0477fe0289f.png)

### After

![Red pressed icon](https://user-images.githubusercontent.com/180032/94617956-b9cf5280-02aa-11eb-96e0-67236710cb41.png)