### PR TITLE
Expose lighting functions to user fragment shader.

### DIFF
--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -2766,14 +2766,56 @@ RasterizerSceneHighEndRD::RasterizerSceneHighEndRD(RasterizerStorageRD *p_storag
 		actions.renames["RADIANCE"] = "custom_radiance";
 		actions.renames["IRRADIANCE"] = "custom_irradiance";
 
+		actions.renames["AMBIENT_LIGHT"] = "ambient_light";
+		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
+		actions.renames["SPECULAR_LIGHT"] = "specular_light";
+		actions.renames["CLUSTER_CELL"] = "cluster_cell";
+		// Functions
+		actions.renames["GET_LIGHTMAP_SH"] = "GET_LIGHTMAP_SH";
+		actions.renames["SH_COEF"] = "SH_COEF";
+		actions.renames["GET_LIGHT_POSITION"] = "GET_LIGHT_POSITION";
+		actions.renames["GET_LIGHT_INV_RADIUS"] = "GET_LIGHT_INV_RADIUS";
+		actions.renames["GET_LIGHT_DIRECTION"] = "GET_LIGHT_DIRECTION";
+		actions.renames["GET_DIR_LIGHT_DIRECTION"] = "GET_DIR_LIGHT_DIRECTION";
+		actions.renames["GET_LIGHT_SIZE_PARAM"] = "GET_LIGHT_SIZE_PARAM";
+		actions.renames["GET_DIR_LIGHT_SIZE_PARAM"] = "GET_DIR_LIGHT_SIZE_PARAM";
+		actions.renames["GET_LIGHT_ATTENUATION_PARAM"] = "GET_LIGHT_ATTENUATION_PARAM";
+		actions.renames["GET_SPOT_ATTENUATION_ANGLE_PARAM"] = "GET_SPOT_ATTENUATION_ANGLE_PARAM";
+		actions.renames["GET_OMNI_LIGHT_ATTENUATION_SIZE"] = "GET_OMNI_LIGHT_ATTENUATION_SIZE";
+		actions.renames["GET_SPOT_LIGHT_ATTENUATION_SIZE"] = "GET_SPOT_LIGHT_ATTENUATION_SIZE";
+		actions.renames["GET_LIGHT_COLOR_SPECULAR"] = "GET_LIGHT_COLOR_SPECULAR";
+		actions.renames["GET_LIGHT_SHADOW_COLOR"] = "GET_LIGHT_SHADOW_COLOR";
+		actions.renames["GET_DIR_LIGHT_COLOR_SPECULAR"] = "GET_DIR_LIGHT_COLOR_SPECULAR";
+		actions.renames["OMNI_PROJECTOR_PROCESS"] = "OMNI_PROJECTOR_PROCESS";
+		actions.renames["SPOT_PROJECTOR_PROCESS"] = "SPOT_PROJECTOR_PROCESS";
+		actions.renames["OMNI_SHADOW_PROCESS"] = "OMNI_SHADOW_PROCESS";
+		actions.renames["SPOT_SHADOW_PROCESS"] = "SPOT_SHADOW_PROCESS";
+		actions.renames["DIRECTIONAL_SHADOW_PROCESS"] = "DIRECTIONAL_SHADOW_PROCESS";
+		actions.renames["AMBIENT_PROCESS"] = "AMBIENT_PROCESS";
+		actions.renames["REFLECTION_PROCESS"] = "REFLECTION_PROCESS";
+		actions.renames["DECAL_PROCESS"] = "DECAL_PROCESS";
+		actions.renames["SHOULD_RENDER_LIGHT"] = "SHOULD_RENDER_LIGHT";
+		actions.renames["SHOULD_RENDER_DIR_LIGHT"] = "SHOULD_RENDER_DIR_LIGHT";
+		actions.renames["OMNI_LIGHT_COUNT"] = "OMNI_LIGHT_COUNT";
+		actions.renames["SPOT_LIGHT_COUNT"] = "SPOT_LIGHT_COUNT";
+		actions.renames["DIRECTIONAL_LIGHT_COUNT"] = "DIRECTIONAL_LIGHT_COUNT";
+		actions.renames["REFLECTION_PROBE_COUNT"] = "REFLECTION_PROBE_COUNT";
+		actions.renames["DECAL_COUNT"] = "DECAL_COUNT";
+		actions.renames["GET_OMNI_LIGHT"] = "GET_OMNI_LIGHT";
+		actions.renames["GET_SPOT_LIGHT"] = "GET_SPOT_LIGHT";
+		actions.renames["GET_DIRECTIONAL_LIGHT"] = "GET_DIRECTIONAL_LIGHT";
+		// Opaque Types
+		actions.renames["DirectionalLightData"] = "uint";
+		actions.renames["LightData"] = "uint";
+		actions.renames["LightmapCapture"] = "uint";
+		actions.renames["ClusterData"] = "uvec4";
+
 		//for light
 		actions.renames["VIEW"] = "view";
 		actions.renames["LIGHT_COLOR"] = "light_color";
 		actions.renames["LIGHT"] = "light";
 		actions.renames["ATTENUATION"] = "attenuation";
 		actions.renames["SHADOW_ATTENUATION"] = "shadow_attenuation";
-		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
-		actions.renames["SPECULAR_LIGHT"] = "specular_light";
 
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
 		actions.usage_defines["BINORMAL"] = "@TANGENT";
@@ -2799,6 +2841,9 @@ RasterizerSceneHighEndRD::RasterizerSceneHighEndRD(RasterizerStorageRD *p_storag
 		actions.usage_defines["SCREEN_TEXTURE"] = "#define SCREEN_TEXTURE_USED\n";
 		actions.usage_defines["SCREEN_UV"] = "#define SCREEN_UV_USED\n";
 
+		actions.usage_defines["CLUSTER_CELL"] = "#define CLUSTER_CELL_USED\n";
+		actions.usage_defines["AMBIENT_LIGHT"] = "#define AMBIENT_LIGHT_USED\n";
+		actions.usage_defines["DECAL_PROCESS"] = "#define DECAL_PROCESS_USED\n";
 		actions.usage_defines["DIFFUSE_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
 		actions.usage_defines["SPECULAR_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
 

--- a/servers/rendering/rasterizer_rd/shader_compiler_rd.cpp
+++ b/servers/rendering/rasterizer_rd/shader_compiler_rd.cpp
@@ -118,6 +118,14 @@ static int _get_datatype_size(SL::DataType p_type) {
 			return 16;
 		case SL::TYPE_SAMPLERCUBEARRAY:
 			return 16;
+		case SL::TYPE_CLUSTERDATA:
+			return 16;
+		case SL::TYPE_LIGHTDATA:
+			return 4;
+		case SL::TYPE_DIRECTIONALLIGHTDATA:
+			return 4;
+		case SL::TYPE_LIGHTMAPCAPTURE:
+			return 4;
 		case SL::TYPE_STRUCT:
 			return 0;
 
@@ -193,6 +201,14 @@ static int _get_datatype_alignment(SL::DataType p_type) {
 			return 16;
 		case SL::TYPE_SAMPLERCUBEARRAY:
 			return 16;
+		case SL::TYPE_CLUSTERDATA:
+			return 16;
+		case SL::TYPE_LIGHTDATA:
+			return 4;
+		case SL::TYPE_DIRECTIONALLIGHTDATA:
+			return 4;
+		case SL::TYPE_LIGHTMAPCAPTURE:
+			return 4;
 		case SL::TYPE_STRUCT:
 			return 0;
 		case SL::TYPE_MAX: {
@@ -1066,6 +1082,15 @@ String ShaderCompilerRD::_dump_node_code(const SL::Node *p_node, int p_level, Ge
 					ERR_FAIL_COND_V(onode->arguments[0]->type != SL::Node::TYPE_VARIABLE, String());
 
 					SL::VariableNode *vnode = (SL::VariableNode *)onode->arguments[0];
+
+					if (p_default_actions.usage_defines.has(vnode->name) && !used_name_defines.has(vnode->name)) {
+						String define = p_default_actions.usage_defines[vnode->name];
+						if (define.begins_with("@")) {
+							define = p_default_actions.usage_defines[define.substr(1, define.length())];
+						}
+						r_gen_code.defines.push_back(define);
+						used_name_defines.insert(vnode->name);
+					}
 
 					bool is_texture_func = false;
 					if (onode->op == SL::OP_STRUCT) {

--- a/servers/rendering/rasterizer_rd/shaders/scene_high_end.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/scene_high_end.glsl
@@ -1603,6 +1603,130 @@ void sdfgi_process(uint cascade, vec3 cascade_pos, vec3 cam_pos, vec3 cam_normal
 	}
 }
 
+bool directional_shadow_process(uint i, vec3 vertex, inout vec3 shadow_color, inout float shadow, inout float transmittance_z) {
+	if (!directional_lights.data[i].shadow_enabled) {
+		return false;
+	}
+
+	float depth_z = -vertex.z;
+
+	vec4 pssm_coord;
+	vec3 light_dir = directional_lights.data[i].direction;
+
+#define BIAS_FUNC(m_var, m_idx)                                                                                                                                  \
+	m_var.xyz += light_dir * directional_lights.data[i].shadow_bias[m_idx];                                                                                      \
+	normal_bias = normalize(normal_interp) * (1.0 - max(0.0, dot(light_dir, -normalize(normal_interp)))) * directional_lights.data[i].shadow_normal_bias[m_idx]; \
+	normal_bias -= light_dir * dot(light_dir, normal_bias);                                                                                                      \
+	m_var.xyz += normal_bias;
+
+	float range_pos;
+	float range_begin;
+	vec2 uv_scale;
+	vec3 normal_bias;
+
+	float pssm_blend;
+	vec3 shadow_color_blend = vec3(0.0);
+	float range_pos_blend;
+	float range_begin_blend;
+	vec2 uv_scale_blend;
+	vec4 pssm_coord_blend;
+
+#ifdef LIGHT_TRANSMITTANCE_USED
+	vec4 trans_coord;
+	float shadow_z_range;
+#define COLLECT_SHADOW_INPUT_TRANSMITTANCE(m_idx_onebase)                                                                                       \
+	vec4 trans_vertex = vec4(vertex - normalize(normal_interp) * directional_lights.data[i].shadow_transmittance_bias[m_idx_onebase - 1], 1.0); \
+	trans_coord = directional_lights.data[i].shadow_matrix##m_idx_onebase * trans_vertex;                                                       \
+	shadow_z_range = directional_lights.data[i].shadow_z_range[m_idx_onebase - 1];
+#else
+#define COLLECT_SHADOW_INPUT_TRANSMITTANCE(m_idx_onebase)
+#endif
+
+#define COLLECT_SHADOW_INPUT(m_idx_onebase, m_blend_idx_onebase, m_pssm_blend_value)                \
+	range_begin = directional_lights.data[i].shadow_range_begin[m_idx_onebase - 1];                 \
+	uv_scale = directional_lights.data[i].uv_scale##m_idx_onebase;                                  \
+	vec4 v = vec4(vertex, 1.0);                                                                     \
+	BIAS_FUNC(v, m_idx_onebase - 1);                                                                \
+	range_pos = dot(directional_lights.data[i].direction, v.xyz);                                   \
+	pssm_coord = (directional_lights.data[i].shadow_matrix##m_idx_onebase * v);                     \
+	shadow_color = directional_lights.data[i].shadow_color##m_idx_onebase.rgb;                      \
+	v = vec4(vertex, 1.0);                                                                          \
+	BIAS_FUNC(v, m_blend_idx_onebase - 1);                                                          \
+	if (directional_lights.data[i].blend_splits) {                                                  \
+		range_begin_blend = directional_lights.data[i].shadow_range_begin[m_blend_idx_onebase - 1]; \
+		uv_scale_blend = directional_lights.data[i].uv_scale##m_blend_idx_onebase;                  \
+		range_pos_blend = dot(directional_lights.data[i].direction, v.xyz);                         \
+		pssm_blend = m_pssm_blend_value;                                                            \
+		pssm_coord_blend = (directional_lights.data[i].shadow_matrix##m_blend_idx_onebase * v);     \
+		shadow_color_blend = directional_lights.data[i].shadow_color##m_blend_idx_onebase.rgb;      \
+	}                                                                                               \
+	COLLECT_SHADOW_INPUT_TRANSMITTANCE(m_idx_onebase);
+
+	if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+		COLLECT_SHADOW_INPUT(1, 2, smoothstep(1.0, directional_lights.data[i].shadow_split_offsets.x, depth_z));
+	} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+		COLLECT_SHADOW_INPUT(2, 3, smoothstep(directional_lights.data[i].shadow_split_offsets.x, directional_lights.data[i].shadow_split_offsets.y, depth_z));
+	} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+		COLLECT_SHADOW_INPUT(3, 4, smoothstep(directional_lights.data[i].shadow_split_offsets.y, directional_lights.data[i].shadow_split_offsets.z, depth_z));
+	} else {
+		COLLECT_SHADOW_INPUT(4, 4, 0.0);
+	}
+#undef COLLECT_SHADOW_INPUT
+#undef COLLECT_SHADOW_INPUT_TRANSMITTANCE
+#undef BIAS_FUNC
+
+	{
+		pssm_coord /= pssm_coord.w;
+
+		if (directional_lights.data[i].softshadow_angle > 0) {
+			float range_pos = range_pos;
+			float range_begin = range_begin;
+			float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
+			vec2 tex_scale = uv_scale * test_radius;
+			shadow = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale);
+		} else {
+			shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
+		}
+
+#ifdef LIGHT_TRANSMITTANCE_USED
+		{
+			trans_coord /= trans_coord.w;
+
+			float shadow_z = textureLod(sampler2D(directional_shadow_atlas, material_samplers[SAMPLER_LINEAR_CLAMP]), trans_coord.xy, 0.0).r;
+			shadow_z *= shadow_z_range;
+			float z = shadow_z_range;
+
+			transmittance_z = z - shadow_z;
+		}
+#endif
+	}
+	if (directional_lights.data[i].blend_splits) {
+		float shadow2;
+
+		if (any(lessThan(vec3(depth_z), vec3(directional_lights.data[i].shadow_split_offsets.xyz)))) {
+			pssm_coord_blend /= pssm_coord_blend.w;
+
+			if (directional_lights.data[i].softshadow_angle > 0) {
+				float range_pos = range_pos_blend;
+				float range_begin = range_begin_blend;
+				float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
+				vec2 tex_scale = uv_scale_blend * test_radius;
+				shadow2 = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord_blend.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale);
+			} else {
+				shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord_blend);
+			}
+		}
+
+		pssm_blend = sqrt(pssm_blend);
+
+		shadow = mix(shadow, shadow2, pssm_blend);
+		shadow_color = mix(shadow_color, shadow_color_blend, pssm_blend);
+	}
+
+	shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+	return true;
+}
+
 #endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 #ifndef MODE_RENDER_DEPTH
@@ -2219,235 +2343,14 @@ FRAGMENT_SHADER_CODE
 				continue; //not masked
 			}
 
-			vec3 shadow_attenuation = vec3(1.0);
+			vec3 shadow_color = vec3(1.0);
+			float shadow = 1.0;
 
-#ifdef LIGHT_TRANSMITTANCE_USED
 			float transmittance_z = transmittance_depth;
-#endif
 
-			if (directional_lights.data[i].shadow_enabled) {
-				float depth_z = -vertex.z;
+			directional_shadow_process(i, vertex, shadow_color, shadow, transmittance_z);
 
-				vec4 pssm_coord;
-				vec3 shadow_color = vec3(0.0);
-				vec3 light_dir = directional_lights.data[i].direction;
-
-#define BIAS_FUNC(m_var, m_idx)                                                                                                                                       \
-	m_var.xyz += light_dir * directional_lights.data[i].shadow_bias[m_idx];                                                                                           \
-	vec3 normal_bias = normalize(normal_interp) * (1.0 - max(0.0, dot(light_dir, -normalize(normal_interp)))) * directional_lights.data[i].shadow_normal_bias[m_idx]; \
-	normal_bias -= light_dir * dot(light_dir, normal_bias);                                                                                                           \
-	m_var.xyz += normal_bias;
-
-				float shadow = 0.0;
-
-				if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
-					vec4 v = vec4(vertex, 1.0);
-
-					BIAS_FUNC(v, 0)
-
-					pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
-					pssm_coord /= pssm_coord.w;
-
-					if (directional_lights.data[i].softshadow_angle > 0) {
-						float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-						float range_begin = directional_lights.data[i].shadow_range_begin.x;
-						float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
-						vec2 tex_scale = directional_lights.data[i].uv_scale1 * test_radius;
-						shadow = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale);
-					} else {
-						shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
-					}
-
-					shadow_color = directional_lights.data[i].shadow_color1.rgb;
-
-#ifdef LIGHT_TRANSMITTANCE_USED
-					{
-						vec4 trans_vertex = vec4(vertex - normalize(normal_interp) * directional_lights.data[i].shadow_transmittance_bias.x, 1.0);
-						vec4 trans_coord = directional_lights.data[i].shadow_matrix1 * trans_vertex;
-						trans_coord /= trans_coord.w;
-
-						float shadow_z = textureLod(sampler2D(directional_shadow_atlas, material_samplers[SAMPLER_LINEAR_CLAMP]), trans_coord.xy, 0.0).r;
-						shadow_z *= directional_lights.data[i].shadow_z_range.x;
-						float z = trans_coord.z * directional_lights.data[i].shadow_z_range.x;
-
-						transmittance_z = z - shadow_z;
-					}
-#endif
-				} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
-					vec4 v = vec4(vertex, 1.0);
-
-					BIAS_FUNC(v, 1)
-
-					pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
-					pssm_coord /= pssm_coord.w;
-
-					if (directional_lights.data[i].softshadow_angle > 0) {
-						float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-						float range_begin = directional_lights.data[i].shadow_range_begin.y;
-						float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
-						vec2 tex_scale = directional_lights.data[i].uv_scale2 * test_radius;
-						shadow = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale);
-					} else {
-						shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
-					}
-
-					shadow_color = directional_lights.data[i].shadow_color2.rgb;
-#ifdef LIGHT_TRANSMITTANCE_USED
-					{
-						vec4 trans_vertex = vec4(vertex - normalize(normal_interp) * directional_lights.data[i].shadow_transmittance_bias.y, 1.0);
-						vec4 trans_coord = directional_lights.data[i].shadow_matrix2 * trans_vertex;
-						trans_coord /= trans_coord.w;
-
-						float shadow_z = textureLod(sampler2D(directional_shadow_atlas, material_samplers[SAMPLER_LINEAR_CLAMP]), trans_coord.xy, 0.0).r;
-						shadow_z *= directional_lights.data[i].shadow_z_range.y;
-						float z = trans_coord.z * directional_lights.data[i].shadow_z_range.y;
-
-						transmittance_z = z - shadow_z;
-					}
-#endif
-				} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
-					vec4 v = vec4(vertex, 1.0);
-
-					BIAS_FUNC(v, 2)
-
-					pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
-					pssm_coord /= pssm_coord.w;
-
-					if (directional_lights.data[i].softshadow_angle > 0) {
-						float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-						float range_begin = directional_lights.data[i].shadow_range_begin.z;
-						float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
-						vec2 tex_scale = directional_lights.data[i].uv_scale3 * test_radius;
-						shadow = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale);
-					} else {
-						shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
-					}
-
-					shadow_color = directional_lights.data[i].shadow_color3.rgb;
-#ifdef LIGHT_TRANSMITTANCE_USED
-					{
-						vec4 trans_vertex = vec4(vertex - normalize(normal_interp) * directional_lights.data[i].shadow_transmittance_bias.z, 1.0);
-						vec4 trans_coord = directional_lights.data[i].shadow_matrix3 * trans_vertex;
-						trans_coord /= trans_coord.w;
-
-						float shadow_z = textureLod(sampler2D(directional_shadow_atlas, material_samplers[SAMPLER_LINEAR_CLAMP]), trans_coord.xy, 0.0).r;
-						shadow_z *= directional_lights.data[i].shadow_z_range.z;
-						float z = trans_coord.z * directional_lights.data[i].shadow_z_range.z;
-
-						transmittance_z = z - shadow_z;
-					}
-#endif
-
-				} else {
-					vec4 v = vec4(vertex, 1.0);
-
-					BIAS_FUNC(v, 3)
-
-					pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
-					pssm_coord /= pssm_coord.w;
-
-					if (directional_lights.data[i].softshadow_angle > 0) {
-						float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-						float range_begin = directional_lights.data[i].shadow_range_begin.w;
-						float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
-						vec2 tex_scale = directional_lights.data[i].uv_scale4 * test_radius;
-						shadow = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale);
-					} else {
-						shadow = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
-					}
-
-					shadow_color = directional_lights.data[i].shadow_color4.rgb;
-
-#ifdef LIGHT_TRANSMITTANCE_USED
-					{
-						vec4 trans_vertex = vec4(vertex - normalize(normal_interp) * directional_lights.data[i].shadow_transmittance_bias.w, 1.0);
-						vec4 trans_coord = directional_lights.data[i].shadow_matrix4 * trans_vertex;
-						trans_coord /= trans_coord.w;
-
-						float shadow_z = textureLod(sampler2D(directional_shadow_atlas, material_samplers[SAMPLER_LINEAR_CLAMP]), trans_coord.xy, 0.0).r;
-						shadow_z *= directional_lights.data[i].shadow_z_range.w;
-						float z = trans_coord.z * directional_lights.data[i].shadow_z_range.w;
-
-						transmittance_z = z - shadow_z;
-					}
-#endif
-				}
-
-				if (directional_lights.data[i].blend_splits) {
-					vec3 shadow_color_blend = vec3(0.0);
-					float pssm_blend;
-					float shadow2;
-
-					if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
-						vec4 v = vec4(vertex, 1.0);
-						BIAS_FUNC(v, 1)
-						pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
-						pssm_coord /= pssm_coord.w;
-
-						if (directional_lights.data[i].softshadow_angle > 0) {
-							float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-							float range_begin = directional_lights.data[i].shadow_range_begin.y;
-							float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
-							vec2 tex_scale = directional_lights.data[i].uv_scale2 * test_radius;
-							shadow2 = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale);
-						} else {
-							shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
-						}
-
-						pssm_blend = smoothstep(0.0, directional_lights.data[i].shadow_split_offsets.x, depth_z);
-						shadow_color_blend = directional_lights.data[i].shadow_color2.rgb;
-					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
-						vec4 v = vec4(vertex, 1.0);
-						BIAS_FUNC(v, 2)
-						pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
-						pssm_coord /= pssm_coord.w;
-
-						if (directional_lights.data[i].softshadow_angle > 0) {
-							float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-							float range_begin = directional_lights.data[i].shadow_range_begin.z;
-							float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
-							vec2 tex_scale = directional_lights.data[i].uv_scale3 * test_radius;
-							shadow2 = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale);
-						} else {
-							shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
-						}
-
-						pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x, directional_lights.data[i].shadow_split_offsets.y, depth_z);
-
-						shadow_color_blend = directional_lights.data[i].shadow_color3.rgb;
-					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
-						vec4 v = vec4(vertex, 1.0);
-						BIAS_FUNC(v, 3)
-						pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
-						pssm_coord /= pssm_coord.w;
-						if (directional_lights.data[i].softshadow_angle > 0) {
-							float range_pos = dot(directional_lights.data[i].direction, v.xyz);
-							float range_begin = directional_lights.data[i].shadow_range_begin.w;
-							float test_radius = (range_pos - range_begin) * directional_lights.data[i].softshadow_angle;
-							vec2 tex_scale = directional_lights.data[i].uv_scale4 * test_radius;
-							shadow2 = sample_directional_soft_shadow(directional_shadow_atlas, pssm_coord.xyz, tex_scale * directional_lights.data[i].soft_shadow_scale);
-						} else {
-							shadow2 = sample_directional_pcf_shadow(directional_shadow_atlas, scene_data.directional_shadow_pixel_size * directional_lights.data[i].soft_shadow_scale, pssm_coord);
-						}
-
-						pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y, directional_lights.data[i].shadow_split_offsets.z, depth_z);
-						shadow_color_blend = directional_lights.data[i].shadow_color4.rgb;
-					} else {
-						pssm_blend = 0.0; //if no blend, same coord will be used (divide by z will result in same value, and already cached)
-					}
-
-					pssm_blend = sqrt(pssm_blend);
-
-					shadow = mix(shadow, shadow2, pssm_blend);
-					shadow_color = mix(shadow_color, shadow_color_blend, pssm_blend);
-				}
-
-				shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
-
-				shadow_attenuation = mix(shadow_color, vec3(1.0), shadow);
-
-#undef BIAS_FUNC
-			}
+			vec3 shadow_attenuation = mix(shadow_color, vec3(1.0), shadow);
 
 			light_compute(normal, directional_lights.data[i].direction, normalize(view), directional_lights.data[i].size, directional_lights.data[i].color * directional_lights.data[i].energy, 1.0, shadow_attenuation, albedo, roughness, metallic, specular, directional_lights.data[i].specular * specular_blob_intensity,
 #ifdef LIGHT_BACKLIGHT_USED

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -129,6 +129,10 @@ const char *ShaderLanguage::token_names[TK_MAX] = {
 	"TYPE_USAMPLER3D",
 	"TYPE_SAMPLERCUBE",
 	"TYPE_SAMPLERCUBEARRAY",
+	"TYPE_CLUSTERDATA",
+	"TYPE_LIGHTDATA",
+	"TYPE_DIRECTIONALLIGHTDATA",
+	"TYPE_LIGHTMAPCAPTURE",
 	"INTERPOLATION_FLAT",
 	"INTERPOLATION_SMOOTH",
 	"CONST",
@@ -279,6 +283,10 @@ const ShaderLanguage::KeyWord ShaderLanguage::keyword_list[] = {
 	{ TK_TYPE_USAMPLER3D, "usampler3D" },
 	{ TK_TYPE_SAMPLERCUBE, "samplerCube" },
 	{ TK_TYPE_SAMPLERCUBEARRAY, "samplerCubeArray" },
+	{ TK_TYPE_CLUSTERDATA, "ClusterData" },
+	{ TK_TYPE_LIGHTDATA, "LightData" },
+	{ TK_TYPE_DIRECTIONALLIGHTDATA, "DirectionalLightData" },
+	{ TK_TYPE_LIGHTMAPCAPTURE, "LightmapCapture" },
 	{ TK_INTERPOLATION_FLAT, "flat" },
 	{ TK_INTERPOLATION_SMOOTH, "smooth" },
 	{ TK_CONST, "const" },
@@ -735,7 +743,11 @@ bool ShaderLanguage::is_token_variable_datatype(TokenType p_type) {
 			p_type == TK_TYPE_VEC4 ||
 			p_type == TK_TYPE_MAT2 ||
 			p_type == TK_TYPE_MAT3 ||
-			p_type == TK_TYPE_MAT4);
+			p_type == TK_TYPE_MAT4 ||
+			p_type == TK_TYPE_LIGHTDATA ||
+			p_type == TK_TYPE_LIGHTMAPCAPTURE ||
+			p_type == TK_TYPE_DIRECTIONALLIGHTDATA ||
+			p_type == TK_TYPE_CLUSTERDATA);
 }
 
 bool ShaderLanguage::is_token_datatype(TokenType p_type) {
@@ -770,7 +782,11 @@ bool ShaderLanguage::is_token_datatype(TokenType p_type) {
 			p_type == TK_TYPE_ISAMPLER3D ||
 			p_type == TK_TYPE_USAMPLER3D ||
 			p_type == TK_TYPE_SAMPLERCUBE ||
-			p_type == TK_TYPE_SAMPLERCUBEARRAY);
+			p_type == TK_TYPE_SAMPLERCUBEARRAY ||
+			p_type == TK_TYPE_LIGHTDATA ||
+			p_type == TK_TYPE_LIGHTMAPCAPTURE ||
+			p_type == TK_TYPE_DIRECTIONALLIGHTDATA ||
+			p_type == TK_TYPE_CLUSTERDATA);
 }
 
 ShaderLanguage::DataType ShaderLanguage::get_token_datatype(TokenType p_type) {
@@ -886,6 +902,14 @@ String ShaderLanguage::get_datatype_name(DataType p_type) {
 			return "samplerCube";
 		case TYPE_SAMPLERCUBEARRAY:
 			return "samplerCubeArray";
+		case TYPE_DIRECTIONALLIGHTDATA:
+			return "uint"; //"DirectionalLightData";
+		case TYPE_LIGHTDATA:
+			return "uint"; //"LightData";
+		case TYPE_LIGHTMAPCAPTURE:
+			return "uint"; //"LightmapCapture";
+		case TYPE_CLUSTERDATA:
+			return "uvec4"; //"ClusterData";
 		case TYPE_STRUCT:
 			return "struct";
 		case TYPE_MAX:
@@ -2156,6 +2180,41 @@ const ShaderLanguage::BuiltinFuncDef ShaderLanguage::builtin_func_defs[] = {
 	{ "fma", TYPE_VEC3, { TYPE_VEC3, TYPE_VEC3, TYPE_VEC3, TYPE_VOID }, TAG_GLOBAL, false },
 	{ "fma", TYPE_VEC4, { TYPE_VEC4, TYPE_VEC4, TYPE_VEC4, TYPE_VOID }, TAG_GLOBAL, false },
 
+	// access to Godot shading information
+	{ "GET_LIGHTMAP_SH", TYPE_BOOL, { TYPE_LIGHTMAPCAPTURE, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "SH_COEF", TYPE_VEC4, { TYPE_LIGHTMAPCAPTURE, TYPE_UINT, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_LIGHT_POSITION", TYPE_VEC3, { TYPE_LIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_LIGHT_INV_RADIUS", TYPE_FLOAT, { TYPE_LIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_LIGHT_DIRECTION", TYPE_VEC3, { TYPE_LIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_DIR_LIGHT_DIRECTION", TYPE_VEC3, { TYPE_DIRECTIONALLIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_LIGHT_SIZE_PARAM", TYPE_FLOAT, { TYPE_LIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_DIR_LIGHT_SIZE_PARAM", TYPE_FLOAT, { TYPE_DIRECTIONALLIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_LIGHT_ATTENUATION_PARAM", TYPE_FLOAT, { TYPE_LIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_SPOT_ATTENUATION_ANGLE_PARAM", TYPE_VEC2, { TYPE_LIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_OMNI_LIGHT_ATTENUATION_SIZE", TYPE_VEC2, { TYPE_LIGHTDATA, TYPE_VEC3, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_SPOT_LIGHT_ATTENUATION_SIZE", TYPE_VEC2, { TYPE_LIGHTDATA, TYPE_VEC3, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_LIGHT_COLOR_SPECULAR", TYPE_VEC4, { TYPE_LIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_LIGHT_SHADOW_COLOR", TYPE_VEC3, { TYPE_LIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_DIR_LIGHT_COLOR_SPECULAR", TYPE_VEC4, { TYPE_DIRECTIONALLIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "OMNI_PROJECTOR_PROCESS", TYPE_VEC3, { TYPE_LIGHTDATA, TYPE_VEC3, TYPE_VEC3, TYPE_VEC3, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "SPOT_PROJECTOR_PROCESS", TYPE_VEC3, { TYPE_LIGHTDATA, TYPE_VEC3, TYPE_VEC3, TYPE_VEC3, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "OMNI_SHADOW_PROCESS", TYPE_BOOL, { TYPE_LIGHTDATA, TYPE_VEC3, TYPE_VEC3, TYPE_FLOAT, TYPE_FLOAT, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "SPOT_SHADOW_PROCESS", TYPE_BOOL, { TYPE_LIGHTDATA, TYPE_VEC3, TYPE_VEC3, TYPE_FLOAT, TYPE_FLOAT, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "DIRECTIONAL_SHADOW_PROCESS", TYPE_BOOL, { TYPE_DIRECTIONALLIGHTDATA, TYPE_VEC3, TYPE_VEC3, TYPE_VEC3, TYPE_FLOAT, TYPE_FLOAT, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "AMBIENT_PROCESS", TYPE_VOID, { TYPE_VEC3, TYPE_VEC3, TYPE_FLOAT, TYPE_FLOAT, TYPE_BOOL, TYPE_VEC3, TYPE_VEC2, TYPE_VEC3, TYPE_VEC3, TYPE_VEC3, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "REFLECTION_PROCESS", TYPE_VOID, { TYPE_CLUSTERDATA, TYPE_UINT, TYPE_VEC3, TYPE_VEC3, TYPE_FLOAT, TYPE_VEC3, TYPE_VEC3, TYPE_VEC4, TYPE_VEC4, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "DECAL_PROCESS", TYPE_BOOL, { TYPE_CLUSTERDATA, TYPE_UINT, TYPE_VEC3, TYPE_VEC3, TYPE_VEC3, TYPE_VEC3, TYPE_VEC3, TYPE_VEC4, TYPE_VEC4, TYPE_VEC4, TYPE_VEC3, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "SHOULD_RENDER_LIGHT", TYPE_BOOL, { TYPE_LIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "SHOULD_RENDER_DIR_LIGHT", TYPE_BOOL, { TYPE_DIRECTIONALLIGHTDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "OMNI_LIGHT_COUNT", TYPE_UINT, { TYPE_CLUSTERDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "SPOT_LIGHT_COUNT", TYPE_UINT, { TYPE_CLUSTERDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "DIRECTIONAL_LIGHT_COUNT", TYPE_UINT, { TYPE_VOID }, TAG_GLOBAL, true },
+	{ "REFLECTION_PROBE_COUNT", TYPE_UINT, { TYPE_CLUSTERDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "DECAL_COUNT", TYPE_UINT, { TYPE_CLUSTERDATA, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_OMNI_LIGHT", TYPE_LIGHTDATA, { TYPE_CLUSTERDATA, TYPE_UINT, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_SPOT_LIGHT", TYPE_LIGHTDATA, { TYPE_CLUSTERDATA, TYPE_UINT, TYPE_VOID }, TAG_GLOBAL, true },
+	{ "GET_DIRECTIONAL_LIGHT", TYPE_DIRECTIONALLIGHTDATA, { TYPE_UINT, TYPE_VOID }, TAG_GLOBAL, true },
+
 	{ nullptr, TYPE_VOID, { TYPE_VOID }, TAG_GLOBAL, false }
 
 };
@@ -2163,6 +2222,13 @@ const ShaderLanguage::BuiltinFuncDef ShaderLanguage::builtin_func_defs[] = {
 const ShaderLanguage::BuiltinFuncOutArgs ShaderLanguage::builtin_func_out_args[] = {
 	//constructors
 	{ "modf", 1 },
+	{ "GET_LIGHTMAP_SH", 0 },
+	{ "AMBIENT_PROCESS", 7 },
+	{ "REFLECTION_PROCESS", 7 },
+	{ "OMNI_SHADOW_PROCESS", 3 },
+	{ "SPOT_SHADOW_PROCESS", 3 },
+	{ "DIRECTIONAL_SHADOW_PROCESS", 3 },
+	{ "DECAL_PROCESS", 6 },
 	{ nullptr, 0 }
 };
 
@@ -2211,7 +2277,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 	bool unsupported_builtin = false;
 	int builtin_idx = 0;
 
-	if (argcount <= 4) {
+	if (argcount <= BuiltinFuncDef::MAX_ARGS - 1) {
 		// test builtins
 		int idx = 0;
 
@@ -2243,7 +2309,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 					}
 				}
 
-				if (!fail && argcount < 4 && builtin_func_defs[idx].args[argcount] != TYPE_VOID) {
+				if (!fail && argcount < BuiltinFuncDef::MAX_ARGS - 1 && builtin_func_defs[idx].args[argcount] != TYPE_VOID) {
 					fail = true; //make sure the number of arguments matches
 				}
 
@@ -2254,7 +2320,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 						if (String(name) == builtin_func_out_args[outarg_idx].name) {
 							int arg_idx = builtin_func_out_args[outarg_idx].argument;
 
-							if (arg_idx < argcount) {
+							while (arg_idx < argcount) {
 								if (p_func->arguments[arg_idx + 1]->type != Node::TYPE_VARIABLE && p_func->arguments[arg_idx + 1]->type != Node::TYPE_MEMBER && p_func->arguments[arg_idx + 1]->type != Node::TYPE_ARRAY) {
 									_set_error("Argument " + itos(arg_idx + 1) + " of function '" + String(name) + "' is not a variable, array or member.");
 									return false;
@@ -2335,6 +2401,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 									_set_error("Argument " + itos(arg_idx + 1) + " of function '" + String(name) + "' can only take a local variable, array or member.");
 									return false;
 								}
+								arg_idx++;
 							}
 						}
 
@@ -2765,6 +2832,12 @@ Variant ShaderLanguage::constant_value_to_variant(const Vector<ShaderLanguage::C
 				// Texture types, likely not relevant here.
 				break;
 			}
+			case ShaderLanguage::TYPE_CLUSTERDATA:
+			case ShaderLanguage::TYPE_LIGHTDATA:
+			case ShaderLanguage::TYPE_DIRECTIONALLIGHTDATA:
+			case ShaderLanguage::TYPE_LIGHTMAPCAPTURE: {
+				break;
+			}
 			case ShaderLanguage::TYPE_STRUCT:
 				break;
 			case ShaderLanguage::TYPE_VOID:
@@ -2875,6 +2948,14 @@ PropertyInfo ShaderLanguage::uniform_to_property_info(const ShaderNode::Uniform 
 			pi.hint = PROPERTY_HINT_RESOURCE_TYPE;
 			pi.hint_string = "TextureLayered";
 		} break;
+		case ShaderLanguage::TYPE_CLUSTERDATA:
+			break;
+		case ShaderLanguage::TYPE_LIGHTDATA:
+			break;
+		case ShaderLanguage::TYPE_DIRECTIONALLIGHTDATA:
+			break;
+		case ShaderLanguage::TYPE_LIGHTMAPCAPTURE:
+			break;
 		case ShaderLanguage::TYPE_STRUCT: {
 			// FIXME: Implement this.
 		} break;
@@ -2926,6 +3007,11 @@ uint32_t ShaderLanguage::get_type_size(DataType p_type) {
 		case TYPE_SAMPLERCUBE:
 		case TYPE_SAMPLERCUBEARRAY:
 			return 4; //not really, but useful for indices
+		case TYPE_CLUSTERDATA:
+		case TYPE_LIGHTDATA:
+		case TYPE_DIRECTIONALLIGHTDATA:
+		case TYPE_LIGHTMAPCAPTURE:
+			return 0;
 		case TYPE_STRUCT:
 			// FIXME: Implement.
 			return 0;
@@ -2975,6 +3061,7 @@ void ShaderLanguage::get_builtin_funcs(List<String> *r_keywords) {
 }
 
 ShaderLanguage::DataType ShaderLanguage::get_scalar_type(DataType p_type) {
+	// FIXME: out of sync with enum
 	static const DataType scalar_types[] = {
 		TYPE_VOID,
 		TYPE_BOOL,
@@ -3000,12 +3087,26 @@ ShaderLanguage::DataType ShaderLanguage::get_scalar_type(DataType p_type) {
 		TYPE_INT,
 		TYPE_UINT,
 		TYPE_FLOAT,
+		TYPE_INT,
+		TYPE_UINT,
+		TYPE_FLOAT,
+		TYPE_INT,
+		TYPE_UINT,
+		TYPE_FLOAT,
+		TYPE_FLOAT,
+		TYPE_FLOAT,
+		TYPE_VOID,
+		TYPE_VOID,
+		TYPE_VOID,
+		TYPE_VOID,
+		TYPE_VOID,
 	};
 
 	return scalar_types[p_type];
 }
 
 int ShaderLanguage::get_cardinality(DataType p_type) {
+	// FIXME: out of sync with enum
 	static const int cardinality_table[] = {
 		0,
 		1,
@@ -3027,6 +3128,22 @@ int ShaderLanguage::get_cardinality(DataType p_type) {
 		4,
 		9,
 		16,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
 		1,
 		1,
 		1,
@@ -7525,7 +7642,7 @@ Error ShaderLanguage::complete(const String &p_code, const Map<StringName, Funct
 							calltip += char32_t(0xFFFF);
 						}
 
-						if (out_arg >= 0 && i == out_arg) {
+						if (out_arg >= 0 && i >= out_arg) {
 							calltip += "out ";
 						}
 

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -79,6 +79,10 @@ public:
 		TK_TYPE_USAMPLER3D,
 		TK_TYPE_SAMPLERCUBE,
 		TK_TYPE_SAMPLERCUBEARRAY,
+		TK_TYPE_CLUSTERDATA,
+		TK_TYPE_LIGHTDATA,
+		TK_TYPE_DIRECTIONALLIGHTDATA,
+		TK_TYPE_LIGHTMAPCAPTURE,
 		TK_INTERPOLATION_FLAT,
 		TK_INTERPOLATION_SMOOTH,
 		TK_CONST,
@@ -219,6 +223,10 @@ public:
 		TYPE_USAMPLER3D,
 		TYPE_SAMPLERCUBE,
 		TYPE_SAMPLERCUBEARRAY,
+		TYPE_CLUSTERDATA,
+		TYPE_LIGHTDATA,
+		TYPE_DIRECTIONALLIGHTDATA,
+		TYPE_LIGHTMAPCAPTURE,
 		TYPE_STRUCT,
 		TYPE_MAX
 	};
@@ -825,7 +833,7 @@ private:
 	bool _validate_operator(OperatorNode *p_op, DataType *r_ret_type = nullptr);
 
 	struct BuiltinFuncDef {
-		enum { MAX_ARGS = 5 };
+		enum { MAX_ARGS = 12 };
 		const char *name;
 		DataType rettype;
 		const DataType args[MAX_ARGS];

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -119,6 +119,9 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["DEPTH"] = ShaderLanguage::TYPE_FLOAT;
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["SCREEN_UV"] = ShaderLanguage::TYPE_VEC2;
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["POINT_COORD"] = constt(ShaderLanguage::TYPE_VEC2);
+	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["AMBIENT_LIGHT"] = ShaderLanguage::TYPE_VEC3;
+	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["DIFFUSE_LIGHT"] = ShaderLanguage::TYPE_VEC3;
+	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["SPECULAR_LIGHT"] = ShaderLanguage::TYPE_VEC3;
 
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["OUTPUT_IS_SRGB"] = constt(ShaderLanguage::TYPE_BOOL);
 
@@ -132,6 +135,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["FOG"] = ShaderLanguage::TYPE_VEC4; // TODO consider adding to light shader
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["RADIANCE"] = ShaderLanguage::TYPE_VEC4;
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["IRRADIANCE"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["CLUSTER_CELL"] = constt(ShaderLanguage::TYPE_CLUSTERDATA);
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].can_discard = true;
 
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["WORLD_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);


### PR DESCRIPTION
Adds functions needed to build custom lighting models on top of Godot 4's existing clustered-forward renderer, while allowing sharing scene shader code for physical correctness when needed.

This PR is an implementation of my proposal for "Non-physical shading" at godotengine/godot-proposals#1620

Expose lighting functions to user fragment shader.

Adds a series of lighting-related accessor and processing methods to allow full light calculations to be done from within fragment().
Includes a major refactor of scene_high_end.glsl to simplify main() and expose these lighting APIs.
Activate by assigning a value to AMBIENT_LIGHT.
Usage of AMBIENT_LIGHT, DIFFUSE_LIGHT and SPECULAR_LIGHT disables light() and builtin lighting.

Please see the working example project at https://github.com/lyuma/Godot-MToon-Shader
![](https://raw.githubusercontent.com/lyuma/Godot-MToon-Shader/master/docs/alicia_realtime_lights.png)

This pull request corresponds to a godot-proposal about adding non-physical rendering and exposing lighting functions to the fragment() shader.

List of new opaque datatypes available in fragment():
- **DirectionalLightData**
- **LightData**
- **LightmapCapture**
- **ClusterData**

List of new variables available in fragment():
- **AMBIENT_LIGHT** (vec3)
- **DIFFUSE_LIGHT** (vec3)
- **SPECULAR_LIGHT** (vec3)
- **CLUSTER_CELL** (ClusterData opaque type)

List of new functions available in fragment():
- **GET_LIGHTMAP_SH**(out LightmapCapture) -> bool
- **SH_COEF**(LightmapCapture, uint) -> vec4
- **GET_LIGHT_POSITION**(LightData) -> vec3
- **GET_LIGHT_INV_RADIUS**(LightData) -> float
- **GET_LIGHT_DIRECTION**(LightData) -> vec3
- **GET_DIR_LIGHT_DIRECTION**(DirectionalLightData) -> vec3
- **GET_LIGHT_SIZE_PARAM**(LightData) -> float
- **GET_DIR_LIGHT_SIZE_PARAM**(DirectionalLightData) -> float
- **GET_LIGHT_ATTENUATION_PARAM**(LightData) -> float
- **GET_SPOT_ATTENUATION_ANGLE_PARAM**(LightData) -> vec2
- **GET_OMNI_LIGHT_ATTENUATION_SIZE**(LightData) -> vec2
- **GET_SPOT_LIGHT_ATTENUATION_SIZE**(LightData) -> vec2
- **GET_LIGHT_COLOR_SPECULAR**(LightData) -> vec4
- **GET_LIGHT_SHADOW_COLOR**(LightData) -> vec3
- **GET_DIR_LIGHT_COLOR_SPECULAR**(DirectionalLightData) -> vec4
- **OMNI_PROJECTOR_PROCESS**(LightData, vec3 vertex, vec3 vertex_ddx, vec3 vertex_ddy) -> vec3
- **SPOT_PROJECTOR_PROCESS**(LightData, vec3 vertex, vec3 vertex_ddx, vec3 vertex_ddy) -> vec3
- **OMNI_SHADOW_PROCESS**(LightData, vec3 vertex, vec3 normal, out float shadow, inout float transmittance_z) -> bool
- **SPOT_SHADOW_PROCESS**(LightData, vec3 vertex, vec3 normal, out float shadow, inout float transmittance_z) -> bool
- **DIRECTIONAL_SHADOW_PROCESS**(DirectionalLightData, vec3 vertex, vec3 normal, out vec3 shadow_color, out float shadow, inout float transmittance_z) -> bool
- **AMBIENT_PROCESS**(vec3 vertex, vec3 normal, float roughness, float specular, bool has_metallic, vec3 view, vec2 uv2, out vec3 ambient_light, out vec3 diffuse_light, out vec3 specular_light) -> void
- **REFLECTION_PROCESS**(ClusterData, uint idx, vec3 vertex, vec3 normal, float roughness, vec3 ambient_light, vec3 specular_light, inout vec4 ambient_accum, inout vec4 reflection_accum) -> void
- **DECAL_PROCESS**(ClusterData, uint idx, vec3 vertex, vec3 normal, vec3 vertex_ddx, vec3 vertex_ddy, normal_interp, out vec3 uv_local, out vec4 decal_albedo_mix, out vec4 decal_normal_mix, out vec4 decal_orm_mix, out vec3 decal_emission) -> bool
- **SHOULD_RENDER_LIGHT**(LightData)
- **SHOULD_RENDER_DIR_LIGHT**(DirectionalLightData)
- **OMNI_LIGHT_COUNT**(ClusterData) -> uint
- **SPOT_LIGHT_COUNT**(ClusterData) -> uint
- **DIRECTIONAL_LIGHT_COUNT**() -> uint
- **REFLECTION_PROBE_COUNT**(ClusterData) -> uint
- **DECAL_COUNT**(ClusterData) -> uint
- **GET_OMNI_LIGHT**(ClusterData, uint idx) -> LightData
- **GET_SPOT_LIGHT**(ClusterData, uint idx) -> LightData
- **GET_DIRECTIONAL_LIGHT**(uint idx) -> DirectionalLightData

