### PR TITLE
Don't write global script class information if there is none

### DIFF
--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -275,7 +275,11 @@ void ScriptServer::save_global_classes() {
 		gcarr.push_back(d);
 	}
 
-	ProjectSettings::get_singleton()->set("_global_script_classes", gcarr);
+	if (gcarr.empty()) {
+		ProjectSettings::get_singleton()->clear("_global_script_classes");
+	} else {
+		ProjectSettings::get_singleton()->set("_global_script_classes", gcarr);
+	}
 	ProjectSettings::get_singleton()->save();
 }
 

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -936,7 +936,11 @@ void EditorData::script_class_save_icon_paths() {
 		}
 	}
 
-	ProjectSettings::get_singleton()->set("_global_script_class_icons", d);
+	if (d.empty()) {
+		ProjectSettings::get_singleton()->clear("_global_script_class_icons");
+	} else {
+		ProjectSettings::get_singleton()->set("_global_script_class_icons", d);
+	}
 	ProjectSettings::get_singleton()->save();
 }
 


### PR DESCRIPTION
Before this PR, an empty project's `project.godot` would look like this at the top, with an empty array and an empty dictionary:

```properties
config_version=4

_global_script_classes=[  ]
_global_script_class_icons={
}

[application]
```

With this PR, it looks like this:

```properties
config_version=4

[application]
```

The loading code already checks if the project settings `has_setting` for these, so we only need to change the saving code.

This could maybe be cherry-picked, but it would create diffs when switching between <= 3.2.3 and >= 3.2.4.