### PR TITLE
Fixed an issue in UWP export caused by duplicate entry for extensions in content types file.

### DIFF
--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -249,7 +249,7 @@ void AppxPackager::make_content_types(const String &p_path) {
 	Map<String, String> types;
 
 	for (int i = 0; i < file_metadata.size(); i++) {
-		String ext = file_metadata[i].name.get_extension();
+		String ext = file_metadata[i].name.get_extension().to_lower();
 
 		if (types.has(ext)) {
 			continue;


### PR DESCRIPTION
Thx to @ZodmanPerth. Info at https://github.com/godotengine/godot/issues/30558#issuecomment-667926124.


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
