### PR TITLE
Remove unneeded filter on joy_axis()

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -890,14 +890,6 @@ void Input::joy_axis(int p_device, int p_axis, const JoyAxis &p_value) {
 		return;
 	}
 
-	if (p_value.value > joy.last_axis[p_axis]) {
-		if (p_value.value < joy.last_axis[p_axis] + joy.filter) {
-			return;
-		}
-	} else if (p_value.value > joy.last_axis[p_axis] - joy.filter) {
-		return;
-	}
-
 	//when changing direction quickly, insert fake event to release pending inputmap actions
 	float last = joy.last_axis[p_axis];
 	if (p_value.min == 0 && (last < 0.25 || last > 0.75) && (last - 0.5) * (p_value.value - 0.5) < 0) {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -146,7 +146,6 @@ private:
 		bool connected = false;
 		bool last_buttons[JOY_BUTTON_MAX] = { false };
 		float last_axis[JOY_AXIS_MAX] = { 0.0f };
-		float filter = 0.01f;
 		int last_hat = HAT_MASK_CENTER;
 		int mapping = -1;
 		int hat_current = 0;


### PR DESCRIPTION
Currently, the `Input::joy_axis()` function ensures that joystick events are only sent if the change is greater than or equal to 0.01. However, changes are only sent to the `joy_axis()` function in steps of 0.004 or 0.008; so the filter is unneeded and results in reduced precision; as identified by @DJKero and explained in #42876.

This PR removes the unneeded filter. Credit to @zyp for identifying the source of the problem.

Fixes #42876 

