### PR TITLE
Add animation reset track feature

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -30,8 +30,8 @@
 
 #include "undo_redo.h"
 
+#include "core/io/resource.h"
 #include "core/os/os.h"
-#include "core/resource.h"
 
 void UndoRedo::_discard_redo() {
 	if (current_action == actions.size() - 1) {

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -31,6 +31,7 @@
 #include "undo_redo.h"
 
 #include "core/os/os.h"
+#include "core/resource.h"
 
 void UndoRedo::_discard_redo() {
 	if (current_action == actions.size() - 1) {
@@ -104,8 +105,8 @@ void UndoRedo::add_do_method(Object *p_object, const StringName &p_method, VARIA
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 	Operation do_op;
 	do_op.object = p_object->get_instance_id();
-	if (Object::cast_to<Resource>(p_object)) {
-		do_op.resref = Ref<Resource>(Object::cast_to<Resource>(p_object));
+	if (Object::cast_to<Reference>(p_object)) {
+		do_op.ref = Ref<Reference>(Object::cast_to<Reference>(p_object));
 	}
 
 	do_op.type = Operation::TYPE_METHOD;
@@ -130,8 +131,8 @@ void UndoRedo::add_undo_method(Object *p_object, const StringName &p_method, VAR
 
 	Operation undo_op;
 	undo_op.object = p_object->get_instance_id();
-	if (Object::cast_to<Resource>(p_object)) {
-		undo_op.resref = Ref<Resource>(Object::cast_to<Resource>(p_object));
+	if (Object::cast_to<Reference>(p_object)) {
+		undo_op.ref = Ref<Reference>(Object::cast_to<Reference>(p_object));
 	}
 
 	undo_op.type = Operation::TYPE_METHOD;
@@ -149,8 +150,8 @@ void UndoRedo::add_do_property(Object *p_object, const StringName &p_property, c
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 	Operation do_op;
 	do_op.object = p_object->get_instance_id();
-	if (Object::cast_to<Resource>(p_object)) {
-		do_op.resref = Ref<Resource>(Object::cast_to<Resource>(p_object));
+	if (Object::cast_to<Reference>(p_object)) {
+		do_op.ref = Ref<Reference>(Object::cast_to<Reference>(p_object));
 	}
 
 	do_op.type = Operation::TYPE_PROPERTY;
@@ -171,8 +172,8 @@ void UndoRedo::add_undo_property(Object *p_object, const StringName &p_property,
 
 	Operation undo_op;
 	undo_op.object = p_object->get_instance_id();
-	if (Object::cast_to<Resource>(p_object)) {
-		undo_op.resref = Ref<Resource>(Object::cast_to<Resource>(p_object));
+	if (Object::cast_to<Reference>(p_object)) {
+		undo_op.ref = Ref<Reference>(Object::cast_to<Reference>(p_object));
 	}
 
 	undo_op.type = Operation::TYPE_PROPERTY;
@@ -187,8 +188,8 @@ void UndoRedo::add_do_reference(Object *p_object) {
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 	Operation do_op;
 	do_op.object = p_object->get_instance_id();
-	if (Object::cast_to<Resource>(p_object)) {
-		do_op.resref = Ref<Resource>(Object::cast_to<Resource>(p_object));
+	if (Object::cast_to<Reference>(p_object)) {
+		do_op.ref = Ref<Reference>(Object::cast_to<Reference>(p_object));
 	}
 
 	do_op.type = Operation::TYPE_REFERENCE;
@@ -207,8 +208,8 @@ void UndoRedo::add_undo_reference(Object *p_object) {
 
 	Operation undo_op;
 	undo_op.object = p_object->get_instance_id();
-	if (Object::cast_to<Resource>(p_object)) {
-		undo_op.resref = Ref<Resource>(Object::cast_to<Resource>(p_object));
+	if (Object::cast_to<Reference>(p_object)) {
+		undo_op.ref = Ref<Reference>(Object::cast_to<Reference>(p_object));
 	}
 
 	undo_op.type = Operation::TYPE_REFERENCE;

--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -31,8 +31,8 @@
 #ifndef UNDO_REDO_H
 #define UNDO_REDO_H
 
-#include "core/io/resource.h"
 #include "core/object/class_db.h"
+#include "core/object/reference.h"
 
 class UndoRedo : public Object {
 	GDCLASS(UndoRedo, Object);
@@ -61,7 +61,7 @@ private:
 		};
 
 		Type type;
-		Ref<Resource> resref;
+		Ref<Reference> ref;
 		ObjectID object;
 		StringName name;
 		Variant args[VARIANT_ARG_MAX];

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -260,6 +260,10 @@
 		<member name="playback_speed" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			The speed scaling ratio. For instance, if this value is 1, then the animation plays at normal speed. If it's 0.5, then it plays at half speed. If it's 2, then it plays at double speed.
 		</member>
+		<member name="reset_on_save" type="bool" setter="set_reset_on_save_enabled" getter="is_reset_on_save_enabled" default="true">
+			This is used by the editor. If set to [code]true[/code], the scene will be saved with the effects of the reset animation applied (as if it had been seeked to time 0), then reverted after saving.
+			In other words, the saved scene file will contain the "default pose", as defined by the reset animation, if any, with the editor keeping the values that the nodes had before saving.
+		</member>
 		<member name="root_node" type="NodePath" setter="set_root" getter="get_root" default="NodePath(&quot;..&quot;)">
 			The node from which node path references will travel.
 		</member>

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -47,6 +47,8 @@
 #include "scene/resources/animation.h"
 #include "scene_tree_editor.h"
 
+class AnimationPlayer;
+
 class AnimationTimelineEdit : public Range {
 	GDCLASS(AnimationTimelineEdit, Range);
 
@@ -285,6 +287,7 @@ class AnimationTrackEditor : public VBoxContainer {
 		EDIT_DELETE_SELECTION,
 		EDIT_GOTO_NEXT_STEP,
 		EDIT_GOTO_PREV_STEP,
+		EDIT_APPLY_RESET,
 		EDIT_OPTIMIZE_ANIMATION,
 		EDIT_OPTIMIZE_ANIMATION_CONFIRM,
 		EDIT_CLEAN_UP_ANIMATION,
@@ -361,6 +364,7 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	Label *insert_confirm_text;
 	CheckBox *insert_confirm_bezier;
+	CheckBox *insert_confirm_reset;
 	ConfirmationDialog *insert_confirm;
 	bool insert_queue;
 	bool inserting;
@@ -369,9 +373,19 @@ class AnimationTrackEditor : public VBoxContainer {
 	uint64_t insert_frame;
 
 	void _query_insert(const InsertData &p_id);
+	Ref<Animation> _create_and_get_reset_animation();
 	void _confirm_insert_list();
-	int _confirm_insert(InsertData p_id, int p_last_track, bool p_create_beziers = false);
-	void _insert_delay();
+	struct TrackIndices {
+		int normal;
+		int reset;
+
+		TrackIndices(const Animation *p_anim = nullptr, const Animation *p_reset_anim = nullptr) {
+			normal = p_anim ? p_anim->get_track_count() : 0;
+			reset = p_reset_anim ? p_reset_anim->get_track_count() : 0;
+		}
+	};
+	TrackIndices _confirm_insert(InsertData p_id, TrackIndices p_next_tracks, bool p_create_reset, bool p_create_beziers);
+	void _insert_delay(bool p_create_reset, bool p_create_beziers);
 
 	void _root_removed(Node *p_root);
 
@@ -447,6 +461,7 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	void _select_all_tracks_for_copy();
 
+	void _edit_menu_about_to_popup();
 	void _edit_menu_pressed(int p_option);
 	int last_menu_track_opt;
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -628,6 +628,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Animation
 	_initial_set("editors/animation/autorename_animation_tracks", true);
 	_initial_set("editors/animation/confirm_insert_track", true);
+	_initial_set("editors/animation/default_create_bezier_tracks", false);
+	_initial_set("editors/animation/default_create_reset_tracks", true);
 	_initial_set("editors/animation/onion_layers_past_color", Color(1, 0, 0));
 	_initial_set("editors/animation/onion_layers_future_color", Color(0, 1, 0));
 

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -105,6 +105,8 @@ class AnimationPlayerEditor : public VBoxContainer {
 	Label *name_title;
 	UndoRedo *undo_redo;
 	Ref<Texture2D> autoplay_icon;
+	Ref<Texture2D> reset_icon;
+	Ref<ImageTexture> autoplay_reset_icon;
 	bool last_active;
 	float timeline_position;
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -36,6 +36,7 @@
 #include "servers/audio/audio_stream.h"
 
 #ifdef TOOLS_ENABLED
+#include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "scene/2d/skeleton_2d.h"
 
@@ -52,6 +53,21 @@ void AnimatedValuesBackup::update_skeletons() {
 			}
 		}
 	}
+}
+
+void AnimatedValuesBackup::restore() const {
+	for (int i = 0; i < entries.size(); i++) {
+		const AnimatedValuesBackup::Entry *entry = &entries[i];
+		if (entry->bone_idx == -1) {
+			entry->object->set_indexed(entry->subpath, entry->value);
+		} else {
+			Object::cast_to<Skeleton3D>(entry->object)->set_bone_pose(entry->bone_idx, entry->value);
+		}
+	}
+}
+
+void AnimatedValuesBackup::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("restore"), &AnimatedValuesBackup::restore);
 }
 #endif
 
@@ -1379,6 +1395,14 @@ String AnimationPlayer::get_autoplay() const {
 	return autoplay;
 }
 
+void AnimationPlayer::set_reset_on_save_enabled(bool p_enabled) {
+	reset_on_save = p_enabled;
+}
+
+bool AnimationPlayer::is_reset_on_save_enabled() const {
+	return reset_on_save;
+}
+
 void AnimationPlayer::set_animation_process_mode(AnimationProcessMode p_mode) {
 	if (animation_process_mode == p_mode) {
 		return;
@@ -1473,15 +1497,15 @@ void AnimationPlayer::get_argument_options(const StringName &p_function, int p_i
 }
 
 #ifdef TOOLS_ENABLED
-AnimatedValuesBackup AnimationPlayer::backup_animated_values() {
+Ref<AnimatedValuesBackup> AnimationPlayer::backup_animated_values() {
+	Ref<AnimatedValuesBackup> backup;
 	if (!playback.current.from) {
-		return AnimatedValuesBackup();
+		return backup;
 	}
 
 	_ensure_node_caches(playback.current.from);
 
-	AnimatedValuesBackup backup;
-
+	backup.instance();
 	for (int i = 0; i < playback.current.from->node_cache.size(); i++) {
 		TrackNodeCache *nc = playback.current.from->node_cache[i];
 		if (!nc) {
@@ -1497,7 +1521,7 @@ AnimatedValuesBackup AnimationPlayer::backup_animated_values() {
 			entry.object = nc->skeleton;
 			entry.bone_idx = nc->bone_idx;
 			entry.value = nc->skeleton->get_bone_pose(nc->bone_idx);
-			backup.entries.push_back(entry);
+			backup->entries.push_back(entry);
 		} else {
 			if (nc->spatial) {
 				AnimatedValuesBackup::Entry entry;
@@ -1505,7 +1529,7 @@ AnimatedValuesBackup AnimationPlayer::backup_animated_values() {
 				entry.subpath.push_back("transform");
 				entry.value = nc->spatial->get_transform();
 				entry.bone_idx = -1;
-				backup.entries.push_back(entry);
+				backup->entries.push_back(entry);
 			} else {
 				for (Map<StringName, TrackNodeCache::PropertyAnim>::Element *E = nc->property_anim.front(); E; E = E->next()) {
 					AnimatedValuesBackup::Entry entry;
@@ -1515,7 +1539,7 @@ AnimatedValuesBackup AnimationPlayer::backup_animated_values() {
 					entry.value = E->value().object->get_indexed(E->value().subpath, &valid);
 					entry.bone_idx = -1;
 					if (valid) {
-						backup.entries.push_back(entry);
+						backup->entries.push_back(entry);
 					}
 				}
 			}
@@ -1525,15 +1549,40 @@ AnimatedValuesBackup AnimationPlayer::backup_animated_values() {
 	return backup;
 }
 
-void AnimationPlayer::restore_animated_values(const AnimatedValuesBackup &p_backup) {
-	for (int i = 0; i < p_backup.entries.size(); i++) {
-		const AnimatedValuesBackup::Entry *entry = &p_backup.entries[i];
-		if (entry->bone_idx == -1) {
-			entry->object->set_indexed(entry->subpath, entry->value);
-		} else {
-			Object::cast_to<Skeleton3D>(entry->object)->set_bone_pose(entry->bone_idx, entry->value);
-		}
+Ref<AnimatedValuesBackup> AnimationPlayer::apply_reset(bool p_user_initiated) {
+	ERR_FAIL_COND_V(!can_apply_reset(), Ref<AnimatedValuesBackup>());
+
+	Ref<Animation> reset_anim = animation_set["RESET"].animation;
+	ERR_FAIL_COND_V(reset_anim.is_null(), Ref<AnimatedValuesBackup>());
+
+	Node *root_node = get_node_or_null(root);
+	ERR_FAIL_COND_V(!root_node, Ref<AnimatedValuesBackup>());
+
+	AnimationPlayer *aux_player = memnew(AnimationPlayer);
+	EditorNode::get_singleton()->add_child(aux_player);
+	aux_player->set_root(aux_player->get_path_to(root_node));
+	aux_player->add_animation("RESET", reset_anim);
+	aux_player->set_assigned_animation("RESET");
+	Ref<AnimatedValuesBackup> old_values = aux_player->backup_animated_values();
+	aux_player->seek(0.0f, true);
+	aux_player->queue_delete();
+
+	if (p_user_initiated) {
+		Ref<AnimatedValuesBackup> new_values = aux_player->backup_animated_values();
+		old_values->restore();
+
+		UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+		ur->create_action(TTR("Anim Apply Reset"));
+		ur->add_do_method(new_values.ptr(), "restore");
+		ur->add_undo_method(old_values.ptr(), "restore");
+		ur->commit_action();
 	}
+
+	return old_values;
+}
+
+bool AnimationPlayer::can_apply_reset() const {
+	return has_animation("RESET") && playback.assigned != StringName("RESET");
 }
 #endif
 
@@ -1577,6 +1626,9 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_autoplay", "name"), &AnimationPlayer::set_autoplay);
 	ClassDB::bind_method(D_METHOD("get_autoplay"), &AnimationPlayer::get_autoplay);
 
+	ClassDB::bind_method(D_METHOD("set_reset_on_save_enabled", "enabled"), &AnimationPlayer::set_reset_on_save_enabled);
+	ClassDB::bind_method(D_METHOD("is_reset_on_save_enabled"), &AnimationPlayer::is_reset_on_save_enabled);
+
 	ClassDB::bind_method(D_METHOD("set_root", "path"), &AnimationPlayer::set_root);
 	ClassDB::bind_method(D_METHOD("get_root"), &AnimationPlayer::get_root);
 
@@ -1600,6 +1652,7 @@ void AnimationPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "current_animation", PROPERTY_HINT_ENUM, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ANIMATE_AS_TRIGGER), "set_current_animation", "get_current_animation");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "assigned_animation", PROPERTY_HINT_NONE, "", 0), "set_assigned_animation", "get_assigned_animation");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "autoplay", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_autoplay", "get_autoplay");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reset_on_save", PROPERTY_HINT_NONE, ""), "set_reset_on_save_enabled", "is_reset_on_save_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "current_animation_length", PROPERTY_HINT_NONE, "", 0), "", "get_current_animation_length");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "current_animation_position", PROPERTY_HINT_NONE, "", 0), "", "get_current_animation_position");
 
@@ -1631,6 +1684,7 @@ AnimationPlayer::AnimationPlayer() {
 	speed_scale = 1;
 	end_reached = false;
 	end_notify = false;
+	reset_on_save = true;
 	animation_process_mode = ANIMATION_PROCESS_IDLE;
 	method_call_mode = ANIMATION_METHOD_CALL_DEFERRED;
 	processing = false;

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -37,8 +37,9 @@
 #include "scene/resources/animation.h"
 
 #ifdef TOOLS_ENABLED
-// To save/restore animated values
-class AnimatedValuesBackup {
+class AnimatedValuesBackup : public Reference {
+	GDCLASS(AnimatedValuesBackup, Reference);
+
 	struct Entry {
 		Object *object;
 		Vector<StringName> subpath; // Unused if bone
@@ -49,8 +50,12 @@ class AnimatedValuesBackup {
 
 	friend class AnimationPlayer;
 
+protected:
+	static void _bind_methods();
+
 public:
 	void update_skeletons();
+	void restore() const;
 };
 #endif
 
@@ -215,6 +220,7 @@ private:
 	bool end_notify;
 
 	String autoplay;
+	bool reset_on_save;
 	AnimationProcessMode animation_process_mode;
 	AnimationMethodCallMode method_call_mode;
 	bool processing;
@@ -304,6 +310,9 @@ public:
 	void set_autoplay(const String &p_name);
 	String get_autoplay() const;
 
+	void set_reset_on_save_enabled(bool p_enabled);
+	bool is_reset_on_save_enabled() const;
+
 	void set_animation_process_mode(AnimationProcessMode p_mode);
 	AnimationProcessMode get_animation_process_mode() const;
 
@@ -325,9 +334,9 @@ public:
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 
 #ifdef TOOLS_ENABLED
-	// These may be interesting for games, but are too dangerous for general use
-	AnimatedValuesBackup backup_animated_values();
-	void restore_animated_values(const AnimatedValuesBackup &p_backup);
+	Ref<AnimatedValuesBackup> backup_animated_values();
+	Ref<AnimatedValuesBackup> apply_reset(bool p_user_initiated = false);
+	bool can_apply_reset() const;
 #endif
 
 	AnimationPlayer();

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -33,8 +33,6 @@
 
 #include "core/math/geometry_3d.h"
 
-#define ANIM_MIN_LENGTH 0.001
-
 bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;
 

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -33,6 +33,8 @@
 
 #include "core/io/resource.h"
 
+#define ANIM_MIN_LENGTH 0.001
+
 class Animation : public Resource {
 	GDCLASS(Animation, Resource);
 	RES_BASE_EXTENSION("anim");


### PR DESCRIPTION
This implements https://github.com/godotengine/godot-proposals/issues/1597.

**NOTE:** This is barely tested, so testing is welcome.

A few notes follow, about aspects not included or not settled on the original proposal:

---

~~Any animation can be the reset animation.~~

~~_Toggle Reset_ is used to make the current animation the reset one, or revert that:~~

~~When clicked, you get one of these:~~

~~The option to toggle reset is there and also asks for confirmation, to avoid accidental clicks that could happen if it was just a button in the animation dock. Also, there's no frequent need to deal with it.~~

---

The reset animation is marked as such in the dropdown:

![image](https://user-images.githubusercontent.com/11797174/97243891-92ab6880-17f7-11eb-906c-63177e09b0a4.png)

If it's the autoplay animation at the same time, it looks like this:

![image](https://user-images.githubusercontent.com/11797174/97243837-7a3b4e00-17f7-11eb-81ea-06975f5ced2b.png)

---

If you have _Create Reset Track(s)_ checked, and there's no reset animation, one will be created with the name _RESET_.

---

You can apply the reset animation any time, unless the it's the current one:

![image](https://user-images.githubusercontent.com/11797174/97244135-1feebd00-17f8-11eb-841c-f08629dbc167.png)

---

There's a new `reset_on_save` property:

![image](https://user-images.githubusercontent.com/11797174/97244535-46612800-17f9-11eb-87f9-9dca1049e900.png)

The cool thing is that it helps in getting a cleaner diff and consistent saved scene, without breaking the workflow, since the current state in the editor is kept. If you need to see how its saved version looks, you can use _Scene-> Reload Saved Scene_.