### PR TITLE
[C#] Added vector constructors to allow create them from one scalar

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -582,6 +582,16 @@ namespace Godot
         }
 
         /// <summary>
+        /// Constructs a new <see cref="Vector2"/> from a single value assigned to all components.
+        /// </summary>
+        /// <param name="xy">The value to assign to all components.</param>
+        public Vector2(real_t xy)
+        {
+            x = xy;
+            y = xy;
+        }
+
+        /// <summary>
         /// Constructs a new <see cref="Vector2"/> from an existing <see cref="Vector2"/>.
         /// </summary>
         /// <param name="v">The existing <see cref="Vector2"/>.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -310,6 +310,16 @@ namespace Godot
         }
 
         /// <summary>
+        /// Constructs a new <see cref="Vector2i"/> from a single value assigned to all components.
+        /// </summary>
+        /// <param name="xy">The value to assign to all components.</param>
+        public Vector2i(int xy)
+        {
+            x = xy;
+            y = xy;
+        }
+
+        /// <summary>
         /// Constructs a new <see cref="Vector2i"/> from an existing <see cref="Vector2i"/>.
         /// </summary>
         /// <param name="vi">The existing <see cref="Vector2i"/>.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -611,6 +611,17 @@ namespace Godot
         }
 
         /// <summary>
+        /// Constructs a new <see cref="Vector3"/> from a single value assigned to all components.
+        /// </summary>
+        /// <param name="xyz">The value to assign to all components.</param>
+        public Vector3(real_t xyz)
+        {
+            x = xyz;
+            y = xyz;
+            z = xyz;
+        }
+
+        /// <summary>
         /// Constructs a new <see cref="Vector3"/> from an existing <see cref="Vector3"/>.
         /// </summary>
         /// <param name="v">The existing <see cref="Vector3"/>.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
@@ -282,6 +282,17 @@ namespace Godot
         }
 
         /// <summary>
+        /// Constructs a new <see cref="Vector3i"/> from a single value assigned to all components.
+        /// </summary>
+        /// <param name="xyz">The value to assign to all components.</param>
+        public Vector3i(int xyz)
+        {
+            x = xyz;
+            y = xyz;
+            z = xyz;
+        }
+
+        /// <summary>
         /// Constructs a new <see cref="Vector3i"/> from an existing <see cref="Vector3i"/>.
         /// </summary>
         /// <param name="vi">The existing <see cref="Vector3i"/>.</param>


### PR DESCRIPTION
Allows to create a vector like:

`var v = new Vector2i(64); // 64x64 vector declaration`

I know it's a syntax sugar but I found it's useful for myself.