### PR TITLE
Fix crash in resoure duplicate

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -209,8 +209,8 @@ Ref<Resource> Resource::duplicate(bool p_subresources) const {
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
 
-	Resource *r = (Resource *)ClassDB::instance(get_class());
-	ERR_FAIL_COND_V(!r, Ref<Resource>());
+	Ref<Resource> r = (Resource *)ClassDB::instance(get_class());
+	ERR_FAIL_COND_V(r.is_null(), Ref<Resource>());
 
 	for (List<PropertyInfo>::Element *E = plist.front(); E; E = E->next()) {
 		if (!(E->get().usage & PROPERTY_USAGE_STORAGE)) {
@@ -230,7 +230,7 @@ Ref<Resource> Resource::duplicate(bool p_subresources) const {
 		}
 	}
 
-	return Ref<Resource>(r);
+	return r;
 }
 
 void Resource::_set_path(const String &p_path) {


### PR DESCRIPTION
Let's recap:
- #43049 made `Variant` behave correctly in 3.2 regarding tracking the ref. count of `Reference`s.
- That was explained in #43225, but since that's considered what should happen, the goal is to fix incorrect usages in the C++ side.
- We were aware of two cases. One was fixed in #43460. The other one is fixed here (was reported in-context at https://github.com/godotengine/godot/pull/43049#issuecomment-717145180; there's no specific numbered bug to be closed).
- If we find other similar issues, we'll fix them individually.

Since this closes all the issues unveiled by #43225 we are aware so far, I'm closing it.