### PR TITLE
Force vertex shading in SpatialMaterial when used

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -31,6 +31,7 @@
 #include "material.h"
 
 #include "core/engine.h"
+#include "core/project_settings.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_settings.h"
@@ -473,7 +474,7 @@ void SpatialMaterial::_update_shader() {
 	if (flags[FLAG_DISABLE_DEPTH_TEST]) {
 		code += ",depth_test_disable";
 	}
-	if (flags[FLAG_USE_VERTEX_LIGHTING]) {
+	if (flags[FLAG_USE_VERTEX_LIGHTING] || force_vertex_shading) {
 		code += ",vertex_lighting";
 	}
 	if (flags[FLAG_TRIPLANAR_USE_WORLD] && (flags[FLAG_UV1_USE_TRIPLANAR] || flags[FLAG_UV2_USE_TRIPLANAR])) {
@@ -623,7 +624,7 @@ void SpatialMaterial::_update_shader() {
 		code += "\tPOINT_SIZE=point_size;\n";
 	}
 
-	if (flags[FLAG_USE_VERTEX_LIGHTING]) {
+	if (flags[FLAG_USE_VERTEX_LIGHTING] || force_vertex_shading) {
 		code += "\tROUGHNESS=roughness;\n";
 	}
 
@@ -2300,6 +2301,9 @@ SpatialMaterial::SpatialMaterial() :
 	for (int i = 0; i < FLAG_MAX; i++) {
 		flags[i] = false;
 	}
+
+	force_vertex_shading = GLOBAL_GET("rendering/quality/shading/force_vertex_shading");
+
 	diffuse_mode = DIFFUSE_BURLEY;
 	specular_mode = SPECULAR_SCHLICK_GGX;
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -434,6 +434,8 @@ private:
 
 	Ref<Texture> textures[TEXTURE_MAX];
 
+	bool force_vertex_shading = false;
+
 	_FORCE_INLINE_ void _validate_feature(const String &text, Feature feature, PropertyInfo &property) const;
 
 	static const int MAX_MATERIALS_FOR_2D = 128;


### PR DESCRIPTION
Fixes: #33835 

When using vertex lighting, roughness needs to be set in the ``vertex()`` function. When set in the SpatialMaterial it adds ``ROUGHNESS = roughness``, but when set in the ProjectSettings, ``ROUGHNESS`` is never set. This PR adds an override into SpatialMaterial so ``ROUGHNESS`` is appropriately set whether vertex lighting is set in the material or in ProjectSettings. 