### PR TITLE
Make `randbase` member protected in `RandomNumberGenerator`

### DIFF
--- a/core/math/random_number_generator.h
+++ b/core/math/random_number_generator.h
@@ -37,9 +37,9 @@
 class RandomNumberGenerator : public Reference {
 	GDCLASS(RandomNumberGenerator, Reference);
 
+protected:
 	RandomPCG randbase;
 
-protected:
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
See #43103.

Allows to extend `RandomNumberGenerator` via C++ modules.

`RandomPCG` is the core behind random number generation.

Should be trivially cherry-pickable to 3.2.