### PR TITLE
Disable active editors when node gets deselected

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1807,6 +1807,7 @@ void EditorNode::push_item(Object *p_object, const String &p_property, bool p_in
 		node_dock->set_node(nullptr);
 		scene_tree_dock->set_selected(nullptr);
 		inspector_dock->update(nullptr);
+		_display_top_editors(false);
 		return;
 	}
 


### PR DESCRIPTION
While making a plugin, I noticed that it's never released when I unselect the edited node. Then I remembered that all plugins have this problem, so here's a fix.

Fixes #38389