### PR TITLE
Implement ResourceImporter version and respect import params when testing for reimport.

### DIFF
--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -97,6 +97,7 @@ class ResourceImporter : public Reference {
 public:
 	virtual String get_importer_name() const = 0;
 	virtual String get_visible_name() const = 0;
+	virtual int get_importer_version() const { return 0; }
 	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
 	virtual String get_save_extension() const = 0;
 	virtual String get_resource_type() const = 0;

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -17,6 +17,9 @@
 		func get_visible_name():
 		    return "Special Mesh Importer"
 
+		func get_importer_version():
+		    return 1;
+
 		func get_recognized_extensions():
 		    return ["special", "spec"]
 
@@ -73,6 +76,13 @@
 			</return>
 			<description>
 				Gets the unique name of the importer.
+			</description>
+		</method>
+		<method name="get_importer_version" qualifiers="virtual">
+			<return type="int">
+			</return>
+			<description>
+				Gets the version of the importer. When the version changes, all associated resources will be re-imported.
 			</description>
 		</method>
 		<method name="get_option_visibility" qualifiers="virtual">

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -356,13 +356,22 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 	String source_md5 = "";
 	Vector<String> dest_files;
 	String dest_md5 = "";
+	String params_md5 = "";
+	String params_hash = "";
+	int importer_current_version = 0;
+	int importer_imported_version = 0;
 
+	bool is_hashing_params = false;
 	while (true) {
 		assign = Variant();
 		next_tag.fields.clear();
 		next_tag.name = String();
 
 		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		if (next_tag.name == "params") {
+			is_hashing_params = true;
+		}
+
 		if (err == ERR_FILE_EOF) {
 			break;
 		} else if (err != OK) {
@@ -371,24 +380,30 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 			return false; //parse error, try reimport manually (Avoid reimport loop on broken file)
 		}
 
-		if (assign != String()) {
-			if (assign.begins_with("path")) {
-				to_check.push_back(value);
-			} else if (assign == "files") {
-				Array fa = value;
-				for (int i = 0; i < fa.size(); i++) {
-					to_check.push_back(fa[i]);
-				}
-			} else if (!p_only_imported_files) {
-				if (assign == "source_file") {
-					source_file = value;
-				} else if (assign == "dest_files") {
-					dest_files = value;
-				}
+		if (assign == String()) {
+			continue;
+		} else if (is_hashing_params) {
+			String hashed_value;
+			VariantWriter::write_to_string(value, hashed_value);
+			params_hash += "::" + assign + "=" + hashed_value;
+		} else if (assign.begins_with("path")) {
+			to_check.push_back(value);
+		} else if (assign == "files") {
+			Array fa = value;
+			for (int i = 0; i < fa.size(); i++) {
+				to_check.push_back(fa[i]);
 			}
-
-		} else if (next_tag.name != "remap" && next_tag.name != "deps") {
-			break;
+		} else if (assign == "importer") {
+			Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(value);
+			if (importer.is_valid()) {
+				importer_current_version = importer->get_importer_version();
+			}
+		} else if (!p_only_imported_files) {
+			if (assign == "source_file") {
+				source_file = value;
+			} else if (assign == "dest_files") {
+				dest_files = value;
+			}
 		}
 	}
 
@@ -424,11 +439,21 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 					source_md5 = value;
 				} else if (assign == "dest_md5") {
 					dest_md5 = value;
+				} else if (assign == "params_md5") {
+					params_md5 = value;
 				}
+			}
+			if (assign == "importer_version") {
+				importer_imported_version = value;
 			}
 		}
 	}
 	memdelete(md5s);
