### PR TITLE
Fix emit_signal timing for GraphEdit's begin/end node move

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -775,6 +775,11 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 	}
 
 	if (mm.is_valid() && dragging) {
+		if (!moving_selection) {
+			emit_signal("_begin_node_move");
+			moving_selection = true;
+		}
+
 		just_selected = true;
 		drag_accum += mm->get_relative();
 		for (int i = get_child_count() - 1; i >= 0; i--) {
@@ -881,16 +886,17 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 			}
 
 			if (drag_accum != Vector2()) {
-				emit_signal("_begin_node_move");
-
 				for (int i = get_child_count() - 1; i >= 0; i--) {
 					GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 					if (gn && gn->is_selected()) {
 						gn->set_drag(false);
 					}
 				}
+			}
 
+			if (moving_selection) {
 				emit_signal("_end_node_move");
+				moving_selection = false;
 			}
 
 			dragging = false;

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -98,6 +98,7 @@ private:
 
 	bool dragging;
 	bool just_selected;
+	bool moving_selection;
 	Vector2 drag_accum;
 
 	float zoom;


### PR DESCRIPTION
Fixes #42854 
Can be cherry-picked to 3.0+

Tested using the attached project.  I also tested AnimationNodeBlendTreeEditor which uses GraphEdit, however it was unaffected by the bug because it uses the `dragged` signal for undo tracking.

Start signal is now emitted on the first drag movement.  End signal is only emitted when the drag ends (mouse up) and if the start signal was sent.

Test project: [GraphEditBug.zip](https://github.com/godotengine/godot/files/5398167/GraphEditBug.zip)
