### PR TITLE
Remove Attempted to free invalid ID error

### DIFF
--- a/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.cpp
+++ b/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.cpp
@@ -2567,6 +2567,4 @@ RasterizerCanvasRD::~RasterizerCanvasRD() {
 
 	storage->free(default_canvas_texture);
 	//pipelines don't need freeing, they are all gone after shaders are gone
-
-	RD::get_singleton()->free(state.default_transforms_uniform_set);
 }


### PR DESCRIPTION
Fixes #43430

Looks that `state.default_transforms_uniform_set` is removed here

https://github.com/godotengine/godot/blob/90edd839d5f67d4252923a720feeef6ad0d76107/servers/rendering/rasterizer_rd/rasterizer_canvas_rd.cpp#L1190

so it is not needed to delete it manually