### PR TITLE
Fix crash duplicating local-to-scene resources [3.2]

### DIFF
--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -155,8 +155,8 @@ Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Res
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
 
-	Resource *r = Object::cast_to<Resource>(ClassDB::instance(get_class()));
-	ERR_FAIL_COND_V(!r, Ref<Resource>());
+	Ref<Resource> r = Object::cast_to<Resource>(ClassDB::instance(get_class()));
+	ERR_FAIL_COND_V(r.is_null(), Ref<Resource>());
 
 	r->local_scene = p_for_scene;
 


### PR DESCRIPTION
Backport of this fix to the 3.2 branch (https://github.com/godotengine/godot/pull/43657)