### PR TITLE
Fix ccd enabled by default on Bullet bodies

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -744,7 +744,7 @@ void RigidBodyBullet::set_continuous_collision_detection(bool p_enable) {
 		}
 		btBody->setCcdSweptSphereRadius(radius * 0.2);
 	} else {
-		btBody->setCcdMotionThreshold(10000.0);
+		btBody->setCcdMotionThreshold(0.);
 		btBody->setCcdSweptSphereRadius(0.);
 	}
 }
@@ -824,7 +824,7 @@ void RigidBodyBullet::reload_shapes() {
 	btBody->updateInertiaTensor();
 
 	reload_kinematic_shapes();
-	set_continuous_collision_detection(btBody->getCcdMotionThreshold() < 9998.0);
+	set_continuous_collision_detection(is_continuous_collision_detection_enabled());
 	reload_body();
 }
 


### PR DESCRIPTION
Fix based on https://github.com/godotengine/godot/pull/42643#issuecomment-732296444

It was due to main_shape_changed being called two times for each added body. The first time it disables ccd, which sets the internal ccd threshold to be 10000. The second time, it enables ccd again because the internal threshold is > 0.

Bodies are now consistently created with disabled ccd by default.

This was causing crashing asserts in Bullet when adding bodies in some scenarios, in `btVector3::normalize()`:
```btAssert(!fuzzyZero());```
