### PR TITLE
Show android device name when connected only one device

### DIFF
--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -76,8 +76,10 @@ void EditorRunNative::_notification(int p_what) {
 				} else {
 					mb->get_popup()->clear();
 					mb->show();
-					mb->set_tooltip(eep->get_options_tooltip());
-					if (dc > 1) {
+					if (dc == 1) {
+						mb->set_tooltip(eep->get_option_tooltip(0));
+					} else {
+						mb->set_tooltip(eep->get_options_tooltip());
 						for (int i = 0; i < dc; i++) {
 							mb->get_popup()->add_icon_item(eep->get_option_icon(i), eep->get_option_label(i));
 							mb->get_popup()->set_item_tooltip(mb->get_popup()->get_item_count() - 1, eep->get_option_tooltip(i));


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fix #33845