### PR TITLE
TextEdit - fix valid bounds in 'set_line'. 

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6406,7 +6406,7 @@ void TextEdit::set_tooltip_request_func(Object *p_obj, const StringName &p_funct
 }
 
 void TextEdit::set_line(int line, String new_text) {
-	if (line < 0 || line > text.size()) {
+	if (line < 0 || line >= text.size()) {
 		return;
 	}
 	_remove_text(line, 0, line, text[line].length());


### PR DESCRIPTION
Fixes #41967
 Can be cherry-picked to 3.x