### PR TITLE
Allow renaming to change the case of Windows directories

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -256,6 +256,11 @@ Error DirAccessWindows::rename(String p_path, String p_new_path) {
 
 	// If we're only changing file name case we need to do a little juggling
 	if (p_path.to_lower() == p_new_path.to_lower()) {
+		if (dir_exists(p_path)) {
+			// The path is a dir; just rename
+			return ::_wrename((LPCWSTR)(p_path.utf16().get_data()), (LPCWSTR)(p_new_path.utf16().get_data())) == 0 ? OK : FAILED;
+		}
+		// The path is a file; juggle
 		WCHAR tmpfile[MAX_PATH];
 
 		if (!GetTempFileNameW((LPCWSTR)(fix_path(get_current_dir()).utf16().get_data()), nullptr, 0, tmpfile)) {


### PR DESCRIPTION
Somewhat related to #42992, but different and on Windows.

Here are the steps to reproduce the problem that this fixes:
- On Windows, create a new folder "Foo" in Godot's file panel
- Right-click -> Rename
- Enter "foO" in the rename dialog that appears and submit it
- **Expected**: the folder is renamed to "foO".
- **Actual**: `Error moving: Foo` alert and the name is unchanged

This was only a problem with folders. Files already had a fix.

I should point out that the `::_wrename()` call used to rename the folders also works on files, so it doesn't seem like the "juggling" workaround in the existing fix is needed anymore, at least on my system.

Tested on Windows 10.

