### PR TITLE
[4.0] [iOS] Keyboard input changes

### DIFF
--- a/platform/iphone/SCsub
+++ b/platform/iphone/SCsub
@@ -17,6 +17,7 @@ iphone_lib = [
     "godot_view_renderer.mm",
     "godot_view_gesture_recognizer.mm",
     "device_metrics.m",
+    "keyboard_input_view.mm",
     "native_video_view.m",
 ]
 

--- a/platform/iphone/display_server_iphone.mm
+++ b/platform/iphone/display_server_iphone.mm
@@ -35,6 +35,7 @@
 #import "device_metrics.h"
 #import "godot_view.h"
 #include "ios.h"
+#import "keyboard_input_view.h"
 #import "native_video_view.h"
 #include "os_iphone.h"
 #import "view_controller.h"
@@ -529,11 +530,17 @@ bool DisplayServerIPhone::screen_is_touchscreen(int p_screen) const {
 }
 
 void DisplayServerIPhone::virtual_keyboard_show(const String &p_existing_text, const Rect2 &p_screen_rect, bool p_multiline, int p_max_length, int p_cursor_start, int p_cursor_end) {
-	[AppDelegate.viewController.godotView becomeFirstResponderWithString:p_existing_text];
+	NSString *existingString = [[NSString alloc] initWithUTF8String:p_existing_text.utf8().get_data()];
+
+	[AppDelegate.viewController.keyboardView
+			becomeFirstResponderWithString:existingString
+								 multiline:p_multiline
+							   cursorStart:p_cursor_start
+								 cursorEnd:p_cursor_end];
 }
 
 void DisplayServerIPhone::virtual_keyboard_hide() {
-	[AppDelegate.viewController.godotView resignFirstResponder];
+	[AppDelegate.viewController.keyboardView resignFirstResponder];
 }
 
 void DisplayServerIPhone::virtual_keyboard_set_height(int height) {

--- a/platform/iphone/godot_view.mm
+++ b/platform/iphone/godot_view.mm
@@ -42,7 +42,6 @@ static const int max_touches = 8;
 
 @interface GodotView () {
 	UITouch *godot_touches[max_touches];
-	String keyboard_text;
 }
 
 @property(assign, nonatomic) BOOL isActive;
@@ -277,40 +276,6 @@ static const int max_touches = 8;
 }
 
 // MARK: - Input
-
-// MARK: Keyboard
-
-- (BOOL)canBecomeFirstResponder {
-	return YES;
-}
-
-- (BOOL)becomeFirstResponderWithString:(String)p_existing {
-	keyboard_text = p_existing;
-	return [self becomeFirstResponder];
-}
-
-- (BOOL)resignFirstResponder {
-	keyboard_text = String();
-	return [super resignFirstResponder];
-}
-
-- (void)deleteBackward {
-	if (keyboard_text.length()) {
-		keyboard_text.erase(keyboard_text.length() - 1, 1);
-	}
-	DisplayServerIPhone::get_singleton()->key(KEY_BACKSPACE, true);
-}
-
-- (BOOL)hasText {
-	return keyboard_text.length() > 0;
-}
-
-- (void)insertText:(NSString *)p_text {
-	String character;
-	character.parse_utf8([p_text UTF8String]);
-	keyboard_text = keyboard_text + character;
-	DisplayServerIPhone::get_singleton()->key(character[0] == 10 ? KEY_ENTER : character[0], true);
-}
 
 // MARK: Touches
 

--- a/platform/iphone/keyboard_input_view.h
+++ b/platform/iphone/keyboard_input_view.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  godot_view.h                                                         */
+/*  keyboard_input_view.h                                                */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -30,25 +30,8 @@
 
 #import <UIKit/UIKit.h>
 
-class String;
+@interface GodotKeyboardInputView : UITextView
 
-@protocol DisplayLayer;
-@protocol GodotViewRendererProtocol;
-
-@interface GodotView : UIView
-
-@property(assign, nonatomic) id<GodotViewRendererProtocol> renderer;
-
-@property(assign, readonly, nonatomic) BOOL isActive;
-
-@property(assign, nonatomic) BOOL useCADisplayLink;
-@property(strong, readonly, nonatomic) CALayer<DisplayLayer> *renderingLayer;
-@property(assign, readonly, nonatomic) BOOL canRender;
-
-@property(assign, nonatomic) NSTimeInterval renderingInterval;
-
-- (CALayer<DisplayLayer> *)initializeRenderingForDriver:(NSString *)driverName;
-- (void)stopRendering;
-- (void)startRendering;
+- (BOOL)becomeFirstResponderWithString:(NSString *)existingString multiline:(BOOL)flag cursorStart:(NSInteger)start cursorEnd:(NSInteger)end;
 
 @end

