### PR TITLE
Increase the default HTTPClient download chunk size to 64 KiB

### DIFF
--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -182,7 +182,8 @@ private:
 
 	int response_num = 0;
 	Vector<String> response_headers;
-	int read_chunk_size = 4096;
+	// 64 KiB by default (favors fast download speeds at the cost of memory usage).
+	int read_chunk_size = 65536;
 
 	Error _get_http_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -180,7 +180,7 @@
 		<member name="connection" type="StreamPeer" setter="set_connection" getter="get_connection">
 			The connection to use for this client.
 		</member>
-		<member name="read_chunk_size" type="int" setter="set_read_chunk_size" getter="get_read_chunk_size" default="4096">
+		<member name="read_chunk_size" type="int" setter="set_read_chunk_size" getter="get_read_chunk_size" default="65536">
 			The size of the buffer used and maximum bytes to read per iteration. See [method read_response_body_chunk].
 		</member>
 	</members>

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -153,9 +153,9 @@
 		<member name="body_size_limit" type="int" setter="set_body_size_limit" getter="get_body_size_limit" default="-1">
 			Maximum allowed size for response bodies. If the response body is compressed, this will be used as the maximum allowed size for the decompressed body.
 		</member>
-		<member name="download_chunk_size" type="int" setter="set_download_chunk_size" getter="get_download_chunk_size" default="4096">
+		<member name="download_chunk_size" type="int" setter="set_download_chunk_size" getter="get_download_chunk_size" default="65536">
 			The size of the buffer used and maximum bytes to read per iteration. See [member HTTPClient.read_chunk_size].
-			Set this to a higher value (e.g. 65536 for 64 KiB) when downloading large files to achieve better speeds at the cost of memory.
+			Set this to a lower value (e.g. 4096 for 4 KiB) when downloading small files to decrease memory usage at the cost of download speeds.
 		</member>
 		<member name="download_file" type="String" setter="set_download_file" getter="get_download_file" default="&quot;&quot;">
 			The file to download into. Will output any received file into it.


### PR DESCRIPTION
This improves download speeds at the cost of increased memory usage.

This change also effects HTTPRequest automatically.

Since this doesn't break backwards compatibility, I marked this as cherry-pickable.

See #32807 and #33862.