### PR TITLE
Exposed setters for sensors

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -85,6 +85,10 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_accelerometer"), &Input::get_accelerometer);
 	ClassDB::bind_method(D_METHOD("get_magnetometer"), &Input::get_magnetometer);
 	ClassDB::bind_method(D_METHOD("get_gyroscope"), &Input::get_gyroscope);
+	ClassDB::bind_method(D_METHOD("set_gravity", "value"), &Input::set_gravity);
+	ClassDB::bind_method(D_METHOD("set_accelerometer", "value"), &Input::set_accelerometer);
+	ClassDB::bind_method(D_METHOD("set_magnetometer", "value"), &Input::set_magnetometer);
+	ClassDB::bind_method(D_METHOD("set_gyroscope", "value"), &Input::set_gyroscope);
 	//ClassDB::bind_method(D_METHOD("get_mouse_position"),&Input::get_mouse_position); - this is not the function you want
 	ClassDB::bind_method(D_METHOD("get_last_mouse_speed"), &Input::get_last_mouse_speed);
 	ClassDB::bind_method(D_METHOD("get_mouse_button_mask"), &Input::get_mouse_button_mask);

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -113,6 +113,10 @@ public:
 	virtual Vector3 get_accelerometer() const = 0;
 	virtual Vector3 get_magnetometer() const = 0;
 	virtual Vector3 get_gyroscope() const = 0;
+	virtual void set_gravity(const Vector3 &p_gravity) = 0;
+	virtual void set_accelerometer(const Vector3 &p_accel) = 0;
+	virtual void set_magnetometer(const Vector3 &p_magnetometer) = 0;
+	virtual void set_gyroscope(const Vector3 &p_gyroscope) = 0;
 
 	virtual void action_press(const StringName &p_action, float p_strength = 1.f) = 0;
 	virtual void action_release(const StringName &p_action) = 0;

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -254,10 +254,10 @@ public:
 
 	virtual void parse_input_event(const Ref<InputEvent> &p_event);
 
-	void set_gravity(const Vector3 &p_gravity);
-	void set_accelerometer(const Vector3 &p_accel);
-	void set_magnetometer(const Vector3 &p_magnetometer);
-	void set_gyroscope(const Vector3 &p_gyroscope);
+	virtual void set_gravity(const Vector3 &p_gravity);
+	virtual void set_accelerometer(const Vector3 &p_accel);
+	virtual void set_magnetometer(const Vector3 &p_magnetometer);
+	virtual void set_gyroscope(const Vector3 &p_gyroscope);
 	void set_joy_axis(int p_device, int p_axis, float p_value);
 
 	virtual void start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration = 0);


### PR DESCRIPTION
set_accelerometer, set_gravity, set_magnetometer and set_gyroscope exposed to use it in scripts.
For example I want to port [my module](https://github.com/DmitriySalnikov/GodotRemote) to GDNative but without this PR sensors data will not be available.