### PR TITLE
Improve the 3D editor selection box appearance (3.2)

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -481,6 +481,7 @@ public:
 	bool last_xform_dirty;
 	Spatial *sp;
 	RID sbox_instance;
+	RID sbox_instance_xray;
 
 	SpatialEditorSelectedItem() {
 		sp = NULL;
@@ -598,6 +599,7 @@ private:
 	float snap_rotate_value;
 	float snap_scale_value;
 
+	Ref<ArrayMesh> selection_box_xray;
 	Ref<ArrayMesh> selection_box;
 	RID indicators;
 	RID indicators_instance;
@@ -687,7 +689,7 @@ private:
 
 	HBoxContainer *hbc_menu;
 
-	void _generate_selection_box();
+	void _generate_selection_boxes();
 	UndoRedo *undo_redo;
 
 	int camera_override_viewport_id;


### PR DESCRIPTION
Backport of #40106 for the `3.2` branch.

- Draw two boxes slightly offset from each other to give the illustion of a thicker outline.
- Decrease the offset compared to the 3D node's AABB to give a more accurate representation of its size.
- Make the box fully visible instead of only displaying the corners.
- Draw a x-ray version of the box that's more translucent, but visible through walls. This helps make the box more visible while still having a sense of depth.
- Use an orange color similar to the 2D editor.

## Preview

![3D selection box](https://user-images.githubusercontent.com/180032/98596340-9818b080-22d7-11eb-87f1-595c82a8854c.png)
