### PR TITLE
Implement CanvasGroup and CanvasItem clipping

### DIFF
--- a/scene/2d/canvas_group.cpp
+++ b/scene/2d/canvas_group.cpp
@@ -1,0 +1,87 @@
+/*************************************************************************/
+/*  canvas_group.cpp                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "canvas_group.h"
+
+void CanvasGroup::set_fit_margin(float p_fit_margin) {
+	ERR_FAIL_COND(p_fit_margin < 0.0);
+
+	fit_margin = p_fit_margin;
+	RS::get_singleton()->canvas_item_set_canvas_group_mode(get_canvas_item(), RS::CANVAS_GROUP_MODE_TRANSPARENT, clear_margin, true, fit_margin, use_mipmaps);
+
+	update();
+}
+
+float CanvasGroup::get_fit_margin() const {
+	return fit_margin;
+}
+
+void CanvasGroup::set_clear_margin(float p_clear_margin) {
+	ERR_FAIL_COND(p_clear_margin < 0.0);
+
+	clear_margin = p_clear_margin;
+	RS::get_singleton()->canvas_item_set_canvas_group_mode(get_canvas_item(), RS::CANVAS_GROUP_MODE_TRANSPARENT, clear_margin, true, clear_margin, use_mipmaps);
+
+	update();
+}
+
+float CanvasGroup::get_clear_margin() const {
+	return clear_margin;
+}
+
+void CanvasGroup::set_use_mipmaps(bool p_use_mipmaps) {
+	use_mipmaps = p_use_mipmaps;
+	RS::get_singleton()->canvas_item_set_canvas_group_mode(get_canvas_item(), RS::CANVAS_GROUP_MODE_TRANSPARENT, clear_margin, true, fit_margin, use_mipmaps);
+}
+bool CanvasGroup::is_using_mipmaps() const {
+	return use_mipmaps;
+}
+
+void CanvasGroup::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_fit_margin", "fit_margin"), &CanvasGroup::set_fit_margin);
+	ClassDB::bind_method(D_METHOD("get_fit_margin"), &CanvasGroup::get_fit_margin);
+
+	ClassDB::bind_method(D_METHOD("set_clear_margin", "clear_margin"), &CanvasGroup::set_clear_margin);
+	ClassDB::bind_method(D_METHOD("get_clear_margin"), &CanvasGroup::get_clear_margin);
+
+	ClassDB::bind_method(D_METHOD("set_use_mipmaps", "use_mipmaps"), &CanvasGroup::set_use_mipmaps);
+	ClassDB::bind_method(D_METHOD("is_using_mipmaps"), &CanvasGroup::is_using_mipmaps);
+
+	ADD_GROUP("Tweaks", "");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fit_margin", PROPERTY_HINT_RANGE, "0,1024,1.0,or_greater"), "set_fit_margin", "get_fit_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "clear_margin", PROPERTY_HINT_RANGE, "0,1024,1.0,or_greater"), "set_clear_margin", "get_clear_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_mipmaps"), "set_use_mipmaps", "is_using_mipmaps");
+}
+
+CanvasGroup::CanvasGroup() {
+	set_fit_margin(10.0); //sets things
+}
+CanvasGroup::~CanvasGroup() {
+}

--- a/scene/2d/canvas_group.h
+++ b/scene/2d/canvas_group.h
@@ -1,0 +1,59 @@
+/*************************************************************************/
+/*  canvas_group.h                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef CANVASGROUP_H
+#define CANVASGROUP_H
+
+#include "scene/2d/node_2d.h"
+
+class CanvasGroup : public Node2D {
+	GDCLASS(CanvasGroup, Node2D)
+	float fit_margin = 10.0;
+	float clear_margin = 10.0;
+	bool use_mipmaps = false;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_fit_margin(float p_fit_margin);
+	float get_fit_margin() const;
+
+	void set_clear_margin(float p_clear_margin);
+	float get_clear_margin() const;
+
+	void set_use_mipmaps(bool p_use_mipmaps);
+	bool is_using_mipmaps() const;
+
+	CanvasGroup();
+	~CanvasGroup();
+};
+
+#endif // CANVASGROUP_H

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -200,6 +200,7 @@ private:
 	Window *window;
 	bool first_draw;
 	bool visible;
+	bool clip_children;
 	bool pending_update;
 	bool top_level;
 	bool drawing;
@@ -314,6 +315,9 @@ public:
 	void hide();
 
 	void update();
+
+	void set_clip_children(bool p_enabled);
+	bool is_clipping_children() const;
 
 	virtual void set_light_mask(int p_light_mask);
 	int get_light_mask() const;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -38,6 +38,7 @@
 #include "scene/2d/audio_stream_player_2d.h"
 #include "scene/2d/back_buffer_copy.h"
 #include "scene/2d/camera_2d.h"
+#include "scene/2d/canvas_group.h"
 #include "scene/2d/canvas_modulate.h"
 #include "scene/2d/collision_polygon_2d.h"
 #include "scene/2d/collision_shape_2d.h"
@@ -602,6 +603,7 @@ void register_scene_types() {
 	/* REGISTER 2D */
 
 	ClassDB::register_class<Node2D>();
