### PR TITLE
[Vulkan] Lighting like in gles2

### DIFF
--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -385,7 +385,7 @@ void Light2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset"), "set_texture_offset", "get_texture_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "texture_scale", PROPERTY_HINT_RANGE, "0.01,50,0.01"), "set_texture_scale", "get_texture_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color", PROPERTY_HINT_COLOR_NO_ALPHA), "set_color", "get_color");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "energy", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater"), "set_energy", "get_energy");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Add,Sub,Mix,Mask"), "set_mode", "get_mode");
 	ADD_GROUP("Range", "range_");

--- a/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.h
@@ -184,6 +184,7 @@ class RasterizerCanvasRD : public RasterizerCanvas {
 		Map<StringName, RID> default_texture_params;
 
 		bool uses_screen_texture;
+		int light_mode;
 
 		virtual void set_code(const String &p_Code);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture);


### PR DESCRIPTION
This PR makes lights look like they did in gles2 and contains some fixes for Light2D. Changes were tested on
Windows, NVIDIA
Debian, Intel UHD 630

closes #40426
closes #40425
closes #36112

**Bugfixes**:
- clear flag bits before render -> light no longer stuck in mix mode
- fix argument order so user light shaders no longer fail to compile

**Light like in gles2**
- items can now be unshaded and light only
- existing and missing light modes have been reworked to look as much as possible like they did in gles2. (see [comment](https://github.com/godotengine/godot/pull/42754#issuecomment-708537187) for differences)