### PR TITLE
Add name and base type to Variant::InternalMethod (on debug)

### DIFF
--- a/core/variant.h
+++ b/core/variant.h
@@ -415,6 +415,11 @@ public:
 	static void interpolate(const Variant &a, const Variant &b, float c, Variant &r_dst);
 
 	class InternalMethod {
+#ifdef DEBUG_ENABLED
+	protected:
+		StringName method_name;
+		Variant::Type base_type;
+#endif
 	public:
 		enum Flags {
 			FLAG_IS_CONST = 1,
@@ -430,6 +435,12 @@ public:
 
 #ifdef DEBUG_ENABLED
 		virtual String get_argument_name(int p_arg) const = 0;
+		StringName get_name() const {
+			return method_name;
+		}
+		Variant::Type get_base_type() const {
+			return base_type;
+		}
 #endif
 		virtual Vector<Variant> get_default_arguments() const = 0;
 		virtual void call(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) = 0;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -111,13 +111,15 @@ struct _VariantCall {
 		InternalMethod(void (T::*p_method)(P...), const Vector<Variant> &p_default_args
 #ifdef DEBUG_ENABLED
 				,
-				const Vector<String> &p_arg_names
+				const Vector<String> &p_arg_names, const StringName &p_method_name, Variant::Type p_base_type
 #endif
 		) {
 			method = p_method;
 			default_values = p_default_args;
 #ifdef DEBUG_ENABLED
 			argument_names = p_arg_names;
+			method_name = p_method_name;
+			base_type = p_base_type;
 #endif
 		}
 	};
@@ -175,13 +177,15 @@ struct _VariantCall {
 		InternalMethodR(R (T::*p_method)(P...), const Vector<Variant> &p_default_args
 #ifdef DEBUG_ENABLED
 				,
-				const Vector<String> &p_arg_names
+				const Vector<String> &p_arg_names, const StringName &p_method_name, Variant::Type p_base_type
 #endif
 		) {
 			method = p_method;
 			default_values = p_default_args;
 #ifdef DEBUG_ENABLED
 			argument_names = p_arg_names;
+			method_name = p_method_name;
+			base_type = p_base_type;
 #endif
 		}
 	};
@@ -238,13 +242,15 @@ struct _VariantCall {
 		InternalMethodRC(R (T::*p_method)(P...) const, const Vector<Variant> &p_default_args
 #ifdef DEBUG_ENABLED
 				,
-				const Vector<String> &p_arg_names
+				const Vector<String> &p_arg_names, const StringName &p_method_name, Variant::Type p_base_type
 #endif
 		) {
 			method = p_method;
 			default_values = p_default_args;
 #ifdef DEBUG_ENABLED
 			argument_names = p_arg_names;
+			method_name = p_method_name;
+			base_type = p_base_type;
 #endif
 		}
 	};
@@ -338,13 +344,15 @@ struct _VariantCall {
 		InternalMethodRS(R (*p_method)(T *, P...), const Vector<Variant> &p_default_args
 #ifdef DEBUG_ENABLED
 				,
-				const Vector<String> &p_arg_names
+				const Vector<String> &p_arg_names, const StringName &p_method_name, Variant::Type p_base_type
 #endif
 		) {
 			method = p_method;
 			default_values = p_default_args;
 #ifdef DEBUG_ENABLED
 			argument_names = p_arg_names;
+			method_name = p_method_name;
+			base_type = p_base_type;
 #endif
 		}
 	};
@@ -397,7 +405,7 @@ struct _VariantCall {
 		InternalMethodVC(MethodVC p_method, uint32_t p_flags, const Vector<Variant::Type> &p_argument_types, const Variant::Type &p_return_type
 #ifdef DEBUG_ENABLED
 				,
-				const Vector<String> &p_arg_names
+				const Vector<String> &p_arg_names, const StringName &p_method_name, Variant::Type p_base_type
 #endif
 		) {
 			methodvc = p_method;
@@ -406,6 +414,8 @@ struct _VariantCall {
 			base_flags = p_flags;
 #ifdef DEBUG_ENABLED
 			argument_names = p_arg_names;
+			method_name = p_method_name;
+			base_type = p_base_type;
 #endif
 		}
 	};
@@ -427,7 +437,7 @@ struct _VariantCall {
 		ERR_FAIL_COND(type_internal_methods[GetTypeInfo<T>::VARIANT_TYPE].has(p_name));
 #endif
 #ifdef DEBUG_ENABLED
-		Variant::InternalMethod *m = memnew((InternalMethod<T, P...>)(p_method, p_default_args, p_argument_names));
+		Variant::InternalMethod *m = memnew((InternalMethod<T, P...>)(p_method, p_default_args, p_argument_names, p_name, GetTypeInfo<T>::VARIANT_TYPE));
 #else
 		Variant::InternalMethod *m = memnew((InternalMethod<T, P...>)(p_method, p_default_args));
 #endif
@@ -449,7 +459,7 @@ struct _VariantCall {
 
 #endif
 #ifdef DEBUG_ENABLED
-		Variant::InternalMethod *m = memnew((InternalMethodRC<T, R, P...>)(p_method, p_default_args, p_argument_names));
+		Variant::InternalMethod *m = memnew((InternalMethodRC<T, R, P...>)(p_method, p_default_args, p_argument_names, p_name, GetTypeInfo<T>::VARIANT_TYPE));
 #else
 		Variant::InternalMethod *m = memnew((InternalMethodRC<T, R, P...>)(p_method, p_default_args));
 #endif
@@ -471,7 +481,7 @@ struct _VariantCall {
 #endif
 
 #ifdef DEBUG_ENABLED
-		Variant::InternalMethod *m = memnew((InternalMethodR<T, R, P...>)(p_method, p_default_args, p_argument_names));
+		Variant::InternalMethod *m = memnew((InternalMethodR<T, R, P...>)(p_method, p_default_args, p_argument_names, p_name, GetTypeInfo<T>::VARIANT_TYPE));
 #else
 		Variant::InternalMethod *m = memnew((InternalMethodR<T, R, P...>)(p_method, p_default_args));
 #endif
@@ -504,7 +514,7 @@ struct _VariantCall {
 #endif
 
 #ifdef DEBUG_ENABLED
-		Variant::InternalMethod *m = memnew((InternalMethodRS<T, R, P...>)(p_method, p_default_args, p_argument_names));
+		Variant::InternalMethod *m = memnew((InternalMethodRS<T, R, P...>)(p_method, p_default_args, p_argument_names, p_name, GetTypeInfo<T>::VARIANT_TYPE));
 #else
 		Variant::InternalMethod *m = memnew((InternalMethodRS<T, R, P...>)(p_method, p_default_args));
 #endif
@@ -527,7 +537,7 @@ struct _VariantCall {
 	) {
 
 #ifdef DEBUG_ENABLED
-		Variant::InternalMethod *m = memnew(InternalMethodVC(p_method, p_flags, p_argument_types, p_return_type, p_argument_names));
+		Variant::InternalMethod *m = memnew(InternalMethodVC(p_method, p_flags, p_argument_types, p_return_type, p_argument_names, p_name, p_type));
 #else
 		Variant::InternalMethod *m = memnew(InternalMethodVC(p_method, p_flags, p_argument_types, p_return_type));
 #endif


### PR DESCRIPTION
This is useful to showing error messages when a pointer to an InternalMethod is the only information available.