### PR TITLE
Core: Always enable ptrcall, remove PTRCALL_ENABLED define

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -67,7 +67,6 @@ if "TERM" in os.environ:
 env_base.AppendENVPath("PATH", os.getenv("PATH"))
 env_base.AppendENVPath("PKG_CONFIG_PATH", os.getenv("PKG_CONFIG_PATH"))
 env_base.disabled_modules = []
-env_base.use_ptrcall = False
 env_base.module_version_string = ""
 env_base.msvc = False
 
@@ -561,8 +560,6 @@ if selected_platform in platform_list:
     env["LIBSUFFIX"] = suffix + env["LIBSUFFIX"]
     env["SHLIBSUFFIX"] = suffix + env["SHLIBSUFFIX"]
 
-    if env.use_ptrcall:
-        env.Append(CPPDEFINES=["PTRCALL_ENABLED"])
     if env["tools"]:
         env.Append(CPPDEFINES=["TOOLS_ENABLED"])
     if env["disable_3d"]:

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -123,10 +123,7 @@ public:
 	_FORCE_INLINE_ int get_argument_count() const { return argument_count; };
 
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) = 0;
-
-#ifdef PTRCALL_ENABLED
 	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) = 0;
-#endif
 
 	StringName get_name() const;
 	void set_name(const StringName &p_name);
@@ -205,11 +202,9 @@ public:
 #endif
 	}
 
-#ifdef PTRCALL_ENABLED
 	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) {
-		ERR_FAIL(); //can't call
-	} //todo
-#endif
+		ERR_FAIL(); // Can't call.
+	}
 
 	void set_method(NativeCall p_method) { call_method = p_method; }
 	virtual bool is_const() const { return false; }
@@ -289,7 +284,6 @@ public:
 		return Variant();
 	}
 
-#ifdef PTRCALL_ENABLED
 	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) {
 #ifdef TYPED_METHOD_BIND
 		call_with_ptr_args<T, P...>(static_cast<T *>(p_object), method, p_args);
@@ -297,7 +291,6 @@ public:
 		call_with_ptr_args<MB_T, P...>((MB_T *)(p_object), method, p_args);
 #endif
 	}
-#endif
 
 	MethodBindT(void (MB_T::*p_method)(P...)) {
 		method = p_method;
@@ -370,7 +363,6 @@ public:
 		return Variant();
 	}
 
-#ifdef PTRCALL_ENABLED
 	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) {
 #ifdef TYPED_METHOD_BIND
 		call_with_ptr_argsc<T, P...>(static_cast<T *>(p_object), method, p_args);
@@ -378,7 +370,6 @@ public:
 		call_with_ptr_argsc<MB_T, P...>((MB_T *)(p_object), method, p_args);
 #endif
 	}
-#endif
 
 	MethodBindTC(void (MB_T::*p_method)(P...) const) {
 		method = p_method;
@@ -462,7 +453,6 @@ public:
 		return ret;
 	}
 
-#ifdef PTRCALL_ENABLED
 	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) {
 #ifdef TYPED_METHOD_BIND
 		call_with_ptr_args_ret<T, R, P...>(static_cast<T *>(p_object), method, p_args, r_ret);
@@ -470,7 +460,6 @@ public:
 		call_with_ptr_args_ret<MB_T, R, P...>((MB_T *)(p_object), method, p_args, r_ret);
 #endif
 	}
-#endif
 
 	MethodBindTR(R (MB_T::*p_method)(P...)) {
 		method = p_method;
@@ -555,7 +544,6 @@ public:
 		return ret;
 	}
 
-#ifdef PTRCALL_ENABLED
 	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) {
 #ifdef TYPED_METHOD_BIND
 		call_with_ptr_args_retc<T, R, P...>(static_cast<T *>(p_object), method, p_args, r_ret);
@@ -563,7 +551,6 @@ public:
 		call_with_ptr_args_retc<MB_T, R, P...>((MB_T *)(p_object), method, p_args, r_ret);
 #endif
 	}
-#endif
 
 	MethodBindTRC(R (MB_T::*p_method)(P...) const) {
 		method = p_method;

--- a/core/object/reference.h
+++ b/core/object/reference.h
@@ -252,8 +252,6 @@ public:
 	WeakRef() {}
 };
 
-#ifdef PTRCALL_ENABLED
-
 template <class T>
 struct PtrToArg<Ref<T>> {
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
@@ -271,8 +269,6 @@ struct PtrToArg<const Ref<T> &> {
 		return Ref<T>((T *)p_ptr);
 	}
 };
-
-#endif // PTRCALL_ENABLED
 
 #ifdef DEBUG_METHODS_ENABLED
 

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -63,8 +63,6 @@ struct VariantCaster<const T &> {
 	}
 };
 
-#ifdef PTRCALL_ENABLED
-
 #define VARIANT_ENUM_CAST(m_enum)                                            \
 	MAKE_ENUM_TYPE_INFO(m_enum)                                              \
 	template <>                                                              \
@@ -82,19 +80,6 @@ struct VariantCaster<const T &> {
 			*(int *)p_ptr = p_val;                                           \
 		}                                                                    \
 	};
