### PR TITLE
FBX Fix roughness and material properties not loading

### DIFF
--- a/modules/fbx/data/fbx_material.h
+++ b/modules/fbx/data/fbx_material.h
@@ -38,7 +38,7 @@
 
 struct FBXMaterial : public Reference {
 	String material_name = String();
-	mutable const FBXDocParser::Material *material = nullptr;
+	FBXDocParser::Material *material = nullptr;
 
 	/* Godot materials
 	 *** Texture Maps:
@@ -67,6 +67,48 @@ struct FBXMaterial : public Reference {
 		AmbientOcclusionM,
 		RefractionM,
 		ReflectionM,
+	};
+
+	/* Returns the string representation of the TextureParam enum */
+	static String get_texture_param_name(SpatialMaterial::TextureParam param) {
+		switch (param) {
+			case SpatialMaterial::TEXTURE_ALBEDO:
+				return "TEXTURE_ALBEDO";
+			case SpatialMaterial::TEXTURE_METALLIC:
+				return "TEXTURE_METALLIC";
+			case SpatialMaterial::TEXTURE_ROUGHNESS:
+				return "TEXTURE_ROUGHNESS";
+			case SpatialMaterial::TEXTURE_EMISSION:
+				return "TEXTURE_EMISSION";
+			case SpatialMaterial::TEXTURE_NORMAL:
+				return "TEXTURE_NORMAL";
+			case SpatialMaterial::TEXTURE_RIM:
+				return "TEXTURE_RIM";
+			case SpatialMaterial::TEXTURE_CLEARCOAT:
+				return "TEXTURE_CLEARCOAT";
+			case SpatialMaterial::TEXTURE_FLOWMAP:
+				return "TEXTURE_FLOWMAP";
+			case SpatialMaterial::TEXTURE_AMBIENT_OCCLUSION:
+				return "TEXTURE_AMBIENT_OCCLUSION";
+			case SpatialMaterial::TEXTURE_DEPTH:
+				return "TEXTURE_DEPTH";
+			case SpatialMaterial::TEXTURE_SUBSURFACE_SCATTERING:
+				return "TEXTURE_SUBSURFACE_SCATTERING";
+			case SpatialMaterial::TEXTURE_TRANSMISSION:
+				return "TEXTURE_TRANSMISSION";
+			case SpatialMaterial::TEXTURE_REFRACTION:
+				return "TEXTURE_REFRACTION";
+			case SpatialMaterial::TEXTURE_DETAIL_MASK:
+				return "TEXTURE_DETAIL_MASK";
+			case SpatialMaterial::TEXTURE_DETAIL_ALBEDO:
+				return "TEXTURE_DETAIL_ALBEDO";
+			case SpatialMaterial::TEXTURE_DETAIL_NORMAL:
+				return "TEXTURE_DETAIL_NORMAL";
+			case SpatialMaterial::TEXTURE_MAX:
+				return "TEXTURE_MAX";
+			default:
+				return "broken horribly";
+		}
 	};
 
 	// TODO make this static?
@@ -105,29 +147,33 @@ struct FBXMaterial : public Reference {
 		{ "Maya|specularColor", SpatialMaterial::TextureParam::TEXTURE_METALLIC },
 		{ "Maya|SpecularTexture", SpatialMaterial::TextureParam::TEXTURE_METALLIC },
 		{ "Maya|SpecularTexture|file", SpatialMaterial::TextureParam::TEXTURE_METALLIC },
-		{ "ShininessExponent", SpatialMaterial::TextureParam::TEXTURE_METALLIC },
+
 		/* Roughness */
-		{ "Maya|diffuseRoughness", SpatialMaterial::TextureParam::TEXTURE_ROUGHNESS },
-		{ "Maya|diffuseRoughness|file", SpatialMaterial::TextureParam::TEXTURE_ROUGHNESS },
+
 		{ "3dsMax|Parameters|roughness_map", SpatialMaterial::TextureParam::TEXTURE_ROUGHNESS },
 		{ "Maya|TEX_roughness_map", SpatialMaterial::TextureParam::TEXTURE_ROUGHNESS },
 		{ "Maya|TEX_roughness_map|file", SpatialMaterial::TextureParam::TEXTURE_ROUGHNESS },
-		{ "ReflectionFactor", SpatialMaterial::TextureParam::TEXTURE_ROUGHNESS },
-		{ "Maya|specularRoughness", SpatialMaterial::TextureParam::TEXTURE_ROUGHNESS },
+
 		/* Normal */
 		{ "NormalMap", SpatialMaterial::TextureParam::TEXTURE_NORMAL },
-		{ "Bump", SpatialMaterial::TextureParam::TEXTURE_NORMAL },
-		{ "3dsMax|Parameters|bump_map", SpatialMaterial::TextureParam::TEXTURE_NORMAL },
+		//{ "Bump", SpatialMaterial::TextureParam::TEXTURE_NORMAL },
+		//{ "3dsMax|Parameters|bump_map", SpatialMaterial::TextureParam::TEXTURE_NORMAL },
 		{ "Maya|NormalTexture", SpatialMaterial::TextureParam::TEXTURE_NORMAL },
-		{ "Maya|normalCamera", SpatialMaterial::TextureParam::TEXTURE_NORMAL },
-		{ "Maya|normalCamera|file", SpatialMaterial::TextureParam::TEXTURE_NORMAL },
+		//{ "Maya|normalCamera", SpatialMaterial::TextureParam::TEXTURE_NORMAL },
+		//{ "Maya|normalCamera|file", SpatialMaterial::TextureParam::TEXTURE_NORMAL },
 		{ "Maya|TEX_normal_map", SpatialMaterial::TextureParam::TEXTURE_NORMAL },
 		{ "Maya|TEX_normal_map|file", SpatialMaterial::TextureParam::TEXTURE_NORMAL },
 		/* AO */
 		{ "Maya|TEX_ao_map", SpatialMaterial::TextureParam::TEXTURE_AMBIENT_OCCLUSION },
 		{ "Maya|TEX_ao_map|file", SpatialMaterial::TextureParam::TEXTURE_AMBIENT_OCCLUSION },
-		//	{"TransparentColor",SpatialMaterial::TextureParam::TEXTURE_CHANNEL_ALPHA },
-		//	{"TransparencyFactor",SpatialMaterial::TextureParam::TEXTURE_CHANNEL_ALPHA }
+
+		//{ "Maya|diffuseRoughness", SpatialMaterial::TextureParam::UNSUPPORTED },
+		//{ "Maya|diffuseRoughness|file", SpatialMaterial::TextureParam::UNSUPPORTED },
+		//{ "Maya|specularRoughness", SpatialMaterial::TextureParam::UNSUPPORTED },
+		//{ "ShininessExponent", SpatialMaterial::TextureParam::UNSUPPORTED },
+		//{ "ReflectionFactor", SpatialMaterial::TextureParam::UNSUPPORTED },
+		//{ "TransparentColor",SpatialMaterial::TextureParam::TEXTURE_CHANNEL_ALPHA },
+		//{ "TransparencyFactor",SpatialMaterial::TextureParam::TEXTURE_CHANNEL_ALPHA }
 	};
 
 	// TODO make this static?
@@ -137,6 +183,10 @@ struct FBXMaterial : public Reference {
 		PROPERTY_DESC_TRANSPARENT,
 		PROPERTY_DESC_METALLIC,
 		PROPERTY_DESC_ROUGHNESS,
+		PROPERTY_DESC_SPECULAR,
+		PROPERTY_DESC_SPECULAR_COLOR,
+		PROPERTY_DESC_SPECULAR_ROUGHNESS,
+		PROPERTY_DESC_SHINYNESS,
 		PROPERTY_DESC_COAT,
 		PROPERTY_DESC_COAT_ROUGHNESS,
 		PROPERTY_DESC_EMISSIVE,
@@ -149,6 +199,13 @@ struct FBXMaterial : public Reference {
 		{ "DiffuseColor", PROPERTY_DESC_ALBEDO_COLOR },
 		{ "Maya|baseColor", PROPERTY_DESC_ALBEDO_COLOR },
 
+		/* Specular */
+		{ "Maya|specular", PROPERTY_DESC_SPECULAR },
+		{ "Maya|specularColor", PROPERTY_DESC_SPECULAR_COLOR },
+
+		/* Specular roughness */
+		{ "Maya|specularRoughness", PROPERTY_DESC_SPECULAR_ROUGHNESS },
+
 		/* Transparent */
 		{ "Opacity", PROPERTY_DESC_TRANSPARENT },
 		{ "TransparencyFactor", PROPERTY_DESC_TRANSPARENT },
@@ -158,9 +215,10 @@ struct FBXMaterial : public Reference {
 		{ "Shininess", PROPERTY_DESC_METALLIC },
 		{ "Reflectivity", PROPERTY_DESC_METALLIC },
 		{ "Maya|metalness", PROPERTY_DESC_METALLIC },
+		{ "Maya|metallic", PROPERTY_DESC_METALLIC },
 
 		/* Roughness */
-		{ "Maya|diffuseRoughness", PROPERTY_DESC_ROUGHNESS },
+		{ "Maya|roughness", PROPERTY_DESC_ROUGHNESS },
 
 		/* Coat */
 		{ "Maya|coat", PROPERTY_DESC_COAT },
@@ -170,14 +228,16 @@ struct FBXMaterial : public Reference {
 
 		/* Emissive */
 		{ "Maya|emission", PROPERTY_DESC_EMISSIVE },
+		{ "Maya|emissive", PROPERTY_DESC_EMISSIVE },
 
 		/* Emissive color */
 		{ "EmissiveColor", PROPERTY_DESC_EMISSIVE_COLOR },
 		{ "Maya|emissionColor", PROPERTY_DESC_EMISSIVE_COLOR },
 
 		/* Ignore */
+		{ "Maya|diffuseRoughness", PROPERTY_DESC_IGNORE },
 		{ "Maya", PROPERTY_DESC_IGNORE },
-		{ "Diffuse", PROPERTY_DESC_IGNORE },
+		{ "Diffuse", PROPERTY_DESC_ALBEDO_COLOR },
 		{ "Maya|TypeId", PROPERTY_DESC_IGNORE },
 		{ "Ambient", PROPERTY_DESC_IGNORE },
 		{ "AmbientColor", PROPERTY_DESC_IGNORE },
@@ -218,7 +278,7 @@ struct FBXMaterial : public Reference {
 
 	String get_material_name() const;
 
-	void set_imported_material(const FBXDocParser::Material *p_material);
+	void set_imported_material(FBXDocParser::Material *p_material);
 
 	struct MaterialInfo {
 		Vector<TextureFileMapping> textures;

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -505,7 +505,7 @@ Spatial *EditorSceneImporterFBX::_generate_scene(
 		for (uint64_t material_id : materials) {
 
 			FBXDocParser::LazyObject *lazy_material = p_document->GetObject(material_id);
-			const FBXDocParser::Material *mat = lazy_material->Get<FBXDocParser::Material>();
+			FBXDocParser::Material *mat = (FBXDocParser::Material *)lazy_material->Get<FBXDocParser::Material>();
 			ERR_CONTINUE_MSG(!mat, "Could not convert fbx material by id: " + itos(material_id));
 
 			Ref<FBXMaterial> material;

--- a/modules/fbx/fbx_parser/FBXDocument.h
+++ b/modules/fbx/fbx_parser/FBXDocument.h
@@ -644,6 +644,10 @@ public:
 		return type;
 	}
 
+	bool IsEmbedded() const {
+		return contentLength > 0;
+	}
+
 	const std::string &FileName() const {
 		return fileName;
 	}

--- a/modules/fbx/fbx_parser/FBXMaterial.cpp
+++ b/modules/fbx/fbx_parser/FBXMaterial.cpp
@@ -109,9 +109,11 @@ Material::Material(uint64_t id, const ElementPtr element, const Document &doc, c
 	std::string templateName;
 
 	if (shading == "phong") {
-		templateName = "Material.FbxSurfacePhong";
+		templateName = "Material.Phong";
 	} else if (shading == "lambert") {
-		templateName = "Material.FbxSurfaceLambert";
+		templateName = "Material.Lambert";
+	} else if (shading == "unknown") {
+		templateName = "Material.StingRay";
 	} else {
 		DOMWarning("shading mode not recognized: " + shading, element);
 	}

--- a/modules/fbx/fbx_parser/FBXProperties.cpp
+++ b/modules/fbx/fbx_parser/FBXProperties.cpp
@@ -124,7 +124,7 @@ PropertyPtr ReadTypedProperty(const ElementPtr element) {
 				ParseTokenAsFloat(tok[4]),
 				ParseTokenAsFloat(tok[5]),
 				ParseTokenAsFloat(tok[6])));
-	} else if (!strcmp(cs, "double") || !strcmp(cs, "Number") || !strcmp(cs, "Float") || !strcmp(cs, "FieldOfView") || !strcmp(cs, "UnitScaleFactor")) {
+	} else if (!strcmp(cs, "double") || !strcmp(cs, "Number") || !strcmp(cs, "Float") || !strcmp(cs, "float") || !strcmp(cs, "FieldOfView") || !strcmp(cs, "UnitScaleFactor")) {
 		return new TypedProperty<float>(ParseTokenAsFloat(tok[4]));
 	}
 
@@ -168,10 +168,18 @@ PropertyTable::PropertyTable(const ElementPtr element, const PropertyTable *temp
 		}
 
 		LazyPropertyMap::const_iterator it = lazyProps.find(name);
+
 		if (it != lazyProps.end()) {
 			DOMWarning("duplicate property name, will hide previous value: " + name, v.second);
 			continue;
 		}
+
+		if (it->second == nullptr) {
+			print_error("skipped invalid element insertion for " + String(name.c_str()));
+			continue;
+		}
+
+		//print_verbose("storing lazy property: " + String(name.c_str()));
 
 		// since the above checks for duplicates we can be sure to insert the only match here.
 		lazyProps[name] = v.second;
@@ -187,28 +195,26 @@ PropertyTable::~PropertyTable() {
 
 // ------------------------------------------------------------------------------------------------
 PropertyPtr PropertyTable::Get(const std::string &name) const {
-	PropertyMap::const_iterator it = props.find(name);
-	if (it == props.end()) {
-		// hasn't been parsed yet?
-		LazyPropertyMap::const_iterator lit = lazyProps.find(name);
-		if (lit != lazyProps.end()) {
-			props[name] = ReadTypedProperty(lit->second);
-			it = props.find(name);
 
-			//ai_assert(it != props.end());
-		}
-
-		if (it == props.end()) {
-			// check property template
-			if (templateProps) {
-				return templateProps->Get(name);
-			}
-
-			return nullptr;
-		}
+	// check if loaded already - return it.
+	PropertyMap::const_iterator loaded_property_element = props.find(name);
+	if (loaded_property_element != props.end()) {
+		//print_verbose("Returning conversion for lazy property: " + String(loaded_property_element->first.c_str()));
+		return loaded_property_element->second;
 	}
 
-	return (*it).second;
+	// now load it since we don't have a match
+	LazyPropertyMap::const_iterator unloadedProperty = lazyProps.find(name);
+	if (unloadedProperty != lazyProps.end()) {
+		PropertyPtr loaded_property = ReadTypedProperty(unloadedProperty->second);
+		ERR_FAIL_COND_V_MSG(!loaded_property, nullptr, "[fbx][serious] unable to load typed property");
+
+		//print_verbose("loaded property successfully: " + String(name.c_str()));
+		props.insert(std::make_pair(name, loaded_property));
+		return loaded_property;
+	}
+
+	return nullptr;
 }
 
 DirectPropertyMap PropertyTable::GetUnparsedProperties() const {


### PR DESCRIPTION
Resolves a lot of regressions in the material handling and makes it much more explicit when there is a real problem rather than something which is mapped in a texture rather than a property. Previously the behaviour was that we'd print all unfound material mappings but now it checks that they don't have a texture mapping first. 

The errors remain for some fields which aren't supported which we do need to add but removes errors for when you don't want to see them when it's not a real error.

This is primarily to support the roughness / PBR model from Maya using Stingray Materials.

**Explicitly fixes:**
- adds roughness supported from Stingray Materials the only PBR workflow in Maya, outside of baking for Arnold.
- resolves problems with typed properties not loading
- resolves incorrect shininess and reflection factor breaking materials
- fixes embedded materials being loaded when they aren't actually embedded in the file.
- errors regarding materials had zero context and made little sense, now you can trace your material mapping from start to finish on import to putting it into the Godot scene.

**TODO:**

~~- make lazy properties stay loaded in memory~~ done

But Hoooray. :partying_face:  :fireworks: 
