### PR TITLE
Tileset hotkeys

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -517,6 +517,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tools[SHAPE_NEW_RECTANGLE]->set_button_group(tg);
 	tools[SHAPE_NEW_RECTANGLE]->set_tooltip(TTR("Create a new rectangle."));
 	tools[SHAPE_NEW_RECTANGLE]->connect("pressed", this, "_on_tool_clicked", varray(SHAPE_NEW_RECTANGLE));
+	tools[SHAPE_NEW_RECTANGLE]->set_shortcut(ED_SHORTCUT("tileset_editor/editmode_collision/shape_new_rectangle", TTR("Collision Mode - New Rectangle"), KEY_MASK_SHIFT | KEY_R));
 
 	tools[SHAPE_NEW_POLYGON] = memnew(ToolButton);
 	toolbar->add_child(tools[SHAPE_NEW_POLYGON]);
@@ -524,6 +525,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tools[SHAPE_NEW_POLYGON]->set_button_group(tg);
 	tools[SHAPE_NEW_POLYGON]->set_tooltip(TTR("Create a new polygon."));
 	tools[SHAPE_NEW_POLYGON]->connect("pressed", this, "_on_tool_clicked", varray(SHAPE_NEW_POLYGON));
+	tools[SHAPE_NEW_POLYGON]->set_shortcut(ED_SHORTCUT("tileset_editor/editmode_collision/shape_new_polygon", TTR("Collision Mode - New Polygon"), KEY_MASK_SHIFT | KEY_P));
 
 	separator_shape_toggle = memnew(VSeparator);
 	toolbar->add_child(separator_shape_toggle);
@@ -536,6 +538,7 @@ TileSetEditor::TileSetEditor(EditorNode *p_editor) {
 	tools[SHAPE_DELETE] = memnew(ToolButton);
 	tools[SHAPE_DELETE]->connect("pressed", this, "_on_tool_clicked", varray(SHAPE_DELETE));
 	toolbar->add_child(tools[SHAPE_DELETE]);
+	tools[SHAPE_DELETE]->set_shortcut(ED_SHORTCUT("tileset_editor/editmode_collision/shape_delete", TTR("Collision Mode - Delete"), KEY_MASK_SHIFT | KEY_DELETE));
 
 	spin_priority = memnew(SpinBox);
 	spin_priority->set_min(1);


### PR DESCRIPTION
added hot keys to the tileset editor plugin sub-buttons for collision editor mode

default for collision rect shape SHIFT-R
default for collision polygon shape SHIFT-P
delete selected shape SHIFT-DELETE
