### PR TITLE
Fix crash duplicating local-to-scene resources

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -147,8 +147,8 @@ Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Res
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
 
-	Resource *r = Object::cast_to<Resource>(ClassDB::instance(get_class()));
-	ERR_FAIL_COND_V(!r, Ref<Resource>());
+	Ref<Resource> r = Object::cast_to<Resource>(ClassDB::instance(get_class()));
+	ERR_FAIL_COND_V(r.is_null(), Ref<Resource>());
 
 	r->local_scene = p_for_scene;
 
@@ -175,9 +175,7 @@ Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Res
 		r->set(E->get().name, p);
 	}
 
-	RES res = Ref<Resource>(r);
-
-	return res;
+	return r;
 }
 
 void Resource::configure_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, Ref<Resource>> &remap_cache) {


### PR DESCRIPTION
With some luck, this is the last case of crashes caused by `Variant` being more clever about `References`.

Striving for that to be true, I've checked all the cases in 3.2 and 4.0 where an arbitrary class is instantiated via `ClassDB` to ensure the obtained `Resource`, if that's the case, is early wrapped by a `Ref` if it's meant be assigned to a `Variant`. I haven't found any other case, but I may have overlooked some, of course.

Fixes #43652.