-
-#else
-
-#define VARIANT_ENUM_CAST(m_enum)                                     \
-	MAKE_ENUM_TYPE_INFO(m_enum)                                       \
-	template <>                                                       \
-	struct VariantCaster<m_enum> {                                    \
-		static _FORCE_INLINE_ m_enum cast(const Variant &p_variant) { \
-			return (m_enum)p_variant.operator int();                  \
-		}                                                             \
-	};
-
-#endif
 
 // Object enum casts must go here
 VARIANT_ENUM_CAST(Object::ConnectFlags);
@@ -118,7 +103,7 @@ struct VariantCaster<char32_t> {
 		return (char32_t)p_variant.operator int();
 	}
 };
-#ifdef PTRCALL_ENABLED
+
 template <>
 struct PtrToArg<char32_t> {
 	_FORCE_INLINE_ static char32_t convert(const void *p_ptr) {
@@ -128,7 +113,6 @@ struct PtrToArg<char32_t> {
 		*(int *)p_ptr = p_val;
 	}
 };
-#endif
 
 template <typename T>
 struct VariantObjectClassChecker {
@@ -228,8 +212,6 @@ void call_with_variant_argsc_helper(T *p_instance, void (T::*p_method)(P...) con
 	(void)(p_args); //avoid warning
 }
 
-#ifdef PTRCALL_ENABLED
-
 template <class T, class... P, size_t... Is>
 void call_with_ptr_args_helper(T *p_instance, void (T::*p_method)(P...), const void **p_args, IndexSequence<Is...>) {
 	(p_instance->*p_method)(PtrToArg<P>::convert(p_args[Is])...);
@@ -254,8 +236,6 @@ template <class T, class R, class... P, size_t... Is>
 void call_with_ptr_args_static_retc_helper(T *p_instance, R (*p_method)(T *, P...), const void **p_args, void *r_ret, IndexSequence<Is...>) {
 	PtrToArg<R>::encode(p_method(p_instance, PtrToArg<P>::convert(p_args[Is])...), r_ret);
 }
-
-#endif // PTRCALL_ENABLED
 
 template <class T, class... P, size_t... Is>
 void call_with_validated_variant_args_helper(T *p_instance, void (T::*p_method)(P...), const Variant **p_args, IndexSequence<Is...>) {
@@ -450,8 +430,6 @@ void call_with_variant_args_retc_dv(T *p_instance, R (T::*p_method)(P...) const,
 	call_with_variant_args_retc_helper(p_instance, p_method, args, r_ret, r_error, BuildIndexSequence<sizeof...(P)>{});
 }
 
-#ifdef PTRCALL_ENABLED
-
 template <class T, class... P>
 void call_with_ptr_args(T *p_instance, void (T::*p_method)(P...), const void **p_args) {
 	call_with_ptr_args_helper<T, P...>(p_instance, p_method, p_args, BuildIndexSequence<sizeof...(P)>{});
@@ -476,8 +454,6 @@ template <class T, class R, class... P>
 void call_with_ptr_args_static_retc(T *p_instance, R (*p_method)(T *, P...), const void **p_args, void *r_ret) {
 	call_with_ptr_args_static_retc_helper<T, R, P...>(p_instance, p_method, p_args, r_ret, BuildIndexSequence<sizeof...(P)>{});
 }
-
-#endif // PTRCALL_ENABLED
 
 template <class T, class... P>
 void call_with_validated_variant_args(Variant *base, void (T::*p_method)(P...), const Variant **p_args) {

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -36,11 +36,8 @@
 #include "core/typedefs.h"
 #include "core/variant/variant.h"
 
-#ifdef PTRCALL_ENABLED
-
 template <class T>
-struct PtrToArg {
-};
+struct PtrToArg {};
 
 #define MAKE_PTRARG(m_type)                                            \
 	template <>                                                        \
@@ -146,7 +143,7 @@ MAKE_PTRARG(PackedVector3Array);
 MAKE_PTRARG(PackedColorArray);
 MAKE_PTRARG_BY_REFERENCE(Variant);
 
-//this is for Object
+// This is for Object.
 
 template <class T>
 struct PtrToArg<T *> {
@@ -170,7 +167,7 @@ struct PtrToArg<const T *> {
 	}
 };
 
-//this is for ObjectID
+// This is for ObjectID.
 
 template <>
 struct PtrToArg<ObjectID> {
@@ -183,7 +180,7 @@ struct PtrToArg<ObjectID> {
 	}
 };
 
-//this is for the special cases used by Variant
+// This is for the special cases used by Variant.
 
 #define MAKE_VECARG(m_type)                                                              \
 	template <>                                                                          \
@@ -274,18 +271,11 @@ struct PtrToArg<ObjectID> {
 			return ret;                                                                  \
 		}                                                                                \
 	}
-/*
-MAKE_VECARG(String);
-MAKE_VECARG(uint8_t);
-MAKE_VECARG(int);
-MAKE_VECARG(float);
-MAKE_VECARG(Vector2);
-MAKE_VECARG(Vector3);
-MAKE_VECARG(Color);
-*/
+
 MAKE_VECARG_ALT(String, StringName);
 
-//for stuff that gets converted to Array vectors
+// For stuff that gets converted to Array vectors.
+
 #define MAKE_VECARR(m_type)                                                    \
 	template <>                                                                \
 	struct PtrToArg<Vector<m_type>> {                                          \
@@ -429,6 +419,7 @@ struct PtrToArg<Vector<Face3>> {
 		}
 	}
 };
+
 template <>
 struct PtrToArg<const Vector<Face3> &> {
 	_FORCE_INLINE_ static Vector<Face3> convert(const void *p_ptr) {
@@ -450,4 +441,3 @@ struct PtrToArg<const Vector<Face3> &> {
 };
 
 #endif // METHOD_PTRCALL_H
-#endif

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -120,8 +120,6 @@ MAKE_TYPED_ARRAY(Vector<Vector2>, Variant::PACKED_VECTOR2_ARRAY)
 MAKE_TYPED_ARRAY(Vector<Vector3>, Variant::PACKED_VECTOR3_ARRAY)
 MAKE_TYPED_ARRAY(Vector<Color>, Variant::PACKED_COLOR_ARRAY)
 
-#ifdef PTRCALL_ENABLED
-
 template <class T>
 struct PtrToArg<TypedArray<T>> {
 	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
@@ -139,8 +137,6 @@ struct PtrToArg<const TypedArray<T> &> {
 		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
 	}
 };
-
-#endif // PTRCALL_ENABLED
 
 #ifdef DEBUG_METHODS_ENABLED
 

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -370,7 +370,6 @@ public:
 #ifdef NEED_LONG_INT
 	Variant(signed long p_long); // real one
 	Variant(unsigned long p_long);
-//Variant(long unsigned int p_long);
 #endif
 	Variant(signed short p_short); // real one
 	Variant(unsigned short p_short);
@@ -471,10 +470,8 @@ public:
 	static Variant::Type get_operator_return_type(Operator p_operator, Type p_type_a, Type p_type_b);
 	typedef void (*ValidatedOperatorEvaluator)(const Variant *left, const Variant *right, Variant *r_ret);
 	static ValidatedOperatorEvaluator get_validated_operator_evaluator(Operator p_operator, Type p_type_a, Type p_type_b);
-#ifdef PTRCALL_ENABLED
 	typedef void (*PTROperatorEvaluator)(const void *left, const void *right, void *r_ret);
 	static PTROperatorEvaluator get_ptr_operator_evaluator(Operator p_operator, Type p_type_a, Type p_type_b);
-#endif
 
 	void zero();
 	Variant duplicate(bool deep = false) const;

--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -47,11 +47,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) + *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) + PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -68,11 +66,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) - *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) - PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -89,11 +85,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) * *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) * PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -110,11 +104,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = VariantGetInternalPtr<A>::get_ptr(left)->xform(*VariantGetInternalPtr<B>::get_ptr(right));
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left).xform(PtrToArg<B>::convert(right)), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -131,11 +123,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = VariantGetInternalPtr<B>::get_ptr(right)->xform_inv(*VariantGetInternalPtr<A>::get_ptr(left));
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<B>::convert(right).xform_inv(PtrToArg<A>::convert(left)), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -152,11 +142,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) / *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) / PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -178,11 +166,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) / *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) / PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -199,11 +185,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) % *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) % PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -225,11 +209,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) % *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) % PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -245,11 +227,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = -*VariantGetInternalPtr<A>::get_ptr(left);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(-PtrToArg<A>::convert(left), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -265,11 +245,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -286,11 +264,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) << *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) << PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -307,11 +283,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) >> *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) >> PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -328,11 +302,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) | *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) | PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -348,11 +320,9 @@ public:
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) & *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) & PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -369,11 +339,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) ^ *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(PtrToArg<A>::convert(left) ^ PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -389,11 +357,9 @@ public:
 		VariantTypeChanger<R>::change(r_ret);
 		*VariantGetInternalPtr<R>::get_ptr(r_ret) = ~*VariantGetInternalPtr<A>::get_ptr(left);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<R>::encode(~PtrToArg<A>::convert(left), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return GetTypeInfo<R>::VARIANT_TYPE; }
 };
 
