### PR TITLE
[Complex Text Layouts] Add variable fonts support.

### DIFF
--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -179,6 +179,23 @@
 				Returns underline thickness in pixels.
 			</description>
 		</method>
+		<method name="get_variation" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="tag" type="String">
+			</argument>
+			<description>
+				Returns variation coordinate [code]tag[/code].
+			</description>
+		</method>
+		<method name="get_variation_list" qualifiers="const">
+			<return type="Dictionary">
+			</return>
+			<description>
+				Returns list of supported [url=https://docs.microsoft.com/en-us/typography/opentype/spec/dvaraxisreg]variation coordinates[/url], each coordinate is returned as [code]tag: Vector3i(min_value,max_value,default_value)[/code].
+				Font variations allow for continuous change of glyph characteristics along some given design axis, such as weight, width or slant.
+			</description>
+		</method>
 		<method name="has_char" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -277,6 +294,17 @@
 			</argument>
 			<description>
 				Adds override for [method is_script_supported].
+			</description>
+		</method>
+		<method name="set_variation">
+			<return type="void">
+			</return>
+			<argument index="0" name="tag" type="String">
+			</argument>
+			<argument index="1" name="value" type="float">
+			</argument>
+			<description>
+				Sets variation coordinate [code]tag[/code].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -326,6 +326,27 @@
 				Returns underline thickness in pixels.
 			</description>
 		</method>
+		<method name="font_get_variation" qualifiers="const">
+			<return type="float">
+			</return>
+			<argument index="0" name="font" type="RID">
+			</argument>
+			<argument index="1" name="tag" type="String">
+			</argument>
+			<description>
+				Returns variation coordinate [code]tag[/code].
+			</description>
+		</method>
+		<method name="font_get_variation_list" qualifiers="const">
+			<return type="Dictionary">
+			</return>
+			<argument index="0" name="font" type="RID">
+			</argument>
+			<description>
+				Returns list of supported [url=https://docs.microsoft.com/en-us/typography/opentype/spec/dvaraxisreg]variation coordinates[/url], each coordinate is returned as [code]tag: Vector3i(min_value,max_value,default_value)[/code].
+				Font variations allow for continuous change of glyph characteristics along some given design axis, such as weight, width or slant.
+			</description>
+		</method>
 		<method name="font_has_char" qualifiers="const">
 			<return type="bool">
 			</return>
@@ -467,6 +488,19 @@
 			</argument>
 			<description>
 				Adds override for [method font_is_script_supported].
+			</description>
+		</method>
+		<method name="font_set_variation">
+			<return type="void">
+			</return>
+			<argument index="0" name="font" type="RID">
+			</argument>
+			<argument index="1" name="tag" type="String">
+			</argument>
+			<argument index="2" name="value" type="float">
+			</argument>
+			<description>
+				Sets variation coordinate [code]name[/code]. Unsupported coordinates will be silently ignored.
 			</description>
 		</method>
 		<method name="format_number" qualifiers="const">
@@ -1160,7 +1194,10 @@
 		<constant name="FEATURE_FONT_SYSTEM" value="32" enum="Feature">
 			TextServer supports loading system fonts.
 		</constant>
-		<constant name="FEATURE_USE_SUPPORT_DATA" value="64" enum="Feature">
+		<constant name="FEATURE_FONT_VARIABLE" value="64" enum="Feature">
+			TextServer supports variable fonts.
+		</constant>
+		<constant name="FEATURE_USE_SUPPORT_DATA" value="128" enum="Feature">
 			TextServer require external data file for some features.
 		</constant>
 	</constants>

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -161,6 +161,14 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 		CustomFontSource->load_resource(custom_font_path_source, default_font_size);
 		CustomFontSource->set_antialiased(font_antialiased);
 		CustomFontSource->set_hinting(font_hinting);
+
+		Vector<String> subtag = String(EditorSettings::get_singleton()->get("interface/editor/code_font_custom_variations")).split(",");
+		for (int i = 0; i < subtag.size(); i++) {
+			Vector<String> subtag_a = subtag[i].split("=");
+			if (subtag_a.size() == 2) {
+				CustomFontSource->set_variation(subtag_a[0], subtag_a[1].to_float());
+			}
+		}
 	} else {
 		EditorSettings::get_singleton()->set_manually("interface/editor/code_font", "");
 	}
@@ -281,6 +289,15 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	dfmono->load_memory(_font_Hack_Regular, _font_Hack_Regular_size, "ttf", default_font_size);
 	dfmono->set_antialiased(font_antialiased);
 	dfmono->set_hinting(font_hinting);
+
+	Vector<String> subtag = String(EditorSettings::get_singleton()->get("interface/editor/code_font_custom_variations")).split(",");
+	Dictionary ftrs;
+	for (int i = 0; i < subtag.size(); i++) {
+		Vector<String> subtag_a = subtag[i].split("=");
+		if (subtag_a.size() == 2) {
+			dfmono->set_variation(subtag_a[0], subtag_a[1].to_float());
+		}
+	}
 
 	// Default font
 	MAKE_DEFAULT_FONT(df);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -336,6 +336,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/code_font_contextual_ligatures", 0);
 	hints["interface/editor/code_font_contextual_ligatures"] = PropertyInfo(Variant::INT, "interface/editor/code_font_contextual_ligatures", PROPERTY_HINT_ENUM, "Default,Disable contextual alternates (coding ligatures),Use custom OpenType feature set", PROPERTY_USAGE_DEFAULT);
 	_initial_set("interface/editor/code_font_custom_opentype_features", "");
+	_initial_set("interface/editor/code_font_custom_variations", "");
 	_initial_set("interface/editor/font_antialiased", true);
 	_initial_set("interface/editor/font_hinting", 0);
 	hints["interface/editor/font_hinting"] = PropertyInfo(Variant::INT, "interface/editor/font_hinting", PROPERTY_HINT_ENUM, "Auto,None,Light,Normal", PROPERTY_USAGE_DEFAULT);

--- a/modules/gdnative/include/text/godot_text.h
+++ b/modules/gdnative/include/text/godot_text.h
@@ -82,6 +82,9 @@ typedef struct {
 	void (*font_set_antialiased)(void *, godot_rid *, bool);
 	bool (*font_get_antialiased)(void *, godot_rid *);
 	godot_dictionary (*font_get_feature_list)(void *, godot_rid *);
+	godot_dictionary (*font_get_variation_list)(void *, godot_rid *);
+	void (*font_set_variation)(void *, godot_rid *, const godot_string *, double);
+	double (*font_get_variation)(void *, godot_rid *, const godot_string *);
 	void (*font_set_distance_field_hint)(void *, godot_rid *, bool);
 	bool (*font_get_distance_field_hint)(void *, godot_rid *);
 	void (*font_set_hinting)(void *, godot_rid *, godot_int);

--- a/modules/gdnative/text/text_server_gdnative.cpp
+++ b/modules/gdnative/text/text_server_gdnative.cpp
@@ -148,6 +148,24 @@ bool TextServerGDNative::font_get_antialiased(RID p_font) const {
 	return interface->font_get_antialiased(data, (godot_rid *)&p_font);
 }
 
+Dictionary TextServerGDNative::font_get_variation_list(RID p_font) const {
+	ERR_FAIL_COND_V(interface == nullptr, Dictionary());
+	godot_dictionary result = interface->font_get_variation_list(data, (godot_rid *)&p_font);
+	Dictionary info = *(Dictionary *)&result;
+	godot_dictionary_destroy(&result);
+
+	return info;
+}
+
+void TextServerGDNative::font_set_variation(RID p_font, const String &p_name, double p_value) {
+	ERR_FAIL_COND(interface == nullptr);
+	interface->font_set_variation(data, (godot_rid *)&p_font, (godot_string *)&p_name, p_value);
+}
+
+double TextServerGDNative::font_get_variation(RID p_font, const String &p_name) const {
+	return interface->font_get_variation(data, (godot_rid *)&p_font, (godot_string *)&p_name);
+}
+
 void TextServerGDNative::font_set_hinting(RID p_font, TextServer::Hinting p_hinting) {
 	ERR_FAIL_COND(interface == nullptr);
 	interface->font_set_hinting(data, (godot_rid *)&p_font, (godot_int)p_hinting);

--- a/modules/gdnative/text/text_server_gdnative.h
+++ b/modules/gdnative/text/text_server_gdnative.h
@@ -76,6 +76,10 @@ public:
 	virtual bool font_get_antialiased(RID p_font) const override;
 
 	virtual Dictionary font_get_feature_list(RID p_font) const override;
+	virtual Dictionary font_get_variation_list(RID p_font) const override;
+
+	virtual void font_set_variation(RID p_font, const String &p_name, double p_value) override;
+	virtual double font_get_variation(RID p_font, const String &p_name) const override;
 
 	virtual void font_set_hinting(RID p_font, Hinting p_hinting) override;
 	virtual Hinting font_get_hinting(RID p_font) const override;

--- a/modules/text_server_adv/dynamic_font_adv.cpp
+++ b/modules/text_server_adv/dynamic_font_adv.cpp
@@ -32,6 +32,7 @@
 
 #include FT_STROKER_H
 #include FT_ADVANCES_H
+#include FT_MULTIPLE_MASTERS_H
 
 DynamicFontDataAdvanced::DataAtSize *DynamicFontDataAdvanced::get_data_for_size(int p_size, int p_outline_size) {
 	ERR_FAIL_COND_V(!valid, nullptr);
@@ -134,14 +135,89 @@ DynamicFontDataAdvanced::DataAtSize *DynamicFontDataAdvanced::get_data_for_size(
 			memdelete(fds);
 			ERR_FAIL_V_MSG(nullptr, "Error loading HB font.");
 		}
+
 		if (p_outline_size != 0) {
 			size_cache_outline[id] = fds;
 		} else {
 			size_cache[id] = fds;
 		}
+
+		// Write variations.
+		if (fds->face->face_flags & FT_FACE_FLAG_MULTIPLE_MASTERS) {
+			FT_MM_Var *amaster;
+
+			FT_Get_MM_Var(fds->face, &amaster);
+
+			Vector<hb_variation_t> hb_vars;
+			Vector<FT_Fixed> coords;
+			coords.resize(amaster->num_axis);
+
+			FT_Get_Var_Design_Coordinates(fds->face, coords.size(), coords.ptrw());
+
+			for (FT_UInt i = 0; i < amaster->num_axis; i++) {
+				hb_variation_t var;
+
+				// Reset to default.
+				var.tag = amaster->axis[i].tag;
+				var.value = (double)amaster->axis[i].def / 65536.f;
+				coords.write[i] = amaster->axis[i].def;
+
+				if (variations.has(var.tag)) {
+					var.value = variations[var.tag];
+					coords.write[i] = CLAMP(variations[var.tag] * 65536.f, amaster->axis[i].minimum, amaster->axis[i].maximum);
+				}
+
+				hb_vars.push_back(var);
+			}
+
+			FT_Set_Var_Design_Coordinates(fds->face, coords.size(), coords.ptrw());
+			hb_font_set_variations(fds->hb_handle, hb_vars.empty() ? nullptr : &hb_vars[0], hb_vars.size());
+
+			FT_Done_MM_Var(library, amaster);
+		}
+	}
+	return fds;
+}
+
+Dictionary DynamicFontDataAdvanced::get_variation_list() const {
+	_THREAD_SAFE_METHOD_
+	DataAtSize *fds = const_cast<DynamicFontDataAdvanced *>(this)->get_data_for_size(base_size);
+	if (fds == nullptr) {
+		return Dictionary();
 	}
 
-	return fds;
+	Dictionary ret;
+	// Read variations.
+	if (fds->face->face_flags & FT_FACE_FLAG_MULTIPLE_MASTERS) {
+		FT_MM_Var *amaster;
+
+		FT_Get_MM_Var(fds->face, &amaster);
+
+		for (FT_UInt i = 0; i < amaster->num_axis; i++) {
+			ret[(int32_t)amaster->axis[i].tag] = Vector3i(amaster->axis[i].minimum / 65536, amaster->axis[i].maximum / 65536, amaster->axis[i].def / 65536);
+		}
+
+		FT_Done_MM_Var(library, amaster);
+	}
+	return ret;
+}
+
+void DynamicFontDataAdvanced::set_variation(const String &p_name, double p_value) {
+	_THREAD_SAFE_METHOD_
+	int32_t tag = TS->name_to_tag(p_name);
+	if (!variations.has(tag) || (variations[tag] != p_value)) {
+		variations[tag] = p_value;
+		clear_cache();
+	}
+}
+
+double DynamicFontDataAdvanced::get_variation(const String &p_name) const {
+	_THREAD_SAFE_METHOD_
+	int32_t tag = TS->name_to_tag(p_name);
+	if (!variations.has(tag)) {
+		return 0.f;
+	}
+	return variations[tag];
 }
 
 Dictionary DynamicFontDataAdvanced::get_feature_list() const {

--- a/modules/text_server_adv/dynamic_font_adv.h
+++ b/modules/text_server_adv/dynamic_font_adv.h
@@ -118,6 +118,8 @@ private:
 	String font_path;
 	Vector<uint8_t> font_mem_cache;
 
+	Map<int32_t, double> variations;
+
 	float rect_margin = 1.f;
 	int base_size = 16;
 	float oversampling = 1.f;
@@ -146,6 +148,10 @@ public:
 	virtual float get_descent(int p_size) const override;
 
 	virtual Dictionary get_feature_list() const override;
+	virtual Dictionary get_variation_list() const override;
+
+	virtual void set_variation(const String &p_name, double p_value) override;
+	virtual double get_variation(const String &p_name) const override;
 
 	virtual float get_underline_position(int p_size) const override;
 	virtual float get_underline_thickness(int p_size) const override;

--- a/modules/text_server_adv/font_adv.h
+++ b/modules/text_server_adv/font_adv.h
@@ -50,6 +50,10 @@ struct FontDataAdvanced {
 	virtual float get_descent(int p_size) const = 0;
 
 	virtual Dictionary get_feature_list() const { return Dictionary(); };
+	virtual Dictionary get_variation_list() const { return Dictionary(); };
+
+	virtual void set_variation(const String &p_name, double p_value){};
+	virtual double get_variation(const String &p_name) const { return 0; };
 
 	virtual float get_underline_position(int p_size) const = 0;
 	virtual float get_underline_thickness(int p_size) const = 0;

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -132,7 +132,7 @@ _FORCE_INLINE_ bool is_linebreak(char32_t p_char) {
 /*************************************************************************/
 
 String TextServerAdvanced::interface_name = "ICU / HarfBuzz / Graphite";
-uint32_t TextServerAdvanced::interface_features = FEATURE_BIDI_LAYOUT | FEATURE_VERTICAL_LAYOUT | FEATURE_SHAPING | FEATURE_KASHIDA_JUSTIFICATION | FEATURE_BREAK_ITERATORS | FEATURE_USE_SUPPORT_DATA;
+uint32_t TextServerAdvanced::interface_features = FEATURE_BIDI_LAYOUT | FEATURE_VERTICAL_LAYOUT | FEATURE_SHAPING | FEATURE_KASHIDA_JUSTIFICATION | FEATURE_BREAK_ITERATORS | FEATURE_USE_SUPPORT_DATA | FEATURE_FONT_VARIABLE;
 
 bool TextServerAdvanced::has_feature(Feature p_feature) {
 	return (interface_features & p_feature) == p_feature;
@@ -620,6 +620,27 @@ bool TextServerAdvanced::font_get_antialiased(RID p_font) const {
 	const FontDataAdvanced *fd = font_owner.getornull(p_font);
 	ERR_FAIL_COND_V(!fd, false);
 	return fd->get_antialiased();
+}
+
+Dictionary TextServerAdvanced::font_get_variation_list(RID p_font) const {
+	_THREAD_SAFE_METHOD_
+	const FontDataAdvanced *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND_V(!fd, Dictionary());
+	return fd->get_variation_list();
+}
+
+void TextServerAdvanced::font_set_variation(RID p_font, const String &p_name, double p_value) {
+	_THREAD_SAFE_METHOD_
+	FontDataAdvanced *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND(!fd);
+	fd->set_variation(p_name, p_value);
+}
+
+double TextServerAdvanced::font_get_variation(RID p_font, const String &p_name) const {
+	_THREAD_SAFE_METHOD_
+	const FontDataAdvanced *fd = font_owner.getornull(p_font);
+	ERR_FAIL_COND_V(!fd, 0);
+	return fd->get_variation(p_name);
 }
 
 void TextServerAdvanced::font_set_distance_field_hint(RID p_font, bool p_distance_field) {

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -138,6 +138,10 @@ public:
 	virtual bool font_get_antialiased(RID p_font) const override;
 
 	virtual Dictionary font_get_feature_list(RID p_font) const override;
+	virtual Dictionary font_get_variation_list(RID p_font) const override;
+
+	virtual void font_set_variation(RID p_font, const String &p_name, double p_value) override;
+	virtual double font_get_variation(RID p_font, const String &p_name) const override;
 
 	virtual void font_set_hinting(RID p_font, Hinting p_hinting) override;
 	virtual Hinting font_get_hinting(RID p_font) const override;

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -53,6 +53,11 @@ void FontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_antialiased", "antialiased"), &FontData::set_antialiased);
 	ClassDB::bind_method(D_METHOD("get_antialiased"), &FontData::get_antialiased);
 
+	ClassDB::bind_method(D_METHOD("get_variation_list"), &FontData::get_variation_list);
+
+	ClassDB::bind_method(D_METHOD("set_variation", "tag", "value"), &FontData::set_variation);
+	ClassDB::bind_method(D_METHOD("get_variation", "tag"), &FontData::get_variation);
+
 	ClassDB::bind_method(D_METHOD("set_hinting", "hinting"), &FontData::set_hinting);
 	ClassDB::bind_method(D_METHOD("get_hinting"), &FontData::get_hinting);
 
@@ -115,6 +120,11 @@ bool FontData::_set(const StringName &p_name, const Variant &p_value) {
 		set_script_support_override(scr, p_value);
 		return true;
 	}
+	if (str.begins_with("variation/")) {
+		String name = str.get_slicec('/', 1);
+		set_variation(name, p_value);
+		return true;
+	}
 
 	return false;
 }
@@ -137,6 +147,12 @@ bool FontData::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = get_script_support_override(scr);
 		return true;
 	}
+	if (str.begins_with("variation/")) {
+		String name = str.get_slicec('/', 1);
+
+		r_ret = get_variation(name);
+		return true;
+	}
 
 	return false;
 }
@@ -153,6 +169,12 @@ void FontData::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::BOOL, "script_support_override/" + scr_over[i], PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE));
 	}
 	p_list->push_back(PropertyInfo(Variant::NIL, "script_support_override/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+
+	Dictionary variations = get_variation_list();
+	for (const Variant *ftr = variations.next(nullptr); ftr != nullptr; ftr = variations.next(ftr)) {
+		Vector3i v = variations[*ftr];
+		p_list->push_back(PropertyInfo(Variant::FLOAT, "variation/" + TS->tag_to_name(*ftr), PROPERTY_HINT_RANGE, itos(v.x) + "," + itos(v.y), PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE));
+	}
 }
 
 RID FontData::get_rid() const {
@@ -237,6 +259,26 @@ float FontData::get_underline_thickness(int p_size) const {
 		return 0.f;
 	}
 	return TS->font_get_underline_thickness(rid, (p_size < 0) ? base_size : p_size);
+}
+
+Dictionary FontData::get_variation_list() const {
+	if (rid == RID()) {
+		return Dictionary();
+	}
+	return TS->font_get_variation_list(rid);
+}
+
+void FontData::set_variation(const String &p_name, double p_value) {
+	ERR_FAIL_COND(rid == RID());
+	TS->font_set_variation(rid, p_name, p_value);
+	emit_changed();
+}
+
+double FontData::get_variation(const String &p_name) const {
+	if (rid == RID()) {
+		return 0;
+	}
+	return TS->font_get_variation(rid, p_name);
 }
 
 void FontData::set_antialiased(bool p_antialiased) {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -68,6 +68,10 @@ public:
 	float get_descent(int p_size) const;
 
 	Dictionary get_feature_list() const;
+	Dictionary get_variation_list() const;
+
+	void set_variation(const String &p_name, double p_value);
+	double get_variation(const String &p_name) const;
 
 	float get_underline_position(int p_size) const;
 	float get_underline_thickness(int p_size) const;

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -231,6 +231,10 @@ void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("font_get_antialiased", "font"), &TextServer::font_get_antialiased);
 
 	ClassDB::bind_method(D_METHOD("font_get_feature_list", "font"), &TextServer::font_get_feature_list);
+	ClassDB::bind_method(D_METHOD("font_get_variation_list", "font"), &TextServer::font_get_variation_list);
+
+	ClassDB::bind_method(D_METHOD("font_set_variation", "font", "tag", "value"), &TextServer::font_set_variation);
+	ClassDB::bind_method(D_METHOD("font_get_variation", "font", "tag"), &TextServer::font_get_variation);
 
 	ClassDB::bind_method(D_METHOD("font_set_hinting", "font", "hinting"), &TextServer::font_set_hinting);
 	ClassDB::bind_method(D_METHOD("font_get_hinting", "font"), &TextServer::font_get_hinting);
@@ -385,6 +389,7 @@ void TextServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(FEATURE_KASHIDA_JUSTIFICATION);
 	BIND_ENUM_CONSTANT(FEATURE_BREAK_ITERATORS);
 	BIND_ENUM_CONSTANT(FEATURE_FONT_SYSTEM);
+	BIND_ENUM_CONSTANT(FEATURE_FONT_VARIABLE);
 	BIND_ENUM_CONSTANT(FEATURE_USE_SUPPORT_DATA);
 }
 

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -94,7 +94,8 @@ public:
 		FEATURE_KASHIDA_JUSTIFICATION = 1 << 3,
 		FEATURE_BREAK_ITERATORS = 1 << 4,
 		FEATURE_FONT_SYSTEM = 1 << 5,
-		FEATURE_USE_SUPPORT_DATA = 1 << 6
+		FEATURE_FONT_VARIABLE = 1 << 6,
+		FEATURE_USE_SUPPORT_DATA = 1 << 7
 	};
 
 	struct Glyph {
@@ -246,6 +247,10 @@ public:
 	virtual bool font_get_antialiased(RID p_font) const = 0;
 
 	virtual Dictionary font_get_feature_list(RID p_font) const { return Dictionary(); };
+	virtual Dictionary font_get_variation_list(RID p_font) const { return Dictionary(); };
+
+	virtual void font_set_variation(RID p_font, const String &p_name, double p_value){};
+	virtual double font_get_variation(RID p_font, const String &p_name) const { return 0; };
 
 	virtual void font_set_distance_field_hint(RID p_font, bool p_distance_field) = 0;
 	virtual bool font_get_distance_field_hint(RID p_font) const = 0;


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/1704

<img width="793" alt="var_props" src="https://user-images.githubusercontent.com/7645683/96966496-90ef5580-1516-11eb-90ae-641c1785299a.png">

![output](https://user-images.githubusercontent.com/7645683/96966499-92b91900-1516-11eb-9dbf-2d04656795db.gif)

All features (variable font and OpenType) are available for the Godot code editor font:
![output](https://user-images.githubusercontent.com/7645683/98156242-31af1f00-1ee0-11eb-80ed-9b4687bf932e.gif)

Demo project: [VarFonts.zip](https://github.com/godotengine/godot/files/5529468/VarFonts.zip)

