### PR TITLE
fix(sprite2d): Rect is not handling pixel snap

### DIFF
--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -366,6 +366,9 @@ Rect2 Sprite2D::get_rect() const {
 	if (centered) {
 		ofs -= Size2(s) / 2;
 	}
+	if (Engine::get_singleton()->get_use_pixel_snap()) {
+		ofs = ofs.floor();
+	}
 
 	if (s == Size2(0, 0)) {
 		s = Size2(1, 1);


### PR DESCRIPTION
Test scenario can be found in related issue https://github.com/godotengine/godot/issues/42985

Before:
![godot_sprite2d-rect-before](https://user-images.githubusercontent.com/1263211/97369655-9bf70c80-18ad-11eb-939e-395c729d6117.PNG)

After:
![godot_sprite2d-rect-after](https://user-images.githubusercontent.com/1263211/97369395-24c17880-18ad-11eb-888b-02d1f3b48e56.PNG)