### PR TITLE
[3.2] Colorpicker overrides backport

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -994,8 +994,6 @@ void ColorPickerButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_popup"), &ColorPickerButton::get_popup);
 	ClassDB::bind_method(D_METHOD("set_edit_alpha", "show"), &ColorPickerButton::set_edit_alpha);
 	ClassDB::bind_method(D_METHOD("is_editing_alpha"), &ColorPickerButton::is_editing_alpha);
-	ClassDB::bind_method(D_METHOD("_color_changed"), &ColorPickerButton::_color_changed);
-	ClassDB::bind_method(D_METHOD("_modal_closed"), &ColorPickerButton::_modal_closed);
 
 	ADD_SIGNAL(MethodInfo("color_changed", PropertyInfo(Variant::COLOR, "color")));
 	ADD_SIGNAL(MethodInfo("popup_closed"));


### PR DESCRIPTION
This is a backport of the removal of method bindings for the `ColorPickerButton`. They got removed in [01afc442c73661df677c2b93f4037a21992ee45b](https://github.com/godotengine/godot/commit/01afc442c73661df677c2b93f4037a21992ee45b#diff-f7fb6c2c4c5d4fce35e389297048f54be3d4b08621edfc55a5586b437031ff10L990) and the availability of these functions led to confusion regarding the signal handling as seen in #42755.

The two methods `_color_changed` and `_modal_closed` will no longer be available in GDScript and code that used to override these has to bind to the signals instead.