### PR TITLE
Documentation change: Explaining the behavior of focus stylebox overlapping the pressed stylebox

### DIFF
--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		StyleBox is [Resource] that provides an abstract base class for drawing stylized boxes for the UI. StyleBoxes are used for drawing the styles of buttons, line edit backgrounds, tree backgrounds, etc. and also for testing a transparency mask for pointer signals. If mask test fails on a StyleBox assigned as mask to a control, clicks and motion signals will go through it to the one below.
+		[b]Note:[/b] For children of [Control] that have [i]Theme Properties[/i], the [code]focus[/code] [StyleBox] is displayed over the [code]normal[/code], [code]hover[/code] or [code]pressed[/code] [StyleBox]. This makes the [code]focus[/code] [StyleBox] more reusable across different nodes.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Fixes #42322

**Issue:** No explanation as to why a focus stylebox is displayed over pressed stylebox, when a node is pressed.

After discussion, a doc addition is made in `Stylebox` class reference to explain why focus stylebox is displayed over pressed stylebox, even when a node is pressed.