### PR TITLE
Clarify that SceneTree::quit() does not immediately end the application.

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -181,7 +181,7 @@
 			<argument index="0" name="exit_code" type="int" default="-1">
 			</argument>
 			<description>
-				Quits the application. A process [code]exit_code[/code] can optionally be passed as an argument. If this argument is [code]0[/code] or greater, it will override the [member OS.exit_code] defined before quitting the application.
+				Quits the application at the end of the current iteration. A process [code]exit_code[/code] can optionally be passed as an argument. If this argument is [code]0[/code] or greater, it will override the [member OS.exit_code] defined before quitting the application.
 			</description>
 		</method>
 		<method name="reload_current_scene">


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
I had written a script that I intended to run from the command line. It required a file path as one of the arguments. If the file did not exist, then it would print an error and quit using SceneTree::quit(). I intended for this to also end the processing of my script, because the rest of the script operates assuming the input file was opened. Since SceneTree::quit() did not function the way I anticipated, I ran in to lots of errors that were confusing for me to debug.

Including this clarification might help other people troubleshoot their scripts better and fix their issues faster.