### PR TITLE
Add LStrip, RStrip, and HexEncode to C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -777,31 +777,10 @@ namespace Godot
             return ParseCol4(str, ofs) * 16 + ParseCol4(str, ofs + 1);
         }
 
-        private String ToHex32(float val)
+        private string ToHex32(float val)
         {
-            int v = Mathf.RoundToInt(Mathf.Clamp(val * 255, 0, 255));
-
-            var ret = string.Empty;
-
-            for (int i = 0; i < 2; i++)
-            {
-                char c;
-                int lv = v & 0xF;
-
-                if (lv < 10)
-                {
-                    c = (char)('0' + lv);
-                }
-                else
-                {
-                    c = (char)('a' + lv - 10);
-                }
-
-                v >>= 4;
-                ret = c + ret;
-            }
-
-            return ret;
+            byte b = (byte)Mathf.RoundToInt(Mathf.Clamp(val * 255, 0, 255));
+            return b.HexEncode();
         }
 
         internal static bool HtmlIsValid(string color)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -322,6 +322,15 @@ namespace Godot
             return instance.IndexOf(what, from, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
         }
 
+        /// <summary>Find the first occurrence of a char. Optionally, the search starting position can be passed.</summary>
+        /// <returns>The first instance of the char, or -1 if not found.</returns>
+        public static int Find(this string instance, char what, int from = 0, bool caseSensitive = true)
+        {
+            // TODO: Could be more efficient if we get a char version of `IndexOf`.
+            // See https://github.com/dotnet/runtime/issues/44116
+            return instance.IndexOf(what.ToString(), from, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+        }
+
         /// <summary>Find the last occurrence of a substring.</summary>
         /// <returns>The starting position of the substring, or -1 if not found.</returns>
         public static int FindLast(this string instance, string what, bool caseSensitive = true)
@@ -659,6 +668,33 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns a copy of the string with characters removed from the left.
+        /// </summary>
+        /// <param name="instance">The string to remove characters from.</param>
+        /// <param name="chars">The characters to be removed.</param>
+        /// <returns>A copy of the string with characters removed from the left.</returns>
+        public static string LStrip(this string instance, string chars)
+        {
+            int len = instance.Length;
+            int beg;
+
+            for (beg = 0; beg < len; beg++)
+            {
+                if (chars.Find(instance[beg]) == -1)
+                {
+                    break;
+                }
+            }
+
+            if (beg == 0)
+            {
+                return instance;
+            }
+
+            return instance.Substr(beg, len - beg);
+        }
+
+        /// <summary>
         /// Do a simple expression match, where '*' matches zero or more arbitrary characters and '?' matches any single character except '.'.
         /// </summary>
         private static bool ExprMatch(this string instance, string expr, bool caseSensitive)
@@ -884,6 +920,33 @@ namespace Godot
                 return string.Empty;
 
             return instance.Substring(pos, instance.Length - pos);
+        }
+
+        /// <summary>
+        /// Returns a copy of the string with characters removed from the right.
+        /// </summary>
+        /// <param name="instance">The string to remove characters from.</param>
+        /// <param name="chars">The characters to be removed.</param>
+        /// <returns>A copy of the string with characters removed from the right.</returns>
+        public static string RStrip(this string instance, string chars)
+        {
+            int len = instance.Length;
+            int end;
+
+            for (end = len - 1; end >= 0; end--)
+            {
+                if (chars.Find(instance[end]) == -1)
+                {
+                    break;
+                }
+            }
+
+            if (end == len - 1)
+            {
+                return instance;
+            }
+
+            return instance.Substr(0, end + 1);
         }
 
         public static byte[] SHA256Buffer(this string instance)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -446,6 +446,53 @@ namespace Godot
             return hashv;
         }
 
+        /// <summary>
+        /// Returns a hexadecimal representation of this byte as a string.
+        /// </summary>
+        /// <param name="bytes">The byte to encode.</param>
+        /// <returns>The hexadecimal representation of this byte.</returns>
+        internal static string HexEncode(this byte b)
+        {
+            var ret = string.Empty;
+
+            for (int i = 0; i < 2; i++)
+            {
+                char c;
+                int lv = b & 0xF;
+
+                if (lv < 10)
+                {
+                    c = (char)('0' + lv);
+                }
+                else
+                {
+                    c = (char)('a' + lv - 10);
+                }
+
+                b >>= 4;
+                ret = c + ret;
+            }
+
+            return ret;
+        }
+
+        /// <summary>
+        /// Returns a hexadecimal representation of this byte array as a string.
+        /// </summary>
+        /// <param name="bytes">The byte array to encode.</param>
+        /// <returns>The hexadecimal representation of this byte array.</returns>
+        public static string HexEncode(this byte[] bytes)
+        {
+            var ret = string.Empty;
+
+            foreach (byte b in bytes)
+            {
+                ret += b.HexEncode();
+            }
+
+            return ret;
+        }
+
         // <summary>
         // Convert a string containing an hexadecimal number into an int.
         // </summary>


### PR DESCRIPTION
These changes were prompted when reviewing #43246. I tested this by cherry-picking these commits on 3.2. `LStrip` and `RStrip` were copied from the C++ code, and HexEncode was created by moving the code that was inside `Color`'s `ToHex32`.

This can safely be cherry-picked to 3.2, but with the HexEncode commit I get a conflict in `Color.cs` which I had to resolve manually. The new `ToHex32` can be copied as-is to replace the old one.