### PR TITLE
[HTML5] Fix audio buffer size and latency hint.

### DIFF
--- a/platform/javascript/audio_driver_javascript.cpp
+++ b/platform/javascript/audio_driver_javascript.cpp
@@ -100,7 +100,7 @@ Error AudioDriverJavaScript::init() {
 	int latency = GLOBAL_GET("audio/output_latency");
 
 	channel_count = godot_audio_init(mix_rate, latency);
-	buffer_length = closest_power_of_2((latency * mix_rate / 1000) * channel_count);
+	buffer_length = closest_power_of_2(latency * mix_rate / 1000);
 	buffer_length = godot_audio_create_processor(buffer_length, channel_count);
 	if (!buffer_length) {
 		return FAILED;

--- a/platform/javascript/native/library_godot_audio.js
+++ b/platform/javascript/native/library_godot_audio.js
@@ -47,7 +47,7 @@ var GodotAudio = {
 	godot_audio_init: function(mix_rate, latency) {
 		GodotAudio.ctx = new (window.AudioContext || window.webkitAudioContext)({
 			sampleRate: mix_rate,
-			latencyHint: latency
+			// latencyHint: latency / 1000 // Do not specify, leave 'interactive' for good performance.
 		});
 		return GodotAudio.ctx.destination.channelCount;
 	},


### PR DESCRIPTION
The size of the audio buffer was incorrectly doubled when creating the script processor.
`latencyHint` is expressed in seconds, not milliseconds.
Additionally, on some browsers it actually affect the performance and stability of the audio driver.
For this reason it has been completely disabled (interactive) and a not has been left for future reference.

Fixes: #43210