### PR TITLE
Remove search results limit in FileSystem dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -815,7 +815,8 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 
 		if (searched_string.length() > 0) {
 			// Display the search results.
-			_search(EditorFileSystem::get_singleton()->get_filesystem(), &file_list, 128);
+			// Limit the number of results displayed to avoid an infinite loop.
+			_search(EditorFileSystem::get_singleton()->get_filesystem(), &file_list, 10000);
 		} else {
 			if (display_mode == DISPLAY_MODE_TREE_ONLY || always_show_folders) {
 				// Display folders in the list.


### PR DESCRIPTION
FileSystem search results limit is hardcoded to 128 (at least in split view), which is too low. I moved this to Editor Settings with saner default value. I know it's not accurate because of recursive nature of _search(), but it solved my problem with e.g. selecting multiple small images to reimport them as TextureAtlas.

![filesystem](https://user-images.githubusercontent.com/1554127/95768105-158bd980-0cb6-11eb-9ae1-f5ed8f6053f0.jpg)

[MultipleImages.zip](https://github.com/godotengine/godot/files/5366210/MultipleImages.zip)
