### PR TITLE
Change render octree balance default

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1202,7 +1202,7 @@
 			See also [member rendering/quality/skinning/force_software_skinning].
 			[b]Note:[/b] When the software skinning fallback is triggered, custom vertex shaders will behave in a different way, because the bone transform will be already applied to the modelview matrix.
 		</member>
-		<member name="rendering/quality/spatial_partitioning/render_tree_balance" type="float" setter="" getter="" default="0.17">
+		<member name="rendering/quality/spatial_partitioning/render_tree_balance" type="float" setter="" getter="" default="0.0">
 			The rendering octree balance can be changed to favor smaller ([code]0[/code]), or larger ([code]1[/code]) branches.
 			Larger branches can increase performance significantly in some projects.
 		</member>

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2441,7 +2441,7 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/quality/skinning/force_software_skinning", false);
 
 	const char *sz_balance_render_tree = "rendering/quality/spatial_partitioning/render_tree_balance";
-	GLOBAL_DEF(sz_balance_render_tree, 0.17f);
+	GLOBAL_DEF(sz_balance_render_tree, 0.0f);
 	ProjectSettings::get_singleton()->set_custom_property_info(sz_balance_render_tree, PropertyInfo(Variant::REAL, sz_balance_render_tree, PROPERTY_HINT_RANGE, "0.0,1.0,0.01"));
 
 	GLOBAL_DEF("rendering/quality/2d/use_software_skinning", true);


### PR DESCRIPTION
Another bug in the octree has been discovered which can cause flickering in rare circumstances : #42895

For safety until this is fixed properly this PR reverts the default settings for the octree to match the old behaviour, which doesn't appear exhibit the bug (or at least not as readily). These can still be overridden via the project setting.

As discussed with @akien-mga 

This is just a temporary fix for the beta, it isn't a massive concern as the bug seems rare, and indeed this PR does swap one bug for another (the runaway depth recursion susceptibility of the old octree #38142, when there is no minimum number of elements required before octant splitting). But probably worth doing as a safety measure if I haven't identified the bug source in time.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
