### PR TITLE
Remove hardcoded shortcuts from /scene and instead use the input action system to allow them to be customised.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -32,6 +32,7 @@
 
 #include "core/core_bind.h"
 #include "core/core_string_names.h"
+#include "core/input/input_map.h"
 #include "core/io/file_access_network.h"
 #include "core/io/file_access_pack.h"
 #include "core/io/marshalls.h"
@@ -1057,16 +1058,34 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save_custom", "file"), &ProjectSettings::_save_custom_bnd);
 }
 
+void ProjectSettings::_add_builtin_input_map() {
+	if (InputMap::get_singleton()) {
+		OrderedHashMap<String, List<Ref<InputEvent>>> builtins = InputMap::get_singleton()->get_builtins();
+
+		for (OrderedHashMap<String, List<Ref<InputEvent>>>::Element E = builtins.front(); E; E = E.next()) {
+			Array events;
+
+			// Convert list of input events into array
+			for (List<Ref<InputEvent>>::Element *I = E.get().front(); I; I = I->next()) {
+				events.push_back(I->get());
+			}
+
+			Dictionary action;
+			action["deadzone"] = Variant(0.5f);
+			action["events"] = events;
+
+			String action_name = "input/" + E.key();
+			GLOBAL_DEF(action_name, action);
+			input_presets.push_back(action_name);
+		}
+	}
+}
+
 ProjectSettings::ProjectSettings() {
 	// Initialization of engine variables should be done in the setup() method,
 	// so that the values can be overridden from project.godot or project.binary.
 
 	singleton = this;
-
-	Array events;
-	Dictionary action;
-	Ref<InputEventKey> key;
-	Ref<InputEventJoypadButton> joyb;
 
 	GLOBAL_DEF_BASIC("application/config/name", "");
 	GLOBAL_DEF_BASIC("application/config/description", "");
@@ -1094,163 +1113,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("editor/script/templates_search_path", "res://script_templates");
 	custom_prop_info["editor/script/templates_search_path"] = PropertyInfo(Variant::STRING, "editor/script/templates_search_path", PROPERTY_HINT_DIR);
 
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_ENTER);
-	events.push_back(key);
-	key.instance();
-	key->set_keycode(KEY_KP_ENTER);
-	events.push_back(key);
-	key.instance();
-	key->set_keycode(KEY_SPACE);
-	events.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_BUTTON_A);
-	events.push_back(joyb);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_accept", action);
-	input_presets.push_back("input/ui_accept");
-
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_SPACE);
-	events.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_BUTTON_Y);
-	events.push_back(joyb);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_select", action);
-	input_presets.push_back("input/ui_select");
-
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_ESCAPE);
-	events.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_BUTTON_B);
-	events.push_back(joyb);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_cancel", action);
-	input_presets.push_back("input/ui_cancel");
-
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_TAB);
-	events.push_back(key);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_focus_next", action);
-	input_presets.push_back("input/ui_focus_next");
-
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_TAB);
-	key->set_shift(true);
-	events.push_back(key);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_focus_prev", action);
-	input_presets.push_back("input/ui_focus_prev");
-
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_LEFT);
-	events.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_BUTTON_DPAD_LEFT);
-	events.push_back(joyb);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_left", action);
-	input_presets.push_back("input/ui_left");
-
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_RIGHT);
-	events.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_BUTTON_DPAD_RIGHT);
-	events.push_back(joyb);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_right", action);
-	input_presets.push_back("input/ui_right");
-
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_UP);
-	events.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_BUTTON_DPAD_UP);
-	events.push_back(joyb);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_up", action);
-	input_presets.push_back("input/ui_up");
-
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_DOWN);
-	events.push_back(key);
-	joyb.instance();
-	joyb->set_button_index(JOY_BUTTON_DPAD_DOWN);
-	events.push_back(joyb);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_down", action);
-	input_presets.push_back("input/ui_down");
-
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_PAGEUP);
-	events.push_back(key);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_page_up", action);
-	input_presets.push_back("input/ui_page_up");
-
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_PAGEDOWN);
-	events.push_back(key);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_page_down", action);
-	input_presets.push_back("input/ui_page_down");
-
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_HOME);
-	events.push_back(key);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_home", action);
-	input_presets.push_back("input/ui_home");
-
-	action = Dictionary();
-	action["deadzone"] = Variant(0.5f);
-	events = Array();
-	key.instance();
-	key->set_keycode(KEY_END);
-	events.push_back(key);
-	action["events"] = events;
-	GLOBAL_DEF("input/ui_end", action);
-	input_presets.push_back("input/ui_end");
+	_add_builtin_input_map();
 
 	custom_prop_info["display/window/handheld/orientation"] = PropertyInfo(Variant::STRING, "display/window/handheld/orientation", PROPERTY_HINT_ENUM, "landscape,portrait,reverse_landscape,reverse_portrait,sensor_landscape,sensor_portrait,sensor");
 	custom_prop_info["rendering/driver/threads/thread_model"] = PropertyInfo(Variant::INT, "rendering/driver/threads/thread_model", PROPERTY_HINT_ENUM, "Single-Unsafe,Single-Safe,Multi-Threaded");

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -116,6 +116,9 @@ protected:
 
 	Error _setup(const String &p_path, const String &p_main_pack, bool p_upwards = false);
 
