### PR TITLE
Fix how Line2D obtains the other object's supports

### DIFF
--- a/servers/physics_2d/collision_solver_2d_sw.cpp
+++ b/servers/physics_2d/collision_solver_2d_sw.cpp
@@ -47,7 +47,7 @@ bool CollisionSolver2DSW::solve_static_line(const Shape2DSW *p_shape_A, const Tr
 	Vector2 supports[2];
 	int support_count;
 
-	p_shape_B->get_supports(p_transform_A.affine_inverse().basis_xform(-n).normalized(), supports, support_count);
+	p_shape_B->get_supports(p_transform_B.affine_inverse().basis_xform(-n).normalized(), supports, support_count);
 
 	bool found = false;
 


### PR DESCRIPTION
Currently, when checking collisions with a `Line2D` and obtaining the supports from the other object, the `Line2D` normal is rotated by the inverse transform of the `Line2D`. However, to obtain the correct supports from an unrotated object, the normal needs to be rotated by the inverse transform or the other object not the `Line2D`. This PR correctly performs an inverse rotation of the normal using the other object's transform.

Fixes #7920.