### PR TITLE
Clear connection data from/to empty after used

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1808,6 +1808,7 @@ VisualShaderNode *VisualShaderEditor::_add_node(int p_idx, int p_op_idx) {
 			}
 		}
 	}
+	_member_cancel();
 
 	VisualShaderNodeUniform *uniform = Object::cast_to<VisualShaderNodeUniform>(vsnode.ptr());
 	if (uniform) {


### PR DESCRIPTION
The connection data provided by `_connection_from_empty` and
`_connection_to_empty` was not cleared and caused unwanted
connections in some cases.

Gif of the actual bug:
![Peek-2020-11-25-00-35](https://user-images.githubusercontent.com/14951430/100165554-d0fd7b80-2eba-11eb-92ea-a5bc6e55e86c.gif)

Steps to reproduce the bug:
- drag from a port and create a node.
- delete that new node.
- Create a node and it gets connected to the node and port you dragged previously.




