### PR TITLE
Allow using SVG images as project icon

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1608,7 +1608,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	GLOBAL_DEF("application/config/icon", String());
 	ProjectSettings::get_singleton()->set_custom_property_info("application/config/icon",
 			PropertyInfo(Variant::STRING, "application/config/icon",
-					PROPERTY_HINT_FILE, "*.png,*.webp"));
+					PROPERTY_HINT_FILE, "*.png,*.webp,*.svg,*.svgz"));
 
 	GLOBAL_DEF("application/config/macos_native_icon", String());
 	ProjectSettings::get_singleton()->set_custom_property_info("application/config/macos_native_icon",


### PR DESCRIPTION
Since exporters will save their own icon, the target platforms don't have to support SVG to display the icon correctly.

In the future, we could consider supporting SVG favicons in the HTML5 export ([whose support is quite good](https://caniuse.com/link-icon-svg)). This would require two things:

- If the project icon is in SVG format, modify the [loading logic](https://github.com/Calinou/godot/blob/0f9432f0609d1e6b64a4038047777c3c108bc047/platform/javascript/export/export.cpp#L500-L518) to copy the SVG icon from the project as `favicon.svg` and reference it in the HTML.
- When a SVG project icon is used, ignore requests to change the project icon from Godot itself, as it can only set a rasterized version of the icon. Perhaps this should be placed behind a project setting.

This closes #23068.

## Preview

![image](https://user-images.githubusercontent.com/180032/98419385-3f51d980-2085-11eb-8a94-2702b6fa4332.png)