@@ -410,14 +376,12 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) == *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) == PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
-//equalobject
+
 class OperatorEvaluatorEqualObject {
 public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
@@ -432,11 +396,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = a == b;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Object *>::convert(left) == PtrToArg<Object *>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -452,11 +414,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = a == nullptr;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Object *>::convert(left) == nullptr, r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -472,11 +432,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = nullptr == b;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(nullptr == PtrToArg<Object *>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -493,11 +451,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) != *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) != PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -515,11 +471,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = a != b;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Object *>::convert(left) != PtrToArg<Object *>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -535,11 +489,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = a != nullptr;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Object *>::convert(left) != nullptr, r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -555,11 +507,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = nullptr != b;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(nullptr != PtrToArg<Object *>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -576,11 +526,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) < *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) < PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -597,11 +545,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) <= *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) <= PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -618,11 +564,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) > *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) > PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -639,11 +583,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) >= *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) >= PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -660,12 +602,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) && *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) && PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
-
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -682,11 +621,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = *VariantGetInternalPtr<A>::get_ptr(left) || *VariantGetInternalPtr<B>::get_ptr(right);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<A>::convert(left) || PtrToArg<B>::convert(right), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -697,7 +634,6 @@ public:
 	_FORCE_INLINE_ static bool xor_op(const A &a, const B &b) {
 		return ((a) || (b)) && !((a) && (b));
 	}
