### PR TITLE
SCons: Refactor and cleanup warnings definition

### DIFF
--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -80,6 +80,9 @@ def configure(env):
     env["ENV"] = os.environ
     vc_base_path = os.environ["VCTOOLSINSTALLDIR"] if "VCTOOLSINSTALLDIR" in os.environ else os.environ["VCINSTALLDIR"]
 
+    # Force to use Unicode encoding
+    env.Append(MSVC_FLAGS=["/utf-8"])
+
     # ANGLE
     angle_root = os.getenv("ANGLE_SRC_PATH")
     env.Prepend(CPPPATH=[angle_root + "/include"])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -222,8 +222,8 @@ def configure_msvc(env, manual_msvc_config):
     ## Compile/link flags
 
     env.AppendUnique(CCFLAGS=["/MT", "/Gd", "/GR", "/nologo"])
-    if int(env["MSVC_VERSION"].split(".")[0]) >= 14:  # vs2015 and later
-        env.AppendUnique(CCFLAGS=["/utf-8"])
+    # Force to use Unicode encoding
+    env.Append(MSVC_FLAGS=["/utf-8"])
     env.AppendUnique(CXXFLAGS=["/TP"])  # assume all sources are C++
     if manual_msvc_config:  # should be automatic if SCons found it
         if os.getenv("WindowsSdkDir") is not None:


### PR DESCRIPTION
~`-Wsuggest-override` is equivalent to Clang's `-Winconsistent-missing-override`
which is enabled by default.~ *Edit:* Catches a lot more issues than Clang's, so we need to fix them first. So I rebased to only keep the cleanup work.

Should help catch potential CI warnings locally when building with GCC.

Thanks @bruvzg for the hint.