### PR TITLE
OSX: Fix linking with osxcross for arm64

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -87,8 +87,8 @@ def configure(env):
 
     if env["arch"] == "arm64":
         print("Building for macOS 10.15+, platform arm64.")
-        env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15", "-target", "arm64-apple-macos10.15"])
-        env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15", "-target", "arm64-apple-macos10.15"])
+        env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15"])
+        env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15"])
     else:
         print("Building for macOS 10.12+, platform x86-64.")
         env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])


### PR DESCRIPTION
~*Edit:* Doesn't seem to work for my issue, investigating further. Might still be a good cleanup for the previous hacky check for `env["CXX"] == "clang++"` though.~

Works fine on osxcross now.