### PR TITLE
Expose _edit_use_rect, _edit_is_selected_on_click and _edit_get_rect to script to handle editor selection for custom drawn nodes

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -60,10 +60,16 @@ bool AnimatedSprite2D::_edit_use_pivot() const {
 }
 
 Rect2 AnimatedSprite2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	return _get_rect();
 }
 
 bool AnimatedSprite2D::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
 	if (!frames.is_valid() || !frames->has_animation(animation) || frame < 0 || frame >= frames->get_frame_count(animation)) {
 		return false;
 	}

--- a/scene/2d/back_buffer_copy.cpp
+++ b/scene/2d/back_buffer_copy.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "back_buffer_copy.h"
+#include "scene/scene_string_names.h"
 
 void BackBufferCopy::_update_copy_mode() {
 	switch (copy_mode) {
@@ -47,10 +48,16 @@ void BackBufferCopy::_update_copy_mode() {
 
 #ifdef TOOLS_ENABLED
 Rect2 BackBufferCopy::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	return rect;
 }
 
 bool BackBufferCopy::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
 	return true;
 }
 #endif

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -35,6 +35,7 @@
 #include "core/math/geometry_2d.h"
 #include "scene/resources/concave_polygon_shape_2d.h"
 #include "scene/resources/convex_polygon_shape_2d.h"
+#include "scene/scene_string_names.h"
 
 #include "thirdparty/misc/triangulator.h"
 
@@ -217,14 +218,23 @@ CollisionPolygon2D::BuildMode CollisionPolygon2D::get_build_mode() const {
 
 #ifdef TOOLS_ENABLED
 Rect2 CollisionPolygon2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	return aabb;
 }
 
 bool CollisionPolygon2D::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
 	return true;
 }
 
 bool CollisionPolygon2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_is_selected_on_click))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_is_selected_on_click, p_point, p_tolerance);
+
 	return Geometry2D::is_point_in_polygon(p_point, Variant(polygon));
 }
 #endif

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -39,6 +39,7 @@
 #include "scene/resources/line_shape_2d.h"
 #include "scene/resources/rectangle_shape_2d.h"
 #include "scene/resources/segment_shape_2d.h"
+#include "scene/scene_string_names.h"
 
 void CollisionShape2D::_shape_changed() {
 	update();
@@ -165,6 +166,9 @@ Ref<Shape2D> CollisionShape2D::get_shape() const {
 }
 
 bool CollisionShape2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_is_selected_on_click))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_is_selected_on_click, p_point, p_tolerance);
+
 	if (!shape.is_valid()) {
 		return false;
 	}

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -33,6 +33,8 @@
 #include "core/config/engine.h"
 #include "servers/rendering_server.h"
 
+#include "scene/scene_string_names.h"
+
 void Light2D::_update_light_visibility() {
 	if (!is_inside_tree()) {
 		return;
@@ -352,6 +354,9 @@ bool PointLight2D::_edit_use_pivot() const {
 }
 
 Rect2 PointLight2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	if (texture.is_null()) {
 		return Rect2();
 	}
@@ -361,6 +366,9 @@ Rect2 PointLight2D::_edit_get_rect() const {
 }
 
 bool PointLight2D::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
 	return !texture.is_null();
 }
 #endif

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "light_occluder_2d.h"
 #include "core/math/geometry_2d.h"
+#include "scene/scene_string_names.h"
 
 #include "core/config/engine.h"
 
@@ -37,6 +38,9 @@
 
 #ifdef TOOLS_ENABLED
 Rect2 OccluderPolygon2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	if (rect_cache_dirty) {
 		if (closed) {
 			const Vector2 *r = polygon.ptr();
@@ -68,6 +72,9 @@ Rect2 OccluderPolygon2D::_edit_get_rect() const {
 }
 
 bool OccluderPolygon2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_is_selected_on_click))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_is_selected_on_click, p_point, p_tolerance);
