### PR TITLE
[DNM] CI: Disable debug symbols on desktop (test)

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=linuxbsd verbose=yes warnings=all werror=yes --jobs=2
+  SCONSFLAGS: platform=linuxbsd verbose=yes debug_symbols=no warnings=all werror=yes --jobs=2
   SCONS_CACHE_LIMIT: 4096
 
 jobs:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=osx verbose=yes warnings=all werror=yes --jobs=2
+  SCONSFLAGS: platform=osx verbose=yes debug_symbols=no warnings=all werror=yes --jobs=2
   SCONS_CACHE_LIMIT: 4096
 
 jobs:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 # SCONS_CACHE for windows must be set in the build environment
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=windows verbose=yes warnings=all werror=yes --jobs=2
+  SCONSFLAGS: platform=windows verbose=yes debug_symbols=no warnings=all werror=yes --jobs=2
   SCONS_CACHE_MSVC_CONFIG: true
   SCONS_CACHE_LIMIT: 4096
 


### PR DESCRIPTION
**Do not merge!**

This is a CI test to get the sizes of desktop builds without debug symbols, to compare with #42826.