### PR TITLE
Add description for "title" in FileDialog

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -83,7 +83,7 @@
 		</member>
 		<member name="title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Save a File&quot;" />
 			The title of the window.
-			[b]Note:[/b] The title bar background is drawn by the window panel and its [Theme].
+			[b]Note:[/b] The title bar background is drawn by the window panel and its [StyleBox]. For the title bar, increase the top Expand Margin to ~20 pixels and set the top border width to ~20 pixels in order to use a different background color.
 	</members>
 	<signals>
 		<signal name="dir_selected">

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -82,6 +82,8 @@
 			If [code]true[/code], the dialog will show hidden files.
 		</member>
 		<member name="title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Save a File&quot;" />
+			The title of the window.
+			[b]Note:[/b] The title bar background is drawn by the window panel and its [Theme].
 	</members>
 	<signals>
 		<signal name="dir_selected">

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -82,8 +82,8 @@
 			If [code]true[/code], the dialog will show hidden files.
 		</member>
 		<member name="title" type="String" setter="set_title" getter="get_title" override="true" default="&quot;Save a File&quot;" />
-			The title of the window.
-			[b]Note:[/b] The title bar background is drawn by the window panel and its [StyleBox]. For the title bar, increase the top Expand Margin to ~20 pixels and set the top border width to ~20 pixels in order to use a different background color.
+			The window's title.
+			[b]Note:[/b] The title bar background is drawn by [WindowDialog]'s [theme_item WindowDialog.panel] stylebox.
 	</members>
 	<signals>
 		<signal name="dir_selected">


### PR DESCRIPTION
Add a description of the "title" member in FileDialog. Add information about the title and the title bar, because it's not explicitly stated anywhere that the title bar background is drawn with the window panel itself. This is important to know when you go to change the theme of the dialog.

This addresses: #40267

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
