### PR TITLE
Mono: Fix typo in Godot.NET.Sdk.nuspec

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.nuspec
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.nuspec
@@ -17,6 +17,6 @@
     <repository url="$projecturl$" />
   </metadata>
   <files>
-    <file src="Sdk\**" target="Sdk" />\
+    <file src="Sdk\**" target="Sdk" />
   </files>
 </package>


### PR DESCRIPTION
Fixes #42666.