### PR TITLE
Add get native handle

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1144,6 +1144,11 @@ void _OS::move_window_to_foreground() {
 	OS::get_singleton()->move_window_to_foreground();
 }
 
+int64_t _OS::get_native_handle(HandleType p_handle_type) {
+
+	return (int64_t)OS::get_singleton()->get_native_handle(p_handle_type);
+}
+
 bool _OS::is_debug_build() const {
 
 #ifdef DEBUG_ENABLED
@@ -1291,6 +1296,8 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_real_window_size"), &_OS::get_real_window_size);
 	ClassDB::bind_method(D_METHOD("center_window"), &_OS::center_window);
 	ClassDB::bind_method(D_METHOD("move_window_to_foreground"), &_OS::move_window_to_foreground);
+
+	ClassDB::bind_method(D_METHOD("get_native_handle", "handle_type"), &_OS::get_native_handle);
 
 	ClassDB::bind_method(D_METHOD("set_borderless_window", "borderless"), &_OS::set_borderless_window);
 	ClassDB::bind_method(D_METHOD("get_borderless_window"), &_OS::get_borderless_window);
@@ -1502,6 +1509,12 @@ void _OS::_bind_methods() {
 	BIND_ENUM_CONSTANT(MONTH_OCTOBER);
 	BIND_ENUM_CONSTANT(MONTH_NOVEMBER);
 	BIND_ENUM_CONSTANT(MONTH_DECEMBER);
+
+	BIND_ENUM_CONSTANT(APPLICATION_HANDLE);
+	BIND_ENUM_CONSTANT(DISPLAY_HANDLE);
+	BIND_ENUM_CONSTANT(WINDOW_HANDLE);
+	BIND_ENUM_CONSTANT(WINDOW_VIEW);
+	BIND_ENUM_CONSTANT(OPENGL_CONTEXT);
 
 	BIND_ENUM_CONSTANT(SCREEN_ORIENTATION_LANDSCAPE);
 	BIND_ENUM_CONSTANT(SCREEN_ORIENTATION_PORTRAIT);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -143,6 +143,14 @@ public:
 		MONTH_DECEMBER
 	};
 
+	enum HandleType {
+		APPLICATION_HANDLE, // HINSTANCE, NSApplication*, UIApplication*, JNIEnv* ...
+		DISPLAY_HANDLE, // X11::Display* ...
+		WINDOW_HANDLE, // HWND, X11::Window*, NSWindow*, UIWindow*, Android activity ...
+		WINDOW_VIEW, // HDC, NSView*, UIView*, Android surface ...
+		OPENGL_CONTEXT, // HGLRC, X11::GLXContext, NSOpenGLContext*, EGLContext* ...
+	};
+
 	void global_menu_add_item(const String &p_menu, const String &p_label, const Variant &p_signal, const Variant &p_meta);
 	void global_menu_add_separator(const String &p_menu);
 	void global_menu_remove_item(const String &p_menu, int p_idx);
@@ -205,6 +213,8 @@ public:
 	virtual void request_attention();
 	virtual void center_window();
 	virtual void move_window_to_foreground();
+
+	virtual int64_t get_native_handle(HandleType p_handle_type);
 
 	virtual void set_borderless_window(bool p_borderless);
 	virtual bool get_borderless_window() const;
@@ -383,6 +393,7 @@ VARIANT_ENUM_CAST(_OS::Weekday);
 VARIANT_ENUM_CAST(_OS::Month);
 VARIANT_ENUM_CAST(_OS::SystemDir);
 VARIANT_ENUM_CAST(_OS::ScreenOrientation);
+VARIANT_ENUM_CAST(_OS::HandleType);
 
 class _Geometry : public Object {
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -238,6 +238,22 @@ public:
 	virtual void request_attention() {}
 	virtual void center_window();
 
+	// Returns internal pointers and handles.
+	// While exposed to GDScript this is mostly to give GDNative plugins access to this information.
+	// Note that whether a valid handle is returned depends on whether it applies to the given
+	// platform and often to the chosen render driver.
+	// NULL will be returned if a handle is not available.
+
+	enum HandleType {
+		APPLICATION_HANDLE, // HINSTANCE, NSApplication*, UIApplication*, JNIEnv* ...
+		DISPLAY_HANDLE, // X11::Display* ...
+		WINDOW_HANDLE, // HWND, X11::Window*, NSWindow*, UIWindow*, Android activity ...
+		WINDOW_VIEW, // HDC, NSView*, UIView*, Android surface ...
+		OPENGL_CONTEXT, // HGLRC, X11::GLXContext, NSOpenGLContext*, EGLContext* ...
+	};
+
+	virtual void *get_native_handle(int p_handle_type) { return NULL; };
+
 	// Returns window area free of hardware controls and other obstacles.
 	// The application should use this to determine where to place UI elements.
 	//

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -291,6 +291,16 @@
 				Returns the name of the host OS. Possible values are: [code]"Android"[/code], [code]"iOS"[/code], [code]"HTML5"[/code], [code]"OSX"[/code], [code]"Server"[/code], [code]"Windows"[/code], [code]"UWP"[/code], [code]"X11"[/code].
 			</description>
 		</method>
+		<method name="get_native_handle">
+			<return type="int">
+			</return>
+			<argument index="0" name="handle_type" type="int" enum="OS.HandleType">
+			</argument>
+			<description>
+				Returns internal structure pointers for use in GDNative plugins.
+				[b]Note:[/b] This method is implemented on Linux and Windows (other OSs will soon be supported).
+			</description>
+		</method>
 		<method name="get_power_percent_left">
 			<return type="int">
 			</return>
@@ -1161,6 +1171,34 @@
 		</constant>
 		<constant name="MONTH_DECEMBER" value="12" enum="Month">
 			December.
+		</constant>
+		<constant name="APPLICATION_HANDLE" value="0" enum="HandleType">
+			Application handle:
+			- Windows: [code]HINSTANCE[/code] of the application
+			- MacOS: [code]NSApplication*[/code] of the application (not yet implemented)
+			- Android: [code]JNIEnv*[/code] of the application (not yet implemented)
+		</constant>
+		<constant name="DISPLAY_HANDLE" value="1" enum="HandleType">
+			Display handle:
+			- Linux: [code]X11::Display*[/code] for the display
+		</constant>
+		<constant name="WINDOW_HANDLE" value="2" enum="HandleType">
+			Window handle:
+			- Windows: [code]HWND[/code] of the main window
+			- Linux: [code]X11::Window*[/code] of the main window
+			- MacOS: [code]NSWindow*[/code] of the main window (not yet implemented)
+			- Android: [code]jObject[/code] the main android activity (not yet implemented)
+		</constant>
+		<constant name="WINDOW_VIEW" value="3" enum="HandleType">
+			Window view:
+			- Windows: [code]HDC[/code] of the main window drawing context
+			- MacOS: [code]NSView*[/code] of the main windows view (not yet implemented)
+		</constant>
+		<constant name="OPENGL_CONTEXT" value="4" enum="HandleType">
+			OpenGL Context:
+			- Windows: [code]HGLRC[/code]
+			- Linux: [code]X11::GLXContext[/code]
+			- MacOS: [code]NSOpenGLContext*[/code] (not yet implemented)
 		</constant>
 		<constant name="SCREEN_ORIENTATION_LANDSCAPE" value="0" enum="ScreenOrientation">
 			Landscape screen orientation.

--- a/platform/windows/context_gl_windows.cpp
+++ b/platform/windows/context_gl_windows.cpp
@@ -60,6 +60,14 @@ void ContextGL_Windows::make_current() {
 	wglMakeCurrent(hDC, hRC);
 }
 
+HDC ContextGL_Windows::get_hdc() {
+	return hDC;
+}
+
+HGLRC ContextGL_Windows::get_hglrc() {
+	return hRC;
+}
+
 int ContextGL_Windows::get_window_width() {
 
 	return OS::get_singleton()->get_video_mode().width;

--- a/platform/windows/context_gl_windows.h
+++ b/platform/windows/context_gl_windows.h
@@ -63,6 +63,9 @@ public:
 
 	void make_current();
 
+	HDC get_hdc();
+	HGLRC get_hglrc();
+
 	int get_window_width();
 	int get_window_height();
 	void swap_buffers();

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2463,6 +2463,17 @@ void OS_Windows::request_attention() {
 	FlashWindowEx(&info);
 }
 
+void *OS_Windows::get_native_handle(int p_handle_type) {
+	switch (p_handle_type) {
+		case APPLICATION_HANDLE: return hInstance;
+		case DISPLAY_HANDLE: return NULL; // Do we have a value to return here?
+		case WINDOW_HANDLE: return hWnd;
+		case WINDOW_VIEW: return gl_context->get_hdc();
+		case OPENGL_CONTEXT: return gl_context->get_hglrc();
+		default: return NULL;
+	}
+}
+
 String OS_Windows::get_name() const {
 
 	return "Windows";

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -466,6 +466,7 @@ public:
 	virtual void set_console_visible(bool p_enabled);
 	virtual bool is_console_visible() const;
 	virtual void request_attention();
+	virtual void *get_native_handle(int p_handle_type);
 
 	virtual void set_borderless_window(bool p_borderless);
 	virtual bool get_borderless_window();

--- a/platform/x11/context_gl_x11.cpp
+++ b/platform/x11/context_gl_x11.cpp
@@ -224,6 +224,14 @@ int ContextGL_X11::get_window_height() {
 	return xwa.height;
 }
 
+void *ContextGL_X11::get_glx_context() {
+	if (p != NULL) {
+		return p->glx_context;
+	} else {
+		return NULL;
+	}
+}
+
 void ContextGL_X11::set_use_vsync(bool p_use) {
 	static bool setup = false;
 	static PFNGLXSWAPINTERVALEXTPROC glXSwapIntervalEXT = NULL;

--- a/platform/x11/context_gl_x11.h
+++ b/platform/x11/context_gl_x11.h
@@ -68,6 +68,7 @@ public:
 	void swap_buffers();
 	int get_window_width();
 	int get_window_height();
+	void *get_glx_context();
 
 	Error initialize();
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1756,6 +1756,17 @@ void OS_X11::request_attention() {
 	XFlush(x11_display);
 }
 
+void *OS_X11::get_native_handle(int p_handle_type) {
+	switch (p_handle_type) {
+		case APPLICATION_HANDLE: return NULL; // Do we have a value to return here?
+		case DISPLAY_HANDLE: return (void *)x11_display;
+		case WINDOW_HANDLE: return (void *)x11_window;
+		case WINDOW_VIEW: return NULL; // Do we have a value to return here?
+		case OPENGL_CONTEXT: return context_gl->get_glx_context();
+		default: return NULL;
+	}
+}
+
 void OS_X11::get_key_modifier_state(unsigned int p_x11_state, Ref<InputEventWithModifiers> state) {
 
 	state->set_shift((p_x11_state & ShiftMask));

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -308,6 +308,7 @@ public:
 	virtual bool is_window_always_on_top() const;
 	virtual bool is_window_focused() const;
 	virtual void request_attention();
+	virtual void *get_native_handle(int p_handle_type);
 
 	virtual void set_borderless_window(bool p_borderless);
 	virtual bool get_borderless_window();


### PR DESCRIPTION
This is an alternative to #41137 and introduces a method called `get_native_handle` to our OS class. It is only exposed to GDScript so it is exposed to GDNative where it is really needed. This is mainly targeted at OpenXR support but will also benefit other solutions that require access to some of the platform internals to work. 

Currently it only implements WINDOW_VIEW (HDC) and OPENGL_INSTANCE (HGLRC) on the Windows platform which is why it's in draft.

We'll need similar implementations for Android (for which currently a custom gdnative API exists that could potentially be retired) and X11, again to support OpenXR and other AR/VR platforms. 

Note, currently focusing on 3.2 but this will be vital to XR on Godot 4 in exposing parts of Vulkan. Note that the index added is meant for Godot 4's multiple window support. I will be adding documentation to this.
 