### PR TITLE
Put in check for zero sized textures

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -906,13 +906,22 @@ PREAMBLE(int)::_batch_find_or_create_tex(const RID &p_texture, const RID &p_norm
 	typename T_STORAGE::Texture *texture = _get_canvas_texture(p_texture);
 
 	if (texture) {
-		new_batch_tex.tex_pixel_size.x = 1.0 / texture->width;
-		new_batch_tex.tex_pixel_size.y = 1.0 / texture->height;
+		// special case, there can be textures with no width or height
+		int w = texture->width;
+		int h = texture->height;
+
+		if (!w || !h) {
+			w = 1;
+			h = 1;
+		}
+
+		new_batch_tex.tex_pixel_size.x = 1.0 / w;
+		new_batch_tex.tex_pixel_size.y = 1.0 / h;
 		new_batch_tex.flags = texture->flags;
 	} else {
 		// maybe doesn't need doing...
-		new_batch_tex.tex_pixel_size.x = 1.0;
-		new_batch_tex.tex_pixel_size.y = 1.0;
+		new_batch_tex.tex_pixel_size.x = 1.0f;
+		new_batch_tex.tex_pixel_size.y = 1.0f;
 		new_batch_tex.flags = 0;
 	}
 


### PR DESCRIPTION
To prevent divide by zero.

Fixes #43772

## Notes
* Turns out you can have zero sized textures in Godot! :grin: 

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
