### PR TITLE
CI: Refactor build workflows to use `SCONSFLAGS`

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -1,9 +1,10 @@
 name: 🤖 Android Builds
 on: [push, pull_request]
 
-# Global Cache Settings
+# Global Settings
 env:
   GODOT_BASE_BRANCH: master
+  SCONSFLAGS: platform=android verbose=yes warnings=all werror=yes --jobs=2
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -70,7 +71,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=android target=release tools=no
+          scons target=release tools=no
           ls -l bin/
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -1,9 +1,10 @@
 name: 🍏 iOS Builds
 on: [push, pull_request]
 
-# Global Cache Settings
+# Global Settings
 env:
   GODOT_BASE_BRANCH: master
+  SCONSFLAGS: platform=iphone verbose=yes warnings=all werror=yes --jobs=2
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -47,7 +48,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=iphone target=release tools=no
+          scons target=release tools=no
           ls -l bin/
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/javascript_builds.disabled
+++ b/.github/workflows/javascript_builds.disabled
@@ -1,9 +1,10 @@
 name: 🌐 JavaScript Builds
 on: [push, pull_request]
 
-# Global Cache Settings
+# Global Settings
 env:
   GODOT_BASE_BRANCH: master
+  SCONSFLAGS: platform=javascript verbose=yes warnings=all werror=yes --jobs=2
   SCONS_CACHE_LIMIT: 4096
   EM_VERSION: 1.39.20
   EM_CACHE_FOLDER: 'emsdk-cache'
@@ -74,7 +75,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=javascript target=release tools=no use_closure_compiler=yes
+          scons target=release tools=no use_closure_compiler=yes
           ls -l bin/
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,9 +1,10 @@
 name: 🐧 Linux Builds
 on: [push, pull_request]
 
-# Global Cache Settings
+# Global Settings
 env:
   GODOT_BASE_BRANCH: master
+  SCONSFLAGS: platform=linuxbsd verbose=yes warnings=all werror=yes --jobs=2
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -61,7 +62,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd tools=yes tests=yes target=release_debug module_mono_enabled=yes mono_glue=no
+          scons tools=yes tests=yes target=release_debug module_mono_enabled=yes mono_glue=no
           ls -l bin/
 
       # Execute unit tests for the editor
@@ -129,7 +130,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd tools=yes tests=yes target=debug use_asan=yes use_ubsan=yes
+          scons tools=yes tests=yes target=debug use_asan=yes use_ubsan=yes
           ls -l bin/
 
       # Execute unit tests for the editor
@@ -196,7 +197,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=linuxbsd target=release tools=no module_mono_enabled=yes mono_glue=no
+          scons target=release tools=no module_mono_enabled=yes mono_glue=no
           ls -l bin/
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -1,9 +1,10 @@
 name: 🍎 macOS Builds
 on: [push, pull_request]
 
-# Global Cache Settings
+# Global Settings
 env:
   GODOT_BASE_BRANCH: master
+  SCONSFLAGS: platform=osx verbose=yes warnings=all werror=yes --jobs=2
   SCONS_CACHE_LIMIT: 4096
 
 jobs:
@@ -49,7 +50,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=osx tools=yes tests=yes target=release_debug
+          scons tools=yes tests=yes target=release_debug
           ls -l bin/
 
       # Execute unit tests for the editor
@@ -103,7 +104,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons -j2 verbose=yes warnings=all werror=yes platform=osx target=release tools=no
+          scons target=release tools=no
           ls -l bin/
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,10 +1,11 @@
 name: 🏁 Windows Builds
 on: [push, pull_request]
 
-# Global Cache Settings
+# Global Settings
 # SCONS_CACHE for windows must be set in the build environment
 env:
   GODOT_BASE_BRANCH: master
+  SCONSFLAGS: platform=windows verbose=yes warnings=all werror=yes --jobs=2
   SCONS_CACHE_MSVC_CONFIG: true
   SCONS_CACHE_LIMIT: 4096
 
@@ -54,7 +55,7 @@ jobs:
       env:
         SCONS_CACHE: /.scons_cache/
       run: |
-        scons -j2 verbose=yes warnings=all werror=yes platform=windows tools=yes tests=yes target=release_debug
+        scons tools=yes tests=yes target=release_debug
         ls -l bin/
 
     # Execute unit tests for the editor
@@ -109,7 +110,7 @@ jobs:
       env:
         SCONS_CACHE: /.scons_cache/
       run: |
-        scons -j2 verbose=yes warnings=all werror=yes platform=windows target=release tools=no
+        scons target=release tools=no
         ls -l bin/
 
     - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Common build options are moved to `SCONSFLAGS` used by `scons` to setup build options from the environment variable, namely: `verbose=yes warnings=all werror=yes --jobs=2`

The `platform` is also set there, because workflows are managed per platform currently.

If needed, these options can be overridden from the command-line interface within the build command itself, such as with the previous `werror=no` for iOS builds.

