### PR TITLE
Fix variant getters not setting return type

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -42,27 +42,6 @@
 typedef void (*VariantFunc)(Variant &r_ret, Variant &p_self, const Variant **p_args);
 typedef void (*VariantConstructFunc)(Variant &r_ret, const Variant **p_args);
 
-template <class T>
-struct TypeAdjust {
-	_FORCE_INLINE_ static void adjust(Variant *r_ret) {
-		VariantTypeChanger<typename GetSimpleTypeT<T>::type_t>::change(r_ret);
-	}
-};
-
-template <> //do nothing for variant
-struct TypeAdjust<Variant> {
-	_FORCE_INLINE_ static void adjust(Variant *r_ret) {
-	}
-};
-
-template <> //do nothing for variant
-struct TypeAdjust<Object *> {
-	_FORCE_INLINE_ static void adjust(Variant *r_ret) {
-		VariantInternal::clear(r_ret);
-		*r_ret = (Object *)nullptr;
-	}
-};
-
 template <class R, class T, class... P>
 static _FORCE_INLINE_ void vc_method_call(R (T::*method)(P...), Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) {
 	call_with_variant_args_ret_dv(VariantGetInternalPtr<T>::get_ptr(base), method, p_args, p_argcount, r_ret, r_error, p_defvals);
@@ -124,12 +103,12 @@ static _FORCE_INLINE_ void vc_ptrcall(void (T::*method)(P...) const, void *p_bas
 
 template <class R, class T, class... P>
 static _FORCE_INLINE_ void vc_change_return_type(R (T::*method)(P...), Variant *v) {
-	TypeAdjust<R>::adjust(v);
+	VariantTypeAdjust<R>::adjust(v);
 }
 
 template <class R, class T, class... P>
 static _FORCE_INLINE_ void vc_change_return_type(R (T::*method)(P...) const, Variant *v) {
-	TypeAdjust<R>::adjust(v);
+	VariantTypeAdjust<R>::adjust(v);
 }
 
 template <class T, class... P>
@@ -144,7 +123,7 @@ static _FORCE_INLINE_ void vc_change_return_type(void (T::*method)(P...) const, 
 
 template <class R, class... P>
 static _FORCE_INLINE_ void vc_change_return_type(R (*method)(P...), Variant *v) {
-	TypeAdjust<R>::adjust(v);
+	VariantTypeAdjust<R>::adjust(v);
 }
 
 template <class R, class T, class... P>

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -1128,4 +1128,26 @@ struct VariantTypeChanger {
 	}
 };
 
+template <class T>
+struct VariantTypeAdjust {
+	_FORCE_INLINE_ static void adjust(Variant *r_ret) {
+		VariantTypeChanger<typename GetSimpleTypeT<T>::type_t>::change(r_ret);
+	}
+};
+
+template <>
+struct VariantTypeAdjust<Variant> {
+	_FORCE_INLINE_ static void adjust(Variant *r_ret) {
+		// Do nothing for variant.
+	}
+};
+
+template <>
+struct VariantTypeAdjust<Object *> {
+	_FORCE_INLINE_ static void adjust(Variant *r_ret) {
+		VariantInternal::clear(r_ret);
+		*r_ret = (Object *)nullptr;
+	}
+};
+
 #endif // VARIANT_INTERNAL_H

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -41,9 +41,6 @@
 #define SETGET_STRUCT(m_base_type, m_member_type, m_member)                                                                          \
 	struct VariantSetGet_##m_base_type##_##m_member {                                                                                \
 		static void get(const Variant *base, Variant *member) {                                                                      \
-			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member;                                                   \
-		}                                                                                                                            \
-		static void validated_get(const Variant *base, Variant *member) {                                                            \
 			VariantTypeAdjust<m_member_type>::adjust(member);                                                                        \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member;    \
 		}                                                                                                                            \
@@ -72,9 +69,6 @@
 #define SETGET_NUMBER_STRUCT(m_base_type, m_member_type, m_member)                                                                \
 	struct VariantSetGet_##m_base_type##_##m_member {                                                                             \
 		static void get(const Variant *base, Variant *member) {                                                                   \
-			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member;                                                \
-		}                                                                                                                         \
-		static void validated_get(const Variant *base, Variant *member) {                                                         \
 			VariantTypeAdjust<m_member_type>::adjust(member);                                                                     \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member; \
 		}                                                                                                                         \
@@ -106,9 +100,6 @@
 #define SETGET_STRUCT_CUSTOM(m_base_type, m_member_type, m_member, m_custom)                                                         \
 	struct VariantSetGet_##m_base_type##_##m_member {                                                                                \
 		static void get(const Variant *base, Variant *member) {                                                                      \
-			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom;                                                   \
-		}                                                                                                                            \
-		static void validated_get(const Variant *base, Variant *member) {                                                            \
 			VariantTypeAdjust<m_member_type>::adjust(member);                                                                        \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom;    \
 		}                                                                                                                            \
@@ -137,9 +128,6 @@
 #define SETGET_NUMBER_STRUCT_CUSTOM(m_base_type, m_member_type, m_member, m_custom)                                               \
 	struct VariantSetGet_##m_base_type##_##m_member {                                                                             \
 		static void get(const Variant *base, Variant *member) {                                                                   \
-			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom;                                                \
-		}                                                                                                                         \
-		static void validated_get(const Variant *base, Variant *member) {                                                         \
 			VariantTypeAdjust<m_member_type>::adjust(member);                                                                     \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom; \
 		}                                                                                                                         \
@@ -171,9 +159,6 @@
 #define SETGET_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter)                                                \
 	struct VariantSetGet_##m_base_type##_##m_member {                                                                               \
 		static void get(const Variant *base, Variant *member) {                                                                     \
-			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter();                                                \
-		}                                                                                                                           \
-		static void validated_get(const Variant *base, Variant *member) {                                                           \
 			VariantTypeAdjust<m_member_type>::adjust(member);                                                                       \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(); \
 		}                                                                                                                           \
@@ -202,9 +187,6 @@
 #define SETGET_NUMBER_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter)                                         \
 	struct VariantSetGet_##m_base_type##_##m_member {                                                                               \
 		static void get(const Variant *base, Variant *member) {                                                                     \
-			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter();                                                \
-		}                                                                                                                           \
-		static void validated_get(const Variant *base, Variant *member) {                                                           \
 			VariantTypeAdjust<m_member_type>::adjust(member);                                                                       \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(); \
 		}                                                                                                                           \
@@ -236,9 +218,6 @@
 #define SETGET_STRUCT_FUNC_INDEX(m_base_type, m_member_type, m_member, m_setter, m_getter, m_index)                                          \
 	struct VariantSetGet_##m_base_type##_##m_member {                                                                                        \
 		static void get(const Variant *base, Variant *member) {                                                                              \
-			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(m_index);                                                  \
-		}                                                                                                                                    \
-		static void validated_get(const Variant *base, Variant *member) {                                                                    \
 			VariantTypeAdjust<m_member_type>::adjust(member);                                                                                \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(m_index);   \
 		}                                                                                                                                    \
@@ -347,7 +326,7 @@ static void register_member(Variant::Type p_type, const StringName &p_member) {
 	sgi.ptr_setter = T::ptr_set;
 
 	sgi.getter = T::get;
-	sgi.validated_getter = T::validated_get;
+	sgi.validated_getter = T::get;
 	sgi.ptr_getter = T::ptr_get;
 
 	sgi.member_type = T::get_type();
@@ -612,18 +591,6 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 				oob = true;                                                                                                          \
 				return;                                                                                                              \
 			}                                                                                                                        \
-			*value = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index];                                                    \
-			oob = false;                                                                                                             \
-		}                                                                                                                            \
-		static void validated_get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                   \
-			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                                                \
-			if (index < 0) {                                                                                                         \
-				index += size;                                                                                                       \
-			}                                                                                                                        \
-			if (index < 0 || index >= size) {                                                                                        \
-				oob = true;                                                                                                          \
-				return;                                                                                                              \
-			}                                                                                                                        \
 			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                           \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index];       \
 			oob = false;                                                                                                             \
