### PR TITLE
Fix mesh instance materials not initialized correctly

### DIFF
--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -355,9 +355,9 @@ void MeshInstance::_initialize_skinning(bool p_force_reset) {
 	}
 
 	RID render_mesh = software_skinning ? software_skinning->mesh_instance->get_rid() : mesh->get_rid();
-	set_base(render_mesh);
+	if (update_mesh || (render_mesh != get_base())) {
+		set_base(render_mesh);
 
-	if (update_mesh) {
 		// Update instance materials after switching mesh.
 		int surface_count = mesh->get_surface_count();
 		for (int surface_index = 0; surface_index < surface_count; ++surface_index) {


### PR DESCRIPTION
This fixes a regression from PR #40313 (support for software skinning in `MeshInstance`).

Before, the base mesh was always updated on load even if not skinning was used, which caused mesh instance materials to be reset on the rendering side.

Now the base mesh is set only when it has been modified (to avoid unnecessary updates on the render side), or when switching software skinning on or off. In this case the mesh instance materials are always updated properly afterwards.

Fixes #42675

CC @lawnjelly 
Thanks for tracking the issue down! In the end I've chosen not to disable the whole call to initialize skinning as you suggested in https://github.com/godotengine/godot/pull/40313#issuecomment-708416105 because I want to make sure skinning is properly reset if needed when the skeleton path is changed.
Since the cause is calling `set_base` without updating materials afterwards it should be fine now.