### PR TITLE
Fixed exit code retrieval of spawned processes on Windows

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -466,8 +466,10 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 	ERR_FAIL_COND_V(ret == 0, ERR_CANT_FORK);
 
 	if (p_blocking) {
-		DWORD ret2 = WaitForSingleObject(pi.pi.hProcess, INFINITE);
+		WaitForSingleObject(pi.pi.hProcess, INFINITE);
 		if (r_exitcode) {
+			DWORD ret2;
+			GetExitCodeProcess(pi.pi.hProcess, &ret2);
 			*r_exitcode = ret2;
 		}
 


### PR DESCRIPTION
The current implementation assumed that `WaitForSingleObject` returns the exit code of the run command, but according to the [docs ](https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject#return-value) it returns 1 of 4 fixed values indicating the event that caused the function to return (which is not the exit code of the program).

I never used the Windows API, but the [GetExitCodeProcess ](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess) functions is probably what we need here. I tested this with various different commands and it works as expected. As i said im not familiar at all with the Windows API, so feel free to correct me if there is a bettter way to do this.

Fixes #43580