### PR TITLE
Update android gradle plugins versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ platform/android/java/lib/.cxx/
 platform/android/java/libs/*
 platform/android/java/app/libs/*
 platform/android/java/lib/.cxx/*
+platform/android/java/nativeSrcsConfigs/.cxx/
 
 # General c++ generated files
 *.lib

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -70,8 +70,8 @@ android {
     buildToolsVersion versions.buildTools
 
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility versions.javaVersion
+        targetCompatibility versions.javaVersion
     }
 
     defaultConfig {

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -6,7 +6,8 @@ ext.versions = [
     buildTools         : '30.0.1',
     supportCoreUtils   : '1.0.0',
     kotlinVersion      : '1.4.10',
-    v4Support          : '1.0.0'
+    v4Support          : '1.0.0',
+    javaVersion        : 1.8
 
 ]
 

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,11 +1,11 @@
 ext.versions = [
-    androidGradlePlugin: '3.5.3',
+    androidGradlePlugin: '4.1.0',
     compileSdk         : 29,
     minSdk             : 18,
     targetSdk          : 29,
-    buildTools         : '29.0.3',
+    buildTools         : '30.0.1',
     supportCoreUtils   : '1.0.0',
-    kotlinVersion      : '1.3.61',
+    kotlinVersion      : '1.4.10',
     v4Support          : '1.0.0'
 
 ]

--- a/platform/android/java/gradle.properties
+++ b/platform/android/java/gradle.properties
@@ -18,3 +18,5 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+org.gradle.warning.mode=all

--- a/platform/android/java/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/java/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -18,6 +18,11 @@ android {
         targetSdkVersion versions.targetSdk
     }
 
+    compileOptions {
+        sourceCompatibility versions.javaVersion
+        targetCompatibility versions.javaVersion
+    }
+
     lintOptions {
         abortOnError false
         disable 'MissingTranslation', 'UnusedResources'
@@ -50,15 +55,6 @@ android {
 
         def buildType = variant.buildType.name.capitalize()
 
-        def taskPrefix = ""
-        if (project.path != ":") {
-            taskPrefix = project.path + ":"
-        }
-
-        // Disable the externalNativeBuild* task as it would cause build failures since the cmake build
-        // files is only setup for editing support.
-        gradle.startParameter.excludedTaskNames += taskPrefix + "externalNativeBuild" + buildType
-
         def releaseTarget = buildType.toLowerCase()
         if (releaseTarget == null || releaseTarget == "") {
             throw new GradleException("Invalid build type: " + buildType)
@@ -77,11 +73,5 @@ android {
 
         // Schedule the tasks so the generated libs are present before the aar file is packaged.
         tasks["merge${buildType}JniLibFolders"].dependsOn taskName
-    }
-
-    externalNativeBuild {
-        cmake {
-            path "CMakeLists.txt"
-        }
     }
 }

--- a/platform/android/java/nativeSrcsConfigs/AndroidManifest.xml
+++ b/platform/android/java/nativeSrcsConfigs/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="org.godotengine.godot" />

--- a/platform/android/java/nativeSrcsConfigs/CMakeLists.txt
+++ b/platform/android/java/nativeSrcsConfigs/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Non functional cmake build file used to provide Android Studio editor support to the project.
 cmake_minimum_required(VERSION 3.6)
 project(godot)
 

--- a/platform/android/java/nativeSrcsConfigs/README.md
+++ b/platform/android/java/nativeSrcsConfigs/README.md
@@ -1,0 +1,4 @@
+## Native sources configs
+
+This is a non functional Android library used to provide Android Studio editor support to the Godot project native files.
+Nothing else should be added to this library.

--- a/platform/android/java/nativeSrcsConfigs/build.gradle
+++ b/platform/android/java/nativeSrcsConfigs/build.gradle
@@ -1,0 +1,54 @@
+// Non functional android library used to provide Android Studio editor support to the project.
+plugins {
+    id 'com.android.library'
+}
+
+android {
+    compileSdkVersion versions.compileSdk
+    buildToolsVersion versions.buildTools
+
+    defaultConfig {
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
+    }
+
+    compileOptions {
+        sourceCompatibility versions.javaVersion
+        targetCompatibility versions.javaVersion
+    }
+
+    packagingOptions {
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/NOTICE'
+
+        // Should be uncommented for development purpose within Android Studio
+        // doNotStrip '**/*.so'
+    }
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path "CMakeLists.txt"
+        }
+    }
+
+    libraryVariants.all { variant ->
+        def buildType = variant.buildType.name.capitalize()
+
+        def taskPrefix = ""
+        if (project.path != ":") {
+            taskPrefix = project.path + ":"
+        }
+
+        // Disable the externalNativeBuild* task as it would cause build failures since the cmake build
+        // files is only setup for editing support.
+        gradle.startParameter.excludedTaskNames += taskPrefix + "externalNativeBuild" + buildType
+    }
+}
+
+dependencies {}

--- a/platform/android/java/settings.gradle
+++ b/platform/android/java/settings.gradle
@@ -3,3 +3,4 @@ rootProject.name = "Godot"
 
 include ':app'
 include ':lib'
+include ':nativeSrcsConfigs'


### PR DESCRIPTION
Bump the Android gradle plugins versions to the latest.

Android Studio 4.1+ seems to stop providing editor support for (and recognizing) Android libraries when they define an external native build whose root includes the library's directory.
As a workaround, I moved the external native build definition into a separate empty Android library. This does not affect the project structure since the external native build definition was added in the first place for Android Studio editor support (the actual native dependencies are handled by `scons`).