### PR TITLE
sprite_3d.cpp: return _is_playing() from public is_playing() function

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1037,7 +1037,7 @@ void AnimatedSprite3D::stop() {
 }
 
 bool AnimatedSprite3D::is_playing() const {
-	return is_processing();
+	return playing;
 }
 
 void AnimatedSprite3D::_reset_timeout() {


### PR DESCRIPTION
**Godot version:**
3.2.3-stable


**OS/device including version:**
Windows 10 / Android


**Issue description:**
The `is_playing()` getter in the `AnimatedSprite3D` class should return the `playing` bool. However, it returns the `Node::is_processing` function instead, which may not always be the same as `playing`. Instead, I think it should be returning the result of the private `AnimatedSprite3D::_is_playing` function to give the expected behaviour.


**Steps to reproduce:**
Create an `AnimatedSprite3d` with an animation. In the `_process` function, print something if `is_playing()`. Nothing is printed.