### PR TITLE
doc: Warn about using Node internal processing

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -782,7 +782,8 @@
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
-				Enables or disables internal physics for this node. Internal physics processing happens in isolation from the normal [method _physics_process] calls and is used by some nodes internally to guarantee proper functioning even if the node is paused or physics processing is disabled for scripting ([method set_physics_process]). Only useful for advanced uses to manipulate built-in nodes' behaviour.
+				Enables or disables internal physics for this node. Internal physics processing happens in isolation from the normal [method _physics_process] calls and is used by some nodes internally to guarantee proper functioning even if the node is paused or physics processing is disabled for scripting ([method set_physics_process]). Only useful for advanced uses to manipulate built-in nodes' behavior.
+				[b]Warning:[/b] Built-in Nodes rely on the internal processing for their own logic, so changing this value from your code may lead to unexpected behavior. Script access to this internal logic is provided for specific advanced uses, but is unsafe and not supported.
 			</description>
 		</method>
 		<method name="set_process">
@@ -809,7 +810,8 @@
 			<argument index="0" name="enable" type="bool">
 			</argument>
 			<description>
-				Enables or disabled internal processing for this node. Internal processing happens in isolation from the normal [method _process] calls and is used by some nodes internally to guarantee proper functioning even if the node is paused or processing is disabled for scripting ([method set_process]). Only useful for advanced uses to manipulate built-in nodes' behaviour.
+				Enables or disabled internal processing for this node. Internal processing happens in isolation from the normal [method _process] calls and is used by some nodes internally to guarantee proper functioning even if the node is paused or processing is disabled for scripting ([method set_process]). Only useful for advanced uses to manipulate built-in nodes' behavior.
+				[b]Warning:[/b] Built-in Nodes rely on the internal processing for their own logic, so changing this value from your code may lead to unexpected behavior. Script access to this internal logic is provided for specific advanced uses, but is unsafe and not supported.
 			</description>
 		</method>
 		<method name="set_process_unhandled_input">

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -348,11 +348,11 @@ Error NetSocketPosix::open(Type p_sock_type, IP::Type &ip_type) {
 		// recv/recvfrom and an ICMP reply was received from a previous send/sendto.
 		unsigned long disable = 0;
 		if (ioctlsocket(_sock, SIO_UDP_CONNRESET, &disable) == SOCKET_ERROR) {
-			print_verbose("Unable to turn off UDP WSAECONNRESET behaviour on Windows");
+			print_verbose("Unable to turn off UDP WSAECONNRESET behavior on Windows");
 		}
 		if (ioctlsocket(_sock, SIO_UDP_NETRESET, &disable) == SOCKET_ERROR) {
 			// This feature seems not to be supported on wine.
-			print_verbose("Unable to turn off UDP WSAENETRESET behaviour on Windows");
+			print_verbose("Unable to turn off UDP WSAENETRESET behavior on Windows");
 		}
 	}
 #endif

--- a/modules/visual_script/doc_classes/VisualScriptLists.xml
+++ b/modules/visual_script/doc_classes/VisualScriptLists.xml
@@ -4,7 +4,7 @@
 		A Visual Script virtual class for in-graph editable nodes.
 	</brief_description>
 	<description>
-		A Visual Script virtual class that defines the shape and the default behaviour of the nodes that have to be in-graph editable nodes.
+		A Visual Script virtual class that defines the shape and the default behavior of the nodes that have to be in-graph editable nodes.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -725,7 +725,7 @@ void SoftBody3D::_update_cache_pin_points_datas() {
 			w[i].spatial_attachment = Object::cast_to<Node3D>(get_node(w[i].spatial_attachment_path));
 		}
 		if (!w[i].spatial_attachment) {
-			ERR_PRINT("Node3D node not defined in the pinned point, Softbody undefined behaviour!");
+			ERR_PRINT("Node3D node not defined in the pinned point, this is undefined behavior for SoftBody3D!");
 		}
 	}
 }


### PR DESCRIPTION
See #43689.

Also 'fixed' some spelling for behavior in publicly visible strings.
(Sorry en_GB, en_CA, en_AU, and more... Silicon Valley won the tech spelling
war.)