### PR TITLE
Removed unused method Geometry3D.get_uv84_normal_bit

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1156,10 +1156,6 @@ Vector<Vector3> _Geometry3D::clip_polygon(const Vector<Vector3> &p_points, const
 	return Geometry3D::clip_polygon(p_points, p_plane);
 }
 
-int _Geometry3D::get_uv84_normal_bit(const Vector3 &p_vector) {
-	return Geometry3D::get_uv84_normal_bit(p_vector);
-}
-
 void _Geometry3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("build_box_planes", "extents"), &_Geometry3D::build_box_planes);
 	ClassDB::bind_method(D_METHOD("build_cylinder_planes", "radius", "height", "sides", "axis"), &_Geometry3D::build_cylinder_planes, DEFVAL(Vector3::AXIS_Z));
@@ -1170,8 +1166,6 @@ void _Geometry3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment", "point", "s1", "s2"), &_Geometry3D::get_closest_point_to_segment);
 
 	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment_uncapped", "point", "s1", "s2"), &_Geometry3D::get_closest_point_to_segment_uncapped);
-
-	ClassDB::bind_method(D_METHOD("get_uv84_normal_bit", "normal"), &_Geometry3D::get_uv84_normal_bit);
 
 	ClassDB::bind_method(D_METHOD("ray_intersects_triangle", "from", "dir", "a", "b", "c"), &_Geometry3D::ray_intersects_triangle);
 	ClassDB::bind_method(D_METHOD("segment_intersects_triangle", "from", "to", "a", "b", "c"), &_Geometry3D::segment_intersects_triangle);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -344,7 +344,6 @@ public:
 	Vector<Vector3> segment_intersects_sphere(const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_sphere_pos, real_t p_sphere_radius);
 	Vector<Vector3> segment_intersects_cylinder(const Vector3 &p_from, const Vector3 &p_to, float p_height, float p_radius);
 	Vector<Vector3> segment_intersects_convex(const Vector3 &p_from, const Vector3 &p_to, const Vector<Plane> &p_planes);
-	int get_uv84_normal_bit(const Vector3 &p_vector);
 
 	Vector<Vector3> clip_polygon(const Vector<Vector3> &p_points, const Plane &p_plane);
 

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -636,54 +636,6 @@ public:
 		void optimize_vertices();
 	};
 
-	_FORCE_INLINE_ static int get_uv84_normal_bit(const Vector3 &p_vector) {
-		int lat = Math::fast_ftoi(Math::floor(Math::acos(p_vector.dot(Vector3(0, 1, 0))) * 4.0 / Math_PI + 0.5));
-
-		if (lat == 0) {
-			return 24;
-		} else if (lat == 4) {
-			return 25;
-		}
-
-		int lon = Math::fast_ftoi(Math::floor((Math_PI + Math::atan2(p_vector.x, p_vector.z)) * 8.0 / (Math_PI * 2.0) + 0.5)) % 8;
-
-		return lon + (lat - 1) * 8;
-	}
-
-	_FORCE_INLINE_ static int get_uv84_normal_bit_neighbors(int p_idx) {
-		if (p_idx == 24) {
-			return 1 | 2 | 4 | 8;
-		} else if (p_idx == 25) {
-			return (1 << 23) | (1 << 22) | (1 << 21) | (1 << 20);
-		} else {
-			int ret = 0;
-			if ((p_idx % 8) == 0) {
-				ret |= (1 << (p_idx + 7));
-			} else {
-				ret |= (1 << (p_idx - 1));
-			}
-			if ((p_idx % 8) == 7) {
-				ret |= (1 << (p_idx - 7));
-			} else {
-				ret |= (1 << (p_idx + 1));
-			}
-
-			int mask = ret | (1 << p_idx);
-			if (p_idx < 8) {
-				ret |= 24;
-			} else {
-				ret |= mask >> 8;
-			}
-
-			if (p_idx >= 16) {
-				ret |= 25;
-			} else {
-				ret |= mask << 8;
-			}
-
-			return ret;
-		}
-	}
 	static MeshData build_convex_mesh(const Vector<Plane> &p_planes);
 	static Vector<Plane> build_sphere_planes(real_t p_radius, int p_lats, int p_lons, Vector3::Axis p_axis = Vector3::AXIS_Z);
 	static Vector<Plane> build_box_planes(const Vector3 &p_extents);

--- a/doc/classes/Geometry3D.xml
+++ b/doc/classes/Geometry3D.xml
@@ -102,15 +102,6 @@
 				Given the two 3D segments ([code]p1[/code], [code]p2[/code]) and ([code]q1[/code], [code]q2[/code]), finds those two points on the two segments that are closest to each other. Returns a [PackedVector3Array] that contains this point on ([code]p1[/code], [code]p2[/code]) as well the accompanying point on ([code]q1[/code], [code]q2[/code]).
 			</description>
 		</method>
-		<method name="get_uv84_normal_bit">
-			<return type="int">
-			</return>
-			<argument index="0" name="normal" type="Vector3">
-			</argument>
-			<description>
-				Used internally by the engine.
-			</description>
-		</method>
 		<method name="ray_intersects_triangle">
 			<return type="Variant">
 			</return>


### PR DESCRIPTION
This method and `get_uv84_normal_bit_neighbors` seems unused even by the engine. I'm not sure whether it's reserved for the future so it's up to @reduz decision to accept this PR or not.
