### PR TITLE
Disable script editor smooth scrolling by default due to bugs

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -554,7 +554,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Behavior: Navigation
 	_initial_set("text_editor/behavior/navigation/move_caret_on_right_click", true);
 	_initial_set("text_editor/behavior/navigation/scroll_past_end_of_file", false);
-	_initial_set("text_editor/behavior/navigation/smooth_scrolling", true);
+	// Disable smooth scrolling by default due to known bugs like GH-28385.
+	_initial_set("text_editor/behavior/navigation/smooth_scrolling", false);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/behavior/navigation/v_scroll_speed", 80, "1,10000,1")
 	_initial_set("text_editor/behavior/navigation/drag_and_drop_selection", true);
 	_initial_set("text_editor/behavior/navigation/stay_in_script_editor_on_node_selected", true);


### PR DESCRIPTION
Fixing the bug where smooth scrolling stops working after increasing the physics ticks per second project setting doesn't appear to be trivial. Disabling smooth scrolling by default alleviates the issue for now.

The way the current smooth scrolling algorithm works isn't really conductive to a good user experience anyway – it is purely linear and line-based, rather than per-pixel. It's the first option I disable in Godot's editor, even though I don't disable the equivalent feature in Visual Studio Code :slightly_smiling_face: 

This partially addresses #28385.