### PR TITLE
Fix return type on builtin validated calls

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -123,6 +123,31 @@ static _FORCE_INLINE_ void vc_ptrcall(void (T::*method)(P...) const, void *p_bas
 }
 
 template <class R, class T, class... P>
+static _FORCE_INLINE_ void vc_change_return_type(R (T::*method)(P...), Variant *v) {
+	TypeAdjust<R>::adjust(v);
+}
+
+template <class R, class T, class... P>
+static _FORCE_INLINE_ void vc_change_return_type(R (T::*method)(P...) const, Variant *v) {
+	TypeAdjust<R>::adjust(v);
+}
+
+template <class T, class... P>
+static _FORCE_INLINE_ void vc_change_return_type(void (T::*method)(P...), Variant *v) {
+	VariantInternal::clear(v);
+}
+
+template <class T, class... P>
+static _FORCE_INLINE_ void vc_change_return_type(void (T::*method)(P...) const, Variant *v) {
+	VariantInternal::clear(v);
+}
+
+template <class R, class... P>
+static _FORCE_INLINE_ void vc_change_return_type(R (*method)(P...), Variant *v) {
+	TypeAdjust<R>::adjust(v);
+}
+
+template <class R, class T, class... P>
 static _FORCE_INLINE_ int vc_get_argument_count(R (T::*method)(P...)) {
 	return sizeof...(P);
 }
@@ -258,7 +283,7 @@ static _FORCE_INLINE_ Variant::Type vc_get_base_type(void (T::*method)(P...) con
 			vc_method_call(m_method_ptr, base, p_args, p_argcount, r_ret, p_defvals, r_error);                                                                    \
 		}                                                                                                                                                         \
 		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) {                                                       \
-			TypeAdjust<m_class>::adjust(r_ret);                                                                                                                   \
+			vc_change_return_type(m_method_ptr, r_ret);                                                                                                           \
 			vc_validated_call(m_method_ptr, base, p_args, r_ret);                                                                                                 \
 		}                                                                                                                                                         \
 		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) {                                                                     \
@@ -301,7 +326,7 @@ static _FORCE_INLINE_ void vc_ptrcall(R (*method)(T *, P...), void *p_base, cons
 			call_with_variant_args_retc_static_helper_dv(VariantGetInternalPtr<m_class>::get_ptr(base), m_method_ptr, p_args, p_argcount, r_ret, p_defvals, r_error); \
 		}                                                                                                                                                             \
 		static void validated_call(Variant *base, const Variant **p_args, int p_argcount, Variant *r_ret) {                                                           \
-			TypeAdjust<m_class>::adjust(r_ret);                                                                                                                       \
+			vc_change_return_type(m_method_ptr, r_ret);                                                                                                               \
 			call_with_validated_variant_args_static_retc(base, m_method_ptr, p_args, r_ret);                                                                          \
 		}                                                                                                                                                             \
 		static void ptrcall(void *p_base, const void **p_args, void *r_ret, int p_argcount) {                                                                         \


### PR DESCRIPTION
Before it was being set to the base type instead of the actual return type.
