### PR TITLE
Fix uninitialised variables in the BaseMaterial3D.

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2637,6 +2637,8 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 	orm = p_orm;
 	// Initialize to the same values as the shader
 	shading_mode = SHADING_MODE_PER_PIXEL;
+	transparency = TRANSPARENCY_DISABLED;
+	alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF;
 	set_albedo(Color(1.0, 1.0, 1.0, 1.0));
 	set_specular(0.5);
 	set_roughness(1.0);


### PR DESCRIPTION
Fix uninitialised variables in the BaseMaterial3D, UBSan report:

```
scene/resources/material.cpp:1467:6: runtime error: load of value 3200171710, which is not a valid value for type 'BaseMaterial3D::Transparency'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior scene/resources/material.cpp:1467:6 in

scene/resources/material.cpp:1481:6: runtime error: load of value 3200171710, which is not a valid value for type 'BaseMaterial3D::AlphaAntiAliasing'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior scene/resources/material.cpp:1481:6 in
```