### PR TITLE
Allow HTTPClient to talk to a proxy server

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -109,24 +109,41 @@ Ref<StreamPeer> HTTPClient::get_connection() const {
 	return connection;
 }
 
+static bool _check_request_url(HTTPClient::Method p_method, const String &p_url) {
+	switch (p_method) {
+		case HTTPClient::METHOD_CONNECT: {
+			// Authority in host:port format, as in RFC7231
+			int pos = p_url.find_char(':');
+			return 0 < pos && pos < p_url.length() - 1;
+		}
+		case HTTPClient::METHOD_OPTIONS: {
+			if (p_url == "*") {
+				return true;
+			}
+			[[fallthrough]];
+		}
+		default:
+			// Absolute path or absolute URL
+			return p_url.begins_with("/") || p_url.begins_with("http://") || p_url.begins_with("https://");
+	}
+}
+
 Error HTTPClient::request_raw(Method p_method, const String &p_url, const Vector<String> &p_headers, const Vector<uint8_t> &p_body) {
 	ERR_FAIL_INDEX_V(p_method, METHOD_MAX, ERR_INVALID_PARAMETER);
-	ERR_FAIL_COND_V(!p_url.begins_with("/"), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(!_check_request_url(p_method, p_url), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(connection.is_null(), ERR_INVALID_DATA);
 
 	String request = String(_methods[p_method]) + " " + p_url + " HTTP/1.1\r\n";
-	if ((ssl && conn_port == PORT_HTTPS) || (!ssl && conn_port == PORT_HTTP)) {
-		// Don't append the standard ports
-		request += "Host: " + conn_host + "\r\n";
-	} else {
-		request += "Host: " + conn_host + ":" + itos(conn_port) + "\r\n";
-	}
+	bool add_host = true;
 	bool add_clen = p_body.size() > 0;
 	bool add_uagent = true;
 	bool add_accept = true;
 	for (int i = 0; i < p_headers.size(); i++) {
 		request += p_headers[i] + "\r\n";
+		if (add_host && p_headers[i].findn("Host:") == 0) {
+			add_host = false;
+		}
 		if (add_clen && p_headers[i].findn("Content-Length:") == 0) {
 			add_clen = false;
 		}
@@ -135,6 +152,14 @@ Error HTTPClient::request_raw(Method p_method, const String &p_url, const Vector
 		}
 		if (add_accept && p_headers[i].findn("Accept:") == 0) {
 			add_accept = false;
+		}
+	}
+	if (add_host) {
+		if ((ssl && conn_port == PORT_HTTPS) || (!ssl && conn_port == PORT_HTTP)) {
+			// Don't append the standard ports
+			request += "Host: " + conn_host + "\r\n";
+		} else {
+			request += "Host: " + conn_host + ":" + itos(conn_port) + "\r\n";
 		}
 	}
 	if (add_clen) {
@@ -178,22 +203,20 @@ Error HTTPClient::request_raw(Method p_method, const String &p_url, const Vector
 
 Error HTTPClient::request(Method p_method, const String &p_url, const Vector<String> &p_headers, const String &p_body) {
 	ERR_FAIL_INDEX_V(p_method, METHOD_MAX, ERR_INVALID_PARAMETER);
-	ERR_FAIL_COND_V(!p_url.begins_with("/"), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(!_check_request_url(p_method, p_url), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(connection.is_null(), ERR_INVALID_DATA);
 
 	String request = String(_methods[p_method]) + " " + p_url + " HTTP/1.1\r\n";
-	if ((ssl && conn_port == PORT_HTTPS) || (!ssl && conn_port == PORT_HTTP)) {
-		// Don't append the standard ports
-		request += "Host: " + conn_host + "\r\n";
-	} else {
-		request += "Host: " + conn_host + ":" + itos(conn_port) + "\r\n";
-	}
+	bool add_host = true;
 	bool add_uagent = true;
 	bool add_accept = true;
 	bool add_clen = p_body.length() > 0;
 	for (int i = 0; i < p_headers.size(); i++) {
 		request += p_headers[i] + "\r\n";
+		if (add_host && p_headers[i].findn("Host:") == 0) {
+			add_host = false;
+		}
 		if (add_clen && p_headers[i].findn("Content-Length:") == 0) {
 			add_clen = false;
 		}
@@ -202,6 +225,14 @@ Error HTTPClient::request(Method p_method, const String &p_url, const Vector<Str
 		}
 		if (add_accept && p_headers[i].findn("Accept:") == 0) {
 			add_accept = false;
+		}
+	}
+	if (add_host) {
+		if ((ssl && conn_port == PORT_HTTPS) || (!ssl && conn_port == PORT_HTTP)) {
+			// Don't append the standard ports
+			request += "Host: " + conn_host + "\r\n";
+		} else {
+			request += "Host: " + conn_host + ":" + itos(conn_port) + "\r\n";
 		}
 	}
 	if (add_clen) {


### PR DESCRIPTION
This PR makes it possible to talk to HTTP/HTTPS proxy server via `HTTPClient`, closes https://github.com/godotengine/godot-proposals/issues/1808

* Makes request uri accept absolute URL and authority
    * This is [allowed](https://tools.ietf.org/html/rfc2616#section-5.1.2) by http protocol, and [required](https://tools.ietf.org/html/rfc7231#section-4.3.6) by the `CONNECT` method
* Adds Host header only when missing
    * Before this PR, "Host" is determined by `connect_to_host` and there is no way to override it

These changes are actually bug fixes. But fixing these bugs makes it possible to talk to proxy servers.

With this PR, requests can be sent through HTTP/HTTPS proxies by setting up proxy manually:
[ProxyTest-3.2.zip](https://github.com/godotengine/godot/files/5535546/ProxyTest-3.2.zip) / [ProxyTest-4.0.zip](https://github.com/godotengine/godot/files/5535548/ProxyTest-4.0.zip)

Tested on the current master (f733746) and 3.2 branch (adf2dab).

_Update_: Instead of removing the `url` check, makes sure that `url` begins with `/`, `http://`, or `https://` for non-`CONNECT` requests.