### PR TITLE
EditorNode now copies all drag and dropped files.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5122,7 +5122,6 @@ void EditorNode::_dropped_files(const Vector<String> &p_files, int p_screen) {
 
 void EditorNode::_add_dropped_files_recursive(const Vector<String> &p_files, String to_path) {
 	DirAccessRef dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	Vector<String> just_copy = String("ttf,otf").split(",");
 
 	for (int i = 0; i < p_files.size(); i++) {
 		String from = p_files[i];
@@ -5153,9 +5152,6 @@ void EditorNode::_add_dropped_files_recursive(const Vector<String> &p_files, Str
 			continue;
 		}
 
-		if (!ResourceFormatImporter::get_singleton()->can_be_imported(from) && (just_copy.find(from.get_extension().to_lower()) == -1)) {
-			continue;
-		}
 		dir->copy(from, to);
 	}
 }


### PR DESCRIPTION
The editor used to only copy drag-dropped files in the File System pane
if the given file was a valid resource, or had a specific file format
(ttf, otf).
With this PR, all drag and dropped files are copied instead, no matter
their extension.

This is very useful in e.g. HTML5 exports, to allow users to drag and drop non resource files that the game needs to use (`dat/json/txt` ecc).

See #42789