### PR TITLE
SCons: Add 'default' parameter for windows_subsystem, restores original behavior

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -65,7 +65,7 @@ def get_opts():
         # Vista support dropped after EOL due to GH-10243
         ("target_win_version", "Targeted Windows version, >= 0x0601 (Windows 7)", "0x0601"),
         EnumVariable("debug_symbols", "Add debugging symbols to release builds", "yes", ("yes", "no", "full")),
-        EnumVariable("windows_subsystem", "Windows subsystem", "gui", ("console", "gui")),
+        EnumVariable("windows_subsystem", "Windows subsystem", "default", ("default", "console", "gui")),
         BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         ("msvc_version", "MSVC version to use. Ignored if VCINSTALLDIR is set in shell env.", None),
         BoolVariable("use_mingw", "Use the Mingw compiler, even if MSVC is installed. Only used on Windows.", False),
@@ -178,8 +178,15 @@ def configure_msvc(env, manual_msvc_config):
     """Configure env to work with MSVC"""
 
     # Build type
+
     if env["tests"]:
         env["windows_subsystem"] = "console"
+    elif env["windows_subsystem"] == "default":
+        # Default means we use console for debug, gui for release.
+        if "debug" in env["target"]:
+            env["windows_subsystem"] = "console"
+        else:
+            env["windows_subsystem"] = "gui"
 
     if env["target"] == "release":
         if env["optimize"] == "speed":  # optimize for speed (default)
@@ -311,6 +318,12 @@ def configure_mingw(env):
 
     if env["tests"]:
         env["windows_subsystem"] = "console"
+    elif env["windows_subsystem"] == "default":
+        # Default means we use console for debug, gui for release.
+        if "debug" in env["target"]:
+            env["windows_subsystem"] = "console"
+        else:
+            env["windows_subsystem"] = "gui"
 
     if env["target"] == "release":
         env.Append(CCFLAGS=["-msse2"])


### PR DESCRIPTION
We want debug builds to have a console and easy stdout redirection by default.
Windows makes reading the stdout/stderr stream from gui applications too cumbersome
(and most users don't know about it, and just wonder why they don't see a thing).