### PR TITLE
Setting visibility on GridMaps parent now works. Closes #41374.

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -706,7 +706,7 @@ void GridMap::_update_visibility() {
 		Octant *octant = e->value();
 		for (int i = 0; i < octant->multimesh_instances.size(); i++) {
 			const Octant::MultimeshInstance &mi = octant->multimesh_instances[i];
-			RS::get_singleton()->instance_set_visible(mi.instance, is_visible());
+			RS::get_singleton()->instance_set_visible(mi.instance, is_visible_in_tree());
 		}
 	}
 }


### PR DESCRIPTION
Continuing the work from f43a0ef3270737d2b526480ecb0f1337ece9e041,
It seems the maps visibility was not actually set and a flase value was propogated to the meshes
Trying to set the maps visibility directly (Using `set_visibility` causes the map to no longer to recieve visibility notifications, instead this approach was chosen

*Bugsquad edit:* Fixes #41374.