### PR TITLE
Favor project.binary over project.godot

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -629,19 +629,26 @@ Error ProjectSettings::_load_settings_text(const String &p_path) {
 }
 
 Error ProjectSettings::_load_settings_text_or_binary(const String &p_text_path, const String &p_bin_path) {
-	// Attempt first to load the text-based project.godot file
-	Error err_text = _load_settings_text(p_text_path);
-	if (err_text == OK) {
+	// Attempt first to load the binary project.godot file.
+	Error err = _load_settings_binary(p_bin_path);
+	if (err == OK) {
 		return OK;
-	} else if (err_text != ERR_FILE_NOT_FOUND) {
-		// If the text-based file exists but can't be loaded, we want to know it
-		ERR_PRINT("Couldn't load file '" + p_text_path + "', error code " + itos(err_text) + ".");
-		return err_text;
+	} else if (err != ERR_FILE_NOT_FOUND) {
+		// If the file exists but can't be loaded, we want to know it.
+		ERR_PRINT("Couldn't load file '" + p_bin_path + "', error code " + itos(err) + ".");
+		return err;
 	}
 
-	// Fallback to binary project.binary file if text-based was not found
-	Error err_bin = _load_settings_binary(p_bin_path);
-	return err_bin;
+	// Fallback to text-based project.godot file if binary was not found.
+	err = _load_settings_text(p_text_path);
+	if (err == OK) {
+		return OK;
+	} else if (err != ERR_FILE_NOT_FOUND) {
+		ERR_PRINT("Couldn't load file '" + p_text_path + "', error code " + itos(err) + ".");
+		return err;
+	}
+
+	return err;
 }
 
 int ProjectSettings::get_order(const String &p_name) const {


### PR DESCRIPTION
Today I wasted few hours, because my `export.cfg`, next to hundreds of other project files, listed `project.godot` in the exported file list. This made the executable load the text project file, which doesn't have custom feature stored, which lead to a *very confusing* situation. Another thing is that when you run your exported executable inside a project directory, the `.pck` file will be loaded, but `project.godot` from the project will be used instead of the `project.binary` from the pck.

This PR resolves both problems, because projects are exported with `project.binary`, so it makes sense that they load it first. Of course this also applies to the editor, but I doubt anyone uses `project.binary` for their edited project.
Resolves #42978