### PR TITLE
Offset and length parameter for send_bytes method (3.2)

### DIFF
--- a/core/io/multiplayer_api.h
+++ b/core/io/multiplayer_api.h
@@ -133,7 +133,11 @@ public:
 	void set_root_node(Node *p_node);
 	void set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_peer);
 	Ref<NetworkedMultiplayerPeer> get_network_peer() const;
-	Error send_bytes(PoolVector<uint8_t> p_data, int p_to = NetworkedMultiplayerPeer::TARGET_PEER_BROADCAST, NetworkedMultiplayerPeer::TransferMode p_mode = NetworkedMultiplayerPeer::TRANSFER_MODE_RELIABLE);
+	Error send_bytes(PoolVector<uint8_t> p_data,
+			int p_to = NetworkedMultiplayerPeer::TARGET_PEER_BROADCAST,
+			NetworkedMultiplayerPeer::TransferMode p_mode = NetworkedMultiplayerPeer::TRANSFER_MODE_RELIABLE,
+			int p_offset = 0,
+			int p_length = -1);
 
 	// Called by Node.rpc
 	void rpcp(Node *p_node, int p_peer_id, bool p_unreliable, const StringName &p_method, const Variant **p_arg, int p_argcount);


### PR DESCRIPTION
Allows specifying a length and offset for the MultiplayerAPI's send_bytes method.