### PR TITLE
fix(editor): TileMap Fill Rectangle icon

### DIFF
--- a/editor/icons/RectangleShape2D.svg
+++ b/editor/icons/RectangleShape2D.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><rect fill="none" height="8" rx=".000017" stroke="#68b6ff" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" width="12" x="2" y="4"/></svg>
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><rect fill="none" height="8" rx=".000017" stroke="#e0e0e0" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" width="12" x="2" y="4"/></svg>


### PR DESCRIPTION
The default color was blue which is the active color, changed it to be gray by default.

Before:
![image](https://user-images.githubusercontent.com/1263211/96769034-d90b5c80-13de-11eb-8a8e-7fea3ad953f9.png)

After:
![image](https://user-images.githubusercontent.com/1263211/96768742-7b771000-13de-11eb-85ee-a39b8fdb6af6.png)

After with focus:
![image](https://user-images.githubusercontent.com/1263211/96769310-3dc6b700-13df-11eb-9c8c-55b7ed8a5722.png)
