### PR TITLE
Use Light hinting for DynamicFonts by default

### DIFF
--- a/doc/classes/DynamicFontData.xml
+++ b/doc/classes/DynamicFontData.xml
@@ -18,7 +18,7 @@
 		<member name="font_path" type="String" setter="set_font_path" getter="get_font_path" default="&quot;&quot;">
 			The path to the vector font file.
 		</member>
-		<member name="hinting" type="int" setter="set_hinting" getter="get_hinting" enum="DynamicFontData.Hinting" default="2">
+		<member name="hinting" type="int" setter="set_hinting" getter="get_hinting" enum="DynamicFontData.Hinting" default="1">
 			The font hinting mode used by FreeType. See [enum Hinting] for options.
 		</member>
 	</members>
@@ -27,10 +27,10 @@
 			Disables font hinting (smoother but less crisp).
 		</constant>
 		<constant name="HINTING_LIGHT" value="1" enum="Hinting">
-			Use the light font hinting mode.
+			Use the light font hinting mode (default).
 		</constant>
 		<constant name="HINTING_NORMAL" value="2" enum="Hinting">
-			Use the default font hinting mode (crisper but less smooth).
+			Use the full font hinting mode (crisper but less smooth).
 		</constant>
 	</constants>
 </class>

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -101,7 +101,7 @@ void DynamicFontData::_bind_methods() {
 DynamicFontData::DynamicFontData() {
 	antialiased = true;
 	force_autohinter = false;
-	hinting = DynamicFontData::HINTING_NORMAL;
+	hinting = DynamicFontData::HINTING_LIGHT;
 	font_mem = nullptr;
 	font_mem_size = 0;
 }


### PR DESCRIPTION
This results in a smoother appearance for fonts. Most operating systems use a variant of Light font hinting by default, so this makes Godot match the OS behavior better. The editor uses Light font hinting by default since 3.2.

Since changing the font hinting mode can change font metrics slightly, complex GUIs may require some modifications to look correct again.