### PR TITLE
CI: Use 🎨 icon to represent Windows builds

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,4 +1,4 @@
-name: 🏁 Windows Builds
+name: 🎨 Windows Builds
 on: [push, pull_request]
 
 # Global Settings


### PR DESCRIPTION
Closes godotengine/godot-proposals#1678.

See https://github.com/godotengine/godot/pull/41461#issuecomment-678750577:

![image](https://user-images.githubusercontent.com/17108460/100156707-0ce01300-2eb2-11eb-806c-1d3cc857e161.png)

That's what I'm using in [Goost](https://github.com/goostengine/goost) for a long time now, and would like Godot follow. 🙂
