### PR TITLE
Do not print a warning when loading an image from `res://` path

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2290,11 +2290,6 @@ Image::AlphaMode Image::detect_alpha() const {
 }
 
 Error Image::load(const String &p_path) {
-#ifdef DEBUG_ENABLED
-	if (p_path.begins_with("res://") && ResourceLoader::exists(p_path)) {
-		WARN_PRINT("Loaded resource as image file, this will not work on export: '" + p_path + "'. Instead, import the image file as an Image resource and load it normally as a resource.");
-	}
-#endif
 	return ImageLoader::load_image(p_path, this);
 }
 


### PR DESCRIPTION
Closes #24222.
Alternative to #39396.
See rationale at https://github.com/godotengine/godot/pull/39396#issuecomment-705482583.

See documentation changes at #42412 instead. I strongly believe this should be part of documentation rather than a warning (which doesn't even apply to all use cases), and the verbosity of the message suggests so. 🙂

There's no need to cherry-pick this to 3.2 if you feel like this warning (deprecation?) has informational value to let people update their projects to use imported resources over loading files dynamically.

As a bonus, removes `ResourceLoader` dependency from the `Image` class.