### PR TITLE
[3.2] Disable iOS SDK version check on osxcross.

### DIFF
--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -13,10 +13,12 @@ def get_name():
 
 def can_build():
 
-    if sys.platform == "darwin" or ("OSXCROSS_IOS" in os.environ):
+    if sys.platform == "darwin":
         if get_darwin_sdk_version("iphone") < 13.0:
             print("Detected iOS SDK version older than 13")
             return False
+        return True
+    elif "OSXCROSS_IOS" in os.environ:
         return True
 
     return False


### PR DESCRIPTION
See #42593 comments.

Fixes #42953