### PR TITLE
[Complex Text Layouts] Add drop-cap support to RTL.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -164,6 +164,27 @@
 				Adds a [code][color][/code] tag to the tag stack.
 			</description>
 		</method>
+		<method name="push_dropcap">
+			<return type="void">
+			</return>
+			<argument index="0" name="string" type="String">
+			</argument>
+			<argument index="1" name="font" type="Font">
+			</argument>
+			<argument index="2" name="size" type="int">
+			</argument>
+			<argument index="3" name="dropcap_margins" type="Rect2" default="Rect2( 0, 0, 0, 0 )">
+			</argument>
+			<argument index="4" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			</argument>
+			<argument index="5" name="outline_size" type="int" default="0">
+			</argument>
+			<argument index="6" name="outline_color" type="Color" default="Color( 0, 0, 0, 0 )">
+			</argument>
+			<description>
+				Adds a [code][dropcap][/code] tag to the tag stack. Drop cap (dropped capital) is a decorative element at the beginning of a paragraph that is larger than the rest of the text.
+			</description>
+		</method>
 		<method name="push_font">
 			<return type="void">
 			</return>
@@ -525,9 +546,11 @@
 		</constant>
 		<constant name="ITEM_RAINBOW" value="20" enum="ItemType">
 		</constant>
-		<constant name="ITEM_CUSTOMFX" value="22" enum="ItemType">
-		</constant>
 		<constant name="ITEM_META" value="21" enum="ItemType">
+		</constant>
+		<constant name="ITEM_DROPCAP" value="22" enum="ItemType">
+		</constant>
+		<constant name="ITEM_CUSTOMFX" value="23" enum="ItemType">
 		</constant>
 	</constants>
 	<theme_items>

--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -49,6 +49,13 @@
 				Clears text paragraph (removes text and inline objects).
 			</description>
 		</method>
+		<method name="clear_dropcap">
+			<return type="void">
+			</return>
+			<description>
+				Removes dropcap.
+			</description>
+		</method>
 		<method name="draw" qualifiers="const">
 			<return type="void">
 			</return>
@@ -58,8 +65,38 @@
 			</argument>
 			<argument index="2" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			</argument>
+			<argument index="3" name="dc_color" type="Color" default="Color( 1, 1, 1, 1 )">
+			</argument>
 			<description>
-				Draw text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+				Draw all lines of the text and drop cap into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+			</description>
+		</method>
+		<method name="draw_dropcap" qualifiers="const">
+			<return type="void">
+			</return>
+			<argument index="0" name="canvas" type="RID">
+			</argument>
+			<argument index="1" name="pos" type="Vector2">
+			</argument>
+			<argument index="2" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			</argument>
+			<description>
+				Draw drop cap into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+			</description>
+		</method>
+		<method name="draw_dropcap_outline" qualifiers="const">
+			<return type="void">
+			</return>
+			<argument index="0" name="canvas" type="RID">
+			</argument>
+			<argument index="1" name="pos" type="Vector2">
+			</argument>
+			<argument index="2" name="outline_size" type="int" default="1">
+			</argument>
+			<argument index="3" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			</argument>
+			<description>
+				Draw drop cap outline into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
 			</description>
 		</method>
 		<method name="draw_line" qualifiers="const">
@@ -99,14 +136,37 @@
 			</return>
 			<argument index="0" name="canvas" type="RID">
 			</argument>
-			<argument index="1" name="outline_size" type="Vector2">
+			<argument index="1" name="pos" type="Vector2">
 			</argument>
-			<argument index="2" name="color" type="int" default="1">
+			<argument index="2" name="outline_size" type="int" default="1">
 			</argument>
-			<argument index="3" name="arg3" type="Color" default="Color( 1, 1, 1, 1 )">
+			<argument index="3" name="color" type="Color" default="Color( 1, 1, 1, 1 )">
+			</argument>
+			<argument index="4" name="dc_color" type="Color" default="Color( 1, 1, 1, 1 )">
 			</argument>
 			<description>
