### PR TITLE
Update EditorSceneImporterFBX.xml to correct bad export settings from Maya.

### DIFF
--- a/modules/fbx/doc_classes/EditorSceneImporterFBX.xml
+++ b/modules/fbx/doc_classes/EditorSceneImporterFBX.xml
@@ -14,7 +14,7 @@
 		- Blend Shapes
 		- Auto Tangents Only
 		- *Do not check* Constraints (as it will break the file)
-		- Units: ANY will work.
+		- Units: Any will work
 		- Binary format in FBX 2020
 		[/codeblock]
 	</description>

--- a/modules/fbx/doc_classes/EditorSceneImporterFBX.xml
+++ b/modules/fbx/doc_classes/EditorSceneImporterFBX.xml
@@ -7,24 +7,15 @@
 		This is an FBX 3D asset importer with full support for most FBX features.
 		If exporting a FBX scene from Autodesk Maya, use these FBX export settings:
 		[codeblock]
-		- Smoothing Groups
-		- Smooth Mesh
+		- Leave settings at default in most exporters. (settings below in Maya are mostly irrelevant as they are the defaults.)
 		- Triangluate (for meshes with blend shapes)
-		- Bake Animation
-		- Resample All
 		- Deformed Models
 		- Skins
 		- Blend Shapes
-		- Curve Filters
-		- Constant Key Reducer
 		- Auto Tangents Only
 		- *Do not check* Constraints (as it will break the file)
-		- Can check Embed Media (embeds textures into the exported FBX file)
-		  - Note that when importing embedded media, the texture and mesh will be a single immutable file.
-		  - You will have to re-export then re-import the FBX if the texture has changed.
-		- Units: Centimeters
-		- Up Axis: Y
-		- Binary format in FBX 2017
+		- Units: ANY will work.
+		- Binary format in FBX 2020
 		[/codeblock]
 	</description>
 	<tutorials>


### PR DESCRIPTION
These settings were wrong I have corrected them.

These options were required for assimp's fbx importer but not for the new one, the new one works with the default settings.