### PR TITLE
Remove unused get_subeditor() method

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -273,16 +273,6 @@ EditorPlugin *EditorData::get_editor(Object *p_object) {
 	return nullptr;
 }
 
-EditorPlugin *EditorData::get_subeditor(Object *p_object) {
-	for (int i = editor_plugins.size() - 1; i > -1; i--) {
-		if (!editor_plugins[i]->has_main_screen() && editor_plugins[i]->handles(p_object)) {
-			return editor_plugins[i];
-		}
-	}
-
-	return nullptr;
-}
-
 Vector<EditorPlugin *> EditorData::get_subeditors(Object *p_object) {
 	Vector<EditorPlugin *> sub_plugins;
 	for (int i = editor_plugins.size() - 1; i > -1; i--) {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -145,7 +145,6 @@ private:
 
 public:
 	EditorPlugin *get_editor(Object *p_object);
-	EditorPlugin *get_subeditor(Object *p_object);
 	Vector<EditorPlugin *> get_subeditors(Object *p_object);
 	EditorPlugin *get_editor(String p_name);
 


### PR DESCRIPTION
I spotted it in the code while looking into something. The method isn't used anywhere nor bound, instead a very similar `get_subeditors()` method is being used.