### PR TITLE
Docs: MeshDataTool: showcase tool in code example

### DIFF
--- a/doc/classes/MeshDataTool.xml
+++ b/doc/classes/MeshDataTool.xml
@@ -7,16 +7,44 @@
 		MeshDataTool provides access to individual vertices in a [Mesh]. It allows users to read and edit vertex data of meshes. It also creates an array of faces and edges.
 		To use MeshDataTool, load a mesh with [method create_from_surface]. When you are finished editing the data commit the data to a mesh with [method commit_to_surface].
 		Below is an example of how MeshDataTool may be used.
-		[codeblock]
+		[codeblocks]
+		[gdscript]
+		var mesh = ArrayMesh.new()
+		mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, CubeMesh.new().get_mesh_arrays())
 		var mdt = MeshDataTool.new()
 		mdt.create_from_surface(mesh, 0)
 		for i in range(mdt.get_vertex_count()):
 		    var vertex = mdt.get_vertex(i)
-		    ...
+		    # In this example we extend the mesh by one unit, which results in seperated faces as it is flat shaded.
+		    vertex += mdt.get_vertex_normal(i)
+		    # Save your change.
 		    mdt.set_vertex(i, vertex)
 		mesh.surface_remove(0)
 		mdt.commit_to_surface(mesh)
-		[/codeblock]
+		var mi = MeshInstance.new()
+		mi.mesh = mesh
+		add_child(mi)
+		[/gdscript]
+		[csharp]
+		var mesh = new ArrayMesh();
+		mesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, new CubeMesh().GetMeshArrays());
+		var mdt = new MeshDataTool();
+		mdt.CreateFromSurface(mesh, 0);
+		for (var i = 0; i &lt; mdt.GetVertexCount(); i++)
+		{
+		    Vector3 vertex = mdt.GetVertex(i);
+		    // In this example we extend the mesh by one unit, which results in seperated faces as it is flat shaded.
+		    vertex += mdt.GetVertexNormal(i);
+		    // Save your change.
+		    mdt.SetVertex(i, vertex);
+		}
+		mesh.SurfaceRemove(0);
+		mdt.CommitToSurface(mesh);
+		var mi = new MeshInstance();
+		mi.Mesh = mesh;
+		AddChild(mi);
+		[/csharp]
+		[/codeblocks]
 		See also [ArrayMesh], [ImmediateGeometry3D] and [SurfaceTool] for procedural geometry generation.
 		[b]Note:[/b] Godot uses clockwise [url=https://learnopengl.com/Advanced-OpenGL/Face-culling]winding order[/url] for front faces of triangle primitive modes.
 	</description>


### PR DESCRIPTION
The code example needs some sort of enhancement, since you can't copy and run it and it does not show what you can do with the tool. I am however not so sure if this example is the best one, altough it demonstrates the tool pretty clearly.
![grafik](https://user-images.githubusercontent.com/14185889/97788481-91908780-1bb9-11eb-8f4a-b288783ad62e.png)
