### PR TITLE
Fix empty and invisible CSG shapes.

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -146,7 +146,13 @@ CSGBrush *CSGShape3D::_get_brush() {
 		if (brush) {
 			memdelete(brush);
 		}
+
 		brush = nullptr;
+
+		if (!is_visible_in_tree()) {
+			dirty = false;
+			return brush;
+		}
 
 		CSGBrush *n = _build_brush();
 
@@ -279,7 +285,14 @@ void CSGShape3D::_update_shape() {
 	root_mesh.unref(); //byebye root mesh
 
 	CSGBrush *n = _get_brush();
-	ERR_FAIL_COND_MSG(!n, "Cannot get CSGBrush.");
+
+	if (!n || n->faces.size() == 0) { // Empty mesh.
+		if (root_collision_shape.is_valid()) {
+			PhysicsServer3D::get_singleton()->body_remove_shape(root_collision_instance, 0);
+			root_collision_shape.unref();
+		}
+		return;
+	}
 
 	OAHashMap<Vector3, Vector3> vec_map;
 
@@ -337,7 +350,12 @@ void CSGShape3D::_update_shape() {
 	}
 
 	// Update collision faces.
-	if (root_collision_shape.is_valid()) {
+	if (use_collision) {
+		if (!root_collision_shape.is_valid()) {
+			root_collision_shape.instance();
+			PhysicsServer3D::get_singleton()->body_add_shape(root_collision_instance, root_collision_shape->get_rid());
+		}
+
 		Vector<Vector3> physics_faces;
 		physics_faces.resize(n->faces.size() * 3);
 		Vector3 *physicsw = physics_faces.ptrw();
@@ -519,9 +537,7 @@ void CSGShape3D::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		if (parent) {
-			parent->_make_dirty();
-		}
+		_make_dirty();
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -83,7 +83,7 @@
 			Snap makes the mesh snap to a given distance so that the faces of two meshes can be perfectly aligned. A lower value results in greater precision but may be harder to adjust.
 		</member>
 		<member name="use_collision" type="bool" setter="set_use_collision" getter="is_using_collision" default="false">
-			Adds a collision shape to the physics engine for our CSG shape. This will always act like a static body. Note that the collision shape is still active even if the CSG shape itself is hidden.
+			Adds a collision shape to the physics engine for our CSG shape. This will always act like a static body.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Currently, there is inconsistency in how CSG shapes create collision shapes when they or their components are invisible or change their visibility:
![CSG323](https://user-images.githubusercontent.com/9253928/98445870-0e6bb600-2112-11eb-8469-c128b2505940.gif)
#40919 significantly improved this, but some inconsistency remains:
![CSG324beta1](https://user-images.githubusercontent.com/9253928/98445913-525ebb00-2112-11eb-990e-a31d000d59ed.gif)
This PR makes the collision shapes consistent with the CSG shape:
![CSG324fixed](https://user-images.githubusercontent.com/9253928/98445960-a10c5500-2112-11eb-8325-d26d022556eb.gif)

Fixes #43251.

For those that are interested, the project used to create the above tests is: [43251.zip](https://github.com/godotengine/godot/files/5505147/43251.zip). It consists of 20 tests: every combination of changing the visibility of a platform or part thereof and a `RigidBody` ball above it to test the `CollisionShape`. 

There are two layers. The top layer creates the shapes with the toggled components visible. The bottom layer creates the shapes with the toggled components invisible. Then the visibility of the CSG shape, or a part of it, is toggled every two seconds.

Each layer has three rows. The front row of each layer has three shapes that consist of a single shape. The second row of each layer has three shapes that consist of double shapes created from two shapes without a `CSGCombiner`. The back row of each layer has four shapes that consist of double shapes created from two shapes inside a `CSGCombiner`.

In the front row, the left two shapes are contained within a `CSGCombiner`; the right one is on its own. The left shape (Test1 and Test11) toggles the visibility of the `CSGCombiner`. The middle shape (Test2 and Test12) toggles the visibility of the shape inside the `CSGCombiner`. The right shape (Test3 and Test13) toggles the visibility of the shape.

In the middle row, the left two shapes toggle the visibility of the parent shape; the right shape toggles the visibility of the child shape. In the left shape (Test4 and Test14) the ball is above the parent shape. In the middle shape (Test5 and Test15) the ball is above the child shape. In the right shape (Test 6 and Test16) the ball is also above the child shape.

In the back row, the left two shapes toggle the visibility of the `CSGCombiner`; the right two shapes toggle the visibility of a child shape. In the left most shape (Test7 and Test17) the ball is above the first child. In the second to left most shape (Test8 and Test18) the ball is above the second child. In the second to right most shape (Test9 and Test19) the ball is above the first child. In the right most shape (Test10 and Test20) the ball is above the second child.

Finally, there was a [discussion](https://github.com/godotengine/godot/issues/43251#issuecomment-721767274) in #43251 about what the right solution was. Two options were floated:
1. Keep one mesh, collisions only happen with visible CSG components i.e. the bug is that invisible individual CSG Shapes are collidable when they shouldn't be.
2. Have separate meshes for the VisualInstance and the CollisionShape. The parameters visible and use_collision could be used to control which CSG components are visible and which are collidable.

This PR implements option 1. However, @hoontee preferred option 2 and created #43322 to implement that approach. I think option 1 is the better solution, because it is more intuitive. Furthermore, if a user has a need for separating the `VisualInstance` and the `CollisionShape`, they can already do this: they literally create two separate meshes and, with one, enable `Use Collision` and remove it from the `VisualInstance` layer. To demonstrate this I've recreated the project presented in [#43322](https://github.com/godotengine/godot/pull/43322#issuecomment-722075246): [43251a.zip](https://github.com/godotengine/godot/files/5505126/43251a.zip). This approach has the added advantage of not constraining the differences to the components of the CSG shape.
![CSGCombo](https://user-images.githubusercontent.com/9253928/98447120-4ecf3200-211a-11eb-9ae8-4d08c9c4f1f2.gif)