### PR TITLE
Make `property_list_changed_notify()` protected in `Object`

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -482,8 +482,6 @@ private:
 	void _set_indexed_bind(const NodePath &p_name, const Variant &p_value);
 	Variant _get_indexed_bind(const NodePath &p_name) const;
 
-	void property_list_changed_notify();
-
 	_FORCE_INLINE_ void _construct_object(bool p_reference);
 
 	friend class Reference;
@@ -525,6 +523,7 @@ protected:
 	static void get_valid_parents_static(List<String> *p_parents);
 	static void _get_valid_parents_static(List<String> *p_parents);
 
+	void property_list_changed_notify();
 	virtual void _changed_callback(Object *p_changed, const char *p_prop);
 
 	//Variant _call_bind(const StringName& p_name, const Variant& p_arg1 = Variant(), const Variant& p_arg2 = Variant(), const Variant& p_arg3 = Variant(), const Variant& p_arg4 = Variant());


### PR DESCRIPTION
Alternative to `_change_notify()` to be called from within C++ classes.

`property_list_changed_notify()` is an alias for `_change_notify()`, and was previously added specifically for scripting purposes, so this achieves low-level consistency with scripting, where this method is exposed for updating the editor (inspector) with new values.

This is mostly useful for C++ custom modules development, for developers already familiar with writing editor plugins via script, but who may not be familiar with C++ side of (editor) development.

I also think that `property_list_changed_notify()` is much more intuitive over `_change_notify()` name even for in-engine usage, because it conveys the most common use case for `_change_notify()`.
