### PR TITLE
Refactor property hint names retrieval in VisualScript

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -628,6 +628,129 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 	}
 }
 
+String Object::get_property_hint_name(const PropertyHint &p_hint) {
+	switch (p_hint) {
+		case PROPERTY_HINT_NONE: {
+			return "None";
+		} break;
+		case PROPERTY_HINT_RANGE: {
+			return "Range";
+		} break;
+		case PROPERTY_HINT_EXP_RANGE: {
+			return "ExpRange";
+		} break;
+		case PROPERTY_HINT_ENUM: {
+			return "Enum";
+		} break;
+		case PROPERTY_HINT_EXP_EASING: {
+			return "ExpEasing";
+		} break;
+		case PROPERTY_HINT_LENGTH: {
+			return "Length";
+		} break;
+		case PROPERTY_HINT_KEY_ACCEL: {
+			return "KeyAccel";
+		} break;
+		case PROPERTY_HINT_FLAGS: {
+			return "Flags";
+		} break;
+		case PROPERTY_HINT_LAYERS_2D_RENDER: {
+			return "Layers2DRender";
+		} break;
+		case PROPERTY_HINT_LAYERS_2D_PHYSICS: {
+			return "Layers2DPhysics";
+		} break;
+		case PROPERTY_HINT_LAYERS_3D_RENDER: {
+			return "Layers3DRender";
+		} break;
+		case PROPERTY_HINT_LAYERS_3D_PHYSICS: {
+			return "Layers3DPhysics";
+		} break;
+		case PROPERTY_HINT_FILE: {
+			return "File";
+		} break;
+		case PROPERTY_HINT_DIR: {
+			return "Dir";
+		} break;
+		case PROPERTY_HINT_GLOBAL_FILE: {
+			return "GlobalFile";
+		} break;
+		case PROPERTY_HINT_GLOBAL_DIR: {
+			return "GlobalDir";
+		} break;
+		case PROPERTY_HINT_RESOURCE_TYPE: {
+			return "ResourceType";
+		} break;
+		case PROPERTY_HINT_MULTILINE_TEXT: {
+			return "MultilineText";
+		} break;
+		case PROPERTY_HINT_PLACEHOLDER_TEXT: {
+			return "PlaceholderText";
+		} break;
+		case PROPERTY_HINT_COLOR_NO_ALPHA: {
+			return "ColorNoAlpha";
+		} break;
+		case PROPERTY_HINT_IMAGE_COMPRESS_LOSSY: {
+			return "ImageCompressLossy";
+		} break;
+		case PROPERTY_HINT_IMAGE_COMPRESS_LOSSLESS: {
+			return "ImageCompressLossLess";
+		} break;
+		case PROPERTY_HINT_OBJECT_ID: {
+			return "ObjectID";
+		} break;
+		case PROPERTY_HINT_TYPE_STRING: {
+			return "String";
+		} break;
+		case PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE: {
+			return "NodePathToEditedNode";
+		} break;
+		case PROPERTY_HINT_METHOD_OF_VARIANT_TYPE: {
+			return "MethodOfVariantType";
+		} break;
+		case PROPERTY_HINT_METHOD_OF_BASE_TYPE: {
+			return "MethodOfBaseType";
+		} break;
+		case PROPERTY_HINT_METHOD_OF_INSTANCE: {
+			return "MethodOfInstance";
+		} break;
+		case PROPERTY_HINT_METHOD_OF_SCRIPT: {
+			return "MethodOfScript";
+		} break;
+		case PROPERTY_HINT_PROPERTY_OF_VARIANT_TYPE: {
+			return "PropertyOfVariantType";
+		} break;
+		case PROPERTY_HINT_PROPERTY_OF_BASE_TYPE: {
+			return "PropertyOfBaseType";
+		} break;
+		case PROPERTY_HINT_PROPERTY_OF_INSTANCE: {
+			return "PropertyOfInstance";
+		} break;
+		case PROPERTY_HINT_PROPERTY_OF_SCRIPT: {
+			return "PropertyOfScript";
+		} break;
+		case PROPERTY_HINT_OBJECT_TOO_BIG: {
+			return "ObjectTooBig";
+		} break;
+		case PROPERTY_HINT_NODE_PATH_VALID_TYPES: {
+			return "NodePathValidTypes";
+		} break;
+		case PROPERTY_HINT_SAVE_FILE: {
+			return "SaveFile";
+		} break;
+		case PROPERTY_HINT_INT_IS_OBJECTID: {
+			return "IntIsObjectID";
+		} break;
+		case PROPERTY_HINT_ARRAY_TYPE: {
+			return "ArrayType";
+		} break;
+		default: {
+			ERR_FAIL_V_MSG("", "Invalid property hint type");
+		}
+	}
+	return "";
+}
+
 void Object::_validate_property(PropertyInfo &property) const {
 }
 

