### PR TITLE
Expose `Node` callbacks for adding and removing children

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -152,6 +152,15 @@
 				If [code]legible_unique_name[/code] is [code]true[/code], the child node will have an human-readable name based on the name of the node being instanced instead of its type.
 			</description>
 		</method>
+		<method name="add_child_notify" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="child" type="Node">
+			</argument>
+			<description>
+				Called when a node is added as a child to this one.
+			</description>
+		</method>
 		<method name="add_to_group">
 			<return type="void">
 			</return>
@@ -498,6 +507,15 @@
 				Moves a child node to a different position (order) among the other children. Since calls, signals, etc are performed by tree order, changing the order of children nodes may be useful.
 			</description>
 		</method>
+		<method name="move_child_notify" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="child" type="Node">
+			</argument>
+			<description>
+				Called when a child is moved inside this node.
+			</description>
+		</method>
 		<method name="print_stray_nodes">
 			<return type="void">
 			</return>
@@ -587,6 +605,15 @@
 			</argument>
 			<description>
 				Removes a child node. The node is NOT deleted and must be deleted manually.
+			</description>
+		</method>
+		<method name="remove_child_notify" qualifiers="virtual">
+			<return type="void">
+			</return>
+			<argument index="0" name="child" type="Node">
+			</argument>
+			<description>
+				Called when a child is removed from this node.
 			</description>
 		</method>
 		<method name="remove_from_group">

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -436,6 +436,7 @@ void Control::_resize(const Size2 &p_size) {
 //moved theme configuration here, so controls can set up even if still not inside active scene
 
 void Control::add_child_notify(Node *p_child) {
+	CanvasItem::add_child_notify(p_child);
 
 	Control *child_c = Object::cast_to<Control>(p_child);
 	if (!child_c)
@@ -447,6 +448,7 @@ void Control::add_child_notify(Node *p_child) {
 }
 
 void Control::remove_child_notify(Node *p_child) {
+	CanvasItem::remove_child_notify(p_child);
 
 	Control *child_c = Object::cast_to<Control>(p_child);
 	if (!child_c)

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -377,18 +377,30 @@ void Node::raise() {
 }
 
 void Node::add_child_notify(Node *p_child) {
-
-	// to be used when not wanted
+	// Called when a node is added as a child to this one.
+	if (get_script_instance()) {
+		Variant c = p_child;
+		const Variant *ptr[1] = { &c };
+		get_script_instance()->call_multilevel("add_child_notify", ptr, 1);
+	}
 }
 
 void Node::remove_child_notify(Node *p_child) {
-
-	// to be used when not wanted
+	// Called when a child is removed from this node.
+	if (get_script_instance()) {
+		Variant c = p_child;
+		const Variant *ptr[1] = { &c };
+		get_script_instance()->call_multilevel("remove_child_notify", ptr, 1);
+	}
 }
 
 void Node::move_child_notify(Node *p_child) {
-
-	// to be used when not wanted
+	// Called when a child is moved inside this node.
+	if (get_script_instance()) {
+		Variant c = p_child;
+		const Variant *ptr[1] = { &c };
+		get_script_instance()->call_multilevel("move_child_notify", ptr, 1);
+	}
 }
 
 void Node::set_physics_process(bool p_process) {
@@ -2735,8 +2747,13 @@ void Node::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_name", "name"), &Node::set_name);
 	ClassDB::bind_method(D_METHOD("get_name"), &Node::get_name);
+
 	ClassDB::bind_method(D_METHOD("add_child", "node", "legible_unique_name"), &Node::add_child, DEFVAL(false));
+	BIND_VMETHOD(MethodInfo("add_child_notify", PropertyInfo(Variant::OBJECT, "child", PROPERTY_HINT_RESOURCE_TYPE, "Node", 0)));
+
 	ClassDB::bind_method(D_METHOD("remove_child", "node"), &Node::remove_child);
+	BIND_VMETHOD(MethodInfo("remove_child_notify", PropertyInfo(Variant::OBJECT, "child", PROPERTY_HINT_RESOURCE_TYPE, "Node", 0)));
+
 	ClassDB::bind_method(D_METHOD("get_child_count"), &Node::get_child_count);
 	ClassDB::bind_method(D_METHOD("get_children"), &Node::_get_children);
 	ClassDB::bind_method(D_METHOD("get_child", "idx"), &Node::get_child);
@@ -2757,7 +2774,10 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_to_group", "group", "persistent"), &Node::add_to_group, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_from_group", "group"), &Node::remove_from_group);
 	ClassDB::bind_method(D_METHOD("is_in_group", "group"), &Node::is_in_group);
+
 	ClassDB::bind_method(D_METHOD("move_child", "child_node", "to_position"), &Node::move_child);
+	BIND_VMETHOD(MethodInfo("move_child_notify", PropertyInfo(Variant::OBJECT, "child", PROPERTY_HINT_RESOURCE_TYPE, "Node", 0)));
+
 	ClassDB::bind_method(D_METHOD("get_groups"), &Node::_get_groups);
 	ClassDB::bind_method(D_METHOD("raise"), &Node::raise);
 	ClassDB::bind_method(D_METHOD("set_owner", "owner"), &Node::set_owner);


### PR DESCRIPTION
Helps godotengine/godot-proposals#724.
Helps godotengine/godot-proposals#2544.

![image](https://user-images.githubusercontent.com/17108460/99841028-35949f80-2b76-11eb-9c66-9ec407acab31.png)

I've found out that the engine already has such mechanism through virtual `add_child_notify`, `remove_child_notify`, and even `move_child_notify` (currently used only on C++ level for `Control` nodes such as `GraphEdit`).

With this, you don't have to:
1. `get_tree().connect("node_added", self, "_on_node_added")` and filter nodes with `get_parent()` checks.
2. Poll the children being added and removed from current one manually in `_process()`.

This way, there's no need to introduce signals such as `node_added`/`child_added`, and instead use existing callbacks.

I don't know the performance impact behind `get_script_instance()` checks yet, but perhaps they're negligible enough for this feature to be implemented. The `_process` callback checks this every frame in contrast, so I think there's nothing to worry about performance-wise.

## Usage
```gdscript
extends Node2D

func add_child_notify(child):
    # Request redraw whenever the child is "changed" is some way.
	child.connect("something_changed", self, "update")

func remove_child_notify(child):
	child.disconnect("something_changed", self, "update")

```

This is mostly useful for implementing general-purpose, adaptable classes to handle the API written by other developers, or when better encapsulation is desired (parent manages/controls children, and not vice versa, where `get_parent()` usage is typically discouraged).

---

I made this for 3.2 currently, 4.0 needs a separate PR due to removal of multilevel calls, but only if the idea behind godotengine/godot-proposals#724 is approved of course.

**Test project:**
[expose_node_callbacks_add_remove.zip](https://github.com/godotengine/godot/files/5575694/expose_node_callbacks_add_remove.zip)