+	ClassDB::register_class<CanvasGroup>();
 	ClassDB::register_class<CPUParticles2D>();
 	ClassDB::register_class<GPUParticles2D>();
 	ClassDB::register_class<Sprite2D>();

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -459,6 +459,8 @@ DynamicFontAtSize::TexturePosition DynamicFontAtSize::_find_texture_pos_for_glyp
 			uint8_t *w = tex.imgdata.ptrw();
 			ERR_FAIL_COND_V(texsize * texsize * p_color_size > tex.imgdata.size(), ret);
 
+			// Initialize the texture to all-white pixels to prevent artifacts when the
+			// font is displayed at a non-default scale with filtering enabled.
 			if (p_color_size == 2) {
 				for (int i = 0; i < texsize * texsize * p_color_size; i += 2) {
 					w[i + 0] = 255;

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -458,8 +458,19 @@ DynamicFontAtSize::TexturePosition DynamicFontAtSize::_find_texture_pos_for_glyp
 			//zero texture
 			uint8_t *w = tex.imgdata.ptrw();
 			ERR_FAIL_COND_V(texsize * texsize * p_color_size > tex.imgdata.size(), ret);
-			for (int i = 0; i < texsize * texsize * p_color_size; i++) {
-				w[i] = 0;
+
+			if (p_color_size == 2) {
+				for (int i = 0; i < texsize * texsize * p_color_size; i += 2) {
+					w[i + 0] = 255;
+					w[i + 1] = 0;
+				}
+			} else {
+				for (int i = 0; i < texsize * texsize * p_color_size; i += 4) {
+					w[i + 0] = 255;
+					w[i + 1] = 255;
+					w[i + 2] = 255;
+					w[i + 3] = 0;
+				}
 			}
 		}
 		tex.offsets.resize(texsize);

--- a/servers/rendering/rasterizer.h
+++ b/servers/rendering/rasterizer.h
@@ -815,7 +815,8 @@ public:
 		CANVAS_RECT_FLIP_H = 4,
 		CANVAS_RECT_FLIP_V = 8,
 		CANVAS_RECT_TRANSPOSE = 16,
-		CANVAS_RECT_CLIP_UV = 32
+		CANVAS_RECT_CLIP_UV = 32,
+		CANVAS_RECT_IS_GROUP = 64,
 	};
 
 	struct Light {
@@ -1060,7 +1061,16 @@ public:
 		bool visible;
 		bool behind;
 		bool update_when_visible;
-		//RS::MaterialBlendMode blend_mode;
+
+		struct CanvasGroup {
+			RS::CanvasGroupMode mode;
+			bool fit_empty;
+			float fit_margin;
+			bool blur_mipmaps;
+			float clear_margin;
+		};
+
+		CanvasGroup *canvas_group = nullptr;
 		int light_mask;
 		int z_final;
 
@@ -1084,6 +1094,7 @@ public:
 		Rect2 final_clip_rect;
 		Item *final_clip_owner;
 		Item *material_owner;
+		Item *canvas_group_owner;
 		ViewportRender *vp_render;
 		bool distance_field;
 		bool light_masked;
@@ -1242,6 +1253,8 @@ public:
 		}
 
 		void clear() {
+			// The first one is always allocated on heap
+			// the rest go in the blocks
 			Command *c = commands;
 			while (c) {
 				Command *n = c->next;
@@ -1282,6 +1295,7 @@ public:
 			vp_render = nullptr;
 			next = nullptr;
 			final_clip_owner = nullptr;
+			canvas_group_owner = nullptr;
 			clip = false;
 			final_modulate = Color(1, 1, 1, 1);
 			visible = true;

--- a/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.h
@@ -391,6 +391,9 @@ class RasterizerCanvasRD : public RasterizerCanvas {
 
 	RID default_canvas_texture;
 
+	RID default_canvas_group_shader;
+	RID default_canvas_group_material;
+
 	RS::CanvasItemTextureFilter default_filter = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
 	RS::CanvasItemTextureRepeat default_repeat = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
 
@@ -398,7 +401,7 @@ class RasterizerCanvasRD : public RasterizerCanvas {
 
 	inline void _bind_canvas_texture(RD::DrawListID p_draw_list, RID p_texture, RS::CanvasItemTextureFilter p_base_filter, RS::CanvasItemTextureRepeat p_base_repeat, RID &r_last_texture, PushConstant &push_constant, Size2 &r_texpixel_size); //recursive, so regular inline used instead.
 	void _render_item(RenderingDevice::DrawListID p_draw_list, const Item *p_item, RenderingDevice::FramebufferFormatID p_framebuffer_format, const Transform2D &p_canvas_transform_inverse, Item *&current_clip, Light *p_lights, PipelineVariants *p_pipeline_variants);
-	void _render_items(RID p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights);
+	void _render_items(RID p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights, bool p_to_backbuffer = false);
 
 	_FORCE_INLINE_ void _update_transform_2d_to_mat2x4(const Transform2D &p_transform, float *p_mat2x4);
 	_FORCE_INLINE_ void _update_transform_2d_to_mat2x3(const Transform2D &p_transform, float *p_mat2x3);

--- a/servers/rendering/rasterizer_rd/rasterizer_effects_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_effects_rd.h
@@ -66,6 +66,8 @@ class RasterizerEffectsRD {
 		COPY_MODE_SIMPLY_COPY,
 		COPY_MODE_SIMPLY_COPY_8BIT,
 		COPY_MODE_SIMPLY_COPY_DEPTH,
+		COPY_MODE_SET_COLOR,
+		COPY_MODE_SET_COLOR_8BIT,
 		COPY_MODE_MIPMAP,
 		COPY_MODE_LINEARIZE_DEPTH,
 		COPY_MODE_CUBE_TO_PANORAMA,
@@ -83,7 +85,8 @@ class RasterizerEffectsRD {
 		COPY_FLAG_FLIP_Y = (1 << 5),
 		COPY_FLAG_FORCE_LUMINANCE = (1 << 6),
 		COPY_FLAG_ALL_SOURCE = (1 << 7),
-		COPY_FLAG_HIGH_QUALITY_GLOW = (1 << 8)
+		COPY_FLAG_HIGH_QUALITY_GLOW = (1 << 8),
+		COPY_FLAG_ALPHA_TO_ONE = (1 << 9),
 	};
 
 	struct CopyPushConstant {
@@ -105,6 +108,8 @@ class RasterizerEffectsRD {
 		float camera_z_far;
 		float camera_z_near;
 		uint32_t pad2[2];
+		//SET color
+		float set_color[4];
 	};
 
 	struct Copy {
@@ -603,12 +608,13 @@ class RasterizerEffectsRD {
 
 public:
 	void copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_alpha_to_zero = false, bool p_srgb = false, RID p_secondary = RID());
-	void copy_to_rect(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_all_source = false, bool p_8_bit_dst = false);
+	void copy_to_rect(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_all_source = false, bool p_8_bit_dst = false, bool p_alpha_to_one = false);
 	void copy_cubemap_to_panorama(RID p_source_cube, RID p_dest_panorama, const Size2i &p_panorama_size, float p_lod, bool p_is_array);
 	void copy_depth_to_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false);
 	void copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y, float p_z_near, float p_z_far);
 	void copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_uv_rect, RD::DrawListID p_draw_list, bool p_flip_y = false, bool p_panorama = false);
 	void gaussian_blur(RID p_source_rd_texture, RID p_texture, RID p_back_texture, const Rect2i &p_region, bool p_8bit_dst = false);
+	void set_color(RID p_dest_texture, const Color &p_color, const Rect2i &p_region, bool p_8bit_dst = false);
 	void gaussian_glow(RID p_source_rd_texture, RID p_back_texture, const Size2i &p_size, float p_strength = 1.0, bool p_high_quality = false, bool p_first_pass = false, float p_luminance_cap = 16.0, float p_exposure = 1.0, float p_bloom = 0.0, float p_hdr_bleed_treshold = 1.0, float p_hdr_bleed_scale = 1.0, RID p_auto_exposure = RID(), float p_auto_exposure_grey = 1.0);
 
 	void cubemap_roughness(RID p_source_rd_texture, RID p_dest_framebuffer, uint32_t p_face_id, uint32_t p_sample_count, float p_roughness, float p_size);

--- a/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
+++ b/servers/rendering/rasterizer_rd/rasterizer_storage_rd.h
@@ -989,6 +989,7 @@ private:
 		bool flags[RENDER_TARGET_FLAG_MAX];
 
 		RID backbuffer; //used for effects
+		RID backbuffer_fb;
 		RID backbuffer_mipmap0;
 
 		struct BackbufferMipmap {
@@ -1916,7 +1917,9 @@ public:
 	void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value);
 	bool render_target_was_used(RID p_render_target);
 	void render_target_set_as_unused(RID p_render_target);
-	void render_target_copy_to_back_buffer(RID p_render_target, const Rect2i &p_region);
+	void render_target_copy_to_back_buffer(RID p_render_target, const Rect2i &p_region, bool p_gen_mipmaps);
+	void render_target_clear_back_buffer(RID p_render_target, const Rect2i &p_region, const Color &p_color);
+	void render_target_gen_back_buffer_mipmaps(RID p_render_target, const Rect2i &p_region);
 
 	RID render_target_get_back_buffer_uniform_set(RID p_render_target, RID p_base_shader);
 
@@ -1930,6 +1933,7 @@ public:
 	RID render_target_get_rd_framebuffer(RID p_render_target);
 	RID render_target_get_rd_texture(RID p_render_target);
 	RID render_target_get_rd_backbuffer(RID p_render_target);
+	RID render_target_get_rd_backbuffer_framebuffer(RID p_render_target);
 
 	RID render_target_get_framebuffer_uniform_set(RID p_render_target);
 	RID render_target_get_backbuffer_uniform_set(RID p_render_target);

--- a/servers/rendering/rendering_server_canvas.h
+++ b/servers/rendering/rendering_server_canvas.h
@@ -216,6 +216,8 @@ public:
 
 	void canvas_item_set_use_parent_material(RID p_item, bool p_enable);
 
+	void canvas_item_set_canvas_group_mode(RID p_item, RS::CanvasGroupMode p_mode, float p_clear_margin = 5.0, bool p_fit_empty = false, float p_fit_margin = 0.0, bool p_blur_mipmaps = false);
+
 	RID canvas_light_create();
 	void canvas_light_attach_to_canvas(RID p_light, RID p_canvas);
 	void canvas_light_set_enabled(RID p_light, bool p_enabled);

--- a/servers/rendering/rendering_server_raster.h
+++ b/servers/rendering/rendering_server_raster.h
@@ -743,6 +743,8 @@ public:
 
 	BIND2(canvas_item_set_use_parent_material, RID, bool)
 
+	BIND6(canvas_item_set_canvas_group_mode, RID, CanvasGroupMode, float, bool, float, bool)
+
 	BIND0R(RID, canvas_light_create)
 	BIND2(canvas_light_attach_to_canvas, RID, RID)
 	BIND2(canvas_light_set_enabled, RID, bool)

--- a/servers/rendering/rendering_server_wrap_mt.h
+++ b/servers/rendering/rendering_server_wrap_mt.h
@@ -642,6 +642,8 @@ public:
 
 	FUNC2(canvas_item_set_use_parent_material, RID, bool)
 
+	FUNC6(canvas_item_set_canvas_group_mode, RID, CanvasGroupMode, float, bool, float, bool)
+
 	FUNC0R(RID, canvas_light_create)
 	FUNC2(canvas_light_attach_to_canvas, RID, RID)
 	FUNC2(canvas_light_set_enabled, RID, bool)

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1184,6 +1184,14 @@ public:
 
 	virtual void canvas_item_set_use_parent_material(RID p_item, bool p_enable) = 0;
 
+	enum CanvasGroupMode {
+		CANVAS_GROUP_MODE_DISABLED,
+		CANVAS_GROUP_MODE_OPAQUE,
+		CANVAS_GROUP_MODE_TRANSPARENT,
+	};
+
+	virtual void canvas_item_set_canvas_group_mode(RID p_item, CanvasGroupMode p_mode, float p_clear_margin = 5.0, bool p_fit_empty = false, float p_fit_margin = 0.0, bool p_blur_mipmaps = false) = 0;
+
 	virtual RID canvas_light_create() = 0;
 	virtual void canvas_light_attach_to_canvas(RID p_light, RID p_canvas) = 0;
 	virtual void canvas_light_set_enabled(RID p_light, bool p_enabled) = 0;


### PR DESCRIPTION
* Allows merging several 2D objects into a single draw operation
* Use current node to clip children nodes
* Further fixes to Vulkan barriers
* Changed font texture generation to white, fixes dark eges when blurred
* Other small misc fixes to backbuffer code.

![mask](https://user-images.githubusercontent.com/6265307/97481483-a65be980-1933-11eb-82df-8e78722a2af5.gif)
![cgroup1](https://user-images.githubusercontent.com/6265307/97481489-a956da00-1933-11eb-98dd-26d4aa7b9a6f.gif)
![clip](https://user-images.githubusercontent.com/6265307/97481515-b2e04200-1933-11eb-9eef-73edaf85be88.png)
