### PR TITLE
Change per frame software skinning check to is_visible

### DIFF
--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -370,7 +370,11 @@ void MeshInstance::_initialize_skinning(bool p_force_reset) {
 
 void MeshInstance::_update_skinning() {
 	ERR_FAIL_COND(!_is_software_skinning_enabled());
+#if defined(TOOLS_ENABLED) && defined(DEBUG_ENABLED)
 	ERR_FAIL_COND(!is_visible_in_tree());
+#else
+	ERR_FAIL_COND(!is_visible());
+#endif
 
 	ERR_FAIL_COND(!software_skinning);
 	Ref<Mesh> software_skinning_mesh = software_skinning->mesh_instance;


### PR DESCRIPTION
My mistake I missed this before the PR got merged:

is_visible_in_tree() should probably be avoided being called per frame unless absolutely necessary, because it is a recursive function that traverses the scene tree. It should be used when deciding on rare occasions whether to switch on or off skeleton processing, but it is better to use the cheaper is_visible() check on the per frame update.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