+
 	if (closed) {
 		return Geometry2D::is_point_in_polygon(p_point, Variant(polygon));
 	} else {
@@ -202,10 +209,16 @@ void LightOccluder2D::_notification(int p_what) {
 
 #ifdef TOOLS_ENABLED
 Rect2 LightOccluder2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	return occluder_polygon.is_valid() ? occluder_polygon->_edit_get_rect() : Rect2();
 }
 
 bool LightOccluder2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_is_selected_on_click))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_is_selected_on_click, p_point, p_tolerance);
+
 	return occluder_polygon.is_valid() ? occluder_polygon->_edit_is_selected_on_click(p_point, p_tolerance) : false;
 }
 #endif

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "line_2d.h"
+#include "scene/scene_string_names.h"
 
 #include "core/core_string_names.h"
 #include "core/math/geometry_2d.h"
@@ -53,6 +54,9 @@ Line2D::Line2D() {
 
 #ifdef TOOLS_ENABLED
 Rect2 Line2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	if (_points.size() == 0) {
 		return Rect2(0, 0, 0, 0);
 	}
@@ -66,10 +70,16 @@ Rect2 Line2D::_edit_get_rect() const {
 }
 
 bool Line2D::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
 	return true;
 }
 
 bool Line2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_is_selected_on_click))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_is_selected_on_click, p_point, p_tolerance);
+
 	const real_t d = _width / 2 + p_tolerance;
 	const Vector2 *points = _points.ptr();
 	for (int i = 0; i < _points.size() - 1; i++) {

--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "mesh_instance_2d.h"
+#include "scene/scene_string_names.h"
 
 void MeshInstance2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
@@ -89,6 +90,9 @@ Ref<Texture2D> MeshInstance2D::get_texture() const {
 
 #ifdef TOOLS_ENABLED
 Rect2 MeshInstance2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	if (mesh.is_valid()) {
 		AABB aabb = mesh->get_aabb();
 		return Rect2(aabb.position.x, aabb.position.y, aabb.size.x, aabb.size.y);

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "multimesh_instance_2d.h"
+#include "scene/scene_string_names.h"
 
 void MultiMeshInstance2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
@@ -89,6 +90,9 @@ Ref<Texture2D> MultiMeshInstance2D::get_normal_map() const {
 
 #ifdef TOOLS_ENABLED
 Rect2 MultiMeshInstance2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	if (multimesh.is_valid()) {
 		AABB aabb = multimesh->get_aabb();
 		return Rect2(aabb.position.x, aabb.position.y, aabb.size.x, aabb.size.y);

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "navigation_region_2d.h"
+#include "scene/scene_string_names.h"
 
 #include "core/config/engine.h"
 #include "core/core_string_names.h"
@@ -41,6 +42,9 @@
 
 #ifdef TOOLS_ENABLED
 Rect2 NavigationPolygon::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	if (rect_cache_dirty) {
 		item_rect = Rect2();
 		bool first = true;
@@ -68,6 +72,9 @@ Rect2 NavigationPolygon::_edit_get_rect() const {
 }
 
 bool NavigationPolygon::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_is_selected_on_click))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_is_selected_on_click, p_point, p_tolerance);
+
 	for (int i = 0; i < outlines.size(); i++) {
 		const Vector<Vector2> &outline = outlines[i];
 		const int outline_size = outline.size();
@@ -383,10 +390,16 @@ bool NavigationRegion2D::is_enabled() const {
 /////////////////////////////
 #ifdef TOOLS_ENABLED
 Rect2 NavigationRegion2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	return navpoly.is_valid() ? navpoly->_edit_get_rect() : Rect2();
 }
 
 bool NavigationRegion2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_is_selected_on_click))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_is_selected_on_click, p_point, p_tolerance);
+
 	return navpoly.is_valid() ? navpoly->_edit_is_selected_on_click(p_point, p_tolerance) : false;
 }
 #endif

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -40,6 +40,9 @@
 
 #ifdef TOOLS_ENABLED
 Rect2 Path2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	if (!curve.is_valid() || curve->get_point_count() == 0) {
 		return Rect2(0, 0, 0, 0);
 	}
@@ -58,10 +61,16 @@ Rect2 Path2D::_edit_get_rect() const {
 }
 
 bool Path2D::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
 	return curve.is_valid() && curve->get_point_count() != 0;
 }
 
 bool Path2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_is_selected_on_click))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_is_selected_on_click, p_point, p_tolerance);
