### PR TITLE
When OptionButton is pressed, give focus to selected option

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -179,6 +179,7 @@ void OptionButton::pressed() {
 	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
 	popup->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
 	popup->set_size(Size2(size.width, 0));
+	popup->set_current_index(current);
 	popup->popup();
 }
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1269,6 +1269,13 @@ bool PopupMenu::is_item_shortcut_disabled(int p_idx) const {
 	return items[p_idx].shortcut_is_disabled;
 }
 
+void PopupMenu::set_current_index(int p_idx) {
+	ERR_FAIL_INDEX(p_idx, items.size());
+	mouse_over = p_idx;
+	_scroll_to_item(mouse_over);
+	control->update();
+}
+
 int PopupMenu::get_current_index() const {
 	return mouse_over;
 }

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -212,6 +212,7 @@ public:
 	Ref<Shortcut> get_item_shortcut(int p_idx) const;
 	int get_item_state(int p_idx) const;
 
+	void set_current_index(int p_idx);
 	int get_current_index() const;
 
 	void set_item_count(int p_count);


### PR DESCRIPTION
A simple usability improvement: give focus to the currently selected option when an `OptionButton` is pressed.

![godot_optionbutton_focus](https://user-images.githubusercontent.com/229837/96195288-a7ad0f80-0f4c-11eb-971f-24052106c3fd.gif)

The previous behavior was to focus on *no option in particular* (index `-1`), which was less clear (find the filled circle), less standard (compare e.g. web browsers) and less convenient. For users of the arrow keys, the previous behavior required (in all but two cases) at least one useless button press (to give focus to the first or last item).

It has been asked on the German Godot Community Discord and [in Q&A](https://godotengine.org/qa/48084/how-to-set-focus-on-an-item-in-option-button-by-code) how to achieve this functionality. As far as I could see it was impossible in plain GDScript. It was easy to implement in C++ (the commit is basically a one-liner), and I see no reason to keep the old behavior or to have any other behavior, hence this humble PR.