### PR TITLE
pending_shape_update_list race condition fix (3.2)

### DIFF
--- a/servers/physics/physics_server_sw.h
+++ b/servers/physics/physics_server_sw.h
@@ -71,6 +71,7 @@ class PhysicsServerSW : public PhysicsServer {
 
 public:
 	static PhysicsServerSW *singleton;
+	Mutex *pending_shape_update_list_lock;
 
 	struct CollCbkData {
 

--- a/servers/physics_2d/physics_2d_server_sw.h
+++ b/servers/physics_2d/physics_2d_server_sw.h
@@ -68,6 +68,7 @@ class Physics2DServerSW : public Physics2DServer {
 	mutable RID_Owner<Joint2DSW> joint_owner;
 
 	static Physics2DServerSW *singletonsw;
+	Mutex *pending_shape_update_list_lock;
 
 	//void _clear_query(Query2DSW *p_query);
 	friend class CollisionObject2DSW;


### PR DESCRIPTION
Add mutex lock to pending_shape_update_list in both internal physics server implementations to prevent race conditions when instantiating collision objects in a separate thread. Keeping this as draft for now since this seemed to fix our issue, but feel the issue may require further investigation before agreeing on a universal fix.