### PR TITLE
Docs: Port code examples to C# (M, N, O, P, Q, R)

### DIFF
--- a/doc/classes/MarginContainer.xml
+++ b/doc/classes/MarginContainer.xml
@@ -6,13 +6,22 @@
 	<description>
 		Adds a top, left, bottom, and right margin to all [Control] nodes that are direct children of the container. To control the [MarginContainer]'s margin, use the [code]margin_*[/code] theme properties listed below.
 		[b]Note:[/b] Be careful, [Control] margin values are different than the constant margin values. If you want to change the custom margin values of the [MarginContainer] by code, you should use the following examples:
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var margin_value = 100
 		set("custom_constants/margin_top", margin_value)
 		set("custom_constants/margin_left", margin_value)
 		set("custom_constants/margin_bottom", margin_value)
 		set("custom_constants/margin_right", margin_value)
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		int marginValue = 100;
+		Set("custom_constants/margin_top", marginValue);
+		Set("custom_constants/margin_left", marginValue);
+		Set("custom_constants/margin_bottom", marginValue);
+		Set("custom_constants/margin_right", marginValue);
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/NavigationPolygon.xml
+++ b/doc/classes/NavigationPolygon.xml
@@ -6,22 +6,41 @@
 	<description>
 		There are two ways to create polygons. Either by using the [method add_outline] method, or using the [method add_polygon] method.
 		Using [method add_outline]:
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var polygon = NavigationPolygon.new()
 		var outline = PackedVector2Array([Vector2(0, 0), Vector2(0, 50), Vector2(50, 50), Vector2(50, 0)])
 		polygon.add_outline(outline)
 		polygon.make_polygons_from_outlines()
 		$NavigationRegion2D.navpoly = polygon
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		var polygon = new NavigationPolygon();
+		var outline = new Vector2[] { new Vector2(0, 0), new Vector2(0, 50), new Vector2(50, 50), new Vector2(50, 0) };
+		polygon.AddOutline(outline);
+		polygon.MakePolygonsFromOutlines();
+		GetNode&lt;NavigationRegion2D&gt;("NavigationRegion2D").Navpoly = polygon;
+		[/csharp]
+		[/codeblocks]
 		Using [method add_polygon] and indices of the vertices array.
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var polygon = NavigationPolygon.new()
 		var vertices = PackedVector2Array([Vector2(0, 0), Vector2(0, 50), Vector2(50, 50), Vector2(50, 0)])
-		polygon.set_vertices(vertices)
+		polygon.vertices = vertices
 		var indices = PackedInt32Array(0, 3, 1)
 		polygon.add_polygon(indices)
 		$NavigationRegion2D.navpoly = polygon
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		var polygon = new NavigationPolygon();
+		var vertices = new Vector2[] { new Vector2(0, 0), new Vector2(0, 50), new Vector2(50, 50), new Vector2(50, 0) };
+		polygon.Vertices = vertices;
+		var indices = new int[] { 0, 3, 1 };
+		polygon.AddPolygon(indices);
+		GetNode&lt;NavigationRegion2D&gt;("NavigationRegion2D").Navpoly = polygon;
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 		<link title="2D Navigation Demo">https://godotengine.org/asset-library/asset/117</link>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -130,11 +130,22 @@
 				Adds a child node. Nodes can have any number of children, but every child must have a unique name. Child nodes are automatically deleted when the parent node is deleted, so an entire scene can be removed by deleting its topmost node.
 				If [code]legible_unique_name[/code] is [code]true[/code], the child node will have an human-readable name based on the name of the node being instanced instead of its type.
 				[b]Note:[/b] If the child node already has a parent, the function will fail. Use [method remove_child] first to remove the node from its current parent. For example:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
+				var child_node = get_child(0)
 				if child_node.get_parent():
 				    child_node.get_parent().remove_child(child_node)
 				add_child(child_node)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Node childNode = GetChild(0);
