### PR TITLE
Removing unneeded FuncRef code in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -39,14 +39,6 @@ namespace Godot
             return val * sgn;
         }
 
-        public static FuncRef FuncRef(Object instance, StringName funcName)
-        {
-            var ret = new FuncRef();
-            ret.SetInstance(instance);
-            ret.SetFunction(funcName);
-            return ret;
-        }
-
         public static int Hash(object var)
         {
             return godot_icall_GD_hash(var);


### PR DESCRIPTION
In PR #43385 FuncRef was removed from source, but there was a reference left on the Mono side of things which breaks compilation. This PR removes this code.