### PR TITLE
Fix premature end of animation playing backwards

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -762,12 +762,10 @@ void AnimationPlayer::_animation_process_data(PlaybackData &cd, float p_delta, f
 			next_pos = len;
 		}
 
-		// fix delta
-		delta = next_pos - cd.pos;
+		bool backwards = signbit(delta); // Negative zero means playing backwards too
+		delta = next_pos - cd.pos; // Fix delta (after determination of backwards because negative zero is lost here)
 
 		if (&cd == &playback.current) {
-			bool backwards = delta < 0;
-
 			if (!backwards && cd.pos <= len && next_pos == len /*&& playback.blend.empty()*/) {
 				//playback finished
 				end_reached = true;


### PR DESCRIPTION
In my game, I noticed that sometimes the main character got stuck in a half-crouched, half-standing pose when going from crouch to standing. That was implemented as playing the crouch animation backwards.

Now I've found why that was happening and this is the fix for it. It didn't happen all the time, but only one of many times, because it depends on the frame time delta and the current playback position to be such that the adjusted delta is zero.