### PR TITLE
Auto-instantiate properties when creating objects via editor inspector (when requested)

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2566,7 +2566,17 @@ void EditorPropertyResource::_menu_option(int p_which) {
 				//make visual script the right type
 				resp->call("set_instance_base_type", get_edited_object()->get_class());
 			}
+			// Check if any Object-type property should be instantiated.
+			List<PropertyInfo> pinfo;
+			obj->get_property_list(&pinfo);
 
+			for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
+				PropertyInfo pi = E->get();
+				if (pi.type == Variant::OBJECT && pi.usage & PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT) {
+					Object *prop = ClassDB::instance(pi.class_name);
+					obj->set(pi.name, prop);
+				}
+			}
 			res = Ref<Resource>(resp);
 			emit_changed(get_edited_property(), res);
 			update_property();


### PR DESCRIPTION
Replicates the same functionality of `CreateDialog`. The code is a literal copy-paste of #39479:

https://github.com/godotengine/godot/blob/bfc79a24349a1590626b49d660b6760cc7fd7468/editor/create_dialog.cpp#L435-L445

Needed by and tested on #42855.

Replying to https://github.com/godotengine/godot/pull/39479#issuecomment-643252072:

> Are there other ways to add nodes in the editor apart from using CreateDialog?

Yes! 🙂

Perhaps this can be refactored into a dedicated method like `EditorNode::instantiate_properties(obj)` or something: #43015.