### PR TITLE
Keep cursor relative position after move lines up/down in text editor

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1138,6 +1138,7 @@ void CodeTextEditor::move_lines_up() {
 		int from_col = text_editor->get_selection_from_column();
 		int to_line = text_editor->get_selection_to_line();
 		int to_column = text_editor->get_selection_to_column();
+		int cursor_line = text_editor->cursor_get_line();
 
 		for (int i = from_line; i <= to_line; i++) {
 			int line_id = i;
@@ -1155,7 +1156,9 @@ void CodeTextEditor::move_lines_up() {
 		}
 		int from_line_up = from_line > 0 ? from_line - 1 : from_line;
 		int to_line_up = to_line > 0 ? to_line - 1 : to_line;
+		int cursor_line_up = cursor_line > 0 ? cursor_line - 1 : cursor_line;
 		text_editor->select(from_line_up, from_col, to_line_up, to_column);
+		text_editor->cursor_set_line(cursor_line_up);
 	} else {
 		int line_id = text_editor->cursor_get_line();
 		int next_id = line_id - 1;
@@ -1181,6 +1184,7 @@ void CodeTextEditor::move_lines_down() {
 		int from_col = text_editor->get_selection_from_column();
 		int to_line = text_editor->get_selection_to_line();
 		int to_column = text_editor->get_selection_to_column();
+		int cursor_line = text_editor->cursor_get_line();
 
 		for (int i = to_line; i >= from_line; i--) {
 			int line_id = i;
@@ -1198,7 +1202,9 @@ void CodeTextEditor::move_lines_down() {
 		}
 		int from_line_down = from_line < text_editor->get_line_count() ? from_line + 1 : from_line;
 		int to_line_down = to_line < text_editor->get_line_count() ? to_line + 1 : to_line;
+		int cursor_line_down = cursor_line < text_editor->get_line_count() ? cursor_line + 1 : cursor_line;
 		text_editor->select(from_line_down, from_col, to_line_down, to_column);
+		text_editor->cursor_set_line(cursor_line_down);
 	} else {
 		int line_id = text_editor->cursor_get_line();
 		int next_id = line_id + 1;


### PR DESCRIPTION
This PR keeps the relative cursor position in the selected text block when moving up/down (alt+up / alt+down).

Before this PR, the cursor will always be on the last line after moving the block up, and will always be on the first line after moving down.

Before:
![before](https://user-images.githubusercontent.com/372476/98802123-c15b4d00-244d-11eb-927b-c5785fa9d642.gif)

After:
![after](https://user-images.githubusercontent.com/372476/98802131-c4eed400-244d-11eb-9810-9e7a715c4d88.gif)

Tested on the current master (10fd107) and 3.2 branch (1dd2cf7).