### PR TITLE
Change android orientations from sensor to user

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -515,13 +515,13 @@ public class GodotIO {
 				activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT);
 			} break;
 			case SCREEN_SENSOR_LANDSCAPE: {
-				activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
+				activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE);
 			} break;
 			case SCREEN_SENSOR_PORTRAIT: {
-				activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+				activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT);
 			} break;
 			case SCREEN_SENSOR: {
-				activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR);
+				activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_FULL_USER);
 			} break;
 		}
 	}


### PR DESCRIPTION
Replaces sensor orientations with user orientations for Android.  User functions the same as Sensor except it also respects user's rotation lock setting.

@pouleyKetchoupp and @m4gr3d
Thanks for the help on my first PR!

 
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
