### PR TITLE
Fix 2d software skinning with scaled polys

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -1625,13 +1625,16 @@ PREAMBLE(bool)::_software_skin_poly(RasterizerCanvas::Item::CommandPolygon *p_po
 
 	if (num_verts && (p_poly->bones.size() == num_verts * 4) && (p_poly->weights.size() == p_poly->bones.size())) {
 
+		const Transform2D &item_transform = p_item->xform;
+		Transform2D item_transform_inv = item_transform.affine_inverse();
+
 		for (int n = 0; n < num_verts; n++) {
 			const Vector2 &src_pos = p_poly->points[n];
 			Vector2 &dst_pos = pTemps[n];
 
 			// there can be an offset on the polygon at rigging time, this has to be accounted for
 			// note it may be possible that this could be concatenated with the bone transforms to save extra transforms - not sure yet
-			Vector2 src_pos_back_transformed = p_item->xform.xform(src_pos);
+			Vector2 src_pos_back_transformed = item_transform.xform(src_pos);
 
 			float total_weight = 0.0f;
 
@@ -1661,7 +1664,7 @@ PREAMBLE(bool)::_software_skin_poly(RasterizerCanvas::Item::CommandPolygon *p_po
 				dst_pos /= total_weight;
 
 				// retransform back from the poly offset space
-				dst_pos = p_item->xform.xform_inv(dst_pos);
+				dst_pos = item_transform_inv.xform(dst_pos);
 			}
 		}
 


### PR DESCRIPTION
In some situations where polygons were scaled, existing software skinning was producing incorrect results.

The transform inverse needed to use an affine inverse rather than a cheaper inverse to account for this scaling.

Fixes #43502

## Notes
* This now approximately matches the `skeleton_transform` and `skeleton_transform_inverse` from the `render_joined_item` funcs. In fact in all cases so far they match exactly, so I may move over to using the same eventually.

There is still a remaining difference between the behaviour in the legacy renderer and the software skinning. When either the skeleton node or the polygon node have an offset in relation to each other, there is a difference, as though there is an extra transform missing from the software skinning.

It seems to be workable, and I'm not quite sure where this extra transform is being introduced in the legacy path yet, I am still investigating to see whether I can get them to match in all circumstances. I can't discount the possibility that the legacy behaviour could be erroneous (as well as the new behaviour, which is more likely), I may need to consult with reduz after more investigations.

In any case this PR moves the software skinning to work in more cases than previously so should be good to merge in the interim.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
