### PR TITLE
Ensure grid index is valid before trying to change value.

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -614,7 +614,7 @@ public:
 
 		const Ref<InputEventMouseButton> mb = p_ev;
 
-		if (mb.is_valid() && mb->get_button_index() == BUTTON_LEFT && mb->is_pressed()) {
+		if (mb.is_valid() && mb->get_button_index() == BUTTON_LEFT && mb->is_pressed() && hovered_index > 0) {
 			// Toggle the flag.
 			// We base our choice on the hovered flag, so that it always matches the hovered flag.
 			if (value & (1 << hovered_index)) {


### PR DESCRIPTION
Currently, when clicking outside of a `EditorPropertyLayersGrid` i.e. when the mousing is not hovering over a valid index box, it adds the value -1, which is converted to an `unsigned int` of 2147483648, which is the equivalent of checking the hidden 32<sup>nd</sup> bit.

This PR ensures the hover index is valid before trying to update the value.

Fixes #41281.
