### PR TITLE
Fixup `ColorRect` and `TextureRect` renames

### DIFF
--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -44,8 +44,8 @@ void AudioStreamEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
 		_play_button->set_icon(get_theme_icon("MainPlay", "EditorIcons"));
 		_stop_button->set_icon(get_theme_icon("Stop", "EditorIcons"));
-		_preview->set_frame_color(get_theme_color("dark_color_2", "Editor"));
-		set_frame_color(get_theme_color("dark_color_1", "Editor"));
+		_preview->set_color(get_theme_color("dark_color_2", "Editor"));
+		set_color(get_theme_color("dark_color_1", "Editor"));
 
 		_indicator->update();
 		_preview->update();

--- a/scene/gui/color_rect.cpp
+++ b/scene/gui/color_rect.cpp
@@ -30,12 +30,12 @@
 
 #include "color_rect.h"
 
-void ColorRect::set_frame_color(const Color &p_color) {
+void ColorRect::set_color(const Color &p_color) {
 	color = p_color;
 	update();
 }
 
-Color ColorRect::get_frame_color() const {
+Color ColorRect::get_color() const {
 	return color;
 }
 
@@ -46,12 +46,8 @@ void ColorRect::_notification(int p_what) {
 }
 
 void ColorRect::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_frame_color", "color"), &ColorRect::set_frame_color);
-	ClassDB::bind_method(D_METHOD("get_frame_color"), &ColorRect::get_frame_color);
+	ClassDB::bind_method(D_METHOD("set_color", "color"), &ColorRect::set_color);
+	ClassDB::bind_method(D_METHOD("get_color"), &ColorRect::get_color);
 
-	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_frame_color", "get_frame_color");
-}
-
-ColorRect::ColorRect() {
-	color = Color(1, 1, 1);
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
 }

--- a/scene/gui/color_rect.h
+++ b/scene/gui/color_rect.h
@@ -36,17 +36,15 @@
 class ColorRect : public Control {
 	GDCLASS(ColorRect, Control);
 
-	Color color;
+	Color color = Color(1, 1, 1);
 
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
-	void set_frame_color(const Color &p_color);
-	Color get_frame_color() const;
-
-	ColorRect();
+	void set_color(const Color &p_color);
+	Color get_color() const;
 };
 
 #endif // COLOR_RECT_H

--- a/scene/gui/nine_patch_rect.h
+++ b/scene/gui/nine_patch_rect.h
@@ -79,4 +79,5 @@ public:
 };
 
 VARIANT_ENUM_CAST(NinePatchRect::AxisStretchMode)
+
 #endif // NINE_PATCH_RECT_H

--- a/scene/gui/texture_rect.h
+++ b/scene/gui/texture_rect.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef TEXTURE_FRAME_H
-#define TEXTURE_FRAME_H
+#ifndef TEXTURE_RECT_H
+#define TEXTURE_RECT_H
 
 #include "scene/gui/control.h"
 
@@ -83,4 +83,5 @@ public:
 };
 
 VARIANT_ENUM_CAST(TextureRect::StretchMode);
-#endif // TEXTURE_FRAME_H
+
+#endif // TEXTURE_RECT_H


### PR DESCRIPTION
See https://github.com/godotengine/godot/commit/da477b76a98ee7ca4ac16773d3baf1299e053da7.

Stumbled upon this while researching stuff around godotengine/godot-proposals#1687.

`AudioStreamEditorPlugin` depends on `ColorRect`.