### PR TITLE
Static/Rigidbody always initializes default value

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -212,6 +212,7 @@ void StaticBody2D::_bind_methods() {
 StaticBody2D::StaticBody2D() :
 		PhysicsBody2D(PhysicsServer2D::BODY_MODE_STATIC) {
 	constant_angular_velocity = 0;
+	_reload_physics_characteristics();
 }
 
 StaticBody2D::~StaticBody2D() {
@@ -889,6 +890,7 @@ RigidBody2D::RigidBody2D() :
 	can_sleep = true;
 
 	PhysicsServer2D::get_singleton()->body_set_force_integration_callback(get_rid(), this, "_direct_state_changed");
+	_reload_physics_characteristics();
 }
 
 RigidBody2D::~RigidBody2D() {

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -223,6 +223,7 @@ void StaticBody3D::_bind_methods() {
 
 StaticBody3D::StaticBody3D() :
 		PhysicsBody3D(PhysicsServer3D::BODY_MODE_STATIC) {
+	_reload_physics_characteristics();
 }
 
 StaticBody3D::~StaticBody3D() {}
@@ -871,6 +872,7 @@ RigidBody3D::RigidBody3D() :
 	can_sleep = true;
 
 	PhysicsServer3D::get_singleton()->body_set_force_integration_callback(get_rid(), this, "_direct_state_changed");
+	_reload_physics_characteristics();
 }
 
 RigidBody3D::~RigidBody3D() {


### PR DESCRIPTION
closes #42567

The bug:
the default values of PhysicsBodies matched those of PhysicsMaterial but were not set during initialization. Instead the PhysicsServer implementation provided the default value.
GodotPhysics2D/3D provided the same values as PhysicsMaterial by default.
Bullet provides a different friction (0.5 instead of 1.0) by default.

This PR makes the physics bodies (static and rigid) always apply their default value.

This PR will break projects using Bullet that assume a default friction of 0.5

Instead of breaking compat with said Bullet projects one could alter the default values of the physics bodies/ materials to match bullet. This however would just create a similar issue/ break compat with 2D projects (and GodotPhysics3D)

Input on how to minimize compat breakage is appreciated.