### PR TITLE
Docs change: More detailed description of StreamPeerTCP.is_connected_to_host()

### DIFF
--- a/doc/classes/StreamPeerTCP.xml
+++ b/doc/classes/StreamPeerTCP.xml
@@ -52,7 +52,7 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if this peer is currently connected to a host, [code]false[/code] otherwise.
+				Returns [code]true[/code] if this peer is currently connected or is connecting to a host, [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="set_no_delay">


### PR DESCRIPTION
**Related issues:** #37036 #18323

The `StreamPeerTCP.is_connected_to_host()` method description is very misleading which may cause some bugs. The method returns TRUE when a socket is connected **or the socket is in connecting state** which was not mentioned in docs. Lets consider the code similar to this:

````gdscript
var tcp = StreamPeerTCP.new()
var tcp_packet = PacketPeerStream.new()
tcp_packet.set_stream_peer(tcp)

tcp.connect_to_host('valid_ip', valid_port)
if tcp.is_connected_to_host():
    tcp_packet.put_packet(some_data)
````

In this case when we pass if statement we should be ensured that connection is established and ready to transfer data but in fact it may be in `STATUS_CONNECTING` state under the hood and the packet will be lost.