### PR TITLE
Improved the importer ability to detect colonly and the other markers.

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -237,24 +237,34 @@ String ResourceImporterScene::get_preset_name(int p_idx) const {
 	return "";
 }
 
+bool is_alpha(char32_t p_ch) {
+	return (p_ch >= 'a' && p_ch <= 'z') || (p_ch >= 'A' && p_ch <= 'Z');
+}
+
 static bool _teststr(const String &p_what, const String &p_str) {
 	String what = p_what;
 
-	//remove trailing spaces and numbers, some apps like blender add ".number" to duplicates so also compensate for this
-	while (what.length() && ((what[what.length() - 1] >= '0' && what[what.length() - 1] <= '9') || what[what.length() - 1] <= 32 || what[what.length() - 1] == '.')) {
-		what = what.substr(0, what.length() - 1);
+	int pos = p_what.findn(p_str);
+
+	if (pos < 0) {
+		return false;
 	}
 
-	if (what.findn("$" + p_str) != -1) { //blender and other stuff
-		return true;
+	if (pos > 0) {
+		const char32_t character = p_what.get(pos - 1);
+		if (is_alpha(character)) {
+			return false;
+		}
 	}
-	if (what.to_lower().ends_with("-" + p_str)) { //collada only supports "_" and "-" besides letters
-		return true;
+
+	if (pos + p_str.length() < p_what.length()) {
+		const char32_t character = p_what.get(pos + p_str.length());
+		if (is_alpha(character)) {
+			return false;
+		}
 	}
-	if (what.to_lower().ends_with("_" + p_str)) { //collada only supports "_" and "-" besides letters
-		return true;
-	}
-	return false;
+
+	return true;
 }
 
 static String _fixstr(const String &p_what, const String &p_str) {


### PR DESCRIPTION
Improved the importer ability to detect `colonly` and the other markers.

Depending on how the scene is composed in blender a different naming convention is used, so the markers `colonly`, `col`, `convcolonly`, `noimport` are not always detected.

For example, blender map my meshes in this way: `Box001|Cube|Dupli|2` and `Box001|Collisin-colonly|Dupli|2`

This PR enhance the detection algorithm. Now it finds the marker and make sure that there are no letters around it.
This allow to always detects the markers and never miss detect it.