### PR TITLE
Don't allow adding Objects to the project settings

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -381,9 +381,12 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 		type->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 		hbc->add_child(type);
 
-		// Start at 1 to avoid adding "Nil" as an option
-		for (int i = 1; i < Variant::VARIANT_MAX; i++) {
-			type->add_item(Variant::get_type_name(Variant::Type(i)));
+		for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+			// There's no point in adding Nil types, and Object types
+			// can't be serialized correctly in the project settings.
+			if (i != Variant::NIL && i != Variant::OBJECT) {
+				type->add_item(Variant::get_type_name(Variant::Type(i)));
+			}
 		}
 
 		l = memnew(Label);


### PR DESCRIPTION
Godot doesn't support serializing objects.

**Note:** I haven't tested this since I can't open the Project Settings in the current `master` branch due to a DisplayServer bug (even in single window mode).

This closes #33667.