### PR TITLE
Clarified usage of TreeItem navigation functions.

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -223,14 +223,14 @@
 		<method name="get_next" qualifiers="const">
 			<return type="TreeItem" />
 			<description>
-				Returns the next TreeItem in the tree or a null object if there is none.
+				Returns the next sibling TreeItem in the tree or a null object if there is none.
 			</description>
 		</method>
 		<method name="get_next_visible">
 			<return type="TreeItem" />
 			<argument index="0" name="wrap" type="bool" default="false" />
 			<description>
-				Returns the next visible TreeItem in the tree or a null object if there is none.
+				Returns the next visible sibling TreeItem in the tree or a null object if there is none.
 				If [code]wrap[/code] is enabled, the method will wrap around to the first visible element in the tree when called on the last visible element, otherwise it returns [code]null[/code].
 			</description>
 		</method>
@@ -243,14 +243,14 @@
 		<method name="get_prev">
 			<return type="TreeItem" />
 			<description>
-				Returns the previous TreeItem in the tree or a null object if there is none.
+				Returns the previous sibling TreeItem in the tree or a null object if there is none.
 			</description>
 		</method>
 		<method name="get_prev_visible">
 			<return type="TreeItem" />
 			<argument index="0" name="wrap" type="bool" default="false" />
 			<description>
-				Returns the previous visible TreeItem in the tree or a null object if there is none.
+				Returns the previous visible sibling TreeItem in the tree or a null object if there is none.
 				If [code]wrap[/code] is enabled, the method will wrap around to the last visible element in the tree when called on the first visible element, otherwise it returns [code]null[/code].
 			</description>
 		</method>


### PR DESCRIPTION
Clarified usage of TreeItem navigation functions.
Added small example to get_children() description to help understand how to walk through the children of a TreeItem.
Clarified that get_next(), get_next_visible(), get_prev() and get_prev_visible() refer to the siblings of the current TreeItem rather than the next/previous child. It seems that is a common misconception based on the original wording that get_children() will return the first child and get_next() will return the next child TreeItem similar to how Directory.list_dir_begin() and Directory.get_next() works.
Addresses issue #42609 

*Bugsquad edit:*
- Fixes #42609.