### PR TITLE
Disallow setting the AudioServer's 'global_rate_scale' to a value equal or inferior to 0

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -905,6 +905,8 @@ bool AudioServer::is_bus_channel_active(int p_bus, int p_channel) const {
 }
 
 void AudioServer::set_global_rate_scale(float p_scale) {
+	ERR_FAIL_COND(p_scale <= 0);
+
 	global_rate_scale = p_scale;
 }
 


### PR DESCRIPTION
This prevents a division by 0 within the code.