### PR TITLE
Ignore query to maximize/minimize window on Windows and X11

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2269,6 +2269,10 @@ bool OS_Windows::is_window_resizable() const {
 }
 void OS_Windows::set_window_minimized(bool p_enabled) {
 
+	if (is_no_window_mode_enabled()) {
+		return;
+	}
+
 	if (p_enabled) {
 		maximized = false;
 		minimized = true;
@@ -2284,6 +2288,10 @@ bool OS_Windows::is_window_minimized() const {
 	return minimized;
 }
 void OS_Windows::set_window_maximized(bool p_enabled) {
+
+	if (is_no_window_mode_enabled()) {
+		return;
+	}
 
 	if (p_enabled) {
 		maximized = true;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -1518,6 +1518,9 @@ bool OS_X11::is_window_resizable() const {
 }
 
 void OS_X11::set_window_minimized(bool p_enabled) {
+	if (is_no_window_mode_enabled()) {
+		return;
+	}
 	// Using ICCCM -- Inter-Client Communication Conventions Manual
 	XEvent xev;
 	Atom wm_change = XInternAtom(x11_display, "WM_CHANGE_STATE", False);
@@ -1581,6 +1584,9 @@ bool OS_X11::is_window_minimized() const {
 }
 
 void OS_X11::set_window_maximized(bool p_enabled) {
+	if (is_no_window_mode_enabled()) {
+		return;
+	}
 	if (is_window_maximized() == p_enabled)
 		return;
 


### PR DESCRIPTION
This makes these platform behave as MacOS in that regard and also fixes the editor window appearing in some cases even when `--no-window` has been passed.

Fixes #43598.

(The problem was that on Windows, to maximize or minimize, you call `ShowWindow()` and that resets the hidden state and at startup, if no `--windowed` has been specified, the window is maximized. I've anyway added the same check to X11, where it was probably not needed, for consistency, since it already was in MacOS.)