### PR TITLE
Provide support for buttons and D-pads mapped to half axes.

### DIFF
--- a/core/input/input.h
+++ b/core/input/input.h
@@ -217,7 +217,7 @@ private:
 	Vector<JoyDeviceMapping> map_db;
 
 	JoyEvent _get_mapped_button_event(const JoyDeviceMapping &mapping, int p_button);
-	JoyEvent _get_mapped_axis_event(const JoyDeviceMapping &mapping, int p_axis, const JoyAxis &p_value);
+	JoyEvent _get_mapped_axis_event(const JoyDeviceMapping &mapping, int p_axis, float p_value);
 	void _get_mapped_hat_events(const JoyDeviceMapping &mapping, int p_hat, JoyEvent r_events[HAT_MAX]);
 	JoyButtonList _get_output_button(String output);
 	JoyAxisList _get_output_axis(String output);


### PR DESCRIPTION
#38151 (and the 3.2 non-compat breaking version #38724) provided support for half axes and inverted axes, but they did not implement support for buttons or D-pads mapped to half axes. Worse, D-pad inputs are expected to be mapped to buttons; so break when they're not. This PR provides support for mapping buttons and D-pads to half axes.

Should fix #41065, but I don't have a controller that has this kind of mapping; so it needs testing.
