### PR TITLE
GDScript: Fix mishandling of stack pointers

### DIFF
--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -139,7 +139,9 @@ public:
 	// virtual void write_elseif(const Address &p_condition) = 0; This kind of makes things more difficult for no real benefit.
 	virtual void write_else() = 0;
 	virtual void write_endif() = 0;
-	virtual void write_for(const Address &p_variable, const Address &p_list) = 0;
+	virtual void start_for(const GDScriptDataType &p_iterator_type, const GDScriptDataType &p_list_type) = 0;
+	virtual void write_for_assignment(const Address &p_variable, const Address &p_list) = 0;
+	virtual void write_for() = 0;
 	virtual void write_endfor() = 0;
 	virtual void start_while_condition() = 0; // Used to allow a jump to the expression evaluation.
 	virtual void write_while(const Address &p_condition) = 0;


### PR DESCRIPTION
- Replace the for loop temporaries by locals. They cause conflicts with the stack when being popped, while locals are properly handled in the scope.
- Change the interface for the codegen so the for loop list doesn't live through the whole block if it's a temporary.
- Keep track of the actual amount of local variables in the stack. Using the size of the map is misleading in cases where multiple cals have the same name (which is allowed when there's no shadowing).
- Added a few debug checks for temporaries, to avoid them being wrongly manipulated in the future. They should not live more than a line of code.
- Rearrange some of compiler code to make sure the temporaries don't live across blocks.