### PR TITLE
Fix completion for built-in load() function

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2315,11 +2315,6 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 
 	if (GDScriptParser::get_builtin_function(call->function_name) < GDScriptFunctions::FUNC_MAX) {
 		MethodInfo info = GDScriptFunctions::get_info(GDScriptParser::get_builtin_function(call->function_name));
-
-		if ((info.name == "load" || info.name == "preload") && bool(EditorSettings::get_singleton()->get("text_editor/completion/complete_file_paths"))) {
-			_get_directory_contents(EditorFileSystem::get_singleton()->get_filesystem(), r_result);
-		}
-
 		r_arghint = _make_arguments_hint(info, p_argidx);
 		return;
 	} else if (GDScriptParser::get_builtin_type(call->function_name) < Variant::VARIANT_MAX) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
![image](https://user-images.githubusercontent.com/25207137/98347092-3d513180-2017-11eb-911f-815920530820.png)
Screenshoot from https://github.com/godotengine/godot/pull/37232 because it solves the same issue in an older version of `master`.
Fixes https://github.com/godotengine/godot/issues/43349
_Edit: Fixes "no argument hint immediately after open a bracket" for built-in functions mentioned in https://github.com/godotengine/godot/issues/40933_