### PR TITLE
Remove `Color.contrasted()` as its behavior is barely useful

### DIFF
--- a/core/color.cpp
+++ b/core/color.cpp
@@ -217,12 +217,6 @@ void Color::invert() {
 	b = 1.0 - b;
 }
 
-void Color::contrast() {
-	r = Math::fmod(r + 0.5, 1.0);
-	g = Math::fmod(g + 0.5, 1.0);
-	b = Math::fmod(b + 0.5, 1.0);
-}
-
 Color Color::hex(uint32_t p_hex) {
 	float a = (p_hex & 0xFF) / 255.0;
 	p_hex >>= 8;
@@ -281,12 +275,6 @@ static int _parse_col8(const String &p_str, int p_ofs) {
 Color Color::inverted() const {
 	Color c = *this;
 	c.invert();
-	return c;
-}
-
-Color Color::contrasted() const {
-	Color c = *this;
-	c.contrast();
 	return c;
 }
 

--- a/core/color.h
+++ b/core/color.h
@@ -91,9 +91,7 @@ struct Color {
 	bool is_equal_approx(const Color &p_color) const;
 
 	void invert();
-	void contrast();
 	Color inverted() const;
-	Color contrasted() const;
 
 	_FORCE_INLINE_ Color lerp(const Color &p_b, float p_t) const {
 		Color res = *this;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1614,7 +1614,6 @@ void register_variant_methods() {
 	bind_method(Color, to_rgba64, sarray(), varray());
 
 	bind_method(Color, inverted, sarray(), varray());
-	bind_method(Color, contrasted, sarray(), varray());
 	bind_method(Color, lerp, sarray("b", "t"), varray());
 	bind_method(Color, lightened, sarray("amount"), varray());
 	bind_method(Color, darkened, sarray("amount"), varray());

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -159,23 +159,6 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="contrasted">
-			<return type="Color">
-			</return>
-			<description>
-				Returns the most contrasting color.
-				[codeblocks]
-				[gdscript]
-				var color = Color(0.3, 0.4, 0.9)
-				var contrasted_color = color.contrasted() # Equivalent to RGBA(204, 229, 102, 255)
-				[/gdscript]
-				[csharp]
-				var color = new Color(0.3f, 0.4f, 0.9f);
-				Color contrastedColor = color.Contrasted(); // Equivalent to RGBA(204, 229, 102, 255)
-				[/csharp]
-				[/codeblocks]
-			</description>
-		</method>
 		<method name="darkened">
 			<return type="Color">
 			</return>

--- a/modules/gdnative/gdnative/color.cpp
+++ b/modules/gdnative/gdnative/color.cpp
@@ -148,13 +148,6 @@ godot_color GDAPI godot_color_inverted(const godot_color *p_self) {
 	return dest;
 }
 
-godot_color GDAPI godot_color_contrasted(const godot_color *p_self) {
-	godot_color dest;
-	const Color *self = (const Color *)p_self;
-	*((Color *)&dest) = self->contrasted();
-	return dest;
-}
-
 godot_color GDAPI godot_color_lerp(const godot_color *p_self, const godot_color *p_b, const godot_real p_t) {
 	godot_color dest;
 	const Color *self = (const Color *)p_self;

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -1255,13 +1255,6 @@
         ]
       },
       {
-        "name": "godot_color_contrasted",
-        "return_type": "godot_color",
-        "arguments": [
-          ["const godot_color *", "p_self"]
-        ]
-      },
-      {
         "name": "godot_color_lerp",
         "return_type": "godot_color",
         "arguments": [

--- a/modules/gdnative/include/gdnative/color.h
+++ b/modules/gdnative/include/gdnative/color.h
@@ -93,8 +93,6 @@ godot_int GDAPI godot_color_to_argb32(const godot_color *p_self);
 
 godot_color GDAPI godot_color_inverted(const godot_color *p_self);
 
-godot_color GDAPI godot_color_contrasted(const godot_color *p_self);
-
 godot_color GDAPI godot_color_lerp(const godot_color *p_self, const godot_color *p_b, const godot_real p_t);
 
 godot_color GDAPI godot_color_blend(const godot_color *p_self, const godot_color *p_over);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -257,20 +257,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the most contrasting color.
-        /// </summary>
-        /// <returns>The most contrasting color</returns>
-        public Color Contrasted()
-        {
-            return new Color(
-                (r + 0.5f) % 1.0f,
-                (g + 0.5f) % 1.0f,
-                (b + 0.5f) % 1.0f,
-                a
-            );
-        }
-
-        /// <summary>
         /// Returns a new color resulting from making this color darker
         /// by the specified ratio (on the range of 0 to 1).
         /// </summary>

--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -357,7 +357,7 @@ void GradientEdit::_notification(int p_what) {
 
 		//Draw point markers
 		for (int i = 0; i < points.size(); i++) {
-			Color col = points[i].color.contrasted();
+			Color col = points[i].color.inverted();
 			col.a = 0.9;
 
 			draw_line(Vector2(points[i].offset * total_w, 0), Vector2(points[i].offset * total_w, h / 2), col);

--- a/tests/test_color.h
+++ b/tests/test_color.h
@@ -185,9 +185,6 @@ TEST_CASE("[Color] Manipulation methods") {
 	CHECK_MESSAGE(
 			blue.inverted().is_equal_approx(Color(1, 1, 0, 0.4)),
 			"Inverted color should have its red, green and blue components inverted.");
-	CHECK_MESSAGE(
-			blue.contrasted().is_equal_approx(Color(0.5, 0.5, 0.5, 0.4)),
-			"Contrasted pure blue should be fully gray.");
 
 	const Color purple = Color(0.5, 0.2, 0.5, 0.25);
 


### PR DESCRIPTION
Returning the most contrasting color isn't a trivial task, as there are often many possible choices. Since there is no "one true way" to find a contrasting color, it's usually best left for the user to implement using a script.

This closes #42922.