### PR TITLE
Remove duplicate Android `orientation` settings.

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -29,7 +29,6 @@
 /*************************************************************************/
 
 #include "export.h"
-#include "gradle_export_util.h"
 
 #include "core/config/project_settings.h"
 #include "core/io/image_loader.h"
@@ -827,7 +826,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 		int version_code = p_preset->get("version/code");
 		String package_name = p_preset->get("package/unique_name");
 
-		int orientation = p_preset->get("screen/orientation");
+		const int screen_orientation = _get_android_orientation_value(_get_screen_orientation());
 
 		bool screen_support_small = p_preset->get("screen/support_small");
 		bool screen_support_normal = p_preset->get("screen/support_normal");
@@ -937,7 +936,7 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 						}
 
 						if (tname == "activity" && attrname == "screenOrientation") {
-							encode_uint32(orientation == 0 ? 0 : 1, &p_manifest.write[iofs + 16]);
+							encode_uint32(screen_orientation, &p_manifest.write[iofs + 16]);
 						}
 
 						if (tname == "supports-screens") {
@@ -1636,7 +1635,6 @@ public:
 		r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/name", PROPERTY_HINT_PLACEHOLDER_TEXT, "Game Name [default if blank]"), ""));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/signed"), true));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/immersive_mode"), true));
-		r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "screen/orientation", PROPERTY_HINT_ENUM, "Landscape,Portrait"), 0));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/support_small"), true));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/support_normal"), true));
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/support_large"), true));

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -44,6 +44,67 @@ const String godot_project_name_xml_string = R"(<?xml version="1.0" encoding="ut
 </resources>
 )";
 
+DisplayServer::ScreenOrientation _get_screen_orientation() {
+	String orientation_settings = ProjectSettings::get_singleton()->get("display/window/handheld/orientation");
+	DisplayServer::ScreenOrientation screen_orientation;
+	if (orientation_settings == "portrait")
+		screen_orientation = DisplayServer::SCREEN_PORTRAIT;
+	else if (orientation_settings == "reverse_landscape")
+		screen_orientation = DisplayServer::SCREEN_REVERSE_LANDSCAPE;
+	else if (orientation_settings == "reverse_portrait")
+		screen_orientation = DisplayServer::SCREEN_REVERSE_PORTRAIT;
+	else if (orientation_settings == "sensor_landscape")
+		screen_orientation = DisplayServer::SCREEN_SENSOR_LANDSCAPE;
+	else if (orientation_settings == "sensor_portrait")
+		screen_orientation = DisplayServer::SCREEN_SENSOR_PORTRAIT;
+	else if (orientation_settings == "sensor")
+		screen_orientation = DisplayServer::SCREEN_SENSOR;
+	else
+		screen_orientation = DisplayServer::SCREEN_LANDSCAPE;
+
+	return screen_orientation;
+}
+
+int _get_android_orientation_value(DisplayServer::ScreenOrientation screen_orientation) {
+	switch (screen_orientation) {
+		case DisplayServer::SCREEN_PORTRAIT:
+			return 1;
+		case DisplayServer::SCREEN_REVERSE_LANDSCAPE:
+			return 8;
+		case DisplayServer::SCREEN_REVERSE_PORTRAIT:
+			return 9;
+		case DisplayServer::SCREEN_SENSOR_LANDSCAPE:
+			return 11;
+		case DisplayServer::SCREEN_SENSOR_PORTRAIT:
+			return 12;
+		case DisplayServer::SCREEN_SENSOR:
+			return 13;
+		case DisplayServer::SCREEN_LANDSCAPE:
+		default:
+			return 0;
+	}
+}
+
+String _get_android_orientation_label(DisplayServer::ScreenOrientation screen_orientation) {
+	switch (screen_orientation) {
+		case DisplayServer::SCREEN_PORTRAIT:
+			return "portrait";
+		case DisplayServer::SCREEN_REVERSE_LANDSCAPE:
+			return "reverseLandscape";
+		case DisplayServer::SCREEN_REVERSE_PORTRAIT:
+			return "reversePortrait";
+		case DisplayServer::SCREEN_SENSOR_LANDSCAPE:
+			return "userLandscape";
+		case DisplayServer::SCREEN_SENSOR_PORTRAIT:
+			return "userPortrait";
+		case DisplayServer::SCREEN_SENSOR:
+			return "fullUser";
+		case DisplayServer::SCREEN_LANDSCAPE:
+		default:
+			return "landscape";
+	}
+}
+
 // Utility method used to create a directory.
 Error create_directory(const String &p_dir) {
 	if (!DirAccess::exists(p_dir)) {
@@ -209,7 +270,7 @@ String _get_plugins_tag(const String &plugins_names) {
 
 String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 	bool uses_xr = (int)(p_preset->get("xr_features/xr_mode")) == 1;
-	String orientation = (int)(p_preset->get("screen/orientation")) == 1 ? "portrait" : "landscape";
+	String orientation = _get_android_orientation_label(_get_screen_orientation());
 	String manifest_activity_text = vformat(
 			"        <activity android:name=\"com.godot.game.GodotApp\" "
 			"tools:replace=\"android:screenOrientation\" "


### PR DESCRIPTION
This PR addresses https://github.com/godotengine/godot/issues/39266#issuecomment-724536884 by removing the Android `orientation` settings from the `Export` window in favor of the ones from the `Project Settings`.