### PR TITLE
Implement INCR mechanism for Linux clipboard

### DIFF
--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -270,6 +270,7 @@ class DisplayServerX11 : public DisplayServer {
 
 	static Bool _predicate_all_events(Display *display, XEvent *event, XPointer arg);
 	static Bool _predicate_clipboard_selection(Display *display, XEvent *event, XPointer arg);
+	static Bool _predicate_clipboard_incr(Display *display, XEvent *event, XPointer arg);
 	static Bool _predicate_clipboard_save_targets(Display *display, XEvent *event, XPointer arg);
 
 protected:


### PR DESCRIPTION
Allows pasting from x11 clipboard to receive data incrementally, which is required when handling data size > 256KB.

*Note:* This PR shares changes around polling x server events with #42652. They should be exactly the same (new method `_wait_for_events` to allow polling events from the main thread).

I'll make a separate PR to backport these changes to the 3.2 branch.
