### PR TITLE
Show tooltips even when paused or time_scale is 0

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -82,6 +82,14 @@ bool SceneTreeTimer::is_process_always() {
 	return process_always;
 }
 
+void SceneTreeTimer::set_ignore_time_scale(bool p_ignore) {
+	ignore_time_scale = p_ignore;
+}
+
+bool SceneTreeTimer::is_ignore_time_scale() {
+	return ignore_time_scale;
+}
+
 void SceneTreeTimer::release_connections() {
 	List<Connection> connections;
 	get_all_signal_connections(&connections);
@@ -466,8 +474,13 @@ bool SceneTree::process(float p_time) {
 			E = N;
 			continue;
 		}
+
 		float time_left = E->get()->get_time_left();
-		time_left -= p_time;
+		if (E->get()->is_ignore_time_scale()) {
+			time_left -= Engine::get_singleton()->get_process_step();
+		} else {
+			time_left -= p_time;
+		}
 		E->get()->set_time_left(time_left);
 
 		if (time_left < 0) {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -54,6 +54,7 @@ class SceneTreeTimer : public RefCounted {
 
 	float time_left = 0.0;
 	bool process_always = true;
+	bool ignore_time_scale = false;
 
 protected:
 	static void _bind_methods();
@@ -64,6 +65,9 @@ public:
 
 	void set_process_always(bool p_process_always);
 	bool is_process_always();
+
+	void set_ignore_time_scale(bool p_ignore);
+	bool is_ignore_time_scale();
 
 	void release_connections();
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -50,6 +50,7 @@ class Label;
 class Timer;
 class Viewport;
 class CollisionObject3D;
+class SceneTreeTimer;
 
 class ViewportTexture : public Texture2D {
 	GDCLASS(ViewportTexture, Texture2D);
@@ -373,7 +374,7 @@ private:
 		bool drag_attempted = false;
 		Variant drag_data;
 		ObjectID drag_preview_id;
-		float tooltip_timer = -1.0;
+		Ref<SceneTreeTimer> tooltip_timer;
 		float tooltip_delay = 0.0;
 		Transform2D focus_inv_xform;
 		bool roots_order_dirty = false;


### PR DESCRIPTION
Fixes #29101
Fixes #29362

I changed the `gui.tooltip_timer` in Viewport from float to SceneTreeTimer (so it's independent) and added a property `ignore_time_scale` for SceneTreeTimers.

Also I took the chance to move the initialization of SceneTreeTimer variables away from the constructor.