### PR TITLE
Add 2d snap transforms option

### DIFF
--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -228,6 +228,7 @@ Engine::Engine() {
 	_target_fps = 0;
 	_time_scale = 1.0;
 	_pixel_snap = false;
+	_snap_2d_transforms = false;
 	_physics_frames = 0;
 	_idle_frames = 0;
 	_in_physics = false;

--- a/core/engine.h
+++ b/core/engine.h
@@ -62,6 +62,7 @@ private:
 	int _target_fps;
 	float _time_scale;
 	bool _pixel_snap;
+	bool _snap_2d_transforms;
 	uint64_t _physics_frames;
 	float _physics_interpolation_fraction;
 
@@ -110,6 +111,7 @@ public:
 	Object *get_singleton_object(const String &p_name) const;
 
 	_FORCE_INLINE_ bool get_use_pixel_snap() const { return _pixel_snap; }
+	bool get_snap_2d_transforms() const { return _snap_2d_transforms; }
 
 #ifdef TOOLS_ENABLED
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) { editor_hint = p_enabled; }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1113,6 +1113,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	Engine::get_singleton()->_pixel_snap = GLOBAL_DEF("rendering/quality/2d/use_pixel_snap", false);
+	Engine::get_singleton()->_snap_2d_transforms = GLOBAL_DEF("rendering/quality/2d/use_transform_snap", false);
 	OS::get_singleton()->_keep_screen_on = GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
 	if (rtm == -1) {
 		rtm = GLOBAL_DEF("rendering/threads/thread_model", OS::RENDER_THREAD_SAFE);

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -452,7 +452,7 @@ void AnimatedSprite::_notification(int p_what) {
 			if (centered)
 				ofs -= s / 2;
 
-			if (Engine::get_singleton()->get_use_pixel_snap()) {
+			if (Engine::get_singleton()->get_snap_2d_transforms()) {
 				ofs = ofs.floor();
 			}
 			Rect2 dst_rect(ofs, s);

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -99,7 +99,7 @@ void Sprite::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_cli
 	Point2 dest_offset = offset;
 	if (centered)
 		dest_offset -= frame_size / 2;
-	if (Engine::get_singleton()->get_use_pixel_snap()) {
+	if (Engine::get_singleton()->get_snap_2d_transforms()) {
 		dest_offset = dest_offset.floor();
 	}
 
@@ -378,7 +378,7 @@ Rect2 Sprite::get_rect() const {
 	Point2 ofs = offset;
 	if (centered)
 		ofs -= Size2(s) / 2;
-	if (Engine::get_singleton()->get_use_pixel_snap()) {
+	if (Engine::get_singleton()->get_snap_2d_transforms()) {
 		ofs = ofs.floor();
 	}
 

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -98,7 +98,12 @@ void VisualServerCanvas::_render_canvas_item(Item *p_canvas_item, const Transfor
 	}
 
 	Rect2 rect = ci->get_rect();
-	Transform2D xform = p_transform * ci->xform;
+	Transform2D xform = ci->xform;
+	if (snap_2d_transforms) {
+		xform.elements[2] = xform.elements[2].floor();
+	}
+	xform = p_transform * xform;
+
 	Rect2 global_rect = xform.xform(rect);
 	global_rect.position += p_clip_rect.position;
 
@@ -1477,6 +1482,7 @@ VisualServerCanvas::VisualServerCanvas() {
 	z_last_list = (RasterizerCanvas::Item **)memalloc(z_range * sizeof(RasterizerCanvas::Item *));
 
 	disable_scale = false;
+	snap_2d_transforms = Engine::get_singleton()->get_snap_2d_transforms();
 }
 
 VisualServerCanvas::~VisualServerCanvas() {

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -158,6 +158,7 @@ public:
 	RID_Owner<RasterizerCanvas::Light> canvas_light_owner;
 
 	bool disable_scale;
+	bool snap_2d_transforms;
 
 private:
 	void _render_canvas_item_tree(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RasterizerCanvas::Light *p_lights);


### PR DESCRIPTION
This is a cut-down backport of reduz snapping PR #43194.
It just offers a global project setting for transform snapping.

Fixes #35606
Fixes #41491

## Notes
* These are based on original idea in #41535 by @m6502
* This is a cutdown version of the changes in reduz PR, notably there are no options per viewport, and there is no refactoring to pixel snap
* If desired this can be fleshed out a bit more, but this may do the job

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
