### PR TITLE
Reapply -Avoid adding margin twice along capsule Y axis

### DIFF
--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -275,7 +275,7 @@ void CapsuleShapeBullet::setup(real_t p_height, real_t p_radius) {
 }
 
 btCollisionShape *CapsuleShapeBullet::create_bt_shape(const btVector3 &p_implicit_scale, real_t p_extra_edge) {
-	return prepare(ShapeBullet::create_shape_capsule(radius * p_implicit_scale[0] + p_extra_edge, height * p_implicit_scale[1] + p_extra_edge));
+	return prepare(ShapeBullet::create_shape_capsule(radius * p_implicit_scale[0] + p_extra_edge, height * p_implicit_scale[1]));
 }
 
 /* Cylinder */


### PR DESCRIPTION
#41806 was accidentally reverted with #42639. This PR simply reapplies the original commit (53e42930d9f0c0ae546f30b0f46cab7e5c094344). I've made the original author the co-author of this commit.