### PR TITLE
Document modification limitations with Pool*Arrays passed by reference

### DIFF
--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold bytes. Optimized for memory usage, does not fragment the memory.
-		[b]Note:[/b] This type is passed by value and not by reference.
+		[b]Note:[/b] This type is usually passed by value and not by reference. However, if a [PoolByteArray] is stored as a class property or as the value of an [Array] or [Dictionary], it will be passed as reference. Due to limitations, attempting to modify a [PoolByteArray] passed as reference with a method such as [method append] won't work.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PoolColorArray.xml
+++ b/doc/classes/PoolColorArray.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold [Color]. Optimized for memory usage, does not fragment the memory.
-		[b]Note:[/b] This type is passed by value and not by reference.
+		[b]Note:[/b] This type is usually passed by value and not by reference. However, if a [PoolColorArray] is stored as a class property or as the value of an [Array] or [Dictionary], it will be passed as reference. Due to limitations, attempting to modify a [PoolColorArray] passed as reference with a method such as [method append] won't work.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PoolIntArray.xml
+++ b/doc/classes/PoolIntArray.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold integer values ([int]). Optimized for memory usage, does not fragment the memory.
-		[b]Note:[/b] This type is passed by value and not by reference.
+		[b]Note:[/b] This type is usually passed by value and not by reference. However, if a [PoolIntArray] is stored as a class property or as the value of an [Array] or [Dictionary], it will be passed as reference. Due to limitations, attempting to modify a [PoolIntArray] passed as reference with a method such as [method append] won't work.
 		[b]Note:[/b] This type is limited to signed 32-bit integers, which means it can only take values in the interval [code][-2^31, 2^31 - 1][/code], i.e. [code][-2147483648, 2147483647][/code]. Exceeding those bounds will wrap around. In comparison, [int] uses signed 64-bit integers which can hold much larger values.
 	</description>
 	<tutorials>

--- a/doc/classes/PoolRealArray.xml
+++ b/doc/classes/PoolRealArray.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold floating-point values ([float]). Optimized for memory usage, does not fragment the memory.
-		[b]Note:[/b] This type is passed by value and not by reference.
+		[b]Note:[/b] This type is usually passed by value and not by reference. However, if a [PoolRealArray] is stored as a class property or as the value of an [Array] or [Dictionary], it will be passed as reference. Due to limitations, attempting to modify a [PoolRealArray] passed as reference with a method such as [method append] won't work.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PoolStringArray.xml
+++ b/doc/classes/PoolStringArray.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold [String]s. Optimized for memory usage, does not fragment the memory.
-		[b]Note:[/b] This type is passed by value and not by reference.
+		[b]Note:[/b] This type is usually passed by value and not by reference. However, if a [PoolStringArray] is stored as a class property or as the value of an [Array] or [Dictionary], it will be passed as reference. Due to limitations, attempting to modify a [PoolStringArray] passed as reference with a method such as [method append] won't work.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PoolVector2Array.xml
+++ b/doc/classes/PoolVector2Array.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold [Vector2]. Optimized for memory usage, does not fragment the memory.
-		[b]Note:[/b] This type is passed by value and not by reference.
+		[b]Note:[/b] This type is usually passed by value and not by reference. However, if a [PoolVector2Array] is stored as a class property or as the value of an [Array] or [Dictionary], it will be passed as reference. Due to limitations, attempting to modify a [PoolVector2Array] passed as reference with a method such as [method append] won't work.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PoolVector3Array.xml
+++ b/doc/classes/PoolVector3Array.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		An [Array] specifically designed to hold [Vector3]. Optimized for memory usage, does not fragment the memory.
-		[b]Note:[/b] This type is passed by value and not by reference.
+		[b]Note:[/b] This type is usually passed by value and not by reference. However, if a [PoolVector3Array] is stored as a class property or as the value of an [Array] or [Dictionary], it will be passed as reference. Due to limitations, attempting to modify a [PoolVector3Array] passed as reference with a method such as [method append] won't work.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
See #15265.

I presume this doesn't apply to PackedArrays in `master`, so I opened this on the `3.2` branch.