+	void _add_builtin_input_map();
+
+protected:
 	static void _bind_methods();
 
 public:

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -604,21 +604,21 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 		}
 	}
 
-	for (const Map<StringName, InputMap::Action>::Element *E = InputMap::get_singleton()->get_action_map().front(); E; E = E->next()) {
-		if (InputMap::get_singleton()->event_is_action(p_event, E->key())) {
+	for (OrderedHashMap<StringName, InputMap::Action>::ConstElement E = InputMap::get_singleton()->get_action_map().front(); E; E = E.next()) {
+		if (InputMap::get_singleton()->event_is_action(p_event, E.key())) {
 			// If not echo and action pressed state has changed
-			if (!p_event->is_echo() && is_action_pressed(E->key(), false) != p_event->is_action_pressed(E->key())) {
+			if (!p_event->is_echo() && is_action_pressed(E.key(), false) != p_event->is_action_pressed(E.key())) {
 				Action action;
 				action.physics_frame = Engine::get_singleton()->get_physics_frames();
 				action.process_frame = Engine::get_singleton()->get_process_frames();
-				action.pressed = p_event->is_action_pressed(E->key());
+				action.pressed = p_event->is_action_pressed(E.key());
 				action.strength = 0.0f;
 				action.raw_strength = 0.0f;
-				action.exact = InputMap::get_singleton()->event_is_action(p_event, E->key(), true);
-				action_state[E->key()] = action;
+				action.exact = InputMap::get_singleton()->event_is_action(p_event, E.key(), true);
+				action_state[E.key()] = action;
 			}
-			action_state[E->key()].strength = p_event->get_action_strength(E->key());
-			action_state[E->key()].raw_strength = p_event->get_action_raw_strength(E->key());
+			action_state[E.key()].strength = p_event->get_action_strength(E.key());
+			action_state[E.key()].raw_strength = p_event->get_action_raw_strength(E.key());
 		}
 	}
 

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -384,6 +384,31 @@ String InputEventKey::to_string() {
 	return vformat("InputEventKey: keycode=%s mods=%s physical=%s pressed=%s echo=%s", kc, mods, physical, p, e);
 }
 
+Ref<InputEventKey> InputEventKey::create_reference(uint32_t p_keycode) {
+	Ref<InputEventKey> ie;
+	ie.instance();
+	ie->set_keycode(p_keycode & KEY_CODE_MASK);
+	ie->set_unicode(p_keycode & KEY_CODE_MASK);
+
+	if (p_keycode & KEY_MASK_SHIFT) {
+		ie->set_shift(true);
+	}
+	if (p_keycode & KEY_MASK_ALT) {
+		ie->set_alt(true);
+	}
+	if (p_keycode & KEY_MASK_CTRL) {
+		ie->set_control(true);
+	}
+	if (p_keycode & KEY_MASK_CMD) {
+		ie->set_command(true);
+	}
+	if (p_keycode & KEY_MASK_META) {
+		ie->set_metakey(true);
+	}
+
+	return ie;
+}
+
 bool InputEventKey::action_match(const Ref<InputEvent> &p_event, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const {
 	Ref<InputEventKey> key = p_event;
 	if (key.is_null()) {
@@ -1009,6 +1034,14 @@ String InputEventJoypadButton::as_text() const {
 
 String InputEventJoypadButton::to_string() {
 	return "InputEventJoypadButton : button_index=" + itos(button_index) + ", pressed=" + (pressed ? "true" : "false") + ", pressure=" + String(Variant(pressure));
+}
+
+Ref<InputEventJoypadButton> InputEventJoypadButton::create_reference(int p_btn_index) {
+	Ref<InputEventJoypadButton> ie;
+	ie.instance();
+	ie->set_button_index(p_btn_index);
+
+	return ie;
 }
 
 void InputEventJoypadButton::_bind_methods() {

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -260,6 +260,8 @@ public:
 	virtual String as_text() const override;
 	virtual String to_string() override;
 
+	static Ref<InputEventKey> create_reference(uint32_t p_keycode_with_modifier_masks);
+
 	InputEventKey() {}
 };
 
@@ -405,6 +407,8 @@ public:
 	virtual bool is_action_type() const override { return true; }
 	virtual String as_text() const override;
 	virtual String to_string() override;
+
+	static Ref<InputEventJoypadButton> create_reference(int p_btn_index);
 
 	InputEventJoypadButton() {}
 };

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -443,6 +443,10 @@ const OrderedHashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs.push_back(InputEventKey::create_reference(KEY_SPACE | KEY_MASK_CMD));
 	default_builtin_cache.insert("ui_text_completion_query", inputs);
 
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(KEY_TAB));
+	default_builtin_cache.insert("ui_text_completion_accept", inputs);
+
 	// Newlines
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(KEY_ENTER));

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -33,6 +33,8 @@
 
 #include "core/input/input_event.h"
 #include "core/object/class_db.h"
+#include "core/object/object.h"
+#include "core/templates/ordered_hash_map.h"
 
 class InputMap : public Object {
 	GDCLASS(InputMap, Object);
@@ -52,7 +54,8 @@ public:
 private:
 	static InputMap *singleton;
 
-	mutable Map<StringName, Action> input_map;
+	mutable OrderedHashMap<StringName, Action> input_map;
+	OrderedHashMap<String, List<Ref<InputEvent>>> default_builtin_cache;
 
 	List<Ref<InputEvent>>::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool p_exact_match = false, bool *p_pressed = nullptr, float *p_strength = nullptr, float *p_raw_strength = nullptr) const;
 
@@ -81,9 +84,13 @@ public:
 	bool event_is_action(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match = false) const;
 	bool event_get_action_status(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match = false, bool *p_pressed = nullptr, float *p_strength = nullptr, float *p_raw_strength = nullptr) const;
 
-	const Map<StringName, Action> &get_action_map() const;
+	const OrderedHashMap<StringName, Action> &get_action_map() const;
 	void load_from_project_settings();
 	void load_default();
+
+	String get_builtin_display_name(const String &p_name) const;
+	// Use an Ordered Map so insertion order is preserved. We want the elements to be 'grouped' somewhat.
+	const OrderedHashMap<String, List<Ref<InputEvent>>> &get_builtins();
 
 	InputMap();
 };

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6215,8 +6215,8 @@ EditorNode::EditorNode() {
 	pm_export->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
 
 	p->add_separator();
-	p->add_shortcut(ED_SHORTCUT("editor/undo", TTR("Undo"), KEY_MASK_CMD + KEY_Z), EDIT_UNDO, true);
-	p->add_shortcut(ED_SHORTCUT("editor/redo", TTR("Redo"), KEY_MASK_CMD + KEY_MASK_SHIFT + KEY_Z), EDIT_REDO, true);
+	p->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO, true);
+	p->add_shortcut(ED_GET_SHORTCUT("ui_redo"), EDIT_REDO, true);
 
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("editor/reload_saved_scene", TTR("Reload Saved Scene")), EDIT_RELOAD_SAVED_SCENE);

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -84,7 +84,8 @@ private:
 	int last_order;
 
 	Ref<Resource> clipboard;
-	Map<String, Ref<Shortcut>> shortcuts;
+	mutable Map<String, Ref<Shortcut>> shortcuts;
+	Map<String, List<Ref<InputEvent>>> builtin_action_overrides;
 
 	String resource_path;
 	String settings_dir;
@@ -185,6 +186,9 @@ public:
 	bool is_shortcut(const String &p_name, const Ref<InputEvent> &p_event) const;
 	Ref<Shortcut> get_shortcut(const String &p_name) const;
 	void get_shortcut_list(List<String> *r_shortcuts);
+
+	void set_builtin_action_override(const String &p_name, const Array &p_events);
+	const Array get_builtin_action_overrides(const String &p_name) const;
 
 	void notify_changes();
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1066,7 +1066,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				return;
 			}
 
-			tx->indent_left();
+			tx->indent_selected_lines_left();
 		} break;
 		case EDIT_INDENT_RIGHT: {
 			Ref<Script> scr = script;
@@ -1074,7 +1074,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				return;
 			}
 
