### PR TITLE
Allow local port control on net_socket connections

### DIFF
--- a/core/io/net_socket.h
+++ b/core/io/net_socket.h
@@ -67,6 +67,7 @@ public:
 
 	virtual bool is_open() const = 0;
 	virtual int get_available_bytes() const = 0;
+	virtual Error get_socket_address(IP_Address *r_ip, uint16_t *r_port) const = 0;
 
 	virtual Error set_broadcasting_enabled(bool p_enabled) = 0; // Returns OK if the socket option has been set successfully.
 	virtual void set_blocking_enabled(bool p_enabled) = 0;

--- a/core/io/packet_peer_udp.h
+++ b/core/io/packet_peer_udp.h
@@ -78,11 +78,12 @@ public:
 	Error connect_shared_socket(Ref<NetSocket> p_sock, IP_Address p_ip, uint16_t p_port, UDPServer *ref); // Used by UDPServer
 	void disconnect_shared_socket(); // Used by UDPServer
 	Error store_packet(IP_Address p_ip, uint32_t p_port, uint8_t *p_buf, int p_buf_size); // Used internally and by UDPServer
-	Error connect_to_host(const IP_Address &p_host, int p_port);
+	Error connect_to_host(const IP_Address &p_host, int p_port, int p_local_port = 0);
 	bool is_connected_to_host() const;
 
 	IP_Address get_packet_address() const;
 	int get_packet_port() const;
+	int get_local_port() const;
 	void set_dest_address(const IP_Address &p_address, int p_port);
 
 	Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;

--- a/core/io/stream_peer_tcp.h
+++ b/core/io/stream_peer_tcp.h
@@ -55,7 +55,7 @@ protected:
 	IP_Address peer_host;
 	uint16_t peer_port = 0;
 
-	Error _connect(const String &p_address, int p_port);
+	Error _connect(const String &p_address, int p_port, int p_local_port = 0);
 	Error _poll_connection();
 	Error write(const uint8_t *p_data, int p_bytes, int &r_sent, bool p_block);
 	Error read(uint8_t *p_buffer, int p_bytes, int &r_received, bool p_block);
@@ -65,10 +65,11 @@ protected:
 public:
 	void accept_socket(Ref<NetSocket> p_sock, IP_Address p_host, uint16_t p_port);
 
-	Error connect_to_host(const IP_Address &p_host, uint16_t p_port);
+	Error connect_to_host(const IP_Address &p_host, int p_port, int p_local_port = 0);
 	bool is_connected_to_host() const;
 	IP_Address get_connected_host() const;
-	uint16_t get_connected_port() const;
+	int get_connected_port() const;
+	int get_local_port() const;
 	void disconnect_from_host();
 
 	int get_available_bytes() const override;

--- a/core/io/tcp_server.cpp
+++ b/core/io/tcp_server.cpp
@@ -34,6 +34,7 @@ void TCP_Server::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("listen", "port", "bind_address"), &TCP_Server::listen, DEFVAL("*"));
 	ClassDB::bind_method(D_METHOD("is_connection_available"), &TCP_Server::is_connection_available);
 	ClassDB::bind_method(D_METHOD("is_listening"), &TCP_Server::is_listening);
+	ClassDB::bind_method(D_METHOD("get_local_port"), &TCP_Server::get_local_port);
 	ClassDB::bind_method(D_METHOD("take_connection"), &TCP_Server::take_connection);
 	ClassDB::bind_method(D_METHOD("stop"), &TCP_Server::stop);
 }
