### PR TITLE
CI: Don't upload linux-sanitizers artifacts

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -138,12 +138,6 @@ jobs:
         run: |
           ./bin/godot.linuxbsd.tools.64s --test
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ github.job }}
-          path: bin/*
-          retention-days: 14
-
   linux-template-mono:
     runs-on: "ubuntu-20.04"
     name: Template w/ Mono (target=release, tools=no)


### PR DESCRIPTION
It's 1.5 GB, that's maybe a bit overkill.