### PR TITLE
Changed shell_open behaviour

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -123,18 +123,39 @@ String OS_LinuxBSD::get_name() const {
 
 Error OS_LinuxBSD::shell_open(String p_uri) {
 	Error ok;
+	int err_code;
 	List<String> args;
 	args.push_back(p_uri);
-	ok = execute("xdg-open", args, false);
-	if (ok == OK) {
+
+	// Agnostic
+	ok = execute("xdg-open", args, true, nullptr, nullptr, &err_code);
+	if (ok == OK && !err_code) {
+		return OK;
+	} else if (err_code == 2) {
+		return ERR_FILE_NOT_FOUND;
+	}
+	// GNOME
+	args.push_front("open"); // The command is `gio open`, so we need to add it to args
+	ok = execute("gio", args, true, nullptr, nullptr, &err_code);
+	if (ok == OK && !err_code) {
+		return OK;
+	} else if (err_code == 2) {
+		return ERR_FILE_NOT_FOUND;
+	}
+	args.pop_front();
+	ok = execute("gvfs-open", args, true, nullptr, nullptr, &err_code);
+	if (ok == OK && !err_code) {
+		return OK;
+	} else if (err_code == 2) {
+		return ERR_FILE_NOT_FOUND;
+	}
+	// KDE
+	ok = execute("kde-open5", args, true, nullptr, nullptr, &err_code);
+	if (ok == OK && !err_code) {
 		return OK;
 	}
-	ok = execute("gnome-open", args, false);
-	if (ok == OK) {
-		return OK;
-	}
-	ok = execute("kde-open", args, false);
-	return ok;
+	ok = execute("kde-open", args, true, nullptr, nullptr, &err_code);
+	return !err_code ? ok : FAILED;
 }
 
 bool OS_LinuxBSD::_check_internal_feature_support(const String &p_feature) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Changed behaviour of `shell_open` to "block" when called, so Godot doesn't spawn multiple "zombie" processes, and changed commands, since `gnome-open` is deprecated for almost [10 years](https://askubuntu.com/questions/101965/what-is-the-replacement-for-gnome-open-in-gnome) and in some cases `kde-open` is actually called `kde-open5`.

Fixes #43048