### PR TITLE
[3.2] Quickfix for misleading editor message when redeclaring variables

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2862,7 +2862,6 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 					return;
 				}
 				StringName n = tokenizer->get_token_literal();
-				tokenizer->advance();
 				if (current_function) {
 					for (int i = 0; i < current_function->arguments.size(); i++) {
 						if (n == current_function->arguments[i]) {
@@ -2879,6 +2878,7 @@ void GDScriptParser::_parse_block(BlockNode *p_block, bool p_static) {
 					}
 					check_block = check_block->parent_block;
 				}
+				tokenizer->advance();
 
 				//must know when the local variable is declared
 				LocalVarNode *lv = alloc_node<LocalVarNode>();


### PR DESCRIPTION
Solves #42884.
Before:
```go
func f():
    var x
    ...
    var x
    pass <- Redeclaration of x
```

Now:
```go
func f():
    var x
    ...
    var x <- Redeclaration of x
    pass 
```

A similar problem is present in master, however there was a rewrite of the parser in there, and this seemed like an easy enough change to be worth doing.