### PR TITLE
Cross-reference `ColorRect` and `ReferenceRect` in the class reference

### DIFF
--- a/doc/classes/ColorRect.xml
+++ b/doc/classes/ColorRect.xml
@@ -4,7 +4,7 @@
 		Colored rectangle.
 	</brief_description>
 	<description>
-		Displays a colored rectangle.
+		Displays a rectangle filled with a solid [member color]. If you need to display the border alone, consider using [ReferenceRect] instead.
 	</description>
 	<tutorials>
 		<link title="2D Dodge The Creeps Demo">https://godotengine.org/asset-library/asset/515</link>

--- a/doc/classes/ReferenceRect.xml
+++ b/doc/classes/ReferenceRect.xml
@@ -4,7 +4,7 @@
 		Reference frame for GUI.
 	</brief_description>
 	<description>
-		A rectangle box that displays only a [member border_color] border color around its rectangle. [ReferenceRect] has no fill [Color].
+		A rectangle box that displays only a [member border_color] border color around its rectangle. [ReferenceRect] has no fill [Color]. If you need to display a rectangle filled with a solid color, consider using [ColorRect] instead.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Helps godotengine/godot-proposals#1687.

They use the same underlying `CanvasItem.draw_rect()` API.
