### PR TITLE
Minor clamp and float fixes

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -251,7 +251,7 @@ Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, real_t
 
 	real_t dot = v1.dot(v2);
 
-	dot = (dot < -1.0) ? -1.0 : ((dot > 1.0) ? 1.0 : dot); //clamp dot to [-1,1]
+	dot = CLAMP(dot, -1.0, 1.0);
 
 	Vector2 v;
 

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -285,7 +285,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 				int64_t i = *p_args[0];
 				r_ret = i < 0 ? -1 : (i > 0 ? +1 : 0);
 			} else if (p_args[0]->get_type() == Variant::FLOAT) {
-				real_t r = *p_args[0];
+				double r = *p_args[0];
 				r_ret = r < 0.0 ? -1.0 : (r > 0.0 ? +1.0 : 0.0);
 			} else {
 				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
@@ -510,8 +510,8 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 				VALIDATE_ARG_NUM(0);
 				VALIDATE_ARG_NUM(1);
 
-				real_t a = *p_args[0];
-				real_t b = *p_args[1];
+				double a = *p_args[0];
+				double b = *p_args[1];
 
 				r_ret = MAX(a, b);
 			}
@@ -527,8 +527,8 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 				VALIDATE_ARG_NUM(0);
 				VALIDATE_ARG_NUM(1);
 
-				real_t a = *p_args[0];
-				real_t b = *p_args[1];
+				double a = *p_args[0];
+				double b = *p_args[1];
 
 				r_ret = MIN(a, b);
 			}
@@ -545,9 +545,9 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 				VALIDATE_ARG_NUM(1);
 				VALIDATE_ARG_NUM(2);
 
-				real_t a = *p_args[0];
-				real_t b = *p_args[1];
-				real_t c = *p_args[2];
+				double a = *p_args[0];
+				double b = *p_args[1];
+				double c = *p_args[2];
 
 				r_ret = CLAMP(a, b, c);
 			}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -221,8 +221,7 @@ namespace Godot
 
             real_t dot = v1.Dot(v2);
 
-            // Clamp dot to [-1, 1]
-            dot = dot < -1.0f ? -1.0f : (dot > 1.0f ? 1.0f : dot);
+            dot = Mathf.Clamp(dot, -1.0f, 1.0f);
 
             Vector2 v;
 


### PR DESCRIPTION
* Use CLAMP macro instead of manually writing it out in Transform2D interpolate code.

* Floats are always 64-bit in GDScript when they're not in a data structure, so we should use `double` to avoid losing precision. Otherwise we end up with `print(clamp(2000.001, 1000, 3000))` outputting `2000.000977` instead of `2000.001`.

There are conflicts when cherry-picking this, so here is a 3.2 version: https://github.com/aaronfranke/godot/tree/3.2-clamp-fixes