### PR TITLE
Fix transforms in custom shaders using large FVF

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -2176,7 +2176,9 @@ void RasterizerCanvasGLES2::render_joined_item(const BItemJoined &p_bij, RenderI
 		}
 	}
 
-	// using software transform
+	// using software transform?
+	// (i.e. don't send the transform matrix, send identity, and either use baked verts,
+	// or large fvf where the transform is done in the shader from transform stored in the fvf.)
 	if (!p_bij.use_hardware_transform()) {
 		state.uniforms.modelview_matrix = Transform2D();
 		// final_modulate will be baked per item ref so the final_modulate can be an identity color

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -203,12 +203,15 @@ VERTEX_SHADER_CODE
 	temp += translate_attrib;
 	outvec.xy = temp;
 
-#endif
+#else
 
+	// transform is in uniforms
 #if !defined(SKIP_TRANSFORM_USED)
 	outvec = extra_matrix_instance * outvec;
 	outvec = modelview_matrix * outvec;
 #endif
+
+#endif // not large integer
 
 	color_interp = color;
 

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1439,7 +1439,9 @@ void RasterizerCanvasGLES3::render_joined_item(const BItemJoined &p_bij, RenderI
 	//	state.final_transform = p_ci->final_transform;
 	//	state.extra_matrix = Transform2D();
 
-	// using software transform
+	// using software transform?
+	// (i.e. don't send the transform matrix, send identity, and either use baked verts,
+	// or large fvf where the transform is done in the shader from transform stored in the fvf.)
 	if (!p_bij.use_hardware_transform()) {
 		state.final_transform = Transform2D();
 		// final_modulate will be baked per item ref so the final_modulate can be an identity color

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -208,12 +208,16 @@ VERTEX_SHADER_CODE
 
 	temp += translate_attrib;
 	outvec.xy = temp;
-#endif
 
+#else
+
+	// transform is in uniforms
 #if !defined(SKIP_TRANSFORM_USED)
 	outvec = extra_matrix * outvec;
 	outvec = modelview_matrix * outvec;
 #endif
+
+#endif // not large integer
 
 #undef extra_matrix
 

--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -2068,6 +2068,11 @@ PREAMBLE(bool)::prefill_joined_item(FillState &r_fill_state, int &r_command_star
 				// break this extra matrix software path (as we don't want to unset it on the GPU etc)
 				if (r_fill_state.extra_matrix_sent) {
 					_prefill_default_batch(r_fill_state, command_num, *p_item);
+
+					// keep track of the combined matrix on the CPU in parallel, in case we use large vertex format
+					RasterizerCanvas::Item::CommandTransform *transform = static_cast<RasterizerCanvas::Item::CommandTransform *>(command);
+					const Transform2D &extra_matrix = transform->xform;
+					r_fill_state.transform_combined = p_item->final_transform * extra_matrix;
 				} else {
 					// Extra matrix fast path.
 					// Instead of sending the command immediately, we store the modified transform (in combined)


### PR DESCRIPTION
In small batches using hardware transform, vertices would be drawn in incorrect positions due to the item transform being applied twice - once in the transform uniform, and once from the transform passed as a vertex attribute.

The solution used here is to disable use of the uniform transform when using large fvf.

Fixes wind custom shader foliage transform problem in #42899

## Notes
* I've noticed I'm probably not dealing with SKIP_TRANSFORM_USED for large_fvf. This is probably rarely used, and better left to a separate PR. It probably needs to prevent batching, similar to the prevent_vertex_baking shader compiler flags.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
