### PR TITLE
Fix to update scroll bar has correct max value in ScrollContainer

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -414,12 +414,12 @@ void ScrollContainer::update_scrollbars() {
 	bool hide_scroll_v = !scroll_v || min.height <= size.height;
 	bool hide_scroll_h = !scroll_h || min.width <= size.width;
 
+	v_scroll->set_max(min.height);
 	if (hide_scroll_v) {
 		v_scroll->hide();
 		scroll.y = 0;
 	} else {
 		v_scroll->show();
-		v_scroll->set_max(min.height);
 		if (hide_scroll_h) {
 			v_scroll->set_page(size.height);
 		} else {
@@ -429,12 +429,12 @@ void ScrollContainer::update_scrollbars() {
 		scroll.y = v_scroll->get_value();
 	}
 
+	h_scroll->set_max(min.width);
 	if (hide_scroll_h) {
 		h_scroll->hide();
 		scroll.x = 0;
 	} else {
 		h_scroll->show();
-		h_scroll->set_max(min.width);
 		if (hide_scroll_v) {
 			h_scroll->set_page(size.width);
 		} else {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

When child container resized to small enough to hide ScrollBar of ScrollContainer,
ScrollBar has wrong value after hidden.
So, scrolling occurs when Emulate Touch From Mouse enabled.

![scrollcontainer](https://user-images.githubusercontent.com/8281454/100148832-a1616a00-2ee0-11eb-91e0-9ab5493e07c3.gif)
