### PR TITLE
Document AtlasTexture not supporting repetition

### DIFF
--- a/doc/classes/AtlasTexture.xml
+++ b/doc/classes/AtlasTexture.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		[Texture] resource aimed at managing big textures files that pack multiple smaller textures. Consists of a [Texture], a margin that defines the border width, and a region that defines the actual area of the AtlasTexture.
+		[b]Note:[/b] AtlasTextures don't support repetition. The [constant Texture.FLAG_REPEAT] and [constant Texture.FLAG_MIRRORED_REPEAT] flags are ignored when using an AtlasTexture.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Texture.xml
+++ b/doc/classes/Texture.xml
@@ -118,6 +118,7 @@
 		</constant>
 		<constant name="FLAG_REPEAT" value="2" enum="Flags">
 			Repeats the texture (instead of clamp to edge).
+			[b]Note:[/b] Ignored when using an [AtlasTexture] as these don't support repetition.
 		</constant>
 		<constant name="FLAG_FILTER" value="4" enum="Flags">
 			Uses a magnifying filter, to enable smooth zooming in of the texture.
@@ -131,6 +132,7 @@
 		</constant>
 		<constant name="FLAG_MIRRORED_REPEAT" value="32" enum="Flags">
 			Repeats the texture with alternate sections mirrored.
+			[b]Note:[/b] Ignored when using an [AtlasTexture] as these don't support repetition.
 		</constant>
 		<constant name="FLAG_VIDEO_SURFACE" value="2048" enum="Flags">
 			Texture is a video surface.


### PR DESCRIPTION
See #5660.

**Note:** Opened against the `3.2` branch as the way texture flags are handle in `master` is different.