### PR TITLE
Rename Node's `rpc()` and `rset()` to `call_remote()` and `set_remote()`

### DIFF
--- a/core/io/multiplayer_api.h
+++ b/core/io/multiplayer_api.h
@@ -103,13 +103,13 @@ public:
 
 	enum RPCMode {
 
-		RPC_MODE_DISABLED, // No rpc for this method, calls to this will be blocked (default)
-		RPC_MODE_REMOTE, // Using rpc() on it will call method / set property in all remote peers
-		RPC_MODE_MASTER, // Using rpc() on it will call method on wherever the master is, be it local or remote
-		RPC_MODE_PUPPET, // Using rpc() on it will call method for all puppets
-		RPC_MODE_REMOTESYNC, // Using rpc() on it will call method / set property in all remote peers and locally
-		RPC_MODE_MASTERSYNC, // Using rpc() on it will call method / set property in the master peer and locally
-		RPC_MODE_PUPPETSYNC, // Using rpc() on it will call method / set property in all puppets peers and locally
+		RPC_MODE_DISABLED, // No RPC for this method, calls to this will be blocked (default)
+		RPC_MODE_REMOTE, // Using `call_remote()` on it will call method / set property in all remote peers
+		RPC_MODE_MASTER, // Using `call_remote()` on it will call method on wherever the master is, be it local or remote
+		RPC_MODE_PUPPET, // Using `call_remote()` on it will call method for all puppets
+		RPC_MODE_REMOTESYNC, // Using `call_remote()` on it will call method / set property in all remote peers and locally
+		RPC_MODE_MASTERSYNC, // Using `call_remote()` on it will call method / set property in the master peer and locally
+		RPC_MODE_PUPPETSYNC, // Using `call_remote()` on it will call method / set property in all puppets peers and locally
 	};
 
 	void poll();

--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -140,16 +140,16 @@
 	</signals>
 	<constants>
 		<constant name="RPC_MODE_DISABLED" value="0" enum="RPCMode">
-			Used with [method Node.rpc_config] or [method Node.rset_config] to disable a method or property for all RPC calls, making it unavailable. Default for all methods.
+			Used with [method Node.call_remote_config] or [method Node.set_remote_config] to disable a method or property for all RPC calls, making it unavailable. Default for all methods.
 		</constant>
 		<constant name="RPC_MODE_REMOTE" value="1" enum="RPCMode">
-			Used with [method Node.rpc_config] or [method Node.rset_config] to set a method to be called or a property to be changed only on the remote end, not locally. Analogous to the [code]remote[/code] keyword. Calls and property changes are accepted from all remote peers, no matter if they are node's master or puppets.
+			Used with [method Node.call_remote_config] or [method Node.set_remote_config] to set a method to be called or a property to be changed only on the remote end, not locally. Analogous to the [code]remote[/code] keyword. Calls and property changes are accepted from all remote peers, no matter if they are node's master or puppets.
 		</constant>
 		<constant name="RPC_MODE_MASTER" value="2" enum="RPCMode">
-			Used with [method Node.rpc_config] or [method Node.rset_config] to set a method to be called or a property to be changed only on the network master for this node. Analogous to the [code]master[/code] keyword. Only accepts calls or property changes from the node's network puppets, see [method Node.set_network_master].
+			Used with [method Node.call_remote_config] or [method Node.set_remote_config] to set a method to be called or a property to be changed only on the network master for this node. Analogous to the [code]master[/code] keyword. Only accepts calls or property changes from the node's network puppets, see [method Node.set_network_master].
 		</constant>
 		<constant name="RPC_MODE_PUPPET" value="3" enum="RPCMode">
-			Used with [method Node.rpc_config] or [method Node.rset_config] to set a method to be called or a property to be changed only on puppets for this node. Analogous to the [code]puppet[/code] keyword. Only accepts calls or property changes from the node's network master, see [method Node.set_network_master].
+			Used with [method Node.call_remote_config] or [method Node.set_remote_config] to set a method to be called or a property to be changed only on puppets for this node. Analogous to the [code]puppet[/code] keyword. Only accepts calls or property changes from the node's network master, see [method Node.set_network_master].
 		</constant>
 		<constant name="RPC_MODE_REMOTESYNC" value="4" enum="RPCMode">
 			Behave like [constant RPC_MODE_REMOTE] but also make the call or property change locally. Analogous to the [code]remotesync[/code] keyword.

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -14,7 +14,7 @@
 		To keep track of the scene hierarchy (especially when instancing scenes into other scenes), an "owner" can be set for the node with the [member owner] property. This keeps track of who instanced what. This is mostly useful when writing editors and tools, though.
 		Finally, when a node is freed with [method Object.free] or [method queue_free], it will also free all its children.
 		[b]Groups:[/b] Nodes can be added to as many groups as you want to be easy to manage, you could create groups like "enemies" or "collectables" for example, depending on your game. See [method add_to_group], [method is_in_group] and [method remove_from_group]. You can then retrieve all nodes in these groups, iterate them and even call methods on groups via the methods on [SceneTree].
