### PR TITLE
Fix rectangle paint tooltip for the tilemap editor on macOS

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1333,7 +1333,11 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_button[UV_MODE_CREATE]->set_tooltip(TTR("Create Polygon"));
 	uv_button[UV_MODE_CREATE_INTERNAL]->set_tooltip(TTR("Create Internal Vertex"));
 	uv_button[UV_MODE_REMOVE_INTERNAL]->set_tooltip(TTR("Remove Internal Vertex"));
+#ifdef OSX_ENABLED
+	uv_button[UV_MODE_EDIT_POINT]->set_tooltip(TTR("Move Points") + "\n" + TTR("Command: Rotate") + "\n" + TTR("Shift: Move All") + "\n" + TTR("Shift+Command: Scale"));
+#else
 	uv_button[UV_MODE_EDIT_POINT]->set_tooltip(TTR("Move Points") + "\n" + TTR("Ctrl: Rotate") + "\n" + TTR("Shift: Move All") + "\n" + TTR("Shift+Ctrl: Scale"));
+#endif
 	uv_button[UV_MODE_MOVE]->set_tooltip(TTR("Move Polygon"));
 	uv_button[UV_MODE_ROTATE]->set_tooltip(TTR("Rotate Polygon"));
 	uv_button[UV_MODE_SCALE]->set_tooltip(TTR("Scale Polygon"));

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -2044,7 +2044,11 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	// Tools.
 	paint_button = memnew(ToolButton);
 	paint_button->set_shortcut(ED_SHORTCUT("tile_map_editor/paint_tile", TTR("Paint Tile"), KEY_P));
+#ifdef OSX_ENABLED
+	paint_button->set_tooltip(TTR("Shift+LMB: Line Draw\nShift+Command+LMB: Rectangle Paint"));
+#else
 	paint_button->set_tooltip(TTR("Shift+LMB: Line Draw\nShift+Ctrl+LMB: Rectangle Paint"));
+#endif
 	paint_button->connect("pressed", this, "_button_tool_select", make_binds(TOOL_NONE));
 	paint_button->set_toggle_mode(true);
 	toolbar->add_child(paint_button);


### PR DESCRIPTION
This also fixes the Move Points tooltip for the 2D polygon editor.

**Note:** I can't find the equivalent feature in the `master` branch, so opening against the `3.2` branch.

This closes #42702.