### PR TITLE
Warn about singleton being a Reference

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -219,3 +219,13 @@ Engine *Engine::get_singleton() {
 Engine::Engine() {
 	singleton = this;
 }
+
+Engine::Singleton::Singleton(const StringName &p_name, Object *p_ptr) :
+		name(p_name),
+		ptr(p_ptr) {
+#ifdef DEBUG_ENABLED
+	if (Object::cast_to<Reference>(p_ptr)) {
+		ERR_PRINT("A class intended to be used as a singleton must *not* inherit from Reference.");
+	}
+#endif
+}

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -41,10 +41,7 @@ public:
 	struct Singleton {
 		StringName name;
 		Object *ptr;
-		Singleton(const StringName &p_name = StringName(), Object *p_ptr = nullptr) :
-				name(p_name),
-				ptr(p_ptr) {
-		}
+		Singleton(const StringName &p_name = StringName(), Object *p_ptr = nullptr);
 	};
 
 private:


### PR DESCRIPTION
This is just to avoid makers of singletons from shooting themselves in their feet.

Given how `Variant` behaves now regarding `Reference`s in both 3.2.4+ and 4.0, the formerly harmless mistake of making a singleton class derive from `Reference` (especially, or exclusively?, at the C++ side) will cause a crash. For instance, that would have been the case with certain core singleton if 9e8e5ebdc74f535df395eaf5d8031002edfe5a10 hadn't existed.

This is just to give some clue to core and module writers about why their registered singletons have been unexpectedly freed.

---
**This code is generously donated by IMVU.**