### PR TITLE
Checking for half_image_size[ x & y ] to be non-negative.

### DIFF
--- a/thirdparty/jpeg-compressor/jpgd.cpp
+++ b/thirdparty/jpeg-compressor/jpgd.cpp
@@ -1669,7 +1669,7 @@ namespace jpgd {
 		int row = m_max_mcu_y_size - m_mcu_lines_left;
 		uint8* d0 = m_pScan_line_0;
 
-		const int half_image_x_size = (m_image_x_size >> 1) - 1;
+		const int half_image_x_size = (m_image_x_size == 1) ? 0 : (m_image_x_size >> 1) - 1;
 		const int row_x8 = row * 8;
 
 		for (int x = 0; x < m_image_x_size; x++)
@@ -1762,7 +1762,7 @@ namespace jpgd {
 		int y = m_image_y_size - m_total_lines_left;
 		int row = y & 15;
 
-		const int half_image_y_size = (m_image_y_size >> 1) - 1;
+		const int half_image_y_size = (m_image_y_size == 1) ? 0 : (m_image_y_size >> 1) - 1;
 
 		uint8* d0 = m_pScan_line_0;
 
@@ -1891,7 +1891,7 @@ namespace jpgd {
 		int y = m_image_y_size - m_total_lines_left;
 		int row = y & 15;
 
-		const int half_image_y_size = (m_image_y_size >> 1) - 1;
+		const int half_image_y_size = (m_image_y_size == 1) ? 0 : (m_image_y_size >> 1) - 1;
 
 		uint8* d0 = m_pScan_line_0;
 
@@ -1915,7 +1915,7 @@ namespace jpgd {
 		const int y0_base = (c_y0 & 7) * 8 + 256;
 		const int y1_base = (c_y1 & 7) * 8 + 256;
 
-		const int half_image_x_size = (m_image_x_size >> 1) - 1;
+		const int half_image_x_size = (m_image_x_size == 1) ? 0 : (m_image_x_size >> 1) - 1;
 
 		static const uint8_t s_muls[2][2][4] =
 		{


### PR DESCRIPTION
This make sure that (1x1) , (1 x X) and (X x 1) pixel images using sub-sampling will get correct half_image_size i.e NON-NEGATIVE.
fix : https://github.com/godotengine/godot/issues/42363

EVIDENCE 💯
here are some jpg images of different sub-sampling imported into Engine.
H1V1 : 👍

![](https://user-images.githubusercontent.com/70578657/98451971-16a70e00-2171-11eb-8248-f7e46a15db95.png)

H1V2 : 👍

![](https://user-images.githubusercontent.com/70578657/98451952-e2335200-2170-11eb-8b53-e1705d9aa638.png)

H2V1 : 👍


![](https://user-images.githubusercontent.com/70578657/98451996-448c5280-2171-11eb-93cc-6618db980334.png)

H2V2 : 👍


![](https://user-images.githubusercontent.com/70578657/98452014-5ff75d80-2171-11eb-91e8-c62140dca252.png)


TESTED - PROJECT :
[gdtest.zip](https://github.com/godotengine/godot/files/5505479/gdtest.zip)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
