### PR TITLE
Refactored binding system for core types

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -330,9 +330,8 @@ struct _ArrayVariantSort {
 	}
 };
 
-Array &Array::sort() {
+void Array::sort() {
 	_p->array.sort_custom<_ArrayVariantSort>();
-	return *this;
 }
 
 struct _ArrayVariantSortCustom {
@@ -349,14 +348,13 @@ struct _ArrayVariantSortCustom {
 		return res;
 	}
 };
-Array &Array::sort_custom(Object *p_obj, const StringName &p_function) {
-	ERR_FAIL_NULL_V(p_obj, *this);
+void Array::sort_custom(Object *p_obj, const StringName &p_function) {
+	ERR_FAIL_NULL(p_obj);
 
 	SortArray<Variant, _ArrayVariantSortCustom, true> avs;
 	avs.compare.obj = p_obj;
 	avs.compare.func = p_function;
 	avs.sort(_p->array.ptrw(), _p->array.size());
-	return *this;
 }
 
 void Array::shuffle() {
@@ -415,9 +413,8 @@ int Array::bsearch_custom(const Variant &p_value, Object *p_obj, const StringNam
 	return bisect(_p->array, p_value, p_before, less);
 }
 
-Array &Array::invert() {
+void Array::invert() {
 	_p->array.invert();
-	return *this;
 }
 
 void Array::push_front(const Variant &p_value) {

--- a/core/array.h
+++ b/core/array.h
@@ -75,12 +75,12 @@ public:
 	Variant front() const;
 	Variant back() const;
 
-	Array &sort();
-	Array &sort_custom(Object *p_obj, const StringName &p_function);
+	void sort();
+	void sort_custom(Object *p_obj, const StringName &p_function);
 	void shuffle();
 	int bsearch(const Variant &p_value, bool p_before = true);
 	int bsearch_custom(const Variant &p_value, Object *p_obj, const StringName &p_function, bool p_before = true);
-	Array &invert();
+	void invert();
 
 	int find(const Variant &p_value, int p_from = 0) const;
 	int rfind(const Variant &p_value, int p_from = -1) const;

--- a/core/callable_method_pointer.h
+++ b/core/callable_method_pointer.h
@@ -36,6 +36,7 @@
 #include "core/object.h"
 #include "core/os/copymem.h"
 #include "core/simple_type.h"
+#include "core/variant_internal.h"
 
 class CallableCustomMethodPointerBase : public CallableCustom {
 	uint32_t *comp_ptr;
@@ -115,7 +116,7 @@ struct VariantCasterAndValidate<const T &> {
 
 #endif // DEBUG_METHODS_ENABLED
 
-// GCC 8 raises "parameter 'p_args' set but not used" here, probably using a
+// GCC raises "parameter 'p_args' set but not used" here, probably using a
 // template version that does not have arguments and thus sees it unused, but
 // obviously the template can be used for functions with and without them, and
 // the optimizer will get rid of it anyway.
@@ -135,9 +136,49 @@ void call_with_variant_args_helper(T *p_instance, void (T::*p_method)(P...), con
 #endif
 }
 
-#if defined(DEBUG_METHODS_ENABLED) && defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+#ifdef PTRCALL_ENABLED
+
+template <class T, class... P, size_t... Is>
+void call_with_ptr_args_helper(T *p_instance, void (T::*p_method)(P...), const void **p_args, IndexSequence<Is...>) {
+	(p_instance->*p_method)(PtrToArg<P>::convert(p_args[Is])...);
+}
+
+template <class T, class R, class... P, size_t... Is>
+void call_with_ptr_args_ret_helper(T *p_instance, R (T::*p_method)(P...), const void **p_args, void *r_ret, IndexSequence<Is...>) {
+	PtrToArg<R>::encode((p_instance->*p_method)(PtrToArg<P>::convert(p_args[Is])...), r_ret);
+}
+
+template <class T, class R, class... P, size_t... Is>
+void call_with_ptr_args_retc_helper(T *p_instance, R (T::*p_method)(P...) const, const void **p_args, void *r_ret, IndexSequence<Is...>) {
+	PtrToArg<R>::encode((p_instance->*p_method)(PtrToArg<P>::convert(p_args[Is])...), r_ret);
+}
+
+template <class T, class R, class... P, size_t... Is>
+void call_with_ptr_args_static_retc_helper(T *p_instance, R (*p_method)(T *, P...), const void **p_args, void *r_ret, IndexSequence<Is...>) {
+	PtrToArg<R>::encode(p_method(p_instance, PtrToArg<P>::convert(p_args[Is])...), r_ret);
+}
+
+#endif // PTRCALL_ENABLED
+
+template <class T, class... P, size_t... Is>
+void call_with_validated_variant_args_helper(T *p_instance, void (T::*p_method)(P...), const Variant **p_args, IndexSequence<Is...>) {
+	(p_instance->*p_method)((VariantInternalAccessor<typename GetSimpleTypeT<P>::type_t>::get(p_args[Is]))...);
+}
+
+template <class T, class R, class... P, size_t... Is>
+void call_with_validated_variant_args_ret_helper(T *p_instance, R (T::*p_method)(P...), const Variant **p_args, Variant *r_ret, IndexSequence<Is...>) {
+	VariantInternalAccessor<typename GetSimpleTypeT<R>::type_t>::set(r_ret, (p_instance->*p_method)((VariantInternalAccessor<typename GetSimpleTypeT<P>::type_t>::get(p_args[Is]))...));
+}
+
+template <class T, class R, class... P, size_t... Is>
+void call_with_validated_variant_args_retc_helper(T *p_instance, R (T::*p_method)(P...) const, const Variant **p_args, Variant *r_ret, IndexSequence<Is...>) {
+	VariantInternalAccessor<typename GetSimpleTypeT<R>::type_t>::set(r_ret, (p_instance->*p_method)((VariantInternalAccessor<typename GetSimpleTypeT<P>::type_t>::get(p_args[Is]))...));
+}
+
+template <class T, class R, class... P, size_t... Is>
+void call_with_validated_variant_args_static_retc_helper(T *p_instance, R (*p_method)(T *, P...), const Variant **p_args, Variant *r_ret, IndexSequence<Is...>) {
+	VariantInternalAccessor<typename GetSimpleTypeT<R>::type_t>::set(r_ret, p_method(p_instance, (VariantInternalAccessor<typename GetSimpleTypeT<P>::type_t>::get(p_args[Is]))...));
+}
 
 template <class T, class... P>
 void call_with_variant_args(T *p_instance, void (T::*p_method)(P...), const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
@@ -156,6 +197,91 @@ void call_with_variant_args(T *p_instance, void (T::*p_method)(P...), const Vari
 #endif
 	call_with_variant_args_helper<T, P...>(p_instance, p_method, p_args, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
+
+#ifdef PTRCALL_ENABLED
+
+template <class T, class... P>
+void call_with_ptr_args(T *p_instance, void (T::*p_method)(P...), const void **p_args) {
+	call_with_ptr_args_helper<T, P...>(p_instance, p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <class T, class R, class... P>
+void call_with_ptr_args_ret(T *p_instance, R (T::*p_method)(P...), const void **p_args, void *r_ret) {
+	call_with_ptr_args_ret_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <class T, class R, class... P>
+void call_with_ptr_args_retc(T *p_instance, R (T::*p_method)(P...) const, const void **p_args, void *r_ret) {
+	call_with_ptr_args_retc_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <class T, class R, class... P>
+void call_with_ptr_args_static_retc(T *p_instance, R (*p_method)(T *, P...), const void **p_args, void *r_ret) {
+	call_with_ptr_args_static_retc_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
+}
+
+#endif // PTRCALL_ENABLED
+
+template <class T, class... P>
+void call_with_validated_variant_args(Variant *base, void (T::*p_method)(P...), const Variant **p_args) {
+	call_with_validated_variant_args_helper<T, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <class T, class R, class... P>
+void call_with_validated_variant_args_ret(Variant *base, R (T::*p_method)(P...), const Variant **p_args, Variant *r_ret) {
+	call_with_validated_variant_args_ret_helper<T, R, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <class T, class R, class... P>
+void call_with_validated_variant_args_retc(Variant *base, R (T::*p_method)(P...) const, const Variant **p_args, Variant *r_ret) {
+	call_with_validated_variant_args_retc_helper<T, R, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <class T, class R, class... P>
+void call_with_validated_variant_args_static_retc(Variant *base, R (*p_method)(T *, P...), const Variant **p_args, Variant *r_ret) {
+	call_with_validated_variant_args_static_retc_helper<T, R, P...>(VariantGetInternalPtr<T>::get_ptr(base), p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
+}
+
+#ifdef DEBUG_METHODS_ENABLED
+
+template <class Q>
+void call_get_argument_type_helper(int p_arg, int &index, Variant::Type &type) {
+	if (p_arg == index) {
+		type = GetTypeInfo<Q>::VARIANT_TYPE;
+	}
+	index++;
+}
+
+// GCC's warnings checker really doesn't like variadic voodoo.
+// It sees `index` unused below in some branches, so it raises a warning.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
+
+template <class... P>
+Variant::Type call_get_argument_type(int p_arg) {
+	Variant::Type type = Variant::NIL;
+	int index = 0;
+	// I think rocket science is simpler than modern C++.
+	using expand_type = int[];
+	expand_type a{ 0, (call_get_argument_type_helper<P>(p_arg, index, type), 0)... };
+	(void)a; // Suppress (valid, but unavoidable) -Wunused-variable warning.
+	return type;
+}
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#else
+
+template <class... P>
+Variant::Type call_get_argument_type(int p_arg) {
+	return Variant::NIL;
+}
+
+#endif // DEBUG_METHODS_ENABLED
 
 template <class T, class... P>
 class CallableCustomMethodPointer : public CallableCustomMethodPointerBase {
@@ -212,15 +338,6 @@ Callable create_custom_callable_function_pointer(T *p_instance,
 
 // VERSION WITH RETURN
 
-// GCC 8 raises "parameter 'p_args' set but not used" here, probably using a
-// template version that does not have arguments and thus sees it unused, but
-// obviously the template can be used for functions with and without them, and
-// the optimizer will get rid of it anyway.
-#if defined(DEBUG_METHODS_ENABLED) && defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-but-set-parameter"
-#endif
-
 template <class T, class R, class... P, size_t... Is>
 void call_with_variant_args_ret_helper(T *p_instance, R (T::*p_method)(P...), const Variant **p_args, Variant &r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
@@ -228,13 +345,9 @@ void call_with_variant_args_ret_helper(T *p_instance, R (T::*p_method)(P...), co
 #ifdef DEBUG_METHODS_ENABLED
 	r_ret = (p_instance->*p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
 #else
-	(p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...);
+	r_ret = (p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...);
 #endif
 }
-
-#if defined(DEBUG_METHODS_ENABLED) && defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 template <class T, class R, class... P>
 void call_with_variant_args_ret(T *p_instance, R (T::*p_method)(P...), const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
@@ -308,10 +421,110 @@ Callable create_custom_callable_function_pointer(T *p_instance,
 	return Callable(ccmp);
 }
 
+// CONST VERSION WITH RETURN
+
+template <class T, class R, class... P, size_t... Is>
+void call_with_variant_args_retc_helper(T *p_instance, R (T::*p_method)(P...) const, const Variant **p_args, Variant &r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
+	r_error.error = Callable::CallError::CALL_OK;
+
+#ifdef DEBUG_METHODS_ENABLED
+	r_ret = (p_instance->*p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
+#else
+	r_ret = (p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...);
+#endif
+}
+
+template <class T, class R, class... P>
+void call_with_variant_args_retc(T *p_instance, R (T::*p_method)(P...) const, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
+#ifdef DEBUG_METHODS_ENABLED
+	if ((size_t)p_argcount > sizeof...(P)) {
+		r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
+		r_error.argument = sizeof...(P);
+		return;
+	}
+
+	if ((size_t)p_argcount < sizeof...(P)) {
+		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
+		r_error.argument = sizeof...(P);
+		return;
+	}
+#endif
+	call_with_variant_args_retc_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
+}
+
+template <class T, class R, class... P>
+class CallableCustomMethodPointerRetC : public CallableCustomMethodPointerBase {
+	struct Data {
+		T *instance;
+#ifdef DEBUG_ENABLED
+		uint64_t object_id;
+#endif
+		R(T::*method)
+		(P...) const;
+	} data;
+
+public:
+	virtual ObjectID get_object() const {
+#ifdef DEBUG_ENABLED
+		if (ObjectDB::get_instance(ObjectID(data.object_id)) == nullptr) {
+			return ObjectID();
+		}
+#endif
+		return data.instance->get_instance_id();
+	}
+
+	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
+#ifdef DEBUG_ENABLED
+		ERR_FAIL_COND_MSG(ObjectDB::get_instance(ObjectID(data.object_id)) == nullptr, "Invalid Object id '" + uitos(data.object_id) + "', can't call method.");
+#endif
+		call_with_variant_args_retc(data.instance, data.method, p_arguments, p_argcount, r_return_value, r_call_error);
+	}
+
+	CallableCustomMethodPointerRetC(T *p_instance, R (T::*p_method)(P...) const) {
+		zeromem(&data, sizeof(Data)); // Clear beforehand, may have padding bytes.
+		data.instance = p_instance;
+#ifdef DEBUG_ENABLED
+		data.object_id = p_instance->get_instance_id();
+#endif
+		data.method = p_method;
+		_setup((uint32_t *)&data, sizeof(Data));
+	}
+};
+
+template <class T, class R, class... P>
+Callable create_custom_callable_function_pointer(T *p_instance,
+#ifdef DEBUG_METHODS_ENABLED
+		const char *p_func_text,
+#endif
+		R (T::*p_method)(P...) const) {
+
+	typedef CallableCustomMethodPointerRetC<T, R, P...> CCMP; // Messes with memnew otherwise.
+	CCMP *ccmp = memnew(CCMP(p_instance, p_method));
+#ifdef DEBUG_METHODS_ENABLED
+	ccmp->set_text(p_func_text + 1); // Try to get rid of the ampersand.
+#endif
+	return Callable(ccmp);
+}
+
 #ifdef DEBUG_METHODS_ENABLED
 #define callable_mp(I, M) create_custom_callable_function_pointer(I, #M, M)
 #else
 #define callable_mp(I, M) create_custom_callable_function_pointer(I, M)
+#endif
+
+template <class T, class R, class... P, size_t... Is>
+void call_with_variant_args_retc_static_helper(T *p_instance, R (*p_method)(T *, P...), const Variant **p_args, Variant &r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
+	r_error.error = Callable::CallError::CALL_OK;
+
+#ifdef DEBUG_METHODS_ENABLED
+	r_ret = (p_method)(p_instance, VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
+#else
+	r_ret = (p_method)(p_instance, VariantCaster<P>::cast(*p_args[Is])...);
+#endif
+}
+
+#if defined(DEBUG_METHODS_ENABLED) && defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
 #endif
 
 #endif // CALLABLE_METHOD_POINTER_H

--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -31,6 +31,7 @@
 #include "aabb.h"
 
 #include "core/print_string.h"
+#include "core/variant.h"
 
 real_t AABB::get_area() const {
 	return size.x * size.y * size.z;
@@ -373,6 +374,21 @@ void AABB::get_edge(int p_edge, Vector3 &r_from, Vector3 &r_to) const {
 
 		} break;
 	}
+}
+
+Variant AABB::intersects_segment_bind(const Vector3 &p_from, const Vector3 &p_to) const {
+	Vector3 inters;
+	if (intersects_segment(p_from, p_to, &inters)) {
+		return inters;
+	}
+	return Variant();
+}
+Variant AABB::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const {
+	Vector3 inters;
+	if (intersects_ray(p_from, p_dir, &inters)) {
+		return inters;
+	}
+	return Variant();
 }
 
 AABB::operator String() const {

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -39,6 +39,7 @@
  * AABB / AABB (Axis Aligned Bounding Box)
  * This is implemented by a point (position) and the box size
  */
+class Variant;
 
 class AABB {
 public:
@@ -102,6 +103,9 @@ public:
 	_FORCE_INLINE_ AABB abs() const {
 		return AABB(Vector3(position.x + MIN(size.x, 0), position.y + MIN(size.y, 0), position.z + MIN(size.z, 0)), size.abs());
 	}
+
+	Variant intersects_segment_bind(const Vector3 &p_from, const Vector3 &p_to) const;
+	Variant intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const;
 
 	operator String() const;
 

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -31,6 +31,7 @@
 #include "plane.h"
 
 #include "core/math/math_funcs.h"
+#include "core/variant.h"
 
 void Plane::set_normal(const Vector3 &p_normal) {
 	normal = p_normal;
@@ -136,6 +137,31 @@ bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vec
 	*p_intersection = p_begin + segment * dist;
 
 	return true;
+}
+
+Variant Plane::intersect_3_bind(const Plane &p_plane1, const Plane &p_plane2) const {
+	Vector3 inters;
+	if (intersect_3(p_plane1, p_plane2, &inters)) {
+		return inters;
+	} else {
+		return Variant();
+	}
+}
+Variant Plane::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const {
+	Vector3 inters;
+	if (intersects_ray(p_from, p_dir, &inters)) {
+		return inters;
+	} else {
+		return Variant();
+	}
+}
+Variant Plane::intersects_segment_bind(const Vector3 &p_begin, const Vector3 &p_end) const {
+	Vector3 inters;
+	if (intersects_segment(p_begin, p_end, &inters)) {
+		return inters;
+	} else {
+		return Variant();
+	}
 }
 
 /* misc */

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -33,6 +33,8 @@
 
 #include "core/math/vector3.h"
 
+class Variant;
+
 class Plane {
 public:
 	Vector3 normal;
@@ -58,6 +60,11 @@ public:
 	bool intersect_3(const Plane &p_plane1, const Plane &p_plane2, Vector3 *r_result = nullptr) const;
 	bool intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *p_intersection) const;
 	bool intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 *p_intersection) const;
+
+	// For Variant bindings.
+	Variant intersect_3_bind(const Plane &p_plane1, const Plane &p_plane2) const;
+	Variant intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const;
+	Variant intersects_segment_bind(const Vector3 &p_begin, const Vector3 &p_end) const;
 
 	_FORCE_INLINE_ Vector3 project(const Vector3 &p_point) const {
 		return p_point - normal * distance_to(p_point);

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -197,6 +197,10 @@ struct Rect2 {
 		return g;
 	}
 
+	inline Rect2 grow_margin_bind(uint32_t p_margin, real_t p_amount) const {
+		return grow_margin(Margin(p_margin), p_amount);
+	}
+
 	inline Rect2 grow_individual(real_t p_left, real_t p_top, real_t p_right, real_t p_bottom) const {
 		Rect2 g = *this;
 		g.position.x -= p_left;
@@ -361,6 +365,10 @@ struct Rect2i {
 				(MARGIN_RIGHT == p_margin) ? p_amount : 0,
 				(MARGIN_BOTTOM == p_margin) ? p_amount : 0);
 		return g;
+	}
+
+	inline Rect2i grow_margin_bind(uint32_t p_margin, int p_amount) const {
+		return grow_margin(Margin(p_margin), p_amount);
 	}
 
 	inline Rect2i grow_individual(int p_left, int p_top, int p_right, int p_bottom) const {

--- a/core/simple_type.h
+++ b/core/simple_type.h
@@ -48,4 +48,9 @@ struct GetSimpleTypeT<T const> {
 	typedef T type_t;
 };
 
+template <class T>
+struct GetSimpleTypeT<T const &> {
+	typedef T type_t;
+};
+
 #endif // SIMPLE_TYPE_H

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -4732,6 +4732,69 @@ String String::unquote() const {
 	return substr(1, length() - 2);
 }
 
+Vector<uint8_t> String::to_ascii_buffer() const {
+	const String *s = this;
+	if (s->empty()) {
+		return Vector<uint8_t>();
+	}
+	CharString charstr = s->ascii();
+
+	Vector<uint8_t> retval;
+	size_t len = charstr.length();
+	retval.resize(len);
+	uint8_t *w = retval.ptrw();
+	copymem(w, charstr.ptr(), len);
+
+	return retval;
+}
+
+Vector<uint8_t> String::to_utf8_buffer() const {
+	const String *s = this;
+	if (s->empty()) {
+		return Vector<uint8_t>();
+	}
+	CharString charstr = s->utf8();
+
+	Vector<uint8_t> retval;
+	size_t len = charstr.length();
+	retval.resize(len);
+	uint8_t *w = retval.ptrw();
+	copymem(w, charstr.ptr(), len);
+
+	return retval;
+}
+
+Vector<uint8_t> String::to_utf16_buffer() const {
+	const String *s = this;
+	if (s->empty()) {
+		return Vector<uint8_t>();
+	}
+	Char16String charstr = s->utf16();
+
+	Vector<uint8_t> retval;
+	size_t len = charstr.length() * 2;
+	retval.resize(len);
+	uint8_t *w = retval.ptrw();
+	copymem(w, (const void *)charstr.ptr(), len);
+
+	return retval;
+}
+
+Vector<uint8_t> String::to_utf32_buffer() const {
+	const String *s = this;
+	if (s->empty()) {
+		return Vector<uint8_t>();
+	}
+
+	Vector<uint8_t> retval;
+	size_t len = s->length() * 4;
+	retval.resize(len);
+	uint8_t *w = retval.ptrw();
+	copymem(w, (const void *)s->ptr(), len);
+
+	return retval;
+}
+
 #ifdef TOOLS_ENABLED
 String TTR(const String &p_text, const String &p_context) {
 	if (TranslationServer::get_singleton()) {

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -440,6 +440,11 @@ public:
 		return *this;
 	}
 
+	Vector<uint8_t> to_ascii_buffer() const;
+	Vector<uint8_t> to_utf8_buffer() const;
+	Vector<uint8_t> to_utf16_buffer() const;
+	Vector<uint8_t> to_utf32_buffer() const;
+
 	String(const char *p_str);
 	String(const wchar_t *p_str);
 	String(const char32_t *p_str);

--- a/core/variant.h
+++ b/core/variant.h
@@ -414,6 +414,34 @@ public:
 	static void blend(const Variant &a, const Variant &b, float c, Variant &r_dst);
 	static void interpolate(const Variant &a, const Variant &b, float c, Variant &r_dst);
 
+	class InternalMethod {
+	public:
+		enum Flags {
+			FLAG_IS_CONST = 1,
+			FLAG_RETURNS_VARIANT = 2,
+			FLAG_NO_PTRCALL = 4,
+			FLAG_VARARGS = 8
+		};
+
+		virtual int get_argument_count() const = 0;
+		virtual Type get_argument_type(int p_arg) const = 0;
+		virtual Type get_return_type() const = 0;
+		virtual uint32_t get_flags() const = 0;
+
+#ifdef DEBUG_ENABLED
+		virtual String get_argument_name(int p_arg) const = 0;
+#endif
+		virtual Vector<Variant> get_default_arguments() const = 0;
+		virtual void call(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) = 0;
+		virtual void validated_call(Variant *base, const Variant **p_args, Variant *r_ret) = 0;
+#ifdef PTRCALL_ENABLED
+		virtual void ptrcall(void *p_base, const void **p_args, void *r_ret) = 0;
+#endif
+		virtual ~InternalMethod() {}
+	};
+
+	static InternalMethod *get_internal_method(Type p_type, const StringName &p_method_name);
+
 	void call_ptr(const StringName &p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error);
 	Variant call(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	Variant call(const StringName &p_method, const Variant &p_arg1 = Variant(), const Variant &p_arg2 = Variant(), const Variant &p_arg3 = Variant(), const Variant &p_arg4 = Variant(), const Variant &p_arg5 = Variant());

--- a/core/variant_internal.h
+++ b/core/variant_internal.h
@@ -113,6 +113,540 @@ public:
 	_FORCE_INLINE_ static const PackedVector3Array *get_vector3_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector3> *>(v->_data.packed_array)->array; }
 	_FORCE_INLINE_ static PackedColorArray *get_color_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Color> *>(v->_data.packed_array)->array; }
 	_FORCE_INLINE_ static const PackedColorArray *get_color_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Color> *>(v->_data.packed_array)->array; }
+
+	_FORCE_INLINE_ static Object **get_object(Variant *v) { return (Object **)&v->_get_obj().obj; }
+	_FORCE_INLINE_ static const Object **get_object(const Variant *v) { return (const Object **)&v->_get_obj().obj; }
+};
+
+template <class T>
+struct VariantGetInternalPtr {
+};
+
+template <>
+struct VariantGetInternalPtr<bool> {
+	static bool *get_ptr(Variant *v) { return VariantInternal::get_bool(v); }
+	static const bool *get_ptr(const Variant *v) { return VariantInternal::get_bool(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<int8_t> {
+	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
+	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<uint8_t> {
+	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
+	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<int16_t> {
+	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
+	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<uint16_t> {
+	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
+	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<int32_t> {
+	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
+	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<uint32_t> {
+	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
+	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<int64_t> {
+	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
+	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<uint64_t> {
+	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
+	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<char32_t> {
+	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
+	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<ObjectID> {
+	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
+	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Error> {
+	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
+	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<float> {
+	static double *get_ptr(Variant *v) { return VariantInternal::get_float(v); }
+	static const double *get_ptr(const Variant *v) { return VariantInternal::get_float(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<double> {
+	static double *get_ptr(Variant *v) { return VariantInternal::get_float(v); }
+	static const double *get_ptr(const Variant *v) { return VariantInternal::get_float(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<String> {
+	static String *get_ptr(Variant *v) { return VariantInternal::get_string(v); }
+	static const String *get_ptr(const Variant *v) { return VariantInternal::get_string(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Vector2> {
+	static Vector2 *get_ptr(Variant *v) { return VariantInternal::get_vector2(v); }
+	static const Vector2 *get_ptr(const Variant *v) { return VariantInternal::get_vector2(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Vector2i> {
+	static Vector2i *get_ptr(Variant *v) { return VariantInternal::get_vector2i(v); }
+	static const Vector2i *get_ptr(const Variant *v) { return VariantInternal::get_vector2i(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Rect2> {
+	static Rect2 *get_ptr(Variant *v) { return VariantInternal::get_rect2(v); }
+	static const Rect2 *get_ptr(const Variant *v) { return VariantInternal::get_rect2(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Rect2i> {
+	static Rect2i *get_ptr(Variant *v) { return VariantInternal::get_rect2i(v); }
+	static const Rect2i *get_ptr(const Variant *v) { return VariantInternal::get_rect2i(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Vector3> {
+	static Vector3 *get_ptr(Variant *v) { return VariantInternal::get_vector3(v); }
+	static const Vector3 *get_ptr(const Variant *v) { return VariantInternal::get_vector3(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Vector3i> {
+	static Vector3i *get_ptr(Variant *v) { return VariantInternal::get_vector3i(v); }
+	static const Vector3i *get_ptr(const Variant *v) { return VariantInternal::get_vector3i(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Transform2D> {
+	static Transform2D *get_ptr(Variant *v) { return VariantInternal::get_transform2d(v); }
+	static const Transform2D *get_ptr(const Variant *v) { return VariantInternal::get_transform2d(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Transform> {
+	static Transform *get_ptr(Variant *v) { return VariantInternal::get_transform(v); }
+	static const Transform *get_ptr(const Variant *v) { return VariantInternal::get_transform(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Plane> {
+	static Plane *get_ptr(Variant *v) { return VariantInternal::get_plane(v); }
+	static const Plane *get_ptr(const Variant *v) { return VariantInternal::get_plane(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Quat> {
+	static Quat *get_ptr(Variant *v) { return VariantInternal::get_quat(v); }
+	static const Quat *get_ptr(const Variant *v) { return VariantInternal::get_quat(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<::AABB> {
+	static ::AABB *get_ptr(Variant *v) { return VariantInternal::get_aabb(v); }
+	static const ::AABB *get_ptr(const Variant *v) { return VariantInternal::get_aabb(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Basis> {
+	static Basis *get_ptr(Variant *v) { return VariantInternal::get_basis(v); }
+	static const Basis *get_ptr(const Variant *v) { return VariantInternal::get_basis(v); }
+};
+
+//
+
+template <>
+struct VariantGetInternalPtr<Color> {
+	static Color *get_ptr(Variant *v) { return VariantInternal::get_color(v); }
+	static const Color *get_ptr(const Variant *v) { return VariantInternal::get_color(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<StringName> {
+	static StringName *get_ptr(Variant *v) { return VariantInternal::get_string_name(v); }
+	static const StringName *get_ptr(const Variant *v) { return VariantInternal::get_string_name(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<NodePath> {
+	static NodePath *get_ptr(Variant *v) { return VariantInternal::get_node_path(v); }
+	static const NodePath *get_ptr(const Variant *v) { return VariantInternal::get_node_path(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<RID> {
+	static RID *get_ptr(Variant *v) { return VariantInternal::get_rid(v); }
+	static const RID *get_ptr(const Variant *v) { return VariantInternal::get_rid(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Callable> {
+	static Callable *get_ptr(Variant *v) { return VariantInternal::get_callable(v); }
+	static const Callable *get_ptr(const Variant *v) { return VariantInternal::get_callable(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Signal> {
+	static Signal *get_ptr(Variant *v) { return VariantInternal::get_signal(v); }
+	static const Signal *get_ptr(const Variant *v) { return VariantInternal::get_signal(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Dictionary> {
+	static Dictionary *get_ptr(Variant *v) { return VariantInternal::get_dictionary(v); }
+	static const Dictionary *get_ptr(const Variant *v) { return VariantInternal::get_dictionary(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<Array> {
+	static Array *get_ptr(Variant *v) { return VariantInternal::get_array(v); }
+	static const Array *get_ptr(const Variant *v) { return VariantInternal::get_array(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<PackedByteArray> {
+	static PackedByteArray *get_ptr(Variant *v) { return VariantInternal::get_byte_array(v); }
+	static const PackedByteArray *get_ptr(const Variant *v) { return VariantInternal::get_byte_array(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<PackedInt32Array> {
+	static PackedInt32Array *get_ptr(Variant *v) { return VariantInternal::get_int32_array(v); }
+	static const PackedInt32Array *get_ptr(const Variant *v) { return VariantInternal::get_int32_array(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<PackedInt64Array> {
+	static PackedInt64Array *get_ptr(Variant *v) { return VariantInternal::get_int64_array(v); }
+	static const PackedInt64Array *get_ptr(const Variant *v) { return VariantInternal::get_int64_array(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<PackedFloat32Array> {
+	static PackedFloat32Array *get_ptr(Variant *v) { return VariantInternal::get_float32_array(v); }
+	static const PackedFloat32Array *get_ptr(const Variant *v) { return VariantInternal::get_float32_array(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<PackedFloat64Array> {
+	static PackedFloat64Array *get_ptr(Variant *v) { return VariantInternal::get_float64_array(v); }
+	static const PackedFloat64Array *get_ptr(const Variant *v) { return VariantInternal::get_float64_array(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<PackedStringArray> {
+	static PackedStringArray *get_ptr(Variant *v) { return VariantInternal::get_string_array(v); }
+	static const PackedStringArray *get_ptr(const Variant *v) { return VariantInternal::get_string_array(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<PackedVector2Array> {
+	static PackedVector2Array *get_ptr(Variant *v) { return VariantInternal::get_vector2_array(v); }
+	static const PackedVector2Array *get_ptr(const Variant *v) { return VariantInternal::get_vector2_array(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<PackedVector3Array> {
+	static PackedVector3Array *get_ptr(Variant *v) { return VariantInternal::get_vector3_array(v); }
+	static const PackedVector3Array *get_ptr(const Variant *v) { return VariantInternal::get_vector3_array(v); }
+};
+
+template <>
+struct VariantGetInternalPtr<PackedColorArray> {
+	static PackedColorArray *get_ptr(Variant *v) { return VariantInternal::get_color_array(v); }
+	static const PackedColorArray *get_ptr(const Variant *v) { return VariantInternal::get_color_array(v); }
+};
+
+template <class T>
+struct VariantInternalAccessor {
+};
+
+template <>
+struct VariantInternalAccessor<bool> {
+	static _FORCE_INLINE_ bool get(const Variant *v) { return *VariantInternal::get_bool(v); }
+	static _FORCE_INLINE_ void set(Variant *v, bool p_value) { *VariantInternal::get_bool(v) = p_value; }
+};
+
+#define VARIANT_ACCESSOR_NUMBER(m_type)                                                                        \
+	template <>                                                                                                \
+	struct VariantInternalAccessor<m_type> {                                                                   \
+		static _FORCE_INLINE_ m_type get(const Variant *v) { return (m_type)*VariantInternal::get_int(v); }    \
+		static _FORCE_INLINE_ void set(Variant *v, m_type p_value) { *VariantInternal::get_int(v) = p_value; } \
+	};
+
+VARIANT_ACCESSOR_NUMBER(int8_t)
+VARIANT_ACCESSOR_NUMBER(uint8_t)
+VARIANT_ACCESSOR_NUMBER(int16_t)
+VARIANT_ACCESSOR_NUMBER(uint16_t)
+VARIANT_ACCESSOR_NUMBER(int32_t)
+VARIANT_ACCESSOR_NUMBER(uint32_t)
+VARIANT_ACCESSOR_NUMBER(int64_t)
+VARIANT_ACCESSOR_NUMBER(uint64_t)
+VARIANT_ACCESSOR_NUMBER(char32_t)
+VARIANT_ACCESSOR_NUMBER(Error)
+VARIANT_ACCESSOR_NUMBER(Margin)
+
+template <>
+struct VariantInternalAccessor<ObjectID> {
+	static _FORCE_INLINE_ ObjectID get(const Variant *v) { return ObjectID(*VariantInternal::get_int(v)); }
+	static _FORCE_INLINE_ void set(Variant *v, ObjectID p_value) { *VariantInternal::get_int(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<float> {
+	static _FORCE_INLINE_ float get(const Variant *v) { return *VariantInternal::get_float(v); }
+	static _FORCE_INLINE_ void set(Variant *v, float p_value) { *VariantInternal::get_float(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<double> {
+	static _FORCE_INLINE_ double get(const Variant *v) { return *VariantInternal::get_float(v); }
+	static _FORCE_INLINE_ void set(Variant *v, double p_value) { *VariantInternal::get_float(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<String> {
+	static _FORCE_INLINE_ const String &get(const Variant *v) { return *VariantInternal::get_string(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const String &p_value) { *VariantInternal::get_string(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Vector2> {
+	static _FORCE_INLINE_ const Vector2 &get(const Variant *v) { return *VariantInternal::get_vector2(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Vector2 &p_value) { *VariantInternal::get_vector2(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Vector2i> {
+	static _FORCE_INLINE_ const Vector2i &get(const Variant *v) { return *VariantInternal::get_vector2i(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Vector2i &p_value) { *VariantInternal::get_vector2i(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Rect2> {
+	static _FORCE_INLINE_ const Rect2 &get(const Variant *v) { return *VariantInternal::get_rect2(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Rect2 &p_value) { *VariantInternal::get_rect2(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Rect2i> {
+	static _FORCE_INLINE_ const Rect2i &get(const Variant *v) { return *VariantInternal::get_rect2i(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Rect2i &p_value) { *VariantInternal::get_rect2i(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Vector3> {
+	static _FORCE_INLINE_ const Vector3 &get(const Variant *v) { return *VariantInternal::get_vector3(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Vector3 &p_value) { *VariantInternal::get_vector3(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Vector3i> {
+	static _FORCE_INLINE_ const Vector3i &get(const Variant *v) { return *VariantInternal::get_vector3i(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Vector3i &p_value) { *VariantInternal::get_vector3i(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Transform2D> {
+	static _FORCE_INLINE_ const Transform2D &get(const Variant *v) { return *VariantInternal::get_transform2d(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Transform2D &p_value) { *VariantInternal::get_transform2d(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Transform> {
+	static _FORCE_INLINE_ const Transform &get(const Variant *v) { return *VariantInternal::get_transform(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Transform &p_value) { *VariantInternal::get_transform(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Plane> {
+	static _FORCE_INLINE_ const Plane &get(const Variant *v) { return *VariantInternal::get_plane(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Plane &p_value) { *VariantInternal::get_plane(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Quat> {
+	static _FORCE_INLINE_ const Quat &get(const Variant *v) { return *VariantInternal::get_quat(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Quat &p_value) { *VariantInternal::get_quat(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<AABB> {
+	static _FORCE_INLINE_ const AABB &get(const Variant *v) { return *VariantInternal::get_aabb(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const AABB &p_value) { *VariantInternal::get_aabb(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Basis> {
+	static _FORCE_INLINE_ const Basis &get(const Variant *v) { return *VariantInternal::get_basis(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Basis &p_value) { *VariantInternal::get_basis(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Color> {
+	static _FORCE_INLINE_ const Color &get(const Variant *v) { return *VariantInternal::get_color(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Color &p_value) { *VariantInternal::get_color(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<StringName> {
+	static _FORCE_INLINE_ const StringName &get(const Variant *v) { return *VariantInternal::get_string_name(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const StringName &p_value) { *VariantInternal::get_string_name(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<NodePath> {
+	static _FORCE_INLINE_ const NodePath &get(const Variant *v) { return *VariantInternal::get_node_path(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const NodePath &p_value) { *VariantInternal::get_node_path(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<RID> {
+	static _FORCE_INLINE_ const RID &get(const Variant *v) { return *VariantInternal::get_rid(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const RID &p_value) { *VariantInternal::get_rid(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Callable> {
+	static _FORCE_INLINE_ const Callable &get(const Variant *v) { return *VariantInternal::get_callable(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Callable &p_value) { *VariantInternal::get_callable(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Signal> {
+	static _FORCE_INLINE_ const Signal &get(const Variant *v) { return *VariantInternal::get_signal(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Signal &p_value) { *VariantInternal::get_signal(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Dictionary> {
+	static _FORCE_INLINE_ const Dictionary &get(const Variant *v) { return *VariantInternal::get_dictionary(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Dictionary &p_value) { *VariantInternal::get_dictionary(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Array> {
+	static _FORCE_INLINE_ const Array &get(const Variant *v) { return *VariantInternal::get_array(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const Array &p_value) { *VariantInternal::get_array(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<PackedByteArray> {
+	static _FORCE_INLINE_ const PackedByteArray &get(const Variant *v) { return *VariantInternal::get_byte_array(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const PackedByteArray &p_value) { *VariantInternal::get_byte_array(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<PackedInt32Array> {
+	static _FORCE_INLINE_ const PackedInt32Array &get(const Variant *v) { return *VariantInternal::get_int32_array(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const PackedInt32Array &p_value) { *VariantInternal::get_int32_array(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<PackedInt64Array> {
+	static _FORCE_INLINE_ const PackedInt64Array &get(const Variant *v) { return *VariantInternal::get_int64_array(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const PackedInt64Array &p_value) { *VariantInternal::get_int64_array(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<PackedFloat32Array> {
+	static _FORCE_INLINE_ const PackedFloat32Array &get(const Variant *v) { return *VariantInternal::get_float32_array(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const PackedFloat32Array &p_value) { *VariantInternal::get_float32_array(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<PackedFloat64Array> {
+	static _FORCE_INLINE_ const PackedFloat64Array &get(const Variant *v) { return *VariantInternal::get_float64_array(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const PackedFloat64Array &p_value) { *VariantInternal::get_float64_array(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<PackedStringArray> {
+	static _FORCE_INLINE_ const PackedStringArray &get(const Variant *v) { return *VariantInternal::get_string_array(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const PackedStringArray &p_value) { *VariantInternal::get_string_array(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<PackedVector2Array> {
+	static _FORCE_INLINE_ const PackedVector2Array &get(const Variant *v) { return *VariantInternal::get_vector2_array(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const PackedVector2Array &p_value) { *VariantInternal::get_vector2_array(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<PackedVector3Array> {
+	static _FORCE_INLINE_ const PackedVector3Array &get(const Variant *v) { return *VariantInternal::get_vector3_array(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const PackedVector3Array &p_value) { *VariantInternal::get_vector3_array(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<PackedColorArray> {
+	static _FORCE_INLINE_ const PackedColorArray &get(const Variant *v) { return *VariantInternal::get_color_array(v); }
+	static _FORCE_INLINE_ void set(Variant *v, const PackedColorArray &p_value) { *VariantInternal::get_color_array(v) = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Object *> {
+	static _FORCE_INLINE_ Object *get(const Variant *v) { return const_cast<Object *>(*VariantInternal::get_object(v)); }
+	static _FORCE_INLINE_ void set(Variant *v, const Object *p_value) { *VariantInternal::get_object(v) = const_cast<Object *>(p_value); }
+};
+
+template <>
+struct VariantInternalAccessor<Variant> {
+	static _FORCE_INLINE_ Variant &get(Variant *v) { return *v; }
+	static _FORCE_INLINE_ const Variant &get(const Variant *v) { return *v; }
+	static _FORCE_INLINE_ void set(Variant *v, const Variant &p_value) { *v = p_value; }
+};
+
+template <>
+struct VariantInternalAccessor<Vector<Variant>> {
+	static _FORCE_INLINE_ Vector<Variant> get(const Variant *v) {
+		Vector<Variant> ret;
+		int s = VariantInternal::get_array(v)->size();
+		ret.resize(s);
+		for (int i = 0; i < s; i++) {
+			ret.write[i] = VariantInternal::get_array(v)->get(i);
+		}
+
+		return ret;
+	}
+	static _FORCE_INLINE_ void set(Variant *v, const Vector<Variant> &p_value) {
+		int s = p_value.size();
+		VariantInternal::get_array(v)->resize(s);
+		for (int i = 0; i < s; i++) {
+			VariantInternal::get_array(v)->set(i, p_value[i]);
+		}
+	}
 };
 
 #endif // VARIANT_INTERNAL_H

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -319,7 +319,7 @@ void LocalizationEditor::_translation_filter_option_changed() {
 		}
 	}
 
-	f_locales = f_locales.sort();
+	f_locales.sort();
 
 	undo_redo->create_action(TTR("Changed Locale Filter"));
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "locale/locale_filter", f_locales_all);


### PR DESCRIPTION
Moved to a system using variadic templates, shared with CallableBind.

New code is cleaner, faster and allows for much better optimization of core
type functions from GDScript and GDNative. Also adds support for prevalidated and pointer calls
to internal methods.

Added Variant::InternalMethod function for direct call access.

**Note: while it should build ok this PR breaks _release_ target (I think its broken already..), a subsequent PR refactoring method binds should fix it.**
