### PR TITLE
Add a signal for detecting action toggle states (pressed/released) in `Input`

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -209,7 +209,7 @@ void Input::_bind_methods() {
 	BIND_ENUM_CONSTANT(CURSOR_HSPLIT);
 	BIND_ENUM_CONSTANT(CURSOR_HELP);
 
-	ADD_SIGNAL(MethodInfo("action_state_changed", PropertyInfo(Variant::STRING, "action"), PropertyInfo(Variant::BOOL, "pressed")));
+	ADD_SIGNAL(MethodInfo("action_toggled", PropertyInfo(Variant::STRING, "action"), PropertyInfo(Variant::BOOL, "pressed")));
 	ADD_SIGNAL(MethodInfo("joy_connection_changed", PropertyInfo(Variant::INT, "device"), PropertyInfo(Variant::BOOL, "connected")));
 }
 
@@ -652,7 +652,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 				action.strength = 0.0f;
 				action.raw_strength = 0.0f;
 				action_state[E->key()] = action;
-				emit_signal("action_state_changed", E->key(), action.pressed);
+				emit_signal("action_toggled", E->key(), action.pressed);
 			}
 			action_state[E->key()].strength = p_event->get_action_strength(E->key());
 			action_state[E->key()].raw_strength = p_event->get_action_raw_strength(E->key());

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -209,6 +209,7 @@ void Input::_bind_methods() {
 	BIND_ENUM_CONSTANT(CURSOR_HSPLIT);
 	BIND_ENUM_CONSTANT(CURSOR_HELP);
 
+	ADD_SIGNAL(MethodInfo("action_state_changed", PropertyInfo(Variant::STRING, "action"), PropertyInfo(Variant::BOOL, "pressed")));
 	ADD_SIGNAL(MethodInfo("joy_connection_changed", PropertyInfo(Variant::INT, "device"), PropertyInfo(Variant::BOOL, "connected")));
 }
 
@@ -651,6 +652,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 				action.strength = 0.0f;
 				action.raw_strength = 0.0f;
 				action_state[E->key()] = action;
+				emit_signal("action_state_changed", E->key(), action.pressed);
 			}
 			action_state[E->key()].strength = p_event->get_action_strength(E->key());
 			action_state[E->key()].raw_strength = p_event->get_action_raw_strength(E->key());

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -249,6 +249,7 @@ protected:
 
 	Map<int, VibrationInfo> joy_vibration;
 
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
Closes godotengine/godot-proposals#1853.

![image](https://user-images.githubusercontent.com/17108460/99542332-9b3c2c80-29ba-11eb-9c7e-f546d19c0aed.png)

Documentation and further improvements can be written later, if the feature is desired/approved.

## To-do:
- [x] Rename signal to `action_toggled`: https://github.com/godotengine/godot/pull/43646#issuecomment-730253012.
- [x] Emit signals per action: https://github.com/godotengine/godot/pull/43646#issuecomment-731573721.
- [ ] Emit signal upon `action_press` and `action_release` methods as well.
- [ ] Define a new signal name in `CoreStringNames` for signal, to optimize for performance somewhat with `StringName` usage.
- [ ] Write documentation.

Works for those "just" pressed/released events. Will also emit signal while simulating action presses.

With GDScript 2.0:
```gdscript
extends Node2D

func _ready():
	Input.action_toggled.connect(Callable(self, "_on_action_toggled"))

func _on_action_toggled(action, pressed):
	if pressed:
		print("Action pressed: " + str(action))
	else:
		print("Action released: " + str(action))

```