### PR TITLE
Fix uninitialized `GridMapEditor::node` and `InputMapEditor::setting` variables.

### DIFF
--- a/editor/input_map_editor.h
+++ b/editor/input_map_editor.h
@@ -69,7 +69,7 @@ class InputMapEditor : public Control {
 	AcceptDialog *message;
 	UndoRedo *undo_redo;
 	String inputmap_changed;
-	bool setting;
+	bool setting = false;
 
 	void _update_actions();
 	void _add_item(int p_item, Ref<InputEvent> p_exiting_event = Ref<InputEvent>());

--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -93,7 +93,7 @@ class GridMapEditor : public VBoxContainer {
 
 	List<SetItem> set_items;
 
-	GridMap *node;
+	GridMap *node = nullptr;
 	MeshLibrary *last_mesh_library;
 	ClipMode clip_mode;
 


### PR DESCRIPTION
Fixes uninitialized variables found by undefined behavior sanitizer:

```
modules/gridmap/grid_map_editor_plugin.cpp:42:16: runtime error: upcast of misaligned address 0xbebebebebebebebe for type 'GridMap', which requires 8 byte alignment
0xbebebebebebebebe: note: pointer points here
<memory cannot be printed>
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior modules/gridmap/grid_map_editor_plugin.cpp:42:16 in


editor/input_map_editor.cpp:641:6: runtime error: load of value 190, which is not a valid value for type 'bool'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior editor/input_map_editor.cpp:641:6 in
```