### PR TITLE
Removed underscore from GraphEdit begin/end_node_move signals

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -193,14 +193,9 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="_begin_node_move">
+		<signal name="begin_node_move">
 			<description>
 				Emitted at the beginning of a GraphNode movement.
-			</description>
-		</signal>
-		<signal name="_end_node_move">
-			<description>
-				Emitted at the end of a GraphNode movement.
 			</description>
 		</signal>
 		<signal name="connection_from_empty">
@@ -264,6 +259,11 @@
 		<signal name="duplicate_nodes_request">
 			<description>
 				Emitted when a GraphNode is attempted to be duplicated in the GraphEdit.
+			</description>
+		</signal>
+		<signal name="end_node_move">
+			<description>
+				Emitted at the end of a GraphNode movement.
 			</description>
 		</signal>
 		<signal name="node_selected">

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -4783,8 +4783,8 @@ VisualScriptEditor::VisualScriptEditor() {
 	graph->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	graph->set_anchors_and_margins_preset(Control::PRESET_WIDE);
 	graph->connect("node_selected", callable_mp(this, &VisualScriptEditor::_node_selected));
-	graph->connect("_begin_node_move", callable_mp(this, &VisualScriptEditor::_begin_node_move));
-	graph->connect("_end_node_move", callable_mp(this, &VisualScriptEditor::_end_node_move));
+	graph->connect("begin_node_move", callable_mp(this, &VisualScriptEditor::_begin_node_move));
+	graph->connect("end_node_move", callable_mp(this, &VisualScriptEditor::_end_node_move));
 	graph->connect("delete_nodes_request", callable_mp(this, &VisualScriptEditor::_on_nodes_delete));
 	graph->connect("duplicate_nodes_request", callable_mp(this, &VisualScriptEditor::_on_nodes_duplicate));
 	graph->connect("gui_input", callable_mp(this, &VisualScriptEditor::_graph_gui_input));

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -776,7 +776,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 
 	if (mm.is_valid() && dragging) {
 		if (!moving_selection) {
-			emit_signal("_begin_node_move");
+			emit_signal("begin_node_move");
 			moving_selection = true;
 		}
 
@@ -895,7 +895,7 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 			}
 
 			if (moving_selection) {
-				emit_signal("_end_node_move");
+				emit_signal("end_node_move");
 				moving_selection = false;
 			}
 
@@ -1287,8 +1287,8 @@ void GraphEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("connection_to_empty", PropertyInfo(Variant::STRING_NAME, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));
 	ADD_SIGNAL(MethodInfo("connection_from_empty", PropertyInfo(Variant::STRING_NAME, "to"), PropertyInfo(Variant::INT, "to_slot"), PropertyInfo(Variant::VECTOR2, "release_position")));
 	ADD_SIGNAL(MethodInfo("delete_nodes_request"));
-	ADD_SIGNAL(MethodInfo("_begin_node_move"));
-	ADD_SIGNAL(MethodInfo("_end_node_move"));
+	ADD_SIGNAL(MethodInfo("begin_node_move"));
+	ADD_SIGNAL(MethodInfo("end_node_move"));
 	ADD_SIGNAL(MethodInfo("scroll_offset_changed", PropertyInfo(Variant::VECTOR2, "ofs")));
 }
 


### PR DESCRIPTION
There is no other signal across the engine with an underscore prefix - the only exception is GraphEdit. I think this should be fixed.