-				Draw outline of the text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+				Draw outilines of all lines of the text and drop cap into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+			</description>
+		</method>
+		<method name="get_dropcap_lines" qualifiers="const">
+			<return type="int">
+			</return>
+			<description>
+				Returns number of lines used by dropcap.
+			</description>
+		</method>
+		<method name="get_dropcap_rid" qualifiers="const">
+			<return type="RID">
+			</return>
+			<description>
+				Return drop cap text buffer RID.
+			</description>
+		</method>
+		<method name="get_dropcap_size" qualifiers="const">
+			<return type="Vector2">
+			</return>
+			<description>
+				Returns drop cap bounding box size.
 			</description>
 		</method>
 		<method name="get_line_ascent" qualifiers="const">
@@ -259,6 +319,26 @@
 			<description>
 				Overrides BiDi for the structured text.
 				Override ranges should cover full source text without overlaps. BiDi algorithm will be used on each range separately.
+			</description>
+		</method>
+		<method name="set_dropcap">
+			<return type="bool">
+			</return>
+			<argument index="0" name="text" type="String">
+			</argument>
+			<argument index="1" name="fonts" type="Font">
+			</argument>
+			<argument index="2" name="size" type="int">
+			</argument>
+			<argument index="3" name="dropcap_margins" type="Rect2" default="Rect2( 0, 0, 0, 0 )">
+			</argument>
+			<argument index="4" name="opentype_features" type="Dictionary" default="{
+}">
+			</argument>
+			<argument index="5" name="language" type="String" default="&quot;&quot;">
+			</argument>
+			<description>
+				Sets drop cap, overrides previously set drop cap. Drop cap (dropped capital) is a decorative element at the beginning of a paragraph that is larger than the rest of the text.
 			</description>
 		</method>
 		<method name="tab_align">

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -76,6 +76,7 @@ public:
 		ITEM_TORNADO,
 		ITEM_RAINBOW,
 		ITEM_META,
+		ITEM_DROPCAP,
 		ITEM_CUSTOMFX
 	};
 
@@ -89,6 +90,9 @@ private:
 		Item *from = nullptr;
 
 		Ref<TextParagraph> text_buf;
+		Color dc_color;
+		int dc_ol_size = 0;
+		Color dc_ol_color;
 
 		Vector2 offset;
 		int char_offset = 0;
@@ -138,6 +142,17 @@ private:
 	struct ItemText : public Item {
 		String text;
 		ItemText() { type = ITEM_TEXT; }
+	};
+
+	struct ItemDropcap : public Item {
+		String text;
+		Ref<Font> font;
+		int font_size;
+		Color color;
+		int ol_size;
+		Color ol_color;
+		Rect2 dropcap_margins;
+		ItemDropcap() { type = ITEM_DROPCAP; }
 	};
 
 	struct ItemImage : public Item {
@@ -391,6 +406,7 @@ private:
 	Dictionary _find_font_features(Item *p_item);
 	int _find_outline_size(Item *p_item);
 	ItemList *_find_list_item(Item *p_item);
+	ItemDropcap *_find_dc_item(Item *p_item);
 	int _find_list(Item *p_item, Vector<int> &r_index, Vector<ItemList *> &r_list);
 	int _find_margin(Item *p_item, const Ref<Font> &p_base_font, int p_base_font_size);
 	Align _find_align(Item *p_item);
@@ -435,6 +451,7 @@ public:
 	void add_image(const Ref<Texture2D> &p_image, const int p_width = 0, const int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), VAlign p_align = VALIGN_TOP);
 	void add_newline();
 	bool remove_line(const int p_line);
+	void push_dropcap(const String &p_string, const Ref<Font> &p_font, int p_size, const Rect2 &p_dropcap_margins = Rect2(), const Color &p_color = Color(1, 1, 1), int p_ol_size = 0, const Color &p_ol_color = Color(0, 0, 0, 0));
 	void push_font(const Ref<Font> &p_font);
 	void push_font_size(int p_font_size);
 	void push_font_features(const Dictionary &p_features);

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -55,6 +55,9 @@ void TextParagraph::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_bidi_override", "override"), &TextParagraph::_set_bidi_override);
 
+	ClassDB::bind_method(D_METHOD("set_dropcap", "text", "fonts", "size", "dropcap_margins", "opentype_features", "language"), &TextParagraph::set_dropcap, DEFVAL(Rect2()), DEFVAL(Dictionary()), DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("clear_dropcap"), &TextParagraph::clear_dropcap);
+
 	ClassDB::bind_method(D_METHOD("add_string", "text", "fonts", "size", "opentype_features", "language"), &TextParagraph::add_string, DEFVAL(Dictionary()), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("add_object", "key", "size", "inline_align", "length"), &TextParagraph::add_object, DEFVAL(VALIGN_CENTER), DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("resize_object", "key", "size", "inline_align"), &TextParagraph::resize_object, DEFVAL(VALIGN_CENTER));
