### PR TITLE
Fix crash in TabContainer in case of no content at all

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -371,8 +371,10 @@ void TabContainer::_notification(int p_what) {
 			// Draw the tab area.
 			panel->draw(canvas, Rect2(0, header_height, size.width, size.height - header_height));
 
-			// Draw selected tab in front
-			_draw_tab(tab_fg, font_color_fg, current, tabs_ofs_cache + x_current);
+			// Draw selected tab in front. Need to check tabs.size() in case of no contents at all.
+			if (tabs.size() > 0) {
+				_draw_tab(tab_fg, font_color_fg, current, tabs_ofs_cache + x_current);
+			}
 
 			// Draw the popup menu.
 			x = get_size().width;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fix #43165

It was safe in previous logic because all tabs are drawn in for loop.
But the regression is caused by drawing selected tab is out of loop.