### PR TITLE
[3.x] Implement ResourceImporter version and respect import params when testing for reimport.

### DIFF
--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -99,6 +99,7 @@ class ResourceImporter : public Reference {
 public:
 	virtual String get_importer_name() const = 0;
 	virtual String get_visible_name() const = 0;
+	virtual int get_importer_version() const { return 0; }
 	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
 	virtual String get_save_extension() const = 0;
 	virtual String get_resource_type() const = 0;

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -17,6 +17,9 @@
 		func get_visible_name():
 		    return "Special Mesh Importer"
 
+		func get_importer_version():
+		    return 1;
+
 		func get_recognized_extensions():
 		    return ["special", "spec"]
 
@@ -73,6 +76,13 @@
 			</return>
 			<description>
 				Gets the unique name of the importer.
+			</description>
+		</method>
+		<method name="get_importer_version" qualifiers="virtual">
+			<return type="int">
+			</return>
+			<description>
+				Gets the version of the importer. When the version changes, all associated resources will be re-imported.
 			</description>
 		</method>
 		<method name="get_option_visibility" qualifiers="virtual">

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -44,6 +44,13 @@ String EditorImportPlugin::get_visible_name() const {
 	return get_script_instance()->call("get_visible_name");
 }
 
+int EditorImportPlugin::get_importer_version() const {
+	if (!(get_script_instance() && get_script_instance()->has_method("get_importer_version"))) {
+		return ResourceImporter::get_importer_version();
+	}
+	return get_script_instance()->call("get_importer_version");
+}
+
 void EditorImportPlugin::get_recognized_extensions(List<String> *p_extensions) const {
 	ERR_FAIL_COND(!(get_script_instance() && get_script_instance()->has_method("get_recognized_extensions")));
 	Array extensions = get_script_instance()->call("get_recognized_extensions");
@@ -156,6 +163,7 @@ void EditorImportPlugin::_bind_methods() {
 
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_importer_name"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_visible_name"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::INT, "get_importer_version"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::INT, "get_preset_count"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_preset_name", PropertyInfo(Variant::INT, "preset")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::ARRAY, "get_recognized_extensions"));

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -43,6 +43,7 @@ public:
 	EditorImportPlugin();
 	virtual String get_importer_name() const;
 	virtual String get_visible_name() const;
+	virtual int get_importer_version() const;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual String get_preset_name(int p_idx) const;
 	virtual int get_preset_count() const;


### PR DESCRIPTION
This is a version of #42689 for **3.2**.

**The problem**
When multiply contributors work on the same project and contributor A changes the import parameter for some resource, this change remains unprocessed by the editor for contributor B. Also, there is no clean way to tell the editor if a custom resource importer updated and affected resources needs to be reimported. All of this leads to sneaky bugs.

**The solution**
To provide consistency between imported resources for multiply project contributors, we need to reimport resources if import params got changed outside the project (via git, for example). For now, only Textures are reimported and only in some cases (if I change compression type, or change supported by project compression formats). With this PR resources will be reimported on any parameter change. This also introduces `ResourceImporter.get_importer_version() -> int`. Changing the version of the importer will re-import all associated resources.

**How to test** 

Reimport on params change:
- open test project
- edit the import file with a text editor, `res://hello.txt.import`, for example
- change param`prefix`
- switch back to Godot editor
- ensure `hello.txt` is reimported - you can inspect `hello.txt-<hash>.tres` in `.godot/import` folder (no reimport without PR)

Reimport on importer version change:
- change value returned by `get_importer_version()` in `res://addons/hello_world/plugin.gd`
- restart the editor
- ensure `hello.txt` is reimported - you can inspect `hello.txt-<hash>.tres` in `.godot/import` folder (no reimport without PR)

**Test project**
[importer_version_3.2.zip](https://github.com/godotengine/godot/files/5358979/importer_version_3.2.zip)


**Notes**
I receive some warnings on import when using EditorImportPlugin (everything is ok with native ResourceImporters), this is related to the way how custom resources works, I guess, not this PR:
<img width="860" alt="Screenshot 2020-10-10 at 15 23 07" src="https://user-images.githubusercontent.com/122736/95655242-8f815e80-0b0e-11eb-91a8-a39a2940db3a.png">