@@ -41,6 +42,7 @@ void TCP_Server::_bind_methods() {
 Error TCP_Server::listen(uint16_t p_port, const IP_Address &p_bind_address) {
 	ERR_FAIL_COND_V(!_sock.is_valid(), ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(_sock->is_open(), ERR_ALREADY_IN_USE);
+	ERR_FAIL_COND_V(p_port < 0 || p_port > 65535, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(!p_bind_address.is_valid() && !p_bind_address.is_wildcard(), ERR_INVALID_PARAMETER);
 
 	Error err;
@@ -72,6 +74,12 @@ Error TCP_Server::listen(uint16_t p_port, const IP_Address &p_bind_address) {
 		return FAILED;
 	}
 	return OK;
+}
+
+int TCP_Server::get_local_port() const {
+	uint16_t local_port;
+	_sock->get_socket_address(nullptr, &local_port);
+	return local_port;
 }
 
 bool TCP_Server::is_listening() const {

--- a/core/io/tcp_server.h
+++ b/core/io/tcp_server.h
@@ -49,6 +49,7 @@ protected:
 
 public:
 	Error listen(uint16_t p_port, const IP_Address &p_bind_address = IP_Address("*"));
+	int get_local_port() const;
 	bool is_listening() const;
 	bool is_connection_available() const;
 	Ref<StreamPeerTCP> take_connection();

--- a/core/io/udp_server.cpp
+++ b/core/io/udp_server.cpp
@@ -34,6 +34,7 @@ void UDPServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("listen", "port", "bind_address"), &UDPServer::listen, DEFVAL("*"));
 	ClassDB::bind_method(D_METHOD("poll"), &UDPServer::poll);
 	ClassDB::bind_method(D_METHOD("is_connection_available"), &UDPServer::is_connection_available);
+	ClassDB::bind_method(D_METHOD("get_local_port"), &UDPServer::get_local_port);
 	ClassDB::bind_method(D_METHOD("is_listening"), &UDPServer::is_listening);
 	ClassDB::bind_method(D_METHOD("take_connection"), &UDPServer::take_connection);
 	ClassDB::bind_method(D_METHOD("stop"), &UDPServer::stop);
@@ -89,6 +90,7 @@ Error UDPServer::poll() {
 Error UDPServer::listen(uint16_t p_port, const IP_Address &p_bind_address) {
 	ERR_FAIL_COND_V(!_sock.is_valid(), ERR_UNAVAILABLE);
 	ERR_FAIL_COND_V(_sock->is_open(), ERR_ALREADY_IN_USE);
+	ERR_FAIL_COND_V(p_port < 0 || p_port > 65535, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(!p_bind_address.is_valid() && !p_bind_address.is_wildcard(), ERR_INVALID_PARAMETER);
 
 	Error err;
@@ -112,9 +114,13 @@ Error UDPServer::listen(uint16_t p_port, const IP_Address &p_bind_address) {
 		stop();
 		return err;
 	}
-	bind_address = p_bind_address;
-	bind_port = p_port;
 	return OK;
+}
+
+int UDPServer::get_local_port() const {
+	uint16_t local_port;
+	_sock->get_socket_address(nullptr, &local_port);
+	return local_port;
 }
 
 bool UDPServer::is_listening() const {
@@ -176,8 +182,6 @@ void UDPServer::stop() {
 	if (_sock.is_valid()) {
 		_sock->close();
 	}
-	bind_port = 0;
-	bind_address = IP_Address();
 	List<Peer>::Element *E = peers.front();
 	while (E) {
 		E->get().peer->disconnect_shared_socket();

--- a/core/io/udp_server.h
+++ b/core/io/udp_server.h
@@ -53,21 +53,18 @@ protected:
 	};
 	uint8_t recv_buffer[PACKET_BUFFER_SIZE];
 
-	int bind_port = 0;
-	IP_Address bind_address;
-
 	List<Peer> peers;
 	List<Peer> pending;
 	int max_pending_connections = 16;
 
 	Ref<NetSocket> _sock;
-
 	static void _bind_methods();
 
 public:
 	void remove_peer(IP_Address p_ip, int p_port);
 	Error listen(uint16_t p_port, const IP_Address &p_bind_address = IP_Address("*"));
 	Error poll();
+	int get_local_port() const;
 	bool is_listening() const;
 	bool is_connection_available() const;
 	void set_max_pending_connections(int p_max);

--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -23,8 +23,10 @@
 			</argument>
 			<argument index="1" name="port" type="int">
 			</argument>
+			<argument index="2" name="local_port" type="int" default="0">
+			</argument>
 			<description>
-				Calling this method connects this UDP peer to the given [code]host[/code]/[code]port[/code] pair. UDP is in reality connectionless, so this option only means that incoming packets from different addresses are automatically discarded, and that outgoing packets are always sent to the connected address (future calls to [method set_dest_address] are not allowed). This method does not send any data to the remote peer, to do that, use [method PacketPeer.put_var] or [method PacketPeer.put_packet] as usual. See also [UDPServer].
+				Calling this method connects this UDP peer to the given [code]host[/code]/[code]port[/code] pair. UDP is in reality connectionless, so this option only means that incoming packets from different addresses are automatically discarded, and that outgoing packets are always sent to the connected address (future calls to [method set_dest_address] are not allowed). This method does not send any data to the remote peer, to do that, use [method PacketPeer.put_var] or [method PacketPeer.put_packet] as usual. See also [UDPServer]. If [code]local_port[/code] is specified, the provided port will be used as source of the connection, otherwise a port number from the ephemeral port range will be provided; this is useful for some NAT traversal techniques.
 				[b]Note:[/b] Connecting to the remote peer does not help to protect from malicious attacks like IP spoofing, etc. Think about using an encryption technique like SSL or DTLS if you feel like your application is transferring sensitive information.
 			</description>
 		</method>
@@ -154,6 +156,13 @@
 		}
 		[/csharp]
 		[/codeblocks]
+			</description>
+		</method>
+		<method name="get_local_port" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the local port of this peer.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/StreamPeerTCP.xml
+++ b/doc/classes/StreamPeerTCP.xml
@@ -16,8 +16,10 @@
 			</argument>
 			<argument index="1" name="port" type="int">
 			</argument>
+			<argument index="2" name="local_port" type="int" default="0">
+			</argument>
 			<description>
-				Connects to the specified [code]host:port[/code] pair. A hostname will be resolved if valid. Returns [constant OK] on success or [constant FAILED] on failure.
+				Connects to the specified [code]host:port[/code] pair. A hostname will be resolved if valid. Returns [constant OK] on success or [constant FAILED] on failure. If [code]local_port[/code] is specified, the provided port will be used as source of the connection, otherwise a port number from the ephemeral port range will be provided; this is useful for some NAT traversal techniques.
 			</description>
 		</method>
 		<method name="disconnect_from_host">
@@ -63,6 +65,13 @@
 			<description>
 				Disables Nagle's algorithm to improve latency for small packets.
 				[b]Note:[/b] For applications that send large packets or need to transfer a lot of data, this can decrease the total available bandwidth.
+			</description>
+		</method>
+		<method name="get_local_port" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the local port of this peer.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TCP_Server.xml
+++ b/doc/classes/TCP_Server.xml
@@ -51,6 +51,13 @@
 				If a connection is available, returns a StreamPeerTCP with the connection.
 			</description>
 		</method>
+		<method name="get_local_port" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the local port this server is listening to.
+			</description>
+		</method>
 	</methods>
 	<constants>
 	</constants>

--- a/doc/classes/UDPServer.xml
+++ b/doc/classes/UDPServer.xml
@@ -169,6 +169,13 @@
 				Returns the first pending connection (connected to the appropriate address/port). Will return [code]null[/code] if no new connection is available. See also [method is_connection_available], [method PacketPeerUDP.connect_to_host].
 			</description>
 		</method>
+		<method name="get_local_port" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns the local port this server is listening to.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="max_pending_connections" type="int" setter="set_max_pending_connections" getter="get_max_pending_connections" default="16">

--- a/drivers/unix/net_socket_posix.h
+++ b/drivers/unix/net_socket_posix.h
@@ -54,7 +54,9 @@ private:
 		ERR_NET_WOULD_BLOCK,
 		ERR_NET_IS_CONNECTED,
 		ERR_NET_IN_PROGRESS,
-		ERR_NET_OTHER
+		ERR_NET_ADDRESS_INVALID_OR_UNAVAILABLE,
+		ERR_NET_UNAUTHORIZED,
+		ERR_NET_OTHER,
 	};
 
 	NetError _get_socket_error() const;
@@ -87,6 +89,7 @@ public:
 
 	virtual bool is_open() const;
 	virtual int get_available_bytes() const;
+	virtual Error get_socket_address(IP_Address *r_ip, uint16_t *r_port) const;
 
 	virtual Error set_broadcasting_enabled(bool p_enabled);
 	virtual void set_blocking_enabled(bool p_enabled);


### PR DESCRIPTION
Allow to set and retrieve the local port of socket based network connections.
Project used to validate developments: [validation-test.zip](https://github.com/godotengine/godot/files/5455974/validation-test.zip)
