### PR TITLE
Add `Vector2` circle points generation method to `RandomNumberGenerator`

### DIFF
--- a/core/math/random_number_generator.cpp
+++ b/core/math/random_number_generator.cpp
@@ -40,5 +40,6 @@ void RandomNumberGenerator::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("randfn", "mean", "deviation"), &RandomNumberGenerator::randfn, DEFVAL(0.0), DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("randf_range", "from", "to"), &RandomNumberGenerator::randf_range);
 	ClassDB::bind_method(D_METHOD("randi_range", "from", "to"), &RandomNumberGenerator::randi_range);
+	ClassDB::bind_method(D_METHOD("randv_circle", "min_radius", "max_radius"), &RandomNumberGenerator::randv_circle, DEFVAL(1.0), DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("randomize"), &RandomNumberGenerator::randomize);
 }

--- a/core/math/random_number_generator.h
+++ b/core/math/random_number_generator.h
@@ -66,6 +66,14 @@ public:
 		}
 	}
 
+	_FORCE_INLINE_ Vector2 randv_circle(real_t p_min_radius = 1.0, real_t p_max_radius = 1.0) { // Unit length by default.
+		real_t r2_max = p_max_radius * p_max_radius;
+		real_t r2_min = p_min_radius * p_min_radius;
+		real_t r = Math::sqrt(randbase.random(0.0, 1.0) * (r2_max - r2_min) + r2_min);
+		real_t t = randbase.random(0.0, 1.0) * Math_TAU;
+		return Vector2(r * Math::cos(t), r * Math::sin(t));
+	}
+
 	RandomNumberGenerator() {}
 };
 

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -72,6 +72,34 @@
 				Setups a time-based seed to generator.
 			</description>
 		</method>
+		<method name="randv_circle">
+			<return type="Vector2">
+			</return>
+			<argument index="0" name="min_radius" type="float" default="1.0">
+			</argument>
+			<argument index="1" name="max_radius" type="float" default="1.0">
+			</argument>
+			<description>
+				Generates a random point uniformly distributed on the circle's boundary, within the circle's area, or the area confined by inner and outer circle ranges specified with [code]min_radius[/code] and [code]max_radius[/code] parameters.
+				By default, generates points [b]on[/b] unit circle with radius [code]1[/code], which produces normalized vectors.
+				If [code]min_radius == 0[/code], generates points inside a unit circle, such that [method Geometry2D.is_point_in_circle] shall return [code]true[/code] given the same radius.
+				If [code]min_radius != max_radius[/code], generates points in a ring, such that the inner area remains unaffected.
+				If [code]min_radius == max_radius[/code], generates points exactly [b]on[/b] the circle's boundary, but do note that a point may slightly deviate from the actual circle's boundary due to floating point error accumulation.
+				[codeblock]
+				var rng = RandomNumberGenerator.new()
+				var point: Vector2()
+				point = rng.randv_circle() # Unit vector.
+				point = rng.randv_circle(0.0, 1.0) # Inside a circle.
+				point = rng.randv_circle(0.5, 1.0) # Within a ring.
+				[/codeblock]
+				The [code]min_radius[/code] and [code]max_radius[/code] are not restricted to unit length of [code]1[/code]. The generated unit vector can be multiplied by a scalar value as well:
+				[codeblock]
+				var rng = RandomNumberGenerator.new()
+				var radius = 64.0
+				var point = rng.randv_circle() * radius
+				[/codeblock]
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="seed" type="int" setter="set_seed" getter="get_seed" default="-6398989897141750821">

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -47,6 +47,7 @@
 #include "test_ordered_hash_map.h"
 #include "test_physics_2d.h"
 #include "test_physics_3d.h"
+#include "test_random_number_generator.h"
 #include "test_render.h"
 #include "test_shader_lang.h"
 #include "test_string.h"

