### PR TITLE
Shader globals bugfixes

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1172,7 +1172,7 @@ void EditorPropertyVector2::setup(double p_min, double p_max, double p_step, boo
 }
 
 EditorPropertyVector2::EditorPropertyVector2(bool p_force_wide) {
-	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector2_editing");
+	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector2_editing"));
 
 	BoxContainer *bc;
 
@@ -1258,7 +1258,7 @@ void EditorPropertyRect2::setup(double p_min, double p_max, double p_step, bool 
 }
 
 EditorPropertyRect2::EditorPropertyRect2(bool p_force_wide) {
-	bool horizontal = !p_force_wide && bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
+	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
 
 	BoxContainer *bc;
 
@@ -1353,7 +1353,7 @@ void EditorPropertyVector3::setup(double p_min, double p_max, double p_step, boo
 }
 
 EditorPropertyVector3::EditorPropertyVector3(bool p_force_wide) {
-	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
+	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
 
 	BoxContainer *bc;
 
@@ -1435,7 +1435,7 @@ void EditorPropertyVector2i::setup(int p_min, int p_max, bool p_no_slider) {
 }
 
 EditorPropertyVector2i::EditorPropertyVector2i(bool p_force_wide) {
-	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector2_editing");
+	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector2_editing"));
 
 	BoxContainer *bc;
 
@@ -1521,7 +1521,7 @@ void EditorPropertyRect2i::setup(int p_min, int p_max, bool p_no_slider) {
 }
 
 EditorPropertyRect2i::EditorPropertyRect2i(bool p_force_wide) {
-	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
+	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
 
 	BoxContainer *bc;
 
@@ -1605,7 +1605,7 @@ void EditorPropertyVector3i::setup(int p_min, int p_max, bool p_no_slider) {
 }
 
 EditorPropertyVector3i::EditorPropertyVector3i(bool p_force_wide) {
-	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
+	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
 
 	BoxContainer *bc;
 	if (p_force_wide) {
@@ -1690,7 +1690,7 @@ void EditorPropertyPlane::setup(double p_min, double p_max, double p_step, bool 
 }
 
 EditorPropertyPlane::EditorPropertyPlane(bool p_force_wide) {
-	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
+	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
 
 	BoxContainer *bc;
 

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -284,7 +284,13 @@ static Variant create_var(RS::GlobalVariableType p_type) {
 			return Vector3i();
 		}
 		case RS::GLOBAL_VAR_TYPE_UVEC4: {
-			return Rect2i();
+			Vector<int> v4;
+			v4.resize(4);
+			v4.write[0] = 0;
+			v4.write[1] = 0;
+			v4.write[2] = 0;
+			v4.write[3] = 0;
+			return v4;
 		}
 		case RS::GLOBAL_VAR_TYPE_FLOAT: {
 			return 0.0;
@@ -324,7 +330,7 @@ static Variant create_var(RS::GlobalVariableType p_type) {
 		}
 		case RS::GLOBAL_VAR_TYPE_MAT4: {
 			Vector<real_t> xform;
-			xform.resize(4);
+			xform.resize(16);
 			xform.write[0] = 1;
 			xform.write[1] = 0;
 			xform.write[2] = 0;

--- a/servers/rendering/rasterizer_rd/shader_compiler_rd.cpp
+++ b/servers/rendering/rasterizer_rd/shader_compiler_rd.cpp
@@ -423,13 +423,13 @@ static String _get_global_variable_from_type_and_index(const String &p_buffer, c
 			return "(" + p_buffer + "[" + p_index + "].x != 0.0)";
 		}
 		case ShaderLanguage::TYPE_BVEC2: {
-			return "(" + p_buffer + "[" + p_index + "].xy != vec2(0.0))";
+			return "(notEqual(" + p_buffer + "[" + p_index + "].xy, vec2(0.0)))";
 		}
 		case ShaderLanguage::TYPE_BVEC3: {
-			return "(" + p_buffer + "[" + p_index + "].xyz != vec3(0.0))";
+			return "(notEqual(" + p_buffer + "[" + p_index + "].xyz, vec3(0.0)))";
 		}
 		case ShaderLanguage::TYPE_BVEC4: {
-			return "(" + p_buffer + "[" + p_index + "].xyzw != vec4(0.0))";
+			return "(notEqual(" + p_buffer + "[" + p_index + "].xyzw, vec4(0.0)))";
 		}
 		case ShaderLanguage::TYPE_INT: {
 			return "floatBitsToInt(" + p_buffer + "[" + p_index + "].x)";
@@ -444,16 +444,16 @@ static String _get_global_variable_from_type_and_index(const String &p_buffer, c
 			return "floatBitsToInt(" + p_buffer + "[" + p_index + "].xyzw)";
 		}
 		case ShaderLanguage::TYPE_UINT: {
-			return "floatBitsToUInt(" + p_buffer + "[" + p_index + "].x)";
+			return "floatBitsToUint(" + p_buffer + "[" + p_index + "].x)";
 		}
 		case ShaderLanguage::TYPE_UVEC2: {
-			return "floatBitsToUInt(" + p_buffer + "[" + p_index + "].xy)";
+			return "floatBitsToUint(" + p_buffer + "[" + p_index + "].xy)";
 		}
 		case ShaderLanguage::TYPE_UVEC3: {
-			return "floatBitsToUInt(" + p_buffer + "[" + p_index + "].xyz)";
+			return "floatBitsToUint(" + p_buffer + "[" + p_index + "].xyz)";
 		}
 		case ShaderLanguage::TYPE_UVEC4: {
-			return "floatBitsToUInt(" + p_buffer + "[" + p_index + "].xyzw)";
+			return "floatBitsToUint(" + p_buffer + "[" + p_index + "].xyzw)";
 		}
 		case ShaderLanguage::TYPE_FLOAT: {
 			return "(" + p_buffer + "[" + p_index + "].x)";


### PR DESCRIPTION
fixes #42898

GUI has been modified to display properties/globals properly as one line. No other part of the engine GUI were altered.
Comparison: 
master
![grafik](https://user-images.githubusercontent.com/25692790/96657134-a7908380-1341-11eb-8f54-be0ff79e4c14.png)
(editor settings horizontal vector 2 and horizontal vector types editing disabled for worst possible effect)
now
![grafik](https://user-images.githubusercontent.com/25692790/96656318-d60d5f00-133f-11eb-9661-e4680b792619.png)
(you will always get this result)

Additional fixes:
- fixed crash caused by wrong allocation size for mat4
- fixed type initialisation of uvec4 global
- fixed some typos preventing global bvecX, uint and uvecX from working

All global non-sampler types (as in the globals editor) work on my NVIDIA GPU. Tested by accessing them individually in a shader. Sampler types were not tested.