### PR TITLE
Fix FileSystem tree preview icon size on HiDPI

### DIFF
--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -164,7 +164,6 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 		r_texture = generated;
 
 		int small_thumbnail_size = EditorNode::get_singleton()->get_theme_base()->get_theme_icon("Object", "EditorIcons")->get_width(); // Kind of a workaround to retrieve the default icon size
-		small_thumbnail_size *= EDSCALE;
 
 		if (preview_generators[i]->can_generate_small_preview()) {
 			Ref<Texture2D> generated_small;


### PR DESCRIPTION
This PR makes the preview icon size the same as other icons in the FileSystem tree.

The preview thumbnail size is based on the size of "Object" editor icon. As editor icons are already scaled by `EDSCALE`, we don't need to apply the scale again.

<details><summary>Before & After screenshots</summary>

![x0.5](https://user-images.githubusercontent.com/372476/94663173-f0a17900-033b-11eb-8c55-9a3ee0ed94c8.png)
![x2](https://user-images.githubusercontent.com/372476/94663185-f303d300-033b-11eb-90ed-e81d4375bf23.png)
![x3](https://user-images.githubusercontent.com/372476/94663187-f39c6980-033b-11eb-8e0f-2026ba3efdc1.png)

</details>

Tested on the current master and 3.2 branch.