### PR TITLE
Fix editor constant redraw from fxaa and debanding.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3020,6 +3020,9 @@ Viewport::MSAA Viewport::get_msaa() const {
 
 void Viewport::set_use_fxaa(bool p_fxaa) {
 
+	if (p_fxaa == use_fxaa) {
+		return;
+	}
 	use_fxaa = p_fxaa;
 	VS::get_singleton()->viewport_set_use_fxaa(viewport, use_fxaa);
 }
@@ -3031,6 +3034,9 @@ bool Viewport::get_use_fxaa() const {
 
 void Viewport::set_use_debanding(bool p_debanding) {
 
+	if (p_debanding == use_debanding) {
+		return;
+	}
 	use_debanding = p_debanding;
 	VS::get_singleton()->viewport_set_use_debanding(viewport, use_debanding);
 }


### PR DESCRIPTION
Every NOTIFICATION_PROCESS the spatial_editor_plugin.cpp is calling set_use_fxaa which is causing a redraw_request(). Same with debanding.

These can be fixed be checking for noop state changes.

Fixes #43228

## Notes
* This will also presumably need matching PR for 4.0, I can't do this (need to upgrade my OS before 4.0 will run) but it should be simple enough for Akien etc.
* Need to check at startup this matches the default state of fxaa and debanding - yes it does seem to match on client side and in the renderer.

## Further
Although this fixes the problem, it strikes me that the whole system of querying a bunch of strings every process in spatial_editor_plugin.cpp (and elsewhere presumably) is very inefficient. Surely there should be a notification sent specifically when a project setting is changed, rather than checking every setting, every frame, just in case? Does anyone know if one exists already? Maybe we could put one in.

This would be very useful in the renderer too to prevent the need for restarts when changing settings.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