-			tx->indent_right();
+			tx->indent_selected_lines_right();
 		} break;
 		case EDIT_DELETE_LINE: {
 			code_editor->delete_lines();
@@ -1632,16 +1632,16 @@ void ScriptTextEditor::_color_changed(const Color &p_color) {
 
 void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color, bool p_foldable, bool p_open_docs, bool p_goto_definition, Vector2 p_pos) {
 	context_menu->clear();
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/undo"), EDIT_UNDO);
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/redo"), EDIT_REDO);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_redo"), EDIT_REDO);
 
 	context_menu->add_separator();
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/cut"), EDIT_CUT);
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/copy"), EDIT_COPY);
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/paste"), EDIT_PASTE);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE);
 
 	context_menu->add_separator();
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/select_all"), EDIT_SELECT_ALL);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_text_select_all"), EDIT_SELECT_ALL);
 
 	context_menu->add_separator();
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent_left"), EDIT_INDENT_LEFT);
@@ -1743,14 +1743,14 @@ void ScriptTextEditor::_enable_code_editor() {
 	search_menu->get_popup()->connect("id_pressed", callable_mp(this, &ScriptTextEditor::_edit_option));
 
 	edit_hb->add_child(edit_menu);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/undo"), EDIT_UNDO);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/redo"), EDIT_REDO);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_redo"), EDIT_REDO);
 	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/cut"), EDIT_CUT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/copy"), EDIT_COPY);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/paste"), EDIT_PASTE);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE);
 	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/select_all"), EDIT_SELECT_ALL);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_select_all"), EDIT_SELECT_ALL);
 	edit_menu->get_popup()->add_separator();
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_up"), EDIT_MOVE_LINE_UP);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_down"), EDIT_MOVE_LINE_DOWN);
@@ -1763,7 +1763,7 @@ void ScriptTextEditor::_enable_code_editor() {
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/unfold_all_lines"), EDIT_UNFOLD_ALL_LINES);
 	edit_menu->get_popup()->add_separator();
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/clone_down"), EDIT_CLONE_DOWN);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/complete_symbol"), EDIT_COMPLETE);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_completion_query"), EDIT_COMPLETE);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/evaluate_selection"), EDIT_EVALUATE);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/trim_trailing_whitespace"), EDIT_TRIM_TRAILING_WHITESAPCE);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_spaces"), EDIT_CONVERT_INDENT_TO_SPACES);
@@ -1915,12 +1915,6 @@ static ScriptEditorBase *create_editor(const RES &p_resource) {
 }
 
 void ScriptTextEditor::register_editor() {
-	ED_SHORTCUT("script_text_editor/undo", TTR("Undo"), KEY_MASK_CMD | KEY_Z);
-	ED_SHORTCUT("script_text_editor/redo", TTR("Redo"), KEY_MASK_CMD | KEY_Y);
-	ED_SHORTCUT("script_text_editor/cut", TTR("Cut"), KEY_MASK_CMD | KEY_X);
-	ED_SHORTCUT("script_text_editor/copy", TTR("Copy"), KEY_MASK_CMD | KEY_C);
-	ED_SHORTCUT("script_text_editor/paste", TTR("Paste"), KEY_MASK_CMD | KEY_V);
-	ED_SHORTCUT("script_text_editor/select_all", TTR("Select All"), KEY_MASK_CMD | KEY_A);
 	ED_SHORTCUT("script_text_editor/move_up", TTR("Move Up"), KEY_MASK_ALT | KEY_UP);
 	ED_SHORTCUT("script_text_editor/move_down", TTR("Move Down"), KEY_MASK_ALT | KEY_DOWN);
 	ED_SHORTCUT("script_text_editor/delete_line", TTR("Delete Line"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_K);
@@ -1936,10 +1930,8 @@ void ScriptTextEditor::register_editor() {
 	ED_SHORTCUT("script_text_editor/unfold_all_lines", TTR("Unfold All Lines"), 0);
 #ifdef OSX_ENABLED
 	ED_SHORTCUT("script_text_editor/clone_down", TTR("Clone Down"), KEY_MASK_SHIFT | KEY_MASK_CMD | KEY_C);
-	ED_SHORTCUT("script_text_editor/complete_symbol", TTR("Complete Symbol"), KEY_MASK_CTRL | KEY_SPACE);
 #else
 	ED_SHORTCUT("script_text_editor/clone_down", TTR("Clone Down"), KEY_MASK_CMD | KEY_D);
-	ED_SHORTCUT("script_text_editor/complete_symbol", TTR("Complete Symbol"), KEY_MASK_CMD | KEY_SPACE);
 #endif
 	ED_SHORTCUT("script_text_editor/evaluate_selection", TTR("Evaluate Selection"), KEY_MASK_CMD | KEY_MASK_SHIFT | KEY_E);
 	ED_SHORTCUT("script_text_editor/trim_trailing_whitespace", TTR("Trim Trailing Whitespace"), KEY_MASK_CMD | KEY_MASK_ALT | KEY_T);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -282,7 +282,7 @@ void ShaderEditor::_menu_option(int p_option) {
 			}
 
 			CodeEdit *tx = shader_editor->get_text_editor();
-			tx->indent_left();
+			tx->indent_selected_lines_left();
 
 		} break;
 		case EDIT_INDENT_RIGHT: {
@@ -291,7 +291,7 @@ void ShaderEditor::_menu_option(int p_option) {
 			}
 
 			CodeEdit *tx = shader_editor->get_text_editor();
-			tx->indent_right();
+			tx->indent_selected_lines_right();
 
 		} break;
 		case EDIT_DELETE_LINE: {
@@ -533,15 +533,15 @@ void ShaderEditor::_bookmark_item_pressed(int p_idx) {
 void ShaderEditor::_make_context_menu(bool p_selection, Vector2 p_position) {
 	context_menu->clear();
 	if (p_selection) {
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/cut"), EDIT_CUT);
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/copy"), EDIT_COPY);
+		context_menu->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT);
+		context_menu->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY);
 	}
 
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/paste"), EDIT_PASTE);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE);
 	context_menu->add_separator();
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/select_all"), EDIT_SELECT_ALL);
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/undo"), EDIT_UNDO);
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/redo"), EDIT_REDO);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_text_select_all"), EDIT_SELECT_ALL);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_redo"), EDIT_REDO);
 
 	context_menu->add_separator();
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent_left"), EDIT_INDENT_LEFT);
@@ -585,14 +585,14 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	edit_menu->set_text(TTR("Edit"));
 	edit_menu->set_switch_on_hover(true);
 
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/undo"), EDIT_UNDO);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/redo"), EDIT_REDO);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_redo"), EDIT_REDO);
 	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/cut"), EDIT_CUT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/copy"), EDIT_COPY);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/paste"), EDIT_PASTE);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE);
 	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/select_all"), EDIT_SELECT_ALL);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_select_all"), EDIT_SELECT_ALL);
 	edit_menu->get_popup()->add_separator();
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_up"), EDIT_MOVE_LINE_UP);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_down"), EDIT_MOVE_LINE_DOWN);
@@ -602,7 +602,7 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/clone_down"), EDIT_CLONE_DOWN);
 	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/complete_symbol"), EDIT_COMPLETE);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_completion_query"), EDIT_COMPLETE);
 	edit_menu->get_popup()->connect("id_pressed", callable_mp(this, &ShaderEditor::_menu_option));
 
 	search_menu = memnew(MenuButton);

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -363,10 +363,10 @@ void TextEditor::_edit_option(int p_op) {
 			code_editor->move_lines_down();
 		} break;
 		case EDIT_INDENT_LEFT: {
-			tx->indent_left();
+			tx->indent_selected_lines_left();
 		} break;
 		case EDIT_INDENT_RIGHT: {
-			tx->indent_right();
+			tx->indent_selected_lines_right();
 		} break;
 		case EDIT_DELETE_LINE: {
 			code_editor->delete_lines();
@@ -514,15 +514,15 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 void TextEditor::_make_context_menu(bool p_selection, bool p_can_fold, bool p_is_folded, Vector2 p_position) {
 	context_menu->clear();
 	if (p_selection) {
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/cut"), EDIT_CUT);
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/copy"), EDIT_COPY);
+		context_menu->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT);
+		context_menu->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY);
 	}
 
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/paste"), EDIT_PASTE);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE);
 	context_menu->add_separator();
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/select_all"), EDIT_SELECT_ALL);
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/undo"), EDIT_UNDO);
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/redo"), EDIT_REDO);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_text_select_all"), EDIT_SELECT_ALL);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("ui_redo"), EDIT_REDO);
 	context_menu->add_separator();
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent_left"), EDIT_INDENT_LEFT);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/indent_right"), EDIT_INDENT_RIGHT);
@@ -584,14 +584,14 @@ TextEditor::TextEditor() {
 	edit_menu->set_switch_on_hover(true);
 	edit_menu->get_popup()->connect("id_pressed", callable_mp(this, &TextEditor::_edit_option));
 
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/undo"), EDIT_UNDO);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/redo"), EDIT_REDO);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("un_redo"), EDIT_REDO);
 	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/cut"), EDIT_CUT);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/copy"), EDIT_COPY);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/paste"), EDIT_PASTE);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE);
 	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/select_all"), EDIT_SELECT_ALL);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_select_all"), EDIT_SELECT_ALL);
 	edit_menu->get_popup()->add_separator();
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_up"), EDIT_MOVE_LINE_UP);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/move_down"), EDIT_MOVE_LINE_DOWN);

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -143,7 +143,7 @@ void EditorSettingsDialog::_unhandled_input(const Ref<InputEvent> &p_event) {
 	if (k.is_valid() && k->is_pressed()) {
 		bool handled = false;
 
-		if (ED_IS_SHORTCUT("editor/undo", p_event)) {
+		if (ED_IS_SHORTCUT("ui_undo", p_event)) {
 			String action = undo_redo->get_current_action_name();
 			if (action != "") {
 				EditorNode::get_log()->add_message("Undo: " + action, EditorLog::MSG_TYPE_EDITOR);
@@ -152,7 +152,7 @@ void EditorSettingsDialog::_unhandled_input(const Ref<InputEvent> &p_event) {
 			handled = true;
 		}
 
-		if (ED_IS_SHORTCUT("editor/redo", p_event)) {
+		if (ED_IS_SHORTCUT("ui_redo", p_event)) {
 			undo_redo->redo();
 			String action = undo_redo->get_current_action_name();
 			if (action != "") {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -515,8 +515,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	MAIN_PRINT("Main: Initialize Globals");
 
-	globals = memnew(ProjectSettings);
 	input_map = memnew(InputMap);
+	globals = memnew(ProjectSettings);
 
 	register_core_settings(); //here globals is present
 

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -4274,13 +4274,13 @@ VisualScriptEditor::VisualScriptEditor() {
 	edit_menu->set_shortcut_context(this);
 	edit_menu->set_text(TTR("Edit"));
 	edit_menu->set_switch_on_hover(true);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("visual_script_editor/delete_selected"), EDIT_DELETE_NODES);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_graph_delete"), EDIT_DELETE_NODES);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("visual_script_editor/toggle_breakpoint"), EDIT_TOGGLE_BREAKPOINT);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("visual_script_editor/find_node_type"), EDIT_FIND_NODE_TYPE);
 	edit_menu->get_popup()->add_separator();
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("visual_script_editor/copy_nodes"), EDIT_COPY_NODES);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("visual_script_editor/cut_nodes"), EDIT_CUT_NODES);
-	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("visual_script_editor/paste_nodes"), EDIT_PASTE_NODES);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_copy"), EDIT_COPY_NODES);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_cut"), EDIT_CUT_NODES);
+	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_paste"), EDIT_PASTE_NODES);
 	edit_menu->get_popup()->add_separator();
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("visual_script_editor/create_function"), EDIT_CREATE_FUNCTION);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("visual_script_editor/refresh_nodes"), REFRESH_GRAPH);
@@ -4520,12 +4520,8 @@ void VisualScriptEditor::free_clipboard() {
 static void register_editor_callback() {
 	ScriptEditor::register_create_script_editor_function(create_editor);
 
-	ED_SHORTCUT("visual_script_editor/delete_selected", TTR("Delete Selected"), KEY_DELETE);
 	ED_SHORTCUT("visual_script_editor/toggle_breakpoint", TTR("Toggle Breakpoint"), KEY_F9);
 	ED_SHORTCUT("visual_script_editor/find_node_type", TTR("Find Node Type"), KEY_MASK_CMD + KEY_F);
-	ED_SHORTCUT("visual_script_editor/copy_nodes", TTR("Copy Nodes"), KEY_MASK_CMD + KEY_C);
-	ED_SHORTCUT("visual_script_editor/cut_nodes", TTR("Cut Nodes"), KEY_MASK_CMD + KEY_X);
-	ED_SHORTCUT("visual_script_editor/paste_nodes", TTR("Paste Nodes"), KEY_MASK_CMD + KEY_V);
 	ED_SHORTCUT("visual_script_editor/create_function", TTR("Make Function"), KEY_MASK_CMD + KEY_G);
 	ED_SHORTCUT("visual_script_editor/refresh_nodes", TTR("Refresh Graph"), KEY_MASK_CMD + KEY_R);
 	ED_SHORTCUT("visual_script_editor/edit_member", TTR("Edit Member"), KEY_MASK_CMD + KEY_E);

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1330,25 +1330,17 @@ void GraphEdit::_gui_input(const Ref<InputEvent> &p_ev) {
 		}
 	}
 
-	Ref<InputEventKey> k = p_ev;
-
-	if (k.is_valid()) {
-		if (k->get_keycode() == KEY_D && k->is_pressed() && k->get_command()) {
+	if (p_ev->is_pressed()) {
+		if (p_ev->is_action("ui_graph_duplicate")) {
 			emit_signal("duplicate_nodes_request");
 			accept_event();
-		}
-
-		if (k->get_keycode() == KEY_C && k->is_pressed() && k->get_command()) {
+		} else if (p_ev->is_action("ui_copy")) {
 			emit_signal("copy_nodes_request");
 			accept_event();
-		}
-
-		if (k->get_keycode() == KEY_V && k->is_pressed() && k->get_command()) {
+		} else if (p_ev->is_action("ui_paste")) {
 			emit_signal("paste_nodes_request");
 			accept_event();
-		}
-
-		if (k->get_keycode() == KEY_DELETE && k->is_pressed()) {
+		} else if (p_ev->is_action("ui_graph_delete")) {
 			emit_signal("delete_nodes_request");
 			accept_event();
 		}

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -163,6 +163,7 @@ private:
 	void _clear_redo();
 	void _create_undo_state();
 
+	int _get_menu_action_accelerator(const String &p_action);
 	void _generate_context_menu();
 
 	void _shape();
@@ -187,6 +188,14 @@ private:
 	void changed_internal();
 
 	void _editor_settings_changed();
+
+	void _swap_current_input_direction();
+	void _move_cursor_left(bool p_select, bool p_move_by_word = false);
+	void _move_cursor_right(bool p_select, bool p_move_by_word = false);
+	void _move_cursor_start(bool p_select);
+	void _move_cursor_end(bool p_select);
+	void _backspace(bool p_word = false, bool p_all_to_left = false);
+	void _delete(bool p_word = false, bool p_all_to_right = false);
 
 	void _gui_input(Ref<InputEvent> p_event);
 	void _notification(int p_what);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1575,53 +1575,36 @@ void RichTextLabel::_gui_input(Ref<InputEvent> p_event) {
 	Ref<InputEventKey> k = p_event;
 
 	if (k.is_valid()) {
-		if (k->is_pressed() && !k->get_alt() && !k->get_shift()) {
+		if (k->is_pressed()) {
 			bool handled = false;
-			switch (k->get_keycode()) {
-				case KEY_PAGEUP: {
-					if (vscroll->is_visible_in_tree()) {
-						vscroll->set_value(vscroll->get_value() - vscroll->get_page());
-						handled = true;
-					}
-				} break;
-				case KEY_PAGEDOWN: {
-					if (vscroll->is_visible_in_tree()) {
-						vscroll->set_value(vscroll->get_value() + vscroll->get_page());
-						handled = true;
-					}
-				} break;
-				case KEY_UP: {
-					if (vscroll->is_visible_in_tree()) {
-						vscroll->set_value(vscroll->get_value() - get_theme_font("normal_font")->get_height(get_theme_font_size("normal_font_size")));
-						handled = true;
-					}
-				} break;
-				case KEY_DOWN: {
-					if (vscroll->is_visible_in_tree()) {
-						vscroll->set_value(vscroll->get_value() + get_theme_font("normal_font")->get_height(get_theme_font_size("normal_font_size")));
-						handled = true;
-					}
-				} break;
-				case KEY_HOME: {
-					if (vscroll->is_visible_in_tree()) {
-						vscroll->set_value(0);
-						handled = true;
-					}
-				} break;
-				case KEY_END: {
-					if (vscroll->is_visible_in_tree()) {
-						vscroll->set_value(vscroll->get_max());
-						handled = true;
-					}
-				} break;
-				case KEY_INSERT:
-				case KEY_C: {
-					if (k->get_command()) {
-						selection_copy();
-						handled = true;
-					}
 
-				} break;
+			if (k->is_action("ui_pageup") && vscroll->is_visible_in_tree()) {
+				vscroll->set_value(vscroll->get_value() - vscroll->get_page());
+				handled = true;
+			}
+			if (k->is_action("ui_pagedown") && vscroll->is_visible_in_tree()) {
+				vscroll->set_value(vscroll->get_value() + vscroll->get_page());
+				handled = true;
+			}
+			if (k->is_action("ui_up") && vscroll->is_visible_in_tree()) {
+				vscroll->set_value(vscroll->get_value() - get_theme_font("normal_font")->get_height(get_theme_font_size("normal_font_size")));
+				handled = true;
+			}
+			if (k->is_action("ui_down") && vscroll->is_visible_in_tree()) {
+				vscroll->set_value(vscroll->get_value() + get_theme_font("normal_font")->get_height(get_theme_font_size("normal_font_size")));
+				handled = true;
+			}
+			if (k->is_action("ui_home") && vscroll->is_visible_in_tree()) {
+				vscroll->set_value(0);
+				handled = true;
+			}
+			if (k->is_action("ui_end") && vscroll->is_visible_in_tree()) {
+				vscroll->set_value(vscroll->get_max());
+				handled = true;
+			}
+			if (k->is_action("ui_copy")) {
+				selection_copy();
+				handled = true;
 			}
 
 			if (handled) {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -408,6 +408,7 @@ private:
 	int _get_control_height() const;
 
 	Point2 _get_local_mouse_pos() const;
+	int _get_menu_action_accelerator(const String &p_action);
 
 	void _reset_caret_blink_timer();
 	void _toggle_draw_caret();
@@ -440,6 +441,26 @@ private:
 
 	int _calculate_spaces_till_next_left_indent(int column);
 	int _calculate_spaces_till_next_right_indent(int column);
+
+	// Methods used in shortcuts
+	void _swap_current_input_direction();
+	void _new_line(bool p_split_current = true, bool p_above = false);
+	void _indent_right();
+	void _indent_left();
+	void _move_cursor_left(bool p_select, bool p_move_by_word = false);
+	void _move_cursor_right(bool p_select, bool p_move_by_word = false);
+	void _move_cursor_up(bool p_select);
+	void _move_cursor_down(bool p_select);
+	void _move_cursor_to_line_start(bool p_select);
+	void _move_cursor_to_line_end(bool p_select);
+	void _move_cursor_page_up(bool p_select);
+	void _move_cursor_page_down(bool p_select);
+	void _backspace(bool p_word = false, bool p_all_to_left = false);
+	void _delete(bool p_word = false, bool p_all_to_right = false);
+	void _delete_selection();
+	void _move_cursor_document_start(bool p_select);
+	void _move_cursor_document_end(bool p_select);
+	void _handle_unicode_character(uint32_t unicode, bool p_had_selection, bool p_update_auto_complete);
 
 protected:
 	struct Cache {
@@ -639,8 +660,8 @@ public:
 	int get_row_height() const;
 	void backspace_at_cursor();
 
-	void indent_left();
-	void indent_right();
+	void indent_selected_lines_left();
+	void indent_selected_lines_right();
 	int get_indent_level(int p_line) const;
 	bool is_line_comment(int p_line) const;
 


### PR DESCRIPTION
* Made shortcuts which were previously hardcoded customisable. (this is just the backend implementation - the UI to do so will come in a later PR)
* Shortcuts that fall into this category are things like cut, copy paste, etc on TextEdit. In the code, these were defined in `gui_input` with things like 
`if (k->is_pressed() && k->get_keycode() == KEY_C && k->get_command() == true){ /* copy */}`
* Cleaned up logic... it is much more readable now. The below code example handles 1) moving the cursor left 1 char, 2) moving the cursor left by 1 word 3) moving the cursor to the start of the line (on Apple only) and finally 4) doing the previous 3 with selection (shift) pressed.

https://github.com/godotengine/godot/blob/07112b92a85de9b2134f3208149b295f871d3642/scene/gui/text_edit.cpp#L2876-L2945

Quite hard to follow in my opinion. This logic now looks like this, except the following logic can use any key combination, not just the left arrow key.
```cpp
// In gui_input:
if (k->is_action("ui_text_caret_left")) {
	_move_cursor_left(shift_pressed, false);
}
if (k->is_action("ui_text_caret_word_left")) {
	_move_cursor_left(shift_pressed, true);
}
// …
if (k->is_action("ui_text_caret_line_start")) {
	_move_cursor_to_line_start(shift_pressed);
}
// Other methods in the class:
void TextEdit::_move_cursor_left(bool p_select, bool p_move_by_word);
void TextEdit::_move_cursor_to_line_start(bool p_select);
```

The keys used to perform these actions are defined in InputMap:
```cpp
inputs = List<Ref<InputEvent>>();
inputs.push_back(InputEventKey::create_reference(KEY_HOME));
map.insert("ui_text_caret_line_start", inputs);

inputs = List<Ref<InputEvent>>();
inputs.push_back(InputEventKey::create_reference(KEY_A, KEY_MASK_CTRL));
inputs.push_back(InputEventKey::create_reference(KEY_LEFT, KEY_MASK_CMD));
map.insert("ui_text_caret_line_start.OSX", inputs);
```

**Added Utility Method**
Added static methods `::create_reference` on InputEventKey and JoypadButton which is a one-line way to do:
```
Ref<InputEventJoypadButton> ie;
ie.instance();
ie->set_button_index(p_btn_index);
```
The above code is used in many places with Buttons and Keys, so moving it to a utility one-liner saves A LOT of lines of code, at least a couple hundred lines.

**Unified definitions of the same shortcuts**
Moved builtin input actions away from being defined twice in ProjectSettings and EditorSettings to only being defined once in InputMap. Project/Editor Settings instead just get the builtin actions and loop through them to add them to their settings list. Reduces code duplication.

Closes #17927
Closes #29490
Closes #12164
Closes #42139
Closes #26854
Closes godotengine/godot-proposals#1532

This is the fourth PR of a larger series based on #42600.