### PR TITLE
shaders: Implement custom ambient sampling and dir lights

### DIFF
--- a/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_scene_high_end_rd.cpp
@@ -2797,6 +2797,9 @@ RasterizerSceneHighEndRD::RasterizerSceneHighEndRD(RasterizerStorageRD *p_storag
 		actions.renames["FOG"] = "custom_fog";
 		actions.renames["RADIANCE"] = "custom_radiance";
 		actions.renames["IRRADIANCE"] = "custom_irradiance";
+		actions.renames["HAS_MAIN_LIGHT"] = "has_main_light";
+		actions.renames["AMBIENT_LIGHT"] = "ambient_light";
+		actions.renames["godot_sample_ambient"] = "godot_sample_ambient";
 
 		//for light
 		actions.renames["VIEW"] = "view";
@@ -2806,6 +2809,7 @@ RasterizerSceneHighEndRD::RasterizerSceneHighEndRD(RasterizerStorageRD *p_storag
 		actions.renames["SHADOW_ATTENUATION"] = "shadow_attenuation";
 		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
 		actions.renames["SPECULAR_LIGHT"] = "specular_light";
+		actions.renames["IS_MAIN_LIGHT"] = "is_main_light";
 
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
 		actions.usage_defines["BINORMAL"] = "@TANGENT";
@@ -2836,6 +2840,9 @@ RasterizerSceneHighEndRD::RasterizerSceneHighEndRD(RasterizerStorageRD *p_storag
 		actions.usage_defines["SCREEN_TEXTURE"] = "#define SCREEN_TEXTURE_USED\n";
 		actions.usage_defines["SCREEN_UV"] = "#define SCREEN_UV_USED\n";
 
+		actions.usage_defines["HAS_MAIN_LIGHT"] = "#define MAIN_LIGHT_USED\n";
+		actions.usage_defines["IS_MAIN_LIGHT"] = "@HAS_MAIN_LIGHT";
+		actions.usage_defines["AMBIENT_LIGHT"] = "#define AMBIENT_LIGHT_USED\n";
 		actions.usage_defines["DIFFUSE_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
 		actions.usage_defines["SPECULAR_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
 

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -734,10 +734,12 @@ public:
 		struct Argument {
 			StringName name;
 			DataType type;
+			ArgumentQualifier qualifier;
 
-			Argument(const StringName &p_name = StringName(), DataType p_type = TYPE_VOID) {
+			Argument(const StringName &p_name = StringName(), DataType p_type = TYPE_VOID, ArgumentQualifier p_qualifier = ARGUMENT_QUALIFIER_IN) {
 				name = p_name;
 				type = p_type;
+				qualifier = p_qualifier;
 			}
 		};
 
@@ -855,6 +857,7 @@ private:
 	Error _validate_datatype(DataType p_type);
 	bool _compare_datatypes_in_nodes(Node *a, Node *b) const;
 
+	bool _validate_out_argument(BlockNode *p_block, const FunctionInfo &p_function_info, OperatorNode *p_func, StringName p_name, int p_arg_idx);
 	bool _validate_function_call(BlockNode *p_block, const FunctionInfo &p_function_info, OperatorNode *p_func, DataType *r_ret_type, StringName *r_ret_type_str);
 	bool _parse_function_arguments(BlockNode *p_block, const FunctionInfo &p_function_info, OperatorNode *p_func, int *r_complete_arg = nullptr);
 	bool _propagate_function_call_sampler_uniform_settings(StringName p_name, int p_argument, TextureFilter p_filter, TextureRepeat p_repeat);

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -119,6 +119,9 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["DEPTH"] = ShaderLanguage::TYPE_FLOAT;
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["SCREEN_UV"] = ShaderLanguage::TYPE_VEC2;
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["POINT_COORD"] = constt(ShaderLanguage::TYPE_VEC2);
+	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["AMBIENT_LIGHT"] = ShaderLanguage::TYPE_VEC3;
+	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["DIFFUSE_LIGHT"] = ShaderLanguage::TYPE_VEC3;
+	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["SPECULAR_LIGHT"] = ShaderLanguage::TYPE_VEC3;
 
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["OUTPUT_IS_SRGB"] = constt(ShaderLanguage::TYPE_BOOL);
 
@@ -132,6 +135,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["FOG"] = ShaderLanguage::TYPE_VEC4; // TODO consider adding to light shader
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["RADIANCE"] = ShaderLanguage::TYPE_VEC4;
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["IRRADIANCE"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["HAS_MAIN_LIGHT"] = constt(ShaderLanguage::TYPE_BOOL);
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].can_discard = true;
 
 	shader_modes[RS::SHADER_SPATIAL].functions["fragment"].built_ins["ALPHA_SCISSOR_THRESHOLD"] = ShaderLanguage::TYPE_FLOAT;
@@ -155,6 +159,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["LIGHT_COLOR"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["ATTENUATION"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["SHADOW_ATTENUATION"] = constt(ShaderLanguage::TYPE_VEC3);
+	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["IS_MAIN_LIGHT"] = constt(ShaderLanguage::TYPE_BOOL);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["ALBEDO"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["BACKLIGHT"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["METALLIC"] = constt(ShaderLanguage::TYPE_FLOAT);
@@ -165,6 +170,22 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].built_ins["ALPHA"] = ShaderLanguage::TYPE_FLOAT;
 
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].can_discard = true;
+
+	{
+		ShaderLanguage::StageFunctionInfo sample_ambient_func;
+		sample_ambient_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("vertex", ShaderLanguage::TYPE_VEC3));
+		sample_ambient_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("normal", ShaderLanguage::TYPE_VEC3));
+		sample_ambient_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("roughness", ShaderLanguage::TYPE_FLOAT));
+		sample_ambient_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("specular", ShaderLanguage::TYPE_FLOAT));
+		sample_ambient_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("metallic", ShaderLanguage::TYPE_FLOAT));
+		sample_ambient_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("uv2", ShaderLanguage::TYPE_VEC2));
+		sample_ambient_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("custom_radiance", ShaderLanguage::TYPE_VEC4));
+		sample_ambient_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("custom_irradiance", ShaderLanguage::TYPE_VEC4));
+		sample_ambient_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("ambient_light", ShaderLanguage::TYPE_VEC3, ShaderLanguage::ARGUMENT_QUALIFIER_OUT));
+		sample_ambient_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("specular_light", ShaderLanguage::TYPE_VEC3, ShaderLanguage::ARGUMENT_QUALIFIER_OUT));
+		sample_ambient_func.return_type = ShaderLanguage::TYPE_VOID;
+		shader_modes[RS::SHADER_SPATIAL].functions["fragment"].stage_functions["godot_sample_ambient"] = sample_ambient_func;
+	}
 
 	//order used puts first enum mode (default) first
 	shader_modes[RS::SHADER_SPATIAL].modes.push_back("blend_mix");


