### PR TITLE
Don't try to compare freed object to nullptr

### DIFF
--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -437,6 +437,9 @@ void ShaderGlobalsEditor::_notification(int p_what) {
 			inspector->edit(interface);
 		}
 	}
+	if (p_what == NOTIFICATION_PREDELETE) {
+		inspector->edit(nullptr);
+	}
 }
 
 ShaderGlobalsEditor::ShaderGlobalsEditor() {
@@ -474,6 +477,5 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 }
 
 ShaderGlobalsEditor::~ShaderGlobalsEditor() {
-	inspector->edit(nullptr);
 	memdelete(interface);
 }


### PR DESCRIPTION
Looks that object at which inspector pointed was freed during program work, so comparing this value with nullptr is dangerous.

I can't find exactly place when `inspector` starts to point at invalid memory, but since this code is executed at the end of life editor I'm almost sure that this will not create a new regressions.

This will again allow to check for memory leaks in the editor using Address Sanitizer

Fixes #37987