### PR TITLE
Fix prints and printt functions printing as errors

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -537,7 +537,7 @@ struct VariantUtilityFunctions {
 			str += p_args[i]->operator String();
 		}
 
-		print_error(str);
+		print_line(str);
 		r_error.error = Callable::CallError::CALL_OK;
 	}
 
@@ -554,7 +554,7 @@ struct VariantUtilityFunctions {
 			str += p_args[i]->operator String();
 		}
 
-		print_error(str);
+		print_line(str);
 		r_error.error = Callable::CallError::CALL_OK;
 	}
 


### PR DESCRIPTION
They should behave like regular print().