### PR TITLE
Fix editing items in tree making changes to the wrong item

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1780,7 +1780,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 
 		/* editing */
 
-		bool bring_up_editor = allow_reselect ? (c.selected && already_selected) : c.selected;
+		bool bring_up_editor = allow_reselect ? (c.selected && already_selected) : already_selected;
 		String editor_text = c.text;
 
 		switch (c.mode) {


### PR DESCRIPTION
This was caused by the fact that selecting a new item would immediately change that item to the "popup_edited_item" which meant that when the `item_edited` method was called, the wrong item was being changed. "popup_edited_item" would change immediately upon selection because bring_up_editor was based on it's current selection status, which could have changed to true just before, in the same method, where selection is handled (see line 1758). This change makes it based upon it's _previous_ selection status (which was already used) so that the editor does not popup immediately on first selection.

This was a pretty big pain to troubleshoot tbh. Tree could do with a refactor... It is quite messy and hard to decipher.

Closes #42419
![tree_fixed](https://user-images.githubusercontent.com/41730826/94638946-5e3eac80-031e-11eb-98f3-edf45a599afb.gif)