+
 	if (curve.is_null()) {
 		return false;
 	}

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -33,6 +33,8 @@
 #include "core/math/geometry_2d.h"
 #include "skeleton_2d.h"
 
+#include "scene/scene_string_names.h"
+
 #ifdef TOOLS_ENABLED
 Dictionary Polygon2D::_edit_get_state() const {
 	Dictionary state = Node2D::_edit_get_state();
@@ -59,6 +61,9 @@ bool Polygon2D::_edit_use_pivot() const {
 }
 
 Rect2 Polygon2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	if (rect_cache_dirty) {
 		int l = polygon.size();
 		const Vector2 *r = polygon.ptr();
@@ -78,10 +83,16 @@ Rect2 Polygon2D::_edit_get_rect() const {
 }
 
 bool Polygon2D::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
 	return polygon.size() > 0;
 }
 
 bool Polygon2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_is_selected_on_click))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_is_selected_on_click, p_point, p_tolerance);
+
 	Vector<Vector2> polygon2d = Variant(polygon);
 	if (internal_vertices > 0) {
 		polygon2d.resize(polygon2d.size() - internal_vertices);

--- a/scene/2d/position_2d.cpp
+++ b/scene/2d/position_2d.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/engine.h"
 #include "scene/resources/texture.h"
+#include "scene/scene_string_names.h"
 
 const float DEFAULT_GIZMO_EXTENTS = 10.0;
 
@@ -44,11 +45,17 @@ void Position2D::_draw_cross() {
 
 #ifdef TOOLS_ENABLED
 Rect2 Position2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	float extents = get_gizmo_extents();
 	return Rect2(Point2(-extents, -extents), Size2(extents * 2, extents * 2));
 }
 
 bool Position2D::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
 	return false;
 }
 #endif

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -61,14 +61,23 @@ bool Sprite2D::_edit_use_pivot() const {
 }
 
 bool Sprite2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_is_selected_on_click))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_is_selected_on_click, p_point, p_tolerance);
+
 	return is_pixel_opaque(p_point);
 }
 
 Rect2 Sprite2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	return get_rect();
 }
 
 bool Sprite2D::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
 	return texture.is_valid();
 }
 #endif

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -34,6 +34,7 @@
 #include "core/io/marshalls.h"
 #include "core/os/os.h"
 #include "scene/2d/area_2d.h"
+#include "scene/scene_string_names.h"
 #include "servers/navigation_server_2d.h"
 #include "servers/physics_server_2d.h"
 
@@ -1248,6 +1249,9 @@ Vector<int> TileMap::_get_tile_data() const {
 
 #ifdef TOOLS_ENABLED
 Rect2 TileMap::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	if (pending_update) {
 		const_cast<TileMap *>(this)->update_dirty_quadrants();
 	} else {

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -34,7 +34,8 @@
 #include "core/input/input_map.h"
 #include "core/os/os.h"
 #include "scene/main/window.h"
-#
+#include "scene/scene_string_names.h"
+
 void TouchScreenButton::set_texture(const Ref<Texture2D> &p_texture) {
 	texture = p_texture;
 	update();
@@ -312,6 +313,9 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 
 #ifdef TOOLS_ENABLED
 Rect2 TouchScreenButton::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	if (texture.is_null()) {
 		return CanvasItem::_edit_get_rect();
 	}
@@ -320,6 +324,9 @@ Rect2 TouchScreenButton::_edit_get_rect() const {
 }
 
 bool TouchScreenButton::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
 	return !texture.is_null();
 }
 #endif

--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -40,10 +40,16 @@
 
 #ifdef TOOLS_ENABLED
 Rect2 VisibilityNotifier2D::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	return rect;
 }
 
 bool VisibilityNotifier2D::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
 	return true;
 }
 #endif

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -124,10 +124,16 @@ void Control::_edit_set_rect(const Rect2 &p_edit_rect) {
 }
 
 Rect2 Control::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
 	return Rect2(Point2(), get_size());
 }
 
 bool Control::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
 	return true;
 }
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -323,11 +323,28 @@ CanvasItemMaterial::~CanvasItemMaterial() {
 ///////////////////////////////////////////////////////////////////
 #ifdef TOOLS_ENABLED
 bool CanvasItem::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_is_selected_on_click))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_is_selected_on_click, p_point, p_tolerance);
