### PR TITLE
Check joint nodes and generate configuration warning messages.

### DIFF
--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -47,28 +47,52 @@ void Joint2D::_update_joint(bool p_only_free) {
 	}
 
 	if (p_only_free || !is_inside_tree()) {
+		warning = String();
 		return;
 	}
 
 	Node *node_a = has_node(get_node_a()) ? get_node(get_node_a()) : (Node *)nullptr;
 	Node *node_b = has_node(get_node_b()) ? get_node(get_node_b()) : (Node *)nullptr;
 
-	if (!node_a || !node_b) {
-		return;
-	}
-
 	PhysicsBody2D *body_a = Object::cast_to<PhysicsBody2D>(node_a);
 	PhysicsBody2D *body_b = Object::cast_to<PhysicsBody2D>(node_b);
 
-	if (!body_a || !body_b) {
+	if (node_a && !body_a && node_b && !body_b) {
+		warning = TTR("Node A and Node B must be PhysicsBody2Ds");
+		update_configuration_warning();
 		return;
 	}
+
+	if (node_a && !body_a) {
+		warning = TTR("Node A must be a PhysicsBody2D");
+		update_configuration_warning();
+		return;
+	}
+
+	if (node_b && !body_b) {
+		warning = TTR("Node B must be a PhysicsBody2D");
+		update_configuration_warning();
+		return;
+	}
+
+	if (!body_a || !body_b) {
+		warning = TTR("Joint is not connected to two PhysicsBody2Ds");
+		update_configuration_warning();
+		return;
+	}
+
+	if (body_a == body_b) {
+		warning = TTR("Node A and Node B must be different PhysicsBody2Ds");
+		update_configuration_warning();
+		return;
+	}
+
+	warning = String();
+	update_configuration_warning();
 
 	joint = _configure_joint(body_a, body_b);
 
-	if (!joint.is_valid()) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(!joint.is_valid(), "Failed to configure the joint.");
 
 	PhysicsServer2D::get_singleton()->get_singleton()->joint_set_param(joint, PhysicsServer2D::JOINT_PARAM_BIAS, bias);
 
@@ -141,6 +165,19 @@ bool Joint2D::get_exclude_nodes_from_collision() const {
 	return exclude_from_collision;
 }
 
+String Joint2D::get_configuration_warning() const {
+	String node_warning = Node2D::get_configuration_warning();
+
+	if (!warning.empty()) {
+		if (!node_warning.empty()) {
+			node_warning += "\n\n";
+		}
+		node_warning += warning;
+	}
+
+	return node_warning;
+}
+
 void Joint2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_node_a", "node"), &Joint2D::set_node_a);
 	ClassDB::bind_method(D_METHOD("get_node_a"), &Joint2D::get_node_a);
@@ -154,8 +191,8 @@ void Joint2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_exclude_nodes_from_collision", "enable"), &Joint2D::set_exclude_nodes_from_collision);
 	ClassDB::bind_method(D_METHOD("get_exclude_nodes_from_collision"), &Joint2D::get_exclude_nodes_from_collision);
 
-	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_a", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "CollisionObject2D"), "set_node_a", "get_node_a");
-	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_b", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "CollisionObject2D"), "set_node_b", "get_node_b");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_a", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody2D"), "set_node_a", "get_node_a");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_b", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody2D"), "set_node_b", "get_node_b");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bias", PROPERTY_HINT_RANGE, "0,0.9,0.001"), "set_bias", "get_bias");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_collision"), "set_exclude_nodes_from_collision", "get_exclude_nodes_from_collision");
 }

--- a/scene/2d/joints_2d.h
+++ b/scene/2d/joints_2d.h
@@ -46,6 +46,7 @@ class Joint2D : public Node2D {
 	real_t bias;
 
 	bool exclude_from_collision;
+	String warning;
 
 protected:
 	void _update_joint(bool p_only_free = false);
@@ -56,6 +57,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual String get_configuration_warning() const override;
+
 	void set_node_a(const NodePath &p_node_a);
 	NodePath get_node_a() const;
 

--- a/scene/3d/physics_joint_3d.h
+++ b/scene/3d/physics_joint_3d.h
@@ -46,6 +46,7 @@ class Joint3D : public Node3D {
 
 	int solver_priority;
 	bool exclude_from_collision;
+	String warning;
 
 protected:
 	void _update_joint(bool p_only_free = false);
@@ -57,6 +58,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual String get_configuration_warning() const override;
+
 	void set_node_a(const NodePath &p_node_a);
 	NodePath get_node_a() const;
 


### PR DESCRIPTION
`Joints` require two different `PhysicsBodies` connected to them, or only one in 3D. Currently, if `Joints` are not configured properly, there are no configuration warnings. Worse, it's possible to configure a `Joint` with an Area or two of the same `PhysicsBody`, which will prevent the `Joint` from working without any warning, or even crash on master with Bullet physics.

This PR checks the `Nodes` attached to a `Joint` in both 2D and 3D, and generates the appropriate configuration warnings. Also ensures that the two `PhysicsBodies` are different, and prevents `Areas` from being added as a potential `Node`.

Fixes #43860
