### PR TITLE
Allow creating projects in non-empty folders with a confirmation popup

### DIFF
--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -98,6 +98,7 @@ class ProjectManager : public Control {
 	void _restart_confirm();
 	void _exit_dialog();
 	void _confirm_update_settings();
+	void _nonempty_confirmation_ok_pressed();
 
 	void _load_recent_projects();
 	void _on_project_created(const String &dir);


### PR DESCRIPTION
Follow-up to #15835, replaces #39220. Implements and closes https://github.com/godotengine/godot-proposals/issues/1811.

Creating projects in non-empty folders can be a dangerous operation, but is sometimes desired, especially by @SubSage.

This PR changes the message from an error to a warning, and adds a confirmation dialog that looks like the below (I moved the windows so that you can see everything at once, but normally they appear on top of each other).

![Screenshot from 2020-11-12 21-28-38](https://user-images.githubusercontent.com/1646875/99021230-369e4f00-252e-11eb-88a1-14c83cb96b93.png)

3.x version: https://github.com/aaronfranke/godot/tree/3.x-project-non-empty (will manually PR if @akien-mga approves, this is not trivially cherry-pick-able with `git cherry-pick`)
