### PR TITLE
Avoid segmentation fault when class_type->identifier is nullptr

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -104,7 +104,7 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 		case GDScriptParser::DataType::CLASS: {
 			// Locate class by constructing the path to it and following that path
 			GDScriptParser::ClassNode *class_type = p_datatype.class_type;
-			if (class_type) {
+			if (class_type && class_type->base_type.kind != GDScriptParser::DataType::UNRESOLVED) {
 				if (class_type->fqcn.begins_with(main_script->path) || (!main_script->name.empty() && class_type->fqcn.begins_with(main_script->name))) {
 					// Local class.
 					List<StringName> names;


### PR DESCRIPTION
Avoid segmentation fault when class_type->identifier is nullptr.

This happens when the file is not found or it's not able to find a parser, so it's enough check if `&& class_type->base_type.kind != GDScriptParser::DataType::UNRESOLVED`

You can reproduce it:
```gdscript
func test(variable: MyClass):
    pass
```
Also, you need this to patch: https://github.com/godotengine/godot/pull/43504 otherwise you will just rise a crash elsewhere.