### PR TITLE
Renamed String.ord_at to unicode_at

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3483,7 +3483,7 @@ String String::right(int p_pos) const {
 	return substr(p_pos, (length() - p_pos));
 }
 
-char32_t String::ord_at(int p_idx) const {
+char32_t String::unicode_at(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, length(), 0);
 	return operator[](p_idx);
 }
@@ -3782,20 +3782,20 @@ String String::http_escape() const {
 String String::http_unescape() const {
 	String res;
 	for (int i = 0; i < length(); ++i) {
-		if (ord_at(i) == '%' && i + 2 < length()) {
-			char32_t ord1 = ord_at(i + 1);
+		if (unicode_at(i) == '%' && i + 2 < length()) {
+			char32_t ord1 = unicode_at(i + 1);
 			if ((ord1 >= '0' && ord1 <= '9') || (ord1 >= 'A' && ord1 <= 'Z')) {
-				char32_t ord2 = ord_at(i + 2);
+				char32_t ord2 = unicode_at(i + 2);
 				if ((ord2 >= '0' && ord2 <= '9') || (ord2 >= 'A' && ord2 <= 'Z')) {
 					char bytes[3] = { (char)ord1, (char)ord2, 0 };
 					res += (char)strtol(bytes, nullptr, 16);
 					i += 2;
 				}
 			} else {
-				res += ord_at(i);
+				res += unicode_at(i);
 			}
 		} else {
-			res += ord_at(i);
+			res += unicode_at(i);
 		}
 	}
 	return String::utf8(res.ascii());

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -366,7 +366,7 @@ public:
 	String get_extension() const;
 	String get_basename() const;
 	String plus_file(const String &p_file) const;
-	char32_t ord_at(int p_idx) const;
+	char32_t unicode_at(int p_idx) const;
 
 	void erase(int p_pos, int p_chars);
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -929,7 +929,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(String, get_extension, sarray(), varray());
 	bind_method(String, get_basename, sarray(), varray());
 	bind_method(String, plus_file, sarray("file"), varray());
-	bind_method(String, ord_at, sarray("at"), varray());
+	bind_method(String, unicode_at, sarray("at"), varray());
 	bind_method(String, dedent, sarray(), varray());
 	// FIXME: String needs to be immutable when binding
 	//bind_method(String, erase, sarray("position", "chars"), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -547,15 +547,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="ord_at">
-			<return type="int">
-			</return>
-			<argument index="0" name="at" type="int">
-			</argument>
-			<description>
-				Returns the character code at position [code]at[/code].
-			</description>
-		</method>
 		<method name="pad_decimals">
 			<return type="String">
 			</return>
@@ -876,6 +867,15 @@
 			</argument>
 			<description>
 				Removes a given string from the end if it ends with it or leaves the string unchanged.
+			</description>
+		</method>
+		<method name="unicode_at">
+			<return type="int">
+			</return>
+			<argument index="0" name="at" type="int">
+			</argument>
+			<description>
+				Returns the character code at position [code]at[/code].
 			</description>
 		</method>
 		<method name="xml_escape">

--- a/tests/test_string.h
+++ b/tests/test_string.h
@@ -266,7 +266,7 @@ TEST_CASE("[String] Operator []") {
 	a[6] = 'C';
 	CHECK(a == "Sugar Cane");
 	CHECK(a[1] == 'u');
-	CHECK(a.ord_at(1) == 'u');
+	CHECK(a.unicode_at(1) == 'u');
 }
 
 TEST_CASE("[String] Case function test") {


### PR DESCRIPTION
One of the proposed renames from https://github.com/godotengine/godot/issues/16863
