### PR TITLE
Refactor auto-instantiation of `Object` properties in editor

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1632,7 +1632,8 @@ Variant ClassDB::class_get_default_property_value(const StringName &p_class, con
 	// Some properties may have an instantiated Object as default value,
 	// (like Path2D's `curve` used to have), but that's not a good practice.
 	// Instead, those properties should use PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT
-	// to be auto-instantiated when created in the editor.
+	// to be auto-instantiated when created in the editor with the following method:
+	// EditorNode::get_editor_data().instantiate_object_properties(obj);
 	if (var.get_type() == Variant::OBJECT) {
 		Object *obj = var.get_validated_object();
 		if (obj) {

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -446,17 +446,7 @@ Variant CreateDialog::instance_selected() {
 	} else {
 		obj = ClassDB::instantiate(selected->get_text(0));
 	}
-
-	// Check if any Object-type property should be instantiated.
-	List<PropertyInfo> pinfo;
-	((Object *)obj)->get_property_list(&pinfo);
-
-	for (const PropertyInfo &pi : pinfo) {
-		if (pi.type == Variant::OBJECT && pi.usage & PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT) {
-			Object *prop = ClassDB::instantiate(pi.class_name);
-			((Object *)obj)->set(pi.name, prop);
-		}
-	}
+	EditorNode::get_editor_data().instantiate_object_properties(obj);
 
 	return obj;
 }

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -520,6 +520,21 @@ void EditorData::remove_custom_type(const String &p_type) {
 	}
 }
 
+void EditorData::instantiate_object_properties(Object *p_object) {
+	ERR_FAIL_NULL(p_object);
+	// Check if any Object-type property should be instantiated.
+	List<PropertyInfo> pinfo;
+	p_object->get_property_list(&pinfo);
+
+	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
+		PropertyInfo pi = E->get();
+		if (pi.type == Variant::OBJECT && pi.usage & PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT) {
+			Object *prop = ClassDB::instantiate(pi.class_name);
+			p_object->set(pi.name, prop);
+		}
+	}
+}
+
 int EditorData::add_edited_scene(int p_at_pos) {
 	if (p_at_pos < 0) {
 		p_at_pos = edited_scene.size();

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -182,6 +182,8 @@ public:
 	void remove_custom_type(const String &p_type);
 	const Map<String, Vector<CustomType>> &get_custom_types() const { return custom_types; }
 
+	void instantiate_object_properties(Object *p_object);
+
 	int add_edited_scene(int p_at_pos);
 	void move_edited_scene_index(int p_idx, int p_to_idx);
 	void remove_scene(int p_idx);

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -375,6 +375,8 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			Resource *resp = Object::cast_to<Resource>(obj);
 			ERR_BREAK(!resp);
 
+			EditorNode::get_editor_data().instantiate_object_properties(obj);
+
 			edited_resource = RES(resp);
 			emit_signal(SNAME("resource_changed"), edited_resource);
 			_update_resource();

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -269,7 +269,9 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 						res->call("set_instance_base_type", owner->get_class());
 					}
 
+					EditorNode::get_editor_data().instantiate_object_properties(obj);
 					v = obj;
+
 					emit_signal(SNAME("variant_changed"));
 
 				} break;
@@ -1080,7 +1082,9 @@ void CustomPropertyEditor::_type_create_selected(int p_idx) {
 		ERR_FAIL_COND(!obj);
 		ERR_FAIL_COND(!Object::cast_to<Resource>(obj));
 
+		EditorNode::get_editor_data().instantiate_object_properties(obj);
 		v = obj;
+
 		emit_signal(SNAME("variant_changed"));
 		hide();
 	}
@@ -1270,7 +1274,9 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 					ERR_BREAK(!obj);
 					ERR_BREAK(!Object::cast_to<Resource>(obj));
 
+					EditorNode::get_editor_data().instantiate_object_properties(obj);
 					v = obj;
+
 					emit_signal(SNAME("variant_changed"));
 					hide();
 				}


### PR DESCRIPTION
Alternative to #43010, to avoid code duplication.
Follow-up to #39479.
Helps #42855.
Closes #56294.

Auto-instantiation is used by the create dialog, but should also be used by the editor inspector (and likely elsewhere).

This refactors object properties auto-instantiation into a dedicated method to be reused throughout editor (and possibly scripting).

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
