### PR TITLE
Re-add the track editor toggle button to Animation dock

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -120,6 +120,7 @@ void AnimationPlayerEditor::_notification(int p_what) {
 			onion_skinning->set_icon(get_theme_icon("GuiTabMenuHl", "EditorIcons"));
 
 			pin->set_icon(get_theme_icon("Pin", "EditorIcons"));
+			track_editor_toggle->set_icon(get_theme_icon("GuiVisibilityVisible", "EditorIcons"));
 
 			tool_anim->add_theme_style_override("normal", get_theme_stylebox("normal", "Button"));
 			track_editor->get_edit_menu()->add_theme_style_override("normal", get_theme_stylebox("normal", "Button"));
@@ -1229,6 +1230,12 @@ void AnimationPlayerEditor::_editor_visibility_changed() {
 	if (is_visible() && animation->get_item_count() > 0) {
 		_start_onion_skinning();
 	}
+
+	if (track_editor->is_visible()) {
+		track_editor_toggle->set_icon(get_theme_icon("GuiVisibilityVisible", "EditorIcons"));
+	} else {
+		track_editor_toggle->set_icon(get_theme_icon("GuiVisibilityHidden", "EditorIcons"));
+	}
 }
 
 bool AnimationPlayerEditor::_are_onion_layers_valid() {
@@ -1459,6 +1466,10 @@ void AnimationPlayerEditor::_pin_pressed() {
 	EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->update_tree();
 }
 
+void AnimationPlayerEditor::_track_editor_toggle_pressed() {
+	track_editor->set_visible(!track_editor_toggle->is_pressed());
+}
+
 void AnimationPlayerEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_animation_new"), &AnimationPlayerEditor::_animation_new);
 	ClassDB::bind_method(D_METHOD("_animation_rename"), &AnimationPlayerEditor::_animation_rename);
@@ -1476,6 +1487,7 @@ void AnimationPlayerEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_prepare_onion_layers_2"), &AnimationPlayerEditor::_prepare_onion_layers_2);
 	ClassDB::bind_method(D_METHOD("_start_onion_skinning"), &AnimationPlayerEditor::_start_onion_skinning);
 	ClassDB::bind_method(D_METHOD("_stop_onion_skinning"), &AnimationPlayerEditor::_stop_onion_skinning);
+	ClassDB::bind_method(D_METHOD("_track_editor_toggle_pressed"), &AnimationPlayerEditor::_track_editor_toggle_pressed);
 }
 
 AnimationPlayerEditor *AnimationPlayerEditor::singleton = nullptr;
@@ -1617,6 +1629,13 @@ AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlay
 	pin->set_tooltip(TTR("Pin AnimationPlayer"));
 	hb->add_child(pin);
 	pin->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_pin_pressed));
+
+	track_editor_toggle = memnew(Button);
+	track_editor_toggle->set_flat(true);
+	track_editor_toggle->set_toggle_mode(true);
+	track_editor_toggle->set_tooltip(TTR("Toggle Track Editor"));
+	hb->add_child(track_editor_toggle);
+	track_editor_toggle->connect("pressed", callable_mp(this, &AnimationPlayerEditor::_track_editor_toggle_pressed));
 
 	file = memnew(EditorFileDialog);
 	add_child(file);

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -99,6 +99,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	Button *onion_toggle;
 	MenuButton *onion_skinning;
 	Button *pin;
+	Button *track_editor_toggle;
 	SpinBox *frame;
 	LineEdit *scale;
 	LineEdit *name;
@@ -213,6 +214,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _stop_onion_skinning();
 
 	void _pin_pressed();
+	void _track_editor_toggle_pressed();
 
 	AnimationPlayerEditor();
 	~AnimationPlayerEditor();


### PR DESCRIPTION
This PR is a "cherry-pick" from the Godot v1 branch *(this is not a joke :sweat_smile:).*

Godot 1 used to have an "edit" button in the Animation Dock, because the default mode was "play mode". This feature was removed when Juan refactored the entire Animation Dock for Godot 2.0.
>Btw I found out about it a few years ago, when I tried Godot 1 just for fun/curiosity.

- Play mode
![image](https://user-images.githubusercontent.com/10428035/95243505-1d93d700-07e7-11eb-9eb3-621bfa6c52ac.png)
- Edit mode
![image](https://user-images.githubusercontent.com/10428035/95243557-30a6a700-07e7-11eb-8cca-3ed8b9abfb59.png)

I'm not good with C++, so I tried to implement it recently as a study, more specifically during this year's GGJ (Godot master branch was still v3.2). I didn't open a PR before because this year is being insanely busy for me.

So, I'm taking advantage of the hacktoberfest opportunity to re-implement (again) and open a PR before I forget it forever :P 

My implementation is a bit different from the original, it's just a simple toggle for the track editor, and the "edit" mode is still the default.

- Edit mode
![image](https://user-images.githubusercontent.com/10428035/95247008-b2003880-07eb-11eb-938f-2aaceb0f1264.png)
- Play mode
![image](https://user-images.githubusercontent.com/10428035/95247111-d4925180-07eb-11eb-9ebb-549b411d1d2f.png)

- Video:
![vokoscreenNG-2020-10-06_14-42-55](https://user-images.githubusercontent.com/10428035/95250371-67cd8600-07f0-11eb-8406-c846a7ea63a7.gif)


Sorry for not opening a GIP in advance, but as it is already implemented, I find it easier to discuss the implementation in this PR.
I implemented it because I found it useful, I always get upset when I just want to play animations, but the Animation Dock takes up almost half of my screen.