### PR TITLE
Add `AspectRatioContainer` class

### DIFF
--- a/doc/classes/AspectRatioContainer.xml
+++ b/doc/classes/AspectRatioContainer.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AspectRatioContainer" inherits="Container" version="4.0">
+	<brief_description>
+		Container that preserves its child controls' aspect ratio.
+	</brief_description>
+	<description>
+		Arranges child controls in a way to preserve their aspect ratio automatically whenever the container is resized. Solves the problem where the container size is dynamic and the contents' size needs to adjust accordingly without losing proportions.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="alignment_horizontal" type="int" setter="set_alignment_horizontal" getter="get_alignment_horizontal" enum="AspectRatioContainer.AlignMode" default="1">
+			Specifies the horizontal relative position of child controls.
+		</member>
+		<member name="alignment_vertical" type="int" setter="set_alignment_vertical" getter="get_alignment_vertical" enum="AspectRatioContainer.AlignMode" default="1">
+			Specifies the vertical relative position of child controls.
+		</member>
+		<member name="ratio" type="float" setter="set_ratio" getter="get_ratio" default="1.0">
+			The aspect ratio to enforce on child controls. This is the width divided by the height. The ratio depends on the [member stretch_mode].
+		</member>
+		<member name="stretch_mode" type="int" setter="set_stretch_mode" getter="get_stretch_mode" enum="AspectRatioContainer.StretchMode" default="2">
+			The stretch mode used to align child controls.
+		</member>
+	</members>
+	<constants>
+		<constant name="STRETCH_WIDTH_CONTROLS_HEIGHT" value="0" enum="StretchMode">
+			The height of child controls is automatically adjusted based on the width of the container.
+		</constant>
+		<constant name="STRETCH_HEIGHT_CONTROLS_WIDTH" value="1" enum="StretchMode">
+			The width of child controls is automatically adjusted based on the height of the container.
+		</constant>
+		<constant name="STRETCH_FIT" value="2" enum="StretchMode">
+			The bounding rectangle of child controls is automatically adjusted to fit inside the container while keeping the aspect ratio.
+		</constant>
+		<constant name="STRETCH_COVER" value="3" enum="StretchMode">
+			The width and height of child controls is automatically adjusted to make their bounding rectangle cover the entire area of the container while keeping the aspect ratio.
+			When the bounding rectangle of child controls exceed the container's size and [member Control.rect_clip_content] is enabled, this allows to show only the container's area restricted by its own bounding rectangle.
+		</constant>
+		<constant name="ALIGN_BEGIN" value="0" enum="AlignMode">
+			Aligns child controls with the beginning (left or top) of the container.
+		</constant>
+		<constant name="ALIGN_CENTER" value="1" enum="AlignMode">
+			Aligns child controls with the center of the container.
+		</constant>
+		<constant name="ALIGN_END" value="2" enum="AlignMode">
+			Aligns child controls with the end (right or bottom) of the container.
+		</constant>
+	</constants>
+</class>

--- a/editor/icons/AspectRatioContainer.svg
+++ b/editor/icons/AspectRatioContainer.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m5 1c-1.1046 0-2 .89543-2 2h2zm2 0v2h2v-2zm4 0v2h2c0-1.1046-.89543-2-2-2zm-8 4v2h2v-2zm8 0v2h2v-2zm-8 4v2h2v-2zm8 0v2h2v-2zm-8 4c0 1.1046.89543 2 2 2v-2zm4 0v2h2v-2zm4 0v2c1.1046 0 2-.89543 2-2z" fill="#a5efac"/></svg>

