### PR TITLE
Apply infinite inertia checks to Godot physics 3D

### DIFF
--- a/servers/physics_3d/space_3d_sw.cpp
+++ b/servers/physics_3d/space_3d_sw.cpp
@@ -802,6 +802,13 @@ bool Space3DSW::test_body_motion(Body3DSW *p_body, const Transform &p_from, cons
 					const CollisionObject3DSW *col_obj = intersection_query_results[i];
 					int shape_idx = intersection_query_subindex_results[i];
 
+					if (CollisionObject3DSW::TYPE_BODY == col_obj->get_type()) {
+						const Body3DSW *b = static_cast<const Body3DSW *>(col_obj);
+						if (p_infinite_inertia && PhysicsServer3D::BODY_MODE_STATIC != b->get_mode() && PhysicsServer3D::BODY_MODE_KINEMATIC != b->get_mode()) {
+							continue;
+						}
+					}
+
 					if (CollisionSolver3DSW::solve_static(body_shape, body_shape_xform, col_obj->get_shape(shape_idx), col_obj->get_transform() * col_obj->get_shape_transform(shape_idx), cbkres, cbkptr, nullptr, p_margin)) {
 						collided = cbk.amount > 0;
 					}
@@ -883,6 +890,13 @@ bool Space3DSW::test_body_motion(Body3DSW *p_body, const Transform &p_from, cons
 			for (int i = 0; i < amount; i++) {
 				const CollisionObject3DSW *col_obj = intersection_query_results[i];
 				int shape_idx = intersection_query_subindex_results[i];
+
+				if (CollisionObject3DSW::TYPE_BODY == col_obj->get_type()) {
+					const Body3DSW *b = static_cast<const Body3DSW *>(col_obj);
+					if (p_infinite_inertia && PhysicsServer3D::BODY_MODE_STATIC != b->get_mode() && PhysicsServer3D::BODY_MODE_KINEMATIC != b->get_mode()) {
+						continue;
+					}
+				}
 
 				//test initial overlap, does it collide if going all the way?
 				Vector3 point_A, point_B;
@@ -988,6 +1002,13 @@ bool Space3DSW::test_body_motion(Body3DSW *p_body, const Transform &p_from, cons
 			for (int i = 0; i < amount; i++) {
 				const CollisionObject3DSW *col_obj = intersection_query_results[i];
 				int shape_idx = intersection_query_subindex_results[i];
+
+				if (CollisionObject3DSW::TYPE_BODY == col_obj->get_type()) {
+					const Body3DSW *b = static_cast<const Body3DSW *>(col_obj);
+					if (p_infinite_inertia && PhysicsServer3D::BODY_MODE_STATIC != b->get_mode() && PhysicsServer3D::BODY_MODE_KINEMATIC != b->get_mode()) {
+						continue;
+					}
+				}
 
 				rcd.object = col_obj;
 				rcd.shape = shape_idx;


### PR DESCRIPTION
#16757 added the `infinite_inertia` parameter to `move_and_slide()`, `move_and_collide()` and `test_move()`, but did not implement it in Godot 3D physics. This PR applies the `infinite_inertia` checks to Godot 3D physics to make it consistent with Godot 2D physics and Bullet physics.
