### PR TITLE
doctest: Do not override command-line options

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -112,10 +112,6 @@ int test_main(int argc, char *argv[]) {
 
 	test_context.applyCommandLine(test_args.size(), doctest_args);
 
-	test_context.setOption("order-by", "name");
-	test_context.setOption("abort-after", 5);
-	test_context.setOption("no-breaks", true);
-
 	for (int x = 0; x < test_args.size(); x++) {
 		delete[] doctest_args[x];
 	}


### PR DESCRIPTION
Those options were likely copy-pasted from documentation examples. This change also allows to break in the debugger by default when assertions fail, and this can be configured via command-line interface anyways. Currently it's not possible to use debugger even if you do specify `--no-breaks=false`, so this change allows to make it happen.

This change is suggested by the doctest's author in https://github.com/onqtam/doctest/issues/397#issuecomment-688216271:

> I also see that you have the [following lines](https://github.com/godotengine/godot/blob/27763b67bb63139319bf611590c40e48663e72d6/tests/test_main.cpp#L109) where you setup the doctest context:
> 
> ```c++
> 	test_context.setOption("order-by", "name");
> 	test_context.setOption("abort-after", 5);
> 	test_context.setOption("no-breaks", true);
> ```
> 
> Those seem to be a copy-paste from the documentation for [providing your own `main()`](https://github.com/onqtam/doctest/blob/master/doc/markdown/main.md?rgh-link-date=2020-09-07T10%3A00%3A14Z) but you don't need to set those - they are used there just as an example, and given that you have [this patch](https://github.com/godotengine/godot/blob/27763b67bb63139319bf611590c40e48663e72d6/thirdparty/doctest/patches/fix-arm64-mac.patch) and have filed [this PR](https://github.com/onqtam/doctest/pull/400) (which I'll merge today) I would assume you don't want `--no-breaks=true`.



