### PR TITLE
[3.2] Update gradle build files to automatically perform signing and zipalign tasks for custom builds

### DIFF
--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -279,7 +279,7 @@ String _get_application_tag(const Ref<EditorExportPreset> &p_preset, const Strin
 	String manifest_application_text =
 			"    <application android:label=\"@string/godot_project_name_string\"\n"
 			"        android:allowBackup=\"false\" tools:ignore=\"GoogleAppIndexingWarning\"\n"
-			"        android:icon=\"@mipmap/icon\">)\n\n"
+			"        android:icon=\"@mipmap/icon\">\n\n"
 			"        <meta-data tools:node=\"remove\" android:name=\"xr_mode_metadata_name\" />\n";
 
 	manifest_application_text += _get_plugins_tag(plugins_names);

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -120,10 +120,41 @@ android {
         // doNotStrip '**/*.so'
     }
 
-    // Both signing and zip-aligning will be done at export time
-    buildTypes.all { buildType ->
-        buildType.zipAlignEnabled false
-        buildType.signingConfig null
+    signingConfigs {
+        release {
+            File keystoreFile = new File(getReleaseKeystoreFile())
+            if (keystoreFile.isFile()) {
+                storeFile keystoreFile
+                storePassword getReleaseKeystorePassword()
+                keyAlias getReleaseKeyAlias()
+                keyPassword getReleaseKeystorePassword()
+            }
+        }
+    }
+
+    buildTypes {
+
+        debug {
+            // Signing and zip-aligning are skipped for prebuilt builds, but
+            // performed for custom builds.
+            zipAlignEnabled shouldZipAlign()
+            if (shouldSign()) {
+                signingConfig signingConfigs.debug
+            } else {
+                signingConfig null
+            }
+        }
+
+        release {
+            // Signing and zip-aligning are skipped for prebuilt builds, but
+            // performed for custom builds.
+            zipAlignEnabled shouldZipAlign()
+            if (shouldSign()) {
+                signingConfig signingConfigs.release
+            } else {
+                signingConfig null
+            }
+        }
     }
 
     sourceSets {

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -34,7 +34,11 @@ ext.getExportVersionCode = { ->
     if (versionCode == null || versionCode.isEmpty()) {
         versionCode = "1"
     }
-    return Integer.parseInt(versionCode)
+    try {
+        return Integer.parseInt(versionCode)
+    } catch (NumberFormatException ignored) {
+        return 1
+    }
 }
 
 ext.getExportVersionName = { ->
@@ -135,4 +139,38 @@ ext.getGodotPluginsLocalBinaries = { ->
     }
 
     return binDeps
+}
+
+ext.getReleaseKeystoreFile = { ->
+    String keystoreFile = project.hasProperty("release_keystore_file") ? project.property("release_keystore_file") : ""
+    if (keystoreFile == null || keystoreFile.isEmpty()) {
+        keystoreFile = "."
+    }
+    return keystoreFile
+}
+
+ext.getReleaseKeystorePassword = { ->
+    String keystorePassword = project.hasProperty("release_keystore_password") ? project.property("release_keystore_password") : ""
+    return keystorePassword
+}
+
+ext.getReleaseKeyAlias = { ->
+    String keyAlias = project.hasProperty("release_keystore_alias") ? project.property("release_keystore_alias") : ""
+    return keyAlias
+}
+
+ext.shouldZipAlign = { ->
+    String zipAlignFlag = project.hasProperty("perform_zipalign") ? project.property("perform_zipalign") : ""
+    if (zipAlignFlag == null || zipAlignFlag.isEmpty()) {
+        zipAlignFlag = "false"
+    }
+    return Boolean.parseBoolean(zipAlignFlag)
+}
+
+ext.shouldSign = { ->
+    String signFlag = project.hasProperty("perform_signing") ? project.property("perform_signing") : ""
+    if (signFlag == null || signFlag.isEmpty()) {
+        signFlag = "false"
+    }
+    return Boolean.parseBoolean(signFlag)
 }


### PR DESCRIPTION
Follow up for issue #43650 which resolves the [invalid `)` character](https://github.com/godotengine/godot/issues/43650#issuecomment-731778604) when generating the manifest and improve the signing and zipalign logic for custom builds.