### PR TITLE
SCons: Remove unnecessary $LINK overrides

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -107,7 +107,6 @@ def configure(env):
 
     env["CC"] = "emcc"
     env["CXX"] = "em++"
-    env["LINK"] = "emcc"
 
     env["AR"] = "emar"
     env["RANLIB"] = "emranlib"

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -129,7 +129,6 @@ def configure(env):
         if "clang++" not in os.path.basename(env["CXX"]):
             env["CC"] = "clang"
             env["CXX"] = "clang++"
-            env["LINK"] = "clang++"
         env.Append(CPPDEFINES=["TYPED_METHOD_BIND"])
         env.extra_suffix = ".llvm" + env.extra_suffix
 

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -99,7 +99,6 @@ def configure(env):
             mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
             mpclangver = env["macports_clang"]
             env["CC"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/clang"
-            env["LINK"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/clang++"
             env["CXX"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/clang++"
             env["AR"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ar"
             env["RANLIB"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ranlib"
@@ -133,12 +132,6 @@ def configure(env):
         env["RANLIB"] = basecmd + "ranlib"
         env["AS"] = basecmd + "as"
         env.Append(CPPDEFINES=["__MACPORTS__"])  # hack to fix libvpx MM256_BROADCASTSI128_SI256 define
-
-    if env["CXX"] == "clang++":
-        # This should now work with clang++, re-enable if there are issues
-        # env.Append(CPPDEFINES=["TYPED_METHOD_BIND"])
-        env["CC"] = "clang"
-        env["LINK"] = "clang++"
 
     if env["use_ubsan"] or env["use_asan"] or env["use_tsan"]:
         env.extra_suffix += "s"

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -94,7 +94,6 @@ def configure(env):
         if "clang++" not in os.path.basename(env["CXX"]):
             env["CC"] = "clang"
             env["CXX"] = "clang++"
-            env["LINK"] = "clang++"
         env.Append(CPPDEFINES=["TYPED_METHOD_BIND"])
         env.extra_suffix = ".llvm" + env.extra_suffix
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -383,18 +383,17 @@ def configure_mingw(env):
 
     if env["use_llvm"]:
         env["CC"] = mingw_prefix + "clang"
-        env["AS"] = mingw_prefix + "as"
         env["CXX"] = mingw_prefix + "clang++"
+        env["AS"] = mingw_prefix + "as"
         env["AR"] = mingw_prefix + "ar"
         env["RANLIB"] = mingw_prefix + "ranlib"
-        env["LINK"] = mingw_prefix + "clang++"
     else:
         env["CC"] = mingw_prefix + "gcc"
-        env["AS"] = mingw_prefix + "as"
         env["CXX"] = mingw_prefix + "g++"
+        env["AS"] = mingw_prefix + "as"
         env["AR"] = mingw_prefix + "gcc-ar"
         env["RANLIB"] = mingw_prefix + "gcc-ranlib"
-        env["LINK"] = mingw_prefix + "g++"
+
     env["x86_libtheora_opt_gcc"] = True
 
     if env["use_lto"]:


### PR DESCRIPTION
As of SCons 4.0.1, the default value for $LINK is $SMARTLINK, which itself
is a function that will use $CXX as linker for C++:

https://github.com/SCons/scons/blob/4.0.1/SCons/Tool/link.py#L327-L328
https://github.com/SCons/scons/blob/4.0.1/SCons/Tool/link.py#L54-L76

So we don't need to manually specify the same value as $CXX for $LINK.

---

Note: The only case which actually changes here is Javascript, which used to use `emcc` instead of `em++` as linker. Needs testing to confirm it works fine.
*Edit:* Seems to work fine locally with emcc 2.0.7.