--- a/platform/iphone/keyboard_input_view.mm
+++ b/platform/iphone/keyboard_input_view.mm
@@ -1,0 +1,195 @@
+/*************************************************************************/
+/*  keyboard_input_view.mm                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#import "keyboard_input_view.h"
+
+#include "core/os/keyboard.h"
+#include "display_server_iphone.h"
+#include "os_iphone.h"
+
+@interface GodotKeyboardInputView () <UITextViewDelegate>
+
+@property(nonatomic, copy) NSString *previousText;
+@property(nonatomic, assign) NSRange previousSelectedRange;
+
+@end
+
+@implementation GodotKeyboardInputView
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+	self = [super initWithCoder:coder];
+
+	if (self) {
+		[self godot_commonInit];
+	}
+
+	return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame textContainer:(NSTextContainer *)textContainer {
+	self = [super initWithFrame:frame textContainer:textContainer];
+
+	if (self) {
+		[self godot_commonInit];
+	}
+
+	return self;
+}
+
+- (void)godot_commonInit {
+	self.hidden = YES;
+	self.delegate = self;
+
+	[[NSNotificationCenter defaultCenter] addObserver:self
+											 selector:@selector(observeTextChange:)
+												 name:UITextViewTextDidChangeNotification
+											   object:self];
+}
+
+- (void)dealloc {
+	self.delegate = nil;
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+// MARK: Keyboard
+
+- (BOOL)canBecomeFirstResponder {
+	return YES;
+}
+
+- (BOOL)becomeFirstResponderWithString:(NSString *)existingString multiline:(BOOL)flag cursorStart:(NSInteger)start cursorEnd:(NSInteger)end {
+	self.text = existingString;
+	self.previousText = existingString;
+
+	NSRange textRange;
+
+	// Either a simple cursor or a selection.
+	if (end > 0) {
+		textRange = NSMakeRange(start, end - start);
+	} else {
+		textRange = NSMakeRange(start, 0);
+	}
+
+	self.selectedRange = textRange;
+	self.previousSelectedRange = textRange;
+
+	return [self becomeFirstResponder];
+}
+
+- (BOOL)resignFirstResponder {
+	self.text = nil;
+	self.previousText = nil;
+	return [super resignFirstResponder];
+}
+
+// MARK: OS Messages
+
+- (void)deleteText:(NSInteger)charactersToDelete {
+	for (int i = 0; i < charactersToDelete; i++) {
+		DisplayServerIPhone::get_singleton()->key(KEY_BACKSPACE, true);
+		DisplayServerIPhone::get_singleton()->key(KEY_BACKSPACE, false);
+	}
+}
+
+- (void)enterText:(NSString *)substring {
+	String characters;
+	characters.parse_utf8([substring UTF8String]);
+
+	for (int i = 0; i < characters.size(); i++) {
+		int character = characters[i];
+
+		switch (character) {
+			case 10:
+				character = KEY_ENTER;
+				break;
+			case 8198:
+				character = KEY_SPACE;
+				break;
+			default:
+				break;
+		}
+
+		DisplayServerIPhone::get_singleton()->key(character, true);
+		DisplayServerIPhone::get_singleton()->key(character, false);
+	}
+}
+
+// MARK: Observer
+
+- (void)observeTextChange:(NSNotification *)notification {
+	if (notification.object != self) {
+		return;
+	}
+
+	if (self.previousSelectedRange.length == 0) {
+		// We are deleting all text before cursor if no range was selected.
+		// This way any inserted or changed text will be updated.
+		NSString *substringToDelete = [self.previousText substringToIndex:self.previousSelectedRange.location];
+		[self deleteText:substringToDelete.length];
+	} else {
+		// If text was previously selected
+		// we are sending only one `backspace`.
+		// It will remove all text from text input.
+		[self deleteText:1];
+	}
+
+	NSString *substringToEnter;
+
+	if (self.selectedRange.length == 0) {
+		// If previous cursor had a selection
+		// we have to calculate an inserted text.
+		if (self.previousSelectedRange.length != 0) {
+			NSInteger rangeEnd = self.selectedRange.location + self.selectedRange.length;
+			NSInteger rangeStart = MIN(self.previousSelectedRange.location, self.selectedRange.location);
+			NSInteger rangeLength = MAX(0, rangeEnd - rangeStart);
+
+			NSRange calculatedRange;
+
+			if (rangeLength >= 0) {
+				calculatedRange = NSMakeRange(rangeStart, rangeLength);
+			} else {
+				calculatedRange = NSMakeRange(rangeStart, 0);
+			}
+
+			substringToEnter = [self.text substringWithRange:calculatedRange];
+		} else {
+			substringToEnter = [self.text substringToIndex:self.selectedRange.location];
+		}
+	} else {
+		substringToEnter = [self.text substringWithRange:self.selectedRange];
+	}
+
+	[self enterText:substringToEnter];
+
+	self.previousText = self.text;
+	self.previousSelectedRange = self.selectedRange;
+}
+
+@end

--- a/platform/iphone/view_controller.h
+++ b/platform/iphone/view_controller.h
@@ -32,11 +32,13 @@
 
 @class GodotView;
 @class GodotNativeVideoView;
+@class GodotKeyboardInputView;
 
 @interface ViewController : UIViewController
 
 @property(nonatomic, readonly, strong) GodotView *godotView;
 @property(nonatomic, readonly, strong) GodotNativeVideoView *videoView;
+@property(nonatomic, readonly, strong) GodotKeyboardInputView *keyboardView;
 
 // MARK: Native Video Player
 

--- a/platform/iphone/view_controller.mm
+++ b/platform/iphone/view_controller.mm
@@ -33,6 +33,7 @@
 #include "display_server_iphone.h"
 #import "godot_view.h"
 #import "godot_view_renderer.h"
+#import "keyboard_input_view.h"
 #import "native_video_view.h"
 #include "os_iphone.h"
 
@@ -43,6 +44,7 @@
 
 @property(strong, nonatomic) GodotViewRenderer *renderer;
 @property(strong, nonatomic) GodotNativeVideoView *videoView;
+@property(strong, nonatomic) GodotKeyboardInputView *keyboardView;
 
 @end
 
@@ -102,6 +104,10 @@
 }
 
 - (void)observeKeyboard {
+	printf("******** setting up keyboard input view\n");
+	self.keyboardView = [GodotKeyboardInputView new];
+	[self.view addSubview:self.keyboardView];
+
 	printf("******** adding observer for keyboard show/hide\n");
 	[[NSNotificationCenter defaultCenter]
 			addObserver:self
@@ -119,6 +125,9 @@
 	[self.videoView stopVideo];
 
 	self.videoView = nil;
+
+	self.keyboardView = nil;
+
 	self.renderer = nil;
 
 	[[NSNotificationCenter defaultCenter] removeObserver:self];

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1559,7 +1559,19 @@ void TextEdit::_notification(int p_what) {
 			}
 
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
-				DisplayServer::get_singleton()->virtual_keyboard_show(get_text(), get_global_rect(), true);
+				String text = _base_get_text(0, 0, selection.selecting_line, selection.selecting_column);
+				int cursor_start = text.length();
+				int cursor_end = -1;
+
+				if (selection.active) {
+					String selected_text = _base_get_text(selection.from_line, selection.from_column, selection.to_line, selection.to_column);
+
+					if (selected_text.length() > 0) {
+						cursor_end = cursor_start + selected_text.length();
+					}
+				}
+
+				DisplayServer::get_singleton()->virtual_keyboard_show(get_text(), get_global_rect(), true, -1, cursor_start, cursor_end);
 			}
 		} break;
 		case NOTIFICATION_FOCUS_EXIT: {


### PR DESCRIPTION
Added a `cursor_start` and `cursor_end` parameters for `TextEdit` control.
Changed a way iOS's keyboard is handled by moving handing into separate class. Now it can display suggestions view for languages that require it. This change also allows to receive text changes made by dictation or any other text input method. 

Fixes https://github.com/godotengine/godot/issues/43256 for `master` branch