### PR TITLE
C# GodotTools: Replace platform Identifier "OSX" with "macOS"

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
@@ -119,7 +119,7 @@ namespace GodotTools.Build
             {
                 var result = new List<string>();
 
-                if (OS.IsmacOS)
+                if (OS.IsMacOS)
                 {
                     result.Add("/Library/Frameworks/Mono.framework/Versions/Current/bin/");
                     result.Add("/usr/local/var/homebrew/linked/mono/bin/");

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
@@ -119,7 +119,7 @@ namespace GodotTools.Build
             {
                 var result = new List<string>();
 
-                if (OS.IsOSX)
+                if (OS.IsmacOS)
                 {
                     result.Add("/Library/Frameworks/Mono.framework/Versions/Current/bin/");
                     result.Add("/usr/local/var/homebrew/linked/mono/bin/");

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -120,7 +120,7 @@ namespace GodotTools.Export
                 string assemblyPath = assembly.Value;
 
                 string outputFileExtension = platform == OS.Platforms.Windows ? ".dll" :
-                    platform == OS.Platforms.OSX ? ".dylib" :
+                    platform == OS.Platforms.macOS ? ".dylib" :
                     ".so";
 
                 string outputFileName = assemblyName + ".dll" + outputFileExtension;
@@ -132,7 +132,7 @@ namespace GodotTools.Export
 
                 ExecuteCompiler(FindCrossCompiler(compilerDirPath), compilerArgs, bclDir);
 
-                if (platform == OS.Platforms.OSX)
+                if (platform == OS.Platforms.macOS)
                 {
                     exporter.AddSharedObject(tempOutputFilePath, tags: null);
                 }
@@ -581,7 +581,7 @@ MONO_AOT_MODE_LAST = 1000,
                         string arch = bits == "64" ? "x86_64" : "i686";
                         return $"windows-{arch}";
                     }
-                case OS.Platforms.OSX:
+                case OS.Platforms.macOS:
                     {
                         Debug.Assert(bits == null || bits == "64");
                         string arch = "x86_64";

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -120,7 +120,7 @@ namespace GodotTools.Export
                 string assemblyPath = assembly.Value;
 
                 string outputFileExtension = platform == OS.Platforms.Windows ? ".dll" :
-                    platform == OS.Platforms.macOS ? ".dylib" :
+                    platform == OS.Platforms.MacOS ? ".dylib" :
                     ".so";
 
                 string outputFileName = assemblyName + ".dll" + outputFileExtension;
@@ -132,7 +132,7 @@ namespace GodotTools.Export
 
                 ExecuteCompiler(FindCrossCompiler(compilerDirPath), compilerArgs, bclDir);
 
-                if (platform == OS.Platforms.macOS)
+                if (platform == OS.Platforms.MacOS)
                 {
                     exporter.AddSharedObject(tempOutputFilePath, tags: null);
                 }
@@ -581,7 +581,7 @@ MONO_AOT_MODE_LAST = 1000,
                         string arch = bits == "64" ? "x86_64" : "i686";
                         return $"windows-{arch}";
                     }
-                case OS.Platforms.macOS:
+                case OS.Platforms.MacOS:
                     {
                         Debug.Assert(bits == null || bits == "64");
                         string arch = "x86_64";

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -340,7 +340,7 @@ namespace GodotTools.Export
         private static bool PlatformHasTemplateDir(string platform)
         {
             // OSX export templates are contained in a zip, so we place our custom template inside it and let Godot do the rest.
-            return !new[] {OS.Platforms.OSX, OS.Platforms.Android, OS.Platforms.iOS, OS.Platforms.HTML5}.Contains(platform);
+            return !new[] {OS.Platforms.macOS, OS.Platforms.Android, OS.Platforms.iOS, OS.Platforms.HTML5}.Contains(platform);
         }
 
         private static bool DeterminePlatformFromFeatures(IEnumerable<string> features, out string platform)
@@ -411,7 +411,7 @@ namespace GodotTools.Export
                 case OS.Platforms.Windows:
                 case OS.Platforms.UWP:
                     return "net_4_x_win";
-                case OS.Platforms.OSX:
+                case OS.Platforms.macOS:
                 case OS.Platforms.LinuxBSD:
                 case OS.Platforms.Server:
                 case OS.Platforms.Haiku:

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -340,7 +340,7 @@ namespace GodotTools.Export
         private static bool PlatformHasTemplateDir(string platform)
         {
             // OSX export templates are contained in a zip, so we place our custom template inside it and let Godot do the rest.
-            return !new[] {OS.Platforms.macOS, OS.Platforms.Android, OS.Platforms.iOS, OS.Platforms.HTML5}.Contains(platform);
+            return !new[] {OS.Platforms.MacOS, OS.Platforms.Android, OS.Platforms.iOS, OS.Platforms.HTML5}.Contains(platform);
         }
 
         private static bool DeterminePlatformFromFeatures(IEnumerable<string> features, out string platform)
@@ -411,7 +411,7 @@ namespace GodotTools.Export
                 case OS.Platforms.Windows:
                 case OS.Platforms.UWP:
                     return "net_4_x_win";
-                case OS.Platforms.macOS:
+                case OS.Platforms.MacOS:
                 case OS.Platforms.LinuxBSD:
                 case OS.Platforms.Server:
                 case OS.Platforms.Haiku:

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -272,7 +272,7 @@ namespace GodotTools
 
                     bool osxAppBundleInstalled = false;
 
-                    if (OS.IsmacOS)
+                    if (OS.IsMacOS)
                     {
                         // The package path is '/Applications/Visual Studio Code.app'
                         const string vscodeBundleId = "com.microsoft.VSCode";
@@ -312,7 +312,7 @@ namespace GodotTools
 
                     string command;
 
-                    if (OS.IsmacOS)
+                    if (OS.IsMacOS)
                     {
                         if (!osxAppBundleInstalled && string.IsNullOrEmpty(_vsCodePath))
                         {
@@ -504,7 +504,7 @@ namespace GodotTools
                                    $",Visual Studio Code:{(int)ExternalEditorId.VsCode}" +
                                    $",JetBrains Rider:{(int)ExternalEditorId.Rider}";
             }
-            else if (OS.IsmacOS)
+            else if (OS.IsMacOS)
             {
                 settingsHintStr += $",Visual Studio:{(int)ExternalEditorId.VisualStudioForMac}" +
                                    $",MonoDevelop:{(int)ExternalEditorId.MonoDevelop}" +

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -272,7 +272,7 @@ namespace GodotTools
 
                     bool osxAppBundleInstalled = false;
 
-                    if (OS.IsOSX)
+                    if (OS.IsmacOS)
                     {
                         // The package path is '/Applications/Visual Studio Code.app'
                         const string vscodeBundleId = "com.microsoft.VSCode";
@@ -312,7 +312,7 @@ namespace GodotTools
 
                     string command;
 
-                    if (OS.IsOSX)
+                    if (OS.IsmacOS)
                     {
                         if (!osxAppBundleInstalled && string.IsNullOrEmpty(_vsCodePath))
                         {
@@ -504,7 +504,7 @@ namespace GodotTools
                                    $",Visual Studio Code:{(int)ExternalEditorId.VsCode}" +
                                    $",JetBrains Rider:{(int)ExternalEditorId.Rider}";
             }
-            else if (OS.IsOSX)
+            else if (OS.IsmacOS)
             {
                 settingsHintStr += $",Visual Studio:{(int)ExternalEditorId.VisualStudioForMac}" +
                                    $",MonoDevelop:{(int)ExternalEditorId.MonoDevelop}" +

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
@@ -111,7 +111,7 @@ namespace GodotTools.Ides
                 {
                     MonoDevelop.Instance GetMonoDevelopInstance(string solutionPath)
                     {
-                        if (Utils.OS.IsOSX && editorId == ExternalEditorId.VisualStudioForMac)
+                        if (Utils.OS.IsmacOS && editorId == ExternalEditorId.VisualStudioForMac)
                         {
                             vsForMacInstance = (vsForMacInstance?.IsDisposed ?? true ? null : vsForMacInstance) ??
                                                new MonoDevelop.Instance(solutionPath, MonoDevelop.EditorId.VisualStudioForMac);

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
@@ -111,7 +111,7 @@ namespace GodotTools.Ides
                 {
                     MonoDevelop.Instance GetMonoDevelopInstance(string solutionPath)
                     {
-                        if (Utils.OS.IsmacOS && editorId == ExternalEditorId.VisualStudioForMac)
+                        if (Utils.OS.IsMacOS && editorId == ExternalEditorId.VisualStudioForMac)
                         {
                             vsForMacInstance = (vsForMacInstance?.IsDisposed ?? true ? null : vsForMacInstance) ??
                                                new MonoDevelop.Instance(solutionPath, MonoDevelop.EditorId.VisualStudioForMac);

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/MonoDevelop/Instance.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/MonoDevelop/Instance.cs
@@ -26,7 +26,7 @@ namespace GodotTools.Ides.MonoDevelop
 
             string command;
 
-            if (OS.IsOSX)
+            if (OS.IsmacOS)
             {
                 string bundleId = BundleIds[editorId];
 
@@ -85,7 +85,7 @@ namespace GodotTools.Ides.MonoDevelop
 
         public Instance(string solutionFile, EditorId editorId)
         {
-            if (editorId == EditorId.VisualStudioForMac && !OS.IsOSX)
+            if (editorId == EditorId.VisualStudioForMac && !OS.IsmacOS)
                 throw new InvalidOperationException($"{nameof(EditorId.VisualStudioForMac)} not supported on this platform");
 
             this.solutionFile = solutionFile;
@@ -103,7 +103,7 @@ namespace GodotTools.Ides.MonoDevelop
 
         static Instance()
         {
-            if (OS.IsOSX)
+            if (OS.IsmacOS)
             {
                 ExecutableNames = new Dictionary<EditorId, string>
                 {

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/MonoDevelop/Instance.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/MonoDevelop/Instance.cs
@@ -26,7 +26,7 @@ namespace GodotTools.Ides.MonoDevelop
 
             string command;
 
-            if (OS.IsmacOS)
+            if (OS.IsMacOS)
             {
                 string bundleId = BundleIds[editorId];
 
@@ -85,7 +85,7 @@ namespace GodotTools.Ides.MonoDevelop
 
         public Instance(string solutionFile, EditorId editorId)
         {
-            if (editorId == EditorId.VisualStudioForMac && !OS.IsmacOS)
+            if (editorId == EditorId.VisualStudioForMac && !OS.IsMacOS)
                 throw new InvalidOperationException($"{nameof(EditorId.VisualStudioForMac)} not supported on this platform");
 
             this.solutionFile = solutionFile;
@@ -103,7 +103,7 @@ namespace GodotTools.Ides.MonoDevelop
 
         static Instance()
         {
-            if (OS.IsmacOS)
+            if (OS.IsMacOS)
             {
                 ExecutableNames = new Dictionary<EditorId, string>
                 {

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathLocator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathLocator.cs
@@ -32,7 +32,7 @@ namespace GodotTools.Ides.Rider
                 {
                     return CollectRiderInfosWindows();
                 }
-                if (OS.IsmacOS)
+                if (OS.IsMacOS)
                 {
                     return CollectRiderInfosMac();
                 }
@@ -138,7 +138,7 @@ namespace GodotTools.Ides.Rider
                 return GetToolboxRiderRootPath(localAppData);
             }
 
-            if (OS.IsmacOS)
+            if (OS.IsMacOS)
             {
                 var home = Environment.GetEnvironmentVariable("HOME");
                 if (string.IsNullOrEmpty(home))
@@ -211,7 +211,7 @@ namespace GodotTools.Ides.Rider
         {
             if (OS.IsWindows || OS.IsUnixLike)
                 return "../../build.txt";
-            if (OS.IsmacOS)
+            if (OS.IsMacOS)
                 return "Contents/Resources/build.txt";
             throw new Exception("Unknown OS.");
         }

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathLocator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathLocator.cs
@@ -32,7 +32,7 @@ namespace GodotTools.Ides.Rider
                 {
                     return CollectRiderInfosWindows();
                 }
-                if (OS.IsOSX)
+                if (OS.IsmacOS)
                 {
                     return CollectRiderInfosMac();
                 }
@@ -138,7 +138,7 @@ namespace GodotTools.Ides.Rider
                 return GetToolboxRiderRootPath(localAppData);
             }
 
-            if (OS.IsOSX)
+            if (OS.IsmacOS)
             {
                 var home = Environment.GetEnvironmentVariable("HOME");
                 if (string.IsNullOrEmpty(home))
@@ -211,7 +211,7 @@ namespace GodotTools.Ides.Rider
         {
             if (OS.IsWindows || OS.IsUnixLike)
                 return "../../build.txt";
-            if (OS.IsOSX)
+            if (OS.IsmacOS)
                 return "Contents/Resources/build.txt";
             throw new Exception("Unknown OS.");
         }

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -21,7 +21,7 @@ namespace GodotTools.Utils
         public static class Names
         {
             public const string Windows = "Windows";
-            public const string macOS = "macOS";
+            public const string MacOS = "macOS";
             public const string Linux = "Linux";
             public const string FreeBSD = "FreeBSD";
             public const string NetBSD = "NetBSD";
@@ -37,7 +37,7 @@ namespace GodotTools.Utils
         public static class Platforms
         {
             public const string Windows = "windows";
-            public const string macOS = "macos";
+            public const string MacOS = "osx";
             public const string LinuxBSD = "linuxbsd";
             public const string Server = "server";
             public const string UWP = "uwp";
@@ -50,7 +50,7 @@ namespace GodotTools.Utils
         public static readonly Dictionary<string, string> PlatformNameMap = new Dictionary<string, string>
         {
             [Names.Windows] = Platforms.Windows,
-            [Names.macOS] = Platforms.macOS,
+            [Names.MacOS] = Platforms.MacOS,
             [Names.Linux] = Platforms.LinuxBSD,
             [Names.FreeBSD] = Platforms.LinuxBSD,
             [Names.NetBSD] = Platforms.LinuxBSD,
@@ -77,11 +77,11 @@ namespace GodotTools.Utils
             new[] {Names.Linux, Names.FreeBSD, Names.NetBSD, Names.BSD};
 
         private static readonly IEnumerable<string> UnixLikePlatforms =
-            new[] {Names.macOS, Names.Server, Names.Haiku, Names.Android, Names.iOS}
+            new[] {Names.MacOS, Names.Server, Names.Haiku, Names.Android, Names.iOS}
                 .Concat(LinuxBSDPlatforms).ToArray();
 
         private static readonly Lazy<bool> _isWindows = new Lazy<bool>(() => IsOS(Names.Windows));
-        private static readonly Lazy<bool> _ismacOS = new Lazy<bool>(() => IsOS(Names.macOS));
+        private static readonly Lazy<bool> _isMacOS = new Lazy<bool>(() => IsOS(Names.MacOS));
         private static readonly Lazy<bool> _isLinuxBSD = new Lazy<bool>(() => IsAnyOS(LinuxBSDPlatforms));
         private static readonly Lazy<bool> _isServer = new Lazy<bool>(() => IsOS(Names.Server));
         private static readonly Lazy<bool> _isUWP = new Lazy<bool>(() => IsOS(Names.UWP));
@@ -92,7 +92,7 @@ namespace GodotTools.Utils
         private static readonly Lazy<bool> _isUnixLike = new Lazy<bool>(() => IsAnyOS(UnixLikePlatforms));
 
         public static bool IsWindows => _isWindows.Value || IsUWP;
-        public static bool IsmacOS => _ismacOS.Value;
+        public static bool IsMacOS => _isMacOS.Value;
         public static bool IsLinuxBSD => _isLinuxBSD.Value;
         public static bool IsServer => _isServer.Value;
         public static bool IsUWP => _isUWP.Value;

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -21,7 +21,7 @@ namespace GodotTools.Utils
         public static class Names
         {
             public const string Windows = "Windows";
-            public const string OSX = "OSX";
+            public const string macOS = "macOS";
             public const string Linux = "Linux";
             public const string FreeBSD = "FreeBSD";
             public const string NetBSD = "NetBSD";
@@ -37,7 +37,7 @@ namespace GodotTools.Utils
         public static class Platforms
         {
             public const string Windows = "windows";
-            public const string OSX = "osx";
+            public const string macOS = "macos";
             public const string LinuxBSD = "linuxbsd";
             public const string Server = "server";
             public const string UWP = "uwp";
@@ -50,7 +50,7 @@ namespace GodotTools.Utils
         public static readonly Dictionary<string, string> PlatformNameMap = new Dictionary<string, string>
         {
             [Names.Windows] = Platforms.Windows,
-            [Names.OSX] = Platforms.OSX,
+            [Names.macOS] = Platforms.macOS,
             [Names.Linux] = Platforms.LinuxBSD,
             [Names.FreeBSD] = Platforms.LinuxBSD,
             [Names.NetBSD] = Platforms.LinuxBSD,
@@ -77,11 +77,11 @@ namespace GodotTools.Utils
             new[] {Names.Linux, Names.FreeBSD, Names.NetBSD, Names.BSD};
 
         private static readonly IEnumerable<string> UnixLikePlatforms =
-            new[] {Names.OSX, Names.Server, Names.Haiku, Names.Android, Names.iOS}
+            new[] {Names.macOS, Names.Server, Names.Haiku, Names.Android, Names.iOS}
                 .Concat(LinuxBSDPlatforms).ToArray();
 
         private static readonly Lazy<bool> _isWindows = new Lazy<bool>(() => IsOS(Names.Windows));
-        private static readonly Lazy<bool> _isOSX = new Lazy<bool>(() => IsOS(Names.OSX));
+        private static readonly Lazy<bool> _ismacOS = new Lazy<bool>(() => IsOS(Names.macOS));
         private static readonly Lazy<bool> _isLinuxBSD = new Lazy<bool>(() => IsAnyOS(LinuxBSDPlatforms));
         private static readonly Lazy<bool> _isServer = new Lazy<bool>(() => IsOS(Names.Server));
         private static readonly Lazy<bool> _isUWP = new Lazy<bool>(() => IsOS(Names.UWP));
@@ -92,7 +92,7 @@ namespace GodotTools.Utils
         private static readonly Lazy<bool> _isUnixLike = new Lazy<bool>(() => IsAnyOS(UnixLikePlatforms));
 
         public static bool IsWindows => _isWindows.Value || IsUWP;
-        public static bool IsOSX => _isOSX.Value;
+        public static bool IsmacOS => _ismacOS.Value;
         public static bool IsLinuxBSD => _isLinuxBSD.Value;
         public static bool IsServer => _isServer.Value;
         public static bool IsUWP => _isUWP.Value;


### PR DESCRIPTION
Because `Strings OS_OSX::get_name() const` now returns "macOS" (15a9f94346c211b7afe96af500cb3405aabcf6b8)
The C# GodotTools were still using "OSX" as identifier, which broke a few things (e.g. dotnet/msbuild exec detection).

There are a few things that need clarification from a maintainer:

1. I used "macOS" (lowercase) as identifier name and not `MacOS` (uppercase) because `iOS` uses a lowercase `i` as well and "macOS" is the official name. But it might be more consistent to make them both uppercase?
2. This also changes part of a name of a `dylib` that is created during export (https://github.com/lolleko/godot/blob/d1bac19fd78bcb7277f33a78050a1d92b2cfca1a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs#L123). I am not sure what implications that will have and if that change is desired.
3. This one might be a bit unrelated to this specific issue but there are various places within Godot that still use "OSX" as identifier e.g.: `DisplayServerOSX::get_name()` or the scons `platform` flag... I think at some point those should be changed to `macOS` as well.