### PR TITLE
Improve output in Debugger Errors tab for scripts

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -487,8 +487,11 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		error->set_text_align(0, TreeItem::ALIGN_LEFT);
 
 		String error_title;
-		// Include method name, when given, in error title.
-		if (!oe.source_func.empty()) {
+		if (oe.callstack.size() > 0) {
+			// If available, use the script's stack in the error title.
+			error_title = oe.callstack[oe.callstack.size() - 1].func + ": ";
+		} else if (!oe.source_func.empty()) {
+			// Otherwise try to use the C++ source function.
 			error_title += oe.source_func + ": ";
 		}
 		// If we have a (custom) error message, use it as title, and add a C++ Error
@@ -529,9 +532,6 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			cpp_source->set_metadata(0, source_meta);
 		}
 
-		error->set_tooltip(0, tooltip);
-		error->set_tooltip(1, tooltip);
-
 		// Format stack trace.
 		// stack_items_count is the number of elements to parse, with 3 items per frame
 		// of the stack trace (script, method, line).
@@ -548,9 +548,16 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 				stack_trace->set_text(0, "<" + TTR("Stack Trace") + ">");
 				stack_trace->set_text_align(0, TreeItem::ALIGN_LEFT);
 				error->set_metadata(0, meta);
+				tooltip += TTR("Stack Trace:") + "\n";
 			}
-			stack_trace->set_text(1, infos[i].file.get_file() + ":" + itos(infos[i].line) + " @ " + infos[i].func + "()");
+
+			String frame_txt = infos[i].file.get_file() + ":" + itos(infos[i].line) + " @ " + infos[i].func + "()";
+			tooltip += frame_txt + "\n";
+			stack_trace->set_text(1, frame_txt);
 		}
+
+		error->set_tooltip(0, tooltip);
+		error->set_tooltip(1, tooltip);
 
 		if (oe.warning) {
 			warning_count++;


### PR DESCRIPTION
Changes the Debugger Errors tab to use the method name provided by the scripting language in the error title and adds the full stack trace to the tooltip. This makes it easier to tell where the log came from at a glance, without expanding the entry.

Before:
![image](https://user-images.githubusercontent.com/4833621/95709398-e007d180-0c5e-11eb-8e50-e22016ebb760.png)

After:
![image](https://user-images.githubusercontent.com/4833621/95709102-388a9f00-0c5e-11eb-926d-214b252e161b.png)
