### PR TITLE
Improve file sorting

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -119,6 +119,11 @@ bool EditorFileSystemDirectory::get_file_import_is_valid(int p_idx) const {
 	return files[p_idx]->import_valid;
 }
 
+uint64_t EditorFileSystemDirectory::get_file_modified_time(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, files.size(), 0);
+	return files[p_idx]->modified_time;
+}
+
 String EditorFileSystemDirectory::get_file_script_class_name(int p_idx) const {
 	return files[p_idx]->script_class_name;
 }

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -89,6 +89,7 @@ public:
 	StringName get_file_type(int p_idx) const;
 	Vector<String> get_file_deps(int p_idx) const;
 	bool get_file_import_is_valid(int p_idx) const;
+	uint64_t get_file_modified_time(int p_idx) const;
 	String get_file_script_class_name(int p_idx) const; //used for scripts
 	String get_file_script_class_extends(int p_idx) const; //used for scripts
 	String get_file_script_class_icon_path(int p_idx) const; //used for scripts

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -71,7 +71,11 @@ public:
 
 	enum FileSortOption {
 		FILE_SORT_NAME = 0,
+		FILE_SORT_NAME_REVERSE,
 		FILE_SORT_TYPE,
+		FILE_SORT_TYPE_REVERSE,
+		FILE_SORT_MODIFIED_TIME,
+		FILE_SORT_MODIFIED_TIME_REVERSE,
 		FILE_SORT_MAX,
 	};
 
@@ -267,16 +271,17 @@ private:
 		StringName type;
 		Vector<String> sources;
 		bool import_broken;
+		uint64_t modified_time;
 
 		bool operator<(const FileInfo &fi) const {
 			return NaturalNoCaseComparator()(name, fi.name);
 		}
 	};
-	struct FileInfoExtensionComparator {
-		bool operator()(const FileInfo &p_a, const FileInfo &p_b) const {
-			return NaturalNoCaseComparator()(p_a.name.get_extension() + p_a.name.get_basename(), p_b.name.get_extension() + p_b.name.get_basename());
-		}
-	};
+
+	struct FileInfoTypeComparator;
+	struct FileInfoModifiedTimeComparator;
+
+	void _sort_file_info_list(List<FileSystemDock::FileInfo> &r_file_list);
 
 	void _search(EditorFileSystemDirectory *p_path, List<FileInfo> *matches, int p_max_items);
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Follow up of #42654.

Modifies the way the type sorting is done by also using the class icons in the comparison function. This specifically group similar resources together.

Also adds the possibility to sort according to the last modification date and in reserve order for each mode.
![output](https://user-images.githubusercontent.com/6093119/96933061-1dbaf480-14c0-11eb-8185-6aa6f50bcc70.gif)

