### PR TITLE
Use Vector2i instead of Vector2 for Image get_pixelv and set_pixelv

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2766,8 +2766,8 @@ Dictionary Image::_get_data() const {
 	return d;
 }
 
-Color Image::get_pixelv(const Point2 &p_src) const {
-	return get_pixel(p_src.x, p_src.y);
+Color Image::get_pixelv(const Point2i &p_point) const {
+	return get_pixel(p_point.x, p_point.y);
 }
 
 Color Image::_get_color_at_ofs(const uint8_t *ptr, uint32_t ofs) const {
@@ -2976,8 +2976,8 @@ Color Image::get_pixel(int p_x, int p_y) const {
 	return _get_color_at_ofs(data.ptr(), ofs);
 }
 
-void Image::set_pixelv(const Point2 &p_dst, const Color &p_color) {
-	set_pixel(p_dst.x, p_dst.y, p_color);
+void Image::set_pixelv(const Point2i &p_point, const Color &p_color) {
+	set_pixel(p_point.x, p_point.y, p_color);
 }
 
 void Image::set_pixel(int p_x, int p_y, const Color &p_color) {
@@ -3132,9 +3132,9 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_data", "data"), &Image::_set_data);
 	ClassDB::bind_method(D_METHOD("_get_data"), &Image::_get_data);
 
-	ClassDB::bind_method(D_METHOD("get_pixelv", "src"), &Image::get_pixelv);
+	ClassDB::bind_method(D_METHOD("get_pixelv", "point"), &Image::get_pixelv);
 	ClassDB::bind_method(D_METHOD("get_pixel", "x", "y"), &Image::get_pixel);
-	ClassDB::bind_method(D_METHOD("set_pixelv", "dst", "color"), &Image::set_pixelv);
+	ClassDB::bind_method(D_METHOD("set_pixelv", "point", "color"), &Image::set_pixelv);
 	ClassDB::bind_method(D_METHOD("set_pixel", "x", "y", "color"), &Image::set_pixel);
 
 	ClassDB::bind_method(D_METHOD("load_png_from_buffer", "buffer"), &Image::load_png_from_buffer);

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -387,9 +387,9 @@ public:
 	UsedChannels detect_used_channels(CompressSource p_source = COMPRESS_SOURCE_GENERIC);
 	void optimize_channels();
 
-	Color get_pixelv(const Point2 &p_src) const;
+	Color get_pixelv(const Point2i &p_point) const;
 	Color get_pixel(int p_x, int p_y) const;
-	void set_pixelv(const Point2 &p_dst, const Color &p_color);
+	void set_pixelv(const Point2i &p_point, const Color &p_color);
 	void set_pixel(int p_x, int p_y, const Color &p_color);
 
 	void set_as_black();

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -269,16 +269,18 @@
 			<argument index="1" name="y" type="int">
 			</argument>
 			<description>
-				Returns the color of the pixel at [code](x, y)[/code]. This is the same as [method get_pixelv], but with two integer arguments instead of a [Vector2] argument.
+				Returns the color of the pixel at [code](x, y)[/code].
+				This is the same as [method get_pixelv], but with two integer arguments instead of a [Vector2i] argument.
 			</description>
 		</method>
 		<method name="get_pixelv" qualifiers="const">
 			<return type="Color">
 			</return>
-			<argument index="0" name="src" type="Vector2">
+			<argument index="0" name="point" type="Vector2i">
 			</argument>
 			<description>
-				Returns the color of the pixel at [code]src[/code]. This is the same as [method get_pixel], but with a [Vector2] argument instead of two integer arguments.
+				Returns the color of the pixel at [code]point[/code].
+				This is the same as [method get_pixel], but with a [Vector2i] argument instead of two integer arguments.
 			</description>
 		</method>
 		<method name="get_rect" qualifiers="const">
@@ -475,28 +477,56 @@
 			<argument index="2" name="color" type="Color">
 			</argument>
 			<description>
-				Sets the [Color] of the pixel at [code](x, y)[/code]. Example:
-				[codeblock]
+				Sets the [Color] of the pixel at [code](x, y)[/code] to [code]color[/code]. Example:
+				[codeblocks]
+				[gdscript]
+				var img_width = 10
+				var img_height = 5
 				var img = Image.new()
 				img.create(img_width, img_height, false, Image.FORMAT_RGBA8)
-				img.set_pixel(x, y, color)
-				[/codeblock]
+
+				img.set_pixel(1, 2, Color.red) # Sets the color at (1, 2) to red.
+				[/gdscript]
+				[csharp]
+				int imgWidth = 10;
+				int imgHeight = 5;
+				var img = new Image();
+				img.Create(imgWidth, imgHeight, false, Image.Format.Rgba8);
+
+				img.SetPixel(1, 2, Colors.Red); // Sets the color at (1, 2) to red.
+				[/csharp]
+				[/codeblocks]
+				This is the same as [method set_pixelv], but with a two integer arguments instead of a [Vector2i] argument.
 			</description>
 		</method>
 		<method name="set_pixelv">
 			<return type="void">
 			</return>
-			<argument index="0" name="dst" type="Vector2">
+			<argument index="0" name="point" type="Vector2i">
 			</argument>
 			<argument index="1" name="color" type="Color">
 			</argument>
 			<description>
-				Sets the [Color] of the pixel at [code](dst.x, dst.y)[/code]. Note that the [code]dst[/code] values must be integers. Example:
-				[codeblock]
+				Sets the [Color] of the pixel at [code]point[/code] to [code]color[/code]. Example:
+				[codeblocks]
+				[gdscript]
+				var img_width = 10
+				var img_height = 5
 				var img = Image.new()
 				img.create(img_width, img_height, false, Image.FORMAT_RGBA8)
-				img.set_pixelv(Vector2(x, y), color)
-				[/codeblock]
+
+				img.set_pixelv(Vector2i(1, 2), Color.red) # Sets the color at (1, 2) to red.
+				[/gdscript]
+				[csharp]
+				int imgWidth = 10;
+				int imgHeight = 5;
+				var img = new Image();
+				img.Create(imgWidth, imgHeight, false, Image.Format.Rgba8);
+
+				img.SetPixelv(new Vector2i(1, 2), Colors.Red); // Sets the color at (1, 2) to red.
+				[/csharp]
+				[/codeblocks]
+				This is the same as [method set_pixel], but with a [Vector2i] argument instead of two integer arguments.
 			</description>
 		</method>
 		<method name="shrink_x2">

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -97,7 +97,7 @@ Error ResourceImporterTextureAtlas::import(const String &p_source_file, const St
 	return OK;
 }
 
-static void _plot_triangle(Vector2 *vertices, const Vector2 &p_offset, bool p_transposed, Ref<Image> p_image, const Ref<Image> &p_src_image) {
+static void _plot_triangle(Vector2i *vertices, const Vector2i &p_offset, bool p_transposed, Ref<Image> p_image, const Ref<Image> &p_src_image) {
 	int width = p_image->get_width();
 	int height = p_image->get_height();
 	int src_width = p_src_image->get_width();
@@ -281,13 +281,13 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 		for (int j = 0; j < pack_data.chart_pieces.size(); j++) {
 			const EditorAtlasPacker::Chart &chart = charts[pack_data.chart_pieces[j]];
 			for (int k = 0; k < chart.faces.size(); k++) {
-				Vector2 positions[3];
+				Vector2i positions[3];
 				for (int l = 0; l < 3; l++) {
 					int vertex_idx = chart.faces[k].vertex[l];
-					positions[l] = chart.vertices[vertex_idx];
+					positions[l] = Vector2i(chart.vertices[vertex_idx]);
 				}
 
-				_plot_triangle(positions, chart.final_offset, chart.transposed, new_atlas, pack_data.image);
+				_plot_triangle(positions, Vector2i(chart.final_offset), chart.transposed, new_atlas, pack_data.image);
 			}
 		}
 	}


### PR DESCRIPTION
Since Vector2i is now available, we should use it for APIs that currently accept two ints. These methods previously had Vector2 versions, so they were converted to Vector2i. The int versions are kept in parallel in this case.