### PR TITLE
Improve the Vector2 rotated code in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -437,8 +437,11 @@ namespace Godot
         /// <returns>The rotated vector.</returns>
         public Vector2 Rotated(real_t phi)
         {
-            real_t rads = Angle() + phi;
-            return new Vector2(Mathf.Cos(rads), Mathf.Sin(rads)) * Length();
+            real_t sine = Mathf.Sin(phi);
+            real_t cosi = Mathf.Cos(phi);
+            return new Vector2(
+                x * cosi - y * sine,
+                x * sine + y * cosi);
         }
 
         /// <summary>


### PR DESCRIPTION
#38064 but in C#. No idea how I managed to completely forget about the C# code when I wrote that.

> The old code was prone to floating point errors (and likely not as performant as it could be), since it had an unnecessary step of grabbing the existing angle.
> 
> This PR changes the code to returning a new Vector2 constructed from the existing components multiplied by a rotation matrix of sin and cos (but not in a transform or anything, just some numbers). Also, `set_rotation` was a (misleading) internal method only used here, so I removed it.
> 
> Fixes #38059