@@ -81,6 +84,7 @@ void TextParagraph::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_rid"), &TextParagraph::get_rid);
 	ClassDB::bind_method(D_METHOD("get_line_rid", "line"), &TextParagraph::get_line_rid);
+	ClassDB::bind_method(D_METHOD("get_dropcap_rid"), &TextParagraph::get_dropcap_rid);
 
 	ClassDB::bind_method(D_METHOD("get_line_count"), &TextParagraph::get_line_count);
 
@@ -94,11 +98,17 @@ void TextParagraph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_line_underline_position", "line"), &TextParagraph::get_line_underline_position);
 	ClassDB::bind_method(D_METHOD("get_line_underline_thickness", "line"), &TextParagraph::get_line_underline_thickness);
 
-	ClassDB::bind_method(D_METHOD("draw", "canvas", "pos", "color"), &TextParagraph::draw, DEFVAL(Color(1, 1, 1)));
-	ClassDB::bind_method(D_METHOD("draw_outline", "canvas", "outline_size", "color"), &TextParagraph::draw_outline, DEFVAL(1), DEFVAL(Color(1, 1, 1)));
+	ClassDB::bind_method(D_METHOD("get_dropcap_size"), &TextParagraph::get_dropcap_size);
+	ClassDB::bind_method(D_METHOD("get_dropcap_lines"), &TextParagraph::get_dropcap_lines);
+
+	ClassDB::bind_method(D_METHOD("draw", "canvas", "pos", "color", "dc_color"), &TextParagraph::draw, DEFVAL(Color(1, 1, 1)), DEFVAL(Color(1, 1, 1)));
+	ClassDB::bind_method(D_METHOD("draw_outline", "canvas", "pos", "outline_size", "color", "dc_color"), &TextParagraph::draw_outline, DEFVAL(1), DEFVAL(Color(1, 1, 1)), DEFVAL(Color(1, 1, 1)));
 
 	ClassDB::bind_method(D_METHOD("draw_line", "canvas", "pos", "line", "color"), &TextParagraph::draw_line, DEFVAL(Color(1, 1, 1)));
 	ClassDB::bind_method(D_METHOD("draw_line_outline", "canvas", "pos", "line", "outline_size", "color"), &TextParagraph::draw_line_outline, DEFVAL(1), DEFVAL(Color(1, 1, 1)));
+
+	ClassDB::bind_method(D_METHOD("draw_dropcap", "canvas", "pos", "color"), &TextParagraph::draw_dropcap, DEFVAL(Color(1, 1, 1)));
+	ClassDB::bind_method(D_METHOD("draw_dropcap_outline", "canvas", "pos", "outline_size", "color"), &TextParagraph::draw_dropcap_outline, DEFVAL(1), DEFVAL(Color(1, 1, 1)));
 
 	ClassDB::bind_method(D_METHOD("hit_test", "coords"), &TextParagraph::hit_test);
 }
@@ -114,7 +124,43 @@ void TextParagraph::_shape_lines() {
 			TS->shaped_text_tab_align(rid, tab_stops);
 		}
 
