### PR TITLE
Clarify Curve3D.get_point_{in,out} position in doc.

### DIFF
--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -80,7 +80,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns the position of the control point leading to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position of the control point leading to the vertex [code]idx[/code]. The returned position is relative to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_out" qualifiers="const">
@@ -89,7 +89,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns the position of the control point leading out of the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position of the control point leading out of the vertex [code]idx[/code]. The returned position is relative to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">
@@ -152,7 +152,7 @@
 			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<description>
-				Sets the position of the control point leading to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console.
+				Sets the position of the control point leading to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
 			</description>
 		</method>
 		<method name="set_point_out">
@@ -163,7 +163,7 @@
 			<argument index="1" name="position" type="Vector2">
 			</argument>
 			<description>
-				Sets the position of the control point leading out of the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console.
+				Sets the position of the control point leading out of the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
 			</description>
 		</method>
 		<method name="set_point_position">

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -95,7 +95,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns the position of the control point leading to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position of the control point leading to the vertex [code]idx[/code]. The returned position is relative to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_out" qualifiers="const">
@@ -104,7 +104,7 @@
 			<argument index="0" name="idx" type="int">
 			</argument>
 			<description>
-				Returns the position of the control point leading out of the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position of the control point leading out of the vertex [code]idx[/code]. The returned position is relative to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">
@@ -189,7 +189,7 @@
 			<argument index="1" name="position" type="Vector3">
 			</argument>
 			<description>
-				Sets the position of the control point leading to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console.
+				Sets the position of the control point leading to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
 			</description>
 		</method>
 		<method name="set_point_out">
@@ -200,7 +200,7 @@
 			<argument index="1" name="position" type="Vector3">
 			</argument>
 			<description>
-				Sets the position of the control point leading out of the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console.
+				Sets the position of the control point leading out of the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
 			</description>
 		</method>
 		<method name="set_point_position">


### PR DESCRIPTION
I verified this experimentally. I added a point at roughly (1,0,0), and
dragged a handle back to the origin. The result was:

```
get_point_position: (0.991079, 0, -0.000069)
get_point_in: (0.993409, 0, 0)
get_point_out: (-0.993409, 0, 0)
```


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->