### PR TITLE
Fix DebuggerMarshalls errors while profiling

### DIFF
--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -171,7 +171,7 @@ bool DebuggerMarshalls::ServersProfilerFrame::deserialize(const Array &p_arr) {
 		}
 		servers.push_back(si);
 	}
-	CHECK_SIZE(p_arr, idx + 3, "ServersProfilerFrame");
+	CHECK_SIZE(p_arr, idx + 1, "ServersProfilerFrame");
 	int func_size = p_arr[idx];
 	idx += 1;
 	CHECK_SIZE(p_arr, idx + func_size, "ServersProfilerFrame");


### PR DESCRIPTION
Fixed check for array size before `func_size`: when `func_size` is 0 there's only 1 entry left and not 3.

Fixes #43795
