### PR TITLE
Free a SortShader and a ParticlesCopyShader

### DIFF
--- a/servers/rendering/rasterizer_rd/rasterizer_effects_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_effects_rd.cpp
@@ -1758,6 +1758,7 @@ RasterizerEffectsRD::~RasterizerEffectsRD() {
 	resolve.shader.version_free(resolve.shader_version);
 	roughness.shader.version_free(roughness.shader_version);
 	roughness_limiter.shader.version_free(roughness_limiter.shader_version);
+	sort.shader.version_free(sort.shader_version);
 	specular_merge.shader.version_free(specular_merge.shader_version);
 	ssao.blur_shader.version_free(ssao.blur_shader_version);
 	ssao.gather_shader.version_free(ssao.gather_shader_version);

--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.cpp
@@ -7884,7 +7884,9 @@ RasterizerStorageRD::~RasterizerStorageRD() {
 	for (int i = 0; i < DEFAULT_RD_BUFFER_MAX; i++) {
 		RD::get_singleton()->free(mesh_default_rd_buffers[i]);
 	}
+
 	giprobe_sdf_shader.version_free(giprobe_sdf_shader_version);
+	particles_shader.copy_shader.version_free(particles_shader.copy_shader_version);
 
 	RD::get_singleton()->free(default_rd_storage_buffer);
 


### PR DESCRIPTION
The errors regarding these shaders not being freed showed up when starting a project(tested in master build https://github.com/godotengine/godot/commit/bf37ab52b3ee4b14f235cfa1ea9e48c24c616bb3). Also, there's another shader `ParticlesShaderRD` in `rasterizer_effects_rd.cpp` which I couldn't fix in this commit as it didn't have `shader_version` so a simple `version_free` wouldn't work.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
