### PR TITLE
[WIP] Default to the first usable extension for saving.

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -869,6 +869,17 @@ void EditorFileDialog::_filter_selected(int) {
 void EditorFileDialog::update_filters() {
 	filter->clear();
 
+	for (int i = 0; i < filters.size(); i++) {
+		String flt = filters[i].get_slice(";", 0).strip_edges();
+		String desc = filters[i].get_slice(";", 1).strip_edges();
+		if (desc.length()) {
+			filter->add_item(desc + " (" + flt + ")");
+		} else {
+			filter->add_item("(" + flt + ")");
+		}
+	}
+
+	filter->add_item(TTR("All Files (*)"));
 	if (filters.size() > 1) {
 		String all_filters;
 
@@ -888,17 +899,6 @@ void EditorFileDialog::update_filters() {
 
 		filter->add_item(TTR("All Recognized") + " (" + all_filters + ")");
 	}
-	for (int i = 0; i < filters.size(); i++) {
-		String flt = filters[i].get_slice(";", 0).strip_edges();
-		String desc = filters[i].get_slice(";", 1).strip_edges();
-		if (desc.length()) {
-			filter->add_item(desc + " (" + flt + ")");
-		} else {
-			filter->add_item("(" + flt + ")");
-		}
-	}
-
-	filter->add_item(TTR("All Files (*)"));
 }
 
 void EditorFileDialog::clear_filters() {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -532,6 +532,18 @@ void FileDialog::_filter_selected(int) {
 void FileDialog::update_filters() {
 	filter->clear();
 
+	for (int i = 0; i < filters.size(); i++) {
+		String flt = filters[i].get_slice(";", 0).strip_edges();
+		String desc = filters[i].get_slice(";", 1).strip_edges();
+		if (desc.length()) {
+			filter->add_item(String(tr(desc)) + " (" + flt + ")");
+		} else {
+			filter->add_item("(" + flt + ")");
+		}
+	}
+
+	filter->add_item(RTR("All Files (*)"));
+
 	if (filters.size() > 1) {
 		String all_filters;
 
@@ -551,17 +563,6 @@ void FileDialog::update_filters() {
 
 		filter->add_item(RTR("All Recognized") + " (" + all_filters + ")");
 	}
-	for (int i = 0; i < filters.size(); i++) {
-		String flt = filters[i].get_slice(";", 0).strip_edges();
-		String desc = filters[i].get_slice(";", 1).strip_edges();
-		if (desc.length()) {
-			filter->add_item(String(tr(desc)) + " (" + flt + ")");
-		} else {
-			filter->add_item("(" + flt + ")");
-		}
-	}
-
-	filter->add_item(RTR("All Files (*)"));
 }
 
 void FileDialog::clear_filters() {


### PR DESCRIPTION
Fixes when saving a resource, if you don't have the right extension selected, it won't save correctly.

Sponsored by IMVU.

I think we should somehow split the label from the filter contents. Not sure, because now we filter the browser to the default too.

> The problem is, you cannot change extension by writing in the field edit it will use whatever is selected in the picker
> so saving a TileSet and renaming the file to res, will still save it as .res.tres
> the "All recognized" option did not have this issue i think


>"I"
> would expect the field edit to update
> and change the extension
> to what you just picked
> or have the dialog not autocomplete the extension in first place



 void EditorFileDialog::update_file_name() has the code for the rename 

