### PR TITLE
Fix focus loss on macOS.

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -3384,9 +3384,6 @@ OS_OSX::OS_OSX() {
 	// Implicitly create shared NSApplication instance
 	[GodotApplication sharedApplication];
 
-	// In case we are unbundled, make us a proper UI application
-	[NSApp setActivationPolicy:(NSApplicationActivationPolicyAccessory)];
-
 	// Menu bar setup must go between sharedApplication above and
 	// finishLaunching below, in order to properly emulate the behavior
 	// of NSApplicationMain


### PR DESCRIPTION
Fixes #43675.

Regression form #42276, removed line works when app is started from terminal, but cause app to minimize on start if bundled. Removing it means that app with `--no-window` will steal focus form terminal / parent process, but with the current way Godot is handling command line arguments unlikely there's a way to do it better.

Probably we need to split argument parsing to have stuff like `no-window` before OS init.
1. Parse arguments for OS init.
2. Init OS.
3. Parse arguments for opening files/projects (in case of macOS, argument list can be changed by OS init, macOS is handling file associations in `openFile:` app delegate callback instead of command line).
4. Init DisplayServer, Audio, etc. and load project.