### PR TITLE
CI: Build with warnings=extra to catch 'em all

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=android verbose=yes warnings=all werror=yes --jobs=2
+  SCONSFLAGS: platform=android verbose=yes warnings=extra werror=yes --jobs=2
   SCONS_CACHE_LIMIT: 4096
 
 jobs:

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=iphone verbose=yes warnings=all werror=yes --jobs=2
+  SCONSFLAGS: platform=iphone verbose=yes warnings=extra werror=yes --jobs=2
   SCONS_CACHE_LIMIT: 4096
 
 jobs:

--- a/.github/workflows/javascript_builds.disabled
+++ b/.github/workflows/javascript_builds.disabled
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=javascript verbose=yes warnings=all werror=yes --jobs=2
+  SCONSFLAGS: platform=javascript verbose=yes warnings=extra werror=yes --jobs=2
   SCONS_CACHE_LIMIT: 4096
   EM_VERSION: 1.39.20
   EM_CACHE_FOLDER: 'emsdk-cache'

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=linuxbsd verbose=yes warnings=all werror=yes --jobs=2
+  SCONSFLAGS: platform=linuxbsd verbose=yes warnings=extra werror=yes --jobs=2
   SCONS_CACHE_LIMIT: 4096
 
 jobs:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: master
-  SCONSFLAGS: platform=osx verbose=yes warnings=all werror=yes --jobs=2
+  SCONSFLAGS: platform=osx verbose=yes warnings=extra werror=yes --jobs=2
   SCONS_CACHE_LIMIT: 4096
 
 jobs:


### PR DESCRIPTION
... on all platforms but MSVC, as it still has a number of unsolved warnings
in its `/Wall` level. Some of it might be valid, others might be overkill,
this needs further assessment and fixes. (We could also change the `extra`
level to `/W4` on MSVC if that's more meaningful.)