### PR TITLE
3.2: Fixes crash after using enums in export variables

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4630,6 +4630,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 						if (subexpr->type != Node::TYPE_CONSTANT) {
 							current_export = PropertyInfo();
 							_set_error("Expected a constant expression.");
+							return;
 						}
 
 						Variant constant = static_cast<ConstantNode *>(subexpr)->value;


### PR DESCRIPTION
This PR fixes #38168.

Accessing `static_cast<ConstantNode *>(subexpr)->value` when `subexpr`'s type is not constant yields invalid value, thus the crash.

This is a PR against the 3.2 branch because the new GDScript is now merged into master, replacing `export` keyword with `@export` annotation, so the issue is no longer reproduciable on the master branch.