### PR TITLE
Revert "fix(editor): TileMap Fill Rectangle icon"

### DIFF
--- a/editor/icons/RectangleShape2D.svg
+++ b/editor/icons/RectangleShape2D.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><rect fill="none" height="8" rx=".000017" stroke="#e0e0e0" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" width="12" x="2" y="4"/></svg>
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><rect fill="none" height="8" rx=".000017" stroke="#68b6ff" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" width="12" x="2" y="4"/></svg>


### PR DESCRIPTION
Reverts godotengine/godot#42972

Rationale: https://github.com/godotengine/godot/pull/42972#issuecomment-714324867