### PR TITLE
[3.2] Fix gdscript multiline string nested highlighting

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -47,9 +47,9 @@ void GDScriptLanguage::get_comment_delimiters(List<String> *p_delimiters) const 
 
 void GDScriptLanguage::get_string_delimiters(List<String> *p_delimiters) const {
 
+	p_delimiters->push_back("\"\"\" \"\"\"");
 	p_delimiters->push_back("\" \"");
 	p_delimiters->push_back("' '");
-	p_delimiters->push_back("\"\"\" \"\"\"");
 }
 
 String GDScriptLanguage::_get_processed_template(const String &p_template, const String &p_base_class_name) const {


### PR DESCRIPTION
Fixes highlighting for nested multiline strings in 3.2 by prioritising the larger key.

issue #41403