### PR TITLE
GDNative: Define special char types in string.h

### DIFF
--- a/modules/gdnative/include/gdnative/string.h
+++ b/modules/gdnative/include/gdnative/string.h
@@ -35,8 +35,13 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
 #include <stdint.h>
-#include <wchar.h>
+
+#ifndef __cplusplus
+typedef uint32_t char32_t;
+typedef uint16_t char16_t;
+#endif
 
 typedef char32_t godot_char_type;
 


### PR DESCRIPTION
Those are standard types in C++ but not on C.

This also removes the wchar header which is not needed anymore and use stddef.h instead (which is needed for size_t).