### PR TITLE
Mono/macOS: Move GodotSharp data to Resources to allow codesigning

### DIFF
--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -179,16 +179,16 @@ private:
 
 #ifdef OSX_ENABLED
 		if (!DirAccess::exists(data_editor_tools_dir)) {
-			data_editor_tools_dir = exe_dir.plus_file("../Frameworks/GodotSharp/Tools");
+			data_editor_tools_dir = exe_dir.plus_file("../Resources/GodotSharp/Tools");
 		}
 
 		if (!DirAccess::exists(data_editor_prebuilt_api_dir)) {
-			data_editor_prebuilt_api_dir = exe_dir.plus_file("../Frameworks/GodotSharp/Api");
+			data_editor_prebuilt_api_dir = exe_dir.plus_file("../Resources/GodotSharp/Api");
 		}
 
 		if (!DirAccess::exists(data_mono_root_dir)) {
 			data_mono_etc_dir = exe_dir.plus_file("../Resources/GodotSharp/Mono/etc");
-			data_mono_lib_dir = exe_dir.plus_file("../Frameworks/GodotSharp/Mono/lib");
+			data_mono_lib_dir = exe_dir.plus_file("../Resources/GodotSharp/Mono/lib");
 		}
 #endif
 
@@ -218,11 +218,11 @@ private:
 #ifdef OSX_ENABLED
 		if (!DirAccess::exists(data_mono_root_dir)) {
 			data_mono_etc_dir = exe_dir.plus_file("../Resources/GodotSharp/Mono/etc");
-			data_mono_lib_dir = exe_dir.plus_file("../Frameworks/GodotSharp/Mono/lib");
+			data_mono_lib_dir = exe_dir.plus_file("../Resources/GodotSharp/Mono/lib");
 		}
 
 		if (!DirAccess::exists(data_game_assemblies_dir)) {
-			data_game_assemblies_dir = exe_dir.plus_file("../Frameworks/GodotSharp/Assemblies");
+			data_game_assemblies_dir = exe_dir.plus_file("../Resources/GodotSharp/Assemblies");
 		}
 #endif
 

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -114,7 +114,7 @@ public:
 	virtual void get_platform_features(List<String> *r_features) override {
 		r_features->push_back("pc");
 		r_features->push_back("s3tc");
-		r_features->push_back("OSX");
+		r_features->push_back("macOS");
 	}
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) override {
@@ -678,14 +678,14 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 					ret = unzGoToNextFile(src_pkg_zip);
 					continue; // skip
 				}
-				file = file.replace("/data.mono.osx.64.release_debug/", "/data_" + pkg_name + "/");
+				file = file.replace("/data.mono.osx.64.release_debug/", "/GodotSharp/");
 			}
 			if (file.find("/data.mono.osx.64.release/") != -1) {
 				if (p_debug) {
 					ret = unzGoToNextFile(src_pkg_zip);
 					continue; // skip
 				}
-				file = file.replace("/data.mono.osx.64.release/", "/data_" + pkg_name + "/");
+				file = file.replace("/data.mono.osx.64.release/", "/GodotSharp/");
 			}
 
 			print_line("ADDING: " + file + " size: " + itos(data.size()));


### PR DESCRIPTION
This fixes #43732 -- that exported Mono projects could not be codesigned on the Mac due to their directory layout. This change creates a directory layout that is capable of being signed, and combined with [a change to the release build scripts](https://github.com/sjml/godot-build-scripts/commit/4c400fc07136ddbf6257cd32ef72335450d68834) will also create a version of the editor and export templates that work similarly. 

A few caveats:
1. ~~In the original issue, @bruvzg indicated that `etc` should go into `Frameworks` but this causes the codesign to fail due to the [policies about nested code](https://developer.apple.com/library/archive/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG201). I've put it into `Resources` instead, where the codesign cares less about the directory structure.~~ Per discussion below, the `lib` directory has been split up between `Resources` and `Frameworks`. 
2. The export no longer has a folder called `data_{GAMENAME}`, since the Mono distribution is more split up through the `.app`. I assume it was originally called that to have parity with the Linux and Windows exports, but since Mac applications are all bundled together and those details are invisible to the user, I didn't think that needed to be preserved. If it's significant for some other reason, please let me know. 
3. ~~[I'm slightly concerned that none of the loading code had to change to accommodate the different directories](https://github.com/godotengine/godot/issues/43732#issuecomment-731715196). I can't tell if Mono is just very good at finding its files, or if it's somehow picking up my system installation at runtime, or what. It works, but it's not 100% clear how, and I'm not a fan of that.~~ The loading code has now been changed, so it's clear there isn't magic going on.
4. Both the produced editor and export templates still produce `.app` packages that are unusable until they have `libMoltenVK.dylib` added to the `Frameworks` directory. I was following the existing build practices there, as it seems like the maintainers haven't yet settled on the best means of including it (#36213). I've poked on that issue thread to re-raise the question, and if it's something that can be decided soon-ish, this PR could easily be amended to accommodate whatever method makes sense. 

Long-term:
* This appears to be an issue with upstream mono as well (mono/mono#20304). It's unclear what the proper solution should be, but some seem to have a degree of success packing things together with [mkbundle](https://linux.die.net/man/1/mkbundle). Might be worth investigating? 
* [Unity ran into similar issues with their embedded Mono](https://issuetracker.unity3d.com/issues/cannot-distribute-macos-builds-codesign-errors-on-monobleedingedge-framework), and fixed them, but I haven't been able to find any documentation of what the change was. I briefly tried to seek out some games made before and after, but that's a hard search. If anyone has any insight or info there, it might be useful. 