### PR TITLE
[HTML5] Scons now expects "emcc" to be in PATH.

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -1,6 +1,7 @@
 import os
 
-from emscripten_helpers import parse_config, run_closure_compiler, create_engine_file
+from emscripten_helpers import run_closure_compiler, create_engine_file
+from SCons.Util import WhereIs
 
 
 def is_active():
@@ -12,7 +13,7 @@ def get_name():
 
 
 def can_build():
-    return "EM_CONFIG" in os.environ or os.path.exists(os.path.expanduser("~/.emscripten"))
+    return WhereIs("emcc") is not None
 
 
 def get_opts():
@@ -99,9 +100,6 @@ def configure(env):
 
     # Closure compiler extern and support for ecmascript specs (const, let, etc).
     env["ENV"]["EMCC_CLOSURE_ARGS"] = "--language_in ECMASCRIPT6"
-
-    em_config = parse_config()
-    env.PrependENVPath("PATH", em_config["EMCC_ROOT"])
 
     env["CC"] = "emcc"
     env["CXX"] = "em++"

--- a/platform/javascript/emscripten_helpers.py
+++ b/platform/javascript/emscripten_helpers.py
@@ -1,28 +1,11 @@
 import os
 
-
-def parse_config():
-    em_config_file = os.getenv("EM_CONFIG") or os.path.expanduser("~/.emscripten")
-    if not os.path.exists(em_config_file):
-        raise RuntimeError("Emscripten configuration file '%s' does not exist" % em_config_file)
-
-    normalized = {}
-    em_config = {}
-    with open(em_config_file) as f:
-        try:
-            # Emscripten configuration file is a Python file with simple assignments.
-            exec(f.read(), em_config)
-        except StandardError as e:
-            raise RuntimeError("Emscripten configuration file '%s' is invalid:\n%s" % (em_config_file, e))
-    normalized["EMCC_ROOT"] = em_config.get("EMSCRIPTEN_ROOT")
-    normalized["NODE_JS"] = em_config.get("NODE_JS")
-    normalized["CLOSURE_BIN"] = os.path.join(normalized["EMCC_ROOT"], "node_modules", ".bin", "google-closure-compiler")
-    return normalized
+from SCons.Util import WhereIs
 
 
 def run_closure_compiler(target, source, env, for_signature):
-    cfg = parse_config()
-    cmd = [cfg["NODE_JS"], cfg["CLOSURE_BIN"]]
+    closure_bin = os.path.join(os.path.dirname(WhereIs("emcc")), "node_modules", ".bin", "google-closure-compiler")
+    cmd = [WhereIs("node"), closure_bin]
     cmd.extend(["--compilation_level", "ADVANCED_OPTIMIZATIONS"])
     for f in env["JSEXTERNS"]:
         cmd.extend(["--externs", f.get_abspath()])


### PR DESCRIPTION
No longer parse emscripten/emsdk config to detect emcc/node paths.
Use WhereIs to find "emcc" and "node", look for "node_modules" in "emcc"
path.

Fixes #40574