### PR TITLE
Handle global classes for `type_exists()` in GDScript

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -1224,7 +1224,7 @@
 			<argument index="0" name="type" type="String">
 			</argument>
 			<description>
-				Returns whether the given class exists in [ClassDB].
+				Returns whether the given class exists in [ClassDB] or whether the class is a global class defined via script.
 				[codeblock]
 				type_exists("Sprite2D") # Returns true
 				type_exists("Variant") # Returns false

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -629,8 +629,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 		} break;
 		case TYPE_EXISTS: {
 			VALIDATE_ARG_COUNT(1);
-			r_ret = ClassDB::class_exists(*p_args[0]);
-
+			r_ret = ClassDB::class_exists(*p_args[0]) || ScriptServer::is_global_class(*p_args[0]);
 		} break;
 		case TEXT_CHAR: {
 			VALIDATE_ARG_COUNT(1);


### PR DESCRIPTION
```gdscript
# custom.gd
class_name Custom extends Node
```

```gdscript
# main.gd
extends Node2D

func _ready():
	assert(type_exists("Custom"))
```

**Test project:**
[type_exists_script.zip](https://github.com/godotengine/godot/files/5445843/type_exists_script.zip)
