### PR TITLE
Fix custom property editor to correctly show Basis

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -1697,13 +1697,18 @@ void CustomPropertyEditor::config_value_editors(int p_amount, int p_columns, int
 	int cell_width = 95;
 	int cell_height = 25;
 	int cell_margin = 5;
-	int hor_spacing = 5; // Spacing between labels and their values
-
 	int rows = ((p_amount - 1) / p_columns) + 1;
 
 	set_size(Size2(cell_margin + p_label_w + (cell_width + cell_margin + p_label_w) * p_columns, cell_margin + (cell_height + cell_margin) * rows) * EDSCALE);
 
 	for (int i = 0; i < MAX_VALUE_EDITORS; i++) {
+		value_label[i]->get_parent()->remove_child(value_label[i]);
+		value_editor[i]->get_parent()->remove_child(value_editor[i]);
+
+		int box_id = i / p_columns;
+		value_hboxes[box_id]->add_child(value_label[i]);
+		value_hboxes[box_id]->add_child(value_editor[i]);
+
 		if (i < MAX_VALUE_EDITORS / 4) {
 			if (i <= p_amount / 4) {
 				value_hboxes[i]->show();
@@ -1712,16 +1717,10 @@ void CustomPropertyEditor::config_value_editors(int p_amount, int p_columns, int
 			}
 		}
 
-		int c = i % p_columns;
-		int r = i / p_columns;
-
 		if (i < p_amount) {
 			value_editor[i]->show();
 			value_label[i]->show();
 			value_label[i]->set_text(i < p_strings.size() ? p_strings[i] : String(""));
-			value_editor[i]->set_position(Point2(cell_margin + p_label_w + hor_spacing + (cell_width + cell_margin + p_label_w + hor_spacing) * c, cell_margin + (cell_height + cell_margin) * r) * EDSCALE);
-			value_editor[i]->set_size(Size2(cell_width, cell_height));
-			value_label[i]->set_position(Point2(cell_margin + (cell_width + cell_margin + p_label_w + hor_spacing) * c, cell_margin + (cell_height + cell_margin) * r) * EDSCALE);
 			value_editor[i]->set_editable(!read_only);
 		} else {
 			value_editor[i]->hide();


### PR DESCRIPTION
Currently, it has an incorrect layout:

![image](https://user-images.githubusercontent.com/3036176/96602849-1f3bbf80-12fc-11eb-845c-180a6cbf56e3.png)

After fix:

![image](https://user-images.githubusercontent.com/3036176/96602951-3da1bb00-12fc-11eb-8bf1-0302c0c5e13d.png)

also removed some redundant code that does not apply to these elements after #39438.