### PR TITLE
Do not set gravity and damping when Custom Integrator is enabled.

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -894,6 +894,13 @@ void RigidBodyBullet::reload_space_override_modificator() {
 		return;
 	}
 
+	if (omit_forces_integration) {
+		// Custom behaviour.
+		btBody->setGravity(btVector3(0, 0, 0));
+		btBody->setDamping(0, 0);
+		return;
+	}
+
 	Vector3 newGravity(0.0, 0.0, 0.0);
 	real_t newLinearDamp = MAX(0.0, linearDamp);
 	real_t newAngularDamp = MAX(0.0, angularDamp);


### PR DESCRIPTION
#40252 was reverted with #42639. However, #40252 included a fix for #40508. This PR provides a similar fix, but performs the check earlier and extends it to include dampening.

Fixes #40508 again.
