### PR TITLE
Fixup `ColorRamp` to `Gradient` renames

### DIFF
--- a/doc/classes/Gradient.xml
+++ b/doc/classes/Gradient.xml
@@ -4,7 +4,7 @@
 		A color interpolator resource which can be used to generate colors between user-defined color points.
 	</brief_description>
 	<description>
-		Given a set of colors, this resource will interpolate them in order. This means that if you have color 1, color 2 and color 3, the ramp will interpolate from color 1 to color 2 and from color 2 to color 3. The ramp will initially have 2 colors (black and white), one (black) at ramp lower offset 0 and the other (white) at the ramp higher offset 1.
+		Given a set of colors, this resource will interpolate them in order. This means that if you have color 1, color 2 and color 3, the gradient will interpolate from color 1 to color 2 and from color 2 to color 3. The gradient will initially have 2 colors (black and white), one (black) at gradient lower offset 0 and the other (white) at the gradient higher offset 1.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -17,7 +17,7 @@
 			<argument index="1" name="color" type="Color">
 			</argument>
 			<description>
-				Adds the specified color to the end of the ramp, with the specified offset.
+				Adds the specified color to the end of the gradient, with the specified offset.
 			</description>
 		</method>
 		<method name="get_color">
@@ -26,7 +26,7 @@
 			<argument index="0" name="point" type="int">
 			</argument>
 			<description>
-				Returns the color of the ramp color at index [code]point[/code].
+				Returns the color of the gradient color at index [code]point[/code].
 			</description>
 		</method>
 		<method name="get_offset">
@@ -35,14 +35,14 @@
 			<argument index="0" name="point" type="int">
 			</argument>
 			<description>
-				Returns the offset of the ramp color at index [code]point[/code].
+				Returns the offset of the gradient color at index [code]point[/code].
 			</description>
 		</method>
 		<method name="get_point_count" qualifiers="const">
 			<return type="int">
 			</return>
 			<description>
-				Returns the number of colors in the ramp.
+				Returns the number of colors in the gradient.
 			</description>
 		</method>
 		<method name="interpolate">
@@ -71,7 +71,7 @@
 			<argument index="1" name="color" type="Color">
 			</argument>
 			<description>
-				Sets the color of the ramp color at index [code]point[/code].
+				Sets the color of the gradient color at index [code]point[/code].
 			</description>
 		</method>
 		<method name="set_offset">
@@ -82,7 +82,7 @@
 			<argument index="1" name="offset" type="float">
 			</argument>
 			<description>
-				Sets the offset for the ramp color at index [code]point[/code].
+				Sets the offset for the gradient color at index [code]point[/code].
 			</description>
 		</method>
 	</methods>

--- a/editor/plugins/gradient_editor_plugin.h
+++ b/editor/plugins/gradient_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef TOOLS_EDITOR_PLUGINS_COLOR_RAMP_EDITOR_PLUGIN_H_
-#define TOOLS_EDITOR_PLUGINS_COLOR_RAMP_EDITOR_PLUGIN_H_
+#ifndef GRADIENT_EDITOR_PLUGIN_H
+#define GRADIENT_EDITOR_PLUGIN_H
 
 #include "editor/editor_node.h"
 #include "editor/editor_plugin.h"
@@ -65,9 +65,9 @@ class GradientEditorPlugin : public EditorPlugin {
 	GDCLASS(GradientEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "ColorRamp"; }
+	virtual String get_name() const override { return "Gradient"; }
 
 	GradientEditorPlugin(EditorNode *p_node);
 };
 
-#endif /* TOOLS_EDITOR_PLUGINS_COLOR_RAMP_EDITOR_PLUGIN_H_ */
+#endif // GRADIENT_EDITOR_PLUGIN_H

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -177,7 +177,7 @@ void Line2D::set_gradient(const Ref<Gradient> &p_gradient) {
 
 	_gradient = p_gradient;
 
-	// Connect to the gradient so the line will update when the ColorRamp is changed
+	// Connect to the gradient so the line will update when the Gradient is changed
 	if (_gradient.is_valid()) {
 		_gradient->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Line2D::_gradient_changed));
 	}

--- a/scene/resources/gradient.cpp
+++ b/scene/resources/gradient.cpp
@@ -32,14 +32,8 @@
 
 #include "core/core_string_names.h"
 
-//setter and getter names for property serialization
-#define COLOR_RAMP_GET_OFFSETS "get_offsets"
-#define COLOR_RAMP_GET_COLORS "get_colors"
-#define COLOR_RAMP_SET_OFFSETS "set_offsets"
-#define COLOR_RAMP_SET_COLORS "set_colors"
-
 Gradient::Gradient() {
-	//Set initial color ramp transition from black to white
+	//Set initial gradient transition from black to white
 	points.resize(2);
 	points.write[0].color = Color(0, 0, 0, 1);
 	points.write[0].offset = 0;
@@ -65,14 +59,14 @@ void Gradient::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_point_count"), &Gradient::get_points_count);
 
-	ClassDB::bind_method(D_METHOD(COLOR_RAMP_SET_OFFSETS, "offsets"), &Gradient::set_offsets);
-	ClassDB::bind_method(D_METHOD(COLOR_RAMP_GET_OFFSETS), &Gradient::get_offsets);
+	ClassDB::bind_method(D_METHOD("set_offsets", "offsets"), &Gradient::set_offsets);
+	ClassDB::bind_method(D_METHOD("get_offsets"), &Gradient::get_offsets);
 
-	ClassDB::bind_method(D_METHOD(COLOR_RAMP_SET_COLORS, "colors"), &Gradient::set_colors);
-	ClassDB::bind_method(D_METHOD(COLOR_RAMP_GET_COLORS), &Gradient::get_colors);
+	ClassDB::bind_method(D_METHOD("set_colors", "colors"), &Gradient::set_colors);
+	ClassDB::bind_method(D_METHOD("get_colors"), &Gradient::get_colors);
 
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "offsets"), COLOR_RAMP_SET_OFFSETS, COLOR_RAMP_GET_OFFSETS);
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_COLOR_ARRAY, "colors"), COLOR_RAMP_SET_COLORS, COLOR_RAMP_GET_COLORS);
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "offsets"), "set_offsets", "get_offsets");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_COLOR_ARRAY, "colors"), "set_colors", "get_colors");
 }
 
 Vector<float> Gradient::get_offsets() const {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1738,12 +1738,6 @@ CurveTexture::~CurveTexture() {
 
 //////////////////
 
-//setter and getter names for property serialization
-#define COLOR_RAMP_GET_OFFSETS "get_offsets"
-#define COLOR_RAMP_GET_COLORS "get_colors"
-#define COLOR_RAMP_SET_OFFSETS "set_offsets"
-#define COLOR_RAMP_SET_COLORS "set_colors"
-
 GradientTexture::GradientTexture() {
 	update_pending = false;
 	width = 2048;


### PR DESCRIPTION
See previous renames bb20f230ad307a2a5f18c03bece3793d29ae208a and #9160.

There are other occurrences of "ramp" or "color_ramp", like in `CPUParticles`, `ParticlesMaterial` and `Environment` (also used via shaders), but I haven't touched those because those do not necessarily represent *gradient* textures I presume, so I've only done unambiguous, obvious changes here.

Detected while working on #42855.
