### PR TITLE
Cross-reference GDScript `load` and `ResourceLoader.load` in classref

### DIFF
--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -6,7 +6,6 @@
 	<description>
 		Singleton used to load resource files from the filesystem.
 		It uses the many [ResourceFormatLoader] classes registered in the engine (either built-in or from a plugin) to load files into memory and convert them to a format that can be used by the engine.
-		GDScript has a simplified [method @GDScript.load] built-in method which can be used in most situations, leaving the use of [ResourceLoader] for more advanced scenarios.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -65,7 +64,8 @@
 				The registered [ResourceFormatLoader]s are queried sequentially to find the first one which can handle the file's extension, and then attempt loading. If loading fails, the remaining ResourceFormatLoaders are also attempted.
 				An optional [code]type_hint[/code] can be used to further specify the [Resource] type that should be handled by the [ResourceFormatLoader].
 				If [code]no_cache[/code] is [code]true[/code], the resource cache will be bypassed and the resource will be loaded anew. Otherwise, the cached resource will be returned if it exists.
-				Returns an empty resource if no ResourceFormatLoader could handle the file.
+				Returns an empty resource if no [ResourceFormatLoader] could handle the file.
+				GDScript has a simplified [method @GDScript.load] built-in method which can be used in most situations, leaving the use of [ResourceLoader] for more advanced scenarios.
 			</description>
 		</method>
 		<method name="load_threaded_get">

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -627,6 +627,7 @@
 				var main = load("res://main.tscn") # main will contain a PackedScene resource.
 				[/codeblock]
 				[b]Important:[/b] The path must be absolute, a local path will just return [code]null[/code].
+				This method is a simplified version of [method ResourceLoader.load], which can be used for more advanced scenarios.
 			</description>
 		</method>
 		<method name="log">


### PR DESCRIPTION
The GDScript `load` mention is moved from the class `ResourceLoader` description to the `ResourceLoader.load` method description instead, where it is more likely to be found.

