### PR TITLE
Reset TileMapEditor painting state on application refocus

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -89,6 +89,25 @@ void TileMapEditor::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			get_tree()->disconnect("node_removed", callable_mp(this, &TileMapEditor::_node_removed));
 		} break;
+
+		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+			if (tool == TOOL_PAINTING) {
+				Vector<int> ids = get_selected_tiles();
+
+				if (ids.size() > 0 && ids[0] != TileMap::INVALID_CELL) {
+					_set_cell(over_tile, ids, flip_h, flip_v, transpose);
+					_finish_undo();
+
+					paint_undo.clear();
+				}
+
+				tool = TOOL_NONE;
+				_update_button_tool();
+			}
+
+			// set flag to ignore over_tile on refocus
+			refocus_over_tile = true;
+		} break;
 	}
 }
 
@@ -1297,6 +1316,12 @@ bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 		if (new_over_tile != over_tile) {
 			over_tile = new_over_tile;
 			CanvasItemEditor::get_singleton()->update_viewport();
+		}
+
+		if (refocus_over_tile) {
+			// editor lost focus; forget last tile position
+			old_over_tile = new_over_tile;
+			refocus_over_tile = false;
 		}
 
 		int tile_under = node->get_cell(over_tile.x, over_tile.y);

--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -119,6 +119,7 @@ class TileMapEditor : public VBoxContainer {
 	Rect2i rectangle;
 
 	Point2i over_tile;
+	bool refocus_over_tile;
 
 	bool *bucket_cache_visited;
 	Rect2i bucket_cache_rect;

--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -119,7 +119,7 @@ class TileMapEditor : public VBoxContainer {
 	Rect2i rectangle;
 
 	Point2i over_tile;
-	bool refocus_over_tile;
+	bool refocus_over_tile = false;
 
 	bool *bucket_cache_visited;
 	Rect2i bucket_cache_rect;


### PR DESCRIPTION
Currently, when focusing another window, then returning to the TileMap editor, a line is drawn from approximately the last in-editor mouse position to the clicked position. This is not desirable and reflected in #24970, #34003, #10949.

A related issue is #39802; Switching window focus (i.e. with Alt+Tab) while painting leaves the editor in a broken state, preventing the user from undoing any further actions in the TileMap editor until restarting Godot. This bug is caused by the undo action_level being incremented on mousedown, but since mouseup occurs after focus is lost, the action_level is never reset.

This PR fixes both bugs by handling application unfocus and resetting state accordingly. It adds a simple flag to the TileMapEditor which prevents extra lines from being drawn when the application is refocused.

Fixes #24970 and resolves the TileMap portion of #39802 (GridMap not fixed in this PR)