### PR TITLE
Add a local rotation function to `Transform3D` 

### DIFF
--- a/core/math/transform.cpp
+++ b/core/math/transform.cpp
@@ -66,6 +66,10 @@ Transform Transform::rotated(const Vector3 &p_axis, real_t p_phi) const {
 	return Transform(Basis(p_axis, p_phi), Vector3()) * (*this);
 }
 
+Transform Transform::rotated_local(const Vector3 &p_axis, real_t p_phi) const {
+	return Transform(Basis(p_axis, p_phi) * this->basis, this->origin);
+}
+
 void Transform::rotate_basis(const Vector3 &p_axis, real_t p_phi) {
 	basis.rotate(p_axis, p_phi);
 }

--- a/core/math/transform.h
+++ b/core/math/transform.h
@@ -47,6 +47,7 @@ public:
 	Transform affine_inverse() const;
 
 	Transform rotated(const Vector3 &p_axis, real_t p_phi) const;
+	Transform rotated_local(const Vector3 &p_axis, real_t p_phi) const;
 
 	void rotate(const Vector3 &p_axis, real_t p_phi);
 	void rotate_basis(const Vector3 &p_axis, real_t p_phi);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1245,6 +1245,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform, affine_inverse, sarray(), varray());
 	bind_method(Transform, orthonormalized, sarray(), varray());
 	bind_method(Transform, rotated, sarray("axis", "phi"), varray());
+	bind_method(Transform, rotated_local, sarray("axis", "phi"), varray());
 	bind_method(Transform, scaled, sarray("scale"), varray());
 	bind_method(Transform, translated, sarray("offset"), varray());
 	bind_method(Transform, looking_at, sarray("target", "up"), varray());

--- a/doc/classes/Transform.xml
+++ b/doc/classes/Transform.xml
@@ -168,7 +168,18 @@
 			<argument index="1" name="phi" type="float">
 			</argument>
 			<description>
-				Rotates the transform around the given axis by the given angle (in radians), using matrix multiplication. The axis must be a normalized vector.
+				Rotates the transform about the origin around the given axis by the given angle (in radians), using matrix multiplication. The axis must be a normalized vector.
+			</description>
+		</method>
+		<method name="rotated_local">
+			<return type="Transform">
+			</return>
+			<argument index="0" name="axis" type="Vector3">
+			</argument>
+			<argument index="1" name="phi" type="float">
+			</argument>
+			<description>
+				Rotates the transform in-place around the given axis by the given angle (in radians), using matrix multiplication. The axis must be a normalized vector.
 			</description>
 		</method>
 		<method name="scaled">

--- a/tests/test_math.h
+++ b/tests/test_math.h
@@ -31,6 +31,7 @@
 #ifndef TEST_MATH_H
 #define TEST_MATH_H
 
+#include "core/math/math_defs.h"
 #include "core/math/math_funcs.h"
 #include "core/math/transform.h"
 #include "core/os/os.h"
@@ -45,8 +46,6 @@ namespace TestMath {
 MainLoop *test();
 }
 
