### PR TITLE
Clarify what the "item_rect_changed" signal does

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -640,7 +640,7 @@
 		</signal>
 		<signal name="item_rect_changed">
 			<description>
-				Emitted when the item rect has changed.
+				Emitted when the item's [Rect2] boundaries (position or size) have changed, or when an action is taking place that may have impacted these boundaries (e.g. changing [member Sprite2D.texture]).
 			</description>
 		</signal>
 		<signal name="visibility_changed">


### PR DESCRIPTION
Clarify what the "item_rect_changed" signal does for CanvasItem by adding to its description. Right now, the docs don't actually explain what "item_rect_changed" means in exact terms. This is an improvement to clarity in a concise manner.

Fixes: #39671

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
