### PR TITLE
Batching - BackBuffer copy fix

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -1946,10 +1946,6 @@ void RasterizerCanvasGLES2::render_joined_item(const BItemJoined &p_bij, RenderI
 	}
 #endif
 
-	// this must be reset for each joined item,
-	// it only exists to prevent capturing the screen more than once per item
-	state.canvas_texscreen_used = false;
-
 	// all the joined items will share the same state with the first item
 	Item *ci = bdata.item_refs[p_bij.first_item_ref].item;
 

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1203,10 +1203,6 @@ void RasterizerCanvasGLES3::render_joined_item(const BItemJoined &p_bij, RenderI
 	}
 #endif
 
-	// this must be reset for each joined item,
-	// it only exists to prevent capturing the screen more than once per item
-	state.canvas_texscreen_used = false;
-
 	// all the joined items will share the same state with the first item
 	Item *p_ci = bdata.item_refs[p_bij.first_item_ref].item;
 

--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -3048,6 +3048,11 @@ PREAMBLE(bool)::_detect_item_batch_break(RenderItemState &r_ris, RasterizerCanva
 
 	} // else
 
+	// special case, back buffer copy, so don't join
+	if (p_ci->copy_back_buffer) {
+		return true;
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
For fixing a previous issue #38004, `state.canvas_texscreen_used` was reset to false at the start of each render_joined_item in PR #38200.

This was causing a later shader that used SCREEN_TEXTURE to force recapturing the back buffer immediately prior to use, which we don't want, in issue #43644.

This PR preserves the state across joined items, and also prevents joining of items that copy the back buffer as this may be problematic.

It turns out that the original issue that needed the line now appears to be fixed (by other improvements since), and the later issue is also fixed by removing it.

Fixes #43644

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
