### PR TITLE
[3.2] [iOS] InAppStore fixes

### DIFF
--- a/platform/iphone/in_app_store.h
+++ b/platform/iphone/in_app_store.h
@@ -35,6 +35,17 @@
 
 #include "core/object.h"
 
+#ifdef __OBJC__
+@class GodotProductsDelegate;
+@class GodotTransactionsObserver;
+
+typedef GodotProductsDelegate InAppStoreProductDelegate;
+typedef GodotTransactionsObserver InAppStoreTransactionObserver;
+#else
+typedef void InAppStoreProductDelegate;
+typedef void InAppStoreTransactionObserver;
+#endif
+
 class InAppStore : public Object {
 
 	GDCLASS(InAppStore, Object);
@@ -43,6 +54,9 @@ class InAppStore : public Object {
 	static void _bind_methods();
 
 	List<Variant> pending_events;
+
+	InAppStoreProductDelegate *products_request_delegate;
+	InAppStoreTransactionObserver *transactions_observer;
 
 public:
 	Error request_product_info(Variant p_params);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/42836

Reworked the way products and transactions delegate and product/transaction value are stored. 
Now they are strong references, which fixes requests and transactions being released too early.
Previous migration to ARC fixed the crash reported in https://github.com/godotengine/godot/issues/42836
