### PR TITLE
Update "open-simplex-noise-in-c" to fix undefined signed overflow

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -378,7 +378,7 @@ Collection of single-file libraries used in Godot components.
   * License: Apache 2.0
 - `open-simplex-noise.{c,h}`
   * Upstream: https://github.com/smcameron/open-simplex-noise-in-c
-  * Version: git (0d555e7f40527d0870906fe9469a3b1bb4020b7f, 2015) + custom changes
+  * Version: git (0fef0dbedd76f767da7e3c894822729d0f07e54d, 2020) + custom changes
   * License: Unlicense
 - `pcg.{cpp,h}`
   * Upstream: http://www.pcg-random.org

--- a/thirdparty/misc/open-simplex-noise.c
+++ b/thirdparty/misc/open-simplex-noise.c
@@ -189,14 +189,15 @@ int open_simplex_noise(int64_t seed, struct osn_context *ctx)
 	permGradIndex3D = ctx->permGradIndex3D;
 // -- GODOT end --
 
+	uint64_t seedU = seed;
 	for (i = 0; i < 256; i++)
 		source[i] = (int16_t) i;
-	seed = seed * 6364136223846793005LL + 1442695040888963407LL;
-	seed = seed * 6364136223846793005LL + 1442695040888963407LL;
-	seed = seed * 6364136223846793005LL + 1442695040888963407LL;
+	seedU = seedU * 6364136223846793005ULL + 1442695040888963407ULL;
+	seedU = seedU * 6364136223846793005ULL + 1442695040888963407ULL;
+	seedU = seedU * 6364136223846793005ULL + 1442695040888963407ULL;
 	for (i = 255; i >= 0; i--) {
-		seed = seed * 6364136223846793005LL + 1442695040888963407LL;
-		r = (int)((seed + 31) % (i + 1));
+		seedU = seedU * 6364136223846793005ULL + 1442695040888963407ULL;
+		r = (int)((seedU + 31) % (i + 1));
 		if (r < 0)
 			r += (i + 1);
 		perm[i] = source[r];


### PR DESCRIPTION
Updates "Open simplex noise" library, by backporting https://github.com/smcameron/open-simplex-noise-in-c/commit/0fef0dbedd76f767da7e3c894822729d0f07e54d, all custom changes remain intact. 

Fixes signed integer overflow, UBSan log:
```
thirdparty/misc/open-simplex-noise.c:195:14: runtime error: signed integer overflow: 1442695040888963407 * 6364136223846793005 cannot be represented in type 'long long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior thirdparty/misc/open-simplex-noise.c:195:14 in
thirdparty/misc/open-simplex-noise.c:196:14: runtime error: signed integer overflow: 1876011003808476466 * 6364136223846793005 cannot be represented in type 'long long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior thirdparty/misc/open-simplex-noise.c:196:14 in
thirdparty/misc/open-simplex-noise.c:198:15: runtime error: signed integer overflow: -7280499659394350823 * 6364136223846793005 cannot be represented in type 'long long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior thirdparty/misc/open-simplex-noise.c:198:15 in
thirdparty/misc/open-simplex-noise.c:198:39: runtime error: signed integer overflow: 8903339076496225463 + 1442695040888963407 cannot be represented in type 'long long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior thirdparty/misc/open-simplex-noise.c:198:39 in
thirdparty/misc/open-simplex-noise.c:194:14: runtime error: signed integer overflow: 2 * 6364136223846793005 cannot be represented in type 'long long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior thirdparty/misc/open-simplex-noise.c:194:14 in
thirdparty/misc/open-simplex-noise.c:195:38: runtime error: signed integer overflow: 8665214161362419545 + 1442695040888963407 cannot be represented in type 'long long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior thirdparty/misc/open-simplex-noise.c:195:38 in
thirdparty/misc/open-simplex-noise.c:194:38: runtime error: signed integer overflow: 8301130017339275202 + 1442695040888963407 cannot be represented in type 'long long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior thirdparty/misc/open-simplex-noise.c:194:38 in
```

Fixes #31291