-
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
 		const A &a = *VariantGetInternalPtr<A>::get_ptr(&p_left);
 		const B &b = *VariantGetInternalPtr<B>::get_ptr(&p_right);
@@ -708,12 +644,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = xor_op(*VariantGetInternalPtr<A>::get_ptr(left), *VariantGetInternalPtr<B>::get_ptr(right));
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(xor_op(PtrToArg<A>::convert(left), PtrToArg<B>::convert(right)), r_ret);
 	}
-#endif
-
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -729,11 +662,9 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = !*VariantGetInternalPtr<A>::get_ptr(left);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(!PtrToArg<A>::convert(left));
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -764,14 +695,11 @@ public:
 		VariantTypeChanger<Array>::change(r_ret);
 		_add_arrays(*VariantGetInternalPtr<Array>::get_ptr(r_ret), *VariantGetInternalPtr<Array>::get_ptr(left), *VariantGetInternalPtr<Array>::get_ptr(right));
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		Array ret;
 		_add_arrays(ret, PtrToArg<Array>::convert(left), PtrToArg<Array>::convert(right));
 		PtrToArg<Array>::encode(ret, r_ret);
 	}
-#endif
-
 	static Variant::Type get_return_type() { return Variant::ARRAY; }
 };
 
@@ -791,14 +719,11 @@ public:
 		*VariantGetInternalPtr<Vector<T>>::get_ptr(r_ret) = *VariantGetInternalPtr<Vector<T>>::get_ptr(left);
 		VariantGetInternalPtr<Vector<T>>::get_ptr(r_ret)->append_array(*VariantGetInternalPtr<Vector<T>>::get_ptr(right));
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		Vector<T> sum = PtrToArg<Vector<T>>::convert(left);
 		sum.append_array(PtrToArg<Vector<T>>::convert(right));
 		PtrToArg<Vector<T>>::encode(sum, r_ret);
 	}
-#endif
-
 	static Variant::Type get_return_type() { return GetTypeInfo<Vector<T>>::VARIANT_TYPE; }
 };
 
@@ -819,16 +744,13 @@ public:
 		*r_ret = do_mod(a, &r_valid);
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<String>::change(r_ret);
 		*VariantGetInternalPtr<String>::get_ptr(r_ret) = do_mod(*VariantGetInternalPtr<String>::get_ptr(left), nullptr);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<String>::encode(do_mod(PtrToArg<String>::convert(left), nullptr), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::STRING; }
 };
 
@@ -846,16 +768,13 @@ public:
 		*r_ret = do_mod(a, *VariantGetInternalPtr<Array>::get_ptr(&p_right), &r_valid);
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<String>::change(r_ret);
 		*VariantGetInternalPtr<String>::get_ptr(r_ret) = do_mod(*VariantGetInternalPtr<String>::get_ptr(left), *VariantGetInternalPtr<Array>::get_ptr(right), nullptr);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<String>::encode(do_mod(PtrToArg<String>::convert(left), PtrToArg<Array>::convert(right), nullptr), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::STRING; }
 };
 
@@ -876,16 +795,13 @@ public:
 		*r_ret = do_mod(a, p_right.get_validated_object(), &r_valid);
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<String>::change(r_ret);
 		*VariantGetInternalPtr<String>::get_ptr(r_ret) = do_mod(*VariantGetInternalPtr<String>::get_ptr(left), right->get_validated_object(), nullptr);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<String>::encode(do_mod(PtrToArg<String>::convert(left), PtrToArg<Object *>::convert(right), nullptr), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::STRING; }
 };
 
@@ -906,16 +822,13 @@ public:
 		*r_ret = do_mod(a, *VariantGetInternalPtr<T>::get_ptr(&p_right), &r_valid);
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<String>::change(r_ret);
 		*VariantGetInternalPtr<String>::get_ptr(r_ret) = do_mod(*VariantGetInternalPtr<String>::get_ptr(left), *VariantGetInternalPtr<T>::get_ptr(right), nullptr);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<String>::encode(do_mod(PtrToArg<String>::convert(left), PtrToArg<T>::convert(right), nullptr), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::STRING; }
 };
 
