### PR TITLE
Avoid reentrant OBJTYPE_RLOCK in ClassDB

### DIFF
--- a/core/class_db.h
+++ b/core/class_db.h
@@ -164,6 +164,11 @@ public:
 	static HashMap<StringName, HashMap<StringName, Variant>> default_values;
 	static Set<StringName> default_values_cached;
 
+private:
+	// Non-locking variants of get_parent_class and is_parent_class.
+	static StringName _get_parent_class(const StringName &p_class);
+	static bool _is_parent_class(const StringName &p_class, const StringName &p_inherits);
+
 public:
 	// DO NOT USE THIS!!!!!! NEEDS TO BE PUBLIC BUT DO NOT USE NO MATTER WHAT!!!
 	template <class T>


### PR DESCRIPTION
Fixes #43020 when a thread uses ClassDB while main thread calls is_parent_class().

I cannot test that this fixes the issue, because it is not easily reproducible currently.