### PR TITLE
CI: upload artifacts

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -72,3 +72,9 @@ jobs:
         run: |
           scons -j2 verbose=yes warnings=all werror=yes platform=android target=release tools=no
           ls -l bin/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.job }}
+          path: bin/*
+          retention-days: 14

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -49,3 +49,9 @@ jobs:
         run: |
           scons -j2 verbose=yes warnings=all werror=yes platform=iphone target=release tools=no
           ls -l bin/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.job }}
+          path: bin/*
+          retention-days: 14

--- a/.github/workflows/javascript_builds.disabled
+++ b/.github/workflows/javascript_builds.disabled
@@ -76,3 +76,9 @@ jobs:
         run: |
           scons -j2 verbose=yes warnings=all werror=yes platform=javascript target=release tools=no use_closure_compiler=yes
           ls -l bin/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.job }}
+          path: bin/*
+          retention-days: 14

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -7,7 +7,7 @@ env:
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
-  linux-editor:
+  linux-editor-mono:
     runs-on: "ubuntu-20.04"
     name: Editor w/ Mono (target=release_debug, tools=yes, tests=yes)
 
@@ -68,6 +68,12 @@ jobs:
       - name: Unit Tests
         run: |
           ./bin/godot.linuxbsd.opt.tools.64.mono --test
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.job }}
+          path: bin/*
+          retention-days: 14
 
   linux-editor-sanitizers:
     runs-on: "ubuntu-20.04"
@@ -131,7 +137,13 @@ jobs:
         run: |
           ./bin/godot.linuxbsd.tools.64s --test
 
-  linux-template:
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.job }}
+          path: bin/*
+          retention-days: 14
+
+  linux-template-mono:
     runs-on: "ubuntu-20.04"
     name: Template w/ Mono (target=release, tools=no)
 
@@ -186,3 +198,9 @@ jobs:
         run: |
           scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd target=release tools=no module_mono_enabled=yes mono_glue=no
           ls -l bin/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.job }}
+          path: bin/*
+          retention-days: 14

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -57,6 +57,12 @@ jobs:
         run: |
           ./bin/godot.osx.opt.tools.64 --test
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.job }}
+          path: bin/*
+          retention-days: 14
+
   macos-template:
     runs-on: "macos-latest"
     name: Template (target=release, tools=no)
@@ -99,3 +105,9 @@ jobs:
         run: |
           scons -j2 verbose=yes warnings=all werror=yes platform=osx target=release tools=no
           ls -l bin/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.job }}
+          path: bin/*
+          retention-days: 14

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -62,14 +62,11 @@ jobs:
       run: |
         ./bin/godot.windows.opt.tools.64.exe --test
 
-# Build Product Upload (tested and working)
-# sorry this is disabled until github can give us some more space as we would hit our limit very quickly
-# tested this code and it works fine so just enable it to get them back
-#    - name: publishing godot windows-editor
-#      uses: actions/upload-artifact@v1
-#      with:
-#        name: windows-editor (x64)
-#        path: bin/godot.windows.opt.tools.64.exe
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}
+        path: bin/*
+        retention-days: 14
 
   windows-template:
     runs-on: "windows-latest"
@@ -115,11 +112,8 @@ jobs:
         scons -j2 verbose=yes warnings=all werror=yes platform=windows target=release tools=no
         ls -l bin/
 
-# Build Product Upload (tested and working)
-# sorry this is disabled until github can give us some more space as we would hit our limit very quickly
-# tested this code and it works fine so just enable it to get them back
-#    - name: publishing godot windows-template
-#      uses: actions/upload-artifact@v1
-#      with:
-#        name: windows-template (x64)
-#        path: bin/godot.windows.opt.64.exe
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}
+        path: bin/*
+        retention-days: 14


### PR DESCRIPTION
In this PR the artifacts generated in CI jobs are uploaded using `actions/upload-artifact@v2`. This feature was already implemented in `windows_builds.yml`, but it was commented out.

For each push or pull request, all successfully generated artifacts will be uploaded in the run. This will allow users to try new features and/or fixes without needing to build Godot themselves.

This is a partial implementation of godotengine/godot-proposals#1412. See also godotengine/godot-proposals#1458.
