### PR TITLE
Add customizable main loop iterator proposal code

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -575,6 +575,18 @@ if selected_platform in platform_list:
                 env.module_icons_paths.append(path + "/" + "icons")
             modules_enabled[name] = path
 
+            if getattr(config, "has_custom_iterator", False) and config.has_custom_iterator():
+                env.AppendUnique(CPPDEFINES=["CUSTOM_ITERATOR"])
+
+            if getattr(config, "disable_main_iterator_process", False) and config.disable_main_iterator_process():
+                env.AppendUnique(CPPDEFINES=["DISABLE_MAIN_ITERATOR_PROCESS"])
+
+            if getattr(config, "disable_main_iterator_physics", False) and config.disable_main_iterator_physics():
+                env.AppendUnique(CPPDEFINES=["DISABLE_MAIN_ITERATOR_PHYSICS"])
+
+            if getattr(config, "disable_main_iterator_audio", False) and config.disable_main_iterator_audio():
+                env.AppendUnique(CPPDEFINES=["DISABLE_MAIN_ITERATOR_AUDIO"])
+
         sys.path.remove(path)
         sys.modules.pop("config")
 

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -88,8 +88,10 @@ public:
 
 	uint64_t get_frames_drawn();
 
+	void set_physics_frames(uint32_t p_physics_frames) { _physics_frames = p_physics_frames; }
 	uint64_t get_physics_frames() const { return _physics_frames; }
 	uint64_t get_process_frames() const { return _process_frames; }
+	void set_in_physics_frame(bool p_in_physics) { _in_physics = p_in_physics; }
 	bool is_in_physics_frame() const { return _in_physics; }
 	uint64_t get_frame_ticks() const { return _frame_ticks; }
 	float get_process_step() const { return _process_step; }

--- a/main/main.h
+++ b/main/main.h
@@ -54,6 +54,9 @@ public:
 #endif
 	static bool start();
 
+#ifdef CUSTOM_ITERATOR
+	static bool custom_iteration(double p_process_step, double p_physics_step, class MainFrameTime *p_frame_time, float p_time_scale);
+#endif
 	static bool iteration();
 	static void force_redraw();
 


### PR DESCRIPTION
_PR has the aim to show the code change needed to integrate this proposal: https://github.com/godotengine/godot-proposals/issues/1592_

---

It's possible to customize the [Main::iterator](https://github.com/godotengine/godot/blob/master/main/main.cpp#L2349) from a module by adding some rules on the module `config.py`:

**my_module/config.py**
```python
def can_build(env, platform):
    return True

def configure(env):
    pass

def has_custom_iterator():
    # Optional
    return True

def disable_main_iterator_process():
    # Optional
    return False

def disable_main_iterator_physics():
    # Optional
    return True

def disable_main_iterator_audio():
    # Optional
    return False
```

**has_custom_iterator**
When `has_custom_iterator` returns `True`, the compiler will add the function `custom_iteration` on the `main.cpp` that the module can implement:

**my_module/custom_iterator.cpp**
```cpp
bool Main::custom_iteration(float p_process_delta, float p_physics_delta, MainFrameTime *p_frame_time, float p_time_scale) {

	// This function is called each frame, before godot `process`.

	// Controls whether wants to stop the engine execution.
	return true;
}
```

You can already see it in action here: https://github.com/AndreaCatania/godex/blob/main/main.cpp#L14

**disable_main_iterator_process**, **disable_main_iterator_physics** and **disable_main_iterator_audio**
When these functions, which are optional, returns `True` the specific process within the iterator function is disabled. For example, when `disable_main_iterator_physics` returns `True` the physics is not processed.

This PR, also adds 2 new functions on the `Engine.h` that fully allow to control the engine physics execution from a module.