### PR TITLE
Add `Image.load_bmp_from_buffer()` for run-time BMP image loading

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -2711,6 +2711,7 @@ ImageMemLoadFunc Image::_png_mem_loader_func = nullptr;
 ImageMemLoadFunc Image::_jpg_mem_loader_func = nullptr;
 ImageMemLoadFunc Image::_webp_mem_loader_func = nullptr;
 ImageMemLoadFunc Image::_tga_mem_loader_func = nullptr;
+ImageMemLoadFunc Image::_bmp_mem_loader_func = nullptr;
 
 void (*Image::_image_compress_bc_func)(Image *, float, Image::UsedChannels) = nullptr;
 void (*Image::_image_compress_bptc_func)(Image *, float, Image::UsedChannels) = nullptr;
@@ -3141,6 +3142,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("load_jpg_from_buffer", "buffer"), &Image::load_jpg_from_buffer);
 	ClassDB::bind_method(D_METHOD("load_webp_from_buffer", "buffer"), &Image::load_webp_from_buffer);
 	ClassDB::bind_method(D_METHOD("load_tga_from_buffer", "buffer"), &Image::load_tga_from_buffer);
+	ClassDB::bind_method(D_METHOD("load_bmp_from_buffer", "buffer"), &Image::load_bmp_from_buffer);
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "_set_data", "_get_data");
 
@@ -3473,8 +3475,19 @@ Error Image::load_webp_from_buffer(const Vector<uint8_t> &p_array) {
 }
 
 Error Image::load_tga_from_buffer(const Vector<uint8_t> &p_array) {
-	ERR_FAIL_NULL_V_MSG(_tga_mem_loader_func, ERR_UNAVAILABLE, "TGA module was not installed.");
+	ERR_FAIL_NULL_V_MSG(
+			_tga_mem_loader_func,
+			ERR_UNAVAILABLE,
+			"The TGA module isn't enabled. Recompile the Godot editor or export template binary with the `module_tga_enabled=yes` SCons option.");
 	return _load_from_buffer(p_array, _tga_mem_loader_func);
+}
+
+Error Image::load_bmp_from_buffer(const Vector<uint8_t> &p_array) {
+	ERR_FAIL_NULL_V_MSG(
+			_bmp_mem_loader_func,
+			ERR_UNAVAILABLE,
+			"The BMP module isn't enabled. Recompile the Godot editor or export template binary with the `module_bmp_enabled=yes` SCons option.");
+	return _load_from_buffer(p_array, _bmp_mem_loader_func);
 }
 
 void Image::convert_rg_to_ra_rgba8() {

--- a/core/image.h
+++ b/core/image.h
@@ -136,6 +136,7 @@ public:
 	static ImageMemLoadFunc _jpg_mem_loader_func;
 	static ImageMemLoadFunc _webp_mem_loader_func;
 	static ImageMemLoadFunc _tga_mem_loader_func;
+	static ImageMemLoadFunc _bmp_mem_loader_func;
 
 	static void (*_image_compress_bc_func)(Image *, float, UsedChannels p_channels);
 	static void (*_image_compress_bptc_func)(Image *, float p_lossy_quality, UsedChannels p_channels);
@@ -375,6 +376,7 @@ public:
 	Error load_jpg_from_buffer(const Vector<uint8_t> &p_array);
 	Error load_webp_from_buffer(const Vector<uint8_t> &p_array);
 	Error load_tga_from_buffer(const Vector<uint8_t> &p_array);
+	Error load_bmp_from_buffer(const Vector<uint8_t> &p_array);
 
 	void convert_rg_to_ra_rgba8();
 	void convert_ra_rgba8_to_rg();

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -346,6 +346,16 @@
 				Loads an image from file [code]path[/code]. See [url=https://docs.godotengine.org/en/latest/getting_started/workflow/assets/importing_images.html#supported-image-formats]Supported image formats[/url] for a list of supported image formats and limitations.
 			</description>
 		</method>
+		<method name="load_bmp_from_buffer">
+			<return type="int" enum="Error">
+			</return>
+			<argument index="0" name="buffer" type="PackedByteArray">
+			</argument>
+			<description>
+				Loads an image from the binary contents of a BMP file.
+				[b]Note:[/b] Godot's BMP module doesn't support 16-bit per pixel images. Only 1-bit, 4-bit, 8-bit, 24-bit, and 32-bit per pixel images are supported.
+			</description>
+		</method>
 		<method name="load_jpg_from_buffer">
 			<return type="int" enum="Error">
 			</return>

--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -30,6 +30,8 @@
 
 #include "image_loader_bmp.h"
 
+#include "core/io/file_access_memory.h"
+
 Error ImageLoaderBMP::convert_to_image(Ref<Image> p_image,
 		const uint8_t *p_buffer,
 		const uint8_t *p_color_buffer,
@@ -293,9 +295,21 @@ Error ImageLoaderBMP::load_image(Ref<Image> p_image, FileAccess *f,
 	return err;
 }
 
-void ImageLoaderBMP::get_recognized_extensions(
-		List<String> *p_extensions) const {
+void ImageLoaderBMP::get_recognized_extensions(List<String> *p_extensions) const {
 	p_extensions->push_back("bmp");
 }
 
-ImageLoaderBMP::ImageLoaderBMP() {}
+static Ref<Image> _bmp_mem_loader_func(const uint8_t *p_bmp, int p_size) {
+	FileAccessMemory memfile;
+	Error open_memfile_error = memfile.open_custom(p_bmp, p_size);
+	ERR_FAIL_COND_V_MSG(open_memfile_error, Ref<Image>(), "Could not create memfile for BMP image buffer.");
+	Ref<Image> img;
+	img.instance();
+	Error load_error = ImageLoaderBMP().load_image(img, &memfile, false, 1.0f);
+	ERR_FAIL_COND_V_MSG(load_error, Ref<Image>(), "Failed to load BMP image.");
+	return img;
+}
+
+ImageLoaderBMP::ImageLoaderBMP() {
+	Image::_bmp_mem_loader_func = _bmp_mem_loader_func;
+}

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -313,9 +313,9 @@ void ImageLoaderTGA::get_recognized_extensions(List<String> *p_extensions) const
 	p_extensions->push_back("tga");
 }
 
-static Ref<Image> _tga_mem_loader_func(const uint8_t *p_png, int p_size) {
+static Ref<Image> _tga_mem_loader_func(const uint8_t *p_tga, int p_size) {
 	FileAccessMemory memfile;
-	Error open_memfile_error = memfile.open_custom(p_png, p_size);
+	Error open_memfile_error = memfile.open_custom(p_tga, p_size);
 	ERR_FAIL_COND_V_MSG(open_memfile_error, Ref<Image>(), "Could not create memfile for TGA image buffer.");
 	Ref<Image> img;
 	img.instance();


### PR DESCRIPTION
This partially addresses https://github.com/godotengine/godot-proposals/issues/676.

Demo project: [test_bmp_exr_loading.zip](https://github.com/godotengine/godot/files/5411725/test_bmp_exr_loading.zip)
As you can see in the demo project, I've also included a run-time OpenEXR loading example. However, I stripped OpenEXR loading from the PR as it increased the binary size for export templates noticeably (+115 KB for a release LTO'd Linux 64-bit export template).
