### PR TITLE
[3.2] Do not raise exception if iOS SDK is not installed.

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -717,7 +717,7 @@ def get_darwin_sdk_version(platform):
         return float(decode_utf8(subprocess.check_output(["xcrun", "--sdk", sdk_name, "--show-sdk-version"]).strip()))
     except (subprocess.CalledProcessError, OSError):
         print("Failed to find SDK version while running xcrun --sdk {} --show-sdk-version.".format(sdk_name))
-        raise
+        return 0.0
 
 
 def detect_darwin_sdk_path(platform, env):


### PR DESCRIPTION
Fixes #43090