-		Vector<Vector2i> line_breaks = TS->shaped_text_get_line_breaks(rid, width, 0, flags);
+		float h_offset = 0.f;
+		float v_offset = 0.f;
+		int start = 0;
+		dropcap_lines = 0;
+
+		if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
+			h_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
+			v_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
+		} else {
+			h_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
+			v_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
+		}
+
+		if (h_offset > 0) {
+			// Dropcap, flow around.
+			Vector<Vector2i> line_breaks = TS->shaped_text_get_line_breaks(rid, width - h_offset, 0, flags);
+			for (int i = 0; i < line_breaks.size(); i++) {
+				RID line = TS->shaped_text_substr(rid, line_breaks[i].x, line_breaks[i].y - line_breaks[i].x);
+				float h = (TS->shaped_text_get_orientation(line) == TextServer::ORIENTATION_HORIZONTAL) ? TS->shaped_text_get_size(line).y : TS->shaped_text_get_size(line).x;
+				if (v_offset < h) {
+					TS->free(line);
+					break;
+				}
+				if (!tab_stops.empty()) {
+					TS->shaped_text_tab_align(line, tab_stops);
+				}
+				if (align == HALIGN_FILL && (line_breaks.size() == 1 || i < line_breaks.size() - 1)) {
+					TS->shaped_text_fit_to_width(line, width - h_offset, flags);
+				}
+				dropcap_lines++;
+				v_offset -= h;
+				start = line_breaks[i].y;
+				lines.push_back(line);
+			}
+		}
+		// Use fixed for the rest of lines.
+		Vector<Vector2i> line_breaks = TS->shaped_text_get_line_breaks(rid, width, start, flags);
 		for (int i = 0; i < line_breaks.size(); i++) {
 			RID line = TS->shaped_text_substr(rid, line_breaks[i].x, line_breaks[i].y - line_breaks[i].x);
 			if (!tab_stops.empty()) {
@@ -139,6 +185,10 @@ RID TextParagraph::get_line_rid(int p_line) const {
 	return lines[p_line];
 }
 
+RID TextParagraph::get_dropcap_rid() const {
+	return dropcap_rid;
+}
+
 void TextParagraph::clear() {
 	spacing_top = 0;
 	spacing_bottom = 0;
@@ -147,10 +197,12 @@ void TextParagraph::clear() {
 	}
 	lines.clear();
 	TS->shaped_text_clear(rid);
+	TS->shaped_text_clear(dropcap_rid);
 }
 
 void TextParagraph::set_preserve_invalid(bool p_enabled) {
 	TS->shaped_text_set_preserve_invalid(rid, p_enabled);
+	TS->shaped_text_set_preserve_invalid(dropcap_rid, p_enabled);
 	dirty_lines = true;
 }
 
@@ -160,6 +212,7 @@ bool TextParagraph::get_preserve_invalid() const {
 
 void TextParagraph::set_preserve_control(bool p_enabled) {
 	TS->shaped_text_set_preserve_control(rid, p_enabled);
+	TS->shaped_text_set_preserve_control(dropcap_rid, p_enabled);
 	dirty_lines = true;
 }
 
@@ -169,6 +222,7 @@ bool TextParagraph::get_preserve_control() const {
 
 void TextParagraph::set_direction(TextServer::Direction p_direction) {
 	TS->shaped_text_set_direction(rid, p_direction);
+	TS->shaped_text_set_direction(dropcap_rid, p_direction);
 	dirty_lines = true;
 }
 
@@ -179,12 +233,27 @@ TextServer::Direction TextParagraph::get_direction() const {
 
 void TextParagraph::set_orientation(TextServer::Orientation p_orientation) {
 	TS->shaped_text_set_orientation(rid, p_orientation);
+	TS->shaped_text_set_orientation(dropcap_rid, p_orientation);
 	dirty_lines = true;
 }
 
 TextServer::Orientation TextParagraph::get_orientation() const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
 	return TS->shaped_text_get_orientation(rid);
+}
+
+bool TextParagraph::set_dropcap(const String &p_text, const Ref<Font> &p_fonts, int p_size, const Rect2 &p_dropcap_margins, const Dictionary &p_opentype_features, const String &p_language) {
+	TS->shaped_text_clear(dropcap_rid);
+	dropcap_margins = p_dropcap_margins;
+	bool res = TS->shaped_text_add_string(dropcap_rid, p_text, p_fonts->get_rids(), p_size, p_opentype_features, p_language);
+	dirty_lines = true;
+	return res;
+}
+
+void TextParagraph::clear_dropcap() {
+	dropcap_margins = Rect2();
+	TS->shaped_text_clear(dropcap_rid);
+	dirty_lines = true;
 }
 
 bool TextParagraph::add_string(const String &p_text, const Ref<Font> &p_fonts, int p_size, const Dictionary &p_opentype_features, const String &p_language) {
@@ -359,16 +428,57 @@ float TextParagraph::get_line_underline_thickness(int p_line) const {
 	return TS->shaped_text_get_underline_thickness(lines[p_line]);
 }
 
-void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_color) const {
+Size2 TextParagraph::get_dropcap_size() const {
+	return TS->shaped_text_get_size(dropcap_rid) + dropcap_margins.size + dropcap_margins.position;
+}
+
+int TextParagraph::get_dropcap_lines() const {
+	return dropcap_lines;
+}
+
+void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_color, const Color &p_dc_color) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
 	Vector2 ofs = p_pos;
+	float h_offset = 0.f;
+	if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
+		h_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
+	} else {
+		h_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
+	}
+
+	if (h_offset > 0) {
+		// Draw dropcap.
+		Vector2 dc_off = ofs;
+		if (TS->shaped_text_get_direction(dropcap_rid) == TextServer::DIRECTION_RTL) {
+			if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
+				dc_off.x += width - h_offset;
+			} else {
+				dc_off.y += width - h_offset;
+			}
+		}
+		TS->shaped_text_draw(dropcap_rid, p_canvas, dc_off + Vector2(0, TS->shaped_text_get_ascent(dropcap_rid) + dropcap_margins.size.y + dropcap_margins.position.y / 2), -1, -1, p_dc_color);
+	}
+
 	for (int i = 0; i < lines.size(); i++) {
+		float l_width = width;
 		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			ofs.x = p_pos.x;
 			ofs.y += TS->shaped_text_get_ascent(lines[i]) + spacing_top;
+			if (i <= dropcap_lines) {
+				if (TS->shaped_text_get_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
+					ofs.x -= h_offset;
+				}
+				l_width -= h_offset;
+			}
 		} else {
 			ofs.y = p_pos.y;
 			ofs.x += TS->shaped_text_get_ascent(lines[i]) + spacing_top;
+			if (i <= dropcap_lines) {
+				if (TS->shaped_text_get_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
+					ofs.x -= h_offset;
+				}
+				l_width -= h_offset;
+			}
 		}
 		float length = TS->shaped_text_get_width(lines[i]);
 		if (width > 0) {
@@ -378,16 +488,16 @@ void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_colo
 					break;
 				case HALIGN_CENTER: {
 					if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-						ofs.x += Math::floor((width - length) / 2.0);
+						ofs.x += Math::floor((l_width - length) / 2.0);
 					} else {
-						ofs.y += Math::floor((width - length) / 2.0);
+						ofs.y += Math::floor((l_width - length) / 2.0);
 					}
 				} break;
 				case HALIGN_RIGHT: {
 					if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-						ofs.x += width - length;
+						ofs.x += l_width - length;
 					} else {
-						ofs.y += width - length;
+						ofs.y += l_width - length;
 					}
 				} break;
 			}
