### PR TITLE
Document InstancePlaceholder.create_instance not being thread-safe.

### DIFF
--- a/doc/classes/InstancePlaceholder.xml
+++ b/doc/classes/InstancePlaceholder.xml
@@ -18,13 +18,14 @@
 			<argument index="1" name="custom_scene" type="PackedScene" default="null">
 			</argument>
 			<description>
+				Not thread-safe. Use [method Object.call_deferred] if calling from a thread.
 			</description>
 		</method>
 		<method name="get_instance_path" qualifiers="const">
 			<return type="String">
 			</return>
 			<description>
-				Gets the path to the [PackedScene] resource file that is loaded by default when calling [method create_instance].
+				Gets the path to the [PackedScene] resource file that is loaded by default when calling [method create_instance]. Not thread-safe. Use [method Object.call_deferred] if calling from a thread.
 			</description>
 		</method>
 		<method name="get_stored_values">


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

See https://github.com/godotengine/godot/issues/43391#issuecomment-723713030

Closes #43391