### PR TITLE
glTF: Workaround import failure with invalid embedded images

### DIFF
--- a/editor/import/editor_scene_importer_gltf.cpp
+++ b/editor/import/editor_scene_importer_gltf.cpp
@@ -1304,12 +1304,14 @@ Error EditorSceneImporterGLTF::_parse_images(GLTFState &state, const String &p_b
 			String uri = d["uri"];
 
 			if (uri.begins_with("data:")) { // Embedded data using base64.
-				// Validate data MIME types and throw an error if it's one we don't know/support.
+				// Validate data MIME types and throw a warning if it's one we don't know/support.
 				if (!uri.begins_with("data:application/octet-stream;base64") &&
 						!uri.begins_with("data:application/gltf-buffer;base64") &&
 						!uri.begins_with("data:image/png;base64") &&
 						!uri.begins_with("data:image/jpeg;base64")) {
-					ERR_PRINT("glTF: Got image data with an unknown URI data type: " + uri);
+					WARN_PRINT(vformat("glTF: Image index '%d' uses an unsupported URI data type: %s. Skipping it.", i, uri));
+					state.images.push_back(Ref<Texture2D>()); // Placeholder to keep count.
+					continue;
 				}
 				data = _parse_base64_uri(uri);
 				data_ptr = data.ptr();
@@ -1344,7 +1346,8 @@ Error EditorSceneImporterGLTF::_parse_images(GLTFState &state, const String &p_b
 			}
 		} else if (d.has("bufferView")) {
 			// Handles the third bullet point from the spec (bufferView).
-			ERR_FAIL_COND_V_MSG(mimetype.empty(), ERR_FILE_CORRUPT, "glTF: Image specifies 'bufferView' but no 'mimeType', which is invalid.");
+			ERR_FAIL_COND_V_MSG(mimetype.empty(), ERR_FILE_CORRUPT,
+					vformat("glTF: Image index '%d' specifies 'bufferView' but no 'mimeType', which is invalid.", i));
 
 			const GLTFBufferViewIndex bvi = d["bufferView"];
 
@@ -1381,7 +1384,8 @@ Error EditorSceneImporterGLTF::_parse_images(GLTFState &state, const String &p_b
 			}
 		}
 
-		ERR_FAIL_COND_V_MSG(img.is_null(), ERR_FILE_CORRUPT, "glTF: Couldn't load image with its given mimetype: " + mimetype);
+		ERR_FAIL_COND_V_MSG(img.is_null(), ERR_FILE_CORRUPT,
+				vformat("glTF: Couldn't load image index '%d' with its given mimetype: %s.", i, mimetype));
 
 		Ref<ImageTexture> t;
 		t.instance();


### PR DESCRIPTION
image/gif is not supported in the glTF 2.0 specification,
these files are broken. But let's be lenient...

Fixes #43638.

---

I chose not to rework the other `ERR_FAIL` conditions as it would make things quite convoluted and eventually, I can't guarantee that the imported file will be useful if we have to skip entries each time they're bogus. For images with wrong mime type it should be OK I guess.