+				if (childNode.GetParent() != null)
+				{
+				    childNode.GetParent().RemoveChild(childNode);
+				}
+				AddChild(childNode);
+				[/csharp]
+				[/codeblocks]
 				If you need the child node to be added below a specific node in the list of children, use [method add_sibling] instead of this method.
 				[b]Note:[/b] If you want a child to be persisted to a [PackedScene], you must set [member owner] in addition to calling [method add_child]. This is typically relevant for [url=https://godot.readthedocs.io/en/latest/tutorials/misc/running_code_in_the_editor.html]tool scripts[/url] and [url=https://godot.readthedocs.io/en/latest/tutorials/plugins/editor/index.html]editor plugins[/url]. If [method add_child] is called without setting [member owner], the newly added [Node] will not be visible in the scene tree, though it will be visible in the 2D/3D view.
 			</description>
@@ -275,12 +286,20 @@
 				/root/Swamp/Goblin
 				[/codeblock]
 				Possible paths are:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				get_node("Sword")
 				get_node("Backpack/Dagger")
 				get_node("../Swamp/Alligator")
 				get_node("/root/MyGame")
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				GetNode("Sword");
+				GetNode("Backpack/Dagger");
+				GetNode("../Swamp/Alligator");
+				GetNode("/root/MyGame");
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_node_and_resource">
@@ -292,11 +311,18 @@
 				Fetches a node and one of its resources as specified by the [NodePath]'s subname (e.g. [code]Area2D/CollisionShape2D:shape[/code]). If several nested resources are specified in the [NodePath], the last one will be fetched.
 				The return value is an array of size 3: the first index points to the [Node] (or [code]null[/code] if not found), the second index points to the [Resource] (or [code]null[/code] if not found), and the third index is the remaining [NodePath], if any.
 				For example, assuming that [code]Area2D/CollisionShape2D[/code] is a valid node and that its [code]shape[/code] property has been assigned a [RectangleShape2D] resource, one could have this kind of output:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				print(get_node_and_resource("Area2D/CollisionShape2D")) # [[CollisionShape2D:1161], Null, ]
 				print(get_node_and_resource("Area2D/CollisionShape2D:shape")) # [[CollisionShape2D:1161], [RectangleShape2D:1156], ]
 				print(get_node_and_resource("Area2D/CollisionShape2D:shape:extents")) # [[CollisionShape2D:1161], [RectangleShape2D:1156], :extents]
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				GD.Print(GetNodeAndResource("Area2D/CollisionShape2D")); // [[CollisionShape2D:1161], Null, ]
+				GD.Print(GetNodeAndResource("Area2D/CollisionShape2D:shape")); // [[CollisionShape2D:1161], [RectangleShape2D:1156], ]
+				GD.Print(GetNodeAndResource("Area2D/CollisionShape2D:shape:extents")); // [[CollisionShape2D:1161], [RectangleShape2D:1156], :extents]
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_node_or_null" qualifiers="const">

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -35,7 +35,7 @@
 				The "subnames" optionally included after the path to the target node can point to resources or properties, and can also be nested.
 				Examples of valid NodePaths (assuming that those nodes exist and have the referenced resources or properties):
 				[codeblock]
-				# Points to the Sprite2D node
+				# Points to the Sprite2D node.
 				"Path2D/PathFollow2D/Sprite2D"
 				# Points to the Sprite2D node and its "texture" resource.
 				# get_node() would retrieve "Sprite2D", while get_node_and_resource()
@@ -54,14 +54,23 @@
 			<return type="NodePath">
 			</return>
 			<description>
-				Returns a node path with a colon character ([code]:[/code]) prepended, transforming it to a pure property path with no node name (defaults to resolving from the current node).
-				[codeblock]
-				# This will be parsed as a node path to the "x" property in the "position" node
+				Returns a node path with a colon character ([code]:[/code]) prepended, transforming it to a pure property path with no node name (defaults to resolving from the from the current node).
+				[codeblocks]
+				[gdscript]
+				# This will be parsed as a node path to the "x" property in the "position" node.
 				var node_path = NodePath("position:x")
-				# This will be parsed as a node path to the "x" component of the "position" property in the current node
+				# This will be parsed as a node path to the "x" component of the "position" property in the current node.
 				var property_path = node_path.get_as_property_path()
 				print(property_path) # :position:x
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				// This will be parsed as a node path to the "x" property in the "position" node.
+				var nodePath = new NodePath("position:x");
+				// This will be parsed as a node path to the "x" component of the "position" property in the current node.
+				NodePath propertyPath = nodePath.GetAsPropertyPath();
+				GD.Print(propertyPath); // :position:x
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_concatenated_subnames">
@@ -69,10 +78,16 @@
 			</return>
 			<description>
 				Returns all subnames concatenated with a colon character ([code]:[/code]) as separator, i.e. the right side of the first colon in a node path.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var nodepath = NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path")
 				print(nodepath.get_concatenated_subnames()) # texture:load_path
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var nodepath = new NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path");
+				GD.Print(nodepath.GetConcatenatedSubnames()); // texture:load_path
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_name">
@@ -82,12 +97,20 @@
 			</argument>
 			<description>
 				Gets the node name indicated by [code]idx[/code] (0 to [method get_name_count]).
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var node_path = NodePath("Path2D/PathFollow2D/Sprite2D")
 				print(node_path.get_name(0)) # Path2D
 				print(node_path.get_name(1)) # PathFollow2D
 				print(node_path.get_name(2)) # Sprite
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var nodePath = new NodePath("Path2D/PathFollow2D/Sprite2D");
+				GD.Print(nodePath.GetName(0)); // Path2D
+				GD.Print(nodePath.GetName(1)); // PathFollow2D
+				GD.Print(nodePath.GetName(2)); // Sprite
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_name_count">
@@ -105,11 +128,18 @@
 			</argument>
 			<description>
 				Gets the resource or property name indicated by [code]idx[/code] (0 to [method get_subname_count]).
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var node_path = NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path")
 				print(node_path.get_subname(0)) # texture
 				print(node_path.get_subname(1)) # load_path
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var nodePath = new NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path");
+				GD.Print(nodePath.GetSubname(0)); // texture
+				GD.Print(nodePath.GetSubname(1)); // load_path
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_subname_count">

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -85,18 +85,36 @@
 				If [code]blocking[/code] is [code]false[/code], the Godot thread will continue while the new process runs. It is not possible to retrieve the shell output in non-blocking mode, so [code]output[/code] will be empty.
 				The return value also depends on the blocking mode. When blocking, the method will return an exit code of the process. When non-blocking, the method returns a process ID, which you can use to monitor the process (and potentially terminate it with [method kill]). If the process forking (non-blocking) or opening (blocking) fails, the method will return [code]-1[/code] or another exit code.
 				Example of blocking mode and retrieving the shell output:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var output = []
 				var exit_code = OS.execute("ls", ["-l", "/tmp"], true, output)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var output = new Godot.Collections.Array();
+				int exitCode = OS.Execute("ls", new string[] {"-l", "/tmp"}, true, output);
+				[/csharp]
+				[/codeblocks]
 				Example of non-blocking mode, running another instance of the project and storing its process ID:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var pid = OS.execute(OS.get_executable_path(), [], false)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var pid = OS.Execute(OS.GetExecutablePath(), new string[] {}, false);
+				[/csharp]
+				[/codeblocks]
 				If you wish to access a shell built-in or perform a composite command, a platform-specific shell can be invoked. For example:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
+				var output = []
 				OS.execute("CMD.exe", ["/C", "cd %TEMP% &amp;&amp; dir"], true, output)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var output = new Godot.Collections.Array();
+				OS.Execute("CMD.exe", new string[] {"/C", "cd %TEMP% &amp;&amp; dir"}, true, output);
+				[/csharp]
+				[/codeblocks]
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
 			</description>
 		</method>
@@ -118,13 +136,26 @@
 				You can also incorporate environment variables using the [method get_environment] method.
 				You can set [code]editor/main_run_args[/code] in the Project Settings to define command-line arguments to be passed by the editor when running the project.
 				Here's a minimal example on how to parse command-line arguments into a dictionary using the [code]--key=value[/code] form for arguments:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var arguments = {}
 				for argument in OS.get_cmdline_args():
 				    if argument.find("=") &gt; -1:
 				        var key_value = argument.split("=")
 				        arguments[key_value[0].lstrip("--")] = key_value[1]
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var arguments = new Godot.Collections.Dictionary();
+				foreach (var argument in OS.GetCmdlineArgs())
+				{
+				    if (argument.Find("=") &gt; -1)
+				    {
+				        string[] keyValue = argument.Split("=");
+				        arguments[keyValue[0].LStrip("--")] = keyValue[1];
+				    }
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_connected_midi_inputs">

--- a/doc/classes/PCKPacker.xml
+++ b/doc/classes/PCKPacker.xml
@@ -5,12 +5,20 @@
 	</brief_description>
 	<description>
 		The [PCKPacker] is used to create packages that can be loaded into a running project using [method ProjectSettings.load_resource_pack].
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var packer = PCKPacker.new()
 		packer.pck_start("test.pck")
 		packer.add_file("res://text.txt", "text.txt")
 		packer.flush()
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		var packer = new PCKPacker();
+		packer.PckStart("test.pck");
+		packer.AddFile("res://text.txt", "text.txt");
+		packer.Flush();
+		[/csharp]
+		[/codeblocks]
 		The above [PCKPacker] creates package [code]test.pck[/code], then adds a file named [code]text.txt[/code] at the root of the package.
 	</description>
 	<tutorials>

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -119,10 +119,16 @@
 			</return>
 			<description>
 				Returns a hexadecimal representation of this array as a [String].
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var array = PackedByteArray([11, 46, 255])
 				print(array.hex_encode()) # Prints: 0b2eff
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var array = new byte[] {11, 46, 255};
+				GD.Print(array.HexEncode()); // Prints: 0b2eff
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="insert">

--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -8,14 +8,23 @@
 		Can be used to save a node to a file. When saving, the node as well as all the node it owns get saved (see [code]owner[/code] property on [Node]).
 		[b]Note:[/b] The node doesn't need to own itself.
 		[b]Example of loading a saved scene:[/b]
-		[codeblock]
-		# Use `load()` instead of `preload()` if the path isn't known at compile-time.
+		[codeblocks]
+		[gdscript]
+		# Use load() instead of preload() if the path isn't known at compile-time.
 		var scene = preload("res://scene.tscn").instance()
 		# Add the node as a child of the node the script is attached to.
 		add_child(scene)
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		// C# has no preload, so you have to always use ResourceLoader.Load&lt;PackedScene&gt;().
+		var scene = ResourceLoader.Load&lt;PackedScene&gt;("res://scene.tscn").Instance();
+		// Add the node as a child of the node the script is attached to.
+		AddChild(scene);
+		[/csharp]
+		[/codeblocks]
 		[b]Example of saving a node with different owners:[/b] The following example creates 3 objects: [code]Node2D[/code] ([code]node[/code]), [code]RigidBody2D[/code] ([code]rigid[/code]) and [code]CollisionObject2D[/code] ([code]collision[/code]). [code]collision[/code] is a child of [code]rigid[/code] which is a child of [code]node[/code]. Only [code]rigid[/code] is owned by [code]node[/code] and [code]pack[/code] will therefore only save those two nodes, but not [code]collision[/code].
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		# Create the objects.
 		var node = Node2D.new()
 		var rigid = RigidBody2D.new()
@@ -27,15 +36,41 @@
 
 		# Change owner of `rigid`, but not of `collision`.
 		rigid.owner = node
-
 		var scene = PackedScene.new()
+
 		# Only `node` and `rigid` are now packed.
 		var result = scene.pack(node)
 		if result == OK:
-		    var error = ResourceSaver.save("res://path/name.scn", scene)  # Or "user://..."
+		    var error = ResourceSaver.save("res://path/name.tscn", scene)  # Or "user://..."
 		    if error != OK:
 		        push_error("An error occurred while saving the scene to disk.")
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		// Create the objects.
+		var node = new Node2D();
+		var rigid = new RigidBody2D();
+		var collision = new CollisionShape2D();
+
+		// Create the object hierarchy.
+		rigid.AddChild(collision);
+		node.AddChild(rigid);
+
+		// Change owner of `rigid`, but not of `collision`.
+		rigid.Owner = node;
+		var scene = new PackedScene();
+
+		// Only `node` and `rigid` are now packed.
+		Error result = scene.Pack(node);
+		if (result == Error.Ok)
+		{
+		    Error error = ResourceSaver.Save("res://path/name.tscn", scene); // Or "user://..."
+		    if (error != Error.Ok)
+		    {
+		        GD.PushError("An error occurred while saving the scene to disk.");
+		    }
+		}
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 		<link title="2D Role Playing Game Demo">https://godotengine.org/asset-library/asset/520</link>

--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -124,17 +124,36 @@
 			<description>
 				Waits for a packet to arrive on the listening port. See [method listen].
 				[b]Note:[/b] [method wait] can't be interrupted once it has been called. This can be worked around by allowing the other party to send a specific "death pill" packet like this:
-				[codeblock]
-				# Server
-				socket.set_dest_address("127.0.0.1", 789)
-				socket.put_packet("Time to stop".to_ascii())
+		[codeblocks]
+		[gdscript]
+		socket = PacketPeerUDP.new()
+		# Server
+		socket.set_dest_address("127.0.0.1", 789)
+		socket.put_packet("Time to stop".to_ascii())
 
-				# Client
-				while socket.wait() == OK:
-				    var data = socket.get_packet().get_string_from_ascii()
-				    if data == "Time to stop":
-				        return
-				[/codeblock]
+		# Client
+		while socket.wait() == OK:
+		    var data = socket.get_packet().get_string_from_ascii()
+		    if data == "Time to stop":
+		        return
+		[/gdscript]
+		[csharp]
+		var socket = new PacketPeerUDP();
+		// Server
+		socket.SetDestAddress("127.0.0.1", 789);
+		socket.PutPacket("Time To Stop".ToAscii());
+
+		// Client
+		while (socket.Wait() == OK)
+		{
+		    string data = socket.GetPacket().GetStringFromASCII();
+		    if (data == "Time to stop")
+		    {
+		        return;
+		    }
+		}
+		[/csharp]
+		[/codeblocks]
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Performance.xml
+++ b/doc/classes/Performance.xml
@@ -24,14 +24,53 @@
 			</argument>
 			<description>
 				Adds a custom monitor with name same as id. You can specify the category of monitor using '/' in id. If there are more than one '/' then default category is used. Default category is "Custom".
-				[codeblock]
-				Performance.add_custom_monitor("MyCategory/MyMonitor", some_callable) # Adds monitor with name "MyName" to category "MyCategory"
-				Performance.add_custom_monitor("MyMonitor", some_callable) # Adds monitor with name "MyName" to category "Custom"
-				# Note: "MyCategory/MyMonitor" and "MyMonitor" have same name but different ids so above code is valid
-				Performance.add_custom_monitor("Custom/MyMonitor", some_callable) # Adds monitor with name "MyName" to category "Custom"
-				# Note: "MyMonitor" and "Custom/MyMonitor" have same name and same category but different ids so above code is valid
-				Performance.add_custom_monitor("MyCategoryOne/MyCategoryTwo/MyMonitor", some_callable) # Adds monitor with name "MyCategoryOne/MyCategoryTwo/MyMonitor" to category "Custom"
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				func _ready():
+				    var monitor_value = Callable(self, "get_monitor_value")
+
+				    # Adds monitor with name "MyName" to category "MyCategory".
+				    Performance.add_custom_monitor("MyCategory/MyMonitor", monitor_value)
+
+				    # Adds monitor with name "MyName" to category "Custom".
+				    # Note: "MyCategory/MyMonitor" and "MyMonitor" have same name but different ids so the code is valid.
+				    Performance.add_custom_monitor("MyMonitor", monitor_value)
+
+				    # Adds monitor with name "MyName" to category "Custom".
+				    # Note: "MyMonitor" and "Custom/MyMonitor" have same name and same category but different ids so the code is valid.
+				    Performance.add_custom_monitor("Custom/MyMonitor", monitor_value)
+
+				    # Adds monitor with name "MyCategoryOne/MyCategoryTwo/MyMonitor" to category "Custom".
+				    Performance.add_custom_monitor("MyCategoryOne/MyCategoryTwo/MyMonitor", monitor_value)
+
+				func get_monitor_value():
+				    return randi() % 25
+				[/gdscript]
+				[csharp]
+				public override void _Ready()
+				{
+				    var monitorValue = new Callable(this, nameof(GetMonitorValue));
+
+				    // Adds monitor with name "MyName" to category "MyCategory".
+				    Performance.AddCustomMonitor("MyCategory/MyMonitor", monitorValue);
+				    // Adds monitor with name "MyName" to category "Custom".
+				    // Note: "MyCategory/MyMonitor" and "MyMonitor" have same name but different ids so the code is valid.
+				    Performance.AddCustomMonitor("MyMonitor", monitorValue);
+
+				    // Adds monitor with name "MyName" to category "Custom".
+				    // Note: "MyMonitor" and "Custom/MyMonitor" have same name and same category but different ids so the code is valid.
+				    Performance.AddCustomMonitor("Custom/MyMonitor", monitorValue);
+
+				    // Adds monitor with name "MyCategoryOne/MyCategoryTwo/MyMonitor" to category "Custom".
+				    Performance.AddCustomMonitor("MyCategoryOne/MyCategoryTwo/MyMonitor", monitorValue);
+				}
+
+				public int GetMonitorValue()
+				{
+				    return GD.Randi() % 25;
+				}
+				[/csharp]
+				[/codeblocks]
 				The debugger calls the callable to get the value of custom monitor. The callable must return a number.
 				Callables are called with arguments supplied in argument array.
 				[b]Note:[/b] It throws an error if given id is already present.
@@ -61,9 +100,14 @@
 			</argument>
 			<description>
 				Returns the value of one of the available monitors. You should provide one of the [enum Monitor] constants as the argument, like this:
-				[codeblock]
-				print(Performance.get_monitor(Performance.TIME_FPS)) # Prints the FPS to the console
-				[/codeblock]
+				[codeblocks]
+				[gdscript]
+				print(Performance.get_monitor(Performance.TIME_FPS)) # Prints the FPS to the console.
+				[/gdscript]
+				[csharp]
+				GD.Print(Performance.GetMonitor(Performance.Monitor.TimeFps)); // Prints the FPS to the console.
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_monitor_modification_time">

--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -34,19 +34,34 @@
 		</member>
 		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid">
 			The queried shape's [RID] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:
-			[codeblock]
-			var shape_rid = PhysicsServer2D.circle_shape_create()
-			var radius = 64
-			PhysicsServer2D.shape_set_data(shape_rid, radius)
+				[codeblocks]
+				[gdscript]
+				var shape_rid = PhysicsServer2D.circle_shape_create()
+				var radius = 64
+				PhysicsServer2D.shape_set_data(shape_rid, radius)
 
-			var params = PhysicsShapeQueryParameters2D.new()
-			params.shape_rid = shape_rid
+				var params = PhysicsShapeQueryParameters2D.new()
+				params.shape_rid = shape_rid
 
-			# Execute physics queries here...
+				# Execute physics queries here...
 
-			# Release the shape when done with physics queries.
-			PhysicsServer2D.free_rid(shape_rid)
-			[/codeblock]
+				# Release the shape when done with physics queries.
+				PhysicsServer2D.free_rid(shape_rid)
+				[/gdscript]
+				[csharp]
+				RID shapeRid = PhysicsServer2D.CircleShapeCreate();
+				int radius = 64;
+				PhysicsServer2D.ShapeSetData(shapeRid, radius);
+
+				var params = new PhysicsShapeQueryParameters2D();
+				params.ShapeRid = shapeRid;
+
+				// Execute physics queries here...
+
+				// Release the shape when done with physics queries.
+				PhysicsServer2D.FreeRid(shapeRid);
+				[/csharp]
+				[/codeblocks]
 		</member>
 		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D( 1, 0, 0, 1, 0, 0 )">
 			The queried shape's transform matrix.

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -31,19 +31,34 @@
 		</member>
 		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid">
 			The queried shape's [RID] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:
-			[codeblock]
-			var shape_rid = PhysicsServer3D.shape_create(PhysicsServer3D.SHAPE_SPHERE)
-			var radius = 2.0
-			PhysicsServer3D.shape_set_data(shape_rid, radius)
+				[codeblocks]
+				[gdscript]
+				var shape_rid = PhysicsServer3D.shape_create(PhysicsServer3D.SHAPE_SPHERE)
+				var radius = 2.0
+				PhysicsServer3D.shape_set_data(shape_rid, radius)
 
-			var params = PhysicsShapeQueryParameters3D.new()
-			params.shape_rid = shape_rid
+				var params = PhysicsShapeQueryParameters3D.new()
+				params.shape_rid = shape_rid
 
-			# Execute physics queries here...
+				# Execute physics queries here...
 
-			# Release the shape when done with physics queries.
-			PhysicsServer3D.free_rid(shape_rid)
-			[/codeblock]
+				# Release the shape when done with physics queries.
+				PhysicsServer3D.free_rid(shape_rid)
+				[/gdscript]
+				[csharp]
+				RID shapeRid = PhysicsServer3D.ShapeCreate(PhysicsServer3D.ShapeType.Sphere);
+				float radius = 2.0f;
+				PhysicsServer3D.ShapeSetData(shapeRid, radius);
+
+				var params = new PhysicsShapeQueryParameters3D();
+				params.ShapeRid = shapeRid;
+
+				// Execute physics queries here...
+
+				// Release the shape when done with physics queries.
+				PhysicsServer3D.FreeRid(shapeRid);
+				[/csharp]
+				[/codeblocks]
 		</member>
 		<member name="transform" type="Transform" setter="set_transform" getter="get_transform" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
 			The queried shape's transform matrix.

--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -14,11 +14,18 @@
 			</return>
 			<description>
 				Returns mesh arrays used to constitute surface of [Mesh]. The result can be passed to [method ArrayMesh.add_surface_from_arrays] to create a new surface. For example:
-				[codeblock]
-				var c := CylinderMesh.new()
-				var arr_mesh := ArrayMesh.new()
+				[codeblocks]
+				[gdscript]
+				var c = CylinderMesh.new()
+				var arr_mesh = ArrayMesh.new()
 				arr_mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, c.get_mesh_arrays())
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var c = new CylinderMesh();
+				var arrMesh = new ArrayMesh();
+				arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, c.GetMeshArrays());
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -25,7 +25,8 @@
 				- [code]type[/code]: [int] (see [enum Variant.Type])
 				- optionally [code]hint[/code]: [int] (see [enum PropertyHint]) and [code]hint_string[/code]: [String]
 				[b]Example:[/b]
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				ProjectSettings.set("category/property_name", 0)
 
 				var property_info = {
@@ -36,7 +37,21 @@
 				}
 
 				ProjectSettings.add_property_info(property_info)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				ProjectSettings.Singleton.Set("category/property_name", 0);
