### PR TITLE
SCons: Do not define TYPED_METHOD_BIND on Linux/clang

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -129,7 +129,6 @@ def configure(env):
         if "clang++" not in os.path.basename(env["CXX"]):
             env["CC"] = "clang"
             env["CXX"] = "clang++"
-        env.Append(CPPDEFINES=["TYPED_METHOD_BIND"])
         env.extra_suffix = ".llvm" + env.extra_suffix
 
     if env["use_lld"]:

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -94,7 +94,6 @@ def configure(env):
         if "clang++" not in os.path.basename(env["CXX"]):
             env["CC"] = "clang"
             env["CXX"] = "clang++"
-        env.Append(CPPDEFINES=["TYPED_METHOD_BIND"])
         env.extra_suffix = ".llvm" + env.extra_suffix
 
     if env["use_coverage"]:


### PR DESCRIPTION
It's now only needed for MSVC.