### PR TITLE
Fix highlight for completion options match

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -256,6 +256,7 @@ struct ScriptCodeCompletionOption {
 	Color font_color;
 	RES icon;
 	Variant default_value;
+	Vector<std::pair<int, int>> matches;
 
 	ScriptCodeCompletionOption() {}
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes https://github.com/godotengine/godot/issues/43551.
Because of the solution I created to find the best intersection (match) to highlight between the option and the written word, where substrings > subsequences. I changed the completion options populate algorithm to prioritize substrings over subsequences.
![completion_new](https://user-images.githubusercontent.com/25207137/99180786-a0367d00-2729-11eb-8766-f7487a1af336.gif)
  
