### PR TITLE
Fix property revert for inherited child nodes

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -414,9 +414,9 @@ bool EditorPropertyRevert::get_instanced_node_original_property(Node *p_node, co
 		node = node->get_owner();
 	}
 
-	if (!found && node) {
+	if (!found && p_node) {
 		//if not found, try default class value
-		Variant attempt = ClassDB::class_get_default_property_value(node->get_class_name(), p_prop);
+		Variant attempt = ClassDB::class_get_default_property_value(p_node->get_class_name(), p_prop);
 		if (attempt.get_type() != Variant::NIL) {
 			found = true;
 			value = attempt;


### PR DESCRIPTION
This PR fixes #28279.

`get_instanced_node_original_property` walks up the node tree to find the instanced / inherited scene node, and query the property value in that scene for the default value. If the property is not overridden in that scene, it will try to use the class default value. But the default value is currently get from the instanced / inherited scene node's class instead of the parameter node's class.

Tested on the current master (0e3b011dee) and 3.2 branch (6aa54c117).