### PR TITLE
Update PathFollow2D when curve is changed

### DIFF
--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -34,6 +34,8 @@
 #include "scene/2d/node_2d.h"
 #include "scene/resources/curve.h"
 
+class Timer;
+
 class Path2D : public Node2D {
 	GDCLASS(Path2D, Node2D);
 
@@ -65,6 +67,7 @@ public:
 private:
 	Path2D *path = nullptr;
 	real_t progress = 0.0;
+	Timer *update_timer = nullptr;
 	real_t h_offset = 0.0;
 	real_t v_offset = 0.0;
 	real_t lookahead = 4.0;
@@ -81,6 +84,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	void path_changed();
+
 	void set_progress(real_t p_progress);
 	real_t get_progress() const;
 


### PR DESCRIPTION
Fixes #20386

I added a second commit (separately because I wasn't sure if it's necessary) that makes the update delayed, [as suggested by Calinou](https://github.com/godotengine/godot/issues/20386#issuecomment-538466693) 

Without delay
![5g1UI0eBZu](https://user-images.githubusercontent.com/2223172/98484383-3bea5980-220f-11eb-8cc2-a9438f64cd89.gif)

With delay
![1Z2ttsJmYJ](https://user-images.githubusercontent.com/2223172/98484387-3ee54a00-220f-11eb-9222-2bb20a8023f3.gif)
