### PR TITLE
Use full float UVs in Sprite3D

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -430,7 +430,7 @@ SpriteBase3D::SpriteBase3D() {
 	mesh_array[VS::ARRAY_COLOR] = mesh_colors;
 	mesh_array[VS::ARRAY_TEX_UV] = mesh_uvs;
 
-	VS::get_singleton()->mesh_add_surface_from_arrays(mesh, VS::PRIMITIVE_TRIANGLE_FAN, mesh_array);
+	VS::get_singleton()->mesh_add_surface_from_arrays(mesh, VS::PRIMITIVE_TRIANGLE_FAN, mesh_array, Array(), VS::ARRAY_COMPRESS_DEFAULT & ~VS::ARRAY_COMPRESS_TEX_UV);
 	const int surface_vertex_len = VS::get_singleton()->mesh_surface_get_array_len(mesh, 0);
 	const int surface_index_len = VS::get_singleton()->mesh_surface_get_array_index_len(mesh, 0);
 
@@ -551,7 +551,7 @@ void Sprite3D::_draw() {
 
 	AABB aabb;
 
-	// Buffer is using default compression, so everything except position is compressed
+	// Everything except position and UV is compressed
 	PoolVector<uint8_t>::Write write_buffer = mesh_buffer.write();
 
 	int8_t v_normal[4] = {
@@ -585,16 +585,11 @@ void Sprite3D::_draw() {
 		} else {
 			aabb.expand_to(vtx);
 		}
-		if (mesh_surface_format & VS::ARRAY_COMPRESS_TEX_UV) {
-			uint16_t v_uv[2] = { Math::make_half_float(uvs[i].x), Math::make_half_float(uvs[i].y) };
-			copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 4);
-		} else {
-			float v_uv[2] = { uvs[i].x, uvs[i].y };
-			copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 8);
-		}
+
+		float v_uv[2] = { uvs[i].x, uvs[i].y };
+		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 8);
 
 		float v_vertex[3] = { vtx.x, vtx.y, vtx.z };
-
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_NORMAL]], v_normal, 4);
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TANGENT]], v_tangent, 4);
@@ -918,7 +913,7 @@ void AnimatedSprite3D::_draw() {
 
 	AABB aabb;
 
-	// Buffer is using default compression, so everything except position is compressed
+	// Everything except position and UV is compressed
 	PoolVector<uint8_t>::Write write_buffer = mesh_buffer.write();
 
 	int8_t v_normal[4] = {
@@ -953,15 +948,10 @@ void AnimatedSprite3D::_draw() {
 			aabb.expand_to(vtx);
 		}
 
-		if (mesh_surface_format & VS::ARRAY_COMPRESS_TEX_UV) {
-			uint16_t v_uv[2] = { Math::make_half_float(uvs[i].x), Math::make_half_float(uvs[i].y) };
-			copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 4);
-		} else {
-			float v_uv[2] = { uvs[i].x, uvs[i].y };
-			copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 8);
-		}
-		float v_vertex[3] = { vtx.x, vtx.y, vtx.z };
+		float v_uv[2] = { uvs[i].x, uvs[i].y };
+		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 8);
 
+		float v_vertex[3] = { vtx.x, vtx.y, vtx.z };
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_NORMAL]], v_normal, 4);
 		copymem(&write_buffer[i * mesh_stride + mesh_surface_offsets[VS::ARRAY_TANGENT]], v_tangent, 4);


### PR DESCRIPTION
Fixes: #42509

ImmediateGeometry never compressed UVs, but ArrayMeshes compress them by default. This PR uses uncompressed UVs so you get better precision on large low-res sprites. 