### PR TITLE
Changes mention of Node3D back to Spatial on 3.2

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -371,7 +371,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				if (preferred_types.empty()) {
 					preferred_types.push_back("Control");
 					preferred_types.push_back("Node2D");
-					preferred_types.push_back("Node3D");
+					preferred_types.push_back("Spatial");
 				}
 
 				for (int i = 0; i < preferred_types.size(); i++) {
@@ -1163,7 +1163,7 @@ void SceneTreeDock::_notification(int p_what) {
 			button_create_script->set_icon(get_icon("ScriptCreate", "EditorIcons"));
 			button_detach_script->set_icon(get_icon("ScriptRemove", "EditorIcons"));
 			button_2d->set_icon(get_icon("Node2D", "EditorIcons"));
-			button_3d->set_icon(get_icon("Node3D", "EditorIcons"));
+			button_3d->set_icon(get_icon("Spatial", "EditorIcons"));
 			button_ui->set_icon(get_icon("Control", "EditorIcons"));
 			button_custom->set_icon(get_icon("Add", "EditorIcons"));
 


### PR DESCRIPTION
This PR changes mention of `Node3D` back to the 3.2 name `Spatial`.

Before this PR, the major issue is that the icon of "3D Scene" button for empty scenes will disappear after toggling the show favourite button or after a theme change.