### PR TITLE
[4.0] [iOS] Add touch delay value to project settings

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -555,6 +555,9 @@
 		<member name="input_devices/pointing/emulate_touch_from_mouse" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], sends touch input events when clicking or dragging the mouse.
 		</member>
+		<member name="input_devices/pointing/ios/touch_delay" type="float" setter="" getter="" default="0.150">
+			Default delay for touch events. This only affects iOS devices.
+		</member>
 		<member name="layer_names/2d_physics/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D physics layer 1.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1369,6 +1369,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					"0,33200,1,or_greater")); // No negative numbers
 
 	GLOBAL_DEF("display/window/ios/hide_home_indicator", true);
+	GLOBAL_DEF("input_devices/pointing/ios/touch_delay", 0.150);
 
 	Engine::get_singleton()->set_frame_delay(frame_delay);
 

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -18,7 +18,7 @@ iphone_lib = [
     "godot_view.mm",
     "display_layer.mm",
     "godot_view_renderer.mm",
-    "godot_view_gesture_recognizer.m",
+    "godot_view_gesture_recognizer.mm",
 ]
 
 env_ios = env.Clone()

--- a/platform/iphone/godot_view_gesture_recognizer.h
+++ b/platform/iphone/godot_view_gesture_recognizer.h
@@ -39,6 +39,8 @@
 
 @interface GodotViewGestureRecognizer : UIGestureRecognizer
 
+@property(nonatomic, readonly, assign) NSTimeInterval delayTimeInterval;
+
 - (instancetype)init;
 
 @end

--- a/platform/iphone/godot_view_gesture_recognizer.mm
+++ b/platform/iphone/godot_view_gesture_recognizer.mm
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  godot_view_gesture_recognizer.m                                      */
+/*  godot_view_gesture_recognizer.mm                                     */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -30,14 +30,19 @@
 
 #import "godot_view_gesture_recognizer.h"
 
-// Using same delay interval that is used for `UIScrollView`
-const NSTimeInterval kGLGestureDelayInterval = 0.150;
+#include "core/project_settings.h"
 
 // Minimum distance for touches to move to fire
 // a delay timer before scheduled time.
 // Should be the low enough to not cause issues with dragging
 // but big enough to allow click to work.
 const CGFloat kGLGestureMovementDistance = 0.5;
+
+@interface GodotViewGestureRecognizer ()
+
+@property(nonatomic, readwrite, assign) NSTimeInterval delayTimeInterval;
+
+@end
 
 @interface GodotViewGestureRecognizer ()
 
@@ -59,6 +64,8 @@ const CGFloat kGLGestureMovementDistance = 0.5;
 	self.cancelsTouchesInView = YES;
 	self.delaysTouchesBegan = YES;
 	self.delaysTouchesEnded = YES;
+
+	self.delayTimeInterval = GLOBAL_GET("input_devices/pointing/ios/touch_delay");
 
 	return self;
 }
@@ -87,7 +94,7 @@ const CGFloat kGLGestureMovementDistance = 0.5;
 	self.delayedEvent = event;
 
 	self.delayTimer = [NSTimer
-			scheduledTimerWithTimeInterval:kGLGestureDelayInterval
+			scheduledTimerWithTimeInterval:self.delayTimeInterval
 									target:self
 								  selector:@selector(fireDelayedTouches:)
 								  userInfo:nil


### PR DESCRIPTION
Fixes #42164

Adds a settings value into `Input Devices` menu. 
Value is also cached upon gesture recognizer initialization, so calling `GLOBAL_GET` shouldn't become a bottleneck.