### PR TITLE
Fix for linux joypad D-pad zeroing

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -459,9 +459,9 @@ void JoypadLinux::process_joypads() {
 							case ABS_HAT0X:
 								if (ev.value != 0) {
 									if (ev.value < 0) {
-										joy->dpad |= Input::HAT_MASK_LEFT;
+										joy->dpad = (joy->dpad | Input::HAT_MASK_LEFT) & ~Input::HAT_MASK_RIGHT;
 									} else {
-										joy->dpad |= Input::HAT_MASK_RIGHT;
+										joy->dpad = (joy->dpad | Input::HAT_MASK_RIGHT) & ~Input::HAT_MASK_LEFT;
 									}
 								} else {
 									joy->dpad &= ~(Input::HAT_MASK_LEFT | Input::HAT_MASK_RIGHT);
@@ -473,9 +473,9 @@ void JoypadLinux::process_joypads() {
 							case ABS_HAT0Y:
 								if (ev.value != 0) {
 									if (ev.value < 0) {
-										joy->dpad |= Input::HAT_MASK_UP;
+										joy->dpad = (joy->dpad | Input::HAT_MASK_UP) & ~Input::HAT_MASK_DOWN;
 									} else {
-										joy->dpad |= Input::HAT_MASK_DOWN;
+										joy->dpad = (joy->dpad | Input::HAT_MASK_DOWN) & ~Input::HAT_MASK_UP;
 									}
 								} else {
 									joy->dpad &= ~(Input::HAT_MASK_UP | Input::HAT_MASK_DOWN);


### PR DESCRIPTION
Some controllers (notably those made by 8bitdo) do not always emit an event to zero out a D-pad axis before flipping direction. For example, when rolling around aggressively the D-pad of an 8bitdo SN30 Pro/Pro+, the following may be observed:

```
ABS_HAT0X : -1
ABS_HAT0Y : -1
ABS_HAT0Y : 0
ABS_HAT0Y : 1
ABS_HAT0X : 1
```

Notable here is that no event for `ABS_HAT0X: 0` is emitted between the events for `ABS_HAT0X: -1` and `ABS_HATOX: 1`. Consequently, the game engine believes that both the negative _and_ positive x-axis of the D-pad are activated simultaneously (i.e `is_joy_button_pressed()` returns `true` for both `JOY_BUTTON_DPAD_LEFT` and `JOY_BUTTON_DPAD_RIGHT`), which should be impossible.

This issue is _not_ reproducible on all controllers. The Xbox One controller in particular will not exhibit this problem (it always emits zeroing out events for an axis before flipping direction).

The fix is to always zero out the opposite direction on the D-pad axis in question when processing an event with a nonzero value. This unfortunately wastes a small number of CPU cycles on controllers that behave nicely.

**I have verified this issue is also reproducible in the stable 3.2 branch**