### PR TITLE
Enhance editor file dialog

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -220,7 +220,6 @@ void EditorFileDialog::update_dir() {
 
 void EditorFileDialog::_dir_entered(String p_dir) {
 	dir_access->change_dir(p_dir);
-	file->set_text("");
 	invalidate();
 	update_dir();
 	_push_history();
@@ -239,6 +238,14 @@ void EditorFileDialog::_save_confirm_pressed() {
 
 void EditorFileDialog::_post_popup() {
 	ConfirmationDialog::_post_popup();
+
+	// Check if the current path doesn't exist and correct it.
+	String current = dir_access->get_current_dir();
+	while (!dir_access->dir_exists(current)) {
+		current = current.get_base_dir();
+	}
+	set_current_dir(current);
+
 	if (invalidated) {
 		update_file_list();
 		invalidated = false;
@@ -277,11 +284,17 @@ void EditorFileDialog::_post_popup() {
 			} else {
 				name = name.get_file() + "/";
 			}
-
-			recent->add_item(name, folder);
-			recent->set_item_metadata(recent->get_item_count() - 1, recentd[i]);
-			recent->set_item_icon_modulate(recent->get_item_count() - 1, folder_color);
+			bool exists = dir_access->dir_exists(recentd[i]);
+			if (!exists) {
+				// Remove invalid directory from the list of Recent directories.
+				recentd.remove(i--);
+			} else {
+				recent->add_item(name, folder);
+				recent->set_item_metadata(recent->get_item_count() - 1, recentd[i]);
+				recent->set_item_icon_modulate(recent->get_item_count() - 1, folder_color);
+			}
 		}
+		EditorSettings::get_singleton()->set_recent_dirs(recentd);
 
 		local_history.clear();
 		local_history_pos = -1;
@@ -432,9 +445,12 @@ void EditorFileDialog::_action_pressed() {
 			}
 		}
 
+		// Add first extension of filter if no valid extension is found.
 		if (!valid) {
-			exterr->popup_centered(Size2(250, 80) * EDSCALE);
-			return;
+			int idx = filter->get_selected();
+			String flt = filters[idx].get_slice(";", 0);
+			String ext = flt.get_slice(",", 0).strip_edges().get_extension();
+			f += "." + ext;
 		}
 
 		if (dir_access->file_exists(f) && !disable_overwrite_warning) {
@@ -1669,10 +1685,6 @@ EditorFileDialog::EditorFileDialog() {
 	mkdirerr = memnew(AcceptDialog);
 	mkdirerr->set_text(TTR("Could not create folder."));
 	add_child(mkdirerr);
-
-	exterr = memnew(AcceptDialog);
-	exterr->set_text(TTR("Must use a valid extension."));
-	add_child(exterr);
 
 	update_filters();
 	update_dir();

--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -110,7 +110,6 @@ private:
 	LineEdit *file;
 	OptionButton *filter;
 	AcceptDialog *mkdirerr;
-	AcceptDialog *exterr;
 	DirAccess *dir_access;
 	ConfirmationDialog *confirm_save;
 	DependencyRemoveDialog *remove_dialog;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2262,7 +2262,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			int scene_idx = (p_option == FILE_SAVE_SCENE) ? -1 : tab_closing;
 
 			Node *scene = editor_data.get_edited_scene_root(scene_idx);
-			if (scene && scene->get_filename() != "") {
+			if (scene && scene->get_filename() != "" && FileAccess::exists(scene->get_filename())) {
 				if (scene_idx != editor_data.get_edited_scene()) {
 					_save_scene_with_preview(scene->get_filename(), scene_idx);
 				} else {
@@ -2307,11 +2307,12 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			}
 
 			if (scene->get_filename() != "") {
-				file->set_current_path(scene->get_filename());
+				String path = scene->get_filename();
+				file->set_current_path(path);
 				if (extensions.size()) {
-					String ext = scene->get_filename().get_extension().to_lower();
+					String ext = path.get_extension().to_lower();
 					if (extensions.find(ext) == nullptr) {
-						file->set_current_path(scene->get_filename().replacen("." + ext, "." + extensions.front()->get()));
+						file->set_current_path(path.replacen("." + ext, "." + extensions.front()->get()));
 					}
 				}
 			} else {


### PR DESCRIPTION
1. show valid directory path when opening editor file dialog
2. keep file name when changing path by entering path
3. add first extension in filter automatically if not given
4. remove directory in recent list if it's not valid anymore

Fix #22509

![editor_file_dialog](https://user-images.githubusercontent.com/8281454/95901293-16179380-0dce-11eb-8660-8aaf5377e813.gif)


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
