### PR TITLE
Fix failing CI, due invalid importing of resources

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -198,8 +198,20 @@ jobs:
           wget2 https://github.com/qarmin/RegressionTestProject/archive/3.2.zip
           unzip 3.2.zip
           mv "RegressionTestProject-3.2" "test_project"
+
+          echo "----- Open editor to import all project resources -----"
           DRI_PRIME=0 timeout 25s xvfb-run bin/godot.x11.tools.64s -e --path test_project 2>&1 | tee sanitizers_log.txt || true
           misc/scripts/check_ci_log.py sanitizers_log.txt
+
+          echo "----- Open it again, because this not always works -----"
+          DRI_PRIME=0 timeout 25s xvfb-run bin/godot.x11.tools.64s -e --path test_project 2>&1 | tee sanitizers_log.txt || true
+          misc/scripts/check_ci_log.py sanitizers_log.txt
+
+          echo "----- Open it third time but this time without timout but with -q flag -----"
+          DRI_PRIME=0 xvfb-run bin/godot.x11.tools.64s -e -q --path test_project 2>&1 | tee sanitizers_log.txt || true
+          misc/scripts/check_ci_log.py sanitizers_log.txt
+
+          echo "----- Run and test project -----"
           DRI_PRIME=0 xvfb-run bin/godot.x11.tools.64s 20 --video-driver GLES3 --path test_project 2>&1 | tee sanitizers_log.txt || true
           misc/scripts/check_ci_log.py sanitizers_log.txt
 


### PR DESCRIPTION
This should fix errors about leaks(due not importing all resources properly) like in this run - https://github.com/godotengine/godot/pull/43049/checks?check_run_id=1329394149

Godot for now doesn't have any method to safely import all resources.
The best option would be to create a command line argument to import all assets - https://github.com/godotengine/godot-proposals/issues/1362

Importing is done 3 times, because I want to be sure that everything should works fine.