### PR TITLE
Return proper texture view format for decals

### DIFF
--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
@@ -5871,7 +5871,7 @@ RID RasterizerStorageRD::decal_atlas_get_texture() const {
 }
 
 RID RasterizerStorageRD::decal_atlas_get_texture_srgb() const {
-	return decal_atlas.texture;
+	return decal_atlas.texture_srgb;
 }
 
 void RasterizerStorageRD::_update_decal_atlas() {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/1219, Closes #42073 

``decal_atlas_get_texture_srgb()`` accidentally returned the non srgb version of the decal atlas. 

**Before: Decal on left, MeshInstance on right**
![Screenshot (240)](https://user-images.githubusercontent.com/16521339/95008192-7dfafc80-05cc-11eb-8da4-1eb6e459e40e.png)

**After: Decal on left, MeshInstance on right**
![Screenshot (239)](https://user-images.githubusercontent.com/16521339/95008193-85baa100-05cc-11eb-8b99-5a0713d4c04b.png)

