### PR TITLE
Fix script used as type gone too early (3.2)

### DIFF
--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -2338,12 +2338,20 @@ Variant::Variant(const RID &p_rid) {
 Variant::Variant(const Object *p_object) {
 
 	type = OBJECT;
+	Object *obj = const_cast<Object *>(p_object);
 
 	memnew_placement(_data._mem, ObjData);
+	Reference *ref = Object::cast_to<Reference>(obj);
+	if (unlikely(ref)) {
+		*reinterpret_cast<Ref<Reference> *>(_get_obj().ref.get_data()) = Ref<Reference>(ref);
 #ifdef DEBUG_ENABLED
-	_get_obj().rc = p_object ? const_cast<Object *>(p_object)->_use_rc() : NULL;
-#else
-	_get_obj().obj = const_cast<Object *>(p_object);
+		_get_obj().rc = NULL;
+	} else {
+		_get_obj().rc = likely(obj) ? obj->_use_rc() : NULL;
+#endif
+	}
+#if !defined(DEBUG_ENABLED)
+	_get_obj().obj = obj;
 #endif
 }
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -914,7 +914,6 @@ void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
 GDScript::GDScript() :
 		script_list(this) {
 
-	_static_ref = this;
 	valid = false;
 	subclass_count = 0;
 	initializer = NULL;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -73,7 +73,6 @@ class GDScript : public Script {
 	friend class GDScriptFunctions;
 	friend class GDScriptLanguage;
 
-	Variant _static_ref; //used for static call
 	Ref<GDScriptNativeClass> native;
 	Ref<GDScript> base;
 	GDScript *_base; //fast pointer access

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -34,7 +34,7 @@
 #include "gdscript.h"
 #include "gdscript_functions.h"
 
-Variant *GDScriptFunction::_get_variant(int p_address, GDScriptInstance *p_instance, GDScript *p_script, Variant &self, Variant *p_stack, String &r_error) const {
+Variant *GDScriptFunction::_get_variant(int p_address, GDScriptInstance *p_instance, GDScript *p_script, Variant &self, Variant &static_ref, Variant *p_stack, String &r_error) const {
 
 	int address = p_address & ADDR_MASK;
 
@@ -52,7 +52,7 @@ Variant *GDScriptFunction::_get_variant(int p_address, GDScriptInstance *p_insta
 		} break;
 		case ADDR_TYPE_CLASS: {
 
-			return &p_script->_static_ref;
+			return &static_ref;
 		} break;
 		case ADDR_TYPE_MEMBER: {
 #ifdef DEBUG_ENABLED
@@ -269,6 +269,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 	r_err.error = Variant::CallError::CALL_OK;
 
 	Variant self;
+	Variant static_ref;
 	Variant retvalue;
 	Variant *stack = NULL;
 	Variant **call_args;
@@ -403,10 +404,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #define CHECK_SPACE(m_space) \
 	GD_ERR_BREAK((ip + m_space) > _code_size)
 
-#define GET_VARIANT_PTR(m_v, m_code_ofs)                                                       \
-	Variant *m_v;                                                                              \
-	m_v = _get_variant(_code_ptr[ip + m_code_ofs], p_instance, script, self, stack, err_text); \
-	if (unlikely(!m_v))                                                                        \
+#define GET_VARIANT_PTR(m_v, m_code_ofs)                                                                   \
+	Variant *m_v;                                                                                          \
+	m_v = _get_variant(_code_ptr[ip + m_code_ofs], p_instance, script, self, static_ref, stack, err_text); \
+	if (unlikely(!m_v))                                                                                    \
 		OPCODE_BREAK;
 
 #else
@@ -414,7 +415,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #define CHECK_SPACE(m_space)
 #define GET_VARIANT_PTR(m_v, m_code_ofs) \
 	Variant *m_v;                        \
-	m_v = _get_variant(_code_ptr[ip + m_code_ofs], p_instance, script, self, stack, err_text);
+	m_v = _get_variant(_code_ptr[ip + m_code_ofs], p_instance, script, self, static_ref, stack, err_text);
 
 #endif
 

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -386,6 +386,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		}
 	}
 
+	static_ref = script;
+
 	String err_text;
 
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -267,7 +267,7 @@ private:
 
 	List<StackDebug> stack_debug;
 
-	_FORCE_INLINE_ Variant *_get_variant(int p_address, GDScriptInstance *p_instance, GDScript *p_script, Variant &self, Variant *p_stack, String &r_error) const;
+	_FORCE_INLINE_ Variant *_get_variant(int p_address, GDScriptInstance *p_instance, GDScript *p_script, Variant &self, Variant &static_ref, Variant *p_stack, String &r_error) const;
 	_FORCE_INLINE_ String _get_call_error(const Variant::CallError &p_err, const String &p_where, const Variant **argptrs) const;
 
 	friend class GDScriptLanguage;


### PR DESCRIPTION
Following up on what I explained in #42323, it seems that the problem with `Variant`'s `Object *` constructor was very needed. The only thing that was preventing me from doing it is that GDScript was leveraging the wrong behavior. However, it seems that @vnen already fixed that.

I've cherry-picked the commit that removes that naughtiness from GDScript and the definitive fix for `Variant` has become possible. `Variant` will now manage the lifetime of a `Reference` nicely even if it's assigned via the `Object *` constructor. As I explained in the mentioned PR, without that fix, two incompatible reference counting mechanisms were being used simultaneously, which was nothing else than summoning the most terrible forces in a cold and stormy night.

**NOTE:** 4.0 already gets this right.

Fixes #43042.

**UPDATE:** Fixes #43166.