### PR TITLE
Add `border_width` to `ReferenceRect`

### DIFF
--- a/doc/classes/ReferenceRect.xml
+++ b/doc/classes/ReferenceRect.xml
@@ -14,6 +14,9 @@
 		<member name="border_color" type="Color" setter="set_border_color" getter="get_border_color" default="Color( 1, 0, 0, 1 )">
 			Sets the border [Color] of the [ReferenceRect].
 		</member>
+		<member name="border_width" type="float" setter="set_border_width" getter="get_border_width" default="1.0">
+			Sets the border width of the [ReferenceRect]. The border grows both inwards and outwards with respect to the rectangle box.
+		</member>
 		<member name="editor_only" type="bool" setter="set_editor_only" getter="get_editor_only" default="true">
 			If set to [code]true[/code], the [ReferenceRect] will only be visible while in editor. Otherwise, [ReferenceRect] will be visible in game.
 		</member>

--- a/scene/gui/reference_rect.cpp
+++ b/scene/gui/reference_rect.cpp
@@ -38,7 +38,7 @@ void ReferenceRect::_notification(int p_what) {
 			return;
 		}
 		if (Engine::get_singleton()->is_editor_hint() || !editor_only) {
-			draw_rect(Rect2(Point2(), get_size()), border_color, false);
+			draw_rect(Rect2(Point2(), get_size()), border_color, false, border_width);
 		}
 	}
 }
@@ -50,6 +50,15 @@ void ReferenceRect::set_border_color(const Color &p_color) {
 
 Color ReferenceRect::get_border_color() const {
 	return border_color;
+}
+
+void ReferenceRect::set_border_width(float p_width) {
+	border_width = MAX(0.0, p_width);
+	update();
+}
+
+float ReferenceRect::get_border_width() const {
+	return border_width;
 }
 
 void ReferenceRect::set_editor_only(const bool &p_enabled) {
@@ -65,14 +74,13 @@ void ReferenceRect::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_border_color"), &ReferenceRect::get_border_color);
 	ClassDB::bind_method(D_METHOD("set_border_color", "color"), &ReferenceRect::set_border_color);
 
+	ClassDB::bind_method(D_METHOD("get_border_width"), &ReferenceRect::get_border_width);
+	ClassDB::bind_method(D_METHOD("set_border_width", "width"), &ReferenceRect::set_border_width);
+
 	ClassDB::bind_method(D_METHOD("get_editor_only"), &ReferenceRect::get_editor_only);
 	ClassDB::bind_method(D_METHOD("set_editor_only", "enabled"), &ReferenceRect::set_editor_only);
 
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "border_color"), "set_border_color", "get_border_color");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "border_width", PROPERTY_HINT_RANGE, "0.0,5.0,0.1,or_greater"), "set_border_width", "get_border_width");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editor_only"), "set_editor_only", "get_editor_only");
-}
-
-ReferenceRect::ReferenceRect() {
-	border_color = Color(1, 0, 0);
-	editor_only = true;
 }

--- a/scene/gui/reference_rect.h
+++ b/scene/gui/reference_rect.h
@@ -35,18 +35,21 @@
 
 class ReferenceRect : public Control {
 	GDCLASS(ReferenceRect, Control);
-	Color border_color;
-	bool editor_only;
+
+	Color border_color = Color(1, 0, 0);
+	float border_width = 1.0;
+	bool editor_only = true;
 
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
-	ReferenceRect();
-
 	void set_border_color(const Color &p_color);
 	Color get_border_color() const;
+
+	void set_border_width(float p_width);
+	float get_border_width() const;
 
 	void set_editor_only(const bool &p_enabled);
 	bool get_editor_only() const;


### PR DESCRIPTION
With #42906, helps godotengine/godot-proposals#1687.

These changes ***complement*** the engine's functionality as provided by `CanvasItem.draw_rect()` used by both `ReferenceRect` and `ColorRect`. Yet `ColorRect` cannot draw non-filled rectangles, so these changes may be worth to cherry-pick to 3.2. But perhaps it's worth to merge the `ReferenceRect` functionality into `ColorRect` in 4.0, as done in #42931.