@@ -682,18 +649,6 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 #define INDEXED_SETGET_STRUCT_TYPED_NUMERIC(m_base_type, m_elem_type, m_assign_type)                                                 \
 	struct VariantIndexedSetGet_##m_base_type {                                                                                      \
 		static void get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                             \
-			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                                                \
-			if (index < 0) {                                                                                                         \
-				index += size;                                                                                                       \
-			}                                                                                                                        \
-			if (index < 0 || index >= size) {                                                                                        \
-				oob = true;                                                                                                          \
-				return;                                                                                                              \
-			}                                                                                                                        \
-			*value = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index];                                                    \
-			oob = false;                                                                                                             \
-		}                                                                                                                            \
-		static void validated_get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                   \
 			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                                                \
 			if (index < 0) {                                                                                                         \
 				index += size;                                                                                                       \
@@ -769,14 +724,6 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 				oob = true;                                                                                                    \
 				return;                                                                                                        \
 			}                                                                                                                  \
-			*value = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index];                                              \
-			oob = false;                                                                                                       \
-		}                                                                                                                      \
-		static void validated_get(const Variant *base, int64_t index, Variant *value, bool &oob) {                             \
-			if (index < 0 || index >= m_max) {                                                                                 \
-				oob = true;                                                                                                    \
-				return;                                                                                                        \
-			}                                                                                                                  \
 			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                     \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index]; \
 			oob = false;                                                                                                       \