+
+				var propertyInfo = new Godot.Collections.Dictionary
+				{
+				    {"name", "category/propertyName"},
+				    {"type", Variant.Type.Int},
+				    {"hint", PropertyHint.Enum},
+				    {"hint_string", "one,two,three"},
+				};
+
+				ProjectSettings.AddPropertyInfo(propertyInfo);
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="clear">
@@ -65,9 +80,14 @@
 			<description>
 				Returns the value of a setting.
 				[b]Example:[/b]
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				print(ProjectSettings.get_setting("application/config/name"))
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				GD.Print(ProjectSettings.GetSetting("application/config/name"));
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="globalize_path" qualifiers="const">
@@ -178,9 +198,14 @@
 			<description>
 				Sets the value of a setting.
 				[b]Example:[/b]
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				ProjectSettings.set_setting("application/config/name", "Example")
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				ProjectSettings.SetSetting("application/config/name", "Example");
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 	</methods>
@@ -888,18 +913,30 @@
 		<member name="physics/2d/default_gravity" type="int" setter="" getter="" default="98">
 			The default gravity strength in 2D.
 			[b]Note:[/b] This property is only read when the project starts. To change the default gravity at runtime, use the following code sample:
-			[codeblock]
+			[codeblocks]
+			[gdscript]
 			# Set the default gravity strength to 98.
