### PR TITLE
Improve format version mismatch error in binary loader

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -863,7 +863,8 @@ void ResourceLoaderBinary::open(FileAccess *p_f) {
 
 	if (ver_format > FORMAT_VERSION || ver_major > VERSION_MAJOR) {
 		f->close();
-		ERR_FAIL_MSG("File format '" + itos(FORMAT_VERSION) + "." + itos(ver_major) + "." + itos(ver_minor) + "' is too new! Please upgrade to a new engine version: " + local_path + ".");
+		ERR_FAIL_MSG(vformat("File '%s' can't be loaded, as it uses a format version (%d) or engine version (%d.%d) which are not supported by your engine version (%s).",
+				local_path, ver_format, ver_major, ver_minor, VERSION_BRANCH));
 	}
 
 	type = get_unicode_string();
@@ -1136,7 +1137,9 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 	if (ver_format > FORMAT_VERSION || ver_major > VERSION_MAJOR) {
 		memdelete(f);
 		memdelete(fw);
-		ERR_FAIL_V_MSG(ERR_FILE_UNRECOGNIZED, "File format '" + itos(FORMAT_VERSION) + "." + itos(ver_major) + "." + itos(ver_minor) + "' is too new! Please upgrade to a new engine version: " + local_path + ".");
+		ERR_FAIL_V_MSG(ERR_FILE_UNRECOGNIZED,
+				vformat("File '%s' can't be loaded, as it uses a format version (%d) or engine version (%d.%d) which are not supported by your engine version (%s).",
+						local_path, ver_format, ver_major, ver_minor, VERSION_BRANCH));
 	}
 
 	// Since we're not actually converting the file contents, leave the version


### PR DESCRIPTION
The previous message would result in e.g. this when opening a project in 3.2 after using the `master` branch, which is somewhat confusing:
```
ERROR: open: File format '3.4.0' is too new! Please upgrade to a new engine version: res://sourceModels/BoxTextured/Texture.material.
   At: core/io/resource_format_binary.cpp:879.
```