### PR TITLE
Make sure to inizialize the r_error.error on Variant::construct

### DIFF
--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -717,6 +717,7 @@ void Variant::_unregister_variant_constructors() {
 }
 
 void Variant::construct(Variant::Type p_type, Variant &base, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+	r_error.error = Callable::CallError::CALL_OK;
 	uint32_t s = construct_data[p_type].size();
 	for (uint32_t i = 0; i < s; i++) {
 		int argc = construct_data[p_type][i].argument_count;


### PR DESCRIPTION
Make sure to initialize the `r_error.error` when `Variant::construct` is called.

The error passed to the function `Variant::construct` is not initialized: https://github.com/godotengine/godot/blob/master/modules/gdscript/gdscript_function.cpp#L958-L959

Since not all the constructors defined here: https://github.com/godotengine/godot/blob/master/core/variant/variant_construct.cpp#L738 always set `r_error.error` to something, happens that the error `Bug, call error: #426275124` is raised with a random number, even when the function succeed.

Correct functions:
- https://github.com/godotengine/godot/blob/master/core/variant/variant_construct.cpp#L434-L437
- https://github.com/godotengine/godot/blob/master/core/variant/variant_construct.cpp#L399-L409
- https://github.com/godotengine/godot/blob/master/core/variant/variant_construct.cpp#L95-L108
- https://github.com/godotengine/godot/blob/master/core/variant/variant_construct.cpp#L66-L70
- ....


**Bad functions:**
- https://github.com/godotengine/godot/blob/master/core/variant/variant_construct.cpp#L341-L358
- https://github.com/godotengine/godot/blob/master/core/variant/variant_construct.cpp#L282-L299
- https://github.com/godotengine/godot/blob/master/core/variant/variant_construct.cpp#L224-L252
- https://github.com/godotengine/godot/blob/master/core/variant/variant_construct.cpp#L167-L195
- https://github.com/godotengine/godot/blob/master/core/variant/variant_construct.cpp#L133-L142
- ....

If we initialize the variable to `CALL_OK`, as I did in this PR, we can just leave the task to the above functions to set the error only when there is an error. In this way we can also make that mechanism less error prone and so more robust. Though, not sure if you would like to also set `CALL_OK` into those functions, or just leave them as are @reduz.