### PR TITLE
Fix crash due to unreachable code in properties

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1421,7 +1421,11 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 #ifdef DEBUG_ENABLED
 	if (unreachable) {
 		current_suite->has_unreachable_code = true;
-		push_warning(result, GDScriptWarning::UNREACHABLE_CODE, current_function->identifier->name);
+		if (current_function) {
+			push_warning(result, GDScriptWarning::UNREACHABLE_CODE, current_function->identifier->name);
+		} else {
+			// TODO: Properties setters and getters with unreachable code are not being warned
+		}
 	}
 #endif
 


### PR DESCRIPTION
Fixes #42556.

Note: As of now, it seems there is no easy way to access the current property name in this context, the `current_function` on the other hand is specified in a global variable. For that reason (and `GDScriptWarning::UNREACHABLE_CODE` being too specific for functions) I decided to just fix the crash and let a `TODO` on the code.