### PR TITLE
Fix 3D physics clearing forces after each iteration.

### DIFF
--- a/doc/classes/RigidDynamicBody3D.xml
+++ b/doc/classes/RigidDynamicBody3D.xml
@@ -101,6 +101,12 @@
 		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity" default="Vector3(0, 0, 0)">
 			RigidDynamicBody3D's rotational velocity.
 		</member>
+		<member name="applied_force" type="Vector3" setter="set_applied_force" getter="get_applied_force" default="Vector3(0, 0, 0)">
+			The body's total applied force.
+		</member>
+		<member name="applied_torque" type="Vector3" setter="set_applied_torque" getter="get_applied_torque" default="Vector3(0, 0, 0)">
+			The body's total applied torque.
+		</member>
 		<member name="can_sleep" type="bool" setter="set_can_sleep" getter="is_able_to_sleep" default="true">
 			If [code]true[/code], the body can enter sleep mode when there is no movement. See [member sleeping].
 		</member>

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -698,21 +698,21 @@ void BulletPhysicsServer3D::body_add_central_force(RID p_body, const Vector3 &p_
 	RigidBodyBullet *body = rigid_body_owner.get_or_null(p_body);
 	ERR_FAIL_COND(!body);
 
-	body->apply_central_force(p_force);
+	body->add_central_force(p_force);
 }
 
 void BulletPhysicsServer3D::body_add_force(RID p_body, const Vector3 &p_force, const Vector3 &p_position) {
 	RigidBodyBullet *body = rigid_body_owner.get_or_null(p_body);
 	ERR_FAIL_COND(!body);
 
-	body->apply_force(p_force, p_position);
+	body->add_force(p_force, p_position);
 }
 
 void BulletPhysicsServer3D::body_add_torque(RID p_body, const Vector3 &p_torque) {
 	RigidBodyBullet *body = rigid_body_owner.get_or_null(p_body);
 	ERR_FAIL_COND(!body);
 
-	body->apply_torque(p_torque);
+	body->add_torque(p_torque);
 }
 
 void BulletPhysicsServer3D::body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) {

--- a/modules/bullet/rigid_body_bullet.h
+++ b/modules/bullet/rigid_body_bullet.h
@@ -202,6 +202,8 @@ private:
 	bool can_sleep = true;
 	bool omit_forces_integration = false;
 	bool can_integrate_forces = false;
+	btVector3 applied_force = btVector3(0, 0, 0);
+	btVector3 applied_torque = btVector3(0, 0, 0);
 
 	Vector<CollisionData> collisions;
 	Vector<RigidBodyBullet *> collision_traces_1;
@@ -287,14 +289,15 @@ public:
 	void apply_impulse(const Vector3 &p_impulse, const Vector3 &p_position = Vector3());
 	void apply_torque_impulse(const Vector3 &p_impulse);
 
-	void apply_central_force(const Vector3 &p_force);
-	void apply_force(const Vector3 &p_force, const Vector3 &p_position = Vector3());
-	void apply_torque(const Vector3 &p_torque);
+	void add_central_force(const Vector3 &p_force);
+	void add_force(const Vector3 &p_force, const Vector3 &p_position = Vector3());
+	void add_torque(const Vector3 &p_torque);
 
 	void set_applied_force(const Vector3 &p_force);
 	Vector3 get_applied_force() const;
 	void set_applied_torque(const Vector3 &p_torque);
 	Vector3 get_applied_torque() const;
+	void apply_forces();
 
 	void set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool lock);
 	bool is_axis_locked(PhysicsServer3D::BodyAxis p_axis) const;