@@ -398,7 +508,7 @@ void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_colo
 		} else {
 			clip_l = MAX(0, p_pos.y - ofs.y);
 		}
-		TS->shaped_text_draw(lines[i], p_canvas, ofs, clip_l, clip_l + width, p_color);
+		TS->shaped_text_draw(lines[i], p_canvas, ofs, clip_l, clip_l + l_width, p_color);
 		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			ofs.x = p_pos.x;
 			ofs.y += TS->shaped_text_get_descent(lines[i]) + spacing_bottom;
@@ -409,16 +519,50 @@ void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_colo
 	}
 }
 
-void TextParagraph::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size, const Color &p_color) const {
+void TextParagraph::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size, const Color &p_color, const Color &p_dc_color) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
 	Vector2 ofs = p_pos;
+
+	float h_offset = 0.f;
+	if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
+		h_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
+	} else {
+		h_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
+	}
+
+	if (h_offset > 0) {
+		// Draw dropcap.
+		Vector2 dc_off = ofs;
+		if (TS->shaped_text_get_direction(dropcap_rid) == TextServer::DIRECTION_RTL) {
+			if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
+				dc_off.x += width - h_offset;
+			} else {
+				dc_off.y += width - h_offset;
+			}
+		}
+		TS->shaped_text_draw_outline(dropcap_rid, p_canvas, dc_off + Vector2(dropcap_margins.position.x, TS->shaped_text_get_ascent(dropcap_rid) + dropcap_margins.position.y), -1, -1, p_outline_size, p_dc_color);
+	}
+
 	for (int i = 0; i < lines.size(); i++) {
+		float l_width = width;
 		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			ofs.x = p_pos.x;
 			ofs.y += TS->shaped_text_get_ascent(lines[i]) + spacing_top;
+			if (i <= dropcap_lines) {
+				if (TS->shaped_text_get_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
+					ofs.x -= h_offset;
+				}
+				l_width -= h_offset;
+			}
 		} else {
 			ofs.y = p_pos.y;
 			ofs.x += TS->shaped_text_get_ascent(lines[i]) + spacing_top;
+			if (i <= dropcap_lines) {
+				if (TS->shaped_text_get_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
+					ofs.x -= h_offset;
+				}
+				l_width -= h_offset;
+			}
 		}
 		float length = TS->shaped_text_get_width(lines[i]);
 		if (width > 0) {
@@ -428,16 +572,16 @@ void TextParagraph::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outli
 					break;
 				case HALIGN_CENTER: {
 					if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-						ofs.x += Math::floor((width - length) / 2.0);
+						ofs.x += Math::floor((l_width - length) / 2.0);
 					} else {
-						ofs.y += Math::floor((width - length) / 2.0);
+						ofs.y += Math::floor((l_width - length) / 2.0);
 					}
 				} break;
 				case HALIGN_RIGHT: {
 					if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-						ofs.x += width - length;
+						ofs.x += l_width - length;
 					} else {
-						ofs.y += width - length;
+						ofs.y += l_width - length;
 					}
 				} break;
 			}
