### PR TITLE
Updating KinematicBody2D "is_on" functions' descriptions

### DIFF
--- a/doc/classes/KinematicBody2D.xml
+++ b/doc/classes/KinematicBody2D.xml
@@ -55,21 +55,21 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the body is on the ceiling. Only updates when calling [method move_and_slide] or [method move_and_slide_with_snap].
+				Returns [code]true[/code] if the body collided with the ceiling on the last call of [method move_and_slide] or [method move_and_slide_with_snap]. Otherwise, returns [code]false[/code].
 			</description>
 		</method>
 		<method name="is_on_floor" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the body is on the floor. Only updates when calling [method move_and_slide] or [method move_and_slide_with_snap].
+				Returns [code]true[/code] if the body collided with the floor on the last call of [method move_and_slide] or [method move_and_slide_with_snap]. Otherwise, returns [code]false[/code].
 			</description>
 		</method>
 		<method name="is_on_wall" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the body is on a wall. Only updates when calling [method move_and_slide] or [method move_and_slide_with_snap].
+				Returns [code]true[/code] if the body collided with a wall on the last call of [method move_and_slide] or [method move_and_slide_with_snap]. Otherwise, returns [code]false[/code].
 			</description>
 		</method>
 		<method name="move_and_collide">

--- a/doc/classes/KinematicBody3D.xml
+++ b/doc/classes/KinematicBody3D.xml
@@ -59,21 +59,21 @@
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the body is on the ceiling. Only updates when calling [method move_and_slide] or [method move_and_slide_with_snap].
+				Returns [code]true[/code] if the body collided with the ceiling on the last call of [method move_and_slide] or [method move_and_slide_with_snap]. Otherwise, returns [code]false[/code].
 			</description>
 		</method>
 		<method name="is_on_floor" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the body is on the floor. Only updates when calling [method move_and_slide] or [method move_and_slide_with_snap].
+				Returns [code]true[/code] if the body collided with the floor on the last call of [method move_and_slide] or [method move_and_slide_with_snap]. Otherwise, returns [code]false[/code].
 			</description>
 		</method>
 		<method name="is_on_wall" qualifiers="const">
 			<return type="bool">
 			</return>
 			<description>
-				Returns [code]true[/code] if the body is on a wall. Only updates when calling [method move_and_slide] or [method move_and_slide_with_snap].
+				Returns [code]true[/code] if the body collided with a wall on the last call of [method move_and_slide] or [method move_and_slide_with_snap]. Otherwise, returns [code]false[/code].
 			</description>
 		</method>
 		<method name="move_and_collide">


### PR DESCRIPTION
From Discord, `#documentation` channel:

@arthurpaulino
Hey I just had some problems with is_on_floor() from KinematicBody2D. On the docs it says:
> Returns true if the body is on the floor. Only updates when calling move_and_slide().

I had a body that was on the floor but it hadn't collided on that exact frame, so is_on_floor() was returning false and causing some unexpected behavior on my code. Fortunately @zacryol helped me figure out the real meaning of what is_on_floor() returns. I think it would be better phrased as:
> Returns true if the body has collided with the floor on the last call of move_and_slide() and false otherwise.

Do you guys think it makes sense?

@NathanLovato 
It's been a common source of confusion. The change seems good to me, some minor tweak to better fit the writing guidelines and using the docs' bbcode:
> Returns [code]true[/code] if the body collided with the floor on the last call of [member move_and_slide]. Otherwise, returns [code]false[/code].