--- a/core/object.h
+++ b/core/object.h
@@ -94,7 +94,6 @@ enum PropertyHint {
 	PROPERTY_HINT_INT_IS_OBJECTID,
 	PROPERTY_HINT_ARRAY_TYPE,
 	PROPERTY_HINT_MAX,
-	// When updating PropertyHint, also sync the hardcoded list in VisualScriptEditorVariableEdit
 };
 
 enum PropertyUsageFlags {
@@ -651,6 +650,7 @@ public:
 	Variant get_indexed(const Vector<StringName> &p_names, bool *r_valid = nullptr) const;
 
 	void get_property_list(List<PropertyInfo> *p_list, bool p_reversed = false) const;
+	static String get_property_hint_name(const PropertyHint &p_hint);
 
 	bool has_method(const StringName &p_method) const;
 	void get_method_list(List<MethodInfo> *p_list) const;

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -309,8 +309,12 @@ protected:
 		}
 		p_list->push_back(PropertyInfo(Variant::INT, "type", PROPERTY_HINT_ENUM, argt));
 		p_list->push_back(PropertyInfo(script->get_variable_info(var).type, "value", script->get_variable_info(var).hint, script->get_variable_info(var).hint_string, PROPERTY_USAGE_DEFAULT));
-		// Update this when PropertyHint changes
-		p_list->push_back(PropertyInfo(Variant::INT, "hint", PROPERTY_HINT_ENUM, "None,Range,ExpRange,Enum,ExpEasing,Length,SpriteFrame,KeyAccel,Flags,Layers2dRender,Layers2dPhysics,Layer3dRender,Layer3dPhysics,File,Dir,GlobalFile,GlobalDir,ResourceType,MultilineText,PlaceholderText,ColorNoAlpha,ImageCompressLossy,ImageCompressLossLess,ObjectId,String,NodePathToEditedNode,MethodOfVariantType,MethodOfBaseType,MethodOfInstance,MethodOfScript,PropertyOfVariantType,PropertyOfBaseType,PropertyOfInstance,PropertyOfScript,ObjectTooBig,NodePathValidTypes"));
+
+		String hints = "None";
+		for (int i = 1; i < PropertyHint::PROPERTY_HINT_MAX; i++) {
+			hints += "," + Object::get_property_hint_name(PropertyHint(i));
+		}
+		p_list->push_back(PropertyInfo(Variant::INT, "hint", PROPERTY_HINT_ENUM, hints));
 		p_list->push_back(PropertyInfo(Variant::STRING, "hint_string"));
 		p_list->push_back(PropertyInfo(Variant::BOOL, "export"));
 	}


### PR DESCRIPTION
**Edit**: closes #52434.

![godot_vs_var_hint](https://user-images.githubusercontent.com/17108460/97716762-ae02c600-1acc-11eb-997a-db2ebccdfff0.png)

Adds `Object::get_property_hint_name()` to be used by `VisualScriptEditorVariableEdit` for populating property hints automatically, without having to hardcode values.

Also naturally updates newly added property hints to visual script.

This mechanism is similar to existing `Variant::get_type_name()`.

This would also be useful for goostengine/goost#30.
