### PR TITLE
[3.x] VisualServer now sorts based on AABB position

### DIFF
--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -2025,8 +2025,8 @@ void VisualServerScene::_prepare_scene(const Transform p_cam_transform, const Ca
 
 				geom->gi_probes_dirty = false;
 			}
-
-			ins->depth = near_plane.distance_to(ins->transform.origin);
+			Vector3 aabb_center = ins->transformed_aabb.position + (ins->transformed_aabb.size * 0.5);
+			ins->depth = near_plane.distance_to(aabb_center);
 			ins->depth_layer = CLAMP(int(ins->depth * 16 / z_far), 0, 15);
 		}
 


### PR DESCRIPTION
this was causing issues with scenes where the origin of the objects
was set for all objects to the center of the scene, making transparent
objects sort improperly

This work was kindly sponsored by IMVU

Co-authored-by: RevoluPowered <gordon@gordonite.tech>