### PR TITLE
Fix Popup crash in single window mode

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -895,11 +895,11 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 
 	if (exclusive_child != nullptr) {
 		Window *focus_target = exclusive_child;
-		while (focus_target->exclusive_child != nullptr) {
-			focus_target->grab_focus();
-			focus_target = focus_target->exclusive_child;
-		}
 		focus_target->grab_focus();
+		while (focus_target->exclusive_child != nullptr) {
+			focus_target = focus_target->exclusive_child;
+			focus_target->grab_focus();
+		}
 
 		if (!is_embedding_subwindows()) { //not embedding, no need for event
 			return;


### PR DESCRIPTION
`focus_target->exclusive_child` could be invalidated during the call to `focus_target->grab_focus()`, now using the same logic with safe accesses to `focus_target`.

Fixes #41637 
Fixes #42645 