### PR TITLE
CSGShape use_collision functionality improvement, plus parent and visibility update fixes

### DIFF
--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -51,13 +51,15 @@ public:
 
 private:
 	Operation operation;
-	CSGShape3D *parent;
+	CSGShape3D *parent_shape;
 
 	CSGBrush *brush;
+	CSGBrush *collision_brush;
 
 	AABB node_aabb;
 
 	bool dirty;
+	bool last_visible;
 	float snap;
 
 	bool use_collision;
@@ -103,18 +105,17 @@ private:
 			const tbool bIsOrientationPreserving, const int iFace, const int iVert);
 
 	void _update_shape();
+	void _update_collision_faces();
 
 protected:
 	void _notification(int p_what);
 	virtual CSGBrush *_build_brush() = 0;
-	void _make_dirty();
+	void _make_dirty(bool p_parent_removing = false);
 
 	static void _bind_methods();
 
 	friend class CSGCombiner3D;
-	CSGBrush *_get_brush();
-
-	virtual void _validate_property(PropertyInfo &property) const override;
+	CSGBrush *_get_brush(bool p_collision = false);
 
 public:
 	Array get_meshes() const;

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -83,7 +83,7 @@
 			Snap makes the mesh snap to a given distance so that the faces of two meshes can be perfectly aligned. A lower value results in greater precision but may be harder to adjust.
 		</member>
 		<member name="use_collision" type="bool" setter="set_use_collision" getter="is_using_collision" default="false">
-			Adds a collision shape to the physics engine for our CSG shape. This will always act like a static body. Note that the collision shape is still active even if the CSG shape itself is hidden.
+			Adds a collision shape to the physics engine comprised of this node's CSG shape and the shapes of any children that also have use_collision enabled. This will always act like a static body. Note that collision is still active even if the CSG shape itself is hidden.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
This PR is identical to #40814, but with changes to `use_collision` detailed in https://github.com/godotengine/godot/issues/43251#issuecomment-721767274.

- `use_collision` is now enabled for all child shapes and can be used to toggle collision on an individual basis.
- Visibility no longer affects collision. Fixes godotengine#43251.
- Prevents unnecessary `CSGShape` updates when changing the parent's visibility or hierarchy. Fixes godotengine#40931.
- Fixes godotengine#41093.
- Refactor: Renames `parent` to `parent_shape`.
- Refactor: Cleaned up `CSGShape3D::_notification`.

##
Test projects:
[40814 Test Suite - Visibility.zip](https://github.com/godotengine/godot/files/5044638/40814.Test.Suite.-.Visibility.zip)
[40814 Test Suite - Scene Tree.zip](https://github.com/godotengine/godot/files/5044637/40814.Test.Suite.-.Scene.Tree.zip)
[40814 Test Suite - Collision.zip](https://github.com/godotengine/godot/files/5044952/40814.Test.Suite.-.Collision.zip)