### PR TITLE
Android: Properly implement OS.native_play_video

### DIFF
--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -192,7 +192,11 @@ String GodotIOJavaWrapper::get_system_dir(int p_dir) {
 }
 
 void GodotIOJavaWrapper::play_video(const String &p_path) {
-	// Why is this not here?!?!
+	if (_play_video) {
+		JNIEnv *env = ThreadAndroid::get_env();
+		jstring jStr = env->NewStringUTF(p_path.utf8().get_data());
+		env->CallVoidMethod(godot_io_instance, _play_video, jStr);
+	}
 }
 
 bool GodotIOJavaWrapper::is_video_playing() {


### PR DESCRIPTION
It was implemented in Java but not called in the IO wrapper it seems.

---

**Not tested yet.** I'm not even sure it compiles :)

The corresponding code has been removed from the `master` branch it seems @CC @m4gr3d @pouleyKetchoupp), and is now only implemented for iOS. We should maybe look into completing removing it from `master` and expose native video playback differently (CC @bruvzg @naithar).