### PR TITLE
Auto-conversion between int and float constants for some cases in shader

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -567,6 +567,9 @@ public:
 		BlockNode *body = nullptr;
 		bool can_discard = false;
 
+		virtual DataType get_datatype() const { return return_type; }
+		virtual String get_datatype_name() const { return String(return_struct_name); }
+
 		FunctionNode() :
 				Node(TYPE_FUNCTION) {}
 	};
@@ -854,6 +857,7 @@ private:
 
 	Error _validate_datatype(DataType p_type);
 	bool _compare_datatypes_in_nodes(Node *a, Node *b) const;
+	void _convert_datatypes(Node *p_a, Node *p_b);
 
 	bool _validate_function_call(BlockNode *p_block, const FunctionInfo &p_function_info, OperatorNode *p_func, DataType *r_ret_type, StringName *r_ret_type_str);
 	bool _parse_function_arguments(BlockNode *p_block, const FunctionInfo &p_function_info, OperatorNode *p_func, int *r_complete_arg = nullptr);


### PR DESCRIPTION
This will enhance the shader parser by automatically converts int to float (and vice-versa) constants in operations like assignments, if, and return statements. 

The examples:

```
float t = 1.0 * 5 + 10.0 / 2;
```

```
vec3 color;
color.r = 1;
```

```
int test() {
   return 0.0;
}
```

```
if(1 == 1.0) { ... }
```

Notes: 

- this is just a parser enhancement and doesn't affect the compiler.

- variables and function calls are not affected by this change which means you still need to convert a result of them like: `float t = float(test()) + 1;` but the concatenation with the constant is work for them.

Targets to close https://github.com/godotengine/godot-proposals/issues/1223