### PR TITLE
Fix godot_js_websocket_send function unused assignment.

### DIFF
--- a/modules/websocket/library_godot_websocket.js
+++ b/modules/websocket/library_godot_websocket.js
@@ -162,10 +162,8 @@ var GodotWebSocket = {
 		for(i = 0; i < p_buf_len; i++) {
 			bytes_array[i] = getValue(p_buf + i, 'i8');
 		}
-		var out = bytes_array;
-		if (p_raw) {
-			out = bytes_array.buffer;
-		} else {
+		var out = bytes_array.buffer;
+		if (!p_raw) {
 			out = new TextDecoder("utf-8").decode(bytes_array);
 		}
 		return GodotWebSocket.send(p_id, out);


### PR DESCRIPTION
As identified by [LGTM](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=javascript&ruleFocus=7900088&severity=warning), the new `GodotWebSocket` `send` function has an unused assignment:
https://github.com/godotengine/godot/blob/c56a071d0c6e282dbb82aa7e69691e33f6c2fd7e/modules/websocket/library_godot_websocket.js#L165-L171
This PR removes the unused assignment.
