### PR TITLE
Add missing javascript semi-colons.

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -320,7 +320,7 @@
 						throw new Error('Invalid status mode');
 				}
 				statusMode = mode;
-			}
+			};
 
 			function animateStatusIndeterminate(ms) {
 				var i = Math.floor(ms / INDETERMINATE_STATUS_STEP_MS % 8);

--- a/platform/javascript/native/audio.worklet.js
+++ b/platform/javascript/native/audio.worklet.js
@@ -45,7 +45,7 @@ class RingBuffer {
 
 	read(output) {
 		const size = this.buffer.length;
-		let from = 0
+		let from = 0;
 		let to_write = output.length;
 		if (this.rpos + to_write > size) {
 			const high = size - this.rpos;
@@ -150,7 +150,7 @@ class GodotProcessor extends AudioWorkletProcessor {
 			const output = outputs[0];
 			const chunk = output[0].length * output.length;
 			if (this.output_buffer.length != chunk) {
-				this.output_buffer = new Float32Array(chunk)
+				this.output_buffer = new Float32Array(chunk);
 			}
 			if (this.output.data_left() >= chunk) {
 				this.output.read(this.output_buffer);


### PR DESCRIPTION
As identified by [LGTM](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=javascript&severity=recommendation&ruleFocus=4860080), #42789 and #43443 introduced a lot of new code and missed a few semi-colons. This PR adds those semi-colons.