--- a/modules/bullet/space_bullet.h
+++ b/modules/bullet/space_bullet.h
@@ -111,6 +111,7 @@ class SpaceBullet : public RIDBullet {
 	real_t angular_damp = 0.0;
 
 	Vector<AreaBullet *> areas;
+	Vector<RigidBodyBullet *> rigid_bodies_with_forces;
 
 	Vector<Vector3> contactDebug;
 	int contactDebugCount = 0;
@@ -149,6 +150,10 @@ public:
 	void add_area(AreaBullet *p_area);
 	void remove_area(AreaBullet *p_area);
 	void reload_collision_filters(AreaBullet *p_area);
+
+	void add_rigid_body_with_force(RigidBodyBullet *p_body);
+	void remove_rigid_body_with_force(RigidBodyBullet *p_body);
+	void apply_rigid_body_forces();
 
 	void add_rigid_body(RigidBodyBullet *p_body);
 	void remove_rigid_body_constraints(RigidBodyBullet *p_body);

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -875,6 +875,22 @@ int RigidDynamicBody3D::get_max_contacts_reported() const {
 	return max_contacts_reported;
 }
 
+void RigidDynamicBody3D::set_applied_force(const Vector3 &p_force) {
+	PhysicsServer3D::get_singleton()->body_set_applied_force(get_rid(), p_force);
+}
+
+Vector3 RigidDynamicBody3D::get_applied_force() const {
+	return PhysicsServer3D::get_singleton()->body_get_applied_force(get_rid());
+}
+
+void RigidDynamicBody3D::set_applied_torque(const Vector3 &p_torque) {
+	PhysicsServer3D::get_singleton()->body_set_applied_torque(get_rid(), p_torque);
+}
+
+Vector3 RigidDynamicBody3D::get_applied_torque() const {
+	return PhysicsServer3D::get_singleton()->body_get_applied_torque(get_rid());
+}
+
 void RigidDynamicBody3D::add_central_force(const Vector3 &p_force) {
 	PhysicsServer3D::get_singleton()->body_add_central_force(get_rid(), p_force);
 }
@@ -1024,6 +1040,12 @@ void RigidDynamicBody3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_axis_velocity", "axis_velocity"), &RigidDynamicBody3D::set_axis_velocity);
 
+	ClassDB::bind_method(D_METHOD("set_applied_force", "force"), &RigidDynamicBody3D::set_applied_force);
+	ClassDB::bind_method(D_METHOD("get_applied_force"), &RigidDynamicBody3D::get_applied_force);
+
+	ClassDB::bind_method(D_METHOD("set_applied_torque", "torque"), &RigidDynamicBody3D::set_applied_torque);
+	ClassDB::bind_method(D_METHOD("get_applied_torque"), &RigidDynamicBody3D::get_applied_torque);
+
 	ClassDB::bind_method(D_METHOD("add_central_force", "force"), &RigidDynamicBody3D::add_central_force);
 	ClassDB::bind_method(D_METHOD("add_force", "force", "position"), &RigidDynamicBody3D::add_force, Vector3());
 	ClassDB::bind_method(D_METHOD("add_torque", "torque"), &RigidDynamicBody3D::add_torque);
@@ -1075,6 +1097,9 @@ void RigidDynamicBody3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "angular_velocity"), "set_angular_velocity", "get_angular_velocity");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "angular_damp_mode", PROPERTY_HINT_ENUM, "Combine,Replace"), "set_angular_damp_mode", "get_angular_damp_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_damp", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), "set_angular_damp", "get_angular_damp");
+	ADD_GROUP("Applied Forces", "applied_");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "applied_force"), "set_applied_force", "get_applied_force");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "applied_torque"), "set_applied_torque", "get_applied_torque");
 
 	ADD_SIGNAL(MethodInfo("body_shape_entered", PropertyInfo(Variant::RID, "body_rid"), PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node"), PropertyInfo(Variant::INT, "body_shape_index"), PropertyInfo(Variant::INT, "local_shape_index")));
 	ADD_SIGNAL(MethodInfo("body_shape_exited", PropertyInfo(Variant::RID, "body_rid"), PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node"), PropertyInfo(Variant::INT, "body_shape_index"), PropertyInfo(Variant::INT, "local_shape_index")));

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -306,6 +306,11 @@ public:
 
 	Array get_colliding_bodies() const;
 
+	void set_applied_force(const Vector3 &p_force);
+	Vector3 get_applied_force() const;
+	void set_applied_torque(const Vector3 &p_torque);
+	Vector3 get_applied_torque() const;
+
 	void add_central_force(const Vector3 &p_force);
 	void add_force(const Vector3 &p_force, const Vector3 &p_position = Vector3());
 	void add_torque(const Vector3 &p_torque);

--- a/servers/physics_3d/godot_body_3d.cpp
+++ b/servers/physics_3d/godot_body_3d.cpp
@@ -657,9 +657,6 @@ void GodotBody3D::integrate_forces(real_t p_step) {
 		}
 	}
 
-	applied_force = Vector3();
-	applied_torque = Vector3();
-
 	biased_angular_velocity = Vector3();
 	biased_linear_velocity = Vector3();
 


### PR DESCRIPTION
As identified in #30061 and discussed in #38646, in 2D physics, `add_central_force()`, `add_force()`, `add_torque()` correctly, and as [documented](https://docs.godotengine.org/en/stable/classes/class_rigidbody2d.html#class-rigidbody2d-method-add-central-force), add a constant force and/or torque to the `RigidBody2D`. However, currently, in 3D physics, `add_central_force()`, `add_force()`, `add_torque()` behave like `apply_central_impulse()`, `apply_impulse()` and `apply_torque_impulse()` i.e. they are not constant. The `applied_force` and `applied_torque` are incorrectly being cleared at the end of each iteration.

Currently, in 3D, the only difference between `add_central_force()`, `add_force()`, `add_torque()`, and `apply_central_impulse()`, `apply_impulse()` and `apply_torque_impulse()` respectively is the unit used; the factor of delta:
- `add_central_force(offset, force)` = `apply_central_impulse(offset, force * delta)`
- `add_force(force)` = `add_impulse(force_vector * delta)`
- `add_torque(force)` = `apply_torque_impulse(force * delta)`

This PR makes 3D physics consistent with 2D physics and the [documentation](https://docs.godotengine.org/en/stable/classes/class_rigidbody.html). It ensures that `add_central_force()`, `add_force()`, `add_torque()` correctly add a constant force and/or torque to the `RigidBody3D`. It also adds the missing properties `applied_force` and `applied_torque` to `RigidBody3D`, which are available in `RigidBody2D`.

Fixes #38646.

Note: This is my suggested alternative to #38648, which also makes 2D and 3D consistent, but would do it by making 2D the same as 3D i.e. incorrectly clearing the `applied_force` and `applied_torque` at the end of each 2D physics iteration, which would incorrectly make `add_central_force()`, `add_force()`, `add_torque()` behave like `apply_central_impulse()`, `apply_impulse()` and `apply_torque_impulse()` respectively.

