### PR TITLE
CI: Set debug_symbols=no for template builds

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -191,7 +191,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons target=release tools=no module_mono_enabled=yes mono_glue=no
+          scons target=release tools=no module_mono_enabled=yes mono_glue=no debug_symbols=no
           ls -l bin/
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -104,7 +104,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons target=release tools=no
+          scons target=release tools=no debug_symbols=no
           ls -l bin/
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -110,7 +110,7 @@ jobs:
       env:
         SCONS_CACHE: /.scons_cache/
       run: |
-        scons target=release tools=no
+        scons target=release tools=no debug_symbols=no
         ls -l bin/
 
     - uses: actions/upload-artifact@v2


### PR DESCRIPTION
This keeps their size small and allows to compare size changes on templates
in PRs, as the template size is what is most relevant to users.

For editor builds we keep debug symbols so they can be used to debug crashes.