### PR TITLE
Remove area or body from map before emitting signals.

### DIFF
--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -180,25 +180,19 @@ void Area2D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 			E->get().shapes.erase(ShapePair(p_body_shape, p_area_shape));
 		}
 
-		bool eraseit = false;
-
+		bool in_tree = E->get().in_tree;
 		if (E->get().rc == 0) {
+			body_map.erase(E);
 			if (node) {
 				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area2D::_body_enter_tree));
 				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area2D::_body_exit_tree));
-				if (E->get().in_tree) {
+				if (in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->body_exited, obj);
 				}
 			}
-
-			eraseit = true;
 		}
-		if (!node || E->get().in_tree) {
+		if (!node || in_tree) {
 			emit_signal(SceneStringNames::get_singleton()->body_shape_exited, objid, obj, p_body_shape, p_area_shape);
-		}
-
-		if (eraseit) {
-			body_map.erase(E);
 		}
 	}
 
@@ -278,25 +272,19 @@ void Area2D::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, i
 			E->get().shapes.erase(AreaShapePair(p_area_shape, p_self_shape));
 		}
 
-		bool eraseit = false;
-
+		bool in_tree = E->get().in_tree;
 		if (E->get().rc == 0) {
+			area_map.erase(E);
 			if (node) {
 				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area2D::_area_enter_tree));
 				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area2D::_area_exit_tree));
-				if (E->get().in_tree) {
+				if (in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
 				}
 			}
-
-			eraseit = true;
 		}
-		if (!node || E->get().in_tree) {
+		if (!node || in_tree) {
 			emit_signal(SceneStringNames::get_singleton()->area_shape_exited, objid, obj, p_area_shape, p_self_shape);
-		}
-
-		if (eraseit) {
-			area_map.erase(E);
 		}
 	}
 

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -180,25 +180,19 @@ void Area3D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 			E->get().shapes.erase(ShapePair(p_body_shape, p_area_shape));
 		}
 
-		bool eraseit = false;
-
+		bool in_tree = E->get().in_tree;
 		if (E->get().rc == 0) {
+			body_map.erase(E);
 			if (node) {
 				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area3D::_body_enter_tree));
 				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area3D::_body_exit_tree));
-				if (E->get().in_tree) {
+				if (in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->body_exited, obj);
 				}
 			}
-
-			eraseit = true;
 		}
-		if (node && E->get().in_tree) {
+		if (node && in_tree) {
 			emit_signal(SceneStringNames::get_singleton()->body_shape_exited, objid, obj, p_body_shape, p_area_shape);
-		}
-
-		if (eraseit) {
-			body_map.erase(E);
 		}
 	}
 
@@ -366,25 +360,19 @@ void Area3D::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, i
 			E->get().shapes.erase(AreaShapePair(p_area_shape, p_self_shape));
 		}
 
-		bool eraseit = false;
-
+		bool in_tree = E->get().in_tree;
 		if (E->get().rc == 0) {
+			area_map.erase(E);
 			if (node) {
 				node->disconnect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area3D::_area_enter_tree));
 				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &Area3D::_area_exit_tree));
-				if (E->get().in_tree) {
+				if (in_tree) {
 					emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
 				}
 			}
-
-			eraseit = true;
 		}
-		if (!node || E->get().in_tree) {
+		if (!node || in_tree) {
 			emit_signal(SceneStringNames::get_singleton()->area_shape_exited, objid, obj, p_area_shape, p_self_shape);
-		}
-
-		if (eraseit) {
-			area_map.erase(E);
 		}
 	}
 


### PR DESCRIPTION
Currently, when an `CollisionObject` leaves an `Area`, they are removed from the list of `Areas` or `PhysicsBodies` that are currently in the `Area` only after the signals that the `Area` or `PhysicsBody` has left the `Area` are emitted. This PR ensures that the list of `Areas` or `PhysicsBodies` that are currently in the `Area` is updated before the signals are emitted. Fixes both 2D and 3D.

Fixes #42494.
