### PR TITLE
Replace String comparisons with "", String() to is_empty()

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -184,7 +184,7 @@ String ProjectSettings::localize_path(const String &p_path) const {
 		String parent = path.substr(0, sep);
 
 		String plocal = localize_path(parent);
-		if (plocal == "") {
+		if (plocal.is_empty()) {
 			return "";
 		}
 		// Only strip the starting '/' from 'path' if its parent ('plocal') ends with '/'
@@ -228,13 +228,13 @@ bool ProjectSettings::get_ignore_value_in_docs(const String &p_name) const {
 
 String ProjectSettings::globalize_path(const String &p_path) const {
 	if (p_path.begins_with("res://")) {
-		if (resource_path != "") {
+		if (!resource_path.is_empty()) {
 			return p_path.replace("res:/", resource_path);
 		}
 		return p_path.replace("res://", "");
 	} else if (p_path.begins_with("user://")) {
 		String data_dir = OS::get_singleton()->get_user_data_dir();
-		if (data_dir != "") {
+		if (!data_dir.is_empty()) {
 			return p_path.replace("user:/", data_dir);
 		}
 		return p_path.replace("user://", "");
@@ -456,7 +456,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 
 	// Attempt with a user-defined main pack first
 
-	if (p_main_pack != "") {
+	if (!p_main_pack.is_empty()) {
 		bool ok = _load_resource_pack(p_main_pack);
 		ERR_FAIL_COND_V_MSG(!ok, ERR_CANT_OPEN, "Cannot open resource pack '" + p_main_pack + "'.");
 
@@ -471,7 +471,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 
 	String exec_path = OS::get_singleton()->get_executable_path();
 
-	if (exec_path != "") {
+	if (!exec_path.is_empty()) {
 		// We do several tests sequentially until one succeeds to find a PCK,
 		// and if so, we attempt loading it at the end.
 
@@ -523,11 +523,11 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 	// Try to use the filesystem for files, according to OS.
 	// (Only Android -when reading from pck- and iOS use this.)
 
-	if (OS::get_singleton()->get_resource_dir() != "") {
+	if (!OS::get_singleton()->get_resource_dir().is_empty()) {
 		// OS will call ProjectSettings->get_resource_path which will be empty if not overridden!
 		// If the OS would rather use a specific location, then it will not be empty.
 		resource_path = OS::get_singleton()->get_resource_dir().replace("\\", "/");
-		if (resource_path != "" && resource_path[resource_path.length() - 1] == '/') {
+		if (!resource_path.is_empty() && resource_path[resource_path.length() - 1] == '/') {
 			resource_path = resource_path.substr(0, resource_path.length() - 1); // Chop end.
 		}
 
@@ -591,7 +591,7 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bo
 	Error err = _setup(p_path, p_main_pack, p_upwards, p_ignore_override);
 	if (err == OK) {
 		String custom_settings = GLOBAL_DEF("application/config/project_settings_override", "");
-		if (custom_settings != "") {
+		if (!custom_settings.is_empty()) {
 			_load_settings_text(custom_settings);
 		}
 	}
@@ -699,21 +699,21 @@ Error ProjectSettings::_load_settings_text(const String &p_path) {
 			return err;
 		}
 
-		if (assign != String()) {
-			if (section == String() && assign == "config_version") {
+		if (!assign.is_empty()) {
+			if (section.is_empty() && assign == "config_version") {
 				config_version = value;
 				if (config_version > CONFIG_VERSION) {
 					memdelete(f);
 					ERR_FAIL_V_MSG(ERR_FILE_CANT_OPEN, vformat("Can't open project at '%s', its `config_version` (%d) is from a more recent and incompatible version of the engine. Expected config version: %d.", p_path, config_version, CONFIG_VERSION));
 				}
 			} else {
-				if (section == String()) {
+				if (section.is_empty()) {
 					set(assign, value);
 				} else {
 					set(section + "/" + assign, value);
 				}
 			}
-		} else if (next_tag.name != String()) {
+		} else if (!next_tag.name.is_empty()) {
 			section = next_tag.name;
 		}
 	}
@@ -797,7 +797,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<Str
 		count += E.value.size();
 	}
 
-	if (p_custom_features != String()) {
+	if (!p_custom_features.is_empty()) {
 		file->store_32(count + 1);
 		//store how many properties are saved, add one for custom featuers, which must always go first
 		String key = CoreStringNames::get_singleton()->_custom_features;
@@ -827,7 +827,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const Map<Str
 
 	for (Map<String, List<String>>::Element *E = props.front(); E; E = E->next()) {
 		for (String &key : E->get()) {
-			if (E->key() != "") {
+			if (!E->key().is_empty()) {
 				key = E->key() + "/" + key;
 			}
 			Variant value;
@@ -881,7 +881,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 	file->store_line("");
 
 	file->store_string("config_version=" + itos(CONFIG_VERSION) + "\n");
-	if (p_custom_features != String()) {
+	if (!p_custom_features.is_empty()) {
 		file->store_string("custom_features=\"" + p_custom_features + "\"\n");
 	}
 	file->store_string("\n");
@@ -891,12 +891,12 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 			file->store_string("\n");
 		}
 
-		if (E->key() != "") {
+		if (!E->key().is_empty()) {
 			file->store_string("[" + E->key() + "]\n\n");
 		}
 		for (const String &F : E->get()) {
 			String key = F;
-			if (E->key() != "") {
+			if (!E->key().is_empty()) {
 				key = E->key() + "/" + key;
 			}
 			Variant value;
@@ -924,7 +924,7 @@ Error ProjectSettings::_save_custom_bnd(const String &p_file) { // add other par
 }
 
 Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_custom, const Vector<String> &p_custom_features, bool p_merge_with_current) {
-	ERR_FAIL_COND_V_MSG(p_path == "", ERR_INVALID_PARAMETER, "Project settings save path cannot be empty.");
+	ERR_FAIL_COND_V_MSG(p_path.is_empty(), ERR_INVALID_PARAMETER, "Project settings save path cannot be empty.");
 
 	PackedStringArray project_features = has_setting("application/config/features") ? (PackedStringArray)get_setting("application/config/features") : PackedStringArray();
 	// If there is no feature list currently present, force one to generate.
@@ -933,7 +933,7 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 	}
 	// Check the rendering API.
 	const String rendering_api = has_setting("rendering/quality/driver/driver_name") ? (String)get_setting("rendering/quality/driver/driver_name") : String();
-	if (rendering_api != "") {
+	if (!rendering_api.is_empty()) {
 		// Add the rendering API as a project feature if it doesn't already exist.
 		if (!project_features.has(rendering_api)) {
 			project_features.append(rendering_api);

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1483,7 +1483,7 @@ String Directory::get_next() {
 	ERR_FAIL_COND_V_MSG(!is_open(), "", "Directory must be opened before use.");
 
 	String next = d->get_next();
-	while (next != "" && ((_list_skip_navigational && (next == "." || next == "..")) || (_list_skip_hidden && d->current_is_hidden()))) {
+	while (!next.is_empty() && ((_list_skip_navigational && (next == "." || next == "..")) || (_list_skip_hidden && d->current_is_hidden()))) {
 		next = d->get_next();
 	}
 	return next;
@@ -1665,7 +1665,7 @@ String Marshalls::variant_to_base64(const Variant &p_var, bool p_full_objects) {
 	ERR_FAIL_COND_V_MSG(err != OK, "", "Error when trying to encode Variant.");
 
 	String ret = CryptoCore::b64_encode_str(&w[0], len);
-	ERR_FAIL_COND_V(ret == "", ret);
+	ERR_FAIL_COND_V(ret.is_empty(), ret);
 
 	return ret;
 }
@@ -1690,7 +1690,7 @@ Variant Marshalls::base64_to_variant(const String &p_str, bool p_allow_objects) 
 
 String Marshalls::raw_to_base64(const Vector<uint8_t> &p_arr) {
 	String ret = CryptoCore::b64_encode_str(p_arr.ptr(), p_arr.size());
-	ERR_FAIL_COND_V(ret == "", ret);
+	ERR_FAIL_COND_V(ret.is_empty(), ret);
 	return ret;
 }
 
@@ -1714,7 +1714,7 @@ Vector<uint8_t> Marshalls::base64_to_raw(const String &p_str) {
 String Marshalls::utf8_to_base64(const String &p_str) {
 	CharString cstr = p_str.utf8();
 	String ret = CryptoCore::b64_encode_str((unsigned char *)cstr.get_data(), cstr.length());
-	ERR_FAIL_COND_V(ret == "", ret);
+	ERR_FAIL_COND_V(ret.is_empty(), ret);
 	return ret;
 }
 

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -139,7 +139,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 		// Cache options
 		String variable_prefix = options["variable_prefix"];
 
-		if (line == "") {
+		if (line.is_empty()) {
 			print_line("\nDebugger Break, Reason: '" + script_lang->debug_get_error() + "'");
 			print_line("*Frame " + itos(current_frame) + " - " + script_lang->debug_get_stack_level_source(current_frame) + ":" + itos(script_lang->debug_get_stack_level_line(current_frame)) + " in function '" + script_lang->debug_get_stack_level_function(current_frame) + "'");
 			print_line("Enter \"help\" for assistance.");

--- a/core/doc_data.cpp
+++ b/core/doc_data.cpp
@@ -33,7 +33,7 @@
 void DocData::return_doc_from_retinfo(DocData::MethodDoc &p_method, const PropertyInfo &p_retinfo) {
 	if (p_retinfo.type == Variant::INT && p_retinfo.hint == PROPERTY_HINT_INT_IS_POINTER) {
 		p_method.return_type = p_retinfo.hint_string;
-		if (p_method.return_type == "") {
+		if (p_method.return_type.is_empty()) {
 			p_method.return_type = "void*";
 		} else {
 			p_method.return_type += "*";
@@ -64,7 +64,7 @@ void DocData::argument_doc_from_arginfo(DocData::ArgumentDoc &p_argument, const 
 
 	if (p_arginfo.type == Variant::INT && p_arginfo.hint == PROPERTY_HINT_INT_IS_POINTER) {
 		p_argument.type = p_arginfo.hint_string;
-		if (p_argument.type == "") {
+		if (p_argument.type.is_empty()) {
 			p_argument.type = "void*";
 		} else {
 			p_argument.type += "*";

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -40,7 +40,7 @@
 
 static String get_type_name(const PropertyInfo &p_info) {
 	if (p_info.type == Variant::INT && (p_info.hint == PROPERTY_HINT_INT_IS_POINTER)) {
-		if (p_info.hint_string == "") {
+		if (p_info.hint_string.is_empty()) {
 			return "void*";
 		} else {
 			return p_info.hint_string + "*";
@@ -340,7 +340,7 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 			int value = CoreConstants::get_global_constant_value(i);
 			String enum_name = CoreConstants::get_global_constant_enum(i);
 			String name = CoreConstants::get_global_constant_name(i);
-			if (enum_name != String()) {
+			if (!enum_name.is_empty()) {
 				enum_list[enum_name].push_back(Pair<String, int>(name, value));
 			} else {
 				Dictionary d;

--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -397,7 +397,7 @@ RES NativeExtensionResourceLoader::load(const String &p_path, const String &p_or
 		}
 	}
 
-	if (library_path == String()) {
+	if (library_path.is_empty()) {
 		if (r_error) {
 			*r_error = ERR_FILE_NOT_FOUND;
 		}

--- a/core/extension/native_extension_manager.cpp
+++ b/core/extension/native_extension_manager.cpp
@@ -115,7 +115,7 @@ void NativeExtensionManager::load_extensions() {
 	FileAccessRef f = FileAccess::open(NativeExtension::get_extension_list_config_file(), FileAccess::READ);
 	while (f && !f->eof_reached()) {
 		String s = f->get_line().strip_edges();
-		if (s != String()) {
+		if (!s.is_empty()) {
 			LoadStatus err = load_extension(s);
 			ERR_CONTINUE_MSG(err == LOAD_STATUS_FAILED, "Error loading extension: " + s);
 		}

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -403,7 +403,7 @@ void Input::joy_connection_changed(int p_idx, bool p_connected, String p_name, S
 
 	if (p_connected) {
 		String uidname = p_guid;
-		if (p_guid == "") {
+		if (p_guid.is_empty()) {
 			int uidlen = MIN(p_name.length(), 16);
 			for (int i = 0; i < uidlen; i++) {
 				uidname = uidname + _hex_str(p_name[i]);
@@ -1249,7 +1249,7 @@ void Input::parse_mapping(String p_mapping) {
 
 	int idx = 1;
 	while (++idx < entry.size()) {
-		if (entry[idx] == "") {
+		if (entry[idx].is_empty()) {
 			continue;
 		}
 
@@ -1420,10 +1420,10 @@ Input::Input() {
 
 	// If defined, parse SDL_GAMECONTROLLERCONFIG for possible new mappings/overrides.
 	String env_mapping = OS::get_singleton()->get_environment("SDL_GAMECONTROLLERCONFIG");
-	if (env_mapping != "") {
+	if (!env_mapping.is_empty()) {
 		Vector<String> entries = env_mapping.split("\n");
 		for (int i = 0; i < entries.size(); i++) {
-			if (entries[i] == "") {
+			if (entries[i].is_empty()) {
 				continue;
 			}
 			parse_mapping(entries[i]);

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -360,12 +360,12 @@ String InputEventKey::as_text() const {
 		kc = keycode_get_string(keycode);
 	}
 
-	if (kc == String()) {
+	if (kc.is_empty()) {
 		return kc;
 	}
 
 	String mods_text = InputEventWithModifiers::as_text();
-	return mods_text == "" ? kc : mods_text + "+" + kc;
+	return mods_text.is_empty() ? kc : mods_text + "+" + kc;
 }
 
 String InputEventKey::to_string() {
@@ -382,7 +382,7 @@ String InputEventKey::to_string() {
 	}
 
 	String mods = InputEventWithModifiers::as_text();
-	mods = mods == "" ? TTR("none") : mods;
+	mods = mods.is_empty() ? TTR("none") : mods;
 
 	return vformat("InputEventKey: keycode=%s, mods=%s, physical=%s, pressed=%s, echo=%s", kc, mods, physical, p, e);
 }
@@ -634,7 +634,7 @@ static const char *_mouse_button_descriptions[9] = {
 String InputEventMouseButton::as_text() const {
 	// Modifiers
 	String mods_text = InputEventWithModifiers::as_text();
-	String full_string = mods_text == "" ? "" : mods_text + "+";
+	String full_string = mods_text.is_empty() ? "" : mods_text + "+";
 
 	// Button
 	MouseButton idx = get_button_index();
@@ -687,7 +687,7 @@ String InputEventMouseButton::to_string() {
 	}
 
 	String mods = InputEventWithModifiers::as_text();
-	mods = mods == "" ? TTR("none") : mods;
+	mods = mods.is_empty() ? TTR("none") : mods;
 
 	// Work around the fact vformat can only take 5 substitutions but 6 need to be passed.
 	String index_and_mods = vformat("button_index=%s, mods=%s", button_index, mods);

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -718,7 +718,7 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins_with
 		String name = split[0];
 		String override_for = split.size() > 1 ? split[1] : String();
 
-		if (override_for != String() && OS::get_singleton()->has_feature(override_for)) {
+		if (!override_for.is_empty() && OS::get_singleton()->has_feature(override_for)) {
 			builtins_with_overrides[name].push_back(override_for);
 		}
 	}
@@ -730,12 +730,12 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins_with
 		String name = split[0];
 		String override_for = split.size() > 1 ? split[1] : String();
 
-		if (builtins_with_overrides.has(name) && override_for == String()) {
+		if (builtins_with_overrides.has(name) && override_for.is_empty()) {
 			// Builtin has an override but this particular one is not an override, so skip.
 			continue;
 		}
 
-		if (override_for != String() && !OS::get_singleton()->has_feature(override_for)) {
+		if (!override_for.is_empty() && !OS::get_singleton()->has_feature(override_for)) {
 			// OS does not support this override - skip.
 			continue;
 		}

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -183,7 +183,7 @@ Error ConfigFile::_internal_save(FileAccess *file) {
 		if (E != values.front()) {
 			file->store_string("\n");
 		}
-		if (E.key() != "") {
+		if (!E.key().is_empty()) {
 			file->store_string("[" + E.key() + "]\n\n");
 		}
 
@@ -287,9 +287,9 @@ Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream) 
 			return err;
 		}
 
-		if (assign != String()) {
+		if (!assign.is_empty()) {
 			set_value(section, assign, value);
-		} else if (next_tag.name != String()) {
+		} else if (!next_tag.name.is_empty()) {
 			section = next_tag.name;
 		}
 	}

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -79,7 +79,7 @@ static Error _erase_recursive(DirAccess *da) {
 
 	da->list_dir_begin();
 	String n = da->get_next();
-	while (n != String()) {
+	while (!n.is_empty()) {
 		if (n != "." && n != "..") {
 			if (da->current_is_dir()) {
 				dirs.push_back(n);
@@ -183,7 +183,7 @@ String DirAccess::fix_path(String p_path) const {
 			if (ProjectSettings::get_singleton()) {
 				if (p_path.begins_with("res://")) {
 					String resource_path = ProjectSettings::get_singleton()->get_resource_path();
-					if (resource_path != "") {
+					if (!resource_path.is_empty()) {
 						return p_path.replace_first("res:/", resource_path);
 					}
 					return p_path.replace_first("res://", "");
@@ -194,7 +194,7 @@ String DirAccess::fix_path(String p_path) const {
 		case ACCESS_USERDATA: {
 			if (p_path.begins_with("user://")) {
 				String data_dir = OS::get_singleton()->get_user_data_dir();
-				if (data_dir != "") {
+				if (!data_dir.is_empty()) {
 					return p_path.replace_first("user:/", data_dir);
 				}
 				return p_path.replace_first("user://", "");
@@ -337,7 +337,7 @@ Error DirAccess::_copy_dir(DirAccess *p_target_da, String p_to, int p_chmod_flag
 	String curdir = get_current_dir();
 	list_dir_begin();
 	String n = get_next();
-	while (n != String()) {
+	while (!n.is_empty()) {
 		if (n != "." && n != "..") {
 			if (p_copy_links && is_link(get_current_dir().plus_file(n))) {
 				create_link(read_link(get_current_dir().plus_file(n)), p_to + n);

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -127,7 +127,7 @@ String FileAccess::fix_path(const String &p_path) const {
 			if (ProjectSettings::get_singleton()) {
 				if (r_path.begins_with("res://")) {
 					String resource_path = ProjectSettings::get_singleton()->get_resource_path();
-					if (resource_path != "") {
+					if (!resource_path.is_empty()) {
 						return r_path.replace("res:/", resource_path);
 					}
 					return r_path.replace("res://", "");
@@ -138,7 +138,7 @@ String FileAccess::fix_path(const String &p_path) const {
 		case ACCESS_USERDATA: {
 			if (r_path.begins_with("user://")) {
 				String data_dir = OS::get_singleton()->get_user_data_dir();
-				if (data_dir != "") {
+				if (!data_dir.is_empty()) {
 					return r_path.replace("user:/", data_dir);
 				}
 				return r_path.replace("user://", "");

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -459,7 +459,7 @@ PackedData::PackedDir *DirAccessPack::_find_dir(String p_dir) {
 
 	nd = nd.simplify_path();
 
-	if (nd == "") {
+	if (nd.is_empty()) {
 		nd = ".";
 	}
 

--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -136,7 +136,7 @@ void RotatedFileLogger::clear_old_backups() {
 	da->list_dir_begin();
 	String f = da->get_next();
 	Set<String> backups;
-	while (f != String()) {
+	while (!f.is_empty()) {
 		if (!da->current_is_dir() && f.begins_with(basename) && f.get_extension() == extension && f != base_path.get_file()) {
 			backups.insert(f);
 		}
@@ -163,7 +163,7 @@ void RotatedFileLogger::rotate_file() {
 		if (max_files > 1) {
 			String timestamp = Time::get_singleton()->get_datetime_string_from_system().replace(":", ".");
 			String backup_name = base_path.get_basename() + timestamp;
-			if (base_path.get_extension() != String()) {
+			if (!base_path.get_extension().is_empty()) {
 				backup_name += "." + base_path.get_extension();
 			}
 

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -562,7 +562,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 					return err;
 				}
 
-				if (str == String()) {
+				if (str.is_empty()) {
 					r_variant = (Object *)nullptr;
 				} else {
 					Object *obj = ClassDB::instantiate(str);

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -52,7 +52,7 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 		return;
 	}
 
-	if (path_cache != "") {
+	if (!path_cache.is_empty()) {
 		ResourceCache::lock.write_lock();
 		ResourceCache::resources.erase(path_cache);
 		ResourceCache::lock.write_unlock();
@@ -82,7 +82,7 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 	}
 	path_cache = p_path;
 
-	if (path_cache != "") {
+	if (!path_cache.is_empty()) {
 		ResourceCache::lock.write_lock();
 		ResourceCache::resources[path_cache] = this;
 		ResourceCache::lock.write_unlock();
@@ -383,7 +383,7 @@ bool Resource::is_translation_remapped() const {
 #ifdef TOOLS_ENABLED
 //helps keep IDs same number when loading/saving scenes. -1 clears ID and it Returns -1 when no id stored
 void Resource::set_id_for_path(const String &p_path, const String &p_id) {
-	if (p_id == "") {
+	if (p_id.is_empty()) {
 		ResourceCache::path_cache_lock.write_lock();
 		ResourceCache::resource_path_cache[p_path].erase(get_path());
 		ResourceCache::path_cache_lock.write_unlock();
@@ -434,7 +434,7 @@ Resource::Resource() :
 		remapped_list(this) {}
 
 Resource::~Resource() {
-	if (path_cache != "") {
+	if (!path_cache.is_empty()) {
 		ResourceCache::lock.write_lock();
 		ResourceCache::resources.erase(path_cache);
 		ResourceCache::lock.write_unlock();

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -727,7 +727,7 @@ Error ResourceLoaderBinary::load() {
 			}
 
 			res = RES(r);
-			if (path != String() && cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
+			if (!path.is_empty() && cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
 				r->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE); //if got here because the resource with same path has different type, replace it
 			}
 			r->set_scene_unique_id(id);
@@ -829,7 +829,7 @@ void ResourceLoaderBinary::get_dependencies(FileAccess *p_f, List<String> *p_dep
 			dep = external_resources[i].path;
 		}
 
-		if (p_add_types && external_resources[i].type != String()) {
+		if (p_add_types && !external_resources[i].type.is_empty()) {
 			dep += "::" + external_resources[i].type;
 		}
 
@@ -1026,7 +1026,7 @@ RES ResourceFormatLoaderBinary::load(const String &p_path, const String &p_origi
 	loader.cache_mode = p_cache_mode;
 	loader.use_sub_threads = p_use_sub_threads;
 	loader.progress = r_progress;
-	String path = p_original_path != "" ? p_original_path : p_path;
+	String path = !p_original_path.is_empty() ? p_original_path : p_path;
 	loader.local_path = ProjectSettings::get_singleton()->localize_path(path);
 	loader.res_path = loader.local_path;
 	//loader.set_local_path( Globals::get_singleton()->localize_path(p_path) );
@@ -1045,7 +1045,7 @@ RES ResourceFormatLoaderBinary::load(const String &p_path, const String &p_origi
 }
 
 void ResourceFormatLoaderBinary::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
-	if (p_type == "") {
+	if (p_type.is_empty()) {
 		get_recognized_extensions(p_extensions);
 		return;
 	}
@@ -1979,7 +1979,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 
 	for (RES &r : saved_resources) {
 		if (r->is_built_in()) {
-			if (r->get_scene_unique_id() != "") {
+			if (!r->get_scene_unique_id().is_empty()) {
 				if (used_unique_ids.has(r->get_scene_unique_id())) {
 					r->set_scene_unique_id("");
 				} else {
@@ -1993,7 +1993,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 	int res_index = 0;
 	for (RES &r : saved_resources) {
 		if (r->is_built_in()) {
-			if (r->get_scene_unique_id() == "") {
+			if (r->get_scene_unique_id().is_empty()) {
 				String new_id;
 
 				while (true) {

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -78,8 +78,8 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 			return err;
 		}
 
-		if (assign != String()) {
-			if (!path_found && assign.begins_with("path.") && r_path_and_type.path == String()) {
+		if (!assign.is_empty()) {
+			if (!path_found && assign.begins_with("path.") && r_path_and_type.path.is_empty()) {
 				String feature = assign.get_slicec('.', 1);
 				if (OS::get_singleton()->has_feature(feature)) {
 					r_path_and_type.path = value;
@@ -112,7 +112,7 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 
 	memdelete(f);
 
-	if (r_path_and_type.path == String() || r_path_and_type.type == String()) {
+	if (r_path_and_type.path.is_empty() || r_path_and_type.type.is_empty()) {
 		return ERR_FILE_CORRUPT;
 	}
 	return OK;
@@ -158,7 +158,7 @@ void ResourceFormatImporter::get_recognized_extensions(List<String> *p_extension
 }
 
 void ResourceFormatImporter::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
-	if (p_type == "") {
+	if (p_type.is_empty()) {
 		get_recognized_extensions(p_extensions);
 		return;
 	}
@@ -167,7 +167,7 @@ void ResourceFormatImporter::get_recognized_extensions_for_type(const String &p_
 
 	for (int i = 0; i < importers.size(); i++) {
 		String res_type = importers[i]->get_resource_type();
-		if (res_type == String()) {
+		if (res_type.is_empty()) {
 			continue;
 		}
 
@@ -246,7 +246,7 @@ int ResourceFormatImporter::get_import_order(const String &p_path) const {
 bool ResourceFormatImporter::handles_type(const String &p_type) const {
 	for (int i = 0; i < importers.size(); i++) {
 		String res_type = importers[i]->get_resource_type();
-		if (res_type == String()) {
+		if (res_type.is_empty()) {
 			continue;
 		}
 		if (ClassDB::is_parent_class(res_type, p_type)) {
@@ -300,7 +300,7 @@ void ResourceFormatImporter::get_internal_resource_path_list(const String &p_pat
 			return;
 		}
 
-		if (assign != String()) {
+		if (!assign.is_empty()) {
 			if (assign.begins_with("path.")) {
 				r_paths->push_back(value);
 			} else if (assign == "path") {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -52,7 +52,7 @@ bool ResourceFormatLoader::recognize_path(const String &p_path, const String &p_
 	String extension = p_path.get_extension();
 
 	List<String> extensions;
-	if (p_for_type == String()) {
+	if (p_for_type.is_empty()) {
 		get_recognized_extensions(&extensions);
 	} else {
 		get_recognized_extensions_for_type(p_for_type, &extensions);
@@ -96,7 +96,7 @@ ResourceUID::ID ResourceFormatLoader::get_resource_uid(const String &p_path) con
 }
 
 void ResourceFormatLoader::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
-	if (p_type == "" || handles_type(p_type)) {
+	if (p_type.is_empty() || handles_type(p_type)) {
 		get_recognized_extensions(p_extensions);
 	}
 }
@@ -194,7 +194,7 @@ RES ResourceLoader::_load(const String &p_path, const String &p_original_path, c
 			continue;
 		}
 		found = true;
-		RES res = loader[i]->load(p_path, p_original_path != String() ? p_original_path : p_path, r_error, p_use_sub_threads, r_progress, p_cache_mode);
+		RES res = loader[i]->load(p_path, !p_original_path.is_empty() ? p_original_path : p_path, r_error, p_use_sub_threads, r_progress, p_cache_mode);
 		if (res.is_null()) {
 			continue;
 		}
@@ -289,7 +289,7 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 
 	thread_load_mutex->lock();
 
-	if (p_source_resource != String()) {
+	if (!p_source_resource.is_empty()) {
 		//must be loading from this resource
 		if (!thread_load_tasks.has(p_source_resource)) {
 			thread_load_mutex->unlock();
@@ -310,7 +310,7 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 
 	if (thread_load_tasks.has(local_path)) {
 		thread_load_tasks[local_path].requests++;
-		if (p_source_resource != String()) {
+		if (!p_source_resource.is_empty()) {
 			thread_load_tasks[p_source_resource].sub_tasks.insert(local_path);
 		}
 		thread_load_mutex->unlock();
@@ -354,7 +354,7 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 			ResourceCache::lock.read_unlock();
 		}
 
-		if (p_source_resource != String()) {
+		if (!p_source_resource.is_empty()) {
 			thread_load_tasks[p_source_resource].sub_tasks.insert(local_path);
 		}
 
@@ -574,7 +574,7 @@ RES ResourceLoader::load(const String &p_path, const String &p_type_hint, Resour
 		bool xl_remapped = false;
 		String path = _path_remap(local_path, &xl_remapped);
 
-		if (path == "") {
+		if (path.is_empty()) {
 			ERR_FAIL_V_MSG(RES(), "Remapping '" + local_path + "' failed.");
 		}
 
@@ -776,7 +776,7 @@ String ResourceLoader::get_resource_type(const String &p_path) {
 
 	for (int i = 0; i < loader_count; i++) {
 		String result = loader[i]->get_resource_type(local_path);
-		if (result != "") {
+		if (!result.is_empty()) {
 			return result;
 		}
 	}

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -87,7 +87,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 
 			// In PO file, "msgctxt" appears before "msgid". If we encounter a "msgctxt", we add what we have read
 			// and set "entered_context" to true to prevent adding twice.
-			if (!skip_this && msg_id != "") {
+			if (!skip_this && !msg_id.is_empty()) {
 				if (status == STATUS_READING_STRING) {
 					translation->add_message(msg_id, msg_str, msg_context);
 				} else if (status == STATUS_READING_PLURAL) {
@@ -125,7 +125,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 				ERR_FAIL_V_MSG(RES(), "Unexpected 'msgid', was expecting 'msgstr' while parsing: " + path + ":" + itos(line));
 			}
 
-			if (msg_id != "") {
+			if (!msg_id.is_empty()) {
 				if (!skip_this && !entered_context) {
 					if (status == STATUS_READING_STRING) {
 						translation->add_message(msg_id, msg_str, msg_context);
@@ -137,7 +137,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 						translation->add_plural_message(msg_id, msgs_plural, msg_context);
 					}
 				}
-			} else if (config == "") {
+			} else if (config.is_empty()) {
 				config = msg_str;
 				// Record plural rule.
 				int p_start = config.find("Plural-Forms");
@@ -178,7 +178,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 			status = STATUS_READING_STRING;
 		}
 
-		if (l == "" || l.begins_with("#")) {
+		if (l.is_empty() || l.begins_with("#")) {
 			if (l.find("fuzzy") != -1) {
 				skip_next = true;
 			}
@@ -236,15 +236,15 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 
 	// Add the last set of data from last iteration.
 	if (status == STATUS_READING_STRING) {
-		if (msg_id != "") {
+		if (!msg_id.is_empty()) {
 			if (!skip_this) {
 				translation->add_message(msg_id, msg_str, msg_context);
 			}
-		} else if (config == "") {
+		} else if (config.is_empty()) {
 			config = msg_str;
 		}
 	} else if (status == STATUS_READING_PLURAL) {
-		if (!skip_this && msg_id != "") {
+		if (!skip_this && !msg_id.is_empty()) {
 			if (plural_index != plural_forms - 1) {
 				memdelete(f);
 				ERR_FAIL_V_MSG(RES(), "Number of 'msgstr[]' doesn't match with number of plural forms: " + path + ":" + itos(line));
@@ -253,7 +253,7 @@ RES TranslationLoaderPO::load_translation(FileAccess *f, Error *r_error) {
 		}
 	}
 
-	ERR_FAIL_COND_V_MSG(config == "", RES(), "No config found in file: " + path + ".");
+	ERR_FAIL_COND_V_MSG(config.is_empty(), RES(), "No config found in file: " + path + ".");
 
 	Vector<String> configs = config.split("\n");
 	for (int i = 0; i < configs.size(); i++) {

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -731,7 +731,7 @@ void ClassDB::bind_integer_constant(const StringName &p_class, const StringName 
 	type->constant_map[p_name] = p_constant;
 
 	String enum_name = p_enum;
-	if (enum_name != String()) {
+	if (!enum_name.is_empty()) {
 		if (enum_name.find(".") != -1) {
 			enum_name = enum_name.get_slicec('.', 1);
 		}

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -990,7 +990,7 @@ void Object::get_meta_list(List<StringName> *p_list) const {
 }
 
 void Object::add_user_signal(const MethodInfo &p_signal) {
-	ERR_FAIL_COND_MSG(p_signal.name == "", "Signal name cannot be empty.");
+	ERR_FAIL_COND_MSG(p_signal.name.is_empty(), "Signal name cannot be empty.");
 	ERR_FAIL_COND_MSG(ClassDB::has_signal(get_class_name(), p_signal.name), "User signal's name conflicts with a built-in signal of '" + get_class_name() + "'.");
 	ERR_FAIL_COND_MSG(signal_map.has(p_signal.name), "Trying to add already existing signal '" + p_signal.name + "'.");
 	SignalData s;
@@ -1253,7 +1253,7 @@ void Object::get_signal_list(List<MethodInfo> *p_signals) const {
 	const StringName *S = nullptr;
 
 	while ((S = signal_map.next(S))) {
-		if (signal_map[*S].user.name != "") {
+		if (!signal_map[*S].user.name.is_empty()) {
 			//user signal
 			p_signals->push_back(signal_map[*S].user);
 		}
@@ -1680,7 +1680,7 @@ void Object::get_translatable_strings(List<String> *p_strings) const {
 
 		String text = get(E.name);
 
-		if (text == "") {
+		if (text.is_empty()) {
 			continue;
 		}
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -352,7 +352,7 @@ public:                                                                         
 	static String get_category_static() {                                                                                                        \
 		String category = m_inherits::get_category_static();                                                                                     \
 		if (_get_category != m_inherits::_get_category) {                                                                                        \
-			if (category != "") {                                                                                                                \
+			if (!category.is_empty()) {                                                                                                          \
 				category += "/";                                                                                                                 \
 			}                                                                                                                                    \
 			category += _get_category();                                                                                                         \

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -190,8 +190,8 @@ static void _OS_printres(Object *p_obj) {
 }
 
 void OS::print_all_resources(String p_to_file) {
-	ERR_FAIL_COND(p_to_file != "" && _OSPRF);
-	if (p_to_file != "") {
+	ERR_FAIL_COND(!p_to_file.is_empty() && _OSPRF);
+	if (!p_to_file.is_empty()) {
 		Error err;
 		_OSPRF = FileAccess::open(p_to_file, FileAccess::WRITE, &err);
 		if (err != OK) {
@@ -202,7 +202,7 @@ void OS::print_all_resources(String p_to_file) {
 
 	ObjectDB::debug_objects(_OS_printres);
 
-	if (p_to_file != "") {
+	if (!p_to_file.is_empty()) {
 		if (_OSPRF) {
 			memdelete(_OSPRF);
 		}

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -368,7 +368,7 @@ NodePath::NodePath(const String &p_path) {
 		for (int i = from; i <= path.length(); i++) {
 			if (path[i] == ':' || path[i] == 0) {
 				String str = path.substr(from, i - from);
-				if (str == "") {
+				if (str.is_empty()) {
 					if (path[i] == 0) {
 						continue; // Allow end-of-path :
 					}

--- a/core/string/string_builder.cpp
+++ b/core/string/string_builder.cpp
@@ -33,7 +33,7 @@
 #include <string.h>
 
 StringBuilder &StringBuilder::append(const String &p_string) {
-	if (p_string == String()) {
+	if (p_string.is_empty()) {
 		return *this;
 	}
 

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -310,7 +310,7 @@ StringName::StringName(const String &p_name, bool p_static) {
 
 	ERR_FAIL_COND(!configured);
 
-	if (p_name == String()) {
+	if (p_name.is_empty()) {
 		return;
 	}
 
@@ -434,7 +434,7 @@ StringName StringName::search(const char32_t *p_name) {
 }
 
 StringName StringName::search(const String &p_name) {
-	ERR_FAIL_COND_V(p_name == "", StringName());
+	ERR_FAIL_COND_V(p_name.is_empty(), StringName());
 
 	MutexLock lock(mutex);
 

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -1287,7 +1287,7 @@ bool TranslationServer::_load_translations(const String &p_from) {
 void TranslationServer::setup() {
 	String test = GLOBAL_DEF("internationalization/locale/test", "");
 	test = test.strip_edges();
-	if (test != "") {
+	if (!test.is_empty()) {
 		set_locale(test);
 	} else {
 		set_locale(OS::get_singleton()->get_locale());

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4283,7 +4283,7 @@ bool String::is_valid_filename() const {
 		return false;
 	}
 
-	if (stripped == String()) {
+	if (stripped.is_empty()) {
 		return false;
 	}
 
@@ -4902,7 +4902,7 @@ String DTRN(const String &p_text, const String &p_text_plural, int p_n, const St
 String RTR(const String &p_text, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
 		String rtr = TranslationServer::get_singleton()->tool_translate(p_text, p_context);
-		if (rtr == String() || rtr == p_text) {
+		if (rtr.is_empty() || rtr == p_text) {
 			return TranslationServer::get_singleton()->translate(p_text, p_context);
 		} else {
 			return rtr;
@@ -4915,7 +4915,7 @@ String RTR(const String &p_text, const String &p_context) {
 String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
 		String rtr = TranslationServer::get_singleton()->tool_translate_plural(p_text, p_text_plural, p_n, p_context);
-		if (rtr == String() || rtr == p_text || rtr == p_text_plural) {
+		if (rtr.is_empty() || rtr == p_text || rtr == p_text_plural) {
 			return TranslationServer::get_singleton()->translate_plural(p_text, p_text_plural, p_n, p_context);
 		} else {
 			return rtr;

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1598,14 +1598,14 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				}
 
 				//try path because it's a file
-				if (res_text == String() && res->get_path().is_resource_file()) {
+				if (res_text.is_empty() && res->get_path().is_resource_file()) {
 					//external resource
 					String path = res->get_path();
 					res_text = "Resource(\"" + path + "\")";
 				}
 
 				//could come up with some sort of text
-				if (res_text != String()) {
+				if (!res_text.is_empty()) {
 					p_store_string_func(p_store_string_ud, res_text);
 					break;
 				}

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -1555,7 +1555,7 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 
 	p_shader->uniforms.clear();
 
-	if (p_shader->code == String()) {
+	if (p_shader->code.is_empty()) {
 		return; //just invalid, but no error
 	}
 

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -342,7 +342,7 @@ Error DirAccessUnix::change_dir(String p_dir) {
 	}
 
 	String base = _get_root_path();
-	if (base != String() && !try_dir.begins_with(base)) {
+	if (!base.is_empty() && !try_dir.begins_with(base)) {
 		ERR_FAIL_COND_V(getcwd(real_current_dir_name, 2048) == nullptr, ERR_BUG);
 		String new_dir;
 		new_dir.parse_utf8(real_current_dir_name);
@@ -360,7 +360,7 @@ Error DirAccessUnix::change_dir(String p_dir) {
 
 String DirAccessUnix::get_current_dir(bool p_include_drive) {
 	String base = _get_root_path();
-	if (base != "") {
+	if (!base.is_empty()) {
 		String bd = current_dir.replace_first(base, "");
 		if (bd.begins_with("/")) {
 			return _get_root_string() + bd.substr(1, bd.length());

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -160,7 +160,7 @@ void FileAccessUnix::close() {
 		close_notification_func(path, flags);
 	}
 
-	if (save_path != "") {
+	if (!save_path.is_empty()) {
 		int rename_error = rename((save_path + ".tmp").utf8().get_data(), save_path.utf8().get_data());
 
 		if (rename_error && close_fail_notify) {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -460,11 +460,11 @@ int OS_Unix::get_processor_count() const {
 
 String OS_Unix::get_user_data_dir() const {
 	String appname = get_safe_dir_name(ProjectSettings::get_singleton()->get("application/config/name"));
-	if (appname != "") {
+	if (!appname.is_empty()) {
 		bool use_custom_dir = ProjectSettings::get_singleton()->get("application/config/use_custom_user_dir");
 		if (use_custom_dir) {
 			String custom_dir = get_safe_dir_name(ProjectSettings::get_singleton()->get("application/config/custom_user_dir_name"), true);
-			if (custom_dir == "") {
+			if (custom_dir.is_empty()) {
 				custom_dir = appname;
 			}
 			return get_data_path().plus_file(custom_dir);
@@ -486,7 +486,7 @@ String OS_Unix::get_executable_path() const {
 	if (len > 0) {
 		b.parse_utf8(buf, len);
 	}
-	if (b == "") {
+	if (b.is_empty()) {
 		WARN_PRINT("Couldn't get executable path from /proc/self/exe, using argv[0]");
 		return OS::get_executable_path();
 	}

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -4249,7 +4249,7 @@ String RenderingDeviceVulkan::_shader_uniform_debug(RID p_shader, int p_set) {
 		}
 		for (int j = 0; j < shader->sets[i].uniform_info.size(); j++) {
 			const UniformInfo &ui = shader->sets[i].uniform_info[j];
-			if (ret != String()) {
+			if (!ret.is_empty()) {
 				ret += "\n";
 			}
 			ret += "Set: " + itos(i) + " Binding: " + itos(ui.binding) + " Type: " + shader_uniform_names[ui.type] + " Length: " + itos(ui.length);

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -133,7 +133,7 @@ Error DirAccessWindows::change_dir(String p_dir) {
 	bool worked = (SetCurrentDirectoryW((LPCWSTR)(p_dir.utf16().get_data())) != 0);
 
 	String base = _get_root_path();
-	if (base != "") {
+	if (!base.is_empty()) {
 		GetCurrentDirectoryW(2048, real_current_dir_name);
 		String new_dir = String::utf16((const char16_t *)real_current_dir_name).replace("\\", "/");
 		if (!new_dir.begins_with(base)) {
@@ -184,7 +184,7 @@ Error DirAccessWindows::make_dir(String p_dir) {
 
 String DirAccessWindows::get_current_dir(bool p_include_drive) {
 	String base = _get_root_path();
-	if (base != "") {
+	if (!base.is_empty()) {
 		String bd = current_dir.replace("\\", "/").replace_first(base, "");
 		if (bd.begins_with("/")) {
 			return _get_root_string() + bd.substr(1, bd.length());
@@ -196,7 +196,7 @@ String DirAccessWindows::get_current_dir(bool p_include_drive) {
 	if (p_include_drive) {
 		return current_dir;
 	} else {
-		if (_get_root_string() == "") {
+		if (_get_root_string().is_empty()) {
 			int p = current_dir.find(":");
 			if (p != -1) {
 				return current_dir.substr(p + 1);

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -99,7 +99,7 @@ Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
 		HANDLE f = FindFirstFileW((LPCWSTR)(path.utf16().get_data()), &d);
 		if (f != INVALID_HANDLE_VALUE) {
 			String fname = String::utf16((const char16_t *)(d.cFileName));
-			if (fname != String()) {
+			if (!fname.is_empty()) {
 				String base_file = path.get_file();
 				if (base_file != fname && base_file.findn(fname) == 0) {
 					WARN_PRINT("Case mismatch opening requested file '" + base_file + "', stored as '" + fname + "' in the filesystem. This file will not open when exported to other case-sensitive platforms.");
@@ -142,7 +142,7 @@ void FileAccessWindows::close() {
 	fclose(f);
 	f = nullptr;
 
-	if (save_path != "") {
+	if (!save_path.is_empty()) {
 		bool rename_error = true;
 		int attempts = 4;
 		while (rename_error && attempts) {

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -761,7 +761,7 @@ void ActionMapEditor::_add_action_pressed() {
 }
 
 void ActionMapEditor::_add_action(const String &p_name) {
-	if (p_name == "" || !_is_action_name_valid(p_name)) {
+	if (p_name.is_empty() || !_is_action_name_valid(p_name)) {
 		show_message(TTR("Invalid action name. It cannot be empty nor contain '/', ':', '=', '\\' or '\"'"));
 		return;
 	}
@@ -785,7 +785,7 @@ void ActionMapEditor::_action_edited() {
 			return;
 		}
 
-		if (new_name == "" || !_is_action_name_valid(new_name)) {
+		if (new_name.is_empty() || !_is_action_name_valid(new_name)) {
 			ti->set_text(0, old_name);
 			show_message(TTR("Invalid action name. It cannot be empty nor contain '/', ':', '=', '\\' or '\"'"));
 			return;

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -650,7 +650,7 @@ public:
 						List<StringName> anims;
 						ap->get_animation_list(&anims);
 						for (const StringName &E : anims) {
-							if (animations != String()) {
+							if (!animations.is_empty()) {
 								animations += ",";
 							}
 
@@ -659,7 +659,7 @@ public:
 					}
 				}
 
-				if (animations != String()) {
+				if (!animations.is_empty()) {
 					animations += ",";
 				}
 				animations += "[stop]";
@@ -1332,7 +1332,7 @@ public:
 							List<StringName> anims;
 							ap->get_animation_list(&anims);
 							for (List<StringName>::Element *G = anims.front(); G; G = G->next()) {
-								if (animations != String()) {
+								if (!animations.is_empty()) {
 									animations += ",";
 								}
 
@@ -1341,7 +1341,7 @@ public:
 						}
 					}
 
-					if (animations != String()) {
+					if (!animations.is_empty()) {
 						animations += ",";
 					}
 					animations += "[stop]";
@@ -2665,7 +2665,7 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 					if (stream.is_valid()) {
 						if (stream->get_path().is_resource_file()) {
 							stream_name = stream->get_path().get_file();
-						} else if (stream->get_name() != "") {
+						} else if (!stream->get_name().is_empty()) {
 							stream_name = stream->get_name();
 						} else {
 							stream_name = stream->get_class();
@@ -3657,7 +3657,7 @@ void AnimationTrackEditor::insert_transform_key(Node3D *p_node, const String &p_
 
 	// Let's build a node path.
 	String path = root->get_path_to(p_node);
-	if (p_sub != "") {
+	if (!p_sub.is_empty()) {
 		path += ":" + p_sub;
 	}
 
@@ -3697,7 +3697,7 @@ bool AnimationTrackEditor::has_track(Node3D *p_node, const String &p_sub, const 
 
 	// Let's build a node path.
 	String path = root->get_path_to(p_node);
-	if (p_sub != "") {
+	if (!p_sub.is_empty()) {
 		path += ":" + p_sub;
 	}
 
@@ -3762,7 +3762,7 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 	EditorHistory *history = EditorNode::get_singleton()->get_editor_history();
 	for (int i = 1; i < history->get_path_size(); i++) {
 		String prop = history->get_path_property(i);
-		ERR_FAIL_COND(prop == "");
+		ERR_FAIL_COND(prop.is_empty());
 		path += ":" + prop;
 	}
 
@@ -3862,7 +3862,7 @@ void AnimationTrackEditor::insert_value_key(const String &p_property, const Vari
 
 	for (int i = 1; i < history->get_path_size(); i++) {
 		String prop = history->get_path_property(i);
-		ERR_FAIL_COND(prop == "");
+		ERR_FAIL_COND(prop.is_empty());
 		path += ":" + prop;
 	}
 
@@ -6021,7 +6021,7 @@ void AnimationTrackEditor::_pick_track_select_recursive(TreeItem *p_item, const 
 	NodePath np = p_item->get_metadata(0);
 	Node *node = get_node(np);
 
-	if (p_filter != String() && ((String)node->get_name()).findn(p_filter) != -1) {
+	if (!p_filter.is_empty() && ((String)node->get_name()).findn(p_filter) != -1) {
 		p_select_candidates.push_back(node);
 	}
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1534,7 +1534,7 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 
 void CodeTextEditor::set_error(const String &p_error) {
 	error->set_text(p_error);
-	if (p_error != "") {
+	if (!p_error.is_empty()) {
 		error->set_default_cursor_shape(CURSOR_POINTING_HAND);
 	} else {
 		error->set_default_cursor_shape(CURSOR_ARROW);
@@ -1547,7 +1547,7 @@ void CodeTextEditor::set_error_pos(int p_line, int p_column) {
 }
 
 void CodeTextEditor::goto_error() {
-	if (error->get_text() != "") {
+	if (!error->get_text().is_empty()) {
 		text_editor->unfold_line(error_line);
 		text_editor->set_caret_line(error_line);
 		text_editor->set_caret_column(error_column);

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -111,7 +111,7 @@ public:
 void ConnectDialog::ok_pressed() {
 	String method_name = dst_method->get_text();
 
-	if (method_name == "") {
+	if (method_name.is_empty()) {
 		error->set_text(TTR("Method in target node must be specified."));
 		error->popup_centered();
 		return;
@@ -234,7 +234,7 @@ void ConnectDialog::_add_bind() {
  */
 void ConnectDialog::_remove_bind() {
 	String st = bind_editor->get_selected_path();
-	if (st == "") {
+	if (st.is_empty()) {
 		return;
 	}
 	int idx = st.get_slice("/", 1).to_int() - 1;
@@ -969,7 +969,7 @@ void ConnectionsDock::update_tree() {
 					} else if (pi.type != Variant::NIL) {
 						tname = Variant::get_type_name(pi.type);
 					}
-					signaldesc += (pi.name == "" ? String("arg " + itos(i)) : pi.name) + ": " + tname;
+					signaldesc += (pi.name.is_empty() ? String("arg " + itos(i)) : pi.name) + ": " + tname;
 					argnames.push_back(pi.name + ":" + tname);
 				}
 			}
@@ -1001,7 +1001,7 @@ void ConnectionsDock::update_tree() {
 				if (!found) {
 					DocTools *dd = EditorHelp::get_doc_data();
 					Map<String, DocData::ClassDoc>::Element *F = dd->class_list.find(base);
-					while (F && descr == String()) {
+					while (F && descr.is_empty()) {
 						for (int i = 0; i < F->get().signals.size(); i++) {
 							if (F->get().signals[i].name == signal_name.operator String()) {
 								descr = DTR(F->get().signals[i].description);

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -173,7 +173,7 @@ void CreateDialog::_update_search() {
 	_configure_search_option_item(root, base_type, ClassDB::class_exists(base_type));
 
 	const String search_text = search_box->get_text();
-	bool empty_search = search_text == "";
+	bool empty_search = search_text.is_empty();
 
 	// Filter all candidate results.
 	Vector<String> candidates;
@@ -244,7 +244,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, icon_fallback));
 	}
 
-	if (search_box->get_text() != "") {
+	if (!search_box->get_text().is_empty()) {
 		r_item->set_collapsed(false);
 	} else {
 		// Don't collapse the root node or an abstract node on the first tree level.
@@ -322,7 +322,7 @@ void CreateDialog::_cleanup() {
 
 void CreateDialog::_confirmed() {
 	String selected_item = get_selected_type();
-	if (selected_item == String()) {
+	if (selected_item.is_empty()) {
 		return;
 	}
 
@@ -642,7 +642,7 @@ void CreateDialog::_load_favorites_and_history() {
 		while (!f->eof_reached()) {
 			String l = f->get_line().strip_edges();
 
-			if (l != String()) {
+			if (!l.is_empty()) {
 				favorite_list.push_back(l);
 			}
 		}

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -79,7 +79,7 @@ void ScriptEditorDebugger::_put_msg(String p_message, Array p_data) {
 
 void ScriptEditorDebugger::debug_copy() {
 	String msg = reason->get_text();
-	if (msg == "") {
+	if (msg.is_empty()) {
 		return;
 	}
 	DisplayServer::get_singleton()->clipboard_set(msg);
@@ -312,7 +312,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		if (is_move_to_foreground()) {
 			DisplayServer::get_singleton()->window_move_to_foreground();
 		}
-		if (error != "") {
+		if (!error.is_empty()) {
 			tabs->set_current_tab(0);
 		}
 		profiler->set_enabled(false);
@@ -1083,7 +1083,7 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
 
 	Resource *res = Object::cast_to<Resource>(p_base);
 
-	if (res && res->get_path() != String()) {
+	if (res && !res->get_path().is_empty()) {
 		String respath = res->get_path();
 		int pathid = _get_res_path_cache(respath);
 
@@ -1113,7 +1113,7 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 
 		if (p_value.is_ref()) {
 			Ref<Resource> res = p_value;
-			if (res.is_valid() && res->get_path() != String()) {
+			if (res.is_valid() && !res->get_path().is_empty()) {
 				Array msg;
 				msg.push_back(pathid);
 				msg.push_back(p_property);
@@ -1133,13 +1133,13 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 
 	Resource *res = Object::cast_to<Resource>(p_base);
 
-	if (res && res->get_path() != String()) {
+	if (res && !res->get_path().is_empty()) {
 		String respath = res->get_path();
 		int pathid = _get_res_path_cache(respath);
 
 		if (p_value.is_ref()) {
 			Ref<Resource> res2 = p_value;
-			if (res2.is_valid() && res2->get_path() != String()) {
+			if (res2.is_valid() && !res2->get_path().is_empty()) {
 				Array msg;
 				msg.push_back(pathid);
 				msg.push_back(p_property);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -75,7 +75,7 @@ void DependencyEditor::_fix_and_find(EditorFileSystemDirectory *efsd, Map<String
 		String path = efsd->get_file_path(i);
 
 		for (KeyValue<String, String> &E : candidates[file]) {
-			if (E.value == String()) {
+			if (E.value.is_empty()) {
 				E.value = path;
 				continue;
 			}
@@ -135,7 +135,7 @@ void DependencyEditor::_fix_all() {
 
 	for (KeyValue<String, Map<String, String>> &E : candidates) {
 		for (const KeyValue<String, String> &F : E.value) {
-			if (F.value != String()) {
+			if (!F.value.is_empty()) {
 				remaps[F.key] = F.value;
 			}
 		}

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -252,17 +252,17 @@ void DocTools::remove_from(const DocTools &p_data) {
 }
 
 void DocTools::add_doc(const DocData::ClassDoc &p_class_doc) {
-	ERR_FAIL_COND(p_class_doc.name == "");
+	ERR_FAIL_COND(p_class_doc.name.is_empty());
 	class_list[p_class_doc.name] = p_class_doc;
 }
 
 void DocTools::remove_doc(const String &p_class_name) {
-	ERR_FAIL_COND(p_class_name == "" || !class_list.has(p_class_name));
+	ERR_FAIL_COND(p_class_name.is_empty() || !class_list.has(p_class_name));
 	class_list.erase(p_class_name);
 }
 
 bool DocTools::has_doc(const String &p_class_name) {
-	if (p_class_name == "") {
+	if (p_class_name.is_empty()) {
 		return false;
 	}
 	return class_list.has(p_class_name);
@@ -437,7 +437,7 @@ void DocTools::generate(bool p_basic_types) {
 		method_list.sort();
 
 		for (const MethodInfo &E : method_list) {
-			if (E.name == "" || (E.name[0] == '_' && !(E.flags & METHOD_FLAG_VIRTUAL))) {
+			if (E.name.is_empty() || (E.name[0] == '_' && !(E.flags & METHOD_FLAG_VIRTUAL))) {
 				continue; //hidden, don't count
 			}
 
@@ -459,21 +459,21 @@ void DocTools::generate(bool p_basic_types) {
 			}
 
 			if (E.flags & METHOD_FLAG_CONST) {
-				if (method.qualifiers != "") {
+				if (!method.qualifiers.is_empty()) {
 					method.qualifiers += " ";
 				}
 				method.qualifiers += "const";
 			}
 
 			if (E.flags & METHOD_FLAG_VARARG) {
-				if (method.qualifiers != "") {
+				if (!method.qualifiers.is_empty()) {
 					method.qualifiers += " ";
 				}
 				method.qualifiers += "vararg";
 			}
 
 			if (E.flags & METHOD_FLAG_STATIC) {
-				if (method.qualifiers != "") {
+				if (!method.qualifiers.is_empty()) {
 					method.qualifiers += " ";
 				}
 				method.qualifiers += "static";
@@ -736,21 +736,21 @@ void DocTools::generate(bool p_basic_types) {
 			DocData::return_doc_from_retinfo(method, mi.return_val);
 
 			if (mi.flags & METHOD_FLAG_VARARG) {
-				if (method.qualifiers != "") {
+				if (!method.qualifiers.is_empty()) {
 					method.qualifiers += " ";
 				}
 				method.qualifiers += "vararg";
 			}
 
 			if (mi.flags & METHOD_FLAG_CONST) {
-				if (method.qualifiers != "") {
+				if (!method.qualifiers.is_empty()) {
 					method.qualifiers += " ";
 				}
 				method.qualifiers += "const";
 			}
 
 			if (mi.flags & METHOD_FLAG_STATIC) {
-				if (method.qualifiers != "") {
+				if (!method.qualifiers.is_empty()) {
 					method.qualifiers += " ";
 				}
 				method.qualifiers += "static";
@@ -885,7 +885,7 @@ void DocTools::generate(bool p_basic_types) {
 				md.name = mi.name;
 
 				if (mi.flags & METHOD_FLAG_VARARG) {
-					if (md.qualifiers != "") {
+					if (!md.qualifiers.is_empty()) {
 						md.qualifiers += " ";
 					}
 					md.qualifiers += "vararg";
@@ -1005,7 +1005,7 @@ Error DocTools::load_classes(const String &p_dir) {
 	da->list_dir_begin();
 	String path;
 	path = da->get_next();
-	while (path != String()) {
+	while (!path.is_empty()) {
 		if (!da->current_is_dir() && path.ends_with("xml")) {
 			Ref<XMLParser> parser = memnew(XMLParser);
 			Error err2 = parser->open(p_dir.plus_file(path));
@@ -1035,7 +1035,7 @@ Error DocTools::erase_classes(const String &p_dir) {
 	da->list_dir_begin();
 	String path;
 	path = da->get_next();
-	while (path != String()) {
+	while (!path.is_empty()) {
 		if (!da->current_is_dir() && path.ends_with("xml")) {
 			to_erase.push_back(path);
 		}
@@ -1236,7 +1236,7 @@ Error DocTools::_load(Ref<XMLParser> parser) {
 }
 
 static void _write_string(FileAccess *f, int p_tablevel, const String &p_string) {
-	if (p_string == "") {
+	if (p_string.is_empty()) {
 		return;
 	}
 	String tab;
@@ -1254,15 +1254,15 @@ static void _write_method_doc(FileAccess *f, const String &p_name, Vector<DocDat
 			const DocData::MethodDoc &m = p_method_docs[i];
 
 			String qualifiers;
-			if (m.qualifiers != "") {
+			if (!m.qualifiers.is_empty()) {
 				qualifiers += " qualifiers=\"" + m.qualifiers.xml_escape() + "\"";
 			}
 
 			_write_string(f, 2, "<" + p_name + " name=\"" + m.name.xml_escape() + "\"" + qualifiers + ">");
 
-			if (m.return_type != "") {
+			if (!m.return_type.is_empty()) {
 				String enum_text;
-				if (m.return_enum != String()) {
+				if (!m.return_enum.is_empty()) {
 					enum_text = " enum=\"" + m.return_enum + "\"";
 				}
 				_write_string(f, 3, "<return type=\"" + m.return_type + "\"" + enum_text + " />");
@@ -1277,11 +1277,11 @@ static void _write_method_doc(FileAccess *f, const String &p_name, Vector<DocDat
 				const DocData::ArgumentDoc &a = m.arguments[j];
 
 				String enum_text;
-				if (a.enumeration != String()) {
+				if (!a.enumeration.is_empty()) {
 					enum_text = " enum=\"" + a.enumeration + "\"";
 				}
 
-				if (a.default_value != "") {
+				if (!a.default_value.is_empty()) {
 					_write_string(f, 3, "<argument index=\"" + itos(j) + "\" name=\"" + a.name.xml_escape() + "\" type=\"" + a.type.xml_escape() + "\"" + enum_text + " default=\"" + a.default_value.xml_escape(true) + "\" />");
 				} else {
 					_write_string(f, 3, "<argument index=\"" + itos(j) + "\" name=\"" + a.name.xml_escape() + "\" type=\"" + a.type.xml_escape() + "\"" + enum_text + " />");
@@ -1319,7 +1319,7 @@ Error DocTools::save_classes(const String &p_default_path, const Map<String, Str
 		_write_string(f, 0, "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
 
 		String header = "<class name=\"" + c.name + "\"";
-		if (c.inherits != "") {
+		if (!c.inherits.is_empty()) {
 			header += " inherits=\"" + c.inherits + "\"";
 		}
 		header += String(" version=\"") + VERSION_BRANCH + "\"";
@@ -1353,10 +1353,10 @@ Error DocTools::save_classes(const String &p_default_path, const Map<String, Str
 
 			for (int i = 0; i < c.properties.size(); i++) {
 				String additional_attributes;
-				if (c.properties[i].enumeration != String()) {
+				if (!c.properties[i].enumeration.is_empty()) {
 					additional_attributes += " enum=\"" + c.properties[i].enumeration + "\"";
 				}
-				if (c.properties[i].default_value != String()) {
+				if (!c.properties[i].default_value.is_empty()) {
 					additional_attributes += " default=\"" + c.properties[i].default_value.xml_escape(true) + "\"";
 				}
 
@@ -1380,13 +1380,13 @@ Error DocTools::save_classes(const String &p_default_path, const Map<String, Str
 			for (int i = 0; i < c.constants.size(); i++) {
 				const DocData::ConstantDoc &k = c.constants[i];
 				if (k.is_value_valid) {
-					if (k.enumeration != String()) {
+					if (!k.enumeration.is_empty()) {
 						_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value + "\" enum=\"" + k.enumeration + "\">");
 					} else {
 						_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value + "\">");
 					}
 				} else {
-					if (k.enumeration != String()) {
+					if (!k.enumeration.is_empty()) {
 						_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"platform-dependent\" enum=\"" + k.enumeration + "\">");
 					} else {
 						_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"platform-dependent\">");
@@ -1406,7 +1406,7 @@ Error DocTools::save_classes(const String &p_default_path, const Map<String, Str
 			for (int i = 0; i < c.theme_properties.size(); i++) {
 				const DocData::ThemeItemDoc &ti = c.theme_properties[i];
 
-				if (ti.default_value != "") {
+				if (!ti.default_value.is_empty()) {
 					_write_string(f, 2, "<theme_item name=\"" + ti.name + "\" data_type=\"" + ti.data_type + "\" type=\"" + ti.type + "\" default=\"" + ti.default_value.xml_escape(true) + "\">");
 				} else {
 					_write_string(f, 2, "<theme_item name=\"" + ti.name + "\" data_type=\"" + ti.data_type + "\" type=\"" + ti.type + "\">");

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -88,7 +88,7 @@ void EditorAssetInstaller::_item_edited() {
 	String path = item->get_metadata(0);
 
 	updating = true;
-	if (path == String() || item == tree->get_root()) { //a dir or root
+	if (path.is_empty() || item == tree->get_root()) { //a dir or root
 		_update_subitems(item, item->is_checked(0), true);
 	}
 
@@ -212,7 +212,7 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 			depth--;
 		}
 
-		if (skip || path == String()) {
+		if (skip || path.is_empty()) {
 			continue;
 		}
 
@@ -307,7 +307,7 @@ void EditorAssetInstaller::ok_pressed() {
 
 		if (status_map.has(name) && status_map[name]->is_checked(0)) {
 			String path = status_map[name]->get_metadata(0);
-			if (path == String()) { // a dir
+			if (path.is_empty()) { // a dir
 
 				String dirpath;
 				TreeItem *t = status_map[name];

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -340,22 +340,22 @@ void EditorAutoloadSettings::_autoload_file_callback(const String &p_path) {
 }
 
 void EditorAutoloadSettings::_autoload_text_submitted(const String p_name) {
-	if (autoload_add_path->get_text() != "" && _autoload_name_is_valid(p_name, nullptr)) {
+	if (!autoload_add_path->get_text().is_empty() && _autoload_name_is_valid(p_name, nullptr)) {
 		_autoload_add();
 	}
 }
 
 void EditorAutoloadSettings::_autoload_path_text_changed(const String p_path) {
 	add_autoload->set_disabled(
-			p_path == "" || !_autoload_name_is_valid(autoload_add_name->get_text(), nullptr));
+			p_path.is_empty() || !_autoload_name_is_valid(autoload_add_name->get_text(), nullptr));
 }
 
 void EditorAutoloadSettings::_autoload_text_changed(const String p_name) {
 	String error_string;
 	bool is_name_valid = _autoload_name_is_valid(p_name, &error_string);
-	add_autoload->set_disabled(autoload_add_path->get_text() == "" || !is_name_valid);
+	add_autoload->set_disabled(autoload_add_path->get_text().is_empty() || !is_name_valid);
 	error_message->set_text(error_string);
-	error_message->set_visible(autoload_add_name->get_text() != "" && !is_name_valid);
+	error_message->set_visible(!autoload_add_name->get_text().is_empty() && !is_name_valid);
 }
 
 Node *EditorAutoloadSettings::_create_autoload(const String &p_path) {

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -164,7 +164,7 @@ void EditorCommandPalette::_sbox_input(const Ref<InputEvent> &p_ie) {
 void EditorCommandPalette::_confirmed() {
 	TreeItem *selected_option = search_options->get_selected();
 	String command_key = selected_option != nullptr ? selected_option->get_metadata(0) : "";
-	if (command_key != "") {
+	if (!command_key.is_empty()) {
 		hide();
 		execute_command(command_key);
 	}

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -100,7 +100,7 @@ void EditorHistory::_add_object(ObjectID p_object, const String &p_property, int
 		history.resize(current + 1); //clip history to next
 	}
 
-	if (p_property != "" && has_prev) {
+	if (!p_property.is_empty() && has_prev) {
 		//add a sub property
 		History &pr = history.write[current];
 		h = pr;
@@ -566,7 +566,7 @@ void EditorData::remove_scene(int p_idx) {
 		current_edited_scene--;
 	}
 
-	if (edited_scene[p_idx].path != String()) {
+	if (!edited_scene[p_idx].path.is_empty()) {
 		ScriptEditor::get_singleton()->close_builtin_scripts_from_scene(edited_scene[p_idx].path);
 	}
 
@@ -583,7 +583,7 @@ bool EditorData::_find_updated_instances(Node *p_root, Node *p_node, Set<String>
 
 	if (p_node == p_root) {
 		ss = p_node->get_scene_inherited_state();
-	} else if (p_node->get_scene_file_path() != String()) {
+	} else if (!p_node->get_scene_file_path().is_empty()) {
 		ss = p_node->get_scene_instance_state();
 	}
 
@@ -647,7 +647,7 @@ bool EditorData::check_and_update_scene(int p_idx) {
 
 		memdelete(edited_scene[p_idx].root);
 		edited_scene.write[p_idx].root = new_scene;
-		if (new_scene->get_scene_file_path() != "") {
+		if (!new_scene->get_scene_file_path().is_empty()) {
 			edited_scene.write[p_idx].path = new_scene->get_scene_file_path();
 		}
 		edited_scene.write[p_idx].selection = new_selection;
@@ -682,14 +682,14 @@ void EditorData::set_edited_scene_root(Node *p_root) {
 	ERR_FAIL_INDEX(current_edited_scene, edited_scene.size());
 	edited_scene.write[current_edited_scene].root = p_root;
 	if (p_root) {
-		if (p_root->get_scene_file_path() != "") {
+		if (!p_root->get_scene_file_path().is_empty()) {
 			edited_scene.write[current_edited_scene].path = p_root->get_scene_file_path();
 		} else {
 			p_root->set_scene_file_path(edited_scene[current_edited_scene].path);
 		}
 	}
 
-	if (edited_scene[current_edited_scene].path != "") {
+	if (!edited_scene[current_edited_scene].path.is_empty()) {
 		edited_scene.write[current_edited_scene].file_modified_time = FileAccess::get_modified_time(edited_scene[current_edited_scene].path);
 	}
 }
@@ -764,7 +764,7 @@ Ref<Script> EditorData::get_scene_root_script(int p_idx) const {
 	Ref<Script> s = edited_scene[p_idx].root->get_script();
 	if (!s.is_valid() && edited_scene[p_idx].root->get_child_count()) {
 		Node *n = edited_scene[p_idx].root->get_child(0);
-		while (!s.is_valid() && n && n->get_scene_file_path() == String()) {
+		while (!s.is_valid() && n && n->get_scene_file_path().is_empty()) {
 			s = n->get_script();
 			n = n->get_parent();
 		}
@@ -777,7 +777,7 @@ String EditorData::get_scene_title(int p_idx, bool p_always_strip_extension) con
 	if (!edited_scene[p_idx].root) {
 		return TTR("[empty]");
 	}
-	if (edited_scene[p_idx].root->get_scene_file_path() == "") {
+	if (edited_scene[p_idx].root->get_scene_file_path().is_empty()) {
 		return TTR("[unsaved]");
 	}
 
@@ -818,7 +818,7 @@ String EditorData::get_scene_path(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), String());
 
 	if (edited_scene[p_idx].root) {
-		if (edited_scene[p_idx].root->get_scene_file_path() == "") {
+		if (edited_scene[p_idx].root->get_scene_file_path().is_empty()) {
 			edited_scene[p_idx].root->set_scene_file_path(edited_scene[p_idx].path);
 		} else {
 			return edited_scene[p_idx].root->get_scene_file_path();

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -49,7 +49,7 @@ void EditorDirDialog::_update_dir(TreeItem *p_item, EditorFileSystemDirectory *p
 	if (!p_item->get_parent()) {
 		p_item->set_text(0, "res://");
 	} else {
-		if (!opened_paths.has(path) && (p_select_path == String() || !p_select_path.begins_with(path))) {
+		if (!opened_paths.has(path) && (p_select_path.is_empty() || !p_select_path.begins_with(path))) {
 			p_item->set_collapsed(true);
 		}
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -264,7 +264,7 @@ void EditorExportPlatform::gen_debug_flags(Vector<String> &r_flags, int p_flags)
 		String passwd = EditorSettings::get_singleton()->get("filesystem/file_server/password");
 		r_flags.push_back("--remote-fs");
 		r_flags.push_back(host + ":" + itos(port));
-		if (passwd != "") {
+		if (!passwd.is_empty()) {
 			r_flags.push_back("--remote-fs-password");
 			r_flags.push_back(passwd);
 		}
@@ -528,7 +528,7 @@ void EditorExportPlatform::_edit_files_with_filter(DirAccess *da, const Vector<S
 }
 
 void EditorExportPlatform::_edit_filter_list(Set<String> &r_list, const String &p_filter, bool exclude) {
-	if (p_filter == "") {
+	if (p_filter.is_empty()) {
 		return;
 	}
 	Vector<String> split = p_filter.split(",");
@@ -683,12 +683,12 @@ EditorExportPlatform::FeatureContainers EditorExportPlatform::get_feature_contai
 		result.features_pv.push_back(E);
 	}
 
-	if (p_preset->get_custom_features() != String()) {
+	if (!p_preset->get_custom_features().is_empty()) {
 		Vector<String> tmp_custom_list = p_preset->get_custom_features().split(",");
 
 		for (int i = 0; i < tmp_custom_list.size(); i++) {
 			String f = tmp_custom_list[i].strip_edges();
-			if (f != String()) {
+			if (!f.is_empty()) {
 				result.features.insert(f);
 				result.features_pv.push_back(f);
 			}
@@ -994,12 +994,12 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 
 	Vector<String> custom_list;
 
-	if (p_preset->get_custom_features() != String()) {
+	if (!p_preset->get_custom_features().is_empty()) {
 		Vector<String> tmp_custom_list = p_preset->get_custom_features().split(",");
 
 		for (int i = 0; i < tmp_custom_list.size(); i++) {
 			String f = tmp_custom_list[i].strip_edges();
-			if (f != String()) {
+			if (!f.is_empty()) {
 				custom_list.push_back(f);
 			}
 		}
@@ -1033,14 +1033,14 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	// Store icon and splash images directly, they need to bypass the import system and be loaded as images
 	String icon = ProjectSettings::get_singleton()->get("application/config/icon");
 	String splash = ProjectSettings::get_singleton()->get("application/boot_splash/image");
-	if (icon != String() && FileAccess::exists(icon)) {
+	if (!icon.is_empty() && FileAccess::exists(icon)) {
 		Vector<uint8_t> array = FileAccess::get_file_as_array(icon);
 		err = p_func(p_udata, icon, array, idx, total, enc_in_filters, enc_ex_filters, key);
 		if (err != OK) {
 			return err;
 		}
 	}
-	if (splash != String() && FileAccess::exists(splash) && icon != splash) {
+	if (!splash.is_empty() && FileAccess::exists(splash) && icon != splash) {
 		Vector<uint8_t> array = FileAccess::get_file_as_array(splash);
 		err = p_func(p_udata, splash, array, idx, total, enc_in_filters, enc_ex_filters, key);
 		if (err != OK) {
@@ -1359,7 +1359,7 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 		String passwd = EditorSettings::get_singleton()->get("filesystem/file_server/password");
 		r_flags.push_back("--remote-fs");
 		r_flags.push_back(host + ":" + itos(port));
-		if (passwd != "") {
+		if (!passwd.is_empty()) {
 			r_flags.push_back("--remote-fs-password");
 			r_flags.push_back(passwd);
 		}
@@ -1855,7 +1855,7 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 
 	template_path = template_path.strip_edges();
 
-	if (template_path == String()) {
+	if (template_path.is_empty()) {
 		if (p_preset->get("binary_format/64_bits")) {
 			if (p_debug) {
 				template_path = find_export_template(debug_file_64);
@@ -1871,7 +1871,7 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 		}
 	}
 
-	if (template_path != String() && !FileAccess::exists(template_path)) {
+	if (!template_path.is_empty() && !FileAccess::exists(template_path)) {
 		EditorNode::get_singleton()->show_warning(TTR("Template file not found:") + "\n" + template_path);
 		return ERR_FILE_NOT_FOUND;
 	}

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -310,7 +310,7 @@ EditorFeatureProfile::EditorFeatureProfile() {}
 void EditorFeatureProfileManager::_notification(int p_what) {
 	if (p_what == NOTIFICATION_READY) {
 		current_profile = EDITOR_GET("_default_feature_profile");
-		if (current_profile != String()) {
+		if (!current_profile.is_empty()) {
 			current.instantiate();
 			Error err = current->load_from_file(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(current_profile + ".profile"));
 			if (err != OK) {
@@ -334,7 +334,7 @@ String EditorFeatureProfileManager::_get_selected_profile() {
 
 void EditorFeatureProfileManager::_update_profile_list(const String &p_select_profile) {
 	String selected_profile;
-	if (p_select_profile == String()) { //default, keep
+	if (p_select_profile.is_empty()) { //default, keep
 		if (profile_list->get_selected() >= 0) {
 			selected_profile = profile_list->get_item_metadata(profile_list->get_selected());
 			if (!FileAccess::exists(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(selected_profile + ".profile"))) {
@@ -352,7 +352,7 @@ void EditorFeatureProfileManager::_update_profile_list(const String &p_select_pr
 	d->list_dir_begin();
 	while (true) {
 		String f = d->get_next();
-		if (f == String()) {
+		if (f.is_empty()) {
 			break;
 		}
 
@@ -371,7 +371,7 @@ void EditorFeatureProfileManager::_update_profile_list(const String &p_select_pr
 	for (int i = 0; i < profiles.size(); i++) {
 		String name = profiles[i];
 
-		if (i == 0 && selected_profile == String()) {
+		if (i == 0 && selected_profile.is_empty()) {
 			selected_profile = name;
 		}
 
@@ -386,15 +386,15 @@ void EditorFeatureProfileManager::_update_profile_list(const String &p_select_pr
 		}
 	}
 
-	class_list_vbc->set_visible(selected_profile != String());
-	property_list_vbc->set_visible(selected_profile != String());
-	no_profile_selected_help->set_visible(selected_profile == String());
-	profile_actions[PROFILE_CLEAR]->set_disabled(current_profile == String());
-	profile_actions[PROFILE_ERASE]->set_disabled(selected_profile == String());
-	profile_actions[PROFILE_EXPORT]->set_disabled(selected_profile == String());
-	profile_actions[PROFILE_SET]->set_disabled(selected_profile == String());
+	class_list_vbc->set_visible(!selected_profile.is_empty());
+	property_list_vbc->set_visible(!selected_profile.is_empty());
+	no_profile_selected_help->set_visible(selected_profile.is_empty());
+	profile_actions[PROFILE_CLEAR]->set_disabled(current_profile.is_empty());
+	profile_actions[PROFILE_ERASE]->set_disabled(selected_profile.is_empty());
+	profile_actions[PROFILE_EXPORT]->set_disabled(selected_profile.is_empty());
+	profile_actions[PROFILE_SET]->set_disabled(selected_profile.is_empty());
 
-	current_profile_name->set_text(current_profile != String() ? current_profile : TTR("(none)"));
+	current_profile_name->set_text(!current_profile.is_empty() ? current_profile : TTR("(none)"));
 
 	_update_selected_profile();
 }
@@ -412,7 +412,7 @@ void EditorFeatureProfileManager::_profile_action(int p_action) {
 		} break;
 		case PROFILE_SET: {
 			String selected = _get_selected_profile();
-			ERR_FAIL_COND(selected == String());
+			ERR_FAIL_COND(selected.is_empty());
 			if (selected == current_profile) {
 				return; // Nothing to do here.
 			}
@@ -438,7 +438,7 @@ void EditorFeatureProfileManager::_profile_action(int p_action) {
 		} break;
 		case PROFILE_ERASE: {
 			String selected = _get_selected_profile();
-			ERR_FAIL_COND(selected == String());
+			ERR_FAIL_COND(selected.is_empty());
 
 			erase_profile_dialog->set_text(vformat(TTR("Remove currently selected profile, '%s'? Cannot be undone."), selected));
 			erase_profile_dialog->popup_centered(Size2(240, 60) * EDSCALE);
@@ -448,7 +448,7 @@ void EditorFeatureProfileManager::_profile_action(int p_action) {
 
 void EditorFeatureProfileManager::_erase_selected_profile() {
 	String selected = _get_selected_profile();
-	ERR_FAIL_COND(selected == String());
+	ERR_FAIL_COND(selected.is_empty());
 	DirAccessRef da = DirAccess::open(EditorSettings::get_singleton()->get_feature_profiles_dir());
 	ERR_FAIL_COND_MSG(!da, "Cannot open directory '" + EditorSettings::get_singleton()->get_feature_profiles_dir() + "'.");
 
@@ -718,7 +718,7 @@ void EditorFeatureProfileManager::_update_selected_profile() {
 	class_list->clear();
 
 	String profile = _get_selected_profile();
-	if (profile == String()) { //nothing selected, nothing edited
+	if (profile.is_empty()) { //nothing selected, nothing edited
 		property_list->clear();
 		edited.unref();
 		return;
@@ -822,7 +822,7 @@ void EditorFeatureProfileManager::_export_profile(const String &p_path) {
 
 void EditorFeatureProfileManager::_save_and_update() {
 	String edited_path = _get_selected_profile();
-	ERR_FAIL_COND(edited_path == String());
+	ERR_FAIL_COND(edited_path.is_empty());
 	ERR_FAIL_COND(edited.is_null());
 
 	edited->save_to_file(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(edited_path + ".profile"));

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -274,7 +274,7 @@ void EditorFileDialog::_post_popup() {
 		file_box->set_visible(true);
 	}
 
-	if (is_visible() && get_current_file() != "") {
+	if (is_visible() && !get_current_file().is_empty()) {
 		_request_single_thumbnail(get_current_dir().plus_file(get_current_file()));
 	}
 

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -241,7 +241,7 @@ void EditorFileSystem::_scan_filesystem() {
 				first = false;
 				continue;
 			}
-			if (l == String()) {
+			if (l.is_empty()) {
 				continue;
 			}
 
@@ -295,7 +295,7 @@ void EditorFileSystem::_scan_filesystem() {
 		{
 			FileAccessRef f2 = FileAccess::open(update_cache, FileAccess::READ);
 			String l = f2->get_line().strip_edges();
-			while (l != String()) {
+			while (!l.is_empty()) {
 				file_cache.erase(l); //erase cache for this, so it gets updated
 				l = f2->get_line().strip_edges();
 			}
@@ -405,7 +405,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 			return false; //parse error, try reimport manually (Avoid reimport loop on broken file)
 		}
 
-		if (assign != String()) {
+		if (!assign.is_empty()) {
 			if (assign.begins_with("path")) {
 				to_check.push_back(value);
 			} else if (assign == "files") {
@@ -476,7 +476,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 			memdelete(md5s);
 			return false; // parse error
 		}
-		if (assign != String()) {
+		if (!assign.is_empty()) {
 			if (!p_only_imported_files) {
 				if (assign == "source_md5") {
 					source_md5 = value;
@@ -497,11 +497,11 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 
 	//check source md5 matching
 	if (!p_only_imported_files) {
-		if (source_file != String() && source_file != p_path) {
+		if (!source_file.is_empty() && source_file != p_path) {
 			return true; //file was moved, reimport
 		}
 
-		if (source_md5 == String()) {
+		if (source_md5.is_empty()) {
 			return true; //lacks md5, so just reimport
 		}
 
@@ -510,7 +510,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 			return true;
 		}
 
-		if (dest_files.size() && dest_md5 != String()) {
+		if (dest_files.size() && !dest_md5.is_empty()) {
 			md5 = FileAccess::get_multiple_md5(dest_files);
 			if (md5 != dest_md5) {
 				return true;
@@ -710,7 +710,7 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, DirAccess
 	da->list_dir_begin();
 	while (true) {
 		String f = da->get_next();
-		if (f == "") {
+		if (f.is_empty()) {
 			break;
 		}
 
@@ -820,7 +820,7 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, DirAccess
 					scan_actions.push_back(ia);
 				}
 
-				if (fc->type == String()) {
+				if (fc->type.is_empty()) {
 					fi->type = ResourceLoader::get_resource_type(path);
 					fi->import_group_file = ResourceLoader::get_import_group_file(path);
 					//there is also the chance that file type changed due to reimport, must probably check this somehow here (or kind of note it for next time in another file?)
@@ -932,7 +932,7 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, const 
 		da->list_dir_begin();
 		while (true) {
 			String f = da->get_next();
-			if (f == "") {
+			if (f.is_empty()) {
 				break;
 			}
 
@@ -1246,7 +1246,7 @@ void EditorFileSystem::_save_filesystem_cache(EditorFileSystemDirectory *p_dir, 
 	p_file->store_line("::" + p_dir->get_path() + "::" + String::num(p_dir->modified_time));
 
 	for (int i = 0; i < p_dir->files.size(); i++) {
-		if (p_dir->files[i]->import_group_file != String()) {
+		if (!p_dir->files[i]->import_group_file.is_empty()) {
 			group_file_cache.insert(p_dir->files[i]->import_group_file);
 		}
 		String s = p_dir->files[i]->file + "::" + p_dir->files[i]->type + "::" + itos(p_dir->files[i]->uid) + "::" + itos(p_dir->files[i]->modified_time) + "::" + itos(p_dir->files[i]->import_modified_time) + "::" + itos(p_dir->files[i]->import_valid) + "::" + p_dir->files[i]->import_group_file + "::" + p_dir->files[i]->script_class_name + "<>" + p_dir->files[i]->script_class_extends + "<>" + p_dir->files[i]->script_class_icon_path;
@@ -1386,7 +1386,7 @@ EditorFileSystemDirectory *EditorFileSystem::get_filesystem_path(const String &p
 
 	f = f.substr(6, f.length());
 	f = f.replace("\\", "/");
-	if (f == String()) {
+	if (f.is_empty()) {
 		return filesystem;
 	}
 
@@ -1465,7 +1465,7 @@ void EditorFileSystem::_scan_script_classes(EditorFileSystemDirectory *p_dir) {
 	int filecount = p_dir->files.size();
 	const EditorFileSystemDirectory::FileInfo *const *files = p_dir->files.ptr();
 	for (int i = 0; i < filecount; i++) {
-		if (files[i]->script_class_name == String()) {
+		if (files[i]->script_class_name.is_empty()) {
 			continue;
 		}
 
@@ -1545,7 +1545,7 @@ void EditorFileSystem::update_file(const String &p_file) {
 	}
 
 	String type = ResourceLoader::get_resource_type(p_file);
-	if (type == "" && textfile_extensions.has(p_file.get_extension())) {
+	if (type.is_empty() && textfile_extensions.has(p_file.get_extension())) {
 		type = "TextFile";
 	}
 	ResourceUID::ID uid = ResourceLoader::get_resource_uid(p_file);
@@ -1616,9 +1616,9 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		ERR_CONTINUE(err != OK);
 		ERR_CONTINUE(!config->has_section_key("remap", "importer"));
 		String file_importer_name = config->get_value("remap", "importer");
-		ERR_CONTINUE(file_importer_name == String());
+		ERR_CONTINUE(file_importer_name.is_empty());
 
-		if (importer_name != String() && importer_name != file_importer_name) {
+		if (!importer_name.is_empty() && importer_name != file_importer_name) {
 			EditorNode::get_singleton()->show_warning(vformat(TTR("There are multiple importers for different types pointing to file %s, import aborted"), p_group_file));
 			ERR_FAIL_V(ERR_FILE_CORRUPT);
 		}
@@ -1656,7 +1656,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		return OK; // (do nothing)
 	}
 
-	ERR_FAIL_COND_V(importer_name == String(), ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V(importer_name.is_empty(), ERR_UNCONFIGURED);
 
 	Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
 
@@ -1677,7 +1677,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		if (version > 0) {
 			f->store_line("importer_version=" + itos(version));
 		}
-		if (importer->get_resource_type() != "") {
+		if (!importer->get_resource_type().is_empty()) {
 			f->store_line("type=\"" + importer->get_resource_type() + "\"");
 		}
 
@@ -1759,7 +1759,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		if (ResourceCache::has(file)) {
 			Resource *r = ResourceCache::get(file);
 
-			if (r->get_import_path() != String()) {
+			if (!r->get_import_path().is_empty()) {
 				String dst_path = ResourceFormatImporter::get_singleton()->get_internal_resource_path(file);
 				r->set_import_path(dst_path);
 				r->set_import_last_modified_time(0);
@@ -1783,7 +1783,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 	Map<StringName, Variant> params;
 	String importer_name; //empty by default though
 
-	if (p_custom_importer != String()) {
+	if (!p_custom_importer.is_empty()) {
 		importer_name = p_custom_importer;
 	}
 	if (p_custom_options != nullptr) {
@@ -1808,7 +1808,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 				}
 
 				if (cf->has_section("remap")) {
-					if (p_custom_importer == String()) {
+					if (p_custom_importer.is_empty()) {
 						importer_name = cf->get_value("remap", "importer");
 					}
 
@@ -1834,7 +1834,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 	Ref<ResourceImporter> importer;
 	bool load_default = false;
 	//find the importer
-	if (importer_name != "") {
+	if (!importer_name.is_empty()) {
 		importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
 	}
 
@@ -1894,7 +1894,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 	if (version > 0) {
 		f->store_line("importer_version=" + itos(version));
 	}
-	if (importer->get_resource_type() != "") {
+	if (!importer->get_resource_type().is_empty()) {
 		f->store_line("type=\"" + importer->get_resource_type() + "\"");
 	}
 
@@ -1907,7 +1907,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 	Vector<String> dest_paths;
 
 	if (err == OK) {
-		if (importer->get_save_extension() == "") {
+		if (importer->get_save_extension().is_empty()) {
 			//no path
 		} else if (import_variants.size()) {
 			//import with variants
@@ -2003,7 +2003,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const Map<StringName
 	if (ResourceCache::has(p_file)) {
 		Resource *r = ResourceCache::get(p_file);
 
-		if (r->get_import_path() != String()) {
+		if (!r->get_import_path().is_empty()) {
 			String dst_path = ResourceFormatImporter::get_singleton()->get_internal_resource_path(p_file);
 			r->set_import_path(dst_path);
 			r->set_import_last_modified_time(0);
@@ -2062,7 +2062,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 			groups_to_reimport.insert(file);
 			//groups do not belong to grups
 			group_file = String();
-		} else if (group_file != String()) {
+		} else if (!group_file.is_empty()) {
 			//it's a group file, add group to import and skip this file
 			groups_to_reimport.insert(group_file);
 		} else {

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -113,7 +113,7 @@ void EditorFolding::_fill_folds(const Node *p_root, const Node *p_node, Array &p
 		if (E.usage & PROPERTY_USAGE_EDITOR) {
 			if (E.type == Variant::OBJECT) {
 				RES res = p_node->get(E.name);
-				if (res.is_valid() && !resources.has(res) && res->get_path() != String() && !res->get_path().is_resource_file()) {
+				if (res.is_valid() && !resources.has(res) && !res->get_path().is_empty() && !res->get_path().is_resource_file()) {
 					Vector<String> res_unfolds = _get_unfolds(res.ptr());
 					resource_folds.push_back(res->get_path());
 					resource_folds.push_back(res_unfolds);
@@ -243,8 +243,8 @@ void EditorFolding::_do_object_unfolds(Object *p_object, Set<RES> &resources) {
 
 		//can unfold
 		if (E.usage & PROPERTY_USAGE_EDITOR) {
-			if (group != "") { //group
-				if (group_base == String() || E.name.begins_with(group_base)) {
+			if (!group.is_empty()) { //group
+				if (group_base.is_empty() || E.name.begins_with(group_base)) {
 					bool can_revert = EditorPropertyRevert::can_property_revert(p_object, E.name);
 					if (can_revert) {
 						unfold_group.insert(group);
@@ -262,7 +262,7 @@ void EditorFolding::_do_object_unfolds(Object *p_object, Set<RES> &resources) {
 
 			if (E.type == Variant::OBJECT) {
 				RES res = p_object->get(E.name);
-				if (res.is_valid() && !resources.has(res) && res->get_path() != String() && !res->get_path().is_resource_file()) {
+				if (res.is_valid() && !resources.has(res) && !res->get_path().is_empty() && !res->get_path().is_resource_file()) {
 					resources.insert(res);
 					_do_object_unfolds(res.ptr(), resources);
 				}

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -78,7 +78,7 @@
 	}                                                                 \
 	{                                                                 \
 		Dictionary variations;                                        \
-		if (m_variations != String()) {                               \
+		if (!m_variations.is_empty()) {                               \
 			Vector<String> variation_tags = m_variations.split(",");  \
 			for (int i = 0; i < variation_tags.size(); i++) {         \
 				Vector<String> tokens = variation_tags[i].split("="); \
@@ -104,7 +104,7 @@
 	}                                                                 \
 	{                                                                 \
 		Dictionary variations;                                        \
-		if (m_variations != String()) {                               \
+		if (!m_variations.is_empty()) {                               \
 			Vector<String> variation_tags = m_variations.split(",");  \
 			for (int i = 0; i < variation_tags.size(); i++) {         \
 				Vector<String> tokens = variation_tags[i].split("="); \
@@ -130,7 +130,7 @@
 	}                                                                 \
 	{                                                                 \
 		Dictionary variations;                                        \
-		if (m_variations != String()) {                               \
+		if (!m_variations.is_empty()) {                               \
 			Vector<String> variation_tags = m_variations.split(",");  \
 			for (int i = 0; i < variation_tags.size(); i++) {         \
 				Vector<String> tokens = variation_tags[i].split("="); \

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -250,7 +250,7 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 		class_desc->add_text(" ");
 	}
 
-	if (p_overview && p_method.description != "") {
+	if (p_overview && !p_method.description.is_empty()) {
 		class_desc->push_meta("@method " + p_method.name);
 	}
 
@@ -258,7 +258,7 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 	_add_text(p_method.name);
 	class_desc->pop();
 
-	if (p_overview && p_method.description != "") {
+	if (p_overview && !p_method.description.is_empty()) {
 		class_desc->pop(); //meta
 	}
 
@@ -275,7 +275,7 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 		_add_text(p_method.arguments[j].name);
 		class_desc->add_text(": ");
 		_add_type(p_method.arguments[j].type, p_method.arguments[j].enumeration);
-		if (p_method.arguments[j].default_value != "") {
+		if (!p_method.arguments[j].default_value.is_empty()) {
 			class_desc->push_color(symbol_color);
 			class_desc->add_text(" = ");
 			class_desc->pop();
@@ -301,7 +301,7 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 	class_desc->push_color(symbol_color);
 	class_desc->add_text(")");
 	class_desc->pop();
-	if (p_method.qualifiers != "") {
+	if (!p_method.qualifiers.is_empty()) {
 		class_desc->push_color(qualifier_color);
 		class_desc->add_text(" ");
 		_add_text(p_method.qualifiers);
@@ -375,7 +375,7 @@ void EditorHelp::_update_method_list(const Vector<DocData::MethodDoc> p_methods,
 			if (i < m.size() - 1 && new_prefix == m[i + 1].name.substr(0, 3) && new_prefix != group_prefix) {
 				is_new_group = i > 0;
 				group_prefix = new_prefix;
-			} else if (group_prefix != "" && new_prefix != group_prefix) {
+			} else if (!group_prefix.is_empty() && new_prefix != group_prefix) {
 				is_new_group = true;
 				group_prefix = "";
 			}
@@ -387,7 +387,7 @@ void EditorHelp::_update_method_list(const Vector<DocData::MethodDoc> p_methods,
 				class_desc->pop(); //cell
 			}
 
-			if (m[i].description != "" || m[i].errors_returned.size() > 0) {
+			if (!m[i].description.is_empty() || m[i].errors_returned.size() > 0) {
 				r_method_descrpitons = true;
 			}
 
@@ -521,19 +521,19 @@ void EditorHelp::_update_doc() {
 	// Inheritance tree
 
 	// Ascendents
-	if (cd.inherits != "") {
+	if (!cd.inherits.is_empty()) {
 		class_desc->push_color(title_color);
 		class_desc->push_font(doc_font);
 		class_desc->add_text(TTR("Inherits:") + " ");
 
 		String inherits = cd.inherits;
 
-		while (inherits != "") {
+		while (!inherits.is_empty()) {
 			_add_type(inherits);
 
 			inherits = doc->class_list[inherits].inherits;
 
-			if (inherits != "") {
+			if (!inherits.is_empty()) {
 				class_desc->add_text(" < ");
 			}
 		}
@@ -577,7 +577,7 @@ void EditorHelp::_update_doc() {
 	class_desc->add_newline();
 
 	// Brief description
-	if (cd.brief_description != "") {
+	if (!cd.brief_description.is_empty()) {
 		class_desc->push_color(text_color);
 		class_desc->push_font(doc_bold_font);
 		class_desc->push_indent(1);
@@ -591,7 +591,7 @@ void EditorHelp::_update_doc() {
 	}
 
 	// Class description
-	if (cd.description != "") {
+	if (!cd.description.is_empty()) {
 		section_line.push_back(Pair<String, int>(TTR("Description"), class_desc->get_line_count() - 2));
 		description_line = class_desc->get_line_count() - 2;
 		class_desc->push_color(title_color);
@@ -694,16 +694,16 @@ void EditorHelp::_update_doc() {
 
 			bool describe = false;
 
-			if (cd.properties[i].setter != "") {
+			if (!cd.properties[i].setter.is_empty()) {
 				skip_methods.insert(cd.properties[i].setter);
 				describe = true;
 			}
-			if (cd.properties[i].getter != "") {
+			if (!cd.properties[i].getter.is_empty()) {
 				skip_methods.insert(cd.properties[i].getter);
 				describe = true;
 			}
 
-			if (cd.properties[i].description != "") {
+			if (!cd.properties[i].description.is_empty()) {
 				describe = true;
 			}
 
@@ -735,7 +735,7 @@ void EditorHelp::_update_doc() {
 			class_desc->push_cell();
 			class_desc->push_font(doc_code_font);
 
-			if (cd.properties[i].default_value != "") {
+			if (!cd.properties[i].default_value.is_empty()) {
 				class_desc->push_color(symbol_color);
 				if (cd.properties[i].overridden) {
 					class_desc->add_text(" [");
@@ -764,18 +764,18 @@ void EditorHelp::_update_doc() {
 			class_desc->push_cell();
 			class_desc->push_font(doc_code_font);
 
-			if (cd.is_script_doc && (cd.properties[i].setter != "" || cd.properties[i].getter != "")) {
+			if (cd.is_script_doc && (!cd.properties[i].setter.is_empty() || !cd.properties[i].getter.is_empty())) {
 				class_desc->push_color(symbol_color);
 				class_desc->add_text(" [" + TTR("property:") + " ");
 				class_desc->pop(); // color
 
-				if (cd.properties[i].setter != "") {
+				if (!cd.properties[i].setter.is_empty()) {
 					class_desc->push_color(value_color);
 					class_desc->add_text("setter");
 					class_desc->pop(); // color
 				}
-				if (cd.properties[i].getter != "") {
-					if (cd.properties[i].setter != "") {
+				if (!cd.properties[i].getter.is_empty()) {
+					if (!cd.properties[i].setter.is_empty()) {
 						class_desc->push_color(symbol_color);
 						class_desc->add_text(", ");
 						class_desc->pop(); // color
@@ -914,7 +914,7 @@ void EditorHelp::_update_doc() {
 			class_desc->pop();
 
 			// Theme item default value.
-			if (cd.theme_properties[i].default_value != "") {
+			if (!cd.theme_properties[i].default_value.is_empty()) {
 				class_desc->push_color(symbol_color);
 				class_desc->add_text(" [" + TTR("default:") + " ");
 				class_desc->pop();
@@ -929,7 +929,7 @@ void EditorHelp::_update_doc() {
 			class_desc->pop(); // monofont
 
 			// Theme item description.
-			if (cd.theme_properties[i].description != "") {
+			if (!cd.theme_properties[i].description.is_empty()) {
 				class_desc->push_font(doc_font);
 				class_desc->push_color(comment_color);
 				class_desc->push_indent(1);
@@ -985,7 +985,7 @@ void EditorHelp::_update_doc() {
 				_add_text(cd.signals[i].arguments[j].name);
 				class_desc->add_text(": ");
 				_add_type(cd.signals[i].arguments[j].type);
-				if (cd.signals[i].arguments[j].default_value != "") {
+				if (!cd.signals[i].arguments[j].default_value.is_empty()) {
 					class_desc->push_color(symbol_color);
 					class_desc->add_text(" = ");
 					class_desc->pop();
@@ -999,7 +999,7 @@ void EditorHelp::_update_doc() {
 			class_desc->add_text(")");
 			class_desc->pop();
 			class_desc->pop(); // end monofont
-			if (cd.signals[i].description != "") {
+			if (!cd.signals[i].description.is_empty()) {
 				class_desc->push_font(doc_font);
 				class_desc->push_color(comment_color);
 				class_desc->push_indent(1);
@@ -1114,7 +1114,7 @@ void EditorHelp::_update_doc() {
 
 					class_desc->add_newline();
 
-					if (enum_list[i].description.strip_edges() != "") {
+					if (!enum_list[i].description.strip_edges().is_empty()) {
 						class_desc->push_font(doc_font);
 						class_desc->push_color(comment_color);
 						_add_text(DTR(enum_list[i].description));
@@ -1183,7 +1183,7 @@ void EditorHelp::_update_doc() {
 
 				class_desc->add_newline();
 
-				if (constants[i].description != "") {
+				if (!constants[i].description.is_empty()) {
 					class_desc->push_font(doc_font);
 					class_desc->push_color(comment_color);
 					_add_text(DTR(constants[i].description));
@@ -1239,7 +1239,7 @@ void EditorHelp::_update_doc() {
 			_add_text(cd.properties[i].name);
 			class_desc->pop(); // color
 
-			if (cd.properties[i].default_value != "") {
+			if (!cd.properties[i].default_value.is_empty()) {
 				class_desc->push_color(symbol_color);
 				class_desc->add_text(" [" + TTR("default:") + " ");
 				class_desc->pop(); // color
@@ -1253,18 +1253,18 @@ void EditorHelp::_update_doc() {
 				class_desc->pop(); // color
 			}
 
-			if (cd.is_script_doc && (cd.properties[i].setter != "" || cd.properties[i].getter != "")) {
+			if (cd.is_script_doc && (!cd.properties[i].setter.is_empty() || !cd.properties[i].getter.is_empty())) {
 				class_desc->push_color(symbol_color);
 				class_desc->add_text(" [" + TTR("property:") + " ");
 				class_desc->pop(); // color
 
-				if (cd.properties[i].setter != "") {
+				if (!cd.properties[i].setter.is_empty()) {
 					class_desc->push_color(value_color);
 					class_desc->add_text("setter");
 					class_desc->pop(); // color
 				}
-				if (cd.properties[i].getter != "") {
-					if (cd.properties[i].setter != "") {
+				if (!cd.properties[i].getter.is_empty()) {
+					if (!cd.properties[i].setter.is_empty()) {
 						class_desc->push_color(symbol_color);
 						class_desc->add_text(", ");
 						class_desc->pop(); // color
@@ -1289,7 +1289,7 @@ void EditorHelp::_update_doc() {
 					method_map[methods[j].name] = methods[j];
 				}
 
-				if (cd.properties[i].setter != "") {
+				if (!cd.properties[i].setter.is_empty()) {
 					class_desc->push_cell();
 					class_desc->pop(); // cell
 
@@ -1313,7 +1313,7 @@ void EditorHelp::_update_doc() {
 					method_line[cd.properties[i].setter] = property_line[cd.properties[i].name];
 				}
 
-				if (cd.properties[i].getter != "") {
+				if (!cd.properties[i].getter.is_empty()) {
 					class_desc->push_cell();
 					class_desc->pop(); // cell
 

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -161,7 +161,7 @@ void EditorHelpSearch::popup_dialog(const String &p_term) {
 		popup_centered_ratio(0.5F);
 	}
 
-	if (p_term == "") {
+	if (p_term.is_empty()) {
 		search_box->clear();
 	} else {
 		if (old_term == p_term) {
@@ -331,7 +331,7 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 
 		// Match class name.
 		if (search_flags & SEARCH_CLASSES) {
-			match.name = term == "" || _match_string(term, class_doc.name);
+			match.name = term.is_empty() || _match_string(term, class_doc.name);
 		}
 
 		// Match members if the term is long enough.
@@ -513,7 +513,7 @@ TreeItem *EditorHelpSearch::Runner::_create_class_hierarchy(const ClassMatch &p_
 
 	// Ensure parent nodes are created first.
 	TreeItem *parent = root_item;
-	if (p_match.doc->inherits != "") {
+	if (!p_match.doc->inherits.is_empty()) {
 		if (class_items.has(p_match.doc->inherits)) {
 			parent = class_items[p_match.doc->inherits];
 		} else {
@@ -558,7 +558,7 @@ TreeItem *EditorHelpSearch::Runner::_create_method_item(TreeItem *p_parent, cons
 	for (int i = 0; i < p_doc->arguments.size(); i++) {
 		const DocData::ArgumentDoc &arg = p_doc->arguments[i];
 		tooltip += arg.type + " " + arg.name;
-		if (arg.default_value != "") {
+		if (!arg.default_value.is_empty()) {
 			tooltip += " = " + arg.default_value;
 		}
 		if (i < p_doc->arguments.size() - 1) {
@@ -574,7 +574,7 @@ TreeItem *EditorHelpSearch::Runner::_create_signal_item(TreeItem *p_parent, cons
 	for (int i = 0; i < p_doc->arguments.size(); i++) {
 		const DocData::ArgumentDoc &arg = p_doc->arguments[i];
 		tooltip += arg.type + " " + arg.name;
-		if (arg.default_value != "") {
+		if (!arg.default_value.is_empty()) {
 			tooltip += " = " + arg.default_value;
 		}
 		if (i < p_doc->arguments.size() - 1) {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2239,7 +2239,7 @@ void EditorInspector::_parse_added_editors(VBoxContainer *current_vbox, Ref<Edit
 					ep->property_usage = 0;
 				}
 
-				if (F.label != String()) {
+				if (!F.label.is_empty()) {
 					ep->set_label(F.label);
 				}
 
@@ -2438,7 +2438,7 @@ void EditorInspector::update_tree() {
 				}
 			}
 			if (category->icon.is_null()) {
-				if (type != String()) { // Can happen for built-in scripts.
+				if (!type.is_empty()) { // Can happen for built-in scripts.
 					category->icon = EditorNode::get_singleton()->get_class_icon(type, "Object");
 				}
 			}
@@ -2459,7 +2459,7 @@ void EditorInspector::update_tree() {
 					class_descr_cache[type2] = descr;
 				}
 
-				category->set_tooltip(p.name + "::" + (class_descr_cache[type2] == "" ? "" : class_descr_cache[type2]));
+				category->set_tooltip(p.name + "::" + (class_descr_cache[type2].is_empty() ? "" : class_descr_cache[type2]));
 			}
 
 			// Add editors at the start of a category.
@@ -2529,7 +2529,7 @@ void EditorInspector::update_tree() {
 			}
 		} else {
 			// Check if we exit or not a subgroup. If there is a prefix, remove it from the property label string.
-			if (subgroup != "" && subgroup_base != "") {
+			if (!subgroup.is_empty() && !subgroup_base.is_empty()) {
 				if (path.begins_with(subgroup_base)) {
 					path = path.trim_prefix(subgroup_base);
 				} else if (subgroup_base.begins_with(path)) {
@@ -2540,7 +2540,7 @@ void EditorInspector::update_tree() {
 			}
 
 			// Check if we exit or not a group. If there is a prefix, remove it from the property label string.
-			if (group != "" && group_base != "" && subgroup == "") {
+			if (!group.is_empty() && !group_base.is_empty() && subgroup.is_empty()) {
 				if (path.begins_with(group_base)) {
 					path = path.trim_prefix(group_base);
 				} else if (group_base.begins_with(path)) {
@@ -2552,10 +2552,10 @@ void EditorInspector::update_tree() {
 			}
 
 			// Add the group and subgroup to the path.
-			if (subgroup != "") {
+			if (!subgroup.is_empty()) {
 				path = subgroup + "/" + path;
 			}
-			if (group != "") {
+			if (!group.is_empty()) {
 				path = group + "/" + path;
 			}
 		}
@@ -2584,7 +2584,7 @@ void EditorInspector::update_tree() {
 		}
 
 		// Ignore properties that do not fit the filter.
-		if (use_filter && filter != "") {
+		if (use_filter && !filter.is_empty()) {
 			if (!filter.is_subsequence_ofi(path) && !filter.is_subsequence_ofi(property_label_string) && property_prefix.to_lower().find(filter.to_lower()) == -1) {
 				continue;
 			}
@@ -2707,7 +2707,7 @@ void EditorInspector::update_tree() {
 
 			// Get the class name.
 			StringName classname = object->get_class_name();
-			if (object_class != String()) {
+			if (!object_class.is_empty()) {
 				classname = object_class;
 			}
 
@@ -2729,7 +2729,7 @@ void EditorInspector::update_tree() {
 				// Build the property description String and add it to the cache.
 				DocTools *dd = EditorHelp::get_doc_data();
 				Map<String, DocData::ClassDoc>::Element *F = dd->class_list.find(classname);
-				while (F && descr == String()) {
+				while (F && descr.is_empty()) {
 					for (int i = 0; i < F->get().properties.size(); i++) {
 						if (F->get().properties[i].name == propname.operator String()) {
 							descr = DTR(F->get().properties[i].description);
@@ -2781,7 +2781,7 @@ void EditorInspector::update_tree() {
 							//and set label?
 						}
 
-						if (F.label != String()) {
+						if (!F.label.is_empty()) {
 							ep->set_label(F.label);
 						} else {
 							// Use the existing one.
@@ -2820,7 +2820,7 @@ void EditorInspector::update_tree() {
 					ep->connect("multiple_properties_changed", callable_mp(this, &EditorInspector::_multiple_properties_changed));
 					ep->connect("resource_selected", callable_mp(this, &EditorInspector::_resource_selected), varray(), CONNECT_DEFERRED);
 					ep->connect("object_id_selected", callable_mp(this, &EditorInspector::_object_id_selected), varray(), CONNECT_DEFERRED);
-					if (doc_hint != String()) {
+					if (!doc_hint.is_empty()) {
 						ep->set_tooltip(property_prefix + p.name + "::" + doc_hint);
 					} else {
 						ep->set_tooltip(property_prefix + p.name);
@@ -3050,7 +3050,7 @@ void EditorInspector::_edit_request_change(Object *p_object, const String &p_pro
 		return;
 	}
 
-	if (p_property == String()) {
+	if (p_property.is_empty()) {
 		update_tree_pending = true;
 	} else {
 		pending.insert(p_property);

--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -74,7 +74,7 @@ void EditorLayoutsDialog::ok_pressed() {
 		for (int i = 0; i < selected_items.size(); ++i) {
 			emit_signal(SNAME("name_confirmed"), layout_names->get_item_text(selected_items[i]));
 		}
-	} else if (name->is_visible() && name->get_text() != "") {
+	} else if (name->is_visible() && !name->get_text().is_empty()) {
 		emit_signal(SNAME("name_confirmed"), name->get_text());
 	}
 }

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -162,11 +162,11 @@ void EditorLog::_clear_request() {
 void EditorLog::_copy_request() {
 	String text = log->get_selected_text();
 
-	if (text == "") {
+	if (text.is_empty()) {
 		text = log->get_text();
 	}
 
-	if (text != "") {
+	if (!text.is_empty()) {
 		DisplayServer::get_singleton()->clipboard_set(text);
 	}
 }
@@ -237,7 +237,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	// Only add the message to the log if it passes the filters.
 	bool filter_active = type_filter_map[p_message.type]->is_active();
 	String search_text = search_box->get_text();
-	bool search_match = search_text == String() || p_message.text.findn(search_text) > -1;
+	bool search_match = search_text.is_empty() || p_message.text.findn(search_text) > -1;
 
 	if (!filter_active || !search_match) {
 		return;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -858,7 +858,7 @@ void EditorNode::_resources_changed(const Vector<String> &p_resources) {
 			continue;
 		}
 
-		if (res->get_import_path() != String()) {
+		if (!res->get_import_path().is_empty()) {
 			// this is an imported resource, will be reloaded if reimported via the _resources_reimported() callback
 			continue;
 		}
@@ -886,7 +886,7 @@ void EditorNode::_fs_changed() {
 
 	// FIXME: Move this to a cleaner location, it's hacky to do this is _fs_changed.
 	String export_error;
-	if (export_defer.preset != "" && !EditorFileSystem::get_singleton()->is_scanning()) {
+	if (!export_defer.preset.is_empty() && !EditorFileSystem::get_singleton()->is_scanning()) {
 		String preset_name = export_defer.preset;
 		// Ensures export_project does not loop infinitely, because notifications may
 		// come during the export.
@@ -1006,7 +1006,7 @@ void EditorNode::_sources_changed(bool p_exist) {
 
 		_load_docks();
 
-		if (defer_load_scene != "") {
+		if (!defer_load_scene.is_empty()) {
 			load_scene(defer_load_scene);
 			defer_load_scene = "";
 		}
@@ -1242,7 +1242,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 		preferred.move_to_front(tres_element);
 	}
 
-	if (p_at_path != String()) {
+	if (!p_at_path.is_empty()) {
 		file->set_current_dir(p_at_path);
 		if (p_resource->get_path().is_resource_file()) {
 			file->set_current_file(p_resource->get_path().get_file());
@@ -1254,7 +1254,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 				file->set_current_file(String());
 			}
 		}
-	} else if (p_resource->get_path() != "") {
+	} else if (!p_resource->get_path().is_empty()) {
 		file->set_current_path(p_resource->get_path());
 		if (extensions.size()) {
 			String ext = p_resource->get_path().get_extension().to_lower();
@@ -1676,7 +1676,7 @@ void EditorNode::_save_scene(String p_file, int idx) {
 		return;
 	}
 
-	if (scene->get_scene_file_path() != String() && _validate_scene_recursive(scene->get_scene_file_path(), scene)) {
+	if (!scene->get_scene_file_path().is_empty() && _validate_scene_recursive(scene->get_scene_file_path(), scene)) {
 		show_accept(TTR("This scene can't be saved because there is a cyclic instancing inclusion.\nPlease resolve it and then attempt to save again."), TTR("OK"));
 		return;
 	}
@@ -1780,7 +1780,7 @@ void EditorNode::restart_editor() {
 	args.push_back("--path");
 	args.push_back(ProjectSettings::get_singleton()->get_resource_path());
 	args.push_back("-e");
-	if (to_reopen != String()) {
+	if (!to_reopen.is_empty()) {
 		args.push_back(to_reopen);
 	}
 
@@ -1792,13 +1792,13 @@ void EditorNode::_save_all_scenes() {
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
 		Node *scene = editor_data.get_edited_scene_root(i);
 		if (scene) {
-			if (scene->get_scene_file_path() != "" && DirAccess::exists(scene->get_scene_file_path().get_base_dir())) {
+			if (!scene->get_scene_file_path().is_empty() && DirAccess::exists(scene->get_scene_file_path().get_base_dir())) {
 				if (i != editor_data.get_edited_scene()) {
 					_save_scene(scene->get_scene_file_path(), i);
 				} else {
 					_save_scene_with_preview(scene->get_scene_file_path());
 				}
-			} else if (scene->get_scene_file_path() != "") {
+			} else if (!scene->get_scene_file_path().is_empty()) {
 				all_saved = false;
 			}
 		}
@@ -1818,7 +1818,7 @@ void EditorNode::_mark_unsaved_scenes() {
 		}
 
 		String path = node->get_scene_file_path();
-		if (!(path == String() || FileAccess::exists(path))) {
+		if (!(path.is_empty() || FileAccess::exists(path))) {
 			if (i == editor_data.get_edited_scene()) {
 				set_current_version(-1);
 			} else {
@@ -2080,7 +2080,7 @@ void EditorNode::push_item(Object *p_object, const String &p_property, bool p_in
 	if (id != editor_history.get_current()) {
 		if (p_inspector_only) {
 			editor_history.add_object_inspector_only(id);
-		} else if (p_property == "") {
+		} else if (p_property.is_empty()) {
 			editor_history.add_object(id);
 		} else {
 			editor_history.add_object(id, p_property);
@@ -2193,7 +2193,7 @@ void EditorNode::_edit_current() {
 			inspector_dock->update(nullptr);
 		}
 
-		if (get_edited_scene() && get_edited_scene()->get_scene_file_path() != String()) {
+		if (get_edited_scene() && !get_edited_scene()->get_scene_file_path().is_empty()) {
 			String source_scene = get_edited_scene()->get_scene_file_path();
 			if (FileAccess::exists(source_scene + ".import")) {
 				editable_warning = TTR("This scene was imported, so changes to it won't be kept.\nInstancing it or inheriting will allow making changes to it.\nPlease read the documentation relevant to importing scenes to better understand this workflow.");
@@ -2316,7 +2316,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 
 	String run_filename;
 
-	if (p_current || (editor_data.get_edited_scene_root() && p_custom != String() && p_custom == editor_data.get_edited_scene_root()->get_scene_file_path())) {
+	if (p_current || (editor_data.get_edited_scene_root() && !p_custom.is_empty() && p_custom == editor_data.get_edited_scene_root()->get_scene_file_path())) {
 		Node *scene = editor_data.get_edited_scene_root();
 
 		if (!scene) {
@@ -2324,7 +2324,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 			return;
 		}
 
-		if (scene->get_scene_file_path() == "") {
+		if (scene->get_scene_file_path().is_empty()) {
 			current_option = -1;
 			_menu_option(FILE_SAVE_AS_SCENE);
 			// Set the option to save and run so when the dialog is accepted, the scene runs.
@@ -2334,11 +2334,11 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 		}
 
 		run_filename = scene->get_scene_file_path();
-	} else if (p_custom != "") {
+	} else if (!p_custom.is_empty()) {
 		run_filename = p_custom;
 	}
 
-	if (run_filename == "") {
+	if (run_filename.is_empty()) {
 		// evidently, run the scene
 		if (!ensure_main_scene(false)) {
 			return;
@@ -2349,7 +2349,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 		if (unsaved_cache) {
 			Node *scene = editor_data.get_edited_scene_root();
 
-			if (scene && scene->get_scene_file_path() != "") { // Only autosave if there is a scene and if it has a path.
+			if (scene && !scene->get_scene_file_path().is_empty()) { // Only autosave if there is a scene and if it has a path.
 				_save_scene_with_preview(scene->get_scene_file_path());
 			}
 		}
@@ -2381,7 +2381,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 	if (p_current) {
 		play_scene_button->set_pressed(true);
 		play_scene_button->set_icon(gui_base->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
-	} else if (p_custom != "") {
+	} else if (!p_custom.is_empty()) {
 		run_custom_filename = p_custom;
 		play_custom_scene_button->set_pressed(true);
 		play_custom_scene_button->set_icon(gui_base->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
@@ -2501,7 +2501,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 					if (scene_root) {
 						String scene_filename = scene_root->get_scene_file_path();
 						save_confirmation->get_ok_button()->set_text(TTR("Save & Close"));
-						save_confirmation->set_text(vformat(TTR("Save changes to '%s' before closing?"), scene_filename != "" ? scene_filename : "unsaved scene"));
+						save_confirmation->set_text(vformat(TTR("Save changes to '%s' before closing?"), !scene_filename.is_empty() ? scene_filename : "unsaved scene"));
 						save_confirmation->popup_centered();
 						break;
 					}
@@ -2519,7 +2519,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case FILE_SAVE_SCENE: {
 			int scene_idx = (p_option == FILE_SAVE_SCENE) ? -1 : tab_closing;
 			Node *scene = editor_data.get_edited_scene_root(scene_idx);
-			if (scene && scene->get_scene_file_path() != "") {
+			if (scene && !scene->get_scene_file_path().is_empty()) {
 				if (DirAccess::exists(scene->get_scene_file_path().get_base_dir())) {
 					if (scene_idx != editor_data.get_edited_scene()) {
 						_save_scene_with_preview(scene->get_scene_file_path(), scene_idx);
@@ -2575,7 +2575,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				file->add_filter("*." + extensions[i] + " ; " + extensions[i].to_upper());
 			}
 
-			if (scene->get_scene_file_path() != "") {
+			if (!scene->get_scene_file_path().is_empty()) {
 				String path = scene->get_scene_file_path();
 				file->set_current_path(path);
 				if (extensions.size()) {
@@ -2649,7 +2649,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 				if (!editor_data.get_undo_redo().undo()) {
 					log->add_message(TTR("Nothing to undo."), EditorLog::MSG_TYPE_EDITOR);
-				} else if (action != "") {
+				} else if (!action.is_empty()) {
 					log->add_message(vformat(TTR("Undo: %s"), action), EditorLog::MSG_TYPE_EDITOR);
 				}
 			}
@@ -2676,7 +2676,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 			String filename = scene->get_scene_file_path();
 
-			if (filename == String()) {
+			if (filename.is_empty()) {
 				show_warning(TTR("Can't reload a scene that was never saved."));
 				break;
 			}
@@ -2746,7 +2746,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		case FILE_SHOW_IN_FILESYSTEM: {
 			String path = editor_data.get_scene_path(editor_data.get_edited_scene());
-			if (path != String()) {
+			if (!path.is_empty()) {
 				filesystem_dock->navigate_to_path(path);
 			}
 		} break;
@@ -3011,7 +3011,7 @@ void EditorNode::_discard_changes(const String &p_str) {
 			Node *scene = editor_data.get_edited_scene_root(tab_closing);
 			if (scene != nullptr) {
 				String scene_filename = scene->get_scene_file_path();
-				if (scene_filename != "") {
+				if (!scene_filename.is_empty()) {
 					previous_scenes.push_back(scene_filename);
 				}
 			}
@@ -3138,7 +3138,7 @@ void EditorNode::_editor_select(int p_which) {
 }
 
 void EditorNode::select_editor_by_name(const String &p_name) {
-	ERR_FAIL_COND(p_name == "");
+	ERR_FAIL_COND(p_name.is_empty());
 
 	for (int i = 0; i < main_editor_buttons.size(); i++) {
 		if (main_editor_buttons[i]->get_text() == p_name) {
@@ -4491,13 +4491,13 @@ void EditorNode::_save_docks_to_config(Ref<ConfigFile> p_layout, const String &p
 		String names;
 		for (int j = 0; j < dock_slot[i]->get_tab_count(); j++) {
 			String name = dock_slot[i]->get_tab_control(j)->get_name();
-			if (names != "") {
+			if (!names.is_empty()) {
 				names += ",";
 			}
 			names += name;
 		}
 
-		if (names != "") {
+		if (!names.is_empty()) {
 			p_layout->set_value(p_section, "dock_" + itos(i + 1), names);
 		}
 	}
@@ -4522,7 +4522,7 @@ void EditorNode::_save_open_scenes_to_config(Ref<ConfigFile> p_layout, const Str
 	Array scenes;
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
 		String path = editor_data.get_scene_path(i);
-		if (path == "") {
+		if (path.is_empty()) {
 			continue;
 		}
 		scenes.push_back(path);
@@ -4789,7 +4789,7 @@ bool EditorNode::ensure_main_scene(bool p_from_native) {
 	pick_main_scene->set_meta("from_native", p_from_native); // whether from play button or native run
 	String main_scene = GLOBAL_DEF("application/run/main_scene", "");
 
-	if (main_scene == "") {
+	if (main_scene.is_empty()) {
 		current_option = -1;
 		pick_main_scene->set_text(TTR("No main scene has ever been defined, select one?\nYou can change it later in \"Project Settings\" under the 'application' category."));
 		pick_main_scene->popup_centered();
@@ -4852,7 +4852,7 @@ bool EditorNode::is_run_playing() const {
 
 String EditorNode::get_run_playing_scene() const {
 	String run_filename = editor_run.get_running_scene();
-	if (run_filename == "" && is_run_playing()) {
+	if (run_filename.is_empty() && is_run_playing()) {
 		run_filename = GLOBAL_DEF("application/run/main_scene", ""); // Must be the main scene then.
 	}
 
@@ -4978,7 +4978,7 @@ void EditorNode::_scene_tab_closed(int p_tab, int option) {
 			: editor_data.get_scene_version(p_tab) != 0;
 	if (unsaved) {
 		save_confirmation->get_ok_button()->set_text(TTR("Save & Close"));
-		save_confirmation->set_text(vformat(TTR("Save changes to '%s' before closing?"), scene->get_scene_file_path() != "" ? scene->get_scene_file_path() : "unsaved scene"));
+		save_confirmation->set_text(vformat(TTR("Save changes to '%s' before closing?"), !scene->get_scene_file_path().is_empty() ? scene->get_scene_file_path() : "unsaved scene"));
 		save_confirmation->popup_centered();
 	} else {
 		_discard_changes();
@@ -4998,7 +4998,7 @@ void EditorNode::_scene_tab_hovered(int p_tab) {
 		tab_preview_panel->hide();
 	} else {
 		String path = editor_data.get_scene_path(p_tab);
-		if (path != String()) {
+		if (!path.is_empty()) {
 			EditorResourcePreview::get_singleton()->queue_resource_preview(path, this, "_thumbnail_done", p_tab);
 		}
 	}
@@ -5307,7 +5307,7 @@ Variant EditorNode::drag_resource(const Ref<Resource> &p_res, Control *p_from) {
 	drag_control->add_child(drag_preview);
 	if (p_res->get_path().is_resource_file()) {
 		label->set_text(p_res->get_path().get_file());
-	} else if (p_res->get_name() != "") {
+	} else if (!p_res->get_name().is_empty()) {
 		label->set_text(p_res->get_name());
 	} else {
 		label->set_text(p_res->get_class());
@@ -5446,7 +5446,7 @@ void EditorNode::_add_dropped_files_recursive(const Vector<String> &p_files, Str
 			sub_dir->list_dir_begin();
 
 			String next_file = sub_dir->get_next();
-			while (next_file != "") {
+			while (!next_file.is_empty()) {
 				if (next_file == "." || next_file == "..") {
 					next_file = sub_dir->get_next();
 					continue;

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -130,14 +130,14 @@ void EditorPath::update_path() {
 					name = r->get_name();
 				}
 
-				if (name == "") {
+				if (name.is_empty()) {
 					name = r->get_class();
 				}
 			} else if (obj->is_class("EditorDebuggerRemoteObject")) {
 				name = obj->call("get_title");
 			} else if (Object::cast_to<Node>(obj)) {
 				name = Object::cast_to<Node>(obj)->get_name();
-			} else if (Object::cast_to<Resource>(obj) && Object::cast_to<Resource>(obj)->get_name() != "") {
+			} else if (Object::cast_to<Resource>(obj) && !Object::cast_to<Resource>(obj)->get_name().is_empty()) {
 				name = Object::cast_to<Resource>(obj)->get_name();
 			} else {
 				name = obj->get_class();

--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -131,7 +131,7 @@ EditorPaths::EditorPaths() {
 		}
 	}
 
-	paths_valid = (data_path != "" && config_path != "" && cache_path != "");
+	paths_valid = (!data_path.is_empty() && !config_path.is_empty() && !cache_path.is_empty());
 	ERR_FAIL_COND_MSG(!paths_valid, "Editor data, config, or cache paths are invalid.");
 
 	// Validate or create each dir and its relevant subdirectories.

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -295,7 +295,7 @@ Error EditorInterface::save_scene() {
 	if (!get_edited_scene_root()) {
 		return ERR_CANT_CREATE;
 	}
-	if (get_edited_scene_root()->get_scene_file_path() == String()) {
+	if (get_edited_scene_root()->get_scene_file_path().is_empty()) {
 		return ERR_CANT_CREATE;
 	}
 

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -165,7 +165,7 @@ Vector<String> EditorPluginSettings::_get_plugins(const String &p_dir) {
 
 	Vector<String> plugins;
 	da->list_dir_begin();
-	for (String path = da->get_next(); path != String(); path = da->get_next()) {
+	for (String path = da->get_next(); !path.is_empty(); path = da->get_next()) {
 		if (path[0] == '.' || !da->current_is_dir()) {
 			continue;
 		}

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -380,7 +380,7 @@ void EditorPropertyPath::_path_pressed() {
 		dialog->set_file_mode(save_mode ? EditorFileDialog::FILE_MODE_SAVE_FILE : EditorFileDialog::FILE_MODE_OPEN_FILE);
 		for (int i = 0; i < extensions.size(); i++) {
 			String e = extensions[i].strip_edges();
-			if (e != String()) {
+			if (!e.is_empty()) {
 				dialog->add_filter(extensions[i].strip_edges());
 			}
 		}
@@ -706,7 +706,7 @@ void EditorPropertyFlags::setup(const Vector<String> &p_options) {
 	bool first = true;
 	for (int i = 0; i < p_options.size(); i++) {
 		String option = p_options[i].strip_edges();
-		if (option != "") {
+		if (!option.is_empty()) {
 			CheckBox *cb = memnew(CheckBox);
 			cb->set_text(option);
 			cb->set_clip_text(true);
@@ -1055,7 +1055,7 @@ void EditorPropertyLayers::setup(LayerType p_layer_type) {
 			name = ProjectSettings::get_singleton()->get(basename + vformat("/layer_%d", i + 1));
 		}
 
-		if (name == "") {
+		if (name.is_empty()) {
 			name = vformat(TTR("Layer %d"), i + 1);
 		}
 
@@ -1186,7 +1186,7 @@ void EditorPropertyObjectID::_edit_pressed() {
 
 void EditorPropertyObjectID::update_property() {
 	String type = base_type;
-	if (type == "") {
+	if (type.is_empty()) {
 		type = "Object";
 	}
 
@@ -3229,7 +3229,7 @@ static EditorPropertyRangeHint _parse_range_hint(PropertyHint p_hint, const Stri
 		}
 	}
 
-	if ((hint.radians || degrees) && hint.suffix == String()) {
+	if ((hint.radians || degrees) && hint.suffix.is_empty()) {
 		hint.suffix = U"\u00B0";
 	}
 
@@ -3514,10 +3514,10 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 		} break;
 		case Variant::NODE_PATH: {
 			EditorPropertyNodePath *editor = memnew(EditorPropertyNodePath);
-			if (p_hint == PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE && p_hint_text != String()) {
+			if (p_hint == PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE && !p_hint_text.is_empty()) {
 				editor->setup(p_hint_text, Vector<StringName>(), (p_usage & PROPERTY_USAGE_NODE_PATH_FROM_SCENE_ROOT));
 			}
-			if (p_hint == PROPERTY_HINT_NODE_PATH_VALID_TYPES && p_hint_text != String()) {
+			if (p_hint == PROPERTY_HINT_NODE_PATH_VALID_TYPES && !p_hint_text.is_empty()) {
 				Vector<String> types = p_hint_text.split(",", false);
 				Vector<StringName> sn = Variant(types); //convert via variant
 				editor->setup(NodePath(), sn, (p_usage & PROPERTY_USAGE_NODE_PATH_FROM_SCENE_ROOT));

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -431,7 +431,7 @@ bool EditorPropertyArray::_is_drop_valid(const Dictionary &p_drag_data) const {
 
 	// When the subtype is of type Object, an additional subtype may be specified in the hint string
 	// (e.g. Resource, Texture2D, ShaderMaterial, etc). We want the allowed type to be that, not just "Object".
-	if (subtype == Variant::OBJECT && subtype_hint_string != "") {
+	if (subtype == Variant::OBJECT && !subtype_hint_string.is_empty()) {
 		allowed_type = subtype_hint_string;
 	}
 

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -52,7 +52,7 @@ void EditorResourcePicker::_update_resource() {
 	} else {
 		assign_button->set_icon(EditorNode::get_singleton()->get_object_icon(edited_resource.operator->(), "Object"));
 
-		if (edited_resource->get_name() != String()) {
+		if (!edited_resource->get_name().is_empty()) {
 			assign_button->set_text(edited_resource->get_name());
 		} else if (edited_resource->get_path().is_resource_file()) {
 			assign_button->set_text(edited_resource->get_path().get_file());
@@ -113,7 +113,7 @@ void EditorResourcePicker::_file_selected(const String &p_path) {
 	RES loaded_resource = ResourceLoader::load(p_path);
 	ERR_FAIL_COND_MSG(loaded_resource.is_null(), "Cannot load resource from path '" + p_path + "'.");
 
-	if (base_type != "") {
+	if (!base_type.is_empty()) {
 		bool any_type_matches = false;
 
 		for (int i = 0; i < base_type.get_slice_count(","); i++) {
@@ -180,7 +180,7 @@ void EditorResourcePicker::_update_menu_items() {
 	RES cb = EditorSettings::get_singleton()->get_resource_clipboard();
 	bool paste_valid = false;
 	if (cb.is_valid()) {
-		if (base_type == "") {
+		if (base_type.is_empty()) {
 			paste_valid = true;
 		} else {
 			for (int i = 0; i < base_type.get_slice_count(","); i++) {
@@ -391,7 +391,7 @@ void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 	}
 
 	// By default provide generic "New ..." options.
-	if (base_type != "") {
+	if (!base_type.is_empty()) {
 		int idx = 0;
 
 		Set<String> allowed_types;
@@ -571,7 +571,7 @@ bool EditorResourcePicker::_is_drop_valid(const Dictionary &p_drag_data) const {
 			String file = files[0];
 
 			String file_type = EditorFileSystem::get_singleton()->get_file_type(file);
-			if (file_type != "" && _is_type_valid(file_type, allowed_types)) {
+			if (!file_type.is_empty() && _is_type_valid(file_type, allowed_types)) {
 				return true;
 			}
 		}

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -141,7 +141,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 		type = ResourceLoader::get_resource_type(p_item.path);
 	}
 
-	if (type == "") {
+	if (type.is_empty()) {
 		r_texture = Ref<ImageTexture>();
 		r_small_texture = Ref<ImageTexture>();
 		return; //could not guess type

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -180,7 +180,7 @@ Error EditorRun::run(const String &p_scene) {
 		args.push_back("--skip-breakpoints");
 	}
 
-	if (p_scene != "") {
+	if (!p_scene.is_empty()) {
 		args.push_back(p_scene);
 	}
 
@@ -244,7 +244,7 @@ Error EditorRun::run(const String &p_scene) {
 	}
 
 	status = STATUS_PLAY;
-	if (p_scene != "") {
+	if (!p_scene.is_empty()) {
 		running_scene = p_scene;
 	}
 

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -45,7 +45,7 @@ class SectionedInspectorFilter : public Object {
 		}
 
 		String name = p_name;
-		if (section != "") {
+		if (!section.is_empty()) {
 			name = section + "/" + name;
 		}
 
@@ -60,7 +60,7 @@ class SectionedInspectorFilter : public Object {
 		}
 
 		String name = p_name;
-		if (section != "") {
+		if (!section.is_empty()) {
 			name = section + "/" + name;
 		}
 
@@ -155,7 +155,7 @@ String SectionedInspector::get_current_section() const {
 String SectionedInspector::get_full_item_path(const String &p_item) {
 	String base = get_current_section();
 
-	if (base != "") {
+	if (!base.is_empty()) {
 		return base + "/" + p_item;
 	} else {
 		return p_item;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -389,14 +389,14 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 				best = locale;
 			}
 
-			if (best == String() && host_lang.begins_with(locale)) {
+			if (best.is_empty() && host_lang.begins_with(locale)) {
 				best = locale;
 			}
 
 			etl++;
 		}
 
-		if (best == String()) {
+		if (best.is_empty()) {
 			best = "en";
 		}
 
@@ -989,7 +989,7 @@ void EditorSettings::setup_network() {
 		if (ip == current) {
 			selected = ip;
 		}
-		if (hint != "") {
+		if (!hint.is_empty()) {
 			hint += ",";
 		}
 		hint += ip;
@@ -1008,7 +1008,7 @@ void EditorSettings::save() {
 		return;
 	}
 
-	if (singleton->config_file_path == "") {
+	if (singleton->config_file_path.is_empty()) {
 		ERR_PRINT("Cannot save EditorSettings config, no valid path");
 		return;
 	}
@@ -1218,7 +1218,7 @@ void EditorSettings::load_favorites() {
 	FileAccess *f = FileAccess::open(get_project_settings_dir().plus_file("favorites"), FileAccess::READ);
 	if (f) {
 		String line = f->get_line().strip_edges();
-		while (line != "") {
+		while (!line.is_empty()) {
 			favorites.push_back(line);
 			line = f->get_line().strip_edges();
 		}
@@ -1228,7 +1228,7 @@ void EditorSettings::load_favorites() {
 	f = FileAccess::open(get_project_settings_dir().plus_file("recent_dirs"), FileAccess::READ);
 	if (f) {
 		String line = f->get_line().strip_edges();
-		while (line != "") {
+		while (!line.is_empty()) {
 			recent_dirs.push_back(line);
 			line = f->get_line().strip_edges();
 		}
@@ -1252,7 +1252,7 @@ void EditorSettings::list_text_editor_themes() {
 		List<String> custom_themes;
 		d->list_dir_begin();
 		String file = d->get_next();
-		while (file != String()) {
+		while (!file.is_empty()) {
 			if (file.get_extension() == "tet" && !_is_default_text_editor_theme(file.get_basename().to_lower())) {
 				custom_themes.push_back(file.get_basename());
 			}
@@ -1371,7 +1371,7 @@ Vector<String> EditorSettings::get_script_templates(const String &p_extension, c
 	if (d) {
 		d->list_dir_begin();
 		String file = d->get_next();
-		while (file != String()) {
+		while (!file.is_empty()) {
 			if (file.get_extension() == p_extension) {
 				templates.push_back(file.get_basename());
 			}

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -262,9 +262,9 @@ void EditorSpinSlider::_update_value_input_stylebox() {
 	// The margin values below were determined by empirical testing.
 	if (is_layout_rtl()) {
 		stylebox->set_default_margin(SIDE_LEFT, 0);
-		stylebox->set_default_margin(SIDE_RIGHT, (get_label() != String() ? 23 : 16) * EDSCALE);
+		stylebox->set_default_margin(SIDE_RIGHT, (!get_label().is_empty() ? 23 : 16) * EDSCALE);
 	} else {
-		stylebox->set_default_margin(SIDE_LEFT, (get_label() != String() ? 23 : 16) * EDSCALE);
+		stylebox->set_default_margin(SIDE_LEFT, (!get_label().is_empty() ? 23 : 16) * EDSCALE);
 		stylebox->set_default_margin(SIDE_RIGHT, 0);
 	}
 
@@ -308,7 +308,7 @@ void EditorSpinSlider::_draw_spin_slider() {
 		lc = fc;
 	}
 
-	if (flat && label != String()) {
+	if (flat && !label.is_empty()) {
 		Color label_bg_color = get_theme_color(SNAME("dark_color_3"), SNAME("Editor"));
 		if (rtl) {
 			draw_rect(Rect2(Vector2(size.width - (sb->get_offset().x * 2 + label_width), 0), Vector2(sb->get_offset().x * 2 + label_width, size.height)), label_bg_color);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1553,7 +1553,7 @@ Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
 	Ref<Theme> theme = create_editor_theme(p_theme);
 
 	const String custom_theme_path = EditorSettings::get_singleton()->get("interface/theme/custom_theme");
-	if (custom_theme_path != "") {
+	if (!custom_theme_path.is_empty()) {
 		Ref<Theme> custom_theme = ResourceLoader::load(custom_theme_path);
 		if (custom_theme.is_valid()) {
 			theme->merge_with(custom_theme);

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -53,7 +53,7 @@ void ExportTemplateManager::_update_template_status() {
 	da->list_dir_begin();
 	if (err == OK) {
 		String c = da->get_next();
-		while (c != String()) {
+		while (!c.is_empty()) {
 			if (da->current_is_dir() && !c.begins_with(".")) {
 				templates.insert(c);
 			}
@@ -424,7 +424,7 @@ bool ExportTemplateManager::_install_file_selected(const String &p_file, bool p_
 		ret = unzGoToNextFile(pkg);
 	}
 
-	if (version == String()) {
+	if (version.is_empty()) {
 		EditorNode::get_singleton()->show_warning(TTR("No version.txt found inside the export templates file."));
 		unzClose(pkg);
 		return false;

--- a/editor/fileserver/editor_file_server.cpp
+++ b/editor/fileserver/editor_file_server.cpp
@@ -88,7 +88,7 @@ void EditorFileServer::_subthread_start(void *s) {
 			ERR_FAIL();
 		}
 	} else {
-		if (cd->efs->password != "") {
+		if (!cd->efs->password.is_empty()) {
 			encode_uint32(ERR_INVALID_DATA, buf4);
 			cd->connection->put_data(buf4, 4);
 			OS::get_singleton()->delay_usec(1000000);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -64,7 +64,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 	// Create a tree item for the subdirectory.
 	TreeItem *subdirectory_item = tree->create_item(p_parent);
 	String dname = p_dir->get_name();
-	if (dname == "") {
+	if (dname.is_empty()) {
 		dname = "res://";
 	}
 
@@ -923,7 +923,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			files->select(item_index, false);
 		}
 
-		if (!p_keep_selection && file != "" && fname == file) {
+		if (!p_keep_selection && !file.is_empty() && fname == file) {
 			files->select(item_index, true);
 			files->ensure_current_is_visible();
 		}
@@ -1670,7 +1670,7 @@ Vector<String> FileSystemDock::_remove_self_included_paths(Vector<String> select
 		selected_strings.sort_custom<NaturalNoCaseComparator>();
 		String last_path = "";
 		for (int i = 0; i < selected_strings.size(); i++) {
-			if (last_path != "" && selected_strings[i].begins_with(last_path)) {
+			if (!last_path.is_empty() && selected_strings[i].begins_with(last_path)) {
 				selected_strings.remove_at(i);
 				i--;
 			}
@@ -2016,7 +2016,7 @@ void FileSystemDock::_search_changed(const String &p_text, const Control *p_from
 		tree_search_box->set_text(searched_string);
 	}
 
-	bool unfold_path = (p_text == String() && path != String());
+	bool unfold_path = (p_text.is_empty() && !path.is_empty());
 	switch (display_mode) {
 		case DISPLAY_MODE_TREE_ONLY: {
 			_update_tree(searched_string.length() == 0 ? uncollapsed_paths_before_search : Vector<String>(), false, false, unfold_path);
@@ -2665,7 +2665,7 @@ void FileSystemDock::_get_imported_files(const String &p_path, Vector<String> &f
 	DirAccess *da = DirAccess::open(p_path);
 	da->list_dir_begin();
 	String n = da->get_next();
-	while (n != String()) {
+	while (!n.is_empty()) {
 		if (n != "." && n != ".." && !n.ends_with(".import")) {
 			String npath = p_path + n + (da->current_is_dir() ? "/" : "");
 			_get_imported_files(npath, files);
@@ -2720,7 +2720,7 @@ void FileSystemDock::_update_import_dock() {
 		if (cf->has_section_key("remap", "type")) {
 			type = cf->get_value("remap", "type");
 		}
-		if (import_type == "") {
+		if (import_type.is_empty()) {
 			import_type = type;
 		} else if (import_type != type) {
 			// All should be the same type.

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -114,7 +114,7 @@ void FindInFiles::_notification(int p_notification) {
 }
 
 void FindInFiles::start() {
-	if (_pattern == "") {
+	if (_pattern.is_empty()) {
 		print_verbose("Nothing to search, pattern is empty");
 		emit_signal(SNAME(SIGNAL_FINISHED));
 		return;
@@ -224,7 +224,7 @@ void FindInFiles::_scan_dir(String path, PackedStringArray &out_folders) {
 	for (int i = 0; i < 1000; ++i) {
 		String file = dir->get_next();
 
-		if (file == "") {
+		if (file.is_empty()) {
 			break;
 		}
 

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -227,7 +227,7 @@ void GroupDialog::_group_renamed() {
 		}
 	}
 
-	if (name == "") {
+	if (name.is_empty()) {
 		renamed_group->set_text(0, selected_group);
 		error->set_text(TTR("Invalid group name."));
 		error->popup_centered();

--- a/editor/import/collada.cpp
+++ b/editor/import/collada.cpp
@@ -1362,7 +1362,7 @@ Collada::Node *Collada::_parse_visual_instance_geometry(XMLParser &parser) {
 			} else if (parser.get_node_name() == "skeleton") {
 				parser.read();
 				String uri = _uri_to_id(parser.get_node_data());
-				if (uri != "") {
+				if (!uri.is_empty()) {
 					geom->skeletons.push_back(uri);
 				}
 			}
@@ -1464,7 +1464,7 @@ Collada::Node *Collada::_parse_visual_scene_node(XMLParser &parser) {
 
 	bool found_name = false;
 
-	if (id == "") {
+	if (id.is_empty()) {
 		id = "%NODEID%" + itos(Math::rand());
 
 	} else {
@@ -1479,7 +1479,7 @@ Collada::Node *Collada::_parse_visual_scene_node(XMLParser &parser) {
 	Node *node = nullptr;
 
 	name = parser.has_attribute("name") ? parser.get_attribute_value_safe("name") : parser.get_attribute_value_safe("id");
-	if (name == "") {
+	if (name.is_empty()) {
 		name = id;
 	} else {
 		found_name = true;
@@ -1499,7 +1499,7 @@ Collada::Node *Collada::_parse_visual_scene_node(XMLParser &parser) {
 			joint->sid = parser.get_attribute_value_safe("name");
 		}
 
-		if (joint->sid != "") {
+		if (!joint->sid.is_empty()) {
 			state.sid_to_node_map[joint->sid] = id;
 		}
 
@@ -1696,16 +1696,16 @@ void Collada::_parse_animation(XMLParser &parser) {
 				source_param_types[current_source] = Vector<String>();
 
 			} else if (name == "float_array") {
-				if (current_source != "") {
+				if (!current_source.is_empty()) {
 					float_sources[current_source] = _read_float_array(parser);
 				}
 
 			} else if (name == "Name_array") {
-				if (current_source != "") {
+				if (!current_source.is_empty()) {
 					string_sources[current_source] = _read_string_array(parser);
 				}
 			} else if (name == "accessor") {
-				if (current_source != "" && parser.has_attribute("stride")) {
+				if (!current_source.is_empty() && parser.has_attribute("stride")) {
 					source_strides[current_source] = parser.get_attribute_value("stride").to_int();
 				}
 			} else if (name == "sampler") {
@@ -1725,7 +1725,7 @@ void Collada::_parse_animation(XMLParser &parser) {
 				}
 
 			} else if (name == "input") {
-				if (current_sampler != "") {
+				if (!current_sampler.is_empty()) {
 					samplers[current_sampler][parser.get_attribute_value("semantic")] = parser.get_attribute_value("source");
 				}
 
@@ -1838,7 +1838,7 @@ void Collada::_parse_animation(XMLParser &parser) {
 					track.component = track.param.get_slice(".", 1).to_upper();
 				}
 				track.param = track.param.get_slice(".", 0);
-				if (names.size() > 1 && track.component == "") {
+				if (names.size() > 1 && track.component.is_empty()) {
 					//this is a guess because the collada spec is ambiguous here...
 					//i suppose if you have many names (outputs) you can't use a component and i should abide to that.
 					track.component = name;
@@ -1855,7 +1855,7 @@ void Collada::_parse_animation(XMLParser &parser) {
 
 			state.referenced_tracks[target].push_back(state.animation_tracks.size() - 1);
 
-			if (id != "") {
+			if (!id.is_empty()) {
 				if (!state.by_id_tracks.has(id)) {
 					state.by_id_tracks[id] = Vector<int>();
 				}
@@ -1953,10 +1953,10 @@ void Collada::_parse_library(XMLParser &parser) {
 				while (parser.read() == OK) {
 					if (parser.get_node_type() == XMLParser::NODE_ELEMENT) {
 						if (parser.get_node_name() == "mesh") {
-							state.mesh_name_map[id] = (name2 != "") ? name2 : id;
+							state.mesh_name_map[id] = (!name2.is_empty()) ? name2 : id;
 							_parse_mesh_geometry(parser, id, name2);
 						} else if (parser.get_node_name() == "spline") {
-							state.mesh_name_map[id] = (name2 != "") ? name2 : id;
+							state.mesh_name_map[id] = (!name2.is_empty()) ? name2 : id;
 							_parse_curve_geometry(parser, id, name2);
 						} else if (!parser.is_empty()) {
 							parser.skip_section();
@@ -2286,7 +2286,7 @@ void Collada::_find_morph_nodes(VisualScene *p_vscene, Node *p_node) {
 		if (nj->controller) {
 			String base = nj->source;
 
-			while (base != "" && !state.mesh_data_map.has(base)) {
+			while (!base.is_empty() && !state.mesh_data_map.has(base)) {
 				if (state.skin_controller_data_map.has(base)) {
 					SkinControllerData &sk = state.skin_controller_data_map[base];
 					base = sk.base;

--- a/editor/import/dynamicfont_import_settings.cpp
+++ b/editor/import/dynamicfont_import_settings.cpp
@@ -1597,7 +1597,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 
 	menu_langs = memnew(PopupMenu);
 	menu_langs->set_name("Language");
-	for (int i = 0; langs[i].name != String(); i++) {
+	for (int i = 0; !langs[i].name.is_empty(); i++) {
 		if (langs[i].name == "-") {
 			menu_langs->add_separator();
 		} else {
@@ -1609,7 +1609,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 
 	menu_scripts = memnew(PopupMenu);
 	menu_scripts->set_name("Script");
-	for (int i = 0; scripts[i].name != String(); i++) {
+	for (int i = 0; !scripts[i].name.is_empty(); i++) {
 		if (scripts[i].name == "-") {
 			menu_scripts->add_separator();
 		} else {
@@ -1826,7 +1826,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	glyph_tree->connect("item_selected", callable_mp(this, &DynamicFontImportSettings::_range_selected));
 	glyph_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	glyph_root = glyph_tree->create_item();
-	for (int i = 0; unicode_ranges[i].name != String(); i++) {
+	for (int i = 0; !unicode_ranges[i].name.is_empty(); i++) {
 		_add_glyph_range_item(unicode_ranges[i].start, unicode_ranges[i].end, unicode_ranges[i].name);
 	}
 

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -303,7 +303,7 @@ Error ColladaImport::_create_scene(Collada::Node *p_node, Node3D *p_parent) {
 		} break;
 	}
 
-	if (p_node->name != "") {
+	if (!p_node->name.is_empty()) {
 		node->set_name(p_node->name);
 	}
 	NodeMap nm;
@@ -317,7 +317,7 @@ Error ColladaImport::_create_scene(Collada::Node *p_node, Node3D *p_parent) {
 	p_parent->add_child(node, true);
 	node->set_owner(scene);
 
-	if (p_node->empty_draw_type != "") {
+	if (!p_node->empty_draw_type.is_empty()) {
 		node->set_meta("empty_draw_type", Variant(p_node->empty_draw_type));
 	}
 
@@ -340,9 +340,9 @@ Error ColladaImport::_create_material(const String &p_target) {
 	Ref<StandardMaterial3D> material = memnew(StandardMaterial3D);
 
 	String base_name;
-	if (src_mat.name != "") {
+	if (!src_mat.name.is_empty()) {
 		base_name = src_mat.name;
-	} else if (effect.name != "") {
+	} else if (!effect.name.is_empty()) {
 		base_name = effect.name;
 	} else {
 		base_name = "Material";
@@ -360,9 +360,9 @@ Error ColladaImport::_create_material(const String &p_target) {
 
 	// DIFFUSE
 
-	if (effect.diffuse.texture != "") {
+	if (!effect.diffuse.texture.is_empty()) {
 		String texfile = effect.get_texture_path(effect.diffuse.texture, collada);
-		if (texfile != "") {
+		if (!texfile.is_empty()) {
 			if (texfile.begins_with("/")) {
 				texfile = texfile.replace_first("/", "res://");
 			}
@@ -381,9 +381,9 @@ Error ColladaImport::_create_material(const String &p_target) {
 
 	// SPECULAR
 
-	if (effect.specular.texture != "") {
+	if (!effect.specular.texture.is_empty()) {
 		String texfile = effect.get_texture_path(effect.specular.texture, collada);
-		if (texfile != "") {
+		if (!texfile.is_empty()) {
 			if (texfile.begins_with("/")) {
 				texfile = texfile.replace_first("/", "res://");
 			}
@@ -406,9 +406,9 @@ Error ColladaImport::_create_material(const String &p_target) {
 
 	// EMISSION
 
-	if (effect.emission.texture != "") {
+	if (!effect.emission.texture.is_empty()) {
 		String texfile = effect.get_texture_path(effect.emission.texture, collada);
-		if (texfile != "") {
+		if (!texfile.is_empty()) {
 			if (texfile.begins_with("/")) {
 				texfile = texfile.replace_first("/", "res://");
 			}
@@ -433,9 +433,9 @@ Error ColladaImport::_create_material(const String &p_target) {
 
 	// NORMAL
 
-	if (effect.bump.texture != "") {
+	if (!effect.bump.texture.is_empty()) {
 		String texfile = effect.get_texture_path(effect.bump.texture, collada);
-		if (texfile != "") {
+		if (!texfile.is_empty()) {
 			if (texfile.begins_with("/")) {
 				texfile = texfile.replace_first("/", "res://");
 			}
@@ -525,7 +525,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				normal_ofs = vertex_ofs;
 			}
 
-			if (normal_source_id != "") {
+			if (!normal_source_id.is_empty()) {
 				ERR_FAIL_COND_V(!meshdata.sources.has(normal_source_id), ERR_INVALID_DATA);
 				normal_src = &meshdata.sources[normal_source_id];
 			}
@@ -545,7 +545,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				binormal_ofs = vertex_ofs;
 			}
 
-			if (binormal_source_id != "") {
+			if (!binormal_source_id.is_empty()) {
 				ERR_FAIL_COND_V(!meshdata.sources.has(binormal_source_id), ERR_INVALID_DATA);
 				binormal_src = &meshdata.sources[binormal_source_id];
 			}
@@ -565,7 +565,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				tangent_ofs = vertex_ofs;
 			}
 
-			if (tangent_source_id != "") {
+			if (!tangent_source_id.is_empty()) {
 				ERR_FAIL_COND_V(!meshdata.sources.has(tangent_source_id), ERR_INVALID_DATA);
 				tangent_src = &meshdata.sources[tangent_source_id];
 			}
@@ -585,7 +585,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				uv_ofs = vertex_ofs;
 			}
 
-			if (uv_source_id != "") {
+			if (!uv_source_id.is_empty()) {
 				ERR_FAIL_COND_V(!meshdata.sources.has(uv_source_id), ERR_INVALID_DATA);
 				uv_src = &meshdata.sources[uv_source_id];
 			}
@@ -605,7 +605,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				uv2_ofs = vertex_ofs;
 			}
 
-			if (uv2_source_id != "") {
+			if (!uv2_source_id.is_empty()) {
 				ERR_FAIL_COND_V(!meshdata.sources.has(uv2_source_id), ERR_INVALID_DATA);
 				uv2_src = &meshdata.sources[uv2_source_id];
 			}
@@ -625,7 +625,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				color_ofs = vertex_ofs;
 			}
 
-			if (color_source_id != "") {
+			if (!color_source_id.is_empty()) {
 				ERR_FAIL_COND_V(!meshdata.sources.has(color_source_id), ERR_INVALID_DATA);
 				color_src = &meshdata.sources[color_source_id];
 			}
@@ -914,7 +914,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 						material = material_cache[target];
 					}
 
-				} else if (p.material != "") {
+				} else if (!p.material.is_empty()) {
 					WARN_PRINT("Collada: Unreferenced material in geometry instance: " + p.material);
 				}
 			}
@@ -1198,7 +1198,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 					}
 				}
 
-				ERR_FAIL_COND_V_MSG(ngsource != "", ERR_INVALID_DATA, "Controller instance source '" + ngsource + "' is neither skin or morph!");
+				ERR_FAIL_COND_V_MSG(!ngsource.is_empty(), ERR_INVALID_DATA, "Controller instance source '" + ngsource + "' is neither skin or morph!");
 
 			} else {
 				meshid = ng2->source;
@@ -1215,13 +1215,13 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 					mesh = Ref<ImporterMesh>(memnew(ImporterMesh));
 					const Collada::MeshData &meshdata = collada.state.mesh_data_map[meshid];
 					String name = meshdata.name;
-					if (name == "") {
+					if (name.is_empty()) {
 						name = "Mesh";
 					}
 					int counter = 2;
 					while (mesh_unique_names.has(name)) {
 						name = meshdata.name;
-						if (name == "") {
+						if (name.is_empty()) {
 							name = "Mesh";
 						}
 						name += itos(counter++);
@@ -1261,7 +1261,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 							}
 
 							mi->set_surface_material(i, material);
-						} else if (matname != "") {
+						} else if (!matname.is_empty()) {
 							WARN_PRINT("Collada: Unreferenced material in geometry instance: " + matname);
 						}
 					}
@@ -1343,7 +1343,7 @@ void ColladaImport::_fix_param_animation_tracks() {
 				// test source(s)
 				String source = ng->source;
 
-				while (source != "") {
+				while (!source.is_empty()) {
 					if (collada.state.skin_controller_data_map.has(source)) {
 						const Collada::SkinControllerData &skin = collada.state.skin_controller_data_map[source];
 
@@ -1796,7 +1796,7 @@ Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint3
 		AnimationPlayer *ap = memnew(AnimationPlayer);
 		for (int i = 0; i < state.animations.size(); i++) {
 			String name;
-			if (state.animations[i]->get_name() == "") {
+			if (state.animations[i]->get_name().is_empty()) {
 				name = "default";
 			} else {
 				name = state.animations[i]->get_name();

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -113,7 +113,7 @@ Error ResourceImporterCSVTranslation::import(const String &p_source_file, const 
 
 	while (line.size() == locales.size() + 1) {
 		String key = line[0];
-		if (key != "") {
+		if (!key.is_empty()) {
 			for (int i = 1; i < line.size(); i++) {
 				translations.write[i - 1]->add_message(key, line[i].c_unescape());
 			}

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -235,7 +235,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 		while (l.length() && l[l.length() - 1] == '\\') {
 			String add = f->get_line().strip_edges();
 			l += add;
-			if (add == String()) {
+			if (add.is_empty()) {
 				break;
 			}
 		}
@@ -301,7 +301,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 						surf_tool->set_normal(normals[norm]);
 					}
 
-					if (face[idx].size() >= 2 && face[idx][1] != String()) {
+					if (face[idx].size() >= 2 && !face[idx][1].is_empty()) {
 						int uv = face[idx][1].to_int() - 1;
 						if (uv < 0) {
 							uv += uvs.size() + 1;
@@ -363,9 +363,9 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 
 				mesh = surf_tool->commit(mesh, mesh_flags);
 
-				if (current_material != String()) {
+				if (!current_material.is_empty()) {
 					mesh->surface_set_name(mesh->get_surface_count() - 1, current_material.get_basename());
-				} else if (current_group != String()) {
+				} else if (!current_group.is_empty()) {
 					mesh->surface_set_name(mesh->get_surface_count() - 1, current_group);
 				}
 

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -481,7 +481,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<I
 					fixed_name = _fixstr(name, "convcolonly");
 				}
 
-				ERR_FAIL_COND_V(fixed_name == String(), nullptr);
+				ERR_FAIL_COND_V(fixed_name.is_empty(), nullptr);
 
 				if (shapes.size()) {
 					StaticBody3D *col = memnew(StaticBody3D);
@@ -577,7 +577,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, Map<Ref<I
 				fixed_name = _fixstr(name, "convcol");
 			}
 
-			if (fixed_name != String()) {
+			if (!fixed_name.is_empty()) {
 				if (mi->get_parent() && !mi->get_parent()->has_node(fixed_name)) {
 					mi->set_name(fixed_name);
 				}
@@ -710,7 +710,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 							mat_id = mat->get_name();
 						}
 
-						if (mat_id != String() && p_material_data.has(mat_id)) {
+						if (!mat_id.is_empty() && p_material_data.has(mat_id)) {
 							Dictionary matdata = p_material_data[mat_id];
 
 							for (int j = 0; j < post_importer_plugins.size(); j++) {
@@ -1433,7 +1433,7 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 	String script_ext_hint;
 
 	for (const String &E : script_extentions) {
-		if (script_ext_hint != "") {
+		if (!script_ext_hint.is_empty()) {
 			script_ext_hint += ",";
 		}
 		script_ext_hint += "*." + E;
@@ -1559,7 +1559,7 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 					mesh_id = src_mesh_node->get_mesh()->get_name();
 				}
 
-				if (mesh_id != String() && p_mesh_data.has(mesh_id)) {
+				if (!mesh_id.is_empty() && p_mesh_data.has(mesh_id)) {
 					Dictionary mesh_settings = p_mesh_data[mesh_id];
 
 					if (mesh_settings.has("generate/shadow_meshes")) {
@@ -1649,7 +1649,7 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 					}
 				}
 
-				if (save_to_file != String()) {
+				if (!save_to_file.is_empty()) {
 					Ref<Mesh> existing = Ref<Resource>(ResourceCache::get(save_to_file));
 					if (existing.is_valid()) {
 						//if somehow an existing one is useful, create
@@ -2051,7 +2051,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	String post_import_script_path = p_options["import_script/path"];
 	Ref<EditorScenePostImport> post_import_script;
 
-	if (post_import_script_path != "") {
+	if (!post_import_script_path.is_empty()) {
 		Ref<Script> scr = ResourceLoader::load(post_import_script_path);
 		if (!scr.is_valid()) {
 			EditorNode::add_io_error(TTR("Couldn't load post-import script:") + " " + post_import_script_path);

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -92,7 +92,7 @@ void SceneImportSettings::_fill_material(Tree *p_tree, const Ref<Material> &p_ma
 	if (p_material->has_meta("import_id")) {
 		import_id = p_material->get_meta("import_id");
 		has_import_id = true;
-	} else if (p_material->get_name() != "") {
+	} else if (!p_material->get_name().is_empty()) {
 		import_id = p_material->get_name();
 		has_import_id = true;
 	} else {
@@ -148,7 +148,7 @@ void SceneImportSettings::_fill_mesh(Tree *p_tree, const Ref<Mesh> &p_mesh, Tree
 	if (p_mesh->has_meta("import_id")) {
 		import_id = p_mesh->get_meta("import_id");
 		has_import_id = true;
-	} else if (p_mesh->get_name() != String()) {
+	} else if (!p_mesh->get_name().is_empty()) {
 		import_id = p_mesh->get_name();
 		has_import_id = true;
 	} else {
@@ -414,7 +414,7 @@ void SceneImportSettings::_update_camera() {
 	float rot_y = cam_rot_y;
 	float zoom = cam_zoom;
 
-	if (selected_type == "Node" || selected_type == "") {
+	if (selected_type == "Node" || selected_type.is_empty()) {
 		camera_aabb = contents_aabb;
 	} else {
 		if (mesh_preview->get_mesh().is_valid()) {

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -525,7 +525,7 @@ void ImportDock::_reimport() {
 			Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
 			ERR_CONTINUE(!importer.is_valid());
 			String group_file_property = importer->get_option_group_file();
-			if (group_file_property != String()) {
+			if (!group_file_property.is_empty()) {
 				//can import from a group (as in, atlas)
 				ERR_CONTINUE(!params->values.has(group_file_property));
 				String group_file = params->values[group_file_property];

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -312,7 +312,7 @@ void InspectorDock::_prepare_history() {
 			Resource *r = Object::cast_to<Resource>(obj);
 			if (r->get_path().is_resource_file()) {
 				text = r->get_path().get_file();
-			} else if (r->get_name() != String()) {
+			} else if (!r->get_name().is_empty()) {
 				text = r->get_name();
 			} else {
 				text = r->get_class();
@@ -460,7 +460,7 @@ void InspectorDock::open_resource(const String &p_type) {
 
 void InspectorDock::set_warning(const String &p_message) {
 	warning->hide();
-	if (p_message != String()) {
+	if (!p_message.is_empty()) {
 		warning->show();
 		warning_dialog->set_text(p_message);
 	}

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -75,7 +75,7 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 			ur->add_do_property(n, name, path);
 		} else {
 			Variant new_value;
-			if (p_field == "") {
+			if (p_field.is_empty()) {
 				// whole value
 				new_value = p_value;
 			} else {

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -552,7 +552,7 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 
 		if (error != error_label->get_text()) {
 			error_label->set_text(error);
-			if (error != String()) {
+			if (!error.is_empty()) {
 				error_panel->show();
 			} else {
 				error_panel->hide();

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -761,7 +761,7 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 
 		if (error != error_label->get_text()) {
 			error_label->set_text(error);
-			if (error != String()) {
+			if (!error.is_empty()) {
 				error_panel->show();
 			} else {
 				error_panel->hide();

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -292,7 +292,7 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 		anode = EditorSettings::get_singleton()->get_resource_clipboard();
 		ERR_FAIL_COND(!anode.is_valid());
 		base_name = anode->get_class();
-	} else if (add_options[p_idx].type != String()) {
+	} else if (!add_options[p_idx].type.is_empty()) {
 		AnimationNode *an = Object::cast_to<AnimationNode>(ClassDB::instantiate(add_options[p_idx].type));
 		ERR_FAIL_COND(!an);
 		anode = Ref<AnimationNode>(an);
@@ -600,7 +600,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 		String accum;
 		for (int i = 0; i < path.get_name_count(); i++) {
 			String name = path.get_name(i);
-			if (accum != String()) {
+			if (!accum.is_empty()) {
 				accum += "/";
 			}
 			accum += name;
@@ -752,7 +752,7 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 
 		if (error != error_label->get_text()) {
 			error_label->set_text(error);
-			if (error != String()) {
+			if (!error.is_empty()) {
 				error_panel->show();
 			} else {
 				error_panel->hide();
@@ -821,13 +821,13 @@ AnimationNodeBlendTreeEditor *AnimationNodeBlendTreeEditor::singleton = nullptr;
 
 void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<AnimationNode> p_node) {
 	String prev_name = blend_tree->get_node_name(p_node);
-	ERR_FAIL_COND(prev_name == String());
+	ERR_FAIL_COND(prev_name.is_empty());
 	GraphNode *gn = Object::cast_to<GraphNode>(graph->get_node(prev_name));
 	ERR_FAIL_COND(!gn);
 
 	const String &new_name = p_text;
 
-	ERR_FAIL_COND(new_name == "" || new_name.find(".") != -1 || new_name.find("/") != -1);
+	ERR_FAIL_COND(new_name.is_empty() || new_name.find(".") != -1 || new_name.find("/") != -1);
 
 	if (new_name == prev_name) {
 		return; //nothing to do

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -190,7 +190,7 @@ void AnimationPlayerEditor::_play_pressed() {
 		current = animation->get_item_text(animation->get_selected());
 	}
 
-	if (current != "") {
+	if (!current.is_empty()) {
 		if (current == player->get_assigned_animation()) {
 			player->stop(); //so it won't blend with itself
 		}
@@ -207,7 +207,7 @@ void AnimationPlayerEditor::_play_from_pressed() {
 		current = animation->get_item_text(animation->get_selected());
 	}
 
-	if (current != "") {
+	if (!current.is_empty()) {
 		float time = player->get_current_animation_position();
 
 		if (current == player->get_assigned_animation() && player->is_playing()) {
@@ -228,7 +228,7 @@ void AnimationPlayerEditor::_play_bw_pressed() {
 		current = animation->get_item_text(animation->get_selected());
 	}
 
-	if (current != "") {
+	if (!current.is_empty()) {
 		if (current == player->get_assigned_animation()) {
 			player->stop(); //so it won't blend with itself
 		}
@@ -245,7 +245,7 @@ void AnimationPlayerEditor::_play_bw_from_pressed() {
 		current = animation->get_item_text(animation->get_selected());
 	}
 
-	if (current != "") {
+	if (!current.is_empty()) {
 		float time = player->get_current_animation_position();
 		if (current == player->get_assigned_animation()) {
 			player->stop(); //so it won't blend with itself
@@ -280,7 +280,7 @@ void AnimationPlayerEditor::_animation_selected(int p_which) {
 		current = animation->get_item_text(animation->get_selected());
 	}
 
-	if (current != "") {
+	if (!current.is_empty()) {
 		player->set_assigned_animation(current);
 
 		Ref<Animation> anim = player->get_animation(current);
@@ -397,7 +397,7 @@ void AnimationPlayerEditor::_animation_save_as(const Ref<Resource> &p_resource) 
 
 	String path;
 	//file->set_current_path(current_path);
-	if (p_resource->get_path() != "") {
+	if (!p_resource->get_path().is_empty()) {
 		path = p_resource->get_path();
 		if (extensions.size()) {
 			if (extensions.find(p_resource->get_path().get_extension().to_lower()) == nullptr) {
@@ -406,7 +406,7 @@ void AnimationPlayerEditor::_animation_save_as(const Ref<Resource> &p_resource) 
 		}
 	} else {
 		if (extensions.size()) {
-			if (p_resource->get_name() != "") {
+			if (!p_resource->get_name().is_empty()) {
 				path = p_resource->get_name() + "." + extensions.front()->get().to_lower();
 			} else {
 				String resource_name_snake_case = p_resource->get_class().camelcase_to_underscore();
@@ -486,7 +486,7 @@ void AnimationPlayerEditor::_animation_name_edited() {
 	player->stop();
 
 	String new_name = name->get_text();
-	if (new_name == "" || new_name.find(":") != -1 || new_name.find("/") != -1) {
+	if (new_name.is_empty() || new_name.find(":") != -1 || new_name.find("/") != -1) {
 		error_dialog->set_text(TTR("Invalid animation name!"));
 		error_dialog->popup_centered();
 		return;
@@ -720,7 +720,7 @@ void AnimationPlayerEditor::_animation_edit() {
 
 void AnimationPlayerEditor::_save_animation(String p_file) {
 	String current = animation->get_item_text(animation->get_selected());
-	if (current != "") {
+	if (!current.is_empty()) {
 		Ref<Animation> anim = player->get_animation(current);
 
 		ERR_FAIL_COND(!Object::cast_to<Resource>(*anim));
@@ -1007,7 +1007,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set, bool 
 
 	updating = true;
 	String current = player->get_assigned_animation();
-	if (current == "" || !player->has_animation(current)) {
+	if (current.is_empty() || !player->has_animation(current)) {
 		updating = false;
 		current = "";
 		return;
@@ -1086,7 +1086,7 @@ void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 	}
 
 	Ref<Animation> anim;
-	if (current != String()) {
+	if (!current.is_empty()) {
 		anim = player->get_animation(current);
 	}
 
@@ -1141,7 +1141,7 @@ void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 			}
 
 			String name = anim2->get_name();
-			if (name == "") {
+			if (name.is_empty()) {
 				name = TTR("Pasted Animation");
 			}
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -438,7 +438,7 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 		return;
 	}
 
-	if (base_name == String()) {
+	if (base_name.is_empty()) {
 		base_name = node->get_class().replace_first("AnimationNode", "");
 	}
 
@@ -927,7 +927,7 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 
 		if (error != error_label->get_text()) {
 			error_label->set_text(error);
-			if (error != String()) {
+			if (!error.is_empty()) {
 				error_panel->show();
 			} else {
 				error_panel->hide();
@@ -1059,7 +1059,7 @@ void AnimationNodeStateMachineEditor::_removed_from_graph() {
 void AnimationNodeStateMachineEditor::_name_edited(const String &p_text) {
 	const String &new_name = p_text;
 
-	ERR_FAIL_COND(new_name == "" || new_name.find(".") != -1 || new_name.find("/") != -1);
+	ERR_FAIL_COND(new_name.is_empty() || new_name.find(".") != -1 || new_name.find("/") != -1);
 
 	if (new_name == prev_name) {
 		return; // Nothing to do.

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -343,7 +343,7 @@ void EditorAssetLibraryItemDownload::_http_download_completed(int p_status, int 
 			if (p_code != 200) {
 				error_text = TTR("Request failed, return code:") + " " + itos(p_code);
 				status->set_text(TTR("Failed:") + " " + itos(p_code));
-			} else if (sha256 != "") {
+			} else if (!sha256.is_empty()) {
 				String download_sha256 = FileAccess::get_sha256(download->get_download_file());
 				if (sha256 != download_sha256) {
 					error_text = TTR("Bad download hash, assuming file has been tampered with.") + "\n";
@@ -354,7 +354,7 @@ void EditorAssetLibraryItemDownload::_http_download_completed(int p_status, int 
 		} break;
 	}
 
-	if (error_text != String()) {
+	if (!error_text.is_empty()) {
 		download_error->set_text(TTR("Asset Download Error:") + "\n" + error_text);
 		download_error->popup_centered();
 		// Let the user retry the download.
@@ -921,7 +921,7 @@ void EditorAssetLibrary::_search(int p_page) {
 			support_list += String(support_key[i]) + "+";
 		}
 	}
-	if (support_list != String()) {
+	if (!support_list.is_empty()) {
 		args += "&support=" + support_list.substr(0, support_list.length() - 1);
 	}
 
@@ -934,7 +934,7 @@ void EditorAssetLibrary::_search(int p_page) {
 		args += "&reverse=true";
 	}
 
-	if (filter->get_text() != String()) {
+	if (!filter->get_text().is_empty()) {
 		args += "&filter=" + filter->get_text().uri_encode();
 	}
 
@@ -1187,7 +1187,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 			library_vb->add_child(asset_bottom_page);
 
 			if (result.is_empty()) {
-				if (filter->get_text() != String()) {
+				if (!filter->get_text().is_empty()) {
 					library_error->set_text(
 							vformat(TTR("No results for \"%s\"."), filter->get_text()));
 				} else {
@@ -1218,7 +1218,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 				item->connect("author_selected", callable_mp(this, &EditorAssetLibrary::_select_author));
 				item->connect("category_selected", callable_mp(this, &EditorAssetLibrary::_select_category));
 
-				if (r.has("icon_url") && r["icon_url"] != "") {
+				if (r.has("icon_url") && !r["icon_url"].operator String().is_empty()) {
 					_request_image(item->get_instance_id(), r["icon_url"], IMAGE_QUEUE_ICON, 0);
 				}
 			}
@@ -1255,7 +1255,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 
 			description->configure(r["title"], r["asset_id"], category_map[r["category_id"]], r["category_id"], r["author"], r["author_id"], r["cost"], r["version"], r["version_string"], r["description"], r["download_url"], r["browse_url"], r["download_hash"]);
 
-			if (r.has("icon_url") && r["icon_url"] != "") {
+			if (r.has("icon_url") && !r["icon_url"].operator String().is_empty()) {
 				_request_image(description->get_instance_id(), r["icon_url"], IMAGE_QUEUE_ICON, 0);
 			}
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1460,7 +1460,7 @@ bool CanvasItemEditor::_gui_input_open_scene_on_double_click(const Ref<InputEven
 		List<CanvasItem *> selection = _get_edited_canvas_items();
 		if (selection.size() == 1) {
 			CanvasItem *canvas_item = selection[0];
-			if (canvas_item->get_scene_file_path() != "" && canvas_item != editor->get_edited_scene()) {
+			if (!canvas_item->get_scene_file_path().is_empty() && canvas_item != editor->get_edited_scene()) {
 				editor->open_request(canvas_item->get_scene_file_path());
 				return true;
 			}
@@ -5843,7 +5843,7 @@ bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, cons
 		return false;
 	}
 
-	if (editor->get_edited_scene()->get_scene_file_path() != "") { // cyclical instancing
+	if (!editor->get_edited_scene()->get_scene_file_path().is_empty()) { // cyclical instancing
 		if (_cyclical_dependency_exists(editor->get_edited_scene()->get_scene_file_path(), instantiated_scene)) {
 			memdelete(instantiated_scene);
 			return false;

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -477,7 +477,7 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size
 	}
 
 	String code = scr->get_source_code().strip_edges();
-	if (code == "") {
+	if (code.is_empty()) {
 		return Ref<Texture2D>();
 	}
 

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -34,7 +34,7 @@ void GPUParticlesCollisionSDF3DEditorPlugin::_bake() {
 	if (col_sdf) {
 		if (col_sdf->get_texture().is_null() || !col_sdf->get_texture()->get_path().is_resource_file()) {
 			String path = get_tree()->get_edited_scene_root()->get_scene_file_path();
-			if (path == String()) {
+			if (path.is_empty()) {
 				path = "res://" + col_sdf->get_name() + "_data.exr";
 			} else {
 				String ext = path.get_extension();

--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -44,10 +44,10 @@ void LightmapGIEditorPlugin::_bake_select_file(const String &p_file) {
 		switch (err) {
 			case LightmapGI::BAKE_ERROR_NO_SAVE_PATH: {
 				String scene_path = lightmap->get_scene_file_path();
-				if (scene_path == String()) {
+				if (scene_path.is_empty()) {
 					scene_path = lightmap->get_owner()->get_scene_file_path();
 				}
-				if (scene_path == String()) {
+				if (scene_path.is_empty()) {
 					EditorNode::get_singleton()->show_warning(TTR("Can't determine a save path for lightmap images.\nSave your scene and try again."));
 					break;
 				}

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -61,7 +61,7 @@ void MeshLibraryEditor::_menu_update_confirm(bool p_apply_xforms) {
 	cd_update->hide();
 	apply_xforms = p_apply_xforms;
 	String existing = mesh_library->get_meta("_editor_source_scene");
-	ERR_FAIL_COND(existing == "");
+	ERR_FAIL_COND(existing.is_empty());
 	_import_scene_cbk(existing);
 }
 

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -48,7 +48,7 @@ void MultiMeshEditor::_populate() {
 
 	Ref<Mesh> mesh;
 
-	if (mesh_source->get_text() == "") {
+	if (mesh_source->get_text().is_empty()) {
 		Ref<MultiMesh> multimesh;
 		multimesh = node->get_multimesh();
 		if (multimesh.is_null()) {
@@ -89,7 +89,7 @@ void MultiMeshEditor::_populate() {
 		}
 	}
 
-	if (surface_source->get_text() == "") {
+	if (surface_source->get_text().is_empty()) {
 		err_dialog->set_text(TTR("No surface source specified."));
 		err_dialog->popup_centered();
 		return;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4080,7 +4080,7 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 		return false;
 	}
 
-	if (editor->get_edited_scene()->get_scene_file_path() != "") { // cyclical instancing
+	if (!editor->get_edited_scene()->get_scene_file_path().is_empty()) { // cyclical instancing
 		if (_cyclical_dependency_exists(editor->get_edited_scene()->get_scene_file_path(), instantiated_scene)) {
 			memdelete(instantiated_scene);
 			return false;

--- a/editor/plugins/occluder_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.cpp
@@ -42,10 +42,10 @@ void OccluderInstance3DEditorPlugin::_bake_select_file(const String &p_file) {
 		switch (err) {
 			case OccluderInstance3D::BAKE_ERROR_NO_SAVE_PATH: {
 				String scene_path = occluder_instance->get_scene_file_path();
-				if (scene_path == String()) {
+				if (scene_path.is_empty()) {
 					scene_path = occluder_instance->get_owner()->get_scene_file_path();
 				}
-				if (scene_path == String()) {
+				if (scene_path.is_empty()) {
 					EditorNode::get_singleton()->show_warning(TTR("Can't determine a save path for the occluder.\nSave your scene and try again."));
 					break;
 				}

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -170,7 +170,7 @@ void Polygon2DEditor::_update_bone_list() {
 		if (np.get_name_count()) {
 			name = np.get_name(np.get_name_count() - 1);
 		}
-		if (name == String()) {
+		if (name.is_empty()) {
 			name = "Bone " + itos(i);
 		}
 		cb->set_text(name);

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -110,7 +110,7 @@ void ResourcePreloaderEditor::_item_edited() {
 			return;
 		}
 
-		if (new_name == "" || new_name.find("\\") != -1 || new_name.find("/") != -1 || preloader->has_resource(new_name)) {
+		if (new_name.is_empty() || new_name.find("\\") != -1 || new_name.find("/") != -1 || preloader->has_resource(new_name)) {
 			s->set_text(0, old_name);
 			return;
 		}
@@ -147,10 +147,10 @@ void ResourcePreloaderEditor::_paste_pressed() {
 	}
 
 	String name = r->get_name();
-	if (name == "") {
+	if (name.is_empty()) {
 		name = r->get_path().get_file();
 	}
-	if (name == "") {
+	if (name.is_empty()) {
 		name = r->get_class();
 	}
 
@@ -300,7 +300,7 @@ void ResourcePreloaderEditor::drop_data_fw(const Point2 &p_point, const Variant 
 
 		if (r.is_valid()) {
 			String basename;
-			if (r->get_name() != "") {
+			if (!r->get_name().is_empty()) {
 				basename = r->get_name();
 			} else if (r->get_path().is_resource_file()) {
 				basename = r->get_path().get_basename();

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -89,7 +89,7 @@ void EditorPropertyRootMotion::_node_assign() {
 		String accum;
 		for (int i = 0; i < path.get_name_count(); i++) {
 			String name = path.get_name(i);
-			if (accum != String()) {
+			if (!accum.is_empty()) {
 				accum += "/";
 			}
 			accum += name;
@@ -277,7 +277,7 @@ bool EditorInspectorRootMotionPlugin::can_handle(Object *p_object) {
 bool EditorInspectorRootMotionPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide) {
 	if (p_path == "root_motion_track" && p_object->is_class("AnimationTree") && p_type == Variant::NODE_PATH) {
 		EditorPropertyRootMotion *editor = memnew(EditorPropertyRootMotion);
-		if (p_hint == PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE && p_hint_text != String()) {
+		if (p_hint == PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE && !p_hint_text.is_empty()) {
 			editor->setup(p_hint_text);
 		}
 		add_property_editor(p_path, editor);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -179,7 +179,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		for (const String &comment : comments) {
 			String beg = comment.get_slice(" ", 0);
 			String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
-			highlighter->add_color_region(beg, end, comment_color, end == "");
+			highlighter->add_color_region(beg, end, comment_color, end.is_empty());
 		}
 
 		/* Strings */
@@ -189,7 +189,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		for (const String &string : strings) {
 			String beg = string.get_slice(" ", 0);
 			String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
-			highlighter->add_color_region(beg, end, string_color, end == "");
+			highlighter->add_color_region(beg, end, string_color, end.is_empty());
 		}
 	}
 }
@@ -321,7 +321,7 @@ void ScriptEditorQuickOpen::_update_search() {
 
 	for (int i = 0; i < functions.size(); i++) {
 		String file = functions[i];
-		if ((search_box->get_text() == "" || file.findn(search_box->get_text()) != -1)) {
+		if ((search_box->get_text().is_empty() || file.findn(search_box->get_text()) != -1)) {
 			TreeItem *ti = search_options->create_item(root);
 			ti->set_text(0, file);
 			if (root->get_first_child() == ti) {
@@ -392,7 +392,7 @@ ScriptEditor *ScriptEditor::script_editor = nullptr;
 
 String ScriptEditor::_get_debug_tooltip(const String &p_text, Node *_se) {
 	String val = EditorDebuggerNode::get_singleton()->get_var_value(p_text);
-	if (val != String()) {
+	if (!val.is_empty()) {
 		return p_text + ": " + val;
 	} else {
 		return String();
@@ -1679,7 +1679,7 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 
 		String base = script->get_path();
 		loaded_scripts.insert(base);
-		if (base.begins_with("local://") || base == "") {
+		if (base.begins_with("local://") || base.is_empty()) {
 			continue;
 		}
 
@@ -1831,7 +1831,7 @@ void ScriptEditor::_update_members_overview() {
 	for (int i = 0; i < functions.size(); i++) {
 		String filter = filter_methods->get_text();
 		String name = functions[i].get_slice(":", 0);
-		if (filter == "" || filter.is_subsequence_ofi(name)) {
+		if (filter.is_empty() || filter.is_subsequence_ofi(name)) {
 			members_overview->add_item(name);
 			members_overview->set_item_metadata(members_overview->get_item_count() - 1, functions[i].get_slice(":", 1).to_int() - 1);
 		}
@@ -2076,7 +2076,7 @@ void ScriptEditor::_update_script_names() {
 	Vector<_ScriptEditorItemData> sedata_filtered;
 	for (int i = 0; i < sedata.size(); i++) {
 		String filter = filter_scripts->get_text();
-		if (filter == "" || filter.is_subsequence_ofi(sedata[i].name)) {
+		if (filter.is_empty() || filter.is_subsequence_ofi(sedata[i].name)) {
 			sedata_filtered.push_back(sedata[i]);
 		}
 	}
@@ -2648,7 +2648,7 @@ void ScriptEditor::_editor_settings_changed() {
 
 	_update_autosave_timer();
 
-	if (current_theme == "") {
+	if (current_theme.is_empty()) {
 		current_theme = EditorSettings::get_singleton()->get("text_editor/theme/color_theme");
 	} else if (current_theme != String(EditorSettings::get_singleton()->get("text_editor/theme/color_theme"))) {
 		current_theme = EditorSettings::get_singleton()->get("text_editor/theme/color_theme");
@@ -2840,7 +2840,7 @@ bool ScriptEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data
 
 		for (int i = 0; i < files.size(); i++) {
 			String file = files[i];
-			if (file == "" || !FileAccess::exists(file)) {
+			if (file.is_empty() || !FileAccess::exists(file)) {
 				continue;
 			}
 			if (ResourceLoader::exists(file, "Script")) {
@@ -2920,7 +2920,7 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 		int num_tabs_before = tab_container->get_child_count();
 		for (int i = 0; i < files.size(); i++) {
 			String file = files[i];
-			if (file == "" || !FileAccess::exists(file)) {
+			if (file.is_empty() || !FileAccess::exists(file)) {
 				continue;
 			}
 
@@ -3126,7 +3126,7 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 
 	for (int i = 0; i < helps.size(); i++) {
 		String path = helps[i];
-		if (path == "") { // invalid, skip
+		if (path.is_empty()) { // invalid, skip
 			continue;
 		}
 		_help_class_open(path);
@@ -3197,7 +3197,7 @@ void ScriptEditor::get_window_layout(Ref<ConfigFile> p_layout) {
 }
 
 void ScriptEditor::_help_class_open(const String &p_class) {
-	if (p_class == "") {
+	if (p_class.is_empty()) {
 		return;
 	}
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -205,7 +205,7 @@ void ScriptTextEditor::_set_theme_for_script() {
 		String beg = string.get_slice(" ", 0);
 		String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
 		if (!text_edit->has_string_delimiter(beg)) {
-			text_edit->add_string_delimiter(beg, end, end == "");
+			text_edit->add_string_delimiter(beg, end, end.is_empty());
 		}
 
 		if (!end.is_empty() && !text_edit->has_auto_brace_completion_open_key(beg)) {
@@ -219,7 +219,7 @@ void ScriptTextEditor::_set_theme_for_script() {
 	for (const String &comment : comments) {
 		String beg = comment.get_slice(" ", 0);
 		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
-		text_edit->add_comment_delimiter(beg, end, end == "");
+		text_edit->add_comment_delimiter(beg, end, end.is_empty());
 
 		if (!end.is_empty() && !text_edit->has_auto_brace_completion_open_key(beg)) {
 			text_edit->add_auto_brace_completion_pair(beg, end);
@@ -381,7 +381,7 @@ String ScriptTextEditor::get_name() {
 		name = TTR("[unsaved]");
 	} else if (script->is_built_in()) {
 		const String &script_name = script->get_name();
-		if (script_name != "") {
+		if (!script_name.is_empty()) {
 			// If the built-in script has a custom resource name defined,
 			// display the built-in script name as follows: `ResourceName (scene_file.tscn)`
 			name = vformat("%s (%s)", script_name, name.get_slice("::", 0));
@@ -990,7 +990,7 @@ void ScriptTextEditor::_gutter_clicked(int p_line, int p_gutter) {
 	}
 
 	String method = code_editor->get_text_editor()->get_line_gutter_metadata(p_line, p_gutter);
-	if (method == "") {
+	if (method.is_empty()) {
 		return;
 	}
 
@@ -1137,7 +1137,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 
 				if (expression.parse(line) == OK) {
 					Variant result = expression.execute(Array(), Variant(), false);
-					if (expression.get_error_text() == "") {
+					if (expression.get_error_text().is_empty()) {
 						results.push_back(whitespace + result.get_construct_string());
 					} else {
 						results.push_back(line);
@@ -1263,19 +1263,19 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		} break;
 		case HELP_CONTEXTUAL: {
 			String text = tx->get_selected_text();
-			if (text == "") {
+			if (text.is_empty()) {
 				text = tx->get_word_under_caret();
 			}
-			if (text != "") {
+			if (!text.is_empty()) {
 				emit_signal(SNAME("request_help"), text);
 			}
 		} break;
 		case LOOKUP_SYMBOL: {
 			String text = tx->get_word_under_caret();
-			if (text == "") {
+			if (text.is_empty()) {
 				text = tx->get_selected_text();
 			}
-			if (text != "") {
+			if (!text.is_empty()) {
 				_lookup_symbol(text, tx->get_caret_line(), tx->get_caret_column());
 			}
 		} break;
@@ -1560,10 +1560,10 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 		}
 
 		String word_at_pos = tx->get_word_at_pos(local_pos);
-		if (word_at_pos == "") {
+		if (word_at_pos.is_empty()) {
 			word_at_pos = tx->get_word_under_caret();
 		}
-		if (word_at_pos == "") {
+		if (word_at_pos.is_empty()) {
 			word_at_pos = tx->get_selected_text();
 		}
 

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -97,7 +97,7 @@ void ShaderFileEditor::_version_selected(int p_option) {
 
 	error_text->push_font(get_theme_font(SNAME("source"), SNAME("EditorFonts")));
 
-	if (error == String()) {
+	if (error.is_empty()) {
 		error_text->add_text(TTR("Shader stage compiled without errors."));
 	} else {
 		error_text->add_text(error);
@@ -107,7 +107,7 @@ void ShaderFileEditor::_version_selected(int p_option) {
 void ShaderFileEditor::_update_options() {
 	ERR_FAIL_COND(shader_file.is_null());
 
-	if (shader_file->get_base_error() != String()) {
+	if (!shader_file->get_base_error().is_empty()) {
 		stage_hb->hide();
 		versions->hide();
 		error_text->clear();
@@ -136,7 +136,7 @@ void ShaderFileEditor::_update_options() {
 
 	for (int i = 0; i < version_list.size(); i++) {
 		String title = version_list[i];
-		if (title == "") {
+		if (title.is_empty()) {
 			title = "default";
 		}
 
@@ -148,7 +148,7 @@ void ShaderFileEditor::_update_options() {
 		bool failed = false;
 		for (int j = 0; j < RD::SHADER_STAGE_MAX; j++) {
 			String error = bytecode->get_stage_compile_error(RD::ShaderStage(j));
-			if (error != String()) {
+			if (!error.is_empty()) {
 				failed = true;
 			}
 		}
@@ -182,7 +182,7 @@ void ShaderFileEditor::_update_options() {
 	for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
 		Vector<uint8_t> bc = bytecode->get_stage_bytecode(RD::ShaderStage(i));
 		String error = bytecode->get_stage_compile_error(RD::ShaderStage(i));
-		bool disable = error == String() && bc.is_empty();
+		bool disable = error.is_empty() && bc.is_empty();
 		stages[i]->set_disabled(disable);
 		if (!disable) {
 			if (stages[i]->is_pressed()) {

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -71,7 +71,7 @@ String TextEditor::get_name() {
 		name = TTR("[unsaved]");
 	} else if (text_file->is_built_in()) {
 		const String &text_file_name = text_file->get_name();
-		if (text_file_name != "") {
+		if (!text_file_name.is_empty()) {
 			// If the built-in text_file has a custom resource name defined,
 			// display the built-in text_file name as follows: `ResourceName (scene_file.tscn)`
 			name = vformat("%s (%s)", text_file_name, name.get_slice("::", 0));

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -266,7 +266,7 @@ void VersionControlEditorPlugin::_display_file_diff(String p_file_path) {
 
 void VersionControlEditorPlugin::_refresh_file_diff() {
 	String open_file = diff_file_name->get_text();
-	if (open_file != "") {
+	if (!open_file.is_empty()) {
 		_display_file_diff(diff_file_name->get_text());
 	}
 }
@@ -299,7 +299,7 @@ void VersionControlEditorPlugin::_update_commit_status() {
 }
 
 void VersionControlEditorPlugin::_update_commit_button() {
-	commit_button->set_disabled(commit_message->get_text().strip_edges() == "");
+	commit_button->set_disabled(commit_message->get_text().strip_edges().is_empty());
 }
 
 void VersionControlEditorPlugin::_commit_message_gui_input(const Ref<InputEvent> &p_event) {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -591,7 +591,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 
 		if (vsnode->is_use_prop_slots()) {
 			String error = vsnode->get_warning(visual_shader->get_mode(), p_type);
-			if (error != String()) {
+			if (!error.is_empty()) {
 				Label *error_label = memnew(Label);
 				error_label->add_theme_color_override("font_color", VisualShaderEditor::get_singleton()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 				error_label->set_text(error);
@@ -877,7 +877,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 	node->add_child(offset);
 
 	String error = vsnode->get_warning(visual_shader->get_mode(), p_type);
-	if (error != String()) {
+	if (!error.is_empty()) {
 		Label *error_label = memnew(Label);
 		error_label->add_theme_color_override("font_color", VisualShaderEditor::get_singleton()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		error_label->set_text(error);
@@ -1191,7 +1191,7 @@ void VisualShaderEditor::update_custom_nodes() {
 			category = category.rstrip("/");
 			category = category.lstrip("/");
 			category = "Addons/" + category;
-			if (subcategory != "") {
+			if (!subcategory.is_empty()) {
 				category += "/" + subcategory;
 			}
 
@@ -1687,7 +1687,7 @@ void VisualShaderEditor::_change_input_port_name(const String &p_text, Object *p
 	ERR_FAIL_COND(!line_edit);
 
 	String validated_name = visual_shader->validate_port_name(p_text, node.ptr(), p_port_id, false);
-	if (validated_name == String() || prev_name == validated_name) {
+	if (validated_name.is_empty() || prev_name == validated_name) {
 		line_edit->set_text(node->get_input_port_name(p_port_id));
 		return;
 	}
@@ -1715,7 +1715,7 @@ void VisualShaderEditor::_change_output_port_name(const String &p_text, Object *
 	ERR_FAIL_COND(!line_edit);
 
 	String validated_name = visual_shader->validate_port_name(p_text, node.ptr(), p_port_id, true);
-	if (validated_name == String() || prev_name == validated_name) {
+	if (validated_name.is_empty() || prev_name == validated_name) {
 		line_edit->set_text(node->get_output_port_name(p_port_id));
 		return;
 	}
@@ -2410,7 +2410,7 @@ void VisualShaderEditor::_add_node(int p_idx, int p_op_idx, String p_resource_pa
 
 	bool is_custom = add_options[p_idx].is_custom;
 
-	if (!is_custom && add_options[p_idx].type != String()) {
+	if (!is_custom && !add_options[p_idx].type.is_empty()) {
 		VisualShaderNode *vsn = Object::cast_to<VisualShaderNode>(ClassDB::instantiate(add_options[p_idx].type));
 		ERR_FAIL_COND(!vsn);
 

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -34,7 +34,7 @@ void VoxelGIEditorPlugin::_bake() {
 	if (voxel_gi) {
 		if (voxel_gi->get_probe_data().is_null()) {
 			String path = get_tree()->get_edited_scene_root()->get_scene_file_path();
-			if (path == String()) {
+			if (path.is_empty()) {
 				path = "res://" + voxel_gi->get_name() + "_data.res";
 			} else {
 				String ext = path.get_extension();

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -178,7 +178,7 @@ void ProjectExportDialog::_update_export_all() {
 		Ref<EditorExportPreset> preset = EditorExport::get_singleton()->get_export_preset(i);
 		bool needs_templates;
 		String error;
-		if (preset->get_export_path() == "" || !preset->get_platform()->can_export(preset, error, needs_templates)) {
+		if (preset->get_export_path().is_empty() || !preset->get_platform()->can_export(preset, error, needs_templates)) {
 			can_export = false;
 			break;
 		}
@@ -244,7 +244,7 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 	bool needs_templates;
 	String error;
 	if (!current->get_platform()->can_export(current, error, needs_templates)) {
-		if (error != String()) {
+		if (!error.is_empty()) {
 			Vector<String> items = error.split("\n", false);
 			error = "";
 			for (int i = 0; i < items.size(); i++) {
@@ -336,7 +336,7 @@ void ProjectExportDialog::_update_feature_list() {
 	Vector<String> custom_list = custom.split(",");
 	for (int i = 0; i < custom_list.size(); i++) {
 		String f = custom_list[i].strip_edges();
-		if (f != String()) {
+		if (!f.is_empty()) {
 			features.push_back(f);
 		}
 	}
@@ -871,7 +871,7 @@ void ProjectExportDialog::_open_export_template_manager() {
 
 void ProjectExportDialog::_validate_export_path(const String &p_path) {
 	// Disable export via OK button or Enter key if LineEdit has an empty filename
-	bool invalid_path = (p_path.get_file().get_basename() == "");
+	bool invalid_path = (p_path.get_file().get_basename().is_empty());
 
 	// Check if state change before needlessly messing with signals
 	if (invalid_path && export_project->get_ok_button()->is_disabled()) {
@@ -904,7 +904,7 @@ void ProjectExportDialog::_export_project() {
 		export_project->add_filter("*." + extension_list[i] + " ; " + platform->get_name() + " Export");
 	}
 
-	if (current->get_export_path() != "") {
+	if (!current->get_export_path().is_empty()) {
 		export_project->set_current_path(current->get_export_path());
 	} else {
 		if (extension_list.size() >= 1) {
@@ -1292,10 +1292,10 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	default_filename = EditorSettings::get_singleton()->get_project_metadata("export_options", "default_filename", "");
 	// If no default set, use project name
-	if (default_filename == "") {
+	if (default_filename.is_empty()) {
 		// If no project name defined, use a sane default
 		default_filename = ProjectSettings::get_singleton()->get("application/config/name");
-		if (default_filename == "") {
+		if (default_filename.is_empty()) {
 			default_filename = "UnnamedProject";
 		}
 	}

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -161,7 +161,7 @@ private:
 			}
 		}
 
-		if (valid_path == "") {
+		if (valid_path.is_empty()) {
 			set_message(TTR("The path specified doesn't exist."), MESSAGE_ERROR);
 			memdelete(d);
 			get_ok_button()->set_disabled(true);
@@ -175,7 +175,7 @@ private:
 				valid_install_path = install_path->get_text().strip_edges();
 			}
 
-			if (valid_install_path == "") {
+			if (valid_install_path.is_empty()) {
 				set_message(TTR("The path specified doesn't exist."), MESSAGE_ERROR, INSTALL_PATH);
 				memdelete(d);
 				get_ok_button()->set_disabled(true);
@@ -184,7 +184,7 @@ private:
 		}
 
 		if (mode == MODE_IMPORT || mode == MODE_RENAME) {
-			if (valid_path != "" && !d->file_exists("project.godot")) {
+			if (!valid_path.is_empty() && !d->file_exists("project.godot")) {
 				if (valid_path.ends_with(".zip")) {
 					FileAccess *src_f = nullptr;
 					zlib_filefunc_def io = zipio_create_io_from_file(&src_f);
@@ -225,7 +225,7 @@ private:
 					d->list_dir_begin();
 					is_folder_empty = true;
 					String n = d->get_next();
-					while (n != String()) {
+					while (!n.is_empty()) {
 						if (!n.begins_with(".")) {
 							// Allow `.`, `..` (reserved current/parent folder names)
 							// and hidden files/folders to be present.
@@ -265,7 +265,7 @@ private:
 			d->list_dir_begin();
 			is_folder_empty = true;
 			String n = d->get_next();
-			while (n != String()) {
+			while (!n.is_empty()) {
 				if (!n.begins_with(".")) {
 					// Allow `.`, `..` (reserved current/parent folder names)
 					// and hidden files/folders to be present.
@@ -295,16 +295,16 @@ private:
 
 	void _path_text_changed(const String &p_path) {
 		String sp = _test_path();
-		if (sp != "") {
+		if (!sp.is_empty()) {
 			// If the project name is empty or default, infer the project name from the selected folder name
-			if (project_name->get_text().strip_edges() == "" || project_name->get_text().strip_edges() == TTR("New Game Project")) {
+			if (project_name->get_text().strip_edges().is_empty() || project_name->get_text().strip_edges() == TTR("New Game Project")) {
 				sp = sp.replace("\\", "/");
 				int lidx = sp.rfind("/");
 
 				if (lidx != -1) {
 					sp = sp.substr(lidx + 1, sp.length()).capitalize();
 				}
-				if (sp == "" && mode == MODE_IMPORT) {
+				if (sp.is_empty() && mode == MODE_IMPORT) {
 					sp = TTR("Imported Project");
 				}
 
@@ -313,7 +313,7 @@ private:
 			}
 		}
 
-		if (created_folder_path != "" && created_folder_path != p_path) {
+		if (!created_folder_path.is_empty() && created_folder_path != p_path) {
 			_remove_created_folder();
 		}
 	}
@@ -382,7 +382,7 @@ private:
 
 	void _create_folder() {
 		const String project_name_no_edges = project_name->get_text().strip_edges();
-		if (project_name_no_edges == "" || created_folder_path != "" || project_name_no_edges.ends_with(".")) {
+		if (project_name_no_edges.is_empty() || !created_folder_path.is_empty() || project_name_no_edges.ends_with(".")) {
 			set_message(TTR("Invalid project name."), MESSAGE_WARNING);
 			return;
 		}
@@ -417,7 +417,7 @@ private:
 
 		_test_path();
 
-		if (p_text.strip_edges() == "") {
+		if (p_text.strip_edges().is_empty()) {
 			set_message(TTR("It would be a good idea to name your project."), MESSAGE_ERROR);
 		}
 	}
@@ -432,7 +432,7 @@ private:
 
 		if (mode == MODE_RENAME) {
 			String dir2 = _test_path();
-			if (dir2 == "") {
+			if (dir2.is_empty()) {
 				set_message(TTR("Invalid project path (changed anything?)."), MESSAGE_ERROR);
 				return;
 			}
@@ -546,7 +546,7 @@ private:
 
 						String path = fname;
 
-						if (path == String() || path == zip_root || !zip_root.is_subsequence_of(path)) {
+						if (path.is_empty() || path == zip_root || !zip_root.is_subsequence_of(path)) {
 							//
 						} else if (path.ends_with("/")) { // a dir
 
@@ -617,7 +617,7 @@ private:
 	}
 
 	void _remove_created_folder() {
-		if (created_folder_path != "") {
+		if (!created_folder_path.is_empty()) {
 			DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 			d->remove(created_folder_path);
 			memdelete(d);
@@ -717,7 +717,7 @@ public:
 
 		} else {
 			fav_dir = EditorSettings::get_singleton()->get("filesystem/directories/default_project_path");
-			if (fav_dir != "") {
+			if (!fav_dir.is_empty()) {
 				project_path->set_text(fav_dir);
 				fdialog->set_current_dir(fav_dir);
 			} else {
@@ -1158,7 +1158,7 @@ void ProjectList::load_project_icon(int p_index) {
 
 	Ref<Texture2D> default_icon = get_theme_icon(SNAME("DefaultProjectIcon"), SNAME("EditorIcons"));
 	Ref<Texture2D> icon;
-	if (item.icon != "") {
+	if (!item.icon.is_empty()) {
 		Ref<Image> img;
 		img.instantiate();
 		Error err = img->load(item.icon.replace_first("res://", item.path + "/"));
@@ -1191,7 +1191,7 @@ ProjectList::Item ProjectList::load_project_data(const String &p_property_key, b
 	String project_name = TTR("Unnamed Project");
 	if (cf_err == OK) {
 		String cf_project_name = static_cast<String>(cf->get_value("application", "config/name", ""));
-		if (cf_project_name != "") {
+		if (!cf_project_name.is_empty()) {
 			project_name = cf_project_name.xml_unescape();
 		}
 		config_version = (int)cf->get_value("", "config_version", 0);
@@ -1473,7 +1473,7 @@ void ProjectList::sort_projects() {
 		Item &item = _projects.write[i];
 
 		bool visible = true;
-		if (_search_term != "") {
+		if (!_search_term.is_empty()) {
 			String search_path;
 			if (_search_term.find("/") != -1) {
 				// Search path will match the whole path
@@ -1785,7 +1785,7 @@ void ProjectList::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
 	const Item &clicked_project = _projects[clicked_index];
 
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
-		if (mb->is_shift_pressed() && _selected_project_keys.size() > 0 && _last_clicked != "" && clicked_project.project_key != _last_clicked) {
+		if (mb->is_shift_pressed() && _selected_project_keys.size() > 0 && !_last_clicked.is_empty() && clicked_project.project_key != _last_clicked) {
 			int anchor_index = -1;
 			for (int i = 0; i < _projects.size(); ++i) {
 				const Item &p = _projects[i];
@@ -2193,7 +2193,7 @@ void ProjectManager::_run_project_confirm() {
 
 	for (int i = 0; i < selected_list.size(); ++i) {
 		const String &selected_main = selected_list[i].main_scene;
-		if (selected_main == "") {
+		if (selected_main.is_empty()) {
 			run_error_diag->set_text(TTR("Can't run project: no main scene defined.\nPlease edit the project and set the main scene in the Project Settings under the \"Application\" category."));
 			run_error_diag->popup_centered();
 			continue;
@@ -2246,7 +2246,7 @@ void ProjectManager::_scan_dir(const String &path, List<String> *r_projects) {
 	ERR_FAIL_COND_MSG(error != OK, "Could not scan directory at: " + path);
 	da->list_dir_begin();
 	String n = da->get_next();
-	while (n != String()) {
+	while (!n.is_empty()) {
 		if (da->current_is_dir() && !n.begins_with(".")) {
 			_scan_dir(da->get_current_dir().plus_file(n), r_projects);
 		} else if (n == "project.godot") {
@@ -2388,7 +2388,7 @@ void ProjectManager::_files_dropped(PackedStringArray p_files, int p_screen) {
 			if (dir->change_dir(folders[0]) == OK) {
 				dir->list_dir_begin();
 				String file = dir->get_next();
-				while (confirm && file != String()) {
+				while (confirm && !file.is_empty()) {
 					if (!dir->current_is_dir() && file.ends_with("project.godot")) {
 						confirm = false;
 					}
@@ -2826,7 +2826,7 @@ ProjectManager::ProjectManager() {
 	}
 
 	String autoscan_path = EditorSettings::get_singleton()->get("filesystem/directories/autoscan_project_path");
-	if (autoscan_path != "") {
+	if (!autoscan_path.is_empty()) {
 		if (dir_access->dir_exists(autoscan_path)) {
 			_scan_begin(autoscan_path);
 		} else {

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -78,7 +78,7 @@ void ProjectSettingsEditor::_advanced_toggled(bool p_button_pressed) {
 }
 
 void ProjectSettingsEditor::_setting_selected(const String &p_path) {
-	if (p_path == String()) {
+	if (p_path.is_empty()) {
 		return;
 	}
 
@@ -147,12 +147,12 @@ void ProjectSettingsEditor::_update_property_box() {
 	const Vector<String> t = setting.split(".", true, 1);
 	const String name = t[0];
 	const String feature = (t.size() == 2) ? t[1] : "";
-	bool feature_invalid = (t.size() == 2) && (t[1] == "");
+	bool feature_invalid = (t.size() == 2) && (t[1].is_empty());
 
 	add_button->set_disabled(true);
 	del_button->set_disabled(true);
 
-	if (feature != "") {
+	if (!feature.is_empty()) {
 		feature_invalid = true;
 		for (int i = 1; i < feature_box->get_item_count(); i++) {
 			if (feature == feature_box->get_item_text(i)) {
@@ -163,11 +163,11 @@ void ProjectSettingsEditor::_update_property_box() {
 		}
 	}
 
-	if (feature == "" || feature_invalid) {
+	if (feature.is_empty() || feature_invalid) {
 		feature_box->select(0);
 	}
 
-	if (property_box->get_text() == "") {
+	if (property_box->get_text().is_empty()) {
 		return;
 	}
 
@@ -244,7 +244,7 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 		Vector<String> custom_list = custom.split(",");
 		for (int j = 0; j < custom_list.size(); j++) {
 			String f = custom_list[j].strip_edges();
-			if (f != String()) {
+			if (!f.is_empty()) {
 				presets.insert(f);
 			}
 		}

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -482,7 +482,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				Vector<String> flags = hint_text.split(",");
 				for (int i = 0; i < flags.size(); i++) {
 					String flag = flags[i];
-					if (flag == "") {
+					if (flag.is_empty()) {
 						continue;
 					}
 					menu->add_check_item(flag, i);
@@ -552,7 +552,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 					add_child(create_dialog);
 				}
 
-				if (hint_text != String()) {
+				if (!hint_text.is_empty()) {
 					create_dialog->set_base_type(hint_text);
 				} else {
 					create_dialog->set_base_type("Object");
@@ -853,7 +853,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			if (p_name == "script" && hint_text == "Script" && Object::cast_to<Node>(owner)) {
 				menu->add_item(TTR("New Script"), OBJ_MENU_NEW_SCRIPT);
 				menu->add_separator();
-			} else if (hint_text != "") {
+			} else if (!hint_text.is_empty()) {
 				int idx = 0;
 
 				Vector<EditorData::CustomType> custom_resources;
@@ -933,7 +933,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			RES cb = EditorSettings::get_singleton()->get_resource_clipboard();
 			bool paste_valid = false;
 			if (cb.is_valid()) {
-				if (hint_text == "") {
+				if (hint_text.is_empty()) {
 					paste_valid = true;
 				} else {
 					for (int i = 0; i < hint_text.get_slice_count(","); i++) {
@@ -1108,7 +1108,7 @@ void CustomPropertyEditor::_node_path_selected(NodePath p_path) {
 		return;
 	}
 
-	if (hint == PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE && hint_text != String()) {
+	if (hint == PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE && !hint_text.is_empty()) {
 		Node *node = get_node(hint_text);
 		if (node) {
 			Node *tonode = node->get_node(p_path);
@@ -1191,7 +1191,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 
 					file->clear_filters();
 
-					if (hint_text != "") {
+					if (!hint_text.is_empty()) {
 						Vector<String> extensions = hint_text.split(",");
 						for (int i = 0; i < extensions.size(); i++) {
 							String filter = extensions[i];

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -181,7 +181,7 @@ void PropertySelector::_update_search() {
 				continue;
 			}
 
-			if (search_box->get_text() != String() && E.name.findn(search_text) == -1) {
+			if (!search_box->get_text().is_empty() && E.name.findn(search_text) == -1) {
 				continue;
 			}
 
@@ -194,7 +194,7 @@ void PropertySelector::_update_search() {
 			item->set_metadata(0, E.name);
 			item->set_icon(0, type_icons[E.type]);
 
-			if (!found && search_box->get_text() != String() && E.name.findn(search_text) != -1) {
+			if (!found && !search_box->get_text().is_empty() && E.name.findn(search_text) != -1) {
 				item->select(0);
 				found = true;
 			}
@@ -269,7 +269,7 @@ void PropertySelector::_update_search() {
 				continue;
 			}
 
-			if (search_box->get_text() != String() && name.findn(search_text) == -1) {
+			if (!search_box->get_text().is_empty() && name.findn(search_text) == -1) {
 				continue;
 			}
 
@@ -318,7 +318,7 @@ void PropertySelector::_update_search() {
 			item->set_metadata(0, name);
 			item->set_selectable(0, true);
 
-			if (!found && search_box->get_text() != String() && name.findn(search_text) != -1) {
+			if (!found && !search_box->get_text().is_empty() && name.findn(search_text) != -1) {
 				item->select(0);
 				found = true;
 			}
@@ -353,7 +353,7 @@ void PropertySelector::_item_selected() {
 	String class_type;
 	if (type != Variant::NIL) {
 		class_type = Variant::get_type_name(type);
-	} else if (base_type != String()) {
+	} else if (!base_type.is_empty()) {
 		class_type = base_type;
 	} else if (instance) {
 		class_type = instance->get_class();
@@ -362,7 +362,7 @@ void PropertySelector::_item_selected() {
 	DocTools *dd = EditorHelp::get_doc_data();
 	String text;
 	if (properties) {
-		while (class_type != String()) {
+		while (!class_type.is_empty()) {
 			Map<String, DocData::ClassDoc>::Element *E = dd->class_list.find(class_type);
 			if (E) {
 				for (int i = 0; i < E->get().properties.size(); i++) {
@@ -373,7 +373,7 @@ void PropertySelector::_item_selected() {
 				}
 			}
 
-			if (text != String()) {
+			if (!text.is_empty()) {
 				break;
 			}
 
@@ -381,7 +381,7 @@ void PropertySelector::_item_selected() {
 			class_type = ClassDB::get_parent_class(class_type);
 		}
 	} else {
-		while (class_type != String()) {
+		while (!class_type.is_empty()) {
 			Map<String, DocData::ClassDoc>::Element *E = dd->class_list.find(class_type);
 			if (E) {
 				for (int i = 0; i < E->get().methods.size(); i++) {
@@ -392,7 +392,7 @@ void PropertySelector::_item_selected() {
 				}
 			}
 
-			if (text != String()) {
+			if (!text.is_empty()) {
 				break;
 			}
 
@@ -401,7 +401,7 @@ void PropertySelector::_item_selected() {
 		}
 	}
 
-	if (text != String()) {
+	if (!text.is_empty()) {
 		// Display both property name and description, since the help bit may be displayed
 		// far away from the location (especially if the dialog was resized to be taller).
 		help_bit->set_text(vformat("[b]%s[/b]: %s", name, text));

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -79,7 +79,7 @@ void EditorQuickOpen::_build_search_cache(EditorFileSystemDirectory *p_efsd) {
 
 void EditorQuickOpen::_update_search() {
 	const String search_text = search_box->get_text();
-	const bool empty_search = search_text == "";
+	const bool empty_search = search_text.is_empty();
 
 	// Filter possible candidates.
 	Vector<Entry> entries;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -190,7 +190,7 @@ void SceneTreeDock::_perform_instantiate_scenes(const Vector<String> &p_files, N
 			break;
 		}
 
-		if (edited_scene->get_scene_file_path() != "") {
+		if (!edited_scene->get_scene_file_path().is_empty()) {
 			if (_cyclical_dependency_exists(edited_scene->get_scene_file_path(), instantiated_scene)) {
 				accept->set_text(vformat(TTR("Cannot instance the scene '%s' because the current scene exists within one of its nodes."), p_files[i]));
 				accept->popup_centered();
@@ -467,7 +467,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			bool has_cycle = false;
-			if (edited_scene->get_scene_file_path() != String()) {
+			if (!edited_scene->get_scene_file_path().is_empty()) {
 				for (Node *E : node_clipboard) {
 					if (edited_scene->get_scene_file_path() == E->get_scene_file_path()) {
 						has_cycle = true;
@@ -810,7 +810,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				return;
 			}
 
-			if (node->get_scene_file_path() != String()) {
+			if (!node->get_scene_file_path().is_empty()) {
 				accept->set_text(TTR("Instantiated scenes can't become root"));
 				accept->popup_centered();
 				return;
@@ -889,7 +889,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 					Node *node = remove_list[0];
 					if (node == editor_data->get_edited_scene_root()) {
 						msg = vformat(TTR("Delete the root node \"%s\"?"), node->get_name());
-					} else if (node->get_scene_file_path() == "" && node->get_child_count() > 0) {
+					} else if (node->get_scene_file_path().is_empty() && node->get_child_count() > 0) {
 						// Display this message only for non-instantiated scenes
 						msg = vformat(TTR("Delete node \"%s\" and its children?"), node->get_name());
 					} else {
@@ -936,7 +936,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			if (tocopy != editor_data->get_edited_scene_root() && tocopy->get_scene_file_path() != "") {
+			if (tocopy != editor_data->get_edited_scene_root() && !tocopy->get_scene_file_path().is_empty()) {
 				accept->set_text(TTR("Can't save the branch of an already instantiated scene.\nTo create a variation of a scene, you can make an inherited scene based on the instantiated scene using Scene > New Inherited Scene... instead."));
 				accept->popup_centered();
 				break;
@@ -1052,7 +1052,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 						break;
 					}
 
-					ERR_FAIL_COND(node->get_scene_file_path() == String());
+					ERR_FAIL_COND(node->get_scene_file_path().is_empty());
 					undo_redo->create_action(TTR("Make Local"));
 					undo_redo->add_do_method(node, "set_scene_file_path", "");
 					undo_redo->add_undo_method(node, "set_scene_file_path", node->get_scene_file_path());
@@ -1703,7 +1703,7 @@ bool SceneTreeDock::_validate_no_instance() {
 	List<Node *> selection = editor_selection->get_selected_node_list();
 
 	for (Node *E : selection) {
-		if (E != edited_scene && E->get_scene_file_path() != "") {
+		if (E != edited_scene && !E->get_scene_file_path().is_empty()) {
 			accept->set_text(TTR("This operation can't be done on instantiated scenes."));
 			accept->popup_centered();
 			return false;
@@ -2761,7 +2761,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 
 		bool can_replace = true;
 		for (Node *E : selection) {
-			if (E != edited_scene && (E->get_owner() != edited_scene || E->get_scene_file_path() != "")) {
+			if (E != edited_scene && (E->get_owner() != edited_scene || !E->get_scene_file_path().is_empty())) {
 				can_replace = false;
 				break;
 			}
@@ -2793,7 +2793,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			menu->add_icon_shortcut(get_theme_icon(SNAME("CopyNodePath"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/copy_node_path"), TOOL_COPY_NODE_PATH);
 		}
 
-		bool is_external = (selection[0]->get_scene_file_path() != "");
+		bool is_external = (!selection[0]->get_scene_file_path().is_empty());
 		if (is_external) {
 			bool is_inherited = selection[0]->get_scene_inherited_state() != nullptr;
 			bool is_top_level = selection[0]->get_owner() == nullptr;
@@ -2906,9 +2906,9 @@ void SceneTreeDock::attach_script_to_selected(bool p_extend) {
 	Ref<Script> existing = selected->get_script();
 
 	String path = selected->get_scene_file_path();
-	if (path == "") {
+	if (path.is_empty()) {
 		String root_path = editor_data->get_edited_scene_root()->get_scene_file_path();
-		if (root_path == "") {
+		if (root_path.is_empty()) {
 			path = String("res://").plus_file(selected->get_name());
 		} else {
 			path = root_path.get_base_dir().plus_file(selected->get_name());
@@ -2956,7 +2956,7 @@ void SceneTreeDock::attach_shader_to_selected(int p_preferred_mode) {
 	}
 
 	String path = selected_shader_material->get_path();
-	if (path == "") {
+	if (path.is_empty()) {
 		String root_path;
 		if (editor_data->get_edited_scene_root()) {
 			root_path = editor_data->get_edited_scene_root()->get_scene_file_path();
@@ -2967,7 +2967,7 @@ void SceneTreeDock::attach_shader_to_selected(int p_preferred_mode) {
 		} else {
 			shader_name = selected_shader_material->get_name();
 		}
-		if (root_path == "") {
+		if (root_path.is_empty()) {
 			path = String("res://").plus_file(shader_name);
 		} else {
 			path = root_path.get_base_dir().plus_file(shader_name);
@@ -3070,7 +3070,7 @@ void SceneTreeDock::_update_create_root_dialog() {
 			while (!f->eof_reached()) {
 				String l = f->get_line().strip_edges();
 
-				if (l != String()) {
+				if (!l.is_empty()) {
 					Button *button = memnew(Button);
 					favorite_nodes->add_child(button);
 					button->set_text(l);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -120,7 +120,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		undo_redo->commit_action();
 	} else if (p_id == BUTTON_WARNING) {
 		String config_err = n->get_configuration_warnings_as_string();
-		if (config_err == String()) {
+		if (config_err.is_empty()) {
 			return;
 		}
 		config_err = config_err.word_wrap(80);
@@ -297,16 +297,16 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		item->add_button(0, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
 
 		String tooltip = String(p_node->get_name()) + "\n" + TTR("Inherits:") + " " + p_node->get_scene_inherited_state()->get_path() + "\n" + TTR("Type:") + " " + p_node->get_class();
-		if (p_node->get_editor_description() != String()) {
+		if (!p_node->get_editor_description().is_empty()) {
 			tooltip += "\n\n" + p_node->get_editor_description();
 		}
 
 		item->set_tooltip(0, tooltip);
-	} else if (p_node != get_scene_node() && p_node->get_scene_file_path() != "" && can_open_instance) {
+	} else if (p_node != get_scene_node() && !p_node->get_scene_file_path().is_empty() && can_open_instance) {
 		item->add_button(0, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
 
 		String tooltip = String(p_node->get_name()) + "\n" + TTR("Instance:") + " " + p_node->get_scene_file_path() + "\n" + TTR("Type:") + " " + p_node->get_class();
-		if (p_node->get_editor_description() != String()) {
+		if (!p_node->get_editor_description().is_empty()) {
 			tooltip += "\n\n" + p_node->get_editor_description();
 		}
 
@@ -318,7 +318,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		}
 
 		String tooltip = String(p_node->get_name()) + "\n" + TTR("Type:") + " " + type;
-		if (p_node->get_editor_description() != String()) {
+		if (!p_node->get_editor_description().is_empty()) {
 			tooltip += "\n\n" + p_node->get_editor_description();
 		}
 
@@ -955,7 +955,7 @@ Variant SceneTreeEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from
 		Node *n = get_node(np);
 		if (n) {
 			// Only allow selection if not part of an instantiated scene.
-			if (!n->get_owner() || n->get_owner() == get_scene_node() || n->get_owner()->get_scene_file_path() == String()) {
+			if (!n->get_owner() || n->get_owner() == get_scene_node() || n->get_owner()->get_scene_file_path().is_empty()) {
 				selected.push_back(n);
 				icons.push_back(next->get_icon(0));
 			}
@@ -1069,7 +1069,7 @@ bool SceneTreeEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 		}
 	}
 
-	return String(d["type"]) == "nodes" && filter == String();
+	return String(d["type"]) == "nodes" && filter.is_empty();
 }
 
 void SceneTreeEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -101,7 +101,7 @@ void ScriptCreateDialog::config(const String &p_base_name, const String &p_base_
 	parent_name->set_text(p_base_name);
 	parent_name->deselect();
 
-	if (p_base_path != "") {
+	if (!p_base_path.is_empty()) {
 		initial_bp = p_base_path.get_basename();
 		file_path->set_text(initial_bp + "." + ScriptServer::get_language(language_menu->get_selected())->get_extension());
 		current_language = language_menu->get_selected();
@@ -163,10 +163,10 @@ bool ScriptCreateDialog::_validate_class(const String &p_string) {
 String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must_exist) {
 	String p = p_path.strip_edges();
 
-	if (p == "") {
+	if (p.is_empty()) {
 		return TTR("Path is empty.");
 	}
-	if (p.get_file().get_basename() == "") {
+	if (p.get_file().get_basename().is_empty()) {
 		return TTR("Filename is empty.");
 	}
 
@@ -227,7 +227,7 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 
 	/* Let ScriptLanguage do custom validation */
 	String path_error = ScriptServer::get_language(language_menu->get_selected())->validate_path(p);
-	if (path_error != "") {
+	if (!path_error.is_empty()) {
 		return path_error;
 	}
 
@@ -295,7 +295,7 @@ void ScriptCreateDialog::_create_new() {
 	String cname_param = _get_class_name();
 
 	Ref<Script> scr;
-	if (script_template != "") {
+	if (!script_template.is_empty()) {
 		scr = ResourceLoader::load(script_template);
 		if (scr.is_null()) {
 			alert->set_text(vformat(TTR("Error loading template '%s'"), script_template));
@@ -358,7 +358,7 @@ void ScriptCreateDialog::_lang_changed(int l) {
 	String selected_ext = "." + language->get_extension();
 	String path = file_path->get_text();
 	String extension = "";
-	if (path != "") {
+	if (!path.is_empty()) {
 		if (path.find(".") != -1) {
 			extension = path.get_extension();
 		}
@@ -582,7 +582,7 @@ void ScriptCreateDialog::_path_changed(const String &p_path) {
 	is_new_script_created = true;
 
 	String path_error = _validate_path(p_path, false);
-	if (path_error != "") {
+	if (!path_error.is_empty()) {
 		_msg_path_valid(false, path_error);
 		_update_dialog();
 		return;

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -148,7 +148,7 @@ void EditorSettingsDialog::unhandled_input(const Ref<InputEvent> &p_event) {
 
 		if (ED_IS_SHORTCUT("ui_undo", p_event)) {
 			String action = undo_redo->get_current_action_name();
-			if (action != "") {
+			if (!action.is_empty()) {
 				EditorNode::get_log()->add_message("Undo: " + action, EditorLog::MSG_TYPE_EDITOR);
 			}
 			undo_redo->undo();
@@ -158,7 +158,7 @@ void EditorSettingsDialog::unhandled_input(const Ref<InputEvent> &p_event) {
 		if (ED_IS_SHORTCUT("ui_redo", p_event)) {
 			undo_redo->redo();
 			String action = undo_redo->get_current_action_name();
-			if (action != "") {
+			if (!action.is_empty()) {
 				EditorNode::get_log()->add_message("Redo: " + action, EditorLog::MSG_TYPE_EDITOR);
 			}
 			handled = true;

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -220,7 +220,7 @@ void ShaderCreateDialog::_language_changed(int p_language) {
 	String path = file_path->get_text();
 	String extension = "";
 
-	if (path != "") {
+	if (!path.is_empty()) {
 		if (path.find(".") != -1) {
 			extension = path.get_extension();
 		}
@@ -303,7 +303,7 @@ void ShaderCreateDialog::_path_changed(const String &p_path) {
 	is_new_shader_created = true;
 
 	String path_error = _validate_path(p_path);
-	if (path_error != "") {
+	if (!path_error.is_empty()) {
 		_msg_path_valid(false, path_error);
 		_update_dialog();
 		return;
@@ -325,7 +325,7 @@ void ShaderCreateDialog::_path_submitted(const String &p_path) {
 }
 
 void ShaderCreateDialog::config(const String &p_base_path, bool p_built_in_enabled, bool p_load_enabled, int p_preferred_type, int p_preferred_mode) {
-	if (p_base_path != "") {
+	if (!p_base_path.is_empty()) {
 		initial_base_path = p_base_path.get_basename();
 		file_path->set_text(initial_base_path + "." + language_data[language_menu->get_selected()].default_extension);
 		current_language = language_menu->get_selected();
@@ -355,10 +355,10 @@ void ShaderCreateDialog::config(const String &p_base_path, bool p_built_in_enabl
 String ShaderCreateDialog::_validate_path(const String &p_path) {
 	String p = p_path.strip_edges();
 
-	if (p == "") {
+	if (p.is_empty()) {
 		return TTR("Path is empty.");
 	}
-	if (p.get_file().get_basename() == "") {
+	if (p.get_file().get_basename().is_empty()) {
 		return TTR("Filename is empty.");
 	}
 

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -372,7 +372,7 @@ static Variant create_var(RS::GlobalVariableType p_type) {
 
 void ShaderGlobalsEditor::_variable_added() {
 	String var = variable_name->get_text().strip_edges();
-	if (var == "" || !var.is_valid_identifier()) {
+	if (var.is_empty() || !var.is_valid_identifier()) {
 		EditorNode::get_singleton()->show_warning(TTR("Please specify a valid variable identifier name."));
 		return;
 	}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -423,7 +423,7 @@ Error Main::test_setup() {
 	register_server_types();
 
 	translation_server->setup(); //register translations, load them, etc.
-	if (locale != "") {
+	if (!locale.is_empty()) {
 		translation_server->set_locale(locale);
 	}
 	translation_server->load_translations();
@@ -1122,7 +1122,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// Network file system needs to be configured before globals, since globals are based on the
 	// 'project.godot' file which will only be available through the network if this is enabled
 	FileAccessNetwork::configure();
-	if (remotefs != "") {
+	if (!remotefs.is_empty()) {
 		file_access_network_client = memnew(FileAccessNetworkClient);
 		int port;
 		if (remotefs.find(":") != -1) {
@@ -1289,7 +1289,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					PROPERTY_HINT_ENUM, "vulkan,opengl3"));
 
 	// if not set on the command line
-	if (rendering_driver == "") {
+	if (rendering_driver.is_empty()) {
 		rendering_driver = GLOBAL_GET("rendering/driver/driver_name");
 	}
 
@@ -1419,7 +1419,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	OS::get_singleton()->set_display_driver_id(display_driver_idx);
 
 	GLOBAL_DEF_RST_NOVAL("audio/driver/driver", AudioDriverManager::get_driver(0)->get_name());
-	if (audio_driver == "") { // Specified in project.godot.
+	if (audio_driver.is_empty()) { // Specified in project.godot.
 		audio_driver = GLOBAL_GET("audio/driver/driver");
 	}
 
@@ -1610,9 +1610,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		ProjectSettings::get_singleton()->set_custom_property_info("input_devices/pen_tablet/driver.windows", PropertyInfo(Variant::STRING, "input_devices/pen_tablet/driver.windows", PROPERTY_HINT_ENUM, "wintab,winink"));
 	}
 
-	if (tablet_driver == "") { // specified in project.godot
+	if (tablet_driver.is_empty()) { // specified in project.godot
 		tablet_driver = GLOBAL_GET("input_devices/pen_tablet/driver");
-		if (tablet_driver == "") {
+		if (tablet_driver.is_empty()) {
 			tablet_driver = DisplayServer::get_singleton()->tablet_get_driver_name(0);
 		}
 	}
@@ -1624,7 +1624,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		}
 	}
 
-	if (DisplayServer::get_singleton()->tablet_get_current_driver() == "") {
+	if (DisplayServer::get_singleton()->tablet_get_current_driver().is_empty()) {
 		DisplayServer::get_singleton()->tablet_set_current_driver(DisplayServer::get_singleton()->tablet_get_driver_name(0));
 	}
 
@@ -1717,7 +1717,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		Ref<Image> boot_logo;
 
 		if (boot_logo_image) {
-			if (boot_logo_path != String()) {
+			if (!boot_logo_path.is_empty()) {
 				boot_logo.instantiate();
 				Error load_err = ImageLoader::load_image(boot_logo_path, boot_logo);
 				if (load_err) {
@@ -1811,7 +1811,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	MAIN_PRINT("Main: Load Translations and Remaps");
 
 	translation_server->setup(); //register translations, load them, etc.
-	if (locale != "") {
+	if (!locale.is_empty()) {
 		translation_server->set_locale(locale);
 	}
 	translation_server->load_translations();
@@ -1833,11 +1833,11 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	ProjectSettings::get_singleton()->set_custom_property_info("internationalization/rendering/text_driver", PropertyInfo(Variant::STRING, "internationalization/rendering/text_driver", PROPERTY_HINT_ENUM, text_driver_options));
 
 	/* Determine text driver */
-	if (text_driver == "") {
+	if (text_driver.is_empty()) {
 		text_driver = GLOBAL_GET("internationalization/rendering/text_driver");
 	}
 
-	if (text_driver != "") {
+	if (!text_driver.is_empty()) {
 		/* Load user selected text server. */
 		for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
 			if (TextServerManager::get_singleton()->get_interface(i)->get_name() == text_driver) {
@@ -1986,7 +1986,7 @@ bool Main::start() {
 		} else if (args[i] == "-p" || args[i] == "--project-manager") {
 			project_manager = true;
 #endif
-		} else if (args[i].length() && args[i][0] != '-' && positional_arg == "") {
+		} else if (args[i].length() && args[i][0] != '-' && positional_arg.is_empty()) {
 			positional_arg = args[i];
 
 			if (args[i].ends_with(".scn") ||
@@ -2045,7 +2045,7 @@ bool Main::start() {
 	}
 
 #ifdef TOOLS_ENABLED
-	if (doc_tool_path != "") {
+	if (!doc_tool_path.is_empty()) {
 		// Needed to instance editor-only classes for their default values
 		Engine::get_singleton()->set_editor_hint(true);
 
@@ -2124,12 +2124,12 @@ bool Main::start() {
 	}
 #endif
 
-	if (script == "" && game_path == "" && String(GLOBAL_GET("application/run/main_scene")) != "") {
+	if (script.is_empty() && game_path.is_empty() && String(GLOBAL_GET("application/run/main_scene")) != "") {
 		game_path = GLOBAL_GET("application/run/main_scene");
 	}
 
 #ifdef TOOLS_ENABLED
-	if (!editor && !project_manager && !cmdline_tool && script == "" && game_path == "") {
+	if (!editor && !project_manager && !cmdline_tool && script.is_empty() && game_path.is_empty()) {
 		// If we end up here, it means we didn't manage to detect what we want to run.
 		// Let's throw an error gently. The code leading to this is pretty brittle so
 		// this might end up triggered by valid usage, in which case we'll have to
@@ -2145,7 +2145,7 @@ bool Main::start() {
 	}
 	String main_loop_type = GLOBAL_DEF("application/run/main_loop_type", "SceneTree");
 
-	if (script != "") {
+	if (!script.is_empty()) {
 		Ref<Script> script_res = ResourceLoader::load(script);
 		ERR_FAIL_COND_V_MSG(script_res.is_null(), false, "Can't load script: " + script);
 
@@ -2194,7 +2194,7 @@ bool Main::start() {
 		}
 	}
 
-	if (!main_loop && main_loop_type == "") {
+	if (!main_loop && main_loop_type.is_empty()) {
 		main_loop_type = "SceneTree";
 	}
 
@@ -2235,7 +2235,7 @@ bool Main::start() {
 		ResourceSaver::add_custom_savers();
 
 		if (!project_manager && !editor) { // game
-			if (game_path != "" || script != "") {
+			if (!game_path.is_empty() || !script.is_empty()) {
 				//autoload
 				OrderedHashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
 
@@ -2302,7 +2302,7 @@ bool Main::start() {
 			editor_node = memnew(EditorNode);
 			sml->get_root()->add_child(editor_node);
 
-			if (_export_preset != "") {
+			if (!_export_preset.is_empty()) {
 				editor_node->export_preset(_export_preset, positional_arg, export_debug, export_pack_only);
 				game_path = ""; // Do not load anything.
 			}
@@ -2417,7 +2417,7 @@ bool Main::start() {
 #endif
 
 		String local_game_path;
-		if (game_path != "" && !project_manager) {
+		if (!game_path.is_empty() && !project_manager) {
 			local_game_path = game_path.replace("\\", "/");
 
 			if (!local_game_path.begins_with("res://")) {
@@ -2473,7 +2473,7 @@ bool Main::start() {
 			// Load SSL Certificates from Project Settings (or builtin).
 			Crypto::load_default_certificates(GLOBAL_DEF("network/ssl/certificate_bundle_override", ""));
 
-			if (game_path != "") {
+			if (!game_path.is_empty()) {
 				Node *scene = nullptr;
 				Ref<PackedScene> scenedata = ResourceLoader::load(local_game_path);
 				if (scenedata.is_valid()) {
@@ -2485,7 +2485,7 @@ bool Main::start() {
 
 #ifdef OSX_ENABLED
 				String mac_iconpath = GLOBAL_DEF("application/config/macos_native_icon", "Variant()");
-				if (mac_iconpath != "") {
+				if (!mac_iconpath.is_empty()) {
 					DisplayServer::get_singleton()->set_native_icon(mac_iconpath);
 					hasicon = true;
 				}
@@ -2493,14 +2493,14 @@ bool Main::start() {
 
 #ifdef WINDOWS_ENABLED
 				String win_iconpath = GLOBAL_DEF("application/config/windows_native_icon", "Variant()");
-				if (win_iconpath != "") {
+				if (!win_iconpath.is_empty()) {
 					DisplayServer::get_singleton()->set_native_icon(win_iconpath);
 					hasicon = true;
 				}
 #endif
 
 				String iconpath = GLOBAL_DEF("application/config/icon", "Variant()");
-				if ((iconpath != "") && (!hasicon)) {
+				if ((!iconpath.is_empty()) && (!hasicon)) {
 					Ref<Image> icon;
 					icon.instantiate();
 					if (ImageLoader::load_image(iconpath, icon) == OK) {

--- a/modules/fbx/data/fbx_material.cpp
+++ b/modules/fbx/data/fbx_material.cpp
@@ -60,7 +60,7 @@ String find_file(const String &p_base, const String &p_file_to_find) {
 
 	dir.list_dir_begin();
 	String n = dir.get_next();
-	while (n != String()) {
+	while (!n.is_empty()) {
 		if (n == "." || n == "..") {
 			n = dir.get_next();
 			continue;
@@ -68,7 +68,7 @@ String find_file(const String &p_base, const String &p_file_to_find) {
 		if (dir.current_is_dir()) {
 			// Don't use `path_to` or the returned path will be wrong.
 			const String f = find_file(p_base + "/" + n, p_file_to_find);
-			if (f != "") {
+			if (!f.is_empty()) {
 				return f;
 			}
 		} else if (n == p_file_to_find) {
@@ -119,7 +119,7 @@ String FBXMaterial::find_texture_path_by_filename(const String p_filename, const
 	dir.open("res://");
 	dir.list_dir_begin();
 	String n = dir.get_next();
-	while (n != String()) {
+	while (!n.is_empty()) {
 		if (n == "." || n == "..") {
 			n = dir.get_next();
 			continue;
@@ -136,7 +136,7 @@ String FBXMaterial::find_texture_path_by_filename(const String p_filename, const
 					lower_n.find("picture") >= 0) {
 				// Don't use `path_to` or the returned path will be wrong.
 				const String f = find_file(String("res://") + n, p_filename);
-				if (f != "") {
+				if (!f.is_empty()) {
 					return f;
 				}
 			}

--- a/modules/fbx/fbx_parser/FBXMeshGeometry.cpp
+++ b/modules/fbx/fbx_parser/FBXMeshGeometry.cpp
@@ -368,7 +368,7 @@ MeshGeometry::MappingData<T> MeshGeometry::resolve_vertex_data_array(
 	// UVIndex, MaterialIndex, NormalIndex, etc..
 	std::string indexDataElementName;
 
-	if (indexOverride != "") {
+	if (!indexOverride.empty()) {
 		// Colors should become ColorIndex
 		indexDataElementName = indexOverride;
 	} else {

--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -397,7 +397,7 @@ List<ClassAPI> generate_c_api_classes() {
 						arg_type = "Variant";
 					} else if (arg_info.type == Variant::OBJECT) {
 						arg_type = arg_info.class_name;
-						if (arg_type == "") {
+						if (arg_type.is_empty()) {
 							arg_type = Variant::get_type_name(arg_info.type);
 						}
 					} else {

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -682,7 +682,7 @@ void NativeScriptInstance::get_property_list(List<PropertyInfo> *p_properties) c
 				ERR_CONTINUE(info.type < 0 || info.type >= Variant::VARIANT_MAX);
 
 				info.name = d["name"];
-				ERR_CONTINUE(info.name == "");
+				ERR_CONTINUE(info.name.is_empty());
 
 				if (d.has("hint")) {
 					info.hint = PropertyHint(d["hint"].operator int64_t());

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -232,8 +232,7 @@ bool PluginScript::instance_has(const Object *p_this) const {
 }
 
 bool PluginScript::has_source_code() const {
-	bool has = _source != "";
-	return has;
+	return !_source.is_empty();
 }
 
 String PluginScript::get_source_code() const {
@@ -257,11 +256,11 @@ Error PluginScript::reload(bool p_keep_state) {
 	_valid = false;
 	String basedir = _path;
 
-	if (basedir == "") {
+	if (basedir.is_empty()) {
 		basedir = get_path();
 	}
 
-	if (basedir != "") {
+	if (!basedir.is_empty()) {
 		basedir = basedir.get_base_dir();
 	}
 

--- a/modules/gdnative/pluginscript/register_types.cpp
+++ b/modules/gdnative/pluginscript/register_types.cpp
@@ -44,9 +44,9 @@
 static List<PluginScriptLanguage *> pluginscript_languages;
 
 static Error _check_language_desc(const godot_pluginscript_language_desc *desc) {
-	ERR_FAIL_COND_V(!desc->name || desc->name == String(), ERR_BUG);
-	ERR_FAIL_COND_V(!desc->type || desc->type == String(), ERR_BUG);
-	ERR_FAIL_COND_V(!desc->extension || desc->extension == String(), ERR_BUG);
+	ERR_FAIL_COND_V(!desc->name, ERR_BUG);
+	ERR_FAIL_COND_V(!desc->type, ERR_BUG);
+	ERR_FAIL_COND_V(!desc->extension, ERR_BUG);
 	ERR_FAIL_COND_V(!desc->recognized_extensions || !desc->recognized_extensions[0], ERR_BUG);
 	ERR_FAIL_COND_V(!desc->init, ERR_BUG);
 	ERR_FAIL_COND_V(!desc->finish, ERR_BUG);

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -413,7 +413,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 					previous_column = j;
 
 					// ignore if just whitespace
-					if (text != "") {
+					if (!text.is_empty()) {
 						previous_text = text;
 					}
 				}
@@ -509,7 +509,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	for (const String &comment : comments) {
 		String beg = comment.get_slice(" ", 0);
 		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
-		add_color_region(beg, end, comment_color, end == "");
+		add_color_region(beg, end, comment_color, end.is_empty());
 	}
 
 	/* Strings */
@@ -519,7 +519,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	for (const String &string : strings) {
 		String beg = string.get_slice(" ", 0);
 		String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
-		add_color_region(beg, end, string_color, end == "");
+		add_color_region(beg, end, string_color, end.is_empty());
 	}
 
 	const Ref<Script> script = _get_edited_resource();

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -389,7 +389,7 @@ bool GDScript::instance_has(const Object *p_this) const {
 }
 
 bool GDScript::has_source_code() const {
-	return source != "";
+	return !source.is_empty();
 }
 
 String GDScript::get_source_code() const {
@@ -458,7 +458,7 @@ void GDScript::_update_doc() {
 	doc.is_script_doc = true;
 
 	if (base.is_valid() && base->is_valid()) {
-		if (base->doc.name != String()) {
+		if (!base->doc.name.is_empty()) {
 			doc.inherits = base->doc.name;
 		} else {
 			doc.inherits = base->get_instance_base_type();
@@ -472,7 +472,7 @@ void GDScript::_update_doc() {
 	doc.tutorials = doc_tutorials;
 
 	for (const KeyValue<String, DocData::EnumDoc> &E : doc_enums) {
-		if (E.value.description != "") {
+		if (!E.value.description.is_empty()) {
 			doc.enums[E.key] = E.value.description;
 		}
 	}
@@ -616,11 +616,11 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 
 		String basedir = path;
 
-		if (basedir == "") {
+		if (basedir.is_empty()) {
 			basedir = get_path();
 		}
 
-		if (basedir != "") {
+		if (!basedir.is_empty()) {
 			basedir = basedir.get_base_dir();
 		}
 
@@ -642,7 +642,7 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 					path = c->extends_path;
 					if (path.is_relative_path()) {
 						String base = get_path();
-						if (base == "" || base.is_relative_path()) {
+						if (base.is_empty() || base.is_relative_path()) {
 							ERR_PRINT(("Could not resolve relative path for parent class: " + path).utf8().get_data());
 						} else {
 							path = base.get_base_dir().plus_file(path);
@@ -656,7 +656,7 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 					}
 				}
 
-				if (path != "") {
+				if (!path.is_empty()) {
 					if (path != get_path()) {
 						Ref<GDScript> bf = ResourceLoader::load(path);
 
@@ -809,11 +809,11 @@ Error GDScript::reload(bool p_keep_state) {
 
 	String basedir = path;
 
-	if (basedir == "") {
+	if (basedir.is_empty()) {
 		basedir = get_path();
 	}
 
-	if (basedir != "") {
+	if (!basedir.is_empty()) {
 		basedir = basedir.get_base_dir();
 	}
 
@@ -1122,7 +1122,7 @@ String GDScript::_get_gdscript_reference_class_name(const GDScript *p_gdscript) 
 
 	String class_name;
 	while (p_gdscript) {
-		if (class_name == "") {
+		if (class_name.is_empty()) {
 			class_name = p_gdscript->get_script_class_name();
 		} else {
 			class_name = p_gdscript->get_script_class_name() + "." + class_name;
@@ -1433,7 +1433,7 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 					pinfo.type = Variant::Type(d["type"].operator int());
 					ERR_CONTINUE(pinfo.type < 0 || pinfo.type >= Variant::VARIANT_MAX);
 					pinfo.name = d["name"];
-					ERR_CONTINUE(pinfo.name == "");
+					ERR_CONTINUE(pinfo.name.is_empty());
 					if (d.has("hint")) {
 						pinfo.hint = PropertyHint(d["hint"].operator int());
 					}

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -117,7 +117,7 @@ void GDScriptCache::remove_script(const String &p_path) {
 Ref<GDScriptParserRef> GDScriptCache::get_parser(const String &p_path, GDScriptParserRef::Status p_status, Error &r_error, const String &p_owner) {
 	MutexLock lock(singleton->lock);
 	Ref<GDScriptParserRef> ref;
-	if (p_owner != String()) {
+	if (!p_owner.is_empty()) {
 		singleton->dependencies[p_owner].insert(p_path);
 	}
 	if (singleton->parser_map.has(p_path)) {
@@ -163,7 +163,7 @@ String GDScriptCache::get_source_code(const String &p_path) {
 
 Ref<GDScript> GDScriptCache::get_shallow_script(const String &p_path, const String &p_owner) {
 	MutexLock lock(singleton->lock);
-	if (p_owner != String()) {
+	if (!p_owner.is_empty()) {
 		singleton->dependencies[p_owner].insert(p_path);
 	}
 	if (singleton->full_gdscript_cache.has(p_path)) {
@@ -186,7 +186,7 @@ Ref<GDScript> GDScriptCache::get_shallow_script(const String &p_path, const Stri
 Ref<GDScript> GDScriptCache::get_full_script(const String &p_path, Error &r_error, const String &p_owner) {
 	MutexLock lock(singleton->lock);
 
-	if (p_owner != String()) {
+	if (!p_owner.is_empty()) {
 		singleton->dependencies[p_owner].insert(p_path);
 	}
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -65,7 +65,7 @@ bool GDScriptCompiler::_is_class_member_property(GDScript *owner, const StringNa
 }
 
 void GDScriptCompiler::_set_error(const String &p_error, const GDScriptParser::Node *p_node) {
-	if (error != "") {
+	if (!error.is_empty()) {
 		return;
 	}
 
@@ -2020,7 +2020,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	if (EngineDebugger::is_active()) {
 		String signature;
 		// Path.
-		if (p_script->get_path() != String()) {
+		if (!p_script->get_path().is_empty()) {
 			signature += p_script->get_path();
 		}
 		// Location.
@@ -2158,7 +2158,7 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 	p_script->tool = parser->is_tool();
 	p_script->name = p_class->identifier ? p_class->identifier->name : "";
 
-	if (p_script->name != "") {
+	if (!p_script->name.is_empty()) {
 		if (ClassDB::class_exists(p_script->name) && ClassDB::is_class_exposed(p_script->name)) {
 			_set_error("The class '" + p_script->name + "' shadows a native class", p_class);
 			return ERR_ALREADY_EXISTS;
@@ -2287,7 +2287,7 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 				p_script->constants.insert(name, constant->initializer->reduced_value);
 #ifdef TOOLS_ENABLED
 				p_script->member_lines[name] = constant->start_line;
-				if (constant->doc_description != String()) {
+				if (!constant->doc_description.is_empty()) {
 					p_script->doc_constants[name] = constant->doc_description;
 				}
 #endif

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1365,7 +1365,7 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 									String arg1 = args[0];
 									if (arg1.begins_with("/root/")) {
 										String which = arg1.get_slice("/", 2);
-										if (which != "") {
+										if (!which.is_empty()) {
 											// Try singletons first
 											if (GDScriptLanguage::get_singleton()->get_named_globals_map().has(which)) {
 												r_type = _type_from_variant(GDScriptLanguage::get_singleton()->get_named_globals_map()[which]);
@@ -2753,7 +2753,7 @@ void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_t
 		}
 
 		String st = l.substr(tc, l.length()).strip_edges();
-		if (st == "" || st.begins_with("#")) {
+		if (st.is_empty() || st.begins_with("#")) {
 			continue; //ignore!
 		}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3100,7 +3100,7 @@ void GDScriptParser::get_class_doc_comment(int p_line, String &p_brief, String &
 	if (!comments.has(p_line)) {
 		return;
 	}
-	ERR_FAIL_COND(p_brief != "" || p_desc != "" || p_tutorials.size() != 0);
+	ERR_FAIL_COND(!p_brief.is_empty() || !p_desc.is_empty() || p_tutorials.size() != 0);
 
 	int line = p_line;
 	bool in_codeblock = false;
@@ -3132,7 +3132,7 @@ void GDScriptParser::get_class_doc_comment(int p_line, String &p_brief, String &
 		String striped_line = doc_line.strip_edges();
 
 		// Set the read mode.
-		if (striped_line.begins_with("@desc:") && p_desc == "") {
+		if (striped_line.begins_with("@desc:") && p_desc.is_empty()) {
 			mode = DESC;
 			striped_line = striped_line.trim_prefix("@desc:");
 			in_codeblock = _in_codeblock(doc_line, in_codeblock);

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -755,7 +755,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (!valid) {
 					String v = index->operator String();
-					if (v != "") {
+					if (!v.is_empty()) {
 						v = "'" + v + "'";
 					} else {
 						v = "of type '" + _get_var_type(index) + "'";
@@ -785,7 +785,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (!valid) {
 					String v = index->operator String();
-					if (v != "") {
+					if (!v.is_empty()) {
 						v = "'" + v + "'";
 					} else {
 						v = "of type '" + _get_var_type(index) + "'";
@@ -817,7 +817,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (oob) {
 					String v = index->operator String();
-					if (v != "") {
+					if (!v.is_empty()) {
 						v = "'" + v + "'";
 					} else {
 						v = "of type '" + _get_var_type(index) + "'";
@@ -848,7 +848,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (!valid) {
 					String v = index->operator String();
-					if (v != "") {
+					if (!v.is_empty()) {
 						v = "'" + v + "'";
 					} else {
 						v = "of type '" + _get_var_type(index) + "'";
@@ -884,7 +884,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (!valid) {
 					String v = key->operator String();
-					if (v != "") {
+					if (!v.is_empty()) {
 						v = "'" + v + "'";
 					} else {
 						v = "of type '" + _get_var_type(key) + "'";
@@ -917,7 +917,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (oob) {
 					String v = index->operator String();
-					if (v != "") {
+					if (!v.is_empty()) {
 						v = "'" + v + "'";
 					} else {
 						v = "of type '" + _get_var_type(index) + "'";
@@ -3295,20 +3295,20 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		//error
 		// function, file, line, error, explanation
 		String err_file;
-		if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && p_instance->script->path != "") {
+		if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && !p_instance->script->path.is_empty()) {
 			err_file = p_instance->script->path;
 		} else if (script) {
 			err_file = script->path;
 		}
-		if (err_file == "") {
+		if (err_file.is_empty()) {
 			err_file = "<built-in>";
 		}
 		String err_func = name;
-		if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && p_instance->script->name != "") {
+		if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && !p_instance->script->name.is_empty()) {
 			err_func = p_instance->script->name + "." + err_func;
 		}
 		int err_line = line;
-		if (err_text == "") {
+		if (err_text.is_empty()) {
 			err_text = "Internal script error! Opcode: " + itos(last_opcode) + " (please report).";
 		}
 

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -267,7 +267,7 @@ bool GDScriptTestRunner::generate_class_index() {
 		String base_type;
 
 		String class_name = GDScriptLanguage::get_singleton()->get_global_class_name(test.get_source_file(), &base_type);
-		if (class_name == String()) {
+		if (class_name.is_empty()) {
 			continue;
 		}
 		ERR_FAIL_COND_V_MSG(ScriptServer::is_global_class(class_name), false,

--- a/modules/glslang/register_types.cpp
+++ b/modules/glslang/register_types.cpp
@@ -120,7 +120,7 @@ static Vector<uint8_t> _compile_shader_glsl(RenderingDevice::ShaderStage p_stage
 		preamble += "#define has_VK_KHR_multiview 1\n";
 	}
 
-	if (preamble != "") {
+	if (!preamble.empty()) {
 		shader.setPreamble(preamble.c_str());
 	}
 

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -885,11 +885,11 @@ void GridMapEditor::update_palette() {
 		String name = mesh_library->get_item_name(id);
 		Ref<Texture2D> preview = mesh_library->get_item_preview(id);
 
-		if (name == "") {
+		if (name.is_empty()) {
 			name = "#" + itos(id);
 		}
 
-		if (filter != "" && !filter.is_subsequence_ofi(name)) {
+		if (!filter.is_empty() && !filter.is_subsequence_ofi(name)) {
 			continue;
 		}
 

--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -41,7 +41,7 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, FileAccess *f, bool p_force
 	while (true) {
 		String line = f->get_line();
 		ERR_FAIL_COND_V(f->eof_reached(), ERR_FILE_UNRECOGNIZED);
-		if (line == "") { // empty line indicates end of header
+		if (line.is_empty()) { // empty line indicates end of header
 			break;
 		}
 		if (line.begins_with("FORMAT=")) { // leave option to implement other commands

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -310,7 +310,7 @@ void CryptoMbedTLS::load_default_certificates(String p_path) {
 	default_certs = memnew(X509CertificateMbedTLS);
 	ERR_FAIL_COND(default_certs == nullptr);
 
-	if (p_path != "") {
+	if (!p_path.is_empty()) {
 		// Use certs defined in project settings.
 		default_certs->load(p_path);
 	}

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -155,7 +155,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 				dir_access->list_dir_begin();
 				String filename = dir_access->get_next();
 
-				while (filename != "") {
+				while (!filename.is_empty()) {
 					if (filename == "." || filename == "..") {
 						filename = dir_access->get_next();
 						continue;

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -4263,7 +4263,7 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_star
 	}
 	hb_buffer_set_script(p_sd->hb_buffer, p_script);
 
-	if (p_sd->spans[p_span].language != String()) {
+	if (!p_sd->spans[p_span].language.is_empty()) {
 		hb_language_t lang = hb_language_from_string(p_sd->spans[p_span].language.ascii().get_data(), -1);
 		hb_buffer_set_language(p_sd->hb_buffer, lang);
 	}
@@ -4971,12 +4971,12 @@ void TextServerAdvanced::_insert_num_systems_lang() {
 }
 
 String TextServerAdvanced::format_number(const String &p_string, const String &p_language) const {
-	const StringName lang = (p_language == "") ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
+	const StringName lang = (p_language.is_empty()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
 
 	String res = p_string;
 	for (int i = 0; i < num_systems.size(); i++) {
 		if (num_systems[i].lang.has(lang)) {
-			if (num_systems[i].digits == String()) {
+			if (num_systems[i].digits.is_empty()) {
 				return p_string;
 			}
 			res.replace("e", num_systems[i].exp);
@@ -4996,12 +4996,12 @@ String TextServerAdvanced::format_number(const String &p_string, const String &p
 }
 
 String TextServerAdvanced::parse_number(const String &p_string, const String &p_language) const {
-	const StringName lang = (p_language == "") ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
+	const StringName lang = (p_language.is_empty()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
 
 	String res = p_string;
 	for (int i = 0; i < num_systems.size(); i++) {
 		if (num_systems[i].lang.has(lang)) {
-			if (num_systems[i].digits == String()) {
+			if (num_systems[i].digits.is_empty()) {
 				return p_string;
 			}
 			res.replace(num_systems[i].exp, "e");
@@ -5024,11 +5024,11 @@ String TextServerAdvanced::parse_number(const String &p_string, const String &p_
 }
 
 String TextServerAdvanced::percent_sign(const String &p_language) const {
-	const StringName lang = (p_language == "") ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
+	const StringName lang = (p_language.is_empty()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
 
 	for (int i = 0; i < num_systems.size(); i++) {
 		if (num_systems[i].lang.has(lang)) {
-			if (num_systems[i].percent_sign == String()) {
+			if (num_systems[i].percent_sign.is_empty()) {
 				return "%";
 			}
 			return num_systems[i].percent_sign;

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -1328,7 +1328,7 @@ void VisualScriptEditor::_create_function_dialog() {
 }
 
 void VisualScriptEditor::_create_function() {
-	String name = _validate_name((func_name_box->get_text() == "") ? "new_func" : func_name_box->get_text());
+	String name = _validate_name((func_name_box->get_text().is_empty()) ? "new_func" : func_name_box->get_text());
 	selected = name;
 	Vector2 pos = _get_available_pos();
 
@@ -2094,7 +2094,7 @@ Variant VisualScriptEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 
 		String type = it->get_metadata(0);
 
-		if (type == String()) {
+		if (type.is_empty()) {
 			return Variant();
 		}
 
@@ -2622,7 +2622,7 @@ String VisualScriptEditor::get_name() {
 		name = TTR("[unsaved]");
 	} else if (script->is_built_in()) {
 		const String &script_name = script->get_name();
-		if (script_name != "") {
+		if (!script_name.is_empty()) {
 			// If the built-in script has a custom resource name defined,
 			// display the built-in script name as follows: `ResourceName (scene_file.tscn)`
 			name = vformat("%s (%s)", script_name, name.get_slice("::", 0));
@@ -2842,7 +2842,7 @@ void VisualScriptEditor::clear_edit_menu() {
 void VisualScriptEditor::_change_base_type_callback() {
 	String bt = select_base_type->get_selected_type();
 
-	ERR_FAIL_COND(bt == String());
+	ERR_FAIL_COND(bt.is_empty());
 	undo_redo->create_action(TTR("Change Base Type"));
 	undo_redo->add_do_method(script.ptr(), "set_instance_base_type", bt);
 	undo_redo->add_undo_method(script.ptr(), "set_instance_base_type", script->get_instance_base_type());
@@ -3213,7 +3213,7 @@ void VisualScriptEditor::_port_action_menu(int p_option) {
 			if (tg.type == Variant::OBJECT) {
 				if (tg.script.is_valid()) {
 					new_connect_node_select->select_from_script(tg.script, "");
-				} else if (type_string != String()) {
+				} else if (!type_string.is_empty()) {
 					new_connect_node_select->select_from_base_type(type_string);
 				} else {
 					new_connect_node_select->select_from_base_type(n->get_base_type());
@@ -3237,7 +3237,7 @@ void VisualScriptEditor::_port_action_menu(int p_option) {
 				property_info = script->get_node(port_action_node)->get_output_value_port_info(port_action_output);
 			}
 			if (tg.type == Variant::OBJECT) {
-				if (property_info.type == Variant::OBJECT && property_info.hint_string != String()) {
+				if (property_info.type == Variant::OBJECT && !property_info.hint_string.is_empty()) {
 					new_connect_node_select->select_from_action(property_info.hint_string);
 				} else {
 					new_connect_node_select->select_from_action("");
@@ -3462,7 +3462,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 					PropertyHint hint = script->get_node(port_action_node)->get_output_value_port_info(port_action_output).hint;
 					String base_type = script->get_node(port_action_node)->get_output_value_port_info(port_action_output).hint_string;
 
-					if (base_type != String() && hint == PROPERTY_HINT_TYPE_STRING) {
+					if (!base_type.is_empty() && hint == PROPERTY_HINT_TYPE_STRING) {
 						vsfc->set_base_type(base_type);
 					}
 					if (p_text == "call" || p_text == "call_deferred") {
@@ -3497,7 +3497,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 					PropertyHint hint = script->get_node(port_action_node)->get_output_value_port_info(port_action_output).hint;
 					String base_type = script->get_node(port_action_node)->get_output_value_port_info(port_action_output).hint_string;
 
-					if (base_type != String() && hint == PROPERTY_HINT_TYPE_STRING) {
+					if (!base_type.is_empty() && hint == PROPERTY_HINT_TYPE_STRING) {
 						vsp->set_base_type(base_type);
 					}
 				}
@@ -3526,7 +3526,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 				} else if (script->get_node(port_action_node).is_valid()) {
 					PropertyHint hint = script->get_node(port_action_node)->get_output_value_port_info(port_action_output).hint;
 					String base_type = script->get_node(port_action_node)->get_output_value_port_info(port_action_output).hint_string;
-					if (base_type != String() && hint == PROPERTY_HINT_TYPE_STRING) {
+					if (!base_type.is_empty() && hint == PROPERTY_HINT_TYPE_STRING) {
 						vsp->set_base_type(base_type);
 					}
 				}

--- a/modules/visual_script/editor/visual_script_property_selector.cpp
+++ b/modules/visual_script/editor/visual_script_property_selector.cpp
@@ -175,7 +175,7 @@ void VisualScriptPropertySelector::_update_search() {
 				String set_text = set_text_raw.capitalize();
 				String input = search_box->get_text().capitalize();
 
-				if (input == String() || get_text_raw.findn(input) != -1 || get_text.findn(input) != -1) {
+				if (input.is_empty() || get_text_raw.findn(input) != -1 || get_text.findn(input) != -1) {
 					TreeItem *item = search_options->create_item(category ? category : root);
 					item->set_text(0, get_text);
 					item->set_metadata(0, F.name);
@@ -188,7 +188,7 @@ void VisualScriptPropertySelector::_update_search() {
 					item->set_metadata(2, connecting);
 				}
 
-				if (input == String() || set_text_raw.findn(input) != -1 || set_text.findn(input) != -1) {
+				if (input.is_empty() || set_text_raw.findn(input) != -1 || set_text.findn(input) != -1) {
 					TreeItem *item = search_options->create_item(category ? category : root);
 					item->set_text(0, set_text);
 					item->set_metadata(0, F.name);
@@ -252,7 +252,7 @@ void VisualScriptPropertySelector::_update_search() {
 			String desc_raw = mi.name + desc_arguments;
 			String desc = desc_raw.capitalize().replace("( ", "(");
 
-			if (search_box->get_text() != String() &&
+			if (!search_box->get_text().is_empty() &&
 					name.findn(search_box->get_text()) == -1 &&
 					desc.findn(search_box->get_text()) == -1 &&
 					desc_raw.findn(search_box->get_text()) == -1) {
@@ -322,7 +322,7 @@ void VisualScriptPropertySelector::_update_search() {
 }
 
 void VisualScriptPropertySelector::create_visualscript_item(const String &name, TreeItem *const root, const String &search_input, const String &text) {
-	if (search_input == String() || text.findn(search_input) != -1) {
+	if (search_input.is_empty() || text.findn(search_input) != -1) {
 		TreeItem *item = search_options->create_item(root);
 		item->set_text(0, text);
 		item->set_icon(0, vbc->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons")));
@@ -352,7 +352,7 @@ void VisualScriptPropertySelector::get_visual_node_names(const String &root_filt
 		bool in_filter = false;
 		Vector<String> tx_filters = search_box->get_text().split(" ");
 		for (int i = 0; i < tx_filters.size(); i++) {
-			if (tx_filters[i] == "") {
+			if (tx_filters[i].is_empty()) {
 				in_filter = true;
 			} else {
 				in_filter = false;
@@ -451,7 +451,7 @@ void VisualScriptPropertySelector::_item_selected() {
 
 	String at_class = class_type;
 
-	while (at_class != String()) {
+	while (!at_class.is_empty()) {
 		Map<String, DocData::ClassDoc>::Element *E = dd->class_list.find(at_class);
 		if (E) {
 			for (int i = 0; i < E->get().properties.size(); i++) {
@@ -465,7 +465,7 @@ void VisualScriptPropertySelector::_item_selected() {
 	}
 	at_class = class_type;
 
-	while (at_class != String()) {
+	while (!at_class.is_empty()) {
 		Map<String, DocData::ClassDoc>::Element *C = dd->class_list.find(at_class);
 		if (C) {
 			for (int i = 0; i < C->get().methods.size(); i++) {
@@ -521,7 +521,7 @@ void VisualScriptPropertySelector::_item_selected() {
 
 	memdelete(names);
 
-	if (text == String()) {
+	if (text.is_empty()) {
 		return;
 	}
 

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1665,8 +1665,8 @@ Variant VisualScriptInstance::_call_internal(const StringName &p_method, void *p
 		String err_func = p_method;
 		int err_line = current_node_id; // Not a line but it works as one.
 
-		if (node && (r_error.error != Callable::CallError::CALL_ERROR_INVALID_METHOD || error_str == String())) {
-			if (error_str != String()) {
+		if (node && (r_error.error != Callable::CallError::CALL_ERROR_INVALID_METHOD || error_str.is_empty())) {
+			if (!error_str.is_empty()) {
 				error_str += " ";
 			}
 
@@ -2379,7 +2379,7 @@ void VisualScriptLanguage::debug_get_stack_level_locals(int p_level, List<String
 
 	for (int i = 0; i < node->input_port_count; i++) {
 		String name = node->get_base_node()->get_input_value_port_info(i).name;
-		if (name == String()) {
+		if (name.is_empty()) {
 			name = "in_" + itos(i);
 		}
 
@@ -2399,7 +2399,7 @@ void VisualScriptLanguage::debug_get_stack_level_locals(int p_level, List<String
 
 	for (int i = 0; i < node->output_port_count; i++) {
 		String name = node->get_base_node()->get_output_value_port_info(i).name;
-		if (name == String()) {
+		if (name.is_empty()) {
 			name = "out_" + itos(i);
 		}
 

--- a/modules/visual_script/visual_script_flow_control.cpp
+++ b/modules/visual_script/visual_script_flow_control.cpp
@@ -724,7 +724,7 @@ String VisualScriptTypeCast::get_caption() const {
 }
 
 String VisualScriptTypeCast::get_text() const {
-	if (script != String()) {
+	if (!script.is_empty()) {
 		return "Is " + script.get_file() + "?";
 	} else {
 		return "Is " + base_type + "?";
@@ -762,7 +762,7 @@ String VisualScriptTypeCast::get_base_script() const {
 VisualScriptTypeCast::TypeGuess VisualScriptTypeCast::guess_output_type(TypeGuess *p_inputs, int p_output) const {
 	TypeGuess tg;
 	tg.type = Variant::OBJECT;
-	if (script != String()) {
+	if (!script.is_empty()) {
 		tg.script = ResourceLoader::load(script);
 	}
 	//if (!tg.script.is_valid()) {
@@ -793,7 +793,7 @@ public:
 			return 0;
 		}
 
-		if (script != String()) {
+		if (!script.is_empty()) {
 			Ref<Script> obj_script = obj->get_script();
 			if (!obj_script.is_valid()) {
 				return 1; //well, definitely not the script because object we got has no script.
@@ -853,7 +853,7 @@ void VisualScriptTypeCast::_bind_methods() {
 
 	String script_ext_hint;
 	for (const String &E : script_extensions) {
-		if (script_ext_hint != String()) {
+		if (!script_ext_hint.is_empty()) {
 			script_ext_hint += ",";
 		}
 		script_ext_hint += "*." + E;

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -370,7 +370,7 @@ void VisualScriptFunctionCall::_update_method_cache() {
 
 	} else if (call_mode == CALL_MODE_INSTANCE) {
 		type = base_type;
-		if (base_script != String()) {
+		if (!base_script.is_empty()) {
 			if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
 				ScriptServer::edit_request_func(base_script); //make sure it's loaded
 			}
@@ -539,7 +539,7 @@ void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const 
 			property.hint = PROPERTY_HINT_ENUM;
 			String sl;
 			for (const Engine::Singleton &E : names) {
-				if (sl != String()) {
+				if (!sl.is_empty()) {
 					sl += ",";
 				}
 				sl += E.name;
@@ -580,7 +580,7 @@ void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const 
 			property.hint = PROPERTY_HINT_METHOD_OF_BASE_TYPE;
 			property.hint_string = base_type;
 
-			if (base_script != String()) {
+			if (!base_script.is_empty()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
 					ScriptServer::edit_request_func(base_script); //make sure it's loaded
 				}
@@ -684,7 +684,7 @@ void VisualScriptFunctionCall::_bind_methods() {
 
 	String script_ext_hint;
 	for (const String &E : script_extensions) {
-		if (script_ext_hint != String()) {
+		if (!script_ext_hint.is_empty()) {
 			script_ext_hint += ",";
 		}
 		script_ext_hint += "*." + E;
@@ -1161,7 +1161,7 @@ void VisualScriptPropertySet::_update_cache() {
 			}
 		} else if (call_mode == CALL_MODE_INSTANCE) {
 			type = base_type;
-			if (base_script != String()) {
+			if (!base_script.is_empty()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
 					ScriptServer::edit_request_func(base_script); //make sure it's loaded
 				}
@@ -1321,7 +1321,7 @@ void VisualScriptPropertySet::_validate_property(PropertyInfo &property) const {
 			property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
 			property.hint_string = base_type;
 
-			if (base_script != String()) {
+			if (!base_script.is_empty()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
 					ScriptServer::edit_request_func(base_script); //make sure it's loaded
 				}
@@ -1361,7 +1361,7 @@ void VisualScriptPropertySet::_validate_property(PropertyInfo &property) const {
 		property.hint = PROPERTY_HINT_ENUM;
 		property.hint_string = options;
 		property.type = Variant::STRING;
-		if (options == "") {
+		if (options.is_empty()) {
 			property.usage = PROPERTY_USAGE_NONE; //hide if type has no usable index
 		}
 	}
@@ -1411,7 +1411,7 @@ void VisualScriptPropertySet::_bind_methods() {
 
 	String script_ext_hint;
 	for (const String &E : script_extensions) {
-		if (script_ext_hint != String()) {
+		if (!script_ext_hint.is_empty()) {
 			script_ext_hint += ",";
 		}
 		script_ext_hint += "*." + E;
@@ -1847,7 +1847,7 @@ void VisualScriptPropertyGet::_update_cache() {
 			}
 		} else if (call_mode == CALL_MODE_INSTANCE) {
 			type = base_type;
-			if (base_script != String()) {
+			if (!base_script.is_empty()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
 					ScriptServer::edit_request_func(base_script); //make sure it's loaded
 				}
@@ -2027,7 +2027,7 @@ void VisualScriptPropertyGet::_validate_property(PropertyInfo &property) const {
 			property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
 			property.hint_string = base_type;
 
-			if (base_script != String()) {
+			if (!base_script.is_empty()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
 					ScriptServer::edit_request_func(base_script); //make sure it's loaded
 				}
@@ -2066,7 +2066,7 @@ void VisualScriptPropertyGet::_validate_property(PropertyInfo &property) const {
 		property.hint = PROPERTY_HINT_ENUM;
 		property.hint_string = options;
 		property.type = Variant::STRING;
-		if (options == "") {
+		if (options.is_empty()) {
 			property.usage = PROPERTY_USAGE_NONE; //hide if type has no usable index
 		}
 	}
@@ -2113,7 +2113,7 @@ void VisualScriptPropertyGet::_bind_methods() {
 
 	String script_ext_hint;
 	for (const String &E : script_extensions) {
-		if (script_ext_hint != String()) {
+		if (!script_ext_hint.is_empty()) {
 			script_ext_hint += ",";
 		}
 		script_ext_hint += "." + E;
@@ -2324,7 +2324,7 @@ void VisualScriptEmitSignal::_validate_property(PropertyInfo &property) const {
 
 		String ml;
 		for (const StringName &E : sigs) {
-			if (ml != String()) {
+			if (!ml.is_empty()) {
 				ml += ",";
 			}
 			ml += E;

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1307,7 +1307,7 @@ void VisualScriptVariableGet::_validate_property(PropertyInfo &property) const {
 
 		String vhint;
 		for (const StringName &E : vars) {
-			if (vhint != String()) {
+			if (!vhint.is_empty()) {
 				vhint += ",";
 			}
 
@@ -1417,7 +1417,7 @@ void VisualScriptVariableSet::_validate_property(PropertyInfo &property) const {
 
 		String vhint;
 		for (const StringName &E : vars) {
-			if (vhint != String()) {
+			if (!vhint.is_empty()) {
 				vhint += ",";
 			}
 
@@ -1615,7 +1615,7 @@ PropertyInfo VisualScriptPreload::get_output_value_port_info(int p_idx) const {
 		pinfo.hint_string = preload->get_class();
 		if (preload->get_path().is_resource_file()) {
 			pinfo.name = preload->get_path();
-		} else if (preload->get_name() != String()) {
+		} else if (!preload->get_name().is_empty()) {
 			pinfo.name = preload->get_name();
 		} else {
 			pinfo.name = preload->get_class();
@@ -1994,7 +1994,7 @@ void VisualScriptClassConstant::_validate_property(PropertyInfo &property) const
 
 		property.hint_string = "";
 		for (const String &E : constants) {
-			if (property.hint_string != String()) {
+			if (!property.hint_string.is_empty()) {
 				property.hint_string += ",";
 			}
 			property.hint_string += E;
@@ -2132,7 +2132,7 @@ void VisualScriptBasicTypeConstant::_validate_property(PropertyInfo &property) c
 		}
 		property.hint_string = "";
 		for (const StringName &E : constants) {
-			if (property.hint_string != String()) {
+			if (!property.hint_string.is_empty()) {
 				property.hint_string += ",";
 			}
 			property.hint_string += String(E);
@@ -2363,7 +2363,7 @@ void VisualScriptEngineSingleton::_validate_property(PropertyInfo &property) con
 			continue; //skip these, too simple named
 		}
 
-		if (cc != String()) {
+		if (!cc.is_empty()) {
 			cc += ",";
 		}
 		cc += E.name;
@@ -3147,7 +3147,7 @@ String VisualScriptSubCall::get_caption() const {
 String VisualScriptSubCall::get_text() const {
 	Ref<Script> script = get_script();
 	if (script.is_valid()) {
-		if (script->get_name() != String()) {
+		if (!script->get_name().is_empty()) {
 			return script->get_name();
 		}
 		if (script->get_path().is_resource_file()) {
@@ -3786,7 +3786,7 @@ void VisualScriptInputAction::_validate_property(PropertyInfo &property) const {
 		al.sort();
 
 		for (int i = 0; i < al.size(); i++) {
-			if (actions != String()) {
+			if (!actions.is_empty()) {
 				actions += ",";
 			}
 			actions += al[i];

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -449,7 +449,7 @@ void VisualScriptYieldSignal::_validate_property(PropertyInfo &property) const {
 
 		String ml;
 		for (const String &E : mstring) {
-			if (ml != String()) {
+			if (!ml.is_empty()) {
 				ml += ",";
 			}
 			ml += E;

--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -83,11 +83,11 @@ bool WSLServer::PendingPeer::_parse_request(const Vector<String> p_protocols, St
 				break;
 			}
 			// Found a protocol
-			if (protocol != "") {
+			if (!protocol.is_empty()) {
 				break;
 			}
 		}
-		if (protocol == "") { // Invalid protocol(s) requested
+		if (protocol.is_empty()) { // Invalid protocol(s) requested
 			return false;
 		}
 	} else if (p_protocols.size() > 0) { // No protocol requested, but we need one
@@ -138,7 +138,7 @@ Error WSLServer::PendingPeer::do_handshake(const Vector<String> p_protocols, uin
 				s += "Upgrade: websocket\r\n";
 				s += "Connection: Upgrade\r\n";
 				s += "Sec-WebSocket-Accept: " + WSLPeer::compute_key_response(key) + "\r\n";
-				if (protocol != "") {
+				if (!protocol.is_empty()) {
 					s += "Sec-WebSocket-Protocol: " + protocol + "\r\n";
 				}
 				s += "\r\n";

--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -102,7 +102,7 @@ String DirAccessJAndroid::get_drive(int p_drive) {
 Error DirAccessJAndroid::change_dir(String p_dir) {
 	JNIEnv *env = get_jni_env();
 
-	if (p_dir == "" || p_dir == "." || (p_dir == ".." && current_dir == ""))
+	if (p_dir.is_empty() || p_dir == "." || (p_dir == ".." && current_dir.is_empty()))
 		return OK;
 
 	String new_dir;
@@ -114,7 +114,7 @@ Error DirAccessJAndroid::change_dir(String p_dir) {
 		new_dir = p_dir.substr(1, p_dir.length());
 	else if (p_dir.begins_with("res://"))
 		new_dir = p_dir.substr(6, p_dir.length());
-	else if (current_dir == "")
+	else if (current_dir.is_empty())
 		new_dir = p_dir;
 	else
 		new_dir = current_dir.plus_file(p_dir);
@@ -141,7 +141,7 @@ String DirAccessJAndroid::get_current_dir(bool p_include_drive) {
 
 bool DirAccessJAndroid::file_exists(String p_file) {
 	String sd;
-	if (current_dir == "")
+	if (current_dir.is_empty())
 		sd = p_file;
 	else
 		sd = current_dir.plus_file(p_file);
@@ -158,7 +158,7 @@ bool DirAccessJAndroid::dir_exists(String p_dir) {
 
 	String sd;
 
-	if (current_dir == "")
+	if (current_dir.is_empty())
 		sd = p_dir;
 	else {
 		if (p_dir.is_relative_path())

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -303,7 +303,7 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 						}
 					}
 
-					if (d.description == "") {
+					if (d.description.is_empty()) {
 						//in the oven, request!
 						args.clear();
 						args.push_back("-s");
@@ -352,7 +352,7 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 						}
 
 						d.name = vendor + " " + device;
-						if (device == String()) {
+						if (device.is_empty()) {
 							continue;
 						}
 					}
@@ -390,13 +390,13 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 
 String EditorExportPlatformAndroid::get_project_name(const String &p_name) const {
 	String aname;
-	if (p_name != "") {
+	if (!p_name.is_empty()) {
 		aname = p_name;
 	} else {
 		aname = ProjectSettings::get_singleton()->get("application/config/name");
 	}
 
-	if (aname == "") {
+	if (aname.is_empty()) {
 		aname = VERSION_NAME;
 	}
 
@@ -420,7 +420,7 @@ String EditorExportPlatformAndroid::get_package_name(const String &p_package) co
 			first = false;
 		}
 	}
-	if (name == "") {
+	if (name.is_empty()) {
 		name = "noname";
 	}
 
@@ -577,7 +577,7 @@ Vector<String> EditorExportPlatformAndroid::list_gdap_files(const String &p_path
 		da->list_dir_begin();
 		while (true) {
 			String file = da->get_next();
-			if (file == "") {
+			if (file.is_empty()) {
 				break;
 			}
 
@@ -2080,7 +2080,7 @@ bool EditorExportPlatformAndroid::can_export(const Ref<EditorExportPreset> &p_pr
 	}
 
 	String sdk_path = EditorSettings::get_singleton()->get("export/android/android_sdk_path");
-	if (sdk_path == "") {
+	if (sdk_path.is_empty()) {
 		err += TTR("A valid Android SDK path is required in Editor Settings.") + "\n";
 		valid = false;
 	} else {
@@ -2127,7 +2127,7 @@ bool EditorExportPlatformAndroid::can_export(const Ref<EditorExportPreset> &p_pr
 	if (apk_expansion) {
 		String apk_expansion_pkey = p_preset->get("apk_expansion/public_key");
 
-		if (apk_expansion_pkey == "") {
+		if (apk_expansion_pkey.is_empty()) {
 			valid = false;
 
 			err += TTR("Invalid public key for APK expansion.") + "\n";
@@ -2143,7 +2143,7 @@ bool EditorExportPlatformAndroid::can_export(const Ref<EditorExportPreset> &p_pr
 	}
 
 	String etc_error = test_etc2();
-	if (etc_error != String()) {
+	if (!etc_error.is_empty()) {
 		valid = false;
 		err += etc_error;
 	}
@@ -2680,13 +2680,13 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		src_apk = p_preset->get("custom_template/release");
 	}
 	src_apk = src_apk.strip_edges();
-	if (src_apk == "") {
+	if (src_apk.is_empty()) {
 		if (p_debug) {
 			src_apk = find_export_template("android_debug.apk");
 		} else {
 			src_apk = find_export_template("android_release.apk");
 		}
-		if (src_apk == "") {
+		if (src_apk.is_empty()) {
 			EditorNode::add_io_error(vformat(TTR("Package not found: %s"), src_apk));
 			return ERR_FILE_NOT_FOUND;
 		}

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -161,7 +161,7 @@ Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset
 	da->list_dir_begin();
 	while (true) {
 		String file = da->get_next();
-		if (file == "") {
+		if (file.is_empty()) {
 			break;
 		}
 		if (!file.begins_with("values-")) {

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -198,7 +198,7 @@ String OS_Android::get_resource_dir() const {
 
 String OS_Android::get_locale() const {
 	String locale = godot_io_java->get_locale();
-	if (locale != "") {
+	if (!locale.is_empty()) {
 		return locale;
 	}
 
@@ -207,7 +207,7 @@ String OS_Android::get_locale() const {
 
 String OS_Android::get_model_name() const {
 	String model = godot_io_java->get_model();
-	if (model != "")
+	if (!model.is_empty())
 		return model;
 
 	return OS_Unix::get_model_name();
@@ -218,11 +218,11 @@ String OS_Android::get_data_path() const {
 }
 
 String OS_Android::get_user_data_dir() const {
-	if (data_dir_cache != String())
+	if (!data_dir_cache.is_empty())
 		return data_dir_cache;
 
 	String data_dir = godot_io_java->get_user_data_dir();
-	if (data_dir != "") {
+	if (!data_dir.is_empty()) {
 		data_dir_cache = _remove_symlink(data_dir);
 		return data_dir_cache;
 	}
@@ -230,11 +230,11 @@ String OS_Android::get_user_data_dir() const {
 }
 
 String OS_Android::get_cache_path() const {
-	if (cache_dir_cache != String())
+	if (!cache_dir_cache.is_empty())
 		return cache_dir_cache;
 
 	String cache_dir = godot_io_java->get_cache_dir();
-	if (cache_dir != "") {
+	if (!cache_dir.is_empty()) {
 		cache_dir_cache = _remove_symlink(cache_dir);
 		return cache_dir_cache;
 	}
@@ -243,7 +243,7 @@ String OS_Android::get_cache_path() const {
 
 String OS_Android::get_unique_id() const {
 	String unique_id = godot_io_java->get_unique_id();
-	if (unique_id != "")
+	if (!unique_id.is_empty())
 		return unique_id;
 
 	return OS::get_unique_id();

--- a/platform/iphone/export/export_plugin.cpp
+++ b/platform/iphone/export/export_plugin.cpp
@@ -1363,10 +1363,10 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 		src_pkg_name = p_preset->get("custom_template/release");
 	}
 
-	if (src_pkg_name == "") {
+	if (src_pkg_name.is_empty()) {
 		String err;
 		src_pkg_name = find_export_template("iphone.zip", &err);
-		if (src_pkg_name == "") {
+		if (src_pkg_name.is_empty()) {
 			EditorNode::add_io_error(err);
 			return ERR_FILE_NOT_FOUND;
 		}
@@ -1767,7 +1767,7 @@ bool EditorExportPlatformIOS::can_export(const Ref<EditorExportPreset> &p_preset
 	}
 
 	String etc_error = test_etc2_or_pvrtc();
-	if (etc_error != String()) {
+	if (!etc_error.is_empty()) {
 		valid = false;
 		err += etc_error;
 	}

--- a/platform/javascript/export/export_plugin.cpp
+++ b/platform/javascript/export/export_plugin.cpp
@@ -380,7 +380,7 @@ bool EditorExportPlatformJavaScript::can_export(const Ref<EditorExportPreset> &p
 
 	if (p_preset->get("vram_texture_compression/for_mobile")) {
 		String etc_error = test_etc2();
-		if (etc_error != String()) {
+		if (!etc_error.is_empty()) {
 			valid = false;
 			err += etc_error;
 		}
@@ -415,7 +415,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 	// Find the correct template
 	String template_path = p_debug ? custom_debug : custom_release;
 	template_path = template_path.strip_edges();
-	if (template_path == String()) {
+	if (template_path.is_empty()) {
 		ExportMode mode = (ExportMode)(int)p_preset->get("variant/export_type");
 		template_path = find_export_template(_get_template_name(mode, p_debug));
 	}
@@ -424,7 +424,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 		return ERR_FILE_BAD_PATH;
 	}
 
-	if (template_path != String() && !FileAccess::exists(template_path)) {
+	if (!template_path.is_empty() && !FileAccess::exists(template_path)) {
 		EditorNode::get_singleton()->show_warning(TTR("Template file not found:") + "\n" + template_path);
 		return ERR_FILE_NOT_FOUND;
 	}

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -419,7 +419,7 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 	String mnt = get_mountpoint(p_path);
 
 	// If there is a directory "[Mountpoint]/.Trash-[UID], use it as the trash can.
-	if (mnt != "") {
+	if (!mnt.is_empty()) {
 		String path(mnt + "/.Trash-" + itos(getuid()));
 		struct stat s;
 		if (!stat(path.utf8().get_data(), &s)) {
@@ -428,7 +428,7 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 	}
 
 	// Otherwise, if ${XDG_DATA_HOME} is defined, use "${XDG_DATA_HOME}/Trash" as the trash can.
-	if (trash_path == "") {
+	if (trash_path.is_empty()) {
 		char *dhome = getenv("XDG_DATA_HOME");
 		if (dhome) {
 			trash_path = String(dhome) + "/Trash";
@@ -436,7 +436,7 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 	}
 
 	// Otherwise, if ${HOME} is defined, use "${HOME}/.local/share/Trash" as the trash can.
-	if (trash_path == "") {
+	if (trash_path.is_empty()) {
 		char *home = getenv("HOME");
 		if (home) {
 			trash_path = String(home) + "/.local/share/Trash";
@@ -444,7 +444,7 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 	}
 
 	// Issue an error if none of the previous locations is appropriate for the trash can.
-	ERR_FAIL_COND_V_MSG(trash_path == "", FAILED, "Could not determine the trash can location");
+	ERR_FAIL_COND_V_MSG(trash_path.is_empty(), FAILED, "Could not determine the trash can location");
 
 	// Create needed directories for decided trash can location.
 	{

--- a/platform/osx/export/export_plugin.cpp
+++ b/platform/osx/export/export_plugin.cpp
@@ -481,10 +481,10 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 		src_pkg_name = p_preset->get("custom_template/release");
 	}
 
-	if (src_pkg_name == "") {
+	if (src_pkg_name.is_empty()) {
 		String err;
 		src_pkg_name = find_export_template("osx.zip", &err);
-		if (src_pkg_name == "") {
+		if (src_pkg_name.is_empty()) {
 			EditorNode::add_io_error(err);
 			return ERR_FILE_NOT_FOUND;
 		}
@@ -607,7 +607,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 				iconpath = ProjectSettings::get_singleton()->get("application/config/icon");
 			}
 
-			if (iconpath != "") {
+			if (!iconpath.is_empty()) {
 				if (iconpath.get_extension() == "icns") {
 					FileAccess *icon = FileAccess::open(iconpath, FileAccess::READ);
 					if (icon) {
@@ -695,7 +695,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 
 		String ent_path = p_preset->get("codesign/entitlements/custom_file");
 		String hlp_ent_path = EditorPaths::get_singleton()->get_cache_dir().plus_file(pkg_name + "_helper.entitlements");
-		if (sign_enabled && (ent_path == "")) {
+		if (sign_enabled && (ent_path.is_empty())) {
 			ent_path = EditorPaths::get_singleton()->get_cache_dir().plus_file(pkg_name + ".entitlements");
 
 			FileAccess *ent_f = FileAccess::open(ent_path, FileAccess::WRITE);

--- a/platform/uwp/export/export_plugin.cpp
+++ b/platform/uwp/export/export_plugin.cpp
@@ -257,7 +257,7 @@ Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_p
 
 	Platform arch = (Platform)(int)p_preset->get("architecture/target");
 
-	if (src_appx == "") {
+	if (src_appx.is_empty()) {
 		String err, infix;
 		switch (arch) {
 			case ARM: {
@@ -275,7 +275,7 @@ Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_p
 		} else {
 			src_appx = find_export_template("uwp" + infix + "release.zip", &err);
 		}
-		if (src_appx == "") {
+		if (src_appx.is_empty()) {
 			EditorNode::add_io_error(err);
 			return ERR_FILE_NOT_FOUND;
 		}
@@ -431,7 +431,7 @@ Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_p
 #ifdef WINDOWS_ENABLED
 	// Sign with signtool
 	String signtool_path = EditorSettings::get_singleton()->get("export/uwp/signtool");
-	if (signtool_path == String()) {
+	if (signtool_path.is_empty()) {
 		return OK;
 	}
 
@@ -452,7 +452,7 @@ Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_p
 		cert_alg = p_preset->get("signing/algorithm");
 	}
 
-	if (cert_path == String()) {
+	if (cert_path.is_empty()) {
 		return OK; // Certificate missing, don't try to sign
 	}
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1565,7 +1565,7 @@ String DisplayServerWindows::keyboard_get_layout_name(int p_index) const {
 	GetKeyboardLayoutList(layout_count, layouts);
 
 	String ret = _get_full_layout_name_from_registry(layouts[p_index]); // Try reading full name from Windows registry, fallback to locale name if failed (e.g. on Wine).
-	if (ret == String()) {
+	if (ret.is_empty()) {
 		WCHAR buf[LOCALE_NAME_MAX_LENGTH];
 		memset(buf, 0, LOCALE_NAME_MAX_LENGTH * sizeof(WCHAR));
 		LCIDToLocaleName(MAKELCID(LOWORD(layouts[p_index]), SORT_DEFAULT), buf, LOCALE_NAME_MAX_LENGTH, 0);

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -82,7 +82,7 @@ void EditorExportPlatformWindows::get_export_options(List<ExportOption> *r_optio
 void EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset> &p_preset, const String &p_path) {
 	String rcedit_path = EditorSettings::get_singleton()->get("export/windows/rcedit");
 
-	if (rcedit_path == String()) {
+	if (rcedit_path.is_empty()) {
 		return;
 	}
 
@@ -95,12 +95,12 @@ void EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset>
 	// On non-Windows we need WINE to run rcedit
 	String wine_path = EditorSettings::get_singleton()->get("export/windows/wine");
 
-	if (wine_path != String() && !FileAccess::exists(wine_path)) {
+	if (!wine_path.is_empty() && !FileAccess::exists(wine_path)) {
 		ERR_PRINT("Could not find wine executable at " + wine_path + ", no icon or app information data will be included.");
 		return;
 	}
 
-	if (wine_path == String()) {
+	if (wine_path.is_empty()) {
 		wine_path = "wine"; // try to run wine from PATH
 	}
 #endif
@@ -117,39 +117,39 @@ void EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset>
 
 	List<String> args;
 	args.push_back(p_path);
-	if (icon_path != String()) {
+	if (!icon_path.is_empty()) {
 		args.push_back("--set-icon");
 		args.push_back(icon_path);
 	}
-	if (file_verion != String()) {
+	if (!file_verion.is_empty()) {
 		args.push_back("--set-file-version");
 		args.push_back(file_verion);
 	}
-	if (product_version != String()) {
+	if (!product_version.is_empty()) {
 		args.push_back("--set-product-version");
 		args.push_back(product_version);
 	}
-	if (company_name != String()) {
+	if (!company_name.is_empty()) {
 		args.push_back("--set-version-string");
 		args.push_back("CompanyName");
 		args.push_back(company_name);
 	}
-	if (product_name != String()) {
+	if (!product_name.is_empty()) {
 		args.push_back("--set-version-string");
 		args.push_back("ProductName");
 		args.push_back(product_name);
 	}
-	if (file_description != String()) {
+	if (!file_description.is_empty()) {
 		args.push_back("--set-version-string");
 		args.push_back("FileDescription");
 		args.push_back(file_description);
 	}
-	if (copyright != String()) {
+	if (!copyright.is_empty()) {
 		args.push_back("--set-version-string");
 		args.push_back("LegalCopyright");
 		args.push_back(copyright);
 	}
-	if (trademarks != String()) {
+	if (!trademarks.is_empty()) {
 		args.push_back("--set-version-string");
 		args.push_back("LegalTrademarks");
 		args.push_back(trademarks);
@@ -169,20 +169,20 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 
 #ifdef WINDOWS_ENABLED
 	String signtool_path = EditorSettings::get_singleton()->get("export/windows/signtool");
-	if (signtool_path != String() && !FileAccess::exists(signtool_path)) {
+	if (!signtool_path.is_empty() && !FileAccess::exists(signtool_path)) {
 		ERR_PRINT("Could not find signtool executable at " + signtool_path + ", aborting.");
 		return ERR_FILE_NOT_FOUND;
 	}
-	if (signtool_path == String()) {
+	if (signtool_path.is_empty()) {
 		signtool_path = "signtool"; // try to run signtool from PATH
 	}
 #else
 	String signtool_path = EditorSettings::get_singleton()->get("export/windows/osslsigncode");
-	if (signtool_path != String() && !FileAccess::exists(signtool_path)) {
+	if (!signtool_path.is_empty() && !FileAccess::exists(signtool_path)) {
 		ERR_PRINT("Could not find osslsigncode executable at " + signtool_path + ", aborting.");
 		return ERR_FILE_NOT_FOUND;
 	}
-	if (signtool_path == String()) {
+	if (signtool_path.is_empty()) {
 		signtool_path = "osslsigncode"; // try to run signtool from PATH
 	}
 #endif

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -606,7 +606,7 @@ String OS_Windows::get_locale() const {
 		wl++;
 	}
 
-	if (neutral != "")
+	if (!neutral.is_empty())
 		return String(neutral).replace("-", "_");
 
 	return "en";
@@ -757,11 +757,11 @@ String OS_Windows::get_system_dir(SystemDir p_dir, bool p_shared_storage) const 
 
 String OS_Windows::get_user_data_dir() const {
 	String appname = get_safe_dir_name(ProjectSettings::get_singleton()->get("application/config/name"));
-	if (appname != "") {
+	if (!appname.is_empty()) {
 		bool use_custom_dir = ProjectSettings::get_singleton()->get("application/config/use_custom_user_dir");
 		if (use_custom_dir) {
 			String custom_dir = get_safe_dir_name(ProjectSettings::get_singleton()->get("application/config/custom_user_dir_name"), true);
-			if (custom_dir == "") {
+			if (custom_dir.is_empty()) {
 				custom_dir = appname;
 			}
 			return get_data_path().plus_file(custom_dir).replace("\\", "/");

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -128,7 +128,7 @@ void AnimatedSprite2D::_validate_property(PropertyInfo &property) const {
 		}
 
 		if (!current_found) {
-			if (property.hint_string == String()) {
+			if (property.hint_string.is_empty()) {
 				property.hint_string = String(animation);
 			} else {
 				property.hint_string = String(animation) + "," + property.hint_string;

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -614,7 +614,7 @@ void LightmapGI::_gen_new_positions_from_octree(const GenProbesOctree *p_cell, f
 }
 
 LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_path, Lightmapper::BakeStepFunc p_bake_step, void *p_bake_userdata) {
-	if (p_image_data_path == "") {
+	if (p_image_data_path.is_empty()) {
 		if (get_light_data().is_null()) {
 			return BAKE_ERROR_NO_SAVE_PATH;
 		}

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -291,7 +291,7 @@ void OccluderInstance3D::_bake_node(Node *p_node, PackedVector3Array &r_vertices
 }
 
 OccluderInstance3D::BakeError OccluderInstance3D::bake(Node *p_from_node, String p_occluder_path) {
-	if (p_occluder_path == "") {
+	if (p_occluder_path.is_empty()) {
 		if (get_occluder().is_null()) {
 			return BAKE_ERROR_NO_SAVE_PATH;
 		}

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -506,7 +506,7 @@ int Skeleton3D::get_bone_axis_forward_enum(int p_bone) {
 // Skeleton creation api
 
 void Skeleton3D::add_bone(const String &p_name) {
-	ERR_FAIL_COND(p_name == "" || p_name.find(":") != -1 || p_name.find("/") != -1);
+	ERR_FAIL_COND(p_name.is_empty() || p_name.find(":") != -1 || p_name.find("/") != -1);
 
 	for (int i = 0; i < bones.size(); i++) {
 		ERR_FAIL_COND(bones[i].name == p_name);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1004,7 +1004,7 @@ void AnimatedSprite3D::_validate_property(PropertyInfo &property) const {
 		}
 
 		if (!current_found) {
-			if (property.hint_string == String()) {
+			if (property.hint_string.is_empty()) {
 				property.hint_string = String(animation);
 			} else {
 				property.hint_string = String(animation) + "," + property.hint_string;

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -57,7 +57,7 @@ void AnimationNodeAnimation::_validate_property(PropertyInfo &property) const {
 			}
 			anims += String(names[i]);
 		}
-		if (anims != String()) {
+		if (!anims.is_empty()) {
 			property.hint = PROPERTY_HINT_ENUM;
 			property.hint_string = anims;
 		}

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -52,7 +52,7 @@ void AnimationNodeStateMachineTransition::set_advance_condition(const StringName
 	String cs = p_condition;
 	ERR_FAIL_COND(cs.find("/") != -1 || cs.find(":") != -1);
 	advance_condition = p_condition;
-	if (cs != String()) {
+	if (!cs.is_empty()) {
 		advance_condition_name = "conditions/" + cs;
 	} else {
 		advance_condition_name = StringName();

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1416,7 +1416,7 @@ bool AnimationPlayer::is_playing() const {
 }
 
 void AnimationPlayer::set_current_animation(const String &p_anim) {
-	if (p_anim == "[stop]" || p_anim == "") {
+	if (p_anim == "[stop]" || p_anim.is_empty()) {
 		stop();
 	} else if (!is_playing() || playback.assigned != p_anim) {
 		play(p_anim);

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -138,7 +138,7 @@ real_t AnimationNode::_pre_process(const StringName &p_base_path, AnimationNode 
 void AnimationNode::make_invalid(const String &p_reason) {
 	ERR_FAIL_COND(!state);
 	state->valid = false;
-	if (state->invalid_reasons != String()) {
+	if (!state->invalid_reasons.is_empty()) {
 		state->invalid_reasons += "\n";
 	}
 	state->invalid_reasons += String::utf8("•  ") + p_reason;

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -226,7 +226,7 @@ void SceneDebugger::add_to_cache(const String &p_filename, Node *p_node) {
 		return;
 	}
 
-	if (EngineDebugger::get_script_debugger() && p_filename != String()) {
+	if (EngineDebugger::get_script_debugger() && !p_filename.is_empty()) {
 		debugger->live_scene_edit_cache[p_filename].insert(p_node);
 	}
 }

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -355,7 +355,7 @@ String BaseButton::get_tooltip(const Point2 &p_pos) const {
 	String tooltip = Control::get_tooltip(p_pos);
 	if (shortcut_in_tooltip && shortcut.is_valid() && shortcut->has_valid_event()) {
 		String text = shortcut->get_name() + " (" + shortcut->get_as_text() + ")";
-		if (tooltip != String() && shortcut->get_name().nocasecmp_to(tooltip) != 0) {
+		if (!tooltip.is_empty() && shortcut->get_name().nocasecmp_to(tooltip) != 0) {
 			text += "\n" + tooltip;
 		}
 		tooltip = text;

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -52,7 +52,7 @@ Size2 Button::get_minimum_size() const {
 
 			if (icon_alignment != HORIZONTAL_ALIGNMENT_CENTER) {
 				minsize.width += _icon->get_width();
-				if (xl_text != "") {
+				if (!xl_text.is_empty()) {
 					minsize.width += get_theme_constant(SNAME("hseparation"));
 				}
 			} else {
@@ -359,7 +359,7 @@ void Button::_shape() {
 	} else {
 		text_buf->set_direction((TextServer::Direction)text_direction);
 	}
-	text_buf->add_string(xl_text, font, font_size, opentype_features, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
+	text_buf->add_string(xl_text, font, font_size, opentype_features, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 }
 
 void Button::set_text(const String &p_text) {

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -189,7 +189,7 @@ void CodeEdit::_notification(int p_what) {
 			}
 
 			/* Code hint */
-			if (caret_visible && code_hint != "" && (!code_completion_active || (code_completion_below != code_hint_draw_below))) {
+			if (caret_visible && !code_hint.is_empty() && (!code_completion_active || (code_completion_below != code_hint_draw_below))) {
 				const int font_height = font->get_height(font_size);
 				Ref<StyleBox> sb = get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel"));
 				Color font_color = get_theme_color(SNAME("font_color"), SNAME("TooltipLabel"));
@@ -315,7 +315,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 		} else {
 			if (mb->get_button_index() == MouseButton::LEFT) {
-				if (mb->is_command_pressed() && symbol_lookup_word != String()) {
+				if (mb->is_command_pressed() && !symbol_lookup_word.is_empty()) {
 					Vector2i mpos = mb->get_position();
 					if (is_layout_rtl()) {
 						mpos.x = get_size().x - mpos.x;
@@ -530,7 +530,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 /* General overrides */
 Control::CursorShape CodeEdit::get_cursor_shape(const Point2 &p_pos) const {
-	if (symbol_lookup_word != String()) {
+	if (!symbol_lookup_word.is_empty()) {
 		return CURSOR_POINTING_HAND;
 	}
 
@@ -2597,7 +2597,7 @@ void CodeEdit::_add_delimiter(const String &p_start_key, const String &p_end_key
 	delimiter.type = p_type;
 	delimiter.start_key = p_start_key;
 	delimiter.end_key = p_end_key;
-	delimiter.line_only = p_line_only || p_end_key == "";
+	delimiter.line_only = p_line_only || p_end_key.is_empty();
 	delimiters.insert(at, delimiter);
 	if (!setting_delimiters) {
 		delimiter_cache.clear();
@@ -2647,7 +2647,7 @@ void CodeEdit::_set_delimiters(const TypedArray<String> &p_delimiters, Delimiter
 		const String start_key = key.get_slice(" ", 0);
 		const String end_key = key.get_slice_count(" ") > 1 ? key.get_slice(" ", 1) : String();
 
-		_add_delimiter(start_key, end_key, end_key == "", p_type);
+		_add_delimiter(start_key, end_key, end_key.is_empty(), p_type);
 	}
 	setting_delimiters = false;
 	_update_delimiter_cache();

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2791,7 +2791,7 @@ void Control::get_argument_options(const StringName &p_function, int p_idx, List
 TypedArray<String> Control::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
-	if (data.mouse_filter == MOUSE_FILTER_IGNORE && data.tooltip != "") {
+	if (data.mouse_filter == MOUSE_FILTER_IGNORE && !data.tooltip.is_empty()) {
 		warnings.push_back(TTR("The Hint Tooltip won't be displayed as the control's Mouse Filter is set to \"Ignore\". To solve this, set the Mouse Filter to \"Stop\" or \"Pass\"."));
 	}
 

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -242,7 +242,7 @@ Button *AcceptDialog::add_button(const String &p_text, bool p_right, const Strin
 		hbc->add_spacer(true);
 	}
 
-	if (p_action != "") {
+	if (!p_action.is_empty()) {
 		button->connect("pressed", callable_mp(this, &AcceptDialog::_custom_action), varray(p_action));
 	}
 
@@ -251,7 +251,7 @@ Button *AcceptDialog::add_button(const String &p_text, bool p_right, const Strin
 
 Button *AcceptDialog::add_cancel_button(const String &p_cancel) {
 	String c = p_cancel;
-	if (p_cancel == "") {
+	if (p_cancel.is_empty()) {
 		c = TTRC("Cancel");
 	}
 	Button *b = swap_cancel_ok ? add_button(c, true) : add_button(c);

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -458,7 +458,7 @@ void GraphNode::_shape() {
 	} else {
 		title_buf->set_direction((TextServer::Direction)text_direction);
 	}
-	title_buf->add_string(title, font, font_size, opentype_features, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
+	title_buf->add_string(title, font, font_size, opentype_features, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 }
 
 #ifdef TOOLS_ENABLED

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -43,7 +43,7 @@ void ItemList::_shape(int p_idx) {
 	} else {
 		item.text_buf->set_direction((TextServer::Direction)item.text_direction);
 	}
-	item.text_buf->add_string(item.text, get_theme_font(SNAME("font")), get_theme_font_size(SNAME("font_size")), item.opentype_features, (item.language != "") ? item.language : TranslationServer::get_singleton()->get_tool_locale());
+	item.text_buf->add_string(item.text, get_theme_font(SNAME("font")), get_theme_font_size(SNAME("font_size")), item.opentype_features, (!item.language.is_empty()) ? item.language : TranslationServer::get_singleton()->get_tool_locale());
 	if (icon_mode == ICON_MODE_TOP && max_text_lines > 0) {
 		item.text_buf->set_flags(TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND | TextServer::BREAK_GRAPHEME_BOUND);
 	} else {
@@ -653,7 +653,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (p_event->is_pressed() && items.size() > 0) {
 		if (p_event->is_action("ui_up")) {
-			if (search_string != "") {
+			if (!search_string.is_empty()) {
 				uint64_t now = OS::get_singleton()->get_ticks_msec();
 				uint64_t diff = now - search_time_msec;
 
@@ -683,7 +683,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				accept_event();
 			}
 		} else if (p_event->is_action("ui_down")) {
-			if (search_string != "") {
+			if (!search_string.is_empty()) {
 				uint64_t now = OS::get_singleton()->get_ticks_msec();
 				uint64_t diff = now - search_time_msec;
 
@@ -920,7 +920,7 @@ void ItemList::_notification(int p_what) {
 						minsize = items[i].get_icon_size() * icon_scale;
 					}
 
-					if (items[i].text != "") {
+					if (!items[i].text.is_empty()) {
 						if (icon_mode == ICON_MODE_TOP) {
 							minsize.y += icon_margin;
 						} else {
@@ -929,7 +929,7 @@ void ItemList::_notification(int p_what) {
 					}
 				}
 
-				if (items[i].text != "") {
+				if (!items[i].text.is_empty()) {
 					int max_width = -1;
 					if (fixed_column_width) {
 						max_width = fixed_column_width;
@@ -1188,7 +1188,7 @@ void ItemList::_notification(int p_what) {
 				draw_texture(items[i].tag_icon, draw_pos + base_ofs);
 			}
 
-			if (items[i].text != "") {
+			if (!items[i].text.is_empty()) {
 				int max_len = -1;
 
 				Vector2 size2 = items[i].text_buf->get_size();
@@ -1360,10 +1360,10 @@ String ItemList::get_tooltip(const Point2 &p_pos) const {
 		if (!items[closest].tooltip_enabled) {
 			return "";
 		}
-		if (items[closest].tooltip != "") {
+		if (!items[closest].tooltip.is_empty()) {
 			return items[closest].tooltip;
 		}
-		if (items[closest].text != "") {
+		if (!items[closest].text.is_empty()) {
 			return items[closest].text;
 		}
 	}

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -96,7 +96,7 @@ void Label::_shape() {
 		if (visible_chars >= 0) {
 			text = text.substr(0, visible_chars);
 		}
-		TS->shaped_text_add_string(text_rid, text, font->get_rids(), font_size, opentype_features, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
+		TS->shaped_text_add_string(text_rid, text, font->get_rids(), font_size, opentype_features, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 		TS->shaped_text_set_bidi_override(text_rid, structured_text_parser(st_parser, st_args, text));
 		dirty = false;
 		lines_dirty = true;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1017,7 +1017,7 @@ void LineEdit::paste_text() {
 	// Strip escape characters like \n and \t as they can't be displayed on LineEdit.
 	String paste_buffer = DisplayServer::get_singleton()->clipboard_get().strip_escapes();
 
-	if (paste_buffer != "") {
+	if (!paste_buffer.is_empty()) {
 		int prev_len = text.length();
 		if (selection.enabled) {
 			selection_delete();
@@ -2078,7 +2078,7 @@ void LineEdit::_shape() {
 	const Ref<Font> &font = get_theme_font(SNAME("font"));
 	int font_size = get_theme_font_size(SNAME("font_size"));
 	ERR_FAIL_COND(font.is_null());
-	TS->shaped_text_add_string(text_rid, t, font->get_rids(), font_size, opentype_features, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
+	TS->shaped_text_add_string(text_rid, t, font->get_rids(), font_size, opentype_features, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 	TS->shaped_text_set_bidi_override(text_rid, structured_text_parser(st_parser, st_args, t));
 
 	full_width = TS->shaped_text_get_size(text_rid).x;

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -42,7 +42,7 @@ void LinkButton::_shape() {
 		text_buf->set_direction((TextServer::Direction)text_direction);
 	}
 	TS->shaped_text_set_bidi_override(text_buf->get_rid(), structured_text_parser(st_parser, st_args, xl_text));
-	text_buf->add_string(xl_text, font, font_size, opentype_features, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
+	text_buf->add_string(xl_text, font, font_size, opentype_features, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 }
 
 void LinkButton::set_text(const String &p_text) {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -80,7 +80,7 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 			accel_max_w = MAX(accel_w, accel_max_w);
 		}
 
-		if (items[i].submenu != "") {
+		if (!items[i].submenu.is_empty()) {
 			size.width += get_theme_icon(SNAME("submenu"))->get_width();
 		}
 
@@ -326,13 +326,13 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 			set_input_as_handled();
 		}
 	} else if (p_event->is_action("ui_right") && p_event->is_pressed()) {
-		if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator && items[mouse_over].submenu != "" && submenu_over != mouse_over) {
+		if (mouse_over >= 0 && mouse_over < items.size() && !!items[mouse_over].separator && items[mouse_over].submenu.is_empty() && submenu_over != mouse_over) {
 			_activate_submenu(mouse_over);
 			set_input_as_handled();
 		}
 	} else if (p_event->is_action("ui_accept") && p_event->is_pressed()) {
 		if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator) {
-			if (items[mouse_over].submenu != "" && submenu_over != mouse_over) {
+			if (!items[mouse_over].submenu.is_empty() && submenu_over != mouse_over) {
 				_activate_submenu(mouse_over);
 			} else {
 				activate_item(mouse_over);
@@ -387,7 +387,7 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 					return;
 				}
 
-				if (items[over].submenu != "") {
+				if (!items[over].submenu.is_empty()) {
 					_activate_submenu(over);
 					return;
 				}
@@ -419,7 +419,7 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 			return;
 		}
 
-		if (items[over].submenu != "" && submenu_over != over) {
+		if (!items[over].submenu.is_empty() && submenu_over != over) {
 			submenu_over = over;
 			submenu_timer->start();
 		}
@@ -558,7 +558,7 @@ void PopupMenu::_draw_items() {
 		if (items[i].separator) {
 			int sep_h = separator->get_center_size().height + separator->get_minimum_size().height;
 			int sep_ofs = Math::floor((h - sep_h) / 2.0);
-			if (text != String()) {
+			if (!text.is_empty()) {
 				int text_size = items[i].text_buf->get_size().width;
 				int text_center = display_width / 2;
 				int text_left = text_center - text_size / 2;
@@ -599,7 +599,7 @@ void PopupMenu::_draw_items() {
 		}
 
 		// Submenu arrow on right hand side
-		if (items[i].submenu != "") {
+		if (!items[i].submenu.is_empty()) {
 			if (rtl) {
 				submenu->draw(ci, Point2(scroll_width + style->get_margin(SIDE_LEFT) + item_end_padding, item_ofs.y + Math::floor(h - submenu->get_height()) / 2), icon_color);
 			} else {
@@ -611,7 +611,7 @@ void PopupMenu::_draw_items() {
 		Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
 		int outline_size = get_theme_constant(SNAME("outline_size"));
 		if (items[i].separator) {
-			if (text != String()) {
+			if (!text.is_empty()) {
 				int center = (display_width - items[i].text_buf->get_size().width) / 2;
 				Vector2 text_pos = Point2(center, item_ofs.y + Math::floor((h - items[i].text_buf->get_size().y) / 2.0));
 				if (outline_size > 0 && font_outline_color.a > 0) {
@@ -701,7 +701,7 @@ void PopupMenu::_shape_item(int p_item) {
 		} else {
 			items.write[p_item].text_buf->set_direction((TextServer::Direction)items[p_item].text_direction);
 		}
-		items.write[p_item].text_buf->add_string(items.write[p_item].xl_text, font, font_size, items[p_item].opentype_features, (items[p_item].language != "") ? items[p_item].language : TranslationServer::get_singleton()->get_tool_locale());
+		items.write[p_item].text_buf->add_string(items.write[p_item].xl_text, font, font_size, items[p_item].opentype_features, !items[p_item].language.is_empty() ? items[p_item].language : TranslationServer::get_singleton()->get_tool_locale());
 
 		items.write[p_item].accel_text_buf->clear();
 		items.write[p_item].accel_text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
@@ -736,7 +736,7 @@ void PopupMenu::_notification(int p_what) {
 			grab_focus();
 		} break;
 		case NOTIFICATION_WM_MOUSE_EXIT: {
-			if (mouse_over >= 0 && (items[mouse_over].submenu == "" || submenu_over != -1)) {
+			if (mouse_over >= 0 && (items[mouse_over].submenu.is_empty() || submenu_over != -1)) {
 				mouse_over = -1;
 				control->update();
 			}
@@ -769,7 +769,7 @@ void PopupMenu::_notification(int p_what) {
 				}
 
 				for (int i = 0; i < items.size(); i++) {
-					if (items[i].submenu == "") {
+					if (items[i].submenu.is_empty()) {
 						continue;
 					}
 
@@ -1323,7 +1323,7 @@ bool PopupMenu::activate_item_by_event(const Ref<InputEvent> &p_event, bool p_fo
 			return true;
 		}
 
-		if (items[i].submenu != "") {
+		if (!items[i].submenu.is_empty()) {
 			Node *n = get_node(items[i].submenu);
 			if (!n) {
 				continue;
@@ -1412,7 +1412,7 @@ void PopupMenu::add_separator(const String &p_text, int p_id) {
 	Item sep;
 	sep.separator = true;
 	sep.id = p_id;
-	if (p_text != String()) {
+	if (!p_text.is_empty()) {
 		sep.text = p_text;
 		sep.xl_text = atr(p_text);
 	}
@@ -1510,7 +1510,7 @@ void PopupMenu::set_parent_rect(const Rect2 &p_rect) {
 
 void PopupMenu::get_translatable_strings(List<String> *p_strings) const {
 	for (int i = 0; i < items.size(); i++) {
-		if (items[i].xl_text != "") {
+		if (!items[i].xl_text.is_empty()) {
 			p_strings->push_back(items[i].xl_text);
 		}
 	}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -670,7 +670,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 			prefix = segment + prefix;
 		}
 	}
-	if (prefix != "") {
+	if (!prefix.is_empty()) {
 		Ref<Font> font = _find_font(l.from);
 		if (font.is_null()) {
 			font = get_theme_font(SNAME("normal_font"));
@@ -1423,7 +1423,7 @@ void RichTextLabel::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_ENTER_TREE: {
-			if (text != "") {
+			if (!text.is_empty()) {
 				set_text(text);
 			}
 
@@ -3853,7 +3853,7 @@ String RichTextLabel::get_selected_text() const {
 void RichTextLabel::selection_copy() {
 	String text = get_selected_text();
 
-	if (text != "") {
+	if (!text.is_empty()) {
 		DisplayServer::get_singleton()->clipboard_set(text);
 	}
 }
@@ -4005,7 +4005,7 @@ float RichTextLabel::get_percent_visible() const {
 
 void RichTextLabel::set_effects(Array p_effects) {
 	custom_effects = p_effects;
-	if ((text != "") && use_bbcode) {
+	if ((!text.is_empty()) && use_bbcode) {
 		parse_bbcode(text);
 	}
 }
@@ -4020,7 +4020,7 @@ void RichTextLabel::install_effect(const Variant effect) {
 
 	if (rteffect.is_valid()) {
 		custom_effects.push_back(effect);
-		if ((text != "") && use_bbcode) {
+		if ((!text.is_empty()) && use_bbcode) {
 			parse_bbcode(text);
 		}
 	}

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -41,10 +41,10 @@ Size2 SpinBox::get_minimum_size() const {
 
 void SpinBox::_value_changed(double) {
 	String value = TS->format_number(String::num(get_value(), Math::range_step_decimals(get_step())));
-	if (prefix != "") {
+	if (!prefix.is_empty()) {
 		value = prefix + " " + value;
 	}
-	if (suffix != "") {
+	if (!suffix.is_empty()) {
 		value += " " + suffix;
 	}
 	line_edit->set_text(value);

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -50,7 +50,7 @@ Size2 TabBar::get_minimum_size() const {
 		Ref<Texture2D> tex = tabs[i].icon;
 		if (tex.is_valid()) {
 			ms.height = MAX(ms.height, tex->get_size().height);
-			if (tabs[i].text != "") {
+			if (!tabs[i].text.is_empty()) {
 				ms.width += get_theme_constant(SNAME("hseparation"));
 			}
 		}
@@ -270,7 +270,7 @@ void TabBar::_shape(int p_tab) {
 		tabs.write[p_tab].text_buf->set_direction((TextServer::Direction)tabs[p_tab].text_direction);
 	}
 
-	tabs.write[p_tab].text_buf->add_string(tabs.write[p_tab].xl_text, font, font_size, tabs[p_tab].opentype_features, (tabs[p_tab].language != "") ? tabs[p_tab].language : TranslationServer::get_singleton()->get_tool_locale());
+	tabs.write[p_tab].text_buf->add_string(tabs.write[p_tab].xl_text, font, font_size, tabs[p_tab].opentype_features, !tabs[p_tab].language.is_empty() ? tabs[p_tab].language : TranslationServer::get_singleton()->get_tool_locale());
 }
 
 void TabBar::_notification(int p_what) {
@@ -385,7 +385,7 @@ void TabBar::_notification(int p_what) {
 					} else {
 						icon->draw(ci, Point2i(w, sb->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - icon->get_height()) / 2));
 					}
-					if (tabs[i].text != "") {
+					if (!tabs[i].text.is_empty()) {
 						w += icon->get_width() + get_theme_constant(SNAME("hseparation"));
 					}
 				}
@@ -980,7 +980,7 @@ int TabBar::get_tab_width(int p_idx) const {
 	Ref<Texture2D> tex = tabs[p_idx].icon;
 	if (tex.is_valid()) {
 		x += tex->get_width();
-		if (tabs[p_idx].text != "") {
+		if (!tabs[p_idx].text.is_empty()) {
 			x += get_theme_constant(SNAME("hseparation"));
 		}
 	}

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -561,7 +561,7 @@ void TabContainer::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, in
 		if (icon.is_valid()) {
 			int y = y_center - (icon->get_height() / 2);
 			icon->draw(canvas, Point2i(x_content, y));
-			if (text != "") {
+			if (!text.is_empty()) {
 				x_content += icon->get_width() + icon_text_distance;
 			}
 		}
@@ -656,7 +656,7 @@ int TabContainer::_get_tab_width(int p_index) const {
 		Ref<Texture2D> icon = control->get_meta("_tab_icon");
 		if (icon.is_valid()) {
 			width += icon->get_width();
-			if (text != "") {
+			if (!text.is_empty()) {
 				width += get_theme_constant(SNAME("icon_separation"));
 			}
 		}
@@ -1108,7 +1108,7 @@ void TabContainer::get_translatable_strings(List<String> *p_strings) const {
 
 		String name = c->get_meta("_tab_name");
 
-		if (name != "") {
+		if (!name.is_empty()) {
 			p_strings->push_back(name);
 		}
 	}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -601,7 +601,7 @@ void TextEdit::_notification(int p_what) {
 			String highlighted_text = get_selected_text();
 
 			// Check if highlighted words contain only whitespaces (tabs or spaces).
-			bool only_whitespaces_highlighted = highlighted_text.strip_edges() == String();
+			bool only_whitespaces_highlighted = highlighted_text.strip_edges().is_empty();
 
 			const int caret_wrap_index = get_caret_wrap_index();
 
@@ -916,7 +916,7 @@ void TextEdit::_notification(int p_what) {
 							switch (gutter.type) {
 								case GUTTER_TYPE_STRING: {
 									const String &text = get_line_gutter_text(line, g);
-									if (text == "") {
+									if (text.is_empty()) {
 										break;
 									}
 
@@ -2428,7 +2428,7 @@ void TextEdit::_update_caches() {
 	} else {
 		dir = (TextServer::Direction)text_direction;
 	}
-	text.set_direction_and_language(dir, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
+	text.set_direction_and_language(dir, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 	text.set_font_features(opentype_features);
 	text.set_draw_control_chars(draw_control_chars);
 	text.set_font(font);
@@ -2611,7 +2611,7 @@ void TextEdit::set_text_direction(Control::TextDirection p_text_direction) {
 		} else {
 			dir = (TextServer::Direction)text_direction;
 		}
-		text.set_direction_and_language(dir, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
+		text.set_direction_and_language(dir, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 		text.invalidate_all();
 
 		if (menu_dir) {
@@ -2662,7 +2662,7 @@ void TextEdit::set_language(const String &p_language) {
 		} else {
 			dir = (TextServer::Direction)text_direction;
 		}
-		text.set_direction_and_language(dir, (language != "") ? language : TranslationServer::get_singleton()->get_tool_locale());
+		text.set_direction_and_language(dir, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 		text.invalidate_all();
 		update();
 	}

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1536,7 +1536,7 @@ void Tree::update_column(int p_col) {
 		columns.write[p_col].text_buf->set_direction((TextServer::Direction)columns[p_col].text_direction);
 	}
 
-	columns.write[p_col].text_buf->add_string(columns[p_col].title, cache.font, cache.font_size, columns[p_col].opentype_features, (columns[p_col].language != "") ? columns[p_col].language : TranslationServer::get_singleton()->get_tool_locale());
+	columns.write[p_col].text_buf->add_string(columns[p_col].title, cache.font, cache.font_size, columns[p_col].opentype_features, !columns[p_col].language.is_empty() ? columns[p_col].language : TranslationServer::get_singleton()->get_tool_locale());
 }
 
 void Tree::update_item_cell(TreeItem *p_item, int p_col) {
@@ -1544,7 +1544,7 @@ void Tree::update_item_cell(TreeItem *p_item, int p_col) {
 
 	p_item->cells.write[p_col].text_buf->clear();
 	if (p_item->cells[p_col].mode == TreeItem::CELL_MODE_RANGE) {
-		if (p_item->cells[p_col].text != "") {
+		if (!p_item->cells[p_col].text.is_empty()) {
 			if (!p_item->cells[p_col].editable) {
 				return;
 			}
@@ -1571,7 +1571,7 @@ void Tree::update_item_cell(TreeItem *p_item, int p_col) {
 		valtext = p_item->cells[p_col].text;
 	}
 
-	if (p_item->cells[p_col].suffix != String()) {
+	if (!p_item->cells[p_col].suffix.is_empty()) {
 		valtext += " " + p_item->cells[p_col].suffix;
 	}
 
@@ -1594,7 +1594,7 @@ void Tree::update_item_cell(TreeItem *p_item, int p_col) {
 	} else {
 		font_size = cache.font_size;
 	}
-	p_item->cells.write[p_col].text_buf->add_string(valtext, font, font_size, p_item->cells[p_col].opentype_features, (p_item->cells[p_col].language != "") ? p_item->cells[p_col].language : TranslationServer::get_singleton()->get_tool_locale());
+	p_item->cells.write[p_col].text_buf->add_string(valtext, font, font_size, p_item->cells[p_col].opentype_features, !p_item->cells[p_col].language.is_empty() ? p_item->cells[p_col].language : TranslationServer::get_singleton()->get_tool_locale());
 	TS->shaped_text_set_bidi_override(p_item->cells[p_col].text_buf->get_rid(), structured_text_parser(p_item->cells[p_col].st_parser, p_item->cells[p_col].st_args, valtext));
 	p_item->cells.write[p_col].dirty = false;
 }
@@ -1660,7 +1660,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 			if (p_item->cells[i].expand_right) {
 				int plus = 1;
-				while (i + plus < columns.size() && !p_item->cells[i + plus].editable && p_item->cells[i + plus].mode == TreeItem::CELL_MODE_STRING && p_item->cells[i + plus].text == "" && p_item->cells[i + plus].icon.is_null()) {
+				while (i + plus < columns.size() && !p_item->cells[i + plus].editable && p_item->cells[i + plus].mode == TreeItem::CELL_MODE_STRING && p_item->cells[i + plus].text.is_empty() && p_item->cells[i + plus].icon.is_null()) {
 					w += get_column_width(i + plus);
 					plus++;
 					skip2++;
@@ -1857,7 +1857,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 				} break;
 				case TreeItem::CELL_MODE_RANGE: {
-					if (p_item->cells[i].text != "") {
+					if (!p_item->cells[i].text.is_empty()) {
 						if (!p_item->cells[i].editable) {
 							break;
 						}
@@ -2337,7 +2337,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 
 			if (p_item->cells[i].expand_right) {
 				int plus = 1;
-				while (i + plus < columns.size() && !p_item->cells[i + plus].editable && p_item->cells[i + plus].mode == TreeItem::CELL_MODE_STRING && p_item->cells[i + plus].text == "" && p_item->cells[i + plus].icon.is_null()) {
+				while (i + plus < columns.size() && !p_item->cells[i + plus].editable && p_item->cells[i + plus].mode == TreeItem::CELL_MODE_STRING && p_item->cells[i + plus].text.is_empty() && p_item->cells[i + plus].icon.is_null()) {
 					col_width += cache.hseparation;
 					col_width += get_column_width(i + plus);
 					plus++;
@@ -2520,7 +2520,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 
 			} break;
 			case TreeItem::CELL_MODE_RANGE: {
-				if (c.text != "") {
+				if (!c.text.is_empty()) {
 					//if (x >= (get_column_width(col)-item_h/2)) {
 					popup_menu->clear();
 					for (int i = 0; i < c.text.get_slice_count(","); i++) {
@@ -3430,7 +3430,7 @@ bool Tree::edit_selected() {
 		item_edited(col, s);
 
 		return true;
-	} else if (c.mode == TreeItem::CELL_MODE_RANGE && c.text != "") {
+	} else if (c.mode == TreeItem::CELL_MODE_RANGE && !c.text.is_empty()) {
 		popup_menu->clear();
 		for (int i = 0; i < c.text.get_slice_count(","); i++) {
 			String s2 = c.text.get_slicec(',', i);
@@ -4679,7 +4679,7 @@ String Tree::get_tooltip(const Point2 &p_pos) const {
 				Size2 size = b->get_size() + cache.button_pressed->get_minimum_size();
 				if (pos.x > col_width - size.width) {
 					String tooltip = c.buttons[j].tooltip;
-					if (tooltip != "") {
+					if (!tooltip.is_empty()) {
 						return tooltip;
 					}
 				}

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -243,7 +243,7 @@ bool HTTPRequest::_handle_response(bool *ret_value) {
 			}
 		}
 
-		if (new_request != "") {
+		if (!new_request.is_empty()) {
 			// Process redirect
 			client->close();
 			int new_redirs = redirections + 1; // Because _request() will clear it
@@ -363,7 +363,7 @@ bool HTTPRequest::_update_connection() {
 					return true;
 				}
 
-				if (download_to_file != String()) {
+				if (!download_to_file.is_empty()) {
 					file = FileAccess::open(download_to_file, FileAccess::WRITE);
 					if (!file) {
 						call_deferred(SNAME("_request_done"), RESULT_DOWNLOAD_FILE_CANT_OPEN, response_code, response_headers, PackedByteArray());

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -892,7 +892,7 @@ void Node::_set_name_nocheck(const StringName &p_name) {
 void Node::set_name(const String &p_name) {
 	String name = p_name.validate_node_name();
 
-	ERR_FAIL_COND(name == "");
+	ERR_FAIL_COND(name.is_empty());
 	data.name = name;
 
 	if (data.parent) {
@@ -1990,7 +1990,7 @@ Node *Node::_duplicate(int p_flags, Map<const Node *, Node *> *r_duplimap) const
 		nip->set_instance_path(ip->get_instance_path());
 		node = nip;
 
-	} else if ((p_flags & DUPLICATE_USE_INSTANCING) && get_scene_file_path() != String()) {
+	} else if ((p_flags & DUPLICATE_USE_INSTANCING) && !get_scene_file_path().is_empty()) {
 		Ref<PackedScene> res = ResourceLoader::load(get_scene_file_path());
 		ERR_FAIL_COND_V(res.is_null(), nullptr);
 		PackedScene::GenEditState ges = PackedScene::GEN_EDIT_STATE_DISABLED;
@@ -2014,7 +2014,7 @@ Node *Node::_duplicate(int p_flags, Map<const Node *, Node *> *r_duplimap) const
 		ERR_FAIL_COND_V(!node, nullptr);
 	}
 
-	if (get_scene_file_path() != "") { //an instance
+	if (!get_scene_file_path().is_empty()) { //an instance
 		node->set_scene_file_path(get_scene_file_path());
 		node->data.editable_instance = data.editable_instance;
 	}
@@ -2046,7 +2046,7 @@ Node *Node::_duplicate(int p_flags, Map<const Node *, Node *> *r_duplimap) const
 
 				node_tree.push_back(descendant);
 
-				if (descendant->get_scene_file_path() != "" && instance_roots.has(descendant->get_owner())) {
+				if (!descendant->get_scene_file_path().is_empty() && instance_roots.has(descendant->get_owner())) {
 					instance_roots.push_back(descendant);
 				}
 			}

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -510,7 +510,7 @@ bool SceneTree::process(double p_time) {
 			cpath = fallback->get_path();
 		}
 		if (cpath != env_path) {
-			if (env_path != String()) {
+			if (!env_path.is_empty()) {
 				fallback = ResourceLoader::load(env_path);
 				if (fallback.is_null()) {
 					//could not load fallback, set as empty
@@ -1290,7 +1290,7 @@ void SceneTree::get_argument_options(const StringName &p_function, int p_idx, Li
 			dir_access->list_dir_begin();
 			String filename = dir_access->get_next();
 
-			while (filename != "") {
+			while (!filename.is_empty()) {
 				if (filename == "." || filename == "..") {
 					filename = dir_access->get_next();
 					continue;
@@ -1400,7 +1400,7 @@ SceneTree::SceneTree() {
 		ResourceLoader::get_recognized_extensions_for_type("Environment", &exts);
 		String ext_hint;
 		for (const String &E : exts) {
-			if (ext_hint != String()) {
+			if (!ext_hint.is_empty()) {
 				ext_hint += ",";
 			}
 			ext_hint += "*." + E;
@@ -1410,7 +1410,7 @@ SceneTree::SceneTree() {
 		// Setup property.
 		ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/defaults/default_environment", PropertyInfo(Variant::STRING, "rendering/viewport/default_environment", PROPERTY_HINT_FILE, ext_hint));
 		env_path = env_path.strip_edges();
-		if (env_path != String()) {
+		if (!env_path.is_empty()) {
 			Ref<Environment> env = ResourceLoader::load(env_path);
 			if (env.is_valid()) {
 				root->get_world_3d()->set_fallback_environment(env);

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -164,7 +164,7 @@ Vector<SceneState::PackState> PropertyUtils::get_node_states_stack(const Node *p
 					}
 				}
 				break;
-			} else if (n->get_scene_file_path() != String()) {
+			} else if (!n->get_scene_file_path().is_empty()) {
 				const Ref<SceneState> &state = n->get_scene_instance_state();
 				_collect_inheritance_chain(state, n->get_path_to(p_node), states_stack);
 			}

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1046,7 +1046,7 @@ void initialize_theme() {
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/custom_font", PropertyInfo(Variant::STRING, "gui/theme/custom_font", PROPERTY_HINT_FILE, "*.tres,*.res,*.font", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
 
 	Ref<Font> font;
-	if (font_path != String()) {
+	if (!font_path.is_empty()) {
 		font = ResourceLoader::load(font_path);
 		if (!font.is_valid()) {
 			ERR_PRINT("Error loading custom font '" + font_path + "'");
@@ -1058,7 +1058,7 @@ void initialize_theme() {
 		make_default_theme(default_theme_hidpi, font);
 	}
 
-	if (theme_path != String()) {
+	if (!theme_path.is_empty()) {
 		Ref<Theme> theme = ResourceLoader::load(theme_path);
 		if (theme.is_valid()) {
 			Theme::set_project_default(theme);

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -653,7 +653,7 @@ Ref<ArrayMesh> ImporterMesh::get_mesh(const Ref<ArrayMesh> &p_base) {
 			if (surfaces[i].material.is_valid()) {
 				mesh->surface_set_material(mesh->get_surface_count() - 1, surfaces[i].material);
 			}
-			if (surfaces[i].name != String()) {
+			if (!surfaces[i].name.is_empty()) {
 				mesh->surface_set_name(mesh->get_surface_count() - 1, surfaces[i].name);
 			}
 		}
@@ -839,7 +839,7 @@ Dictionary ImporterMesh::_get_data() const {
 			d["material"] = surfaces[i].material;
 		}
 
-		if (surfaces[i].name != String()) {
+		if (!surfaces[i].name.is_empty()) {
 			d["name"] = surfaces[i].name;
 		}
 

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1104,7 +1104,7 @@ Array ArrayMesh::_get_surfaces() const {
 			data["material"] = surfaces[i].material;
 		}
 
-		if (surfaces[i].name != String()) {
+		if (!surfaces[i].name.is_empty()) {
 			data["name"] = surfaces[i].name;
 		}
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -417,7 +417,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 
 	// save the child instantiated scenes that are chosen as editable, so they can be restored
 	// upon load back
-	if (p_node != p_owner && p_node->get_scene_file_path() != String() && p_owner->is_editable_instance(p_node)) {
+	if (p_node != p_owner && !p_node->get_scene_file_path().is_empty() && p_owner->is_editable_instance(p_node)) {
 		editable_instances.push_back(p_owner->get_path_to(p_node));
 		// Node is the root of an editable instance.
 		is_editable_instance = true;
@@ -451,7 +451,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 	bool instantiated_by_owner = false;
 	Vector<SceneState::PackState> states_stack = PropertyUtils::get_node_states_stack(p_node, p_owner, &instantiated_by_owner);
 
-	if (p_node->get_scene_file_path() != String() && p_node->get_owner() == p_owner && instantiated_by_owner) {
+	if (!p_node->get_scene_file_path().is_empty() && p_node->get_owner() == p_owner && instantiated_by_owner) {
 		if (p_node->get_scene_instance_load_placeholder()) {
 			//it's a placeholder, use the placeholder path
 			nd.instance = _vm_get_variant(p_node->get_scene_file_path(), variant_map);
@@ -656,7 +656,7 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, Map<StringName
 
 			ERR_CONTINUE(!common_parent);
 
-			if (common_parent != p_owner && common_parent->get_scene_file_path() == String()) {
+			if (common_parent != p_owner && common_parent->get_scene_file_path().is_empty()) {
 				common_parent = common_parent->get_owner();
 			}
 
@@ -716,7 +716,7 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, Map<StringName
 
 						nl = nullptr;
 					} else {
-						if (nl->get_scene_file_path() != String()) {
+						if (!nl->get_scene_file_path().is_empty()) {
 							//is an instance
 							Ref<SceneState> state = nl->get_scene_instance_state();
 							if (state.is_valid()) {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -274,12 +274,12 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 					}
 				}
 
-				if (assign != String()) {
+				if (!assign.is_empty()) {
 					int nameidx = packed_scene->get_state()->add_name(assign);
 					int valueidx = packed_scene->get_state()->add_value(value);
 					packed_scene->get_state()->add_node_property(node_id, nameidx, valueidx);
 					//it's assignment
-				} else if (next_tag.name != String()) {
+				} else if (!next_tag.name.is_empty()) {
 					break;
 				}
 			}
@@ -575,12 +575,12 @@ Error ResourceLoaderText::load() {
 				return error;
 			}
 
-			if (assign != String()) {
+			if (!assign.is_empty()) {
 				if (do_assign) {
 					res->set(assign, value);
 				}
 				//it's assignment
-			} else if (next_tag.name != String()) {
+			} else if (!next_tag.name.is_empty()) {
 				error = OK;
 				break;
 			} else {
@@ -659,10 +659,10 @@ Error ResourceLoaderText::load() {
 				return error;
 			}
 
-			if (assign != String()) {
+			if (!assign.is_empty()) {
 				resource->set(assign, value);
 				//it's assignment
-			} else if (next_tag.name != String()) {
+			} else if (!next_tag.name.is_empty()) {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Extra tag found when parsing main resource file";
 				_printerr();
@@ -1166,13 +1166,13 @@ Error ResourceLoaderText::save_as_binary(FileAccess *p_f, const String &p_path) 
 				return error;
 			}
 
-			if (assign != String()) {
+			if (!assign.is_empty()) {
 				Map<StringName, int> empty_string_map; //unused
 				bs_save_unicode_string(wf2, assign, true);
 				ResourceFormatSaverBinaryInstance::write_variant(wf2, value, dummy_read.resource_index_map, dummy_read.external_resources, empty_string_map);
 				prop_count++;
 
-			} else if (next_tag.name != String()) {
+			} else if (!next_tag.name.is_empty()) {
 				error = OK;
 				break;
 			} else {
@@ -1350,7 +1350,7 @@ RES ResourceFormatLoaderText::load(const String &p_path, const String &p_origina
 	ERR_FAIL_COND_V_MSG(err != OK, RES(), "Cannot open file '" + p_path + "'.");
 
 	ResourceLoaderText loader;
-	String path = p_original_path != "" ? p_original_path : p_path;
+	String path = !p_original_path.is_empty() ? p_original_path : p_path;
 	loader.cache_mode = p_cache_mode;
 	loader.use_sub_threads = p_use_sub_threads;
 	loader.local_path = ProjectSettings::get_singleton()->localize_path(path);
@@ -1369,7 +1369,7 @@ RES ResourceFormatLoaderText::load(const String &p_path, const String &p_origina
 }
 
 void ResourceFormatLoaderText::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
-	if (p_type == "") {
+	if (p_type.is_empty()) {
 		get_recognized_extensions(p_extensions);
 		return;
 	}
@@ -1655,7 +1655,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 	Set<String> cached_ids_found;
 	for (KeyValue<RES, String> &E : external_resources) {
 		String cached_id = E.key->get_id_for_path(local_path);
-		if (cached_id == "" || cached_ids_found.has(cached_id)) {
+		if (cached_id.is_empty() || cached_ids_found.has(cached_id)) {
 			int sep_pos = E.value.find("_");
 			if (sep_pos != -1) {
 				E.value = E.value.substr(0, sep_pos + 1); // Keep the order found, for improved thread loading performance.
@@ -1729,7 +1729,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 	for (List<RES>::Element *E = saved_resources.front(); E; E = E->next()) {
 		RES res = E->get();
 		if (E->next() && res->is_built_in()) {
-			if (res->get_scene_unique_id() != "") {
+			if (!res->get_scene_unique_id().is_empty()) {
 				if (used_unique_ids.has(res->get_scene_unique_id())) {
 					res->set_scene_unique_id(""); // Repeated.
 				} else {
@@ -1752,7 +1752,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 			f->store_line("[resource]");
 		} else {
 			String line = "[sub_resource ";
-			if (res->get_scene_unique_id() == "") {
+			if (res->get_scene_unique_id().is_empty()) {
 				String new_id;
 				while (true) {
 					new_id = res->get_class() + "_" + Resource::generate_scene_unique_id();
@@ -1866,7 +1866,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 
 			f->store_string(header);
 
-			if (instance_placeholder != String()) {
+			if (!instance_placeholder.is_empty()) {
 				String vars;
 				f->store_string(" instance_placeholder=");
 				VariantWriter::write_to_string(instance_placeholder, vars, _write_resources, this);

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -493,7 +493,7 @@ void CodeHighlighter::add_color_region(const String &p_start_key, const String &
 	color_region.color = p_color;
 	color_region.start_key = p_start_key;
 	color_region.end_key = p_end_key;
-	color_region.line_only = p_line_only || p_end_key == "";
+	color_region.line_only = p_line_only || p_end_key.is_empty();
 	color_regions.insert(at, color_region);
 	clear_highlighting_cache();
 }
@@ -529,7 +529,7 @@ void CodeHighlighter::set_color_regions(const Dictionary &p_color_regions) {
 		String start_key = key.get_slice(" ", 0);
 		String end_key = key.get_slice_count(" ") > 1 ? key.get_slice(" ", 1) : String();
 
-		add_color_region(start_key, end_key, p_color_regions[key], end_key == "");
+		add_color_region(start_key, end_key, p_color_regions[key], end_key.is_empty());
 	}
 	clear_highlighting_cache();
 }

--- a/scene/resources/text_file.cpp
+++ b/scene/resources/text_file.cpp
@@ -33,7 +33,7 @@
 #include "core/io/file_access.h"
 
 bool TextFile::has_text() const {
-	return text != "";
+	return !text.is_empty();
 }
 
 String TextFile::get_text() const {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -553,7 +553,7 @@ Error StreamTexture2D::load(const String &p_path) {
 	path_to_file = p_path;
 	format = image->get_format();
 
-	if (get_path() == String()) {
+	if (get_path().is_empty()) {
 		//temporarily set path if no path set for resource, helps find errors
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
@@ -927,7 +927,7 @@ Error StreamTexture3D::load(const String &p_path) {
 
 	path_to_file = p_path;
 
-	if (get_path() == String()) {
+	if (get_path().is_empty()) {
 		//temporarily set path if no path set for resource, helps find errors
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
@@ -2680,7 +2680,7 @@ Error StreamTextureLayered::load(const String &p_path) {
 
 	path_to_file = p_path;
 
-	if (get_path() == String()) {
+	if (get_path().is_empty()) {
 		//temporarily set path if no path set for resource, helps find errors
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -979,7 +979,7 @@ String VisualShader::generate_preview_shader(Type p_type, int p_node, int p_port
 String VisualShader::validate_port_name(const String &p_port_name, VisualShaderNode *p_node, int p_port_id, bool p_output) const {
 	String name = p_port_name;
 
-	if (name == String()) {
+	if (name.is_empty()) {
 		return String();
 	}
 
@@ -987,7 +987,7 @@ String VisualShader::validate_port_name(const String &p_port_name, VisualShaderN
 		name = name.substr(1, name.length() - 1);
 	}
 
-	if (name != String()) {
+	if (!name.is_empty()) {
 		String valid_name;
 
 		for (int i = 0; i < name.length(); i++) {
@@ -1031,7 +1031,7 @@ String VisualShader::validate_uniform_name(const String &p_name, const Ref<Visua
 	while (name.length() && !IS_INITIAL_CHAR(name[0])) {
 		name = name.substr(1, name.length() - 1);
 	}
-	if (name != String()) {
+	if (!name.is_empty()) {
 		String valid_name;
 
 		for (int i = 0; i < name.length(); i++) {
@@ -1045,7 +1045,7 @@ String VisualShader::validate_uniform_name(const String &p_name, const Ref<Visua
 		name = valid_name;
 	}
 
-	if (name == String()) {
+	if (name.is_empty()) {
 		name = p_uniform->get_caption();
 	}
 
@@ -1075,7 +1075,7 @@ String VisualShader::validate_uniform_name(const String &p_name, const Ref<Visua
 			while (name.length() && name[name.length() - 1] >= '0' && name[name.length() - 1] <= '9') {
 				name = name.substr(0, name.length() - 1);
 			}
-			ERR_FAIL_COND_V(name == String(), String());
+			ERR_FAIL_COND_V(name.is_empty(), String());
 			name += itos(attempt);
 		} else {
 			break;
@@ -1568,7 +1568,7 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 	}
 
 	node_code += vsnode->generate_code(get_mode(), type, node, inputs, outputs, for_preview);
-	if (node_code != String()) {
+	if (!node_code.is_empty()) {
 		code += node_name;
 		code += node_code;
 		code += "\n";
@@ -1664,7 +1664,7 @@ void VisualShader::_update_shader() const {
 						String mode = ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(shader_mode))[i];
 						if (mode.begins_with(render_mode_enums[idx].string)) {
 							if (count == which) {
-								if (render_mode != String()) {
+								if (!render_mode.is_empty()) {
 									render_mode += ", ";
 								}
 								render_mode += mode;
@@ -1682,7 +1682,7 @@ void VisualShader::_update_shader() const {
 		for (int i = 0; i < ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(shader_mode)).size(); i++) {
 			String mode = ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(shader_mode))[i];
 			if (flags.has(mode)) {
-				if (render_mode != String()) {
+				if (!render_mode.is_empty()) {
 					render_mode += ", ";
 				}
 				render_mode += mode;
@@ -1690,7 +1690,7 @@ void VisualShader::_update_shader() const {
 		}
 	}
 
-	if (render_mode != String()) {
+	if (!render_mode.is_empty()) {
 		global_code += "render_mode " + render_mode + ";\n\n";
 	}
 
@@ -2468,7 +2468,7 @@ String VisualShaderNodeInput::generate_code(Shader::Mode p_mode, VisualShader::T
 			idx++;
 		}
 
-		if (code == String()) {
+		if (code.is_empty()) {
 			switch (get_output_port_type(0)) {
 				case PORT_TYPE_SCALAR: {
 					code = "	" + p_output_vars[0] + " = 0.0;\n";
@@ -2502,7 +2502,7 @@ String VisualShaderNodeInput::generate_code(Shader::Mode p_mode, VisualShader::T
 			idx++;
 		}
 
-		if (code == String()) {
+		if (code.is_empty()) {
 			code = "	" + p_output_vars[0] + " = 0.0;\n"; //default (none found) is scalar
 		}
 
@@ -2605,7 +2605,7 @@ void VisualShaderNodeInput::_validate_property(PropertyInfo &property) const {
 
 		while (ports[idx].mode != Shader::MODE_MAX) {
 			if (ports[idx].mode == shader_mode && ports[idx].shader_type == shader_type) {
-				if (port_list != String()) {
+				if (!port_list.is_empty()) {
 					port_list += ",";
 				}
 				port_list += ports[idx].name;
@@ -2613,7 +2613,7 @@ void VisualShaderNodeInput::_validate_property(PropertyInfo &property) const {
 			idx++;
 		}
 
-		if (port_list == "") {
+		if (port_list.is_empty()) {
 			port_list = TTR("None");
 		}
 		property.hint_string = port_list;
@@ -3063,7 +3063,7 @@ String VisualShaderNodeOutput::generate_code(Shader::Mode p_mode, VisualShader::
 	String code;
 	while (ports[idx].mode != Shader::MODE_MAX) {
 		if (ports[idx].mode == shader_mode && ports[idx].shader_type == shader_type) {
-			if (p_input_vars[count] != String()) {
+			if (!p_input_vars[count].is_empty()) {
 				String s = ports[idx].string;
 				if (s.find(":") != -1) {
 					code += "	" + s.get_slicec(':', 0) + " = " + p_input_vars[count] + "." + s.get_slicec(':', 1) + ";\n";

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -535,15 +535,15 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 	if (source == SOURCE_TEXTURE) {
 		String id = make_unique_id(p_type, p_id, "tex");
 		String code;
-		if (p_input_vars[0] == String()) { // Use UV by default.
+		if (p_input_vars[0].is_empty()) { // Use UV by default.
 
-			if (p_input_vars[1] == String()) {
+			if (p_input_vars[1].is_empty()) {
 				code += "	vec4 " + id + "_read = texture(" + id + ", " + default_uv + ");\n";
 			} else {
 				code += "	vec4 " + id + "_read = textureLod(" + id + ", " + default_uv + ", " + p_input_vars[1] + ");\n";
 			}
 
-		} else if (p_input_vars[1] == String()) {
+		} else if (p_input_vars[1].is_empty()) {
 			//no lod
 			code += "	vec4 " + id + "_read = texture(" + id + ", " + p_input_vars[0] + ".xy);\n";
 		} else {
@@ -560,18 +560,18 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 
 		String code;
 		code += "	{\n";
-		if (id == String()) {
+		if (id.is_empty()) {
 			code += "		vec4 " + id + "_tex_read = vec4(0.0);\n";
 		} else {
-			if (p_input_vars[0] == String()) { // Use UV by default.
+			if (p_input_vars[0].is_empty()) { // Use UV by default.
 
-				if (p_input_vars[1] == String()) {
+				if (p_input_vars[1].is_empty()) {
 					code += "		vec4 " + id + "_tex_read = texture(" + id + ", " + default_uv + ");\n";
 				} else {
 					code += "		vec4 " + id + "_tex_read = textureLod(" + id + ", " + default_uv + ", " + p_input_vars[1] + ");\n";
 				}
 
-			} else if (p_input_vars[1] == String()) {
+			} else if (p_input_vars[1].is_empty()) {
 				//no lod
 				code += "		vec4 " + id + "_tex_read = texture(" + id + ", " + p_input_vars[0] + ".xy);\n";
 			} else {
@@ -587,15 +587,15 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 
 	if (source == SOURCE_SCREEN && (p_mode == Shader::MODE_SPATIAL || p_mode == Shader::MODE_CANVAS_ITEM) && p_type == VisualShader::TYPE_FRAGMENT) {
 		String code = "	{\n";
-		if (p_input_vars[0] == String() || p_for_preview) { // Use UV by default.
+		if (p_input_vars[0].is_empty() || p_for_preview) { // Use UV by default.
 
-			if (p_input_vars[1] == String()) {
+			if (p_input_vars[1].is_empty()) {
 				code += "		vec4 _tex_read = textureLod(SCREEN_TEXTURE, " + default_uv + ", 0.0 );\n";
 			} else {
 				code += "		vec4 _tex_read = textureLod(SCREEN_TEXTURE, " + default_uv + ", " + p_input_vars[1] + ");\n";
 			}
 
-		} else if (p_input_vars[1] == String()) {
+		} else if (p_input_vars[1].is_empty()) {
 			//no lod
 			code += "		vec4 _tex_read = textureLod(SCREEN_TEXTURE, " + p_input_vars[0] + ".xy, 0.0);\n";
 		} else {
@@ -610,15 +610,15 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 
 	if (source == SOURCE_2D_TEXTURE && p_mode == Shader::MODE_CANVAS_ITEM && p_type == VisualShader::TYPE_FRAGMENT) {
 		String code = "	{\n";
-		if (p_input_vars[0] == String()) { // Use UV by default.
+		if (p_input_vars[0].is_empty()) { // Use UV by default.
 
-			if (p_input_vars[1] == String()) {
+			if (p_input_vars[1].is_empty()) {
 				code += "		vec4 _tex_read = texture(TEXTURE, " + default_uv + ");\n";
 			} else {
 				code += "		vec4 _tex_read = textureLod(TEXTURE, " + default_uv + ", " + p_input_vars[1] + ");\n";
 			}
 
-		} else if (p_input_vars[1] == String()) {
+		} else if (p_input_vars[1].is_empty()) {
 			//no lod
 			code += "		vec4 _tex_read = texture(TEXTURE, " + p_input_vars[0] + ".xy);\n";
 		} else {
@@ -633,15 +633,15 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 
 	if (source == SOURCE_2D_NORMAL && p_mode == Shader::MODE_CANVAS_ITEM && p_type == VisualShader::TYPE_FRAGMENT) {
 		String code = "	{\n";
-		if (p_input_vars[0] == String()) { // Use UV by default.
+		if (p_input_vars[0].is_empty()) { // Use UV by default.
 
-			if (p_input_vars[1] == String()) {
+			if (p_input_vars[1].is_empty()) {
 				code += "		vec4 _tex_read = texture(NORMAL_TEXTURE, " + default_uv + ");\n";
 			} else {
 				code += "		vec4 _tex_read = textureLod(NORMAL_TEXTURE, " + default_uv + ", " + p_input_vars[1] + ");\n";
 			}
 
-		} else if (p_input_vars[1] == String()) {
+		} else if (p_input_vars[1].is_empty()) {
 			//no lod
 			code += "		vec4 _tex_read = texture(NORMAL_TEXTURE, " + p_input_vars[0] + ".xy);\n";
 		} else {
@@ -666,15 +666,15 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 
 	if (source == SOURCE_DEPTH && p_mode == Shader::MODE_SPATIAL && p_type == VisualShader::TYPE_FRAGMENT) {
 		String code = "	{\n";
-		if (p_input_vars[0] == String()) { // Use UV by default.
+		if (p_input_vars[0].is_empty()) { // Use UV by default.
 
-			if (p_input_vars[1] == String()) {
+			if (p_input_vars[1].is_empty()) {
 				code += "		float _depth = texture(DEPTH_TEXTURE, " + default_uv + ").r;\n";
 			} else {
 				code += "		float _depth = textureLod(DEPTH_TEXTURE, " + default_uv + ", " + p_input_vars[1] + ").r;\n";
 			}
 
-		} else if (p_input_vars[1] == String()) {
+		} else if (p_input_vars[1].is_empty()) {
 			//no lod
 			code += "		float _depth = texture(DEPTH_TEXTURE, " + p_input_vars[0] + ".xy).r;\n";
 		} else {
@@ -883,7 +883,7 @@ String VisualShaderNodeCurveTexture::generate_global(Shader::Mode p_mode, Visual
 }
 
 String VisualShaderNodeCurveTexture::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	if (p_input_vars[0] == String()) {
+	if (p_input_vars[0].is_empty()) {
 		return "	" + p_output_vars[0] + " = 0.0;\n";
 	}
 	String id = make_unique_id(p_type, p_id, "curve");
@@ -968,7 +968,7 @@ String VisualShaderNodeCurveXYZTexture::generate_global(Shader::Mode p_mode, Vis
 }
 
 String VisualShaderNodeCurveXYZTexture::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	if (p_input_vars[0] == String()) {
+	if (p_input_vars[0].is_empty()) {
 		return "	" + p_output_vars[0] + " = vec3(0.0);\n";
 	}
 	String id = make_unique_id(p_type, p_id, "curve3d");
@@ -1076,14 +1076,14 @@ String VisualShaderNodeSample3D::generate_code(Shader::Mode p_mode, VisualShader
 		} else {
 			id = p_input_vars[2];
 		}
-		if (id != String()) {
-			if (p_input_vars[0] == String()) { // Use UV by default.
-				if (p_input_vars[1] == String()) {
+		if (!id.is_empty()) {
+			if (p_input_vars[0].is_empty()) { // Use UV by default.
+				if (p_input_vars[1].is_empty()) {
 					code += "		vec4 " + id + "_tex_read = texture(" + id + ", " + default_uv + ");\n";
 				} else {
 					code += "		vec4 " + id + "_tex_read = textureLod(" + id + ", " + default_uv + ", " + p_input_vars[1] + ");\n";
 				}
-			} else if (p_input_vars[1] == String()) {
+			} else if (p_input_vars[1].is_empty()) {
 				//no lod
 				code += "		vec4 " + id + "_tex_read = texture(" + id + ", " + p_input_vars[0] + ");\n";
 			} else {
@@ -1364,7 +1364,7 @@ String VisualShaderNodeCubemap::generate_code(Shader::Mode p_mode, VisualShader:
 
 	code += "	{\n";
 
-	if (id == String()) {
+	if (id.is_empty()) {
 		code += "		vec4 " + id + "_read = vec4(0.0);\n";
 		code += "		" + p_output_vars[0] + " = " + id + "_read.rgb;\n";
 		code += "		" + p_output_vars[1] + " = " + id + "_read.a;\n";
@@ -1372,15 +1372,15 @@ String VisualShaderNodeCubemap::generate_code(Shader::Mode p_mode, VisualShader:
 		return code;
 	}
 
-	if (p_input_vars[0] == String()) { // Use UV by default.
+	if (p_input_vars[0].is_empty()) { // Use UV by default.
 
-		if (p_input_vars[1] == String()) {
+		if (p_input_vars[1].is_empty()) {
 			code += "		vec4 " + id + "_read = texture(" + id + ", " + default_uv + ");\n";
 		} else {
 			code += "		vec4 " + id + "_read = textureLod(" + id + ", " + default_uv + ", " + p_input_vars[1] + " );\n";
 		}
 
-	} else if (p_input_vars[1] == String()) {
+	} else if (p_input_vars[1].is_empty()) {
 		//no lod
 		code += "		vec4 " + id + "_read = texture(" + id + ", " + p_input_vars[0] + ");\n";
 	} else {
@@ -4902,13 +4902,13 @@ String VisualShaderNodeTextureUniform::generate_code(Shader::Mode p_mode, Visual
 
 	String id = get_uniform_name();
 	String code = "	{\n";
-	if (p_input_vars[0] == String()) { // Use UV by default.
-		if (p_input_vars[1] == String()) {
+	if (p_input_vars[0].is_empty()) { // Use UV by default.
+		if (p_input_vars[1].is_empty()) {
 			code += "		vec4 n_tex_read = texture(" + id + ", " + default_uv + ");\n";
 		} else {
 			code += "		vec4 n_tex_read = textureLod(" + id + ", " + default_uv + ", " + p_input_vars[1] + ");\n";
 		}
-	} else if (p_input_vars[1] == String()) {
+	} else if (p_input_vars[1].is_empty()) {
 		//no lod
 		code += "		vec4 n_tex_read = texture(" + id + ", " + p_input_vars[0] + ".xy);\n";
 	} else {
@@ -5070,11 +5070,11 @@ String VisualShaderNodeTextureUniformTriplanar::generate_code(Shader::Mode p_mod
 	String id = get_uniform_name();
 	String code = "	{\n";
 
-	if (p_input_vars[0] == String() && p_input_vars[1] == String()) {
+	if (p_input_vars[0].is_empty() && p_input_vars[1].is_empty()) {
 		code += "		vec4 n_tex_read = triplanar_texture(" + id + ", triplanar_power_normal, triplanar_pos);\n";
-	} else if (p_input_vars[0] != String() && p_input_vars[1] == String()) {
+	} else if (!p_input_vars[0].is_empty() && p_input_vars[1].is_empty()) {
 		code += "		vec4 n_tex_read = triplanar_texture(" + id + ", " + p_input_vars[0] + ", triplanar_pos);\n";
-	} else if (p_input_vars[0] == String() && p_input_vars[1] != String()) {
+	} else if (p_input_vars[0].is_empty() && !p_input_vars[1].is_empty()) {
 		code += "		vec4 n_tex_read = triplanar_texture(" + id + ", triplanar_power_normal, " + p_input_vars[1] + ");\n";
 	} else {
 		code += "		vec4 n_tex_read = triplanar_texture(" + id + ", " + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
@@ -5600,12 +5600,12 @@ bool VisualShaderNodeFresnel::is_generate_input_var(int p_port) const {
 String VisualShaderNodeFresnel::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String normal;
 	String view;
-	if (p_input_vars[0] == String()) {
+	if (p_input_vars[0].is_empty()) {
 		normal = "NORMAL";
 	} else {
 		normal = p_input_vars[0];
 	}
-	if (p_input_vars[1] == String()) {
+	if (p_input_vars[1].is_empty()) {
 		view = "VIEW";
 	} else {
 		view = p_input_vars[1];

--- a/scene/resources/visual_shader_sdf_nodes.cpp
+++ b/scene/resources/visual_shader_sdf_nodes.cpp
@@ -61,7 +61,7 @@ String VisualShaderNodeSDFToScreenUV::get_output_port_name(int p_port) const {
 }
 
 String VisualShaderNodeSDFToScreenUV::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	return "		" + p_output_vars[0] + " = vec3(sdf_to_screen_uv(" + (p_input_vars[0] == String() ? "vec2(0.0)" : p_input_vars[0] + ".xy") + "), 0.0f);\n";
+	return "		" + p_output_vars[0] + " = vec3(sdf_to_screen_uv(" + (p_input_vars[0].is_empty() ? "vec2(0.0)" : p_input_vars[0] + ".xy") + "), 0.0f);\n";
 }
 
 VisualShaderNodeSDFToScreenUV::VisualShaderNodeSDFToScreenUV() {
@@ -105,7 +105,7 @@ String VisualShaderNodeScreenUVToSDF::get_input_port_default_hint(int p_port) co
 }
 
 String VisualShaderNodeScreenUVToSDF::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	return "		" + p_output_vars[0] + " = vec3(screen_uv_to_sdf(" + (p_input_vars[0] == String() ? "SCREEN_UV" : p_input_vars[0] + ".xy") + "), 0.0f);\n";
+	return "		" + p_output_vars[0] + " = vec3(screen_uv_to_sdf(" + (p_input_vars[0].is_empty() ? "SCREEN_UV" : p_input_vars[0] + ".xy") + "), 0.0f);\n";
 }
 
 VisualShaderNodeScreenUVToSDF::VisualShaderNodeScreenUVToSDF() {
@@ -142,7 +142,7 @@ String VisualShaderNodeTextureSDF::get_output_port_name(int p_port) const {
 }
 
 String VisualShaderNodeTextureSDF::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	return "		" + p_output_vars[0] + " = texture_sdf(" + (p_input_vars[0] == String() ? "vec2(0.0)" : p_input_vars[0] + ".xy") + ");\n";
+	return "		" + p_output_vars[0] + " = texture_sdf(" + (p_input_vars[0].is_empty() ? "vec2(0.0)" : p_input_vars[0] + ".xy") + ");\n";
 }
 
 VisualShaderNodeTextureSDF::VisualShaderNodeTextureSDF() {
@@ -179,7 +179,7 @@ String VisualShaderNodeTextureSDFNormal::get_output_port_name(int p_port) const 
 }
 
 String VisualShaderNodeTextureSDFNormal::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	return "		" + p_output_vars[0] + " = vec3(texture_sdf_normal(" + (p_input_vars[0] == String() ? "vec2(0.0)" : p_input_vars[0] + ".xy") + "), 0.0f);\n";
+	return "		" + p_output_vars[0] + " = vec3(texture_sdf_normal(" + (p_input_vars[0].is_empty() ? "vec2(0.0)" : p_input_vars[0] + ".xy") + "), 0.0f);\n";
 }
 
 VisualShaderNodeTextureSDFNormal::VisualShaderNodeTextureSDFNormal() {
@@ -242,13 +242,13 @@ String VisualShaderNodeSDFRaymarch::generate_code(Shader::Mode p_mode, VisualSha
 
 	code += "		{\n";
 
-	if (p_input_vars[0] == String()) {
+	if (p_input_vars[0].is_empty()) {
 		code += "				vec2 __from_pos = vec2(0.0f);\n";
 	} else {
 		code += "				vec2 __from_pos = " + p_input_vars[0] + ".xy;\n";
 	}
 
-	if (p_input_vars[1] == String()) {
+	if (p_input_vars[1].is_empty()) {
 		code += "				vec2 __to_pos = vec2(0.0f);\n";
 	} else {
 		code += "				vec2 __to_pos = " + p_input_vars[1] + ".xy;\n";

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -44,7 +44,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	uniforms.clear();
 	uses_screen_texture = false;
 
-	if (code == String()) {
+	if (code.is_empty()) {
 		return; //just invalid, but no error
 	}
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -47,7 +47,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	uniforms.clear();
 	uses_screen_texture = false;
 
-	if (code == String()) {
+	if (code.is_empty()) {
 		return; //just invalid, but no error
 	}
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1953,7 +1953,7 @@ void RendererCanvasRenderRD::ShaderData::set_code(const String &p_code) {
 	uses_sdf = false;
 	uses_time = false;
 
-	if (code == String()) {
+	if (code.is_empty()) {
 		return; //just invalid, but no error
 	}
 

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -240,7 +240,7 @@ RendererCompositorRD *RendererCompositorRD::singleton = nullptr;
 RendererCompositorRD::RendererCompositorRD() {
 	{
 		String shader_cache_dir = Engine::get_singleton()->get_shader_cache_path();
-		if (shader_cache_dir == String()) {
+		if (shader_cache_dir.is_empty()) {
 			shader_cache_dir = "user://";
 		}
 		DirAccessRef da = DirAccess::open(shader_cache_dir);
@@ -261,7 +261,7 @@ RendererCompositorRD::RendererCompositorRD() {
 					shader_cache_dir = String(); //disable only if not editor
 				}
 
-				if (shader_cache_dir != String()) {
+				if (!shader_cache_dir.is_empty()) {
 					bool compress = GLOBAL_GET("rendering/shader_compiler/shader_cache/compress");
 					bool use_zstd = GLOBAL_GET("rendering/shader_compiler/shader_cache/use_zstd_compression");
 					bool strip_debug = GLOBAL_GET("rendering/shader_compiler/shader_cache/strip_debug");

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -3581,7 +3581,7 @@ void RendererSceneRenderRD::FogShaderData::set_code(const String &p_code) {
 	ubo_size = 0;
 	uniforms.clear();
 
-	if (code == String()) {
+	if (code.is_empty()) {
 		return; //just invalid, but no error
 	}
 

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -46,7 +46,7 @@ void RendererSceneSkyRD::SkyShaderData::set_code(const String &p_code) {
 	ubo_size = 0;
 	uniforms.clear();
 
-	if (code == String()) {
+	if (code.is_empty()) {
 		return; //just invalid, but no error
 	}
 

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -2861,7 +2861,7 @@ void RendererStorageRD::MaterialData::update_textures(const Map<StringName, Vari
 				}
 			}
 #ifdef TOOLS_ENABLED
-			if (roughness_detect_texture && normal_detect_texture && normal_detect_texture->path != String()) {
+			if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty()) {
 				roughness_detect_texture->detect_roughness_callback(roughness_detect_texture->detect_roughness_callback_ud, normal_detect_texture->path, roughness_channel);
 			}
 #endif
@@ -2901,7 +2901,7 @@ void RendererStorageRD::MaterialData::update_textures(const Map<StringName, Vari
 					rd_texture = singleton->texture_rd_get_default(DEFAULT_RD_TEXTURE_WHITE);
 				}
 #ifdef TOOLS_ENABLED
-				if (roughness_detect_texture && normal_detect_texture && normal_detect_texture->path != String()) {
+				if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty()) {
 					roughness_detect_texture->detect_roughness_callback(roughness_detect_texture->detect_roughness_callback_ud, normal_detect_texture->path, roughness_channel);
 				}
 #endif
@@ -5820,7 +5820,7 @@ void RendererStorageRD::ParticlesShaderData::set_code(const String &p_code) {
 	uniforms.clear();
 	uses_collision = false;
 
-	if (code == String()) {
+	if (code.is_empty()) {
 		return; //just invalid, but no error
 	}
 

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -79,7 +79,7 @@ void ShaderRD::_add_stage(const char *p_code, StageType p_stage_type) {
 		}
 
 		if (push_chunk) {
-			if (text != String()) {
+			if (!text.is_empty()) {
 				StageTemplate::Chunk text_chunk;
 				text_chunk.type = StageTemplate::Chunk::TYPE_TEXT;
 				text_chunk.text = text.utf8();
@@ -90,7 +90,7 @@ void ShaderRD::_add_stage(const char *p_code, StageType p_stage_type) {
 		}
 	}
 
-	if (text != String()) {
+	if (!text.is_empty()) {
 		StageTemplate::Chunk text_chunk;
 		text_chunk.type = StageTemplate::Chunk::TYPE_TEXT;
 		text_chunk.text = text.utf8();
@@ -638,7 +638,7 @@ void ShaderRD::initialize(const Vector<String> &p_variant_defines, const String 
 		variants_enabled.push_back(true);
 	}
 
-	if (shader_cache_dir != String()) {
+	if (!shader_cache_dir.is_empty()) {
 		StringBuilder hash_build;
 
 		hash_build.append("[base_hash]");

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -205,7 +205,7 @@ Vector<uint8_t> RenderingDevice::_shader_compile_binary_from_spirv(const Ref<RDS
 		ShaderStageSPIRVData sd;
 		sd.shader_stage = stage;
 		String error = p_spirv->get_stage_compile_error(stage);
-		ERR_FAIL_COND_V_MSG(error != String(), Vector<uint8_t>(), "Can't create a shader from an errored bytecode. Check errors in source bytecode.");
+		ERR_FAIL_COND_V_MSG(!error.is_empty(), Vector<uint8_t>(), "Can't create a shader from an errored bytecode. Check errors in source bytecode.");
 		sd.spir_v = p_spirv->get_stage_bytecode(stage);
 		if (sd.spir_v.is_empty()) {
 			continue;
@@ -225,7 +225,7 @@ RID RenderingDevice::_shader_create_from_spirv(const Ref<RDShaderSPIRV> &p_spirv
 		ShaderStageSPIRVData sd;
 		sd.shader_stage = stage;
 		String error = p_spirv->get_stage_compile_error(stage);
-		ERR_FAIL_COND_V_MSG(error != String(), RID(), "Can't create a shader from an errored bytecode. Check errors in source bytecode.");
+		ERR_FAIL_COND_V_MSG(!error.is_empty(), RID(), "Can't create a shader from an errored bytecode. Check errors in source bytecode.");
 		sd.spir_v = p_spirv->get_stage_bytecode(stage);
 		if (sd.spir_v.is_empty()) {
 			continue;

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -80,7 +80,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 						}
 					}
 
-					if (base_error != String()) {
+					if (!base_error.is_empty()) {
 						break;
 					}
 				}
@@ -89,7 +89,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 			}
 		}
 
-		if (stage == RD::SHADER_STAGE_MAX && line.strip_edges() != "") {
+		if (stage == RD::SHADER_STAGE_MAX && !line.strip_edges().is_empty()) {
 			line = line.strip_edges();
 			if (line.begins_with("//") || line.begins_with("/*")) {
 				continue; //assuming comment (single line)
@@ -98,7 +98,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 
 		if (reading_versions) {
 			String l = line.strip_edges();
-			if (l != "") {
+			if (!l.is_empty()) {
 				if (l.find("=") == -1) {
 					base_error = "Missing `=` in '" + l + "'. Version syntax is `version = \"<defines with C escaping>\";`.";
 					break;
@@ -124,7 +124,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 				version_texts[version] = define + "\n" + p_defines;
 			}
 		} else {
-			if (stage == RD::SHADER_STAGE_MAX && line.strip_edges() != "") {
+			if (stage == RD::SHADER_STAGE_MAX && !line.strip_edges().is_empty()) {
 				base_error = "Text was found that does not belong to a valid section: " + line;
 				break;
 			}
@@ -140,7 +140,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 						}
 						include = include.substr(1, include.length() - 2).strip_edges();
 						String include_text = p_include_func(include, p_include_func_userdata);
-						if (include_text != String()) {
+						if (!include_text.is_empty()) {
 							stage_code[stage] += "\n" + include_text + "\n";
 						} else {
 							base_error = "#include failed for file '" + include + "'";
@@ -158,7 +158,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 	Ref<RDShaderFile> shader_file;
 	shader_file.instantiate();
 
-	if (base_error == "") {
+	if (base_error.is_empty()) {
 		if (stage_found[RD::SHADER_STAGE_COMPUTE] && stages_found > 1) {
 			ERR_FAIL_V_MSG(ERR_PARSE_ERROR, "When writing compute shaders, [compute] mustbe the only stage present.");
 		}
@@ -177,14 +177,14 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 
 			for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
 				String code = stage_code[i];
-				if (code == String()) {
+				if (code.is_empty()) {
 					continue;
 				}
 				code = code.replace("VERSION_DEFINES", E.value);
 				String error;
 				Vector<uint8_t> spirv = RenderingDevice::get_singleton()->shader_compile_spirv_from_source(RD::ShaderStage(i), code, RD::SHADER_LANGUAGE_GLSL, &error, false);
 				bytecode->set_stage_bytecode(RD::ShaderStage(i), spirv);
-				if (error != "") {
+				if (!error.is_empty()) {
 					error += String() + "\n\nStage '" + stage_str[i] + "' source code: \n\n";
 					Vector<String> sclines = code.split("\n");
 					for (int j = 0; j < sclines.size(); j++) {

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -368,13 +368,13 @@ public:
 	}
 
 	void print_errors(const String &p_file) {
-		if (base_error != "") {
+		if (!base_error.is_empty()) {
 			ERR_PRINT("Error parsing shader '" + p_file + "':\n\n" + base_error);
 		} else {
 			for (KeyValue<StringName, Ref<RDShaderSPIRV>> &E : versions) {
 				for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
 					String error = E.value->get_stage_compile_error(RD::ShaderStage(i));
-					if (error != String()) {
+					if (!error.is_empty()) {
 						static const char *stage_str[RD::SHADER_STAGE_MAX] = {
 							"vertex",
 							"fragment",

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -2999,7 +2999,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 		}
 
 		FunctionNode *pfunc = shader->functions[i].function;
-		if (arg_list == "") {
+		if (arg_list.is_empty()) {
 			for (int j = 0; j < pfunc->arguments.size(); j++) {
 				if (j > 0) {
 					arg_list += ", ";
@@ -7236,7 +7236,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			if (tk.type == TK_SEMICOLON) {
 				//all is good
 				if (b->parent_function->return_type != TYPE_VOID) {
-					_set_error("Expected return with an expression of type '" + (return_struct_name != "" ? return_struct_name : get_datatype_name(b->parent_function->return_type)) + array_size_string + "'");
+					_set_error("Expected return with an expression of type '" + (!return_struct_name.is_empty() ? return_struct_name : get_datatype_name(b->parent_function->return_type)) + array_size_string + "'");
 					return ERR_PARSE_ERROR;
 				}
 			} else {
@@ -7248,7 +7248,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				}
 
 				if (b->parent_function->return_type != expr->get_datatype() || b->parent_function->return_array_size != expr->get_array_size() || return_struct_name != expr->get_datatype_name()) {
-					_set_error("Expected return with an expression of type '" + (return_struct_name != "" ? return_struct_name : get_datatype_name(b->parent_function->return_type)) + array_size_string + "'");
+					_set_error("Expected return with an expression of type '" + (!return_struct_name.is_empty() ? return_struct_name : get_datatype_name(b->parent_function->return_type)) + array_size_string + "'");
 					return ERR_PARSE_ERROR;
 				}
 
@@ -7370,7 +7370,7 @@ String ShaderLanguage::_get_shader_type_list(const Set<String> &p_shader_types) 
 	// Return a list of shader types as an human-readable string
 	String valid_types;
 	for (const Set<String>::Element *E = p_shader_types.front(); E; E = E->next()) {
-		if (valid_types != String()) {
+		if (!valid_types.is_empty()) {
 			valid_types += ", ";
 		}
 
@@ -8933,7 +8933,7 @@ String ShaderLanguage::get_shader_type(const String &p_code) {
 			break;
 
 		} else if (p_code[i] <= 32) {
-			if (cur_identifier != String()) {
+			if (!cur_identifier.is_empty()) {
 				if (!reading_type) {
 					if (cur_identifier != "shader_type") {
 						return String();

--- a/tests/core/io/test_file_access.h
+++ b/tests/core/io/test_file_access.h
@@ -53,7 +53,7 @@ TEST_CASE("[FileAccess] CSV read") {
 	REQUIRE(row2.size() == 3);
 	CHECK(row2[0] == "GOOD_EVENING");
 	CHECK(row2[1] == "Good Evening");
-	CHECK(row2[2] == ""); // Use case: not yet translated!
+	CHECK(row2[2].is_empty()); // Use case: not yet translated!
 	// https://github.com/godotengine/godot/issues/44269
 	CHECK_MESSAGE(row2[2] != "\"", "Should not parse empty string as a single double quote.");
 

--- a/tests/core/math/test_math.cpp
+++ b/tests/core/math/test_math.cpp
@@ -312,7 +312,7 @@ public:
 					}
 				}
 
-				if (name != String()) {
+				if (!name.is_empty()) {
 					namespace_stack[at_level] = name;
 				}
 

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -157,10 +157,10 @@ TEST_CASE("[String] Invalid UTF8") {
 	String s;
 	bool err = s.parse_utf8((const char *)u8str);
 	CHECK(err);
-	CHECK(s == String());
+	CHECK(s.is_empty());
 
 	CharString cs = (const char *)u8str;
-	CHECK(String::utf8(cs) == String());
+	CHECK(String::utf8(cs).is_empty());
 	ERR_PRINT_ON
 }
 
@@ -170,10 +170,10 @@ TEST_CASE("[String] Invalid UTF16") {
 	String s;
 	bool err = s.parse_utf16(u16str);
 	CHECK(err);
-	CHECK(s == String());
+	CHECK(s.is_empty());
 
 	Char16String cs = u16str;
-	CHECK(String::utf16(cs) == String());
+	CHECK(String::utf16(cs).is_empty());
 	ERR_PRINT_ON
 }
 
@@ -1438,6 +1438,24 @@ TEST_CASE("[String] Variant ptr indexed set") {
 	setter(&s, 1, &v);
 
 	CHECK_EQ(s, String("azcd"));
+}
+
+TEST_CASE("[Stress][String] Empty via ' == String()'") {
+	for (int i = 0; i < 100000; ++i) {
+		String str = "Hello World!";
+		if (str.is_empty()) {
+			continue;
+		}
+	}
+}
+
+TEST_CASE("[Stress][String] Empty via `is_empty()`") {
+	for (int i = 0; i < 100000; ++i) {
+		String str = "Hello World!";
+		if (str.is_empty()) {
+			continue;
+		}
+	}
 }
 } // namespace TestString
 

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -3235,7 +3235,7 @@ TEST_CASE("[SceneTree][CodeEdit] Backspace delete") {
 	code_edit->insert_text_at_caret("line 1\nline 2\nline 3");
 	code_edit->select_all();
 	code_edit->backspace();
-	CHECK(code_edit->get_text() == "");
+	CHECK(code_edit->get_text().is_empty());
 
 	/* Backspace at the beginning without selection has no effect. */
 	code_edit->set_text("");


### PR DESCRIPTION
Regex to replace:
```
((?:[a-zA-Z0-9_]+::)?([a-zA-Z0-9_]+(\(\))?(\[.+\])*)((\.|->)(([a-zA-Z0-9_]+(\(\))?(\[.+\])*)))*) == (String\(\)|"")
```
to
```
$1.is_empty()
```
---
```
((?:[a-zA-Z0-9_]+::)?([a-zA-Z0-9_]+(\(\))?(\[.+\])*)((\.|->)(([a-zA-Z0-9_]+(\(\))?(\[.+\])*)))*) != (String\(\)|"")
```
to
```
!$1.is_empty()
```

Include files:
```
*.cpp, *.h, *.hpp
```
Ignore files:
```
thirdparty/*, tests/core/test_string.h
```

~~Opening this as a draft to encourage discussion on how this condition should be formatted. Also, possible recommendations for the format script/check.~~

**BENCHMARKS** (Thanks @Xrayez)
```
===============================================================================
tests/test_string.h:1300:
TEST CASE:  [Stress][String] Empty via ' == String()'

0.017540 s: [Stress][String] Empty via ' == String()'
===============================================================================
tests/test_string.h:1309:
TEST CASE:  [Stress][String] Empty via `is_empty()`

0.015278 s: [Stress][String] Empty via `is_empty()`
===============================================================================
```

---

# Important: This PR also:

~~- Adds `is_empty` and `length` to `string_name.h`~~
- Adds two stress tests to `test_string.h`
- Changes to `.empty()` on `std::string`s
~~- Makes some formatting/organization on `string_name.h`~~

All manual changes are in my branch, [`string-empty-manual`](https://github.com/nathanfranke/godot/tree/string-empty-prelude)