-			PhysicsServer2D.area_set_param(get_viewport().find_world_2d().get_space(), PhysicsServer2D.AREA_PARAM_GRAVITY, 98)
-			[/codeblock]
+			PhysicsServer2D.area_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.AREA_PARAM_GRAVITY, 98)
+			[/gdscript]
+			[csharp]
+			// Set the default gravity strength to 98.
+			PhysicsServer2D.AreaSetParam(GetViewport().FindWorld2d().Space, PhysicsServer2D.AreaParameter.Gravity, 98);
+			[/csharp]
+			[/codeblocks]
 		</member>
 		<member name="physics/2d/default_gravity_vector" type="Vector2" setter="" getter="" default="Vector2( 0, 1 )">
 			The default gravity direction in 2D.
 			[b]Note:[/b] This property is only read when the project starts. To change the default gravity vector at runtime, use the following code sample:
-			[codeblock]
+			[codeblocks]
+			[gdscript]
 			# Set the default gravity direction to `Vector2(0, 1)`.
-			PhysicsServer2D.area_set_param(get_viewport().find_world_2d().get_space(), PhysicsServer2D.AREA_PARAM_GRAVITY_VECTOR, Vector2(0, 1))
-			[/codeblock]
+			PhysicsServer2D.area_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.AREA_PARAM_GRAVITY_VECTOR, Vector2.DOWN)
+			[/gdscript]
+			[csharp]
+			// Set the default gravity direction to `Vector2(0, 1)`.
+			PhysicsServer2D.AreaSetParam(GetViewport().FindWorld2d().Space, PhysicsServer2D.AreaParameter.GravityVector, Vector2.Down)
+			[/csharp]
+			[/codeblocks]
 		</member>
 		<member name="physics/2d/default_linear_damp" type="float" setter="" getter="" default="0.1">
 			The default linear damp in 2D.
