### PR TITLE
fixed Camera2D rotation with non-square zoom

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -198,10 +198,10 @@ Transform2D Camera2D::get_camera_transform() {
 	camera_screen_center = screen_rect.position + screen_rect.size * 0.5;
 
 	Transform2D xform;
+	xform.scale_basis(zoom);
 	if (rotating) {
 		xform.set_rotation(angle);
 	}
-	xform.scale_basis(zoom);
 	xform.set_origin(screen_rect.position /*.floor()*/);
 
 	/*


### PR DESCRIPTION
**Godot version:** 3.2.3, 4.0

**OS/device including version:** Tested on HTML5 and Linux, but shouldn't matter

**Issue description:**
Changing the Zoom on a Camera2D to a non-square value breaks camera rotation.

**Steps to reproduce:**
- Create 2d scene.
- add Camera2D
- change zoom to `x=1,y=0.5`
- rotate camera
- watch blue camera preview lines pass through the origin instead of rotate around it. 

When this fixed is applied (move `xform.scale_basis(zoom);` to before the rotation check), the camera spins around the origin as expected.

This fix should work on both 3.2.3+ and 4.0.

**Minimal reproduction project:**

[camera2dTestProject.zip](https://github.com/godotengine/godot/files/5580710/camera2dTestProject.zip)

