### PR TITLE
Fix glow on devices with only 8 texture slots in GLES2

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2968,6 +2968,9 @@ void RasterizerSceneGLES2::_post_process(Environment *env, const CameraMatrix &p
 			}
 		}
 
+		// If max_texture_image_units is 8, our max glow level is 5, which allows 6 layers of glow
+		max_glow_level = MIN(max_glow_level, storage->config.max_texture_image_units - 3);
+
 		for (int i = 0; i < (max_glow_level + 1); i++) {
 
 			int vp_w = storage->frame.current_rt->mip_maps[1].sizes[i].width;
@@ -3070,7 +3073,7 @@ void RasterizerSceneGLES2::_post_process(Environment *env, const CameraMatrix &p
 					}
 				}
 			}
-			glActiveTexture(GL_TEXTURE1);
+			glActiveTexture(GL_TEXTURE2);
 			glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].color);
 		} else {
 
@@ -3080,7 +3083,7 @@ void RasterizerSceneGLES2::_post_process(Environment *env, const CameraMatrix &p
 
 				if (glow_mask & (1 << i)) {
 					active_glow_level++;
-					glActiveTexture(GL_TEXTURE0 + active_glow_level);
+					glActiveTexture(GL_TEXTURE1 + active_glow_level);
 					glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->mip_maps[0].sizes[i + 1].color);
 					if (active_glow_level == 1) {
 						state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_GLOW_LEVEL1, true);
@@ -3119,7 +3122,7 @@ void RasterizerSceneGLES2::_post_process(Environment *env, const CameraMatrix &p
 		RasterizerStorageGLES2::Texture *tex = storage->texture_owner.getornull(env->color_correction);
 		if (tex) {
 			state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_COLOR_CORRECTION, true);
-			glActiveTexture(GL_TEXTURE2);
+			glActiveTexture(GL_TEXTURE1);
 			glBindTexture(tex->target, tex->tex_id);
 		}
 	}

--- a/drivers/gles2/shaders/tonemap.glsl
+++ b/drivers/gles2/shaders/tonemap.glsl
@@ -75,15 +75,17 @@ uniform highp sampler2D source; //texunit:0
 #define USING_GLOW // only use glow when at least one glow level is selected
 
 #ifdef USE_MULTI_TEXTURE_GLOW
-uniform highp sampler2D source_glow1; //texunit:1
-uniform highp sampler2D source_glow2; //texunit:2
-uniform highp sampler2D source_glow3; //texunit:3
-uniform highp sampler2D source_glow4; //texunit:4
-uniform highp sampler2D source_glow5; //texunit:5
-uniform highp sampler2D source_glow6; //texunit:6
-uniform highp sampler2D source_glow7; //texunit:7
+uniform highp sampler2D source_glow1; //texunit:2
+uniform highp sampler2D source_glow2; //texunit:3
+uniform highp sampler2D source_glow3; //texunit:4
+uniform highp sampler2D source_glow4; //texunit:5
+uniform highp sampler2D source_glow5; //texunit:6
+uniform highp sampler2D source_glow6; //texunit:7
+#ifdef USE_GLOW_LEVEL7
+uniform highp sampler2D source_glow7; //texunit:8
+#endif
 #else
-uniform highp sampler2D source_glow; //texunit:1
+uniform highp sampler2D source_glow; //texunit:2
 #endif
 uniform highp float glow_intensity;
 #endif
@@ -93,7 +95,7 @@ uniform vec3 bcs;
 #endif
 
 #ifdef USE_COLOR_CORRECTION
-uniform sampler2D color_correction; //texunit:2
+uniform sampler2D color_correction; //texunit:1
 #endif
 
 #ifdef GL_EXT_gpu_shader4


### PR DESCRIPTION
Fixes: #42421 

This was caused by color correction and glow level 2 sharing a texture unit. 

Unfortunately many older GLES2 devices have the minimum of 8 texture units. https://opengles.gpuinfo.org/displaycapability.php?name=GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS&esversion=2

We need 1 texture for the screen texture, 7 textures for glow, and 1 texture for color correction. So on devices that only support 8 texture units we just ignore the seventh glow level. Devices that support more than 8 texture units can use everything normally. 
