### PR TITLE
Add append_array() method to Array class

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -192,6 +192,11 @@ void Array::push_back(const Variant &p_value) {
 	_p->array.push_back(p_value);
 }
 
+void Array::append_array(const Array &p_array) {
+	ERR_FAIL_COND(!_p->typed.validate(p_array, "append_array"));
+	_p->array.append_array(p_array._p->array);
+}
+
 Error Array::resize(int p_new_size) {
 	return _p->array.resize(p_new_size);
 }

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -68,6 +68,7 @@ public:
 
 	void push_back(const Variant &p_value);
 	_FORCE_INLINE_ void append(const Variant &p_value) { push_back(p_value); } //for python compatibility
+	void append_array(const Array &p_array);
 	Error resize(int p_new_size);
 
 	void insert(int p_pos, const Variant &p_value);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1762,6 +1762,7 @@ void register_variant_methods() {
 	bind_method(Array, push_back, sarray("value"), varray());
 	bind_method(Array, push_front, sarray("value"), varray());
 	bind_method(Array, append, sarray("value"), varray());
+	bind_method(Array, append_array, sarray("array"), varray());
 	bind_method(Array, resize, sarray("size"), varray());
 	bind_method(Array, insert, sarray("position", "value"), varray());
 	bind_method(Array, remove, sarray("position"), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -38,6 +38,7 @@
 		GD.Print(array1 + array2); // Prints [One, 2, 3, Four]
 		[/csharp]
 		[/codeblocks]
+		Note that concatenating with [code]+=[/code] operator will create a new array. If you want to append another array to an existing array, [method append_array] is more efficient.
 		[b]Note:[/b] Arrays are always passed by reference. To get a copy of an array which can be modified independently of the original array, use [method duplicate].
 	</description>
 	<tutorials>
@@ -131,6 +132,21 @@
 			</argument>
 			<description>
 				Appends an element at the end of the array (alias of [method push_back]).
+			</description>
+		</method>
+		<method name="append_array">
+			<return type="void">
+			</return>
+			<argument index="0" name="array" type="Array">
+			</argument>
+			<description>
+				Appends another array at the end of this array.
+				[codeblock]
+				var array1 = [1, 2, 3]
+				var array2 = [4, 5, 6]
+				array1.append_array(array2)
+				print(array1) # Prints [1, 2, 3, 4, 5, 6].
+				[/codeblock]
 			</description>
 		</method>
 		<method name="back">


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/1718

Vector class (used internally by Array) already had `append_array` method, so this PR pretty much only exposes it.