### PR TITLE
A couple of GDScript fixes

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -978,7 +978,7 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 
 						if (!call->arguments[i]->is_constant) {
 							all_is_constant = false;
-						} else {
+						} else if (all_is_constant) {
 							args.write[i] = call->arguments[i]->reduced_value;
 						}
 
@@ -1011,11 +1011,15 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 					}
 				}
 
-				GDScriptParser::DataType list_type;
-				list_type.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
-				list_type.kind = GDScriptParser::DataType::BUILTIN;
-				list_type.builtin_type = Variant::ARRAY;
-				p_for->list->set_datatype(list_type);
+				if (p_for->list->is_constant) {
+					p_for->list->set_datatype(type_from_variant(p_for->list->reduced_value, p_for->list));
+				} else {
+					GDScriptParser::DataType list_type;
+					list_type.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
+					list_type.kind = GDScriptParser::DataType::BUILTIN;
+					list_type.builtin_type = Variant::ARRAY;
+					p_for->list->set_datatype(list_type);
+				}
 			}
 		}
 	}

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -437,7 +437,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				gen->pop_temporary();
 			}
 
-			return source;
+			return result;
 		} break;
 		case GDScriptParser::Node::CALL: {
 			const GDScriptParser::CallNode *call = static_cast<const GDScriptParser::CallNode *>(p_expression);


### PR DESCRIPTION
* Fix type of range() when used in a for loop, since it's optimized to Vector2/3 or int to not allocate an array.
* Fix the return value of a cast when compiling. It was returning the source value instead of the result.

Found those while testing the typed VM and the #43775 fix.