### PR TITLE
Fix HTTPClient::poll crash after connection is self-assigned

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -96,6 +96,10 @@ Error HTTPClient::connect_to_host(const String &p_host, int p_port, bool p_ssl, 
 void HTTPClient::set_connection(const Ref<StreamPeer> &p_connection) {
 	ERR_FAIL_COND_MSG(p_connection.is_null(), "Connection is not a reference to a valid StreamPeer object.");
 
+	if (connection == p_connection) {
+		return;
+	}
+
 	close();
 	connection = p_connection;
 	status = STATUS_CONNECTED;


### PR DESCRIPTION
This PR fixes a `HTTPClient::poll` crash after connection is self-assigned if the HTTPClient was previously connected to an HTTPS host.

To reproduce the crash, you can run the following script.

```gdscript
extends SceneTree

func _init():
    var http = HTTPClient.new()

    var err = http.connect_to_host("https://httpbin.org")
    assert(err == OK)

    http.connection = http.connection
    http.poll()
```

Tested on the current master and 3.2 branch.