+
+	//imported with different importer version, reimport
+	if (importer_current_version != importer_imported_version) {
+		return true;
+	}
 
 	//imported files are gone, reimport
 	for (List<String>::Element *E = to_check.front(); E; E = E->next()) {
@@ -439,6 +464,10 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 
 	//check source md5 matching
 	if (!p_only_imported_files) {
+		if (params_md5 != params_hash.md5_text()) {
+			return true; //params had changed, reimport
+		}
+
 		if (source_file != String() && source_file != p_path) {
 			return true; //file was moved, reimport
 		}
@@ -1595,6 +1624,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 
 		List<ResourceImporter::ImportOption> options;
 		importer->get_import_options(&options);
+		String params_md5 = "";
 		//set default values
 		for (List<ResourceImporter::ImportOption>::Element *F = options.front(); F; F = F->next()) {
 			String base = F->get().option.name;
@@ -1605,6 +1635,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 			String value;
 			VariantWriter::write_to_string(v, value);
 			f->store_line(base + "=" + value);
+			params_md5 += "::" + base + "=" + value;
 		}
 
 		f->close();
@@ -1613,6 +1644,8 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		FileAccessRef md5s = FileAccess::open(base_path + ".md5", FileAccess::WRITE);
 		ERR_FAIL_COND_V_MSG(!md5s, ERR_FILE_CANT_OPEN, "Cannot open MD5 file '" + base_path + ".md5'.");
 
+		md5s->store_line("importer_version=" + Variant(importer->get_importer_version()).get_construct_string());
+		md5s->store_line("params_md5=\"" + params_md5.md5_text() + "\"");
 		md5s->store_line("source_md5=\"" + FileAccess::get_md5(file) + "\"");
 		if (dest_paths.size()) {
 			md5s->store_line("dest_md5=\"" + FileAccess::get_multiple_md5(dest_paths) + "\"\n");
@@ -1804,11 +1837,13 @@ void EditorFileSystem::_reimport_file(const String &p_file) {
 
 	//store options in provided order, to avoid file changing. Order is also important because first match is accepted first.
 
+	String params_md5 = "";
 	for (List<ResourceImporter::ImportOption>::Element *E = opts.front(); E; E = E->next()) {
 		String base = E->get().option.name;
 		String value;
 		VariantWriter::write_to_string(params[base], value);
 		f->store_line(base + "=" + value);
+		params_md5 += "::" + base + "=" + value;
 	}
 
 	f->close();
@@ -1818,6 +1853,8 @@ void EditorFileSystem::_reimport_file(const String &p_file) {
 	FileAccess *md5s = FileAccess::open(base_path + ".md5", FileAccess::WRITE);
 	ERR_FAIL_COND_MSG(!md5s, "Cannot open MD5 file '" + base_path + ".md5'.");
 
+	md5s->store_line("importer_version=" + Variant(importer->get_importer_version()).get_construct_string());
+	md5s->store_line("params_md5=\"" + params_md5.md5_text() + "\"");
 	md5s->store_line("source_md5=\"" + FileAccess::get_md5(p_file) + "\"");
 	if (dest_paths.size()) {
 		md5s->store_line("dest_md5=\"" + FileAccess::get_multiple_md5(dest_paths) + "\"\n");

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -44,6 +44,13 @@ String EditorImportPlugin::get_visible_name() const {
 	return get_script_instance()->call("get_visible_name");
 }
 
+int EditorImportPlugin::get_importer_version() const {
+	if (!(get_script_instance() && get_script_instance()->has_method("get_importer_version"))) {
+		return ResourceImporter::get_importer_version();
+	}
+	return get_script_instance()->call("get_importer_version");
+}
+
 void EditorImportPlugin::get_recognized_extensions(List<String> *p_extensions) const {
 	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("get_recognized_extensions")));
 	Array extensions = get_script_instance()->call("get_recognized_extensions");
@@ -153,6 +160,7 @@ Error EditorImportPlugin::import(const String &p_source_file, const String &p_sa
 void EditorImportPlugin::_bind_methods() {
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_importer_name"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_visible_name"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::INT, "get_importer_name"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::INT, "get_preset_count"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_preset_name", PropertyInfo(Variant::INT, "preset")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::ARRAY, "get_recognized_extensions"));

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -43,6 +43,7 @@ public:
 	EditorImportPlugin();
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
+	virtual int get_importer_version() const override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual String get_preset_name(int p_idx) const override;
 	virtual int get_preset_count() const override;


### PR DESCRIPTION
**The problem**
When multiply contributors work on the same project and contributor A changes the import parameter for some resource, this change remains unprocessed by the editor for contributor B. Also, there is no clean way to tell the editor if a custom resource importer updated and affected resources needs to be reimported. All of this leads to sneaky bugs.

**The solution**
To provide consistency between imported resources for multiply project contributors, we need to reimport resources if import params got changed outside the project (via git, for example). For now, only Textures are reimported and only in some cases (if I change compression type, or change supported by project compression formats). With this PR resources will be reimported on any parameter change. This also introduces `ResourceImporter.get_importer_version() -> int`. Changing the version of the importer will re-import all associated resources.

**How to test** 

Reimport on params change:
- open test project
- edit the import file with a text editor, `res://hello.txt.import`, for example
- change param`prefix`
- switch back to Godot editor
- ensure `hello.txt` is reimported - you can inspect `hello.txt-<hash>.tres` in `.godot/import` folder (no reimport without PR)

Reimport on importer version change:
- change value returned by `get_importer_version()` in `res://addons/hello_world/plugin.gd`
- restart the editor
- ensure `hello.txt` is reimported - you can inspect `hello.txt-<hash>.tres` in `.godot/import` folder (no reimport without PR)

**Test project**
[importer_version_4.0.zip](https://github.com/godotengine/godot/files/5358973/importer_version_4.0.zip)

**Notes**
I receive some warnings on import when using EditorImportPlugin (everything is ok with native ResourceImporters), this is related to the way how custom resources works, I guess, not this PR:
<img width="860" alt="Screenshot 2020-10-10 at 15 23 07" src="https://user-images.githubusercontent.com/122736/95655242-8f815e80-0b0e-11eb-91a8-a39a2940db3a.png">

