### PR TITLE
[3.x] Add GDScript warning when internal native C++ callback is overridden via script

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2079,6 +2079,10 @@ String GDScriptWarning::get_message() const {
 			CHECK_SYMBOLS(1);
 			return "Function declaration of '" + symbols[0] + "()' conflicts with a constant of the same name.";
 		} break;
+		case FUNCTION_OVERRIDES_INTERNAL_CALLBACK: {
+			CHECK_SYMBOLS(1);
+			return "Function declaration '" + symbols[0] + "()' overrides internal callback.";
+		} break;
 		case INCOMPATIBLE_TERNARY: {
 			return "Values of the ternary conditional are not mutually compatible.";
 		} break;
@@ -2158,6 +2162,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"VARIABLE_CONFLICTS_FUNCTION",
 		"FUNCTION_CONFLICTS_VARIABLE",
 		"FUNCTION_CONFLICTS_CONSTANT",
+		"FUNCTION_OVERRIDES_INTERNAL_CALLBACK",
 		"INCOMPATIBLE_TERNARY",
 		"UNUSED_SIGNAL",
 		"RETURN_VALUE_DISCARDED",

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -292,6 +292,7 @@ struct GDScriptWarning {
 		VARIABLE_CONFLICTS_FUNCTION, // Variable has the same name of a function
 		FUNCTION_CONFLICTS_VARIABLE, // Function has the same name of a variable
 		FUNCTION_CONFLICTS_CONSTANT, // Function has the same name of a constant
+		FUNCTION_OVERRIDES_INTERNAL_CALLBACK, // Function has the same name of an internal callback prefixed with "_".
 		INCOMPATIBLE_TERNARY, // Possible values of a ternary if are not mutually compatible
 		UNUSED_SIGNAL, // Signal is defined but never emitted
 		RETURN_VALUE_DISCARDED, // Function call returns something but the value isn't used


### PR DESCRIPTION
Closes #42755.

This introduces a new type of GDScript warning in 3.2 for when a user attempts to override an internal, non-virtual, private callback prefixed with `_` in C++ code, which are hidden by default in the documentation and the editor, but nonetheless still accessible through the GDScript code:

![gdscript_warn_internal_callback](https://user-images.githubusercontent.com/17108460/96752660-71054800-13d7-11eb-8567-caeb45ed53c4.png)

This may be a problem in 4.0 as well, so upon pre-approval, I could make another PR for the `master` branch.

P.S. This is my first major endeavor at tinkering with GDScript parser code, but this seems to be functional already.