### PR TITLE
Rename button group property to button_group

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -44,6 +44,9 @@
 		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" enum="BaseButton.ActionMode" default="1">
 			Determines when the button is considered clicked, one of the [enum ActionMode] constants.
 		</member>
+		<member name="button_group" type="ButtonGroup" setter="set_button_group" getter="get_button_group">
+			The [ButtonGroup] associated with the button. Not to be confused with node groups.
+		</member>
 		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask" default="1">
 			Binary mask to choose which mouse buttons this button will respond to.
 			To allow both left-click and right-click, use [code]BUTTON_MASK_LEFT | BUTTON_MASK_RIGHT[/code].
@@ -52,9 +55,6 @@
 			If [code]true[/code], the button is in disabled state and can't be clicked or toggled.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" override="true" enum="Control.FocusMode" default="2" />
-		<member name="group" type="ButtonGroup" setter="set_button_group" getter="get_button_group">
-			[ButtonGroup] associated to the button.
-		</member>
 		<member name="keep_pressed_outside" type="bool" setter="set_keep_pressed_outside" getter="is_keep_pressed_outside" default="false">
 			If [code]true[/code], the button stays pressed when moving the cursor outside the button while pressing it.
 			[b]Note:[/b] This property only affects the button's visual appearance. Signals will be emitted at the same moment regardless of this property's value.

--- a/doc/classes/ButtonGroup.xml
+++ b/doc/classes/ButtonGroup.xml
@@ -14,7 +14,7 @@
 			<return type="Array">
 			</return>
 			<description>
-				Returns an [Array] of [Button]s who have this as their [ButtonGroup] (see [member BaseButton.group]).
+				Returns an [Array] of [Button]s who have this as their [ButtonGroup] (see [member BaseButton.button_group]).
 			</description>
 		</method>
 		<method name="get_pressed_button">

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -401,7 +401,7 @@ void BaseButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_mask", PROPERTY_HINT_FLAGS, "Mouse Left, Mouse Right, Mouse Middle"), "set_button_mask", "get_button_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_pressed_outside"), "set_keep_pressed_outside", "is_keep_pressed_outside");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut", PROPERTY_HINT_RESOURCE_TYPE, "Shortcut"), "set_shortcut", "get_shortcut");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "group", PROPERTY_HINT_RESOURCE_TYPE, "ButtonGroup"), "set_button_group", "get_button_group");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "button_group", PROPERTY_HINT_RESOURCE_TYPE, "ButtonGroup"), "set_button_group", "get_button_group");
 
 	BIND_ENUM_CONSTANT(DRAW_NORMAL);
 	BIND_ENUM_CONSTANT(DRAW_PRESSED);


### PR DESCRIPTION
The property for `ButtonGroup` on `BaseButton` was called `group`, but the getter and setter both end in `_button_group`, and the member is also called `button_group`, so rename the property to `button_group` for consistency and to avoid confusion with node groups. This change was prompted by someone on Discord who was very confused by "Group" not being related to node groups.