### PR TITLE
Make Godot close the file's tab when it is deleted

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1524,11 +1524,7 @@ void EditorNode::_mark_unsaved_scenes() {
 
 		String path = node->get_filename();
 		if (!(path == String() || FileAccess::exists(path))) {
-			if (i == editor_data.get_edited_scene()) {
-				set_current_version(-1);
-			} else {
-				editor_data.set_edited_scene_version(-1, i);
-			}
+			_remove_scene(i);
 		}
 	}
 


### PR DESCRIPTION
- Fixes #39469
- Closes https://github.com/godotengine/godot-proposals/issues/1550

Changed default behavior of Godot when deleting an open file; instead of leaving it as an unsaved file, now it removes it from the tab.
![Peek 2020-10-18 12-49](https://user-images.githubusercontent.com/6501975/96366661-e0153f00-1140-11eb-97bf-a11ebf4ae44f.gif)