@@ -935,18 +972,30 @@
 		<member name="physics/3d/default_gravity" type="float" setter="" getter="" default="9.8">
 			The default gravity strength in 3D.
 			[b]Note:[/b] This property is only read when the project starts. To change the default gravity at runtime, use the following code sample:
-			[codeblock]
+			[codeblocks]
+			[gdscript]
 			# Set the default gravity strength to 9.8.
-			PhysicsServer3D.area_set_param(get_viewport().find_world().get_space(), PhysicsServer3D.AREA_PARAM_GRAVITY, 9.8)
-			[/codeblock]
+			PhysicsServer3D.area_set_param(get_viewport().find_world().space, PhysicsServer3D.AREA_PARAM_GRAVITY, 9.8)
+			[/gdscript]
+			[csharp]
+			// Set the default gravity strength to 9.8.
+			PhysicsServer3D.AreaSetParam(GetViewport().FindWorld().Space, PhysicsServer3D.AreaParameter.Gravity, 9.8);
+			[/csharp]
+			[/codeblocks]
 		</member>
 		<member name="physics/3d/default_gravity_vector" type="Vector3" setter="" getter="" default="Vector3( 0, -1, 0 )">
 			The default gravity direction in 3D.
 			[b]Note:[/b] This property is only read when the project starts. To change the default gravity vector at runtime, use the following code sample:
