### PR TITLE
Change 2d transform snapping from floor to round

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -453,6 +453,8 @@ void AnimatedSprite::_notification(int p_what) {
 				ofs -= s / 2;
 
 			if (Engine::get_singleton()->get_snap_2d_transforms()) {
+				ofs = ofs.round();
+			} else if (Engine::get_singleton()->get_use_pixel_snap()) {
 				ofs = ofs.floor();
 			}
 			Rect2 dst_rect(ofs, s);

--- a/scene/2d/sprite.cpp
+++ b/scene/2d/sprite.cpp
@@ -99,7 +99,10 @@ void Sprite::_get_rects(Rect2 &r_src_rect, Rect2 &r_dst_rect, bool &r_filter_cli
 	Point2 dest_offset = offset;
 	if (centered)
 		dest_offset -= frame_size / 2;
-	if (Engine::get_singleton()->get_use_pixel_snap()) {
+
+	if (Engine::get_singleton()->get_snap_2d_transforms()) {
+		dest_offset = dest_offset.round();
+	} else if (Engine::get_singleton()->get_use_pixel_snap()) {
 		dest_offset = dest_offset.floor();
 	}
 
@@ -378,7 +381,9 @@ Rect2 Sprite::get_rect() const {
 	Point2 ofs = offset;
 	if (centered)
 		ofs -= Size2(s) / 2;
-	if (Engine::get_singleton()->get_use_pixel_snap()) {
+	if (Engine::get_singleton()->get_snap_2d_transforms()) {
+		ofs = ofs.round();
+	} else if (Engine::get_singleton()->get_use_pixel_snap()) {
 		ofs = ofs.floor();
 	}
 

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -100,7 +100,7 @@ void VisualServerCanvas::_render_canvas_item(Item *p_canvas_item, const Transfor
 	Rect2 rect = ci->get_rect();
 	Transform2D xform = ci->xform;
 	if (snap_2d_transforms) {
-		xform.elements[2] = xform.elements[2].floor();
+		xform.elements[2] = xform.elements[2].round();
 	}
 	xform = p_transform * xform;
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -47,7 +47,7 @@ static Transform2D _canvas_get_transform(VisualServerViewport::Viewport *p_viewp
 
 		Transform2D c_xform = p_viewport->canvas_map[p_canvas->parent].transform;
 		if (snap) {
-			c_xform.elements[2] = c_xform.elements[2].floor();
+			c_xform.elements[2] = c_xform.elements[2].round();
 		}
 		xf = xf * c_xform;
 		scale = p_canvas->parent_scale;
@@ -55,7 +55,7 @@ static Transform2D _canvas_get_transform(VisualServerViewport::Viewport *p_viewp
 
 	Transform2D c_xform = p_canvas_data->transform;
 	if (snap) {
-		c_xform.elements[2] = c_xform.elements[2].floor();
+		c_xform.elements[2] = c_xform.elements[2].round();
 	}
 	xf = xf * c_xform;
 


### PR DESCRIPTION
Two common problems have emerged as a result of transform snapping:
1) Camera jitter with a camera following a snapped object
2) Pixel gaps between e.g. a platform and a player, where a platform rounds down and a player rounds up

Using round seems to greatly reduce problems due to camera jitter. It also may prove better for  pixel gaps because pixel art is often designed on a grid, so whole numbers are too expected, which are unstable with floor().

Fixes @CritCorsac camera jitter in #43554
Fixes worst effects of #43800
Fixes #44048
Fixes #46504

## Notes
* I started by making a PR which enabled switching between `floor` and `round` for transform snapping
* While testing this switchable PR it became apparent that round() seemed to work much better in all tests, especially reducing camera jitter

See first section of this gif to see camera jitter, and 2nd half shows the effect this PR would have:

![cam_delay_physics](https://user-images.githubusercontent.com/21999379/100083134-f51c7680-2e40-11eb-9cb7-c94d4616c9e1.gif)

So instead this PR simply replaces the existing floor method. Alternatively I could push the PR with selectable method if preferred, but in tests so far, I haven't found a situation where floor was better, and it might save on some confusion for users.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
