### PR TITLE
Give each RigidBody its own DirectBodyState wrapper.

### DIFF
--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -850,8 +850,8 @@ bool BulletPhysicsServer3D::body_is_ray_pickable(RID p_body) const {
 
 PhysicsDirectBodyState3D *BulletPhysicsServer3D::body_get_direct_state(RID p_body) {
 	RigidBodyBullet *body = rigid_body_owner.getornull(p_body);
-	ERR_FAIL_COND_V(!body, nullptr);
-	return BulletPhysicsDirectBodyState3D::get_singleton(body);
+	ERR_FAIL_COND_V_MSG(!body, nullptr, "Body with RID " + itos(p_body.get_id()) + " not owned by this server.");
+	return body->get_direct_state();
 }
 
 bool BulletPhysicsServer3D::body_test_motion(RID p_body, const Transform &p_from, const Vector3 &p_motion, bool p_infinite_inertia, MotionResult *r_result, bool p_exclude_raycast_shapes) {
@@ -1522,15 +1522,12 @@ void BulletPhysicsServer3D::free(RID p_rid) {
 }
 
 void BulletPhysicsServer3D::init() {
-	BulletPhysicsDirectBodyState3D::initSingleton();
 }
 
 void BulletPhysicsServer3D::step(real_t p_deltaTime) {
 	if (!active) {
 		return;
 	}
-
-	BulletPhysicsDirectBodyState3D::singleton_setDeltaTime(p_deltaTime);
 
 	for (int i = 0; i < active_spaces_count; ++i) {
 		active_spaces[i]->step(p_deltaTime);
@@ -1548,7 +1545,6 @@ void BulletPhysicsServer3D::flush_queries() {
 }
 
 void BulletPhysicsServer3D::finish() {
-	BulletPhysicsDirectBodyState3D::destroySingleton();
 }
 
 int BulletPhysicsServer3D::get_process_info(ProcessInfo p_info) {

--- a/modules/bullet/rigid_body_bullet.h
+++ b/modules/bullet/rigid_body_bullet.h
@@ -45,49 +45,15 @@ class AreaBullet;
 class SpaceBullet;
 class btRigidBody;
 class GodotMotionState;
-class BulletPhysicsDirectBodyState3D;
 
-/// This class could be used in multi thread with few changes but currently
-/// is set to be only in one single thread.
-///
-/// In the system there is only one object at a time that manage all bodies and is
-/// created by BulletPhysicsServer3D and is held by the "singleton" variable of this class
-/// Each time something require it, the body must be set again.
 class BulletPhysicsDirectBodyState3D : public PhysicsDirectBodyState3D {
 	GDCLASS(BulletPhysicsDirectBodyState3D, PhysicsDirectBodyState3D);
 
-	static BulletPhysicsDirectBodyState3D *singleton;
-
-public:
-	/// This class avoid the creation of more object of this class
-	static void initSingleton() {
-		if (!singleton) {
-			singleton = memnew(BulletPhysicsDirectBodyState3D);
-		}
-	}
-
-	static void destroySingleton() {
-		memdelete(singleton);
-		singleton = nullptr;
-	}
-
-	static void singleton_setDeltaTime(real_t p_deltaTime) {
-		singleton->deltaTime = p_deltaTime;
-	}
-
-	static BulletPhysicsDirectBodyState3D *get_singleton(RigidBodyBullet *p_body) {
-		singleton->body = p_body;
-		return singleton;
-	}
-
 public:
 	RigidBodyBullet *body = nullptr;
-	real_t deltaTime = 0.0;
 
-private:
 	BulletPhysicsDirectBodyState3D() {}
 
-public:
 	virtual Vector3 get_total_gravity() const override;
 	virtual real_t get_total_angular_damp() const override;
 	virtual real_t get_total_linear_damp() const override;
@@ -133,7 +99,7 @@ public:
 	virtual int get_contact_collider_shape(int p_contact_idx) const override;
 	virtual Vector3 get_contact_collider_velocity_at_position(int p_contact_idx) const override;
 
-	virtual real_t get_step() const override { return deltaTime; }
+	virtual real_t get_step() const override;
 	virtual void integrate_forces() override {
 		// Skip the execution of this function
 	}
@@ -185,6 +151,7 @@ public:
 	};
 
 private:
+	BulletPhysicsDirectBodyState3D *direct_access = nullptr;
 	friend class BulletPhysicsDirectBodyState3D;
 
 	// This is required only for Kinematic movement
@@ -228,6 +195,8 @@ private:
 public:
 	RigidBodyBullet();
 	~RigidBodyBullet();
+
+	BulletPhysicsDirectBodyState3D *get_direct_state() const { return direct_access; }
 
 	void init_kinematic_utilities();
 	void destroy_kinematic_utilities();

--- a/servers/physics_2d/body_2d_sw.cpp
+++ b/servers/physics_2d/body_2d_sw.cpp
@@ -585,10 +585,7 @@ void Body2DSW::wakeup_neighbours() {
 
 void Body2DSW::call_queries() {
 	if (fi_callback) {
-		PhysicsDirectBodyState2DSW *dbs = PhysicsDirectBodyState2DSW::singleton;
-		dbs->body = this;
-
-		Variant v = dbs;
+		Variant v = direct_access;
 		const Variant *vp[2] = { &v, &fi_callback->callback_udata };
 
 		Object *obj = ObjectDB::get_instance(fi_callback->id);
@@ -674,18 +671,24 @@ Body2DSW::Body2DSW() :
 	continuous_cd_mode = PhysicsServer2D::CCD_MODE_DISABLED;
 	can_sleep = true;
 	fi_callback = nullptr;
+
+	direct_access = memnew(PhysicsDirectBodyState2DSW);
+	direct_access->body = this;
 }
 
 Body2DSW::~Body2DSW() {
+	memdelete(direct_access);
 	if (fi_callback) {
 		memdelete(fi_callback);
 	}
 }
 
-PhysicsDirectBodyState2DSW *PhysicsDirectBodyState2DSW::singleton = nullptr;
-
 PhysicsDirectSpaceState2D *PhysicsDirectBodyState2DSW::get_space_state() {
 	return body->get_space()->get_direct_state();
+}
+
+real_t PhysicsDirectBodyState2DSW::get_step() const {
+	return body->get_space()->get_step();
 }
 
 Variant PhysicsDirectBodyState2DSW::get_contact_collider_shape_metadata(int p_contact_idx) const {

--- a/servers/physics_2d/body_2d_sw.h
+++ b/servers/physics_2d/body_2d_sw.h
@@ -38,6 +38,7 @@
 #include "core/templates/vset.h"
 
 class Constraint2DSW;
+class PhysicsDirectBodyState2DSW;
 
 class Body2DSW : public CollisionObject2DSW {
 	PhysicsServer2D::BodyMode mode;
@@ -130,6 +131,7 @@ class Body2DSW : public CollisionObject2DSW {
 
 	_FORCE_INLINE_ void _compute_area_gravity_and_dampenings(const Area2DSW *p_area);
 
+	PhysicsDirectBodyState2DSW *direct_access = nullptr;
 	friend class PhysicsDirectBodyState2DSW; // i give up, too many functions to expose
 
 public:
@@ -289,6 +291,8 @@ public:
 
 	bool sleep_test(real_t p_step);
 
+	PhysicsDirectBodyState2DSW *get_direct_state() const { return direct_access; }
+
 	Body2DSW();
 	~Body2DSW();
 };
@@ -341,9 +345,7 @@ class PhysicsDirectBodyState2DSW : public PhysicsDirectBodyState2D {
 	GDCLASS(PhysicsDirectBodyState2DSW, PhysicsDirectBodyState2D);
 
 public:
-	static PhysicsDirectBodyState2DSW *singleton;
-	Body2DSW *body;
-	real_t step;
+	Body2DSW *body = nullptr;
 
 	virtual Vector2 get_total_gravity() const override { return body->gravity; } // get gravity vector working on this body space/area
 	virtual real_t get_total_angular_damp() const override { return body->area_angular_damp; } // get density of this body space/area
@@ -411,11 +413,9 @@ public:
 
 	virtual PhysicsDirectSpaceState2D *get_space_state() override;
 
-	virtual real_t get_step() const override { return step; }
-	PhysicsDirectBodyState2DSW() {
-		singleton = this;
-		body = nullptr;
-	}
+	virtual real_t get_step() const override;
+
+	PhysicsDirectBodyState2DSW() {}
 };
 
 #endif // BODY_2D_SW_H

--- a/servers/physics_2d/physics_server_2d_sw.h
+++ b/servers/physics_2d/physics_server_2d_sw.h
@@ -46,7 +46,6 @@ class PhysicsServer2DSW : public PhysicsServer2D {
 	bool active;
 	int iterations;
 	bool doing_sync;
-	real_t last_step;
 
 	int island_count;
 	int active_objects;
@@ -58,8 +57,6 @@ class PhysicsServer2DSW : public PhysicsServer2D {
 
 	Step2DSW *stepper;
 	Set<const Space2DSW *> active_spaces;
-
-	PhysicsDirectBodyState2DSW *direct_state;
 
 	mutable RID_PtrOwner<Shape2DSW, true> shape_owner;
 	mutable RID_PtrOwner<Space2DSW, true> space_owner;

--- a/servers/physics_2d/space_2d_sw.cpp
+++ b/servers/physics_2d/space_2d_sw.cpp
@@ -803,7 +803,7 @@ bool Space2DSW::test_body_motion(Body2DSW *p_body, const Transform2D &p_from, co
 								//fix for moving platforms (kinematic and dynamic), margin is increased by how much it moved in the given direction
 								Vector2 lv = b->get_linear_velocity();
 								//compute displacement from linear velocity
-								Vector2 motion = lv * PhysicsDirectBodyState2DSW::singleton->step;
+								Vector2 motion = lv * step;
 								real_t motion_len = motion.length();
 								motion.normalize();
 								cbk.valid_depth += motion_len * MAX(motion.dot(-cbk.valid_dir), 0.0);

--- a/servers/physics_2d/space_2d_sw.h
+++ b/servers/physics_2d/space_2d_sw.h
@@ -117,6 +117,7 @@ private:
 
 	bool locked;
 
+	real_t step;
 	int island_count;
 	int active_objects;
 	int collision_pairs;
@@ -131,6 +132,9 @@ private:
 public:
 	_FORCE_INLINE_ void set_self(const RID &p_self) { self = p_self; }
 	_FORCE_INLINE_ RID get_self() const { return self; }
+
+	_FORCE_INLINE_ void set_step(const real_t &p_step) { step = p_step; }
+	_FORCE_INLINE_ real_t get_step() const { return step; }
 
 	void set_default_area(Area2DSW *p_area) { area = p_area; }
 	Area2DSW *get_default_area() const { return area; }

--- a/servers/physics_2d/step_2d_sw.cpp
+++ b/servers/physics_2d/step_2d_sw.cpp
@@ -130,7 +130,7 @@ void Step2DSW::_check_suspend(Body2DSW *p_island, real_t p_delta) {
 
 void Step2DSW::step(Space2DSW *p_space, real_t p_delta, int p_iterations) {
 	p_space->lock(); // can't access space during this
-
+	p_space->set_step(p_delta);
 	p_space->setup(); //update inertias, etc
 
 	const SelfList<Body2DSW>::List *body_list = &p_space->get_active_body_list();

--- a/servers/physics_3d/body_3d_sw.cpp
+++ b/servers/physics_3d/body_3d_sw.cpp
@@ -682,10 +682,7 @@ void Body3DSW::wakeup_neighbours() {
 
 void Body3DSW::call_queries() {
 	if (fi_callback) {
-		PhysicsDirectBodyState3DSW *dbs = PhysicsDirectBodyState3DSW::singleton;
-		dbs->body = this;
-
-		Variant v = dbs;
+		Variant v = direct_access;
 
 		Object *obj = ObjectDB::get_instance(fi_callback->id);
 		if (!obj) {
@@ -772,16 +769,22 @@ Body3DSW::Body3DSW() :
 	continuous_cd = false;
 	can_sleep = true;
 	fi_callback = nullptr;
+
+	direct_access = memnew(PhysicsDirectBodyState3DSW);
+	direct_access->body = this;
 }
 
 Body3DSW::~Body3DSW() {
+	memdelete(direct_access);
 	if (fi_callback) {
 		memdelete(fi_callback);
 	}
 }
 
-PhysicsDirectBodyState3DSW *PhysicsDirectBodyState3DSW::singleton = nullptr;
-
 PhysicsDirectSpaceState3D *PhysicsDirectBodyState3DSW::get_space_state() {
 	return body->get_space()->get_direct_state();
+}
+
+real_t PhysicsDirectBodyState3DSW::get_step() const {
+	return body->get_space()->get_step();
 }

--- a/servers/physics_3d/body_3d_sw.h
+++ b/servers/physics_3d/body_3d_sw.h
@@ -36,6 +36,7 @@
 #include "core/templates/vset.h"
 
 class Constraint3DSW;
+class PhysicsDirectBodyState3DSW;
 
 class Body3DSW : public CollisionObject3DSW {
 	PhysicsServer3D::BodyMode mode;
@@ -142,6 +143,7 @@ class Body3DSW : public CollisionObject3DSW {
 
 	_FORCE_INLINE_ void _update_transform_dependant();
 
+	PhysicsDirectBodyState3DSW *direct_access = nullptr;
 	friend class PhysicsDirectBodyState3DSW; // i give up, too many functions to expose
 
 public:
@@ -326,6 +328,8 @@ public:
 
 	bool sleep_test(real_t p_step);
 
+	PhysicsDirectBodyState3DSW *get_direct_state() const { return direct_access; }
+
 	Body3DSW();
 	~Body3DSW();
 };
@@ -378,9 +382,7 @@ class PhysicsDirectBodyState3DSW : public PhysicsDirectBodyState3D {
 	GDCLASS(PhysicsDirectBodyState3DSW, PhysicsDirectBodyState3D);
 
 public:
-	static PhysicsDirectBodyState3DSW *singleton;
-	Body3DSW *body;
-	real_t step;
+	Body3DSW *body = nullptr;
 
 	virtual Vector3 get_total_gravity() const override { return body->gravity; } // get gravity vector working on this body space/area
 	virtual real_t get_total_angular_damp() const override { return body->area_angular_damp; } // get density of this body space/area
@@ -457,11 +459,9 @@ public:
 
 	virtual PhysicsDirectSpaceState3D *get_space_state() override;
 
-	virtual real_t get_step() const override { return step; }
-	PhysicsDirectBodyState3DSW() {
-		singleton = this;
-		body = nullptr;
-	}
+	virtual real_t get_step() const override;
+
+	PhysicsDirectBodyState3DSW() {}
 };
 
 #endif // BODY__SW_H

--- a/servers/physics_3d/physics_server_3d_sw.h
+++ b/servers/physics_3d/physics_server_3d_sw.h
@@ -44,7 +44,6 @@ class PhysicsServer3DSW : public PhysicsServer3D {
 	friend class PhysicsDirectSpaceState3DSW;
 	bool active;
 	int iterations;
-	real_t last_step;
 
 	int island_count;
 	int active_objects;
@@ -56,8 +55,6 @@ class PhysicsServer3DSW : public PhysicsServer3D {
 
 	Step3DSW *stepper;
 	Set<const Space3DSW *> active_spaces;
-
-	PhysicsDirectBodyState3DSW *direct_state;
 
 	mutable RID_PtrOwner<Shape3DSW, true> shape_owner;
 	mutable RID_PtrOwner<Space3DSW, true> space_owner;

--- a/servers/physics_3d/space_3d_sw.h
+++ b/servers/physics_3d/space_3d_sw.h
@@ -110,6 +110,7 @@ private:
 
 	bool locked;
 
+	real_t step;
 	int island_count;
 	int active_objects;
 	int collision_pairs;
@@ -126,6 +127,9 @@ private:
 public:
 	_FORCE_INLINE_ void set_self(const RID &p_self) { self = p_self; }
 	_FORCE_INLINE_ RID get_self() const { return self; }
+
+	_FORCE_INLINE_ void set_step(const real_t &p_step) { step = p_step; }
+	_FORCE_INLINE_ real_t get_step() const { return step; }
 
 	void set_default_area(Area3DSW *p_area) { area = p_area; }
 	Area3DSW *get_default_area() const { return area; }

--- a/servers/physics_3d/step_3d_sw.cpp
+++ b/servers/physics_3d/step_3d_sw.cpp
@@ -141,7 +141,7 @@ void Step3DSW::_check_suspend(Body3DSW *p_island, real_t p_delta) {
 
 void Step3DSW::step(Space3DSW *p_space, real_t p_delta, int p_iterations) {
 	p_space->lock(); // can't access space during this
-
+	p_space->set_step(p_delta);
 	p_space->setup(); //update inertias, etc
 
 	const SelfList<Body3DSW>::List *body_list = &p_space->get_active_body_list();


### PR DESCRIPTION
Currently 2D and 3D, Godot and Bullet physics servers have a singleton wrapper for `DirectBodyState`. This means that only one `RigidBody`'s `DirectBodyState` can be accessed at any one time. This is an unnecessary and cumbersome restriction that is not thread safe. Aside from also being used to store the current step size, it's just a wrapper, so I can see no reason why this should be a singleton.

This PR gives each `RigidBody` its own `DirectBodyState` wrapper and moves the current step size to `Space`, where it belongs and already done in Bullet.

Fixes #42877.
