### PR TITLE
Fix code duplication in CSharpScript

### DIFF
--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -164,6 +164,7 @@ private:
 	// Do not use unless you know what you are doing
 	friend void GDMonoInternals::tie_managed_to_unmanaged(MonoObject *, Object *);
 	static Ref<CSharpScript> create_for_managed_type(GDMonoClass *p_class, GDMonoClass *p_native);
+	static void update_script_class_info(Ref<CSharpScript> p_script);
 	static void initialize_for_managed_type(Ref<CSharpScript> p_script, GDMonoClass *p_class, GDMonoClass *p_native);
 
 	MultiplayerAPI::RPCMode _member_get_rpc_mode(IMonoClassMember *p_member) const;


### PR DESCRIPTION
Removes code duplication between `CSharpScript::reload()` and `CSharpScript::initialize_for_managed_type()`.

Removes a redundant `CSharpScript::update_exports()` call in `CSharpLanguage::reload_assemblies()` as `CSharpScript::reload()` already calls it when appropriate.

Fixes missing update of RPC information in `CSharpScript::initialize_for_managed_type()`.

@neikeq has recommended these changes [on Discord](https://discordapp.com/channels/212250894228652034/389794884585914368/738749665599553616) after being [asked](https://discordapp.com/channels/212250894228652034/389794884585914368/737895644655779962) about the code duplication.