### PR TITLE
Temporary disable exported build in CI

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -189,8 +189,8 @@ jobs:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
           scons tools=yes target=debug use_asan=yes use_ubsan=yes
-          scons tools=no target=release debug_symbols=full use_ubsan=yes use_asan=yes
           ls -l bin/
+#          scons tools=no target=release debug_symbols=full use_ubsan=yes use_asan=yes
 
       # Download and test project to check leaks and invalid memory usage
       - name: Importing and running project project
@@ -203,14 +203,14 @@ jobs:
           DRI_PRIME=0 xvfb-run bin/godot.x11.tools.64s 20 --video-driver GLES3 --path test_project 2>&1 | tee sanitizers_log.txt || true
           misc/scripts/check_ci_log.py sanitizers_log.txt
 
-      # Export project and run it to check for possible leaks and invalid memory usage
-      - name: Exporting and running project
-        run: |
-          mkdir exported_project
-          sed -i 's:PATH_TO_CHANGE:'`pwd`/bin/godot.x11.debug.64s':' test_project/export_presets.cfg
-          cd test_project
-          DRI_PRIME=0 xvfb-run ../bin/godot.x11.tools.64s --export-debug "Linux/X11" ../exported_project/test_project 2>&1 | tee sanitizers_log.txt || true
-          cd ..
-          misc/scripts/check_ci_log.py sanitizers_log.txt
-          DRI_PRIME=0 xvfb-run exported_project/test_project 20 2>&1 | tee sanitizers_log.txt || true
-          misc/scripts/check_ci_log.py sanitizers_log.txt
+#      # Export project and run it to check for possible leaks and invalid memory usage
+#      - name: Exporting and running project
+#        run: |
+#          mkdir exported_project
+#          sed -i 's:PATH_TO_CHANGE:'`pwd`/bin/godot.x11.debug.64s':' test_project/export_presets.cfg
+#          cd test_project
+#          DRI_PRIME=0 xvfb-run ../bin/godot.x11.tools.64s --export-debug "Linux/X11" ../exported_project/test_project 2>&1 | tee sanitizers_log.txt || true
+#          cd ..
+#          misc/scripts/check_ci_log.py sanitizers_log.txt
+#          DRI_PRIME=0 xvfb-run exported_project/test_project 20 2>&1 | tee sanitizers_log.txt || true
+#          misc/scripts/check_ci_log.py sanitizers_log.txt


### PR DESCRIPTION
Due to an accidental rebase in https://github.com/qarmin/RegressionTestProject, the builds in branch 3.2 end in failure e.g. - https://github.com/godotengine/godot/pull/43126/checks?check_run_id=1319478042.

I'm trying to prevent from similar possible accidents in future by adding CI to this PR - https://github.com/qarmin/RegressionTestProject/pull/3 

When trying to fix this, probably I found a bug with exporting project, so I want to check it first.