### PR TITLE
[macOS] Fix GPU 3D particles shader compilation.

### DIFF
--- a/servers/rendering/rasterizer_rd/shaders/particles.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/particles.glsl
@@ -80,7 +80,7 @@ struct ParticleEmission {
 	vec4 custom;
 };
 
-layout(set = 1, binding = 2, std430) restrict volatile coherent buffer SourceEmission {
+layout(set = 1, binding = 2, std430) restrict buffer SourceEmission {
 	int particle_count;
 	uint pad0;
 	uint pad1;


### PR DESCRIPTION
Changes qualifiers to make sure `src_particles` and `particles` are in the same memory heap.

Fixes multiple `no viable overloaded operator[]` shader compilation errors, see: https://github.com/godotengine/godot/pull/41810#issuecomment-687782516.

Note: SDF GI shaper errors mentioned in https://github.com/godotengine/godot/pull/39827#discussion_r471532550 and https://github.com/godotengine/godot/pull/39827#discussion_r471549299 seems to be fixed in the new v1.1.0 (SDK 1.2.154).