### PR TITLE
Added get_peer_ping method to the ENet module

### DIFF
--- a/modules/enet/networked_multiplayer_enet.cpp
+++ b/modules/enet/networked_multiplayer_enet.cpp
@@ -799,8 +799,8 @@ void NetworkedMultiplayerENet::enet_compressor_destroy(void *context) {
 
 IP_Address NetworkedMultiplayerENet::get_peer_address(int p_peer_id) const {
 
-	ERR_FAIL_COND_V_MSG(!peer_map.has(p_peer_id), IP_Address(), vformat("Peer ID %d not found in the list of peers.", p_peer_id));
 	ERR_FAIL_COND_V_MSG(!is_server() && p_peer_id != 1, IP_Address(), "Can't get the address of peers other than the server (ID -1) when acting as a client.");
+	ERR_FAIL_COND_V_MSG(!peer_map.has(p_peer_id), IP_Address(), vformat("Peer ID %d not found in the list of peers.", p_peer_id));
 	ERR_FAIL_COND_V_MSG(peer_map[p_peer_id] == NULL, IP_Address(), vformat("Peer ID %d found in the list of peers, but is null.", p_peer_id));
 
 	IP_Address out;
@@ -815,14 +815,22 @@ IP_Address NetworkedMultiplayerENet::get_peer_address(int p_peer_id) const {
 
 int NetworkedMultiplayerENet::get_peer_port(int p_peer_id) const {
 
-	ERR_FAIL_COND_V_MSG(!peer_map.has(p_peer_id), 0, vformat("Peer ID %d not found in the list of peers.", p_peer_id));
 	ERR_FAIL_COND_V_MSG(!is_server() && p_peer_id != 1, 0, "Can't get the address of peers other than the server (ID -1) when acting as a client.");
+	ERR_FAIL_COND_V_MSG(!peer_map.has(p_peer_id), 0, vformat("Peer ID %d not found in the list of peers.", p_peer_id));
 	ERR_FAIL_COND_V_MSG(peer_map[p_peer_id] == NULL, 0, vformat("Peer ID %d found in the list of peers, but is null.", p_peer_id));
 #ifdef GODOT_ENET
 	return peer_map[p_peer_id]->address.port;
 #else
 	return peer_map[p_peer_id]->address.port;
 #endif
+}
+
+int NetworkedMultiplayerENet::get_peer_ping(int p_peer_id) const {
+
+	ERR_FAIL_COND_V_MSG(!is_server() && p_peer_id != 1, 0, "Can't get the ping of peers other than the server (ID -1) when acting as a client.");
+	ERR_FAIL_COND_V_MSG(!peer_map.has(p_peer_id), 0, vformat("Peer ID %d not found in the list of peers.", p_peer_id));
+	ERR_FAIL_COND_V_MSG(peer_map[p_peer_id] == NULL, 0, vformat("Peer ID %d found in the list of peers, but is null.", p_peer_id));
+	return peer_map[p_peer_id]->lowestRoundTripTime;
 }
 
 void NetworkedMultiplayerENet::set_transfer_channel(int p_channel) {
@@ -882,6 +890,7 @@ void NetworkedMultiplayerENet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_dtls_verify_enabled"), &NetworkedMultiplayerENet::is_dtls_verify_enabled);
 	ClassDB::bind_method(D_METHOD("get_peer_address", "id"), &NetworkedMultiplayerENet::get_peer_address);
 	ClassDB::bind_method(D_METHOD("get_peer_port", "id"), &NetworkedMultiplayerENet::get_peer_port);
+	ClassDB::bind_method(D_METHOD("get_peer_ping", "id"), &NetworkedMultiplayerENet::get_peer_ping);
 
 	ClassDB::bind_method(D_METHOD("get_packet_channel"), &NetworkedMultiplayerENet::get_packet_channel);
 	ClassDB::bind_method(D_METHOD("get_last_packet_channel"), &NetworkedMultiplayerENet::get_last_packet_channel);

--- a/modules/enet/networked_multiplayer_enet.h
+++ b/modules/enet/networked_multiplayer_enet.h
@@ -130,6 +130,8 @@ public:
 	virtual IP_Address get_peer_address(int p_peer_id) const;
 	virtual int get_peer_port(int p_peer_id) const;
 
+	virtual int get_peer_ping(int p_peer_id) const;
+
 	Error create_server(int p_port, int p_max_clients = 32, int p_in_bandwidth = 0, int p_out_bandwidth = 0);
 	Error create_client(const String &p_address, int p_port, int p_in_bandwidth = 0, int p_out_bandwidth = 0, int p_client_port = 0);
 


### PR DESCRIPTION
There was no functionality to get a peer's ping.
The server can get a peer's ping using the peer's id.
A client can only get the server's ping calling the method with id=1.

Additionally I changed the order of some ERR_FAIL_COND_V_MSG; checking
if a peer is in the list of peers before checking if the peer is the
server only generates error messages related to the former while the new
ordering allows the programmer to directly spot the mistake.