### PR TITLE
fix(editor): TileMap floodfill with same tile ID and different variation

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -649,9 +649,15 @@ Vector<Vector2> TileMapEditor::_bucket_fill(const Point2i &p_start, bool erase, 
 		return Vector<Vector2>();
 	}
 
+	// Check if the tile variation is the same
+	Vector2 prev_position = node->get_cell_autotile_coord(p_start.x, p_start.y);
 	if (ids.size() == 1 && ids[0] == prev_id) {
-		// Same ID, nothing to change
-		return Vector<Vector2>();
+		int current = manual_palette->get_current();
+		Vector2 position = manual_palette->get_item_metadata(current);
+		if (prev_position == position) {
+			// Same ID and variation, nothing to change
+			return Vector<Vector2>();
+		}
 	}
 
 	Rect2i r = node->get_used_rect();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/40435

---

The concept of handling the tile variations / tile position is a little bit complicated to understand, is there any technical documentation on how it works?