### PR TITLE
Detect plugins recursively

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3026,8 +3026,7 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 
 	Ref<ConfigFile> cf;
 	cf.instance();
-	String addon_path = String("res://addons").plus_file(p_addon).plus_file("plugin.cfg");
-	if (!DirAccess::exists(addon_path.get_base_dir())) {
+	if (!DirAccess::exists(p_addon.get_base_dir())) {
 		ProjectSettings *ps = ProjectSettings::get_singleton();
 		PackedStringArray enabled_plugins = ps->get("editor_plugins/enabled");
 		for (int i = 0; i < enabled_plugins.size(); ++i) {
@@ -3041,14 +3040,14 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 		WARN_PRINT("Addon '" + p_addon + "' failed to load. No directory found. Removing from enabled plugins.");
 		return;
 	}
-	Error err = cf->load(addon_path);
+	Error err = cf->load(p_addon);
 	if (err != OK) {
-		show_warning(vformat(TTR("Unable to enable addon plugin at: '%s' parsing of config failed."), addon_path));
+		show_warning(vformat(TTR("Unable to enable addon plugin at: '%s' parsing of config failed."), p_addon));
 		return;
 	}
 
 	if (!cf->has_section_key("plugin", "script")) {
-		show_warning(vformat(TTR("Unable to find script field for addon plugin at: 'res://addons/%s'."), p_addon));
+		show_warning(vformat(TTR("Unable to find script field for addon plugin at: '%s'."), p_addon));
 		return;
 	}
 
@@ -3057,7 +3056,7 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 
 	// Only try to load the script if it has a name. Else, the plugin has no init script.
 	if (script_path.length() > 0) {
-		script_path = String("res://addons").plus_file(p_addon).plus_file(script_path);
+		script_path = p_addon.get_base_dir().plus_file(script_path);
 		script = ResourceLoader::load(script_path);
 
 		if (script.is_null()) {

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -49,44 +49,16 @@ void EditorPluginSettings::_notification(int p_what) {
 
 void EditorPluginSettings::update_plugins() {
 	plugin_list->clear();
-
-	DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	Error err = da->change_dir("res://addons");
-	if (err != OK) {
-		memdelete(da);
-		return;
-	}
-
 	updating = true;
-
 	TreeItem *root = plugin_list->create_item();
 
-	da->list_dir_begin();
-
-	String d = da->get_next();
-
-	Vector<String> plugins;
-
-	while (d != String()) {
-		bool dir = da->current_is_dir();
-		String path = "res://addons/" + d + "/plugin.cfg";
-
-		if (dir && FileAccess::exists(path)) {
-			plugins.push_back(d);
-		}
-
-		d = da->get_next();
-	}
-
-	da->list_dir_end();
-	memdelete(da);
-
+	Vector<String> plugins = _get_plugins("res://addons");
 	plugins.sort();
 
 	for (int i = 0; i < plugins.size(); i++) {
 		Ref<ConfigFile> cf;
 		cf.instance();
-		String path = "res://addons/" + plugins[i] + "/plugin.cfg";
+		const String path = plugins[i];
 
 		Error err2 = cf->load(path);
 
@@ -117,7 +89,6 @@ void EditorPluginSettings::update_plugins() {
 			}
 
 			if (!key_missing) {
-				String d2 = plugins[i];
 				String name = cf->get_value("plugin", "name");
 				String author = cf->get_value("plugin", "author");
 				String version = cf->get_value("plugin", "version");
@@ -127,14 +98,14 @@ void EditorPluginSettings::update_plugins() {
 				TreeItem *item = plugin_list->create_item(root);
 				item->set_text(0, name);
 				item->set_tooltip(0, TTR("Name:") + " " + name + "\n" + TTR("Path:") + " " + path + "\n" + TTR("Main Script:") + " " + script + "\n" + TTR("Description:") + " " + description);
-				item->set_metadata(0, d2);
+				item->set_metadata(0, path);
 				item->set_text(1, version);
 				item->set_metadata(1, script);
 				item->set_text(2, author);
 				item->set_metadata(2, description);
 				item->set_cell_mode(3, TreeItem::CELL_MODE_CHECK);
 				item->set_text(3, TTR("Enable"));
-				bool is_active = EditorNode::get_singleton()->is_addon_plugin_enabled(d2);
+				bool is_active = EditorNode::get_singleton()->is_addon_plugin_enabled(path);
 				item->set_checked(3, is_active);
 				item->set_editable(3, true);
 				item->add_button(4, get_theme_icon("Edit", "EditorIcons"), BUTTON_PLUGIN_EDIT, false, TTR("Edit Plugin"));
@@ -179,10 +150,37 @@ void EditorPluginSettings::_cell_button_pressed(Object *p_item, int p_column, in
 	if (p_id == BUTTON_PLUGIN_EDIT) {
 		if (p_column == 4) {
 			String dir = item->get_metadata(0);
-			plugin_config_dialog->config("res://addons/" + dir + "/plugin.cfg");
+			plugin_config_dialog->config(dir);
 			plugin_config_dialog->popup_centered();
 		}
 	}
+}
+
+Vector<String> EditorPluginSettings::_get_plugins(const String &p_dir) {
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	Error err = da->change_dir(p_dir);
+	if (err != OK) {
+		return Vector<String>();
+	}
+
+	Vector<String> plugins;
+	da->list_dir_begin();
+	for (String path = da->get_next(); path != String(); path = da->get_next()) {
+		if (path[0] == '.' || !da->current_is_dir()) {
+			continue;
+		}
+
+		const String full_path = p_dir.plus_file(path);
+		const String plugin_config = full_path.plus_file("plugin.cfg");
+		if (FileAccess::exists(plugin_config)) {
+			plugins.push_back(plugin_config);
+		} else {
+			plugins.append_array(_get_plugins(full_path));
+		}
+	}
+
+	da->list_dir_end();
+	return plugins;
 }
 
 void EditorPluginSettings::_bind_methods() {

--- a/editor/editor_plugin_settings.h
+++ b/editor/editor_plugin_settings.h
@@ -54,6 +54,8 @@ class EditorPluginSettings : public VBoxContainer {
 	void _create_clicked();
 	void _cell_button_pressed(Object *p_item, int p_column, int p_id);
 
+	static Vector<String> _get_plugins(const String &p_dir);
+
 protected:
 	void _notification(int p_what);
 


### PR DESCRIPTION
Recursion doesn't go deeper after finding `plugin.cfg` (to avoid including subplugins). Also `plugin_addons` now contains full paths with the configuration file (it looks even simpler and more efficient).

I do not know any plugins for 4.0, so I tested this changes on 3.2 and it works as expected.

Closes https://github.com/godotengine/godot-proposals/issues/1623.
References https://github.com/godotengine/godot-proposals/issues/554.