### PR TITLE
FBX polyfill the skin information for deformers which were optimised out of the FBX

### DIFF
--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -694,17 +694,10 @@ Spatial *EditorSceneImporterFBX::_generate_scene(
 			Ref<FBXBone> bone = elem->value();
 			Transform ignore_t;
 			Ref<FBXSkeleton> skeleton = bone->fbx_skeleton;
-
-			if (!bone->cluster) {
-				continue; // some bones have no skin this is OK.
-			}
-
-			Ref<FBXNode> bone_link = bone->get_link(state);
-			ERR_CONTINUE_MSG(bone_link.is_null(), "invalid skin pose bone link");
-
+			// grab the skin bind
 			bool valid_bind = false;
-
 			Transform bind = bone->get_vertex_skin_xform(state, fbx_node->pivot_transform->GlobalTransform, valid_bind);
+
 			ERR_CONTINUE_MSG(!valid_bind, "invalid bind");
 
 			if (bind.basis.determinant() == 0) {
@@ -918,7 +911,7 @@ Spatial *EditorSceneImporterFBX::_generate_scene(
 						// note: do not use C++17 syntax here for dicts.
 						// this is banned in Godot.
 						for (std::pair<const std::string, const FBXDocParser::AnimationCurve *> &kvp : curves) {
-							String curve_element = ImportUtils::FBXNodeToName(kvp.first);
+							const String curve_element = ImportUtils::FBXNodeToName(kvp.first);
 							const FBXDocParser::AnimationCurve *curve = kvp.second;
 							String curve_name = ImportUtils::FBXNodeToName(curve->Name());
 							uint64_t curve_id = curve->ID();
@@ -930,7 +923,7 @@ Spatial *EditorSceneImporterFBX::_generate_scene(
 							}
 
 							// FBX has no name for AnimCurveNode::, most of the time, not seen any with valid name here.
-							const std::map<int64_t, float> track_time = curve->GetValueTimeTrack();
+							const std::map<int64_t, float> &track_time = curve->GetValueTimeTrack();
 
 							if (track_time.size() > 0) {
 								for (std::pair<int64_t, float> keyframe : track_time) {


### PR DESCRIPTION
This happens in 3.2 and 4.0.

Ideally we make the rasteriser able to handle a different bone count in the skin, to the skeleton for now we just dump in an identity transform in the skin and expand the skin by a lot of binds.

- Resolves bug with sensei model and various others (including work assets)

I think rasteriser should be modified to handle indexes individually for skin and skeleton bind counts for 4.0 might make skinning faster? IDK

<img width="1009" alt="Screenshot 2020-11-03 at 18 27 46" src="https://user-images.githubusercontent.com/748770/98026000-6187f500-1e02-11eb-931c-da16e649ad9f.png">
