### PR TITLE
Fix artifacts in DynamicFont when scaling with filtering enabled

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -471,8 +471,21 @@ DynamicFontAtSize::TexturePosition DynamicFontAtSize::_find_texture_pos_for_glyp
 			//zero texture
 			PoolVector<uint8_t>::Write w = tex.imgdata.write();
 			ERR_FAIL_COND_V(texsize * texsize * p_color_size > tex.imgdata.size(), ret);
-			for (int i = 0; i < texsize * texsize * p_color_size; i++) {
-				w[i] = 0;
+
+			// Initialize the texture to all-white pixels to prevent artifacts when the
+			// font is displayed at a non-default scale with filtering enabled.
+			if (p_color_size == 2) {
+				for (int i = 0; i < texsize * texsize * p_color_size; i += 2) {
+					w[i + 0] = 255;
+					w[i + 1] = 0;
+				}
+			} else {
+				for (int i = 0; i < texsize * texsize * p_color_size; i += 4) {
+					w[i + 0] = 255;
+					w[i + 1] = 255;
+					w[i + 2] = 255;
+					w[i + 3] = 0;
+				}
 			}
 		}
 		tex.offsets.resize(texsize);


### PR DESCRIPTION
This backports the fix from #43167 to the `3.2` branch.

## Preview

### Before

![dynamicfont_scaling_gray_before](https://user-images.githubusercontent.com/180032/97507975-b9e07200-197e-11eb-99e2-9eb26fdfda14.png)

![dynamicfont_scaling_white_before](https://user-images.githubusercontent.com/180032/97507988-bf3dbc80-197e-11eb-86b1-f9f621addef7.png)

### After

![dynamicfont_scaling_gray_after](https://user-images.githubusercontent.com/180032/97507973-b947db80-197e-11eb-99fc-4d012953faa3.png)

![dynamicfont_scaling_white_after](https://user-images.githubusercontent.com/180032/97507976-ba790880-197e-11eb-98cd-bc06eb494a1b.png)


Test project: [test_font_scaling.zip](https://github.com/godotengine/godot/files/5455314/test_font_scaling.zip)