-const float FM_PI = 3.1415926535897932384626433832795028841971693993751f;
-
 TEST_CASE("[Transform] Rotate around global origin") {
 	// Start with the default orientation, but not centered on the origin.
 	// Rotating should rotate both our basis and the origin.
@@ -58,8 +57,8 @@ TEST_CASE("[Transform] Rotate around global origin") {
 	expected.basis.set_axis(0, Vector3(-1, 0, 0));
 	expected.basis.set_axis(2, Vector3(0, 0, -1));
 
-	Transform rotatedTransform = transform.rotated(Vector3(0, 1, 0), FM_PI);
-	REQUIRE(rotatedTransform.is_equal_approx(expected));
+	Transform rotated_transform = transform.rotated(Vector3(0, 1, 0), Math_PI);
+	REQUIRE(rotated_transform.is_equal_approx(expected));
 }
 
 TEST_CASE("[Transform] Rotate in-place") {
@@ -73,10 +72,10 @@ TEST_CASE("[Transform] Rotate in-place") {
 	expected.basis.set_axis(0, Vector3(-1, 0, 0));
 	expected.basis.set_axis(2, Vector3(0, 0, -1));
 
-	Transform rotated_transform = transform.rotated_local(Vector3(0, 1, 0), FM_PI);
+	Transform rotated_transform = transform.rotated_local(Vector3(0, 1, 0), Math_PI);
 	REQUIRE(rotated_transform.is_equal_approx(expected));
 
-	// Make sure that the rotatedTransform isn't sharing references with the original transform.
+	// Make sure that the rotated transform isn't sharing references with the original transform.
 	REQUIRE(&rotated_transform.basis != &transform.basis);
 	REQUIRE(&rotated_transform.origin != &transform.origin);
 }

--- a/tests/test_math.h
+++ b/tests/test_math.h
@@ -31,8 +31,8 @@
 #ifndef TEST_MATH_H
 #define TEST_MATH_H
 
-#include "core/math/transform.h"
 #include "core/math/math_funcs.h"
+#include "core/math/transform.h"
 #include "core/os/os.h"
 
 #include <math.h>

--- a/tests/test_math.h
+++ b/tests/test_math.h
@@ -54,9 +54,9 @@ TEST_CASE("[Transform] Rotate around global origin") {
 	transform.origin = Vector3(0, 0, 1);
 
 	Transform expected = Transform();
-	expected.origin = Vector3(1, 0, 0);
-	expected.basis.set_axis(0, Vector3(0, 0, 1));
-	expected.basis.set_axis(2, Vector3(-1, 0, 0));
+	expected.origin = Vector3(0, 0, -1);
+	expected.basis.set_axis(0, Vector3(-1, 0, 0));
+	expected.basis.set_axis(2, Vector3(0, 0, -1));
 
 	Transform rotatedTransform = transform.rotated(Vector3(0, 1, 0), FM_PI);
 	REQUIRE(rotatedTransform.is_equal_approx(expected));
@@ -64,14 +64,14 @@ TEST_CASE("[Transform] Rotate around global origin") {
 
 TEST_CASE("[Transform] Rotate in-place") {
 	//Start with the default orientation, but not centered on the origin.
-	//Rotating should rotate both our basis and the origin.
+	//Rotating in-place should only rotate the basis, leaving the origin alone.
 	Transform transform = Transform();
 	transform.origin = Vector3(0, 0, 1);
 
 	Transform expected = Transform();
 	expected.origin = Vector3(0, 0, 1);
-	expected.basis.set_axis(0, Vector3(0, 0, 1));
-	expected.basis.set_axis(2, Vector3(-1, 0, 0));
+	expected.basis.set_axis(0, Vector3(-1, 0, 0));
+	expected.basis.set_axis(2, Vector3(0, 0, -1));
 
 	Transform rotatedTransform = transform.rotated_local(Vector3(0, 1, 0), FM_PI);
 	REQUIRE(rotatedTransform.is_equal_approx(expected));

--- a/tests/test_math.h
+++ b/tests/test_math.h
@@ -48,8 +48,8 @@ MainLoop *test();
 const float FM_PI = 3.1415926535897932384626433832795028841971693993751f;
 
 TEST_CASE("[Transform] Rotate around global origin") {
-	//Start with the default orientation, but not centered on the origin.
-	//Rotating should rotate both our basis and the origin.
+	// Start with the default orientation, but not centered on the origin.
+	// Rotating should rotate both our basis and the origin.
 	Transform transform = Transform();
 	transform.origin = Vector3(0, 0, 1);
 
@@ -63,8 +63,8 @@ TEST_CASE("[Transform] Rotate around global origin") {
 }
 
 TEST_CASE("[Transform] Rotate in-place") {
-	//Start with the default orientation, but not centered on the origin.
-	//Rotating in-place should only rotate the basis, leaving the origin alone.
+	// Start with the default orientation, but not centered on the origin.
+	// Rotating in-place should only rotate the basis, leaving the origin alone.
 	Transform transform = Transform();
 	transform.origin = Vector3(0, 0, 1);
 
@@ -73,12 +73,12 @@ TEST_CASE("[Transform] Rotate in-place") {
 	expected.basis.set_axis(0, Vector3(-1, 0, 0));
 	expected.basis.set_axis(2, Vector3(0, 0, -1));
 
-	Transform rotatedTransform = transform.rotated_local(Vector3(0, 1, 0), FM_PI);
-	REQUIRE(rotatedTransform.is_equal_approx(expected));
+	Transform rotated_transform = transform.rotated_local(Vector3(0, 1, 0), FM_PI);
+	REQUIRE(rotated_transform.is_equal_approx(expected));
 
-	//Make sure that the rotatedTransform isn't sharing references with the original transform.
-	REQUIRE(&rotatedTransform.basis != &transform.basis);
-	REQUIRE(&rotatedTransform.origin != &transform.origin);
+	// Make sure that the rotatedTransform isn't sharing references with the original transform.
+	REQUIRE(&rotated_transform.basis != &transform.basis);
+	REQUIRE(&rotated_transform.origin != &transform.origin);
 }
 
 #endif

--- a/tests/test_math.h
+++ b/tests/test_math.h
@@ -31,11 +31,54 @@
 #ifndef TEST_MATH_H
 #define TEST_MATH_H
 
-#include "core/os/main_loop.h"
+#include "core/math/transform.h"
+#include "core/math/math_funcs.h"
+#include "core/os/os.h"
+
+#include <math.h>
+#include <stdio.h>
+
+#include "tests/test_macros.h"
 
 namespace TestMath {
 
 MainLoop *test();
+}
+
+const float FM_PI = 3.1415926535897932384626433832795028841971693993751f;
+
+TEST_CASE("[Transform] Rotate around global origin") {
+	//Start with the default orientation, but not centered on the origin.
+	//Rotating should rotate both our basis and the origin.
+	Transform transform = Transform();
+	transform.origin = Vector3(0, 0, 1);
+
+	Transform expected = Transform();
+	expected.origin = Vector3(1, 0, 0);
+	expected.basis.set_axis(0, Vector3(0, 0, 1));
+	expected.basis.set_axis(2, Vector3(-1, 0, 0));
+
+	Transform rotatedTransform = transform.rotated(Vector3(0, 1, 0), FM_PI);
+	REQUIRE(rotatedTransform.is_equal_approx(expected));
+}
+
+TEST_CASE("[Transform] Rotate in-place") {
+	//Start with the default orientation, but not centered on the origin.
+	//Rotating should rotate both our basis and the origin.
+	Transform transform = Transform();
+	transform.origin = Vector3(0, 0, 1);
+
+	Transform expected = Transform();
+	expected.origin = Vector3(0, 0, 1);
+	expected.basis.set_axis(0, Vector3(0, 0, 1));
+	expected.basis.set_axis(2, Vector3(-1, 0, 0));
+
+	Transform rotatedTransform = transform.rotated_local(Vector3(0, 1, 0), FM_PI);
+	REQUIRE(rotatedTransform.is_equal_approx(expected));
+
+	//Make sure that the rotatedTransform isn't sharing references with the original transform.
+	REQUIRE(&rotatedTransform.basis != &transform.basis);
+	REQUIRE(&rotatedTransform.origin != &transform.origin);
 }
 
 #endif


### PR DESCRIPTION
Implements proposal 1778: https://github.com/godotengine/godot-proposals/issues/1788

Adds a new `rotated_local` function to `Transform`, usable in GDScript. This makes it more clear that the `Transform.rotated` function will change `Transform.origin`. 

I'm not 100% sure that `rotated_local` is the best name for the new function.

<i>Bugsquad edit</i>: Fix https://github.com/godotengine/godot-proposals/issues/1788