### PR TITLE
Add `randv_circle()` to `RandomNumberGenerator` to generate unit vectors in 2D

### DIFF
--- a/core/math/random_number_generator.cpp
+++ b/core/math/random_number_generator.cpp
@@ -39,6 +39,7 @@ void RandomNumberGenerator::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("randfn", "mean", "deviation"), &RandomNumberGenerator::randfn, DEFVAL(0.0), DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("randf_range", "from", "to"), &RandomNumberGenerator::randf_range);
 	ClassDB::bind_method(D_METHOD("randi_range", "from", "to"), &RandomNumberGenerator::randi_range);
+	ClassDB::bind_method(D_METHOD("randv_circle"), &RandomNumberGenerator::randv_circle);
 	ClassDB::bind_method(D_METHOD("randomize"), &RandomNumberGenerator::randomize);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "seed"), "set_seed", "get_seed");

--- a/core/math/random_number_generator.h
+++ b/core/math/random_number_generator.h
@@ -72,6 +72,11 @@ public:
 		return randbase.rand(range) + min;
 	}
 
+	_FORCE_INLINE_ Vector2 randv_circle() {
+		real_t t = randbase.randf() * Math_TAU;
+		return Vector2(Math::cos(t), Math::sin(t));
+	}
+
 	RandomNumberGenerator() {}
 };
 

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -72,6 +72,19 @@
 				Setups a time-based seed to generator.
 			</description>
 		</method>
+		<method name="randv_circle">
+			<return type="Vector2">
+			</return>
+			<description>
+				Generates a normalized vector, also known as point on a unit circle. The unit vector can be multiplied by a scalar value to produce points on a circle with an arbitrary radius:
+				[codeblock]
+				var rng = RandomNumberGenerator.new()
+				var direction = rng.randv_circle()
+				var radius = 64
+				var impulse = direction * radius
+				[/codeblock]
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="seed" type="int" setter="set_seed" getter="get_seed" default="0">

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -47,6 +47,7 @@
 #include "test_ordered_hash_map.h"
 #include "test_physics_2d.h"
 #include "test_physics_3d.h"
+#include "test_random_number_generator.h"
 #include "test_render.h"
 #include "test_shader_lang.h"
 #include "test_string.h"

--- a/tests/test_random_number_generator.h
+++ b/tests/test_random_number_generator.h
@@ -1,0 +1,61 @@
+/*************************************************************************/
+/*  test_random_number_generator.h                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_RANDOM_NUMBER_GENERATOR_H
+#define TEST_RANDOM_NUMBER_GENERATOR_H
+
+#include "core/math/random_number_generator.h"
+#include "tests/test_macros.h"
+
+namespace TestRandomNumberGenerator {
+
+TEST_CASE("[RandomNumberGenerator] On unit circle") {
+	Ref<RandomNumberGenerator> rng = memnew(RandomNumberGenerator);
+	rng->set_seed(0);
+	for (int i = 0; i < 100; ++i) {
+		const Vector2 &point = rng->randv_circle();
+		INFO(point.length());
+		CHECK(Math::is_equal_approx(point.length(), 1.0));
+		CHECK(point.is_normalized());
+	}
+}
+
+TEST_CASE("[Stress][RandomNumberGenerator] On unit circle") {
+	Ref<RandomNumberGenerator> rng = memnew(RandomNumberGenerator);
+	rng->set_seed(0);
+	for (int i = 0; i < 100000; ++i) {
+		const Vector2 &point = rng->randv_circle();
+		INFO(point);
+	}
+}
+
+} // namespace TestRandomNumberGenerator
+
+#endif // TEST_RANDOM_NUMBER_GENERATOR_H


### PR DESCRIPTION
Solves the 2D part of godotengine/godot-proposals#1731.
Alternative to #43103.

When comparing to #43103:
- the same `randv_circle()` is implemented, except that *this* implementation doesn't have `min_radius` and `max_radius` parameters;
- due to the above, *this* PR doesn't provide within circle generation and ring point generation out of the box. This can be simulated by multiplying by scalar, which takes extra work for users;
- due to the above, implementation in *this* PR is minimal and quite simple.

Performance-wise, *this* PR is x1.3 faster:

```
.\bin\godot --test --source-file="*test_random_number_generator*" --test-case="*stress*" --duration
```

### From #43103

![godot_randv_circle_doctest](https://user-images.githubusercontent.com/17108460/98309027-22a89980-1fd2-11eb-8d9a-955447efb5f6.png)

### From this PR

![godot_rng_unit_circle](https://user-images.githubusercontent.com/17108460/98309033-26d4b700-1fd2-11eb-80d5-d6291f2d8f47.png)

But if you do want to generate points *inside* circle or ring with *this* PR, this is where the performance may actually suffer quite a bit in GDScript, likely because multiplication by scalar takes quite some time to perform via script:

```gdscript
extends Node2D

const COUNT = 100000
var rng = RandomNumberGenerator.new()

func _input(event: InputEvent):
	if event.is_action_pressed("ui_accept"):
		on_unit_circle()
		on_unit_circle_multiply_radius_via_script()
		on_circle_radius_via_native_args()

# This PR.
func on_unit_circle():
	for i in COUNT:
		var p = rng.randv_circle()

# From #43103.
func on_unit_circle_multiply_radius_via_script():
	for i in COUNT:
		var p = rng.randv_circle() * 32

# From #43103.
func on_circle_radius_via_native_args():
	for i in COUNT:
		var p = rng.randv_circle(32, 32)
```

![godot_randv_circle_perf_test](https://user-images.githubusercontent.com/17108460/98309371-eaee2180-1fd2-11eb-997a-8aae540aa30a.png)

I've ran perf tests several times with mostly reproducible results. I have no idea why overriding default arguments (`on_circle_radius_via_native_args` case) makes it faster compared to `on_unit_circle` case in GDScript. Probably because it takes some extra steps to substitute default arguments.

## Conclusion

Replying to @groud in https://github.com/godotengine/godot/pull/43103#issuecomment-717276143:

> Simply allow generating a random unit vector then let the user multiply it. That's a simple and efficient API.

The performance difference is mostly negligible, with some cases performing a bit worse when multiplying by scalar in GDScript, and #43103 helps to alleviate this performance cost in GDScript, while also providing a more complete solution (both PRs provide the same *default* behavior as well).

So, the only reason for not merging #43103 is added maintenance cost.

In any case, I personally invite users (and contributors) to try out the functionality behind #43103 in the [Goost](https://github.com/goostengine/goost) module, where these methods are already implemented as `Random2D.direction` as property for generating unit vectors, and `Random2D.point_in_circle()` method to handle it all, along with other useful stuff such as `Random2D.point_in_triangle`, `Random2D.point_in_polygon` etc, which won't likely be implemented in Godot out of the box: goostengine/goost#32.