--- a/tests/test_random_number_generator.h
+++ b/tests/test_random_number_generator.h
@@ -1,0 +1,110 @@
+/*************************************************************************/
+/*  test_random_number_generator.h                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_RANDOM_NUMBER_GENERATOR_H
+#define TEST_RANDOM_NUMBER_GENERATOR_H
+
+#include "core/math/random_number_generator.h"
+#include "tests/test_macros.h"
+
+namespace TestRandomNumberGenerator {
+
+TEST_CASE("[RandomNumberGenerator] On unit circle") {
+	Ref<RandomNumberGenerator> rng = memnew(RandomNumberGenerator);
+	rng->set_seed(0);
+	for (int i = 0; i < 100; ++i) {
+		const Vector2 &point = rng->randv_circle(); // Default: 1.0..1.0.
+		INFO(point.length());
+		CHECK(Math::is_equal_approx(point.length(), 1.0));
+		CHECK(point.is_normalized());
+	}
+}
+
+TEST_CASE("[RandomNumberGenerator] Inside unit circle") {
+	Ref<RandomNumberGenerator> rng = memnew(RandomNumberGenerator);
+	rng->set_seed(0);
+	for (int i = 0; i < 100; ++i) {
+		const Vector2 &point = rng->randv_circle(0.0, 1.0);
+		INFO(point.length());
+		CHECK(point.length() < 1.0);
+	}
+}
+
+TEST_CASE("[RandomNumberGenerator] Within circle range") {
+	Ref<RandomNumberGenerator> rng = memnew(RandomNumberGenerator);
+	rng->set_seed(0);
+	for (int i = 0; i < 100; ++i) {
+		const Vector2 &point = rng->randv_circle(0.5, 1.0);
+		INFO(point.length());
+		CHECK(point.length() > 0.5);
+		CHECK(point.length() < 1.0);
+	}
+}
+
+TEST_CASE("[RandomNumberGenerator] On circle, non-unit radius") {
+	Ref<RandomNumberGenerator> rng = memnew(RandomNumberGenerator);
+	rng->set_seed(0);
+	for (int i = 0; i < 100; ++i) {
+		const Vector2 &point = rng->randv_circle(10.0, 10.0);
+		INFO(point.length());
+		CHECK(Math::is_equal_approx(point.length(), 10.0));
+	}
+}
+
+TEST_CASE("[Stress][RandomNumberGenerator] On unit circle, 100000 iterations") {
+	Ref<RandomNumberGenerator> rng = memnew(RandomNumberGenerator);
+	rng->set_seed(0);
+	for (int i = 0; i < 100000; ++i) {
+		const Vector2 &point = rng->randv_circle(); // Default: 1.0..1.0.
+		INFO(point);
+	}
+}
+
+TEST_CASE("[Stress][RandomNumberGenerator] Inside unit circle, 100000 iterations") {
+	Ref<RandomNumberGenerator> rng = memnew(RandomNumberGenerator);
+	rng->set_seed(0);
+	for (int i = 0; i < 100000; ++i) {
+		const Vector2 &point = rng->randv_circle(0.0, 1.0);
+		INFO(point);
+	}
+}
+
+TEST_CASE("[Stress][RandomNumberGenerator] Within circle range, 100000 iterations") {
+	Ref<RandomNumberGenerator> rng = memnew(RandomNumberGenerator);
+	rng->set_seed(0);
+	for (int i = 0; i < 100000; ++i) {
+		const Vector2 &point = rng->randv_circle(0.5, 1.0);
+		INFO(point);
+	}
+}
+
+} // namespace TestRandomNumberGenerator
+
+#endif // TEST_RANDOM_NUMBER_GENERATOR_H


### PR DESCRIPTION
Solves the 2D part for godotengine/godot-proposals#1731.
Closes #34301, resolves #28264.

![godot_randv_circle_range](https://user-images.githubusercontent.com/17108460/97215695-7561a480-17cd-11eb-8aac-506633dc22db.png)

Provides uniform distribution for generating points in a circle (unit on the circle's boundary by default, but any radius can be specified).

Added documentation and unit tests (tests via separate commit).

```gdscript
func _ready():
	var rng = RandomNumberGenerator.new()
	var point: Vector2
	point = rng.randv_circle(0.0, 1.0) # Full circle, first picture.
	point = rng.randv_circle(0.5, 1.0) # Ring, second picture.
	point = rng.randv_circle() # Boundary, normalized unit vector, third picture.
```

**Test project:**
[randv_circle.zip](https://github.com/godotengine/godot/files/5446260/randv_circle.zip)

---

P.S. This is probably the first feature PR with both documentation and unit tests written ever in Godot. 🙂
