### PR TITLE
Add option to display stack trace for errors and warnings

### DIFF
--- a/core/error/error_call_stack.cpp
+++ b/core/error/error_call_stack.cpp
@@ -1,0 +1,152 @@
+/*************************************************************************/
+/*  error_call_stack.cpp                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2020 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "error_call_stack.h"
+
+#ifdef DEBUG_ENABLED
+#include "core/config/project_settings.h"
+#include "core/debugger/engine_debugger.h"
+#include "core/os/os.h"
+
+ErrorCallStack *ErrorCallStack::singleton = nullptr;
+
+void ErrorCallStack::initialize() {
+	ERR_FAIL_COND(singleton != nullptr);
+
+	GLOBAL_DEF("debug/settings/error_handler/max_call_stack", 0);
+
+	singleton = new ErrorCallStack();
+
+	singleton->handler.errfunc = _err_handler;
+	singleton->handler.userdata = singleton;
+	add_error_handler(&singleton->handler);
+}
+
+void ErrorCallStack::finalize() {
+	ERR_FAIL_COND(singleton == nullptr);
+
+	remove_error_handler(&singleton->handler);
+	singleton->handler.errfunc = nullptr;
+	singleton->handler.userdata = nullptr;
+
+	delete singleton;
+	singleton = nullptr;
+}
+
+void ErrorCallStack::_err_handler(void *p_ud, const char *p_func, const char *p_file, int p_line, const char *p_err, const char *p_descr, ErrorHandlerType p_type) {
+	ERR_FAIL_COND(singleton == nullptr);
+	singleton->_err_handler_internal(p_ud, p_func, p_file, p_line, p_err, p_descr, p_type);
+}
+
+void ErrorCallStack::_err_handler_internal(void *p_ud, const char *p_func, const char *p_file, int p_line, const char *p_err, const char *p_descr, ErrorHandlerType p_type) {
+	if (processing) {
+		return;
+	}
+
+	processing = true;
+
+	if (!OS::get_singleton()) {
+		processing = false;
+		return;
+	}
+
+	if (!ProjectSettings::get_singleton()) {
+		processing = false;
+		return;
+	}
+
+	int max_frames = GLOBAL_GET("debug/settings/error_handler/max_call_stack");
+	if (max_frames < 1) {
+		processing = false;
+		return;
+	}
+
+	LocalVector<OS::StackFrame> stack;
+	OS::get_singleton()->get_stack_trace(stack, 3, max_frames);
+
+	int frame_count = stack.size();
+	if (frame_count > 0) {
+		OS::get_singleton()->printerr("Call Stack:\n");
+
+		bool skip_frames = true;
+
+		for (int frame_index = 0; frame_index < frame_count; ++frame_index) {
+			OS::StackFrame &frame = stack[frame_index];
+
+			// Skip frames until the error location is found to get rid of error handling calls.
+			// Skipping a fixed amount of frames is not accurate due to compiler optimizations.
+			if (skip_frames) {
+				if (frame.file.ends_with(p_file)) {
+					skip_frames = false;
+				} else {
+					continue;
+				}
+			}
+
+			if (frame.module.empty()) {
+				OS::get_singleton()->printerr("  - %s\n", frame.function.utf8().get_data());
+			} else {
+				OS::get_singleton()->printerr("  - %s:%s\n", frame.module.utf8().get_data(), frame.function.utf8().get_data());
+			}
+			if (!frame.file.empty()) {
+				OS::get_singleton()->printerr("    At %s, line %d\n", frame.file.utf8().get_data(), frame.line);
+			}
+
+			if (EngineDebugger::is_active()) {
+				if (frame.function.find("GDScriptFunction::call") || frame.function.find("GDScriptFunctions::call")) {
+					Vector<ScriptLanguage::StackInfo> si;
+					String language;
+
+					for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+						ScriptLanguage *scriptLanguage = ScriptServer::get_language(i);
+						si = scriptLanguage->debug_get_current_stack_info();
+						if (0 < si.size()) {
+							language = scriptLanguage->get_name();
+							break;
+						}
+					}
+
+					int num_script_frames = MIN(si.size(), frame_count - frame_index + 1);
+					if (0 < num_script_frames) {
+						for (int script_index = 0; script_index < num_script_frames; ++script_index) {
+							ScriptLanguage::StackInfo const &script_frame = si[script_index];
+							OS::get_singleton()->printerr("  - %s:%s\n", language.utf8().get_data(), script_frame.func.utf8().get_data());
+							OS::get_singleton()->printerr("    At %s, line %d\n", script_frame.file.utf8().get_data(), script_frame.line);
+						}
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	processing = false;
+}
+#endif

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -37,6 +37,7 @@
 #include "core/os/main_loop.h"
 #include "core/string/ustring.h"
 #include "core/templates/list.h"
+#include "core/templates/local_vector.h"
 #include "core/templates/vector.h"
 
 #include <stdarg.h>
@@ -120,6 +121,17 @@ public:
 	virtual PackedStringArray get_connected_midi_inputs();
 	virtual void open_midi_inputs();
 	virtual void close_midi_inputs();
+
+#ifdef DEBUG_ENABLED
+	struct StackFrame {
+		String function;
+		String module;
+		unsigned int line;
+		String file;
+	};
+
+	virtual void get_stack_trace(LocalVector<StackFrame> &p_frames, int p_skip_frames, int p_max_frames, void *p_context = nullptr) const {}
+#endif
 
 	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false) { return ERR_UNAVAILABLE; }
 	virtual Error close_dynamic_library(void *p_library_handle) { return ERR_UNAVAILABLE; }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -34,6 +34,7 @@
 #include "core/core_string_names.h"
 #include "core/crypto/crypto.h"
 #include "core/debugger/engine_debugger.h"
+#include "core/error/error_call_stack.h"
 #include "core/input/input.h"
 #include "core/input/input_map.h"
 #include "core/io/file_access_network.h"
@@ -522,6 +523,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	GLOBAL_DEF("debug/settings/crash_handler/message",
 			String("Please include this when reporting the bug on https://github.com/godotengine/godot/issues"));
+
+#ifdef DEBUG_ENABLED
+	ErrorCallStack::initialize();
+#endif
 
 	MAIN_PRINT("Main: Parse CMDLine");
 
@@ -2565,6 +2570,10 @@ void Main::cleanup() {
 	if (camera_server) {
 		memdelete(camera_server);
 	}
+
+#ifdef DEBUG_ENABLED
+	ErrorCallStack::finalize();
+#endif
 
 	OS::get_singleton()->finalize();
 

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -94,6 +94,10 @@ public:
 
 	void run();
 
+#ifdef DEBUG_ENABLED
+	virtual void get_stack_trace(LocalVector<StackFrame> &p_frames, int p_skip_frames, int p_max_frames, void *p_context = nullptr) const override;
+#endif
+
 	void disable_crash_handler();
 	bool is_disable_crash_handler() const;
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -271,6 +271,9 @@ def configure_msvc(env, manual_msvc_config):
         "dwmapi",
     ]
 
+    if env["target"] == "debug" or env["target"] == "release_debug":
+        LIBS += ["dbghelp"]
+
     env.AppendUnique(CPPDEFINES=["VULKAN_ENABLED"])
     if not env["builtin_vulkan"]:
         LIBS += ["vulkan"]
@@ -440,6 +443,9 @@ def configure_mingw(env):
             "dwmapi",
         ]
     )
+
+    if env["target"] == "debug" or env["target"] == "release_debug":
+        env.Append(LIBS=["dbghelp"])
 
     env.Append(CPPDEFINES=["VULKAN_ENABLED"])
     if not env["builtin_vulkan"]:

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -111,6 +111,10 @@ protected:
 	Map<ProcessID, ProcessInfo> *process_map;
 
 public:
+#ifdef DEBUG_ENABLED
+	virtual void get_stack_trace(LocalVector<StackFrame> &p_frames, int p_skip_frames, int p_max_frames, void *p_context = nullptr) const override;
+#endif
+
 	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false);
 	virtual Error close_dynamic_library(void *p_library_handle);
 	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false);


### PR DESCRIPTION
Support for optional stack traces in log on errors and warnings, based on a project setting option to set the call stack size, from https://github.com/godotengine/godot-proposals/issues/963.

Windows, Linux:
Implemented stack trace code in specific OS utility, used in common with the crash handler.

*Note:* On Windows, stack traces work only with MSVC, not with MingW (see #42540).

Other platforms:
Not supported yet.

----

**Example script:**
```
extends Node

func _ready():
	_test_error()

func _test_error():
	push_error("Test error")
	get_node("abc")
```

**Example output:**
```
ERROR: Test error
   at: GDScriptFunctions::call (modules\gdscript\gdscript_functions.cpp:749)
Callstack:
  - godot.windows.tools.64.exe:GDScriptFunctions::call
    At C:\dev\source\godot\modules\gdscript\gdscript_functions.cpp, line 750
  - GDScript:_test_error
    At res://Node.gd, line 7
  - GDScript:_ready
    At res://Node.gd, line 4
ERROR: Node not found: abc.
   at: (scene\main\node.cpp:1413)
Callstack:
  - godot.windows.tools.64.exe:Node::get_node
    At C:\dev\source\godot\scene\main\node.cpp, line 1413
  - godot.windows.tools.64.exe:call_with_variant_args_retc_helper<Node,Node *,NodePath const &,0>
    At C:\dev\source\godot\core\variant\binder_common.h, line 615
  - godot.windows.tools.64.exe:call_with_variant_args_retc_dv<Node,Node *,NodePath const &>
    At C:\dev\source\godot\core\variant\binder_common.h, line 451
  - godot.windows.tools.64.exe:MethodBindTRC<Node,Node *,NodePath const &>::call
    At C:\dev\source\godot\core\object\method_bind.h, line 555
  - godot.windows.tools.64.exe:GDScriptFunction::call
    At C:\dev\source\godot\modules\gdscript\gdscript_vm.cpp, line 1479
  - GDScript:_test_error
    At res://Node.gd, line 8
  - GDScript:_ready
    At res://Node.gd, line 4
```