### PR TITLE
Move call to update the 3D grid into check for updating the view

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -351,8 +351,8 @@ void Node3DEditorViewport::_update_camera(float p_interp_delta) {
 
 		update_transform_gizmo_view();
 		rotation_control->update();
+		spatial_editor->update_grid();
 	}
-	spatial_editor->update_grid();
 }
 
 Transform Node3DEditorViewport::to_camera_transform(const Cursor &p_cursor) const {


### PR DESCRIPTION
Fixes a minor performance regression from #28289, found while testing #43206.

The update spinner still continuously spins, but at least now there is one fewer reason for that happening.