### PR TITLE
GDNative XR: remove redundant `config.py`

### DIFF
--- a/modules/gdnative/xr/config.py
+++ b/modules/gdnative/xr/config.py
@@ -1,6 +1,0 @@
-def can_build(env, platform):
-    return True
-
-
-def configure(env):
-    pass


### PR DESCRIPTION
It's not an engine module. This is handled by GDNative's `SCsub` instead, as done for other subdirectories already.

This was detected by initial version of #43057, preventing the engine to be built. It's not an issue there anymore because C++ built-in modules are not collected recursively by default, but it's totally possible to re-organize `modules/`.

