### PR TITLE
Remove property groups for Pause Mode and Script

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -597,9 +597,6 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 	_get_property_listv(p_list, p_reversed);
 
 	if (!is_class("Script")) { // can still be set, but this is for userfriendlyness
-#ifdef TOOLS_ENABLED
-		p_list->push_back(PropertyInfo(Variant::NIL, "Script", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
-#endif
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT));
 	}
 	if (!metadata.empty()) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2889,7 +2889,6 @@ void Node::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("tree_exiting"));
 	ADD_SIGNAL(MethodInfo("tree_exited"));
 
-	ADD_GROUP("Pause", "pause_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "pause_mode", PROPERTY_HINT_ENUM, "Inherit,Stop,Process"), "set_pause_mode", "get_pause_mode");
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "name", PROPERTY_HINT_NONE, "", 0), "set_name", "get_name");


### PR DESCRIPTION
Each of those only grouped 1 property, making them useless.

This closes https://github.com/godotengine/godot-proposals/issues/1840.

## Preview

![image](https://user-images.githubusercontent.com/180032/99188394-ff14ea00-275b-11eb-8a06-fb5070f45108.png)