### PR TITLE
GDScript: New VM now requires ptrcall

### DIFF
--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -30,5 +30,3 @@ _, gensource = env_gdnative.CommandNoCache(
     env.Run(gdnative_builders.build_gdnative_api_struct, "Generating GDNative API."),
 )
 env_gdnative.add_source_files(env.modules_sources, [gensource])
-
-env.use_ptrcall = True

--- a/modules/gdscript/config.py
+++ b/modules/gdscript/config.py
@@ -3,7 +3,7 @@ def can_build(env, platform):
 
 
 def configure(env):
-    pass
+    env.use_ptrcall = True
 
 
 def get_doc_classes():


### PR DESCRIPTION
GDNative change is because it's a duplicate define, already in config.py.

---

Note that this change isn't sufficient to build the engine without `PTRCALL_ENABLED` (i.e. with GDScript, GDNative and Mono disabled too), as recently refactored Variant code now has unguarded ptrcall templates. Either Variant should be fixed with appropriate guards, or we should make `PTRCALL_ENABLED` always true (and thus drop the define). @reduz