### PR TITLE
Docs: Fix TileMap::map_to_world description

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -144,7 +144,7 @@
 			<argument index="1" name="ignore_half_ofs" type="bool" default="false">
 			</argument>
 			<description>
-				Returns the global position corresponding to the given tilemap (grid-based) coordinates.
+				Returns the local position corresponding to the given tilemap (grid-based) coordinates.
 				Optionally, the tilemap's half offset can be ignored.
 			</description>
 		</method>


### PR DESCRIPTION
Description of `TileMap::map_to_world` wrongly stated it returns a global position. This fix is analogous to #25136.
Relevant source code:
https://github.com/godotengine/godot/blob/d5bda5964978b6af7a956262cecf80de1797500c/scene/2d/tile_map.cpp#L1535-L1537
https://github.com/godotengine/godot/blob/d5bda5964978b6af7a956262cecf80de1797500c/scene/2d/tile_map.cpp#L1470-L1492