### PR TITLE
Do not start `Timer` upon manual switching of internal process

### DIFF
--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -46,7 +46,7 @@ void Timer::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			if (timer_process_mode == TIMER_PROCESS_PHYSICS || !is_processing_internal()) {
+			if (!processing || timer_process_mode == TIMER_PROCESS_PHYSICS || !is_processing_internal()) {
 				return;
 			}
 			time_left -= get_process_delta_time();
@@ -63,7 +63,7 @@ void Timer::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
-			if (timer_process_mode == TIMER_PROCESS_IDLE || !is_physics_processing_internal()) {
+			if (!processing || timer_process_mode == TIMER_PROCESS_IDLE || !is_physics_processing_internal()) {
 				return;
 			}
 			time_left -= get_physics_process_delta_time();


### PR DESCRIPTION
Fixes #43689.

Prevents `Timer` to prematurely start and timeout immediately if internal processing is enabled manually with `Timer.set_process_internal(true)` or `Timer.set_physics_process_internal(true)`.

Even if the internal processing is enabled manually, the user still has to actually start the timer with `start()` method explicitly (just the way it's intended).

Turns out the class already has `bool processing` which is set exactly upon `start()`, `stop()`, `set_paused()` methods, so this just makes sure the internal logic is not processed unless the timer is actually started.

In any case, this makes it fail-proof to use, it's not recommended to manipulate internal processing, despite it being public API, I'm in no way facilitating or endorsing such usage.

**Test project:**
[premature_timer.zip](https://github.com/godotengine/godot/files/5570301/premature_timer.zip)