-		[b]Networking with nodes:[/b] After connecting to a server (or making one, see [NetworkedMultiplayerENet]), it is possible to use the built-in RPC (remote procedure call) system to communicate over the network. By calling [method rpc] with a method name, it will be called locally and in all connected peers (peers = clients and the server that accepts connections). To identify which node receives the RPC call, Godot will use its [NodePath] (make sure node names are the same on all peers). Also, take a look at the high-level networking tutorial and corresponding demos.
+		[b]Networking with nodes:[/b] After connecting to a server (or making one, see [NetworkedMultiplayerENet]), it is possible to use the built-in RPC (remote procedure call) system to communicate over the network. By calling [method call_remote] with a method name, it will be called locally and in all connected peers (peers = clients and the server that accepts connections). To identify which node receives the RPC call, Godot will use its [NodePath] (make sure node names are the same on all peers). Also, take a look at the [url=https://docs.godotengine.org/en/latest/tutorials/networking/high_level_multiplayer.html]high-level networking tutorial[/url] and corresponding demos.
 	</description>
 	<tutorials>
 		<link title="Scenes and nodes">https://docs.godotengine.org/en/latest/getting_started/step_by_step/scenes_and_nodes.html</link>
@@ -162,6 +162,58 @@
 			<description>
 				Adds the node to a group. Groups are helpers to name and organize a subset of nodes, for example "enemies" or "collectables". A node can be in any number of groups. Nodes can be assigned a group at any time, but will not be added until they are inside the scene tree (see [method is_inside_tree]). See notes in the description, and the group methods in [SceneTree].
 				The [code]persistent[/code] option is used when packing node to [PackedScene] and saving to file. Non-persistent groups aren't stored.
+			</description>
+		</method>
+		<method name="call_remote" qualifiers="vararg">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="method" type="StringName">
+			</argument>
+			<description>
+				Sends a remote procedure call request for the given [code]method[/code] to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same [NodePath], including the exact same node name. Behaviour depends on the RPC configuration for the given method, see [method call_remote_config]. Methods are not exposed to RPCs by default. See also [method set_remote] and [method set_remote_config] for properties. Returns an empty [Variant].
+				[b]Note:[/b] You can only safely use RPCs on clients after you received the [code]connected_to_server[/code] signal from the [SceneTree]. You also need to keep track of the connection state, either by the [SceneTree] signals like [code]server_disconnected[/code] or by checking [code]SceneTree.network_peer.get_connection_status() == CONNECTION_CONNECTED[/code].
+			</description>
+		</method>
+		<method name="call_remote_config">
+			<return type="int">
+			</return>
+			<argument index="0" name="method" type="StringName">
+			</argument>
+			<argument index="1" name="mode" type="int" enum="MultiplayerAPI.RPCMode">
+			</argument>
+			<description>
+				Changes the RPC mode for the given [code]method[/code] to the given [code]mode[/code]. See [enum MultiplayerAPI.RPCMode]. An alternative is annotating methods and properties with the corresponding keywords ([code]remote[/code], [code]master[/code], [code]puppet[/code], [code]remotesync[/code], [code]mastersync[/code], [code]puppetsync[/code]). By default, methods are not exposed to networking (and RPCs). See also [method set_remote] and [method set_remote_config] for properties.
+			</description>
+		</method>
+		<method name="call_remote_id" qualifiers="vararg">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="peer_id" type="int">
+			</argument>
+			<argument index="1" name="method" type="StringName">
+			</argument>
+			<description>
+				Sends a [method call_remote] to a specific peer identified by [code]peer_id[/code] (see [method NetworkedMultiplayerPeer.set_target_peer]). Returns an empty [Variant].
+			</description>
+		</method>
+		<method name="call_remote_unreliable" qualifiers="vararg">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="method" type="StringName">
+			</argument>
+			<description>
+				Sends a [method call_remote] using an unreliable protocol. Returns an empty [Variant].
+			</description>
+		</method>
+		<method name="call_remote_unreliable_id" qualifiers="vararg">
+			<return type="Variant">
+			</return>
+			<argument index="0" name="peer_id" type="int">
+			</argument>
+			<argument index="1" name="method" type="StringName">
+			</argument>
+			<description>
+				Sends a [method call_remote] to a specific peer identified by [code]peer_id[/code] using an unreliable protocol (see [method NetworkedMultiplayerPeer.set_target_peer]). Returns an empty [Variant].
 			</description>
 		</method>
 		<method name="can_process" qualifiers="const">
@@ -610,117 +662,6 @@
 				Requests that [code]_ready[/code] be called again. Note that the method won't be called immediately, but is scheduled for when the node is added to the scene tree again (see [method _ready]). [code]_ready[/code] is called only for the node which requested it, which means that you need to request ready for each child if you want them to call [code]_ready[/code] too (in which case, [code]_ready[/code] will be called in the same order as it would normally).
 			</description>
 		</method>
-		<method name="rpc" qualifiers="vararg">
-			<return type="Variant">
-			</return>
-			<argument index="0" name="method" type="StringName">
-			</argument>
-			<description>
-				Sends a remote procedure call request for the given [code]method[/code] to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same [NodePath], including the exact same node name. Behaviour depends on the RPC configuration for the given method, see [method rpc_config]. Methods are not exposed to RPCs by default. See also [method rset] and [method rset_config] for properties. Returns an empty [Variant].
-				[b]Note:[/b] You can only safely use RPCs on clients after you received the [code]connected_to_server[/code] signal from the [SceneTree]. You also need to keep track of the connection state, either by the [SceneTree] signals like [code]server_disconnected[/code] or by checking [code]SceneTree.network_peer.get_connection_status() == CONNECTION_CONNECTED[/code].
-			</description>
-		</method>
-		<method name="rpc_config">
-			<return type="int">
-			</return>
-			<argument index="0" name="method" type="StringName">
-			</argument>
-			<argument index="1" name="mode" type="int" enum="MultiplayerAPI.RPCMode">
-			</argument>
-			<description>
-				Changes the RPC mode for the given [code]method[/code] to the given [code]mode[/code]. See [enum MultiplayerAPI.RPCMode]. An alternative is annotating methods and properties with the corresponding keywords ([code]remote[/code], [code]master[/code], [code]puppet[/code], [code]remotesync[/code], [code]mastersync[/code], [code]puppetsync[/code]). By default, methods are not exposed to networking (and RPCs). See also [method rset] and [method rset_config] for properties.
-			</description>
-		</method>
-		<method name="rpc_id" qualifiers="vararg">
-			<return type="Variant">
-			</return>
-			<argument index="0" name="peer_id" type="int">
-			</argument>
-			<argument index="1" name="method" type="StringName">
-			</argument>
-			<description>
-				Sends a [method rpc] to a specific peer identified by [code]peer_id[/code] (see [method NetworkedMultiplayerPeer.set_target_peer]). Returns an empty [Variant].
-			</description>
-		</method>
-		<method name="rpc_unreliable" qualifiers="vararg">
-			<return type="Variant">
-			</return>
-			<argument index="0" name="method" type="StringName">
-			</argument>
-			<description>
-				Sends a [method rpc] using an unreliable protocol. Returns an empty [Variant].
-			</description>
-		</method>
-		<method name="rpc_unreliable_id" qualifiers="vararg">
-			<return type="Variant">
-			</return>
-			<argument index="0" name="peer_id" type="int">
-			</argument>
-			<argument index="1" name="method" type="StringName">
-			</argument>
-			<description>
-				Sends a [method rpc] to a specific peer identified by [code]peer_id[/code] using an unreliable protocol (see [method NetworkedMultiplayerPeer.set_target_peer]). Returns an empty [Variant].
-			</description>
-		</method>
-		<method name="rset">
-			<return type="void">
-			</return>
-			<argument index="0" name="property" type="StringName">
-			</argument>
-			<argument index="1" name="value" type="Variant">
-			</argument>
-			<description>
-				Remotely changes a property's value on other peers (and locally). Behaviour depends on the RPC configuration for the given property, see [method rset_config]. See also [method rpc] for RPCs for methods, most information applies to this method as well.
-			</description>
-		</method>
-		<method name="rset_config">
-			<return type="int">
-			</return>
-			<argument index="0" name="property" type="StringName">
-			</argument>
-			<argument index="1" name="mode" type="int" enum="MultiplayerAPI.RPCMode">
-			</argument>
-			<description>
-				Changes the RPC mode for the given [code]property[/code] to the given [code]mode[/code]. See [enum MultiplayerAPI.RPCMode]. An alternative is annotating methods and properties with the corresponding keywords ([code]remote[/code], [code]master[/code], [code]puppet[/code], [code]remotesync[/code], [code]mastersync[/code], [code]puppetsync[/code]). By default, properties are not exposed to networking (and RPCs). See also [method rpc] and [method rpc_config] for methods.
-			</description>
-		</method>
-		<method name="rset_id">
-			<return type="void">
-			</return>
-			<argument index="0" name="peer_id" type="int">
-			</argument>
-			<argument index="1" name="property" type="StringName">
-			</argument>
-			<argument index="2" name="value" type="Variant">
-			</argument>
-			<description>
-				Remotely changes the property's value on a specific peer identified by [code]peer_id[/code] (see [method NetworkedMultiplayerPeer.set_target_peer]).
-			</description>
-		</method>
-		<method name="rset_unreliable">
-			<return type="void">
-			</return>
-			<argument index="0" name="property" type="StringName">
-			</argument>
-			<argument index="1" name="value" type="Variant">
-			</argument>
-			<description>
-				Remotely changes the property's value on other peers (and locally) using an unreliable protocol.
-			</description>
-		</method>
-		<method name="rset_unreliable_id">
-			<return type="void">
-			</return>
-			<argument index="0" name="peer_id" type="int">
-			</argument>
-			<argument index="1" name="property" type="StringName">
-			</argument>
-			<argument index="2" name="value" type="Variant">
-			</argument>
-			<description>
-				Remotely changes property's value on a specific peer identified by [code]peer_id[/code] using an unreliable protocol (see [method NetworkedMultiplayerPeer.set_target_peer]).
-			</description>
-		</method>
 		<method name="set_display_folded">
 			<return type="void">
 			</return>
@@ -804,6 +745,65 @@
 				Enables unhandled key input processing. Enabled automatically if [method _unhandled_key_input] is overridden. Any calls to this before [method _ready] will be ignored.
 			</description>
 		</method>
+		<method name="set_remote">
+			<return type="void">
+			</return>
+			<argument index="0" name="property" type="StringName">
+			</argument>
+			<argument index="1" name="value" type="Variant">
+			</argument>
+			<description>
+				Remotely changes a property's value on other peers (and locally). Behaviour depends on the RPC configuration for the given property, see [method set_remote_config]. See also [method call_remote] for RPCs for methods, most information applies to this method as well.
+			</description>
+		</method>
+		<method name="set_remote_config">
+			<return type="int">
+			</return>
+			<argument index="0" name="property" type="StringName">
+			</argument>
+			<argument index="1" name="mode" type="int" enum="MultiplayerAPI.RPCMode">
+			</argument>
+			<description>
+				Changes the RPC mode for the given [code]property[/code] to the given [code]mode[/code]. See [enum MultiplayerAPI.RPCMode]. An alternative is annotating methods and properties with the corresponding keywords ([code]remote[/code], [code]master[/code], [code]puppet[/code], [code]remotesync[/code], [code]mastersync[/code], [code]puppetsync[/code]). By default, properties are not exposed to networking (and RPCs). See also [method call_remote] and [method call_remote_config] for methods.
+			</description>
+		</method>
+		<method name="set_remote_id">
+			<return type="void">
+			</return>
+			<argument index="0" name="peer_id" type="int">
+			</argument>
+			<argument index="1" name="property" type="StringName">
+			</argument>
+			<argument index="2" name="value" type="Variant">
+			</argument>
+			<description>
+				Remotely changes the property's value on a specific peer identified by [code]peer_id[/code] (see [method NetworkedMultiplayerPeer.set_target_peer]).
+			</description>
+		</method>
+		<method name="set_remote_unreliable">
+			<return type="void">
+			</return>
+			<argument index="0" name="property" type="StringName">
+			</argument>
+			<argument index="1" name="value" type="Variant">
+			</argument>
+			<description>
+				Remotely changes the property's value on other peers (and locally) using an unreliable protocol.
+			</description>
+		</method>
+		<method name="set_remote_unreliable_id">
+			<return type="void">
+			</return>
+			<argument index="0" name="peer_id" type="int">
+			</argument>
+			<argument index="1" name="property" type="StringName">
+			</argument>
+			<argument index="2" name="value" type="Variant">
+			</argument>
+			<description>
+				Remotely changes property's value on a specific peer identified by [code]peer_id[/code] using an unreliable protocol (see [method NetworkedMultiplayerPeer.set_target_peer]).
+			</description>
+		</method>
 		<method name="set_scene_instance_load_placeholder">
 			<return type="void">
 			</return>
@@ -817,7 +817,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Updates the warning displayed for this node in the Scene Dock.
+				Updates the warning displayed for this node in the Scene tree dock.
 				Use [method _get_configuration_warning] to setup the warning message to display.
 			</description>
 		</method>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -492,7 +492,7 @@ uint16_t Node::rset_config(const StringName &p_property, MultiplayerAPI::RPCMode
 
 /***** RPC FUNCTIONS ********/
 
-void Node::rpc(const StringName &p_method, VARIANT_ARG_DECLARE) {
+void Node::call_remote(const StringName &p_method, VARIANT_ARG_DECLARE) {
 	VARIANT_ARGPTRS;
 
 	int argc = 0;
@@ -506,7 +506,7 @@ void Node::rpc(const StringName &p_method, VARIANT_ARG_DECLARE) {
 	rpcp(0, false, p_method, argptr, argc);
 }
 
-void Node::rpc_id(int p_peer_id, const StringName &p_method, VARIANT_ARG_DECLARE) {
+void Node::call_remote_id(int p_peer_id, const StringName &p_method, VARIANT_ARG_DECLARE) {
 	VARIANT_ARGPTRS;
 
 	int argc = 0;
@@ -520,7 +520,7 @@ void Node::rpc_id(int p_peer_id, const StringName &p_method, VARIANT_ARG_DECLARE
 	rpcp(p_peer_id, false, p_method, argptr, argc);
 }
 
-void Node::rpc_unreliable(const StringName &p_method, VARIANT_ARG_DECLARE) {
+void Node::call_remote_unreliable(const StringName &p_method, VARIANT_ARG_DECLARE) {
 	VARIANT_ARGPTRS;
 
 	int argc = 0;
@@ -534,7 +534,7 @@ void Node::rpc_unreliable(const StringName &p_method, VARIANT_ARG_DECLARE) {
 	rpcp(0, true, p_method, argptr, argc);
 }
 
-void Node::rpc_unreliable_id(int p_peer_id, const StringName &p_method, VARIANT_ARG_DECLARE) {
+void Node::call_remote_unreliable_id(int p_peer_id, const StringName &p_method, VARIANT_ARG_DECLARE) {
 	VARIANT_ARGPTRS;
 
 	int argc = 0;
@@ -663,19 +663,19 @@ void Node::rsetp(int p_peer_id, bool p_unreliable, const StringName &p_property,
 }
 
 /******** RSET *********/
-void Node::rset(const StringName &p_property, const Variant &p_value) {
+void Node::set_remote(const StringName &p_property, const Variant &p_value) {
 	rsetp(0, false, p_property, p_value);
 }
 
-void Node::rset_id(int p_peer_id, const StringName &p_property, const Variant &p_value) {
+void Node::set_remote_id(int p_peer_id, const StringName &p_property, const Variant &p_value) {
 	rsetp(p_peer_id, false, p_property, p_value);
 }
 
-void Node::rset_unreliable(const StringName &p_property, const Variant &p_value) {
+void Node::set_remote_unreliable(const StringName &p_property, const Variant &p_value) {
 	rsetp(0, true, p_property, p_value);
 }
 
-void Node::rset_unreliable_id(int p_peer_id, const StringName &p_property, const Variant &p_value) {
+void Node::set_remote_unreliable_id(int p_peer_id, const StringName &p_property, const Variant &p_value) {
 	rsetp(p_peer_id, true, p_property, p_value);
 }
 
@@ -2819,23 +2819,23 @@ void Node::_bind_methods() {
 
 		mi.arguments.push_back(PropertyInfo(Variant::STRING_NAME, "method"));
 
-		mi.name = "rpc";
-		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "rpc", &Node::_rpc_bind, mi);
-		mi.name = "rpc_unreliable";
-		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "rpc_unreliable", &Node::_rpc_unreliable_bind, mi);
+		mi.name = "call_remote";
+		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "call_remote", &Node::_rpc_bind, mi);
+		mi.name = "call_remote_unreliable";
+		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "call_remote_unreliable", &Node::_rpc_unreliable_bind, mi);
 
 		mi.arguments.push_front(PropertyInfo(Variant::INT, "peer_id"));
 
-		mi.name = "rpc_id";
-		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "rpc_id", &Node::_rpc_id_bind, mi);
-		mi.name = "rpc_unreliable_id";
-		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "rpc_unreliable_id", &Node::_rpc_unreliable_id_bind, mi);
+		mi.name = "call_remote_id";
+		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "call_remote_id", &Node::_rpc_id_bind, mi);
+		mi.name = "call_remote_unreliable_id";
+		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "call_remote_unreliable_id", &Node::_rpc_unreliable_id_bind, mi);
 	}
 
-	ClassDB::bind_method(D_METHOD("rset", "property", "value"), &Node::rset);
-	ClassDB::bind_method(D_METHOD("rset_id", "peer_id", "property", "value"), &Node::rset_id);
-	ClassDB::bind_method(D_METHOD("rset_unreliable", "property", "value"), &Node::rset_unreliable);
-	ClassDB::bind_method(D_METHOD("rset_unreliable_id", "peer_id", "property", "value"), &Node::rset_unreliable_id);
+	ClassDB::bind_method(D_METHOD("set_remote", "property", "value"), &Node::set_remote);
+	ClassDB::bind_method(D_METHOD("set_remote_id", "peer_id", "property", "value"), &Node::set_remote_id);
+	ClassDB::bind_method(D_METHOD("set_remote_unreliable", "property", "value"), &Node::set_remote_unreliable);
+	ClassDB::bind_method(D_METHOD("set_remote_unreliable_id", "peer_id", "property", "value"), &Node::set_remote_unreliable_id);
 
 	ClassDB::bind_method(D_METHOD("update_configuration_warning"), &Node::update_configuration_warning);
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -432,15 +432,15 @@ public:
 	uint16_t rpc_config(const StringName &p_method, MultiplayerAPI::RPCMode p_mode); // config a local method for RPC
 	uint16_t rset_config(const StringName &p_property, MultiplayerAPI::RPCMode p_mode); // config a local property for RPC
 
-	void rpc(const StringName &p_method, VARIANT_ARG_LIST); //rpc call, honors RPCMode
-	void rpc_unreliable(const StringName &p_method, VARIANT_ARG_LIST); //rpc call, honors RPCMode
-	void rpc_id(int p_peer_id, const StringName &p_method, VARIANT_ARG_LIST); //rpc call, honors RPCMode
-	void rpc_unreliable_id(int p_peer_id, const StringName &p_method, VARIANT_ARG_LIST); //rpc call, honors RPCMode
+	void call_remote(const StringName &p_method, VARIANT_ARG_LIST); //rpc call, honors RPCMode
+	void call_remote_unreliable(const StringName &p_method, VARIANT_ARG_LIST); //rpc call, honors RPCMode
+	void call_remote_id(int p_peer_id, const StringName &p_method, VARIANT_ARG_LIST); //rpc call, honors RPCMode
+	void call_remote_unreliable_id(int p_peer_id, const StringName &p_method, VARIANT_ARG_LIST); //rpc call, honors RPCMode
 
-	void rset(const StringName &p_property, const Variant &p_value); //remote set call, honors RPCMode
-	void rset_unreliable(const StringName &p_property, const Variant &p_value); //remote set call, honors RPCMode
-	void rset_id(int p_peer_id, const StringName &p_property, const Variant &p_value); //remote set call, honors RPCMode
-	void rset_unreliable_id(int p_peer_id, const StringName &p_property, const Variant &p_value); //remote set call, honors RPCMode
+	void set_remote(const StringName &p_property, const Variant &p_value); //remote set call, honors RPCMode
+	void set_remote_unreliable(const StringName &p_property, const Variant &p_value); //remote set call, honors RPCMode
+	void set_remote_id(int p_peer_id, const StringName &p_property, const Variant &p_value); //remote set call, honors RPCMode
+	void set_remote_unreliable_id(int p_peer_id, const StringName &p_property, const Variant &p_value); //remote set call, honors RPCMode
 
 	void rpcp(int p_peer_id, bool p_unreliable, const StringName &p_method, const Variant **p_arg, int p_argcount);
 	void rsetp(int p_peer_id, bool p_unreliable, const StringName &p_property, const Variant &p_value);


### PR DESCRIPTION
The new naming matches Object's `call()` and `set()` methods, making it more consistent and less cryptic.

See https://github.com/godotengine/godot/issues/16863#issuecomment-568718291 for rationale.