### PR TITLE
Fixes crash if Vulkan presentation surface is not available.

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -707,7 +707,8 @@ Error VulkanContext::_window_create(DisplayServer::WindowID p_window_id, VkSurfa
 		// We use a single GPU, but we need a surface to initialize the
 		// queues, so this process must be deferred until a surface
 		// is created.
-		_initialize_queues(p_surface);
+		Error err = _initialize_queues(p_surface);
+		ERR_FAIL_COND_V(err != OK, ERR_CANT_CREATE);
 	}
 
 	Window window;

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -3852,6 +3852,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 			(screen_get_size(0).width - p_resolution.width) / 2,
 			(screen_get_size(0).height - p_resolution.height) / 2);
 	WindowID main_window = _create_window(p_mode, p_flags, Rect2i(window_position, p_resolution));
+	if (main_window == INVALID_WINDOW_ID) {
+		r_error = ERR_CANT_CREATE;
+		return;
+	}
 	for (int i = 0; i < WINDOW_FLAG_MAX; i++) {
 		if (p_flags & (1 << i)) {
 			window_set_flag(WindowFlags(i), true, main_window);


### PR DESCRIPTION
Adds missing checks to fix crash #38428.

Note: It's not fixing the aforementioned issue, only crash. Godot still won't run on X11 server without presentation surface (e.g. Xvfb + lavapipe ICD), it will show `Your video card driver does not support any of the supported Vulkan versions.` error message and quit.
