### PR TITLE
Fixes rotation in select mode on macOS

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1513,7 +1513,7 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 	// Start rotation
 	if (drag_type == DRAG_NONE) {
 		if (b.is_valid() && b->get_button_index() == BUTTON_LEFT && b->is_pressed()) {
-			if ((b->get_control() && !b->get_alt() && tool == TOOL_SELECT) || tool == TOOL_ROTATE) {
+			if ((b->get_command() && !b->get_alt() && tool == TOOL_SELECT) || tool == TOOL_ROTATE) {
 				List<CanvasItem *> selection = _get_edited_canvas_items();
 
 				// Remove not movable nodes


### PR DESCRIPTION
This PR fixes rotation in select mode (Command+Drag) on macOS.

Command+Drag did not work because it was checking for Control+Drag. And Control+LMB does not work either because that's interpreted as RMB on macOS.

Tested on the current master (bfed10185a) and 3.2 branch (545931545).