### PR TITLE
Batching - blank UVs in polys that contain no UVs

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -1621,6 +1621,8 @@ bool C_PREAMBLE::_prefill_polygon(RasterizerCanvas::Item::CommandPolygon *p_poly
 			if (ind < p_poly->uvs.size()) {
 				const Point2 &uv = p_poly->uvs[ind];
 				bvs[n].uv.set(uv.x, uv.y);
+			} else {
+				bvs[n].uv.set(0.0f, 0.0f);
 			}
 
 			vertex_colors[n] = precalced_colors[ind];
@@ -1756,6 +1758,8 @@ PREAMBLE(bool)::_software_skin_poly(RasterizerCanvas::Item::CommandPolygon *p_po
 		if (ind < p_poly->uvs.size()) {
 			const Point2 &uv = p_poly->uvs[ind];
 			bvs[n].uv.set(uv.x, uv.y);
+		} else {
+			bvs[n].uv.set(0.0f, 0.0f);
 		}
 
 		vertex_colors[n] = p_precalced_colors[ind];


### PR DESCRIPTION
Polys that have no texture assigned contain no UVs in the poly command. These were previously not blanked, leading to random values if read from a custom shader.

This PR just blanks them.

Fixes #43637

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
