### PR TITLE
Set Bullet collision shape index to zero when using a single shape or ConcavePolygonShape

### DIFF
--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -229,6 +229,7 @@
 			<description>
 				Emitted when a body enters into contact with this one. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions.
 				This signal not only receives the body that collided with this one, but also its [RID] ([code]body_id[/code]), the shape index from the colliding body ([code]body_shape[/code]), and the shape index from this body ([code]local_shape[/code]) the other body collided with.
+				[b]Note:[/b] Bullet physics cannot identify the shape index when using a [ConcavePolygonShape3D]. Don't use multiple [CollisionShape3D]s when using a [ConcavePolygonShape3D] with Bullet physics if you need shape indices.
 			</description>
 		</signal>
 		<signal name="body_shape_exited">
@@ -243,6 +244,7 @@
 			<description>
 				Emitted when a body shape exits contact with this one. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions.
 				This signal not only receives the body that stopped colliding with this one, but also its [RID] ([code]body_id[/code]), the shape index from the colliding body ([code]body_shape[/code]), and the shape index from this body ([code]local_shape[/code]) the other body stopped colliding with.
+				[b]Note:[/b] Bullet physics cannot identify the shape index when using a [ConcavePolygonShape3D]. Don't use multiple [CollisionShape3D]s when using a [ConcavePolygonShape3D] with Bullet physics if you need shape indices.
 			</description>
 		</signal>
 		<signal name="sleeping_state_changed">

--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -828,17 +828,29 @@ void SpaceBullet::check_body_collision() {
 					float appliedImpulse = pt.m_appliedImpulse;
 					B_TO_G(pt.m_normalWorldOnB, normalOnB);
 
+					// The pt.m_index only contains the shape index when more than one collision shape is used
+					// and only if the collision shape is not a concave collision shape.
+					// A value of -1 in pt.m_partId indicates the pt.m_index is a shape index.
+					int shape_index_a = 0;
+					if (bodyA->get_shape_count() > 1 && pt.m_partId0 == -1) {
+						shape_index_a = pt.m_index0;
+					}
+					int shape_index_b = 0;
+					if (bodyB->get_shape_count() > 1 && pt.m_partId1 == -1) {
+						shape_index_b = pt.m_index1;
+					}
+
 					if (bodyA->can_add_collision()) {
 						B_TO_G(pt.getPositionWorldOnB(), collisionWorldPosition);
 						/// pt.m_localPointB Doesn't report the exact point in local space
 						B_TO_G(pt.getPositionWorldOnB() - contactManifold->getBody1()->getWorldTransform().getOrigin(), collisionLocalPosition);
-						bodyA->add_collision_object(bodyB, collisionWorldPosition, collisionLocalPosition, normalOnB, appliedImpulse, pt.m_index1, pt.m_index0);
+						bodyA->add_collision_object(bodyB, collisionWorldPosition, collisionLocalPosition, normalOnB, appliedImpulse, shape_index_b, shape_index_a);
 					}
 					if (bodyB->can_add_collision()) {
 						B_TO_G(pt.getPositionWorldOnA(), collisionWorldPosition);
 						/// pt.m_localPointA Doesn't report the exact point in local space
 						B_TO_G(pt.getPositionWorldOnA() - contactManifold->getBody0()->getWorldTransform().getOrigin(), collisionLocalPosition);
-						bodyB->add_collision_object(bodyA, collisionWorldPosition, collisionLocalPosition, normalOnB * -1, appliedImpulse * -1, pt.m_index0, pt.m_index1);
+						bodyB->add_collision_object(bodyA, collisionWorldPosition, collisionLocalPosition, normalOnB * -1, appliedImpulse * -1, shape_index_a, shape_index_b);
 					}
 
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
Fixes #39767 and documents that Bullet physics is unable to detect the shape index when colliding with a `ConcavePolygonShape`.
