### PR TITLE
feat: HMAC support in Crypto APIs

### DIFF
--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -67,6 +67,23 @@ public:
 	virtual Error save(String p_path) = 0;
 };
 
+class HMACContext : public Reference {
+	GDCLASS(HMACContext, Reference);
+
+protected:
+	static void _bind_methods();
+	static HMACContext *(*_create)();
+
+public:
+	static HMACContext *create();
+
+	virtual Error start(HashingContext::HashType p_hash_type, PackedByteArray p_key) = 0;
+	virtual Error update(PackedByteArray p_data) = 0;
+	virtual PackedByteArray finish() = 0;
+
+	HMACContext() {}
+};
+
 class Crypto : public Reference {
 	GDCLASS(Crypto, Reference);
 
@@ -87,6 +104,12 @@ public:
 	virtual bool verify(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Vector<uint8_t> p_signature, Ref<CryptoKey> p_key) = 0;
 	virtual Vector<uint8_t> encrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_plaintext) = 0;
 	virtual Vector<uint8_t> decrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_ciphertext) = 0;
+
+	PackedByteArray hmac_digest(HashingContext::HashType p_hash_type, PackedByteArray p_key, PackedByteArray p_msg);
+
+	// Compares two PackedByteArrays for equality without leaking timing information in order to prevent timing attacks.
+	// @see: https://paragonie.com/blog/2015/11/preventing-timing-attacks-on-string-comparison-with-double-hmac-strategy
+	bool constant_time_compare(PackedByteArray p_trusted, PackedByteArray p_received);
 
 	Crypto() {}
 };

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -168,6 +168,7 @@ void register_core_types() {
 	ClassDB::register_class<AESContext>();
 	ClassDB::register_custom_instance_class<X509Certificate>();
 	ClassDB::register_custom_instance_class<CryptoKey>();
+	ClassDB::register_custom_instance_class<HMACContext>();
 	ClassDB::register_custom_instance_class<Crypto>();
 	ClassDB::register_custom_instance_class<StreamPeerSSL>();
 

--- a/doc/classes/Crypto.xml
+++ b/doc/classes/Crypto.xml
@@ -73,6 +73,18 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="constant_time_compare">
+			<return type="bool">
+			</return>
+			<argument index="0" name="trusted" type="PackedByteArray">
+			</argument>
+			<argument index="1" name="received" type="PackedByteArray">
+			</argument>
+			<description>
+				Compares two [PackedByteArray]s for equality without leaking timing information in order to prevent timing attacks.
+				See [url=https://paragonie.com/blog/2015/11/preventing-timing-attacks-on-string-comparison-with-double-hmac-strategy]this blog post[/url] for more information.
+			</description>
+		</method>
 		<method name="decrypt">
 			<return type="PackedByteArray">
 			</return>
@@ -145,6 +157,20 @@
 				X509Certificate cert = crypto.GenerateSelfSignedCertificate(key, "CN=mydomain.com,O=My Game Company,C=IT");
 				[/csharp]
 				[/codeblocks]
+			</description>
+		</method>
+		<method name="hmac_digest">
+			<return type="PackedByteArray">
+			</return>
+			<argument index="0" name="hash_type" type="int" enum="HashingContext.HashType">
+			</argument>
+			<argument index="1" name="key" type="PackedByteArray">
+			</argument>
+			<argument index="2" name="msg" type="PackedByteArray">
+			</argument>
+			<description>
+				Generates an [url=https://en.wikipedia.org/wiki/HMAC]HMAC[/url] digest of [code]msg[/code] using [code]key[/code]. The [code]hash_type[/code] parameter is the hashing algorithm that is used for the inner and outer hashes.
+				Currently, only [constant HashingContext.HASH_SHA256] and [constant HashingContext.HASH_SHA1] are supported.
 			</description>
 		</method>
 		<method name="sign">

--- a/doc/classes/HMACContext.xml
+++ b/doc/classes/HMACContext.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="HMACContext" inherits="Reference" version="4.0">
+	<brief_description>
+		Used to create an HMAC for a message using a key.
+	</brief_description>
+	<description>
+		The HMACContext class is useful for advanced HMAC use cases, such as streaming the message as it supports creating the message over time rather than providing it all at once.
+	[codeblocks]
+	[gdscript]
+	extends Node
+	var ctx = HMACContext.new()
+
+	func _ready():
+	    var key = "supersecret".to_utf8()
+	    var err = ctx.start(HashingContext.HASH_SHA256, key)
+	    assert(err == OK)
+	    var msg1 = "this is ".to_utf8()
+	    var msg2 = "vewy vewy secret".to_utf8()
+	    err = ctx.update(msg1)
+	    assert(err == OK)
+	    err = ctx.update(msg2)
+	    assert(err == OK)
+	    var hmac = ctx.finish()
+	    print(hmac.hex_encode())
+
+	[/gdscript]
+	[csharp]
+	using Godot;
+	using System;
+	using System.Diagnostics;
+
+	public class CryptoNode : Node
+	{
+	    private HMACContext ctx = new HMACContext();
+	    public override void _Ready()
+	    {
+	        PackedByteArray key = String("supersecret").to_utf8();
+	        Error err = ctx.Start(HashingContext.HASH_SHA256, key);
+	        GD.Assert(err == OK);
+	        PackedByteArray msg1 = String("this is ").to_utf8();
+	        PackedByteArray msg2 = String("vewy vew secret").to_utf8();
+	        err = ctx.Update(msg1);
+	        GD.Assert(err == OK);
+	        err = ctx.Update(msg2);
+	        GD.Assert(err == OK);
+	        PackedByteArray hmac = ctx.Finish();
+	        GD.Print(hmac.HexEncode());
+	    }
+	}
+
+	[/csharp]
+	[/codeblocks]
+	[b]Note:[/b] Not available in HTML5 exports.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="finish">
+			<return type="PackedByteArray">
+			</return>
+			<description>
+				Returns the resulting HMAC. If the HMAC failed, an empty [PackedByteArray] is returned.
+			</description>
+		</method>
+		<method name="start">
+			<return type="int" enum="Error">
+			</return>
+			<argument index="0" name="hash_type" type="int" enum="HashingContext.HashType">
+			</argument>
+			<argument index="1" name="key" type="PackedByteArray">
+			</argument>
+			<description>
+				Initializes the HMACContext. This method cannot be called again on the same HMACContext until [method finish] has been called.
+			</description>
+		</method>
+		<method name="update">
+			<return type="int" enum="Error">
+			</return>
+			<argument index="0" name="data" type="PackedByteArray">
+			</argument>
+			<description>
+				Updates the message to be HMACed. This can be called multiple times before [method finish] is called to append [code]data[/code] to the message, but cannot be called until [method start] has been called.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/modules/mbedtls/SCsub
+++ b/modules/mbedtls/SCsub
@@ -100,3 +100,7 @@ if env["builtin_mbedtls"]:
 
 # Module sources
 env_mbed_tls.add_source_files(env.modules_sources, "*.cpp")
+
+if env["tests"]:
+    env_mbed_tls.Append(CPPDEFINES=["TESTS_ENABLED"])
+    env_mbed_tls.add_source_files(env.modules_sources, "./tests/*.cpp")

--- a/modules/mbedtls/crypto_mbedtls.h
+++ b/modules/mbedtls/crypto_mbedtls.h
@@ -101,12 +101,31 @@ public:
 	friend class SSLContextMbedTLS;
 };
 
+class HMACContextMbedTLS : public HMACContext {
+private:
+	HashingContext::HashType hash_type;
+	int hash_len = 0;
+	void *ctx = nullptr;
+
+public:
+	static HMACContext *create();
+	static void make_default() { HMACContext::_create = create; }
+	static void finalize() { HMACContext::_create = nullptr; }
+
+	static bool is_md_type_allowed(mbedtls_md_type_t p_md_type);
+
+	virtual Error start(HashingContext::HashType p_hash_type, PackedByteArray p_key);
+	virtual Error update(PackedByteArray p_data);
+	virtual PackedByteArray finish();
+
+	HMACContextMbedTLS() {}
+};
+
 class CryptoMbedTLS : public Crypto {
 private:
 	mbedtls_entropy_context entropy;
 	mbedtls_ctr_drbg_context ctr_drbg;
 	static X509CertificateMbedTLS *default_certs;
-	mbedtls_md_type_t _md_type_from_hashtype(HashingContext::HashType p_hash_type, int &r_size);
 
 public:
 	static Crypto *create();
@@ -114,6 +133,7 @@ public:
 	static void finalize_crypto();
 	static X509CertificateMbedTLS *get_default_certificates();
 	static void load_default_certificates(String p_path);
+	static mbedtls_md_type_t md_type_from_hashtype(HashingContext::HashType p_hash_type, int &r_size);
 
 	virtual PackedByteArray generate_random_bytes(int p_bytes);
 	virtual Ref<CryptoKey> generate_rsa(int p_bytes);

--- a/modules/mbedtls/tests/test_crypto_mbedtls.h
+++ b/modules/mbedtls/tests/test_crypto_mbedtls.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  register_types.cpp                                                   */
+/*  test_crypto_mbedtls.h                                                */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,27 +28,34 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "register_types.h"
+#ifndef TEST_CRYPTO_MBEDTLS_H
+#define TEST_CRYPTO_MBEDTLS_H
 
-#include "crypto_mbedtls.h"
-#include "dtls_server_mbedtls.h"
-#include "packet_peer_mbed_dtls.h"
-#include "stream_peer_mbedtls.h"
+#include "core/crypto/hashing_context.h"
 
-#ifdef TESTS_ENABLED
-#include "tests/test_crypto_mbedtls.h"
-#endif
+#include "tests/test_macros.h"
 
-void register_mbedtls_types() {
-	CryptoMbedTLS::initialize_crypto();
-	StreamPeerMbedTLS::initialize_ssl();
-	PacketPeerMbedDTLS::initialize_dtls();
-	DTLSServerMbedTLS::initialize();
+namespace TestCryptoMbedTLS {
+
+void hmac_digest_test(HashingContext::HashType ht, String expected_hex);
+
+TEST_CASE("[CryptoMbedTLS] HMAC digest") {
+	// SHA-256
+	hmac_digest_test(HashingContext::HashType::HASH_SHA256, "fe442023f8a7d36a810e1e7cd8a8e2816457f350a008fbf638296afa12085e59");
+
+	// SHA-1
+	hmac_digest_test(HashingContext::HashType::HASH_SHA1, "a0ac4cd68a2f4812c355983d94e8d025afe7dddf");
 }
 
-void unregister_mbedtls_types() {
-	DTLSServerMbedTLS::finalize();
-	PacketPeerMbedDTLS::finalize_dtls();
-	StreamPeerMbedTLS::finalize_ssl();
-	CryptoMbedTLS::finalize_crypto();
+void hmac_context_digest_test(HashingContext::HashType ht, String expected_hex);
+
+TEST_CASE("[HMACContext] HMAC digest") {
+	// SHA-256
+	hmac_context_digest_test(HashingContext::HashType::HASH_SHA256, "fe442023f8a7d36a810e1e7cd8a8e2816457f350a008fbf638296afa12085e59");
+
+	// SHA-1
+	hmac_context_digest_test(HashingContext::HashType::HASH_SHA1, "a0ac4cd68a2f4812c355983d94e8d025afe7dddf");
 }
+} // namespace TestCryptoMbedTLS
+
+#endif // TEST_CRYPTO_MBEDTLS_H

--- a/tests/test_crypto.h
+++ b/tests/test_crypto.h
@@ -1,0 +1,74 @@
+/*************************************************************************/
+/*  test_crypto.h                                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_CRYPTO_H
+#define TEST_CRYPTO_H
+
+#include "core/crypto/crypto.h"
+#include "tests/test_macros.h"
+#include <stdio.h>
+
+namespace TestCrypto {
+
+class _MockCrypto : public Crypto {
+	virtual PackedByteArray generate_random_bytes(int p_bytes) { return PackedByteArray(); }
+	virtual Ref<CryptoKey> generate_rsa(int p_bytes) { return nullptr; }
+	virtual Ref<X509Certificate> generate_self_signed_certificate(Ref<CryptoKey> p_key, String p_issuer_name, String p_not_before, String p_not_after) { return nullptr; }
+
+	virtual Vector<uint8_t> sign(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Ref<CryptoKey> p_key) { return Vector<uint8_t>(); }
+	virtual bool verify(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Vector<uint8_t> p_signature, Ref<CryptoKey> p_key) { return false; }
+	virtual Vector<uint8_t> encrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_plaintext) { return Vector<uint8_t>(); }
+	virtual Vector<uint8_t> decrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_ciphertext) { return Vector<uint8_t>(); }
+	virtual PackedByteArray hmac_digest(HashingContext::HashType p_hash_type, PackedByteArray p_key, PackedByteArray p_msg) { return PackedByteArray(); }
+};
+
+PackedByteArray raw_to_pba(const uint8_t *arr, size_t len) {
+	PackedByteArray pba;
+	pba.resize(len);
+	for (size_t i = 0; i < len; i++) {
+		pba.set(i, arr[i]);
+	}
+	return pba;
+}
+
+TEST_CASE("[Crypto] PackedByteArray constant time compare") {
+	const uint8_t hm1[] = { 144, 140, 176, 38, 88, 113, 101, 45, 71, 105, 10, 91, 248, 16, 117, 244, 189, 30, 238, 29, 219, 134, 82, 130, 212, 114, 161, 166, 188, 169, 200, 106 };
+	const uint8_t hm2[] = { 80, 30, 144, 228, 108, 38, 188, 125, 150, 64, 165, 127, 221, 118, 144, 232, 45, 100, 15, 248, 193, 244, 245, 34, 116, 147, 132, 200, 110, 27, 38, 75 };
+	PackedByteArray p1 = raw_to_pba(hm1, sizeof(hm1) / sizeof(hm1[0]));
+	PackedByteArray p2 = raw_to_pba(hm2, sizeof(hm2) / sizeof(hm2[0]));
+	_MockCrypto crypto;
+	bool equal = crypto.constant_time_compare(p1, p1);
+	CHECK(equal);
+	equal = crypto.constant_time_compare(p1, p2);
+	CHECK(!equal);
+}
+} // namespace TestCrypto
+
+#endif // TEST_CRYPTO_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -39,6 +39,7 @@
 #include "test_color.h"
 #include "test_command_queue.h"
 #include "test_config_file.h"
+#include "test_crypto.h"
 #include "test_curve.h"
 #include "test_expression.h"
 #include "test_gradient.h"


### PR DESCRIPTION
fixes: https://github.com/godotengine/godot-proposals/issues/1098

Couple different ways to use this. The more low level approach (especially useful for HMACing streamed content:

```gdscript
extends Node

var hmac = HMACContext.new()

func _ready():
	var key = "supersecretkey" # Key can be of any size greater than 0.
	var data = "Return of the MAC!" # Data size can be any size greater than 0 as well.
	hmac.start(HashingContext.HASH_SHA256, key.to_utf8())
	hmac.update(data.to_utf8())
	var digest = hmac.finish()
        print_hex(digest)
```

Or the more high level approach that is going to be most useful 99% of the time:

```gdscript
extends Node

var crypto = Crypto.new()

func _ready():
    var key = "supersecretkey" # Key can be of any size greater than 0.
    var data = "Return of the MAC!" # Data size can be any size greater than 0 as well.
    var digest = crypto.hmac_digest(HashingContext.HASH_SHA256, key.to_utf8(), data.to_utf8())
    print_hex(digest)
```

I've also provided a convenience function for comparing two HMAC digests in a way that is impervious to timing attacks:

```gdscript
extends Node

var crypto = Crypto.new()

func _ready():
    var hm1 # PackedByteArray containing an HMACdigest
    var hm2 # PackedByteArray containing a second HMAC digest
    var equal = crypto.hmac_equals(hm1, hm2)
    print(equal)
````