### PR TITLE
Add ability to bind an unbind arguments to Callable.

### DIFF
--- a/core/callable.h
+++ b/core/callable.h
@@ -80,12 +80,17 @@ public:
 		return method != StringName();
 	}
 
+	Callable bind(const Variant **p_arguments, int p_argcount) const;
+	Callable unbind(int p_argcount) const;
+
 	Object *get_object() const;
 	ObjectID get_object_id() const;
 	StringName get_method() const;
 	CallableCustom *get_custom() const;
 
 	uint32_t hash() const;
+
+	const Callable *get_base_comparator() const; //used for bind/unbind to do less precise comparisons (ignoring binds) in signal connect/disconnect
 
 	bool operator==(const Callable &p_callable) const;
 	bool operator!=(const Callable &p_callable) const;
@@ -119,6 +124,7 @@ public:
 	virtual CompareLessFunc get_compare_less_func() const = 0;
 	virtual ObjectID get_object() const = 0; //must always be able to provide an object
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const = 0;
+	virtual const Callable *get_base_comparator() const;
 
 	CallableCustom();
 	virtual ~CallableCustom() {}

--- a/core/callable_bind.cpp
+++ b/core/callable_bind.cpp
@@ -1,0 +1,193 @@
+/*************************************************************************/
+/*  callable_bind.cpp                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "callable_bind.h"
+
+//////////////////////////////////
+
+uint32_t CallableCustomBind::hash() const {
+	return callable.hash();
+}
+String CallableCustomBind::get_as_text() const {
+	return callable.operator String();
+}
+
+bool CallableCustomBind::_equal_func(const CallableCustom *p_a, const CallableCustom *p_b) {
+	const CallableCustomBind *a = (const CallableCustomBind *)p_a;
+	const CallableCustomBind *b = (const CallableCustomBind *)p_b;
+
+	if (!(a->callable != b->callable)) {
+		return false;
+	}
+
+	if (a->binds.size() != b->binds.size()) {
+		return false;
+	}
+
+	return true;
+}
+
+bool CallableCustomBind::_less_func(const CallableCustom *p_a, const CallableCustom *p_b) {
+	const CallableCustomBind *a = (const CallableCustomBind *)p_a;
+	const CallableCustomBind *b = (const CallableCustomBind *)p_b;
+
+	if (a->callable < b->callable) {
+		return true;
+	} else if (b->callable < a->callable) {
+		return false;
+	}
+
+	return a->binds.size() < b->binds.size();
+}
+
+CallableCustom::CompareEqualFunc CallableCustomBind::get_compare_equal_func() const {
+	return _equal_func;
+}
+CallableCustom::CompareLessFunc CallableCustomBind::get_compare_less_func() const {
+	return _less_func;
+}
+ObjectID CallableCustomBind::get_object() const {
+	return callable.get_object_id();
+}
+const Callable *CallableCustomBind::get_base_comparator() const {
+	return &callable;
+}
+
+void CallableCustomBind::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
+	const Variant **args = (const Variant **)alloca(sizeof(const Variant **) * (binds.size() + p_argcount));
+	for (int i = 0; i < p_argcount; i++) {
+		args[i] = (const Variant *)p_arguments[i];
+	}
+	for (int i = 0; i < binds.size(); i++) {
+		args[i + p_argcount] = (const Variant *)&binds[i];
+	}
+
+	callable.call(args, p_argcount + binds.size(), r_return_value, r_call_error);
+}
+
+CallableCustomBind::CallableCustomBind(const Callable &p_callable, const Vector<Variant> &p_binds) {
+	callable = p_callable;
+	binds = p_binds;
+}
+
+CallableCustomBind::~CallableCustomBind() {
+}
+
+//////////////////////////////////
+
+uint32_t CallableCustomUnbind::hash() const {
+	return callable.hash();
+}
+String CallableCustomUnbind::get_as_text() const {
+	return callable.operator String();
+}
+
+bool CallableCustomUnbind::_equal_func(const CallableCustom *p_a, const CallableCustom *p_b) {
+	const CallableCustomUnbind *a = (const CallableCustomUnbind *)p_a;
+	const CallableCustomUnbind *b = (const CallableCustomUnbind *)p_b;
+
+	if (!(a->callable != b->callable)) {
+		return false;
+	}
+
+	if (a->argcount != b->argcount) {
+		return false;
+	}
+
+	return true;
+}
+
+bool CallableCustomUnbind::_less_func(const CallableCustom *p_a, const CallableCustom *p_b) {
+	const CallableCustomUnbind *a = (const CallableCustomUnbind *)p_a;
+	const CallableCustomUnbind *b = (const CallableCustomUnbind *)p_b;
+
+	if (a->callable < b->callable) {
+		return true;
+	} else if (b->callable < a->callable) {
+		return false;
+	}
+
+	return a->argcount < b->argcount;
+}
+
+CallableCustom::CompareEqualFunc CallableCustomUnbind::get_compare_equal_func() const {
+	return _equal_func;
+}
+CallableCustom::CompareLessFunc CallableCustomUnbind::get_compare_less_func() const {
+	return _less_func;
+}
+ObjectID CallableCustomUnbind::get_object() const {
+	return callable.get_object_id();
+}
+const Callable *CallableCustomUnbind::get_base_comparator() const {
+	return &callable;
+}
+
+void CallableCustomUnbind::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
+	if (argcount > p_argcount) {
+		r_call_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
+		r_call_error.argument = 0;
+		r_call_error.expected = argcount;
+		return;
+	}
+	callable.call(p_arguments, p_argcount - argcount, r_return_value, r_call_error);
+}
+
+CallableCustomUnbind::CallableCustomUnbind(const Callable &p_callable, int p_argcount) {
+	callable = p_callable;
+	argcount = p_argcount;
+}
+
+CallableCustomUnbind::~CallableCustomUnbind() {
+}
+
+Callable callable_bind(const Callable &p_callable, const Variant &p_arg1) {
+	return p_callable.bind((const Variant **)&p_arg1, 1);
+}
+
+Callable callable_bind(const Callable &p_callable, const Variant &p_arg1, const Variant &p_arg2) {
+	const Variant *args[2] = { &p_arg1, &p_arg2 };
+	return p_callable.bind(args, 2);
+}
+
+Callable callable_bind(const Callable &p_callable, const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3) {
+	const Variant *args[3] = { &p_arg1, &p_arg2, &p_arg3 };
+	return p_callable.bind(args, 3);
+}
+
+Callable callable_bind(const Callable &p_callable, const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3, const Variant &p_arg4) {
+	const Variant *args[4] = { &p_arg1, &p_arg2, &p_arg3, &p_arg4 };
+	return p_callable.bind(args, 4);
+}
+
+Callable callable_bind(const Callable &p_callable, const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3, const Variant &p_arg4, const Variant &p_arg5) {
+	const Variant *args[5] = { &p_arg1, &p_arg2, &p_arg3, &p_arg4, &p_arg5 };
+	return p_callable.bind(args, 5);
+}

--- a/core/callable_bind.h
+++ b/core/callable_bind.h
@@ -1,0 +1,85 @@
+/*************************************************************************/
+/*  callable_bind.h                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef CALLABLE_BIND_H
+#define CALLABLE_BIND_H
+
+#include "core/callable.h"
+#include "core/variant.h"
+
+class CallableCustomBind : public CallableCustom {
+	Callable callable;
+	Vector<Variant> binds;
+
+	static bool _equal_func(const CallableCustom *p_a, const CallableCustom *p_b);
+	static bool _less_func(const CallableCustom *p_a, const CallableCustom *p_b);
+
+public:
+	//for every type that inherits, these must always be the same for this type
+	virtual uint32_t hash() const;
+	virtual String get_as_text() const;
+	virtual CompareEqualFunc get_compare_equal_func() const;
+	virtual CompareLessFunc get_compare_less_func() const;
+	virtual ObjectID get_object() const; //must always be able to provide an object
+	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const;
+	virtual const Callable *get_base_comparator() const;
+
+	CallableCustomBind(const Callable &p_callable, const Vector<Variant> &p_binds);
+	virtual ~CallableCustomBind();
+};
+
+class CallableCustomUnbind : public CallableCustom {
+	Callable callable;
+	int argcount;
+
+	static bool _equal_func(const CallableCustom *p_a, const CallableCustom *p_b);
+	static bool _less_func(const CallableCustom *p_a, const CallableCustom *p_b);
+
+public:
+	//for every type that inherits, these must always be the same for this type
+	virtual uint32_t hash() const;
+	virtual String get_as_text() const;
+	virtual CompareEqualFunc get_compare_equal_func() const;
+	virtual CompareLessFunc get_compare_less_func() const;
+	virtual ObjectID get_object() const; //must always be able to provide an object
+	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const;
+	virtual const Callable *get_base_comparator() const;
+
+	CallableCustomUnbind(const Callable &p_callable, int p_argcount);
+	virtual ~CallableCustomUnbind();
+};
+
+Callable callable_bind(const Callable &p_callable, const Variant &p_arg1);
+Callable callable_bind(const Callable &p_callable, const Variant &p_arg1, const Variant &p_arg2);
+Callable callable_bind(const Callable &p_callable, const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3);
+Callable callable_bind(const Callable &p_callable, const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3, const Variant &p_arg4);
+Callable callable_bind(const Callable &p_callable, const Variant &p_arg1, const Variant &p_arg2, const Variant &p_arg3, const Variant &p_arg4, const Variant &p_arg5);
+
+#endif // CALLABLE_BIND_H

--- a/core/core_string_names.cpp
+++ b/core/core_string_names.cpp
@@ -73,6 +73,8 @@ CoreStringNames::CoreStringNames() :
 		a8(StaticCString::create("a8")),
 		call(StaticCString::create("call")),
 		call_deferred(StaticCString::create("call_deferred")),
+		bind(StaticCString::create("bind")),
+		unbind(StaticCString::create("unbind")),
 		emit(StaticCString::create("emit")),
 		notification(StaticCString::create("notification")) {
 }

--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -92,6 +92,8 @@ public:
 
 	StringName call;
 	StringName call_deferred;
+	StringName bind;
+	StringName unbind;
 	StringName emit;
 	StringName notification;
 };

--- a/core/object.h
+++ b/core/object.h
@@ -31,6 +31,7 @@
 #ifndef OBJECT_H
 #define OBJECT_H
 
+#include "core/callable_bind.h"
 #include "core/hash_map.h"
 #include "core/list.h"
 #include "core/map.h"

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -586,6 +586,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM0(Callable, get_object_id);
 	VCALL_LOCALMEM0(Callable, get_method);
 	VCALL_LOCALMEM0(Callable, hash);
+	VCALL_LOCALMEM1R(Callable, unbind);
 
 	VCALL_LOCALMEM0R(Signal, is_null);
 	VCALL_LOCALMEM0R(Signal, get_object);
@@ -1347,11 +1348,14 @@ void Variant::call_ptr(const StringName &p_method, const Variant **p_args, int p
 				if (p_method == CoreStringNames::get_singleton()->call) {
 					reinterpret_cast<const Callable *>(_data._mem)->call(p_args, p_argcount, ret, r_error);
 					valid = true;
-				}
-				if (p_method == CoreStringNames::get_singleton()->call_deferred) {
+				} else if (p_method == CoreStringNames::get_singleton()->call_deferred) {
 					reinterpret_cast<const Callable *>(_data._mem)->call_deferred(p_args, p_argcount);
 					valid = true;
+				} else if (p_method == CoreStringNames::get_singleton()->bind) {
+					ret = reinterpret_cast<const Callable *>(_data._mem)->bind(p_args, p_argcount);
+					valid = true;
 				}
+
 			} else if (type == SIGNAL) {
 				if (p_method == CoreStringNames::get_singleton()->emit) {
 					if (r_ret) {
@@ -1696,9 +1700,13 @@ void Variant::get_method_list(List<MethodInfo> *p_list) const {
 
 	if (type == CALLABLE) {
 		MethodInfo mi;
+
+		mi.name = "bind";
+		mi.flags |= METHOD_FLAG_VARARG;
+		p_list->push_back(mi);
+
 		mi.name = "call";
 		mi.return_val.usage = PROPERTY_USAGE_NIL_IS_VARIANT;
-		mi.flags |= METHOD_FLAG_VARARG;
 
 		p_list->push_back(mi);
 
@@ -2130,6 +2138,7 @@ void register_variant_methods() {
 	ADDFUNC0R(CALLABLE, INT, Callable, get_object_id, varray());
 	ADDFUNC0R(CALLABLE, STRING_NAME, Callable, get_method, varray());
 	ADDFUNC0R(CALLABLE, INT, Callable, hash, varray());
+	ADDFUNC1R(CALLABLE, CALLABLE, Callable, unbind, INT, "argcount", varray());
 
 	ADDFUNC0R(SIGNAL, BOOL, Signal, is_null, varray());
 	ADDFUNC0R(SIGNAL, OBJECT, Signal, get_object, varray());

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1141,7 +1141,7 @@ void SceneTreeDock::_notification(int p_what) {
 			node_shortcuts->add_child(button_custom);
 			button_custom->set_text(TTR("Other Node"));
 			button_custom->set_icon(get_theme_icon("Add", "EditorIcons"));
-			button_custom->connect("pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(TOOL_NEW, false));
+			button_custom->connect("pressed", callable_bind(callable_mp(this, &SceneTreeDock::_tool_selected), TOOL_NEW, false));
 
 			node_shortcuts->add_spacer();
 			create_root_dialog->add_child(node_shortcuts);


### PR DESCRIPTION
After the today's contributor meeting we decided to change the way arguments are bound and unbound to signals and other structures by doing this directly in Callable.

As such, its now possible to bind and unbind arguments directly from the Callable:

```GDScript
func myfunc(extraarg):
    print("hello",extraarg)

func myfunc2():
    print("hello")

func _ready():
#old style (remains supported for more flexibility, but no longer the recommended way)
    $Button.connect("pressed",this,"myfunc",["watsup"])
#new style
    $Button.pressed.connect( myfunc.bind("watsup") )
#unbinding also possible, discard the extra argument
    $AnimationPlayer.finished.connect( myfunc2.unbind(1) )
```

from C++, the callable_bind() functions were added, can be used like this:

```c++
button->connect(callable_bind( callable_mp(this,&MyClass::_myfunc), "watsup" ) );
```

The ability to pass an array in the connect() version that takes a callable, in both C++ and script languages will be removed, so these will have to be used from now on in Godot 4.0 (the connect method for Object will remain unchanged in case flexibility is desired)). This change will be done project wide in a subsequent pull request.