### PR TITLE
Use LONG instead of DWORD (unsigned int) when interacting with DIJOFS constants

### DIFF
--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -194,7 +194,7 @@ void JoypadWindows::setup_joypad_object(const DIDEVICEOBJECTINSTANCE *ob, int p_
 		HRESULT res;
 		DIPROPRANGE prop_range;
 		DIPROPDWORD dilong;
-		DWORD ofs;
+		LONG ofs;
 		if (ob->guidType == GUID_XAxis)
 			ofs = DIJOFS_X;
 		else if (ob->guidType == GUID_YAxis)
@@ -395,7 +395,7 @@ void JoypadWindows::process_joypads() {
 
 		// on mingw, these constants are not constants
 		int count = 8;
-		unsigned int axes[] = { DIJOFS_X, DIJOFS_Y, DIJOFS_Z, DIJOFS_RX, DIJOFS_RY, DIJOFS_RZ, DIJOFS_SLIDER(0), DIJOFS_SLIDER(1) };
+		LONG axes[] = { DIJOFS_X, DIJOFS_Y, DIJOFS_Z, DIJOFS_RX, DIJOFS_RY, DIJOFS_RZ, (LONG)DIJOFS_SLIDER(0), (LONG)DIJOFS_SLIDER(1) };
 		int values[] = { js.lX, js.lY, js.lZ, js.lRx, js.lRy, js.lRz, js.rglSlider[0], js.rglSlider[1] };
 
 		for (int j = 0; j < joy->joy_axis.size(); j++) {

--- a/platform/windows/joypad_windows.h
+++ b/platform/windows/joypad_windows.h
@@ -77,7 +77,7 @@ private:
 		DWORD last_pad;
 
 		LPDIRECTINPUTDEVICE8 di_joy;
-		List<DWORD> joy_axis;
+		List<LONG> joy_axis;
 		GUID guid;
 
 		dinput_gamepad() {


### PR DESCRIPTION
Currently, Godot is incorrectly using `DWORD`s or unsigned ints instead of `LONG`s when referencing the DirectInput Device Constants `DIJOFS*` constants, which are are actually macros that extract the values from the `DIJOYSTATE` `struct`, where they are [defined ](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ee416627(v=vs.85)) as LONGs.

Note: The `DIJOFS_SLIDER` values need to be cast to `LONG`, because there is a bug in the macro in the `dinput.h` header for extracting the `DIJOFS_SLIDER` values:
```
#define DIJOFS_SLIDER(n)	(FIELD_OFFSET(DIJOYSTATE, rglSlider) + \
                                                        (n) * sizeof(LONG))
```
The macro returns values of type `size_t` (typedefed to `long long unsigned`) instead of `LONG` (typedefed to `long`), because of the implicit cast to `long long unsigned` when adding the array offset.

Fixes #43352.