### PR TITLE
Make CSharpScript::reload search through loaded assemblies if it couldn't find the class through the scripts metadata

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -3365,9 +3365,10 @@ Error CSharpScript::reload(bool p_keep_state) {
 			if (klass && CACHED_CLASS(GodotObject)->is_assignable_from(klass)) {
 				script_class = klass;
 			}
-		} else {
-			// Missing script metadata. Fallback to legacy method
-			script_class = project_assembly->get_object_derived_class(name);
+		}
+		if (!script_class) {
+			// Missing script metadata or unable to find before. Fallback to searching loaded assemblies
+			script_class = GDMono::get_singleton()->find_object_derived_class(name);
 		}
 
 		valid = script_class != nullptr;

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -1209,6 +1209,25 @@ GDMonoClass *GDMono::get_class(const StringName &p_namespace, const StringName &
 	return nullptr;
 }
 
+GDMonoClass *GDMono::find_object_derived_class(const StringName &p_name) {
+
+    const uint32_t *k = nullptr;
+    while ((k = assemblies.next(k))) {
+        HashMap<String, GDMonoAssembly *> &domain_assemblies = assemblies.get(*k);
+
+        const String *kk = nullptr;
+        while ((kk = domain_assemblies.next(kk))) {
+            GDMonoAssembly *assembly = domain_assemblies.get(*kk);
+            
+            GDMonoClass *klass = assembly->get_object_derived_class(p_name); 
+            if (klass) {
+                return klass;
+            }
+        }
+    }
+    return nullptr;
+}
+
 void GDMono::_domain_assemblies_cleanup(int32_t p_domain_id) {
 	HashMap<String, GDMonoAssembly *> &domain_assemblies = assemblies[p_domain_id];
 

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -228,6 +228,8 @@ public:
 
 	GDMonoClass *get_class(MonoClass *p_raw_class);
 	GDMonoClass *get_class(const StringName &p_namespace, const StringName &p_name);
+	
+	GDMonoClass *find_object_derived_class(const StringName &p_name);
 
 #ifdef GD_MONO_HOT_RELOAD
 	Error reload_scripts_domain();


### PR DESCRIPTION
Otherwise, classes from assemblies loaded later on (such as for [mods](https://docs.godotengine.org/en/stable/getting_started/workflow/export/exporting_pcks.html)) can't be used as scenes because they can't be found.

I don't think this will properly differentiate between `NamespaceA.MyClass` and `NamespaceB.MyClass`, but I don't think that currently works anyways from what I saw? Not sure on that though.

I don't know if there's a better way of doing this. Maybe outputting scripts metadata when exporting a pck and then merging it with the existing one when loading a pck?

I tested this on the 3.2.3-stable with my current project and then cherry picked onto master and made some adjustments (mainly I noticed the code uses `nullptr` instead of `NULL` now). Let me know if I missed something or need to make some other changes.