### PR TITLE
Correct documentation about NinePatchRect stretch modes

### DIFF
--- a/doc/classes/NinePatchRect.xml
+++ b/doc/classes/NinePatchRect.xml
@@ -32,10 +32,10 @@
 	</methods>
 	<members>
 		<member name="axis_stretch_horizontal" type="int" setter="set_h_axis_stretch_mode" getter="get_h_axis_stretch_mode" enum="NinePatchRect.AxisStretchMode" default="0">
-			Doesn't do anything at the time of writing.
+			The stretch mode to use for horizontal stretching/tiling. See [enum NinePatchRect.AxisStretchMode] for possible values.
 		</member>
 		<member name="axis_stretch_vertical" type="int" setter="set_v_axis_stretch_mode" getter="get_v_axis_stretch_mode" enum="NinePatchRect.AxisStretchMode" default="0">
-			Doesn't do anything at the time of writing.
+			The stretch mode to use for vertical stretching/tiling. See [enum NinePatchRect.AxisStretchMode] for possible values.
 		</member>
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled" default="true">
 			If [code]true[/code], draw the panel's center. Else, only draw the 9-slice's borders.
@@ -69,13 +69,15 @@
 	</signals>
 	<constants>
 		<constant name="AXIS_STRETCH_MODE_STRETCH" value="0" enum="AxisStretchMode">
-			Doesn't do anything at the time of writing.
+			Stretches the center texture across the NinePatchRect. This may cause the texture to be distorted.
 		</constant>
 		<constant name="AXIS_STRETCH_MODE_TILE" value="1" enum="AxisStretchMode">
-			Doesn't do anything at the time of writing.
+			Repeats the center texture across the NinePatchRect. This won't cause any visible distortion. The texture must be seamless for this to work without displaying artifacts between edges.
+			[b]Note:[/b] Only supported when using the GLES3 renderer. When using the GLES2 renderer, this will behave like [constant AXIS_STRETCH_MODE_STRETCH].
 		</constant>
 		<constant name="AXIS_STRETCH_MODE_TILE_FIT" value="2" enum="AxisStretchMode">
-			Doesn't do anything at the time of writing.
+			Repeats the center texture across the NinePatchRect, but will also stretch the texture to make sure each tile is visible in full. This may cause the texture to be distorted, but less than [constant AXIS_STRETCH_MODE_STRETCH]. The texture must be seamless for this to work without displaying artifacts between edges.
+			[b]Note:[/b] Only supported when using the GLES3 renderer. When using the GLES2 renderer, this will behave like [constant AXIS_STRETCH_MODE_STRETCH].
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
Tested on Godot 3.2.4beta1 with batching enabled.

PS: We should also add node configuration warnings to NinePatchRect, but I'll do this against the `3.2` branch since this isn't relevant to the Vulkan renderer.

This closes https://github.com/godotengine/godot-docs/issues/4333.