### PR TITLE
Fixing exporting on Linux to Mac for 3.2

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -3428,6 +3428,7 @@ Error OS_X11::move_to_trash(const String &p_path) {
 	// The trash can is successfully created, now move the given resource to it.
 	// Do not use DirAccess:rename() because it can't move files across multiple mountpoints.
 	List<String> mv_args;
+  mv_args.push_back("--backup=t");
 	mv_args.push_back(p_path);
 	mv_args.push_back(trash_can);
 	int retval;


### PR DESCRIPTION
Resolving issue #42232 for branch 3.2. I've added a flag to the mv command when the old Mac export is moved to trash. It now appends a number while moving so that there isn't an error thrown because of an existing old Mac export already in the trash.

The new filenames in the trash now have this format -

NameOfGame.app.~2~