@@ -832,14 +779,6 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 				oob = true;                                                                                                               \
 				return;                                                                                                                   \
 			}                                                                                                                             \
-			*value = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))m_accessor[index];                                               \
-			oob = false;                                                                                                                  \
-		}                                                                                                                                 \
-		static void validated_get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                        \
-			if (index < 0 || index >= m_max) {                                                                                            \
-				oob = true;                                                                                                               \
-				return;                                                                                                                   \
-			}                                                                                                                             \
 			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                                \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))m_accessor[index];  \
 			oob = false;                                                                                                                  \
@@ -885,14 +824,6 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 #define INDEXED_SETGET_STRUCT_BULTIN_FUNC(m_base_type, m_elem_type, m_set, m_get, m_max)                                           \
 	struct VariantIndexedSetGet_##m_base_type {                                                                                    \
 		static void get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                           \
-			if (index < 0 || index >= m_max) {                                                                                     \
-				oob = true;                                                                                                        \
-				return;                                                                                                            \
-			}                                                                                                                      \
-			*value = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_get(index);                                              \
-			oob = false;                                                                                                           \
-		}                                                                                                                          \
-		static void validated_get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                 \
 			if (index < 0 || index >= m_max) {                                                                                     \
 				oob = true;                                                                                                        \
 				return;                                                                                                            \
@@ -953,18 +884,6 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			*value = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index];                     \
 			oob = false;                                                                              \
 		}                                                                                             \