+
 	if (_edit_use_rect()) {
 		return _edit_get_rect().has_point(p_point);
 	} else {
 		return p_point.length() < p_tolerance;
 	}
+}
+
+bool CanvasItem::_edit_use_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_use_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_use_rect);
+
+	return false;
+}
+
+Rect2 CanvasItem::_edit_get_rect() const {
+	if (get_script_instance() && get_script_instance()->has_method(SceneStringNames::get_singleton()->_edit_get_rect))
+		return get_script_instance()->call(SceneStringNames::get_singleton()->_edit_get_rect);
+
+	return Rect2(0, 0, 0, 0);
 }
 
 Transform2D CanvasItem::_edit_get_transform() const {
@@ -1114,6 +1131,10 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_edit_get_pivot"), &CanvasItem::_edit_get_pivot);
 	ClassDB::bind_method(D_METHOD("_edit_use_pivot"), &CanvasItem::_edit_use_pivot);
 	ClassDB::bind_method(D_METHOD("_edit_get_transform"), &CanvasItem::_edit_get_transform);
+
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::RECT2, "_edit_get_rect"));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_edit_is_selected_on_click", PropertyInfo(Variant::VECTOR2, "position"), PropertyInfo(Variant::FLOAT, "tolerance")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "_edit_use_rect"));
 #endif
 
 	ClassDB::bind_method(D_METHOD("get_canvas_item"), &CanvasItem::get_canvas_item);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -294,9 +294,9 @@ public:
 	virtual float _edit_get_rotation() const { return 0.0; };
 
 	// Used to resize/move the node
-	virtual bool _edit_use_rect() const { return false; }; // MAYBE REPLACE BY A _edit_get_editmode()
+	virtual bool _edit_use_rect() const; // MAYBE REPLACE BY A _edit_get_editmode()
 	virtual void _edit_set_rect(const Rect2 &p_rect) {}
-	virtual Rect2 _edit_get_rect() const { return Rect2(0, 0, 0, 0); };
+	virtual Rect2 _edit_get_rect() const;
 	virtual Size2 _edit_get_minimum_size() const { return Size2(-1, -1); }; // LOOKS WEIRD
 
 	// Used to set a pivot

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -100,6 +100,10 @@ SceneStringNames::SceneStringNames() {
 	_exit_world = StaticCString::create("_exit_world");
 	_ready = StaticCString::create("_ready");
 
+	_edit_get_rect = StaticCString::create("_edit_get_rect");
+	_edit_use_rect = StaticCString::create("_edit_use_rect");
+	_edit_is_selected_on_click = StaticCString::create("_edit_is_selected_on_click");
+
 	_update_scroll = StaticCString::create("_update_scroll");
 	_update_xform = StaticCString::create("_update_xform");
 

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -123,6 +123,10 @@ public:
 	StringName _unhandled_input;
 	StringName _unhandled_key_input;
 
+	StringName _edit_get_rect;
+	StringName _edit_is_selected_on_click;
+	StringName _edit_use_rect;
+
 	StringName _pressed;
 	StringName _toggled;
 


### PR DESCRIPTION
I'm one of the core developer of the SmartShape tool for Godot, and it seems not possible to capture when a node is being clicked in the editor if that node is custom drawn. This pull request addresses that by exposing the tool only calls from C++ to the script.

Below is a working example of that change.  Please consider for a 3.2 Cherry-pick.

![select_from_edit_window3](https://user-images.githubusercontent.com/7462993/99910226-6e399380-2cb2-11eb-8476-98e0d8ca59a9.gif)

Sample GDScript of its use:

![image](https://user-images.githubusercontent.com/7462993/99910292-c2dd0e80-2cb2-11eb-9923-b75819ca3927.png)
