### PR TITLE
Set locking to also group selected nodes.

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4744,6 +4744,10 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				undo_redo->add_undo_method(canvas_item, "remove_meta", "_edit_lock_");
 				undo_redo->add_do_method(this, "emit_signal", "item_lock_status_changed");
 				undo_redo->add_undo_method(this, "emit_signal", "item_lock_status_changed");
+				undo_redo->add_do_method(canvas_item, "set_meta", "_edit_group_", true);
+				undo_redo->add_undo_method(canvas_item, "remove_meta", "_edit_group_");
+				undo_redo->add_do_method(this, "emit_signal", "item_group_status_changed");
+				undo_redo->add_undo_method(this, "emit_signal", "item_group_status_changed");
 			}
 			undo_redo->add_do_method(viewport, "update", Variant());
 			undo_redo->add_undo_method(viewport, "update", Variant());
@@ -4766,6 +4770,10 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				undo_redo->add_undo_method(canvas_item, "set_meta", "_edit_lock_", true);
 				undo_redo->add_do_method(this, "emit_signal", "item_lock_status_changed");
 				undo_redo->add_undo_method(this, "emit_signal", "item_lock_status_changed");
+				undo_redo->add_do_method(canvas_item, "remove_meta", "_edit_group_");
+				undo_redo->add_undo_method(canvas_item, "set_meta", "_edit_group_", true);
+				undo_redo->add_do_method(this, "emit_signal", "item_group_status_changed");
+				undo_redo->add_undo_method(this, "emit_signal", "item_group_status_changed");
 			}
 			undo_redo->add_do_method(viewport, "update", Variant());
 			undo_redo->add_undo_method(viewport, "update", Variant());

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5005,6 +5005,10 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 				undo_redo->add_undo_method(spatial, "remove_meta", "_edit_lock_");
 				undo_redo->add_do_method(this, "emit_signal", "item_lock_status_changed");
 				undo_redo->add_undo_method(this, "emit_signal", "item_lock_status_changed");
+				undo_redo->add_do_method(spatial, "set_meta", "_edit_group_", true);
+				undo_redo->add_undo_method(spatial, "remove_meta", "_edit_group_");
+				undo_redo->add_do_method(this, "emit_signal", "item_group_status_changed");
+				undo_redo->add_undo_method(this, "emit_signal", "item_group_status_changed");
 			}
 
 			undo_redo->add_do_method(this, "_refresh_menu_icons");
@@ -5030,6 +5034,10 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 				undo_redo->add_undo_method(spatial, "set_meta", "_edit_lock_", true);
 				undo_redo->add_do_method(this, "emit_signal", "item_lock_status_changed");
 				undo_redo->add_undo_method(this, "emit_signal", "item_lock_status_changed");
+				undo_redo->add_do_method(spatial, "remove_meta", "_edit_group_");
+				undo_redo->add_undo_method(spatial, "set_meta", "_edit_group_", true);
+				undo_redo->add_do_method(this, "emit_signal", "item_group_status_changed");
+				undo_redo->add_undo_method(this, "emit_signal", "item_group_status_changed");
 			}
 
 			undo_redo->add_do_method(this, "_refresh_menu_icons");


### PR DESCRIPTION
Usability fix to make the lock button more discoverable and fit the mental model of locking.

* Click on lock will also set group selection
* Click on lock and then group selection will lock and use the previous behaviour of ungrouped selections.
* Clicking lock again will unlock and ungroup
* Same changes for canvas and Node3d

Solves problem described https://github.com/godotengine/godot-proposals/issues/1449

Sponsored by IMVU.
