### PR TITLE
Fix useless assignement in webrtc/library_godot_webrtc.js

### DIFF
--- a/modules/webrtc/library_godot_webrtc.js
+++ b/modules/webrtc/library_godot_webrtc.js
@@ -208,7 +208,7 @@ const GodotRTCPeerConnection = {
 			if (!ref) {
 				return;
 			}
-			let state = 5; // CLOSED
+			let state;
 			switch (p_conn.iceConnectionState) {
 			case 'new':
 				state = 0;


### PR DESCRIPTION
As identified by [LGTM](https://lgtm.com/projects/g/godotengine/godot/alerts/?mode=tree&lang=javascript&ruleFocus=7900088&id=js%2Fuseless-assignment-to-local), #43443 (e2083871eb) refactor introduced a useless assignment (the `switch` has a default assignment). This PR removes the useless assignment.
