### PR TITLE
Fixed a bug which caused Set Index to not function

### DIFF
--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1706,8 +1706,10 @@ public:
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) {
 		bool valid;
+		// *p_output[0] points to the same place as *p_inputs[2] so we need a temp to store the value before the change in the next line
+		Variant temp = *p_inputs[2];
 		*p_outputs[0] = *p_inputs[0];
-		p_outputs[0]->set(*p_inputs[1], *p_inputs[2], &valid);
+		p_outputs[0]->set(*p_inputs[1], temp, &valid);
 
 		if (!valid) {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;


### PR DESCRIPTION
Fixes some parts of https://github.com/godotengine/godot/issues/40046
Inside the step function the code was trying to change the value of an input variable. What the developer failed to realize was that *p_outputs[0] and *p_inputs[2] point to the same place. so when *p_outputs[0] is overwritten, so that we can change the array, it also changes *p_inputs[2]. I created a temp variable to store the value of *p_inputs[2] so it is not lost.