### PR TITLE
SceneTree: Fix reparent crash with animation tracks renaming disabled

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1270,10 +1270,6 @@ void SceneTreeDock::_fill_path_renames(Vector<StringName> base_path, Vector<Stri
 }
 
 void SceneTreeDock::fill_path_renames(Node *p_node, Node *p_new_parent, List<Pair<NodePath, NodePath>> *p_renames) {
-	if (!bool(EDITOR_DEF("editors/animation/autorename_animation_tracks", true))) {
-		return;
-	}
-
 	Vector<StringName> base_path;
 	Node *n = p_node->get_parent();
 	while (n) {


### PR DESCRIPTION
This check was there since the first commit in 2014, but a later feature added in 2018
with #17717 did not properly update the code while adding non animation-related code
in `perform_node_renames`.

Fixes #40532.