@@ -448,7 +592,7 @@ void TextParagraph::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outli
 		} else {
 			clip_l = MAX(0, p_pos.y - ofs.y);
 		}
-		TS->shaped_text_draw_outline(lines[i], p_canvas, ofs, clip_l, clip_l + width, p_outline_size, p_color);
+		TS->shaped_text_draw_outline(lines[i], p_canvas, ofs, clip_l, clip_l + l_width, p_outline_size, p_color);
 		if (TS->shaped_text_get_orientation(lines[i]) == TextServer::ORIENTATION_HORIZONTAL) {
 			ofs.x = p_pos.x;
 			ofs.y += TS->shaped_text_get_descent(lines[i]) + spacing_bottom;
@@ -485,11 +629,56 @@ int TextParagraph::hit_test(const Point2 &p_coords) const {
 	return TS->shaped_text_get_range(rid).y;
 }
 
+void TextParagraph::draw_dropcap(RID p_canvas, const Vector2 &p_pos, const Color &p_color) const {
+	Vector2 ofs = p_pos;
+	float h_offset = 0.f;
+	if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
+		h_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
+	} else {
+		h_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
+	}
+
+	if (h_offset > 0) {
+		// Draw dropcap.
+		if (TS->shaped_text_get_direction(dropcap_rid) == TextServer::DIRECTION_RTL) {
+			if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
+				ofs.x += width - h_offset;
+			} else {
+				ofs.y += width - h_offset;
+			}
+		}
+		TS->shaped_text_draw(dropcap_rid, p_canvas, ofs + Vector2(dropcap_margins.position.x, TS->shaped_text_get_ascent(dropcap_rid) + dropcap_margins.position.y), -1, -1, p_color);
+	}
+}
+
+void TextParagraph::draw_dropcap_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size, const Color &p_color) const {
+	Vector2 ofs = p_pos;
+	float h_offset = 0.f;
+	if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
+		h_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
+	} else {
+		h_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
+	}
+
+	if (h_offset > 0) {
+		// Draw dropcap.
+		if (TS->shaped_text_get_direction(dropcap_rid) == TextServer::DIRECTION_RTL) {
+			if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
+				ofs.x += width - h_offset;
+			} else {
+				ofs.y += width - h_offset;
+			}
+		}
+		TS->shaped_text_draw_outline(dropcap_rid, p_canvas, ofs + Vector2(dropcap_margins.position.x, TS->shaped_text_get_ascent(dropcap_rid) + dropcap_margins.position.y), -1, -1, p_outline_size, p_color);
+	}
+}
+
 void TextParagraph::draw_line(RID p_canvas, const Vector2 &p_pos, int p_line, const Color &p_color) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
 	ERR_FAIL_COND(p_line < 0 || p_line >= lines.size());
 
 	Vector2 ofs = p_pos;
