### PR TITLE
Register methods for drawing 3D editor overlays

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -292,6 +292,56 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="forward_spatial_draw_over_viewport" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="overlay" type="Control">
+			</argument>
+			<description>
+				Called by the engine when the 3D editor's viewport is updated. Use the [code]overlay[/code] [Control] for drawing. You can update the viewport manually by calling [method update_overlays].
+				[codeblocks]
+				[gdscript]
+				func forward_spatial_draw_over_viewport(overlay):
+				    # Draw a circle at cursor position.
+				    overlay.draw_circle(overlay.get_local_mouse_position(), 64)
+
+				func forward_spatial_gui_input(camera, event):
+				    if event is InputEventMouseMotion:
+				        # Redraw viewport when cursor is moved.
+				        update_overlays()
+				        return true
+				    return false
+				[/gdscript]
+				[csharp]
+				public override void ForwardSpatialDrawOverViewport(Godot.Control overlay)
+				{
+				    // Draw a circle at cursor position.
+				    overlay.DrawCircle(overlay.GetLocalMousePosition(), 64, Colors.White);
+				}
+
+				public override bool ForwardSpatialGuiInput(Godot.Camera3D camera, InputEvent @event)
+				{
+				    if (@event is InputEventMouseMotion)
+				    {
+				        // Redraw viewport when cursor is moved.
+				        UpdateOverlays();
+				        return true;
+				    }
+				    return false;
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
+		<method name="forward_spatial_force_draw_over_viewport" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="overlay" type="Control">
+			</argument>
+			<description>
+				This method is the same as [method forward_spatial_draw_over_viewport], except it draws on top of everything. Useful when you need an extra layer that shows over anything else.
+				You need to enable calling of this method by using [method set_force_draw_over_forwarding_enabled].
+			</description>
+		</method>
 		<method name="forward_spatial_gui_input" qualifiers="virtual">
 			<return type="bool">
 			</return>
@@ -584,7 +634,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Enables calling of [method forward_canvas_force_draw_over_viewport] when the 2D editor's viewport is updated. You need to call this method only once and it will work permanently for this plugin.
+				Enables calling of [method forward_canvas_force_draw_over_viewport] for the 2D editor and [method forward_spatial_force_draw_over_viewport] for the 3D editor when their viewports are updated. You need to call this method only once and it will work permanently for this plugin.
 			</description>
 		</method>
 		<method name="set_input_event_forwarding_always_enabled">
@@ -616,7 +666,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Updates the overlays of the 2D and 3D editor viewport. Causes [method forward_canvas_draw_over_viewport] and [method forward_canvas_force_draw_over_viewport] to be called.
+				Updates the overlays of the 2D and 3D editor viewport. Causes methods [method forward_canvas_draw_over_viewport], [method forward_canvas_force_draw_over_viewport], [method forward_spatial_draw_over_viewport] and [method forward_spatial_force_draw_over_viewport] to be called.
 			</description>
 		</method>
 	</methods>

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -866,6 +866,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_canvas_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_canvas_force_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "forward_spatial_gui_input", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Camera3D"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_spatial_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo("forward_spatial_force_draw_over_viewport", PropertyInfo(Variant::OBJECT, "overlay", PROPERTY_HINT_RESOURCE_TYPE, "Control")));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::STRING, "get_plugin_name"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "get_plugin_icon"));
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "has_main_screen"));


### PR DESCRIPTION
Follow-up/depends on #43356
I noticed that 3D editor has similar methods and they are called by the EditorPlugin, but they were never registered in the API, so they didn't appear in the documentation.