### PR TITLE
Updated NinePatchRect's patch margin descriptions

### DIFF
--- a/doc/classes/NinePatchRect.xml
+++ b/doc/classes/NinePatchRect.xml
@@ -45,13 +45,13 @@
 			The height of the 9-slice's bottom row. A margin of 16 means the 9-slice's bottom corners and side will have a height of 16 pixels. You can set all 4 margin values individually to create panels with non-uniform borders.
 		</member>
 		<member name="patch_margin_left" type="int" setter="set_patch_margin" getter="get_patch_margin" default="0">
-			The height of the 9-slice's left column.
+			The width of the 9-slice's left column. A margin of 16 means the 9-slice's left corners and side will have a width of 16 pixels. You can set all 4 margin values individually to create panels with non-uniform borders.
 		</member>
 		<member name="patch_margin_right" type="int" setter="set_patch_margin" getter="get_patch_margin" default="0">
-			The height of the 9-slice's right column.
+			The width of the 9-slice's right column. A margin of 16 means the 9-slice's right corners and side will have a width of 16 pixels. You can set all 4 margin values individually to create panels with non-uniform borders.
 		</member>
 		<member name="patch_margin_top" type="int" setter="set_patch_margin" getter="get_patch_margin" default="0">
-			The height of the 9-slice's top row.
+			The height of the 9-slice's top row. A margin of 16 means the 9-slice's top corners and side will have a height of 16 pixels. You can set all 4 margin values individually to create panels with non-uniform borders.
 		</member>
 		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2( 0, 0, 0, 0 )">
 			Rectangular region of the texture to sample from. If you're working with an atlas, use this property to define the area the 9-slice should use. All other properties are relative to this one. If the rect is empty, NinePatchRect will use the whole texture.


### PR DESCRIPTION
Updated class reference for NinePatchRect to fix this issue: https://github.com/godotengine/godot-docs/issues/4044

*Bugsquad edit:* Fixes https://github.com/godotengine/godot-docs/issues/4044