### PR TITLE
[3.2] Fix leak with events mutex in OS_X11

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -870,6 +870,8 @@ void OS_X11::finalize() {
 	if (xmbstring)
 		memfree(xmbstring);
 
+	memdelete(events_mutex);
+
 	args.clear();
 }
 


### PR DESCRIPTION
Adding missing delete for `events_mutex` member introduced in #42341. The leak only affects the 3.2 version of the PR.

See https://github.com/godotengine/godot/pull/42464#issuecomment-702138896

CC @akien-mga @qarmin 