-		static void validated_get(const Variant *base, int64_t index, Variant *value, bool &oob) {    \
-			int64_t size = VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                 \
-			if (index < 0) {                                                                          \
-				index += size;                                                                        \
-			}                                                                                         \
-			if (index < 0 || index >= size) {                                                         \
-				oob = true;                                                                           \
-				return;                                                                               \
-			}                                                                                         \
-			*value = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index];                     \
-			oob = false;                                                                              \
-		}                                                                                             \
 		static void ptr_get(const void *base, int64_t index, void *member) {                          \
 			/* avoid ptrconvert for performance*/                                                     \
 			const m_base_type &v = *reinterpret_cast<const m_base_type *>(base);                      \
@@ -1014,15 +933,6 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 #define INDEXED_SETGET_STRUCT_DICT(m_base_type)                                                                                     \
 	struct VariantIndexedSetGet_##m_base_type {                                                                                     \
 		static void get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                            \
-			const Variant *ptr = VariantGetInternalPtr<m_base_type>::get_ptr(base)->getptr(index);                                  \
-			if (!ptr) {                                                                                                             \
-				oob = true;                                                                                                         \
-				return;                                                                                                             \
-			}                                                                                                                       \
-			*value = *ptr;                                                                                                          \
-			oob = false;                                                                                                            \
-		}                                                                                                                           \
-		static void validated_get(const Variant *base, int64_t index, Variant *value, bool &oob) {                                  \
 			const Variant *ptr = VariantGetInternalPtr<m_base_type>::get_ptr(base)->getptr(index);                                  \
 			if (!ptr) {                                                                                                             \
 				oob = true;                                                                                                         \
@@ -1106,7 +1016,7 @@ static void register_indexed_member(Variant::Type p_type) {
 	sgi.ptr_setter = T::ptr_set;
 
 	sgi.getter = T::get;
-	sgi.validated_getter = T::validated_get;
+	sgi.validated_getter = T::get;
 	sgi.ptr_getter = T::ptr_get;
 
 	sgi.index_type = T::get_index_type();

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -44,6 +44,7 @@
 			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member;                                                   \
 		}                                                                                                                            \
 		static void validated_get(const Variant *base, Variant *member) {                                                            \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                                        \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member;    \
 		}                                                                                                                            \
 		static void ptr_get(const void *base, void *member) {                                                                        \
@@ -74,6 +75,7 @@
 			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member;                                                \
 		}                                                                                                                         \
 		static void validated_get(const Variant *base, Variant *member) {                                                         \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                                     \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_member; \
 		}                                                                                                                         \
 		static void ptr_get(const void *base, void *member) {                                                                     \
@@ -107,6 +109,7 @@
 			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom;                                                   \
 		}                                                                                                                            \
 		static void validated_get(const Variant *base, Variant *member) {                                                            \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                                        \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom;    \
 		}                                                                                                                            \
 		static void ptr_get(const void *base, void *member) {                                                                        \
@@ -137,6 +140,7 @@
 			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom;                                                \
 		}                                                                                                                         \
 		static void validated_get(const Variant *base, Variant *member) {                                                         \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                                     \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_custom; \
 		}                                                                                                                         \
 		static void ptr_get(const void *base, void *member) {                                                                     \
@@ -170,6 +174,7 @@
 			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter();                                                \
 		}                                                                                                                           \
 		static void validated_get(const Variant *base, Variant *member) {                                                           \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                                       \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(); \
 		}                                                                                                                           \
 		static void ptr_get(const void *base, void *member) {                                                                       \
@@ -200,6 +205,7 @@
 			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter();                                                \
 		}                                                                                                                           \
 		static void validated_get(const Variant *base, Variant *member) {                                                           \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                                       \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(); \
 		}                                                                                                                           \
 		static void ptr_get(const void *base, void *member) {                                                                       \
@@ -233,6 +239,7 @@
 			*member = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(m_index);                                                  \
 		}                                                                                                                                    \
 		static void validated_get(const Variant *base, Variant *member) {                                                                    \
+			VariantTypeAdjust<m_member_type>::adjust(member);                                                                                \
 			*VariantGetInternalPtr<m_member_type>::get_ptr(member) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_getter(m_index);   \
 		}                                                                                                                                    \
 		static void ptr_get(const void *base, void *member) {                                                                                \
@@ -617,6 +624,7 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 				oob = true;                                                                                                          \
 				return;                                                                                                              \
 			}                                                                                                                        \
+			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                           \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index];       \
 			oob = false;                                                                                                             \
 		}                                                                                                                            \
@@ -694,6 +702,7 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 				oob = true;                                                                                                          \
 				return;                                                                                                              \
 			}                                                                                                                        \
+			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                           \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index];       \
 			oob = false;                                                                                                             \
 		}                                                                                                                            \
@@ -768,6 +777,7 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 				oob = true;                                                                                                    \
 				return;                                                                                                        \
 			}                                                                                                                  \
+			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                     \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))[index]; \
 			oob = false;                                                                                                       \
 		}                                                                                                                      \
@@ -830,6 +840,7 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 				oob = true;                                                                                                               \
 				return;                                                                                                                   \
 			}                                                                                                                             \
+			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                                \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = (*VariantGetInternalPtr<m_base_type>::get_ptr(base))m_accessor[index];  \
 			oob = false;                                                                                                                  \
 		}                                                                                                                                 \
@@ -886,6 +897,7 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 				oob = true;                                                                                                        \
 				return;                                                                                                            \
 			}                                                                                                                      \
+			VariantTypeAdjust<m_elem_type>::adjust(value);                                                                         \
 			*VariantGetInternalPtr<m_elem_type>::get_ptr(value) = VariantGetInternalPtr<m_base_type>::get_ptr(base)->m_get(index); \
 			oob = false;                                                                                                           \
 		}                                                                                                                          \


### PR DESCRIPTION
The validated getters were only setting the value without changing the type, leading to wrong results. This uses the same path used for methods to the same purpose.
