### PR TITLE
Add `filled`, `border_width`, `editor_only` properties to `ColorRect`

### DIFF
--- a/doc/classes/ColorRect.xml
+++ b/doc/classes/ColorRect.xml
@@ -4,7 +4,8 @@
 		Colored rectangle.
 	</brief_description>
 	<description>
-		Displays a colored rectangle.
+		Displays a rectangle filled with a solid [member color] by default, but can be used as a reference box which displays only a border around its rectangle.
+		If you need more advanced functionality, [ColorRect] uses [method CanvasItem.draw_rect] for drawing rectangles, so you can extend [ColorRect] or create a new class via script.
 	</description>
 	<tutorials>
 		<link title="2D Dodge The Creeps Demo">https://godotengine.org/asset-library/asset/515</link>
@@ -12,8 +13,12 @@
 	<methods>
 	</methods>
 	<members>
-		<member name="color" type="Color" setter="set_frame_color" getter="get_frame_color" default="Color( 1, 1, 1, 1 )">
-			The fill color.
+		<member name="border_width" type="float" setter="set_border_width" getter="get_border_width" default="1.0">
+			Sets the border width of the [ColorRect]. The border grows both inwards and outwards with respect to the rectangle box.
+			[b]Note:[/b] This property has no effect when [member filled] is [code]true[/code].
+		</member>
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">
+			Sets the rectangle's fill and border color.
 			[codeblocks]
 			[gdscript]
 			$ColorRect.color = Color(1, 0, 0, 1) # Set ColorRect's color to red.
@@ -22,6 +27,12 @@
 			GetNode&lt;ColorRect&gt;("ColorRect").Color = new Color(1, 0, 0, 1); // Set ColorRect's color to red.
 			[/csharp]
 			[/codeblocks]
+		</member>
+		<member name="editor_only" type="bool" setter="set_editor_only" getter="is_editor_only" default="false">
+			If set to [code]true[/code], the [ColorRect] will only be visible while in editor. Otherwise, [ColorRect] will be visible in game.
+		</member>
+		<member name="filled" type="bool" setter="set_filled" getter="is_filled" default="true">
+			If set to [code]true[/code], the [ColorRect]'s area is filled with a solid [member color], otherwise only the rectangle's border is displayed.
 		</member>
 	</members>
 	<constants>

--- a/scene/gui/color_rect.cpp
+++ b/scene/gui/color_rect.cpp
@@ -39,9 +39,50 @@ Color ColorRect::get_color() const {
 	return color;
 }
 
+void ColorRect::set_filled(bool p_filled) {
+	filled = p_filled;
+	update();
+	_change_notify();
+}
+
+bool ColorRect::is_filled() const {
+	return filled;
+}
+
+void ColorRect::set_border_width(float p_width) {
+	border_width = p_width;
+	update();
+}
+
+float ColorRect::get_border_width() const {
+	return border_width;
+}
+
+void ColorRect::set_editor_only(bool p_enabled) {
+	editor_only = p_enabled;
+	update();
+}
+
+bool ColorRect::is_editor_only() const {
+	return editor_only;
+}
+
 void ColorRect::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
-		draw_rect(Rect2(Point2(), get_size()), color);
+		if (!is_inside_tree()) {
+			return;
+		}
+		if (Engine::get_singleton()->is_editor_hint() || !editor_only) {
+			draw_rect(Rect2(Point2(), get_size()), color, filled, filled ? 1.0 : border_width);
+		}
+	}
+}
+
+void ColorRect::_validate_property(PropertyInfo &property) const {
+	if (property.name == "border_width") {
+		if (filled) {
+			property.usage = PROPERTY_USAGE_NOEDITOR;
+		}
 	}
 }
 
@@ -49,5 +90,17 @@ void ColorRect::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_color", "color"), &ColorRect::set_color);
 	ClassDB::bind_method(D_METHOD("get_color"), &ColorRect::get_color);
 
+	ClassDB::bind_method(D_METHOD("set_filled", "filled"), &ColorRect::set_filled);
+	ClassDB::bind_method(D_METHOD("is_filled"), &ColorRect::is_filled);
+
+	ClassDB::bind_method(D_METHOD("set_border_width", "width"), &ColorRect::set_border_width);
+	ClassDB::bind_method(D_METHOD("get_border_width"), &ColorRect::get_border_width);
+
+	ClassDB::bind_method(D_METHOD("is_editor_only"), &ColorRect::is_editor_only);
+	ClassDB::bind_method(D_METHOD("set_editor_only", "enabled"), &ColorRect::set_editor_only);
+
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filled"), "set_filled", "is_filled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "border_width", PROPERTY_HINT_RANGE, "0.0,5.0,0.1,or_greater"), "set_border_width", "get_border_width"); // Should be after `filled`.
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editor_only"), "set_editor_only", "is_editor_only");
 }

--- a/scene/gui/color_rect.h
+++ b/scene/gui/color_rect.h
@@ -37,14 +37,27 @@ class ColorRect : public Control {
 	GDCLASS(ColorRect, Control);
 
 	Color color = Color(1, 1, 1);
+	bool filled = true;
+	float border_width = 1.0; // Has no effect when `filled` is `true`.
+	bool editor_only = false;
 
 protected:
 	void _notification(int p_what);
+	virtual void _validate_property(PropertyInfo &property) const override;
 	static void _bind_methods();
 
 public:
 	void set_color(const Color &p_color);
 	Color get_color() const;
+
+	void set_filled(bool p_filled);
+	bool is_filled() const;
+
+	void set_border_width(float p_width);
+	float get_border_width() const;
+
+	void set_editor_only(bool p_enabled);
+	bool is_editor_only() const;
 };
 
 #endif // COLOR_RECT_H


### PR DESCRIPTION
Closes godotengine/godot-proposals#1687.

![godot_color_rect_ref](https://user-images.githubusercontent.com/17108460/96575560-91e77380-12d9-11eb-9730-4dcb5997f3d0.png)

In effect, this merges the functionality behind existing [`ReferenceRect`](https://docs.godotengine.org/en/3.2/classes/class_referencerect.html) into [`ColorRect`](https://docs.godotengine.org/en/3.2/classes/class_colorrect.html). This way, `ReferenceRect` can be easily replicated via a simple script extending `ColorRect`:

```gdscript
@tool
class_name EditorRect extends ColorRect

func _init():
	color = Color.red
	filled = false
	editor_only = true
```

In theory, `ReferenceRect` can be removed from 4.0 because of that, but I have no strong opinion about this. If someone wants to remove `ReferenceRect` class, then I'll leave this up to others.

Note that the `antialiased` parameter is not present in 4.0, only in 3.2.

See also #42906 and #42907.

**Test project:**
[color_rect.zip](https://github.com/godotengine/godot/files/5408104/color_rect.zip)

