### PR TITLE
doc: Clarify documentation for Control._make_custom_tooltip

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -75,15 +75,17 @@
 			</description>
 		</method>
 		<method name="_make_custom_tooltip" qualifiers="virtual">
-			<return type="Object">
+			<return type="Control">
 			</return>
 			<argument index="0" name="for_text" type="String">
 			</argument>
 			<description>
-				Virtual method to be implemented by the user. Returns a [Control] node that should be used as a tooltip instead of the default one. Use [code]for_text[/code] parameter to determine what text the tooltip should contain (likely the contents of [member hint_tooltip]).
-				The returned node must be of type [Control] or Control-derieved. It can have child nodes of any type. It is freed when the tooltip disappears, so make sure you always provide a new instance, not e.g. a node from scene. When [code]null[/code] or non-Control node is returned, the default tooltip will be used instead.
+				Virtual method to be implemented by the user. Returns a [Control] node that should be used as a tooltip instead of the default one. The [code]for_text[/code] includes the contents of the [member hint_tooltip] property.
+				The returned node must be of type [Control] or Control-derived. It can have child nodes of any type. It is freed when the tooltip disappears, so make sure you always provide a new instance (if you want to use a pre-existing node from your scene tree, you can duplicate it and pass the duplicated instance).When [code]null[/code] or a non-Control node is returned, the default tooltip will be used instead.
+				The returned node will be added as child to a [PopupPanel], so you should only provide the contents of that panel.
 				[b]Note:[/b] The tooltip is shrunk to minimal size. If you want to ensure it's fully visible, you might want to set its [member rect_min_size] to some non-zero value.
-				Example of usage with custom-constructed node:
+				[b]Note:[/b] The node (and any relevant children) should be [member CanvasItem.visible] when returned, otherwise the viewport that instantiates it will not be able to calculate its minimum size reliably.
+				Example of usage with a custom-constructed node:
 				[codeblocks]
 				[gdscript]
 				func _make_custom_tooltip(for_text):
@@ -92,7 +94,7 @@
 				    return label
 				[/gdscript]
 				[csharp]
-				public override Godot.Object _MakeCustomTooltip(String forText)
+				public override Godot.Control _MakeCustomTooltip(String forText)
 				{
 				    var label = new Label();
 				    label.Text = forText;
@@ -100,18 +102,18 @@
 				}
 				[/csharp]
 				[/codeblocks]
-				Example of usage with custom scene instance:
+				Example of usage with a custom scene instance:
 				[codeblocks]
 				[gdscript]
 				func _make_custom_tooltip(for_text):
-				    var tooltip = preload("SomeTooltipScene.tscn").instance()
+				    var tooltip = preload("res://SomeTooltipScene.tscn").instance()
 				    tooltip.get_node("Label").text = for_text
 				    return tooltip
 				[/gdscript]
 				[csharp]
-				public override Godot.Object _MakeCustomTooltip(String forText)
+				public override Godot.Control _MakeCustomTooltip(String forText)
 				{
-				    Node tooltip = ResourceLoader.Load&lt;PackedScene&gt;("SomeTooltipScene.tscn").Instance();
+				    Node tooltip = ResourceLoader.Load&lt;PackedScene&gt;("res://SomeTooltipScene.tscn").Instance();
 				    tooltip.GetNode&lt;Label&gt;("Label").Text = forText;
 				    return tooltip;
 				}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2738,7 +2738,9 @@ void Control::_bind_methods() {
 
 	BIND_VMETHOD(MethodInfo(Variant::BOOL, "can_drop_data", PropertyInfo(Variant::VECTOR2, "position"), PropertyInfo(Variant::NIL, "data")));
 	BIND_VMETHOD(MethodInfo("drop_data", PropertyInfo(Variant::VECTOR2, "position"), PropertyInfo(Variant::NIL, "data")));
-	BIND_VMETHOD(MethodInfo(Variant::OBJECT, "_make_custom_tooltip", PropertyInfo(Variant::STRING, "for_text")));
+	BIND_VMETHOD(MethodInfo(
+			PropertyInfo(Variant::OBJECT, "control", PROPERTY_HINT_RESOURCE_TYPE, "Control"),
+			"_make_custom_tooltip", PropertyInfo(Variant::STRING, "for_text")));
 	BIND_VMETHOD(MethodInfo(Variant::BOOL, "_clips_input"));
 
 	ADD_GROUP("Anchor", "anchor_");


### PR DESCRIPTION
The return type is Control, and users should make sure to return a visible
node for proper size calculations.

Moreover in the current master branch, a PopupPanel will be added as parent
to the provided tooltip to make it a sub-window.

Fixes #39677.

---

Note to self: When cherry-picking, the line about PopupPanel should be removed as it's not the case in `3.2`.

The change to the hinting of the return type might also be considered compat breaking for C#?