### PR TITLE
Release pressed action if event is removed

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -31,6 +31,7 @@
 #include "input_map.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input.h"
 #include "core/os/keyboard.h"
 
 InputMap *InputMap::singleton = nullptr;
@@ -145,6 +146,9 @@ void InputMap::action_erase_event(const StringName &p_action, const Ref<InputEve
 	List<Ref<InputEvent>>::Element *E = _find_event(input_map[p_action], p_event);
 	if (E) {
 		input_map[p_action].inputs.erase(E);
+		if (Input::get_singleton()->is_action_pressed(p_action)) {
+			Input::get_singleton()->action_release(p_action);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #43232

Note that the action will be released even if another event was pressed. This is because Actions don't really keep track of pressed events (related to #30888). Removing event when action is pressed is rare anyways, so it's not really a problem.