### PR TITLE
SCons: Add an option to detect C++ modules recursively

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -123,6 +123,7 @@ opts.Add(BoolVariable("deprecated", "Enable deprecated features", True))
 opts.Add(BoolVariable("minizip", "Enable ZIP archive support using minizip", True))
 opts.Add(BoolVariable("xaudio2", "Enable the XAudio2 audio driver", False))
 opts.Add("custom_modules", "A list of comma-separated directory paths containing custom modules to build.", "")
+opts.Add(BoolVariable("custom_modules_recursive", "Detect custom modules recursively for each specified path.", True))
 
 # Advanced options
 opts.Add(BoolVariable("verbose", "Enable verbose output for the compilation", False))
@@ -199,8 +200,14 @@ if env_base["custom_modules"]:
             Exit(255)
 
 for path in module_search_paths:
+    if path == "modules":
+        # Built-in modules don't have nested modules,
+        # so save the time it takes to parse directories.
+        modules = methods.detect_modules(path, recursive=False)
+    else:  # External.
+        modules = methods.detect_modules(path, env_base["custom_modules_recursive"])
     # Note: custom modules can override built-in ones.
-    modules_detected.update(methods.detect_modules(path))
+    modules_detected.update(modules)
     include_path = os.path.dirname(path)
     if include_path:
         env_base.Prepend(CPPPATH=[include_path])


### PR DESCRIPTION
Closes godotengine/godot-proposals#1619.

This adds `custom_modules_recursive` SCons build option which allows to detect and collect all nested C++ modules which may reside in any directory specified by `custom_modules` option. This option is enabled by default for external modules to achieve the greatest convenience for users.

The detection logic is made to be more strict because `SCSub` may be used for organizing hierarchical builds within a module itself, so the existence of `register_types.h` and `config.py` is checked as well (these are all required for a C++ module to be compiled by Godot, likely throughout existence of Godot).

For performance reasons, built-in modules are not checked recursively, and there's no benefit of doing so in the first place, so this has almost no performance impact for built-in modules.

### Important improvement

It's now possible to specify a directory path pointing to a *single* module, and it may contain nested modules which are detected recursively. This is another improvement if you just want to compile a single module alone, as compiling with `custom_modules` was cumbersome if you also have other modules in the same parent directory (which also may or not be compatible with current Godot source). Scripts can be further simplified by removing various module detection hacks, for example in [Goost's `SConstruct`](https://github.com/goostengine/goost/blob/330b5051bbe6461927d368d8251a8eb4e77245fe/SConstruct):

```diff
diff --git a/SConstruct b/SConstruct
index 1840490..34f988f 100644
--- a/SConstruct
+++ b/SConstruct
@@ -138,14 +138,7 @@ for arg in ARGLIST:
 
 # Link this module as a custom module.
 modules = []
-modules.append(Dir("..").abspath)
-
-# This module may provide other nested modules, just like this one.
-try:
-    modules_path = config.get_modules_path()
-    modules.append(os.path.join(Dir(".").abspath, modules_path))
-except AttributeError:
-    pass
+modules.append(Dir(".").abspath)
 
 # We use the `custom_modules` build option to build this module, 
 # but allow to specify additional modules to build along this one.
@@ -155,23 +148,6 @@ if "custom_modules" in ARGUMENTS:
 
 build_args.append("custom_modules=%s" % ",".join(modules))
 
-# We cannot link to a single module using the `custom_modules` build option,
-# so this may compile other modules which reside in the same location as this 
-# module. To prevent this, we disable all modules there, excluding this one.
-if not env["parent_modules_enabled"]:
-    DIRNAMES = 1
-    dirs = next(os.walk(Dir("..").abspath))[DIRNAMES]
-    parent_modules = []
-
-    for d in dirs:
-        if d == module_name:
-            continue
-        if os.path.exists(os.path.join(Dir("..").abspath, d, "SCsub")):
-            parent_modules.append(d)
-
-    for m in parent_modules:
-        build_args.append("module_%s_enabled=no" % m)
-
 # Optionally disable Godot's built-in modules which are non-essential in order
 # to test out this module in the engine. For more details, refer to Godot docs:
 # https://docs.godotengine.org/en/latest/development/compiling/optimizing_for_size.html
```

These changes are backward-compatible with Godot 3.2 (not trivially cherry-pickable).
