### PR TITLE
Made serialization of Command toggleable when saving InputEvents.

### DIFF
--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -209,6 +209,8 @@ public:
 class InputEventWithModifiers : public InputEventFromWindow {
 	GDCLASS(InputEventWithModifiers, InputEventFromWindow);
 
+	bool store_command = true;
+
 	bool shift = false;
 	bool alt = false;
 #ifdef APPLE_STYLE_KEYS
@@ -228,8 +230,12 @@ class InputEventWithModifiers : public InputEventFromWindow {
 
 protected:
 	static void _bind_methods();
+	virtual void _validate_property(PropertyInfo &property) const override;
 
 public:
+	void set_store_command(bool p_enabled);
+	bool is_storing_command() const;
+
 	void set_shift(bool p_enabled);
 	bool get_shift() const;
 

--- a/doc/classes/InputEventWithModifiers.xml
+++ b/doc/classes/InputEventWithModifiers.xml
@@ -27,6 +27,10 @@
 		<member name="shift" type="bool" setter="set_shift" getter="get_shift" default="false">
 			State of the [kbd]Shift[/kbd] modifier.
 		</member>
+		<member name="store_command" type="bool" setter="set_store_command" getter="is_storing_command" default="true">
+			If [code]true[/code], pressing [kbd]Cmd[/kbd] on macOS or [kbd]Ctrl[/kbd] on all other platforms will both be serialized as [member command]. If [code]false[/code], those same keys will be serialized as [member meta] on macOS and [member control] on all other platforms.
+			This aids with cross-platform compatibility when developing e.g. on Windows for macOS, or vice-versa.
+		</member>
 	</members>
 	<constants>
 	</constants>


### PR DESCRIPTION
Made serialization of Command optional. If command is serialized, Control (On Win/Linux) or Meta (on Mac) are not.
Example use case: You are on Windows and you set a shortcut to be Control + E. Currently, this would serialize as Command=true and Control=true. If you then run this project on Mac, you would need to press Command AND Control to activate the shortcut - which is not what is intended. Now, you can set store_command to true, and it will only serialize to Command = true (no Control serialized). On Windows, this means Control. On Mac, it means only command.

This was discussed at length with Reduz on IRC, and he seemed happy with this solution. Closes #42351 in some ways... but doesn't fully close it until a UI is created to actually change this option in the editor.

This is the third PR of a larger series based on #42600. In this PR, there is no UI to allow users to edit this setting. This comes in a later PR. This is the InputEvent implementation only.