-			[codeblock]
+			[codeblocks]
+			[gdscript]
 			# Set the default gravity direction to `Vector3(0, -1, 0)`.
-			PhysicsServer3D.area_set_param(get_viewport().find_world().get_space(), PhysicsServer3D.AREA_PARAM_GRAVITY_VECTOR, Vector3(0, -1, 0))
-			[/codeblock]
+			PhysicsServer3D.area_set_param(get_viewport().find_world().get_space(), PhysicsServer3D.AREA_PARAM_GRAVITY_VECTOR, Vector3.DOWN)
+			[/gdscript]
+			[csharp]
+			// Set the default gravity direction to `Vector3(0, -1, 0)`.
+			PhysicsServer3D.AreaSetParam(GetViewport().FindWorld().Space, PhysicsServer3D.AreaParameter.GravityVector, Vector3.Down)
+			[/csharp]
+			[/codeblocks]
 		</member>
 		<member name="physics/3d/default_linear_damp" type="float" setter="" getter="" default="0.1">
 			The default linear damp in 3D.


### PR DESCRIPTION
Includes:
 * MarginContainer
 * NavigationPolygon
 * Node
 * NodePath
 * OS
 * PackedByteArray
 * PackedScene
 * PacketPeerUDP
 * PCKPacker
 * Performance
 * PhysicsShapeQueryParameters2D
 * PhysicsShapeQueryParameters3D
 * PrimitiveMesh
 * ProjectSettings