### PR TITLE
Fix debanding slightly brightening the whole viewport

### DIFF
--- a/servers/rendering/rasterizer_rd/shaders/tonemap.glsl
+++ b/servers/rendering/rasterizer_rd/shaders/tonemap.glsl
@@ -311,7 +311,8 @@ vec3 screen_space_dither(vec2 frag_coord) {
 	vec3 dither = vec3(dot(vec2(171.0, 231.0), frag_coord));
 	dither.rgb = fract(dither.rgb / vec3(103.0, 71.0, 97.0));
 
-	return dither.rgb / 255.0;
+	// Subtract 0.5 to avoid slightly brightening the whole viewport.
+	return (dither.rgb - 0.5) / 255.0;
 }
 
 void main() {
@@ -338,7 +339,8 @@ void main() {
 		color = do_fxaa(color, exposure, uv_interp);
 	}
 	if (params.use_debanding) {
-		// Debanding should be done before tonemapping.
+		// For best results, debanding should be done before tonemapping.
+		// Otherwise, we're adding noise to an already-quantized image.
 		color += screen_space_dither(gl_FragCoord.xy);
 	}
 	color = apply_tonemapping(color, params.white);


### PR DESCRIPTION
Thanks to Mikkel Gjoel on Twitter for the tip :slightly_smiling_face: 

## Preview

### Debanding disabled

![Debanding disabled](https://user-images.githubusercontent.com/180032/96510654-2613f500-125e-11eb-9937-27fa809a2944.png)

### Debanding enabled (old)

![Debanding enabled (old)](https://user-images.githubusercontent.com/180032/96510667-29a77c00-125e-11eb-9c48-33a43aab178c.png)

### Debanding enabled (new)

*This is the version included in the PR.*

![Debanding enabled (new)](https://user-images.githubusercontent.com/180032/96510664-28764f00-125e-11eb-866a-d2f6f434eb2a.png)

### Debanding enabled (attempt to run it after tonemapping and linear -> sRGB conversion, doesn't look as good when viewed at default browser scale)

*This was attempted for testing purposes and isn't included in this PR.*

![Debanding enabled (attempt to run it after tonemapping and linear -> sRGB conversion, doesn't look as good)](https://user-images.githubusercontent.com/180032/96510662-27ddb880-125e-11eb-8118-4fb9b840e6e2.png)