### PR TITLE
Fix duplicate variant constructor typo.

### DIFF
--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -594,7 +594,7 @@ void Variant::_register_variant_constructors() {
 	add_constructor<VariantConstructorToArray<PackedByteArray>>(sarray("from"));
 	add_constructor<VariantConstructorToArray<PackedInt32Array>>(sarray("from"));
 	add_constructor<VariantConstructorToArray<PackedInt64Array>>(sarray("from"));
-	add_constructor<VariantConstructorToArray<PackedFloat64Array>>(sarray("from"));
+	add_constructor<VariantConstructorToArray<PackedFloat32Array>>(sarray("from"));
 	add_constructor<VariantConstructorToArray<PackedFloat64Array>>(sarray("from"));
 	add_constructor<VariantConstructorToArray<PackedStringArray>>(sarray("from"));
 	add_constructor<VariantConstructorToArray<PackedVector2Array>>(sarray("from"));


### PR DESCRIPTION
Fix `PackedFloat64Array` added twice, instead of `PackedFloat32Array`.
See https://github.com/godotengine/godot/pull/43403#discussion_r519920314 comment.
