### PR TITLE
Fix android apk contents having mtime 1 month in future

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -592,7 +592,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		zipfi.tmz_date.tm_hour = time.hour;
 		zipfi.tmz_date.tm_mday = date.day;
 		zipfi.tmz_date.tm_min = time.min;
-		zipfi.tmz_date.tm_mon = date.month;
+		zipfi.tmz_date.tm_mon = date.month - 1; // tm_mon is zero indexed
 		zipfi.tmz_date.tm_sec = time.sec;
 		zipfi.tmz_date.tm_year = date.year;
 		zipfi.dosDate = 0;


### PR DESCRIPTION
minizip documentation describes tm_mon as expecting the number of months
since January - [0, 11], but the month returned by OS.get_date() is in
the range of [1, 12].

Fixes #41885

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
