### PR TITLE
GDScript: Fix native class not set with inheritance

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1963,6 +1963,8 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 			}
 
 			p_script->member_indices = base->member_indices;
+			native = base->native;
+			p_script->native = native;
 		} break;
 		default: {
 			_set_error("Parser bug: invalid inheritance.", p_class);


### PR DESCRIPTION
This is a bug that may make compilation be wrong in certain cases.