### PR TITLE
Per object rid info for 3.2

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -761,11 +761,24 @@ public:
 
 	void render_info_begin_capture() {}
 	void render_info_end_capture() {}
-	int get_captured_render_info(VS::RenderInfo p_info) { return 0; }
 
 	int get_render_info(VS::RenderInfo p_info) { return 0; }
 	String get_video_adapter_name() const { return String(); }
 	String get_video_adapter_vendor() const { return String(); }
+
+	const Vector<int> get_captured_render_info() { return Vector<int>(); }
+	const Vector<int> get_captured_selected_render_info(const Vector<RID> &p_rids) {
+		Vector<int> new_info;
+		new_info.resize(VS::INFO_MAX);
+		return new_info;
+	}
+	const Vector<int> get_render_info() {
+		Vector<int> new_info;
+		new_info.resize(VS::INFO_MAX);
+		return new_info;
+	}
+
+	bool has_shadows() { return true; }
 
 	static RasterizerStorage *base_singleton;
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5880,68 +5880,40 @@ void RasterizerStorageGLES2::render_info_end_capture() {
 	info.snap._2d_draw_call_count = info.render._2d_draw_call_count - info.snap._2d_draw_call_count;
 }
 
-int RasterizerStorageGLES2::get_captured_render_info(VS::RenderInfo p_info) {
-
-	switch (p_info) {
-		case VS::INFO_OBJECTS_IN_FRAME: {
-			return info.snap.object_count;
-		} break;
-		case VS::INFO_VERTICES_IN_FRAME: {
-			return info.snap.vertices_count;
-		} break;
-		case VS::INFO_MATERIAL_CHANGES_IN_FRAME: {
-			return info.snap.material_switch_count;
-		} break;
-		case VS::INFO_SHADER_CHANGES_IN_FRAME: {
-			return info.snap.shader_rebind_count;
-		} break;
-		case VS::INFO_SURFACE_CHANGES_IN_FRAME: {
-			return info.snap.surface_switch_count;
-		} break;
-		case VS::INFO_DRAW_CALLS_IN_FRAME: {
-			return info.snap.draw_call_count;
-		} break;
-		case VS::INFO_2D_ITEMS_IN_FRAME: {
-			return info.snap._2d_item_count;
-		} break;
-		case VS::INFO_2D_DRAW_CALLS_IN_FRAME: {
-			return info.snap._2d_draw_call_count;
-		} break;
-		default: {
-			return get_render_info(p_info);
-		}
-	}
+const Vector<int> RasterizerStorageGLES2::get_captured_selected_render_info(const Vector<RID> &p_rids) {
+	Vector<int> new_info;
+	new_info.resize(VS::INFO_MAX);
+	return new_info;
 }
 
-int RasterizerStorageGLES2::get_render_info(VS::RenderInfo p_info) {
-	switch (p_info) {
-		case VS::INFO_OBJECTS_IN_FRAME:
-			return info.render_final.object_count;
-		case VS::INFO_VERTICES_IN_FRAME:
-			return info.render_final.vertices_count;
-		case VS::INFO_MATERIAL_CHANGES_IN_FRAME:
-			return info.render_final.material_switch_count;
-		case VS::INFO_SHADER_CHANGES_IN_FRAME:
-			return info.render_final.shader_rebind_count;
-		case VS::INFO_SURFACE_CHANGES_IN_FRAME:
-			return info.render_final.surface_switch_count;
-		case VS::INFO_DRAW_CALLS_IN_FRAME:
-			return info.render_final.draw_call_count;
-		case VS::INFO_2D_ITEMS_IN_FRAME:
-			return info.render_final._2d_item_count;
-		case VS::INFO_2D_DRAW_CALLS_IN_FRAME:
-			return info.render_final._2d_draw_call_count;
-		case VS::INFO_USAGE_VIDEO_MEM_TOTAL:
-			return 0; //no idea
-		case VS::INFO_VIDEO_MEM_USED:
-			return info.vertex_mem + info.texture_mem;
-		case VS::INFO_TEXTURE_MEM_USED:
-			return info.texture_mem;
-		case VS::INFO_VERTEX_MEM_USED:
-			return info.vertex_mem;
-		default:
-			return 0; //no idea either
-	}
+const Vector<int> RasterizerStorageGLES2::get_captured_render_info() {
+	Vector<int> new_info;
+	new_info.resize(VS::INFO_MAX);
+	int *info_write = new_info.ptrw();
+	info_write[VS::INFO_OBJECTS_IN_FRAME] = info.snap.object_count;
+	info_write[VS::INFO_VERTICES_IN_FRAME] = info.snap.vertices_count;
+	info_write[VS::INFO_MATERIAL_CHANGES_IN_FRAME] = info.snap.material_switch_count;
+	info_write[VS::INFO_SHADER_CHANGES_IN_FRAME] = info.snap.shader_rebind_count;
+	info_write[VS::INFO_SURFACE_CHANGES_IN_FRAME] = info.snap.surface_switch_count;
+	info_write[VS::INFO_DRAW_CALLS_IN_FRAME] = info.snap.draw_call_count;
+	return new_info;
+}
+
+const Vector<int> RasterizerStorageGLES2::get_render_info() {
+	Vector<int> new_info;
+	new_info.resize(VS::INFO_MAX);
+	int *info_write = new_info.ptrw();
+	info_write[VS::INFO_OBJECTS_IN_FRAME] = info.render_final.object_count;
+	info_write[VS::INFO_VERTICES_IN_FRAME] = info.render_final.vertices_count;
+	info_write[VS::INFO_MATERIAL_CHANGES_IN_FRAME] = info.render_final.material_switch_count;
+	info_write[VS::INFO_SHADER_CHANGES_IN_FRAME] = info.render_final.shader_rebind_count;
+	info_write[VS::INFO_SURFACE_CHANGES_IN_FRAME] = info.render_final.surface_switch_count;
+	info_write[VS::INFO_DRAW_CALLS_IN_FRAME] = info.render_final.draw_call_count;
+	info_write[VS::INFO_USAGE_VIDEO_MEM_TOTAL] = 0; //no idea
+	info_write[VS::INFO_VIDEO_MEM_USED] = info.vertex_mem + info.texture_mem;
+	info_write[VS::INFO_TEXTURE_MEM_USED] = info.texture_mem;
+	info_write[VS::INFO_VERTEX_MEM_USED] = info.vertex_mem;
+	return new_info;
 }
 
 String RasterizerStorageGLES2::get_video_adapter_name() const {

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1325,6 +1325,8 @@ public:
 
 	} frame;
 
+	Vector<RID> render_info_rids;
+
 	void initialize();
 	void finalize();
 
@@ -1336,13 +1338,16 @@ public:
 
 	virtual void set_debug_generate_wireframes(bool p_generate);
 
+	virtual const Vector<int> get_captured_render_info();
+	virtual const Vector<int> get_captured_selected_render_info(const Vector<RID> &p_rids);
+	virtual void set_object_detail_list(Vector<RID> p_rids) { render_info_rids.append_array(p_rids); };
+	virtual void clear_object_detail_list() { render_info_rids.clear(); }
 	virtual void render_info_begin_capture();
 	virtual void render_info_end_capture();
-	virtual int get_captured_render_info(VS::RenderInfo p_info);
 
-	virtual int get_render_info(VS::RenderInfo p_info);
 	virtual String get_video_adapter_name() const;
 	virtual String get_video_adapter_vendor() const;
+	virtual const Vector<int> get_render_info();
 
 	void buffer_orphan_and_upload(unsigned int p_buffer_size, unsigned int p_offset, unsigned int p_data_size, const void *p_data, GLenum p_target = GL_ARRAY_BUFFER, GLenum p_usage = GL_DYNAMIC_DRAW, bool p_optional_orphan = false) const;
 	bool safe_buffer_sub_data(unsigned int p_total_buffer_size, GLenum p_target, unsigned int p_offset, unsigned int p_data_size, const void *p_data, unsigned int &r_offset_after) const;

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -216,6 +216,11 @@ void RasterizerGLES3::begin_frame(double frame_step) {
 	storage->info.render_final = storage->info.render;
 	storage->info.render.reset();
 
+	for (Map<RID_Data *, RasterizerStorageGLES3::Info::Render>::Element *E = storage->info.rid_render_info_render.front(); E; E = E->next()) {
+		storage->info.rid_render_info_final[E->key()] = E->get();
+	}
+	storage->info.rid_render_info_render.clear();
+
 	scene->iteration();
 }
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1532,19 +1532,41 @@ void RasterizerSceneGLES3::_render_geometry(RenderList::Element *e) {
 			if (state.debug_draw == VS::VIEWPORT_DEBUG_DRAW_WIREFRAME && s->array_wireframe_id) {
 
 				glDrawElements(GL_LINES, s->index_wireframe_len, GL_UNSIGNED_INT, 0);
+				if (storage->info.per_id_instance) {
+					RasterizerStorageGLES3::Info::Render render = {};
+					if (storage->info.rid_render_info_render.has(s->mesh)) {
+						render = storage->info.rid_render_info_render[s->mesh];
+					}
+					render.vertices_count += s->index_array_len;
+					storage->info.rid_render_info_render[s->mesh] = render;
+				}
 				storage->info.render.vertices_count += s->index_array_len;
 			} else
 #endif
 					if (s->index_array_len > 0) {
 
 				glDrawElements(gl_primitive[s->primitive], s->index_array_len, (s->array_len >= (1 << 16)) ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT, 0);
-
+				if (storage->info.per_id_instance) {
+					RasterizerStorageGLES3::Info::Render render = {};
+					if (storage->info.rid_render_info_render.has(s->mesh)) {
+						render = storage->info.rid_render_info_render[s->mesh];
+					}
+					render.vertices_count += s->index_array_len;
+					storage->info.rid_render_info_render[s->mesh] = render;
+				}
 				storage->info.render.vertices_count += s->index_array_len;
 
 			} else {
 
 				glDrawArrays(gl_primitive[s->primitive], 0, s->array_len);
-
+				if (storage->info.per_id_instance) {
+					RasterizerStorageGLES3::Info::Render render = {};
+					if (storage->info.rid_render_info_render.has(s->mesh)) {
+						render = storage->info.rid_render_info_render[s->mesh];
+					}
+					render.vertices_count += s->array_len;
+					storage->info.rid_render_info_render[s->mesh] = render;
+				}
 				storage->info.render.vertices_count += s->array_len;
 			}
 
@@ -1564,19 +1586,41 @@ void RasterizerSceneGLES3::_render_geometry(RenderList::Element *e) {
 			if (state.debug_draw == VS::VIEWPORT_DEBUG_DRAW_WIREFRAME && s->array_wireframe_id) {
 
 				glDrawElementsInstanced(GL_LINES, s->index_wireframe_len, GL_UNSIGNED_INT, 0, amount);
+				if (storage->info.per_id_instance) {
+					RasterizerStorageGLES3::Info::Render render = {};
+					if (storage->info.rid_render_info_render.has(s->mesh)) {
+						render = storage->info.rid_render_info_render[s->mesh];
+					}
+					render.vertices_count += s->index_array_len * amount;
+					storage->info.rid_render_info_render[s->mesh] = render;
+				}
 				storage->info.render.vertices_count += s->index_array_len * amount;
 			} else
 #endif
 					if (s->index_array_len > 0) {
 
 				glDrawElementsInstanced(gl_primitive[s->primitive], s->index_array_len, (s->array_len >= (1 << 16)) ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT, 0, amount);
-
+				if (storage->info.per_id_instance) {
+					RasterizerStorageGLES3::Info::Render render = {};
+					if (storage->info.rid_render_info_render.has(s->mesh)) {
+						render = storage->info.rid_render_info_render[s->mesh];
+					}
+					render.vertices_count += s->index_array_len * amount;
+					storage->info.rid_render_info_render[s->mesh] = render;
+				}
 				storage->info.render.vertices_count += s->index_array_len * amount;
 
 			} else {
 
 				glDrawArraysInstanced(gl_primitive[s->primitive], 0, s->array_len, amount);
-
+				if (storage->info.per_id_instance) {
+					RasterizerStorageGLES3::Info::Render render = {};
+					if (storage->info.rid_render_info_render.has(s->mesh)) {
+						render = storage->info.rid_render_info_render[s->mesh];
+					}
+					render.vertices_count += s->array_len * amount;
+					storage->info.rid_render_info_render[s->mesh] = render;
+				}
 				storage->info.render.vertices_count += s->array_len * amount;
 			}
 
@@ -1602,7 +1646,6 @@ void RasterizerSceneGLES3::_render_geometry(RenderList::Element *e) {
 
 				int vertices = c.vertices.size();
 				uint32_t buf_ofs = 0;
-
 				storage->info.render.vertices_count += vertices;
 
 				if (c.texture.is_valid() && storage->texture_owner.owns(c.texture)) {
@@ -1746,19 +1789,41 @@ void RasterizerSceneGLES3::_render_geometry(RenderList::Element *e) {
 					if (state.debug_draw == VS::VIEWPORT_DEBUG_DRAW_WIREFRAME && s->array_wireframe_id) {
 
 						glDrawElementsInstanced(GL_LINES, s->index_wireframe_len, GL_UNSIGNED_INT, 0, amount - split);
+						if (storage->info.per_id_instance) {
+							RasterizerStorageGLES3::Info::Render render = {};
+							if (storage->info.rid_render_info_render.has(s)) {
+								render = storage->info.rid_render_info_render[s];
+							}
+							render.vertices_count += s->index_array_len * (amount - split);
+							storage->info.rid_render_info_render[s] = render;
+						}
 						storage->info.render.vertices_count += s->index_array_len * (amount - split);
 					} else
 #endif
 							if (s->index_array_len > 0) {
 
 						glDrawElementsInstanced(gl_primitive[s->primitive], s->index_array_len, (s->array_len >= (1 << 16)) ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT, 0, amount - split);
-
+						if (storage->info.per_id_instance) {
+							RasterizerStorageGLES3::Info::Render render = {};
+							if (storage->info.rid_render_info_render.has(s->mesh)) {
+								render = storage->info.rid_render_info_render[s->mesh];
+							}
+							render.vertices_count += s->index_array_len * (amount - split);
+							storage->info.rid_render_info_render[s->mesh] = render;
+						}
 						storage->info.render.vertices_count += s->index_array_len * (amount - split);
 
 					} else {
 
 						glDrawArraysInstanced(gl_primitive[s->primitive], 0, s->array_len, amount - split);
-
+						if (storage->info.per_id_instance) {
+							RasterizerStorageGLES3::Info::Render render = {};
+							if (storage->info.rid_render_info_render.has(s->mesh)) {
+								render = storage->info.rid_render_info_render[s->mesh];
+							}
+							render.vertices_count += s->array_len * (amount - split);
+							storage->info.rid_render_info_render[s->mesh] = render;
+						}
 						storage->info.render.vertices_count += s->array_len * (amount - split);
 					}
 				}
@@ -1784,19 +1849,40 @@ void RasterizerSceneGLES3::_render_geometry(RenderList::Element *e) {
 					if (state.debug_draw == VS::VIEWPORT_DEBUG_DRAW_WIREFRAME && s->array_wireframe_id) {
 
 						glDrawElementsInstanced(GL_LINES, s->index_wireframe_len, GL_UNSIGNED_INT, 0, split);
+						if (storage->info.per_id_instance) {
+							RasterizerStorageGLES3::Info::Render render = {};
+							if (storage->info.rid_render_info_render.has(s->mesh)) {
+								render = storage->info.rid_render_info_render[s->mesh];
+							}
+							render.vertices_count += s->index_array_len * split;
+						}
 						storage->info.render.vertices_count += s->index_array_len * split;
 					} else
 #endif
 							if (s->index_array_len > 0) {
 
 						glDrawElementsInstanced(gl_primitive[s->primitive], s->index_array_len, (s->array_len >= (1 << 16)) ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT, 0, split);
-
+						if (storage->info.per_id_instance) {
+							RasterizerStorageGLES3::Info::Render render = {};
+							if (storage->info.rid_render_info_render.has(s->mesh)) {
+								render = storage->info.rid_render_info_render[s->mesh];
+							}
+							render.vertices_count += s->index_array_len * split;
+							storage->info.rid_render_info_render[s->mesh] = render;
+						}
 						storage->info.render.vertices_count += s->index_array_len * split;
 
 					} else {
 
 						glDrawArraysInstanced(gl_primitive[s->primitive], 0, s->array_len, split);
-
+						if (storage->info.per_id_instance) {
+							RasterizerStorageGLES3::Info::Render render = {};
+							if (storage->info.rid_render_info_render.has(s->mesh)) {
+								render = storage->info.rid_render_info_render[s->mesh];
+							}
+							render.vertices_count += s->array_len * split;
+							storage->info.rid_render_info_render[s->mesh] = render;
+						}
 						storage->info.render.vertices_count += s->array_len * split;
 					}
 				}
@@ -1808,6 +1894,14 @@ void RasterizerSceneGLES3::_render_geometry(RenderList::Element *e) {
 				if (state.debug_draw == VS::VIEWPORT_DEBUG_DRAW_WIREFRAME && s->array_wireframe_id) {
 
 					glDrawElementsInstanced(GL_LINES, s->index_wireframe_len, GL_UNSIGNED_INT, 0, amount);
+					if (storage->info.per_id_instance) {
+						RasterizerStorageGLES3::Info::Render render = {};
+						if (storage->info.rid_render_info_render.has(s->mesh)) {
+							render = storage->info.rid_render_info_render[s->mesh];
+						}
+						render.vertices_count += s->index_array_len * amount;
+						storage->info.rid_render_info_render[s->mesh] = render;
+					}
 					storage->info.render.vertices_count += s->index_array_len * amount;
 				} else
 #endif
@@ -1815,13 +1909,27 @@ void RasterizerSceneGLES3::_render_geometry(RenderList::Element *e) {
 						if (s->index_array_len > 0) {
 
 					glDrawElementsInstanced(gl_primitive[s->primitive], s->index_array_len, (s->array_len >= (1 << 16)) ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT, 0, amount);
-
+					if (storage->info.per_id_instance) {
+						RasterizerStorageGLES3::Info::Render render = {};
+						if (storage->info.rid_render_info_render.has(s->mesh)) {
+							render = storage->info.rid_render_info_render[s->mesh];
+						}
+						render.vertices_count += s->index_array_len * amount;
+						storage->info.rid_render_info_render[s->mesh] = render;
+					}
 					storage->info.render.vertices_count += s->index_array_len * amount;
 
 				} else {
 
 					glDrawArraysInstanced(gl_primitive[s->primitive], 0, s->array_len, amount);
-
+					if (storage->info.per_id_instance) {
+						RasterizerStorageGLES3::Info::Render render = {};
+						if (storage->info.rid_render_info_render.has(s->mesh)) {
+							render = storage->info.rid_render_info_render[s->mesh];
+						}
+						render.vertices_count += s->array_len * amount;
+						storage->info.rid_render_info_render[s->mesh] = render;
+					}
 					storage->info.render.vertices_count += s->array_len * amount;
 				}
 			}
@@ -2042,6 +2150,15 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 	for (int i = 0; i < p_element_count; i++) {
 
 		RenderList::Element *e = p_elements[i];
+		RasterizerStorageGLES3::Info::Render render = {};
+		RasterizerStorageGLES3::Surface *s = nullptr;
+		if (e->instance->base_type == VS::INSTANCE_MESH) {
+			s = static_cast<RasterizerStorageGLES3::Surface *>(e->geometry);
+			render = storage->info.rid_render_info_render[s->mesh];
+		}
+		if (storage->info.per_id_instance) {
+			render.draw_call_count++;
+		}
 		RasterizerStorageGLES3::Material *material = e->material;
 		RasterizerStorageGLES3::Skeleton *skeleton = NULL;
 		if (e->instance->skeleton.is_valid()) {
@@ -2207,11 +2324,16 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 		if (material != prev_material || rebind) {
 
 			storage->info.render.material_switch_count++;
-
+			if (storage->info.per_id_instance) {
+				render.material_switch_count++;
+			}
 			rebind = _setup_material(material, use_opaque_prepass, p_alpha_pass);
 
 			if (rebind) {
 				storage->info.render.shader_rebind_count++;
+				if (storage->info.per_id_instance) {
+					render.shader_rebind_count++;
+				}
 			}
 		}
 
@@ -2222,13 +2344,18 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 		if (e->owner != prev_owner || prev_base_type != e->instance->base_type || prev_geometry != e->geometry) {
 
 			_setup_geometry(e, p_view_transform);
+			if (storage->info.per_id_instance) {
+				render.surface_switch_count++;
+			}
 			storage->info.render.surface_switch_count++;
 		}
 
 		_set_cull(e->sort_key & RenderList::SORT_KEY_MIRROR_FLAG, e->sort_key & RenderList::SORT_KEY_CULL_DISABLED_FLAG, p_reverse_cull);
 
 		state.scene_shader.set_uniform(SceneShaderGLES3::WORLD_TRANSFORM, e->instance->transform);
-
+		if (s) {
+			storage->info.rid_render_info_render[s->mesh] = render;
+		}
 		_render_geometry(e);
 
 		prev_material = material;
@@ -3149,7 +3276,14 @@ void RasterizerSceneGLES3::_fill_render_list(InstanceBase **p_cull_result, int p
 
 				RasterizerStorageGLES3::Mesh *mesh = storage->mesh_owner.getptr(inst->base);
 				ERR_CONTINUE(!mesh);
-
+				if (storage->info.rid_render_info_render.has(mesh)) {
+					if (storage->info.per_id_instance) {
+						RasterizerStorageGLES3::Info::Render render = {};
+						render = storage->info.rid_render_info_render[mesh];
+						render.object_count++;
+						storage->info.rid_render_info_render[mesh] = render;
+					}
+				}
 				int ssize = mesh->surfaces.size();
 
 				for (int j = 0; j < ssize; j++) {
@@ -3166,7 +3300,14 @@ void RasterizerSceneGLES3::_fill_render_list(InstanceBase **p_cull_result, int p
 
 				RasterizerStorageGLES3::MultiMesh *multi_mesh = storage->multimesh_owner.getptr(inst->base);
 				ERR_CONTINUE(!multi_mesh);
-
+				if (storage->info.rid_render_info_render.has(multi_mesh)) {
+					if (storage->info.per_id_instance) {
+						RasterizerStorageGLES3::Info::Render render = {};
+						render = storage->info.rid_render_info_render[multi_mesh];
+						render.object_count++;
+						storage->info.rid_render_info_render[multi_mesh] = render;
+					}
+				}
 				if (multi_mesh->size == 0 || multi_mesh->visible_instances == 0)
 					continue;
 
@@ -3187,7 +3328,14 @@ void RasterizerSceneGLES3::_fill_render_list(InstanceBase **p_cull_result, int p
 
 				RasterizerStorageGLES3::Immediate *immediate = storage->immediate_owner.getptr(inst->base);
 				ERR_CONTINUE(!immediate);
-
+				if (storage->info.rid_render_info_render.has(immediate)) {
+					if (storage->info.per_id_instance) {
+						RasterizerStorageGLES3::Info::Render render = {};
+						render = storage->info.rid_render_info_render[immediate];
+						render.object_count++;
+						storage->info.rid_render_info_render[immediate] = render;
+					}
+				}
 				_add_geometry(immediate, inst, NULL, -1, p_depth_pass, p_shadow_pass);
 
 			} break;
@@ -3195,7 +3343,14 @@ void RasterizerSceneGLES3::_fill_render_list(InstanceBase **p_cull_result, int p
 
 				RasterizerStorageGLES3::Particles *particles = storage->particles_owner.getptr(inst->base);
 				ERR_CONTINUE(!particles);
-
+				if (storage->info.rid_render_info_render.has(particles)) {
+					if (storage->info.per_id_instance) {
+						RasterizerStorageGLES3::Info::Render render = {};
+						render = storage->info.rid_render_info_render[particles];
+						render.object_count++;
+						storage->info.rid_render_info_render[particles] = render;
+					}
+				}
 				for (int j = 0; j < particles->draw_passes.size(); j++) {
 
 					RID pmesh = particles->draw_passes[j];

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -8243,6 +8243,10 @@ void RasterizerStorageGLES3::set_debug_generate_wireframes(bool p_generate) {
 void RasterizerStorageGLES3::render_info_begin_capture() {
 
 	info.snap = info.render;
+	info.rid_render_info_snap.clear();
+	for (Map<RID_Data *, Info::Render>::Element *E = info.rid_render_info_render.front(); E; E = E->next()) {
+		info.rid_render_info_snap[E->key()] = E->get();
+	}
 }
 
 void RasterizerStorageGLES3::render_info_end_capture() {
@@ -8255,73 +8259,109 @@ void RasterizerStorageGLES3::render_info_end_capture() {
 	info.snap.vertices_count = info.render.vertices_count - info.snap.vertices_count;
 	info.snap._2d_item_count = info.render._2d_item_count - info.snap._2d_item_count;
 	info.snap._2d_draw_call_count = info.render._2d_draw_call_count - info.snap._2d_draw_call_count;
+	for (Map<RID_Data *, Info::Render>::Element *E = info.rid_render_info_render.front(); E; E = E->next()) {
+		Info::Render render = E->get();
+		Map<RID_Data *, Info::Render>::Element *value = info.rid_render_info_snap.find(E->key());
+		Info::Render snap = value ? value->get() : Info::Render();
+		snap.object_count = render.object_count - snap.object_count;
+		snap.draw_call_count = render.draw_call_count - snap.draw_call_count;
+		snap.material_switch_count = render.material_switch_count - snap.material_switch_count;
+		snap.surface_switch_count = render.surface_switch_count - snap.surface_switch_count;
+		snap.shader_rebind_count = render.shader_rebind_count - snap.shader_rebind_count;
+		snap.vertices_count = render.vertices_count - snap.vertices_count;
+		info.rid_render_info_snap[E->key()] = snap;
+	}
 }
 
-int RasterizerStorageGLES3::get_captured_render_info(VS::RenderInfo p_info) {
+const Vector<int> RasterizerStorageGLES3::get_captured_render_info() {
+	Vector<int> new_info;
+	new_info.resize(VS::INFO_MAX);
+	int *info_write = new_info.ptrw();
+	info_write[VS::INFO_OBJECTS_IN_FRAME] = info.snap.object_count;
+	info_write[VS::INFO_VERTICES_IN_FRAME] = info.snap.vertices_count;
+	info_write[VS::INFO_MATERIAL_CHANGES_IN_FRAME] = info.snap.material_switch_count;
+	info_write[VS::INFO_SHADER_CHANGES_IN_FRAME] = info.snap.shader_rebind_count;
+	info_write[VS::INFO_SURFACE_CHANGES_IN_FRAME] = info.snap.surface_switch_count;
+	info_write[VS::INFO_DRAW_CALLS_IN_FRAME] = info.snap.draw_call_count;
+	return new_info;
+}
 
-	switch (p_info) {
-		case VS::INFO_OBJECTS_IN_FRAME: {
-
-			return info.snap.object_count;
-		} break;
-		case VS::INFO_VERTICES_IN_FRAME: {
-
-			return info.snap.vertices_count;
-		} break;
-		case VS::INFO_MATERIAL_CHANGES_IN_FRAME: {
-			return info.snap.material_switch_count;
-		} break;
-		case VS::INFO_SHADER_CHANGES_IN_FRAME: {
-			return info.snap.shader_rebind_count;
-		} break;
-		case VS::INFO_SURFACE_CHANGES_IN_FRAME: {
-			return info.snap.surface_switch_count;
-		} break;
-		case VS::INFO_DRAW_CALLS_IN_FRAME: {
-			return info.snap.draw_call_count;
-		} break;
-		case VS::INFO_2D_ITEMS_IN_FRAME: {
-			return info.snap._2d_item_count;
-		} break;
-		case VS::INFO_2D_DRAW_CALLS_IN_FRAME: {
-			return info.snap._2d_draw_call_count;
-		} break;
-		default: {
-			return get_render_info(p_info);
+const Vector<int> RasterizerStorageGLES3::get_captured_selected_render_info(const Vector<RID> &p_rids) {
+	Vector<int> new_info;
+	new_info.resize(VS::VIEWPORT_RENDER_INFO_MAX);
+	int *info_write = new_info.ptrw();
+	{
+		int32_t object_count = 0;
+		for (int32_t i = 0; i < p_rids.size(); i++) {
+			Info::Render snap = info.rid_render_info_snap[p_rids[i].get_data()];
+			object_count += snap.object_count;
+			info.rid_render_info_snap[p_rids[i].get_data()] = snap;
 		}
+		info_write[VS::INFO_OBJECTS_IN_FRAME] = object_count;
 	}
+	{
+		int32_t vertices_count = 0;
+		for (int32_t i = 0; i < p_rids.size(); i++) {
+			Info::Render snap = info.rid_render_info_snap[p_rids[i].get_data()];
+			vertices_count += snap.vertices_count;
+			info.rid_render_info_snap[p_rids[i].get_data()] = snap;
+		}
+		info_write[VS::INFO_VERTICES_IN_FRAME] = vertices_count;
+	}
+	{
+		int32_t material_switch_count = 0;
+		for (int32_t i = 0; i < p_rids.size(); i++) {
+			Info::Render snap = info.rid_render_info_snap[p_rids[i].get_data()];
+			material_switch_count += snap.material_switch_count;
+			info.rid_render_info_snap[p_rids[i].get_data()] = snap;
+		}
+		info_write[VS::INFO_MATERIAL_CHANGES_IN_FRAME] = material_switch_count;
+	}
+	{
+		int32_t shader_rebind_count = 0;
+		for (int32_t i = 0; i < p_rids.size(); i++) {
+			Info::Render snap = info.rid_render_info_snap[p_rids[i].get_data()];
+			shader_rebind_count += snap.shader_rebind_count;
+			info.rid_render_info_snap[p_rids[i].get_data()] = snap;
+		}
+		info_write[VS::INFO_SHADER_CHANGES_IN_FRAME] = shader_rebind_count;
+	}
+	{
+		int32_t surface_switch_count = 0;
+		for (int32_t i = 0; i < p_rids.size(); i++) {
+			Info::Render snap = info.rid_render_info_snap[p_rids[i].get_data()];
+			surface_switch_count += snap.surface_switch_count;
+			info.rid_render_info_snap[p_rids[i].get_data()] = snap;
+		}
+		info_write[VS::INFO_SURFACE_CHANGES_IN_FRAME] = surface_switch_count;
+	}
+	{
+		int32_t draw_call_count = 0;
+		for (int32_t i = 0; i < p_rids.size(); i++) {
+			Info::Render snap = info.rid_render_info_snap[p_rids[i].get_data()];
+			draw_call_count += snap.draw_call_count;
+			info.rid_render_info_snap[p_rids[i].get_data()] = snap;
+		}
+		info_write[VS::INFO_DRAW_CALLS_IN_FRAME] = draw_call_count;
+	}
+	return new_info;
 }
 
-int RasterizerStorageGLES3::get_render_info(VS::RenderInfo p_info) {
-
-	switch (p_info) {
-		case VS::INFO_OBJECTS_IN_FRAME:
-			return info.render_final.object_count;
-		case VS::INFO_VERTICES_IN_FRAME:
-			return info.render_final.vertices_count;
-		case VS::INFO_MATERIAL_CHANGES_IN_FRAME:
-			return info.render_final.material_switch_count;
-		case VS::INFO_SHADER_CHANGES_IN_FRAME:
-			return info.render_final.shader_rebind_count;
-		case VS::INFO_SURFACE_CHANGES_IN_FRAME:
-			return info.render_final.surface_switch_count;
-		case VS::INFO_DRAW_CALLS_IN_FRAME:
-			return info.render_final.draw_call_count;
-		case VS::INFO_2D_ITEMS_IN_FRAME:
-			return info.render_final._2d_item_count;
-		case VS::INFO_2D_DRAW_CALLS_IN_FRAME:
-			return info.render_final._2d_draw_call_count;
-		case VS::INFO_USAGE_VIDEO_MEM_TOTAL:
-			return 0; //no idea
-		case VS::INFO_VIDEO_MEM_USED:
-			return info.vertex_mem + info.texture_mem;
-		case VS::INFO_TEXTURE_MEM_USED:
-			return info.texture_mem;
-		case VS::INFO_VERTEX_MEM_USED:
-			return info.vertex_mem;
-		default:
-			return 0; //no idea either
-	}
+const Vector<int> RasterizerStorageGLES3::get_render_info() {
+	Vector<int> new_info;
+	new_info.resize(VS::INFO_MAX);
+	int *info_write = new_info.ptrw();
+	info_write[VS::INFO_OBJECTS_IN_FRAME] = info.render_final.object_count;
+	info_write[VS::INFO_VERTICES_IN_FRAME] = info.render_final.vertices_count;
+	info_write[VS::INFO_MATERIAL_CHANGES_IN_FRAME] = info.render_final.material_switch_count;
+	info_write[VS::INFO_SHADER_CHANGES_IN_FRAME] = info.render_final.shader_rebind_count;
+	info_write[VS::INFO_SURFACE_CHANGES_IN_FRAME] = info.render_final.surface_switch_count;
+	info_write[VS::INFO_DRAW_CALLS_IN_FRAME] = info.render_final.draw_call_count;
+	info_write[VS::INFO_USAGE_VIDEO_MEM_TOTAL] = 0;
+	info_write[VS::INFO_VIDEO_MEM_USED] = info.vertex_mem + info.texture_mem;
+	info_write[VS::INFO_TEXTURE_MEM_USED] = info.texture_mem;
+	info_write[VS::INFO_VERTEX_MEM_USED] = info.vertex_mem;
+	return new_info;
 }
 
 String RasterizerStorageGLES3::get_video_adapter_name() const {

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -175,12 +175,21 @@ public:
 			}
 		} render, render_final, snap;
 
+		bool per_id_instance = true;
+
+		Map<RID_Data *, Render> rid_render_info_render, rid_render_info_final, rid_render_info_snap;
+
 		Info() {
 
+#ifndef TOOLS_ENABLED
+			per_id_instance = false;
+#endif
 			texture_mem = 0;
 			vertex_mem = 0;
 			render.reset();
 			render_final.reset();
+			rid_render_info_render.clear();
+			rid_render_info_final.clear();
 		}
 
 	} info;
@@ -1493,6 +1502,8 @@ public:
 
 	} frame;
 
+	Vector<RID> render_info_rids;
+
 	void initialize();
 	void finalize();
 
@@ -1504,9 +1515,10 @@ public:
 
 	virtual void render_info_begin_capture();
 	virtual void render_info_end_capture();
-	virtual int get_captured_render_info(VS::RenderInfo p_info);
 
-	virtual int get_render_info(VS::RenderInfo p_info);
+	virtual const Vector<int> get_captured_render_info();
+	virtual const Vector<int> get_captured_selected_render_info(const Vector<RID> &p_rids);
+	virtual const Vector<int> get_render_info();
 	virtual String get_video_adapter_name() const;
 	virtual String get_video_adapter_vendor() const;
 

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -36,6 +36,7 @@
 #include "editor/editor_scale.h"
 #include "scene/3d/immediate_geometry.h"
 #include "scene/3d/light.h"
+#include "scene/3d/mesh_instance.h"
 #include "scene/3d/visual_instance.h"
 #include "scene/gui/panel_container.h"
 
@@ -284,6 +285,7 @@ private:
 		_FORCE_INLINE_ bool operator<(const _RayResult &p_rr) const { return depth < p_rr.depth; }
 	};
 
+	void _update_render_info();
 	void _update_name();
 	void _compute_edit(const Point2 &p_point);
 	void _clear_selected();
@@ -313,6 +315,7 @@ private:
 	float get_zfar() const;
 	float get_fov() const;
 
+	void _get_children_rids(Node *p_current);
 	ObjectID clicked;
 	Vector<_RayResult> selection_results;
 	bool clicked_includes_current;

--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -143,20 +143,24 @@ float Performance::get_monitor(Monitor p_monitor) const {
 		case MEMORY_MESSAGE_BUFFER_MAX: return MessageQueue::get_singleton()->get_max_buffer_usage();
 		case OBJECT_COUNT: return ObjectDB::get_object_count();
 		case OBJECT_RESOURCE_COUNT: return ResourceCache::get_cached_resource_count();
-		case OBJECT_NODE_COUNT: return _get_node_count();
-		case OBJECT_ORPHAN_NODE_COUNT: return Node::orphan_node_count;
-		case RENDER_OBJECTS_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_OBJECTS_IN_FRAME);
-		case RENDER_VERTICES_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_VERTICES_IN_FRAME);
-		case RENDER_MATERIAL_CHANGES_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_MATERIAL_CHANGES_IN_FRAME);
-		case RENDER_SHADER_CHANGES_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_SHADER_CHANGES_IN_FRAME);
-		case RENDER_SURFACE_CHANGES_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_SURFACE_CHANGES_IN_FRAME);
-		case RENDER_DRAW_CALLS_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_DRAW_CALLS_IN_FRAME);
-		case RENDER_2D_ITEMS_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_2D_ITEMS_IN_FRAME);
-		case RENDER_2D_DRAW_CALLS_IN_FRAME: return VS::get_singleton()->get_render_info(VS::INFO_2D_DRAW_CALLS_IN_FRAME);
-		case RENDER_VIDEO_MEM_USED: return VS::get_singleton()->get_render_info(VS::INFO_VIDEO_MEM_USED);
-		case RENDER_TEXTURE_MEM_USED: return VS::get_singleton()->get_render_info(VS::INFO_TEXTURE_MEM_USED);
-		case RENDER_VERTEX_MEM_USED: return VS::get_singleton()->get_render_info(VS::INFO_VERTEX_MEM_USED);
-		case RENDER_USAGE_VIDEO_MEM_TOTAL: return VS::get_singleton()->get_render_info(VS::INFO_USAGE_VIDEO_MEM_TOTAL);
+		case OBJECT_NODE_COUNT: {
+
+			MainLoop *ml = OS::get_singleton()->get_main_loop();
+			SceneTree *sml = Object::cast_to<SceneTree>(ml);
+			if (!sml)
+				return 0;
+			return sml->get_node_count();
+		};
+		case RENDER_OBJECTS_IN_FRAME: return VS::get_singleton()->get_render_info()[VS::INFO_OBJECTS_IN_FRAME];
+		case RENDER_VERTICES_IN_FRAME: return VS::get_singleton()->get_render_info()[VS::INFO_VERTICES_IN_FRAME];
+		case RENDER_MATERIAL_CHANGES_IN_FRAME: return VS::get_singleton()->get_render_info()[VS::INFO_MATERIAL_CHANGES_IN_FRAME];
+		case RENDER_SHADER_CHANGES_IN_FRAME: return VS::get_singleton()->get_render_info()[VS::INFO_SHADER_CHANGES_IN_FRAME];
+		case RENDER_SURFACE_CHANGES_IN_FRAME: return VS::get_singleton()->get_render_info()[VS::INFO_SURFACE_CHANGES_IN_FRAME];
+		case RENDER_DRAW_CALLS_IN_FRAME: return VS::get_singleton()->get_render_info()[VS::INFO_DRAW_CALLS_IN_FRAME];
+		case RENDER_VIDEO_MEM_USED: return VS::get_singleton()->get_render_info()[VS::INFO_VIDEO_MEM_USED];
+		case RENDER_TEXTURE_MEM_USED: return VS::get_singleton()->get_render_info()[VS::INFO_TEXTURE_MEM_USED];
+		case RENDER_VERTEX_MEM_USED: return VS::get_singleton()->get_render_info()[VS::INFO_VERTEX_MEM_USED];
+		case RENDER_USAGE_VIDEO_MEM_TOTAL: return VS::get_singleton()->get_render_info()[VS::INFO_USAGE_VIDEO_MEM_TOTAL];
 		case PHYSICS_2D_ACTIVE_OBJECTS: return Physics2DServer::get_singleton()->get_process_info(Physics2DServer::INFO_ACTIVE_OBJECTS);
 		case PHYSICS_2D_COLLISION_PAIRS: return Physics2DServer::get_singleton()->get_process_info(Physics2DServer::INFO_COLLISION_PAIRS);
 		case PHYSICS_2D_ISLAND_COUNT: return Physics2DServer::get_singleton()->get_process_info(Physics2DServer::INFO_ISLAND_COUNT);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3114,9 +3114,9 @@ Viewport::DebugDraw Viewport::get_debug_draw() const {
 	return debug_draw;
 }
 
-int Viewport::get_render_info(RenderInfo p_info) {
+Vector<int> Viewport::get_render_info() {
 
-	return VS::get_singleton()->viewport_get_render_info(viewport, VS::ViewportRenderInfo(p_info));
+	return VS::get_singleton()->viewport_get_render_info(viewport);
 }
 
 void Viewport::set_snap_controls_to_pixels(bool p_enable) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -552,7 +552,7 @@ public:
 	void set_debug_draw(DebugDraw p_debug_draw);
 	DebugDraw get_debug_draw() const;
 
-	int get_render_info(RenderInfo p_info);
+	Vector<int> get_render_info();
 
 	void set_snap_controls_to_pixels(bool p_enable);
 	bool is_snap_controls_to_pixels_enabled() const;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -595,12 +595,12 @@ public:
 
 	virtual void render_info_begin_capture() = 0;
 	virtual void render_info_end_capture() = 0;
-	virtual int get_captured_render_info(VS::RenderInfo p_info) = 0;
 
-	virtual int get_render_info(VS::RenderInfo p_info) = 0;
 	virtual String get_video_adapter_name() const = 0;
 	virtual String get_video_adapter_vendor() const = 0;
-
+	virtual const Vector<int> get_captured_render_info() = 0;
+	virtual const Vector<int> get_captured_selected_render_info(const Vector<RID> &p_rids) = 0;
+	virtual const Vector<int> get_render_info() = 0;
 	static RasterizerStorage *base_singleton;
 	RasterizerStorage();
 	virtual ~RasterizerStorage() {}

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -148,9 +148,9 @@ void VisualServerRaster::finish() {
 
 /* STATUS INFORMATION */
 
-int VisualServerRaster::get_render_info(RenderInfo p_info) {
+Vector<int> VisualServerRaster::get_render_info() {
 
-	return VSG::storage->get_render_info(p_info);
+	return VSG::storage->get_render_info();
 }
 
 String VisualServerRaster::get_video_adapter_name() const {

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -103,6 +103,8 @@ public:
 	m_r m_name(m_type1 arg1, m_type2 arg2) { return BINDBASE->m_name(arg1, arg2); }
 #define BIND2RC(m_r, m_name, m_type1, m_type2) \
 	m_r m_name(m_type1 arg1, m_type2 arg2) const { return BINDBASE->m_name(arg1, arg2); }
+#define BIND3R(m_r, m_name, m_type1, m_type2, m_type3) \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3) { return BINDBASE->m_name(arg1, arg2, arg3); }
 #define BIND3RC(m_r, m_name, m_type1, m_type2, m_type3) \
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3) const { return BINDBASE->m_name(arg1, arg2, arg3); }
 #define BIND4RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4) \
@@ -490,7 +492,11 @@ public:
 	BIND2(viewport_set_hdr, RID, bool)
 	BIND2(viewport_set_usage, RID, ViewportUsage)
 
-	BIND2R(int, viewport_get_render_info, RID, ViewportRenderInfo)
+	BIND1R(Vector<int>, viewport_get_render_info, RID)
+	BIND1R(Vector<int>, viewport_get_selected_render_info, RID)
+	BIND2(viewport_queue_selected_render_info, RID, RID);
+	BIND1(viewport_selected_render_info_clear, RID);
+
 	BIND2(viewport_set_debug_draw, RID, ViewportDebugDraw)
 
 	/* ENVIRONMENT API */
@@ -685,7 +691,7 @@ public:
 
 	/* STATUS INFORMATION */
 
-	virtual int get_render_info(RenderInfo p_info);
+	virtual Vector<int> get_render_info();
 	virtual String get_video_adapter_name() const;
 	virtual String get_video_adapter_vendor() const;
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -342,16 +342,21 @@ void VisualServerViewport::draw_viewports() {
 
 			// render standard mono camera
 			_draw_viewport(vp);
-
 			VSG::storage->render_info_end_capture();
-			vp->render_info[VS::VIEWPORT_RENDER_INFO_OBJECTS_IN_FRAME] = VSG::storage->get_captured_render_info(VS::INFO_OBJECTS_IN_FRAME);
-			vp->render_info[VS::VIEWPORT_RENDER_INFO_VERTICES_IN_FRAME] = VSG::storage->get_captured_render_info(VS::INFO_VERTICES_IN_FRAME);
-			vp->render_info[VS::VIEWPORT_RENDER_INFO_MATERIAL_CHANGES_IN_FRAME] = VSG::storage->get_captured_render_info(VS::INFO_MATERIAL_CHANGES_IN_FRAME);
-			vp->render_info[VS::VIEWPORT_RENDER_INFO_SHADER_CHANGES_IN_FRAME] = VSG::storage->get_captured_render_info(VS::INFO_SHADER_CHANGES_IN_FRAME);
-			vp->render_info[VS::VIEWPORT_RENDER_INFO_SURFACE_CHANGES_IN_FRAME] = VSG::storage->get_captured_render_info(VS::INFO_SURFACE_CHANGES_IN_FRAME);
-			vp->render_info[VS::VIEWPORT_RENDER_INFO_DRAW_CALLS_IN_FRAME] = VSG::storage->get_captured_render_info(VS::INFO_DRAW_CALLS_IN_FRAME);
-			vp->render_info[VS::VIEWPORT_RENDER_INFO_2D_ITEMS_IN_FRAME] = VSG::storage->get_captured_render_info(VS::INFO_2D_ITEMS_IN_FRAME);
-			vp->render_info[VS::VIEWPORT_RENDER_INFO_2D_DRAW_CALLS_IN_FRAME] = VSG::storage->get_captured_render_info(VS::INFO_2D_DRAW_CALLS_IN_FRAME);
+			const Vector<int> frame_info = VSG::storage->get_captured_render_info();
+			vp->render_info[VS::VIEWPORT_RENDER_INFO_OBJECTS_IN_FRAME] = frame_info[VS::INFO_OBJECTS_IN_FRAME];
+			vp->render_info[VS::VIEWPORT_RENDER_INFO_VERTICES_IN_FRAME] = frame_info[VS::INFO_VERTICES_IN_FRAME];
+			vp->render_info[VS::VIEWPORT_RENDER_INFO_MATERIAL_CHANGES_IN_FRAME] = frame_info[VS::INFO_MATERIAL_CHANGES_IN_FRAME];
+			vp->render_info[VS::VIEWPORT_RENDER_INFO_SHADER_CHANGES_IN_FRAME] = frame_info[VS::INFO_SHADER_CHANGES_IN_FRAME];
+			vp->render_info[VS::VIEWPORT_RENDER_INFO_SURFACE_CHANGES_IN_FRAME] = frame_info[VS::INFO_SURFACE_CHANGES_IN_FRAME];
+			vp->render_info[VS::VIEWPORT_RENDER_INFO_DRAW_CALLS_IN_FRAME] = frame_info[VS::INFO_DRAW_CALLS_IN_FRAME];
+			const Vector<int> &selected_info = VSG::storage->get_captured_selected_render_info(vp->queued_render_info);
+			vp->selected_render_info[VS::VIEWPORT_RENDER_INFO_OBJECTS_IN_FRAME] = selected_info[VS::INFO_OBJECTS_IN_FRAME];
+			vp->selected_render_info[VS::VIEWPORT_RENDER_INFO_VERTICES_IN_FRAME] = selected_info[VS::INFO_VERTICES_IN_FRAME];
+			vp->selected_render_info[VS::VIEWPORT_RENDER_INFO_MATERIAL_CHANGES_IN_FRAME] = selected_info[VS::INFO_MATERIAL_CHANGES_IN_FRAME];
+			vp->selected_render_info[VS::VIEWPORT_RENDER_INFO_SHADER_CHANGES_IN_FRAME] = selected_info[VS::INFO_SHADER_CHANGES_IN_FRAME];
+			vp->selected_render_info[VS::VIEWPORT_RENDER_INFO_SURFACE_CHANGES_IN_FRAME] = selected_info[VS::INFO_SURFACE_CHANGES_IN_FRAME];
+			vp->selected_render_info[VS::VIEWPORT_RENDER_INFO_DRAW_CALLS_IN_FRAME] = selected_info[VS::INFO_DRAW_CALLS_IN_FRAME];
 
 			if (vp->viewport_to_screen_rect != Rect2() && (!vp->viewport_render_direct_to_screen || !VSG::rasterizer->is_low_end())) {
 				//copy to screen if set as such
@@ -715,15 +720,51 @@ void VisualServerViewport::viewport_set_usage(RID p_viewport, VS::ViewportUsage 
 	}
 }
 
-int VisualServerViewport::viewport_get_render_info(RID p_viewport, VS::ViewportRenderInfo p_info) {
+Vector<int> VisualServerViewport::viewport_get_render_info(RID p_viewport) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	Vector<int> new_info;
+	new_info.resize(VS::INFO_MAX);
+	if (!viewport)
+		return new_info; //there should be a lock here..
 
-	ERR_FAIL_INDEX_V(p_info, VS::VIEWPORT_RENDER_INFO_MAX, -1);
+	int *info_write = new_info.ptrw();
+	info_write[VS::VIEWPORT_RENDER_INFO_OBJECTS_IN_FRAME] = viewport->render_info[VS::INFO_OBJECTS_IN_FRAME];
+	info_write[VS::VIEWPORT_RENDER_INFO_VERTICES_IN_FRAME] = viewport->render_info[VS::INFO_VERTICES_IN_FRAME];
+	info_write[VS::VIEWPORT_RENDER_INFO_MATERIAL_CHANGES_IN_FRAME] = viewport->render_info[VS::INFO_MATERIAL_CHANGES_IN_FRAME];
+	info_write[VS::VIEWPORT_RENDER_INFO_SHADER_CHANGES_IN_FRAME] = viewport->render_info[VS::INFO_SHADER_CHANGES_IN_FRAME];
+	info_write[VS::VIEWPORT_RENDER_INFO_SURFACE_CHANGES_IN_FRAME] = viewport->render_info[VS::INFO_SURFACE_CHANGES_IN_FRAME];
+	info_write[VS::VIEWPORT_RENDER_INFO_DRAW_CALLS_IN_FRAME] = viewport->render_info[VS::INFO_DRAW_CALLS_IN_FRAME];
+	return new_info;
+}
 
+Vector<int> VisualServerViewport::viewport_get_selected_render_info(RID p_viewport) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	Vector<int> new_info;
+	new_info.resize(VS::INFO_MAX);
+	int *info_write = new_info.ptrw();
+	if (!viewport)
+		return new_info; //there should be a lock here..
+
+	info_write[VS::VIEWPORT_RENDER_INFO_OBJECTS_IN_FRAME] = viewport->selected_render_info[VS::INFO_OBJECTS_IN_FRAME];
+	info_write[VS::VIEWPORT_RENDER_INFO_VERTICES_IN_FRAME] = viewport->selected_render_info[VS::INFO_VERTICES_IN_FRAME];
+	info_write[VS::VIEWPORT_RENDER_INFO_MATERIAL_CHANGES_IN_FRAME] = viewport->selected_render_info[VS::INFO_MATERIAL_CHANGES_IN_FRAME];
+	info_write[VS::VIEWPORT_RENDER_INFO_SHADER_CHANGES_IN_FRAME] = viewport->selected_render_info[VS::INFO_SHADER_CHANGES_IN_FRAME];
+	info_write[VS::VIEWPORT_RENDER_INFO_SURFACE_CHANGES_IN_FRAME] = viewport->selected_render_info[VS::INFO_SURFACE_CHANGES_IN_FRAME];
+	info_write[VS::VIEWPORT_RENDER_INFO_DRAW_CALLS_IN_FRAME] = viewport->selected_render_info[VS::INFO_DRAW_CALLS_IN_FRAME];
+	return new_info;
+}
+
+void VisualServerViewport::viewport_queue_selected_render_info(RID p_viewport, RID p_rid) {
 	Viewport *viewport = viewport_owner.getornull(p_viewport);
 	if (!viewport)
-		return 0; //there should be a lock here..
-
-	return viewport->render_info[p_info];
+		return; //there should be a lock here..
+	viewport->queued_render_info.push_back(p_rid);
+}
+void VisualServerViewport::viewport_selected_render_info_clear(RID p_viewport) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	if (!viewport)
+		return; //there should be a lock here..
+	viewport->queued_render_info.clear();
 }
 
 void VisualServerViewport::viewport_set_debug_draw(RID p_viewport, VS::ViewportDebugDraw p_draw) {

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -71,6 +71,11 @@ public:
 		int shadow_atlas_size;
 
 		int render_info[VS::VIEWPORT_RENDER_INFO_MAX];
+
+		int selected_render_info[VS::VIEWPORT_RENDER_INFO_MAX];
+
+		Vector<RID> queued_render_info;
+
 		VS::ViewportDebugDraw debug_draw;
 
 		VS::ViewportClearMode clear_mode;
@@ -195,7 +200,11 @@ public:
 	void viewport_set_hdr(RID p_viewport, bool p_enabled);
 	void viewport_set_usage(RID p_viewport, VS::ViewportUsage p_usage);
 
-	virtual int viewport_get_render_info(RID p_viewport, VS::ViewportRenderInfo p_info);
+	virtual Vector<int> viewport_get_render_info(RID p_viewport);
+	virtual Vector<int> viewport_get_selected_render_info(RID p_viewport);
+	virtual void viewport_queue_selected_render_info(RID p_viewport, RID p_rid);
+	virtual void viewport_selected_render_info_clear(RID p_viewport);
+
 	virtual void viewport_set_debug_draw(RID p_viewport, VS::ViewportDebugDraw p_draw);
 
 	void set_default_clear_color(const Color &p_color);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -418,8 +418,23 @@ public:
 	FUNC2(viewport_set_usage, RID, ViewportUsage)
 
 	//this passes directly to avoid stalling, but it's pretty dangerous, so don't call after freeing a viewport
-	virtual int viewport_get_render_info(RID p_viewport, ViewportRenderInfo p_info) {
-		return visual_server->viewport_get_render_info(p_viewport, p_info);
+	virtual Vector<int> viewport_get_render_info(RID p_viewport) {
+		return visual_server->viewport_get_render_info(p_viewport);
+	}
+
+	//this passes directly to avoid stalling, but it's pretty dangerous, so don't call after freeing a viewport
+	virtual Vector<int> viewport_get_selected_render_info(RID p_viewport) {
+		return visual_server->viewport_get_selected_render_info(p_viewport);
+	}
+
+	//this passes directly to avoid stalling, but it's pretty dangerous, so don't call after freeing a viewport
+	virtual void viewport_queue_selected_render_info(RID p_viewport, RID p_rid) {
+		visual_server->viewport_queue_selected_render_info(p_viewport, p_rid);
+	}
+
+	//this passes directly to avoid stalling, but it's pretty dangerous, so don't call after freeing a viewport
+	virtual void viewport_selected_render_info_clear(RID p_viewport) {
+		visual_server->viewport_selected_render_info_clear(p_viewport);
 	}
 
 	FUNC2(viewport_set_debug_draw, RID, ViewportDebugDraw)
@@ -604,8 +619,8 @@ public:
 	/* RENDER INFO */
 
 	//this passes directly to avoid stalling
-	virtual int get_render_info(RenderInfo p_info) {
-		return visual_server->get_render_info(p_info);
+	virtual Vector<int> get_render_info() {
+		return visual_server->get_render_info();
 	}
 
 	virtual String get_video_adapter_name() const {

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1895,7 +1895,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_use_debanding", "viewport", "debanding"), &VisualServer::viewport_set_use_debanding);
 	ClassDB::bind_method(D_METHOD("viewport_set_hdr", "viewport", "enabled"), &VisualServer::viewport_set_hdr);
 	ClassDB::bind_method(D_METHOD("viewport_set_usage", "viewport", "usage"), &VisualServer::viewport_set_usage);
-	ClassDB::bind_method(D_METHOD("viewport_get_render_info", "viewport", "info"), &VisualServer::viewport_get_render_info);
+	ClassDB::bind_method(D_METHOD("viewport_get_render_info", "viewport"), &VisualServer::viewport_get_render_info);
 	ClassDB::bind_method(D_METHOD("viewport_set_debug_draw", "viewport", "draw"), &VisualServer::viewport_set_debug_draw);
 
 	ClassDB::bind_method(D_METHOD("environment_create"), &VisualServer::environment_create);
@@ -2034,7 +2034,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_changed"), &VisualServer::has_changed);
 	ClassDB::bind_method(D_METHOD("init"), &VisualServer::init);
 	ClassDB::bind_method(D_METHOD("finish"), &VisualServer::finish);
-	ClassDB::bind_method(D_METHOD("get_render_info", "info"), &VisualServer::get_render_info);
+	ClassDB::bind_method(D_METHOD("get_render_info"), &VisualServer::get_render_info);
 	ClassDB::bind_method(D_METHOD("get_video_adapter_name"), &VisualServer::get_video_adapter_name);
 	ClassDB::bind_method(D_METHOD("get_video_adapter_vendor"), &VisualServer::get_video_adapter_vendor);
 #ifndef _3D_DISABLED

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -706,8 +706,11 @@ public:
 		VIEWPORT_RENDER_INFO_MAX
 	};
 
-	virtual int viewport_get_render_info(RID p_viewport, ViewportRenderInfo p_info) = 0;
+	virtual Vector<int> viewport_get_render_info(RID p_viewport) = 0;
+	virtual void viewport_queue_selected_render_info(RID p_viewport, RID p_rid) = 0;
+	virtual void viewport_selected_render_info_clear(RID p_viewport) = 0;
 
+	virtual Vector<int> viewport_get_selected_render_info(RID p_rid) = 0;
 	enum ViewportDebugDraw {
 		VIEWPORT_DEBUG_DRAW_DISABLED,
 		VIEWPORT_DEBUG_DRAW_UNSHADED,
@@ -1036,9 +1039,10 @@ public:
 		INFO_VIDEO_MEM_USED,
 		INFO_TEXTURE_MEM_USED,
 		INFO_VERTEX_MEM_USED,
+		INFO_MAX
 	};
 
-	virtual int get_render_info(RenderInfo p_info) = 0;
+	virtual Vector<int> get_render_info() = 0;
 	virtual String get_video_adapter_name() const = 0;
 	virtual String get_video_adapter_vendor() const = 0;
 


### PR DESCRIPTION
Made a pr branch for @lawnjelly to review per rid object info. Per rid object info is not trivial to port to Godot Engine master, but I wanted to share.

Partially supports https://github.com/godotengine/godot-proposals/issues/63 by having individual object information.

![image](https://user-images.githubusercontent.com/32321/100135564-ac63be00-2e3e-11eb-9f69-20c8655866fd.png)

Improvement notes:

1. The calculation are wrong. Instancing isn't being subtracted.
2. 2d render info isn't in.
3. Write proposal

I don't expect this to be merged in 3.2.

Sponsored by IMVU.