### PR TITLE
Collapse Resource Preview Properly

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2898,6 +2898,7 @@ void EditorPropertyResource::update_property() {
 	if (res == RES()) {
 		assign->set_icon(Ref<Texture2D>());
 		assign->set_text(TTR("[empty]"));
+		assign->set_custom_minimum_size(Size2(1, 1));
 	} else {
 		assign->set_icon(EditorNode::get_singleton()->get_object_icon(res.operator->(), "Object"));
 


### PR DESCRIPTION
Previously, cleared resources in the inspector do not reset the size taken by the preview, leading to an unusually large control.
![image](https://user-images.githubusercontent.com/14253836/97424429-b695a980-18de-11eb-921c-ad1278297194.png)

This PR fixes the bug by setting the minsize to zero as would be done in `_resource_preview`