### PR TITLE
Handle key release events in Line/Text Edits

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -152,7 +152,11 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 	Ref<InputEventKey> k = p_event;
 
 	if (k.is_valid()) {
+		//accept release event only if not a special key
 		if (!k->is_pressed()) {
+			if (!(k->get_keycode() & SPKEY)) {
+				accept_event();
+			}
 			return;
 		}
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2370,7 +2370,11 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 		}
 
+		//accept release event only if not a special key
 		if (!k->is_pressed()) {
+			if (!(k->get_keycode() & SPKEY)) {
+				accept_event();
+			}
 			return;
 		}
 


### PR DESCRIPTION
Fixes #43701

Currently, Line and Text Edits ignore any key event that isn't pressed allowing them to be caught by the _unhandled_input function. This fixes that behavior for any non-special key.
