### PR TITLE
Make search results font follow code editor font

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -690,6 +690,9 @@ void FindInFilesPanel::stop_search() {
 void FindInFilesPanel::_notification(int p_what) {
 	if (p_what == NOTIFICATION_PROCESS) {
 		_progress_bar->set_as_ratio(_finder->get_progress());
+	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
+		_search_text_label->add_theme_font_override("font", get_theme_font("source", "EditorFonts"));
+		_results_display->add_theme_font_override("font", get_theme_font("source", "EditorFonts"));
 	}
 }
 


### PR DESCRIPTION
The font size of the Find in Files dialog used to get out of sync with the code editor font size.

The font of the Find in Files dialog is now updated each time there is a change to the theme. This way, the font size of the Find in Files results changes in response to the code font size being changed using Ctrl +/- or using the Editor Settings.

Fixes #35499

(4.0 version of #41782)
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