+
 	if (TS->shaped_text_get_orientation(lines[p_line]) == TextServer::ORIENTATION_HORIZONTAL) {
 		ofs.y += TS->shaped_text_get_ascent(lines[p_line]) + spacing_top;
 	} else {
@@ -521,6 +710,7 @@ TextParagraph::TextParagraph(const String &p_text, const Ref<Font> &p_fonts, int
 
 TextParagraph::TextParagraph() {
 	rid = TS->create_shaped_text();
+	dropcap_rid = TS->create_shaped_text();
 }
 
 TextParagraph::~TextParagraph() {
@@ -529,4 +719,5 @@ TextParagraph::~TextParagraph() {
 	}
 	lines.clear();
 	TS->free(rid);
+	TS->free(dropcap_rid);
 }

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -39,6 +39,10 @@
 class TextParagraph : public Reference {
 	GDCLASS(TextParagraph, Reference);
 
+	RID dropcap_rid;
+	int dropcap_lines = 0;
+	Rect2 dropcap_margins;
+
 	RID rid;
 	Vector<RID> lines;
 	int spacing_top = 0;
@@ -60,6 +64,7 @@ protected:
 public:
 	RID get_rid() const;
 	RID get_line_rid(int p_line) const;
+	RID get_dropcap_rid() const;
 
 	void clear();
 
@@ -76,6 +81,9 @@ public:
 	bool get_preserve_control() const;
 
 	void set_bidi_override(const Vector<Vector2i> &p_override);
+
+	bool set_dropcap(const String &p_text, const Ref<Font> &p_fonts, int p_size, const Rect2 &p_dropcap_margins = Rect2(), const Dictionary &p_opentype_features = Dictionary(), const String &p_language = "");
+	void clear_dropcap();
 
 	bool add_string(const String &p_text, const Ref<Font> &p_fonts, int p_size, const Dictionary &p_opentype_features = Dictionary(), const String &p_language = "");
 	bool add_object(Variant p_key, const Size2 &p_size, VAlign p_inline_align = VALIGN_CENTER, int p_length = 1);
@@ -108,11 +116,17 @@ public:
 	float get_line_underline_position(int p_line) const;
 	float get_line_underline_thickness(int p_line) const;
 
-	void draw(RID p_canvas, const Vector2 &p_pos, const Color &p_color = Color(1, 1, 1)) const;
-	void draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size = 1, const Color &p_color = Color(1, 1, 1)) const;
+	Size2 get_dropcap_size() const;
+	int get_dropcap_lines() const;
+
+	void draw(RID p_canvas, const Vector2 &p_pos, const Color &p_color = Color(1, 1, 1), const Color &p_dc_color = Color(1, 1, 1)) const;
+	void draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size = 1, const Color &p_color = Color(1, 1, 1), const Color &p_dc_color = Color(1, 1, 1)) const;
 
 	void draw_line(RID p_canvas, const Vector2 &p_pos, int p_line, const Color &p_color = Color(1, 1, 1)) const;
 	void draw_line_outline(RID p_canvas, const Vector2 &p_pos, int p_line, int p_outline_size = 1, const Color &p_color = Color(1, 1, 1)) const;
+
+	void draw_dropcap(RID p_canvas, const Vector2 &p_pos, const Color &p_color = Color(1, 1, 1)) const;
+	void draw_dropcap_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size = 1, const Color &p_color = Color(1, 1, 1)) const;
 
 	int hit_test(const Point2 &p_coords) const;
 


### PR DESCRIPTION
Implements thus closes https://github.com/godotengine/godot-proposals/issues/1838

<img width="796" alt="Screenshot 2020-11-20 at 09 34 02" src="https://user-images.githubusercontent.com/7645683/99772498-9474fd00-2b13-11eb-94b7-b986dd65ace1.png">

Adds `[dropcap font=name font_size=72 color=red margins=0,0,0,0 outline_size=2 outline_color=blue]AB[/dropcap]` tag, all options can be omitted.

Margins can be used to add extra offset (positive), or cut excessive font ascent/descent (negative):
<img width="327" alt="Screenshot 2020-11-20 at 09 39 00" src="https://user-images.githubusercontent.com/7645683/99773300-eb2f0680-2b14-11eb-90a5-28584d69563f.png">
Or add raised lines and outdent (indent whole paragraph and add negative left margin):
<img width="221" alt="Screenshot 2020-11-20 at 09 52 25" src="https://user-images.githubusercontent.com/7645683/99774248-3990d500-2b16-11eb-8ae4-7cd8091221fb.png">


