### PR TITLE
In LineEdit Changed "mouse cursor"  to the "caret (text cursor)". 

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -270,7 +270,7 @@
 			<return type="String">
 			</return>
 			<description>
-				Returns a [String] text with the word under the mouse cursor location.
+				Returns a [String] text with the word under the caret (text cursor) location.
 			</description>
 		</method>
 		<method name="insert_text_at_cursor">


### PR DESCRIPTION
Fixes the issue https://docs.godotengine.org/ru/stable/classes/class_textedit.html#class-textedit-method-get-word-under-cursor

*Bugsquad edit:* Fixes https://github.com/godotengine/godot-docs/issues/4061.