@@ -926,16 +839,13 @@ public:
 		*r_ret = true;
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = true;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(true, r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -946,16 +856,13 @@ public:
 		*r_ret = false;
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = false;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(false, r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -964,9 +871,11 @@ public:
 _FORCE_INLINE_ static bool _operate_or(bool p_left, bool p_right) {
 	return p_left || p_right;
 }
+
 _FORCE_INLINE_ static bool _operate_and(bool p_left, bool p_right) {
 	return p_left && p_right;
 }
+
 _FORCE_INLINE_ static bool _operate_xor(bool p_left, bool p_right) {
 	return (p_left || p_right) && !(p_left && p_right);
 }
@@ -990,29 +899,6 @@ _FORCE_INLINE_ static bool _operate_get_float(const Variant *p_ptr) {
 _FORCE_INLINE_ static bool _operate_get_object(const Variant *p_ptr) {
 	return p_ptr->get_validated_object() != nullptr;
 }
-
-#ifndef PTRCALL_ENABLED
-
-#define OP_EVALUATOR(m_class_name, m_left, m_right, m_op)                                                                    \
-	class m_class_name {                                                                                                     \
-	public:                                                                                                                  \
-		static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {                 \
-			*r_ret = m_op(_operate_get_##m_left(&p_left), _operate_get_##m_right(&p_right));                                 \
-			r_valid = true;                                                                                                  \
-		}                                                                                                                    \
-                                                                                                                             \
-		static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {                          \
-			VariantTypeChanger<bool>::change(r_ret);                                                                         \
-			*VariantGetInternalPtr<bool>::get_ptr(r_ret) = m_op(_operate_get_##m_left(left), _operate_get_##m_right(right)); \
-		}                                                                                                                    \
-                                                                                                                             \
-		static Variant::Type                                                                                                 \
-		get_return_type() {                                                                                                  \
-			return Variant::BOOL;                                                                                            \
-		}                                                                                                                    \
-	};
-
-#else
 
 _FORCE_INLINE_ static bool _operate_get_ptr_nil(const void *p_ptr) {
 	return false;
@@ -1056,11 +942,9 @@ _FORCE_INLINE_ static bool _operate_get_ptr_object(const void *p_ptr) {
 		}                                                                                                                    \
 	};
 
-#endif
-
 // OR
 
-//nil
+// nil
 OP_EVALUATOR(OperatorEvaluatorNilXBoolOr, nil, bool, _operate_or)
 OP_EVALUATOR(OperatorEvaluatorBoolXNilOr, bool, nil, _operate_or)
 
@@ -1073,7 +957,7 @@ OP_EVALUATOR(OperatorEvaluatorFloatXNilOr, float, nil, _operate_or)
 OP_EVALUATOR(OperatorEvaluatorObjectXNilOr, object, nil, _operate_or)
 OP_EVALUATOR(OperatorEvaluatorNilXObjectOr, nil, object, _operate_or)
 
-//bool
+// bool
 OP_EVALUATOR(OperatorEvaluatorBoolXBoolOr, bool, bool, _operate_or)
 
 OP_EVALUATOR(OperatorEvaluatorBoolXIntOr, bool, int, _operate_or)
@@ -1085,8 +969,7 @@ OP_EVALUATOR(OperatorEvaluatorFloatXBoolOr, float, bool, _operate_or)
 OP_EVALUATOR(OperatorEvaluatorBoolXObjectOr, bool, object, _operate_or)
 OP_EVALUATOR(OperatorEvaluatorObjectXBoolOr, object, bool, _operate_or)
 
-//int
-
+// int
 OP_EVALUATOR(OperatorEvaluatorIntXIntOr, int, int, _operate_or)
 
 OP_EVALUATOR(OperatorEvaluatorIntXFloatOr, int, float, _operate_or)
@@ -1095,20 +978,18 @@ OP_EVALUATOR(OperatorEvaluatorFloatXIntOr, float, int, _operate_or)
 OP_EVALUATOR(OperatorEvaluatorIntXObjectOr, int, object, _operate_or)
 OP_EVALUATOR(OperatorEvaluatorObjectXIntOr, object, int, _operate_or)
 
-//float
-
+// float
 OP_EVALUATOR(OperatorEvaluatorFloatXFloatOr, float, float, _operate_or)
 
 OP_EVALUATOR(OperatorEvaluatorFloatXObjectOr, float, object, _operate_or)
 OP_EVALUATOR(OperatorEvaluatorObjectXFloatOr, object, float, _operate_or)
 
-//object
-
+// object
 OP_EVALUATOR(OperatorEvaluatorObjectXObjectOr, object, object, _operate_or)
 
 // AND
 
-//nil
+// nil
 OP_EVALUATOR(OperatorEvaluatorNilXBoolAnd, nil, bool, _operate_and)
 OP_EVALUATOR(OperatorEvaluatorBoolXNilAnd, bool, nil, _operate_and)
 
@@ -1121,7 +1002,7 @@ OP_EVALUATOR(OperatorEvaluatorFloatXNilAnd, float, nil, _operate_and)
 OP_EVALUATOR(OperatorEvaluatorObjectXNilAnd, object, nil, _operate_and)
 OP_EVALUATOR(OperatorEvaluatorNilXObjectAnd, nil, object, _operate_and)
 
-//bool
+// bool
 OP_EVALUATOR(OperatorEvaluatorBoolXBoolAnd, bool, bool, _operate_and)
 
 OP_EVALUATOR(OperatorEvaluatorBoolXIntAnd, bool, int, _operate_and)
@@ -1133,8 +1014,7 @@ OP_EVALUATOR(OperatorEvaluatorFloatXBoolAnd, float, bool, _operate_and)
 OP_EVALUATOR(OperatorEvaluatorBoolXObjectAnd, bool, object, _operate_and)
 OP_EVALUATOR(OperatorEvaluatorObjectXBoolAnd, object, bool, _operate_and)
 
-//int
-
+// int
 OP_EVALUATOR(OperatorEvaluatorIntXIntAnd, int, int, _operate_and)
 
 OP_EVALUATOR(OperatorEvaluatorIntXFloatAnd, int, float, _operate_and)
@@ -1143,20 +1023,18 @@ OP_EVALUATOR(OperatorEvaluatorFloatXIntAnd, float, int, _operate_and)
 OP_EVALUATOR(OperatorEvaluatorIntXObjectAnd, int, object, _operate_and)
 OP_EVALUATOR(OperatorEvaluatorObjectXIntAnd, object, int, _operate_and)
 
-//float
-
+// float
 OP_EVALUATOR(OperatorEvaluatorFloatXFloatAnd, float, float, _operate_and)
 
 OP_EVALUATOR(OperatorEvaluatorFloatXObjectAnd, float, object, _operate_and)
 OP_EVALUATOR(OperatorEvaluatorObjectXFloatAnd, object, float, _operate_and)
 
-//object
-
+// object
 OP_EVALUATOR(OperatorEvaluatorObjectXObjectAnd, object, object, _operate_and)
 
 // XOR
 
-//nil
+// nil
 OP_EVALUATOR(OperatorEvaluatorNilXBoolXor, nil, bool, _operate_xor)
 OP_EVALUATOR(OperatorEvaluatorBoolXNilXor, bool, nil, _operate_xor)
 
@@ -1169,7 +1047,7 @@ OP_EVALUATOR(OperatorEvaluatorFloatXNilXor, float, nil, _operate_xor)
 OP_EVALUATOR(OperatorEvaluatorObjectXNilXor, object, nil, _operate_xor)
 OP_EVALUATOR(OperatorEvaluatorNilXObjectXor, nil, object, _operate_xor)
 
-//bool
+// bool
 OP_EVALUATOR(OperatorEvaluatorBoolXBoolXor, bool, bool, _operate_xor)
 
 OP_EVALUATOR(OperatorEvaluatorBoolXIntXor, bool, int, _operate_xor)
@@ -1181,8 +1059,7 @@ OP_EVALUATOR(OperatorEvaluatorFloatXBoolXor, float, bool, _operate_xor)
 OP_EVALUATOR(OperatorEvaluatorBoolXObjectXor, bool, object, _operate_xor)
 OP_EVALUATOR(OperatorEvaluatorObjectXBoolXor, object, bool, _operate_xor)
 
-//int
-
+// int
 OP_EVALUATOR(OperatorEvaluatorIntXIntXor, int, int, _operate_xor)
 
 OP_EVALUATOR(OperatorEvaluatorIntXFloatXor, int, float, _operate_xor)
@@ -1191,15 +1068,13 @@ OP_EVALUATOR(OperatorEvaluatorFloatXIntXor, float, int, _operate_xor)
 OP_EVALUATOR(OperatorEvaluatorIntXObjectXor, int, object, _operate_xor)
 OP_EVALUATOR(OperatorEvaluatorObjectXIntXor, object, int, _operate_xor)
 
-//float
-
+// float
 OP_EVALUATOR(OperatorEvaluatorFloatXFloatXor, float, float, _operate_xor)
 
 OP_EVALUATOR(OperatorEvaluatorFloatXObjectXor, float, object, _operate_xor)
 OP_EVALUATOR(OperatorEvaluatorObjectXFloatXor, object, float, _operate_xor)
 
-//object
-
+// object
 OP_EVALUATOR(OperatorEvaluatorObjectXObjectXor, object, object, _operate_xor)
 
 class OperatorEvaluatorNotBool {
@@ -1208,17 +1083,13 @@ public:
 		*r_ret = !*VariantGetInternalPtr<bool>::get_ptr(&p_left);
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = !*VariantGetInternalPtr<bool>::get_ptr(left);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(!PtrToArg<bool>::convert(left), r_ret);
 	}
-#endif
-
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1228,17 +1099,13 @@ public:
 		*r_ret = !*VariantGetInternalPtr<int64_t>::get_ptr(&p_left);
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = !*VariantGetInternalPtr<int64_t>::get_ptr(left);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(!PtrToArg<int64_t>::convert(left), r_ret);
 	}
-#endif
-
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1248,17 +1115,13 @@ public:
 		*r_ret = !*VariantGetInternalPtr<double>::get_ptr(&p_left);
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = !*VariantGetInternalPtr<double>::get_ptr(left);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(!PtrToArg<double>::convert(left), r_ret);
 	}
-#endif
-
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1268,17 +1131,13 @@ public:
 		*r_ret = p_left.get_validated_object() == nullptr;
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = left->get_validated_object() == nullptr;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Object *>::convert(left) == nullptr, r_ret);
 	}
-#endif
-
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1293,18 +1152,15 @@ public:
 		*r_ret = str_b.find(str_a) != -1;
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		const String &str_a = *VariantGetInternalPtr<String>::get_ptr(left);
 		const String &str_b = *VariantGetInternalPtr<String>::get_ptr(right);
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = str_b.find(str_a) != -1;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<String>::convert(right).find(PtrToArg<String>::convert(left)) != -1, r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1318,18 +1174,15 @@ public:
 		*r_ret = b.find(a) != -1;
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		const A &a = *VariantGetInternalPtr<A>::get_ptr(left);
 		const B &b = *VariantGetInternalPtr<B>::get_ptr(right);
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = b.find(a) != -1;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<B>::convert(right).find(PtrToArg<A>::convert(left)) != -1, r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1340,17 +1193,14 @@ public:
 		*r_ret = b.find(Variant()) != -1;
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		const Array &b = *VariantGetInternalPtr<Array>::get_ptr(right);
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = b.find(Variant()) != -1;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Array>::convert(right).find(Variant()) != -1, r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1361,17 +1211,14 @@ public:
 		*r_ret = b.find(p_left) != -1;
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		const Array &b = *VariantGetInternalPtr<Array>::get_ptr(right);
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = b.find(*left) != -1;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Array>::convert(right).find(PtrToArg<Object *>::convert(left)) != -1, r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1385,18 +1232,15 @@ public:
 		*r_ret = b.has(a);
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		const Dictionary &b = *VariantGetInternalPtr<Dictionary>::get_ptr(right);
 		const A &a = *VariantGetInternalPtr<A>::get_ptr(left);
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = b.has(a);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Dictionary>::convert(right).has(PtrToArg<A>::convert(left)), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1408,17 +1252,14 @@ public:
 		*r_ret = b.has(Variant());
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		const Dictionary &b = *VariantGetInternalPtr<Dictionary>::get_ptr(right);
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = b.has(Variant());
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Dictionary>::convert(right).has(Variant()), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1430,17 +1271,14 @@ public:
 		*r_ret = b.has(p_left);
 		r_valid = true;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		const Dictionary &b = *VariantGetInternalPtr<Dictionary>::get_ptr(right);
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = b.has(*left);
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		PtrToArg<bool>::encode(PtrToArg<Dictionary>::convert(right).has(PtrToArg<Object *>::convert(left)), r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1459,7 +1297,6 @@ public:
 		b->get(a, &r_valid);
 		*r_ret = r_valid;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		Object *l = right->get_validated_object();
 		ERR_FAIL_COND(l == nullptr);
@@ -1470,13 +1307,11 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = valid;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		bool valid;
 		PtrToArg<Object *>::convert(right)->get(PtrToArg<String>::convert(left), &valid);
 		PtrToArg<bool>::encode(valid, r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1495,7 +1330,6 @@ public:
 		b->get(a, &r_valid);
 		*r_ret = r_valid;
 	}
-
 	static void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		Object *l = right->get_validated_object();
 		ERR_FAIL_COND(l == nullptr);
@@ -1506,13 +1340,11 @@ public:
 		VariantTypeChanger<bool>::change(r_ret);
 		*VariantGetInternalPtr<bool>::get_ptr(r_ret) = valid;
 	}
-#ifdef PTRCALL_ENABLED
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		bool valid;
 		PtrToArg<Object *>::convert(right)->get(PtrToArg<StringName>::convert(left), &valid);
 		PtrToArg<bool>::encode(valid, r_ret);
 	}
