### PR TITLE
[Windows, MSVC] Correctly set source file encoding.

### DIFF
--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -81,7 +81,7 @@ def configure(env):
     vc_base_path = os.environ["VCTOOLSINSTALLDIR"] if "VCTOOLSINSTALLDIR" in os.environ else os.environ["VCINSTALLDIR"]
 
     # Force to use Unicode encoding
-    env.Append(MSVC_FLAGS=["/utf-8"])
+    env.AppendUnique(CCFLAGS=["/utf-8"])
 
     # ANGLE
     angle_root = os.getenv("ANGLE_SRC_PATH")

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -223,7 +223,7 @@ def configure_msvc(env, manual_msvc_config):
 
     env.AppendUnique(CCFLAGS=["/MT", "/Gd", "/GR", "/nologo"])
     # Force to use Unicode encoding
-    env.Append(MSVC_FLAGS=["/utf-8"])
+    env.AppendUnique(CCFLAGS=["/utf-8"])
     env.AppendUnique(CXXFLAGS=["/TP"])  # assume all sources are C++
     if manual_msvc_config:  # should be automatic if SCons found it
         if os.getenv("WindowsSdkDir") is not None:


### PR DESCRIPTION
Revert `MSVC_FLAGS` to `CCFLAGS` (was changed in #42634), `MSVC_FLAGS` seems to do absolutely nothing.

While UTF-8 literals decoded at runtime (`String::utf8("something")`) works anyway, MSVC is not reading string literals correctly, literals that are decoded to UTF-16 (`u"something"`) or UTF-32 (`U"something"`) during compilation are broken or cause "error C2015: too many characters in constant" build error. `U"..."` style string literals are used in the ICU and `TextServer` tests (breaks #41100).
