### PR TITLE
Added support for node2D (custom draw) in editor to know when it has been clicked within the editor by exposing a call to _edit_is_selected_on_click to the script attached to the node.

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -356,6 +356,9 @@ bool CanvasItem::_edit_is_selected_on_click(const Point2 &p_point, double p_tole
 	if (_edit_use_rect()) {
 		return _edit_get_rect().has_point(p_point);
 	} else {
+		if (get_script_instance() && get_script_instance()->has_method("_edit_is_selected_on_click")) {
+			return get_script_instance()->call("_edit_is_selected_on_click", Vector2(p_point.x, p_point.y));
+		}
 		return p_point.length() < p_tolerance;
 	}
 }
@@ -1142,6 +1145,8 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_edit_get_pivot"), &CanvasItem::_edit_get_pivot);
 	ClassDB::bind_method(D_METHOD("_edit_use_pivot"), &CanvasItem::_edit_use_pivot);
 	ClassDB::bind_method(D_METHOD("_edit_get_transform"), &CanvasItem::_edit_get_transform);
+
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_edit_is_selected_on_click", PropertyInfo(Variant::VECTOR2, "position")));
 #endif
 
 	ClassDB::bind_method(D_METHOD("get_canvas_item"), &CanvasItem::get_canvas_item);


### PR DESCRIPTION
I'm one of the core developer of the SmartShape tool for Godot, and it seems not possible to capture when a node is being clicked in the editor if that node is custom drawn.  This pull request addresses that by exposing the tool only call from C++ to the script.

Below is a working example of that change.

![select_from_edit_window2](https://user-images.githubusercontent.com/7462993/99887884-b94d9b00-2c0d-11eb-923e-243c10dbc7a2.gif)

The script then only needs to return true to show it is selected, or false.

![image](https://user-images.githubusercontent.com/7462993/99887940-2103e600-2c0e-11eb-8be0-1e17936a38f9.png)

 