### PR TITLE
Raise error if Resource is of wrong type as function argument

### DIFF
--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -122,6 +122,18 @@ struct VariantObjectClassChecker {
 	}
 };
 
+template <typename T>
+class Ref;
+
+template <typename T>
+struct VariantObjectClassChecker<const Ref<T> &> {
+	static _FORCE_INLINE_ bool check(const Variant &p_variant) {
+		Object *obj = p_variant;
+		const Ref<T> node = p_variant;
+		return node.ptr() || !obj;
+	}
+};
+
 template <>
 struct VariantObjectClassChecker<Node *> {
 	static _FORCE_INLINE_ bool check(const Variant &p_variant) {


### PR DESCRIPTION
Passing an invalid Resource type to a godot function implicitly converts it to `null`, leading to hard to trace errors. With this PR, the debugger errors out.

Breaks compat though, as some may have relied on the implicit coercion to `null`.

Fixes #11588 and fixes #41722