--- a/scene/gui/aspect_ratio_container.cpp
+++ b/scene/gui/aspect_ratio_container.cpp
@@ -1,0 +1,167 @@
+/*************************************************************************/
+/*  aspect_ratio_container.cpp                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "aspect_ratio_container.h"
+
+Size2 AspectRatioContainer::get_minimum_size() const {
+	Size2 ms;
+	for (int i = 0; i < get_child_count(); i++) {
+		Control *c = Object::cast_to<Control>(get_child(i));
+		if (!c) {
+			continue;
+		}
+		if (c->is_set_as_top_level()) {
+			continue;
+		}
+		if (!c->is_visible()) {
+			continue;
+		}
+		Size2 minsize = c->get_combined_minimum_size();
+		ms.width = MAX(ms.width, minsize.width);
+		ms.height = MAX(ms.height, minsize.height);
+	}
+	return ms;
+}
+
+void AspectRatioContainer::set_ratio(float p_ratio) {
+	ratio = p_ratio;
+	queue_sort();
+}
+
+void AspectRatioContainer::set_stretch_mode(StretchMode p_mode) {
+	stretch_mode = p_mode;
+	queue_sort();
+}
+
+void AspectRatioContainer::set_alignment_horizontal(AlignMode p_alignment_horizontal) {
+	alignment_horizontal = p_alignment_horizontal;
+	queue_sort();
+}
+
+void AspectRatioContainer::set_alignment_vertical(AlignMode p_alignment_vertical) {
+	alignment_vertical = p_alignment_vertical;
+	queue_sort();
+}
+
+void AspectRatioContainer::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_SORT_CHILDREN: {
+			Size2 size = get_size();
+			for (int i = 0; i < get_child_count(); i++) {
+				Control *c = Object::cast_to<Control>(get_child(i));
+				if (!c) {
+					continue;
+				}
+				if (c->is_set_as_top_level()) {
+					continue;
+				}
+				Size2 child_minsize = c->get_combined_minimum_size();
+				Size2 child_size = Size2(ratio, 1.0);
+				float scale_factor = 1.0;
+
+				switch (stretch_mode) {
+					case STRETCH_WIDTH_CONTROLS_HEIGHT: {
+						scale_factor = size.x / child_size.x;
+					} break;
+					case STRETCH_HEIGHT_CONTROLS_WIDTH: {
+						scale_factor = size.y / child_size.y;
+					} break;
+					case STRETCH_FIT: {
+						scale_factor = MIN(size.x / child_size.x, size.y / child_size.y);
+					} break;
+					case STRETCH_COVER: {
+						scale_factor = MAX(size.x / child_size.x, size.y / child_size.y);
+					} break;
+				}
+				child_size *= scale_factor;
+				child_size.x = MAX(child_size.x, child_minsize.x);
+				child_size.y = MAX(child_size.y, child_minsize.y);
+
+				float align_x = 0.5;
+				switch (alignment_horizontal) {
+					case ALIGN_BEGIN: {
+						align_x = 0.0;
+					} break;
+					case ALIGN_CENTER: {
+						align_x = 0.5;
+					} break;
+					case ALIGN_END: {
+						align_x = 1.0;
+					} break;
+				}
+				float align_y = 0.5;
+				switch (alignment_vertical) {
+					case ALIGN_BEGIN: {
+						align_y = 0.0;
+					} break;
+					case ALIGN_CENTER: {
+						align_y = 0.5;
+					} break;
+					case ALIGN_END: {
+						align_y = 1.0;
+					} break;
+				}
+				Vector2 offset = (size - child_size) * Vector2(align_x, align_y);
+
+				fit_child_in_rect(c, Rect2(offset, child_size));
+			}
+		} break;
+	}
+}
+
+void AspectRatioContainer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_ratio", "ratio"), &AspectRatioContainer::set_ratio);
+	ClassDB::bind_method(D_METHOD("get_ratio"), &AspectRatioContainer::get_ratio);
+
+	ClassDB::bind_method(D_METHOD("set_stretch_mode", "stretch_mode"), &AspectRatioContainer::set_stretch_mode);
+	ClassDB::bind_method(D_METHOD("get_stretch_mode"), &AspectRatioContainer::get_stretch_mode);
+
+	ClassDB::bind_method(D_METHOD("set_alignment_horizontal", "alignment_horizontal"), &AspectRatioContainer::set_alignment_horizontal);
+	ClassDB::bind_method(D_METHOD("get_alignment_horizontal"), &AspectRatioContainer::get_alignment_horizontal);
+
+	ClassDB::bind_method(D_METHOD("set_alignment_vertical", "alignment_vertical"), &AspectRatioContainer::set_alignment_vertical);
+	ClassDB::bind_method(D_METHOD("get_alignment_vertical"), &AspectRatioContainer::get_alignment_vertical);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ratio"), "set_ratio", "get_ratio");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_mode", PROPERTY_HINT_ENUM, "Width controls height,Height controls width,Fit,Cover"), "set_stretch_mode", "get_stretch_mode");
+
+	ADD_GROUP("Alignment", "alignment_");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment_horizontal", PROPERTY_HINT_ENUM, "Begin,Center,End"), "set_alignment_horizontal", "get_alignment_horizontal");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment_vertical", PROPERTY_HINT_ENUM, "Begin,Center,End"), "set_alignment_vertical", "get_alignment_vertical");
+
+	BIND_ENUM_CONSTANT(STRETCH_WIDTH_CONTROLS_HEIGHT);
+	BIND_ENUM_CONSTANT(STRETCH_HEIGHT_CONTROLS_WIDTH);
+	BIND_ENUM_CONSTANT(STRETCH_FIT);
+	BIND_ENUM_CONSTANT(STRETCH_COVER);
+
+	BIND_ENUM_CONSTANT(ALIGN_BEGIN);
+	BIND_ENUM_CONSTANT(ALIGN_CENTER);
+	BIND_ENUM_CONSTANT(ALIGN_END);
+}

--- a/scene/gui/aspect_ratio_container.h
+++ b/scene/gui/aspect_ratio_container.h
@@ -1,0 +1,80 @@
+/*************************************************************************/
+/*  aspect_ratio_container.h                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef ASPECT_RATIO_CONTAINER_H
+#define ASPECT_RATIO_CONTAINER_H
+
+#include "scene/gui/container.h"
+
+class AspectRatioContainer : public Container {
+	GDCLASS(AspectRatioContainer, Container);
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+	virtual Size2 get_minimum_size() const override;
+
+public:
+	enum StretchMode {
+		STRETCH_WIDTH_CONTROLS_HEIGHT,
+		STRETCH_HEIGHT_CONTROLS_WIDTH,
+		STRETCH_FIT,
+		STRETCH_COVER,
+	};
+	enum AlignMode {
+		ALIGN_BEGIN,
+		ALIGN_CENTER,
+		ALIGN_END,
+	};
+
+private:
+	float ratio = 1.0;
+	StretchMode stretch_mode = STRETCH_FIT;
+	AlignMode alignment_horizontal = ALIGN_CENTER;
+	AlignMode alignment_vertical = ALIGN_CENTER;
+
+public:
+	void set_ratio(float p_ratio);
+	float get_ratio() const { return ratio; }
+
+	void set_stretch_mode(StretchMode p_mode);
+	StretchMode get_stretch_mode() const { return stretch_mode; }
+
+	void set_alignment_horizontal(AlignMode p_alignment_horizontal);
+	AlignMode get_alignment_horizontal() const { return alignment_horizontal; }
+
+	void set_alignment_vertical(AlignMode p_alignment_vertical);
+	AlignMode get_alignment_vertical() const { return alignment_vertical; }
+};
+
+VARIANT_ENUM_CAST(AspectRatioContainer::StretchMode);
+VARIANT_ENUM_CAST(AspectRatioContainer::AlignMode);
+
+#endif // ASPECT_RATIO_CONTAINER_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -77,6 +77,7 @@
 #include "scene/animation/tween.h"
 #include "scene/audio/audio_stream_player.h"
 #include "scene/debugger/scene_debugger.h"
+#include "scene/gui/aspect_ratio_container.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/center_container.h"
@@ -324,6 +325,7 @@ void register_scene_types() {
 	ClassDB::register_class<ColorRect>();
 	ClassDB::register_class<NinePatchRect>();
 	ClassDB::register_class<ReferenceRect>();
+	ClassDB::register_class<AspectRatioContainer>();
 	ClassDB::register_class<TabContainer>();
 	ClassDB::register_class<Tabs>();
 	ClassDB::register_virtual_class<Separator>();


### PR DESCRIPTION
Closes godotengine/godot-proposals#69.
Based on work by @UgisBrekis in #32169, co-authored-by: @UgisBrekis (this will be reflected in commit history).

![image](https://user-images.githubusercontent.com/17108460/100029244-87009100-2df9-11eb-8582-c8d4940f2c29.png)

Main differences with #32169:
1. Alignment is changed to `enum` type rather than scalar, to achieve consistency with HBox/VBox containers. This actually made the implementation more complex, but this is the consensus I've inferred from godotengine/godot-proposals#69 as stated by @groud there https://github.com/godotengine/godot/pull/32169#issuecomment-535529095:

    > Ah indeed you are right and I was wrong here. But in that case, I do think this option could be removed from the H/VBoxContainers.
    > _Edit: though I am not sure there is a simple way to achieve the same result without this option. The fact that those containers do not shrink automatically to the smallest size might makes things complex_
    > 
    > Also, if we want it to be added, it will have to be consistent with the HBox and VBox containers, so it will have to be a enum. Consistency is more important here.

    And I actually lean towards solution proposed by @UgisBrekis here. Initially, I've even removed those `aligntment_x` and `alignment_y` properties altogether, but the default alignment behavior was quite confusing, and I couldn't figure out how to do the alignment properly *without* those options, so I think those properties are indeed needed (even if they're just `enum` properties), else it would be quite confusing to beginners to figure this out (even if there's a way to achieve desired alignment without those properties). I think this kind of reasoning also applies to existing HBox/VBox containers, to make usage intuitive out of the box.

2. `alignment_x/y` renamed to `alignment_horizontal/vertical`, because they are grouped in the inspector anyway.
3. Generated and written documentation, based on description in godotengine/godot-proposals#69.
4. Various code/convention/consistency fixes and minor typos.

There's no editor icon, but perhaps someone could design one (or perhaps there's existing one which I left unnoticed).
