### PR TITLE
Add generic support to PackedScene.Instance in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/PackedSceneExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/PackedSceneExtensions.cs
@@ -1,0 +1,27 @@
+namespace Godot
+{
+    public partial class PackedScene
+    {
+        /// <summary>
+        /// Instantiates the scene's node hierarchy, erroring on failure.
+        /// Triggers child scene instantiation(s). Triggers a
+        /// `Node.NotificationInstanced` notification on the root node.
+        /// </summary>
+        /// <typeparam name="T">The type to cast to. Should be a descendant of Node.</typeparam>
+        public T Instance<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
+        {
+            return (T)(object)Instance(editState);
+        }
+
+        /// <summary>
+        /// Instantiates the scene's node hierarchy, returning null on failure.
+        /// Triggers child scene instantiation(s). Triggers a
+        /// `Node.NotificationInstanced` notification on the root node.
+        /// </summary>
+        /// <typeparam name="T">The type to cast to. Should be a descendant of Node.</typeparam>
+        public T InstanceOrNull<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
+        {
+            return Instance(editState) as T;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -30,6 +30,7 @@
     <Compile Include="Core\DynamicObject.cs" />
     <Compile Include="Core\Extensions\NodeExtensions.cs" />
     <Compile Include="Core\Extensions\ObjectExtensions.cs" />
+    <Compile Include="Core\Extensions\PackedSceneExtensions.cs" />
     <Compile Include="Core\Extensions\ResourceLoaderExtensions.cs" />
     <Compile Include="Core\Extensions\SceneTreeExtensions.cs" />
     <Compile Include="Core\GD.cs" />


### PR DESCRIPTION
I noticed these methods were missing, so I added them: `Instance<T>` and `InstanceOrNull<T>`. These are similar to the ones in `NodeExtensions.cs`, and they require ~~`where T : Node` (btw, why does NodeExtensions have `where T : class`? another note, why does NodeExtensions have `(T)(object)` instead of just `(T)`?).~~ EDIT: After a brief discussion in #22658 this has now been changed to `where T : class` to allow for generically casting to an interface.

This was tested by cherry-picking this onto 3.2 and modifying Dodge the Creeps with C# to use these.