### PR TITLE
Add a script to install Linux/*BSD dependencies for building

### DIFF
--- a/misc/scripts/install_linuxbsd_deps.sh
+++ b/misc/scripts/install_linuxbsd_deps.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env sh
+set -eu
+IFS=$(printf '\n\t')
+
+print_info() {
+	printf "\e[1m%b\e[0m\n" "$1"
+}
+
+print_success() {
+	printf "\e[1;92m%b\e[0m\n" "$1"
+}
+
+print_error() {
+	printf "\e[1;91mERROR: \e[22m%b\e[0m\n" "$1"
+}
+
+# The detection below also covers derivatives such as Linux Mint and Manjaro.
+if [ -f "/etc/alpine-release" ]; then
+	distribution="alpine"
+	distribution_name="\e[94mAlpine"
+elif [ -f "/etc/arch-release" ]; then
+	distribution="arch"
+	distribution_name="\e[96mArch Linux"
+elif [ -f "/etc/fedora-release" ]; then
+	distribution="fedora"
+	distribution_name="\e[94mFedora"
+elif [ -f "/etc/gentoo-release" ]; then
+	distribution="gentoo"
+	distribution_name="\e[95mGentoo"
+elif [ -f "/etc/mageia-release" ]; then
+	distribution="mageia"
+	distribution_name="\e[94mMageia"
+elif grep -q openSUSE /etc/os-release; then
+	distribution="opensuse"
+	distribution_name="\e[92mopenSUSE"
+elif [ -f "/etc/solus-release" ]; then
+	distribution="solus"
+	distribution_name="\e[96mSolus"
+elif [ -f "/etc/lsb-release" ]; then
+	# Check for lsb-release last as distributions like Mageia also have this file.
+	# Ubuntu must be checked before checking for Debian as Ubuntu also has `/etc/debian_version`.
+	distribution="ubuntu"
+	distribution_name="\e[38;5;208mUbuntu"
+elif [ -f "/etc/debian_version" ]; then
+	distribution="debian"
+	distribution_name="\e[91mDebian"
+elif [ "$(uname -s)" = "FreeBSD" ]; then
+	distribution="freebsd"
+	distribution_name="\e[91mFreeBSD"
+elif [ "$(uname -s)" = "OpenBSD" ]; then
+	distribution="openbsd"
+	distribution_name="\e[93mOpenBSD"
+elif [ "$(uname -s)" = "NetBSD" ]; then
+	distribution="netbsd"
+	distribution_name="\e[38;5;208mNetBSD"
+else
+	print_error "Couldn't detect your Linux/*BSD distribution. No dependencies have been installed.\n       You'll have to install dependencies manually using your distribution's package manager:\n\n       https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_linuxbsd.html"
+	exit 1
+fi
+
+print_info "Detected Linux/*BSD distribution: $distribution_name"
+
+if [ -n "$(command -v sudo)" ]; then
+	# Use `sudo` when needed.
+	sudo="sudo"
+	print_info "Installing dependencies with sudo... (you may be prompted for your password)"
+else
+	# Don't use `sudo`.
+	sudo=""
+	print_info "Installing dependencies..."
+fi
+
+case "$distribution" in
+alpine)
+	$sudo apk add \
+		scons \
+		pkgconf \
+		gcc \
+		g++ \
+		libx11-dev \
+		libxcursor-dev \
+		libxinerama-dev \
+		libxi-dev \
+		libxrandr-dev \
+		mesa-dev \
+		eudev-dev \
+		alsa-lib-dev \
+		pulseaudio-dev
+	;;
+arch)
+	$sudo pacman -Sy --noconfirm --needed \
+		scons \
+		pkgconf \
+		gcc \
+		libxcursor \
+		libxinerama \
+		libxi \
+		libxrandr \
+		wayland-utils \
+		mesa \
+		glu \
+		libglvnd \
+		alsa-lib \
+		pulseaudio
+	;;
+debian | ubuntu)
+	export DEBIAN_FRONTEND="noninteractive"
+	$sudo apt-get update
+	$sudo apt-get install -y \
+		build-essential \
+		scons \
+		pkg-config \
+		libx11-dev \
+		libxcursor-dev \
+		libxinerama-dev \
+		libgl1-mesa-dev \
+		libglu1-mesa-dev \
+		libasound2-dev \
+		libpulse-dev \
+		libudev-dev \
+		libxi-dev \
+		libxrandr-dev \
+		libwayland-dev
+	;;
+fedora)
+	$sudo dnf install -y \
+		scons \
+		pkgconfig \
+		gcc-c++ \
+		libstdc++-static \
+		wayland-devel
+	;;
+freebsd)
+	$sudo pkg install \
+		py37-scons \
+		pkgconf \
+		xorg-libraries \
+		libXcursor \
+		libXrandr \
+		libXi \
+		xorgproto \
+		libGLU \
+		alsa-lib \
+		pulseaudio
+	;;
+gentoo)
+	$sudo emerge -an \
+		dev-build/scons \
+		x11-libs/libX11 \
+		x11-libs/libXcursor \
+		x11-libs/libXinerama \
+		x11-libs/libXi \
+		dev-util/wayland-scanner \
+		media-libs/mesa \
+		media-libs/glu \
+		media-libs/alsa-lib \
+		media-sound/pulseaudio
+	;;
+mageia)
+	$sudo urpmi --auto \
+		scons \
+		task-c++-devel \
+		wayland-devel \
+		"pkgconfig(alsa)" \
+		"pkgconfig(glu)" \
+		"pkgconfig(libpulse)" \
+		"pkgconfig(udev)" \
+		"pkgconfig(x11)" \
+		"pkgconfig(xcursor)" \
+		"pkgconfig(xinerama)" \
+		"pkgconfig(xi)" \
+		"pkgconfig(xrandr)"
+	;;
+netbsd)
+	$sudo pkg_add \
+		pkg-config \
+		py37-scons
+	;;
+openbsd)
+	$sudo pkg_add \
+		python \
+		scons \
+		llvm
+	;;
+opensuse)
+	$sudo zypper install -y \
+		scons \
+		pkgconfig \
+		libX11-devel \
+		libXcursor-devel \
+		libXrandr-devel \
+		libXinerama-devel \
+		libXi-devel \
+		wayland-devel \
+		Mesa-libGL-devel \
+		alsa-devel \
+		libpulse-devel \
+		libudev-devel \
+		gcc-c++ \
+		libGLU1
+	;;
+solus)
+	$sudo eopkg install -y \
+		-c system.devel \
+		scons \
+		libxcursor-devel \
+		libxinerama-devel \
+		libxi-devel \
+		libxrandr-devel \
+		wayland-devel \
+		mesalib-devel \
+		libglu \
+		alsa-lib-devel \
+		pulseaudio-devel
+	;;
+esac
+
+# shellcheck disable=SC2016
+print_success 'Dependencies successfully installed! You can now build Godot using the `scons` command.'


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-proposals/issues/1614.

The list of commands is taken from [Compiling for Linux/*BSD](https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_linuxbsd.html), but with Wayland packages added and unattended CLI arguments (such as `-y`) added.

For Alpine, `libexecinfo-dev` has been removed from the package list due to https://github.com/DataDog/dd-trace-php/issues/1824. See also https://github.com/godotengine/godot/pull/91817.

https://github.com/godotengine/godot-docs/pull/9357 updates the commands in the documentation to be a perfect match for the ones in this script.

Command to test on a fresh system:

```bash
# Install `curl` using the distribution's package manager, then run:
curl -LO https://github.com/Calinou/godot/archive/add-linux-dependencies-install-script.tar.gz && tar xf add-linux-dependencies-install-script.tar.gz && cd godot-add-linux-dependencies-install-script && misc/scripts/install_linuxbsd_deps.sh && scons
# (triple-click to select the whole line)
```

*All systems listed below are fresh Docker containers.*

## Successfully tested on

- Alpine 3.19.1
  - Script is now written in POSIX sh to work out of the box on Alpine, which doesn't ship with Bash.
- Debian 11 (`oldstable`), 12 (`stable`), 13 (`testing`)
- Fedora 39, 40
- Ubuntu 20.04, 22.04, 24.04
- Arch Linux (May 2024)
- Mageia 9
- openSUSE Leap, Tumbleweed
- Solus 4.5

## Not tested on

**Please test on these platforms if you can!**

- Gentoo
- FreeBSD
- OpenBSD
- NetBSD