### PR TITLE
Keep property values when extending script

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3603,7 +3603,10 @@ void EditorPropertyResource::_resource_selected(const Ref<Resource> &p_resource,
 void EditorPropertyResource::_resource_changed(const Ref<Resource> &p_resource) {
 	// Make visual script the correct type.
 	Ref<Script> s = p_resource;
+	bool is_script = false;
 	if (get_edited_object() && s.is_valid()) {
+		is_script = true;
+		InspectorDock::get_singleton()->store_script_properties(get_edited_object());
 		s->call("set_instance_base_type", get_edited_object()->get_class());
 	}
 
@@ -3628,6 +3631,11 @@ void EditorPropertyResource::_resource_changed(const Ref<Resource> &p_resource) 
 
 	emit_changed(get_edited_property(), p_resource);
 	update_property();
+
+	if (is_script) {
+		// Restore properties if script was changed.
+		InspectorDock::get_singleton()->apply_script_properties(get_edited_object());
+	}
 
 	// Automatically suggest setting up the path for a ViewportTexture.
 	if (vpt.is_valid() && vpt->get_viewport_path_in_scene().is_empty()) {

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -453,6 +453,9 @@ void InspectorDock::_bind_methods() {
 
 	ClassDB::bind_method("edit_resource", &InspectorDock::edit_resource);
 
+	ClassDB::bind_method("store_script_properties", &InspectorDock::store_script_properties);
+	ClassDB::bind_method("apply_script_properties", &InspectorDock::apply_script_properties);
+
 	ADD_SIGNAL(MethodInfo("request_help"));
 }
 
@@ -563,6 +566,31 @@ void InspectorDock::go_back() {
 
 EditorPropertyNameProcessor::Style InspectorDock::get_property_name_style() const {
 	return property_name_style;
+}
+
+void InspectorDock::store_script_properties(Object *p_object) {
+	ERR_FAIL_NULL(p_object);
+	ScriptInstance *si = p_object->get_script_instance();
+	if (!si) {
+		return;
+	}
+	si->get_property_state(stored_properties);
+}
+
+void InspectorDock::apply_script_properties(Object *p_object) {
+	ERR_FAIL_NULL(p_object);
+	ScriptInstance *si = p_object->get_script_instance();
+	if (!si) {
+		return;
+	}
+
+	for (const Pair<StringName, Variant> &E : stored_properties) {
+		Variant current;
+		if (si->get(E.first, current) && current.get_type() == E.second.get_type()) {
+			si->set(E.first, E.second);
+		}
+	}
+	stored_properties.clear();
 }
 
 InspectorDock::InspectorDock(EditorData &p_editor_data) {

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -100,6 +100,7 @@ class InspectorDock : public VBoxContainer {
 	Tree *unique_resources_list_tree = nullptr;
 
 	EditorPropertyNameProcessor::Style property_name_style;
+	List<Pair<StringName, Variant>> stored_properties;
 
 	void _prepare_menu();
 	void _menu_option(int p_option);
@@ -148,6 +149,9 @@ public:
 	EditorInspector *get_inspector() { return inspector; }
 
 	EditorPropertyNameProcessor::Style get_property_name_style() const;
+
+	void store_script_properties(Object *p_object);
+	void apply_script_properties(Object *p_object);
 
 	InspectorDock(EditorData &p_editor_data);
 	~InspectorDock();


### PR DESCRIPTION
Closes #37480
EDIT: Closes https://github.com/godotengine/godot-proposals/issues/4415

~~This can also trigger when replacing a script for one node. Making it work only with script extending would make the code more complicated, because the editor doesn't really differentiate between extending and attaching. I don't think this is a big issue.~~

I added 2 methods in EditorNode:
`store_object_properties()` and `apply_object_properties()`. The first one gets properties from the script instance and stores it in EditorNode, the second one applies it to the new instance, to the properties that have matching name and type. The intended usage is that you call these methods as part of a UndoRedo action that changes script and the exported values are carried to the new script.

The values will be preserved when:
- extending script
- making script unique
- attaching a new script
- if you know any other action that can potentially clear exported variables, please comment