### PR TITLE
Implement OS.get_screen_orientation() for Android

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -473,7 +473,7 @@ public:
 	};
 
 	virtual void set_screen_orientation(ScreenOrientation p_orientation);
-	ScreenOrientation get_screen_orientation() const;
+	virtual ScreenOrientation get_screen_orientation() const;
 
 	virtual void enable_for_stealing_focus(ProcessID pid) {}
 	virtual void move_window_to_foreground() {}

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -561,6 +561,10 @@ public class GodotIO {
 		}
 	};
 
+	public int getScreenOrientation() {
+		return activity.getRequestedOrientation();
+	}
+
 	public void setEdit(GodotEditText _edit) {
 		edit = _edit;
 	}

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -57,6 +57,7 @@ GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instanc
 		_show_keyboard = p_env->GetMethodID(cls, "showKeyboard", "(Ljava/lang/String;ZIII)V");
 		_hide_keyboard = p_env->GetMethodID(cls, "hideKeyboard", "()V");
 		_set_screen_orientation = p_env->GetMethodID(cls, "setScreenOrientation", "(I)V");
+		_get_screen_orientation = p_env->GetMethodID(cls, "getScreenOrientation", "()I");
 		_get_system_dir = p_env->GetMethodID(cls, "getSystemDir", "(I)Ljava/lang/String;");
 		_play_video = p_env->GetMethodID(cls, "playVideo", "(Ljava/lang/String;)V");
 		_is_video_playing = p_env->GetMethodID(cls, "isVideoPlaying", "()Z");
@@ -168,6 +169,15 @@ void GodotIOJavaWrapper::set_screen_orientation(int p_orient) {
 	if (_set_screen_orientation) {
 		JNIEnv *env = ThreadAndroid::get_env();
 		env->CallVoidMethod(godot_io_instance, _set_screen_orientation, p_orient);
+	}
+}
+
+int GodotIOJavaWrapper::get_screen_orientation() const {
+	if (_get_screen_orientation) {
+		JNIEnv *env = ThreadAndroid::get_env();
+		return env->CallIntMethod(godot_io_instance, _get_screen_orientation);
+	} else {
+		return 0;
 	}
 }
 

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -55,6 +55,7 @@ private:
 	jmethodID _show_keyboard = 0;
 	jmethodID _hide_keyboard = 0;
 	jmethodID _set_screen_orientation = 0;
+	jmethodID _get_screen_orientation = 0;
 	jmethodID _get_system_dir = 0;
 	jmethodID _play_video = 0;
 	jmethodID _is_video_playing = 0;
@@ -80,6 +81,7 @@ public:
 	int get_vk_height();
 	void set_vk_height(int p_height);
 	void set_screen_orientation(int p_orient);
+	int get_screen_orientation() const;
 	String get_system_dir(int p_dir);
 	void play_video(const String &p_path);
 	bool is_video_playing();

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -846,6 +846,11 @@ void OS_Android::set_screen_orientation(ScreenOrientation p_orientation) {
 	godot_io_java->set_screen_orientation(p_orientation);
 }
 
+OS::ScreenOrientation OS_Android::get_screen_orientation() const {
+	const int orientation = godot_io_java->get_screen_orientation();
+	return OS::ScreenOrientation(orientation);
+}
+
 String OS_Android::get_unique_id() const {
 
 	String unique_id = godot_io_java->get_unique_id();

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -184,6 +184,7 @@ public:
 	void set_context_is_16_bits(bool p_is_16);
 
 	virtual void set_screen_orientation(ScreenOrientation p_orientation);
+	virtual ScreenOrientation get_screen_orientation() const;
 
 	virtual Error shell_open(String p_uri);
 	virtual String get_user_data_dir() const;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
I'm fairly certain this fixes #17109, I'm also happy to do this as a change against `master`, but I can't get that to run on my android device at the moment :smiley: 

tested on my Google Pixel 3 :+1: 