### PR DESCRIPTION
Adds new function `godot_sample_ambient()`, and allows writing to `AMBIENT_LIGHT` to override builtin ambient processing.

Furthermore, sets `IS_MAIN_LIGHT` on the strongest directional light in light().
Adds `HAS_MAIN_LIGHT` to fragment() to allow for fallback logic, if a light with `IS_MAIN_LIGHT`=true does not exist.

This is an implementation of the proposal at godotengine/godot-proposals#1778

The proposal, and this commit, serves to form a *bare minimum* set of engine changes needed to enable many kinds of non-physical shading currently possible in other engines.

List of new variables available in fragment():
- **AMBIENT_LIGHT** (vec3)
- **DIFFUSE_LIGHT** (vec3)
- **SPECULAR_LIGHT** (vec3)
- **HAS_MAIN_LIGHT** (bool)

New variable available in light():
- **IS_MAIN_LIGHT** (bool)

New stage function available in fragment():
- **godot_sample_ambient**(vec3 vertex, vec3 normal, float roughness, float specular, float metallic, vec2 uv2, vec4 custom_radiance, vec4 custom_irradiance, **out** vec3 ambient_light, **out** vec3 specular_light) -> void

Activate by assigning a value to `AMBIENT_LIGHT`.
Usage of `AMBIENT_LIGHT`, `DIFFUSE_LIGHT` and `SPECULAR_LIGHT` in the fragment shader disables builtin ambient lighting, reflection and lightmap lookups.

Please see the working example project at https://github.com/lyuma/Godot-MToon-Shader ( `godot_sample_ambient` branch )