### PR TITLE
Fix camera2d zoom when set to zero (affine_invert: Condition ' det == 0 ' is true)

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -77,6 +77,9 @@ void Camera2D::_update_process_mode() {
 }
 
 void Camera2D::set_zoom(const Vector2 &p_zoom) {
+	// Setting zoom to zero causes 'affine_invert' issues
+	ERR_FAIL_COND_MSG(Math::is_zero_approx(p_zoom.x) || Math::is_zero_approx(p_zoom.y), "Zoom level must be different from 0 (can be negative).");
+
 	zoom = p_zoom;
 	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
 	_update_scroll();


### PR DESCRIPTION
Fixes: #41873
Can be cherry-picked to 3.x