### PR TITLE
Clarify that `MultiMesh.set_instance_color()` multiplies vertex colors

### DIFF
--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -65,7 +65,7 @@
 			<argument index="1" name="color" type="Color">
 			</argument>
 			<description>
-				Sets the color of a specific instance.
+				Sets the color of a specific instance by [i]multiplying[/i] the mesh's existing vertex colors.
 				For the color to take effect, ensure that [member use_colors] is [code]true[/code] on the [MultiMesh] and [member BaseMaterial3D.vertex_color_use_as_albedo] is [code]true[/code] on the material.
 			</description>
 		</method>


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-docs/issues/4273.