### PR TITLE
fix(editor): Create new icon for TileMap Rectangle

### DIFF
--- a/editor/icons/Rectangle.svg
+++ b/editor/icons/Rectangle.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><rect fill="none" height="8" rx=".000017" stroke="#e0e0e0" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" width="12" x="2" y="4"/></svg>

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -65,7 +65,7 @@ void TileMapEditor::_notification(int p_what) {
 
 			paint_button->set_icon(get_theme_icon("Edit", "EditorIcons"));
 			line_button->set_icon(get_theme_icon("CurveLinear", "EditorIcons"));
-			rectangle_button->set_icon(get_theme_icon("RectangleShape2D", "EditorIcons"));
+			rectangle_button->set_icon(get_theme_icon("Rectangle", "EditorIcons"));
 			bucket_fill_button->set_icon(get_theme_icon("Bucket", "EditorIcons"));
 			picker_button->set_icon(get_theme_icon("ColorPick", "EditorIcons"));
 			select_button->set_icon(get_theme_icon("ActionCopy", "EditorIcons"));


### PR DESCRIPTION
ref: #42972

messed up git history in https://github.com/godotengine/godot/pull/42991