### PR TITLE
Increase the default `profiler_frame_max_functions` to 512

### DIFF
--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -764,7 +764,7 @@ EditorProfiler::EditorProfiler() {
 	last_metric = -1;
 	hover_metric = -1;
 
-	EDITOR_DEF("debugger/profiler_frame_max_functions", 64);
+	EDITOR_DEF("debugger/profiler_frame_max_functions", 512);
 
 	frame_delay = memnew(Timer);
 	frame_delay->set_wait_time(0.1);


### PR DESCRIPTION
`3.2` version of https://github.com/godotengine/godot/pull/58729.

This should decrease the number of instances in which functions don't appear in the profiler.

This partially addresses #40251.

**Note:** This should be done differently for the `master` branch as the debugger code is better and able to handle a much larger amount of functions without trouble.