-#endif
 	static Variant::Type get_return_type() { return Variant::BOOL; }
 };
 
@@ -1521,27 +1353,21 @@ typedef void (*VariantEvaluatorFunction)(const Variant &p_left, const Variant &p
 static Variant::Type operator_return_type_table[Variant::OP_MAX][Variant::VARIANT_MAX][Variant::VARIANT_MAX];
 static VariantEvaluatorFunction operator_evaluator_table[Variant::OP_MAX][Variant::VARIANT_MAX][Variant::VARIANT_MAX];
 static Variant::ValidatedOperatorEvaluator validated_operator_evaluator_table[Variant::OP_MAX][Variant::VARIANT_MAX][Variant::VARIANT_MAX];
-#ifdef PTRCALL_ENABLED
 static Variant::PTROperatorEvaluator ptr_operator_evaluator_table[Variant::OP_MAX][Variant::VARIANT_MAX][Variant::VARIANT_MAX];
-#endif
 
 template <class T>
 void register_op(Variant::Operator p_op, Variant::Type p_type_a, Variant::Type p_type_b) {
 	operator_return_type_table[p_op][p_type_a][p_type_b] = T::get_return_type();
 	operator_evaluator_table[p_op][p_type_a][p_type_b] = T::evaluate;
 	validated_operator_evaluator_table[p_op][p_type_a][p_type_b] = T::validated_evaluate;
-#ifdef PTRCALL_ENABLED
 	ptr_operator_evaluator_table[p_op][p_type_a][p_type_b] = T::ptr_evaluate;
-#endif
 }
 
 void Variant::_register_variant_operators() {
 	zeromem(operator_return_type_table, sizeof(operator_return_type_table));
 	zeromem(operator_evaluator_table, sizeof(operator_evaluator_table));
 	zeromem(validated_operator_evaluator_table, sizeof(validated_operator_evaluator_table));
-#ifdef PTRCALL_ENABLED
 	zeromem(ptr_operator_evaluator_table, sizeof(ptr_operator_evaluator_table));
-#endif
 
 	register_op<OperatorEvaluatorAdd<int64_t, int64_t, int64_t>>(Variant::OP_ADD, Variant::INT, Variant::INT);
 	register_op<OperatorEvaluatorAdd<double, int64_t, double>>(Variant::OP_ADD, Variant::INT, Variant::FLOAT);
@@ -1896,7 +1722,7 @@ void Variant::_register_variant_operators() {
 
 	register_op<OperatorEvaluatorAlwaysFalse<Variant::OP_OR, Variant::NIL, Variant::NIL>>(Variant::OP_OR, Variant::NIL, Variant::NIL);
 
-	//OR
+	// OR
 	register_op<OperatorEvaluatorNilXBoolOr>(Variant::OP_OR, Variant::NIL, Variant::BOOL);
 	register_op<OperatorEvaluatorBoolXNilOr>(Variant::OP_OR, Variant::BOOL, Variant::NIL);
 	register_op<OperatorEvaluatorNilXIntOr>(Variant::OP_OR, Variant::NIL, Variant::INT);
@@ -1924,7 +1750,8 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorFloatXObjectOr>(Variant::OP_OR, Variant::FLOAT, Variant::OBJECT);
 	register_op<OperatorEvaluatorObjectXFloatOr>(Variant::OP_OR, Variant::OBJECT, Variant::FLOAT);
 	register_op<OperatorEvaluatorObjectXObjectOr>(Variant::OP_OR, Variant::OBJECT, Variant::OBJECT);
-	//AND
+
+	// AND
 	register_op<OperatorEvaluatorNilXBoolAnd>(Variant::OP_AND, Variant::NIL, Variant::BOOL);
 	register_op<OperatorEvaluatorBoolXNilAnd>(Variant::OP_AND, Variant::BOOL, Variant::NIL);
 	register_op<OperatorEvaluatorNilXIntAnd>(Variant::OP_AND, Variant::NIL, Variant::INT);
@@ -1952,7 +1779,8 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorFloatXObjectAnd>(Variant::OP_AND, Variant::FLOAT, Variant::OBJECT);
 	register_op<OperatorEvaluatorObjectXFloatAnd>(Variant::OP_AND, Variant::OBJECT, Variant::FLOAT);
 	register_op<OperatorEvaluatorObjectXObjectAnd>(Variant::OP_AND, Variant::OBJECT, Variant::OBJECT);
-	//XOR
+
+	// XOR
 	register_op<OperatorEvaluatorNilXBoolXor>(Variant::OP_XOR, Variant::NIL, Variant::BOOL);
 	register_op<OperatorEvaluatorBoolXNilXor>(Variant::OP_XOR, Variant::BOOL, Variant::NIL);
 	register_op<OperatorEvaluatorNilXIntXor>(Variant::OP_XOR, Variant::NIL, Variant::INT);
@@ -2124,15 +1952,13 @@ Variant::ValidatedOperatorEvaluator Variant::get_validated_operator_evaluator(Op
 	ERR_FAIL_INDEX_V(p_type_b, Variant::VARIANT_MAX, nullptr);
 	return validated_operator_evaluator_table[p_operator][p_type_a][p_type_b];
 }
-#ifdef PTRCALL_ENABLED
+
 Variant::PTROperatorEvaluator Variant::get_ptr_operator_evaluator(Operator p_operator, Type p_type_a, Type p_type_b) {
 	ERR_FAIL_INDEX_V(p_operator, Variant::OP_MAX, nullptr);
 	ERR_FAIL_INDEX_V(p_type_a, Variant::VARIANT_MAX, nullptr);
 	ERR_FAIL_INDEX_V(p_type_b, Variant::VARIANT_MAX, nullptr);
 	return ptr_operator_evaluator_table[p_operator][p_type_a][p_type_b];
 }
-
-#endif
 
 static const char *_op_names[Variant::OP_MAX] = {
 	"==",

--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -30,5 +30,3 @@ _, gensource = env_gdnative.CommandNoCache(
     env.Run(gdnative_builders.build_gdnative_api_struct, "Generating GDNative API."),
 )
 env_gdnative.add_source_files(env.modules_sources, [gensource])
-
-env.use_ptrcall = True

--- a/modules/gdnative/config.py
+++ b/modules/gdnative/config.py
@@ -3,7 +3,7 @@ def can_build(env, platform):
 
 
 def configure(env):
-    env.use_ptrcall = True
+    pass
 
 
 def get_doc_classes():

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -11,7 +11,6 @@ def configure(env):
     if platform not in supported_platforms:
         raise RuntimeError("This module does not currently support building for this platform")
 
-    env.use_ptrcall = True
     env.add_module_version_string("mono")
 
     from SCons.Script import BoolVariable, PathVariable, Variables, Help


### PR DESCRIPTION
ptrcall is now also used to optimize calls in GDScript, on top of the existing
use by the GDNative and Mono modules.

It no longer makes sense to make it optional.

---

Fixes build with GDNative and Mono modules disabled (as those two were the only ones to explicitly require ptrcall enabled).
Supersedes #43849.