### PR TITLE
Use separate texture unit for light_texture

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -2604,7 +2604,7 @@ void RasterizerCanvasGLES2::_canvas_render_item(Item *p_ci, RenderItemState &r_r
 				_set_uniforms();
 				state.canvas_shader.use_material((void *)material_ptr);
 
-				glActiveTexture(GL_TEXTURE0 + storage->config.max_texture_image_units - 4);
+				glActiveTexture(GL_TEXTURE0 + storage->config.max_texture_image_units - 6);
 				RasterizerStorageGLES2::Texture *t = storage->texture_owner.getornull(light->texture);
 				if (!t) {
 					glBindTexture(GL_TEXTURE_2D, storage->resources.white_tex);
@@ -3000,7 +3000,7 @@ void RasterizerCanvasGLES2::render_joined_item(const BItemJoined &p_bij, RenderI
 				_set_uniforms();
 				state.canvas_shader.use_material((void *)material_ptr);
 
-				glActiveTexture(GL_TEXTURE0 + storage->config.max_texture_image_units - 4);
+				glActiveTexture(GL_TEXTURE0 + storage->config.max_texture_image_units - 6);
 				RasterizerStorageGLES2::Texture *t = storage->texture_owner.getornull(light->texture);
 				if (!t) {
 					glBindTexture(GL_TEXTURE_2D, storage->resources.white_tex);

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -333,7 +333,7 @@ uniform highp float light_height;
 uniform highp float light_outside_alpha;
 uniform highp float shadow_distance_mult;
 
-uniform lowp sampler2D light_texture; // texunit:-4
+uniform lowp sampler2D light_texture; // texunit:-6
 varying vec4 light_uv_interp;
 varying vec2 transformed_light_uv;
 


### PR DESCRIPTION
Fixes: #42521

This bug has been present since the early stages of the GLES2 renderer. In https://github.com/godotengine/godot/commit/a366d458565f36856ec29b1f555edb8ecd7e16df when reduz added the screen_texture he made it share a texture unit with the light texture. I am not sure why. As a result, when lights are drawn over sprites that read from ``SCREEN_TEXTURE``, during the fragment pass they read from the light texture instead of the screen texture which results in a weird ghosting artifact. 

About 30% of GLES2 devices have only 8 texture units so we try to use as few internal texture units as possible. That may be why reduz chose to share light texture and screen texture. This change makes the Godot internal shader take up 6 texture units which leaves the user with only 2 for themselves one these devices. 

In light of the above, reduz needs to approve this change himself. It may have been an oversight, but there also may be a legitimate reason to avoid using the 6th texture unit. 