### PR TITLE
[3.2] [iOS] Add touch delay value to project settings

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -567,6 +567,9 @@
 		<member name="input_devices/pointing/emulate_touch_from_mouse" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], sends touch input events when clicking or dragging the mouse.
 		</member>
+		<member name="input_devices/pointing/ios/touch_delay" type="float" setter="" getter="" default="0.150">
+			Default delay for touch events. This only affects iOS devices.
+		</member>
 		<member name="layer_names/2d_physics/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D physics layer 1.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1202,6 +1202,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	ProjectSettings::get_singleton()->set_custom_property_info("application/run/low_processor_mode_sleep_usec", PropertyInfo(Variant::INT, "application/run/low_processor_mode_sleep_usec", PROPERTY_HINT_RANGE, "0,33200,1,or_greater")); // No negative numbers
 
 	GLOBAL_DEF("display/window/ios/hide_home_indicator", true);
+	GLOBAL_DEF("input_devices/pointing/ios/touch_delay", 0.150);
 
 	Engine::get_singleton()->set_frame_delay(frame_delay);
 

--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -14,7 +14,7 @@ iphone_lib = [
     "in_app_store.mm",
     "icloud.mm",
     "ios.mm",
-    "gl_view_gesture_recognizer.m",
+    "gl_view_gesture_recognizer.mm",
 ]
 
 env_ios = env.Clone()

--- a/platform/iphone/gl_view_gesture_recognizer.h
+++ b/platform/iphone/gl_view_gesture_recognizer.h
@@ -49,6 +49,8 @@
 	UIEvent *delayedEvent;
 }
 
+@property(nonatomic, readonly, assign) NSTimeInterval delayTimeInterval;
+
 - (instancetype)init;
 
 @end

--- a/platform/iphone/gl_view_gesture_recognizer.mm
+++ b/platform/iphone/gl_view_gesture_recognizer.mm
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gl_view_gesture_recognizer.m                                         */
+/*  gl_view_gesture_recognizer.mm                                        */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -30,14 +30,19 @@
 
 #import "gl_view_gesture_recognizer.h"
 
-// Using same delay interval that is used for `UIScrollView`
-const NSTimeInterval kGLGestureDelayInterval = 0.150;
+#include "core/project_settings.h"
 
 // Minimum distance for touches to move to fire
 // a delay timer before scheduled time.
 // Should be the low enough to not cause issues with dragging
 // but big enough to allow click to work.
 const CGFloat kGLGestureMovementDistance = 0.5;
+
+@interface GLViewGestureRecognizer ()
+
+@property(nonatomic, readwrite, assign) NSTimeInterval delayTimeInterval;
+
+@end
 
 @implementation GLViewGestureRecognizer
 
@@ -48,6 +53,8 @@ const CGFloat kGLGestureMovementDistance = 0.5;
 	self.delaysTouchesBegan = YES;
 	self.delaysTouchesEnded = YES;
 
+	self.delayTimeInterval = GLOBAL_GET("input_devices/pointing/ios/touch_delay");
+
 	return self;
 }
 
@@ -57,7 +64,7 @@ const CGFloat kGLGestureMovementDistance = 0.5;
 	delayedTouches = touches;
 	delayedEvent = event;
 
-	delayTimer = [NSTimer scheduledTimerWithTimeInterval:kGLGestureDelayInterval target:self selector:@selector(fireDelayedTouches:) userInfo:nil repeats:NO];
+	delayTimer = [NSTimer scheduledTimerWithTimeInterval:self.delayTimeInterval target:self selector:@selector(fireDelayedTouches:) userInfo:nil repeats:NO];
 }
 
 - (void)fireDelayedTouches:(id)timer {


### PR DESCRIPTION
Fixes #42164

Mater PR: #42454

Adds a settings value into `Input Devices` menu. 
Value is also cached upon gesture recognizer initialization, so calling `GLOBAL_GET` shouldn't become a bottleneck.